### PR TITLE
Remove nodeAppear animation from canvas nodes

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -10,7 +10,6 @@
   flex-direction: column;
   overflow: hidden;
   transition: box-shadow 0.15s ease, border-color 0.15s ease;
-  animation: nodeAppear 0.2s ease;
 }
 
 .canvas-node:hover {
@@ -219,17 +218,6 @@
   10% { opacity: 1; transform: translateY(0); }
   80% { opacity: 1; transform: translateY(0); }
   100% { opacity: 0; transform: translateY(-2px); }
-}
-
-@keyframes nodeAppear {
-  from {
-    opacity: 0;
-    transform: translate(var(--x, 0), var(--y, 0)) scale(0.95);
-  }
-  to {
-    opacity: 1;
-    transform: translate(var(--x, 0), var(--y, 0)) scale(1);
-  }
 }
 
 @keyframes nodeHighlight {


### PR DESCRIPTION
## Summary
Removed the `nodeAppear` animation that was applied to canvas nodes on render, along with its associated keyframe definition.

## Changes
- Removed the `animation: nodeAppear 0.2s ease;` CSS property from the `.canvas-node` class
- Deleted the `@keyframes nodeAppear` animation definition that provided a fade-in and scale effect (0.95 to 1.0 scale with opacity transition)

## Details
This change simplifies the canvas node styling by eliminating the entrance animation. Canvas nodes will now appear instantly without the previous 0.2s fade-in and scale-up effect. This may improve perceived performance or address animation-related issues with node rendering.

https://claude.ai/code/session_01VziQzFPhpDMocSuittjvyR