### PR TITLE
Add text node type with TLDRAW-style editing and color pickers

### DIFF
--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -26,7 +26,7 @@ const STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
 
 // ─── Types mirrored from canvas-cli ────────────────────────────────
 
-type NodeType = 'file' | 'terminal' | 'frame' | 'agent';
+type NodeType = 'file' | 'terminal' | 'frame' | 'agent' | 'text';
 
 interface CanvasNode {
   id: string;
@@ -51,6 +51,7 @@ const DEFAULT_DIMENSIONS: Record<NodeType, { title: string; width: number; heigh
   terminal: { title: 'Terminal', width: 480, height: 300 },
   frame: { title: 'Frame', width: 600, height: 400 },
   agent: { title: 'Agent', width: 520, height: 380 },
+  text: { title: 'Text', width: 260, height: 120 },
 };
 
 // ─── Helpers ───────────────────────────────────────────────────────
@@ -231,18 +232,21 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
         'and `data.status` to "running" to auto-launch (default "idle" shows a picker). ' +
         'Use `data.prompt` to inject a task/context — it is written to a file in the cwd and piped directly ' +
         'to the agent as its initial prompt. Include relevant canvas content so the agent knows the context. ' +
-        'Optional `data.agentArgs` overrides the auto-generated CLI arguments.',
+        'Optional `data.agentArgs` overrides the auto-generated CLI arguments.\n' +
+        '- **text**: Creates a free-form text label (TLDRAW-style). Use `content` for the text body, ' +
+        'and `data.textColor` / `data.backgroundColor` (hex or "transparent") for styling. Optional `data.fontSize`.',
       inputSchema: z.object({
-        type: z.enum(['file', 'terminal', 'frame', 'agent']).describe('Node type.'),
+        type: z.enum(['file', 'terminal', 'frame', 'agent', 'text']).describe('Node type.'),
         title: z.string().optional().describe('Node title.'),
-        content: z.string().optional().describe('Initial content (for file nodes).'),
+        content: z.string().optional().describe('Initial content (for file and text nodes).'),
         x: z.number().optional().describe('X position (auto-placed if omitted).'),
         y: z.number().optional().describe('Y position (auto-placed if omitted).'),
         data: z.record(z.string(), z.unknown()).optional().describe(
           'Additional node data. Keys vary by type:\n' +
           '- terminal: { cwd?: string }\n' +
           '- agent: { agentType?: "claude-code"|"codex"|"pulse-coder", cwd?: string, status?: "idle"|"running", prompt?: string, agentArgs?: string }\n' +
-          '- frame: { color?: string, label?: string }',
+          '- frame: { color?: string, label?: string }\n' +
+          '- text: { textColor?: string, backgroundColor?: string, fontSize?: number }',
         ),
       }),
       execute: async (input) => {
@@ -308,6 +312,14 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
             };
             break;
           }
+          case 'text':
+            nodeData = {
+              content,
+              textColor: (extraData.textColor as string) ?? '#1f2328',
+              backgroundColor: (extraData.backgroundColor as string) ?? 'transparent',
+              fontSize: (extraData.fontSize as number) ?? 18,
+            };
+            break;
         }
 
         // For file nodes, create a backing notes file
@@ -352,12 +364,12 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
     canvas_update_node: {
       name: 'canvas_update_node',
       description:
-        'Update an existing canvas node. For file nodes, updates the file content. For frame nodes, updates label/color.',
+        'Update an existing canvas node. For file and text nodes, updates `content`. For frame nodes, updates label/color. For text nodes, `data.textColor`/`data.backgroundColor`/`data.fontSize` can also be patched.',
       inputSchema: z.object({
         nodeId: z.string().describe('The ID of the node to update.'),
         title: z.string().optional().describe('New title (optional).'),
-        content: z.string().optional().describe('New content for file nodes.'),
-        data: z.record(z.string(), z.unknown()).optional().describe('Partial data update (e.g. label, color for frames).'),
+        content: z.string().optional().describe('New content for file and text nodes.'),
+        data: z.record(z.string(), z.unknown()).optional().describe('Partial data update (e.g. label, color for frames; textColor, backgroundColor, fontSize for text).'),
       }),
       execute: async (input) => {
         const nodeId = input.nodeId as string;
@@ -375,6 +387,10 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
           if (node.data.filePath) {
             await fs.writeFile(node.data.filePath as string, content, 'utf-8');
           }
+        }
+
+        if (node.type === 'text' && input.content != null) {
+          node.data.content = input.content as string;
         }
 
         if (input.data) {

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
@@ -18,10 +18,10 @@ interface CanvasOverlaysProps {
   scale: number;
   chatPanelOpen?: boolean;
   onChatToggle?: () => void;
-  onCreateNode: (type: 'file' | 'terminal' | 'frame' | 'agent') => void;
+  onCreateNode: (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text') => void;
   onCloseContextMenu: () => void;
   onToolChange: (tool: string) => void;
-  onAddNode: (type: 'file' | 'terminal' | 'frame' | 'agent') => void;
+  onAddNode: (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text') => void;
   onResetTransform: () => void;
   onSearchSelect: (node: CanvasNode) => void;
   onCloseSearch: () => void;

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
@@ -20,7 +20,15 @@ interface CanvasSurfaceProps {
   highlightedId: string | null;
   externallyEditedIds: Set<string>;
   onDragStart: (e: React.MouseEvent, node: CanvasNode) => void;
-  onResizeStart: (e: React.MouseEvent, nodeId: string, width: number, height: number, edge: ResizeEdge) => void;
+  onResizeStart: (
+    e: React.MouseEvent,
+    nodeId: string,
+    width: number,
+    height: number,
+    edge: ResizeEdge,
+    minWidth?: number,
+    minHeight?: number
+  ) => void;
   onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
   onRemove: (id: string) => void;
   onSelect: (id: string) => void;

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -170,7 +170,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
   );
 
   const handleCreateNode = useCallback(
-    (type: 'file' | 'terminal' | 'frame' | 'agent') => {
+    (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text') => {
       if (!contextMenu) return;
       const node = addNode(type, contextMenu.canvasX, contextMenu.canvasY);
       setSelectedNodeIds([node.id]);
@@ -180,12 +180,21 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
   );
 
   const handleToolbarAddNode = useCallback(
-    (type: 'file' | 'terminal' | 'frame' | 'agent') => {
+    (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text') => {
       if (!containerRef.current) return;
       const rect = containerRef.current.getBoundingClientRect();
       const pos = screenToCanvas(rect.left + rect.width / 2, rect.top + rect.height / 2, containerRef.current);
-      const halfW = type === 'file' ? 210 : type === 'terminal' ? 240 : type === 'agent' ? 260 : 300;
-      const node = addNode(type, pos.x - halfW, pos.y - (type === 'frame' ? 200 : 150));
+      const halfW =
+        type === 'file' ? 210
+        : type === 'terminal' ? 240
+        : type === 'agent' ? 260
+        : type === 'text' ? 130
+        : 300;
+      const halfH =
+        type === 'frame' ? 200
+        : type === 'text' ? 60
+        : 150;
+      const node = addNode(type, pos.x - halfW, pos.y - halfH);
       setSelectedNodeIds([node.id]);
     },
     [addNode, screenToCanvas]

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -200,7 +200,13 @@ export const CanvasNodeView = ({
         ) : node.type === "frame" ? (
           <FrameNodeBody node={node} onUpdate={onUpdate} />
         ) : node.type === "text" ? (
-          <TextNodeBody node={node} onUpdate={onUpdate} />
+          <TextNodeBody
+            node={node}
+            onUpdate={onUpdate}
+            isSelected={isSelected}
+            onSelect={onSelect}
+            onDragStart={onDragStart}
+          />
         ) : (
           <AgentNodeBody node={node} allNodes={allNodes} rootFolder={rootFolder} workspaceId={workspaceId} workspaceName={workspaceName} onUpdate={onUpdate} />
         )}

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -234,14 +234,21 @@ export const CanvasNodeView = ({
         className="resize-handle resize-handle--right"
         onMouseDown={makeResizeHandler("right")}
       />
-      <div
-        className="resize-handle resize-handle--bottom"
-        onMouseDown={makeResizeHandler("bottom")}
-      />
-      <div
-        className="resize-handle resize-handle--corner"
-        onMouseDown={makeResizeHandler("bottom-right")}
-      />
+      {/* Text nodes grow vertically to fit content, so a bottom/corner
+          handle would either do nothing or fight the auto-height. Offer only
+          the right-edge handle as a wrap-width control. */}
+      {node.type !== "text" && (
+        <>
+          <div
+            className="resize-handle resize-handle--bottom"
+            onMouseDown={makeResizeHandler("bottom")}
+          />
+          <div
+            className="resize-handle resize-handle--corner"
+            onMouseDown={makeResizeHandler("bottom-right")}
+          />
+        </>
+      )}
     </div>
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import "./index.css";
-import type { CanvasNode, FrameNodeData, AgentNodeData } from "../../types";
+import type { CanvasNode, FrameNodeData, AgentNodeData, TextNodeData } from "../../types";
 import type { ResizeEdge } from "../../hooks/useNodeResize";
 import { FileNodeBody } from "../FileNodeBody";
 import { TerminalNodeBody } from "../TerminalNodeBody";
@@ -26,7 +26,9 @@ interface Props {
     nodeId: string,
     width: number,
     height: number,
-    edge: ResizeEdge
+    edge: ResizeEdge,
+    minWidth?: number,
+    minHeight?: number
   ) => void;
   onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
   onRemove: (id: string) => void;
@@ -96,10 +98,25 @@ export const CanvasNodeView = ({
 
   const makeResizeHandler = useCallback(
     (edge: ResizeEdge) => (e: React.MouseEvent) => {
+      if (node.type === "text") {
+        // Dragging a resize handle on a text node switches it out of auto-size
+        // mode so the dragged width/height becomes the authoritative frame.
+        const data = node.data as TextNodeData;
+        if (data.autoSize !== false) {
+          onUpdate(node.id, { data: { ...data, autoSize: false } });
+        }
+        // Text labels should be shrinkable well below the standard 200×120
+        // floor — a tiny tag is a valid shape.
+        onResizeStart(e, node.id, node.width, node.height, edge, 40, 28);
+        return;
+      }
       onResizeStart(e, node.id, node.width, node.height, edge);
     },
-    [onResizeStart, node.id, node.width, node.height]
+    [onResizeStart, onUpdate, node.id, node.type, node.width, node.height, node.data]
   );
+
+  const textAutoSize =
+    node.type === "text" && (node.data as TextNodeData).autoSize !== false;
 
   const classes = [
     "canvas-node",
@@ -108,7 +125,8 @@ export const CanvasNodeView = ({
     isResizing && "canvas-node--resizing",
     isSelected && "canvas-node--selected",
     isHighlighted && "canvas-node--highlighted",
-    isAgentEdited && "canvas-node--agent-edited"
+    isAgentEdited && "canvas-node--agent-edited",
+    textAutoSize && "canvas-node--text-auto"
   ]
     .filter(Boolean)
     .join(" ");

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -6,6 +6,7 @@ import { FileNodeBody } from "../FileNodeBody";
 import { TerminalNodeBody } from "../TerminalNodeBody";
 import { FrameNodeBody, FrameColorPicker } from "../FrameNodeBody";
 import { AgentNodeBody } from "../AgentNodeBody";
+import { TextNodeBody, TextColorPicker } from "../TextNodeBody";
 
 interface Props {
   node: CanvasNode;
@@ -145,6 +146,10 @@ export const CanvasNodeView = ({
               <rect x="2" y="2" width="12" height="12" rx="2" stroke="currentColor" strokeWidth="1.3" />
               <rect x="4.5" y="4.5" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="1" strokeDasharray="2 1.5" />
             </svg>
+          ) : node.type === "text" ? (
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+              <path d="M3 4h10M8 4v9M6 13h4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+            </svg>
           ) : (
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
               <circle cx="8" cy="5.5" r="3" stroke="currentColor" strokeWidth="1.3" />
@@ -172,6 +177,9 @@ export const CanvasNodeView = ({
         {node.type === "frame" && (
           <FrameColorPicker node={node} onUpdate={onUpdate} />
         )}
+        {node.type === "text" && (
+          <TextColorPicker node={node} onUpdate={onUpdate} />
+        )}
         <button className="node-focus" onClick={handleFocus} title="Focus">
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
             <circle cx="6" cy="6" r="2" stroke="currentColor" strokeWidth="1.3" />
@@ -191,6 +199,8 @@ export const CanvasNodeView = ({
           <TerminalNodeBody node={node} allNodes={allNodes} rootFolder={rootFolder} workspaceId={workspaceId} workspaceName={workspaceName} onUpdate={onUpdate} />
         ) : node.type === "frame" ? (
           <FrameNodeBody node={node} onUpdate={onUpdate} />
+        ) : node.type === "text" ? (
+          <TextNodeBody node={node} onUpdate={onUpdate} />
         ) : (
           <AgentNodeBody node={node} allNodes={allNodes} rootFolder={rootFolder} workspaceId={workspaceId} workspaceName={workspaceName} onUpdate={onUpdate} />
         )}

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
@@ -3,7 +3,7 @@ import './index.css';
 interface Props {
   activeTool: string;
   onToolChange: (tool: string) => void;
-  onAddNode: (type: "file" | "terminal" | "frame" | "agent") => void;
+  onAddNode: (type: "file" | "terminal" | "frame" | "agent" | "text") => void;
   chatPanelOpen?: boolean;
   onChatToggle?: () => void;
 }
@@ -138,6 +138,19 @@ export const FloatingToolbar = ({
             />
           </svg>
           <span className="toolbar-btn-label">Frame</span>
+        </button>
+        <button
+          className="toolbar-btn toolbar-btn--create"
+          onClick={() => onAddNode("text")}
+          title="Add Text"
+        >
+          <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+            <path
+              d="M4 5h10M9 5v9M7 14h4"
+              stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"
+            />
+          </svg>
+          <span className="toolbar-btn-label">Text</span>
         </button>
         <button
           className="toolbar-btn toolbar-btn--create"

--- a/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from "react";
 interface Props {
   x: number;
   y: number;
-  onCreate: (type: "file" | "terminal" | "frame" | "agent") => void;
+  onCreate: (type: "file" | "terminal" | "frame" | "agent" | "text") => void;
   onClose: () => void;
 }
 
@@ -70,6 +70,16 @@ export const NodeContextMenu = ({ x, y, onCreate, onClose }: Props) => {
         <span className="context-menu-label">
           <strong>Frame</strong>
           <small>Visual container group</small>
+        </span>
+      </button>
+      <button
+        className="context-menu-item"
+        onClick={() => onCreate("text")}
+      >
+        <span className="context-menu-icon">{"\u0041"}</span>
+        <span className="context-menu-label">
+          <strong>Text</strong>
+          <small>Free-form text label</small>
         </span>
       </button>
       <button

--- a/apps/canvas-workspace/src/renderer/src/components/SearchPalette/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/SearchPalette/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import "./index.css";
-import type { CanvasNode, FileNodeData } from "../../types";
+import type { CanvasNode, FileNodeData, TextNodeData } from "../../types";
 
 interface SearchResult {
   node: CanvasNode;
@@ -73,6 +73,16 @@ export const SearchPalette = ({ nodes, onSelect, onClose }: Props) => {
         }
 
         const content = fileData.content || "";
+        if (content.toLowerCase().includes(q)) {
+          const idx = content.toLowerCase().indexOf(q);
+          const start = Math.max(0, idx - 20);
+          const end = Math.min(content.length, idx + q.length + 20);
+          const snippet = (start > 0 ? "..." : "") + content.slice(start, end) + (end < content.length ? "..." : "");
+          results.push({ node, matchType: "content", matchText: snippet });
+          continue;
+        }
+      } else if (node.type === "text") {
+        const content = (node.data as TextNodeData).content || "";
         if (content.toLowerCase().includes(q)) {
           const idx = content.toLowerCase().indexOf(q);
           const start = Math.max(0, idx - 20);

--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.css
@@ -7,15 +7,15 @@
  *    the two color pickers and the delete button. The title is intentionally
  *    hidden so the node reads as "a piece of text".
  *  - Click-drag: moves the node.
- *  - Double-click: enters editing mode (raw markdown source).
- *  - Resize handles (right / bottom / corner) appear on hover or selected so
- *    the user can pin the width and let text wrap inside the frame.
+ *  - Double-click: enters editing mode (tiptap WYSIWYG).
+ *  - A single right-edge resize handle lets the user pin a wrap width.
  *
  * Size model:
- *  - `.canvas-node--text-auto` → width/height driven by content (max-content).
- *    Applied by default and while editing.
- *  - Without `.canvas-node--text-auto` → the user has manually resized and
- *    node.width/height are honored as a hard frame (text wraps inside).
+ *  - Height is ALWAYS driven by content — a text node never clips vertically
+ *    or scrolls. tldraw and Figma behave the same way.
+ *  - `.canvas-node--text-auto` → width also driven by content (max-content).
+ *  - Without `.canvas-node--text-auto` → user has dragged the right handle;
+ *    width is honored as a wrap-width, height still follows the text.
  * ------------------------------------------------------------------------- */
 
 /* --- Wrapper: no card chrome --------------------------------------------- */
@@ -34,11 +34,16 @@
   display: block;
 }
 
-/* Auto-size mode: content drives the wrapper. `!important` is needed to
- * override the inline width/height React writes from node.width/height. */
+/* Height is always content-driven — override the inline height React writes
+ * from node.height so the frame grows with the text instead of clipping it. */
+.canvas-node--text {
+  height: max-content !important;
+}
+
+/* Auto-size mode: width is also driven by content. `!important` is needed to
+ * override the inline width React writes from node.width. */
 .canvas-node--text.canvas-node--text-auto {
   width: max-content !important;
-  height: max-content !important;
   max-width: 600px;
 }
 
@@ -102,24 +107,23 @@
 /* --- Body --------------------------------------------------------------- */
 .canvas-node--text .node-body {
   width: 100%;
-  height: 100%;
-  /* In manual (fixed-frame) mode, clip overflow so the user's dragged
-   * height acts like a real frame. */
-  overflow: hidden;
+  /* Never clip or scroll — prosemirror's auto-scroll-into-view would
+   * otherwise push the top of the text above the visible area when the
+   * editor grows past a fixed-height frame. Height follows content. */
+  height: auto;
+  overflow: visible;
   border-radius: var(--radius-md, 6px);
   flex: none;
 }
 
 .canvas-node--text.canvas-node--text-auto .node-body {
   width: auto;
-  height: auto;
-  overflow: visible;
 }
 
 .text-node-body {
   display: block;
   width: 100%;
-  height: 100%;
+  height: auto;
   min-width: 32px;
   min-height: 28px;
   padding: 6px 10px;
@@ -139,7 +143,6 @@
 .canvas-node--text.canvas-node--text-auto .text-node-body {
   width: max-content;
   max-width: 600px;
-  height: auto;
 }
 
 .text-node-body--editing {

--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.css
@@ -1,89 +1,130 @@
 /* ---------------------------------------------------------------------------
- * Text node styling
+ * Text node styling — TLDRAW-inspired
  *
- * Design goals:
- *  - A TLDRAW-style label: minimal chrome by default, content-forward.
- *  - The whole node wrapper (not just the body) takes the background color
- *    so picking "Yellow" turns the entire card yellow, matching user intent.
- *  - When bg is "transparent", the node has no visible card — just text on
- *    the canvas, like tldraw.
+ * Shape of the interaction:
+ *  - Idle state: no card chrome. The text sits on the canvas as a label.
+ *  - Hover / selected: a compact floating toolbar appears above the node with
+ *    color pickers + delete. The title badge is intentionally hidden so the
+ *    node reads as "a piece of text", not "a card named Text".
+ *  - Click-drag on the text moves the node.
+ *  - Double-click on the text enters editing. Blur / Escape exits.
+ *  - Size is driven by content: `width: max-content` lets the wrapper shrink
+ *    to the text. We still persist the measured size back into node.width /
+ *    node.height via useLayoutEffect so Canvas hit-testing & frame containment
+ *    use the real rendered bounds.
  * ------------------------------------------------------------------------- */
 
-/* Neutralize the shared .canvas-node chrome for text nodes. Background is
- * driven by the inline style on .text-node-body, not by the wrapper, so that
- * "transparent" actually reveals the canvas grid. The wrapper border is only
- * shown on hover/selection to keep the node feeling like a bare label. */
+/* --- Wrapper: no card chrome, content-driven size ----------------------- */
 .canvas-node--text {
+  /* Ignore the stored width/height so the wrapper sizes to the text body. */
+  width: max-content !important;
+  height: max-content !important;
+  min-width: 32px;
+  min-height: 28px;
+  max-width: 600px;
+
   background: transparent;
-  border-color: transparent;
+  border: 1px solid transparent;
   box-shadow: none;
-  /* .canvas-node has overflow: hidden by default — clear it so the header tab
-   * (positioned at top: -32px) isn't clipped. */
+  /* .canvas-node defaults to overflow: hidden — clear it so the floating
+   * toolbar (positioned at top: -36px) isn't clipped. */
   overflow: visible;
+  /* Wrapper is a flex column in .canvas-node base styles. Clear it so the
+   * inline-sized body doesn't get stretched to the max-content max. */
+  display: block;
 }
 
 .canvas-node--text:hover {
-  border-color: rgba(0, 0, 0, 0.12);
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  border-color: rgba(0, 0, 0, 0.08);
 }
 
 .canvas-node--text.canvas-node--selected {
   border-color: var(--accent-border);
-  box-shadow: 0 0 0 2px rgba(35, 131, 226, 0.18);
+  box-shadow: 0 0 0 1.5px rgba(35, 131, 226, 0.35);
 }
 
-/* Hide the header until the node is hovered / selected so the node reads as
- * pure text on the canvas (TLDRAW-style). */
+.canvas-node--text.canvas-node--dragging {
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
+}
+
+/* --- Header: hidden by default, compact toolbar on hover/selected ------- */
 .canvas-node--text .node-header {
   position: absolute;
-  top: -32px;
+  top: -36px;
   left: 0;
-  right: 0;
+  /* Don't force `right: 0` — let the toolbar shrink to its natural content
+   * width so it doesn't span the full text block. */
+  right: auto;
   min-height: 28px;
   height: 28px;
-  padding: 4px 6px 4px 8px;
+  padding: 4px 6px;
   background: var(--surface, #fff);
   border: 1px solid var(--border-light, rgba(0, 0, 0, 0.08));
   border-radius: 6px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
-  /* Keep header chrome in screen space so it doesn't balloon when the canvas
-   * is zoomed in. Matches the frame header behavior. */
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  /* Keep toolbar size constant regardless of canvas zoom, same trick as the
+   * frame header. */
   transform: scale(calc(1 / var(--canvas-scale, 1)));
   transform-origin: left bottom;
   z-index: 2;
+  cursor: default;
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.12s ease;
 }
 
 .canvas-node--text:hover .node-header,
-.canvas-node--text.canvas-node--selected .node-header,
-.canvas-node--text.canvas-node--dragging .node-header {
+.canvas-node--text.canvas-node--selected .node-header {
   opacity: 1;
   pointer-events: auto;
 }
 
+/* Hide the badge, title, and focus button — text nodes have no identity
+ * other than their text. The only affordances in the toolbar are the two
+ * color pickers and the delete button. */
+.canvas-node--text .node-type-badge,
+.canvas-node--text .node-title,
+.canvas-node--text .node-focus {
+  display: none !important;
+}
+
+/* Always show the close button in the toolbar — no hover-to-reveal dance. */
+.canvas-node--text .node-close {
+  opacity: 1;
+}
+
+/* --- Body: fills wrapper; its own intrinsic size drives the wrapper ----- */
 .canvas-node--text .node-body {
-  height: 100%;
-  overflow: hidden;
+  width: auto;
+  height: auto;
+  overflow: visible;
+  flex: none;
 }
 
 .text-node-body {
-  width: 100%;
-  height: 100%;
-  padding: 12px 14px;
-  border-radius: var(--radius-lg, 10px);
+  display: block;
+  min-width: 32px;
+  min-height: 28px;
+  padding: 6px 10px;
+  border-radius: var(--radius-md, 6px);
   outline: none;
   white-space: pre-wrap;
   word-break: break-word;
   overflow-wrap: anywhere;
-  overflow: auto;
   line-height: 1.4;
   font-weight: 500;
   letter-spacing: -0.005em;
+  cursor: move;
+  box-sizing: border-box;
+  /* color + background-color + font-size are applied via inline style so
+   * they persist in node.data. */
+}
+
+.text-node-body--editing {
   cursor: text;
-  /* color + background-color + font-size are set via inline style so they
-   * persist in node.data. */
+  /* Subtle ring so the user can tell editing is active even if the bg is
+   * transparent. */
+  box-shadow: 0 0 0 1px rgba(35, 131, 226, 0.35) inset;
 }
 
 .text-node-body:focus {
@@ -97,9 +138,12 @@
   pointer-events: none;
 }
 
-/* ---- Color trigger (in header) ----
- * Always-visible dots in the hover header so the picker is reachable the
- * moment the header appears. */
+/* Hide resize handles — text auto-sizes from content, no manual resize. */
+.canvas-node--text .resize-handle {
+  display: none;
+}
+
+/* --- Color pickers (rendered in the toolbar) ---------------------------- */
 .text-color-trigger {
   position: relative;
   display: flex;
@@ -138,8 +182,7 @@
   border-color: rgba(0, 0, 0, 0.35);
 }
 
-/* "None" background swatch + transparent dot — diagonal slash to read as
- * "no color". */
+/* "None" bg + transparent dot — diagonal slash reads as "no color". */
 .text-color-dot--transparent,
 .text-color-swatch--none {
   background-color: #ffffff;

--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.css
@@ -1,0 +1,193 @@
+/* ---------------------------------------------------------------------------
+ * Text node styling
+ *
+ * Design goals:
+ *  - A TLDRAW-style label: minimal chrome by default, content-forward.
+ *  - The whole node wrapper (not just the body) takes the background color
+ *    so picking "Yellow" turns the entire card yellow, matching user intent.
+ *  - When bg is "transparent", the node has no visible card — just text on
+ *    the canvas, like tldraw.
+ * ------------------------------------------------------------------------- */
+
+/* Neutralize the shared .canvas-node chrome for text nodes. Background is
+ * driven by the inline style on .text-node-body, not by the wrapper, so that
+ * "transparent" actually reveals the canvas grid. The wrapper border is only
+ * shown on hover/selection to keep the node feeling like a bare label. */
+.canvas-node--text {
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  /* .canvas-node has overflow: hidden by default — clear it so the header tab
+   * (positioned at top: -32px) isn't clipped. */
+  overflow: visible;
+}
+
+.canvas-node--text:hover {
+  border-color: rgba(0, 0, 0, 0.12);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+}
+
+.canvas-node--text.canvas-node--selected {
+  border-color: var(--accent-border);
+  box-shadow: 0 0 0 2px rgba(35, 131, 226, 0.18);
+}
+
+/* Hide the header until the node is hovered / selected so the node reads as
+ * pure text on the canvas (TLDRAW-style). */
+.canvas-node--text .node-header {
+  position: absolute;
+  top: -32px;
+  left: 0;
+  right: 0;
+  min-height: 28px;
+  height: 28px;
+  padding: 4px 6px 4px 8px;
+  background: var(--surface, #fff);
+  border: 1px solid var(--border-light, rgba(0, 0, 0, 0.08));
+  border-radius: 6px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
+  /* Keep header chrome in screen space so it doesn't balloon when the canvas
+   * is zoomed in. Matches the frame header behavior. */
+  transform: scale(calc(1 / var(--canvas-scale, 1)));
+  transform-origin: left bottom;
+  z-index: 2;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s ease;
+}
+
+.canvas-node--text:hover .node-header,
+.canvas-node--text.canvas-node--selected .node-header,
+.canvas-node--text.canvas-node--dragging .node-header {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.canvas-node--text .node-body {
+  height: 100%;
+  overflow: hidden;
+}
+
+.text-node-body {
+  width: 100%;
+  height: 100%;
+  padding: 12px 14px;
+  border-radius: var(--radius-lg, 10px);
+  outline: none;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  overflow: auto;
+  line-height: 1.4;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  cursor: text;
+  /* color + background-color + font-size are set via inline style so they
+   * persist in node.data. */
+}
+
+.text-node-body:focus {
+  outline: none;
+}
+
+.text-node-body[data-placeholder]:empty::before {
+  content: attr(data-placeholder);
+  color: currentColor;
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+/* ---- Color trigger (in header) ----
+ * Always-visible dots in the hover header so the picker is reachable the
+ * moment the header appears. */
+.text-color-trigger {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+}
+
+.text-color-dot {
+  position: relative;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 1.5px solid rgba(0, 0, 0, 0.18);
+  transition: transform 0.1s ease, border-color 0.15s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+}
+
+.text-color-dot-glyph {
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+  color: rgba(0, 0, 0, 0.55);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  pointer-events: none;
+}
+
+.text-color-trigger:hover .text-color-dot {
+  transform: scale(1.12);
+  border-color: rgba(0, 0, 0, 0.35);
+}
+
+/* "None" background swatch + transparent dot — diagonal slash to read as
+ * "no color". */
+.text-color-dot--transparent,
+.text-color-swatch--none {
+  background-color: #ffffff;
+  background-image: linear-gradient(
+    to top right,
+    transparent calc(50% - 1px),
+    #e03131 calc(50% - 0.5px),
+    #e03131 calc(50% + 0.5px),
+    transparent calc(50% + 1px)
+  );
+}
+
+.text-color-popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  display: none;
+  gap: 4px;
+  padding: 6px 8px;
+  background: var(--surface, #fff);
+  border: 1px solid var(--border-light, rgba(0, 0, 0, 0.08));
+  border-radius: 8px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.16);
+  z-index: 20;
+  white-space: nowrap;
+}
+
+.text-color-popover--open {
+  display: flex;
+}
+
+.text-color-swatch {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1.5px solid rgba(0, 0, 0, 0.12);
+  cursor: pointer;
+  padding: 0;
+  transition: transform 0.1s ease, border-color 0.1s ease;
+}
+
+.text-color-swatch:hover {
+  transform: scale(1.25);
+  border-color: rgba(0, 0, 0, 0.3);
+}
+
+.text-color-swatch--active {
+  border-color: rgba(0, 0, 0, 0.5);
+  box-shadow: 0 0 0 1.5px rgba(0, 0, 0, 0.12);
+}

--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.css
@@ -1,37 +1,45 @@
 /* ---------------------------------------------------------------------------
  * Text node styling — TLDRAW-inspired
  *
- * Shape of the interaction:
- *  - Idle state: no card chrome. The text sits on the canvas as a label.
+ * Interaction model:
+ *  - Idle: no card chrome. Formatted markdown sits on the canvas.
  *  - Hover / selected: a compact floating toolbar appears above the node with
- *    color pickers + delete. The title badge is intentionally hidden so the
- *    node reads as "a piece of text", not "a card named Text".
- *  - Click-drag on the text moves the node.
- *  - Double-click on the text enters editing. Blur / Escape exits.
- *  - Size is driven by content: `width: max-content` lets the wrapper shrink
- *    to the text. We still persist the measured size back into node.width /
- *    node.height via useLayoutEffect so Canvas hit-testing & frame containment
- *    use the real rendered bounds.
+ *    the two color pickers and the delete button. The title is intentionally
+ *    hidden so the node reads as "a piece of text".
+ *  - Click-drag: moves the node.
+ *  - Double-click: enters editing mode (raw markdown source).
+ *  - Resize handles (right / bottom / corner) appear on hover or selected so
+ *    the user can pin the width and let text wrap inside the frame.
+ *
+ * Size model:
+ *  - `.canvas-node--text-auto` → width/height driven by content (max-content).
+ *    Applied by default and while editing.
+ *  - Without `.canvas-node--text-auto` → the user has manually resized and
+ *    node.width/height are honored as a hard frame (text wraps inside).
  * ------------------------------------------------------------------------- */
 
-/* --- Wrapper: no card chrome, content-driven size ----------------------- */
+/* --- Wrapper: no card chrome --------------------------------------------- */
 .canvas-node--text {
-  /* Ignore the stored width/height so the wrapper sizes to the text body. */
-  width: max-content !important;
-  height: max-content !important;
   min-width: 32px;
   min-height: 28px;
-  max-width: 600px;
 
   background: transparent;
   border: 1px solid transparent;
   box-shadow: none;
   /* .canvas-node defaults to overflow: hidden — clear it so the floating
-   * toolbar (positioned at top: -36px) isn't clipped. */
+   * toolbar (positioned at top: -36px) and resize handles aren't clipped. */
   overflow: visible;
-  /* Wrapper is a flex column in .canvas-node base styles. Clear it so the
-   * inline-sized body doesn't get stretched to the max-content max. */
+  /* Default `.canvas-node` is flex-column; we don't need that structure here
+   * because the body owns the full shape. */
   display: block;
+}
+
+/* Auto-size mode: content drives the wrapper. `!important` is needed to
+ * override the inline width/height React writes from node.width/height. */
+.canvas-node--text.canvas-node--text-auto {
+  width: max-content !important;
+  height: max-content !important;
+  max-width: 600px;
 }
 
 .canvas-node--text:hover {
@@ -47,12 +55,12 @@
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
 }
 
-/* --- Header: hidden by default, compact toolbar on hover/selected ------- */
+/* --- Header: hidden by default, compact toolbar on hover/selected -------- */
 .canvas-node--text .node-header {
   position: absolute;
   top: -36px;
   left: 0;
-  /* Don't force `right: 0` — let the toolbar shrink to its natural content
+  /* Don't force right: 0 — let the toolbar shrink to its natural content
    * width so it doesn't span the full text block. */
   right: auto;
   min-height: 28px;
@@ -62,8 +70,7 @@
   border: 1px solid var(--border-light, rgba(0, 0, 0, 0.08));
   border-radius: 6px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  /* Keep toolbar size constant regardless of canvas zoom, same trick as the
-   * frame header. */
+  /* Keep toolbar size constant regardless of canvas zoom. */
   transform: scale(calc(1 / var(--canvas-scale, 1)));
   transform-origin: left bottom;
   z-index: 2;
@@ -80,8 +87,7 @@
 }
 
 /* Hide the badge, title, and focus button — text nodes have no identity
- * other than their text. The only affordances in the toolbar are the two
- * color pickers and the delete button. */
+ * beyond their text. The toolbar shows only color pickers + delete. */
 .canvas-node--text .node-type-badge,
 .canvas-node--text .node-title,
 .canvas-node--text .node-focus {
@@ -93,16 +99,27 @@
   opacity: 1;
 }
 
-/* --- Body: fills wrapper; its own intrinsic size drives the wrapper ----- */
+/* --- Body --------------------------------------------------------------- */
 .canvas-node--text .node-body {
+  width: 100%;
+  height: 100%;
+  /* In manual (fixed-frame) mode, clip overflow so the user's dragged
+   * height acts like a real frame. */
+  overflow: hidden;
+  border-radius: var(--radius-md, 6px);
+  flex: none;
+}
+
+.canvas-node--text.canvas-node--text-auto .node-body {
   width: auto;
   height: auto;
   overflow: visible;
-  flex: none;
 }
 
 .text-node-body {
   display: block;
+  width: 100%;
+  height: 100%;
   min-width: 32px;
   min-height: 28px;
   padding: 6px 10px;
@@ -120,10 +137,16 @@
    * they persist in node.data. */
 }
 
+.canvas-node--text.canvas-node--text-auto .text-node-body {
+  width: max-content;
+  max-width: 600px;
+  height: auto;
+}
+
 .text-node-body--editing {
   cursor: text;
-  /* Subtle ring so the user can tell editing is active even if the bg is
-   * transparent. */
+  /* Subtle inset ring so the user can tell they're editing even when the
+   * background is transparent. */
   box-shadow: 0 0 0 1px rgba(35, 131, 226, 0.35) inset;
 }
 
@@ -138,9 +161,137 @@
   pointer-events: none;
 }
 
-/* Hide resize handles — text auto-sizes from content, no manual resize. */
+/* --- Markdown element styles -------------------------------------------- *
+ * markdown-it wraps paragraphs in <p>, so we strip the default margins and
+ * apply tight spacing that fits a label. Lists, headings, inline formatting
+ * use their native semantics. */
+.text-node-body p {
+  margin: 0;
+}
+
+.text-node-body p + p,
+.text-node-body p + ul,
+.text-node-body p + ol,
+.text-node-body ul + p,
+.text-node-body ol + p,
+.text-node-body h1 + *,
+.text-node-body h2 + *,
+.text-node-body h3 + *,
+.text-node-body * + h1,
+.text-node-body * + h2,
+.text-node-body * + h3 {
+  margin-top: 0.35em;
+}
+
+.text-node-body ul,
+.text-node-body ol {
+  margin: 0;
+  padding-left: 1.4em;
+}
+
+.text-node-body li {
+  margin: 0;
+}
+
+.text-node-body li + li {
+  margin-top: 0.1em;
+}
+
+.text-node-body h1,
+.text-node-body h2,
+.text-node-body h3 {
+  margin: 0;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  line-height: 1.2;
+}
+
+.text-node-body h1 {
+  font-size: 1.5em;
+}
+
+.text-node-body h2 {
+  font-size: 1.28em;
+}
+
+.text-node-body h3 {
+  font-size: 1.12em;
+}
+
+.text-node-body strong {
+  font-weight: 700;
+}
+
+.text-node-body em {
+  font-style: italic;
+}
+
+.text-node-body u {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.text-node-body del,
+.text-node-body s {
+  text-decoration: line-through;
+  opacity: 0.7;
+}
+
+.text-node-body code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.9em;
+  padding: 0.08em 0.35em;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.text-node-body pre {
+  margin: 0.35em 0 0;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.05);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.9em;
+  overflow-x: auto;
+}
+
+.text-node-body pre code {
+  padding: 0;
+  background: transparent;
+  border-radius: 0;
+}
+
+.text-node-body blockquote {
+  margin: 0.2em 0;
+  padding: 0.15em 0 0.15em 0.8em;
+  border-left: 3px solid rgba(0, 0, 0, 0.15);
+  opacity: 0.88;
+}
+
+.text-node-body hr {
+  border: none;
+  border-top: 1px solid rgba(0, 0, 0, 0.12);
+  margin: 0.5em 0;
+}
+
+/* --- Resize handles: visible on hover/selected -------------------------- *
+ * In auto-size mode the wrapper ignores inline width/height, so resize
+ * handles at the right/bottom/corner would sit in the wrong place. Show them
+ * only on hover or when selected, and fade them in so idle nodes stay clean.
+ * The first drag flips the wrapper out of auto-size mode (see CanvasNodeView)
+ * and subsequent drags feel natural. */
 .canvas-node--text .resize-handle {
-  display: none;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+
+.canvas-node--text:hover .resize-handle,
+.canvas-node--text.canvas-node--selected .resize-handle {
+  opacity: 1;
+}
+
+.canvas-node--text .resize-handle--right {
+  top: 4px;
 }
 
 /* --- Color pickers (rendered in the toolbar) ---------------------------- */

--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.css
@@ -125,7 +125,6 @@
   padding: 6px 10px;
   border-radius: var(--radius-md, 6px);
   outline: none;
-  white-space: pre-wrap;
   word-break: break-word;
   overflow-wrap: anywhere;
   line-height: 1.4;
@@ -150,21 +149,29 @@
   box-shadow: 0 0 0 1px rgba(35, 131, 226, 0.35) inset;
 }
 
-.text-node-body:focus {
+/* Tiptap (prosemirror) root — it fills the wrapper, inherits color, and
+ * handles its own caret. Margin-collapse is disabled so a leading <p> sits
+ * flush against the padding edge. */
+.text-node-body .ProseMirror {
   outline: none;
+  white-space: pre-wrap;
+  min-height: 1.4em;
 }
 
-.text-node-body[data-placeholder]:empty::before {
+/* Placeholder rendered by @tiptap/extension-placeholder on the empty
+ * document. Floated so it doesn't push the caret down. */
+.text-node-body .ProseMirror p.is-editor-empty:first-child::before {
   content: attr(data-placeholder);
   color: currentColor;
   opacity: 0.35;
   pointer-events: none;
+  float: left;
+  height: 0;
 }
 
 /* --- Markdown element styles -------------------------------------------- *
- * markdown-it wraps paragraphs in <p>, so we strip the default margins and
- * apply tight spacing that fits a label. Lists, headings, inline formatting
- * use their native semantics. */
+ * tiptap emits clean HTML with no stray whitespace nodes between blocks, so
+ * margins here control spacing directly. */
 .text-node-body p {
   margin: 0;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.tsx
@@ -1,31 +1,37 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import "./index.css";
 import type { CanvasNode, TextNodeData } from "../../types";
 
 interface Props {
   node: CanvasNode;
   onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
+  isSelected: boolean;
+  onSelect: (id: string) => void;
+  onDragStart: (e: React.MouseEvent, node: CanvasNode) => void;
 }
 
 /**
  * TLDRAW-style text node body.
  *
- * Renders a contentEditable plain-text surface. Styling (text color, bg color,
- * font size) is read from `node.data` and persisted via `onUpdate`. The
- * parent CanvasNodeView disables dragging on mousedown inside `.node-body`,
- * so caret placement and selection behave like a normal editor.
+ * UX model:
+ *  - Idle: node reads as pure text on the canvas — no card, no title chrome.
+ *  - Click + drag: moves the node (like tldraw's text shape).
+ *  - Double-click: enters editing mode. Caret appears and keystrokes edit.
+ *  - Blur / Escape / deselect: exits editing mode.
  *
- * The DOM text is only rewritten from props when it differs from the current
- * innerText — otherwise every keystroke would reset the caret to position 0
- * because React re-renders on each `onUpdate`.
+ * The wrapper's width/height are driven by the text body's intrinsic size
+ * (`width: max-content` in CSS). After layout we measure and write the actual
+ * size back to `node.width` / `node.height` so hit-testing, frame containment,
+ * and spatial queries stay in sync with what's rendered.
  */
-export const TextNodeBody = ({ node, onUpdate }: Props) => {
+export const TextNodeBody = ({ node, onUpdate, isSelected, onSelect, onDragStart }: Props) => {
   const data = node.data as TextNodeData;
   const ref = useRef<HTMLDivElement>(null);
+  const [editing, setEditing] = useState(false);
 
-  // Only sync DOM → when external content diverges (e.g. undo/redo, CLI edit,
-  // duplicate). Skipping this when the ref already matches avoids wiping the
-  // user's caret position on every keystroke.
+  // Keep the DOM innerText aligned with `data.content` without clobbering the
+  // caret on every keystroke. We only overwrite when the values diverge — e.g.
+  // after undo/redo, a canvas-cli edit, or a duplicate-paste.
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
@@ -33,6 +39,40 @@ export const TextNodeBody = ({ node, onUpdate }: Props) => {
       el.innerText = data.content;
     }
   }, [data.content]);
+
+  // Auto-size the wrapper to fit the text body. `.canvas-node--text` uses
+  // `width: max-content` in CSS so the rendered size already fits content;
+  // this effect just persists that measurement back to the node model so
+  // Canvas hit-testing / frame containment use the real rendered bounds.
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const w = Math.max(40, Math.ceil(el.offsetWidth));
+    const h = Math.max(28, Math.ceil(el.offsetHeight));
+    if (Math.abs(w - node.width) > 1 || Math.abs(h - node.height) > 1) {
+      onUpdate(node.id, { width: w, height: h });
+    }
+  });
+
+  // First-mount: if the node was just created with empty content, drop
+  // straight into editing mode so typing works immediately.
+  useEffect(() => {
+    if (data.content === "" && ref.current) {
+      setEditing(true);
+      const el = ref.current;
+      const t = setTimeout(() => el.focus(), 0);
+      return () => clearTimeout(t);
+    }
+    return undefined;
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Deselecting exits editing — matches tldraw (clicking away finalizes edit).
+  useEffect(() => {
+    if (!isSelected && editing) {
+      setEditing(false);
+      ref.current?.blur();
+    }
+  }, [isSelected, editing]);
 
   const handleInput = useCallback(
     (e: React.FormEvent<HTMLDivElement>) => {
@@ -44,26 +84,53 @@ export const TextNodeBody = ({ node, onUpdate }: Props) => {
     [node.id, data, onUpdate]
   );
 
-  // Autofocus the editor when the node is first created with empty content,
-  // so typing works immediately without an extra click.
-  useEffect(() => {
-    if (data.content === "" && ref.current) {
-      const el = ref.current;
-      // Defer one tick so the element is attached and any drag/click finishes.
-      const t = setTimeout(() => el.focus(), 0);
-      return () => clearTimeout(t);
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      if (editing) {
+        // In editing mode, mousedown places the caret / starts a selection.
+        // Stop here so the wrapper doesn't try to drag the node.
+        e.stopPropagation();
+        return;
+      }
+      // Not editing → click-drag moves the node, tldraw-style.
+      onSelect(node.id);
+      onDragStart(e, node);
+    },
+    [editing, node, onSelect, onDragStart]
+  );
+
+  const handleDoubleClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    setEditing(true);
+    // contentEditable="true" is applied after the state flush; focus once
+    // it's in the DOM so the caret lands where the user double-clicked.
+    setTimeout(() => ref.current?.focus(), 0);
+  }, []);
+
+  const handleBlur = useCallback(() => {
+    setEditing(false);
+  }, []);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      ref.current?.blur();
+      setEditing(false);
     }
-    return undefined;
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div
       ref={ref}
-      className="text-node-body"
-      contentEditable
+      className={`text-node-body${editing ? " text-node-body--editing" : ""}`}
+      contentEditable={editing}
       suppressContentEditableWarning
       spellCheck={false}
       onInput={handleInput}
+      onMouseDown={handleMouseDown}
+      onDoubleClick={handleDoubleClick}
+      onBlur={handleBlur}
+      onKeyDown={handleKeyDown}
       style={{
         color: data.textColor,
         backgroundColor: data.backgroundColor,
@@ -74,10 +141,8 @@ export const TextNodeBody = ({ node, onUpdate }: Props) => {
   );
 };
 
-/* ---- Color pickers (rendered in header) ---- */
+/* ---- Color pickers (rendered in the hover/selected header) ---- */
 
-// TLDRAW-ish palette for text colors. Black/dark first, then saturated hues,
-// then white for use on dark backgrounds.
 const TEXT_COLOR_PRESETS: Array<{ name: string; value: string }> = [
   { name: "Black", value: "#1f2328" },
   { name: "Gray", value: "#6b7280" },
@@ -90,8 +155,6 @@ const TEXT_COLOR_PRESETS: Array<{ name: string; value: string }> = [
   { name: "White", value: "#ffffff" },
 ];
 
-// Background presets lead with "transparent" (chrome-free label) and follow
-// with soft pastels that read well against the black default text color.
 const BG_COLOR_PRESETS: Array<{ name: string; value: string }> = [
   { name: "None", value: "transparent" },
   { name: "White", value: "#ffffff" },

--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.tsx
@@ -116,20 +116,25 @@ export const TextNodeBody = ({ node, onUpdate, isSelected, onSelect, onDragStart
     }
   }, [isSelected, editing, editor]);
 
-  // Auto-size the wrapper to fit content. Manual-size mode (user has dragged
-  // a resize handle) is authoritative — we don't write anything back, and
-  // .node-body clips any overflow.
+  // Auto-size the wrapper to fit content. Height ALWAYS tracks content so a
+  // text node can never clip or scroll (prosemirror's auto-scroll-into-view
+  // would otherwise push the top of the text off-screen). Width is
+  // content-driven only while `autoSize` is true; once the user drags the
+  // right handle it becomes the authoritative wrap width.
   useLayoutEffect(() => {
-    if (!autoSize) return;
     const el = wrapperRef.current;
     if (!el) return;
     const measuredW = Math.max(40, Math.ceil(el.offsetWidth));
     const measuredH = Math.max(28, Math.ceil(el.offsetHeight));
-    if (
-      Math.abs(measuredW - node.width) > 1 ||
-      Math.abs(measuredH - node.height) > 1
-    ) {
-      onUpdate(node.id, { width: measuredW, height: measuredH });
+    const patch: Partial<CanvasNode> = {};
+    if (autoSize && Math.abs(measuredW - node.width) > 1) {
+      patch.width = measuredW;
+    }
+    if (Math.abs(measuredH - node.height) > 1) {
+      patch.height = measuredH;
+    }
+    if (patch.width !== undefined || patch.height !== undefined) {
+      onUpdate(node.id, patch);
     }
   });
 

--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.tsx
@@ -59,7 +59,13 @@ export const TextNodeBody = ({ node, onUpdate, isSelected, onSelect, onDragStart
       // same as the rest of the app.
       StarterKit.configure({ underline: false }),
       Underline,
-      Placeholder.configure({ placeholder: "Type something…" }),
+      // `showOnlyWhenEditable: false` — an empty text node is otherwise
+      // invisible on the canvas (transparent bg, no chrome). The placeholder
+      // doubles as a "there's a node here" marker at rest.
+      Placeholder.configure({
+        placeholder: "Double-click to edit",
+        showOnlyWhenEditable: false,
+      }),
       Markdown.configure({ html: false, transformPastedText: true }),
     ],
     content: data.content || "",

--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.tsx
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import MarkdownIt from "markdown-it";
+import { EditorContent, useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import Underline from "@tiptap/extension-underline";
+import Placeholder from "@tiptap/extension-placeholder";
+import { Markdown } from "tiptap-markdown";
 import "./index.css";
 import type { CanvasNode, TextNodeData } from "../../types";
 
@@ -12,82 +16,112 @@ interface Props {
 }
 
 /* ---------------------------------------------------------------------------
- * Markdown rendering
+ * TLDRAW-style text node body (tiptap-backed).
  *
- * `html: false` prevents users from injecting raw HTML through the contenteditable
- * surface. `breaks: true` turns a single newline into <br>, which matches what
- * users expect when typing into a plain text box.
- *
- * CommonMark doesn't cover underline, so `++text++` is a small extension handled
- * by a post-process substitution — narrow regex (no line-break, no nested `+`)
- * keeps it from catching `x += y` style text.
- * ------------------------------------------------------------------------- */
-const md = new MarkdownIt({
-  html: false,
-  breaks: true,
-  linkify: false,
-  typographer: false,
-});
-
-const UNDERLINE_RE = /\+\+([^+\n][^\n]*?)\+\+/g;
-
-function renderMarkdown(src: string): string {
-  if (!src) return "";
-  const html = md.render(src);
-  return html.replace(UNDERLINE_RE, "<u>$1</u>");
-}
-
-/* ---------------------------------------------------------------------------
- * TLDRAW-style text node body.
- *
- * UX model:
- *  - Idle: no card chrome. Content renders as formatted markdown on the canvas.
- *  - Click + drag: moves the node.
- *  - Double-click: enters editing. The body swaps to plain-text contenteditable
- *    (raw markdown source) so the user can edit the syntax directly.
- *  - Blur / Escape / deselect: exits editing, re-renders as HTML.
+ * Design:
+ *  - Tiptap gives true WYSIWYG, robust IME handling, and all the markdown
+ *    keyboard shortcuts for free. Content is stored as markdown in
+ *    node.data.content via the `tiptap-markdown` bridge.
+ *  - Idle state: editor is non-editable. Clicks hit our outer wrapper and
+ *    start a drag; the node feels like a label.
+ *  - Editing: double-click flips the editor to editable and focuses it.
+ *    Blur, Escape, or deselection commits the edit.
  *
  * Size:
- *  - When `data.autoSize !== false` (default), CSS `width: max-content` drives
- *    the wrapper's rendered size. useLayoutEffect persists the measured size
- *    back to node.width / node.height so Canvas hit-testing & frame containment
- *    stay accurate.
- *  - When the user drags a resize handle, CanvasNodeView flips `autoSize` to
- *    false. The wrapper honors node.width/height as a fixed frame, text wraps
- *    inside, and overflowing content is clipped by the .node-body. The measure
- *    effect is a no-op in this mode — the user's drag is authoritative.
+ *  - `data.autoSize !== false` (default) → wrapper tracks content via CSS
+ *    `max-content`. useLayoutEffect persists the measured size so Canvas
+ *    hit-testing / frame containment stay in sync.
+ *  - After a resize-handle drag (CanvasNodeView flips `autoSize` to false),
+ *    node.width/height becomes a fixed frame; text wraps inside and the
+ *    .node-body clips overflow.
  * ------------------------------------------------------------------------- */
 export const TextNodeBody = ({ node, onUpdate, isSelected, onSelect, onDragStart }: Props) => {
   const data = node.data as TextNodeData;
   const autoSize = data.autoSize !== false;
-  const ref = useRef<HTMLDivElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const [editing, setEditing] = useState(false);
 
-  // Keep DOM content in sync with `data.content`. Editing shows raw markdown
-  // (innerText), display mode shows rendered HTML (innerHTML). We only write
-  // when the rendered form diverges from what's already there — otherwise every
-  // keystroke would clobber the caret position.
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-    if (editing) {
-      if (el.innerText !== data.content) {
-        el.innerText = data.content;
-      }
-    } else {
-      const html = renderMarkdown(data.content);
-      if (el.innerHTML !== html) {
-        el.innerHTML = html;
-      }
-    }
-  }, [editing, data.content]);
+  // Refs that onUpdate / editor callbacks need without re-registering on every
+  // keystroke. This is the same pattern useFileNodeEditor uses for the note
+  // editor.
+  const dataRef = useRef(data);
+  dataRef.current = data;
+  const nodeIdRef = useRef(node.id);
+  nodeIdRef.current = node.id;
+  const prevContentRef = useRef(data.content);
+  const onUpdateRef = useRef(onUpdate);
+  onUpdateRef.current = onUpdate;
 
-  // Auto-size the wrapper to fit content. In manual mode the user's dragged
-  // dimensions are authoritative, so we don't write anything back — the
-  // .node-body clips any overflow (CSS), matching tldraw's "fixed frame" feel.
+  const editor = useEditor({
+    extensions: [
+      // StarterKit bundles an inline Underline; we swap it for the explicit
+      // extension so keyboard shortcuts (Cmd+U) and serialization behave the
+      // same as the rest of the app.
+      StarterKit.configure({ underline: false }),
+      Underline,
+      Placeholder.configure({ placeholder: "Type something…" }),
+      Markdown.configure({ html: false, transformPastedText: true }),
+    ],
+    content: data.content || "",
+    editable: false,
+    onUpdate: ({ editor }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const md = ((editor.storage as any)?.markdown?.getMarkdown() as string | undefined) ?? "";
+      if (md === dataRef.current.content) return;
+      prevContentRef.current = md;
+      onUpdateRef.current(nodeIdRef.current, {
+        data: { ...dataRef.current, content: md },
+      });
+    },
+    onBlur: () => {
+      setEditing(false);
+    },
+  });
+
+  // Sync the editable flag with our `editing` state. Tiptap's options are
+  // captured once, so we toggle imperatively.
+  useEffect(() => {
+    if (!editor) return;
+    editor.setEditable(editing);
+  }, [editor, editing]);
+
+  // External content change (undo/redo, CLI edit, duplicate-paste) — reset
+  // the editor so it mirrors node.data without clobbering user typing.
+  useEffect(() => {
+    if (!editor) return;
+    if (data.content === prevContentRef.current) return;
+    prevContentRef.current = data.content;
+    // `emitUpdate: false` avoids firing our onUpdate → onUpdate loop.
+    editor.commands.setContent(data.content || "", { emitUpdate: false });
+  }, [editor, data.content]);
+
+  // First-mount: empty-content nodes drop straight into editing so typing
+  // works immediately without an extra double-click.
+  useEffect(() => {
+    if (!editor) return;
+    if (data.content === "") {
+      setEditing(true);
+      // Defer focus until editable=true has applied to the DOM.
+      const t = setTimeout(() => editor.commands.focus(), 0);
+      return () => clearTimeout(t);
+    }
+    return undefined;
+  }, [editor]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Deselection commits the edit — matches tldraw's click-away-to-finalize feel.
+  useEffect(() => {
+    if (!isSelected && editing) {
+      setEditing(false);
+      editor?.commands.blur();
+    }
+  }, [isSelected, editing, editor]);
+
+  // Auto-size the wrapper to fit content. Manual-size mode (user has dragged
+  // a resize handle) is authoritative — we don't write anything back, and
+  // .node-body clips any overflow.
   useLayoutEffect(() => {
     if (!autoSize) return;
-    const el = ref.current;
+    const el = wrapperRef.current;
     if (!el) return;
     const measuredW = Math.max(40, Math.ceil(el.offsetWidth));
     const measuredH = Math.max(28, Math.ceil(el.offsetHeight));
@@ -99,41 +133,11 @@ export const TextNodeBody = ({ node, onUpdate, isSelected, onSelect, onDragStart
     }
   });
 
-  // First mount: empty content → drop straight into editing mode so typing
-  // works immediately. Skipped for nodes that already have content (paste,
-  // duplicate, reload from storage).
-  useEffect(() => {
-    if (data.content === "" && ref.current) {
-      setEditing(true);
-      const el = ref.current;
-      const t = setTimeout(() => el.focus(), 0);
-      return () => clearTimeout(t);
-    }
-    return undefined;
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Deselection finalizes the edit — matches tldraw's click-away-to-commit feel.
-  useEffect(() => {
-    if (!isSelected && editing) {
-      setEditing(false);
-      ref.current?.blur();
-    }
-  }, [isSelected, editing]);
-
-  const handleInput = useCallback(
-    (e: React.FormEvent<HTMLDivElement>) => {
-      const next = e.currentTarget.innerText;
-      if (next !== data.content) {
-        onUpdate(node.id, { data: { ...data, content: next } });
-      }
-    },
-    [node.id, data, onUpdate]
-  );
-
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {
       if (editing) {
-        // Caret placement / text selection — don't drag.
+        // Let prosemirror handle caret placement / text selection; just make
+        // sure the wrapper's drag listeners don't fire.
         e.stopPropagation();
         return;
       }
@@ -143,90 +147,42 @@ export const TextNodeBody = ({ node, onUpdate, isSelected, onSelect, onDragStart
     [editing, node, onSelect, onDragStart]
   );
 
-  const handleDoubleClick = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-    setEditing(true);
-    // contentEditable=true is applied after the state flush; focus once it's
-    // in the DOM so the caret lands where the user double-clicked.
-    setTimeout(() => ref.current?.focus(), 0);
-  }, []);
+  const handleDoubleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (editing) return;
+      setEditing(true);
+      setTimeout(() => editor?.commands.focus(), 0);
+    },
+    [editing, editor]
+  );
 
-  const handleBlur = useCallback(() => {
-    setEditing(false);
-  }, []);
-
-  // Cmd/Ctrl + B / I / U wraps the current selection with a markdown marker
-  // (`**`, `*`, `++`). The wrapping tokens become part of the source text so
-  // markdown-it renders them as <strong>, <em>, <u> once the user exits edit
-  // mode.
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === "Escape") {
         e.preventDefault();
-        ref.current?.blur();
+        editor?.commands.blur();
         setEditing(false);
-        return;
-      }
-      if ((e.metaKey || e.ctrlKey) && !e.altKey) {
-        const key = e.key.toLowerCase();
-        let marker: string | null = null;
-        if (key === "b") marker = "**";
-        else if (key === "i") marker = "*";
-        else if (key === "u") marker = "++";
-        if (marker) {
-          e.preventDefault();
-          const el = ref.current;
-          if (!el) return;
-          const sel = window.getSelection();
-          if (!sel || sel.rangeCount === 0) return;
-          const range = sel.getRangeAt(0);
-          if (!el.contains(range.commonAncestorContainer)) return;
-          const selectedText = range.toString();
-          const wrapped = `${marker}${selectedText}${marker}`;
-          range.deleteContents();
-          const textNode = document.createTextNode(wrapped);
-          range.insertNode(textNode);
-          // Caret placement: if user had a selection, park the caret after
-          // the wrapped text. If empty selection, put it between the markers
-          // so they can start typing the styled text.
-          const after = document.createRange();
-          if (selectedText) {
-            after.setStartAfter(textNode);
-          } else {
-            after.setStart(textNode, marker.length);
-          }
-          after.collapse(true);
-          sel.removeAllRanges();
-          sel.addRange(after);
-          const next = el.innerText;
-          if (next !== data.content) {
-            onUpdate(node.id, { data: { ...data, content: next } });
-          }
-        }
       }
     },
-    [node.id, data, onUpdate]
+    [editor]
   );
 
   return (
     <div
-      ref={ref}
+      ref={wrapperRef}
       className={`text-node-body${editing ? " text-node-body--editing" : ""}`}
-      contentEditable={editing}
-      suppressContentEditableWarning
-      spellCheck={false}
-      onInput={editing ? handleInput : undefined}
       onMouseDown={handleMouseDown}
       onDoubleClick={handleDoubleClick}
-      onBlur={editing ? handleBlur : undefined}
-      onKeyDown={editing ? handleKeyDown : undefined}
+      onKeyDown={handleKeyDown}
       style={{
         color: data.textColor,
         backgroundColor: data.backgroundColor,
         fontSize: data.fontSize ?? 18,
       }}
-      data-placeholder="Type something…"
-    />
+    >
+      <EditorContent editor={editor} />
+    </div>
   );
 };
 
@@ -303,7 +259,12 @@ const TextColorTrigger = ({
       ref={triggerRef}
       className={`text-color-trigger${open ? " text-color-trigger--open" : ""}`}
       title={title}
-      onMouseDown={(e) => e.stopPropagation()}
+      // preventDefault on mousedown keeps the editor focused when the user
+      // reaches for a color while editing — no exit-and-re-enter ceremony.
+      onMouseDown={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
+      }}
     >
       <div
         className={`text-color-dot${isTransparent ? " text-color-dot--transparent" : ""}`}
@@ -332,6 +293,7 @@ const TextColorTrigger = ({
                   backgroundColor: isNone ? undefined : preset.value,
                 }}
                 title={preset.name}
+                onMouseDown={(e) => e.preventDefault()}
                 onClick={(e) => {
                   e.stopPropagation();
                   handlePick(preset.value);

--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.tsx
@@ -1,0 +1,207 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import "./index.css";
+import type { CanvasNode, TextNodeData } from "../../types";
+
+interface Props {
+  node: CanvasNode;
+  onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
+}
+
+/**
+ * TLDRAW-style text node body.
+ *
+ * Renders a contentEditable plain-text surface. Styling (text color, bg color,
+ * font size) is read from `node.data` and persisted via `onUpdate`. The
+ * parent CanvasNodeView disables dragging on mousedown inside `.node-body`,
+ * so caret placement and selection behave like a normal editor.
+ *
+ * The DOM text is only rewritten from props when it differs from the current
+ * innerText — otherwise every keystroke would reset the caret to position 0
+ * because React re-renders on each `onUpdate`.
+ */
+export const TextNodeBody = ({ node, onUpdate }: Props) => {
+  const data = node.data as TextNodeData;
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Only sync DOM → when external content diverges (e.g. undo/redo, CLI edit,
+  // duplicate). Skipping this when the ref already matches avoids wiping the
+  // user's caret position on every keystroke.
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    if (el.innerText !== data.content) {
+      el.innerText = data.content;
+    }
+  }, [data.content]);
+
+  const handleInput = useCallback(
+    (e: React.FormEvent<HTMLDivElement>) => {
+      const next = e.currentTarget.innerText;
+      if (next !== data.content) {
+        onUpdate(node.id, { data: { ...data, content: next } });
+      }
+    },
+    [node.id, data, onUpdate]
+  );
+
+  // Autofocus the editor when the node is first created with empty content,
+  // so typing works immediately without an extra click.
+  useEffect(() => {
+    if (data.content === "" && ref.current) {
+      const el = ref.current;
+      // Defer one tick so the element is attached and any drag/click finishes.
+      const t = setTimeout(() => el.focus(), 0);
+      return () => clearTimeout(t);
+    }
+    return undefined;
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div
+      ref={ref}
+      className="text-node-body"
+      contentEditable
+      suppressContentEditableWarning
+      spellCheck={false}
+      onInput={handleInput}
+      style={{
+        color: data.textColor,
+        backgroundColor: data.backgroundColor,
+        fontSize: data.fontSize ?? 18,
+      }}
+      data-placeholder="Type something…"
+    />
+  );
+};
+
+/* ---- Color pickers (rendered in header) ---- */
+
+// TLDRAW-ish palette for text colors. Black/dark first, then saturated hues,
+// then white for use on dark backgrounds.
+const TEXT_COLOR_PRESETS: Array<{ name: string; value: string }> = [
+  { name: "Black", value: "#1f2328" },
+  { name: "Gray", value: "#6b7280" },
+  { name: "Red", value: "#e03131" },
+  { name: "Orange", value: "#f08c00" },
+  { name: "Yellow", value: "#e8b800" },
+  { name: "Green", value: "#2f9e44" },
+  { name: "Blue", value: "#1c7ed6" },
+  { name: "Purple", value: "#7048e8" },
+  { name: "White", value: "#ffffff" },
+];
+
+// Background presets lead with "transparent" (chrome-free label) and follow
+// with soft pastels that read well against the black default text color.
+const BG_COLOR_PRESETS: Array<{ name: string; value: string }> = [
+  { name: "None", value: "transparent" },
+  { name: "White", value: "#ffffff" },
+  { name: "Gray", value: "#e9ecef" },
+  { name: "Red", value: "#ffe3e3" },
+  { name: "Orange", value: "#ffe8cc" },
+  { name: "Yellow", value: "#fff3bf" },
+  { name: "Green", value: "#d3f9d8" },
+  { name: "Blue", value: "#d0ebff" },
+  { name: "Purple", value: "#e5dbff" },
+];
+
+type PickerKind = "text" | "bg";
+
+const TextColorTrigger = ({
+  node,
+  onUpdate,
+  kind,
+}: {
+  node: CanvasNode;
+  onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
+  kind: PickerKind;
+}) => {
+  const data = node.data as TextNodeData;
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLDivElement>(null);
+
+  const currentValue = kind === "text" ? data.textColor : data.backgroundColor;
+  const presets = kind === "text" ? TEXT_COLOR_PRESETS : BG_COLOR_PRESETS;
+  const title = kind === "text" ? "Text color" : "Background color";
+
+  const handlePick = useCallback(
+    (value: string) => {
+      const patch: Partial<TextNodeData> =
+        kind === "text" ? { textColor: value } : { backgroundColor: value };
+      onUpdate(node.id, { data: { ...data, ...patch } });
+      setOpen(false);
+    },
+    [kind, node.id, data, onUpdate]
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (triggerRef.current && !triggerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  const isTransparent = currentValue === "transparent";
+
+  return (
+    <div
+      ref={triggerRef}
+      className={`text-color-trigger${open ? " text-color-trigger--open" : ""}`}
+      title={title}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      <div
+        className={`text-color-dot${isTransparent ? " text-color-dot--transparent" : ""}`}
+        style={{ backgroundColor: isTransparent ? undefined : currentValue }}
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+      >
+        {kind === "text" && <span className="text-color-dot-glyph">A</span>}
+      </div>
+      {open && (
+        <div className="text-color-popover text-color-popover--open">
+          {presets.map((preset) => {
+            const active = currentValue === preset.value;
+            const isNone = preset.value === "transparent";
+            return (
+              <button
+                key={preset.name}
+                className={
+                  "text-color-swatch" +
+                  (active ? " text-color-swatch--active" : "") +
+                  (isNone ? " text-color-swatch--none" : "")
+                }
+                style={{
+                  backgroundColor: isNone ? undefined : preset.value,
+                }}
+                title={preset.name}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handlePick(preset.value);
+                }}
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const TextColorPicker = ({
+  node,
+  onUpdate,
+}: {
+  node: CanvasNode;
+  onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
+}) => (
+  <>
+    <TextColorTrigger node={node} onUpdate={onUpdate} kind="text" />
+    <TextColorTrigger node={node} onUpdate={onUpdate} kind="bg" />
+  </>
+);

--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import MarkdownIt from "markdown-it";
 import "./index.css";
 import type { CanvasNode, TextNodeData } from "../../types";
 
@@ -10,52 +11,97 @@ interface Props {
   onDragStart: (e: React.MouseEvent, node: CanvasNode) => void;
 }
 
-/**
+/* ---------------------------------------------------------------------------
+ * Markdown rendering
+ *
+ * `html: false` prevents users from injecting raw HTML through the contenteditable
+ * surface. `breaks: true` turns a single newline into <br>, which matches what
+ * users expect when typing into a plain text box.
+ *
+ * CommonMark doesn't cover underline, so `++text++` is a small extension handled
+ * by a post-process substitution — narrow regex (no line-break, no nested `+`)
+ * keeps it from catching `x += y` style text.
+ * ------------------------------------------------------------------------- */
+const md = new MarkdownIt({
+  html: false,
+  breaks: true,
+  linkify: false,
+  typographer: false,
+});
+
+const UNDERLINE_RE = /\+\+([^+\n][^\n]*?)\+\+/g;
+
+function renderMarkdown(src: string): string {
+  if (!src) return "";
+  const html = md.render(src);
+  return html.replace(UNDERLINE_RE, "<u>$1</u>");
+}
+
+/* ---------------------------------------------------------------------------
  * TLDRAW-style text node body.
  *
  * UX model:
- *  - Idle: node reads as pure text on the canvas — no card, no title chrome.
- *  - Click + drag: moves the node (like tldraw's text shape).
- *  - Double-click: enters editing mode. Caret appears and keystrokes edit.
- *  - Blur / Escape / deselect: exits editing mode.
+ *  - Idle: no card chrome. Content renders as formatted markdown on the canvas.
+ *  - Click + drag: moves the node.
+ *  - Double-click: enters editing. The body swaps to plain-text contenteditable
+ *    (raw markdown source) so the user can edit the syntax directly.
+ *  - Blur / Escape / deselect: exits editing, re-renders as HTML.
  *
- * The wrapper's width/height are driven by the text body's intrinsic size
- * (`width: max-content` in CSS). After layout we measure and write the actual
- * size back to `node.width` / `node.height` so hit-testing, frame containment,
- * and spatial queries stay in sync with what's rendered.
- */
+ * Size:
+ *  - When `data.autoSize !== false` (default), CSS `width: max-content` drives
+ *    the wrapper's rendered size. useLayoutEffect persists the measured size
+ *    back to node.width / node.height so Canvas hit-testing & frame containment
+ *    stay accurate.
+ *  - When the user drags a resize handle, CanvasNodeView flips `autoSize` to
+ *    false. The wrapper honors node.width/height as a fixed frame, text wraps
+ *    inside, and overflowing content is clipped by the .node-body. The measure
+ *    effect is a no-op in this mode — the user's drag is authoritative.
+ * ------------------------------------------------------------------------- */
 export const TextNodeBody = ({ node, onUpdate, isSelected, onSelect, onDragStart }: Props) => {
   const data = node.data as TextNodeData;
+  const autoSize = data.autoSize !== false;
   const ref = useRef<HTMLDivElement>(null);
   const [editing, setEditing] = useState(false);
 
-  // Keep the DOM innerText aligned with `data.content` without clobbering the
-  // caret on every keystroke. We only overwrite when the values diverge — e.g.
-  // after undo/redo, a canvas-cli edit, or a duplicate-paste.
+  // Keep DOM content in sync with `data.content`. Editing shows raw markdown
+  // (innerText), display mode shows rendered HTML (innerHTML). We only write
+  // when the rendered form diverges from what's already there — otherwise every
+  // keystroke would clobber the caret position.
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
-    if (el.innerText !== data.content) {
-      el.innerText = data.content;
+    if (editing) {
+      if (el.innerText !== data.content) {
+        el.innerText = data.content;
+      }
+    } else {
+      const html = renderMarkdown(data.content);
+      if (el.innerHTML !== html) {
+        el.innerHTML = html;
+      }
     }
-  }, [data.content]);
+  }, [editing, data.content]);
 
-  // Auto-size the wrapper to fit the text body. `.canvas-node--text` uses
-  // `width: max-content` in CSS so the rendered size already fits content;
-  // this effect just persists that measurement back to the node model so
-  // Canvas hit-testing / frame containment use the real rendered bounds.
+  // Auto-size the wrapper to fit content. In manual mode the user's dragged
+  // dimensions are authoritative, so we don't write anything back — the
+  // .node-body clips any overflow (CSS), matching tldraw's "fixed frame" feel.
   useLayoutEffect(() => {
+    if (!autoSize) return;
     const el = ref.current;
     if (!el) return;
-    const w = Math.max(40, Math.ceil(el.offsetWidth));
-    const h = Math.max(28, Math.ceil(el.offsetHeight));
-    if (Math.abs(w - node.width) > 1 || Math.abs(h - node.height) > 1) {
-      onUpdate(node.id, { width: w, height: h });
+    const measuredW = Math.max(40, Math.ceil(el.offsetWidth));
+    const measuredH = Math.max(28, Math.ceil(el.offsetHeight));
+    if (
+      Math.abs(measuredW - node.width) > 1 ||
+      Math.abs(measuredH - node.height) > 1
+    ) {
+      onUpdate(node.id, { width: measuredW, height: measuredH });
     }
   });
 
-  // First-mount: if the node was just created with empty content, drop
-  // straight into editing mode so typing works immediately.
+  // First mount: empty content → drop straight into editing mode so typing
+  // works immediately. Skipped for nodes that already have content (paste,
+  // duplicate, reload from storage).
   useEffect(() => {
     if (data.content === "" && ref.current) {
       setEditing(true);
@@ -66,7 +112,7 @@ export const TextNodeBody = ({ node, onUpdate, isSelected, onSelect, onDragStart
     return undefined;
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Deselecting exits editing — matches tldraw (clicking away finalizes edit).
+  // Deselection finalizes the edit — matches tldraw's click-away-to-commit feel.
   useEffect(() => {
     if (!isSelected && editing) {
       setEditing(false);
@@ -87,12 +133,10 @@ export const TextNodeBody = ({ node, onUpdate, isSelected, onSelect, onDragStart
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {
       if (editing) {
-        // In editing mode, mousedown places the caret / starts a selection.
-        // Stop here so the wrapper doesn't try to drag the node.
+        // Caret placement / text selection — don't drag.
         e.stopPropagation();
         return;
       }
-      // Not editing → click-drag moves the node, tldraw-style.
       onSelect(node.id);
       onDragStart(e, node);
     },
@@ -102,8 +146,8 @@ export const TextNodeBody = ({ node, onUpdate, isSelected, onSelect, onDragStart
   const handleDoubleClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
     setEditing(true);
-    // contentEditable="true" is applied after the state flush; focus once
-    // it's in the DOM so the caret lands where the user double-clicked.
+    // contentEditable=true is applied after the state flush; focus once it's
+    // in the DOM so the caret lands where the user double-clicked.
     setTimeout(() => ref.current?.focus(), 0);
   }, []);
 
@@ -111,13 +155,58 @@ export const TextNodeBody = ({ node, onUpdate, isSelected, onSelect, onDragStart
     setEditing(false);
   }, []);
 
-  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if (e.key === "Escape") {
-      e.preventDefault();
-      ref.current?.blur();
-      setEditing(false);
-    }
-  }, []);
+  // Cmd/Ctrl + B / I / U wraps the current selection with a markdown marker
+  // (`**`, `*`, `++`). The wrapping tokens become part of the source text so
+  // markdown-it renders them as <strong>, <em>, <u> once the user exits edit
+  // mode.
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        ref.current?.blur();
+        setEditing(false);
+        return;
+      }
+      if ((e.metaKey || e.ctrlKey) && !e.altKey) {
+        const key = e.key.toLowerCase();
+        let marker: string | null = null;
+        if (key === "b") marker = "**";
+        else if (key === "i") marker = "*";
+        else if (key === "u") marker = "++";
+        if (marker) {
+          e.preventDefault();
+          const el = ref.current;
+          if (!el) return;
+          const sel = window.getSelection();
+          if (!sel || sel.rangeCount === 0) return;
+          const range = sel.getRangeAt(0);
+          if (!el.contains(range.commonAncestorContainer)) return;
+          const selectedText = range.toString();
+          const wrapped = `${marker}${selectedText}${marker}`;
+          range.deleteContents();
+          const textNode = document.createTextNode(wrapped);
+          range.insertNode(textNode);
+          // Caret placement: if user had a selection, park the caret after
+          // the wrapped text. If empty selection, put it between the markers
+          // so they can start typing the styled text.
+          const after = document.createRange();
+          if (selectedText) {
+            after.setStartAfter(textNode);
+          } else {
+            after.setStart(textNode, marker.length);
+          }
+          after.collapse(true);
+          sel.removeAllRanges();
+          sel.addRange(after);
+          const next = el.innerText;
+          if (next !== data.content) {
+            onUpdate(node.id, { data: { ...data, content: next } });
+          }
+        }
+      }
+    },
+    [node.id, data, onUpdate]
+  );
 
   return (
     <div
@@ -126,11 +215,11 @@ export const TextNodeBody = ({ node, onUpdate, isSelected, onSelect, onDragStart
       contentEditable={editing}
       suppressContentEditableWarning
       spellCheck={false}
-      onInput={handleInput}
+      onInput={editing ? handleInput : undefined}
       onMouseDown={handleMouseDown}
       onDoubleClick={handleDoubleClick}
-      onBlur={handleBlur}
-      onKeyDown={handleKeyDown}
+      onBlur={editing ? handleBlur : undefined}
+      onKeyDown={editing ? handleKeyDown : undefined}
       style={{
         color: data.textColor,
         backgroundColor: data.backgroundColor,

--- a/apps/canvas-workspace/src/renderer/src/components/icons/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/icons/index.tsx
@@ -187,6 +187,18 @@ export const NodeTypeIcon = ({ type, size = 14, className }: NodeTypeIconProps) 
           />
         </svg>
       );
+    case 'text':
+      // Serif-style "A" drawn as a capital letter glyph to read as "text"
+      return (
+        <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className}>
+          <path
+            d="M3 3h10M8 3v10M6 13h4"
+            stroke="currentColor"
+            strokeWidth="1.3"
+            strokeLinecap="round"
+          />
+        </svg>
+      );
     default:
       return (
         <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className}>

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodeResize.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodeResize.ts
@@ -1,7 +1,7 @@
 import { useCallback, useRef, useState } from "react";
 
-const MIN_WIDTH = 200;
-const MIN_HEIGHT = 120;
+const DEFAULT_MIN_WIDTH = 200;
+const DEFAULT_MIN_HEIGHT = 120;
 
 export const useNodeResize = (
   resizeNode: (id: string, width: number, height: number) => void,
@@ -13,6 +13,8 @@ export const useNodeResize = (
     startY: number;
     startW: number;
     startH: number;
+    minW: number;
+    minH: number;
     edge: ResizeEdge;
   } | null>(null);
   const [resizingId, setResizingId] = useState<string | null>(null);
@@ -23,7 +25,9 @@ export const useNodeResize = (
       nodeId: string,
       width: number,
       height: number,
-      edge: ResizeEdge
+      edge: ResizeEdge,
+      minWidth?: number,
+      minHeight?: number
     ) => {
       if (e.button !== 0) return;
       e.stopPropagation();
@@ -34,6 +38,8 @@ export const useNodeResize = (
         startY: e.clientY,
         startW: width,
         startH: height,
+        minW: minWidth ?? DEFAULT_MIN_WIDTH,
+        minH: minHeight ?? DEFAULT_MIN_HEIGHT,
         edge
       };
       setResizingId(nodeId);
@@ -52,10 +58,10 @@ export const useNodeResize = (
       let newH = r.startH;
 
       if (r.edge === "right" || r.edge === "bottom-right") {
-        newW = Math.max(MIN_WIDTH, r.startW + dx);
+        newW = Math.max(r.minW, r.startW + dx);
       }
       if (r.edge === "bottom" || r.edge === "bottom-right") {
-        newH = Math.max(MIN_HEIGHT, r.startH + dy);
+        newH = Math.max(r.minH, r.startH + dy);
       }
 
       resizeNode(r.id, Math.round(newW), Math.round(newH));

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { CanvasNode, CanvasTransform, CanvasSaveData, FrameNodeData, FileNodeData } from '../types';
+import type { CanvasNode, CanvasTransform, CanvasSaveData, FrameNodeData, FileNodeData, TextNodeData } from '../types';
 import { genId, createDefaultNode, createNodeData } from '../utils/nodeFactory';
 import { useNodeHistory } from './useNodeHistory';
 
@@ -380,7 +380,9 @@ export const useNodes = (
         y: source.y + 24,
         data: source.type === 'frame'
           ? { ...(source.data as FrameNodeData) }
-          : createNodeData(source.type),
+          : source.type === 'text'
+            ? { ...(source.data as TextNodeData) }
+            : createNodeData(source.type),
         updatedAt: Date.now(),
       };
       if (newNode.type === 'file') {
@@ -419,7 +421,9 @@ export const useNodes = (
         y: source.y + offsetY,
         data: source.type === 'frame'
           ? { ...(source.data as FrameNodeData) }
-          : createNodeData(source.type),
+          : source.type === 'text'
+            ? { ...(source.data as TextNodeData) }
+            : createNodeData(source.type),
         updatedAt: now,
       }));
       newNodes.forEach((newNode) => {

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -51,8 +51,18 @@ export interface AgentNodeData {
 
 /**
  * TLDRAW-style free-form text label on the canvas.
- * Content is plain text; colors are applied via inline styles so they persist
- * across reloads. `backgroundColor: 'transparent'` renders a chrome-free label.
+ *
+ * Content is markdown (supports **bold**, *italic*, ++underline++, lists,
+ * headings, etc.). Colors are applied via inline styles so they persist
+ * across reloads. `backgroundColor: 'transparent'` renders a chrome-free
+ * label.
+ *
+ * `autoSize` controls how the wrapper dimensions are interpreted:
+ *  - `true` (default): width/height track the rendered content via CSS
+ *    `max-content`. Useful while typing so the node hugs its text.
+ *  - `false`: the user has manually resized the node; `width`/`height`
+ *    become a hard frame and long text wraps within. Set by the resize
+ *    drag handles.
  */
 export interface TextNodeData {
   content: string;
@@ -60,6 +70,8 @@ export interface TextNodeData {
   backgroundColor: string;
   /** Optional font size in px; defaults to 18 when unset. */
   fontSize?: number;
+  /** When false, the user has dragged a resize handle — respect width/height. */
+  autoSize?: boolean;
 }
 
 export interface CanvasTransform {

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -1,12 +1,17 @@
 export interface CanvasNode {
   id: string;
-  type: "file" | "terminal" | "frame" | "agent";
+  type: "file" | "terminal" | "frame" | "agent" | "text";
   title: string;
   x: number;
   y: number;
   width: number;
   height: number;
-  data: FileNodeData | TerminalNodeData | FrameNodeData | AgentNodeData;
+  data:
+    | FileNodeData
+    | TerminalNodeData
+    | FrameNodeData
+    | AgentNodeData
+    | TextNodeData;
   /** Epoch millis of last mutation; used for cross-process merge. */
   updatedAt?: number;
 }
@@ -42,6 +47,19 @@ export interface AgentNodeData {
   inlinePrompt?: string;
   /** Relative path to a prompt file in cwd for long prompts. */
   promptFile?: string;
+}
+
+/**
+ * TLDRAW-style free-form text label on the canvas.
+ * Content is plain text; colors are applied via inline styles so they persist
+ * across reloads. `backgroundColor: 'transparent'` renders a chrome-free label.
+ */
+export interface TextNodeData {
+  content: string;
+  textColor: string;
+  backgroundColor: string;
+  /** Optional font size in px; defaults to 18 when unset. */
+  fontSize?: number;
 }
 
 export interface CanvasTransform {

--- a/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
@@ -17,7 +17,7 @@ export const createNodeData = (type: CanvasNode['type']): FileNodeData | Termina
     case 'terminal': return { sessionId: '' };
     case 'frame':    return { color: '#9575d4' };
     case 'agent':    return { sessionId: '', agentType: 'claude-code', status: 'idle' };
-    case 'text':     return { content: '', textColor: '#1f2328', backgroundColor: 'transparent', fontSize: 18 };
+    case 'text':     return { content: '', textColor: '#1f2328', backgroundColor: 'transparent', fontSize: 18, autoSize: true };
   }
 };
 

--- a/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
@@ -1,4 +1,4 @@
-import type { CanvasNode, FileNodeData, TerminalNodeData, FrameNodeData, AgentNodeData } from '../types';
+import type { CanvasNode, FileNodeData, TerminalNodeData, FrameNodeData, AgentNodeData, TextNodeData } from '../types';
 
 let nodeIdCounter = 0;
 export const genId = (): string => `node-${Date.now()}-${++nodeIdCounter}`;
@@ -8,14 +8,16 @@ const NODE_DEFAULTS: Record<CanvasNode['type'], { title: string; width: number; 
   terminal: { title: 'Terminal', width: 480, height: 300 },
   frame:    { title: 'Frame',    width: 600, height: 400 },
   agent:    { title: 'Agent',    width: 520, height: 380 },
+  text:     { title: 'Text',     width: 260, height: 120 },
 };
 
-export const createNodeData = (type: CanvasNode['type']): FileNodeData | TerminalNodeData | FrameNodeData | AgentNodeData => {
+export const createNodeData = (type: CanvasNode['type']): FileNodeData | TerminalNodeData | FrameNodeData | AgentNodeData | TextNodeData => {
   switch (type) {
     case 'file':     return { filePath: '', content: '', saved: false, modified: false };
     case 'terminal': return { sessionId: '' };
     case 'frame':    return { color: '#9575d4' };
     case 'agent':    return { sessionId: '', agentType: 'claude-code', status: 'idle' };
+    case 'text':     return { content: '', textColor: '#1f2328', backgroundColor: 'transparent', fontSize: 18 };
   }
 };
 


### PR DESCRIPTION
## Summary
Introduces a new "text" node type to the canvas, enabling free-form text labels with TLDRAW-inspired interaction patterns. Text nodes support inline editing, customizable text and background colors, and auto-sizing based on content.

## Key Changes

- **New TextNodeBody component** (`TextNodeBody/index.tsx`): 
  - Implements TLDRAW-style UX: idle state shows plain text, double-click enters edit mode, blur/Escape exits
  - Auto-sizes wrapper to content using `width: max-content` with `useLayoutEffect` to persist measured dimensions back to node model
  - Syncs DOM `innerText` with `data.content` without clobbering caret during editing
  - Supports click-drag to move nodes when not in edit mode

- **TextColorPicker component**: 
  - Dual color pickers for text color and background color
  - Preset color swatches (9 text colors, 9 background options including transparent)
  - Popover UI with click-outside detection

- **Styling** (`TextNodeBody/index.css`):
  - Minimal card chrome in idle state; compact floating toolbar appears on hover/select
  - Hides title badge and resize handles (text auto-sizes from content)
  - Toolbar scales with canvas zoom using CSS transform trick
  - Placeholder text "Type something…" appears when empty

- **Type system updates** (`types.ts`):
  - Added `TextNodeData` interface with `content`, `textColor`, `backgroundColor`, and optional `fontSize`
  - Updated `CanvasNode` type union to include text nodes

- **Integration across components**:
  - Updated `Canvas`, `CanvasNodeView`, `FloatingToolbar`, `NodeContextMenu`, `SearchPalette` to support text node creation and rendering
  - Added text node icon (stylized "A") to node type indicators
  - Text content is searchable in the search palette

- **Backend support** (`canvas-agent/tools.ts`):
  - Added text to `NodeType` enum and default dimensions
  - Updated create-node tool schema and documentation to support text nodes with color/font customization

## Implementation Details

- Text nodes use `contentEditable="true"` only during edit mode to avoid constant DOM mutations
- Content syncing uses `innerText` comparison to avoid overwriting during active editing
- Auto-sizing uses `useLayoutEffect` (not `useEffect`) to measure and update dimensions synchronously before paint
- Color values persist as inline styles in node data (hex colors or "transparent" string)
- Toolbar positioning uses `position: absolute; top: -36px` with scale transform to stay readable at any zoom level

https://claude.ai/code/session_01FnKBQHB7gL7pnMc8qshjWE