### PR TITLE
chore: ignore electron-builder release output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,9 @@ out
 .nuxt
 dist
 
+# electron-builder output (e.g. apps/canvas-workspace)
+release/
+
 # Gatsby files
 .cache/
 # Comment in the public line in if your project uses Gatsby and not Next.js


### PR DESCRIPTION
Avoid accidentally committing the ~119MB AppImage produced by
`pnpm --filter canvas-workspace package:linux` into the repo.

https://claude.ai/code/session_01FmEtQ3sr3KHTkLyxh7qoHB