### PR TITLE
Add Agent node type for launching coding agents

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
@@ -4,52 +4,132 @@
   height: 100%;
 }
 
+/* ── Picker (idle state) ── */
+
 .agent-picker {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 20px 16px;
+  gap: 14px;
+  padding: 16px 14px;
   height: 100%;
   box-sizing: border-box;
 }
 
-.agent-picker-field {
+.agent-picker-section {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
 }
 
-.agent-picker-field label {
+.agent-picker-label {
   font-size: 11px;
   font-weight: 600;
-  color: #8c8c8c;
+  color: #9a9a9a;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: 0.4px;
 }
 
-.agent-picker-field select,
-.agent-picker-field input {
-  padding: 6px 8px;
-  border: 1px solid #e0e0e0;
-  border-radius: 6px;
+/* ── Agent cards ── */
+
+.agent-card-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.agent-card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border: 1.5px solid #e8e8e8;
+  border-radius: 8px;
+  background: #fff;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.12s, background 0.12s, box-shadow 0.12s;
+}
+
+.agent-card:hover {
+  border-color: #d0d0d0;
+  background: #fafafa;
+}
+
+.agent-card--selected {
+  border-color: #7c5cff;
+  background: #f8f5ff;
+  box-shadow: 0 0 0 1px rgba(124, 92, 255, 0.15);
+}
+
+.agent-card--selected:hover {
+  border-color: #7c5cff;
+  background: #f4f0ff;
+}
+
+.agent-card-icon {
+  font-size: 20px;
+  line-height: 1;
+  flex-shrink: 0;
+  width: 28px;
+  text-align: center;
+}
+
+.agent-card-info {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.agent-card-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: #333;
+  line-height: 1.3;
+}
+
+.agent-card-desc {
+  font-size: 11px;
+  color: #999;
+  line-height: 1.3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Folder picker button ── */
+
+.agent-folder-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  border: 1.5px solid #e8e8e8;
+  border-radius: 8px;
+  background: #fff;
+  cursor: pointer;
+  color: #555;
+  transition: border-color 0.12s, background 0.12s;
   font-size: 13px;
   font-family: inherit;
+  text-align: left;
+}
+
+.agent-folder-btn:hover {
+  border-color: #d0d0d0;
   background: #fafafa;
-  color: #333;
-  outline: none;
-  transition: border-color 0.15s;
 }
 
-.agent-picker-field select:focus,
-.agent-picker-field input:focus {
-  border-color: #7c5cff;
+.agent-folder-path {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #666;
 }
 
-.agent-picker-description {
-  font-size: 11px;
-  color: #aaa;
-  margin-top: -4px;
-}
+/* ── Launch button ── */
 
 .agent-launch-btn {
   margin-top: auto;
@@ -67,6 +147,8 @@
 .agent-launch-btn:hover {
   background: #6a4de6;
 }
+
+/* ── Terminal (running state) ── */
 
 .agent-xterm-container {
   height: 100%;
@@ -91,6 +173,8 @@
 .agent-xterm-container .xterm-rows {
   padding: 0 4px;
 }
+
+/* ── Restart overlay ── */
 
 .agent-restart-overlay {
   position: absolute;

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
@@ -4,13 +4,13 @@
   height: 100%;
 }
 
-/* ── Picker (idle state) ── */
+/* ── Picker (idle state) ───────────────────────────────── */
 
 .agent-picker {
   display: flex;
   flex-direction: column;
-  gap: 14px;
-  padding: 16px 14px;
+  gap: 16px;
+  padding: 14px;
   height: 100%;
   box-sizing: border-box;
 }
@@ -23,101 +23,99 @@
 
 .agent-picker-label {
   font-size: 11px;
-  font-weight: 600;
-  color: #9a9a9a;
-  text-transform: uppercase;
-  letter-spacing: 0.4px;
+  font-weight: 500;
+  color: var(--text-muted);
+  letter-spacing: 0.3px;
+  padding-left: 1px;
 }
 
 /* ── Agent cards ── */
 
 .agent-card-list {
   display: flex;
-  flex-direction: column;
   gap: 6px;
 }
 
 .agent-card {
+  flex: 1;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 10px;
-  padding: 8px 10px;
-  border: 1.5px solid #e8e8e8;
-  border-radius: 8px;
-  background: #fff;
+  gap: 4px;
+  padding: 10px 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
   cursor: pointer;
-  text-align: left;
-  transition: border-color 0.12s, background 0.12s, box-shadow 0.12s;
+  text-align: center;
+  transition: border-color 0.12s, background 0.12s;
 }
 
 .agent-card:hover {
-  border-color: #d0d0d0;
-  background: #fafafa;
+  background: var(--surface-hover);
+  border-color: var(--border);
 }
 
-.agent-card--selected {
-  border-color: #7c5cff;
-  background: #f8f5ff;
-  box-shadow: 0 0 0 1px rgba(124, 92, 255, 0.15);
+.agent-card--active {
+  border-color: var(--accent-border);
+  background: var(--accent-light);
 }
 
-.agent-card--selected:hover {
-  border-color: #7c5cff;
-  background: #f4f0ff;
+.agent-card--active:hover {
+  border-color: var(--accent-border);
+  background: var(--accent-light);
 }
 
 .agent-card-icon {
-  font-size: 20px;
-  line-height: 1;
-  flex-shrink: 0;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 28px;
-  text-align: center;
+  height: 28px;
+  border-radius: var(--radius-sm);
+  background: var(--border-light);
+  transition: color 0.12s, background 0.12s;
 }
 
-.agent-card-info {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  min-width: 0;
+.agent-card--active .agent-card-icon {
+  color: var(--accent);
+  background: rgba(35, 131, 226, 0.10);
 }
 
 .agent-card-name {
-  font-size: 13px;
-  font-weight: 600;
-  color: #333;
-  line-height: 1.3;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text);
+  line-height: 1.2;
 }
 
 .agent-card-desc {
-  font-size: 11px;
-  color: #999;
-  line-height: 1.3;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  font-size: 10px;
+  color: var(--text-muted);
+  line-height: 1.2;
 }
 
-/* ── Folder picker button ── */
+/* ── Folder picker ── */
 
 .agent-folder-btn {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 7px 10px;
-  border: 1.5px solid #e8e8e8;
-  border-radius: 8px;
-  background: #fff;
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
   cursor: pointer;
-  color: #555;
+  color: var(--text-secondary);
   transition: border-color 0.12s, background 0.12s;
   font-size: 13px;
-  font-family: inherit;
+  font-family: var(--font);
   text-align: left;
 }
 
 .agent-folder-btn:hover {
-  border-color: #d0d0d0;
-  background: #fafafa;
+  background: var(--surface-hover);
 }
 
 .agent-folder-path {
@@ -126,29 +124,39 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 /* ── Launch button ── */
 
 .agent-launch-btn {
   margin-top: auto;
-  padding: 8px 16px;
-  border: none;
-  border-radius: 8px;
-  background: #7c5cff;
-  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 7px 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: var(--text);
   font-size: 13px;
-  font-weight: 600;
+  font-weight: 500;
+  font-family: var(--font);
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background 0.12s, border-color 0.12s;
 }
 
 .agent-launch-btn:hover {
-  background: #6a4de6;
+  background: var(--surface-hover);
+  border-color: var(--text-muted);
 }
 
-/* ── Terminal (running state) ── */
+.agent-launch-btn svg {
+  color: var(--text-muted);
+}
+
+/* ── Terminal (running state) ──────────────────────────── */
 
 .agent-xterm-container {
   height: 100%;
@@ -178,26 +186,31 @@
 
 .agent-restart-overlay {
   position: absolute;
-  bottom: 12px;
+  bottom: 10px;
   left: 50%;
   transform: translateX(-50%);
   z-index: 10;
 }
 
 .agent-restart-btn {
-  padding: 6px 16px;
-  border: none;
-  border-radius: 8px;
-  background: #7c5cff;
-  color: #fff;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: var(--text-secondary);
   font-size: 12px;
-  font-weight: 600;
+  font-weight: 500;
+  font-family: var(--font);
   cursor: pointer;
-  opacity: 0.9;
-  transition: opacity 0.15s, background 0.15s;
+  box-shadow: var(--shadow-sm);
+  transition: background 0.12s, border-color 0.12s;
 }
 
 .agent-restart-btn:hover {
-  opacity: 1;
-  background: #6a4de6;
+  background: var(--surface-hover);
+  border-color: var(--text-muted);
+  color: var(--text);
 }

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
@@ -1,0 +1,119 @@
+.agent-body-wrap {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.agent-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 20px 16px;
+  height: 100%;
+  box-sizing: border-box;
+}
+
+.agent-picker-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.agent-picker-field label {
+  font-size: 11px;
+  font-weight: 600;
+  color: #8c8c8c;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.agent-picker-field select,
+.agent-picker-field input {
+  padding: 6px 8px;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  font-size: 13px;
+  font-family: inherit;
+  background: #fafafa;
+  color: #333;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.agent-picker-field select:focus,
+.agent-picker-field input:focus {
+  border-color: #7c5cff;
+}
+
+.agent-picker-description {
+  font-size: 11px;
+  color: #aaa;
+  margin-top: -4px;
+}
+
+.agent-launch-btn {
+  margin-top: auto;
+  padding: 8px 16px;
+  border: none;
+  border-radius: 8px;
+  background: #7c5cff;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.agent-launch-btn:hover {
+  background: #6a4de6;
+}
+
+.agent-xterm-container {
+  height: 100%;
+  background: #fafaf9;
+  padding: 6px 4px 4px;
+  overflow: hidden;
+}
+
+.agent-xterm-container .xterm {
+  height: 100%;
+}
+
+.agent-xterm-container .xterm-viewport {
+  overflow-y: auto;
+  background: transparent !important;
+}
+
+.agent-xterm-container .xterm-screen {
+  height: 100%;
+}
+
+.agent-xterm-container .xterm-rows {
+  padding: 0 4px;
+}
+
+.agent-restart-overlay {
+  position: absolute;
+  bottom: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+}
+
+.agent-restart-btn {
+  padding: 6px 16px;
+  border: none;
+  border-radius: 8px;
+  background: #7c5cff;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  opacity: 0.9;
+  transition: opacity 0.15s, background 0.15s;
+}
+
+.agent-restart-btn:hover {
+  opacity: 1;
+  background: #6a4de6;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -32,6 +32,19 @@ const serializeBuffer = (term: Terminal): string => {
   return text;
 };
 
+/** Truncate a path for display, keeping the last N segments. */
+const truncatePath = (p: string, maxLen = 36): string => {
+  if (p.length <= maxLen) return p;
+  const parts = p.replace(/\/$/, '').split('/');
+  let result = parts[parts.length - 1];
+  for (let i = parts.length - 2; i >= 0; i--) {
+    const next = parts[i] + '/' + result;
+    if (next.length > maxLen) return '\u2026/' + result;
+    result = next;
+  }
+  return result;
+};
+
 export const AgentNodeBody = ({ node, rootFolder, workspaceId, onUpdate }: Props) => {
   const data = node.data as AgentNodeData;
   const status = data.status ?? 'idle';
@@ -97,7 +110,31 @@ export const AgentNodeBody = ({ node, rootFolder, workspaceId, onUpdate }: Props
       return;
     }
 
-    const removeData = api.onData(sessionId, (d: string) => { term.write(d); });
+    // Resolve the agent command to write once the shell is ready
+    const command = getAgentCommand(agentType);
+    const writeCommand = () => {
+      if (command) {
+        const args = dataRef.current.agentArgs ? ` ${dataRef.current.agentArgs}` : '';
+        api.write(sessionId, `${command}${args}\n`);
+      } else {
+        term.writeln(`\x1b[33mUnknown agent type: ${agentType}\x1b[0m`);
+      }
+    };
+
+    // Wait for the shell to emit its first output (prompt) before writing
+    // the agent command. Writing immediately after spawn() would send the
+    // command while the shell is still sourcing init scripts, causing it to
+    // be lost or garbled.
+    let prompted = false;
+    const promptRemove = api.onData(sessionId, (d: string) => {
+      term.write(d);
+      if (!prompted) {
+        prompted = true;
+        promptRemove();
+        setTimeout(writeCommand, 100);
+      }
+    });
+
     const removeExit = api.onExit(sessionId, (code: number) => {
       term.writeln(`\r\n\x1b[2m[Agent exited with code ${code}]\x1b[0m`);
       onUpdateRef.current(nodeIdRef.current, {
@@ -110,15 +147,6 @@ export const AgentNodeBody = ({ node, rootFolder, workspaceId, onUpdate }: Props
     });
 
     term.onResize(({ cols, rows }) => { api.resize(sessionId, cols, rows); });
-
-    // Launch the agent command
-    const command = getAgentCommand(agentType);
-    if (command) {
-      const args = dataRef.current.agentArgs ? ` ${dataRef.current.agentArgs}` : '';
-      api.write(sessionId, `${command}${args}\n`);
-    } else {
-      term.writeln(`\x1b[33mUnknown agent type: ${agentType}\x1b[0m`);
-    }
 
     onUpdateRef.current(nodeIdRef.current, {
       data: { ...dataRef.current, agentType, cwd: spawnCwd ?? '', status: 'running', sessionId },
@@ -134,7 +162,7 @@ export const AgentNodeBody = ({ node, rootFolder, workspaceId, onUpdate }: Props
     }, SCROLLBACK_SAVE_INTERVAL);
 
     cleanupRef.current = () => {
-      removeData();
+      if (!prompted) promptRemove();
       removeExit();
       api.kill(sessionId);
     };
@@ -182,7 +210,6 @@ export const AgentNodeBody = ({ node, rootFolder, workspaceId, onUpdate }: Props
   }, [spawnAgent, selectedAgent, cwdInput]);
 
   const handleRestart = useCallback(() => {
-    // Clean up existing session
     if (saveTimerRef.current) clearInterval(saveTimerRef.current);
     cleanupRef.current?.();
     termRef.current?.dispose();
@@ -199,34 +226,47 @@ export const AgentNodeBody = ({ node, rootFolder, workspaceId, onUpdate }: Props
     setLaunched(false);
   }, []);
 
-  const agentDef = AGENT_REGISTRY.find(a => a.id === selectedAgent);
+  const handlePickFolder = useCallback(async () => {
+    const api = window.canvasWorkspace?.dialog;
+    if (!api) return;
+    const result = await api.openFolder();
+    if (result.ok && !result.canceled && result.folderPath) {
+      setCwdInput(result.folderPath);
+    }
+  }, []);
 
   if (!launched) {
     return (
       <div className="agent-body-wrap">
         <div className="agent-picker">
-          <div className="agent-picker-field">
-            <label>Agent</label>
-            <select
-              value={selectedAgent}
-              onChange={(e) => setSelectedAgent(e.target.value)}
-            >
+          <div className="agent-picker-section">
+            <span className="agent-picker-label">Select Agent</span>
+            <div className="agent-card-list">
               {AGENT_REGISTRY.map(a => (
-                <option key={a.id} value={a.id}>{a.label}</option>
+                <button
+                  key={a.id}
+                  className={`agent-card${selectedAgent === a.id ? ' agent-card--selected' : ''}`}
+                  onClick={() => setSelectedAgent(a.id)}
+                >
+                  <span className="agent-card-icon">{a.icon}</span>
+                  <span className="agent-card-info">
+                    <span className="agent-card-name">{a.label}</span>
+                    <span className="agent-card-desc">{a.description}</span>
+                  </span>
+                </button>
               ))}
-            </select>
-            {agentDef && (
-              <span className="agent-picker-description">{agentDef.description}</span>
-            )}
+            </div>
           </div>
-          <div className="agent-picker-field">
-            <label>Working Directory</label>
-            <input
-              type="text"
-              placeholder={rootFolder || 'default'}
-              value={cwdInput}
-              onChange={(e) => setCwdInput(e.target.value)}
-            />
+          <div className="agent-picker-section">
+            <span className="agent-picker-label">Working Directory</span>
+            <button className="agent-folder-btn" onClick={handlePickFolder}>
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+                <path d="M2 4.5A1.5 1.5 0 013.5 3H6l1.5 1.5h5A1.5 1.5 0 0114 6v5.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 012 11.5v-7z" stroke="currentColor" strokeWidth="1.2" />
+              </svg>
+              <span className="agent-folder-path">
+                {cwdInput ? truncatePath(cwdInput) : rootFolder ? truncatePath(rootFolder) : 'Select folder\u2026'}
+              </span>
+            </button>
           </div>
           <button className="agent-launch-btn" onClick={handleLaunch}>
             Launch Agent

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -4,7 +4,35 @@ import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import type { CanvasNode, AgentNodeData } from '../../types';
 import { TERMINAL_OPTIONS } from '../../config/terminalTheme';
-import { AGENT_REGISTRY, getAgentCommand } from '../../config/agentRegistry';
+import { AGENT_REGISTRY, getAgentCommand, type AgentDef } from '../../config/agentRegistry';
+
+/** Monoline SVG icon per agent, matching the app's stroke-icon style. */
+const AgentIcon = ({ id }: { id: string }) => {
+  switch (id) {
+    case 'claude-code':
+      return (
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+          <path d="M5.5 6.5L7.5 8.5 5.5 10.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+          <path d="M9 10.5h2" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+          <rect x="1.5" y="2.5" width="13" height="11" rx="2" stroke="currentColor" strokeWidth="1.3" />
+        </svg>
+      );
+    case 'codex':
+      return (
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+          <circle cx="8" cy="8" r="5.5" stroke="currentColor" strokeWidth="1.3" />
+          <path d="M8 5v3l2 1.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      );
+    default:
+      return (
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+          <path d="M4 13V8l4-5 4 5v5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+          <path d="M7 13v-3h2v3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      );
+  }
+};
 
 interface Props {
   node: CanvasNode;
@@ -260,40 +288,42 @@ export const AgentNodeBody = ({ node, rootFolder, workspaceId, onUpdate }: Props
   }, []);
 
   if (!launched) {
+    const agentDef = AGENT_REGISTRY.find((a: AgentDef) => a.id === selectedAgent);
     return (
       <div className="agent-body-wrap">
         <div className="agent-picker">
           <div className="agent-picker-section">
-            <span className="agent-picker-label">Select Agent</span>
+            <span className="agent-picker-label">Agent</span>
             <div className="agent-card-list">
-              {AGENT_REGISTRY.map(a => (
+              {AGENT_REGISTRY.map((a: AgentDef) => (
                 <button
                   key={a.id}
-                  className={`agent-card${selectedAgent === a.id ? ' agent-card--selected' : ''}`}
+                  className={`agent-card${selectedAgent === a.id ? ' agent-card--active' : ''}`}
                   onClick={() => setSelectedAgent(a.id)}
                 >
-                  <span className="agent-card-icon">{a.icon}</span>
-                  <span className="agent-card-info">
-                    <span className="agent-card-name">{a.label}</span>
-                    <span className="agent-card-desc">{a.description}</span>
-                  </span>
+                  <span className="agent-card-icon"><AgentIcon id={a.id} /></span>
+                  <span className="agent-card-name">{a.label}</span>
+                  <span className="agent-card-desc">{a.description}</span>
                 </button>
               ))}
             </div>
           </div>
           <div className="agent-picker-section">
-            <span className="agent-picker-label">Working Directory</span>
+            <span className="agent-picker-label">Directory</span>
             <button className="agent-folder-btn" onClick={handlePickFolder}>
               <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
                 <path d="M2 4.5A1.5 1.5 0 013.5 3H6l1.5 1.5h5A1.5 1.5 0 0114 6v5.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 012 11.5v-7z" stroke="currentColor" strokeWidth="1.2" />
               </svg>
               <span className="agent-folder-path">
-                {cwdInput ? truncatePath(cwdInput) : rootFolder ? truncatePath(rootFolder) : 'Select folder\u2026'}
+                {cwdInput ? truncatePath(cwdInput) : rootFolder ? truncatePath(rootFolder) : 'Choose folder\u2026'}
               </span>
             </button>
           </div>
           <button className="agent-launch-btn" onClick={handleLaunch}>
-            Launch Agent
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+              <path d="M4 3l9 5-9 5V3z" fill="currentColor" />
+            </svg>
+            Start {agentDef?.label ?? 'Agent'}
           </button>
         </div>
       </div>

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -1,0 +1,255 @@
+import { useEffect, useRef, useCallback, useState } from 'react';
+import './index.css';
+import { Terminal } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import type { CanvasNode, AgentNodeData } from '../../types';
+import { TERMINAL_OPTIONS } from '../../config/terminalTheme';
+import { AGENT_REGISTRY, getAgentCommand } from '../../config/agentRegistry';
+
+interface Props {
+  node: CanvasNode;
+  allNodes?: CanvasNode[];
+  rootFolder?: string;
+  workspaceId?: string;
+  workspaceName?: string;
+  onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
+}
+
+const SCROLLBACK_SAVE_INTERVAL = 2000;
+const MAX_SCROLLBACK_CHARS = 50000;
+
+const serializeBuffer = (term: Terminal): string => {
+  const buf = term.buffer.active;
+  const lines: string[] = [];
+  const count = buf.length;
+  for (let i = 0; i < count; i++) {
+    const line = buf.getLine(i);
+    if (line) lines.push(line.translateToString(true));
+  }
+  let text = lines.join('\n');
+  text = text.replace(/\n+$/, '');
+  if (text.length > MAX_SCROLLBACK_CHARS) text = text.slice(-MAX_SCROLLBACK_CHARS);
+  return text;
+};
+
+export const AgentNodeBody = ({ node, rootFolder, workspaceId, onUpdate }: Props) => {
+  const data = node.data as AgentNodeData;
+  const status = data.status ?? 'idle';
+
+  const [selectedAgent, setSelectedAgent] = useState(data.agentType || 'claude-code');
+  const [cwdInput, setCwdInput] = useState(data.cwd || '');
+  const [launched, setLaunched] = useState(status === 'running' || status === 'done');
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const termRef = useRef<Terminal | null>(null);
+  const fitRef = useRef<FitAddon | null>(null);
+  const cleanupRef = useRef<(() => void) | null>(null);
+  const spawnedRef = useRef(false);
+  const saveTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const sessionId = data.sessionId || node.id;
+  const nodeIdRef = useRef(node.id);
+  nodeIdRef.current = node.id;
+  const dataRef = useRef(data);
+  dataRef.current = data;
+  const onUpdateRef = useRef(onUpdate);
+  onUpdateRef.current = onUpdate;
+  const initialScrollback = useRef(data.scrollback ?? '');
+
+  const spawnAgent = useCallback(async (agentType: string, cwd: string) => {
+    if (!containerRef.current || termRef.current || spawnedRef.current) return;
+    spawnedRef.current = true;
+
+    const term = new Terminal(TERMINAL_OPTIONS);
+    const fitAddon = new FitAddon();
+    term.loadAddon(fitAddon);
+    term.open(containerRef.current);
+    termRef.current = term;
+    fitRef.current = fitAddon;
+
+    if (initialScrollback.current) {
+      const RESTORE_TAIL_LINES = 10;
+      const lastLines = initialScrollback.current
+        .split('\n')
+        .slice(-RESTORE_TAIL_LINES)
+        .join('\r\n');
+      term.writeln('\x1b[2m--- session restored ---\x1b[0m');
+      term.write(lastLines + '\r\n');
+      term.writeln('\x1b[2m--- new session ---\x1b[0m\r\n');
+    }
+
+    requestAnimationFrame(() => {
+      try { fitAddon.fit(); } catch { /* ignore */ }
+    });
+
+    const api = window.canvasWorkspace?.pty;
+    if (!api) {
+      term.writeln('\x1b[31mError: pty API not available (preload missing)\x1b[0m');
+      return;
+    }
+
+    const spawnCwd = cwd || rootFolder || undefined;
+    const result = await api.spawn(sessionId, term.cols, term.rows, spawnCwd, workspaceId);
+    if (!result.ok) {
+      term.writeln(`\x1b[31mFailed to spawn shell: ${result.error}\x1b[0m`);
+      onUpdateRef.current(nodeIdRef.current, {
+        data: { ...dataRef.current, status: 'error' },
+      });
+      return;
+    }
+
+    const removeData = api.onData(sessionId, (d: string) => { term.write(d); });
+    const removeExit = api.onExit(sessionId, (code: number) => {
+      term.writeln(`\r\n\x1b[2m[Agent exited with code ${code}]\x1b[0m`);
+      onUpdateRef.current(nodeIdRef.current, {
+        data: { ...dataRef.current, status: 'done' },
+      });
+    });
+
+    term.onData((d: string) => {
+      api.write(sessionId, d);
+    });
+
+    term.onResize(({ cols, rows }) => { api.resize(sessionId, cols, rows); });
+
+    // Launch the agent command
+    const command = getAgentCommand(agentType);
+    if (command) {
+      const args = dataRef.current.agentArgs ? ` ${dataRef.current.agentArgs}` : '';
+      api.write(sessionId, `${command}${args}\n`);
+    } else {
+      term.writeln(`\x1b[33mUnknown agent type: ${agentType}\x1b[0m`);
+    }
+
+    onUpdateRef.current(nodeIdRef.current, {
+      data: { ...dataRef.current, agentType, cwd: spawnCwd ?? '', status: 'running', sessionId },
+    });
+
+    saveTimerRef.current = setInterval(async () => {
+      const scrollback = serializeBuffer(term);
+      const cwdResult = await api.getCwd(sessionId);
+      const curCwd = cwdResult.ok && cwdResult.cwd ? cwdResult.cwd : dataRef.current.cwd;
+      onUpdateRef.current(nodeIdRef.current, {
+        data: { ...dataRef.current, scrollback, cwd: curCwd },
+      });
+    }, SCROLLBACK_SAVE_INTERVAL);
+
+    cleanupRef.current = () => {
+      removeData();
+      removeExit();
+      api.kill(sessionId);
+    };
+  }, [sessionId, rootFolder, workspaceId]);
+
+  // If already launched (e.g. restored from save with running status), auto-spawn
+  useEffect(() => {
+    if (launched && !spawnedRef.current) {
+      void spawnAgent(data.agentType, data.cwd ?? '');
+    }
+    return () => {
+      const api = window.canvasWorkspace?.pty;
+      if (termRef.current && api) {
+        const scrollback = serializeBuffer(termRef.current);
+        void api.getCwd(sessionId).then((r) => {
+          const cwd = r.ok && r.cwd ? r.cwd : dataRef.current.cwd;
+          onUpdateRef.current(nodeIdRef.current, {
+            data: { ...dataRef.current, scrollback, cwd },
+          });
+        });
+      }
+      if (saveTimerRef.current) clearInterval(saveTimerRef.current);
+      cleanupRef.current?.();
+      termRef.current?.dispose();
+      termRef.current = null;
+      fitRef.current = null;
+      spawnedRef.current = false;
+      cleanupRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [launched]);
+
+  useEffect(() => {
+    if (!fitRef.current) return;
+    const observer = new ResizeObserver(() => {
+      try { fitRef.current?.fit(); } catch { /* ignore */ }
+    });
+    if (containerRef.current) observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, [launched]);
+
+  const handleLaunch = useCallback(() => {
+    setLaunched(true);
+    void spawnAgent(selectedAgent, cwdInput);
+  }, [spawnAgent, selectedAgent, cwdInput]);
+
+  const handleRestart = useCallback(() => {
+    // Clean up existing session
+    if (saveTimerRef.current) clearInterval(saveTimerRef.current);
+    cleanupRef.current?.();
+    termRef.current?.dispose();
+    termRef.current = null;
+    fitRef.current = null;
+    spawnedRef.current = false;
+    cleanupRef.current = null;
+    initialScrollback.current = '';
+
+    onUpdateRef.current(nodeIdRef.current, {
+      data: { ...dataRef.current, status: 'idle', scrollback: '', sessionId: '' },
+    });
+
+    setLaunched(false);
+  }, []);
+
+  const agentDef = AGENT_REGISTRY.find(a => a.id === selectedAgent);
+
+  if (!launched) {
+    return (
+      <div className="agent-body-wrap">
+        <div className="agent-picker">
+          <div className="agent-picker-field">
+            <label>Agent</label>
+            <select
+              value={selectedAgent}
+              onChange={(e) => setSelectedAgent(e.target.value)}
+            >
+              {AGENT_REGISTRY.map(a => (
+                <option key={a.id} value={a.id}>{a.label}</option>
+              ))}
+            </select>
+            {agentDef && (
+              <span className="agent-picker-description">{agentDef.description}</span>
+            )}
+          </div>
+          <div className="agent-picker-field">
+            <label>Working Directory</label>
+            <input
+              type="text"
+              placeholder={rootFolder || 'default'}
+              value={cwdInput}
+              onChange={(e) => setCwdInput(e.target.value)}
+            />
+          </div>
+          <button className="agent-launch-btn" onClick={handleLaunch}>
+            Launch Agent
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="agent-body-wrap">
+      <div
+        ref={containerRef}
+        className="agent-xterm-container"
+        onMouseDown={(e) => e.stopPropagation()}
+      />
+      {status === 'done' && (
+        <div className="agent-restart-overlay">
+          <button className="agent-restart-btn" onClick={handleRestart}>
+            Restart Agent
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -125,12 +125,23 @@ export const AgentNodeBody = ({ node, rootFolder, workspaceId, onUpdate }: Props
     // the agent command. Writing immediately after spawn() would send the
     // command while the shell is still sourcing init scripts, causing it to
     // be lost or garbled.
+    //
+    // We start with a temporary onData listener that detects the first
+    // output, then swap to the permanent listener that simply forwards all
+    // data to xterm.
     let prompted = false;
+    let removeData: (() => void) | null = null;
+
+    const attachPermanentListener = () => {
+      removeData = api.onData(sessionId, (d: string) => { term.write(d); });
+    };
+
     const promptRemove = api.onData(sessionId, (d: string) => {
       term.write(d);
       if (!prompted) {
         prompted = true;
         promptRemove();
+        attachPermanentListener();
         setTimeout(writeCommand, 100);
       }
     });
@@ -163,6 +174,7 @@ export const AgentNodeBody = ({ node, rootFolder, workspaceId, onUpdate }: Props
 
     cleanupRef.current = () => {
       if (!prompted) promptRemove();
+      removeData?.();
       removeExit();
       api.kill(sessionId);
     };

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -53,6 +53,11 @@ export const AgentNodeBody = ({ node, rootFolder, workspaceId, onUpdate }: Props
   const [cwdInput, setCwdInput] = useState(data.cwd || '');
   const [launched, setLaunched] = useState(status === 'running' || status === 'done');
 
+  // Refs that survive across the picker→terminal transition so the
+  // useEffect that spawns after re-render can read the user's selection.
+  const pendingAgentRef = useRef(data.agentType || 'claude-code');
+  const pendingCwdRef = useRef(data.cwd || '');
+
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
@@ -180,10 +185,12 @@ export const AgentNodeBody = ({ node, rootFolder, workspaceId, onUpdate }: Props
     };
   }, [sessionId, rootFolder, workspaceId]);
 
-  // If already launched (e.g. restored from save with running status), auto-spawn
+  // Spawn the agent after React renders the terminal container.
+  // pendingAgentRef / pendingCwdRef hold the user's picker selection
+  // (or the restored values when resuming a previous session).
   useEffect(() => {
     if (launched && !spawnedRef.current) {
-      void spawnAgent(data.agentType, data.cwd ?? '');
+      void spawnAgent(pendingAgentRef.current, pendingCwdRef.current);
     }
     return () => {
       const api = window.canvasWorkspace?.pty;
@@ -217,9 +224,14 @@ export const AgentNodeBody = ({ node, rootFolder, workspaceId, onUpdate }: Props
   }, [launched]);
 
   const handleLaunch = useCallback(() => {
+    // Store the user's selection in refs so the useEffect (which fires
+    // after React re-renders the terminal container) can read them.
+    // We must NOT call spawnAgent here because containerRef is still null
+    // (the picker UI is rendered, not the terminal div).
+    pendingAgentRef.current = selectedAgent;
+    pendingCwdRef.current = cwdInput;
     setLaunched(true);
-    void spawnAgent(selectedAgent, cwdInput);
-  }, [spawnAgent, selectedAgent, cwdInput]);
+  }, [selectedAgent, cwdInput]);
 
   const handleRestart = useCallback(() => {
     if (saveTimerRef.current) clearInterval(saveTimerRef.current);

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -173,7 +173,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
   );
 
   const handleCreateNode = useCallback(
-    (type: 'file' | 'terminal' | 'frame') => {
+    (type: 'file' | 'terminal' | 'frame' | 'agent') => {
       if (!contextMenu) return;
       const node = addNode(type, contextMenu.canvasX, contextMenu.canvasY);
       setSelectedNodeIds([node.id]);
@@ -183,11 +183,11 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
   );
 
   const handleToolbarAddNode = useCallback(
-    (type: 'file' | 'terminal' | 'frame') => {
+    (type: 'file' | 'terminal' | 'frame' | 'agent') => {
       if (!containerRef.current) return;
       const rect = containerRef.current.getBoundingClientRect();
       const pos = screenToCanvas(rect.left + rect.width / 2, rect.top + rect.height / 2, containerRef.current);
-      const halfW = type === 'file' ? 210 : type === 'terminal' ? 240 : 300;
+      const halfW = type === 'file' ? 210 : type === 'terminal' ? 240 : type === 'agent' ? 260 : 300;
       const node = addNode(type, pos.x - halfW, pos.y - (type === 'frame' ? 200 : 150));
       setSelectedNodeIds([node.id]);
     },

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -72,6 +72,10 @@
   color: var(--accent-frame);
 }
 
+.node-type-badge--agent {
+  color: #7c5cff;
+}
+
 .node-title {
   flex: 1;
   font-size: 13px;

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -5,6 +5,7 @@ import type { ResizeEdge } from "../hooks/useNodeResize";
 import { FileNodeBody } from "../FileNodeBody";
 import { TerminalNodeBody } from "../TerminalNodeBody";
 import { FrameNodeBody, FrameColorPicker } from "../FrameNodeBody";
+import { AgentNodeBody } from "../AgentNodeBody";
 
 interface Props {
   node: CanvasNode;
@@ -139,10 +140,17 @@ export const CanvasNodeView = ({
               <rect x="1.5" y="2.5" width="13" height="11" rx="1.5" stroke="currentColor" strokeWidth="1.3" />
               <path d="M4.5 7l2 1.5-2 1.5M8 10.5h3.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
             </svg>
-          ) : (
+          ) : node.type === "frame" ? (
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
               <rect x="2" y="2" width="12" height="12" rx="2" stroke="currentColor" strokeWidth="1.3" />
               <rect x="4.5" y="4.5" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="1" strokeDasharray="2 1.5" />
+            </svg>
+          ) : (
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+              <circle cx="8" cy="5.5" r="3" stroke="currentColor" strokeWidth="1.3" />
+              <path d="M4 14c0-2.2 1.8-4 4-4s4 1.8 4 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+              <circle cx="6.5" cy="5" r="0.8" fill="currentColor" />
+              <circle cx="9.5" cy="5" r="0.8" fill="currentColor" />
             </svg>
           )}
         </span>
@@ -176,8 +184,10 @@ export const CanvasNodeView = ({
           <FileNodeBody node={node} onUpdate={onUpdate} workspaceId={workspaceId} />
         ) : node.type === "terminal" ? (
           <TerminalNodeBody node={node} allNodes={allNodes} rootFolder={rootFolder} workspaceId={workspaceId} workspaceName={workspaceName} onUpdate={onUpdate} />
-        ) : (
+        ) : node.type === "frame" ? (
           <FrameNodeBody node={node} onUpdate={onUpdate} />
+        ) : (
+          <AgentNodeBody node={node} allNodes={allNodes} rootFolder={rootFolder} workspaceId={workspaceId} workspaceName={workspaceName} onUpdate={onUpdate} />
         )}
       </div>
 

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
@@ -3,7 +3,7 @@ import './index.css';
 interface Props {
   activeTool: string;
   onToolChange: (tool: string) => void;
-  onAddNode: (type: "file" | "terminal" | "frame") => void;
+  onAddNode: (type: "file" | "terminal" | "frame" | "agent") => void;
 }
 
 const tools = [
@@ -111,6 +111,22 @@ export const FloatingToolbar = ({
             />
           </svg>
           <span className="toolbar-btn-label">Frame</span>
+        </button>
+        <button
+          className="toolbar-btn toolbar-btn--create"
+          onClick={() => onAddNode("agent")}
+          title="Add Agent Card"
+        >
+          <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+            <circle cx="9" cy="6.5" r="3.5" stroke="currentColor" strokeWidth="1.3" />
+            <path
+              d="M4.5 16c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5"
+              stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"
+            />
+            <circle cx="7.5" cy="6" r="0.7" fill="currentColor" />
+            <circle cx="10.5" cy="6" r="0.7" fill="currentColor" />
+          </svg>
+          <span className="toolbar-btn-label">Agent</span>
         </button>
       </div>
     </div>

--- a/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from "react";
 interface Props {
   x: number;
   y: number;
-  onCreate: (type: "file" | "terminal" | "frame") => void;
+  onCreate: (type: "file" | "terminal" | "frame" | "agent") => void;
   onClose: () => void;
 }
 
@@ -70,6 +70,16 @@ export const NodeContextMenu = ({ x, y, onCreate, onClose }: Props) => {
         <span className="context-menu-label">
           <strong>Frame</strong>
           <small>Visual container group</small>
+        </span>
+      </button>
+      <button
+        className="context-menu-item"
+        onClick={() => onCreate("agent")}
+      >
+        <span className="context-menu-icon">{"\u2726"}</span>
+        <span className="context-menu-label">
+          <strong>Agent</strong>
+          <small>Launch a coding agent</small>
         </span>
       </button>
     </div>

--- a/apps/canvas-workspace/src/renderer/src/config/agentRegistry.ts
+++ b/apps/canvas-workspace/src/renderer/src/config/agentRegistry.ts
@@ -2,13 +2,14 @@ export interface AgentDef {
   id: string;
   label: string;
   command: string;
+  icon: string;
   description: string;
 }
 
 export const AGENT_REGISTRY: AgentDef[] = [
-  { id: 'claude-code', label: 'Claude Code', command: 'claude', description: 'Anthropic Claude Code agent' },
-  { id: 'codex', label: 'Codex', command: 'codex', description: 'OpenAI Codex CLI agent' },
-  { id: 'pulse-coder', label: 'Pulse Coder', command: 'pulse-coder', description: 'Pulse Coder agent' },
+  { id: 'claude-code', label: 'Claude Code', command: 'claude', icon: '\u{1F916}', description: 'Anthropic Claude Code agent' },
+  { id: 'codex', label: 'Codex', command: 'codex', icon: '\u{1F9E0}', description: 'OpenAI Codex CLI agent' },
+  { id: 'pulse-coder', label: 'Pulse Coder', command: 'pulse-coder', icon: '\u26A1', description: 'Pulse Coder agent' },
 ];
 
 export const getAgentCommand = (agentType: string): string | undefined =>

--- a/apps/canvas-workspace/src/renderer/src/config/agentRegistry.ts
+++ b/apps/canvas-workspace/src/renderer/src/config/agentRegistry.ts
@@ -2,14 +2,13 @@ export interface AgentDef {
   id: string;
   label: string;
   command: string;
-  icon: string;
   description: string;
 }
 
 export const AGENT_REGISTRY: AgentDef[] = [
-  { id: 'claude-code', label: 'Claude Code', command: 'claude', icon: '\u{1F916}', description: 'Anthropic Claude Code agent' },
-  { id: 'codex', label: 'Codex', command: 'codex', icon: '\u{1F9E0}', description: 'OpenAI Codex CLI agent' },
-  { id: 'pulse-coder', label: 'Pulse Coder', command: 'pulse-coder', icon: '\u26A1', description: 'Pulse Coder agent' },
+  { id: 'claude-code', label: 'Claude Code', command: 'claude', description: 'Anthropic' },
+  { id: 'codex', label: 'Codex', command: 'codex', description: 'OpenAI' },
+  { id: 'pulse-coder', label: 'Pulse Coder', command: 'pulse-coder', description: 'Pulse' },
 ];
 
 export const getAgentCommand = (agentType: string): string | undefined =>

--- a/apps/canvas-workspace/src/renderer/src/config/agentRegistry.ts
+++ b/apps/canvas-workspace/src/renderer/src/config/agentRegistry.ts
@@ -1,0 +1,15 @@
+export interface AgentDef {
+  id: string;
+  label: string;
+  command: string;
+  description: string;
+}
+
+export const AGENT_REGISTRY: AgentDef[] = [
+  { id: 'claude-code', label: 'Claude Code', command: 'claude', description: 'Anthropic Claude Code agent' },
+  { id: 'codex', label: 'Codex', command: 'codex', description: 'OpenAI Codex CLI agent' },
+  { id: 'pulse-coder', label: 'Pulse Coder', command: 'pulse-coder', description: 'Pulse Coder agent' },
+];
+
+export const getAgentCommand = (agentType: string): string | undefined =>
+  AGENT_REGISTRY.find(a => a.id === agentType)?.command;

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -1,12 +1,12 @@
 export interface CanvasNode {
   id: string;
-  type: "file" | "terminal" | "frame";
+  type: "file" | "terminal" | "frame" | "agent";
   title: string;
   x: number;
   y: number;
   width: number;
   height: number;
-  data: FileNodeData | TerminalNodeData | FrameNodeData;
+  data: FileNodeData | TerminalNodeData | FrameNodeData | AgentNodeData;
   /** Epoch millis of last mutation; used for cross-process merge. */
   updatedAt?: number;
 }
@@ -27,6 +27,15 @@ export interface TerminalNodeData {
 export interface FrameNodeData {
   color: string;
   label?: string;
+}
+
+export interface AgentNodeData {
+  sessionId: string;
+  scrollback?: string;
+  cwd?: string;
+  agentType: string;
+  status?: 'idle' | 'running' | 'done' | 'error';
+  agentArgs?: string;
 }
 
 export interface CanvasTransform {

--- a/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
@@ -1,4 +1,4 @@
-import type { CanvasNode, FileNodeData, TerminalNodeData, FrameNodeData } from '../types';
+import type { CanvasNode, FileNodeData, TerminalNodeData, FrameNodeData, AgentNodeData } from '../types';
 
 let nodeIdCounter = 0;
 export const genId = (): string => `node-${Date.now()}-${++nodeIdCounter}`;
@@ -7,13 +7,15 @@ const NODE_DEFAULTS: Record<CanvasNode['type'], { title: string; width: number; 
   file:     { title: 'Untitled', width: 420, height: 360 },
   terminal: { title: 'Terminal', width: 480, height: 300 },
   frame:    { title: 'Frame',    width: 600, height: 400 },
+  agent:    { title: 'Agent',    width: 520, height: 380 },
 };
 
-export const createNodeData = (type: CanvasNode['type']): FileNodeData | TerminalNodeData | FrameNodeData => {
+export const createNodeData = (type: CanvasNode['type']): FileNodeData | TerminalNodeData | FrameNodeData | AgentNodeData => {
   switch (type) {
     case 'file':     return { filePath: '', content: '', saved: false, modified: false };
     case 'terminal': return { sessionId: '' };
     case 'frame':    return { color: '#9575d4' };
+    case 'agent':    return { sessionId: '', agentType: 'claude-code', status: 'idle' };
   }
 };
 

--- a/packages/canvas-cli/src/commands/node.ts
+++ b/packages/canvas-cli/src/commands/node.ts
@@ -98,6 +98,9 @@ export function registerNodeCommands(program: Command): void {
         if (d.type === 'frame') {
           return `Frame: ${d.label || '(no label)'}  color: ${d.color ?? ''}`;
         }
+        if (d.type === 'agent') {
+          return `Agent [${d.agentType ?? 'unknown'}] (${d.status ?? 'idle'})\ncwd: ${d.cwd ?? 'unknown'}\n${d.scrollback ?? ''}`;
+        }
         return JSON.stringify(d, null, 2);
       });
     });
@@ -138,7 +141,7 @@ export function registerNodeCommands(program: Command): void {
     });
 
   node.command('create')
-    .requiredOption('--type <type>', 'Node type: file, terminal, frame')
+    .requiredOption('--type <type>', 'Node type: file, terminal, frame, agent')
     .option('--title <title>', 'Node title')
     .option('--x <n>', 'X position on canvas', parseFloat)
     .option('--y <n>', 'Y position on canvas', parseFloat)
@@ -149,7 +152,7 @@ export function registerNodeCommands(program: Command): void {
     .action(async function (this: Command, cmdOpts: { type: string; title?: string; x?: number; y?: number; width?: number; height?: number; data?: string }) {
       const { format, storeDir, workspace } = getOpts(this);
 
-      const validTypes: NodeType[] = ['file', 'terminal', 'frame'];
+      const validTypes: NodeType[] = ['file', 'terminal', 'frame', 'agent'];
       if (!validTypes.includes(cmdOpts.type as NodeType)) {
         errorOutput(`Invalid type "${cmdOpts.type}". Must be: ${validTypes.join(', ')}`);
       }
@@ -177,6 +180,9 @@ export function registerNodeCommands(program: Command): void {
 
       if (cmdOpts.type === 'terminal') {
         console.error('Note: Terminal nodes created via CLI have no active PTY session.');
+      }
+      if (cmdOpts.type === 'agent') {
+        console.error('Note: Agent nodes created via CLI have no active PTY session.');
       }
 
       output(result.data, format, (d) => {

--- a/packages/canvas-cli/src/core/constants.ts
+++ b/packages/canvas-cli/src/core/constants.ts
@@ -8,12 +8,14 @@ export const NODE_CAPABILITIES: Record<NodeType, NodeCapability[]> = {
   file: ['read', 'write'],
   terminal: ['read', 'exec'],
   frame: ['read', 'write'],
+  agent: ['read', 'exec'],
 };
 
 export const DEFAULT_NODE_DIMENSIONS: Record<NodeType, { title: string; width: number; height: number }> = {
   file: { title: 'Untitled', width: 420, height: 360 },
   terminal: { title: 'Terminal', width: 480, height: 300 },
   frame: { title: 'Frame', width: 600, height: 400 },
+  agent: { title: 'Agent', width: 520, height: 380 },
 };
 
 export const AGENTS_MD_TEMPLATE = `# Canvas Agent Config

--- a/packages/canvas-cli/src/core/nodes.ts
+++ b/packages/canvas-cli/src/core/nodes.ts
@@ -46,6 +46,15 @@ export async function readNode(node: CanvasNode): Promise<NodeReadResult> {
         label: node.data.label ?? '',
         color: node.data.color ?? '',
       };
+    case 'agent':
+      return {
+        type: 'agent',
+        capabilities,
+        cwd: node.data.cwd ?? '',
+        scrollback: node.data.scrollback ?? '',
+        agentType: node.data.agentType ?? 'claude-code',
+        status: node.data.status ?? 'idle',
+      };
     default:
       return { type: node.type, capabilities };
   }
@@ -92,6 +101,8 @@ export async function writeNode(
     }
     case 'terminal':
       return { ok: false, error: 'Terminal nodes do not support write. Use canvas_exec to send commands.' };
+    case 'agent':
+      return { ok: false, error: 'Agent nodes do not support write. Use canvas_exec to send commands.' };
     default:
       return { ok: false, error: 'Unknown node type' };
   }
@@ -157,6 +168,9 @@ export async function createNode(
       break;
     case 'frame':
       nodeData = { color: (inputData as Record<string, string>).color ?? '#9575d4', label: (inputData as Record<string, string>).label ?? '' };
+      break;
+    case 'agent':
+      nodeData = { sessionId: '', cwd: (inputData as Record<string, string>).cwd ?? '', agentType: (inputData as Record<string, string>).agentType ?? 'claude-code', status: 'idle' };
       break;
   }
 

--- a/packages/canvas-cli/src/core/types.ts
+++ b/packages/canvas-cli/src/core/types.ts
@@ -1,4 +1,4 @@
-export type NodeType = 'file' | 'terminal' | 'frame';
+export type NodeType = 'file' | 'terminal' | 'frame' | 'agent';
 export type NodeCapability = 'read' | 'write' | 'exec';
 
 export interface CanvasNodeData {


### PR DESCRIPTION
## Summary
This PR introduces a new "Agent" node type to the canvas workspace, enabling users to launch and interact with coding agents (Claude Code, Codex, Pulse Coder, etc.) directly within the canvas interface.

## Key Changes

- **New Agent Node Component** (`AgentNodeBody`): A full-featured terminal-based UI for spawning and managing agent sessions
  - Displays an agent picker with descriptions before launch
  - Renders an xterm terminal for interactive agent interaction
  - Supports session persistence with scrollback history (up to 50KB)
  - Auto-restores previous sessions and tracks working directory changes
  - Provides restart functionality when agent exits

- **Agent Registry** (`agentRegistry.ts`): Centralized configuration for available agents
  - Defines agent metadata (id, label, command, description)
  - Currently supports Claude Code, Codex, and Pulse Coder

- **Type System Updates**:
  - Added `AgentNodeData` interface with fields for sessionId, scrollback, cwd, agentType, status, and agentArgs
  - Updated `CanvasNode` type to include "agent" as valid node type
  - Added agent capabilities ('read', 'exec') to node capability system

- **UI Integration**:
  - Added "Agent" button to FloatingToolbar with custom icon
  - Added "Agent" option to NodeContextMenu
  - Added agent node type badge styling (purple #7c5cff)
  - Updated CanvasNodeView to render AgentNodeBody component

- **CLI Support** (`canvas-cli`):
  - Added agent node creation via `node create --type agent`
  - Added agent node reading with status and scrollback display
  - Prevents direct write operations on agent nodes (use exec instead)

## Implementation Details

- Uses xterm.js with FitAddon for terminal rendering and auto-fitting
- Integrates with existing PTY API for shell spawning and communication
- Periodically saves terminal scrollback (every 2 seconds) to preserve session state
- Handles cleanup and session termination on component unmount
- Supports custom working directory and agent arguments
- Restores last 10 lines of previous session history when resuming

https://claude.ai/code/session_012kuhtq7XBDXNjT9pTi1BQ2