### PR TITLE
Add workspace isolation to terminal sessions via environment variable

### DIFF
--- a/apps/canvas-workspace/src/main/pty-manager.ts
+++ b/apps/canvas-workspace/src/main/pty-manager.ts
@@ -50,9 +50,9 @@ export const setupPtyIpc = () => {
     "pty:spawn",
     (
       _event,
-      payload: { id: string; cols?: number; rows?: number; cwd?: string }
+      payload: { id: string; cols?: number; rows?: number; cwd?: string; workspaceId?: string }
     ) => {
-      const { id, cols = 80, rows = 24, cwd } = payload;
+      const { id, cols = 80, rows = 24, cwd, workspaceId } = payload;
 
       if (sessions.has(id)) {
         return { ok: true, reused: true };
@@ -60,12 +60,18 @@ export const setupPtyIpc = () => {
 
       try {
         const shell = defaultShell();
+        const spawnEnv: Record<string, string> = {
+          ...(process.env as Record<string, string>),
+        };
+        if (workspaceId) {
+          spawnEnv.CURRENT_WORKSPACE_ID = workspaceId;
+        }
         const proc = pty.spawn(shell, [], {
           name: "xterm-256color",
           cols,
           rows,
           cwd: cwd || homedir(),
-          env: process.env as Record<string, string>
+          env: spawnEnv
         });
 
         sessions.set(id, proc);

--- a/apps/canvas-workspace/src/preload/index.ts
+++ b/apps/canvas-workspace/src/preload/index.ts
@@ -16,8 +16,8 @@ contextBridge.exposeInMainWorld("canvasWorkspace", {
   version: "0.1.0",
 
   pty: {
-    spawn: (id: string, cols?: number, rows?: number, cwd?: string) =>
-      ipcRenderer.invoke("pty:spawn", { id, cols, rows, cwd }),
+    spawn: (id: string, cols?: number, rows?: number, cwd?: string, workspaceId?: string) =>
+      ipcRenderer.invoke("pty:spawn", { id, cols, rows, cwd, workspaceId }),
 
     write: (id: string, data: string) =>
       ipcRenderer.send("pty:write", { id, data }),

--- a/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody/index.tsx
@@ -196,9 +196,8 @@ export const TerminalNodeBody = ({ node, allNodes, rootFolder, workspaceId, work
       const filePath = selected.type === 'file'
         ? (selected.data as FileNodeData).filePath
         : undefined;
-      const mention = filePath
-        ? `[@canvas-node:${selected.type}:${selected.id}](${filePath})`
-        : `[@canvas-node:${selected.type}:${selected.id}](${selected.title})`;
+      const label = filePath ? filePath.split('/').pop() : selected.title;
+      const mention = `@[${label}](canvas:${selected.id})`;
       void api.write(sessionId, mention);
     }
     termRef.current?.focus();

--- a/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useCallback, useState } from 'react';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
-import type { CanvasNode, TerminalNodeData } from '../../types';
+import type { CanvasNode, FileNodeData, TerminalNodeData } from '../../types';
 import { TERMINAL_OPTIONS } from '../../config/terminalTheme';
 import { AI_TOOL_PATTERN, writeCanvasContext } from '../../utils/canvasContextWriter';
 import { NodeMentionPicker } from '../NodeMentionPicker';
@@ -106,7 +106,7 @@ export const TerminalNodeBody = ({ node, allNodes, rootFolder, workspaceId, work
     }
 
     const spawnCwd = initialCwd.current || rootFolder || undefined;
-    const result = await api.spawn(sessionId, term.cols, term.rows, spawnCwd);
+    const result = await api.spawn(sessionId, term.cols, term.rows, spawnCwd, workspaceIdRef.current);
     if (!result.ok) {
       term.writeln(`\x1b[31mFailed to spawn shell: ${result.error}\x1b[0m`);
       return;
@@ -192,7 +192,15 @@ export const TerminalNodeBody = ({ node, allNodes, rootFolder, workspaceId, work
   const handleMentionSelect = useCallback((selected: CanvasNode) => {
     setPickerOpen(false);
     const api = window.canvasWorkspace?.pty;
-    if (api) void api.write(sessionId, selected.title);
+    if (api) {
+      const filePath = selected.type === 'file'
+        ? (selected.data as FileNodeData).filePath
+        : undefined;
+      const mention = filePath
+        ? `[@canvas-node:${selected.type}:${selected.id}](${filePath})`
+        : `[@canvas-node:${selected.type}:${selected.id}](${selected.title})`;
+      void api.write(sessionId, mention);
+    }
     termRef.current?.focus();
   }, [sessionId]);
 

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -98,7 +98,8 @@ export interface CanvasWorkspaceApi {
       id: string,
       cols?: number,
       rows?: number,
-      cwd?: string
+      cwd?: string,
+      workspaceId?: string
     ) => Promise<{ ok: boolean; pid?: number; error?: string; reused?: boolean }>;
     write: (id: string, data: string) => void;
     resize: (id: string, cols: number, rows: number) => void;

--- a/apps/canvas-workspace/src/renderer/src/utils/canvasContextWriter.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/canvasContextWriter.ts
@@ -101,15 +101,20 @@ const writeCanvasAgentsMd = async (
   await fileApi.write(`${canvasDir}/AGENTS.md`, updated);
 };
 
-const buildPointerSection = (canvasDir: string, wsId: string, label: string): string =>
-  [
+const buildPointerSection = (canvasDir: string, wsId: string, label: string): string => {
+  const lines = [
     `## Pulse Canvas (${label})`,
     '',
     `Canvas agent config: \`${canvasDir}/AGENTS.md\``,
     '',
     '> 读取上方文件获取画布结构、笔记列表和 Agent 指令。',
     '',
-  ].join('\n');
+    `**Workspace Isolation:** Environment variable \`CURRENT_WORKSPACE_ID=${wsId}\` is injected into this terminal.`,
+    'Always use this workspace ID when calling canvas MCP tools to avoid cross-canvas reads/writes.',
+    '',
+  ];
+  return lines.join('\n');
+};
 
 export const writeCanvasContext = async (
   nodes: CanvasNode[],

--- a/apps/canvas-workspace/src/renderer/src/utils/canvasContextWriter.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/canvasContextWriter.ts
@@ -36,6 +36,13 @@ const buildCanvasContext = (
     `Folder: ${workspaceFolder}`,
   ];
 
+  if (workspaceId) {
+    lines.push('', '## Workspace Isolation');
+    lines.push('', `Environment variable \`CURRENT_WORKSPACE_ID=${workspaceId}\` is injected into this terminal session.`);
+    lines.push('Use this to scope all canvas operations to the current workspace and avoid reading/writing nodes from other canvases.');
+    lines.push('When calling MCP canvas tools, always pass this workspace ID to ensure isolation.');
+  }
+
   if (canvasDir) {
     lines.push(`Canvas dir: ${canvasDir}`);
     lines.push(`Canvas data: ${canvasDir}/canvas.json`);


### PR DESCRIPTION
## Summary
This PR implements workspace isolation for terminal sessions by injecting a `CURRENT_WORKSPACE_ID` environment variable into spawned shells. This allows canvas operations to be scoped to the current workspace and prevents accidental reads/writes from other canvases.

## Key Changes
- **Environment Variable Injection**: The `CURRENT_WORKSPACE_ID` environment variable is now passed to spawned PTY sessions, enabling workspace-scoped operations
- **Documentation Updates**: Added workspace isolation guidance to canvas context documentation in both the main context section and pointer sections
- **Terminal Node Improvements**: Enhanced node mention functionality to generate proper canvas references with format `@[label](canvas:nodeId)` instead of just the node title
- **API Updates**: Updated the `spawn` method signature across the IPC layer (preload, main process, and renderer) to accept and pass through the `workspaceId` parameter

## Implementation Details
- The workspace ID is injected into the PTY environment by merging it into the spawn options before creating the process
- Documentation now explicitly instructs users to pass the workspace ID when calling MCP canvas tools
- Node mentions in the terminal now properly format file paths and generate clickable canvas references
- The changes maintain backward compatibility by making the `workspaceId` parameter optional throughout the call chain

https://claude.ai/code/session_0172rmCTP4fJgiiftmX4JgEN