### PR TITLE
feat(devtools): split TTFT vs TTFB

### DIFF
--- a/apps/devtools-web/src/App.tsx
+++ b/apps/devtools-web/src/App.tsx
@@ -23,8 +23,13 @@ interface LlmSpan {
   startedAt: number;
   endedAt?: number;
   durationMs?: number;
+  requestStartAt?: number;
   firstChunkAt?: number;
+  firstTextAt?: number;
+  enginePrepMs?: number;
+  ttfbMs?: number;
   ttftMs?: number;
+  ttftTextMs?: number;
   streamDurationMs?: number;
   finishReason?: string;
   textLength?: number;
@@ -366,12 +371,28 @@ export default function App() {
         const ttft =
           span.ttftMs ??
           (span.firstChunkAt && span.startedAt ? Math.max(0, span.firstChunkAt - span.startedAt) : undefined);
+        const enginePrep =
+          span.enginePrepMs ??
+          (span.requestStartAt && span.startedAt ? Math.max(0, span.requestStartAt - span.startedAt) : undefined);
+        const ttfb =
+          span.ttfbMs ??
+          (span.firstChunkAt
+            ? Math.max(0, span.firstChunkAt - (span.requestStartAt ?? span.startedAt))
+            : undefined);
+        const ttftText =
+          span.ttftTextMs ??
+          (span.firstTextAt
+            ? Math.max(0, span.firstTextAt - (span.requestStartAt ?? span.startedAt))
+            : undefined);
         const stream =
           span.streamDurationMs ??
           (span.firstChunkAt && span.endedAt ? Math.max(0, span.endedAt - span.firstChunkAt) : undefined);
         const toolTime = toolTimeForSpan(span);
         const toolWait = span.durationMs !== undefined ? Math.max(0, (span.durationMs ?? 0) - toolTime) : undefined;
         const tooltip = [
+          `Engine prep: ${formatMetric(enginePrep)}`,
+          `TTFB: ${formatMetric(ttfb)}`,
+          `TTFT (text): ${formatMetric(ttftText)}`,
           `TTFT: ${formatMetric(ttft)}`,
           `Stream: ${formatMetric(stream)}`,
           `Tool wait: ${formatMetric(toolWait)}`,
@@ -786,6 +807,7 @@ export default function App() {
                     <th>Index</th>
                     <th>Duration</th>
                     <th>TTFT</th>
+                    <th>TTFB</th>
                     <th>Stream</th>
                     <th>Tool Wait</th>
                     <th>Finish</th>
@@ -803,6 +825,11 @@ export default function App() {
                     const ttft =
                       span.ttftMs ??
                       (span.firstChunkAt && span.startedAt ? Math.max(0, span.firstChunkAt - span.startedAt) : undefined);
+                    const ttfb =
+                      span.ttfbMs ??
+                      (span.firstChunkAt
+                        ? Math.max(0, span.firstChunkAt - (span.requestStartAt ?? span.startedAt))
+                        : undefined);
                     const stream =
                       span.streamDurationMs ??
                       (span.firstChunkAt && span.endedAt ? Math.max(0, span.endedAt - span.firstChunkAt) : undefined);
@@ -815,6 +842,7 @@ export default function App() {
                       <td>#{span.index}</td>
                       <td>{formatDuration(span.durationMs)}</td>
                       <td>{ttft !== undefined ? formatDuration(ttft) : 'n/a'}</td>
+                      <td>{ttfb !== undefined ? formatDuration(ttfb) : 'n/a'}</td>
                       <td>{stream !== undefined ? formatDuration(stream) : 'n/a'}</td>
                       <td>{toolWait !== undefined ? formatDuration(toolWait) : 'n/a'}</td>
                       <td>{span.finishReason || 'n/a'}</td>

--- a/packages/engine/src/core/loop.ts
+++ b/packages/engine/src/core/loop.ts
@@ -240,9 +240,12 @@ export async function loop(context: Context, options?: LoopOptions): Promise<str
         return 'Request aborted.';
       }
 
+      let requestStartAt: number | undefined;
       let firstChunkAt: number | undefined;
+      let firstTextAt: number | undefined;
       let lastChunkAt: number | undefined;
 
+      requestStartAt = Date.now();
       const result = streamTextAI(context.messages, tools, {
         abortSignal: options?.abortSignal,
         toolExecutionContext,
@@ -256,6 +259,9 @@ export async function loop(context: Context, options?: LoopOptions): Promise<str
           const chunkAt = Date.now();
           if (firstChunkAt === undefined) {
             firstChunkAt = chunkAt;
+          }
+          if (chunk.type === 'text-delta' && firstTextAt === undefined) {
+            firstTextAt = chunkAt;
           }
           lastChunkAt = chunkAt;
           if (chunk.type === 'text-delta') {
@@ -302,7 +308,9 @@ export async function loop(context: Context, options?: LoopOptions): Promise<str
             text,
             usage,
             timings: {
+              requestStartAt,
               firstChunkAt,
+              firstTextAt,
               lastChunkAt,
             },
           });

--- a/packages/engine/src/plugin/EnginePlugin.ts
+++ b/packages/engine/src/plugin/EnginePlugin.ts
@@ -42,7 +42,9 @@ export interface AfterLLMCallInput {
   text: string;
   usage?: any;
   timings?: {
+    requestStartAt?: number;
     firstChunkAt?: number;
+    firstTextAt?: number;
     lastChunkAt?: number;
   };
 }

--- a/packages/plugin-kit/src/devtools/index.ts
+++ b/packages/plugin-kit/src/devtools/index.ts
@@ -28,8 +28,13 @@ export interface DevtoolsLlmSpan {
   startedAt: number;
   endedAt?: number;
   durationMs?: number;
+  requestStartAt?: number;
   firstChunkAt?: number;
+  firstTextAt?: number;
+  enginePrepMs?: number;
+  ttfbMs?: number;
   ttftMs?: number;
+  ttftTextMs?: number;
   streamDurationMs?: number;
   finishReason?: string;
   textLength?: number;
@@ -404,10 +409,19 @@ export class DevtoolsStore {
     }
     span.endedAt = timestamp;
     span.durationMs = Math.max(0, timestamp - span.startedAt);
+    if (timings?.requestStartAt && Number.isFinite(timings.requestStartAt)) {
+      span.requestStartAt = timings.requestStartAt;
+      span.enginePrepMs = Math.max(0, timings.requestStartAt - span.startedAt);
+    }
     if (timings?.firstChunkAt && Number.isFinite(timings.firstChunkAt)) {
       span.firstChunkAt = timings.firstChunkAt;
+      span.ttfbMs = Math.max(0, timings.firstChunkAt - (timings.requestStartAt ?? span.startedAt));
       span.ttftMs = Math.max(0, timings.firstChunkAt - span.startedAt);
       span.streamDurationMs = Math.max(0, timestamp - timings.firstChunkAt);
+    }
+    if (timings?.firstTextAt && Number.isFinite(timings.firstTextAt)) {
+      span.firstTextAt = timings.firstTextAt;
+      span.ttftTextMs = Math.max(0, timings.firstTextAt - (timings.requestStartAt ?? span.startedAt));
     }
     span.finishReason = finishReason;
     span.textLength = typeof text === 'string' ? text.length : undefined;


### PR DESCRIPTION
## Summary
- capture requestStart/firstText timing to split TTFT vs TTFB and engine prep
- surface TTFB in LLM span table and add breakdown to tooltips

## Testing
- pnpm --filter @pulse-coder/remote-server build
- pnpm --filter devtools-web build
- plugin-kit DTS may OOM on 4GB machine