### PR TITLE
Add getTools() API and refactor agent tool initialization

### DIFF
--- a/packages/engine/src/plugin/EnginePlugin.ts
+++ b/packages/engine/src/plugin/EnginePlugin.ts
@@ -36,6 +36,8 @@ export interface EnginePluginContext {
   registerTool(name: string, tool: Tool): void;
   registerTools(tools: Record<string, Tool>): void;
   getTool(name: string): Tool | undefined;
+  /** Returns a snapshot of all tools registered by plugins so far. */
+  getTools(): Record<string, Tool>;
 
   registerRunHook(name: string, hook: EngineRunHook): void;
   getRunHook(name: string): EngineRunHook | undefined;

--- a/packages/engine/src/shared/types.ts
+++ b/packages/engine/src/shared/types.ts
@@ -77,24 +77,6 @@ export interface Context {
   messages: ModelMessage[];
 }
 
-export interface IPlugin {
-  name: string;
-  version: string;
-  extensions: Extension[];
-  activate(context: IExtensionContext): Promise<void>;
-  deactivate?(): Promise<void>;
-}
-
-export interface Extension {
-  type: 'skill' | 'mcp' | 'tool' | 'context';
-  provider: any;
-}
-
-export interface IExtensionContext {
-  registerTools(toolName: string, tool: Tool<any, any>): void;
-  logger: ILogger;
-}
-
 export interface ILogger {
   debug(message: string, meta?: Record<string, unknown>): void;
   info(message: string, meta?: Record<string, unknown>): void;


### PR DESCRIPTION
## Summary
This PR improves the plugin system's tool management by introducing a `getTools()` API for dynamic tool discovery and refactoring the SubAgentPlugin to use lazy evaluation instead of static snapshots.

## Key Changes

- **Added `getTools()` API**: New method in `EnginePluginContext` that returns a snapshot of all currently registered tools, enabling plugins to discover tools at runtime rather than at initialization time.

- **Refactored SubAgentPlugin initialization**: Changed from eagerly collecting tools during plugin load to lazily evaluating tools when agent tools are actually invoked. This ensures that tools registered by plugins loaded after SubAgentPlugin are available to agents.

- **Enhanced capability validation**: Restructured `validateCoreCapabilities()` to support:
  - Required capabilities with alias matching (throws error if missing)
  - Recommended capabilities with alias matching (warns if missing, doesn't block startup)
  - Currently no required capabilities, leaving room for future extensions

- **Removed obsolete code**: Deleted unused `IPlugin`, `Extension`, and `IExtensionContext` interfaces from shared types that were superseded by the `EnginePlugin` system.

## Implementation Details

The key improvement is moving from a static tool snapshot taken at plugin initialization to dynamic tool resolution at execution time. When an agent tool is invoked, it now calls `context.getTools()` to merge builtin tools with all currently registered plugin tools, ensuring late-loaded plugins' tools are available.

This change maintains backward compatibility while fixing the issue where tools registered after SubAgentPlugin initialization were not accessible to agents.

https://claude.ai/code/session_01HUrZzmhkMGfLzCsGghprCH