### PR TITLE
Extract shared icon primitives into reusable components

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useCallback, Fragment } from 'react';
 import MarkdownIt from 'markdown-it';
 import type { AgentChatMessage, AgentSessionInfo, CanvasNode } from '../../types';
+import { AvatarIcon, CloseIcon, PlusIcon, ListLinesIcon } from '../icons';
 
 interface OtherWorkspaceSession extends AgentSessionInfo {
   sourceWorkspaceId: string;
@@ -153,7 +154,13 @@ const md = new MarkdownIt({ html: false, linkify: true, breaks: true });
 // ─── @ Mention rendering ─────────────────────────────────────────
 const MENTION_RE = /@\[([^\]]+)\]/g;
 
-/** SVG icon markup for a given node type (HTML attributes use kebab-case). */
+/**
+ * Inner SVG markup for a given node type, shared between two rendering paths:
+ *  - `mentionIconSvg` (HTML string concatenation, used inside `renderMdWithMentions`)
+ *  - `MentionNodeIcon` (JSX component, used inside `renderUserContent` and the mention picker)
+ * Path data is tuned for a 14×14 viewBox that's specific to chat mention chips;
+ * the broader 16×16 `NodeTypeIcon` family in `components/icons` is used elsewhere.
+ */
 function mentionIconSvg(nodeType: string): string {
   switch (nodeType) {
     case 'terminal':
@@ -168,6 +175,17 @@ function mentionIconSvg(nodeType: string): string {
       return '<rect x="2" y="1.5" width="10" height="11" rx="1.5" stroke="currentColor" stroke-width="1.2"/><path d="M4.5 5h5M4.5 7.5h3" stroke="currentColor" stroke-width="1" stroke-linecap="round"/>';
   }
 }
+
+/** JSX wrapper over `mentionIconSvg` — one source of truth for mention icon paths. */
+const MentionNodeIcon = ({ nodeType, size = 12 }: { nodeType: string; size?: number }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 14 14"
+    fill="none"
+    dangerouslySetInnerHTML={{ __html: mentionIconSvg(nodeType) }}
+  />
+);
 
 /**
  * Extract `@[canvas:Name]` tokens from a serialized message and resolve each
@@ -235,12 +253,7 @@ function renderUserContent(content: string, nodes?: CanvasNode[]): React.ReactNo
           data-node-type="workspace"
         >
           <span className="chat-mention-chip-icon">
-            <svg width="12" height="12" viewBox="0 0 14 14" fill="none">
-              <rect x="1.5" y="1.5" width="11" height="11" rx="1.5" stroke="currentColor" strokeWidth="1.2" />
-              <rect x="3.5" y="3.5" width="3" height="3" rx="0.5" stroke="currentColor" strokeWidth="1" />
-              <rect x="7.5" y="3.5" width="3" height="3" rx="0.5" stroke="currentColor" strokeWidth="1" />
-              <rect x="3.5" y="7.5" width="3" height="3" rx="0.5" stroke="currentColor" strokeWidth="1" />
-            </svg>
+            <MentionNodeIcon nodeType="workspace" />
           </span>
           <span className="chat-mention-chip-label">{wsLabel}</span>
         </span>
@@ -254,26 +267,7 @@ function renderUserContent(content: string, nodes?: CanvasNode[]): React.ReactNo
     parts.push(
       <span key={match.index} className="chat-mention-chip chat-mention-chip--clickable" data-node-type={node?.type} data-node-id={node?.id}>
         <span className="chat-mention-chip-icon">
-          {node?.type === 'terminal' ? (
-            <svg width="12" height="12" viewBox="0 0 14 14" fill="none">
-              <rect x="1.5" y="2" width="11" height="10" rx="1.5" stroke="currentColor" strokeWidth="1.2" />
-              <path d="M4 6l2 1.5L4 9" stroke="currentColor" strokeWidth="1" strokeLinecap="round" strokeLinejoin="round" />
-            </svg>
-          ) : node?.type === 'agent' ? (
-            <svg width="12" height="12" viewBox="0 0 14 14" fill="none">
-              <circle cx="7" cy="5" r="2.5" stroke="currentColor" strokeWidth="1.2" />
-              <path d="M3.5 12c0-1.9 1.6-3.5 3.5-3.5s3.5 1.6 3.5 3.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-            </svg>
-          ) : node?.type === 'frame' ? (
-            <svg width="12" height="12" viewBox="0 0 14 14" fill="none">
-              <rect x="2" y="2" width="10" height="10" rx="2" stroke="currentColor" strokeWidth="1.2" />
-            </svg>
-          ) : (
-            <svg width="12" height="12" viewBox="0 0 14 14" fill="none">
-              <rect x="2" y="1.5" width="10" height="11" rx="1.5" stroke="currentColor" strokeWidth="1.2" />
-              <path d="M4.5 5h5M4.5 7.5h3" stroke="currentColor" strokeWidth="1" strokeLinecap="round" />
-            </svg>
-          )}
+          <MentionNodeIcon nodeType={node?.type ?? 'file'} />
         </span>
         <span className="chat-mention-chip-label">{label}</span>
       </span>
@@ -883,10 +877,7 @@ export const ChatPanel = ({ workspaceId, allWorkspaces, nodes, rootFolder, onClo
       <div className="chat-panel-header">
         <div className="chat-panel-title-wrapper" ref={sessionMenuRef}>
           <button className="chat-panel-title-btn" onClick={() => void openSessionMenu()}>
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-              <circle cx="8" cy="6" r="3" stroke="currentColor" strokeWidth="1.3" />
-              <path d="M4 14c0-2.2 1.8-4 4-4s4 1.8 4 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
-            </svg>
+            <AvatarIcon size={16} />
             <span>Pulse Agent</span>
             <svg className="chat-panel-title-chevron" width="12" height="12" viewBox="0 0 12 12" fill="none">
               <path d="M3 4.5l3 3 3-3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
@@ -895,9 +886,7 @@ export const ChatPanel = ({ workspaceId, allWorkspaces, nodes, rootFolder, onClo
           {sessionMenuOpen && (
             <div className="chat-session-menu">
               <button className="chat-session-menu-new" onClick={() => void handleNewSession()}>
-                <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-                  <path d="M7 3v8M3 7h8" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
-                </svg>
+                <PlusIcon size={14} strokeWidth={1.3} />
                 <span>New chat</span>
               </button>
               {sessions.length > 0 && (
@@ -914,9 +903,7 @@ export const ChatPanel = ({ workspaceId, allWorkspaces, nodes, rootFolder, onClo
                           else setSessionMenuOpen(false);
                         }}
                       >
-                        <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-                          <path d="M4 3.5h6M4 7h4M4 10.5h5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-                        </svg>
+                        <ListLinesIcon size={14} />
                         <span className="chat-session-menu-item-text">
                           {s.isCurrent ? 'Current chat' : (s.preview || s.date)}
                         </span>
@@ -937,9 +924,7 @@ export const ChatPanel = ({ workspaceId, allWorkspaces, nodes, rootFolder, onClo
                         className="chat-session-menu-item chat-session-menu-item--other-ws"
                         onClick={() => void handleLoadSession(s.sessionId, s.sourceWorkspaceId)}
                       >
-                        <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-                          <path d="M4 3.5h6M4 7h4M4 10.5h5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-                        </svg>
+                        <ListLinesIcon size={14} />
                         <span className="chat-session-menu-item-text">
                           {s.preview || s.date}
                         </span>
@@ -959,14 +944,10 @@ export const ChatPanel = ({ workspaceId, allWorkspaces, nodes, rootFolder, onClo
             onClick={() => void handleNewSession()}
             title="New chat"
           >
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-              <path d="M8 3v10M3 8h10" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
-            </svg>
+            <PlusIcon size={16} strokeWidth={1.3} />
           </button>
           <button className="chat-panel-action-btn" onClick={onClose} title="Close panel">
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-              <path d="M12 4L4 12M4 4l8 8" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
-            </svg>
+            <CloseIcon size={16} strokeWidth={1.3} />
           </button>
         </div>
       </div>
@@ -1006,10 +987,7 @@ export const ChatPanel = ({ workspaceId, allWorkspaces, nodes, rootFolder, onClo
               <div key={i} className={`chat-message chat-message-${msg.role}`}>
                 {msg.role === 'assistant' && (
                   <div className="chat-message-avatar">
-                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-                      <circle cx="8" cy="6" r="3" stroke="currentColor" strokeWidth="1.3" />
-                      <path d="M4 14c0-2.2 1.8-4 4-4s4 1.8 4 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
-                    </svg>
+                    <AvatarIcon size={14} />
                   </div>
                 )}
                 <div className="chat-message-body">
@@ -1044,10 +1022,7 @@ export const ChatPanel = ({ workspaceId, allWorkspaces, nodes, rootFolder, onClo
           {loading && !(messages.length > 0 && messages[messages.length - 1].role === 'assistant') && (
             <div className="chat-message chat-message-assistant">
               <div className="chat-message-avatar">
-                <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-                  <circle cx="8" cy="6" r="3" stroke="currentColor" strokeWidth="1.3" />
-                  <path d="M4 14c0-2.2 1.8-4 4-4s4 1.8 4 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
-                </svg>
+                <AvatarIcon size={14} />
               </div>
               <div className="chat-message-body">
                 <div className="chat-loading">
@@ -1080,26 +1055,16 @@ export const ChatPanel = ({ workspaceId, allWorkspaces, nodes, rootFolder, onClo
                     onMouseEnter={() => setMentionIndex(i)}
                   >
                     <span className="chat-mention-item-icon">
-                      {item.type === 'workspace' ? (
-                        <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-                          <rect x="1.5" y="1.5" width="11" height="11" rx="1.5" stroke="currentColor" strokeWidth="1.2" />
-                          <rect x="3.5" y="3.5" width="3" height="3" rx="0.5" stroke="currentColor" strokeWidth="1" />
-                          <rect x="7.5" y="3.5" width="3" height="3" rx="0.5" stroke="currentColor" strokeWidth="1" />
-                          <rect x="3.5" y="7.5" width="3" height="3" rx="0.5" stroke="currentColor" strokeWidth="1" />
-                        </svg>
-                      ) : item.type === 'node' ? (
-                        <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-                          {item.nodeType === 'file' && <><rect x="2" y="1.5" width="10" height="11" rx="1.5" stroke="currentColor" strokeWidth="1.2" /><path d="M4.5 5h5M4.5 7.5h3" stroke="currentColor" strokeWidth="1" strokeLinecap="round" /></>}
-                          {item.nodeType === 'terminal' && <><rect x="1.5" y="2" width="11" height="10" rx="1.5" stroke="currentColor" strokeWidth="1.2" /><path d="M4 6l2 1.5L4 9" stroke="currentColor" strokeWidth="1" strokeLinecap="round" strokeLinejoin="round" /></>}
-                          {item.nodeType === 'agent' && <><circle cx="7" cy="5" r="2.5" stroke="currentColor" strokeWidth="1.2" /><path d="M3.5 12c0-1.9 1.6-3.5 3.5-3.5s3.5 1.6 3.5 3.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" /></>}
-                          {item.nodeType === 'frame' && <rect x="2" y="2" width="10" height="10" rx="2" stroke="currentColor" strokeWidth="1.2" />}
-                        </svg>
-                      ) : (
-                        <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-                          <rect x="2" y="1.5" width="10" height="11" rx="1.5" stroke="currentColor" strokeWidth="1.2" />
-                          <path d="M4.5 5h5M4.5 7.5h3" stroke="currentColor" strokeWidth="1" strokeLinecap="round" />
-                        </svg>
-                      )}
+                      <MentionNodeIcon
+                        size={14}
+                        nodeType={
+                          item.type === 'workspace'
+                            ? 'workspace'
+                            : item.type === 'node'
+                              ? item.nodeType ?? 'file'
+                              : 'file'
+                        }
+                      />
                     </span>
                     <span className="chat-mention-item-label">{item.label}</span>
                   </button>

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
@@ -467,7 +467,7 @@
 .sidebar-layer-count {
   font-size: 11px;
   color: var(--text-muted);
-  margin-left: auto;
+  padding: 0 2px;
 }
 
 .sidebar-layers-scroll {
@@ -560,8 +560,8 @@
 }
 
 .sidebar-layer-children {
-  padding-left: 12px;
-  margin-left: 8px;
+  padding: 0 0 0 10px;
+  margin: 0 6px 0 12px;
   border-left: 1.5px solid var(--border-light);
 }
 
@@ -593,7 +593,7 @@
 
 .sidebar-folder-children {
   padding: 0 0 0 10px;
-  margin: 0 6px 0 16px;
+  margin: 0 6px 0 12px;
   border-left: 1.5px solid var(--border-light);
   transition: border-color 0.15s;
   min-height: 2px;
@@ -680,4 +680,10 @@
 .sidebar-layer-context-menu-item--danger:hover {
   background: rgba(192, 57, 43, 0.08);
   color: #c0392b;
+}
+
+.sidebar-layer-context-menu-separator {
+  height: 1px;
+  background: var(--border-light);
+  margin: 4px 2px;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
@@ -541,6 +541,12 @@
   transform: rotate(90deg);
 }
 
+.sidebar-layer-spacer {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
 .sidebar-layer-child-count {
   font-size: 10px;
   color: var(--text-muted);

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useMemo, useRef, useState, useCallback, type DragEvent, type MouseEvent as ReactMouseEvent } from 'react';
 import type { WorkspaceEntry, FolderEntry } from '../../hooks/useWorkspaces';
 import type { CanvasNode } from '../../types';
+import {
+  CloseIcon,
+  PlusIcon,
+  ChevronRightIcon,
+  WorkspaceIcon,
+  FolderIcon,
+  NodeTypeIcon,
+} from '../icons';
 import './index.css';
 
 /* ---- Spatial containment (same logic as useNodeDrag) ---- */
@@ -53,57 +61,13 @@ const buildLayerTree = (nodes: CanvasNode[]): LayerTreeNode[] => {
   return tree;
 };
 
-/* ---- Per-type icon for the Layers panel ---- */
-const LayerIcon = ({ type }: { type: CanvasNode['type'] }) => {
-  switch (type) {
-    case 'file':
-      return (
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-          <path d="M4 2h5l3 3v9H4V2z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
-          <path d="M9 2v3h3" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
-      );
-    case 'terminal':
-      return (
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-          <rect x="2" y="3" width="12" height="10" rx="1.5" stroke="currentColor" strokeWidth="1.2" />
-          <path d="M5 7l2 1.5L5 10" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
-          <path d="M9 10h2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-        </svg>
-      );
-    case 'frame':
-      // Four corner brackets — conveys "container / crop frame"
-      return (
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-          <path
-            d="M3 6V4a1 1 0 011-1h2M10 3h2a1 1 0 011 1v2M13 10v2a1 1 0 01-1 1h-2M6 13H4a1 1 0 01-1-1v-2"
-            stroke="currentColor"
-            strokeWidth="1.3"
-            strokeLinecap="round"
-          />
-        </svg>
-      );
-    case 'agent':
-      // Pulse waveform matching the Pulse Canvas brand mark
-      return (
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-          <path
-            d="M2 8H6L7 5L8 12L9 4L10 8H14"
-            stroke="currentColor"
-            strokeWidth="1.4"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-      );
-    default:
-      return (
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-          <rect x="2" y="2" width="12" height="12" rx="2" stroke="currentColor" strokeWidth="1.2" strokeDasharray="2 2" />
-        </svg>
-      );
-  }
-};
+/** Icon for the sidebar panel toggle (used in both expanded + collapsed states). */
+const SidebarToggleIcon = ({ size = 14 }: { size?: number }) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none">
+    <rect x="1.5" y="2.5" width="13" height="11" rx="2" stroke="currentColor" strokeWidth="1.3" />
+    <path d="M6 2.5v11" stroke="currentColor" strokeWidth="1.3" />
+  </svg>
+);
 
 interface Props {
   collapsed: boolean;
@@ -418,19 +382,14 @@ export const Sidebar = ({
             title="Double-click to rename"
           >
             <span className="sidebar-item-icon">
-              <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-                <rect x="2" y="2" width="12" height="12" rx="2" stroke="currentColor" strokeWidth="1.3" />
-                <path d="M5 6h6M5 9h4" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-              </svg>
+              <WorkspaceIcon size={14} />
             </span>
             <span className="sidebar-item-name">{ws.name}</span>
           </button>
         )}
         {workspaces.length > 1 && renamingId !== ws.id && (
           <button className="sidebar-item-delete" onClick={() => onDelete(ws.id)} title="Delete">
-            <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
-              <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-            </svg>
+            <CloseIcon size={12} strokeWidth={1.5} />
           </button>
         )}
       </div>
@@ -475,15 +434,10 @@ export const Sidebar = ({
                 onClick={() => setShowAddMenu((v) => !v)}
                 title="Add workspace or folder"
               >
-                <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-                  <path d="M8 3v10M3 8h10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-                </svg>
+                <PlusIcon size={14} />
               </button>
               <button className="sidebar-section-btn" onClick={onToggle} title="Collapse sidebar">
-                <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-                  <rect x="1.5" y="2.5" width="13" height="11" rx="2" stroke="currentColor" strokeWidth="1.3" />
-                  <path d="M6 2.5v11" stroke="currentColor" strokeWidth="1.3" />
-                </svg>
+                <SidebarToggleIcon size={14} />
               </button>
               {showAddMenu && (
                 <div className="sidebar-add-menu">
@@ -491,19 +445,14 @@ export const Sidebar = ({
                     className="sidebar-add-menu-item"
                     onClick={() => { setShowAddMenu(false); setInlineCreate('workspace'); setInlineCreateValue(''); }}
                   >
-                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-                      <rect x="2" y="2" width="12" height="12" rx="2" stroke="currentColor" strokeWidth="1.3" />
-                      <path d="M5 6h6M5 9h4" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-                    </svg>
+                    <WorkspaceIcon size={14} />
                     <span>New Workspace</span>
                   </button>
                   <button
                     className="sidebar-add-menu-item"
                     onClick={() => { setShowAddMenu(false); setInlineCreate('folder'); setInlineCreateValue(''); }}
                   >
-                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-                      <path d="M2 4.5A1.5 1.5 0 013.5 3H6l1.5 1.5h5A1.5 1.5 0 0114 6v5.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 012 11.5v-7z" stroke="currentColor" strokeWidth="1.2" />
-                    </svg>
+                    <FolderIcon size={14} />
                     <span>New Folder</span>
                   </button>
                 </div>
@@ -565,18 +514,10 @@ export const Sidebar = ({
                         title="Click to toggle · Double-click to rename"
                       >
                         <span className={`sidebar-folder-chevron${isOpen ? ' sidebar-folder-chevron--open' : ''}`}>
-                          <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
-                            <path d="M6 4l4 4-4 4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
-                          </svg>
+                          <ChevronRightIcon size={10} />
                         </span>
                         <span className="sidebar-folder-icon">
-                          <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-                            {isOpen ? (
-                              <path d="M2 5.5A1.5 1.5 0 013.5 4H6l1.5 1.5h5A1.5 1.5 0 0114 7v4.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 012 11.5v-6z" fill="currentColor" opacity="0.15" stroke="currentColor" strokeWidth="1.1" />
-                            ) : (
-                              <path d="M2 4.5A1.5 1.5 0 013.5 3H6l1.5 1.5h5A1.5 1.5 0 0114 6v5.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 012 11.5v-7z" stroke="currentColor" strokeWidth="1.2" />
-                            )}
-                          </svg>
+                          <FolderIcon size={18} open={isOpen} strokeWidth={isOpen ? 1.1 : 1.2} />
                         </span>
                         <span className="sidebar-folder-name">{folder.name}</span>
                       </button>
@@ -587,9 +528,7 @@ export const Sidebar = ({
                         onClick={() => onDeleteFolder(folder.id)}
                         title="Delete folder"
                       >
-                        <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
-                          <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-                        </svg>
+                        <CloseIcon size={12} strokeWidth={1.5} />
                       </button>
                     )}
                   </div>
@@ -622,16 +561,7 @@ export const Sidebar = ({
               <div className="sidebar-list">
                 <div className="sidebar-inline-create">
                   <span className="sidebar-item-icon">
-                    {inlineCreate === 'folder' ? (
-                      <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-                        <path d="M2 4.5A1.5 1.5 0 013.5 3H6l1.5 1.5h5A1.5 1.5 0 0114 6v5.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 012 11.5v-7z" stroke="currentColor" strokeWidth="1.2" />
-                      </svg>
-                    ) : (
-                      <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-                        <rect x="2" y="2" width="12" height="12" rx="2" stroke="currentColor" strokeWidth="1.3" />
-                        <path d="M5 6h6M5 9h4" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-                      </svg>
-                    )}
+                    {inlineCreate === 'folder' ? <FolderIcon size={14} /> : <WorkspaceIcon size={14} />}
                   </span>
                   <input
                     ref={inlineCreateRef}
@@ -708,15 +638,13 @@ export const Sidebar = ({
                         className={`sidebar-layer-chevron${isOpen ? ' sidebar-layer-chevron--open' : ''}`}
                         onClick={(e) => { e.stopPropagation(); toggleLayerCollapse(node.id); }}
                       >
-                        <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
-                          <path d="M6 4l4 4-4 4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
-                        </svg>
+                        <ChevronRightIcon size={10} />
                       </span>
                     ) : (
                       <span className="sidebar-layer-spacer" aria-hidden="true" />
                     )}
                     <span className="sidebar-layer-icon">
-                      <LayerIcon type={node.type} />
+                      <NodeTypeIcon type={node.type} />
                     </span>
                     <span className="sidebar-layer-name">
                       {node.type === 'frame' ? (node.title || (node.data as { label?: string }).label || 'Frame') : node.title}
@@ -737,7 +665,7 @@ export const Sidebar = ({
                           title={child.title}
                         >
                           <span className="sidebar-layer-icon">
-                            <LayerIcon type={child.type} />
+                            <NodeTypeIcon type={child.type} />
                           </span>
                           <span className="sidebar-layer-name">{child.title}</span>
                         </button>
@@ -814,10 +742,7 @@ export const Sidebar = ({
       {collapsed && (
         <div className="sidebar-collapsed-toggle">
           <button className="sidebar-toggle" onClick={onToggle} title="Expand sidebar">
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-              <rect x="1.5" y="2.5" width="13" height="11" rx="2" stroke="currentColor" strokeWidth="1.3" />
-              <path d="M6 2.5v11" stroke="currentColor" strokeWidth="1.3" />
-            </svg>
+            <SidebarToggleIcon size={16} />
           </button>
         </div>
       )}

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
@@ -170,6 +170,23 @@ export const Sidebar = ({
   } | null>(null);
 
   const layerTree = useMemo(() => buildLayerTree(activeNodes), [activeNodes]);
+  const frameIds = useMemo(
+    () => layerTree.filter((n) => n.node.type === 'frame').map((n) => n.node.id),
+    [layerTree],
+  );
+  const anyFrameExpanded = useMemo(
+    () => frameIds.some((id) => !collapsedLayers.has(id)),
+    [frameIds, collapsedLayers],
+  );
+
+  const toggleAllLayers = useCallback(() => {
+    setCollapsedLayers((prev) => {
+      if (frameIds.length === 0) return prev;
+      // If any frame is currently expanded → collapse them all. Otherwise expand.
+      const anyExpanded = frameIds.some((id) => !prev.has(id));
+      return anyExpanded ? new Set(frameIds) : new Set();
+    });
+  }, [frameIds]);
 
   const handleLayerContextMenu = useCallback((e: ReactMouseEvent, nodeId: string) => {
     e.preventDefault();
@@ -640,7 +657,39 @@ export const Sidebar = ({
         <div className="sidebar-layers">
           <div className="sidebar-section-header">
             <span className="sidebar-section-title">Layers</span>
-            <span className="sidebar-layer-count">{activeNodes.length}</span>
+            <div className="sidebar-section-actions">
+              <span className="sidebar-layer-count">{activeNodes.length}</span>
+              {frameIds.length > 0 && (
+                <button
+                  className="sidebar-section-btn"
+                  onClick={toggleAllLayers}
+                  title={anyFrameExpanded ? 'Collapse all frames' : 'Expand all frames'}
+                  aria-label={anyFrameExpanded ? 'Collapse all frames' : 'Expand all frames'}
+                >
+                  {anyFrameExpanded ? (
+                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+                      <path
+                        d="M4 2l4 4 4-4M4 14l4-4 4 4"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  ) : (
+                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+                      <path
+                        d="M4 6l4-4 4 4M4 10l4 4 4-4"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  )}
+                </button>
+              )}
+            </div>
           </div>
           <div className="sidebar-layers-scroll">
             {layerTree.map(({ node, children }) => {
@@ -732,6 +781,21 @@ export const Sidebar = ({
           onMouseDown={(e) => e.stopPropagation()}
           onContextMenu={(e) => e.preventDefault()}
         >
+          <button
+            className="sidebar-layer-context-menu-item"
+            onClick={() => {
+              onNodeFocus?.(layerContextMenu.nodeId);
+              setLayerContextMenu(null);
+            }}
+          >
+            <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
+              <circle cx="8" cy="8" r="5" stroke="currentColor" strokeWidth="1.3" />
+              <circle cx="8" cy="8" r="1.2" fill="currentColor" />
+              <path d="M8 1.5v1.5M8 13v1.5M1.5 8h1.5M13 8h1.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+            </svg>
+            <span>Focus</span>
+          </button>
+          <div className="sidebar-layer-context-menu-separator" />
           <button
             className="sidebar-layer-context-menu-item sidebar-layer-context-menu-item--danger"
             onClick={() => {

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
@@ -53,6 +53,58 @@ const buildLayerTree = (nodes: CanvasNode[]): LayerTreeNode[] => {
   return tree;
 };
 
+/* ---- Per-type icon for the Layers panel ---- */
+const LayerIcon = ({ type }: { type: CanvasNode['type'] }) => {
+  switch (type) {
+    case 'file':
+      return (
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+          <path d="M4 2h5l3 3v9H4V2z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
+          <path d="M9 2v3h3" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      );
+    case 'terminal':
+      return (
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+          <rect x="2" y="3" width="12" height="10" rx="1.5" stroke="currentColor" strokeWidth="1.2" />
+          <path d="M5 7l2 1.5L5 10" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+          <path d="M9 10h2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+        </svg>
+      );
+    case 'frame':
+      // Four corner brackets — conveys "container / crop frame"
+      return (
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+          <path
+            d="M3 6V4a1 1 0 011-1h2M10 3h2a1 1 0 011 1v2M13 10v2a1 1 0 01-1 1h-2M6 13H4a1 1 0 01-1-1v-2"
+            stroke="currentColor"
+            strokeWidth="1.3"
+            strokeLinecap="round"
+          />
+        </svg>
+      );
+    case 'agent':
+      // Pulse waveform matching the Pulse Canvas brand mark
+      return (
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+          <path
+            d="M2 8H6L7 5L8 12L9 4L10 8H14"
+            stroke="currentColor"
+            strokeWidth="1.4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      );
+    default:
+      return (
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+          <rect x="2" y="2" width="12" height="12" rx="2" stroke="currentColor" strokeWidth="1.2" strokeDasharray="2 2" />
+        </svg>
+      );
+  }
+};
+
 interface Props {
   collapsed: boolean;
   onToggle: () => void;
@@ -602,7 +654,7 @@ export const Sidebar = ({
                     onContextMenu={(e) => handleLayerContextMenu(e, node.id)}
                     title={node.title}
                   >
-                    {isFrame && (
+                    {isFrame ? (
                       <span
                         className={`sidebar-layer-chevron${isOpen ? ' sidebar-layer-chevron--open' : ''}`}
                         onClick={(e) => { e.stopPropagation(); toggleLayerCollapse(node.id); }}
@@ -611,24 +663,11 @@ export const Sidebar = ({
                           <path d="M6 4l4 4-4 4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
                         </svg>
                       </span>
+                    ) : (
+                      <span className="sidebar-layer-spacer" aria-hidden="true" />
                     )}
                     <span className="sidebar-layer-icon">
-                      {node.type === 'file' ? (
-                        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-                          <path d="M4 2h5l3 3v9H4V2z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
-                          <path d="M9 2v3h3" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
-                        </svg>
-                      ) : node.type === 'terminal' ? (
-                        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-                          <rect x="2" y="3" width="12" height="10" rx="1.5" stroke="currentColor" strokeWidth="1.2" />
-                          <path d="M5 7l2 1.5L5 10" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
-                          <path d="M9 10h2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-                        </svg>
-                      ) : (
-                        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-                          <rect x="2" y="2" width="12" height="12" rx="2" stroke="currentColor" strokeWidth="1.2" strokeDasharray="2 2" />
-                        </svg>
-                      )}
+                      <LayerIcon type={node.type} />
                     </span>
                     <span className="sidebar-layer-name">
                       {node.type === 'frame' ? (node.title || (node.data as { label?: string }).label || 'Frame') : node.title}
@@ -649,18 +688,7 @@ export const Sidebar = ({
                           title={child.title}
                         >
                           <span className="sidebar-layer-icon">
-                            {child.type === 'file' ? (
-                              <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-                                <path d="M4 2h5l3 3v9H4V2z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
-                                <path d="M9 2v3h3" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
-                              </svg>
-                            ) : (
-                              <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-                                <rect x="2" y="3" width="12" height="10" rx="1.5" stroke="currentColor" strokeWidth="1.2" />
-                                <path d="M5 7l2 1.5L5 10" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
-                                <path d="M9 10h2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-                              </svg>
-                            )}
+                            <LayerIcon type={child.type} />
                           </span>
                           <span className="sidebar-layer-name">{child.title}</span>
                         </button>

--- a/apps/canvas-workspace/src/renderer/src/components/icons/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/icons/index.tsx
@@ -1,0 +1,206 @@
+/**
+ * Shared icon primitives used across Sidebar, ChatPanel, etc.
+ *
+ * Scope: only icons that are either (a) duplicated in ≥2 places with the
+ * same underlying path, or (b) represent a canonical brand concept like a
+ * canvas node type. Context-specific icons (e.g. 18×18 FloatingToolbar
+ * glyphs, 12×12 CanvasNodeView badges) intentionally stay inline because
+ * their path data has been tuned for that context.
+ */
+import type { CanvasNode } from '../../types';
+
+interface IconProps {
+  size?: number;
+  className?: string;
+  strokeWidth?: number;
+}
+
+/** Close / cancel (×). Canonical 16×16 path. */
+export const CloseIcon = ({ size = 16, className, strokeWidth = 1.3 }: IconProps) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className}>
+    <path
+      d="M4 4l8 8M12 4l-8 8"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/** Plus / add (+). Canonical 16×16 path. */
+export const PlusIcon = ({ size = 16, className, strokeWidth = 1.5 }: IconProps) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className}>
+    <path
+      d="M8 3v10M3 8h10"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/** Right-pointing chevron (›). Used for expand/collapse. */
+export const ChevronRightIcon = ({ size = 10, className, strokeWidth = 1.8 }: IconProps) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className}>
+    <path
+      d="M6 4l4 4-4 4"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+/** Workspace card icon — a bordered card with two lines inside. */
+export const WorkspaceIcon = ({ size = 14, className, strokeWidth = 1.3 }: IconProps) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className}>
+    <rect
+      x="2"
+      y="2"
+      width="12"
+      height="12"
+      rx="2"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+    />
+    <path d="M5 6h6M5 9h4" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+  </svg>
+);
+
+interface FolderIconProps extends IconProps {
+  open?: boolean;
+}
+
+/** Folder icon with optional open (filled) variant. */
+export const FolderIcon = ({ size = 14, className, strokeWidth = 1.2, open = false }: FolderIconProps) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className}>
+    {open ? (
+      <path
+        d="M2 5.5A1.5 1.5 0 013.5 4H6l1.5 1.5h5A1.5 1.5 0 0114 7v4.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 012 11.5v-6z"
+        fill="currentColor"
+        opacity="0.15"
+        stroke="currentColor"
+        strokeWidth={strokeWidth}
+      />
+    ) : (
+      <path
+        d="M2 4.5A1.5 1.5 0 013.5 3H6l1.5 1.5h5A1.5 1.5 0 0114 6v5.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 012 11.5v-7z"
+        stroke="currentColor"
+        strokeWidth={strokeWidth}
+      />
+    )}
+  </svg>
+);
+
+/** Simple person / agent silhouette. Used as the assistant avatar. */
+export const AvatarIcon = ({ size = 16, className, strokeWidth = 1.3 }: IconProps) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className}>
+    <circle cx="8" cy="6" r="3" stroke="currentColor" strokeWidth={strokeWidth} />
+    <path
+      d="M4 14c0-2.2 1.8-4 4-4s4 1.8 4 4"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/** Three horizontal lines representing a list entry. */
+export const ListLinesIcon = ({ size = 14, className }: IconProps) => (
+  <svg width={size} height={size} viewBox="0 0 14 14" fill="none" className={className}>
+    <path
+      d="M4 3.5h6M4 7h4M4 10.5h5"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+interface NodeTypeIconProps {
+  type: CanvasNode['type'];
+  size?: number;
+  className?: string;
+}
+
+/**
+ * Canonical 16×16 icon for a canvas node type. Used anywhere that
+ * surfaces the node's type (sidebar Layers, future contexts).
+ */
+export const NodeTypeIcon = ({ type, size = 14, className }: NodeTypeIconProps) => {
+  switch (type) {
+    case 'file':
+      return (
+        <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className}>
+          <path
+            d="M4 2h5l3 3v9H4V2z"
+            stroke="currentColor"
+            strokeWidth="1.2"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M9 2v3h3"
+            stroke="currentColor"
+            strokeWidth="1.2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      );
+    case 'terminal':
+      return (
+        <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className}>
+          <rect x="2" y="3" width="12" height="10" rx="1.5" stroke="currentColor" strokeWidth="1.2" />
+          <path
+            d="M5 7l2 1.5L5 10"
+            stroke="currentColor"
+            strokeWidth="1.2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <path d="M9 10h2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+        </svg>
+      );
+    case 'frame':
+      // Four corner brackets — conveys "container / crop frame"
+      return (
+        <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className}>
+          <path
+            d="M3 6V4a1 1 0 011-1h2M10 3h2a1 1 0 011 1v2M13 10v2a1 1 0 01-1 1h-2M6 13H4a1 1 0 01-1-1v-2"
+            stroke="currentColor"
+            strokeWidth="1.3"
+            strokeLinecap="round"
+          />
+        </svg>
+      );
+    case 'agent':
+      // Pulse waveform matching the Pulse Canvas brand mark
+      return (
+        <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className}>
+          <path
+            d="M2 8H6L7 5L8 12L9 4L10 8H14"
+            stroke="currentColor"
+            strokeWidth="1.4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      );
+    default:
+      return (
+        <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className}>
+          <rect
+            x="2"
+            y="2"
+            width="12"
+            height="12"
+            rx="2"
+            stroke="currentColor"
+            strokeWidth="1.2"
+            strokeDasharray="2 2"
+          />
+        </svg>
+      );
+  }
+};


### PR DESCRIPTION
## Summary
Consolidates duplicated SVG icon definitions across the Sidebar and ChatPanel components into a centralized, reusable icon library. This reduces code duplication, improves maintainability, and establishes a single source of truth for canonical icon designs.

## Key Changes

- **New `components/icons/index.tsx`**: Created a shared icon primitives module containing:
  - Generic utility icons: `CloseIcon`, `PlusIcon`, `ChevronRightIcon`
  - Domain-specific icons: `WorkspaceIcon`, `FolderIcon`, `AvatarIcon`, `ListLinesIcon`
  - `NodeTypeIcon` component that renders canonical 16×16 icons for canvas node types (file, terminal, frame, agent)
  - Consistent `IconProps` interface for size, className, and strokeWidth customization

- **Sidebar refactoring**: 
  - Replaced 15+ inline SVG definitions with imported icon components
  - Added `SidebarToggleIcon` helper for the sidebar collapse/expand button
  - Implemented "expand/collapse all frames" functionality in the Layers section with toggle state tracking
  - Added "Focus" action to layer context menu
  - Improved layer tree spacing with `sidebar-layer-spacer` for non-frame nodes

- **ChatPanel refactoring**:
  - Replaced inline SVG definitions with imported icons (`AvatarIcon`, `CloseIcon`, `PlusIcon`, `ListLinesIcon`)
  - Created `MentionNodeIcon` JSX wrapper over existing `mentionIconSvg` function to unify mention icon rendering paths
  - Maintained chat-specific 14×14 mention icon paths while leveraging shared icon infrastructure

- **CSS updates**:
  - Adjusted `.sidebar-section-header` layout to accommodate new expand/collapse button
  - Refined layer tree indentation and spacing for visual consistency
  - Added `.sidebar-layer-context-menu-separator` for menu organization
  - Updated `.sidebar-layer-count` padding to work with new button layout

## Implementation Details

- Icon components accept optional `size`, `className`, and `strokeWidth` props for flexibility across different contexts
- `NodeTypeIcon` uses a switch statement to render type-specific paths, with a dashed-box fallback for unknown types
- Chat mention icons maintain their tuned 14×14 viewBox while reusing path data through `mentionIconSvg`
- Layer expand/collapse state is tracked via `collapsedLayers` Set, with new `toggleAllLayers` callback for bulk operations

https://claude.ai/code/session_0163cNzZ1bC1ochMbgAuMTCY