### PR TITLE
Fix Discord thread mention replies and context handling

### DIFF
--- a/apps/remote-server/src/adapters/discord/platform-key.ts
+++ b/apps/remote-server/src/adapters/discord/platform-key.ts
@@ -1,0 +1,28 @@
+export const DISCORD_THREAD_CHANNEL_TYPES = new Set<number>([10, 11, 12]);
+
+export function isDiscordThreadChannelType(channelType: number | null | undefined): boolean {
+  if (typeof channelType !== 'number') {
+    return false;
+  }
+
+  return DISCORD_THREAD_CHANNEL_TYPES.has(channelType);
+}
+
+export function buildDiscordPlatformKey(options: {
+  guildId?: string;
+  channelId: string;
+  userId: string;
+  isThread: boolean;
+}): string {
+  const { guildId, channelId, userId, isThread } = options;
+
+  if (!guildId) {
+    return `discord:${userId}`;
+  }
+
+  if (isThread) {
+    return `discord:thread:${channelId}`;
+  }
+
+  return `discord:channel:${channelId}:${userId}`;
+}


### PR DESCRIPTION
Improve Discord thread behavior so mentions in newly created threads are handled reliably.

- Add shared platform key construction with explicit thread-aware keys
- Detect thread messages in gateway using payload thread info with channel-type fallback
- Auto-join threads before typing, sending, editing, and uploading files
- Cache channel type lookups to reduce repeated Discord API metadata requests
- Align adapter and gateway flows to keep consistent thread conversation context