### PR TITLE
feat(canvas-workspace): add MCP server with canvas read/write tools

### DIFF
--- a/apps/canvas-workspace/src/main/file-watcher.ts
+++ b/apps/canvas-workspace/src/main/file-watcher.ts
@@ -1,0 +1,84 @@
+import { ipcMain, BrowserWindow } from 'electron';
+import { watch, FSWatcher, promises as fs } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+const STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
+const DEBOUNCE_MS = 300;
+
+let activeWatcher: FSWatcher | null = null;
+let activeWorkspaceId: string | null = null;
+const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+function sendToRenderer(channel: string, payload: unknown): void {
+  BrowserWindow.getAllWindows()[0]?.webContents.send(channel, payload);
+}
+
+function stopWatcher(): void {
+  if (activeWatcher) {
+    activeWatcher.close();
+    activeWatcher = null;
+  }
+  activeWorkspaceId = null;
+  debounceTimers.forEach((t) => clearTimeout(t));
+  debounceTimers.clear();
+}
+
+function startWatcher(workspaceId: string): void {
+  stopWatcher();
+
+  const notesDir = join(STORE_DIR, workspaceId, 'notes');
+
+  void fs.mkdir(notesDir, { recursive: true }).then(() => {
+    activeWorkspaceId = workspaceId;
+
+    try {
+      activeWatcher = watch(notesDir, { recursive: false }, (_eventType: string, filename: string | null) => {
+        if (!filename || !filename.endsWith('.md')) return;
+
+        const filePath = join(notesDir, filename);
+
+        // Debounce per file to coalesce rapid write events
+        const existing = debounceTimers.get(filePath);
+        if (existing) clearTimeout(existing);
+
+        debounceTimers.set(
+          filePath,
+          setTimeout(() => {
+            debounceTimers.delete(filePath);
+            void fs.readFile(filePath, 'utf-8')
+              .then((content: string) => {
+                sendToRenderer('canvas:file-changed', { filePath, content });
+              })
+              .catch((_err: unknown) => {
+                // File deleted or unreadable — ignore
+              });
+          }, DEBOUNCE_MS)
+        );
+      });
+
+      activeWatcher.on('error', (err: unknown) => {
+        console.warn('[FileWatcher] Watch error:', err);
+      });
+
+      console.log(`[FileWatcher] Watching ${notesDir}`);
+    } catch (err) {
+      console.warn('[FileWatcher] Could not start watcher for', notesDir, err);
+    }
+  });
+}
+
+export function setupFileWatcherIpc(): void {
+  ipcMain.handle(
+    'canvas:watchWorkspace',
+    (_event: unknown, { workspaceId }: { workspaceId: string }) => {
+      if (workspaceId === activeWorkspaceId) return { ok: true };
+      startWatcher(workspaceId);
+      return { ok: true };
+    }
+  );
+}
+
+export function teardownFileWatcher(): void {
+  stopWatcher();
+}

--- a/apps/canvas-workspace/src/main/index.ts
+++ b/apps/canvas-workspace/src/main/index.ts
@@ -7,6 +7,7 @@ import { setupCanvasStoreIpc } from "./canvas-store";
 import { setupFileManagerIpc } from "./file-manager";
 import { startMCPServer } from "./mcp-server";
 import { ensureMCPRegistered } from "./mcp-registration";
+import { setupFileWatcherIpc, teardownFileWatcher } from "./file-watcher";
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const preloadPath = join(currentDir, "../preload/index.mjs");
@@ -98,6 +99,7 @@ app.whenReady().then(() => {
   setupPtyIpc();
   setupCanvasStoreIpc();
   setupFileManagerIpc();
+  setupFileWatcherIpc();
   startMCPServer();
   void ensureMCPRegistered();
 
@@ -112,6 +114,7 @@ app.whenReady().then(() => {
 
 app.on("window-all-closed", () => {
   killAllPty();
+  teardownFileWatcher();
   if (process.platform !== "darwin") {
     app.quit();
   }

--- a/apps/canvas-workspace/src/main/index.ts
+++ b/apps/canvas-workspace/src/main/index.ts
@@ -5,6 +5,8 @@ import { fileURLToPath } from "url";
 import { setupPtyIpc, killAllPty } from "./pty-manager";
 import { setupCanvasStoreIpc } from "./canvas-store";
 import { setupFileManagerIpc } from "./file-manager";
+import { startMCPServer } from "./mcp-server";
+import { ensureMCPRegistered } from "./mcp-registration";
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const preloadPath = join(currentDir, "../preload/index.mjs");
@@ -96,6 +98,8 @@ app.whenReady().then(() => {
   setupPtyIpc();
   setupCanvasStoreIpc();
   setupFileManagerIpc();
+  startMCPServer();
+  void ensureMCPRegistered();
 
   createWindow();
 

--- a/apps/canvas-workspace/src/main/mcp-registration.ts
+++ b/apps/canvas-workspace/src/main/mcp-registration.ts
@@ -1,7 +1,4 @@
 import { execFile } from 'child_process';
-import { promises as fs } from 'fs';
-import { join } from 'path';
-import { homedir } from 'os';
 import { promisify } from 'util';
 import { MCP_PORT } from './mcp-server';
 
@@ -10,103 +7,35 @@ const execFileAsync = promisify(execFile);
 const SERVER_NAME = 'canvas-workspace';
 const SERVER_URL = `http://localhost:${MCP_PORT}/mcp`;
 
-// ---------------------------------------------------------------------------
-// Claude Code
-// MCP servers live in ~/.claude.json under the "mcpServers" key (user scope).
-// We prefer the CLI (`claude mcp add`) and fall back to direct file write.
-// Format: { "type": "http", "url": "..." }
-// ---------------------------------------------------------------------------
-
-async function isClaudeRegistered(): Promise<boolean> {
+async function ensureClaudeCodeRegistered(): Promise<void> {
   try {
     const { stdout } = await execFileAsync('claude', ['mcp', 'get', SERVER_NAME]);
-    return stdout.includes(SERVER_NAME);
+    if (stdout.includes(SERVER_NAME)) return;
   } catch {
-    return false;
+    // not registered or claude not installed
   }
-}
-
-async function registerClaudeCLI(): Promise<boolean> {
   try {
-    await execFileAsync('claude', [
-      'mcp', 'add',
-      '--transport', 'http',
-      SERVER_NAME,
-      SERVER_URL,
-    ]);
-    console.log('[MCP] Registered with Claude Code (via CLI)');
-    return true;
+    await execFileAsync('claude', ['mcp', 'add', '--transport', 'http', SERVER_NAME, SERVER_URL]);
+    console.log('[MCP] Registered with Claude Code');
   } catch {
-    return false;
+    // claude not installed — skip silently
   }
 }
-
-async function registerClaudeFile(): Promise<void> {
-  // User-scope config: ~/.claude.json
-  const filePath = join(homedir(), '.claude.json');
-  try {
-    let config: Record<string, unknown> = {};
-    try {
-      const raw = await fs.readFile(filePath, 'utf-8');
-      config = JSON.parse(raw) as Record<string, unknown>;
-    } catch {
-      // file missing or invalid — start fresh
-    }
-
-    const servers = (config.mcpServers ?? {}) as Record<string, unknown>;
-    if (servers[SERVER_NAME]) return; // already present
-
-    servers[SERVER_NAME] = { type: 'http', url: SERVER_URL };
-    config.mcpServers = servers;
-
-    await fs.writeFile(filePath, JSON.stringify(config, null, 2), 'utf-8');
-    console.log('[MCP] Registered with Claude Code (~/.claude.json)');
-  } catch (err) {
-    console.warn('[MCP] Could not register with Claude Code via file:', err);
-  }
-}
-
-async function ensureClaudeCodeRegistered(): Promise<void> {
-  if (await isClaudeRegistered()) return;
-  const ok = await registerClaudeCLI();
-  if (!ok) await registerClaudeFile();
-}
-
-// ---------------------------------------------------------------------------
-// Codex
-// Config: ~/.codex/config.toml  (TOML format)
-// HTTP servers use `url = "..."` under [mcp_servers.<name>].
-// CLI only supports stdio; we write the TOML directly.
-// ---------------------------------------------------------------------------
 
 async function ensureCodexRegistered(): Promise<void> {
-  const configPath = join(homedir(), '.codex', 'config.toml');
-  const marker = `[mcp_servers.${SERVER_NAME}]`;
   try {
-    let config = '';
-    try {
-      config = await fs.readFile(configPath, 'utf-8');
-    } catch {
-      // file missing — will be created
-    }
-
-    if (config.includes(marker)) return; // already present
-
-    // experimental_use_rmcp_client is required by older Codex versions for
-    // Streamable HTTP support; harmless on newer ones.
-    const needsFlag = !config.includes('experimental_use_rmcp_client');
-    const flag = needsFlag ? 'experimental_use_rmcp_client = true\n' : '';
-    const entry = `\n${marker}\nurl = "${SERVER_URL}"\nenabled = true\n`;
-
-    await fs.mkdir(join(homedir(), '.codex'), { recursive: true });
-    await fs.writeFile(configPath, flag + config + entry, 'utf-8');
-    console.log('[MCP] Registered with Codex (~/.codex/config.toml)');
-  } catch (err) {
-    console.warn('[MCP] Could not register with Codex:', err);
+    const { stdout } = await execFileAsync('codex', ['mcp', 'list']);
+    if (stdout.includes(SERVER_NAME)) return;
+  } catch {
+    // not registered or codex not installed
+  }
+  try {
+    await execFileAsync('codex', ['mcp', 'add', SERVER_NAME, '--url', SERVER_URL]);
+    console.log('[MCP] Registered with Codex');
+  } catch {
+    // codex not installed — skip silently
   }
 }
-
-// ---------------------------------------------------------------------------
 
 /**
  * Ensure canvas-workspace MCP server is registered with both

--- a/apps/canvas-workspace/src/main/mcp-registration.ts
+++ b/apps/canvas-workspace/src/main/mcp-registration.ts
@@ -92,9 +92,14 @@ async function ensureCodexRegistered(): Promise<void> {
 
     if (config.includes(marker)) return; // already present
 
+    // experimental_use_rmcp_client is required by older Codex versions for
+    // Streamable HTTP support; harmless on newer ones.
+    const needsFlag = !config.includes('experimental_use_rmcp_client');
+    const flag = needsFlag ? 'experimental_use_rmcp_client = true\n' : '';
     const entry = `\n${marker}\nurl = "${SERVER_URL}"\nenabled = true\n`;
+
     await fs.mkdir(join(homedir(), '.codex'), { recursive: true });
-    await fs.writeFile(configPath, config + entry, 'utf-8');
+    await fs.writeFile(configPath, flag + config + entry, 'utf-8');
     console.log('[MCP] Registered with Codex (~/.codex/config.toml)');
   } catch (err) {
     console.warn('[MCP] Could not register with Codex:', err);

--- a/apps/canvas-workspace/src/main/mcp-registration.ts
+++ b/apps/canvas-workspace/src/main/mcp-registration.ts
@@ -1,0 +1,73 @@
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { MCP_PORT } from './mcp-server';
+
+const SERVER_NAME = 'canvas-workspace';
+const SERVER_URL = `http://localhost:${MCP_PORT}/mcp`;
+
+/**
+ * Write canvas-workspace MCP server entry into ~/.claude/settings.json.
+ * Merges with existing settings; no-ops if already registered.
+ */
+async function ensureClaudeCodeRegistered(): Promise<void> {
+  const settingsPath = join(homedir(), '.claude', 'settings.json');
+  try {
+    let settings: Record<string, unknown> = {};
+    try {
+      const raw = await fs.readFile(settingsPath, 'utf-8');
+      settings = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      // file missing or invalid JSON — start fresh
+    }
+
+    const servers = (settings.mcpServers ?? {}) as Record<string, unknown>;
+    if (servers[SERVER_NAME]) return; // already present
+
+    servers[SERVER_NAME] = { url: SERVER_URL };
+    settings.mcpServers = servers;
+
+    await fs.mkdir(join(homedir(), '.claude'), { recursive: true });
+    await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
+    console.log('[MCP] Registered with Claude Code (~/.claude/settings.json)');
+  } catch (err) {
+    console.warn('[MCP] Could not register with Claude Code:', err);
+  }
+}
+
+/**
+ * Append canvas-workspace MCP server entry into ~/.codex/config.toml.
+ * No-ops if already registered.
+ */
+async function ensureCodexRegistered(): Promise<void> {
+  const configPath = join(homedir(), '.codex', 'config.toml');
+  const marker = `[mcp_servers.${SERVER_NAME}]`;
+  try {
+    let config = '';
+    try {
+      config = await fs.readFile(configPath, 'utf-8');
+    } catch {
+      // file missing — will be created
+    }
+
+    if (config.includes(marker)) return; // already present
+
+    const entry = `\n${marker}\nurl = "${SERVER_URL}"\nenabled = true\n`;
+    await fs.mkdir(join(homedir(), '.codex'), { recursive: true });
+    await fs.writeFile(configPath, config + entry, 'utf-8');
+    console.log('[MCP] Registered with Codex (~/.codex/config.toml)');
+  } catch (err) {
+    console.warn('[MCP] Could not register with Codex:', err);
+  }
+}
+
+/**
+ * Ensure canvas-workspace MCP server is registered with both
+ * Claude Code and Codex. Runs at app startup; safe to call repeatedly.
+ */
+export async function ensureMCPRegistered(): Promise<void> {
+  await Promise.allSettled([
+    ensureClaudeCodeRegistered(),
+    ensureCodexRegistered()
+  ]);
+}

--- a/apps/canvas-workspace/src/main/mcp-registration.ts
+++ b/apps/canvas-workspace/src/main/mcp-registration.ts
@@ -1,44 +1,84 @@
+import { execFile } from 'child_process';
 import { promises as fs } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+import { promisify } from 'util';
 import { MCP_PORT } from './mcp-server';
+
+const execFileAsync = promisify(execFile);
 
 const SERVER_NAME = 'canvas-workspace';
 const SERVER_URL = `http://localhost:${MCP_PORT}/mcp`;
 
-/**
- * Write canvas-workspace MCP server entry into ~/.claude/settings.json.
- * Merges with existing settings; no-ops if already registered.
- */
-async function ensureClaudeCodeRegistered(): Promise<void> {
-  const settingsPath = join(homedir(), '.claude', 'settings.json');
+// ---------------------------------------------------------------------------
+// Claude Code
+// MCP servers live in ~/.claude.json under the "mcpServers" key (user scope).
+// We prefer the CLI (`claude mcp add`) and fall back to direct file write.
+// Format: { "type": "http", "url": "..." }
+// ---------------------------------------------------------------------------
+
+async function isClaudeRegistered(): Promise<boolean> {
   try {
-    let settings: Record<string, unknown> = {};
-    try {
-      const raw = await fs.readFile(settingsPath, 'utf-8');
-      settings = JSON.parse(raw) as Record<string, unknown>;
-    } catch {
-      // file missing or invalid JSON — start fresh
-    }
-
-    const servers = (settings.mcpServers ?? {}) as Record<string, unknown>;
-    if (servers[SERVER_NAME]) return; // already present
-
-    servers[SERVER_NAME] = { url: SERVER_URL };
-    settings.mcpServers = servers;
-
-    await fs.mkdir(join(homedir(), '.claude'), { recursive: true });
-    await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
-    console.log('[MCP] Registered with Claude Code (~/.claude/settings.json)');
-  } catch (err) {
-    console.warn('[MCP] Could not register with Claude Code:', err);
+    const { stdout } = await execFileAsync('claude', ['mcp', 'get', SERVER_NAME]);
+    return stdout.includes(SERVER_NAME);
+  } catch {
+    return false;
   }
 }
 
-/**
- * Append canvas-workspace MCP server entry into ~/.codex/config.toml.
- * No-ops if already registered.
- */
+async function registerClaudeCLI(): Promise<boolean> {
+  try {
+    await execFileAsync('claude', [
+      'mcp', 'add',
+      '--transport', 'http',
+      SERVER_NAME,
+      SERVER_URL,
+    ]);
+    console.log('[MCP] Registered with Claude Code (via CLI)');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function registerClaudeFile(): Promise<void> {
+  // User-scope config: ~/.claude.json
+  const filePath = join(homedir(), '.claude.json');
+  try {
+    let config: Record<string, unknown> = {};
+    try {
+      const raw = await fs.readFile(filePath, 'utf-8');
+      config = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      // file missing or invalid — start fresh
+    }
+
+    const servers = (config.mcpServers ?? {}) as Record<string, unknown>;
+    if (servers[SERVER_NAME]) return; // already present
+
+    servers[SERVER_NAME] = { type: 'http', url: SERVER_URL };
+    config.mcpServers = servers;
+
+    await fs.writeFile(filePath, JSON.stringify(config, null, 2), 'utf-8');
+    console.log('[MCP] Registered with Claude Code (~/.claude.json)');
+  } catch (err) {
+    console.warn('[MCP] Could not register with Claude Code via file:', err);
+  }
+}
+
+async function ensureClaudeCodeRegistered(): Promise<void> {
+  if (await isClaudeRegistered()) return;
+  const ok = await registerClaudeCLI();
+  if (!ok) await registerClaudeFile();
+}
+
+// ---------------------------------------------------------------------------
+// Codex
+// Config: ~/.codex/config.toml  (TOML format)
+// HTTP servers use `url = "..."` under [mcp_servers.<name>].
+// CLI only supports stdio; we write the TOML directly.
+// ---------------------------------------------------------------------------
+
 async function ensureCodexRegistered(): Promise<void> {
   const configPath = join(homedir(), '.codex', 'config.toml');
   const marker = `[mcp_servers.${SERVER_NAME}]`;
@@ -61,6 +101,8 @@ async function ensureCodexRegistered(): Promise<void> {
   }
 }
 
+// ---------------------------------------------------------------------------
+
 /**
  * Ensure canvas-workspace MCP server is registered with both
  * Claude Code and Codex. Runs at app startup; safe to call repeatedly.
@@ -68,6 +110,6 @@ async function ensureCodexRegistered(): Promise<void> {
 export async function ensureMCPRegistered(): Promise<void> {
   await Promise.allSettled([
     ensureClaudeCodeRegistered(),
-    ensureCodexRegistered()
+    ensureCodexRegistered(),
   ]);
 }

--- a/apps/canvas-workspace/src/main/mcp-server.ts
+++ b/apps/canvas-workspace/src/main/mcp-server.ts
@@ -292,15 +292,23 @@ async function handleMCPRequest(body: string): Promise<unknown> {
 
   try {
     switch (method) {
-      case 'initialize':
+      case 'initialize': {
+        // Negotiate protocol version: accept what the client requests if we support it,
+        // otherwise respond with our latest supported version.
+        const SUPPORTED_VERSIONS = ['2025-03-26', '2024-11-05'];
+        const clientVersion = (params as { protocolVersion?: string } | undefined)?.protocolVersion ?? '';
+        const protocolVersion = SUPPORTED_VERSIONS.includes(clientVersion)
+          ? clientVersion
+          : '2025-03-26';
         return {
           jsonrpc: '2.0', id,
           result: {
-            protocolVersion: '2024-11-05',
+            protocolVersion,
             capabilities: { tools: {} },
             serverInfo: { name: 'canvas-workspace', version: '0.1.0' }
           }
         };
+      }
 
       case 'ping':
         return { jsonrpc: '2.0', id, result: {} };

--- a/apps/canvas-workspace/src/main/mcp-server.ts
+++ b/apps/canvas-workspace/src/main/mcp-server.ts
@@ -1,0 +1,381 @@
+import { createServer, IncomingMessage, ServerResponse } from 'http';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+export const MCP_PORT = 3333;
+
+const STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
+
+// --- Types ---
+
+interface CanvasNodeData {
+  filePath?: string;
+  content?: string;
+  scrollback?: string;
+  cwd?: string;
+  color?: string;
+  label?: string;
+  [key: string]: unknown;
+}
+
+interface CanvasNode {
+  id: string;
+  type: 'file' | 'terminal' | 'frame';
+  title: string;
+  data: CanvasNodeData;
+}
+
+interface CanvasSaveData {
+  nodes: CanvasNode[];
+  transform: unknown;
+  savedAt: string;
+}
+
+interface WorkspaceEntry {
+  id: string;
+  name: string;
+}
+
+interface WorkspaceManifest {
+  entries: WorkspaceEntry[];
+}
+
+// --- Canvas data access ---
+
+async function loadCanvas(workspaceId: string): Promise<CanvasSaveData | null> {
+  try {
+    const raw = await fs.readFile(join(STORE_DIR, workspaceId, 'canvas.json'), 'utf-8');
+    return JSON.parse(raw) as CanvasSaveData;
+  } catch {
+    return null;
+  }
+}
+
+async function saveCanvas(workspaceId: string, data: CanvasSaveData): Promise<void> {
+  await fs.writeFile(
+    join(STORE_DIR, workspaceId, 'canvas.json'),
+    JSON.stringify(data, null, 2),
+    'utf-8'
+  );
+}
+
+async function loadWorkspaceManifest(): Promise<WorkspaceManifest> {
+  try {
+    const raw = await fs.readFile(join(STORE_DIR, '__workspaces__.json'), 'utf-8');
+    return JSON.parse(raw) as WorkspaceManifest;
+  } catch {
+    return { entries: [] };
+  }
+}
+
+async function listWorkspaceIds(): Promise<string[]> {
+  try {
+    await fs.mkdir(STORE_DIR, { recursive: true });
+    const entries = await fs.readdir(STORE_DIR, { withFileTypes: true });
+    return entries
+      .filter((e: import('fs').Dirent) => e.isDirectory() && e.name !== '__workspaces__')
+      .map((e: import('fs').Dirent) => e.name);
+  } catch {
+    return [];
+  }
+}
+
+// --- Node providers ---
+
+async function readNode(node: CanvasNode): Promise<string> {
+  switch (node.type) {
+    case 'file': {
+      if (node.data.filePath) {
+        try {
+          return await fs.readFile(node.data.filePath, 'utf-8');
+        } catch {
+          // fall through to in-memory content
+        }
+      }
+      return node.data.content ?? '';
+    }
+    case 'terminal':
+      return node.data.scrollback ?? '';
+    case 'frame':
+      return JSON.stringify({ label: node.data.label ?? '', color: node.data.color ?? '' });
+    default:
+      return '';
+  }
+}
+
+async function writeNode(
+  workspaceId: string,
+  nodeId: string,
+  content: string
+): Promise<{ ok: boolean; error?: string }> {
+  const canvas = await loadCanvas(workspaceId);
+  if (!canvas) return { ok: false, error: `Workspace not found: ${workspaceId}` };
+
+  const node = canvas.nodes.find(n => n.id === nodeId);
+  if (!node) return { ok: false, error: `Node not found: ${nodeId}` };
+
+  switch (node.type) {
+    case 'file': {
+      if (node.data.filePath) {
+        await fs.writeFile(node.data.filePath, content, 'utf-8');
+      }
+      node.data.content = content;
+      canvas.savedAt = new Date().toISOString();
+      await saveCanvas(workspaceId, canvas);
+      return { ok: true };
+    }
+    case 'frame': {
+      try {
+        const patch = JSON.parse(content) as { label?: string; color?: string };
+        if (patch.label !== undefined) node.data.label = patch.label;
+        if (patch.color !== undefined) node.data.color = patch.color;
+        canvas.savedAt = new Date().toISOString();
+        await saveCanvas(workspaceId, canvas);
+        return { ok: true };
+      } catch {
+        return { ok: false, error: 'Frame write expects JSON: { label?: string, color?: string }' };
+      }
+    }
+    case 'terminal':
+      return { ok: false, error: 'Terminal nodes are read-only via MCP' };
+    default:
+      return { ok: false, error: 'Unknown node type' };
+  }
+}
+
+// --- MCP tool definitions ---
+
+const TOOLS = [
+  {
+    name: 'canvas_list',
+    description:
+      'List all nodes in the canvas workspace. Returns node IDs, types, titles, and which workspace they belong to.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        workspaceId: {
+          type: 'string',
+          description: 'Optional: restrict to a specific workspace ID'
+        }
+      }
+    }
+  },
+  {
+    name: 'canvas_read',
+    description:
+      'Read the content of a canvas node. File nodes return markdown content, terminal nodes return scrollback buffer, frame nodes return JSON with label and color.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        workspaceId: { type: 'string', description: 'Workspace ID' },
+        nodeId: { type: 'string', description: 'Node ID to read' }
+      },
+      required: ['workspaceId', 'nodeId']
+    }
+  },
+  {
+    name: 'canvas_write',
+    description:
+      'Write content to a canvas node. File nodes accept markdown text. Frame nodes accept JSON: { label?: string, color?: string }. Terminal nodes are read-only.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        workspaceId: { type: 'string', description: 'Workspace ID' },
+        nodeId: { type: 'string', description: 'Node ID to write to' },
+        content: { type: 'string', description: 'Content to write' }
+      },
+      required: ['workspaceId', 'nodeId', 'content']
+    }
+  }
+];
+
+// --- MCP tool dispatch ---
+
+type ToolArgs = Record<string, string | undefined>;
+
+async function handleToolCall(
+  name: string,
+  args: ToolArgs
+): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
+  let text: string;
+
+  try {
+    switch (name) {
+      case 'canvas_list': {
+        const ids = args.workspaceId ? [args.workspaceId] : await listWorkspaceIds();
+        const manifest = await loadWorkspaceManifest();
+        const nameMap = new Map(manifest.entries.map(e => [e.id, e.name]));
+
+        const rows: Array<{
+          workspaceId: string;
+          workspaceName: string;
+          nodeId: string;
+          type: string;
+          title: string;
+        }> = [];
+
+        for (const wsId of ids) {
+          const canvas = await loadCanvas(wsId);
+          if (!canvas) continue;
+          for (const node of canvas.nodes) {
+            rows.push({
+              workspaceId: wsId,
+              workspaceName: nameMap.get(wsId) ?? wsId,
+              nodeId: node.id,
+              type: node.type,
+              title: node.title
+            });
+          }
+        }
+
+        text = JSON.stringify(rows, null, 2);
+        break;
+      }
+
+      case 'canvas_read': {
+        const { workspaceId, nodeId } = args;
+        if (!workspaceId || !nodeId) {
+          text = 'Error: workspaceId and nodeId are required';
+          break;
+        }
+        const canvas = await loadCanvas(workspaceId);
+        if (!canvas) { text = `Error: workspace not found: ${workspaceId}`; break; }
+        const node = canvas.nodes.find(n => n.id === nodeId);
+        if (!node) { text = `Error: node not found: ${nodeId}`; break; }
+        text = await readNode(node);
+        break;
+      }
+
+      case 'canvas_write': {
+        const { workspaceId, nodeId, content } = args;
+        if (!workspaceId || !nodeId || content === undefined) {
+          text = 'Error: workspaceId, nodeId, and content are required';
+          break;
+        }
+        const result = await writeNode(workspaceId, nodeId, content);
+        text = result.ok ? 'OK' : `Error: ${result.error}`;
+        break;
+      }
+
+      default:
+        text = `Error: unknown tool "${name}"`;
+    }
+  } catch (err) {
+    text = `Error: ${String(err)}`;
+  }
+
+  return { content: [{ type: 'text', text }] };
+}
+
+// --- JSON-RPC / MCP request handler ---
+
+interface JsonRpcRequest {
+  jsonrpc: string;
+  id?: string | number | null;
+  method: string;
+  params?: unknown;
+}
+
+async function handleMCPRequest(body: string): Promise<unknown> {
+  let req: JsonRpcRequest;
+  try {
+    req = JSON.parse(body) as JsonRpcRequest;
+  } catch {
+    return { jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } };
+  }
+
+  const { id, method, params } = req;
+
+  // JSON-RPC notifications have no id and need no response
+  if (id === undefined) return null;
+
+  try {
+    switch (method) {
+      case 'initialize':
+        return {
+          jsonrpc: '2.0', id,
+          result: {
+            protocolVersion: '2024-11-05',
+            capabilities: { tools: {} },
+            serverInfo: { name: 'canvas-workspace', version: '0.1.0' }
+          }
+        };
+
+      case 'ping':
+        return { jsonrpc: '2.0', id, result: {} };
+
+      case 'tools/list':
+        return { jsonrpc: '2.0', id, result: { tools: TOOLS } };
+
+      case 'tools/call': {
+        const p = params as { name: string; arguments?: ToolArgs };
+        const result = await handleToolCall(p.name, p.arguments ?? {});
+        return { jsonrpc: '2.0', id, result };
+      }
+
+      default:
+        return {
+          jsonrpc: '2.0', id,
+          error: { code: -32601, message: `Method not found: ${method}` }
+        };
+    }
+  } catch (err) {
+    return { jsonrpc: '2.0', id, error: { code: -32603, message: String(err) } };
+  }
+}
+
+// --- HTTP server ---
+
+export function startMCPServer(): void {
+  const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Mcp-Session-Id');
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    if (req.url === '/health' && req.method === 'GET') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, service: 'canvas-workspace-mcp' }));
+      return;
+    }
+
+    if (req.url === '/mcp' && req.method === 'POST') {
+      let body = '';
+      req.on('data', (chunk: unknown) => { body += String(chunk); });
+      req.on('end', () => {
+        void (async () => {
+          const response = await handleMCPRequest(body);
+          if (response === null) {
+            res.writeHead(204);
+            res.end();
+            return;
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(response));
+        })();
+      });
+      return;
+    }
+
+    res.writeHead(404);
+    res.end();
+  });
+
+  server.listen(MCP_PORT, '127.0.0.1', () => {
+    console.log(`[MCP] Canvas workspace server on localhost:${MCP_PORT}`);
+  });
+
+  server.on('error', (err: Error & { code?: string }) => {
+    if (err.code === 'EADDRINUSE') {
+      console.warn(`[MCP] Port ${MCP_PORT} in use — server not started`);
+    } else {
+      console.error('[MCP] Server error:', err);
+    }
+  });
+}

--- a/apps/canvas-workspace/src/preload/index.ts
+++ b/apps/canvas-workspace/src/preload/index.ts
@@ -65,7 +65,10 @@ contextBridge.exposeInMainWorld("canvasWorkspace", {
       ipcRenderer.invoke("canvas:delete", { id }),
 
     getDir: (id: string) =>
-      ipcRenderer.invoke("canvas:getDir", { id })
+      ipcRenderer.invoke("canvas:getDir", { id }),
+
+    watchWorkspace: (workspaceId: string) =>
+      ipcRenderer.invoke("canvas:watchWorkspace", { workspaceId })
   },
 
   file: {
@@ -87,7 +90,16 @@ contextBridge.exposeInMainWorld("canvasWorkspace", {
       ipcRenderer.invoke("file:saveAsDialog", { defaultName, content }),
 
     saveImage: (workspaceId: string | undefined, data: string, ext?: string) =>
-      ipcRenderer.invoke("file:saveImage", { workspaceId, data, ext })
+      ipcRenderer.invoke("file:saveImage", { workspaceId, data, ext }),
+
+    onChanged: (callback: (filePath: string, content: string) => void) => {
+      const handler = (
+        _event: Electron.IpcRendererEvent,
+        payload: { filePath: string; content: string }
+      ) => callback(payload.filePath, payload.content);
+      ipcRenderer.on("canvas:file-changed", handler);
+      return () => ipcRenderer.removeListener("canvas:file-changed", handler);
+    }
   },
 
   dialog: {

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { CanvasNode, CanvasTransform, CanvasSaveData, FrameNodeData } from '../types';
+import type { CanvasNode, CanvasTransform, CanvasSaveData, FrameNodeData, FileNodeData } from '../types';
 import { genId, createDefaultNode, createNodeData } from '../utils/nodeFactory';
 import { useNodeHistory } from './useNodeHistory';
 
@@ -41,6 +41,34 @@ export const useNodes = (
     },
     [scheduleSave]
   );
+
+  // Start watching the workspace notes directory for external file changes (e.g. from MCP writes).
+  // Only updates nodes that are not currently being edited by the user (modified === false).
+  useEffect(() => {
+    const storeApi = window.canvasWorkspace?.store;
+    const fileApi = window.canvasWorkspace?.file;
+    if (!storeApi || !fileApi) return;
+
+    void storeApi.watchWorkspace(canvasId);
+
+    const cleanup = fileApi.onChanged((filePath, content) => {
+      const node = nodesRef.current.find(
+        (n) =>
+          n.type === 'file' &&
+          (n.data as FileNodeData).filePath === filePath &&
+          !(n.data as FileNodeData).modified
+      );
+      if (!node) return;
+      const updated = nodesRef.current.map((n) =>
+        n.id === node.id
+          ? { ...n, data: { ...(n.data as FileNodeData), content, modified: false } }
+          : n
+      );
+      applyNodes(updated, false);
+    });
+
+    return cleanup;
+  }, [canvasId, applyNodes, nodesRef]);
 
   useEffect(() => {
     const api = window.canvasWorkspace?.store;

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -84,6 +84,7 @@ export interface FileApi {
     data: string,
     ext?: string
   ) => Promise<{ ok: boolean; filePath?: string; fileName?: string; error?: string }>;
+  onChanged: (callback: (filePath: string, content: string) => void) => () => void;
 }
 
 export interface DialogApi {
@@ -117,6 +118,7 @@ export interface CanvasWorkspaceApi {
     list: () => Promise<{ ok: boolean; ids?: string[]; error?: string }>;
     delete: (id: string) => Promise<{ ok: boolean; error?: string }>;
     getDir: (id: string) => Promise<{ ok: boolean; dir?: string; error?: string }>;
+    watchWorkspace: (workspaceId: string) => Promise<{ ok: boolean }>;
   };
   file: FileApi;
   dialog: DialogApi;


### PR DESCRIPTION
- Add mcp-server.ts: minimal MCP HTTP server on localhost:3333 exposing
  canvas_list / canvas_read / canvas_write tools backed by NodeProvider
  abstraction (file → markdown, terminal → scrollback, frame → JSON)
- Add mcp-registration.ts: auto-registers canvas-workspace into
  ~/.claude/settings.json (Claude Code) and ~/.codex/config.toml (Codex)
  on app startup; idempotent, silently skips if already present or CLI
  not installed
- Wire both into index.ts app.whenReady

https://claude.ai/code/session_0121RKC3UP3uXweSfqcpHbwY