### PR TITLE
feat(engine): support dynamic modelType for LLM provider selection

### DIFF
--- a/apps/remote-server/.pulse-coder/config.json
+++ b/apps/remote-server/.pulse-coder/config.json
@@ -1,8 +1,18 @@
 {
-  "models": [
-    {
-      "name": "gpt-5.2-codex"
-    }
-  ],
-  "current_model": "gpt-5.3-codex"
+  "current_model": "gpt-5.2-codex",
+  "provider_type": "openai",
+  "options": [
+    { "name": "gpt-5-codex", "provider_type": "openai" },
+    { "name": "gpt-5.1", "provider_type": "openai" },
+    { "name": "gpt-5.1-codex", "provider_type": "openai" },
+    { "name": "gpt-5.1-codex-mini", "provider_type": "openai" },
+    { "name": "gpt-5.1-codex-max", "provider_type": "openai" },
+    { "name": "gpt-5", "provider_type": "openai" },
+    { "name": "gpt-5.2", "provider_type": "openai" },
+    { "name": "gpt-5.2-codex", "provider_type": "openai" },
+    { "name": "gpt-5.3-codex", "provider_type": "openai" },
+    { "name": "gpt-5.4", "provider_type": "openai" },
+    { "name": "claude-opus-4-6", "provider_type": "claude" },
+    { "name": "claude-sonnet-4-6", "provider_type": "claude" }
+  ]
 }

--- a/apps/remote-server/src/core/agent-runner.ts
+++ b/apps/remote-server/src/core/agent-runner.ts
@@ -232,7 +232,7 @@ export async function executeAgentTurn(input: ExecuteAgentTurnInput): Promise<Ex
   const context = session.context;
   const callbacks = input.callbacks ?? {};
   const compactions: CompactionSnapshot[] = [];
-  const modelOverride = await resolveModelForRun(input.platformKey);
+  const { model: modelOverride, modelType } = await resolveModelForRun(input.platformKey);
 
   context.messages.push({ role: 'user', content: input.userText });
 
@@ -278,6 +278,7 @@ export async function executeAgentTurn(input: ExecuteAgentTurnInput): Promise<Ex
 
       return engine.run(context, {
         model: modelOverride,
+        modelType,
         runContext,
         systemPrompt: (() => {
           const channelPrompt = buildChannelSystemPrompt(input.platformKey);

--- a/apps/remote-server/src/core/chat-commands/handlers/model-commands.ts
+++ b/apps/remote-server/src/core/chat-commands/handlers/model-commands.ts
@@ -1,4 +1,4 @@
-import { clearModelOverride, getModelStatus, writeModelConfig } from '../../model-config.js';
+import { clearModelOverride, getModelStatus, resolveModelOption, writeModelConfig } from '../../model-config.js';
 import type { CommandResult } from '../types.js';
 
 export async function handleModelCommand(args: string[]): Promise<CommandResult> {
@@ -26,10 +26,15 @@ export async function handleModelCommand(args: string[]): Promise<CommandResult>
 
   const model = raw;
   try {
-    const result = await writeModelConfig({ current_model: model });
+    const option = await resolveModelOption(model);
+    const next = option
+      ? { current_model: option.name, provider_type: option.provider_type }
+      : { current_model: model };
+    const result = await writeModelConfig(next);
+    const providerHint = option?.provider_type ? ` (${option.provider_type})` : '';
     return {
       type: 'handled',
-      message: `✅ 已更新模型为 ${model}\nConfig: ${result.path}`,
+      message: `✅ 已更新模型为 ${model}${providerHint}\nConfig: ${result.path}`,
     };
   } catch (error) {
     console.error('[model-config] failed to update model config:', error);
@@ -52,7 +57,8 @@ async function renderModelStatus(): Promise<CommandResult> {
 
     const lines = ['🧠 当前模型信息：', `- Config: ${status.path}`];
     if (status.currentModel) {
-      lines.push(`- current_model: ${status.currentModel}`);
+      const providerHint = status.providerType ? ` (${status.providerType})` : '';
+      lines.push(`- current_model: ${status.currentModel}${providerHint}`);
     } else {
       lines.push('- current_model: (未设置)');
     }
@@ -61,7 +67,13 @@ async function renderModelStatus(): Promise<CommandResult> {
     } else {
       lines.push('- resolved_model: (未解析到)');
     }
-    if (status.models && status.models.length > 0) {
+    if (status.options && status.options.length > 0) {
+      lines.push('- options:');
+      for (const opt of status.options) {
+        const providerLabel = opt.provider_type ? ` [${opt.provider_type}]` : '';
+        lines.push(`  • ${opt.name}${providerLabel}`);
+      }
+    } else if (status.models && status.models.length > 0) {
       lines.push(`- models: ${status.models.join(', ')}`);
     }
     return {

--- a/apps/remote-server/src/core/model-config.ts
+++ b/apps/remote-server/src/core/model-config.ts
@@ -4,6 +4,7 @@ import { join, resolve, dirname } from 'path';
 
 type ModelConfig = {
   current_model?: string;
+  provider_type?: 'openai' | 'claude';
   models?: Array<{
     name?: string;
   }>;
@@ -188,28 +189,34 @@ export async function getModelStatus(): Promise<ModelStatus> {
   };
 }
 
-export async function resolveModelForRun(_platformKey: string): Promise<string | undefined> {
+export async function resolveModelForRun(_platformKey: string): Promise<{ model?: string; modelType?: 'openai' | 'claude' }> {
   const envPath = process.env.PULSE_CODER_MODEL_CONFIG?.trim();
   const configPath = await findConfigPath();
   const path = envPath || configPath || null;
   if (!path) {
-    return undefined;
+    return {};
   }
 
   try {
     const stat = await fs.stat(path);
     if (cachedConfig && cachedConfig.path === path && cachedConfig.mtimeMs === stat.mtimeMs) {
-      return selectModel(cachedConfig.data) ?? undefined;
+      return {
+        model: selectModel(cachedConfig.data) ?? undefined,
+        modelType: cachedConfig.data?.provider_type,
+      };
     }
 
     const data = await loadConfigFromPath(path, { warn: true });
     if (!data) {
-      return undefined;
+      return {};
     }
     cachedConfig = { path, mtimeMs: stat.mtimeMs, data };
-    return selectModel(data) ?? undefined;
+    return {
+      model: selectModel(data) ?? undefined,
+      modelType: data.provider_type,
+    };
   } catch {
-    return undefined;
+    return {};
   }
 }
 

--- a/apps/remote-server/src/core/model-config.ts
+++ b/apps/remote-server/src/core/model-config.ts
@@ -2,9 +2,15 @@ import { promises as fs } from 'fs';
 import { homedir } from 'os';
 import { join, resolve, dirname } from 'path';
 
+type ModelOption = {
+  name: string;
+  provider_type?: 'openai' | 'claude';
+};
+
 type ModelConfig = {
   current_model?: string;
   provider_type?: 'openai' | 'claude';
+  options?: ModelOption[];
   models?: Array<{
     name?: string;
   }>;
@@ -18,7 +24,9 @@ type ModelConfigWriteResult = {
 type ModelStatus = {
   path: string | null;
   currentModel?: string;
+  providerType?: 'openai' | 'claude';
   resolvedModel?: string;
+  options?: ModelOption[];
   models?: string[];
 };
 
@@ -184,9 +192,32 @@ export async function getModelStatus(): Promise<ModelStatus> {
   return {
     path,
     currentModel: normalizeModel(data?.current_model) ?? undefined,
+    providerType: data?.provider_type,
     resolvedModel: resolvedModel ?? undefined,
+    options: Array.isArray(data?.options) && data.options.length > 0 ? data.options : undefined,
     models: models && models.length > 0 ? models : undefined,
   };
+}
+
+export async function resolveModelOption(name: string): Promise<ModelOption | null> {
+  const envPath = process.env.PULSE_CODER_MODEL_CONFIG?.trim();
+  const configPath = await findConfigPath();
+  const path = envPath || configPath || null;
+  if (!path) return null;
+
+  try {
+    const stat = await fs.stat(path);
+    let data: ModelConfig | null;
+    if (cachedConfig && cachedConfig.path === path && cachedConfig.mtimeMs === stat.mtimeMs) {
+      data = cachedConfig.data;
+    } else {
+      data = await loadConfigFromPath(path, { warn: true });
+      if (data) cachedConfig = { path, mtimeMs: stat.mtimeMs, data };
+    }
+    return data?.options?.find((o) => o.name === name) ?? null;
+  } catch {
+    return null;
+  }
 }
 
 export async function resolveModelForRun(_platformKey: string): Promise<{ model?: string; modelType?: 'openai' | 'claude' }> {

--- a/packages/engine/src/Engine.ts
+++ b/packages/engine/src/Engine.ts
@@ -1,4 +1,4 @@
-import type { Context, Tool, LLMProviderFactory, SystemPromptOption, ToolHooks, ILogger, PulseEngineInstance } from './shared/types';
+import type { Context, Tool, LLMProviderFactory, SystemPromptOption, ToolHooks, ILogger, PulseEngineInstance, ModelType } from './shared/types';
 import type { LoopOptions, LoopHooks } from './core/loop';
 import type { EnginePluginLoadOptions } from './plugin/EnginePlugin.js';
 import type { UserConfigPluginLoadOptions } from './plugin/UserConfigPlugin.js';
@@ -9,6 +9,7 @@ import { maybeCompactContext } from './context/index.js';
 import { BuiltinToolsMap } from './tools/index.js';
 import { PluginManager } from './plugin/PluginManager.js';
 import { builtInPlugins } from './built-in/index.js';
+import { buildProvider } from './config/index.js';
 
 /**
  * 引擎配置选项
@@ -39,6 +40,15 @@ export interface EngineOptions {
    * });
    */
   llmProvider?: LLMProviderFactory;
+
+  /**
+   * Named provider type. Convenience alternative to `llmProvider` — engine will construct
+   * the SDK adapter from environment variables automatically.
+   * Ignored when `llmProvider` is set explicitly.
+   * - `'openai'` → OPENAI_API_KEY / OPENAI_API_URL
+   * - `'claude'` → ANTHROPIC_API_KEY / ANTHROPIC_API_URL
+   */
+  modelType?: ModelType;
 
   /**
    * 模型名称，传递给 llmProvider。未设置时使用 DEFAULT_MODEL。
@@ -253,7 +263,10 @@ export class Engine {
     const resultText = await loop(context, {
       ...options,
       tools,
-      provider: options?.provider ?? this.options.llmProvider,
+      provider: options?.provider
+        ?? (options?.modelType ? buildProvider(options.modelType) : undefined)
+        ?? this.options.llmProvider
+        ?? (this.options.modelType ? buildProvider(this.options.modelType) : undefined),
       model: options?.model ?? this.options.model,
       systemPrompt,
       hooks: loopHooks,

--- a/packages/engine/src/config/index.ts
+++ b/packages/engine/src/config/index.ts
@@ -2,6 +2,7 @@ import dotenv from "dotenv";
 import { createOpenAI } from '@ai-sdk/openai';
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { LanguageModel } from "ai";
+import type { ModelType, LLMProviderFactory } from '../shared/types.js';
 
 dotenv.config();
 
@@ -14,6 +15,24 @@ export const CoderAI = (process.env.USE_ANTHROPIC
     apiKey: process.env.OPENAI_API_KEY || '',
     baseURL: process.env.OPENAI_API_URL || 'https://api.openai.com/v1'
   }).responses) as (model: string) => LanguageModel;
+
+/**
+ * Construct a LLMProviderFactory from a named ModelType using environment variables.
+ * - 'claude' → ANTHROPIC_API_KEY / ANTHROPIC_API_URL
+ * - 'openai' → OPENAI_API_KEY / OPENAI_API_URL
+ */
+export function buildProvider(type: ModelType): LLMProviderFactory {
+  if (type === 'claude') {
+    return createAnthropic({
+      apiKey: process.env.ANTHROPIC_API_KEY || '',
+      baseURL: process.env.ANTHROPIC_API_URL || 'https://api.anthropic.com/v1',
+    }) as LLMProviderFactory;
+  }
+  return createOpenAI({
+    apiKey: process.env.OPENAI_API_KEY || '',
+    baseURL: process.env.OPENAI_API_URL || 'https://api.openai.com/v1',
+  }).responses as LLMProviderFactory;
+}
 
 export const DEFAULT_MODEL = process.env.ANTHROPIC_MODEL || process.env.OPENAI_MODEL || 'novita/deepseek/deepseek_v3';
 

--- a/packages/engine/src/core/loop.ts
+++ b/packages/engine/src/core/loop.ts
@@ -1,12 +1,13 @@
 import { ToolSet, type StepResult, type ModelMessage } from "ai";
-import type { Context, ClarificationRequest, Tool, LLMProviderFactory, SystemPromptOption } from "../shared/types";
+import type { Context, ClarificationRequest, Tool, LLMProviderFactory, SystemPromptOption, ModelType } from "../shared/types";
 import type { EngineHookMap, OnCompactedEvent } from "../plugin/EnginePlugin.js";
 import { streamTextAI } from "../ai";
 import { maybeCompactContext, type CompactStats } from "../context";
 import {
   MAX_COMPACTION_ATTEMPTS,
   MAX_ERROR_COUNT,
-  MAX_STEPS
+  MAX_STEPS,
+  buildProvider,
 } from "../config/index.js";
 
 /**
@@ -43,6 +44,13 @@ export interface LoopOptions {
 
   /** Custom LLM provider factory. Overrides the default provider when set. */
   provider?: LLMProviderFactory;
+  /**
+   * Named provider type. Used to construct a provider from env vars without importing the SDK.
+   * Ignored when `provider` is set explicitly.
+   * - `'openai'` → OPENAI_API_KEY / OPENAI_API_URL
+   * - `'claude'` → ANTHROPIC_API_KEY / ANTHROPIC_API_URL
+   */
+  modelType?: ModelType;
   /** Model name passed to the provider. Overrides DEFAULT_MODEL when set. */
   model?: string;
   /** Custom system prompt. See SystemPromptOption for the three supported forms. */
@@ -249,7 +257,7 @@ export async function loop(context: Context, options?: LoopOptions): Promise<str
       const result = streamTextAI(context.messages, tools, {
         abortSignal: options?.abortSignal,
         toolExecutionContext,
-        provider: options?.provider,
+        provider: options?.provider ?? (options?.modelType ? buildProvider(options.modelType) : undefined),
         model: options?.model,
         systemPrompt,
         onStepFinish: (step) => {

--- a/packages/engine/src/shared/types.ts
+++ b/packages/engine/src/shared/types.ts
@@ -15,6 +15,15 @@ import type { FlexibleSchema, ModelMessage, LanguageModel } from "ai";
 export type LLMProviderFactory = (model: string) => LanguageModel;
 
 /**
+ * Named LLM provider type. Used to select a built-in provider from environment variables
+ * without needing to import or construct the SDK adapter manually.
+ *
+ * - `'openai'` — uses OPENAI_API_KEY / OPENAI_API_URL
+ * - `'claude'` — uses ANTHROPIC_API_KEY / ANTHROPIC_API_URL
+ */
+export type ModelType = 'openai' | 'claude';
+
+/**
  * System prompt customization.
  * - `string` — replaces the built-in prompt entirely.
  * - `() => string` — factory evaluated on every request (supports dynamic prompts).


### PR DESCRIPTION
## Summary

- Add `ModelType = 'openai' | 'claude'` to `packages/engine/src/shared/types.ts`
- Add `buildProvider(type: ModelType): LLMProviderFactory` to `packages/engine/src/config/index.ts` — constructs the right SDK adapter (`@ai-sdk/openai` or `@ai-sdk/anthropic`) from env vars, no SDK import required by callers
- Add `modelType?: ModelType` to `EngineOptions` and `LoopOptions` with the following priority chain:
  ```
  run.provider > run.modelType > engine.llmProvider > engine.modelType > CoderAI default
  ```
- Extend `model-config.ts` to read `provider_type` from `config.json`; `resolveModelForRun()` now returns `{ model?, modelType? }`
- Pass `modelType` through to `engine.run()` in `agent-runner.ts`

## Usage

Set in `.pulse-coder/config.json`:
```json
{
  "current_model": "claude-opus-4-6",
  "provider_type": "claude"
}
```

Or pass directly when calling the engine:
```ts
engine.run(context, { modelType: 'claude', model: 'claude-opus-4-6' })
```

## Test plan

- [x] Build passes: `pnpm --filter @pulse-coder/remote-server build` ✅
- [x] No new type errors in changed engine files ✅
- [x] Manually verify switching `provider_type` in config.json routes to correct SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)