### PR TITLE
Unify Discord memory key across DM and guild

### DIFF
--- a/apps/remote-server/src/adapters/discord/adapter.ts
+++ b/apps/remote-server/src/adapters/discord/adapter.ts
@@ -8,7 +8,7 @@ import { clarificationQueue } from '../../core/clarification-queue.js';
 import { getActiveStreamId } from '../../core/active-run-store.js';
 import { extractGeminiImageResult } from '../feishu/image-result.js';
 import { DiscordClient } from './client.js';
-import { buildDiscordPlatformKey, isDiscordThreadChannelType } from './platform-key.js';
+import { buildDiscordMemoryKey, buildDiscordPlatformKey, isDiscordThreadChannelType } from './platform-key.js';
 
 interface DiscordInteraction {
   id: string;
@@ -146,6 +146,7 @@ export class DiscordAdapter implements PlatformAdapter {
       userId,
       isThread,
     });
+    const memoryKey = buildDiscordMemoryKey(userId);
 
     const activeStreamId = getActiveStreamId(platformKey);
     if (activeStreamId && clarificationQueue.hasPending(activeStreamId)) {
@@ -168,7 +169,7 @@ export class DiscordAdapter implements PlatformAdapter {
     this.streamMetaByPlatformKey.set(platformKey, streamMeta);
     this.ackByRequest.set(req, { type: 5 });
 
-    return { platformKey, text, streamId };
+    return { platformKey, memoryKey, text, streamId };
   }
 
   ackRequest(c: HonoContext, incoming: IncomingMessage | null): Response {

--- a/apps/remote-server/src/adapters/discord/gateway.ts
+++ b/apps/remote-server/src/adapters/discord/gateway.ts
@@ -3,7 +3,7 @@ import type { IncomingMessage } from '../../core/types.js';
 import { discordAdapter } from './adapter.js';
 import { DiscordClient } from './client.js';
 import { getDiscordProxyDispatcher } from './proxy.js';
-import { buildDiscordPlatformKey, isDiscordThreadChannelType } from './platform-key.js';
+import { buildDiscordMemoryKey, buildDiscordPlatformKey, isDiscordThreadChannelType } from './platform-key.js';
 
 interface GatewayPayload {
   op: number;
@@ -281,6 +281,7 @@ export class DiscordDmGateway {
       userId,
       isThread: resolvedIsThread,
     });
+    const memoryKey = buildDiscordMemoryKey(userId);
 
     const clarificationText = normalizeGatewayText(stripSelfMention(rawContent, this.selfUserId));
     if (clarificationText) {
@@ -314,6 +315,7 @@ export class DiscordDmGateway {
 
     const incoming: IncomingMessage = {
       platformKey,
+      memoryKey,
       text: normalizedText,
       streamId: messageId,
     };

--- a/apps/remote-server/src/adapters/discord/platform-key.ts
+++ b/apps/remote-server/src/adapters/discord/platform-key.ts
@@ -26,3 +26,7 @@ export function buildDiscordPlatformKey(options: {
 
   return `discord:channel:${channelId}:${userId}`;
 }
+
+export function buildDiscordMemoryKey(userId: string): string {
+  return `discord:user:${userId}`;
+}

--- a/apps/remote-server/src/core/dispatcher.ts
+++ b/apps/remote-server/src/core/dispatcher.ts
@@ -74,6 +74,7 @@ export function dispatchIncoming(adapter: PlatformAdapter, incoming: IncomingMes
 
 async function runAgentAsync(adapter: PlatformAdapter, incoming: IncomingMessage): Promise<void> {
   const { platformKey, forceNewSession } = incoming;
+  const memoryKey = incoming.memoryKey ?? platformKey;
   let text = incoming.text;
 
   // Start streaming feedback early for long-running slash commands (for better UX on Feishu/Telegram)
@@ -151,7 +152,7 @@ async function runAgentAsync(adapter: PlatformAdapter, incoming: IncomingMessage
 
     const finalText = await memoryIntegration.withRunContext(
       {
-        platformKey,
+        platformKey: memoryKey,
         sessionId,
         userText: text,
       },
@@ -208,7 +209,7 @@ async function runAgentAsync(adapter: PlatformAdapter, incoming: IncomingMessage
 
     await sessionStore.save(sessionId, context);
     await recordDailyLogFromSuccessPath({
-      platformKey,
+      platformKey: memoryKey,
       sessionId,
       userText: text,
       assistantText: finalText,

--- a/apps/remote-server/src/core/types.ts
+++ b/apps/remote-server/src/core/types.ts
@@ -10,6 +10,11 @@ export type { Context, ClarificationRequest };
 export interface IncomingMessage {
   /** "feishu:ou_abc123" | "telegram:987654" | "web:user-xyz" */
   platformKey: string;
+  /**
+   * Optional memory identity key. If omitted, platformKey is used.
+   * This lets adapters share long-term memory without merging runtime session/concurrency scopes.
+   */
+  memoryKey?: string;
   /** The user's text input */
   text: string;
   /** True when the platform payload explicitly requests a fresh session */


### PR DESCRIPTION
Route Discord memory operations through a user-scoped key while preserving existing session and concurrency isolation.

- Add optional IncomingMessage.memoryKey and fallback to platformKey.
- Introduce buildDiscordMemoryKey(userId) => discord:user:<userId>.
- Populate memoryKey in Discord interaction and gateway adapters.
- Use memoryKey in dispatcher memory run context and daily-log writes.
- Update /memory commands to operate on memoryKey.