### PR TITLE
Improve Lark loading status with animated dots

### DIFF
--- a/apps/remote-server/src/adapters/feishu/adapter.ts
+++ b/apps/remote-server/src/adapters/feishu/adapter.ts
@@ -148,6 +148,7 @@ export class FeishuAdapter implements PlatformAdapter {
 
     const PROGRESS_UPDATE_INTERVAL_MS = 800;
     const HEARTBEAT_INTERVAL_MS = 12000;
+    const DOT_ANIMATION_STEP_MS = 4000;
     const runStartedAt = Date.now();
 
     let throttleHandle: ReturnType<typeof setTimeout> | null = null;
@@ -172,11 +173,15 @@ export class FeishuAdapter implements PlatformAdapter {
     };
 
     const renderProgressText = (): string => {
-      const baseText = accumulatedText
+      const dotCount = 2 + Math.floor((Date.now() - runStartedAt) / DOT_ANIMATION_STEP_MS) % 3;
+      const loadingTitle = `Pulse 努力生成中${'.'.repeat(dotCount)}`;
+      const detailText = accumulatedText
         ? (latestToolHint ? `${latestToolHint}\n\n${accumulatedText}` : accumulatedText)
-        : (latestToolHint || 'Pulse is thinking...');
+        : latestToolHint;
 
-      return `${baseText}\n\n⏱️ Elapsed: ${formatElapsed()}`;
+      return detailText
+        ? `${loadingTitle}\n\n${detailText}\n\n⏱️ Elapsed: ${formatElapsed()}`
+        : `${loadingTitle}\n\n⏱️ Elapsed: ${formatElapsed()}`;
     };
 
     const clearScheduledProgress = () => {


### PR DESCRIPTION
Refine Feishu progress card readability by surfacing a stable top loading state while preserving details.

- Add a timed dot animation step for the loading title
- Show  at the top with 2-4 trailing dots
- Keep tool/output details in the middle when available
- Keep elapsed time at the bottom for run visibility
- Reuse existing heartbeat/throttle cadence without extra update pressure