### PR TITLE
Add deferTools to remote-server MCP config

### DIFF
--- a/apps/remote-server/.pulse-coder/mcp.json
+++ b/apps/remote-server/.pulse-coder/mcp.json
@@ -2,15 +2,18 @@
   "servers": {
     "eido_mind": {
       "transport": "http",
-      "url": "http://localhost:3060/mcp/server"
+      "url": "http://localhost:3060/mcp/server",
+      "deferTools": true
     },
     "deepwiki": {
       "transport": "http",
-      "url": "https://mcp.deepwiki.com/mcp"
+      "url": "https://mcp.deepwiki.com/mcp",
+      "deferTools": true
     },
     "exa": {
       "transport": "http",
-      "url": "https://mcp.exa.ai/mcp"
+      "url": "https://mcp.exa.ai/mcp",
+      "deferTools": true
     },
     "twitter": {
       "transport": "stdio",
@@ -20,7 +23,8 @@
         "/root/pulse-coder/.vendors/opentwitter-mcp",
         "run",
         "opentwitter-mcp"
-      ]
+      ],
+      "deferTools": true
     }
   }
 }


### PR DESCRIPTION
## Summary
- set deferTools in remote-server MCP config so MCP tools default to deferred loading

## Testing
- not run (config-only change)