### PR TITLE
refactor: remove unused registerProtocol from plugin system

### DIFF
--- a/docs/plugin-system/API-REFERENCE.md
+++ b/docs/plugin-system/API-REFERENCE.md
@@ -28,9 +28,6 @@ interface EngineContext {
   registerTool(tool: Tool): void;
   registerTools(tools: Record<string, Tool>): void;
   
-  // 协议注册
-  registerProtocol(name: string, handler: ProtocolHandler): void;
-  
   // 配置管理
   getConfig<T>(key: string): T | undefined;
   setConfig<T>(key: string, value: T): void;
@@ -104,7 +101,6 @@ const mcpPlugin: EnginePlugin = {
     await mcpClient.connect();
     
     context.registerService('mcpClient', mcpClient);
-    context.registerProtocol('mcp', mcpClient);
   },
   
   async destroy(context) {
@@ -132,21 +128,6 @@ interface DynamicToolPlugin extends EnginePlugin {
         execute: tool.handler
       });
     }
-  }
-}
-```
-
-#### 协议扩展
-```typescript
-interface ProtocolPlugin extends EnginePlugin {
-  async initialize(context) {
-    class CustomProtocolHandler {
-      async handle(message: ProtocolMessage) {
-        // 协议实现
-      }
-    }
-    
-    context.registerProtocol('custom', new CustomProtocolHandler());
   }
 }
 ```

--- a/docs/plugin-system/ARCHITECTURE.md
+++ b/docs/plugin-system/ARCHITECTURE.md
@@ -19,7 +19,6 @@ graph TD
     C3 --> E[MCP客户端]
     C3 --> F[SubAgent管理]
     C3 --> G[新工具类型]
-    C3 --> H[协议扩展]
     
     D3 --> I[工具配置]
     D3 --> J[提示词定制]
@@ -151,7 +150,6 @@ class PluginRegistry {
 ```typescript
 // 引擎插件能力
 interface EngineCapabilities {
-  registerProtocol(name: string, handler: ProtocolHandler): void;
   registerToolType(type: string, factory: ToolFactory): void;
   extendContextProcessor(processor: ContextProcessor): void;
 }

--- a/docs/plugin-system/README.md
+++ b/docs/plugin-system/README.md
@@ -52,9 +52,6 @@ interface EngineContext {
   registerTool(tool: Tool): void;
   registerTools(tools: Record<string, Tool>): void;
   
-  // 协议注册
-  registerProtocol(protocol: string, handler: ProtocolHandler): void;
-  
   // 配置管理
   getConfig<T>(key: string): T | undefined;
   setConfig<T>(key: string, value: T): void;
@@ -112,7 +109,6 @@ export default {
     const mcpClient = new MCPClient();
     await mcpClient.connect();
     
-    context.registerProtocol('mcp', mcpClient);
     context.registerTool(createMcpTool(mcpClient));
     
     context.logger.info('MCP client plugin initialized');
@@ -336,7 +332,7 @@ describe('MCP Plugin', () => {
     const context = createTestContext();
     await mcpPlugin.initialize(context);
     
-    expect(context.hasProtocol('mcp')).toBe(true);
+    expect(context.getService('mcpClient')).toBeDefined();
   });
 });
 ```

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -2,7 +2,22 @@ export { Engine } from './Engine.js';
 export { Engine as PulseAgent } from './Engine.js'; // 添加 PulseAgent 别名
 
 // 插件系统导出
-export type { EnginePlugin, EnginePluginContext } from './plugin/EnginePlugin.js';
+export type {
+  EnginePlugin,
+  EnginePluginContext,
+  EngineHookMap,
+  EngineHookName,
+  BeforeRunInput,
+  BeforeRunResult,
+  BeforeLLMCallInput,
+  BeforeLLMCallResult,
+  AfterRunInput,
+  AfterLLMCallInput,
+  BeforeToolCallInput,
+  BeforeToolCallResult,
+  AfterToolCallInput,
+  AfterToolCallResult,
+} from './plugin/EnginePlugin.js';
 export type { UserConfigPlugin, UserConfigPluginLoadOptions } from './plugin/UserConfigPlugin.js';
 export { PluginManager } from './plugin/PluginManager.js';
 

--- a/packages/engine/src/plugin/EnginePlugin.ts
+++ b/packages/engine/src/plugin/EnginePlugin.ts
@@ -42,9 +42,6 @@ export interface EnginePluginContext {
   registerRunHook(name: string, hook: EngineRunHook): void;
   getRunHook(name: string): EngineRunHook | undefined;
 
-  registerProtocol(name: string, handler: ProtocolHandler): void;
-  getProtocol(name: string): ProtocolHandler | undefined;
-
   registerService<T>(name: string, service: T): void;
   getService<T>(name: string): T | undefined;
 
@@ -59,11 +56,6 @@ export interface EnginePluginContext {
     warn(message: string, meta?: any): void;
     error(message: string, error?: Error, meta?: any): void;
   };
-}
-
-export interface ProtocolHandler {
-  name: string;
-  handle(message: any): Promise<any>;
 }
 
 export interface EnginePluginLoadOptions {

--- a/packages/engine/src/plugin/PluginManager.ts
+++ b/packages/engine/src/plugin/PluginManager.ts
@@ -17,7 +17,6 @@ export class PluginManager {
   private tools = new Map<string, any>();
   private runHooks = new Map<string, EngineRunHook>();
   private services = new Map<string, any>();
-  private protocols = new Map<string, any>();
   private config = new Map<string, any>();
 
   private events = new EventEmitter();
@@ -166,11 +165,6 @@ export class PluginManager {
           this.runHooks.set(name, hook);
         },
         getRunHook: (name) => this.runHooks.get(name),
-
-        registerProtocol: (name, handler) => {
-          this.protocols.set(name, handler);
-        },
-        getProtocol: (name) => this.protocols.get(name),
 
         registerService: (name, service) => {
           this.services.set(name, service);
@@ -439,13 +433,6 @@ export class PluginManager {
 
 
   /**
-   * 协议获取
-   */
-  getProtocol(name: string): any {
-    return this.protocols.get(name);
-  }
-
-  /**
    * 获取插件状态
    */
   getStatus() {
@@ -454,8 +441,7 @@ export class PluginManager {
       userConfigPlugins: this.userConfigPlugins.map(c => c.name || 'unnamed'),
       tools: Array.from(this.tools.keys()),
       runHooks: Array.from(this.runHooks.keys()),
-      services: Array.from(this.services.keys()),
-      protocols: Array.from(this.protocols.keys())
+      services: Array.from(this.services.keys())
     };
   }
 

--- a/packages/engine/src/plugin/PluginManager.ts
+++ b/packages/engine/src/plugin/PluginManager.ts
@@ -3,10 +3,15 @@ import path from 'path';
 import { glob } from 'glob';
 import { EventEmitter } from 'events';
 
-import type { EnginePlugin, EnginePluginContext, EnginePluginLoadOptions, EngineRunHook } from './EnginePlugin.js';
+import type { EnginePlugin, EnginePluginContext, EnginePluginLoadOptions, EngineHookMap, EngineHookName } from './EnginePlugin.js';
 import type { UserConfigPlugin, UserConfigPluginLoadOptions } from './UserConfigPlugin.js';
 import type { ILogger } from '../shared/types.js';
 import { ConfigVariableResolver } from './UserConfigPlugin.js';
+
+// Internal storage: each hook name maps to an array of handlers
+type HookStore = {
+  [K in EngineHookName]: Array<EngineHookMap[K]>;
+};
 
 /**
  * 插件管理器 - 管理双轨插件系统
@@ -15,7 +20,14 @@ export class PluginManager {
   private enginePlugins = new Map<string, EnginePlugin>();
   private userConfigPlugins: UserConfigPlugin[] = [];
   private tools = new Map<string, any>();
-  private runHooks = new Map<string, EngineRunHook>();
+  private hooks: HookStore = {
+    beforeRun: [],
+    afterRun: [],
+    beforeLLMCall: [],
+    afterLLMCall: [],
+    beforeToolCall: [],
+    afterToolCall: [],
+  };
   private services = new Map<string, any>();
   private config = new Map<string, any>();
 
@@ -161,10 +173,10 @@ export class PluginManager {
         getTool: (name) => this.tools.get(name),
         getTools: () => Object.fromEntries(this.tools),
 
-        registerRunHook: (name, hook) => {
-          this.runHooks.set(name, hook);
+        registerHook: (hookName, handler) => {
+          this.hooks[hookName].push(handler as any);
+          this.logger.debug(`Plugin "${plugin.name}" registered hook: ${hookName}`);
         },
-        getRunHook: (name) => this.runHooks.get(name),
 
         registerService: (name, service) => {
           this.services.set(name, service);
@@ -416,12 +428,11 @@ export class PluginManager {
     return Object.fromEntries(this.tools);
   }
 
-
   /**
-   * 运行时钩子获取
+   * 获取指定类型的 hook 处理函数数组
    */
-  getRunHooks(): EngineRunHook[] {
-    return Array.from(this.runHooks.values());
+  getHooks<K extends EngineHookName>(hookName: K): Array<EngineHookMap[K]> {
+    return [...this.hooks[hookName]] as Array<EngineHookMap[K]>;
   }
 
   /**
@@ -431,7 +442,6 @@ export class PluginManager {
     return this.services.get(name);
   }
 
-
   /**
    * 获取插件状态
    */
@@ -440,7 +450,9 @@ export class PluginManager {
       enginePlugins: Array.from(this.enginePlugins.keys()),
       userConfigPlugins: this.userConfigPlugins.map(c => c.name || 'unnamed'),
       tools: Array.from(this.tools.keys()),
-      runHooks: Array.from(this.runHooks.keys()),
+      hooks: Object.fromEntries(
+        Object.entries(this.hooks).map(([k, v]) => [k, (v as any[]).length])
+      ),
       services: Array.from(this.services.keys())
     };
   }


### PR DESCRIPTION
registerProtocol/ProtocolHandler was a placeholder with no consumers
anywhere in the codebase. Remove it from EnginePluginContext interface,
PluginManager implementation, and all documentation references.

https://claude.ai/code/session_01TQCqvkxcLuuMEfndLvPX5i