### PR TITLE
fix(engine): persist runtime soul registry

### DIFF
--- a/packages/engine/src/built-in/role-soul-plugin/index.test.ts
+++ b/packages/engine/src/built-in/role-soul-plugin/index.test.ts
@@ -1,0 +1,143 @@
+import { EventEmitter } from 'node:events';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { EnginePluginContext } from '../../plugin/EnginePlugin.js';
+import type { Tool } from '../../shared/types.js';
+import { builtInRoleSoulPlugin } from './index.js';
+
+function createPluginContextHarness(): {
+  context: EnginePluginContext;
+  tools: Record<string, Tool<any, any>>;
+} {
+  const tools: Record<string, Tool<any, any>> = {};
+  const services = new Map<string, any>();
+  const configs = new Map<string, any>();
+  const hooks = new Map<string, Array<(input: any) => Promise<any>>>();
+
+  const context: EnginePluginContext = {
+    registerTool: (name: string, tool: any) => {
+      tools[name] = tool;
+    },
+    registerTools: (nextTools: Record<string, any>) => {
+      Object.assign(tools, nextTools);
+    },
+    getTool: (name: string) => tools[name],
+    getTools: () => ({ ...tools }),
+    getEngineInstance: () => ({}) as any,
+    registerHook: (hookName: any, handler: any) => {
+      const current = hooks.get(hookName) ?? [];
+      current.push(handler);
+      hooks.set(hookName, current);
+    },
+    registerService: <T>(name: string, service: T) => {
+      services.set(name, service);
+    },
+    getService: <T>(name: string) => services.get(name) as T | undefined,
+    getConfig: <T>(key: string) => configs.get(key) as T | undefined,
+    setConfig: <T>(key: string, value: T) => {
+      configs.set(key, value);
+    },
+    events: new EventEmitter(),
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  };
+
+  return { context, tools };
+}
+
+describe('builtInRoleSoulPlugin runtime registration persistence', () => {
+  let tempDir = '';
+  let originalStateDir: string | undefined;
+  let originalRegistryPath: string | undefined;
+  let originalPersist: string | undefined;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), 'pulse-coder-soul-runtime-'));
+
+    originalStateDir = process.env.PULSE_CODER_SOUL_STATE_DIR;
+    originalRegistryPath = process.env.PULSE_CODER_SOUL_REGISTRY_PATH;
+    originalPersist = process.env.PULSE_CODER_SOUL_PERSIST;
+
+    process.env.PULSE_CODER_SOUL_STATE_DIR = path.join(tempDir, 'state');
+    process.env.PULSE_CODER_SOUL_REGISTRY_PATH = path.join(tempDir, 'runtime-registry.json');
+    process.env.PULSE_CODER_SOUL_PERSIST = '1';
+  });
+
+  afterEach(async () => {
+    if (originalStateDir === undefined) {
+      delete process.env.PULSE_CODER_SOUL_STATE_DIR;
+    } else {
+      process.env.PULSE_CODER_SOUL_STATE_DIR = originalStateDir;
+    }
+
+    if (originalRegistryPath === undefined) {
+      delete process.env.PULSE_CODER_SOUL_REGISTRY_PATH;
+    } else {
+      process.env.PULSE_CODER_SOUL_REGISTRY_PATH = originalRegistryPath;
+    }
+
+    if (originalPersist === undefined) {
+      delete process.env.PULSE_CODER_SOUL_PERSIST;
+    } else {
+      process.env.PULSE_CODER_SOUL_PERSIST = originalPersist;
+    }
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('persists registered souls across plugin re-initialization', async () => {
+    const soulId = '__vitest_runtime_persisted_soul__';
+
+    const firstHarness = createPluginContextHarness();
+    await builtInRoleSoulPlugin.initialize(firstHarness.context);
+
+    await firstHarness.tools.soul_register.execute({
+      id: soulId,
+      name: 'Runtime Persisted Soul',
+      prompt: 'Stay grounded and evidence-based.',
+    });
+
+    const secondHarness = createPluginContextHarness();
+    await builtInRoleSoulPlugin.initialize(secondHarness.context);
+
+    const soulList = await secondHarness.tools.soul_list.execute({ format: 'full' }) as Array<Record<string, any>>;
+    const persistedSoul = soulList.find((item) => item.id === soulId);
+
+    expect(persistedSoul).toBeDefined();
+    expect(persistedSoul?.location).toBe('runtime');
+  });
+
+  it('keeps registered souls after soul_clear removes active session state', async () => {
+    const soulId = '__vitest_runtime_clear_keeps_registry__';
+    const sessionId = 'session-clear-keeps-registry';
+
+    const harness = createPluginContextHarness();
+    await builtInRoleSoulPlugin.initialize(harness.context);
+
+    await harness.tools.soul_register.execute({
+      id: soulId,
+      name: 'Clear Keeps Registry',
+      prompt: 'Clear active state but keep registration.',
+    });
+
+    await harness.tools.soul_use.execute({ sessionId, soulId });
+    const beforeClear = await harness.tools.soul_status.execute({ sessionId }) as { state?: { activeSoulIds?: string[] } };
+    expect(beforeClear.state?.activeSoulIds).toContain(soulId);
+
+    await harness.tools.soul_clear.execute({ sessionId });
+
+    const afterClear = await harness.tools.soul_status.execute({ sessionId }) as { state?: { activeSoulIds?: string[] } };
+    expect(afterClear.state?.activeSoulIds ?? []).toEqual([]);
+
+    const soulList = await harness.tools.soul_list.execute({ format: 'summary' }) as Array<{ id: string }>;
+    expect(soulList.some((item) => item.id === soulId)).toBe(true);
+  });
+});

--- a/packages/engine/src/built-in/role-soul-plugin/index.test.ts
+++ b/packages/engine/src/built-in/role-soul-plugin/index.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events';
-import { mkdtemp, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
 import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -8,6 +8,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { EnginePluginContext } from '../../plugin/EnginePlugin.js';
 import type { Tool } from '../../shared/types.js';
 import { builtInRoleSoulPlugin } from './index.js';
+
+const SOUL_BASE_DIR = path.join(homedir(), '.pulse-coder', 'souls');
 
 function createPluginContextHarness(): {
   context: EnginePluginContext;
@@ -56,18 +58,16 @@ function createPluginContextHarness(): {
 describe('builtInRoleSoulPlugin runtime registration persistence', () => {
   let tempDir = '';
   let originalStateDir: string | undefined;
-  let originalRegistryPath: string | undefined;
   let originalPersist: string | undefined;
+  const createdSoulDirs = new Set<string>();
 
   beforeEach(async () => {
     tempDir = await mkdtemp(path.join(tmpdir(), 'pulse-coder-soul-runtime-'));
 
     originalStateDir = process.env.PULSE_CODER_SOUL_STATE_DIR;
-    originalRegistryPath = process.env.PULSE_CODER_SOUL_REGISTRY_PATH;
     originalPersist = process.env.PULSE_CODER_SOUL_PERSIST;
 
     process.env.PULSE_CODER_SOUL_STATE_DIR = path.join(tempDir, 'state');
-    process.env.PULSE_CODER_SOUL_REGISTRY_PATH = path.join(tempDir, 'runtime-registry.json');
     process.env.PULSE_CODER_SOUL_PERSIST = '1';
   });
 
@@ -78,23 +78,25 @@ describe('builtInRoleSoulPlugin runtime registration persistence', () => {
       process.env.PULSE_CODER_SOUL_STATE_DIR = originalStateDir;
     }
 
-    if (originalRegistryPath === undefined) {
-      delete process.env.PULSE_CODER_SOUL_REGISTRY_PATH;
-    } else {
-      process.env.PULSE_CODER_SOUL_REGISTRY_PATH = originalRegistryPath;
-    }
-
     if (originalPersist === undefined) {
       delete process.env.PULSE_CODER_SOUL_PERSIST;
     } else {
       process.env.PULSE_CODER_SOUL_PERSIST = originalPersist;
     }
 
+    for (const soulDir of createdSoulDirs) {
+      await rm(soulDir, { recursive: true, force: true });
+    }
+    createdSoulDirs.clear();
+
     await rm(tempDir, { recursive: true, force: true });
   });
 
-  it('persists registered souls across plugin re-initialization', async () => {
-    const soulId = '__vitest_runtime_persisted_soul__';
+  it('persists registered souls to ~/.pulse-coder/souls/<id>/SOUL.md and reloads after re-initialization', async () => {
+    const soulId = `__vitest_runtime_persisted_soul_${Date.now()}__`;
+    const soulDir = path.join(SOUL_BASE_DIR, soulId);
+    const soulFile = path.join(soulDir, 'SOUL.md');
+    createdSoulDirs.add(soulDir);
 
     const firstHarness = createPluginContextHarness();
     await builtInRoleSoulPlugin.initialize(firstHarness.context);
@@ -105,6 +107,13 @@ describe('builtInRoleSoulPlugin runtime registration persistence', () => {
       prompt: 'Stay grounded and evidence-based.',
     });
 
+    const fileStat = await stat(soulFile);
+    expect(fileStat.isFile()).toBe(true);
+
+    const persistedContent = await readFile(soulFile, 'utf-8');
+    expect(persistedContent).toContain(`id: "${soulId}"`);
+    expect(persistedContent).toContain('Stay grounded and evidence-based.');
+
     const secondHarness = createPluginContextHarness();
     await builtInRoleSoulPlugin.initialize(secondHarness.context);
 
@@ -112,12 +121,15 @@ describe('builtInRoleSoulPlugin runtime registration persistence', () => {
     const persistedSoul = soulList.find((item) => item.id === soulId);
 
     expect(persistedSoul).toBeDefined();
-    expect(persistedSoul?.location).toBe('runtime');
+    expect(String(persistedSoul?.location ?? '')).toContain('SOUL.md');
   });
 
-  it('keeps registered souls after soul_clear removes active session state', async () => {
-    const soulId = '__vitest_runtime_clear_keeps_registry__';
+  it('keeps registered soul definition after soul_clear removes active session state', async () => {
+    const soulId = `__vitest_runtime_clear_keeps_registry_${Date.now()}__`;
     const sessionId = 'session-clear-keeps-registry';
+    const soulDir = path.join(SOUL_BASE_DIR, soulId);
+    const soulFile = path.join(soulDir, 'SOUL.md');
+    createdSoulDirs.add(soulDir);
 
     const harness = createPluginContextHarness();
     await builtInRoleSoulPlugin.initialize(harness.context);
@@ -139,5 +151,8 @@ describe('builtInRoleSoulPlugin runtime registration persistence', () => {
 
     const soulList = await harness.tools.soul_list.execute({ format: 'summary' }) as Array<{ id: string }>;
     expect(soulList.some((item) => item.id === soulId)).toBe(true);
+
+    const fileStat = await stat(soulFile);
+    expect(fileStat.isFile()).toBe(true);
   });
 });

--- a/packages/engine/src/built-in/role-soul-plugin/index.ts
+++ b/packages/engine/src/built-in/role-soul-plugin/index.ts
@@ -46,8 +46,23 @@ export interface SoulService {
   buildPromptAppend(sessionId: string): Promise<string | null>;
 }
 
-const DEFAULT_STATE_DIR = path.join(homedir(), '.pulse-coder', 'souls', 'state');
+const DEFAULT_SOUL_BASE_DIR = path.join(homedir(), '.pulse-coder', 'souls');
+const DEFAULT_STATE_DIR = path.join(DEFAULT_SOUL_BASE_DIR, 'state');
+const DEFAULT_RUNTIME_REGISTRY_PATH = path.join(DEFAULT_SOUL_BASE_DIR, 'runtime-registry.json');
 const DEFAULT_STATE_DEBOUNCE_MS = 250;
+
+const RUNTIME_SOUL_RECORD_SCHEMA = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().optional(),
+  prompt: z.string().min(1),
+});
+
+const PERSISTED_RUNTIME_REGISTRY_SCHEMA = z.object({
+  version: z.literal(1),
+  updatedAt: z.number().optional(),
+  souls: z.array(RUNTIME_SOUL_RECORD_SCHEMA),
+});
 
 const SOUL_REGISTER_INPUT_SCHEMA = z.object({
   id: z.string().min(1).describe('Soul id (unique key).'),
@@ -168,6 +183,10 @@ class SoulRegistry {
 
   get(id: string): SoulDefinition | undefined {
     return this.souls.get(normalizeSoulKey(id));
+  }
+
+  getRuntimeSouls(): SoulDefinition[] {
+    return this.getAll().filter((soul) => soul.location === 'runtime');
   }
 
   registerSoul(soul: SoulDefinition): { soulId: string; replaced: boolean; total: number } {
@@ -334,18 +353,92 @@ class SoulStateStore {
   }
 }
 
+class SoulRuntimeRegistryStore {
+  private filePath: string;
+  private enabled: boolean;
+
+  constructor(options?: { filePath?: string; enabled?: boolean }) {
+    this.filePath = options?.filePath ?? DEFAULT_RUNTIME_REGISTRY_PATH;
+    this.enabled = options?.enabled ?? true;
+  }
+
+  async initialize(): Promise<void> {
+    if (!this.enabled) {
+      return;
+    }
+    await fs.mkdir(path.dirname(this.filePath), { recursive: true });
+  }
+
+  async load(): Promise<SoulDefinition[]> {
+    if (!this.enabled) {
+      return [];
+    }
+
+    try {
+      const raw = await fs.readFile(this.filePath, 'utf-8');
+      const parsed = JSON.parse(raw);
+      const validated = PERSISTED_RUNTIME_REGISTRY_SCHEMA.safeParse(parsed);
+      if (!validated.success) {
+        return [];
+      }
+
+      return validated.data.souls.map((item: z.infer<typeof RUNTIME_SOUL_RECORD_SCHEMA>) => ({
+        id: item.id,
+        name: item.name,
+        description: item.description,
+        prompt: item.prompt,
+        location: 'runtime',
+        metadata: { source: 'runtime' },
+      }));
+    } catch {
+      return [];
+    }
+  }
+
+  async save(souls: SoulDefinition[]): Promise<void> {
+    if (!this.enabled) {
+      return;
+    }
+
+    const payload = {
+      version: 1 as const,
+      updatedAt: now(),
+      souls: souls.map((soul) => ({
+        id: soul.id,
+        name: soul.name,
+        description: soul.description,
+        prompt: soul.prompt,
+      })),
+    };
+
+    try {
+      await fs.mkdir(path.dirname(this.filePath), { recursive: true });
+      await fs.writeFile(this.filePath, JSON.stringify(payload, null, 2), 'utf-8');
+    } catch {
+      return;
+    }
+  }
+}
+
 class BuiltInSoulService implements SoulService {
   private registry = new SoulRegistry();
-  private store: SoulStateStore;
+  private stateStore: SoulStateStore;
+  private runtimeRegistryStore: SoulRuntimeRegistryStore;
   private states = new Map<string, SoulState>();
   private loadedSessions = new Set<string>();
   private logger: EnginePluginContext['logger'];
 
   constructor(logger: EnginePluginContext['logger']) {
-    const baseDir = process.env.PULSE_CODER_SOUL_STATE_DIR?.trim();
+    const stateDir = process.env.PULSE_CODER_SOUL_STATE_DIR?.trim();
+    const runtimeRegistryPath = process.env.PULSE_CODER_SOUL_REGISTRY_PATH?.trim();
     const enabled = process.env.PULSE_CODER_SOUL_PERSIST?.trim() !== '0';
-    this.store = new SoulStateStore({
-      baseDir: baseDir || undefined,
+
+    this.stateStore = new SoulStateStore({
+      baseDir: stateDir || undefined,
+      enabled,
+    });
+    this.runtimeRegistryStore = new SoulRuntimeRegistryStore({
+      filePath: runtimeRegistryPath || undefined,
       enabled,
     });
     this.logger = logger;
@@ -353,7 +446,18 @@ class BuiltInSoulService implements SoulService {
 
   async initialize(): Promise<void> {
     await this.registry.initialize(process.cwd());
-    await this.store.initialize();
+    await this.stateStore.initialize();
+    await this.runtimeRegistryStore.initialize();
+
+    const persistedSouls = await this.runtimeRegistryStore.load();
+    for (const soul of persistedSouls) {
+      this.registry.registerSoul(soul);
+    }
+    if (persistedSouls.length > 0) {
+      this.logger.info('[RoleSoul] Loaded persisted runtime souls', {
+        count: persistedSouls.length,
+      });
+    }
   }
 
   listSouls(): SoulDefinition[] {
@@ -402,7 +506,7 @@ class BuiltInSoulService implements SoulService {
     };
 
     this.states.set(sessionId, nextState);
-    this.store.scheduleSave(nextState);
+    this.stateStore.scheduleSave(nextState);
 
     return { ok: true, state: nextState };
   }
@@ -410,7 +514,7 @@ class BuiltInSoulService implements SoulService {
   async clearSession(sessionId: string): Promise<{ ok: boolean; reason?: string }> {
     this.states.delete(sessionId);
     this.loadedSessions.add(sessionId);
-    await this.store.remove(sessionId);
+    await this.stateStore.remove(sessionId);
     return { ok: true };
   }
 
@@ -431,7 +535,7 @@ class BuiltInSoulService implements SoulService {
 
     this.states.set(toSessionId, nextState);
     this.loadedSessions.add(toSessionId);
-    this.store.scheduleSave(nextState);
+    this.stateStore.scheduleSave(nextState);
     return { ok: true };
   }
 
@@ -463,7 +567,7 @@ class BuiltInSoulService implements SoulService {
     return lines.join('\n');
   }
 
-  registerSoul(input: { id: string; name: string; description?: string; prompt: string }): SoulDefinition {
+  async registerSoul(input: { id: string; name: string; description?: string; prompt: string }): Promise<SoulDefinition> {
     const soul: SoulDefinition = {
       id: input.id.trim(),
       name: input.name.trim(),
@@ -474,7 +578,13 @@ class BuiltInSoulService implements SoulService {
     };
 
     this.registry.registerSoul(soul);
+    await this.persistRuntimeSouls();
     return soul;
+  }
+
+  private async persistRuntimeSouls(): Promise<void> {
+    const runtimeSouls = this.registry.getRuntimeSouls();
+    await this.runtimeRegistryStore.save(runtimeSouls);
   }
 
   private async setSoulState(
@@ -507,7 +617,7 @@ class BuiltInSoulService implements SoulService {
     };
 
     this.states.set(sessionId, nextState);
-    this.store.scheduleSave(nextState);
+    this.stateStore.scheduleSave(nextState);
 
     return { ok: true, state: nextState, soul };
   }
@@ -518,7 +628,7 @@ class BuiltInSoulService implements SoulService {
     }
 
     this.loadedSessions.add(sessionId);
-    const stored = await this.store.load(sessionId);
+    const stored = await this.stateStore.load(sessionId);
     if (stored) {
       this.states.set(sessionId, stored);
       return;
@@ -683,10 +793,10 @@ function buildSoulClearTool(service: BuiltInSoulService): Tool {
 function buildSoulRegisterTool(service: BuiltInSoulService): Tool {
   return {
     name: 'soul_register',
-    description: 'Register or replace a soul definition at runtime.',
+    description: 'Register or replace a soul definition. Persists when soul persistence is enabled.',
     inputSchema: SOUL_REGISTER_INPUT_SCHEMA,
     execute: async (input) => {
-      const soul = service.registerSoul({
+      const soul = await service.registerSoul({
         id: input.id,
         name: input.name,
         description: input.description,

--- a/packages/engine/src/built-in/role-soul-plugin/index.ts
+++ b/packages/engine/src/built-in/role-soul-plugin/index.ts
@@ -48,21 +48,8 @@ export interface SoulService {
 
 const DEFAULT_SOUL_BASE_DIR = path.join(homedir(), '.pulse-coder', 'souls');
 const DEFAULT_STATE_DIR = path.join(DEFAULT_SOUL_BASE_DIR, 'state');
-const DEFAULT_RUNTIME_REGISTRY_PATH = path.join(DEFAULT_SOUL_BASE_DIR, 'runtime-registry.json');
 const DEFAULT_STATE_DEBOUNCE_MS = 250;
 
-const RUNTIME_SOUL_RECORD_SCHEMA = z.object({
-  id: z.string().min(1),
-  name: z.string().min(1),
-  description: z.string().optional(),
-  prompt: z.string().min(1),
-});
-
-const PERSISTED_RUNTIME_REGISTRY_SCHEMA = z.object({
-  version: z.literal(1),
-  updatedAt: z.number().optional(),
-  souls: z.array(RUNTIME_SOUL_RECORD_SCHEMA),
-});
 
 const SOUL_REGISTER_INPUT_SCHEMA = z.object({
   id: z.string().min(1).describe('Soul id (unique key).'),
@@ -104,6 +91,30 @@ function normalizeSoulKey(value: string): string {
 
 function now(): number {
   return Date.now();
+}
+
+function soulDirNameFromId(id: string): string {
+  const trimmed = id.trim();
+  if (!trimmed || trimmed === '.' || trimmed === '..' || trimmed.includes('/') || trimmed.includes('\\')) {
+    throw new Error(`invalid soul id for persistence path: ${id}`);
+  }
+  return trimmed;
+}
+
+function buildPersistedSoulContent(soul: SoulDefinition): string {
+  const frontMatterLines = [
+    '---',
+    `id: ${JSON.stringify(soul.id)}`,
+    `name: ${JSON.stringify(soul.name)}`,
+  ];
+
+  if (soul.description) {
+    frontMatterLines.push(`description: ${JSON.stringify(soul.description)}`);
+  }
+
+  frontMatterLines.push('---');
+
+  return `${frontMatterLines.join('\n')}\n\n${soul.prompt.trim()}\n`;
 }
 
 function appendSystemPrompt(base: SystemPromptOption | undefined, append: string): SystemPromptOption {
@@ -183,10 +194,6 @@ class SoulRegistry {
 
   get(id: string): SoulDefinition | undefined {
     return this.souls.get(normalizeSoulKey(id));
-  }
-
-  getRuntimeSouls(): SoulDefinition[] {
-    return this.getAll().filter((soul) => soul.location === 'runtime');
   }
 
   registerSoul(soul: SoulDefinition): { soulId: string; replaced: boolean; total: number } {
@@ -353,111 +360,29 @@ class SoulStateStore {
   }
 }
 
-class SoulRuntimeRegistryStore {
-  private filePath: string;
-  private enabled: boolean;
-
-  constructor(options?: { filePath?: string; enabled?: boolean }) {
-    this.filePath = options?.filePath ?? DEFAULT_RUNTIME_REGISTRY_PATH;
-    this.enabled = options?.enabled ?? true;
-  }
-
-  async initialize(): Promise<void> {
-    if (!this.enabled) {
-      return;
-    }
-    await fs.mkdir(path.dirname(this.filePath), { recursive: true });
-  }
-
-  async load(): Promise<SoulDefinition[]> {
-    if (!this.enabled) {
-      return [];
-    }
-
-    try {
-      const raw = await fs.readFile(this.filePath, 'utf-8');
-      const parsed = JSON.parse(raw);
-      const validated = PERSISTED_RUNTIME_REGISTRY_SCHEMA.safeParse(parsed);
-      if (!validated.success) {
-        return [];
-      }
-
-      return validated.data.souls.map((item: z.infer<typeof RUNTIME_SOUL_RECORD_SCHEMA>) => ({
-        id: item.id,
-        name: item.name,
-        description: item.description,
-        prompt: item.prompt,
-        location: 'runtime',
-        metadata: { source: 'runtime' },
-      }));
-    } catch {
-      return [];
-    }
-  }
-
-  async save(souls: SoulDefinition[]): Promise<void> {
-    if (!this.enabled) {
-      return;
-    }
-
-    const payload = {
-      version: 1 as const,
-      updatedAt: now(),
-      souls: souls.map((soul) => ({
-        id: soul.id,
-        name: soul.name,
-        description: soul.description,
-        prompt: soul.prompt,
-      })),
-    };
-
-    try {
-      await fs.mkdir(path.dirname(this.filePath), { recursive: true });
-      await fs.writeFile(this.filePath, JSON.stringify(payload, null, 2), 'utf-8');
-    } catch {
-      return;
-    }
-  }
-}
-
 class BuiltInSoulService implements SoulService {
   private registry = new SoulRegistry();
   private stateStore: SoulStateStore;
-  private runtimeRegistryStore: SoulRuntimeRegistryStore;
+  private persistEnabled: boolean;
   private states = new Map<string, SoulState>();
   private loadedSessions = new Set<string>();
   private logger: EnginePluginContext['logger'];
 
   constructor(logger: EnginePluginContext['logger']) {
     const stateDir = process.env.PULSE_CODER_SOUL_STATE_DIR?.trim();
-    const runtimeRegistryPath = process.env.PULSE_CODER_SOUL_REGISTRY_PATH?.trim();
     const enabled = process.env.PULSE_CODER_SOUL_PERSIST?.trim() !== '0';
 
     this.stateStore = new SoulStateStore({
       baseDir: stateDir || undefined,
       enabled,
     });
-    this.runtimeRegistryStore = new SoulRuntimeRegistryStore({
-      filePath: runtimeRegistryPath || undefined,
-      enabled,
-    });
+    this.persistEnabled = enabled;
     this.logger = logger;
   }
 
   async initialize(): Promise<void> {
     await this.registry.initialize(process.cwd());
     await this.stateStore.initialize();
-    await this.runtimeRegistryStore.initialize();
-
-    const persistedSouls = await this.runtimeRegistryStore.load();
-    for (const soul of persistedSouls) {
-      this.registry.registerSoul(soul);
-    }
-    if (persistedSouls.length > 0) {
-      this.logger.info('[RoleSoul] Loaded persisted runtime souls', {
-        count: persistedSouls.length,
-      });
-    }
   }
 
   listSouls(): SoulDefinition[] {
@@ -578,13 +503,27 @@ class BuiltInSoulService implements SoulService {
     };
 
     this.registry.registerSoul(soul);
-    await this.persistRuntimeSouls();
+    await this.persistRuntimeSoulAsFile(soul);
     return soul;
   }
 
-  private async persistRuntimeSouls(): Promise<void> {
-    const runtimeSouls = this.registry.getRuntimeSouls();
-    await this.runtimeRegistryStore.save(runtimeSouls);
+  private async persistRuntimeSoulAsFile(soul: SoulDefinition): Promise<void> {
+    if (!this.persistEnabled) {
+      return;
+    }
+
+    const soulDirName = soulDirNameFromId(soul.id);
+    const soulDir = path.join(DEFAULT_SOUL_BASE_DIR, soulDirName);
+    const soulFile = path.join(soulDir, 'SOUL.md');
+    const content = buildPersistedSoulContent(soul);
+
+    await fs.mkdir(soulDir, { recursive: true });
+    await fs.writeFile(soulFile, content, 'utf-8');
+
+    this.logger.info('[RoleSoul] Persisted registered soul to SOUL.md', {
+      soulId: soul.id,
+      soulFile,
+    });
   }
 
   private async setSoulState(
@@ -793,7 +732,7 @@ function buildSoulClearTool(service: BuiltInSoulService): Tool {
 function buildSoulRegisterTool(service: BuiltInSoulService): Tool {
   return {
     name: 'soul_register',
-    description: 'Register or replace a soul definition. Persists when soul persistence is enabled.',
+    description: 'Register or replace a soul definition. Persists to ~/.pulse-coder/souls/<id>/SOUL.md when enabled.',
     inputSchema: SOUL_REGISTER_INPUT_SCHEMA,
     execute: async (input) => {
       const soul = await service.registerSoul({


### PR DESCRIPTION
Persist runtime-registered souls and keep soul_clear scoped to session activation state.

- add runtime soul registry store and persist  data to disk
- load persisted runtime souls during role-soul plugin initialization
- keep  behavior session-only (clear active state, do not delete registry)
- add role-soul plugin tests for registration persistence and clear semantics