### PR TITLE
Add canvas_send_to_agent tool for follow-up prompts to running agents

### DIFF
--- a/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
@@ -41,6 +41,7 @@ Your system prompt contains a summary of all canvas nodes. For detailed content:
 - \`canvas_read_node\`: Read a single node's content in detail
 - \`canvas_create_node\`: Create new file/frame nodes (generic)
 - \`canvas_create_agent_node\`: **Create and launch an AI agent node** — preferred for agent creation
+- \`canvas_send_to_agent\`: **Send a follow-up prompt to an already-running agent node** — use for any interaction AFTER the initial launch
 - \`canvas_create_terminal_node\`: **Create a terminal node** — preferred for terminal creation
 - \`canvas_update_node\`: Update existing nodes (content, title, data)
 - \`canvas_delete_node\`: Remove a node from the canvas
@@ -64,6 +65,13 @@ Example:
   "prompt": "## Task\\nImplement the login feature.\\n\\n## Context from Canvas\\n(PRD content here...)"
 }
 \`\`\`
+
+### Following Up with a Running Agent Node
+After an agent node is launched, use \`canvas_send_to_agent\` to send any additional prompts — follow-up questions, corrections, new tasks, approvals, etc. The text is written straight to the agent's PTY and Enter is auto-appended, so the agent receives and executes each call as one submission.
+
+- Use \`canvas_read_node\` first if you need to see what the agent most recently output before deciding what to send.
+- Do NOT use \`canvas_create_agent_node\` again just to say something more — that would spawn a second agent. Only create a new node when you want a fresh agent process.
+- The target node must be \`type="agent"\`, \`status="running"\`, and still open on the canvas (closing the node tears down its PTY).
 
 ### Creating Terminal Nodes
 Use \`canvas_create_terminal_node\` to spawn an interactive shell.

--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -20,6 +20,7 @@ import {
   readNodeDetail,
   formatSummaryForPrompt,
 } from './context-builder';
+import { hasSession, writeToSession } from '../pty-manager';
 
 const STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
 
@@ -530,6 +531,74 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
         broadcastUpdate(workspaceId, [nodeId]);
 
         return JSON.stringify({ ok: true, nodeId, agentType, title, autoLaunch });
+      },
+    },
+
+    // ─── Follow-up input to an existing agent node ──────────────────
+
+    canvas_send_to_agent: {
+      name: 'canvas_send_to_agent',
+      description:
+        'Send a follow-up prompt to an existing, RUNNING agent node (Claude Code / Codex / Pulse Coder). ' +
+        'Writes the text directly to the agent\'s PTY as if the user typed it, and auto-appends Enter ' +
+        '(a carriage return) so the agent receives and executes it immediately — you do NOT need to ' +
+        'call this twice or send a separate newline. ' +
+        'Use this for any interaction AFTER the initial launch: follow-up questions, corrections, ' +
+        'redirections, approvals, etc. ' +
+        'For the FIRST launch of a brand-new agent, use `canvas_create_agent_node` instead. ' +
+        'Requirements: the target node must be `type="agent"`, `status="running"`, and its backing PTY ' +
+        'session must still be alive (the agent node must be open in the canvas UI — closing the node ' +
+        'tears down the PTY).',
+      inputSchema: z.object({
+        nodeId: z.string().describe('The agent node ID to send the prompt to.'),
+        input: z.string().describe(
+          'The text to send. Enter is appended automatically, so provide exactly what you want the ' +
+          'agent to receive as one submission — no trailing newline needed.',
+        ),
+      }),
+      execute: async (input) => {
+        const nodeId = input.nodeId as string;
+        const text = (input.input as string) ?? '';
+
+        const canvas = await loadCanvas(workspaceId);
+        if (!canvas) return 'Error: workspace not found';
+
+        const node = canvas.nodes.find(n => n.id === nodeId);
+        if (!node) return `Error: node not found: ${nodeId}`;
+        if (node.type !== 'agent') {
+          return `Error: canvas_send_to_agent only works on agent nodes (got "${node.type}"). ` +
+            'For terminal nodes use the MCP `canvas_exec` tool; for file/frame nodes use `canvas_update_node`.';
+        }
+
+        const status = (node.data.status as string) ?? 'idle';
+        if (status !== 'running') {
+          return `Error: agent node "${node.title}" is not running (status="${status}"). ` +
+            'The agent must have been launched (status="running") before you can send follow-up input. ' +
+            'Create a new agent node with a prompt, or ask the user to launch this one.';
+        }
+
+        const sessionId = (node.data.sessionId as string) ?? '';
+        if (!sessionId || !hasSession(sessionId)) {
+          return `Error: agent node "${node.title}" has no active PTY session. ` +
+            'The agent node must be open in the canvas UI — closing or collapsing the node tears ' +
+            'down its PTY. Ask the user to reopen the node, or relaunch the agent.';
+        }
+
+        // Strip any trailing CR/LF the caller might have included, then append
+        // exactly one \r. \r is what xterm emits when the user presses Enter,
+        // and is what execInSession uses for its command writes.
+        const trimmed = text.replace(/[\r\n]+$/, '');
+        const payload = trimmed + '\r';
+        const ok = writeToSession(sessionId, payload);
+        if (!ok) {
+          return `Error: failed to write to PTY session ${sessionId} (session disappeared).`;
+        }
+
+        return JSON.stringify({
+          ok: true,
+          nodeId,
+          bytesSent: payload.length,
+        });
       },
     },
 

--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -584,20 +584,37 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
             'down its PTY. Ask the user to reopen the node, or relaunch the agent.';
         }
 
-        // Strip any trailing CR/LF the caller might have included, then append
-        // exactly one \r. \r is what xterm emits when the user presses Enter,
-        // and is what execInSession uses for its command writes.
-        const trimmed = text.replace(/[\r\n]+$/, '');
-        const payload = trimmed + '\r';
-        const ok = writeToSession(sessionId, payload);
-        if (!ok) {
-          return `Error: failed to write to PTY session ${sessionId} (session disappeared).`;
+        // Strip any trailing CR/LF the caller might have included so we
+        // control the submit signal ourselves.
+        const body = text.replace(/[\r\n]+$/, '');
+
+        // Write body and Enter as TWO separate writes with a small gap.
+        //
+        // Why: some TUI agents (notably Codex, which uses a ratatui-style
+        // input editor with paste protection) distinguish "paste" from
+        // "keystroke" by timing. If the text body and the \r arrive in the
+        // same read, the \r gets absorbed into the editor buffer as a
+        // literal newline and the prompt is never submitted — you end up
+        // with the text sitting in the input box waiting for a real Enter.
+        // Writing the body, yielding the event loop for ~120ms, then
+        // writing \r as a second call makes the Enter arrive as an
+        // independent keystroke, which Codex's editor treats as submit.
+        // Claude Code is happy either way, so this is safe for all
+        // agent types.
+        if (body) {
+          if (!writeToSession(sessionId, body)) {
+            return `Error: failed to write to PTY session ${sessionId} (session disappeared).`;
+          }
+          await new Promise<void>((resolve) => setTimeout(resolve, 120));
+        }
+        if (!writeToSession(sessionId, '\r')) {
+          return `Error: failed to write Enter to PTY session ${sessionId} (session disappeared).`;
         }
 
         return JSON.stringify({
           ok: true,
           nodeId,
-          bytesSent: payload.length,
+          bytesSent: body.length + 1,
         });
       },
     },

--- a/apps/canvas-workspace/src/main/pty-manager.ts
+++ b/apps/canvas-workspace/src/main/pty-manager.ts
@@ -234,6 +234,18 @@ export function hasSession(sessionId: string): boolean {
   return sessions.has(sessionId);
 }
 
+/**
+ * Write raw data to an existing PTY session (as if the user typed it).
+ * Does NOT capture output — for command+output capture use execInSession.
+ * Returns false if the session does not exist.
+ */
+export function writeToSession(sessionId: string, data: string): boolean {
+  const proc = sessions.get(sessionId);
+  if (!proc) return false;
+  proc.write(data);
+  return true;
+}
+
 /** Get the PID of a PTY session (for cwd lookup etc.) */
 export function getSessionPid(sessionId: string): number | null {
   const proc = sessions.get(sessionId);


### PR DESCRIPTION
## Summary
Adds a new `canvas_send_to_agent` tool that allows sending follow-up prompts to already-running agent nodes without spawning new agents. This complements the existing `canvas_create_agent_node` tool by enabling interactive conversations with agents after their initial launch.

## Key Changes

- **New tool: `canvas_send_to_agent`** in `tools.ts`
  - Sends text directly to a running agent node's PTY session
  - Automatically appends carriage return (`\r`) so the agent receives and executes input immediately
  - Validates that the target node is an agent type with `running` status and an active PTY session
  - Returns success/failure status with bytes sent

- **New export: `writeToSession()`** in `pty-manager.ts`
  - Low-level function to write raw data to an existing PTY session
  - Returns boolean indicating success (false if session doesn't exist)
  - Complements existing `hasSession()` and `execInSession()` functions

- **Updated system prompt** in `canvas-agent.ts`
  - Documents the new `canvas_send_to_agent` tool in the agent's instructions
  - Clarifies the workflow: use `canvas_create_agent_node` for initial launch, then `canvas_send_to_agent` for follow-ups
  - Explains that closing a node tears down its PTY session

## Implementation Details

- The tool strips any trailing newlines from user input before appending exactly one `\r` (matching xterm behavior)
- Comprehensive error messages distinguish between missing nodes, wrong node types, inactive agents, and dead PTY sessions
- Follows the same validation pattern as other canvas tools (load workspace, find node, check state)

https://claude.ai/code/session_01RwnH31JU1SFedpsCZ7mpbc