### PR TITLE
feat(canvas-workspace): apply Pulse Canvas logo across UI surfaces

### DIFF
--- a/apps/canvas-workspace/src/main/index.ts
+++ b/apps/canvas-workspace/src/main/index.ts
@@ -102,6 +102,16 @@ app.whenReady().then(() => {
     }
   }
 
+  // About panel: shown by the native menu (macOS: Pulse Canvas > About;
+  // Linux: Help > About). iconPath is honored on Linux/Windows; macOS
+  // reads the icon from the app bundle.
+  app.setAboutPanelOptions({
+    applicationName: "Pulse Canvas",
+    applicationVersion: app.getVersion(),
+    copyright: "Copyright © 2025",
+    ...(resolvedIconPath ? { iconPath: resolvedIconPath } : {})
+  });
+
   ipcMain.on("app:log", (_event, payload) => {
     const level = payload?.level ?? "renderer";
     const message = payload?.message ?? "log";

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEmptyHint/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEmptyHint/index.css
@@ -10,8 +10,8 @@
 }
 
 .hint-icon {
-  width: 48px;
-  height: 48px;
+  width: 56px;
+  height: 56px;
   border-radius: var(--radius-lg);
   background: var(--surface);
   box-shadow: var(--shadow-card);

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEmptyHint/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEmptyHint/index.tsx
@@ -3,21 +3,13 @@ import './index.css';
 export const CanvasEmptyHint = () => (
   <div className="canvas-empty-hint">
     <div className="hint-icon">
-      <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-        <rect
-          x="4"
-          y="4"
-          width="16"
-          height="16"
-          rx="3"
-          stroke="currentColor"
-          strokeWidth="1.5"
-        />
+      <svg width="32" height="32" viewBox="0 0 512 512" fill="none" aria-hidden="true">
         <path
-          d="M10 12h4M12 10v4"
+          d="M 80,268 H 188 L 228,178 L 260,370 L 292,148 L 328,268 H 432"
           stroke="currentColor"
-          strokeWidth="1.5"
+          strokeWidth="22"
           strokeLinecap="round"
+          strokeLinejoin="round"
         />
       </svg>
     </div>

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
@@ -38,10 +38,32 @@
   justify-content: center;
 }
 
+.sidebar-brand-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px 12px;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.sidebar-brand-mark {
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.sidebar-brand-mark svg {
+  display: block;
+}
+
 .sidebar-brand {
   font-size: 13px;
   font-weight: 600;
   color: var(--text);
+  letter-spacing: -0.01em;
   flex: 1;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
@@ -380,6 +380,23 @@ export const Sidebar = ({
     <aside className={`sidebar${collapsed ? ' sidebar--collapsed' : ''}`}>
       {!collapsed && (
         <>
+          {/* Brand header */}
+          <div className="sidebar-brand-header">
+            <span className="sidebar-brand-mark" aria-hidden="true">
+              <svg width="22" height="22" viewBox="0 0 512 512" fill="none">
+                <rect x="32" y="32" width="448" height="448" rx="96" ry="96" fill="#1D1D1F" />
+                <path
+                  d="M 80,268 H 188 L 228,178 L 260,370 L 292,148 L 328,268 H 432"
+                  stroke="#FFFFFF"
+                  strokeWidth="22"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </span>
+            <span className="sidebar-brand">Pulse Canvas</span>
+          </div>
+
           {/* Section header with add + collapse buttons */}
           <div className="sidebar-section-header">
             <span className="sidebar-section-title">Workspaces</span>


### PR DESCRIPTION
- CanvasEmptyHint: replace generic placeholder with the Pulse mark
- Sidebar: add brand header ("icon + Pulse Canvas") using the existing .sidebar-brand CSS hook
- Main process: register app.setAboutPanelOptions so the native About dialog shows product name, version, copyright, and icon

https://claude.ai/code/session_01PNiUKk1mgJ2YqgmeCWXdQJ