### PR TITLE
feat(remote-server): support /merge referenced session context

### DIFF
--- a/apps/remote-server/src/core/agent-runner.ts
+++ b/apps/remote-server/src/core/agent-runner.ts
@@ -9,6 +9,103 @@ import { memoryIntegration, recordDailyLogFromSuccessPath } from './memory-integ
 import { buildRemoteWorktreeRunContext, worktreeIntegration } from './worktree/integration.js';
 import { buildRemoteVaultRunContext, vaultIntegration } from './vault/integration.js';
 import { resolveModelForRun } from './model-config.js';
+
+const MERGED_CONTEXT_MAX_SESSIONS = 5;
+const MERGED_CONTEXT_MAX_MESSAGES_PER_SESSION = 24;
+const MERGED_CONTEXT_MAX_CHARS_PER_MESSAGE = 600;
+
+function messageContentToText(content: unknown): string {
+  if (typeof content === 'string') {
+    return content.trim();
+  }
+
+  if (Array.isArray(content)) {
+    const parts = content
+      .map((part) => {
+        if (typeof part === 'string') {
+          return part;
+        }
+
+        if (typeof part === 'object' && part !== null && 'text' in part) {
+          const text = (part as { text?: unknown }).text;
+          return typeof text === 'string' ? text : '';
+        }
+
+        return '';
+      })
+      .filter((part) => part.length > 0);
+
+    if (parts.length > 0) {
+      return parts.join(' ').trim();
+    }
+  }
+
+  try {
+    return JSON.stringify(content);
+  } catch {
+    return String(content);
+  }
+}
+
+function formatMergedMessage(message: unknown): string | null {
+  if (typeof message === 'string') {
+    const text = message.trim();
+    if (!text) {
+      return null;
+    }
+    return text.length > MERGED_CONTEXT_MAX_CHARS_PER_MESSAGE
+      ? `${text.slice(0, MERGED_CONTEXT_MAX_CHARS_PER_MESSAGE)}...`
+      : text;
+  }
+
+  if (typeof message !== 'object' || message === null) {
+    return null;
+  }
+
+  const role = typeof (message as { role?: unknown }).role === 'string'
+    ? (message as { role: string }).role
+    : 'unknown';
+  const content = messageContentToText((message as { content?: unknown }).content);
+  if (!content) {
+    return null;
+  }
+
+  const clipped = content.length > MERGED_CONTEXT_MAX_CHARS_PER_MESSAGE
+    ? `${content.slice(0, MERGED_CONTEXT_MAX_CHARS_PER_MESSAGE)}...`
+    : content;
+
+  return `${role}: ${clipped}`;
+}
+
+function buildMergedContextPrompt(mergedSessions: Array<{ id: string; messages: unknown[] }>): string | null {
+  if (mergedSessions.length === 0) {
+    return null;
+  }
+
+  const lines: string[] = [
+    'Merged session context (read-only references from /merge):',
+    'Use as supplemental background only. Current session and latest user input have highest priority.',
+  ];
+
+  for (const session of mergedSessions.slice(0, MERGED_CONTEXT_MAX_SESSIONS)) {
+    lines.push(`\n[Session ${session.id}]`);
+    const recentMessages = session.messages.slice(-MERGED_CONTEXT_MAX_MESSAGES_PER_SESSION);
+    for (const message of recentMessages) {
+      const formatted = formatMergedMessage(message);
+      if (!formatted) {
+        continue;
+      }
+      lines.push(`- ${formatted}`);
+    }
+
+    if (session.messages.length > recentMessages.length) {
+      lines.push('- ...(older messages omitted)');
+    }
+  }
+
+  return lines.join('\n');
+}
+
 const ACP_CLIENT_INFO = {
   name: 'pulse-remote-server',
   title: 'Pulse Remote Server',
@@ -103,6 +200,7 @@ function buildRunContext(input: {
   caller?: string;
   callerSelectors?: string[];
   latestAttachments?: unknown[];
+  mergedSessionIds?: string[];
 }): Record<string, any> {
   const channel = parseChannelInfo(input.platformKey);
   const callerContext = buildToolCallerContext({
@@ -121,6 +219,7 @@ function buildRunContext(input: {
     callerSelectors: callerContext.callerSelectors,
     latestAttachments: input.latestAttachments ?? [],
     attachments: input.latestAttachments ?? [],
+    mergedSessionIds: input.mergedSessionIds ?? [],
   };
 }
 
@@ -256,6 +355,12 @@ export async function executeAgentTurn(input: ExecuteAgentTurnInput): Promise<Ex
   }
 
   const attachmentPrompt = buildAttachmentSystemPrompt(latestAttachments);
+  const mergedSessionDetails = await sessionStore.getMergedSessionDetails(
+    input.platformKey,
+    sessionId,
+    input.memoryKey,
+  );
+  const mergedSessionPrompt = buildMergedContextPrompt(mergedSessionDetails);
 
   context.messages.push({ role: 'user', content: input.userText });
 
@@ -268,6 +373,7 @@ export async function executeAgentTurn(input: ExecuteAgentTurnInput): Promise<Ex
     caller: input.caller,
     callerSelectors: input.callerSelectors,
     latestAttachments,
+    mergedSessionIds: mergedSessionDetails.map((session) => session.id),
   });
 
   const acpState = await getAcpState(input.platformKey);
@@ -308,7 +414,7 @@ export async function executeAgentTurn(input: ExecuteAgentTurnInput): Promise<Ex
         runContext,
         systemPrompt: (() => {
           const channelPrompt = buildChannelSystemPrompt(input.platformKey);
-          const parts = [channelPrompt, attachmentPrompt].filter(Boolean) as string[];
+          const parts = [channelPrompt, attachmentPrompt, mergedSessionPrompt].filter(Boolean) as string[];
           if (parts.length === 0) {
             return undefined;
           }

--- a/apps/remote-server/src/core/chat-commands.ts
+++ b/apps/remote-server/src/core/chat-commands.ts
@@ -9,6 +9,7 @@ import {
   handleClearCommand,
   handleCompactCommand,
   handleCurrentSessionCommand,
+  handleMergeCommand,
   handleDetachCommand,
   handleForkCommand,
   handleNewCommand,
@@ -48,7 +49,7 @@ export async function processIncomingCommand(incoming: IncomingMessage): Promise
   if (tokens.length === 0) {
     return {
       type: 'handled',
-      message: '⚠️ 请输入命令，例如 `/new`、`/clear`、`/compact`、`/resume`、`/fork`、`/memory`、`/status`、`/stop`、`/skills`、`/wt`。',
+      message: '⚠️ 请输入命令，例如 `/new`、`/clear`、`/compact`、`/resume`、`/fork`、`/merge`、`/memory`、`/status`、`/stop`、`/skills`、`/wt`。',
     };
   }
 
@@ -96,6 +97,9 @@ export async function processIncomingCommand(incoming: IncomingMessage): Promise
 
     case 'fork':
       return await handleForkCommand(incoming.platformKey, memoryKey, args);
+
+    case 'merge':
+      return await handleMergeCommand(incoming.platformKey, memoryKey, args);
 
     case 'status':
       return await handleStatusCommand(incoming.platformKey);

--- a/apps/remote-server/src/core/chat-commands/command-defs.ts
+++ b/apps/remote-server/src/core/chat-commands/command-defs.ts
@@ -9,6 +9,7 @@ export const COMMANDS_ALLOWED_WHILE_RUNNING = new Set([
   'memory',
   'mode',
   'fork',
+  'merge',
   'wt',
   'insight',
   'model',

--- a/apps/remote-server/src/core/chat-commands/handlers/session-commands.ts
+++ b/apps/remote-server/src/core/chat-commands/handlers/session-commands.ts
@@ -136,6 +136,88 @@ export async function handleForkCommand(platformKey: string, memoryKey: string, 
   };
 }
 
+
+export async function handleMergeCommand(platformKey: string, memoryKey: string, args: string[]): Promise<CommandResult> {
+  const firstArg = args[0]?.toLowerCase();
+  const listRequested = args.length === 0 || firstArg === 'list' || firstArg === 'ls';
+
+  if (listRequested) {
+    const currentSessionId = sessionStore.getCurrentSessionId(platformKey);
+    if (!currentSessionId) {
+      return {
+        type: 'handled',
+        message: 'ℹ️ 当前没有已绑定会话。先发送一条普通消息，再执行 `/merge <session-id>`。',
+      };
+    }
+
+    const merged = await sessionStore.listMergedSessionSummaries(platformKey, memoryKey);
+    if (merged.sessions.length === 0) {
+      return {
+        type: 'handled',
+        message: [
+          'ℹ️ 当前会话尚未引用其他会话。',
+          `- Current Session ID: ${currentSessionId}`,
+          '用法：/merge <session-id>',
+        ].join('\n'),
+      };
+    }
+
+    const lines = merged.sessions.map((session, index) => {
+      const preview = session.preview.length > 80 ? `${session.preview.slice(0, 80)}...` : session.preview;
+      return `${index + 1}. ${session.id} | ${session.messageCount} 条消息 | ${formatTime(session.updatedAt)}\n   ${preview}`;
+    });
+
+    return {
+      type: 'handled',
+      message: [
+        `🧩 当前会话已引用 ${merged.sessions.length} 个会话：`,
+        `- Current Session ID: ${merged.currentSessionId ?? currentSessionId}`,
+        lines.join('\n'),
+        '用法：/merge <session-id>',
+      ].join('\n'),
+    };
+  }
+
+  const targetSessionId = args[0]?.trim();
+  if (!targetSessionId) {
+    return {
+      type: 'handled',
+      message: '❌ 缺少 session-id\n用法：/merge <session-id>',
+    };
+  }
+
+  const result = await sessionStore.mergeSessionReference(platformKey, targetSessionId, memoryKey);
+  if (!result.ok) {
+    return {
+      type: 'handled',
+      message: `❌ 无法合并会话：${result.reason ?? '未知错误'}\n用法：/merge <session-id>`,
+    };
+  }
+
+  if (result.alreadyMerged) {
+    return {
+      type: 'handled',
+      message: [
+        'ℹ️ 该会话已在当前引用列表中。',
+        `- Current Session ID: ${result.currentSessionId}`,
+        `- Merged Session ID: ${result.mergedSessionId ?? targetSessionId}`,
+        `- 引用会话数：${result.mergedCount ?? 0}`,
+      ].join('\n'),
+    };
+  }
+
+  return {
+    type: 'handled',
+    message: [
+      '✅ 已引用会话上下文',
+      `- Current Session ID: ${result.currentSessionId}`,
+      `- Merged Session ID: ${result.mergedSessionId ?? targetSessionId}`,
+      `- 引用会话数：${result.mergedCount ?? 0}`,
+      '提示：后续对话会自动带上被引用会话上下文。',
+    ].join('\n'),
+  };
+}
+
 export async function handleStatusCommand(platformKey: string): Promise<CommandResult> {
   const activeRun = getActiveRun(platformKey);
   const sessionStatus = await sessionStore.getCurrentStatus(platformKey);

--- a/apps/remote-server/src/core/chat-commands/help.ts
+++ b/apps/remote-server/src/core/chat-commands/help.ts
@@ -27,6 +27,8 @@ export function buildHelpMessage(): string {
     '/sessions - /resume 的别名',
     '/resume <session-id> - 恢复指定会话',
     '/fork <session-id> - 基于指定会话创建新分叉会话并自动切换',
+    '/merge <session-id> - 引用指定会话上下文（软合并，不改写历史）',
+    '/merge [list] - 查看当前已引用的会话列表',
     '/status - 查看当前运行状态与会话信息',
     '/stop - 停止当前正在运行的任务',
     '/cancel - /stop 的别名',

--- a/apps/remote-server/src/core/session-store.ts
+++ b/apps/remote-server/src/core/session-store.ts
@@ -16,6 +16,7 @@ interface RemoteSession {
   updatedAt: number;
   messages: unknown[]; // Stored as-is; cast to Context['messages'] on load
   latestAttachments?: StoredAttachment[];
+  mergedSessionIds?: string[];
 }
 
 export interface RemoteSessionSummary {
@@ -44,6 +45,22 @@ export interface ClearSessionResult {
   createdNew: boolean;
 }
 
+export interface MergeSessionResult {
+  ok: boolean;
+  currentSessionId?: string;
+  mergedSessionId?: string;
+  mergedCount?: number;
+  alreadyMerged?: boolean;
+  reason?: string;
+}
+
+export interface MergedSessionSummary {
+  id: string;
+  updatedAt: number;
+  messageCount: number;
+  preview: string;
+}
+
 export interface ForkSessionResult {
   ok: boolean;
   sessionId?: string;
@@ -60,6 +77,7 @@ export interface SessionDetail {
   updatedAt: number;
   messages: unknown[];
   latestAttachments?: StoredAttachment[];
+  mergedSessionIds?: string[];
 }
 
 /**
@@ -132,6 +150,7 @@ class RemoteSessionStore {
       updatedAt: session.updatedAt,
       messages: this.cloneMessages(session.messages),
       latestAttachments: this.cloneAttachments(session.latestAttachments),
+      mergedSessionIds: this.cloneMergedSessionIds(session.mergedSessionIds),
     };
   }
 
@@ -178,6 +197,7 @@ class RemoteSessionStore {
       updatedAt: Date.now(),
       messages: [],
       latestAttachments: [],
+      mergedSessionIds: [],
     };
 
     await this.writeSession(session);
@@ -343,6 +363,7 @@ class RemoteSessionStore {
 
     session.messages = [];
     session.latestAttachments = [];
+    session.mergedSessionIds = [];
     session.updatedAt = Date.now();
     await this.writeSession(session);
 
@@ -373,6 +394,7 @@ class RemoteSessionStore {
       updatedAt: now,
       messages: this.cloneMessages(session.messages),
       latestAttachments: this.cloneAttachments(session.latestAttachments),
+      mergedSessionIds: this.cloneMergedSessionIds(session.mergedSessionIds),
     };
 
     await this.writeSession(forkedSession);
@@ -385,6 +407,154 @@ class RemoteSessionStore {
       sourceSessionId,
       messageCount: forkedSession.messages.length,
     };
+  }
+
+
+  async mergeSessionReference(platformKey: string, targetSessionId: string, ownerKey?: string): Promise<MergeSessionResult> {
+    const normalizedTarget = targetSessionId.trim();
+    if (!normalizedTarget) {
+      return { ok: false, reason: 'Missing target session id' };
+    }
+
+    const currentBinding = await this.getOrCreate(platformKey, false, ownerKey);
+    const currentSessionId = currentBinding.sessionId;
+    const currentSession = await this.readSession(currentSessionId);
+    if (!currentSession || currentSession.platformKey !== platformKey) {
+      return { ok: false, reason: 'Current session not found', currentSessionId };
+    }
+
+    if (normalizedTarget === currentSessionId) {
+      return { ok: false, reason: 'Cannot merge the current session itself', currentSessionId };
+    }
+
+    const targetSession = await this.readSession(normalizedTarget);
+    if (!targetSession) {
+      return { ok: false, reason: `Session not found: ${normalizedTarget}`, currentSessionId };
+    }
+
+    if (!this.canAccessSession(targetSession, platformKey, ownerKey)) {
+      return { ok: false, reason: 'Session does not belong to current user', currentSessionId };
+    }
+
+    const mergedSessionIds = this.cloneMergedSessionIds(currentSession.mergedSessionIds);
+    if (mergedSessionIds.includes(normalizedTarget)) {
+      return {
+        ok: true,
+        currentSessionId,
+        mergedSessionId: normalizedTarget,
+        mergedCount: mergedSessionIds.length,
+        alreadyMerged: true,
+      };
+    }
+
+    mergedSessionIds.push(normalizedTarget);
+    currentSession.mergedSessionIds = mergedSessionIds;
+    currentSession.updatedAt = Date.now();
+    await this.writeSession(currentSession);
+
+    return {
+      ok: true,
+      currentSessionId,
+      mergedSessionId: normalizedTarget,
+      mergedCount: mergedSessionIds.length,
+      alreadyMerged: false,
+    };
+  }
+
+  async listMergedSessionSummaries(
+    platformKey: string,
+    ownerKey?: string,
+  ): Promise<{ currentSessionId?: string; sessions: MergedSessionSummary[] }> {
+    const currentSessionId = this.index[platformKey];
+    if (!currentSessionId) {
+      return { sessions: [] };
+    }
+
+    const currentSession = await this.readSession(currentSessionId);
+    if (!currentSession || currentSession.platformKey !== platformKey) {
+      return { sessions: [] };
+    }
+
+    const mergedSessionIds = this.cloneMergedSessionIds(currentSession.mergedSessionIds);
+    if (mergedSessionIds.length === 0) {
+      return { currentSessionId, sessions: [] };
+    }
+
+    const sessions: MergedSessionSummary[] = [];
+    const validIds: string[] = [];
+
+    for (const mergedSessionId of mergedSessionIds) {
+      const session = await this.readSession(mergedSessionId);
+      if (!session) {
+        continue;
+      }
+      if (!this.canAccessSession(session, platformKey, ownerKey)) {
+        continue;
+      }
+
+      validIds.push(mergedSessionId);
+      sessions.push({
+        id: session.id,
+        updatedAt: session.updatedAt,
+        messageCount: session.messages.length,
+        preview: this.buildPreview(session.messages),
+      });
+    }
+
+    if (validIds.length !== mergedSessionIds.length) {
+      currentSession.mergedSessionIds = validIds;
+      currentSession.updatedAt = Date.now();
+      await this.writeSession(currentSession);
+    }
+
+    return { currentSessionId, sessions };
+  }
+
+  async getMergedSessionDetails(
+    platformKey: string,
+    currentSessionId: string,
+    ownerKey?: string,
+  ): Promise<SessionDetail[]> {
+    const currentSession = await this.readSession(currentSessionId);
+    if (!currentSession || currentSession.platformKey !== platformKey) {
+      return [];
+    }
+
+    const mergedSessionIds = this.cloneMergedSessionIds(currentSession.mergedSessionIds);
+    if (mergedSessionIds.length === 0) {
+      return [];
+    }
+
+    const details: SessionDetail[] = [];
+    const seenSessionIds = new Set<string>();
+
+    for (const mergedSessionId of mergedSessionIds) {
+      if (seenSessionIds.has(mergedSessionId) || mergedSessionId === currentSessionId) {
+        continue;
+      }
+      seenSessionIds.add(mergedSessionId);
+
+      const mergedSession = await this.readSession(mergedSessionId);
+      if (!mergedSession) {
+        continue;
+      }
+      if (!this.canAccessSession(mergedSession, platformKey, ownerKey)) {
+        continue;
+      }
+
+      details.push({
+        id: mergedSession.id,
+        platformKey: mergedSession.platformKey,
+        ownerKey: mergedSession.ownerKey,
+        createdAt: mergedSession.createdAt,
+        updatedAt: mergedSession.updatedAt,
+        messages: this.cloneMessages(mergedSession.messages),
+        latestAttachments: this.cloneAttachments(mergedSession.latestAttachments),
+        mergedSessionIds: this.cloneMergedSessionIds(mergedSession.mergedSessionIds),
+      });
+    }
+
+    return details;
   }
 
   /**
@@ -500,6 +670,20 @@ class RemoteSessionStore {
     } catch {
       return [...messages];
     }
+  }
+
+
+  private cloneMergedSessionIds(mergedSessionIds?: string[]): string[] {
+    if (!Array.isArray(mergedSessionIds) || mergedSessionIds.length === 0) {
+      return [];
+    }
+
+    const normalized = mergedSessionIds
+      .filter((sessionId): sessionId is string => typeof sessionId === 'string')
+      .map((sessionId) => sessionId.trim())
+      .filter((sessionId) => sessionId.length > 0);
+
+    return [...new Set(normalized)];
   }
 
   private canAccessSession(session: RemoteSession, platformKey: string, ownerKey?: string): boolean {


### PR DESCRIPTION
Add soft-merge support for remote chat sessions so users can reference another session with /merge without rewriting history.

- add /merge command handling with list mode in remote chat command router
- persist mergedSessionIds in remote session store with ownership/access checks
- inject bounded merged session transcript into system prompt during agent runs
- update help and command allowlist to include /merge