### PR TITLE
Fix canvas flicker: remove renderer-side merge callback

### DIFF
--- a/apps/canvas-workspace/src/main/canvas-store.ts
+++ b/apps/canvas-workspace/src/main/canvas-store.ts
@@ -167,14 +167,6 @@ export const setupCanvasStoreIpc = () => {
             JSON.stringify(merged, null, 2),
             'utf-8'
           );
-          // Tell renderer about externally-added nodes so UI stays in sync
-          const memoryNodes = Array.isArray((payload.data as CanvasSaveData).nodes)
-            ? (payload.data as CanvasSaveData).nodes!
-            : [];
-          const mergedNodes = Array.isArray(merged.nodes) ? merged.nodes : [];
-          if (mergedNodes.length > memoryNodes.length) {
-            return { ok: true, mergedNodes };
-          }
         }
         return { ok: true };
       } catch (err) {

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
@@ -15,32 +15,17 @@ export const useNodes = (
   const onRestoreTransformRef = useRef(onRestoreTransform);
   onRestoreTransformRef.current = onRestoreTransform;
 
-  // Refs to break circular dependency: scheduleSave needs nodesRef/setNodes,
-  // but those come from useNodeHistory which takes scheduleSave as argument.
-  const nodesRefBridge = useRef<CanvasNode[]>([]);
-  const setNodesBridge = useRef<React.Dispatch<React.SetStateAction<CanvasNode[]>>>(() => {});
-
   const scheduleSave = useCallback(() => {
     if (saveTimer.current) clearTimeout(saveTimer.current);
     saveTimer.current = setTimeout(() => {
       const api = window.canvasWorkspace?.store;
       if (!api) return;
       const payload: CanvasSaveData = {
-        nodes: nodesRefBridge.current,
+        nodes: nodesRef.current,
         transform: transformRef.current,
         savedAt: new Date().toISOString(),
       };
-      void api.save(canvasId, payload).then((res) => {
-        // If main process merged in externally-added nodes (e.g. from CLI),
-        // update in-memory state so they appear on canvas.
-        if (res?.mergedNodes && Array.isArray(res.mergedNodes)) {
-          const merged = res.mergedNodes as CanvasNode[];
-          if (merged.length > nodesRefBridge.current.length) {
-            nodesRefBridge.current = merged;
-            setNodesBridge.current(merged);
-          }
-        }
-      });
+      void api.save(canvasId, payload);
     }, SAVE_DEBOUNCE_MS);
   }, [canvasId]);
 
@@ -50,10 +35,6 @@ export const useNodes = (
     nodes, setNodes, nodesRef, historyRef, historyIndexRef,
     applyNodes, commitHistory, undo, redo,
   } = useNodeHistory(scheduleSave);
-
-  // Keep bridges in sync
-  nodesRefBridge.current = nodesRef.current;
-  setNodesBridge.current = setNodes;
 
   const setTransformForSave = useCallback(
     (t: CanvasTransform) => {

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -126,7 +126,7 @@ export interface CanvasWorkspaceApi {
     save: (
       id: string,
       data: unknown
-    ) => Promise<{ ok: boolean; mergedNodes?: CanvasNode[]; error?: string }>;
+    ) => Promise<{ ok: boolean; error?: string }>;
     load: (
       id: string
     ) => Promise<{ ok: boolean; data?: CanvasSaveData | null; error?: string }>;


### PR DESCRIPTION
The merge-on-save callback in scheduleSave caused an infinite loop: nodesRef never got updated with merged nodes, so main kept "discovering" the same external nodes and returning mergedNodes on every save cycle.

Fix: keep merge-on-save in main process (prevents CLI nodes from being overwritten on disk) but remove the renderer callback. CLI-added nodes appear on next workspace load/switch instead of live, avoiding the circular re-render entirely.

https://claude.ai/code/session_01KXexvoX7jGuawWA7mBTSXz