### PR TITLE
fix(remote-server): proxy Discord attachment downloads

### DIFF
--- a/apps/remote-server/src/core/attachments.test.ts
+++ b/apps/remote-server/src/core/attachments.test.ts
@@ -1,8 +1,25 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
-import { buildAttachmentSystemPrompt, hasIncomingImageAttachments, isImageAttachment, resolveIncomingAttachments } from './attachments.js';
+import { getDiscordProxyDispatcher } from '../adapters/discord/proxy.js';
+import {
+  buildAttachmentSystemPrompt,
+  hasIncomingImageAttachments,
+  isImageAttachment,
+  resolveAttachmentDispatcher,
+  resolveIncomingAttachments,
+} from './attachments.js';
 
 describe('attachment helpers', () => {
+  const originalDiscordProxyUrl = process.env.DISCORD_PROXY_URL;
+
+  afterEach(() => {
+    if (originalDiscordProxyUrl === undefined) {
+      delete process.env.DISCORD_PROXY_URL;
+      return;
+    }
+    process.env.DISCORD_PROXY_URL = originalDiscordProxyUrl;
+  });
+
   it('detects image attachments by mime type and filename', () => {
     expect(isImageAttachment({ url: 'https://example.com/file', mimeType: 'image/png' })).toBe(true);
     expect(isImageAttachment({ url: 'https://example.com/file.JPG', name: 'photo.JPG' })).toBe(true);
@@ -13,6 +30,13 @@ describe('attachment helpers', () => {
     expect(hasIncomingImageAttachments()).toBe(false);
     expect(hasIncomingImageAttachments([{ url: 'https://example.com/file.pdf', name: 'file.pdf', mimeType: 'application/pdf' }])).toBe(false);
     expect(hasIncomingImageAttachments([{ url: 'https://example.com/file.png', name: 'file.png' }])).toBe(true);
+  });
+
+  it('routes discord attachment downloads through the discord proxy dispatcher', () => {
+    process.env.DISCORD_PROXY_URL = 'http://127.0.0.1:8080';
+
+    expect(resolveAttachmentDispatcher({ url: 'https://cdn.discordapp.com/image.png', source: 'discord' })).toBe(getDiscordProxyDispatcher());
+    expect(resolveAttachmentDispatcher({ url: 'https://example.com/image.png', source: 'web' })).toBeUndefined();
   });
 
   it('does not treat non-image attachments as latest image attachments', async () => {

--- a/apps/remote-server/src/core/attachments.ts
+++ b/apps/remote-server/src/core/attachments.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'fs';
 import { homedir } from 'os';
 import { basename, extname, join } from 'path';
 import { fetch } from 'undici';
+import { getDiscordProxyDispatcher } from '../adapters/discord/proxy.js';
 import type { IncomingAttachment } from './types.js';
 import { vaultIntegration, buildRemoteVaultRunContext } from './vault/integration.js';
 
@@ -135,6 +136,7 @@ async function downloadAttachment(attachment: IncomingAttachment, targetDir: str
   try {
     response = await fetch(url, {
       method: 'GET',
+      dispatcher: resolveAttachmentDispatcher(attachment),
       headers: {
         'User-Agent': 'pulse-remote-server',
       },
@@ -182,6 +184,13 @@ async function downloadAttachment(attachment: IncomingAttachment, targetDir: str
     createdAt: Date.now(),
     originalUrl: attachment.url,
   };
+}
+
+export function resolveAttachmentDispatcher(attachment: IncomingAttachment) {
+  if (attachment.source !== 'discord') {
+    return undefined;
+  }
+  return getDiscordProxyDispatcher();
 }
 
 export function isImageAttachment(attachment: IncomingAttachment): boolean {


### PR DESCRIPTION
Ensure Discord image attachments can be downloaded before image analysis runs.

- route Discord attachment fetches through the configured Discord proxy
- keep non-Discord attachment downloads unchanged
- add regression coverage for dispatcher selection in attachment tests