### PR TITLE
fix: disable FileWatcher to unblock canvas editing

### DIFF
--- a/apps/canvas-workspace/src/main/file-watcher.ts
+++ b/apps/canvas-workspace/src/main/file-watcher.ts
@@ -6,6 +6,13 @@ import { homedir } from 'os';
 const STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
 const DEBOUNCE_MS = 300;
 
+/**
+ * FileWatcher is currently disabled to diagnose canvas editing issues.
+ * Set to `true` to re-enable watching workspace notes directories for
+ * external file changes.
+ */
+const FILE_WATCHER_ENABLED = false;
+
 let activeWatcher: FSWatcher | null = null;
 let activeWorkspaceId: string | null = null;
 let watchGeneration = 0;
@@ -27,6 +34,11 @@ function stopWatcher(): void {
 }
 
 function startWatcher(workspaceId: string): void {
+  if (!FILE_WATCHER_ENABLED) {
+    activeWorkspaceId = workspaceId;
+    return;
+  }
+
   stopWatcher();
 
   // Increment generation so stale async callbacks become no-ops


### PR DESCRIPTION
FileWatcher is temporarily disabled via FILE_WATCHER_ENABLED flag to diagnose whether it is the root cause of the inability to add nodes and modify files in the canvas workspace. The flag can be flipped back to true once the issue is resolved.

https://claude.ai/code/session_01W41ep6U98DWieQr5J4yDnT