### PR TITLE
feat(devtools): timeline UX + usage debug

### DIFF
--- a/apps/devtools-web/src/App.tsx
+++ b/apps/devtools-web/src/App.tsx
@@ -37,6 +37,8 @@ interface LlmSpan {
   outputTokens?: number;
   cacheReadTokens?: number;
   cacheWriteTokens?: number;
+  usageRaw?: string;
+  usageTruncated?: boolean;
 }
 
 interface ToolSpan {
@@ -792,6 +794,7 @@ export default function App() {
                     <th>Output Tok</th>
                     <th>Cache Read</th>
                     <th>Cache Write</th>
+                    <th>Usage</th>
                     <th>Tools</th>
                   </tr>
                 </thead>
@@ -820,6 +823,19 @@ export default function App() {
                       <td>{span.outputTokens ?? 'n/a'}</td>
                       <td>{span.cacheReadTokens ?? 'n/a'}</td>
                       <td>{span.cacheWriteTokens ?? 'n/a'}</td>
+                      <td>
+                        {span.usageRaw ? (
+                          <details className="usage-details">
+                            <summary className="usage-summary">View</summary>
+                            <pre className="usage-block">
+                              {span.usageRaw}
+                              {span.usageTruncated ? '\n…(truncated)' : ''}
+                            </pre>
+                          </details>
+                        ) : (
+                          'n/a'
+                        )}
+                      </td>
                       <td>
                         {span.toolCalls?.length
                           ? span.toolCalls.map((call, idx) => (

--- a/apps/devtools-web/src/styles.css
+++ b/apps/devtools-web/src/styles.css
@@ -507,6 +507,33 @@ th {
   white-space: nowrap;
 }
 
+.usage-details {
+  font-size: 12px;
+}
+
+.usage-summary {
+  cursor: pointer;
+  color: var(--accent);
+  list-style: none;
+}
+
+.usage-summary::-webkit-details-marker {
+  display: none;
+}
+
+.usage-block {
+  margin: 6px 0 0;
+  padding: 8px;
+  border-radius: 8px;
+  background: #fbfaf8;
+  border: 1px solid var(--border);
+  font-family: "Source Code Pro", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  white-space: pre-wrap;
+  max-height: 180px;
+  overflow: auto;
+}
+
 .empty {
   color: var(--text-muted);
   font-size: 14px;

--- a/packages/plugin-kit/src/devtools/index.ts
+++ b/packages/plugin-kit/src/devtools/index.ts
@@ -37,6 +37,8 @@ export interface DevtoolsLlmSpan {
   outputTokens?: number;
   cacheReadTokens?: number;
   cacheWriteTokens?: number;
+  usageRaw?: string;
+  usageTruncated?: boolean;
   toolCalls?: Array<{
     name: string;
     inputSize?: number;
@@ -409,6 +411,17 @@ export class DevtoolsStore {
     }
     span.finishReason = finishReason;
     span.textLength = typeof text === 'string' ? text.length : undefined;
+    if (usage !== undefined) {
+      const rawUsage = safeStringify(usage);
+      const limit = 4000;
+      if (rawUsage.length > limit) {
+        span.usageRaw = `${rawUsage.slice(0, limit)}...`;
+        span.usageTruncated = true;
+      } else {
+        span.usageRaw = rawUsage;
+        span.usageTruncated = false;
+      }
+    }
     const usageTokens = extractUsageTokens(usage);
     if (usageTokens.inputTokens !== undefined) {
       span.inputTokens = usageTokens.inputTokens;


### PR DESCRIPTION
## Summary
- add timeline tabs/filters + turn separators for consistent UX
- add LLM timing breakdown (TTFT/stream/tool wait) with tooltips
- show raw usage payload for cache/debug visibility
- improve detail panel scroll handling

## Testing
- pnpm --filter @pulse-coder/remote-server build
- pnpm --filter devtools-web build
- plugin-kit build: OOM on 4GB machine when generating DTS