### PR TITLE
Add read deduplication warnings and file exploration constraints

### DIFF
--- a/packages/engine/src/ai/index.ts
+++ b/packages/engine/src/ai/index.ts
@@ -7,6 +7,14 @@ import type { Tool as CoderTool, ToolExecutionContext, LLMProviderFactory, Syste
 
 const providerOptions = { openai: { store: false, reasoningEffort: OPENAI_REASONING_EFFORT } }
 
+const GPT_EXPLORATION_CONSTRAINT = `
+## File exploration discipline
+- Read only the files that are directly required for the current task. Do not speculatively explore the codebase.
+- Never read the same file more than once unless you have a specific reason to re-verify changed content.
+- Start acting as soon as you have sufficient context; do not keep exploring for completeness or reassurance.
+- Prefer targeted reads (specific file you know you need) over broad directory listings.
+`.trim();
+
 /** Resolve a SystemPromptOption into a final string. */
 const resolveSystemPrompt = (option: SystemPromptOption | undefined): string => {
   const base = generateSystemPrompt();
@@ -97,9 +105,10 @@ export const streamTextAI = (messages: ModelMessage[], tools: Record<string, Cod
     : messages;
 
   const baseSystemPrompt = resolveSystemPrompt(options?.systemPrompt);
+  const gptExtra = options?.modelType !== 'claude' ? `\n\n${GPT_EXPLORATION_CONSTRAINT}` : '';
   const finalSystemPrompt = extraSystemParts.length > 0
-    ? `${baseSystemPrompt}\n\n${extraSystemParts.join('\n\n')}`
-    : baseSystemPrompt;
+    ? `${baseSystemPrompt}${gptExtra}\n\n${extraSystemParts.join('\n\n')}`
+    : `${baseSystemPrompt}${gptExtra}`;
 
   return streamText({
     model: provider(model),

--- a/packages/engine/src/core/loop.ts
+++ b/packages/engine/src/core/loop.ts
@@ -60,6 +60,40 @@ export interface LoopOptions {
   hooks?: LoopHooks;
 }
 
+/**
+ * Wraps read/ls tools to warn the model when it accesses the same path more than once.
+ * The seenPaths map persists for the lifetime of a single loop() call.
+ */
+function wrapToolsWithReadDedup(
+  tools: Record<string, Tool>,
+  seenPaths: Map<string, number>,
+): Record<string, Tool> {
+  const READ_TOOL_NAMES = new Set(['read', 'ls']);
+  const wrapped: Record<string, Tool> = {};
+  for (const [name, t] of Object.entries(tools)) {
+    if (!READ_TOOL_NAMES.has(name)) {
+      wrapped[name] = t;
+      continue;
+    }
+    wrapped[name] = {
+      ...t,
+      execute: async (input: any, ctx: any) => {
+        const pathKey = input?.filePath ?? input?.path ?? name;
+        const count = seenPaths.get(pathKey) ?? 0;
+        seenPaths.set(pathKey, count + 1);
+        const output = await t.execute(input, ctx);
+        if (count > 0) {
+          const note = `[You have already accessed "${pathKey}" ${count} time(s) in this session. Avoid redundant reads unless strictly necessary.]`;
+          if (typeof output === 'string') return `${output}\n${note}`;
+          if (output && typeof output === 'object') return { ...output, _note: note };
+        }
+        return output;
+      },
+    };
+  }
+  return wrapped;
+}
+
 /** Wraps tools so each execute() passes through beforeToolCall / afterToolCall hooks. */
 function wrapToolsWithHooks(
   tools: Record<string, Tool>,
@@ -176,6 +210,7 @@ export async function loop(context: Context, options?: LoopOptions): Promise<str
   let errorCount = 0;
   let totalSteps = 0;
   let compactionAttempts = 0;
+  const seenPaths = new Map<string, number>();
 
   const loopHooks = options?.hooks ?? {};
 
@@ -229,6 +264,9 @@ export async function loop(context: Context, options?: LoopOptions): Promise<str
           }
         }
       }
+
+      // Inject read/ls deduplication warnings
+      tools = wrapToolsWithReadDedup(tools, seenPaths);
 
       // Wrap tools with beforeToolCall / afterToolCall hooks
       const beforeToolHooks = loopHooks.beforeToolCall ?? [];

--- a/packages/engine/src/prompt/system.ts
+++ b/packages/engine/src/prompt/system.ts
@@ -60,7 +60,7 @@ Exception: If working within an existing website or design system, preserve the 
 You are producing plain text that will later be styled by the CLI. Follow these rules exactly. Formatting should make results easy to scan, but not feel mechanical. Use judgment to decide how much structure adds value.
 
 - Default: be very concise; friendly coding teammate tone.
-- Default: do the work without asking questions. Treat short tasks as sufficient direction; infer missing details by reading the codebase and following existing conventions.
+- Default: do the work without asking questions. Treat short tasks as sufficient direction; infer missing details by following existing conventions, reading only the files directly relevant to the task.
 - Questions: only ask when you are truly blocked after checking relevant context AND you cannot safely pick a reasonable default. This usually means one of:
   * The request is ambiguous in a way that materially changes the result and you cannot disambiguate by reading the repo.
   * The action is destructive/irreversible, touches production, or changes billing/security posture.
@@ -81,7 +81,7 @@ Use the 'clarify' tool when you genuinely need information from the user to proc
 **When NOT to use clarify:**
 - For trivial decisions you can make based on codebase conventions or common practices
 - For permission questions like "Should I proceed?" (just proceed with the best option)
-- For information that's likely in the codebase, configuration files, or documentation (read those first)
+- For information that's likely in the codebase, configuration files, or documentation (check those if needed, but only what's directly relevant)
 - Multiple times in a row - complete all non-blocked work first, then ask one clear question
 - For choices where a reasonable default exists (use the default and mention what you chose)
 


### PR DESCRIPTION
## Summary
This PR improves the AI model's file exploration behavior by adding warnings when the same file is read multiple times within a single loop, and by introducing explicit constraints to discourage speculative codebase exploration.

## Key Changes

- **Read deduplication warnings**: Added `wrapToolsWithReadDedup()` function that tracks file paths accessed via `read` and `ls` tools during a loop execution. When a path is accessed more than once, the model receives a warning appended to the tool output, encouraging it to avoid redundant reads.

- **File exploration constraints**: Introduced `GPT_EXPLORATION_CONSTRAINT` prompt guidance that is injected into the system prompt for non-Claude models. This constraint emphasizes:
  - Reading only directly required files, not speculative exploration
  - Avoiding duplicate file reads unless necessary
  - Acting promptly once sufficient context is available
  - Preferring targeted reads over broad directory listings

- **System prompt refinements**: Updated existing system prompt guidance to emphasize reading "only the files directly relevant to the task" rather than general codebase exploration, and clarified when the `clarify` tool should be used.

## Implementation Details

- The `seenPaths` map is created fresh for each `loop()` call and persists across all tool invocations within that loop
- Read deduplication wrapping is applied before hook wrapping to ensure warnings are included in hook contexts
- The exploration constraint is conditionally applied only to GPT models (not Claude), allowing for model-specific guidance
- Warnings are appended to string outputs or added as `_note` field to object outputs to preserve tool output structure

https://claude.ai/code/session_01Hxf6SimU8AjvCy4UzUFx9z