### PR TITLE
Add image paste support to file node editor

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -82,6 +82,7 @@
   },
   "dependencies": {
     "@tiptap/extension-bubble-menu": "^3.20.4",
+    "@tiptap/extension-image": "^3.20.5",
     "@tiptap/extension-placeholder": "^3.20.4",
     "@tiptap/extension-task-item": "^3.20.4",
     "@tiptap/extension-task-list": "^3.20.4",

--- a/apps/canvas-workspace/src/main/file-manager.ts
+++ b/apps/canvas-workspace/src/main/file-manager.ts
@@ -149,6 +149,26 @@ export const setupFileManagerIpc = () => {
     }
   });
 
+  // Save an image (base64) to the workspace images directory
+  ipcMain.handle(
+    "file:saveImage",
+    async (_event, payload: { workspaceId?: string; data: string; ext?: string }) => {
+      try {
+        const wsId = payload.workspaceId ?? "default";
+        const imagesDir = join(STORE_DIR, wsId, "images");
+        await fs.mkdir(imagesDir, { recursive: true });
+        const ext = payload.ext ?? "png";
+        const fileName = `img-${Date.now()}.${ext}`;
+        const filePath = join(imagesDir, fileName);
+        const buffer = Buffer.from(payload.data, "base64");
+        await fs.writeFile(filePath, buffer);
+        return { ok: true, filePath, fileName };
+      } catch (err) {
+        return { ok: false, error: String(err) };
+      }
+    }
+  );
+
   // Save-as dialog
   ipcMain.handle(
     "file:saveAsDialog",

--- a/apps/canvas-workspace/src/preload/index.ts
+++ b/apps/canvas-workspace/src/preload/index.ts
@@ -84,7 +84,10 @@ contextBridge.exposeInMainWorld("canvasWorkspace", {
     openDialog: () => ipcRenderer.invoke("file:openDialog"),
 
     saveAsDialog: (defaultName: string, content: string) =>
-      ipcRenderer.invoke("file:saveAsDialog", { defaultName, content })
+      ipcRenderer.invoke("file:saveAsDialog", { defaultName, content }),
+
+    saveImage: (workspaceId: string | undefined, data: string, ext?: string) =>
+      ipcRenderer.invoke("file:saveImage", { workspaceId, data, ext })
   },
 
   dialog: {

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView.tsx
@@ -167,7 +167,7 @@ export const CanvasNodeView = ({
       </div>
       <div className="node-body">
         {node.type === "file" ? (
-          <FileNodeBody node={node} onUpdate={onUpdate} />
+          <FileNodeBody node={node} onUpdate={onUpdate} workspaceId={workspaceId} />
         ) : node.type === "terminal" ? (
           <TerminalNodeBody node={node} allNodes={allNodes} rootFolder={rootFolder} workspaceId={workspaceId} workspaceName={workspaceName} onUpdate={onUpdate} />
         ) : (

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBody.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBody.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { useEditor, EditorContent } from '@tiptap/react';
 import type { Editor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
+import Image from '@tiptap/extension-image';
 import Placeholder from '@tiptap/extension-placeholder';
 import TaskList from '@tiptap/extension-task-list';
 import TaskItem from '@tiptap/extension-task-item';
@@ -13,6 +14,7 @@ import { SlashCommandMenu, type SlashCommandDef } from './SlashCommandMenu';
 interface Props {
   node: CanvasNode;
   onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
+  workspaceId?: string;
 }
 
 const AUTO_SAVE_MS = 1500;
@@ -84,7 +86,7 @@ interface BubbleState {
   y: number;
 }
 
-export const FileNodeBody = ({ node, onUpdate }: Props) => {
+export const FileNodeBody = ({ node, onUpdate, workspaceId }: Props) => {
   const data = node.data as FileNodeData;
   const [modified, setModified] = useState(false);
   const [statusText, setStatusText] = useState('');
@@ -96,6 +98,8 @@ export const FileNodeBody = ({ node, onUpdate }: Props) => {
   nodeIdRef.current = node.id;
   const prevContentRef = useRef(data.content);
   const containerRef = useRef<HTMLDivElement>(null);
+  const workspaceIdRef = useRef(workspaceId);
+  workspaceIdRef.current = workspaceId;
 
   // Slash command menu state
   interface SlashMenuState { x: number; y: number; query: string; index: number; slashFrom: number }
@@ -127,12 +131,47 @@ export const FileNodeBody = ({ node, onUpdate }: Props) => {
   const editor = useEditor({
     extensions: [
       StarterKit,
+      Image.configure({ inline: false }),
       Placeholder.configure({ placeholder: 'Start writing…' }),
       TaskList,
       TaskItem.configure({ nested: true }),
       Markdown.configure({ html: false, transformPastedText: true }),
     ],
     content: data.content || '',
+    editorProps: {
+      handlePaste: (view, event) => {
+        const items = Array.from(event.clipboardData?.items ?? []);
+        const imageItem = items.find((i) => i.type.startsWith('image/'));
+        if (!imageItem) return false;
+        event.preventDefault();
+        const blob = imageItem.getAsFile();
+        if (!blob) return false;
+        const reader = new FileReader();
+        reader.onload = async () => {
+          const dataUrl = reader.result as string;
+          const base64 = dataUrl.split(',')[1];
+          if (!base64) return;
+          const ext = imageItem.type.replace('image/', '').split(';')[0] ?? 'png';
+          const api = window.canvasWorkspace?.file;
+          if (!api) return;
+          // Derive workspaceId from file path if prop is not provided
+          const wsId =
+            workspaceIdRef.current ??
+            dataRef.current.filePath.match(/canvas[/\\]([^/\\]+)[/\\]/)?.[1] ??
+            'default';
+          const res = await api.saveImage(wsId, base64, ext);
+          if (!res.ok || !res.filePath) return;
+          const src = `file://${res.filePath}`;
+          const { state, dispatch } = view;
+          const imageNode = state.schema.nodes['image']?.create({ src });
+          if (imageNode) {
+            dispatch(state.tr.replaceSelectionWith(imageNode));
+          }
+        };
+        reader.readAsDataURL(blob);
+        return true;
+      },
+    },
     onUpdate: ({ editor }) => {
       const markdown = getMarkdown(editor);
       prevContentRef.current = markdown;

--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -961,6 +961,19 @@ body {
   font-size: 0.85em;
 }
 
+.note-tiptap-editor .ProseMirror img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 4px;
+  display: block;
+  margin: 8px 0;
+}
+
+.note-tiptap-editor .ProseMirror img.ProseMirror-selectednode {
+  outline: 2px solid var(--accent-file);
+  outline-offset: 2px;
+}
+
 /* ---- Bubble Menu ---- */
 
 .note-bubble-menu {

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -79,6 +79,11 @@ export interface FileApi {
     fileName?: string;
     error?: string;
   }>;
+  saveImage: (
+    workspaceId: string | undefined,
+    data: string,
+    ext?: string
+  ) => Promise<{ ok: boolean; filePath?: string; fileName?: string; error?: string }>;
 }
 
 export interface DialogApi {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@tiptap/extension-bubble-menu':
         specifier: ^3.20.4
         version: 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)
+      '@tiptap/extension-image':
+        specifier: ^3.20.5
+        version: 3.20.5(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))
       '@tiptap/extension-placeholder':
         specifier: ^3.20.4
         version: 3.20.4(@tiptap/extensions@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4))
@@ -1184,6 +1187,11 @@ packages:
     peerDependencies:
       '@tiptap/core': ^3.20.4
       '@tiptap/pm': ^3.20.4
+
+  '@tiptap/extension-image@3.20.5':
+    resolution: {integrity: sha512-qxKupWKhX75Xc9GJ9Uel+KIFL9x6tb8W3RvQM1UolyJX/H7wyBO7sXp9XmKRkHZsDXRgLVbnkYBe+X83o16AIA==}
+    peerDependencies:
+      '@tiptap/core': ^3.20.5
 
   '@tiptap/extension-italic@3.20.4':
     resolution: {integrity: sha512-4ZqiWr7cmqPFux8tj1ZLiYytyWf343IvQemNX6AvVWvscrJcrfj3YX4Le2BA0RW3A3M6RpLQXXozuF8vxYFDeQ==}
@@ -4032,6 +4040,10 @@ snapshots:
     dependencies:
       '@tiptap/core': 3.20.4(@tiptap/pm@3.20.4)
       '@tiptap/pm': 3.20.4
+
+  '@tiptap/extension-image@3.20.5(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))':
+    dependencies:
+      '@tiptap/core': 3.20.4(@tiptap/pm@3.20.4)
 
   '@tiptap/extension-italic@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))':
     dependencies:


### PR DESCRIPTION
## Summary
This PR adds the ability to paste images directly into file node editors. When users paste an image from their clipboard, it is automatically saved to the workspace's images directory and embedded in the document.

## Key Changes
- **Editor Enhancement**: Added Tiptap Image extension and implemented a custom paste handler in `FileNodeBody` that:
  - Detects image data in clipboard paste events
  - Converts images to base64 format
  - Saves images to the workspace via IPC
  - Inserts image nodes into the editor at the cursor position
  
- **Backend Support**: Added `file:saveImage` IPC handler in `file-manager.ts` that:
  - Saves base64-encoded images to `{STORE_DIR}/{workspaceId}/images/`
  - Generates timestamped filenames to avoid collisions
  - Returns the file path for embedding in the document
  
- **Styling**: Added CSS rules for image rendering in the editor:
  - Images are responsive with `max-width: 100%`
  - Selected images show a blue outline for visual feedback
  - Proper spacing and border radius for better appearance
  
- **API Exposure**: Extended the preload bridge to expose `saveImage` method and updated type definitions

- **Component Integration**: Passed `workspaceId` prop from `CanvasNodeView` to `FileNodeBody` to enable workspace-aware image saving

## Implementation Details
- The paste handler gracefully falls back to deriving workspace ID from the file path if not provided as a prop
- Images are stored separately in a dedicated `images` directory per workspace
- The implementation uses `FileReader` API for client-side base64 conversion before sending to the main process

https://claude.ai/code/session_01SS2sMsrQwbZtdpaRbmfLRq