### PR TITLE
feat(mcp): support sse and stdio transports

### DIFF
--- a/MIGRATION-BUILT-IN-PLUGINS.md
+++ b/MIGRATION-BUILT-IN-PLUGINS.md
@@ -78,8 +78,8 @@ const engine = new Engine({
 ## 功能保持不变
 
 ### MCP 功能
-- 配置文件位置: `.coder/mcp.json`
-- 支持的传输方式: HTTP
+- 配置文件位置: `.coder/mcp.json`（兼容 `.pulse-coder/mcp.json`）
+- 支持的传输方式: HTTP / SSE / STDIO（默认 `http`）
 - 工具命名空间: `mcp_{serverName}_{toolName}`
 
 ### Skills 功能

--- a/README-CN.md
+++ b/README-CN.md
@@ -160,12 +160,28 @@ pnpm start
 ```json
 {
   "servers": {
-    "my_server": {
+    "remote_http": {
+      "transport": "http",
       "url": "http://localhost:3060/mcp/server"
+    },
+    "legacy_sse": {
+      "transport": "sse",
+      "url": "https://example.com/sse"
+    },
+    "local_stdio": {
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "."],
+      "cwd": "."
     }
   }
 }
 ```
+
+说明：
+- `transport` 支持 `http`、`sse`、`stdio`。
+- 若未填写 `transport`，默认按 `http` 处理（向后兼容）。
+- `http`/`sse` 使用 `url`（可选 `headers`）；`stdio` 使用 `command`（可选 `args`、`env`、`cwd`）。
 
 ### Skills
 创建 `.pulse-coder/skills/<skill-name>/SKILL.md`：

--- a/README.md
+++ b/README.md
@@ -161,12 +161,28 @@ Create `.pulse-coder/mcp.json`:
 ```json
 {
   "servers": {
-    "my_server": {
+    "remote_http": {
+      "transport": "http",
       "url": "http://localhost:3060/mcp/server"
+    },
+    "legacy_sse": {
+      "transport": "sse",
+      "url": "https://example.com/sse"
+    },
+    "local_stdio": {
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "."],
+      "cwd": "."
     }
   }
 }
 ```
+
+Notes:
+- `transport` supports `http`, `sse`, and `stdio`.
+- If `transport` is omitted, it defaults to `http` for backward compatibility.
+- `http`/`sse` use `url` (optional `headers`), while `stdio` uses `command` (+ optional `args`, `env`, `cwd`).
 
 ### Skills
 Create `.pulse-coder/skills/<skill-name>/SKILL.md`:

--- a/architecture/en/08-built-in-plugins.md
+++ b/architecture/en/08-built-in-plugins.md
@@ -28,6 +28,7 @@ flowchart LR
 ### 2.1 Function
 
 - Reads `.pulse-coder/mcp.json` (compatible with `.coder/mcp.json`)
+- Supports `http`, `sse`, and `stdio` transports (`http` by default)
 - Creates MCP client per configured server
 - Fetches server tools and registers them into engine
 

--- a/architecture/zh/08-built-in-plugins.md
+++ b/architecture/zh/08-built-in-plugins.md
@@ -28,6 +28,7 @@ flowchart LR
 ### 2.1 功能
 
 - 读取 `.pulse-coder/mcp.json`（兼容 `.coder/mcp.json`）
+- 支持 `http`、`sse`、`stdio` 三种传输（默认 `http`）
 - 逐个服务器建立 MCP client
 - 拉取 server tools 并注册到引擎
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -67,13 +67,19 @@ coder
 ## 配置文件
 
 ### MCP 配置
-创建 `.coder/mcp.json`：
+创建 `.pulse-coder/mcp.json`（兼容 `.coder/mcp.json`）：
 ```json
 {
   "servers": {
     "eido_mind": {
       "transport": "http",
       "url": "http://localhost:3060/mcp/server"
+    },
+    "local_stdio": {
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "."],
+      "cwd": "."
     }
   }
 }

--- a/packages/engine/src/built-in/mcp-plugin/index.ts
+++ b/packages/engine/src/built-in/mcp-plugin/index.ts
@@ -4,12 +4,31 @@
  */
 
 import { EnginePlugin, EnginePluginContext } from '../../plugin/EnginePlugin';
-import { createMCPClient } from '@ai-sdk/mcp';
+import { createMCPClient, type MCPClientConfig } from '@ai-sdk/mcp';
+import { Experimental_StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio';
 import { existsSync, readFileSync } from 'fs';
 import * as path from 'path';
 
+type RawMCPServerConfig = Record<string, unknown>;
+
+interface HTTPOrSSEServerConfig {
+  transport: 'http' | 'sse';
+  url: string;
+  headers?: Record<string, string>;
+}
+
+interface StdioServerConfig {
+  transport: 'stdio';
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+}
+
+type NormalizedMCPServerConfig = HTTPOrSSEServerConfig | StdioServerConfig;
+
 export interface MCPPluginConfig {
-  servers: Record<string, { url: string }>;
+  servers: Record<string, RawMCPServerConfig>;
 }
 
 export async function loadMCPConfig(cwd: string): Promise<MCPPluginConfig> {
@@ -31,23 +50,113 @@ export async function loadMCPConfig(cwd: string): Promise<MCPPluginConfig> {
       return { servers: {} };
     }
 
-    return { servers: parsed.servers };
+    return { servers: parsed.servers as Record<string, RawMCPServerConfig> };
   } catch (error) {
     console.warn(`[MCP] Failed to load config: ${error instanceof Error ? error.message : 'Unknown error'}`);
     return { servers: {} };
   }
 }
 
-function createHTTPTransport(config: { url: string }) {
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  return Object.values(value).every(item => typeof item === 'string');
+}
+
+function normalizeServerConfig(serverName: string, raw: RawMCPServerConfig): NormalizedMCPServerConfig | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    console.warn(`[MCP] Server "${serverName}" config must be an object, skipping`);
+    return null;
+  }
+
+  const transport = typeof raw.transport === 'string' ? raw.transport.toLowerCase() : 'http';
+
+  if (transport === 'http' || transport === 'sse') {
+    if (typeof raw.url !== 'string' || !raw.url.trim()) {
+      console.warn(`[MCP] Server "${serverName}" missing URL for ${transport} transport, skipping`);
+      return null;
+    }
+
+    const normalized: HTTPOrSSEServerConfig = {
+      transport,
+      url: raw.url
+    };
+
+    if (raw.headers !== undefined) {
+      if (!isStringRecord(raw.headers)) {
+        console.warn(`[MCP] Server "${serverName}" has invalid headers; expected string map, ignoring headers`);
+      } else {
+        normalized.headers = raw.headers;
+      }
+    }
+
+    return normalized;
+  }
+
+  if (transport === 'stdio') {
+    if (typeof raw.command !== 'string' || !raw.command.trim()) {
+      console.warn(`[MCP] Server "${serverName}" missing command for stdio transport, skipping`);
+      return null;
+    }
+
+    const normalized: StdioServerConfig = {
+      transport: 'stdio',
+      command: raw.command
+    };
+
+    if (raw.args !== undefined) {
+      if (!Array.isArray(raw.args) || !raw.args.every(arg => typeof arg === 'string')) {
+        console.warn(`[MCP] Server "${serverName}" has invalid args; expected string array, ignoring args`);
+      } else {
+        normalized.args = raw.args;
+      }
+    }
+
+    if (raw.env !== undefined) {
+      if (!isStringRecord(raw.env)) {
+        console.warn(`[MCP] Server "${serverName}" has invalid env; expected string map, ignoring env`);
+      } else {
+        normalized.env = raw.env;
+      }
+    }
+
+    if (raw.cwd !== undefined) {
+      if (typeof raw.cwd !== 'string' || !raw.cwd.trim()) {
+        console.warn(`[MCP] Server "${serverName}" has invalid cwd; expected non-empty string, ignoring cwd`);
+      } else {
+        normalized.cwd = raw.cwd;
+      }
+    }
+
+    return normalized;
+  }
+
+  console.warn(`[MCP] Server "${serverName}" has unsupported transport "${transport}", skipping`);
+  return null;
+}
+
+function createTransport(config: NormalizedMCPServerConfig): MCPClientConfig['transport'] {
+  if (config.transport === 'stdio') {
+    return new Experimental_StdioMCPTransport({
+      command: config.command,
+      args: config.args,
+      env: config.env,
+      cwd: config.cwd
+    });
+  }
+
   return {
-    type: 'http' as const,
-    url: config.url
+    type: config.transport,
+    url: config.url,
+    headers: config.headers
   };
 }
 
 export const builtInMCPPlugin: EnginePlugin = {
   name: 'pulse-coder-engine/built-in-mcp',
-  version: '1.0.0',
+  version: '1.1.0',
 
   async initialize(context: EnginePluginContext) {
     const config = await loadMCPConfig(process.cwd());
@@ -60,14 +169,14 @@ export const builtInMCPPlugin: EnginePlugin = {
 
     let loadedCount = 0;
 
-    for (const [serverName, serverConfig] of Object.entries(config.servers)) {
+    for (const [serverName, rawServerConfig] of Object.entries(config.servers)) {
       try {
-        if (!serverConfig.url) {
-          console.warn(`[MCP] Server "${serverName}" missing URL, skipping`);
+        const normalizedConfig = normalizeServerConfig(serverName, rawServerConfig);
+        if (!normalizedConfig) {
           continue;
         }
 
-        const transport = createHTTPTransport(serverConfig);
+        const transport = createTransport(normalizedConfig);
         const client = await createMCPClient({ transport });
 
         const tools = await client.tools();


### PR DESCRIPTION
- extend built-in MCP plugin to handle http/sse/stdio configs

- keep backward compatibility by defaulting transport to http

- update docs and migration notes with new MCP transport options
