### PR TITLE
Introduce memory plugin with semantic recall

### DIFF
--- a/apps/remote-server/.env.example
+++ b/apps/remote-server/.env.example
@@ -8,6 +8,21 @@ PORT=3000
 # Bind address (default public; use 127.0.0.1 to lock down all routes)
 HOST=0.0.0.0
 
+# === Memory Plugin ===
+# Enable semantic recall and vector scoring.
+MEMORY_SEMANTIC_RECALL_ENABLED=true
+# hash (local lightweight) | openai (model embeddings)
+MEMORY_EMBEDDING_STRATEGY=hash
+# Hash strategy defaults to 256; OpenAI strategy defaults to 1536.
+MEMORY_EMBEDDING_DIMENSIONS=256
+# Optional timeout for openai strategy
+MEMORY_EMBEDDING_TIMEOUT_MS=15000
+# Optional dedicated embedding endpoint credentials (falls back to OPENAI_* when empty)
+MEMORY_EMBEDDING_API_KEY=
+MEMORY_EMBEDDING_API_URL=
+# Optional; falls back to OPENAI_EMBEDDING_MODEL and then text-embedding-3-small
+MEMORY_EMBEDDING_MODEL=
+
 # === 飞书 / Feishu ===
 FEISHU_APP_ID=
 FEISHU_APP_SECRET=

--- a/apps/remote-server/package.json
+++ b/apps/remote-server/package.json
@@ -19,7 +19,8 @@
     "dotenv": "^16.4.7",
     "hono": "^4.6.0",
     "pulse-coder-engine": "workspace:*",
-    "pulse-coder-memory-plugin": "workspace:*"
+    "pulse-coder-memory-plugin": "workspace:*",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/apps/remote-server/package.json
+++ b/apps/remote-server/package.json
@@ -18,7 +18,8 @@
     "@larksuiteoapi/node-sdk": "^1.59.0",
     "dotenv": "^16.4.7",
     "hono": "^4.6.0",
-    "pulse-coder-engine": "workspace:*"
+    "pulse-coder-engine": "workspace:*",
+    "pulse-coder-memory-plugin": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/apps/remote-server/src/core/engine-run-context.ts
+++ b/apps/remote-server/src/core/engine-run-context.ts
@@ -1,0 +1,20 @@
+import { AsyncLocalStorage } from 'async_hooks';
+
+export interface EngineMemoryRunContext {
+  platformKey: string;
+  sessionId: string;
+  userText: string;
+}
+
+const engineMemoryRunContextStore = new AsyncLocalStorage<EngineMemoryRunContext>();
+
+export async function withEngineMemoryRunContext<T>(
+  context: EngineMemoryRunContext,
+  run: () => Promise<T>,
+): Promise<T> {
+  return engineMemoryRunContextStore.run(context, run);
+}
+
+export function getEngineMemoryRunContext(): EngineMemoryRunContext | undefined {
+  return engineMemoryRunContextStore.getStore();
+}

--- a/apps/remote-server/src/core/engine-singleton.ts
+++ b/apps/remote-server/src/core/engine-singleton.ts
@@ -1,8 +1,13 @@
 import { Engine } from 'pulse-coder-engine';
+import { memoryEnginePlugin } from './memory-engine-plugin.js';
 
 /**
  * Single Engine instance shared across all platform adapters.
  * engine.run(context, options) is stateless per-call — each invocation
  * receives its own Context object, so concurrent runs from different users are safe.
  */
-export const engine = new Engine();
+export const engine = new Engine({
+  enginePlugins: {
+    plugins: [memoryEnginePlugin],
+  },
+});

--- a/apps/remote-server/src/core/memory-embedding.ts
+++ b/apps/remote-server/src/core/memory-embedding.ts
@@ -1,0 +1,239 @@
+import type { EmbeddingProvider } from 'pulse-coder-memory-plugin';
+
+type EmbeddingStrategy = 'hash' | 'openai';
+
+interface MemoryEmbeddingRuntimeConfig {
+  semanticRecallEnabled: boolean;
+  strategy: EmbeddingStrategy;
+  embeddingDimensions?: number;
+  embeddingProvider?: EmbeddingProvider;
+}
+
+interface OpenAIEmbeddingProviderOptions {
+  apiKey: string;
+  baseUrl: string;
+  model: string;
+  dimensions: number;
+  timeoutMs: number;
+}
+
+interface OpenAIEmbeddingsResponse {
+  data?: Array<{
+    embedding?: number[];
+  }>;
+}
+
+const MIN_EMBEDDING_DIMENSIONS = 64;
+const MAX_EMBEDDING_DIMENSIONS = 4096;
+const DEFAULT_HASH_DIMENSIONS = 256;
+const DEFAULT_OPENAI_DIMENSIONS = 1536;
+const DEFAULT_OPENAI_MODEL = 'text-embedding-3-small';
+const DEFAULT_OPENAI_TIMEOUT_MS = 15000;
+
+export function resolveMemoryEmbeddingRuntimeConfigFromEnv(): MemoryEmbeddingRuntimeConfig {
+  const semanticRecallEnabled = parseBooleanEnv(process.env.MEMORY_SEMANTIC_RECALL_ENABLED, true);
+  if (!semanticRecallEnabled) {
+    console.log('[memory-service] semantic recall disabled via MEMORY_SEMANTIC_RECALL_ENABLED=false');
+    return {
+      semanticRecallEnabled,
+      strategy: 'hash',
+    };
+  }
+
+  const strategy = parseEmbeddingStrategy(process.env.MEMORY_EMBEDDING_STRATEGY);
+  if (strategy === 'openai') {
+    const openAIProvider = buildOpenAIEmbeddingProviderFromEnv();
+    if (openAIProvider) {
+      console.log(
+        `[memory-service] embedding strategy=openai model=${openAIProvider.model} dimensions=${openAIProvider.provider.dimensions}`,
+      );
+      return {
+        semanticRecallEnabled,
+        strategy,
+        embeddingDimensions: openAIProvider.provider.dimensions,
+        embeddingProvider: openAIProvider.provider,
+      };
+    }
+
+    console.warn(
+      '[memory-service] MEMORY_EMBEDDING_STRATEGY=openai is set but API key/base URL is missing. Set MEMORY_EMBEDDING_API_KEY and MEMORY_EMBEDDING_API_URL (or OPENAI_* fallbacks). Falling back to hash embeddings.',
+    );
+  }
+
+  const hashDimensions = clamp(
+    parseIntegerEnv(process.env.MEMORY_EMBEDDING_DIMENSIONS) ?? DEFAULT_HASH_DIMENSIONS,
+    MIN_EMBEDDING_DIMENSIONS,
+    MAX_EMBEDDING_DIMENSIONS,
+  );
+
+  console.log(`[memory-service] embedding strategy=hash dimensions=${hashDimensions}`);
+
+  return {
+    semanticRecallEnabled,
+    strategy: 'hash',
+    embeddingDimensions: hashDimensions,
+  };
+}
+
+class OpenAICompatibleEmbeddingProvider implements EmbeddingProvider {
+  readonly dimensions: number;
+
+  private readonly apiKey: string;
+  private readonly endpoint: string;
+  private readonly model: string;
+  private readonly timeoutMs: number;
+
+  constructor(options: OpenAIEmbeddingProviderOptions) {
+    this.apiKey = options.apiKey;
+    this.endpoint = `${normalizeEmbeddingBaseUrl(options.baseUrl)}/embeddings`;
+    this.model = options.model;
+    this.dimensions = options.dimensions;
+    this.timeoutMs = options.timeoutMs;
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const response = await fetch(this.endpoint, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: this.model,
+          input: text,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const bodyPreview = await readResponsePreview(response);
+        throw new Error(`embedding API request failed with status ${response.status}: ${bodyPreview}`);
+      }
+
+      const payload = (await response.json()) as OpenAIEmbeddingsResponse;
+      const vector = payload.data?.[0]?.embedding;
+
+      if (!Array.isArray(vector) || vector.length === 0) {
+        throw new Error('embedding API response is missing data[0].embedding');
+      }
+
+      return vector.map((value) => (typeof value === 'number' && Number.isFinite(value) ? value : 0));
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function buildOpenAIEmbeddingProviderFromEnv(): {
+  provider: EmbeddingProvider;
+  model: string;
+} | undefined {
+  const apiKey = firstNonEmpty(process.env.MEMORY_EMBEDDING_API_KEY, process.env.OPENAI_API_KEY);
+  const baseUrl = firstNonEmpty(process.env.MEMORY_EMBEDDING_API_URL, process.env.OPENAI_API_URL);
+  if (!apiKey || !baseUrl) {
+    return undefined;
+  }
+
+  const model = firstNonEmpty(process.env.MEMORY_EMBEDDING_MODEL, process.env.OPENAI_EMBEDDING_MODEL, DEFAULT_OPENAI_MODEL) ?? DEFAULT_OPENAI_MODEL;
+  const dimensions = clamp(
+    parseIntegerEnv(process.env.MEMORY_EMBEDDING_DIMENSIONS) ?? DEFAULT_OPENAI_DIMENSIONS,
+    MIN_EMBEDDING_DIMENSIONS,
+    MAX_EMBEDDING_DIMENSIONS,
+  );
+  const timeoutMs = Math.max(
+    1000,
+    parseIntegerEnv(process.env.MEMORY_EMBEDDING_TIMEOUT_MS) ?? DEFAULT_OPENAI_TIMEOUT_MS,
+  );
+
+  return {
+    provider: new OpenAICompatibleEmbeddingProvider({
+      apiKey,
+      baseUrl,
+      model,
+      dimensions,
+      timeoutMs,
+    }),
+    model,
+  };
+}
+
+function parseEmbeddingStrategy(raw: string | undefined): EmbeddingStrategy {
+  const normalized = raw?.trim().toLowerCase();
+  if (normalized === 'openai') {
+    return 'openai';
+  }
+  return 'hash';
+}
+
+function parseBooleanEnv(raw: string | undefined, defaultValue: boolean): boolean {
+  const normalized = raw?.trim().toLowerCase();
+  if (!normalized) {
+    return defaultValue;
+  }
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) {
+    return true;
+  }
+  if (['0', 'false', 'no', 'off'].includes(normalized)) {
+    return false;
+  }
+  return defaultValue;
+}
+
+function parseIntegerEnv(raw: string | undefined): number | undefined {
+  if (!raw) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(raw.trim(), 10);
+  if (!Number.isFinite(parsed)) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return undefined;
+}
+
+function normalizeEmbeddingBaseUrl(value: string): string {
+  const trimmed = trimTrailingSlash(value);
+  if (trimmed.endsWith('/chat/completions')) {
+    return trimmed.slice(0, -'/chat/completions'.length);
+  }
+  return trimmed;
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+async function readResponsePreview(response: Response): Promise<string> {
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!contentType.includes('application/json')) {
+    const text = await response.text();
+    return text.slice(0, 300);
+  }
+
+  try {
+    const payload = await response.json();
+    return JSON.stringify(payload).slice(0, 300);
+  } catch {
+    const text = await response.text();
+    return text.slice(0, 300);
+  }
+}

--- a/apps/remote-server/src/core/memory-engine-plugin.ts
+++ b/apps/remote-server/src/core/memory-engine-plugin.ts
@@ -1,6 +1,31 @@
-import type { EnginePlugin, SystemPromptOption } from 'pulse-coder-engine';
+import { z } from 'zod';
+import type { Tool, EnginePlugin, SystemPromptOption } from 'pulse-coder-engine';
+import type { MemoryItem } from 'pulse-coder-memory-plugin';
 import { getEngineMemoryRunContext } from './engine-run-context.js';
 import { memoryService } from './memory-service.js';
+
+const MEMORY_RECALL_INPUT_SCHEMA = z.object({
+  query: z.string().optional().describe('Natural language recall query. Defaults to current user message when omitted.'),
+  limit: z.number().int().min(1).max(8).optional().describe('Maximum number of memory items to return.'),
+});
+
+const MEMORY_RECORD_INPUT_SCHEMA = z.object({
+  content: z.string().min(1).describe('The memory content to store.'),
+  kind: z
+    .enum(['preference', 'rule', 'fix'])
+    .optional()
+    .describe('Memory kind. rule is user-level, preference/fix are session-level.'),
+});
+
+type MemoryRecordKind = 'preference' | 'rule' | 'fix';
+
+const MEMORY_TOOL_POLICY_APPEND = [
+  '## Memory Tool Policy (On-Demand)',
+  'Memory access is tool-based. Do not read/write memory on every turn.',
+  'Use `memory_recall` only when memory is relevant to the current task.',
+  'Use `memory_record` only when the user provides stable preferences/rules or when a fix is worth remembering.',
+  'If user intent conflicts with recalled memory, follow the latest user instruction.',
+].join('\n');
 
 function appendSystemPrompt(base: SystemPromptOption | undefined, append: string): SystemPromptOption {
   const normalizedAppend = append.trim();
@@ -26,62 +51,134 @@ function appendSystemPrompt(base: SystemPromptOption | undefined, append: string
   };
 }
 
+function requireRunContext() {
+  const runContext = getEngineMemoryRunContext();
+  if (!runContext) {
+    throw new Error('memory tools require active engine run context');
+  }
+  return runContext;
+}
+
+function normalizeText(value: string): string {
+  return value.replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+function summarizeMemoryItem(item: MemoryItem): Record<string, unknown> {
+  return {
+    id: item.id,
+    scope: item.scope,
+    type: item.type,
+    summary: item.summary,
+    content: item.content,
+    pinned: item.pinned,
+    updatedAt: item.updatedAt,
+  };
+}
+
+function toRecordTurnPayload(content: string, kind: MemoryRecordKind): { userText: string; assistantText: string } {
+  const normalized = content.trim();
+  if (kind === 'rule') {
+    return {
+      userText: `Rule: must follow this constraint. ${normalized}`,
+      assistantText: 'Acknowledged.',
+    };
+  }
+
+  if (kind === 'fix') {
+    return {
+      userText: `Issue context: ${normalized}`,
+      assistantText: `Fixed and resolved: ${normalized}`,
+    };
+  }
+
+  return {
+    userText: `Remember this preference for later: ${normalized}`,
+    assistantText: 'Noted.',
+  };
+}
+
+function buildMemoryRecallTool(): Tool<z.infer<typeof MEMORY_RECALL_INPUT_SCHEMA>, unknown> {
+  return {
+    name: 'memory_recall',
+    description: 'Recall relevant memory items for the current user/session when needed.',
+    inputSchema: MEMORY_RECALL_INPUT_SCHEMA,
+    execute: async ({ query, limit }) => {
+      const runContext = requireRunContext();
+      const recallQuery = query?.trim() || runContext.userText;
+
+      const recalled = await memoryService.recall({
+        platformKey: runContext.platformKey,
+        sessionId: runContext.sessionId,
+        query: recallQuery,
+        limit,
+      });
+
+      return {
+        enabled: recalled.enabled,
+        count: recalled.items.length,
+        query: recallQuery,
+        promptAppend: recalled.promptAppend,
+        items: recalled.items.map((item) => summarizeMemoryItem(item)),
+      };
+    },
+  };
+}
+
+function buildMemoryRecordTool(): Tool<z.infer<typeof MEMORY_RECORD_INPUT_SCHEMA>, unknown> {
+  return {
+    name: 'memory_record',
+    description: 'Persist an important preference/rule/fix into memory when explicitly useful.',
+    inputSchema: MEMORY_RECORD_INPUT_SCHEMA,
+    execute: async ({ content, kind }) => {
+      const runContext = requireRunContext();
+      const normalizedContent = content.trim();
+      const normalizedKind: MemoryRecordKind = kind ?? 'preference';
+      const payload = toRecordTurnPayload(normalizedContent, normalizedKind);
+
+      await memoryService.recordTurn({
+        platformKey: runContext.platformKey,
+        sessionId: runContext.sessionId,
+        userText: payload.userText,
+        assistantText: payload.assistantText,
+      });
+
+      const list = await memoryService.list({
+        platformKey: runContext.platformKey,
+        sessionId: runContext.sessionId,
+        limit: 20,
+      });
+
+      const normalizedTarget = normalizeText(normalizedContent);
+      const matched = list.find((item) => {
+        const contentMatch = normalizeText(item.content).includes(normalizedTarget);
+        const summaryMatch = normalizeText(item.summary).includes(normalizedTarget);
+        return contentMatch || summaryMatch;
+      });
+
+      return {
+        ok: true,
+        kind: normalizedKind,
+        stored: Boolean(matched),
+        item: matched ? summarizeMemoryItem(matched) : undefined,
+      };
+    },
+  };
+}
+
 export const memoryEnginePlugin: EnginePlugin = {
   name: 'remote-memory',
-  version: '0.0.1',
+  version: '0.0.2',
 
   async initialize(context) {
     context.registerService('memoryService', memoryService);
 
-    context.registerHook('beforeRun', async ({ systemPrompt }) => {
-      const runContext = getEngineMemoryRunContext();
-      if (!runContext) {
-        return;
-      }
-
-      try {
-        const recall = await memoryService.recall({
-          platformKey: runContext.platformKey,
-          sessionId: runContext.sessionId,
-          query: runContext.userText,
-        });
-
-        if (!recall.promptAppend) {
-          return;
-        }
-
-        return {
-          systemPrompt: appendSystemPrompt(systemPrompt, recall.promptAppend),
-        };
-      } catch (error) {
-        context.logger.warn('[memory-engine-plugin] recall failed', {
-          platformKey: runContext.platformKey,
-          sessionId: runContext.sessionId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
+    context.registerTools({
+      memory_recall: buildMemoryRecallTool(),
+      memory_record: buildMemoryRecordTool(),
     });
 
-    context.registerHook('afterRun', async ({ result }) => {
-      const runContext = getEngineMemoryRunContext();
-      if (!runContext) {
-        return;
-      }
-
-      try {
-        await memoryService.recordTurn({
-          platformKey: runContext.platformKey,
-          sessionId: runContext.sessionId,
-          userText: runContext.userText,
-          assistantText: result,
-        });
-      } catch (error) {
-        context.logger.warn('[memory-engine-plugin] record turn failed', {
-          platformKey: runContext.platformKey,
-          sessionId: runContext.sessionId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    });
+    context.registerHook('beforeRun', async ({ systemPrompt }) => ({
+      systemPrompt: appendSystemPrompt(systemPrompt, MEMORY_TOOL_POLICY_APPEND),
+    }));
   },
 };

--- a/apps/remote-server/src/core/memory-engine-plugin.ts
+++ b/apps/remote-server/src/core/memory-engine-plugin.ts
@@ -1,0 +1,87 @@
+import type { EnginePlugin, SystemPromptOption } from 'pulse-coder-engine';
+import { getEngineMemoryRunContext } from './engine-run-context.js';
+import { memoryService } from './memory-service.js';
+
+function appendSystemPrompt(base: SystemPromptOption | undefined, append: string): SystemPromptOption {
+  const normalizedAppend = append.trim();
+  if (!normalizedAppend) {
+    return base ?? { append: '' };
+  }
+
+  if (!base) {
+    return { append: normalizedAppend };
+  }
+
+  if (typeof base === 'string') {
+    return `${base}\n\n${normalizedAppend}`;
+  }
+
+  if (typeof base === 'function') {
+    return () => `${base()}\n\n${normalizedAppend}`;
+  }
+
+  const currentAppend = base.append.trim();
+  return {
+    append: currentAppend ? `${currentAppend}\n\n${normalizedAppend}` : normalizedAppend,
+  };
+}
+
+export const memoryEnginePlugin: EnginePlugin = {
+  name: 'remote-memory',
+  version: '0.0.1',
+
+  async initialize(context) {
+    context.registerService('memoryService', memoryService);
+
+    context.registerHook('beforeRun', async ({ systemPrompt }) => {
+      const runContext = getEngineMemoryRunContext();
+      if (!runContext) {
+        return;
+      }
+
+      try {
+        const recall = await memoryService.recall({
+          platformKey: runContext.platformKey,
+          sessionId: runContext.sessionId,
+          query: runContext.userText,
+        });
+
+        if (!recall.promptAppend) {
+          return;
+        }
+
+        return {
+          systemPrompt: appendSystemPrompt(systemPrompt, recall.promptAppend),
+        };
+      } catch (error) {
+        context.logger.warn('[memory-engine-plugin] recall failed', {
+          platformKey: runContext.platformKey,
+          sessionId: runContext.sessionId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    });
+
+    context.registerHook('afterRun', async ({ result }) => {
+      const runContext = getEngineMemoryRunContext();
+      if (!runContext) {
+        return;
+      }
+
+      try {
+        await memoryService.recordTurn({
+          platformKey: runContext.platformKey,
+          sessionId: runContext.sessionId,
+          userText: runContext.userText,
+          assistantText: result,
+        });
+      } catch (error) {
+        context.logger.warn('[memory-engine-plugin] record turn failed', {
+          platformKey: runContext.platformKey,
+          sessionId: runContext.sessionId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    });
+  },
+};

--- a/apps/remote-server/src/core/memory-service.ts
+++ b/apps/remote-server/src/core/memory-service.ts
@@ -1,7 +1,13 @@
 import { join } from 'path';
 import { homedir } from 'os';
 import { FileMemoryPluginService } from 'pulse-coder-memory-plugin';
+import { resolveMemoryEmbeddingRuntimeConfigFromEnv } from './memory-embedding.js';
+
+const embeddingRuntime = resolveMemoryEmbeddingRuntimeConfigFromEnv();
 
 export const memoryService = new FileMemoryPluginService({
   baseDir: join(homedir(), '.pulse-coder', 'remote-memory'),
+  semanticRecallEnabled: embeddingRuntime.semanticRecallEnabled,
+  embeddingDimensions: embeddingRuntime.embeddingDimensions,
+  embeddingProvider: embeddingRuntime.embeddingProvider,
 });

--- a/apps/remote-server/src/core/memory-service.ts
+++ b/apps/remote-server/src/core/memory-service.ts
@@ -1,0 +1,7 @@
+import { join } from 'path';
+import { homedir } from 'os';
+import { FileMemoryPluginService } from 'pulse-coder-memory-plugin';
+
+export const memoryService = new FileMemoryPluginService({
+  baseDir: join(homedir(), '.pulse-coder', 'remote-memory'),
+});

--- a/apps/remote-server/src/index.ts
+++ b/apps/remote-server/src/index.ts
@@ -3,12 +3,15 @@ import { serve } from '@hono/node-server';
 import { createApp } from './server.js';
 import { engine } from './core/engine-singleton.js';
 import { sessionStore } from './core/session-store.js';
+import { memoryService } from './core/memory-service.js';
 
 async function main() {
   // Initialize session store (creates directories if needed, loads index)
   await sessionStore.initialize();
 
-  // Initialize the AI engine and all its plugins
+  // Initialize memory store
+  await memoryService.initialize();
+
   await engine.initialize();
 
   const app = createApp();

--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
     "packages/*",
     "apps/*"
   ],
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3"
+    ]
+  },
   "scripts": {
     "build": "pnpm -r build",
     "dev": "pnpm --parallel --filter \"./packages/*\" dev",

--- a/packages/memory-plugin/package.json
+++ b/packages/memory-plugin/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "pulse-coder-memory-plugin",
+  "version": "0.0.1",
+  "description": "Host-side memory plugin service for Pulse Coder runtimes",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./src": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "files": [
+    "dist"
+  ],
+  "devDependencies": {
+    "@types/node": "^25.0.10",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/memory-plugin/package.json
+++ b/packages/memory-plugin/package.json
@@ -28,7 +28,11 @@
   "files": [
     "dist"
   ],
+  "dependencies": {
+    "better-sqlite3": "^11.10.0"
+  },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^25.0.10",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",

--- a/packages/memory-plugin/src/index.ts
+++ b/packages/memory-plugin/src/index.ts
@@ -1,0 +1,2 @@
+export * from './types.js';
+export * from './service.js';

--- a/packages/memory-plugin/src/service.test.ts
+++ b/packages/memory-plugin/src/service.test.ts
@@ -1,0 +1,155 @@
+import BetterSqlite3 from 'better-sqlite3';
+import { access, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { FileMemoryPluginService, HashEmbeddingProvider } from './service.js';
+import type { EmbeddingProvider, FileMemoryServiceOptions } from './types.js';
+
+const createdDirs: string[] = [];
+
+async function createService(options: FileMemoryServiceOptions = {}) {
+  const baseDir = await mkdtemp(join(tmpdir(), 'memory-plugin-test-'));
+  createdDirs.push(baseDir);
+  const service = new FileMemoryPluginService({
+    baseDir,
+    ...options,
+  });
+  await service.initialize();
+  return { baseDir, service };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    createdDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe('FileMemoryPluginService', () => {
+  it('records and recalls memories with default hash embeddings', async () => {
+    const { service } = await createService();
+
+    await service.recordTurn({
+      platformKey: 'test-platform',
+      sessionId: 'session-1',
+      userText: 'Please remember: default to TypeScript and use pnpm in this repo.',
+      assistantText: 'I fixed the root cause and aligned the tooling.',
+    });
+
+    const listed = await service.list({
+      platformKey: 'test-platform',
+      sessionId: 'session-1',
+      limit: 10,
+    });
+
+    expect(listed.length).toBeGreaterThan(0);
+
+    const recall = await service.recall({
+      platformKey: 'test-platform',
+      sessionId: 'session-1',
+      query: 'what language and package manager should we use',
+      limit: 5,
+    });
+
+    expect(recall.enabled).toBe(true);
+    expect(recall.items.length).toBeGreaterThan(0);
+    expect(recall.promptAppend).toContain('Memory context from previous conversations');
+  });
+
+  it('stops recording and recall when session is disabled', async () => {
+    const { service } = await createService();
+
+    await service.setSessionEnabled('test-platform', 'session-2', false);
+
+    await service.recordTurn({
+      platformKey: 'test-platform',
+      sessionId: 'session-2',
+      userText: 'Remember to always run tests before merge.',
+      assistantText: 'Understood.',
+    });
+
+    const listed = await service.list({
+      platformKey: 'test-platform',
+      sessionId: 'session-2',
+      limit: 10,
+    });
+
+    expect(listed).toHaveLength(0);
+
+    const recall = await service.recall({
+      platformKey: 'test-platform',
+      sessionId: 'session-2',
+      query: 'should we run tests',
+      limit: 5,
+    });
+
+    expect(recall.enabled).toBe(false);
+    expect(recall.items).toHaveLength(0);
+    expect(recall.promptAppend).toBeUndefined();
+  });
+
+  it('supports keyword-only recall when semantic recall is disabled', async () => {
+    const { baseDir, service } = await createService({ semanticRecallEnabled: false });
+
+    await service.recordTurn({
+      platformKey: 'test-platform',
+      sessionId: 'session-3',
+      userText: 'Please remember: never use yarn in this project.',
+      assistantText: 'Acknowledged.',
+    });
+
+    const recall = await service.recall({
+      platformKey: 'test-platform',
+      sessionId: 'session-3',
+      query: 'should we use yarn',
+      limit: 5,
+    });
+
+    expect(recall.enabled).toBe(true);
+    expect(recall.items.length).toBeGreaterThan(0);
+
+    const vectorPath = join(baseDir, 'vectors.sqlite');
+    await expect(access(vectorPath)).rejects.toThrow();
+  });
+
+  it('uses explicit embedding dimensions with a custom provider', async () => {
+    class TinyEmbeddingProvider implements EmbeddingProvider {
+      readonly dimensions = 128;
+
+      async embed(): Promise<number[]> {
+        return [1, 2, 3];
+      }
+    }
+
+    const { baseDir, service } = await createService({
+      embeddingProvider: new TinyEmbeddingProvider(),
+      embeddingDimensions: 256,
+    });
+
+    await service.recordTurn({
+      platformKey: 'test-platform',
+      sessionId: 'session-4',
+      userText: 'Remember this rule: must include tests before merge.',
+      assistantText: 'Resolved.',
+    });
+
+    const db = new BetterSqlite3(join(baseDir, 'vectors.sqlite'), { readonly: true });
+    const row = db.prepare('SELECT vector FROM memory_vectors LIMIT 1').get() as { vector: string } | undefined;
+    db.close();
+
+    expect(row).toBeDefined();
+    const vector = JSON.parse(row!.vector) as number[];
+    expect(vector.length).toBe(256);
+    expect(vector.some((value) => value !== 0)).toBe(true);
+  });
+});
+
+describe('HashEmbeddingProvider', () => {
+  it('clamps dimensions into supported range', () => {
+    const low = new HashEmbeddingProvider(1);
+    const high = new HashEmbeddingProvider(99999);
+
+    expect(low.dimensions).toBe(64);
+    expect(high.dimensions).toBe(4096);
+  });
+});

--- a/packages/memory-plugin/src/service.ts
+++ b/packages/memory-plugin/src/service.ts
@@ -1,0 +1,374 @@
+import { randomUUID } from 'crypto';
+import { promises as fs } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import type {
+  FileMemoryServiceOptions,
+  ListInput,
+  MemoryItem,
+  MemoryScope,
+  MemoryState,
+  MemoryType,
+  MutateResult,
+  RecallInput,
+  RecallResult,
+  RecordTurnInput,
+  ToggleResult,
+} from './types.js';
+
+interface ExtractedMemory {
+  scope: MemoryScope;
+  type: MemoryType;
+  content: string;
+  summary: string;
+  keywords: string[];
+  confidence: number;
+  importance: number;
+}
+
+export class FileMemoryPluginService {
+  private readonly baseDir: string;
+  private readonly statePath: string;
+  private readonly maxItemsPerUser: number;
+  private readonly defaultRecallLimit: number;
+
+  private initialized = false;
+  private state: MemoryState = { items: [], sessionEnabled: {} };
+
+  constructor(options: FileMemoryServiceOptions = {}) {
+    this.baseDir = options.baseDir ?? join(homedir(), '.pulse-coder', 'memory-plugin');
+    this.statePath = join(this.baseDir, 'state.json');
+    this.maxItemsPerUser = options.maxItemsPerUser ?? 500;
+    this.defaultRecallLimit = options.defaultRecallLimit ?? 5;
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initialized) {
+      return;
+    }
+
+    await fs.mkdir(this.baseDir, { recursive: true });
+
+    try {
+      const raw = await fs.readFile(this.statePath, 'utf-8');
+      const parsed = JSON.parse(raw) as Partial<MemoryState>;
+      this.state.items = Array.isArray(parsed.items) ? parsed.items : [];
+      this.state.sessionEnabled = parsed.sessionEnabled && typeof parsed.sessionEnabled === 'object'
+        ? parsed.sessionEnabled
+        : {};
+    } catch {
+      this.state = { items: [], sessionEnabled: {} };
+    }
+
+    this.initialized = true;
+  }
+
+  isSessionEnabled(platformKey: string, sessionId: string): boolean {
+    const key = this.sessionKey(platformKey, sessionId);
+    return this.state.sessionEnabled[key] !== false;
+  }
+
+  async setSessionEnabled(platformKey: string, sessionId: string, enabled: boolean): Promise<ToggleResult> {
+    const key = this.sessionKey(platformKey, sessionId);
+    this.state.sessionEnabled[key] = enabled;
+    await this.saveState();
+    return { ok: true, enabled };
+  }
+
+  async recall(input: RecallInput): Promise<RecallResult> {
+    const enabled = this.isSessionEnabled(input.platformKey, input.sessionId);
+    if (!enabled) {
+      return { enabled, items: [] };
+    }
+
+    const limit = clamp(input.limit ?? this.defaultRecallLimit, 1, 8);
+    const queryTokens = tokenize(input.query);
+    const now = Date.now();
+
+    const ranked = this.state.items
+      .filter((item) => this.isCandidateVisible(item, input.platformKey, input.sessionId))
+      .map((item) => ({
+        item,
+        score: scoreItem(item, queryTokens, now),
+      }))
+      .filter((entry) => entry.score > 0.15)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, limit)
+      .map((entry) => entry.item);
+
+    const promptAppend = buildMemoryPrompt(ranked);
+    return {
+      enabled,
+      items: ranked,
+      promptAppend,
+    };
+  }
+
+  async list(input: ListInput): Promise<MemoryItem[]> {
+    const now = Date.now();
+    return this.state.items
+      .filter((item) => this.isCandidateVisible(item, input.platformKey, input.sessionId))
+      .sort((a, b) => {
+        if (a.pinned !== b.pinned) {
+          return a.pinned ? -1 : 1;
+        }
+        return b.updatedAt - a.updatedAt;
+      })
+      .slice(0, clamp(input.limit ?? 20, 1, 50))
+      .map((item) => ({ ...item, lastAccessedAt: item.lastAccessedAt || now }));
+  }
+
+  async pin(platformKey: string, id: string): Promise<MutateResult> {
+    const item = this.state.items.find((candidate) => candidate.id === id && candidate.platformKey === platformKey && !candidate.deleted);
+    if (!item) {
+      return { ok: false, reason: 'memory not found' };
+    }
+
+    item.pinned = true;
+    item.updatedAt = Date.now();
+    await this.saveState();
+    return { ok: true, item };
+  }
+
+  async forget(platformKey: string, id: string): Promise<MutateResult> {
+    const item = this.state.items.find((candidate) => candidate.id === id && candidate.platformKey === platformKey && !candidate.deleted);
+    if (!item) {
+      return { ok: false, reason: 'memory not found' };
+    }
+
+    item.deleted = true;
+    item.updatedAt = Date.now();
+    await this.saveState();
+    return { ok: true, item };
+  }
+
+  async recordTurn(input: RecordTurnInput): Promise<void> {
+    if (!this.isSessionEnabled(input.platformKey, input.sessionId)) {
+      return;
+    }
+
+    const extracted = extractMemoryCandidates(input.userText, input.assistantText).slice(0, 3);
+    if (extracted.length === 0) {
+      return;
+    }
+
+    const now = Date.now();
+    for (const candidate of extracted) {
+      const duplicate = this.state.items.find((item) => {
+        if (item.platformKey !== input.platformKey || item.deleted) {
+          return false;
+        }
+        return normalizeContent(item.content) === normalizeContent(candidate.content);
+      });
+
+      if (duplicate) {
+        duplicate.updatedAt = now;
+        duplicate.lastAccessedAt = now;
+        duplicate.confidence = Math.max(duplicate.confidence, candidate.confidence);
+        duplicate.importance = Math.max(duplicate.importance, candidate.importance);
+        duplicate.keywords = uniqueWords([...duplicate.keywords, ...candidate.keywords]);
+        continue;
+      }
+
+      const nextItem: MemoryItem = {
+        id: randomUUID().slice(0, 8),
+        platformKey: input.platformKey,
+        sessionId: candidate.scope === 'session' ? input.sessionId : undefined,
+        scope: candidate.scope,
+        type: candidate.type,
+        content: candidate.content,
+        summary: candidate.summary,
+        keywords: candidate.keywords,
+        confidence: candidate.confidence,
+        importance: candidate.importance,
+        pinned: false,
+        deleted: false,
+        createdAt: now,
+        updatedAt: now,
+        lastAccessedAt: now,
+      };
+      this.state.items.push(nextItem);
+    }
+
+    this.compact(input.platformKey);
+    await this.saveState();
+  }
+
+  private async saveState(): Promise<void> {
+    await fs.writeFile(this.statePath, JSON.stringify(this.state, null, 2), 'utf-8');
+  }
+
+  private sessionKey(platformKey: string, sessionId: string): string {
+    return `${platformKey}:${sessionId}`;
+  }
+
+  private compact(platformKey: string): void {
+    const active = this.state.items
+      .filter((item) => item.platformKey === platformKey && !item.deleted)
+      .sort((a, b) => {
+        if (a.pinned !== b.pinned) {
+          return a.pinned ? -1 : 1;
+        }
+        const scoreA = a.importance * 0.6 + a.confidence * 0.4;
+        const scoreB = b.importance * 0.6 + b.confidence * 0.4;
+        if (scoreA !== scoreB) {
+          return scoreB - scoreA;
+        }
+        return b.updatedAt - a.updatedAt;
+      });
+
+    if (active.length <= this.maxItemsPerUser) {
+      return;
+    }
+
+    const toDrop = new Set(active.slice(this.maxItemsPerUser).map((item) => item.id));
+    this.state.items = this.state.items.filter((item) => {
+      if (item.platformKey !== platformKey) {
+        return true;
+      }
+      return !toDrop.has(item.id);
+    });
+  }
+
+  private isCandidateVisible(item: MemoryItem, platformKey: string, sessionId?: string): boolean {
+    if (item.platformKey !== platformKey || item.deleted) {
+      return false;
+    }
+
+    if (item.scope === 'session') {
+      return Boolean(sessionId) && item.sessionId === sessionId;
+    }
+
+    return true;
+  }
+}
+
+function extractMemoryCandidates(userText: string, assistantText: string): ExtractedMemory[] {
+  const results: ExtractedMemory[] = [];
+  const normalizedUser = userText.trim();
+  if (normalizedUser.length === 0) {
+    return results;
+  }
+
+  const preferencePattern = /(prefer|always|never|please use|remember|default to|\u8bf7\u7528|\u4ee5\u540e|\u8bb0\u4f4f|\u9ed8\u8ba4|\u4e0d\u8981|\u5fc5\u987b)/i;
+  const rulePattern = /(rule|constraint|must|should|require|\u89c4\u8303|\u7ea6\u675f|\u5fc5\u987b|\u7981\u6b62)/i;
+
+  if (preferencePattern.test(normalizedUser) || rulePattern.test(normalizedUser)) {
+    const summary = summarize(normalizedUser, 120);
+    const type: MemoryType = rulePattern.test(normalizedUser) ? 'rule' : 'preference';
+    const scope: MemoryScope = type === 'rule' ? 'user' : 'session';
+
+    results.push({
+      scope,
+      type,
+      content: normalizeWhitespace(normalizedUser),
+      summary,
+      keywords: tokenize(normalizedUser),
+      confidence: 0.72,
+      importance: type === 'rule' ? 0.8 : 0.65,
+    });
+  }
+
+  const normalizedAssistant = assistantText.trim();
+  const fixPattern = /(fixed|resolved|workaround|root cause|\u5df2\u4fee\u590d|\u95ee\u9898\u539f\u56e0|\u89e3\u51b3\u65b9\u6848)/i;
+  if (normalizedAssistant.length > 0 && fixPattern.test(normalizedAssistant)) {
+    results.push({
+      scope: 'session',
+      type: 'fix',
+      content: summarize(normalizedAssistant, 180),
+      summary: summarize(normalizedAssistant, 100),
+      keywords: tokenize(normalizedAssistant),
+      confidence: 0.6,
+      importance: 0.55,
+    });
+  }
+
+  return dedupeExtracted(results);
+}
+
+function dedupeExtracted(items: ExtractedMemory[]): ExtractedMemory[] {
+  const seen = new Set<string>();
+  const deduped: ExtractedMemory[] = [];
+  for (const item of items) {
+    const key = normalizeContent(item.content);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(item);
+  }
+  return deduped;
+}
+
+function scoreItem(item: MemoryItem, queryTokens: string[], now: number): number {
+  const haystack = `${item.summary} ${item.content} ${item.keywords.join(' ')}`.toLowerCase();
+  const matched = queryTokens.filter((token) => haystack.includes(token));
+  const keywordScore = queryTokens.length === 0 ? 0 : matched.length / queryTokens.length;
+
+  const ageDays = Math.max(0, now - item.updatedAt) / (1000 * 60 * 60 * 24);
+  const recencyScore = 1 / (1 + ageDays / 7);
+  const qualityScore = item.confidence * 0.5 + item.importance * 0.5;
+
+  let score = 0.55 * keywordScore + 0.25 * recencyScore + 0.2 * qualityScore;
+  if (item.pinned) {
+    score += 0.2;
+  }
+
+  if (queryTokens.length === 0) {
+    score = recencyScore * 0.7 + qualityScore * 0.3 + (item.pinned ? 0.2 : 0);
+  }
+
+  return score;
+}
+
+function buildMemoryPrompt(items: MemoryItem[]): string | undefined {
+  if (items.length === 0) {
+    return undefined;
+  }
+
+  const lines = [
+    'Memory context from previous conversations (use only when relevant):',
+    ...items.map((item, index) => {
+      const flags = [item.type, item.scope, item.pinned ? 'pinned' : null].filter(Boolean).join(', ');
+      return `${index + 1}. [${item.id}] (${flags}) ${item.summary}`;
+    }),
+    'If memory conflicts with the latest user instruction, follow the latest user instruction.',
+  ];
+
+  return lines.join('\n');
+}
+
+function normalizeWhitespace(input: string): string {
+  return input.replace(/\s+/g, ' ').trim();
+}
+
+function summarize(input: string, maxLength: number): string {
+  const compact = normalizeWhitespace(input);
+  if (compact.length <= maxLength) {
+    return compact;
+  }
+  return `${compact.slice(0, maxLength - 3)}...`;
+}
+
+function normalizeContent(input: string): string {
+  return normalizeWhitespace(input).toLowerCase();
+}
+
+function tokenize(input: string): string[] {
+  return uniqueWords(
+    input
+      .toLowerCase()
+      .replace(/[^a-z0-9\u4e00-\u9fff\s]/g, ' ')
+      .split(/\s+/)
+      .filter((token) => token.length >= 2)
+      .slice(0, 30),
+  );
+}
+
+function uniqueWords(items: string[]): string[] {
+  return [...new Set(items)].slice(0, 40);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}

--- a/packages/memory-plugin/src/service.ts
+++ b/packages/memory-plugin/src/service.ts
@@ -44,7 +44,7 @@ interface StoredEmbeddingRow {
 
 const DEFAULT_EMBEDDING_DIMENSIONS = 256;
 const MIN_EMBEDDING_DIMENSIONS = 64;
-const MAX_EMBEDDING_DIMENSIONS = 1024;
+const MAX_EMBEDDING_DIMENSIONS = 4096;
 
 const SEMANTIC_SYNONYMS: Record<string, string[]> = {
   bug: ['issue', 'error', 'defect', 'problem'],
@@ -79,12 +79,12 @@ export class FileMemoryPluginService {
     this.semanticRecallEnabled = options.semanticRecallEnabled ?? true;
 
     const embeddingDimensions = clamp(
-      options.embeddingDimensions ?? DEFAULT_EMBEDDING_DIMENSIONS,
+      options.embeddingDimensions ?? options.embeddingProvider?.dimensions ?? DEFAULT_EMBEDDING_DIMENSIONS,
       MIN_EMBEDDING_DIMENSIONS,
       MAX_EMBEDDING_DIMENSIONS,
     );
     this.embeddingProvider = options.embeddingProvider ?? new HashEmbeddingProvider(embeddingDimensions);
-    this.embeddingDimensions = this.embeddingProvider.dimensions;
+    this.embeddingDimensions = embeddingDimensions;
   }
 
   async initialize(): Promise<void> {
@@ -468,7 +468,7 @@ export class FileMemoryPluginService {
   }
 }
 
-class HashEmbeddingProvider implements EmbeddingProvider {
+export class HashEmbeddingProvider implements EmbeddingProvider {
   readonly dimensions: number;
 
   constructor(dimensions: number) {

--- a/packages/memory-plugin/src/service.ts
+++ b/packages/memory-plugin/src/service.ts
@@ -1,8 +1,10 @@
+import BetterSqlite3 from 'better-sqlite3';
 import { randomUUID } from 'crypto';
 import { promises as fs } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
 import type {
+  EmbeddingProvider,
   FileMemoryServiceOptions,
   ListInput,
   MemoryItem,
@@ -26,20 +28,63 @@ interface ExtractedMemory {
   importance: number;
 }
 
+interface RecallScoreInput {
+  keywordScore: number;
+  semanticScore: number;
+  recencyScore: number;
+  qualityScore: number;
+  pinned: boolean;
+  hasKeywords: boolean;
+  hasSemantic: boolean;
+}
+
+interface StoredEmbeddingRow {
+  vector: string;
+}
+
+const DEFAULT_EMBEDDING_DIMENSIONS = 256;
+const MIN_EMBEDDING_DIMENSIONS = 64;
+const MAX_EMBEDDING_DIMENSIONS = 1024;
+
+const SEMANTIC_SYNONYMS: Record<string, string[]> = {
+  bug: ['issue', 'error', 'defect', 'problem'],
+  fix: ['resolve', 'repair', 'patch', 'correct'],
+  refactor: ['cleanup', 'restructure', 'rewrite'],
+  optimize: ['improve', 'speed', 'performance', 'tune'],
+  memory: ['remember', 'recall', 'context'],
+  preference: ['prefer', 'default', 'habit'],
+  rule: ['constraint', 'must', 'policy', 'guideline'],
+};
+
 export class FileMemoryPluginService {
   private readonly baseDir: string;
   private readonly statePath: string;
+  private readonly vectorStorePath: string;
   private readonly maxItemsPerUser: number;
   private readonly defaultRecallLimit: number;
+  private readonly embeddingProvider: EmbeddingProvider;
+  private readonly embeddingDimensions: number;
 
   private initialized = false;
+  private semanticRecallEnabled: boolean;
+  private vectorDb?: InstanceType<typeof BetterSqlite3>;
   private state: MemoryState = { items: [], sessionEnabled: {} };
 
   constructor(options: FileMemoryServiceOptions = {}) {
     this.baseDir = options.baseDir ?? join(homedir(), '.pulse-coder', 'memory-plugin');
     this.statePath = join(this.baseDir, 'state.json');
+    this.vectorStorePath = options.vectorStorePath ?? join(this.baseDir, 'vectors.sqlite');
     this.maxItemsPerUser = options.maxItemsPerUser ?? 500;
     this.defaultRecallLimit = options.defaultRecallLimit ?? 5;
+    this.semanticRecallEnabled = options.semanticRecallEnabled ?? true;
+
+    const embeddingDimensions = clamp(
+      options.embeddingDimensions ?? DEFAULT_EMBEDDING_DIMENSIONS,
+      MIN_EMBEDDING_DIMENSIONS,
+      MAX_EMBEDDING_DIMENSIONS,
+    );
+    this.embeddingProvider = options.embeddingProvider ?? new HashEmbeddingProvider(embeddingDimensions);
+    this.embeddingDimensions = this.embeddingProvider.dimensions;
   }
 
   async initialize(): Promise<void> {
@@ -59,6 +104,9 @@ export class FileMemoryPluginService {
     } catch {
       this.state = { items: [], sessionEnabled: {} };
     }
+
+    this.initializeVectorStore();
+    await this.backfillMissingEmbeddings();
 
     this.initialized = true;
   }
@@ -83,15 +131,51 @@ export class FileMemoryPluginService {
 
     const limit = clamp(input.limit ?? this.defaultRecallLimit, 1, 8);
     const queryTokens = tokenize(input.query);
+    const hasKeywordQuery = queryTokens.length > 0;
+    const queryVector = await this.embedText(input.query);
+    const hasSemanticQuery = Boolean(queryVector);
     const now = Date.now();
 
-    const ranked = this.state.items
-      .filter((item) => this.isCandidateVisible(item, input.platformKey, input.sessionId))
-      .map((item) => ({
-        item,
-        score: scoreItem(item, queryTokens, now),
-      }))
-      .filter((entry) => entry.score > 0.15)
+    const visibleItems = this.state.items
+      .filter((item) => this.isCandidateVisible(item, input.platformKey, input.sessionId));
+
+    const embeddingMap = hasSemanticQuery
+      ? this.loadEmbeddings(visibleItems.map((item) => item.id))
+      : new Map<string, number[]>();
+
+    const ranked = visibleItems
+      .map((item) => {
+        const haystack = `${item.summary} ${item.content} ${item.keywords.join(' ')}`.toLowerCase();
+        const matched = queryTokens.filter((token) => haystack.includes(token));
+        const keywordScore = hasKeywordQuery ? matched.length / queryTokens.length : 0;
+
+        const itemVector = embeddingMap.get(item.id);
+        const semanticScore = queryVector && itemVector
+          ? cosineSimilarity(queryVector, itemVector)
+          : 0;
+
+        const ageDays = Math.max(0, now - item.updatedAt) / (1000 * 60 * 60 * 24);
+        const recencyScore = 1 / (1 + ageDays / 7);
+        const qualityScore = item.confidence * 0.5 + item.importance * 0.5;
+
+        const score = combineRecallScore({
+          keywordScore,
+          semanticScore,
+          recencyScore,
+          qualityScore,
+          pinned: item.pinned,
+          hasKeywords: hasKeywordQuery,
+          hasSemantic: hasSemanticQuery,
+        });
+
+        return { item, score };
+      })
+      .filter((entry) => {
+        if (!hasKeywordQuery && !hasSemanticQuery) {
+          return true;
+        }
+        return entry.score >= 0.18;
+      })
       .sort((a, b) => b.score - a.score)
       .slice(0, limit)
       .map((entry) => entry.item);
@@ -139,6 +223,7 @@ export class FileMemoryPluginService {
     item.deleted = true;
     item.updatedAt = Date.now();
     await this.saveState();
+    this.deleteEmbeddings([item.id]);
     return { ok: true, item };
   }
 
@@ -153,6 +238,8 @@ export class FileMemoryPluginService {
     }
 
     const now = Date.now();
+    const touchedItems: MemoryItem[] = [];
+
     for (const candidate of extracted) {
       const duplicate = this.state.items.find((item) => {
         if (item.platformKey !== input.platformKey || item.deleted) {
@@ -167,6 +254,7 @@ export class FileMemoryPluginService {
         duplicate.confidence = Math.max(duplicate.confidence, candidate.confidence);
         duplicate.importance = Math.max(duplicate.importance, candidate.importance);
         duplicate.keywords = uniqueWords([...duplicate.keywords, ...candidate.keywords]);
+        touchedItems.push(duplicate);
         continue;
       }
 
@@ -188,10 +276,143 @@ export class FileMemoryPluginService {
         lastAccessedAt: now,
       };
       this.state.items.push(nextItem);
+      touchedItems.push(nextItem);
     }
 
-    this.compact(input.platformKey);
+    const compactedIds = this.compact(input.platformKey);
     await this.saveState();
+
+    await Promise.all(
+      touchedItems.map(async (item) => {
+        await this.upsertEmbedding(item);
+      }),
+    );
+    this.deleteEmbeddings(compactedIds);
+  }
+
+  private initializeVectorStore(): void {
+    if (!this.semanticRecallEnabled) {
+      return;
+    }
+
+    try {
+      const db = new BetterSqlite3(this.vectorStorePath);
+      db.pragma('journal_mode = WAL');
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS memory_vectors (
+          memory_id TEXT PRIMARY KEY,
+          platform_key TEXT NOT NULL,
+          vector TEXT NOT NULL,
+          updated_at INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_memory_vectors_platform_key ON memory_vectors(platform_key);
+      `);
+      this.vectorDb = db;
+    } catch (error) {
+      this.semanticRecallEnabled = false;
+      this.vectorDb = undefined;
+      console.warn('[memory-plugin] semantic recall disabled: failed to initialize vector store', error);
+    }
+  }
+
+  private async backfillMissingEmbeddings(): Promise<void> {
+    if (!this.semanticRecallEnabled || !this.vectorDb) {
+      return;
+    }
+
+    let existing = new Set<string>();
+    try {
+      const rows = this.vectorDb
+        .prepare('SELECT memory_id FROM memory_vectors')
+        .all() as Array<{ memory_id: string }>;
+      existing = new Set(rows.map((row) => row.memory_id));
+    } catch {
+      return;
+    }
+
+    const missing = this.state.items.filter((item) => !item.deleted && !existing.has(item.id));
+    for (const item of missing) {
+      await this.upsertEmbedding(item);
+    }
+
+    const deletedIds = this.state.items.filter((item) => item.deleted).map((item) => item.id);
+    this.deleteEmbeddings(deletedIds);
+  }
+
+  private loadEmbeddings(memoryIds: string[]): Map<string, number[]> {
+    const result = new Map<string, number[]>();
+    if (!this.semanticRecallEnabled || !this.vectorDb || memoryIds.length === 0) {
+      return result;
+    }
+
+    const stmt = this.vectorDb.prepare('SELECT vector FROM memory_vectors WHERE memory_id = ?') as {
+      get: (memoryId: string) => StoredEmbeddingRow | undefined;
+    };
+
+    for (const memoryId of memoryIds) {
+      const row = stmt.get(memoryId);
+      if (!row) {
+        continue;
+      }
+      const vector = parseEmbedding(row.vector, this.embeddingDimensions);
+      if (vector) {
+        result.set(memoryId, vector);
+      }
+    }
+
+    return result;
+  }
+
+  private async upsertEmbedding(item: MemoryItem): Promise<void> {
+    if (!this.semanticRecallEnabled || !this.vectorDb || item.deleted) {
+      return;
+    }
+
+    const text = [item.type, item.summary, item.content, item.keywords.join(' ')].filter(Boolean).join(' ');
+    const embedding = await this.embedText(text);
+    if (!embedding) {
+      return;
+    }
+
+    const stmt = this.vectorDb.prepare(`
+      INSERT INTO memory_vectors (memory_id, platform_key, vector, updated_at)
+      VALUES (?, ?, ?, ?)
+      ON CONFLICT(memory_id) DO UPDATE SET
+        platform_key = excluded.platform_key,
+        vector = excluded.vector,
+        updated_at = excluded.updated_at
+    `);
+
+    stmt.run(item.id, item.platformKey, JSON.stringify(embedding), Date.now());
+  }
+
+  private deleteEmbeddings(memoryIds: string[]): void {
+    if (!this.semanticRecallEnabled || !this.vectorDb || memoryIds.length === 0) {
+      return;
+    }
+
+    const stmt = this.vectorDb.prepare('DELETE FROM memory_vectors WHERE memory_id = ?');
+    for (const memoryId of new Set(memoryIds)) {
+      stmt.run(memoryId);
+    }
+  }
+
+  private async embedText(text: string): Promise<number[] | undefined> {
+    if (!this.semanticRecallEnabled) {
+      return undefined;
+    }
+
+    const compact = normalizeWhitespace(text);
+    if (!compact) {
+      return undefined;
+    }
+
+    try {
+      const vector = await this.embeddingProvider.embed(compact);
+      return normalizeEmbeddingVector(vector, this.embeddingDimensions);
+    } catch {
+      return undefined;
+    }
   }
 
   private async saveState(): Promise<void> {
@@ -202,7 +423,7 @@ export class FileMemoryPluginService {
     return `${platformKey}:${sessionId}`;
   }
 
-  private compact(platformKey: string): void {
+  private compact(platformKey: string): string[] {
     const active = this.state.items
       .filter((item) => item.platformKey === platformKey && !item.deleted)
       .sort((a, b) => {
@@ -218,16 +439,20 @@ export class FileMemoryPluginService {
       });
 
     if (active.length <= this.maxItemsPerUser) {
-      return;
+      return [];
     }
 
-    const toDrop = new Set(active.slice(this.maxItemsPerUser).map((item) => item.id));
+    const droppedIds = active.slice(this.maxItemsPerUser).map((item) => item.id);
+    const toDrop = new Set(droppedIds);
+
     this.state.items = this.state.items.filter((item) => {
       if (item.platformKey !== platformKey) {
         return true;
       }
       return !toDrop.has(item.id);
     });
+
+    return droppedIds;
   }
 
   private isCandidateVisible(item: MemoryItem, platformKey: string, sessionId?: string): boolean {
@@ -240,6 +465,35 @@ export class FileMemoryPluginService {
     }
 
     return true;
+  }
+}
+
+class HashEmbeddingProvider implements EmbeddingProvider {
+  readonly dimensions: number;
+
+  constructor(dimensions: number) {
+    this.dimensions = clamp(dimensions, MIN_EMBEDDING_DIMENSIONS, MAX_EMBEDDING_DIMENSIONS);
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const normalized = normalizeWhitespace(text).toLowerCase();
+    if (!normalized) {
+      return new Array(this.dimensions).fill(0);
+    }
+
+    const vector = new Array(this.dimensions).fill(0);
+    const tokens = expandSemanticTokens(tokenize(normalized));
+    const charNgrams = buildCharacterNgrams(normalized, 3, 120);
+
+    for (const token of tokens) {
+      addHashedWeight(vector, `tok:${token}`, 1.4);
+    }
+
+    for (const ngram of charNgrams) {
+      addHashedWeight(vector, `chr:${ngram}`, 0.6);
+    }
+
+    return normalizeEmbeddingVector(vector, this.dimensions);
   }
 }
 
@@ -300,22 +554,30 @@ function dedupeExtracted(items: ExtractedMemory[]): ExtractedMemory[] {
   return deduped;
 }
 
-function scoreItem(item: MemoryItem, queryTokens: string[], now: number): number {
-  const haystack = `${item.summary} ${item.content} ${item.keywords.join(' ')}`.toLowerCase();
-  const matched = queryTokens.filter((token) => haystack.includes(token));
-  const keywordScore = queryTokens.length === 0 ? 0 : matched.length / queryTokens.length;
+function combineRecallScore(input: RecallScoreInput): number {
+  const {
+    keywordScore,
+    semanticScore,
+    recencyScore,
+    qualityScore,
+    pinned,
+    hasKeywords,
+    hasSemantic,
+  } = input;
 
-  const ageDays = Math.max(0, now - item.updatedAt) / (1000 * 60 * 60 * 24);
-  const recencyScore = 1 / (1 + ageDays / 7);
-  const qualityScore = item.confidence * 0.5 + item.importance * 0.5;
-
-  let score = 0.55 * keywordScore + 0.25 * recencyScore + 0.2 * qualityScore;
-  if (item.pinned) {
-    score += 0.2;
+  let score = 0;
+  if (hasKeywords && hasSemantic) {
+    score = keywordScore * 0.38 + semanticScore * 0.32 + recencyScore * 0.17 + qualityScore * 0.13;
+  } else if (hasKeywords) {
+    score = keywordScore * 0.55 + recencyScore * 0.25 + qualityScore * 0.2;
+  } else if (hasSemantic) {
+    score = semanticScore * 0.65 + recencyScore * 0.2 + qualityScore * 0.15;
+  } else {
+    score = recencyScore * 0.7 + qualityScore * 0.3;
   }
 
-  if (queryTokens.length === 0) {
-    score = recencyScore * 0.7 + qualityScore * 0.3 + (item.pinned ? 0.2 : 0);
+  if (pinned) {
+    score += 0.2;
   }
 
   return score;
@@ -367,6 +629,109 @@ function tokenize(input: string): string[] {
 
 function uniqueWords(items: string[]): string[] {
   return [...new Set(items)].slice(0, 40);
+}
+
+function expandSemanticTokens(tokens: string[]): string[] {
+  const expanded: string[] = [];
+  for (const token of tokens) {
+    expanded.push(token);
+    const synonyms = SEMANTIC_SYNONYMS[token];
+    if (synonyms) {
+      expanded.push(...synonyms);
+    }
+  }
+  return uniqueWords(expanded);
+}
+
+function buildCharacterNgrams(text: string, n: number, maxCount: number): string[] {
+  const compact = text.replace(/\s+/g, '');
+  if (compact.length < n) {
+    return compact ? [compact] : [];
+  }
+
+  const grams: string[] = [];
+  for (let i = 0; i <= compact.length - n && grams.length < maxCount; i += 1) {
+    grams.push(compact.slice(i, i + n));
+  }
+  return grams;
+}
+
+function addHashedWeight(vector: number[], token: string, weight: number): void {
+  const hash = hashString(token);
+  const index = hash % vector.length;
+  const sign = (hash & 1) === 0 ? 1 : -1;
+  vector[index] += sign * weight;
+}
+
+function hashString(input: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function normalizeEmbeddingVector(vector: number[], dimensions: number): number[] {
+  const trimmed = vector.slice(0, dimensions);
+  while (trimmed.length < dimensions) {
+    trimmed.push(0);
+  }
+
+  let norm = 0;
+  for (const value of trimmed) {
+    norm += value * value;
+  }
+
+  if (norm === 0) {
+    return trimmed;
+  }
+
+  const scale = 1 / Math.sqrt(norm);
+  return trimmed.map((value) => value * scale);
+}
+
+function parseEmbedding(raw: string, dimensions: number): number[] | undefined {
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return undefined;
+    }
+
+    const vector = parsed
+      .slice(0, dimensions)
+      .map((value) => (typeof value === 'number' && Number.isFinite(value) ? value : 0));
+
+    return normalizeEmbeddingVector(vector, dimensions);
+  } catch {
+    return undefined;
+  }
+}
+
+function cosineSimilarity(left: number[], right: number[]): number {
+  const dimensions = Math.min(left.length, right.length);
+  if (dimensions === 0) {
+    return 0;
+  }
+
+  let dot = 0;
+  let leftNorm = 0;
+  let rightNorm = 0;
+
+  for (let i = 0; i < dimensions; i += 1) {
+    const l = left[i] ?? 0;
+    const r = right[i] ?? 0;
+    dot += l * r;
+    leftNorm += l * l;
+    rightNorm += r * r;
+  }
+
+  if (leftNorm === 0 || rightNorm === 0) {
+    return 0;
+  }
+
+  const cosine = dot / (Math.sqrt(leftNorm) * Math.sqrt(rightNorm));
+  return clamp(cosine, 0, 1);
 }
 
 function clamp(value: number, min: number, max: number): number {

--- a/packages/memory-plugin/src/types.ts
+++ b/packages/memory-plugin/src/types.ts
@@ -62,8 +62,17 @@ export interface MutateResult {
   item?: MemoryItem;
 }
 
+export interface EmbeddingProvider {
+  dimensions: number;
+  embed(text: string): Promise<number[]>;
+}
+
 export interface FileMemoryServiceOptions {
   baseDir?: string;
+  vectorStorePath?: string;
   maxItemsPerUser?: number;
   defaultRecallLimit?: number;
+  semanticRecallEnabled?: boolean;
+  embeddingDimensions?: number;
+  embeddingProvider?: EmbeddingProvider;
 }

--- a/packages/memory-plugin/src/types.ts
+++ b/packages/memory-plugin/src/types.ts
@@ -1,0 +1,69 @@
+export type MemoryScope = 'session' | 'user';
+
+export type MemoryType = 'preference' | 'rule' | 'decision' | 'fix' | 'fact';
+
+export interface MemoryItem {
+  id: string;
+  platformKey: string;
+  sessionId?: string;
+  scope: MemoryScope;
+  type: MemoryType;
+  content: string;
+  summary: string;
+  keywords: string[];
+  confidence: number;
+  importance: number;
+  pinned: boolean;
+  deleted: boolean;
+  createdAt: number;
+  updatedAt: number;
+  lastAccessedAt: number;
+}
+
+export interface MemoryState {
+  items: MemoryItem[];
+  sessionEnabled: Record<string, boolean>;
+}
+
+export interface RecallResult {
+  enabled: boolean;
+  items: MemoryItem[];
+  promptAppend?: string;
+}
+
+export interface RecordTurnInput {
+  platformKey: string;
+  sessionId: string;
+  userText: string;
+  assistantText: string;
+}
+
+export interface RecallInput {
+  platformKey: string;
+  sessionId: string;
+  query: string;
+  limit?: number;
+}
+
+export interface ListInput {
+  platformKey: string;
+  sessionId?: string;
+  limit?: number;
+}
+
+export interface ToggleResult {
+  ok: boolean;
+  enabled: boolean;
+}
+
+export interface MutateResult {
+  ok: boolean;
+  reason?: string;
+  item?: MemoryItem;
+}
+
+export interface FileMemoryServiceOptions {
+  baseDir?: string;
+  maxItemsPerUser?: number;
+  defaultRecallLimit?: number;
+}

--- a/packages/memory-plugin/tsconfig.json
+++ b/packages/memory-plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/memory-plugin/tsup.config.ts
+++ b/packages/memory-plugin/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+  },
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  splitting: false,
+  sourcemap: true,
+  target: 'es2022',
+});

--- a/packages/memory-plugin/tsup.config.ts
+++ b/packages/memory-plugin/tsup.config.ts
@@ -10,4 +10,5 @@ export default defineConfig({
   splitting: false,
   sourcemap: true,
   target: 'es2022',
+  external: ['better-sqlite3'],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,7 +167,14 @@ importers:
         version: 1.6.1(@types/node@25.0.10)
 
   packages/memory-plugin:
+    dependencies:
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
     devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.12
+        version: 7.6.13
       '@types/node':
         specifier: ^25.0.10
         version: 25.0.10
@@ -760,6 +767,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -844,6 +854,21 @@ packages:
   axios@1.13.5:
     resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  better-sqlite3@11.10.0:
+    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -872,6 +897,9 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -908,13 +936,25 @@ packages:
       supports-color:
         optional: true
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-eql@4.1.4:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
     engines: {node: '>=6'}
 
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
@@ -940,6 +980,9 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -983,6 +1026,10 @@ packages:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
     engines: {node: '>=0.10.0'}
@@ -995,6 +1042,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
@@ -1015,6 +1065,9 @@ packages:
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1041,6 +1094,9 @@ packages:
 
   get-tsconfig@4.13.0:
     resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob@11.0.1:
     resolution: {integrity: sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==}
@@ -1075,6 +1131,15 @@ packages:
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   is-extendable@0.1.1:
     resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
@@ -1169,13 +1234,23 @@ packages:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   minimatch@10.1.1:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
     engines: {node: 20 || >=22}
 
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
@@ -1191,6 +1266,13 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  node-abi@3.87.0:
+    resolution: {integrity: sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==}
+    engines: {node: '>=10'}
+
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1202,6 +1284,9 @@ packages:
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
@@ -1275,6 +1360,11 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -1286,12 +1376,23 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  pump@3.0.3:
+    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+
   qs@6.15.0:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
 
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -1309,9 +1410,17 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   section-matter@1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
     engines: {node: '>=4'}
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1344,6 +1453,12 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1369,6 +1484,9 @@ packages:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -1385,6 +1503,10 @@ packages:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
 
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
   strip-literal@2.1.1:
     resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
@@ -1392,6 +1514,13 @@ packages:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -1449,6 +1578,9 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
   type-detect@4.1.0:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
@@ -1466,6 +1598,9 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vite-node@1.6.1:
     resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
@@ -1545,6 +1680,9 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
@@ -1940,6 +2078,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 25.0.10
+
   '@types/estree@1.0.8': {}
 
   '@types/glob@8.1.0':
@@ -2032,6 +2174,28 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  base64-js@1.5.1: {}
+
+  better-sqlite3@11.10.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   bundle-require@5.1.0(esbuild@0.27.2):
     dependencies:
       esbuild: 0.27.2
@@ -2067,6 +2231,8 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  chownr@1.1.4: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -2093,11 +2259,19 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-eql@4.1.4:
     dependencies:
       type-detect: 4.1.0
 
+  deep-extend@0.6.0: {}
+
   delayed-stream@1.0.0: {}
+
+  detect-libc@2.1.2: {}
 
   diff-sequences@29.6.3: {}
 
@@ -2116,6 +2290,10 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   es-define-property@1.0.1: {}
 
@@ -2207,6 +2385,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
+  expand-template@2.0.3: {}
+
   extend-shallow@2.0.1:
     dependencies:
       is-extendable: 0.1.1
@@ -2214,6 +2394,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  file-uri-to-path@1.0.0: {}
 
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
@@ -2235,6 +2417,8 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
+
+  fs-constants@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -2267,6 +2451,8 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  github-from-package@0.0.0: {}
+
   glob@11.0.1:
     dependencies:
       foreground-child: 3.3.1
@@ -2298,6 +2484,12 @@ snapshots:
   hono@4.11.9: {}
 
   human-signals@5.0.0: {}
+
+  ieee754@1.2.1: {}
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   is-extendable@0.1.1: {}
 
@@ -2365,11 +2557,17 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
+  mimic-response@3.1.0: {}
+
   minimatch@10.1.1:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
 
+  minimist@1.2.8: {}
+
   minipass@7.1.2: {}
+
+  mkdirp-classic@0.5.3: {}
 
   mlly@1.8.0:
     dependencies:
@@ -2388,6 +2586,12 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  napi-build-utils@2.0.0: {}
+
+  node-abi@3.87.0:
+    dependencies:
+      semver: 7.7.4
+
   npm-run-path@5.3.0:
     dependencies:
       path-key: 4.0.0
@@ -2395,6 +2599,10 @@ snapshots:
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   onetime@6.0.0:
     dependencies:
@@ -2449,6 +2657,21 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.87.0
+      pump: 3.0.3
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   pretty-format@29.7.0:
     dependencies:
       '@jest/schemas': 29.6.3
@@ -2472,11 +2695,29 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  pump@3.0.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
 
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+
   react-is@18.3.1: {}
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
 
@@ -2515,10 +2756,14 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
 
+  safe-buffer@5.2.1: {}
+
   section-matter@1.0.0:
     dependencies:
       extend-shallow: 2.0.1
       kind-of: 6.0.3
+
+  semver@7.7.4: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -2558,6 +2803,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   source-map-js@1.2.1: {}
 
   source-map@0.7.6: {}
@@ -2580,6 +2833,10 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.1.2
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -2591,6 +2848,8 @@ snapshots:
   strip-bom-string@1.0.0: {}
 
   strip-final-newline@3.0.0: {}
+
+  strip-json-comments@2.0.1: {}
 
   strip-literal@2.1.1:
     dependencies:
@@ -2605,6 +2864,21 @@ snapshots:
       pirates: 4.0.7
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.3
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   thenify-all@1.6.0:
     dependencies:
@@ -2666,6 +2940,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   type-detect@4.1.0: {}
 
   typescript@5.9.3: {}
@@ -2675,6 +2953,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
+
+  util-deprecate@1.0.2: {}
 
   vite-node@1.6.1(@types/node@25.0.10):
     dependencies:
@@ -2757,6 +3037,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 5.1.2
       strip-ansi: 7.1.2
+
+  wrappy@1.0.2: {}
 
   ws@8.19.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       pulse-coder-memory-plugin:
         specifier: workspace:*
         version: link:../../packages/memory-plugin
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: ^20.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       pulse-coder-engine:
         specifier: workspace:*
         version: link:../../packages/engine
+      pulse-coder-memory-plugin:
+        specifier: workspace:*
+        version: link:../../packages/memory-plugin
     devDependencies:
       '@types/node':
         specifier: ^20.0.0
@@ -150,6 +153,21 @@ importers:
       '@types/glob':
         specifier: ^8.1.0
         version: 8.1.0
+      '@types/node':
+        specifier: ^25.0.10
+        version: 25.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@25.0.10)
+
+  packages/memory-plugin:
+    devDependencies:
       '@types/node':
         specifier: ^25.0.10
         version: 25.0.10


### PR DESCRIPTION
Add a standalone memory plugin and integrate it into remote-server via Engine hooks.

- Extract memory logic into `pulse-coder-memory-plugin` package
- Add semantic recall with local hash embeddings and optional OpenAI-compatible embeddings
- Wire memory into remote-server through `beforeRun`/`afterRun` plugin hooks
- Add `/memory` command support and session-level memory controls
- Add tests and docs for memory service behavior and design
