### PR TITLE
Unify Feishu memory key across chats

### DIFF
--- a/apps/remote-server/src/adapters/feishu/adapter.ts
+++ b/apps/remote-server/src/adapters/feishu/adapter.ts
@@ -104,6 +104,7 @@ export class FeishuAdapter implements PlatformAdapter {
     const platformKey = chatType === 'group' && chatId
       ? `feishu:group:${chatId}:${openId}`
       : `feishu:${openId}`;
+    const memoryKey = `feishu:user:${openId}`;
 
     if (messageId) {
       // Best-effort acknowledgement reaction for accepted user messages.
@@ -131,7 +132,7 @@ export class FeishuAdapter implements PlatformAdapter {
       return null;
     }
 
-    return { platformKey, text };
+    return { platformKey, memoryKey, text };
   }
 
   // URL verification challenge to return in ackRequest


### PR DESCRIPTION
Route Feishu memory operations through a user-scoped key while preserving existing chat/session isolation behavior.

- Add memoryKey in Feishu adapter as feishu:user:<openId>.
- Keep platformKey unchanged for runtime session and concurrency isolation.
- Return { platformKey, memoryKey, text } from Feishu incoming parsing.