### PR TITLE
Enable deferred loading for heavy tools and agents

### DIFF
--- a/.pulse-coder/agents/code-reviewer.md
+++ b/.pulse-coder/agents/code-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: code-reviewer
 description: 专业代码审查子代理，专注代码质量和最佳实践
+defer_loading: true
 ---
 
 你是一个经验丰富的代码审查专家，拥有超过10年的开发经验。你的任务是全面审查代码，提供有价值的改进建议。

--- a/.pulse-coder/agents/doc-generator.md
+++ b/.pulse-coder/agents/doc-generator.md
@@ -1,6 +1,7 @@
 ---
 name: doc-generator
 description: 专业文档生成子代理，专注创建清晰、准确的技术文档
+defer_loading: true
 ---
 
 你是一个专业的技术文档工程师，擅长将代码和技术概念转化为清晰易懂的文档。

--- a/.pulse-coder/agents/test-writer.md
+++ b/.pulse-coder/agents/test-writer.md
@@ -1,6 +1,7 @@
 ---
 name: test-writer
 description: 专业测试编写子代理，专注创建高质量的测试用例
+defer_loading: true
 ---
 
 你是一个测试驱动开发(TDD)专家，擅长为各种代码编写全面、有效的测试用例。

--- a/apps/remote-server/.pulse-coder/agents/code-reviewer.md
+++ b/apps/remote-server/.pulse-coder/agents/code-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: code-reviewer
 description: 专业代码审查子代理，专注代码质量和最佳实践
+defer_loading: true
 ---
 
 你是一个经验丰富的代码审查专家，拥有超过10年的开发经验。你的任务是全面审查代码，提供有价值的改进建议。

--- a/apps/remote-server/.pulse-coder/agents/doc-generator.md
+++ b/apps/remote-server/.pulse-coder/agents/doc-generator.md
@@ -1,6 +1,7 @@
 ---
 name: doc-generator
 description: 专业文档生成子代理，专注创建清晰、准确的技术文档
+defer_loading: true
 ---
 
 你是一个专业的技术文档工程师，擅长将代码和技术概念转化为清晰易懂的文档。

--- a/apps/remote-server/.pulse-coder/agents/test-writer.md
+++ b/apps/remote-server/.pulse-coder/agents/test-writer.md
@@ -1,6 +1,7 @@
 ---
 name: test-writer
 description: 专业测试编写子代理，专注创建高质量的测试用例
+defer_loading: true
 ---
 
 你是一个测试驱动开发(TDD)专家，擅长为各种代码编写全面、有效的测试用例。

--- a/apps/remote-server/.pulse-coder/config.json
+++ b/apps/remote-server/.pulse-coder/config.json
@@ -1,6 +1,8 @@
 {
-  "current_model": "gpt-5.2-codex",
   "models": [
-    { "name": "gpt-5.2-codex" }
-  ]
+    {
+      "name": "gpt-5.2-codex"
+    }
+  ],
+  "current_model": "gpt-5.3-codex"
 }

--- a/apps/remote-server/src/core/tools/cron-job.ts
+++ b/apps/remote-server/src/core/tools/cron-job.ts
@@ -93,6 +93,7 @@ interface NotifyTarget {
 export const cronJobTool: Tool<CronJobInput, CronJobResult> = {
   name: 'cron_job',
   description: 'Create or update a cron runner that calls /internal/agent/run with optional notify targets.',
+  defer_loading: true,
   inputSchema: toolSchema,
   execute: async (input, context?: ToolExecutionContext) => {
     const normalized = normalizeInput(input, context?.runContext);

--- a/apps/remote-server/src/core/tools/jina-ai.ts
+++ b/apps/remote-server/src/core/tools/jina-ai.ts
@@ -46,6 +46,7 @@ function buildTargetUrl(rawUrl: string): { sourceUrl: string; targetUrl: string 
 export const jinaAiReadTool: Tool<JinaAiReadInput, JinaAiReadResult> = {
   name: 'jina_ai_read',
   description: 'Fetch readable page text via r.jina.ai, including pages behind login walls (e.g., X).',
+  defer_loading: true,
   inputSchema: toolSchema,
   execute: async (input): Promise<JinaAiReadResult> => {
     const { sourceUrl, targetUrl } = buildTargetUrl(input.url);

--- a/packages/engine/src/built-in/agent-teams-plugin/index.ts
+++ b/packages/engine/src/built-in/agent-teams-plugin/index.ts
@@ -40,6 +40,7 @@ export const builtInAgentTeamsPlugin: EnginePlugin = {
     const tool: Tool<TeamRunInput, TeamRunOutput> = {
       name: 'agent_teams_run',
       description: 'Run a fixed DAG agent team with role routing and aggregation.',
+      defer_loading: true,
       inputSchema: TEAM_RUN_INPUT_SCHEMA,
       execute: async (input) => {
         const roleTools = registry.resolveRoleTools(input.roleTools);

--- a/packages/engine/src/built-in/sub-agent-plugin/index.ts
+++ b/packages/engine/src/built-in/sub-agent-plugin/index.ts
@@ -5,13 +5,14 @@ import type { EnginePlugin, EnginePluginContext } from '../../plugin/EnginePlugi
 import type { Context } from '../../shared/types.js';
 import { loop } from '../../core/loop';
 import { BuiltinToolsMap } from '../../tools';
-import { Tool } from 'ai';
+import type { Tool } from '../../shared/types';
 
 interface AgentConfig {
   name: string;
   description: string;
   systemPrompt: string;
   filePath: string;
+  deferLoading?: boolean;
 }
 
 class ConfigLoader {
@@ -64,6 +65,7 @@ class ConfigLoader {
       let name = '';
       let description = '';
       let systemPrompt = '';
+      let deferLoading: boolean | undefined;
       let inFrontmatter = false;
       let frontmatterEnd = false;
 
@@ -82,8 +84,13 @@ class ConfigLoader {
           const match = line.match(/^\s*(\w+)\s*:\s*(.+)$/);
           if (match) {
             const [, key, value] = match;
-            if (key === 'name') name = value.trim();
-            if (key === 'description') description = value.trim();
+            const normalizedValue = value.trim();
+            if (key === 'name') name = normalizedValue;
+            if (key === 'description') description = normalizedValue;
+            if (key === 'defer_loading' || key === 'deferLoading') {
+              if (normalizedValue === 'true') deferLoading = true;
+              if (normalizedValue === 'false') deferLoading = false;
+            }
           }
         } else if (frontmatterEnd) {
           systemPrompt += line + '\n';
@@ -98,7 +105,8 @@ class ConfigLoader {
         name: name.trim(),
         description: description.trim(),
         systemPrompt: systemPrompt.trim(),
-        filePath
+        filePath,
+        deferLoading,
       };
     } catch (error) {
       console.warn(`Failed to parse agent config ${filePath}: ${error}`);
@@ -159,7 +167,9 @@ export class SubAgentPlugin implements EnginePlugin {
     const toolName = `${config.name}_agent`;
 
     const tool: Tool = {
+      name: toolName,
       description: config.description,
+      ...(config.deferLoading === true ? { defer_loading: true } : {}),
       inputSchema: z.object({
         task: z.string().describe('要执行的任务描述'),
         context: z.any().optional().describe('任务上下文信息')

--- a/packages/engine/src/tools/gemini-pro-image.ts
+++ b/packages/engine/src/tools/gemini-pro-image.ts
@@ -57,6 +57,7 @@ export const GeminiProImageTool: Tool<
   name: 'gemini_pro_image',
   description:
     'Generate an image with Gemini and save it to local disk. Requires GEMINI_API_KEY. Model defaults to GEMINI_PRO_IMAGE_MODEL or gemini-pro-image.',
+  defer_loading: true,
   inputSchema: z.object({
     prompt: z.string().describe('The prompts for image generation need to describe in detail the content, style, and composition of the image you want to generate.'),
     model: z.string().optional().describe('Gemini model name. Defaults to GEMINI_PRO_IMAGE_MODEL or google/gemini-3-pro-image-preview.'),

--- a/packages/engine/src/tools/tavily.ts
+++ b/packages/engine/src/tools/tavily.ts
@@ -146,6 +146,7 @@ export const TavilyExtractTool: Tool<
   name: 'tavily_extract',
   description:
     'Extract cleaned content from one or more URLs via Tavily Extract API. Useful after search to fetch full page text.',
+  defer_loading: true,
   inputSchema: z.object({
     urls: z
       .union([z.string(), z.array(z.string()).min(1)])
@@ -254,6 +255,7 @@ export const TavilyCrawlTool: Tool<
   name: 'tavily_crawl',
   description:
     'Crawl a site from a starting URL and extract page content. Best for collecting docs or multi-page website context.',
+  defer_loading: true,
   inputSchema: z.object({
     url: z.string().describe('Starting URL to crawl.'),
     maxDepth: z.number().optional().describe('Maximum crawl depth from the starting URL.'),
@@ -369,6 +371,7 @@ export const TavilyMapTool: Tool<
   name: 'tavily_map',
   description:
     'Discover site URLs from a base page without full content extraction. Best for URL discovery before targeted crawl/extract.',
+  defer_loading: true,
   inputSchema: z.object({
     url: z.string().describe('Base URL to map.'),
     maxDepth: z.number().optional().describe('Maximum traversal depth from the base URL.'),


### PR DESCRIPTION
Optimize tool loading by deferring non-core/high-cost tools and sub-agents.

- Add `defer_loading` for `tavily_extract`, `tavily_crawl`, `tavily_map`, and `gemini_pro_image`
- Defer `agent_teams_run` and remote-server tools `cron_job` and `jina_ai_read`
- Extend sub-agent plugin to parse frontmatter `defer_loading` and propagate it to `<agent>_agent` tools
- Mark code-reviewer/doc-generator/test-writer agent configs as deferred in both root and remote-server profiles
- Include existing remote-server model config update in this branch (`gpt-5.3-codex`)