### PR TITLE
Enforce structured output format for all sub-agent final responses

### DIFF
--- a/.pulse-coder/agents/executor.md
+++ b/.pulse-coder/agents/executor.md
@@ -19,10 +19,14 @@ You are a code execution agent. Make precise, minimal code changes.
 3. `edit` to apply changes.
 4. `bash` to build/typecheck.
 
-## Output format
+## Output format (MANDATORY — your final message MUST use this exact structure)
 
 ### Changes
-- <file>: <what changed>
+- <file:line>: <what changed and why>
 
 ### Verification
 - Build: pass/fail
+- Command: <the exact command you ran>
+
+### Summary
+- <1-2 sentences: what was implemented and how it works>

--- a/.pulse-coder/agents/researcher.md
+++ b/.pulse-coder/agents/researcher.md
@@ -19,7 +19,7 @@ You are a **read-only** research agent. Investigate code and report findings.
 2. `read` the 1-3 most relevant files (only the sections you need).
 3. Write your report.
 
-## Output format
+## Output format (MANDATORY — your final message MUST use this exact structure)
 
 ### Findings
 - <what you found, with file:line references>

--- a/.pulse-coder/agents/reviewer.md
+++ b/.pulse-coder/agents/reviewer.md
@@ -26,7 +26,7 @@ You are a **read-only** code review agent. Review changes and report issues.
 - **Types**: type safety, any casts, missing null checks
 - **Style**: consistency with surrounding code
 
-## Output format
+## Output format (MANDATORY — your final message MUST use this exact structure)
 
 ### Must fix
 - <blocking issues>

--- a/.pulse-coder/agents/tester.md
+++ b/.pulse-coder/agents/tester.md
@@ -19,7 +19,7 @@ You are a testing agent. Write focused tests for the code changes described in u
 3. `write` or `edit` test file(s).
 4. `bash` to run tests and confirm they pass.
 
-## Output format
+## Output format (MANDATORY — your final message MUST use this exact structure)
 
 ### Tests added
 - <test file>: <what scenarios are covered>

--- a/.pulse-coder/agents/writer.md
+++ b/.pulse-coder/agents/writer.md
@@ -18,7 +18,7 @@ You are a documentation agent. Write or update docs to reflect code changes.
 2. `grep`/`read` any existing doc files that need updating.
 3. `edit` to update docs, or `write` if a new file is required.
 
-## Output format
+## Output format (MANDATORY — your final message MUST use this exact structure)
 
 ### Updated
 - <file>: <what changed>

--- a/packages/engine/src/prompt/agent-base.ts
+++ b/packages/engine/src/prompt/agent-base.ts
@@ -13,4 +13,4 @@ export const AGENT_BASE_RULES = `## Tool discipline
 ## Output discipline
 - Be concise. Lead with actions and results, not explanations.
 - Do not repeat the task description back.
-- When done, summarize what you did in a few bullet points.`;
+- **Your FINAL message MUST follow the "Output format" section in your role prompt exactly.** This is critical — downstream agents depend on your structured output. Never end with a casual one-liner.`;


### PR DESCRIPTION
Sub-agents (especially executor) were returning casual one-liners instead of following the defined Output format, causing downstream nodes to receive useless context. Strengthened AGENT_BASE_RULES and all 5 agent prompts to make the output format mandatory.

https://claude.ai/code/session_01NZki5cD4cHqfjVZGTHNctV