### PR TITLE
feat(devtools): cache tokens + stall analysis

### DIFF
--- a/apps/devtools-web/src/App.tsx
+++ b/apps/devtools-web/src/App.tsx
@@ -30,6 +30,10 @@ interface LlmSpan {
     inputSize?: number;
     inputPreview?: string;
   }>;
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
 }
 
 interface ToolSpan {
@@ -65,6 +69,12 @@ interface RunDetail extends RunSummary {
   llmSpans: LlmSpan[];
   toolSpans: ToolSpan[];
   compactionEvents: CompactionEvent[];
+  pluginHooks: Array<{
+    pluginName: string;
+    hookName: string;
+    startedAt: number;
+    durationMs: number;
+  }>;
   resultTextPreview?: string;
 }
 
@@ -235,9 +245,15 @@ export default function App() {
 
     const llmSpans = selectedRun.llmSpans.filter((span) => span.durationMs !== undefined);
     const toolSpans = selectedRun.toolSpans.filter((span) => span.durationMs !== undefined);
+    const pluginHooks = selectedRun.pluginHooks ?? [];
 
     const totalLlmTime = llmSpans.reduce((sum, span) => sum + (span.durationMs ?? 0), 0);
     const totalToolTime = toolSpans.reduce((sum, span) => sum + (span.durationMs ?? 0), 0);
+    const totalHookTime = pluginHooks.reduce((sum, hook) => sum + (hook.durationMs ?? 0), 0);
+    const totalCacheRead = selectedRun.llmSpans.reduce((sum, span) => sum + (span.cacheReadTokens ?? 0), 0);
+    const totalCacheWrite = selectedRun.llmSpans.reduce((sum, span) => sum + (span.cacheWriteTokens ?? 0), 0);
+    const hasCacheRead = selectedRun.llmSpans.some((span) => span.cacheReadTokens !== undefined);
+    const hasCacheWrite = selectedRun.llmSpans.some((span) => span.cacheWriteTokens !== undefined);
 
     const slowestLlm = llmSpans.reduce<LlmSpan | null>((acc, span) => {
       if (!acc || (span.durationMs ?? 0) > (acc.durationMs ?? 0)) {
@@ -251,6 +267,15 @@ export default function App() {
       }
       return acc;
     }, null);
+    const slowestHook = pluginHooks.reduce<{ pluginName: string; hookName: string; durationMs: number } | null>(
+      (acc, hook) => {
+        if (!acc || hook.durationMs > acc.durationMs) {
+          return hook;
+        }
+        return acc;
+      },
+      null,
+    );
 
     const topLlm = [...llmSpans]
       .sort((a, b) => (b.durationMs ?? 0) - (a.durationMs ?? 0))
@@ -258,8 +283,80 @@ export default function App() {
     const topTool = [...toolSpans]
       .sort((a, b) => (b.durationMs ?? 0) - (a.durationMs ?? 0))
       .slice(0, 5);
+    const topHooks = [...pluginHooks]
+      .sort((a, b) => b.durationMs - a.durationMs)
+      .slice(0, 5);
     const maxLlm = topLlm[0]?.durationMs ?? 0;
     const maxTool = topTool[0]?.durationMs ?? 0;
+    const maxHook = topHooks[0]?.durationMs ?? 0;
+
+    const runStart = selectedRun.startedAt;
+    const runEnd = selectedRun.endedAt ?? now;
+    const runDuration = Math.max(1, runEnd - runStart);
+    const timelineEvents = [
+      ...selectedRun.llmSpans.map((span) => ({
+        type: 'llm' as const,
+        label: `LLM #${span.index}`,
+        start: span.startedAt,
+        end: span.endedAt ?? now,
+        duration: span.durationMs ?? Math.max(0, now - span.startedAt),
+      })),
+      ...selectedRun.toolSpans.map((span) => ({
+        type: 'tool' as const,
+        label: span.name,
+        start: span.startedAt,
+        end: span.endedAt ?? now,
+        duration: span.durationMs ?? Math.max(0, now - span.startedAt),
+      })),
+      ...pluginHooks.map((hook, idx) => ({
+        type: 'hook' as const,
+        label: `${hook.pluginName}.${hook.hookName} #${idx + 1}`,
+        start: hook.startedAt,
+        end: hook.startedAt + hook.durationMs,
+        duration: hook.durationMs,
+      })),
+    ]
+      .filter((event) => Number.isFinite(event.start) && Number.isFinite(event.end))
+      .sort((a, b) => a.start - b.start);
+
+    const gapEvents: Array<{
+      start: number;
+      end: number;
+      duration: number;
+      before: string;
+      after: string;
+    }> = [];
+    let lastEnd = runStart;
+    let lastLabel = 'Run start';
+    for (const event of timelineEvents) {
+      if (event.start > lastEnd) {
+        gapEvents.push({
+          start: lastEnd,
+          end: event.start,
+          duration: event.start - lastEnd,
+          before: lastLabel,
+          after: event.label,
+        });
+      }
+      if (event.end > lastEnd) {
+        lastEnd = event.end;
+        lastLabel = event.label;
+      }
+    }
+    if (runEnd > lastEnd) {
+      gapEvents.push({
+        start: lastEnd,
+        end: runEnd,
+        duration: runEnd - lastEnd,
+        before: lastLabel,
+        after: 'Run end',
+      });
+    }
+
+    const sortedGaps = [...gapEvents].sort((a, b) => b.duration - a.duration);
+    const topGaps = sortedGaps.slice(0, 5);
+    const totalGapTime = gapEvents.reduce((sum, gap) => sum + gap.duration, 0);
+    const largestGap = topGaps[0];
 
     return (
       <div className="detail">
@@ -272,6 +369,8 @@ export default function App() {
           <InfoCard label="Tool Calls" value={String(selectedRun.toolCalls)} />
           <InfoCard label="Compactions" value={String(selectedRun.compactions)} />
           <InfoCard label="Last Event" value={formatTime(selectedRun.lastEventAt)} />
+          <InfoCard label="Cache Read" value={hasCacheRead ? String(totalCacheRead) : 'n/a'} />
+          <InfoCard label="Cache Write" value={hasCacheWrite ? String(totalCacheWrite) : 'n/a'} />
         </div>
 
         <div className="pill-row">
@@ -307,6 +406,26 @@ export default function App() {
             <div className="hot-card">
               <div className="hot-label">Total tool time</div>
               <div className="hot-value">{formatDuration(totalToolTime)}</div>
+            </div>
+            <div className="hot-card">
+              <div className="hot-label">Slowest hook</div>
+              <div className="hot-value">
+                {slowestHook ? `${slowestHook.pluginName}.${slowestHook.hookName} · ${formatDuration(slowestHook.durationMs)}` : 'n/a'}
+              </div>
+            </div>
+            <div className="hot-card">
+              <div className="hot-label">Total hook time</div>
+              <div className="hot-value">{formatDuration(totalHookTime)}</div>
+            </div>
+            <div className="hot-card">
+              <div className="hot-label">Idle gaps total</div>
+              <div className="hot-value">{formatDuration(totalGapTime)}</div>
+            </div>
+            <div className="hot-card">
+              <div className="hot-label">Largest idle gap</div>
+              <div className="hot-value">
+                {largestGap ? `${formatDuration(largestGap.duration)} · ${formatTime(largestGap.start)}` : 'n/a'}
+              </div>
             </div>
           </div>
 
@@ -349,6 +468,26 @@ export default function App() {
               <div className="empty">No tool calls yet.</div>
             )}
           </div>
+
+          <div className="bar-block">
+            <div className="bar-title">Top plugin hooks</div>
+            {topHooks.length ? (
+              topHooks.map((hook, idx) => (
+                <div key={`hook-${idx}`} className="bar-row">
+                  <div className="bar-label">{hook.pluginName}.{hook.hookName}</div>
+                  <div className="bar-track">
+                    <div
+                      className="bar-fill"
+                      style={{ width: `${Math.max(6, (hook.durationMs / (maxHook || 1)) * 100)}%` }}
+                    />
+                  </div>
+                  <div className="bar-value">{formatDuration(hook.durationMs)}</div>
+                </div>
+              ))
+            ) : (
+              <div className="empty">No hook timings yet.</div>
+            )}
+          </div>
         </section>
 
         {selectedRun.userText ? (
@@ -366,6 +505,62 @@ export default function App() {
         ) : null}
 
         <section className="section">
+          <h2>Timeline</h2>
+          {timelineEvents.length ? (
+            <div className="timeline">
+              {timelineEvents.map((event, idx) => {
+                const left = ((event.start - runStart) / runDuration) * 100;
+                const width = ((event.end - event.start) / runDuration) * 100;
+                return (
+                  <div key={`${event.type}-${idx}`} className={`timeline-row ${event.type}`}>
+                    <div className="timeline-label">{event.label}</div>
+                    <div className="timeline-track">
+                      <div
+                        className="timeline-bar"
+                        style={{ left: `${Math.max(0, left)}%`, width: `${Math.max(2, width)}%` }}
+                      />
+                    </div>
+                    <div className="timeline-value">{formatDuration(event.duration)}</div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="empty">No timeline data yet.</div>
+          )}
+        </section>
+
+        <section className="section">
+          <h2>Stall Analysis</h2>
+          {topGaps.length ? (
+            <div className="table-scroll">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Gap</th>
+                    <th>Start</th>
+                    <th>Between</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {topGaps.map((gap, idx) => (
+                    <tr key={`${gap.start}-${idx}`}>
+                      <td>{formatDuration(gap.duration)}</td>
+                      <td>{formatTime(gap.start)}</td>
+                      <td>
+                        {gap.before} → {gap.after}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <div className="empty">No idle gaps detected.</div>
+          )}
+        </section>
+
+        <section className="section">
           <h2>LLM Spans</h2>
           {selectedRun.llmSpans.length ? (
             <div className="table-scroll">
@@ -376,6 +571,10 @@ export default function App() {
                     <th>Duration</th>
                     <th>Finish</th>
                     <th>Text Len</th>
+                    <th>Input Tok</th>
+                    <th>Output Tok</th>
+                    <th>Cache Read</th>
+                    <th>Cache Write</th>
                     <th>Tools</th>
                   </tr>
                 </thead>
@@ -386,6 +585,10 @@ export default function App() {
                       <td>{formatDuration(span.durationMs)}</td>
                       <td>{span.finishReason || 'n/a'}</td>
                       <td>{span.textLength ?? 'n/a'}</td>
+                      <td>{span.inputTokens ?? 'n/a'}</td>
+                      <td>{span.outputTokens ?? 'n/a'}</td>
+                      <td>{span.cacheReadTokens ?? 'n/a'}</td>
+                      <td>{span.cacheWriteTokens ?? 'n/a'}</td>
                       <td>
                         {span.toolCalls?.length
                           ? span.toolCalls.map((call, idx) => (
@@ -436,6 +639,36 @@ export default function App() {
             </div>
           ) : (
             <div className="empty">No tool spans.</div>
+          )}
+        </section>
+
+        <section className="section">
+          <h2>Plugin Hooks</h2>
+          {selectedRun.pluginHooks.length ? (
+            <div className="table-scroll">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Plugin</th>
+                    <th>Hook</th>
+                    <th>Duration</th>
+                    <th>Start</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {selectedRun.pluginHooks.map((hook, idx) => (
+                    <tr key={`${hook.pluginName}-${hook.hookName}-${idx}`}>
+                      <td>{hook.pluginName}</td>
+                      <td>{hook.hookName}</td>
+                      <td>{formatDuration(hook.durationMs)}</td>
+                      <td>{formatTime(hook.startedAt)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <div className="empty">No plugin hooks.</div>
           )}
         </section>
 

--- a/apps/devtools-web/src/styles.css
+++ b/apps/devtools-web/src/styles.css
@@ -523,9 +523,64 @@ th {
   text-align: right;
 }
 
+.timeline {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+
+.timeline-row {
+  display: grid;
+  grid-template-columns: 160px 1fr 80px;
+  gap: 10px;
+  align-items: center;
+}
+
+.timeline-label {
+  font-size: 12px;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.timeline-track {
+  position: relative;
+  height: 10px;
+  background: #f1f0ed;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.timeline-row.llm .timeline-bar {
+  background: rgba(15, 123, 108, 0.55);
+}
+
+.timeline-row.tool .timeline-bar {
+  background: rgba(33, 105, 185, 0.45);
+}
+
+.timeline-row.hook .timeline-bar {
+  background: rgba(176, 132, 52, 0.45);
+}
+
+.timeline-bar {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  border-radius: 999px;
+}
+
+.timeline-value {
+  font-size: 12px;
+  color: var(--text-muted);
+  text-align: right;
+}
+
 .table-scroll {
   max-height: 240px;
   overflow-y: auto;
+  overflow-x: auto;
   border: 1px solid var(--border);
   border-radius: 10px;
   background: #fff;
@@ -533,6 +588,7 @@ th {
 
 .table-scroll table {
   border-collapse: collapse;
+  min-width: 720px;
 }
 
 .table-scroll th,
@@ -558,6 +614,12 @@ th {
     gap: 6px;
   }
   .bar-value {
+    text-align: left;
+  }
+  .timeline-row {
+    grid-template-columns: 1fr;
+  }
+  .timeline-value {
     text-align: left;
   }
 }

--- a/packages/engine/src/core/loop.ts
+++ b/packages/engine/src/core/loop.ts
@@ -57,6 +57,7 @@ function wrapToolsWithHooks(
   tools: Record<string, Tool>,
   beforeHooks: Array<EngineHookMap['beforeToolCall']>,
   afterHooks: Array<EngineHookMap['afterToolCall']>,
+  context: Context,
 ): Record<string, Tool> {
   const wrapped: Record<string, Tool> = {};
   for (const [name, t] of Object.entries(tools)) {
@@ -66,7 +67,7 @@ function wrapToolsWithHooks(
         // Run all beforeToolCall hooks sequentially
         let finalInput = input;
         for (const hook of beforeHooks) {
-          const result = await hook({ name, input: finalInput });
+          const result = await hook({ context, name, input: finalInput });
           if (result && 'input' in result) {
             finalInput = result.input;
           }
@@ -77,7 +78,7 @@ function wrapToolsWithHooks(
         // Run all afterToolCall hooks sequentially
         let finalOutput = output;
         for (const hook of afterHooks) {
-          const result = await hook({ name, input: finalInput, output: finalOutput });
+          const result = await hook({ context, name, input: finalInput, output: finalOutput });
           if (result && 'output' in result) {
             finalOutput = result.output;
           }
@@ -225,7 +226,7 @@ export async function loop(context: Context, options?: LoopOptions): Promise<str
       const beforeToolHooks = loopHooks.beforeToolCall ?? [];
       const afterToolHooks = loopHooks.afterToolCall ?? [];
       if (beforeToolHooks.length || afterToolHooks.length) {
-        tools = wrapToolsWithHooks(tools, beforeToolHooks, afterToolHooks);
+        tools = wrapToolsWithHooks(tools, beforeToolHooks, afterToolHooks, context);
       }
 
       // Prepare tool execution context
@@ -267,10 +268,12 @@ export async function loop(context: Context, options?: LoopOptions): Promise<str
         },
       });
 
-      const [text, steps, finishReason] = await Promise.all([
+      const usagePromise = (result as any).usage;
+      const [text, steps, finishReason, usage] = await Promise.all([
         result.text,
         result.steps,
         result.finishReason,
+        usagePromise ? Promise.resolve(usagePromise) : Promise.resolve(undefined),
       ]);
 
       totalSteps += steps.length;
@@ -285,7 +288,7 @@ export async function loop(context: Context, options?: LoopOptions): Promise<str
       // --- afterLLMCall hooks ---
       if (loopHooks.afterLLMCall?.length) {
         for (const hook of loopHooks.afterLLMCall) {
-          await hook({ context, finishReason, text });
+          await hook({ context, finishReason, text, usage });
         }
       }
 

--- a/packages/engine/src/plugin/EnginePlugin.ts
+++ b/packages/engine/src/plugin/EnginePlugin.ts
@@ -40,11 +40,13 @@ export interface AfterLLMCallInput {
   context: Context;
   finishReason: string;
   text: string;
+  usage?: any;
 }
 
 // -- beforeToolCall --
 
 export interface BeforeToolCallInput {
+  context?: Context;
   name: string;
   input: any;
 }
@@ -56,6 +58,7 @@ export interface BeforeToolCallResult {
 // -- afterToolCall --
 
 export interface AfterToolCallInput {
+  context?: Context;
   name: string;
   input: any;
   output: any;

--- a/packages/engine/src/plugin/PluginManager.ts
+++ b/packages/engine/src/plugin/PluginManager.ts
@@ -184,7 +184,26 @@ export class PluginManager {
         },
 
         registerHook: (hookName, handler) => {
-          this.hooks[hookName].push(handler as any);
+          const wrapped = async (input: any) => {
+            const start = Date.now();
+            try {
+              return await (handler as any)(input);
+            } finally {
+              const payload = {
+                hookName,
+                pluginName: plugin.name,
+                durationMs: Date.now() - start,
+                at: start,
+                context: input?.context,
+              };
+              try {
+                this.events.emit('hookTiming', payload);
+              } catch {
+                // best-effort only
+              }
+            }
+          };
+          this.hooks[hookName].push(wrapped as any);
           this.logger.debug(`Plugin "${plugin.name}" registered hook: ${hookName}`);
         },
 

--- a/packages/plugin-kit/src/devtools/index.ts
+++ b/packages/plugin-kit/src/devtools/index.ts
@@ -30,6 +30,10 @@ export interface DevtoolsLlmSpan {
   durationMs?: number;
   finishReason?: string;
   textLength?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
   toolCalls?: Array<{
     name: string;
     inputSize?: number;
@@ -70,7 +74,15 @@ export interface DevtoolsRunRecord extends DevtoolsRunSummary {
   llmSpans: DevtoolsLlmSpan[];
   toolSpans: DevtoolsToolSpan[];
   compactionEvents: DevtoolsCompactionEvent[];
+  pluginHooks: DevtoolsPluginHookSpan[];
   resultTextPreview?: string;
+}
+
+export interface DevtoolsPluginHookSpan {
+  pluginName: string;
+  hookName: string;
+  startedAt: number;
+  durationMs: number;
 }
 
 interface DevtoolsRunCreateInput {
@@ -139,6 +151,110 @@ function buildPreview(value: unknown, limit = 180): string {
     return text;
   }
   return `${text.slice(0, limit)}...`;
+}
+
+function estimateTokensFromText(text: string): number {
+  if (!text) {
+    return 0;
+  }
+  return Math.ceil(text.length / 4);
+}
+
+function estimateTokensFromMessages(messages: Array<{ role?: string; content?: any }>): number {
+  let totalChars = 0;
+  for (const message of messages) {
+    totalChars += (message.role ?? '').length;
+    if (typeof message.content === 'string') {
+      totalChars += message.content.length;
+    } else if (message.content !== undefined) {
+      totalChars += safeStringify(message.content).length;
+    }
+  }
+  return Math.ceil(totalChars / 4);
+}
+
+function pickNumber(source: any, keys: string[]): number | undefined {
+  if (!source || typeof source !== 'object') {
+    return undefined;
+  }
+  for (const key of keys) {
+    const value = (source as any)[key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function pickNumberDeep(source: any, paths: string[][]): number | undefined {
+  if (!source || typeof source !== 'object') {
+    return undefined;
+  }
+  for (const path of paths) {
+    let cursor: any = source;
+    for (const key of path) {
+      if (!cursor || typeof cursor !== 'object') {
+        cursor = undefined;
+        break;
+      }
+      cursor = cursor[key];
+    }
+    if (typeof cursor === 'number' && Number.isFinite(cursor)) {
+      return cursor;
+    }
+  }
+  return undefined;
+}
+
+function extractUsageTokens(usage: any): {
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+} {
+  if (!usage) {
+    return {};
+  }
+
+  const inputTokens = pickNumber(usage, [
+    'inputTokens',
+    'promptTokens',
+    'input_tokens',
+    'prompt_tokens',
+  ]);
+
+  const outputTokens = pickNumber(usage, [
+    'outputTokens',
+    'completionTokens',
+    'output_tokens',
+    'completion_tokens',
+  ]);
+
+  const cacheReadTokens = pickNumber(usage, [
+    'cacheReadInputTokens',
+    'cache_read_input_tokens',
+    'cache_read_tokens',
+  ]) ?? pickNumberDeep(usage, [
+    ['prompt_tokens_details', 'cached_tokens'],
+    ['promptTokensDetails', 'cachedTokens'],
+  ]);
+
+  const cacheWriteTokens = pickNumber(usage, [
+    'cacheWriteInputTokens',
+    'cache_creation_input_tokens',
+    'cache_create_input_tokens',
+    'cache_write_tokens',
+  ]) ?? pickNumberDeep(usage, [
+    ['prompt_tokens_details', 'cache_creation_tokens'],
+    ['promptTokensDetails', 'cacheCreationTokens'],
+  ]);
+
+  return {
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
+  };
 }
 
 export class DevtoolsStore {
@@ -222,6 +338,7 @@ export class DevtoolsStore {
       llmSpans: [],
       toolSpans: [],
       compactionEvents: [],
+      pluginHooks: [],
     };
 
     this.runs.set(input.runId, record);
@@ -249,7 +366,7 @@ export class DevtoolsStore {
     this.scheduleIndexFlush();
   }
 
-  recordLLMStart(runId: string): void {
+  recordLLMStart(runId: string, inputTokens?: number): void {
     const record = this.runs.get(runId);
     if (!record) {
       return;
@@ -259,11 +376,12 @@ export class DevtoolsStore {
     record.llmSpans.push({
       index: record.llmCalls,
       startedAt: timestamp,
+      inputTokens,
     });
     this.touch(record, timestamp);
   }
 
-  recordLLMEnd(runId: string, finishReason?: string, text?: string): void {
+  recordLLMEnd(runId: string, finishReason?: string, text?: string, usage?: any): void {
     const record = this.runs.get(runId);
     if (!record) {
       return;
@@ -277,7 +395,31 @@ export class DevtoolsStore {
     span.durationMs = Math.max(0, timestamp - span.startedAt);
     span.finishReason = finishReason;
     span.textLength = typeof text === 'string' ? text.length : undefined;
+    const usageTokens = extractUsageTokens(usage);
+    if (usageTokens.inputTokens !== undefined) {
+      span.inputTokens = usageTokens.inputTokens;
+    }
+    if (usageTokens.outputTokens !== undefined) {
+      span.outputTokens = usageTokens.outputTokens;
+    } else if (typeof text === 'string') {
+      span.outputTokens = estimateTokensFromText(text);
+    }
+    if (usageTokens.cacheReadTokens !== undefined) {
+      span.cacheReadTokens = usageTokens.cacheReadTokens;
+    }
+    if (usageTokens.cacheWriteTokens !== undefined) {
+      span.cacheWriteTokens = usageTokens.cacheWriteTokens;
+    }
     this.touch(record, timestamp);
+  }
+
+  recordPluginHook(runId: string, hook: DevtoolsPluginHookSpan): void {
+    const record = this.runs.get(runId);
+    if (!record) {
+      return;
+    }
+    record.pluginHooks.push(hook);
+    this.touch(record);
   }
 
   recordToolCall(runId: string, name: string, input: unknown): void {
@@ -572,7 +714,21 @@ export function createDevtoolsIntegration(options: DevtoolsIntegrationOptions = 
       context.registerHook('beforeLLMCall', (input) => {
         const runId = runIdByContext.get(input.context);
         if (runId) {
-          store.recordLLMStart(runId);
+          const messageTokens = estimateTokensFromMessages(input.context?.messages ?? []);
+          let systemPromptTokens = 0;
+          if (typeof input.systemPrompt === 'string') {
+            systemPromptTokens = estimateTokensFromText(input.systemPrompt);
+          } else if (typeof input.systemPrompt === 'function') {
+            try {
+              systemPromptTokens = estimateTokensFromText(input.systemPrompt());
+            } catch {
+              systemPromptTokens = 0;
+            }
+          } else if (input.systemPrompt && typeof input.systemPrompt.append === 'string') {
+            systemPromptTokens = estimateTokensFromText(input.systemPrompt.append);
+          }
+          const inputTokens = messageTokens + systemPromptTokens;
+          store.recordLLMStart(runId, inputTokens);
         }
         return { tools: wrapTools(input.tools, store) };
       });
@@ -580,7 +736,7 @@ export function createDevtoolsIntegration(options: DevtoolsIntegrationOptions = 
       context.registerHook('afterLLMCall', (input) => {
         const runId = runIdByContext.get(input.context);
         if (runId) {
-          store.recordLLMEnd(runId, input.finishReason, input.text);
+          store.recordLLMEnd(runId, input.finishReason, input.text, input.usage);
         }
       });
 
@@ -608,6 +764,19 @@ export function createDevtoolsIntegration(options: DevtoolsIntegrationOptions = 
           store.finishRun(runId, input.result);
           runIdByContext.delete(input.context);
         }
+      });
+
+      context.events.on('hookTiming', (payload: any) => {
+        const runId = payload?.context ? runIdByContext.get(payload.context) : undefined;
+        if (!runId) {
+          return;
+        }
+        store.recordPluginHook(runId, {
+          pluginName: String(payload.pluginName ?? 'unknown'),
+          hookName: String(payload.hookName ?? 'unknown'),
+          startedAt: Number(payload.at ?? now()),
+          durationMs: Number(payload.durationMs ?? 0),
+        });
       });
     },
   };


### PR DESCRIPTION
## Summary
- record LLM cache read/write tokens when usage is available
- add stall/idle gap analysis + plugin hook timeline/table in devtools UI
- improve LLM span table with cache token columns

## Testing
- pnpm --filter @pulse-coder/remote-server build
- pnpm --filter devtools-web build
- plugin-kit build: ESM/CJS ok; DTS OOM on 4GB machine