### PR TITLE
refactor(engine): rename ANTHROPIC_API_URL to PULSE_ANTHROPIC_API_URL

### DIFF
--- a/packages/engine/src/Engine.ts
+++ b/packages/engine/src/Engine.ts
@@ -46,7 +46,7 @@ export interface EngineOptions {
    * the SDK adapter from environment variables automatically.
    * Ignored when `llmProvider` is set explicitly.
    * - `'openai'` → OPENAI_API_KEY / OPENAI_API_URL
-   * - `'claude'` → ANTHROPIC_API_KEY / ANTHROPIC_API_URL
+   * - `'claude'` → ANTHROPIC_API_KEY / PULSE_ANTHROPIC_API_URL
    */
   modelType?: ModelType;
 

--- a/packages/engine/src/config/index.ts
+++ b/packages/engine/src/config/index.ts
@@ -9,7 +9,7 @@ dotenv.config();
 export const CoderAI = (process.env.USE_ANTHROPIC
   ? createAnthropic({
     apiKey: process.env.ANTHROPIC_API_KEY || '',
-    baseURL: process.env.ANTHROPIC_API_URL || 'https://api.anthropic.com/v1'
+    baseURL: process.env.PULSE_ANTHROPIC_API_URL || 'https://api.anthropic.com/v1'
   })
   : createOpenAI({
     apiKey: process.env.OPENAI_API_KEY || '',
@@ -22,7 +22,7 @@ export const CoderAI = (process.env.USE_ANTHROPIC
  * the OpenAI-compatible endpoint (/v1/chat/completions).
  *
  * - 'openai' → OPENAI_API_KEY / OPENAI_API_URL
- * - 'claude' → ANTHROPIC_API_KEY / ANTHROPIC_API_URL (falls back to OPENAI_* if unset)
+ * - 'claude' → ANTHROPIC_API_KEY / PULSE_ANTHROPIC_API_URL (falls back to OPENAI_* if unset)
  *
  * The modelType is still meaningful for pre-processing (e.g. system message consolidation).
  */
@@ -30,7 +30,7 @@ export function buildProvider(type: ModelType): LLMProviderFactory {
   if (type === 'claude') {
     return createAnthropic({
       apiKey: process.env.ANTHROPIC_API_KEY || '',
-      baseURL: process.env.ANTHROPIC_API_URL || 'https://api.anthropic.com/v1',
+      baseURL: process.env.PULSE_ANTHROPIC_API_URL || 'https://api.anthropic.com/v1',
       headers: { 'user-agent': 'claude-code/2.1.63' },
     }) as LLMProviderFactory;
   }

--- a/packages/engine/src/core/loop.ts
+++ b/packages/engine/src/core/loop.ts
@@ -48,7 +48,7 @@ export interface LoopOptions {
    * Named provider type. Used to construct a provider from env vars without importing the SDK.
    * Ignored when `provider` is set explicitly.
    * - `'openai'` → OPENAI_API_KEY / OPENAI_API_URL
-   * - `'claude'` → ANTHROPIC_API_KEY / ANTHROPIC_API_URL
+   * - `'claude'` → ANTHROPIC_API_KEY / PULSE_ANTHROPIC_API_URL
    */
   modelType?: ModelType;
   /** Model name passed to the provider. Overrides DEFAULT_MODEL when set. */

--- a/packages/engine/src/shared/types.ts
+++ b/packages/engine/src/shared/types.ts
@@ -19,7 +19,7 @@ export type LLMProviderFactory = (model: string) => LanguageModel;
  * without needing to import or construct the SDK adapter manually.
  *
  * - `'openai'` — uses OPENAI_API_KEY / OPENAI_API_URL
- * - `'claude'` — uses ANTHROPIC_API_KEY / ANTHROPIC_API_URL
+ * - `'claude'` — uses ANTHROPIC_API_KEY / PULSE_ANTHROPIC_API_URL
  */
 export type ModelType = 'openai' | 'claude';
 


### PR DESCRIPTION
Rename the Anthropic base URL env var to use the project-specific `PULSE_` prefix for better namespacing.

## Changes

- Replace `process.env.ANTHROPIC_API_URL` with `process.env.PULSE_ANTHROPIC_API_URL` in `CoderAI` and `buildProvider` (`config/index.ts`)
- Update JSDoc comments in `Engine.ts`, `loop.ts`, and `shared/types.ts` to reflect the renamed env var

## Migration

If you previously set `ANTHROPIC_API_URL` in your `.env`, rename it to `PULSE_ANTHROPIC_API_URL`. The fallback default (`https://api.anthropic.com/v1`) is unchanged.