### PR TITLE
Add Agent node type support to Canvas

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
@@ -1,0 +1,34 @@
+.agent-body-wrap {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.agent-badge {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #8b5cf6;
+  background: rgba(139, 92, 246, 0.06);
+  border-bottom: 1px solid rgba(139, 92, 246, 0.12);
+}
+
+.agent-badge-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #8b5cf6;
+  animation: agentDotPulse 2s ease-in-out infinite;
+}
+
+.agent-badge-label {
+  letter-spacing: 0.02em;
+}
+
+@keyframes agentDotPulse {
+  0%, 100% { opacity: 0.5; }
+  50% { opacity: 1; }
+}

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -1,0 +1,34 @@
+import './index.css';
+import type { CanvasNode, AgentNodeData } from '../../types';
+import { TerminalNodeBody } from '../TerminalNodeBody';
+
+interface Props {
+  node: CanvasNode;
+  allNodes?: CanvasNode[];
+  rootFolder?: string;
+  workspaceId?: string;
+  workspaceName?: string;
+  onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
+}
+
+export const AgentNodeBody = ({ node, allNodes, rootFolder, workspaceId, workspaceName, onUpdate }: Props) => {
+  const data = node.data as AgentNodeData;
+
+  return (
+    <div className="agent-body-wrap">
+      <div className="agent-badge">
+        <span className="agent-badge-dot" />
+        <span className="agent-badge-label">{data.agentType ?? 'claude-code'}</span>
+      </div>
+      <TerminalNodeBody
+        node={node}
+        allNodes={allNodes}
+        rootFolder={rootFolder}
+        workspaceId={workspaceId}
+        workspaceName={workspaceName}
+        onUpdate={onUpdate}
+        autoCommand={data.agentCommand}
+      />
+    </div>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -18,7 +18,7 @@ export const AgentNodeBody = ({ node, allNodes, rootFolder, workspaceId, workspa
     <div className="agent-body-wrap">
       <div className="agent-badge">
         <span className="agent-badge-dot" />
-        <span className="agent-badge-label">{data.agentType ?? 'claude-code'}</span>
+        <span className="agent-badge-label">{data.agentType ?? 'codex'}</span>
       </div>
       <TerminalNodeBody
         node={node}

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -173,7 +173,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
   );
 
   const handleCreateNode = useCallback(
-    (type: 'file' | 'terminal' | 'frame') => {
+    (type: 'file' | 'terminal' | 'frame' | 'agent') => {
       if (!contextMenu) return;
       const node = addNode(type, contextMenu.canvasX, contextMenu.canvasY);
       setSelectedNodeIds([node.id]);
@@ -183,11 +183,11 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
   );
 
   const handleToolbarAddNode = useCallback(
-    (type: 'file' | 'terminal' | 'frame') => {
+    (type: 'file' | 'terminal' | 'frame' | 'agent') => {
       if (!containerRef.current) return;
       const rect = containerRef.current.getBoundingClientRect();
       const pos = screenToCanvas(rect.left + rect.width / 2, rect.top + rect.height / 2, containerRef.current);
-      const halfW = type === 'file' ? 210 : type === 'terminal' ? 240 : 300;
+      const halfW = type === 'file' ? 210 : type === 'terminal' ? 240 : type === 'agent' ? 260 : 300;
       const node = addNode(type, pos.x - halfW, pos.y - (type === 'frame' ? 200 : 150));
       setSelectedNodeIds([node.id]);
     },

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -173,9 +173,9 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
   );
 
   const handleCreateNode = useCallback(
-    (type: 'file' | 'terminal' | 'frame' | 'agent') => {
+    (type: 'file' | 'terminal' | 'frame' | 'agent', data?: Record<string, unknown>) => {
       if (!contextMenu) return;
-      const node = addNode(type, contextMenu.canvasX, contextMenu.canvasY);
+      const node = addNode(type, contextMenu.canvasX, contextMenu.canvasY, data);
       setSelectedNodeIds([node.id]);
       setContextMenu(null);
     },

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -72,6 +72,10 @@
   color: var(--accent-frame);
 }
 
+.node-type-badge--agent {
+  color: #8b5cf6;
+}
+
 .node-title {
   flex: 1;
   font-size: 13px;

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -142,7 +142,11 @@ export const CanvasNodeView = ({
             </svg>
           ) : node.type === "agent" ? (
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
-              <path d="M8 1l1.8 3.6L14 5.4l-3 2.9.7 4.1L8 10.5l-3.7 1.9.7-4.1-3-2.9 4.2-.8L8 1z" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round" />
+              <rect x="3" y="6" width="10" height="7" rx="1.5" stroke="currentColor" strokeWidth="1.3" />
+              <circle cx="6.5" cy="9.5" r="1" fill="currentColor" />
+              <circle cx="9.5" cy="9.5" r="1" fill="currentColor" />
+              <path d="M8 6V4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+              <circle cx="8" cy="3" r="1" fill="currentColor" />
             </svg>
           ) : (
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none">

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -5,6 +5,7 @@ import type { ResizeEdge } from "../hooks/useNodeResize";
 import { FileNodeBody } from "../FileNodeBody";
 import { TerminalNodeBody } from "../TerminalNodeBody";
 import { FrameNodeBody, FrameColorPicker } from "../FrameNodeBody";
+import { AgentNodeBody } from "../AgentNodeBody";
 
 interface Props {
   node: CanvasNode;
@@ -139,6 +140,10 @@ export const CanvasNodeView = ({
               <rect x="1.5" y="2.5" width="13" height="11" rx="1.5" stroke="currentColor" strokeWidth="1.3" />
               <path d="M4.5 7l2 1.5-2 1.5M8 10.5h3.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
             </svg>
+          ) : node.type === "agent" ? (
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+              <path d="M8 1l1.8 3.6L14 5.4l-3 2.9.7 4.1L8 10.5l-3.7 1.9.7-4.1-3-2.9 4.2-.8L8 1z" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round" />
+            </svg>
           ) : (
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
               <rect x="2" y="2" width="12" height="12" rx="2" stroke="currentColor" strokeWidth="1.3" />
@@ -176,6 +181,8 @@ export const CanvasNodeView = ({
           <FileNodeBody node={node} onUpdate={onUpdate} workspaceId={workspaceId} />
         ) : node.type === "terminal" ? (
           <TerminalNodeBody node={node} allNodes={allNodes} rootFolder={rootFolder} workspaceId={workspaceId} workspaceName={workspaceName} onUpdate={onUpdate} />
+        ) : node.type === "agent" ? (
+          <AgentNodeBody node={node} allNodes={allNodes} rootFolder={rootFolder} workspaceId={workspaceId} workspaceName={workspaceName} onUpdate={onUpdate} />
         ) : (
           <FrameNodeBody node={node} onUpdate={onUpdate} />
         )}

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
@@ -117,11 +117,12 @@ export const FloatingToolbar = ({
           onClick={() => onAddNode("agent")}
           title="Add Agent"
         >
-          <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-            <path
-              d="M9 2l2.2 4.4 4.8 1-3.5 3.4.8 4.7L9 13.2l-4.3 2.3.8-4.7L2 7.4l4.8-1L9 2z"
-              stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round"
-            />
+          <svg width="18" height="18" viewBox="0 0 16 16" fill="none">
+            <rect x="3" y="6" width="10" height="7" rx="1.5" stroke="currentColor" strokeWidth="1.3" />
+            <circle cx="6.5" cy="9.5" r="1" fill="currentColor" />
+            <circle cx="9.5" cy="9.5" r="1" fill="currentColor" />
+            <path d="M8 6V4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+            <circle cx="8" cy="3" r="1" fill="currentColor" />
           </svg>
           <span className="toolbar-btn-label">Agent</span>
         </button>

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
@@ -3,7 +3,7 @@ import './index.css';
 interface Props {
   activeTool: string;
   onToolChange: (tool: string) => void;
-  onAddNode: (type: "file" | "terminal" | "frame") => void;
+  onAddNode: (type: "file" | "terminal" | "frame" | "agent") => void;
 }
 
 const tools = [
@@ -111,6 +111,19 @@ export const FloatingToolbar = ({
             />
           </svg>
           <span className="toolbar-btn-label">Frame</span>
+        </button>
+        <button
+          className="toolbar-btn toolbar-btn--create"
+          onClick={() => onAddNode("agent")}
+          title="Add Agent"
+        >
+          <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+            <path
+              d="M9 2l2.2 4.4 4.8 1-3.5 3.4.8 4.7L9 13.2l-4.3 2.3.8-4.7L2 7.4l4.8-1L9 2z"
+              stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round"
+            />
+          </svg>
+          <span className="toolbar-btn-label">Agent</span>
         </button>
       </div>
     </div>

--- a/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.css
@@ -51,14 +51,15 @@
   color: var(--accent-file);
 }
 
-.context-menu-item:last-of-type .context-menu-icon {
-  background: rgba(15, 123, 108, 0.08);
-  color: var(--accent-term);
+.context-menu-icon--agent {
+  background: rgba(139, 92, 246, 0.08);
+  color: #8b5cf6;
 }
 
 .context-menu-label {
   display: flex;
   flex-direction: column;
+  flex: 1;
 }
 
 .context-menu-label strong {
@@ -70,4 +71,35 @@
 .context-menu-label small {
   font-size: 11px;
   color: var(--text-secondary);
+}
+
+/* Submenu trigger */
+.context-menu-item--submenu {
+  position: relative;
+}
+
+.context-menu-chevron {
+  font-size: 10px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+/* Submenu panel */
+.context-submenu {
+  position: absolute;
+  left: 100%;
+  top: -4px;
+  min-width: 160px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-float);
+  padding: 4px;
+  animation: menuAppear 0.12s ease;
+}
+
+.context-submenu .context-menu-item {
+  gap: 8px;
+  padding: 6px 10px;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.css
@@ -90,6 +90,7 @@
   position: absolute;
   left: 100%;
   top: -4px;
+  z-index: 1001;
   min-width: 160px;
   background: var(--surface);
   border: 1px solid var(--border);

--- a/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
@@ -1,15 +1,22 @@
 import "./index.css";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+
+const AGENT_OPTIONS = [
+  { type: 'codex', label: 'Codex', command: 'codex' },
+  { type: 'claude-code', label: 'Claude Code', command: 'claude' },
+  { type: 'pulse-coder', label: 'Pulse Coder', command: 'pulse-coder' },
+];
 
 interface Props {
   x: number;
   y: number;
-  onCreate: (type: "file" | "terminal" | "frame" | "agent") => void;
+  onCreate: (type: "file" | "terminal" | "frame" | "agent", data?: Record<string, unknown>) => void;
   onClose: () => void;
 }
 
 export const NodeContextMenu = ({ x, y, onCreate, onClose }: Props) => {
   const menuRef = useRef<HTMLDivElement>(null);
+  const [agentSubmenuOpen, setAgentSubmenuOpen] = useState(false);
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
@@ -72,16 +79,42 @@ export const NodeContextMenu = ({ x, y, onCreate, onClose }: Props) => {
           <small>Visual container group</small>
         </span>
       </button>
-      <button
-        className="context-menu-item"
-        onClick={() => onCreate("agent")}
+      <div
+        className="context-menu-item context-menu-item--submenu"
+        onMouseEnter={() => setAgentSubmenuOpen(true)}
+        onMouseLeave={() => setAgentSubmenuOpen(false)}
       >
-        <span className="context-menu-icon">{"\u2726"}</span>
+        <span className="context-menu-icon context-menu-icon--agent">
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+            <rect x="3" y="6" width="10" height="7" rx="1.5" stroke="currentColor" strokeWidth="1.3" />
+            <circle cx="6.5" cy="9.5" r="1" fill="currentColor" />
+            <circle cx="9.5" cy="9.5" r="1" fill="currentColor" />
+            <path d="M8 6V4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+            <circle cx="8" cy="3" r="1" fill="currentColor" />
+          </svg>
+        </span>
         <span className="context-menu-label">
           <strong>Agent</strong>
           <small>Launch a coding agent</small>
         </span>
-      </button>
+        <span className="context-menu-chevron">{"\u25B8"}</span>
+
+        {agentSubmenuOpen && (
+          <div className="context-submenu">
+            {AGENT_OPTIONS.map((agent) => (
+              <button
+                key={agent.type}
+                className="context-menu-item"
+                onClick={() => onCreate("agent", { agentType: agent.type, agentCommand: agent.command })}
+              >
+                <span className="context-menu-label">
+                  <strong>{agent.label}</strong>
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
@@ -80,9 +80,11 @@ export const NodeContextMenu = ({ x, y, onCreate, onClose }: Props) => {
         </span>
       </button>
       <div
-        className="context-menu-item context-menu-item--submenu"
-        onMouseEnter={() => setAgentSubmenuOpen(true)}
-        onMouseLeave={() => setAgentSubmenuOpen(false)}
+        className={`context-menu-item context-menu-item--submenu${agentSubmenuOpen ? ' context-menu-item--submenu-open' : ''}`}
+        onClick={(e) => {
+          e.stopPropagation();
+          setAgentSubmenuOpen((v) => !v);
+        }}
       >
         <span className="context-menu-icon context-menu-icon--agent">
           <svg width="14" height="14" viewBox="0 0 16 16" fill="none">

--- a/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from "react";
 interface Props {
   x: number;
   y: number;
-  onCreate: (type: "file" | "terminal" | "frame") => void;
+  onCreate: (type: "file" | "terminal" | "frame" | "agent") => void;
   onClose: () => void;
 }
 
@@ -70,6 +70,16 @@ export const NodeContextMenu = ({ x, y, onCreate, onClose }: Props) => {
         <span className="context-menu-label">
           <strong>Frame</strong>
           <small>Visual container group</small>
+        </span>
+      </button>
+      <button
+        className="context-menu-item"
+        onClick={() => onCreate("agent")}
+      >
+        <span className="context-menu-icon">{"\u2726"}</span>
+        <span className="context-menu-label">
+          <strong>Agent</strong>
+          <small>Launch a coding agent</small>
         </span>
       </button>
     </div>

--- a/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
@@ -107,7 +107,10 @@ export const NodeContextMenu = ({ x, y, onCreate, onClose }: Props) => {
               <button
                 key={agent.type}
                 className="context-menu-item"
-                onClick={() => onCreate("agent", { agentType: agent.type, agentCommand: agent.command })}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCreate("agent", { agentType: agent.type, agentCommand: agent.command });
+                }}
               >
                 <span className="context-menu-label">
                   <strong>{agent.label}</strong>

--- a/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody/index.tsx
@@ -14,6 +14,8 @@ interface Props {
   workspaceId?: string;
   workspaceName?: string;
   onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
+  /** If set, this command is automatically written to the PTY after spawn. */
+  autoCommand?: string;
 }
 
 const SCROLLBACK_SAVE_INTERVAL = 2000;
@@ -33,7 +35,7 @@ const serializeBuffer = (term: Terminal): string => {
   return text;
 };
 
-export const TerminalNodeBody = ({ node, allNodes, rootFolder, workspaceId, workspaceName, onUpdate }: Props) => {
+export const TerminalNodeBody = ({ node, allNodes, rootFolder, workspaceId, workspaceName, onUpdate, autoCommand }: Props) => {
   const [pickerOpen, setPickerOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
@@ -111,6 +113,10 @@ export const TerminalNodeBody = ({ node, allNodes, rootFolder, workspaceId, work
     if (!result.ok) {
       term.writeln(`\x1b[31mFailed to spawn shell: ${result.error}\x1b[0m`);
       return;
+    }
+
+    if (autoCommand) {
+      api.write(sessionId, autoCommand + '\n');
     }
 
     const removeData = api.onData(sessionId, (d: string) => { term.write(d); });

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
@@ -276,8 +276,8 @@ export const useNodes = (
   }, [canvasId]);
 
   const addNode = useCallback(
-    (type: CanvasNode['type'], x: number, y: number) => {
-      const node = { ...createDefaultNode(type, x, y), updatedAt: Date.now() };
+    (type: CanvasNode['type'], x: number, y: number, data?: Record<string, unknown>) => {
+      const node = { ...createDefaultNode(type, x, y, data), updatedAt: Date.now() };
 
       if (type === 'file') {
         const api = window.canvasWorkspace?.file;

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -1,12 +1,12 @@
 export interface CanvasNode {
   id: string;
-  type: "file" | "terminal" | "frame";
+  type: "file" | "terminal" | "frame" | "agent";
   title: string;
   x: number;
   y: number;
   width: number;
   height: number;
-  data: FileNodeData | TerminalNodeData | FrameNodeData;
+  data: FileNodeData | TerminalNodeData | FrameNodeData | AgentNodeData;
   /** Epoch millis of last mutation; used for cross-process merge. */
   updatedAt?: number;
 }
@@ -27,6 +27,14 @@ export interface TerminalNodeData {
 export interface FrameNodeData {
   color: string;
   label?: string;
+}
+
+export interface AgentNodeData {
+  sessionId: string;
+  scrollback?: string;
+  cwd?: string;
+  agentType: string;
+  agentCommand: string;
 }
 
 export interface CanvasTransform {

--- a/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
@@ -1,4 +1,4 @@
-import type { CanvasNode, FileNodeData, TerminalNodeData, FrameNodeData } from '../types';
+import type { CanvasNode, FileNodeData, TerminalNodeData, FrameNodeData, AgentNodeData } from '../types';
 
 let nodeIdCounter = 0;
 export const genId = (): string => `node-${Date.now()}-${++nodeIdCounter}`;
@@ -7,13 +7,15 @@ const NODE_DEFAULTS: Record<CanvasNode['type'], { title: string; width: number; 
   file:     { title: 'Untitled', width: 420, height: 360 },
   terminal: { title: 'Terminal', width: 480, height: 300 },
   frame:    { title: 'Frame',    width: 600, height: 400 },
+  agent:    { title: 'Agent',    width: 520, height: 360 },
 };
 
-export const createNodeData = (type: CanvasNode['type']): FileNodeData | TerminalNodeData | FrameNodeData => {
+export const createNodeData = (type: CanvasNode['type']): FileNodeData | TerminalNodeData | FrameNodeData | AgentNodeData => {
   switch (type) {
     case 'file':     return { filePath: '', content: '', saved: false, modified: false };
     case 'terminal': return { sessionId: '' };
     case 'frame':    return { color: '#9575d4' };
+    case 'agent':    return { sessionId: '', agentType: 'claude-code', agentCommand: 'claude' };
   }
 };
 

--- a/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
@@ -30,6 +30,6 @@ export const createDefaultNode = (type: CanvasNode['type'], x: number, y: number
     y,
     width: def.width,
     height: def.height,
-    data: initialData ? { ...data, ...initialData } : data,
+    data: (initialData ? { ...data, ...initialData } : data) as CanvasNode['data'],
   };
 };

--- a/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
@@ -15,12 +15,13 @@ export const createNodeData = (type: CanvasNode['type']): FileNodeData | Termina
     case 'file':     return { filePath: '', content: '', saved: false, modified: false };
     case 'terminal': return { sessionId: '' };
     case 'frame':    return { color: '#9575d4' };
-    case 'agent':    return { sessionId: '', agentType: 'claude-code', agentCommand: 'claude' };
+    case 'agent':    return { sessionId: '', agentType: 'codex', agentCommand: 'codex' };
   }
 };
 
-export const createDefaultNode = (type: CanvasNode['type'], x: number, y: number): CanvasNode => {
+export const createDefaultNode = (type: CanvasNode['type'], x: number, y: number, initialData?: Record<string, unknown>): CanvasNode => {
   const def = NODE_DEFAULTS[type];
+  const data = createNodeData(type);
   return {
     id: genId(),
     type,
@@ -29,6 +30,6 @@ export const createDefaultNode = (type: CanvasNode['type'], x: number, y: number
     y,
     width: def.width,
     height: def.height,
-    data: createNodeData(type),
+    data: initialData ? { ...data, ...initialData } : data,
   };
 };

--- a/packages/canvas-cli/src/core/__tests__/nodes.test.ts
+++ b/packages/canvas-cli/src/core/__tests__/nodes.test.ts
@@ -55,7 +55,7 @@ function makeTerminalNode(id: string): CanvasNode {
   };
 }
 
-function makeAgentNode(id: string, agentType = 'claude-code', agentCommand = 'claude'): CanvasNode {
+function makeAgentNode(id: string, agentType = 'codex', agentCommand = 'codex'): CanvasNode {
   return {
     id,
     type: 'agent',
@@ -107,11 +107,11 @@ describe('readNode', () => {
   });
 
   it('reads agent node', async () => {
-    const node = makeAgentNode('a1', 'claude-code', 'claude');
+    const node = makeAgentNode('a1', 'codex', 'codex');
     const result = await readNode(node);
     expect(result.type).toBe('agent');
-    expect(result.agentType).toBe('claude-code');
-    expect(result.agentCommand).toBe('claude');
+    expect(result.agentType).toBe('codex');
+    expect(result.agentCommand).toBe('codex');
     expect(result.cwd).toBe('/home/user');
   });
 });
@@ -232,14 +232,13 @@ describe('createNode', () => {
     expect(canvas!.nodes[0].title).toBe('First');
   });
 
-  it('creates an agent node with default preset', async () => {
+  it('creates an agent node with default codex preset', async () => {
     const canvas = makeCanvas([]);
     await saveCanvas('ws-1', canvas, testDir);
 
     const result = await createNode('ws-1', {
       type: 'agent',
       title: 'My Agent',
-      data: { agentType: 'claude-code' },
     }, testDir);
 
     expect(result.ok).toBe(true);
@@ -250,6 +249,24 @@ describe('createNode', () => {
 
     const updated = await loadCanvas('ws-1', testDir);
     expect(updated!.nodes).toHaveLength(1);
+    expect(updated!.nodes[0].data.agentType).toBe('codex');
+    expect(updated!.nodes[0].data.agentCommand).toBe('codex');
+  });
+
+  it('creates an agent node with explicit agent type', async () => {
+    const canvas = makeCanvas([]);
+    await saveCanvas('ws-1', canvas, testDir);
+
+    const result = await createNode('ws-1', {
+      type: 'agent',
+      title: 'Claude Agent',
+      data: { agentType: 'claude-code' },
+    }, testDir);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const updated = await loadCanvas('ws-1', testDir);
     expect(updated!.nodes[0].data.agentType).toBe('claude-code');
     expect(updated!.nodes[0].data.agentCommand).toBe('claude');
   });

--- a/packages/canvas-cli/src/core/__tests__/nodes.test.ts
+++ b/packages/canvas-cli/src/core/__tests__/nodes.test.ts
@@ -55,11 +55,22 @@ function makeTerminalNode(id: string): CanvasNode {
   };
 }
 
+function makeAgentNode(id: string, agentType = 'claude-code', agentCommand = 'claude'): CanvasNode {
+  return {
+    id,
+    type: 'agent',
+    title: 'Test Agent',
+    x: 0, y: 0, width: 520, height: 360,
+    data: { sessionId: '', cwd: '/home/user', scrollback: '', agentType, agentCommand },
+  };
+}
+
 describe('getNodeCapabilities', () => {
   it('returns correct capabilities', () => {
     expect(getNodeCapabilities('file')).toEqual(['read', 'write']);
     expect(getNodeCapabilities('terminal')).toEqual(['read', 'exec']);
     expect(getNodeCapabilities('frame')).toEqual(['read', 'write']);
+    expect(getNodeCapabilities('agent')).toEqual(['read', 'exec']);
   });
 });
 
@@ -94,6 +105,15 @@ describe('readNode', () => {
     expect(result.label).toBe('Important');
     expect(result.color).toBe('#ff0000');
   });
+
+  it('reads agent node', async () => {
+    const node = makeAgentNode('a1', 'claude-code', 'claude');
+    const result = await readNode(node);
+    expect(result.type).toBe('agent');
+    expect(result.agentType).toBe('claude-code');
+    expect(result.agentCommand).toBe('claude');
+    expect(result.cwd).toBe('/home/user');
+  });
 });
 
 describe('writeNode', () => {
@@ -125,6 +145,14 @@ describe('writeNode', () => {
     await saveCanvas('ws-1', canvas, testDir);
 
     const result = await writeNode('ws-1', 't1', 'hello', testDir);
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects write to agent node', async () => {
+    const canvas = makeCanvas([makeAgentNode('a1')]);
+    await saveCanvas('ws-1', canvas, testDir);
+
+    const result = await writeNode('ws-1', 'a1', 'hello', testDir);
     expect(result.ok).toBe(false);
   });
 
@@ -202,6 +230,28 @@ describe('createNode', () => {
     expect(canvas).not.toBeNull();
     expect(canvas!.nodes).toHaveLength(1);
     expect(canvas!.nodes[0].title).toBe('First');
+  });
+
+  it('creates an agent node with default preset', async () => {
+    const canvas = makeCanvas([]);
+    await saveCanvas('ws-1', canvas, testDir);
+
+    const result = await createNode('ws-1', {
+      type: 'agent',
+      title: 'My Agent',
+      data: { agentType: 'claude-code' },
+    }, testDir);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.data.type).toBe('agent');
+    expect(result.data.title).toBe('My Agent');
+
+    const updated = await loadCanvas('ws-1', testDir);
+    expect(updated!.nodes).toHaveLength(1);
+    expect(updated!.nodes[0].data.agentType).toBe('claude-code');
+    expect(updated!.nodes[0].data.agentCommand).toBe('claude');
   });
 
   it('creates file node with initial content', async () => {

--- a/packages/canvas-cli/src/core/constants.ts
+++ b/packages/canvas-cli/src/core/constants.ts
@@ -8,12 +8,20 @@ export const NODE_CAPABILITIES: Record<NodeType, NodeCapability[]> = {
   file: ['read', 'write'],
   terminal: ['read', 'exec'],
   frame: ['read', 'write'],
+  agent: ['read', 'exec'],
 };
 
 export const DEFAULT_NODE_DIMENSIONS: Record<NodeType, { title: string; width: number; height: number }> = {
   file: { title: 'Untitled', width: 420, height: 360 },
   terminal: { title: 'Terminal', width: 480, height: 300 },
   frame: { title: 'Frame', width: 600, height: 400 },
+  agent: { title: 'Agent', width: 520, height: 360 },
+};
+
+export const AGENT_PRESETS: Record<string, { label: string; command: string }> = {
+  'claude-code': { label: 'Claude Code', command: 'claude' },
+  'codex': { label: 'Codex', command: 'codex' },
+  'pulse-coder': { label: 'Pulse Coder', command: 'pulse-coder' },
 };
 
 export const AGENTS_MD_TEMPLATE = `# Canvas Agent Config

--- a/packages/canvas-cli/src/core/nodes.ts
+++ b/packages/canvas-cli/src/core/nodes.ts
@@ -52,8 +52,8 @@ export async function readNode(node: CanvasNode): Promise<NodeReadResult> {
         capabilities,
         cwd: node.data.cwd ?? '',
         scrollback: node.data.scrollback ?? '',
-        agentType: node.data.agentType ?? 'claude-code',
-        agentCommand: node.data.agentCommand ?? 'claude',
+        agentType: node.data.agentType ?? 'codex',
+        agentCommand: node.data.agentCommand ?? 'codex',
       };
     default:
       return { type: node.type, capabilities };
@@ -170,9 +170,9 @@ export async function createNode(
       nodeData = { color: (inputData as Record<string, string>).color ?? '#9575d4', label: (inputData as Record<string, string>).label ?? '' };
       break;
     case 'agent': {
-      const agentType = (inputData as Record<string, string>).agentType ?? 'claude-code';
+      const agentType = (inputData as Record<string, string>).agentType ?? 'codex';
       const preset = AGENT_PRESETS[agentType];
-      const agentCommand = (inputData as Record<string, string>).agentCommand ?? preset?.command ?? 'claude';
+      const agentCommand = (inputData as Record<string, string>).agentCommand ?? preset?.command ?? 'codex';
       nodeData = { sessionId: '', cwd: (inputData as Record<string, string>).cwd ?? '', agentType, agentCommand };
       break;
     }

--- a/packages/canvas-cli/src/core/nodes.ts
+++ b/packages/canvas-cli/src/core/nodes.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs';
 import { join } from 'path';
-import { NODE_CAPABILITIES, DEFAULT_NODE_DIMENSIONS } from './constants';
+import { NODE_CAPABILITIES, DEFAULT_NODE_DIMENSIONS, AGENT_PRESETS } from './constants';
 import { loadCanvas, saveCanvas, ensureWorkspaceDir, getWorkspaceDir, commitNodeMutation } from './store';
 import { notifyCanvasUpdated } from './notifier';
 import type {
@@ -45,6 +45,15 @@ export async function readNode(node: CanvasNode): Promise<NodeReadResult> {
         capabilities,
         label: node.data.label ?? '',
         color: node.data.color ?? '',
+      };
+    case 'agent':
+      return {
+        type: 'agent',
+        capabilities,
+        cwd: node.data.cwd ?? '',
+        scrollback: node.data.scrollback ?? '',
+        agentType: node.data.agentType ?? 'claude-code',
+        agentCommand: node.data.agentCommand ?? 'claude',
       };
     default:
       return { type: node.type, capabilities };
@@ -92,6 +101,8 @@ export async function writeNode(
     }
     case 'terminal':
       return { ok: false, error: 'Terminal nodes do not support write. Use canvas_exec to send commands.' };
+    case 'agent':
+      return { ok: false, error: 'Agent nodes do not support write. Use canvas_exec to send commands.' };
     default:
       return { ok: false, error: 'Unknown node type' };
   }
@@ -158,6 +169,13 @@ export async function createNode(
     case 'frame':
       nodeData = { color: (inputData as Record<string, string>).color ?? '#9575d4', label: (inputData as Record<string, string>).label ?? '' };
       break;
+    case 'agent': {
+      const agentType = (inputData as Record<string, string>).agentType ?? 'claude-code';
+      const preset = AGENT_PRESETS[agentType];
+      const agentCommand = (inputData as Record<string, string>).agentCommand ?? preset?.command ?? 'claude';
+      nodeData = { sessionId: '', cwd: (inputData as Record<string, string>).cwd ?? '', agentType, agentCommand };
+      break;
+    }
   }
 
   // For file nodes, always create a notes file so the node has a valid filePath

--- a/packages/canvas-cli/src/core/types.ts
+++ b/packages/canvas-cli/src/core/types.ts
@@ -1,4 +1,4 @@
-export type NodeType = 'file' | 'terminal' | 'frame';
+export type NodeType = 'file' | 'terminal' | 'frame' | 'agent';
 export type NodeCapability = 'read' | 'write' | 'exec';
 
 export interface CanvasNodeData {
@@ -11,6 +11,8 @@ export interface CanvasNodeData {
   sessionId?: string;
   color?: string;
   label?: string;
+  agentType?: string;
+  agentCommand?: string;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary
This PR introduces a new "Agent" node type to the Canvas system, enabling users to launch and interact with coding agents (like Claude Code) directly within the canvas workspace.

## Key Changes

### Core Type System
- Added `'agent'` to the `NodeType` union type across the codebase
- Created `AgentNodeData` interface with properties: `sessionId`, `scrollback`, `cwd`, `agentType`, and `agentCommand`
- Updated all node type unions to include the new agent type

### Backend (canvas-cli)
- Added agent node capabilities (`['read', 'exec']`) to `NODE_CAPABILITIES`
- Added default agent node dimensions (520x360) to `DEFAULT_NODE_DIMENSIONS`
- Created `AGENT_PRESETS` constant defining available agent types (claude-code, codex, pulse-coder) with their default commands
- Implemented `readNode()` support for agent nodes, returning agent-specific metadata
- Implemented `writeNode()` rejection for agent nodes (agents don't support write operations)
- Implemented `createNode()` support for agent nodes with preset-based command defaults
- Added comprehensive test coverage for agent node operations

### Frontend (canvas-workspace)
- Created new `AgentNodeBody` component that wraps `TerminalNodeBody` with an agent badge displaying the agent type
- Added agent badge styling with animated pulse indicator
- Updated `TerminalNodeBody` to accept optional `autoCommand` prop for automatic command execution on spawn
- Added agent node creation UI in `FloatingToolbar` and `NodeContextMenu`
- Updated `CanvasNodeView` to render agent nodes with appropriate icon and body component
- Updated `nodeFactory.ts` to generate agent node data with default values
- Added agent node styling with purple accent color (#8b5cf6)

### Type Updates
- Updated all node type signatures in Canvas, toolbar, and context menu components to include `'agent'`
- Updated node factory and dimension calculations to handle agent nodes

## Implementation Details
- Agent nodes reuse the terminal infrastructure via `TerminalNodeBody`, inheriting all terminal functionality
- The `autoCommand` feature allows agents to automatically execute their configured command upon session spawn
- Agent presets provide sensible defaults for different agent types, with extensibility for future agents
- Agent nodes support the same read/exec capabilities as terminal nodes but explicitly reject write operations

https://claude.ai/code/session_016pZgjS6mYQA4Gy3idh2Lfq