### PR TITLE
Add dedicated model config for compact summaries

### DIFF
--- a/apps/remote-server/.env.example
+++ b/apps/remote-server/.env.example
@@ -8,6 +8,8 @@ CONTEXT_WINDOW_TOKENS=128000
 # COMPACT_TRIGGER=96000
 # COMPACT_TARGET=64000
 # KEEP_LAST_TURNS=4
+# Optional: dedicated model for compaction summaries (fallback: OPENAI_MODEL/ANTHROPIC_MODEL)
+# COMPACT_SUMMARY_MODEL=gpt-4o-mini
 
 # === Gemini Pro Image Tool ===
 # Required to enable gemini_pro_image built-in tool

--- a/packages/engine/src/ai/index.ts
+++ b/packages/engine/src/ai/index.ts
@@ -1,5 +1,5 @@
 import { generateText, streamText, tool, type ModelMessage, type StepResult, type Tool } from 'ai';
-import { CoderAI, DEFAULT_MODEL, COMPACT_SUMMARY_MAX_TOKENS, OPENAI_REASONING_EFFORT } from '../config';
+import { CoderAI, DEFAULT_MODEL, COMPACT_SUMMARY_MAX_TOKENS, COMPACT_SUMMARY_MODEL, OPENAI_REASONING_EFFORT } from '../config';
 import z from 'zod';
 import { generateSystemPrompt } from '../prompt';
 import type { Tool as CoderTool, ToolExecutionContext, LLMProviderFactory, SystemPromptOption } from '../shared/types';
@@ -96,7 +96,7 @@ export const summarizeMessages = async (
   options?: { maxOutputTokens?: number; provider?: LLMProviderFactory; model?: string }
 ): Promise<string> => {
   const provider = options?.provider ?? CoderAI;
-  const model = options?.model ?? DEFAULT_MODEL;
+  const model = options?.model ?? COMPACT_SUMMARY_MODEL ?? DEFAULT_MODEL;
   const SUMMARY_SYSTEM_PROMPT =
     '你是负责压缩对话上下文的助手。请基于给定历史消息，提炼关键事实与决策，避免臆测或扩展。';
 

--- a/packages/engine/src/config/index.ts
+++ b/packages/engine/src/config/index.ts
@@ -26,6 +26,7 @@ export const CONTEXT_WINDOW_TOKENS = Number(process.env.CONTEXT_WINDOW_TOKENS ??
 export const COMPACT_TRIGGER = Number(process.env.COMPACT_TRIGGER ?? Math.floor(CONTEXT_WINDOW_TOKENS * 0.75));
 export const COMPACT_TARGET = Number(process.env.COMPACT_TARGET ?? Math.floor(CONTEXT_WINDOW_TOKENS * 0.5));
 export const KEEP_LAST_TURNS = Number(process.env.KEEP_LAST_TURNS ?? 4);
+export const COMPACT_SUMMARY_MODEL = (process.env.COMPACT_SUMMARY_MODEL ?? '').trim();
 export const COMPACT_SUMMARY_MAX_TOKENS = Number(process.env.COMPACT_SUMMARY_MAX_TOKENS ?? 1200);
 export const MAX_COMPACTION_ATTEMPTS = Number(process.env.MAX_COMPACTION_ATTEMPTS ?? 2);
 export const OPENAI_REASONING_EFFORT = process.env.OPENAI_REASONING_EFFORT;


### PR DESCRIPTION
Add support for configuring a dedicated model for context compaction summaries.

- Add `COMPACT_SUMMARY_MODEL` to engine config
- Update `summarizeMessages` fallback order to use compact model first
- Document `COMPACT_SUMMARY_MODEL` in remote-server env example
- Keep default behavior by falling back to existing default model