### PR TITLE
Reset deferred tool loads per run

### DIFF
--- a/packages/engine/src/built-in/tool-search-plugin/tool-search-plugin.ts
+++ b/packages/engine/src/built-in/tool-search-plugin/tool-search-plugin.ts
@@ -197,6 +197,10 @@ class ToolSearchService {
     }
     return added;
   }
+
+  resetLoadedTools(): void {
+    this.loadedToolNames.clear();
+  }
 }
 
 function appendSystemPrompt(base: SystemPromptOption | undefined, append: string): SystemPromptOption {
@@ -283,6 +287,10 @@ export const builtInToolSearchPlugin: EnginePlugin = {
 
     const service = new ToolSearchService(config, context.logger);
     context.registerService(TOOL_SEARCH_SERVICE_NAME, service);
+
+    context.registerHook('beforeRun', () => {
+      service.resetLoadedTools();
+    });
 
     context.registerHook('beforeLLMCall', ({ tools, systemPrompt }) => {
       const toolSearchService = context.getService<ToolSearchService>(TOOL_SEARCH_SERVICE_NAME) ?? service;


### PR DESCRIPTION
## Summary
- reset deferred tool load state on each engine run so loaded tools do not persist across sessions
- add a ToolSearchService reset hook on beforeRun

## Testing
- not run (logic-only change)