### PR TITLE
Auto-fit canvas nodes on initial load and collapse sidebar by default

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -4,7 +4,7 @@ import { Sidebar } from './components/Sidebar';
 import { useWorkspaces } from './hooks/useWorkspaces';
 
 const App = () => {
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(true);
   const {
     workspaces,
     activeId,

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas.tsx
@@ -337,6 +337,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden }: { canvasId:
             isSelected={selectedNodeId === node.id}
             isHighlighted={highlightedId === node.id}
             canvasScale={transform.scale}
+            canvasAnimating={animating}
             onDragStart={onDragStart}
             onResizeStart={onResizeStart}
             onUpdate={updateNode}

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas.tsx
@@ -321,8 +321,11 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden }: { canvasId:
         className="canvas-transform"
         style={{
           transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`,
-          transition: animating ? 'transform 0.32s cubic-bezier(0.25, 0.46, 0.45, 0.94)' : undefined
-        }}
+          '--canvas-scale': transform.scale,
+          transition: animating
+            ? 'transform 0.32s cubic-bezier(0.25, 0.46, 0.45, 0.94), --canvas-scale 0.32s cubic-bezier(0.25, 0.46, 0.45, 0.94)'
+            : undefined
+        } as React.CSSProperties}
       >
         {sortedNodes.map((node) => (
           <CanvasNodeView
@@ -336,8 +339,6 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden }: { canvasId:
             isResizing={resizingId === node.id}
             isSelected={selectedNodeId === node.id}
             isHighlighted={highlightedId === node.id}
-            canvasScale={transform.scale}
-            canvasAnimating={animating}
             onDragStart={onDragStart}
             onResizeStart={onResizeStart}
             onUpdate={updateNode}

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas.tsx
@@ -19,6 +19,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden }: { canvasId:
   const [searchOpen, setSearchOpen] = useState(false);
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
   const highlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hasAutoFitted = useRef(false);
 
   const {
     transform,
@@ -52,11 +53,38 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden }: { canvasId:
     [setTransform]
   );
 
-  const handleRestoreTransform = useCallback(
-    (t: CanvasTransform) => {
-      setTransform(t);
+  const fitAllNodes = useCallback(
+    (nodeList: CanvasNode[]) => {
+      if (!containerRef.current || nodeList.length === 0) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      const padding = 80;
+      const minX = Math.min(...nodeList.map((n) => n.x));
+      const minY = Math.min(...nodeList.map((n) => n.y));
+      const maxX = Math.max(...nodeList.map((n) => n.x + n.width));
+      const maxY = Math.max(...nodeList.map((n) => n.y + n.height));
+      const boundsW = maxX - minX;
+      const boundsH = maxY - minY;
+      if (boundsW === 0 || boundsH === 0) return;
+      const fitScale = Math.min(
+        (rect.width - padding * 2) / boundsW,
+        (rect.height - padding * 2) / boundsH
+      );
+      const targetScale = Math.min(Math.max(0.1, fitScale), 1.5);
+      const tx = rect.width / 2 - (minX + boundsW / 2) * targetScale;
+      const ty = rect.height / 2 - (minY + boundsH / 2) * targetScale;
+      setAnimating(true);
+      setTransform({ x: tx, y: ty, scale: targetScale });
+      if (animTimerRef.current) clearTimeout(animTimerRef.current);
+      animTimerRef.current = setTimeout(() => setAnimating(false), 380);
     },
     [setTransform]
+  );
+
+  const handleRestoreTransform = useCallback(
+    (_t: CanvasTransform) => {
+      // Transform will be overridden by auto-fit on initial load
+    },
+    []
   );
 
   const {
@@ -74,6 +102,16 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden }: { canvasId:
   useEffect(() => {
     setTransformForSave(transform);
   }, [transform, setTransformForSave]);
+
+  // Auto-fit all nodes into view on initial load
+  useEffect(() => {
+    if (loaded && !hasAutoFitted.current) {
+      hasAutoFitted.current = true;
+      if (nodes.length > 0) {
+        fitAllNodes(nodes);
+      }
+    }
+  }, [loaded, nodes, fitAllNodes]);
 
   useCanvasContext(rootFolder, nodes, canvasName);
 

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas.tsx
@@ -336,6 +336,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden }: { canvasId:
             isResizing={resizingId === node.id}
             isSelected={selectedNodeId === node.id}
             isHighlighted={highlightedId === node.id}
+            canvasScale={transform.scale}
             onDragStart={onDragStart}
             onResizeStart={onResizeStart}
             onUpdate={updateNode}

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView.tsx
@@ -16,6 +16,7 @@ interface Props {
   isSelected: boolean;
   isHighlighted: boolean;
   canvasScale?: number;
+  canvasAnimating?: boolean;
   onDragStart: (e: React.MouseEvent, node: CanvasNode) => void;
   onResizeStart: (
     e: React.MouseEvent,
@@ -41,6 +42,7 @@ export const CanvasNodeView = ({
   isSelected,
   isHighlighted,
   canvasScale = 1,
+  canvasAnimating = false,
   onDragStart,
   onResizeStart,
   onUpdate,
@@ -127,6 +129,7 @@ export const CanvasNodeView = ({
         style={node.type === 'frame' ? {
           transform: `scale(${1 / canvasScale})`,
           transformOrigin: 'left bottom',
+          transition: canvasAnimating ? 'transform 0.32s cubic-bezier(0.25, 0.46, 0.45, 0.94)' : undefined,
         } : undefined}
       >
         <span className={`node-type-badge node-type-badge--${node.type}`}>

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView.tsx
@@ -15,8 +15,6 @@ interface Props {
   isResizing: boolean;
   isSelected: boolean;
   isHighlighted: boolean;
-  canvasScale?: number;
-  canvasAnimating?: boolean;
   onDragStart: (e: React.MouseEvent, node: CanvasNode) => void;
   onResizeStart: (
     e: React.MouseEvent,
@@ -41,8 +39,6 @@ export const CanvasNodeView = ({
   isResizing,
   isSelected,
   isHighlighted,
-  canvasScale = 1,
-  canvasAnimating = false,
   onDragStart,
   onResizeStart,
   onUpdate,
@@ -126,11 +122,6 @@ export const CanvasNodeView = ({
       <div
         className="node-header"
         onMouseDown={handleHeaderMouseDown}
-        style={node.type === 'frame' ? {
-          transform: `scale(${1 / canvasScale})`,
-          transformOrigin: 'left bottom',
-          transition: canvasAnimating ? 'transform 0.32s cubic-bezier(0.25, 0.46, 0.45, 0.94)' : undefined,
-        } : undefined}
       >
         <span className={`node-type-badge node-type-badge--${node.type}`}>
           {node.type === "file" ? (

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView.tsx
@@ -15,6 +15,7 @@ interface Props {
   isResizing: boolean;
   isSelected: boolean;
   isHighlighted: boolean;
+  canvasScale?: number;
   onDragStart: (e: React.MouseEvent, node: CanvasNode) => void;
   onResizeStart: (
     e: React.MouseEvent,
@@ -39,6 +40,7 @@ export const CanvasNodeView = ({
   isResizing,
   isSelected,
   isHighlighted,
+  canvasScale = 1,
   onDragStart,
   onResizeStart,
   onUpdate,
@@ -119,7 +121,14 @@ export const CanvasNodeView = ({
       }}
       onClick={handleNodeClick}
     >
-      <div className="node-header" onMouseDown={handleHeaderMouseDown}>
+      <div
+        className="node-header"
+        onMouseDown={handleHeaderMouseDown}
+        style={node.type === 'frame' ? {
+          transform: `scale(${1 / canvasScale})`,
+          transformOrigin: 'left bottom',
+        } : undefined}
+      >
         <span className={`node-type-badge node-type-badge--${node.type}`}>
           {node.type === "file" ? (
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none">

--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -1,3 +1,10 @@
+/* Allow --canvas-scale to be animated via CSS transition */
+@property --canvas-scale {
+  syntax: '<number>';
+  initial-value: 1;
+  inherits: true;
+}
+
 /* ---- Reset & Foundation ---- */
 
 :root {
@@ -435,6 +442,8 @@ body {
   border-bottom: none;
   padding: 0 8px;
   color: white;
+  transform: scale(calc(1 / var(--canvas-scale, 1)));
+  transform-origin: left bottom;
 }
 
 .canvas-node--frame .node-header .node-type-badge--frame,


### PR DESCRIPTION
## Summary
This PR improves the initial canvas experience by automatically fitting all nodes into view when the canvas first loads, and changes the default sidebar state to collapsed.

## Key Changes
- **Auto-fit functionality**: Added a new `fitAllNodes` callback that calculates optimal zoom and pan to fit all canvas nodes within the viewport with padding
  - Computes bounding box of all nodes
  - Calculates appropriate scale (0.1 to 1.5 range) to fit content
  - Centers the view on the node collection
  - Animates the transition over 380ms
  - Uses a `hasAutoFitted` ref to ensure this only runs once on initial load

- **Transform restoration**: Modified `handleRestoreTransform` to be a no-op, allowing the auto-fit to take precedence over any saved transform on initial load

- **Default sidebar state**: Changed the initial sidebar state from expanded to collapsed (`useState(true)`)

## Implementation Details
- The auto-fit logic runs in a `useEffect` that triggers when `loaded` becomes true and nodes are available
- Includes safety checks for empty node lists and zero-dimension bounds
- The animation state is managed via `setAnimating` with a timer to reset after the transition completes
- Padding of 80px is applied around the fitted content for visual breathing room

https://claude.ai/code/session_015DiCoDA9xQ2SoGv8T2pxLa