### PR TITLE
Add folder organization and drag-drop support to workspace sidebar

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -7,12 +7,18 @@ const App = () => {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(true);
   const {
     workspaces,
+    folders,
     activeId,
     selectWorkspace,
     createWorkspace,
     renameWorkspace,
     deleteWorkspace,
     setRootFolder,
+    createFolder,
+    renameFolder,
+    deleteFolder,
+    toggleFolder,
+    moveWorkspace,
   } = useWorkspaces();
 
   return (
@@ -22,12 +28,18 @@ const App = () => {
           collapsed={sidebarCollapsed}
           onToggle={() => setSidebarCollapsed((c) => !c)}
           workspaces={workspaces}
+          folders={folders}
           activeId={activeId}
           onSelect={selectWorkspace}
           onCreate={createWorkspace}
           onRename={renameWorkspace}
           onDelete={deleteWorkspace}
           onSetRootFolder={setRootFolder}
+          onCreateFolder={createFolder}
+          onRenameFolder={renameFolder}
+          onDeleteFolder={deleteFolder}
+          onToggleFolder={toggleFolder}
+          onMoveWorkspace={moveWorkspace}
         />
         <div className="canvas-viewport">
           {workspaces.map((ws) => (

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
@@ -1,35 +1,58 @@
-import { useEffect, useRef, useState, useCallback } from 'react';
-import type { WorkspaceEntry } from '../hooks/useWorkspaces';
+import { useEffect, useRef, useState, useCallback, type DragEvent } from 'react';
+import type { WorkspaceEntry, FolderEntry } from '../../hooks/useWorkspaces';
 
 interface Props {
   collapsed: boolean;
   onToggle: () => void;
   workspaces: WorkspaceEntry[];
+  folders: FolderEntry[];
   activeId: string;
   onSelect: (id: string) => void;
   onCreate: (name: string) => void;
   onRename: (id: string, name: string) => void;
   onDelete: (id: string) => void;
   onSetRootFolder: (id: string, folderPath: string) => void;
+  onCreateFolder: (name: string) => void;
+  onRenameFolder: (id: string, name: string) => void;
+  onDeleteFolder: (id: string) => void;
+  onToggleFolder: (id: string) => void;
+  onMoveWorkspace: (workspaceId: string, folderId: string | undefined) => void;
 }
+
+/* ---- Drag data helpers ---- */
+const DRAG_TYPE = 'application/x-workspace-id';
 
 export const Sidebar = ({
   collapsed,
   onToggle,
   workspaces,
+  folders,
   activeId,
   onSelect,
   onCreate,
   onRename,
   onDelete,
   onSetRootFolder,
+  onCreateFolder,
+  onRenameFolder,
+  onDeleteFolder,
+  onToggleFolder,
+  onMoveWorkspace,
 }: Props) => {
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
   const [creating, setCreating] = useState(false);
   const [newName, setNewName] = useState('');
+  const [creatingFolder, setCreatingFolder] = useState(false);
+  const [newFolderName, setNewFolderName] = useState('');
+  const [renamingFolderId, setRenamingFolderId] = useState<string | null>(null);
+  const [renameFolderValue, setRenameFolderValue] = useState('');
+  const [dropTarget, setDropTarget] = useState<string | null>(null); // folder id or '__root__'
+
   const renameInputRef = useRef<HTMLInputElement>(null);
   const newInputRef = useRef<HTMLInputElement>(null);
+  const newFolderInputRef = useRef<HTMLInputElement>(null);
+  const renameFolderInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (renamingId && renameInputRef.current) {
@@ -39,51 +62,79 @@ export const Sidebar = ({
   }, [renamingId]);
 
   useEffect(() => {
-    if (creating && newInputRef.current) {
-      newInputRef.current.focus();
-    }
+    if (creating && newInputRef.current) newInputRef.current.focus();
   }, [creating]);
 
+  useEffect(() => {
+    if (creatingFolder && newFolderInputRef.current) newFolderInputRef.current.focus();
+  }, [creatingFolder]);
+
+  useEffect(() => {
+    if (renamingFolderId && renameFolderInputRef.current) {
+      renameFolderInputRef.current.focus();
+      renameFolderInputRef.current.select();
+    }
+  }, [renamingFolderId]);
+
+  /* ---- Workspace rename ---- */
   const startRename = (ws: WorkspaceEntry) => {
     setRenamingId(ws.id);
     setRenameValue(ws.name);
   };
-
   const commitRename = () => {
     if (renamingId) onRename(renamingId, renameValue);
     setRenamingId(null);
   };
-
   const cancelRename = () => setRenamingId(null);
 
+  /* ---- Workspace create ---- */
   const commitCreate = () => {
     if (newName.trim()) onCreate(newName.trim());
     setNewName('');
     setCreating(false);
   };
-
   const cancelCreate = () => {
     setNewName('');
     setCreating(false);
   };
 
+  /* ---- Folder rename ---- */
+  const startFolderRename = (f: FolderEntry) => {
+    setRenamingFolderId(f.id);
+    setRenameFolderValue(f.name);
+  };
+  const commitFolderRename = () => {
+    if (renamingFolderId) onRenameFolder(renamingFolderId, renameFolderValue);
+    setRenamingFolderId(null);
+  };
+  const cancelFolderRename = () => setRenamingFolderId(null);
+
+  /* ---- Folder create ---- */
+  const commitFolderCreate = () => {
+    if (newFolderName.trim()) onCreateFolder(newFolderName.trim());
+    setNewFolderName('');
+    setCreatingFolder(false);
+  };
+  const cancelFolderCreate = () => {
+    setNewFolderName('');
+    setCreatingFolder(false);
+  };
+
+  /* ---- Skills install ---- */
   const [installStatus, setInstallStatus] = useState<'idle' | 'installing' | 'done' | 'partial'>('idle');
   const [installMessage, setInstallMessage] = useState('');
 
   const handleInstallSkills = useCallback(async () => {
     const api = window.canvasWorkspace?.skills;
     if (!api) return;
-
     setInstallStatus('installing');
     setInstallMessage('');
-
     const result = await api.install();
     if (!result.ok) {
       setInstallStatus('idle');
       setInstallMessage(`Failed: ${result.error}`);
       return;
     }
-
     if (result.cliInstalled) {
       setInstallStatus('done');
       setInstallMessage('Canvas CLI and Skills installed successfully.');
@@ -104,83 +155,181 @@ export const Sidebar = ({
     }
   };
 
+  /* ---- Drag & Drop handlers ---- */
+  const handleDragStart = (e: DragEvent, wsId: string) => {
+    e.dataTransfer.setData(DRAG_TYPE, wsId);
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleDragOver = (e: DragEvent, targetId: string) => {
+    if (!e.dataTransfer.types.includes(DRAG_TYPE)) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    setDropTarget(targetId);
+  };
+
+  const handleDragLeave = (e: DragEvent, targetId: string) => {
+    // Only clear if leaving the actual target (not entering a child)
+    const related = e.relatedTarget as HTMLElement | null;
+    const current = e.currentTarget as HTMLElement;
+    if (related && current.contains(related)) return;
+    if (dropTarget === targetId) setDropTarget(null);
+  };
+
+  const handleDrop = (e: DragEvent, folderId: string | undefined) => {
+    e.preventDefault();
+    const wsId = e.dataTransfer.getData(DRAG_TYPE);
+    if (wsId) onMoveWorkspace(wsId, folderId);
+    setDropTarget(null);
+  };
+
+  const handleDragEnd = () => setDropTarget(null);
+
+  /* ---- Render a workspace item ---- */
+  const renderWorkspaceItem = (ws: WorkspaceEntry) => (
+    <div
+      key={ws.id}
+      className="sidebar-workspace-entry"
+      draggable
+      onDragStart={(e) => handleDragStart(e, ws.id)}
+      onDragEnd={handleDragEnd}
+    >
+      <div className="sidebar-item-row">
+        {renamingId === ws.id ? (
+          <input
+            ref={renameInputRef}
+            className="sidebar-rename-input"
+            value={renameValue}
+            onChange={(e) => setRenameValue(e.target.value)}
+            onBlur={commitRename}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') commitRename();
+              if (e.key === 'Escape') cancelRename();
+            }}
+          />
+        ) : (
+          <button
+            className={`sidebar-item${activeId === ws.id ? ' sidebar-item--active' : ''}`}
+            onClick={() => onSelect(ws.id)}
+            onDoubleClick={() => startRename(ws)}
+            title="Drag to move · Double-click to rename"
+          >
+            <span className="sidebar-item-icon">
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+                <rect x="2" y="2" width="12" height="12" rx="2" stroke="currentColor" strokeWidth="1.3" />
+                <path d="M5 6h6M5 9h4" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+              </svg>
+            </span>
+            <span className="sidebar-item-name">{ws.name}</span>
+          </button>
+        )}
+        {workspaces.length > 1 && renamingId !== ws.id && (
+          <button className="sidebar-item-delete" onClick={() => onDelete(ws.id)} title="Delete workspace">
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+              <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+          </button>
+        )}
+      </div>
+      {ws.rootFolder && (
+        <div className="sidebar-root-folder" title={ws.rootFolder}>
+          {ws.rootFolder.split('/').slice(-2).join('/')}
+        </div>
+      )}
+    </div>
+  );
+
+  /* ---- Root-level workspaces (no folder) ---- */
+  const rootWorkspaces = workspaces.filter((ws) => !ws.folderId);
+
   return (
     <aside className={`sidebar${collapsed ? ' sidebar--collapsed' : ''}`}>
       {!collapsed && (
         <>
           <div className="sidebar-section-title">Workspaces</div>
-          <div className="sidebar-list">
-            {workspaces.map((ws) => (
-              <div key={ws.id} className="sidebar-workspace-entry">
-                <div className="sidebar-item-row">
-                  {renamingId === ws.id ? (
+
+          {/* Root drop zone */}
+          <div
+            className={`sidebar-list sidebar-drop-zone${dropTarget === '__root__' ? ' sidebar-drop-zone--active' : ''}`}
+            onDragOver={(e) => handleDragOver(e, '__root__')}
+            onDragLeave={(e) => handleDragLeave(e, '__root__')}
+            onDrop={(e) => handleDrop(e, undefined)}
+          >
+            {rootWorkspaces.map(renderWorkspaceItem)}
+          </div>
+
+          {/* Folders */}
+          {folders.map((folder) => {
+            const folderWorkspaces = workspaces.filter((ws) => ws.folderId === folder.id);
+            const isCollapsed = folder.collapsed;
+            const isDrop = dropTarget === folder.id;
+
+            return (
+              <div key={folder.id} className="sidebar-folder">
+                <div className="sidebar-folder-header">
+                  {renamingFolderId === folder.id ? (
                     <input
-                      ref={renameInputRef}
+                      ref={renameFolderInputRef}
                       className="sidebar-rename-input"
-                      value={renameValue}
-                      onChange={(e) => setRenameValue(e.target.value)}
-                      onBlur={commitRename}
+                      value={renameFolderValue}
+                      onChange={(e) => setRenameFolderValue(e.target.value)}
+                      onBlur={commitFolderRename}
                       onKeyDown={(e) => {
-                        if (e.key === 'Enter') commitRename();
-                        if (e.key === 'Escape') cancelRename();
+                        if (e.key === 'Enter') commitFolderRename();
+                        if (e.key === 'Escape') cancelFolderRename();
                       }}
                     />
                   ) : (
                     <button
-                      className={`sidebar-item${activeId === ws.id ? ' sidebar-item--active' : ''}`}
-                      onClick={() => onSelect(ws.id)}
-                      onDoubleClick={() => startRename(ws)}
+                      className="sidebar-folder-toggle"
+                      onClick={() => onToggleFolder(folder.id)}
+                      onDoubleClick={() => startFolderRename(folder)}
                       title="Double-click to rename"
                     >
-                      <span className="sidebar-item-icon">
-                        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-                          <rect
-                            x="2"
-                            y="2"
-                            width="12"
-                            height="12"
-                            rx="2"
-                            stroke="currentColor"
-                            strokeWidth="1.3"
-                          />
-                          <path
-                            d="M5 6h6M5 9h4"
-                            stroke="currentColor"
-                            strokeWidth="1.2"
-                            strokeLinecap="round"
-                          />
+                      <span className={`sidebar-folder-chevron${isCollapsed ? '' : ' sidebar-folder-chevron--open'}`}>
+                        <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+                          <path d="M6 4l4 4-4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
                         </svg>
                       </span>
-                      <span className="sidebar-item-name">{ws.name}</span>
+                      <span className="sidebar-folder-icon">
+                        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+                          <path d="M2 4.5A1.5 1.5 0 013.5 3H6l1.5 1.5h5A1.5 1.5 0 0114 6v5.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 012 11.5v-7z" stroke="currentColor" strokeWidth="1.2" />
+                        </svg>
+                      </span>
+                      <span className="sidebar-folder-name">{folder.name}</span>
+                      <span className="sidebar-folder-count">{folderWorkspaces.length}</span>
                     </button>
                   )}
-
-                  {workspaces.length > 1 && renamingId !== ws.id && (
+                  {renamingFolderId !== folder.id && (
                     <button
-                      className="sidebar-item-delete"
-                      onClick={() => onDelete(ws.id)}
-                      title="Delete workspace"
+                      className="sidebar-folder-delete"
+                      onClick={() => onDeleteFolder(folder.id)}
+                      title="Delete folder"
                     >
                       <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
-                        <path
-                          d="M4 4l8 8M12 4l-8 8"
-                          stroke="currentColor"
-                          strokeWidth="1.5"
-                          strokeLinecap="round"
-                        />
+                        <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
                       </svg>
                     </button>
                   )}
                 </div>
-                {ws.rootFolder && (
-                  <div className="sidebar-root-folder" title={ws.rootFolder}>
-                    {ws.rootFolder.split('/').slice(-2).join('/')}
-                  </div>
-                )}
+                <div
+                  className={`sidebar-folder-children${isCollapsed ? ' sidebar-folder-children--collapsed' : ''}${isDrop ? ' sidebar-drop-zone--active' : ''}`}
+                  onDragOver={(e) => handleDragOver(e, folder.id)}
+                  onDragLeave={(e) => handleDragLeave(e, folder.id)}
+                  onDrop={(e) => handleDrop(e, folder.id)}
+                >
+                  {!isCollapsed && folderWorkspaces.map(renderWorkspaceItem)}
+                  {!isCollapsed && folderWorkspaces.length === 0 && (
+                    <div className="sidebar-folder-empty">Drop workspaces here</div>
+                  )}
+                </div>
               </div>
-            ))}
+            );
+          })}
 
-            {creating && (
+          {/* Create inputs */}
+          {creating && (
+            <div className="sidebar-list">
               <div className="sidebar-item-row">
                 <input
                   ref={newInputRef}
@@ -195,25 +344,46 @@ export const Sidebar = ({
                   }}
                 />
               </div>
-            )}
-          </div>
+            </div>
+          )}
 
+          {creatingFolder && (
+            <div className="sidebar-list">
+              <div className="sidebar-item-row">
+                <input
+                  ref={newFolderInputRef}
+                  className="sidebar-rename-input sidebar-rename-input--new"
+                  placeholder="Folder name…"
+                  value={newFolderName}
+                  onChange={(e) => setNewFolderName(e.target.value)}
+                  onBlur={() => (newFolderName.trim() ? commitFolderCreate() : cancelFolderCreate())}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') commitFolderCreate();
+                    if (e.key === 'Escape') cancelFolderCreate();
+                  }}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Actions */}
           <div className="sidebar-list" style={{ marginTop: 4 }}>
-            <button
-              className="sidebar-item sidebar-item--muted"
-              onClick={() => setCreating(true)}
-            >
+            <button className="sidebar-item sidebar-item--muted" onClick={() => setCreating(true)}>
               <span className="sidebar-item-icon">
                 <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-                  <path
-                    d="M8 3v10M3 8h10"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                  />
+                  <path d="M8 3v10M3 8h10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
                 </svg>
               </span>
               <span className="sidebar-item-name">New Workspace</span>
+            </button>
+            <button className="sidebar-item sidebar-item--muted" onClick={() => setCreatingFolder(true)}>
+              <span className="sidebar-item-icon">
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+                  <path d="M2 4.5A1.5 1.5 0 013.5 3H6l1.5 1.5h5A1.5 1.5 0 0114 6v5.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 012 11.5v-7z" stroke="currentColor" strokeWidth="1.2" />
+                  <path d="M8 6.5v4M6 8.5h4" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+                </svg>
+              </span>
+              <span className="sidebar-item-name">New Folder</span>
             </button>
           </div>
         </>
@@ -243,9 +413,7 @@ export const Sidebar = ({
             </span>
           </button>
           {installMessage && (
-            <div className="sidebar-install-message">
-              {installMessage}
-            </div>
+            <div className="sidebar-install-message">{installMessage}</div>
           )}
         </div>
       )}

--- a/apps/canvas-workspace/src/renderer/src/hooks/useWorkspaces.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useWorkspaces.ts
@@ -4,10 +4,18 @@ export interface WorkspaceEntry {
   id: string;
   name: string;
   rootFolder?: string;
+  folderId?: string;
+}
+
+export interface FolderEntry {
+  id: string;
+  name: string;
+  collapsed?: boolean;
 }
 
 interface WorkspaceManifest {
   workspaces: WorkspaceEntry[];
+  folders?: FolderEntry[];
 }
 
 const MANIFEST_ID = '__workspaces__';
@@ -15,9 +23,12 @@ const DEFAULT_WORKSPACE: WorkspaceEntry = { id: 'default', name: 'Workspace' };
 
 export const useWorkspaces = () => {
   const [workspaces, setWorkspaces] = useState<WorkspaceEntry[]>([DEFAULT_WORKSPACE]);
+  const [folders, setFolders] = useState<FolderEntry[]>([]);
   const [activeId, setActiveId] = useState('default');
   const activeIdRef = useRef(activeId);
   activeIdRef.current = activeId;
+  const foldersRef = useRef(folders);
+  foldersRef.current = folders;
 
   useEffect(() => {
     const api = window.canvasWorkspace?.store;
@@ -27,6 +38,9 @@ export const useWorkspaces = () => {
         const manifest = res.data as unknown as WorkspaceManifest;
         if (Array.isArray(manifest.workspaces) && manifest.workspaces.length > 0) {
           setWorkspaces(manifest.workspaces);
+          if (Array.isArray(manifest.folders)) {
+            setFolders(manifest.folders);
+          }
           // Restore last active workspace if still in list
           const savedActiveId = (res.data as unknown as { activeId?: string }).activeId;
           if (savedActiveId && manifest.workspaces.some((w) => w.id === savedActiveId)) {
@@ -34,17 +48,18 @@ export const useWorkspaces = () => {
           }
         }
       } else {
-        void api.save(MANIFEST_ID, { workspaces: [DEFAULT_WORKSPACE], activeId: 'default' });
+        void api.save(MANIFEST_ID, { workspaces: [DEFAULT_WORKSPACE], folders: [], activeId: 'default' });
       }
     });
   }, []);
 
   const saveManifest = useCallback(
-    (ws: WorkspaceEntry[], newActiveId?: string) => {
+    (ws: WorkspaceEntry[], newActiveId?: string, newFolders?: FolderEntry[]) => {
       const api = window.canvasWorkspace?.store;
       if (!api) return;
       void api.save(MANIFEST_ID, {
         workspaces: ws,
+        folders: newFolders ?? foldersRef.current,
         activeId: newActiveId ?? activeIdRef.current,
       });
     },
@@ -118,13 +133,93 @@ export const useWorkspaces = () => {
     [saveManifest]
   );
 
+  /* ---- Folder CRUD ---- */
+
+  const createFolder = useCallback(
+    (name: string) => {
+      const id = `folder-${Date.now()}`;
+      const entry: FolderEntry = { id, name: name.trim() || 'Untitled Folder' };
+      setFolders((prev) => {
+        const next = [...prev, entry];
+        saveManifest(workspaces, undefined, next);
+        return next;
+      });
+      return id;
+    },
+    [saveManifest, workspaces]
+  );
+
+  const renameFolder = useCallback(
+    (id: string, name: string) => {
+      const trimmed = name.trim();
+      if (!trimmed) return;
+      setFolders((prev) => {
+        const next = prev.map((f) => (f.id === id ? { ...f, name: trimmed } : f));
+        saveManifest(workspaces, undefined, next);
+        return next;
+      });
+    },
+    [saveManifest, workspaces]
+  );
+
+  const deleteFolder = useCallback(
+    (id: string) => {
+      setFolders((prev) => {
+        const next = prev.filter((f) => f.id !== id);
+        // Un-folder workspaces that were in this folder
+        setWorkspaces((wsPrev) => {
+          const wsNext = wsPrev.map((w) =>
+            w.folderId === id ? { ...w, folderId: undefined } : w
+          );
+          saveManifest(wsNext, undefined, next);
+          return wsNext;
+        });
+        return next;
+      });
+    },
+    [saveManifest]
+  );
+
+  const toggleFolder = useCallback(
+    (id: string) => {
+      setFolders((prev) => {
+        const next = prev.map((f) =>
+          f.id === id ? { ...f, collapsed: !f.collapsed } : f
+        );
+        saveManifest(workspaces, undefined, next);
+        return next;
+      });
+    },
+    [saveManifest, workspaces]
+  );
+
+  /** Move a workspace into a folder (or to root if folderId is undefined) */
+  const moveWorkspace = useCallback(
+    (workspaceId: string, folderId: string | undefined) => {
+      setWorkspaces((prev) => {
+        const next = prev.map((w) =>
+          w.id === workspaceId ? { ...w, folderId } : w
+        );
+        saveManifest(next);
+        return next;
+      });
+    },
+    [saveManifest]
+  );
+
   return {
     workspaces,
+    folders,
     activeId,
     selectWorkspace,
     createWorkspace,
     renameWorkspace,
     deleteWorkspace,
     setRootFolder,
+    createFolder,
+    renameFolder,
+    deleteFolder,
+    toggleFolder,
+    moveWorkspace,
   };
 };

--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -306,6 +306,157 @@ body {
   text-overflow: ellipsis;
 }
 
+/* ---- Sidebar Folders ---- */
+
+.sidebar-folder {
+  margin: 2px 0;
+}
+
+.sidebar-folder-header {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 0 6px;
+  position: relative;
+}
+
+.sidebar-folder-toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+  padding: 5px 6px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  text-align: left;
+  transition: background 0.1s;
+}
+
+.sidebar-folder-toggle:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.sidebar-folder-chevron {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  transition: transform 0.15s ease;
+  color: var(--text-muted);
+}
+
+.sidebar-folder-chevron--open {
+  transform: rotate(90deg);
+}
+
+.sidebar-folder-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  color: var(--text-secondary);
+}
+
+.sidebar-folder-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+
+.sidebar-folder-count {
+  font-size: 11px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+  margin-left: auto;
+  padding-left: 4px;
+}
+
+.sidebar-folder-delete {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  transition: background 0.1s, color 0.1s;
+}
+
+.sidebar-folder-header:hover .sidebar-folder-delete {
+  display: flex;
+}
+
+.sidebar-folder-delete:hover {
+  background: rgba(224, 62, 62, 0.08);
+  color: #e03e3e;
+}
+
+.sidebar-folder-children {
+  padding: 0 0 0 12px;
+  margin: 0 6px;
+  border-left: 1.5px solid var(--border-light);
+  transition: border-color 0.15s;
+  min-height: 4px;
+}
+
+.sidebar-folder-children--collapsed {
+  display: none;
+}
+
+.sidebar-folder-empty {
+  padding: 4px 8px 4px 20px;
+  font-size: 11px;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+/* ---- Drag & Drop States ---- */
+
+.sidebar-workspace-entry {
+  display: flex;
+  flex-direction: column;
+  cursor: grab;
+}
+
+.sidebar-workspace-entry:active {
+  cursor: grabbing;
+}
+
+.sidebar-workspace-entry[draggable="true"] {
+  transition: opacity 0.15s;
+}
+
+.sidebar-drop-zone {
+  transition: background 0.15s, border-color 0.15s;
+  border-radius: var(--radius-sm);
+  min-height: 8px;
+}
+
+.sidebar-drop-zone--active {
+  background: var(--accent-light);
+  border-color: var(--accent-border) !important;
+}
+
+.sidebar-folder-children.sidebar-drop-zone--active {
+  border-left-color: var(--accent);
+}
+
 /* ---- Canvas Viewport (keep-alive wrapper) ---- */
 
 .canvas-viewport {


### PR DESCRIPTION
## Summary
This PR adds folder-based organization to the workspace sidebar with full drag-and-drop support for moving workspaces between folders and the root level.

## Key Changes

### Sidebar Component (`Sidebar/index.tsx`)
- Added folder management UI with collapsible folder headers showing workspace counts
- Implemented drag-and-drop handlers for moving workspaces between folders and root
- Added folder CRUD operations: create, rename, delete, and toggle collapse state
- Extracted workspace item rendering into a reusable `renderWorkspaceItem` function
- Added visual feedback for drag-over states with drop zone highlighting
- Organized code with clear section comments for different feature areas

### Hooks (`useWorkspaces.ts`)
- Extended `WorkspaceEntry` interface with optional `folderId` field to track folder membership
- Added new `FolderEntry` interface with `id`, `name`, and optional `collapsed` state
- Implemented folder CRUD operations: `createFolder`, `renameFolder`, `deleteFolder`, `toggleFolder`
- Added `moveWorkspace` function to move workspaces between folders or to root
- Updated manifest persistence to save and restore folder state alongside workspaces
- Properly handles un-foldering workspaces when their parent folder is deleted

### Styling (`styles.css`)
- Added comprehensive folder styling with toggle chevron and folder icon
- Implemented drag-and-drop visual states with accent highlighting
- Added folder children container with left border for visual hierarchy
- Styled empty folder state with placeholder text
- Added smooth transitions for collapse/expand and drag states

### App Component (`App.tsx`)
- Wired up all new folder-related callbacks from `useWorkspaces` hook to `Sidebar` component
- Passed `folders` array and folder operation handlers to sidebar

## Implementation Details

- **Drag & Drop**: Uses `application/x-workspace-id` MIME type for drag data, with proper `dragover`, `dragleave`, and `drop` event handling
- **Drop Zones**: Root level and each folder act as drop targets with visual feedback
- **Folder Collapse**: Folders can be toggled between expanded/collapsed states, persisted in manifest
- **Workspace Filtering**: Root workspaces and folder workspaces are filtered and rendered separately
- **Empty State**: Folders show "Drop workspaces here" message when empty and expanded

https://claude.ai/code/session_01VwNHE8Cws714vAKkGx7EYW