### PR TITLE
Add built-in plan mode plugin

### DIFF
--- a/docs/plan-mode/plan-mode-prompt-first.md
+++ b/docs/plan-mode/plan-mode-prompt-first.md
@@ -1,0 +1,164 @@
+# Plan Mode (Prompt-first) Design
+
+## Goal
+Implement a minimal Plan Mode for the coding agent with prompt-level restrictions only:
+- In `planning` mode, the agent should primarily read, analyze, and produce plans.
+- The agent should avoid write/execute behavior through system prompt constraints.
+- Runtime tool hard-blocking is intentionally deferred to a later phase.
+
+This document defines a low-cost MVP that is compatible with a future upgrade to hard tool gating.
+
+## Scope
+In scope (now):
+- Mode-aware prompt strategy (`planning` vs `executing`).
+- Tool metadata model that can be injected into prompts.
+- Intent-based transition from planning to executing via user language (e.g., "开始执行").
+- Basic observability for prompt violations (model attempted disallowed tools).
+
+Out of scope (later):
+- Runtime enforcement that blocks tool calls by mode.
+- Security-grade policy engine and destructive command filtering.
+- Full approval workflow UI.
+
+## Product Behavior
+### Planning Mode
+- Primary behavior: inspect codebase, gather context, decompose tasks, propose execution plan.
+- Prompt must explicitly prohibit write/edit/execute-oriented tools.
+- If user requests implementation, agent should either:
+  1) Ask for execution authorization, or
+  2) If intent is explicit, transition to executing mode and proceed.
+
+### Executing Mode
+- Prompt allows implementation behavior and tool usage for code changes.
+- Agent follows the approved/proposed plan and updates progress.
+
+## Mode State
+Use a simple two-state model:
+- `planning`
+- `executing`
+
+Recommended defaults:
+- Start sessions in `planning` for complex tasks.
+- Start sessions in `executing` for simple fix requests (optional heuristic).
+
+## Prompt Strategy
+Maintain two system prompt profiles.
+
+### Planning Prompt Requirements
+Must include:
+- Role objective: "analyze and plan first".
+- Explicit disallowed actions in this mode (write/edit/exec classes).
+- Instruction to provide a concrete plan format:
+  - goals
+  - assumptions
+  - steps
+  - risks
+  - validation approach
+- Transition rule:
+  - If user explicitly authorizes execution, switch to `executing`.
+
+Example policy snippet for planning prompt:
+- "You are in PLANNING mode. Focus on reading, analysis, and plan generation. Do not perform code-modifying or command-execution actions in this mode. If the user explicitly asks to start implementation, acknowledge the mode switch and then proceed in EXECUTING mode."
+
+### Executing Prompt Requirements
+Must include:
+- Follow plan steps before broad exploration.
+- Make targeted edits and keep changes scoped.
+- Report what changed and how it was verified.
+
+## Tool Metadata (Prompt Injection Only)
+Define tool metadata once, even before runtime gating.
+
+Suggested shape:
+
+```ts
+export type ToolMeta = {
+  name: string;
+  category: "read" | "search" | "write" | "execute" | "other";
+  risk: "low" | "medium" | "high";
+  description: string;
+  examples?: string[];
+};
+
+export type ModePolicy = {
+  mode: "planning" | "executing";
+  allowedCategories: ToolMeta["category"][];
+  disallowedCategories: ToolMeta["category"][];
+  notes?: string;
+};
+```
+
+For MVP, this policy is used to render prompt text only.
+
+## Intent-Based Transition (No Manual Mode Command Required)
+Allow user language to switch from planning to executing.
+
+### Detection Layers
+1. Rule-based keyword matching (high precision)
+2. Optional LLM intent classifier fallback
+
+Suggested intent labels:
+- `PLAN_ONLY`
+- `EXECUTE_NOW`
+- `UNCLEAR`
+
+Suggested explicit triggers (zh/en examples):
+- "开始执行"
+- "按这个计划做"
+- "可以改代码了"
+- "直接实现"
+- "go ahead"
+- "proceed"
+- "implement it"
+
+Transition behavior:
+- If `EXECUTE_NOW`, set state to `executing` and emit acknowledgment.
+- Otherwise stay in `planning`.
+
+## Observability (Important Even in Prompt-only Phase)
+Log the following events:
+- `mode_entered` (planning/executing)
+- `execution_intent_detected`
+- `mode_switched_by_intent`
+- `disallowed_tool_attempt_in_planning` (soft violation)
+
+Why this matters:
+- You can quantify prompt adherence.
+- You get baseline data before introducing hard runtime policy.
+
+## Known Risks (Prompt-only)
+- Model may still call disallowed tools under pressure/context drift.
+- Safety depends on instruction following, not system guarantees.
+- Different models vary in compliance.
+
+Mitigations in this phase:
+- Keep planning prompt short, explicit, and repetitive on constraints.
+- Add self-check instruction before each tool call in planning mode.
+- Track violations for follow-up hardening.
+
+## Upgrade Path (Phase 2)
+When ready, add runtime gating using the same `ModePolicy` metadata:
+- Intercept tool calls.
+- Deny disallowed categories in `planning`.
+- Return structured error code (example: `TOOL_BLOCKED_BY_MODE`).
+
+Because metadata is already structured, this becomes an implementation change, not a redesign.
+
+## MVP Checklist
+- [ ] Add mode state to session context
+- [ ] Implement planning/executing prompt templates
+- [ ] Inject tool metadata and mode policy text into system prompt
+- [ ] Add intent detection for execution transition
+- [ ] Add mode-switch acknowledgment response
+- [ ] Add soft-violation observability events
+- [ ] Document known limitations
+
+## Acceptance Criteria
+- In planning mode, agent output is predominantly analysis/plan content.
+- Agent transitions to executing mode on explicit user authorization language.
+- Prompt includes clear mode-specific tool guidance.
+- Soft violations are logged for later policy hardening.
+
+## Notes
+This MVP intentionally optimizes for speed of adoption and low implementation cost.
+It is not a security boundary. Treat it as behavior shaping before enforcement.

--- a/packages/engine/src/built-in/index.ts
+++ b/packages/engine/src/built-in/index.ts
@@ -5,6 +5,7 @@
 
 import { builtInMCPPlugin } from './mcp-plugin';
 import { builtInSkillsPlugin } from './skills-plugin';
+import { builtInPlanModePlugin } from './plan-mode-plugin';
 import { SubAgentPlugin } from './sub-agent-plugin';
 
 /**
@@ -14,6 +15,7 @@ import { SubAgentPlugin } from './sub-agent-plugin';
 export const builtInPlugins = [
   builtInMCPPlugin,
   builtInSkillsPlugin,
+  builtInPlanModePlugin,
   new SubAgentPlugin()
 ];
 
@@ -22,6 +24,19 @@ export const builtInPlugins = [
  */
 export { builtInMCPPlugin } from './mcp-plugin';
 export { builtInSkillsPlugin, BuiltInSkillRegistry } from './skills-plugin';
+export { builtInPlanModePlugin, BuiltInPlanModeService } from './plan-mode-plugin';
+export type {
+  PlanMode,
+  PlanIntentLabel,
+  ToolCategory,
+  ToolRisk,
+  ToolMeta,
+  ModePolicy,
+  PlanModeEvent,
+  PlanModeEventName,
+  PlanModeTransitionResult,
+  PlanModeService
+} from './plan-mode-plugin';
 export { SubAgentPlugin } from './sub-agent-plugin';
 
 export default builtInPlugins;

--- a/packages/engine/src/built-in/plan-mode-plugin/index.ts
+++ b/packages/engine/src/built-in/plan-mode-plugin/index.ts
@@ -180,7 +180,7 @@ class BuiltInPlanModeService implements PlanModeService {
   constructor(
     private readonly logger: LoggerLike,
     private readonly eventEmitter: EventEmitter,
-    initialMode: PlanMode = 'planning'
+    initialMode: PlanMode = 'executing'
   ) {
     this.mode = initialMode;
     this.emitEvent('mode_entered', { reason: 'initialize' });

--- a/packages/engine/src/built-in/plan-mode-plugin/index.ts
+++ b/packages/engine/src/built-in/plan-mode-plugin/index.ts
@@ -1,0 +1,534 @@
+import type { EventEmitter } from 'events';
+import type { ModelMessage } from 'ai';
+
+import type { ToolHooks, SystemPromptOption } from '../../shared/types';
+import type { EnginePlugin, EnginePluginContext } from '../../plugin/EnginePlugin';
+
+export type PlanMode = 'planning' | 'executing';
+export type PlanIntentLabel = 'PLAN_ONLY' | 'EXECUTE_NOW' | 'UNCLEAR';
+export type ToolCategory = 'read' | 'search' | 'write' | 'execute' | 'other';
+export type ToolRisk = 'low' | 'medium' | 'high';
+
+export type PlanModeEventName =
+  | 'mode_entered'
+  | 'execution_intent_detected'
+  | 'mode_switched_by_intent'
+  | 'disallowed_tool_attempt_in_planning';
+
+export interface ToolMeta {
+  name: string;
+  category: ToolCategory;
+  risk: ToolRisk;
+  description: string;
+  examples?: string[];
+}
+
+export interface ModePolicy {
+  mode: PlanMode;
+  allowedCategories: ToolCategory[];
+  disallowedCategories: ToolCategory[];
+  notes?: string;
+}
+
+export interface PlanModeEvent {
+  name: PlanModeEventName;
+  mode: PlanMode;
+  timestamp: number;
+  payload?: Record<string, unknown>;
+}
+
+export interface PlanModeTransitionResult {
+  modeBefore: PlanMode;
+  modeAfter: PlanMode;
+  switched: boolean;
+  intent: PlanIntentLabel;
+  userInput: string;
+}
+
+export interface PlanModeService {
+  getMode(): PlanMode;
+  setMode(mode: PlanMode, reason?: string): void;
+  detectIntent(input: string): PlanIntentLabel;
+  processContextMessages(messages: ModelMessage[]): PlanModeTransitionResult;
+  getModePolicy(mode?: PlanMode): ModePolicy;
+  getToolMetadata(toolNames: string[]): ToolMeta[];
+  buildPromptAppend(toolNames: string[], transition?: PlanModeTransitionResult): string;
+  applyHooks(baseHooks?: ToolHooks): ToolHooks;
+  getEvents(limit?: number): PlanModeEvent[];
+}
+
+type LoggerLike = EnginePluginContext['logger'];
+
+const PLANNING_POLICY: ModePolicy = {
+  mode: 'planning',
+  allowedCategories: ['read', 'search', 'other'],
+  disallowedCategories: ['write', 'execute'],
+  notes:
+    'Planning mode is prompt-constrained only. Disallowed tool attempts are observed and logged, not hard-blocked.'
+};
+
+const EXECUTING_POLICY: ModePolicy = {
+  mode: 'executing',
+  allowedCategories: ['read', 'search', 'write', 'execute', 'other'],
+  disallowedCategories: []
+};
+
+const EXECUTE_PATTERNS: RegExp[] = [
+  /开始执行/i,
+  /按这个计划做/i,
+  /可以改代码了/i,
+  /直接实现/i,
+  /go\s+ahead/i,
+  /proceed/i,
+  /implement\s+it/i,
+  /start\s+implement/i,
+  /start\s+coding/i
+];
+
+const NEGATIVE_PATTERNS: RegExp[] = [
+  /先不(要)?执行/i,
+  /先别执行/i,
+  /不要执行/i,
+  /暂时不要执行/i,
+  /先别改代码/i,
+  /先不要改代码/i,
+  /先不要实现/i,
+  /not\s+now/i,
+  /hold\s+off/i,
+  /do\s+not\s+(start|execute|implement|proceed)/i,
+  /don't\s+(start|execute|implement|proceed)/i
+];
+
+const PLAN_PATTERNS: RegExp[] = [/先计划/i, /先分析/i, /先出方案/i, /plan\s+first/i, /analysis\s+first/i];
+
+
+function appendSystemPrompt(base: SystemPromptOption | undefined, append: string): SystemPromptOption {
+  if (!append.trim()) {
+    return base ?? { append: '' };
+  }
+
+  if (!base) {
+    return { append };
+  }
+
+  if (typeof base === 'string') {
+    return `${base}\n\n${append}`;
+  }
+
+  if (typeof base === 'function') {
+    return () => `${base()}\n\n${append}`;
+  }
+
+  const currentAppend = base.append.trim();
+  return {
+    append: currentAppend ? `${currentAppend}\n\n${append}` : append
+  };
+}
+
+const KNOWN_TOOL_META: Record<string, Omit<ToolMeta, 'name'>> = {
+  read: {
+    category: 'read',
+    risk: 'low',
+    description: 'Read file contents from the workspace.'
+  },
+  ls: {
+    category: 'read',
+    risk: 'low',
+    description: 'List files and directories.'
+  },
+  grep: {
+    category: 'search',
+    risk: 'low',
+    description: 'Search text content across files.'
+  },
+  tavily: {
+    category: 'search',
+    risk: 'low',
+    description: 'Search web results from external sources.'
+  },
+  skill: {
+    category: 'search',
+    risk: 'low',
+    description: 'Load procedural guidance from installed skills.'
+  },
+  write: {
+    category: 'write',
+    risk: 'high',
+    description: 'Create or overwrite file content.'
+  },
+  edit: {
+    category: 'write',
+    risk: 'high',
+    description: 'Modify existing files using exact replacements.'
+  },
+  bash: {
+    category: 'execute',
+    risk: 'high',
+    description: 'Execute shell commands.'
+  },
+  clarify: {
+    category: 'other',
+    risk: 'low',
+    description: 'Ask the user a targeted clarification question.'
+  }
+};
+
+class BuiltInPlanModeService implements PlanModeService {
+  private mode: PlanMode;
+  private readonly events: PlanModeEvent[] = [];
+
+  constructor(
+    private readonly logger: LoggerLike,
+    private readonly eventEmitter: EventEmitter,
+    initialMode: PlanMode = 'planning'
+  ) {
+    this.mode = initialMode;
+    this.emitEvent('mode_entered', { reason: 'initialize' });
+  }
+
+  getMode(): PlanMode {
+    return this.mode;
+  }
+
+  setMode(mode: PlanMode, reason: string = 'manual'): void {
+    if (this.mode === mode) {
+      return;
+    }
+
+    this.mode = mode;
+    this.emitEvent('mode_entered', { reason });
+  }
+
+  detectIntent(input: string): PlanIntentLabel {
+    const text = input.trim();
+    if (!text) {
+      return 'UNCLEAR';
+    }
+
+    if (NEGATIVE_PATTERNS.some((pattern) => pattern.test(text))) {
+      return 'PLAN_ONLY';
+    }
+
+    if (EXECUTE_PATTERNS.some((pattern) => pattern.test(text))) {
+      return 'EXECUTE_NOW';
+    }
+
+    if (PLAN_PATTERNS.some((pattern) => pattern.test(text))) {
+      return 'PLAN_ONLY';
+    }
+
+    return 'UNCLEAR';
+  }
+
+  processContextMessages(messages: ModelMessage[]): PlanModeTransitionResult {
+    const userInput = this.getLatestUserText(messages);
+    const modeBefore = this.mode;
+
+    if (!userInput) {
+      return {
+        modeBefore,
+        modeAfter: this.mode,
+        switched: false,
+        intent: 'UNCLEAR',
+        userInput: ''
+      };
+    }
+
+    const intent = this.detectIntent(userInput);
+
+    if (intent === 'EXECUTE_NOW') {
+      this.emitEvent('execution_intent_detected', { intent, userInput });
+
+      if (this.mode === 'planning') {
+        this.mode = 'executing';
+        this.emitEvent('mode_switched_by_intent', {
+          from: 'planning',
+          to: 'executing',
+          userInput
+        });
+        this.emitEvent('mode_entered', {
+          reason: 'intent',
+          from: 'planning'
+        });
+      }
+    }
+
+    return {
+      modeBefore,
+      modeAfter: this.mode,
+      switched: modeBefore !== this.mode,
+      intent,
+      userInput
+    };
+  }
+
+  getModePolicy(mode: PlanMode = this.mode): ModePolicy {
+    return mode === 'planning' ? PLANNING_POLICY : EXECUTING_POLICY;
+  }
+
+  getToolMetadata(toolNames: string[]): ToolMeta[] {
+    return Array.from(new Set(toolNames)).sort().map((name) => this.inferToolMeta(name));
+  }
+
+  buildPromptAppend(toolNames: string[], transition?: PlanModeTransitionResult): string {
+    const mode = this.mode;
+    const policy = this.getModePolicy(mode);
+    const toolMeta = this.getToolMetadata(toolNames);
+    const shownTools = toolMeta.slice(0, 40);
+    const omittedCount = toolMeta.length - shownTools.length;
+
+    const lines: string[] = [
+      '## Plan Mode Policy (Built-in Plugin)',
+      `Current mode: ${mode.toUpperCase()}`,
+      `Allowed tool categories: ${policy.allowedCategories.join(', ')}`,
+      `Disallowed tool categories: ${policy.disallowedCategories.join(', ') || 'none'}`,
+      policy.notes ? `Policy notes: ${policy.notes}` : ''
+    ].filter(Boolean);
+
+    if (mode === 'planning') {
+      lines.push(
+        'Planning objective: prioritize reading, analysis, and plan generation.',
+        'In planning mode, do not intentionally perform write/edit/execute actions.',
+        'If implementation is requested but intent is not explicit, ask for execution authorization.',
+        'Before each tool call in planning mode, self-check category compliance.',
+        'Plan format must include: goals, assumptions, steps, risks, validation approach.'
+      );
+    } else {
+      lines.push(
+        'Executing objective: follow the agreed plan before broad exploration.',
+        'Make targeted edits and keep changes scoped.',
+        'Report what changed and how it was validated.'
+      );
+    }
+
+    if (transition?.switched && transition.modeAfter === 'executing') {
+      lines.push(
+        'Mode transition: the latest user message explicitly authorized execution.',
+        'In your next reply, acknowledge switching to EXECUTING mode before implementation details.'
+      );
+    }
+
+    lines.push('Tool metadata (prompt-level policy reference):');
+    for (const meta of shownTools) {
+      lines.push(`- ${meta.name}: category=${meta.category}, risk=${meta.risk}, ${meta.description}`);
+    }
+
+    if (omittedCount > 0) {
+      lines.push(`- ... ${omittedCount} additional tool(s) omitted for brevity.`);
+    }
+
+    return lines.join('\n');
+  }
+
+  applyHooks(baseHooks?: ToolHooks): ToolHooks {
+    return {
+      onBeforeToolCall: async (name, input) => {
+        this.observePotentialPolicyViolation(name, input);
+
+        if (baseHooks?.onBeforeToolCall) {
+          const nextInput = await baseHooks.onBeforeToolCall(name, input);
+          return nextInput ?? input;
+        }
+
+        return input;
+      },
+      onAfterToolCall: async (name, input, output) => {
+        if (baseHooks?.onAfterToolCall) {
+          const nextOutput = await baseHooks.onAfterToolCall(name, input, output);
+          return nextOutput ?? output;
+        }
+
+        return output;
+      }
+    };
+  }
+
+  getEvents(limit: number = 50): PlanModeEvent[] {
+    return this.events.slice(-Math.max(0, limit));
+  }
+
+  private observePotentialPolicyViolation(toolName: string, input: unknown): void {
+    if (this.mode !== 'planning') {
+      return;
+    }
+
+    const meta = this.inferToolMeta(toolName);
+    const policy = this.getModePolicy('planning');
+
+    if (!policy.disallowedCategories.includes(meta.category)) {
+      return;
+    }
+
+    this.emitEvent('disallowed_tool_attempt_in_planning', {
+      toolName,
+      category: meta.category,
+      risk: meta.risk,
+      input
+    });
+  }
+
+  private inferToolMeta(name: string): ToolMeta {
+    const knownMeta = KNOWN_TOOL_META[name];
+    if (knownMeta) {
+      return {
+        name,
+        ...knownMeta
+      };
+    }
+
+    if (name.startsWith('mcp_')) {
+      return {
+        name,
+        category: 'execute',
+        risk: 'medium',
+        description: 'MCP external tool invocation.'
+      };
+    }
+
+    if (name.endsWith('_agent')) {
+      return {
+        name,
+        category: 'execute',
+        risk: 'high',
+        description: 'Sub-agent task execution tool.'
+      };
+    }
+
+    if (/read|list|cat/i.test(name)) {
+      return {
+        name,
+        category: 'read',
+        risk: 'low',
+        description: 'Likely a read-only inspection tool inferred by name.'
+      };
+    }
+
+    if (/search|find|query|grep/i.test(name)) {
+      return {
+        name,
+        category: 'search',
+        risk: 'low',
+        description: 'Likely a search tool inferred by name.'
+      };
+    }
+
+    if (/write|edit|patch|update|create|delete|remove/i.test(name)) {
+      return {
+        name,
+        category: 'write',
+        risk: 'high',
+        description: 'Likely a file-modifying tool inferred by name.'
+      };
+    }
+
+    if (/bash|exec|run|shell|deploy|build|test/i.test(name)) {
+      return {
+        name,
+        category: 'execute',
+        risk: 'high',
+        description: 'Likely a command execution tool inferred by name.'
+      };
+    }
+
+    return {
+      name,
+      category: 'other',
+      risk: 'low',
+      description: 'Tool category could not be inferred with high confidence.'
+    };
+  }
+
+  private getLatestUserText(messages: ModelMessage[]): string {
+    for (let i = messages.length - 1; i >= 0; i -= 1) {
+      const message = messages[i];
+      if (message.role !== 'user') {
+        continue;
+      }
+
+      return this.messageContentToText(message.content);
+    }
+
+    return '';
+  }
+
+  private messageContentToText(content: ModelMessage['content']): string {
+    if (typeof content === 'string') {
+      return content;
+    }
+
+    if (!Array.isArray(content)) {
+      return '';
+    }
+
+    const textParts: string[] = [];
+
+    for (const part of content) {
+      if (typeof part === 'string') {
+        textParts.push(part);
+        continue;
+      }
+
+      if (part && typeof part === 'object' && 'text' in part && typeof part.text === 'string') {
+        textParts.push(part.text);
+      }
+    }
+
+    return textParts.join('\n');
+  }
+
+  private emitEvent(name: PlanModeEventName, payload?: Record<string, unknown>): void {
+    const event: PlanModeEvent = {
+      name,
+      mode: this.mode,
+      timestamp: Date.now(),
+      payload
+    };
+
+    this.events.push(event);
+    if (this.events.length > 500) {
+      this.events.shift();
+    }
+
+    this.eventEmitter.emit(name, event);
+    this.eventEmitter.emit('plan_mode_event', event);
+
+    if (name === 'disallowed_tool_attempt_in_planning') {
+      this.logger.warn('[PlanMode] Soft violation detected in planning mode', payload);
+      return;
+    }
+
+    this.logger.info(`[PlanMode] ${name}`, payload);
+  }
+}
+
+export const builtInPlanModePlugin: EnginePlugin = {
+  name: 'pulse-coder-engine/built-in-plan-mode',
+  version: '1.0.0',
+
+  async initialize(context: EnginePluginContext): Promise<void> {
+    const service = new BuiltInPlanModeService(context.logger, context.events, 'planning');
+
+    context.registerRunHook('plan-mode', ({ context: runContext, tools, systemPrompt, hooks }) => {
+      const transition = service.processContextMessages(runContext.messages);
+      const append = service.buildPromptAppend(Object.keys(tools), transition);
+
+      const finalSystemPrompt = appendSystemPrompt(systemPrompt, append);
+
+      return {
+        systemPrompt: finalSystemPrompt,
+        hooks: service.applyHooks(hooks)
+      };
+    });
+
+    context.registerService('planMode', service);
+    context.registerService('planModeService', service);
+
+    context.logger.info('[PlanMode] Built-in plan mode plugin initialized', {
+      mode: service.getMode()
+    });
+  }
+};
+
+export { BuiltInPlanModeService };
+
+export default builtInPlanModePlugin;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -7,7 +7,26 @@ export type { UserConfigPlugin, UserConfigPluginLoadOptions } from './plugin/Use
 export { PluginManager } from './plugin/PluginManager.js';
 
 // 内置插件导出
-export { builtInPlugins, builtInMCPPlugin, builtInSkillsPlugin, BuiltInSkillRegistry } from './built-in/index.js';
+export {
+  builtInPlugins,
+  builtInMCPPlugin,
+  builtInSkillsPlugin,
+  builtInPlanModePlugin,
+  BuiltInSkillRegistry,
+  BuiltInPlanModeService
+} from './built-in/index.js';
+export type {
+  PlanMode,
+  PlanIntentLabel,
+  ToolCategory,
+  ToolRisk,
+  ToolMeta,
+  ModePolicy,
+  PlanModeEvent,
+  PlanModeEventName,
+  PlanModeTransitionResult,
+  PlanModeService
+} from './built-in/index.js';
 
 // 原有导出保持不变
 export * from './shared/types.js';

--- a/packages/engine/src/plugin/EnginePlugin.ts
+++ b/packages/engine/src/plugin/EnginePlugin.ts
@@ -1,25 +1,44 @@
-import type { Tool } from 'ai';
+import type { Tool, ModelMessage } from 'ai';
 import type { EventEmitter } from 'events';
 
-// 修复：确保类型正确导出
+import type { Context, SystemPromptOption, ToolHooks } from '../shared/types.js';
+
 export interface EnginePlugin {
   name: string;
   version: string;
   dependencies?: string[];
 
-  // 生命周期钩子 - 添加类型标注
   beforeInitialize?(context: EnginePluginContext): Promise<void>;
   initialize(context: EnginePluginContext): Promise<void>;
   afterInitialize?(context: EnginePluginContext): Promise<void>;
 
-  // 清理钩子
   destroy?(context: EnginePluginContext): Promise<void>;
 }
+
+export interface EngineRunHookInput {
+  context: Context;
+  messages: ModelMessage[];
+  tools: Record<string, Tool>;
+  systemPrompt?: SystemPromptOption;
+  hooks?: ToolHooks;
+}
+
+export interface EngineRunHookResult {
+  systemPrompt?: SystemPromptOption;
+  hooks?: ToolHooks;
+}
+
+export type EngineRunHook = (
+  input: EngineRunHookInput
+) => Promise<EngineRunHookResult | void> | EngineRunHookResult | void;
 
 export interface EnginePluginContext {
   registerTool(name: string, tool: Tool): void;
   registerTools(tools: Record<string, Tool>): void;
   getTool(name: string): Tool | undefined;
+
+  registerRunHook(name: string, hook: EngineRunHook): void;
+  getRunHook(name: string): EngineRunHook | undefined;
 
   registerProtocol(name: string, handler: ProtocolHandler): void;
   getProtocol(name: string): ProtocolHandler | undefined;


### PR DESCRIPTION
Add built-in plan mode support and wire it into engine runtime flow.

- Implement planning/executing mode policy handling
- Integrate prompt append and tool hook observation
- Register plan mode services in engine/plugin system
- Add plan mode docs and remove debug logging