### PR TITLE
Add Canvas Agent — workspace-scoped AI Copilot with agentic tools

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -97,10 +97,12 @@
     "node-pty": "^1.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "tiptap-markdown": "^0.9.0"
+    "tiptap-markdown": "^0.9.0",
+    "markdown-it": "^14.1.0"
   },
   "devDependencies": {
     "@electron/rebuild": "^4.0.3",
+    "@types/markdown-it": "^14.1.0",
     "@types/node": "^20.14.9",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -81,6 +81,9 @@
     }
   },
   "dependencies": {
+    "@ai-sdk/openai": "^3.0.21",
+    "ai": "^6.0.57",
+    "zod": "^4.0.0",
     "@tiptap/extension-bubble-menu": "^3.20.4",
     "@tiptap/extension-image": "^3.20.5",
     "@tiptap/extension-placeholder": "^3.20.4",

--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -82,6 +82,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.21",
+    "pulse-coder-engine": "workspace:*",
     "ai": "^6.0.57",
     "zod": "^4.0.0",
     "@tiptap/extension-bubble-menu": "^3.20.4",

--- a/apps/canvas-workspace/src/main/canvas-agent-ipc.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent-ipc.ts
@@ -2,14 +2,20 @@
  * IPC handlers for the Canvas Agent.
  *
  * Channels:
- *   canvas-agent:chat     — send a message, get a response
+ *   canvas-agent:chat     — send a message, stream text deltas, get final response
  *   canvas-agent:status   — check if agent is active
  *   canvas-agent:history  — get current session messages
  *   canvas-agent:activate — explicitly start the agent
  *   canvas-agent:deactivate — stop the agent and archive session
+ *
+ * Streaming:
+ *   canvas-agent:chat returns { ok, sessionId } immediately.
+ *   Text deltas arrive on  `canvas-agent:text-delta:{sessionId}`.
+ *   Completion arrives on   `canvas-agent:chat-complete:{sessionId}`.
  */
 
 import { ipcMain } from 'electron';
+import { randomUUID } from 'crypto';
 import { CanvasAgentService } from './canvas-agent/service';
 
 let service: CanvasAgentService | null = null;
@@ -26,8 +32,33 @@ export function setupCanvasAgentIpc(): void {
 
   ipcMain.handle(
     'canvas-agent:chat',
-    async (_event, payload: { workspaceId: string; message: string }) => {
-      return await svc.chat(payload.workspaceId, payload.message);
+    async (event, payload: { workspaceId: string; message: string }) => {
+      const sessionId = randomUUID();
+      const sender = event.sender;
+
+      // Fire-and-forget: run the agent asynchronously, streaming text deltas
+      void (async () => {
+        try {
+          const result = await svc.chat(payload.workspaceId, payload.message, (delta) => {
+            if (!sender.isDestroyed()) {
+              sender.send(`canvas-agent:text-delta:${sessionId}`, delta);
+            }
+          });
+          if (!sender.isDestroyed()) {
+            sender.send(`canvas-agent:chat-complete:${sessionId}`, result);
+          }
+        } catch (err) {
+          if (!sender.isDestroyed()) {
+            sender.send(`canvas-agent:chat-complete:${sessionId}`, {
+              ok: false,
+              error: String(err),
+            });
+          }
+        }
+      })();
+
+      // Return immediately with the sessionId for the renderer to subscribe
+      return { ok: true, sessionId };
     },
   );
 

--- a/apps/canvas-workspace/src/main/canvas-agent-ipc.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent-ipc.ts
@@ -1,0 +1,78 @@
+/**
+ * IPC handlers for the Canvas Agent.
+ *
+ * Channels:
+ *   canvas-agent:chat     — send a message, get a response
+ *   canvas-agent:status   — check if agent is active
+ *   canvas-agent:history  — get current session messages
+ *   canvas-agent:activate — explicitly start the agent
+ *   canvas-agent:deactivate — stop the agent and archive session
+ */
+
+import { ipcMain } from 'electron';
+import { CanvasAgentService } from './canvas-agent/service';
+
+let service: CanvasAgentService | null = null;
+
+function getService(): CanvasAgentService {
+  if (!service) {
+    service = new CanvasAgentService();
+  }
+  return service;
+}
+
+export function setupCanvasAgentIpc(): void {
+  const svc = getService();
+
+  ipcMain.handle(
+    'canvas-agent:chat',
+    async (_event, payload: { workspaceId: string; message: string }) => {
+      return await svc.chat(payload.workspaceId, payload.message);
+    },
+  );
+
+  ipcMain.handle(
+    'canvas-agent:status',
+    (_event, payload: { workspaceId: string }) => {
+      return svc.getStatus(payload.workspaceId);
+    },
+  );
+
+  ipcMain.handle(
+    'canvas-agent:history',
+    (_event, payload: { workspaceId: string }) => {
+      return { ok: true, messages: svc.getHistory(payload.workspaceId) };
+    },
+  );
+
+  ipcMain.handle(
+    'canvas-agent:activate',
+    async (_event, payload: { workspaceId: string }) => {
+      try {
+        await svc.activate(payload.workspaceId);
+        return { ok: true };
+      } catch (err) {
+        return { ok: false, error: String(err) };
+      }
+    },
+  );
+
+  ipcMain.handle(
+    'canvas-agent:deactivate',
+    async (_event, payload: { workspaceId: string }) => {
+      try {
+        await svc.deactivate(payload.workspaceId);
+        return { ok: true };
+      } catch (err) {
+        return { ok: false, error: String(err) };
+      }
+    },
+  );
+}
+
+export function teardownCanvasAgent(): void {
+  if (service) {
+    void service.deactivateAll();
+    service = null;
+  }
+}

--- a/apps/canvas-workspace/src/main/canvas-agent-ipc.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent-ipc.ts
@@ -2,11 +2,14 @@
  * IPC handlers for the Canvas Agent.
  *
  * Channels:
- *   canvas-agent:chat     — send a message, stream text deltas, get final response
- *   canvas-agent:status   — check if agent is active
- *   canvas-agent:history  — get current session messages
- *   canvas-agent:activate — explicitly start the agent
- *   canvas-agent:deactivate — stop the agent and archive session
+ *   canvas-agent:chat         — send a message, stream text deltas, get final response
+ *   canvas-agent:status       — check if agent is active
+ *   canvas-agent:history      — get current session messages
+ *   canvas-agent:sessions     — list all sessions (current + archived)
+ *   canvas-agent:new-session  — start a new session
+ *   canvas-agent:load-session — load an archived session
+ *   canvas-agent:activate     — explicitly start the agent
+ *   canvas-agent:deactivate   — stop the agent and archive session
  *
  * Streaming:
  *   canvas-agent:chat returns { ok, sessionId } immediately.
@@ -73,6 +76,40 @@ export function setupCanvasAgentIpc(): void {
     'canvas-agent:history',
     (_event, payload: { workspaceId: string }) => {
       return { ok: true, messages: svc.getHistory(payload.workspaceId) };
+    },
+  );
+
+  ipcMain.handle(
+    'canvas-agent:sessions',
+    async (_event, payload: { workspaceId: string }) => {
+      try {
+        const sessions = await svc.listSessions(payload.workspaceId);
+        return { ok: true, sessions };
+      } catch (err) {
+        return { ok: false, error: String(err) };
+      }
+    },
+  );
+
+  ipcMain.handle(
+    'canvas-agent:new-session',
+    async (_event, payload: { workspaceId: string }) => {
+      try {
+        return await svc.newSession(payload.workspaceId);
+      } catch (err) {
+        return { ok: false, error: String(err) };
+      }
+    },
+  );
+
+  ipcMain.handle(
+    'canvas-agent:load-session',
+    async (_event, payload: { workspaceId: string; sessionId: string }) => {
+      try {
+        return await svc.loadSession(payload.workspaceId, payload.sessionId);
+      } catch (err) {
+        return { ok: false, error: String(err) };
+      }
     },
   );
 

--- a/apps/canvas-workspace/src/main/canvas-agent-ipc.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent-ipc.ts
@@ -13,8 +13,10 @@
  *
  * Streaming:
  *   canvas-agent:chat returns { ok, sessionId } immediately.
- *   Text deltas arrive on  `canvas-agent:text-delta:{sessionId}`.
- *   Completion arrives on   `canvas-agent:chat-complete:{sessionId}`.
+ *   Text deltas arrive on    `canvas-agent:text-delta:{sessionId}`.
+ *   Tool call starts arrive on `canvas-agent:tool-call:{sessionId}`.
+ *   Tool results arrive on    `canvas-agent:tool-result:{sessionId}`.
+ *   Completion arrives on     `canvas-agent:chat-complete:{sessionId}`.
  */
 
 import { ipcMain } from 'electron';
@@ -42,11 +44,25 @@ export function setupCanvasAgentIpc(): void {
       // Fire-and-forget: run the agent asynchronously, streaming text deltas
       void (async () => {
         try {
-          const result = await svc.chat(payload.workspaceId, payload.message, (delta) => {
-            if (!sender.isDestroyed()) {
-              sender.send(`canvas-agent:text-delta:${sessionId}`, delta);
-            }
-          });
+          const result = await svc.chat(
+            payload.workspaceId,
+            payload.message,
+            (delta) => {
+              if (!sender.isDestroyed()) {
+                sender.send(`canvas-agent:text-delta:${sessionId}`, delta);
+              }
+            },
+            (toolCall) => {
+              if (!sender.isDestroyed()) {
+                sender.send(`canvas-agent:tool-call:${sessionId}`, toolCall);
+              }
+            },
+            (toolResult) => {
+              if (!sender.isDestroyed()) {
+                sender.send(`canvas-agent:tool-result:${sessionId}`, toolResult);
+              }
+            },
+          );
           if (!sender.isDestroyed()) {
             sender.send(`canvas-agent:chat-complete:${sessionId}`, result);
           }

--- a/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
@@ -103,8 +103,9 @@ export class CanvasAgent {
 
   /**
    * Send a user message and get the agent's response.
+   * @param onText — optional callback receiving streaming text deltas
    */
-  async chat(message: string): Promise<string> {
+  async chat(message: string, onText?: (delta: string) => void): Promise<string> {
     // Refresh workspace summary for system prompt
     const summary = await buildWorkspaceSummary(this.config.workspaceId);
     const systemPrompt = buildSystemPrompt(summary);
@@ -119,6 +120,7 @@ export class CanvasAgent {
     const resultText = await this.engine.run(context, {
       systemPrompt,
       maxSteps: 10,
+      onText,
       onResponse: (msgs: ModelMessage[]) => {
         for (const msg of msgs) {
           this.messages.push(msg);

--- a/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
@@ -1,13 +1,14 @@
 /**
  * Canvas Agent — the workspace-scoped AI Copilot.
  *
- * Uses the Vercel AI SDK directly (not the engine) to run an agentic loop
- * with canvas-specific tools. Runs in the Electron main process.
+ * Uses pulse-coder-engine's Engine class to run an agentic loop with
+ * canvas-specific tools + built-in filesystem tools (read, write, edit,
+ * grep, ls, bash). Runs in the Electron main process.
  */
 
-import { generateText, tool, stepCountIs, type ModelMessage, type Tool as AITool, type ToolSet } from 'ai';
+import { Engine } from 'pulse-coder-engine';
 import { createOpenAI } from '@ai-sdk/openai';
-import { z } from 'zod';
+import type { ModelMessage } from 'ai';
 import { buildWorkspaceSummary, formatSummaryForPrompt } from './context-builder';
 import { createCanvasTools } from './tools';
 import { SessionStore } from './session-store';
@@ -21,7 +22,8 @@ const BASE_SYSTEM_PROMPT = `You are the Canvas Agent — the AI Copilot for this
 You are the single AI entry point for this workspace. You can:
 - Understand and explain everything on the canvas (files, terminals, agents, frames)
 - Create, update, delete, and organize canvas nodes
-- Read and write files directly
+- Read and write project files directly
+- Run shell commands
 - Generate documents, PRDs, and technical specs
 
 ## Context Strategy
@@ -37,11 +39,22 @@ Your system prompt contains a summary of all canvas nodes. For detailed content:
 - \`canvas_delete_node\`: Remove a node from the canvas
 - \`canvas_move_node\`: Reposition a node
 
+## Filesystem Tools (built-in)
+- \`read\`: Read file contents (with offset/limit support)
+- \`write\`: Write or create files
+- \`edit\`: Edit files with find & replace
+- \`grep\`: Search file contents by regex
+- \`ls\`: List directory contents
+- \`bash\`: Execute shell commands
+
+Use these alongside canvas_* tools for full workspace control.
+
 ## Guidelines
 - Be concise and direct
 - When creating file nodes, give them meaningful titles
 - When the user references a node by title, look it up in the summary below
 - For canvas-related tasks, use the canvas_* tools
+- For code-related tasks, use the filesystem tools (read, write, edit, grep, bash)
 
 `;
 
@@ -52,42 +65,35 @@ function buildSystemPrompt(summary: WorkspaceSummary | null): string {
   return BASE_SYSTEM_PROMPT + '\n## Current Canvas\n' + formatSummaryForPrompt(summary);
 }
 
-// ─── AI SDK tool adapter ───────────────────────────────────────────
-
-function buildAITools(workspaceId: string): ToolSet {
-  const rawTools = createCanvasTools(workspaceId);
-  const aiTools: ToolSet = {};
-
-  for (const [name, def] of Object.entries(rawTools)) {
-    aiTools[name] = tool({
-      description: def.description,
-      inputSchema: z.object({}).passthrough(),
-      execute: async (input: Record<string, unknown>) => {
-        return await def.execute(input);
-      },
-    });
-  }
-
-  return aiTools;
-}
-
 // ─── Canvas Agent ──────────────────────────────────────────────────
 
 export class CanvasAgent {
+  private engine: any; // Engine type from pulse-coder-engine (no .d.ts yet)
   private messages: ModelMessage[] = [];
   private sessionStore: SessionStore;
   private config: CanvasAgentConfig;
-  private aiTools: ToolSet = {};
 
   constructor(config: CanvasAgentConfig) {
     this.config = config;
     this.sessionStore = new SessionStore(config.workspaceId);
+
+    const canvasTools = createCanvasTools(config.workspaceId);
+
+    this.engine = new Engine({
+      disableBuiltInPlugins: true,
+      llmProvider: createOpenAI({
+        apiKey: process.env.OPENAI_API_KEY,
+        baseURL: process.env.OPENAI_API_URL,
+      }),
+      model: config.model ?? process.env.OPENAI_MODEL ?? 'gpt-4o',
+      tools: canvasTools,
+    });
   }
 
   async initialize(): Promise<void> {
     console.info(`[canvas-agent] Initializing for workspace: ${this.config.workspaceId}`);
 
-    this.aiTools = buildAITools(this.config.workspaceId);
+    await this.engine.initialize();
 
     // Start a new session
     await this.sessionStore.startSession();
@@ -104,31 +110,29 @@ export class CanvasAgent {
     const systemPrompt = buildSystemPrompt(summary);
 
     // Add user message
-    this.messages.push({ role: 'user', content: [{ type: 'text', text: message }] });
+    this.messages.push({ role: 'user', content: message } as ModelMessage);
     this.sessionStore.addMessage({ role: 'user', content: message, timestamp: Date.now() });
 
-    // Build the provider from env vars
-    const provider = createOpenAI({
-      apiKey: process.env.OPENAI_API_KEY,
-      baseURL: process.env.OPENAI_API_URL,
+    // Build the context — pass a mutable reference so onResponse/onCompacted can update it
+    const context = { messages: this.messages };
+
+    const resultText = await this.engine.run(context, {
+      systemPrompt,
+      maxSteps: 10,
+      onResponse: (msgs: ModelMessage[]) => {
+        for (const msg of msgs) {
+          this.messages.push(msg);
+        }
+      },
+      onCompacted: (newMessages: ModelMessage[]) => {
+        this.messages = newMessages;
+        context.messages = newMessages;
+      },
     });
 
-    const model = this.config.model
-      ?? process.env.OPENAI_MODEL
-      ?? 'gpt-4o';
+    const responseText = resultText || '(no response)';
 
-    const result = await generateText({
-      model: provider(model),
-      system: systemPrompt,
-      messages: this.messages,
-      tools: this.aiTools,
-      stopWhen: stepCountIs(10),
-    });
-
-    const responseText = result.text || '(no response)';
-
-    // Add assistant response
-    this.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
+    // Persist assistant response
     this.sessionStore.addMessage({ role: 'assistant', content: responseText, timestamp: Date.now() });
 
     return responseText;

--- a/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
@@ -130,17 +130,20 @@ export class CanvasAgent {
       onText,
       onToolCall: onToolCall
         ? (chunk: any) => {
-            // AI SDK v6 uses `input` not `args`
-            onToolCall({ name: chunk.toolName, args: chunk.input ?? chunk.args });
+            // AI SDK v6 uses `input`; older versions use `args`
+            const args = chunk.input ?? chunk.args;
+            console.info('[canvas-agent] tool-call chunk keys:', Object.keys(chunk), 'input:', chunk.input, 'args:', chunk.args);
+            onToolCall({ name: chunk.toolName, args });
           }
         : undefined,
       onToolResult: onToolResult
         ? (chunk: any) => {
-            // AI SDK v6 uses `output` not `result`
-            const result = chunk.output ?? chunk.result;
+            // AI SDK v6 uses `output`; older versions use `result`
+            const raw = chunk.output ?? chunk.result;
+            console.info('[canvas-agent] tool-result chunk keys:', Object.keys(chunk), 'output:', typeof chunk.output, 'result:', typeof chunk.result);
             onToolResult({
               name: chunk.toolName,
-              result: typeof result === 'string' ? result : JSON.stringify(result),
+              result: typeof raw === 'string' ? raw : JSON.stringify(raw),
             });
           }
         : undefined,

--- a/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
@@ -1,0 +1,159 @@
+/**
+ * Canvas Agent — the workspace-scoped AI Copilot.
+ *
+ * Uses the Vercel AI SDK directly (not the engine) to run an agentic loop
+ * with canvas-specific tools. Runs in the Electron main process.
+ */
+
+import { generateText, tool, stepCountIs, type ModelMessage, type Tool as AITool, type ToolSet } from 'ai';
+import { createOpenAI } from '@ai-sdk/openai';
+import { z } from 'zod';
+import { buildWorkspaceSummary, formatSummaryForPrompt } from './context-builder';
+import { createCanvasTools } from './tools';
+import { SessionStore } from './session-store';
+import type { CanvasAgentConfig, CanvasAgentMessage, WorkspaceSummary } from './types';
+
+// ─── System prompt ─────────────────────────────────────────────────
+
+const BASE_SYSTEM_PROMPT = `You are the Canvas Agent — the AI Copilot for this workspace.
+
+## Your Role
+You are the single AI entry point for this workspace. You can:
+- Understand and explain everything on the canvas (files, terminals, agents, frames)
+- Create, update, delete, and organize canvas nodes
+- Read and write files directly
+- Generate documents, PRDs, and technical specs
+
+## Context Strategy
+Your system prompt contains a summary of all canvas nodes. For detailed content:
+- Use \`canvas_read_node\` to read a specific node's full content
+- Use \`canvas_read_context\` with detail="full" for everything at once
+
+## Canvas Tools
+- \`canvas_read_context\`: Read workspace overview or full context
+- \`canvas_read_node\`: Read a single node's content in detail
+- \`canvas_create_node\`: Create new file/terminal/frame/agent nodes
+- \`canvas_update_node\`: Update existing nodes (content, title, data)
+- \`canvas_delete_node\`: Remove a node from the canvas
+- \`canvas_move_node\`: Reposition a node
+
+## Guidelines
+- Be concise and direct
+- When creating file nodes, give them meaningful titles
+- When the user references a node by title, look it up in the summary below
+- For canvas-related tasks, use the canvas_* tools
+
+`;
+
+function buildSystemPrompt(summary: WorkspaceSummary | null): string {
+  if (!summary) {
+    return BASE_SYSTEM_PROMPT + '\n## Current Canvas\n(empty workspace — no nodes yet)\n';
+  }
+  return BASE_SYSTEM_PROMPT + '\n## Current Canvas\n' + formatSummaryForPrompt(summary);
+}
+
+// ─── AI SDK tool adapter ───────────────────────────────────────────
+
+function buildAITools(workspaceId: string): ToolSet {
+  const rawTools = createCanvasTools(workspaceId);
+  const aiTools: ToolSet = {};
+
+  for (const [name, def] of Object.entries(rawTools)) {
+    aiTools[name] = tool({
+      description: def.description,
+      inputSchema: z.object({}).passthrough(),
+      execute: async (input: Record<string, unknown>) => {
+        return await def.execute(input);
+      },
+    });
+  }
+
+  return aiTools;
+}
+
+// ─── Canvas Agent ──────────────────────────────────────────────────
+
+export class CanvasAgent {
+  private messages: ModelMessage[] = [];
+  private sessionStore: SessionStore;
+  private config: CanvasAgentConfig;
+  private aiTools: ToolSet = {};
+
+  constructor(config: CanvasAgentConfig) {
+    this.config = config;
+    this.sessionStore = new SessionStore(config.workspaceId);
+  }
+
+  async initialize(): Promise<void> {
+    console.info(`[canvas-agent] Initializing for workspace: ${this.config.workspaceId}`);
+
+    this.aiTools = buildAITools(this.config.workspaceId);
+
+    // Start a new session
+    await this.sessionStore.startSession();
+
+    console.info('[canvas-agent] Initialized');
+  }
+
+  /**
+   * Send a user message and get the agent's response.
+   */
+  async chat(message: string): Promise<string> {
+    // Refresh workspace summary for system prompt
+    const summary = await buildWorkspaceSummary(this.config.workspaceId);
+    const systemPrompt = buildSystemPrompt(summary);
+
+    // Add user message
+    this.messages.push({ role: 'user', content: [{ type: 'text', text: message }] });
+    this.sessionStore.addMessage({ role: 'user', content: message, timestamp: Date.now() });
+
+    // Build the provider from env vars
+    const provider = createOpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+      baseURL: process.env.OPENAI_API_URL,
+    });
+
+    const model = this.config.model
+      ?? process.env.OPENAI_MODEL
+      ?? 'gpt-4o';
+
+    const result = await generateText({
+      model: provider(model),
+      system: systemPrompt,
+      messages: this.messages,
+      tools: this.aiTools,
+      stopWhen: stepCountIs(10),
+    });
+
+    const responseText = result.text || '(no response)';
+
+    // Add assistant response
+    this.messages.push({ role: 'assistant', content: [{ type: 'text', text: responseText }] });
+    this.sessionStore.addMessage({ role: 'assistant', content: responseText, timestamp: Date.now() });
+
+    return responseText;
+  }
+
+  /**
+   * Get conversation history for the current session.
+   */
+  getHistory(): CanvasAgentMessage[] {
+    return this.sessionStore.getMessages();
+  }
+
+  /**
+   * Get the message count for the current session.
+   */
+  getMessageCount(): number {
+    return this.sessionStore.getMessages().length;
+  }
+
+  /**
+   * Destroy the agent (called when workspace is closed).
+   */
+  async destroy(): Promise<void> {
+    console.info(`[canvas-agent] Destroying for workspace: ${this.config.workspaceId}`);
+    await this.sessionStore.archiveSession();
+    this.messages = [];
+  }
+}

--- a/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
@@ -129,11 +129,15 @@ export class CanvasAgent {
       maxSteps: 10,
       onText,
       onToolCall: onToolCall
-        ? (chunk: any) => { onToolCall({ name: chunk.toolName, args: chunk.args }); }
+        ? (chunk: any) => {
+            // AI SDK v6 uses `input` not `args`
+            onToolCall({ name: chunk.toolName, args: chunk.input ?? chunk.args });
+          }
         : undefined,
       onToolResult: onToolResult
         ? (chunk: any) => {
-            const result = chunk.result;
+            // AI SDK v6 uses `output` not `result`
+            const result = chunk.output ?? chunk.result;
             onToolResult({
               name: chunk.toolName,
               result: typeof result === 'string' ? result : JSON.stringify(result),

--- a/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
@@ -148,10 +148,62 @@ export class CanvasAgent {
   }
 
   /**
+   * Get the current session ID.
+   */
+  getCurrentSessionId(): string | null {
+    return this.sessionStore.getCurrentSession()?.sessionId ?? null;
+  }
+
+  /**
    * Get the message count for the current session.
    */
   getMessageCount(): number {
     return this.sessionStore.getMessages().length;
+  }
+
+  /**
+   * List all sessions (current + archived).
+   */
+  async listSessions(): Promise<Array<{ sessionId: string; date: string; messageCount: number; isCurrent: boolean }>> {
+    const archived = await this.sessionStore.listArchivedSessions();
+    const result: Array<{ sessionId: string; date: string; messageCount: number; isCurrent: boolean }> = [];
+
+    // Add current session first if it exists
+    const current = this.sessionStore.getCurrentSession();
+    if (current) {
+      result.push({
+        sessionId: current.sessionId,
+        date: current.startedAt.slice(0, 10),
+        messageCount: current.messages.length,
+        isCurrent: true,
+      });
+    }
+
+    // Add archived sessions
+    for (const s of archived) {
+      result.push({ ...s, isCurrent: false });
+    }
+
+    return result;
+  }
+
+  /**
+   * Start a new session (archives current if any).
+   */
+  async newSession(): Promise<void> {
+    await this.sessionStore.startSession();
+    this.messages = [];
+  }
+
+  /**
+   * Load a specific archived session by sessionId.
+   */
+  async loadSession(sessionId: string): Promise<CanvasAgentMessage[]> {
+    const session = await this.sessionStore.loadSession(sessionId);
+    if (!session) return [];
+    // Rebuild in-memory messages from loaded session
+    this.messages = session.messages.map(m => ({ role: m.role, content: m.content } as any));
+    return session.messages;
   }
 
   /**

--- a/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
@@ -104,8 +104,15 @@ export class CanvasAgent {
   /**
    * Send a user message and get the agent's response.
    * @param onText — optional callback receiving streaming text deltas
+   * @param onToolCall — optional callback when a tool call starts
+   * @param onToolResult — optional callback when a tool call completes
    */
-  async chat(message: string, onText?: (delta: string) => void): Promise<string> {
+  async chat(
+    message: string,
+    onText?: (delta: string) => void,
+    onToolCall?: (data: { name: string; args: any }) => void,
+    onToolResult?: (data: { name: string; result: string }) => void,
+  ): Promise<string> {
     // Refresh workspace summary for system prompt
     const summary = await buildWorkspaceSummary(this.config.workspaceId);
     const systemPrompt = buildSystemPrompt(summary);
@@ -121,6 +128,18 @@ export class CanvasAgent {
       systemPrompt,
       maxSteps: 10,
       onText,
+      onToolCall: onToolCall
+        ? (chunk: any) => { onToolCall({ name: chunk.toolName, args: chunk.args }); }
+        : undefined,
+      onToolResult: onToolResult
+        ? (chunk: any) => {
+            const result = chunk.result;
+            onToolResult({
+              name: chunk.toolName,
+              result: typeof result === 'string' ? result : JSON.stringify(result),
+            });
+          }
+        : undefined,
       onResponse: (msgs: ModelMessage[]) => {
         for (const msg of msgs) {
           this.messages.push(msg);

--- a/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
@@ -190,18 +190,20 @@ export class CanvasAgent {
   /**
    * List all sessions (current + archived).
    */
-  async listSessions(): Promise<Array<{ sessionId: string; date: string; messageCount: number; isCurrent: boolean }>> {
+  async listSessions(): Promise<Array<{ sessionId: string; date: string; messageCount: number; isCurrent: boolean; preview: string }>> {
     const archived = await this.sessionStore.listArchivedSessions();
-    const result: Array<{ sessionId: string; date: string; messageCount: number; isCurrent: boolean }> = [];
+    const result: Array<{ sessionId: string; date: string; messageCount: number; isCurrent: boolean; preview: string }> = [];
 
     // Add current session first if it exists
     const current = this.sessionStore.getCurrentSession();
     if (current) {
+      const firstUserMsg = current.messages.find(m => m.role === 'user');
       result.push({
         sessionId: current.sessionId,
         date: current.startedAt.slice(0, 10),
         messageCount: current.messages.length,
         isCurrent: true,
+        preview: firstUserMsg ? firstUserMsg.content.slice(0, 50) : '',
       });
     }
 

--- a/apps/canvas-workspace/src/main/canvas-agent/context-builder.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/context-builder.ts
@@ -1,0 +1,282 @@
+/**
+ * Context builder for the Canvas Agent.
+ *
+ * Produces a lightweight workspace summary (always injected into system prompt)
+ * and a detailed context (loaded on demand via canvas_read_context tool).
+ */
+
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import type { NodeSummary, WorkspaceSummary } from './types';
+
+const STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
+
+interface CanvasNode {
+  id: string;
+  type: string;
+  title: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  data: Record<string, unknown>;
+  updatedAt?: number;
+}
+
+interface CanvasSaveData {
+  nodes: CanvasNode[];
+  transform: { x: number; y: number; scale: number };
+  savedAt: string;
+}
+
+interface WorkspaceManifest {
+  workspaces: Array<{ id: string; name: string }>;
+  activeId?: string;
+}
+
+// ─── Low-level readers ─────────────────────────────────────────────
+
+async function loadCanvasJson(workspaceId: string): Promise<CanvasSaveData | null> {
+  try {
+    const raw = await fs.readFile(join(STORE_DIR, workspaceId, 'canvas.json'), 'utf-8');
+    return JSON.parse(raw) as CanvasSaveData;
+  } catch {
+    return null;
+  }
+}
+
+async function loadManifest(): Promise<WorkspaceManifest> {
+  try {
+    const raw = await fs.readFile(join(STORE_DIR, '__workspaces__.json'), 'utf-8');
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const workspaces = (parsed.workspaces ?? parsed.entries ?? []) as WorkspaceManifest['workspaces'];
+    return { workspaces, activeId: parsed.activeId as string | undefined };
+  } catch {
+    return { workspaces: [] };
+  }
+}
+
+// ─── Summary builder ───────────────────────────────────────────────
+
+function summarizeNode(node: CanvasNode): NodeSummary {
+  const summary: NodeSummary = {
+    id: node.id,
+    type: node.type,
+    title: node.title,
+  };
+
+  switch (node.type) {
+    case 'file':
+      summary.path = (node.data.filePath as string) || undefined;
+      break;
+    case 'terminal':
+      summary.path = (node.data.cwd as string) || undefined;
+      break;
+    case 'agent':
+      summary.path = (node.data.cwd as string) || undefined;
+      summary.agentType = (node.data.agentType as string) || 'claude-code';
+      summary.status = (node.data.status as string) || 'idle';
+      break;
+    case 'frame':
+      summary.color = (node.data.color as string) || undefined;
+      summary.label = (node.data.label as string) || undefined;
+      break;
+  }
+
+  return summary;
+}
+
+/**
+ * Build a lightweight workspace summary. This is cheap and always injected
+ * into the Canvas Agent's system prompt so it "knows what's on the canvas".
+ */
+export async function buildWorkspaceSummary(workspaceId: string): Promise<WorkspaceSummary | null> {
+  const canvas = await loadCanvasJson(workspaceId);
+  if (!canvas) return null;
+
+  const manifest = await loadManifest();
+  const entry = manifest.workspaces.find(e => e.id === workspaceId);
+  const workspaceName = entry?.name ?? workspaceId;
+  const canvasDir = join(STORE_DIR, workspaceId);
+
+  return {
+    workspaceId,
+    workspaceName,
+    canvasDir,
+    nodeCount: canvas.nodes.length,
+    nodes: canvas.nodes.map(summarizeNode),
+  };
+}
+
+// ─── Detailed context (on-demand) ──────────────────────────────────
+
+interface DetailedNodeContext extends NodeSummary {
+  content?: string;
+  scrollback?: string;
+  cwd?: string;
+}
+
+interface DetailedWorkspaceContext {
+  workspaceId: string;
+  workspaceName: string;
+  canvasDir: string;
+  nodes: DetailedNodeContext[];
+  agentsMd?: string;
+}
+
+/**
+ * Build a full detailed context including file contents and terminal
+ * scrollback. This is expensive and only loaded via the canvas_read_context
+ * tool when the agent needs deep context.
+ */
+export async function buildDetailedContext(workspaceId: string): Promise<DetailedWorkspaceContext | null> {
+  const canvas = await loadCanvasJson(workspaceId);
+  if (!canvas) return null;
+
+  const manifest = await loadManifest();
+  const entry = manifest.workspaces.find(e => e.id === workspaceId);
+  const workspaceName = entry?.name ?? workspaceId;
+  const canvasDir = join(STORE_DIR, workspaceId);
+
+  const nodes: DetailedNodeContext[] = [];
+
+  for (const node of canvas.nodes) {
+    const base = summarizeNode(node);
+    const detailed: DetailedNodeContext = { ...base };
+
+    switch (node.type) {
+      case 'file': {
+        const filePath = node.data.filePath as string;
+        if (filePath) {
+          try {
+            detailed.content = await fs.readFile(filePath, 'utf-8');
+          } catch {
+            detailed.content = (node.data.content as string) ?? '';
+          }
+        } else {
+          detailed.content = (node.data.content as string) ?? '';
+        }
+        break;
+      }
+      case 'terminal':
+        detailed.scrollback = (node.data.scrollback as string) ?? '';
+        detailed.cwd = (node.data.cwd as string) ?? '';
+        break;
+      case 'agent':
+        detailed.scrollback = (node.data.scrollback as string) ?? '';
+        detailed.cwd = (node.data.cwd as string) ?? '';
+        break;
+    }
+
+    nodes.push(detailed);
+  }
+
+  // Read AGENTS.md if present
+  let agentsMd: string | undefined;
+  try {
+    agentsMd = await fs.readFile(join(canvasDir, 'AGENTS.md'), 'utf-8');
+  } catch {
+    // not present
+  }
+
+  return { workspaceId, workspaceName, canvasDir, nodes, agentsMd };
+}
+
+// ─── Read a single node in detail ──────────────────────────────────
+
+export async function readNodeDetail(workspaceId: string, nodeId: string): Promise<DetailedNodeContext | null> {
+  const canvas = await loadCanvasJson(workspaceId);
+  if (!canvas) return null;
+
+  const node = canvas.nodes.find(n => n.id === nodeId);
+  if (!node) return null;
+
+  const base = summarizeNode(node);
+  const detailed: DetailedNodeContext = { ...base };
+
+  switch (node.type) {
+    case 'file': {
+      const filePath = node.data.filePath as string;
+      if (filePath) {
+        try {
+          detailed.content = await fs.readFile(filePath, 'utf-8');
+        } catch {
+          detailed.content = (node.data.content as string) ?? '';
+        }
+      } else {
+        detailed.content = (node.data.content as string) ?? '';
+      }
+      break;
+    }
+    case 'terminal':
+      detailed.scrollback = (node.data.scrollback as string) ?? '';
+      detailed.cwd = (node.data.cwd as string) ?? '';
+      break;
+    case 'agent':
+      detailed.scrollback = (node.data.scrollback as string) ?? '';
+      detailed.cwd = (node.data.cwd as string) ?? '';
+      break;
+    case 'frame':
+      // nothing extra beyond summary
+      break;
+  }
+
+  return detailed;
+}
+
+// ─── Format summary as system prompt section ───────────────────────
+
+export function formatSummaryForPrompt(summary: WorkspaceSummary): string {
+  const lines: string[] = [
+    `# Canvas Workspace: ${summary.workspaceName}`,
+    `Workspace ID: ${summary.workspaceId}`,
+    `Canvas directory: ${summary.canvasDir}`,
+    `Total nodes: ${summary.nodeCount}`,
+    '',
+  ];
+
+  const byType: Record<string, NodeSummary[]> = {};
+  for (const node of summary.nodes) {
+    (byType[node.type] ??= []).push(node);
+  }
+
+  if (byType.file?.length) {
+    lines.push('## File Nodes');
+    for (const n of byType.file) {
+      const pathHint = n.path ? ` (${n.path})` : ' (unsaved)';
+      lines.push(`- [${n.id}] **${n.title}**${pathHint}`);
+    }
+    lines.push('');
+  }
+
+  if (byType.frame?.length) {
+    lines.push('## Frames');
+    for (const n of byType.frame) {
+      const labelHint = n.label ? ` — ${n.label}` : '';
+      lines.push(`- [${n.id}] **${n.title}**${labelHint}`);
+    }
+    lines.push('');
+  }
+
+  if (byType.terminal?.length) {
+    lines.push('## Terminals');
+    for (const n of byType.terminal) {
+      const cwdHint = n.path ? ` (cwd: ${n.path})` : '';
+      lines.push(`- [${n.id}] **${n.title}**${cwdHint}`);
+    }
+    lines.push('');
+  }
+
+  if (byType.agent?.length) {
+    lines.push('## Agent Nodes');
+    for (const n of byType.agent) {
+      const info = `${n.agentType ?? 'unknown'}, ${n.status ?? 'idle'}`;
+      const cwdHint = n.path ? `, cwd: ${n.path}` : '';
+      lines.push(`- [${n.id}] **${n.title}** (${info}${cwdHint})`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}

--- a/apps/canvas-workspace/src/main/canvas-agent/engine.d.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/engine.d.ts
@@ -1,0 +1,12 @@
+// Shim for pulse-coder-engine (no .d.ts generated in dist yet).
+// Remove this file once the engine's tsup DTS build is fixed.
+declare module 'pulse-coder-engine' {
+  export class Engine {
+    constructor(options?: any);
+    initialize(): Promise<void>;
+    run(context: any, options?: any): Promise<string>;
+    getTools(): Record<string, any>;
+    getService<T>(name: string): T | undefined;
+    compactContext(context: any, options?: any): Promise<any>;
+  }
+}

--- a/apps/canvas-workspace/src/main/canvas-agent/index.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/index.ts
@@ -1,0 +1,16 @@
+export { CanvasAgent } from './canvas-agent';
+export { CanvasAgentService } from './service';
+export { SessionStore } from './session-store';
+export type {
+  CanvasAgentConfig,
+  CanvasAgentMessage,
+  CanvasAgentSession,
+  CanvasAgentEvent,
+  CanvasAgentEventType,
+  ChatRequest,
+  ChatResponse,
+  AgentStatusResponse,
+  SessionListResponse,
+  WorkspaceSummary,
+  NodeSummary,
+} from './types';

--- a/apps/canvas-workspace/src/main/canvas-agent/service.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/service.ts
@@ -41,12 +41,13 @@ export class CanvasAgentService {
   /**
    * Send a chat message to the workspace's Canvas Agent.
    * Auto-activates the agent if not already active.
+   * @param onText — optional callback receiving streaming text deltas
    */
-  async chat(workspaceId: string, message: string): Promise<ChatResponse> {
+  async chat(workspaceId: string, message: string, onText?: (delta: string) => void): Promise<ChatResponse> {
     try {
       await this.activate(workspaceId);
       const agent = this.agents.get(workspaceId)!;
-      const response = await agent.chat(message);
+      const response = await agent.chat(message, onText);
       return { ok: true, response };
     } catch (err) {
       console.error(`[canvas-agent-service] chat error for ${workspaceId}:`, err);

--- a/apps/canvas-workspace/src/main/canvas-agent/service.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/service.ts
@@ -1,0 +1,91 @@
+/**
+ * CanvasAgentService — manages one Canvas Agent per workspace.
+ *
+ * Lifecycle:
+ *   activate(workspaceId)  → creates + initializes agent
+ *   chat(workspaceId, msg) → runs a turn
+ *   deactivate(workspaceId) → archives session + destroys agent
+ */
+
+import { join } from 'path';
+import { homedir } from 'os';
+import { CanvasAgent } from './canvas-agent';
+import type {
+  ChatResponse,
+  AgentStatusResponse,
+  SessionListResponse,
+  CanvasAgentMessage,
+} from './types';
+
+const STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
+
+export class CanvasAgentService {
+  private agents = new Map<string, CanvasAgent>();
+
+  /**
+   * Activate the Canvas Agent for a workspace. Idempotent — if already
+   * active, returns immediately.
+   */
+  async activate(workspaceId: string): Promise<void> {
+    if (this.agents.has(workspaceId)) return;
+
+    const agent = new CanvasAgent({
+      workspaceId,
+      workspaceDir: join(STORE_DIR, workspaceId),
+    });
+
+    await agent.initialize();
+    this.agents.set(workspaceId, agent);
+  }
+
+  /**
+   * Send a chat message to the workspace's Canvas Agent.
+   * Auto-activates the agent if not already active.
+   */
+  async chat(workspaceId: string, message: string): Promise<ChatResponse> {
+    try {
+      await this.activate(workspaceId);
+      const agent = this.agents.get(workspaceId)!;
+      const response = await agent.chat(message);
+      return { ok: true, response };
+    } catch (err) {
+      console.error(`[canvas-agent-service] chat error for ${workspaceId}:`, err);
+      return { ok: false, error: String(err) };
+    }
+  }
+
+  /**
+   * Get the agent's status for a workspace.
+   */
+  getStatus(workspaceId: string): AgentStatusResponse {
+    const agent = this.agents.get(workspaceId);
+    if (!agent) return { ok: true, active: false, messageCount: 0 };
+    return { ok: true, active: true, messageCount: agent.getMessageCount() };
+  }
+
+  /**
+   * Get conversation history for the current session.
+   */
+  getHistory(workspaceId: string): CanvasAgentMessage[] {
+    const agent = this.agents.get(workspaceId);
+    return agent?.getHistory() ?? [];
+  }
+
+  /**
+   * Deactivate and archive the Canvas Agent for a workspace.
+   */
+  async deactivate(workspaceId: string): Promise<void> {
+    const agent = this.agents.get(workspaceId);
+    if (!agent) return;
+    await agent.destroy();
+    this.agents.delete(workspaceId);
+  }
+
+  /**
+   * Deactivate all agents (called on app shutdown).
+   */
+  async deactivateAll(): Promise<void> {
+    const ids = Array.from(this.agents.keys());
+    await Promise.all(ids.map(id => this.deactivate(id)));
+  }
+}

--- a/apps/canvas-workspace/src/main/canvas-agent/service.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/service.ts
@@ -43,11 +43,17 @@ export class CanvasAgentService {
    * Auto-activates the agent if not already active.
    * @param onText — optional callback receiving streaming text deltas
    */
-  async chat(workspaceId: string, message: string, onText?: (delta: string) => void): Promise<ChatResponse> {
+  async chat(
+    workspaceId: string,
+    message: string,
+    onText?: (delta: string) => void,
+    onToolCall?: (data: { name: string; args: any }) => void,
+    onToolResult?: (data: { name: string; result: string }) => void,
+  ): Promise<ChatResponse> {
     try {
       await this.activate(workspaceId);
       const agent = this.agents.get(workspaceId)!;
-      const response = await agent.chat(message, onText);
+      const response = await agent.chat(message, onText, onToolCall, onToolResult);
       return { ok: true, response };
     } catch (err) {
       console.error(`[canvas-agent-service] chat error for ${workspaceId}:`, err);

--- a/apps/canvas-workspace/src/main/canvas-agent/service.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/service.ts
@@ -73,6 +73,43 @@ export class CanvasAgentService {
   }
 
   /**
+   * List all sessions (current + archived) for a workspace.
+   */
+  async listSessions(workspaceId: string): Promise<Array<{ sessionId: string; date: string; messageCount: number; isCurrent: boolean }>> {
+    await this.activate(workspaceId);
+    const agent = this.agents.get(workspaceId)!;
+    return agent.listSessions();
+  }
+
+  /**
+   * Start a new session for a workspace.
+   */
+  async newSession(workspaceId: string): Promise<{ ok: boolean; error?: string }> {
+    try {
+      await this.activate(workspaceId);
+      const agent = this.agents.get(workspaceId)!;
+      await agent.newSession();
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: String(err) };
+    }
+  }
+
+  /**
+   * Load a specific session by sessionId.
+   */
+  async loadSession(workspaceId: string, sessionId: string): Promise<{ ok: boolean; messages?: CanvasAgentMessage[]; error?: string }> {
+    try {
+      await this.activate(workspaceId);
+      const agent = this.agents.get(workspaceId)!;
+      const messages = await agent.loadSession(sessionId);
+      return { ok: true, messages };
+    } catch (err) {
+      return { ok: false, error: String(err) };
+    }
+  }
+
+  /**
    * Deactivate and archive the Canvas Agent for a workspace.
    */
   async deactivate(workspaceId: string): Promise<void> {

--- a/apps/canvas-workspace/src/main/canvas-agent/session-store.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/session-store.ts
@@ -1,0 +1,151 @@
+/**
+ * Session persistence for the Canvas Agent.
+ *
+ * Storage layout:
+ *   ~/.pulse-coder/canvas/<workspace-id>/agent-sessions/
+ *   ├── current.json          ← active session
+ *   └── archive/
+ *       ├── 2026-04-08.json   ← archived sessions by date
+ *       └── 2026-04-07.json
+ */
+
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import type { CanvasAgentMessage, CanvasAgentSession } from './types';
+
+const STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
+
+export class SessionStore {
+  private workspaceId: string;
+  private sessionsDir: string;
+  private currentPath: string;
+  private archiveDir: string;
+
+  private session: CanvasAgentSession | null = null;
+
+  constructor(workspaceId: string) {
+    this.workspaceId = workspaceId;
+    this.sessionsDir = join(STORE_DIR, workspaceId, 'agent-sessions');
+    this.currentPath = join(this.sessionsDir, 'current.json');
+    this.archiveDir = join(this.sessionsDir, 'archive');
+  }
+
+  /**
+   * Start a new session. If a current session exists, archive it first.
+   */
+  async startSession(): Promise<void> {
+    await fs.mkdir(this.sessionsDir, { recursive: true });
+    await fs.mkdir(this.archiveDir, { recursive: true });
+
+    // Archive any existing current session
+    await this.archiveCurrentIfExists();
+
+    const sessionId = `session-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    this.session = {
+      sessionId,
+      workspaceId: this.workspaceId,
+      startedAt: new Date().toISOString(),
+      messages: [],
+    };
+
+    await this.persist();
+  }
+
+  /**
+   * Add a message to the current session and persist.
+   */
+  addMessage(message: CanvasAgentMessage): void {
+    if (!this.session) return;
+    this.session.messages.push(message);
+    // Fire-and-forget persist
+    void this.persist();
+  }
+
+  /**
+   * Get all messages from the current session.
+   */
+  getMessages(): CanvasAgentMessage[] {
+    return this.session?.messages ?? [];
+  }
+
+  /**
+   * Archive the current session and clear it.
+   */
+  async archiveSession(): Promise<void> {
+    await this.archiveCurrentIfExists();
+    this.session = null;
+  }
+
+  /**
+   * List archived sessions (date + message count).
+   */
+  async listArchivedSessions(): Promise<Array<{ sessionId: string; date: string; messageCount: number }>> {
+    try {
+      const files = await fs.readdir(this.archiveDir);
+      const sessions: Array<{ sessionId: string; date: string; messageCount: number }> = [];
+
+      for (const file of files) {
+        if (!file.endsWith('.json')) continue;
+        try {
+          const raw = await fs.readFile(join(this.archiveDir, file), 'utf-8');
+          const data = JSON.parse(raw) as CanvasAgentSession;
+          sessions.push({
+            sessionId: data.sessionId,
+            date: file.replace('.json', ''),
+            messageCount: data.messages.length,
+          });
+        } catch {
+          // skip corrupted files
+        }
+      }
+
+      return sessions.sort((a, b) => b.date.localeCompare(a.date));
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Read a specific archived session by date.
+   */
+  async readArchivedSession(date: string): Promise<CanvasAgentSession | null> {
+    try {
+      const raw = await fs.readFile(join(this.archiveDir, `${date}.json`), 'utf-8');
+      return JSON.parse(raw) as CanvasAgentSession;
+    } catch {
+      return null;
+    }
+  }
+
+  // ─── Internal ────────────────────────────────────────────────
+
+  private async persist(): Promise<void> {
+    if (!this.session) return;
+    try {
+      await fs.writeFile(this.currentPath, JSON.stringify(this.session, null, 2), 'utf-8');
+    } catch (err) {
+      console.error('[session-store] Failed to persist session:', err);
+    }
+  }
+
+  private async archiveCurrentIfExists(): Promise<void> {
+    try {
+      const raw = await fs.readFile(this.currentPath, 'utf-8');
+      const existing = JSON.parse(raw) as CanvasAgentSession;
+
+      if (existing.messages.length > 0) {
+        // Archive with date-based filename; append timestamp to avoid collisions
+        const date = existing.startedAt.slice(0, 10); // YYYY-MM-DD
+        const ts = Date.now();
+        const archivePath = join(this.archiveDir, `${date}-${ts}.json`);
+        await fs.writeFile(archivePath, raw, 'utf-8');
+      }
+
+      // Remove current
+      await fs.unlink(this.currentPath).catch(() => undefined);
+    } catch {
+      // No current session or corrupted — nothing to archive
+    }
+  }
+}

--- a/apps/canvas-workspace/src/main/canvas-agent/session-store.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/session-store.ts
@@ -80,20 +80,22 @@ export class SessionStore {
   /**
    * List archived sessions (date + message count).
    */
-  async listArchivedSessions(): Promise<Array<{ sessionId: string; date: string; messageCount: number }>> {
+  async listArchivedSessions(): Promise<Array<{ sessionId: string; date: string; messageCount: number; preview: string }>> {
     try {
       const files = await fs.readdir(this.archiveDir);
-      const sessions: Array<{ sessionId: string; date: string; messageCount: number }> = [];
+      const sessions: Array<{ sessionId: string; date: string; messageCount: number; preview: string }> = [];
 
       for (const file of files) {
         if (!file.endsWith('.json')) continue;
         try {
           const raw = await fs.readFile(join(this.archiveDir, file), 'utf-8');
           const data = JSON.parse(raw) as CanvasAgentSession;
+          const firstUserMsg = data.messages.find(m => m.role === 'user');
           sessions.push({
             sessionId: data.sessionId,
-            date: file.replace('.json', ''),
+            date: data.startedAt?.slice(0, 10) || file.replace('.json', '').slice(0, 10),
             messageCount: data.messages.length,
+            preview: firstUserMsg ? firstUserMsg.content.slice(0, 50) : '',
           });
         } catch {
           // skip corrupted files

--- a/apps/canvas-workspace/src/main/canvas-agent/session-store.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/session-store.ts
@@ -118,6 +118,40 @@ export class SessionStore {
     }
   }
 
+  /**
+   * Get the current session metadata (for listing alongside archived ones).
+   */
+  getCurrentSession(): CanvasAgentSession | null {
+    return this.session;
+  }
+
+  /**
+   * Load an archived session as the current session (for viewing/resuming).
+   * Archives the current session first if it has messages.
+   */
+  async loadSession(sessionId: string): Promise<CanvasAgentSession | null> {
+    // Find the archived session by sessionId
+    try {
+      const files = await fs.readdir(this.archiveDir);
+      for (const file of files) {
+        if (!file.endsWith('.json')) continue;
+        const raw = await fs.readFile(join(this.archiveDir, file), 'utf-8');
+        const data = JSON.parse(raw) as CanvasAgentSession;
+        if (data.sessionId === sessionId) {
+          // Archive current session first
+          await this.archiveCurrentIfExists();
+          // Set as current
+          this.session = data;
+          await this.persist();
+          return data;
+        }
+      }
+    } catch {
+      // ignore
+    }
+    return null;
+  }
+
   // ─── Internal ────────────────────────────────────────────────
 
   private async persist(): Promise<void> {

--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -3,12 +3,16 @@
  *
  * These tools operate directly on the canvas filesystem (canvas.json + notes/)
  * in the Electron main process. They do NOT go through the CLI.
+ *
+ * Tool interface matches pulse-coder-engine's Tool type:
+ *   { name, description, inputSchema (Zod), execute }
  */
 
 import { promises as fs } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { BrowserWindow } from 'electron';
+import { z } from 'zod';
 import {
   buildWorkspaceSummary,
   buildDetailedContext,
@@ -96,33 +100,28 @@ function autoPlace(nodes: CanvasNode[]): { x: number; y: number } {
   return { x: maxRight + 40, y: bestY };
 }
 
-// ─── Tool definitions ──────────────────────────────────────────────
+// ─── Canvas Tool type (matches Engine's Tool interface) ────────────
 
-export interface CanvasToolDefs {
-  [name: string]: {
-    description: string;
-    parameters: Record<string, unknown>;
-    execute: (input: Record<string, unknown>) => Promise<string>;
-  };
+export interface CanvasTool {
+  name: string;
+  description: string;
+  inputSchema: z.ZodType;
+  execute: (input: any) => Promise<string>;
 }
 
-export function createCanvasTools(workspaceId: string): CanvasToolDefs {
+// ─── Tool definitions ──────────────────────────────────────────────
+
+export function createCanvasTools(workspaceId: string): Record<string, CanvasTool> {
   return {
     canvas_read_context: {
+      name: 'canvas_read_context',
       description:
         'Read the current workspace context. Use detail="summary" (default) for a quick overview of all nodes, or detail="full" to include file contents and terminal scrollback.',
-      parameters: {
-        type: 'object',
-        properties: {
-          detail: {
-            type: 'string',
-            enum: ['summary', 'full'],
-            description: 'Level of detail. "summary" returns node list with metadata. "full" includes file contents and terminal scrollback.',
-          },
-        },
-      },
+      inputSchema: z.object({
+        detail: z.enum(['summary', 'full']).optional().describe('Level of detail. "summary" returns node list with metadata. "full" includes file contents and terminal scrollback.'),
+      }),
       execute: async (input) => {
-        const detail = (input.detail as string) ?? 'summary';
+        const detail = input.detail ?? 'summary';
         if (detail === 'full') {
           const ctx = await buildDetailedContext(workspaceId);
           if (!ctx) return 'Error: workspace not found';
@@ -135,15 +134,12 @@ export function createCanvasTools(workspaceId: string): CanvasToolDefs {
     },
 
     canvas_read_node: {
+      name: 'canvas_read_node',
       description:
         'Read the full content of a specific canvas node. For file nodes, returns the file content. For terminal/agent nodes, returns scrollback output.',
-      parameters: {
-        type: 'object',
-        properties: {
-          nodeId: { type: 'string', description: 'The ID of the node to read.' },
-        },
-        required: ['nodeId'],
-      },
+      inputSchema: z.object({
+        nodeId: z.string().describe('The ID of the node to read.'),
+      }),
       execute: async (input) => {
         const nodeId = input.nodeId as string;
         const detail = await readNodeDetail(workspaceId, nodeId);
@@ -153,20 +149,17 @@ export function createCanvasTools(workspaceId: string): CanvasToolDefs {
     },
 
     canvas_create_node: {
+      name: 'canvas_create_node',
       description:
         'Create a new node on the canvas. For file nodes, a notes file is automatically created in the workspace.',
-      parameters: {
-        type: 'object',
-        properties: {
-          type: { type: 'string', enum: ['file', 'terminal', 'frame', 'agent'], description: 'Node type.' },
-          title: { type: 'string', description: 'Node title.' },
-          content: { type: 'string', description: 'Initial content (for file nodes).' },
-          x: { type: 'number', description: 'X position (auto-placed if omitted).' },
-          y: { type: 'number', description: 'Y position (auto-placed if omitted).' },
-          data: { type: 'object', description: 'Additional node data (e.g. color/label for frames, cwd for terminals).' },
-        },
-        required: ['type'],
-      },
+      inputSchema: z.object({
+        type: z.enum(['file', 'terminal', 'frame', 'agent']).describe('Node type.'),
+        title: z.string().optional().describe('Node title.'),
+        content: z.string().optional().describe('Initial content (for file nodes).'),
+        x: z.number().optional().describe('X position (auto-placed if omitted).'),
+        y: z.number().optional().describe('Y position (auto-placed if omitted).'),
+        data: z.record(z.string(), z.unknown()).optional().describe('Additional node data (e.g. color/label for frames, cwd for terminals).'),
+      }),
       execute: async (input) => {
         const nodeType = input.type as NodeType;
         const title = (input.title as string) ?? DEFAULT_DIMENSIONS[nodeType]?.title ?? 'Untitled';
@@ -248,18 +241,15 @@ export function createCanvasTools(workspaceId: string): CanvasToolDefs {
     },
 
     canvas_update_node: {
+      name: 'canvas_update_node',
       description:
         'Update an existing canvas node. For file nodes, updates the file content. For frame nodes, updates label/color.',
-      parameters: {
-        type: 'object',
-        properties: {
-          nodeId: { type: 'string', description: 'The ID of the node to update.' },
-          title: { type: 'string', description: 'New title (optional).' },
-          content: { type: 'string', description: 'New content for file nodes.' },
-          data: { type: 'object', description: 'Partial data update (e.g. label, color for frames).' },
-        },
-        required: ['nodeId'],
-      },
+      inputSchema: z.object({
+        nodeId: z.string().describe('The ID of the node to update.'),
+        title: z.string().optional().describe('New title (optional).'),
+        content: z.string().optional().describe('New content for file nodes.'),
+        data: z.record(z.string(), z.unknown()).optional().describe('Partial data update (e.g. label, color for frames).'),
+      }),
       execute: async (input) => {
         const nodeId = input.nodeId as string;
         const canvas = await loadCanvas(workspaceId);
@@ -299,14 +289,11 @@ export function createCanvasTools(workspaceId: string): CanvasToolDefs {
     },
 
     canvas_delete_node: {
+      name: 'canvas_delete_node',
       description: 'Delete a node from the canvas.',
-      parameters: {
-        type: 'object',
-        properties: {
-          nodeId: { type: 'string', description: 'The ID of the node to delete.' },
-        },
-        required: ['nodeId'],
-      },
+      inputSchema: z.object({
+        nodeId: z.string().describe('The ID of the node to delete.'),
+      }),
       execute: async (input) => {
         const nodeId = input.nodeId as string;
         const canvas = await loadCanvas(workspaceId);
@@ -327,16 +314,13 @@ export function createCanvasTools(workspaceId: string): CanvasToolDefs {
     },
 
     canvas_move_node: {
+      name: 'canvas_move_node',
       description: 'Move a node to a new position on the canvas.',
-      parameters: {
-        type: 'object',
-        properties: {
-          nodeId: { type: 'string', description: 'The ID of the node to move.' },
-          x: { type: 'number', description: 'New X position.' },
-          y: { type: 'number', description: 'New Y position.' },
-        },
-        required: ['nodeId', 'x', 'y'],
-      },
+      inputSchema: z.object({
+        nodeId: z.string().describe('The ID of the node to move.'),
+        x: z.number().describe('New X position.'),
+        y: z.number().describe('New Y position.'),
+      }),
       execute: async (input) => {
         const nodeId = input.nodeId as string;
         const canvas = await loadCanvas(workspaceId);

--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -1,0 +1,362 @@
+/**
+ * Canvas-specific tools for the Canvas Agent.
+ *
+ * These tools operate directly on the canvas filesystem (canvas.json + notes/)
+ * in the Electron main process. They do NOT go through the CLI.
+ */
+
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { BrowserWindow } from 'electron';
+import {
+  buildWorkspaceSummary,
+  buildDetailedContext,
+  readNodeDetail,
+  formatSummaryForPrompt,
+} from './context-builder';
+
+const STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
+
+// ─── Types mirrored from canvas-cli ────────────────────────────────
+
+type NodeType = 'file' | 'terminal' | 'frame' | 'agent';
+
+interface CanvasNode {
+  id: string;
+  type: string;
+  title: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  data: Record<string, unknown>;
+  updatedAt?: number;
+}
+
+interface CanvasSaveData {
+  nodes: CanvasNode[];
+  transform: { x: number; y: number; scale: number };
+  savedAt: string;
+}
+
+const DEFAULT_DIMENSIONS: Record<NodeType, { title: string; width: number; height: number }> = {
+  file: { title: 'Untitled', width: 420, height: 360 },
+  terminal: { title: 'Terminal', width: 480, height: 300 },
+  frame: { title: 'Frame', width: 600, height: 400 },
+  agent: { title: 'Agent', width: 520, height: 380 },
+};
+
+// ─── Helpers ───────────────────────────────────────────────────────
+
+function canvasPath(workspaceId: string): string {
+  return join(STORE_DIR, workspaceId, 'canvas.json');
+}
+
+async function loadCanvas(workspaceId: string): Promise<CanvasSaveData | null> {
+  try {
+    const raw = await fs.readFile(canvasPath(workspaceId), 'utf-8');
+    const data = JSON.parse(raw) as CanvasSaveData;
+    data.nodes = data.nodes ?? [];
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+async function saveCanvas(workspaceId: string, data: CanvasSaveData): Promise<void> {
+  data.savedAt = new Date().toISOString();
+  await fs.writeFile(canvasPath(workspaceId), JSON.stringify(data, null, 2), 'utf-8');
+}
+
+function broadcastUpdate(workspaceId: string, nodeIds: string[]): void {
+  const payload = {
+    type: 'canvas:updated' as const,
+    workspaceId,
+    nodeIds,
+    source: 'canvas-agent' as const,
+  };
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (win.isDestroyed()) continue;
+    win.webContents.send('canvas:external-update', payload);
+  }
+}
+
+function autoPlace(nodes: CanvasNode[]): { x: number; y: number } {
+  if (nodes.length === 0) return { x: 100, y: 100 };
+  let maxRight = 0;
+  let bestY = 100;
+  for (const n of nodes) {
+    const right = n.x + n.width;
+    if (right > maxRight) {
+      maxRight = right;
+      bestY = n.y;
+    }
+  }
+  return { x: maxRight + 40, y: bestY };
+}
+
+// ─── Tool definitions ──────────────────────────────────────────────
+
+export interface CanvasToolDefs {
+  [name: string]: {
+    description: string;
+    parameters: Record<string, unknown>;
+    execute: (input: Record<string, unknown>) => Promise<string>;
+  };
+}
+
+export function createCanvasTools(workspaceId: string): CanvasToolDefs {
+  return {
+    canvas_read_context: {
+      description:
+        'Read the current workspace context. Use detail="summary" (default) for a quick overview of all nodes, or detail="full" to include file contents and terminal scrollback.',
+      parameters: {
+        type: 'object',
+        properties: {
+          detail: {
+            type: 'string',
+            enum: ['summary', 'full'],
+            description: 'Level of detail. "summary" returns node list with metadata. "full" includes file contents and terminal scrollback.',
+          },
+        },
+      },
+      execute: async (input) => {
+        const detail = (input.detail as string) ?? 'summary';
+        if (detail === 'full') {
+          const ctx = await buildDetailedContext(workspaceId);
+          if (!ctx) return 'Error: workspace not found';
+          return JSON.stringify(ctx, null, 2);
+        }
+        const summary = await buildWorkspaceSummary(workspaceId);
+        if (!summary) return 'Error: workspace not found';
+        return formatSummaryForPrompt(summary);
+      },
+    },
+
+    canvas_read_node: {
+      description:
+        'Read the full content of a specific canvas node. For file nodes, returns the file content. For terminal/agent nodes, returns scrollback output.',
+      parameters: {
+        type: 'object',
+        properties: {
+          nodeId: { type: 'string', description: 'The ID of the node to read.' },
+        },
+        required: ['nodeId'],
+      },
+      execute: async (input) => {
+        const nodeId = input.nodeId as string;
+        const detail = await readNodeDetail(workspaceId, nodeId);
+        if (!detail) return `Error: node not found: ${nodeId}`;
+        return JSON.stringify(detail, null, 2);
+      },
+    },
+
+    canvas_create_node: {
+      description:
+        'Create a new node on the canvas. For file nodes, a notes file is automatically created in the workspace.',
+      parameters: {
+        type: 'object',
+        properties: {
+          type: { type: 'string', enum: ['file', 'terminal', 'frame', 'agent'], description: 'Node type.' },
+          title: { type: 'string', description: 'Node title.' },
+          content: { type: 'string', description: 'Initial content (for file nodes).' },
+          x: { type: 'number', description: 'X position (auto-placed if omitted).' },
+          y: { type: 'number', description: 'Y position (auto-placed if omitted).' },
+          data: { type: 'object', description: 'Additional node data (e.g. color/label for frames, cwd for terminals).' },
+        },
+        required: ['type'],
+      },
+      execute: async (input) => {
+        const nodeType = input.type as NodeType;
+        const title = (input.title as string) ?? DEFAULT_DIMENSIONS[nodeType]?.title ?? 'Untitled';
+        const content = (input.content as string) ?? '';
+        const extraData = (input.data as Record<string, unknown>) ?? {};
+
+        const canvas = await loadCanvas(workspaceId);
+        if (!canvas) return 'Error: workspace not found';
+
+        const nodeId = `node-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const def = DEFAULT_DIMENSIONS[nodeType];
+        if (!def) return `Error: unsupported node type: ${nodeType}`;
+
+        const pos = (input.x != null && input.y != null)
+          ? { x: input.x as number, y: input.y as number }
+          : autoPlace(canvas.nodes);
+
+        let nodeData: Record<string, unknown>;
+        switch (nodeType) {
+          case 'file':
+            nodeData = { filePath: '', content, saved: false, modified: false };
+            break;
+          case 'terminal':
+            nodeData = { sessionId: '', cwd: (extraData.cwd as string) ?? '' };
+            break;
+          case 'frame':
+            nodeData = {
+              color: (extraData.color as string) ?? '#9575d4',
+              label: (extraData.label as string) ?? '',
+            };
+            break;
+          case 'agent':
+            nodeData = {
+              sessionId: '',
+              cwd: (extraData.cwd as string) ?? '',
+              agentType: (extraData.agentType as string) ?? 'claude-code',
+              status: 'idle',
+            };
+            break;
+        }
+
+        // For file nodes, create a backing notes file
+        if (nodeType === 'file') {
+          const notesDir = join(STORE_DIR, workspaceId, 'notes');
+          await fs.mkdir(notesDir, { recursive: true });
+          const safeTitle = title.replace(/[^a-zA-Z0-9_-]/g, '_');
+          const noteFile = join(notesDir, `${safeTitle}-${nodeId}.md`);
+          await fs.writeFile(noteFile, content, 'utf-8');
+          nodeData.filePath = noteFile;
+          nodeData.saved = true;
+          nodeData.modified = false;
+        }
+
+        const newNode: CanvasNode = {
+          id: nodeId,
+          type: nodeType,
+          title,
+          x: pos.x,
+          y: pos.y,
+          width: def.width,
+          height: def.height,
+          data: nodeData,
+          updatedAt: Date.now(),
+        };
+
+        // Re-read canvas before writing to avoid clobbering concurrent changes
+        const fresh = (await loadCanvas(workspaceId)) ?? canvas;
+        fresh.nodes.push(newNode);
+        await saveCanvas(workspaceId, fresh);
+        broadcastUpdate(workspaceId, [nodeId]);
+
+        return JSON.stringify({
+          ok: true,
+          nodeId,
+          type: nodeType,
+          title,
+        });
+      },
+    },
+
+    canvas_update_node: {
+      description:
+        'Update an existing canvas node. For file nodes, updates the file content. For frame nodes, updates label/color.',
+      parameters: {
+        type: 'object',
+        properties: {
+          nodeId: { type: 'string', description: 'The ID of the node to update.' },
+          title: { type: 'string', description: 'New title (optional).' },
+          content: { type: 'string', description: 'New content for file nodes.' },
+          data: { type: 'object', description: 'Partial data update (e.g. label, color for frames).' },
+        },
+        required: ['nodeId'],
+      },
+      execute: async (input) => {
+        const nodeId = input.nodeId as string;
+        const canvas = await loadCanvas(workspaceId);
+        if (!canvas) return 'Error: workspace not found';
+
+        const node = canvas.nodes.find(n => n.id === nodeId);
+        if (!node) return `Error: node not found: ${nodeId}`;
+
+        if (input.title) node.title = input.title as string;
+
+        if (node.type === 'file' && input.content != null) {
+          const content = input.content as string;
+          node.data.content = content;
+          if (node.data.filePath) {
+            await fs.writeFile(node.data.filePath as string, content, 'utf-8');
+          }
+        }
+
+        if (input.data) {
+          const patch = input.data as Record<string, unknown>;
+          for (const [k, v] of Object.entries(patch)) {
+            node.data[k] = v;
+          }
+        }
+
+        node.updatedAt = Date.now();
+
+        // Re-read and commit
+        const fresh = (await loadCanvas(workspaceId)) ?? canvas;
+        const idx = fresh.nodes.findIndex(n => n.id === nodeId);
+        if (idx >= 0) fresh.nodes[idx] = node;
+        await saveCanvas(workspaceId, fresh);
+        broadcastUpdate(workspaceId, [nodeId]);
+
+        return JSON.stringify({ ok: true, nodeId });
+      },
+    },
+
+    canvas_delete_node: {
+      description: 'Delete a node from the canvas.',
+      parameters: {
+        type: 'object',
+        properties: {
+          nodeId: { type: 'string', description: 'The ID of the node to delete.' },
+        },
+        required: ['nodeId'],
+      },
+      execute: async (input) => {
+        const nodeId = input.nodeId as string;
+        const canvas = await loadCanvas(workspaceId);
+        if (!canvas) return 'Error: workspace not found';
+
+        const idx = canvas.nodes.findIndex(n => n.id === nodeId);
+        if (idx === -1) return `Error: node not found: ${nodeId}`;
+
+        // Re-read and commit
+        const fresh = (await loadCanvas(workspaceId)) ?? canvas;
+        const freshIdx = fresh.nodes.findIndex(n => n.id === nodeId);
+        if (freshIdx >= 0) fresh.nodes.splice(freshIdx, 1);
+        await saveCanvas(workspaceId, fresh);
+        broadcastUpdate(workspaceId, [nodeId]);
+
+        return JSON.stringify({ ok: true, nodeId });
+      },
+    },
+
+    canvas_move_node: {
+      description: 'Move a node to a new position on the canvas.',
+      parameters: {
+        type: 'object',
+        properties: {
+          nodeId: { type: 'string', description: 'The ID of the node to move.' },
+          x: { type: 'number', description: 'New X position.' },
+          y: { type: 'number', description: 'New Y position.' },
+        },
+        required: ['nodeId', 'x', 'y'],
+      },
+      execute: async (input) => {
+        const nodeId = input.nodeId as string;
+        const canvas = await loadCanvas(workspaceId);
+        if (!canvas) return 'Error: workspace not found';
+
+        const node = canvas.nodes.find(n => n.id === nodeId);
+        if (!node) return `Error: node not found: ${nodeId}`;
+
+        node.x = input.x as number;
+        node.y = input.y as number;
+        node.updatedAt = Date.now();
+
+        const fresh = (await loadCanvas(workspaceId)) ?? canvas;
+        const idx = fresh.nodes.findIndex(n => n.id === nodeId);
+        if (idx >= 0) fresh.nodes[idx] = node;
+        await saveCanvas(workspaceId, fresh);
+        broadcastUpdate(workspaceId, [nodeId]);
+
+        return JSON.stringify({ ok: true, nodeId });
+      },
+    },
+  };
+}

--- a/apps/canvas-workspace/src/main/canvas-agent/types.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/types.ts
@@ -1,0 +1,97 @@
+/**
+ * Canvas Agent type definitions.
+ *
+ * The Canvas Agent is a workspace-scoped AI Copilot that runs in the
+ * Electron main process. It understands the entire canvas context and
+ * can perform canvas operations, file I/O, and coding tasks directly.
+ */
+
+// ─── Configuration ──────────────────────────────────────────────────
+
+export interface CanvasAgentConfig {
+  workspaceId: string;
+  workspaceDir: string;
+  /** Optional model override (e.g. 'gpt-4o', 'claude-sonnet-4-20250514'). */
+  model?: string;
+}
+
+// ─── Messages ───────────────────────────────────────────────────────
+
+export interface CanvasAgentMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: number;
+}
+
+// ─── Session persistence ────────────────────────────────────────────
+
+export interface CanvasAgentSession {
+  sessionId: string;
+  workspaceId: string;
+  startedAt: string;
+  messages: CanvasAgentMessage[];
+}
+
+// ─── Workspace context (lightweight summary) ────────────────────────
+
+export interface NodeSummary {
+  id: string;
+  type: string;
+  title: string;
+  /** File path for file nodes, cwd for terminal/agent nodes. */
+  path?: string;
+  /** Agent type for agent nodes. */
+  agentType?: string;
+  /** Running status for agent nodes. */
+  status?: string;
+  /** Frame color for frame nodes. */
+  color?: string;
+  /** Frame label for frame nodes. */
+  label?: string;
+}
+
+export interface WorkspaceSummary {
+  workspaceId: string;
+  workspaceName: string;
+  canvasDir: string;
+  nodeCount: number;
+  nodes: NodeSummary[];
+}
+
+// ─── Events (main → renderer) ──────────────────────────────────────
+
+export type CanvasAgentEventType =
+  | 'chunk'          // streaming text delta
+  | 'tool-call'      // agent is calling a tool
+  | 'tool-result'    // tool call completed
+  | 'done'           // turn complete
+  | 'error';         // error occurred
+
+export interface CanvasAgentEvent {
+  type: CanvasAgentEventType;
+  data: Record<string, unknown>;
+}
+
+// ─── IPC payloads ──────────────────────────────────────────────────
+
+export interface ChatRequest {
+  workspaceId: string;
+  message: string;
+}
+
+export interface ChatResponse {
+  ok: boolean;
+  response?: string;
+  error?: string;
+}
+
+export interface AgentStatusResponse {
+  ok: boolean;
+  active: boolean;
+  messageCount: number;
+}
+
+export interface SessionListResponse {
+  ok: boolean;
+  sessions?: Array<{ sessionId: string; date: string; messageCount: number }>;
+}

--- a/apps/canvas-workspace/src/main/index.ts
+++ b/apps/canvas-workspace/src/main/index.ts
@@ -10,6 +10,7 @@ import { setupFileManagerIpc } from "./file-manager";
 // import { ensureMCPRegistered } from "./mcp-registration";
 import { setupFileWatcherIpc, teardownFileWatcher } from "./file-watcher";
 import { setupSkillInstallerIpc } from "./skill-installer";
+import { setupCanvasAgentIpc, teardownCanvasAgent } from "./canvas-agent-ipc";
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const preloadPath = join(currentDir, "../preload/index.mjs");
@@ -103,6 +104,7 @@ app.whenReady().then(() => {
   setupFileManagerIpc();
   setupFileWatcherIpc();
   setupSkillInstallerIpc();
+  setupCanvasAgentIpc();
   // MCP server disabled — canvas-cli is the preferred agent interface now.
   // startMCPServer();
   // void ensureMCPRegistered();
@@ -120,6 +122,7 @@ app.on("window-all-closed", () => {
   killAllPty();
   teardownFileWatcher();
   teardownCanvasWatchers();
+  teardownCanvasAgent();
   if (process.platform !== "darwin") {
     app.quit();
   }

--- a/apps/canvas-workspace/src/preload/index.ts
+++ b/apps/canvas-workspace/src/preload/index.ts
@@ -131,5 +131,22 @@ contextBridge.exposeInMainWorld("canvasWorkspace", {
 
   skills: {
     install: () => ipcRenderer.invoke("skills:install")
+  },
+
+  agent: {
+    chat: (workspaceId: string, message: string) =>
+      ipcRenderer.invoke("canvas-agent:chat", { workspaceId, message }),
+
+    getStatus: (workspaceId: string) =>
+      ipcRenderer.invoke("canvas-agent:status", { workspaceId }),
+
+    getHistory: (workspaceId: string) =>
+      ipcRenderer.invoke("canvas-agent:history", { workspaceId }),
+
+    activate: (workspaceId: string) =>
+      ipcRenderer.invoke("canvas-agent:activate", { workspaceId }),
+
+    deactivate: (workspaceId: string) =>
+      ipcRenderer.invoke("canvas-agent:deactivate", { workspaceId }),
   }
 });

--- a/apps/canvas-workspace/src/preload/index.ts
+++ b/apps/canvas-workspace/src/preload/index.ts
@@ -137,6 +137,31 @@ contextBridge.exposeInMainWorld("canvasWorkspace", {
     chat: (workspaceId: string, message: string) =>
       ipcRenderer.invoke("canvas-agent:chat", { workspaceId, message }),
 
+    onTextDelta: (sessionId: string, callback: (delta: string) => void) => {
+      const channel = `canvas-agent:text-delta:${sessionId}`;
+      const handler = (_event: Electron.IpcRendererEvent, delta: string) =>
+        callback(delta);
+      ipcRenderer.on(channel, handler);
+      return () => {
+        ipcRenderer.removeListener(channel, handler);
+      };
+    },
+
+    onChatComplete: (
+      sessionId: string,
+      callback: (result: { ok: boolean; response?: string; error?: string }) => void
+    ) => {
+      const channel = `canvas-agent:chat-complete:${sessionId}`;
+      const handler = (
+        _event: Electron.IpcRendererEvent,
+        result: { ok: boolean; response?: string; error?: string }
+      ) => callback(result);
+      ipcRenderer.on(channel, handler);
+      return () => {
+        ipcRenderer.removeListener(channel, handler);
+      };
+    },
+
     getStatus: (workspaceId: string) =>
       ipcRenderer.invoke("canvas-agent:status", { workspaceId }),
 

--- a/apps/canvas-workspace/src/preload/index.ts
+++ b/apps/canvas-workspace/src/preload/index.ts
@@ -162,6 +162,26 @@ contextBridge.exposeInMainWorld("canvasWorkspace", {
       };
     },
 
+    onToolCall: (sessionId: string, callback: (data: { name: string; args: any }) => void) => {
+      const channel = `canvas-agent:tool-call:${sessionId}`;
+      const handler = (_event: Electron.IpcRendererEvent, data: { name: string; args: any }) =>
+        callback(data);
+      ipcRenderer.on(channel, handler);
+      return () => {
+        ipcRenderer.removeListener(channel, handler);
+      };
+    },
+
+    onToolResult: (sessionId: string, callback: (data: { name: string; result: string }) => void) => {
+      const channel = `canvas-agent:tool-result:${sessionId}`;
+      const handler = (_event: Electron.IpcRendererEvent, data: { name: string; result: string }) =>
+        callback(data);
+      ipcRenderer.on(channel, handler);
+      return () => {
+        ipcRenderer.removeListener(channel, handler);
+      };
+    },
+
     getStatus: (workspaceId: string) =>
       ipcRenderer.invoke("canvas-agent:status", { workspaceId }),
 

--- a/apps/canvas-workspace/src/preload/index.ts
+++ b/apps/canvas-workspace/src/preload/index.ts
@@ -168,6 +168,15 @@ contextBridge.exposeInMainWorld("canvasWorkspace", {
     getHistory: (workspaceId: string) =>
       ipcRenderer.invoke("canvas-agent:history", { workspaceId }),
 
+    listSessions: (workspaceId: string) =>
+      ipcRenderer.invoke("canvas-agent:sessions", { workspaceId }),
+
+    newSession: (workspaceId: string) =>
+      ipcRenderer.invoke("canvas-agent:new-session", { workspaceId }),
+
+    loadSession: (workspaceId: string, sessionId: string) =>
+      ipcRenderer.invoke("canvas-agent:load-session", { workspaceId, sessionId }),
+
     activate: (workspaceId: string) =>
       ipcRenderer.invoke("canvas-agent:activate", { workspaceId }),
 

--- a/apps/canvas-workspace/src/renderer/src/App.css
+++ b/apps/canvas-workspace/src/renderer/src/App.css
@@ -25,8 +25,9 @@
   overflow: hidden;
   flex-shrink: 0;
   transition: width 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
 }
 
 .chat-panel-wrapper--open {
-  width: 380px;
+  width: 380px; /* fallback; overridden by inline style when resized */
 }

--- a/apps/canvas-workspace/src/renderer/src/App.css
+++ b/apps/canvas-workspace/src/renderer/src/App.css
@@ -19,3 +19,14 @@
   position: relative;
   overflow: hidden;
 }
+
+.chat-panel-wrapper {
+  width: 0;
+  overflow: hidden;
+  flex-shrink: 0;
+  transition: width 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.chat-panel-wrapper--open {
+  width: 380px;
+}

--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -1,12 +1,14 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 import './App.css';
 import { Canvas } from './components/Canvas';
+import { ChatPanel } from './components/ChatPanel';
 import { Sidebar } from './components/Sidebar';
 import { useWorkspaces } from './hooks/useWorkspaces';
 import type { CanvasNode } from './types';
 
 const App = () => {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(true);
+  const [chatPanelOpen, setChatPanelOpen] = useState(false);
   const [allNodes, setAllNodes] = useState<Record<string, CanvasNode[]>>({});
   const [focusNodeId, setFocusNodeId] = useState<string | undefined>();
   const [deleteNodeId, setDeleteNodeId] = useState<string | undefined>();
@@ -40,6 +42,18 @@ const App = () => {
     moveWorkspace,
     reorderFolder,
   } = useWorkspaces();
+
+  // Keyboard shortcut: Cmd/Ctrl+Shift+A to toggle chat panel
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'a') {
+        e.preventDefault();
+        setChatPanelOpen(prev => !prev);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
 
   return (
     <div className="app">
@@ -81,6 +95,12 @@ const App = () => {
             />
           ))}
         </div>
+        {chatPanelOpen && activeId && (
+          <ChatPanel
+            workspaceId={activeId}
+            onClose={() => setChatPanelOpen(false)}
+          />
+        )}
       </div>
     </div>
   );

--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useEffect } from 'react';
+import { useCallback, useState, useEffect, useRef } from 'react';
 import './App.css';
 import { Canvas } from './components/Canvas';
 import { ChatPanel } from './components/ChatPanel';
@@ -6,12 +6,18 @@ import { Sidebar } from './components/Sidebar';
 import { useWorkspaces } from './hooks/useWorkspaces';
 import type { CanvasNode } from './types';
 
+const DEFAULT_CHAT_WIDTH = 380;
+const MIN_CHAT_WIDTH = 280;
+const MAX_CHAT_WIDTH = 600;
+
 const App = () => {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(true);
   const [chatPanelOpen, setChatPanelOpen] = useState(false);
+  const [chatWidth, setChatWidth] = useState(DEFAULT_CHAT_WIDTH);
   const [allNodes, setAllNodes] = useState<Record<string, CanvasNode[]>>({});
   const [focusNodeId, setFocusNodeId] = useState<string | undefined>();
   const [deleteNodeId, setDeleteNodeId] = useState<string | undefined>();
+  const resizing = useRef(false);
 
   const handleNodesChange = useCallback((canvasId: string, nodes: CanvasNode[]) => {
     setAllNodes(prev => {
@@ -54,6 +60,32 @@ const App = () => {
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
   }, []);
+
+  const handleResizeStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    resizing.current = true;
+    const startX = e.clientX;
+    const startWidth = chatWidth;
+
+    const onMouseMove = (ev: MouseEvent) => {
+      const delta = startX - ev.clientX;
+      const newWidth = Math.min(MAX_CHAT_WIDTH, Math.max(MIN_CHAT_WIDTH, startWidth + delta));
+      setChatWidth(newWidth);
+    };
+
+    const onMouseUp = () => {
+      resizing.current = false;
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  }, [chatWidth]);
 
   return (
     <div className="app">
@@ -98,10 +130,14 @@ const App = () => {
           ))}
         </div>
         {activeId && (
-          <div className={`chat-panel-wrapper${chatPanelOpen ? ' chat-panel-wrapper--open' : ''}`}>
+          <div
+            className={`chat-panel-wrapper${chatPanelOpen ? ' chat-panel-wrapper--open' : ''}`}
+            style={chatPanelOpen ? { width: chatWidth } : undefined}
+          >
             <ChatPanel
               workspaceId={activeId}
               onClose={() => setChatPanelOpen(false)}
+              onResizeStart={handleResizeStart}
             />
           </div>
         )}

--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -97,11 +97,13 @@ const App = () => {
             />
           ))}
         </div>
-        {chatPanelOpen && activeId && (
-          <ChatPanel
-            workspaceId={activeId}
-            onClose={() => setChatPanelOpen(false)}
-          />
+        {activeId && (
+          <div className={`chat-panel-wrapper${chatPanelOpen ? ' chat-panel-wrapper--open' : ''}`}>
+            <ChatPanel
+              workspaceId={activeId}
+              onClose={() => setChatPanelOpen(false)}
+            />
+          </div>
         )}
       </div>
     </div>

--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -136,6 +136,8 @@ const App = () => {
           >
             <ChatPanel
               workspaceId={activeId}
+              nodes={allNodes[activeId] || []}
+              rootFolder={workspaces.find(w => w.id === activeId)?.rootFolder}
               onClose={() => setChatPanelOpen(false)}
               onResizeStart={handleResizeStart}
             />

--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -46,7 +46,7 @@ const App = () => {
   // Keyboard shortcut: Cmd/Ctrl+Shift+A to toggle chat panel
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'a') {
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'a') {
         e.preventDefault();
         setChatPanelOpen(prev => !prev);
       }
@@ -92,6 +92,8 @@ const App = () => {
               onFocusComplete={handleFocusComplete}
               deleteNodeId={ws.id === activeId ? deleteNodeId : undefined}
               onDeleteComplete={handleDeleteComplete}
+              chatPanelOpen={chatPanelOpen}
+              onChatToggle={() => setChatPanelOpen(prev => !prev)}
             />
           ))}
         </div>

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -15,7 +15,7 @@ import { ZoomIndicator } from '../ZoomIndicator';
 import { SearchPalette } from '../SearchPalette';
 import { CanvasEmptyHint } from '../CanvasEmptyHint';
 
-export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange, focusNodeId, onFocusComplete, deleteNodeId, onDeleteComplete }: { canvasId: string; canvasName?: string; rootFolder?: string; hidden?: boolean; onNodesChange?: (canvasId: string, nodes: CanvasNode[]) => void; focusNodeId?: string; onFocusComplete?: () => void; deleteNodeId?: string; onDeleteComplete?: () => void }) => {
+export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange, focusNodeId, onFocusComplete, deleteNodeId, onDeleteComplete, chatPanelOpen, onChatToggle }: { canvasId: string; canvasName?: string; rootFolder?: string; hidden?: boolean; onNodesChange?: (canvasId: string, nodes: CanvasNode[]) => void; focusNodeId?: string; onFocusComplete?: () => void; deleteNodeId?: string; onDeleteComplete?: () => void; chatPanelOpen?: boolean; onChatToggle?: () => void }) => {
   const [activeTool, setActiveTool] = useState('select');
   const [selectedNodeIds, setSelectedNodeIds] = useState<string[]>([]);
   const [clipboardNodes, setClipboardNodes] = useState<CanvasNode[]>([]);
@@ -306,6 +306,8 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
         activeTool={activeTool}
         onToolChange={setActiveTool}
         onAddNode={handleToolbarAddNode}
+        chatPanelOpen={chatPanelOpen}
+        onChatToggle={onChatToggle}
       />
 
       <ZoomIndicator scale={transform.scale} onReset={resetTransform} />

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
@@ -570,7 +570,7 @@
 }
 
 .chat-tool-calls--collapsed {
-  display: flex;
+  flex-direction: row;
   align-items: center;
   gap: 5px;
   padding: 3px 4px;

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
@@ -1,0 +1,175 @@
+.chat-panel {
+  width: 360px;
+  min-width: 280px;
+  max-width: 500px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+  border-left: 1px solid #e0e0e0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+.chat-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid #e0e0e0;
+  flex-shrink: 0;
+}
+
+.chat-panel-header h3 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: #333;
+}
+
+.chat-panel-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  color: #666;
+  font-size: 18px;
+  line-height: 1;
+}
+
+.chat-panel-close:hover {
+  background: #f0f0f0;
+  color: #333;
+}
+
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.chat-messages-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #999;
+  font-size: 13px;
+  text-align: center;
+  padding: 24px;
+}
+
+.chat-message {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.chat-message-user {
+  align-items: flex-end;
+}
+
+.chat-message-assistant {
+  align-items: flex-start;
+}
+
+.chat-message-bubble {
+  max-width: 85%;
+  padding: 8px 12px;
+  border-radius: 12px;
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.chat-message-user .chat-message-bubble {
+  background: #007aff;
+  color: #fff;
+  border-bottom-right-radius: 4px;
+}
+
+.chat-message-assistant .chat-message-bubble {
+  background: #f0f0f0;
+  color: #333;
+  border-bottom-left-radius: 4px;
+}
+
+.chat-input-area {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  padding: 12px 16px;
+  border-top: 1px solid #e0e0e0;
+  flex-shrink: 0;
+}
+
+.chat-input {
+  flex: 1;
+  resize: none;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 13px;
+  font-family: inherit;
+  line-height: 1.4;
+  max-height: 120px;
+  outline: none;
+  background: #fafafa;
+}
+
+.chat-input:focus {
+  border-color: #007aff;
+  background: #fff;
+}
+
+.chat-send-btn {
+  background: #007aff;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.chat-send-btn:hover:not(:disabled) {
+  background: #0066dd;
+}
+
+.chat-send-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.chat-loading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  color: #999;
+  font-size: 12px;
+}
+
+.chat-loading-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #999;
+  animation: chat-bounce 1.4s infinite both;
+}
+
+.chat-loading-dot:nth-child(1) { animation-delay: 0s; }
+.chat-loading-dot:nth-child(2) { animation-delay: 0.16s; }
+.chat-loading-dot:nth-child(3) { animation-delay: 0.32s; }
+
+@keyframes chat-bounce {
+  0%, 80%, 100% { transform: scale(0); }
+  40% { transform: scale(1); }
+}

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
@@ -564,17 +564,30 @@
 }
 
 .chat-tool-call {
-  display: flex;
-  align-items: center;
-  gap: 6px;
   font-size: 12px;
   line-height: 20px;
   color: rgba(55, 53, 47, 0.5);
-  padding: 2px 0;
+  padding: 1px 0;
 }
 
 .chat-tool-call--done {
   color: rgba(55, 53, 47, 0.45);
+}
+
+.chat-tool-call-header {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 1px 0;
+  border-radius: 4px;
+}
+
+.chat-tool-call-header[style*="cursor"] {
+  transition: background 0.1s;
+}
+
+.chat-tool-call-header[style*="cursor"]:hover {
+  background: rgba(55, 53, 47, 0.04);
 }
 
 .chat-tool-call-icon {
@@ -582,8 +595,8 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
 }
 
 .chat-tool-call-spinner {
@@ -594,26 +607,49 @@
   to { transform: rotate(360deg); }
 }
 
-.chat-tool-call-name {
+.chat-tool-call-sig {
   font-family: 'SF Mono', 'Fira Code', 'Fira Mono', Menlo, monospace;
   font-size: 11.5px;
-  font-weight: 500;
-  color: rgba(55, 53, 47, 0.65);
-  flex-shrink: 0;
-}
-
-.chat-tool-call--done .chat-tool-call-name {
-  color: rgba(55, 53, 47, 0.45);
-}
-
-.chat-tool-call-args {
-  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', Menlo, monospace;
-  font-size: 11px;
-  color: rgba(55, 53, 47, 0.35);
+  color: rgba(55, 53, 47, 0.55);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  max-width: 200px;
+}
+
+.chat-tool-call--done .chat-tool-call-sig {
+  color: rgba(55, 53, 47, 0.4);
+}
+
+.chat-tool-call-chevron {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  color: rgba(55, 53, 47, 0.3);
+  transition: transform 0.15s;
+}
+
+.chat-tool-call-chevron--open {
+  transform: rotate(180deg);
+}
+
+.chat-tool-call-result {
+  margin: 2px 0 4px 19px;
+  padding: 6px 8px;
+  background: rgba(55, 53, 47, 0.03);
+  border: 1px solid rgba(55, 53, 47, 0.06);
+  border-radius: 6px;
+  overflow: auto;
+  max-height: 200px;
+}
+
+.chat-tool-call-result pre {
+  margin: 0;
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', Menlo, monospace;
+  font-size: 11px;
+  line-height: 1.5;
+  color: rgba(55, 53, 47, 0.6);
+  white-space: pre-wrap;
+  word-break: break-all;
 }
 
 /* ─── @ Mention popup ────────────────────────────────────── */

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
@@ -351,6 +351,7 @@
 /* ─── Input area ───────────────────────────────────────────── */
 
 .chat-input-container {
+  position: relative;
   padding: 8px 12px 12px;
   flex-shrink: 0;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
@@ -569,6 +569,41 @@
   padding: 4px 0;
 }
 
+.chat-tool-calls--collapsed {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 4px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  color: rgba(55, 53, 47, 0.4);
+  transition: background 0.1s;
+}
+
+.chat-tool-calls--collapsed:hover {
+  background: rgba(55, 53, 47, 0.04);
+}
+
+.chat-tool-calls-summary {
+  font-size: 11.5px;
+  color: rgba(55, 53, 47, 0.4);
+}
+
+.chat-tool-calls-section-header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 4px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.chat-tool-calls-section-header:hover {
+  background: rgba(55, 53, 47, 0.04);
+}
+
 .chat-tool-call {
   font-size: 12px;
   line-height: 20px;

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
@@ -1,14 +1,15 @@
 /* ─── Panel container ─────────────────────────────────────── */
 
 .chat-panel {
-  width: 380px;
-  min-width: 380px;
+  width: 100%;
+  min-width: 0;
   height: 100%;
   display: flex;
   flex-direction: column;
   background: #fff;
   border-left: 1px solid rgba(0, 0, 0, 0.06);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  position: relative;
 }
 
 /* ─── Header ──────────────────────────────────────────────── */
@@ -285,4 +286,127 @@
 
 .chat-send-btn:disabled {
   cursor: not-allowed;
+}
+
+/* ─── Markdown content ────────────────────────────────────── */
+
+.chat-md {
+  white-space: normal;
+}
+
+.chat-md p {
+  margin: 0 0 8px;
+}
+
+.chat-md p:last-child {
+  margin-bottom: 0;
+}
+
+.chat-md h1,
+.chat-md h2,
+.chat-md h3,
+.chat-md h4 {
+  margin: 12px 0 4px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.chat-md h1 { font-size: 1.25em; }
+.chat-md h2 { font-size: 1.15em; }
+.chat-md h3 { font-size: 1.05em; }
+.chat-md h4 { font-size: 1em; }
+
+.chat-md ul,
+.chat-md ol {
+  margin: 4px 0 8px;
+  padding-left: 20px;
+}
+
+.chat-md li {
+  margin: 2px 0;
+}
+
+.chat-md code {
+  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+  font-size: 0.9em;
+  background: rgba(55, 53, 47, 0.06);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+.chat-md pre {
+  margin: 8px 0;
+  background: rgba(55, 53, 47, 0.04);
+  border-radius: 6px;
+  overflow-x: auto;
+  padding: 10px 12px;
+}
+
+.chat-md pre code {
+  background: none;
+  padding: 0;
+  font-size: 0.85em;
+  line-height: 1.5;
+}
+
+.chat-md blockquote {
+  margin: 8px 0;
+  padding: 2px 12px;
+  border-left: 3px solid rgba(55, 53, 47, 0.16);
+  color: #787774;
+}
+
+.chat-md hr {
+  border: none;
+  border-top: 1px solid rgba(55, 53, 47, 0.08);
+  margin: 12px 0;
+}
+
+.chat-md a {
+  color: #2eaadc;
+  text-decoration: none;
+}
+
+.chat-md a:hover {
+  text-decoration: underline;
+}
+
+.chat-md strong {
+  font-weight: 600;
+}
+
+.chat-md table {
+  border-collapse: collapse;
+  margin: 8px 0;
+  font-size: 0.9em;
+  width: 100%;
+}
+
+.chat-md th,
+.chat-md td {
+  border: 1px solid rgba(55, 53, 47, 0.12);
+  padding: 4px 8px;
+  text-align: left;
+}
+
+.chat-md th {
+  background: rgba(55, 53, 47, 0.04);
+  font-weight: 600;
+}
+
+/* ─── Resize handle ──────────────────────────────────────── */
+
+.chat-panel-resize {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 4px;
+  height: 100%;
+  cursor: col-resize;
+  z-index: 10;
+}
+
+.chat-panel-resize:hover,
+.chat-panel-resize--active {
+  background: rgba(55, 53, 47, 0.12);
 }

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
@@ -551,11 +551,16 @@
 
 /* ─── Tool call indicators ───────────────────────────────── */
 
+.chat-message-body {
+  flex: 1;
+  min-width: 0;
+}
+
 .chat-tool-calls {
   display: flex;
   flex-direction: column;
   gap: 2px;
-  padding: 4px 16px 4px 40px;
+  padding: 4px 0;
 }
 
 .chat-tool-call {

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
@@ -183,6 +183,23 @@
   padding: 2px 0;
 }
 
+/* Blinking cursor while streaming */
+.chat-md--streaming::after {
+  content: '';
+  display: inline-block;
+  width: 2px;
+  height: 1em;
+  background: #37352f;
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  animation: chat-cursor-blink 0.8s steps(2) infinite;
+}
+
+@keyframes chat-cursor-blink {
+  0% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
 /* ─── Loading ──────────────────────────────────────────────── */
 
 .chat-loading {

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
@@ -294,11 +294,17 @@
   max-width: 85%;
 }
 
+.chat-message-user .chat-message-body {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .chat-message-user .chat-message-content {
   background: rgba(55, 53, 47, 0.06);
   padding: 8px 12px;
   border-radius: 12px;
   border-bottom-right-radius: 4px;
+  max-width: 85%;
 }
 
 .chat-message-assistant .chat-message-content {

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
@@ -1,46 +1,135 @@
+/* ─── Panel container ─────────────────────────────────────── */
+
 .chat-panel {
-  width: 360px;
-  min-width: 280px;
+  width: 380px;
+  min-width: 300px;
   max-width: 500px;
   height: 100%;
   display: flex;
   flex-direction: column;
   background: #fff;
-  border-left: 1px solid #e0e0e0;
+  border-left: 1px solid rgba(0, 0, 0, 0.06);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
+
+/* ─── Header ──────────────────────────────────────────────── */
 
 .chat-panel-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 16px;
-  border-bottom: 1px solid #e0e0e0;
+  padding: 10px 12px;
+  flex-shrink: 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.04);
+}
+
+.chat-panel-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #37352f;
+}
+
+.chat-panel-title svg {
+  color: #9b9a97;
+}
+
+.chat-panel-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.chat-panel-action-btn {
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #9b9a97;
+  transition: background 0.1s, color 0.1s;
+}
+
+.chat-panel-action-btn:hover {
+  background: rgba(55, 53, 47, 0.08);
+  color: #37352f;
+}
+
+/* ─── Empty state ──────────────────────────────────────────── */
+
+.chat-empty-state {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 24px;
+  gap: 0;
+}
+
+.chat-empty-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: rgba(55, 53, 47, 0.04);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #9b9a97;
+  margin-bottom: 12px;
+}
+
+.chat-empty-greeting {
+  font-size: 16px;
+  font-weight: 500;
+  color: #37352f;
+  margin-bottom: 20px;
+}
+
+.chat-quick-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 100%;
+  max-width: 280px;
+}
+
+.chat-quick-action {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border: none;
+  background: transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  color: #37352f;
+  text-align: left;
+  transition: background 0.1s;
+}
+
+.chat-quick-action:hover {
+  background: rgba(55, 53, 47, 0.04);
+}
+
+.chat-quick-action-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  color: #9b9a97;
   flex-shrink: 0;
 }
 
-.chat-panel-header h3 {
-  margin: 0;
-  font-size: 14px;
-  font-weight: 600;
-  color: #333;
-}
-
-.chat-panel-close {
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 4px;
-  border-radius: 4px;
-  color: #666;
-  font-size: 18px;
-  line-height: 1;
-}
-
-.chat-panel-close:hover {
-  background: #f0f0f0;
-  color: #333;
-}
+/* ─── Messages ─────────────────────────────────────────────── */
 
 .chat-messages {
   flex: 1;
@@ -48,120 +137,66 @@
   padding: 16px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
-}
-
-.chat-messages-empty {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #999;
-  font-size: 13px;
-  text-align: center;
-  padding: 24px;
+  gap: 16px;
 }
 
 .chat-message {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.chat-message-user {
-  align-items: flex-end;
-}
-
-.chat-message-assistant {
+  gap: 8px;
   align-items: flex-start;
 }
 
-.chat-message-bubble {
-  max-width: 85%;
-  padding: 8px 12px;
-  border-radius: 12px;
-  font-size: 13px;
-  line-height: 1.5;
-  white-space: pre-wrap;
-  word-break: break-word;
+.chat-message-user {
+  flex-direction: row-reverse;
 }
 
-.chat-message-user .chat-message-bubble {
-  background: #007aff;
-  color: #fff;
+.chat-message-avatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: rgba(55, 53, 47, 0.06);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #9b9a97;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.chat-message-content {
+  font-size: 14px;
+  line-height: 1.6;
+  color: #37352f;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-width: 85%;
+}
+
+.chat-message-user .chat-message-content {
+  background: rgba(55, 53, 47, 0.06);
+  padding: 8px 12px;
+  border-radius: 12px;
   border-bottom-right-radius: 4px;
 }
 
-.chat-message-assistant .chat-message-bubble {
-  background: #f0f0f0;
-  color: #333;
-  border-bottom-left-radius: 4px;
+.chat-message-assistant .chat-message-content {
+  padding: 2px 0;
 }
 
-.chat-input-area {
-  display: flex;
-  align-items: flex-end;
-  gap: 8px;
-  padding: 12px 16px;
-  border-top: 1px solid #e0e0e0;
-  flex-shrink: 0;
-}
-
-.chat-input {
-  flex: 1;
-  resize: none;
-  border: 1px solid #ddd;
-  border-radius: 8px;
-  padding: 8px 12px;
-  font-size: 13px;
-  font-family: inherit;
-  line-height: 1.4;
-  max-height: 120px;
-  outline: none;
-  background: #fafafa;
-}
-
-.chat-input:focus {
-  border-color: #007aff;
-  background: #fff;
-}
-
-.chat-send-btn {
-  background: #007aff;
-  color: #fff;
-  border: none;
-  border-radius: 8px;
-  padding: 8px 14px;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  flex-shrink: 0;
-  white-space: nowrap;
-}
-
-.chat-send-btn:hover:not(:disabled) {
-  background: #0066dd;
-}
-
-.chat-send-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
+/* ─── Loading ──────────────────────────────────────────────── */
 
 .chat-loading {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
-  color: #999;
-  font-size: 12px;
+  gap: 4px;
+  padding: 6px 0;
 }
 
 .chat-loading-dot {
-  width: 6px;
-  height: 6px;
+  width: 5px;
+  height: 5px;
   border-radius: 50%;
-  background: #999;
+  background: #9b9a97;
   animation: chat-bounce 1.4s infinite both;
 }
 
@@ -172,4 +207,83 @@
 @keyframes chat-bounce {
   0%, 80%, 100% { transform: scale(0); }
   40% { transform: scale(1); }
+}
+
+/* ─── Input area ───────────────────────────────────────────── */
+
+.chat-input-container {
+  padding: 8px 12px 12px;
+  flex-shrink: 0;
+}
+
+.chat-input-box {
+  border: 1px solid rgba(55, 53, 47, 0.16);
+  border-radius: 10px;
+  background: #fff;
+  overflow: hidden;
+  transition: border-color 0.15s;
+}
+
+.chat-input-box:focus-within {
+  border-color: rgba(55, 53, 47, 0.4);
+}
+
+.chat-input {
+  display: block;
+  width: 100%;
+  resize: none;
+  border: none;
+  padding: 10px 12px 4px;
+  font-size: 14px;
+  font-family: inherit;
+  line-height: 1.5;
+  max-height: 120px;
+  outline: none;
+  background: transparent;
+  color: #37352f;
+  box-sizing: border-box;
+}
+
+.chat-input::placeholder {
+  color: #b4b4b0;
+}
+
+.chat-input-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 6px 6px;
+}
+
+.chat-input-footer-left {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.chat-send-btn {
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(55, 53, 47, 0.06);
+  color: #b4b4b0;
+  transition: background 0.1s, color 0.1s;
+}
+
+.chat-send-btn--active {
+  background: #37352f;
+  color: #fff;
+}
+
+.chat-send-btn--active:hover {
+  background: #2f2e2a;
+}
+
+.chat-send-btn:disabled {
+  cursor: not-allowed;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
@@ -549,3 +549,131 @@
 .chat-panel-resize--active {
   background: rgba(55, 53, 47, 0.12);
 }
+
+/* ─── Tool call indicators ───────────────────────────────── */
+
+.chat-tool-calls {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 4px 16px 4px 40px;
+}
+
+.chat-tool-call {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  line-height: 20px;
+  color: rgba(55, 53, 47, 0.5);
+  padding: 2px 0;
+}
+
+.chat-tool-call--done {
+  color: rgba(55, 53, 47, 0.45);
+}
+
+.chat-tool-call-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+}
+
+.chat-tool-call-spinner {
+  animation: tool-call-spin 0.8s linear infinite;
+}
+
+@keyframes tool-call-spin {
+  to { transform: rotate(360deg); }
+}
+
+.chat-tool-call-name {
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', Menlo, monospace;
+  font-size: 11.5px;
+  font-weight: 500;
+  color: rgba(55, 53, 47, 0.65);
+  flex-shrink: 0;
+}
+
+.chat-tool-call--done .chat-tool-call-name {
+  color: rgba(55, 53, 47, 0.45);
+}
+
+.chat-tool-call-args {
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', Menlo, monospace;
+  font-size: 11px;
+  color: rgba(55, 53, 47, 0.35);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 200px;
+}
+
+/* ─── @ Mention popup ────────────────────────────────────── */
+
+.chat-mention-popup {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  right: 0;
+  margin-bottom: 4px;
+  background: #fff;
+  border: 1px solid rgba(55, 53, 47, 0.09);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(15, 15, 15, 0.1), 0 0 0 1px rgba(15, 15, 15, 0.04);
+  max-height: 240px;
+  overflow-y: auto;
+  padding: 4px;
+  z-index: 20;
+}
+
+.chat-mention-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 8px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  cursor: pointer;
+  font-size: 13px;
+  color: rgb(55, 53, 47);
+  text-align: left;
+  line-height: 1.4;
+}
+
+.chat-mention-item:hover,
+.chat-mention-item--active {
+  background: rgba(55, 53, 47, 0.06);
+}
+
+.chat-mention-item-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  background: rgba(55, 53, 47, 0.06);
+  color: rgba(55, 53, 47, 0.5);
+}
+
+.chat-mention-item-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.chat-mention-item-type {
+  flex-shrink: 0;
+  font-size: 11px;
+  color: rgba(55, 53, 47, 0.35);
+  text-transform: capitalize;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
@@ -23,23 +23,145 @@
   border-bottom: 1px solid rgba(0, 0, 0, 0.04);
 }
 
-.chat-panel-title {
+.chat-panel-title-wrapper {
+  position: relative;
+}
+
+.chat-panel-title-btn {
   display: flex;
   align-items: center;
   gap: 6px;
   font-size: 14px;
   font-weight: 500;
   color: #37352f;
+  border: none;
+  background: transparent;
+  border-radius: 4px;
+  padding: 4px 6px;
+  cursor: pointer;
+  transition: background 0.1s;
 }
 
-.chat-panel-title svg {
+.chat-panel-title-btn:hover {
+  background: rgba(55, 53, 47, 0.06);
+}
+
+.chat-panel-title-btn svg {
   color: #9b9a97;
+}
+
+.chat-panel-title-chevron {
+  color: #b4b4b0 !important;
+  margin-left: -2px;
 }
 
 .chat-panel-actions {
   display: flex;
   align-items: center;
   gap: 2px;
+}
+
+/* ─── Session menu ────────────────────────────────────────── */
+
+.chat-session-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 100;
+  min-width: 220px;
+  max-width: 280px;
+  background: #fff;
+  border: 1px solid rgba(55, 53, 47, 0.09);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08), 0 0 0 1px rgba(0, 0, 0, 0.02);
+  padding: 4px;
+  animation: chat-menu-in 0.12s ease-out;
+}
+
+@keyframes chat-menu-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.chat-session-menu-new {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 10px;
+  border: none;
+  background: transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 13px;
+  color: #37352f;
+  transition: background 0.1s;
+}
+
+.chat-session-menu-new:hover {
+  background: rgba(55, 53, 47, 0.06);
+}
+
+.chat-session-menu-divider {
+  height: 1px;
+  background: rgba(55, 53, 47, 0.06);
+  margin: 4px 0;
+}
+
+.chat-session-menu-label {
+  font-size: 11px;
+  font-weight: 500;
+  color: #9b9a97;
+  padding: 4px 10px 2px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.chat-session-menu-list {
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.chat-session-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 5px 10px;
+  border: none;
+  background: transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 13px;
+  color: #37352f;
+  transition: background 0.1s;
+  text-align: left;
+}
+
+.chat-session-menu-item:hover {
+  background: rgba(55, 53, 47, 0.06);
+}
+
+.chat-session-menu-item--active {
+  background: rgba(55, 53, 47, 0.04);
+}
+
+.chat-session-menu-item svg {
+  color: #9b9a97;
+  flex-shrink: 0;
+}
+
+.chat-session-menu-item-text {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-session-menu-item-count {
+  font-size: 11px;
+  color: #b4b4b0;
+  flex-shrink: 0;
 }
 
 .chat-panel-action-btn {

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
@@ -2,8 +2,7 @@
 
 .chat-panel {
   width: 380px;
-  min-width: 300px;
-  max-width: 500px;
+  min-width: 380px;
   height: 100%;
   display: flex;
   flex-direction: column;

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
@@ -307,19 +307,17 @@
 
 /* Blinking cursor while streaming */
 .chat-md--streaming::after {
-  content: '';
+  content: ' ...';
   display: inline-block;
-  width: 2px;
-  height: 1em;
-  background: #37352f;
-  margin-left: 2px;
-  vertical-align: text-bottom;
-  animation: chat-cursor-blink 0.8s steps(2) infinite;
+  width: 0;
+  overflow: hidden;
+  vertical-align: bottom;
+  color: rgba(55, 53, 47, 0.35);
+  animation: chat-dots 1.4s steps(4, end) infinite;
 }
 
-@keyframes chat-cursor-blink {
-  0% { opacity: 1; }
-  100% { opacity: 0; }
+@keyframes chat-dots {
+  to { width: 1.5em; }
 }
 
 /* ─── Loading ──────────────────────────────────────────────── */

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
@@ -12,9 +12,11 @@ interface ChatPanelProps {
 }
 
 interface ToolCallStatus {
+  id: number;
   name: string;
   args?: any;
   status: 'running' | 'done';
+  result?: string;
 }
 
 interface MentionItem {
@@ -24,17 +26,33 @@ interface MentionItem {
   path?: string;
 }
 
-function formatToolArgs(name: string, args: any): string {
-  if (!args) return '';
-  if (name === 'read' || name === 'write' || name === 'edit') return args.file_path || args.filePath || '';
-  if (name === 'bash') return args.command ? args.command.slice(0, 60) : '';
-  if (name === 'grep') return args.pattern || '';
-  if (name === 'ls') return args.path || '';
-  if (name === 'canvas_read_node') return args.nodeId || '';
-  if (name === 'canvas_create_node') return args.type || '';
-  if (name === 'canvas_update_node') return args.nodeId || '';
-  if (name === 'canvas_delete_node') return args.nodeId || '';
-  return '';
+function truncStr(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max - 3) + '...' : s;
+}
+
+function formatToolSignature(name: string, args: any): string {
+  if (!args) return `${name}()`;
+  const parts: string[] = [];
+  if (name === 'read' || name === 'write') {
+    if (args.file_path || args.filePath) parts.push(JSON.stringify(args.file_path || args.filePath));
+  } else if (name === 'edit') {
+    if (args.file_path || args.filePath) parts.push(JSON.stringify(args.file_path || args.filePath));
+    if (args.old_string) parts.push(JSON.stringify(truncStr(args.old_string, 30)));
+  } else if (name === 'bash') {
+    if (args.command) parts.push(JSON.stringify(truncStr(args.command, 60)));
+  } else if (name === 'grep') {
+    if (args.pattern) parts.push(JSON.stringify(args.pattern));
+    if (args.path) parts.push(JSON.stringify(args.path));
+  } else if (name === 'ls') {
+    if (args.path) parts.push(JSON.stringify(args.path));
+  } else {
+    for (const v of Object.values(args)) {
+      if (parts.length >= 3) break;
+      if (typeof v === 'string') parts.push(JSON.stringify(truncStr(v, 40)));
+      else if (typeof v === 'number') parts.push(String(v));
+    }
+  }
+  return `${name}(${parts.join(', ')})`;
 }
 
 const QUICK_ACTIONS = [
@@ -88,6 +106,8 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
   const [sessionMenuOpen, setSessionMenuOpen] = useState(false);
   const [sessions, setSessions] = useState<AgentSessionInfo[]>([]);
   const [streamingTools, setStreamingTools] = useState<ToolCallStatus[]>([]);
+  const [expandedTools, setExpandedTools] = useState<Set<number>>(new Set());
+  const toolIdCounter = useRef(0);
 
   // @ mention state
   const [mentionOpen, setMentionOpen] = useState(false);
@@ -263,13 +283,16 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
 
       // Subscribe to tool call events
       const unsubToolCall = window.canvasWorkspace.agent.onToolCall(sessionId, (data) => {
-        toolCalls.push({ name: data.name, args: data.args, status: 'running' });
+        toolCalls.push({ id: ++toolIdCounter.current, name: data.name, args: data.args, status: 'running' });
         setStreamingTools([...toolCalls]);
       });
 
       const unsubToolResult = window.canvasWorkspace.agent.onToolResult(sessionId, (data) => {
         const tc = toolCalls.find(t => t.name === data.name && t.status === 'running');
-        if (tc) tc.status = 'done';
+        if (tc) {
+          tc.status = 'done';
+          tc.result = data.result;
+        }
         setStreamingTools([...toolCalls]);
       });
 
@@ -296,6 +319,7 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
         unsubToolCall();
         unsubToolResult();
         setStreamingTools([]);
+        setExpandedTools(new Set());
 
         if (!completeResult.ok) {
           setMessages(prev => {
@@ -372,6 +396,54 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
       void sendMessage();
     }
   }, [sendMessage, mentionOpen, mentionItems, mentionIndex, selectMention]);
+
+  const toggleToolExpand = useCallback((id: number) => {
+    setExpandedTools(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const renderToolCalls = (tools: ToolCallStatus[]) => (
+    <div className="chat-tool-calls">
+      {tools.map((tc) => (
+        <div key={tc.id} className={`chat-tool-call chat-tool-call--${tc.status}`}>
+          <div
+            className="chat-tool-call-header"
+            onClick={tc.status === 'done' && tc.result ? () => toggleToolExpand(tc.id) : undefined}
+            style={tc.status === 'done' && tc.result ? { cursor: 'pointer' } : undefined}
+          >
+            <span className="chat-tool-call-icon">
+              {tc.status === 'running' ? (
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none" className="chat-tool-call-spinner">
+                  <circle cx="6" cy="6" r="4.5" stroke="currentColor" strokeWidth="1.2" strokeDasharray="14 14" strokeLinecap="round" />
+                </svg>
+              ) : (
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                  <path d="M3 6l2 2 4-4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              )}
+            </span>
+            <span className="chat-tool-call-sig">{formatToolSignature(tc.name, tc.args)}</span>
+            {tc.status === 'done' && tc.result && (
+              <span className={`chat-tool-call-chevron${expandedTools.has(tc.id) ? ' chat-tool-call-chevron--open' : ''}`}>
+                <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+                  <path d="M3 4l2 2 2-2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              </span>
+            )}
+          </div>
+          {expandedTools.has(tc.id) && tc.result && (
+            <div className="chat-tool-call-result">
+              <pre>{tc.result.length > 2000 ? tc.result.slice(0, 2000) + '\n...(truncated)' : tc.result}</pre>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
 
   const handleQuickAction = useCallback((prompt: string) => {
     if (prompt) {
@@ -495,29 +567,7 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
                   </div>
                 )}
                 <div className="chat-message-body">
-                  {isStreaming && streamingTools.length > 0 && (
-                    <div className="chat-tool-calls">
-                      {streamingTools.map((tc, idx) => (
-                        <div key={idx} className={`chat-tool-call chat-tool-call--${tc.status}`}>
-                          <span className="chat-tool-call-icon">
-                            {tc.status === 'running' ? (
-                              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" className="chat-tool-call-spinner">
-                                <circle cx="6" cy="6" r="4.5" stroke="currentColor" strokeWidth="1.2" strokeDasharray="14 14" strokeLinecap="round" />
-                              </svg>
-                            ) : (
-                              <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-                                <path d="M3 6l2 2 4-4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
-                              </svg>
-                            )}
-                          </span>
-                          <span className="chat-tool-call-name">{tc.name}</span>
-                          {formatToolArgs(tc.name, tc.args) && (
-                            <span className="chat-tool-call-args">{formatToolArgs(tc.name, tc.args)}</span>
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                  )}
+                  {isStreaming && streamingTools.length > 0 && renderToolCalls(streamingTools)}
                   {msg.role === 'assistant' ? (
                     isStreaming ? (
                       <div className="chat-message-content chat-md chat-md--streaming">
@@ -545,29 +595,7 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
                 </svg>
               </div>
               <div className="chat-message-body">
-                {streamingTools.length > 0 ? (
-                  <div className="chat-tool-calls">
-                    {streamingTools.map((tc, idx) => (
-                      <div key={idx} className={`chat-tool-call chat-tool-call--${tc.status}`}>
-                        <span className="chat-tool-call-icon">
-                          {tc.status === 'running' ? (
-                            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" className="chat-tool-call-spinner">
-                              <circle cx="6" cy="6" r="4.5" stroke="currentColor" strokeWidth="1.2" strokeDasharray="14 14" strokeLinecap="round" />
-                            </svg>
-                          ) : (
-                            <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-                              <path d="M3 6l2 2 4-4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
-                            </svg>
-                          )}
-                        </span>
-                        <span className="chat-tool-call-name">{tc.name}</span>
-                        {formatToolArgs(tc.name, tc.args) && (
-                          <span className="chat-tool-call-args">{formatToolArgs(tc.name, tc.args)}</span>
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                ) : (
+                {streamingTools.length > 0 ? renderToolCalls(streamingTools) : (
                   <div className="chat-loading">
                     <div className="chat-loading-dot" />
                     <div className="chat-loading-dot" />

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
@@ -98,21 +98,67 @@ export const ChatPanel = ({ workspaceId, onClose }: ChatPanelProps) => {
 
     try {
       const result = await window.canvasWorkspace.agent.chat(workspaceId, text);
-      if (result.ok && result.response) {
-        const assistantMsg: AgentChatMessage = {
-          role: 'assistant',
-          content: result.response,
-          timestamp: Date.now(),
-        };
-        setMessages(prev => [...prev, assistantMsg]);
-      } else {
+      if (!result.ok || !result.sessionId) {
         const errorMsg: AgentChatMessage = {
           role: 'assistant',
-          content: `Error: ${result.error ?? 'Unknown error'}`,
+          content: `Error: ${result.error ?? 'Failed to start chat'}`,
           timestamp: Date.now(),
         };
         setMessages(prev => [...prev, errorMsg]);
+        setLoading(false);
+        return;
       }
+
+      const sessionId = result.sessionId;
+
+      // Add a placeholder assistant message for streaming
+      const placeholderIdx = { current: -1 };
+      setMessages(prev => {
+        placeholderIdx.current = prev.length;
+        return [...prev, { role: 'assistant' as const, content: '', timestamp: Date.now() }];
+      });
+
+      // Subscribe to text deltas
+      const unsubDelta = window.canvasWorkspace.agent.onTextDelta(sessionId, (delta) => {
+        setMessages(prev => {
+          const idx = placeholderIdx.current;
+          if (idx < 0 || idx >= prev.length) return prev;
+          const updated = [...prev];
+          updated[idx] = { ...updated[idx], content: updated[idx].content + delta };
+          return updated;
+        });
+      });
+
+      // Subscribe to completion
+      const unsubComplete = window.canvasWorkspace.agent.onChatComplete(sessionId, (completeResult) => {
+        unsubDelta();
+        unsubComplete();
+
+        if (!completeResult.ok) {
+          setMessages(prev => {
+            const idx = placeholderIdx.current;
+            if (idx < 0 || idx >= prev.length) return prev;
+            const updated = [...prev];
+            const existing = updated[idx].content;
+            updated[idx] = {
+              ...updated[idx],
+              content: existing || `Error: ${completeResult.error ?? 'Unknown error'}`,
+            };
+            return updated;
+          });
+        } else if (completeResult.response) {
+          // Replace with final complete text for accuracy
+          setMessages(prev => {
+            const idx = placeholderIdx.current;
+            if (idx < 0 || idx >= prev.length) return prev;
+            const updated = [...prev];
+            updated[idx] = { ...updated[idx], content: completeResult.response! };
+            return updated;
+          });
+        }
+
+        setLoading(false);
+      });
     } catch (err) {
       const errorMsg: AgentChatMessage = {
         role: 'assistant',
@@ -120,7 +166,6 @@ export const ChatPanel = ({ workspaceId, onClose }: ChatPanelProps) => {
         timestamp: Date.now(),
       };
       setMessages(prev => [...prev, errorMsg]);
-    } finally {
       setLoading(false);
     }
   }, [input, loading, workspaceId]);

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
@@ -107,7 +107,11 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
   const [sessions, setSessions] = useState<AgentSessionInfo[]>([]);
   const [streamingTools, setStreamingTools] = useState<ToolCallStatus[]>([]);
   const [expandedTools, setExpandedTools] = useState<Set<number>>(new Set());
+  // Persist tool calls per message (msgIndex → tools). Not stored in message data.
+  const [messageTools, setMessageTools] = useState<Map<number, ToolCallStatus[]>>(new Map());
+  const [collapsedSections, setCollapsedSections] = useState<Set<number>>(new Set());
   const toolIdCounter = useRef(0);
+  const streamingMsgIdx = useRef(-1);
 
   // @ mention state
   const [mentionOpen, setMentionOpen] = useState(false);
@@ -161,6 +165,8 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
     setSessionMenuOpen(false);
     await window.canvasWorkspace.agent.newSession(workspaceId);
     setMessages([]);
+    setMessageTools(new Map());
+    setCollapsedSections(new Set());
   }, [workspaceId]);
 
   const handleLoadSession = useCallback(async (sessionId: string) => {
@@ -169,6 +175,8 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
     if (result.ok && result.messages) {
       setMessages(result.messages);
     }
+    setMessageTools(new Map());
+    setCollapsedSections(new Set());
   }, [workspaceId]);
 
   // Scroll to bottom when messages or streaming tools change
@@ -286,6 +294,7 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
         setMessages(prev => {
           if (assistantIdx.current >= 0) return prev;
           assistantIdx.current = prev.length;
+          streamingMsgIdx.current = prev.length;
           return [...prev, { role: 'assistant' as const, content: '', timestamp: Date.now() }];
         });
       };
@@ -294,7 +303,12 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
       const unsubToolCall = window.canvasWorkspace.agent.onToolCall(sessionId, (data) => {
         ensureAssistantMessage();
         toolCalls.push({ id: ++toolIdCounter.current, name: data.name, args: data.args, status: 'running' });
-        setStreamingTools([...toolCalls]);
+        const snapshot = [...toolCalls];
+        setStreamingTools(snapshot);
+        // Persist to messageTools
+        if (assistantIdx.current >= 0) {
+          setMessageTools(prev => new Map(prev).set(assistantIdx.current, snapshot));
+        }
       });
 
       const unsubToolResult = window.canvasWorkspace.agent.onToolResult(sessionId, (data) => {
@@ -303,7 +317,11 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
           tc.status = 'done';
           tc.result = data.result;
         }
-        setStreamingTools([...toolCalls]);
+        const snapshot = [...toolCalls];
+        setStreamingTools(snapshot);
+        if (assistantIdx.current >= 0) {
+          setMessageTools(prev => new Map(prev).set(assistantIdx.current, snapshot));
+        }
       });
 
       // Subscribe to text deltas
@@ -324,8 +342,13 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
         unsubComplete();
         unsubToolCall();
         unsubToolResult();
+        // Collapse the tool section (don't clear — keep in messageTools)
+        if (assistantIdx.current >= 0 && toolCalls.length > 0) {
+          setCollapsedSections(prev => new Set(prev).add(assistantIdx.current));
+        }
         setStreamingTools([]);
         setExpandedTools(new Set());
+        streamingMsgIdx.current = -1;
 
         if (!completeResult.ok) {
           setMessages(prev => {
@@ -412,44 +435,82 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
     });
   }, []);
 
-  const renderToolCalls = (tools: ToolCallStatus[]) => (
-    <div className="chat-tool-calls">
-      {tools.map((tc) => (
-        <div key={tc.id} className={`chat-tool-call chat-tool-call--${tc.status}`}>
-          <div
-            className="chat-tool-call-header"
-            onClick={tc.status === 'done' && tc.result ? () => toggleToolExpand(tc.id) : undefined}
-            style={tc.status === 'done' && tc.result ? { cursor: 'pointer' } : undefined}
-          >
-            <span className="chat-tool-call-icon">
-              {tc.status === 'running' ? (
-                <svg width="12" height="12" viewBox="0 0 12 12" fill="none" className="chat-tool-call-spinner">
-                  <circle cx="6" cy="6" r="4.5" stroke="currentColor" strokeWidth="1.2" strokeDasharray="14 14" strokeLinecap="round" />
-                </svg>
-              ) : (
-                <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-                  <path d="M3 6l2 2 4-4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
-              )}
+  const toggleSection = useCallback((msgIdx: number) => {
+    setCollapsedSections(prev => {
+      const next = new Set(prev);
+      if (next.has(msgIdx)) next.delete(msgIdx);
+      else next.add(msgIdx);
+      return next;
+    });
+  }, []);
+
+  const renderToolCalls = (tools: ToolCallStatus[], msgIdx: number, collapsed: boolean) => {
+    if (collapsed) {
+      return (
+        <div className="chat-tool-calls chat-tool-calls--collapsed" onClick={() => toggleSection(msgIdx)}>
+          <span className="chat-tool-call-icon">
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+              <path d="M3 6l2 2 4-4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </span>
+          <span className="chat-tool-calls-summary">{tools.length} tool call{tools.length > 1 ? 's' : ''}</span>
+          <span className="chat-tool-call-chevron">
+            <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+              <path d="M3 4l2 2 2-2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </span>
+        </div>
+      );
+    }
+    return (
+      <div className="chat-tool-calls">
+        {!loading && tools.length > 0 && (
+          <div className="chat-tool-calls-section-header" onClick={() => toggleSection(msgIdx)}>
+            <span className="chat-tool-calls-summary">{tools.length} tool call{tools.length > 1 ? 's' : ''}</span>
+            <span className="chat-tool-call-chevron chat-tool-call-chevron--open">
+              <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+                <path d="M3 4l2 2 2-2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
             </span>
-            <span className="chat-tool-call-sig">{formatToolSignature(tc.name, tc.args)}</span>
-            {tc.status === 'done' && tc.result && (
-              <span className={`chat-tool-call-chevron${expandedTools.has(tc.id) ? ' chat-tool-call-chevron--open' : ''}`}>
-                <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
-                  <path d="M3 4l2 2 2-2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
+          </div>
+        )}
+        {tools.map((tc) => (
+          <div key={tc.id} className={`chat-tool-call chat-tool-call--${tc.status}`}>
+            <div
+              className="chat-tool-call-header"
+              onClick={tc.status === 'done' && tc.result ? () => toggleToolExpand(tc.id) : undefined}
+              style={tc.status === 'done' && tc.result ? { cursor: 'pointer' } : undefined}
+            >
+              <span className="chat-tool-call-icon">
+                {tc.status === 'running' ? (
+                  <svg width="12" height="12" viewBox="0 0 12 12" fill="none" className="chat-tool-call-spinner">
+                    <circle cx="6" cy="6" r="4.5" stroke="currentColor" strokeWidth="1.2" strokeDasharray="14 14" strokeLinecap="round" />
+                  </svg>
+                ) : (
+                  <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                    <path d="M3 6l2 2 4-4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                )}
               </span>
+              <span className="chat-tool-call-sig">{formatToolSignature(tc.name, tc.args)}</span>
+              {tc.status === 'done' && tc.result && (
+                <span className={`chat-tool-call-chevron${expandedTools.has(tc.id) ? ' chat-tool-call-chevron--open' : ''}`}>
+                  <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+                    <path d="M3 4l2 2 2-2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </span>
+              )}
+            </div>
+            {expandedTools.has(tc.id) && tc.result && (
+              <div className="chat-tool-call-result">
+                <pre>{tc.result.length > 2000 ? tc.result.slice(0, 2000) + '\n...(truncated)' : tc.result}</pre>
+              </div>
             )}
           </div>
-          {expandedTools.has(tc.id) && tc.result && (
-            <div className="chat-tool-call-result">
-              <pre>{tc.result.length > 2000 ? tc.result.slice(0, 2000) + '\n...(truncated)' : tc.result}</pre>
-            </div>
-          )}
-        </div>
-      ))}
-    </div>
-  );
+        ))}
+      </div>
+    );
+  };
 
   const handleQuickAction = useCallback((prompt: string) => {
     if (prompt) {
@@ -562,6 +623,8 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
         <div className="chat-messages">
           {messages.map((msg, i) => {
             const isStreaming = loading && msg.role === 'assistant' && i === messages.length - 1;
+            const tools = isStreaming ? streamingTools : messageTools.get(i);
+            const isCollapsed = collapsedSections.has(i);
             return (
               <div key={i} className={`chat-message chat-message-${msg.role}`}>
                 {msg.role === 'assistant' && (
@@ -573,7 +636,7 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
                   </div>
                 )}
                 <div className="chat-message-body">
-                  {isStreaming && streamingTools.length > 0 && renderToolCalls(streamingTools)}
+                  {msg.role === 'assistant' && tools && tools.length > 0 && renderToolCalls(tools, i, isCollapsed)}
                   {msg.role === 'assistant' ? (
                     isStreaming ? (
                       msg.content ? (
@@ -581,7 +644,7 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
                           className="chat-message-content chat-md chat-md--streaming"
                           dangerouslySetInnerHTML={{ __html: md.render(msg.content) }}
                         />
-                      ) : streamingTools.length === 0 ? (
+                      ) : (!tools || tools.length === 0) ? (
                         <div className="chat-loading">
                           <div className="chat-loading-dot" />
                           <div className="chat-loading-dot" />

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
@@ -277,12 +277,22 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
 
       const sessionId = result.sessionId;
 
-      // Lazily create assistant message on first text delta
+      // Create assistant message lazily on first event (tool call or text delta)
       const assistantIdx = { current: -1 };
       const toolCalls: ToolCallStatus[] = [];
 
+      const ensureAssistantMessage = () => {
+        if (assistantIdx.current >= 0) return;
+        setMessages(prev => {
+          if (assistantIdx.current >= 0) return prev;
+          assistantIdx.current = prev.length;
+          return [...prev, { role: 'assistant' as const, content: '', timestamp: Date.now() }];
+        });
+      };
+
       // Subscribe to tool call events
       const unsubToolCall = window.canvasWorkspace.agent.onToolCall(sessionId, (data) => {
+        ensureAssistantMessage();
         toolCalls.push({ id: ++toolIdCounter.current, name: data.name, args: data.args, status: 'running' });
         setStreamingTools([...toolCalls]);
       });
@@ -298,14 +308,10 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
 
       // Subscribe to text deltas
       const unsubDelta = window.canvasWorkspace.agent.onTextDelta(sessionId, (delta) => {
+        ensureAssistantMessage();
         setMessages(prev => {
-          if (assistantIdx.current < 0) {
-            // First delta — create the assistant message now
-            assistantIdx.current = prev.length;
-            return [...prev, { role: 'assistant' as const, content: delta, timestamp: Date.now() }];
-          }
           const idx = assistantIdx.current;
-          if (idx >= prev.length) return prev;
+          if (idx < 0 || idx >= prev.length) return prev;
           const updated = [...prev];
           updated[idx] = { ...updated[idx], content: updated[idx].content + delta };
           return updated;
@@ -570,9 +576,17 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
                   {isStreaming && streamingTools.length > 0 && renderToolCalls(streamingTools)}
                   {msg.role === 'assistant' ? (
                     isStreaming ? (
-                      <div className="chat-message-content chat-md chat-md--streaming">
-                        {msg.content}
-                      </div>
+                      msg.content ? (
+                        <div className="chat-message-content chat-md chat-md--streaming">
+                          {msg.content}
+                        </div>
+                      ) : streamingTools.length === 0 ? (
+                        <div className="chat-loading">
+                          <div className="chat-loading-dot" />
+                          <div className="chat-loading-dot" />
+                          <div className="chat-loading-dot" />
+                        </div>
+                      ) : null
                     ) : (
                       <div
                         className="chat-message-content chat-md"
@@ -595,13 +609,11 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
                 </svg>
               </div>
               <div className="chat-message-body">
-                {streamingTools.length > 0 ? renderToolCalls(streamingTools) : (
-                  <div className="chat-loading">
-                    <div className="chat-loading-dot" />
-                    <div className="chat-loading-dot" />
-                    <div className="chat-loading-dot" />
-                  </div>
-                )}
+                <div className="chat-loading">
+                  <div className="chat-loading-dot" />
+                  <div className="chat-loading-dot" />
+                  <div className="chat-loading-dot" />
+                </div>
               </div>
             </div>
           )}

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
@@ -577,9 +577,10 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
                   {msg.role === 'assistant' ? (
                     isStreaming ? (
                       msg.content ? (
-                        <div className="chat-message-content chat-md chat-md--streaming">
-                          {msg.content}
-                        </div>
+                        <div
+                          className="chat-message-content chat-md chat-md--streaming"
+                          dangerouslySetInnerHTML={{ __html: md.render(msg.content) }}
+                        />
                       ) : streamingTools.length === 0 ? (
                         <div className="chat-loading">
                           <div className="chat-loading-dot" />

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
@@ -494,47 +494,49 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
                     </svg>
                   </div>
                 )}
-                {msg.role === 'assistant' ? (
-                  isStreaming ? (
-                    <div className="chat-message-content chat-md chat-md--streaming">
-                      {msg.content}
+                <div className="chat-message-body">
+                  {isStreaming && streamingTools.length > 0 && (
+                    <div className="chat-tool-calls">
+                      {streamingTools.map((tc, idx) => (
+                        <div key={idx} className={`chat-tool-call chat-tool-call--${tc.status}`}>
+                          <span className="chat-tool-call-icon">
+                            {tc.status === 'running' ? (
+                              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" className="chat-tool-call-spinner">
+                                <circle cx="6" cy="6" r="4.5" stroke="currentColor" strokeWidth="1.2" strokeDasharray="14 14" strokeLinecap="round" />
+                              </svg>
+                            ) : (
+                              <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                                <path d="M3 6l2 2 4-4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+                              </svg>
+                            )}
+                          </span>
+                          <span className="chat-tool-call-name">{tc.name}</span>
+                          {formatToolArgs(tc.name, tc.args) && (
+                            <span className="chat-tool-call-args">{formatToolArgs(tc.name, tc.args)}</span>
+                          )}
+                        </div>
+                      ))}
                     </div>
+                  )}
+                  {msg.role === 'assistant' ? (
+                    isStreaming ? (
+                      <div className="chat-message-content chat-md chat-md--streaming">
+                        {msg.content}
+                      </div>
+                    ) : (
+                      <div
+                        className="chat-message-content chat-md"
+                        dangerouslySetInnerHTML={{ __html: md.render(msg.content) }}
+                      />
+                    )
                   ) : (
-                    <div
-                      className="chat-message-content chat-md"
-                      dangerouslySetInnerHTML={{ __html: md.render(msg.content) }}
-                    />
-                  )
-                ) : (
-                  <div className="chat-message-content">{msg.content}</div>
-                )}
+                    <div className="chat-message-content">{msg.content}</div>
+                  )}
+                </div>
               </div>
             );
           })}
-          {streamingTools.length > 0 && (
-            <div className="chat-tool-calls">
-              {streamingTools.map((tc, i) => (
-                <div key={i} className={`chat-tool-call chat-tool-call--${tc.status}`}>
-                  <span className="chat-tool-call-icon">
-                    {tc.status === 'running' ? (
-                      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" className="chat-tool-call-spinner">
-                        <circle cx="6" cy="6" r="4.5" stroke="currentColor" strokeWidth="1.2" strokeDasharray="14 14" strokeLinecap="round" />
-                      </svg>
-                    ) : (
-                      <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-                        <path d="M3 6l2 2 4-4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
-                      </svg>
-                    )}
-                  </span>
-                  <span className="chat-tool-call-name">{tc.name}</span>
-                  {formatToolArgs(tc.name, tc.args) && (
-                    <span className="chat-tool-call-args">{formatToolArgs(tc.name, tc.args)}</span>
-                  )}
-                </div>
-              ))}
-            </div>
-          )}
-          {loading && !(messages.length > 0 && messages[messages.length - 1].role === 'assistant') && streamingTools.length === 0 && (
+          {loading && !(messages.length > 0 && messages[messages.length - 1].role === 'assistant') && (
             <div className="chat-message chat-message-assistant">
               <div className="chat-message-avatar">
                 <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
@@ -542,10 +544,36 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
                   <path d="M4 14c0-2.2 1.8-4 4-4s4 1.8 4 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
                 </svg>
               </div>
-              <div className="chat-loading">
-                <div className="chat-loading-dot" />
-                <div className="chat-loading-dot" />
-                <div className="chat-loading-dot" />
+              <div className="chat-message-body">
+                {streamingTools.length > 0 ? (
+                  <div className="chat-tool-calls">
+                    {streamingTools.map((tc, idx) => (
+                      <div key={idx} className={`chat-tool-call chat-tool-call--${tc.status}`}>
+                        <span className="chat-tool-call-icon">
+                          {tc.status === 'running' ? (
+                            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" className="chat-tool-call-spinner">
+                              <circle cx="6" cy="6" r="4.5" stroke="currentColor" strokeWidth="1.2" strokeDasharray="14 14" strokeLinecap="round" />
+                            </svg>
+                          ) : (
+                            <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                              <path d="M3 6l2 2 4-4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+                            </svg>
+                          )}
+                        </span>
+                        <span className="chat-tool-call-name">{tc.name}</span>
+                        {formatToolArgs(tc.name, tc.args) && (
+                          <span className="chat-tool-call-args">{formatToolArgs(tc.name, tc.args)}</span>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="chat-loading">
+                    <div className="chat-loading-dot" />
+                    <div className="chat-loading-dot" />
+                    <div className="chat-loading-dot" />
+                  </div>
+                )}
               </div>
             </div>
           )}

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
@@ -1,0 +1,151 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+import type { AgentChatMessage } from '../../types';
+import './ChatPanel.css';
+
+interface ChatPanelProps {
+  workspaceId: string;
+  onClose: () => void;
+}
+
+export const ChatPanel = ({ workspaceId, onClose }: ChatPanelProps) => {
+  const [messages, setMessages] = useState<AgentChatMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Load history on mount
+  useEffect(() => {
+    void (async () => {
+      const result = await window.canvasWorkspace.agent.getHistory(workspaceId);
+      if (result.ok && result.messages) {
+        setMessages(result.messages);
+      }
+    })();
+  }, [workspaceId]);
+
+  // Scroll to bottom when messages change
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  // Auto-resize textarea
+  const handleInputChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setInput(e.target.value);
+    const el = e.target;
+    el.style.height = 'auto';
+    el.style.height = Math.min(el.scrollHeight, 120) + 'px';
+  }, []);
+
+  const sendMessage = useCallback(async () => {
+    const text = input.trim();
+    if (!text || loading) return;
+
+    // Add user message immediately
+    const userMsg: AgentChatMessage = {
+      role: 'user',
+      content: text,
+      timestamp: Date.now(),
+    };
+    setMessages(prev => [...prev, userMsg]);
+    setInput('');
+    setLoading(true);
+
+    // Reset textarea height
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
+    }
+
+    try {
+      const result = await window.canvasWorkspace.agent.chat(workspaceId, text);
+      if (result.ok && result.response) {
+        const assistantMsg: AgentChatMessage = {
+          role: 'assistant',
+          content: result.response,
+          timestamp: Date.now(),
+        };
+        setMessages(prev => [...prev, assistantMsg]);
+      } else {
+        const errorMsg: AgentChatMessage = {
+          role: 'assistant',
+          content: `Error: ${result.error ?? 'Unknown error'}`,
+          timestamp: Date.now(),
+        };
+        setMessages(prev => [...prev, errorMsg]);
+      }
+    } catch (err) {
+      const errorMsg: AgentChatMessage = {
+        role: 'assistant',
+        content: `Error: ${String(err)}`,
+        timestamp: Date.now(),
+      };
+      setMessages(prev => [...prev, errorMsg]);
+    } finally {
+      setLoading(false);
+    }
+  }, [input, loading, workspaceId]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      void sendMessage();
+    }
+  }, [sendMessage]);
+
+  return (
+    <div className="chat-panel">
+      <div className="chat-panel-header">
+        <h3>Canvas Agent</h3>
+        <button className="chat-panel-close" onClick={onClose} title="Close">
+          ×
+        </button>
+      </div>
+
+      {messages.length === 0 && !loading ? (
+        <div className="chat-messages-empty">
+          Ask me anything about this workspace.
+          <br />
+          I can read, create, and organize canvas nodes,
+          <br />
+          write code, and run commands.
+        </div>
+      ) : (
+        <div className="chat-messages">
+          {messages.map((msg, i) => (
+            <div key={i} className={`chat-message chat-message-${msg.role}`}>
+              <div className="chat-message-bubble">{msg.content}</div>
+            </div>
+          ))}
+          {loading && (
+            <div className="chat-loading">
+              <div className="chat-loading-dot" />
+              <div className="chat-loading-dot" />
+              <div className="chat-loading-dot" />
+            </div>
+          )}
+          <div ref={messagesEndRef} />
+        </div>
+      )}
+
+      <div className="chat-input-area">
+        <textarea
+          ref={textareaRef}
+          className="chat-input"
+          placeholder="Ask the Canvas Agent..."
+          value={input}
+          onChange={handleInputChange}
+          onKeyDown={handleKeyDown}
+          rows={1}
+          disabled={loading}
+        />
+        <button
+          className="chat-send-btn"
+          onClick={() => void sendMessage()}
+          disabled={!input.trim() || loading}
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
@@ -1,10 +1,12 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
+import MarkdownIt from 'markdown-it';
 import type { AgentChatMessage } from '../../types';
 import './ChatPanel.css';
 
 interface ChatPanelProps {
   workspaceId: string;
   onClose: () => void;
+  onResizeStart?: (e: React.MouseEvent) => void;
 }
 
 const QUICK_ACTIONS = [
@@ -49,7 +51,9 @@ const QUICK_ACTIONS = [
   },
 ];
 
-export const ChatPanel = ({ workspaceId, onClose }: ChatPanelProps) => {
+const md = new MarkdownIt({ html: false, linkify: true, breaks: true });
+
+export const ChatPanel = ({ workspaceId, onClose, onResizeStart }: ChatPanelProps) => {
   const [messages, setMessages] = useState<AgentChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
@@ -189,13 +193,16 @@ export const ChatPanel = ({ workspaceId, onClose }: ChatPanelProps) => {
 
   return (
     <div className="chat-panel">
+      {onResizeStart && (
+        <div className="chat-panel-resize" onMouseDown={onResizeStart} />
+      )}
       <div className="chat-panel-header">
         <div className="chat-panel-title">
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
             <circle cx="8" cy="6" r="3" stroke="currentColor" strokeWidth="1.3" />
             <path d="M4 14c0-2.2 1.8-4 4-4s4 1.8 4 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
           </svg>
-          <span>Canvas Agent</span>
+          <span>Pulse Agent</span>
         </div>
         <div className="chat-panel-actions">
           <button className="chat-panel-action-btn" onClick={onClose} title="Close panel">
@@ -243,10 +250,17 @@ export const ChatPanel = ({ workspaceId, onClose }: ChatPanelProps) => {
                   </svg>
                 </div>
               )}
-              <div className="chat-message-content">{msg.content}</div>
+              {msg.role === 'assistant' ? (
+                <div
+                  className="chat-message-content chat-md"
+                  dangerouslySetInnerHTML={{ __html: md.render(msg.content) }}
+                />
+              ) : (
+                <div className="chat-message-content">{msg.content}</div>
+              )}
             </div>
           ))}
-          {loading && (
+          {loading && !messages.some((m, i) => i === messages.length - 1 && m.role === 'assistant' && m.content) && (
             <div className="chat-message chat-message-assistant">
               <div className="chat-message-avatar">
                 <svg width="14" height="14" viewBox="0 0 16 16" fill="none">

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
@@ -1,12 +1,40 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import MarkdownIt from 'markdown-it';
-import type { AgentChatMessage, AgentSessionInfo } from '../../types';
+import type { AgentChatMessage, AgentSessionInfo, CanvasNode } from '../../types';
 import './ChatPanel.css';
 
 interface ChatPanelProps {
   workspaceId: string;
+  nodes?: CanvasNode[];
+  rootFolder?: string;
   onClose: () => void;
   onResizeStart?: (e: React.MouseEvent) => void;
+}
+
+interface ToolCallStatus {
+  name: string;
+  args?: any;
+  status: 'running' | 'done';
+}
+
+interface MentionItem {
+  type: 'node' | 'file';
+  label: string;
+  nodeType?: string;
+  path?: string;
+}
+
+function formatToolArgs(name: string, args: any): string {
+  if (!args) return '';
+  if (name === 'read' || name === 'write' || name === 'edit') return args.file_path || args.filePath || '';
+  if (name === 'bash') return args.command ? args.command.slice(0, 60) : '';
+  if (name === 'grep') return args.pattern || '';
+  if (name === 'ls') return args.path || '';
+  if (name === 'canvas_read_node') return args.nodeId || '';
+  if (name === 'canvas_create_node') return args.type || '';
+  if (name === 'canvas_update_node') return args.nodeId || '';
+  if (name === 'canvas_delete_node') return args.nodeId || '';
+  return '';
 }
 
 const QUICK_ACTIONS = [
@@ -53,15 +81,26 @@ const QUICK_ACTIONS = [
 
 const md = new MarkdownIt({ html: false, linkify: true, breaks: true });
 
-export const ChatPanel = ({ workspaceId, onClose, onResizeStart }: ChatPanelProps) => {
+export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeStart }: ChatPanelProps) => {
   const [messages, setMessages] = useState<AgentChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
   const [sessionMenuOpen, setSessionMenuOpen] = useState(false);
   const [sessions, setSessions] = useState<AgentSessionInfo[]>([]);
+  const [streamingTools, setStreamingTools] = useState<ToolCallStatus[]>([]);
+
+  // @ mention state
+  const [mentionOpen, setMentionOpen] = useState(false);
+  const [mentionQuery, setMentionQuery] = useState('');
+  const [mentionItems, setMentionItems] = useState<MentionItem[]>([]);
+  const [mentionIndex, setMentionIndex] = useState(0);
+  const [mentionStart, setMentionStart] = useState(-1); // cursor position of '@'
+  const filesCacheRef = useRef<MentionItem[] | null>(null);
+
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const sessionMenuRef = useRef<HTMLDivElement>(null);
+  const mentionRef = useRef<HTMLDivElement>(null);
 
   // Load history on mount
   useEffect(() => {
@@ -112,18 +151,79 @@ export const ChatPanel = ({ workspaceId, onClose, onResizeStart }: ChatPanelProp
     }
   }, [workspaceId]);
 
-  // Scroll to bottom when messages change
+  // Scroll to bottom when messages or streaming tools change
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages]);
+  }, [messages, streamingTools]);
 
-  // Auto-resize textarea
+  // Build mention items from nodes + files
+  const buildMentionItems = useCallback(async (query: string) => {
+    const items: MentionItem[] = [];
+    // Canvas nodes
+    if (nodes) {
+      for (const n of nodes) {
+        items.push({ type: 'node', label: n.title, nodeType: n.type, path: (n.data as any)?.filePath });
+      }
+    }
+    // Project files (cached)
+    if (rootFolder) {
+      if (!filesCacheRef.current) {
+        try {
+          const result = await window.canvasWorkspace.file.listDir(rootFolder, 2);
+          if (result.ok && result.entries) {
+            const flatFiles: MentionItem[] = [];
+            const flatten = (entries: any[], prefix: string) => {
+              for (const e of entries) {
+                const path = prefix ? `${prefix}/${e.name}` : e.name;
+                if (e.type === 'file') {
+                  flatFiles.push({ type: 'file', label: path, path: `${rootFolder}/${path}` });
+                } else if (e.children) {
+                  flatten(e.children, path);
+                }
+              }
+            };
+            flatten(result.entries, '');
+            filesCacheRef.current = flatFiles;
+          }
+        } catch {
+          filesCacheRef.current = [];
+        }
+      }
+      if (filesCacheRef.current) items.push(...filesCacheRef.current);
+    }
+    // Filter by query
+    const q = query.toLowerCase();
+    const filtered = q ? items.filter(it => it.label.toLowerCase().includes(q)) : items;
+    return filtered.slice(0, 12);
+  }, [nodes, rootFolder]);
+
+  // Auto-resize textarea + detect @ mention
   const handleInputChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setInput(e.target.value);
+    const val = e.target.value;
+    setInput(val);
     const el = e.target;
     el.style.height = 'auto';
     el.style.height = Math.min(el.scrollHeight, 120) + 'px';
-  }, []);
+
+    // Detect @ mention trigger
+    const pos = el.selectionStart ?? val.length;
+    const textBefore = val.slice(0, pos);
+    const atMatch = textBefore.match(/@([^\s@]*)$/);
+
+    if (atMatch) {
+      const start = pos - atMatch[0].length;
+      const query = atMatch[1];
+      setMentionStart(start);
+      setMentionQuery(query);
+      setMentionIndex(0);
+      void buildMentionItems(query).then(items => {
+        setMentionItems(items);
+        setMentionOpen(items.length > 0);
+      });
+    } else {
+      setMentionOpen(false);
+    }
+  }, [buildMentionItems]);
 
   const sendMessage = useCallback(async (overrideText?: string) => {
     const text = (overrideText ?? input).trim();
@@ -159,6 +259,19 @@ export const ChatPanel = ({ workspaceId, onClose, onResizeStart }: ChatPanelProp
 
       // Lazily create assistant message on first text delta
       const assistantIdx = { current: -1 };
+      const toolCalls: ToolCallStatus[] = [];
+
+      // Subscribe to tool call events
+      const unsubToolCall = window.canvasWorkspace.agent.onToolCall(sessionId, (data) => {
+        toolCalls.push({ name: data.name, args: data.args, status: 'running' });
+        setStreamingTools([...toolCalls]);
+      });
+
+      const unsubToolResult = window.canvasWorkspace.agent.onToolResult(sessionId, (data) => {
+        const tc = toolCalls.find(t => t.name === data.name && t.status === 'running');
+        if (tc) tc.status = 'done';
+        setStreamingTools([...toolCalls]);
+      });
 
       // Subscribe to text deltas
       const unsubDelta = window.canvasWorkspace.agent.onTextDelta(sessionId, (delta) => {
@@ -180,6 +293,9 @@ export const ChatPanel = ({ workspaceId, onClose, onResizeStart }: ChatPanelProp
       const unsubComplete = window.canvasWorkspace.agent.onChatComplete(sessionId, (completeResult) => {
         unsubDelta();
         unsubComplete();
+        unsubToolCall();
+        unsubToolResult();
+        setStreamingTools([]);
 
         if (!completeResult.ok) {
           setMessages(prev => {
@@ -218,12 +334,44 @@ export const ChatPanel = ({ workspaceId, onClose, onResizeStart }: ChatPanelProp
     }
   }, [input, loading, workspaceId]);
 
+  const selectMention = useCallback((item: MentionItem) => {
+    // Replace @query with @[label]
+    const before = input.slice(0, mentionStart);
+    const after = input.slice(mentionStart + 1 + mentionQuery.length);
+    const newInput = `${before}@[${item.label}] ${after}`;
+    setInput(newInput);
+    setMentionOpen(false);
+    textareaRef.current?.focus();
+  }, [input, mentionStart, mentionQuery]);
+
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (mentionOpen && mentionItems.length > 0) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setMentionIndex(i => (i + 1) % mentionItems.length);
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setMentionIndex(i => (i - 1 + mentionItems.length) % mentionItems.length);
+        return;
+      }
+      if (e.key === 'Enter' || e.key === 'Tab') {
+        e.preventDefault();
+        selectMention(mentionItems[mentionIndex]);
+        return;
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        setMentionOpen(false);
+        return;
+      }
+    }
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       void sendMessage();
     }
-  }, [sendMessage]);
+  }, [sendMessage, mentionOpen, mentionItems, mentionIndex, selectMention]);
 
   const handleQuickAction = useCallback((prompt: string) => {
     if (prompt) {
@@ -357,7 +505,30 @@ export const ChatPanel = ({ workspaceId, onClose, onResizeStart }: ChatPanelProp
               </div>
             );
           })}
-          {loading && !(messages.length > 0 && messages[messages.length - 1].role === 'assistant') && (
+          {streamingTools.length > 0 && (
+            <div className="chat-tool-calls">
+              {streamingTools.map((tc, i) => (
+                <div key={i} className={`chat-tool-call chat-tool-call--${tc.status}`}>
+                  <span className="chat-tool-call-icon">
+                    {tc.status === 'running' ? (
+                      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" className="chat-tool-call-spinner">
+                        <circle cx="6" cy="6" r="4.5" stroke="currentColor" strokeWidth="1.2" strokeDasharray="14 14" strokeLinecap="round" />
+                      </svg>
+                    ) : (
+                      <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                        <path d="M3 6l2 2 4-4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+                      </svg>
+                    )}
+                  </span>
+                  <span className="chat-tool-call-name">{tc.name}</span>
+                  {formatToolArgs(tc.name, tc.args) && (
+                    <span className="chat-tool-call-args">{formatToolArgs(tc.name, tc.args)}</span>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+          {loading && !(messages.length > 0 && messages[messages.length - 1].role === 'assistant') && streamingTools.length === 0 && (
             <div className="chat-message chat-message-assistant">
               <div className="chat-message-avatar">
                 <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
@@ -377,6 +548,37 @@ export const ChatPanel = ({ workspaceId, onClose, onResizeStart }: ChatPanelProp
       )}
 
       <div className="chat-input-container">
+        {mentionOpen && mentionItems.length > 0 && (
+          <div className="chat-mention-popup" ref={mentionRef}>
+            {mentionItems.map((item, i) => (
+              <button
+                key={`${item.type}-${item.label}`}
+                className={`chat-mention-item${i === mentionIndex ? ' chat-mention-item--active' : ''}`}
+                onMouseDown={(e) => { e.preventDefault(); selectMention(item); }}
+                onMouseEnter={() => setMentionIndex(i)}
+              >
+                <span className="chat-mention-item-icon">
+                  {item.type === 'node' ? (
+                    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                      {item.nodeType === 'file' && <><rect x="2" y="1.5" width="10" height="11" rx="1.5" stroke="currentColor" strokeWidth="1.2" /><path d="M4.5 5h5M4.5 7.5h3" stroke="currentColor" strokeWidth="1" strokeLinecap="round" /></>}
+                      {item.nodeType === 'terminal' && <><rect x="1.5" y="2" width="11" height="10" rx="1.5" stroke="currentColor" strokeWidth="1.2" /><path d="M4 6l2 1.5L4 9" stroke="currentColor" strokeWidth="1" strokeLinecap="round" strokeLinejoin="round" /></>}
+                      {item.nodeType === 'agent' && <><circle cx="7" cy="5" r="2.5" stroke="currentColor" strokeWidth="1.2" /><path d="M3.5 12c0-1.9 1.6-3.5 3.5-3.5s3.5 1.6 3.5 3.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" /></>}
+                      {item.nodeType === 'frame' && <rect x="2" y="2" width="10" height="10" rx="2" stroke="currentColor" strokeWidth="1.2" />}
+                    </svg>
+                  ) : (
+                    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                      <path d="M7 1.5v11M4 4l-2.5 2.5L4 9M10 4l2.5 2.5L10 9" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  )}
+                </span>
+                <span className="chat-mention-item-label">{item.label}</span>
+                {item.type === 'node' && item.nodeType && (
+                  <span className="chat-mention-item-type">{item.nodeType}</span>
+                )}
+              </button>
+            ))}
+          </div>
+        )}
         <div className="chat-input-box">
           <textarea
             ref={textareaRef}

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
@@ -495,10 +495,16 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
                   </div>
                 )}
                 {msg.role === 'assistant' ? (
-                  <div
-                    className={`chat-message-content chat-md${isStreaming ? ' chat-md--streaming' : ''}`}
-                    dangerouslySetInnerHTML={{ __html: md.render(msg.content) }}
-                  />
+                  isStreaming ? (
+                    <div className="chat-message-content chat-md chat-md--streaming">
+                      {msg.content}
+                    </div>
+                  ) : (
+                    <div
+                      className="chat-message-content chat-md"
+                      dangerouslySetInnerHTML={{ __html: md.render(msg.content) }}
+                    />
+                  )
                 ) : (
                   <div className="chat-message-content">{msg.content}</div>
                 )}

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
@@ -242,26 +242,29 @@ export const ChatPanel = ({ workspaceId, onClose, onResizeStart }: ChatPanelProp
         </div>
       ) : (
         <div className="chat-messages">
-          {messages.map((msg, i) => (
-            <div key={i} className={`chat-message chat-message-${msg.role}`}>
-              {msg.role === 'assistant' && (
-                <div className="chat-message-avatar">
-                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-                    <circle cx="8" cy="6" r="3" stroke="currentColor" strokeWidth="1.3" />
-                    <path d="M4 14c0-2.2 1.8-4 4-4s4 1.8 4 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
-                  </svg>
-                </div>
-              )}
-              {msg.role === 'assistant' ? (
-                <div
-                  className="chat-message-content chat-md"
-                  dangerouslySetInnerHTML={{ __html: md.render(msg.content) }}
-                />
-              ) : (
-                <div className="chat-message-content">{msg.content}</div>
-              )}
-            </div>
-          ))}
+          {messages.map((msg, i) => {
+            const isStreaming = loading && msg.role === 'assistant' && i === messages.length - 1;
+            return (
+              <div key={i} className={`chat-message chat-message-${msg.role}`}>
+                {msg.role === 'assistant' && (
+                  <div className="chat-message-avatar">
+                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+                      <circle cx="8" cy="6" r="3" stroke="currentColor" strokeWidth="1.3" />
+                      <path d="M4 14c0-2.2 1.8-4 4-4s4 1.8 4 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+                    </svg>
+                  </div>
+                )}
+                {msg.role === 'assistant' ? (
+                  <div
+                    className={`chat-message-content chat-md${isStreaming ? ' chat-md--streaming' : ''}`}
+                    dangerouslySetInnerHTML={{ __html: md.render(msg.content) }}
+                  />
+                ) : (
+                  <div className="chat-message-content">{msg.content}</div>
+                )}
+              </div>
+            );
+          })}
           {loading && !(messages.length > 0 && messages[messages.length - 1].role === 'assistant') && (
             <div className="chat-message chat-message-assistant">
               <div className="chat-message-avatar">

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
@@ -7,6 +7,48 @@ interface ChatPanelProps {
   onClose: () => void;
 }
 
+const QUICK_ACTIONS = [
+  {
+    icon: (
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+        <circle cx="7" cy="7" r="5.5" stroke="currentColor" strokeWidth="1.3" />
+        <path d="M11 11l3 3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+      </svg>
+    ),
+    label: 'What\u2019s on the canvas?',
+    prompt: 'What\u2019s on the canvas? Give me an overview.',
+  },
+  {
+    icon: (
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+        <rect x="2" y="2" width="12" height="12" rx="2" stroke="currentColor" strokeWidth="1.3" />
+        <path d="M6 8h4M8 6v4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+      </svg>
+    ),
+    label: 'Create a new note',
+    prompt: 'Create a new note on the canvas.',
+  },
+  {
+    icon: (
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+        <path d="M2 4h12M2 8h8M2 12h10" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+      </svg>
+    ),
+    label: 'Summarize my notes',
+    prompt: 'Summarize all the notes on my canvas.',
+  },
+  {
+    icon: (
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+        <path d="M4 6l2.5 2L4 10M8 10h4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+        <rect x="1.5" y="2" width="13" height="12" rx="2" stroke="currentColor" strokeWidth="1.3" />
+      </svg>
+    ),
+    label: 'Run a command',
+    prompt: '',
+  },
+];
+
 export const ChatPanel = ({ workspaceId, onClose }: ChatPanelProps) => {
   const [messages, setMessages] = useState<AgentChatMessage[]>([]);
   const [input, setInput] = useState('');
@@ -37,11 +79,10 @@ export const ChatPanel = ({ workspaceId, onClose }: ChatPanelProps) => {
     el.style.height = Math.min(el.scrollHeight, 120) + 'px';
   }, []);
 
-  const sendMessage = useCallback(async () => {
-    const text = input.trim();
+  const sendMessage = useCallback(async (overrideText?: string) => {
+    const text = (overrideText ?? input).trim();
     if (!text || loading) return;
 
-    // Add user message immediately
     const userMsg: AgentChatMessage = {
       role: 'user',
       content: text,
@@ -51,7 +92,6 @@ export const ChatPanel = ({ workspaceId, onClose }: ChatPanelProps) => {
     setInput('');
     setLoading(true);
 
-    // Reset textarea height
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto';
     }
@@ -92,59 +132,120 @@ export const ChatPanel = ({ workspaceId, onClose }: ChatPanelProps) => {
     }
   }, [sendMessage]);
 
+  const handleQuickAction = useCallback((prompt: string) => {
+    if (prompt) {
+      void sendMessage(prompt);
+    } else {
+      textareaRef.current?.focus();
+    }
+  }, [sendMessage]);
+
+  const hasMessages = messages.length > 0 || loading;
+
   return (
     <div className="chat-panel">
       <div className="chat-panel-header">
-        <h3>Canvas Agent</h3>
-        <button className="chat-panel-close" onClick={onClose} title="Close">
-          ×
-        </button>
+        <div className="chat-panel-title">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <circle cx="8" cy="6" r="3" stroke="currentColor" strokeWidth="1.3" />
+            <path d="M4 14c0-2.2 1.8-4 4-4s4 1.8 4 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+          </svg>
+          <span>Canvas Agent</span>
+        </div>
+        <div className="chat-panel-actions">
+          <button className="chat-panel-action-btn" onClick={onClose} title="Close panel">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+              <path d="M12 4L4 12M4 4l8 8" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
       </div>
 
-      {messages.length === 0 && !loading ? (
-        <div className="chat-messages-empty">
-          Ask me anything about this workspace.
-          <br />
-          I can read, create, and organize canvas nodes,
-          <br />
-          write code, and run commands.
+      {!hasMessages ? (
+        <div className="chat-empty-state">
+          <div className="chat-empty-icon">
+            <svg width="32" height="32" viewBox="0 0 32 32" fill="none">
+              <circle cx="16" cy="12" r="6" stroke="currentColor" strokeWidth="1.5" />
+              <path d="M8 28c0-4.4 3.6-8 8-8s8 3.6 8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+              <circle cx="13.5" cy="11" r="1" fill="currentColor" />
+              <circle cx="18.5" cy="11" r="1" fill="currentColor" />
+              <path d="M13.5 14c0 0 1 1.5 2.5 1.5s2.5-1.5 2.5-1.5" stroke="currentColor" strokeWidth="1" strokeLinecap="round" />
+            </svg>
+          </div>
+          <div className="chat-empty-greeting">Hi, how can I help?</div>
+          <div className="chat-quick-actions">
+            {QUICK_ACTIONS.map((action, i) => (
+              <button
+                key={i}
+                className="chat-quick-action"
+                onClick={() => handleQuickAction(action.prompt)}
+              >
+                <span className="chat-quick-action-icon">{action.icon}</span>
+                <span>{action.label}</span>
+              </button>
+            ))}
+          </div>
         </div>
       ) : (
         <div className="chat-messages">
           {messages.map((msg, i) => (
             <div key={i} className={`chat-message chat-message-${msg.role}`}>
-              <div className="chat-message-bubble">{msg.content}</div>
+              {msg.role === 'assistant' && (
+                <div className="chat-message-avatar">
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+                    <circle cx="8" cy="6" r="3" stroke="currentColor" strokeWidth="1.3" />
+                    <path d="M4 14c0-2.2 1.8-4 4-4s4 1.8 4 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+                  </svg>
+                </div>
+              )}
+              <div className="chat-message-content">{msg.content}</div>
             </div>
           ))}
           {loading && (
-            <div className="chat-loading">
-              <div className="chat-loading-dot" />
-              <div className="chat-loading-dot" />
-              <div className="chat-loading-dot" />
+            <div className="chat-message chat-message-assistant">
+              <div className="chat-message-avatar">
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+                  <circle cx="8" cy="6" r="3" stroke="currentColor" strokeWidth="1.3" />
+                  <path d="M4 14c0-2.2 1.8-4 4-4s4 1.8 4 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+                </svg>
+              </div>
+              <div className="chat-loading">
+                <div className="chat-loading-dot" />
+                <div className="chat-loading-dot" />
+                <div className="chat-loading-dot" />
+              </div>
             </div>
           )}
           <div ref={messagesEndRef} />
         </div>
       )}
 
-      <div className="chat-input-area">
-        <textarea
-          ref={textareaRef}
-          className="chat-input"
-          placeholder="Ask the Canvas Agent..."
-          value={input}
-          onChange={handleInputChange}
-          onKeyDown={handleKeyDown}
-          rows={1}
-          disabled={loading}
-        />
-        <button
-          className="chat-send-btn"
-          onClick={() => void sendMessage()}
-          disabled={!input.trim() || loading}
-        >
-          Send
-        </button>
+      <div className="chat-input-container">
+        <div className="chat-input-box">
+          <textarea
+            ref={textareaRef}
+            className="chat-input"
+            placeholder="Ask anything..."
+            value={input}
+            onChange={handleInputChange}
+            onKeyDown={handleKeyDown}
+            rows={1}
+            disabled={loading}
+          />
+          <div className="chat-input-footer">
+            <div className="chat-input-footer-left" />
+            <button
+              className={`chat-send-btn${input.trim() ? ' chat-send-btn--active' : ''}`}
+              onClick={() => void sendMessage()}
+              disabled={!input.trim() || loading}
+              title="Send message"
+            >
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                <path d="M8 12V4M8 4l-3.5 3.5M8 4l3.5 3.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
@@ -565,9 +565,9 @@ export const ChatPanel = ({ workspaceId, nodes, rootFolder, onClose, onResizeSta
                           <path d="M4 3.5h6M4 7h4M4 10.5h5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
                         </svg>
                         <span className="chat-session-menu-item-text">
-                          {s.isCurrent ? 'Current chat' : s.date}
+                          {s.isCurrent ? 'Current chat' : (s.preview || s.date)}
                         </span>
-                        <span className="chat-session-menu-item-count">{s.messageCount} msgs</span>
+                        <span className="chat-session-menu-item-count">{s.messageCount}</span>
                       </button>
                     ))}
                   </div>

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
@@ -115,18 +115,19 @@ export const ChatPanel = ({ workspaceId, onClose, onResizeStart }: ChatPanelProp
 
       const sessionId = result.sessionId;
 
-      // Add a placeholder assistant message for streaming
-      const placeholderIdx = { current: -1 };
-      setMessages(prev => {
-        placeholderIdx.current = prev.length;
-        return [...prev, { role: 'assistant' as const, content: '', timestamp: Date.now() }];
-      });
+      // Lazily create assistant message on first text delta
+      const assistantIdx = { current: -1 };
 
       // Subscribe to text deltas
       const unsubDelta = window.canvasWorkspace.agent.onTextDelta(sessionId, (delta) => {
         setMessages(prev => {
-          const idx = placeholderIdx.current;
-          if (idx < 0 || idx >= prev.length) return prev;
+          if (assistantIdx.current < 0) {
+            // First delta — create the assistant message now
+            assistantIdx.current = prev.length;
+            return [...prev, { role: 'assistant' as const, content: delta, timestamp: Date.now() }];
+          }
+          const idx = assistantIdx.current;
+          if (idx >= prev.length) return prev;
           const updated = [...prev];
           updated[idx] = { ...updated[idx], content: updated[idx].content + delta };
           return updated;
@@ -140,21 +141,22 @@ export const ChatPanel = ({ workspaceId, onClose, onResizeStart }: ChatPanelProp
 
         if (!completeResult.ok) {
           setMessages(prev => {
-            const idx = placeholderIdx.current;
-            if (idx < 0 || idx >= prev.length) return prev;
+            if (assistantIdx.current < 0) {
+              return [...prev, { role: 'assistant' as const, content: `Error: ${completeResult.error ?? 'Unknown error'}`, timestamp: Date.now() }];
+            }
+            const idx = assistantIdx.current;
             const updated = [...prev];
-            const existing = updated[idx].content;
-            updated[idx] = {
-              ...updated[idx],
-              content: existing || `Error: ${completeResult.error ?? 'Unknown error'}`,
-            };
+            const existing = updated[idx]?.content;
+            updated[idx] = { ...updated[idx], content: existing || `Error: ${completeResult.error ?? 'Unknown error'}` };
             return updated;
           });
         } else if (completeResult.response) {
-          // Replace with final complete text for accuracy
           setMessages(prev => {
-            const idx = placeholderIdx.current;
-            if (idx < 0 || idx >= prev.length) return prev;
+            if (assistantIdx.current < 0) {
+              // No deltas arrived — add complete message directly
+              return [...prev, { role: 'assistant' as const, content: completeResult.response!, timestamp: Date.now() }];
+            }
+            const idx = assistantIdx.current;
             const updated = [...prev];
             updated[idx] = { ...updated[idx], content: completeResult.response! };
             return updated;
@@ -260,7 +262,7 @@ export const ChatPanel = ({ workspaceId, onClose, onResizeStart }: ChatPanelProp
               )}
             </div>
           ))}
-          {loading && !messages.some((m, i) => i === messages.length - 1 && m.role === 'assistant' && m.content) && (
+          {loading && !(messages.length > 0 && messages[messages.length - 1].role === 'assistant') && (
             <div className="chat-message chat-message-assistant">
               <div className="chat-message-avatar">
                 <svg width="14" height="14" viewBox="0 0 16 16" fill="none">

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import MarkdownIt from 'markdown-it';
-import type { AgentChatMessage } from '../../types';
+import type { AgentChatMessage, AgentSessionInfo } from '../../types';
 import './ChatPanel.css';
 
 interface ChatPanelProps {
@@ -57,8 +57,11 @@ export const ChatPanel = ({ workspaceId, onClose, onResizeStart }: ChatPanelProp
   const [messages, setMessages] = useState<AgentChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
+  const [sessionMenuOpen, setSessionMenuOpen] = useState(false);
+  const [sessions, setSessions] = useState<AgentSessionInfo[]>([]);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const sessionMenuRef = useRef<HTMLDivElement>(null);
 
   // Load history on mount
   useEffect(() => {
@@ -68,6 +71,45 @@ export const ChatPanel = ({ workspaceId, onClose, onResizeStart }: ChatPanelProp
         setMessages(result.messages);
       }
     })();
+  }, [workspaceId]);
+
+  // Close session menu on outside click
+  useEffect(() => {
+    if (!sessionMenuOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (sessionMenuRef.current && !sessionMenuRef.current.contains(e.target as Node)) {
+        setSessionMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [sessionMenuOpen]);
+
+  // Load sessions list when menu opens
+  const openSessionMenu = useCallback(async () => {
+    if (sessionMenuOpen) {
+      setSessionMenuOpen(false);
+      return;
+    }
+    const result = await window.canvasWorkspace.agent.listSessions(workspaceId);
+    if (result.ok && result.sessions) {
+      setSessions(result.sessions);
+    }
+    setSessionMenuOpen(true);
+  }, [sessionMenuOpen, workspaceId]);
+
+  const handleNewSession = useCallback(async () => {
+    setSessionMenuOpen(false);
+    await window.canvasWorkspace.agent.newSession(workspaceId);
+    setMessages([]);
+  }, [workspaceId]);
+
+  const handleLoadSession = useCallback(async (sessionId: string) => {
+    setSessionMenuOpen(false);
+    const result = await window.canvasWorkspace.agent.loadSession(workspaceId, sessionId);
+    if (result.ok && result.messages) {
+      setMessages(result.messages);
+    }
   }, [workspaceId]);
 
   // Scroll to bottom when messages change
@@ -199,14 +241,64 @@ export const ChatPanel = ({ workspaceId, onClose, onResizeStart }: ChatPanelProp
         <div className="chat-panel-resize" onMouseDown={onResizeStart} />
       )}
       <div className="chat-panel-header">
-        <div className="chat-panel-title">
-          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-            <circle cx="8" cy="6" r="3" stroke="currentColor" strokeWidth="1.3" />
-            <path d="M4 14c0-2.2 1.8-4 4-4s4 1.8 4 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
-          </svg>
-          <span>Pulse Agent</span>
+        <div className="chat-panel-title-wrapper" ref={sessionMenuRef}>
+          <button className="chat-panel-title-btn" onClick={() => void openSessionMenu()}>
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+              <circle cx="8" cy="6" r="3" stroke="currentColor" strokeWidth="1.3" />
+              <path d="M4 14c0-2.2 1.8-4 4-4s4 1.8 4 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+            </svg>
+            <span>Pulse Agent</span>
+            <svg className="chat-panel-title-chevron" width="12" height="12" viewBox="0 0 12 12" fill="none">
+              <path d="M3 4.5l3 3 3-3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </button>
+          {sessionMenuOpen && (
+            <div className="chat-session-menu">
+              <button className="chat-session-menu-new" onClick={() => void handleNewSession()}>
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                  <path d="M7 3v8M3 7h8" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+                </svg>
+                <span>New chat</span>
+              </button>
+              {sessions.length > 0 && (
+                <>
+                  <div className="chat-session-menu-divider" />
+                  <div className="chat-session-menu-label">Recent</div>
+                  <div className="chat-session-menu-list">
+                    {sessions.map((s) => (
+                      <button
+                        key={s.sessionId}
+                        className={`chat-session-menu-item${s.isCurrent ? ' chat-session-menu-item--active' : ''}`}
+                        onClick={() => {
+                          if (!s.isCurrent) void handleLoadSession(s.sessionId);
+                          else setSessionMenuOpen(false);
+                        }}
+                      >
+                        <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                          <path d="M4 3.5h6M4 7h4M4 10.5h5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+                        </svg>
+                        <span className="chat-session-menu-item-text">
+                          {s.isCurrent ? 'Current chat' : s.date}
+                        </span>
+                        <span className="chat-session-menu-item-count">{s.messageCount} msgs</span>
+                      </button>
+                    ))}
+                  </div>
+                </>
+              )}
+            </div>
+          )}
         </div>
         <div className="chat-panel-actions">
+          <button
+            className="chat-panel-action-btn"
+            onClick={() => void handleNewSession()}
+            title="New chat"
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+              <path d="M8 3v10M3 8h10" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+            </svg>
+          </button>
           <button className="chat-panel-action-btn" onClick={onClose} title="Close panel">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
               <path d="M12 4L4 12M4 4l8 8" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
@@ -49,6 +49,31 @@ export const FloatingToolbar = ({
 }: Props) => {
   return (
     <div className="floating-toolbar">
+      {onChatToggle && (
+        <>
+          <div className="toolbar-group">
+            <button
+              className={`toolbar-btn${chatPanelOpen ? " toolbar-btn--active" : ""}`}
+              onClick={onChatToggle}
+              title="Toggle AI Chat (Cmd/Ctrl+Shift+A)"
+            >
+              <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+                <path
+                  d="M3 4a2 2 0 012-2h8a2 2 0 012 2v6a2 2 0 01-2 2H8l-3 2.5V12H5a2 2 0 01-2-2V4z"
+                  stroke="currentColor"
+                  strokeWidth="1.3"
+                  strokeLinejoin="round"
+                />
+                <circle cx="7" cy="7" r="0.8" fill="currentColor" />
+                <circle cx="9" cy="7" r="0.8" fill="currentColor" />
+                <circle cx="11" cy="7" r="0.8" fill="currentColor" />
+              </svg>
+            </button>
+          </div>
+          <div className="toolbar-divider" />
+        </>
+      )}
+
       <div className="toolbar-group">
         {tools.map((t) => (
           <button
@@ -133,32 +158,6 @@ export const FloatingToolbar = ({
           <span className="toolbar-btn-label">Agent</span>
         </button>
       </div>
-
-      {onChatToggle && (
-        <>
-          <div className="toolbar-divider" />
-          <div className="toolbar-group">
-            <button
-              className={`toolbar-btn toolbar-btn--create${chatPanelOpen ? " toolbar-btn--active" : ""}`}
-              onClick={onChatToggle}
-              title="Toggle AI Chat (Cmd/Ctrl+Shift+A)"
-            >
-              <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-                <path
-                  d="M3 4a2 2 0 012-2h8a2 2 0 012 2v6a2 2 0 01-2 2H8l-3 2.5V12H5a2 2 0 01-2-2V4z"
-                  stroke="currentColor"
-                  strokeWidth="1.3"
-                  strokeLinejoin="round"
-                />
-                <circle cx="7" cy="7" r="0.8" fill="currentColor" />
-                <circle cx="9" cy="7" r="0.8" fill="currentColor" />
-                <circle cx="11" cy="7" r="0.8" fill="currentColor" />
-              </svg>
-              <span className="toolbar-btn-label">AI Chat</span>
-            </button>
-          </div>
-        </>
-      )}
     </div>
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
@@ -58,15 +58,13 @@ export const FloatingToolbar = ({
               title="Toggle AI Chat (Cmd/Ctrl+Shift+A)"
             >
               <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+                <circle cx="9" cy="6.5" r="3.5" stroke="currentColor" strokeWidth="1.3" />
                 <path
-                  d="M3 4a2 2 0 012-2h8a2 2 0 012 2v6a2 2 0 01-2 2H8l-3 2.5V12H5a2 2 0 01-2-2V4z"
-                  stroke="currentColor"
-                  strokeWidth="1.3"
-                  strokeLinejoin="round"
+                  d="M4.5 16c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5"
+                  stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"
                 />
-                <circle cx="7" cy="7" r="0.8" fill="currentColor" />
-                <circle cx="9" cy="7" r="0.8" fill="currentColor" />
-                <circle cx="11" cy="7" r="0.8" fill="currentColor" />
+                <circle cx="7.5" cy="6" r="0.7" fill="currentColor" />
+                <circle cx="10.5" cy="6" r="0.7" fill="currentColor" />
               </svg>
             </button>
           </div>

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
@@ -4,6 +4,8 @@ interface Props {
   activeTool: string;
   onToolChange: (tool: string) => void;
   onAddNode: (type: "file" | "terminal" | "frame" | "agent") => void;
+  chatPanelOpen?: boolean;
+  onChatToggle?: () => void;
 }
 
 const tools = [
@@ -41,7 +43,9 @@ const tools = [
 export const FloatingToolbar = ({
   activeTool,
   onToolChange,
-  onAddNode
+  onAddNode,
+  chatPanelOpen,
+  onChatToggle,
 }: Props) => {
   return (
     <div className="floating-toolbar">
@@ -129,6 +133,32 @@ export const FloatingToolbar = ({
           <span className="toolbar-btn-label">Agent</span>
         </button>
       </div>
+
+      {onChatToggle && (
+        <>
+          <div className="toolbar-divider" />
+          <div className="toolbar-group">
+            <button
+              className={`toolbar-btn toolbar-btn--create${chatPanelOpen ? " toolbar-btn--active" : ""}`}
+              onClick={onChatToggle}
+              title="Toggle AI Chat (Cmd/Ctrl+Shift+A)"
+            >
+              <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+                <path
+                  d="M3 4a2 2 0 012-2h8a2 2 0 012 2v6a2 2 0 01-2 2H8l-3 2.5V12H5a2 2 0 01-2-2V4z"
+                  stroke="currentColor"
+                  strokeWidth="1.3"
+                  strokeLinejoin="round"
+                />
+                <circle cx="7" cy="7" r="0.8" fill="currentColor" />
+                <circle cx="9" cy="7" r="0.8" fill="currentColor" />
+                <circle cx="11" cy="7" r="0.8" fill="currentColor" />
+              </svg>
+              <span className="toolbar-btn-label">AI Chat</span>
+            </button>
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -126,7 +126,15 @@ export interface AgentApi {
   chat: (
     workspaceId: string,
     message: string
-  ) => Promise<{ ok: boolean; response?: string; error?: string }>;
+  ) => Promise<{ ok: boolean; sessionId?: string; error?: string }>;
+  onTextDelta: (
+    sessionId: string,
+    callback: (delta: string) => void
+  ) => () => void;
+  onChatComplete: (
+    sessionId: string,
+    callback: (result: { ok: boolean; response?: string; error?: string }) => void
+  ) => () => void;
   getStatus: (
     workspaceId: string
   ) => Promise<{ ok: boolean; active: boolean; messageCount: number }>;

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -116,6 +116,27 @@ export interface SkillsApi {
   install: () => Promise<SkillsInstallResult>;
 }
 
+export interface AgentChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: number;
+}
+
+export interface AgentApi {
+  chat: (
+    workspaceId: string,
+    message: string
+  ) => Promise<{ ok: boolean; response?: string; error?: string }>;
+  getStatus: (
+    workspaceId: string
+  ) => Promise<{ ok: boolean; active: boolean; messageCount: number }>;
+  getHistory: (
+    workspaceId: string
+  ) => Promise<{ ok: boolean; messages?: AgentChatMessage[] }>;
+  activate: (workspaceId: string) => Promise<{ ok: boolean; error?: string }>;
+  deactivate: (workspaceId: string) => Promise<{ ok: boolean; error?: string }>;
+}
+
 export interface CanvasWorkspaceApi {
   version: string;
   pty: {
@@ -157,6 +178,7 @@ export interface CanvasWorkspaceApi {
   file: FileApi;
   dialog: DialogApi;
   skills: SkillsApi;
+  agent: AgentApi;
 }
 
 declare global {

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -127,6 +127,7 @@ export interface AgentSessionInfo {
   date: string;
   messageCount: number;
   isCurrent: boolean;
+  preview?: string;
 }
 
 export interface AgentApi {

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -122,6 +122,13 @@ export interface AgentChatMessage {
   timestamp: number;
 }
 
+export interface AgentSessionInfo {
+  sessionId: string;
+  date: string;
+  messageCount: number;
+  isCurrent: boolean;
+}
+
 export interface AgentApi {
   chat: (
     workspaceId: string,
@@ -141,6 +148,16 @@ export interface AgentApi {
   getHistory: (
     workspaceId: string
   ) => Promise<{ ok: boolean; messages?: AgentChatMessage[] }>;
+  listSessions: (
+    workspaceId: string
+  ) => Promise<{ ok: boolean; sessions?: AgentSessionInfo[]; error?: string }>;
+  newSession: (
+    workspaceId: string
+  ) => Promise<{ ok: boolean; error?: string }>;
+  loadSession: (
+    workspaceId: string,
+    sessionId: string
+  ) => Promise<{ ok: boolean; messages?: AgentChatMessage[]; error?: string }>;
   activate: (workspaceId: string) => Promise<{ ok: boolean; error?: string }>;
   deactivate: (workspaceId: string) => Promise<{ ok: boolean; error?: string }>;
 }

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -142,6 +142,14 @@ export interface AgentApi {
     sessionId: string,
     callback: (result: { ok: boolean; response?: string; error?: string }) => void
   ) => () => void;
+  onToolCall: (
+    sessionId: string,
+    callback: (data: { name: string; args: any }) => void
+  ) => () => void;
+  onToolResult: (
+    sessionId: string,
+    callback: (data: { name: string; result: string }) => void
+  ) => () => void;
   getStatus: (
     workspaceId: string
   ) => Promise<{ ok: boolean; active: boolean; messageCount: number }>;

--- a/packages/canvas-cli/src/core/context.ts
+++ b/packages/canvas-cli/src/core/context.ts
@@ -66,6 +66,11 @@ export async function generateContext(
         base.label = (readResult as NodeReadResult & { label?: string }).label ?? '';
         base.color = (readResult as NodeReadResult & { color?: string }).color ?? '';
         break;
+      case 'agent':
+        base.agentType = (readResult as NodeReadResult & { agentType?: string }).agentType ?? 'claude-code';
+        base.status = (readResult as NodeReadResult & { status?: string }).status ?? 'idle';
+        base.cwd = (readResult as NodeReadResult & { cwd?: string }).cwd ?? '';
+        break;
     }
 
     nodes.push(base);
@@ -85,6 +90,7 @@ export function formatContextAsText(ctx: CanvasContext): string {
   const fileNodes = ctx.nodes.filter(n => n.type === 'file');
   const terminalNodes = ctx.nodes.filter(n => n.type === 'terminal');
   const frameNodes = ctx.nodes.filter(n => n.type === 'frame');
+  const agentNodes = ctx.nodes.filter(n => n.type === 'agent');
 
   if (fileNodes.length > 0) {
     lines.push('', '## Files', '');
@@ -108,6 +114,15 @@ export function formatContextAsText(ctx: CanvasContext): string {
     for (const node of terminalNodes) {
       const cwd = node.cwd ? ` (cwd: \`${node.cwd}\`)` : '';
       lines.push(`- **${node.title}**${cwd}`);
+    }
+  }
+
+  if (agentNodes.length > 0) {
+    lines.push('', '## Agents', '');
+    for (const node of agentNodes) {
+      const info = `${node.agentType ?? 'unknown'}, ${node.status ?? 'idle'}`;
+      const cwd = node.cwd ? `, cwd: \`${node.cwd}\`` : '';
+      lines.push(`- **${node.title}** (${info}${cwd})`);
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
 
   apps/canvas-workspace:
     dependencies:
+      '@ai-sdk/openai':
+        specifier: ^3.0.21
+        version: 3.0.21(zod@4.3.6)
       '@tiptap/extension-bubble-menu':
         specifier: ^3.20.4
         version: 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2)
@@ -47,6 +50,9 @@ importers:
       '@xterm/xterm':
         specifier: ^6.0.0
         version: 6.0.0
+      ai:
+        specifier: ^6.0.57
+        version: 6.0.57(zod@4.3.6)
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0
@@ -59,6 +65,9 @@ importers:
       tiptap-markdown:
         specifier: ^0.9.0
         version: 0.9.0(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.6
     devDependencies:
       '@electron/rebuild':
         specifier: ^4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       ai:
         specifier: ^6.0.57
         version: 6.0.57(zod@4.3.6)
+      markdown-it:
+        specifier: ^14.1.0
+        version: 14.1.1
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0
@@ -75,6 +78,9 @@ importers:
       '@electron/rebuild':
         specifier: ^4.0.3
         version: 4.0.3
+      '@types/markdown-it':
+        specifier: ^14.1.0
+        version: 14.1.2
       '@types/node':
         specifier: ^20.14.9
         version: 20.19.33

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0
+      pulse-coder-engine:
+        specifier: workspace:*
+        version: link:../../packages/engine
       react:
         specifier: ^18.3.1
         version: 18.3.1


### PR DESCRIPTION
## Summary
Introduces the **Canvas Agent**, a workspace-scoped AI Copilot that runs in the Electron main process. The agent understands the entire canvas context and can perform canvas operations, file I/O, and coding tasks directly using an agentic loop powered by `pulse-coder-engine`.

## Key Changes

### Core Agent Infrastructure
- **`canvas-agent.ts`**: Main agent class using `pulse-coder-engine`'s `Engine` to run an agentic loop with canvas-specific tools and built-in filesystem tools (read, write, edit, grep, ls, bash)
- **`service.ts`**: `CanvasAgentService` manages one agent per workspace with lifecycle methods (activate, chat, deactivate)
- **`session-store.ts`**: Persists agent conversations to `~/.pulse-coder/canvas/<workspace-id>/agent-sessions/` with current session + date-based archive

### Canvas-Specific Tools
- **`tools.ts`**: Five canvas tools matching `pulse-coder-engine`'s Tool interface:
  - `canvas_read_context`: Read workspace summary or full context with file contents
  - `canvas_read_node`: Read a single node's full content
  - `canvas_create_node`: Create new file/terminal/frame/agent nodes with auto-placement
  - `canvas_update_node`: Update node content, title, and metadata
  - `canvas_delete_node`: Remove nodes from canvas
  - `canvas_move_node`: Reposition nodes

### Context Building
- **`context-builder.ts`**: Produces lightweight workspace summaries (always injected into system prompt) and detailed contexts (loaded on demand)
  - `buildWorkspaceSummary()`: Quick overview of all nodes with metadata
  - `buildDetailedContext()`: Full context including file contents and terminal scrollback
  - `readNodeDetail()`: Read a single node in detail
  - `formatSummaryForPrompt()`: Format summary as system prompt section

### UI Integration
- **`ChatPanel` component**: New right-side chat panel for interacting with the Canvas Agent
  - Message history display with auto-scroll
  - Auto-resizing textarea input
  - Loading indicator with animated dots
  - Keyboard shortcuts (Enter to send, Shift+Enter for newline)
- **`ChatPanel.css`**: Styling for chat interface (iOS-like message bubbles, input area)

### IPC & Preload
- **`canvas-agent-ipc.ts`**: IPC handlers for chat, status, history, activate, deactivate
- **`preload/index.ts`**: Expose `agent` API to renderer (chat, getStatus, getHistory)
- **`types.ts`**: Add `AgentChatMessage` and `AgentApi` interfaces

### System Integration
- **`App.tsx`**: Add ChatPanel toggle state and render ChatPanel when open
- **`main/index.ts`**: Setup Canvas Agent IPC on app start, teardown on exit
- **`types.ts`**: Add agent-related type definitions

### Type Definitions
- **`types.ts`**: Comprehensive types for agent config, messages, sessions, workspace context, and IPC payloads
- **`engine.d.ts`**: Temporary type shim for `pulse-coder-engine` (until upstream DTS build is fixed)

## Notable Implementation Details

- **System Prompt Strategy**: Base prompt explains agent capabilities + lightweight workspace summary. Detailed content loaded on-demand via tools to keep context window efficient.
- **Concurrent Safety**: Canvas tools re-read canvas.json before writing to avoid clobbering concurrent changes from the UI.
- **Auto-Placement**: New nodes are positioned to the right of existing nodes, with sensible defaults for dimensions.
- **File Backing**: File nodes automatically create markdown files in `notes/` directory with content persistence.
- **Session Persistence**: Conversations are saved to disk with automatic archival by date, enabling history replay.
- **Workspace-Scoped**: Each workspace gets its own agent instance, session store, and context.

https://claude.ai/code/session_01B8rAFveiMBwsCeVCYbS9iP