### PR TITLE
Fix remote-server PM2 startup with CJS bundle

### DIFF
--- a/apps/remote-server/README.md
+++ b/apps/remote-server/README.md
@@ -33,4 +33,4 @@ pm2 startup
 pm2 save
 ```
 
-> `ecosystem.config.cjs` is configured to run `dist/index.js` in fork mode with autorestart and memory guard.
+> `ecosystem.config.cjs` is configured to run `dist/index.cjs` in fork mode with autorestart and memory guard.

--- a/apps/remote-server/ecosystem.config.cjs
+++ b/apps/remote-server/ecosystem.config.cjs
@@ -3,7 +3,7 @@ module.exports = {
     {
       name: 'remote-server',
       cwd: __dirname,
-      script: 'dist/index.js',
+      script: 'dist/index.cjs',
       interpreter: 'node',
       exec_mode: 'fork',
       instances: 1,

--- a/apps/remote-server/package.json
+++ b/apps/remote-server/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsup",
-    "start": "node dist/index.js",
+    "start": "node dist/index.cjs",
     "pm2:start": "npm run build && pm2 start ecosystem.config.cjs --env production",
     "pm2:restart": "npm run build && pm2 restart remote-server --update-env",
     "pm2:stop": "pm2 stop remote-server",

--- a/apps/remote-server/tsup.config.ts
+++ b/apps/remote-server/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: { index: 'src/index.ts' },
-  format: ['esm'],
+  format: ['cjs'],
   dts: false,
   clean: true,
   splitting: false,
@@ -10,4 +10,9 @@ export default defineConfig({
   target: 'es2022',
   platform: 'node',
   noExternal: ['pulse-coder-engine'],
+  outExtension({ format }) {
+    return {
+      js: format === 'cjs' ? '.cjs' : '.js',
+    };
+  },
 });


### PR DESCRIPTION
Fix remote-server runtime compatibility under PM2 by switching the server build output to CommonJS.

- Change tsup output format from ESM to CJS and emit dist/index.cjs
- Update start script and PM2 ecosystem config to run dist/index.cjs
- Update remote-server README to reflect the new runtime entry file