### PR TITLE
fix: switch to Responses API and remove duplicate assistant message

### DIFF
--- a/packages/engine/src/ai/index.ts
+++ b/packages/engine/src/ai/index.ts
@@ -5,9 +5,12 @@ import { generateSystemPrompt } from '../prompt';
 import type { Tool as CoderTool, ToolExecutionContext, LLMProviderFactory, SystemPromptOption } from '../shared/types';
 
 
-const providerOptions = OPENAI_REASONING_EFFORT
-  ? { openai: { reasoningEffort: OPENAI_REASONING_EFFORT } }
-  : undefined;
+const providerOptions = {
+  openai: {
+    store: false,
+    ...(OPENAI_REASONING_EFFORT ? { reasoningEffort: OPENAI_REASONING_EFFORT } : {}),
+  },
+};
 
 /** Resolve a SystemPromptOption into a final string. */
 const resolveSystemPrompt = (option: SystemPromptOption | undefined): string => {

--- a/packages/engine/src/ai/index.ts
+++ b/packages/engine/src/ai/index.ts
@@ -1,5 +1,5 @@
 import { generateText, streamText, tool, type ModelMessage, type StepResult, type Tool } from 'ai';
-import { CoderAI, DEFAULT_MODEL, COMPACT_SUMMARY_MAX_TOKENS, OPENAI_REASONING_EFFORT } from '../config';
+import { CoderAI, DEFAULT_MODEL, COMPACT_SUMMARY_MAX_TOKENS, OPENAI_REASONING_EFFORT, MAX_STEPS } from '../config';
 import z from 'zod';
 import { generateSystemPrompt } from '../prompt';
 import type { Tool as CoderTool, ToolExecutionContext, LLMProviderFactory, SystemPromptOption } from '../shared/types';
@@ -84,6 +84,7 @@ export const streamTextAI = (messages: ModelMessage[], tools: Record<string, Cod
     system: resolveSystemPrompt(options?.systemPrompt),
     messages,
     tools: wrappedTools as Record<string, Tool>,
+    maxSteps: MAX_STEPS,
     providerOptions,
     abortSignal: options?.abortSignal,
     onStepFinish: options?.onStepFinish,


### PR DESCRIPTION
- Replace .chat with .responses in OpenAI provider config to use the
  Responses API instead of Chat Completions
- Remove the redundant manual assistant message push after agent.run(),
  since onResponse already accumulates step.response.messages; the
  duplicate caused consecutive assistant messages which broke multi-turn
  conversations in the Responses API

https://claude.ai/code/session_01FLbdEJ2hYu4mwmkLvFiNbx