### PR TITLE
feat(remote-server): reuse latest image attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ bower_components
 build/Release
 
 # Dependency directories
+/node_modules
 node_modules/
 jspm_packages/
 

--- a/apps/remote-server/src/adapters/discord/gateway.ts
+++ b/apps/remote-server/src/adapters/discord/gateway.ts
@@ -1,5 +1,5 @@
 import { dispatchIncoming } from '../../core/dispatcher.js';
-import type { IncomingMessage } from '../../core/types.js';
+import type { IncomingMessage, IncomingAttachment } from '../../core/types.js';
 import { discordAdapter } from './adapter.js';
 import { DiscordClient } from './client.js';
 import { getDiscordProxyDispatcher } from './proxy.js';
@@ -37,6 +37,16 @@ interface MessageCreatePayload {
   mentions?: Array<{
     id?: string;
   }>;
+  attachments?: DiscordMessageAttachment[];
+}
+
+interface DiscordMessageAttachment {
+  id?: string;
+  filename?: string;
+  content_type?: string;
+  size?: number;
+  url?: string;
+  proxy_url?: string;
 }
 
 interface ThreadCreatePayload {
@@ -408,7 +418,9 @@ export class DiscordDmGateway {
 
     const textSource = isGuildMessage ? stripSelfMention(rawContent, this.selfUserId) : rawContent;
     const normalizedText = normalizeGatewayText(textSource);
-    if (!normalizedText) {
+    const attachments = extractIncomingAttachments(message.attachments, messageId);
+
+    if (!normalizedText && attachments.length === 0) {
       return;
     }
 
@@ -422,6 +434,7 @@ export class DiscordDmGateway {
       platformKey,
       memoryKey,
       text: normalizedText,
+      attachments: attachments.length > 0 ? attachments : undefined,
       streamId: messageId,
     };
 
@@ -559,6 +572,35 @@ async function toGatewayPayloadText(raw: unknown): Promise<string | null> {
   }
 
   return null;
+}
+
+function extractIncomingAttachments(
+  attachments: DiscordMessageAttachment[] | undefined,
+  messageId?: string,
+): IncomingAttachment[] {
+  if (!attachments || attachments.length === 0) {
+    return [];
+  }
+
+  const results: IncomingAttachment[] = [];
+  for (const attachment of attachments) {
+    const url = attachment.url?.trim() || attachment.proxy_url?.trim();
+    if (!url) {
+      continue;
+    }
+
+    results.push({
+      id: attachment.id,
+      url,
+      name: attachment.filename?.trim() || undefined,
+      mimeType: attachment.content_type?.trim() || undefined,
+      size: typeof attachment.size === 'number' ? attachment.size : undefined,
+      source: 'discord',
+      messageId,
+    });
+  }
+
+  return results;
 }
 
 function normalizeGatewayText(text: string): string {

--- a/apps/remote-server/src/core/agent-runner.ts
+++ b/apps/remote-server/src/core/agent-runner.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from 'crypto';
-import type { CompactionEvent } from 'pulse-coder-engine';
-import type { ClarificationRequest } from './types.js';
+import type { CompactionEvent, ModelMessage } from 'pulse-coder-engine';
+import type { ClarificationRequest, IncomingAttachment } from './types.js';
 import { engine } from './engine-singleton.js';
 import { getAcpState, runAcp } from 'pulse-coder-acp';
 import { sessionStore } from './session-store.js';
+import { buildAttachmentSystemPrompt, resolveIncomingAttachments } from './attachments.js';
 import { memoryIntegration, recordDailyLogFromSuccessPath } from './memory-integration.js';
 import { buildRemoteWorktreeRunContext, worktreeIntegration } from './worktree/integration.js';
 import { buildRemoteVaultRunContext, vaultIntegration } from './vault/integration.js';
@@ -39,6 +40,7 @@ export interface ExecuteAgentTurnInput {
   forceNewSession?: boolean;
   userText: string;
   source: 'dispatcher' | 'internal';
+  attachments?: IncomingAttachment[];
   caller?: string;
   callerSelectors?: string[];
   abortSignal?: AbortSignal;
@@ -100,6 +102,7 @@ function buildRunContext(input: {
   ownerKey?: string;
   caller?: string;
   callerSelectors?: string[];
+  latestAttachments?: unknown[];
 }): Record<string, any> {
   const channel = parseChannelInfo(input.platformKey);
   const callerContext = buildToolCallerContext({
@@ -116,6 +119,8 @@ function buildRunContext(input: {
     channel: channel ?? undefined,
     caller: callerContext.caller,
     callerSelectors: callerContext.callerSelectors,
+    latestAttachments: input.latestAttachments ?? [],
+    attachments: input.latestAttachments ?? [],
   };
 }
 
@@ -234,6 +239,24 @@ export async function executeAgentTurn(input: ExecuteAgentTurnInput): Promise<Ex
   const compactions: CompactionSnapshot[] = [];
   const { model: modelOverride, modelType } = await resolveModelForRun(input.platformKey);
 
+  let latestAttachments = session.latestAttachments ?? [];
+  if (input.attachments?.length) {
+    const resolved = await resolveIncomingAttachments({
+      platformKey: input.platformKey,
+      ownerKey: input.memoryKey,
+      attachments: input.attachments,
+    });
+    if (resolved.hadImageAttachments) {
+      latestAttachments = resolved.attachments;
+      await sessionStore.setLatestAttachments(sessionId, latestAttachments);
+    }
+    if (resolved.errors.length > 0) {
+      console.warn(`[agent-runner] Attachment download errors for ${input.platformKey}:`, resolved.errors);
+    }
+  }
+
+  const attachmentPrompt = buildAttachmentSystemPrompt(latestAttachments);
+
   context.messages.push({ role: 'user', content: input.userText });
 
   const runContext = buildRunContext({
@@ -244,6 +267,7 @@ export async function executeAgentTurn(input: ExecuteAgentTurnInput): Promise<Ex
     ownerKey: input.memoryKey,
     caller: input.caller,
     callerSelectors: input.callerSelectors,
+    latestAttachments,
   });
 
   const acpState = await getAcpState(input.platformKey);
@@ -284,18 +308,22 @@ export async function executeAgentTurn(input: ExecuteAgentTurnInput): Promise<Ex
         runContext,
         systemPrompt: (() => {
           const channelPrompt = buildChannelSystemPrompt(input.platformKey);
-          return channelPrompt ? { append: `\n${channelPrompt}` } : undefined;
+          const parts = [channelPrompt, attachmentPrompt].filter(Boolean) as string[];
+          if (parts.length === 0) {
+            return undefined;
+          }
+          return { append: `\n${parts.join('\n\n')}` };
         })(),
         abortSignal: input.abortSignal,
         onText: callbacks.onText,
         onToolCall: callbacks.onToolCall,
         onToolResult: callbacks.onToolResult,
-        onResponse: (messages) => {
+        onResponse: (messages: ModelMessage[]) => {
           for (const msg of messages) {
             context.messages.push(msg);
           }
         },
-        onCompacted: (newMessages, event) => {
+        onCompacted: (newMessages: ModelMessage[], event: CompactionSnapshot | undefined) => {
           if (event) {
             compactions.push(event);
             callbacks.onCompactionEvent?.(event);

--- a/apps/remote-server/src/core/attachments.test.ts
+++ b/apps/remote-server/src/core/attachments.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildAttachmentSystemPrompt, hasIncomingImageAttachments, isImageAttachment, resolveIncomingAttachments } from './attachments.js';
+
+describe('attachment helpers', () => {
+  it('detects image attachments by mime type and filename', () => {
+    expect(isImageAttachment({ url: 'https://example.com/file', mimeType: 'image/png' })).toBe(true);
+    expect(isImageAttachment({ url: 'https://example.com/file.JPG', name: 'photo.JPG' })).toBe(true);
+    expect(isImageAttachment({ url: 'https://example.com/file.pdf', name: 'file.pdf', mimeType: 'application/pdf' })).toBe(false);
+  });
+
+  it('reports whether an incoming message contains any image attachments', () => {
+    expect(hasIncomingImageAttachments()).toBe(false);
+    expect(hasIncomingImageAttachments([{ url: 'https://example.com/file.pdf', name: 'file.pdf', mimeType: 'application/pdf' }])).toBe(false);
+    expect(hasIncomingImageAttachments([{ url: 'https://example.com/file.png', name: 'file.png' }])).toBe(true);
+  });
+
+  it('does not treat non-image attachments as latest image attachments', async () => {
+    const result = await resolveIncomingAttachments({
+      platformKey: 'discord:thread:test',
+      attachments: [
+        {
+          url: 'https://example.com/report.pdf',
+          name: 'report.pdf',
+          mimeType: 'application/pdf',
+        },
+      ],
+    });
+
+    expect(result.hadImageAttachments).toBe(false);
+    expect(result.attachments).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('builds a system prompt for the latest attachments', () => {
+    const prompt = buildAttachmentSystemPrompt([
+      {
+        id: 'att-1',
+        path: '/tmp/photo.png',
+        name: 'photo.png',
+        mimeType: 'image/png',
+        size: 2048,
+        createdAt: 1,
+      },
+    ]);
+
+    expect(prompt).toContain('Latest attachments available:');
+    expect(prompt).toContain('name=photo.png');
+    expect(prompt).toContain('Use tool analyze_image without imagePaths');
+  });
+});

--- a/apps/remote-server/src/core/attachments.ts
+++ b/apps/remote-server/src/core/attachments.ts
@@ -1,0 +1,239 @@
+import { randomUUID } from 'crypto';
+import { promises as fs } from 'fs';
+import { homedir } from 'os';
+import { basename, extname, join } from 'path';
+import { fetch } from 'undici';
+import type { IncomingAttachment } from './types.js';
+import { vaultIntegration, buildRemoteVaultRunContext } from './vault/integration.js';
+
+export interface StoredAttachment {
+  id: string;
+  path: string;
+  mimeType?: string;
+  name?: string;
+  size?: number;
+  source?: string;
+  messageId?: string;
+  createdAt: number;
+  originalUrl?: string;
+}
+
+export interface ResolveAttachmentsResult {
+  attachments: StoredAttachment[];
+  errors: string[];
+  hadImageAttachments: boolean;
+}
+
+const DEFAULT_MAX_BYTES = 10 * 1024 * 1024;
+const DEFAULT_MAX_COUNT = 6;
+const DEFAULT_TIMEOUT_MS = 20000;
+const DEFAULT_FALLBACK_DIR = join(homedir(), '.pulse-coder', 'remote-attachments');
+
+const IMAGE_EXTENSIONS = new Set([
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.webp',
+  '.gif',
+  '.bmp',
+]);
+
+const MIME_EXTENSION_MAP: Record<string, string> = {
+  'image/png': '.png',
+  'image/jpeg': '.jpg',
+  'image/jpg': '.jpg',
+  'image/webp': '.webp',
+  'image/gif': '.gif',
+  'image/bmp': '.bmp',
+};
+
+export async function resolveIncomingAttachments(input: {
+  platformKey: string;
+  ownerKey?: string;
+  attachments?: IncomingAttachment[];
+}): Promise<ResolveAttachmentsResult> {
+  const incoming = input.attachments ?? [];
+  const maxCount = readEnvInt('ATTACHMENT_MAX_COUNT', DEFAULT_MAX_COUNT);
+
+  if (incoming.length === 0) {
+    return { attachments: [], errors: [], hadImageAttachments: false };
+  }
+
+  const candidates = incoming.filter((attachment) => isImageAttachment(attachment)).slice(0, maxCount);
+  const errors: string[] = [];
+  const hadImageAttachments = candidates.length > 0;
+
+  if (candidates.length === 0) {
+    return { attachments: [], errors, hadImageAttachments };
+  }
+
+  const targetDir = await resolveAttachmentDirectory(input.platformKey, input.ownerKey);
+  await fs.mkdir(targetDir, { recursive: true });
+
+  const results: StoredAttachment[] = [];
+  for (const attachment of candidates) {
+    try {
+      const stored = await downloadAttachment(attachment, targetDir);
+      if (stored) {
+        results.push(stored);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      errors.push(message);
+    }
+  }
+
+  return { attachments: results, errors, hadImageAttachments };
+}
+
+export function hasIncomingImageAttachments(attachments?: IncomingAttachment[]): boolean {
+  return (attachments ?? []).some((attachment) => isImageAttachment(attachment));
+}
+
+export function buildAttachmentSystemPrompt(attachments: StoredAttachment[]): string | null {
+  if (!attachments.length) {
+    return null;
+  }
+
+  const lines = [
+    'Latest attachments available:',
+    ...attachments.map((attachment, index) => {
+      const sizeLabel = attachment.size ? `${Math.round(attachment.size / 1024)}KB` : 'unknown';
+      const nameLabel = attachment.name ? ` name=${attachment.name}` : '';
+      const mimeLabel = attachment.mimeType ? ` mime=${attachment.mimeType}` : '';
+      return `- [${index + 1}] id=${attachment.id}${nameLabel}${mimeLabel} size=${sizeLabel}`;
+    }),
+    'Use tool analyze_image without imagePaths to analyze the latest attachments by default.',
+  ];
+
+  return lines.join('\n');
+}
+
+async function resolveAttachmentDirectory(platformKey: string, ownerKey?: string): Promise<string> {
+  const vault = await vaultIntegration.getVault({
+    runContext: buildRemoteVaultRunContext(platformKey),
+    engineRunContext: { platformKey, ownerKey },
+  });
+
+  const baseDir = vault?.artifactsPath ?? DEFAULT_FALLBACK_DIR;
+  return join(baseDir, 'attachments', sanitizeSegment(platformKey));
+}
+
+async function downloadAttachment(attachment: IncomingAttachment, targetDir: string): Promise<StoredAttachment | null> {
+  const timeoutMs = readEnvInt('ATTACHMENT_TIMEOUT_MS', DEFAULT_TIMEOUT_MS);
+  const maxBytes = readEnvInt('ATTACHMENT_MAX_BYTES', DEFAULT_MAX_BYTES);
+
+  const url = attachment.url.trim();
+  if (!url) {
+    return null;
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'User-Agent': 'pulse-remote-server',
+      },
+      signal: controller.signal,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to fetch attachment: ${message}`);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Attachment download failed (${response.status} ${response.statusText}): ${body}`);
+  }
+
+  const contentLength = Number(response.headers.get('content-length') ?? '0');
+  if (contentLength && contentLength > maxBytes) {
+    throw new Error(`Attachment exceeds size limit (${contentLength} > ${maxBytes})`);
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+  if (buffer.length > maxBytes) {
+    throw new Error(`Attachment exceeds size limit (${buffer.length} > ${maxBytes})`);
+  }
+
+  const resolvedMime = normalizeMimeType(attachment.mimeType || response.headers.get('content-type'));
+  const extension = resolveExtension(attachment.name, resolvedMime, url);
+  const displayName = attachment.name ? sanitizeFileName(attachment.name) : undefined;
+  const fileNameBase = displayName || `${attachment.id ?? randomUUID()}${extension}`;
+  const fileName = `${Date.now()}-${fileNameBase}`;
+  const outputPath = join(targetDir, fileName);
+
+  await fs.writeFile(outputPath, buffer);
+
+  return {
+    id: attachment.id ?? randomUUID(),
+    path: outputPath,
+    mimeType: resolvedMime ?? undefined,
+    name: displayName ?? basename(outputPath),
+    size: buffer.length,
+    source: attachment.source,
+    messageId: attachment.messageId,
+    createdAt: Date.now(),
+    originalUrl: attachment.url,
+  };
+}
+
+export function isImageAttachment(attachment: IncomingAttachment): boolean {
+  if (attachment.mimeType && attachment.mimeType.startsWith('image/')) {
+    return true;
+  }
+
+  const extension = resolveExtension(attachment.name, attachment.mimeType, attachment.url);
+  return IMAGE_EXTENSIONS.has(extension);
+}
+
+function resolveExtension(name?: string, mimeType?: string | null, url?: string): string {
+  const fromName = name ? extname(name).toLowerCase() : '';
+  if (fromName) {
+    return fromName;
+  }
+
+  const fromUrl = url ? extname(url.split('?')[0]).toLowerCase() : '';
+  if (fromUrl) {
+    return fromUrl;
+  }
+
+  const normalizedMime = normalizeMimeType(mimeType);
+  if (normalizedMime && MIME_EXTENSION_MAP[normalizedMime]) {
+    return MIME_EXTENSION_MAP[normalizedMime];
+  }
+
+  return '';
+}
+
+function normalizeMimeType(mimeType?: string | null): string | null {
+  if (!mimeType) {
+    return null;
+  }
+  const normalized = mimeType.split(';')[0]?.trim().toLowerCase();
+  return normalized || null;
+}
+
+function sanitizeSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+function sanitizeFileName(name: string): string {
+  const base = basename(name);
+  return base.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+function readEnvInt(key: string, fallback: number): number {
+  const raw = process.env[key]?.trim();
+  if (!raw) {
+    return fallback;
+  }
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}

--- a/apps/remote-server/src/core/dispatcher.ts
+++ b/apps/remote-server/src/core/dispatcher.ts
@@ -5,6 +5,7 @@ import { clarificationQueue } from './clarification-queue.js';
 import { processIncomingCommand } from './chat-commands.js';
 import type { CommandResult } from './chat-commands/types.js';
 import { executeAgentTurn, formatCompactionEvents } from './agent-runner.js';
+import { hasIncomingImageAttachments } from './attachments.js';
 import {
   hasActiveRun,
   setActiveRun,
@@ -110,6 +111,10 @@ async function runAgentAsync(adapter: PlatformAdapter, incoming: IncomingMessage
     text = commandResult.text;
   }
 
+  if (!text.trim() && hasIncomingImageAttachments(incoming.attachments)) {
+    text = '用户上传了图片，请结合最新附件回答。';
+  }
+
   // Prevent concurrent runs for the same user
   if (hasActiveRun(platformKey)) {
     const handle = await adapter.createStreamHandle(incoming, 'busy');
@@ -134,6 +139,7 @@ async function runAgentAsync(adapter: PlatformAdapter, incoming: IncomingMessage
       memoryKey,
       forceNewSession,
       userText: text,
+      attachments: incoming.attachments,
       source: 'dispatcher',
       caller: incoming.caller,
       callerSelectors: incoming.callerSelectors,

--- a/apps/remote-server/src/core/engine-singleton.ts
+++ b/apps/remote-server/src/core/engine-singleton.ts
@@ -2,6 +2,7 @@ import { Engine } from 'pulse-coder-engine';
 import { memoryIntegration } from './memory-integration.js';
 import { worktreeIntegration } from './worktree/integration.js';
 import { vaultIntegration } from './vault/integration.js';
+import { analyzeImageTool } from './tools/analyze-image.js';
 import { cronJobTool } from './tools/cron-job.js';
 import { deferDemoTool } from './tools/defer-demo.js';
 import { jinaAiReadTool } from './tools/jina-ai.js';
@@ -25,6 +26,7 @@ export const engine = new Engine({
     ],
   },
   tools: {
+    analyze_image: analyzeImageTool,
     cron_job: cronJobTool,
     deferred_demo: deferDemoTool,
     jina_ai_read: jinaAiReadTool,

--- a/apps/remote-server/src/core/session-store.ts
+++ b/apps/remote-server/src/core/session-store.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
 import type { Context } from './types.js';
+import type { StoredAttachment } from './attachments.js';
 // ModelMessage is the Vercel AI SDK type, re-exported via pulse-coder-engine
 // Context.messages is ModelMessage[] so we can use unknown[] as the storage type
 // and cast when needed — avoids adding `ai` as a direct dependency
@@ -14,6 +15,7 @@ interface RemoteSession {
   createdAt: number;
   updatedAt: number;
   messages: unknown[]; // Stored as-is; cast to Context['messages'] on load
+  latestAttachments?: StoredAttachment[];
 }
 
 export interface RemoteSessionSummary {
@@ -57,6 +59,7 @@ export interface SessionDetail {
   createdAt: number;
   updatedAt: number;
   messages: unknown[];
+  latestAttachments?: StoredAttachment[];
 }
 
 /**
@@ -128,6 +131,7 @@ class RemoteSessionStore {
       createdAt: session.createdAt,
       updatedAt: session.updatedAt,
       messages: this.cloneMessages(session.messages),
+      latestAttachments: this.cloneAttachments(session.latestAttachments),
     };
   }
 
@@ -143,7 +147,7 @@ class RemoteSessionStore {
     platformKey: string,
     forceNew?: boolean,
     ownerKey?: string,
-  ): Promise<{ sessionId: string; context: Context; isNew: boolean }> {
+  ): Promise<{ sessionId: string; context: Context; latestAttachments: StoredAttachment[]; isNew: boolean }> {
     let sessionId = forceNew ? undefined : this.index[platformKey];
 
     if (sessionId) {
@@ -153,7 +157,12 @@ class RemoteSessionStore {
           session.ownerKey = ownerKey;
           await this.writeSession(session);
         }
-        return { sessionId, context: { messages: session.messages as Context['messages'] }, isNew: false };
+        return {
+          sessionId,
+          context: { messages: session.messages as Context['messages'] },
+          latestAttachments: this.cloneAttachments(session.latestAttachments),
+          isNew: false,
+        };
       }
       // Session file missing — create fresh
       sessionId = undefined;
@@ -168,13 +177,19 @@ class RemoteSessionStore {
       createdAt: Date.now(),
       updatedAt: Date.now(),
       messages: [],
+      latestAttachments: [],
     };
 
     await this.writeSession(session);
     this.index[platformKey] = sessionId;
     await this.saveIndex();
 
-    return { sessionId, context: { messages: [] }, isNew: true };
+    return {
+      sessionId,
+      context: { messages: [] },
+      latestAttachments: [],
+      isNew: true,
+    };
   }
 
   /**
@@ -189,7 +204,7 @@ class RemoteSessionStore {
   /**
    * Load the currently attached session context for a user.
    */
-  async getCurrent(platformKey: string): Promise<{ sessionId: string; context: Context } | null> {
+  async getCurrent(platformKey: string): Promise<{ sessionId: string; context: Context; latestAttachments: StoredAttachment[] } | null> {
     const sessionId = this.index[platformKey];
     if (!sessionId) {
       return null;
@@ -203,6 +218,7 @@ class RemoteSessionStore {
     return {
       sessionId,
       context: { messages: session.messages as Context['messages'] },
+      latestAttachments: this.cloneAttachments(session.latestAttachments),
     };
   }
 
@@ -252,6 +268,26 @@ class RemoteSessionStore {
       await this.writeSession(session);
     } catch (err) {
       console.error(`[session-store] Failed to save session ${sessionId}:`, err);
+    }
+  }
+
+  /**
+   * Persist the latest attachments for a session.
+   */
+  async setLatestAttachments(sessionId: string, attachments: StoredAttachment[]): Promise<void> {
+    const session = await this.readSession(sessionId);
+    if (!session) {
+      console.error(`[session-store] Failed to update attachments ${sessionId}: session not found`);
+      return;
+    }
+
+    session.latestAttachments = this.cloneAttachments(attachments);
+    session.updatedAt = Date.now();
+
+    try {
+      await this.writeSession(session);
+    } catch (err) {
+      console.error(`[session-store] Failed to update attachments ${sessionId}:`, err);
     }
   }
 
@@ -306,6 +342,7 @@ class RemoteSessionStore {
     }
 
     session.messages = [];
+    session.latestAttachments = [];
     session.updatedAt = Date.now();
     await this.writeSession(session);
 
@@ -335,6 +372,7 @@ class RemoteSessionStore {
       createdAt: now,
       updatedAt: now,
       messages: this.cloneMessages(session.messages),
+      latestAttachments: this.cloneAttachments(session.latestAttachments),
     };
 
     await this.writeSession(forkedSession);
@@ -426,6 +464,26 @@ class RemoteSessionStore {
   private truncate(text: string, max = 120): string {
     if (!text) return '(no text)';
     return text.length > max ? `${text.slice(0, max)}...` : text;
+  }
+
+  private cloneAttachments(attachments?: StoredAttachment[]): StoredAttachment[] {
+    if (!attachments || attachments.length === 0) {
+      return [];
+    }
+
+    if (typeof structuredClone === 'function') {
+      try {
+        return structuredClone(attachments);
+      } catch {
+        // Fall through to JSON cloning for non-cloneable values.
+      }
+    }
+
+    try {
+      return JSON.parse(JSON.stringify(attachments)) as StoredAttachment[];
+    } catch {
+      return attachments.map((entry) => ({ ...entry }));
+    }
   }
 
   private cloneMessages(messages: unknown[]): unknown[] {

--- a/apps/remote-server/src/core/tools/analyze-image.test.ts
+++ b/apps/remote-server/src/core/tools/analyze-image.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const { mockFetch } = vi.hoisted(() => ({
+  mockFetch: vi.fn(),
+}));
+
+vi.mock('undici', () => ({
+  fetch: mockFetch,
+}));
+
+import { analyzeImageTool } from './analyze-image.js';
+
+describe('analyzeImageTool', () => {
+  let tempDir: string;
+  let attachmentPath: string;
+  let explicitPath: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'analyze-image-tool-'));
+    attachmentPath = join(tempDir, 'attachment.png');
+    explicitPath = join(tempDir, 'explicit.jpg');
+    await writeFile(attachmentPath, 'attachment-image');
+    await writeFile(explicitPath, 'explicit-image');
+    process.env.GEMINI_API_KEY = 'test-key';
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        candidates: [
+          {
+            content: {
+              parts: [{ text: 'analysis result' }],
+            },
+          },
+        ],
+      }),
+    });
+  });
+
+  afterEach(async () => {
+    delete process.env.GEMINI_API_KEY;
+    await rm(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('uses runContext latestAttachments when imagePaths are omitted', async () => {
+    const result = await analyzeImageTool.execute(
+      { prompt: 'describe it' },
+      {
+        runContext: {
+          latestAttachments: [
+            {
+              id: 'att-1',
+              path: attachmentPath,
+              mimeType: 'image/png',
+              createdAt: Date.now(),
+            },
+          ],
+        },
+      },
+    );
+
+    expect(result.source).toBe('runContext.latestAttachments');
+    expect(result.imagePaths).toEqual([attachmentPath]);
+    expect(result.text).toBe('analysis result');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const request = mockFetch.mock.calls[0]?.[1];
+    const body = JSON.parse(String(request?.body));
+    expect(body.contents[0].parts[0].text).toBe('describe it');
+    expect(body.contents[0].parts[1].inlineData.mimeType).toBe('image/png');
+  });
+
+  it('prefers explicit imagePaths over runContext attachments', async () => {
+    const result = await analyzeImageTool.execute(
+      { imagePaths: [explicitPath] },
+      {
+        runContext: {
+          latestAttachments: [
+            {
+              id: 'att-1',
+              path: attachmentPath,
+              mimeType: 'image/png',
+              createdAt: Date.now(),
+            },
+          ],
+        },
+      },
+    );
+
+    expect(result.source).toBe('input.imagePaths');
+    expect(result.imagePaths).toEqual([explicitPath]);
+
+    const request = mockFetch.mock.calls[0]?.[1];
+    const body = JSON.parse(String(request?.body));
+    expect(body.contents[0].parts[1].inlineData.mimeType).toBe('image/jpeg');
+  });
+
+  it('throws when neither imagePaths nor latestAttachments are available', async () => {
+    await expect(analyzeImageTool.execute({}, { runContext: {} })).rejects.toThrow(
+      'No images available. Provide imagePaths or upload images so runContext.latestAttachments is populated.',
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/remote-server/src/core/tools/analyze-image.ts
+++ b/apps/remote-server/src/core/tools/analyze-image.ts
@@ -1,0 +1,251 @@
+import { promises as fs } from 'fs';
+import { fetch } from 'undici';
+import z from 'zod';
+import type { Tool, ToolExecutionContext } from 'pulse-coder-engine';
+import type { StoredAttachment } from '../attachments.js';
+
+interface AnalyzeImageRequestTarget {
+  endpoint: string;
+  headers: Record<string, string>;
+  model: string;
+}
+
+interface GenerateContentResponse {
+  candidates?: Array<{
+    content?: {
+      parts?: Array<{
+        text?: string;
+      }>;
+    };
+    finishReason?: string;
+  }>;
+  promptFeedback?: {
+    blockReason?: string;
+  };
+}
+
+const toolSchema = z.object({
+  prompt: z.string().optional().describe('Question or instruction for the image analysis. Defaults to a concise Chinese image analysis prompt.'),
+  imagePaths: z.array(z.string().min(1)).optional().describe('Optional local image paths. When omitted, the tool uses runContext.latestAttachments.'),
+  maxImages: z.number().int().positive().max(10).optional().describe('Maximum number of images to analyze. Defaults to 6.'),
+  timeoutMs: z.number().int().positive().max(600000).optional().describe('Request timeout in milliseconds. Defaults to 120000.'),
+});
+
+type AnalyzeImageInput = z.infer<typeof toolSchema>;
+
+interface AnalyzeImageResult {
+  ok: boolean;
+  model: string;
+  prompt: string;
+  imageCount: number;
+  imagePaths: string[];
+  text: string;
+  source: 'runContext.latestAttachments' | 'input.imagePaths';
+}
+
+interface AnalyzeImageToolContext extends ToolExecutionContext {
+  runContext?: Record<string, any>;
+}
+
+const DEFAULT_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta';
+const DEFAULT_MODEL = 'gemini-2.5-flash';
+const DEFAULT_TIMEOUT_MS = 120000;
+const DEFAULT_MAX_IMAGES = 6;
+const DEFAULT_PROMPT = '请按图片顺序描述关键信息，识别文字，提取主体内容，并结合用户上下文回答问题。如果存在多个图片，先分别概述，再总结。';
+
+type ImageInlinePart = {
+  inlineData: {
+    mimeType: string;
+    data: string;
+  };
+};
+
+export const analyzeImageTool: Tool<AnalyzeImageInput, AnalyzeImageResult> = {
+  name: 'analyze_image',
+  description: 'Analyze one or more local images with Gemini. If imagePaths are omitted, automatically uses runContext.latestAttachments from the latest image message.',
+  inputSchema: toolSchema,
+  execute: async (input: AnalyzeImageInput, context?: AnalyzeImageToolContext): Promise<AnalyzeImageResult> => {
+    const apiKey = process.env.GEMINI_API_KEY?.trim();
+    if (!apiKey) {
+      throw new Error('GEMINI_API_KEY environment variable is not set');
+    }
+
+    const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const maxImages = input.maxImages ?? DEFAULT_MAX_IMAGES;
+    const prompt = input.prompt?.trim() || DEFAULT_PROMPT;
+
+    const runContextAttachments = extractRunContextAttachments(context?.runContext);
+    const resolvedPaths = (input.imagePaths?.length ? input.imagePaths : runContextAttachments.map((item) => item.path))
+      .map((value: string) => value.trim())
+      .filter((value: string) => value.length > 0)
+      .slice(0, maxImages);
+
+    if (resolvedPaths.length === 0) {
+      throw new Error('No images available. Provide imagePaths or upload images so runContext.latestAttachments is populated.');
+    }
+
+    const imageParts: ImageInlinePart[] = await Promise.all(
+      resolvedPaths.map(async (imagePath: string): Promise<ImageInlinePart> => {
+        const buffer = await fs.readFile(imagePath);
+        const mimeType = resolveMimeType(imagePath, runContextAttachments);
+        return {
+          inlineData: {
+            mimeType,
+            data: buffer.toString('base64'),
+          },
+        };
+      }),
+    );
+
+    const baseUrl = (process.env.GEMINI_API_BASE_URL?.trim() || DEFAULT_BASE_URL).replace(/\/$/, '');
+    const model = process.env.GEMINI_ANALYZE_IMAGE_MODEL?.trim() || process.env.GEMINI_VISION_MODEL?.trim() || DEFAULT_MODEL;
+    const requestTarget = buildGenerateRequestTarget(baseUrl, model, apiKey);
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+    let response: Response;
+    try {
+      response = await fetch(requestTarget.endpoint, {
+        method: 'POST',
+        headers: requestTarget.headers,
+        body: JSON.stringify({
+          contents: [
+            {
+              role: 'user',
+              parts: [
+                { text: prompt },
+                ...imageParts,
+              ],
+            },
+          ],
+        }),
+        signal: controller.signal,
+      });
+    } catch (error) {
+      const isAbort = error instanceof Error && error.name === 'AbortError';
+      if (isAbort) {
+        throw new Error(`Image analysis request timed out after ${timeoutMs}ms`);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Image analysis API error: ${response.status} ${response.statusText} - ${body}`);
+    }
+
+    const data = await response.json() as GenerateContentResponse;
+    const text = extractText(data);
+    if (!text) {
+      const blockReason = data.promptFeedback?.blockReason;
+      if (blockReason) {
+        throw new Error(`Image analysis blocked the request: ${blockReason}`);
+      }
+      throw new Error('Image analysis response did not include text');
+    }
+
+    return {
+      ok: true,
+      model: requestTarget.model,
+      prompt,
+      imageCount: resolvedPaths.length,
+      imagePaths: resolvedPaths,
+      text,
+      source: input.imagePaths?.length ? 'input.imagePaths' : 'runContext.latestAttachments',
+    };
+  },
+};
+
+function extractRunContextAttachments(runContext?: Record<string, any>): StoredAttachment[] {
+  const raw = runContext?.latestAttachments ?? runContext?.attachments;
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  return raw
+    .filter((item): item is StoredAttachment => Boolean(item) && typeof item === 'object' && typeof (item as StoredAttachment).path === 'string')
+    .map((item) => ({ ...item }));
+}
+
+function extractText(data: GenerateContentResponse): string {
+  const chunks: string[] = [];
+
+  for (const candidate of data.candidates ?? []) {
+    for (const part of candidate.content?.parts ?? []) {
+      if (part.text?.trim()) {
+        chunks.push(part.text.trim());
+      }
+    }
+  }
+
+  return chunks.join('\n').trim();
+}
+
+function resolveMimeType(imagePath: string, attachments: StoredAttachment[]): string {
+  const matched = attachments.find((item) => item.path === imagePath);
+  if (matched?.mimeType) {
+    return matched.mimeType;
+  }
+
+  const lower = imagePath.toLowerCase();
+  if (lower.endsWith('.png')) return 'image/png';
+  if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return 'image/jpeg';
+  if (lower.endsWith('.webp')) return 'image/webp';
+  if (lower.endsWith('.gif')) return 'image/gif';
+  if (lower.endsWith('.bmp')) return 'image/bmp';
+  return 'application/octet-stream';
+}
+
+function buildGenerateRequestTarget(baseUrl: string, model: string, apiKey: string): AnalyzeImageRequestTarget {
+  if (isVertexBaseUrl(baseUrl)) {
+    const normalizedVertexBaseUrl = baseUrl.replace(/\/v1(?:beta)?$/, '');
+    const vertexModel = parseVertexModel(model);
+
+    return {
+      endpoint: `${normalizedVertexBaseUrl}/v1/publishers/${encodeURIComponent(vertexModel.provider)}/models/${encodeURIComponent(vertexModel.model)}:generateContent`,
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      model: vertexModel.fullModel,
+    };
+  }
+
+  return {
+    endpoint: `${baseUrl}/models/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(apiKey)}`,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    model,
+  };
+}
+
+function isVertexBaseUrl(baseUrl: string): boolean {
+  return baseUrl.includes('/api/vertex-ai');
+}
+
+function parseVertexModel(model: string): { provider: string; model: string; fullModel: string } {
+  const slashIndex = model.indexOf('/');
+  if (slashIndex === -1) {
+    return {
+      provider: 'google',
+      model,
+      fullModel: `google/${model}`,
+    };
+  }
+
+  const provider = model.slice(0, slashIndex).trim();
+  const modelName = model.slice(slashIndex + 1).trim();
+  if (!provider || !modelName) {
+    throw new Error(`Invalid Vertex AI model "${model}". Expected "<provider>/<model>".`);
+  }
+
+  return {
+    provider,
+    model: modelName,
+    fullModel: `${provider}/${modelName}`,
+  };
+}

--- a/apps/remote-server/src/core/types.ts
+++ b/apps/remote-server/src/core/types.ts
@@ -4,6 +4,16 @@ import type { HonoRequest, Context as HonoContext } from 'hono';
 
 export type { Context, ClarificationRequest };
 
+export interface IncomingAttachment {
+  id?: string;
+  url: string;
+  name?: string;
+  mimeType?: string;
+  size?: number;
+  source?: string;
+  messageId?: string;
+}
+
 /**
  * Unified message structure parsed from any platform's raw webhook payload.
  */
@@ -17,6 +27,8 @@ export interface IncomingMessage {
   memoryKey?: string;
   /** The user's text input */
   text: string;
+  /** Optional attachments (e.g. images) parsed from platform payload */
+  attachments?: IncomingAttachment[];
   /** True when the platform payload explicitly requests a fresh session */
   forceNewSession?: boolean;
   /**

--- a/docs/05-attachment-latest-flow.md
+++ b/docs/05-attachment-latest-flow.md
@@ -1,0 +1,100 @@
+# 文档五：自动使用最新附件（图片）设计
+
+## 1. 目标
+
+- 支持用户在平台发送图片（附件），自动保存到本地并记录到会话。
+- 识图工具默认使用“最新一条消息里的所有图片”，无需用户显式传入路径。
+- 附件信息写入 `runContext` 和 system prompt，方便 LLM 感知与调用。
+
+## 2. 数据流（高层）
+
+```
+平台事件（含附件）
+  └─ adapter.parseIncoming() 解析附件元信息
+      └─ dispatcher.runAgentAsync()
+          ├─ 下载附件到 vault.artifacts
+          ├─ sessionStore.latestAttachments 更新
+          ├─ runContext 注入 latestAttachments
+          └─ systemPrompt 追加附件摘要
+              └─ LLM 调用 analyze_image（默认使用最新附件）
+```
+
+## 3. 核心规则
+
+- **默认规则**：自动使用“最新一条消息里的所有图片”。
+- 当用户没有继续上传图片时，依旧复用该最新附件列表。
+- 若当前消息仅包含附件、无文本，也要触发会话更新，并提供一个占位文本用于进入 agent loop。
+
+## 4. 结构定义
+
+### 4.1 IncomingAttachment（平台输入）
+
+```ts
+interface IncomingAttachment {
+  id?: string;
+  url: string;
+  name?: string;
+  mimeType?: string;
+  size?: number;
+  source?: string;      // discord | feishu | web ...
+  messageId?: string;
+}
+```
+
+### 4.2 StoredAttachment（会话落盘）
+
+```ts
+interface StoredAttachment {
+  id: string;
+  path: string;         // 本地绝对路径
+  mimeType?: string;
+  name?: string;
+  size?: number;
+  source?: string;
+  messageId?: string;
+  createdAt: number;
+  originalUrl?: string;
+}
+```
+
+### 4.3 Session Storage
+
+- `RemoteSession.latestAttachments?: StoredAttachment[]`
+- 新附件到达即覆盖旧值（保持“最新一条消息”语义）
+- `/clear` 或新会话时清空
+
+## 5. 运行时注入
+
+### 5.1 runContext
+
+```ts
+runContext.latestAttachments = StoredAttachment[]
+```
+
+### 5.2 system prompt 附加信息（示例）
+
+```
+Latest attachments available:
+- [1] id=... name=... mime=image/png size=...
+- [2] id=... name=... mime=image/jpeg size=...
+Use tool analyze_image without imagePaths to analyze the latest attachments by default.
+```
+
+## 6. 工具行为（analyze_image）
+
+- 入参 `imagePaths` 可选。
+- 未提供 `imagePaths` 时，自动使用 `runContext.latestAttachments` 的本地路径。
+- 默认 prompt：`请描述图片并回答用户问题`（或由用户 input.prompt 覆盖）
+- 依赖 `GEMINI_API_KEY`（可配置为其它 Vision Provider）
+
+## 7. 安全与约束
+
+- 仅接受 `image/*` MIME 或常见图片扩展名
+- 限制单张图片大小（默认 10MB）
+- 下载失败时：清空 latestAttachments 并提示用户重试
+
+## 8. 迭代空间
+
+- TTL 过期策略（防止过旧图片误用）
+- 多平台附件解析扩展（Feishu/Web）
+- 按 messageId/turnId 追溯附件历史


### PR DESCRIPTION
Add latest-image attachment reuse for remote-server sessions and image analysis.

- parse Discord image attachments and persist latestAttachments in remote sessions
- inject attachment context into agent runContext and system prompt
- add analyze_image tool fallback to latest session attachments
- document the attachment flow and cover it with targeted Vitest tests

Tests:
- pnpm --filter @pulse-coder/remote-server build
- pnpm exec vitest run apps/remote-server/src/core/attachments.test.ts apps/remote-server/src/core/tools/analyze-image.test.ts