### PR TITLE
fix: prevent canvas state reset on every render due to unstable useEf…

### DIFF
--- a/apps/canvas-workspace/src/main/file-watcher.ts
+++ b/apps/canvas-workspace/src/main/file-watcher.ts
@@ -11,7 +11,7 @@ const DEBOUNCE_MS = 300;
  * Set to `true` to re-enable watching workspace notes directories for
  * external file changes.
  */
-const FILE_WATCHER_ENABLED = false;
+const FILE_WATCHER_ENABLED = true;
 
 let activeWatcher: FSWatcher | null = null;
 let activeWorkspaceId: string | null = null;

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
@@ -12,6 +12,8 @@ export const useNodes = (
 ) => {
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const transformRef = useRef<CanvasTransform>({ x: 0, y: 0, scale: 1 });
+  const onRestoreTransformRef = useRef(onRestoreTransform);
+  onRestoreTransformRef.current = onRestoreTransform;
 
   const scheduleSave = useCallback(() => {
     if (saveTimer.current) clearTimeout(saveTimer.current);
@@ -92,8 +94,8 @@ export const useNodes = (
           historyRef.current = [[]];
           historyIndexRef.current = 0;
         }
-        if (saved.transform && onRestoreTransform) {
-          onRestoreTransform(saved.transform);
+        if (saved.transform && onRestoreTransformRef.current) {
+          onRestoreTransformRef.current(saved.transform);
         }
       } else {
         historyRef.current = [[]];
@@ -101,7 +103,8 @@ export const useNodes = (
       }
       setLoaded(true);
     });
-  }, [canvasId, onRestoreTransform]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [canvasId]);
 
   const addNode = useCallback(
     (type: CanvasNode['type'], x: number, y: number) => {


### PR DESCRIPTION
…fect dep

Root cause: Canvas passes `() => {}` (inline function) as onRestoreTransform to useNodes. Since inline functions create a new reference on every render, the load-from-disk useEffect (which had onRestoreTransform in its deps) was re-firing after every single render — reloading stale data from canvas.json and resetting all in-memory state before the debounced save could persist it.

This made adding nodes and editing files appear broken: changes would be immediately overwritten by the stale disk data on the next render cycle.

Fix: store onRestoreTransform in a ref and remove it from the useEffect dependency array so the load effect only fires when canvasId changes.

Also re-enables FileWatcher (with generation guard from prior commit).

https://claude.ai/code/session_01W41ep6U98DWieQr5J4yDnT