### PR TITLE
Add Edit and Grep tools, enhance Read, Write, and Bash tools

### DIFF
--- a/packages/engine/src/tools/bash.ts
+++ b/packages/engine/src/tools/bash.ts
@@ -4,25 +4,53 @@ import type { Tool } from "../shared/types";
 import { truncateOutput } from "./utils";
 
 export const BashTool: Tool<
-  { command: string },
-  { output: string; error?: string }
+  { command: string; timeout?: number; cwd?: string; description?: string },
+  { output: string; error?: string; exitCode?: number }
 > = {
   name: 'bash',
-  description: 'Execute a bash command and return the output',
+  description: 'Execute a bash command and return the output. Supports timeout and working directory configuration.',
   inputSchema: z.object({
     command: z.string().describe('The bash command to execute'),
+    timeout: z.number().optional().describe('Optional timeout in milliseconds (max 600000ms / 10 minutes). Defaults to 120000ms (2 minutes).'),
+    cwd: z.string().optional().describe('Optional working directory for command execution. Defaults to current directory.'),
+    description: z.string().optional().describe('Optional description of what this command does (for logging/debugging)'),
   }),
-  execute: async ({ command }) => {
+  execute: async ({ command, timeout = 120000, cwd, description }) => {
+    // Validate timeout
+    if (timeout && (timeout < 0 || timeout > 600000)) {
+      throw new Error('Timeout must be between 0 and 600000ms (10 minutes)');
+    }
+
     try {
       const output = execSync(command, {
         encoding: 'utf-8',
         maxBuffer: 1024 * 1024 * 10, // 10MB
+        timeout: timeout || 120000,
+        cwd: cwd || process.cwd(),
+        shell: '/bin/bash',
       });
-      return { output: truncateOutput(output) };
-    } catch (error: any) {
       return {
-        output: truncateOutput(String(error.stdout || '')),
-        error: truncateOutput(String(error.stderr || error.message || '')),
+        output: truncateOutput(output || '(command completed with no output)'),
+        exitCode: 0,
+      };
+    } catch (error: any) {
+      const exitCode = error.status || error.code || 1;
+      const stdout = String(error.stdout || '');
+      const stderr = String(error.stderr || error.message || '');
+
+      // Check if it's a timeout error
+      if (error.killed && error.signal === 'SIGTERM') {
+        return {
+          output: truncateOutput(stdout),
+          error: truncateOutput(`Command timed out after ${timeout}ms\n${stderr}`),
+          exitCode,
+        };
+      }
+
+      return {
+        output: truncateOutput(stdout),
+        error: truncateOutput(stderr),
+        exitCode,
       };
     }
   },

--- a/packages/engine/src/tools/edit.ts
+++ b/packages/engine/src/tools/edit.ts
@@ -1,0 +1,79 @@
+import z from "zod";
+import { readFileSync, writeFileSync } from "fs";
+import type { Tool } from "../shared/types";
+import { truncateOutput } from "./utils";
+
+export const EditTool: Tool<
+  { filePath: string; oldString: string; newString: string; replaceAll?: boolean },
+  { success: boolean; replacements: number; preview?: string }
+> = {
+  name: 'edit',
+  description: 'Performs exact string replacements in files. Use this to edit existing files by replacing old_string with new_string.',
+  inputSchema: z.object({
+    filePath: z.string().describe('The absolute path to the file to modify'),
+    oldString: z.string().describe('The exact text to replace (must match exactly)'),
+    newString: z.string().describe('The text to replace it with (must be different from old_string)'),
+    replaceAll: z.boolean().optional().default(false).describe('Replace all occurrences of old_string (default false)'),
+  }),
+  execute: async ({ filePath, oldString, newString, replaceAll = false }) => {
+    // Validate that old and new strings are different
+    if (oldString === newString) {
+      throw new Error('old_string and new_string must be different');
+    }
+
+    // Read the file
+    const content = readFileSync(filePath, 'utf-8');
+
+    // Check if oldString exists in the file
+    if (!content.includes(oldString)) {
+      throw new Error(`old_string not found in file: ${filePath}`);
+    }
+
+    let newContent: string;
+    let replacements = 0;
+
+    if (replaceAll) {
+      // Replace all occurrences
+      const parts = content.split(oldString);
+      replacements = parts.length - 1;
+      newContent = parts.join(newString);
+    } else {
+      // Replace only the first occurrence
+      const index = content.indexOf(oldString);
+      if (index === -1) {
+        throw new Error(`old_string not found in file: ${filePath}`);
+      }
+
+      // Check if the string is unique (appears only once)
+      const secondIndex = content.indexOf(oldString, index + oldString.length);
+      if (secondIndex !== -1) {
+        throw new Error(
+          'old_string is not unique in the file. Either provide a larger string with more surrounding context to make it unique or use replace_all to change every instance.'
+        );
+      }
+
+      newContent = content.slice(0, index) + newString + content.slice(index + oldString.length);
+      replacements = 1;
+    }
+
+    // Write the modified content back
+    writeFileSync(filePath, newContent, 'utf-8');
+
+    // Generate a preview of the changes (show the changed section with context)
+    const changedIndex = newContent.indexOf(newString);
+    const contextLength = 200;
+    const start = Math.max(0, changedIndex - contextLength);
+    const end = Math.min(newContent.length, changedIndex + newString.length + contextLength);
+    const preview = truncateOutput(
+      `...${newContent.slice(start, end)}...`
+    );
+
+    return {
+      success: true,
+      replacements,
+      preview,
+    };
+  },
+};
+
+export default EditTool;

--- a/packages/engine/src/tools/grep.ts
+++ b/packages/engine/src/tools/grep.ts
@@ -1,0 +1,148 @@
+import z from "zod";
+import { execSync } from "child_process";
+import { existsSync } from "fs";
+import type { Tool } from "../shared/types";
+import { truncateOutput } from "./utils";
+
+export const GrepTool: Tool<
+  {
+    pattern: string;
+    path?: string;
+    glob?: string;
+    type?: string;
+    outputMode?: 'content' | 'files_with_matches' | 'count';
+    context?: number;
+    caseInsensitive?: boolean;
+    headLimit?: number;
+    offset?: number;
+    multiline?: boolean;
+  },
+  { output: string; matches?: number }
+> = {
+  name: 'grep',
+  description: 'A powerful search tool built on ripgrep. Supports regex patterns, file filtering, and multiple output modes.',
+  inputSchema: z.object({
+    pattern: z.string().describe('The regular expression pattern to search for in file contents'),
+    path: z.string().optional().describe('File or directory to search in. Defaults to current working directory.'),
+    glob: z.string().optional().describe('Glob pattern to filter files (e.g. "*.js", "*.{ts,tsx}")'),
+    type: z.string().optional().describe('File type to search (e.g., js, py, rust, go, java, ts, tsx, json, md)'),
+    outputMode: z.enum(['content', 'files_with_matches', 'count']).optional().default('files_with_matches')
+      .describe('Output mode: "content" shows matching lines, "files_with_matches" shows file paths, "count" shows match counts'),
+    context: z.number().optional().describe('Number of lines to show before and after each match (only with output_mode: "content")'),
+    caseInsensitive: z.boolean().optional().default(false).describe('Case insensitive search'),
+    headLimit: z.number().optional().default(0).describe('Limit output to first N lines/entries. 0 means unlimited.'),
+    offset: z.number().optional().default(0).describe('Skip first N lines/entries before applying head_limit'),
+    multiline: z.boolean().optional().default(false).describe('Enable multiline mode where patterns can span lines'),
+  }),
+  execute: async ({
+    pattern,
+    path = '.',
+    glob,
+    type,
+    outputMode = 'files_with_matches',
+    context,
+    caseInsensitive = false,
+    headLimit = 0,
+    offset = 0,
+    multiline = false,
+  }) => {
+    // Build ripgrep command
+    const args: string[] = ['rg'];
+
+    // Pattern
+    args.push(pattern);
+
+    // Case sensitivity
+    if (caseInsensitive) {
+      args.push('-i');
+    }
+
+    // Output mode
+    if (outputMode === 'files_with_matches') {
+      args.push('-l'); // --files-with-matches
+    } else if (outputMode === 'count') {
+      args.push('-c'); // --count
+    } else if (outputMode === 'content') {
+      args.push('-n'); // Show line numbers
+      if (context !== undefined) {
+        args.push(`-C${context}`);
+      }
+    }
+
+    // Multiline mode
+    if (multiline) {
+      args.push('-U'); // --multiline
+      args.push('--multiline-dotall');
+    }
+
+    // File filtering
+    if (glob) {
+      args.push('--glob', glob);
+    }
+    if (type) {
+      args.push('--type', type);
+    }
+
+    // Path
+    if (path && path !== '.') {
+      // Verify path exists
+      if (!existsSync(path)) {
+        throw new Error(`Path does not exist: ${path}`);
+      }
+      args.push(path);
+    }
+
+    // Build the command string
+    let command = args.map(arg => {
+      // Quote arguments that contain spaces or special characters
+      if (arg.includes(' ') || arg.includes('$') || arg.includes('*')) {
+        return `'${arg.replace(/'/g, "'\\''")}'`;
+      }
+      return arg;
+    }).join(' ');
+
+    // Add tail/head for offset/limit
+    if (offset > 0) {
+      command += ` | tail -n +${offset + 1}`;
+    }
+    if (headLimit > 0) {
+      command += ` | head -n ${headLimit}`;
+    }
+
+    try {
+      const output = execSync(command, {
+        encoding: 'utf-8',
+        maxBuffer: 1024 * 1024 * 10, // 10MB
+        shell: '/bin/bash',
+      });
+
+      // Count matches for count mode
+      let matches: number | undefined;
+      if (outputMode === 'count') {
+        matches = output.split('\n').filter(line => line.trim()).length;
+      } else if (outputMode === 'files_with_matches') {
+        matches = output.split('\n').filter(line => line.trim()).length;
+      }
+
+      return {
+        output: truncateOutput(output || '(no matches found)'),
+        matches,
+      };
+    } catch (error: any) {
+      // Exit code 1 means no matches found (not an error)
+      if (error.status === 1) {
+        return {
+          output: '(no matches found)',
+          matches: 0,
+        };
+      }
+
+      // Other errors
+      throw new Error(
+        `grep failed: ${error.stderr || error.message}\nCommand: ${command}`
+      );
+    }
+  },
+};
+
+export default GrepTool;

--- a/packages/engine/src/tools/index.ts
+++ b/packages/engine/src/tools/index.ts
@@ -1,5 +1,7 @@
 import { ReadTool } from './read';
 import { WriteTool } from './write';
+import { EditTool } from './edit';
+import { GrepTool } from './grep';
 import { LsTool } from './ls';
 import { BashTool } from './bash';
 import { TavilyTool } from './tavily';
@@ -10,6 +12,8 @@ import { Tool } from 'ai';
 export const BuiltinTools = [
   ReadTool,
   WriteTool,
+  EditTool,
+  GrepTool,
   LsTool,
   BashTool,
   TavilyTool,
@@ -31,6 +35,8 @@ export const getFinalToolsMap = (customTools?: Record<string, Tool>) => {
 export {
   ReadTool,
   WriteTool,
+  EditTool,
+  GrepTool,
   LsTool,
   BashTool,
   TavilyTool,

--- a/packages/engine/src/tools/read.ts
+++ b/packages/engine/src/tools/read.ts
@@ -1,20 +1,68 @@
 import z from "zod";
-import { readFileSync } from "fs";
+import { readFileSync, existsSync, statSync } from "fs";
 import type { Tool } from "../shared/types";
 import { truncateOutput } from "./utils";
 
 export const ReadTool: Tool<
-  { filePath: string },
-  { content: string }
+  { filePath: string; offset?: number; limit?: number },
+  { content: string; totalLines?: number }
 > = {
   name: 'read',
-  description: 'Read the contents of a file',
+  description: 'Read the contents of a file. Supports reading specific line ranges with offset and limit.',
   inputSchema: z.object({
-    filePath: z.string().describe('The path to the file to read'),
+    filePath: z.string().describe('The absolute path to the file to read'),
+    offset: z.number().optional().describe('The line number to start reading from (0-based). Only provide if the file is too large to read at once.'),
+    limit: z.number().optional().describe('The number of lines to read. Only provide if the file is too large to read at once.'),
   }),
-  execute: async ({ filePath }) => {
+  execute: async ({ filePath, offset, limit }) => {
+    // Check if file exists
+    if (!existsSync(filePath)) {
+      throw new Error(`File does not exist: ${filePath}`);
+    }
+
+    // Check if it's a directory
+    const stats = statSync(filePath);
+    if (stats.isDirectory()) {
+      throw new Error(`Cannot read directory: ${filePath}. Use 'ls' tool to list directory contents.`);
+    }
+
+    // Read the entire file
     const content = readFileSync(filePath, 'utf-8');
-    return { content: truncateOutput(content) };
+    const lines = content.split('\n');
+    const totalLines = lines.length;
+
+    // If no offset/limit specified, return the entire file
+    if (offset === undefined && limit === undefined) {
+      return {
+        content: truncateOutput(content),
+        totalLines,
+      };
+    }
+
+    // Apply offset and limit
+    const startLine = offset || 0;
+    const endLine = limit ? startLine + limit : lines.length;
+
+    // Validate range
+    if (startLine < 0 || startLine >= totalLines) {
+      throw new Error(`Invalid offset: ${startLine}. File has ${totalLines} lines.`);
+    }
+
+    // Extract the requested lines
+    const selectedLines = lines.slice(startLine, endLine);
+
+    // Format with line numbers (1-based for display)
+    const numberedContent = selectedLines
+      .map((line, idx) => {
+        const lineNum = startLine + idx + 1;
+        return `${String(lineNum).padStart(6, ' ')}→${line}`;
+      })
+      .join('\n');
+
+    return {
+      content: truncateOutput(numberedContent),
+      totalLines,
+    };
   },
 };
 

--- a/packages/engine/src/tools/write.ts
+++ b/packages/engine/src/tools/write.ts
@@ -1,20 +1,41 @@
 import z from "zod";
-import { writeFileSync } from "fs";
+import { writeFileSync, mkdirSync, existsSync } from "fs";
+import { dirname } from "path";
 import type { Tool } from "../shared/types";
 
 export const WriteTool: Tool<
   { filePath: string; content: string },
-  { success: boolean }
+  { success: boolean; created: boolean; bytes: number }
 > = {
   name: 'write',
-  description: 'Write contents to a file',
+  description: 'Write contents to a file. Automatically creates parent directories if they do not exist. Will overwrite existing files.',
   inputSchema: z.object({
-    filePath: z.string().describe('The path to the file to write'),
+    filePath: z.string().describe('The absolute path to the file to write (must be absolute, not relative)'),
     content: z.string().describe('The content to write to the file'),
   }),
   execute: async ({ filePath, content }) => {
+    // Check if file already exists
+    const fileExists = existsSync(filePath);
+
+    // Get the directory path
+    const dir = dirname(filePath);
+
+    // Create parent directories if they don't exist
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+
+    // Write the file
     writeFileSync(filePath, content, 'utf-8');
-    return { success: true };
+
+    // Calculate bytes written
+    const bytes = Buffer.byteLength(content, 'utf-8');
+
+    return {
+      success: true,
+      created: !fileExists,
+      bytes,
+    };
   },
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,53 +117,6 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@25.0.10)
 
-  packages/mcp-plugin:
-    dependencies:
-      '@ai-sdk/mcp':
-        specifier: 1.0.19
-        version: 1.0.19(zod@4.3.6)
-      '@coder/engine':
-        specifier: workspace:*
-        version: link:../engine
-    devDependencies:
-      '@types/node':
-        specifier: ^25.0.10
-        version: 25.0.10
-      tsup:
-        specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
-
-  packages/skills:
-    dependencies:
-      '@coder/engine':
-        specifier: workspace:*
-        version: link:../engine
-      glob:
-        specifier: ^11.0.1
-        version: 11.0.1
-      gray-matter:
-        specifier: ^4.0.3
-        version: 4.0.3
-      zod:
-        specifier: ^4.3.6
-        version: 4.3.6
-    devDependencies:
-      '@types/node':
-        specifier: ^25.0.10
-        version: 25.0.10
-      tsup:
-        specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
-      vitest:
-        specifier: ^1.0.0
-        version: 1.6.1(@types/node@25.0.10)
-
 packages:
 
   '@ai-sdk/anthropic@3.0.42':
@@ -588,79 +541,66 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}


### PR DESCRIPTION
## Summary
This PR adds two new powerful tools for file manipulation and searching, while enhancing existing tools with additional functionality and better error handling.

## Key Changes

### New Tools
- **EditTool**: Performs exact string replacements in files with support for single or multiple replacements. Includes validation to ensure old and new strings are different, and requires unique context when replacing single occurrences.
- **GrepTool**: A powerful search tool built on ripgrep with support for:
  - Regex pattern matching
  - Multiple output modes (content, files_with_matches, count)
  - File filtering via glob patterns and file types
  - Context lines, case-insensitive search, and multiline mode
  - Offset and limit for pagination of results

### Enhanced Existing Tools
- **ReadTool**: 
  - Added support for reading specific line ranges with `offset` and `limit` parameters
  - Added file existence and directory validation
  - Returns `totalLines` count for better context
  - Displays line numbers when using offset/limit
  
- **WriteTool**:
  - Automatically creates parent directories if they don't exist
  - Returns additional metadata: `created` flag and `bytes` written
  - Improved documentation about absolute path requirement

- **BashTool**:
  - Added configurable timeout support (0-600000ms, default 120s)
  - Added working directory (`cwd`) parameter
  - Added optional description parameter for logging
  - Improved error handling with exit code tracking
  - Better timeout error detection and reporting
  - Explicit shell specification (`/bin/bash`)

## Implementation Details
- All tools use proper input validation with Zod schemas
- Error messages are descriptive and actionable
- Output is truncated using the existing `truncateOutput` utility
- Tools follow consistent patterns for return types and error handling
- EditTool prevents accidental no-op replacements and handles non-unique strings gracefully
- GrepTool properly handles ripgrep exit codes (exit code 1 = no matches, not an error)

https://claude.ai/code/session_01PbEZeQJ7d2yjfKwajgvirM