### PR TITLE
Make Discord guild mention requirement configurable

### DIFF
--- a/apps/remote-server/.env.example
+++ b/apps/remote-server/.env.example
@@ -61,6 +61,8 @@ DISCORD_GATEWAY_URL=
 DISCORD_PROXY_URL=
 # Set false/0/off/no to disable Discord Gateway listener (DM + guild @mention)
 DISCORD_DM_GATEWAY_ENABLED=true
+# Set false/0/off/no to allow plain text in guild channels without @mention
+DISCORD_GUILD_REQUIRE_MENTION=true
 
 # === Telegram ===
 TELEGRAM_BOT_TOKEN=

--- a/apps/remote-server/README.md
+++ b/apps/remote-server/README.md
@@ -44,9 +44,13 @@ DISCORD_BOT_TOKEN=your_discord_bot_token
 
 ### 3) Guild usage (no HTTPS required)
 
-- Mention the bot in a guild channel, then type your prompt.
+- Default behavior: mention the bot in a guild channel, then type your prompt.
 - Example: `@YourBot explain this stack trace`
-- Plain text without mentioning the bot is ignored in guild channels.
+- To allow plain text without mention in guild channels, set:
+
+```bash
+DISCORD_GUILD_REQUIRE_MENTION=false
+```
 
 ### 4) Slash commands (optional, requires HTTPS interactions endpoint)
 


### PR DESCRIPTION
Add a config toggle for Discord guild mention handling.

- Add  env flag in gateway logic
- Keep current behavior as default () to avoid breaking existing setups
- Update  with the new flag and usage note
- Update README guild usage section with no-mention configuration