### PR TITLE
Add memory plugin integration to CLI runtime

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,6 +19,7 @@
   ],
   "dependencies": {
     "pulse-coder-engine": "workspace:*",
+    "pulse-coder-memory-plugin": "workspace:*",
     "pulse-sandbox": "workspace:*"
   },
   "devDependencies": {

--- a/packages/cli/src/memory-integration.ts
+++ b/packages/cli/src/memory-integration.ts
@@ -1,0 +1,69 @@
+import { homedir } from 'os';
+import { join } from 'path';
+import { createMemoryIntegrationFromEnv } from 'pulse-coder-memory-plugin';
+
+const DEFAULT_MEMORY_USER = 'local';
+
+const memoryPlatformKey = resolveMemoryPlatformKey();
+
+export const memoryIntegration = createMemoryIntegrationFromEnv({
+  env: process.env,
+  baseDir: join(homedir(), '.pulse-coder', 'cli-memory'),
+  pluginName: 'cli-memory',
+  pluginVersion: '0.0.1',
+});
+
+interface BuildMemoryRunContextInput {
+  sessionId: string;
+  userText: string;
+}
+
+interface RecordDailyLogInput {
+  sessionId: string;
+  userText: string;
+  assistantText: string;
+}
+
+export function buildMemoryRunContext(input: BuildMemoryRunContextInput) {
+  return {
+    platformKey: memoryPlatformKey,
+    sessionId: input.sessionId,
+    userText: input.userText,
+  };
+}
+
+export async function recordDailyLogFromSuccessPath(input: RecordDailyLogInput): Promise<void> {
+  const userText = input.userText.trim();
+  const assistantText = input.assistantText.trim();
+  if (!userText && !assistantText) {
+    return;
+  }
+
+  try {
+    await memoryIntegration.service.recordTurn({
+      platformKey: memoryPlatformKey,
+      sessionId: input.sessionId,
+      userText,
+      assistantText,
+      sourceType: 'daily-log',
+    });
+  } catch (error) {
+    console.warn(
+      `[memory-plugin] cli daily-log write failed platform=${memoryPlatformKey} session=${input.sessionId}`,
+      error,
+    );
+  }
+}
+
+function resolveMemoryPlatformKey(): string {
+  const fromEnv = process.env.PULSE_CODER_MEMORY_PLATFORM_KEY?.trim();
+  if (fromEnv) {
+    return fromEnv;
+  }
+
+  const user = process.env.PULSE_CODER_MEMORY_USER?.trim()
+    || process.env.USER?.trim()
+    || process.env.LOGNAME?.trim()
+    || DEFAULT_MEMORY_USER;
+  return `cli:${user}`;
+}


### PR DESCRIPTION
Enable memory recall/record support in the CLI by wiring the memory plugin into the agent runtime and session flow.

- Add `pulse-coder-memory-plugin` as a CLI dependency
- Register memory engine plugin in CLI agent initialization
- Initialize memory integration during CLI startup
- Run agent calls with memory run context (platform/session/user text)
- Persist daily-log memories after successful assistant responses
- Add dedicated CLI memory integration module with env-based platform key resolution