### PR TITLE
feat(agent-teams): artifact store, node instruction, parallel graph

### DIFF
--- a/docs/05-orchestrator-plan.md
+++ b/docs/05-orchestrator-plan.md
@@ -112,6 +112,40 @@ team 任务不是一次性调用，而是有状态的多轮会话：
 - 与现有 `clarification-queue` 对齐，提升到编排层
 - 执行状态持久化（runId + 节点状态快照）
 
+#### 会话模型与 dispatcher 的冲突
+
+> **重要约束**：现有 dispatcher 基于"一条消息 → 一次完整 run → 结束"的模型，
+> `platformKey` 锁在 run 期间，run 完立即释放。
+> team 会话横跨多条消息，与这个模型天然冲突：
+>
+> ```
+> 现在：  消息1 → run → 结束
+>               消息2 → run → 结束
+>
+> team：  消息1 → session 开始（规划）
+>               消息2 → 路由到 session（确认）
+>               消息3 → 路由到 session（执行中反问）
+>               消息4 → session 结束
+> ```
+>
+> 支持完整会话生命周期需要改造 dispatcher 路由逻辑，增加
+> `hasActiveSession(platformKey)` 判断，将消息转发给已有 session 而非新开 agent run。
+> 这是改造难度最高的部分，放在完整版实现。
+
+#### 最小可行版本（Phase 2 第一步）
+
+跳过多轮澄清和执行中反问，先只做"一次性执行"：
+
+```
+/team <task>
+  → 直接调 orchestrator.run()（无多轮澄清）
+  → 实时打印节点进度
+  → 返回最终结果
+```
+
+dispatcher 完全不需要改造，session 概念暂不引入。
+等基础版稳定后，再迭代引入 OrchestratorSession 支持多轮交互。
+
 ### Phase 3：`apps/canvas-workspace` 可视化层
 
 **目标**：将 TaskGraph 映射为 Canvas 上的节点 + 边，支持可视化编排与实时执行监控。

--- a/docs/05-orchestrator-plan.md
+++ b/docs/05-orchestrator-plan.md
@@ -1,0 +1,99 @@
+# Orchestrator 编排层计划
+
+## 背景
+
+当前 `agent-teams-plugin` 作为 engine 内置插件实现了基础的多 agent 协作能力，但存在以下限制：
+
+- 编排逻辑耦合在 engine 层，职责边界不清晰
+- 无法管理多个 Engine 实例的生命周期
+- 不同 agent 无法使用不同模型/工具集
+- remote-server / CLI / canvas-workspace 无法共用编排能力
+
+长期目标是将编排逻辑提升为独立层，engine 回归"单 agent 执行器"的职责。
+
+---
+
+## 当前 agent-teams 现状（已完成）
+
+### 能力
+- DAG 任务图执行（`scheduler.ts`）
+- 角色路由：`auto`（关键词）/ `all`（全角色）/ `plan`（LLM 动态规划）
+- 并行执行：`reviewer` / `writer` / `tester` 在 `executor` 完成后并行
+- Node 粒度 `instruction` 字段，支持差异化 prompt
+- Artifact Store：节点产物写入本地文件，下游节点读取
+
+### 已知局限
+- 所有 agent 共用同一 engine 实例（同一模型/工具集）
+- artifact 无 cleanup 逻辑
+- 聚合策略只有 `concat`，缺少 `last` 等策略
+- 整体仍在 engine 层，是临时方案
+
+---
+
+## 路线规划
+
+### Phase 1：`packages/orchestrator`（核心编排层）
+
+**目标**：从 engine 层解耦，成为独立 package，CLI / remote-server / canvas-workspace 均可接入。
+
+核心职责：
+- 管理多个 Engine 实例的生命周期
+- 持有 TaskGraph 执行状态
+- 跨 agent artifact 共享（升级现有 artifact-store）
+- 统一执行状态事件流（`pending` / `running` / `success` / `failed`）
+
+主要迁移内容（从 agent-teams-plugin 搬过来，去掉 EnginePluginContext 依赖）：
+- `scheduler.ts` → 依赖 `OrchestratorContext` 而非 engine context
+- `graph.ts` / `planner.ts` / `artifact-store.ts` 基本可直接复用
+- `router.ts` 可继续保留在 engine plugin 作为 thin adapter
+
+补充能力：
+- 每个 TaskNode 可指定独立的模型 / system prompt / 工具集
+- artifact cleanup（按 runId TTL 清理）
+- 聚合策略扩展：`concat` / `last` / `summary`（LLM 汇总）
+
+### Phase 2：`apps/canvas-workspace` 可视化层
+
+**目标**：将 TaskGraph 映射为 Canvas 上的节点 + 边，支持可视化编排与实时执行监控。
+
+新增节点类型：
+- **Agent 节点**：显示角色名、运行状态、产物预览
+- **连线/边**：表达 DAG 依赖关系
+
+交互流程：
+1. 用户在 Canvas 上拖拽 Agent 节点、连线定义依赖
+2. 点击执行 → 调用 orchestrator
+3. 节点状态实时更新（颜色/进度指示）
+4. 节点产物可直接在 Canvas 上预览（File 节点联动）
+
+与 engine 通信方案：
+- 优先通过 remote-server HTTP API（`/internal/agent/run`）
+- 或在 Electron main process 直接引入 orchestrator package
+
+### Phase 3：remote-server / CLI 接入
+
+将 `agent-teams-plugin` 降级为 thin adapter，核心逻辑迁移到 orchestrator。
+remote-server 的 `agent-runner.ts` 可直接调用 orchestrator 而不是通过工具调用。
+
+---
+
+## 依赖关系
+
+```
+packages/engine          ← 单 agent 执行器，保持轻量
+packages/orchestrator    ← 多 agent 编排，依赖 engine
+apps/remote-server       ← 接入 orchestrator
+packages/cli             ← 接入 orchestrator
+apps/canvas-workspace    ← 可视化层，接入 orchestrator
+```
+
+---
+
+## 近期待办
+
+- [ ] 补全 artifact cleanup（TTL 清理 runId 目录）
+- [ ] 聚合策略补充 `last`
+- [ ] 初始化 `packages/orchestrator` 骨架
+- [ ] 定义 `OrchestratorContext` 接口，替换 `EnginePluginContext` 依赖
+- [ ] canvas-workspace 新增连线/边基础能力
+- [ ] canvas-workspace 新增 Agent 节点类型

--- a/docs/05-orchestrator-plan.md
+++ b/docs/05-orchestrator-plan.md
@@ -32,7 +32,7 @@
 
 ## 路线规划
 
-### Phase 1：`packages/orchestrator`（核心编排层）
+### Phase 1：`packages/orchestrator`（核心编排层）✅
 
 **目标**：从 engine 层解耦，成为独立 package，CLI / remote-server / canvas-workspace 均可接入。
 
@@ -43,16 +43,76 @@
 - 统一执行状态事件流（`pending` / `running` / `success` / `failed`）
 
 主要迁移内容（从 agent-teams-plugin 搬过来，去掉 EnginePluginContext 依赖）：
-- `scheduler.ts` → 依赖 `OrchestratorContext` 而非 engine context
+- `scheduler.ts` → 依赖 `AgentRunner` 接口而非 engine context
 - `graph.ts` / `planner.ts` / `artifact-store.ts` 基本可直接复用
-- `router.ts` 可继续保留在 engine plugin 作为 thin adapter
+- `EngineAgentRunner` adapter 连接 engine 工具系统
 
 补充能力：
 - 每个 TaskNode 可指定独立的模型 / system prompt / 工具集
 - artifact cleanup（按 runId TTL 清理）
 - 聚合策略扩展：`concat` / `last` / `summary`（LLM 汇总）
 
-### Phase 2：`apps/canvas-workspace` 可视化层
+### Phase 2：remote-server / CLI 接入
+
+**目标**：将 `agent-teams-plugin` 降级为 thin adapter，CLI/remote-server 直接驱动 orchestrator，
+绕过 LLM tool 调用，实现中间过程可见。
+
+#### 执行模式切换
+
+team 模式通过**模式命令**触发，而非 LLM 工具调用：
+
+```
+/team <task>              → 直接走 orchestrator，实时输出节点进度
+/team --route=plan <task> → LLM 动态规划 graph 再执行
+普通对话                   → 单 engine 模式（默认）
+```
+
+工具调用模式（现有）保留作为 LLM 自主触发的备用路径。
+
+#### 中间过程可见
+
+CLI 监听 orchestrator logger 事件，实时打印节点状态：
+
+```
+[orchestrator] Starting: research (researcher)
+[orchestrator] ✓ research completed (12.3s)
+[orchestrator] Starting: execute (executor)
+[orchestrator] Starting: review (reviewer)   ← 并行
+[orchestrator] ✓ review completed (8.1s)
+[orchestrator] ✓ execute completed (21.4s)
+```
+
+remote-server 则通过 Feishu/Discord 推送每个节点进度消息。
+
+#### Team 任务的会话生命周期
+
+team 任务不是一次性调用，而是有状态的多轮会话：
+
+```
+1. 规划阶段（多轮澄清）
+   用户发起 /team 任务
+   → orchestrator 通过多轮对话澄清目标、范围、约束
+   → 逐步完善 TaskGraph
+
+2. 确认阶段
+   → 展示生成的 TaskGraph 让用户 review
+   → 用户确认或调整后再执行
+
+3. 执行阶段
+   → 执行 TaskGraph，实时推送进度
+   → 某节点遇到歧义时暂停，反问用户后继续
+
+4. 续跑能力
+   → 会话状态持久化
+   → 中断后可从断点恢复
+```
+
+对应 orchestrator 需要补充的能力：
+- `OrchestratorSession`：持有会话状态（规划/确认/执行/暂停）
+- 与现有 `clarification-queue` 对齐，提升到编排层
+- 执行状态持久化（runId + 节点状态快照）
+
+### Phase 3：`apps/canvas-workspace` 可视化层
 
 **目标**：将 TaskGraph 映射为 Canvas 上的节点 + 边，支持可视化编排与实时执行监控。
 
@@ -67,13 +127,8 @@
 4. 节点产物可直接在 Canvas 上预览（File 节点联动）
 
 与 engine 通信方案：
-- 优先通过 remote-server HTTP API（`/internal/agent/run`）
+- 优先通过 remote-server HTTP API
 - 或在 Electron main process 直接引入 orchestrator package
-
-### Phase 3：remote-server / CLI 接入
-
-将 `agent-teams-plugin` 降级为 thin adapter，核心逻辑迁移到 orchestrator。
-remote-server 的 `agent-runner.ts` 可直接调用 orchestrator 而不是通过工具调用。
 
 ---
 
@@ -82,18 +137,24 @@ remote-server 的 `agent-runner.ts` 可直接调用 orchestrator 而不是通过
 ```
 packages/engine          ← 单 agent 执行器，保持轻量
 packages/orchestrator    ← 多 agent 编排，依赖 engine
-apps/remote-server       ← 接入 orchestrator
-packages/cli             ← 接入 orchestrator
-apps/canvas-workspace    ← 可视化层，接入 orchestrator
+apps/remote-server       ← 接入 orchestrator（Phase 2）
+packages/cli             ← 接入 orchestrator（Phase 2）
+apps/canvas-workspace    ← 可视化层，接入 orchestrator（Phase 3）
 ```
 
 ---
 
 ## 近期待办
 
-- [ ] 补全 artifact cleanup（TTL 清理 runId 目录）
-- [ ] 聚合策略补充 `last`
-- [ ] 初始化 `packages/orchestrator` 骨架
-- [ ] 定义 `OrchestratorContext` 接口，替换 `EnginePluginContext` 依赖
+- [x] packages/orchestrator 骨架搭建
+- [x] AgentRunner 接口 + EngineAgentRunner adapter
+- [x] 核心模块迁移（scheduler/graph/router/planner/artifact-store/aggregator）
+- [x] artifact cleanup 方法
+- [x] 聚合策略 `last`
+- [ ] agent-teams-plugin 改为 thin adapter（调用 orchestrator）
+- [ ] CLI 新增 `/team` 模式命令，接入 orchestrator
+- [ ] OrchestratorSession：会话生命周期管理（规划/确认/执行/暂停）
+- [ ] 执行状态持久化与断点续跑
+- [ ] remote-server 节点进度推送（Feishu/Discord）
 - [ ] canvas-workspace 新增连线/边基础能力
 - [ ] canvas-workspace 新增 Agent 节点类型

--- a/packages/engine/src/built-in/agent-teams-plugin/artifact-store.ts
+++ b/packages/engine/src/built-in/agent-teams-plugin/artifact-store.ts
@@ -1,0 +1,25 @@
+import { mkdir, writeFile } from 'fs/promises';
+import { join } from 'path';
+
+export interface ArtifactStore {
+  write(runId: string, nodeId: string, role: string, content: string): Promise<string>;
+  getPath(runId: string, nodeId: string): string;
+  cleanup?(runId: string): Promise<void>;
+}
+
+export class LocalArtifactStore implements ArtifactStore {
+  constructor(private baseDir: string = '.pulse-coder/agent-teams') {}
+
+  getPath(runId: string, nodeId: string): string {
+    return join(this.baseDir, runId, `${nodeId}.md`);
+  }
+
+  async write(runId: string, nodeId: string, role: string, content: string): Promise<string> {
+    const dir = join(this.baseDir, runId);
+    await mkdir(dir, { recursive: true });
+    const filePath = this.getPath(runId, nodeId);
+    const body = `# [${role}] ${nodeId}\n\n${content}`;
+    await writeFile(filePath, body, 'utf-8');
+    return filePath;
+  }
+}

--- a/packages/engine/src/built-in/agent-teams-plugin/graph.ts
+++ b/packages/engine/src/built-in/agent-teams-plugin/graph.ts
@@ -14,6 +14,7 @@ export function buildTaskGraph(options: GraphBuildOptions): TaskGraph {
   const { task, roles } = options;
   const nodes: TaskNode[] = [];
 
+  // researcher 先跑，无依赖
   if (roles.includes('researcher')) {
     nodes.push({
       id: 'research',
@@ -24,7 +25,8 @@ export function buildTaskGraph(options: GraphBuildOptions): TaskGraph {
     });
   }
 
-  const executeDeps = nodes.map(node => node.id);
+  // executor 依赖 researcher（如有），否则无依赖
+  const executeDeps = roles.includes('researcher') ? ['research'] : [];
   if (roles.includes('executor')) {
     nodes.push({
       id: 'execute',
@@ -34,34 +36,35 @@ export function buildTaskGraph(options: GraphBuildOptions): TaskGraph {
     });
   }
 
-  const reviewDeps = nodes.length > 0 ? [nodes[nodes.length - 1].id] : [];
+  // executor 完成后的基准节点（用于 reviewer/writer/tester 的共同依赖）
+  const postExecuteDeps: string[] = roles.includes('executor') ? ['execute'] : executeDeps;
+
+  // reviewer / writer / tester 都只依赖 postExecuteDeps，互相之间并行
   if (roles.includes('reviewer')) {
     nodes.push({
       id: 'review',
       role: 'reviewer',
-      deps: reviewDeps,
+      deps: [...postExecuteDeps],
       input: task,
       optional: true
     });
   }
 
-  const writeDeps = nodes.length > 0 ? [nodes[nodes.length - 1].id] : [];
   if (roles.includes('writer')) {
     nodes.push({
       id: 'write',
       role: 'writer',
-      deps: writeDeps,
+      deps: [...postExecuteDeps],
       input: task,
       optional: true
     });
   }
 
-  const testDeps = nodes.length > 0 ? [nodes[nodes.length - 1].id] : [];
   if (roles.includes('tester')) {
     nodes.push({
       id: 'test',
       role: 'tester',
-      deps: testDeps,
+      deps: [...postExecuteDeps],
       input: task,
       optional: true
     });

--- a/packages/engine/src/built-in/agent-teams-plugin/index.ts
+++ b/packages/engine/src/built-in/agent-teams-plugin/index.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { randomUUID } from 'crypto';
 
 import type { EnginePlugin, EnginePluginContext } from '../../plugin/EnginePlugin';
 import type { Tool } from '../../shared/types';
@@ -8,6 +9,7 @@ import { buildTaskGraph, validateTaskGraph } from './graph';
 import { routeRoles } from './router';
 import { runTaskGraph } from './scheduler';
 import { aggregateResults } from './aggregator';
+import { LocalArtifactStore } from './artifact-store';
 import type { TeamRole, TeamRunInput, TeamRunOutput, TaskGraph } from './types';
 
 const TEAM_RUN_INPUT_SCHEMA = z.object({
@@ -37,12 +39,15 @@ export const builtInAgentTeamsPlugin: EnginePlugin = {
   async initialize(context: EnginePluginContext): Promise<void> {
     const registry = new RoleRegistry();
 
+    const artifactStore = new LocalArtifactStore();
+
     const tool: Tool<TeamRunInput, TeamRunOutput> = {
       name: 'agent_teams_run',
       description: 'Run a fixed DAG agent team with role routing and aggregation.',
       defer_loading: true,
       inputSchema: TEAM_RUN_INPUT_SCHEMA,
       execute: async (input) => {
+        const runId = randomUUID();
         const roleTools = registry.resolveRoleTools(input.roleTools);
         const tools = context.getTools();
         const availableRoles = Object.keys(roleTools) as TeamRole[];
@@ -80,12 +85,14 @@ export const builtInAgentTeamsPlugin: EnginePlugin = {
           context,
           graph,
           task: input.task,
+          runId,
           maxConcurrency: input.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY,
           retries: input.retries ?? DEFAULT_RETRIES,
           nodeTimeoutMs: input.nodeTimeoutMs ?? DEFAULT_TIMEOUT_MS,
           roleTools,
           tools,
-          runContext: input.context
+          runContext: input.context,
+          artifactStore
         });
 
         return {

--- a/packages/engine/src/built-in/agent-teams-plugin/index.ts
+++ b/packages/engine/src/built-in/agent-teams-plugin/index.ts
@@ -10,6 +10,7 @@ import { routeRoles } from './router';
 import { runTaskGraph } from './scheduler';
 import { aggregateResults } from './aggregator';
 import { LocalArtifactStore } from './artifact-store';
+import { planTaskGraph } from './planner';
 import type { TeamRole, TeamRunInput, TeamRunOutput, TaskGraph } from './types';
 
 const TEAM_RUN_INPUT_SCHEMA = z.object({
@@ -17,7 +18,7 @@ const TEAM_RUN_INPUT_SCHEMA = z.object({
   context: z.any().optional().describe('任务上下文信息'),
   roles: z.array(z.string()).optional().describe('明确指定的角色列表'),
   graph: z.any().optional().describe('自定义 TaskGraph'),
-  route: z.enum(['auto', 'all']).optional().describe('自动路由或全角色执行'),
+  route: z.enum(['auto', 'all', 'plan']).optional().describe('auto=关键词路由, all=全角色, plan=LLM动态规划'),
   includeRoles: z.array(z.string()).optional().describe('强制包含的角色'),
   excludeRoles: z.array(z.string()).optional().describe('排除的角色'),
   roleTools: z.record(z.string(), z.string()).optional().describe('角色到工具名称映射'),
@@ -72,6 +73,9 @@ export const builtInAgentTeamsPlugin: EnginePlugin = {
         let graph: TaskGraph;
         if (input.graph) {
           graph = input.graph as TaskGraph;
+        } else if (input.route === 'plan') {
+          context.logger.info('[AgentTeams] Planning task graph with LLM...');
+          graph = await planTaskGraph({ task: input.task, availableRoles });
         } else {
           graph = buildTaskGraph({ task: input.task, roles });
         }

--- a/packages/engine/src/built-in/agent-teams-plugin/planner.ts
+++ b/packages/engine/src/built-in/agent-teams-plugin/planner.ts
@@ -1,0 +1,66 @@
+import { generateTextAI } from '../../ai';
+import type { TaskGraph, TeamRole } from './types';
+
+export interface PlannerOptions {
+  task: string;
+  availableRoles: TeamRole[];
+}
+
+const PLANNER_SYSTEM_PROMPT = `你是一个 agent team 规划器。
+根据用户描述的任务，输出一个合理的 TaskGraph JSON，决定需要哪些角色、执行顺序和依赖关系。
+
+TaskGraph 格式：
+{
+  "nodes": [
+    {
+      "id": "唯一标识符",
+      "role": "角色名",
+      "deps": ["依赖的节点 id"],
+      "input": "该节点的具体任务描述（可选，不填则用原始任务）",
+      "instruction": "该节点 agent 的执行指令（可选，用于差异化 prompt）",
+      "optional": true/false
+    }
+  ]
+}
+
+规则：
+- deps 必须引用已存在的节点 id，不能有环
+- 没有依赖关系的节点会并行执行
+- optional=true 的节点失败不会阻断后续流程
+- 只使用 availableRoles 中列出的角色
+- 直接输出 JSON，不要加任何说明文字`;
+
+export async function planTaskGraph(options: PlannerOptions): Promise<TaskGraph> {
+  const { task, availableRoles } = options;
+
+  const userPrompt = `任务：${task}
+
+可用角色：${availableRoles.join(', ')}
+
+请输出 TaskGraph JSON：`;
+
+  const result = await generateTextAI(
+    [{ role: 'user', content: userPrompt }],
+    {},
+    { systemPrompt: PLANNER_SYSTEM_PROMPT }
+  );
+
+  const raw = result.text?.trim() ?? '';
+
+  // 提取 JSON（兼容 LLM 可能包裹在 ```json ``` 里的情况）
+  const jsonMatch = raw.match(/```(?:json)?\s*([\s\S]*?)```/) ?? null;
+  const jsonStr = jsonMatch ? jsonMatch[1].trim() : raw;
+
+  let graph: TaskGraph;
+  try {
+    graph = JSON.parse(jsonStr) as TaskGraph;
+  } catch {
+    throw new Error(`Planner returned invalid JSON: ${jsonStr.slice(0, 200)}`);
+  }
+
+  if (!Array.isArray(graph.nodes)) {
+    throw new Error('Planner returned invalid TaskGraph: missing nodes array');
+  }
+
+  return graph;
+}

--- a/packages/engine/src/built-in/agent-teams-plugin/scheduler.ts
+++ b/packages/engine/src/built-in/agent-teams-plugin/scheduler.ts
@@ -1,16 +1,19 @@
 import type { NodeResult, TaskGraph, TaskNode } from './types';
 import type { EnginePluginContext } from '../../plugin/EnginePlugin';
+import type { ArtifactStore } from './artifact-store';
 
 export interface ScheduleOptions {
   context: EnginePluginContext;
   graph: TaskGraph;
   task: string;
+  runId: string;
   maxConcurrency: number;
   retries: number;
   nodeTimeoutMs: number;
   roleTools: Record<string, string>;
   tools: Record<string, any>;
   runContext?: Record<string, any>;
+  artifactStore?: ArtifactStore;
 }
 
 export async function runTaskGraph(options: ScheduleOptions): Promise<Record<string, NodeResult>> {
@@ -52,7 +55,7 @@ export async function runTaskGraph(options: ScheduleOptions): Promise<Record<str
   };
 
   const runNode = async (node: TaskNode) => {
-    const { context, task, roleTools, tools, runContext } = options;
+    const { context, task, roleTools, tools, runContext, artifactStore, runId } = options;
     const now = Date.now();
     const result: NodeResult = {
       nodeId: node.id,
@@ -94,9 +97,33 @@ export async function runTaskGraph(options: ScheduleOptions): Promise<Record<str
       return;
     }
 
+    // 收集上游 artifact 文件路径
+    const depArtifacts = artifactStore
+      ? node.deps
+          .map(dep => {
+            const r = results[dep];
+            if (r?.status === 'success') {
+              return { role: r.role, nodeId: dep, path: artifactStore.getPath(runId, dep) };
+            }
+            return null;
+          })
+          .filter((d): d is { role: string; nodeId: string; path: string } => d !== null)
+      : [];
+
+    const depFilesNote =
+      depArtifacts.length > 0
+        ? '\n\n上游结果文件：\n' +
+          depArtifacts.map(d => `- [${d.role}] ${d.path}`).join('\n') +
+          '\n请先阅读上述文件，再执行任务。'
+        : '';
+
+    const taskInput = node.instruction
+      ? `${node.instruction}\n\n${node.input ?? task}${depFilesNote}`
+      : `${node.input ?? task}${depFilesNote}`;
+
     const runOnce = async () => {
       const input = {
-        task: node.input ?? task,
+        task: taskInput,
         context: {
           task,
           role: node.role,
@@ -120,6 +147,16 @@ export async function runTaskGraph(options: ScheduleOptions): Promise<Record<str
         result.endedAt = Date.now();
         result.durationMs = result.endedAt - result.startedAt;
         results[node.id] = result;
+
+        // 写入 artifact
+        if (artifactStore && result.output) {
+          try {
+            await artifactStore.write(runId, node.id, node.role, result.output);
+          } catch {
+            // artifact 写入失败不影响主流程
+          }
+        }
+
         completed.add(node.id);
         return;
       } catch (error) {

--- a/packages/engine/src/built-in/agent-teams-plugin/types.ts
+++ b/packages/engine/src/built-in/agent-teams-plugin/types.ts
@@ -15,6 +15,7 @@ export interface TaskNode {
   input: string;
   optional?: boolean;
   tool?: string;
+  instruction?: string;
 }
 
 export interface TaskGraph {

--- a/packages/engine/src/built-in/agent-teams-plugin/types.ts
+++ b/packages/engine/src/built-in/agent-teams-plugin/types.ts
@@ -41,7 +41,7 @@ export interface TeamRunInput {
   context?: Record<string, any>;
   roles?: TeamRole[];
   graph?: TaskGraph;
-  route?: 'auto' | 'all';
+  route?: 'auto' | 'all' | 'plan';
   includeRoles?: TeamRole[];
   excludeRoles?: TeamRole[];
   roleTools?: Record<string, string>;

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "pulse-coder-orchestrator",
+  "version": "0.0.1-alpha.1",
+  "description": "Multi-agent orchestration layer for Pulse Coder",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "pulse-coder-engine": "workspace:*",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.10",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/orchestrator/src/adapters/engine-agent-runner.ts
+++ b/packages/orchestrator/src/adapters/engine-agent-runner.ts
@@ -1,0 +1,28 @@
+import type { AgentRunner, AgentRunInput } from '../runner';
+
+/**
+ * EngineAgentRunner
+ *
+ * 将 engine 的工具系统适配为 AgentRunner 接口。
+ * engine 层注册的 xxx_agent 工具可以直接被 Orchestrator 驱动。
+ *
+ * 使用方式：
+ *   const runner = new EngineAgentRunner(context.getTools());
+ *   const orchestrator = new Orchestrator({ runner });
+ */
+export class EngineAgentRunner implements AgentRunner {
+  constructor(private tools: Record<string, any>) {}
+
+  async run(input: AgentRunInput): Promise<string> {
+    const tool = this.tools[input.agentName];
+    if (!tool) {
+      throw new Error(`Agent tool not found: ${input.agentName}`);
+    }
+    const output = await tool.execute({ task: input.task, context: input.context });
+    return typeof output === 'string' ? output : JSON.stringify(output, null, 2);
+  }
+
+  getAvailableAgents(): string[] {
+    return Object.keys(this.tools).filter(name => name.endsWith('_agent'));
+  }
+}

--- a/packages/orchestrator/src/aggregator.ts
+++ b/packages/orchestrator/src/aggregator.ts
@@ -1,0 +1,19 @@
+import type { NodeResult, AggregateStrategy } from './types';
+
+export function aggregateResults(
+  results: Record<string, NodeResult>,
+  strategy: AggregateStrategy = 'concat'
+): string {
+  const ordered = Object.values(results).sort((a, b) => a.startedAt - b.startedAt);
+
+  if (strategy === 'last') {
+    const last = ordered.filter(r => r.status === 'success').at(-1);
+    return last?.output ?? '';
+  }
+
+  // concat
+  return ordered
+    .map(r => `[${r.role}] ${r.status.toUpperCase()}\n${r.output ?? r.error ?? r.skippedReason ?? ''}`.trim())
+    .filter(Boolean)
+    .join('\n\n');
+}

--- a/packages/orchestrator/src/artifact-store.ts
+++ b/packages/orchestrator/src/artifact-store.ts
@@ -1,0 +1,29 @@
+import { mkdir, writeFile, rm } from 'fs/promises';
+import { join } from 'path';
+
+export interface ArtifactStore {
+  write(runId: string, nodeId: string, role: string, content: string): Promise<string>;
+  getPath(runId: string, nodeId: string): string;
+  cleanup(runId: string): Promise<void>;
+}
+
+export class LocalArtifactStore implements ArtifactStore {
+  constructor(private baseDir: string = '.pulse-coder/agent-teams') {}
+
+  getPath(runId: string, nodeId: string): string {
+    return join(this.baseDir, runId, `${nodeId}.md`);
+  }
+
+  async write(runId: string, nodeId: string, role: string, content: string): Promise<string> {
+    const dir = join(this.baseDir, runId);
+    await mkdir(dir, { recursive: true });
+    const filePath = this.getPath(runId, nodeId);
+    await writeFile(filePath, `# [${role}] ${nodeId}\n\n${content}`, 'utf-8');
+    return filePath;
+  }
+
+  async cleanup(runId: string): Promise<void> {
+    const dir = join(this.baseDir, runId);
+    await rm(dir, { recursive: true, force: true });
+  }
+}

--- a/packages/orchestrator/src/graph.ts
+++ b/packages/orchestrator/src/graph.ts
@@ -1,0 +1,57 @@
+import type { TaskGraph, TaskNode, TeamRole } from './types';
+
+export interface GraphBuildOptions {
+  task: string;
+  roles: TeamRole[];
+}
+
+export interface GraphValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+export function buildTaskGraph(options: GraphBuildOptions): TaskGraph {
+  const { task, roles } = options;
+  const nodes: TaskNode[] = [];
+
+  if (roles.includes('researcher')) {
+    nodes.push({ id: 'research', role: 'researcher', deps: [], input: task, optional: true });
+  }
+
+  const executeDeps = roles.includes('researcher') ? ['research'] : [];
+  if (roles.includes('executor')) {
+    nodes.push({ id: 'execute', role: 'executor', deps: executeDeps, input: task });
+  }
+
+  // reviewer / writer / tester 共同依赖 executor，互相并行
+  const postExecuteDeps: string[] = roles.includes('executor') ? ['execute'] : executeDeps;
+
+  if (roles.includes('reviewer')) {
+    nodes.push({ id: 'review', role: 'reviewer', deps: [...postExecuteDeps], input: task, optional: true });
+  }
+  if (roles.includes('writer')) {
+    nodes.push({ id: 'write', role: 'writer', deps: [...postExecuteDeps], input: task, optional: true });
+  }
+  if (roles.includes('tester')) {
+    nodes.push({ id: 'test', role: 'tester', deps: [...postExecuteDeps], input: task, optional: true });
+  }
+
+  return { nodes };
+}
+
+export function validateTaskGraph(graph: TaskGraph): GraphValidationResult {
+  const errors: string[] = [];
+  const ids = new Set<string>();
+
+  for (const node of graph.nodes) {
+    if (ids.has(node.id)) errors.push(`Duplicate node id: ${node.id}`);
+    ids.add(node.id);
+  }
+  for (const node of graph.nodes) {
+    for (const dep of node.deps) {
+      if (!ids.has(dep)) errors.push(`Missing dependency ${dep} for node ${node.id}`);
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -1,0 +1,26 @@
+export { Orchestrator } from './orchestrator';
+export type { OrchestratorOptions } from './orchestrator';
+
+export type {
+  TeamRole,
+  TaskNode,
+  TaskGraph,
+  NodeResult,
+  TaskNodeStatus,
+  AggregateStrategy,
+  OrchestrationInput,
+  OrchestrationResult,
+} from './types';
+
+export type { AgentRunner, AgentRunInput, OrchestratorLogger } from './runner';
+export { defaultLogger } from './runner';
+
+export type { ArtifactStore } from './artifact-store';
+export { LocalArtifactStore } from './artifact-store';
+
+export { buildTaskGraph, validateTaskGraph } from './graph';
+export { routeRoles } from './router';
+export { planTaskGraph } from './planner';
+export { aggregateResults } from './aggregator';
+
+export { EngineAgentRunner } from './adapters/engine-agent-runner';

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -1,0 +1,113 @@
+import { randomUUID } from 'crypto';
+import type { OrchestrationInput, OrchestrationResult, TaskGraph, TeamRole } from './types';
+import type { AgentRunner, OrchestratorLogger } from './runner';
+import type { ArtifactStore } from './artifact-store';
+import { LocalArtifactStore } from './artifact-store';
+import { buildTaskGraph, validateTaskGraph } from './graph';
+import { routeRoles } from './router';
+import { planTaskGraph } from './planner';
+import { runTaskGraph } from './scheduler';
+import { aggregateResults } from './aggregator';
+import { defaultLogger } from './runner';
+
+const DEFAULT_ROLE_AGENTS: Record<string, string> = {
+  researcher: 'researcher_agent',
+  executor:   'executor_agent',
+  reviewer:   'reviewer_agent',
+  writer:     'writer_agent',
+  tester:     'tester_agent',
+};
+
+const DEFAULT_MAX_CONCURRENCY = 3;
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
+const DEFAULT_RETRIES = 1;
+
+export interface OrchestratorOptions {
+  runner: AgentRunner;
+  artifactStore?: ArtifactStore;
+  logger?: OrchestratorLogger;
+  /** 角色到 agent 名称的默认映射，可覆盖内置默认值 */
+  defaultRoleAgents?: Record<string, string>;
+  /** 调用 LLM 的函数，plan 模式下必须提供 */
+  llmCall?: (systemPrompt: string, userPrompt: string) => Promise<string>;
+}
+
+export class Orchestrator {
+  private runner: AgentRunner;
+  private artifactStore: ArtifactStore;
+  private logger: OrchestratorLogger;
+  private defaultRoleAgents: Record<string, string>;
+  private llmCall?: (systemPrompt: string, userPrompt: string) => Promise<string>;
+
+  constructor(options: OrchestratorOptions) {
+    this.runner = options.runner;
+    this.artifactStore = options.artifactStore ?? new LocalArtifactStore();
+    this.logger = options.logger ?? defaultLogger;
+    this.defaultRoleAgents = { ...DEFAULT_ROLE_AGENTS, ...(options.defaultRoleAgents ?? {}) };
+    this.llmCall = options.llmCall;
+  }
+
+  async run(input: OrchestrationInput): Promise<OrchestrationResult> {
+    const runId = randomUUID();
+    const roleAgents = { ...this.defaultRoleAgents, ...(input.roleAgents ?? {}) };
+    const availableRoles = Object.keys(roleAgents) as TeamRole[];
+
+    this.logger.info(`Starting orchestration run ${runId}: ${input.task.slice(0, 80)}`);
+
+    // 决定角色列表
+    let roles: TeamRole[];
+    if (input.roles?.length) {
+      roles = input.roles;
+    } else if (input.route === 'all') {
+      roles = availableRoles;
+    } else {
+      roles = routeRoles(input.task, availableRoles);
+    }
+
+    if (input.includeRoles?.length) {
+      roles = Array.from(new Set([...roles, ...input.includeRoles]));
+    }
+    if (input.excludeRoles?.length) {
+      const excluded = new Set(input.excludeRoles);
+      roles = roles.filter(r => !excluded.has(r));
+    }
+
+    // 构建 TaskGraph
+    let graph: TaskGraph;
+    if (input.graph) {
+      graph = input.graph;
+    } else if (input.route === 'plan') {
+      if (!this.llmCall) throw new Error('llmCall is required for route="plan"');
+      this.logger.info('Planning task graph with LLM...');
+      graph = await planTaskGraph({ task: input.task, availableRoles: roles, llmCall: this.llmCall });
+    } else {
+      graph = buildTaskGraph({ task: input.task, roles });
+    }
+
+    const validation = validateTaskGraph(graph);
+    if (!validation.valid) {
+      throw new Error(`Invalid TaskGraph: ${validation.errors.join('; ')}`);
+    }
+
+    this.logger.info(`Executing graph with ${graph.nodes.length} nodes`);
+
+    const results = await runTaskGraph({
+      runner: this.runner,
+      graph,
+      task: input.task,
+      runId,
+      roleAgents,
+      maxConcurrency: input.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY,
+      retries: input.retries ?? DEFAULT_RETRIES,
+      nodeTimeoutMs: input.nodeTimeoutMs ?? DEFAULT_TIMEOUT_MS,
+      artifactStore: this.artifactStore,
+      runContext: input.context,
+      logger: this.logger,
+    });
+
+    const aggregate = aggregateResults(results, input.aggregate ?? 'concat');
+    this.logger.info(`Orchestration run ${runId} completed`);
+
+    return { task: input.task, runId, roles, graph, results, aggregate };
+  }
+}

--- a/packages/orchestrator/src/planner.ts
+++ b/packages/orchestrator/src/planner.ts
@@ -1,0 +1,55 @@
+import type { TaskGraph, TeamRole } from './types';
+
+export interface PlannerOptions {
+  task: string;
+  availableRoles: TeamRole[];
+  /** 调用 LLM 的函数，由外部注入，解耦对 engine ai 模块的直接依赖 */
+  llmCall: (systemPrompt: string, userPrompt: string) => Promise<string>;
+}
+
+const SYSTEM_PROMPT = `你是一个 agent team 规划器。
+根据用户描述的任务，输出一个合理的 TaskGraph JSON，决定需要哪些角色、执行顺序和依赖关系。
+
+TaskGraph 格式：
+{
+  "nodes": [
+    {
+      "id": "唯一标识符",
+      "role": "角色名",
+      "deps": ["依赖的节点 id"],
+      "input": "该节点的具体任务描述（可选）",
+      "instruction": "该节点 agent 的执行指令（可选，用于差异化 prompt）",
+      "optional": true
+    }
+  ]
+}
+
+规则：
+- deps 必须引用已存在的节点 id，不能有环
+- 没有依赖关系的节点会并行执行
+- optional=true 的节点失败不会阻断后续流程
+- 只使用 availableRoles 中列出的角色
+- 直接输出 JSON，不要加任何说明文字`;
+
+export async function planTaskGraph(options: PlannerOptions): Promise<TaskGraph> {
+  const { task, availableRoles, llmCall } = options;
+
+  const userPrompt = `任务：${task}\n\n可用角色：${availableRoles.join(', ')}\n\n请输出 TaskGraph JSON：`;
+  const raw = (await llmCall(SYSTEM_PROMPT, userPrompt)).trim();
+
+  const jsonMatch = raw.match(/```(?:json)?\s*([\s\S]*?)```/) ?? null;
+  const jsonStr = jsonMatch ? jsonMatch[1].trim() : raw;
+
+  let graph: TaskGraph;
+  try {
+    graph = JSON.parse(jsonStr) as TaskGraph;
+  } catch {
+    throw new Error(`Planner returned invalid JSON: ${jsonStr.slice(0, 200)}`);
+  }
+
+  if (!Array.isArray(graph.nodes)) {
+    throw new Error('Planner returned invalid TaskGraph: missing nodes array');
+  }
+
+  return graph;
+}

--- a/packages/orchestrator/src/router.ts
+++ b/packages/orchestrator/src/router.ts
@@ -1,0 +1,21 @@
+import type { TeamRole } from './types';
+
+const DEFAULT_KEYWORDS = {
+  tester:   [/\btest\b/i, /\btesting\b/i, /\btests\b/i, /\bqa\b/i, /测试/, /用例/],
+  writer:   [/\bdoc\b/i, /\bdocs\b/i, /\bdocument\b/i, /\bdocumentation\b/i, /文档/, /说明/],
+  reviewer: [/\breview\b/i, /\bcode review\b/i, /评审/, /审查/],
+};
+
+export function routeRoles(task: string, availableRoles: TeamRole[]): TeamRole[] {
+  const roles = new Set<TeamRole>();
+  const t = task.toLowerCase();
+
+  if (availableRoles.includes('researcher')) roles.add('researcher');
+  if (availableRoles.includes('executor'))   roles.add('executor');
+
+  if (availableRoles.includes('reviewer') && DEFAULT_KEYWORDS.reviewer.some(r => r.test(t))) roles.add('reviewer');
+  if (availableRoles.includes('writer')   && DEFAULT_KEYWORDS.writer.some(r => r.test(t)))   roles.add('writer');
+  if (availableRoles.includes('tester')   && DEFAULT_KEYWORDS.tester.some(r => r.test(t)))   roles.add('tester');
+
+  return Array.from(roles);
+}

--- a/packages/orchestrator/src/runner.ts
+++ b/packages/orchestrator/src/runner.ts
@@ -1,0 +1,30 @@
+/**
+ * AgentRunner: 编排层与执行层之间的抽象边界。
+ * 编排层只知道"用哪个 agent 跑什么任务"，不感知底层是 engine、HTTP 还是其他实现。
+ */
+export interface AgentRunInput {
+  agentName: string;
+  task: string;
+  context?: Record<string, any>;
+}
+
+export interface AgentRunner {
+  /** 执行一个 agent，返回文本结果 */
+  run(input: AgentRunInput): Promise<string>;
+  /** 返回当前可用的 agent 名称列表 */
+  getAvailableAgents(): string[];
+}
+
+export interface OrchestratorLogger {
+  debug(message: string, meta?: any): void;
+  info(message: string, meta?: any): void;
+  warn(message: string, meta?: any): void;
+  error(message: string, error?: Error, meta?: any): void;
+}
+
+export const defaultLogger: OrchestratorLogger = {
+  debug: () => {},
+  info: (msg) => console.log(`[Orchestrator] ${msg}`),
+  warn: (msg) => console.warn(`[Orchestrator] ${msg}`),
+  error: (msg, err) => console.error(`[Orchestrator] ${msg}`, err ?? ''),
+};

--- a/packages/orchestrator/src/scheduler.ts
+++ b/packages/orchestrator/src/scheduler.ts
@@ -1,0 +1,158 @@
+import type { NodeResult, TaskGraph, TaskNode } from './types';
+import type { AgentRunner, OrchestratorLogger } from './runner';
+import type { ArtifactStore } from './artifact-store';
+
+export interface ScheduleOptions {
+  runner: AgentRunner;
+  graph: TaskGraph;
+  task: string;
+  runId: string;
+  roleAgents: Record<string, string>;
+  maxConcurrency: number;
+  retries: number;
+  nodeTimeoutMs: number;
+  artifactStore?: ArtifactStore;
+  runContext?: Record<string, any>;
+  logger: OrchestratorLogger;
+}
+
+export async function runTaskGraph(options: ScheduleOptions): Promise<Record<string, NodeResult>> {
+  const { graph, maxConcurrency, retries, nodeTimeoutMs, logger } = options;
+  const nodes = graph.nodes;
+  const results: Record<string, NodeResult> = {};
+
+  if (nodes.length === 0) return results;
+
+  const pending = new Set(nodes.map(n => n.id));
+  const inFlight = new Map<string, Promise<void>>();
+  const completed = new Set<string>();
+  const failed = new Set<string>();
+  const nodeById = new Map(nodes.map(n => [n.id, n]));
+
+  const canRun = (node: TaskNode) =>
+    failed.size === 0 && node.deps.every(dep => completed.has(dep));
+
+  const markSkipped = (node: TaskNode, reason: string) => {
+    const now = Date.now();
+    results[node.id] = { nodeId: node.id, role: node.role, status: 'skipped', attempts: 0, startedAt: now, endedAt: now, durationMs: 0, skippedReason: reason };
+    pending.delete(node.id);
+  };
+
+  const runNode = async (node: TaskNode) => {
+    const { runner, task, roleAgents, artifactStore, runId, runContext } = options;
+    const now = Date.now();
+    const result: NodeResult = { nodeId: node.id, role: node.role, status: 'failed', attempts: 0, startedAt: now, endedAt: now, durationMs: 0 };
+
+    const agentName = node.agent ?? roleAgents[node.role];
+    if (!agentName) {
+      const reason = `Missing agent for role ${node.role}`;
+      result.status = node.optional ? 'skipped' : 'failed';
+      result.error = reason;
+      result.skippedReason = node.optional ? reason : undefined;
+      result.endedAt = Date.now();
+      result.durationMs = result.endedAt - result.startedAt;
+      results[node.id] = result;
+      if (result.status === 'failed') failed.add(node.id);
+      return;
+    }
+
+    // 收集上游 artifact 文件路径
+    const depArtifacts = artifactStore
+      ? node.deps
+          .map(dep => {
+            const r = results[dep];
+            return r?.status === 'success'
+              ? { role: r.role, path: artifactStore.getPath(runId, dep) }
+              : null;
+          })
+          .filter((d): d is { role: string; path: string } => d !== null)
+      : [];
+
+    const depNote = depArtifacts.length > 0
+      ? '\n\n上游结果文件：\n' + depArtifacts.map(d => `- [${d.role}] ${d.path}`).join('\n') + '\n请先阅读上述文件，再执行任务。'
+      : '';
+
+    const taskInput = node.instruction
+      ? `${node.instruction}\n\n${node.input ?? task}${depNote}`
+      : `${node.input ?? task}${depNote}`;
+
+    const runOnce = async () => {
+      result.attempts += 1;
+      result.agentName = agentName;
+      const output = await runner.run({ agentName, task: taskInput, context: { task, role: node.role, nodeId: node.id, deps: node.deps, runContext } });
+      result.output = output;
+    };
+
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= retries; attempt++) {
+      try {
+        await withTimeout(runOnce(), nodeTimeoutMs);
+        result.status = 'success';
+        result.endedAt = Date.now();
+        result.durationMs = result.endedAt - result.startedAt;
+        results[node.id] = result;
+
+        if (artifactStore && result.output) {
+          try { await artifactStore.write(runId, node.id, node.role, result.output); } catch { /* non-fatal */ }
+        }
+
+        completed.add(node.id);
+        logger.info(`Node ${node.id} (${node.role}) completed in ${result.durationMs}ms`);
+        return;
+      } catch (err) {
+        lastError = err;
+      }
+    }
+
+    const msg = lastError instanceof Error ? lastError.message : String(lastError ?? 'Unknown error');
+    result.status = node.optional ? 'skipped' : 'failed';
+    result.error = msg;
+    result.skippedReason = node.optional ? msg : undefined;
+    result.endedAt = Date.now();
+    result.durationMs = result.endedAt - result.startedAt;
+    results[node.id] = result;
+    if (result.status === 'failed') {
+      failed.add(node.id);
+      logger.error(`Node ${node.id} (${node.role}) failed: ${msg}`);
+    }
+  };
+
+  while (pending.size > 0) {
+    const runnable = Array.from(pending)
+      .map(id => nodeById.get(id))
+      .filter((n): n is TaskNode => !!n && canRun(n));
+
+    if (runnable.length === 0) {
+      if (failed.size > 0) {
+        for (const id of pending) {
+          const node = nodeById.get(id);
+          if (node) markSkipped(node, 'Blocked by failed dependency');
+        }
+        break;
+      }
+      throw new Error('No runnable nodes; check DAG for cycles');
+    }
+
+    while (runnable.length > 0 && inFlight.size < maxConcurrency) {
+      const node = runnable.shift()!;
+      pending.delete(node.id);
+      const p = runNode(node).finally(() => inFlight.delete(node.id));
+      inFlight.set(node.id, p);
+    }
+
+    if (inFlight.size > 0) await Promise.race(inFlight.values());
+  }
+
+  if (inFlight.size > 0) await Promise.all(inFlight.values());
+  return results;
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  if (!ms || ms <= 0) return promise;
+  let id: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    id = setTimeout(() => reject(new Error('Node execution timed out')), ms);
+  });
+  try { return await Promise.race([promise, timeout]); }
+  finally { if (id) clearTimeout(id); }
+}

--- a/packages/orchestrator/src/types.ts
+++ b/packages/orchestrator/src/types.ts
@@ -1,0 +1,69 @@
+export type TeamRole =
+  | 'researcher'
+  | 'executor'
+  | 'reviewer'
+  | 'writer'
+  | 'tester'
+  | (string & {});
+
+export type TaskNodeStatus = 'success' | 'failed' | 'skipped';
+
+export interface TaskNode {
+  id: string;
+  role: TeamRole;
+  deps: string[];
+  input?: string;
+  optional?: boolean;
+  /** 覆盖该节点使用的 agent 名称（不填则从 roleAgents 映射查找） */
+  agent?: string;
+  /** node 粒度的 prompt 指令，会前置拼接到 task 中 */
+  instruction?: string;
+}
+
+export interface TaskGraph {
+  nodes: TaskNode[];
+}
+
+export interface NodeResult {
+  nodeId: string;
+  role: TeamRole;
+  status: TaskNodeStatus;
+  agentName?: string;
+  output?: string;
+  error?: string;
+  attempts: number;
+  startedAt: number;
+  endedAt: number;
+  durationMs: number;
+  skippedReason?: string;
+}
+
+export type AggregateStrategy = 'concat' | 'last';
+
+export interface OrchestrationInput {
+  task: string;
+  context?: Record<string, any>;
+  /** 明确指定角色列表 */
+  roles?: TeamRole[];
+  /** 直接传入自定义 TaskGraph（优先级最高） */
+  graph?: TaskGraph;
+  /** auto=关键词路由, all=全角色, plan=LLM动态规划 */
+  route?: 'auto' | 'all' | 'plan';
+  includeRoles?: TeamRole[];
+  excludeRoles?: TeamRole[];
+  /** 角色到 agent 名称的映射，可覆盖默认 registry */
+  roleAgents?: Record<string, string>;
+  maxConcurrency?: number;
+  nodeTimeoutMs?: number;
+  retries?: number;
+  aggregate?: AggregateStrategy;
+}
+
+export interface OrchestrationResult {
+  task: string;
+  runId: string;
+  roles: TeamRole[];
+  graph: TaskGraph;
+  results: Record<string, NodeResult>;
+  aggregate: string;
+}

--- a/packages/orchestrator/tsconfig.json
+++ b/packages/orchestrator/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/orchestrator/tsup.config.ts
+++ b/packages/orchestrator/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  splitting: false,
+  sourcemap: true,
+  target: 'es2022'
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,6 +326,28 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@25.0.10)
 
+  packages/orchestrator:
+    dependencies:
+      pulse-coder-engine:
+        specifier: workspace:*
+        version: link:../engine
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^25.0.10
+        version: 25.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@25.0.10)
+
   packages/plugin-kit:
     dependencies:
       pulse-coder-engine:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,8 @@
     "allowSyntheticDefaultImports": true,
     "noEmit": true,
     "paths": {
+      "pulse-coder-orchestrator": ["./packages/orchestrator/src/index.ts"],
+      "pulse-coder-orchestrator/*": ["./packages/orchestrator/src/*"],
       "pulse-coder-engine": ["./packages/engine/src/index.ts"],
       "pulse-coder-engine/*": ["./packages/engine/src/*"],
       "pulse-coder-plugin-kit": ["./packages/plugin-kit/src/index.ts"],


### PR DESCRIPTION
- 新增 artifact-store.ts：ArtifactStore 接口 + LocalArtifactStore 实现，节点产物写入 .pulse-coder/agent-teams/{runId}/{nodeId}.md
- scheduler 集成 artifact store：节点成功后写文件，下游节点 input 注入上游文件路径提示
- TaskNode 新增 instruction 字段，支持 node 粒度 prompt 差异化
- graph.ts 修复默认串行依赖：reviewer/writer/tester 改为共同依赖 executor，三者互相并行

https://claude.ai/code/session_011SQqTZHi9dSuoCSYBwG5og