### PR TITLE
Fix fork session access at user scope

### DIFF
--- a/apps/remote-server/src/core/chat-commands.ts
+++ b/apps/remote-server/src/core/chat-commands.ts
@@ -68,7 +68,7 @@ export async function processIncomingCommand(incoming: IncomingMessage): Promise
       return { type: 'handled', message: buildHelpMessage() };
 
     case 'new': {
-      const sessionId = await sessionStore.createNewSession(incoming.platformKey);
+      const sessionId = await sessionStore.createNewSession(incoming.platformKey, memoryKey);
       return {
         type: 'handled',
         message: `✅ 已创建新会话\nSession ID: ${sessionId}`,
@@ -76,7 +76,7 @@ export async function processIncomingCommand(incoming: IncomingMessage): Promise
     }
 
     case 'clear': {
-      const result = await sessionStore.clearCurrent(incoming.platformKey);
+      const result = await sessionStore.clearCurrent(incoming.platformKey, memoryKey);
       if (result.createdNew) {
         return {
           type: 'handled',
@@ -95,7 +95,7 @@ export async function processIncomingCommand(incoming: IncomingMessage): Promise
       return await handleResumeCommand(incoming.platformKey, args);
 
     case 'fork':
-      return await handleForkCommand(incoming.platformKey, args);
+      return await handleForkCommand(incoming.platformKey, memoryKey, args);
 
     case 'status':
       return await handleStatusCommand(incoming.platformKey);
@@ -188,7 +188,7 @@ async function handleResumeCommand(platformKey: string, args: string[]): Promise
   };
 }
 
-async function handleForkCommand(platformKey: string, args: string[]): Promise<CommandResult> {
+async function handleForkCommand(platformKey: string, memoryKey: string, args: string[]): Promise<CommandResult> {
   const sourceSessionId = args[0]?.trim();
   if (!sourceSessionId) {
     return {
@@ -197,7 +197,7 @@ async function handleForkCommand(platformKey: string, args: string[]): Promise<C
     };
   }
 
-  const result = await sessionStore.forkSession(platformKey, sourceSessionId);
+  const result = await sessionStore.forkSession(platformKey, sourceSessionId, memoryKey);
   if (!result.ok || !result.sessionId) {
     return {
       type: 'handled',

--- a/apps/remote-server/src/core/dispatcher.ts
+++ b/apps/remote-server/src/core/dispatcher.ts
@@ -141,7 +141,7 @@ async function runAgentAsync(adapter: PlatformAdapter, incoming: IncomingMessage
   const compactionEvents: CompactionSnapshot[] = [];
 
   try {
-    const result = await sessionStore.getOrCreate(platformKey, forceNewSession);
+    const result = await sessionStore.getOrCreate(platformKey, forceNewSession, memoryKey);
     sessionId = result.sessionId;
     const context = result.context;
 

--- a/apps/remote-server/src/routes/internal.ts
+++ b/apps/remote-server/src/routes/internal.ts
@@ -112,7 +112,7 @@ internalRouter.post('/agent/run', async (c) => {
   const imageNotifyTasks: Promise<void>[] = [];
 
   try {
-    const session = await sessionStore.getOrCreate(platformKey, forceNewSession);
+    const session = await sessionStore.getOrCreate(platformKey, forceNewSession, platformKey);
     sessionId = session.sessionId;
     const context = session.context;
 


### PR DESCRIPTION
Allow `/fork` to work across the same user identity instead of requiring the exact same platform scope.

- Authorize fork by `ownerKey` (memory identity) in addition to `platformKey`
- Persist `ownerKey` on session creation and backfill missing values on read
- Update dispatcher and command handlers to pass owner identity into session operations
- Keep internal route behavior unchanged by using platform key as owner key
- Improve compatibility for legacy sessions via owner key derivation from existing platform keys