### PR TITLE
Send Gemini-generated images directly to Feishu

### DIFF
--- a/apps/remote-server/.env.example
+++ b/apps/remote-server/.env.example
@@ -36,6 +36,8 @@ FEISHU_APP_ID=
 FEISHU_APP_SECRET=
 FEISHU_ENCRYPT_KEY=
 FEISHU_VERIFICATION_TOKEN=
+# Optional custom Feishu Open API base URL (default: https://open.feishu.cn)
+FEISHU_API_BASE_URL=
 
 # === Telegram ===
 TELEGRAM_BOT_TOKEN=

--- a/apps/remote-server/src/adapters/web/adapter.ts
+++ b/apps/remote-server/src/adapters/web/adapter.ts
@@ -61,6 +61,7 @@ export class WebAdapter implements PlatformAdapter {
     return {
       async onText(delta) { push('text', { delta }); },
       async onToolCall(name, input) { push('tool_call', { toolName: name, input }); },
+      async onToolResult(result) { push('tool_result', { result }); },
       async onClarification(req: ClarificationRequest) { push('clarification', req); },
       async onDone(result) {
         push('done', { result });

--- a/apps/remote-server/src/core/dispatcher.ts
+++ b/apps/remote-server/src/core/dispatcher.ts
@@ -120,6 +120,9 @@ async function runAgentAsync(adapter: PlatformAdapter, incoming: IncomingMessage
         onToolCall: (toolCall) => {
           handle?.onToolCall(toolCall.toolName ?? toolCall.name ?? 'unknown', toolCall.args ?? toolCall.input ?? {}).catch(console.error);
         },
+        onToolResult: (toolResult) => {
+          handle?.onToolResult?.(toolResult).catch(console.error);
+        },
         onResponse: (messages) => {
           for (const msg of messages) {
             context.messages.push(msg);

--- a/apps/remote-server/src/core/types.ts
+++ b/apps/remote-server/src/core/types.ts
@@ -29,6 +29,7 @@ export interface IncomingMessage {
 export interface StreamHandle {
   onText(delta: string): Promise<void>;
   onToolCall(name: string, input: unknown): Promise<void>;
+  onToolResult?(result: unknown): Promise<void>;
   onClarification(req: ClarificationRequest): Promise<void>;
   onDone(result: string): Promise<void>;
   onError(err: Error): Promise<void>;
@@ -36,7 +37,7 @@ export interface StreamHandle {
 
 /**
  * Each platform implements this interface.
- * The dispatcher is fully platform-agnostic — it only calls these 5 methods.
+ * The dispatcher is fully platform-agnostic — it only calls these lifecycle methods.
  */
 export interface PlatformAdapter {
   name: string;

--- a/apps/remote-server/src/routes/api.ts
+++ b/apps/remote-server/src/routes/api.ts
@@ -20,7 +20,7 @@ apiRouter.post('/chat', (c) => dispatch(webAdapter, c));
  * GET /api/stream/:streamId
  * Open an SSE connection to receive events from an agent run.
  *
- * Events: text | tool_call | clarification | done | error
+ * Events: text | tool_call | tool_result | clarification | done | error
  */
 apiRouter.get('/stream/:streamId', (c) => {
   const { streamId } = c.req.param();


### PR DESCRIPTION
Enable Feishu to deliver images produced by the  tool during agent runs.

- Add tool-result callback plumbing from dispatcher to platform stream handles
- Upload local Gemini output images to Feishu and send them as image messages
- Detect and de-duplicate Gemini image tool outputs in Feishu adapter
- Emit  SSE events for web adapter and document the event type
- Add optional  configuration in 