### PR TITLE
Add undo/redo history and multi-select with clipboard support

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas.tsx
@@ -13,13 +13,20 @@ import { SearchPalette } from "./SearchPalette";
 
 export const Canvas = ({ canvasId, canvasName, rootFolder, hidden }: { canvasId: string; canvasName?: string; rootFolder?: string; hidden?: boolean }) => {
   const [activeTool, setActiveTool] = useState("select");
-  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [selectedNodeIds, setSelectedNodeIds] = useState<string[]>([]);
+  const [clipboardNodes, setClipboardNodes] = useState<CanvasNode[]>([]);
   const [animating, setAnimating] = useState(false);
   const animTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [searchOpen, setSearchOpen] = useState(false);
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
   const highlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hasAutoFitted = useRef(false);
+  const [contextMenu, setContextMenu] = useState<{
+    screenX: number;
+    screenY: number;
+    canvasX: number;
+    canvasY: number;
+  } | null>(null);
 
   const {
     transform,
@@ -93,10 +100,16 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden }: { canvasId:
     addNode,
     updateNode,
     removeNode,
+    removeNodes,
     moveNode,
     moveNodes,
     resizeNode,
-    setTransformForSave
+    setTransformForSave,
+    commitHistory,
+    undo,
+    redo,
+    duplicateNode,
+    pasteNodes,
   } = useNodes(canvasId, handleRestoreTransform);
 
   useEffect(() => {
@@ -115,25 +128,94 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden }: { canvasId:
 
   useCanvasContext(rootFolder, nodes, canvasName);
 
-  // Cmd/Ctrl+K to open search
+  // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
-        const activeEl = document.activeElement;
-        const isEditable = activeEl && (
-          activeEl.tagName === 'INPUT' ||
-          activeEl.tagName === 'TEXTAREA' ||
-          (activeEl as HTMLElement).isContentEditable
-        );
-        if (!isEditable) {
-          e.preventDefault();
-          setSearchOpen((prev) => !prev);
+      const active = document.activeElement;
+      const isEditable = active && (
+        active.tagName === 'INPUT' ||
+        active.tagName === 'TEXTAREA' ||
+        (active as HTMLElement).isContentEditable
+      );
+      const isMod = e.metaKey || e.ctrlKey;
+
+      // Cmd/Ctrl+K: toggle search palette
+      if (isMod && e.key === 'k' && !isEditable) {
+        e.preventDefault();
+        setSearchOpen((prev) => !prev);
+        return;
+      }
+
+      // Cmd/Ctrl+Z: undo
+      if (isMod && !e.shiftKey && e.key === 'z' && !isEditable) {
+        e.preventDefault();
+        undo();
+        return;
+      }
+
+      // Cmd/Ctrl+Shift+Z: redo
+      if (isMod && e.shiftKey && e.key === 'z' && !isEditable) {
+        e.preventDefault();
+        redo();
+        return;
+      }
+
+      // Cmd/Ctrl+A: select all nodes
+      if (isMod && e.key === 'a' && !isEditable) {
+        e.preventDefault();
+        setSelectedNodeIds(nodes.map((n) => n.id));
+        return;
+      }
+
+      // Cmd/Ctrl+D: duplicate selected node
+      if (isMod && e.key === 'd' && !isEditable) {
+        e.preventDefault();
+        if (selectedNodeIds.length === 1) {
+          const newNode = duplicateNode(selectedNodeIds[0]);
+          if (newNode) setSelectedNodeIds([newNode.id]);
         }
+        return;
+      }
+
+      // Cmd/Ctrl+C: copy selected nodes
+      if (isMod && e.key === 'c' && !isEditable) {
+        const selected = nodes.filter((n) => selectedNodeIds.includes(n.id));
+        if (selected.length > 0) setClipboardNodes(selected);
+        return;
+      }
+
+      // Cmd/Ctrl+V: paste nodes
+      if (isMod && e.key === 'v' && !isEditable) {
+        if (clipboardNodes.length > 0) {
+          e.preventDefault();
+          const created = pasteNodes(clipboardNodes);
+          setSelectedNodeIds(created.map((n) => n.id));
+        }
+        return;
+      }
+
+      // Escape: close modals then clear selection
+      if (e.key === 'Escape') {
+        if (searchOpen) { setSearchOpen(false); return; }
+        if (contextMenu) { setContextMenu(null); return; }
+        setSelectedNodeIds([]);
+        return;
+      }
+
+      // Delete / Backspace: delete selected nodes
+      if ((e.key === 'Delete' || e.key === 'Backspace') && !isEditable) {
+        if (selectedNodeIds.length > 0) {
+          e.preventDefault();
+          removeNodes(selectedNodeIds);
+          setSelectedNodeIds([]);
+        }
+        return;
       }
     };
+
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, []);
+  }, [undo, redo, nodes, selectedNodeIds, duplicateNode, clipboardNodes, pasteNodes, removeNodes, searchOpen, contextMenu]);
 
   // Clear highlight after animation
   useEffect(() => {
@@ -144,7 +226,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden }: { canvasId:
   }, [highlightedId]);
 
   const handleSearchSelect = useCallback((node: CanvasNode) => {
-    setSelectedNodeId(node.id);
+    setSelectedNodeIds([node.id]);
     setHighlightedId(node.id);
     handleFocusNode(node);
   }, [handleFocusNode]);
@@ -159,13 +241,6 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden }: { canvasId:
     useNodeResize(resizeNode, transform.scale);
 
   const containerRef = useRef<HTMLDivElement>(null);
-
-  const [contextMenu, setContextMenu] = useState<{
-    screenX: number;
-    screenY: number;
-    canvasX: number;
-    canvasY: number;
-  } | null>(null);
 
   const isBlankCanvasTarget = useCallback((target: EventTarget | null) => {
     if (!(target instanceof HTMLElement)) return false;
@@ -209,7 +284,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden }: { canvasId:
     (type: "file" | "terminal" | "frame") => {
       if (!contextMenu) return;
       const node = addNode(type, contextMenu.canvasX, contextMenu.canvasY);
-      setSelectedNodeId(node.id);
+      setSelectedNodeIds([node.id]);
       setContextMenu(null);
     },
     [addNode, contextMenu]
@@ -232,7 +307,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden }: { canvasId:
         pos.x - halfW,
         pos.y - (type === "frame" ? 200 : 150)
       );
-      setSelectedNodeId(node.id);
+      setSelectedNodeIds([node.id]);
     },
     [addNode, screenToCanvas]
   );
@@ -241,16 +316,14 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden }: { canvasId:
     (e: React.MouseEvent) => {
       if (contextMenu) setContextMenu(null);
       if ((e.target as HTMLElement).closest(".canvas-node")) return;
-      setSelectedNodeId(null);
+      setSelectedNodeIds([]);
     },
     [contextMenu]
   );
 
   const handleNodeSelect = useCallback((nodeId: string) => {
-    setSelectedNodeId(nodeId);
+    setSelectedNodeIds([nodeId]);
   }, []);
-
-
 
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {
@@ -272,7 +345,8 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden }: { canvasId:
     canvasMouseUp();
     onDragEnd();
     onResizeEnd();
-  }, [canvasMouseUp, onDragEnd, onResizeEnd]);
+    commitHistory();
+  }, [canvasMouseUp, onDragEnd, onResizeEnd, commitHistory]);
 
   // Frames render first so they appear behind other nodes
   const sortedNodes = useMemo(
@@ -337,7 +411,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden }: { canvasId:
             workspaceName={canvasName}
             isDragging={draggingId === node.id}
             isResizing={resizingId === node.id}
-            isSelected={selectedNodeId === node.id}
+            isSelected={selectedNodeIds.includes(node.id)}
             isHighlighted={highlightedId === node.id}
             onDragStart={onDragStart}
             onResizeStart={onResizeStart}

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { CanvasNode, CanvasTransform, CanvasSaveData } from "../types";
+import type { CanvasNode, CanvasTransform, CanvasSaveData, FrameNodeData } from "../types";
 
 let nodeIdCounter = 0;
 const genId = () => `node-${Date.now()}-${++nodeIdCounter}`;
 
 const SAVE_DEBOUNCE_MS = 800;
+const MAX_HISTORY = 100;
 const DEFAULT_CANVAS_ID = "default";
 
 export const useNodes = (
@@ -17,6 +18,8 @@ export const useNodes = (
   const nodesRef = useRef(nodes);
   nodesRef.current = nodes;
   const transformRef = useRef<CanvasTransform>({ x: 0, y: 0, scale: 1 });
+  const historyRef = useRef<CanvasNode[][]>([]);
+  const historyIndexRef = useRef(-1);
 
   const scheduleSave = useCallback(() => {
     if (saveTimer.current) clearTimeout(saveTimer.current);
@@ -40,9 +43,29 @@ export const useNodes = (
     [scheduleSave]
   );
 
+  // Central mutation point — optionally pushes a history snapshot
+  const applyNodes = useCallback(
+    (newNodes: CanvasNode[], addToHistory = true) => {
+      if (addToHistory) {
+        const trimmed = historyRef.current.slice(0, historyIndexRef.current + 1);
+        trimmed.push(newNodes);
+        if (trimmed.length > MAX_HISTORY) trimmed.shift();
+        historyIndexRef.current = trimmed.length - 1;
+        historyRef.current = trimmed;
+      }
+      setNodes(newNodes);
+      nodesRef.current = newNodes;
+      scheduleSave();
+    },
+    [scheduleSave]
+  );
+
   useEffect(() => {
     const api = window.canvasWorkspace?.store;
     if (!api) {
+      const empty: CanvasNode[] = [];
+      historyRef.current = [empty];
+      historyIndexRef.current = 0;
       setLoaded(true);
       return;
     }
@@ -51,10 +74,19 @@ export const useNodes = (
         const saved = result.data;
         if (Array.isArray(saved.nodes)) {
           setNodes(saved.nodes);
+          nodesRef.current = saved.nodes;
+          historyRef.current = [saved.nodes];
+          historyIndexRef.current = 0;
+        } else {
+          historyRef.current = [[]];
+          historyIndexRef.current = 0;
         }
         if (saved.transform && onRestoreTransform) {
           onRestoreTransform(saved.transform);
         }
+      } else {
+        historyRef.current = [[]];
+        historyIndexRef.current = 0;
       }
       setLoaded(true);
     });
@@ -84,8 +116,8 @@ export const useNodes = (
         if (api) {
           void api.createNote(canvasId).then((res) => {
             if (res.ok && res.filePath) {
-              setNodes((prev) =>
-                prev.map((n) =>
+              setNodes((prev) => {
+                const updated = prev.map((n) =>
                   n.id === node.id
                     ? {
                         ...n,
@@ -96,64 +128,188 @@ export const useNodes = (
                         }
                       }
                     : n
-                )
-              );
+                );
+                nodesRef.current = updated;
+                return updated;
+              });
               scheduleSave();
             }
           });
         }
       }
 
-      setNodes((prev) => [...prev, node]);
-      scheduleSave();
+      applyNodes([...nodesRef.current, node]);
       return node;
     },
-    [scheduleSave]
+    [applyNodes, scheduleSave, canvasId]
   );
 
   const updateNode = useCallback(
     (id: string, patch: Partial<CanvasNode>) => {
-      setNodes((prev) =>
-        prev.map((n) => (n.id === id ? { ...n, ...patch } : n))
-      );
-      scheduleSave();
+      applyNodes(nodesRef.current.map((n) => (n.id === id ? { ...n, ...patch } : n)));
     },
-    [scheduleSave]
+    [applyNodes]
   );
 
   const removeNode = useCallback(
     (id: string) => {
-      setNodes((prev) => prev.filter((n) => n.id !== id));
-      scheduleSave();
+      applyNodes(nodesRef.current.filter((n) => n.id !== id));
     },
-    [scheduleSave]
+    [applyNodes]
+  );
+
+  const removeNodes = useCallback(
+    (ids: string[]) => {
+      if (ids.length === 0) return;
+      applyNodes(nodesRef.current.filter((n) => !ids.includes(n.id)));
+    },
+    [applyNodes]
   );
 
   const moveNode = useCallback(
     (id: string, x: number, y: number) => {
-      updateNode(id, { x, y });
+      applyNodes(
+        nodesRef.current.map((n) => (n.id === id ? { ...n, x, y } : n)),
+        false
+      );
     },
-    [updateNode]
+    [applyNodes]
   );
 
   const moveNodes = useCallback(
     (moves: Array<{ id: string; x: number; y: number }>) => {
-      setNodes((prev) =>
-        prev.map((n) => {
+      applyNodes(
+        nodesRef.current.map((n) => {
           const m = moves.find((mv) => mv.id === n.id);
           return m ? { ...n, x: m.x, y: m.y } : n;
-        })
+        }),
+        false
       );
-      scheduleSave();
     },
-    [scheduleSave]
+    [applyNodes]
   );
 
   const resizeNode = useCallback(
     (id: string, width: number, height: number) => {
-      updateNode(id, { width, height });
+      applyNodes(
+        nodesRef.current.map((n) => (n.id === id ? { ...n, width, height } : n)),
+        false
+      );
     },
-    [updateNode]
+    [applyNodes]
+  );
+
+  // Call after drag/resize ends to commit the final position to history
+  const commitHistory = useCallback(() => {
+    const current = nodesRef.current;
+    const last = historyRef.current[historyIndexRef.current];
+    if (current === last) return;
+    const trimmed = historyRef.current.slice(0, historyIndexRef.current + 1);
+    trimmed.push(current);
+    if (trimmed.length > MAX_HISTORY) trimmed.shift();
+    historyIndexRef.current = trimmed.length - 1;
+    historyRef.current = trimmed;
+  }, []);
+
+  const undo = useCallback(() => {
+    if (historyIndexRef.current <= 0) return;
+    historyIndexRef.current--;
+    const snapshot = historyRef.current[historyIndexRef.current];
+    setNodes(snapshot);
+    nodesRef.current = snapshot;
+    scheduleSave();
+  }, [scheduleSave]);
+
+  const redo = useCallback(() => {
+    if (historyIndexRef.current >= historyRef.current.length - 1) return;
+    historyIndexRef.current++;
+    const snapshot = historyRef.current[historyIndexRef.current];
+    setNodes(snapshot);
+    nodesRef.current = snapshot;
+    scheduleSave();
+  }, [scheduleSave]);
+
+  const duplicateNode = useCallback(
+    (id: string) => {
+      const source = nodesRef.current.find((n) => n.id === id);
+      if (!source) return null;
+      const newNode: CanvasNode = {
+        ...source,
+        id: genId(),
+        x: source.x + 24,
+        y: source.y + 24,
+        data:
+          source.type === 'file'
+            ? { filePath: '', content: '', saved: false, modified: false }
+            : source.type === 'terminal'
+              ? { sessionId: '' }
+              : { ...(source.data as FrameNodeData) },
+      };
+      if (newNode.type === 'file') {
+        const api = window.canvasWorkspace?.file;
+        if (api) {
+          void api.createNote(canvasId).then((res) => {
+            if (res.ok && res.filePath) {
+              setNodes((prev) => {
+                const updated = prev.map((n) =>
+                  n.id === newNode.id
+                    ? { ...n, title: res.fileName?.replace(/\.md$/, '') || n.title, data: { ...n.data, filePath: res.filePath ?? '' } }
+                    : n
+                );
+                nodesRef.current = updated;
+                return updated;
+              });
+              scheduleSave();
+            }
+          });
+        }
+      }
+      applyNodes([...nodesRef.current, newNode]);
+      return newNode;
+    },
+    [applyNodes, scheduleSave, canvasId]
+  );
+
+  const pasteNodes = useCallback(
+    (sources: CanvasNode[], offsetX = 24, offsetY = 24) => {
+      if (sources.length === 0) return [];
+      const newNodes = sources.map((source) => ({
+        ...source,
+        id: genId(),
+        x: source.x + offsetX,
+        y: source.y + offsetY,
+        data:
+          source.type === 'file'
+            ? { filePath: '', content: '', saved: false, modified: false }
+            : source.type === 'terminal'
+              ? { sessionId: '' }
+              : { ...(source.data as FrameNodeData) },
+      }));
+      newNodes.forEach((newNode) => {
+        if (newNode.type === 'file') {
+          const api = window.canvasWorkspace?.file;
+          if (api) {
+            void api.createNote(canvasId).then((res) => {
+              if (res.ok && res.filePath) {
+                setNodes((prev) => {
+                  const updated = prev.map((n) =>
+                    n.id === newNode.id
+                      ? { ...n, title: res.fileName?.replace(/\.md$/, '') || n.title, data: { ...n.data, filePath: res.filePath ?? '' } }
+                      : n
+                  );
+                  nodesRef.current = updated;
+                  return updated;
+                });
+                scheduleSave();
+              }
+            });
+          }
+        }
+      });
+      applyNodes([...nodesRef.current, ...newNodes]);
+      return newNodes;
+    },
+    [applyNodes, scheduleSave, canvasId]
   );
 
   return {
@@ -162,9 +318,15 @@ export const useNodes = (
     addNode,
     updateNode,
     removeNode,
+    removeNodes,
     moveNode,
     moveNodes,
     resizeNode,
-    setTransformForSave
+    setTransformForSave,
+    commitHistory,
+    undo,
+    redo,
+    duplicateNode,
+    pasteNodes,
   };
 };


### PR DESCRIPTION
## Summary
This PR adds comprehensive undo/redo functionality with history management, multi-node selection, and clipboard operations (copy/paste/duplicate) to the canvas workspace. It refactors node mutations through a centralized `applyNodes` function to enable proper history tracking.

## Key Changes

- **History Management**: Introduced `historyRef` and `historyIndexRef` to track node state snapshots with a maximum of 100 history entries. History is properly managed when nodes are modified, with separate handling for interactive operations (drag/resize) vs. committed changes.

- **Centralized Node Mutations**: Created `applyNodes()` callback that serves as the single point for node state updates, with optional history tracking via `addToHistory` parameter. This allows drag/resize operations to update state without creating intermediate history entries.

- **Multi-Select Support**: Changed `selectedNodeId` to `selectedNodeIds` array to support selecting multiple nodes at once. Updated all selection-related logic throughout the Canvas component.

- **Keyboard Shortcuts**: Added comprehensive keyboard shortcuts:
  - Cmd/Ctrl+Z: Undo
  - Cmd/Ctrl+Shift+Z: Redo
  - Cmd/Ctrl+A: Select all nodes
  - Cmd/Ctrl+D: Duplicate selected node
  - Cmd/Ctrl+C: Copy selected nodes
  - Cmd/Ctrl+V: Paste nodes
  - Delete/Backspace: Delete selected nodes
  - Escape: Close modals and clear selection

- **New Node Operations**: 
  - `removeNodes()`: Delete multiple nodes by ID
  - `duplicateNode()`: Clone a node with offset positioning and reset data
  - `pasteNodes()`: Paste multiple nodes with offset positioning
  - `commitHistory()`: Explicitly commit current state to history (called after drag/resize ends)
  - `undo()` and `redo()`: Navigate through history

- **Clipboard State**: Added `clipboardNodes` state to store copied nodes for paste operations.

- **Interactive Operation Optimization**: Drag and resize operations now use `addToHistory: false` to avoid creating intermediate history entries, with a single `commitHistory()` call on operation end.

## Implementation Details

- History snapshots are stored as complete node arrays, allowing instant state restoration
- File node duplication/pasting creates new file notes via the API while maintaining proper state
- Terminal and frame nodes are duplicated with reset data (empty sessionId/frame data)
- Context menu state management was reorganized for clarity
- All node mutation callbacks now depend on `applyNodes` instead of directly calling `setNodes` and `scheduleSave`

https://claude.ai/code/session_01Ekm57FYuxzW5PwxrzFCSMp