### PR TITLE
Introduce built-in agent teams plugin

### DIFF
--- a/packages/engine/src/built-in/agent-teams-plugin/aggregator.ts
+++ b/packages/engine/src/built-in/agent-teams-plugin/aggregator.ts
@@ -1,0 +1,16 @@
+import type { NodeResult } from './types';
+
+export interface AggregateOptions {
+  results: Record<string, NodeResult>;
+}
+
+export function aggregateResults(options: AggregateOptions): string {
+  const ordered = Object.values(options.results).sort((a, b) => a.startedAt - b.startedAt);
+  const sections = ordered.map(result => {
+    const header = `[${result.role}] ${result.status.toUpperCase()}`;
+    const body = result.output ?? result.error ?? result.skippedReason ?? '';
+    return `${header}\n${body}`.trim();
+  });
+
+  return sections.filter(Boolean).join('\n\n');
+}

--- a/packages/engine/src/built-in/agent-teams-plugin/graph.ts
+++ b/packages/engine/src/built-in/agent-teams-plugin/graph.ts
@@ -1,0 +1,93 @@
+import type { TaskGraph, TaskNode, TeamRole } from './types';
+
+export interface GraphBuildOptions {
+  task: string;
+  roles: TeamRole[];
+}
+
+export interface GraphValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+export function buildTaskGraph(options: GraphBuildOptions): TaskGraph {
+  const { task, roles } = options;
+  const nodes: TaskNode[] = [];
+
+  if (roles.includes('researcher')) {
+    nodes.push({
+      id: 'research',
+      role: 'researcher',
+      deps: [],
+      input: task,
+      optional: true
+    });
+  }
+
+  const executeDeps = nodes.map(node => node.id);
+  if (roles.includes('executor')) {
+    nodes.push({
+      id: 'execute',
+      role: 'executor',
+      deps: executeDeps,
+      input: task
+    });
+  }
+
+  const reviewDeps = nodes.length > 0 ? [nodes[nodes.length - 1].id] : [];
+  if (roles.includes('reviewer')) {
+    nodes.push({
+      id: 'review',
+      role: 'reviewer',
+      deps: reviewDeps,
+      input: task,
+      optional: true
+    });
+  }
+
+  const writeDeps = nodes.length > 0 ? [nodes[nodes.length - 1].id] : [];
+  if (roles.includes('writer')) {
+    nodes.push({
+      id: 'write',
+      role: 'writer',
+      deps: writeDeps,
+      input: task,
+      optional: true
+    });
+  }
+
+  const testDeps = nodes.length > 0 ? [nodes[nodes.length - 1].id] : [];
+  if (roles.includes('tester')) {
+    nodes.push({
+      id: 'test',
+      role: 'tester',
+      deps: testDeps,
+      input: task,
+      optional: true
+    });
+  }
+
+  return { nodes };
+}
+
+export function validateTaskGraph(graph: TaskGraph): GraphValidationResult {
+  const errors: string[] = [];
+  const ids = new Set<string>();
+
+  for (const node of graph.nodes) {
+    if (ids.has(node.id)) {
+      errors.push(`Duplicate node id: ${node.id}`);
+    }
+    ids.add(node.id);
+  }
+
+  for (const node of graph.nodes) {
+    for (const dep of node.deps) {
+      if (!ids.has(dep)) {
+        errors.push(`Missing dependency ${dep} for node ${node.id}`);
+      }
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}

--- a/packages/engine/src/built-in/agent-teams-plugin/index.ts
+++ b/packages/engine/src/built-in/agent-teams-plugin/index.ts
@@ -1,0 +1,106 @@
+import { z } from 'zod';
+
+import type { EnginePlugin, EnginePluginContext } from '../../plugin/EnginePlugin';
+import type { Tool } from '../../shared/types';
+
+import { RoleRegistry } from './registry';
+import { buildTaskGraph, validateTaskGraph } from './graph';
+import { routeRoles } from './router';
+import { runTaskGraph } from './scheduler';
+import { aggregateResults } from './aggregator';
+import type { TeamRole, TeamRunInput, TeamRunOutput, TaskGraph } from './types';
+
+const TEAM_RUN_INPUT_SCHEMA = z.object({
+  task: z.string().describe('要执行的任务描述'),
+  context: z.any().optional().describe('任务上下文信息'),
+  roles: z.array(z.string()).optional().describe('明确指定的角色列表'),
+  graph: z.any().optional().describe('自定义 TaskGraph'),
+  route: z.enum(['auto', 'all']).optional().describe('自动路由或全角色执行'),
+  includeRoles: z.array(z.string()).optional().describe('强制包含的角色'),
+  excludeRoles: z.array(z.string()).optional().describe('排除的角色'),
+  roleTools: z.record(z.string()).optional().describe('角色到工具名称映射'),
+  maxConcurrency: z.number().int().min(1).optional().describe('最大并发数'),
+  nodeTimeoutMs: z.number().int().min(0).optional().describe('单节点超时'),
+  retries: z.number().int().min(0).optional().describe('重试次数'),
+  aggregate: z.enum(['concat']).optional().describe('聚合策略')
+});
+
+const DEFAULT_MAX_CONCURRENCY = 3;
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
+const DEFAULT_RETRIES = 1;
+
+export const builtInAgentTeamsPlugin: EnginePlugin = {
+  name: 'pulse-coder-engine/built-in-agent-teams',
+  version: '1.0.0',
+  dependencies: ['sub-agent'],
+
+  async initialize(context: EnginePluginContext): Promise<void> {
+    const registry = new RoleRegistry();
+
+    const tool: Tool<TeamRunInput, TeamRunOutput> = {
+      name: 'agent_teams_run',
+      description: 'Run a fixed DAG agent team with role routing and aggregation.',
+      inputSchema: TEAM_RUN_INPUT_SCHEMA,
+      execute: async (input) => {
+        const roleTools = registry.resolveRoleTools(input.roleTools);
+        const tools = context.getTools();
+        const availableRoles = Object.keys(roleTools) as TeamRole[];
+
+        let roles: TeamRole[] = [];
+        if (input.roles && input.roles.length > 0) {
+          roles = input.roles as TeamRole[];
+        } else if (input.route === 'all') {
+          roles = availableRoles;
+        } else {
+          roles = routeRoles(input.task, availableRoles).roles;
+        }
+
+        if (input.includeRoles?.length) {
+          roles = Array.from(new Set([...roles, ...(input.includeRoles as TeamRole[])]));
+        }
+        if (input.excludeRoles?.length) {
+          const excluded = new Set(input.excludeRoles as TeamRole[]);
+          roles = roles.filter(role => !excluded.has(role));
+        }
+
+        let graph: TaskGraph;
+        if (input.graph) {
+          graph = input.graph as TaskGraph;
+        } else {
+          graph = buildTaskGraph({ task: input.task, roles });
+        }
+
+        const validation = validateTaskGraph(graph);
+        if (!validation.valid) {
+          throw new Error(`Invalid TaskGraph: ${validation.errors.join('; ')}`);
+        }
+
+        const results = await runTaskGraph({
+          context,
+          graph,
+          task: input.task,
+          maxConcurrency: input.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY,
+          retries: input.retries ?? DEFAULT_RETRIES,
+          nodeTimeoutMs: input.nodeTimeoutMs ?? DEFAULT_TIMEOUT_MS,
+          roleTools,
+          tools,
+          runContext: input.context
+        });
+
+        return {
+          task: input.task,
+          roles,
+          graph,
+          results,
+          aggregate: aggregateResults({ results })
+        };
+      }
+    };
+
+    context.registerTool('agent_teams_run', tool);
+    context.registerService('agentTeamsRoleRegistry', registry);
+    context.logger.info('[AgentTeams] Built-in agent teams plugin initialized');
+  }
+};
+
+export default builtInAgentTeamsPlugin;

--- a/packages/engine/src/built-in/agent-teams-plugin/registry.ts
+++ b/packages/engine/src/built-in/agent-teams-plugin/registry.ts
@@ -1,0 +1,35 @@
+import type { TeamRole } from './types';
+
+export interface RoleRegistryConfig {
+  roleTools?: Record<string, string>;
+}
+
+export class RoleRegistry {
+  private roleTools: Record<string, string>;
+
+  constructor(config?: RoleRegistryConfig) {
+    this.roleTools = { ...defaultRoleTools(), ...(config?.roleTools ?? {}) };
+  }
+
+  getTool(role: TeamRole): string | undefined {
+    return this.roleTools[role];
+  }
+
+  resolveRoleTools(overrides?: Record<string, string>): Record<string, string> {
+    return { ...this.roleTools, ...(overrides ?? {}) };
+  }
+
+  getRoles(): TeamRole[] {
+    return Object.keys(this.roleTools) as TeamRole[];
+  }
+}
+
+export function defaultRoleTools(): Record<string, string> {
+  return {
+    researcher: 'researcher_agent',
+    executor: 'executor_agent',
+    reviewer: 'reviewer_agent',
+    writer: 'writer_agent',
+    tester: 'tester_agent'
+  };
+}

--- a/packages/engine/src/built-in/agent-teams-plugin/router.ts
+++ b/packages/engine/src/built-in/agent-teams-plugin/router.ts
@@ -1,0 +1,39 @@
+import type { TeamRole } from './types';
+
+const DEFAULT_KEYWORDS = {
+  tester: [/\btest\b/i, /\btesting\b/i, /\btests\b/i, /\bqa\b/i, /测试/, /用例/],
+  writer: [/\bdoc\b/i, /\bdocs\b/i, /\bdocument\b/i, /\bdocumentation\b/i, /文档/, /说明/],
+  reviewer: [/\breview\b/i, /\bcode review\b/i, /评审/, /审查/]
+};
+
+export interface RouteDecision {
+  roles: TeamRole[];
+}
+
+export function routeRoles(task: string, availableRoles: TeamRole[]): RouteDecision {
+  const roles = new Set<TeamRole>();
+
+  if (availableRoles.includes('researcher')) {
+    roles.add('researcher');
+  }
+
+  if (availableRoles.includes('executor')) {
+    roles.add('executor');
+  }
+
+  const normalizedTask = task.toLowerCase();
+
+  if (availableRoles.includes('reviewer') && DEFAULT_KEYWORDS.reviewer.some(rule => rule.test(normalizedTask))) {
+    roles.add('reviewer');
+  }
+
+  if (availableRoles.includes('writer') && DEFAULT_KEYWORDS.writer.some(rule => rule.test(normalizedTask))) {
+    roles.add('writer');
+  }
+
+  if (availableRoles.includes('tester') && DEFAULT_KEYWORDS.tester.some(rule => rule.test(normalizedTask))) {
+    roles.add('tester');
+  }
+
+  return { roles: Array.from(roles) };
+}

--- a/packages/engine/src/built-in/agent-teams-plugin/scheduler.ts
+++ b/packages/engine/src/built-in/agent-teams-plugin/scheduler.ts
@@ -1,0 +1,203 @@
+import type { NodeResult, TaskGraph, TaskNode } from './types';
+import type { EnginePluginContext } from '../../plugin/EnginePlugin';
+
+export interface ScheduleOptions {
+  context: EnginePluginContext;
+  graph: TaskGraph;
+  task: string;
+  maxConcurrency: number;
+  retries: number;
+  nodeTimeoutMs: number;
+  roleTools: Record<string, string>;
+  tools: Record<string, any>;
+  runContext?: Record<string, any>;
+}
+
+export async function runTaskGraph(options: ScheduleOptions): Promise<Record<string, NodeResult>> {
+  const { graph, maxConcurrency, retries, nodeTimeoutMs } = options;
+  const nodes = graph.nodes;
+  const results: Record<string, NodeResult> = {};
+
+  if (nodes.length === 0) {
+    return results;
+  }
+
+  const pending = new Set<string>(nodes.map(node => node.id));
+  const inFlight = new Map<string, Promise<void>>();
+  const completed = new Set<string>();
+  const failed = new Set<string>();
+
+  const nodeById = new Map(nodes.map(node => [node.id, node] as const));
+
+  const canRunNode = (node: TaskNode): boolean => {
+    if (failed.size > 0) {
+      return false;
+    }
+    return node.deps.every(dep => completed.has(dep));
+  };
+
+  const markSkipped = (node: TaskNode, reason: string) => {
+    const now = Date.now();
+    results[node.id] = {
+      nodeId: node.id,
+      role: node.role,
+      status: 'skipped',
+      attempts: 0,
+      startedAt: now,
+      endedAt: now,
+      durationMs: 0,
+      skippedReason: reason
+    };
+    pending.delete(node.id);
+  };
+
+  const runNode = async (node: TaskNode) => {
+    const { context, task, roleTools, tools, runContext } = options;
+    const now = Date.now();
+    const result: NodeResult = {
+      nodeId: node.id,
+      role: node.role,
+      status: 'failed',
+      attempts: 0,
+      startedAt: now,
+      endedAt: now,
+      durationMs: 0
+    };
+
+    const toolName = node.tool ?? roleTools[node.role];
+    if (!toolName) {
+      const reason = `Missing tool for role ${node.role}`;
+      result.status = node.optional ? 'skipped' : 'failed';
+      result.error = reason;
+      result.skippedReason = node.optional ? reason : undefined;
+      result.endedAt = Date.now();
+      result.durationMs = result.endedAt - result.startedAt;
+      results[node.id] = result;
+      if (result.status === 'failed') {
+        failed.add(node.id);
+      }
+      return;
+    }
+
+    if (!tools[toolName]) {
+      const reason = `Tool not found: ${toolName}`;
+      result.status = node.optional ? 'skipped' : 'failed';
+      result.error = reason;
+      result.skippedReason = node.optional ? reason : undefined;
+      result.toolName = toolName;
+      result.endedAt = Date.now();
+      result.durationMs = result.endedAt - result.startedAt;
+      results[node.id] = result;
+      if (result.status === 'failed') {
+        failed.add(node.id);
+      }
+      return;
+    }
+
+    const runOnce = async () => {
+      const input = {
+        task: node.input ?? task,
+        context: {
+          task,
+          role: node.role,
+          nodeId: node.id,
+          deps: node.deps,
+          runContext
+        }
+      };
+      const tool = tools[toolName];
+      result.attempts += 1;
+      result.toolName = toolName;
+      const output = await tool.execute(input);
+      result.output = typeof output === 'string' ? output : JSON.stringify(output, null, 2);
+    };
+
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= retries; attempt += 1) {
+      try {
+        await withTimeout(runOnce(), nodeTimeoutMs);
+        result.status = 'success';
+        result.endedAt = Date.now();
+        result.durationMs = result.endedAt - result.startedAt;
+        results[node.id] = result;
+        completed.add(node.id);
+        return;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+
+    const errorMessage = lastError instanceof Error ? lastError.message : String(lastError ?? 'Unknown error');
+    result.status = node.optional ? 'skipped' : 'failed';
+    result.error = errorMessage;
+    result.skippedReason = node.optional ? errorMessage : undefined;
+    result.endedAt = Date.now();
+    result.durationMs = result.endedAt - result.startedAt;
+    results[node.id] = result;
+    if (result.status === 'failed') {
+      failed.add(node.id);
+    }
+  };
+
+  while (pending.size > 0) {
+    const runnable = Array.from(pending)
+      .map(id => nodeById.get(id))
+      .filter((node): node is TaskNode => !!node && canRunNode(node));
+
+    if (runnable.length === 0) {
+      if (failed.size > 0) {
+        for (const id of pending) {
+          const node = nodeById.get(id);
+          if (node) {
+            markSkipped(node, 'Blocked by failed dependency');
+          }
+        }
+        break;
+      }
+      throw new Error('No runnable nodes available; check DAG for cycles');
+    }
+
+    while (runnable.length > 0 && inFlight.size < maxConcurrency) {
+      const node = runnable.shift();
+      if (!node) {
+        continue;
+      }
+      pending.delete(node.id);
+      const promise = runNode(node).finally(() => {
+        inFlight.delete(node.id);
+      });
+      inFlight.set(node.id, promise);
+    }
+
+    if (inFlight.size > 0) {
+      await Promise.race(inFlight.values());
+    }
+  }
+
+  if (inFlight.size > 0) {
+    await Promise.all(inFlight.values());
+  }
+
+  return results;
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  if (!timeoutMs || timeoutMs <= 0) {
+    return promise;
+  }
+
+  let timeoutId: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(new Error('Node execution timed out'));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}

--- a/packages/engine/src/built-in/agent-teams-plugin/types.ts
+++ b/packages/engine/src/built-in/agent-teams-plugin/types.ts
@@ -1,0 +1,59 @@
+export type TeamRole =
+  | 'researcher'
+  | 'executor'
+  | 'reviewer'
+  | 'writer'
+  | 'tester'
+  | (string & {});
+
+export type TaskNodeStatus = 'success' | 'failed' | 'skipped';
+
+export interface TaskNode {
+  id: string;
+  role: TeamRole;
+  deps: string[];
+  input: string;
+  optional?: boolean;
+  tool?: string;
+}
+
+export interface TaskGraph {
+  nodes: TaskNode[];
+}
+
+export interface NodeResult {
+  nodeId: string;
+  role: TeamRole;
+  status: TaskNodeStatus;
+  toolName?: string;
+  output?: string;
+  error?: string;
+  attempts: number;
+  startedAt: number;
+  endedAt: number;
+  durationMs: number;
+  skippedReason?: string;
+}
+
+export interface TeamRunInput {
+  task: string;
+  context?: Record<string, any>;
+  roles?: TeamRole[];
+  graph?: TaskGraph;
+  route?: 'auto' | 'all';
+  includeRoles?: TeamRole[];
+  excludeRoles?: TeamRole[];
+  roleTools?: Record<string, string>;
+  maxConcurrency?: number;
+  nodeTimeoutMs?: number;
+  retries?: number;
+  aggregate?: 'concat';
+}
+
+export interface TeamRunOutput {
+  task: string;
+  roles: TeamRole[];
+  graph: TaskGraph;
+  results: Record<string, NodeResult>;
+  aggregate: string;
+}

--- a/packages/engine/src/built-in/index.ts
+++ b/packages/engine/src/built-in/index.ts
@@ -8,6 +8,7 @@ import { builtInSkillsPlugin } from './skills-plugin';
 import { builtInPlanModePlugin } from './plan-mode-plugin';
 import { builtInTaskTrackingPlugin } from './task-tracking-plugin';
 import { SubAgentPlugin } from './sub-agent-plugin';
+import { builtInAgentTeamsPlugin } from './agent-teams-plugin';
 
 /**
  * 默认内置插件列表
@@ -18,7 +19,8 @@ export const builtInPlugins = [
   builtInSkillsPlugin,
   builtInPlanModePlugin,
   builtInTaskTrackingPlugin,
-  new SubAgentPlugin()
+  new SubAgentPlugin(),
+  builtInAgentTeamsPlugin
 ];
 
 /**
@@ -29,6 +31,8 @@ export { builtInSkillsPlugin, BuiltInSkillRegistry } from './skills-plugin';
 export { builtInPlanModePlugin, BuiltInPlanModeService } from './plan-mode-plugin';
 export { builtInTaskTrackingPlugin, TaskListService } from './task-tracking-plugin';
 export type { TaskStatus, WorkTask, WorkTaskListSnapshot } from './task-tracking-plugin';
+export { builtInAgentTeamsPlugin } from './agent-teams-plugin';
+export type { TeamRole, TaskGraph, TaskNode, NodeResult, TeamRunInput, TeamRunOutput } from './agent-teams-plugin/types';
 export type {
   PlanMode,
   PlanIntentLabel,

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -30,6 +30,7 @@ export {
   builtInSkillsPlugin,
   builtInPlanModePlugin,
   builtInTaskTrackingPlugin,
+  builtInAgentTeamsPlugin,
   BuiltInSkillRegistry,
   BuiltInPlanModeService,
   TaskListService,
@@ -47,7 +48,13 @@ export type {
   PlanModeService,
   TaskStatus,
   WorkTask,
-  WorkTaskListSnapshot
+  WorkTaskListSnapshot,
+  TeamRole,
+  TaskGraph,
+  TaskNode,
+  NodeResult,
+  TeamRunInput,
+  TeamRunOutput
 } from './built-in/index.js';
 
 // 原有导出保持不变


### PR DESCRIPTION
Add built-in agent teams orchestration support

- Implement router, graph builder, scheduler, and aggregator modules
- Register agent_teams_run tool and role registry service
- Export the plugin in engine built-ins and public index