### PR TITLE
fix: improve sidebar folder UX - drag handles, add menu, folder reorder

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -19,6 +19,7 @@ const App = () => {
     deleteFolder,
     toggleFolder,
     moveWorkspace,
+    reorderFolder,
   } = useWorkspaces();
 
   return (
@@ -40,6 +41,7 @@ const App = () => {
           onDeleteFolder={deleteFolder}
           onToggleFolder={toggleFolder}
           onMoveWorkspace={moveWorkspace}
+          onReorderFolder={reorderFolder}
         />
         <div className="canvas-viewport">
           {workspaces.map((ws) => (

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
@@ -17,10 +17,12 @@ interface Props {
   onDeleteFolder: (id: string) => void;
   onToggleFolder: (id: string) => void;
   onMoveWorkspace: (workspaceId: string, folderId: string | undefined) => void;
+  onReorderFolder: (folderId: string, beforeFolderId: string | null) => void;
 }
 
-/* ---- Drag data helpers ---- */
-const DRAG_TYPE = 'application/x-workspace-id';
+/* ---- Drag data keys ---- */
+const WS_DRAG = 'application/x-workspace-id';
+const FOLDER_DRAG = 'application/x-folder-id';
 
 export const Sidebar = ({
   collapsed,
@@ -38,22 +40,25 @@ export const Sidebar = ({
   onDeleteFolder,
   onToggleFolder,
   onMoveWorkspace,
+  onReorderFolder,
 }: Props) => {
+  /* ---- Local state ---- */
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
-  const [creating, setCreating] = useState(false);
-  const [newName, setNewName] = useState('');
-  const [creatingFolder, setCreatingFolder] = useState(false);
-  const [newFolderName, setNewFolderName] = useState('');
   const [renamingFolderId, setRenamingFolderId] = useState<string | null>(null);
   const [renameFolderValue, setRenameFolderValue] = useState('');
-  const [dropTarget, setDropTarget] = useState<string | null>(null); // folder id or '__root__'
+  const [inlineCreate, setInlineCreate] = useState<'workspace' | 'folder' | null>(null);
+  const [inlineCreateValue, setInlineCreateValue] = useState('');
+  const [dropTarget, setDropTarget] = useState<string | null>(null);
+  const [folderDropTarget, setFolderDropTarget] = useState<string | null>(null);
+  const [showAddMenu, setShowAddMenu] = useState(false);
 
   const renameInputRef = useRef<HTMLInputElement>(null);
-  const newInputRef = useRef<HTMLInputElement>(null);
-  const newFolderInputRef = useRef<HTMLInputElement>(null);
   const renameFolderInputRef = useRef<HTMLInputElement>(null);
+  const inlineCreateRef = useRef<HTMLInputElement>(null);
+  const addMenuRef = useRef<HTMLDivElement>(null);
 
+  /* ---- Focus management ---- */
   useEffect(() => {
     if (renamingId && renameInputRef.current) {
       renameInputRef.current.focus();
@@ -62,19 +67,29 @@ export const Sidebar = ({
   }, [renamingId]);
 
   useEffect(() => {
-    if (creating && newInputRef.current) newInputRef.current.focus();
-  }, [creating]);
-
-  useEffect(() => {
-    if (creatingFolder && newFolderInputRef.current) newFolderInputRef.current.focus();
-  }, [creatingFolder]);
-
-  useEffect(() => {
     if (renamingFolderId && renameFolderInputRef.current) {
       renameFolderInputRef.current.focus();
       renameFolderInputRef.current.select();
     }
   }, [renamingFolderId]);
+
+  useEffect(() => {
+    if (inlineCreate && inlineCreateRef.current) {
+      inlineCreateRef.current.focus();
+    }
+  }, [inlineCreate]);
+
+  // Close add-menu on outside click
+  useEffect(() => {
+    if (!showAddMenu) return;
+    const handler = (e: MouseEvent) => {
+      if (addMenuRef.current && !addMenuRef.current.contains(e.target as Node)) {
+        setShowAddMenu(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [showAddMenu]);
 
   /* ---- Workspace rename ---- */
   const startRename = (ws: WorkspaceEntry) => {
@@ -82,21 +97,10 @@ export const Sidebar = ({
     setRenameValue(ws.name);
   };
   const commitRename = () => {
-    if (renamingId) onRename(renamingId, renameValue);
+    if (renamingId && renameValue.trim()) onRename(renamingId, renameValue);
     setRenamingId(null);
   };
   const cancelRename = () => setRenamingId(null);
-
-  /* ---- Workspace create ---- */
-  const commitCreate = () => {
-    if (newName.trim()) onCreate(newName.trim());
-    setNewName('');
-    setCreating(false);
-  };
-  const cancelCreate = () => {
-    setNewName('');
-    setCreating(false);
-  };
 
   /* ---- Folder rename ---- */
   const startFolderRename = (f: FolderEntry) => {
@@ -104,20 +108,24 @@ export const Sidebar = ({
     setRenameFolderValue(f.name);
   };
   const commitFolderRename = () => {
-    if (renamingFolderId) onRenameFolder(renamingFolderId, renameFolderValue);
+    if (renamingFolderId && renameFolderValue.trim()) onRenameFolder(renamingFolderId, renameFolderValue);
     setRenamingFolderId(null);
   };
   const cancelFolderRename = () => setRenamingFolderId(null);
 
-  /* ---- Folder create ---- */
-  const commitFolderCreate = () => {
-    if (newFolderName.trim()) onCreateFolder(newFolderName.trim());
-    setNewFolderName('');
-    setCreatingFolder(false);
+  /* ---- Inline create (workspace or folder) ---- */
+  const commitInlineCreate = () => {
+    const v = inlineCreateValue.trim();
+    if (v) {
+      if (inlineCreate === 'workspace') onCreate(v);
+      else if (inlineCreate === 'folder') onCreateFolder(v);
+    }
+    setInlineCreate(null);
+    setInlineCreateValue('');
   };
-  const cancelFolderCreate = () => {
-    setNewFolderName('');
-    setCreatingFolder(false);
+  const cancelInlineCreate = () => {
+    setInlineCreate(null);
+    setInlineCreateValue('');
   };
 
   /* ---- Skills install ---- */
@@ -146,55 +154,95 @@ export const Sidebar = ({
     }
   }, []);
 
-  const pickFolder = async (wsId: string) => {
-    const api = window.canvasWorkspace?.dialog;
-    if (!api) return;
-    const result = await api.openFolder();
-    if (result.ok && result.folderPath) {
-      onSetRootFolder(wsId, result.folderPath);
-    }
-  };
-
-  /* ---- Drag & Drop handlers ---- */
-  const handleDragStart = (e: DragEvent, wsId: string) => {
-    e.dataTransfer.setData(DRAG_TYPE, wsId);
+  /* ---- Workspace drag & drop ---- */
+  const handleWsDragStart = (e: DragEvent, wsId: string) => {
+    e.dataTransfer.setData(WS_DRAG, wsId);
     e.dataTransfer.effectAllowed = 'move';
+    // Add a subtle drag class
+    (e.currentTarget as HTMLElement).classList.add('sidebar-dragging');
   };
 
-  const handleDragOver = (e: DragEvent, targetId: string) => {
-    if (!e.dataTransfer.types.includes(DRAG_TYPE)) return;
+  const handleWsDragEnd = (e: DragEvent) => {
+    (e.currentTarget as HTMLElement).classList.remove('sidebar-dragging');
+    setDropTarget(null);
+  };
+
+  const handleDropZoneDragOver = (e: DragEvent, targetId: string) => {
+    if (!e.dataTransfer.types.includes(WS_DRAG)) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = 'move';
     setDropTarget(targetId);
   };
 
-  const handleDragLeave = (e: DragEvent, targetId: string) => {
-    // Only clear if leaving the actual target (not entering a child)
+  const handleDropZoneDragLeave = (e: DragEvent, targetId: string) => {
     const related = e.relatedTarget as HTMLElement | null;
     const current = e.currentTarget as HTMLElement;
     if (related && current.contains(related)) return;
     if (dropTarget === targetId) setDropTarget(null);
   };
 
-  const handleDrop = (e: DragEvent, folderId: string | undefined) => {
+  const handleDropZoneDrop = (e: DragEvent, folderId: string | undefined) => {
     e.preventDefault();
-    const wsId = e.dataTransfer.getData(DRAG_TYPE);
+    const wsId = e.dataTransfer.getData(WS_DRAG);
     if (wsId) onMoveWorkspace(wsId, folderId);
     setDropTarget(null);
   };
 
-  const handleDragEnd = () => setDropTarget(null);
+  /* ---- Folder drag & drop (reorder) ---- */
+  const handleFolderDragStart = (e: DragEvent, folderId: string) => {
+    e.dataTransfer.setData(FOLDER_DRAG, folderId);
+    e.dataTransfer.effectAllowed = 'move';
+    (e.currentTarget as HTMLElement).classList.add('sidebar-dragging');
+  };
 
-  /* ---- Render a workspace item ---- */
+  const handleFolderDragEnd = (e: DragEvent) => {
+    (e.currentTarget as HTMLElement).classList.remove('sidebar-dragging');
+    setFolderDropTarget(null);
+  };
+
+  const handleFolderDragOver = (e: DragEvent, targetFolderId: string) => {
+    if (!e.dataTransfer.types.includes(FOLDER_DRAG)) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    setFolderDropTarget(targetFolderId);
+  };
+
+  const handleFolderDragLeave = (e: DragEvent, targetFolderId: string) => {
+    const related = e.relatedTarget as HTMLElement | null;
+    const current = e.currentTarget as HTMLElement;
+    if (related && current.contains(related)) return;
+    if (folderDropTarget === targetFolderId) setFolderDropTarget(null);
+  };
+
+  const handleFolderDrop = (e: DragEvent, beforeFolderId: string | null) => {
+    e.preventDefault();
+    const folderId = e.dataTransfer.getData(FOLDER_DRAG);
+    if (folderId && folderId !== beforeFolderId) {
+      onReorderFolder(folderId, beforeFolderId);
+    }
+    setFolderDropTarget(null);
+  };
+
+  /* ---- Render a single workspace row ---- */
   const renderWorkspaceItem = (ws: WorkspaceEntry) => (
     <div
       key={ws.id}
       className="sidebar-workspace-entry"
       draggable
-      onDragStart={(e) => handleDragStart(e, ws.id)}
-      onDragEnd={handleDragEnd}
+      onDragStart={(e) => handleWsDragStart(e, ws.id)}
+      onDragEnd={handleWsDragEnd}
     >
       <div className="sidebar-item-row">
+        <span className="sidebar-drag-handle" title="Drag to move">
+          <svg width="10" height="14" viewBox="0 0 10 14" fill="none">
+            <circle cx="3" cy="3" r="1.2" fill="currentColor"/>
+            <circle cx="7" cy="3" r="1.2" fill="currentColor"/>
+            <circle cx="3" cy="7" r="1.2" fill="currentColor"/>
+            <circle cx="7" cy="7" r="1.2" fill="currentColor"/>
+            <circle cx="3" cy="11" r="1.2" fill="currentColor"/>
+            <circle cx="7" cy="11" r="1.2" fill="currentColor"/>
+          </svg>
+        </span>
         {renamingId === ws.id ? (
           <input
             ref={renameInputRef}
@@ -212,7 +260,7 @@ export const Sidebar = ({
             className={`sidebar-item${activeId === ws.id ? ' sidebar-item--active' : ''}`}
             onClick={() => onSelect(ws.id)}
             onDoubleClick={() => startRename(ws)}
-            title="Drag to move · Double-click to rename"
+            title="Double-click to rename"
           >
             <span className="sidebar-item-icon">
               <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
@@ -224,7 +272,7 @@ export const Sidebar = ({
           </button>
         )}
         {workspaces.length > 1 && renamingId !== ws.id && (
-          <button className="sidebar-item-delete" onClick={() => onDelete(ws.id)} title="Delete workspace">
+          <button className="sidebar-item-delete" onClick={() => onDelete(ws.id)} title="Delete">
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
               <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
             </svg>
@@ -239,152 +287,200 @@ export const Sidebar = ({
     </div>
   );
 
-  /* ---- Root-level workspaces (no folder) ---- */
+  /* ---- Computed ---- */
   const rootWorkspaces = workspaces.filter((ws) => !ws.folderId);
 
   return (
     <aside className={`sidebar${collapsed ? ' sidebar--collapsed' : ''}`}>
       {!collapsed && (
         <>
-          <div className="sidebar-section-title">Workspaces</div>
-
-          {/* Root drop zone */}
-          <div
-            className={`sidebar-list sidebar-drop-zone${dropTarget === '__root__' ? ' sidebar-drop-zone--active' : ''}`}
-            onDragOver={(e) => handleDragOver(e, '__root__')}
-            onDragLeave={(e) => handleDragLeave(e, '__root__')}
-            onDrop={(e) => handleDrop(e, undefined)}
-          >
-            {rootWorkspaces.map(renderWorkspaceItem)}
-          </div>
-
-          {/* Folders */}
-          {folders.map((folder) => {
-            const folderWorkspaces = workspaces.filter((ws) => ws.folderId === folder.id);
-            const isCollapsed = folder.collapsed;
-            const isDrop = dropTarget === folder.id;
-
-            return (
-              <div key={folder.id} className="sidebar-folder">
-                <div className="sidebar-folder-header">
-                  {renamingFolderId === folder.id ? (
-                    <input
-                      ref={renameFolderInputRef}
-                      className="sidebar-rename-input"
-                      value={renameFolderValue}
-                      onChange={(e) => setRenameFolderValue(e.target.value)}
-                      onBlur={commitFolderRename}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') commitFolderRename();
-                        if (e.key === 'Escape') cancelFolderRename();
-                      }}
-                    />
-                  ) : (
-                    <button
-                      className="sidebar-folder-toggle"
-                      onClick={() => onToggleFolder(folder.id)}
-                      onDoubleClick={() => startFolderRename(folder)}
-                      title="Double-click to rename"
-                    >
-                      <span className={`sidebar-folder-chevron${isCollapsed ? '' : ' sidebar-folder-chevron--open'}`}>
-                        <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
-                          <path d="M6 4l4 4-4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                        </svg>
-                      </span>
-                      <span className="sidebar-folder-icon">
-                        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-                          <path d="M2 4.5A1.5 1.5 0 013.5 3H6l1.5 1.5h5A1.5 1.5 0 0114 6v5.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 012 11.5v-7z" stroke="currentColor" strokeWidth="1.2" />
-                        </svg>
-                      </span>
-                      <span className="sidebar-folder-name">{folder.name}</span>
-                      <span className="sidebar-folder-count">{folderWorkspaces.length}</span>
-                    </button>
-                  )}
-                  {renamingFolderId !== folder.id && (
-                    <button
-                      className="sidebar-folder-delete"
-                      onClick={() => onDeleteFolder(folder.id)}
-                      title="Delete folder"
-                    >
-                      <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
-                        <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-                      </svg>
-                    </button>
-                  )}
-                </div>
-                <div
-                  className={`sidebar-folder-children${isCollapsed ? ' sidebar-folder-children--collapsed' : ''}${isDrop ? ' sidebar-drop-zone--active' : ''}`}
-                  onDragOver={(e) => handleDragOver(e, folder.id)}
-                  onDragLeave={(e) => handleDragLeave(e, folder.id)}
-                  onDrop={(e) => handleDrop(e, folder.id)}
-                >
-                  {!isCollapsed && folderWorkspaces.map(renderWorkspaceItem)}
-                  {!isCollapsed && folderWorkspaces.length === 0 && (
-                    <div className="sidebar-folder-empty">Drop workspaces here</div>
-                  )}
-                </div>
-              </div>
-            );
-          })}
-
-          {/* Create inputs */}
-          {creating && (
-            <div className="sidebar-list">
-              <div className="sidebar-item-row">
-                <input
-                  ref={newInputRef}
-                  className="sidebar-rename-input sidebar-rename-input--new"
-                  placeholder="Workspace name…"
-                  value={newName}
-                  onChange={(e) => setNewName(e.target.value)}
-                  onBlur={() => (newName.trim() ? commitCreate() : cancelCreate())}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') commitCreate();
-                    if (e.key === 'Escape') cancelCreate();
-                  }}
-                />
-              </div>
-            </div>
-          )}
-
-          {creatingFolder && (
-            <div className="sidebar-list">
-              <div className="sidebar-item-row">
-                <input
-                  ref={newFolderInputRef}
-                  className="sidebar-rename-input sidebar-rename-input--new"
-                  placeholder="Folder name…"
-                  value={newFolderName}
-                  onChange={(e) => setNewFolderName(e.target.value)}
-                  onBlur={() => (newFolderName.trim() ? commitFolderCreate() : cancelFolderCreate())}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') commitFolderCreate();
-                    if (e.key === 'Escape') cancelFolderCreate();
-                  }}
-                />
-              </div>
-            </div>
-          )}
-
-          {/* Actions */}
-          <div className="sidebar-list" style={{ marginTop: 4 }}>
-            <button className="sidebar-item sidebar-item--muted" onClick={() => setCreating(true)}>
-              <span className="sidebar-item-icon">
+          {/* Section header with add button */}
+          <div className="sidebar-section-header">
+            <span className="sidebar-section-title">Workspaces</span>
+            <div className="sidebar-section-actions" ref={addMenuRef}>
+              <button
+                className="sidebar-section-btn"
+                onClick={() => setShowAddMenu((v) => !v)}
+                title="Add workspace or folder"
+              >
                 <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
                   <path d="M8 3v10M3 8h10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
                 </svg>
-              </span>
-              <span className="sidebar-item-name">New Workspace</span>
-            </button>
-            <button className="sidebar-item sidebar-item--muted" onClick={() => setCreatingFolder(true)}>
-              <span className="sidebar-item-icon">
-                <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-                  <path d="M2 4.5A1.5 1.5 0 013.5 3H6l1.5 1.5h5A1.5 1.5 0 0114 6v5.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 012 11.5v-7z" stroke="currentColor" strokeWidth="1.2" />
-                  <path d="M8 6.5v4M6 8.5h4" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-                </svg>
-              </span>
-              <span className="sidebar-item-name">New Folder</span>
-            </button>
+              </button>
+              {showAddMenu && (
+                <div className="sidebar-add-menu">
+                  <button
+                    className="sidebar-add-menu-item"
+                    onClick={() => { setShowAddMenu(false); setInlineCreate('workspace'); setInlineCreateValue(''); }}
+                  >
+                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+                      <rect x="2" y="2" width="12" height="12" rx="2" stroke="currentColor" strokeWidth="1.3" />
+                      <path d="M5 6h6M5 9h4" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+                    </svg>
+                    <span>New Workspace</span>
+                  </button>
+                  <button
+                    className="sidebar-add-menu-item"
+                    onClick={() => { setShowAddMenu(false); setInlineCreate('folder'); setInlineCreateValue(''); }}
+                  >
+                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+                      <path d="M2 4.5A1.5 1.5 0 013.5 3H6l1.5 1.5h5A1.5 1.5 0 0114 6v5.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 012 11.5v-7z" stroke="currentColor" strokeWidth="1.2" />
+                    </svg>
+                    <span>New Folder</span>
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Scrollable list area */}
+          <div className="sidebar-scroll">
+            {/* Root drop zone for un-foldered workspaces */}
+            <div
+              className={`sidebar-list sidebar-drop-zone${dropTarget === '__root__' ? ' sidebar-drop-zone--active' : ''}`}
+              onDragOver={(e) => handleDropZoneDragOver(e, '__root__')}
+              onDragLeave={(e) => handleDropZoneDragLeave(e, '__root__')}
+              onDrop={(e) => handleDropZoneDrop(e, undefined)}
+            >
+              {rootWorkspaces.map(renderWorkspaceItem)}
+            </div>
+
+            {/* Folders */}
+            {folders.map((folder) => {
+              const folderWorkspaces = workspaces.filter((ws) => ws.folderId === folder.id);
+              const isOpen = !folder.collapsed;
+              const isWsDrop = dropTarget === folder.id;
+              const isFolderDrop = folderDropTarget === folder.id;
+
+              return (
+                <div
+                  key={folder.id}
+                  className={`sidebar-folder${isFolderDrop ? ' sidebar-folder--drop-target' : ''}`}
+                  draggable
+                  onDragStart={(e) => handleFolderDragStart(e, folder.id)}
+                  onDragEnd={handleFolderDragEnd}
+                  onDragOver={(e) => {
+                    handleDropZoneDragOver(e, folder.id);
+                    handleFolderDragOver(e, folder.id);
+                  }}
+                  onDragLeave={(e) => {
+                    handleDropZoneDragLeave(e, folder.id);
+                    handleFolderDragLeave(e, folder.id);
+                  }}
+                  onDrop={(e) => {
+                    // Workspace drop takes priority
+                    if (e.dataTransfer.types.includes(WS_DRAG)) {
+                      handleDropZoneDrop(e, folder.id);
+                    } else if (e.dataTransfer.types.includes(FOLDER_DRAG)) {
+                      handleFolderDrop(e, folder.id);
+                    }
+                  }}
+                >
+                  <div className="sidebar-folder-header">
+                    <span className="sidebar-drag-handle" title="Drag to reorder">
+                      <svg width="10" height="14" viewBox="0 0 10 14" fill="none">
+                        <circle cx="3" cy="3" r="1.2" fill="currentColor"/>
+                        <circle cx="7" cy="3" r="1.2" fill="currentColor"/>
+                        <circle cx="3" cy="7" r="1.2" fill="currentColor"/>
+                        <circle cx="7" cy="7" r="1.2" fill="currentColor"/>
+                        <circle cx="3" cy="11" r="1.2" fill="currentColor"/>
+                        <circle cx="7" cy="11" r="1.2" fill="currentColor"/>
+                      </svg>
+                    </span>
+                    {renamingFolderId === folder.id ? (
+                      <input
+                        ref={renameFolderInputRef}
+                        className="sidebar-rename-input"
+                        value={renameFolderValue}
+                        onChange={(e) => setRenameFolderValue(e.target.value)}
+                        onBlur={commitFolderRename}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') commitFolderRename();
+                          if (e.key === 'Escape') cancelFolderRename();
+                        }}
+                      />
+                    ) : (
+                      <button
+                        className="sidebar-folder-toggle"
+                        onClick={() => onToggleFolder(folder.id)}
+                        onDoubleClick={() => startFolderRename(folder)}
+                        title="Click to toggle · Double-click to rename"
+                      >
+                        <span className={`sidebar-folder-chevron${isOpen ? ' sidebar-folder-chevron--open' : ''}`}>
+                          <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
+                            <path d="M6 4l4 4-4 4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+                          </svg>
+                        </span>
+                        <span className="sidebar-folder-icon">
+                          <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+                            {isOpen ? (
+                              <path d="M2 5.5A1.5 1.5 0 013.5 4H6l1.5 1.5h5A1.5 1.5 0 0114 7v4.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 012 11.5v-6z" fill="currentColor" opacity="0.15" stroke="currentColor" strokeWidth="1.1" />
+                            ) : (
+                              <path d="M2 4.5A1.5 1.5 0 013.5 3H6l1.5 1.5h5A1.5 1.5 0 0114 6v5.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 012 11.5v-7z" stroke="currentColor" strokeWidth="1.2" />
+                            )}
+                          </svg>
+                        </span>
+                        <span className="sidebar-folder-name">{folder.name}</span>
+                        <span className="sidebar-folder-count">{folderWorkspaces.length}</span>
+                      </button>
+                    )}
+                    {renamingFolderId !== folder.id && (
+                      <button
+                        className="sidebar-folder-delete"
+                        onClick={() => onDeleteFolder(folder.id)}
+                        title="Delete folder"
+                      >
+                        <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+                          <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                        </svg>
+                      </button>
+                    )}
+                  </div>
+
+                  {/* Folder children */}
+                  <div
+                    className={`sidebar-folder-children${!isOpen ? ' sidebar-folder-children--collapsed' : ''}${isWsDrop ? ' sidebar-drop-zone--active' : ''}`}
+                  >
+                    {isOpen && folderWorkspaces.map(renderWorkspaceItem)}
+                    {isOpen && folderWorkspaces.length === 0 && (
+                      <div className="sidebar-folder-empty">Drop workspaces here</div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+
+            {/* Inline create input */}
+            {inlineCreate && (
+              <div className="sidebar-list">
+                <div className="sidebar-inline-create">
+                  <span className="sidebar-item-icon">
+                    {inlineCreate === 'folder' ? (
+                      <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+                        <path d="M2 4.5A1.5 1.5 0 013.5 3H6l1.5 1.5h5A1.5 1.5 0 0114 6v5.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 012 11.5v-7z" stroke="currentColor" strokeWidth="1.2" />
+                      </svg>
+                    ) : (
+                      <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+                        <rect x="2" y="2" width="12" height="12" rx="2" stroke="currentColor" strokeWidth="1.3" />
+                        <path d="M5 6h6M5 9h4" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+                      </svg>
+                    )}
+                  </span>
+                  <input
+                    ref={inlineCreateRef}
+                    className="sidebar-rename-input sidebar-rename-input--new"
+                    placeholder={inlineCreate === 'folder' ? 'Folder name…' : 'Workspace name…'}
+                    value={inlineCreateValue}
+                    onChange={(e) => setInlineCreateValue(e.target.value)}
+                    onBlur={() => (inlineCreateValue.trim() ? commitInlineCreate() : cancelInlineCreate())}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') commitInlineCreate();
+                      if (e.key === 'Escape') cancelInlineCreate();
+                    }}
+                  />
+                </div>
+              </div>
+            )}
           </div>
         </>
       )}
@@ -399,13 +495,7 @@ export const Sidebar = ({
           >
             <span className="sidebar-item-icon">
               <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-                <path
-                  d="M8 2v8M5 7l3 3 3-3M3 12h10"
-                  stroke="currentColor"
-                  strokeWidth="1.3"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
+                <path d="M8 2v8M5 7l3 3 3-3M3 12h10" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
               </svg>
             </span>
             <span className="sidebar-item-name">

--- a/apps/canvas-workspace/src/renderer/src/hooks/useWorkspaces.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useWorkspaces.ts
@@ -207,6 +207,28 @@ export const useWorkspaces = () => {
     [saveManifest]
   );
 
+  /** Reorder a folder by moving it before another folder (or to end) */
+  const reorderFolder = useCallback(
+    (folderId: string, beforeFolderId: string | null) => {
+      setFolders((prev) => {
+        const moving = prev.find((f) => f.id === folderId);
+        if (!moving) return prev;
+        const without = prev.filter((f) => f.id !== folderId);
+        if (beforeFolderId === null) {
+          const next = [...without, moving];
+          saveManifest(workspaces, undefined, next);
+          return next;
+        }
+        const idx = without.findIndex((f) => f.id === beforeFolderId);
+        if (idx === -1) return prev;
+        const next = [...without.slice(0, idx), moving, ...without.slice(idx)];
+        saveManifest(workspaces, undefined, next);
+        return next;
+      });
+    },
+    [saveManifest, workspaces]
+  );
+
   return {
     workspaces,
     folders,
@@ -221,5 +243,6 @@ export const useWorkspaces = () => {
     deleteFolder,
     toggleFolder,
     moveWorkspace,
+    reorderFolder,
   };
 };

--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -306,16 +306,125 @@ body {
   text-overflow: ellipsis;
 }
 
+/* ---- Sidebar Section Header ---- */
+
+.sidebar-section-header {
+  display: flex;
+  align-items: center;
+  padding: 16px 14px 6px;
+}
+
+.sidebar-section-header .sidebar-section-title {
+  padding: 0;
+}
+
+.sidebar-section-actions {
+  margin-left: auto;
+  position: relative;
+}
+
+.sidebar-section-btn {
+  width: 22px;
+  height: 22px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  transition: background 0.1s, color 0.1s;
+}
+
+.sidebar-section-btn:hover {
+  background: rgba(0, 0, 0, 0.06);
+  color: var(--text-secondary);
+}
+
+/* ---- Add menu popover ---- */
+
+.sidebar-add-menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 4px;
+  min-width: 160px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-float);
+  padding: 4px;
+  z-index: 100;
+}
+
+.sidebar-add-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 8px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--text);
+  text-align: left;
+  transition: background 0.1s;
+}
+
+.sidebar-add-menu-item:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.sidebar-add-menu-item svg {
+  flex-shrink: 0;
+  color: var(--text-secondary);
+}
+
+/* ---- Sidebar Scrollable List ---- */
+
+.sidebar-scroll {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  min-height: 0;
+}
+
+/* ---- Inline create row ---- */
+
+.sidebar-inline-create {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 6px;
+}
+
+.sidebar-inline-create .sidebar-item-icon {
+  color: var(--text-muted);
+}
+
+.sidebar-inline-create .sidebar-rename-input {
+  flex: 1;
+}
+
 /* ---- Sidebar Folders ---- */
 
 .sidebar-folder {
   margin: 2px 0;
+  transition: background 0.15s;
+  border-radius: var(--radius-sm);
+}
+
+.sidebar-folder--drop-target {
+  background: rgba(35, 131, 226, 0.04);
 }
 
 .sidebar-folder-header {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: 0;
   padding: 0 6px;
   position: relative;
 }
@@ -323,10 +432,10 @@ body {
 .sidebar-folder-toggle {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 3px;
   flex: 1;
   min-width: 0;
-  padding: 5px 6px;
+  padding: 5px 4px;
   border: none;
   background: transparent;
   border-radius: var(--radius-sm);
@@ -349,7 +458,8 @@ body {
   width: 16px;
   height: 16px;
   flex-shrink: 0;
-  transition: transform 0.15s ease;
+  transform: rotate(0deg);
+  transition: transform 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
   color: var(--text-muted);
 }
 
@@ -361,8 +471,8 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 16px;
-  height: 16px;
+  width: 18px;
+  height: 18px;
   flex-shrink: 0;
   color: var(--text-secondary);
 }
@@ -373,6 +483,7 @@ body {
   text-overflow: ellipsis;
   flex: 1;
   min-width: 0;
+  margin-left: 2px;
 }
 
 .sidebar-folder-count {
@@ -408,11 +519,11 @@ body {
 }
 
 .sidebar-folder-children {
-  padding: 0 0 0 12px;
-  margin: 0 6px;
+  padding: 0 0 0 10px;
+  margin: 0 6px 0 16px;
   border-left: 1.5px solid var(--border-light);
   transition: border-color 0.15s;
-  min-height: 4px;
+  min-height: 2px;
 }
 
 .sidebar-folder-children--collapsed {
@@ -420,10 +531,40 @@ body {
 }
 
 .sidebar-folder-empty {
-  padding: 4px 8px 4px 20px;
+  padding: 6px 8px 6px 14px;
   font-size: 11px;
   color: var(--text-muted);
   font-style: italic;
+}
+
+/* ---- Drag Handle ---- */
+
+.sidebar-drag-handle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 20px;
+  flex-shrink: 0;
+  color: var(--text-muted);
+  cursor: grab;
+  opacity: 0;
+  transition: opacity 0.1s;
+  margin-right: 2px;
+}
+
+.sidebar-drag-handle:active {
+  cursor: grabbing;
+}
+
+.sidebar-item-row:hover .sidebar-drag-handle,
+.sidebar-folder-header:hover .sidebar-drag-handle {
+  display: flex;
+  opacity: 0.6;
+}
+
+.sidebar-drag-handle:hover {
+  opacity: 1 !important;
 }
 
 /* ---- Drag & Drop States ---- */
@@ -431,15 +572,14 @@ body {
 .sidebar-workspace-entry {
   display: flex;
   flex-direction: column;
-  cursor: grab;
-}
-
-.sidebar-workspace-entry:active {
-  cursor: grabbing;
 }
 
 .sidebar-workspace-entry[draggable="true"] {
   transition: opacity 0.15s;
+}
+
+.sidebar-dragging {
+  opacity: 0.4;
 }
 
 .sidebar-drop-zone {


### PR DESCRIPTION
- Add visible drag handles (6-dot grip) on hover for both workspaces and folders
- Replace "New Workspace"/"New Folder" full-width buttons with a compact "+" dropdown menu in the section header
- Make folders draggable for reorder via drag-and-drop
- Improve chevron animation with cubic-bezier easing
- Folder icon changes to filled style when expanded
- Add opacity feedback on dragged items
- Wrap list area in scrollable container

https://claude.ai/code/session_01VwNHE8Cws714vAKkGx7EYW