### PR TITLE
style(canvas-workspace): refresh frame node palette, header, and borders

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.css
@@ -29,6 +29,14 @@
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--frame-color, #A8B0BD) 22%, transparent);
 }
 
+/* While the color picker popover is open, hoist the entire frame above its
+ * non-frame siblings. Frames are painted first (see Canvas sortedNodes), so
+ * without this the popover — a descendant of the frame — gets painted under
+ * later siblings (child cards) even though it floats above the header tab. */
+.canvas-node--frame:has(.frame-color-trigger--open) {
+  z-index: 1000;
+}
+
 /* ---- Header tab ---- */
 
 .canvas-node--frame .node-header {
@@ -125,9 +133,11 @@
   transform: scale(1.15);
 }
 
+/* Popover floats ABOVE the header tab (not below), so it opens into empty
+ * canvas space instead of overlapping child nodes inside the frame body. */
 .frame-color-popover {
   position: absolute;
-  top: calc(100% + 6px);
+  bottom: calc(100% + 6px);
   left: 50%;
   transform: translateX(-50%);
   display: none;
@@ -136,7 +146,7 @@
   background: var(--surface, #fff);
   border: 1px solid var(--border-light, rgba(0,0,0,0.08));
   border-radius: 8px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.14);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.16);
   z-index: 20;
   white-space: nowrap;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.css
@@ -29,14 +29,6 @@
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--frame-color, #A8B0BD) 22%, transparent);
 }
 
-/* While the color picker popover is open, hoist the entire frame above its
- * non-frame siblings. Frames are painted first (see Canvas sortedNodes), so
- * without this the popover — a descendant of the frame — gets painted under
- * later siblings (child cards) even though it floats above the header tab. */
-.canvas-node--frame:has(.frame-color-trigger--open) {
-  z-index: 1000;
-}
-
 /* ---- Header tab ---- */
 
 .canvas-node--frame .node-header {

--- a/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.css
@@ -1,50 +1,83 @@
+/* ---------------------------------------------------------------------------
+ * Frame node styling
+ *
+ * Design goals:
+ *  - Soft, cohesive FigJam-style palette (see COLOR_PRESETS in index.tsx).
+ *  - Dashed default border to signal "container" (not a solid card).
+ *  - Solid border + stronger glow when selected, so selection reads clearly.
+ *  - Narrow header tab with dark text derived from the frame color, so every
+ *    hue stays legible (white text on mid-saturation hues looked washed out).
+ * ------------------------------------------------------------------------- */
+
 .canvas-node--frame {
-  background: color-mix(in srgb, var(--frame-color, #9575d4) 8%, transparent);
-  border: 2px solid color-mix(in srgb, var(--frame-color, #9575d4) 55%, transparent);
+  /* Mix the tint over --surface (not transparent) so frames don't pick up the
+   * canvas background underneath and look muddy. */
+  background: color-mix(in srgb, var(--frame-color, #A8B0BD) 6%, var(--surface));
+  border: 1.5px dashed color-mix(in srgb, var(--frame-color, #A8B0BD) 50%, transparent);
   box-shadow: none;
   overflow: visible;
 }
 
 .canvas-node--frame:hover {
-  border-color: var(--frame-color, #9575d4);
+  border-color: color-mix(in srgb, var(--frame-color, #A8B0BD) 75%, transparent);
   box-shadow: none;
 }
 
 .canvas-node--frame.canvas-node--selected {
-  border-color: var(--frame-color, #9575d4);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--frame-color, #9575d4) 20%, transparent);
+  border-style: solid;
+  border-color: var(--frame-color, #A8B0BD);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--frame-color, #A8B0BD) 22%, transparent);
 }
+
+/* ---- Header tab ---- */
 
 .canvas-node--frame .node-header {
   position: absolute;
-  top: -34px;
-  left: -2px;
-  height: 32px;
-  min-width: max-content;
-  background: var(--frame-color, #9575d4);
-  border-radius: 6px 6px 0 0;
+  top: -26px;
+  left: -1.5px;
+  height: 24px;
+  min-width: 120px;
+  max-width: 100%;
+  /* Soft tint background: frame color mixed with white produces a label-like
+   * pastel across every hue. */
+  background: color-mix(in srgb, var(--frame-color, #A8B0BD) 22%, #ffffff);
+  border: 1px solid color-mix(in srgb, var(--frame-color, #A8B0BD) 45%, transparent);
   border-bottom: none;
+  border-radius: 6px 6px 0 0;
   padding: 0 8px;
-  color: white;
+  /* Dark text derived from frame color — readable on every preset hue. */
+  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 70%, #111111);
   transform: scale(calc(1 / var(--canvas-scale, 1)));
   transform-origin: left bottom;
   z-index: 2;
 }
 
-.canvas-node--frame .node-header .node-type-badge--frame,
+.canvas-node--frame .node-header .node-type-badge--frame {
+  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 65%, #111111);
+}
+
 .canvas-node--frame .node-header .node-title {
-  color: rgba(255, 255, 255, 0.95);
+  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 70%, #111111);
+  font-weight: 600;
+}
+
+.canvas-node--frame .node-header .node-title:focus {
+  background: rgba(255, 255, 255, 0.5);
 }
 
 .canvas-node--frame .node-header .node-focus,
 .canvas-node--frame .node-header .node-close {
-  color: rgba(255, 255, 255, 0.65);
+  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 55%, #333333);
 }
 
-.canvas-node--frame .node-header .node-focus:hover,
+.canvas-node--frame .node-header .node-focus:hover {
+  background: color-mix(in srgb, var(--frame-color, #A8B0BD) 25%, transparent);
+  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 80%, #000000);
+}
+
 .canvas-node--frame .node-header .node-close:hover {
-  background: rgba(255, 255, 255, 0.15);
-  color: white;
+  background: rgba(0, 0, 0, 0.08);
+  color: #d03b3b;
 }
 
 .canvas-node--frame .node-body {
@@ -58,12 +91,18 @@
   position: relative;
 }
 
+/* ---- Color trigger (in header) ----
+ * Reserve a fixed 16px slot so the header width doesn't jump when the dot
+ * fades in on hover. */
 .frame-color-trigger {
   position: relative;
   display: flex;
   align-items: center;
+  justify-content: center;
   cursor: pointer;
   flex-shrink: 0;
+  width: 16px;
+  height: 16px;
   opacity: 0;
   transition: opacity 0.15s ease;
 }
@@ -74,15 +113,16 @@
 }
 
 .frame-color-dot {
-  width: 14px;
-  height: 14px;
+  width: 12px;
+  height: 12px;
   border-radius: 50%;
-  border: 1.5px solid rgba(255, 255, 255, 0.5);
-  transition: border-color 0.15s ease;
+  border: 1.5px solid color-mix(in srgb, var(--frame-color, #A8B0BD) 55%, #ffffff);
+  transition: border-color 0.15s ease, transform 0.1s ease;
 }
 
 .frame-color-trigger:hover .frame-color-dot {
-  border-color: white;
+  border-color: color-mix(in srgb, var(--frame-color, #A8B0BD) 80%, #000000);
+  transform: scale(1.15);
 }
 
 .frame-color-popover {

--- a/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.css
@@ -36,6 +36,10 @@
   top: -26px;
   left: -1.5px;
   height: 24px;
+  /* Override the generic .node-header min-height: 32px so the tab actually
+   * renders at its intended 24px height instead of dipping into the frame
+   * body by 6px. */
+  min-height: 0;
   min-width: 120px;
   max-width: 100%;
   /* Soft tint background: frame color mixed with white produces a label-like

--- a/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.css
@@ -16,6 +16,7 @@
   border: 1.5px dashed color-mix(in srgb, var(--frame-color, #A8B0BD) 50%, transparent);
   box-shadow: none;
   overflow: visible;
+  border-top-left-radius: 0px;
 }
 
 .canvas-node--frame:hover {
@@ -33,9 +34,9 @@
 
 .canvas-node--frame .node-header {
   position: absolute;
-  top: -26px;
+  top: -30px;
   left: -1.5px;
-  height: 24px;
+  height: 28px;
   /* Override the generic .node-header min-height: 32px so the tab actually
    * renders at its intended 24px height instead of dipping into the frame
    * body by 6px. */

--- a/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.tsx
@@ -13,16 +13,19 @@ export const FrameNodeBody = ({ node: _node, onUpdate: _onUpdate }: Props) => {
 
 /* ---- Color picker (rendered in header) ---- */
 
+// FigJam-style soft palette: L≈70, S≈55%, hues evenly distributed.
+// These read as a cohesive family and produce good dark-text contrast in the
+// narrow header tab (see FrameNodeBody/index.css).
 const COLOR_PRESETS = [
-  { name: "Red", value: "#e8615a" },
-  { name: "Orange", value: "#e89545" },
-  { name: "Yellow", value: "#d4a030" },
-  { name: "Green", value: "#3eb889" },
-  { name: "Cyan", value: "#35aec2" },
-  { name: "Blue", value: "#5594e8" },
-  { name: "Purple", value: "#9575d4" },
-  { name: "Pink", value: "#e06aa0" },
-  { name: "Gray", value: "#8b96a4" }
+  { name: "Red", value: "#F08F82" },
+  { name: "Orange", value: "#F5B36B" },
+  { name: "Yellow", value: "#E8C468" },
+  { name: "Green", value: "#7BC89B" },
+  { name: "Teal", value: "#6FBFC7" },
+  { name: "Blue", value: "#7AA7E8" },
+  { name: "Purple", value: "#A594E0" },
+  { name: "Pink", value: "#E89BBF" },
+  { name: "Gray", value: "#A8B0BD" }
 ];
 
 interface ColorPickerProps {

--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -21,7 +21,7 @@
   --accent-border: rgba(35, 131, 226, 0.45);
   --accent-file: #d9730d;
   --accent-term: #0f7b6c;
-  --accent-frame: #9575d4;
+  --accent-frame: #A594E0;
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.04);
   --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.04), 0 4px 12px rgba(0, 0, 0, 0.05);
   --shadow-card-hover: 0 2px 6px rgba(0, 0, 0, 0.06), 0 8px 20px rgba(0, 0, 0, 0.07);


### PR DESCRIPTION
- Swap frame color presets to a FigJam-style soft palette (L≈70, S≈55%) so hues read as a cohesive family instead of mixed marker tones.
- Redesign the frame header as a narrow 24px label tab with a soft tint background and dark, frame-derived text color — fixes the low contrast white-on-mid-saturation legibility problem on green/yellow frames.
- Dashed default border + solid border with stronger glow on select signals "container, not card" and makes selection clearly visible.
- Tint the frame body over --surface instead of over transparent to avoid muddy overlays on the canvas background.
- Reserve a fixed 16px slot for the color-picker dot so the header width no longer jumps on hover.
- Update --accent-frame token to the new palette purple (#A594E0) so generic frame badges in CanvasNodeView and NodeMentionPicker match the refreshed look.