### PR TITLE
feat(skills): support loading remote skills from HTTP endpoints

### DIFF
--- a/packages/engine/src/built-in/skills-plugin/index.ts
+++ b/packages/engine/src/built-in/skills-plugin/index.ts
@@ -26,19 +26,19 @@ export interface RemoteSkillsConfig {
 }
 
 export async function loadRemoteSkillsConfig(cwd: string): Promise<RemoteSkillsConfig> {
-  const configPath = path.join(cwd, '.pulse-coder', 'remote-skills.json');
+  const configPath = path.join(cwd, '.pulse-coder', 'skills', 'remote.json');
   if (!existsSync(configPath)) {
     return { endpoints: [] };
   }
   try {
     const parsed = JSON.parse(readFileSync(configPath, 'utf-8'));
     if (!Array.isArray(parsed.endpoints)) {
-      console.warn('[Skills] remote-skills.json missing "endpoints" array');
+      console.warn('[Skills] skills/remote.json missing "endpoints" array');
       return { endpoints: [] };
     }
     return { endpoints: parsed.endpoints };
   } catch (error) {
-    console.warn(`[Skills] Failed to load remote-skills.json: ${error instanceof Error ? error.message : error}`);
+    console.warn(`[Skills] Failed to load skills/remote.json: ${error instanceof Error ? error.message : error}`);
     return { endpoints: [] };
   }
 }


### PR DESCRIPTION
Reads `.pulse-coder/remote-skills.json` at engine init time and fetches
skill metadata (name, description, content) from each configured endpoint.
Remote skills are merged into the skill registry alongside local SKILL.md
files. Single-object and array responses are both supported. Fetch errors
are warned and skipped gracefully.

Config example (.pulse-coder/remote-skills.json):
{
  "endpoints": [
    { "url": "https://example.com/skills" },
    { "url": "https://api.example.com/skills", "headers": { "Authorization": "Bearer <token>" } }
  ]
}

Remote endpoint response format:
[{ "name": "...", "description": "...", "content": "..." }]

https://claude.ai/code/session_013MKx15U4pUeiEhU33hE46U