### PR TITLE
Add Cmd/Ctrl+Tab keyboard shortcut to cycle through nodes

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas.tsx
@@ -135,6 +135,36 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden }: { canvasId:
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, []);
 
+  // Cmd/Ctrl+Tab to cycle through nodes (Shift reverses direction)
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'Tab') {
+        const activeEl = document.activeElement;
+        const isEditable = activeEl && (
+          activeEl.tagName === 'INPUT' ||
+          activeEl.tagName === 'TEXTAREA' ||
+          (activeEl as HTMLElement).isContentEditable
+        );
+        if (!isEditable && nodes.length > 0) {
+          e.preventDefault();
+          const currentIndex = nodes.findIndex((n) => n.id === selectedNodeId);
+          let nextIndex: number;
+          if (e.shiftKey) {
+            nextIndex = currentIndex <= 0 ? nodes.length - 1 : currentIndex - 1;
+          } else {
+            nextIndex = currentIndex >= nodes.length - 1 ? 0 : currentIndex + 1;
+          }
+          const nextNode = nodes[nextIndex];
+          setSelectedNodeId(nextNode.id);
+          setHighlightedId(nextNode.id);
+          handleFocusNode(nextNode);
+        }
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [nodes, selectedNodeId, handleFocusNode]);
+
   // Clear highlight after animation
   useEffect(() => {
     if (highlightedId) {


### PR DESCRIPTION
## Summary
Added keyboard navigation support to cycle through nodes in the canvas using Cmd/Ctrl+Tab (or Cmd/Ctrl+Shift+Tab to reverse direction).

## Key Changes
- Added a new `useEffect` hook that listens for Cmd/Ctrl+Tab keyboard events
- When the shortcut is pressed, the next node in the list is selected and focused
- Shift+Tab reverses the cycling direction (goes to previous node instead)
- The shortcut is disabled when focus is on editable elements (input, textarea, or contentEditable elements) to avoid interfering with text editing
- Cycling wraps around: pressing Tab on the last node selects the first node, and Shift+Tab on the first node selects the last node

## Implementation Details
- The handler checks if the active element is editable before processing the keyboard event
- Uses `findIndex` to locate the currently selected node and calculate the next index
- Calls `setSelectedNodeId`, `setHighlightedId`, and `handleFocusNode` to update the UI and focus state
- Dependencies include `nodes`, `selectedNodeId`, and `handleFocusNode` to ensure the effect stays in sync with state changes

https://claude.ai/code/session_01T2iCYjJJKUhdd8bsmN3BQS