### PR TITLE
feat(engine): add remote skill loading support

### DIFF
--- a/packages/engine/src/Engine.ts
+++ b/packages/engine/src/Engine.ts
@@ -3,12 +3,13 @@ import type { LoopOptions, LoopHooks } from './core/loop';
 import type { EnginePluginLoadOptions } from './plugin/EnginePlugin.js';
 import type { UserConfigPluginLoadOptions } from './plugin/UserConfigPlugin.js';
 import type { PlanMode, PlanModeService } from './built-in/index.js';
+import type { RemoteSkillConfig } from './built-in/skills-plugin/index.js';
 
 import { loop } from './core/loop.js';
 import { maybeCompactContext } from './context/index.js';
 import { BuiltinToolsMap } from './tools/index.js';
 import { PluginManager } from './plugin/PluginManager.js';
-import { builtInPlugins } from './built-in/index.js';
+import { builtInMCPPlugin, builtInPlanModePlugin, builtInTaskTrackingPlugin, SubAgentPlugin, createBuiltInSkillsPlugin } from './built-in/index.js';
 
 /**
  * 引擎配置选项
@@ -111,6 +112,45 @@ export interface EngineOptions {
    * const engine = new Engine({ logger });
    */
   logger?: ILogger;
+
+  /**
+   * 远程 skill 配置。
+   * 提供后，engine 初始化时会通过 HTTP GET 拉取指定 endpoint 的 skill 列表，
+   * 与本地 SKILL.md 文件合并（本地同名 skill 优先）。
+   *
+   * 远程 endpoint 需返回以下格式的 JSON：
+   * {
+   *   "skills": [
+   *     {
+   *       "name": "string",
+   *       "description": "string",
+   *       "content": "string",   // skill 正文 (Markdown)
+   *       "version": "string",   // 可选
+   *       "author": "string"     // 可选
+   *     }
+   *   ]
+   * }
+   *
+   * @example 单个 endpoint
+   * const engine = new Engine({
+   *   remoteSkills: {
+   *     endpoints: 'https://skills.example.com/api/skills',
+   *   }
+   * });
+   *
+   * @example 多个 endpoint，带鉴权头和超时
+   * const engine = new Engine({
+   *   remoteSkills: {
+   *     endpoints: [
+   *       'https://internal.example.com/api/skills',
+   *       'https://public.example.com/api/skills',
+   *     ],
+   *     headers: { Authorization: 'Bearer <token>' },
+   *     timeout: 8000,
+   *   }
+   * });
+   */
+  remoteSkills?: RemoteSkillConfig;
 }
 
 /**
@@ -173,8 +213,14 @@ export class Engine {
       return userPlugins;
     }
 
-    // 合并内置插件和用户插件
-    const builtInPluginList = [...builtInPlugins];
+    // 内置插件列表：skills 插件通过工厂创建，以便传入远程 skill 配置
+    const builtInPluginList = [
+      builtInMCPPlugin,
+      createBuiltInSkillsPlugin({ remoteSkills: this.options.remoteSkills }),
+      builtInPlanModePlugin,
+      builtInTaskTrackingPlugin,
+      new SubAgentPlugin(),
+    ];
     const userPluginList = userPlugins.plugins || [];
 
     return {
@@ -349,3 +395,5 @@ export type { LoopOptions, LoopHooks, CompactionEvent } from './core/loop.js';
 export { streamTextAI } from './ai/index.js';
 export { maybeCompactContext } from './context/index.js';
 export * from './tools/index.js';
+export type { RemoteSkillConfig, BuiltInSkillsPluginOptions } from './built-in/skills-plugin/index.js';
+export { createBuiltInSkillsPlugin } from './built-in/index.js';

--- a/packages/engine/src/built-in/index.ts
+++ b/packages/engine/src/built-in/index.ts
@@ -25,7 +25,15 @@ export const builtInPlugins = [
  * 单独导出各个内置插件，便于外部使用
  */
 export { builtInMCPPlugin } from './mcp-plugin';
-export { builtInSkillsPlugin, BuiltInSkillRegistry } from './skills-plugin';
+export {
+  builtInSkillsPlugin,
+  createBuiltInSkillsPlugin,
+  BuiltInSkillRegistry,
+} from './skills-plugin';
+export type {
+  RemoteSkillConfig,
+  BuiltInSkillsPluginOptions,
+} from './skills-plugin';
 export { builtInPlanModePlugin, BuiltInPlanModeService } from './plan-mode-plugin';
 export { builtInTaskTrackingPlugin, TaskListService } from './task-tracking-plugin';
 export type { TaskStatus, WorkTask, WorkTaskListSnapshot } from './task-tracking-plugin';

--- a/packages/engine/src/built-in/skills-plugin/remote-skill-loader.ts
+++ b/packages/engine/src/built-in/skills-plugin/remote-skill-loader.ts
@@ -1,0 +1,189 @@
+/**
+ * Remote Skill Loader
+ * 从远程 endpoint 拉取 skill 元数据与内容
+ *
+ * 远程 endpoint 协议 (GET <endpoint>):
+ * {
+ *   "skills": [
+ *     {
+ *       "name": "skill-name",          // 必填
+ *       "description": "...",          // 必填
+ *       "content": "# Markdown...",    // 必填，skill 正文（等同于 SKILL.md body）
+ *       "version": "1.0.0",            // 可选
+ *       "author": "...",               // 可选
+ *       [key: string]: any             // 其他自定义元数据
+ *     }
+ *   ]
+ * }
+ */
+
+import type { SkillInfo } from './index.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** 远程 endpoint 响应中单条 skill 的结构 */
+export interface RemoteSkillEntry {
+  name: string;
+  description: string;
+  content: string;
+  version?: string;
+  author?: string;
+  [key: string]: unknown;
+}
+
+/** 远程 endpoint 响应体结构 */
+export interface RemoteSkillEndpointResponse {
+  skills: RemoteSkillEntry[];
+}
+
+/** 远程 skill 加载配置 */
+export interface RemoteSkillConfig {
+  /**
+   * 一个或多个远程 skill endpoint URL。
+   * 每个 endpoint 必须支持 GET 请求并返回 RemoteSkillEndpointResponse 格式的 JSON。
+   */
+  endpoints: string | string[];
+
+  /**
+   * 请求超时（毫秒），默认 5000ms。
+   */
+  timeout?: number;
+
+  /**
+   * 自定义请求头，例如用于鉴权：{ Authorization: 'Bearer <token>' }
+   */
+  headers?: Record<string, string>;
+}
+
+// ---------------------------------------------------------------------------
+// Loader
+// ---------------------------------------------------------------------------
+
+/**
+ * 从单个远程 endpoint 拉取 skill 列表。
+ * 若请求失败或响应格式非法，会打印警告并返回空数组（不抛错，保证 engine 启动不中断）。
+ */
+export async function loadRemoteSkillsFromEndpoint(
+  endpoint: string,
+  options?: Pick<RemoteSkillConfig, 'timeout' | 'headers'>
+): Promise<SkillInfo[]> {
+  const timeout = options?.timeout ?? 5000;
+
+  let response: Response;
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeout);
+
+    response = await fetch(endpoint, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        ...options?.headers,
+      },
+      signal: controller.signal,
+    });
+
+    clearTimeout(timer);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.warn(`[RemoteSkills] Failed to fetch ${endpoint}: ${reason}`);
+    return [];
+  }
+
+  if (!response.ok) {
+    console.warn(
+      `[RemoteSkills] Endpoint ${endpoint} returned HTTP ${response.status} ${response.statusText}`
+    );
+    return [];
+  }
+
+  let json: unknown;
+  try {
+    json = await response.json();
+  } catch {
+    console.warn(`[RemoteSkills] Endpoint ${endpoint} returned non-JSON response`);
+    return [];
+  }
+
+  if (!isValidResponse(json)) {
+    console.warn(
+      `[RemoteSkills] Endpoint ${endpoint} response is missing "skills" array`
+    );
+    return [];
+  }
+
+  const skills: SkillInfo[] = [];
+
+  for (const entry of json.skills) {
+    if (!isValidEntry(entry)) {
+      console.warn(
+        `[RemoteSkills] Skipping entry from ${endpoint}: missing required fields (name, description, content)`
+      );
+      continue;
+    }
+
+    const { name, description, content, ...rest } = entry;
+
+    skills.push({
+      name: name.trim(),
+      description,
+      content,
+      location: endpoint,
+      metadata: {
+        ...rest,
+        remote: true,
+        source: endpoint,
+      },
+    });
+  }
+
+  return skills;
+}
+
+/**
+ * 从多个 endpoint 批量拉取 skill，并发执行。
+ */
+export async function loadRemoteSkills(
+  config: RemoteSkillConfig
+): Promise<SkillInfo[]> {
+  const endpoints = Array.isArray(config.endpoints)
+    ? config.endpoints
+    : [config.endpoints];
+
+  const results = await Promise.all(
+    endpoints.map((ep) =>
+      loadRemoteSkillsFromEndpoint(ep, {
+        timeout: config.timeout,
+        headers: config.headers,
+      })
+    )
+  );
+
+  return results.flat();
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isValidResponse(json: unknown): json is RemoteSkillEndpointResponse {
+  return (
+    typeof json === 'object' &&
+    json !== null &&
+    'skills' in json &&
+    Array.isArray((json as Record<string, unknown>).skills)
+  );
+}
+
+function isValidEntry(entry: unknown): entry is RemoteSkillEntry {
+  if (typeof entry !== 'object' || entry === null) return false;
+  const e = entry as Record<string, unknown>;
+  return (
+    typeof e.name === 'string' &&
+    e.name.trim().length > 0 &&
+    typeof e.description === 'string' &&
+    typeof e.content === 'string'
+  );
+}


### PR DESCRIPTION
Allows the engine to fetch skills from one or more HTTP endpoints at
initialization time, merging them with locally discovered SKILL.md files
(local skills take priority on name collision).

Key changes:
- Add `remote-skill-loader.ts`: typed fetch helpers that call a remote
  endpoint (GET → { skills: [...] }) with configurable timeout and headers.
  Errors are caught gracefully so engine startup is never interrupted.
- Extend `BuiltInSkillRegistry.loadRemoteEndpoints()` to pull remote skills
  into the registry after local scan is complete.
- Convert `builtInSkillsPlugin` constant to `createBuiltInSkillsPlugin()`
  factory so remote config can be injected at construction time; the legacy
  `builtInSkillsPlugin` export is kept as a zero-config default instance.
- Add `remoteSkills?: RemoteSkillConfig` to `EngineOptions`; the engine
  passes it to the skills-plugin factory during `prepareEnginePlugins()`.
- Export `RemoteSkillConfig`, `BuiltInSkillsPluginOptions`, and
  `createBuiltInSkillsPlugin` from the engine's public API.

Usage:
  const engine = new Engine({
    remoteSkills: {
      endpoints: 'https://skills.example.com/api/skills',
      headers: { Authorization: 'Bearer <token>' },
      timeout: 8000,
    }
  });

https://claude.ai/code/session_01GUYBJParncC2gYCv84EBT5