### PR TITLE
feat: add built-in PTC rule-based orchestration

### DIFF
--- a/apps/remote-server/README.md
+++ b/apps/remote-server/README.md
@@ -19,7 +19,52 @@ Expected behavior:
 - First run: model uses tool search and discovers `deferred_demo`.
 - Second run: `deferred_demo` is now loaded and can be called directly.
 
-## Enabled webhook endpoints
+## PTC demo tools
+
+`remote-server` now includes several demo tools to validate PTC filtering by caller selectors.
+
+Registered demo tools:
+- `ptc_demo_caller_probe` (no restrictions)
+- `ptc_demo_discord_only` (`allowed_callers: ["platform:discord"]`)
+- `ptc_demo_feishu_only` (`allowed_callers: ["platform:feishu"]`)
+- `ptc_demo_internal_only` (`allowed_callers: ["platform:internal"]`)
+- `ptc_demo_group_only` (`allowed_callers: ["kind:group", "kind:channel"]`)
+
+How selectors are produced in remote-server:
+- `runContext.callerSelectors` always includes `platform_key:<platformKey-lowercase>`
+- plus platform selector like `platform:discord` / `platform:feishu` / `platform:internal`
+- plus kind selector like `kind:dm` / `kind:channel` / `kind:group`
+- plus `thread:true|false` for Discord thread/channel cases
+
+Quick internal API checks:
+
+```bash
+# internal caller: should allow internal_only, block discord_only/feishu_only
+curl -sS -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $INTERNAL_API_SECRET" \
+  http://127.0.0.1:3000/internal/agent/run \
+  -d '{"platformKey":"internal:ptc-demo","text":"Call ptc_demo_internal_only with message=ok, then call ptc_demo_discord_only."}'
+```
+
+```bash
+# discord channel caller: should allow discord_only and group_only
+curl -sS -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $INTERNAL_API_SECRET" \
+  http://127.0.0.1:3000/internal/agent/run \
+  -d '{"platformKey":"discord:channel:123456:789","text":"Call ptc_demo_discord_only and ptc_demo_group_only with message=ok."}'
+```
+
+```bash
+# feishu dm caller: should allow feishu_only, block group_only
+curl -sS -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $INTERNAL_API_SECRET" \
+  http://127.0.0.1:3000/internal/agent/run \
+  -d '{"platformKey":"feishu:ou_xxx","text":"Call ptc_demo_feishu_only and then ptc_demo_group_only."}'
+```
+
 
 - `POST /webhooks/feishu`
 - `POST /webhooks/discord`

--- a/apps/remote-server/src/core/agent-runner.ts
+++ b/apps/remote-server/src/core/agent-runner.ts
@@ -47,11 +47,15 @@ function buildRunContext(input: {
   ownerKey?: string;
 }): Record<string, any> {
   const channel = parseChannelInfo(input.platformKey);
+  const callerSelectors = buildCallerSelectors(input.platformKey, channel);
+
   return {
     sessionId: input.sessionId,
     userText: input.userText,
     platformKey: input.platformKey,
     ownerKey: input.ownerKey,
+    caller: callerSelectors[0],
+    callerSelectors,
     channel: channel ?? undefined,
   };
 }
@@ -140,6 +144,33 @@ function parseChannelInfo(platformKey: string): RunChannelInfo | undefined {
   }
 
   return { platform: 'unknown' };
+}
+
+function buildCallerSelectors(platformKey: string, channel?: RunChannelInfo): string[] {
+  const selectors = new Set<string>();
+  const normalizedPlatformKey = platformKey.trim().toLowerCase();
+
+  if (normalizedPlatformKey) {
+    selectors.add(`platform_key:${normalizedPlatformKey}`);
+  }
+
+  if (channel?.platform) {
+    selectors.add(`platform:${channel.platform}`);
+  }
+
+  if (channel?.kind) {
+    selectors.add(`kind:${channel.kind}`);
+  }
+
+  if (channel?.isThread === true) {
+    selectors.add('thread:true');
+  }
+
+  if (channel?.isThread === false) {
+    selectors.add('thread:false');
+  }
+
+  return [...selectors];
 }
 
 function buildChannelSystemPrompt(platformKey: string): string | null {

--- a/apps/remote-server/src/core/engine-singleton.ts
+++ b/apps/remote-server/src/core/engine-singleton.ts
@@ -5,6 +5,7 @@ import { cronJobTool } from './tools/cron-job.js';
 import { deferDemoTool } from './tools/defer-demo.js';
 import { jinaAiReadTool } from './tools/jina-ai.js';
 import { sessionSummaryTool } from './tools/session-summary.js';
+import { ptcDemoTools } from './tools/ptc-demo.js';
 
 /**
  * Single Engine instance shared across all platform adapters.
@@ -23,5 +24,6 @@ export const engine = new Engine({
     deferred_demo: deferDemoTool,
     jina_ai_read: jinaAiReadTool,
     session_summary: sessionSummaryTool,
+    ...ptcDemoTools,
   },
 });

--- a/apps/remote-server/src/core/engine-singleton.ts
+++ b/apps/remote-server/src/core/engine-singleton.ts
@@ -1,4 +1,4 @@
-import { Engine, builtInPtcPlugin } from 'pulse-coder-engine';
+import { Engine } from 'pulse-coder-engine';
 import { memoryIntegration } from './memory-integration.js';
 import { worktreeIntegration } from './worktree/integration.js';
 import { cronJobTool } from './tools/cron-job.js';
@@ -14,7 +14,6 @@ import { sessionSummaryTool } from './tools/session-summary.js';
 export const engine = new Engine({
   enginePlugins: {
     plugins: [
-      builtInPtcPlugin,
       memoryIntegration.enginePlugin,
       worktreeIntegration.enginePlugin,
     ],

--- a/apps/remote-server/src/core/engine-singleton.ts
+++ b/apps/remote-server/src/core/engine-singleton.ts
@@ -1,4 +1,4 @@
-import { Engine } from 'pulse-coder-engine';
+import { Engine, builtInPtcPlugin } from 'pulse-coder-engine';
 import { memoryIntegration } from './memory-integration.js';
 import { worktreeIntegration } from './worktree/integration.js';
 import { cronJobTool } from './tools/cron-job.js';
@@ -14,6 +14,7 @@ import { sessionSummaryTool } from './tools/session-summary.js';
 export const engine = new Engine({
   enginePlugins: {
     plugins: [
+      builtInPtcPlugin,
       memoryIntegration.enginePlugin,
       worktreeIntegration.enginePlugin,
     ],

--- a/apps/remote-server/src/core/tools/ptc-demo.ts
+++ b/apps/remote-server/src/core/tools/ptc-demo.ts
@@ -1,0 +1,100 @@
+import z from 'zod';
+import type { Tool, ToolExecutionContext } from 'pulse-coder-engine';
+
+const toolSchema = z.object({
+  message: z.string().optional().describe('Optional message echoed in response.'),
+});
+
+type DemoInput = z.infer<typeof toolSchema>;
+
+interface DemoResult {
+  ok: true;
+  tool: string;
+  message: string;
+  caller?: string;
+  callerSelectors: string[];
+  platformKey?: string;
+  note: string;
+}
+
+function resolveSelectors(context?: ToolExecutionContext): string[] {
+  const selectors = context?.runContext?.callerSelectors;
+  if (typeof selectors === 'string') {
+    return [selectors];
+  }
+  if (Array.isArray(selectors)) {
+    return selectors.filter((item): item is string => typeof item === 'string');
+  }
+  return [];
+}
+
+function buildDemoTool(
+  name: string,
+  description: string,
+  note: string,
+  allowedCallers?: string[],
+): Tool<DemoInput, DemoResult> {
+  return {
+    name,
+    description,
+    inputSchema: toolSchema,
+    allowed_callers: allowedCallers,
+    execute: async (input, context) => {
+      const callerSelectors = resolveSelectors(context);
+      const caller = typeof context?.runContext?.caller === 'string' ? context.runContext.caller : undefined;
+      const platformKey = typeof context?.runContext?.platformKey === 'string' ? context.runContext.platformKey : undefined;
+
+      return {
+        ok: true,
+        tool: name,
+        message: input.message?.trim() || 'PTC demo success',
+        caller,
+        callerSelectors,
+        platformKey,
+        note,
+      };
+    },
+  };
+}
+
+export const ptcDemoCallerProbeTool = buildDemoTool(
+  'ptc_demo_caller_probe',
+  'Inspect caller selectors in runContext for PTC demo.',
+  'Unrestricted tool. Always callable if exposed by normal tool registration.',
+);
+
+export const ptcDemoDiscordOnlyTool = buildDemoTool(
+  'ptc_demo_discord_only',
+  'PTC demo tool that is only available to Discord callers.',
+  'Restricted by allowed_callers=["platform:discord"].',
+  ['platform:discord'],
+);
+
+export const ptcDemoFeishuOnlyTool = buildDemoTool(
+  'ptc_demo_feishu_only',
+  'PTC demo tool that is only available to Feishu callers.',
+  'Restricted by allowed_callers=["platform:feishu"].',
+  ['platform:feishu'],
+);
+
+export const ptcDemoInternalOnlyTool = buildDemoTool(
+  'ptc_demo_internal_only',
+  'PTC demo tool that is only available to internal callers.',
+  'Restricted by allowed_callers=["platform:internal"].',
+  ['platform:internal'],
+);
+
+export const ptcDemoGroupOnlyTool = buildDemoTool(
+  'ptc_demo_group_only',
+  'PTC demo tool that is only available in group-like channels.',
+  'Restricted by allowed_callers=["kind:group", "kind:channel"].',
+  ['kind:group', 'kind:channel'],
+);
+
+export const ptcDemoTools: Record<string, Tool> = {
+  ptc_demo_caller_probe: ptcDemoCallerProbeTool,
+  ptc_demo_discord_only: ptcDemoDiscordOnlyTool,
+  ptc_demo_feishu_only: ptcDemoFeishuOnlyTool,
+  ptc_demo_internal_only: ptcDemoInternalOnlyTool,
+  ptc_demo_group_only: ptcDemoGroupOnlyTool,
+};

--- a/packages/engine/src/built-in/index.ts
+++ b/packages/engine/src/built-in/index.ts
@@ -38,6 +38,7 @@ export { builtInTaskTrackingPlugin, TaskListService } from './task-tracking-plug
 export type { TaskStatus, WorkTask, WorkTaskListSnapshot } from './task-tracking-plugin';
 export { builtInAgentTeamsPlugin } from './agent-teams-plugin';
 export { builtInRoleSoulPlugin } from './role-soul-plugin';
+export { builtInPtcPlugin } from './ptc-plugin';
 export type { TeamRole, TaskGraph, TaskNode, NodeResult, TeamRunInput, TeamRunOutput } from './agent-teams-plugin/types';
 export type {
   PlanMode,

--- a/packages/engine/src/built-in/index.ts
+++ b/packages/engine/src/built-in/index.ts
@@ -11,6 +11,7 @@ import { builtInTaskTrackingPlugin } from './task-tracking-plugin';
 import { builtInRoleSoulPlugin } from './role-soul-plugin';
 import { SubAgentPlugin } from './sub-agent-plugin';
 import { builtInAgentTeamsPlugin } from './agent-teams-plugin';
+import { builtInPtcPlugin } from './ptc-plugin';
 
 /**
  * 默认内置插件列表
@@ -25,6 +26,7 @@ export const builtInPlugins = [
   new SubAgentPlugin(),
   builtInAgentTeamsPlugin,
   builtInRoleSoulPlugin,
+  builtInPtcPlugin,
 ];
 
 /**

--- a/packages/engine/src/built-in/ptc-plugin/index.ts
+++ b/packages/engine/src/built-in/ptc-plugin/index.ts
@@ -1,0 +1,1 @@
+export { builtInPtcPlugin } from './ptc-plugin';

--- a/packages/engine/src/built-in/ptc-plugin/ptc-plugin.test.ts
+++ b/packages/engine/src/built-in/ptc-plugin/ptc-plugin.test.ts
@@ -55,7 +55,7 @@ describe('builtInPtcPlugin', () => {
     vi.stubEnv('PULSE_CODER_PTC_STRICT', 'false');
   });
 
-  it('filters tools by allowed_callers using runContext channel selectors', async () => {
+  it('filters tools by allowed_callers using runContext.callerSelectors', async () => {
     const { context, hooks } = createPluginContext();
     await builtInPtcPlugin.initialize(context);
 
@@ -66,11 +66,7 @@ describe('builtInPtcPlugin', () => {
       context: { messages: [] },
       tools: {},
       runContext: {
-        channel: {
-          platform: 'discord',
-          kind: 'thread',
-          channelId: '123',
-        },
+        callerSelectors: ['discord:thread'],
       },
     });
 
@@ -91,7 +87,7 @@ describe('builtInPtcPlugin', () => {
         inputSchema: {} as never,
         allowed_callers: ['discord:thread'],
         execute: threadToolExecute,
-      } as Tool,
+      },
       feishu_group_tool: {
         name: 'feishu_group_tool',
         description: 'feishu group only',
@@ -115,6 +111,41 @@ describe('builtInPtcPlugin', () => {
     expect(Object.keys(result!.tools!)).not.toContain('feishu_group_tool');
   });
 
+  it('supports runContext.caller fallback for selector matching', async () => {
+    const { context, hooks } = createPluginContext();
+    await builtInPtcPlugin.initialize(context);
+
+    const beforeRun = firstHook(hooks, 'beforeRun');
+    const beforeLLMCall = firstHook(hooks, 'beforeLLMCall');
+
+    await beforeRun({
+      context: { messages: [] },
+      tools: {},
+      runContext: {
+        caller: 'cron',
+      },
+    });
+
+    const cronExecute = vi.fn(async () => 'ok');
+    const tools: Record<string, Tool> = {
+      cron_only_tool: {
+        name: 'cron_only_tool',
+        description: 'cron only',
+        inputSchema: {} as never,
+        allowed_callers: ['cron'],
+        execute: cronExecute,
+      },
+    };
+
+    const result = await beforeLLMCall({
+      context: { messages: [] },
+      tools,
+      systemPrompt: undefined,
+    });
+
+    expect(result?.tools?.cron_only_tool).toBeDefined();
+  });
+
   it('blocks runtime execution when execution runContext does not match allowed_callers', async () => {
     const { context, hooks } = createPluginContext();
     await builtInPtcPlugin.initialize(context);
@@ -126,10 +157,7 @@ describe('builtInPtcPlugin', () => {
       context: { messages: [] },
       tools: {},
       runContext: {
-        channel: {
-          platform: 'discord',
-          kind: 'thread',
-        },
+        callerSelectors: ['discord:thread'],
       },
     });
 
@@ -141,7 +169,7 @@ describe('builtInPtcPlugin', () => {
         inputSchema: {} as never,
         allowed_callers: ['discord:thread'],
         execute,
-      } as Tool,
+      },
     };
 
     const result = await beforeLLMCall({
@@ -156,10 +184,7 @@ describe('builtInPtcPlugin', () => {
     await expect(
       guardedTool!.execute({}, {
         runContext: {
-          channel: {
-            platform: 'feishu',
-            kind: 'group',
-          },
+          callerSelectors: ['feishu:group'],
         },
       }),
     ).rejects.toThrow('[PTC] Tool "guarded_tool" is not allowed for the current caller.');
@@ -188,7 +213,7 @@ describe('builtInPtcPlugin', () => {
         inputSchema: {} as never,
         allowed_callers: ['*'],
         execute,
-      } as Tool,
+      },
     };
 
     const result = await beforeLLMCall({

--- a/packages/engine/src/built-in/ptc-plugin/ptc-plugin.test.ts
+++ b/packages/engine/src/built-in/ptc-plugin/ptc-plugin.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { EngineHookMap, EngineHookName, EnginePluginContext } from '../../plugin/EnginePlugin.js';
+import type { Tool } from '../../shared/types.js';
+import { builtInPtcPlugin } from './ptc-plugin.js';
+
+type HookStore = {
+  [K in EngineHookName]?: Array<EngineHookMap[K]>;
+};
+
+function createPluginContext() {
+  const hooks: HookStore = {};
+  const services = new Map<string, unknown>();
+
+  const context: EnginePluginContext = {
+    registerTool: () => undefined,
+    registerTools: () => undefined,
+    getTool: () => undefined,
+    getTools: () => ({}),
+    getEngineInstance: () => ({ tools: {} }),
+    registerHook: (hookName, handler) => {
+      (hooks[hookName] ??= []).push(handler as never);
+    },
+    registerService: (name, service) => {
+      services.set(name, service);
+    },
+    getService: (name) => services.get(name),
+    getConfig: () => undefined,
+    setConfig: () => undefined,
+    events: { emit: () => true } as never,
+    logger: {
+      debug: () => undefined,
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    },
+  };
+
+  return { context, hooks };
+}
+
+function firstHook<K extends EngineHookName>(hooks: HookStore, name: K): EngineHookMap[K] {
+  const handlers = hooks[name];
+  if (!handlers || handlers.length === 0) {
+    throw new Error(`Missing hook: ${name}`);
+  }
+  return handlers[0] as EngineHookMap[K];
+}
+
+describe('builtInPtcPlugin', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('PULSE_CODER_PTC_ENABLED', 'true');
+    vi.stubEnv('PULSE_CODER_PTC_APPEND_PROMPT', 'false');
+    vi.stubEnv('PULSE_CODER_PTC_STRICT', 'false');
+  });
+
+  it('filters tools by allowed_callers using runContext channel selectors', async () => {
+    const { context, hooks } = createPluginContext();
+    await builtInPtcPlugin.initialize(context);
+
+    const beforeRun = firstHook(hooks, 'beforeRun');
+    const beforeLLMCall = firstHook(hooks, 'beforeLLMCall');
+
+    await beforeRun({
+      context: { messages: [] },
+      tools: {},
+      runContext: {
+        channel: {
+          platform: 'discord',
+          kind: 'thread',
+          channelId: '123',
+        },
+      },
+    });
+
+    const publicToolExecute = vi.fn(async () => 'public');
+    const threadToolExecute = vi.fn(async () => 'discord-thread');
+    const feishuToolExecute = vi.fn(async () => 'feishu-group');
+
+    const tools: Record<string, Tool> = {
+      public_tool: {
+        name: 'public_tool',
+        description: 'always available',
+        inputSchema: {} as never,
+        execute: publicToolExecute,
+      },
+      discord_thread_tool: {
+        name: 'discord_thread_tool',
+        description: 'discord thread only',
+        inputSchema: {} as never,
+        allowed_callers: ['discord:thread'],
+        execute: threadToolExecute,
+      } as Tool,
+      feishu_group_tool: {
+        name: 'feishu_group_tool',
+        description: 'feishu group only',
+        inputSchema: {} as never,
+        ptc: {
+          allowed_callers: ['feishu:group'],
+        },
+        execute: feishuToolExecute,
+      } as Tool,
+    };
+
+    const result = await beforeLLMCall({
+      context: { messages: [] },
+      tools,
+      systemPrompt: undefined,
+    });
+
+    expect(result?.tools).toBeDefined();
+    expect(Object.keys(result!.tools!)).toContain('public_tool');
+    expect(Object.keys(result!.tools!)).toContain('discord_thread_tool');
+    expect(Object.keys(result!.tools!)).not.toContain('feishu_group_tool');
+  });
+
+  it('blocks runtime execution when execution runContext does not match allowed_callers', async () => {
+    const { context, hooks } = createPluginContext();
+    await builtInPtcPlugin.initialize(context);
+
+    const beforeRun = firstHook(hooks, 'beforeRun');
+    const beforeLLMCall = firstHook(hooks, 'beforeLLMCall');
+
+    await beforeRun({
+      context: { messages: [] },
+      tools: {},
+      runContext: {
+        channel: {
+          platform: 'discord',
+          kind: 'thread',
+        },
+      },
+    });
+
+    const execute = vi.fn(async () => 'ok');
+    const tools: Record<string, Tool> = {
+      guarded_tool: {
+        name: 'guarded_tool',
+        description: 'guarded',
+        inputSchema: {} as never,
+        allowed_callers: ['discord:thread'],
+        execute,
+      } as Tool,
+    };
+
+    const result = await beforeLLMCall({
+      context: { messages: [] },
+      tools,
+      systemPrompt: undefined,
+    });
+
+    const guardedTool = result?.tools?.guarded_tool;
+    expect(guardedTool).toBeDefined();
+
+    await expect(
+      guardedTool!.execute({}, {
+        runContext: {
+          channel: {
+            platform: 'feishu',
+            kind: 'group',
+          },
+        },
+      }),
+    ).rejects.toThrow('[PTC] Tool "guarded_tool" is not allowed for the current caller.');
+
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('supports wildcard allowed_callers', async () => {
+    const { context, hooks } = createPluginContext();
+    await builtInPtcPlugin.initialize(context);
+
+    const beforeRun = firstHook(hooks, 'beforeRun');
+    const beforeLLMCall = firstHook(hooks, 'beforeLLMCall');
+
+    await beforeRun({
+      context: { messages: [] },
+      tools: {},
+      runContext: undefined,
+    });
+
+    const execute = vi.fn(async () => 'ok');
+    const tools: Record<string, Tool> = {
+      wildcard_tool: {
+        name: 'wildcard_tool',
+        description: 'wildcard',
+        inputSchema: {} as never,
+        allowed_callers: ['*'],
+        execute,
+      } as Tool,
+    };
+
+    const result = await beforeLLMCall({
+      context: { messages: [] },
+      tools,
+      systemPrompt: undefined,
+    });
+
+    expect(result?.tools?.wildcard_tool).toBeDefined();
+    await expect(result!.tools!.wildcard_tool.execute({}, { runContext: {} })).resolves.toBe('ok');
+  });
+});

--- a/packages/engine/src/built-in/ptc-plugin/ptc-plugin.ts
+++ b/packages/engine/src/built-in/ptc-plugin/ptc-plugin.ts
@@ -5,7 +5,6 @@ type ToolWithPtc = Tool & {
   ptc?: {
     allowed_callers?: string[];
   };
-  allowed_callers?: string[];
 };
 
 type PtcConfig = {
@@ -17,7 +16,7 @@ type PtcConfig = {
 
 type PtcSnapshot = {
   active: boolean;
-  callerTypes: string[];
+  callerSelectors: string[];
   exposedToolNames: string[];
 };
 
@@ -82,55 +81,17 @@ function resolveCallerSelectors(runContext?: Record<string, any>): string[] {
   }
 
   const selectors = new Set<string>();
+  const rawSelectors = runContext.callerSelectors;
+
+  if (typeof rawSelectors === 'string') {
+    addCallerToken(selectors, rawSelectors);
+  } else if (Array.isArray(rawSelectors)) {
+    for (const selector of rawSelectors) {
+      addCallerToken(selectors, selector);
+    }
+  }
 
   addCallerToken(selectors, runContext.caller);
-  addCallerToken(selectors, runContext.callerType);
-  addCallerToken(selectors, runContext.caller_type);
-  addCallerToken(selectors, runContext.platform);
-  addCallerToken(selectors, runContext.platformKey);
-  addCallerToken(selectors, runContext.platform_key);
-  addCallerToken(selectors, runContext.source);
-
-  if (Array.isArray(runContext.callers)) {
-    for (const caller of runContext.callers) {
-      addCallerToken(selectors, caller);
-    }
-  }
-
-  const channel = runContext.channel;
-  if (channel && typeof channel === 'object') {
-    const channelInfo = channel as Record<string, any>;
-    const platform = normalizeCallerToken(channelInfo.platform);
-    const kind = normalizeCallerToken(channelInfo.kind);
-    const channelId = normalizeCallerToken(channelInfo.channelId ?? channelInfo.channel_id);
-    const userId = normalizeCallerToken(channelInfo.userId ?? channelInfo.user_id);
-
-    if (platform) {
-      selectors.add(platform);
-    }
-
-    if (kind) {
-      selectors.add(kind);
-    }
-
-    if (platform && kind) {
-      selectors.add(`${platform}:${kind}`);
-    }
-
-    if (channelId) {
-      selectors.add(channelId);
-      if (platform && kind) {
-        selectors.add(`${platform}:${kind}:${channelId}`);
-      }
-    }
-
-    if (userId) {
-      selectors.add(userId);
-      if (platform) {
-        selectors.add(`${platform}:${userId}`);
-      }
-    }
-  }
 
   return [...selectors];
 }
@@ -212,7 +173,7 @@ function resolveAllowedCallers(
   tool: ToolWithPtc,
 ): string[] | undefined {
   if (tool.allowed_callers !== undefined && !Array.isArray(tool.allowed_callers)) {
-    failOrWarn(context, config.strict, `Tool "${toolName}" has invalid allowed_callers at top level.`);
+    failOrWarn(context, config.strict, `Tool "${toolName}" has invalid allowed_callers.`);
   }
 
   if (tool.ptc?.allowed_callers !== undefined && !Array.isArray(tool.ptc.allowed_callers)) {
@@ -238,7 +199,7 @@ function buildPromptHint(snapshot: PtcSnapshot, maxTools: number): string {
 
   return [
     'PTC plugin active.',
-    `PTC caller types: ${snapshot.callerTypes.length > 0 ? snapshot.callerTypes.join(', ') : '(none)'}`,
+    `PTC caller selectors: ${snapshot.callerSelectors.length > 0 ? snapshot.callerSelectors.join(', ') : '(none)'}`,
     `Tools exposed to callers: ${visibleNames.join(', ')}${suffix}`,
   ].join('\n');
 }
@@ -248,7 +209,7 @@ class PtcService {
 
   private snapshot: PtcSnapshot = {
     active: false,
-    callerTypes: [],
+    callerSelectors: [],
     exposedToolNames: [],
   };
 
@@ -287,7 +248,7 @@ export const builtInPtcPlugin: EnginePlugin = {
       service.setCallerSelectors(callerSelectors);
       service.setSnapshot({
         active: true,
-        callerTypes: callerSelectors,
+        callerSelectors,
         exposedToolNames: [],
       });
     });
@@ -300,35 +261,30 @@ export const builtInPtcPlugin: EnginePlugin = {
       for (const [toolName, originalTool] of Object.entries(tools)) {
         const tool = originalTool as ToolWithPtc;
         const allowedCallers = resolveAllowedCallers(context, config, toolName, tool);
-        if (!allowedCallers) {
-          nextTools[toolName] = tool;
+
+        if (!allowedCallers || isCallerAllowed(allowedCallers, callerSelectors)) {
+          nextTools[toolName] = {
+            ...tool,
+            execute: async (input: unknown, executionContext?: ToolExecutionContext) => {
+              if (!allowedCallers) {
+                return await tool.execute(input, executionContext);
+              }
+
+              const runtimeSelectors = resolveCallerSelectors(executionContext?.runContext);
+              const selectors = runtimeSelectors.length > 0 ? runtimeSelectors : callerSelectors;
+              if (!isCallerAllowed(allowedCallers, selectors)) {
+                throw new Error(`[PTC] Tool "${toolName}" is not allowed for the current caller.`);
+              }
+              return await tool.execute(input, executionContext);
+            },
+          } as Tool;
           exposedToolNames.push(toolName);
-          continue;
         }
-
-        if (!isCallerAllowed(allowedCallers, callerSelectors)) {
-          continue;
-        }
-
-        nextTools[toolName] = {
-          ...tool,
-          allowed_callers: allowedCallers,
-          execute: async (input: unknown, executionContext?: ToolExecutionContext) => {
-            const runtimeSelectors = resolveCallerSelectors(executionContext?.runContext);
-            const selectors = runtimeSelectors.length > 0 ? runtimeSelectors : callerSelectors;
-            if (!isCallerAllowed(allowedCallers, selectors)) {
-              throw new Error(`[PTC] Tool "${toolName}" is not allowed for the current caller.`);
-            }
-            return await tool.execute(input, executionContext);
-          },
-        } as Tool;
-
-        exposedToolNames.push(toolName);
       }
 
       const snapshot: PtcSnapshot = {
         active: true,
-        callerTypes: callerSelectors,
+        callerSelectors,
         exposedToolNames,
       };
       service.setSnapshot(snapshot);
@@ -342,7 +298,6 @@ export const builtInPtcPlugin: EnginePlugin = {
         systemPrompt: appendSystemPrompt(systemPrompt, buildPromptHint(snapshot, config.appendPromptMaxTools)),
       };
     });
-
 
     context.logger.info('[PTC] Built-in PTC plugin initialized', {
       strict: config.strict,

--- a/packages/engine/src/built-in/ptc-plugin/ptc-plugin.ts
+++ b/packages/engine/src/built-in/ptc-plugin/ptc-plugin.ts
@@ -1,5 +1,5 @@
 import type { EnginePlugin, EnginePluginContext } from '../../plugin/EnginePlugin';
-import type { SystemPromptOption, Tool } from '../../shared/types';
+import type { SystemPromptOption, Tool, ToolExecutionContext } from '../../shared/types';
 
 type ToolWithPtc = Tool & {
   ptc?: {
@@ -58,6 +58,112 @@ function normalizeCallerList(raw: unknown): string[] {
       .map((item) => item.trim())
       .filter((item) => item.length > 0),
   );
+}
+
+function normalizeCallerToken(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function addCallerToken(target: Set<string>, value: unknown): void {
+  const normalized = normalizeCallerToken(value);
+  if (normalized) {
+    target.add(normalized);
+  }
+}
+
+function resolveCallerSelectors(runContext?: Record<string, any>): string[] {
+  if (!runContext || typeof runContext !== 'object') {
+    return [];
+  }
+
+  const selectors = new Set<string>();
+
+  addCallerToken(selectors, runContext.caller);
+  addCallerToken(selectors, runContext.callerType);
+  addCallerToken(selectors, runContext.caller_type);
+  addCallerToken(selectors, runContext.platform);
+  addCallerToken(selectors, runContext.platformKey);
+  addCallerToken(selectors, runContext.platform_key);
+  addCallerToken(selectors, runContext.source);
+
+  if (Array.isArray(runContext.callers)) {
+    for (const caller of runContext.callers) {
+      addCallerToken(selectors, caller);
+    }
+  }
+
+  const channel = runContext.channel;
+  if (channel && typeof channel === 'object') {
+    const channelInfo = channel as Record<string, any>;
+    const platform = normalizeCallerToken(channelInfo.platform);
+    const kind = normalizeCallerToken(channelInfo.kind);
+    const channelId = normalizeCallerToken(channelInfo.channelId ?? channelInfo.channel_id);
+    const userId = normalizeCallerToken(channelInfo.userId ?? channelInfo.user_id);
+
+    if (platform) {
+      selectors.add(platform);
+    }
+
+    if (kind) {
+      selectors.add(kind);
+    }
+
+    if (platform && kind) {
+      selectors.add(`${platform}:${kind}`);
+    }
+
+    if (channelId) {
+      selectors.add(channelId);
+      if (platform && kind) {
+        selectors.add(`${platform}:${kind}:${channelId}`);
+      }
+    }
+
+    if (userId) {
+      selectors.add(userId);
+      if (platform) {
+        selectors.add(`${platform}:${userId}`);
+      }
+    }
+  }
+
+  return [...selectors];
+}
+
+function isCallerAllowed(allowedCallers: string[], callerSelectors: string[]): boolean {
+  if (allowedCallers.length === 0) {
+    return true;
+  }
+
+  const selectorSet = new Set<string>();
+  for (const selector of callerSelectors) {
+    const normalized = normalizeCallerToken(selector);
+    if (normalized) {
+      selectorSet.add(normalized);
+    }
+  }
+
+  for (const allowed of allowedCallers) {
+    const normalized = normalizeCallerToken(allowed);
+    if (!normalized) {
+      continue;
+    }
+
+    if (normalized === '*') {
+      return true;
+    }
+
+    if (selectorSet.has(normalized)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function appendSystemPrompt(base: SystemPromptOption | undefined, append: string): SystemPromptOption {
@@ -132,17 +238,27 @@ function buildPromptHint(snapshot: PtcSnapshot, maxTools: number): string {
 
   return [
     'PTC plugin active.',
-    `PTC caller types: ${snapshot.callerTypes.join(', ')}`,
+    `PTC caller types: ${snapshot.callerTypes.length > 0 ? snapshot.callerTypes.join(', ') : '(none)'}`,
     `Tools exposed to callers: ${visibleNames.join(', ')}${suffix}`,
   ].join('\n');
 }
 
 class PtcService {
+  private callerSelectors: string[] = [];
+
   private snapshot: PtcSnapshot = {
     active: false,
     callerTypes: [],
     exposedToolNames: [],
   };
+
+  setCallerSelectors(selectors: string[]): void {
+    this.callerSelectors = selectors;
+  }
+
+  getCallerSelectors(): string[] {
+    return this.callerSelectors;
+  }
 
   setSnapshot(snapshot: PtcSnapshot): void {
     this.snapshot = snapshot;
@@ -166,38 +282,53 @@ export const builtInPtcPlugin: EnginePlugin = {
     const service = new PtcService();
     context.registerService(PTC_SERVICE_NAME, service);
 
-    context.registerHook('beforeRun', () => {
+    context.registerHook('beforeRun', ({ runContext }) => {
+      const callerSelectors = resolveCallerSelectors(runContext);
+      service.setCallerSelectors(callerSelectors);
       service.setSnapshot({
         active: true,
-        callerTypes: [],
+        callerTypes: callerSelectors,
         exposedToolNames: [],
       });
     });
 
     context.registerHook('beforeLLMCall', ({ tools, systemPrompt }) => {
-      const nextTools: Record<string, Tool> = { ...tools };
+      const callerSelectors = service.getCallerSelectors();
+      const nextTools: Record<string, Tool> = {};
       const exposedToolNames: string[] = [];
-      const callerTypes: string[] = [];
 
       for (const [toolName, originalTool] of Object.entries(tools)) {
         const tool = originalTool as ToolWithPtc;
         const allowedCallers = resolveAllowedCallers(context, config, toolName, tool);
         if (!allowedCallers) {
+          nextTools[toolName] = tool;
+          exposedToolNames.push(toolName);
+          continue;
+        }
+
+        if (!isCallerAllowed(allowedCallers, callerSelectors)) {
           continue;
         }
 
         nextTools[toolName] = {
           ...tool,
           allowed_callers: allowedCallers,
+          execute: async (input: unknown, executionContext?: ToolExecutionContext) => {
+            const runtimeSelectors = resolveCallerSelectors(executionContext?.runContext);
+            const selectors = runtimeSelectors.length > 0 ? runtimeSelectors : callerSelectors;
+            if (!isCallerAllowed(allowedCallers, selectors)) {
+              throw new Error(`[PTC] Tool "${toolName}" is not allowed for the current caller.`);
+            }
+            return await tool.execute(input, executionContext);
+          },
         } as Tool;
 
         exposedToolNames.push(toolName);
-        callerTypes.push(...allowedCallers);
       }
 
       const snapshot: PtcSnapshot = {
         active: true,
-        callerTypes: unique(callerTypes),
+        callerTypes: callerSelectors,
         exposedToolNames,
       };
       service.setSnapshot(snapshot);
@@ -211,6 +342,7 @@ export const builtInPtcPlugin: EnginePlugin = {
         systemPrompt: appendSystemPrompt(systemPrompt, buildPromptHint(snapshot, config.appendPromptMaxTools)),
       };
     });
+
 
     context.logger.info('[PTC] Built-in PTC plugin initialized', {
       strict: config.strict,

--- a/packages/engine/src/built-in/ptc-plugin/ptc-plugin.ts
+++ b/packages/engine/src/built-in/ptc-plugin/ptc-plugin.ts
@@ -1,0 +1,222 @@
+import type { EnginePlugin, EnginePluginContext } from '../../plugin/EnginePlugin';
+import type { SystemPromptOption, Tool } from '../../shared/types';
+
+type ToolWithPtc = Tool & {
+  ptc?: {
+    allowed_callers?: string[];
+  };
+  allowed_callers?: string[];
+};
+
+type PtcConfig = {
+  enabled: boolean;
+  strict: boolean;
+  appendPrompt: boolean;
+  appendPromptMaxTools: number;
+};
+
+type PtcSnapshot = {
+  active: boolean;
+  callerTypes: string[];
+  exposedToolNames: string[];
+};
+
+const PTC_SERVICE_NAME = 'ptcService';
+
+function parseBoolean(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined) {
+    return fallback;
+  }
+  return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase());
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+
+  return Math.floor(parsed);
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function normalizeCallerList(raw: unknown): string[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  return unique(
+    raw
+      .filter((item) => typeof item === 'string')
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0),
+  );
+}
+
+function appendSystemPrompt(base: SystemPromptOption | undefined, append: string): SystemPromptOption {
+  if (!append.trim()) {
+    return base ?? { append: '' };
+  }
+
+  if (!base) {
+    return { append };
+  }
+
+  if (typeof base === 'string') {
+    return `${base}\n\n${append}`;
+  }
+
+  if (typeof base === 'function') {
+    return () => `${base()}\n\n${append}`;
+  }
+
+  const currentAppend = base.append.trim();
+  return {
+    append: currentAppend ? `${currentAppend}\n\n${append}` : append,
+  };
+}
+
+function buildConfigFromEnv(): PtcConfig {
+  return {
+    enabled: parseBoolean(process.env.PULSE_CODER_PTC_ENABLED, true),
+    strict: parseBoolean(process.env.PULSE_CODER_PTC_STRICT, false),
+    appendPrompt: parseBoolean(process.env.PULSE_CODER_PTC_APPEND_PROMPT, false),
+    appendPromptMaxTools: parsePositiveInt(process.env.PULSE_CODER_PTC_APPEND_PROMPT_MAX_TOOLS, 12),
+  };
+}
+
+function failOrWarn(context: EnginePluginContext, strict: boolean, message: string): void {
+  if (strict) {
+    throw new Error(`[PTC] ${message}`);
+  }
+  context.logger.warn(`[PTC] ${message}`);
+}
+
+function resolveAllowedCallers(
+  context: EnginePluginContext,
+  config: PtcConfig,
+  toolName: string,
+  tool: ToolWithPtc,
+): string[] | undefined {
+  if (tool.allowed_callers !== undefined && !Array.isArray(tool.allowed_callers)) {
+    failOrWarn(context, config.strict, `Tool "${toolName}" has invalid allowed_callers at top level.`);
+  }
+
+  if (tool.ptc?.allowed_callers !== undefined && !Array.isArray(tool.ptc.allowed_callers)) {
+    failOrWarn(context, config.strict, `Tool "${toolName}" has invalid ptc.allowed_callers.`);
+  }
+
+  const topLevelMany = normalizeCallerList(tool.allowed_callers);
+  const ptcMany = normalizeCallerList(tool.ptc?.allowed_callers);
+  const merged = unique([...topLevelMany, ...ptcMany]);
+
+  return merged.length > 0 ? merged : undefined;
+}
+
+function buildPromptHint(snapshot: PtcSnapshot, maxTools: number): string {
+  if (!snapshot.active || snapshot.exposedToolNames.length === 0) {
+    return 'PTC plugin active. No tools are currently exposed to any caller.';
+  }
+
+  const visibleNames = snapshot.exposedToolNames.slice(0, maxTools);
+  const suffix = snapshot.exposedToolNames.length > visibleNames.length
+    ? ` ... (+${snapshot.exposedToolNames.length - visibleNames.length} more)`
+    : '';
+
+  return [
+    'PTC plugin active.',
+    `PTC caller types: ${snapshot.callerTypes.join(', ')}`,
+    `Tools exposed to callers: ${visibleNames.join(', ')}${suffix}`,
+  ].join('\n');
+}
+
+class PtcService {
+  private snapshot: PtcSnapshot = {
+    active: false,
+    callerTypes: [],
+    exposedToolNames: [],
+  };
+
+  setSnapshot(snapshot: PtcSnapshot): void {
+    this.snapshot = snapshot;
+  }
+
+  getSnapshot(): PtcSnapshot {
+    return this.snapshot;
+  }
+}
+
+export const builtInPtcPlugin: EnginePlugin = {
+  name: 'pulse-coder-engine/built-in-ptc',
+  version: '0.1.0',
+  async initialize(context: EnginePluginContext) {
+    const config = buildConfigFromEnv();
+    if (!config.enabled) {
+      context.logger.info('[PTC] Disabled via config');
+      return;
+    }
+
+    const service = new PtcService();
+    context.registerService(PTC_SERVICE_NAME, service);
+
+    context.registerHook('beforeRun', () => {
+      service.setSnapshot({
+        active: true,
+        callerTypes: [],
+        exposedToolNames: [],
+      });
+    });
+
+    context.registerHook('beforeLLMCall', ({ tools, systemPrompt }) => {
+      const nextTools: Record<string, Tool> = { ...tools };
+      const exposedToolNames: string[] = [];
+      const callerTypes: string[] = [];
+
+      for (const [toolName, originalTool] of Object.entries(tools)) {
+        const tool = originalTool as ToolWithPtc;
+        const allowedCallers = resolveAllowedCallers(context, config, toolName, tool);
+        if (!allowedCallers) {
+          continue;
+        }
+
+        nextTools[toolName] = {
+          ...tool,
+          allowed_callers: allowedCallers,
+        } as Tool;
+
+        exposedToolNames.push(toolName);
+        callerTypes.push(...allowedCallers);
+      }
+
+      const snapshot: PtcSnapshot = {
+        active: true,
+        callerTypes: unique(callerTypes),
+        exposedToolNames,
+      };
+      service.setSnapshot(snapshot);
+
+      if (!config.appendPrompt) {
+        return { tools: nextTools };
+      }
+
+      return {
+        tools: nextTools,
+        systemPrompt: appendSystemPrompt(systemPrompt, buildPromptHint(snapshot, config.appendPromptMaxTools)),
+      };
+    });
+
+    context.logger.info('[PTC] Built-in PTC plugin initialized', {
+      strict: config.strict,
+      appendPrompt: config.appendPrompt,
+    });
+  },
+};
+
+export default builtInPtcPlugin;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -32,6 +32,7 @@ export {
   builtInTaskTrackingPlugin,
   builtInAgentTeamsPlugin,
   builtInRoleSoulPlugin,
+  builtInPtcPlugin,
   BuiltInSkillRegistry,
   BuiltInPlanModeService,
   TaskListService,

--- a/packages/engine/src/shared/types.ts
+++ b/packages/engine/src/shared/types.ts
@@ -71,6 +71,8 @@ export interface Tool<Input = any, Output = any> {
   name: string;
   description: string;
   inputSchema: FlexibleSchema<Input>;
+  outputSchema?: FlexibleSchema<Output>;
+  allowed_callers?: string[];
   defer_loading?: boolean;
   deferLoading?: boolean;
   execute: (input: Input, context?: ToolExecutionContext) => Promise<Output>;


### PR DESCRIPTION
Implement provider-agnostic, rule-based PTC orchestration in engine built-ins.\n\n- Add caller-aware tool filtering in PTC using runContext.callerSelectors/caller\n- Enforce runtime guard for allowed_callers to block mismatched callers\n- Extend Tool metadata with optional allowed_callers and outputSchema\n- Auto-load built-in PTC plugin from engine built-in plugin list\n- Update PTC tests for selector filtering, caller fallback, runtime blocking, and wildcard\n- Remove duplicate PTC registration from remote-server engine singleton