### PR TITLE
Update package versions across core packages

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pulse-coder-cli",
-  "version": "0.0.1-alpha.10",
+  "version": "0.0.1-alpha.11",
   "description": "CLI interface for Pulse Coder",
   "type": "commonjs",
   "main": "./dist/index.cjs",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pulse-coder-engine",
-  "version": "0.0.1-alpha.9",
+  "version": "0.0.1-alpha.10",
   "description": "Plugin-based AI engine for Pulse Coder",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/pulse-sandbox/package.json
+++ b/packages/pulse-sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pulse-sandbox",
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.1-alpha.3",
   "description": "Sandboxed JavaScript runtime and engine tool adapter for Pulse Coder",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Bump package versions for the latest alpha release updates.

- Update pulse-coder-cli from 0.0.1-alpha.10 to 0.0.1-alpha.11
- Update pulse-coder-engine from 0.0.1-alpha.9 to 0.0.1-alpha.10
- Update pulse-sandbox from 0.0.1-alpha.2 to 0.0.1-alpha.3