### PR TITLE
Fix Lark heartbeat updates for long tool runs

### DIFF
--- a/apps/remote-server/src/adapters/feishu/client.ts
+++ b/apps/remote-server/src/adapters/feishu/client.ts
@@ -83,7 +83,7 @@ export function buildThinkingCard(): object {
     schema: '2.0',
     config: { enable_forward: false },
     body: {
-      elements: [{ tag: 'markdown', content: '⏳ Working on it...' }],
+      elements: [{ tag: 'markdown', content: 'Pulse is thinking...' }],
     },
   };
 }
@@ -93,7 +93,7 @@ export function buildProgressCard(text: string): object {
     schema: '2.0',
     config: { enable_forward: false },
     body: {
-      elements: [{ tag: 'markdown', content: text || '⏳ Working on it...' }],
+      elements: [{ tag: 'markdown', content: text || 'Pulse is thinking...' }],
     },
   };
 }


### PR DESCRIPTION
Improve Feishu (Lark) run feedback reliability during long tool calls and preserve error delivery state.

- Add periodic heartbeat card updates (12s) to avoid long silent gaps
- Include elapsed time in progress card content for visible keepalive updates
- Stop heartbeat and timers on done and error to avoid stale updates
- Reuse the same stream handle in dispatcher error path before fallback creation
- Update default thinking copy to "Pulse is thinking..."