### PR TITLE
feat: add DeepWiki MCP server integration

### DIFF
--- a/.pulse-coder/mcp.json
+++ b/.pulse-coder/mcp.json
@@ -3,6 +3,10 @@
     "eido_mind": {
       "transport": "http",
       "url": "http://localhost:3060/mcp/server"
+    },
+    "deepwiki": {
+      "transport": "http",
+      "url": "https://mcp.deepwiki.com/mcp"
     }
   }
 }

--- a/apps/remote-server/.pulse-coder/mcp.json
+++ b/apps/remote-server/.pulse-coder/mcp.json
@@ -3,6 +3,10 @@
     "eido_mind": {
       "transport": "http",
       "url": "http://localhost:3060/mcp/server"
+    },
+    "deepwiki": {
+      "transport": "http",
+      "url": "https://mcp.deepwiki.com/mcp"
     }
   }
 }

--- a/packages/cli/.pulse-coder/mcp.json
+++ b/packages/cli/.pulse-coder/mcp.json
@@ -3,6 +3,10 @@
     "eido_mind": {
       "transport": "http",
       "url": "http://localhost:3060/mcp/server"
+    },
+    "deepwiki": {
+      "transport": "http",
+      "url": "https://mcp.deepwiki.com/mcp"
     }
   }
 }


### PR DESCRIPTION
Add DeepWiki MCP (https://mcp.deepwiki.com/mcp) to all mcp.json configs:
- .pulse-coder/mcp.json (root)
- apps/remote-server/.pulse-coder/mcp.json
- packages/cli/.pulse-coder/mcp.json

DeepWiki provides free, no-auth access to public GitHub repo knowledge
via Streamable HTTP transport, enabling ask_question tool for repo Q&A.

https://claude.ai/code/session_01M2qzpeFWFvvaFjoXhFFAb5