### PR TITLE
feat: enforce worktree-aware tool path resolution

### DIFF
--- a/apps/remote-server/src/core/runtime-paths.ts
+++ b/apps/remote-server/src/core/runtime-paths.ts
@@ -1,0 +1,44 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+const RUNTIME_REPO_ROOT_ENV = 'PULSE_CODER_RUNTIME_REPO_ROOT';
+
+export async function alignProcessCwdToGitRepoRoot(): Promise<string | undefined> {
+  const repoRoot = await resolveGitRepoRoot(process.cwd());
+  if (!repoRoot) {
+    return undefined;
+  }
+
+  process.env[RUNTIME_REPO_ROOT_ENV] = repoRoot;
+
+  if (process.cwd() !== repoRoot) {
+    process.chdir(repoRoot);
+  }
+
+  return repoRoot;
+}
+
+export function getRuntimeRepoRoot(): string | undefined {
+  const fromEnv = process.env[RUNTIME_REPO_ROOT_ENV]?.trim();
+  if (!fromEnv) {
+    return undefined;
+  }
+
+  return fromEnv;
+}
+
+async function resolveGitRepoRoot(cwd: string): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync('git', ['rev-parse', '--show-toplevel'], {
+      cwd,
+      timeout: 15000,
+      maxBuffer: 1024 * 1024,
+    });
+
+    const repoRoot = stdout.trim();
+    return repoRoot || undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/remote-server/src/core/worktree/commands.ts
+++ b/apps/remote-server/src/core/worktree/commands.ts
@@ -3,6 +3,7 @@ import { mkdir } from 'fs/promises';
 import { join } from 'path';
 import { promisify } from 'util';
 import { worktreeService } from './integration.js';
+import { getRuntimeRepoRoot } from '../runtime-paths.js';
 
 const COMMAND_PREFIX = '/wt';
 const MAX_PATH_LENGTH = 400;
@@ -276,7 +277,7 @@ async function parseAutoUseArgs(args: string[]): Promise<
 
   let repoRoot = '';
   try {
-    repoRoot = await resolveGitRepoRoot();
+    repoRoot = await resolveGitRepoRoot(getRuntimeRepoRoot());
   } catch {
     return {
       ok: false,
@@ -346,9 +347,10 @@ async function parseAutoUseArgs(args: string[]): Promise<
   };
 }
 
-async function resolveGitRepoRoot(): Promise<string> {
+async function resolveGitRepoRoot(basePath?: string): Promise<string> {
+  const cwd = basePath && basePath.trim().length > 0 ? basePath : process.cwd();
   const { stdout } = await execFileAsync('git', ['rev-parse', '--show-toplevel'], {
-    cwd: process.cwd(),
+    cwd,
     timeout: 15000,
     maxBuffer: 1024 * 1024,
   });

--- a/apps/remote-server/src/core/worktree/integration.ts
+++ b/apps/remote-server/src/core/worktree/integration.ts
@@ -1,6 +1,7 @@
 import { homedir } from 'os';
 import { join } from 'path';
 import { createWorktreeIntegration } from 'pulse-coder-plugin-kit/worktree';
+import { getRuntimeRepoRoot } from '../runtime-paths.js';
 
 const DEFAULT_RUNTIME_KEY = 'remote-server';
 
@@ -8,6 +9,7 @@ export const worktreeIntegration = createWorktreeIntegration({
   baseDir: join(homedir(), '.pulse-coder', 'worktree-state'),
   pluginName: 'remote-worktree-binding',
   pluginVersion: '0.0.1',
+  getDefaultToolBasePath: () => getRuntimeRepoRoot(),
 });
 
 export const worktreeService = worktreeIntegration.service;

--- a/apps/remote-server/src/index.ts
+++ b/apps/remote-server/src/index.ts
@@ -6,8 +6,11 @@ import { sessionStore } from './core/session-store.js';
 import { memoryIntegration } from './core/memory-integration.js';
 import { worktreeIntegration } from './core/worktree/integration.js';
 import { startDiscordGateway } from './adapters/discord/gateway-manager.js';
+import { alignProcessCwdToGitRepoRoot } from './core/runtime-paths.js';
 
 async function main() {
+  await alignProcessCwdToGitRepoRoot();
+
   // Initialize session store (creates directories if needed, loads index)
   await sessionStore.initialize();
 

--- a/packages/plugin-kit/src/worktree/integration.ts
+++ b/packages/plugin-kit/src/worktree/integration.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from 'async_hooks';
+import { isAbsolute, resolve } from 'path';
 import type { EnginePlugin, SystemPromptOption } from 'pulse-coder-engine';
 import type { FileWorktreeServiceOptions, UpsertWorktreeInput, WorktreeBindingView, WorktreeScope } from './types.js';
 import { FileWorktreePluginService } from './service.js';
@@ -10,6 +11,9 @@ const DEFAULT_PROMPT = [
   '- If a command result suggests another directory, treat that as unexpected and return to the bound worktree.',
   '- Before major operations, validate context with `pwd && git branch --show-current && git status -sb`.',
 ].join('\n');
+
+const TOOL_NAMES_WITH_FILE_PATH = new Set(['read', 'write', 'edit']);
+const TOOL_NAMES_WITH_PATH = new Set(['ls', 'grep']);
 
 export interface WorktreeRunContext {
   runtimeKey: string;
@@ -27,6 +31,7 @@ export interface CreateWorktreeIntegrationOptions extends FileWorktreeServiceOpt
   pluginName?: string;
   pluginVersion?: string;
   promptHeader?: string;
+  getDefaultToolBasePath?: () => string | undefined;
 }
 
 export interface CreateWorktreeEnginePluginOptions {
@@ -35,6 +40,7 @@ export interface CreateWorktreeEnginePluginOptions {
   name?: string;
   version?: string;
   promptHeader?: string;
+  getDefaultToolBasePath?: () => string | undefined;
 }
 
 export interface WorktreeIntegration {
@@ -57,6 +63,7 @@ export function createWorktreeIntegration(options: CreateWorktreeIntegrationOpti
     pluginName,
     pluginVersion,
     promptHeader,
+    getDefaultToolBasePath,
     ...serviceOptions
   } = options;
 
@@ -68,6 +75,7 @@ export function createWorktreeIntegration(options: CreateWorktreeIntegrationOpti
     name: pluginName,
     version: pluginVersion,
     promptHeader,
+    getDefaultToolBasePath,
   });
 
   return {
@@ -104,6 +112,34 @@ export function createWorktreeEnginePlugin(options: CreateWorktreeEnginePluginOp
         const append = buildBindingPrompt(promptHeader, binding);
         return {
           systemPrompt: appendSystemPrompt(systemPrompt, append),
+        };
+      });
+
+      context.registerHook('beforeToolCall', async ({ name, input }) => {
+        if (!isMutableObject(input)) {
+          return;
+        }
+
+        const runContext = options.getRunContext();
+        if (!runContext) {
+          return;
+        }
+
+        const binding = await options.service.getScopeBinding(toScope(runContext));
+        if (!binding) {
+          return;
+        }
+
+        const normalizedInput = normalizeToolInputForWorktree(name, input, {
+          worktreePath: binding.worktree.worktreePath,
+          defaultBasePath: options.getDefaultToolBasePath?.() ?? binding.worktree.worktreePath,
+        });
+        if (normalizedInput === input) {
+          return;
+        }
+
+        return {
+          input: normalizedInput,
         };
       });
     },
@@ -188,4 +224,78 @@ function appendSystemPrompt(base: SystemPromptOption | undefined, append: string
   return {
     append: currentAppend ? `${currentAppend}\n\n${normalizedAppend}` : normalizedAppend,
   };
+}
+
+function normalizeToolInputForWorktree(
+  toolName: string,
+  input: Record<string, unknown>,
+  options: {
+    worktreePath: string;
+    defaultBasePath: string;
+  },
+): Record<string, unknown> {
+  let changed = false;
+  const nextInput: Record<string, unknown> = { ...input };
+
+  if (toolName === 'bash') {
+    const cwdValue = toTrimmedString(input.cwd);
+    if (!cwdValue) {
+      nextInput.cwd = options.worktreePath;
+      changed = true;
+    } else {
+      const resolvedCwd = resolvePathAgainstBase(options.defaultBasePath, cwdValue);
+      if (resolvedCwd !== cwdValue) {
+        nextInput.cwd = resolvedCwd;
+        changed = true;
+      }
+    }
+  }
+
+  if (TOOL_NAMES_WITH_PATH.has(toolName)) {
+    const pathValue = toTrimmedString(input.path);
+    if (!pathValue) {
+      nextInput.path = options.worktreePath;
+      changed = true;
+    } else {
+      const resolvedPath = resolvePathAgainstBase(options.defaultBasePath, pathValue);
+      if (resolvedPath !== pathValue) {
+        nextInput.path = resolvedPath;
+        changed = true;
+      }
+    }
+  }
+
+  if (TOOL_NAMES_WITH_FILE_PATH.has(toolName)) {
+    const filePathValue = toTrimmedString(input.filePath);
+    if (filePathValue) {
+      const resolvedFilePath = resolvePathAgainstBase(options.defaultBasePath, filePathValue);
+      if (resolvedFilePath !== filePathValue) {
+        nextInput.filePath = resolvedFilePath;
+        changed = true;
+      }
+    }
+  }
+
+  return changed ? nextInput : input;
+}
+
+function resolvePathAgainstBase(basePath: string, value: string): string {
+  if (isAbsolute(value)) {
+    return value;
+  }
+
+  return resolve(basePath, value);
+}
+
+function toTrimmedString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function isMutableObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }


### PR DESCRIPTION
Ensure tool calls use repo-root defaults and worktree-bound execution paths for safer branch isolation.

- Align remote-server startup cwd to the git repo root and persist runtime repo root.
- Inject runtime repo root into worktree integration as default tool base path.
- Add beforeToolCall normalization for bash/ls/grep/read/write/edit:
  - keep explicit absolute paths unchanged
  - resolve relative paths against runtime base path
  - default missing cwd/path to the bound worktree path
- Update `/wt use <branch>` auto mode to resolve repo root from runtime base path.

Impact:
- Default execution starts at repo root when no worktree is bound.
- Tool execution is session-scoped to bound worktree paths, reducing accidental edits in main workspace.