### PR TITLE
fix(canvas-workspace): stop hover from showing note toolbar; align task list checkboxes

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.css
@@ -19,7 +19,6 @@
   transition: height 0.15s ease, padding 0.15s ease, border-color 0.15s ease;
 }
 
-.canvas-node:hover .note-file-hint,
 .canvas-node--selected .note-file-hint {
   height: 22px;
   padding: 2px 10px 3px;
@@ -110,22 +109,33 @@
 
 .note-tiptap-editor .ProseMirror ul[data-type="taskList"] li {
   display: flex;
-  align-items: baseline;
+  align-items: flex-start;
   gap: 6px;
+  margin: 0.15em 0;
 }
 
 .note-tiptap-editor .ProseMirror ul[data-type="taskList"] li > label {
   flex-shrink: 0;
-  margin-top: 2px;
+  display: inline-flex;
+  align-items: center;
+  /* match first-line height so the checkbox vertically centers with the text */
+  height: calc(14px * 1.8);
+  margin: 0;
 }
 
 .note-tiptap-editor .ProseMirror ul[data-type="taskList"] li > label input[type="checkbox"] {
   accent-color: var(--accent);
   cursor: pointer;
+  margin: 0;
 }
 
 .note-tiptap-editor .ProseMirror ul[data-type="taskList"] li > div {
   flex: 1;
+  min-width: 0;
+}
+
+.note-tiptap-editor .ProseMirror ul[data-type="taskList"] li > div > p {
+  margin: 0;
 }
 
 .note-tiptap-editor .ProseMirror blockquote {

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeToolbar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeToolbar/index.css
@@ -11,7 +11,6 @@
   transition: height 0.15s ease, padding 0.15s ease, border-color 0.15s ease;
 }
 
-.canvas-node:hover .note-toolbar,
 .canvas-node--selected .note-toolbar {
   height: 30px;
   padding: 3px 6px;


### PR DESCRIPTION
stop hover from showing note toolbar; align task list checkboxes

- Only reveal the FileNode toolbar and filename hint when the node is selected. Hover alone was too sensitive and triggered the dropdown unintentionally.
- Replace baseline alignment on task list items with flex-start plus a fixed label height equal to the text line-height so the checkbox is visually centered on the first line. Zero out paragraph margin inside task items so nested items line up with their checkbox.

https://claude.ai/code/session_01YBTvLaHsuVH6jAy4kvY7uX