### PR TITLE
Send generated images to active Feishu sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Pulse Coder generated images
+apps/remote-server/.pulse-coder/generated-images/

--- a/apps/remote-server/src/adapters/feishu/adapter.ts
+++ b/apps/remote-server/src/adapters/feishu/adapter.ts
@@ -4,6 +4,7 @@ import type { PlatformAdapter, IncomingMessage, StreamHandle } from '../../core/
 import type { ClarificationRequest } from '../../core/types.js';
 import { clarificationQueue } from '../../core/clarification-queue.js';
 import { getActiveStreamId } from '../../core/active-run-store.js';
+import { extractGeminiImageResult } from './image-result.js';
 import {
   createLarkClient,
   sendTextMessage,
@@ -313,95 +314,6 @@ export class FeishuAdapter implements PlatformAdapter {
   }
 }
 
-
-interface GeminiImageResult {
-  outputPath: string;
-  mimeType?: string;
-}
-
-function extractGeminiImageResult(toolResult: unknown): GeminiImageResult | null {
-  const toolName = extractToolName(toolResult);
-  const payload = extractToolPayload(toolResult);
-
-  if (!payload || !isRecord(payload)) {
-    return null;
-  }
-
-  const outputPath = asString(payload.outputPath);
-  if (!outputPath) {
-    return null;
-  }
-
-  const mimeType = asString(payload.mimeType) ?? undefined;
-
-  if (toolName && toolName !== 'gemini_pro_image') {
-    return null;
-  }
-
-  if (!toolName && !looksLikeGeminiImagePayload(payload)) {
-    return null;
-  }
-
-  return {
-    outputPath,
-    mimeType,
-  };
-}
-
-function extractToolName(toolResult: unknown): string | null {
-  if (!isRecord(toolResult)) {
-    return null;
-  }
-
-  const topLevel = asString(toolResult.toolName) || asString(toolResult.name);
-  if (topLevel) {
-    return topLevel;
-  }
-
-  const nestedToolCall = isRecord(toolResult.toolCall) ? toolResult.toolCall : null;
-  if (nestedToolCall) {
-    return asString(nestedToolCall.toolName) || asString(nestedToolCall.name) || null;
-  }
-
-  return null;
-}
-
-function extractToolPayload(toolResult: unknown): unknown {
-  if (!isRecord(toolResult)) {
-    return null;
-  }
-
-  if (isRecord(toolResult.result)) {
-    return toolResult.result;
-  }
-
-  if (isRecord(toolResult.output)) {
-    return toolResult.output;
-  }
-
-  return toolResult;
-}
-
-function looksLikeGeminiImagePayload(payload: Record<string, unknown>): boolean {
-  return (
-    asString(payload.model) !== null
-    && asString(payload.outputPath) !== null
-    && asString(payload.mimeType)?.startsWith('image/') === true
-  );
-}
-
-function asString(value: unknown): string | null {
-  if (typeof value !== 'string') {
-    return null;
-  }
-
-  const trimmed = value.trim();
-  return trimmed ? trimmed : null;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
 
 export const feishuAdapter = new FeishuAdapter();
 

--- a/apps/remote-server/src/adapters/feishu/image-result.ts
+++ b/apps/remote-server/src/adapters/feishu/image-result.ts
@@ -1,0 +1,88 @@
+interface GeminiImageResult {
+  outputPath: string;
+  mimeType?: string;
+}
+
+export function extractGeminiImageResult(toolResult: unknown): GeminiImageResult | null {
+  const toolName = extractToolName(toolResult);
+  const payload = extractToolPayload(toolResult);
+
+  if (!payload || !isRecord(payload)) {
+    return null;
+  }
+
+  const outputPath = asString(payload.outputPath);
+  if (!outputPath) {
+    return null;
+  }
+
+  const mimeType = asString(payload.mimeType) ?? undefined;
+
+  if (toolName && toolName !== 'gemini_pro_image') {
+    return null;
+  }
+
+  if (!toolName && !looksLikeGeminiImagePayload(payload)) {
+    return null;
+  }
+
+  return {
+    outputPath,
+    mimeType,
+  };
+}
+
+function extractToolName(toolResult: unknown): string | null {
+  if (!isRecord(toolResult)) {
+    return null;
+  }
+
+  const topLevel = asString(toolResult.toolName) || asString(toolResult.name);
+  if (topLevel) {
+    return topLevel;
+  }
+
+  const nestedToolCall = isRecord(toolResult.toolCall) ? toolResult.toolCall : null;
+  if (nestedToolCall) {
+    return asString(nestedToolCall.toolName) || asString(nestedToolCall.name) || null;
+  }
+
+  return null;
+}
+
+function extractToolPayload(toolResult: unknown): unknown {
+  if (!isRecord(toolResult)) {
+    return null;
+  }
+
+  if (isRecord(toolResult.result)) {
+    return toolResult.result;
+  }
+
+  if (isRecord(toolResult.output)) {
+    return toolResult.output;
+  }
+
+  return toolResult;
+}
+
+function looksLikeGeminiImagePayload(payload: Record<string, unknown>): boolean {
+  return (
+    asString(payload.model) !== null
+    && asString(payload.outputPath) !== null
+    && asString(payload.mimeType)?.startsWith('image/') === true
+  );
+}
+
+function asString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}


### PR DESCRIPTION
Enable internal agent runs to send generated images back to the same Feishu conversation instead of a fixed target.

- Add Feishu target inference from platformKey for group and direct chats
- Handle gemini_pro_image tool results in /internal/agent/run and send image messages to the resolved target
- Wait for queued image-send tasks before final notify text for consistent delivery
- Extract and reuse shared Gemini image-result parsing in src/adapters/feishu/image-result.ts