### PR TITLE
Fix Discord thread mentions in newly created threads

### DIFF
--- a/apps/remote-server/src/adapters/discord/client.ts
+++ b/apps/remote-server/src/adapters/discord/client.ts
@@ -29,6 +29,10 @@ interface ChannelTypeCacheEntry {
   expiresAt: number;
 }
 
+interface EnsureThreadMembershipOptions {
+  assumeThread?: boolean;
+}
+
 export class DiscordClient {
   private readonly baseUrl: string;
   private readonly botToken: string;
@@ -83,9 +87,10 @@ export class DiscordClient {
     });
   }
 
-  async ensureThreadMembership(channelId: string): Promise<void> {
-    const channelType = await this.getChannelType(channelId);
-    if (channelType === null || !isDiscordThreadChannelType(channelType)) {
+  async ensureThreadMembership(channelId: string, options: EnsureThreadMembershipOptions = {}): Promise<void> {
+    const assumeThread = options.assumeThread === true;
+    const channelType = assumeThread ? null : await this.getChannelType(channelId);
+    if (!assumeThread && (channelType === null || !isDiscordThreadChannelType(channelType))) {
       return;
     }
 


### PR DESCRIPTION
Ensure the bot can respond to mentions immediately after a Discord thread is created.

- Handle  gateway events and proactively join the new thread
- Add an  option to thread membership checks for creation-time joins
- Keep existing message-based thread detection as a fallback path
- Reduce first-message misses caused by membership timing in fresh threads