### PR TITLE
Add session fork command for Discord and Feishu

### DIFF
--- a/apps/remote-server/generated/agentic-summary-page-v2/index.html
+++ b/apps/remote-server/generated/agentic-summary-page-v2/index.html
@@ -1,0 +1,435 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>第三时代：AI 软件工厂编排</title>
+  <meta name="description" content="Karpathy 与 Michael Truell 观点可视化：AI 软件开发从手工编码走向 Agentic Engineering。">
+  <meta property="og:title" content="第三时代：AI 软件工厂编排">
+  <meta property="og:description" content="抽象层上移，但细节责任仍在人类：目标、约束、边界、验收。">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="michael-truell-third-era-summary-zh.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <style>
+    :root {
+      --ink: #f7f3e9;
+      --ink-dim: #d5d9df;
+      --line: rgba(255, 255, 255, 0.18);
+      --panel: rgba(7, 17, 28, 0.76);
+      --accent-a: #f7ad4f;
+      --accent-b: #5fd7ff;
+      --accent-c: #9af5b9;
+      --bg-a: #081525;
+      --bg-b: #122a43;
+      --bg-c: #30243f;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      color: var(--ink);
+      font-family: "Songti SC", "Noto Serif SC", serif;
+      background:
+        radial-gradient(1100px 500px at 88% 0%, rgba(247, 173, 79, 0.22), transparent 58%),
+        radial-gradient(900px 480px at 8% 14%, rgba(95, 215, 255, 0.18), transparent 60%),
+        linear-gradient(132deg, var(--bg-a), var(--bg-b) 48%, var(--bg-c));
+      min-height: 100vh;
+      overflow-x: hidden;
+    }
+
+    .grain {
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      opacity: 0.2;
+      background-image:
+        linear-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px);
+      background-size: 26px 26px;
+      mask-image: radial-gradient(circle at center, black 40%, transparent 100%);
+    }
+
+    .wrap {
+      width: min(1180px, 93vw);
+      margin: 0 auto;
+      padding: 28px 0 56px;
+    }
+
+    .hero {
+      position: relative;
+      border: 1px solid var(--line);
+      border-radius: 26px;
+      background: linear-gradient(145deg, rgba(4, 14, 25, 0.92), rgba(20, 37, 58, 0.84));
+      padding: 34px 30px;
+      box-shadow: 0 26px 52px rgba(0, 0, 0, 0.33);
+      overflow: hidden;
+      animation: inUp 0.8s ease both;
+    }
+
+    .hero::before {
+      content: "";
+      position: absolute;
+      width: 320px;
+      height: 320px;
+      right: -80px;
+      top: -90px;
+      border-radius: 50%;
+      background: radial-gradient(circle, rgba(247, 173, 79, 0.38), transparent 64%);
+      filter: blur(5px);
+    }
+
+    .kicker {
+      margin: 0 0 10px;
+      font-family: "PingFang SC", "Noto Sans SC", sans-serif;
+      letter-spacing: 0.14em;
+      font-size: 12px;
+      color: var(--accent-b);
+      text-transform: uppercase;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(30px, 5.5vw, 64px);
+      line-height: 1.05;
+      letter-spacing: 0.01em;
+      max-width: 13ch;
+      text-wrap: balance;
+    }
+
+    .subtitle {
+      margin: 14px 0 0;
+      color: #ffe0bd;
+      font-size: clamp(17px, 2.4vw, 25px);
+      font-family: "Kaiti SC", "STKaiti", serif;
+    }
+
+    .deck {
+      margin-top: 14px;
+      max-width: 72ch;
+      font-size: 16px;
+      line-height: 1.78;
+      color: var(--ink-dim);
+      font-family: "PingFang SC", "Noto Sans SC", sans-serif;
+    }
+
+    .banner {
+      margin-top: 18px;
+      padding: 12px 14px;
+      border-left: 4px solid var(--accent-a);
+      background: rgba(247, 173, 79, 0.1);
+      border-radius: 8px;
+      font-family: "PingFang SC", "Noto Sans SC", sans-serif;
+      color: #ffebcf;
+      font-weight: 600;
+    }
+
+    .layout {
+      margin-top: 22px;
+      display: grid;
+      grid-template-columns: 1.18fr .82fr;
+      gap: 16px;
+      align-items: start;
+    }
+
+    .panel {
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      background: var(--panel);
+      box-shadow: 0 14px 28px rgba(0, 0, 0, 0.24);
+    }
+
+    .main {
+      padding: 18px;
+      animation: inUp 0.9s ease both;
+      animation-delay: 0.08s;
+    }
+
+    .side {
+      padding: 16px;
+      animation: inUp 1s ease both;
+      animation-delay: 0.14s;
+    }
+
+    h2 {
+      margin: 0;
+      font-size: 24px;
+    }
+
+    .muted {
+      margin: 6px 0 0;
+      color: var(--ink-dim);
+      font-family: "PingFang SC", "Noto Sans SC", sans-serif;
+      font-size: 13px;
+      letter-spacing: 0.01em;
+    }
+
+    .era-grid {
+      margin-top: 14px;
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 10px;
+    }
+
+    .era {
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      background: rgba(255, 255, 255, 0.03);
+      padding: 12px;
+      min-height: 166px;
+      transform: translateY(6px);
+      opacity: 0;
+      animation: cardIn 0.8s ease forwards;
+    }
+
+    .era:nth-child(1) { animation-delay: 0.2s; }
+    .era:nth-child(2) { animation-delay: 0.32s; }
+    .era:nth-child(3) { animation-delay: 0.44s; }
+
+    .tag {
+      display: inline-block;
+      padding: 3px 8px;
+      border-radius: 999px;
+      font-size: 11px;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      font-family: "PingFang SC", "Noto Sans SC", sans-serif;
+      border: 1px solid rgba(255,255,255,0.24);
+    }
+
+    .era h3 {
+      margin: 10px 0 4px;
+      font-size: 18px;
+    }
+
+    .era p {
+      margin: 0;
+      font-size: 14px;
+      line-height: 1.65;
+      color: #e0ebf5;
+      font-family: "PingFang SC", "Noto Sans SC", sans-serif;
+    }
+
+    .metrics {
+      margin-top: 14px;
+      display: grid;
+      gap: 9px;
+    }
+
+    .metric {
+      border: 1px dashed rgba(255, 255, 255, 0.24);
+      border-radius: 10px;
+      padding: 10px;
+      background: rgba(255, 255, 255, 0.02);
+      font-family: "PingFang SC", "Noto Sans SC", sans-serif;
+    }
+
+    .metric b {
+      color: var(--accent-c);
+      font-size: 20px;
+      margin-right: 5px;
+    }
+
+    .flow {
+      margin-top: 14px;
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 8px;
+    }
+
+    .node {
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      padding: 9px;
+      text-align: center;
+      font-size: 13px;
+      line-height: 1.35;
+      font-family: "PingFang SC", "Noto Sans SC", sans-serif;
+      background: rgba(255, 255, 255, 0.035);
+    }
+
+    .node b {
+      display: block;
+      color: #ffe3ba;
+      margin-bottom: 2px;
+      font-size: 12px;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    .split {
+      margin-top: 12px;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 8px;
+    }
+
+    .mini {
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      padding: 10px;
+      background: rgba(255, 255, 255, 0.03);
+    }
+
+    .mini h4 {
+      margin: 0;
+      font-size: 15px;
+    }
+
+    .mini ul {
+      margin: 7px 0 0;
+      padding-left: 1.15em;
+      font-family: "PingFang SC", "Noto Sans SC", sans-serif;
+      color: #e4edf6;
+      font-size: 13px;
+      line-height: 1.6;
+    }
+
+    .gallery {
+      margin-top: 16px;
+      display: grid;
+      gap: 10px;
+    }
+
+    figure {
+      margin: 0;
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      overflow: hidden;
+      background: rgba(5, 11, 20, 0.76);
+    }
+
+    img {
+      width: 100%;
+      display: block;
+      height: auto;
+    }
+
+    figcaption {
+      padding: 8px 10px;
+      color: var(--ink-dim);
+      font-size: 12px;
+      font-family: "PingFang SC", "Noto Sans SC", sans-serif;
+    }
+
+    .tail {
+      margin-top: 12px;
+      text-align: center;
+      color: var(--ink-dim);
+      font-size: 12px;
+      font-family: "PingFang SC", "Noto Sans SC", sans-serif;
+      letter-spacing: 0.02em;
+    }
+
+    @keyframes inUp {
+      from { opacity: 0; transform: translateY(10px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    @keyframes cardIn {
+      from { opacity: 0; transform: translateY(8px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    @media (max-width: 980px) {
+      .layout { grid-template-columns: 1fr; }
+      .era-grid { grid-template-columns: 1fr; }
+      .flow { grid-template-columns: 1fr 1fr; }
+      .split { grid-template-columns: 1fr; }
+      h1 { max-width: none; }
+    }
+
+    @media (max-width: 560px) {
+      .hero { padding: 24px 18px; }
+      .wrap { padding-top: 16px; }
+      .flow { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <div class="grain"></div>
+  <main class="wrap">
+    <section class="hero">
+      <p class="kicker">Agentic Engineering / Frontend Design v2</p>
+      <h1>AI 软件开发的第三时代</h1>
+      <p class="subtitle">从“手工编码”到“软件工厂编排”</p>
+      <p class="deck">这页把你和我刚才聊的重点整成一个可分享画布：Karpathy 讲的是能力跃迁与抽象层上移，Truell 讲的是云端自治 Agent 的规模化生产。两者合起来就是一句话：人类不再逐行写代码，而是管理并行的软件生产系统。</p>
+      <div class="banner">结论：抽象层上移，细节责任不消失；细节从“实现”迁移到“约束、验收、纠偏”。</div>
+    </section>
+
+    <section class="layout">
+      <article class="panel main">
+        <h2>三阶段迁移</h2>
+        <p class="muted">Michael Truell 的框架：Tab -> 同步 Agent -> 云端自治 Agent</p>
+        <div class="era-grid">
+          <section class="era">
+            <span class="tag">Era 1</span>
+            <h3>Tab 自动补全</h3>
+            <p>面向低熵重复工作，核心是逐行提效。人仍然是主要实现者。</p>
+          </section>
+          <section class="era">
+            <span class="tag">Era 2</span>
+            <h3>同步 Agent</h3>
+            <p>提示-响应回路，人机高频交互。任务可更长，但依赖人工持续盯控。</p>
+          </section>
+          <section class="era">
+            <span class="tag">Era 3</span>
+            <h3>云端自治 Agent</h3>
+            <p>可在独立环境中跑更长链路任务，产出日志、预览、PR 供人快速评审。</p>
+          </section>
+        </div>
+
+        <div class="flow">
+          <div class="node"><b>Goal</b>目标定义</div>
+          <div class="node"><b>Rule</b>约束注入</div>
+          <div class="node"><b>Edge</b>边界样例</div>
+          <div class="node"><b>Test</b>验收标准</div>
+        </div>
+
+        <div class="split">
+          <section class="mini">
+            <h4>人类新职责</h4>
+            <ul>
+              <li>拆解问题并设定质量门槛</li>
+              <li>并行调度多个 Agent</li>
+              <li>审阅 artifacts 与关键代码</li>
+            </ul>
+          </section>
+          <section class="mini">
+            <h4>落地挑战</h4>
+            <ul>
+              <li>flaky test 会被规模放大</li>
+              <li>环境漂移会中断自治流程</li>
+              <li>高风险域仍要人工兜底</li>
+            </ul>
+          </section>
+        </div>
+      </article>
+
+      <aside class="panel side">
+        <h2>关键指标</h2>
+        <div class="metrics">
+          <div class="metric"><b>15x+</b>Agent 使用量一年增长</div>
+          <div class="metric"><b>35%</b>内部合并 PR 由自治 Agent 生成</div>
+          <div class="metric"><b>Flip</b>用户结构从 Tab 主导转向 Agent 主导</div>
+        </div>
+
+        <div class="gallery">
+          <figure>
+            <img src="karpathy-agentic-engineering-summary-zh.png" alt="Karpathy summary">
+            <figcaption>Karpathy：阶段突变与抽象层上移</figcaption>
+          </figure>
+          <figure>
+            <img src="michael-truell-third-era-summary-zh.png" alt="Michael Truell summary">
+            <figcaption>Truell：第三时代与云端自治 Agent</figcaption>
+          </figure>
+        </div>
+      </aside>
+    </section>
+
+    <p class="tail">Prepared for Jasper · Built with frontend-design workflow</p>
+  </main>
+</body>
+</html>

--- a/apps/remote-server/generated/agentic-summary-page-v3/index.html
+++ b/apps/remote-server/generated/agentic-summary-page-v3/index.html
@@ -1,0 +1,283 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Agentic Engineering · 第三时代实战图</title>
+  <meta name="description" content="AI 软件开发进入第三时代：从编码执行转向软件工厂编排。">
+  <meta property="og:title" content="Agentic Engineering · 第三时代实战图">
+  <meta property="og:description" content="抽象层上移，细节责任仍在人类：目标、约束、边界、验收。">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="__OG_URL__">
+  <meta property="og:image" content="__OG_IMAGE__">
+  <meta name="twitter:card" content="summary_large_image">
+  <style>
+    :root {
+      --bg: #0b1322;
+      --ink: #f8f5ef;
+      --soft: #ced8e6;
+      --line: rgba(255,255,255,.16);
+      --panel: rgba(12, 24, 39, .78);
+      --orange: #f4a349;
+      --cyan: #67d4ff;
+      --green: #95efba;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      color: var(--ink);
+      font-family: "Songti SC", "Noto Serif SC", serif;
+      background:
+        radial-gradient(900px 480px at 88% -4%, rgba(244,163,73,.28), transparent 62%),
+        radial-gradient(760px 420px at 6% 10%, rgba(103,212,255,.18), transparent 64%),
+        linear-gradient(135deg, #07111e, #10233a 45%, #2c3247 100%);
+      min-height: 100vh;
+    }
+    .grid {
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      opacity: .18;
+      background-image:
+        linear-gradient(to right, rgba(255,255,255,.08) 1px, transparent 1px),
+        linear-gradient(to bottom, rgba(255,255,255,.08) 1px, transparent 1px);
+      background-size: 28px 28px;
+      mask-image: radial-gradient(circle at center, black 42%, transparent 100%);
+    }
+    .wrap {
+      width: min(1120px, 93vw);
+      margin: 0 auto;
+      padding: 30px 0 52px;
+    }
+    .hero {
+      border: 1px solid var(--line);
+      border-radius: 22px;
+      background: linear-gradient(150deg, rgba(6,16,27,.9), rgba(19,36,58,.83));
+      box-shadow: 0 18px 46px rgba(0,0,0,.35);
+      padding: 28px 24px;
+      animation: in .7s ease both;
+    }
+    .eyebrow {
+      margin: 0;
+      color: var(--cyan);
+      letter-spacing: .14em;
+      text-transform: uppercase;
+      font-size: 12px;
+      font-family: "PingFang SC", "Noto Sans SC", sans-serif;
+    }
+    h1 {
+      margin: 10px 0 0;
+      line-height: 1.05;
+      font-size: clamp(30px, 5.4vw, 58px);
+      max-width: 12ch;
+      text-wrap: balance;
+    }
+    .lead {
+      margin: 14px 0 0;
+      color: var(--soft);
+      font-size: 16px;
+      line-height: 1.75;
+      max-width: 72ch;
+      font-family: "PingFang SC", "Noto Sans SC", sans-serif;
+    }
+    .slogan {
+      margin-top: 14px;
+      border-left: 3px solid var(--orange);
+      padding: 10px 12px;
+      border-radius: 8px;
+      background: rgba(244,163,73,.12);
+      font-family: "PingFang SC", "Noto Sans SC", sans-serif;
+      color: #ffe8c7;
+      font-weight: 600;
+    }
+    .layout {
+      margin-top: 16px;
+      display: grid;
+      gap: 14px;
+      grid-template-columns: 1.15fr .85fr;
+    }
+    .panel {
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      background: var(--panel);
+      box-shadow: 0 10px 24px rgba(0,0,0,.24);
+      padding: 16px;
+      animation: in .8s ease both;
+    }
+    .panel h2 {
+      margin: 0;
+      font-size: 23px;
+    }
+    .sub {
+      margin: 6px 0 0;
+      color: var(--soft);
+      font-size: 13px;
+      font-family: "PingFang SC", "Noto Sans SC", sans-serif;
+    }
+    .cards {
+      margin-top: 12px;
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 8px;
+    }
+    .card {
+      border: 1px solid var(--line);
+      border-radius: 11px;
+      padding: 10px;
+      background: rgba(255,255,255,.03);
+    }
+    .card b {
+      display: inline-block;
+      border: 1px solid rgba(255,255,255,.24);
+      border-radius: 999px;
+      padding: 2px 7px;
+      font-size: 11px;
+      letter-spacing: .06em;
+      text-transform: uppercase;
+      color: var(--green);
+      font-family: "PingFang SC", "Noto Sans SC", sans-serif;
+    }
+    .card h3 {
+      margin: 8px 0 4px;
+      font-size: 17px;
+    }
+    .card p {
+      margin: 0;
+      color: #e1ebf7;
+      font-size: 13px;
+      line-height: 1.6;
+      font-family: "PingFang SC", "Noto Sans SC", sans-serif;
+    }
+    .pipeline {
+      margin-top: 10px;
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 8px;
+    }
+    .node {
+      border: 1px dashed rgba(255,255,255,.26);
+      border-radius: 10px;
+      padding: 8px;
+      text-align: center;
+      font-family: "PingFang SC", "Noto Sans SC", sans-serif;
+      font-size: 13px;
+      line-height: 1.35;
+      background: rgba(255,255,255,.02);
+    }
+    .node strong {
+      display: block;
+      color: #ffd9ae;
+      letter-spacing: .04em;
+      font-size: 12px;
+      text-transform: uppercase;
+    }
+    .metric {
+      margin-top: 10px;
+      display: grid;
+      gap: 7px;
+    }
+    .metric div {
+      border: 1px dashed rgba(255,255,255,.24);
+      border-radius: 9px;
+      padding: 9px;
+      font-family: "PingFang SC", "Noto Sans SC", sans-serif;
+      background: rgba(255,255,255,.02);
+      font-size: 14px;
+    }
+    .metric b { color: var(--green); font-size: 20px; margin-right: 5px; }
+    figure {
+      margin: 10px 0 0;
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      overflow: hidden;
+      background: rgba(0,0,0,.24);
+    }
+    img { display: block; width: 100%; height: auto; }
+    figcaption {
+      padding: 7px 9px;
+      color: var(--soft);
+      font-size: 12px;
+      font-family: "PingFang SC", "Noto Sans SC", sans-serif;
+    }
+    .foot {
+      margin-top: 12px;
+      text-align: center;
+      color: var(--soft);
+      font-size: 12px;
+      font-family: "PingFang SC", "Noto Sans SC", sans-serif;
+    }
+    @keyframes in {
+      from { opacity: 0; transform: translateY(8px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+    @media (max-width: 950px) {
+      .layout { grid-template-columns: 1fr; }
+      .cards { grid-template-columns: 1fr; }
+      .pipeline { grid-template-columns: 1fr 1fr; }
+    }
+    @media (max-width: 560px) {
+      .pipeline { grid-template-columns: 1fr; }
+      .hero { padding: 22px 16px; }
+      .wrap { padding-top: 14px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="grid"></div>
+  <main class="wrap">
+    <section class="hero">
+      <p class="eyebrow">Frontend v3 · Agentic Engineering</p>
+      <h1>从代码执行者到软件工厂编排者</h1>
+      <p class="lead">这版重新生产了一个全新 HTML 页面。核心观点来自 Karpathy 与 Michael Truell：AI 编程不是“写得更快”而已，而是进入“多 Agent 并行生产 + 人类定义标准与验收”的新工作方式。</p>
+      <div class="slogan">一句话：抽象层上移，细节责任仍在你手里。</div>
+    </section>
+
+    <section class="layout">
+      <article class="panel">
+        <h2>三阶段演进</h2>
+        <p class="sub">Tab 自动补全 -> 同步 Agent -> 云端自治 Agent</p>
+        <div class="cards">
+          <section class="card">
+            <b>Era 1</b>
+            <h3>Tab</h3>
+            <p>逐行补全，自动化低熵重复任务。</p>
+          </section>
+          <section class="card">
+            <b>Era 2</b>
+            <h3>同步 Agent</h3>
+            <p>提示-响应循环，仍需高频在环。</p>
+          </section>
+          <section class="card">
+            <b>Era 3</b>
+            <h3>云端自治 Agent</h3>
+            <p>可长时独立执行，返回可评审产物。</p>
+          </section>
+        </div>
+
+        <div class="pipeline">
+          <div class="node"><strong>Goal</strong>目标</div>
+          <div class="node"><strong>Rules</strong>约束</div>
+          <div class="node"><strong>Edge</strong>边界</div>
+          <div class="node"><strong>Tests</strong>验收</div>
+        </div>
+      </article>
+
+      <aside class="panel">
+        <h2>关键信号</h2>
+        <div class="metric">
+          <div><b>15x+</b>Agent 使用量一年增长</div>
+          <div><b>35%</b>内部合并 PR 由自治 Agent 生成</div>
+          <div><b>Flip</b>用户结构从 Tab 主导转向 Agent 主导</div>
+        </div>
+
+        <figure>
+          <img src="michael-truell-third-era-summary-zh.png" alt="Third Era">
+          <figcaption>第三时代：云端自治 Agent 与并行软件生产</figcaption>
+        </figure>
+      </aside>
+    </section>
+
+    <div class="foot">Prepared for Jasper · New address / New HTML</div>
+  </main>
+</body>
+</html>

--- a/apps/remote-server/generated/agentic-summary-page/index.html
+++ b/apps/remote-server/generated/agentic-summary-page/index.html
@@ -1,0 +1,281 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>AI 编程范式转移：从编码到编排</title>
+  <meta name="description" content="基于 Karpathy 与 Michael Truell 观点的 AI 编程范式转移总结：从手工编码到软件工厂编排。">
+  <meta property="og:title" content="AI 编程范式转移：从编码到编排">
+  <meta property="og:description" content="抽象层上移，但细节责任仍在人类：目标、约束、边界、验收。">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="http://42.192.62.24/apps/s-20260226-171342-g9o9/">
+  <meta property="og:image" content="http://42.192.62.24/apps/s-20260226-171342-g9o9/michael-truell-third-era-summary-zh.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <style>
+    :root {
+      --bg-1: #07111f;
+      --bg-2: #0e2c44;
+      --bg-3: #f28f45;
+      --ink: #f6f3ea;
+      --muted: #c2d1de;
+      --card: rgba(7, 18, 30, 0.72);
+      --line: rgba(255, 255, 255, 0.12);
+      --accent: #ffcc66;
+      --ok: #73e0b1;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      color: var(--ink);
+      font-family: "Noto Serif SC", "Source Han Serif SC", "Songti SC", serif;
+      background:
+        radial-gradient(1200px 500px at 80% -10%, rgba(242, 143, 69, 0.22), transparent 60%),
+        radial-gradient(900px 420px at -10% 10%, rgba(65, 187, 255, 0.16), transparent 65%),
+        linear-gradient(130deg, var(--bg-1), var(--bg-2) 54%, #183147 70%, var(--bg-3));
+      min-height: 100vh;
+    }
+
+    .grid {
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      opacity: 0.2;
+      background-image:
+        linear-gradient(to right, rgba(255,255,255,0.07) 1px, transparent 1px),
+        linear-gradient(to bottom, rgba(255,255,255,0.07) 1px, transparent 1px);
+      background-size: 40px 40px;
+      mask-image: radial-gradient(circle at center, black 40%, transparent 100%);
+    }
+
+    .container {
+      width: min(1080px, 92vw);
+      margin: 0 auto;
+      padding: 42px 0 64px;
+    }
+
+    .hero {
+      background: linear-gradient(140deg, rgba(4, 16, 29, 0.88), rgba(19, 35, 54, 0.84));
+      border: 1px solid var(--line);
+      border-radius: 24px;
+      padding: 34px 28px;
+      box-shadow: 0 18px 44px rgba(0, 0, 0, 0.35);
+      backdrop-filter: blur(2px);
+      animation: rise .8s ease-out both;
+    }
+
+    .eyebrow {
+      color: var(--accent);
+      letter-spacing: .08em;
+      font-size: 13px;
+      margin-bottom: 10px;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(28px, 5.4vw, 52px);
+      line-height: 1.08;
+      letter-spacing: .01em;
+      text-wrap: balance;
+    }
+
+    .lead {
+      margin-top: 16px;
+      color: var(--muted);
+      font-family: "Noto Sans SC", "PingFang SC", sans-serif;
+      font-size: 17px;
+      line-height: 1.75;
+      max-width: 72ch;
+    }
+
+    .band {
+      margin-top: 18px;
+      padding: 13px 16px;
+      border-left: 3px solid var(--accent);
+      background: rgba(255, 204, 102, 0.08);
+      border-radius: 8px;
+      font-family: "Noto Sans SC", "PingFang SC", sans-serif;
+      color: #ffe8b8;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+    }
+
+    .cols {
+      margin-top: 26px;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 18px;
+    }
+
+    .card {
+      background: var(--card);
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      padding: 20px;
+      box-shadow: 0 10px 24px rgba(0, 0, 0, 0.24);
+      animation: rise .8s ease-out both;
+    }
+
+    .card h2 {
+      margin: 0 0 10px;
+      font-size: 22px;
+    }
+
+    .meta {
+      margin: 0 0 10px;
+      color: var(--muted);
+      font-family: "Noto Sans SC", "PingFang SC", sans-serif;
+      font-size: 14px;
+    }
+
+    ul {
+      margin: 0;
+      padding-left: 1.15em;
+    }
+
+    li {
+      margin: 8px 0;
+      line-height: 1.6;
+      font-family: "Noto Sans SC", "PingFang SC", sans-serif;
+      color: #ecf4fb;
+    }
+
+    .workflow {
+      margin-top: 18px;
+      display: grid;
+      gap: 12px;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+
+    .step {
+      padding: 12px 10px;
+      border-radius: 10px;
+      border: 1px dashed rgba(255,255,255,.24);
+      text-align: center;
+      background: rgba(255,255,255,0.04);
+      font-family: "Noto Sans SC", "PingFang SC", sans-serif;
+      font-size: 14px;
+      line-height: 1.45;
+    }
+
+    .step strong { color: var(--ok); font-size: 13px; }
+
+    .images {
+      margin-top: 26px;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 16px;
+    }
+
+    figure {
+      margin: 0;
+      background: rgba(4, 13, 22, 0.72);
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      overflow: hidden;
+    }
+
+    img {
+      display: block;
+      width: 100%;
+      height: auto;
+      background: #09111a;
+    }
+
+    figcaption {
+      padding: 10px 12px;
+      font-family: "Noto Sans SC", "PingFang SC", sans-serif;
+      font-size: 13px;
+      color: var(--muted);
+    }
+
+    .footer {
+      margin-top: 22px;
+      font-family: "Noto Sans SC", "PingFang SC", sans-serif;
+      font-size: 13px;
+      color: var(--muted);
+      text-align: center;
+    }
+
+    @keyframes rise {
+      from { opacity: 0; transform: translateY(10px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    @media (max-width: 900px) {
+      .cols, .images { grid-template-columns: 1fr; }
+      .workflow { grid-template-columns: 1fr 1fr; }
+      .container { padding-top: 24px; }
+      .hero { padding: 24px 18px; border-radius: 18px; }
+    }
+
+    @media (max-width: 520px) {
+      .workflow { grid-template-columns: 1fr; }
+      .lead { font-size: 16px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="grid"></div>
+  <main class="container">
+    <section class="hero">
+      <div class="eyebrow">AGENTIC ENGINEERING BRIEF · 2026</div>
+      <h1>AI 编程正在经历范式转移：<br>从“手工编码”走向“软件工厂编排”</h1>
+      <p class="lead">
+        基于 Karpathy 与 Michael Truell 的观点：开发已从逐行输入代码，升级为让多个 Agent 在云端并行执行。
+        人类职责从“写细节”转向“定义问题、设约束、做验收与纠偏”。
+      </p>
+      <div class="band">核心结论：抽象层上移，但细节责任没有消失，只是从“实现细节”迁移到“管理细节”。</div>
+    </section>
+
+    <section class="cols">
+      <article class="card" style="animation-delay: .08s;">
+        <h2>Karpathy：阶段突变</h2>
+        <p class="meta">关键词：非线性跃迁、长程一致性、任务接管</p>
+        <ul>
+          <li>2025 年 12 月前后，coding agent 从“基本不可用”跨到“可独立完成长任务”。</li>
+          <li>开发流程被重写：人类在英文层面分派任务，再并行审查结果。</li>
+          <li>高杠杆来自构建 orchestrator：工具、记忆、指令与多 Agent 协同。</li>
+          <li>仍需判断与监督：方向、品味、边界 case、测试验收不可省略。</li>
+        </ul>
+      </article>
+
+      <article class="card" style="animation-delay: .16s;">
+        <h2>Truell（Cursor）：第三时代</h2>
+        <p class="meta">关键词：云端自治、工厂化、并行规模化</p>
+        <ul>
+          <li>第一阶段 Tab：逐行提效；第二阶段同步 Agent：高频人机回合。</li>
+          <li>第三阶段是云端自治 Agent：更长时、更大任务、低监督执行。</li>
+          <li>关键数据：Agent 使用量一年 15x+，内部约 35% PR 已由自治 Agent 生成。</li>
+          <li>角色变化：开发者从编码者，转向软件生产系统编排者。</li>
+        </ul>
+      </article>
+    </section>
+
+    <section class="card" style="margin-top: 18px; animation-delay: .22s;">
+      <h2>你问到的关键：还要不要懂细节？</h2>
+      <p class="meta">答案：要。不是“全懂再做”，而是“识别关键细节并可验证”。</p>
+      <div class="workflow">
+        <div class="step"><strong>1. 目标</strong><br>明确要达成的业务结果</div>
+        <div class="step"><strong>2. 约束</strong><br>成本、时延、安全、兼容性</div>
+        <div class="step"><strong>3. 边界</strong><br>失败样例与极端输入</div>
+        <div class="step"><strong>4. 验收</strong><br>可跑测试与通过标准</div>
+      </div>
+    </section>
+
+    <section class="images">
+      <figure>
+        <img src="karpathy-agentic-engineering-summary-zh.png" alt="Karpathy 观点信息图">
+        <figcaption>Karpathy 观点图：抽象层上移与细节责任共存</figcaption>
+      </figure>
+      <figure>
+        <img src="michael-truell-third-era-summary-zh.png" alt="Michael Truell 观点信息图">
+        <figcaption>Truell 观点图：AI 软件开发第三时代</figcaption>
+      </figure>
+    </section>
+
+    <div class="footer">Prepared for Jasper · Agentic workflow notes</div>
+  </main>
+</body>
+</html>

--- a/apps/remote-server/src/adapters/discord/adapter.ts
+++ b/apps/remote-server/src/adapters/discord/adapter.ts
@@ -447,6 +447,7 @@ const PASSTHROUGH_SLASH_COMMANDS = new Set([
   'detach',
   'resume',
   'sessions',
+  'fork',
   'status',
   'stop',
   'cancel',


### PR DESCRIPTION
Add a new `/fork <session-id>` command to duplicate an existing session into a new one and switch context to the forked session.

- Implement `forkSession` in remote session store with ownership checks
- Deep-clone source message list into a newly generated session ID
- Attach the new session as current after forking
- Add `/fork` command handling, validation, and help text updates
- Allow Discord slash passthrough for `fork`
- Note: current branch also includes generated files under `generated/*`