### PR TITLE
Fix Discord gateway replies to quote user messages

### DIFF
--- a/apps/remote-server/src/adapters/discord/adapter.ts
+++ b/apps/remote-server/src/adapters/discord/adapter.ts
@@ -46,6 +46,7 @@ interface DiscordChannelStreamMeta {
   kind: 'channel';
   channelId: string;
   isThread: boolean;
+  replyToMessageId?: string;
 }
 
 type DiscordStreamMeta = DiscordInteractionStreamMeta | DiscordChannelStreamMeta;
@@ -177,11 +178,18 @@ export class DiscordAdapter implements PlatformAdapter {
     return c.json(payload, 200);
   }
 
-  registerChannelStreamMeta(platformKey: string, streamId: string, channelId: string, isThread = false): void {
+  registerChannelStreamMeta(
+    platformKey: string,
+    streamId: string,
+    channelId: string,
+    isThread = false,
+    replyToMessageId?: string,
+  ): void {
     const streamMeta: DiscordChannelStreamMeta = {
       kind: 'channel',
       channelId,
       isThread,
+      replyToMessageId,
     };
 
     this.streamMetaByStreamId.set(streamId, streamMeta);
@@ -246,6 +254,7 @@ export class DiscordAdapter implements PlatformAdapter {
   private async createChannelStreamHandle(meta: DiscordChannelStreamMeta): Promise<StreamHandle> {
     const initial = await this.client.sendChannelMessage(meta.channelId, 'Working on it...', {
       assumeThread: meta.isThread,
+      replyToMessageId: meta.replyToMessageId,
     });
 
     return this.createStreamingHandle({

--- a/apps/remote-server/src/adapters/discord/client.ts
+++ b/apps/remote-server/src/adapters/discord/client.ts
@@ -38,6 +38,7 @@ interface EnsureThreadMembershipOptions {
 
 interface ChannelRequestOptions {
   assumeThread?: boolean;
+  replyToMessageId?: string;
 }
 
 export class DiscordClient {
@@ -204,7 +205,7 @@ export class DiscordClient {
         {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ content: limitDiscordContent(content) }),
+          body: JSON.stringify(buildChannelMessagePayload(content, options.replyToMessageId)),
         },
         true,
       ),
@@ -405,6 +406,25 @@ function limitDiscordContent(text: string): string {
   }
 
   return `${normalized.slice(0, DISCORD_MESSAGE_LIMIT - 3)}...`;
+}
+
+function buildChannelMessagePayload(content: string, replyToMessageId?: string): { content: string; message_reference?: { message_id: string; fail_if_not_exists: boolean } } {
+  const payload: {
+    content: string;
+    message_reference?: { message_id: string; fail_if_not_exists: boolean };
+  } = {
+    content: limitDiscordContent(content),
+  };
+
+  const trimmedReplyId = replyToMessageId?.trim();
+  if (trimmedReplyId) {
+    payload.message_reference = {
+      message_id: trimmedReplyId,
+      fail_if_not_exists: false,
+    };
+  }
+
+  return payload;
 }
 
 function wait(ms: number): Promise<void> {

--- a/apps/remote-server/src/adapters/discord/gateway.ts
+++ b/apps/remote-server/src/adapters/discord/gateway.ts
@@ -310,13 +310,15 @@ export class DiscordDmGateway {
       console.error('[discord-gateway] Failed to send typing indicator:', err);
     });
 
+    const replyToMessageId = messageId;
+
     const incoming: IncomingMessage = {
       platformKey,
       text: normalizedText,
       streamId: messageId,
     };
 
-    discordAdapter.registerChannelStreamMeta(platformKey, messageId, channelId, resolvedIsThread);
+    discordAdapter.registerChannelStreamMeta(platformKey, messageId, channelId, resolvedIsThread, replyToMessageId);
     dispatchIncoming(discordAdapter, incoming);
   }
 


### PR DESCRIPTION
Enable quote-style replies for Discord gateway message handling.

- Add  to Discord channel stream metadata
- Pass incoming message id from gateway to stream registration
- Include  when sending the initial channel response
- Keep follow-up behavior unchanged (editing same primary response)