### PR TITLE
Introduce sandbox runner package and CLI integration

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,6 +16,10 @@
   "files": [
     "dist"
   ],
+  "dependencies": {
+    "pulse-coder-engine": "workspace:*",
+    "pulse-sandbox": "workspace:*"
+  },
   "devDependencies": {
     "typescript": "^5.0.0",
     "tsup": "^8.0.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,5 @@
 import { PulseAgent } from 'pulse-coder-engine';
+import { createJsExecutor, createRunJsTool } from 'pulse-sandbox';
 import * as readline from 'readline';
 import type { Context } from 'pulse-coder-engine';
 import { SessionCommands } from './session-commands.js';
@@ -11,6 +12,10 @@ class CoderCLI {
   private inputManager: InputManager;
 
   constructor() {
+    const runJsTool = createRunJsTool({
+      executor: createJsExecutor()
+    });
+
     // 🎯 现在引擎自动包含内置插件，无需显式配置！
     this.agent = new PulseAgent({
       enginePlugins: {
@@ -21,6 +26,9 @@ class CoderCLI {
       userConfigPlugins: {
         dirs: ['.pulse-coder/config', '.coder/config', '~/.pulse-coder/config', '~/.coder/config'],
         scan: true
+      },
+      tools: {
+        [runJsTool.name]: runJsTool
       }
       // 注意：不再需要 plugins: [...] 配置
     });

--- a/packages/cli/src/sandbox-runner.ts
+++ b/packages/cli/src/sandbox-runner.ts
@@ -1,0 +1,211 @@
+import vm from 'vm';
+import { inspect } from 'util';
+
+interface RunnerRequest {
+  code: string;
+  input: unknown;
+  maxOutputChars: number;
+}
+
+interface RunnerSuccessMessage {
+  type: 'success';
+  result: unknown;
+  stdout: string;
+  stderr: string;
+  outputTruncated: boolean;
+}
+
+interface RunnerErrorMessage {
+  type: 'error';
+  errorCode: 'RUNTIME_ERROR' | 'INTERNAL';
+  errorMessage: string;
+  stdout: string;
+  stderr: string;
+  outputTruncated: boolean;
+}
+
+type RunnerMessage = RunnerSuccessMessage | RunnerErrorMessage;
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack ?? error.message;
+  }
+
+  return String(error);
+}
+
+function appendWithLimit(buffer: string, chunk: string, maxChars: number): { value: string; truncated: boolean } {
+  const merged = buffer + chunk;
+
+  if (merged.length <= maxChars) {
+    return { value: merged, truncated: false };
+  }
+
+  return {
+    value: merged.slice(0, maxChars),
+    truncated: true
+  };
+}
+
+function formatLogArgs(args: unknown[]): string {
+  return args
+    .map((arg) => {
+      if (typeof arg === 'string') {
+        return arg;
+      }
+
+      return inspect(arg, {
+        depth: 4,
+        breakLength: 120,
+        compact: true,
+        maxArrayLength: 100
+      });
+    })
+    .join(' ');
+}
+
+function createConsoleProxy(
+  append: (stream: 'stdout' | 'stderr', text: string) => void
+): Console {
+  return {
+    log: (...args: unknown[]) => append('stdout', `${formatLogArgs(args)}\n`),
+    info: (...args: unknown[]) => append('stdout', `${formatLogArgs(args)}\n`),
+    warn: (...args: unknown[]) => append('stderr', `${formatLogArgs(args)}\n`),
+    error: (...args: unknown[]) => append('stderr', `${formatLogArgs(args)}\n`),
+    debug: (...args: unknown[]) => append('stdout', `${formatLogArgs(args)}\n`),
+    trace: (...args: unknown[]) => append('stderr', `${formatLogArgs(args)}\n`),
+    dir: (item: unknown) => append('stdout', `${inspect(item)}\n`),
+    dirxml: (item: unknown) => append('stdout', `${inspect(item)}\n`),
+    assert: (condition: unknown, ...args: unknown[]) => {
+      if (!condition) {
+        append('stderr', `${formatLogArgs(args.length ? args : ['Assertion failed'])}\n`);
+      }
+    },
+    clear: () => {},
+    count: () => {},
+    countReset: () => {},
+    group: (...args: unknown[]) => append('stdout', `${formatLogArgs(args)}\n`),
+    groupCollapsed: (...args: unknown[]) => append('stdout', `${formatLogArgs(args)}\n`),
+    groupEnd: () => {},
+    table: (tabularData: unknown) => append('stdout', `${inspect(tabularData, { depth: 3 })}\n`),
+    time: () => {},
+    timeLog: (...args: unknown[]) => append('stdout', `${formatLogArgs(args)}\n`),
+    timeEnd: (...args: unknown[]) => append('stdout', `${formatLogArgs(args)}\n`),
+    timeStamp: () => {},
+    profile: () => {},
+    profileEnd: () => {}
+  } as unknown as Console;
+}
+
+function buildSandbox(input: unknown, consoleProxy: Console): vm.Context {
+  const sandbox: Record<string, unknown> = {
+    input,
+    console: consoleProxy,
+    fetch: undefined,
+    WebSocket: undefined,
+    EventSource: undefined,
+    require: undefined,
+    process: undefined,
+    module: undefined,
+    exports: undefined,
+    Buffer: undefined,
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval
+  };
+
+  sandbox.globalThis = sandbox;
+  sandbox.global = sandbox;
+
+  return vm.createContext(sandbox, {
+    codeGeneration: {
+      strings: false,
+      wasm: false
+    }
+  });
+}
+
+async function executeInSandbox(payload: RunnerRequest): Promise<RunnerMessage> {
+  let stdout = '';
+  let stderr = '';
+  let outputTruncated = false;
+
+  const append = (stream: 'stdout' | 'stderr', text: string): void => {
+    if (stream === 'stdout') {
+      const next = appendWithLimit(stdout, text, payload.maxOutputChars);
+      stdout = next.value;
+      if (next.truncated) {
+        outputTruncated = true;
+      }
+      return;
+    }
+
+    const next = appendWithLimit(stderr, text, payload.maxOutputChars);
+    stderr = next.value;
+    if (next.truncated) {
+      outputTruncated = true;
+    }
+  };
+
+  try {
+    const consoleProxy = createConsoleProxy(append);
+    const context = buildSandbox(payload.input, consoleProxy);
+    const wrappedCode = `'use strict';\n(async () => {\n${payload.code}\n})()`;
+    const script = new vm.Script(wrappedCode, { filename: 'pulse-sandbox-user-code.js' });
+    const result = await script.runInContext(context);
+
+    return {
+      type: 'success',
+      result,
+      stdout,
+      stderr,
+      outputTruncated
+    };
+  } catch (error) {
+    append('stderr', `${toErrorMessage(error)}\n`);
+
+    return {
+      type: 'error',
+      errorCode: 'RUNTIME_ERROR',
+      errorMessage: toErrorMessage(error),
+      stdout,
+      stderr,
+      outputTruncated
+    };
+  }
+}
+
+function sendAndExit(message: RunnerMessage, exitCode: number): void {
+  if (!process.send) {
+    process.exit(exitCode);
+    return;
+  }
+
+  process.send(message, (error) => {
+    if (error) {
+      process.exit(1);
+      return;
+    }
+
+    process.exit(exitCode);
+  });
+}
+
+process.once('message', async (payload: RunnerRequest) => {
+  try {
+    const result = await executeInSandbox(payload);
+    sendAndExit(result, 0);
+  } catch (error) {
+    const fallback: RunnerErrorMessage = {
+      type: 'error',
+      errorCode: 'INTERNAL',
+      errorMessage: toErrorMessage(error),
+      stdout: '',
+      stderr: toErrorMessage(error),
+      outputTruncated: false
+    };
+
+    sendAndExit(fallback, 1);
+  }
+});

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: {
+    index: 'src/index.ts',
+    runner: 'src/sandbox-runner.ts'
+  },
   format: ['cjs'],
   dts: false,
   clean: true,
@@ -14,6 +17,6 @@ export default defineConfig({
   platform: 'node',
   // 确保所有依赖都打包进来，包括 workspace 依赖
   external: [],
-  noExternal: ['pulse-coder-engine'], // 强制包含这个 workspace 依赖
+  noExternal: ['pulse-coder-engine', 'pulse-sandbox'],
   outExtension: () => ({ js: '.cjs' })
 });

--- a/packages/pulse-sandbox/package.json
+++ b/packages/pulse-sandbox/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "pulse-sandbox",
+  "version": "0.0.1-alpha.0",
+  "description": "Sandboxed JavaScript runtime and engine tool adapter for Pulse Coder",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.10",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/pulse-sandbox/src/executor.ts
+++ b/packages/pulse-sandbox/src/executor.ts
@@ -1,0 +1,379 @@
+import { fork, type ChildProcess } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type {
+  JsExecutionErrorCode,
+  JsExecutionRequest,
+  JsExecutionResult,
+  JsExecutor,
+  JsExecutorOptions
+} from './types.js';
+
+interface RunnerRequest {
+  code: string;
+  input: unknown;
+  maxOutputChars: number;
+}
+
+interface RunnerSuccessMessage {
+  type: 'success';
+  result: unknown;
+  stdout: string;
+  stderr: string;
+  outputTruncated: boolean;
+}
+
+interface RunnerErrorMessage {
+  type: 'error';
+  errorCode: 'RUNTIME_ERROR' | 'INTERNAL';
+  errorMessage: string;
+  stdout: string;
+  stderr: string;
+  outputTruncated: boolean;
+}
+
+type RunnerMessage = RunnerSuccessMessage | RunnerErrorMessage;
+
+const DEFAULT_TIMEOUT_MS = 2_000;
+const DEFAULT_MEMORY_LIMIT_MB = 64;
+const DEFAULT_MAX_OUTPUT_CHARS = 20_000;
+const DEFAULT_MAX_CODE_LENGTH = 20_000;
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+function appendWithLimit(buffer: string, chunk: string, maxChars: number): { value: string; truncated: boolean } {
+  const merged = buffer + chunk;
+
+  if (merged.length <= maxChars) {
+    return { value: merged, truncated: false };
+  }
+
+  return {
+    value: merged.slice(0, maxChars),
+    truncated: true
+  };
+}
+
+function clampText(value: string, maxChars: number): { value: string; truncated: boolean } {
+  if (value.length <= maxChars) {
+    return { value, truncated: false };
+  }
+
+  return {
+    value: value.slice(0, maxChars),
+    truncated: true
+  };
+}
+
+function mergeText(first: string, second: string): string {
+  if (!first) {
+    return second;
+  }
+
+  if (!second) {
+    return first;
+  }
+
+  return `${first}\n${second}`;
+}
+
+function inferExitErrorCode(signal: NodeJS.Signals | null, stderr: string): JsExecutionErrorCode {
+  if (signal === 'SIGABRT' || /heap out of memory/i.test(stderr)) {
+    return 'OOM';
+  }
+
+  return 'INTERNAL';
+}
+
+function createErrorResult(
+  startedAt: number,
+  stdout: string,
+  stderr: string,
+  errorCode: JsExecutionErrorCode,
+  errorMessage: string,
+  outputTruncated: boolean
+): JsExecutionResult {
+  return {
+    ok: false,
+    stdout,
+    stderr,
+    durationMs: Date.now() - startedAt,
+    outputTruncated,
+    error: {
+      code: errorCode,
+      message: errorMessage
+    }
+  };
+}
+
+function resolveRunnerPath(): string {
+  const requireForResolve = createRequire(import.meta.url);
+  const localDir = path.dirname(fileURLToPath(import.meta.url));
+  const localCandidates = [path.join(localDir, 'runner.js'), path.join(localDir, 'runner.cjs')];
+
+  for (const candidate of localCandidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  try {
+    const packageEntryPath = requireForResolve.resolve('pulse-sandbox');
+    const packageDir = path.dirname(packageEntryPath);
+    const packageCandidates = [path.join(packageDir, 'runner.js'), path.join(packageDir, 'runner.cjs')];
+
+    for (const candidate of packageCandidates) {
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  } catch {
+    // Ignore and fall through to final fallback.
+  }
+
+  return localCandidates[0];
+}
+
+export function createJsExecutor(options: JsExecutorOptions = {}): JsExecutor {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const memoryLimitMb = options.memoryLimitMb ?? DEFAULT_MEMORY_LIMIT_MB;
+  const maxOutputChars = options.maxOutputChars ?? DEFAULT_MAX_OUTPUT_CHARS;
+  const maxCodeLength = options.maxCodeLength ?? DEFAULT_MAX_CODE_LENGTH;
+
+  return {
+    async execute(request: JsExecutionRequest): Promise<JsExecutionResult> {
+      const startedAt = Date.now();
+      const effectiveTimeoutMs = request.timeoutMs ?? timeoutMs;
+
+      if (!Number.isInteger(effectiveTimeoutMs) || effectiveTimeoutMs <= 0) {
+        return createErrorResult(
+          startedAt,
+          '',
+          '',
+          'POLICY_BLOCKED',
+          'timeoutMs must be a positive integer.',
+          false
+        );
+      }
+
+      if (!request.code || request.code.trim().length === 0) {
+        return createErrorResult(
+          startedAt,
+          '',
+          '',
+          'POLICY_BLOCKED',
+          'code must be a non-empty string.',
+          false
+        );
+      }
+
+      if (request.code.length > maxCodeLength) {
+        return createErrorResult(
+          startedAt,
+          '',
+          '',
+          'POLICY_BLOCKED',
+          `code exceeds maxCodeLength (${maxCodeLength}).`,
+          false
+        );
+      }
+
+      const runnerPath = resolveRunnerPath();
+
+      return new Promise<JsExecutionResult>((resolve) => {
+        let child: ChildProcess | undefined;
+        let finished = false;
+        let timedOut = false;
+        let stdoutBuffer = '';
+        let stderrBuffer = '';
+        let streamTruncated = false;
+
+        const finish = (result: JsExecutionResult): void => {
+          if (finished) {
+            return;
+          }
+
+          finished = true;
+          resolve(result);
+        };
+
+        try {
+          child = fork(runnerPath, {
+            stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+            serialization: 'advanced',
+            execArgv: [`--max-old-space-size=${memoryLimitMb}`]
+          });
+        } catch (error) {
+          finish(
+            createErrorResult(
+              startedAt,
+              '',
+              '',
+              'INTERNAL',
+              `Failed to start sandbox process: ${toErrorMessage(error)}`,
+              false
+            )
+          );
+          return;
+        }
+
+        const timeoutHandle = setTimeout(() => {
+          if (finished) {
+            return;
+          }
+
+          timedOut = true;
+          child?.kill('SIGKILL');
+        }, effectiveTimeoutMs);
+
+        const collectStreamChunk = (source: 'stdout' | 'stderr', chunk: string): void => {
+          const currentBuffer = source === 'stdout' ? stdoutBuffer : stderrBuffer;
+          const next = appendWithLimit(currentBuffer, chunk, maxOutputChars);
+
+          if (next.truncated) {
+            streamTruncated = true;
+          }
+
+          if (source === 'stdout') {
+            stdoutBuffer = next.value;
+            return;
+          }
+
+          stderrBuffer = next.value;
+        };
+
+        child.stdout?.on('data', (chunk: Buffer | string) => {
+          collectStreamChunk('stdout', String(chunk));
+        });
+
+        child.stderr?.on('data', (chunk: Buffer | string) => {
+          collectStreamChunk('stderr', String(chunk));
+        });
+
+        child.once('error', (error) => {
+          clearTimeout(timeoutHandle);
+          finish(
+            createErrorResult(
+              startedAt,
+              stdoutBuffer,
+              stderrBuffer,
+              'INTERNAL',
+              `Sandbox process error: ${toErrorMessage(error)}`,
+              streamTruncated
+            )
+          );
+        });
+
+        child.once('message', (message: RunnerMessage) => {
+          clearTimeout(timeoutHandle);
+
+          const mergedStdout = mergeText(message.stdout, stdoutBuffer);
+          const mergedStderr = mergeText(message.stderr, stderrBuffer);
+
+          const clampedStdout = clampText(mergedStdout, maxOutputChars);
+          const clampedStderr = clampText(mergedStderr, maxOutputChars);
+          const outputTruncated =
+            message.outputTruncated ||
+            streamTruncated ||
+            clampedStdout.truncated ||
+            clampedStderr.truncated;
+
+          if (message.type === 'success') {
+            finish({
+              ok: true,
+              result: message.result,
+              stdout: clampedStdout.value,
+              stderr: clampedStderr.value,
+              durationMs: Date.now() - startedAt,
+              outputTruncated
+            });
+            if (child.connected) {
+              child.disconnect();
+            }
+            return;
+          }
+
+          finish(
+            createErrorResult(
+              startedAt,
+              clampedStdout.value,
+              clampedStderr.value,
+              message.errorCode,
+              message.errorMessage,
+              outputTruncated
+            )
+          );
+          if (child.connected) {
+            child.disconnect();
+          }
+        });
+
+        child.once('exit', (_code, signal) => {
+          clearTimeout(timeoutHandle);
+
+          if (finished) {
+            return;
+          }
+
+          if (timedOut) {
+            finish(
+              createErrorResult(
+                startedAt,
+                stdoutBuffer,
+                stderrBuffer,
+                'TIMEOUT',
+                `Execution timed out after ${effectiveTimeoutMs}ms.`,
+                streamTruncated
+              )
+            );
+            return;
+          }
+
+          const errorCode = inferExitErrorCode(signal, stderrBuffer);
+          finish(
+            createErrorResult(
+              startedAt,
+              stdoutBuffer,
+              stderrBuffer,
+              errorCode,
+              'Sandbox process exited unexpectedly.',
+              streamTruncated
+            )
+          );
+        });
+
+        const payload: RunnerRequest = {
+          code: request.code,
+          input: request.input,
+          maxOutputChars
+        };
+
+        try {
+          child.send(payload);
+        } catch (error) {
+          clearTimeout(timeoutHandle);
+          child.kill('SIGKILL');
+          finish(
+            createErrorResult(
+              startedAt,
+              stdoutBuffer,
+              stderrBuffer,
+              'INTERNAL',
+              `Failed to send payload to sandbox: ${toErrorMessage(error)}`,
+              streamTruncated
+            )
+          );
+        }
+      });
+    }
+  };
+}

--- a/packages/pulse-sandbox/src/index.ts
+++ b/packages/pulse-sandbox/src/index.ts
@@ -1,0 +1,14 @@
+export { createJsExecutor } from './executor.js';
+export { createRunJsTool } from './tool.js';
+
+export type {
+  JsExecutionError,
+  JsExecutionErrorCode,
+  JsExecutionRequest,
+  JsExecutionResult,
+  JsExecutor,
+  JsExecutorOptions,
+  RunJsToolInput,
+  RunJsToolOptions,
+  RunJsToolOutput
+} from './types.js';

--- a/packages/pulse-sandbox/src/runner.ts
+++ b/packages/pulse-sandbox/src/runner.ts
@@ -1,0 +1,211 @@
+import vm from 'vm';
+import { inspect } from 'util';
+
+interface RunnerRequest {
+  code: string;
+  input: unknown;
+  maxOutputChars: number;
+}
+
+interface RunnerSuccessMessage {
+  type: 'success';
+  result: unknown;
+  stdout: string;
+  stderr: string;
+  outputTruncated: boolean;
+}
+
+interface RunnerErrorMessage {
+  type: 'error';
+  errorCode: 'RUNTIME_ERROR' | 'INTERNAL';
+  errorMessage: string;
+  stdout: string;
+  stderr: string;
+  outputTruncated: boolean;
+}
+
+type RunnerMessage = RunnerSuccessMessage | RunnerErrorMessage;
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack ?? error.message;
+  }
+
+  return String(error);
+}
+
+function appendWithLimit(buffer: string, chunk: string, maxChars: number): { value: string; truncated: boolean } {
+  const merged = buffer + chunk;
+
+  if (merged.length <= maxChars) {
+    return { value: merged, truncated: false };
+  }
+
+  return {
+    value: merged.slice(0, maxChars),
+    truncated: true
+  };
+}
+
+function formatLogArgs(args: unknown[]): string {
+  return args
+    .map((arg) => {
+      if (typeof arg === 'string') {
+        return arg;
+      }
+
+      return inspect(arg, {
+        depth: 4,
+        breakLength: 120,
+        compact: true,
+        maxArrayLength: 100
+      });
+    })
+    .join(' ');
+}
+
+function createConsoleProxy(
+  append: (stream: 'stdout' | 'stderr', text: string) => void
+): Console {
+  return {
+    log: (...args: unknown[]) => append('stdout', `${formatLogArgs(args)}\n`),
+    info: (...args: unknown[]) => append('stdout', `${formatLogArgs(args)}\n`),
+    warn: (...args: unknown[]) => append('stderr', `${formatLogArgs(args)}\n`),
+    error: (...args: unknown[]) => append('stderr', `${formatLogArgs(args)}\n`),
+    debug: (...args: unknown[]) => append('stdout', `${formatLogArgs(args)}\n`),
+    trace: (...args: unknown[]) => append('stderr', `${formatLogArgs(args)}\n`),
+    dir: (item: unknown) => append('stdout', `${inspect(item)}\n`),
+    dirxml: (item: unknown) => append('stdout', `${inspect(item)}\n`),
+    assert: (condition: unknown, ...args: unknown[]) => {
+      if (!condition) {
+        append('stderr', `${formatLogArgs(args.length ? args : ['Assertion failed'])}\n`);
+      }
+    },
+    clear: () => {},
+    count: () => {},
+    countReset: () => {},
+    group: (...args: unknown[]) => append('stdout', `${formatLogArgs(args)}\n`),
+    groupCollapsed: (...args: unknown[]) => append('stdout', `${formatLogArgs(args)}\n`),
+    groupEnd: () => {},
+    table: (tabularData: unknown) => append('stdout', `${inspect(tabularData, { depth: 3 })}\n`),
+    time: () => {},
+    timeLog: (...args: unknown[]) => append('stdout', `${formatLogArgs(args)}\n`),
+    timeEnd: (...args: unknown[]) => append('stdout', `${formatLogArgs(args)}\n`),
+    timeStamp: () => {},
+    profile: () => {},
+    profileEnd: () => {}
+  } as unknown as Console;
+}
+
+function buildSandbox(input: unknown, consoleProxy: Console): vm.Context {
+  const sandbox: Record<string, unknown> = {
+    input,
+    console: consoleProxy,
+    fetch: undefined,
+    WebSocket: undefined,
+    EventSource: undefined,
+    require: undefined,
+    process: undefined,
+    module: undefined,
+    exports: undefined,
+    Buffer: undefined,
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval
+  };
+
+  sandbox.globalThis = sandbox;
+  sandbox.global = sandbox;
+
+  return vm.createContext(sandbox, {
+    codeGeneration: {
+      strings: false,
+      wasm: false
+    }
+  });
+}
+
+async function executeInSandbox(payload: RunnerRequest): Promise<RunnerMessage> {
+  let stdout = '';
+  let stderr = '';
+  let outputTruncated = false;
+
+  const append = (stream: 'stdout' | 'stderr', text: string): void => {
+    if (stream === 'stdout') {
+      const next = appendWithLimit(stdout, text, payload.maxOutputChars);
+      stdout = next.value;
+      if (next.truncated) {
+        outputTruncated = true;
+      }
+      return;
+    }
+
+    const next = appendWithLimit(stderr, text, payload.maxOutputChars);
+    stderr = next.value;
+    if (next.truncated) {
+      outputTruncated = true;
+    }
+  };
+
+  try {
+    const consoleProxy = createConsoleProxy(append);
+    const context = buildSandbox(payload.input, consoleProxy);
+    const wrappedCode = `'use strict';\n(async () => {\n${payload.code}\n})()`;
+    const script = new vm.Script(wrappedCode, { filename: 'pulse-sandbox-user-code.js' });
+    const result = await script.runInContext(context);
+
+    return {
+      type: 'success',
+      result,
+      stdout,
+      stderr,
+      outputTruncated
+    };
+  } catch (error) {
+    append('stderr', `${toErrorMessage(error)}\n`);
+
+    return {
+      type: 'error',
+      errorCode: 'RUNTIME_ERROR',
+      errorMessage: toErrorMessage(error),
+      stdout,
+      stderr,
+      outputTruncated
+    };
+  }
+}
+
+function sendAndExit(message: RunnerMessage, exitCode: number): void {
+  if (!process.send) {
+    process.exit(exitCode);
+    return;
+  }
+
+  process.send(message, (error) => {
+    if (error) {
+      process.exit(1);
+      return;
+    }
+
+    process.exit(exitCode);
+  });
+}
+
+process.once('message', async (payload: RunnerRequest) => {
+  try {
+    const result = await executeInSandbox(payload);
+    sendAndExit(result, 0);
+  } catch (error) {
+    const fallback: RunnerErrorMessage = {
+      type: 'error',
+      errorCode: 'INTERNAL',
+      errorMessage: toErrorMessage(error),
+      stdout: '',
+      stderr: toErrorMessage(error),
+      outputTruncated: false
+    };
+
+    sendAndExit(fallback, 1);
+  }
+});

--- a/packages/pulse-sandbox/src/tool.ts
+++ b/packages/pulse-sandbox/src/tool.ts
@@ -1,0 +1,30 @@
+import z from 'zod';
+
+import type { RunJsToolInput, RunJsToolOptions, RunJsToolOutput } from './types.js';
+
+const DEFAULT_TOOL_NAME = 'run_js';
+const DEFAULT_TOOL_DESCRIPTION =
+  'Execute JavaScript in an isolated sandbox process. Returns result, stdout, stderr, and execution metadata.';
+
+export function createRunJsTool(options: RunJsToolOptions) {
+  const name = options.name ?? DEFAULT_TOOL_NAME;
+  const description = options.description ?? DEFAULT_TOOL_DESCRIPTION;
+
+  return {
+    name,
+    description,
+    inputSchema: z.object({
+      code: z.string().describe('JavaScript source code to execute in sandbox.'),
+      input: z.any().optional().describe('Optional input object exposed as global `input` in sandbox.'),
+      timeoutMs: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe('Optional timeout in milliseconds. Defaults to executor timeout.')
+    }),
+    execute: async (input: RunJsToolInput): Promise<RunJsToolOutput> => {
+      return options.executor.execute(input);
+    }
+  };
+}

--- a/packages/pulse-sandbox/src/types.ts
+++ b/packages/pulse-sandbox/src/types.ts
@@ -1,0 +1,52 @@
+export type JsExecutionErrorCode =
+  | 'TIMEOUT'
+  | 'OOM'
+  | 'RUNTIME_ERROR'
+  | 'POLICY_BLOCKED'
+  | 'INTERNAL';
+
+export interface JsExecutionError {
+  code: JsExecutionErrorCode;
+  message: string;
+}
+
+export interface JsExecutionRequest {
+  code: string;
+  input?: unknown;
+  timeoutMs?: number;
+}
+
+export interface JsExecutionResult {
+  ok: boolean;
+  result?: unknown;
+  stdout: string;
+  stderr: string;
+  error?: JsExecutionError;
+  durationMs: number;
+  outputTruncated: boolean;
+}
+
+export interface JsExecutor {
+  execute(request: JsExecutionRequest): Promise<JsExecutionResult>;
+}
+
+export interface JsExecutorOptions {
+  timeoutMs?: number;
+  memoryLimitMb?: number;
+  maxOutputChars?: number;
+  maxCodeLength?: number;
+}
+
+export interface RunJsToolInput {
+  code: string;
+  input?: unknown;
+  timeoutMs?: number;
+}
+
+export type RunJsToolOutput = JsExecutionResult;
+
+export interface RunJsToolOptions {
+  executor: JsExecutor;
+  name?: string;
+  description?: string;
+}

--- a/packages/pulse-sandbox/tsconfig.json
+++ b/packages/pulse-sandbox/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/pulse-sandbox/tsup.config.ts
+++ b/packages/pulse-sandbox/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    runner: 'src/runner.ts'
+  },
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  splitting: false,
+  sourcemap: true,
+  target: 'es2022'
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,13 @@ importers:
         version: link:../../packages/engine
 
   packages/cli:
+    dependencies:
+      pulse-coder-engine:
+        specifier: workspace:*
+        version: link:../engine
+      pulse-sandbox:
+        specifier: workspace:*
+        version: link:../pulse-sandbox
     devDependencies:
       '@types/node':
         specifier: ^25.0.10
@@ -112,6 +119,25 @@ importers:
       '@types/glob':
         specifier: ^8.1.0
         version: 8.1.0
+      '@types/node':
+        specifier: ^25.0.10
+        version: 25.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@25.0.10)
+
+  packages/pulse-sandbox:
+    dependencies:
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
       '@types/node':
         specifier: ^25.0.10
         version: 25.0.10


### PR DESCRIPTION
Add a new sandbox execution package and wire it into the CLI toolchain.

- Add  with executor, runner, tool, and types modules
- Integrate sandbox runner into CLI via  and 
- Update build configuration (CLI Building entry: {"index":"src/index.ts","runner":"src/sandbox-runner.ts"}
- Update workspace dependencies and lockfile to include sandbox package