### PR TITLE
Relocate sidebar toggle to footer and hide titlebar

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -17,9 +17,6 @@ const App = () => {
 
   return (
     <div className="app">
-      <div className="app-titlebar">
-        <span className="titlebar-title">Canvas Workspace</span>
-      </div>
       <div className="app-body">
         <Sidebar
           collapsed={sidebarCollapsed}

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas.tsx
@@ -4,7 +4,7 @@ import { useNodes } from "../hooks/useNodes";
 import { useNodeDrag } from "../hooks/useNodeDrag";
 import { useNodeResize } from "../hooks/useNodeResize";
 import { useCanvasContext } from "../hooks/useCanvasContext";
-import type { CanvasTransform } from "../types";
+import type { CanvasNode, CanvasTransform } from "../types";
 import { CanvasNodeView } from "./CanvasNodeView";
 import { NodeContextMenu } from "./NodeContextMenu";
 import { FloatingToolbar } from "./FloatingToolbar";
@@ -13,6 +13,8 @@ import { ZoomIndicator } from "./ZoomIndicator";
 export const Canvas = ({ canvasId, rootFolder, hidden }: { canvasId: string; rootFolder?: string; hidden?: boolean }) => {
   const [activeTool, setActiveTool] = useState("select");
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [animating, setAnimating] = useState(false);
+  const animTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const {
     transform,
@@ -138,6 +140,27 @@ useEffect(() => {
     setSelectedNodeId(nodeId);
   }, []);
 
+  const handleFocusNode = useCallback(
+    (node: CanvasNode) => {
+      if (!containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      const padding = 80;
+      const fitScale = Math.min(
+        (rect.width - padding * 2) / node.width,
+        (rect.height - padding * 2) / node.height
+      );
+      const targetScale = Math.min(Math.max(0.1, fitScale), 1.5);
+      const tx = rect.width / 2 - (node.x + node.width / 2) * targetScale;
+      const ty = rect.height / 2 - (node.y + node.height / 2) * targetScale;
+
+      setAnimating(true);
+      setTransform({ x: tx, y: ty, scale: targetScale });
+      if (animTimerRef.current) clearTimeout(animTimerRef.current);
+      animTimerRef.current = setTimeout(() => setAnimating(false), 380);
+    },
+    [setTransform]
+  );
+
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {
       canvasMouseDown(e);
@@ -196,7 +219,8 @@ useEffect(() => {
       <div
         className="canvas-transform"
         style={{
-          transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`
+          transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`,
+          transition: animating ? 'transform 0.32s cubic-bezier(0.25, 0.46, 0.45, 0.94)' : undefined
         }}
       >
         {nodes.map((node) => (
@@ -213,6 +237,7 @@ useEffect(() => {
             onUpdate={updateNode}
             onRemove={removeNode}
             onSelect={handleNodeSelect}
+            onFocus={handleFocusNode}
           />
         ))}
       </div>

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView.tsx
@@ -22,6 +22,7 @@ interface Props {
   onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
   onRemove: (id: string) => void;
   onSelect: (id: string) => void;
+  onFocus: (node: CanvasNode) => void;
 }
 
 export const CanvasNodeView = ({
@@ -35,7 +36,8 @@ export const CanvasNodeView = ({
   onResizeStart,
   onUpdate,
   onRemove,
-  onSelect
+  onSelect,
+  onFocus
 }: Props) => {
   const handleHeaderMouseDown = useCallback(
     (e: React.MouseEvent) => {
@@ -59,6 +61,14 @@ export const CanvasNodeView = ({
       onRemove(node.id);
     },
     [onRemove, node.id]
+  );
+
+  const handleFocus = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onFocus(node);
+    },
+    [onFocus, node]
   );
 
   const handleTitleChange = useCallback(
@@ -121,6 +131,12 @@ export const CanvasNodeView = ({
         >
           {node.title}
         </span>
+        <button className="node-focus" onClick={handleFocus} title="Focus">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <circle cx="6" cy="6" r="2" stroke="currentColor" strokeWidth="1.3" />
+            <path d="M6 1v2M6 9v2M1 6h2M9 6h2" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+          </svg>
+        </button>
         <button className="node-close" onClick={handleClose} title="Remove">
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
             <path d="M3 3l6 6M9 3l-6 6" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar.tsx
@@ -78,20 +78,6 @@ export const Sidebar = ({
 
   return (
     <aside className={`sidebar${collapsed ? ' sidebar--collapsed' : ''}`}>
-      <div className="sidebar-header">
-        <button className="sidebar-toggle" onClick={onToggle} title="Toggle sidebar">
-          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-            <path
-              d={collapsed ? 'M6 3l5 5-5 5' : 'M10 3L5 8l5 5'}
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-        </button>
-      </div>
-
       {!collapsed && (
         <>
           <div className="sidebar-section-title">Workspaces</div>
@@ -204,6 +190,20 @@ export const Sidebar = ({
           </div>
         </>
       )}
+
+      <div className="sidebar-footer">
+        <button className="sidebar-toggle" onClick={onToggle} title="Toggle sidebar">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <path
+              d={collapsed ? 'M6 3l5 5-5 5' : 'M10 3L5 8l5 5'}
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
     </aside>
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -457,6 +457,7 @@ body {
   background: rgba(0, 0, 0, 0.03);
 }
 
+.node-focus,
 .node-close {
   width: 20px;
   height: 20px;
@@ -473,8 +474,14 @@ body {
   transition: opacity 0.1s, background 0.1s, color 0.1s;
 }
 
+.canvas-node:hover .node-focus,
 .canvas-node:hover .node-close {
   opacity: 1;
+}
+
+.node-focus:hover {
+  background: var(--accent-light);
+  color: var(--accent);
 }
 
 .node-close:hover {

--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -55,21 +55,7 @@ body {
 }
 
 .app-titlebar {
-  height: var(--titlebar-height);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--surface);
-  border-bottom: 1px solid var(--border);
-  -webkit-app-region: drag;
-  user-select: none;
-  flex-shrink: 0;
-}
-
-.titlebar-title {
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--text-secondary);
+  display: none;
 }
 
 .app-body {
@@ -95,13 +81,13 @@ body {
   width: var(--sidebar-collapsed);
 }
 
-.sidebar-header {
-  height: 44px;
+.sidebar-footer {
+  margin-top: auto;
+  padding: 8px;
   display: flex;
   align-items: center;
-  padding: 0 12px;
-  gap: 8px;
-  border-bottom: 1px solid var(--border-light);
+  border-top: 1px solid var(--border-light);
+  flex-shrink: 0;
 }
 
 .sidebar-brand {


### PR DESCRIPTION
## Summary
This PR reorganizes the sidebar layout by moving the toggle button from the header to a new footer section, and removes the application titlebar from the UI.

## Key Changes
- **Removed sidebar header**: Deleted the `sidebar-header` div containing the toggle button and its styling
- **Added sidebar footer**: Created a new `sidebar-footer` section at the bottom of the sidebar with the toggle button, using flexbox with `margin-top: auto` to push it to the bottom
- **Hidden titlebar**: Set `.app-titlebar` to `display: none` and removed the titlebar title element from the DOM
- **Updated styles**: 
  - Replaced `.sidebar-header` styles with `.sidebar-footer` styles (margin-top auto, padding, border-top instead of border-bottom)
  - Simplified `.app-titlebar` to just hide the element

## Implementation Details
- The toggle button functionality remains unchanged; only its position in the DOM has moved
- The footer uses `margin-top: auto` to ensure it stays at the bottom of the sidebar, even when content doesn't fill the full height
- The border styling was updated from `border-bottom` on the header to `border-top` on the footer to maintain visual separation

https://claude.ai/code/session_01WCUz9cW2Q8x9RgMniVxBCL