### PR TITLE
feat: support env-configurable loop limits

### DIFF
--- a/apps/remote-server/.env.example
+++ b/apps/remote-server/.env.example
@@ -2,6 +2,9 @@
 OPENAI_API_KEY=
 OPENAI_API_URL=
 OPENAI_MODEL=
+# Optional loop caps (defaults shown)
+# MAX_TURNS=240
+# MAX_STEPS=240
 # Context compaction thresholds
 # Defaults: trigger = 75% of CONTEXT_WINDOW_TOKENS, target = 50%
 CONTEXT_WINDOW_TOKENS=128000

--- a/packages/engine/src/config/index.ts
+++ b/packages/engine/src/config/index.ts
@@ -17,9 +17,23 @@ export const CoderAI = (process.env.USE_ANTHROPIC
 
 export const DEFAULT_MODEL = process.env.ANTHROPIC_MODEL || process.env.OPENAI_MODEL || 'novita/deepseek/deepseek_v3';
 
-export const MAX_TURNS = 100;
+const parsePositiveIntEnv = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+
+  return parsed;
+};
+
+export const MAX_TURNS = parsePositiveIntEnv('MAX_TURNS', 240);
 export const MAX_ERROR_COUNT = 3;
-export const MAX_STEPS = 100;
+export const MAX_STEPS = parsePositiveIntEnv('MAX_STEPS', 240);
 export const MAX_TOOL_OUTPUT_LENGTH = 30_000;
 
 export const CONTEXT_WINDOW_TOKENS = Number(process.env.CONTEXT_WINDOW_TOKENS ?? 64_000);


### PR DESCRIPTION
Enable loop limit tuning via environment variables and document it for remote-server setup.

- Add shared positive-int env parser in engine config
- Read MAX_TURNS from env with fallback default (240)
- Read MAX_STEPS from env with fallback default (240)
- Document optional MAX_TURNS and MAX_STEPS in remote-server .env.example