### PR TITLE
docs: add comprehensive READMEs for all packages and apps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,20 +21,30 @@ Primary packages:
 - `packages/cli` (`pulse-coder-cli`): interactive terminal app built on the engine.
 - `packages/pulse-sandbox` (`pulse-sandbox`): sandboxed JS executor used by `run_js`.
 - `packages/memory-plugin` (`pulse-coder-memory-plugin`): memory service/integration helpers.
+- `packages/plugin-kit` (`pulse-coder-plugin-kit`): shared utilities for building plugins — exports worktree helpers, vault (secret storage), and devtools utilities.
+- `packages/orchestrator` (`pulse-coder-orchestrator`): multi-agent orchestration layer (TaskGraph, planner, scheduler, runner, aggregator).
+- `packages/agent-teams` (`pulse-coder-agent-teams`): agent teams coordination built on orchestrator.
+- `packages/acp` (`pulse-coder-acp`): Agent Context Protocol — typed client, runner, and state store for Claude's native ACP session protocol.
 
 Apps:
-- `apps/remote-server`: HTTP wrapper around engine runtime.
+- `apps/remote-server`: HTTP wrapper around engine runtime (Feishu/Discord/Telegram adapters).
+- `apps/teams-cli`: CLI for multi-agent teams workflows.
+- `apps/canvas-workspace`: canvas-based workspace app.
 - `apps/coder-demo`: legacy experimental app.
 
 ## Build, Dev, and Test Commands
 
 ```bash
 pnpm install
-pnpm run build
+pnpm run build          # builds packages/* + remote-server + teams-cli (SKIP_DTS=1)
+pnpm run build:all      # builds everything including apps
 pnpm run dev
-pnpm start
-pnpm test
-pnpm run test:apps
+pnpm start              # starts pulse-coder-cli
+pnpm start:debug        # starts CLI with debug logging
+pnpm test               # alias for test:core (packages/* + remote-server + teams-cli)
+pnpm run test:packages  # packages/* only
+pnpm run test:apps      # apps/* only (may fail in coder-demo)
+pnpm run test:all       # all packages and apps
 ```
 
 Useful filtered commands:
@@ -45,12 +55,17 @@ pnpm --filter pulse-coder-engine typecheck
 pnpm --filter pulse-coder-cli test
 pnpm --filter pulse-sandbox test
 pnpm --filter pulse-coder-memory-plugin test
+pnpm --filter pulse-coder-plugin-kit test
+pnpm --filter pulse-coder-orchestrator test
+pnpm --filter pulse-coder-agent-teams test
 pnpm --filter @pulse-coder/remote-server build
 pnpm --filter @pulse-coder/remote-server dev
 ```
 
+All packages use **vitest** (`vitest run`) for tests and `tsc --noEmit` for typechecking.
+
 Notes:
-- `pnpm test` runs package tests only (`./packages/*`).
+- `pnpm test` (`test:core`) covers `packages/*`, `@pulse-coder/remote-server`, and `@pulse-coder/teams-cli`.
 - `pnpm run test:apps` includes app tests and may fail due to placeholder scripts in `apps/coder-demo`.
 
 ## Architecture Notes
@@ -68,6 +83,7 @@ It supports:
 - streaming text/tool events,
 - LLM hooks (`beforeLLMCall`, `afterLLMCall`),
 - tool hooks (`beforeToolCall`, `afterToolCall`),
+- run-level hooks (`beforeRun`, `afterRun`) — fired once per `Engine.run()` call; `beforeRun` can mutate `systemPrompt` and `tools`,
 - retry/backoff on retryable errors,
 - abort handling,
 - context compaction.
@@ -78,7 +94,21 @@ Registered from `packages/engine/src/built-in/index.ts`:
 - skills plugin (`SKILL.md` scanning + `skill` tool),
 - plan-mode plugin,
 - task-tracking plugin,
-- sub-agent plugin (`.pulse-coder/agents/*.md`).
+- sub-agent plugin (`.pulse-coder/agents/*.md`),
+- tool-search plugin (deferred tool discovery),
+- role-soul plugin (persona/system prompt injection),
+- agent-teams plugin (multi-agent coordination),
+- ptc plugin (PTC workflow integration).
+
+### Writing a plugin
+Implement `EnginePlugin` from `pulse-coder-engine`. The `initialize(ctx: EnginePluginContext)` method receives a context with:
+- `ctx.registerTool(name, tool)` / `ctx.registerTools(map)` — add tools to the engine,
+- `ctx.registerHook(hookName, handler)` — subscribe to any hook in `EngineHookMap` (`beforeRun`, `afterRun`, `beforeLLMCall`, `afterLLMCall`, `beforeToolCall`, `afterToolCall`, `onToolCall`, `onCompacted`),
+- `ctx.registerService(name, service)` / `ctx.getService(name)` — share objects between plugins,
+- `ctx.getConfig(key)` / `ctx.setConfig(key, val)` — engine-scoped config,
+- `ctx.events` (EventEmitter), `ctx.logger`.
+
+Pass custom plugins via `EngineOptions.enginePlugins.plugins` or drop `.plugin.js` files into `.pulse-coder/engine-plugins/`.
 
 ### Built-in tools
 Engine toolset (`packages/engine/src/tools/`):
@@ -89,6 +119,15 @@ CLI adds:
 
 Task tracking adds:
 - `task_create`, `task_get`, `task_list`, `task_update`.
+
+### Orchestrator (`packages/orchestrator`)
+Runs a **TaskGraph** — a DAG of `TaskNode` objects with `{ id, role, deps[], input?, agent?, instruction? }`.
+Routing strategies (`OrchestrationInput.route`):
+- `'auto'` — keyword-based role selection,
+- `'all'` — every registered role runs,
+- `'plan'` — LLM dynamically builds the graph.
+
+Built-in roles: `researcher`, `executor`, `reviewer`, `writer`, `tester`. Results are aggregated via `concat | last | llm`. The `agent-teams` plugin exposes orchestration to the engine as a tool.
 
 ### Remote server runtime (`apps/remote-server`)
 Entry and server:
@@ -126,6 +165,15 @@ Environment variables (common):
 - `OPENAI_API_KEY`, `OPENAI_API_URL`, `OPENAI_MODEL`
 - optional Anthropic path: `USE_ANTHROPIC`, `ANTHROPIC_API_KEY`, `ANTHROPIC_API_URL`, `ANTHROPIC_MODEL`
 - optional tools: `TAVILY_API_KEY`, `GEMINI_API_KEY`
+- default model: `novita/deepseek/deepseek_v3` (override with `OPENAI_MODEL` or `ANTHROPIC_MODEL`)
+
+Context compaction tuning:
+- `CONTEXT_WINDOW_TOKENS` (default 64 000) — estimated token budget before compaction triggers.
+- `COMPACT_TRIGGER` (default 75% of window), `COMPACT_TARGET` (default 50%), `KEEP_LAST_TURNS` (default 4).
+- `COMPACT_SUMMARY_MODEL`, `COMPACT_SUMMARY_MAX_TOKENS` (default 1200), `MAX_COMPACTION_ATTEMPTS` (default 2).
+
+Clarification:
+- `CLARIFICATION_ENABLED` (default `true`), `CLARIFICATION_TIMEOUT` (default 300 000 ms).
 
 Config paths:
 - MCP: `.pulse-coder/mcp.json`
@@ -140,3 +188,4 @@ Config paths:
 - Follow local file style (2 spaces, semicolons, single quotes in most TS files).
 - Keep diffs minimal and preserve existing architecture patterns.
 - Prefer extending plugin/hooks/tool boundaries rather than hardcoding behavior into the loop.
+- Cross-package imports in source use path aliases defined in root `tsconfig.json` (e.g. `pulse-coder-engine`, `pulse-coder-plugin-kit`). Published packages use their npm names.

--- a/apps/canvas-workspace/README.md
+++ b/apps/canvas-workspace/README.md
@@ -1,0 +1,86 @@
+# Pulse Canvas
+
+An Electron desktop app that provides a free-form canvas workspace for AI-assisted coding. Users arrange **nodes** on an infinite canvas and interact with an embedded AI agent.
+
+## Tech Stack
+
+- **Electron** (v30) + **electron-vite** — desktop shell and build pipeline
+- **React** (v18) + **wouter** — renderer UI and routing
+- **Tiptap** — rich-text editor for file nodes
+- **xterm.js** + **node-pty** — terminal emulation in terminal/agent nodes
+- **pulse-coder-engine** — powers the in-app AI agent (chat and canvas agent nodes)
+
+## Node Types
+
+| Type | Description |
+|------|-------------|
+| `file` | Tiptap-based rich-text/markdown editor backed by a real file path |
+| `terminal` | Full PTY terminal session |
+| `agent` | Runs an external AI agent CLI (e.g. `claude`) in a PTY; accepts inline prompts or prompt files |
+| `frame` | Visual grouping rectangle with a label/color |
+
+## Views
+
+- **Canvas view** (`/`) — free-form canvas with sidebar, node editing, and an optional right-side chat panel.
+- **Chat view** (`/chat`) — full-screen AI chat page backed by `pulse-coder-engine`.
+
+### Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd/Ctrl+Shift+A` | Toggle right-side chat panel (canvas view only) |
+| `Cmd/Ctrl+Shift+L` | Toggle full-screen chat view |
+| `Esc` | Return to canvas from chat view |
+
+## Project Structure
+
+```
+src/
+  main/             # Electron main process
+    canvas-agent/   # CanvasAgent + CanvasAgentService (engine-backed AI chat)
+    canvas-store.ts # Canvas state persistence (JSON per workspace)
+    file-manager.ts # File read/write/dialog IPC handlers
+    file-watcher.ts # Filesystem watcher → external update events
+    mcp-server.ts   # Local MCP server exposed to agent nodes
+    pty-manager.ts  # node-pty session management
+    skill-installer.ts
+  preload/          # Context bridge (exposes window.canvasWorkspace API)
+  renderer/src/
+    components/     # Canvas, Sidebar, AgentNodeBody, FileNodeBody, chat/, …
+    hooks/          # useWorkspaces, canvas interaction hooks
+    types.ts        # Shared types (CanvasNode, CanvasWorkspaceApi, …)
+```
+
+The renderer communicates with the main process exclusively through `window.canvasWorkspace` (defined in `types.ts`), which is bridged via `src/preload/`.
+
+## Dev & Build Commands
+
+```bash
+# Install (also runs electron-rebuild for node-pty)
+pnpm install
+
+# Development (hot reload)
+pnpm --filter canvas-workspace dev
+
+# Production build
+pnpm --filter canvas-workspace build
+
+# Package for distribution
+pnpm --filter canvas-workspace package          # current platform
+pnpm --filter canvas-workspace package:mac      # macOS dmg (arm64 + x64)
+pnpm --filter canvas-workspace package:win      # Windows nsis x64
+pnpm --filter canvas-workspace package:linux    # Linux AppImage + deb x64
+
+# Typecheck
+pnpm --filter canvas-workspace typecheck
+```
+
+Packaged output goes to `release/`. App ID: `com.pulse-coder.canvas-workspace`.
+
+## Canvas Agent
+
+The AI chat feature is powered by `CanvasAgentService` (`src/main/canvas-agent/`), which wraps `pulse-coder-engine`. Each workspace maintains its own agent session, persisted under the workspace data directory. The agent receives a workspace/node summary as context on every turn.
+
+## Data Persistence
+
+Canvas state (node positions, types, data) is saved per workspace as JSON via `canvas-store.ts`. File nodes are backed by real files on disk; the file watcher pushes external changes into the renderer via IPC.

--- a/apps/remote-server/README.md
+++ b/apps/remote-server/README.md
@@ -1,184 +1,230 @@
-# remote-server
+# @pulse-coder/remote-server
 
-## Built-in X list tool
+HTTP server that wraps `pulse-coder-engine` and exposes it to messaging platforms. Incoming messages are dispatched to a per-channel agent session; responses stream back through the original platform's API.
 
-A deferred tool named `twitter_list_tweets` is available for fetching tweets from X lists.
+## Tech Stack
 
-Quick test (local-only internal endpoint):
+- **Hono** + **@hono/node-server** — HTTP framework
+- **tsup** — bundles to `dist/index.cjs`
+- **tsx** — TypeScript watch mode for development
+- `pulse-coder-engine`, `pulse-coder-memory-plugin`, `pulse-coder-plugin-kit`, `pulse-coder-acp` — workspace deps
 
-```bash
-curl -sS -X POST \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $INTERNAL_API_SECRET" \
-  http://127.0.0.1:3000/internal/agent/run \
-  -d '{"text":"Use tool_search_tool_bm25 to find twitter_list_tweets, then call it with listUrl=https://x.com/i/lists/1234567890 and limit=10."}'
-```
+## Endpoints
 
-Tool behavior:
-- Uses Nitter-compatible RSS (`/i/lists/<id>/rss`) with fallback instances.
-- Returns normalized tweet records with dedupe metadata.
-- If all instances fail, returns `ok=false` with attempted instances and error details.
+| Method | Path | Access |
+|--------|------|--------|
+| `GET` | `/health` | Public |
+| `POST` | `/webhooks/feishu` | Public (HMAC-verified) |
+| `POST` | `/webhooks/discord` | Public (ED25519-verified) |
+| `POST` | `/internal/agent/run` | Loopback + Bearer token |
+| `GET` | `/internal/discord/gateway/status` | Loopback + Bearer token |
+| `POST` | `/internal/discord/gateway/restart` | Loopback + Bearer token |
+| `GET` | `/api/devtools/runs` | Local dev |
 
-## Deferred tool demo
+> Telegram and Web API adapters exist in code but are not mounted by default.
 
-A demo tool named `deferred_demo` is registered with `defer_loading: true`.
-It will not be sent to the AI SDK until it is discovered via tool search.
-
-Quick test (local-only internal endpoint):
-
-```bash
-curl -sS -X POST \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $INTERNAL_API_SECRET" \
-  http://127.0.0.1:3000/internal/agent/run \
-  -d '{"text":"Use tool_search_tool_bm25 to find the deferred_demo tool, then call it with message=hello."}'
-```
-
-Expected behavior:
-- First run: model uses tool search and discovers `deferred_demo`.
-- Second run: `deferred_demo` is now loaded and can be called directly.
-
-## PTC allowed_callers demo
-
-`allowed_callers` in this repo is implemented as a caller tool-name allowlist.
-
-- `ptc_demo_caller_probe`: unrestricted probe tool
-- `ptc_demo_caller_only`: `allowed_callers=["ptc_demo_caller_probe"]`
-- `ptc_demo_cron_only`: `allowed_callers=["cron_job"]`
-- `ptc_demo_deferred_only`: `allowed_callers=["deferred_demo"]`
-
-Quick test via internal endpoint:
+## Dev & Build
 
 ```bash
-curl -sS -X POST \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $INTERNAL_API_SECRET" \
-  http://127.0.0.1:3000/internal/agent/run \
-  -d '{
-    "text": "Call ptc_demo_caller_only with message=hello",
-    "caller": "ptc_demo_caller_probe",
-    "callerSelectors": ["ptc_demo_caller_probe"]
-  }'
+# From repo root
+pnpm --filter @pulse-coder/remote-server dev    # tsx watch
+pnpm --filter @pulse-coder/remote-server build  # tsup → dist/index.cjs
+
+# Or from this directory
+npm run dev
+npm run build
+npm start                                        # node dist/index.cjs
 ```
 
-If you use a non-matching caller (or omit it), restricted demo tools should be filtered out by PTC rules.
+## Configuration
 
-## Enabled webhook endpoints
+Copy `.env.example` to `.env`. Key variables:
 
-- `POST /webhooks/feishu`
-- `POST /webhooks/discord`
+```bash
+# === LLM ===
+OPENAI_API_KEY=
+OPENAI_API_URL=
+OPENAI_MODEL=
 
-> Telegram and Web API adapters exist in code but are currently not mounted by default.
+# === Server ===
+PORT=3000
+HOST=0.0.0.0
+INTERNAL_API_SECRET=          # Required in production
 
-## Discord setup (gateway-friendly)
+# === Feishu ===
+FEISHU_APP_ID=
+FEISHU_APP_SECRET=
+FEISHU_ENCRYPT_KEY=
+FEISHU_VERIFICATION_TOKEN=
 
-Gateway mode behavior:
+# === Discord ===
+DISCORD_PUBLIC_KEY=
+DISCORD_BOT_TOKEN=            # Required for DM / gateway mode
+```
 
-- Guild/channel chats support **@mention direct text** via Discord Gateway listener.
-- Guild/channel slash commands via interactions webhook still work if you have an HTTPS endpoint.
-- DM chats support **direct text messages** (no `/ask` required) via Discord Gateway listener.
+See `.env.example` for the full list including memory plugin, Gemini, Telegram, ACP, and compaction tuning.
 
-### 1) Configure app settings in Discord Developer Portal
+Model overrides per-channel can be set in `.pulse-coder/config.json` (cwd) or via `$PULSE_CODER_MODEL_CONFIG`.
+
+## Slash Commands
+
+Users can type these in any connected channel:
+
+| Command | Description |
+|---------|-------------|
+| `/new` | Start a new session (clear history) |
+| `/clear` | Alias for `/new` |
+| `/resume [id]` | List recent sessions or resume a specific one |
+| `/fork` | Fork current session into a new branch |
+| `/merge` | Merge a linked session |
+| `/status` | Show current run status |
+| `/current` | Show active session ID |
+| `/stop` | Abort the running agent turn |
+| `/compact` | Manually trigger context compaction |
+| `/memory [show\|clear]` | View or clear memory logs |
+| `/model <name>` | Override LLM model for this channel |
+| `/mode <plan\|act>` | Switch agent mode |
+| `/soul [name]` | Set or clear persona injection |
+| `/skills [list\|install]` | Manage skills |
+| `/wt <bind\|unbind\|status>` | Git worktree binding |
+| `/acp on <claude\|codex>` | Switch to ACP agent mode |
+| `/acp off` | Return to engine mode |
+| `/restart` | Rebuild and restart (PM2 only) |
+| `/ping` | Health check reply |
+| `/help` | Show command list |
+
+`//command` (double slash) forwards the command directly to a running ACP agent.
+
+## Feishu Setup
+
+1. In the Feishu Developer Console, create an app and note `App ID` / `App Secret`.
+2. Enable **Encrypt Key** and **Verification Token** (Event Subscription → Security Settings).
+3. Set the webhook URL:
+   ```
+   https://your-server/webhooks/feishu
+   ```
+4. Subscribe to the event `im.message.receive_v1`.
+5. Grant bot permissions: `im:message:send_as_bot`, `im:message.group_at_msg` (for group chats).
+6. Set `FEISHU_APP_ID`, `FEISHU_APP_SECRET`, `FEISHU_ENCRYPT_KEY`, `FEISHU_VERIFICATION_TOKEN` in `.env`.
+
+## Discord Setup
+
+### 1) Developer Portal
 
 1. Copy the **Public Key** from your application settings.
-2. Optional (only when you have HTTPS): configure **Interactions Endpoint URL**:
+2. Optional (requires HTTPS): set **Interactions Endpoint URL** to `https://your-server/webhooks/discord`.
+3. In **Bot** settings, enable intents: `Direct Messages`, `Server Messages`, `Message Content Intent`.
 
-```text
-https://your-server-domain/webhooks/discord
-```
-
-3. In **Bot** settings, enable intents:
-   - `Direct Messages`
-   - `Server Messages`
-   - `Message Content Intent`
-
-### 2) Set environment variables
+### 2) Environment Variables
 
 ```bash
 DISCORD_PUBLIC_KEY=your_discord_public_key
 DISCORD_BOT_TOKEN=your_discord_bot_token
 
-# Optional overrides:
+# Optional:
 # DISCORD_API_BASE_URL=https://discord.com/api/v10
 # DISCORD_GATEWAY_URL=wss://gateway.discord.gg/?v=10&encoding=json
 # DISCORD_PROXY_URL=http://127.0.0.1:7890
 # DISCORD_DM_GATEWAY_ENABLED=true
+# DISCORD_GUILD_REQUIRE_MENTION=true
 # DISCORD_COMMAND_REGISTER_ENABLED=true
-# DISCORD_COMMAND_GUILD_IDS=123456789012345678,987654321098765432
+# DISCORD_COMMAND_GUILD_IDS=123456789,987654321   # faster dev registration
 ```
 
-### 3) Guild usage (no HTTPS required)
+### 3) Usage
 
-- Default behavior: mention the bot in a guild channel, then type your prompt.
-- Example: `@YourBot explain this stack trace`
-- To allow plain text without mention in guild channels, set:
+- **Guild channels** — mention the bot: `@YourBot explain this stack trace`. Set `DISCORD_GUILD_REQUIRE_MENTION=false` to allow plain text.
+- **DMs** — send text directly; `/ask`, `/chat`, `/prompt` prefixes are normalized and stripped.
+- **Slash commands** — `/ask <text>` and management commands (`/restart`, `/new`, etc.) are auto-registered on startup.
 
-```bash
-DISCORD_GUILD_REQUIRE_MENTION=false
-```
-
-### 4) Slash commands (optional, requires HTTPS interactions endpoint)
-
-- `/ask <text>` for prompts in guild channels.
-- Optional pass-through commands: `/help`, `/new`, `/compact`, `/resume`, `/status`, `/restart`, `/soul`, etc.
-- `/restart` is auto-registered on startup when `DISCORD_COMMAND_REGISTER_ENABLED=true`.
-- Slash option mapping: `mode=status` -> `/restart status`, `mode=update branch=<name>` -> `/restart update <name>`.
-- For faster propagation during development, set `DISCORD_COMMAND_GUILD_IDS`; global registration may take up to ~1 hour.
-
-### 5) DM usage
-
-- DM message text is forwarded directly to the agent.
-- `/ask foo`, `/chat foo`, `/prompt foo` in DM are normalized to `foo` for compatibility.
-
-### 6) Discord gateway internal ops (local only)
-
-The server now exposes local-only, auth-protected internal endpoints to inspect/restart Discord gateway without restarting the whole process.
+### 4) Gateway Internal Ops
 
 ```bash
-# status
+# Check gateway health
 curl -sS \
   -H "Authorization: Bearer $INTERNAL_API_SECRET" \
   http://127.0.0.1:3000/internal/discord/gateway/status
 
-# restart only discord gateway
+# Restart only the Discord gateway (no full process restart)
 curl -sS -X POST \
   -H "Authorization: Bearer $INTERNAL_API_SECRET" \
   http://127.0.0.1:3000/internal/discord/gateway/restart
 ```
 
-For watchdog checks, poll every ~90s and trigger restart only after consecutive unhealthy checks.
+The included `scripts/discord-gateway-watchdog.sh` polls this endpoint every ~90 s and triggers a restart after consecutive unhealthy checks.
 
-## PM2 deployment (recommended)
+## Internal Agent API
 
-Use PM2 instead of `setsid ... &` for long-running server processes.
+`POST /internal/agent/run` — loopback-only, requires `Authorization: Bearer $INTERNAL_API_SECRET`.
 
-### 1) Install PM2
+```bash
+curl -sS -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $INTERNAL_API_SECRET" \
+  http://127.0.0.1:3000/internal/agent/run \
+  -d '{"text": "summarize the latest news", "platformKey": "cron:daily-brief"}'
+```
+
+Key body fields:
+
+| Field | Description |
+|-------|-------------|
+| `text` / `message` / `prompt` | User prompt (first non-empty wins) |
+| `skill` | Invoke a named skill (`[use skill](name)` shorthand) |
+| `platformKey` | Session namespace key (default: `internal:agent-run`) |
+| `forceNewSession` | Start a fresh session (default: `true`) |
+| `caller` | Caller identity for PTC tool filtering |
+| `callerSelectors` | Allowed caller tool names |
+| `notify.feishu` | `{ receiveId, receiveIdType }` — post result to Feishu |
+| `notify.discord` | `{ channelId, isThread }` — post result to Discord |
+
+Response includes `result`, `toolCalls`, `compactions`, and `notify` fields.
+
+## Custom Tools
+
+Registered in `src/core/engine-singleton.ts`:
+
+| Tool | Notes |
+|------|-------|
+| `cron_job` | Schedules recurring internal agent runs |
+| `twitter_list_tweets` | Fetches X/Twitter list via Nitter RSS with fallback instances |
+| `jina_ai_read` | Web page reader via Jina AI |
+| `session_summary` | Summarizes a stored session |
+| `deferred_demo` | `defer_loading: true` demo — discovered only via tool search |
+| `ptc_demo_*` | PTC `allowed_callers` demos |
+
+`defer_loading: true` tools are not sent to the LLM until the `tool_search_tool_bm25` tool discovers them.
+
+## PTC `allowed_callers`
+
+`allowed_callers` restricts which caller tool names can invoke a tool:
+
+- `ptc_demo_caller_only` — only callable by `ptc_demo_caller_probe`
+- `ptc_demo_cron_only` — only callable by `cron_job`
+- `ptc_demo_deferred_only` — only callable by `deferred_demo`
+
+```bash
+curl -sS -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $INTERNAL_API_SECRET" \
+  http://127.0.0.1:3000/internal/agent/run \
+  -d '{"text":"Call ptc_demo_caller_only with message=hello","caller":"ptc_demo_caller_probe","callerSelectors":["ptc_demo_caller_probe"]}'
+```
+
+## PM2 Deployment
 
 ```bash
 npm i -g pm2
+
+npm run pm2:start       # Build + start
+npm run pm2:restart     # Rebuild + restart
+npm run pm2:logs        # Stream logs
+npm run pm2:stop
+npm run pm2:delete
+npm run pm2:save        # Persist process list across reboots
+
+# Enable startup on reboot
+pm2 startup && pm2 save
 ```
 
-### 2) Start service (build + run)
-
-```bash
-npm run pm2:start
-```
-
-### 3) Daily operations
-
-```bash
-npm run pm2:logs      # view logs
-npm run pm2:restart   # rebuild + restart
-npm run pm2:stop      # stop process
-npm run pm2:delete    # remove process from pm2
-npm run pm2:save      # persist process list
-```
-
-### 4) Enable startup on reboot
-
-```bash
-pm2 startup
-pm2 save
-```
-
-> `ecosystem.config.cjs` is configured to run `dist/index.cjs` in fork mode with autorestart and memory guard.
+`ecosystem.config.cjs` runs `dist/index.cjs` in fork mode with autorestart and a memory guard.

--- a/packages/acp/README.md
+++ b/packages/acp/README.md
@@ -1,0 +1,71 @@
+# pulse-coder-acp
+
+Agent Context Protocol (ACP) client and runner for Pulse Coder hosts. Enables remote-server channels to delegate execution to external ACP-compatible agents (Claude Code, Codex) via JSON-RPC over stdio.
+
+## How It Works
+
+```
+Host (remote-server)
+  → AcpClient spawns agent CLI as child process
+  → JSON-RPC 2.0 over stdin/stdout
+  → initialize → session/new → session/prompt (streaming)
+  → SessionUpdate notifications → text deltas / tool calls
+```
+
+The `AcpClient` manages the child process lifecycle, and `runAcp` wraps the full session flow (init → new/resume → prompt → collect result) with retry and state persistence.
+
+## Supported Agents
+
+| Agent | Default command | Env override |
+|-------|----------------|-------------|
+| `claude` | `claude-agent-acp` | `ACP_CLAUDE_CODE_CMD` |
+| `codex` | `codex-acp` | `ACP_CODEX_CMD` |
+
+Install via `npm install -g @zed-industries/claude-agent-acp` or `@zed-industries/codex-acp`.
+
+## Exports
+
+| Export | Description |
+|--------|-------------|
+| `AcpClient` | Low-level JSON-RPC client — spawn, send requests/notifications, handle responses |
+| `runAcp(input)` | High-level runner — full session lifecycle with retry, state persistence, and streaming callbacks |
+| `FileAcpStateStore` | File-based state store at `~/.pulse-coder/acp-state.json` — tracks active agent/cwd/sessionId per channel |
+| `getAcpState` / `setAcpState` / `clearAcpState` | Convenience functions using the default `FileAcpStateStore` |
+
+## Usage
+
+```typescript
+import { runAcp } from 'pulse-coder-acp';
+
+const result = await runAcp({
+  platformKey: 'discord:user:123',
+  agent: 'claude',
+  cwd: '/path/to/project',
+  userText: 'Explain the auth module',
+  callbacks: {
+    onText: (delta) => process.stdout.write(delta),
+    onToolCall: (tc) => console.log('tool:', tc),
+  },
+});
+
+console.log(result.text);       // final response
+console.log(result.sessionId);  // persisted for /resume
+```
+
+## Configuration
+
+| Env var | Description |
+|---------|-------------|
+| `ACP_PERMISSION_MODE` | `allow` (default) or `prompt` — controls tool permission handling |
+| `ACP_DEBUG` | `1` to log all raw JSON-RPC messages |
+| `ACP_RETRY_MAX` | Max retries on transient failures (default: 2) |
+| `ACP_RETRY_BASE_DELAY_MS` | Retry backoff base (default: 750) |
+| `ACP_DISABLE_PROXY` | `1` to strip `HTTP_PROXY`/`HTTPS_PROXY` from child env |
+
+## Build & Test
+
+```bash
+pnpm --filter pulse-coder-acp build
+pnpm --filter pulse-coder-acp test
+pnpm --filter pulse-coder-acp typecheck
+```

--- a/packages/agent-teams/README.md
+++ b/packages/agent-teams/README.md
@@ -1,0 +1,183 @@
+# pulse-coder-agent-teams
+
+Multi-session collaborative agent coordination layer for Pulse Coder. Each teammate gets its own independent `Engine` instance (and thus its own context window, model, and toolset) while sharing a common task queue and mailbox.
+
+## Architecture
+
+```
+TeamLead
+ └── Team
+      ├── Mailbox         # inter-agent message passing
+      ├── TaskList        # shared task queue with dependency tracking
+      └── Teammate[]      # independent Engine instances
+```
+
+### Core Classes
+
+| Class | Description |
+|-------|-------------|
+| `Team` | Lifecycle manager — spawns teammates, owns the TaskList and Mailbox, drives the execution loop |
+| `TeamLead` | High-level orchestrator — adds LLM-driven planning, result synthesis, and follow-up flows |
+| `Teammate` | Wraps a single `Engine` instance; claims tasks, executes them, communicates via mailbox |
+| `TaskList` | Shared in-memory + file-backed task queue with dependency resolution and work-stealing guard |
+| `Mailbox` | Typed message bus (`message`, `broadcast`, `shutdown_request`, `plan_approval_request`, …) |
+
+State is persisted to `~/.pulse-coder/teams/<name>/` (configurable via `TeamConfig.stateDir`).
+
+## Installation
+
+```bash
+pnpm add pulse-coder-agent-teams
+```
+
+## Usage
+
+### Option A — Automated (`TeamLead.orchestrate`)
+
+The simplest path: give a goal string and `TeamLead` handles planning, spawning, execution, and synthesis.
+
+```typescript
+import { TeamLead } from 'pulse-coder-agent-teams';
+
+const lead = new TeamLead({
+  teamName: 'my-team',
+  cwd: '/path/to/project',
+});
+await lead.initialize();
+
+const { plan, results, synthesis } = await lead.orchestrate(
+  'Audit the codebase for security vulnerabilities and propose fixes',
+  {
+    // Optional: inspect and approve the plan before execution
+    onPlan: async (plan) => {
+      console.log('Plan:', plan);
+      return true; // return false to abort
+    },
+    timeoutMs: 20 * 60 * 1000, // 20 min
+    concurrency: 3,             // max teammates running at once
+  },
+);
+
+console.log(synthesis);
+await lead.team.cleanup();
+```
+
+`orchestrate` runs five phases internally:
+1. **Plan** — LLM decomposes the goal into teammates and tasks
+2. **Spawn** — creates one `Engine` per planned teammate
+3. **Create tasks** — populates the shared `TaskList` with dependency edges
+4. **Run** — teammates claim and execute tasks in parallel
+5. **Synthesize** — lead summarises all results into a final response
+
+### Option B — Manual (`Team` directly)
+
+Use `Team` directly when you want full control over teammates and tasks.
+
+```typescript
+import { Team } from 'pulse-coder-agent-teams';
+
+const team = new Team({ name: 'my-team', cwd: '/path/to/project' });
+
+// Spawn teammates (each gets its own Engine)
+await team.spawnTeammates([
+  { id: 'researcher', name: 'researcher', spawnPrompt: 'You are a researcher.' },
+  { id: 'writer',     name: 'writer',     spawnPrompt: 'You are a technical writer.' },
+]);
+
+// Create tasks with optional dependency edges
+await team.createTasks([
+  { title: 'Research topic', description: 'Investigate X thoroughly.' },
+  { title: 'Write summary',  description: 'Summarise findings.', deps: ['<research-task-id>'] },
+]);
+
+// Run — teammates claim tasks in parallel until all are done
+const { results, stats } = await team.run({ timeoutMs: 10 * 60 * 1000 });
+console.log(stats); // { total, completed, failed, skipped }
+
+await team.cleanup();
+```
+
+### Follow-up Turns
+
+After `orchestrate`, call `followUp` to add more work to the same team without re-spawning existing teammates.
+
+```typescript
+const { synthesis } = await lead.followUp(
+  'Now write integration tests for the fixes that were identified',
+);
+```
+
+## Task Model
+
+```typescript
+interface Task {
+  id: string;
+  title: string;
+  description: string;
+  status: 'pending' | 'in_progress' | 'completed' | 'failed';
+  deps: string[];       // IDs of tasks that must complete first
+  assignee: string | null;
+  createdBy: string;
+  result?: string;      // populated on completion
+}
+```
+
+Tasks without pending deps are immediately claimable. When a task completes its result is automatically injected as context into dependent tasks.
+
+## Teammate Tools
+
+Every teammate is automatically equipped with team-aware tools:
+
+| Tool | Description |
+|------|-------------|
+| `team_complete_task` | Mark the current task as done with a result summary |
+| `team_send_message` | Send a message to a specific teammate |
+| `team_notify_lead` | Send a message to the team lead |
+| `team_list_tasks` | List tasks filtered by status or assignee |
+| `team_get_messages` | Read unread mailbox messages |
+
+If a teammate finishes its `Engine.run()` without calling `team_complete_task`, the task is auto-completed with the run output.
+
+## Hooks
+
+```typescript
+const team = new Team(config, {
+  onTeammateIdle: async (id, name) => {
+    // Return a string to keep the teammate working, or undefined to let it stop
+    return undefined;
+  },
+  onTaskCreated: async (task) => {
+    // Return a string to block creation with feedback, or undefined to allow
+    return undefined;
+  },
+  onTaskCompleted: async (task) => {
+    // Return a string to reject the completion, or undefined to accept
+    return undefined;
+  },
+});
+```
+
+## Events
+
+Subscribe to team events with `team.on(handler)`:
+
+```typescript
+const off = team.on((event) => {
+  console.log(event.type, event.data);
+});
+// Later: off() to unsubscribe
+```
+
+Event types: `teammate:spawned`, `teammate:idle`, `teammate:stopped`, `teammate:status`, `teammate:output`, `teammate:run_start`, `teammate:run_end`, `task:created`, `task:claimed`, `task:completed`, `task:failed`, `message:sent`, `message:received`, `team:phase`, `team:started`, `team:completed`, `team:cleanup`.
+
+## Plan Approval
+
+Set `requirePlanApproval: true` on a `TeammateOptions` to put that teammate in plan mode. The teammate submits its plan via mailbox before executing; the lead (or a hook) sends a `plan_approval_response` to approve or reject with feedback.
+
+## Build & Test
+
+```bash
+pnpm --filter pulse-coder-agent-teams build
+pnpm --filter pulse-coder-agent-teams test
+pnpm --filter pulse-coder-agent-teams typecheck
+```

--- a/packages/canvas-cli/README.md
+++ b/packages/canvas-cli/README.md
@@ -1,0 +1,116 @@
+# @pulse-coder/canvas-cli
+
+CLI for Pulse Canvas — lets external agents (Claude Code, Codex, etc.) read from and write to canvas workspaces without the Electron app being involved.
+
+The CLI operates directly on the JSON store at `~/.pulse-coder/canvas/` (default). When the Electron app is running, its `fs.watch` picks up changes automatically — no IPC required.
+
+## Install
+
+```bash
+# From the monorepo
+pnpm --filter @pulse-coder/canvas-cli build
+
+# Or link globally
+cd packages/canvas-cli && npm link
+```
+
+Binary name: `pulse-canvas`.
+
+## Global Options
+
+| Flag | Description |
+|------|-------------|
+| `--format <json\|text>` | Output format (default: `text`) |
+| `--store-dir <path>` | Canvas store directory (default: `~/.pulse-coder/canvas/`) |
+| `-w, --workspace <id>` | Workspace ID (default: `$PULSE_CANVAS_WORKSPACE_ID`) |
+
+The Electron app sets `PULSE_CANVAS_WORKSPACE_ID` for agent nodes automatically, so most commands need no explicit workspace flag.
+
+## Commands
+
+### Workspace
+
+```bash
+pulse-canvas workspace list                     # List all workspaces
+pulse-canvas workspace info <id>                # Node counts, types, last saved
+pulse-canvas workspace create <name>            # Create a new workspace
+pulse-canvas workspace delete <id> --confirm    # Delete (irreversible)
+pulse-canvas workspace recover <id>             # Rebuild file nodes from notes/*.md files
+pulse-canvas workspace recover <id> --dry-run   # Preview without writing
+```
+
+### Node
+
+All `node` commands require a workspace (via `-w` or `$PULSE_CANVAS_WORKSPACE_ID`).
+
+```bash
+pulse-canvas node list                          # List nodes with types and capabilities
+pulse-canvas node read <nodeId>                 # Read node content
+pulse-canvas node create --type file --title "Report" --data '{"content":"..."}'
+pulse-canvas node write <nodeId> --content "..."        # interprets \n, \t escapes
+pulse-canvas node write <nodeId> --content "..." --raw  # verbatim, no unescaping
+pulse-canvas node write <nodeId> --file ./result.md     # read content from file
+echo "hello" | pulse-canvas node write <nodeId>         # read from stdin
+pulse-canvas node delete <nodeId>
+```
+
+Node types and capabilities:
+
+| Type | Capabilities | Notes |
+|------|-------------|-------|
+| `file` | read, write | Backed by a real file; content is markdown |
+| `terminal` | read, exec | PTY session (read-only from CLI — no active PTY) |
+| `frame` | read | Visual grouping rectangle with label/color |
+| `agent` | read, exec | Agent PTY node (read-only from CLI) |
+
+### Context
+
+```bash
+pulse-canvas context                # Structured summary of all nodes in the workspace
+pulse-canvas context --format json  # Machine-readable for agent consumption
+```
+
+Returns workspace metadata plus a per-node summary: file paths, frame labels, terminal cwds, agent statuses. This is the recommended entry point for agents — run it first to understand the canvas layout.
+
+### Install Skills
+
+```bash
+pulse-canvas install-skills               # Install to all global skill dirs
+pulse-canvas install-skills --dir <path>  # Install to a specific directory
+```
+
+Copies bundled `SKILL.md` files (`canvas`, `canvas-bootstrap`) into global skill directories so that agents (Claude Code, Codex, etc.) discover canvas capabilities automatically. Target directories:
+
+- `~/.pulse-coder/skills/`
+- `~/.claude/skills/`
+- `~/.codex/skills/`
+
+## Programmatic API
+
+The `core` subpath export provides store and node operations without the CLI layer:
+
+```typescript
+import {
+  loadCanvas,
+  saveCanvas,
+  listWorkspaceIds,
+  createWorkspace,
+} from '@pulse-coder/canvas-cli/core';
+```
+
+## Agent Integration Flow
+
+1. Agent spawns inside a canvas agent node → `$PULSE_CANVAS_WORKSPACE_ID` is set
+2. Agent runs `pulse-canvas context --format json` to discover canvas layout
+3. Agent reads relevant file nodes with `pulse-canvas node read <id>`
+4. Agent does its work (code changes, research, etc.)
+5. Agent writes results back with `pulse-canvas node write <id> --content "..."`
+6. Electron main detects the canvas.json change via `fs.watch` and refreshes the UI
+
+## Build & Test
+
+```bash
+pnpm --filter @pulse-coder/canvas-cli build      # tsup + copy skills/
+pnpm --filter @pulse-coder/canvas-cli test
+pnpm --filter @pulse-coder/canvas-cli typecheck
+```

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -1,0 +1,131 @@
+# pulse-coder-engine
+
+Core runtime for Pulse Coder — provides the agent execution loop, tool system, plugin manager, and built-in plugins. This is the foundational package that all other packages and apps depend on.
+
+## Architecture
+
+```
+Engine
+ ├── PluginManager        # dual-track: engine plugins + user config plugins
+ │    ├── Built-in plugins (MCP, skills, plan-mode, tasks, sub-agent, …)
+ │    └── User plugins     (.pulse-coder/engine-plugins/)
+ ├── Tools                 # read, write, edit, grep, ls, bash, tavily, gemini, clarify
+ ├── Loop                  # core agent loop (streamText → tool exec → retry → compact)
+ ├── AI adapter            # Vercel AI SDK wrapper (OpenAI / Anthropic)
+ └── Context compaction    # summary-based token management
+```
+
+### Execution Loop (`src/core/loop.ts`)
+
+Each `Engine.run()` call enters a loop that:
+1. Fires `beforeRun` hooks (plugins can mutate system prompt and tools)
+2. Calls `streamText` via the AI adapter
+3. Executes tool calls with `beforeToolCall` / `afterToolCall` hooks
+4. Checks token usage and triggers compaction when needed
+5. Retries on recoverable errors (up to `MAX_ERROR_COUNT`)
+6. Fires `afterRun` hooks on completion
+
+### Plugin System
+
+Dual-track architecture:
+- **Engine plugins** (`EnginePlugin` interface) — code-level extensions that register tools, hooks, and services.
+- **User config plugins** — declarative JSON/YAML configs for tools, prompts, MCP servers, and sub-agents.
+
+Plugins interact with the engine through `EnginePluginContext`:
+- `registerTool(name, tool)` / `registerTools(map)`
+- `registerHook(hookName, handler)` — all hooks from `EngineHookMap`
+- `registerService(name, service)` / `getService(name)`
+- `getConfig(key)` / `setConfig(key, val)`
+- `events` (EventEmitter), `logger`
+
+### Built-in Plugins
+
+Registered automatically from `src/built-in/index.ts`:
+
+| Plugin | Description |
+|--------|-------------|
+| MCP | Connects to MCP servers from `.pulse-coder/mcp.json` |
+| Skills | Scans `SKILL.md` files and registers the `skill` tool |
+| Plan mode | Adds `plan` / `act` mode switching with tool filtering |
+| Task tracking | Shared task list with `task_create`, `task_get`, `task_list`, `task_update` tools |
+| Sub-agent | Loads agent definitions from `.pulse-coder/agents/*.md` |
+| Tool search | BM25-based deferred tool discovery (`tool_search_tool_bm25`) |
+| Role/Soul | Injects persona prompts from `.pulse-coder/agents/` |
+| Agent teams | Multi-agent coordination via `pulse-coder-orchestrator` |
+| PTC | PTC workflow integration with `allowed_callers` filtering |
+
+### Built-in Tools
+
+| Tool | Description |
+|------|-------------|
+| `read` | Read file contents |
+| `write` | Write/create files |
+| `edit` | String-replacement file editing |
+| `grep` | Regex search via ripgrep-style |
+| `ls` | Directory listing |
+| `bash` | Shell command execution |
+| `tavily` | Web search + extract + crawl + map |
+| `gemini_pro_image` | Image generation via Gemini Pro |
+| `clarify` | Request clarification from the user |
+
+## Usage
+
+```typescript
+import { Engine } from 'pulse-coder-engine';
+
+const engine = new Engine({
+  model: 'gpt-4o',
+  systemPrompt: { append: 'Always respond in English.' },
+  tools: { myCustomTool },
+});
+
+await engine.initialize();
+
+const result = await engine.run(
+  { messages: [{ role: 'user', content: 'Explain the auth module' }] },
+  {
+    onText: (delta) => process.stdout.write(delta),
+    onToolCall: (tc) => console.log('tool:', tc.toolName),
+  },
+);
+```
+
+### LLM Provider
+
+Default provider is built from env vars. Override per-engine or per-run:
+
+```typescript
+// Via named type (uses env vars)
+new Engine({ modelType: 'claude', model: 'claude-sonnet-4-20250514' });
+
+// Via custom factory
+import { createOpenAI } from '@ai-sdk/openai';
+new Engine({ llmProvider: createOpenAI({ apiKey: '...' }).responses });
+```
+
+## Configuration
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `OPENAI_API_KEY` / `OPENAI_API_URL` | — | OpenAI credentials |
+| `USE_ANTHROPIC` | — | Set to use Anthropic as default provider |
+| `ANTHROPIC_API_KEY` / `ANTHROPIC_API_URL` | — | Anthropic credentials |
+| `OPENAI_MODEL` / `ANTHROPIC_MODEL` | `novita/deepseek/deepseek_v3` | Default model |
+| `CONTEXT_WINDOW_TOKENS` | 64000 | Token budget for compaction |
+| `COMPACT_TRIGGER` | 75% of window | Compaction trigger threshold |
+| `COMPACT_TARGET` | 50% of window | Target after compaction |
+| `KEEP_LAST_TURNS` | 4 | Recent turns preserved during compaction |
+| `COMPACT_SUMMARY_MODEL` | (main model) | Dedicated model for summaries |
+| `MAX_COMPACTION_ATTEMPTS` | 2 | Retry limit for compaction |
+| `CLARIFICATION_ENABLED` | true | Enable the `clarify` tool |
+| `CLARIFICATION_TIMEOUT` | 300000 | Clarification wait timeout (ms) |
+| `TAVILY_API_KEY` | — | Enable Tavily web search tools |
+| `GEMINI_API_KEY` | — | Enable Gemini image tool |
+
+## Build & Test
+
+```bash
+pnpm --filter pulse-coder-engine build
+pnpm --filter pulse-coder-engine test
+pnpm --filter pulse-coder-engine typecheck
+```

--- a/packages/memory-plugin/README.md
+++ b/packages/memory-plugin/README.md
@@ -1,0 +1,116 @@
+# pulse-coder-memory-plugin
+
+Host-side memory service for Pulse Coder runtimes. Provides persistent, scoped memory with semantic recall, daily logging, and automatic injection into agent context.
+
+## Architecture
+
+```
+FileMemoryPluginService
+ ├── Layered state store    # user/ soul/ daily/ subdirs per platformKey
+ ├── Embedding providers    # hash (local) or OpenAI (API)
+ ├── SQLite vector store    # semantic recall via cosine similarity
+ ├── Daily log processor    # auto-extraction + quota + quality gates
+ └── Engine plugin hooks    # beforeRun injection + afterRun logging
+```
+
+### Memory Scopes
+
+| Scope | Purpose | Surfacing |
+|-------|---------|-----------|
+| `user` | Persistent preferences, rules, facts (profile) | Auto-injected into system prompt every run |
+| `soul` | Personality traits and character notes | Private — only surfaced when explicitly queried |
+| `session` | Session-specific decisions, fixes, daily logs | Recalled by semantic similarity to current query |
+
+### Storage Layout
+
+```
+~/.pulse-coder/memory-plugin/{platformKey}/
+  user/memories.json       # persistent user memories
+  soul/memories.json       # soul/personality memories
+  daily/YYYY-MM-DD.json    # daily log entries
+```
+
+### Recall Strategy
+
+Hybrid scoring combines:
+- **Vector similarity** (65%) — cosine distance via SQLite vector store
+- **Keyword matching** (35%) — term overlap scoring
+- **Recency bonus** — recent memories rank higher
+- **Quality weight** — confidence and specificity factors
+
+Fallback to recency-only when no query signals are available.
+
+## Memory Tools
+
+The engine plugin registers these tools:
+
+| Tool | Description |
+|------|-------------|
+| `memory_recall` | Query memories by topic/keyword with hybrid scoring |
+| `memory_record` | Store a new memory (type: preference, rule, decision, fix, fact) |
+| `memory_get_daily_log_by_day` | Retrieve daily log entries for a specific date |
+
+## Embedding Strategies
+
+| Strategy | Env var | Description |
+|----------|---------|-------------|
+| `hash` (default) | `MEMORY_EMBEDDING_STRATEGY=hash` | Local content-addressable hashing with synonym expansion and n-grams. Zero API calls. |
+| `openai` | `MEMORY_EMBEDDING_STRATEGY=openai` | OpenAI-compatible embedding API. Requires `MEMORY_EMBEDDING_API_KEY`. |
+
+## Configuration
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `MEMORY_SEMANTIC_RECALL_ENABLED` | `true` | Enable vector-based semantic recall |
+| `MEMORY_EMBEDDING_STRATEGY` | `hash` | `hash` or `openai` |
+| `MEMORY_EMBEDDING_DIMENSIONS` | 256 (hash) / 1536 (openai) | Embedding vector dimensions |
+| `MEMORY_EMBEDDING_MODEL` | `text-embedding-3-small` | Model for openai strategy |
+| `MEMORY_EMBEDDING_API_KEY` | (falls back to `OPENAI_API_KEY`) | Dedicated embedding API key |
+| `MEMORY_EMBEDDING_API_URL` | (falls back to `OPENAI_API_URL`) | Dedicated embedding endpoint |
+| `MEMORY_EMBEDDING_TIMEOUT_MS` | 15000 | Embedding API timeout |
+
+## Usage
+
+```typescript
+import { FileMemoryPluginService } from 'pulse-coder-memory-plugin';
+
+const memory = new FileMemoryPluginService({
+  baseDir: '~/.pulse-coder/remote-memory',
+});
+await memory.initialize();
+
+// Record a memory
+await memory.record('user:123', {
+  type: 'preference',
+  scope: 'user',
+  content: 'User prefers TypeScript with strict mode',
+});
+
+// Recall by query
+const results = await memory.recall('user:123', {
+  query: 'coding preferences',
+  limit: 5,
+});
+```
+
+### Engine Integration
+
+The plugin auto-injects user memories into the system prompt via `beforeRun` hook, and can auto-extract daily log entries from conversation turns via `afterRun`.
+
+```typescript
+import { createMemoryEnginePlugin } from 'pulse-coder-memory-plugin';
+
+const engine = new Engine({
+  enginePlugins: {
+    plugins: [createMemoryEnginePlugin({ baseDir })],
+  },
+});
+```
+
+## Build & Test
+
+```bash
+pnpm --filter pulse-coder-memory-plugin build
+pnpm --filter pulse-coder-memory-plugin test
+pnpm --filter pulse-coder-memory-plugin typecheck
+```

--- a/packages/orchestrator/README.md
+++ b/packages/orchestrator/README.md
@@ -1,0 +1,105 @@
+# pulse-coder-orchestrator
+
+Multi-agent orchestration layer for Pulse Coder. Builds a dependency-aware **TaskGraph**, schedules nodes across agents in parallel, and aggregates results. This package has **zero engine dependency** — it defines an `AgentRunner` interface so any execution backend can be plugged in.
+
+## Architecture
+
+```
+Orchestrator.run(input)
+ ├── 1. Route roles    → auto (keyword) / all / plan (LLM)
+ ├── 2. Build graph    → static template or LLM-planned TaskGraph
+ ├── 3. Validate       → check IDs, deps, cycles
+ ├── 4. Schedule       → run nodes in parallel respecting deps + concurrency
+ └── 5. Aggregate      → concat / last / llm
+```
+
+### Pipeline
+
+| Step | Module | Description |
+|------|--------|-------------|
+| Route | `router.ts` | Keyword-based role selection from task text |
+| Plan | `planner.ts` | LLM-generated TaskGraph with per-node sub-task descriptions |
+| Graph | `graph.ts` | Static graph builder (researcher → executor → reviewer/writer/tester) |
+| Schedule | `scheduler.ts` | Concurrent DAG executor with retry, timeout, and optional-node skipping |
+| Aggregate | `aggregator.ts` | Merge results via concatenation, last-success, or LLM synthesis |
+
+### Built-in Roles
+
+`researcher`, `executor`, `reviewer`, `writer`, `tester` — plus any custom `string` role.
+
+### Routing Strategies
+
+| `route` | Behavior |
+|---------|----------|
+| `'auto'` | Keyword matching — always includes researcher + executor; adds reviewer/writer/tester if task text matches patterns |
+| `'all'` | Every registered role participates |
+| `'plan'` (default) | LLM dynamically builds the TaskGraph from available roles |
+
+## Usage
+
+```typescript
+import { Orchestrator } from 'pulse-coder-orchestrator';
+
+const orchestrator = new Orchestrator({
+  runner: myAgentRunner,       // implements AgentRunner interface
+  llmCall: myLlmCallFn,       // required for route='plan' and aggregate='llm'
+});
+
+const result = await orchestrator.run({
+  task: 'Review the auth module for security issues',
+  route: 'auto',
+  maxConcurrency: 3,
+  retries: 1,
+  aggregate: 'concat',
+});
+
+console.log(result.aggregate);  // merged output from all agents
+console.log(result.results);    // per-node NodeResult map
+```
+
+### AgentRunner Interface
+
+```typescript
+interface AgentRunner {
+  run(input: { agentName: string; task: string; context?: Record<string, any> }): Promise<string>;
+  getAvailableAgents(): string[];
+}
+```
+
+The included `EngineAgentRunner` adapter bridges engine tools to this interface:
+
+```typescript
+import { EngineAgentRunner } from 'pulse-coder-orchestrator';
+
+const runner = new EngineAgentRunner(() => engine.getTools());
+```
+
+### TaskGraph
+
+```typescript
+interface TaskGraph {
+  nodes: TaskNode[];
+}
+
+interface TaskNode {
+  id: string;
+  role: TeamRole;
+  deps: string[];          // node IDs that must complete first
+  input?: string;          // sub-task description
+  optional?: boolean;      // failure doesn't block dependents
+  agent?: string;          // override agent name (default: roleAgents mapping)
+  instruction?: string;    // prepended to the task prompt
+}
+```
+
+### ArtifactStore
+
+Results are optionally persisted via `ArtifactStore`. The default `LocalArtifactStore` writes to `.pulse-coder/agent-teams/{runId}/{nodeId}.md`.
+
+## Build & Test
+
+```bash
+pnpm --filter pulse-coder-orchestrator build
+pnpm --filter pulse-coder-orchestrator test
+pnpm --filter pulse-coder-orchestrator typecheck
+```

--- a/packages/plugin-kit/README.md
+++ b/packages/plugin-kit/README.md
@@ -1,0 +1,82 @@
+# pulse-coder-plugin-kit
+
+Shared toolkit for building Engine plugins. Provides three subsystems — **Worktree**, **Vault**, and **Devtools** — each with a file-backed service, an engine plugin factory, and `AsyncLocalStorage`-based per-run context management.
+
+## Subpath Exports
+
+```typescript
+import { ... } from 'pulse-coder-plugin-kit';            // everything
+import { ... } from 'pulse-coder-plugin-kit/worktree';   // worktree only
+import { ... } from 'pulse-coder-plugin-kit/vault';      // vault only
+import { ... } from 'pulse-coder-plugin-kit/devtools';   // devtools only
+```
+
+## Worktree
+
+Manages git worktree bindings so that multi-tenant sessions (e.g. Discord channels) each resolve to their own worktree directory.
+
+### Key exports
+
+| Export | Description |
+|--------|-------------|
+| `FileWorktreePluginService` | File-backed state at `~/.pulse-coder/worktree-state/` — CRUD for worktrees and scope→worktree bindings |
+| `createWorktreeIntegration(options)` | Factory that returns `{ service, initialize(), buildRunContext(scope) }` |
+| `createWorktreeEnginePlugin(integration)` | Returns an `EnginePlugin` that injects worktree cwd into the system prompt via `beforeRun` hook |
+
+### Data model
+
+- **WorktreeRecord** — `{ id, repoRoot, worktreePath, branch? }`
+- **WorktreeBindingRecord** — `{ runtimeKey, scopeKey } → worktreeId`
+- Scope = `{ runtimeKey, scopeKey }` — e.g. `{ runtimeKey: 'discord', scopeKey: 'channel:123' }`
+
+## Vault
+
+Manages isolated workspace directories for per-project or per-tenant state (config files, artifacts, logs).
+
+### Key exports
+
+| Export | Description |
+|--------|-------------|
+| `FileVaultPluginService` | File-backed state at `~/.pulse-coder/vault-state/` — ensures vault dirs with standard subdirectories (`config/`, `state/`, `artifacts/`, `logs/`) |
+| `createVaultIntegration(options)` | Factory with `{ service, initialize(), resolveVault(input) }` |
+| `createVaultEnginePlugin(integration)` | Returns an `EnginePlugin` that injects vault path into system prompt and optionally registers a `vault_inspect` tool |
+
+### Data model
+
+- **VaultRecord** — `{ id, key, attributes? }`
+- **VaultContext** — extends VaultRecord with resolved paths: `root`, `configPath`, `statePath`, `artifactsPath`, `logsPath`
+
+## Devtools
+
+Records detailed telemetry for debugging and analytics. Tracks LLM calls, tool executions, compaction events, and more.
+
+### Key exports
+
+| Export | Description |
+|--------|-------------|
+| `DevtoolsStore` | In-memory + file-backed store for run spans and events |
+| `createDevtoolsIntegration(options)` | Factory that returns an engine plugin hooking into `afterLLMCall`, `afterToolCall`, `onCompacted`, `beforeRun`, `afterRun` |
+
+### Tracked data
+
+- **Run spans** — start/end, status, tool calls, LLM calls, compaction events
+- **LLM call spans** — model, finish reason, token usage, timing (request start → first chunk → first text → last chunk)
+- **Tool call spans** — name, input, output, duration
+- **Compaction events** — before/after message counts, token estimates, strategy used
+
+## Shared Patterns
+
+All three subsystems follow the same structure:
+1. **Service** — `File*PluginService` with atomic JSON persistence
+2. **Integration** — factory function returning `{ service, initialize(), ... }` plus `AsyncLocalStorage`-based per-run context
+3. **Engine plugin** — registers `beforeRun` hooks for system prompt injection and optional tools
+
+## Build & Test
+
+```bash
+pnpm --filter pulse-coder-plugin-kit build
+pnpm --filter pulse-coder-plugin-kit test
+pnpm --filter pulse-coder-plugin-kit typecheck
+```
+
+Note: the build uses a two-step process (`tsup` for JS + separate `tsc` for declarations). Set `SKIP_DTS=1` to skip declaration generation.

--- a/packages/pulse-sandbox/README.md
+++ b/packages/pulse-sandbox/README.md
@@ -1,0 +1,97 @@
+# pulse-sandbox
+
+Sandboxed JavaScript runtime for Pulse Coder. Executes user-provided JS code in an isolated Node.js `vm` context with strict resource limits. Used by the CLI's `run_js` tool.
+
+## How It Works
+
+```
+createJsExecutor()
+  → spawns child process (runner.ts)
+  → runner creates vm.Context with restricted globals
+  → wraps code in 'use strict' async IIFE
+  → executes with timeout + memory limit
+  → returns { ok, result, stdout, stderr, durationMs }
+```
+
+### Sandbox Restrictions
+
+The VM context **disables**:
+- `require`, `module`, `__filename`, `__dirname`
+- `process`, `Buffer`, `global`, `globalThis`
+- `fetch`, `WebSocket`, `XMLHttpRequest`
+- `setTimeout`, `setInterval` (and their clear counterparts)
+- File system and network access
+
+The VM context **provides**:
+- `console` (log/error/warn/info/debug — captured to stdout/stderr buffers)
+- `JSON`, `Math`, `Date`, `Array`, `Object`, `Map`, `Set`, `Promise`, `RegExp`, etc.
+- `input` — the optional input value passed via `JsExecutionRequest`
+
+### Resource Limits
+
+| Limit | Default | Description |
+|-------|---------|-------------|
+| `timeoutMs` | 2000 | Max execution time before SIGKILL |
+| `memoryLimitMb` | 64 | V8 heap limit for child process |
+| `maxOutputChars` | 20000 | Combined stdout+stderr truncation |
+| `maxCodeLength` | 20000 | Max input code length |
+
+## Exports
+
+| Export | Description |
+|--------|-------------|
+| `createJsExecutor(options?)` | Creates a `JsExecutor` that spawns isolated child processes |
+| `createRunJsTool(options)` | Creates a Zod-validated engine tool wrapping the executor |
+
+## Usage
+
+### As an engine tool
+
+```typescript
+import { createJsExecutor, createRunJsTool } from 'pulse-sandbox';
+
+const executor = createJsExecutor({ timeoutMs: 5000 });
+const tool = createRunJsTool({ executor });
+
+// Register with engine
+const engine = new Engine({ tools: { run_js: tool } });
+```
+
+### Standalone
+
+```typescript
+import { createJsExecutor } from 'pulse-sandbox';
+
+const executor = createJsExecutor();
+
+const result = await executor.execute({
+  code: `
+    const sum = input.numbers.reduce((a, b) => a + b, 0);
+    console.log('Sum:', sum);
+    return { sum };
+  `,
+  input: { numbers: [1, 2, 3, 4, 5] },
+});
+
+// result.ok === true
+// result.stdout === 'Sum: 15\n'
+// result.result === { sum: 15 }
+```
+
+### Error Codes
+
+| Code | Trigger |
+|------|---------|
+| `TIMEOUT` | Execution exceeded `timeoutMs` |
+| `OOM` | Child process exceeded `memoryLimitMb` |
+| `RUNTIME_ERROR` | Uncaught exception in user code |
+| `POLICY_BLOCKED` | Invalid input (empty code, zero timeout, code too long) |
+| `INTERNAL` | Unexpected executor failure |
+
+## Build & Test
+
+```bash
+pnpm --filter pulse-sandbox build
+pnpm --filter pulse-sandbox test
+pnpm --filter pulse-sandbox typecheck
+```


### PR DESCRIPTION
## Summary
- Improve root `CLAUDE.md` with plugin authoring guide, hook map details, orchestrator routing strategies, and env var documentation
- Rewrite `apps/remote-server/README.md` with full endpoints table, 20+ slash commands, Feishu/Discord setup, internal API docs, and PM2 deployment
- Add `apps/canvas-workspace/README.md` covering Electron desktop app (tech stack, node types, shortcuts, canvas agent)
- Add READMEs for all 8 packages: `engine`, `acp`, `agent-teams`, `canvas-cli`, `memory-plugin`, `orchestrator`, `plugin-kit`, `pulse-sandbox`

**11 files changed, +1213 / -131 lines — all documentation, zero code changes.**

## Test plan
- [x] All files are markdown documentation only, no code changes
- [ ] Verify README links and code examples are accurate
- [ ] Confirm no sensitive information is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)