### PR TITLE
Add /status and /stop commands to remote server

### DIFF
--- a/apps/remote-server/src/adapters/feishu/adapter.ts
+++ b/apps/remote-server/src/adapters/feishu/adapter.ts
@@ -2,7 +2,7 @@ import type { HonoRequest, Context as HonoContext } from 'hono';
 import type { PlatformAdapter, IncomingMessage, StreamHandle } from '../../core/types.js';
 import type { ClarificationRequest } from '../../core/types.js';
 import { clarificationQueue } from '../../core/clarification-queue.js';
-import { getActiveStreamId } from '../../core/dispatcher.js';
+import { getActiveStreamId } from '../../core/active-run-store.js';
 import {
   createLarkClient,
   sendTextMessage,

--- a/apps/remote-server/src/adapters/telegram/adapter.ts
+++ b/apps/remote-server/src/adapters/telegram/adapter.ts
@@ -2,7 +2,7 @@ import type { HonoRequest, Context as HonoContext } from 'hono';
 import type { PlatformAdapter, IncomingMessage, StreamHandle } from '../../core/types.js';
 import type { ClarificationRequest } from '../../core/types.js';
 import { clarificationQueue } from '../../core/clarification-queue.js';
-import { getActiveStreamId } from '../../core/dispatcher.js';
+import { getActiveStreamId } from '../../core/active-run-store.js';
 import { TelegramClient } from './client.js';
 
 /**
@@ -53,7 +53,7 @@ export class TelegramAdapter implements PlatformAdapter {
     if (text === '/start') {
       await this.client.sendMessage(
         chatId,
-        'Hi! I\'m your AI coding assistant.\n\nAvailable commands:\n/new - Start a new session\n/clear - Clear current session context\n/compact - Force compact current session context\n/resume - List recent sessions\n/resume <id> - Resume a specific session\n/skills list - Show available skills\n/skills <name|index> <message> - Run one message with a skill'
+        'Hi! I\'m your AI coding assistant.\n\nAvailable commands:\n/new - Start a new session\n/clear - Clear current session context\n/compact - Force compact current session context\n/resume - List recent sessions\n/sessions - Alias of /resume\n/resume <id> - Resume a specific session\n/status - Show current run/session status\n/stop - Stop current running task\n/skills list - Show available skills\n/skills <name|index> <message> - Run one message with a skill'
       );
       return null;
     }

--- a/apps/remote-server/src/core/active-run-store.ts
+++ b/apps/remote-server/src/core/active-run-store.ts
@@ -1,0 +1,39 @@
+import type { ActiveRun } from './types.js';
+
+const activeRuns = new Map<string, ActiveRun>();
+
+export function hasActiveRun(platformKey: string): boolean {
+  return activeRuns.has(platformKey);
+}
+
+export function getActiveRun(platformKey: string): ActiveRun | undefined {
+  return activeRuns.get(platformKey);
+}
+
+export function setActiveRun(platformKey: string, run: ActiveRun): void {
+  activeRuns.set(platformKey, run);
+}
+
+export function clearActiveRun(platformKey: string): void {
+  activeRuns.delete(platformKey);
+}
+
+export function getActiveStreamId(platformKey: string): string | undefined {
+  return activeRuns.get(platformKey)?.streamId;
+}
+
+export function abortActiveRun(platformKey: string): { aborted: boolean; startedAt?: number } {
+  const run = activeRuns.get(platformKey);
+  if (!run) {
+    return { aborted: false };
+  }
+
+  if (!run.ac.signal.aborted) {
+    run.ac.abort();
+  }
+
+  return {
+    aborted: true,
+    startedAt: run.startedAt,
+  };
+}

--- a/apps/remote-server/src/core/session-store.ts
+++ b/apps/remote-server/src/core/session-store.ts
@@ -23,6 +23,13 @@ export interface RemoteSessionSummary {
   preview: string;
 }
 
+export interface CurrentSessionStatus {
+  sessionId: string;
+  createdAt: number;
+  updatedAt: number;
+  messageCount: number;
+}
+
 export interface AttachSessionResult {
   ok: boolean;
   reason?: string;
@@ -157,6 +164,28 @@ class RemoteSessionStore {
    */
   getCurrentSessionId(platformKey: string): string | undefined {
     return this.index[platformKey];
+  }
+
+  /**
+   * Get summary of the currently attached session for a user.
+   */
+  async getCurrentStatus(platformKey: string): Promise<CurrentSessionStatus | null> {
+    const sessionId = this.index[platformKey];
+    if (!sessionId) {
+      return null;
+    }
+
+    const session = await this.readSession(sessionId);
+    if (!session || session.platformKey !== platformKey) {
+      return null;
+    }
+
+    return {
+      sessionId,
+      createdAt: session.createdAt,
+      updatedAt: session.updatedAt,
+      messageCount: session.messages.length,
+    };
   }
 
   /**

--- a/apps/remote-server/src/core/types.ts
+++ b/apps/remote-server/src/core/types.ts
@@ -72,4 +72,5 @@ export interface PlatformAdapter {
 export interface ActiveRun {
   streamId: string;
   ac: AbortController;
+  startedAt: number;
 }


### PR DESCRIPTION
Enhance remote chat command controls and run-state handling in the remote server.

- Add  as an alias of  for session listing
- Add  to report active run state and current session metadata
- Add  to abort in-flight runs cleanly
- Introduce  to share active run state across dispatcher and adapters
- Update Feishu/Telegram adapters to use centralized active stream lookup
- Return a clear "stopped" result for aborted runs instead of generic errors

Validation
- pnpm --filter @pulse-coder/remote-server build