### PR TITLE
Add task tracking plugin with dynamic skill registry

### DIFF
--- a/.pulse-coder/skills/agent-research/SKILL.md
+++ b/.pulse-coder/skills/agent-research/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: agent-research
+description: Strict research and design workflow for general coding-agent loops with evidence-backed benchmarking, iterative user discussion, and explicit execution handoff.
+version: 1.1.0
+author: Pulse Coder Team
+---
+
+# Agent Research & Design Skill (Strict, English)
+
+## Goal
+
+This skill is for systematically researching and designing a general Agent Loop / Coding Agent capability model, ensuring:
+1. Atomic capabilities are clearly defined and implementable.
+2. Benchmarking against mainstream implementations (pi-mono / OpenCode / Claude Code) is evidence-backed.
+3. The proposed design is discussion-ready and iteration-friendly.
+4. No implementation starts before explicit user confirmation.
+
+---
+
+## Non-Negotiable Rules
+
+1. **Research first, design second, execution last.**  
+   Do not move into implementation before research + design convergence.
+
+2. **All key claims must be source-traceable.**  
+   Every important claim must include URL citations. If not, mark as assumption/speculation.
+
+3. **Separate facts from interpretation.**  
+   Explicitly label output as:
+   - `Fact`
+   - `Inference`
+   - `Proposal`
+
+4. **Minimum research depth is mandatory.**
+   - At least **8 rounds** of search, at most **12 rounds**.
+   - At least **12 unique source URLs**.
+   - Must cover **3 required targets**: pi-mono, OpenCode, Claude Code.
+
+5. **Atomic capabilities must follow a standard schema.**  
+   Each capability must include: definition, input, output, trigger, failure mode, recovery strategy, success metrics.
+
+6. **No execution without explicit user Yes.**  
+   Always ask for final execution confirmation before implementation actions.
+
+---
+
+## Required Execution Flow
+
+### Phase 0: Scope Alignment
+
+Before research starts, clarify:
+- Target context (CLI agent / IDE agent / server agent)
+- Constraints (time, budget, model limits, tool permissions)
+- Deliverable depth (concept paper / technical design / executable task plan)
+
+If missing info exists, ask questions first.
+
+---
+
+### Phase 1: Atomic Capability Design
+
+Draft the capability map first, including at least:
+- Task Understanding
+- Planning
+- Tool Use
+- Context Management
+- Code Execution Loop
+- Reflection / Critique
+- Safety & Guardrails
+- Memory
+- Human-in-the-loop
+- Evaluation & Telemetry
+
+For each capability, provide:
+- Name
+- Definition
+- Input
+- Output
+- Trigger
+- Tool/Context dependencies
+- Failure mode
+- Recovery strategy
+- Success metrics (prefer measurable metrics)
+
+---
+
+### Phase 2: External Benchmarking
+
+#### Mandatory Targets
+- pi-mono
+- OpenCode
+- Claude Code
+
+#### Optional Targets
+- Cursor Agent
+- Aider
+- Copilot CLI
+
+#### Research Constraints
+- 8-12 progressive search rounds (overview → architecture → loop mechanics → trade-offs → validation)
+- For each round, report: objective, queries, new findings, open questions
+- At least 12 unique URLs
+- Source priority: official docs > source repo/code > technical blogs > secondary summaries
+- Cross-validate key claims with at least 2 sources (otherwise mark as low confidence)
+
+---
+
+### Phase 3: Synthesis & Proposal
+
+Output must include:
+1. **Atomic capability catalog (standardized definitions)**
+2. **Benchmark matrix (implementation comparison)**
+3. **Recommended architecture (MVP / v1 / v2)**
+4. **Core trade-offs (complexity, cost, robustness, extensibility)**
+5. **Risk register with mitigation strategies**
+6. **Open decisions list (5-10 items)**
+
+Also explicitly mark:
+- what is fact,
+- what is inference,
+- what is proposal.
+
+---
+
+### Phase 4: Discussion Loop with User
+
+In each discussion iteration:
+- Provide “current recommendation + 3-5 key questions”
+- Maintain status buckets:
+  - Confirmed
+  - Pending
+  - Changed
+- Publish a decision snapshot at the end of each iteration
+
+Move to final confirmation when pending items ≤ 2, or user says design is converged.
+
+---
+
+### Phase 5: Execution Confirmation
+
+Use an explicit confirmation question:
+
+> “The design is now largely converged. Do you want me to enter execution mode? Options:
+> 1) detailed technical design,
+> 2) task breakdown & timeline,
+> 3) code skeleton,
+> 4) direct implementation.”
+
+- If user confirms: re-confirm scope boundaries, then execute.
+- If user declines: deliver finalized design artifacts and next-step recommendations only.
+
+---
+
+## Required Output Artifacts
+
+### A. Capability Spec Table
+| Capability | Definition | Input | Output | Trigger | Failure Mode | Recovery | KPI |
+|---|---|---|---|---|---|---|---|
+
+### B. Benchmark Matrix
+| System | Loop Pattern | Tool Strategy | Context Strategy | Safety Mechanism | Strengths | Limitations |
+|---|---|---|---|---|---|---|
+
+### C. Evidence Ledger
+| Claim | Type (Fact/Inference) | Source URL | Confidence (High/Med/Low) | Notes |
+|---|---|---|---|---|
+
+### D. Roadmap
+- MVP (2-4 weeks)
+- v1 (1-2 months)
+- v2 (continuous optimization)
+
+### E. Decision Log
+- Confirmed
+- Pending
+- Changed
+
+---
+
+## Completion Criteria
+
+This skill is complete only when all items are satisfied:
+- [ ] 8+ research rounds completed
+- [ ] 12+ unique sources provided
+- [ ] Atomic capabilities standardized
+- [ ] Benchmark matrix + evidence ledger delivered
+- [ ] At least one user discussion iteration completed
+- [ ] Explicit execution confirmation asked and recorded

--- a/.pulse-coder/skills/agent-research/SKILL.zh.md
+++ b/.pulse-coder/skills/agent-research/SKILL.zh.md
@@ -1,0 +1,190 @@
+---
+name: agent-research
+description: Strict research and design workflow for general coding-agent loops with evidence-backed benchmarking, iterative user discussion, and explicit execution handoff.
+description_zh: 强约束的通用 coding-agent loop 调研与设计流程：证据化对标、迭代讨论、明确执行确认。
+version: 1.1.0
+author: Pulse Coder Team
+---
+
+# Agent Research & Design Skill (Strict)
+
+## Goal
+
+用于系统性调研并设计通用 Agent Loop / Coding Agent 能力体系，确保：
+1. 原子能力定义完整且可落地；
+2. 对标主流实现（pi-mono / OpenCode / Claude Code）有证据支持；
+3. 方案输出可讨论、可迭代、可决策；
+4. 在用户明确确认前，不进入执行实现。
+
+---
+
+## Non-Negotiable Rules（硬约束）
+
+1. **先调研后设计，先设计后执行**  
+   未完成调研与讨论收敛前，不得进入代码实现。
+
+2. **所有关键结论必须可追溯到来源**  
+   关键结论必须标注 URL；无来源的内容只能标记为“假设/推测”。
+
+3. **事实与判断必须分离**  
+   输出中必须显式区分：
+   - `Fact`（可验证事实）
+   - `Inference`（基于事实的推断）
+   - `Proposal`（建议方案）
+
+4. **最少调研深度要求**  
+   - 至少 **8 轮** 搜索，最多 **12 轮**；
+   - 至少 **12 个唯一来源 URL**；
+   - 至少覆盖 **3 个必选对象**：pi-mono、OpenCode、Claude Code。
+
+5. **关键能力必须标准化描述**  
+   每个原子能力必须包含：定义、输入、输出、触发条件、失败模式、恢复策略、成功指标。
+
+6. **未获得明确确认，不得执行**  
+   最终必须询问用户是否进入执行阶段；用户未明确 `Yes` 前，不进行实现类动作。
+
+---
+
+## Required Execution Flow
+
+### Phase 0: Scope Alignment（范围对齐）
+
+在开始调研前，先确认：
+- 目标场景（CLI agent / IDE agent / server agent）
+- 约束（时间、成本、模型、工具权限）
+- 交付粒度（概念方案 / 技术设计 / 可执行任务清单）
+
+若信息不足，先提问再继续。
+
+---
+
+### Phase 1: Atomic Capability Design（原子能力拆解）
+
+先给出能力地图，建议至少覆盖：
+- Task Understanding
+- Planning
+- Tool Use
+- Context Management
+- Code Execution Loop
+- Reflection / Critique
+- Safety & Guardrails
+- Memory
+- Human-in-the-loop
+- Evaluation & Telemetry
+
+每个能力必须用统一模板：
+- 能力名
+- 定义
+- 输入
+- 输出
+- 触发条件
+- 依赖工具/上下文
+- 失败模式
+- 恢复策略
+- 成功指标（可量化优先）
+
+---
+
+### Phase 2: External Benchmarking（外部方案调研）
+
+#### Mandatory Targets
+- pi-mono
+- OpenCode
+- Claude Code
+
+#### Optional Targets（建议）
+- Cursor Agent
+- Aider
+- Copilot CLI
+
+#### Research Constraints（强约束）
+- 8-12 轮渐进式搜索（overview → architecture → loop mechanics → trade-offs → validation）
+- 每轮说明：目标、查询词、新增发现、仍存疑问
+- 至少 12 个唯一 URL
+- 优先级：官方文档 > 源码/仓库 > 技术博客 > 二手解读
+- 关键结论至少双来源交叉验证（若无法双证，标记“低置信度”）
+
+---
+
+### Phase 3: Synthesis & Proposal（综合与设计建议）
+
+输出必须包含：
+
+1. **原子能力清单（标准化定义）**
+2. **对标矩阵（实现差异）**
+3. **推荐架构（MVP / v1 / v2）**
+4. **核心 trade-off（复杂度、成本、鲁棒性、扩展性）**
+5. **风险清单与缓解策略**
+6. **待决策问题清单（5-10项）**
+
+并明确标记：
+- 哪些结论是事实
+- 哪些是推断
+- 哪些是建议
+
+---
+
+### Phase 4: Discussion Loop（与用户迭代）
+
+进入讨论模式后：
+- 每轮给出“当前建议 + 3~5 个关键问题”
+- 维护以下状态：
+  - 已确认（Confirmed）
+  - 待确认（Pending）
+  - 被修改（Changed）
+- 每轮结束更新一次决策快照
+
+当待确认问题 ≤ 2，或用户表示“方案已收敛”，进入下一阶段。
+
+---
+
+### Phase 5: Execution Confirmation（执行确认）
+
+必须使用明确问句：
+
+> “方案已基本收敛。是否需要我进入执行阶段？可选：
+> 1) 详细技术设计，
+> 2) 任务拆解与排期，
+> 3) 代码骨架，
+> 4) 直接实现。”
+
+- 若用户确认：再确认执行范围与边界后执行。
+- 若用户拒绝：输出最终设计文档与后续建议，不执行代码改动。
+
+---
+
+## Required Output Artifacts
+
+### A. Capability Spec Table
+| Capability | Definition | Input | Output | Trigger | Failure Mode | Recovery | KPI |
+|---|---|---|---|---|---|---|---|
+
+### B. Benchmark Matrix
+| System | Loop Pattern | Tool Strategy | Context Strategy | Safety Mechanism | Strengths | Limitations |
+|---|---|---|---|---|---|---|
+
+### C. Evidence Ledger
+| Claim | Type (Fact/Inference) | Source URL | Confidence (High/Med/Low) | Notes |
+|---|---|---|---|---|
+
+### D. Roadmap
+- MVP（2-4 周）
+- v1（1-2 个月）
+- v2（持续优化）
+
+### E. Decision Log
+- Confirmed
+- Pending
+- Changed
+
+---
+
+## Completion Criteria
+
+仅当以下条件全部满足，才算完成本 skill：
+- [ ] 完成 8+ 轮调研
+- [ ] 提供 12+ 唯一来源
+- [ ] 完成原子能力标准化定义
+- [ ] 输出对标矩阵与证据台账
+- [ ] 至少完成 1 轮与用户讨论迭代
+- [ ] 明确询问并记录“是否执行”

--- a/packages/cli/src/session.ts
+++ b/packages/cli/src/session.ts
@@ -24,6 +24,7 @@ export interface Session {
     totalMessages: number;
     lastMessageAt?: number;
     tags?: string[];
+    taskListId?: string;
   };
 }
 
@@ -34,6 +35,7 @@ export interface SessionSummary {
   updatedAt: number;
   messageCount: number;
   preview: string;
+  taskListId?: string;
 }
 
 export class SessionManager {
@@ -41,6 +43,10 @@ export class SessionManager {
 
   constructor() {
     this.sessionsDir = path.join(homedir(), '.pulse-coder', 'sessions');
+  }
+
+  private buildTaskListId(sessionId: string): string {
+    return `session-${sessionId}`;
   }
 
   async initialize(): Promise<void> {
@@ -52,14 +58,16 @@ export class SessionManager {
   }
 
   async createSession(title?: string): Promise<Session> {
+    const sessionId = randomUUID();
     const session: Session = {
-      id: randomUUID(),
+      id: sessionId,
       title: title || `Session ${new Date().toLocaleString()}`,
       createdAt: Date.now(),
       updatedAt: Date.now(),
       messages: [],
       metadata: {
         totalMessages: 0,
+        taskListId: this.buildTaskListId(sessionId),
       },
     };
 
@@ -118,9 +126,10 @@ export class SessionManager {
           createdAt: session.createdAt,
           updatedAt: session.updatedAt,
           messageCount: session.messages.length,
-          preview: session.messages.length > 0 
+          preview: session.messages.length > 0
             ? this.safeContent(session.messages[session.messages.length - 1].content).substring(0, 100) + '...'
             : 'No messages',
+          taskListId: session.metadata?.taskListId,
         }));
     } catch (error) {
       return [];

--- a/packages/engine/src/built-in/index.ts
+++ b/packages/engine/src/built-in/index.ts
@@ -6,6 +6,7 @@
 import { builtInMCPPlugin } from './mcp-plugin';
 import { builtInSkillsPlugin } from './skills-plugin';
 import { builtInPlanModePlugin } from './plan-mode-plugin';
+import { builtInTaskTrackingPlugin } from './task-tracking-plugin';
 import { SubAgentPlugin } from './sub-agent-plugin';
 
 /**
@@ -16,6 +17,7 @@ export const builtInPlugins = [
   builtInMCPPlugin,
   builtInSkillsPlugin,
   builtInPlanModePlugin,
+  builtInTaskTrackingPlugin,
   new SubAgentPlugin()
 ];
 
@@ -25,6 +27,8 @@ export const builtInPlugins = [
 export { builtInMCPPlugin } from './mcp-plugin';
 export { builtInSkillsPlugin, BuiltInSkillRegistry } from './skills-plugin';
 export { builtInPlanModePlugin, BuiltInPlanModeService } from './plan-mode-plugin';
+export { builtInTaskTrackingPlugin, TaskListService } from './task-tracking-plugin';
+export type { TaskStatus, WorkTask, WorkTaskListSnapshot } from './task-tracking-plugin';
 export type {
   PlanMode,
   PlanIntentLabel,

--- a/packages/engine/src/built-in/plan-mode-plugin/index.ts
+++ b/packages/engine/src/built-in/plan-mode-plugin/index.ts
@@ -169,6 +169,26 @@ const KNOWN_TOOL_META: Record<string, Omit<ToolMeta, 'name'>> = {
     category: 'other',
     risk: 'low',
     description: 'Ask the user a targeted clarification question.'
+  },
+  task_create: {
+    category: 'other',
+    risk: 'low',
+    description: 'Create tracked task entries for planning and execution visibility.'
+  },
+  task_get: {
+    category: 'other',
+    risk: 'low',
+    description: 'Inspect a task entry by ID.'
+  },
+  task_list: {
+    category: 'other',
+    risk: 'low',
+    description: 'List task tracking entries and status summary.'
+  },
+  task_update: {
+    category: 'other',
+    risk: 'low',
+    description: 'Update task tracking fields and status.'
   }
 };
 

--- a/packages/engine/src/built-in/task-tracking-plugin/index.ts
+++ b/packages/engine/src/built-in/task-tracking-plugin/index.ts
@@ -1,0 +1,539 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { homedir } from 'os';
+import { randomUUID } from 'crypto';
+import { z } from 'zod';
+
+import type { BuiltInSkillRegistry, SkillInfo } from '../skills-plugin';
+
+import type { Tool } from '../../shared/types';
+import type { EnginePlugin, EnginePluginContext } from '../../plugin/EnginePlugin';
+
+const TASK_STATUSES = ['pending', 'in_progress', 'completed', 'blocked'] as const;
+
+export type TaskStatus = (typeof TASK_STATUSES)[number];
+
+export interface WorkTask {
+  id: string;
+  title: string;
+  details?: string;
+  status: TaskStatus;
+  dependencies: string[];
+  blockedReason?: string;
+  metadata?: Record<string, any>;
+  createdAt: number;
+  updatedAt: number;
+  completedAt?: number;
+}
+
+export interface WorkTaskListSnapshot {
+  taskListId: string;
+  storagePath: string;
+  createdAt: number;
+  updatedAt: number;
+  total: number;
+  tasks: WorkTask[];
+}
+
+interface TaskListStoreFile {
+  taskListId: string;
+  createdAt: number;
+  updatedAt: number;
+  tasks: WorkTask[];
+}
+
+interface CreateTaskInput {
+  title: string;
+  details?: string;
+  status?: TaskStatus;
+  dependencies?: string[];
+  blockedReason?: string;
+  metadata?: Record<string, any>;
+}
+
+interface ListTaskOptions {
+  statuses?: TaskStatus[];
+  includeCompleted?: boolean;
+  limit?: number;
+}
+
+interface UpdateTaskInput {
+  id: string;
+  title?: string;
+  details?: string;
+  status?: TaskStatus;
+  dependencies?: string[];
+  blockedReason?: string;
+  metadata?: Record<string, any>;
+  delete?: boolean;
+}
+
+const CREATE_TASK_ITEM_SCHEMA = z.object({
+  title: z.string().min(1).describe('Task title'),
+  details: z.string().optional().describe('Task details / acceptance notes'),
+  status: z.enum(TASK_STATUSES).optional().describe('Initial status; defaults to pending'),
+  dependencies: z.array(z.string()).optional().describe('Task IDs that must be completed first'),
+  blockedReason: z.string().optional().describe('Reason when status is blocked'),
+  metadata: z.record(z.string(), z.any()).optional().describe('Additional machine-readable metadata')
+});
+
+const TASK_CREATE_INPUT_SCHEMA = z
+  .object({
+    title: z.string().min(1).optional().describe('Task title (single-task mode)'),
+    details: z.string().optional().describe('Task details (single-task mode)'),
+    status: z.enum(TASK_STATUSES).optional().describe('Initial status (single-task mode)'),
+    dependencies: z.array(z.string()).optional().describe('Dependencies (single-task mode)'),
+    blockedReason: z.string().optional().describe('Blocked reason (single-task mode)'),
+    metadata: z.record(z.string(), z.any()).optional().describe('Metadata (single-task mode)'),
+    tasks: z.array(CREATE_TASK_ITEM_SCHEMA).min(1).optional().describe('Batch create mode')
+  })
+  .refine((value) => !!value.tasks?.length || !!value.title, {
+    message: 'Either provide `tasks` or `title` for single-task mode.'
+  });
+
+const TASK_GET_INPUT_SCHEMA = z.object({
+  id: z.string().min(1).describe('Task ID to retrieve')
+});
+
+const TASK_LIST_INPUT_SCHEMA = z.object({
+  statuses: z.array(z.enum(TASK_STATUSES)).optional().describe('Filter by statuses'),
+  includeCompleted: z.boolean().optional().describe('Set false to hide completed tasks'),
+  limit: z.number().int().positive().max(500).optional().describe('Maximum tasks to return')
+});
+const TASK_TRACKING_SKILL: SkillInfo = {
+  name: 'task-tracking-workflow',
+  description: 'Track complex execution with task tools and proceed directly without confirmation unless the user explicitly asks for confirmation.',
+  location: 'pulse-coder-engine/built-in/task-tracking-plugin',
+  content: `# Task Tracking Workflow
+
+## When to use
+- The request has multiple phases or deliverables.
+- Work may span multiple tool calls or sessions.
+- You need explicit progress visibility and blocker management.
+
+## Execution autonomy
+- Default behavior: execute directly and call tools without asking for confirmation.
+- Only ask for confirmation when the user explicitly requires confirmation.
+- If critical information is missing, ask only the minimum clarifying question needed to continue.
+
+## Required flow
+1. Start by reviewing existing tasks with \`task_list\`.
+2. If no suitable tasks exist, create focused tasks with \`task_create\` (prefer batch mode).
+3. Keep exactly one primary task in \`in_progress\` where possible.
+4. Update status with \`task_update\` after meaningful progress.
+5. Mark blockers with \`status=blocked\` and a concrete \`blockedReason\`.
+6. Mark done tasks as \`completed\` and move to the next actionable item.
+
+## Quality rules
+- Keep tasks atomic and verifiable.
+- Avoid single oversized umbrella tasks.
+- Reuse existing in-progress tasks instead of duplicating.
+- Keep dependency links explicit when order matters.`
+};
+
+const TASK_UPDATE_INPUT_SCHEMA = z.object({
+  id: z.string().min(1).describe('Task ID to update'),
+  title: z.string().min(1).optional().describe('New title'),
+  details: z.string().optional().describe('New details'),
+  status: z.enum(TASK_STATUSES).optional().describe('New status'),
+  dependencies: z.array(z.string()).optional().describe('Replace dependencies with this list'),
+  blockedReason: z.string().optional().describe('Blocked reason, used with status=blocked'),
+  metadata: z.record(z.string(), z.any()).optional().describe('Replace metadata object'),
+  delete: z.boolean().optional().describe('Delete this task')
+});
+
+function normalizeTaskListId(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return 'default';
+  }
+
+  return trimmed.replace(/[^a-zA-Z0-9._-]/g, '-').slice(0, 120) || 'default';
+}
+
+function now(): number {
+  return Date.now();
+}
+
+
+function dedupeStrings(values: string[] | undefined): string[] {
+  if (!values?.length) {
+    return [];
+  }
+
+  return Array.from(new Set(values.map((value) => String(value).trim()).filter(Boolean)));
+}
+
+export class TaskListService {
+  taskListId: string;
+  storagePath: string;
+
+  private readonly storageDir: string;
+  private initialized = false;
+  private createdAt = now();
+  private updatedAt = now();
+  private tasks = new Map<string, WorkTask>();
+
+  constructor(
+    taskListId: string = TaskListService.resolveTaskListId(),
+    storageDir: string = TaskListService.resolveStorageDir()
+  ) {
+    const normalized = normalizeTaskListId(taskListId);
+
+    this.storageDir = storageDir;
+    this.taskListId = normalized;
+    this.storagePath = path.join(this.storageDir, `${normalized}.json`);
+  }
+
+  static resolveTaskListId(): string {
+    return process.env.PULSE_CODER_TASK_LIST_ID
+      || process.env.CLAUDE_CODE_TASK_LIST_ID
+      || 'default';
+  }
+
+  static resolveStorageDir(): string {
+    return process.env.PULSE_CODER_TASKS_DIR
+      || path.join(homedir(), '.pulse-coder', 'tasks');
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initialized) {
+      return;
+    }
+
+    await this.loadTaskList(this.taskListId);
+  }
+
+  async setTaskListId(taskListId: string): Promise<{ switched: boolean; taskListId: string; storagePath: string }> {
+    await this.initialize();
+
+    const normalized = normalizeTaskListId(taskListId);
+    if (normalized === this.taskListId) {
+      return {
+        switched: false,
+        taskListId: this.taskListId,
+        storagePath: this.storagePath
+      };
+    }
+
+    await this.loadTaskList(normalized);
+
+    return {
+      switched: true,
+      taskListId: this.taskListId,
+      storagePath: this.storagePath
+    };
+  }
+
+  async createTask(input: CreateTaskInput): Promise<WorkTask> {
+    await this.initialize();
+
+    const timestamp = now();
+    const status = input.status ?? 'pending';
+
+    const task: WorkTask = {
+      id: randomUUID(),
+      title: input.title.trim(),
+      details: input.details,
+      status,
+      dependencies: dedupeStrings(input.dependencies),
+      blockedReason: status === 'blocked' ? input.blockedReason ?? 'Blocked without reason' : undefined,
+      metadata: input.metadata,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      completedAt: status === 'completed' ? timestamp : undefined
+    };
+
+    this.tasks.set(task.id, task);
+    this.updatedAt = timestamp;
+    await this.persist();
+
+    return task;
+  }
+
+  async createTasks(inputs: CreateTaskInput[]): Promise<WorkTask[]> {
+    const created: WorkTask[] = [];
+    for (const input of inputs) {
+      created.push(await this.createTask(input));
+    }
+    return created;
+  }
+
+  async listTasks(options?: ListTaskOptions): Promise<WorkTask[]> {
+    await this.initialize();
+
+    const statuses = options?.statuses?.length ? new Set(options.statuses) : null;
+    const includeCompleted = options?.includeCompleted ?? true;
+
+    let tasks = Array.from(this.tasks.values()).filter((task) => {
+      if (!includeCompleted && task.status === 'completed') {
+        return false;
+      }
+      if (statuses && !statuses.has(task.status)) {
+        return false;
+      }
+      return true;
+    });
+
+    tasks = tasks.sort((a, b) => a.createdAt - b.createdAt);
+
+    if (options?.limit && options.limit > 0) {
+      tasks = tasks.slice(0, options.limit);
+    }
+
+    return tasks;
+  }
+
+  async getTask(id: string): Promise<WorkTask | null> {
+    await this.initialize();
+    return this.tasks.get(id) ?? null;
+  }
+
+  async updateTask(input: UpdateTaskInput): Promise<WorkTask | null> {
+    await this.initialize();
+
+    if (input.delete) {
+      const deleted = this.tasks.delete(input.id);
+      if (!deleted) {
+        return null;
+      }
+
+      this.updatedAt = now();
+      await this.persist();
+      return null;
+    }
+
+    const existing = this.tasks.get(input.id);
+    if (!existing) {
+      return null;
+    }
+
+    const timestamp = now();
+    const nextStatus = input.status ?? existing.status;
+
+    const next: WorkTask = {
+      ...existing,
+      title: input.title !== undefined ? input.title : existing.title,
+      details: input.details !== undefined ? input.details : existing.details,
+      status: nextStatus,
+      dependencies: input.dependencies !== undefined ? dedupeStrings(input.dependencies) : existing.dependencies,
+      metadata: input.metadata !== undefined ? input.metadata : existing.metadata,
+      blockedReason: this.resolveBlockedReason(nextStatus, input.blockedReason, existing.blockedReason),
+      updatedAt: timestamp,
+      completedAt: nextStatus === 'completed'
+        ? (existing.completedAt ?? timestamp)
+        : undefined
+    };
+
+    this.tasks.set(input.id, next);
+    this.updatedAt = timestamp;
+    await this.persist();
+
+    return next;
+  }
+
+  async snapshot(options?: ListTaskOptions): Promise<WorkTaskListSnapshot> {
+    const tasks = await this.listTasks(options);
+
+    return {
+      taskListId: this.taskListId,
+      storagePath: this.storagePath,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+      total: tasks.length,
+      tasks
+    };
+  }
+
+  private resolveBlockedReason(status: TaskStatus, blockedReasonInput: string | undefined, previous?: string): string | undefined {
+    if (status !== 'blocked') {
+      return undefined;
+    }
+
+    if (blockedReasonInput !== undefined) {
+      return blockedReasonInput || 'Blocked without reason';
+    }
+
+    return previous ?? 'Blocked without reason';
+  }
+
+  private async loadTaskList(taskListId: string): Promise<void> {
+    const normalized = normalizeTaskListId(taskListId);
+
+    this.taskListId = normalized;
+    this.storagePath = path.join(this.storageDir, `${normalized}.json`);
+
+    await fs.mkdir(this.storageDir, { recursive: true });
+
+    try {
+      const raw = await fs.readFile(this.storagePath, 'utf-8');
+      const parsed = JSON.parse(raw) as Partial<TaskListStoreFile>;
+
+      const parsedTasks = Array.isArray(parsed.tasks) ? parsed.tasks : [];
+      this.tasks = new Map(parsedTasks.filter((task): task is WorkTask => !!task?.id).map((task) => [task.id, task]));
+      this.createdAt = typeof parsed.createdAt === 'number' ? parsed.createdAt : now();
+      this.updatedAt = typeof parsed.updatedAt === 'number' ? parsed.updatedAt : now();
+    } catch (error: any) {
+      if (error?.code !== 'ENOENT') {
+        throw error;
+      }
+
+      const timestamp = now();
+      this.tasks = new Map();
+      this.createdAt = timestamp;
+      this.updatedAt = timestamp;
+      await this.persist();
+    }
+
+    this.initialized = true;
+  }
+
+  private async persist(): Promise<void> {
+    const payload: TaskListStoreFile = {
+      taskListId: this.taskListId,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+      tasks: Array.from(this.tasks.values()).sort((a, b) => a.createdAt - b.createdAt)
+    };
+
+    await fs.writeFile(this.storagePath, JSON.stringify(payload, null, 2), 'utf-8');
+  }
+}
+
+function buildTaskCreateTool(service: TaskListService): Tool {
+  return {
+    name: 'task_create',
+    description: 'Create one or more tracked tasks for complex work. Use this when work has multiple steps, dependencies, or blockers.',
+    inputSchema: TASK_CREATE_INPUT_SCHEMA,
+    execute: async ({ tasks, title, details, status, dependencies, blockedReason, metadata }) => {
+      const items: CreateTaskInput[] = tasks?.length
+        ? tasks
+        : [{ title: title!, details, status, dependencies, blockedReason, metadata }];
+
+      const created = await service.createTasks(items);
+
+      return {
+        taskListId: service.taskListId,
+        storagePath: service.storagePath,
+        createdCount: created.length,
+        tasks: created
+      };
+    }
+  };
+}
+
+function buildTaskGetTool(service: TaskListService): Tool {
+  return {
+    name: 'task_get',
+    description: 'Get full details for a single task by task ID.',
+    inputSchema: TASK_GET_INPUT_SCHEMA,
+    execute: async ({ id }) => {
+      const task = await service.getTask(id);
+      if (!task) {
+        throw new Error(`Task not found: ${id}`);
+      }
+
+      return {
+        taskListId: service.taskListId,
+        storagePath: service.storagePath,
+        task
+      };
+    }
+  };
+}
+
+function buildTaskListTool(service: TaskListService): Tool {
+  return {
+    name: 'task_list',
+    description: 'List tasks and their current status. Use this to check progress before and after major changes.',
+    inputSchema: TASK_LIST_INPUT_SCHEMA,
+    execute: async ({ statuses, includeCompleted, limit }) => {
+      const snapshot = await service.snapshot({ statuses, includeCompleted, limit });
+      const completed = snapshot.tasks.filter((task) => task.status === 'completed').length;
+      const inProgress = snapshot.tasks.filter((task) => task.status === 'in_progress').length;
+      const pending = snapshot.tasks.filter((task) => task.status === 'pending').length;
+      const blocked = snapshot.tasks.filter((task) => task.status === 'blocked').length;
+
+      return {
+        ...snapshot,
+        summary: {
+          total: snapshot.total,
+          completed,
+          inProgress,
+          pending,
+          blocked
+        }
+      };
+    }
+  };
+}
+
+
+
+function buildTaskUpdateTool(service: TaskListService): Tool {
+  return {
+    name: 'task_update',
+    description: 'Update task fields, move status (pending/in_progress/completed/blocked), or delete tasks.',
+    inputSchema: TASK_UPDATE_INPUT_SCHEMA,
+    execute: async (input) => {
+      const task = await service.updateTask(input);
+
+      if (input.delete) {
+        return {
+          taskListId: service.taskListId,
+          storagePath: service.storagePath,
+          deleted: true,
+          id: input.id
+        };
+      }
+
+      if (!task) {
+        throw new Error(`Task not found: ${input.id}`);
+      }
+
+      return {
+        taskListId: service.taskListId,
+        storagePath: service.storagePath,
+        deleted: false,
+        task
+      };
+    }
+  };
+}
+
+export const builtInTaskTrackingPlugin: EnginePlugin = {
+  name: 'pulse-coder-engine/built-in-task-tracking',
+  version: '1.0.0',
+  dependencies: ['pulse-coder-engine/built-in-skills'],
+
+  async initialize(context: EnginePluginContext): Promise<void> {
+    const service = new TaskListService();
+    await service.initialize();
+
+    context.registerService('taskListService', service);
+    context.registerService('taskTracking', service);
+
+    const skillRegistry = context.getService<BuiltInSkillRegistry>('skillRegistry');
+    if (skillRegistry) {
+      const registration = skillRegistry.registerSkill(TASK_TRACKING_SKILL);
+      context.logger.info('[TaskTracking] Registered built-in task tracking skill', registration);
+    } else {
+      context.logger.warn('[TaskTracking] skillRegistry service unavailable; skipped task tracking skill registration');
+    }
+
+    context.registerTools({
+      task_create: buildTaskCreateTool(service),
+      task_get: buildTaskGetTool(service),
+      task_list: buildTaskListTool(service),
+      task_update: buildTaskUpdateTool(service)
+    });
+
+    context.logger.info('[TaskTracking] Registered task tools', {
+      taskListId: service.taskListId,
+      storagePath: service.storagePath,
+      skillRegistryAvailable: !!skillRegistry
+    });
+  }
+};
+
+export default builtInTaskTrackingPlugin;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -27,8 +27,10 @@ export {
   builtInMCPPlugin,
   builtInSkillsPlugin,
   builtInPlanModePlugin,
+  builtInTaskTrackingPlugin,
   BuiltInSkillRegistry,
-  BuiltInPlanModeService
+  BuiltInPlanModeService,
+  TaskListService,
 } from './built-in/index.js';
 export type {
   PlanMode,
@@ -40,7 +42,10 @@ export type {
   PlanModeEvent,
   PlanModeEventName,
   PlanModeTransitionResult,
-  PlanModeService
+  PlanModeService,
+  TaskStatus,
+  WorkTask,
+  WorkTaskListSnapshot
 } from './built-in/index.js';
 
 // 原有导出保持不变


### PR DESCRIPTION
Introduce built-in task tracking and runtime skill registration.

- Add a built-in task-tracking plugin with task_create/task_get/task_list/task_update and persisted task storage
- Register task-tracking-workflow skill during task plugin initialization
- Extend the skills registry with runtime registerSkill support and case-insensitive lookup
- Refresh skill tool metadata before each run so newly injected skills are visible
- Wire engine/CLI built-in registrations and add agent-research skill docs