### PR TITLE
Fix compact context no-gain behavior

### DIFF
--- a/apps/remote-server/package.json
+++ b/apps/remote-server/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "type": "module",
   "scripts": {
+    "prebuild": "npm --prefix ../../packages/engine run build",
     "dev": "tsx watch src/index.ts",
     "build": "tsup",
     "start": "node dist/index.cjs",

--- a/packages/engine/src/Engine.ts
+++ b/packages/engine/src/Engine.ts
@@ -345,7 +345,7 @@ export * from './shared/types.js';
 export * from './plugin/EnginePlugin.js';
 export * from './plugin/UserConfigPlugin.js';
 export { loop } from './core/loop.js';
-export type { LoopOptions, LoopHooks } from './core/loop.js';
+export type { LoopOptions, LoopHooks, CompactionEvent } from './core/loop.js';
 export { streamTextAI } from './ai/index.js';
 export { maybeCompactContext } from './context/index.js';
 export * from './tools/index.js';

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -51,6 +51,7 @@ export type {
 // 原有导出保持不变
 export * from './shared/types.js';
 export { loop } from './core/loop.js';
+export type { LoopOptions, LoopHooks, CompactionEvent } from './core/loop.js';
 export { streamTextAI } from './ai/index.js';
 export { maybeCompactContext } from './context/index.js';
 export * from './tools/index.js';


### PR DESCRIPTION
Improve compact behavior and observability across engine and remote server.

- Prevent force compact from applying when summary/fallback does not reduce estimated tokens
- Add compaction stats/event payloads in engine context+loop and export CompactionEvent types
- Surface compaction events in dispatcher/internal route logs and tool-call hints
- Improve  command diagnostics and include engine prebuild in remote-server build flow