### PR TITLE
feat: pass x-session-id for Claude remote sessions

### DIFF
--- a/apps/remote-server/ecosystem.config.cjs
+++ b/apps/remote-server/ecosystem.config.cjs
@@ -18,11 +18,13 @@ module.exports = {
         NODE_ENV: 'development',
         PORT: 3000,
         HOST: '0.0.0.0',
+        NODE_USE_ENV_PROXY: '1',
       },
       env_production: {
         NODE_ENV: 'production',
         PORT: 3000,
         HOST: '0.0.0.0',
+        NODE_USE_ENV_PROXY: '1',
         ACP_RETRY_MAX: '3',
         ACP_RETRY_BASE_DELAY_MS: '1000',
       },

--- a/apps/remote-server/src/core/agent-runner.ts
+++ b/apps/remote-server/src/core/agent-runner.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto';
-import type { CompactionEvent, ModelMessage } from 'pulse-coder-engine';
+import { buildProvider, type CompactionEvent, type LLMProviderFactory } from 'pulse-coder-engine';
+import type { ModelMessage } from 'ai';
 import type { ClarificationRequest, IncomingAttachment } from './types.js';
 import { engine } from './engine-singleton.js';
 import { getAcpState, runAcp } from 'pulse-coder-acp';
@@ -230,6 +231,21 @@ function buildChannelSystemPrompt(platformKey: string): string | null {
   return lines.join('\n');
 }
 
+function resolveRunProvider(
+  modelType: 'openai' | 'claude' | undefined,
+  sessionId: string,
+): LLMProviderFactory | undefined {
+  if (modelType !== 'claude') {
+    return undefined;
+  }
+
+  return buildProvider('claude', {
+    headers: {
+      'x-session-id': sessionId,
+    },
+  });
+}
+
 export async function executeAgentTurn(input: ExecuteAgentTurnInput): Promise<ExecuteAgentTurnResult> {
   const session = await sessionStore.getOrCreate(input.platformKey, input.forceNewSession, input.memoryKey);
   const sessionId = session.sessionId;
@@ -238,6 +254,7 @@ export async function executeAgentTurn(input: ExecuteAgentTurnInput): Promise<Ex
   const callbacks = input.callbacks ?? {};
   const compactions: CompactionSnapshot[] = [];
   const { model: modelOverride, modelType } = await resolveModelForRun(input.platformKey);
+  const providerOverride = resolveRunProvider(modelType, sessionId);
 
   let latestAttachments = session.latestAttachments ?? [];
   if (input.attachments?.length) {
@@ -303,6 +320,7 @@ export async function executeAgentTurn(input: ExecuteAgentTurnInput): Promise<Ex
       console.log('modelType', modelType);
 
       return engine.run(context, {
+        provider: providerOverride,
         model: modelOverride,
         modelType,
         runContext,

--- a/packages/engine/src/config/index.ts
+++ b/packages/engine/src/config/index.ts
@@ -16,6 +16,10 @@ export const CoderAI = (process.env.USE_ANTHROPIC
     baseURL: process.env.OPENAI_API_URL || 'https://api.openai.com/v1'
   }).responses) as (model: string) => LanguageModel;
 
+export interface BuildProviderOptions {
+  headers?: Record<string, string>;
+}
+
 /**
  * Construct a LLMProviderFactory from a named ModelType using environment variables.
  * Both types use the OpenAI-compatible SDK since most proxies expose models via
@@ -26,17 +30,21 @@ export const CoderAI = (process.env.USE_ANTHROPIC
  *
  * The modelType is still meaningful for pre-processing (e.g. system message consolidation).
  */
-export function buildProvider(type: ModelType): LLMProviderFactory {
+export function buildProvider(type: ModelType, options?: BuildProviderOptions): LLMProviderFactory {
   if (type === 'claude') {
     return createAnthropic({
       apiKey: process.env.ANTHROPIC_API_KEY || '',
       baseURL: process.env.ANTHROPIC_API_URL || 'https://api.anthropic.com/v1',
-      headers: { 'user-agent': 'claude-code/2.1.63' },
+      headers: {
+        'user-agent': 'claude-code/2.1.63',
+        ...(options?.headers ?? {}),
+      },
     }) as LLMProviderFactory;
   }
   return createOpenAI({
     apiKey: process.env.OPENAI_API_KEY || '',
     baseURL: process.env.OPENAI_API_URL || 'https://api.openai.com/v1',
+    headers: options?.headers,
   }).responses as LLMProviderFactory;
 }
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -66,4 +66,5 @@ export { loop } from './core/loop.js';
 export type { LoopOptions, LoopHooks, CompactionEvent } from './core/loop.js';
 export { streamTextAI, generateTextAI } from './ai/index.js';
 export { maybeCompactContext } from './context/index.js';
+export { buildProvider } from './config/index.js';
 export * from './tools/index.js';


### PR DESCRIPTION
Enable session-aware Claude routing by forwarding the remote server session id to the upstream provider.\n\n- inject per-run \'x-session-id\' header in remote-server when modelType is claude\n- extend engine buildProvider to accept custom headers for both Anthropic/OpenAI adapters\n- export buildProvider from pulse-coder-engine for reuse in remote-server\n- set NODE_USE_ENV_PROXY in remote-server ecosystem dev/prod env blocks