### PR TITLE
Add role soul plugin and remote soul commands

### DIFF
--- a/apps/remote-server/src/core/chat-commands.ts
+++ b/apps/remote-server/src/core/chat-commands.ts
@@ -19,20 +19,14 @@ interface SoulSummary {
   description?: string;
 }
 
-interface SoulStateSnapshot {
-  sessionId: string;
-  activeSoulIds: string[];
-  primarySoulId?: string;
-  updatedAt: number;
-}
-
 interface SoulService {
   listSouls: () => SoulSummary[];
-  getState: (sessionId: string) => Promise<SoulStateSnapshot | undefined>;
+  getState: (sessionId: string) => Promise<{ activeSoulIds: string[] } | undefined>;
   useSoul: (sessionId: string, soulId: string) => Promise<{ ok: boolean; reason?: string }>;
   addSoul: (sessionId: string, soulId: string) => Promise<{ ok: boolean; reason?: string }>;
   removeSoul: (sessionId: string, soulId: string) => Promise<{ ok: boolean; reason?: string }>;
   clearSession: (sessionId: string) => Promise<{ ok: boolean; reason?: string }>;
+  cloneState: (fromSessionId: string, toSessionId: string) => Promise<{ ok: boolean; reason?: string }>;
 }
 
 interface SkillRegistryService {
@@ -123,7 +117,10 @@ export async function processIncomingCommand(incoming: IncomingMessage): Promise
         };
       }
 
-      await sessionStore.clearSoulState(result.sessionId);
+      const soulService = getSoulService();
+      if (soulService) {
+        await soulService.clearSession(result.sessionId);
+      }
 
       return {
         type: 'handled',
@@ -235,7 +232,8 @@ async function handleResumeCommand(platformKey: string, args: string[]): Promise
     };
   }
 
-  const soulState = await sessionStore.getSoulState(sessionId);
+  const soulService = getSoulService();
+  const soulState = soulService ? await soulService.getState(sessionId) : undefined;
 
   return {
     type: 'handled',
@@ -260,6 +258,11 @@ async function handleForkCommand(platformKey: string, memoryKey: string, args: s
       type: 'handled',
       message: `❌ 无法 fork 会话：${result.reason ?? '未知错误'}\n用法：/fork <session-id>`,
     };
+  }
+
+  const soulService = getSoulService();
+  if (soulService) {
+    await soulService.cloneState(sourceSessionId, result.sessionId);
   }
 
   return {
@@ -292,7 +295,8 @@ async function handleStatusCommand(platformKey: string): Promise<CommandResult> 
     lines.push(`- 消息数：${sessionStatus.messageCount}`);
     lines.push(`- 最后更新：${formatTime(sessionStatus.updatedAt)}`);
 
-    const soulState = await sessionStore.getSoulState(sessionStatus.sessionId);
+    const soulService = getSoulService();
+    const soulState = soulService ? await soulService.getState(sessionStatus.sessionId) : undefined;
     if (soulState?.activeSoulIds?.length) {
       lines.push(`- 当前 soul：${soulState.activeSoulIds.join(', ')}`);
     } else {
@@ -758,7 +762,7 @@ function getSoulService(): SoulService | undefined {
   return engine.getService<SoulService>('soulService');
 }
 
-function buildSoulListMessage(souls: SoulSummary[], state?: SoulStateSnapshot | null): string {
+function buildSoulListMessage(souls: SoulSummary[], state?: { activeSoulIds: string[] } | null): string {
   if (souls.length === 0) {
     return '📭 当前没有可用的 soul。';
   }
@@ -804,7 +808,7 @@ async function handleSoulCommand(platformKey: string, args: string[]): Promise<C
   }
 
   if (sub === 'list' || sub === 'ls') {
-    const state = await sessionStore.getSoulState(sessionId);
+    const state = await service.getState(sessionId);
     return {
       type: 'handled',
       message: buildSoulListMessage(service.listSouls(), state),
@@ -812,7 +816,7 @@ async function handleSoulCommand(platformKey: string, args: string[]): Promise<C
   }
 
   if (sub === 'status') {
-    const state = await sessionStore.getSoulState(sessionId);
+    const state = await service.getState(sessionId);
     return {
       type: 'handled',
       message: state?.activeSoulIds?.length
@@ -823,7 +827,6 @@ async function handleSoulCommand(platformKey: string, args: string[]): Promise<C
 
   if (sub === 'clear') {
     await service.clearSession(sessionId);
-    await sessionStore.clearSoulState(sessionId);
     return {
       type: 'handled',
       message: `🧹 已清除当前会话 soul\nSession ID: ${sessionId}`,
@@ -847,11 +850,6 @@ async function handleSoulCommand(platformKey: string, args: string[]): Promise<C
       };
     }
 
-    const state = await service.getState(sessionId);
-    if (state) {
-      sessionStore.scheduleSoulStateSave(state);
-    }
-
     return {
       type: 'handled',
       message: `✅ 已启用 soul：${soulId}`,
@@ -867,11 +865,6 @@ async function handleSoulCommand(platformKey: string, args: string[]): Promise<C
       };
     }
 
-    const state = await service.getState(sessionId);
-    if (state) {
-      sessionStore.scheduleSoulStateSave(state);
-    }
-
     return {
       type: 'handled',
       message: `✅ 已追加 soul：${soulId}`,
@@ -885,11 +878,6 @@ async function handleSoulCommand(platformKey: string, args: string[]): Promise<C
         type: 'handled',
         message: `❌ soul 移除失败：${result.reason ?? 'unknown error'}`,
       };
-    }
-
-    const state = await service.getState(sessionId);
-    if (state) {
-      sessionStore.scheduleSoulStateSave(state);
     }
 
     return {

--- a/apps/remote-server/src/core/chat-commands.ts
+++ b/apps/remote-server/src/core/chat-commands.ts
@@ -13,6 +13,28 @@ interface SkillSummary {
   description: string;
 }
 
+interface SoulSummary {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+interface SoulStateSnapshot {
+  sessionId: string;
+  activeSoulIds: string[];
+  primarySoulId?: string;
+  updatedAt: number;
+}
+
+interface SoulService {
+  listSouls: () => SoulSummary[];
+  getState: (sessionId: string) => Promise<SoulStateSnapshot | undefined>;
+  useSoul: (sessionId: string, soulId: string) => Promise<{ ok: boolean; reason?: string }>;
+  addSoul: (sessionId: string, soulId: string) => Promise<{ ok: boolean; reason?: string }>;
+  removeSoul: (sessionId: string, soulId: string) => Promise<{ ok: boolean; reason?: string }>;
+  clearSession: (sessionId: string) => Promise<{ ok: boolean; reason?: string }>;
+}
+
 interface SkillRegistryService {
   getAll: () => SkillSummary[];
   get: (name: string) => SkillSummary | undefined;
@@ -24,7 +46,7 @@ export type CommandResult =
   | { type: 'handled_silent' }
   | { type: 'transformed'; text: string };
 
-const COMMANDS_ALLOWED_WHILE_RUNNING = new Set(['help', 'start', 'status', 'stop', 'current', 'ping', 'memory', 'mode', 'fork', 'wt', 'insight', 'model']);
+const COMMANDS_ALLOWED_WHILE_RUNNING = new Set(['help', 'start', 'status', 'stop', 'current', 'ping', 'memory', 'mode', 'fork', 'wt', 'insight', 'model', 'soul']);
 const COMMAND_ALIASES: Record<string, string> = {
   '?': 'help',
   h: 'help',
@@ -36,6 +58,7 @@ const COMMAND_ALIASES: Record<string, string> = {
   session: 'current',
   mem: 'memory',
   clone: 'fork',
+  role: 'soul',
 };
 /**
  * Parse and execute slash commands for remote chat channels.
@@ -100,6 +123,8 @@ export async function processIncomingCommand(incoming: IncomingMessage): Promise
         };
       }
 
+      await sessionStore.clearSoulState(result.sessionId);
+
       return {
         type: 'handled',
         message: `🧹 已清空当前会话上下文\nSession ID: ${result.sessionId}`,
@@ -148,6 +173,9 @@ export async function processIncomingCommand(incoming: IncomingMessage): Promise
 
     case 'insight':
       return handleInsightCommand(args);
+
+    case 'soul':
+      return await handleSoulCommand(incoming.platformKey, args);
 
     default:
       return {
@@ -207,9 +235,13 @@ async function handleResumeCommand(platformKey: string, args: string[]): Promise
     };
   }
 
+  const soulState = await sessionStore.getSoulState(sessionId);
+
   return {
     type: 'handled',
-    message: `✅ 已恢复会话：${sessionId}`,
+    message: soulState?.activeSoulIds?.length
+      ? `✅ 已恢复会话：${sessionId}\n🎭 已加载 soul：${soulState.activeSoulIds.join(', ')}`
+      : `✅ 已恢复会话：${sessionId}`,
   };
 }
 
@@ -259,6 +291,13 @@ async function handleStatusCommand(platformKey: string): Promise<CommandResult> 
     lines.push(`- 当前会话：${sessionStatus.sessionId}`);
     lines.push(`- 消息数：${sessionStatus.messageCount}`);
     lines.push(`- 最后更新：${formatTime(sessionStatus.updatedAt)}`);
+
+    const soulState = await sessionStore.getSoulState(sessionStatus.sessionId);
+    if (soulState?.activeSoulIds?.length) {
+      lines.push(`- 当前 soul：${soulState.activeSoulIds.join(', ')}`);
+    } else {
+      lines.push('- 当前 soul：无');
+    }
   } else {
     lines.push('- 当前会话：无（发送普通消息会自动创建）');
   }
@@ -715,6 +754,156 @@ function getSkillRegistry(): SkillRegistryService | undefined {
   return engine.getService<SkillRegistryService>('skillRegistry');
 }
 
+function getSoulService(): SoulService | undefined {
+  return engine.getService<SoulService>('soulService');
+}
+
+function buildSoulListMessage(souls: SoulSummary[], state?: SoulStateSnapshot | null): string {
+  if (souls.length === 0) {
+    return '📭 当前没有可用的 soul。';
+  }
+
+  const active = state?.activeSoulIds?.length ? new Set(state.activeSoulIds.map((id) => id.toLowerCase())) : new Set<string>();
+  const lines = souls.map((soul, index) => {
+    const isActive = active.has(soul.id.toLowerCase());
+    const marker = isActive ? '🎭' : '  ';
+    const desc = soul.description ? ` - ${soul.description}` : '';
+    return `${String(index + 1).padStart(2, ' ')}. ${marker} ${soul.id}${desc}`;
+  });
+
+  const header = state?.activeSoulIds?.length
+    ? `🎭 已启用 soul：${state.activeSoulIds.join(', ')}`
+    : '🎭 当前未启用 soul';
+
+  return [
+    header,
+    '🧩 可用 soul：',
+    ...lines,
+    '',
+    '用法：/soul list | /soul use <id> | /soul add <id> | /soul remove <id> | /soul clear',
+  ].join('\n');
+}
+
+async function handleSoulCommand(platformKey: string, args: string[]): Promise<CommandResult> {
+  const service = getSoulService();
+  if (!service) {
+    return {
+      type: 'handled',
+      message: '⚠️ 当前引擎未启用 soul 服务。',
+    };
+  }
+
+  const sub = args[0]?.toLowerCase() ?? 'list';
+  const sessionId = sessionStore.getCurrentSessionId(platformKey);
+
+  if (!sessionId) {
+    return {
+      type: 'handled',
+      message: 'ℹ️ 当前没有会话，先发送一条普通消息创建会话后再使用 soul 命令。',
+    };
+  }
+
+  if (sub === 'list' || sub === 'ls') {
+    const state = await sessionStore.getSoulState(sessionId);
+    return {
+      type: 'handled',
+      message: buildSoulListMessage(service.listSouls(), state),
+    };
+  }
+
+  if (sub === 'status') {
+    const state = await sessionStore.getSoulState(sessionId);
+    return {
+      type: 'handled',
+      message: state?.activeSoulIds?.length
+        ? `🎭 当前 soul：${state.activeSoulIds.join(', ')}`
+        : '🎭 当前未启用 soul。',
+    };
+  }
+
+  if (sub === 'clear') {
+    await service.clearSession(sessionId);
+    await sessionStore.clearSoulState(sessionId);
+    return {
+      type: 'handled',
+      message: `🧹 已清除当前会话 soul\nSession ID: ${sessionId}`,
+    };
+  }
+
+  const soulId = args[1];
+  if (!soulId) {
+    return {
+      type: 'handled',
+      message: '❌ 缺少 soul id\n用法：/soul use|add|remove <id>',
+    };
+  }
+
+  if (sub === 'use') {
+    const result = await service.useSoul(sessionId, soulId);
+    if (!result.ok) {
+      return {
+        type: 'handled',
+        message: `❌ soul 设置失败：${result.reason ?? 'unknown error'}`,
+      };
+    }
+
+    const state = await service.getState(sessionId);
+    if (state) {
+      sessionStore.scheduleSoulStateSave(state);
+    }
+
+    return {
+      type: 'handled',
+      message: `✅ 已启用 soul：${soulId}`,
+    };
+  }
+
+  if (sub === 'add') {
+    const result = await service.addSoul(sessionId, soulId);
+    if (!result.ok) {
+      return {
+        type: 'handled',
+        message: `❌ soul 追加失败：${result.reason ?? 'unknown error'}`,
+      };
+    }
+
+    const state = await service.getState(sessionId);
+    if (state) {
+      sessionStore.scheduleSoulStateSave(state);
+    }
+
+    return {
+      type: 'handled',
+      message: `✅ 已追加 soul：${soulId}`,
+    };
+  }
+
+  if (sub === 'remove' || sub === 'rm') {
+    const result = await service.removeSoul(sessionId, soulId);
+    if (!result.ok) {
+      return {
+        type: 'handled',
+        message: `❌ soul 移除失败：${result.reason ?? 'unknown error'}`,
+      };
+    }
+
+    const state = await service.getState(sessionId);
+    if (state) {
+      sessionStore.scheduleSoulStateSave(state);
+    }
+
+    return {
+      type: 'handled',
+      message: `✅ 已移除 soul：${soulId}`,
+    };
+  }
+
+  return {
+    type: 'handled',
+    message: '❌ 用法：/soul list | /soul status | /soul use <id> | /soul add <id> | /soul remove <id> | /soul clear',
+  };
+}
+
 function handleModeCommand(args: string[]): CommandResult {
   const sub = args[0]?.toLowerCase();
   const mode = engine.getMode();
@@ -813,6 +1002,13 @@ function buildHelpMessage(): string {
     '/insight [days] - 汇总近 N 天会话洞见（默认 7 天，N 范围 1-365）',
     '/skills - 查看可用技能',
     '/skills <name|index> <message> - 使用技能',
+    '/soul - 查看可用 soul',
+    '/soul list - 列出可用 soul',
+    '/soul status - 查看当前会话 soul 状态',
+    '/soul use <id> - 切换到指定 soul',
+    '/soul add <id> - 追加一个 soul',
+    '/soul remove <id> - 移除一个 soul',
+    '/soul clear - 清除当前会话 soul',
     '/wt status - 查看当前会话绑定的 worktree',
     '/wt use <id> - 复用已有或创建新的 worktree 并绑定',
     '/wt use <id> <repoRoot> <worktreePath> [branch] - 绑定/更新当前会话 worktree',

--- a/apps/remote-server/src/core/session-store.ts
+++ b/apps/remote-server/src/core/session-store.ts
@@ -50,6 +50,13 @@ export interface ForkSessionResult {
   reason?: string;
 }
 
+export interface SoulStateSnapshot {
+  sessionId: string;
+  activeSoulIds: string[];
+  primarySoulId?: string;
+  updatedAt: number;
+}
+
 export interface SessionDetail {
   id: string;
   platformKey: string;
@@ -77,15 +84,27 @@ class RemoteSessionStore {
   private sessionsDir: string;
   private indexPath: string;
   private index: Record<string, string> = {};
+  private readonly soulDir: string;
+  private readonly soulStateDir: string;
+  private readonly soulCache = new Map<string, SoulStateSnapshot>();
+  private readonly soulDebounceTimers = new Map<string, NodeJS.Timeout>();
+  private readonly soulDebounceMs = 250;
+  private readonly soulPersistEnabled: boolean;
 
   constructor() {
     this.baseDir = join(homedir(), '.pulse-coder', 'remote-sessions');
     this.sessionsDir = join(this.baseDir, 'sessions');
     this.indexPath = join(this.baseDir, 'index.json');
+    this.soulDir = join(homedir(), '.pulse-coder', 'souls');
+    this.soulStateDir = join(this.soulDir, 'state', 'sessions');
+    this.soulPersistEnabled = process.env.PULSE_CODER_SOUL_PERSIST?.trim() !== '0';
   }
 
   async initialize(): Promise<void> {
     await fs.mkdir(this.sessionsDir, { recursive: true });
+    if (this.soulPersistEnabled) {
+      await fs.mkdir(this.soulStateDir, { recursive: true });
+    }
     try {
       const raw = await fs.readFile(this.indexPath, 'utf-8');
       this.index = JSON.parse(raw);
@@ -96,6 +115,85 @@ class RemoteSessionStore {
 
   private async saveIndex(): Promise<void> {
     await fs.writeFile(this.indexPath, JSON.stringify(this.index, null, 2), 'utf-8');
+  }
+
+  private soulStatePath(sessionId: string): string {
+    return join(this.soulStateDir, `${sessionId}.json`);
+  }
+
+  async getSoulState(sessionId: string): Promise<SoulStateSnapshot | null> {
+    const cached = this.soulCache.get(sessionId);
+    if (cached) {
+      return cached;
+    }
+
+    if (!this.soulPersistEnabled) {
+      return null;
+    }
+
+    try {
+      const raw = await fs.readFile(this.soulStatePath(sessionId), 'utf-8');
+      const parsed = JSON.parse(raw) as SoulStateSnapshot;
+      if (!parsed || parsed.sessionId !== sessionId) {
+        return null;
+      }
+      this.soulCache.set(sessionId, parsed);
+      return parsed;
+    } catch {
+      return null;
+    }
+  }
+
+  scheduleSoulStateSave(state: SoulStateSnapshot): void {
+    if (!this.soulPersistEnabled) {
+      return;
+    }
+
+    this.soulCache.set(state.sessionId, state);
+    if (this.soulDebounceTimers.has(state.sessionId)) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      this.soulDebounceTimers.delete(state.sessionId);
+      const latest = this.soulCache.get(state.sessionId);
+      if (latest) {
+        void this.persistSoulState(latest);
+      }
+    }, this.soulDebounceMs);
+
+    this.soulDebounceTimers.set(state.sessionId, timer);
+  }
+
+  async clearSoulState(sessionId: string): Promise<void> {
+    this.soulCache.delete(sessionId);
+    const timer = this.soulDebounceTimers.get(sessionId);
+    if (timer) {
+      clearTimeout(timer);
+      this.soulDebounceTimers.delete(sessionId);
+    }
+
+    if (!this.soulPersistEnabled) {
+      return;
+    }
+
+    try {
+      await fs.unlink(this.soulStatePath(sessionId));
+    } catch {
+      return;
+    }
+  }
+
+  private async persistSoulState(state: SoulStateSnapshot): Promise<void> {
+    if (!this.soulPersistEnabled) {
+      return;
+    }
+
+    try {
+      await fs.writeFile(this.soulStatePath(state.sessionId), JSON.stringify(state, null, 2), 'utf-8');
+    } catch {
+      return;
+    }
   }
 
   private sessionPath(sessionId: string): string {
@@ -340,6 +438,16 @@ class RemoteSessionStore {
     await this.writeSession(forkedSession);
     this.index[platformKey] = forkedSessionId;
     await this.saveIndex();
+
+    const sourceSoulState = await this.getSoulState(sourceSessionId);
+    if (sourceSoulState) {
+      this.scheduleSoulStateSave({
+        sessionId: forkedSessionId,
+        activeSoulIds: [...sourceSoulState.activeSoulIds],
+        primarySoulId: sourceSoulState.primarySoulId,
+        updatedAt: now,
+      });
+    }
 
     return {
       ok: true,

--- a/apps/remote-server/src/core/session-store.ts
+++ b/apps/remote-server/src/core/session-store.ts
@@ -50,13 +50,6 @@ export interface ForkSessionResult {
   reason?: string;
 }
 
-export interface SoulStateSnapshot {
-  sessionId: string;
-  activeSoulIds: string[];
-  primarySoulId?: string;
-  updatedAt: number;
-}
-
 export interface SessionDetail {
   id: string;
   platformKey: string;
@@ -84,27 +77,15 @@ class RemoteSessionStore {
   private sessionsDir: string;
   private indexPath: string;
   private index: Record<string, string> = {};
-  private readonly soulDir: string;
-  private readonly soulStateDir: string;
-  private readonly soulCache = new Map<string, SoulStateSnapshot>();
-  private readonly soulDebounceTimers = new Map<string, NodeJS.Timeout>();
-  private readonly soulDebounceMs = 250;
-  private readonly soulPersistEnabled: boolean;
 
   constructor() {
     this.baseDir = join(homedir(), '.pulse-coder', 'remote-sessions');
     this.sessionsDir = join(this.baseDir, 'sessions');
     this.indexPath = join(this.baseDir, 'index.json');
-    this.soulDir = join(homedir(), '.pulse-coder', 'souls');
-    this.soulStateDir = join(this.soulDir, 'state', 'sessions');
-    this.soulPersistEnabled = process.env.PULSE_CODER_SOUL_PERSIST?.trim() !== '0';
   }
 
   async initialize(): Promise<void> {
     await fs.mkdir(this.sessionsDir, { recursive: true });
-    if (this.soulPersistEnabled) {
-      await fs.mkdir(this.soulStateDir, { recursive: true });
-    }
     try {
       const raw = await fs.readFile(this.indexPath, 'utf-8');
       this.index = JSON.parse(raw);
@@ -115,85 +96,6 @@ class RemoteSessionStore {
 
   private async saveIndex(): Promise<void> {
     await fs.writeFile(this.indexPath, JSON.stringify(this.index, null, 2), 'utf-8');
-  }
-
-  private soulStatePath(sessionId: string): string {
-    return join(this.soulStateDir, `${sessionId}.json`);
-  }
-
-  async getSoulState(sessionId: string): Promise<SoulStateSnapshot | null> {
-    const cached = this.soulCache.get(sessionId);
-    if (cached) {
-      return cached;
-    }
-
-    if (!this.soulPersistEnabled) {
-      return null;
-    }
-
-    try {
-      const raw = await fs.readFile(this.soulStatePath(sessionId), 'utf-8');
-      const parsed = JSON.parse(raw) as SoulStateSnapshot;
-      if (!parsed || parsed.sessionId !== sessionId) {
-        return null;
-      }
-      this.soulCache.set(sessionId, parsed);
-      return parsed;
-    } catch {
-      return null;
-    }
-  }
-
-  scheduleSoulStateSave(state: SoulStateSnapshot): void {
-    if (!this.soulPersistEnabled) {
-      return;
-    }
-
-    this.soulCache.set(state.sessionId, state);
-    if (this.soulDebounceTimers.has(state.sessionId)) {
-      return;
-    }
-
-    const timer = setTimeout(() => {
-      this.soulDebounceTimers.delete(state.sessionId);
-      const latest = this.soulCache.get(state.sessionId);
-      if (latest) {
-        void this.persistSoulState(latest);
-      }
-    }, this.soulDebounceMs);
-
-    this.soulDebounceTimers.set(state.sessionId, timer);
-  }
-
-  async clearSoulState(sessionId: string): Promise<void> {
-    this.soulCache.delete(sessionId);
-    const timer = this.soulDebounceTimers.get(sessionId);
-    if (timer) {
-      clearTimeout(timer);
-      this.soulDebounceTimers.delete(sessionId);
-    }
-
-    if (!this.soulPersistEnabled) {
-      return;
-    }
-
-    try {
-      await fs.unlink(this.soulStatePath(sessionId));
-    } catch {
-      return;
-    }
-  }
-
-  private async persistSoulState(state: SoulStateSnapshot): Promise<void> {
-    if (!this.soulPersistEnabled) {
-      return;
-    }
-
-    try {
-      await fs.writeFile(this.soulStatePath(state.sessionId), JSON.stringify(state, null, 2), 'utf-8');
-    } catch {
-      return;
-    }
   }
 
   private sessionPath(sessionId: string): string {
@@ -438,16 +340,6 @@ class RemoteSessionStore {
     await this.writeSession(forkedSession);
     this.index[platformKey] = forkedSessionId;
     await this.saveIndex();
-
-    const sourceSoulState = await this.getSoulState(sourceSessionId);
-    if (sourceSoulState) {
-      this.scheduleSoulStateSave({
-        sessionId: forkedSessionId,
-        activeSoulIds: [...sourceSoulState.activeSoulIds],
-        primarySoulId: sourceSoulState.primarySoulId,
-        updatedAt: now,
-      });
-    }
 
     return {
       ok: true,

--- a/packages/engine/src/Engine.ts
+++ b/packages/engine/src/Engine.ts
@@ -235,7 +235,7 @@ export class Engine {
     // --- beforeRun hooks ---
     const beforeRunHooks = this.pluginManager.getHooks('beforeRun');
     for (const hook of beforeRunHooks) {
-      const result = await hook({ context, systemPrompt, tools });
+      const result = await hook({ context, systemPrompt, tools, runContext: options?.runContext });
       if (result) {
         if ('systemPrompt' in result && result.systemPrompt !== undefined) {
           systemPrompt = result.systemPrompt;

--- a/packages/engine/src/built-in/index.ts
+++ b/packages/engine/src/built-in/index.ts
@@ -8,6 +8,7 @@ import { builtInSkillsPlugin } from './skills-plugin';
 import { builtInPlanModePlugin } from './plan-mode-plugin';
 import { builtInToolSearchPlugin } from './tool-search-plugin';
 import { builtInTaskTrackingPlugin } from './task-tracking-plugin';
+import { builtInRoleSoulPlugin } from './role-soul-plugin';
 import { SubAgentPlugin } from './sub-agent-plugin';
 import { builtInAgentTeamsPlugin } from './agent-teams-plugin';
 
@@ -22,7 +23,8 @@ export const builtInPlugins = [
   builtInPlanModePlugin,
   builtInTaskTrackingPlugin,
   new SubAgentPlugin(),
-  builtInAgentTeamsPlugin
+  builtInAgentTeamsPlugin,
+  builtInRoleSoulPlugin,
 ];
 
 /**
@@ -35,6 +37,7 @@ export { builtInToolSearchPlugin } from './tool-search-plugin';
 export { builtInTaskTrackingPlugin, TaskListService } from './task-tracking-plugin';
 export type { TaskStatus, WorkTask, WorkTaskListSnapshot } from './task-tracking-plugin';
 export { builtInAgentTeamsPlugin } from './agent-teams-plugin';
+export { builtInRoleSoulPlugin } from './role-soul-plugin';
 export type { TeamRole, TaskGraph, TaskNode, NodeResult, TeamRunInput, TeamRunOutput } from './agent-teams-plugin/types';
 export type {
   PlanMode,

--- a/packages/engine/src/built-in/role-soul-plugin/index.ts
+++ b/packages/engine/src/built-in/role-soul-plugin/index.ts
@@ -42,6 +42,7 @@ export interface SoulService {
   addSoul(sessionId: string, soulId: string): Promise<SoulActionResult>;
   removeSoul(sessionId: string, soulId: string): Promise<SoulActionResult>;
   clearSession(sessionId: string): Promise<{ ok: boolean; reason?: string }>;
+  cloneState(fromSessionId: string, toSessionId: string): Promise<{ ok: boolean; reason?: string }>;
   buildPromptAppend(sessionId: string): Promise<string | null>;
 }
 
@@ -410,6 +411,27 @@ class BuiltInSoulService implements SoulService {
     this.states.delete(sessionId);
     this.loadedSessions.add(sessionId);
     await this.store.remove(sessionId);
+    return { ok: true };
+  }
+
+  async cloneState(fromSessionId: string, toSessionId: string): Promise<{ ok: boolean; reason?: string }> {
+    await this.ensureLoaded(fromSessionId);
+    const state = this.states.get(fromSessionId);
+    if (!state || state.activeSoulIds.length === 0) {
+      await this.clearSession(toSessionId);
+      return { ok: true };
+    }
+
+    const nextState: SoulState = {
+      sessionId: toSessionId,
+      activeSoulIds: [...state.activeSoulIds],
+      primarySoulId: state.primarySoulId,
+      updatedAt: now(),
+    };
+
+    this.states.set(toSessionId, nextState);
+    this.loadedSessions.add(toSessionId);
+    this.store.scheduleSave(nextState);
     return { ok: true };
   }
 

--- a/packages/engine/src/built-in/role-soul-plugin/index.ts
+++ b/packages/engine/src/built-in/role-soul-plugin/index.ts
@@ -1,0 +1,682 @@
+import { readFileSync } from 'fs';
+import { promises as fs } from 'fs';
+import { homedir } from 'os';
+import path from 'path';
+import { globSync } from 'glob';
+import matter from 'gray-matter';
+import { z } from 'zod';
+
+import type { EnginePlugin, EnginePluginContext } from '../../plugin/EnginePlugin.js';
+import type { SystemPromptOption } from '../../shared/types.js';
+import type { Tool } from '../../shared/types.js';
+
+export interface SoulDefinition {
+  id: string;
+  name: string;
+  description?: string;
+  prompt: string;
+  location: string;
+  metadata?: Record<string, any>;
+}
+
+export interface SoulState {
+  sessionId: string;
+  activeSoulIds: string[];
+  primarySoulId?: string;
+  updatedAt: number;
+}
+
+export interface SoulActionResult {
+  ok: boolean;
+  reason?: string;
+  state?: SoulState;
+  soul?: SoulDefinition;
+}
+
+export interface SoulService {
+  initialize(): Promise<void>;
+  listSouls(): SoulDefinition[];
+  getSoul(id: string): SoulDefinition | undefined;
+  getState(sessionId: string): Promise<SoulState | undefined>;
+  useSoul(sessionId: string, soulId: string): Promise<SoulActionResult>;
+  addSoul(sessionId: string, soulId: string): Promise<SoulActionResult>;
+  removeSoul(sessionId: string, soulId: string): Promise<SoulActionResult>;
+  clearSession(sessionId: string): Promise<{ ok: boolean; reason?: string }>;
+  buildPromptAppend(sessionId: string): Promise<string | null>;
+}
+
+const DEFAULT_STATE_DIR = path.join(homedir(), '.pulse-coder', 'souls', 'state');
+const DEFAULT_STATE_DEBOUNCE_MS = 250;
+
+const SOUL_REGISTER_INPUT_SCHEMA = z.object({
+  id: z.string().min(1).describe('Soul id (unique key).'),
+  name: z.string().min(1).describe('Soul display name.'),
+  description: z.string().optional().describe('Short description.'),
+  prompt: z.string().min(1).describe('Soul system prompt.'),
+});
+
+const SOUL_LIST_INPUT_SCHEMA = z.object({
+  format: z.enum(['summary', 'full']).optional().describe('Output format. Defaults to summary.'),
+});
+
+const SOUL_STATUS_INPUT_SCHEMA = z.object({
+  sessionId: z.string().min(1).optional().describe('Session id. Defaults to tool runContext.sessionId.'),
+});
+
+const SOUL_USE_INPUT_SCHEMA = z.object({
+  soulId: z.string().min(1).describe('Soul id to set as primary.'),
+  sessionId: z.string().min(1).optional().describe('Session id. Defaults to tool runContext.sessionId.'),
+});
+
+const SOUL_ADD_INPUT_SCHEMA = z.object({
+  soulId: z.string().min(1).describe('Soul id to append.'),
+  sessionId: z.string().min(1).optional().describe('Session id. Defaults to tool runContext.sessionId.'),
+});
+
+const SOUL_REMOVE_INPUT_SCHEMA = z.object({
+  soulId: z.string().min(1).describe('Soul id to remove.'),
+  sessionId: z.string().min(1).optional().describe('Session id. Defaults to tool runContext.sessionId.'),
+});
+
+const SOUL_CLEAR_INPUT_SCHEMA = z.object({
+  sessionId: z.string().min(1).optional().describe('Session id. Defaults to tool runContext.sessionId.'),
+});
+
+function normalizeSoulKey(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function now(): number {
+  return Date.now();
+}
+
+function appendSystemPrompt(base: SystemPromptOption | undefined, append: string): SystemPromptOption {
+  const normalizedAppend = append.trim();
+  if (!normalizedAppend) {
+    return base ?? { append: '' };
+  }
+
+  if (!base) {
+    return { append: normalizedAppend };
+  }
+
+  if (typeof base === 'string') {
+    return `${base}\n\n${normalizedAppend}`;
+  }
+
+  if (typeof base === 'function') {
+    return () => `${base()}\n\n${normalizedAppend}`;
+  }
+
+  const currentAppend = base.append.trim();
+  return {
+    append: currentAppend ? `${currentAppend}\n\n${normalizedAppend}` : normalizedAppend,
+  };
+}
+
+function describeSoul(soul: SoulDefinition): Record<string, any> {
+  return {
+    id: soul.id,
+    name: soul.name,
+    description: soul.description,
+    prompt: soul.prompt,
+    location: soul.location,
+  };
+}
+
+function summarizeSoul(soul: SoulDefinition): Record<string, any> {
+  return {
+    id: soul.id,
+    name: soul.name,
+    description: soul.description,
+  };
+}
+
+function resolveSessionId(input: { sessionId?: string }, runContext?: Record<string, any>): string | null {
+  const candidate = input.sessionId ?? runContext?.sessionId ?? runContext?.session_id;
+  if (typeof candidate !== 'string') {
+    return null;
+  }
+
+  const trimmed = candidate.trim();
+  return trimmed ? trimmed : null;
+}
+
+class SoulRegistry {
+  private souls = new Map<string, SoulDefinition>();
+  private initialized = false;
+
+  async initialize(cwd: string): Promise<void> {
+    if (this.initialized) {
+      return;
+    }
+
+    const soulList = await this.scanSouls(cwd);
+    this.souls.clear();
+
+    for (const soul of soulList) {
+      this.registerSoul(soul);
+    }
+
+    this.initialized = true;
+  }
+
+  getAll(): SoulDefinition[] {
+    return Array.from(this.souls.values());
+  }
+
+  get(id: string): SoulDefinition | undefined {
+    return this.souls.get(normalizeSoulKey(id));
+  }
+
+  registerSoul(soul: SoulDefinition): { soulId: string; replaced: boolean; total: number } {
+    const key = normalizeSoulKey(soul.id);
+    const replaced = this.souls.has(key);
+    this.souls.set(key, soul);
+
+    return {
+      soulId: soul.id,
+      replaced,
+      total: this.souls.size,
+    };
+  }
+
+  private async scanSouls(cwd: string): Promise<SoulDefinition[]> {
+    const souls: SoulDefinition[] = [];
+
+    const scanPaths = [
+      { base: cwd, pattern: '.pulse-coder/souls/**/SOUL.md' },
+      { base: cwd, pattern: '.agents/souls/**/SOUL.md' },
+      { base: cwd, pattern: '.coder/souls/**/SOUL.md' },
+      { base: homedir(), pattern: '.pulse-coder/souls/**/SOUL.md' },
+      { base: homedir(), pattern: '.agents/souls/**/SOUL.md' },
+      { base: homedir(), pattern: '.coder/souls/**/SOUL.md' },
+    ];
+
+    for (const { base, pattern } of scanPaths) {
+      try {
+        const files = globSync(pattern, { cwd: base, absolute: true });
+        for (const filePath of files) {
+          const soul = this.parseSoulFile(filePath);
+          if (soul) {
+            souls.push(soul);
+          }
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    return souls;
+  }
+
+  private parseSoulFile(filePath: string): SoulDefinition | null {
+    try {
+      const content = readFileSync(filePath, 'utf-8');
+      const parsed = matter(content);
+      const metadata = parsed.data as Record<string, any>;
+      const prompt = parsed.content.trim();
+
+      const id = String(metadata.id ?? metadata.name ?? path.basename(filePath, '.md')).trim();
+      if (!id) {
+        return null;
+      }
+
+      const name = String(metadata.name ?? id).trim();
+      if (!prompt) {
+        return null;
+      }
+
+      return {
+        id,
+        name,
+        description: metadata.description ? String(metadata.description).trim() : undefined,
+        prompt,
+        location: filePath,
+        metadata,
+      };
+    } catch {
+      return null;
+    }
+  }
+}
+
+class SoulStateStore {
+  private baseDir: string;
+  private sessionsDir: string;
+  private writeTimers = new Map<string, NodeJS.Timeout>();
+  private pendingStates = new Map<string, SoulState>();
+  private enabled: boolean;
+
+  constructor(options?: { baseDir?: string; enabled?: boolean }) {
+    this.baseDir = options?.baseDir ?? DEFAULT_STATE_DIR;
+    this.sessionsDir = path.join(this.baseDir, 'sessions');
+    this.enabled = options?.enabled ?? true;
+  }
+
+  async initialize(): Promise<void> {
+    if (!this.enabled) {
+      return;
+    }
+    await fs.mkdir(this.sessionsDir, { recursive: true });
+  }
+
+  async load(sessionId: string): Promise<SoulState | null> {
+    if (!this.enabled) {
+      return null;
+    }
+
+    try {
+      const raw = await fs.readFile(this.sessionPath(sessionId), 'utf-8');
+      const parsed = JSON.parse(raw) as SoulState;
+      if (!parsed || parsed.sessionId !== sessionId) {
+        return null;
+      }
+      return parsed;
+    } catch {
+      return null;
+    }
+  }
+
+  scheduleSave(state: SoulState): void {
+    if (!this.enabled) {
+      return;
+    }
+
+    this.pendingStates.set(state.sessionId, state);
+    if (this.writeTimers.has(state.sessionId)) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      this.writeTimers.delete(state.sessionId);
+      const latest = this.pendingStates.get(state.sessionId);
+      this.pendingStates.delete(state.sessionId);
+      if (latest) {
+        void this.persist(latest);
+      }
+    }, DEFAULT_STATE_DEBOUNCE_MS);
+
+    this.writeTimers.set(state.sessionId, timer);
+  }
+
+  async remove(sessionId: string): Promise<void> {
+    if (!this.enabled) {
+      return;
+    }
+
+    const timer = this.writeTimers.get(sessionId);
+    if (timer) {
+      clearTimeout(timer);
+      this.writeTimers.delete(sessionId);
+    }
+    this.pendingStates.delete(sessionId);
+
+    try {
+      await fs.unlink(this.sessionPath(sessionId));
+    } catch {
+      return;
+    }
+  }
+
+  private async persist(state: SoulState): Promise<void> {
+    try {
+      await fs.mkdir(this.sessionsDir, { recursive: true });
+      await fs.writeFile(this.sessionPath(state.sessionId), JSON.stringify(state, null, 2), 'utf-8');
+    } catch {
+      return;
+    }
+  }
+
+  private sessionPath(sessionId: string): string {
+    return path.join(this.sessionsDir, `${sessionId}.json`);
+  }
+}
+
+class BuiltInSoulService implements SoulService {
+  private registry = new SoulRegistry();
+  private store: SoulStateStore;
+  private states = new Map<string, SoulState>();
+  private loadedSessions = new Set<string>();
+  private logger: EnginePluginContext['logger'];
+
+  constructor(logger: EnginePluginContext['logger']) {
+    const baseDir = process.env.PULSE_CODER_SOUL_STATE_DIR?.trim();
+    const enabled = process.env.PULSE_CODER_SOUL_PERSIST?.trim() !== '0';
+    this.store = new SoulStateStore({
+      baseDir: baseDir || undefined,
+      enabled,
+    });
+    this.logger = logger;
+  }
+
+  async initialize(): Promise<void> {
+    await this.registry.initialize(process.cwd());
+    await this.store.initialize();
+  }
+
+  listSouls(): SoulDefinition[] {
+    return this.registry.getAll();
+  }
+
+  getSoul(id: string): SoulDefinition | undefined {
+    return this.registry.get(id);
+  }
+
+  async getState(sessionId: string): Promise<SoulState | undefined> {
+    await this.ensureLoaded(sessionId);
+    return this.states.get(sessionId);
+  }
+
+  async useSoul(sessionId: string, soulId: string): Promise<SoulActionResult> {
+    return this.setSoulState(sessionId, soulId, 'replace');
+  }
+
+  async addSoul(sessionId: string, soulId: string): Promise<SoulActionResult> {
+    return this.setSoulState(sessionId, soulId, 'append');
+  }
+
+  async removeSoul(sessionId: string, soulId: string): Promise<SoulActionResult> {
+    await this.ensureLoaded(sessionId);
+    const state = this.states.get(sessionId);
+    if (!state || state.activeSoulIds.length === 0) {
+      return { ok: false, reason: '当前会话没有启用任何 soul' };
+    }
+
+    const targetKey = normalizeSoulKey(soulId);
+    const nextIds = state.activeSoulIds.filter((id) => normalizeSoulKey(id) !== targetKey);
+    if (nextIds.length === state.activeSoulIds.length) {
+      return { ok: false, reason: `未找到 soul: ${soulId}` };
+    }
+
+    const primary = state.primarySoulId && normalizeSoulKey(state.primarySoulId) === targetKey
+      ? nextIds[0]
+      : state.primarySoulId;
+
+    const nextState: SoulState = {
+      ...state,
+      activeSoulIds: nextIds,
+      primarySoulId: primary,
+      updatedAt: now(),
+    };
+
+    this.states.set(sessionId, nextState);
+    this.store.scheduleSave(nextState);
+
+    return { ok: true, state: nextState };
+  }
+
+  async clearSession(sessionId: string): Promise<{ ok: boolean; reason?: string }> {
+    this.states.delete(sessionId);
+    this.loadedSessions.add(sessionId);
+    await this.store.remove(sessionId);
+    return { ok: true };
+  }
+
+  async buildPromptAppend(sessionId: string): Promise<string | null> {
+    await this.ensureLoaded(sessionId);
+    const state = this.states.get(sessionId);
+    if (!state || state.activeSoulIds.length === 0) {
+      return null;
+    }
+
+    const souls: SoulDefinition[] = [];
+    for (const id of state.activeSoulIds) {
+      const soul = this.registry.get(id);
+      if (soul) {
+        souls.push(soul);
+      }
+    }
+
+    if (souls.length === 0) {
+      return null;
+    }
+
+    const lines: string[] = ['## Role Soul'];
+    for (const soul of souls) {
+      lines.push(`### ${soul.name}`);
+      lines.push(soul.prompt.trim());
+    }
+
+    return lines.join('\n');
+  }
+
+  registerSoul(input: { id: string; name: string; description?: string; prompt: string }): SoulDefinition {
+    const soul: SoulDefinition = {
+      id: input.id.trim(),
+      name: input.name.trim(),
+      description: input.description?.trim(),
+      prompt: input.prompt.trim(),
+      location: 'runtime',
+      metadata: { source: 'runtime' },
+    };
+
+    this.registry.registerSoul(soul);
+    return soul;
+  }
+
+  private async setSoulState(
+    sessionId: string,
+    soulId: string,
+    mode: 'replace' | 'append',
+  ): Promise<SoulActionResult> {
+    await this.ensureLoaded(sessionId);
+    const soul = this.registry.get(soulId);
+    if (!soul) {
+      return { ok: false, reason: `未找到 soul: ${soulId}` };
+    }
+
+    const current = this.states.get(sessionId);
+    const nextIds = current?.activeSoulIds ? [...current.activeSoulIds] : [];
+    const targetKey = normalizeSoulKey(soul.id);
+
+    if (mode === 'replace') {
+      nextIds.length = 0;
+      nextIds.push(soul.id);
+    } else if (!nextIds.some((id) => normalizeSoulKey(id) === targetKey)) {
+      nextIds.push(soul.id);
+    }
+
+    const nextState: SoulState = {
+      sessionId,
+      activeSoulIds: nextIds,
+      primarySoulId: mode === 'replace' ? soul.id : (current?.primarySoulId ?? soul.id),
+      updatedAt: now(),
+    };
+
+    this.states.set(sessionId, nextState);
+    this.store.scheduleSave(nextState);
+
+    return { ok: true, state: nextState, soul };
+  }
+
+  private async ensureLoaded(sessionId: string): Promise<void> {
+    if (this.loadedSessions.has(sessionId)) {
+      return;
+    }
+
+    this.loadedSessions.add(sessionId);
+    const stored = await this.store.load(sessionId);
+    if (stored) {
+      this.states.set(sessionId, stored);
+      return;
+    }
+
+    if (!this.states.has(sessionId)) {
+      this.states.set(sessionId, {
+        sessionId,
+        activeSoulIds: [],
+        updatedAt: now(),
+      });
+    }
+  }
+}
+
+export const builtInRoleSoulPlugin: EnginePlugin = {
+  name: 'pulse-coder-engine/built-in-role-soul',
+  version: '0.1.0',
+
+  async initialize(context: EnginePluginContext): Promise<void> {
+    const service = new BuiltInSoulService(context.logger);
+    await service.initialize();
+
+    context.registerService('soulService', service);
+
+    context.registerTools({
+      soul_list: buildSoulListTool(service),
+      soul_status: buildSoulStatusTool(service),
+      soul_use: buildSoulUseTool(service),
+      soul_add: buildSoulAddTool(service),
+      soul_remove: buildSoulRemoveTool(service),
+      soul_clear: buildSoulClearTool(service),
+      soul_register: buildSoulRegisterTool(service),
+    });
+
+    context.registerHook('beforeRun', async ({ systemPrompt, runContext }) => {
+      const sessionId = typeof runContext?.sessionId === 'string'
+        ? runContext.sessionId
+        : (typeof runContext?.session_id === 'string' ? runContext.session_id : undefined);
+
+      if (!sessionId) {
+        return;
+      }
+
+      try {
+        const append = await service.buildPromptAppend(sessionId);
+        if (!append) {
+          return;
+        }
+        return { systemPrompt: appendSystemPrompt(systemPrompt, append) };
+      } catch (error) {
+        context.logger.warn('[RoleSoul] Failed to build prompt append', error as Error);
+        return;
+      }
+    });
+
+    context.logger.info('[RoleSoul] Built-in role soul plugin initialized', {
+      souls: service.listSouls().length,
+    });
+  },
+};
+
+function buildSoulListTool(service: BuiltInSoulService): Tool {
+  return {
+    name: 'soul_list',
+    description: 'List available souls.',
+    inputSchema: SOUL_LIST_INPUT_SCHEMA,
+    execute: async (input) => {
+      const format = input.format ?? 'summary';
+      const list = service.listSouls();
+      return format === 'full'
+        ? list.map((soul) => describeSoul(soul))
+        : list.map((soul) => summarizeSoul(soul));
+    },
+  };
+}
+
+function buildSoulStatusTool(service: BuiltInSoulService): Tool {
+  return {
+    name: 'soul_status',
+    description: 'Get soul state for the current session.',
+    inputSchema: SOUL_STATUS_INPUT_SCHEMA,
+    execute: async (input, context) => {
+      const sessionId = resolveSessionId(input, context?.runContext);
+      if (!sessionId) {
+        throw new Error('sessionId is required to read soul state');
+      }
+
+      const state = await service.getState(sessionId);
+      return {
+        sessionId,
+        state: state ?? null,
+      };
+    },
+  };
+}
+
+function buildSoulUseTool(service: BuiltInSoulService): Tool {
+  return {
+    name: 'soul_use',
+    description: 'Replace active souls with the specified soul.',
+    inputSchema: SOUL_USE_INPUT_SCHEMA,
+    execute: async (input, context) => {
+      const sessionId = resolveSessionId(input, context?.runContext);
+      if (!sessionId) {
+        throw new Error('sessionId is required to update soul state');
+      }
+
+      return await service.useSoul(sessionId, input.soulId);
+    },
+  };
+}
+
+function buildSoulAddTool(service: BuiltInSoulService): Tool {
+  return {
+    name: 'soul_add',
+    description: 'Add a soul to the active list for the current session.',
+    inputSchema: SOUL_ADD_INPUT_SCHEMA,
+    execute: async (input, context) => {
+      const sessionId = resolveSessionId(input, context?.runContext);
+      if (!sessionId) {
+        throw new Error('sessionId is required to update soul state');
+      }
+
+      return await service.addSoul(sessionId, input.soulId);
+    },
+  };
+}
+
+function buildSoulRemoveTool(service: BuiltInSoulService): Tool {
+  return {
+    name: 'soul_remove',
+    description: 'Remove a soul from the active list for the current session.',
+    inputSchema: SOUL_REMOVE_INPUT_SCHEMA,
+    execute: async (input, context) => {
+      const sessionId = resolveSessionId(input, context?.runContext);
+      if (!sessionId) {
+        throw new Error('sessionId is required to update soul state');
+      }
+
+      return await service.removeSoul(sessionId, input.soulId);
+    },
+  };
+}
+
+function buildSoulClearTool(service: BuiltInSoulService): Tool {
+  return {
+    name: 'soul_clear',
+    description: 'Clear soul state for the current session.',
+    inputSchema: SOUL_CLEAR_INPUT_SCHEMA,
+    execute: async (input, context) => {
+      const sessionId = resolveSessionId(input, context?.runContext);
+      if (!sessionId) {
+        throw new Error('sessionId is required to clear soul state');
+      }
+
+      return await service.clearSession(sessionId);
+    },
+  };
+}
+
+function buildSoulRegisterTool(service: BuiltInSoulService): Tool {
+  return {
+    name: 'soul_register',
+    description: 'Register or replace a soul definition at runtime.',
+    inputSchema: SOUL_REGISTER_INPUT_SCHEMA,
+    execute: async (input) => {
+      const soul = service.registerSoul({
+        id: input.id,
+        name: input.name,
+        description: input.description,
+        prompt: input.prompt,
+      });
+
+      return {
+        ok: true,
+        soul: summarizeSoul(soul),
+      };
+    },
+  };
+}
+
+export default builtInRoleSoulPlugin;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -31,6 +31,7 @@ export {
   builtInPlanModePlugin,
   builtInTaskTrackingPlugin,
   builtInAgentTeamsPlugin,
+  builtInRoleSoulPlugin,
   BuiltInSkillRegistry,
   BuiltInPlanModeService,
   TaskListService,

--- a/packages/engine/src/plugin/EnginePlugin.ts
+++ b/packages/engine/src/plugin/EnginePlugin.ts
@@ -16,6 +16,7 @@ export interface BeforeRunInput {
   context: Context;
   systemPrompt?: SystemPromptOption;
   tools: Record<string, any>;
+  runContext?: Record<string, any>;
 }
 
 export interface BeforeRunResult {


### PR DESCRIPTION
Add built-in role soul support and remote command wiring

- register role soul plugin with tools and prompt injection
- centralize soul state persistence and cloning in engine
- slim remote-server integration to command forwarding