### PR TITLE
feat: Add compaction hook and daily-log memory capture

### DIFF
--- a/packages/engine/src/Engine.ts
+++ b/packages/engine/src/Engine.ts
@@ -194,6 +194,7 @@ export class Engine {
       afterLLMCall: this.pluginManager.getHooks('afterLLMCall'),
       beforeToolCall: [...this.pluginManager.getHooks('beforeToolCall')],
       afterToolCall: [...this.pluginManager.getHooks('afterToolCall')],
+      onCompacted: this.pluginManager.getHooks('onCompacted'),
     };
 
     // Convert legacy EngineOptions.hooks (ToolHooks) to hook entries

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -17,6 +17,8 @@ export type {
   BeforeToolCallResult,
   AfterToolCallInput,
   AfterToolCallResult,
+  OnCompactedEvent,
+  OnCompactedInput,
 } from './plugin/EnginePlugin.js';
 export type { UserConfigPlugin, UserConfigPluginLoadOptions } from './plugin/UserConfigPlugin.js';
 export { PluginManager } from './plugin/PluginManager.js';

--- a/packages/engine/src/plugin/PluginManager.ts
+++ b/packages/engine/src/plugin/PluginManager.ts
@@ -27,6 +27,7 @@ export class PluginManager {
     afterLLMCall: [],
     beforeToolCall: [],
     afterToolCall: [],
+    onCompacted: [],
   };
   private services = new Map<string, any>();
   private config = new Map<string, any>();

--- a/packages/engine/src/plugin/plugin-manager.test.ts
+++ b/packages/engine/src/plugin/plugin-manager.test.ts
@@ -56,6 +56,8 @@ describe('PluginManager', () => {
     expect(status.enginePlugins).toEqual(['alpha', 'beta']);
     expect(status.tools).toContain('alphaTool');
     expect(status.services).toContain('alphaService');
+    expect(status.hooks.beforeRun).toBe(1);
+    expect(status.hooks.onCompacted).toBe(0);
   });
 
   it('throws when dependency is missing', async () => {

--- a/packages/memory-plugin/src/types.ts
+++ b/packages/memory-plugin/src/types.ts
@@ -14,6 +14,16 @@ export interface MemoryDailyLogPolicy {
   maxPerDay: number;
 }
 
+export type MemoryCompactionExtractor = 'rule';
+
+export interface MemoryCompactionWritePolicy {
+  enabled: boolean;
+  minTokenDelta: number;
+  minRemovedMessages: number;
+  maxPerRun: number;
+  extractor: MemoryCompactionExtractor;
+}
+
 export interface MemorySourceRef {
   path: string;
   offset: number;
@@ -103,4 +113,5 @@ export interface FileMemoryServiceOptions {
   embeddingDimensions?: number;
   embeddingProvider?: EmbeddingProvider;
   dailyLogPolicy?: Partial<MemoryDailyLogPolicy>;
+  compactionWritePolicy?: Partial<MemoryCompactionWritePolicy>;
 }

--- a/packages/memory-plugin/src/write-env.ts
+++ b/packages/memory-plugin/src/write-env.ts
@@ -21,7 +21,7 @@ const DEFAULT_DAILY_LOG_POLICY: MemoryDailyLogPolicy = {
 };
 
 const DEFAULT_COMPACTION_WRITE_POLICY: MemoryCompactionWritePolicy = {
-  enabled: false,
+  enabled: true,
   minTokenDelta: 8000,
   minRemovedMessages: 4,
   maxPerRun: 1,

--- a/packages/memory-plugin/src/write-env.ts
+++ b/packages/memory-plugin/src/write-env.ts
@@ -1,4 +1,4 @@
-import type { MemoryDailyLogMode, MemoryDailyLogPolicy } from './types.js';
+import type { MemoryCompactionExtractor, MemoryCompactionWritePolicy, MemoryDailyLogMode, MemoryDailyLogPolicy } from './types.js';
 import {
   clamp,
   clampInteger,
@@ -9,6 +9,7 @@ import {
 
 export interface MemoryWriteRuntimeConfig {
   dailyLogPolicy: MemoryDailyLogPolicy;
+  compactionWritePolicy: MemoryCompactionWritePolicy;
 }
 
 const DEFAULT_DAILY_LOG_POLICY: MemoryDailyLogPolicy = {
@@ -17,6 +18,14 @@ const DEFAULT_DAILY_LOG_POLICY: MemoryDailyLogPolicy = {
   minConfidence: 0.65,
   maxPerTurn: 3,
   maxPerDay: 30,
+};
+
+const DEFAULT_COMPACTION_WRITE_POLICY: MemoryCompactionWritePolicy = {
+  enabled: false,
+  minTokenDelta: 8000,
+  minRemovedMessages: 4,
+  maxPerRun: 1,
+  extractor: 'rule',
 };
 
 export function resolveMemoryWriteRuntimeConfigFromEnv(
@@ -40,6 +49,30 @@ export function resolveMemoryWriteRuntimeConfigFromEnv(
     200,
   );
 
+  const compactionEnabled = parseBooleanEnv(
+    env.MEMORY_COMPACTION_WRITE_ENABLED,
+    DEFAULT_COMPACTION_WRITE_POLICY.enabled,
+  );
+  const compactionMinTokenDelta = clampInteger(
+    parseIntegerEnv(env.MEMORY_COMPACTION_MIN_TOKEN_DELTA) ?? DEFAULT_COMPACTION_WRITE_POLICY.minTokenDelta,
+    1,
+    200000,
+  );
+  const compactionMinRemovedMessages = clampInteger(
+    parseIntegerEnv(env.MEMORY_COMPACTION_MIN_REMOVED_MESSAGES) ?? DEFAULT_COMPACTION_WRITE_POLICY.minRemovedMessages,
+    1,
+    200,
+  );
+  const compactionMaxPerRun = clampInteger(
+    parseIntegerEnv(env.MEMORY_COMPACTION_MAX_PER_RUN) ?? DEFAULT_COMPACTION_WRITE_POLICY.maxPerRun,
+    1,
+    10,
+  );
+  const compactionExtractor = parseCompactionExtractor(
+    env.MEMORY_COMPACTION_EXTRACTOR,
+    DEFAULT_COMPACTION_WRITE_POLICY.extractor,
+  );
+
   return {
     dailyLogPolicy: {
       enabled,
@@ -47,6 +80,13 @@ export function resolveMemoryWriteRuntimeConfigFromEnv(
       minConfidence,
       maxPerTurn,
       maxPerDay,
+    },
+    compactionWritePolicy: {
+      enabled: compactionEnabled,
+      minTokenDelta: compactionMinTokenDelta,
+      minRemovedMessages: compactionMinRemovedMessages,
+      maxPerRun: compactionMaxPerRun,
+      extractor: compactionExtractor,
     },
   };
 }
@@ -58,6 +98,17 @@ function parseDailyLogMode(raw: string | undefined, fallback: MemoryDailyLogMode
   }
   if (normalized === 'write') {
     return 'write';
+  }
+  return fallback;
+}
+
+function parseCompactionExtractor(
+  raw: string | undefined,
+  fallback: MemoryCompactionExtractor,
+): MemoryCompactionExtractor {
+  const normalized = raw?.trim().toLowerCase();
+  if (normalized === 'rule') {
+    return 'rule';
   }
   return fallback;
 }


### PR DESCRIPTION
Add compaction-aware memory capture from engine to memory-plugin.

- Add engine-level `onCompacted` hook and expose it in plugin APIs
- Emit compaction events with previous/new messages and token stats
- Wire `onCompacted` through loop hook collection and plugin manager
- Add memory-plugin compaction write policy with env-based config
- Capture compacted context into `daily-log` writes with per-run limits
- Add tests for hook plumbing, plugin manager status, and compaction writes