### PR TITLE
fix color picker swatches not clickable due to stacking context

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -461,6 +461,7 @@ body {
   color: white;
   transform: scale(calc(1 / var(--canvas-scale, 1)));
   transform-origin: left bottom;
+  z-index: 2; /* stack above .node-body so color popover is clickable */
 }
 
 .canvas-node--frame .node-header .node-type-badge--frame,


### PR DESCRIPTION
The frame header's transform creates a stacking context, so the popover's z-index only applies within it. Meanwhile .node-body comes later in DOM order and paints on top, intercepting clicks. Add z-index:2 to the header so it stacks above the body.

https://claude.ai/code/session_0195Qo8rKSAcRxsdSd8eiNSC