### PR TITLE
Add built-in tool search and deferred loading

### DIFF
--- a/apps/remote-server/README.md
+++ b/apps/remote-server/README.md
@@ -1,5 +1,24 @@
 # remote-server
 
+## Deferred tool demo
+
+A demo tool named `deferred_demo` is registered with `defer_loading: true`.
+It will not be sent to the AI SDK until it is discovered via tool search.
+
+Quick test (local-only internal endpoint):
+
+```bash
+curl -sS -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $INTERNAL_API_SECRET" \
+  http://127.0.0.1:3000/internal/agent/run \
+  -d '{"text":"Use tool_search_tool_bm25 to find the deferred_demo tool, then call it with message=hello."}'
+```
+
+Expected behavior:
+- First run: model uses tool search and discovers `deferred_demo`.
+- Second run: `deferred_demo` is now loaded and can be called directly.
+
 ## Enabled webhook endpoints
 
 - `POST /webhooks/feishu`

--- a/apps/remote-server/src/core/engine-singleton.ts
+++ b/apps/remote-server/src/core/engine-singleton.ts
@@ -2,6 +2,7 @@ import { Engine } from 'pulse-coder-engine';
 import { memoryIntegration } from './memory-integration.js';
 import { worktreeIntegration } from './worktree/integration.js';
 import { cronJobTool } from './tools/cron-job.js';
+import { deferDemoTool } from './tools/defer-demo.js';
 import { jinaAiReadTool } from './tools/jina-ai.js';
 import { sessionSummaryTool } from './tools/session-summary.js';
 
@@ -19,6 +20,7 @@ export const engine = new Engine({
   },
   tools: {
     cron_job: cronJobTool,
+    deferred_demo: deferDemoTool,
     jina_ai_read: jinaAiReadTool,
     session_summary: sessionSummaryTool,
   },

--- a/apps/remote-server/src/core/tools/defer-demo.ts
+++ b/apps/remote-server/src/core/tools/defer-demo.ts
@@ -1,0 +1,28 @@
+import z from 'zod';
+import type { Tool } from 'pulse-coder-engine';
+
+const toolSchema = z.object({
+  message: z.string().min(1).describe('Message to echo back.'),
+});
+
+type DeferDemoInput = z.infer<typeof toolSchema>;
+
+type DeferDemoResult = {
+  ok: true;
+  echoed: string;
+  receivedAt: string;
+};
+
+export const deferDemoTool: Tool<DeferDemoInput, DeferDemoResult> = {
+  name: 'deferred_demo',
+  description: 'Demo deferred tool that echoes a short message.',
+  inputSchema: toolSchema,
+  defer_loading: true,
+  execute: async (input) => {
+    return {
+      ok: true,
+      echoed: input.message,
+      receivedAt: new Date().toISOString(),
+    };
+  },
+};

--- a/packages/engine/src/built-in/index.ts
+++ b/packages/engine/src/built-in/index.ts
@@ -6,6 +6,7 @@
 import { builtInMCPPlugin } from './mcp-plugin';
 import { builtInSkillsPlugin } from './skills-plugin';
 import { builtInPlanModePlugin } from './plan-mode-plugin';
+import { builtInToolSearchPlugin } from './tool-search-plugin';
 import { builtInTaskTrackingPlugin } from './task-tracking-plugin';
 import { SubAgentPlugin } from './sub-agent-plugin';
 import { builtInAgentTeamsPlugin } from './agent-teams-plugin';
@@ -17,6 +18,7 @@ import { builtInAgentTeamsPlugin } from './agent-teams-plugin';
 export const builtInPlugins = [
   builtInMCPPlugin,
   builtInSkillsPlugin,
+  builtInToolSearchPlugin,
   builtInPlanModePlugin,
   builtInTaskTrackingPlugin,
   new SubAgentPlugin(),
@@ -29,6 +31,8 @@ export const builtInPlugins = [
 export { builtInMCPPlugin } from './mcp-plugin';
 export { builtInSkillsPlugin, BuiltInSkillRegistry } from './skills-plugin';
 export { builtInPlanModePlugin, BuiltInPlanModeService } from './plan-mode-plugin';
+export { builtInToolSearchPlugin } from './tool-search-plugin';
+export type { ToolSearchDeferredSummary } from './tool-search-plugin';
 export { builtInTaskTrackingPlugin, TaskListService } from './task-tracking-plugin';
 export type { TaskStatus, WorkTask, WorkTaskListSnapshot } from './task-tracking-plugin';
 export { builtInAgentTeamsPlugin } from './agent-teams-plugin';

--- a/packages/engine/src/built-in/tool-search-plugin/index.ts
+++ b/packages/engine/src/built-in/tool-search-plugin/index.ts
@@ -1,0 +1,2 @@
+export { builtInToolSearchPlugin } from './tool-search-plugin';
+export type { ToolSearchDeferredSummary } from './tool-search-plugin';

--- a/packages/engine/src/built-in/tool-search-plugin/tool-search-plugin.ts
+++ b/packages/engine/src/built-in/tool-search-plugin/tool-search-plugin.ts
@@ -1,0 +1,652 @@
+import type { EnginePlugin, EnginePluginContext } from '../../plugin/EnginePlugin';
+import type { ModelMessage } from 'ai';
+import type { SystemPromptOption, Tool } from '../../shared/types';
+import { z } from 'zod';
+import {
+  buildToolSearchReferenceResult,
+  buildToolSearchSummary,
+  filterImmediateTools,
+  getSearchableToolCatalog,
+  searchToolsBm25,
+  searchToolsRegex,
+  type ToolSearchVariant,
+} from './utils';
+
+type ToolSearchResultPayload = {
+  type: 'tool_search_tool_search_result';
+  tool_references: Array<{ type: 'tool_reference'; tool_name: string }>;
+};
+
+type ToolSearchConfig = {
+  enabled: boolean;
+  variant: ToolSearchVariant;
+  limit: number;
+  candidates: number;
+  maxRegexQueryLength: number;
+  exposeSummary: boolean;
+};
+
+const DEFAULT_CONFIG: ToolSearchConfig = {
+  enabled: true,
+  variant: 'bm25',
+  limit: 10,
+  candidates: 20,
+  maxRegexQueryLength: 200,
+  exposeSummary: true,
+};
+
+const TOOL_SEARCH_SERVICE_NAME = 'toolSearchService';
+
+const parseBoolean = (value: string | undefined, fallback: boolean): boolean => {
+  if (value === undefined) {
+    return fallback;
+  }
+  return ['1', 'true', 'yes', 'on'].includes(value.toLowerCase());
+};
+
+const parseNumber = (value: string | undefined, fallback: number): number => {
+  if (!value) {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
+};
+
+const VALID_VARIANTS: ToolSearchVariant[] = ['regex', 'bm25'];
+
+const buildConfig = (): ToolSearchConfig => {
+  const rawVariant = process.env.PULSE_CODER_TOOL_SEARCH_VARIANT;
+  const variant = VALID_VARIANTS.includes(rawVariant as ToolSearchVariant)
+    ? (rawVariant as ToolSearchVariant)
+    : DEFAULT_CONFIG.variant;
+
+  return {
+    enabled: parseBoolean(process.env.PULSE_CODER_TOOL_SEARCH_ENABLED, DEFAULT_CONFIG.enabled),
+    variant,
+    limit: parseNumber(process.env.PULSE_CODER_TOOL_SEARCH_LIMIT, DEFAULT_CONFIG.limit),
+    candidates: parseNumber(process.env.PULSE_CODER_TOOL_SEARCH_CANDIDATES, DEFAULT_CONFIG.candidates),
+    maxRegexQueryLength: parseNumber(
+      process.env.PULSE_CODER_TOOL_SEARCH_MAX_REGEX_LENGTH,
+      DEFAULT_CONFIG.maxRegexQueryLength
+    ),
+    exposeSummary: parseBoolean(process.env.PULSE_CODER_TOOL_SEARCH_SUMMARY, DEFAULT_CONFIG.exposeSummary),
+  };
+};
+
+const searchToolSchema = z.object({
+  query: z.string().describe('Query string for tool search'),
+  limit: z.number().optional().describe('Maximum number of tools to return'),
+});
+
+type SearchToolInput = z.infer<typeof searchToolSchema>;
+
+function selectSearchTools(tools: Record<string, Tool>): Record<string, Tool> {
+  return getSearchableToolCatalog(tools);
+}
+
+function buildSearchResult(
+  tools: Record<string, Tool>,
+  input: SearchToolInput,
+  variant: ToolSearchVariant,
+  config: ToolSearchConfig
+): ToolSearchResultPayload {
+  const effectiveLimit = input.limit ?? config.limit;
+  const effectiveCatalog = getSearchableToolCatalog(tools);
+
+  if (variant === 'regex') {
+    const query = input.query;
+    if (query.length > config.maxRegexQueryLength) {
+      throw new Error(`Regex query exceeds ${config.maxRegexQueryLength} characters`);
+    }
+    const matches = searchToolsRegex(effectiveCatalog, query, { limit: effectiveLimit });
+    return buildToolSearchReferenceResult(matches, { limit: effectiveLimit });
+  }
+
+  const matches = searchToolsBm25(effectiveCatalog, input.query, {
+    limit: effectiveLimit,
+    candidates: config.candidates,
+  });
+  return buildToolSearchReferenceResult(matches, { limit: effectiveLimit });
+}
+
+function createRegexTool(context: EnginePluginContext, config: ToolSearchConfig): Tool<SearchToolInput, ToolSearchResultPayload> {
+  return {
+    name: 'tool_search_tool_regex',
+    description: 'Search available tools using a Python-style regex query.',
+    inputSchema: searchToolSchema,
+    execute: async (input: SearchToolInput) => {
+      const tools = context.getTools();
+      return buildSearchResult(tools, input, 'regex', config);
+    },
+  };
+}
+
+function createBm25Tool(context: EnginePluginContext, config: ToolSearchConfig): Tool<SearchToolInput, ToolSearchResultPayload> {
+  return {
+    name: 'tool_search_tool_bm25',
+    description: 'Search available tools using natural language queries.',
+    inputSchema: searchToolSchema,
+    execute: async (input: SearchToolInput) => {
+      const tools = context.getTools();
+      return buildSearchResult(tools, input, 'bm25', config);
+    },
+  };
+}
+
+function buildToolSearchSystemAppend(tools: Record<string, Tool>, config: ToolSearchConfig): string {
+  const lines: string[] = [
+    'Tool search is available for deferred tools.',
+    'Use tool_search_tool_bm25 for natural language queries, or tool_search_tool_regex for regex.',
+    'Deferred tools are not listed explicitly; use tool search and call tools by name after discovery.',
+  ];
+
+  if (config.exposeSummary) {
+    lines.push(buildToolSearchSummary(tools));
+  }
+
+  return lines.join('\n');
+}
+
+class ToolSearchService {
+  private readonly config: ToolSearchConfig;
+  private readonly logger: EnginePluginContext['logger'];
+  private readonly loadedToolNames = new Set<string>();
+
+  constructor(config: ToolSearchConfig, logger: EnginePluginContext['logger']) {
+    this.config = config;
+    this.logger = logger;
+  }
+
+  getConfig(): ToolSearchConfig {
+    return this.config;
+  }
+
+  buildSystemPrompt(tools: Record<string, Tool>): string {
+    return buildToolSearchSystemAppend(tools, this.config);
+  }
+
+  splitTools(tools: Record<string, Tool>): { immediate: Record<string, Tool>; deferred: Record<string, Tool> } {
+    return {
+      immediate: filterImmediateTools(tools),
+      deferred: selectSearchTools(tools),
+    };
+  }
+
+  getLoadedTools(tools: Record<string, Tool>): Record<string, Tool> {
+    const loaded: Record<string, Tool> = {};
+    for (const name of this.loadedToolNames) {
+      const tool = tools[name];
+      if (tool) {
+        loaded[name] = tool;
+      }
+    }
+    return loaded;
+  }
+
+  addLoadedTools(toolNames: string[]): string[] {
+    const added: string[] = [];
+    for (const name of toolNames) {
+      if (!name || this.loadedToolNames.has(name)) {
+        continue;
+      }
+      this.loadedToolNames.add(name);
+      added.push(name);
+    }
+    return added;
+  }
+}
+
+function appendSystemPrompt(base: SystemPromptOption | undefined, append: string): SystemPromptOption {
+  if (!append.trim()) {
+    return base ?? { append: '' };
+  }
+
+  if (!base) {
+    return { append };
+  }
+
+  if (typeof base === 'string') {
+    return `${base}\n\n${append}`;
+  }
+
+  if (typeof base === 'function') {
+    return () => `${base()}\n\n${append}`;
+  }
+
+  const currentAppend = base.append.trim();
+  return {
+    append: currentAppend ? `${currentAppend}\n\n${append}` : append,
+  };
+}
+
+function extractToolReferences(messages: ModelMessage[]): string[] {
+  if (!messages.length) {
+    return [];
+  }
+
+  const latest = messages[messages.length - 1];
+  if (!latest || latest.role !== 'assistant') {
+    return [];
+  }
+
+  if (!Array.isArray(latest.content)) {
+    return [];
+  }
+
+  const references: string[] = [];
+  for (const part of latest.content) {
+    if (!part || typeof part !== 'object') {
+      continue;
+    }
+
+    const type = (part as { type?: string }).type;
+    if (type !== 'tool-result') {
+      continue;
+    }
+
+    const output = (part as { output?: unknown }).output as { tool_references?: Array<{ tool_name?: string }> } | undefined;
+    const toolReferences = output?.tool_references;
+    if (!Array.isArray(toolReferences)) {
+      continue;
+    }
+
+    for (const ref of toolReferences) {
+      const toolName = ref?.tool_name;
+      if (!toolName) {
+        continue;
+      }
+      references.push(toolName);
+    }
+  }
+
+  return references;
+}
+
+export const builtInToolSearchPlugin: EnginePlugin = {
+  name: 'pulse-coder-engine/built-in-tool-search',
+  version: '0.1.0',
+  async initialize(context: EnginePluginContext) {
+    const config = buildConfig();
+    if (!config.enabled) {
+      context.logger.info('[ToolSearch] Disabled via config');
+      return;
+    }
+
+    const regexTool = createRegexTool(context, config);
+    const bm25Tool = createBm25Tool(context, config);
+
+    context.registerTool(regexTool.name, regexTool);
+    context.registerTool(bm25Tool.name, bm25Tool);
+
+    const service = new ToolSearchService(config, context.logger);
+    context.registerService(TOOL_SEARCH_SERVICE_NAME, service);
+
+    context.registerHook('beforeLLMCall', ({ tools, systemPrompt }) => {
+      const toolSearchService = context.getService<ToolSearchService>(TOOL_SEARCH_SERVICE_NAME) ?? service;
+      const split = toolSearchService.splitTools(tools);
+      const loadedTools = toolSearchService.getLoadedTools(tools);
+      const nextPrompt = appendSystemPrompt(systemPrompt, toolSearchService.buildSystemPrompt(tools));
+
+      return {
+        tools: {
+          ...split.immediate,
+          ...loadedTools,
+          [regexTool.name]: regexTool,
+          [bm25Tool.name]: bm25Tool,
+        },
+        systemPrompt: nextPrompt,
+      };
+    });
+
+    context.registerHook('afterLLMCall', ({ context: runContext, finishReason }) => {
+      if (finishReason !== 'tool-calls') {
+        return;
+      }
+
+      const references = extractToolReferences(runContext.messages);
+      if (references.length === 0) {
+        return;
+      }
+
+      const added = service.addLoadedTools(references);
+      if (added.length === 0) {
+        return;
+      }
+
+      runContext.messages.push({
+        role: 'system',
+        content: `Tool search loaded: ${added.join(', ')}`,
+      });
+    });
+
+    context.logger.info('[ToolSearch] Built-in tool search plugin initialized', {
+      variant: config.variant,
+      limit: config.limit,
+      candidates: config.candidates,
+    });
+  },
+};
+
+export default builtInToolSearchPlugin;
+type ToolSearchResultPayload = {
+  type: 'tool_search_tool_search_result';
+  tool_references: Array<{ type: 'tool_reference'; tool_name: string }>;
+};
+
+type ToolSearchConfig = {
+  enabled: boolean;
+  variant: ToolSearchVariant;
+  limit: number;
+  candidates: number;
+  maxRegexQueryLength: number;
+  exposeSummary: boolean;
+};
+
+const DEFAULT_CONFIG: ToolSearchConfig = {
+  enabled: true,
+  variant: 'bm25',
+  limit: 10,
+  candidates: 20,
+  maxRegexQueryLength: 200,
+  exposeSummary: true,
+};
+
+const TOOL_SEARCH_SERVICE_NAME = 'toolSearchService';
+
+const parseBoolean = (value: string | undefined, fallback: boolean): boolean => {
+  if (value === undefined) {
+    return fallback;
+  }
+  return ['1', 'true', 'yes', 'on'].includes(value.toLowerCase());
+};
+
+const parseNumber = (value: string | undefined, fallback: number): number => {
+  if (!value) {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
+};
+
+const VALID_VARIANTS: ToolSearchVariant[] = ['regex', 'bm25'];
+
+const buildConfig = (): ToolSearchConfig => {
+  const rawVariant = process.env.PULSE_CODER_TOOL_SEARCH_VARIANT;
+  const variant = VALID_VARIANTS.includes(rawVariant as ToolSearchVariant)
+    ? (rawVariant as ToolSearchVariant)
+    : DEFAULT_CONFIG.variant;
+
+  return {
+    enabled: parseBoolean(process.env.PULSE_CODER_TOOL_SEARCH_ENABLED, DEFAULT_CONFIG.enabled),
+    variant,
+    limit: parseNumber(process.env.PULSE_CODER_TOOL_SEARCH_LIMIT, DEFAULT_CONFIG.limit),
+    candidates: parseNumber(process.env.PULSE_CODER_TOOL_SEARCH_CANDIDATES, DEFAULT_CONFIG.candidates),
+    maxRegexQueryLength: parseNumber(
+      process.env.PULSE_CODER_TOOL_SEARCH_MAX_REGEX_LENGTH,
+      DEFAULT_CONFIG.maxRegexQueryLength
+    ),
+    exposeSummary: parseBoolean(process.env.PULSE_CODER_TOOL_SEARCH_SUMMARY, DEFAULT_CONFIG.exposeSummary),
+  };
+};
+
+const searchToolSchema = z.object({
+  query: z.string().describe('Query string for tool search'),
+  limit: z.number().optional().describe('Maximum number of tools to return'),
+});
+
+type SearchToolInput = z.infer<typeof searchToolSchema>;
+
+function selectSearchTools(tools: Record<string, Tool>): Record<string, Tool> {
+  return getSearchableToolCatalog(tools);
+}
+
+function buildSearchResult(
+  tools: Record<string, Tool>,
+  input: SearchToolInput,
+  variant: ToolSearchVariant,
+  config: ToolSearchConfig
+): ToolSearchResultPayload {
+  const effectiveLimit = input.limit ?? config.limit;
+  const effectiveCatalog = getSearchableToolCatalog(tools);
+
+  if (variant === 'regex') {
+    const query = input.query;
+    if (query.length > config.maxRegexQueryLength) {
+      throw new Error(`Regex query exceeds ${config.maxRegexQueryLength} characters`);
+    }
+    const matches = searchToolsRegex(effectiveCatalog, query, { limit: effectiveLimit });
+    return buildToolSearchReferenceResult(matches, { limit: effectiveLimit });
+  }
+
+  const matches = searchToolsBm25(effectiveCatalog, input.query, {
+    limit: effectiveLimit,
+    candidates: config.candidates,
+  });
+  return buildToolSearchReferenceResult(matches, { limit: effectiveLimit });
+}
+
+function createRegexTool(context: EnginePluginContext, config: ToolSearchConfig): Tool<SearchToolInput, ToolSearchResultPayload> {
+  return {
+    name: 'tool_search_tool_regex',
+    description: 'Search available tools using a Python-style regex query.',
+    inputSchema: searchToolSchema,
+    execute: async (input: SearchToolInput) => {
+      const tools = context.getTools();
+      return buildSearchResult(tools, input, 'regex', config);
+    },
+  };
+}
+
+function createBm25Tool(context: EnginePluginContext, config: ToolSearchConfig): Tool<SearchToolInput, ToolSearchResultPayload> {
+  return {
+    name: 'tool_search_tool_bm25',
+    description: 'Search available tools using natural language queries.',
+    inputSchema: searchToolSchema,
+    execute: async (input: SearchToolInput) => {
+      const tools = context.getTools();
+      return buildSearchResult(tools, input, 'bm25', config);
+    },
+  };
+}
+
+function buildToolSearchSystemAppend(tools: Record<string, Tool>, config: ToolSearchConfig): string {
+  const lines: string[] = [
+    'Tool search is available for deferred tools.',
+    'Use tool_search_tool_bm25 for natural language queries, or tool_search_tool_regex for regex.',
+    'Deferred tools are not listed explicitly; use tool search and call tools by name after discovery.',
+  ];
+
+  if (config.exposeSummary) {
+    lines.push(buildToolSearchSummary(tools));
+  }
+
+  return lines.join('\n');
+}
+
+class ToolSearchService {
+  private readonly config: ToolSearchConfig;
+  private readonly logger: EnginePluginContext['logger'];
+  private readonly loadedToolNames = new Set<string>();
+
+  constructor(config: ToolSearchConfig, logger: EnginePluginContext['logger']) {
+    this.config = config;
+    this.logger = logger;
+  }
+
+  getConfig(): ToolSearchConfig {
+    return this.config;
+  }
+
+  buildSystemPrompt(tools: Record<string, Tool>): string {
+    return buildToolSearchSystemAppend(tools, this.config);
+  }
+
+  splitTools(tools: Record<string, Tool>): { immediate: Record<string, Tool>; deferred: Record<string, Tool> } {
+    return {
+      immediate: filterImmediateTools(tools),
+      deferred: selectSearchTools(tools),
+    };
+  }
+
+  getLoadedTools(tools: Record<string, Tool>): Record<string, Tool> {
+    const loaded: Record<string, Tool> = {};
+    for (const name of this.loadedToolNames) {
+      const tool = tools[name];
+      if (tool) {
+        loaded[name] = tool;
+      }
+    }
+    return loaded;
+  }
+
+  addLoadedTools(toolNames: string[]): string[] {
+    const added: string[] = [];
+    for (const name of toolNames) {
+      if (!name || this.loadedToolNames.has(name)) {
+        continue;
+      }
+      this.loadedToolNames.add(name);
+      added.push(name);
+    }
+    return added;
+  }
+}
+
+function appendSystemPrompt(base: SystemPromptOption | undefined, append: string): SystemPromptOption {
+  if (!append.trim()) {
+    return base ?? { append: '' };
+  }
+
+  if (!base) {
+    return { append };
+  }
+
+  if (typeof base === 'string') {
+    return `${base}\n\n${append}`;
+  }
+
+  if (typeof base === 'function') {
+    return () => `${base()}\n\n${append}`;
+  }
+
+  const currentAppend = base.append.trim();
+  return {
+    append: currentAppend ? `${currentAppend}\n\n${append}` : append,
+  };
+}
+
+function extractToolReferences(messages: ModelMessage[]): string[] {
+  if (!messages.length) {
+    return [];
+  }
+
+  const latest = messages[messages.length - 1];
+  if (!latest || latest.role !== 'assistant') {
+    return [];
+  }
+
+  if (!Array.isArray(latest.content)) {
+    return [];
+  }
+
+  const references: string[] = [];
+  for (const part of latest.content) {
+    if (!part || typeof part !== 'object') {
+      continue;
+    }
+
+    const type = (part as { type?: string }).type;
+    if (type !== 'tool-result') {
+      continue;
+    }
+
+    const output = (part as { output?: unknown }).output as { tool_references?: Array<{ tool_name?: string }> } | undefined;
+    const toolReferences = output?.tool_references;
+    if (!Array.isArray(toolReferences)) {
+      continue;
+    }
+
+    for (const ref of toolReferences) {
+      const toolName = ref?.tool_name;
+      if (!toolName) {
+        continue;
+      }
+      references.push(toolName);
+    }
+  }
+
+  return references;
+}
+
+export const builtInToolSearchPlugin: EnginePlugin = {
+  name: 'pulse-coder-engine/built-in-tool-search',
+  version: '0.1.0',
+  async initialize(context: EnginePluginContext) {
+    const config = buildConfig();
+    if (!config.enabled) {
+      context.logger.info('[ToolSearch] Disabled via config');
+      return;
+    }
+
+    const regexTool = createRegexTool(context, config);
+    const bm25Tool = createBm25Tool(context, config);
+
+    context.registerTool(regexTool.name, regexTool);
+    context.registerTool(bm25Tool.name, bm25Tool);
+
+    const service = new ToolSearchService(config, context.logger);
+    context.registerService(TOOL_SEARCH_SERVICE_NAME, service);
+
+    context.registerHook('beforeLLMCall', ({ tools, systemPrompt }) => {
+      const toolSearchService = context.getService<ToolSearchService>(TOOL_SEARCH_SERVICE_NAME) ?? service;
+      const split = toolSearchService.splitTools(tools);
+      const loadedTools = toolSearchService.getLoadedTools(tools);
+      const nextPrompt = appendSystemPrompt(systemPrompt, toolSearchService.buildSystemPrompt(tools));
+
+      return {
+        tools: {
+          ...split.immediate,
+          ...loadedTools,
+          [regexTool.name]: regexTool,
+          [bm25Tool.name]: bm25Tool,
+        },
+        systemPrompt: nextPrompt,
+      };
+    });
+
+    context.registerHook('afterLLMCall', ({ context: runContext, finishReason }) => {
+      if (finishReason !== 'tool-calls') {
+        return;
+      }
+
+      const references = extractToolReferences(runContext.messages);
+      if (references.length === 0) {
+        return;
+      }
+
+      const added = service.addLoadedTools(references);
+      if (added.length === 0) {
+        return;
+      }
+
+      runContext.messages.push({
+        role: 'system',
+        content: `Tool search loaded: ${added.join(', ')}`,
+      });
+    });
+
+    context.logger.info('[ToolSearch] Built-in tool search plugin initialized', {
+      variant: config.variant,
+      limit: config.limit,
+      candidates: config.candidates,
+    });
+  },
+};
+
+export default builtInToolSearchPlugin;

--- a/packages/engine/src/built-in/tool-search-plugin/utils.ts
+++ b/packages/engine/src/built-in/tool-search-plugin/utils.ts
@@ -1,0 +1,228 @@
+import type { Tool } from '../../shared/types';
+
+export type ToolSearchVariant = 'regex' | 'bm25';
+
+export interface ToolSearchResult {
+  toolName: string;
+  score: number;
+  reason?: string;
+}
+
+const DEFAULT_CANDIDATES = 20;
+const DEFAULT_LIMIT = 10;
+const DEFAULT_WEIGHTS = {
+  name: 3,
+  description: 2,
+  argName: 2,
+  argDescription: 1,
+};
+
+type SearchableField = {
+  text: string;
+  weight: number;
+};
+
+function extractToolFields(tool: Tool): SearchableField[] {
+  const fields: SearchableField[] = [];
+  const weights = DEFAULT_WEIGHTS;
+
+  fields.push({ text: tool.name, weight: weights.name });
+  if (tool.description) {
+    fields.push({ text: tool.description, weight: weights.description });
+  }
+
+  const schema: any = tool.inputSchema as any;
+  const shape = schema?.shape ?? schema?._def?.shape ?? schema?._def?.schema?.shape;
+  const resolvedShape = typeof shape === 'function' ? shape() : shape;
+
+  if (resolvedShape && typeof resolvedShape === 'object') {
+    for (const [argName, argSchema] of Object.entries(resolvedShape)) {
+      fields.push({ text: String(argName), weight: weights.argName });
+      const description = (argSchema as any)?._def?.description;
+      if (description) {
+        fields.push({ text: String(description), weight: weights.argDescription });
+      }
+    }
+  }
+
+  return fields.filter((field) => field.text && field.text.trim().length > 0);
+}
+
+function tokenize(value: string): string[] {
+  return value
+    .toLowerCase()
+    .split(/[^a-z0-9_\-]+/g)
+    .map((token) => token.trim())
+    .filter(Boolean);
+}
+
+function termFrequency(term: string, docTokens: string[]): number {
+  let count = 0;
+  for (const token of docTokens) {
+    if (token === term) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+export function searchToolsRegex(
+  tools: Record<string, Tool>,
+  query: string,
+  options?: { limit?: number }
+): ToolSearchResult[] {
+  if (!query) {
+    return [];
+  }
+
+  let regex: RegExp;
+  try {
+    regex = new RegExp(query);
+  } catch (error) {
+    throw new Error(`Invalid regex query: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  const results: ToolSearchResult[] = [];
+  for (const tool of Object.values(tools)) {
+    const fields = extractToolFields(tool);
+    let score = 0;
+    for (const field of fields) {
+      if (regex.test(field.text)) {
+        score += field.weight;
+      }
+    }
+    if (score > 0) {
+      results.push({ toolName: tool.name, score });
+    }
+  }
+
+  results.sort((a, b) => b.score - a.score || a.toolName.localeCompare(b.toolName));
+  return results.slice(0, options?.limit ?? DEFAULT_LIMIT);
+}
+
+export function searchToolsBm25(
+  tools: Record<string, Tool>,
+  query: string,
+  options?: { limit?: number; candidates?: number }
+): ToolSearchResult[] {
+  if (!query.trim()) {
+    return [];
+  }
+
+  const tokens = tokenize(query);
+  if (tokens.length === 0) {
+    return [];
+  }
+
+  const docs = Object.values(tools).map((tool) => {
+    const fields = extractToolFields(tool);
+    const docText = fields.map((field) => field.text).join(' ');
+    const docTokens = tokenize(docText);
+    return {
+      tool,
+      fields,
+      docTokens,
+      length: docTokens.length || 1,
+    };
+  });
+
+  const avgDocLength = docs.reduce((sum, doc) => sum + doc.length, 0) / (docs.length || 1);
+  const totalDocs = docs.length || 1;
+
+  const docFrequency = new Map<string, number>();
+  for (const token of tokens) {
+    let count = 0;
+    for (const doc of docs) {
+      if (doc.docTokens.includes(token)) {
+        count += 1;
+      }
+    }
+    docFrequency.set(token, count);
+  }
+
+  const k1 = 1.2;
+  const b = 0.75;
+
+  const results: ToolSearchResult[] = [];
+  for (const doc of docs) {
+    let score = 0;
+    for (const term of tokens) {
+      const df = docFrequency.get(term) || 0;
+      if (df === 0) {
+        continue;
+      }
+      const idf = Math.log(1 + (totalDocs - df + 0.5) / (df + 0.5));
+      const tf = termFrequency(term, doc.docTokens);
+      const numerator = tf * (k1 + 1);
+      const denominator = tf + k1 * (1 - b + b * (doc.length / avgDocLength));
+      score += idf * (numerator / denominator);
+    }
+
+    if (score > 0) {
+      results.push({ toolName: doc.tool.name, score });
+    }
+  }
+
+  results.sort((a, b) => b.score - a.score || a.toolName.localeCompare(b.toolName));
+  const candidateLimit = options?.candidates ?? DEFAULT_CANDIDATES;
+  return results.slice(0, candidateLimit).slice(0, options?.limit ?? DEFAULT_LIMIT);
+}
+
+export function buildToolSearchReferenceResult(
+  matches: ToolSearchResult[],
+  options?: { limit?: number }
+): { type: 'tool_search_tool_search_result'; tool_references: Array<{ type: 'tool_reference'; tool_name: string }> } {
+  const limit = options?.limit ?? DEFAULT_LIMIT;
+  const tool_references = matches.slice(0, limit).map((match) => ({
+    type: 'tool_reference',
+    tool_name: match.toolName,
+  }));
+
+  return { type: 'tool_search_tool_search_result', tool_references };
+}
+
+export function filterDeferredTools(tools: Record<string, Tool>): Record<string, Tool> {
+  const deferred: Record<string, Tool> = {};
+  for (const [name, tool] of Object.entries(tools)) {
+    if (tool.defer_loading || tool.deferLoading) {
+      deferred[name] = tool;
+    }
+  }
+  return deferred;
+}
+
+export function filterImmediateTools(tools: Record<string, Tool>): Record<string, Tool> {
+  const immediate: Record<string, Tool> = {};
+  for (const [name, tool] of Object.entries(tools)) {
+    if (tool.defer_loading || tool.deferLoading) {
+      continue;
+    }
+    immediate[name] = tool;
+  }
+  return immediate;
+}
+
+export function getSearchableToolCatalog(tools: Record<string, Tool>): Record<string, Tool> {
+  return filterDeferredTools(tools);
+}
+
+export function buildToolSearchSummary(tools: Record<string, Tool>, limit: number = 40): string {
+  const deferred = Object.values(filterDeferredTools(tools));
+  const names = deferred.map((tool) => tool.name).sort();
+  const shown = names.slice(0, Math.max(0, limit));
+  const omitted = names.length - shown.length;
+
+  const lines = [
+    `Tool search catalog: ${names.length} deferred tool(s).`,
+  ];
+
+  if (shown.length > 0) {
+    lines.push(`Deferred tools preview: ${shown.join(', ')}`);
+  }
+
+  if (omitted > 0) {
+    lines.push(`... ${omitted} additional deferred tool(s) omitted for brevity.`);
+  }
+
+  return lines.join('\n');
+}

--- a/packages/engine/src/shared/types.ts
+++ b/packages/engine/src/shared/types.ts
@@ -71,6 +71,8 @@ export interface Tool<Input = any, Output = any> {
   name: string;
   description: string;
   inputSchema: FlexibleSchema<Input>;
+  defer_loading?: boolean;
+  deferLoading?: boolean;
   execute: (input: Input, context?: ToolExecutionContext) => Promise<Output>;
 }
 


### PR DESCRIPTION
Introduce built-in tool search with deferred tool loading

- add tool-search plugin and register in built-ins
- implement search utilities (BM25/regex) and env config
- extend Tool type with defer_loading/deferLoading
- inject deferred tools on next LLM call