### PR TITLE
feat: support skill command 

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pulse-coder-cli",
-  "version": "0.0.1-alpha.12",
+  "version": "0.0.1-alpha.13",
   "description": "CLI interface for Pulse Coder",
   "type": "commonjs",
   "main": "./dist/index.cjs",

--- a/packages/cli/src/skill-commands.ts
+++ b/packages/cli/src/skill-commands.ts
@@ -1,0 +1,120 @@
+import type { PulseAgent } from 'pulse-coder-engine';
+
+interface SkillSummary {
+  name: string;
+  description: string;
+}
+
+interface SkillRegistryService {
+  getAll: () => SkillSummary[];
+  get: (name: string) => SkillSummary | undefined;
+}
+
+export class SkillCommands {
+  constructor(private agent: PulseAgent) {}
+
+  async transformSkillsCommandToMessage(args: string[]): Promise<string | null> {
+    const registry = this.getSkillRegistry();
+    if (!registry) {
+      console.log('\n⚠️ skill registry unavailable. Ensure built-in skills plugin is enabled.');
+      return null;
+    }
+
+    const skills = this.getAvailableSkills();
+    if (skills.length === 0) {
+      console.log('\n📭 No skills found. Add SKILL.md under .pulse-coder/skills/**/SKILL.md');
+      return null;
+    }
+
+    const subCommand = args[0]?.toLowerCase();
+
+    if (!subCommand || subCommand === 'list') {
+      this.printSkillList(skills);
+      console.log('\nUsage: /skills <name|index> <message>');
+      return null;
+    }
+
+    if (subCommand === 'current' || subCommand === 'clear' || subCommand === 'off' || subCommand === 'none') {
+      console.log('\nℹ️ Skills are single-use. Use /skills <name|index> <message> to run one prompt with a skill.');
+      return null;
+    }
+
+    let selectionTokens = args;
+    if (subCommand === 'use') {
+      selectionTokens = args.slice(1);
+    }
+
+    if (selectionTokens.length < 2) {
+      console.log('\n❌ Please provide both a skill and a message.');
+      console.log('Usage: /skills <name|index> <message>');
+      return null;
+    }
+
+    const skillTarget = selectionTokens[0];
+    const selectedSkill = this.resolveSkillSelection(skillTarget, skills);
+    if (!selectedSkill) {
+      console.log(`\n❌ Skill not found: ${skillTarget}`);
+      console.log('Run /skills list to see available skills.');
+      return null;
+    }
+
+    const message = selectionTokens.slice(1).join(' ').trim();
+    if (!message) {
+      console.log('\n❌ Message cannot be empty.');
+      console.log('Usage: /skills <name|index> <message>');
+      return null;
+    }
+
+    const transformed = `[use skill](${selectedSkill.name}) ${message}`;
+    console.log(`\n✅ One-shot skill message prepared with: ${selectedSkill.name}`);
+    return transformed;
+  }
+
+  private printSkillList(skills: SkillSummary[]): void {
+    console.log('\n🧰 Available skills:');
+    skills.forEach((skill, index) => {
+      console.log(`${String(index + 1).padStart(2, ' ')}. ${skill.name} - ${skill.description}`);
+    });
+  }
+
+  private getSkillRegistry(): SkillRegistryService | undefined {
+    return this.agent.getService<SkillRegistryService>('skillRegistry');
+  }
+
+  private getAvailableSkills(): SkillSummary[] {
+    const registry = this.getSkillRegistry();
+    if (!registry) {
+      return [];
+    }
+
+    return [...registry.getAll()].sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  private resolveSkillSelection(target: string, skills: SkillSummary[]): SkillSummary | null {
+    const trimmed = target.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    if (/^\d+$/.test(trimmed)) {
+      const index = Number.parseInt(trimmed, 10);
+      if (index >= 1 && index <= skills.length) {
+        return skills[index - 1];
+      }
+      return null;
+    }
+
+    const lower = trimmed.toLowerCase();
+    const exact = skills.find((skill) => skill.name.toLowerCase() === lower);
+    if (exact) {
+      return exact;
+    }
+
+    const fuzzy = skills.filter((skill) => skill.name.toLowerCase().includes(lower));
+    if (fuzzy.length === 1) {
+      return fuzzy[0];
+    }
+
+    return null;
+  }
+}

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pulse-coder-engine",
-  "version": "0.0.1-alpha.11",
+  "version": "0.0.1-alpha.12",
   "description": "Plugin-based AI engine for Pulse Coder",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/engine/src/core/loop.ts
+++ b/packages/engine/src/core/loop.ts
@@ -181,16 +181,19 @@ export async function loop(context: Context, options?: LoopOptions): Promise<str
       }
 
       if (finishReason === 'stop') {
+        if (!text) {
+          continue;
+        }
         return text || 'Task completed.';
       }
 
       if (finishReason === 'length') {
         if (compactionAttempts < MAX_COMPACTION_ATTEMPTS) {
           const { didCompact, newMessages } = await maybeCompactContext(context, {
-          force: true,
-          provider: options?.provider,
-          model: options?.model,
-        });
+            force: true,
+            provider: options?.provider,
+            model: options?.model,
+          });
           if (didCompact) {
             compactionAttempts++;
             if (newMessages) {
@@ -214,6 +217,10 @@ export async function loop(context: Context, options?: LoopOptions): Promise<str
         if (totalSteps >= MAX_STEPS) {
           return text || 'Max steps reached, task may be incomplete.';
         }
+        continue;
+      }
+
+      if (!text) {
         continue;
       }
 

--- a/packages/pulse-sandbox/package.json
+++ b/packages/pulse-sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pulse-sandbox",
-  "version": "0.0.1-alpha.4",
+  "version": "0.0.1-alpha.5",
   "description": "Sandboxed JavaScript runtime and engine tool adapter for Pulse Coder",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Add CLI and engine support for skill command execution flow

- Add new skill-commands module in CLI for command handling
- Wire skill command execution into src/index.ts
- Update engine loop logic to support task plugin integration path
- Keep changes focused on command dispatch and runtime flow coordination