### PR TITLE
Add context menu with delete functionality to sidebar layers

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -9,6 +9,7 @@ const App = () => {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(true);
   const [allNodes, setAllNodes] = useState<Record<string, CanvasNode[]>>({});
   const [focusNodeId, setFocusNodeId] = useState<string | undefined>();
+  const [deleteNodeId, setDeleteNodeId] = useState<string | undefined>();
 
   const handleNodesChange = useCallback((canvasId: string, nodes: CanvasNode[]) => {
     setAllNodes(prev => {
@@ -19,6 +20,9 @@ const App = () => {
 
   const handleFocusComplete = useCallback(() => {
     setFocusNodeId(undefined);
+  }, []);
+  const handleDeleteComplete = useCallback(() => {
+    setDeleteNodeId(undefined);
   }, []);
   const {
     workspaces,
@@ -59,6 +63,7 @@ const App = () => {
           onReorderFolder={reorderFolder}
           activeNodes={allNodes[activeId] || []}
           onNodeFocus={setFocusNodeId}
+          onNodeDelete={setDeleteNodeId}
         />
         <div className="canvas-viewport">
           {workspaces.map((ws) => (
@@ -71,6 +76,8 @@ const App = () => {
               onNodesChange={handleNodesChange}
               focusNodeId={ws.id === activeId ? focusNodeId : undefined}
               onFocusComplete={handleFocusComplete}
+              deleteNodeId={ws.id === activeId ? deleteNodeId : undefined}
+              onDeleteComplete={handleDeleteComplete}
             />
           ))}
         </div>

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -15,7 +15,7 @@ import { ZoomIndicator } from '../ZoomIndicator';
 import { SearchPalette } from '../SearchPalette';
 import { CanvasEmptyHint } from '../CanvasEmptyHint';
 
-export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange, focusNodeId, onFocusComplete }: { canvasId: string; canvasName?: string; rootFolder?: string; hidden?: boolean; onNodesChange?: (canvasId: string, nodes: CanvasNode[]) => void; focusNodeId?: string; onFocusComplete?: () => void }) => {
+export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange, focusNodeId, onFocusComplete, deleteNodeId, onDeleteComplete }: { canvasId: string; canvasName?: string; rootFolder?: string; hidden?: boolean; onNodesChange?: (canvasId: string, nodes: CanvasNode[]) => void; focusNodeId?: string; onFocusComplete?: () => void; deleteNodeId?: string; onDeleteComplete?: () => void }) => {
   const [activeTool, setActiveTool] = useState('select');
   const [selectedNodeIds, setSelectedNodeIds] = useState<string[]>([]);
   const [clipboardNodes, setClipboardNodes] = useState<CanvasNode[]>([]);
@@ -105,6 +105,16 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
     }
     onFocusComplete?.();
   }, [focusNodeId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Handle external delete request (e.g. from sidebar layers context menu)
+  useEffect(() => {
+    if (!deleteNodeId) return;
+    if (nodes.some((n) => n.id === deleteNodeId)) {
+      removeNode(deleteNodeId);
+      setSelectedNodeIds((ids) => ids.filter((id) => id !== deleteNodeId));
+    }
+    onDeleteComplete?.();
+  }, [deleteNodeId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useCanvasContext(rootFolder, nodes, canvasName);
 

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
@@ -611,3 +611,45 @@
 .sidebar-folder-children.sidebar-drop-zone--active {
   border-left-color: var(--accent);
 }
+
+/* ---- Layer Context Menu ---- */
+
+.sidebar-layer-context-menu {
+  position: fixed;
+  z-index: 1000;
+  min-width: 140px;
+  padding: 4px;
+  background: var(--bg, #ffffff);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md, 6px);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.12), 0 2px 6px rgba(0, 0, 0, 0.06);
+}
+
+.sidebar-layer-context-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 10px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--text);
+  text-align: left;
+  transition: background 0.1s, color 0.1s;
+}
+
+.sidebar-layer-context-menu-item:hover {
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.sidebar-layer-context-menu-item--danger {
+  color: #c0392b;
+}
+
+.sidebar-layer-context-menu-item--danger:hover {
+  background: rgba(192, 57, 43, 0.08);
+  color: #c0392b;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, useCallback, type DragEvent } from 'react';
+import { useEffect, useMemo, useRef, useState, useCallback, type DragEvent, type MouseEvent as ReactMouseEvent } from 'react';
 import type { WorkspaceEntry, FolderEntry } from '../../hooks/useWorkspaces';
 import type { CanvasNode } from '../../types';
 import './index.css';
@@ -72,6 +72,7 @@ interface Props {
   onReorderFolder: (folderId: string, beforeFolderId: string | null) => void;
   activeNodes?: CanvasNode[];
   onNodeFocus?: (nodeId: string) => void;
+  onNodeDelete?: (nodeId: string) => void;
 }
 
 /* ---- Drag data keys ---- */
@@ -97,6 +98,7 @@ export const Sidebar = ({
   onReorderFolder,
   activeNodes = [],
   onNodeFocus,
+  onNodeDelete,
 }: Props) => {
   /* ---- Local state ---- */
   const [renamingId, setRenamingId] = useState<string | null>(null);
@@ -109,8 +111,34 @@ export const Sidebar = ({
   const [folderDropTarget, setFolderDropTarget] = useState<string | null>(null);
   const [showAddMenu, setShowAddMenu] = useState(false);
   const [collapsedLayers, setCollapsedLayers] = useState<Set<string>>(new Set());
+  const [layerContextMenu, setLayerContextMenu] = useState<{
+    x: number;
+    y: number;
+    nodeId: string;
+  } | null>(null);
 
   const layerTree = useMemo(() => buildLayerTree(activeNodes), [activeNodes]);
+
+  const handleLayerContextMenu = useCallback((e: ReactMouseEvent, nodeId: string) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setLayerContextMenu({ x: e.clientX, y: e.clientY, nodeId });
+  }, []);
+
+  // Close layer context menu on outside click or Escape
+  useEffect(() => {
+    if (!layerContextMenu) return;
+    const close = () => setLayerContextMenu(null);
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setLayerContextMenu(null);
+    };
+    document.addEventListener('mousedown', close);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', close);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [layerContextMenu]);
 
   const toggleLayerCollapse = useCallback((id: string) => {
     setCollapsedLayers((prev) => {
@@ -399,17 +427,7 @@ export const Sidebar = ({
 
           {/* Scrollable list area */}
           <div className="sidebar-scroll">
-            {/* Root drop zone for un-foldered workspaces */}
-            <div
-              className={`sidebar-list sidebar-drop-zone${dropTarget === '__root__' ? ' sidebar-drop-zone--active' : ''}`}
-              onDragOver={(e) => handleDropZoneDragOver(e, '__root__')}
-              onDragLeave={(e) => handleDropZoneDragLeave(e, '__root__')}
-              onDrop={(e) => handleDropZoneDrop(e, undefined)}
-            >
-              {rootWorkspaces.map(renderWorkspaceItem)}
-            </div>
-
-            {/* Folders */}
+            {/* Folders (shown above root workspaces) */}
             {folders.map((folder) => {
               const folderWorkspaces = workspaces.filter((ws) => ws.folderId === folder.id);
               const isOpen = !folder.collapsed;
@@ -503,6 +521,16 @@ export const Sidebar = ({
               );
             })}
 
+            {/* Root drop zone for un-foldered workspaces (shown below folders) */}
+            <div
+              className={`sidebar-list sidebar-drop-zone${dropTarget === '__root__' ? ' sidebar-drop-zone--active' : ''}`}
+              onDragOver={(e) => handleDropZoneDragOver(e, '__root__')}
+              onDragLeave={(e) => handleDropZoneDragLeave(e, '__root__')}
+              onDrop={(e) => handleDropZoneDrop(e, undefined)}
+            >
+              {rootWorkspaces.map(renderWorkspaceItem)}
+            </div>
+
             {/* Inline create input */}
             {inlineCreate && (
               <div className="sidebar-list">
@@ -554,6 +582,7 @@ export const Sidebar = ({
                   <button
                     className={`sidebar-layer-item${isFrame ? ' sidebar-layer-item--frame' : ''}`}
                     onClick={() => onNodeFocus?.(node.id)}
+                    onContextMenu={(e) => handleLayerContextMenu(e, node.id)}
                     title={node.title}
                   >
                     {isFrame && (
@@ -599,6 +628,7 @@ export const Sidebar = ({
                           key={child.id}
                           className="sidebar-layer-item"
                           onClick={() => onNodeFocus?.(child.id)}
+                          onContextMenu={(e) => handleLayerContextMenu(e, child.id)}
                           title={child.title}
                         >
                           <span className="sidebar-layer-icon">
@@ -647,6 +677,28 @@ export const Sidebar = ({
           {installMessage && (
             <div className="sidebar-install-message">{installMessage}</div>
           )}
+        </div>
+      )}
+
+      {layerContextMenu && (
+        <div
+          className="sidebar-layer-context-menu"
+          style={{ left: layerContextMenu.x, top: layerContextMenu.y }}
+          onMouseDown={(e) => e.stopPropagation()}
+          onContextMenu={(e) => e.preventDefault()}
+        >
+          <button
+            className="sidebar-layer-context-menu-item sidebar-layer-context-menu-item--danger"
+            onClick={() => {
+              onNodeDelete?.(layerContextMenu.nodeId);
+              setLayerContextMenu(null);
+            }}
+          >
+            <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
+              <path d="M3 4h10M6 4V2.5a1 1 0 011-1h2a1 1 0 011 1V4M5 4l.5 9a1 1 0 001 1h3a1 1 0 001-1L11 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+            <span>Delete</span>
+          </button>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
This PR adds a right-click context menu to layer items in the sidebar, allowing users to delete nodes directly from the layers panel. The delete action is propagated through the component hierarchy to the Canvas component for execution.

## Key Changes
- **Sidebar Component**: 
  - Added `onNodeDelete` callback prop to handle delete requests
  - Implemented `handleLayerContextMenu` to capture right-click events on layer items
  - Added state management for context menu positioning and target node
  - Added event listeners to close context menu on outside clicks or Escape key
  - Rendered context menu with delete button at cursor position
  - Applied context menu handlers to both root and child layer items

- **Canvas Component**:
  - Added `deleteNodeId` and `onDeleteComplete` props to receive delete requests
  - Implemented effect hook to handle node deletion when `deleteNodeId` changes
  - Removes the node from the canvas and clears it from selection

- **App Component**:
  - Added state management for `deleteNodeId` to coordinate between Sidebar and Canvas
  - Added `handleDeleteComplete` callback to reset delete state after operation
  - Wired up `onNodeDelete` and `onDeleteComplete` callbacks through component props

- **Styling**:
  - Added CSS for context menu positioning, appearance, and animations
  - Styled delete button with danger color (#c0392b) and hover effects
  - Included trash icon SVG in the delete menu item

## Implementation Details
- Context menu uses `position: fixed` for proper positioning relative to viewport
- Menu automatically closes on outside clicks or Escape key press
- Delete action is handled asynchronously through state updates to maintain unidirectional data flow
- Reordered sidebar layout to show folders above root workspaces for better UX

https://claude.ai/code/session_01WK7ycBAkgwSppdb6nwoEck