### PR TITLE
Preserve empty lines in editor through markdown serialization

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -91,6 +91,7 @@
     "@tiptap/extension-highlight": "^3.20.4",
     "@tiptap/extension-image": "^3.20.5",
     "@tiptap/extension-link": "^3.20.4",
+    "@tiptap/extension-paragraph": "^3.20.4",
     "@tiptap/extension-placeholder": "^3.20.4",
     "@tiptap/extension-table": "^3.20.4",
     "@tiptap/extension-table-cell": "^3.20.4",

--- a/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Image from '@tiptap/extension-image';
+import Paragraph from '@tiptap/extension-paragraph';
 import Placeholder from '@tiptap/extension-placeholder';
 import TaskList from '@tiptap/extension-task-list';
 import TaskItem from '@tiptap/extension-task-item';
@@ -21,6 +22,33 @@ import { ALL_SLASH_COMMANDS, filterCmds, type SlashCmdContext } from '../editor/
 import { NoteSearchExtension } from '../editor/noteSearchExtension';
 
 const lowlight = createLowlight(common);
+
+// Markdown collapses consecutive blank lines into a single paragraph
+// separator, so empty paragraphs typed by the user (Enter → Enter) are
+// lost after save+reload. Preserve them by emitting a non-breaking space
+// during markdown serialization — that keeps one paragraph per blank line
+// through the markdown roundtrip, matching the pre-reload editor view.
+const EMPTY_PARAGRAPH_MARKER = '\u00A0';
+
+const EmptyLinePreservingParagraph = Paragraph.extend({
+  addStorage() {
+    return {
+      ...this.parent?.(),
+      markdown: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        serialize(state: any, node: any) {
+          if (node.childCount === 0) {
+            state.write(EMPTY_PARAGRAPH_MARKER);
+          } else {
+            state.renderInline(node);
+          }
+          state.closeBlock(node);
+        },
+        parse: {},
+      },
+    };
+  },
+});
 
 interface SlashMenuState {
   x: number;
@@ -75,11 +103,14 @@ export const useFileNodeEditor = ({
     extensions: [
       // StarterKit v3 bundles Link + Underline + CodeBlock — disable the
       // built-ins since we register explicit configured versions below.
+      // Also disable Paragraph so our empty-line-preserving version wins.
       StarterKit.configure({
         codeBlock: false,
         link: false,
         underline: false,
+        paragraph: false,
       }),
+      EmptyLinePreservingParagraph,
       Image.configure({ inline: false }),
       Placeholder.configure({ placeholder: 'Start writing…' }),
       TaskList,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@tiptap/extension-link':
         specifier: ^3.20.4
         version: 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2)
+      '@tiptap/extension-paragraph':
+        specifier: ^3.20.4
+        version: 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))
       '@tiptap/extension-placeholder':
         specifier: ^3.20.4
         version: 3.22.2(@tiptap/extensions@3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2))


### PR DESCRIPTION
## Summary
This PR fixes an issue where empty lines (consecutive blank paragraphs) created by the user in the editor were lost after saving and reloading the document. The fix implements custom markdown serialization for paragraphs to preserve empty lines through the markdown roundtrip.

## Key Changes
- Added `@tiptap/extension-paragraph` dependency to enable custom paragraph handling
- Created `EmptyLinePreservingParagraph` extension that extends the base Paragraph extension with custom markdown serialization logic
- Modified serialization to emit a non-breaking space (`\u00A0`) for empty paragraphs, which preserves them through markdown conversion while maintaining the visual appearance of blank lines
- Disabled the default Paragraph extension from StarterKit and registered the custom version instead

## Implementation Details
- Empty paragraphs are detected by checking `node.childCount === 0`
- A non-breaking space is used as a marker because markdown collapses consecutive blank lines into a single paragraph separator, so this approach ensures one paragraph per blank line is maintained through the save/reload cycle
- The custom serialization only affects empty paragraphs; non-empty paragraphs use the standard inline rendering

https://claude.ai/code/session_01EdNSMhEg9g6NArFBdkMta6