### PR TITLE
Reapply shared agent runner refactor

### DIFF
--- a/apps/remote-server/package.json
+++ b/apps/remote-server/package.json
@@ -21,6 +21,7 @@
     "hono": "^4.6.0",
     "pulse-coder-engine": "workspace:*",
     "pulse-coder-memory-plugin": "workspace:*",
+    "pulse-coder-plugin-kit": "workspace:*",
     "undici": "^6.23.0",
     "zod": "^4.3.6"
   },

--- a/apps/remote-server/src/core/agent-runner.ts
+++ b/apps/remote-server/src/core/agent-runner.ts
@@ -1,0 +1,116 @@
+import type { ClarificationRequest } from './types.js';
+import type { CompactionEvent } from 'pulse-coder-engine';
+import { engine } from './engine-singleton.js';
+import { sessionStore } from './session-store.js';
+import { memoryIntegration, recordDailyLogFromSuccessPath } from './memory-integration.js';
+import { buildRemoteWorktreeRunContext, worktreeIntegration } from './worktree/integration.js';
+
+export type CompactionSnapshot = CompactionEvent;
+
+export interface AgentTurnCallbacks {
+  onText?: (delta: string) => void;
+  onToolCall?: (toolCall: any) => void;
+  onToolResult?: (toolResult: any) => void;
+  onClarificationRequest?: (request: ClarificationRequest) => Promise<string>;
+  onCompactionEvent?: (event: CompactionSnapshot) => void;
+}
+
+export interface ExecuteAgentTurnInput {
+  platformKey: string;
+  memoryKey: string;
+  forceNewSession?: boolean;
+  userText: string;
+  source: 'dispatcher' | 'internal';
+  abortSignal?: AbortSignal;
+  callbacks?: AgentTurnCallbacks;
+}
+
+export interface ExecuteAgentTurnResult {
+  sessionId: string;
+  resultText: string;
+  compactions: CompactionSnapshot[];
+}
+
+export async function executeAgentTurn(input: ExecuteAgentTurnInput): Promise<ExecuteAgentTurnResult> {
+  const session = await sessionStore.getOrCreate(input.platformKey, input.forceNewSession, input.memoryKey);
+  const sessionId = session.sessionId;
+  const context = session.context;
+  const callbacks = input.callbacks ?? {};
+  const compactions: CompactionSnapshot[] = [];
+
+  context.messages.push({ role: 'user', content: input.userText });
+
+  const resultText = await runWithAgentContexts(
+    {
+      platformKey: input.platformKey,
+      memoryKey: input.memoryKey,
+      sessionId,
+      userText: input.userText,
+    },
+    async () => engine.run(context, {
+      abortSignal: input.abortSignal,
+      onText: callbacks.onText,
+      onToolCall: callbacks.onToolCall,
+      onToolResult: callbacks.onToolResult,
+      onResponse: (messages) => {
+        for (const msg of messages) {
+          context.messages.push(msg);
+        }
+      },
+      onCompacted: (newMessages, event) => {
+        if (event) {
+          compactions.push(event);
+          callbacks.onCompactionEvent?.(event);
+        }
+        context.messages = newMessages;
+      },
+      onClarificationRequest: callbacks.onClarificationRequest,
+    }),
+  );
+
+  await sessionStore.save(sessionId, context);
+  await recordDailyLogFromSuccessPath({
+    platformKey: input.memoryKey,
+    sessionId,
+    userText: input.userText,
+    assistantText: resultText,
+    source: input.source,
+  });
+
+  return {
+    sessionId,
+    resultText,
+    compactions,
+  };
+}
+
+export async function runWithAgentContexts<T>(
+  input: {
+    platformKey: string;
+    memoryKey: string;
+    sessionId: string;
+    userText: string;
+  },
+  run: () => Promise<T>,
+): Promise<T> {
+  return worktreeIntegration.withRunContext(
+    buildRemoteWorktreeRunContext(input.platformKey),
+    async () => memoryIntegration.withRunContext(
+      {
+        platformKey: input.memoryKey,
+        sessionId: input.sessionId,
+        userText: input.userText,
+      },
+      run,
+    ),
+  );
+}
+
+export function formatCompactionEvents(events: CompactionSnapshot[]): string {
+  return events
+    .map((event) => {
+      const reason = event.reason ?? event.strategy;
+      return `#${event.attempt} ${event.trigger} ${reason} msgs:${event.beforeMessageCount}->${event.afterMessageCount} tokens:${event.beforeEstimatedTokens}->${event.afterEstimatedTokens}`;
+    })
+    .join(' | ');
+}

--- a/apps/remote-server/src/core/engine-singleton.ts
+++ b/apps/remote-server/src/core/engine-singleton.ts
@@ -1,5 +1,6 @@
 import { Engine } from 'pulse-coder-engine';
 import { memoryIntegration } from './memory-integration.js';
+import { worktreeIntegration } from './worktree/integration.js';
 
 /**
  * Single Engine instance shared across all platform adapters.
@@ -8,6 +9,9 @@ import { memoryIntegration } from './memory-integration.js';
  */
 export const engine = new Engine({
   enginePlugins: {
-    plugins: [memoryIntegration.enginePlugin],
+    plugins: [
+      memoryIntegration.enginePlugin,
+      worktreeIntegration.enginePlugin,
+    ],
   },
 });

--- a/apps/remote-server/src/core/worktree/commands.ts
+++ b/apps/remote-server/src/core/worktree/commands.ts
@@ -1,0 +1,235 @@
+import { worktreeService } from './integration.js';
+
+const COMMAND_PREFIX = '/wt';
+const MAX_PATH_LENGTH = 400;
+
+export interface WorktreeCommandResult {
+  handled: boolean;
+  message?: string;
+}
+
+interface ParsedTokens {
+  command: string;
+  args: string[];
+}
+
+interface UpdateBindingInput {
+  runtimeKey: string;
+  scopeKey: string;
+  id: string;
+  repoRoot: string;
+  worktreePath: string;
+  branch?: string;
+}
+
+export async function processWorktreeCommand(input: {
+  text: string;
+  runtimeKey: string;
+  scopeKey: string;
+}): Promise<WorktreeCommandResult> {
+  const raw = input.text.trim();
+  if (!raw.startsWith(COMMAND_PREFIX)) {
+    return { handled: false };
+  }
+
+  const tokens = parseTokens(raw);
+  if (!tokens) {
+    return {
+      handled: true,
+      message: buildHelpMessage(),
+    };
+  }
+
+  switch (tokens.command) {
+    case 'help':
+      return {
+        handled: true,
+        message: buildHelpMessage(),
+      };
+
+    case 'status': {
+      const binding = await worktreeService.getScopeBinding({
+        runtimeKey: input.runtimeKey,
+        scopeKey: input.scopeKey,
+      });
+
+      if (!binding) {
+        return {
+          handled: true,
+          message: [
+            '🧭 当前没有绑定 worktree。',
+            '使用 `/wt use <id> <repoRoot> <worktreePath> [branch]` 绑定。',
+          ].join('\n'),
+        };
+      }
+
+      const lines = [
+        '🧭 当前 worktree 绑定：',
+        `- id: ${binding.worktree.id}`,
+        `- repoRoot: ${binding.worktree.repoRoot}`,
+        `- worktreePath: ${binding.worktree.worktreePath}`,
+      ];
+
+      if (binding.worktree.branch) {
+        lines.push(`- branch: ${binding.worktree.branch}`);
+      }
+
+      return {
+        handled: true,
+        message: lines.join('\n'),
+      };
+    }
+
+    case 'use': {
+      const parseResult = parseUseArgs(tokens.args);
+      if (!parseResult.ok) {
+        return {
+          handled: true,
+          message: parseResult.reason,
+        };
+      }
+
+      const binding = await worktreeService.upsertAndBind(
+        {
+          runtimeKey: input.runtimeKey,
+          scopeKey: input.scopeKey,
+        },
+        {
+          id: parseResult.value.id,
+          repoRoot: parseResult.value.repoRoot,
+          worktreePath: parseResult.value.worktreePath,
+          branch: parseResult.value.branch,
+        },
+      );
+
+      const lines = [
+        '✅ 已更新 worktree 绑定。',
+        `- id: ${binding.worktree.id}`,
+        `- repoRoot: ${binding.worktree.repoRoot}`,
+        `- worktreePath: ${binding.worktree.worktreePath}`,
+      ];
+      if (binding.worktree.branch) {
+        lines.push(`- branch: ${binding.worktree.branch}`);
+      }
+
+      return {
+        handled: true,
+        message: lines.join('\n'),
+      };
+    }
+
+    case 'clear': {
+      const result = await worktreeService.clearScopeBinding({
+        runtimeKey: input.runtimeKey,
+        scopeKey: input.scopeKey,
+      });
+
+      if (!result.ok) {
+        return {
+          handled: true,
+          message: '❌ 清除绑定失败，请稍后重试。',
+        };
+      }
+
+      if (!result.cleared) {
+        return {
+          handled: true,
+          message: 'ℹ️ 当前没有 worktree 绑定。',
+        };
+      }
+
+      return {
+        handled: true,
+        message: `🧹 已清除绑定：${result.cleared.worktreeId}`,
+      };
+    }
+
+    default:
+      return {
+        handled: true,
+        message: `⚠️ 未知子命令：${tokens.command}\n\n${buildHelpMessage()}`,
+      };
+  }
+}
+
+export async function updateScopeWorktreeBinding(input: UpdateBindingInput): Promise<void> {
+  await worktreeService.upsertAndBind(
+    {
+      runtimeKey: input.runtimeKey,
+      scopeKey: input.scopeKey,
+    },
+    {
+      id: input.id,
+      repoRoot: input.repoRoot,
+      worktreePath: input.worktreePath,
+      branch: input.branch,
+    },
+  );
+}
+
+export async function clearScopeWorktreeBinding(input: { runtimeKey: string; scopeKey: string }): Promise<void> {
+  await worktreeService.clearScopeBinding({
+    runtimeKey: input.runtimeKey,
+    scopeKey: input.scopeKey,
+  });
+}
+
+function parseTokens(raw: string): ParsedTokens | null {
+  const parts = raw.split(/\s+/).filter((part) => part.length > 0);
+  if (parts.length === 0 || parts[0].toLowerCase() !== COMMAND_PREFIX) {
+    return null;
+  }
+
+  const command = (parts[1] ?? 'help').toLowerCase();
+  const args = parts.slice(2);
+  return { command, args };
+}
+
+function parseUseArgs(args: string[]):
+  | { ok: true; value: { id: string; repoRoot: string; worktreePath: string; branch?: string } }
+  | { ok: false; reason: string } {
+  if (args.length < 3) {
+    return {
+      ok: false,
+      reason: '❌ 参数不足\n用法：/wt use <id> <repoRoot> <worktreePath> [branch]',
+    };
+  }
+
+  const id = args[0]?.trim() ?? '';
+  const repoRoot = args[1]?.trim() ?? '';
+  const worktreePath = args[2]?.trim() ?? '';
+  const branch = args[3]?.trim();
+
+  if (!id || !repoRoot || !worktreePath) {
+    return {
+      ok: false,
+      reason: '❌ id/repoRoot/worktreePath 不能为空。',
+    };
+  }
+
+  if (repoRoot.length > MAX_PATH_LENGTH || worktreePath.length > MAX_PATH_LENGTH) {
+    return {
+      ok: false,
+      reason: '❌ 路径过长，请缩短后重试。',
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      id,
+      repoRoot,
+      worktreePath,
+      branch: branch || undefined,
+    },
+  };
+}
+
+function buildHelpMessage(): string {
+  return [
+    '🧩 Worktree 命令：',
+    '/wt status - 查看当前会话绑定的 worktree',
+    '/wt use <id> <repoRoot> <worktreePath> [branch] - 绑定/更新当前会话 worktree',
+    '/wt clear - 清除当前会话 worktree 绑定',
+  ].join('\n');
+}

--- a/apps/remote-server/src/core/worktree/integration.ts
+++ b/apps/remote-server/src/core/worktree/integration.ts
@@ -1,0 +1,29 @@
+import { homedir } from 'os';
+import { join } from 'path';
+import { createWorktreeIntegration } from 'pulse-coder-plugin-kit/worktree';
+
+const DEFAULT_RUNTIME_KEY = 'remote-server';
+
+export const worktreeIntegration = createWorktreeIntegration({
+  baseDir: join(homedir(), '.pulse-coder', 'worktree-state'),
+  pluginName: 'remote-worktree-binding',
+  pluginVersion: '0.0.1',
+});
+
+export const worktreeService = worktreeIntegration.service;
+
+export function buildRemoteWorktreeRunContext(scopeKey: string) {
+  return {
+    runtimeKey: resolveRemoteWorktreeRuntimeKey(),
+    scopeKey,
+  };
+}
+
+function resolveRemoteWorktreeRuntimeKey(): string {
+  const fromEnv = process.env.PULSE_CODER_WORKTREE_RUNTIME_KEY?.trim();
+  if (fromEnv) {
+    return fromEnv;
+  }
+
+  return DEFAULT_RUNTIME_KEY;
+}

--- a/apps/remote-server/src/index.ts
+++ b/apps/remote-server/src/index.ts
@@ -4,6 +4,7 @@ import { createApp } from './server.js';
 import { engine } from './core/engine-singleton.js';
 import { sessionStore } from './core/session-store.js';
 import { memoryIntegration } from './core/memory-integration.js';
+import { worktreeIntegration } from './core/worktree/integration.js';
 import { startDiscordGateway } from './adapters/discord/gateway-manager.js';
 
 async function main() {
@@ -12,6 +13,9 @@ async function main() {
 
   // Initialize memory store
   await memoryIntegration.initialize();
+
+  // Initialize worktree binding state store
+  await worktreeIntegration.initialize();
 
   await engine.initialize();
 

--- a/apps/remote-server/src/routes/internal.ts
+++ b/apps/remote-server/src/routes/internal.ts
@@ -5,9 +5,7 @@ import { getConnInfo } from '@hono/node-server/conninfo';
 import { createLarkClient, sendImageMessage, sendTextMessage } from '../adapters/feishu/client.js';
 import { extractGeminiImageResult } from '../adapters/feishu/image-result.js';
 import { getDiscordGatewayStatus, restartDiscordGateway } from '../adapters/discord/gateway-manager.js';
-import { engine } from '../core/engine-singleton.js';
-import { sessionStore } from '../core/session-store.js';
-import { memoryIntegration, recordDailyLogFromSuccessPath } from '../core/memory-integration.js';
+import { executeAgentTurn, formatCompactionEvents, type CompactionSnapshot } from '../core/agent-runner.js';
 import type { ClarificationRequest } from '../core/types.js';
 
 type ReceiveIdType = 'open_id' | 'chat_id' | 'user_id' | 'union_id' | 'email';
@@ -38,18 +36,6 @@ interface NotifyResult {
   ok: boolean;
   skipped: boolean;
   error?: string;
-}
-
-interface CompactionSnapshot {
-  attempt: number;
-  trigger: 'pre-loop' | 'length-retry';
-  reason?: string;
-  forced: boolean;
-  strategy: 'summary' | 'summary-too-large' | 'fallback';
-  beforeMessageCount: number;
-  afterMessageCount: number;
-  beforeEstimatedTokens: number;
-  afterEstimatedTokens: number;
 }
 
 interface ToolCallSnapshot {
@@ -132,19 +118,13 @@ internalRouter.post('/agent/run', async (c) => {
   const imageNotifyTasks: Promise<void>[] = [];
 
   try {
-    const session = await sessionStore.getOrCreate(platformKey, forceNewSession, platformKey);
-    sessionId = session.sessionId;
-    const context = session.context;
-
-    context.messages.push({ role: 'user', content: text });
-
-    const result = await memoryIntegration.withRunContext(
-      {
-        platformKey,
-        sessionId,
-        userText: text,
-      },
-      async () => engine.run(context, {
+    const turn = await executeAgentTurn({
+      platformKey,
+      memoryKey: platformKey,
+      forceNewSession,
+      userText: text,
+      source: 'internal',
+      callbacks: {
         onToolCall: (toolCall) => {
           const name = toolCall.toolName ?? toolCall.name ?? 'unknown';
           const input = toolCall.args ?? toolCall.input ?? {};
@@ -178,44 +158,16 @@ internalRouter.post('/agent/run', async (c) => {
               }),
           );
         },
-        onResponse: (messages) => {
-          for (const msg of messages) {
-            context.messages.push(msg);
-          }
-        },
-        onCompacted: (newMessages, event) => {
-          if (event) {
-            compactions.push({
-              attempt: event.attempt,
-              trigger: event.trigger,
-              reason: event.reason,
-              forced: event.forced,
-              strategy: event.strategy,
-              beforeMessageCount: event.beforeMessageCount,
-              afterMessageCount: event.afterMessageCount,
-              beforeEstimatedTokens: event.beforeEstimatedTokens,
-              afterEstimatedTokens: event.afterEstimatedTokens,
-            });
-          }
-
-          context.messages = newMessages;
-        },
         onClarificationRequest: async (request: ClarificationRequest) => {
           const answer = resolveClarificationAnswer(request, askPolicy);
           clarifications.push({ id: request.id, usedDefault: request.defaultAnswer !== undefined });
           return answer;
         },
-      }),
-    );
-
-    await sessionStore.save(sessionId, context);
-    await recordDailyLogFromSuccessPath({
-      platformKey,
-      sessionId,
-      userText: text,
-      assistantText: result,
-      source: 'internal',
+      },
     });
+
+    sessionId = turn.sessionId;
+    compactions.push(...turn.compactions);
 
     await Promise.allSettled(imageNotifyTasks);
 
@@ -231,7 +183,7 @@ internalRouter.post('/agent/run', async (c) => {
       skill: body.skill,
       sessionId,
       ok: true,
-      result,
+      result: turn.resultText,
     });
 
     return c.json({
@@ -240,7 +192,7 @@ internalRouter.post('/agent/run', async (c) => {
       platformKey,
       sessionId,
       requestText: text,
-      result,
+      result: turn.resultText,
       toolCalls,
       compactionCount: compactions.length,
       compactions,
@@ -279,16 +231,6 @@ internalRouter.post('/agent/run', async (c) => {
     );
   }
 });
-
-
-function formatCompactionEvents(events: CompactionSnapshot[]): string {
-  return events
-    .map((event) => {
-      const reason = event.reason ?? event.strategy;
-      return `#${event.attempt} ${event.trigger} ${reason} msgs:${event.beforeMessageCount}->${event.afterMessageCount} tokens:${event.beforeEstimatedTokens}->${event.afterEstimatedTokens}`;
-    })
-    .join(' | ');
-}
 
 function isLocalInternalRequest(c: Context): boolean {
   const connInfo = getConnInfo(c);

--- a/packages/plugin-kit/package.json
+++ b/packages/plugin-kit/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "pulse-coder-plugin-kit",
+  "version": "0.0.1",
+  "description": "Toolkit package for Pulse Coder runtime plugins",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./worktree": {
+      "types": "./dist/worktree.d.ts",
+      "import": "./dist/worktree.js",
+      "require": "./dist/worktree.cjs"
+    },
+    "./src": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    },
+    "./src/worktree": {
+      "types": "./src/worktree/index.ts",
+      "import": "./src/worktree/index.ts"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "pulse-coder-engine": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.10",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/plugin-kit/src/index.ts
+++ b/packages/plugin-kit/src/index.ts
@@ -1,0 +1,1 @@
+export * from './worktree/index.js';

--- a/packages/plugin-kit/src/worktree/index.ts
+++ b/packages/plugin-kit/src/worktree/index.ts
@@ -1,0 +1,3 @@
+export * from './types.js';
+export * from './service.js';
+export * from './integration.js';

--- a/packages/plugin-kit/src/worktree/integration.ts
+++ b/packages/plugin-kit/src/worktree/integration.ts
@@ -1,0 +1,191 @@
+import { AsyncLocalStorage } from 'async_hooks';
+import type { EnginePlugin, SystemPromptOption } from 'pulse-coder-engine';
+import type { FileWorktreeServiceOptions, UpsertWorktreeInput, WorktreeBindingView, WorktreeScope } from './types.js';
+import { FileWorktreePluginService } from './service.js';
+
+const DEFAULT_PROMPT = [
+  '## Git Worktree Binding',
+  'This runtime has a bound git worktree for the current session.',
+  '- Always run git, build, and file-editing commands in the bound worktree path.',
+  '- If a command result suggests another directory, treat that as unexpected and return to the bound worktree.',
+  '- Before major operations, validate context with `pwd && git branch --show-current && git status -sb`.',
+].join('\n');
+
+export interface WorktreeRunContext {
+  runtimeKey: string;
+  scopeKey: string;
+}
+
+export interface WorktreeRunContextAdapter {
+  withContext<T>(context: WorktreeRunContext, run: () => Promise<T>): Promise<T>;
+  getContext(): WorktreeRunContext | undefined;
+}
+
+export interface CreateWorktreeIntegrationOptions extends FileWorktreeServiceOptions {
+  service?: FileWorktreePluginService;
+  runContextAdapter?: WorktreeRunContextAdapter;
+  pluginName?: string;
+  pluginVersion?: string;
+  promptHeader?: string;
+}
+
+export interface CreateWorktreeEnginePluginOptions {
+  service: FileWorktreePluginService;
+  getRunContext: () => WorktreeRunContext | undefined;
+  name?: string;
+  version?: string;
+  promptHeader?: string;
+}
+
+export interface WorktreeIntegration {
+  service: FileWorktreePluginService;
+  enginePlugin: EnginePlugin;
+  initialize(): Promise<void>;
+  withRunContext<T>(context: WorktreeRunContext, run: () => Promise<T>): Promise<T>;
+  getRunContext(): WorktreeRunContext | undefined;
+}
+
+export interface SetWorktreeBindingInput extends UpsertWorktreeInput {
+  runtimeKey: string;
+  scopeKey: string;
+}
+
+export function createWorktreeIntegration(options: CreateWorktreeIntegrationOptions = {}): WorktreeIntegration {
+  const {
+    service,
+    runContextAdapter,
+    pluginName,
+    pluginVersion,
+    promptHeader,
+    ...serviceOptions
+  } = options;
+
+  const worktreeService = service ?? new FileWorktreePluginService(serviceOptions);
+  const adapter = runContextAdapter ?? createAsyncLocalRunContextAdapter();
+  const enginePlugin = createWorktreeEnginePlugin({
+    service: worktreeService,
+    getRunContext: () => adapter.getContext(),
+    name: pluginName,
+    version: pluginVersion,
+    promptHeader,
+  });
+
+  return {
+    service: worktreeService,
+    enginePlugin,
+    initialize: () => worktreeService.initialize(),
+    withRunContext: (context, run) => adapter.withContext(context, run),
+    getRunContext: () => adapter.getContext(),
+  };
+}
+
+export function createWorktreeEnginePlugin(options: CreateWorktreeEnginePluginOptions): EnginePlugin {
+  const pluginName = options.name ?? 'git-worktree-binding';
+  const pluginVersion = options.version ?? '0.0.1';
+  const promptHeader = options.promptHeader?.trim() || DEFAULT_PROMPT;
+
+  return {
+    name: pluginName,
+    version: pluginVersion,
+    async initialize(context) {
+      context.registerService('worktreeService', options.service);
+
+      context.registerHook('beforeRun', async ({ systemPrompt }) => {
+        const runContext = options.getRunContext();
+        if (!runContext) {
+          return;
+        }
+
+        const binding = await options.service.getScopeBinding(toScope(runContext));
+        if (!binding) {
+          return;
+        }
+
+        const append = buildBindingPrompt(promptHeader, binding);
+        return {
+          systemPrompt: appendSystemPrompt(systemPrompt, append),
+        };
+      });
+    },
+  };
+}
+
+export async function setWorktreeBinding(
+  service: FileWorktreePluginService,
+  input: SetWorktreeBindingInput,
+): Promise<WorktreeBindingView> {
+  const scope = toScope(input);
+  return service.upsertAndBind(scope, {
+    id: input.id,
+    repoRoot: input.repoRoot,
+    worktreePath: input.worktreePath,
+    branch: input.branch,
+  });
+}
+
+export async function clearWorktreeBinding(
+  service: FileWorktreePluginService,
+  scope: WorktreeRunContext,
+): Promise<boolean> {
+  const result = await service.clearScopeBinding(toScope(scope));
+  return result.ok;
+}
+
+function toScope(input: WorktreeRunContext): WorktreeScope {
+  return {
+    runtimeKey: input.runtimeKey,
+    scopeKey: input.scopeKey,
+  };
+}
+
+function buildBindingPrompt(header: string, binding: WorktreeBindingView): string {
+  const lines = [
+    header,
+    `- worktree.id: ${binding.worktree.id}`,
+    `- repo.root: ${binding.worktree.repoRoot}`,
+    `- worktree.path: ${binding.worktree.worktreePath}`,
+  ];
+
+  if (binding.worktree.branch) {
+    lines.push(`- git.branch: ${binding.worktree.branch}`);
+  }
+
+  return lines.join('\n');
+}
+
+function createAsyncLocalRunContextAdapter(): WorktreeRunContextAdapter {
+  const store = new AsyncLocalStorage<WorktreeRunContext>();
+
+  return {
+    withContext<T>(context: WorktreeRunContext, run: () => Promise<T>): Promise<T> {
+      return store.run(context, run);
+    },
+    getContext() {
+      return store.getStore();
+    },
+  };
+}
+
+function appendSystemPrompt(base: SystemPromptOption | undefined, append: string): SystemPromptOption {
+  const normalizedAppend = append.trim();
+  if (!normalizedAppend) {
+    return base ?? { append: '' };
+  }
+
+  if (!base) {
+    return { append: normalizedAppend };
+  }
+
+  if (typeof base === 'string') {
+    return `${base}\n\n${normalizedAppend}`;
+  }
+
+  if (typeof base === 'function') {
+    return () => `${base()}\n\n${normalizedAppend}`;
+  }
+
+  const currentAppend = base.append.trim();
+  return {
+    append: currentAppend ? `${currentAppend}\n\n${normalizedAppend}` : normalizedAppend,
+  };
+}

--- a/packages/plugin-kit/src/worktree/service.ts
+++ b/packages/plugin-kit/src/worktree/service.ts
@@ -1,0 +1,410 @@
+import { promises as fs } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import type {
+  FileWorktreeServiceOptions,
+  RemoveWorktreeResult,
+  UpsertWorktreeInput,
+  WorktreeBindingRecord,
+  WorktreeBindingView,
+  WorktreeRecord,
+  WorktreeScope,
+  WorktreeState,
+} from './types.js';
+
+const STATE_VERSION = 1;
+
+export interface BindScopeResult {
+  ok: boolean;
+  binding?: WorktreeBindingView;
+  reason?: string;
+}
+
+export interface ClearScopeResult {
+  ok: boolean;
+  cleared?: WorktreeBindingRecord;
+}
+
+export class FileWorktreePluginService {
+  private readonly baseDir: string;
+  private readonly statePath: string;
+
+  private state: WorktreeState = createEmptyState();
+  private initialized = false;
+  private initPromise: Promise<void> | null = null;
+  private operationQueue: Promise<void> = Promise.resolve();
+
+  constructor(options: FileWorktreeServiceOptions = {}) {
+    this.baseDir = options.baseDir ?? join(homedir(), '.pulse-coder', 'worktree-state');
+    this.statePath = join(this.baseDir, 'state.json');
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initialized) {
+      return;
+    }
+
+    if (this.initPromise) {
+      await this.initPromise;
+      return;
+    }
+
+    this.initPromise = this.runInitialize();
+    await this.initPromise;
+  }
+
+  async getScopeBinding(scope: WorktreeScope): Promise<WorktreeBindingView | undefined> {
+    return this.withLock(async () => {
+      const key = buildBindingKey(scope);
+      const binding = this.state.bindings[key];
+      if (!binding) {
+        return undefined;
+      }
+
+      const worktree = this.state.worktrees[binding.worktreeId];
+      if (!worktree) {
+        return undefined;
+      }
+
+      return {
+        binding: { ...binding },
+        worktree: { ...worktree },
+      };
+    });
+  }
+
+  async getWorktree(id: string): Promise<WorktreeRecord | undefined> {
+    const normalizedId = id.trim();
+    if (!normalizedId) {
+      return undefined;
+    }
+
+    return this.withLock(async () => {
+      const worktree = this.state.worktrees[normalizedId];
+      return worktree ? { ...worktree } : undefined;
+    });
+  }
+
+  async listWorktrees(): Promise<WorktreeRecord[]> {
+    return this.withLock(async () => {
+      return Object.values(this.state.worktrees)
+        .map((worktree) => ({ ...worktree }))
+        .sort((left, right) => right.updatedAt - left.updatedAt);
+    });
+  }
+
+  async listBindings(runtimeKey?: string): Promise<WorktreeBindingRecord[]> {
+    return this.withLock(async () => {
+      return Object.values(this.state.bindings)
+        .filter((binding) => !runtimeKey || binding.runtimeKey === runtimeKey)
+        .map((binding) => ({ ...binding }))
+        .sort((left, right) => right.updatedAt - left.updatedAt);
+    });
+  }
+
+  async upsertWorktree(input: UpsertWorktreeInput): Promise<WorktreeRecord> {
+    const normalized = normalizeUpsertInput(input);
+    if (!normalized) {
+      throw new Error('Invalid worktree input. id, repoRoot, and worktreePath are required.');
+    }
+
+    return this.withLock(async () => {
+      const now = Date.now();
+      const previous = this.state.worktrees[normalized.id];
+      const next: WorktreeRecord = {
+        id: normalized.id,
+        repoRoot: normalized.repoRoot,
+        worktreePath: normalized.worktreePath,
+        branch: normalized.branch,
+        createdAt: previous?.createdAt ?? now,
+        updatedAt: now,
+      };
+
+      this.state.worktrees[next.id] = next;
+      this.state.updatedAt = now;
+      await this.persistState();
+      return { ...next };
+    });
+  }
+
+  async bindScopeToWorktree(scope: WorktreeScope, worktreeId: string): Promise<BindScopeResult> {
+    const normalizedId = worktreeId.trim();
+    if (!normalizedId) {
+      return {
+        ok: false,
+        reason: 'worktree id is required',
+      };
+    }
+
+    return this.withLock(async () => {
+      const worktree = this.state.worktrees[normalizedId];
+      if (!worktree) {
+        return {
+          ok: false,
+          reason: `worktree not found: ${normalizedId}`,
+        };
+      }
+
+      const now = Date.now();
+      const key = buildBindingKey(scope);
+      const binding: WorktreeBindingRecord = {
+        key,
+        runtimeKey: scope.runtimeKey,
+        scopeKey: scope.scopeKey,
+        worktreeId: normalizedId,
+        updatedAt: now,
+      };
+
+      this.state.bindings[key] = binding;
+      this.state.updatedAt = now;
+      await this.persistState();
+
+      return {
+        ok: true,
+        binding: {
+          binding: { ...binding },
+          worktree: { ...worktree },
+        },
+      };
+    });
+  }
+
+  async upsertAndBind(scope: WorktreeScope, input: UpsertWorktreeInput): Promise<WorktreeBindingView> {
+    const normalized = normalizeUpsertInput(input);
+    if (!normalized) {
+      throw new Error('Invalid worktree input. id, repoRoot, and worktreePath are required.');
+    }
+
+    return this.withLock(async () => {
+      const now = Date.now();
+      const existingWorktree = this.state.worktrees[normalized.id];
+      const worktree: WorktreeRecord = {
+        id: normalized.id,
+        repoRoot: normalized.repoRoot,
+        worktreePath: normalized.worktreePath,
+        branch: normalized.branch,
+        createdAt: existingWorktree?.createdAt ?? now,
+        updatedAt: now,
+      };
+
+      const key = buildBindingKey(scope);
+      const binding: WorktreeBindingRecord = {
+        key,
+        runtimeKey: scope.runtimeKey,
+        scopeKey: scope.scopeKey,
+        worktreeId: worktree.id,
+        updatedAt: now,
+      };
+
+      this.state.worktrees[worktree.id] = worktree;
+      this.state.bindings[key] = binding;
+      this.state.updatedAt = now;
+      await this.persistState();
+
+      return {
+        binding: { ...binding },
+        worktree: { ...worktree },
+      };
+    });
+  }
+
+  async clearScopeBinding(scope: WorktreeScope): Promise<ClearScopeResult> {
+    return this.withLock(async () => {
+      const key = buildBindingKey(scope);
+      const existing = this.state.bindings[key];
+      if (!existing) {
+        return {
+          ok: true,
+        };
+      }
+
+      delete this.state.bindings[key];
+      this.state.updatedAt = Date.now();
+      await this.persistState();
+
+      return {
+        ok: true,
+        cleared: { ...existing },
+      };
+    });
+  }
+
+  async removeWorktree(id: string): Promise<RemoveWorktreeResult> {
+    const normalizedId = id.trim();
+    if (!normalizedId) {
+      return {
+        ok: false,
+        reason: 'worktree id is required',
+      };
+    }
+
+    return this.withLock(async () => {
+      const existing = this.state.worktrees[normalizedId];
+      if (!existing) {
+        return {
+          ok: false,
+          reason: `worktree not found: ${normalizedId}`,
+        };
+      }
+
+      delete this.state.worktrees[normalizedId];
+      for (const [key, binding] of Object.entries(this.state.bindings)) {
+        if (binding.worktreeId === normalizedId) {
+          delete this.state.bindings[key];
+        }
+      }
+
+      this.state.updatedAt = Date.now();
+      await this.persistState();
+      return {
+        ok: true,
+        removed: { ...existing },
+      };
+    });
+  }
+
+  private async runInitialize(): Promise<void> {
+    await fs.mkdir(this.baseDir, { recursive: true });
+
+    try {
+      const raw = await fs.readFile(this.statePath, 'utf-8');
+      this.state = normalizeState(raw);
+    } catch {
+      this.state = createEmptyState();
+    }
+
+    this.initialized = true;
+  }
+
+  private async withLock<T>(operation: () => Promise<T>): Promise<T> {
+    await this.initialize();
+
+    const run = this.operationQueue.then(operation, operation);
+    this.operationQueue = run.then(() => undefined, () => undefined);
+    return run;
+  }
+
+  private async persistState(): Promise<void> {
+    const serialized = JSON.stringify(this.state, null, 2);
+    const tempPath = join(this.baseDir, `.state.${process.pid}.${Date.now()}.tmp`);
+    await fs.writeFile(tempPath, serialized, 'utf-8');
+    await fs.rename(tempPath, this.statePath);
+  }
+}
+
+function buildBindingKey(scope: WorktreeScope): string {
+  return `${scope.runtimeKey}:${scope.scopeKey}`;
+}
+
+function normalizeUpsertInput(input: UpsertWorktreeInput): UpsertWorktreeInput | null {
+  const id = input.id.trim();
+  const repoRoot = input.repoRoot.trim();
+  const worktreePath = input.worktreePath.trim();
+  const branch = input.branch?.trim();
+
+  if (!id || !repoRoot || !worktreePath) {
+    return null;
+  }
+
+  return {
+    id,
+    repoRoot,
+    worktreePath,
+    branch: branch || undefined,
+  };
+}
+
+function createEmptyState(): WorktreeState {
+  return {
+    version: STATE_VERSION,
+    updatedAt: Date.now(),
+    worktrees: {},
+    bindings: {},
+  };
+}
+
+function normalizeState(raw: string): WorktreeState {
+  try {
+    const parsed = JSON.parse(raw) as Partial<WorktreeState>;
+    const worktrees = normalizeWorktrees(parsed.worktrees);
+    const bindings = normalizeBindings(parsed.bindings);
+
+    return {
+      version: STATE_VERSION,
+      updatedAt: typeof parsed.updatedAt === 'number' ? parsed.updatedAt : Date.now(),
+      worktrees,
+      bindings,
+    };
+  } catch {
+    return createEmptyState();
+  }
+}
+
+function normalizeWorktrees(input: unknown): Record<string, WorktreeRecord> {
+  if (!input || typeof input !== 'object') {
+    return {};
+  }
+
+  const normalized: Record<string, WorktreeRecord> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (!value || typeof value !== 'object') {
+      continue;
+    }
+
+    const candidate = value as Partial<WorktreeRecord>;
+    const id = typeof candidate.id === 'string' ? candidate.id.trim() : key.trim();
+    const repoRoot = typeof candidate.repoRoot === 'string' ? candidate.repoRoot.trim() : '';
+    const worktreePath = typeof candidate.worktreePath === 'string' ? candidate.worktreePath.trim() : '';
+    const branch = typeof candidate.branch === 'string' ? candidate.branch.trim() : undefined;
+    const createdAt = typeof candidate.createdAt === 'number' ? candidate.createdAt : Date.now();
+    const updatedAt = typeof candidate.updatedAt === 'number' ? candidate.updatedAt : createdAt;
+
+    if (!id || !repoRoot || !worktreePath) {
+      continue;
+    }
+
+    normalized[id] = {
+      id,
+      repoRoot,
+      worktreePath,
+      branch: branch || undefined,
+      createdAt,
+      updatedAt,
+    };
+  }
+
+  return normalized;
+}
+
+function normalizeBindings(input: unknown): Record<string, WorktreeBindingRecord> {
+  if (!input || typeof input !== 'object') {
+    return {};
+  }
+
+  const normalized: Record<string, WorktreeBindingRecord> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (!value || typeof value !== 'object') {
+      continue;
+    }
+
+    const candidate = value as Partial<WorktreeBindingRecord>;
+    const runtimeKey = typeof candidate.runtimeKey === 'string' ? candidate.runtimeKey.trim() : '';
+    const scopeKey = typeof candidate.scopeKey === 'string' ? candidate.scopeKey.trim() : '';
+    const worktreeId = typeof candidate.worktreeId === 'string' ? candidate.worktreeId.trim() : '';
+    const normalizedKey = `${runtimeKey}:${scopeKey}`;
+
+    if (!runtimeKey || !scopeKey || !worktreeId) {
+      continue;
+    }
+
+    normalized[normalizedKey] = {
+      key: normalizedKey,
+      runtimeKey,
+      scopeKey,
+      worktreeId,
+      updatedAt: typeof candidate.updatedAt === 'number' ? candidate.updatedAt : Date.now(),
+    };
+  }
+
+  return normalized;
+}

--- a/packages/plugin-kit/src/worktree/types.ts
+++ b/packages/plugin-kit/src/worktree/types.ts
@@ -1,0 +1,50 @@
+export interface WorktreeScope {
+  runtimeKey: string;
+  scopeKey: string;
+}
+
+export interface WorktreeRecord {
+  id: string;
+  repoRoot: string;
+  worktreePath: string;
+  branch?: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface WorktreeBindingRecord {
+  key: string;
+  runtimeKey: string;
+  scopeKey: string;
+  worktreeId: string;
+  updatedAt: number;
+}
+
+export interface WorktreeBindingView {
+  binding: WorktreeBindingRecord;
+  worktree: WorktreeRecord;
+}
+
+export interface WorktreeState {
+  version: 1;
+  updatedAt: number;
+  worktrees: Record<string, WorktreeRecord>;
+  bindings: Record<string, WorktreeBindingRecord>;
+}
+
+export interface FileWorktreeServiceOptions {
+  baseDir?: string;
+}
+
+export interface UpsertWorktreeInput {
+  id: string;
+  repoRoot: string;
+  worktreePath: string;
+  branch?: string;
+}
+
+export interface RemoveWorktreeResult {
+  ok: boolean;
+  reason?: string;
+  removed?: WorktreeRecord;
+}

--- a/packages/plugin-kit/tsconfig.json
+++ b/packages/plugin-kit/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugin-kit/tsup.config.ts
+++ b/packages/plugin-kit/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    worktree: 'src/worktree/index.ts',
+  },
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  splitting: false,
+  sourcemap: true,
+  target: 'es2022',
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       pulse-coder-memory-plugin:
         specifier: workspace:*
         version: link:../../packages/memory-plugin
+      pulse-coder-plugin-kit:
+        specifier: workspace:*
+        version: link:../../packages/plugin-kit
       undici:
         specifier: ^6.23.0
         version: 6.23.0
@@ -190,6 +193,25 @@ importers:
       '@types/better-sqlite3':
         specifier: ^7.6.12
         version: 7.6.13
+      '@types/node':
+        specifier: ^25.0.10
+        version: 25.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@25.0.10)
+
+  packages/plugin-kit:
+    dependencies:
+      pulse-coder-engine:
+        specifier: workspace:*
+        version: link:../engine
+    devDependencies:
       '@types/node':
         specifier: ^25.0.10
         version: 25.0.10

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,9 @@
     "noEmit": true,
     "paths": {
       "pulse-coder-engine": ["./packages/engine/src/index.ts"],
-      "pulse-coder-engine/*": ["./packages/engine/src/*"]
+      "pulse-coder-engine/*": ["./packages/engine/src/*"],
+      "pulse-coder-plugin-kit": ["./packages/plugin-kit/src/index.ts"],
+      "pulse-coder-plugin-kit/*": ["./packages/plugin-kit/src/*"]
     }
   },
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
Restore the extracted agent turn runner and worktree integration

- Reintroduce agent-runner module and dispatcher wiring
- Restore worktree command handling and integration hooks
- Bring back plugin-kit worktree service and types
- Re-add plugin-kit wiring in package.json/tsconfig/pnpm-lock