### PR TITLE
Auto-inject persistent user memory in each run

### DIFF
--- a/packages/memory-plugin/src/integration.test.ts
+++ b/packages/memory-plugin/src/integration.test.ts
@@ -1,0 +1,155 @@
+import { EventEmitter } from 'events';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { SystemPromptOption } from 'pulse-coder-engine';
+import { createMemoryEnginePlugin, type MemoryRunContext } from './integration.js';
+import { FileMemoryPluginService } from './service.js';
+
+const createdDirs: string[] = [];
+
+async function createService() {
+  const baseDir = await mkdtemp(join(tmpdir(), 'memory-plugin-integration-test-'));
+  createdDirs.push(baseDir);
+
+  const service = new FileMemoryPluginService({ baseDir });
+  await service.initialize();
+  return { baseDir, service };
+}
+
+function resolveSystemPrompt(option: SystemPromptOption | undefined): string {
+  if (!option) {
+    return '';
+  }
+
+  if (typeof option === 'string') {
+    return option;
+  }
+
+  if (typeof option === 'function') {
+    return option();
+  }
+
+  return option.append;
+}
+
+function createPluginContextMock() {
+  const hooks: Record<string, Array<(input: any) => Promise<any>>> = {};
+
+  return {
+    hooks,
+    context: {
+      registerTool: () => {},
+      registerTools: () => {},
+      getTool: () => undefined,
+      getTools: () => ({}),
+      registerHook: (name: string, handler: (input: any) => Promise<any>) => {
+        hooks[name] = hooks[name] ?? [];
+        hooks[name].push(handler);
+      },
+      registerService: () => {},
+      getService: () => undefined,
+      getConfig: () => undefined,
+      setConfig: () => {},
+      events: new EventEmitter(),
+      logger: {
+        debug: () => {},
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+      },
+    },
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    createdDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe('memory-plugin beforeRun auto injection', () => {
+  it('injects user-scope profile/rule memory into system prompt each run', async () => {
+    const { service } = await createService();
+
+    await service.recordTurn({
+      platformKey: 'test-platform',
+      sessionId: 'session-a',
+      userText: 'Profile: my name is Jasper.',
+      assistantText: 'Profile captured.',
+      sourceType: 'explicit',
+    });
+
+    await service.recordTurn({
+      platformKey: 'test-platform',
+      sessionId: 'session-a',
+      userText: 'Rule: must keep responses concise.',
+      assistantText: 'Acknowledged.',
+      sourceType: 'explicit',
+    });
+
+    await service.recordTurn({
+      platformKey: 'test-platform',
+      sessionId: 'session-a',
+      userText: 'Remember this preference for later: use emoji in status updates.',
+      assistantText: 'Noted.',
+      sourceType: 'explicit',
+    });
+
+    let runContext: MemoryRunContext | undefined = {
+      platformKey: 'test-platform',
+      sessionId: 'session-b',
+      userText: 'continue',
+    };
+
+    const plugin = createMemoryEnginePlugin({
+      service,
+      getRunContext: () => runContext,
+    });
+
+    const mock = createPluginContextMock();
+    await plugin.initialize(mock.context as any);
+
+    const beforeRun = mock.hooks.beforeRun?.[0];
+    expect(beforeRun).toBeDefined();
+
+    const result = await beforeRun({
+      context: { messages: [] },
+      systemPrompt: undefined,
+      tools: {},
+    });
+
+    const prompt = resolveSystemPrompt(result?.systemPrompt);
+    expect(prompt).toContain('Memory Tool Policy (On-Demand)');
+    expect(prompt).toContain('Persistent user memory (auto-injected each run');
+    expect(prompt).toContain('my name is Jasper');
+    expect(prompt).toContain('must keep responses concise');
+    expect(prompt).not.toContain('use emoji in status updates');
+
+    runContext = undefined;
+  });
+
+  it('keeps policy append when run context is unavailable', async () => {
+    const { service } = await createService();
+
+    const plugin = createMemoryEnginePlugin({
+      service,
+      getRunContext: () => undefined,
+    });
+
+    const mock = createPluginContextMock();
+    await plugin.initialize(mock.context as any);
+
+    const beforeRun = mock.hooks.beforeRun?.[0];
+    const result = await beforeRun({
+      context: { messages: [] },
+      systemPrompt: undefined,
+      tools: {},
+    });
+
+    const prompt = resolveSystemPrompt(result?.systemPrompt);
+    expect(prompt).toContain('Memory Tool Policy (On-Demand)');
+    expect(prompt).not.toContain('Persistent user memory (auto-injected each run');
+  });
+});

--- a/packages/memory-plugin/src/service.ts
+++ b/packages/memory-plugin/src/service.ts
@@ -676,10 +676,21 @@ function extractMemoryCandidates(userText: string, assistantText: string): Extra
   const normalizedUser = userText.trim();
 
   if (normalizedUser.length > 0) {
+    const profilePattern = /(^profile:|my name is|call me|i go by|\u6211\u53eb|\u6211\u7684\u540d\u5b57\u662f|\u540d\u5b57\u662f|\u79f0\u547c\u6211)/i;
     const preferencePattern = /(prefer|always|never|please use|remember|default to|\u8bf7\u7528|\u4ee5\u540e|\u8bb0\u4f4f|\u9ed8\u8ba4|\u4e0d\u8981|\u5fc5\u987b)/i;
     const rulePattern = /(rule|constraint|must|should|require|\u89c4\u8303|\u7ea6\u675f|\u5fc5\u987b|\u7981\u6b62)/i;
 
-    if (preferencePattern.test(normalizedUser) || rulePattern.test(normalizedUser)) {
+    if (profilePattern.test(normalizedUser)) {
+      results.push({
+        scope: 'user',
+        type: 'fact',
+        content: normalizeWhitespace(normalizedUser),
+        summary: summarize(normalizedUser, 120),
+        keywords: tokenize(normalizedUser),
+        confidence: 0.78,
+        importance: 0.78,
+      });
+    } else if (preferencePattern.test(normalizedUser) || rulePattern.test(normalizedUser)) {
       const summary = summarize(normalizedUser, 120);
       const type: MemoryType = rulePattern.test(normalizedUser) ? 'rule' : 'preference';
       const scope: MemoryScope = type === 'rule' ? 'user' : 'session';


### PR DESCRIPTION
Enhance memory behavior so stable user-level memory is available across sessions and automatically injected into run context.\n\n- add  as a  and make it the default kind\n- detect profile phrases (name/call-me style) as user-scope  memories\n- auto-append top user-scope / memory lines in \n- keep injection lightweight (filtered + capped) to control prompt size\n- add tests for cross-session profile persistence and beforeRun auto-injection\n\nValidation\n- 
> pulse-coder-memory-plugin@0.0.1 test /root/pulse-coder/packages/memory-plugin
> vitest run


 RUN  v1.6.1 /root/pulse-coder/packages/memory-plugin

stdout | src/service.test.ts > FileMemoryPluginService > dedupes daily-log writes on the same day and increments hit counts
[memory-plugin] daily-log mode=write platform=test-platform session=session-daily-dedupe attempted=2 accepted=2 deduped=0 rejected=0 skippedQuota=0

stdout | src/service.test.ts > FileMemoryPluginService > dedupes daily-log writes on the same day and increments hit counts
[memory-plugin] daily-log mode=write platform=test-platform session=session-daily-dedupe attempted=2 accepted=2 deduped=2 rejected=0 skippedQuota=0

 ✓ src/integration.test.ts  (2 tests) 36ms
stdout | src/service.test.ts > FileMemoryPluginService > enforces daily-log per-day quota
[memory-plugin] daily-log mode=write platform=test-platform session=session-daily-quota attempted=1 accepted=1 deduped=0 rejected=0 skippedQuota=0
[memory-plugin] daily-log mode=write platform=test-platform session=session-daily-quota attempted=1 accepted=0 deduped=0 rejected=1 skippedQuota=1 rejectReasons=quota_day:1

stdout | src/service.test.ts > FileMemoryPluginService > applies daily-log quality gate for low-signal candidates
[memory-plugin] daily-log mode=write platform=test-platform session=session-daily-quality attempted=1 accepted=0 deduped=0 rejected=1 skippedQuota=0 rejectReasons=too_short:1

stdout | src/service.test.ts > FileMemoryPluginService > supports shadow mode for daily-log without persisting items
[memory-plugin] daily-log mode=shadow platform=test-platform session=session-daily-shadow attempted=2 accepted=2 deduped=0 rejected=0 skippedQuota=0

 ✓ src/service.test.ts  (11 tests) 130ms

 Test Files  2 passed (2)
      Tests  13 passed (13)
   Start at  15:06:19
   Duration  843ms (transform 232ms, setup 1ms, collect 433ms, tests 166ms, environment 1ms, prepare 307ms)\n- 
> @pulse-coder/remote-server@0.0.1 prebuild /root/pulse-coder/apps/remote-server
> npm --prefix ../../packages/engine run build


> pulse-coder-engine@0.0.1-alpha.15 build
> tsup

CLI Building entry: {"index":"src/index.ts","built-in/index":"src/built-in/index.ts"}
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Using tsup config: /root/pulse-coder/packages/engine/tsup.config.ts
CLI Target: es2022
CLI Cleaning output folder
ESM Build start
CJS Build start
ESM dist/index.js              106.11 KB
ESM dist/built-in/index.js     88.18 KB
ESM dist/index.js.map          201.49 KB
ESM dist/built-in/index.js.map 161.96 KB
ESM ⚡️ Build success in 104ms
CJS dist/built-in/index.cjs     92.34 KB
CJS dist/index.cjs              111.37 KB
CJS dist/built-in/index.cjs.map 162.24 KB
CJS dist/index.cjs.map          203.37 KB
CJS ⚡️ Build success in 108ms
DTS Build start
DTS ⚡️ Build success in 4084ms
DTS dist/index.d.ts           16.64 KB
DTS dist/built-in/index.d.ts  571.00 B
DTS dist/index-DOGlUVTn.d.ts  12.80 KB
DTS dist/index.d.cts          16.64 KB
DTS dist/built-in/index.d.cts 572.00 B
DTS dist/index-DOGlUVTn.d.cts 12.80 KB

> @pulse-coder/remote-server@0.0.1 build /root/pulse-coder/apps/remote-server
> tsup

CLI Building entry: {"index":"src/index.ts"}
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Using tsup config: /root/pulse-coder/apps/remote-server/tsup.config.ts
CLI Target: es2022
CLI Cleaning output folder
CJS Build start
CJS dist/index.cjs     1.64 MB
CJS dist/index.cjs.map 3.61 MB
CJS ⚡️ Build success in 462ms