### PR TITLE
fix: disable FileWatcher on both main and renderer sides

### DIFF
--- a/apps/canvas-workspace/src/main/file-watcher.ts
+++ b/apps/canvas-workspace/src/main/file-watcher.ts
@@ -11,7 +11,7 @@ const DEBOUNCE_MS = 300;
  * Set to `true` to re-enable watching workspace notes directories for
  * external file changes.
  */
-const FILE_WATCHER_ENABLED = true;
+const FILE_WATCHER_ENABLED = false;
 
 let activeWatcher: FSWatcher | null = null;
 let activeWorkspaceId: string | null = null;

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
@@ -44,33 +44,34 @@ export const useNodes = (
     [scheduleSave]
   );
 
-  // Start watching the workspace notes directory for external file changes (e.g. from MCP writes).
-  // Only updates nodes that are not currently being edited by the user (modified === false).
-  useEffect(() => {
-    const storeApi = window.canvasWorkspace?.store;
-    const fileApi = window.canvasWorkspace?.file;
-    if (!storeApi || !fileApi) return;
-
-    void storeApi.watchWorkspace(canvasId);
-
-    const cleanup = fileApi.onChanged((filePath, content) => {
-      const node = nodesRef.current.find(
-        (n) =>
-          n.type === 'file' &&
-          (n.data as FileNodeData).filePath === filePath &&
-          !(n.data as FileNodeData).modified
-      );
-      if (!node) return;
-      const updated = nodesRef.current.map((n) =>
-        n.id === node.id
-          ? { ...n, data: { ...(n.data as FileNodeData), content, modified: false } }
-          : n
-      );
-      applyNodes(updated, false);
-    });
-
-    return cleanup;
-  }, [canvasId, applyNodes, nodesRef]);
+  // File-watcher sync is temporarily disabled.  The fs.watch-based watcher
+  // introduced race conditions with user edits (the onChanged callback could
+  // call applyNodes with stale nodesRef.current, reverting in-flight changes).
+  // To re-enable, flip FILE_WATCHER_ENABLED in file-watcher.ts and uncomment
+  // the block below.
+  //
+  // useEffect(() => {
+  //   const storeApi = window.canvasWorkspace?.store;
+  //   const fileApi = window.canvasWorkspace?.file;
+  //   if (!storeApi || !fileApi) return;
+  //   void storeApi.watchWorkspace(canvasId);
+  //   const cleanup = fileApi.onChanged((filePath, content) => {
+  //     const node = nodesRef.current.find(
+  //       (n) =>
+  //         n.type === 'file' &&
+  //         (n.data as FileNodeData).filePath === filePath &&
+  //         !(n.data as FileNodeData).modified
+  //     );
+  //     if (!node) return;
+  //     const updated = nodesRef.current.map((n) =>
+  //       n.id === node.id
+  //         ? { ...n, data: { ...(n.data as FileNodeData), content, modified: false } }
+  //         : n
+  //     );
+  //     applyNodes(updated, false);
+  //   });
+  //   return cleanup;
+  // }, [canvasId, applyNodes, nodesRef]);
 
   useEffect(() => {
     const api = window.canvasWorkspace?.store;


### PR DESCRIPTION
Two independent issues were causing canvas editing to break:

1. (Prior commit) The load-from-disk useEffect had onRestoreTransform in its deps — an inline `() => {}` that changed every render, causing the effect to reload stale data from canvas.json on every re-render and overwrite in-memory state before the debounced save could persist it.

2. (This commit) The FileWatcher's onChanged callback races with user operations: when createNote/persistToFile writes to disk, the watcher fires ~300ms later and calls applyNodes with a snapshot built from potentially stale nodesRef.current, reverting the user's in-flight changes (new nodes disappear, edits revert).

Disables the watcher on both sides:
- Main: FILE_WATCHER_ENABLED = false (no FSWatcher created)
- Renderer: comment out the watchWorkspace + onChanged useEffect entirely

https://claude.ai/code/session_01W41ep6U98DWieQr5J4yDnT