### PR TITLE
Add remote model switch command

### DIFF
--- a/apps/remote-server/src/core/chat-commands.ts
+++ b/apps/remote-server/src/core/chat-commands.ts
@@ -6,6 +6,7 @@ import { abortActiveRun, getActiveRun } from './active-run-store.js';
 import { processWorktreeCommand } from './worktree/commands.js';
 import { buildRemoteWorktreeRunContext } from './worktree/integration.js';
 import { memoryIntegration, recordCompactSummaryDailyLog } from './memory-integration.js';
+import { writeModelConfig } from './model-config.js';
 
 interface SkillSummary {
   name: string;
@@ -23,7 +24,7 @@ export type CommandResult =
   | { type: 'handled_silent' }
   | { type: 'transformed'; text: string };
 
-const COMMANDS_ALLOWED_WHILE_RUNNING = new Set(['help', 'start', 'status', 'stop', 'current', 'ping', 'memory', 'mode', 'fork', 'wt', 'insight']);
+const COMMANDS_ALLOWED_WHILE_RUNNING = new Set(['help', 'start', 'status', 'stop', 'current', 'ping', 'memory', 'mode', 'fork', 'wt', 'insight', 'model']);
 const COMMAND_ALIASES: Record<string, string> = {
   '?': 'help',
   h: 'help',
@@ -141,6 +142,9 @@ export async function processIncomingCommand(incoming: IncomingMessage): Promise
 
     case 'mode':
       return handleModeCommand(args);
+
+    case 'model':
+      return await handleModelCommand(args);
 
     case 'insight':
       return handleInsightCommand(args);
@@ -524,6 +528,32 @@ async function handleMemoryCommand(platformKey: string, memoryKey: string, args:
     ].join('\n'),
   };
 }
+
+async function handleModelCommand(args: string[]): Promise<CommandResult> {
+  const raw = args.join(' ').trim();
+  if (!raw || raw.toLowerCase() === 'status') {
+    return {
+      type: 'handled',
+      message: 'ℹ️ 用法：/model <name>\n示例：/model gpt-5',
+    };
+  }
+
+  const model = raw;
+  try {
+    const result = await writeModelConfig({ current_model: model });
+    return {
+      type: 'handled',
+      message: `✅ 已更新模型为 ${model}\nConfig: ${result.path}`,
+    };
+  } catch (error) {
+    console.error('[model-config] failed to update model config:', error);
+    return {
+      type: 'handled',
+      message: '❌ 更新模型失败，请检查服务日志。',
+    };
+  }
+}
+
 async function handleInsightCommand(args: string[]): Promise<CommandResult> {
   const raw = args[0]?.trim();
   const days = parseInsightDays(raw);
@@ -712,6 +742,7 @@ function buildHelpMessage(): string {
     '/mode - 查看当前模式',
     '/mode planning - 切换到 planning 模式',
     '/mode executing - 切换到 executing 模式',
+    '/model <name> - 切换模型（写入 config.json）',
     '/memory - 查看 memory 列表',
     '/memory on|off - 开关当前会话 memory',
     '/memory pin <id> - 置顶一条 memory',

--- a/apps/remote-server/src/core/model-config.ts
+++ b/apps/remote-server/src/core/model-config.ts
@@ -1,12 +1,17 @@
 import { promises as fs } from 'fs';
 import { homedir } from 'os';
-import { join, resolve } from 'path';
+import { join, resolve, dirname } from 'path';
 
 type ModelConfig = {
   current_model?: string;
   models?: Array<{
     name?: string;
   }>;
+};
+
+type ModelConfigWriteResult = {
+  path: string;
+  config: ModelConfig;
 };
 
 type CachedConfig = {
@@ -50,7 +55,10 @@ async function findConfigPath(): Promise<string | null> {
   return null;
 }
 
-async function readConfig(path: string): Promise<ModelConfig | null> {
+async function loadConfigFromPath(
+  path: string,
+  options?: { warn?: boolean },
+): Promise<ModelConfig | null> {
   try {
     const raw = await fs.readFile(path, 'utf8');
     const parsed = JSON.parse(raw) as unknown;
@@ -59,10 +67,42 @@ async function readConfig(path: string): Promise<ModelConfig | null> {
     }
     return parsed as ModelConfig;
   } catch (error) {
-    console.warn('[model-config] failed to parse model config:', error);
+    if (options?.warn) {
+      console.warn('[model-config] failed to parse model config:', error);
+    }
     return null;
   }
 }
+
+async function ensureConfigDir(path: string): Promise<void> {
+  await fs.mkdir(dirname(path), { recursive: true });
+}
+
+export async function writeModelConfig(next: ModelConfig): Promise<ModelConfigWriteResult> {
+  const envPath = process.env.PULSE_CODER_MODEL_CONFIG?.trim();
+  const configPath = await findConfigPath();
+  const path = envPath || configPath || resolve(process.cwd(), '.pulse-coder', 'config.json');
+
+  await ensureConfigDir(path);
+  const existing = await loadConfigFromPath(path, { warn: true });
+  const merged: ModelConfig = {
+    ...(existing ?? {}),
+    ...next,
+  };
+
+  const payload = `${JSON.stringify(merged, null, 2)}\n`;
+  await fs.writeFile(path, payload, 'utf8');
+
+  try {
+    const stat = await fs.stat(path);
+    cachedConfig = { path, mtimeMs: stat.mtimeMs, data: merged };
+  } catch {
+    cachedConfig = { path, mtimeMs: 0, data: merged };
+  }
+
+  return { path, config: merged };
+}
+
 
 function selectModel(config: ModelConfig | null): string | null {
   if (!config) {
@@ -90,7 +130,10 @@ export async function resolveModelForRun(_platformKey: string): Promise<string |
       return selectModel(cachedConfig.data) ?? undefined;
     }
 
-    const data = await readConfig(configPath);
+    const data = await loadConfigFromPath(configPath, { warn: true });
+    if (!data) {
+      return undefined;
+    }
     cachedConfig = { path: configPath, mtimeMs: stat.mtimeMs, data };
     return selectModel(data) ?? undefined;
   } catch {


### PR DESCRIPTION
Implement a /model command to persist model overrides from remote chat

- Allow /model while a run is active
- Persist model config updates with directory creation
- Surface the new command in help text