### PR TITLE
Update Canvas to use selectedNodeIds array instead of single selectedNodeId

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas.tsx
@@ -229,7 +229,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden }: { canvasId:
         );
         if (!isEditable && nodes.length > 0) {
           e.preventDefault();
-          const currentIndex = nodes.findIndex((n) => n.id === selectedNodeId);
+          const currentIndex = nodes.findIndex((n) => n.id === selectedNodeIds[0]);
           let nextIndex: number;
           if (e.shiftKey) {
             nextIndex = currentIndex <= 0 ? nodes.length - 1 : currentIndex - 1;
@@ -237,7 +237,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden }: { canvasId:
             nextIndex = currentIndex >= nodes.length - 1 ? 0 : currentIndex + 1;
           }
           const nextNode = nodes[nextIndex];
-          setSelectedNodeId(nextNode.id);
+          setSelectedNodeIds([nextNode.id]);
           setHighlightedId(nextNode.id);
           handleFocusNode(nextNode);
         }
@@ -245,7 +245,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden }: { canvasId:
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [nodes, selectedNodeId, handleFocusNode]);
+  }, [nodes, selectedNodeIds, handleFocusNode]);
 
   // Clear highlight after animation
   useEffect(() => {


### PR DESCRIPTION
## Summary
This change refactors the Canvas component's node selection logic to use an array-based approach (`selectedNodeIds`) instead of a single node ID (`selectedNodeId`), enabling support for multi-select functionality.

## Key Changes
- Updated keyboard navigation handler to read from `selectedNodeIds[0]` instead of `selectedNodeId` when determining the current selected node
- Changed `setSelectedNodeId()` calls to `setSelectedNodeIds()` with array syntax when updating the selection after keyboard navigation
- Updated the useEffect dependency array to track `selectedNodeIds` instead of `selectedNodeId`

## Implementation Details
The changes maintain backward compatibility with the existing keyboard navigation behavior (arrow keys and Shift+arrow keys) while preparing the codebase for multi-select support. The logic still operates on a single node at a time during navigation, but now uses the array-based state management that can support multiple selections in the future.

https://claude.ai/code/session_019dvVC1NUHKyVyoBGU8CKUT