### PR TITLE
Add dynamic model selection config

### DIFF
--- a/apps/remote-server/.pulse-coder/config.json
+++ b/apps/remote-server/.pulse-coder/config.json
@@ -1,0 +1,6 @@
+{
+  "current_model": "gpt-5.2-codex",
+  "models": [
+    { "name": "gpt-5.2-codex" }
+  ]
+}

--- a/apps/remote-server/src/core/agent-runner.ts
+++ b/apps/remote-server/src/core/agent-runner.ts
@@ -4,6 +4,7 @@ import { engine } from './engine-singleton.js';
 import { sessionStore } from './session-store.js';
 import { memoryIntegration, recordDailyLogFromSuccessPath } from './memory-integration.js';
 import { buildRemoteWorktreeRunContext, worktreeIntegration } from './worktree/integration.js';
+import { resolveModelForRun } from './model-config.js';
 
 export type CompactionSnapshot = CompactionEvent;
 
@@ -37,6 +38,7 @@ export async function executeAgentTurn(input: ExecuteAgentTurnInput): Promise<Ex
   const context = session.context;
   const callbacks = input.callbacks ?? {};
   const compactions: CompactionSnapshot[] = [];
+  const modelOverride = await resolveModelForRun(input.platformKey);
 
   context.messages.push({ role: 'user', content: input.userText });
 
@@ -48,6 +50,7 @@ export async function executeAgentTurn(input: ExecuteAgentTurnInput): Promise<Ex
       userText: input.userText,
     },
     async () => engine.run(context, {
+      model: modelOverride,
       abortSignal: input.abortSignal,
       onText: callbacks.onText,
       onToolCall: callbacks.onToolCall,

--- a/apps/remote-server/src/core/model-config.ts
+++ b/apps/remote-server/src/core/model-config.ts
@@ -1,0 +1,99 @@
+import { promises as fs } from 'fs';
+import { homedir } from 'os';
+import { join, resolve } from 'path';
+
+type ModelConfig = {
+  current_model?: string;
+  models?: Array<{
+    name?: string;
+  }>;
+};
+
+type CachedConfig = {
+  path: string;
+  mtimeMs: number;
+  data: ModelConfig | null;
+};
+
+let cachedConfig: CachedConfig | null = null;
+
+function normalizeModel(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+async function findConfigPath(): Promise<string | null> {
+  const candidates: string[] = [];
+  const envPath = process.env.PULSE_CODER_MODEL_CONFIG?.trim();
+  if (envPath) {
+    candidates.push(envPath);
+  }
+
+  candidates.push(resolve(process.cwd(), '.pulse-coder', 'config.json'));
+  candidates.push(join(homedir(), '.pulse-coder', 'config.json'));
+
+  for (const candidate of candidates) {
+    try {
+      const stat = await fs.stat(candidate);
+      if (stat.isFile()) {
+        return candidate;
+      }
+    } catch {
+      // Ignore missing files.
+    }
+  }
+
+  return null;
+}
+
+async function readConfig(path: string): Promise<ModelConfig | null> {
+  try {
+    const raw = await fs.readFile(path, 'utf8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as ModelConfig;
+  } catch (error) {
+    console.warn('[model-config] failed to parse model config:', error);
+    return null;
+  }
+}
+
+function selectModel(config: ModelConfig | null): string | null {
+  if (!config) {
+    return null;
+  }
+
+  const current = normalizeModel(config.current_model);
+  if (current) {
+    return current;
+  }
+
+  const firstModel = Array.isArray(config.models) ? config.models[0] : null;
+  return normalizeModel(firstModel?.name);
+}
+
+export async function resolveModelForRun(_platformKey: string): Promise<string | undefined> {
+  const configPath = await findConfigPath();
+  if (!configPath) {
+    return undefined;
+  }
+
+  try {
+    const stat = await fs.stat(configPath);
+    if (cachedConfig && cachedConfig.path === configPath && cachedConfig.mtimeMs === stat.mtimeMs) {
+      return selectModel(cachedConfig.data) ?? undefined;
+    }
+
+    const data = await readConfig(configPath);
+    cachedConfig = { path: configPath, mtimeMs: stat.mtimeMs, data };
+    return selectModel(data) ?? undefined;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
Introduce runtime model selection for remote-server

- Read current_model/models from .pulse-coder config
- Pass model override into engine.run
- Add default gpt-5.2-codex config file