### PR TITLE
fix: harden discord thread auto-join reliability

### DIFF
--- a/apps/remote-server/src/adapters/discord/client.ts
+++ b/apps/remote-server/src/adapters/discord/client.ts
@@ -5,6 +5,7 @@ import { isDiscordThreadChannelType } from './platform-key.js';
 const DEFAULT_DISCORD_API_BASE_URL = 'https://discord.com/api/v10';
 const DISCORD_MESSAGE_LIMIT = 2000;
 const CHANNEL_TYPE_CACHE_TTL_MS = 5 * 60 * 1000;
+const TRANSIENT_RETRY_DELAY_MS = 350;
 
 interface DiscordApiError {
   message?: string;
@@ -30,6 +31,12 @@ interface ChannelTypeCacheEntry {
 }
 
 interface EnsureThreadMembershipOptions {
+  assumeThread?: boolean;
+  source?: string;
+  log?: boolean;
+}
+
+interface ChannelRequestOptions {
   assumeThread?: boolean;
 }
 
@@ -89,21 +96,47 @@ export class DiscordClient {
 
   async ensureThreadMembership(channelId: string, options: EnsureThreadMembershipOptions = {}): Promise<void> {
     const assumeThread = options.assumeThread === true;
+    const source = options.source?.trim() || 'unknown';
+    const shouldLog = options.log === true;
     const channelType = assumeThread ? null : await this.getChannelType(channelId);
-    if (!assumeThread && (channelType === null || !isDiscordThreadChannelType(channelType))) {
+    const isThread = assumeThread || (channelType !== null && isDiscordThreadChannelType(channelType));
+
+    if (shouldLog) {
+      console.log(
+        `[discord] ensureThreadMembership channel=${channelId} source=${source} assumeThread=${assumeThread} isThread=${isThread}`,
+      );
+    }
+
+    if (!isThread) {
       return;
     }
 
     if (this.joinedThreadIds.has(channelId)) {
+      if (shouldLog) {
+        console.log(`[discord] Thread already joined channel=${channelId} source=${source}`);
+      }
       return;
     }
 
     try {
-      await this.joinThread(channelId);
+      await this.retryOnceOnTransient('join_thread', () => this.joinThread(channelId));
       this.joinedThreadIds.add(channelId);
+      if (shouldLog) {
+        console.log(`[discord] Joined thread channel=${channelId} source=${source}`);
+      }
     } catch (err) {
-      console.warn(`[discord] Failed to join thread ${channelId}:`, err);
+      console.warn(
+        `[discord] Failed to join thread ${channelId} source=${source} assumeThread=${assumeThread} err=${this.describeError(err)}`,
+      );
     }
+  }
+
+  markThreadJoined(channelId: string): void {
+    if (!channelId) {
+      return;
+    }
+
+    this.joinedThreadIds.add(channelId);
   }
 
   async getChannelType(channelId: string): Promise<number | null> {
@@ -117,7 +150,7 @@ export class DiscordClient {
     }
 
     try {
-      const channel = await this.getChannel(channelId);
+      const channel = await this.retryOnceOnTransient('get_channel_type', () => this.getChannel(channelId));
       const type = typeof channel.type === 'number' ? channel.type : null;
       this.channelTypeCache.set(channelId, {
         type,
@@ -154,46 +187,70 @@ export class DiscordClient {
     );
   }
 
-  async sendChannelMessage(channelId: string, content: string): Promise<DiscordMessageResponse> {
+  async sendChannelMessage(
+    channelId: string,
+    content: string,
+    options: ChannelRequestOptions = {},
+  ): Promise<DiscordMessageResponse> {
     this.ensureBotToken();
-    await this.ensureThreadMembership(channelId);
+    await this.ensureThreadMembership(channelId, {
+      assumeThread: options.assumeThread,
+      source: 'send_channel_message',
+    });
 
-    return this.request<DiscordMessageResponse>(
-      `/channels/${encodeURIComponent(channelId)}/messages`,
-      {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ content: limitDiscordContent(content) }),
-      },
-      true,
+    return this.retryOnceOnTransient('send_channel_message', () =>
+      this.request<DiscordMessageResponse>(
+        `/channels/${encodeURIComponent(channelId)}/messages`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ content: limitDiscordContent(content) }),
+        },
+        true,
+      ),
     );
   }
 
-  async triggerTypingIndicator(channelId: string): Promise<void> {
+  async triggerTypingIndicator(channelId: string, options: ChannelRequestOptions = {}): Promise<void> {
     this.ensureBotToken();
-    await this.ensureThreadMembership(channelId);
+    await this.ensureThreadMembership(channelId, {
+      assumeThread: options.assumeThread,
+      source: 'trigger_typing',
+    });
 
-    await this.request<void>(
-      `/channels/${encodeURIComponent(channelId)}/typing`,
-      {
-        method: 'POST',
-      },
-      true,
+    await this.retryOnceOnTransient('trigger_typing', () =>
+      this.request<void>(
+        `/channels/${encodeURIComponent(channelId)}/typing`,
+        {
+          method: 'POST',
+        },
+        true,
+      ),
     );
   }
 
-  async editChannelMessage(channelId: string, messageId: string, content: string): Promise<void> {
+  async editChannelMessage(
+    channelId: string,
+    messageId: string,
+    content: string,
+    options: ChannelRequestOptions = {},
+  ): Promise<void> {
     this.ensureBotToken();
-    await this.ensureThreadMembership(channelId);
+    await this.ensureThreadMembership(channelId, {
+      assumeThread: options.assumeThread,
+      source: 'edit_channel_message',
+    });
 
-    await this.request<void>(
-      `/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(messageId)}`,
-      {
-        method: 'PATCH',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ content: limitDiscordContent(content) }),
-      },
-      true,
+    await this.retryOnceOnTransient('edit_channel_message', () =>
+      this.request<void>(
+        `/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(messageId)}`,
+        {
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ content: limitDiscordContent(content) }),
+        },
+        true,
+      ),
     );
   }
 
@@ -203,28 +260,35 @@ export class DiscordClient {
     fileName: string,
     mimeType = 'application/octet-stream',
     content?: string,
+    options: ChannelRequestOptions = {},
   ): Promise<void> {
     this.ensureBotToken();
-    await this.ensureThreadMembership(channelId);
+    await this.ensureThreadMembership(channelId, {
+      assumeThread: options.assumeThread,
+      source: 'send_channel_file',
+    });
 
     const fileBuffer = await readFile(filePath);
-    const payload = {
-      content: content ? limitDiscordContent(content) : undefined,
-      attachments: [{ id: 0, filename: fileName }],
-    };
 
-    const formData = new FormData();
-    formData.append('payload_json', JSON.stringify(payload));
-    formData.append('files[0]', new Blob([fileBuffer], { type: mimeType }), fileName);
+    await this.retryOnceOnTransient('send_channel_file', async () => {
+      const payload = {
+        content: content ? limitDiscordContent(content) : undefined,
+        attachments: [{ id: 0, filename: fileName }],
+      };
 
-    await this.request<void>(
-      `/channels/${encodeURIComponent(channelId)}/messages`,
-      {
-        method: 'POST',
-        body: formData,
-      },
-      true,
-    );
+      const formData = new FormData();
+      formData.append('payload_json', JSON.stringify(payload));
+      formData.append('files[0]', new Blob([fileBuffer], { type: mimeType }), fileName);
+
+      await this.request<void>(
+        `/channels/${encodeURIComponent(channelId)}/messages`,
+        {
+          method: 'POST',
+          body: formData,
+        },
+        true,
+      );
+    });
   }
 
   private async request<T>(path: string, init: RequestInit, useBotAuthorization = false): Promise<T> {
@@ -263,6 +327,70 @@ export class DiscordClient {
     return (payload.data as T) ?? (payload as unknown as T);
   }
 
+  private async retryOnceOnTransient<T>(operation: string, run: () => Promise<T>): Promise<T> {
+    try {
+      return await run();
+    } catch (err) {
+      if (!this.isTransientNetworkError(err)) {
+        throw err;
+      }
+
+      console.warn(`[discord] Retrying transient request op=${operation} err=${this.describeError(err)}`);
+      await wait(TRANSIENT_RETRY_DELAY_MS);
+      return run();
+    }
+  }
+
+  private isTransientNetworkError(err: unknown): boolean {
+    if (!(err instanceof Error)) {
+      return false;
+    }
+
+    const code = this.getErrorCode(err);
+    if (
+      code === 'ECONNRESET'
+      || code === 'ETIMEDOUT'
+      || code === 'UND_ERR_CONNECT_TIMEOUT'
+      || code === 'UND_ERR_SOCKET'
+    ) {
+      return true;
+    }
+
+    const message = err.message.toLowerCase();
+    return (
+      message.includes('fetch failed')
+      || message.includes('timeout')
+      || message.includes('network')
+      || message.includes('socket')
+      || message.includes('discord api request failed (502')
+      || message.includes('discord api request failed (503')
+      || message.includes('discord api request failed (504')
+    );
+  }
+
+  private describeError(err: unknown): string {
+    if (!(err instanceof Error)) {
+      return String(err);
+    }
+
+    const code = this.getErrorCode(err);
+    return code ? `${code} ${err.message}` : err.message;
+  }
+
+  private getErrorCode(err: Error): string {
+    const directCode = (err as Error & { code?: unknown }).code;
+    if (typeof directCode === 'string') {
+      return directCode;
+    }
+
+    const cause = (err as Error & { cause?: { code?: unknown } }).cause;
+    if (typeof cause?.code === 'string') {
+      return cause.code;
+    }
+
+    return '';
+  }
+
   private ensureBotToken(): void {
     if (!this.botToken) {
       throw new Error('DISCORD_BOT_TOKEN is required for Discord DM mode');
@@ -277,4 +405,10 @@ function limitDiscordContent(text: string): string {
   }
 
   return `${normalized.slice(0, DISCORD_MESSAGE_LIMIT - 3)}...`;
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
 }


### PR DESCRIPTION
- auto-join on THREAD_CREATE when member payload missing and log hasMember state

- propagate thread context through stream send/edit/typing/file paths

- retry transient discord network failures for thread-aware requests including join