### PR TITLE
Add more remote chat commands and aliases

### DIFF
--- a/apps/remote-server/src/adapters/telegram/adapter.ts
+++ b/apps/remote-server/src/adapters/telegram/adapter.ts
@@ -53,7 +53,7 @@ export class TelegramAdapter implements PlatformAdapter {
     if (text === '/start') {
       await this.client.sendMessage(
         chatId,
-        'Hi! I\'m your AI coding assistant.\n\nAvailable commands:\n/new - Start a new session\n/clear - Clear current session context\n/compact - Force compact current session context\n/resume - List recent sessions\n/sessions - Alias of /resume\n/resume <id> - Resume a specific session\n/status - Show current run/session status\n/stop - Stop current running task\n/skills list - Show available skills\n/skills <name|index> <message> - Run one message with a skill'
+        'Hi! I\'m your AI coding assistant.\n\nAvailable commands:\n/help - Show command help\n/ping - Check bot health\n/new - Start a new session\n/restart - Alias of /new\n/clear - Clear current session context\n/reset - Alias of /clear\n/compact - Force compact current session context\n/current - Show current bound session\n/detach - Detach current session binding\n/resume - List recent sessions\n/resume [list] [N] - List recent N sessions (1-30)\n/sessions - Alias of /resume\n/resume <id> - Resume a specific session\n/status - Show current run/session status\n/stop - Stop current running task\n/cancel - Alias of /stop\n/skills list - Show available skills\n/skills <name|index> <message> - Run one message with a skill'
       );
       return null;
     }


### PR DESCRIPTION
Expand remote chat command coverage and improve command ergonomics.

- Add /ping, /current, and /detach command handlers
- Add command aliases (/restart, /reset, /cancel, /halt, /ls, /session, /h, /?)
- Extend /resume to support list mode with configurable limits (1-30)
- Update help output and Telegram /start command guide to match new commands