### PR TITLE
feat: add task plugin for sub-agent capability

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,4 @@
-import { Engine } from '@coder/engine';
+import { Engine, taskPlugin } from '@coder/engine';
 import { skillRegistryPlugin } from '@coder/skills';
 import { mcpPlugin } from '@coder/mcp-plugin';
 import * as readline from 'readline';
@@ -15,7 +15,7 @@ class CoderCLI {
   constructor() {
     this.engine = new Engine({
       enginePlugins: {
-        plugins: [skillRegistryPlugin, mcpPlugin],
+        plugins: [skillRegistryPlugin, mcpPlugin, taskPlugin],
         dirs: ['.coder/engine-plugins', '~/.coder/engine-plugins'],
         scan: true
       },

--- a/packages/engine/src/Engine.ts
+++ b/packages/engine/src/Engine.ts
@@ -45,6 +45,10 @@ export class Engine {
   async initialize(): Promise<void> {
     console.log('Initializing engine...', this.config);
 
+    // Register a lazy tools getter so plugins (e.g. task plugin) can
+    // access the full tools map at execution time, after all tools are merged.
+    this.pluginManager.registerService('getToolsMap', () => ({ ...this.tools }));
+
     // 插件管理器会自动处理加载顺序
     await this.pluginManager.initialize({
       enginePlugins: {
@@ -118,3 +122,5 @@ export { loop } from './core/loop.js';
 export { streamTextAI } from './ai/index.js';
 export { maybeCompactContext } from './context/index.js';
 export * from './tools/index.js';
+export { taskPlugin, createTaskTool } from './plugins/task/index.js';
+export type { TaskToolOptions } from './plugins/task/index.js';

--- a/packages/engine/src/plugin/PluginManager.ts
+++ b/packages/engine/src/plugin/PluginManager.ts
@@ -384,6 +384,13 @@ export class PluginManager {
   }
 
   /**
+   * 服务注册
+   */
+  registerService<T>(name: string, service: T): void {
+    this.services.set(name, service);
+  }
+
+  /**
    * 服务获取
    */
   getService<T>(name: string): T | undefined {

--- a/packages/engine/src/plugins/task/__tests__/task.tool.test.ts
+++ b/packages/engine/src/plugins/task/__tests__/task.tool.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createTaskTool } from '../task.tool.js';
+
+// Mock the loop module
+vi.mock('../../../core/loop.js', () => ({
+  loop: vi.fn(async () => 'Sub-agent completed the task successfully.'),
+}));
+
+import { loop } from '../../../core/loop.js';
+
+describe('createTaskTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const mockTools = {
+    read: { name: 'read', description: 'Read a file', inputSchema: {}, execute: vi.fn() },
+    write: { name: 'write', description: 'Write a file', inputSchema: {}, execute: vi.fn() },
+    bash: { name: 'bash', description: 'Run bash', inputSchema: {}, execute: vi.fn() },
+    task: { name: 'task', description: 'Task tool', inputSchema: {}, execute: vi.fn() },
+  };
+
+  it('should create a tool with correct name and description', () => {
+    const tool = createTaskTool({ getTools: () => mockTools as any });
+    expect(tool.name).toBe('task');
+    expect(tool.description).toContain('sub-agent');
+  });
+
+  it('should exclude the task tool itself from sub-agent tools', async () => {
+    const tool = createTaskTool({ getTools: () => mockTools as any });
+
+    await tool.execute({ description: 'Test task', prompt: 'Do something' });
+
+    expect(loop).toHaveBeenCalledTimes(1);
+    const callArgs = vi.mocked(loop).mock.calls[0];
+    const loopOptions = callArgs[1]!;
+    const subTools = loopOptions.tools!;
+
+    // task tool should be excluded
+    expect(subTools).not.toHaveProperty('task');
+    // other tools should be present
+    expect(subTools).toHaveProperty('read');
+    expect(subTools).toHaveProperty('write');
+    expect(subTools).toHaveProperty('bash');
+  });
+
+  it('should create a fresh context with the prompt', async () => {
+    const tool = createTaskTool({ getTools: () => mockTools as any });
+
+    await tool.execute({ description: 'Search code', prompt: 'Find all usages of foo' });
+
+    const callArgs = vi.mocked(loop).mock.calls[0];
+    const context = callArgs[0];
+
+    expect(context.messages).toHaveLength(1);
+    expect(context.messages[0].role).toBe('user');
+    expect(context.messages[0].content).toContain('Search code');
+    expect(context.messages[0].content).toContain('Find all usages of foo');
+  });
+
+  it('should return the loop result', async () => {
+    const tool = createTaskTool({ getTools: () => mockTools as any });
+    const result = await tool.execute({ description: 'Test', prompt: 'Do it' });
+    expect(result).toEqual({ result: 'Sub-agent completed the task successfully.' });
+  });
+
+  it('should pass abort signal to sub-loop', async () => {
+    const tool = createTaskTool({ getTools: () => mockTools as any });
+    const ac = new AbortController();
+
+    await tool.execute(
+      { description: 'Test', prompt: 'Do it' },
+      { abortSignal: ac.signal }
+    );
+
+    const callArgs = vi.mocked(loop).mock.calls[0];
+    const loopOptions = callArgs[1]!;
+    expect(loopOptions.abortSignal).toBe(ac.signal);
+  });
+});

--- a/packages/engine/src/plugins/task/index.ts
+++ b/packages/engine/src/plugins/task/index.ts
@@ -1,0 +1,3 @@
+export { taskPlugin } from './task.plugin.js';
+export { createTaskTool } from './task.tool.js';
+export type { TaskToolOptions } from './task.tool.js';

--- a/packages/engine/src/plugins/task/task.plugin.ts
+++ b/packages/engine/src/plugins/task/task.plugin.ts
@@ -1,0 +1,37 @@
+import type { EnginePlugin, EnginePluginContext } from '../../plugin/EnginePlugin.js';
+import { createTaskTool } from './task.tool.js';
+
+/**
+ * Task Plugin - Provides sub-agent spawning capability.
+ *
+ * Registers a `task` tool that allows the main agent to delegate
+ * complex subtasks to independent sub-agents. Each sub-agent runs
+ * in its own context through the same agent loop.
+ */
+export const taskPlugin: EnginePlugin = {
+  name: '@coder/engine/task',
+  version: '1.0.0',
+
+  async initialize(context: EnginePluginContext) {
+    const taskTool = createTaskTool({
+      getTools: () => {
+        // Dynamically collect all registered tools at invocation time,
+        // so tools registered after this plugin are also available.
+        const tools: Record<string, any> = {};
+        // We rely on the PluginManager context to access all tools.
+        // The getTool method only gets a single tool by name, so we
+        // store a reference to the full tools map via a service.
+        const toolsMap = context.getService<() => Record<string, any>>('getToolsMap');
+        if (toolsMap) {
+          return toolsMap();
+        }
+        return tools;
+      },
+    });
+
+    context.registerTool('task', taskTool);
+    context.logger?.info?.('Task plugin initialized - sub-agent capability enabled');
+  },
+};
+
+export default taskPlugin;

--- a/packages/engine/src/plugins/task/task.tool.ts
+++ b/packages/engine/src/plugins/task/task.tool.ts
@@ -1,0 +1,87 @@
+import z from 'zod';
+import type { Tool, ToolExecutionContext, Context } from '../../shared/types.js';
+import { loop, type LoopOptions } from '../../core/loop.js';
+import { truncateOutput } from '../../tools/utils.js';
+
+export interface TaskToolOptions {
+  /** All available tools (task tool will be excluded to prevent recursion) */
+  getTools: () => Record<string, Tool>;
+  /** Max steps for a sub-task (defaults to 30) */
+  maxSubTaskSteps?: number;
+}
+
+/**
+ * Create a Task tool that spawns a sub-agent to handle complex subtasks autonomously.
+ *
+ * The sub-agent gets its own context and runs through the same agent loop,
+ * but without access to the `task` tool itself (preventing infinite recursion).
+ */
+export function createTaskTool(options: TaskToolOptions): Tool<
+  { description: string; prompt: string },
+  { result: string }
+> {
+  const TaskTool: Tool<
+    { description: string; prompt: string },
+    { result: string }
+  > = {
+    name: 'task',
+    description: [
+      'Launch a sub-agent to handle a complex subtask autonomously.',
+      'The sub-agent has access to the same tools (read, write, bash, ls, etc.) and works independently.',
+      'Use this when a task can be broken into independent sub-problems that benefit from focused execution.',
+      'The sub-agent will return its result when finished.',
+      '',
+      'When to use:',
+      '- Exploratory tasks: searching codebases, gathering context',
+      '- Independent sub-problems: implementing a helper, writing tests, fixing a specific bug',
+      '- Research: reading multiple files to answer a question',
+      '',
+      'When NOT to use:',
+      '- Simple operations that take 1-2 tool calls',
+      '- Tasks that require conversation with the user (use clarify instead)',
+    ].join('\n'),
+    inputSchema: z.object({
+      description: z.string().describe('A short (3-5 word) description of the subtask'),
+      prompt: z.string().describe('Detailed instructions for the sub-agent to execute'),
+    }),
+    execute: async ({ description, prompt }, executionContext?: ToolExecutionContext) => {
+      const allTools = options.getTools();
+
+      // Exclude the task tool itself to prevent infinite recursion
+      const subTools: Record<string, Tool> = {};
+      for (const [name, tool] of Object.entries(allTools)) {
+        if (name !== 'task') {
+          subTools[name] = tool;
+        }
+      }
+
+      // Create a fresh context for the sub-agent
+      const subContext: Context = {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              `You are a sub-agent working on a specific subtask. Complete the following task and report your findings/results clearly.`,
+              '',
+              `## Task: ${description}`,
+              '',
+              prompt,
+            ].join('\n'),
+          },
+        ],
+      };
+
+      const loopOptions: LoopOptions = {
+        tools: subTools,
+        abortSignal: executionContext?.abortSignal,
+        onClarificationRequest: executionContext?.onClarificationRequest,
+      };
+
+      const result = await loop(subContext, loopOptions);
+
+      return { result: truncateOutput(result) };
+    },
+  };
+
+  return TaskTool;
+}

--- a/packages/engine/src/prompt/system.ts
+++ b/packages/engine/src/prompt/system.ts
@@ -55,6 +55,27 @@ You are producing plain text that will later be styled by the CLI. Follow these 
 - If you must ask: do all non-blocked work first, then ask exactly one targeted question, include your recommended default, and state what would change based on the answer.
 - Never ask permission questions like "Should I proceed?" or "Do you want me to run tests?"; proceed with the most reasonable option and mention what you did.
 
+## Task Tool
+
+Use the 'task' tool to spawn sub-agents for complex subtasks that can run independently.
+
+**When to use task:**
+- Exploratory tasks: searching and reading multiple files to gather context
+- Independent sub-problems: implementing a helper function, writing tests for a module, fixing a specific bug
+- Research: reading through code to answer a specific question about the codebase
+- Parallel work: breaking a problem into independent sub-tasks
+
+**When NOT to use task:**
+- Simple operations that take 1-2 tool calls (just do them directly)
+- Tasks that require conversation with the user (use clarify instead)
+- Tasks that depend on each other's results (do them sequentially)
+
+**How to use task:**
+- Provide a short description (3-5 words) and a detailed prompt
+- The sub-agent has access to read, write, bash, ls, and other tools
+- The sub-agent returns its result when finished
+- You can launch multiple tasks if the sub-problems are independent
+
 ## Clarification Tool
 
 Use the 'clarify' tool when you genuinely need information from the user to proceed. This tool pauses execution and waits for user input.


### PR DESCRIPTION
Implement a Task engine plugin that allows the main agent to spawn
independent sub-agents for complex subtasks. Each sub-agent runs in
its own context through the same agent loop with access to all tools
except the task tool itself (preventing infinite recursion).

- Add task tool (createTaskTool) and task engine plugin (taskPlugin)
- Register getToolsMap service in Engine for runtime tool access
- Add registerService public method to PluginManager
- Update system prompt with Task tool usage guidance
- Register taskPlugin in CLI alongside skill and MCP plugins
- Add unit tests for task tool

https://claude.ai/code/session_01GunUwaNN2w9AMmQuBbWaig