### PR TITLE
Fix OpenAI Responses API compatibility in CLI engine

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -279,11 +279,6 @@ class CoderCLI {
             console.log();
           }
 
-          this.context.messages.push({
-            role: 'assistant',
-            content: result,
-          });
-
           await this.sessionCommands.saveContext(this.context);
         }
       } catch (error) {

--- a/packages/engine/src/ai/index.ts
+++ b/packages/engine/src/ai/index.ts
@@ -26,17 +26,10 @@ export const generateTextAI = (
   const provider = options?.provider ?? CoderAI;
   const model = options?.model ?? DEFAULT_MODEL;
 
-  const finalMessages = [
-    {
-      role: 'system',
-      content: resolveSystemPrompt(options?.systemPrompt),
-    },
-    ...messages,
-  ] as ModelMessage[];
-
   return generateText({
     model: provider(model),
-    messages: finalMessages,
+    system: resolveSystemPrompt(options?.systemPrompt),
+    messages,
     tools,
     providerOptions,
   }) as unknown as ReturnType<typeof generateText> & { steps: StepResult<any>[]; finishReason: string };
@@ -81,14 +74,6 @@ export const streamTextAI = (messages: ModelMessage[], tools: Record<string, Cod
   const provider = options?.provider ?? CoderAI;
   const model = options?.model ?? DEFAULT_MODEL;
 
-  const finalMessages = [
-    {
-      role: 'system',
-      content: resolveSystemPrompt(options?.systemPrompt),
-    },
-    ...messages,
-  ] as ModelMessage[];
-
   // Wrap tools with execution context if provided
   const wrappedTools = options?.toolExecutionContext
     ? wrapToolsWithContext(tools, options.toolExecutionContext)
@@ -96,7 +81,8 @@ export const streamTextAI = (messages: ModelMessage[], tools: Record<string, Cod
 
   return streamText({
     model: provider(model),
-    messages: finalMessages,
+    system: resolveSystemPrompt(options?.systemPrompt),
+    messages,
     tools: wrappedTools as Record<string, Tool>,
     providerOptions,
     abortSignal: options?.abortSignal,
@@ -129,8 +115,8 @@ export const summarizeMessages = async (
 
   const result = await generateText({
     model: provider(model),
+    system: SUMMARY_SYSTEM_PROMPT,
     messages: [
-      { role: 'system', content: SUMMARY_SYSTEM_PROMPT },
       ...messages,
       { role: 'user', content: SUMMARY_USER_PROMPT },
     ],

--- a/packages/engine/src/ai/index.ts
+++ b/packages/engine/src/ai/index.ts
@@ -5,9 +5,7 @@ import { generateSystemPrompt } from '../prompt';
 import type { Tool as CoderTool, ToolExecutionContext, LLMProviderFactory, SystemPromptOption } from '../shared/types';
 
 
-const providerOptions = OPENAI_REASONING_EFFORT
-  ? { openai: { reasoningEffort: OPENAI_REASONING_EFFORT } }
-  : undefined;
+const providerOptions = { openai: { store: false, reasoningEffort: OPENAI_REASONING_EFFORT } }
 
 /** Resolve a SystemPromptOption into a final string. */
 const resolveSystemPrompt = (option: SystemPromptOption | undefined): string => {

--- a/packages/engine/src/built-in/sub-agent-plugin/index.ts
+++ b/packages/engine/src/built-in/sub-agent-plugin/index.ts
@@ -116,7 +116,6 @@ class AgentRunner {
   ): Promise<string> {
     const subContext: Context = {
       messages: [
-        { role: 'system', content: config.systemPrompt },
         { role: 'user', content: task }
       ]
     };
@@ -128,7 +127,7 @@ class AgentRunner {
       });
     }
 
-    return await loop(subContext, { tools });
+    return await loop(subContext, { tools, systemPrompt: config.systemPrompt });
   }
 }
 

--- a/packages/engine/src/config/index.ts
+++ b/packages/engine/src/config/index.ts
@@ -13,7 +13,7 @@ export const CoderAI = (process.env.USE_ANTHROPIC
   : createOpenAI({
     apiKey: process.env.OPENAI_API_KEY || '',
     baseURL: process.env.OPENAI_API_URL || 'https://api.openai.com/v1'
-  }).chat) as (model: string) => LanguageModel;
+  }).responses) as (model: string) => LanguageModel;
 
 export const DEFAULT_MODEL = process.env.ANTHROPIC_MODEL || process.env.OPENAI_MODEL || 'novita/deepseek/deepseek_v3';
 


### PR DESCRIPTION
## Why
The CLI AI flow had compatibility issues with OpenAI Responses API behavior, including prompt handling mismatches and duplicate assistant output.

## What
- Switched the request/response flow to align with OpenAI Responses API expectations
- Adjusted system prompt handling for Responses API compatibility
- Removed duplicate assistant message emission in the response path
- Cleaned up related logic in `engine/src/ai/index.ts`

## Impact
- More stable and predictable AI responses in CLI interactions
- Better compatibility with current OpenAI API behavior
- Reduced duplicated output in user-facing responses

## Risk
- Low to medium: changes are focused in AI response orchestration logic

## Verification
- Verified changes are committed and pushed on branch:
  `claude/plan-openai-api-support-dKNbu-v2`
- Latest commit included:
  `169fb85 chore: update staged changes`