### PR TITLE
fix(canvas-workspace): stop mousedown propagation on node title and body

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -147,6 +147,7 @@ export const CanvasNodeView = ({
           suppressContentEditableWarning
           spellCheck={false}
           onBlur={handleTitleChange}
+          onMouseDown={(e) => e.stopPropagation()}
         >
           {node.title}
         </span>
@@ -165,7 +166,7 @@ export const CanvasNodeView = ({
           </svg>
         </button>
       </div>
-      <div className="node-body">
+      <div className="node-body" onMouseDown={(e) => e.stopPropagation()}>
         {node.type === "file" ? (
           <FileNodeBody node={node} onUpdate={onUpdate} workspaceId={workspaceId} />
         ) : node.type === "terminal" ? (


### PR DESCRIPTION
- node-title: clicking the contentEditable title was triggering the
  header's onMouseDown drag handler, making it impossible to click
  into the title for editing without accidentally dragging the node.
- node-body: mousedown in the editor area bubbled up to canvas-container,
  which in hand-tool mode called e.preventDefault() and prevented the
  TipTap editor from receiving focus.

https://claude.ai/code/session_01RZHcKxddyGmUAVxJHTmjS8