### PR TITLE
Add node mention picker to terminal with @ reference support

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/NodeMentionPicker/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeMentionPicker/index.tsx
@@ -66,7 +66,7 @@ export const NodeMentionPicker = ({ nodes, onSelect, onClose }: Props) => {
       <div className="node-mention-picker" onClick={(e) => e.stopPropagation()}>
         <div className="node-mention-header">
           <span className="node-mention-label">@ 引用节点</span>
-          <kbd className="node-mention-kbd">Ctrl+;</kbd>
+          <kbd className="node-mention-kbd">Ctrl/⌘+2</kbd>
         </div>
         <div className="node-mention-search">
           <input

--- a/apps/canvas-workspace/src/renderer/src/components/NodeMentionPicker/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeMentionPicker/index.tsx
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { CanvasNode, FileNodeData } from '../types';
+
+interface Props {
+  nodes: CanvasNode[];
+  onSelect: (node: CanvasNode) => void;
+  onClose: () => void;
+}
+
+const MAX_RESULTS = 20;
+
+export const NodeMentionPicker = ({ nodes, onSelect, onClose }: Props) => {
+  const [query, setQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const filtered = useMemo((): CanvasNode[] => {
+    if (!query.trim()) return nodes.slice(0, MAX_RESULTS);
+    const q = query.toLowerCase();
+    return nodes
+      .filter((n) => {
+        if (n.title.toLowerCase().includes(q)) return true;
+        if (n.type === 'file') {
+          const fp = (n.data as FileNodeData).filePath ?? '';
+          return fp.toLowerCase().includes(q);
+        }
+        return false;
+      })
+      .slice(0, MAX_RESULTS);
+  }, [query, nodes]);
+
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setSelectedIndex((i) => Math.min(i + 1, filtered.length - 1));
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setSelectedIndex((i) => Math.max(i - 1, 0));
+        return;
+      }
+      if (e.key === 'Enter' && filtered[selectedIndex]) {
+        onSelect(filtered[selectedIndex]);
+        return;
+      }
+    },
+    [filtered, selectedIndex, onSelect, onClose],
+  );
+
+  return (
+    <div className="node-mention-backdrop" onMouseDown={(e) => e.stopPropagation()} onClick={onClose}>
+      <div className="node-mention-picker" onClick={(e) => e.stopPropagation()}>
+        <div className="node-mention-header">
+          <span className="node-mention-label">@ 引用节点</span>
+          <kbd className="node-mention-kbd">Ctrl+;</kbd>
+        </div>
+        <div className="node-mention-search">
+          <input
+            ref={inputRef}
+            type="text"
+            className="node-mention-input"
+            placeholder="搜索节点名称..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+          />
+        </div>
+        <div className="node-mention-list">
+          {filtered.length === 0 ? (
+            <div className="node-mention-empty">无匹配节点</div>
+          ) : (
+            filtered.map((node, idx) => {
+              const filePath = node.type === 'file' ? (node.data as FileNodeData).filePath : undefined;
+              const fileName = filePath ? filePath.split('/').pop() : undefined;
+              return (
+                <div
+                  key={node.id}
+                  className={`node-mention-item${idx === selectedIndex ? ' selected' : ''}`}
+                  onClick={() => onSelect(node)}
+                  onMouseEnter={() => setSelectedIndex(idx)}
+                >
+                  <span className={`node-mention-badge node-mention-badge--${node.type}`}>
+                    {node.type}
+                  </span>
+                  <span className="node-mention-title">{node.title}</span>
+                  {fileName && <span className="node-mention-path">{fileName}</span>}
+                </div>
+              );
+            })
+          )}
+        </div>
+        <div className="node-mention-hint">
+          <span>↑↓ 导航</span>
+          <span>↵ 插入</span>
+          <span>Esc 关闭</span>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody/index.tsx
@@ -88,7 +88,7 @@ export const TerminalNodeBody = ({ node, allNodes, rootFolder, workspaceId, work
     }
 
     term.attachCustomKeyEventHandler((e: KeyboardEvent) => {
-      if (e.type === 'keydown' && e.key === ';' && e.ctrlKey && !e.altKey && !e.metaKey) {
+      if (e.type === 'keydown' && e.key === '2' && (e.ctrlKey || e.metaKey) && !e.altKey) {
         setPickerOpen(true);
         return false;
       }

--- a/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody/index.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useRef, useCallback, useState } from 'react';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import type { CanvasNode, TerminalNodeData } from '../../types';
 import { TERMINAL_OPTIONS } from '../../config/terminalTheme';
 import { AI_TOOL_PATTERN, writeCanvasContext } from '../../utils/canvasContextWriter';
+import { NodeMentionPicker } from '../NodeMentionPicker';
 
 interface Props {
   node: CanvasNode;
@@ -32,6 +33,7 @@ const serializeBuffer = (term: Terminal): string => {
 };
 
 export const TerminalNodeBody = ({ node, allNodes, rootFolder, workspaceId, workspaceName, onUpdate }: Props) => {
+  const [pickerOpen, setPickerOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
@@ -84,6 +86,14 @@ export const TerminalNodeBody = ({ node, allNodes, rootFolder, workspaceId, work
       term.write(lastLines + '\r\n');
       term.writeln('\x1b[2m--- new session ---\x1b[0m\r\n');
     }
+
+    term.attachCustomKeyEventHandler((e: KeyboardEvent) => {
+      if (e.type === 'keydown' && e.key === ';' && e.ctrlKey && !e.altKey && !e.metaKey) {
+        setPickerOpen(true);
+        return false;
+      }
+      return true;
+    });
 
     requestAnimationFrame(() => {
       try { fitAddon.fit(); } catch { /* ignore */ }
@@ -179,8 +189,27 @@ export const TerminalNodeBody = ({ node, allNodes, rootFolder, workspaceId, work
     return () => observer.disconnect();
   }, []);
 
+  const handleMentionSelect = useCallback((selected: CanvasNode) => {
+    setPickerOpen(false);
+    const api = window.canvasWorkspace?.pty;
+    if (api) void api.write(sessionId, selected.title);
+    termRef.current?.focus();
+  }, [sessionId]);
+
+  const handleMentionClose = useCallback(() => {
+    setPickerOpen(false);
+    termRef.current?.focus();
+  }, []);
+
   return (
     <div className="terminal-body-wrap">
+      {pickerOpen && (
+        <NodeMentionPicker
+          nodes={allNodes ?? []}
+          onSelect={handleMentionSelect}
+          onClose={handleMentionClose}
+        />
+      )}
       <div
         ref={containerRef}
         className="terminal-xterm-container"

--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -1132,6 +1132,155 @@ body {
   padding: 0 4px;
 }
 
+/* ---- Node Mention Picker ---- */
+
+.node-mention-backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+}
+
+.node-mention-picker {
+  margin: 8px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-float), 0 8px 32px rgba(0, 0, 0, 0.12);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  max-height: 260px;
+  animation: menuAppear 0.12s ease;
+}
+
+.node-mention-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 7px 12px 6px;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.node-mention-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.node-mention-kbd {
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  background: var(--surface-hover);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 5px;
+}
+
+.node-mention-search {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.node-mention-input {
+  width: 100%;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-size: 13px;
+  font-family: var(--font);
+  color: var(--text);
+}
+
+.node-mention-input::placeholder {
+  color: var(--text-muted);
+}
+
+.node-mention-list {
+  overflow-y: auto;
+  flex: 1;
+  padding: 4px;
+}
+
+.node-mention-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background 0.08s;
+}
+
+.node-mention-item.selected,
+.node-mention-item:hover {
+  background: var(--accent-light);
+}
+
+.node-mention-badge {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 4px;
+  flex-shrink: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.node-mention-badge--file {
+  background: rgba(217, 115, 13, 0.1);
+  color: var(--accent-file);
+}
+
+.node-mention-badge--terminal {
+  background: rgba(15, 123, 108, 0.1);
+  color: var(--accent-term);
+}
+
+.node-mention-badge--frame {
+  background: rgba(144, 101, 176, 0.1);
+  color: var(--accent-frame);
+}
+
+.node-mention-title {
+  font-size: 13px;
+  color: var(--text);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.node-mention-path {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  flex-shrink: 0;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.node-mention-empty {
+  padding: 16px;
+  text-align: center;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.node-mention-hint {
+  display: flex;
+  gap: 12px;
+  padding: 6px 12px;
+  border-top: 1px solid var(--border-light);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
 /* ---- Context Menu ---- */
 
 .context-menu {


### PR DESCRIPTION
## Summary
Adds a node mention picker UI component that allows users to reference other canvas nodes in the terminal using the `@` symbol. Users can search for and insert node references with keyboard navigation.

## Key Changes
- **New Component**: `NodeMentionPicker` - A searchable dropdown menu for selecting nodes to mention
  - Supports filtering nodes by title and file path
  - Keyboard navigation (arrow keys, Enter, Escape)
  - Shows node type badges (file, terminal, frame) with color coding
  - Displays file names for file nodes
  - Limits results to 20 items for performance
  
- **Terminal Integration**: Modified `TerminalNodeBody` to trigger the mention picker
  - Detects `Ctrl+;` keyboard shortcut to open the picker
  - Inserts selected node title into terminal on selection
  - Maintains focus management between picker and terminal
  
- **Styling**: Added comprehensive CSS for the mention picker UI
  - Backdrop overlay with z-index 200
  - Animated menu appearance
  - Styled search input, item list, and keyboard hints
  - Color-coded badges for different node types (file: orange, terminal: teal, frame: purple)
  - Responsive layout with max-height and scrolling

## Implementation Details
- Uses React hooks for state management (query, selectedIndex)
- Memoized filtering for performance with large node lists
- Event handlers prevent event propagation to avoid unintended interactions
- Keyboard event handler attached to xterm terminal for shortcut detection
- Chinese UI labels and placeholder text

https://claude.ai/code/session_014bzGXgdG4iFoHc2k17izqG