### PR TITLE
feat(canvas-workspace): add dedicated full-screen AI Chat page

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -86,9 +86,6 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.21",
-    "pulse-coder-engine": "workspace:*",
-    "ai": "^6.0.57",
-    "zod": "^4.0.0",
     "@tiptap/extension-bubble-menu": "^3.20.4",
     "@tiptap/extension-image": "^3.20.5",
     "@tiptap/extension-placeholder": "^3.20.4",
@@ -98,11 +95,15 @@
     "@tiptap/starter-kit": "^3.20.4",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
+    "ai": "^6.0.57",
+    "markdown-it": "^14.1.0",
     "node-pty": "^1.1.0",
+    "pulse-coder-engine": "workspace:*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tiptap-markdown": "^0.9.0",
-    "markdown-it": "^14.1.0"
+    "wouter": "^3.9.0",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@electron/rebuild": "^4.0.3",

--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState, useEffect, useRef } from 'react';
+import { useLocation } from 'wouter';
 import './App.css';
 import { Canvas } from './components/Canvas';
 import { ChatPage, ChatPanel } from './components/chat';
@@ -10,13 +11,18 @@ const DEFAULT_CHAT_WIDTH = 420;
 const MIN_CHAT_WIDTH = 280;
 const MAX_CHAT_WIDTH = 600;
 
+const ROUTE_CANVAS = '/';
+const ROUTE_CHAT = '/chat';
+
 type ActiveView = 'canvas' | 'chat';
 
 const App = () => {
+  const [location, setLocation] = useLocation();
+  const activeView: ActiveView = location === ROUTE_CHAT ? 'chat' : 'canvas';
+
   const [sidebarCollapsed, setSidebarCollapsed] = useState(true);
   const [chatPanelOpen, setChatPanelOpen] = useState(false);
   const [chatWidth, setChatWidth] = useState(DEFAULT_CHAT_WIDTH);
-  const [activeView, setActiveView] = useState<ActiveView>('canvas');
   const [allNodes, setAllNodes] = useState<Record<string, CanvasNode[]>>({});
   const [focusNodeId, setFocusNodeId] = useState<string | undefined>();
   const [deleteNodeId, setDeleteNodeId] = useState<string | undefined>();
@@ -56,12 +62,12 @@ const App = () => {
     // When entering the full-screen page, also close the right-side panel so
     // only one ChatView instance (and one set of IPC subscriptions) is live.
     setChatPanelOpen(false);
-    setActiveView('chat');
-  }, []);
+    setLocation(ROUTE_CHAT);
+  }, [setLocation]);
 
   const exitChatView = useCallback(() => {
-    setActiveView('canvas');
-  }, []);
+    setLocation(ROUTE_CANVAS);
+  }, [setLocation]);
 
   // Keyboard shortcuts:
   //   Cmd/Ctrl+Shift+A → toggle right-side chat panel (canvas view only)
@@ -77,8 +83,12 @@ const App = () => {
       }
       if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'l') {
         e.preventDefault();
-        setActiveView(prev => (prev === 'chat' ? 'canvas' : 'chat'));
-        if (activeView !== 'chat') setChatPanelOpen(false);
+        if (activeView === 'chat') {
+          setLocation(ROUTE_CANVAS);
+        } else {
+          setChatPanelOpen(false);
+          setLocation(ROUTE_CHAT);
+        }
         return;
       }
       if (e.key === 'Escape' && activeView === 'chat') {
@@ -86,12 +96,12 @@ const App = () => {
         const target = e.target as HTMLElement | null;
         const tag = target?.tagName;
         if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
-        setActiveView('canvas');
+        setLocation(ROUTE_CANVAS);
       }
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [activeView]);
+  }, [activeView, setLocation]);
 
   const handleResizeStart = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -122,8 +132,8 @@ const App = () => {
   // Jumping to a node from the chat page: focus it AND return to canvas.
   const handleNodeFocusFromChatPage = useCallback((nodeId: string) => {
     setFocusNodeId(nodeId);
-    setActiveView('canvas');
-  }, []);
+    setLocation(ROUTE_CANVAS);
+  }, [setLocation]);
 
   const activeWorkspace = workspaces.find((ws) => ws.id === activeId);
 

--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState, useEffect, useRef } from 'react';
 import './App.css';
 import { Canvas } from './components/Canvas';
-import { ChatPanel } from './components/chat';
+import { ChatPage, ChatPanel } from './components/chat';
 import { Sidebar } from './components/Sidebar';
 import { useWorkspaces } from './hooks/useWorkspaces';
 import type { CanvasNode } from './types';
@@ -10,10 +10,13 @@ const DEFAULT_CHAT_WIDTH = 420;
 const MIN_CHAT_WIDTH = 280;
 const MAX_CHAT_WIDTH = 600;
 
+type ActiveView = 'canvas' | 'chat';
+
 const App = () => {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(true);
   const [chatPanelOpen, setChatPanelOpen] = useState(false);
   const [chatWidth, setChatWidth] = useState(DEFAULT_CHAT_WIDTH);
+  const [activeView, setActiveView] = useState<ActiveView>('canvas');
   const [allNodes, setAllNodes] = useState<Record<string, CanvasNode[]>>({});
   const [focusNodeId, setFocusNodeId] = useState<string | undefined>();
   const [deleteNodeId, setDeleteNodeId] = useState<string | undefined>();
@@ -49,17 +52,46 @@ const App = () => {
     reorderFolder,
   } = useWorkspaces();
 
-  // Keyboard shortcut: Cmd/Ctrl+Shift+A to toggle chat panel
+  const enterChatView = useCallback(() => {
+    // When entering the full-screen page, also close the right-side panel so
+    // only one ChatView instance (and one set of IPC subscriptions) is live.
+    setChatPanelOpen(false);
+    setActiveView('chat');
+  }, []);
+
+  const exitChatView = useCallback(() => {
+    setActiveView('canvas');
+  }, []);
+
+  // Keyboard shortcuts:
+  //   Cmd/Ctrl+Shift+A → toggle right-side chat panel (canvas view only)
+  //   Cmd/Ctrl+Shift+L → toggle full-screen chat page
+  //   Esc (while on chat page) → return to canvas
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'a') {
+        if (activeView !== 'canvas') return;
         e.preventDefault();
         setChatPanelOpen(prev => !prev);
+        return;
+      }
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'l') {
+        e.preventDefault();
+        setActiveView(prev => (prev === 'chat' ? 'canvas' : 'chat'));
+        if (activeView !== 'chat') setChatPanelOpen(false);
+        return;
+      }
+      if (e.key === 'Escape' && activeView === 'chat') {
+        // Don't swallow Esc if the user is typing in a text field (mention popup, etc.)
+        const target = e.target as HTMLElement | null;
+        const tag = target?.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
+        setActiveView('canvas');
       }
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, []);
+  }, [activeView]);
 
   const handleResizeStart = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -87,6 +119,14 @@ const App = () => {
     document.addEventListener('mouseup', onMouseUp);
   }, [chatWidth]);
 
+  // Jumping to a node from the chat page: focus it AND return to canvas.
+  const handleNodeFocusFromChatPage = useCallback((nodeId: string) => {
+    setFocusNodeId(nodeId);
+    setActiveView('canvas');
+  }, []);
+
+  const activeWorkspace = workspaces.find((ws) => ws.id === activeId);
+
   return (
     <div className="app">
       <div className="app-body">
@@ -110,42 +150,61 @@ const App = () => {
           activeNodes={allNodes[activeId] || []}
           onNodeFocus={setFocusNodeId}
           onNodeDelete={setDeleteNodeId}
+          activeView={activeView}
+          onEnterChat={enterChatView}
+          onExitChat={exitChatView}
         />
-        <div className="canvas-viewport">
-          {workspaces.map((ws) => (
-            <Canvas
-              key={ws.id}
-              canvasId={ws.id}
-              canvasName={ws.name}
-              rootFolder={ws.rootFolder}
-              hidden={ws.id !== activeId}
-              onNodesChange={handleNodesChange}
-              focusNodeId={ws.id === activeId ? focusNodeId : undefined}
-              onFocusComplete={handleFocusComplete}
-              deleteNodeId={ws.id === activeId ? deleteNodeId : undefined}
-              onDeleteComplete={handleDeleteComplete}
-              chatPanelOpen={chatPanelOpen}
-              onChatToggle={() => setChatPanelOpen(prev => !prev)}
-            />
-          ))}
-        </div>
-        {workspaces.map((ws) => (
-          <div
-            key={ws.id}
-            className={`chat-panel-wrapper${chatPanelOpen && ws.id === activeId ? ' chat-panel-wrapper--open' : ''}`}
-            style={ws.id !== activeId ? { display: 'none' } : chatPanelOpen ? { width: chatWidth } : undefined}
-          >
-            <ChatPanel
-              workspaceId={ws.id}
-              allWorkspaces={workspaces}
-              nodes={allNodes[ws.id] || []}
-              rootFolder={ws.rootFolder}
-              onClose={() => setChatPanelOpen(false)}
-              onResizeStart={handleResizeStart}
-              onNodeFocus={setFocusNodeId}
-            />
-          </div>
-        ))}
+        {activeView === 'canvas' && (
+          <>
+            <div className="canvas-viewport">
+              {workspaces.map((ws) => (
+                <Canvas
+                  key={ws.id}
+                  canvasId={ws.id}
+                  canvasName={ws.name}
+                  rootFolder={ws.rootFolder}
+                  hidden={ws.id !== activeId}
+                  onNodesChange={handleNodesChange}
+                  focusNodeId={ws.id === activeId ? focusNodeId : undefined}
+                  onFocusComplete={handleFocusComplete}
+                  deleteNodeId={ws.id === activeId ? deleteNodeId : undefined}
+                  onDeleteComplete={handleDeleteComplete}
+                  chatPanelOpen={chatPanelOpen}
+                  onChatToggle={() => setChatPanelOpen(prev => !prev)}
+                />
+              ))}
+            </div>
+            {workspaces.map((ws) => (
+              <div
+                key={ws.id}
+                className={`chat-panel-wrapper${chatPanelOpen && ws.id === activeId ? ' chat-panel-wrapper--open' : ''}`}
+                style={ws.id !== activeId ? { display: 'none' } : chatPanelOpen ? { width: chatWidth } : undefined}
+              >
+                <ChatPanel
+                  workspaceId={ws.id}
+                  allWorkspaces={workspaces}
+                  nodes={allNodes[ws.id] || []}
+                  rootFolder={ws.rootFolder}
+                  onClose={() => setChatPanelOpen(false)}
+                  onResizeStart={handleResizeStart}
+                  onNodeFocus={setFocusNodeId}
+                  onExpand={enterChatView}
+                />
+              </div>
+            ))}
+          </>
+        )}
+        {activeView === 'chat' && (
+          <ChatPage
+            workspaceId={activeId}
+            allWorkspaces={workspaces}
+            nodes={allNodes[activeId] || []}
+            rootFolder={activeWorkspace?.rootFolder}
+            onExit={exitChatView}
+            onSelectWorkspace={selectWorkspace}
+            onNodeFocus={handleNodeFocusFromChatPage}
+          />
+        )}
       </div>
     </div>
   );

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
@@ -35,7 +35,75 @@
 .sidebar-collapsed-toggle {
   padding: 10px 8px;
   display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.sidebar-toggle--active {
+  background: var(--accent-light);
+  color: var(--accent);
+}
+
+.sidebar-toggle--active:hover {
+  background: var(--accent-light);
+}
+
+/* ---- Top-level view nav (Canvas / AI Chat) ---- */
+
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  padding: 6px 6px 2px;
+  gap: 1px;
+}
+
+.sidebar-nav-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--text);
+  text-align: left;
+  transition: background 0.1s, color 0.1s;
+  width: 100%;
+}
+
+.sidebar-nav-item:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.sidebar-nav-item--active {
+  background: var(--accent-light);
+  color: var(--accent);
+}
+
+.sidebar-nav-item--active:hover {
+  background: var(--accent-light);
+}
+
+.sidebar-nav-icon {
+  display: flex;
+  align-items: center;
   justify-content: center;
+  width: 20px;
+  height: 20px;
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.sidebar-nav-item--active .sidebar-nav-icon {
+  color: var(--accent);
+}
+
+.sidebar-nav-label {
+  flex: 1;
+  font-weight: 500;
 }
 
 .sidebar-brand-header {

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState, useCallback, type DragEvent, type
 import type { WorkspaceEntry, FolderEntry } from '../../hooks/useWorkspaces';
 import type { CanvasNode } from '../../types';
 import {
+  AvatarIcon,
   CloseIcon,
   PlusIcon,
   ChevronRightIcon,
@@ -89,6 +90,9 @@ interface Props {
   activeNodes?: CanvasNode[];
   onNodeFocus?: (nodeId: string) => void;
   onNodeDelete?: (nodeId: string) => void;
+  activeView: 'canvas' | 'chat';
+  onEnterChat: () => void;
+  onExitChat: () => void;
 }
 
 /* ---- Drag data keys ---- */
@@ -115,6 +119,9 @@ export const Sidebar = ({
   activeNodes = [],
   onNodeFocus,
   onNodeDelete,
+  activeView,
+  onEnterChat,
+  onExitChat,
 }: Props) => {
   /* ---- Local state ---- */
   const [renamingId, setRenamingId] = useState<string | null>(null);
@@ -423,6 +430,30 @@ export const Sidebar = ({
               </svg>
             </span>
             <span className="sidebar-brand">Pulse Canvas</span>
+          </div>
+
+          {/* Top-level view nav (Canvas vs AI Chat) */}
+          <div className="sidebar-nav">
+            <button
+              className={`sidebar-nav-item${activeView === 'canvas' ? ' sidebar-nav-item--active' : ''}`}
+              onClick={onExitChat}
+              title="Canvas view"
+            >
+              <span className="sidebar-nav-icon">
+                <WorkspaceIcon size={14} />
+              </span>
+              <span className="sidebar-nav-label">Canvas</span>
+            </button>
+            <button
+              className={`sidebar-nav-item${activeView === 'chat' ? ' sidebar-nav-item--active' : ''}`}
+              onClick={onEnterChat}
+              title="AI Chat page (⌘/Ctrl+Shift+L)"
+            >
+              <span className="sidebar-nav-icon">
+                <AvatarIcon size={14} />
+              </span>
+              <span className="sidebar-nav-label">AI Chat</span>
+            </button>
           </div>
 
           {/* Section header with add + collapse buttons */}
@@ -751,6 +782,22 @@ export const Sidebar = ({
         <div className="sidebar-collapsed-toggle">
           <button className="sidebar-toggle" onClick={onToggle} title="Expand sidebar">
             <SidebarToggleIcon size={16} />
+          </button>
+          <button
+            className={`sidebar-toggle${activeView === 'canvas' ? ' sidebar-toggle--active' : ''}`}
+            onClick={onExitChat}
+            title="Canvas view"
+            aria-label="Canvas view"
+          >
+            <WorkspaceIcon size={16} />
+          </button>
+          <button
+            className={`sidebar-toggle${activeView === 'chat' ? ' sidebar-toggle--active' : ''}`}
+            onClick={onEnterChat}
+            title="AI Chat page"
+            aria-label="AI Chat page"
+          >
+            <AvatarIcon size={16} />
           </button>
         </div>
       )}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatHeader.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatHeader.tsx
@@ -16,7 +16,20 @@ interface ChatHeaderProps {
   onNewSession: () => Promise<void>;
   onLoadSession: (sessionId: string, sourceWorkspaceId?: string) => Promise<void>;
   onClose: () => void;
+  onExpand?: () => void;
 }
+
+const ExpandIcon = ({ size = 16 }: { size?: number }) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none">
+    <path
+      d="M9.5 2.5h4v4M13.5 2.5L9 7M6.5 13.5h-4v-4M2.5 13.5L7 9"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
 
 export const ChatHeader = ({
   sessionMenuOpen,
@@ -27,6 +40,7 @@ export const ChatHeader = ({
   onNewSession,
   onLoadSession,
   onClose,
+  onExpand,
 }: ChatHeaderProps) => (
   <div className="chat-panel-header">
     <div className="chat-panel-title-wrapper" ref={sessionMenuRef}>
@@ -103,6 +117,16 @@ export const ChatHeader = ({
       >
         <PlusIcon size={16} strokeWidth={1.3} />
       </button>
+      {onExpand && (
+        <button
+          className="chat-panel-action-btn"
+          onClick={onExpand}
+          title="Open full screen"
+          aria-label="Open full screen"
+        >
+          <ExpandIcon size={14} />
+        </button>
+      )}
       <button className="chat-panel-action-btn" onClick={onClose} title="Close panel">
         <CloseIcon size={16} strokeWidth={1.3} />
       </button>

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.css
@@ -1,0 +1,228 @@
+/* ─── ChatPage container ──────────────────────────────────── */
+
+.chat-page {
+  flex: 1;
+  min-width: 0;
+  height: 100%;
+  display: flex;
+  background: #fff;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  overflow: hidden;
+}
+
+/* ─── Sessions rail (left) ─────────────────────────────────── */
+
+.chat-page-rail {
+  width: 260px;
+  flex-shrink: 0;
+  border-right: 1px solid rgba(0, 0, 0, 0.06);
+  display: flex;
+  flex-direction: column;
+  padding: 12px 8px;
+  gap: 10px;
+  overflow-y: auto;
+  background: #fafaf9;
+}
+
+.chat-page-rail-new {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid rgba(55, 53, 47, 0.12);
+  background: #fff;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+  color: #37352f;
+  font-weight: 500;
+  transition: background 0.1s, border-color 0.1s;
+  width: 100%;
+}
+
+.chat-page-rail-new:hover {
+  background: rgba(55, 53, 47, 0.04);
+  border-color: rgba(55, 53, 47, 0.18);
+}
+
+.chat-page-rail-group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.chat-page-rail-label {
+  font-size: 10px;
+  font-weight: 600;
+  color: #9b9a97;
+  padding: 6px 10px 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.chat-page-rail-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.chat-page-rail-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border: none;
+  background: transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 13px;
+  color: #37352f;
+  text-align: left;
+  transition: background 0.1s;
+  width: 100%;
+}
+
+.chat-page-rail-item:hover {
+  background: rgba(55, 53, 47, 0.06);
+}
+
+.chat-page-rail-item--active {
+  background: rgba(55, 53, 47, 0.08);
+}
+
+.chat-page-rail-item svg {
+  color: #9b9a97;
+  flex-shrink: 0;
+}
+
+.chat-page-rail-item-text {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-page-rail-item-count {
+  font-size: 11px;
+  color: #b4b4b0;
+  flex-shrink: 0;
+}
+
+.chat-page-rail-item-ws {
+  font-size: 10px;
+  color: #9b9a97;
+  background: rgba(55, 53, 47, 0.06);
+  border-radius: 3px;
+  padding: 1px 5px;
+  flex-shrink: 0;
+  white-space: nowrap;
+  max-width: 90px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-page-rail-item--other .chat-page-rail-item-text {
+  opacity: 0.85;
+}
+
+.chat-page-rail-empty {
+  padding: 12px 10px;
+  font-size: 12px;
+  color: #9b9a97;
+  line-height: 1.5;
+}
+
+/* ─── Main column (right) ──────────────────────────────────── */
+
+.chat-page-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+}
+
+.chat-page-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.04);
+  flex-shrink: 0;
+  gap: 12px;
+}
+
+.chat-page-workspace-switcher {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.chat-page-workspace-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: #9b9a97;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.chat-page-workspace-select {
+  font-size: 13px;
+  font-family: inherit;
+  color: #37352f;
+  background: #fff;
+  border: 1px solid rgba(55, 53, 47, 0.12);
+  border-radius: 6px;
+  padding: 4px 8px;
+  cursor: pointer;
+  outline: none;
+  min-width: 140px;
+}
+
+.chat-page-workspace-select:hover {
+  border-color: rgba(55, 53, 47, 0.2);
+}
+
+.chat-page-workspace-select:focus {
+  border-color: rgba(55, 53, 47, 0.4);
+}
+
+.chat-page-workspace-name {
+  font-size: 14px;
+  font-weight: 500;
+  color: #37352f;
+}
+
+/* ─── Body (chat view inside the page) ────────────────────── */
+
+.chat-page-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* Wider readable column for messages and input on ultra-wide screens. */
+.chat-page-body .chat-messages {
+  max-width: 820px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 24px 24px 8px;
+}
+
+.chat-page-body .chat-message-content {
+  max-width: 100%;
+}
+
+.chat-page-body .chat-empty-state {
+  max-width: 560px;
+  margin: 0 auto;
+}
+
+.chat-page-body .chat-input-container {
+  max-width: 820px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 8px 24px 20px;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.tsx
@@ -1,0 +1,184 @@
+import { useCallback } from 'react';
+import type { CanvasNode } from '../../types';
+import { CloseIcon } from '../icons';
+import './ChatPage.css';
+import './ChatPanel.css';
+import { ChatSessionsRail } from './ChatSessionsRail';
+import { ChatView } from './ChatView';
+import { useChatSessions } from './hooks/useChatSessions';
+import { useChatStream } from './hooks/useChatStream';
+import { useMentions } from './hooks/useMentions';
+import type { WorkspaceOption } from './types';
+
+interface ChatPageProps {
+  workspaceId: string;
+  allWorkspaces: WorkspaceOption[];
+  nodes?: CanvasNode[];
+  rootFolder?: string;
+  onExit: () => void;
+  onSelectWorkspace?: (id: string) => void;
+  onNodeFocus?: (nodeId: string) => void;
+}
+
+/**
+ * Full-screen AI Chat page. Reuses the same hooks and body as ChatPanel via
+ * ChatView, but adds a visible sessions rail and a wider main column.
+ *
+ * Mutual exclusion with ChatPanel is enforced at the App level — only one
+ * surface should be mounted at a time to avoid duplicate IPC subscriptions.
+ */
+export const ChatPage = ({
+  workspaceId,
+  allWorkspaces,
+  nodes,
+  rootFolder,
+  onExit,
+  onSelectWorkspace,
+  onNodeFocus,
+}: ChatPageProps) => {
+  const {
+    abort,
+    answerClarification,
+    clarifyInput,
+    collapsedSections,
+    expandedTools,
+    loading,
+    messageTools,
+    messages,
+    pendingClarify,
+    replaceMessages,
+    sendMessage,
+    setClarifyInput,
+    streamingTools,
+    toggleSection,
+    toggleToolExpand,
+  } = useChatStream({ workspaceId, allWorkspaces });
+
+  const {
+    otherSessions,
+    handleLoadSession,
+    handleNewSession,
+    sessions,
+  } = useChatSessions({
+    workspaceId,
+    allWorkspaces,
+    onMessagesLoaded: replaceMessages,
+    eagerLoad: true,
+  });
+
+  const {
+    clearInput,
+    editableRef,
+    focusInput,
+    handleInput,
+    handleKeyDown,
+    handlePaste,
+    input,
+    mentionIndex,
+    mentionItems,
+    mentionOpen,
+    selectMention,
+    setMentionIndex,
+    submitCurrentInput,
+  } = useMentions({
+    allWorkspaces,
+    workspaceId,
+    nodes,
+    rootFolder,
+    onSubmit: sendMessage,
+  });
+
+  const handleQuickAction = useCallback(async (prompt: string) => {
+    if (!prompt) {
+      focusInput();
+      return;
+    }
+
+    const ok = await sendMessage(prompt);
+    if (ok) {
+      clearInput();
+    }
+  }, [clearInput, focusInput, sendMessage]);
+
+  // Clicking a mention chip should jump back to the canvas and focus the node.
+  const handleNodeFocus = useCallback((nodeId: string) => {
+    onNodeFocus?.(nodeId);
+    onExit();
+  }, [onExit, onNodeFocus]);
+
+  const activeWorkspace = allWorkspaces.find((ws) => ws.id === workspaceId);
+
+  return (
+    <div className="chat-page">
+      <ChatSessionsRail
+        sessions={sessions}
+        otherSessions={otherSessions}
+        onNewSession={handleNewSession}
+        onLoadSession={handleLoadSession}
+      />
+
+      <div className="chat-page-main">
+        <div className="chat-page-topbar">
+          {allWorkspaces.length > 1 && onSelectWorkspace ? (
+            <label className="chat-page-workspace-switcher">
+              <span className="chat-page-workspace-label">Workspace</span>
+              <select
+                className="chat-page-workspace-select"
+                value={workspaceId}
+                onChange={(event) => onSelectWorkspace(event.target.value)}
+              >
+                {allWorkspaces.map((ws) => (
+                  <option key={ws.id} value={ws.id}>{ws.name}</option>
+                ))}
+              </select>
+            </label>
+          ) : (
+            <span className="chat-page-workspace-name">
+              {activeWorkspace?.name ?? 'Workspace'}
+            </span>
+          )}
+
+          <button
+            className="chat-panel-action-btn"
+            onClick={onExit}
+            title="Back to canvas (Esc)"
+            aria-label="Back to canvas"
+          >
+            <CloseIcon size={16} strokeWidth={1.3} />
+          </button>
+        </div>
+
+        <ChatView
+          className="chat-page-body"
+          messages={messages}
+          loading={loading}
+          streamingTools={streamingTools}
+          messageTools={messageTools}
+          collapsedSections={collapsedSections}
+          expandedTools={expandedTools}
+          pendingClarify={pendingClarify}
+          clarifyInput={clarifyInput}
+          onClarifyInputChange={setClarifyInput}
+          onAnswerClarification={answerClarification}
+          onToggleSection={toggleSection}
+          onToggleToolExpand={toggleToolExpand}
+          nodes={nodes}
+          onNodeFocus={handleNodeFocus}
+          onQuickAction={handleQuickAction}
+          input={input}
+          editableRef={editableRef}
+          mentionOpen={mentionOpen}
+          mentionItems={mentionItems}
+          mentionIndex={mentionIndex}
+          onSelectMention={selectMention}
+          onMentionIndexChange={setMentionIndex}
+          onInput={handleInput}
+          onKeyDown={handleKeyDown}
+          onPaste={handlePaste}
+          onSubmit={submitCurrentInput}
+          onAbort={abort}
+        />
+      </div>
+    </div>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.tsx
@@ -1,10 +1,7 @@
 import { useCallback } from 'react';
-import { ChatEmptyState } from './ChatEmptyState';
 import { ChatHeader } from './ChatHeader';
-import { ChatInput } from './ChatInput';
-import { ChatMentionPopup } from './ChatMentionPopup';
-import { ChatMessages } from './ChatMessages';
 import './ChatPanel.css';
+import { ChatView } from './ChatView';
 import { useChatSessions } from './hooks/useChatSessions';
 import { useChatStream } from './hooks/useChatStream';
 import { useMentions } from './hooks/useMentions';
@@ -18,6 +15,7 @@ export const ChatPanel = ({
   onClose,
   onResizeStart,
   onNodeFocus,
+  onExpand,
 }: ChatPanelProps) => {
   const {
     abort,
@@ -85,61 +83,50 @@ export const ChatPanel = ({
     }
   }, [clearInput, focusInput, sendMessage]);
 
-  const hasMessages = messages.length > 0 || loading;
-
   return (
-    <div className="chat-panel">
-      {onResizeStart && (
-        <div className="chat-panel-resize" onMouseDown={onResizeStart} />
-      )}
-      <ChatHeader
-        sessionMenuOpen={sessionMenuOpen}
-        sessionMenuRef={sessionMenuRef}
-        sessions={sessions}
-        otherSessions={otherSessions}
-        onToggleSessionMenu={openSessionMenu}
-        onNewSession={handleNewSession}
-        onLoadSession={handleLoadSession}
-        onClose={onClose}
-      />
-      {hasMessages ? (
-        <ChatMessages
-          messages={messages}
-          loading={loading}
-          nodes={nodes}
-          streamingTools={streamingTools}
-          messageTools={messageTools}
-          collapsedSections={collapsedSections}
-          expandedTools={expandedTools}
-          pendingClarify={pendingClarify}
-          clarifyInput={clarifyInput}
-          onClarifyInputChange={setClarifyInput}
-          onAnswerClarification={answerClarification}
-          onToggleSection={toggleSection}
-          onToggleToolExpand={toggleToolExpand}
-          onNodeFocus={onNodeFocus}
+    <ChatView
+      className="chat-panel"
+      onResizeStart={onResizeStart}
+      header={
+        <ChatHeader
+          sessionMenuOpen={sessionMenuOpen}
+          sessionMenuRef={sessionMenuRef}
+          sessions={sessions}
+          otherSessions={otherSessions}
+          onToggleSessionMenu={openSessionMenu}
+          onNewSession={handleNewSession}
+          onLoadSession={handleLoadSession}
+          onClose={onClose}
+          onExpand={onExpand}
         />
-      ) : (
-        <ChatEmptyState onQuickAction={handleQuickAction} />
-      )}
-      <ChatInput
-        loading={loading}
-        input={input}
-        editableRef={editableRef}
-        mentionPopup={mentionOpen && mentionItems.length > 0 ? (
-          <ChatMentionPopup
-            mentionItems={mentionItems}
-            mentionIndex={mentionIndex}
-            onSelectMention={selectMention}
-            onMentionIndexChange={setMentionIndex}
-          />
-        ) : undefined}
-        onInput={handleInput}
-        onKeyDown={handleKeyDown}
-        onPaste={handlePaste}
-        onSend={submitCurrentInput}
-        onAbort={abort}
-      />
-    </div>
+      }
+      messages={messages}
+      loading={loading}
+      streamingTools={streamingTools}
+      messageTools={messageTools}
+      collapsedSections={collapsedSections}
+      expandedTools={expandedTools}
+      pendingClarify={pendingClarify}
+      clarifyInput={clarifyInput}
+      onClarifyInputChange={setClarifyInput}
+      onAnswerClarification={answerClarification}
+      onToggleSection={toggleSection}
+      onToggleToolExpand={toggleToolExpand}
+      nodes={nodes}
+      onNodeFocus={onNodeFocus}
+      onQuickAction={handleQuickAction}
+      input={input}
+      editableRef={editableRef}
+      mentionOpen={mentionOpen}
+      mentionItems={mentionItems}
+      mentionIndex={mentionIndex}
+      onSelectMention={selectMention}
+      onMentionIndexChange={setMentionIndex}
+      onInput={handleInput}
+      onKeyDown={handleKeyDown}
+      onPaste={handlePaste}
+      onSubmit={submitCurrentInput}
+      onAbort={abort}
+    />
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatSessionsRail.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatSessionsRail.tsx
@@ -1,0 +1,82 @@
+import type { AgentSessionInfo } from '../../types';
+import { ListLinesIcon, PlusIcon } from '../icons';
+import type { OtherWorkspaceSession } from './types';
+
+interface ChatSessionsRailProps {
+  sessions: AgentSessionInfo[];
+  otherSessions: OtherWorkspaceSession[];
+  onNewSession: () => Promise<void>;
+  onLoadSession: (sessionId: string, sourceWorkspaceId?: string) => Promise<void>;
+}
+
+/**
+ * Always-visible sessions rail shown in ChatPage. This is the full-screen
+ * equivalent of the dropdown menu in ChatHeader (panel).
+ */
+export const ChatSessionsRail = ({
+  sessions,
+  otherSessions,
+  onNewSession,
+  onLoadSession,
+}: ChatSessionsRailProps) => (
+  <aside className="chat-page-rail">
+    <button
+      className="chat-page-rail-new"
+      onClick={() => void onNewSession()}
+    >
+      <PlusIcon size={14} strokeWidth={1.3} />
+      <span>New chat</span>
+    </button>
+
+    {sessions.length > 0 && (
+      <div className="chat-page-rail-group">
+        <div className="chat-page-rail-label">Recent</div>
+        <div className="chat-page-rail-list">
+          {sessions.map((session) => (
+            <button
+              key={session.sessionId}
+              className={`chat-page-rail-item${session.isCurrent ? ' chat-page-rail-item--active' : ''}`}
+              onClick={() => {
+                if (session.isCurrent) return;
+                void onLoadSession(session.sessionId);
+              }}
+              title={session.preview || session.date}
+            >
+              <ListLinesIcon size={14} />
+              <span className="chat-page-rail-item-text">
+                {session.isCurrent ? 'Current chat' : (session.preview || session.date)}
+              </span>
+              <span className="chat-page-rail-item-count">{session.messageCount}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+    )}
+
+    {otherSessions.length > 0 && (
+      <div className="chat-page-rail-group">
+        <div className="chat-page-rail-label">Other Workspaces</div>
+        <div className="chat-page-rail-list">
+          {otherSessions.map((session) => (
+            <button
+              key={`${session.sourceWorkspaceId}:${session.sessionId}`}
+              className="chat-page-rail-item chat-page-rail-item--other"
+              onClick={() => void onLoadSession(session.sessionId, session.sourceWorkspaceId)}
+              title={`${session.workspaceName} · ${session.preview || session.date}`}
+            >
+              <ListLinesIcon size={14} />
+              <span className="chat-page-rail-item-text">
+                {session.preview || session.date}
+              </span>
+              <span className="chat-page-rail-item-ws">{session.workspaceName}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+    )}
+
+    {sessions.length === 0 && otherSessions.length === 0 && (
+      <div className="chat-page-rail-empty">No previous chats yet.</div>
+    )}
+  </aside>
+);

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatView.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatView.tsx
@@ -1,0 +1,146 @@
+import type {
+  ClipboardEventHandler,
+  KeyboardEventHandler,
+  MouseEvent as ReactMouseEvent,
+  ReactNode,
+  RefObject,
+} from 'react';
+import type { AgentChatMessage, CanvasNode } from '../../types';
+import { ChatEmptyState } from './ChatEmptyState';
+import { ChatInput } from './ChatInput';
+import { ChatMentionPopup } from './ChatMentionPopup';
+import { ChatMessages } from './ChatMessages';
+import type { MentionItem, PendingClarification, ToolCallStatus } from './types';
+
+interface ChatViewProps {
+  className?: string;
+  header?: ReactNode;
+  beforeHeader?: ReactNode;
+
+  // Streaming + messages
+  messages: AgentChatMessage[];
+  loading: boolean;
+  streamingTools: ToolCallStatus[];
+  messageTools: Map<number, ToolCallStatus[]>;
+  collapsedSections: Set<number>;
+  expandedTools: Set<number>;
+  pendingClarify: PendingClarification | null;
+  clarifyInput: string;
+  onClarifyInputChange: (value: string) => void;
+  onAnswerClarification: () => Promise<void>;
+  onToggleSection: (messageIndex: number) => void;
+  onToggleToolExpand: (toolId: number) => void;
+
+  // Canvas context
+  nodes?: CanvasNode[];
+  onNodeFocus?: (nodeId: string) => void;
+
+  // Quick actions (empty state)
+  onQuickAction: (prompt: string) => Promise<void> | void;
+
+  // Input
+  input: string;
+  editableRef: RefObject<HTMLDivElement>;
+  mentionOpen: boolean;
+  mentionItems: MentionItem[];
+  mentionIndex: number;
+  onSelectMention: (item: MentionItem) => void;
+  onMentionIndexChange: (index: number) => void;
+  onInput: () => void;
+  onKeyDown: KeyboardEventHandler<HTMLDivElement>;
+  onPaste: ClipboardEventHandler<HTMLDivElement>;
+  onSubmit: () => Promise<boolean>;
+  onAbort: () => Promise<void>;
+
+  // Optional decoration
+  onResizeStart?: (e: ReactMouseEvent) => void;
+}
+
+/**
+ * Presentational body used by both ChatPanel (narrow right-side panel) and
+ * ChatPage (full-screen page). Owns no state; callers pass the result of
+ * useChatStream + useChatSessions + useMentions.
+ */
+export const ChatView = ({
+  className,
+  header,
+  beforeHeader,
+  messages,
+  loading,
+  streamingTools,
+  messageTools,
+  collapsedSections,
+  expandedTools,
+  pendingClarify,
+  clarifyInput,
+  onClarifyInputChange,
+  onAnswerClarification,
+  onToggleSection,
+  onToggleToolExpand,
+  nodes,
+  onNodeFocus,
+  onQuickAction,
+  input,
+  editableRef,
+  mentionOpen,
+  mentionItems,
+  mentionIndex,
+  onSelectMention,
+  onMentionIndexChange,
+  onInput,
+  onKeyDown,
+  onPaste,
+  onSubmit,
+  onAbort,
+  onResizeStart,
+}: ChatViewProps) => {
+  const hasMessages = messages.length > 0 || loading;
+
+  return (
+    <div className={className ?? 'chat-view'}>
+      {onResizeStart && (
+        <div className="chat-panel-resize" onMouseDown={onResizeStart} />
+      )}
+      {beforeHeader}
+      {header}
+      {hasMessages ? (
+        <ChatMessages
+          messages={messages}
+          loading={loading}
+          nodes={nodes}
+          streamingTools={streamingTools}
+          messageTools={messageTools}
+          collapsedSections={collapsedSections}
+          expandedTools={expandedTools}
+          pendingClarify={pendingClarify}
+          clarifyInput={clarifyInput}
+          onClarifyInputChange={onClarifyInputChange}
+          onAnswerClarification={onAnswerClarification}
+          onToggleSection={onToggleSection}
+          onToggleToolExpand={onToggleToolExpand}
+          onNodeFocus={onNodeFocus}
+        />
+      ) : (
+        <ChatEmptyState onQuickAction={onQuickAction} />
+      )}
+      <ChatInput
+        loading={loading}
+        input={input}
+        editableRef={editableRef}
+        mentionPopup={mentionOpen && mentionItems.length > 0 ? (
+          <ChatMentionPopup
+            mentionItems={mentionItems}
+            mentionIndex={mentionIndex}
+            onSelectMention={onSelectMention}
+            onMentionIndexChange={onMentionIndexChange}
+          />
+        ) : undefined}
+        onInput={onInput}
+        onKeyDown={onKeyDown}
+        onPaste={onPaste}
+        onSend={onSubmit}
+        onAbort={onAbort}
+      />
+    </div>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatSessions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatSessions.ts
@@ -6,12 +6,15 @@ interface UseChatSessionsOptions {
   workspaceId: string;
   allWorkspaces?: WorkspaceOption[];
   onMessagesLoaded: (messages: AgentChatMessage[]) => void;
+  /** When true, load the session list on mount and whenever workspaceId changes. */
+  eagerLoad?: boolean;
 }
 
 export function useChatSessions({
   workspaceId,
   allWorkspaces,
   onMessagesLoaded,
+  eagerLoad = false,
 }: UseChatSessionsOptions) {
   const [sessionMenuOpen, setSessionMenuOpen] = useState(false);
   const [sessions, setSessions] = useState<AgentSessionInfo[]>([]);
@@ -40,12 +43,7 @@ export function useChatSessions({
     return () => document.removeEventListener('mousedown', handleMouseDown);
   }, [sessionMenuOpen]);
 
-  const openSessionMenu = useCallback(async () => {
-    if (sessionMenuOpen) {
-      setSessionMenuOpen(false);
-      return;
-    }
-
+  const loadSessions = useCallback(async () => {
     const result = await window.canvasWorkspace.agent.listSessions(workspaceId);
     if (result.ok && result.sessions) {
       setSessions(result.sessions);
@@ -77,9 +75,22 @@ export function useChatSessions({
     } else {
       setOtherSessions([]);
     }
+  }, [allWorkspaces, workspaceId]);
 
+  useEffect(() => {
+    if (!eagerLoad) return;
+    void loadSessions();
+  }, [eagerLoad, loadSessions]);
+
+  const openSessionMenu = useCallback(async () => {
+    if (sessionMenuOpen) {
+      setSessionMenuOpen(false);
+      return;
+    }
+
+    await loadSessions();
     setSessionMenuOpen(true);
-  }, [allWorkspaces, sessionMenuOpen, workspaceId]);
+  }, [loadSessions, sessionMenuOpen]);
 
   const handleNewSession = useCallback(async () => {
     setSessionMenuOpen(false);
@@ -103,6 +114,7 @@ export function useChatSessions({
     otherSessions,
     handleLoadSession,
     handleNewSession,
+    loadSessions,
     openSessionMenu,
     sessionMenuOpen,
     sessionMenuRef,

--- a/apps/canvas-workspace/src/renderer/src/components/chat/index.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/index.ts
@@ -1,1 +1,2 @@
+export { ChatPage } from './ChatPage';
 export { ChatPanel } from './ChatPanel';

--- a/apps/canvas-workspace/src/renderer/src/components/chat/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/types.ts
@@ -14,6 +14,7 @@ export interface ChatPanelProps {
   onClose: () => void;
   onResizeStart?: (e: MouseEvent) => void;
   onNodeFocus?: (nodeId: string) => void;
+  onExpand?: () => void;
 }
 
 export interface OtherWorkspaceSession extends AgentSessionInfo {

--- a/apps/canvas-workspace/src/renderer/src/main.tsx
+++ b/apps/canvas-workspace/src/renderer/src/main.tsx
@@ -1,4 +1,6 @@
 import { createRoot } from "react-dom/client";
+import { Router } from "wouter";
+import { useHashLocation } from "wouter/use-hash-location";
 import App from "./App";
 import "@xterm/xterm/css/xterm.css";
 import "./styles.css";
@@ -10,4 +12,8 @@ if (!root) {
   throw new Error("Root element not found");
 }
 
-createRoot(root).render(<App />);
+createRoot(root).render(
+  <Router hook={useHashLocation}>
+    <App />
+  </Router>,
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       tiptap-markdown:
         specifier: ^0.9.0
         version: 0.9.0(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))
+      wouter:
+        specifier: ^3.9.0
+        version: 3.9.0(react@18.3.1)
       zod:
         specifier: ^4.0.0
         version: 4.3.6
@@ -2483,6 +2486,9 @@ packages:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
 
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
@@ -2826,6 +2832,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  regexparam@3.0.0:
+    resolution: {integrity: sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q==}
+    engines: {node: '>=8'}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -3300,6 +3310,11 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wouter@3.9.0:
+    resolution: {integrity: sha512-sF/od/PIgqEQBQcrN7a2x3MX6MQE6nW0ygCfy9hQuUkuB28wEZuu/6M5GyqkrrEu9M6jxdkgE12yDFsQMKos4Q==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -5538,6 +5553,8 @@ snapshots:
     dependencies:
       minipass: 7.1.2
 
+  mitt@3.0.1: {}
+
   mkdirp-classic@0.5.3: {}
 
   mkdirp@0.5.6:
@@ -5931,6 +5948,8 @@ snapshots:
       util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
+
+  regexparam@3.0.0: {}
 
   require-directory@2.1.1: {}
 
@@ -6450,6 +6469,13 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wouter@3.9.0(react@18.3.1):
+    dependencies:
+      mitt: 3.0.1
+      react: 18.3.1
+      regexparam: 3.0.0
+      use-sync-external-store: 1.6.0(react@18.3.1)
 
   wrap-ansi@7.0.0:
     dependencies:


### PR DESCRIPTION
Introduces a standalone AI Chat view that coexists with the existing right-side
ChatPanel so users can pick between "side-by-side with canvas" and "focused
full-screen conversation" modes.

- Extract shared ChatView body so ChatPanel and the new ChatPage reuse the
  same messages/input/mention rendering without duplicating hooks or state.
- Add ChatPage with a visible sessions rail (replacing the panel's dropdown
  menu), a workspace switcher in the top bar, and a wider readable content
  column (max-width ~820px).
- Add ChatSessionsRail to expose recent and cross-workspace sessions as a
  first-class affordance instead of a hidden dropdown.
- Extend useChatSessions with an eagerLoad option so the page can populate
  its rail on mount without clicking.
- App toggles between 'canvas' and 'chat' via a simple view state (no router).
  Surfaces are mutually exclusive so useChatStream never has two live IPC
  subscriptions for the same workspace.
- Sidebar gains Canvas / AI Chat nav entries (expanded + collapsed rails).
- Add Cmd/Ctrl+Shift+L to toggle the page and Esc to exit back to canvas.
- Panel header gains an "Open full screen" button for quick handoff.
- Clicking a mention chip in ChatPage jumps back to canvas and focuses the
  node so the chat-to-canvas link still works.

https://claude.ai/code/session_01L7TrKU2zTh8835dnbQoKhp