### PR TITLE
Limit terminal scrollback restoration to last 10 lines

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody.tsx
@@ -110,7 +110,7 @@ export const TerminalNodeBody = ({ node, onUpdate }: Props) => {
 
     if (initialScrollback.current) {
       term.writeln("\x1b[2m--- session restored ---\x1b[0m");
-      term.writeln(initialScrollback.current);
+      term.write(initialScrollback.current.replace(/\n/g, "\r\n") + "\r\n");
       term.writeln("\x1b[2m--- new session ---\x1b[0m\r\n");
     }
 

--- a/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody.tsx
@@ -109,8 +109,13 @@ export const TerminalNodeBody = ({ node, onUpdate }: Props) => {
     fitRef.current = fitAddon;
 
     if (initialScrollback.current) {
+      const RESTORE_TAIL_LINES = 10;
+      const lastLines = initialScrollback.current
+        .split("\n")
+        .slice(-RESTORE_TAIL_LINES)
+        .join("\r\n");
       term.writeln("\x1b[2m--- session restored ---\x1b[0m");
-      term.write(initialScrollback.current.replace(/\n/g, "\r\n") + "\r\n");
+      term.write(lastLines + "\r\n");
       term.writeln("\x1b[2m--- new session ---\x1b[0m\r\n");
     }
 


### PR DESCRIPTION
## Summary
Modified the terminal session restoration logic to only display the last 10 lines of scrollback history instead of the entire scrollback buffer. This prevents overwhelming the terminal with excessive historical output when restoring a session.

## Key Changes
- Added `RESTORE_TAIL_LINES` constant set to 10 to control how many lines of history are restored
- Changed scrollback restoration to extract only the last N lines from the full scrollback buffer using `slice(-RESTORE_TAIL_LINES)`
- Updated line ending handling from `\n` to `\r\n` for proper terminal formatting
- Changed from `writeln()` to `write()` for the restored content to have explicit control over line endings

## Implementation Details
- The scrollback is split by newlines, sliced to get the tail lines, and rejoined with `\r\n` (carriage return + line feed) for proper terminal display
- This approach maintains the session restoration UI markers ("--- session restored ---" and "--- new session ---") while limiting the amount of historical content shown

https://claude.ai/code/session_01UZJN9rZ4GaSgLJsvQMkPAc