### PR TITLE
Refactor frame hierarchy logic and improve layer tree structure

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
@@ -12,6 +12,9 @@ interface CanvasSurfaceProps {
   canvasId: string;
   canvasName?: string;
   draggingId: string | null;
+  /** Every node participating in the current drag — includes descendants of a
+   *  dragged frame so the full group can share the lifted stacking context. */
+  draggingIds: Set<string>;
   resizingId: string | null;
   selectedNodeIds: string[];
   highlightedId: string | null;
@@ -33,6 +36,7 @@ export const CanvasSurface = ({
   canvasId,
   canvasName,
   draggingId,
+  draggingIds,
   resizingId,
   selectedNodeIds,
   highlightedId,
@@ -62,7 +66,7 @@ export const CanvasSurface = ({
         rootFolder={rootFolder}
         workspaceId={canvasId}
         workspaceName={canvasName}
-        isDragging={draggingId === node.id}
+        isDragging={draggingIds.has(node.id) || draggingId === node.id}
         isResizing={resizingId === node.id}
         isSelected={selectedNodeIds.includes(node.id)}
         isHighlighted={highlightedId === node.id}

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -137,7 +137,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
     handleFocusNode(node);
   }, [handleFocusNode]);
 
-  const { draggingId, onDragStart, onDragMove, onDragEnd } = useNodeDrag(
+  const { draggingId, draggingIds, onDragStart, onDragMove, onDragEnd } = useNodeDrag(
     moveNode, moveNodes, transform.scale, nodes
   );
   const { resizingId, onResizeStart, onResizeMove, onResizeEnd } =
@@ -273,6 +273,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
         canvasId={canvasId}
         canvasName={canvasName}
         draggingId={draggingId}
+        draggingIds={draggingIds}
         resizingId={resizingId}
         selectedNodeIds={selectedNodeIds}
         highlightedId={highlightedId}

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -8,6 +8,7 @@ import { useCanvasContext } from '../../hooks/useCanvasContext';
 import { useCanvasFit } from '../../hooks/useCanvasFit';
 import { useCanvasKeyboard } from '../../hooks/useCanvasKeyboard';
 import type { CanvasNode } from '../../types';
+import { computeFrameDepths } from '../../utils/frameHierarchy';
 import { CanvasSurface } from './CanvasSurface';
 import { CanvasOverlays } from './CanvasOverlays';
 
@@ -216,11 +217,20 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
   }, [canvasMouseUp, onDragEnd, onResizeEnd, commitHistory]);
 
   const sortedNodes = useMemo(
-    () => [...nodes].sort((a, b) => {
-      if (a.type === 'frame' && b.type !== 'frame') return -1;
-      if (a.type !== 'frame' && b.type === 'frame') return 1;
-      return 0;
-    }),
+    () => {
+      const depths = computeFrameDepths(nodes);
+      return [...nodes].sort((a, b) => {
+        // Non-frames always render in front of frames.
+        if (a.type === 'frame' && b.type !== 'frame') return -1;
+        if (a.type !== 'frame' && b.type === 'frame') return 1;
+        // Among frames, shallower frames render first (i.e. behind deeper
+        // frames), so a nested child frame paints on top of its parent.
+        if (a.type === 'frame' && b.type === 'frame') {
+          return (depths.get(a.id) ?? 0) - (depths.get(b.id) ?? 0);
+        }
+        return 0;
+      });
+    },
     [nodes]
   );
 

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/LayerItem.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/LayerItem.tsx
@@ -1,26 +1,25 @@
 import type { MouseEvent as ReactMouseEvent } from 'react';
-import type { CanvasNode } from '../../types';
+import type { LayerTreeNode } from './utils/layers';
 import { ChevronRightIcon, NodeTypeIcon } from '../icons';
 
 interface LayerItemProps {
-  node: CanvasNode;
-  children: CanvasNode[];
-  isCollapsed: boolean;
+  tree: LayerTreeNode;
+  collapsedLayers: Set<string>;
   onFocus: (nodeId: string) => void;
   onContextMenu: (e: ReactMouseEvent, nodeId: string) => void;
   onToggleCollapse: (id: string) => void;
 }
 
 export const LayerItem = ({
-  node,
-  children,
-  isCollapsed,
+  tree,
+  collapsedLayers,
   onFocus,
   onContextMenu,
   onToggleCollapse,
 }: LayerItemProps) => {
+  const { node, children } = tree;
   const isFrame = node.type === 'frame';
-  const isOpen = isFrame && !isCollapsed;
+  const isOpen = isFrame && !collapsedLayers.has(node.id);
 
   return (
     <div className="sidebar-layer-group">
@@ -60,18 +59,14 @@ export const LayerItem = ({
         >
           <div className="sidebar-layer-children-inner">
             {children.map((child) => (
-              <button
-                key={child.id}
-                className="sidebar-layer-item"
-                onClick={() => onFocus(child.id)}
-                onContextMenu={(e) => onContextMenu(e, child.id)}
-                title={child.title}
-              >
-                <span className="sidebar-layer-icon">
-                  <NodeTypeIcon type={child.type} />
-                </span>
-                <span className="sidebar-layer-name">{child.title}</span>
-              </button>
+              <LayerItem
+                key={child.node.id}
+                tree={child}
+                collapsedLayers={collapsedLayers}
+                onFocus={onFocus}
+                onContextMenu={onContextMenu}
+                onToggleCollapse={onToggleCollapse}
+              />
             ))}
           </div>
         </div>

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/LayersPanel.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/LayersPanel.tsx
@@ -1,5 +1,4 @@
 import type { MouseEvent as ReactMouseEvent } from 'react';
-import type { CanvasNode } from '../../types';
 import type { LayerTreeNode } from './utils/layers';
 import { LayerItem } from './LayerItem';
 
@@ -64,12 +63,11 @@ export const LayersPanel = ({
       </div>
     </div>
     <div className="sidebar-layers-scroll">
-      {layerTree.map(({ node, children }) => (
+      {layerTree.map((tree) => (
         <LayerItem
-          key={node.id}
-          node={node}
-          children={children}
-          isCollapsed={collapsedLayers.has(node.id)}
+          key={tree.node.id}
+          tree={tree}
+          collapsedLayers={collapsedLayers}
           onFocus={onNodeFocus}
           onContextMenu={onContextMenu}
           onToggleCollapse={onToggleCollapse}

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState, useCallback, type DragEvent, type
 import type { WorkspaceEntry, FolderEntry } from '../../hooks/useWorkspaces';
 import type { CanvasNode } from '../../types';
 import './index.css';
-import { buildLayerTree } from './utils/layers';
+import { buildLayerTree, collectFrameIds } from './utils/layers';
 import { SidebarHeader, SidebarToggleIcon } from './SidebarHeader';
 import { WorkspaceItem } from './WorkspaceItem';
 import { WorkspaceList } from './WorkspaceList';
@@ -55,7 +55,7 @@ export const Sidebar = ({
   const [layerContextMenu, setLayerContextMenu] = useState<{ x: number; y: number; nodeId: string } | null>(null);
 
   const layerTree = useMemo(() => buildLayerTree(activeNodes), [activeNodes]);
-  const frameIds = useMemo(() => layerTree.filter((n) => n.node.type === 'frame').map((n) => n.node.id), [layerTree]);
+  const frameIds = useMemo(() => collectFrameIds(layerTree), [layerTree]);
   const anyFrameExpanded = useMemo(() => frameIds.some((id) => !collapsedLayers.has(id)), [frameIds, collapsedLayers]);
 
   const toggleAllLayers = useCallback(() => {

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/utils/layers.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/utils/layers.ts
@@ -1,48 +1,48 @@
 import type { CanvasNode } from '../../../types';
+import { computeParentFrameMap } from '../../../utils/frameHierarchy';
 
 export interface LayerTreeNode {
   node: CanvasNode;
-  children: CanvasNode[];
+  children: LayerTreeNode[];
 }
 
-const isInsideFrame = (node: CanvasNode, frame: CanvasNode): boolean => {
-  const cx = node.x + node.width / 2;
-  const cy = node.y + node.height / 2;
-  return (
-    cx >= frame.x &&
-    cx <= frame.x + frame.width &&
-    cy >= frame.y &&
-    cy <= frame.y + frame.height
-  );
+/**
+ * Build a recursive tree. Each node is nested under its most-specific
+ * containing frame (see `computeParentFrameMap`). Frames may contain both
+ * regular nodes AND other frames.
+ */
+export const buildLayerTree = (nodes: CanvasNode[]): LayerTreeNode[] => {
+  const parentMap = computeParentFrameMap(nodes);
+  const byId = new Map(nodes.map((n) => [n.id, n] as const));
+
+  // Preserve the input ordering by walking `nodes` when grouping children.
+  const childrenOf = new Map<string | null, string[]>();
+  for (const n of nodes) {
+    const key = parentMap.get(n.id) ?? null;
+    const arr = childrenOf.get(key);
+    if (arr) arr.push(n.id);
+    else childrenOf.set(key, [n.id]);
+  }
+
+  const buildNode = (id: string): LayerTreeNode => {
+    const node = byId.get(id)!;
+    const childIds = childrenOf.get(id) ?? [];
+    return { node, children: childIds.map(buildNode) };
+  };
+
+  const rootIds = childrenOf.get(null) ?? [];
+  return rootIds.map(buildNode);
 };
 
-/** Build a tree: frames contain non-frame nodes whose center is inside them. */
-export const buildLayerTree = (nodes: CanvasNode[]): LayerTreeNode[] => {
-  const frames = nodes.filter((n) => n.type === 'frame');
-  const nonFrames = nodes.filter((n) => n.type !== 'frame');
-
-  const childrenOf = new Map<string, CanvasNode[]>();
-  const assigned = new Set<string>();
-
-  for (const frame of frames) {
-    const kids: CanvasNode[] = [];
-    for (const n of nonFrames) {
-      if (!assigned.has(n.id) && isInsideFrame(n, frame)) {
-        kids.push(n);
-        assigned.add(n.id);
-      }
+/** Walk a layer tree and collect every frame id (including nested frames). */
+export const collectFrameIds = (tree: LayerTreeNode[]): string[] => {
+  const out: string[] = [];
+  const walk = (nodes: LayerTreeNode[]) => {
+    for (const n of nodes) {
+      if (n.node.type === 'frame') out.push(n.node.id);
+      if (n.children.length > 0) walk(n.children);
     }
-    childrenOf.set(frame.id, kids);
-  }
-
-  const tree: LayerTreeNode[] = [];
-  for (const frame of frames) {
-    tree.push({ node: frame, children: childrenOf.get(frame.id) || [] });
-  }
-  for (const n of nonFrames) {
-    if (!assigned.has(n.id)) {
-      tree.push({ node: n, children: [] });
-    }
-  }
-  return tree;
+  };
+  walk(tree);
+  return out;
 };

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodeDrag.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodeDrag.ts
@@ -1,17 +1,6 @@
 import { useCallback, useRef, useState } from "react";
 import type { CanvasNode } from "../types";
-
-/** Check if a node's center is inside a frame's bounding box */
-const isInsideFrame = (node: CanvasNode, frame: CanvasNode): boolean => {
-  const cx = node.x + node.width / 2;
-  const cy = node.y + node.height / 2;
-  return (
-    cx >= frame.x &&
-    cx <= frame.x + frame.width &&
-    cy >= frame.y &&
-    cy <= frame.y + frame.height
-  );
-};
+import { collectFrameDescendants } from "../utils/frameHierarchy";
 
 export const useNodeDrag = (
   moveNode: (id: string, x: number, y: number) => void,
@@ -34,12 +23,15 @@ export const useNodeDrag = (
       if (e.button !== 0 || e.altKey) return;
       e.stopPropagation();
 
-      // If dragging a frame, find contained child nodes
+      // If dragging a frame, also drag every transitive descendant — both
+      // regular nodes and nested child frames.
       let children: Array<{ id: string; nodeX: number; nodeY: number }> = [];
       if (node.type === "frame") {
-        children = nodes
-          .filter((n) => n.id !== node.id && n.type !== "frame" && isInsideFrame(n, node))
-          .map((n) => ({ id: n.id, nodeX: n.x, nodeY: n.y }));
+        children = collectFrameDescendants(node.id, nodes).map((n) => ({
+          id: n.id,
+          nodeX: n.x,
+          nodeY: n.y,
+        }));
       }
 
       dragging.current = {

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodeDrag.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodeDrag.ts
@@ -17,6 +17,11 @@ export const useNodeDrag = (
     children: Array<{ id: string; nodeX: number; nodeY: number }>;
   } | null>(null);
   const [draggingId, setDraggingId] = useState<string | null>(null);
+  // Every node that moves with the drag (the primary node plus, for frames,
+  // every descendant frame / node). Used so the whole group can share the
+  // lifted `.canvas-node--dragging` stacking context — otherwise a dragged
+  // parent frame's opaque body would paint over its nested children.
+  const [draggingIds, setDraggingIds] = useState<Set<string>>(() => new Set());
 
   const onDragStart = useCallback(
     (e: React.MouseEvent, node: CanvasNode) => {
@@ -43,6 +48,7 @@ export const useNodeDrag = (
         children
       };
       setDraggingId(node.id);
+      setDraggingIds(new Set([node.id, ...children.map((c) => c.id)]));
     },
     [nodes]
   );
@@ -75,7 +81,8 @@ export const useNodeDrag = (
   const onDragEnd = useCallback(() => {
     dragging.current = null;
     setDraggingId(null);
+    setDraggingIds(new Set());
   }, []);
 
-  return { draggingId, onDragStart, onDragMove, onDragEnd };
+  return { draggingId, draggingIds, onDragStart, onDragMove, onDragEnd };
 };

--- a/apps/canvas-workspace/src/renderer/src/utils/frameHierarchy.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/frameHierarchy.ts
@@ -1,0 +1,110 @@
+import type { CanvasNode } from '../types';
+
+/** True when a node's center point falls inside a frame's bounding box. */
+export const isInsideFrame = (node: CanvasNode, frame: CanvasNode): boolean => {
+  const cx = node.x + node.width / 2;
+  const cy = node.y + node.height / 2;
+  return (
+    cx >= frame.x &&
+    cx <= frame.x + frame.width &&
+    cy >= frame.y &&
+    cy <= frame.y + frame.height
+  );
+};
+
+const frameArea = (frame: CanvasNode) => frame.width * frame.height;
+
+/**
+ * For each node, find its parent frame — the smallest (by area) frame whose
+ * bounding box contains the node's center. Returns a map of nodeId → parent
+ * frameId (or null for root-level nodes).
+ *
+ * When `n` is itself a frame, a candidate frame `f` can only be its parent if
+ * `f` is strictly "bigger" than `n` in the total order (area desc, then id
+ * asc). This guarantees acyclic parenthood even when two frames share a bbox.
+ */
+export const computeParentFrameMap = (
+  nodes: CanvasNode[]
+): Map<string, string | null> => {
+  const frames = nodes.filter((n) => n.type === 'frame');
+  const map = new Map<string, string | null>();
+
+  for (const n of nodes) {
+    let best: CanvasNode | null = null;
+    let bestArea = Infinity;
+    const nArea = n.type === 'frame' ? frameArea(n) : -1;
+
+    for (const f of frames) {
+      if (f.id === n.id) continue;
+      if (!isInsideFrame(n, f)) continue;
+
+      const fArea = frameArea(f);
+      // For frame-in-frame, require strict "bigger" ancestor to avoid cycles.
+      if (n.type === 'frame') {
+        if (fArea < nArea) continue;
+        if (fArea === nArea && f.id >= n.id) continue;
+      }
+
+      if (fArea < bestArea) {
+        best = f;
+        bestArea = fArea;
+      } else if (fArea === bestArea && best && f.id < best.id) {
+        best = f;
+      }
+    }
+
+    map.set(n.id, best ? best.id : null);
+  }
+
+  return map;
+};
+
+/**
+ * Collect all transitive descendants of a frame (nodes whose parent chain
+ * passes through `frameId`). Does NOT include the frame itself.
+ */
+export const collectFrameDescendants = (
+  frameId: string,
+  nodes: CanvasNode[]
+): CanvasNode[] => {
+  const parentMap = computeParentFrameMap(nodes);
+  const result: CanvasNode[] = [];
+
+  for (const n of nodes) {
+    if (n.id === frameId) continue;
+    let cur = parentMap.get(n.id) ?? null;
+    while (cur) {
+      if (cur === frameId) {
+        result.push(n);
+        break;
+      }
+      cur = parentMap.get(cur) ?? null;
+    }
+  }
+
+  return result;
+};
+
+/**
+ * Compute the nesting depth of each frame (root frames = 0, frame inside a
+ * root frame = 1, and so on). Non-frames are not included in the result.
+ */
+export const computeFrameDepths = (nodes: CanvasNode[]): Map<string, number> => {
+  const parentMap = computeParentFrameMap(nodes);
+  const depths = new Map<string, number>();
+
+  const depthOf = (id: string): number => {
+    const cached = depths.get(id);
+    if (cached !== undefined) return cached;
+    const parent = parentMap.get(id) ?? null;
+    const d = parent ? depthOf(parent) + 1 : 0;
+    depths.set(id, d);
+    return d;
+  };
+
+  for (const n of nodes) {
+    if (n.type === 'frame') depthOf(n.id);
+  }
+
+  return depths;
+};


### PR DESCRIPTION
## Summary
This PR extracts frame hierarchy computation into a reusable utility module and refactors the layer tree structure to properly support nested frames. The changes enable correct handling of frame-in-frame nesting and improve drag behavior for frames with descendants.

## Key Changes

- **New `frameHierarchy.ts` utility module** with three core functions:
  - `isInsideFrame()`: Checks if a node's center falls within a frame's bounding box
  - `computeParentFrameMap()`: Computes parent-child relationships between frames and nodes, with cycle prevention for frame-in-frame scenarios
  - `collectFrameDescendants()`: Collects all transitive descendants of a frame
  - `computeFrameDepths()`: Calculates nesting depth for each frame

- **Refactored `buildLayerTree()`** to use the new `computeParentFrameMap()`:
  - Changed `LayerTreeNode.children` from `CanvasNode[]` to `LayerTreeNode[]` for proper recursive nesting
  - Now correctly supports frames containing other frames, not just leaf nodes
  - Preserves input node ordering when building the tree

- **Updated `LayerItem` component** to work with recursive tree structure:
  - Now recursively renders `LayerItem` for child nodes instead of flat button rendering
  - Simplified props to accept `LayerTreeNode` directly

- **Improved drag behavior** in `useNodeDrag`:
  - When dragging a frame, now includes all transitive descendants (both regular nodes and nested frames)
  - Added `draggingIds` Set to track all nodes participating in a drag operation
  - Ensures proper stacking context for dragged frame hierarchies

- **Enhanced canvas rendering** in `Canvas` component:
  - Uses `computeFrameDepths()` to sort frames by nesting depth
  - Nested frames now render on top of their parent frames
  - Non-frames continue to render in front of all frames

- **Removed duplicate code**:
  - Deleted `isInsideFrame()` implementations from `layers.ts` and `useNodeDrag.ts`
  - Both now import from the centralized `frameHierarchy` utility

## Notable Implementation Details

- Frame-in-frame cycle prevention: When a frame is a candidate parent for another frame, it must be strictly "bigger" (by area, then by ID) to ensure acyclic relationships
- The layer tree now maintains full hierarchy information, enabling proper recursive rendering and frame depth calculations
- Drag operations on frames now correctly move the entire subtree of descendants, with all participating nodes sharing the lifted stacking context

https://claude.ai/code/session_01X3yDr3sr2T7AXK5VuwSsB3