### PR TITLE
Interpret escape sequences in --content CLI argument

### DIFF
--- a/packages/canvas-cli/src/commands/__tests__/node.test.ts
+++ b/packages/canvas-cli/src/commands/__tests__/node.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { unescapeContentArg } from '../node';
+
+describe('unescapeContentArg', () => {
+  it('converts literal \\n into real newlines', () => {
+    expect(unescapeContentArg('# Title\\n\\n## Section')).toBe('# Title\n\n## Section');
+  });
+
+  it('handles \\r, \\t, \\\\ and quote escapes', () => {
+    expect(unescapeContentArg('a\\tb\\rc\\\\d\\"e\\\'f\\`g')).toBe('a\tb\rc\\d"e\'f`g');
+  });
+
+  it('leaves real newlines and unrelated backslashes alone', () => {
+    expect(unescapeContentArg('real\nnewline\\x')).toBe('real\nnewline\\x');
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(unescapeContentArg('')).toBe('');
+  });
+
+  it('handles the reported markdown bug example', () => {
+    const input = '# AI Agent\\n\\n## 定义\\n- **AI Agent** 指具备自主感知能力';
+    const out = unescapeContentArg(input);
+    expect(out).toBe('# AI Agent\n\n## 定义\n- **AI Agent** 指具备自主感知能力');
+    expect(out).toContain('\n\n');
+    expect(out).not.toContain('\\n');
+  });
+});

--- a/packages/canvas-cli/src/commands/node.ts
+++ b/packages/canvas-cli/src/commands/node.ts
@@ -11,6 +11,30 @@ import {
 import { output, errorOutput, type OutputFormat } from '../output';
 import type { NodeType } from '../core/types';
 
+/**
+ * Interpret common escape sequences in a CLI --content argument.
+ *
+ * Shells and agent tool invocations deliver `\n`, `\t`, etc. as literal
+ * backslash-letter pairs in argv. Writing those verbatim into a file node
+ * yields content like `# Title\n\n## Section` instead of real line breaks.
+ * This helper unescapes the standard sequences so `--content "a\nb"` behaves
+ * the way users expect. Pass `--raw` to opt out.
+ */
+export function unescapeContentArg(s: string): string {
+  return s.replace(/\\(n|r|t|\\|"|'|`)/g, (_, c: string) => {
+    switch (c) {
+      case 'n': return '\n';
+      case 'r': return '\r';
+      case 't': return '\t';
+      case '\\': return '\\';
+      case '"': return '"';
+      case "'": return "'";
+      case '`': return '`';
+      default: return c;
+    }
+  });
+}
+
 function getOpts(cmd: Command): { format: OutputFormat; storeDir?: string; workspace: string } {
   const root = cmd.parent?.parent ?? cmd.parent;
   const opts = root?.opts() ?? {};
@@ -80,15 +104,16 @@ export function registerNodeCommands(program: Command): void {
 
   node.command('write')
     .argument('<nodeId>', 'Node ID')
-    .option('--content <text>', 'Content to write')
+    .option('--content <text>', 'Content to write (interprets \\n, \\r, \\t, \\\\ escape sequences; use --raw to disable, or --file/stdin for literal content)')
     .option('--file <path>', 'Read content from file')
+    .option('--raw', 'Treat --content verbatim without interpreting escape sequences', false)
     .description('Write content to a canvas node')
-    .action(async function (this: Command, nodeId: string, cmdOpts: { content?: string; file?: string }) {
+    .action(async function (this: Command, nodeId: string, cmdOpts: { content?: string; file?: string; raw?: boolean }) {
       const { format, storeDir, workspace } = getOpts(this);
 
       let content: string;
       if (cmdOpts.content !== undefined) {
-        content = cmdOpts.content;
+        content = cmdOpts.raw ? cmdOpts.content : unescapeContentArg(cmdOpts.content);
       } else if (cmdOpts.file) {
         try {
           content = await fs.readFile(cmdOpts.file, 'utf-8');


### PR DESCRIPTION
## Summary
Add support for interpreting common escape sequences (`\n`, `\r`, `\t`, `\\`, `"`, `'`, `` ` ``) in the `canvas node write --content` argument. This fixes an issue where shells and agent tool invocations deliver escape sequences as literal backslash-letter pairs, causing content like `# Title\n\n## Section` to be written verbatim instead of with real line breaks.

## Changes
- **New `unescapeContentArg()` function**: Converts literal escape sequence pairs in strings to their actual character equivalents. Supports `\n`, `\r`, `\t`, `\\`, and quote characters.
- **Updated `node write` command**:
  - Added `--raw` flag to opt out of escape sequence interpretation when needed
  - Modified `--content` option help text to document the escape sequence behavior
  - Updated action handler to conditionally unescape content based on the `--raw` flag
- **Comprehensive test suite**: Added `node.test.ts` with 5 test cases covering newlines, various escape sequences, unrelated backslashes, empty strings, and a real-world markdown example with Chinese characters

## Implementation Details
- The unescape function uses a regex pattern `/\\(n|r|t|\\|"|'|`)/g` to match escape sequences and a switch statement to convert them
- Unrelated backslashes (e.g., `\x`) are left untouched
- The `--raw` flag defaults to `false`, making escape sequence interpretation the default behavior
- Users can still use `--file` or stdin for truly literal content without any processing

https://claude.ai/code/session_014L2p99P3icK8ygd4uFwBth