### PR TITLE
Add canvas CLI and agent skill support for workspace automation

### DIFF
--- a/apps/canvas-workspace/src/main/index.ts
+++ b/apps/canvas-workspace/src/main/index.ts
@@ -8,6 +8,7 @@ import { setupFileManagerIpc } from "./file-manager";
 import { startMCPServer } from "./mcp-server";
 import { ensureMCPRegistered } from "./mcp-registration";
 import { setupFileWatcherIpc, teardownFileWatcher } from "./file-watcher";
+import { setupSkillInstallerIpc } from "./skill-installer";
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const preloadPath = join(currentDir, "../preload/index.mjs");
@@ -100,6 +101,7 @@ app.whenReady().then(() => {
   setupCanvasStoreIpc();
   setupFileManagerIpc();
   setupFileWatcherIpc();
+  setupSkillInstallerIpc();
   startMCPServer();
   void ensureMCPRegistered();
 

--- a/apps/canvas-workspace/src/main/pty-manager.ts
+++ b/apps/canvas-workspace/src/main/pty-manager.ts
@@ -50,9 +50,9 @@ export const setupPtyIpc = () => {
     "pty:spawn",
     (
       _event,
-      payload: { id: string; cols?: number; rows?: number; cwd?: string }
+      payload: { id: string; cols?: number; rows?: number; cwd?: string; workspaceId?: string }
     ) => {
-      const { id, cols = 80, rows = 24, cwd } = payload;
+      const { id, cols = 80, rows = 24, cwd, workspaceId } = payload;
 
       if (sessions.has(id)) {
         return { ok: true, reused: true };
@@ -60,12 +60,18 @@ export const setupPtyIpc = () => {
 
       try {
         const shell = defaultShell();
+        const env: Record<string, string> = {
+          ...(process.env as Record<string, string>),
+        };
+        if (workspaceId) {
+          env.PULSE_CANVAS_WORKSPACE_ID = workspaceId;
+        }
         const proc = pty.spawn(shell, [], {
           name: "xterm-256color",
           cols,
           rows,
           cwd: cwd || homedir(),
-          env: process.env as Record<string, string>
+          env,
         });
 
         sessions.set(id, proc);

--- a/apps/canvas-workspace/src/main/skill-installer.ts
+++ b/apps/canvas-workspace/src/main/skill-installer.ts
@@ -15,37 +15,39 @@ version: 1.0.0
 
 Interact with canvas workspaces via the \`pulse-canvas\` CLI. The canvas is a shared workspace between humans and agents.
 
+The current workspace ID is available via \`$PULSE_CANVAS_WORKSPACE_ID\` environment variable (auto-set by canvas). All \`node\` and \`context\` commands use it automatically — no need to pass workspace ID explicitly.
+
 ## Core Commands
 
 ### Read workspace context (start here)
 \`\`\`bash
-pulse-canvas context <workspaceId> --format json
+pulse-canvas context --format json
 \`\`\`
 Returns all nodes with structured info: file paths, frame groups, labels.
 
-### List workspaces
-\`\`\`bash
-pulse-canvas workspace list --format json
-\`\`\`
-
 ### List nodes
 \`\`\`bash
-pulse-canvas node list <workspaceId> --format json
+pulse-canvas node list --format json
 \`\`\`
 
 ### Read a node
 \`\`\`bash
-pulse-canvas node read <workspaceId> <nodeId> --format json
+pulse-canvas node read <nodeId> --format json
 \`\`\`
 
 ### Write to a node
 \`\`\`bash
-pulse-canvas node write <workspaceId> <nodeId> --content "..."
+pulse-canvas node write <nodeId> --content "..."
 \`\`\`
 
 ### Create a node
 \`\`\`bash
-pulse-canvas node create <workspaceId> --type file --title "Report" --data '{"content":"..."}'
+pulse-canvas node create --type file --title "Report" --data '{"content":"..."}'
+\`\`\`
+
+### List workspaces
+\`\`\`bash
+pulse-canvas workspace list --format json
 \`\`\`
 
 ## Usage Principles

--- a/apps/canvas-workspace/src/main/skill-installer.ts
+++ b/apps/canvas-workspace/src/main/skill-installer.ts
@@ -1,0 +1,106 @@
+import { ipcMain } from 'electron';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+const SKILLS_DIR = join(homedir(), '.pulse-coder', 'skills', 'canvas');
+
+const SKILL_CONTENT = `---
+name: canvas
+description: Operate Pulse Canvas workspaces — read user-curated context, write results, create nodes
+version: 1.0.0
+---
+
+# Pulse Canvas
+
+Interact with canvas workspaces via the \`pulse-canvas\` CLI. The canvas is a shared workspace between humans and agents.
+
+## Core Commands
+
+### Read workspace context (start here)
+\`\`\`bash
+pulse-canvas context <workspaceId> --format json
+\`\`\`
+Returns all nodes with structured info: file paths, frame groups, labels.
+
+### List workspaces
+\`\`\`bash
+pulse-canvas workspace list --format json
+\`\`\`
+
+### List nodes
+\`\`\`bash
+pulse-canvas node list <workspaceId> --format json
+\`\`\`
+
+### Read a node
+\`\`\`bash
+pulse-canvas node read <workspaceId> <nodeId> --format json
+\`\`\`
+
+### Write to a node
+\`\`\`bash
+pulse-canvas node write <workspaceId> <nodeId> --content "..."
+\`\`\`
+
+### Create a node
+\`\`\`bash
+pulse-canvas node create <workspaceId> --type file --title "Report" --data '{"content":"..."}'
+\`\`\`
+
+## Usage Principles
+- Before starting a task, run \`context\` to understand the user's canvas layout and intent
+- Files on the canvas = files the user considers important — prioritize them
+- Frame groups = file associations — understand files in the same group together
+- After completing work, write results back to the canvas for the user to review
+`;
+
+async function installSkillFile(): Promise<{ ok: boolean; path: string; error?: string }> {
+  try {
+    await fs.mkdir(SKILLS_DIR, { recursive: true });
+    const targetPath = join(SKILLS_DIR, 'SKILL.md');
+    await fs.writeFile(targetPath, SKILL_CONTENT, 'utf-8');
+    return { ok: true, path: targetPath };
+  } catch (err) {
+    return { ok: false, path: SKILLS_DIR, error: String(err) };
+  }
+}
+
+async function installCli(): Promise<{ ok: boolean; error?: string; command?: string }> {
+  const command = 'npm install -g @pulse-coder/canvas-cli';
+  try {
+    await execFileAsync('npm', ['install', '-g', '@pulse-coder/canvas-cli'], { timeout: 60_000 });
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: String(err), command };
+  }
+}
+
+export function setupSkillInstallerIpc(): void {
+  ipcMain.handle('skills:install', async () => {
+    const skillResult = await installSkillFile();
+    if (!skillResult.ok) {
+      return {
+        ok: false,
+        skillsInstalled: false,
+        cliInstalled: false,
+        error: skillResult.error,
+        manualCommand: null,
+      };
+    }
+
+    const cliResult = await installCli();
+    return {
+      ok: true,
+      skillsInstalled: true,
+      skillsPath: skillResult.path,
+      cliInstalled: cliResult.ok,
+      manualCommand: cliResult.ok ? null : cliResult.command,
+      cliError: cliResult.ok ? null : cliResult.error,
+    };
+  });
+}

--- a/apps/canvas-workspace/src/main/skill-installer.ts
+++ b/apps/canvas-workspace/src/main/skill-installer.ts
@@ -2,10 +2,6 @@ import { ipcMain } from 'electron';
 import { promises as fs } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
-import { execFile } from 'child_process';
-import { promisify } from 'util';
-
-const execFileAsync = promisify(execFile);
 
 const SKILLS_DIR = join(homedir(), '.pulse-coder', 'skills', 'canvas');
 
@@ -70,16 +66,6 @@ async function installSkillFile(): Promise<{ ok: boolean; path: string; error?: 
   }
 }
 
-async function installCli(): Promise<{ ok: boolean; error?: string; command?: string }> {
-  const command = 'npm install -g @pulse-coder/canvas-cli';
-  try {
-    await execFileAsync('npm', ['install', '-g', '@pulse-coder/canvas-cli'], { timeout: 60_000 });
-    return { ok: true };
-  } catch (err) {
-    return { ok: false, error: String(err), command };
-  }
-}
-
 export function setupSkillInstallerIpc(): void {
   ipcMain.handle('skills:install', async () => {
     const skillResult = await installSkillFile();
@@ -93,14 +79,14 @@ export function setupSkillInstallerIpc(): void {
       };
     }
 
-    const cliResult = await installCli();
+    // CLI is not published yet — provide local build instructions
     return {
       ok: true,
       skillsInstalled: true,
       skillsPath: skillResult.path,
-      cliInstalled: cliResult.ok,
-      manualCommand: cliResult.ok ? null : cliResult.command,
-      cliError: cliResult.ok ? null : cliResult.error,
+      cliInstalled: false,
+      manualCommand: 'cd <project-root> && pnpm --filter @pulse-coder/canvas-cli build && pnpm link --global --filter @pulse-coder/canvas-cli',
+      cliError: null,
     };
   });
 }

--- a/apps/canvas-workspace/src/preload/index.ts
+++ b/apps/canvas-workspace/src/preload/index.ts
@@ -16,8 +16,8 @@ contextBridge.exposeInMainWorld("canvasWorkspace", {
   version: "0.1.0",
 
   pty: {
-    spawn: (id: string, cols?: number, rows?: number, cwd?: string) =>
-      ipcRenderer.invoke("pty:spawn", { id, cols, rows, cwd }),
+    spawn: (id: string, cols?: number, rows?: number, cwd?: string, workspaceId?: string) =>
+      ipcRenderer.invoke("pty:spawn", { id, cols, rows, cwd, workspaceId }),
 
     write: (id: string, data: string) =>
       ipcRenderer.send("pty:write", { id, data }),

--- a/apps/canvas-workspace/src/preload/index.ts
+++ b/apps/canvas-workspace/src/preload/index.ts
@@ -104,5 +104,9 @@ contextBridge.exposeInMainWorld("canvasWorkspace", {
 
   dialog: {
     openFolder: () => ipcRenderer.invoke("dialog:openFolder")
+  },
+
+  skills: {
+    install: () => ipcRenderer.invoke("skills:install")
   }
 });

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
@@ -90,7 +90,7 @@ export const Sidebar = ({
     } else {
       setInstallStatus('partial');
       setInstallMessage(
-        `Skills installed. CLI install failed, run manually:\n${result.manualCommand ?? 'npm install -g @pulse-coder/canvas-cli'}`
+        `Skills installed. To enable CLI, run:\n${result.manualCommand ?? 'pnpm --filter @pulse-coder/canvas-cli build && pnpm link --global --filter @pulse-coder/canvas-cli'}`
       );
     }
   }, []);
@@ -243,7 +243,7 @@ export const Sidebar = ({
             </span>
           </button>
           {installMessage && (
-            <div className={`sidebar-install-message${installStatus === 'partial' ? ' sidebar-install-message--warn' : ''}`}>
+            <div className="sidebar-install-message">
               {installMessage}
             </div>
           )}

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import type { WorkspaceEntry } from '../hooks/useWorkspaces';
 
 interface Props {
@@ -66,6 +66,34 @@ export const Sidebar = ({
     setNewName('');
     setCreating(false);
   };
+
+  const [installStatus, setInstallStatus] = useState<'idle' | 'installing' | 'done' | 'partial'>('idle');
+  const [installMessage, setInstallMessage] = useState('');
+
+  const handleInstallSkills = useCallback(async () => {
+    const api = window.canvasWorkspace?.skills;
+    if (!api) return;
+
+    setInstallStatus('installing');
+    setInstallMessage('');
+
+    const result = await api.install();
+    if (!result.ok) {
+      setInstallStatus('idle');
+      setInstallMessage(`Failed: ${result.error}`);
+      return;
+    }
+
+    if (result.cliInstalled) {
+      setInstallStatus('done');
+      setInstallMessage('Canvas CLI and Skills installed successfully.');
+    } else {
+      setInstallStatus('partial');
+      setInstallMessage(
+        `Skills installed. CLI install failed, run manually:\n${result.manualCommand ?? 'npm install -g @pulse-coder/canvas-cli'}`
+      );
+    }
+  }, []);
 
   const pickFolder = async (wsId: string) => {
     const api = window.canvasWorkspace?.dialog;
@@ -189,6 +217,37 @@ export const Sidebar = ({
             </button>
           </div>
         </>
+      )}
+
+      {!collapsed && (
+        <div className="sidebar-install-section">
+          <button
+            className="sidebar-item sidebar-item--muted"
+            onClick={handleInstallSkills}
+            disabled={installStatus === 'installing'}
+            title="Install canvas CLI and skills for agent discovery"
+          >
+            <span className="sidebar-item-icon">
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+                <path
+                  d="M8 2v8M5 7l3 3 3-3M3 12h10"
+                  stroke="currentColor"
+                  strokeWidth="1.3"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </span>
+            <span className="sidebar-item-name">
+              {installStatus === 'installing' ? 'Installing...' : 'Install for Agents'}
+            </span>
+          </button>
+          {installMessage && (
+            <div className={`sidebar-install-message${installStatus === 'partial' ? ' sidebar-install-message--warn' : ''}`}>
+              {installMessage}
+            </div>
+          )}
+        </div>
       )}
 
       <div className="sidebar-footer">

--- a/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody/index.tsx
@@ -106,7 +106,7 @@ export const TerminalNodeBody = ({ node, allNodes, rootFolder, workspaceId, work
     }
 
     const spawnCwd = initialCwd.current || rootFolder || undefined;
-    const result = await api.spawn(sessionId, term.cols, term.rows, spawnCwd);
+    const result = await api.spawn(sessionId, term.cols, term.rows, spawnCwd, workspaceIdRef.current);
     if (!result.ok) {
       term.writeln(`\x1b[31mFailed to spawn shell: ${result.error}\x1b[0m`);
       return;

--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -89,6 +89,23 @@ body {
   width: var(--sidebar-collapsed);
 }
 
+.sidebar-install-section {
+  padding: 4px 0;
+  border-top: 1px solid var(--border-light);
+}
+
+.sidebar-install-message {
+  font-size: 11px;
+  color: var(--text-secondary, #666);
+  padding: 4px 12px 4px 32px;
+  white-space: pre-wrap;
+  line-height: 1.4;
+}
+
+.sidebar-install-message--warn {
+  color: var(--text-warning, #b45309);
+}
+
 .sidebar-footer {
   margin-top: auto;
   padding: 8px;

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -91,6 +91,20 @@ export interface DialogApi {
   openFolder: () => Promise<{ ok: boolean; canceled?: boolean; folderPath?: string; error?: string }>;
 }
 
+export interface SkillsInstallResult {
+  ok: boolean;
+  skillsInstalled: boolean;
+  skillsPath?: string;
+  cliInstalled: boolean;
+  manualCommand?: string | null;
+  cliError?: string | null;
+  error?: string;
+}
+
+export interface SkillsApi {
+  install: () => Promise<SkillsInstallResult>;
+}
+
 export interface CanvasWorkspaceApi {
   version: string;
   pty: {
@@ -122,6 +136,7 @@ export interface CanvasWorkspaceApi {
   };
   file: FileApi;
   dialog: DialogApi;
+  skills: SkillsApi;
 }
 
 declare global {

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -112,7 +112,8 @@ export interface CanvasWorkspaceApi {
       id: string,
       cols?: number,
       rows?: number,
-      cwd?: string
+      cwd?: string,
+      workspaceId?: string
     ) => Promise<{ ok: boolean; pid?: number; error?: string; reused?: boolean }>;
     write: (id: string, data: string) => void;
     resize: (id: string, cols: number, rows: number) => void;

--- a/packages/canvas-cli/package.json
+++ b/packages/canvas-cli/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@pulse-coder/canvas-cli",
+  "version": "0.0.1-alpha.1",
+  "description": "CLI for Pulse Canvas — agent communication channel for canvas workspaces",
+  "type": "commonjs",
+  "main": "./dist/index.cjs",
+  "bin": {
+    "pulse-canvas": "./dist/index.cjs"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.cjs"
+    },
+    "./core": {
+      "types": "./dist/core/index.d.ts",
+      "require": "./dist/core/index.cjs"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "files": [
+    "dist",
+    "skills"
+  ],
+  "dependencies": {
+    "commander": "^13.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.10",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/canvas-cli/skills/canvas/SKILL.md
+++ b/packages/canvas-cli/skills/canvas/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: canvas
+description: Operate Pulse Canvas workspaces — read user-curated context, write results, create nodes
+version: 1.0.0
+---
+
+# Pulse Canvas
+
+Interact with canvas workspaces via the `pulse-canvas` CLI. The canvas is a shared workspace between humans and agents.
+
+## Core Commands
+
+### Read workspace context (start here)
+```bash
+pulse-canvas context <workspaceId> --format json
+```
+Returns all nodes with structured info: file paths, frame groups, labels.
+
+### List workspaces
+```bash
+pulse-canvas workspace list --format json
+```
+
+### List nodes
+```bash
+pulse-canvas node list <workspaceId> --format json
+```
+
+### Read a node
+```bash
+pulse-canvas node read <workspaceId> <nodeId> --format json
+```
+
+### Write to a node
+```bash
+pulse-canvas node write <workspaceId> <nodeId> --content "..."
+```
+
+### Create a node
+```bash
+pulse-canvas node create <workspaceId> --type file --title "Report" --data '{"content":"..."}'
+```
+
+## Usage Principles
+- Before starting a task, run `context` to understand the user's canvas layout and intent
+- Files on the canvas = files the user considers important — prioritize them
+- Frame groups = file associations — understand files in the same group together
+- After completing work, write results back to the canvas for the user to review

--- a/packages/canvas-cli/skills/canvas/SKILL.md
+++ b/packages/canvas-cli/skills/canvas/SKILL.md
@@ -8,37 +8,39 @@ version: 1.0.0
 
 Interact with canvas workspaces via the `pulse-canvas` CLI. The canvas is a shared workspace between humans and agents.
 
+The current workspace ID is available via `$PULSE_CANVAS_WORKSPACE_ID` environment variable (auto-set by canvas). All `node` and `context` commands use it automatically — no need to pass workspace ID explicitly.
+
 ## Core Commands
 
 ### Read workspace context (start here)
 ```bash
-pulse-canvas context <workspaceId> --format json
+pulse-canvas context --format json
 ```
 Returns all nodes with structured info: file paths, frame groups, labels.
 
-### List workspaces
-```bash
-pulse-canvas workspace list --format json
-```
-
 ### List nodes
 ```bash
-pulse-canvas node list <workspaceId> --format json
+pulse-canvas node list --format json
 ```
 
 ### Read a node
 ```bash
-pulse-canvas node read <workspaceId> <nodeId> --format json
+pulse-canvas node read <nodeId> --format json
 ```
 
 ### Write to a node
 ```bash
-pulse-canvas node write <workspaceId> <nodeId> --content "..."
+pulse-canvas node write <nodeId> --content "..."
 ```
 
 ### Create a node
 ```bash
-pulse-canvas node create <workspaceId> --type file --title "Report" --data '{"content":"..."}'
+pulse-canvas node create --type file --title "Report" --data '{"content":"..."}'
+```
+
+### List workspaces
+```bash
+pulse-canvas workspace list --format json
 ```
 
 ## Usage Principles

--- a/packages/canvas-cli/src/cli.ts
+++ b/packages/canvas-cli/src/cli.ts
@@ -4,6 +4,8 @@ import { registerNodeCommands } from './commands/node';
 import { registerContextCommand } from './commands/context';
 import { registerInstallSkillsCommand } from './commands/install-skills';
 
+export const ENV_WORKSPACE_ID = 'PULSE_CANVAS_WORKSPACE_ID';
+
 export function createCli(): Command {
   const program = new Command();
 
@@ -12,7 +14,8 @@ export function createCli(): Command {
     .description('CLI for Pulse Canvas — agent communication channel for canvas workspaces')
     .version('0.0.1-alpha.1')
     .option('--format <format>', 'Output format: json or text', 'text')
-    .option('--store-dir <path>', 'Canvas store directory (default: ~/.pulse-coder/canvas/)');
+    .option('--store-dir <path>', 'Canvas store directory (default: ~/.pulse-coder/canvas/)')
+    .option('-w, --workspace <id>', `Workspace ID (default: $${ENV_WORKSPACE_ID})`, process.env[ENV_WORKSPACE_ID]);
 
   registerWorkspaceCommands(program);
   registerNodeCommands(program);

--- a/packages/canvas-cli/src/cli.ts
+++ b/packages/canvas-cli/src/cli.ts
@@ -1,0 +1,23 @@
+import { Command } from 'commander';
+import { registerWorkspaceCommands } from './commands/workspace';
+import { registerNodeCommands } from './commands/node';
+import { registerContextCommand } from './commands/context';
+import { registerInstallSkillsCommand } from './commands/install-skills';
+
+export function createCli(): Command {
+  const program = new Command();
+
+  program
+    .name('pulse-canvas')
+    .description('CLI for Pulse Canvas — agent communication channel for canvas workspaces')
+    .version('0.0.1-alpha.1')
+    .option('--format <format>', 'Output format: json or text', 'text')
+    .option('--store-dir <path>', 'Canvas store directory (default: ~/.pulse-coder/canvas/)');
+
+  registerWorkspaceCommands(program);
+  registerNodeCommands(program);
+  registerContextCommand(program);
+  registerInstallSkillsCommand(program);
+
+  return program;
+}

--- a/packages/canvas-cli/src/commands/context.ts
+++ b/packages/canvas-cli/src/commands/context.ts
@@ -1,0 +1,21 @@
+import { Command } from 'commander';
+import { generateContext, formatContextAsText } from '../core/context';
+import { output, errorOutput, type OutputFormat } from '../output';
+
+export function registerContextCommand(program: Command): void {
+  program
+    .command('context')
+    .argument('<workspaceId>', 'Workspace ID')
+    .description('Generate canvas context for agent consumption')
+    .action(async function (this: Command, workspaceId: string) {
+      const root = this.parent;
+      const opts = root?.opts() ?? {};
+      const format: OutputFormat = opts.format ?? 'text';
+      const storeDir: string | undefined = opts.storeDir;
+
+      const ctx = await generateContext(workspaceId, storeDir);
+      if (!ctx) errorOutput(`Workspace not found: ${workspaceId}`);
+
+      output(ctx, format, (data) => formatContextAsText(data as NonNullable<typeof ctx>));
+    });
+}

--- a/packages/canvas-cli/src/commands/context.ts
+++ b/packages/canvas-cli/src/commands/context.ts
@@ -5,16 +5,20 @@ import { output, errorOutput, type OutputFormat } from '../output';
 export function registerContextCommand(program: Command): void {
   program
     .command('context')
-    .argument('<workspaceId>', 'Workspace ID')
     .description('Generate canvas context for agent consumption')
-    .action(async function (this: Command, workspaceId: string) {
+    .action(async function (this: Command) {
       const root = this.parent;
       const opts = root?.opts() ?? {};
       const format: OutputFormat = opts.format ?? 'text';
       const storeDir: string | undefined = opts.storeDir;
+      const workspace: string | undefined = opts.workspace;
 
-      const ctx = await generateContext(workspaceId, storeDir);
-      if (!ctx) errorOutput(`Workspace not found: ${workspaceId}`);
+      if (!workspace) {
+        errorOutput('Workspace ID required. Use --workspace <id> or set $PULSE_CANVAS_WORKSPACE_ID');
+      }
+
+      const ctx = await generateContext(workspace, storeDir);
+      if (!ctx) errorOutput(`Workspace not found: ${workspace}`);
 
       output(ctx, format, (data) => formatContextAsText(data as NonNullable<typeof ctx>));
     });

--- a/packages/canvas-cli/src/commands/install-skills.ts
+++ b/packages/canvas-cli/src/commands/install-skills.ts
@@ -1,0 +1,102 @@
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { Command } from 'commander';
+import { output, type OutputFormat } from '../output';
+
+const SKILLS_DIR = join(homedir(), '.pulse-coder', 'skills', 'canvas');
+
+export async function installSkills(targetDir?: string): Promise<{ ok: boolean; path: string; error?: string }> {
+  const dir = targetDir ?? SKILLS_DIR;
+  try {
+    await fs.mkdir(dir, { recursive: true });
+
+    // Read the bundled SKILL.md from the package
+    const skillSource = join(__dirname, '..', 'skills', 'canvas', 'SKILL.md');
+    let skillContent: string;
+    try {
+      skillContent = await fs.readFile(skillSource, 'utf-8');
+    } catch {
+      // Fallback: inline skill content if the file isn't found (e.g. during development)
+      skillContent = getInlineSkillContent();
+    }
+
+    const targetPath = join(dir, 'SKILL.md');
+    await fs.writeFile(targetPath, skillContent, 'utf-8');
+    return { ok: true, path: targetPath };
+  } catch (err) {
+    return { ok: false, path: dir, error: String(err) };
+  }
+}
+
+function getInlineSkillContent(): string {
+  return `---
+name: canvas
+description: Operate Pulse Canvas workspaces — read user-curated context, write results, create nodes
+version: 1.0.0
+---
+
+# Pulse Canvas
+
+Interact with canvas workspaces via the \`pulse-canvas\` CLI. The canvas is a shared workspace between humans and agents.
+
+## Core Commands
+
+### Read workspace context (start here)
+\`\`\`bash
+pulse-canvas context <workspaceId> --format json
+\`\`\`
+Returns all nodes with structured info: file paths, frame groups, labels.
+
+### List workspaces
+\`\`\`bash
+pulse-canvas workspace list --format json
+\`\`\`
+
+### List nodes
+\`\`\`bash
+pulse-canvas node list <workspaceId> --format json
+\`\`\`
+
+### Read a node
+\`\`\`bash
+pulse-canvas node read <workspaceId> <nodeId> --format json
+\`\`\`
+
+### Write to a node
+\`\`\`bash
+pulse-canvas node write <workspaceId> <nodeId> --content "..."
+\`\`\`
+
+### Create a node
+\`\`\`bash
+pulse-canvas node create <workspaceId> --type file --title "Report" --data '{"content":"..."}'
+\`\`\`
+
+## Usage Principles
+- Before starting a task, run \`context\` to understand the user's canvas layout and intent
+- Files on the canvas = files the user considers important — prioritize them
+- Frame groups = file associations — understand files in the same group together
+- After completing work, write results back to the canvas for the user to review
+`;
+}
+
+export function registerInstallSkillsCommand(program: Command): void {
+  program
+    .command('install-skills')
+    .option('--dir <path>', 'Custom target directory for skills')
+    .description('Install canvas skills for agent discovery')
+    .action(async function (this: Command, cmdOpts: { dir?: string }) {
+      const root = this.parent;
+      const format: OutputFormat = root?.opts()?.format ?? 'text';
+
+      const result = await installSkills(cmdOpts.dir);
+      if (!result.ok) {
+        console.error(`Failed to install skills: ${result.error}`);
+        console.error(`You can manually create the file at: ${result.path}/SKILL.md`);
+        process.exit(1);
+      }
+
+      output({ installed: result.path }, format, () => `Skills installed to: ${result.path}`);
+    });
+}

--- a/packages/canvas-cli/src/commands/install-skills.ts
+++ b/packages/canvas-cli/src/commands/install-skills.ts
@@ -40,37 +40,39 @@ version: 1.0.0
 
 Interact with canvas workspaces via the \`pulse-canvas\` CLI. The canvas is a shared workspace between humans and agents.
 
+The current workspace ID is available via \`$PULSE_CANVAS_WORKSPACE_ID\` environment variable (auto-set by canvas). All \`node\` and \`context\` commands use it automatically — no need to pass workspace ID explicitly.
+
 ## Core Commands
 
 ### Read workspace context (start here)
 \`\`\`bash
-pulse-canvas context <workspaceId> --format json
+pulse-canvas context --format json
 \`\`\`
 Returns all nodes with structured info: file paths, frame groups, labels.
 
-### List workspaces
-\`\`\`bash
-pulse-canvas workspace list --format json
-\`\`\`
-
 ### List nodes
 \`\`\`bash
-pulse-canvas node list <workspaceId> --format json
+pulse-canvas node list --format json
 \`\`\`
 
 ### Read a node
 \`\`\`bash
-pulse-canvas node read <workspaceId> <nodeId> --format json
+pulse-canvas node read <nodeId> --format json
 \`\`\`
 
 ### Write to a node
 \`\`\`bash
-pulse-canvas node write <workspaceId> <nodeId> --content "..."
+pulse-canvas node write <nodeId> --content "..."
 \`\`\`
 
 ### Create a node
 \`\`\`bash
-pulse-canvas node create <workspaceId> --type file --title "Report" --data '{"content":"..."}'
+pulse-canvas node create --type file --title "Report" --data '{"content":"..."}'
+\`\`\`
+
+### List workspaces
+\`\`\`bash
+pulse-canvas workspace list --format json
 \`\`\`
 
 ## Usage Principles

--- a/packages/canvas-cli/src/commands/node.ts
+++ b/packages/canvas-cli/src/commands/node.ts
@@ -1,0 +1,167 @@
+import { promises as fs } from 'fs';
+import { Command } from 'commander';
+import { loadCanvas } from '../core/store';
+import {
+  getNodeCapabilities,
+  readNode,
+  writeNode,
+  createNode,
+  deleteNode,
+} from '../core/nodes';
+import { output, errorOutput, type OutputFormat } from '../output';
+import type { NodeType } from '../core/types';
+
+function getOpts(cmd: Command): { format: OutputFormat; storeDir?: string } {
+  const root = cmd.parent?.parent ?? cmd.parent;
+  const opts = root?.opts() ?? {};
+  return { format: opts.format ?? 'text', storeDir: opts.storeDir };
+}
+
+export function registerNodeCommands(program: Command): void {
+  const node = program
+    .command('node')
+    .description('Manage canvas nodes');
+
+  node.command('list')
+    .argument('<workspaceId>', 'Workspace ID')
+    .description('List all nodes in a workspace')
+    .action(async function (this: Command, workspaceId: string) {
+      const { format, storeDir } = getOpts(this);
+      const canvas = await loadCanvas(workspaceId, storeDir);
+      if (!canvas) errorOutput(`Workspace not found: ${workspaceId}`);
+
+      const rows = canvas!.nodes.map(n => ({
+        id: n.id,
+        type: n.type,
+        title: n.title,
+        capabilities: getNodeCapabilities(n.type),
+      }));
+
+      output(rows, format, (data) => {
+        const items = data as typeof rows;
+        if (items.length === 0) return 'No nodes found.';
+        const lines = items.map(r =>
+          `  ${r.id}  [${r.type}]  ${r.title}  (${r.capabilities.join(', ')})`
+        );
+        return `Nodes:\n${lines.join('\n')}`;
+      });
+    });
+
+  node.command('read')
+    .argument('<workspaceId>', 'Workspace ID')
+    .argument('<nodeId>', 'Node ID')
+    .description('Read a canvas node')
+    .action(async function (this: Command, workspaceId: string, nodeId: string) {
+      const { format, storeDir } = getOpts(this);
+      const canvas = await loadCanvas(workspaceId, storeDir);
+      if (!canvas) errorOutput(`Workspace not found: ${workspaceId}`);
+
+      const canvasNode = canvas!.nodes.find(n => n.id === nodeId);
+      if (!canvasNode) errorOutput(`Node not found: ${nodeId}`);
+
+      const result = await readNode(canvasNode!);
+
+      output(result, format, (data) => {
+        const d = data as Record<string, unknown>;
+        if (d.type === 'file') {
+          return String(d.content ?? '');
+        }
+        if (d.type === 'terminal') {
+          return `Terminal (cwd: ${d.cwd ?? 'unknown'})\n${d.scrollback ?? ''}`;
+        }
+        if (d.type === 'frame') {
+          return `Frame: ${d.label || '(no label)'}  color: ${d.color ?? ''}`;
+        }
+        return JSON.stringify(d, null, 2);
+      });
+    });
+
+  node.command('write')
+    .argument('<workspaceId>', 'Workspace ID')
+    .argument('<nodeId>', 'Node ID')
+    .option('--content <text>', 'Content to write')
+    .option('--file <path>', 'Read content from file')
+    .description('Write content to a canvas node')
+    .action(async function (this: Command, workspaceId: string, nodeId: string, cmdOpts: { content?: string; file?: string }) {
+      const { format, storeDir } = getOpts(this);
+
+      let content: string;
+      if (cmdOpts.content !== undefined) {
+        content = cmdOpts.content;
+      } else if (cmdOpts.file) {
+        try {
+          content = await fs.readFile(cmdOpts.file, 'utf-8');
+        } catch (err) {
+          errorOutput(`Cannot read file: ${cmdOpts.file} — ${String(err)}`);
+        }
+      } else if (!process.stdin.isTTY) {
+        // Read from stdin
+        const chunks: Buffer[] = [];
+        for await (const chunk of process.stdin) {
+          chunks.push(chunk as Buffer);
+        }
+        content = Buffer.concat(chunks).toString('utf-8');
+      } else {
+        errorOutput('Provide content via --content, --file, or stdin');
+      }
+
+      const result = await writeNode(workspaceId, nodeId, content!, storeDir);
+      if (!result.ok) errorOutput(result.error);
+
+      output({ ok: true }, format, () => 'OK');
+    });
+
+  node.command('create')
+    .argument('<workspaceId>', 'Workspace ID')
+    .requiredOption('--type <type>', 'Node type: file, terminal, frame')
+    .option('--title <title>', 'Node title')
+    .option('--data <json>', 'Initial data as JSON')
+    .description('Create a new canvas node')
+    .action(async function (this: Command, workspaceId: string, cmdOpts: { type: string; title?: string; data?: string }) {
+      const { format, storeDir } = getOpts(this);
+
+      const validTypes: NodeType[] = ['file', 'terminal', 'frame'];
+      if (!validTypes.includes(cmdOpts.type as NodeType)) {
+        errorOutput(`Invalid type "${cmdOpts.type}". Must be: ${validTypes.join(', ')}`);
+      }
+
+      let data: Record<string, unknown> | undefined;
+      if (cmdOpts.data) {
+        try {
+          data = JSON.parse(cmdOpts.data) as Record<string, unknown>;
+        } catch {
+          errorOutput('--data must be valid JSON');
+        }
+      }
+
+      const result = await createNode(workspaceId, {
+        type: cmdOpts.type as NodeType,
+        title: cmdOpts.title,
+        data,
+      }, storeDir);
+
+      if (!result.ok) errorOutput(result.error);
+
+      if (cmdOpts.type === 'terminal') {
+        console.error('Note: Terminal nodes created via CLI have no active PTY session.');
+      }
+
+      output(result.data, format, (d) => {
+        const r = d as { nodeId: string; type: string; title: string };
+        return `Created ${r.type} node: ${r.nodeId} (${r.title})`;
+      });
+    });
+
+  node.command('delete')
+    .argument('<workspaceId>', 'Workspace ID')
+    .argument('<nodeId>', 'Node ID')
+    .description('Delete a canvas node')
+    .action(async function (this: Command, workspaceId: string, nodeId: string) {
+      const { format, storeDir } = getOpts(this);
+
+      const result = await deleteNode(workspaceId, nodeId, storeDir);
+      if (!result.ok) errorOutput(result.error);
+
+      output({ deleted: nodeId }, format, () => `Deleted node: ${nodeId}`);
+    });
+}

--- a/packages/canvas-cli/src/commands/node.ts
+++ b/packages/canvas-cli/src/commands/node.ts
@@ -11,10 +11,14 @@ import {
 import { output, errorOutput, type OutputFormat } from '../output';
 import type { NodeType } from '../core/types';
 
-function getOpts(cmd: Command): { format: OutputFormat; storeDir?: string } {
+function getOpts(cmd: Command): { format: OutputFormat; storeDir?: string; workspace: string } {
   const root = cmd.parent?.parent ?? cmd.parent;
   const opts = root?.opts() ?? {};
-  return { format: opts.format ?? 'text', storeDir: opts.storeDir };
+  const workspace = opts.workspace as string | undefined;
+  if (!workspace) {
+    errorOutput('Workspace ID required. Use --workspace <id> or set $PULSE_CANVAS_WORKSPACE_ID');
+  }
+  return { format: opts.format ?? 'text', storeDir: opts.storeDir, workspace };
 }
 
 export function registerNodeCommands(program: Command): void {
@@ -23,12 +27,11 @@ export function registerNodeCommands(program: Command): void {
     .description('Manage canvas nodes');
 
   node.command('list')
-    .argument('<workspaceId>', 'Workspace ID')
-    .description('List all nodes in a workspace')
-    .action(async function (this: Command, workspaceId: string) {
-      const { format, storeDir } = getOpts(this);
-      const canvas = await loadCanvas(workspaceId, storeDir);
-      if (!canvas) errorOutput(`Workspace not found: ${workspaceId}`);
+    .description('List all nodes in the workspace')
+    .action(async function (this: Command) {
+      const { format, storeDir, workspace } = getOpts(this);
+      const canvas = await loadCanvas(workspace, storeDir);
+      if (!canvas) errorOutput(`Workspace not found: ${workspace}`);
 
       const rows = canvas!.nodes.map(n => ({
         id: n.id,
@@ -48,13 +51,12 @@ export function registerNodeCommands(program: Command): void {
     });
 
   node.command('read')
-    .argument('<workspaceId>', 'Workspace ID')
     .argument('<nodeId>', 'Node ID')
     .description('Read a canvas node')
-    .action(async function (this: Command, workspaceId: string, nodeId: string) {
-      const { format, storeDir } = getOpts(this);
-      const canvas = await loadCanvas(workspaceId, storeDir);
-      if (!canvas) errorOutput(`Workspace not found: ${workspaceId}`);
+    .action(async function (this: Command, nodeId: string) {
+      const { format, storeDir, workspace } = getOpts(this);
+      const canvas = await loadCanvas(workspace, storeDir);
+      if (!canvas) errorOutput(`Workspace not found: ${workspace}`);
 
       const canvasNode = canvas!.nodes.find(n => n.id === nodeId);
       if (!canvasNode) errorOutput(`Node not found: ${nodeId}`);
@@ -77,13 +79,12 @@ export function registerNodeCommands(program: Command): void {
     });
 
   node.command('write')
-    .argument('<workspaceId>', 'Workspace ID')
     .argument('<nodeId>', 'Node ID')
     .option('--content <text>', 'Content to write')
     .option('--file <path>', 'Read content from file')
     .description('Write content to a canvas node')
-    .action(async function (this: Command, workspaceId: string, nodeId: string, cmdOpts: { content?: string; file?: string }) {
-      const { format, storeDir } = getOpts(this);
+    .action(async function (this: Command, nodeId: string, cmdOpts: { content?: string; file?: string }) {
+      const { format, storeDir, workspace } = getOpts(this);
 
       let content: string;
       if (cmdOpts.content !== undefined) {
@@ -105,20 +106,19 @@ export function registerNodeCommands(program: Command): void {
         errorOutput('Provide content via --content, --file, or stdin');
       }
 
-      const result = await writeNode(workspaceId, nodeId, content!, storeDir);
+      const result = await writeNode(workspace, nodeId, content!, storeDir);
       if (!result.ok) errorOutput(result.error);
 
       output({ ok: true }, format, () => 'OK');
     });
 
   node.command('create')
-    .argument('<workspaceId>', 'Workspace ID')
     .requiredOption('--type <type>', 'Node type: file, terminal, frame')
     .option('--title <title>', 'Node title')
     .option('--data <json>', 'Initial data as JSON')
     .description('Create a new canvas node')
-    .action(async function (this: Command, workspaceId: string, cmdOpts: { type: string; title?: string; data?: string }) {
-      const { format, storeDir } = getOpts(this);
+    .action(async function (this: Command, cmdOpts: { type: string; title?: string; data?: string }) {
+      const { format, storeDir, workspace } = getOpts(this);
 
       const validTypes: NodeType[] = ['file', 'terminal', 'frame'];
       if (!validTypes.includes(cmdOpts.type as NodeType)) {
@@ -134,7 +134,7 @@ export function registerNodeCommands(program: Command): void {
         }
       }
 
-      const result = await createNode(workspaceId, {
+      const result = await createNode(workspace, {
         type: cmdOpts.type as NodeType,
         title: cmdOpts.title,
         data,
@@ -153,13 +153,12 @@ export function registerNodeCommands(program: Command): void {
     });
 
   node.command('delete')
-    .argument('<workspaceId>', 'Workspace ID')
     .argument('<nodeId>', 'Node ID')
     .description('Delete a canvas node')
-    .action(async function (this: Command, workspaceId: string, nodeId: string) {
-      const { format, storeDir } = getOpts(this);
+    .action(async function (this: Command, nodeId: string) {
+      const { format, storeDir, workspace } = getOpts(this);
 
-      const result = await deleteNode(workspaceId, nodeId, storeDir);
+      const result = await deleteNode(workspace, nodeId, storeDir);
       if (!result.ok) errorOutput(result.error);
 
       output({ deleted: nodeId }, format, () => `Deleted node: ${nodeId}`);

--- a/packages/canvas-cli/src/commands/workspace.ts
+++ b/packages/canvas-cli/src/commands/workspace.ts
@@ -1,0 +1,111 @@
+import { Command } from 'commander';
+import {
+  listWorkspaceIds,
+  loadWorkspaceManifest,
+  loadCanvas,
+  getWorkspaceDir,
+  createWorkspace,
+  deleteWorkspace,
+} from '../core/store';
+import { getNodeCapabilities } from '../core/nodes';
+import { output, errorOutput, type OutputFormat } from '../output';
+
+function getOpts(cmd: Command): { format: OutputFormat; storeDir?: string } {
+  const root = cmd.parent?.parent ?? cmd.parent;
+  const opts = root?.opts() ?? {};
+  return { format: opts.format ?? 'text', storeDir: opts.storeDir };
+}
+
+export function registerWorkspaceCommands(program: Command): void {
+  const ws = program
+    .command('workspace')
+    .description('Manage canvas workspaces');
+
+  ws.command('list')
+    .description('List all workspaces')
+    .action(async function (this: Command) {
+      const { format, storeDir } = getOpts(this);
+      const ids = await listWorkspaceIds(storeDir);
+      const manifest = await loadWorkspaceManifest(storeDir);
+      const nameMap = new Map(manifest.entries.map(e => [e.id, e.name]));
+
+      const rows = ids.map(id => ({
+        id,
+        name: nameMap.get(id) ?? id,
+      }));
+
+      output(rows, format, (data) => {
+        const items = data as typeof rows;
+        if (items.length === 0) return 'No workspaces found.';
+        const lines = items.map(r => `  ${r.id}  ${r.name}`);
+        return `Workspaces:\n${lines.join('\n')}`;
+      });
+    });
+
+  ws.command('info')
+    .argument('<workspaceId>', 'Workspace ID')
+    .description('Show workspace details')
+    .action(async function (this: Command, workspaceId: string) {
+      const { format, storeDir } = getOpts(this);
+      const canvas = await loadCanvas(workspaceId, storeDir);
+      if (!canvas) errorOutput(`Workspace not found: ${workspaceId}`);
+
+      const manifest = await loadWorkspaceManifest(storeDir);
+      const entry = manifest.entries.find(e => e.id === workspaceId);
+
+      const typeCounts: Record<string, number> = {};
+      for (const node of canvas!.nodes) {
+        typeCounts[node.type] = (typeCounts[node.type] ?? 0) + 1;
+      }
+
+      const info = {
+        id: workspaceId,
+        name: entry?.name ?? workspaceId,
+        path: getWorkspaceDir(workspaceId, storeDir),
+        nodeCount: canvas!.nodes.length,
+        nodeTypes: typeCounts,
+        savedAt: canvas!.savedAt,
+      };
+
+      output(info, format, (data) => {
+        const d = data as typeof info;
+        const types = Object.entries(d.nodeTypes).map(([t, c]) => `${t}: ${c}`).join(', ');
+        return [
+          `Workspace: ${d.name} (${d.id})`,
+          `Path: ${d.path}`,
+          `Nodes: ${d.nodeCount} (${types || 'none'})`,
+          `Last saved: ${d.savedAt}`,
+        ].join('\n');
+      });
+    });
+
+  ws.command('create')
+    .argument('<name>', 'Workspace name')
+    .description('Create a new workspace')
+    .action(async function (this: Command, name: string) {
+      const { format, storeDir } = getOpts(this);
+      const result = await createWorkspace(name, storeDir);
+      if (!result.ok) errorOutput(result.error);
+
+      output(result.data, format, (data) => {
+        const d = data as { id: string };
+        return `Created workspace: ${d.id}`;
+      });
+    });
+
+  ws.command('delete')
+    .argument('<workspaceId>', 'Workspace ID')
+    .option('--confirm', 'Skip confirmation')
+    .description('Delete a workspace')
+    .action(async function (this: Command, workspaceId: string, cmdOpts: { confirm?: boolean }) {
+      const { format, storeDir } = getOpts(this);
+      if (!cmdOpts.confirm) {
+        errorOutput('Use --confirm to delete a workspace. This action is irreversible.');
+      }
+
+      const result = await deleteWorkspace(workspaceId, storeDir);
+      if (!result.ok) errorOutput(result.error);
+
+      output({ deleted: workspaceId }, format, () => `Deleted workspace: ${workspaceId}`);
+    });
+}

--- a/packages/canvas-cli/src/core/__tests__/nodes.test.ts
+++ b/packages/canvas-cli/src/core/__tests__/nodes.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { saveCanvas, loadCanvas } from '../store';
+import { readNode, writeNode, createNode, deleteNode, getNodeCapabilities } from '../nodes';
+import type { CanvasSaveData, CanvasNode } from '../types';
+
+let testDir: string;
+
+beforeEach(async () => {
+  testDir = join(tmpdir(), `canvas-cli-test-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`);
+  await fs.mkdir(testDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await fs.rm(testDir, { recursive: true, force: true });
+});
+
+function makeCanvas(nodes: CanvasNode[]): CanvasSaveData {
+  return {
+    nodes,
+    transform: { x: 0, y: 0, scale: 1 },
+    savedAt: '2025-01-01T00:00:00.000Z',
+  };
+}
+
+function makeFileNode(id: string, content: string, filePath?: string): CanvasNode {
+  return {
+    id,
+    type: 'file',
+    title: 'Test File',
+    x: 0, y: 0, width: 420, height: 360,
+    data: { content, filePath: filePath ?? '' },
+  };
+}
+
+function makeFrameNode(id: string, label: string, color: string): CanvasNode {
+  return {
+    id,
+    type: 'frame',
+    title: 'Test Frame',
+    x: 0, y: 0, width: 600, height: 400,
+    data: { label, color },
+  };
+}
+
+function makeTerminalNode(id: string): CanvasNode {
+  return {
+    id,
+    type: 'terminal',
+    title: 'Test Terminal',
+    x: 0, y: 0, width: 480, height: 300,
+    data: { sessionId: '', cwd: '/home/user', scrollback: 'ls\nfile.txt' },
+  };
+}
+
+describe('getNodeCapabilities', () => {
+  it('returns correct capabilities', () => {
+    expect(getNodeCapabilities('file')).toEqual(['read', 'write']);
+    expect(getNodeCapabilities('terminal')).toEqual(['read', 'exec']);
+    expect(getNodeCapabilities('frame')).toEqual(['read', 'write']);
+  });
+});
+
+describe('readNode', () => {
+  it('reads file node with in-memory content', async () => {
+    const node = makeFileNode('n1', 'hello world');
+    const result = await readNode(node);
+    expect(result.type).toBe('file');
+    expect(result.content).toBe('hello world');
+  });
+
+  it('reads file node from disk when filePath exists', async () => {
+    const filePath = join(testDir, 'test.md');
+    await fs.writeFile(filePath, 'disk content', 'utf-8');
+    const node = makeFileNode('n1', 'in-memory', filePath);
+    const result = await readNode(node);
+    expect(result.content).toBe('disk content');
+  });
+
+  it('reads terminal node', async () => {
+    const node = makeTerminalNode('t1');
+    const result = await readNode(node);
+    expect(result.type).toBe('terminal');
+    expect(result.cwd).toBe('/home/user');
+    expect(result.scrollback).toBe('ls\nfile.txt');
+  });
+
+  it('reads frame node', async () => {
+    const node = makeFrameNode('f1', 'Important', '#ff0000');
+    const result = await readNode(node);
+    expect(result.type).toBe('frame');
+    expect(result.label).toBe('Important');
+    expect(result.color).toBe('#ff0000');
+  });
+});
+
+describe('writeNode', () => {
+  it('writes to file node in-memory', async () => {
+    const canvas = makeCanvas([makeFileNode('n1', 'old')]);
+    await saveCanvas('ws-1', canvas, testDir);
+
+    const result = await writeNode('ws-1', 'n1', 'new content', testDir);
+    expect(result.ok).toBe(true);
+
+    const updated = await loadCanvas('ws-1', testDir);
+    expect(updated!.nodes[0].data.content).toBe('new content');
+  });
+
+  it('writes to frame node with JSON', async () => {
+    const canvas = makeCanvas([makeFrameNode('f1', 'old', '#000')]);
+    await saveCanvas('ws-1', canvas, testDir);
+
+    const result = await writeNode('ws-1', 'f1', '{"label":"new label","color":"#fff"}', testDir);
+    expect(result.ok).toBe(true);
+
+    const updated = await loadCanvas('ws-1', testDir);
+    expect(updated!.nodes[0].data.label).toBe('new label');
+    expect(updated!.nodes[0].data.color).toBe('#fff');
+  });
+
+  it('rejects write to terminal node', async () => {
+    const canvas = makeCanvas([makeTerminalNode('t1')]);
+    await saveCanvas('ws-1', canvas, testDir);
+
+    const result = await writeNode('ws-1', 't1', 'hello', testDir);
+    expect(result.ok).toBe(false);
+  });
+
+  it('returns error for missing workspace', async () => {
+    const result = await writeNode('nonexistent', 'n1', 'data', testDir);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('createNode', () => {
+  it('creates a file node', async () => {
+    const canvas = makeCanvas([]);
+    await saveCanvas('ws-1', canvas, testDir);
+
+    const result = await createNode('ws-1', { type: 'file', title: 'New File' }, testDir);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.data.type).toBe('file');
+    expect(result.data.title).toBe('New File');
+
+    const updated = await loadCanvas('ws-1', testDir);
+    expect(updated!.nodes).toHaveLength(1);
+    expect(updated!.nodes[0].id).toBe(result.data.nodeId);
+  });
+
+  it('creates a frame node with data', async () => {
+    const canvas = makeCanvas([]);
+    await saveCanvas('ws-1', canvas, testDir);
+
+    const result = await createNode('ws-1', {
+      type: 'frame',
+      title: 'Group',
+      data: { color: '#ff0000', label: 'Core' },
+    }, testDir);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const updated = await loadCanvas('ws-1', testDir);
+    expect(updated!.nodes[0].data.color).toBe('#ff0000');
+    expect(updated!.nodes[0].data.label).toBe('Core');
+  });
+
+  it('auto-places nodes to the right', async () => {
+    const canvas = makeCanvas([
+      { ...makeFileNode('n1', ''), x: 100, width: 420 } as CanvasNode,
+    ]);
+    await saveCanvas('ws-1', canvas, testDir);
+
+    const result = await createNode('ws-1', { type: 'file' }, testDir);
+    expect(result.ok).toBe(true);
+
+    const updated = await loadCanvas('ws-1', testDir);
+    const newNode = updated!.nodes[1];
+    expect(newNode.x).toBe(560); // 100 + 420 + 40
+  });
+});
+
+describe('deleteNode', () => {
+  it('removes node from canvas', async () => {
+    const canvas = makeCanvas([makeFileNode('n1', 'keep'), makeFileNode('n2', 'delete')]);
+    await saveCanvas('ws-1', canvas, testDir);
+
+    const result = await deleteNode('ws-1', 'n2', testDir);
+    expect(result.ok).toBe(true);
+
+    const updated = await loadCanvas('ws-1', testDir);
+    expect(updated!.nodes).toHaveLength(1);
+    expect(updated!.nodes[0].id).toBe('n1');
+  });
+
+  it('returns error for missing node', async () => {
+    const canvas = makeCanvas([]);
+    await saveCanvas('ws-1', canvas, testDir);
+
+    const result = await deleteNode('ws-1', 'nonexistent', testDir);
+    expect(result.ok).toBe(false);
+  });
+});

--- a/packages/canvas-cli/src/core/__tests__/store.test.ts
+++ b/packages/canvas-cli/src/core/__tests__/store.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  loadCanvas,
+  saveCanvas,
+  loadWorkspaceManifest,
+  saveWorkspaceManifest,
+  listWorkspaceIds,
+  createWorkspace,
+  deleteWorkspace,
+  getWorkspaceDir,
+  ensureWorkspaceDir,
+} from '../store';
+import type { CanvasSaveData } from '../types';
+
+let testDir: string;
+
+beforeEach(async () => {
+  testDir = join(tmpdir(), `canvas-cli-test-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`);
+  await fs.mkdir(testDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await fs.rm(testDir, { recursive: true, force: true });
+});
+
+const emptyCanvas: CanvasSaveData = {
+  nodes: [],
+  transform: { x: 0, y: 0, scale: 1 },
+  savedAt: '2025-01-01T00:00:00.000Z',
+};
+
+describe('store', () => {
+  describe('workspace manifest', () => {
+    it('returns empty manifest when none exists', async () => {
+      const manifest = await loadWorkspaceManifest(testDir);
+      expect(manifest.entries).toEqual([]);
+    });
+
+    it('saves and loads manifest', async () => {
+      const manifest = { entries: [{ id: 'ws-1', name: 'Test' }] };
+      await saveWorkspaceManifest(manifest, testDir);
+      const loaded = await loadWorkspaceManifest(testDir);
+      expect(loaded.entries).toEqual([{ id: 'ws-1', name: 'Test' }]);
+    });
+  });
+
+  describe('canvas CRUD', () => {
+    it('returns null for non-existent canvas', async () => {
+      const canvas = await loadCanvas('nonexistent', testDir);
+      expect(canvas).toBeNull();
+    });
+
+    it('saves and loads canvas', async () => {
+      await saveCanvas('ws-1', emptyCanvas, testDir);
+      const loaded = await loadCanvas('ws-1', testDir);
+      expect(loaded).toEqual(emptyCanvas);
+    });
+  });
+
+  describe('listWorkspaceIds', () => {
+    it('returns empty array when no workspaces', async () => {
+      const ids = await listWorkspaceIds(testDir);
+      expect(ids).toEqual([]);
+    });
+
+    it('lists workspace directories', async () => {
+      await saveCanvas('ws-a', emptyCanvas, testDir);
+      await saveCanvas('ws-b', emptyCanvas, testDir);
+      const ids = await listWorkspaceIds(testDir);
+      expect(ids.sort()).toEqual(['ws-a', 'ws-b']);
+    });
+  });
+
+  describe('createWorkspace', () => {
+    it('creates workspace with manifest entry', async () => {
+      const result = await createWorkspace('My Workspace', testDir);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const ids = await listWorkspaceIds(testDir);
+      expect(ids).toContain(result.data.id);
+
+      const manifest = await loadWorkspaceManifest(testDir);
+      expect(manifest.entries).toContainEqual({ id: result.data.id, name: 'My Workspace' });
+
+      const canvas = await loadCanvas(result.data.id, testDir);
+      expect(canvas).not.toBeNull();
+      expect(canvas!.nodes).toEqual([]);
+    });
+  });
+
+  describe('deleteWorkspace', () => {
+    it('deletes workspace and updates manifest', async () => {
+      const createResult = await createWorkspace('To Delete', testDir);
+      expect(createResult.ok).toBe(true);
+      if (!createResult.ok) return;
+
+      const wsId = createResult.data.id;
+      const deleteResult = await deleteWorkspace(wsId, testDir);
+      expect(deleteResult.ok).toBe(true);
+
+      const ids = await listWorkspaceIds(testDir);
+      expect(ids).not.toContain(wsId);
+
+      const manifest = await loadWorkspaceManifest(testDir);
+      expect(manifest.entries.find(e => e.id === wsId)).toBeUndefined();
+    });
+  });
+
+  describe('ensureWorkspaceDir', () => {
+    it('creates directory and seeds AGENTS.md', async () => {
+      await ensureWorkspaceDir('ws-new', testDir);
+      const dir = getWorkspaceDir('ws-new', testDir);
+      const agentsMd = await fs.readFile(join(dir, 'AGENTS.md'), 'utf-8');
+      expect(agentsMd).toContain('Canvas Agent Config');
+    });
+
+    it('does not overwrite existing AGENTS.md', async () => {
+      await ensureWorkspaceDir('ws-existing', testDir);
+      const dir = getWorkspaceDir('ws-existing', testDir);
+      await fs.writeFile(join(dir, 'AGENTS.md'), 'custom content', 'utf-8');
+
+      await ensureWorkspaceDir('ws-existing', testDir);
+      const content = await fs.readFile(join(dir, 'AGENTS.md'), 'utf-8');
+      expect(content).toBe('custom content');
+    });
+  });
+});

--- a/packages/canvas-cli/src/core/constants.ts
+++ b/packages/canvas-cli/src/core/constants.ts
@@ -1,0 +1,31 @@
+import { join } from 'path';
+import { homedir } from 'os';
+import type { NodeType, NodeCapability } from './types';
+
+export const DEFAULT_STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
+
+export const NODE_CAPABILITIES: Record<NodeType, NodeCapability[]> = {
+  file: ['read', 'write'],
+  terminal: ['read', 'exec'],
+  frame: ['read', 'write'],
+};
+
+export const DEFAULT_NODE_DIMENSIONS: Record<NodeType, { title: string; width: number; height: number }> = {
+  file: { title: 'Untitled', width: 420, height: 360 },
+  terminal: { title: 'Terminal', width: 480, height: 300 },
+  frame: { title: 'Frame', width: 600, height: 400 },
+};
+
+export const AGENTS_MD_TEMPLATE = `# Canvas Agent Config
+
+## Purpose
+<!-- Describe what this workspace is for -->
+
+## Instructions
+<!-- Conventions, style, or constraints for agents working in this workspace -->
+
+---
+
+<!-- canvas:auto-start -->
+<!-- canvas:auto-end -->
+`;

--- a/packages/canvas-cli/src/core/context.ts
+++ b/packages/canvas-cli/src/core/context.ts
@@ -1,0 +1,116 @@
+import { loadCanvas, loadWorkspaceManifest, getWorkspaceDir } from './store';
+import { getNodeCapabilities, readNode } from './nodes';
+import type { CanvasNode, NodeReadResult } from './types';
+
+interface ContextNode {
+  id: string;
+  type: string;
+  title: string;
+  capabilities: string[];
+  [key: string]: unknown;
+}
+
+interface CanvasContext {
+  workspaceId: string;
+  workspaceName: string;
+  canvasDir: string;
+  nodes: ContextNode[];
+}
+
+function extractDescription(content: string): string {
+  const lines = content.split('\n').map(l => l.trim()).filter(Boolean);
+  for (const line of lines) {
+    const heading = line.match(/^#{1,3}\s+(.+)/);
+    if (heading) return heading[1];
+    if (/^[-*_]{3,}$/.test(line)) continue;
+    return line.replace(/[*_`#>]/g, '').trim().slice(0, 80);
+  }
+  return '';
+}
+
+export async function generateContext(
+  workspaceId: string,
+  storeDir?: string,
+): Promise<CanvasContext | null> {
+  const canvas = await loadCanvas(workspaceId, storeDir);
+  if (!canvas) return null;
+
+  const manifest = await loadWorkspaceManifest(storeDir);
+  const entry = manifest.entries.find(e => e.id === workspaceId);
+  const workspaceName = entry?.name ?? workspaceId;
+  const canvasDir = getWorkspaceDir(workspaceId, storeDir);
+
+  const nodes: ContextNode[] = [];
+
+  for (const node of canvas.nodes) {
+    const readResult = await readNode(node);
+    const base: ContextNode = {
+      id: node.id,
+      type: node.type,
+      title: node.title,
+      capabilities: getNodeCapabilities(node.type),
+    };
+
+    switch (node.type) {
+      case 'file': {
+        const content = (readResult as NodeReadResult & { content?: string }).content ?? '';
+        base.path = (readResult as NodeReadResult & { path?: string }).path ?? '';
+        base.language = (readResult as NodeReadResult & { language?: string }).language ?? '';
+        base.description = extractDescription(content);
+        break;
+      }
+      case 'terminal':
+        base.cwd = (readResult as NodeReadResult & { cwd?: string }).cwd ?? '';
+        break;
+      case 'frame':
+        base.label = (readResult as NodeReadResult & { label?: string }).label ?? '';
+        base.color = (readResult as NodeReadResult & { color?: string }).color ?? '';
+        break;
+    }
+
+    nodes.push(base);
+  }
+
+  return { workspaceId, workspaceName, canvasDir, nodes };
+}
+
+export function formatContextAsText(ctx: CanvasContext): string {
+  const lines: string[] = [
+    '# Pulse Canvas Context',
+    '',
+    `Workspace: ${ctx.workspaceName} (${ctx.workspaceId})`,
+    `Canvas dir: ${ctx.canvasDir}`,
+  ];
+
+  const fileNodes = ctx.nodes.filter(n => n.type === 'file');
+  const terminalNodes = ctx.nodes.filter(n => n.type === 'terminal');
+  const frameNodes = ctx.nodes.filter(n => n.type === 'frame');
+
+  if (fileNodes.length > 0) {
+    lines.push('', '## Files', '');
+    for (const node of fileNodes) {
+      const pathHint = node.path ? `\`${node.path}\`` : '(unsaved)';
+      const desc = node.description ? ` — ${node.description}` : '';
+      lines.push(`- **${node.title}** ${pathHint}${desc}`);
+    }
+  }
+
+  if (frameNodes.length > 0) {
+    lines.push('', '## Frames', '');
+    for (const node of frameNodes) {
+      const label = node.label ? ` — ${node.label}` : '';
+      lines.push(`- **${node.title}**${label}`);
+    }
+  }
+
+  if (terminalNodes.length > 0) {
+    lines.push('', '## Terminals', '');
+    for (const node of terminalNodes) {
+      const cwd = node.cwd ? ` (cwd: \`${node.cwd}\`)` : '';
+      lines.push(`- **${node.title}**${cwd}`);
+    }
+  }
+
+  lines.push('', '> Use file paths above to read content as needed.', '');
+  return lines.join('\n');
+}

--- a/packages/canvas-cli/src/core/index.ts
+++ b/packages/canvas-cli/src/core/index.ts
@@ -1,0 +1,5 @@
+export * from './types';
+export * from './constants';
+export * from './store';
+export * from './nodes';
+export * from './context';

--- a/packages/canvas-cli/src/core/nodes.ts
+++ b/packages/canvas-cli/src/core/nodes.ts
@@ -1,0 +1,193 @@
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { NODE_CAPABILITIES, DEFAULT_NODE_DIMENSIONS } from './constants';
+import { loadCanvas, saveCanvas, getWorkspaceDir } from './store';
+import type {
+  NodeType,
+  NodeCapability,
+  CanvasNode,
+  NodeReadResult,
+  Result,
+} from './types';
+
+export function getNodeCapabilities(type: NodeType): NodeCapability[] {
+  return NODE_CAPABILITIES[type] ?? ['read'];
+}
+
+export async function readNode(node: CanvasNode): Promise<NodeReadResult> {
+  const capabilities = getNodeCapabilities(node.type);
+
+  switch (node.type) {
+    case 'file': {
+      let content = node.data.content ?? '';
+      if (node.data.filePath) {
+        try {
+          content = await fs.readFile(node.data.filePath, 'utf-8');
+        } catch {
+          // fall through to in-memory content
+        }
+      }
+      const ext = node.data.filePath?.split('.').pop() ?? '';
+      return { type: 'file', capabilities, path: node.data.filePath ?? '', content, language: ext };
+    }
+    case 'terminal':
+      return {
+        type: 'terminal',
+        capabilities,
+        cwd: node.data.cwd ?? '',
+        scrollback: node.data.scrollback ?? '',
+      };
+    case 'frame':
+      return {
+        type: 'frame',
+        capabilities,
+        label: node.data.label ?? '',
+        color: node.data.color ?? '',
+      };
+    default:
+      return { type: node.type, capabilities };
+  }
+}
+
+export async function writeNode(
+  workspaceId: string,
+  nodeId: string,
+  content: string,
+  storeDir?: string,
+): Promise<Result> {
+  const canvas = await loadCanvas(workspaceId, storeDir);
+  if (!canvas) return { ok: false, error: `Workspace not found: ${workspaceId}` };
+
+  const node = canvas.nodes.find(n => n.id === nodeId);
+  if (!node) return { ok: false, error: `Node not found: ${nodeId}` };
+
+  switch (node.type) {
+    case 'file': {
+      if (node.data.filePath) {
+        await fs.writeFile(node.data.filePath, content, 'utf-8');
+      }
+      node.data.content = content;
+      canvas.savedAt = new Date().toISOString();
+      await saveCanvas(workspaceId, canvas, storeDir);
+      return { ok: true, data: undefined };
+    }
+    case 'frame': {
+      try {
+        const patch = JSON.parse(content) as { label?: string; color?: string };
+        if (patch.label !== undefined) node.data.label = patch.label;
+        if (patch.color !== undefined) node.data.color = patch.color;
+        canvas.savedAt = new Date().toISOString();
+        await saveCanvas(workspaceId, canvas, storeDir);
+        return { ok: true, data: undefined };
+      } catch {
+        return { ok: false, error: 'Frame write expects JSON: { label?: string, color?: string }' };
+      }
+    }
+    case 'terminal':
+      return { ok: false, error: 'Terminal nodes do not support write. Use canvas_exec to send commands.' };
+    default:
+      return { ok: false, error: 'Unknown node type' };
+  }
+}
+
+function autoPlaceX(nodes: Array<{ x?: number; width?: number }>): number {
+  if (nodes.length === 0) return 100;
+  let maxRight = 0;
+  for (const n of nodes) {
+    const right = (n.x ?? 0) + (n.width ?? 400);
+    if (right > maxRight) maxRight = right;
+  }
+  return maxRight + 40;
+}
+
+export interface CreateNodeOptions {
+  type: NodeType;
+  title?: string;
+  x?: number;
+  y?: number;
+  data?: Record<string, unknown>;
+}
+
+export async function createNode(
+  workspaceId: string,
+  opts: CreateNodeOptions,
+  storeDir?: string,
+): Promise<Result<{ nodeId: string; type: NodeType; title: string; capabilities: NodeCapability[] }>> {
+  const canvas = await loadCanvas(workspaceId, storeDir);
+  if (!canvas) return { ok: false, error: `Workspace not found: ${workspaceId}` };
+
+  const nodeId = `node-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const def = DEFAULT_NODE_DIMENSIONS[opts.type];
+  if (!def) return { ok: false, error: `Unsupported node type: ${opts.type}` };
+
+  const x = opts.x ?? autoPlaceX(canvas.nodes as Array<{ x?: number; width?: number }>);
+  const y = opts.y ?? 100;
+
+  const inputData = opts.data ?? {};
+  let nodeData: Record<string, unknown>;
+  switch (opts.type) {
+    case 'file':
+      nodeData = { filePath: '', content: (inputData as Record<string, string>).content ?? '', saved: false, modified: false };
+      break;
+    case 'terminal':
+      nodeData = { sessionId: '', cwd: (inputData as Record<string, string>).cwd ?? '' };
+      break;
+    case 'frame':
+      nodeData = { color: (inputData as Record<string, string>).color ?? '#9065b0', label: (inputData as Record<string, string>).label ?? '' };
+      break;
+  }
+
+  const newNode: CanvasNode = {
+    id: nodeId,
+    type: opts.type,
+    title: opts.title ?? def.title,
+    x,
+    y,
+    width: def.width,
+    height: def.height,
+    data: nodeData,
+  };
+
+  canvas.nodes.push(newNode);
+  canvas.savedAt = new Date().toISOString();
+  await saveCanvas(workspaceId, canvas, storeDir);
+
+  // If file node with content, create a workspace note file
+  if (opts.type === 'file' && nodeData.content) {
+    const notesDir = join(getWorkspaceDir(workspaceId, storeDir), 'notes');
+    await fs.mkdir(notesDir, { recursive: true });
+    const noteFile = join(notesDir, `${nodeId}.md`);
+    await fs.writeFile(noteFile, String(nodeData.content), 'utf-8');
+    newNode.data.filePath = noteFile;
+    canvas.savedAt = new Date().toISOString();
+    await saveCanvas(workspaceId, canvas, storeDir);
+  }
+
+  return {
+    ok: true,
+    data: {
+      nodeId,
+      type: opts.type,
+      title: newNode.title,
+      capabilities: getNodeCapabilities(opts.type),
+    },
+  };
+}
+
+export async function deleteNode(
+  workspaceId: string,
+  nodeId: string,
+  storeDir?: string,
+): Promise<Result> {
+  const canvas = await loadCanvas(workspaceId, storeDir);
+  if (!canvas) return { ok: false, error: `Workspace not found: ${workspaceId}` };
+
+  const idx = canvas.nodes.findIndex(n => n.id === nodeId);
+  if (idx === -1) return { ok: false, error: `Node not found: ${nodeId}` };
+
+  canvas.nodes.splice(idx, 1);
+  canvas.savedAt = new Date().toISOString();
+  await saveCanvas(workspaceId, canvas, storeDir);
+
+  return { ok: true, data: undefined };
+}

--- a/packages/canvas-cli/src/core/store.ts
+++ b/packages/canvas-cli/src/core/store.ts
@@ -1,0 +1,118 @@
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { DEFAULT_STORE_DIR, AGENTS_MD_TEMPLATE } from './constants';
+import type { CanvasSaveData, WorkspaceManifest, Result } from './types';
+
+function resolveDir(storeDir?: string): string {
+  return storeDir ?? DEFAULT_STORE_DIR;
+}
+
+function manifestPath(storeDir?: string): string {
+  return join(resolveDir(storeDir), '__workspaces__.json');
+}
+
+function canvasPath(workspaceId: string, storeDir?: string): string {
+  return join(resolveDir(storeDir), workspaceId, 'canvas.json');
+}
+
+export function getWorkspaceDir(workspaceId: string, storeDir?: string): string {
+  return join(resolveDir(storeDir), workspaceId);
+}
+
+export async function loadWorkspaceManifest(storeDir?: string): Promise<WorkspaceManifest> {
+  try {
+    const raw = await fs.readFile(manifestPath(storeDir), 'utf-8');
+    return JSON.parse(raw) as WorkspaceManifest;
+  } catch {
+    return { entries: [] };
+  }
+}
+
+export async function saveWorkspaceManifest(manifest: WorkspaceManifest, storeDir?: string): Promise<void> {
+  const dir = resolveDir(storeDir);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(manifestPath(storeDir), JSON.stringify(manifest, null, 2), 'utf-8');
+}
+
+export async function listWorkspaceIds(storeDir?: string): Promise<string[]> {
+  const dir = resolveDir(storeDir);
+  try {
+    await fs.mkdir(dir, { recursive: true });
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    return entries
+      .filter(e => e.isDirectory() && e.name !== '__workspaces__')
+      .map(e => e.name);
+  } catch {
+    return [];
+  }
+}
+
+export async function ensureWorkspaceDir(workspaceId: string, storeDir?: string): Promise<void> {
+  const dir = getWorkspaceDir(workspaceId, storeDir);
+  await fs.mkdir(dir, { recursive: true });
+  const agentsPath = join(dir, 'AGENTS.md');
+  const exists = await fs.access(agentsPath).then(() => true).catch(() => false);
+  if (!exists) {
+    await fs.writeFile(agentsPath, AGENTS_MD_TEMPLATE, 'utf-8');
+  }
+}
+
+export async function loadCanvas(workspaceId: string, storeDir?: string): Promise<CanvasSaveData | null> {
+  try {
+    const raw = await fs.readFile(canvasPath(workspaceId, storeDir), 'utf-8');
+    return JSON.parse(raw) as CanvasSaveData;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveCanvas(workspaceId: string, data: CanvasSaveData, storeDir?: string): Promise<void> {
+  await ensureWorkspaceDir(workspaceId, storeDir);
+  await fs.writeFile(canvasPath(workspaceId, storeDir), JSON.stringify(data, null, 2), 'utf-8');
+}
+
+export async function createWorkspace(
+  name: string,
+  storeDir?: string,
+): Promise<Result<{ id: string }>> {
+  try {
+    const id = `ws-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    await ensureWorkspaceDir(id, storeDir);
+
+    // Initialize empty canvas
+    const emptyCanvas: CanvasSaveData = {
+      nodes: [],
+      transform: { x: 0, y: 0, scale: 1 },
+      savedAt: new Date().toISOString(),
+    };
+    await saveCanvas(id, emptyCanvas, storeDir);
+
+    // Update manifest
+    const manifest = await loadWorkspaceManifest(storeDir);
+    manifest.entries.push({ id, name });
+    await saveWorkspaceManifest(manifest, storeDir);
+
+    return { ok: true, data: { id } };
+  } catch (err) {
+    return { ok: false, error: String(err) };
+  }
+}
+
+export async function deleteWorkspace(
+  workspaceId: string,
+  storeDir?: string,
+): Promise<Result> {
+  try {
+    const dir = getWorkspaceDir(workspaceId, storeDir);
+    await fs.rm(dir, { recursive: true, force: true });
+
+    // Update manifest
+    const manifest = await loadWorkspaceManifest(storeDir);
+    manifest.entries = manifest.entries.filter(e => e.id !== workspaceId);
+    await saveWorkspaceManifest(manifest, storeDir);
+
+    return { ok: true, data: undefined };
+  } catch (err) {
+    return { ok: false, error: String(err) };
+  }
+}

--- a/packages/canvas-cli/src/core/types.ts
+++ b/packages/canvas-cli/src/core/types.ts
@@ -1,0 +1,57 @@
+export type NodeType = 'file' | 'terminal' | 'frame';
+export type NodeCapability = 'read' | 'write' | 'exec';
+
+export interface CanvasNodeData {
+  filePath?: string;
+  content?: string;
+  saved?: boolean;
+  modified?: boolean;
+  scrollback?: string;
+  cwd?: string;
+  sessionId?: string;
+  color?: string;
+  label?: string;
+  [key: string]: unknown;
+}
+
+export interface CanvasNode {
+  id: string;
+  type: NodeType;
+  title: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  data: CanvasNodeData;
+}
+
+export interface CanvasTransform {
+  x: number;
+  y: number;
+  scale: number;
+}
+
+export interface CanvasSaveData {
+  nodes: CanvasNode[];
+  transform: CanvasTransform;
+  savedAt: string;
+}
+
+export interface WorkspaceEntry {
+  id: string;
+  name: string;
+}
+
+export interface WorkspaceManifest {
+  entries: WorkspaceEntry[];
+}
+
+export interface NodeReadResult {
+  type: NodeType;
+  capabilities: NodeCapability[];
+  [key: string]: unknown;
+}
+
+export type Result<T = void> =
+  | { ok: true; data: T }
+  | { ok: false; error: string };

--- a/packages/canvas-cli/src/index.ts
+++ b/packages/canvas-cli/src/index.ts
@@ -1,0 +1,6 @@
+import { createCli } from './cli';
+
+createCli().parseAsync(process.argv).catch((err: Error) => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/packages/canvas-cli/src/output.ts
+++ b/packages/canvas-cli/src/output.ts
@@ -1,0 +1,14 @@
+export type OutputFormat = 'json' | 'text';
+
+export function output(data: unknown, format: OutputFormat, textFn: (d: unknown) => string): void {
+  if (format === 'json') {
+    console.log(JSON.stringify(data, null, 2));
+  } else {
+    console.log(textFn(data));
+  }
+}
+
+export function errorOutput(message: string): never {
+  console.error(`Error: ${message}`);
+  process.exit(1);
+}

--- a/packages/canvas-cli/tsconfig.json
+++ b/packages/canvas-cli/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/canvas-cli/tsup.config.ts
+++ b/packages/canvas-cli/tsup.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    'core/index': 'src/core/index.ts',
+  },
+  format: ['cjs'],
+  dts: true,
+  clean: true,
+  splitting: false,
+  sourcemap: true,
+  target: 'es2022',
+  platform: 'node',
+  banner: { js: '#!/usr/bin/env node' },
+  outExtension: () => ({ js: '.cjs' }),
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,6 +265,25 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@25.0.10)
 
+  packages/canvas-cli:
+    dependencies:
+      commander:
+        specifier: ^13.0.0
+        version: 13.1.0
+    devDependencies:
+      '@types/node':
+        specifier: ^25.0.10
+        version: 25.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@25.0.10)
+
   packages/cli:
     dependencies:
       pulse-coder-acp:
@@ -1729,6 +1748,10 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -4725,6 +4748,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  commander@13.1.0: {}
 
   commander@4.1.1: {}
 


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive CLI tool (`@pulse-coder/canvas-cli`) for programmatic interaction with Pulse Canvas workspaces, along with agent skill discovery support. The CLI enables agents and external tools to read workspace context, manage nodes (files, terminals, frames), and integrate with the canvas as a communication channel.

## Key Changes

### Canvas CLI Package (`packages/canvas-cli/`)
- **Core API** (`src/core/`):
  - `store.ts`: Workspace and canvas persistence layer with CRUD operations
  - `nodes.ts`: Node management (read, write, create, delete) with capability-based access control
  - `context.ts`: Context generation for agent consumption with structured node information
  - `types.ts`: TypeScript definitions for canvas data structures
  - `constants.ts`: Node capabilities, default dimensions, and configuration

- **CLI Commands** (`src/commands/`):
  - `workspace.ts`: List, create, delete, and inspect workspaces
  - `node.ts`: List, read, write, and create canvas nodes with flexible input (stdin, file, direct content)
  - `context.ts`: Generate structured workspace context for agents
  - `install-skills.ts`: Install canvas skill definitions for agent discovery

- **Build & Configuration**:
  - `tsup.config.ts`: CommonJS build configuration with CLI shebang
  - `package.json`: Published as `@pulse-coder/canvas-cli` with `pulse-canvas` CLI binary
  - Comprehensive test suite (`__tests__/`) covering all core operations

### Skill Installation & Discovery
- **CLI-side** (`src/commands/install-skills.ts`): Installs `SKILL.md` to `~/.pulse-coder/skills/canvas/`
- **Electron-side** (`apps/canvas-workspace/src/main/skill-installer.ts`): IPC handler for skill installation from the workspace app
- **Skill Definition** (`packages/canvas-cli/skills/canvas/SKILL.md`): Documents canvas CLI commands and usage principles for agents

### Workspace App Integration
- **Sidebar Enhancement** (`apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx`):
  - Added "Install Skills" button with status feedback
  - Displays installation progress and manual CLI setup instructions
  - Handles partial installation (skills without CLI)

- **IPC & Type Updates**:
  - `apps/canvas-workspace/src/preload/index.ts`: Exposed `skills.install()` API
  - `apps/canvas-workspace/src/main/index.ts`: Registered skill installer IPC handler
  - `apps/canvas-workspace/src/renderer/src/types.ts`: Added `SkillsInstallResult` interface

- **Styling** (`apps/canvas-workspace/src/renderer/src/styles.css`): Added `.sidebar-install-section` and message styling

## Notable Implementation Details

- **Node Capabilities**: Each node type (file, terminal, frame) declares supported operations (read/write/exec)
- **File Persistence**: File nodes can store content in-memory or on disk; disk content takes precedence on read
- **Auto-placement**: New nodes are positioned to the right of existing nodes with 40px spacing
- **JSON Patching**: Frame nodes accept JSON patches for label/color updates
- **Workspace Isolation**: Each workspace has its own directory with `AGENTS.md` template for agent instructions
- **Context Generation**: Extracts descriptions from file content and formats workspace state for agent consumption
- **Flexible Input**: Node write command accepts content via `--content`, `--file`, or stdin

## Testing
Comprehensive test coverage for:
- Workspace CRUD operations
- Canvas persistence and loading
- Node read/write/create/delete operations
- Context generation and formatting
- Manifest management

https://claude.ai/code/session_01KXexvoX7jGuawWA7mBTSXz