### PR TITLE
Add Agent node type for AI agent runner integration

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
@@ -5,27 +5,49 @@
   overflow: hidden;
 }
 
-.agent-prompt-section {
-  padding: 8px;
+.agent-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border-light);
+  flex-shrink: 0;
+  background: var(--surface);
+}
+
+.agent-type-select {
+  padding: 3px 6px;
+  border: 1px solid var(--border-light);
+  border-radius: 4px;
+  background: var(--surface);
+  color: var(--text);
+  font-size: 12px;
+  font-family: inherit;
+  outline: none;
+  cursor: pointer;
   flex-shrink: 0;
 }
 
+.agent-type-select:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.agent-type-select:focus {
+  border-color: var(--accent-border);
+}
+
 .agent-prompt-input {
-  width: 100%;
-  min-height: 60px;
-  max-height: 120px;
-  padding: 8px 10px;
+  flex: 1;
+  min-width: 0;
+  padding: 3px 8px;
   border: 1px solid var(--border-light);
-  border-radius: 6px;
+  border-radius: 4px;
   background: var(--surface);
   color: var(--text);
-  font-size: 13px;
+  font-size: 12px;
   font-family: inherit;
-  line-height: 1.5;
-  resize: vertical;
   outline: none;
-  transition: border-color 0.15s;
-  box-sizing: border-box;
 }
 
 .agent-prompt-input:focus {
@@ -36,135 +58,44 @@
   color: var(--text-muted);
 }
 
-.agent-controls {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 4px 8px 6px;
-  gap: 8px;
-  flex-shrink: 0;
-}
-
-.agent-status {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  color: var(--text-muted);
-}
-
-.agent-status-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--text-muted);
-  flex-shrink: 0;
-}
-
-.agent-status--idle .agent-status-dot {
-  background: var(--text-muted);
-}
-
-.agent-status--running .agent-status-dot {
-  background: #e89545;
-  animation: agentPulse 1.2s ease-in-out infinite;
-}
-
-.agent-status--done .agent-status-dot {
-  background: #3eb889;
-}
-
-.agent-status--error .agent-status-dot {
-  background: #e8615a;
-}
-
-.agent-status--running {
-  color: #e89545;
-}
-
-.agent-status--done {
-  color: #3eb889;
-}
-
-.agent-status--error {
-  color: #e8615a;
-}
-
-@keyframes agentPulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.4; }
-}
-
-.agent-actions {
-  display: flex;
-  gap: 4px;
-}
-
-.agent-btn {
+.agent-start-btn {
   padding: 3px 10px;
   border: none;
   border-radius: 4px;
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.12s, opacity 0.12s;
-}
-
-.agent-btn:disabled {
-  opacity: 0.4;
-  cursor: default;
-}
-
-.agent-btn--run {
   background: #7c5cff;
   color: #fff;
+  flex-shrink: 0;
+  transition: background 0.12s;
 }
 
-.agent-btn--run:hover:not(:disabled) {
+.agent-start-btn:hover {
   background: #6a48e6;
 }
 
-.agent-btn--stop {
-  background: #e8615a;
-  color: #fff;
-}
-
-.agent-btn--stop:hover {
-  background: #d4504a;
-}
-
-.agent-btn--clear {
-  background: rgba(0, 0, 0, 0.05);
-  color: var(--text-muted);
-}
-
-.agent-btn--clear:hover {
-  background: rgba(0, 0, 0, 0.08);
-}
-
-.agent-output-section {
+.agent-xterm-container {
   flex: 1;
-  overflow: auto;
-  padding: 0 8px 8px;
   min-height: 0;
+  background: #fafaf9;
+  padding: 6px 4px 4px;
+  overflow: hidden;
 }
 
-.agent-output {
-  margin: 0;
-  padding: 8px 10px;
-  border-radius: 6px;
-  background: rgba(0, 0, 0, 0.03);
-  font-size: 12px;
-  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
-  line-height: 1.5;
-  color: var(--text);
-  white-space: pre-wrap;
-  word-break: break-word;
+.agent-xterm-container .xterm {
+  height: 100%;
 }
 
-.agent-output--error {
-  background: rgba(232, 97, 90, 0.08);
-  color: #e8615a;
+.agent-xterm-container .xterm-viewport {
+  overflow-y: auto;
+  background: transparent !important;
+}
+
+.agent-xterm-container .xterm-screen {
+  height: 100%;
+}
+
+.agent-xterm-container .xterm-rows {
+  padding: 0 4px;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
@@ -1,0 +1,170 @@
+.agent-body {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.agent-prompt-section {
+  padding: 8px;
+  flex-shrink: 0;
+}
+
+.agent-prompt-input {
+  width: 100%;
+  min-height: 60px;
+  max-height: 120px;
+  padding: 8px 10px;
+  border: 1px solid var(--border-light);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+  font-size: 13px;
+  font-family: inherit;
+  line-height: 1.5;
+  resize: vertical;
+  outline: none;
+  transition: border-color 0.15s;
+  box-sizing: border-box;
+}
+
+.agent-prompt-input:focus {
+  border-color: var(--accent-border);
+}
+
+.agent-prompt-input::placeholder {
+  color: var(--text-muted);
+}
+
+.agent-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 8px 6px;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.agent-status {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--text-muted);
+}
+
+.agent-status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.agent-status--idle .agent-status-dot {
+  background: var(--text-muted);
+}
+
+.agent-status--running .agent-status-dot {
+  background: #e89545;
+  animation: agentPulse 1.2s ease-in-out infinite;
+}
+
+.agent-status--done .agent-status-dot {
+  background: #3eb889;
+}
+
+.agent-status--error .agent-status-dot {
+  background: #e8615a;
+}
+
+.agent-status--running {
+  color: #e89545;
+}
+
+.agent-status--done {
+  color: #3eb889;
+}
+
+.agent-status--error {
+  color: #e8615a;
+}
+
+@keyframes agentPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.agent-actions {
+  display: flex;
+  gap: 4px;
+}
+
+.agent-btn {
+  padding: 3px 10px;
+  border: none;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.12s, opacity 0.12s;
+}
+
+.agent-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.agent-btn--run {
+  background: #7c5cff;
+  color: #fff;
+}
+
+.agent-btn--run:hover:not(:disabled) {
+  background: #6a48e6;
+}
+
+.agent-btn--stop {
+  background: #e8615a;
+  color: #fff;
+}
+
+.agent-btn--stop:hover {
+  background: #d4504a;
+}
+
+.agent-btn--clear {
+  background: rgba(0, 0, 0, 0.05);
+  color: var(--text-muted);
+}
+
+.agent-btn--clear:hover {
+  background: rgba(0, 0, 0, 0.08);
+}
+
+.agent-output-section {
+  flex: 1;
+  overflow: auto;
+  padding: 0 8px 8px;
+  min-height: 0;
+}
+
+.agent-output {
+  margin: 0;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.03);
+  font-size: 12px;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  line-height: 1.5;
+  color: var(--text);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.agent-output--error {
+  background: rgba(232, 97, 90, 0.08);
+  color: #e8615a;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
@@ -71,8 +71,17 @@
   transition: background 0.12s;
 }
 
-.agent-start-btn:hover {
+.agent-start-btn:hover:not(:disabled) {
   background: #6a48e6;
+}
+
+.agent-start-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.agent-start-btn--launch {
+  flex: 1;
 }
 
 .agent-xterm-container {

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -1,105 +1,274 @@
-import { useCallback, useRef, useState } from 'react';
+import { useEffect, useRef, useCallback, useState } from 'react';
 import './index.css';
-import type { CanvasNode, AgentNodeData } from '../../types';
+import { Terminal } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import type { CanvasNode, AgentNodeData, AgentType } from '../../types';
+import { TERMINAL_OPTIONS } from '../../config/terminalTheme';
 
 interface Props {
   node: CanvasNode;
+  rootFolder?: string;
+  workspaceId?: string;
   onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
 }
 
-const STATUS_LABELS: Record<AgentNodeData['status'], string> = {
-  idle: 'Idle',
-  running: 'Running...',
-  done: 'Done',
-  error: 'Error',
+const SCROLLBACK_SAVE_INTERVAL = 2000;
+const MAX_SCROLLBACK_CHARS = 50000;
+
+const AGENT_CONFIGS: Record<AgentType, { label: string; cmd: string }> = {
+  'claude-code': { label: 'Claude Code', cmd: 'claude' },
+  'codex':       { label: 'Codex CLI',   cmd: 'codex' },
+  'pulse-coder': { label: 'Pulse Coder', cmd: 'pulse-coder' },
 };
 
-export const AgentNodeBody = ({ node, onUpdate }: Props) => {
+const serializeBuffer = (term: Terminal): string => {
+  const buf = term.buffer.active;
+  const lines: string[] = [];
+  const count = buf.length;
+  for (let i = 0; i < count; i++) {
+    const line = buf.getLine(i);
+    if (line) lines.push(line.translateToString(true));
+  }
+  let text = lines.join('\n');
+  text = text.replace(/\n+$/, '');
+  if (text.length > MAX_SCROLLBACK_CHARS) text = text.slice(-MAX_SCROLLBACK_CHARS);
+  return text;
+};
+
+export const AgentNodeBody = ({ node, rootFolder, workspaceId, onUpdate }: Props) => {
   const data = node.data as AgentNodeData;
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const [localPrompt, setLocalPrompt] = useState(data.prompt);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const termRef = useRef<Terminal | null>(null);
+  const fitRef = useRef<FitAddon | null>(null);
+  const cleanupRef = useRef<(() => void) | null>(null);
+  const spawnedRef = useRef(false);
+  const saveTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const sessionId = data.sessionId || node.id;
+  const nodeIdRef = useRef(node.id);
+  nodeIdRef.current = node.id;
+  const dataRef = useRef(data);
+  dataRef.current = data;
+  const onUpdateRef = useRef(onUpdate);
+  onUpdateRef.current = onUpdate;
+  const workspaceIdRef = useRef(workspaceId);
+  workspaceIdRef.current = workspaceId;
+  const initialScrollback = useRef(data.scrollback ?? '');
+  const initialCwd = useRef(data.cwd ?? '');
+  const initialAgentType = useRef(data.agentType);
+  const initialStarted = useRef(data.started ?? false);
 
-  const handlePromptChange = useCallback(
-    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      setLocalPrompt(e.target.value);
-    },
-    []
-  );
+  const [agentType, setAgentType] = useState<AgentType>(data.agentType);
+  const [started, setStarted] = useState(data.started ?? false);
 
-  const handlePromptBlur = useCallback(() => {
-    if (localPrompt !== data.prompt) {
-      onUpdate(node.id, { data: { ...data, prompt: localPrompt } });
+  const persistState = useCallback(() => {
+    const term = termRef.current;
+    const scrollback = term ? serializeBuffer(term) : dataRef.current.scrollback;
+    onUpdateRef.current(nodeIdRef.current, {
+      data: {
+        agentType: dataRef.current.agentType,
+        sessionId: dataRef.current.sessionId,
+        scrollback,
+        cwd: dataRef.current.cwd,
+        started: dataRef.current.started,
+      },
+    });
+  }, []);
+
+  const launchAgent = useCallback((prompt?: string) => {
+    const api = window.canvasWorkspace?.pty;
+    if (!api) return;
+    const cfg = AGENT_CONFIGS[dataRef.current.agentType];
+    let cmd = cfg.cmd;
+    if (prompt && prompt.trim()) {
+      // Pass the prompt via -p flag (works for claude, codex, pulse-coder)
+      const escaped = prompt.replace(/'/g, "'\\''");
+      cmd = `${cfg.cmd} -p '${escaped}'`;
     }
-  }, [localPrompt, data, node.id, onUpdate]);
-
-  const handleRun = useCallback(() => {
-    if (data.status === 'running') return;
-    onUpdate(node.id, {
-      data: { ...data, prompt: localPrompt, status: 'running', output: '', error: undefined },
+    api.write(sessionId, cmd + '\n');
+    dataRef.current = { ...dataRef.current, started: true };
+    setStarted(true);
+    onUpdateRef.current(nodeIdRef.current, {
+      data: { ...dataRef.current, started: true },
     });
-  }, [data, localPrompt, node.id, onUpdate]);
+  }, [sessionId]);
 
-  const handleStop = useCallback(() => {
-    if (data.status !== 'running') return;
-    onUpdate(node.id, {
-      data: { ...data, status: 'idle' },
-    });
-  }, [data, node.id, onUpdate]);
+  const initTerminal = useCallback(async () => {
+    if (!containerRef.current || termRef.current || spawnedRef.current) return;
+    spawnedRef.current = true;
 
-  const handleClear = useCallback(() => {
-    onUpdate(node.id, {
-      data: { ...data, output: '', error: undefined, status: 'idle' },
+    const term = new Terminal(TERMINAL_OPTIONS);
+    const fitAddon = new FitAddon();
+    term.loadAddon(fitAddon);
+    term.open(containerRef.current);
+    termRef.current = term;
+    fitRef.current = fitAddon;
+
+    if (initialScrollback.current) {
+      const RESTORE_TAIL_LINES = 10;
+      const lastLines = initialScrollback.current
+        .split('\n')
+        .slice(-RESTORE_TAIL_LINES)
+        .join('\r\n');
+      term.writeln('\x1b[2m--- session restored ---\x1b[0m');
+      term.write(lastLines + '\r\n');
+      term.writeln('\x1b[2m--- new session ---\x1b[0m\r\n');
+    }
+
+    requestAnimationFrame(() => {
+      try { fitAddon.fit(); } catch { /* ignore */ }
     });
-  }, [data, node.id, onUpdate]);
+
+    const api = window.canvasWorkspace?.pty;
+    if (!api) {
+      term.writeln('\x1b[31mError: pty API not available (preload missing)\x1b[0m');
+      return;
+    }
+
+    const spawnCwd = initialCwd.current || rootFolder || undefined;
+    const result = await api.spawn(sessionId, term.cols, term.rows, spawnCwd, workspaceIdRef.current);
+    if (!result.ok) {
+      term.writeln(`\x1b[31mFailed to spawn shell: ${result.error}\x1b[0m`);
+      return;
+    }
+
+    const removeData = api.onData(sessionId, (d: string) => { term.write(d); });
+    const removeExit = api.onExit(sessionId, (code: number) => {
+      term.writeln(`\r\n\x1b[2m[Process exited with code ${code}]\x1b[0m`);
+    });
+
+    term.onData((d: string) => {
+      api.write(sessionId, d);
+    });
+
+    term.onResize(({ cols, rows }) => { api.resize(sessionId, cols, rows); });
+
+    saveTimerRef.current = setInterval(async () => {
+      const scrollback = serializeBuffer(term);
+      const cwdResult = await api.getCwd(sessionId);
+      const cwd = cwdResult.ok && cwdResult.cwd ? cwdResult.cwd : dataRef.current.cwd;
+      onUpdateRef.current(nodeIdRef.current, {
+        data: {
+          agentType: dataRef.current.agentType,
+          sessionId: dataRef.current.sessionId,
+          scrollback,
+          cwd,
+          started: dataRef.current.started,
+        },
+      });
+    }, SCROLLBACK_SAVE_INTERVAL);
+
+    cleanupRef.current = () => {
+      removeData();
+      removeExit();
+      api.kill(sessionId);
+    };
+
+    // If this is a fresh node (not restored), show a welcome hint
+    if (!initialStarted.current && !initialScrollback.current) {
+      const cfg = AGENT_CONFIGS[initialAgentType.current];
+      term.writeln(`\x1b[2m[Agent: ${cfg.label}] Select agent type above and click Start.\x1b[0m\r\n`);
+    }
+  }, [sessionId, rootFolder, persistState, launchAgent]);
+
+  useEffect(() => {
+    void initTerminal();
+    return () => {
+      const api = window.canvasWorkspace?.pty;
+      if (termRef.current && api) {
+        const scrollback = serializeBuffer(termRef.current);
+        void api.getCwd(sessionId).then((r) => {
+          const cwd = r.ok && r.cwd ? r.cwd : dataRef.current.cwd;
+          onUpdateRef.current(nodeIdRef.current, {
+            data: {
+              agentType: dataRef.current.agentType,
+              sessionId: dataRef.current.sessionId,
+              scrollback,
+              cwd,
+              started: dataRef.current.started,
+            },
+          });
+        });
+      } else if (termRef.current) {
+        persistState();
+      }
+      if (saveTimerRef.current) clearInterval(saveTimerRef.current);
+      cleanupRef.current?.();
+      termRef.current?.dispose();
+      termRef.current = null;
+      fitRef.current = null;
+      spawnedRef.current = false;
+      cleanupRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!fitRef.current) return;
+    const observer = new ResizeObserver(() => {
+      try { fitRef.current?.fit(); } catch { /* ignore */ }
+    });
+    if (containerRef.current) observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, []);
+
+  const handleAgentTypeChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newType = e.target.value as AgentType;
+    setAgentType(newType);
+    dataRef.current = { ...dataRef.current, agentType: newType };
+    onUpdateRef.current(nodeIdRef.current, {
+      data: { ...dataRef.current, agentType: newType },
+    });
+  }, []);
+
+  const [promptValue, setPromptValue] = useState('');
+
+  const handleStart = useCallback(() => {
+    launchAgent(promptValue);
+    setPromptValue('');
+  }, [launchAgent, promptValue]);
+
+  const handlePromptKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      launchAgent(promptValue);
+      setPromptValue('');
+    }
+  }, [launchAgent, promptValue]);
 
   return (
     <div className="agent-body">
-      <div className="agent-prompt-section">
-        <textarea
-          ref={textareaRef}
+      <div className="agent-toolbar" onMouseDown={(e) => e.stopPropagation()}>
+        <select
+          className="agent-type-select"
+          value={agentType}
+          onChange={handleAgentTypeChange}
+          disabled={started}
+        >
+          {Object.entries(AGENT_CONFIGS).map(([key, cfg]) => (
+            <option key={key} value={key}>{cfg.label}</option>
+          ))}
+        </select>
+        <input
           className="agent-prompt-input"
-          placeholder="Enter prompt for the agent..."
-          value={localPrompt}
-          onChange={handlePromptChange}
-          onBlur={handlePromptBlur}
-          onMouseDown={(e) => e.stopPropagation()}
+          type="text"
+          placeholder="Prompt (optional)..."
+          value={promptValue}
+          onChange={(e) => setPromptValue(e.target.value)}
+          onKeyDown={handlePromptKeyDown}
         />
+        <button
+          className="agent-start-btn"
+          onClick={handleStart}
+          title={started ? 'Send prompt to agent' : 'Start agent'}
+        >
+          {started ? 'Send' : 'Start'}
+        </button>
       </div>
-      <div className="agent-controls">
-        <div className={`agent-status agent-status--${data.status}`}>
-          <span className="agent-status-dot" />
-          <span className="agent-status-label">{STATUS_LABELS[data.status]}</span>
-        </div>
-        <div className="agent-actions">
-          {data.status === 'running' ? (
-            <button className="agent-btn agent-btn--stop" onClick={handleStop}>
-              Stop
-            </button>
-          ) : (
-            <button
-              className="agent-btn agent-btn--run"
-              onClick={handleRun}
-              disabled={!localPrompt.trim()}
-            >
-              Run
-            </button>
-          )}
-          {(data.output || data.error) && data.status !== 'running' && (
-            <button className="agent-btn agent-btn--clear" onClick={handleClear}>
-              Clear
-            </button>
-          )}
-        </div>
-      </div>
-      {(data.output || data.error) && (
-        <div className="agent-output-section">
-          {data.error ? (
-            <pre className="agent-output agent-output--error">{data.error}</pre>
-          ) : (
-            <pre className="agent-output">{data.output}</pre>
-          )}
-        </div>
-      )}
+      <div
+        ref={containerRef}
+        className="agent-xterm-container"
+        onMouseDown={(e) => e.stopPropagation()}
+      />
     </div>
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -74,22 +74,24 @@ export const AgentNodeBody = ({ node, rootFolder, workspaceId, onUpdate }: Props
     });
   }, []);
 
-  const launchAgent = useCallback((prompt?: string) => {
+  const launchAgent = useCallback(() => {
     const api = window.canvasWorkspace?.pty;
     if (!api) return;
     const cfg = AGENT_CONFIGS[dataRef.current.agentType];
-    let cmd = cfg.cmd;
-    if (prompt && prompt.trim()) {
-      // Pass the prompt via -p flag (works for claude, codex, pulse-coder)
-      const escaped = prompt.replace(/'/g, "'\\''");
-      cmd = `${cfg.cmd} -p '${escaped}'`;
-    }
-    api.write(sessionId, cmd + '\n');
+    // Launch in interactive mode — no -p flag so the user can keep talking
+    api.write(sessionId, cfg.cmd + '\n');
     dataRef.current = { ...dataRef.current, started: true };
     setStarted(true);
     onUpdateRef.current(nodeIdRef.current, {
       data: { ...dataRef.current, started: true },
     });
+  }, [sessionId]);
+
+  /** Send text to the running agent's stdin. */
+  const sendToAgent = useCallback((text: string) => {
+    const api = window.canvasWorkspace?.pty;
+    if (!api || !text.trim()) return;
+    api.write(sessionId, text + '\n');
   }, [sessionId]);
 
   const initTerminal = useCallback(async () => {
@@ -168,7 +170,7 @@ export const AgentNodeBody = ({ node, rootFolder, workspaceId, onUpdate }: Props
       const cfg = AGENT_CONFIGS[initialAgentType.current];
       term.writeln(`\x1b[2m[Agent: ${cfg.label}] Select agent type above and click Start.\x1b[0m\r\n`);
     }
-  }, [sessionId, rootFolder, persistState, launchAgent]);
+  }, [sessionId, rootFolder, persistState]);
 
   useEffect(() => {
     void initTerminal();
@@ -223,17 +225,21 @@ export const AgentNodeBody = ({ node, rootFolder, workspaceId, onUpdate }: Props
   const [promptValue, setPromptValue] = useState('');
 
   const handleStart = useCallback(() => {
-    launchAgent(promptValue);
+    if (started) {
+      // Agent already running — send the prompt text to stdin
+      sendToAgent(promptValue);
+    } else {
+      launchAgent();
+    }
     setPromptValue('');
-  }, [launchAgent, promptValue]);
+  }, [started, launchAgent, sendToAgent, promptValue]);
 
   const handlePromptKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      launchAgent(promptValue);
-      setPromptValue('');
+      handleStart();
     }
-  }, [launchAgent, promptValue]);
+  }, [handleStart]);
 
   return (
     <div className="agent-body">
@@ -248,21 +254,34 @@ export const AgentNodeBody = ({ node, rootFolder, workspaceId, onUpdate }: Props
             <option key={key} value={key}>{cfg.label}</option>
           ))}
         </select>
-        <input
-          className="agent-prompt-input"
-          type="text"
-          placeholder="Prompt (optional)..."
-          value={promptValue}
-          onChange={(e) => setPromptValue(e.target.value)}
-          onKeyDown={handlePromptKeyDown}
-        />
-        <button
-          className="agent-start-btn"
-          onClick={handleStart}
-          title={started ? 'Send prompt to agent' : 'Start agent'}
-        >
-          {started ? 'Send' : 'Start'}
-        </button>
+        {started ? (
+          <>
+            <input
+              className="agent-prompt-input"
+              type="text"
+              placeholder="Send message to agent..."
+              value={promptValue}
+              onChange={(e) => setPromptValue(e.target.value)}
+              onKeyDown={handlePromptKeyDown}
+            />
+            <button
+              className="agent-start-btn"
+              onClick={handleStart}
+              disabled={!promptValue.trim()}
+              title="Send message to agent"
+            >
+              Send
+            </button>
+          </>
+        ) : (
+          <button
+            className="agent-start-btn agent-start-btn--launch"
+            onClick={handleStart}
+            title="Launch agent in interactive mode"
+          >
+            Start
+          </button>
+        )}
       </div>
       <div
         ref={containerRef}

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -1,0 +1,105 @@
+import { useCallback, useRef, useState } from 'react';
+import './index.css';
+import type { CanvasNode, AgentNodeData } from '../../types';
+
+interface Props {
+  node: CanvasNode;
+  onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
+}
+
+const STATUS_LABELS: Record<AgentNodeData['status'], string> = {
+  idle: 'Idle',
+  running: 'Running...',
+  done: 'Done',
+  error: 'Error',
+};
+
+export const AgentNodeBody = ({ node, onUpdate }: Props) => {
+  const data = node.data as AgentNodeData;
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [localPrompt, setLocalPrompt] = useState(data.prompt);
+
+  const handlePromptChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setLocalPrompt(e.target.value);
+    },
+    []
+  );
+
+  const handlePromptBlur = useCallback(() => {
+    if (localPrompt !== data.prompt) {
+      onUpdate(node.id, { data: { ...data, prompt: localPrompt } });
+    }
+  }, [localPrompt, data, node.id, onUpdate]);
+
+  const handleRun = useCallback(() => {
+    if (data.status === 'running') return;
+    onUpdate(node.id, {
+      data: { ...data, prompt: localPrompt, status: 'running', output: '', error: undefined },
+    });
+  }, [data, localPrompt, node.id, onUpdate]);
+
+  const handleStop = useCallback(() => {
+    if (data.status !== 'running') return;
+    onUpdate(node.id, {
+      data: { ...data, status: 'idle' },
+    });
+  }, [data, node.id, onUpdate]);
+
+  const handleClear = useCallback(() => {
+    onUpdate(node.id, {
+      data: { ...data, output: '', error: undefined, status: 'idle' },
+    });
+  }, [data, node.id, onUpdate]);
+
+  return (
+    <div className="agent-body">
+      <div className="agent-prompt-section">
+        <textarea
+          ref={textareaRef}
+          className="agent-prompt-input"
+          placeholder="Enter prompt for the agent..."
+          value={localPrompt}
+          onChange={handlePromptChange}
+          onBlur={handlePromptBlur}
+          onMouseDown={(e) => e.stopPropagation()}
+        />
+      </div>
+      <div className="agent-controls">
+        <div className={`agent-status agent-status--${data.status}`}>
+          <span className="agent-status-dot" />
+          <span className="agent-status-label">{STATUS_LABELS[data.status]}</span>
+        </div>
+        <div className="agent-actions">
+          {data.status === 'running' ? (
+            <button className="agent-btn agent-btn--stop" onClick={handleStop}>
+              Stop
+            </button>
+          ) : (
+            <button
+              className="agent-btn agent-btn--run"
+              onClick={handleRun}
+              disabled={!localPrompt.trim()}
+            >
+              Run
+            </button>
+          )}
+          {(data.output || data.error) && data.status !== 'running' && (
+            <button className="agent-btn agent-btn--clear" onClick={handleClear}>
+              Clear
+            </button>
+          )}
+        </div>
+      </div>
+      {(data.output || data.error) && (
+        <div className="agent-output-section">
+          {data.error ? (
+            <pre className="agent-output agent-output--error">{data.error}</pre>
+          ) : (
+            <pre className="agent-output">{data.output}</pre>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -72,6 +72,10 @@
   color: var(--accent-frame);
 }
 
+.node-type-badge--agent {
+  color: #7c5cff;
+}
+
 .node-title {
   flex: 1;
   font-size: 13px;

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -184,7 +184,7 @@ export const CanvasNodeView = ({
         ) : node.type === "terminal" ? (
           <TerminalNodeBody node={node} allNodes={allNodes} rootFolder={rootFolder} workspaceId={workspaceId} workspaceName={workspaceName} onUpdate={onUpdate} />
         ) : node.type === "agent" ? (
-          <AgentNodeBody node={node} onUpdate={onUpdate} />
+          <AgentNodeBody node={node} rootFolder={rootFolder} workspaceId={workspaceId} onUpdate={onUpdate} />
         ) : (
           <FrameNodeBody node={node} onUpdate={onUpdate} />
         )}

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -5,6 +5,7 @@ import type { ResizeEdge } from "../hooks/useNodeResize";
 import { FileNodeBody } from "../FileNodeBody";
 import { TerminalNodeBody } from "../TerminalNodeBody";
 import { FrameNodeBody, FrameColorPicker } from "../FrameNodeBody";
+import { AgentNodeBody } from "../AgentNodeBody";
 
 interface Props {
   node: CanvasNode;
@@ -139,6 +140,12 @@ export const CanvasNodeView = ({
               <rect x="1.5" y="2.5" width="13" height="11" rx="1.5" stroke="currentColor" strokeWidth="1.3" />
               <path d="M4.5 7l2 1.5-2 1.5M8 10.5h3.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
             </svg>
+          ) : node.type === "agent" ? (
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+              <circle cx="8" cy="6" r="3.5" stroke="currentColor" strokeWidth="1.3" />
+              <path d="M3 13.5c0-2.5 2.2-4 5-4s5 1.5 5 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+              <circle cx="8" cy="5.5" r="1" fill="currentColor" />
+            </svg>
           ) : (
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
               <rect x="2" y="2" width="12" height="12" rx="2" stroke="currentColor" strokeWidth="1.3" />
@@ -176,6 +183,8 @@ export const CanvasNodeView = ({
           <FileNodeBody node={node} onUpdate={onUpdate} workspaceId={workspaceId} />
         ) : node.type === "terminal" ? (
           <TerminalNodeBody node={node} allNodes={allNodes} rootFolder={rootFolder} workspaceId={workspaceId} workspaceName={workspaceName} onUpdate={onUpdate} />
+        ) : node.type === "agent" ? (
+          <AgentNodeBody node={node} onUpdate={onUpdate} />
         ) : (
           <FrameNodeBody node={node} onUpdate={onUpdate} />
         )}

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
@@ -3,7 +3,7 @@ import './index.css';
 interface Props {
   activeTool: string;
   onToolChange: (tool: string) => void;
-  onAddNode: (type: "file" | "terminal" | "frame") => void;
+  onAddNode: (type: "file" | "terminal" | "frame" | "agent") => void;
 }
 
 const tools = [
@@ -111,6 +111,21 @@ export const FloatingToolbar = ({
             />
           </svg>
           <span className="toolbar-btn-label">Frame</span>
+        </button>
+        <button
+          className="toolbar-btn toolbar-btn--create"
+          onClick={() => onAddNode("agent")}
+          title="Add Agent"
+        >
+          <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+            <circle cx="9" cy="7" r="3.5" stroke="currentColor" strokeWidth="1.3" />
+            <path
+              d="M4 15.5c0-2.5 2.2-4 5-4s5 1.5 5 4"
+              stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"
+            />
+            <circle cx="9" cy="6.5" r="1" fill="currentColor" />
+          </svg>
+          <span className="toolbar-btn-label">Agent</span>
         </button>
       </div>
     </div>

--- a/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from "react";
 interface Props {
   x: number;
   y: number;
-  onCreate: (type: "file" | "terminal" | "frame") => void;
+  onCreate: (type: "file" | "terminal" | "frame" | "agent") => void;
   onClose: () => void;
 }
 
@@ -70,6 +70,16 @@ export const NodeContextMenu = ({ x, y, onCreate, onClose }: Props) => {
         <span className="context-menu-label">
           <strong>Frame</strong>
           <small>Visual container group</small>
+        </span>
+      </button>
+      <button
+        className="context-menu-item"
+        onClick={() => onCreate("agent")}
+      >
+        <span className="context-menu-icon">{"\u2726"}</span>
+        <span className="context-menu-label">
+          <strong>Agent</strong>
+          <small>AI agent runner</small>
         </span>
       </button>
     </div>

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -29,12 +29,17 @@ export interface FrameNodeData {
   label?: string;
 }
 
+export type AgentType = 'claude-code' | 'codex' | 'pulse-coder';
+
 export interface AgentNodeData {
-  agentId: string;
-  prompt: string;
-  status: 'idle' | 'running' | 'done' | 'error';
-  output: string;
-  error?: string;
+  /** Which agent CLI to launch. */
+  agentType: AgentType;
+  /** PTY session id (same pattern as TerminalNodeData). */
+  sessionId: string;
+  scrollback?: string;
+  cwd?: string;
+  /** Whether the agent process has been launched in this session. */
+  started?: boolean;
 }
 
 export interface CanvasTransform {

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -1,12 +1,12 @@
 export interface CanvasNode {
   id: string;
-  type: "file" | "terminal" | "frame";
+  type: "file" | "terminal" | "frame" | "agent";
   title: string;
   x: number;
   y: number;
   width: number;
   height: number;
-  data: FileNodeData | TerminalNodeData | FrameNodeData;
+  data: FileNodeData | TerminalNodeData | FrameNodeData | AgentNodeData;
   /** Epoch millis of last mutation; used for cross-process merge. */
   updatedAt?: number;
 }
@@ -27,6 +27,14 @@ export interface TerminalNodeData {
 export interface FrameNodeData {
   color: string;
   label?: string;
+}
+
+export interface AgentNodeData {
+  agentId: string;
+  prompt: string;
+  status: 'idle' | 'running' | 'done' | 'error';
+  output: string;
+  error?: string;
 }
 
 export interface CanvasTransform {

--- a/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
@@ -15,7 +15,7 @@ export const createNodeData = (type: CanvasNode['type']): FileNodeData | Termina
     case 'file':     return { filePath: '', content: '', saved: false, modified: false };
     case 'terminal': return { sessionId: '' };
     case 'frame':    return { color: '#9575d4' };
-    case 'agent':    return { agentId: '', prompt: '', status: 'idle', output: '' };
+    case 'agent':    return { agentType: 'claude-code', sessionId: '', started: false };
   }
 };
 

--- a/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
@@ -1,4 +1,4 @@
-import type { CanvasNode, FileNodeData, TerminalNodeData, FrameNodeData } from '../types';
+import type { CanvasNode, FileNodeData, TerminalNodeData, FrameNodeData, AgentNodeData } from '../types';
 
 let nodeIdCounter = 0;
 export const genId = (): string => `node-${Date.now()}-${++nodeIdCounter}`;
@@ -7,13 +7,15 @@ const NODE_DEFAULTS: Record<CanvasNode['type'], { title: string; width: number; 
   file:     { title: 'Untitled', width: 420, height: 360 },
   terminal: { title: 'Terminal', width: 480, height: 300 },
   frame:    { title: 'Frame',    width: 600, height: 400 },
+  agent:    { title: 'Agent',    width: 460, height: 400 },
 };
 
-export const createNodeData = (type: CanvasNode['type']): FileNodeData | TerminalNodeData | FrameNodeData => {
+export const createNodeData = (type: CanvasNode['type']): FileNodeData | TerminalNodeData | FrameNodeData | AgentNodeData => {
   switch (type) {
     case 'file':     return { filePath: '', content: '', saved: false, modified: false };
     case 'terminal': return { sessionId: '' };
     case 'frame':    return { color: '#9575d4' };
+    case 'agent':    return { agentId: '', prompt: '', status: 'idle', output: '' };
   }
 };
 

--- a/packages/canvas-cli/src/core/constants.ts
+++ b/packages/canvas-cli/src/core/constants.ts
@@ -8,7 +8,7 @@ export const NODE_CAPABILITIES: Record<NodeType, NodeCapability[]> = {
   file: ['read', 'write'],
   terminal: ['read', 'exec'],
   frame: ['read', 'write'],
-  agent: ['read', 'write', 'exec'],
+  agent: ['read', 'exec'],
 };
 
 export const DEFAULT_NODE_DIMENSIONS: Record<NodeType, { title: string; width: number; height: number }> = {

--- a/packages/canvas-cli/src/core/constants.ts
+++ b/packages/canvas-cli/src/core/constants.ts
@@ -8,12 +8,14 @@ export const NODE_CAPABILITIES: Record<NodeType, NodeCapability[]> = {
   file: ['read', 'write'],
   terminal: ['read', 'exec'],
   frame: ['read', 'write'],
+  agent: ['read', 'write', 'exec'],
 };
 
 export const DEFAULT_NODE_DIMENSIONS: Record<NodeType, { title: string; width: number; height: number }> = {
   file: { title: 'Untitled', width: 420, height: 360 },
   terminal: { title: 'Terminal', width: 480, height: 300 },
   frame: { title: 'Frame', width: 600, height: 400 },
+  agent: { title: 'Agent', width: 460, height: 400 },
 };
 
 export const AGENTS_MD_TEMPLATE = `# Canvas Agent Config

--- a/packages/canvas-cli/src/core/nodes.ts
+++ b/packages/canvas-cli/src/core/nodes.ts
@@ -50,11 +50,10 @@ export async function readNode(node: CanvasNode): Promise<NodeReadResult> {
       return {
         type: 'agent',
         capabilities,
-        agentId: node.data.agentId ?? '',
-        prompt: node.data.prompt ?? '',
-        status: node.data.status ?? 'idle',
-        output: node.data.output ?? '',
-        error: node.data.error ?? '',
+        agentType: node.data.agentType ?? 'claude-code',
+        cwd: node.data.cwd ?? '',
+        scrollback: node.data.scrollback ?? '',
+        started: node.data.started ?? false,
       };
     default:
       return { type: node.type, capabilities };
@@ -105,23 +104,19 @@ export async function writeNode(
     case 'agent': {
       try {
         const patch = JSON.parse(content) as {
-          prompt?: string;
-          status?: string;
-          output?: string;
-          error?: string;
-          agentId?: string;
+          agentType?: string;
+          cwd?: string;
+          started?: boolean;
         };
-        if (patch.prompt !== undefined) node.data.prompt = patch.prompt;
-        if (patch.status !== undefined) node.data.status = patch.status as 'idle' | 'running' | 'done' | 'error';
-        if (patch.output !== undefined) node.data.output = patch.output;
-        if (patch.error !== undefined) node.data.error = patch.error;
-        if (patch.agentId !== undefined) node.data.agentId = patch.agentId;
+        if (patch.agentType !== undefined) node.data.agentType = patch.agentType as 'claude-code' | 'codex' | 'pulse-coder';
+        if (patch.cwd !== undefined) node.data.cwd = patch.cwd;
+        if (patch.started !== undefined) node.data.started = patch.started;
         node.updatedAt = Date.now();
         await commitNodeMutation(workspaceId, { upsert: node }, storeDir);
         await notifyCanvasUpdated({ workspaceId, nodeIds: [nodeId], kind: 'update' });
         return { ok: true, data: undefined };
       } catch {
-        return { ok: false, error: 'Agent write expects JSON: { prompt?, status?, output?, error?, agentId? }' };
+        return { ok: false, error: 'Agent write expects JSON: { agentType?, cwd?, started? }' };
       }
     }
     default:
@@ -192,10 +187,10 @@ export async function createNode(
       break;
     case 'agent':
       nodeData = {
-        agentId: (inputData as Record<string, string>).agentId ?? '',
-        prompt: (inputData as Record<string, string>).prompt ?? '',
-        status: 'idle',
-        output: '',
+        agentType: (inputData as Record<string, string>).agentType ?? 'claude-code',
+        sessionId: '',
+        cwd: (inputData as Record<string, string>).cwd ?? '',
+        started: false,
       };
       break;
   }

--- a/packages/canvas-cli/src/core/nodes.ts
+++ b/packages/canvas-cli/src/core/nodes.ts
@@ -46,6 +46,16 @@ export async function readNode(node: CanvasNode): Promise<NodeReadResult> {
         label: node.data.label ?? '',
         color: node.data.color ?? '',
       };
+    case 'agent':
+      return {
+        type: 'agent',
+        capabilities,
+        agentId: node.data.agentId ?? '',
+        prompt: node.data.prompt ?? '',
+        status: node.data.status ?? 'idle',
+        output: node.data.output ?? '',
+        error: node.data.error ?? '',
+      };
     default:
       return { type: node.type, capabilities };
   }
@@ -92,6 +102,28 @@ export async function writeNode(
     }
     case 'terminal':
       return { ok: false, error: 'Terminal nodes do not support write. Use canvas_exec to send commands.' };
+    case 'agent': {
+      try {
+        const patch = JSON.parse(content) as {
+          prompt?: string;
+          status?: string;
+          output?: string;
+          error?: string;
+          agentId?: string;
+        };
+        if (patch.prompt !== undefined) node.data.prompt = patch.prompt;
+        if (patch.status !== undefined) node.data.status = patch.status as 'idle' | 'running' | 'done' | 'error';
+        if (patch.output !== undefined) node.data.output = patch.output;
+        if (patch.error !== undefined) node.data.error = patch.error;
+        if (patch.agentId !== undefined) node.data.agentId = patch.agentId;
+        node.updatedAt = Date.now();
+        await commitNodeMutation(workspaceId, { upsert: node }, storeDir);
+        await notifyCanvasUpdated({ workspaceId, nodeIds: [nodeId], kind: 'update' });
+        return { ok: true, data: undefined };
+      } catch {
+        return { ok: false, error: 'Agent write expects JSON: { prompt?, status?, output?, error?, agentId? }' };
+      }
+    }
     default:
       return { ok: false, error: 'Unknown node type' };
   }
@@ -157,6 +189,14 @@ export async function createNode(
       break;
     case 'frame':
       nodeData = { color: (inputData as Record<string, string>).color ?? '#9575d4', label: (inputData as Record<string, string>).label ?? '' };
+      break;
+    case 'agent':
+      nodeData = {
+        agentId: (inputData as Record<string, string>).agentId ?? '',
+        prompt: (inputData as Record<string, string>).prompt ?? '',
+        status: 'idle',
+        output: '',
+      };
       break;
   }
 

--- a/packages/canvas-cli/src/core/types.ts
+++ b/packages/canvas-cli/src/core/types.ts
@@ -11,11 +11,8 @@ export interface CanvasNodeData {
   sessionId?: string;
   color?: string;
   label?: string;
-  agentId?: string;
-  prompt?: string;
-  status?: 'idle' | 'running' | 'done' | 'error';
-  output?: string;
-  error?: string;
+  agentType?: 'claude-code' | 'codex' | 'pulse-coder';
+  started?: boolean;
   [key: string]: unknown;
 }
 

--- a/packages/canvas-cli/src/core/types.ts
+++ b/packages/canvas-cli/src/core/types.ts
@@ -1,4 +1,4 @@
-export type NodeType = 'file' | 'terminal' | 'frame';
+export type NodeType = 'file' | 'terminal' | 'frame' | 'agent';
 export type NodeCapability = 'read' | 'write' | 'exec';
 
 export interface CanvasNodeData {
@@ -11,6 +11,11 @@ export interface CanvasNodeData {
   sessionId?: string;
   color?: string;
   label?: string;
+  agentId?: string;
+  prompt?: string;
+  status?: 'idle' | 'running' | 'done' | 'error';
+  output?: string;
+  error?: string;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary
This PR introduces a new **Agent** node type to the canvas workspace, enabling users to launch and interact with AI agent CLIs (Claude Code, Codex, Pulse Coder) directly within the canvas. Agents run in interactive PTY sessions with persistent state, scrollback history, and the ability to send prompts via a toolbar interface.

## Key Changes

### New Agent Node Component
- **AgentNodeBody** (`apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/`)
  - Full xterm.js terminal integration with FitAddon for responsive sizing
  - PTY session management via `window.canvasWorkspace.pty` API
  - Agent type selection (claude-code, codex, pulse-coder) with launch button
  - Interactive prompt input that sends messages to running agent
  - Automatic scrollback persistence (50KB limit) saved every 2 seconds
  - Session restoration showing last 10 lines of previous output
  - Responsive ResizeObserver for terminal fitting on container resize

### Type System Updates
- Added `AgentType` union type: `'claude-code' | 'codex' | 'pulse-coder'`
- Added `AgentNodeData` interface with fields:
  - `agentType`: which agent CLI to launch
  - `sessionId`: PTY session identifier
  - `scrollback`: terminal output history
  - `cwd`: current working directory
  - `started`: whether agent process has been launched
- Updated `CanvasNode` type to include agent nodes

### CLI Integration
- Extended `packages/canvas-cli/src/core/nodes.ts`:
  - `readNode()` returns agent node data with capabilities
  - `writeNode()` accepts JSON patch for agent properties (agentType, cwd, started)
  - `createNode()` initializes agent nodes with defaults
- Updated `NODE_CAPABILITIES` to grant agent nodes `['read', 'exec']` permissions
- Updated `NodeType` to include `'agent'`

### UI Integration
- Added Agent button to FloatingToolbar with custom SVG icon
- Added Agent option to NodeContextMenu
- Updated CanvasNodeView to render AgentNodeBody component
- Added agent type badge styling (purple #7c5cff)
- Updated nodeFactory to support agent node creation with defaults

## Implementation Details

- **Session Persistence**: Terminal scrollback is serialized from xterm buffer, truncated to 50KB, and saved to node data every 2 seconds
- **Interactive Mode**: Agent launches without `-p` flag, allowing continuous user interaction
- **State Management**: Uses refs to maintain stable references across re-renders while keeping UI state in useState
- **Cleanup**: Proper teardown of PTY sessions, event listeners, and timers on unmount
- **Accessibility**: Toolbar prevents canvas drag interactions via `stopPropagation()`

https://claude.ai/code/session_01LLEMxugRw2Suz42Y5yBS84