### PR TITLE
Add clarification request support to Canvas Agent chat

### DIFF
--- a/apps/canvas-workspace/src/main/canvas-agent-ipc.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent-ipc.ts
@@ -2,21 +2,24 @@
  * IPC handlers for the Canvas Agent.
  *
  * Channels:
- *   canvas-agent:chat         — send a message, stream text deltas, get final response
- *   canvas-agent:status       — check if agent is active
- *   canvas-agent:history      — get current session messages
- *   canvas-agent:sessions     — list all sessions (current + archived)
- *   canvas-agent:new-session  — start a new session
- *   canvas-agent:load-session — load an archived session
- *   canvas-agent:activate     — explicitly start the agent
- *   canvas-agent:deactivate   — stop the agent and archive session
+ *   canvas-agent:chat              — send a message, stream text deltas, get final response
+ *   canvas-agent:abort             — interrupt the currently-running chat turn
+ *   canvas-agent:clarify-answer    — deliver a user reply to a pending clarification
+ *   canvas-agent:status            — check if agent is active
+ *   canvas-agent:history           — get current session messages
+ *   canvas-agent:sessions          — list all sessions (current + archived)
+ *   canvas-agent:new-session       — start a new session
+ *   canvas-agent:load-session      — load an archived session
+ *   canvas-agent:activate          — explicitly start the agent
+ *   canvas-agent:deactivate        — stop the agent and archive session
  *
  * Streaming:
  *   canvas-agent:chat returns { ok, sessionId } immediately.
- *   Text deltas arrive on    `canvas-agent:text-delta:{sessionId}`.
- *   Tool call starts arrive on `canvas-agent:tool-call:{sessionId}`.
- *   Tool results arrive on    `canvas-agent:tool-result:{sessionId}`.
- *   Completion arrives on     `canvas-agent:chat-complete:{sessionId}`.
+ *   Text deltas arrive on         `canvas-agent:text-delta:{sessionId}`.
+ *   Tool call starts arrive on    `canvas-agent:tool-call:{sessionId}`.
+ *   Tool results arrive on        `canvas-agent:tool-result:{sessionId}`.
+ *   Clarification requests arrive on `canvas-agent:clarify-request:{sessionId}`.
+ *   Completion arrives on         `canvas-agent:chat-complete:{sessionId}`.
  */
 
 import { ipcMain } from 'electron';
@@ -24,6 +27,14 @@ import { randomUUID } from 'crypto';
 import { CanvasAgentService } from './canvas-agent/service';
 
 let service: CanvasAgentService | null = null;
+
+/**
+ * Track which workspace each in-flight sessionId belongs to, so that
+ * clarification answers from the renderer can be routed back to the right
+ * agent instance. Entries are cleared when the corresponding chat turn
+ * completes or is aborted.
+ */
+const sessionWorkspaceMap = new Map<string, string>();
 
 function getService(): CanvasAgentService {
   if (!service) {
@@ -43,6 +54,7 @@ export function setupCanvasAgentIpc(): void {
     ) => {
       const sessionId = randomUUID();
       const sender = event.sender;
+      sessionWorkspaceMap.set(sessionId, payload.workspaceId);
 
       // Fire-and-forget: run the agent asynchronously, streaming text deltas
       void (async () => {
@@ -66,6 +78,11 @@ export function setupCanvasAgentIpc(): void {
               }
             },
             payload.mentionedWorkspaceIds,
+            (req) => {
+              if (!sender.isDestroyed()) {
+                sender.send(`canvas-agent:clarify-request:${sessionId}`, req);
+              }
+            },
           );
           if (!sender.isDestroyed()) {
             sender.send(`canvas-agent:chat-complete:${sessionId}`, result);
@@ -77,11 +94,38 @@ export function setupCanvasAgentIpc(): void {
               error: String(err),
             });
           }
+        } finally {
+          sessionWorkspaceMap.delete(sessionId);
         }
       })();
 
       // Return immediately with the sessionId for the renderer to subscribe
       return { ok: true, sessionId };
+    },
+  );
+
+  ipcMain.handle(
+    'canvas-agent:abort',
+    (_event, payload: { sessionId?: string; workspaceId?: string }) => {
+      const workspaceId =
+        payload.workspaceId ??
+        (payload.sessionId ? sessionWorkspaceMap.get(payload.sessionId) : undefined);
+      if (!workspaceId) return { ok: false, error: 'No active run for sessionId' };
+      svc.abort(workspaceId);
+      return { ok: true };
+    },
+  );
+
+  ipcMain.handle(
+    'canvas-agent:clarify-answer',
+    (
+      _event,
+      payload: { sessionId: string; requestId: string; answer: string },
+    ) => {
+      const workspaceId = sessionWorkspaceMap.get(payload.sessionId);
+      if (!workspaceId) return { ok: false, error: 'No active run for sessionId' };
+      const matched = svc.answerClarification(workspaceId, payload.requestId, payload.answer);
+      return { ok: matched, error: matched ? undefined : 'No pending clarification matched' };
     },
   );
 

--- a/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
@@ -44,6 +44,7 @@ Your system prompt contains a summary of all canvas nodes. For detailed content:
 - \`canvas_update_node\`: Update existing nodes (content, title, data)
 - \`canvas_delete_node\`: Remove a node from the canvas
 - \`canvas_move_node\`: Reposition a node
+- \`canvas_ask_user\`: **Ask the user a clarifying question** — use this whenever the request is ambiguous, you need a choice between options, or you need confirmation before taking a destructive action. Prefer asking over guessing.
 
 ### Delegating Tasks to Agent Nodes
 Use \`canvas_create_agent_node\` to spawn another agent (Claude Code, Codex, Pulse Coder) with context.
@@ -132,11 +133,23 @@ function buildSystemPrompt(
 
 // ─── Canvas Agent ──────────────────────────────────────────────────
 
+/** Request payload emitted when the agent wants to ask the user a question. */
+export interface CanvasClarificationRequest {
+  id: string;
+  question: string;
+  context?: string;
+}
+
 export class CanvasAgent {
   private engine: any; // Engine type from pulse-coder-engine (no .d.ts yet)
   private messages: ModelMessage[] = [];
   private sessionStore: SessionStore;
   private config: CanvasAgentConfig;
+
+  /** AbortController for the currently-running chat turn, if any. */
+  private currentAbortController: AbortController | null = null;
+  /** Pending clarification resolvers keyed by request id. */
+  private pendingClarifications = new Map<string, (answer: string) => void>();
 
   constructor(config: CanvasAgentConfig) {
     this.config = config;
@@ -171,9 +184,15 @@ export class CanvasAgent {
 
   /**
    * Send a user message and get the agent's response.
+   *
    * @param onText — optional callback receiving streaming text deltas
    * @param onToolCall — optional callback when a tool call starts
    * @param onToolResult — optional callback when a tool call completes
+   * @param mentionedWorkspaceIds — workspaces the user @-mentioned
+   * @param onClarificationRequest — optional callback invoked when the agent
+   *   wants to ask the user a clarifying question. The caller is responsible
+   *   for displaying it and eventually calling `answerClarification` with the
+   *   user's reply (or `abort()` to cancel the run).
    */
   async chat(
     message: string,
@@ -181,6 +200,7 @@ export class CanvasAgent {
     onToolCall?: (data: { name: string; args: any }) => void,
     onToolResult?: (data: { name: string; result: string }) => void,
     mentionedWorkspaceIds?: string[],
+    onClarificationRequest?: (req: CanvasClarificationRequest) => void,
   ): Promise<string> {
     // Refresh workspace summary for system prompt
     const summary = await buildWorkspaceSummary(this.config.workspaceId);
@@ -206,46 +226,97 @@ export class CanvasAgent {
     // Build the context — pass a mutable reference so onResponse/onCompacted can update it
     const context = { messages: this.messages };
 
-    const resultText = await this.engine.run(context, {
-      systemPrompt,
-      maxSteps: 10,
-      onText,
-      onToolCall: onToolCall
-        ? (chunk: any) => {
-            // AI SDK v6 uses `input`; older versions use `args`
-            const args = chunk.input ?? chunk.args;
-            console.info('[canvas-agent] tool-call chunk keys:', Object.keys(chunk), 'input:', chunk.input, 'args:', chunk.args);
-            onToolCall({ name: chunk.toolName, args });
-          }
-        : undefined,
-      onToolResult: onToolResult
-        ? (chunk: any) => {
-            // AI SDK v6 uses `output`; older versions use `result`
-            const raw = chunk.output ?? chunk.result;
-            console.info('[canvas-agent] tool-result chunk keys:', Object.keys(chunk), 'output:', typeof chunk.output, 'result:', typeof chunk.result);
-            onToolResult({
-              name: chunk.toolName,
-              result: typeof raw === 'string' ? raw : JSON.stringify(raw),
+    // One AbortController per chat turn. Exposed via this.abort() so callers
+    // can interrupt a long-running generation.
+    const abortController = new AbortController();
+    this.currentAbortController = abortController;
+
+    // Wire the clarify tool through: each clarification request gets a
+    // resolver stashed in `pendingClarifications` keyed by request id. The
+    // caller (IPC handler) dispatches the request to the renderer and calls
+    // `answerClarification(id, answer)` when the user replies.
+    const engineClarificationHandler = onClarificationRequest
+      ? async (req: { id: string; question: string; context?: string }) => {
+          return await new Promise<string>((resolve) => {
+            this.pendingClarifications.set(req.id, resolve);
+            onClarificationRequest({
+              id: req.id,
+              question: req.question,
+              context: req.context,
             });
-          }
-        : undefined,
-      onResponse: (msgs: ModelMessage[]) => {
-        for (const msg of msgs) {
-          this.messages.push(msg);
+          });
         }
-      },
-      onCompacted: (newMessages: ModelMessage[]) => {
-        this.messages = newMessages;
-        context.messages = newMessages;
-      },
-    });
+      : undefined;
 
-    const responseText = resultText || '(no response)';
+    try {
+      const resultText = await this.engine.run(context, {
+        systemPrompt,
+        maxSteps: 10,
+        abortSignal: abortController.signal,
+        onClarificationRequest: engineClarificationHandler,
+        onText,
+        onToolCall: onToolCall
+          ? (chunk: any) => {
+              // AI SDK v6 uses `input`; older versions use `args`
+              const args = chunk.input ?? chunk.args;
+              console.info('[canvas-agent] tool-call chunk keys:', Object.keys(chunk), 'input:', chunk.input, 'args:', chunk.args);
+              onToolCall({ name: chunk.toolName, args });
+            }
+          : undefined,
+        onToolResult: onToolResult
+          ? (chunk: any) => {
+              // AI SDK v6 uses `output`; older versions use `result`
+              const raw = chunk.output ?? chunk.result;
+              console.info('[canvas-agent] tool-result chunk keys:', Object.keys(chunk), 'output:', typeof chunk.output, 'result:', typeof chunk.result);
+              onToolResult({
+                name: chunk.toolName,
+                result: typeof raw === 'string' ? raw : JSON.stringify(raw),
+              });
+            }
+          : undefined,
+        onResponse: (msgs: ModelMessage[]) => {
+          for (const msg of msgs) {
+            this.messages.push(msg);
+          }
+        },
+        onCompacted: (newMessages: ModelMessage[]) => {
+          this.messages = newMessages;
+          context.messages = newMessages;
+        },
+      });
 
-    // Persist assistant response
-    this.sessionStore.addMessage({ role: 'assistant', content: responseText, timestamp: Date.now() });
+      const responseText = resultText || '(no response)';
 
-    return responseText;
+      // Persist assistant response
+      this.sessionStore.addMessage({ role: 'assistant', content: responseText, timestamp: Date.now() });
+
+      return responseText;
+    } finally {
+      if (this.currentAbortController === abortController) {
+        this.currentAbortController = null;
+      }
+      this.pendingClarifications.clear();
+    }
+  }
+
+  /**
+   * Abort the current chat turn if one is running. Safe to call when no
+   * turn is active — it becomes a no-op.
+   */
+  abort(): void {
+    this.currentAbortController?.abort();
+  }
+
+  /**
+   * Deliver a user's answer to a pending clarification request. Returns
+   * true if the answer matched a pending request, false otherwise.
+   */
+  answerClarification(requestId: string, answer: string): boolean {
+    const resolver = this.pendingClarifications.get(requestId);
+    if (!resolver) return false;
+    this.pendingClarifications.delete(requestId);
+    resolver(answer);
+    return true;
   }
 
   /**

--- a/apps/canvas-workspace/src/main/canvas-agent/service.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/service.ts
@@ -9,7 +9,7 @@
 
 import { join } from 'path';
 import { homedir } from 'os';
-import { CanvasAgent } from './canvas-agent';
+import { CanvasAgent, type CanvasClarificationRequest } from './canvas-agent';
 import { SessionStore } from './session-store';
 import type {
   ChatResponse,
@@ -44,6 +44,9 @@ export class CanvasAgentService {
    * Send a chat message to the workspace's Canvas Agent.
    * Auto-activates the agent if not already active.
    * @param onText — optional callback receiving streaming text deltas
+   * @param onClarificationRequest — invoked when the agent needs to ask the
+   *   user a clarifying question; the caller must eventually deliver the
+   *   reply via `answerClarification` or cancel via `abort`.
    */
   async chat(
     workspaceId: string,
@@ -52,6 +55,7 @@ export class CanvasAgentService {
     onToolCall?: (data: { name: string; args: any }) => void,
     onToolResult?: (data: { name: string; result: string }) => void,
     mentionedWorkspaceIds?: string[],
+    onClarificationRequest?: (req: CanvasClarificationRequest) => void,
   ): Promise<ChatResponse> {
     try {
       await this.activate(workspaceId);
@@ -62,12 +66,31 @@ export class CanvasAgentService {
         onToolCall,
         onToolResult,
         mentionedWorkspaceIds,
+        onClarificationRequest,
       );
       return { ok: true, response };
     } catch (err) {
       console.error(`[canvas-agent-service] chat error for ${workspaceId}:`, err);
       return { ok: false, error: String(err) };
     }
+  }
+
+  /**
+   * Abort the workspace's currently-running chat turn (if any). No-op when
+   * the agent is idle or not activated.
+   */
+  abort(workspaceId: string): void {
+    this.agents.get(workspaceId)?.abort();
+  }
+
+  /**
+   * Deliver the user's answer to a pending clarification request.
+   * Returns true if a matching pending request was resolved.
+   */
+  answerClarification(workspaceId: string, requestId: string, answer: string): boolean {
+    const agent = this.agents.get(workspaceId);
+    if (!agent) return false;
+    return agent.answerClarification(requestId, answer);
   }
 
   /**

--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -11,6 +11,7 @@
 import { promises as fs } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+import { randomUUID } from 'crypto';
 import { BrowserWindow } from 'electron';
 import { z } from 'zod';
 import {
@@ -102,11 +103,28 @@ function autoPlace(nodes: CanvasNode[]): { x: number; y: number } {
 
 // ─── Canvas Tool type (matches Engine's Tool interface) ────────────
 
+/**
+ * Subset of pulse-coder-engine's ToolExecutionContext that canvas tools may
+ * use. Kept loose so the shim (engine.d.ts) does not need to export this type.
+ */
+export interface CanvasToolExecutionContext {
+  /** Called when a tool needs to ask the user a clarifying question. */
+  onClarificationRequest?: (request: {
+    id: string;
+    question: string;
+    context?: string;
+    defaultAnswer?: string;
+    timeout: number;
+  }) => Promise<string>;
+  /** Abort signal for the current engine run. */
+  abortSignal?: AbortSignal;
+}
+
 export interface CanvasTool {
   name: string;
   description: string;
   inputSchema: z.ZodType;
-  execute: (input: any) => Promise<string>;
+  execute: (input: any, ctx?: CanvasToolExecutionContext) => Promise<string>;
 }
 
 /** Prompts shorter than this are passed directly as CLI args; longer ones go to a file. */
@@ -116,6 +134,49 @@ const INLINE_PROMPT_THRESHOLD = 256;
 
 export function createCanvasTools(workspaceId: string): Record<string, CanvasTool> {
   return {
+    canvas_ask_user: {
+      name: 'canvas_ask_user',
+      description:
+        'Ask the user a clarifying question and wait for their reply. Use this whenever you need more information, a choice between options, or confirmation before proceeding. Do NOT guess — ask.',
+      inputSchema: z.object({
+        question: z.string().describe('The question to ask the user. Be concise and specific.'),
+        context: z.string().optional().describe('Optional extra context to help the user answer.'),
+      }),
+      execute: async (input, ctx) => {
+        const ask = ctx?.onClarificationRequest;
+        if (!ask) {
+          return 'Clarification is not supported in this context. Proceed with best judgement.';
+        }
+        const signal = ctx?.abortSignal;
+        const requestId = randomUUID();
+        const askPromise = ask({
+          id: requestId,
+          question: input.question,
+          context: input.context,
+          timeout: 0,
+        });
+        if (!signal) return askPromise;
+        return await new Promise<string>((resolve, reject) => {
+          if (signal.aborted) {
+            reject(new Error('Aborted'));
+            return;
+          }
+          const onAbort = () => reject(new Error('Aborted'));
+          signal.addEventListener('abort', onAbort, { once: true });
+          askPromise.then(
+            (answer) => {
+              signal.removeEventListener('abort', onAbort);
+              resolve(answer);
+            },
+            (err) => {
+              signal.removeEventListener('abort', onAbort);
+              reject(err);
+            },
+          );
+        });
+      },
+    },
+
     canvas_read_context: {
       name: 'canvas_read_context',
       description:

--- a/apps/canvas-workspace/src/preload/index.ts
+++ b/apps/canvas-workspace/src/preload/index.ts
@@ -182,6 +182,27 @@ contextBridge.exposeInMainWorld("canvasWorkspace", {
       };
     },
 
+    onClarifyRequest: (
+      sessionId: string,
+      callback: (data: { id: string; question: string; context?: string }) => void,
+    ) => {
+      const channel = `canvas-agent:clarify-request:${sessionId}`;
+      const handler = (
+        _event: Electron.IpcRendererEvent,
+        data: { id: string; question: string; context?: string },
+      ) => callback(data);
+      ipcRenderer.on(channel, handler);
+      return () => {
+        ipcRenderer.removeListener(channel, handler);
+      };
+    },
+
+    answerClarification: (sessionId: string, requestId: string, answer: string) =>
+      ipcRenderer.invoke("canvas-agent:clarify-answer", { sessionId, requestId, answer }),
+
+    abort: (sessionId: string) =>
+      ipcRenderer.invoke("canvas-agent:abort", { sessionId }),
+
     getStatus: (workspaceId: string) =>
       ipcRenderer.invoke("canvas-agent:status", { workspaceId }),
 

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/ChatPanel.css
@@ -453,6 +453,129 @@
   cursor: not-allowed;
 }
 
+.chat-send-btn--stop {
+  background: #37352f;
+  color: #fff;
+}
+
+.chat-send-btn--stop:hover {
+  background: #2f2e2a;
+}
+
+/* ─── Generating state (input while a turn is streaming) ──── */
+
+.chat-input-box--generating {
+  /* Subtle animated border to signal "generating" without disabling input. */
+  border-color: rgba(55, 53, 47, 0.32);
+  box-shadow: 0 0 0 3px rgba(55, 53, 47, 0.04);
+}
+
+.chat-input-box--generating:focus-within {
+  border-color: rgba(55, 53, 47, 0.45);
+}
+
+.chat-generating-indicator {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 4px;
+  color: #8a8a87;
+  font-size: 12px;
+  line-height: 1;
+}
+
+.chat-generating-indicator .chat-loading-dot {
+  width: 4px;
+  height: 4px;
+}
+
+.chat-generating-label {
+  margin-left: 2px;
+}
+
+/* ─── Clarification card ──────────────────────────────────── */
+
+.chat-clarify-card {
+  border: 1px solid rgba(55, 53, 47, 0.12);
+  border-radius: 10px;
+  background: #fafaf9;
+  padding: 12px 14px;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+.chat-clarify-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #8a8a87;
+  margin-bottom: 6px;
+}
+
+.chat-clarify-question {
+  font-size: 14px;
+  color: #37352f;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.chat-clarify-context {
+  margin-top: 6px;
+  font-size: 12px;
+  color: #6b6b68;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.chat-clarify-form {
+  display: flex;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.chat-clarify-input {
+  flex: 1;
+  min-width: 0;
+  padding: 7px 10px;
+  font-size: 13px;
+  font-family: inherit;
+  color: #37352f;
+  background: #fff;
+  border: 1px solid rgba(55, 53, 47, 0.16);
+  border-radius: 6px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.chat-clarify-input:focus {
+  border-color: rgba(55, 53, 47, 0.4);
+}
+
+.chat-clarify-submit {
+  padding: 0 12px;
+  height: 30px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #fff;
+  background: #37352f;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.chat-clarify-submit:hover:not(:disabled) {
+  background: #2f2e2a;
+}
+
+.chat-clarify-submit:disabled {
+  background: rgba(55, 53, 47, 0.2);
+  cursor: not-allowed;
+}
+
 /* ─── Markdown content ────────────────────────────────────── */
 
 .chat-md {

--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
@@ -300,6 +300,12 @@ function renderMdWithMentions(content: string, nodes?: CanvasNode[]): string {
   });
 }
 
+interface PendingClarification {
+  id: string;
+  question: string;
+  context?: string;
+}
+
 export const ChatPanel = ({ workspaceId, allWorkspaces, nodes, rootFolder, onClose, onResizeStart, onNodeFocus }: ChatPanelProps) => {
   const [messages, setMessages] = useState<AgentChatMessage[]>([]);
   const [input, setInput] = useState('');
@@ -314,6 +320,14 @@ export const ChatPanel = ({ workspaceId, allWorkspaces, nodes, rootFolder, onClo
   const [collapsedSections, setCollapsedSections] = useState<Set<number>>(new Set());
   const toolIdCounter = useRef(0);
   const streamingMsgIdx = useRef(-1);
+
+  // SessionId of the currently-running chat turn, used by the stop button
+  // and the clarification answer flow. Null when idle.
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+  // In-flight clarification request — when set, render an inline question
+  // card with its own input. Cleared on answer, abort, or completion.
+  const [pendingClarify, setPendingClarify] = useState<PendingClarification | null>(null);
+  const [clarifyInput, setClarifyInput] = useState('');
 
   // Track active streaming subscriptions so they can be cleaned up on unmount
   const activeUnsubsRef = useRef<(() => void)[]>([]);
@@ -338,6 +352,12 @@ export const ChatPanel = ({ workspaceId, allWorkspaces, nodes, rootFolder, onClo
         setMessages(result.messages);
       }
     })();
+
+    // Reset per-run state when the user switches workspaces so nothing from
+    // a previous workspace's in-flight run leaks into the new panel.
+    setActiveSessionId(null);
+    setPendingClarify(null);
+    setClarifyInput('');
 
     return () => {
       // Unsubscribe any in-flight streaming listeners on unmount
@@ -421,10 +441,10 @@ export const ChatPanel = ({ workspaceId, allWorkspaces, nodes, rootFolder, onClo
     setCollapsedSections(new Set());
   }, [workspaceId]);
 
-  // Scroll to bottom when messages or streaming tools change
+  // Scroll to bottom when messages, streaming tools, or a clarification card change
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages, streamingTools]);
+  }, [messages, streamingTools, pendingClarify]);
 
   // Build mention items from nodes + files + other workspaces
   const buildMentionItems = useCallback(async (query: string) => {
@@ -550,6 +570,7 @@ export const ChatPanel = ({ workspaceId, allWorkspaces, nodes, rootFolder, onClo
       }
 
       const sessionId = result.sessionId;
+      setActiveSessionId(sessionId);
 
       // Create assistant message lazily on first event (tool call or text delta)
       const assistantIdx = { current: -1 };
@@ -570,6 +591,7 @@ export const ChatPanel = ({ workspaceId, allWorkspaces, nodes, rootFolder, onClo
         unsubComplete();
         unsubToolCall();
         unsubToolResult();
+        unsubClarify();
         activeUnsubsRef.current = [];
       };
 
@@ -610,6 +632,14 @@ export const ChatPanel = ({ workspaceId, allWorkspaces, nodes, rootFolder, onClo
         });
       });
 
+      // Subscribe to clarification requests — render an inline card with its
+      // own input so the user can answer without touching the main composer.
+      const unsubClarify = window.canvasWorkspace.agent.onClarifyRequest(sessionId, (req) => {
+        ensureAssistantMessage();
+        setPendingClarify({ id: req.id, question: req.question, context: req.context });
+        setClarifyInput('');
+      });
+
       // Subscribe to completion
       const unsubComplete = window.canvasWorkspace.agent.onChatComplete(sessionId, (completeResult) => {
         cleanupAllSubs();
@@ -620,6 +650,9 @@ export const ChatPanel = ({ workspaceId, allWorkspaces, nodes, rootFolder, onClo
         setStreamingTools([]);
         setExpandedTools(new Set());
         streamingMsgIdx.current = -1;
+        setActiveSessionId(null);
+        setPendingClarify(null);
+        setClarifyInput('');
 
         if (!completeResult.ok) {
           setMessages(prev => {
@@ -649,7 +682,7 @@ export const ChatPanel = ({ workspaceId, allWorkspaces, nodes, rootFolder, onClo
       });
 
       // Track all subscriptions so they can be cleaned up on workspace switch
-      activeUnsubsRef.current.push(unsubToolCall, unsubToolResult, unsubDelta, unsubComplete);
+      activeUnsubsRef.current.push(unsubToolCall, unsubToolResult, unsubDelta, unsubComplete, unsubClarify);
     } catch (err) {
       const errorMsg: AgentChatMessage = {
         role: 'assistant',
@@ -658,8 +691,43 @@ export const ChatPanel = ({ workspaceId, allWorkspaces, nodes, rootFolder, onClo
       };
       setMessages(prev => [...prev, errorMsg]);
       setLoading(false);
+      setActiveSessionId(null);
+      setPendingClarify(null);
+      setClarifyInput('');
     }
   }, [input, loading, workspaceId, allWorkspaces]);
+
+  /** Interrupt the currently-running generation. */
+  const handleAbort = useCallback(async () => {
+    const sid = activeSessionId;
+    if (!sid) return;
+    // Optimistically clear the pending clarify card so the UI responds
+    // instantly; the chat-complete event will finish resetting state.
+    setPendingClarify(null);
+    setClarifyInput('');
+    try {
+      await window.canvasWorkspace.agent.abort(sid);
+    } catch (err) {
+      console.error('[chat-panel] abort failed:', err);
+    }
+  }, [activeSessionId]);
+
+  /** Submit the user's reply to an in-flight clarification request. */
+  const handleAnswerClarification = useCallback(async () => {
+    const pending = pendingClarify;
+    const sid = activeSessionId;
+    if (!pending || !sid) return;
+    const answer = clarifyInput.trim();
+    if (!answer) return;
+    // Hide the card immediately — the agent will continue and stream again.
+    setPendingClarify(null);
+    setClarifyInput('');
+    try {
+      await window.canvasWorkspace.agent.answerClarification(sid, pending.id, answer);
+    } catch (err) {
+      console.error('[chat-panel] clarification answer failed:', err);
+    }
+  }, [pendingClarify, activeSessionId, clarifyInput]);
 
   const selectMention = useCallback((item: MentionItem) => {
     const el = editableRef.current;
@@ -1033,6 +1101,45 @@ export const ChatPanel = ({ workspaceId, allWorkspaces, nodes, rootFolder, onClo
               </div>
             </div>
           )}
+          {pendingClarify && (
+            <div className="chat-message chat-message-assistant">
+              <div className="chat-message-avatar">
+                <AvatarIcon size={14} />
+              </div>
+              <div className="chat-message-body">
+                <div className="chat-clarify-card">
+                  <div className="chat-clarify-label">Needs clarification</div>
+                  <div className="chat-clarify-question">{pendingClarify.question}</div>
+                  {pendingClarify.context && (
+                    <div className="chat-clarify-context">{pendingClarify.context}</div>
+                  )}
+                  <div className="chat-clarify-form">
+                    <input
+                      type="text"
+                      className="chat-clarify-input"
+                      value={clarifyInput}
+                      onChange={(e) => setClarifyInput(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' && !e.shiftKey) {
+                          e.preventDefault();
+                          void handleAnswerClarification();
+                        }
+                      }}
+                      placeholder="Type your answer…"
+                      autoFocus
+                    />
+                    <button
+                      className="chat-clarify-submit"
+                      onClick={() => void handleAnswerClarification()}
+                      disabled={!clarifyInput.trim()}
+                    >
+                      Reply
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
           <div ref={messagesEndRef} />
         </div>
       )}
@@ -1073,29 +1180,51 @@ export const ChatPanel = ({ workspaceId, allWorkspaces, nodes, rootFolder, onClo
             })}
           </div>
         )}
-        <div className="chat-input-box">
+        <div className={`chat-input-box${loading ? ' chat-input-box--generating' : ''}`}>
           <div
             ref={editableRef}
             className="chat-input"
-            contentEditable={!loading}
+            contentEditable={true}
             role="textbox"
-            data-placeholder="Ask anything..."
+            data-placeholder={loading ? 'Generating… you can type your next message' : 'Ask anything...'}
             onInput={handleInput}
             onKeyDown={handleKeyDown}
             onPaste={handlePaste}
           />
           <div className="chat-input-footer">
-            <div className="chat-input-footer-left" />
-            <button
-              className={`chat-send-btn${input.trim() ? ' chat-send-btn--active' : ''}`}
-              onClick={() => void sendMessage()}
-              disabled={!input.trim() || loading}
-              title="Send message"
-            >
-              <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                <path d="M8 12V4M8 4l-3.5 3.5M8 4l3.5 3.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-              </svg>
-            </button>
+            <div className="chat-input-footer-left">
+              {loading && (
+                <div className="chat-generating-indicator" aria-live="polite">
+                  <div className="chat-loading-dot" />
+                  <div className="chat-loading-dot" />
+                  <div className="chat-loading-dot" />
+                  <span className="chat-generating-label">Generating…</span>
+                </div>
+              )}
+            </div>
+            {loading ? (
+              <button
+                className="chat-send-btn chat-send-btn--stop"
+                onClick={() => void handleAbort()}
+                title="Stop generating"
+                aria-label="Stop generating"
+              >
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                  <rect x="3" y="3" width="8" height="8" rx="1.5" fill="currentColor" />
+                </svg>
+              </button>
+            ) : (
+              <button
+                className={`chat-send-btn${input.trim() ? ' chat-send-btn--active' : ''}`}
+                onClick={() => void sendMessage()}
+                disabled={!input.trim()}
+                title="Send message"
+              >
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                  <path d="M8 12V4M8 4l-3.5 3.5M8 4l3.5 3.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -164,6 +164,16 @@ export interface AgentApi {
     sessionId: string,
     callback: (data: { name: string; result: string }) => void
   ) => () => void;
+  onClarifyRequest: (
+    sessionId: string,
+    callback: (data: { id: string; question: string; context?: string }) => void
+  ) => () => void;
+  answerClarification: (
+    sessionId: string,
+    requestId: string,
+    answer: string
+  ) => Promise<{ ok: boolean; error?: string }>;
+  abort: (sessionId: string) => Promise<{ ok: boolean; error?: string }>;
   getStatus: (
     workspaceId: string
   ) => Promise<{ ok: boolean; active: boolean; messageCount: number }>;


### PR DESCRIPTION
## Summary
Adds support for the Canvas Agent to ask clarifying questions during chat interactions. When the agent needs more information, user confirmation, or a choice between options, it can now pause execution and request clarification via a new `canvas_ask_user` tool. The user sees an inline clarification card in the chat panel and can reply without interrupting their workflow.

## Key Changes

- **New `canvas_ask_user` tool**: Allows the agent to ask clarifying questions with optional context. The tool is documented in the system prompt and preferred over guessing.

- **Clarification request flow**: 
  - Agent calls `canvas_ask_user` → request emitted via `onClarificationRequest` callback
  - Renderer displays inline clarification card with question and input field
  - User replies → `answerClarification()` resolves the pending request
  - Agent resumes execution with the user's answer

- **Chat panel UI enhancements**:
  - Clarification card renders as a styled message with question, optional context, and reply input
  - Input remains enabled during generation with visual indicator ("Generating…")
  - New stop button (square icon) replaces send button while generating
  - Smooth scroll to clarification card when it appears

- **Session and abort management**:
  - Track active session ID to support stop button and clarification flow
  - `abort()` method interrupts current generation and clears pending clarifications
  - `answerClarification()` delivers user reply to pending request
  - Cleanup on workspace switch prevents state leakage between workspaces

- **IPC layer updates**:
  - New `canvas-agent:abort` handler to interrupt running turns
  - New `canvas-agent:clarify-answer` handler to deliver user replies
  - New `canvas-agent:clarify-request:{sessionId}` event for streaming clarification requests
  - Session-to-workspace mapping to route clarifications to correct agent instance

- **Engine integration**:
  - Pass `abortSignal` and `onClarificationRequest` to engine.run()
  - Clarification requests are awaited as promises, allowing agent to pause and resume
  - Abort signal properly cancels pending clarifications

## Implementation Details

- Clarification requests are tracked by UUID and stored in a map until answered or aborted
- The clarification card is rendered inline in the message stream, maintaining conversation context
- User can press Enter or click Reply button to submit answer; button is disabled until input is non-empty
- All pending state (activeSessionId, pendingClarify, clarifyInput) is reset on workspace switch and chat completion
- Stop button uses optimistic UI update to clear clarification card immediately while abort completes asynchronously

https://claude.ai/code/session_01RaV43KRwQZeYNrPN3UySRZ