### PR TITLE
fix color picker: stop mousedown propagation to prevent drag hijacking

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.tsx
@@ -55,7 +55,12 @@ export const FrameColorPicker = ({ node, onUpdate }: ColorPickerProps) => {
   }, [open]);
 
   return (
-    <div className="frame-color-trigger" ref={triggerRef} title="Frame color">
+    <div
+      className={`frame-color-trigger${open ? ' frame-color-trigger--open' : ''}`}
+      ref={triggerRef}
+      title="Frame color"
+      onMouseDown={(e) => e.stopPropagation()}
+    >
       <div
         className="frame-color-dot"
         style={{ backgroundColor: data.color }}

--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -502,8 +502,9 @@ body {
   transition: opacity 0.15s ease;
 }
 
-/* Show color dot when hovering the header */
-.node-header:hover .frame-color-trigger {
+/* Show color dot when hovering the header or when popover is open */
+.node-header:hover .frame-color-trigger,
+.frame-color-trigger--open {
   opacity: 1;
 }
 


### PR DESCRIPTION
Two issues fixed:
1. mousedown on the color dot was bubbling to the header and starting a drag operation, preventing the click from registering properly. Now stopPropagation on mousedown at the trigger level.
2. The trigger stayed invisible (opacity:0) when the popover was open but header hover was lost. Added --open class to keep it visible.

https://claude.ai/code/session_0195Qo8rKSAcRxsdSd8eiNSC