### PR TITLE
feat: add agent clarification capability

### DIFF
--- a/packages/cli/src/input-manager.ts
+++ b/packages/cli/src/input-manager.ts
@@ -1,0 +1,113 @@
+import type { ClarificationRequest } from '@coder/engine';
+
+interface PendingRequest {
+  request: ClarificationRequest;
+  resolve: (answer: string) => void;
+  reject: (error: Error) => void;
+  timeoutId?: NodeJS.Timeout;
+}
+
+/**
+ * InputManager handles asynchronous user input for clarification requests.
+ * It manages pending clarification requests and coordinates with the readline interface.
+ */
+export class InputManager {
+  private pendingRequest: PendingRequest | null = null;
+
+  /**
+   * Request user input for a clarification
+   * @param request The clarification request details
+   * @returns Promise that resolves with the user's answer
+   */
+  async requestInput(request: ClarificationRequest): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      // If there's already a pending request, reject this one
+      if (this.pendingRequest) {
+        reject(new Error('Another clarification request is already pending'));
+        return;
+      }
+
+      // Display the question to the user
+      console.log(`\n❓ ${request.question}`);
+      if (request.context) {
+        console.log(`   ${request.context}`);
+      }
+      if (request.defaultAnswer) {
+        console.log(`   (Default: ${request.defaultAnswer})`);
+      }
+      console.log(''); // Empty line for spacing
+
+      // Set up timeout if specified
+      let timeoutId: NodeJS.Timeout | undefined;
+      if (request.timeout > 0) {
+        timeoutId = setTimeout(() => {
+          if (this.pendingRequest?.request.id === request.id) {
+            const error = new Error(`Clarification request timed out after ${request.timeout}ms`);
+            this.pendingRequest.reject(error);
+            this.pendingRequest = null;
+          }
+        }, request.timeout);
+      }
+
+      // Store the pending request
+      this.pendingRequest = {
+        request,
+        resolve,
+        reject,
+        timeoutId
+      };
+    });
+  }
+
+  /**
+   * Handle user input - checks if there's a pending clarification request
+   * @param input The user's input
+   * @returns true if input was consumed by a pending clarification, false otherwise
+   */
+  handleUserInput(input: string): boolean {
+    if (!this.pendingRequest) {
+      return false;
+    }
+
+    // Clear the timeout if it exists
+    if (this.pendingRequest.timeoutId) {
+      clearTimeout(this.pendingRequest.timeoutId);
+    }
+
+    // Resolve the pending request with the user's input
+    const trimmedInput = input.trim();
+    this.pendingRequest.resolve(trimmedInput);
+    this.pendingRequest = null;
+
+    return true;
+  }
+
+  /**
+   * Cancel any pending clarification request
+   * @param reason Optional cancellation reason
+   */
+  cancel(reason?: string): void {
+    if (this.pendingRequest) {
+      if (this.pendingRequest.timeoutId) {
+        clearTimeout(this.pendingRequest.timeoutId);
+      }
+
+      this.pendingRequest.reject(new Error(reason || 'Clarification request cancelled'));
+      this.pendingRequest = null;
+    }
+  }
+
+  /**
+   * Check if there's a pending clarification request
+   */
+  hasPendingRequest(): boolean {
+    return this.pendingRequest !== null;
+  }
+
+  /**
+   * Get the current pending request (for debugging/testing)
+   */
+  getPendingRequest(): ClarificationRequest | null {
+    return this.pendingRequest?.request || null;
+  }
+}

--- a/packages/cli/src/session.ts
+++ b/packages/cli/src/session.ts
@@ -4,9 +4,14 @@ import { homedir } from 'os';
 import { randomUUID } from 'crypto';
 
 export interface SessionMessage {
-  role: 'user' | 'assistant' | 'system';
+  role: 'user' | 'assistant' | 'system' | 'clarification';
   content: string;
   timestamp: number;
+  metadata?: {
+    clarificationType?: 'question' | 'answer';
+    clarificationId?: string;
+    [key: string]: any;
+  };
 }
 
 export interface Session {

--- a/packages/engine/src/Engine.ts
+++ b/packages/engine/src/Engine.ts
@@ -69,7 +69,8 @@ export class Engine {
       tools: this.tools,
       onToolCall: (toolCall) => {
         options?.onToolCall?.(toolCall);
-      }
+      },
+      onClarificationRequest: options?.onClarificationRequest,
     });
   }
 

--- a/packages/engine/src/config/index.ts
+++ b/packages/engine/src/config/index.ts
@@ -22,3 +22,7 @@ export const KEEP_LAST_TURNS = Number(process.env.KEEP_LAST_TURNS ?? 6);
 export const COMPACT_SUMMARY_MAX_TOKENS = Number(process.env.COMPACT_SUMMARY_MAX_TOKENS ?? 1200);
 export const MAX_COMPACTION_ATTEMPTS = Number(process.env.MAX_COMPACTION_ATTEMPTS ?? 2);
 export const OPENAI_REASONING_EFFORT = process.env.OPENAI_REASONING_EFFORT;
+
+// Clarification settings
+export const CLARIFICATION_TIMEOUT = Number(process.env.CLARIFICATION_TIMEOUT ?? 300_000); // 5 minutes
+export const CLARIFICATION_ENABLED = process.env.CLARIFICATION_ENABLED !== 'false';

--- a/packages/engine/src/prompt/system.ts
+++ b/packages/engine/src/prompt/system.ts
@@ -54,6 +54,31 @@ You are producing plain text that will later be styled by the CLI. Follow these 
   * You need a secret/credential/value that cannot be inferred (API key, account id, etc.).
 - If you must ask: do all non-blocked work first, then ask exactly one targeted question, include your recommended default, and state what would change based on the answer.
 - Never ask permission questions like "Should I proceed?" or "Do you want me to run tests?"; proceed with the most reasonable option and mention what you did.
+
+## Clarification Tool
+
+Use the 'clarify' tool when you genuinely need information from the user to proceed. This tool pauses execution and waits for user input.
+
+**When to use clarify:**
+- The request is ambiguous in a way that materially affects the implementation and cannot be resolved by reading the codebase
+- You cannot safely infer the answer from existing code, conventions, or context
+- You need confirmation before destructive or irreversible actions (e.g., deleting resources, modifying production data)
+- You need specific values that cannot be guessed (API keys, account IDs, specific user choices between valid alternatives)
+
+**When NOT to use clarify:**
+- For trivial decisions you can make based on codebase conventions or common practices
+- For permission questions like "Should I proceed?" (just proceed with the best option)
+- For information that's likely in the codebase, configuration files, or documentation (read those first)
+- Multiple times in a row - complete all non-blocked work first, then ask one clear question
+- For choices where a reasonable default exists (use the default and mention what you chose)
+
+**How to use clarify:**
+- Ask ONE clear, specific question per clarification
+- Provide context if needed to help the user understand the choice
+- Include a recommended default answer when applicable
+- Explain briefly what would change based on the answer
+
+Example usage: Call clarify with a question, optional context, and optional default answer. The tool will pause and wait for the user's response.
 - For substantial work, summarize clearly; follow final‑answer formatting.
 - Skip heavy formatting for simple confirmations.
 - Don't dump large files you've written; reference paths only.

--- a/packages/engine/src/shared/types.ts
+++ b/packages/engine/src/shared/types.ts
@@ -1,10 +1,23 @@
 import type { FlexibleSchema, ModelMessage } from "ai";
 
+export interface ClarificationRequest {
+  id: string;
+  question: string;
+  context?: string;
+  defaultAnswer?: string;
+  timeout: number;
+}
+
+export interface ToolExecutionContext {
+  onClarificationRequest?: (request: ClarificationRequest) => Promise<string>;
+  abortSignal?: AbortSignal;
+}
+
 export interface Tool<Input = any, Output = any> {
   name: string;
   description: string;
   inputSchema: FlexibleSchema<Input>;
-  execute: (input: Input) => Promise<Output>;
+  execute: (input: Input, context?: ToolExecutionContext) => Promise<Output>;
 }
 
 export interface Context {

--- a/packages/engine/src/tools/clarify.ts
+++ b/packages/engine/src/tools/clarify.ts
@@ -1,0 +1,74 @@
+import z from "zod";
+import type { Tool, ToolExecutionContext } from "../shared/types";
+import { CLARIFICATION_TIMEOUT } from "../config/index.js";
+import { randomUUID } from "crypto";
+
+export interface ClarifyInput {
+  question: string;
+  context?: string;
+  defaultAnswer?: string;
+  timeout?: number;
+}
+
+export interface ClarifyOutput {
+  answer: string;
+  timedOut: boolean;
+}
+
+export const ClarifyTool: Tool<ClarifyInput, ClarifyOutput> = {
+  name: 'clarify',
+  description: 'Ask the user a clarifying question and wait for their response. Use this when you need information from the user to proceed with the task.',
+  inputSchema: z.object({
+    question: z.string().describe('The question to ask the user'),
+    context: z.string().optional().describe('Additional context to help the user answer'),
+    defaultAnswer: z.string().optional().describe('Default answer if user does not respond within timeout'),
+    timeout: z.number().optional().describe('Timeout in milliseconds (default: 5 minutes)')
+  }),
+  execute: async (input, toolContext) => {
+    if (!toolContext?.onClarificationRequest) {
+      throw new Error('Clarification is not supported in this context. The clarify tool requires a CLI interface with user interaction.');
+    }
+
+    const timeout = input.timeout ?? CLARIFICATION_TIMEOUT;
+    const requestId = randomUUID();
+
+    try {
+      // Create a promise that rejects on timeout
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        setTimeout(() => {
+          reject(new Error(`Clarification request timed out after ${timeout}ms`));
+        }, timeout);
+      });
+
+      // Race between user response and timeout
+      const answer = await Promise.race([
+        toolContext.onClarificationRequest({
+          id: requestId,
+          question: input.question,
+          context: input.context,
+          defaultAnswer: input.defaultAnswer,
+          timeout
+        }),
+        timeoutPromise
+      ]);
+
+      return {
+        answer,
+        timedOut: false
+      };
+    } catch (error: any) {
+      // If timeout occurred and we have a default answer, use it
+      if (error?.message?.includes('timed out') && input.defaultAnswer) {
+        return {
+          answer: input.defaultAnswer,
+          timedOut: true
+        };
+      }
+
+      // Otherwise, re-throw the error
+      throw error;
+    }
+  },
+};
+
+export default ClarifyTool;

--- a/packages/engine/src/tools/index.ts
+++ b/packages/engine/src/tools/index.ts
@@ -3,6 +3,7 @@ import { WriteTool } from './write';
 import { LsTool } from './ls';
 import { BashTool } from './bash';
 import { TavilyTool } from './tavily';
+import { ClarifyTool } from './clarify';
 import { Tool } from 'ai';
 // import { SkillTool } from './skill;
 
@@ -12,6 +13,7 @@ export const BuiltinTools = [
   LsTool,
   BashTool,
   TavilyTool,
+  ClarifyTool,
 ] as const;
 
 export const BuiltinToolsMap = BuiltinTools.reduce((acc, toolInstance) => {
@@ -32,4 +34,5 @@ export {
   LsTool,
   BashTool,
   TavilyTool,
+  ClarifyTool,
 };


### PR DESCRIPTION
This commit implements the ability for the AI agent to ask clarifying questions
during execution and wait for user responses before continuing.

**Key Changes:**

Engine Layer:
- Extended Tool interface to accept optional ToolExecutionContext parameter
- Created new ClarifyTool that pauses execution and waits for user input
- Added onClarificationRequest callback to LoopOptions
- Implemented tool wrapper to inject execution context into tool calls
- Added CLARIFICATION_TIMEOUT and CLARIFICATION_ENABLED configuration

CLI Layer:
- Created InputManager class to handle asynchronous user input
- Integrated clarification handling in CLI readline interface
- Added support for clarification messages in session storage
- Implemented Ctrl+C handling to cancel pending clarifications

System Prompt:
- Added detailed guidance on when and how to use the clarify tool
- Emphasized using clarification only when truly needed
- Provided examples and best practices

**Architecture:**
The implementation uses a tool-based approach where the clarify tool's execute
method returns a Promise that resolves when the user provides input. This
naturally pauses the agent loop without requiring modifications to the core
loop logic.

https://claude.ai/code/session_01NdbxBhuiZQMfxYSbMPe9B6