### PR TITLE
Fix race condition in file watcher initialization

### DIFF
--- a/apps/canvas-workspace/src/main/file-watcher.ts
+++ b/apps/canvas-workspace/src/main/file-watcher.ts
@@ -8,6 +8,7 @@ const DEBOUNCE_MS = 300;
 
 let activeWatcher: FSWatcher | null = null;
 let activeWorkspaceId: string | null = null;
+let watchGeneration = 0;
 const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 function sendToRenderer(channel: string, payload: unknown): void {
@@ -15,6 +16,7 @@ function sendToRenderer(channel: string, payload: unknown): void {
 }
 
 function stopWatcher(): void {
+  ++watchGeneration;
   if (activeWatcher) {
     activeWatcher.close();
     activeWatcher = null;
@@ -27,9 +29,15 @@ function stopWatcher(): void {
 function startWatcher(workspaceId: string): void {
   stopWatcher();
 
+  // Increment generation so stale async callbacks become no-ops
+  const gen = ++watchGeneration;
   const notesDir = join(STORE_DIR, workspaceId, 'notes');
 
   void fs.mkdir(notesDir, { recursive: true }).then(() => {
+    // Guard: if another startWatcher/stopWatcher call happened while we were
+    // awaiting mkdir, this callback is stale — bail out to avoid orphaned watchers.
+    if (gen !== watchGeneration) return;
+
     activeWorkspaceId = workspaceId;
 
     try {


### PR DESCRIPTION
## Summary
Fixes a race condition in the file watcher that could result in orphaned watchers when `startWatcher()` is called multiple times in quick succession.

## Key Changes
- Added `watchGeneration` counter to track the current watcher lifecycle
- Increment generation counter in `stopWatcher()` to invalidate any pending async operations
- Capture generation at the start of `startWatcher()` and validate it after async `mkdir()` completes
- Guard against stale callbacks by bailing out if the generation has changed, preventing orphaned watchers from being created

## Implementation Details
The fix uses a generation-based approach to handle the async nature of the watcher initialization. When `startWatcher()` is called while a previous initialization is still pending (awaiting `mkdir()`), the new call increments the generation counter. The stale callback from the previous call detects this mismatch and returns early, preventing it from creating a watcher that would never be properly cleaned up.

https://claude.ai/code/session_01W41ep6U98DWieQr5J4yDnT