### PR TITLE
Refactor agent loop and AI initialization for better lifecycle management

### DIFF
--- a/apps/coder-demo/src/ai.ts
+++ b/apps/coder-demo/src/ai.ts
@@ -1,15 +1,25 @@
-import { generateText, Output, tool, type ModelMessage, type Tool } from 'ai';
+import { generateText, tool, type ModelMessage, type Tool } from 'ai';
 import { CoderAI, DEFAULT_MODEL } from './config';
-import { BuiltinTools } from './tools';
 import { generateSystemPrompt } from './prompt';
-import z from 'zod';
+import type { Tool as CoderTool } from './typings';
 
-const BuiltinToolsMap = BuiltinTools.reduce((acc, toolInstance) => {
-  acc[toolInstance.name] = tool(toolInstance as Tool);
-  return acc;
-}, {} as Record<string, Tool>);
+let cachedToolsMap: Record<string, Tool> | null = null;
+
+/**
+ * Initialize the tools map. Must be called once after skillRegistry.initialize().
+ */
+export function initializeAI(tools: CoderTool[]): void {
+  cachedToolsMap = tools.reduce((acc, t) => {
+    acc[t.name] = tool(t as Tool);
+    return acc;
+  }, {} as Record<string, Tool>);
+}
 
 export const generateTextAI = (messages: ModelMessage[]): ReturnType<typeof generateText> => {
+  if (!cachedToolsMap) {
+    throw new Error('AI not initialized. Call initializeAI() first.');
+  }
+
   const finalMessages = [
     {
       role: 'system',
@@ -21,36 +31,8 @@ export const generateTextAI = (messages: ModelMessage[]): ReturnType<typeof gene
   return generateText({
     model: CoderAI.chat(DEFAULT_MODEL),
     messages: finalMessages,
-    tools: BuiltinToolsMap
+    tools: cachedToolsMap,
   }) as unknown as ReturnType<typeof generateText>;
-}
-
-export const generateObject = async <T extends z.ZodSchema>(messages: ModelMessage[], schema: T, description: string) => {
-  // 使用 tool calling 的方式来实现结构化输出
-  const result = await generateText({
-    model: CoderAI.chat(DEFAULT_MODEL),
-    messages: messages,
-    tools: {
-      respond: tool({
-        description,
-        inputSchema: schema,
-        execute: async (input: any) => input,
-      })
-    },
-    toolChoice: {
-      type: 'tool',
-      toolName: 'respond',
-    }
-  });
-
-  // 返回 tool call 的结果
-  if (result.toolCalls && result.toolCalls.length > 0) {
-    return result!.toolCalls[0]!.input as z.infer<T>;
-  }
-
-  console.log(result);
-
-  throw new Error('No structured output generated');
 }
 
 export default generateTextAI;

--- a/apps/coder-demo/src/tools/index.ts
+++ b/apps/coder-demo/src/tools/index.ts
@@ -3,16 +3,28 @@ import WriteTool from './write';
 import LsTool from './ls';
 import BashTool from './bash';
 import TavilyTool from './tavily';
-import SkillTool from './skill';
+import { createSkillTool } from './skill';
+import type { Tool } from '../typings';
 
-const BuiltinTools = [
+/** Static tools that don't depend on runtime initialization */
+const StaticTools = [
   ReadTool,
   WriteTool,
   LsTool,
   BashTool,
   TavilyTool,
-  SkillTool,
 ] as const;
+
+/**
+ * Build the full tool list. Must be called after skillRegistry.initialize()
+ * so the skill tool can read from the populated registry.
+ */
+export function buildTools(): Tool[] {
+  return [
+    ...StaticTools,
+    createSkillTool(),
+  ];
+}
 
 export {
   ReadTool,
@@ -20,6 +32,5 @@ export {
   LsTool,
   BashTool,
   TavilyTool,
-  BuiltinTools,
-  SkillTool,
+  createSkillTool,
 };

--- a/apps/coder-demo/src/tools/skill.ts
+++ b/apps/coder-demo/src/tools/skill.ts
@@ -1,45 +1,87 @@
 import z from "zod";
 import type { Tool } from "../typings";
-import { scanSkills, type SkillInfo } from "../skill";
+import { skillRegistry } from "../skill";
 
-const skills = scanSkills(process.cwd());
+/**
+ * Build the tool description dynamically from registered skills.
+ * Called lazily so that the registry is already initialized.
+ */
+function buildDescription(): string {
+  const skills = skillRegistry.getAll();
 
-const getSkillsPrompt = (availableSkills: SkillInfo[]) => {
-  return [
-    "If query matches an available skill's description or instruction [use skill], use the skill tool to get detailed instructions.",
-    "Load a skill to get detailed instructions for a specific task.",
-    "Skills provide specialized knowledge and step-by-step guidance.",
+  if (skills.length === 0) {
+    return "No skills are currently loaded.";
+  }
+
+  const lines = [
+    "Load a skill to get detailed step-by-step instructions for a specific task.",
     "Use this when a task matches an available skill's description.",
-    "Only the skills listed here are available:",
-    "[!important] You should follow the skill's step-by-step guidance. If the skill is not complete, ask the user for more information.",
+    "[!important] Follow the skill's guidance carefully once loaded.",
+    "",
     "<available_skills>",
-    ...availableSkills.flatMap((skill) => [
+    ...skills.flatMap((s) => [
       `  <skill>`,
-      `    <name>${skill.name}</name>`,
-      `    <description>${skill.description}</description>`,
+      `    <name>${s.name}</name>`,
+      `    <description>${s.description}</description>`,
       `  </skill>`,
     ]),
     "</available_skills>",
-  ].join(" ")
+  ];
+
+  return lines.join("\n");
 }
 
-const SkillTool: Tool<
-  { name: string; },
-  { name: string; content: string }
-> = {
-  name: 'skill',
-  description: getSkillsPrompt(skills),
-  inputSchema: z.object({
-    name: z.string().describe('The name of the skill to execute'),
-  }),
-  execute: async ({ name }) => {
-    const skill = skills.find((skill) => skill.name === name);
-    if (!skill) {
-      throw new Error(`Skill ${name} not found`);
-    }
-    return skill;
-  },
-};
+interface SkillToolOutput {
+  name: string;
+  description: string;
+  content: string;
+  metadata: Record<string, any> | undefined;
+}
 
-export default SkillTool;
+/**
+ * Create the skill tool instance.
+ * Must be called **after** skillRegistry.initialize() so the registry is populated.
+ */
+export function createSkillTool(): Tool<{ name: string }, SkillToolOutput> {
+  return {
+    name: 'skill',
+    description: buildDescription(),
+    inputSchema: z.object({
+      name: z.string().describe('The name of the skill to load'),
+    }),
+    execute: async ({ name }): Promise<SkillToolOutput> => {
+      // Exact match first
+      const exactMatch = skillRegistry.get(name);
 
+      if (exactMatch) {
+        return {
+          name: exactMatch.name,
+          description: exactMatch.description,
+          content: exactMatch.content,
+          metadata: exactMatch.metadata,
+        };
+      }
+
+      // Fuzzy fallback
+      const matches = skillRegistry.search(name);
+      if (matches.length === 1 && matches[0]) {
+        return {
+          name: matches[0].name,
+          description: matches[0].description,
+          content: matches[0].content,
+          metadata: matches[0].metadata,
+        };
+      }
+
+      if (matches.length > 1) {
+        const names = matches.map((s) => s.name).join(', ');
+        throw new Error(`Multiple skills match "${name}": ${names}. Please use the exact name.`);
+      }
+
+      const all = skillRegistry.getAll().map((s) => s.name).join(', ');
+      throw new Error(`Skill "${name}" not found. Available: ${all}`);
+    },
+  };
+}
+
+export default createSkillTool;

--- a/apps/coder-demo/src/typings/index.ts
+++ b/apps/coder-demo/src/typings/index.ts
@@ -1,7 +1,6 @@
 import type { FlexibleSchema, ModelMessage } from "ai";
-import type z from "zod";
 
-export interface Tool<Input, Output> {
+export interface Tool<Input = any, Output = any> {
   name: string;
   description: string;
   inputSchema: FlexibleSchema<Input>;
@@ -10,4 +9,65 @@ export interface Tool<Input, Output> {
 
 export interface Context {
   messages: ModelMessage[];
+  /** Abort signal to cancel the loop externally */
+  abortSignal?: AbortSignal;
+}
+
+/** Information about a single tool invocation within a turn */
+export interface ToolCallInfo {
+  toolCallId: string;
+  toolName: string;
+  input: unknown;
+  output?: unknown;
+  error?: string;
+  durationMs: number;
+}
+
+/** Snapshot of a single agent turn */
+export interface TurnInfo {
+  /** 1-based turn index */
+  index: number;
+  /** Tool calls executed in this turn */
+  toolCalls: ToolCallInfo[];
+  /** Whether the AI produced a text response */
+  hasText: boolean;
+  /** Duration of the entire turn in ms */
+  durationMs: number;
+}
+
+/** Final result returned by the agent loop */
+export interface LoopResult {
+  /** Final text response from the agent */
+  text: string;
+  /** All turns executed */
+  turns: TurnInfo[];
+  /** Why the loop finished */
+  finishReason: 'complete' | 'max_turns' | 'max_errors' | 'aborted';
+  /** Total duration in ms */
+  totalDurationMs: number;
+}
+
+/** Lifecycle hooks for the agent loop */
+export interface LoopHooks {
+  /** Called at the start of each turn */
+  onTurnStart?: (turn: { index: number }) => void;
+  /** Called at the end of each turn */
+  onTurnEnd?: (turn: TurnInfo) => void;
+  /** Called before each tool is executed */
+  onToolCallStart?: (info: { toolCallId: string; toolName: string; input: unknown }) => void;
+  /** Called after each tool finishes */
+  onToolCallEnd?: (info: ToolCallInfo) => void;
+  /** Called when the AI produces a text response (per-step) */
+  onText?: (text: string) => void;
+  /** Called when an error occurs */
+  onError?: (error: Error, turn: { index: number }) => void;
+}
+
+export interface LoopOptions {
+  /** Maximum number of turns before stopping */
+  maxTurns?: number;
+  /** Maximum consecutive errors before stopping */
+  maxErrors?: number;
+  /** Lifecycle hooks */
+  hooks?: LoopHooks;
 }


### PR DESCRIPTION
## Summary
This PR refactors the agent loop architecture and AI initialization to improve lifecycle management, add comprehensive instrumentation hooks, and simplify the tool execution flow. The main changes include:

- **Lazy AI initialization**: Moved from static tool setup to explicit `initializeAI()` call after skill registry is ready
- **Structured loop results**: Replaced string returns with `LoopResult` objects containing turn-by-turn telemetry
- **Lifecycle hooks**: Added comprehensive `LoopHooks` for observability (turn start/end, tool execution, text generation, errors)
- **Removed unnecessary LLM calls**: Eliminated the `checkLoopFinish()` function that made an extra LLM call every turn; now uses standard ReAct pattern (no tool calls = done)
- **Improved CLI UX**: Added slash command support for direct skill invocation (`/skill-name`), skill listing (`/skills`), and better formatted output with timing/metrics

## Key Changes

### AI & Loop Architecture
- `ai.ts`: Removed static `BuiltinToolsMap` initialization; added `initializeAI(tools)` function that must be called after skill registry setup
- `loop.ts`: Complete rewrite with structured `LoopResult` return type, `LoopHooks` for lifecycle events, and removal of the extra `checkLoopFinish()` LLM call
- `core.ts`: Updated initialization sequence: registry → build tools → initialize AI; added slash command parsing and skill invocation
- Removed `generateObject()` function (was unused and relied on tool-calling for structured output)

### Tools & Skills
- `tools/index.ts`: Introduced `buildTools()` factory function; separated static tools from dynamic skill tool
- `tools/skill.ts`: Changed from static export to `createSkillTool()` factory; now reads from initialized registry with fuzzy search fallback
- `prompt/system.ts`: Added `buildSkillsSection()` to dynamically include loaded skills in system prompt

### Type System
- `typings/index.ts`: Added `LoopResult`, `TurnInfo`, `ToolCallInfo`, `LoopHooks`, and `LoopOptions` interfaces for better type safety and observability
- Added `abortSignal` to `Context` for external loop cancellation

### CLI Improvements
- Slash command support: `/skill-name [args]` invokes skills directly
- `/skills` command lists all loaded skills
- Better output formatting with turn count, tool call count, duration, and finish reason
- Per-turn and per-tool lifecycle hooks for detailed logging

## Implementation Details
- The loop now follows the standard ReAct pattern: if the model returns text without tool calls, the task is complete
- Tool execution is sequential with hooks fired before/after each call for observability
- Error handling tracks consecutive errors and stops after `MAX_ERROR_COUNT`
- All timing is captured at turn and tool granularity for performance analysis
- Skill tool uses exact match first, then fuzzy search, with helpful error messages listing available skills

https://claude.ai/code/session_01Q5TnLskGfMzuS7VZLLXRCS