### PR TITLE
Support ZenMux Vertex AI image generation

### DIFF
--- a/apps/remote-server/.env.example
+++ b/apps/remote-server/.env.example
@@ -6,9 +6,11 @@ OPENAI_MODEL=
 # === Gemini Pro Image Tool ===
 # Required to enable gemini_pro_image built-in tool
 GEMINI_API_KEY=
-# Optional endpoint override (default: https://generativelanguage.googleapis.com/v1beta)
+# Optional endpoint override (Google default: https://generativelanguage.googleapis.com/v1beta)
+# For ZenMux Vertex AI set: https://zenmux.ai/api/vertex-ai
 GEMINI_API_BASE_URL=
 # Optional model override (default: gemini-pro-image)
+# For ZenMux Vertex AI prefer provider-qualified model, e.g. google/gemini-3-pro-image-preview
 GEMINI_PRO_IMAGE_MODEL=
 
 # === Server ===


### PR DESCRIPTION
Add ZenMux Vertex AI compatibility for gemini_pro_image requests.

- Route Vertex base URL requests to the publishers/models generateContent endpoint
- Use Bearer auth in Vertex mode while keeping API-key query auth for Google endpoint
- Normalize provider/model parsing with google as the default provider
- Document ZenMux base URL and model format in remote-server env example