### PR TITLE
Clear initial prompt after execution to prevent replay

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -165,6 +165,17 @@ export const AgentNodeBody = ({ node, rootFolder, workspaceId, onUpdate }: Props
       } else {
         api.write(sessionId, `${command}\n`);
       }
+
+      // The initial prompt is a one-shot task: once it has been written to
+      // the PTY it has been consumed and must not be replayed. Clear the
+      // persisted fields so that reopening the canvas re-attaches without
+      // re-executing the same command. (We intentionally leave agentArgs
+      // alone — that's a stable CLI arg the user may want on restart.)
+      if (inlinePrompt || promptFile) {
+        onUpdateRef.current(nodeIdRef.current, {
+          data: { ...dataRef.current, inlinePrompt: '', promptFile: '' },
+        });
+      }
     };
 
     // Wait for the shell to emit its first output (prompt) before writing


### PR DESCRIPTION
## Summary
Modified the AgentNodeBody component to clear the initial prompt fields after they have been written to the PTY, preventing the same command from being re-executed when the canvas is reopened.

## Key Changes
- Added logic to clear `inlinePrompt` and `promptFile` fields after the initial command is written to the terminal
- The cleared state is persisted so that reopening the canvas re-attaches to the agent without replaying the consumed command
- Intentionally preserves `agentArgs` as it represents stable CLI arguments the user may want to retain on restart

## Implementation Details
- The prompt clearing occurs immediately after `api.write()` is called, ensuring the command has been sent to the PTY
- Uses the existing `onUpdateRef` callback to persist the cleared state to the node data
- Includes a detailed comment explaining the one-shot nature of the initial prompt and the rationale for selective field clearing

https://claude.ai/code/session_013j2pPfxxusHe3RBRExRUmi