### PR TITLE
Renew remote-server engine on worktree switch

### DIFF
--- a/apps/remote-server/src/core/agent-runner.ts
+++ b/apps/remote-server/src/core/agent-runner.ts
@@ -1,6 +1,6 @@
 import type { ClarificationRequest } from './types.js';
 import type { CompactionEvent } from 'pulse-coder-engine';
-import { engine } from './engine-singleton.js';
+import { getOrInitializeEngine } from './engine-singleton.js';
 import { sessionStore } from './session-store.js';
 import { memoryIntegration, recordDailyLogFromSuccessPath } from './memory-integration.js';
 import { buildRemoteWorktreeRunContext, worktreeIntegration } from './worktree/integration.js';
@@ -40,6 +40,7 @@ export async function executeAgentTurn(input: ExecuteAgentTurnInput): Promise<Ex
 
   context.messages.push({ role: 'user', content: input.userText });
 
+  const engine = await getOrInitializeEngine();
   const resultText = await runWithAgentContexts(
     {
       platformKey: input.platformKey,

--- a/apps/remote-server/src/core/chat-commands.ts
+++ b/apps/remote-server/src/core/chat-commands.ts
@@ -1,4 +1,4 @@
-import { engine } from './engine-singleton.js';
+import { tryGetEngine } from './engine-singleton.js';
 import { sessionStore } from './session-store.js';
 import type { IncomingMessage } from './types.js';
 import { memoryService } from './memory-integration.js';
@@ -62,6 +62,7 @@ export async function processIncomingCommand(incoming: IncomingMessage): Promise
     text: raw,
     runtimeKey: worktreeContext.runtimeKey,
     scopeKey: worktreeContext.scopeKey,
+    platformKey: incoming.platformKey,
   });
   if (worktreeCommand.handled) {
     return {
@@ -334,6 +335,14 @@ async function handleCompactCommand(platformKey: string): Promise<CommandResult>
   const keepLastTurns = getKeepLastTurns();
 
   try {
+    const engine = tryGetEngine();
+    if (!engine) {
+      return {
+        type: 'handled',
+        message: '⚠️ 引擎尚未初始化，请稍后重试。',
+      };
+    }
+
     const compactResult = await engine.compactContext(current.context, { force: true });
 
     if (!compactResult.didCompact || !compactResult.newMessages) {
@@ -565,6 +574,11 @@ function handleSkillsCommand(args: string[]): CommandResult {
 }
 
 function getSkillRegistry(): SkillRegistryService | undefined {
+  const engine = tryGetEngine();
+  if (!engine) {
+    return undefined;
+  }
+
   return engine.getService<SkillRegistryService>('skillRegistry');
 }
 

--- a/apps/remote-server/src/core/engine-singleton.ts
+++ b/apps/remote-server/src/core/engine-singleton.ts
@@ -2,16 +2,100 @@ import { Engine } from 'pulse-coder-engine';
 import { memoryIntegration } from './memory-integration.js';
 import { worktreeIntegration } from './worktree/integration.js';
 
-/**
- * Single Engine instance shared across all platform adapters.
- * engine.run(context, options) is stateless per-call - each invocation
- * receives its own Context object, so concurrent runs from different users are safe.
- */
-export const engine = new Engine({
-  enginePlugins: {
-    plugins: [
-      memoryIntegration.enginePlugin,
-      worktreeIntegration.enginePlugin,
-    ],
-  },
-});
+export interface EngineLifecycleSnapshot {
+  generation: number;
+  previousGeneration: number;
+  renewedAt: number;
+  reason: string;
+}
+
+interface EngineState {
+  engine: Engine;
+  generation: number;
+  createdAt: number;
+}
+
+let state: EngineState | null = null;
+let lifecycleQueue: Promise<void> = Promise.resolve();
+
+function createEngine(): Engine {
+  return new Engine({
+    enginePlugins: {
+      plugins: [
+        memoryIntegration.enginePlugin,
+        worktreeIntegration.enginePlugin,
+      ],
+    },
+  });
+}
+
+async function runLifecycleOperation<T>(operation: () => Promise<T>): Promise<T> {
+  const run = lifecycleQueue.then(operation, operation);
+  lifecycleQueue = run.then(() => undefined, () => undefined);
+  return run;
+}
+
+export async function initializeEngine(): Promise<Engine> {
+  return runLifecycleOperation(async () => {
+    if (state) {
+      return state.engine;
+    }
+
+    const engine = createEngine();
+    await engine.initialize();
+    state = {
+      engine,
+      generation: 1,
+      createdAt: Date.now(),
+    };
+
+    return engine;
+  });
+}
+
+export async function getOrInitializeEngine(): Promise<Engine> {
+  if (state) {
+    return state.engine;
+  }
+
+  return initializeEngine();
+}
+
+export function tryGetEngine(): Engine | undefined {
+  return state?.engine;
+}
+
+export async function renewEngine(reason: string): Promise<EngineLifecycleSnapshot> {
+  return runLifecycleOperation(async () => {
+    const previousGeneration = state?.generation ?? 0;
+    const engine = createEngine();
+    await engine.initialize();
+
+    state = {
+      engine,
+      generation: previousGeneration + 1,
+      createdAt: Date.now(),
+    };
+
+    return {
+      generation: state.generation,
+      previousGeneration,
+      renewedAt: state.createdAt,
+      reason,
+    };
+  });
+}
+
+export function getEngineLifecycleInfo(): { generation: number; createdAt: number } {
+  if (!state) {
+    return {
+      generation: 0,
+      createdAt: 0,
+    };
+  }
+
+  return {
+    generation: state.generation,
+    createdAt: state.createdAt,
+  };
+}

--- a/apps/remote-server/src/index.ts
+++ b/apps/remote-server/src/index.ts
@@ -1,7 +1,7 @@
 import 'dotenv/config';
 import { serve } from '@hono/node-server';
 import { createApp } from './server.js';
-import { engine } from './core/engine-singleton.js';
+import { initializeEngine } from './core/engine-singleton.js';
 import { sessionStore } from './core/session-store.js';
 import { memoryIntegration } from './core/memory-integration.js';
 import { worktreeIntegration } from './core/worktree/integration.js';
@@ -17,7 +17,7 @@ async function main() {
   // Initialize worktree binding state store
   await worktreeIntegration.initialize();
 
-  await engine.initialize();
+  await initializeEngine();
 
   startDiscordGateway();
 


### PR DESCRIPTION
Enable engine lifecycle renewal when worktree bindings change in remote-server.

- Replace static engine singleton with lifecycle-managed APIs (initialize/get/renew)
- Renew engine after  and , with generation info in command output
- Block worktree switching while a run is active to avoid mid-run context drift
- Update startup and run paths to consume the new engine lifecycle entry points