### PR TITLE
Fix Gemini image payload and ignore generated images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,8 @@ vite.config.ts.timestamp-*
 
 # Pulse Coder generated images
 apps/remote-server/.pulse-coder/generated-images/
+apps/remote-server/*.png
+apps/remote-server/*.jpg
+apps/remote-server/*.jpeg
+apps/remote-server/*.webp
+apps/remote-server/*.svg

--- a/packages/engine/src/tools/gemini-pro-image.ts
+++ b/packages/engine/src/tools/gemini-pro-image.ts
@@ -73,7 +73,7 @@ export const GeminiProImageTool: Tool<
       .optional()
       .describe('Request timeout in milliseconds. Defaults to 120000 (2 minutes).'),
   }),
-  execute: async ({ prompt, model, outputPath, mimeType = 'image/png', includeBase64 = false, timeout = DEFAULT_TIMEOUT }) => {
+  execute: async ({ prompt, model, outputPath, includeBase64 = false, timeout = DEFAULT_TIMEOUT }) => {
     if (!prompt.trim()) {
       throw new Error('prompt is required');
     }


### PR DESCRIPTION
Align Gemini image request handling and keep generated artifacts out of git

- Remove mimeType usage in Gemini image tool execution path
- Ensure image requests only rely on responseModalities
- Ignore remote-server generated image files in .gitignore