### PR TITLE
Improve sidebar collapse animations with CSS grid transitions

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatPanel/index.tsx
@@ -46,11 +46,11 @@ const CANVAS_MENTION_PREFIX = 'canvas:';
  * header text the user sees.
  */
 const MENTION_GROUPS = [
-  { key: 'canvas',    label: 'Canvas' },
   { key: 'file',      label: 'File' },
   { key: 'agent',     label: 'Agent' },
   { key: 'terminal',  label: 'Terminal' },
   { key: 'frame',     label: 'Frame' },
+  { key: 'canvas',    label: 'Canvas' },
   { key: 'proj-file', label: 'Project Files' },
 ] as const;
 
@@ -449,7 +449,7 @@ export const ChatPanel = ({ workspaceId, allWorkspaces, nodes, rootFolder, onClo
   // Build mention items from nodes + files + other workspaces
   const buildMentionItems = useCallback(async (query: string) => {
     const items: MentionItem[] = [];
-    // Other canvases (workspaces) — shown first so they're easy to reach
+    // Other canvases (workspaces) — ordering is handled by MENTION_GROUPS below
     if (allWorkspaces) {
       for (const ws of allWorkspaces) {
         if (ws.id === workspaceId) continue;

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
@@ -560,9 +560,28 @@
 }
 
 .sidebar-layer-children {
+  display: grid;
+  grid-template-rows: 1fr;
   padding: 0 0 0 10px;
   margin: 0 6px 0 12px;
   border-left: 1.5px solid var(--border-light);
+  transition:
+    grid-template-rows 0.2s ease,
+    opacity 0.18s ease,
+    border-left-color 0.2s ease;
+  min-height: 0;
+}
+
+.sidebar-layer-children-inner {
+  min-height: 0;
+  overflow: hidden;
+}
+
+.sidebar-layer-children--collapsed {
+  grid-template-rows: 0fr;
+  opacity: 0;
+  pointer-events: none;
+  border-left-color: transparent;
 }
 
 .sidebar-folder-delete {
@@ -592,15 +611,28 @@
 }
 
 .sidebar-folder-children {
+  display: grid;
+  grid-template-rows: 1fr;
   padding: 0 0 0 10px;
   margin: 0 6px 0 12px;
   border-left: 1.5px solid var(--border-light);
-  transition: border-color 0.15s;
-  min-height: 2px;
+  transition:
+    grid-template-rows 0.2s ease,
+    opacity 0.18s ease,
+    border-left-color 0.2s ease;
+  min-height: 0;
+}
+
+.sidebar-folder-children-inner {
+  min-height: 0;
+  overflow: hidden;
 }
 
 .sidebar-folder-children--collapsed {
-  display: none;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  pointer-events: none;
+  border-left-color: transparent;
 }
 
 .sidebar-folder-empty {

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
@@ -536,11 +536,14 @@ export const Sidebar = ({
                   {/* Folder children */}
                   <div
                     className={`sidebar-folder-children${!isOpen ? ' sidebar-folder-children--collapsed' : ''}${isWsDrop ? ' sidebar-drop-zone--active' : ''}`}
+                    aria-hidden={!isOpen}
                   >
-                    {isOpen && folderWorkspaces.map(renderWorkspaceItem)}
-                    {isOpen && folderWorkspaces.length === 0 && (
-                      <div className="sidebar-folder-empty">Drop workspaces here</div>
-                    )}
+                    <div className="sidebar-folder-children-inner">
+                      {folderWorkspaces.map(renderWorkspaceItem)}
+                      {folderWorkspaces.length === 0 && (
+                        <div className="sidebar-folder-empty">Drop workspaces here</div>
+                      )}
+                    </div>
                   </div>
                 </div>
               );
@@ -654,22 +657,27 @@ export const Sidebar = ({
                     )}
                   </button>
                   {/* Children of frame */}
-                  {isFrame && isOpen && children.length > 0 && (
-                    <div className="sidebar-layer-children">
-                      {children.map((child) => (
-                        <button
-                          key={child.id}
-                          className="sidebar-layer-item"
-                          onClick={() => onNodeFocus?.(child.id)}
-                          onContextMenu={(e) => handleLayerContextMenu(e, child.id)}
-                          title={child.title}
-                        >
-                          <span className="sidebar-layer-icon">
-                            <NodeTypeIcon type={child.type} />
-                          </span>
-                          <span className="sidebar-layer-name">{child.title}</span>
-                        </button>
-                      ))}
+                  {isFrame && children.length > 0 && (
+                    <div
+                      className={`sidebar-layer-children${!isOpen ? ' sidebar-layer-children--collapsed' : ''}`}
+                      aria-hidden={!isOpen}
+                    >
+                      <div className="sidebar-layer-children-inner">
+                        {children.map((child) => (
+                          <button
+                            key={child.id}
+                            className="sidebar-layer-item"
+                            onClick={() => onNodeFocus?.(child.id)}
+                            onContextMenu={(e) => handleLayerContextMenu(e, child.id)}
+                            title={child.title}
+                          >
+                            <span className="sidebar-layer-icon">
+                              <NodeTypeIcon type={child.type} />
+                            </span>
+                            <span className="sidebar-layer-name">{child.title}</span>
+                          </button>
+                        ))}
+                      </div>
                     </div>
                   )}
                 </div>


### PR DESCRIPTION
## Summary
This PR improves the sidebar folder and layer children collapse/expand animations by replacing conditional rendering with CSS grid-based transitions, providing smoother visual feedback when toggling visibility.

## Key Changes

- **Sidebar folder children**: 
  - Replaced `display: none` with CSS grid `grid-template-rows: 0fr` for collapsed state
  - Added smooth transitions for grid-template-rows, opacity, and border-left-color
  - Wrapped children in inner div with `min-height: 0` to enable proper grid animation
  - Removed conditional rendering (`{isOpen &&}`) to keep DOM elements present

- **Sidebar layer children**:
  - Applied same CSS grid animation pattern as folder children
  - Added `aria-hidden` attribute to hide from accessibility tree when collapsed
  - Wrapped children in inner div with `min-height: 0` for proper animation
  - Removed `isOpen` conditional from render logic

- **ChatPanel mention groups**:
  - Reordered mention groups to show Canvas last instead of first
  - Updated comment to reflect that ordering is now handled by MENTION_GROUPS array

## Implementation Details

The animation uses CSS Grid's `grid-template-rows` property to smoothly transition between `1fr` (expanded) and `0fr` (collapsed) states. This approach:
- Keeps DOM elements in place for better performance
- Provides smooth height transitions without JavaScript calculations
- Uses `pointer-events: none` to prevent interaction with hidden elements
- Maintains accessibility with `aria-hidden` attributes
- Includes opacity fade and border color transitions for visual polish

https://claude.ai/code/session_01XDteHAqU8ZifMAzVj3zDxD