### PR TITLE
Expose engine instance in plugin context for tool search

### DIFF
--- a/packages/engine/src/Engine.ts
+++ b/packages/engine/src/Engine.ts
@@ -1,4 +1,4 @@
-import type { Context, Tool, LLMProviderFactory, SystemPromptOption, ToolHooks, ILogger } from './shared/types';
+import type { Context, Tool, LLMProviderFactory, SystemPromptOption, ToolHooks, ILogger, PulseEngineInstance } from './shared/types';
 import type { LoopOptions, LoopHooks } from './core/loop';
 import type { EnginePluginLoadOptions } from './plugin/EnginePlugin.js';
 import type { UserConfigPluginLoadOptions } from './plugin/UserConfigPlugin.js';
@@ -123,13 +123,21 @@ export class Engine {
   private options: EngineOptions = {};
   private config: Record<string, any> = {};
 
+  get instance(): PulseEngineInstance {
+    return {
+      tools: this.tools,
+    };
+  }
+
   constructor(options?: EngineOptions) {
-    this.pluginManager = new PluginManager(options?.logger);
+    this.pluginManager = new PluginManager(() => this.instance, options?.logger);
 
     // 初始化全局配置
     this.config = options?.config || {};
     this.options = options || {};
   }
+
+
 
   /**
    * 初始化引擎和插件系统

--- a/packages/engine/src/built-in/tool-search-plugin/tool-search-plugin.ts
+++ b/packages/engine/src/built-in/tool-search-plugin/tool-search-plugin.ts
@@ -118,7 +118,7 @@ function createRegexTool(context: EnginePluginContext, config: ToolSearchConfig)
     description: 'Search available tools using a Python-style regex query.',
     inputSchema: searchToolSchema,
     execute: async (input: SearchToolInput) => {
-      const tools = context.getTools();
+      const tools = context.getEngineInstance().tools;
       return buildSearchResult(tools, input, 'regex', config);
     },
   };
@@ -130,7 +130,7 @@ function createBm25Tool(context: EnginePluginContext, config: ToolSearchConfig):
     description: 'Search available tools using natural language queries.',
     inputSchema: searchToolSchema,
     execute: async (input: SearchToolInput) => {
-      const tools = context.getTools();
+      const tools = context.getEngineInstance().tools;
       return buildSearchResult(tools, input, 'bm25', config);
     },
   };
@@ -228,7 +228,7 @@ function extractToolReferences(messages: ModelMessage[]): string[] {
   }
 
   const latest = messages[messages.length - 1];
-  if (!latest || latest.role !== 'assistant') {
+  if (!latest || latest.role !== 'tool') {
     return [];
   }
 

--- a/packages/engine/src/built-in/tool-search-plugin/tool-search-plugin.ts
+++ b/packages/engine/src/built-in/tool-search-plugin/tool-search-plugin.ts
@@ -247,8 +247,8 @@ function extractToolReferences(messages: ModelMessage[]): string[] {
       continue;
     }
 
-    const output = (part as { output?: unknown }).output as { tool_references?: Array<{ tool_name?: string }> } | undefined;
-    const toolReferences = output?.tool_references;
+    const result = (part as { output?: any }).output?.value as { tool_references?: Array<{ tool_name?: string }> } | undefined;
+    const toolReferences = result?.tool_references;
     if (!Array.isArray(toolReferences)) {
       continue;
     }

--- a/packages/engine/src/plugin/EnginePlugin.ts
+++ b/packages/engine/src/plugin/EnginePlugin.ts
@@ -142,6 +142,10 @@ export interface EnginePluginContext {
   /** Returns a snapshot of all tools registered by plugins so far. */
   getTools(): Record<string, any>;
 
+  getEngineInstance(): {
+    tools: Record<string, any>;
+  };
+
   // Hook registration (replaces the old registerRunHook)
   registerHook<K extends EngineHookName>(hookName: K, handler: EngineHookMap[K]): void;
 

--- a/packages/engine/src/plugin/EnginePlugin.ts
+++ b/packages/engine/src/plugin/EnginePlugin.ts
@@ -1,7 +1,7 @@
 import type { EventEmitter } from 'events';
 import type { ModelMessage } from 'ai';
 
-import type { Context, SystemPromptOption } from '../shared/types.js';
+import type { Context, PulseEngineInstance, SystemPromptOption } from '../shared/types.js';
 
 // ---------------------------------------------------------------------------
 // Hook input / result types
@@ -142,9 +142,7 @@ export interface EnginePluginContext {
   /** Returns a snapshot of all tools registered by plugins so far. */
   getTools(): Record<string, any>;
 
-  getEngineInstance(): {
-    tools: Record<string, any>;
-  };
+  getEngineInstance(): PulseEngineInstance;
 
   // Hook registration (replaces the old registerRunHook)
   registerHook<K extends EngineHookName>(hookName: K, handler: EngineHookMap[K]): void;

--- a/packages/engine/src/plugin/PluginManager.ts
+++ b/packages/engine/src/plugin/PluginManager.ts
@@ -5,7 +5,7 @@ import { EventEmitter } from 'events';
 
 import type { EnginePlugin, EnginePluginContext, EnginePluginLoadOptions, EngineHookMap, EngineHookName } from './EnginePlugin.js';
 import type { UserConfigPlugin, UserConfigPluginLoadOptions } from './UserConfigPlugin.js';
-import type { ILogger } from '../shared/types.js';
+import type { ILogger, PulseEngineInstance } from '../shared/types.js';
 import { ConfigVariableResolver } from './UserConfigPlugin.js';
 
 // Internal storage: each hook name maps to an array of handlers
@@ -35,13 +35,17 @@ export class PluginManager {
   private events = new EventEmitter();
   private logger: ILogger;
 
-  constructor(logger?: ILogger) {
+  private getEngineInstance: () => PulseEngineInstance;
+
+  constructor(getEngineInstance: () => PulseEngineInstance, logger?: ILogger,) {
     this.logger = logger ?? {
       debug: (msg: string, meta?: any) => console.debug(`[PluginManager] ${msg}`, meta),
       info: (msg: string, meta?: any) => console.info(`[PluginManager] ${msg}`, meta),
       warn: (msg: string, meta?: any) => console.warn(`[PluginManager] ${msg}`, meta),
       error: (msg: string, error?: Error, meta?: any) => console.error(`[PluginManager] ${msg}`, error, meta),
     };
+
+    this.getEngineInstance = getEngineInstance;
   }
 
   /**
@@ -173,6 +177,10 @@ export class PluginManager {
         },
         getTool: (name) => this.tools.get(name),
         getTools: () => Object.fromEntries(this.tools),
+
+        getEngineInstance: () => {
+          return this.getEngineInstance();
+        },
 
         registerHook: (hookName, handler) => {
           this.hooks[hookName].push(handler as any);

--- a/packages/engine/src/shared/types.ts
+++ b/packages/engine/src/shared/types.ts
@@ -86,3 +86,8 @@ export interface ILogger {
   warn(message: string, meta?: Record<string, unknown>): void;
   error(message: string, error?: Error, meta?: Record<string, unknown>): void;
 }
+
+// Engine instance, 不能直接暴露实际例子，只能通过插件上下文获取
+export interface PulseEngineInstance {
+  tools: Record<string, Tool>;
+}

--- a/packages/engine/src/tools/defer-demo.ts
+++ b/packages/engine/src/tools/defer-demo.ts
@@ -1,0 +1,28 @@
+import type { Tool } from "../shared/types";
+import z from 'zod';
+
+const toolSchema = z.object({
+  message: z.string().min(1).describe('Message to echo back.'),
+});
+
+type DeferDemoInput = z.infer<typeof toolSchema>;
+
+type DeferDemoResult = {
+  ok: true;
+  echoed: string;
+  receivedAt: string;
+};
+
+export const deferDemoTool: Tool<DeferDemoInput, DeferDemoResult> = {
+  name: 'deferred_demo',
+  description: 'Demo deferred tool that echoes a short message.',
+  inputSchema: toolSchema,
+  defer_loading: true,
+  execute: async (input) => {
+    return {
+      ok: true,
+      echoed: input.message,
+      receivedAt: new Date().toISOString(),
+    };
+  },
+};

--- a/packages/engine/src/tools/index.ts
+++ b/packages/engine/src/tools/index.ts
@@ -8,6 +8,7 @@ import { TavilyTool, TavilyExtractTool, TavilyCrawlTool, TavilyMapTool } from '.
 import { GeminiProImageTool } from './gemini-pro-image';
 import { ClarifyTool } from './clarify';
 import { Tool } from 'ai';
+import { deferDemoTool } from './defer-demo';
 // import { SkillTool } from './skill;
 
 export const BuiltinTools = [
@@ -23,6 +24,7 @@ export const BuiltinTools = [
   TavilyMapTool,
   GeminiProImageTool,
   ClarifyTool,
+  deferDemoTool
 ] as const;
 
 export const BuiltinToolsMap = BuiltinTools.reduce((acc, toolInstance) => {


### PR DESCRIPTION
Improve plugin context access to runtime tools and add deferred tool discovery coverage.

- Pass an engine instance accessor into  and expose  in plugin context
- Update tool-search plugin to read tools from engine instance instead of plugin-only tool snapshots
- Fix tool-search reference extraction to inspect latest  message role
- Add a  built-in tool and register it in the built-in tools index for deferred tool discovery testing