### PR TITLE
Add iframe node type to embed external web pages on canvas

### DIFF
--- a/apps/canvas-workspace/src/main/canvas-agent/context-builder.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/context-builder.ts
@@ -96,6 +96,9 @@ function summarizeNode(node: CanvasNode): NodeSummary {
       summary.color = (node.data.color as string) || undefined;
       summary.label = (node.data.label as string) || undefined;
       break;
+    case 'iframe':
+      summary.url = (node.data.url as string) || undefined;
+      break;
   }
 
   return summary;
@@ -288,6 +291,15 @@ export function formatSummaryForPrompt(summary: WorkspaceSummary): string {
       const info = `${n.agentType ?? 'unknown'}, ${n.status ?? 'idle'}`;
       const cwdHint = n.path ? `, cwd: ${n.path}` : '';
       lines.push(`- [${n.id}] **${n.title}** (${info}${cwdHint})`);
+    }
+    lines.push('');
+  }
+
+  if (byType.iframe?.length) {
+    lines.push('## Link Nodes');
+    for (const n of byType.iframe) {
+      const urlHint = n.url ? ` — ${n.url}` : ' (empty)';
+      lines.push(`- [${n.id}] **${n.title}**${urlHint}`);
     }
     lines.push('');
   }

--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -26,7 +26,7 @@ const STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
 
 // ─── Types mirrored from canvas-cli ────────────────────────────────
 
-type NodeType = 'file' | 'terminal' | 'frame' | 'agent' | 'text';
+type NodeType = 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe';
 
 interface CanvasNode {
   id: string;
@@ -52,6 +52,7 @@ const DEFAULT_DIMENSIONS: Record<NodeType, { title: string; width: number; heigh
   frame: { title: 'Frame', width: 600, height: 400 },
   agent: { title: 'Agent', width: 520, height: 380 },
   text: { title: 'Text', width: 260, height: 120 },
+  iframe: { title: 'Web', width: 520, height: 400 },
 };
 
 // ─── Helpers ───────────────────────────────────────────────────────
@@ -234,9 +235,11 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
         'to the agent as its initial prompt. Include relevant canvas content so the agent knows the context. ' +
         'Optional `data.agentArgs` overrides the auto-generated CLI arguments.\n' +
         '- **text**: Creates a free-form text label (TLDRAW-style). Use `content` for the text body, ' +
-        'and `data.textColor` / `data.backgroundColor` (hex or "transparent") for styling. Optional `data.fontSize`.',
+        'and `data.textColor` / `data.backgroundColor` (hex or "transparent") for styling. Optional `data.fontSize`.\n' +
+        '- **iframe**: Embeds an external web page on the canvas. Pass `data.url` with the full URL (including protocol). ' +
+        'Note: some sites block embedding via X-Frame-Options / CSP.',
       inputSchema: z.object({
-        type: z.enum(['file', 'terminal', 'frame', 'agent', 'text']).describe('Node type.'),
+        type: z.enum(['file', 'terminal', 'frame', 'agent', 'text', 'iframe']).describe('Node type.'),
         title: z.string().optional().describe('Node title.'),
         content: z.string().optional().describe('Initial content (for file and text nodes).'),
         x: z.number().optional().describe('X position (auto-placed if omitted).'),
@@ -246,7 +249,8 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
           '- terminal: { cwd?: string }\n' +
           '- agent: { agentType?: "claude-code"|"codex"|"pulse-coder", cwd?: string, status?: "idle"|"running", prompt?: string, agentArgs?: string }\n' +
           '- frame: { color?: string, label?: string }\n' +
-          '- text: { textColor?: string, backgroundColor?: string, fontSize?: number }',
+          '- text: { textColor?: string, backgroundColor?: string, fontSize?: number }\n' +
+          '- iframe: { url: string }',
         ),
       }),
       execute: async (input) => {
@@ -318,6 +322,11 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
               textColor: (extraData.textColor as string) ?? '#1f2328',
               backgroundColor: (extraData.backgroundColor as string) ?? 'transparent',
               fontSize: (extraData.fontSize as number) ?? 18,
+            };
+            break;
+          case 'iframe':
+            nodeData = {
+              url: (extraData.url as string) ?? '',
             };
             break;
         }

--- a/apps/canvas-workspace/src/main/canvas-agent/types.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/types.ts
@@ -48,6 +48,8 @@ export interface NodeSummary {
   color?: string;
   /** Frame label for frame nodes. */
   label?: string;
+  /** Embedded URL for iframe nodes. */
+  url?: string;
 }
 
 export interface WorkspaceSummary {

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
@@ -18,10 +18,10 @@ interface CanvasOverlaysProps {
   scale: number;
   chatPanelOpen?: boolean;
   onChatToggle?: () => void;
-  onCreateNode: (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text') => void;
+  onCreateNode: (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe') => void;
   onCloseContextMenu: () => void;
   onToolChange: (tool: string) => void;
-  onAddNode: (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text') => void;
+  onAddNode: (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe') => void;
   onResetTransform: () => void;
   onSearchSelect: (node: CanvasNode) => void;
   onCloseSearch: () => void;

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -170,7 +170,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
   );
 
   const handleCreateNode = useCallback(
-    (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text') => {
+    (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe') => {
       if (!contextMenu) return;
       const node = addNode(type, contextMenu.canvasX, contextMenu.canvasY);
       setSelectedNodeIds([node.id]);
@@ -180,7 +180,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
   );
 
   const handleToolbarAddNode = useCallback(
-    (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text') => {
+    (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe') => {
       if (!containerRef.current) return;
       const rect = containerRef.current.getBoundingClientRect();
       const pos = screenToCanvas(rect.left + rect.width / 2, rect.top + rect.height / 2, containerRef.current);
@@ -189,10 +189,12 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
         : type === 'terminal' ? 240
         : type === 'agent' ? 260
         : type === 'text' ? 130
+        : type === 'iframe' ? 260
         : 300;
       const halfH =
         type === 'frame' ? 200
         : type === 'text' ? 60
+        : type === 'iframe' ? 200
         : 150;
       const node = addNode(type, pos.x - halfW, pos.y - halfH);
       setSelectedNodeIds([node.id]);

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -113,6 +113,10 @@
   color: #7c5cff;
 }
 
+.node-type-badge--iframe {
+  color: var(--text-muted);
+}
+
 .node-title {
   flex: 1;
   font-size: 13px;

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -7,6 +7,7 @@ import { TerminalNodeBody } from "../TerminalNodeBody";
 import { FrameNodeBody, FrameColorPicker } from "../FrameNodeBody";
 import { AgentNodeBody } from "../AgentNodeBody";
 import { TextNodeBody, TextColorPicker } from "../TextNodeBody";
+import { IframeNodeBody } from "../IframeNodeBody";
 
 interface Props {
   node: CanvasNode;
@@ -168,6 +169,11 @@ export const CanvasNodeView = ({
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
               <path d="M3 4h10M8 4v9M6 13h4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
             </svg>
+          ) : node.type === "iframe" ? (
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+              <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.3" />
+              <path d="M2 8h12M8 2c2 2 2 10 0 12M8 2c-2 2-2 10 0 12" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" />
+            </svg>
           ) : (
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
               <circle cx="8" cy="5.5" r="3" stroke="currentColor" strokeWidth="1.3" />
@@ -225,6 +231,8 @@ export const CanvasNodeView = ({
             onSelect={onSelect}
             onDragStart={onDragStart}
           />
+        ) : node.type === "iframe" ? (
+          <IframeNodeBody node={node} onUpdate={onUpdate} />
         ) : (
           <AgentNodeBody node={node} allNodes={allNodes} rootFolder={rootFolder} workspaceId={workspaceId} workspaceName={workspaceName} onUpdate={onUpdate} />
         )}

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.css
@@ -34,14 +34,23 @@
   background: transparent;
   border-radius: var(--radius);
   cursor: pointer;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 4px;
   padding: 0 8px;
   color: var(--text-secondary);
   font-size: 12px;
+  line-height: 1;
   transition: background 0.1s, color 0.1s;
+}
+
+/* Make the SVG a block so its baseline gap doesn't misalign against the
+   text label; without this, inline SVGs sit on the text baseline and the
+   glyph reads a pixel or two low next to the label. */
+.toolbar-btn svg {
+  display: block;
+  flex-shrink: 0;
 }
 
 .toolbar-btn:hover {
@@ -66,4 +75,9 @@
 .toolbar-btn-label {
   font-size: 12px;
   font-weight: 500;
+  line-height: 1;
+  /* Labels are set in the app's default sans stack, which on macOS sits
+     ~0.5px above the optical center of the 18px icons. A hairline nudge
+     brings the cap-height of the text in line with the icon midline. */
+  transform: translateY(0.5px);
 }

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
@@ -3,7 +3,7 @@ import './index.css';
 interface Props {
   activeTool: string;
   onToolChange: (tool: string) => void;
-  onAddNode: (type: "file" | "terminal" | "frame" | "agent" | "text") => void;
+  onAddNode: (type: "file" | "terminal" | "frame" | "agent" | "text" | "iframe") => void;
   chatPanelOpen?: boolean;
   onChatToggle?: () => void;
 }
@@ -90,6 +90,19 @@ export const FloatingToolbar = ({
       <div className="toolbar-group">
         <button
           className="toolbar-btn toolbar-btn--create"
+          onClick={() => onAddNode("text")}
+          title="Add Text"
+        >
+          <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+            <path
+              d="M4 5h10M9 5v9M7 14h4"
+              stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"
+            />
+          </svg>
+          <span className="toolbar-btn-label">Text</span>
+        </button>
+        <button
+          className="toolbar-btn toolbar-btn--create"
           onClick={() => onAddNode("file")}
           title="Add Note Card"
         >
@@ -141,16 +154,17 @@ export const FloatingToolbar = ({
         </button>
         <button
           className="toolbar-btn toolbar-btn--create"
-          onClick={() => onAddNode("text")}
-          title="Add Text"
+          onClick={() => onAddNode("iframe")}
+          title="Add Link (embed a web page)"
         >
           <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+            <circle cx="9" cy="9" r="6.5" stroke="currentColor" strokeWidth="1.3" />
             <path
-              d="M4 5h10M9 5v9M7 14h4"
-              stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"
+              d="M2.5 9h13M9 2.5c2.2 2.2 2.2 10.8 0 13M9 2.5c-2.2 2.2-2.2 10.8 0 13"
+              stroke="currentColor" strokeWidth="1.2" strokeLinecap="round"
             />
           </svg>
-          <span className="toolbar-btn-label">Text</span>
+          <span className="toolbar-btn-label">Link</span>
         </button>
         <button
           className="toolbar-btn toolbar-btn--create"

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.css
@@ -1,0 +1,157 @@
+.iframe-body {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background: var(--surface);
+}
+
+.iframe-bar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 6px;
+  border-bottom: 1px solid var(--border-light);
+  background: var(--surface);
+  flex-shrink: 0;
+}
+
+.iframe-bar-btn {
+  width: 22px;
+  height: 22px;
+  border: none;
+  background: transparent;
+  border-radius: 4px;
+  color: var(--text-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background 0.1s, color 0.1s;
+}
+
+.iframe-bar-btn:hover {
+  background: rgba(0, 0, 0, 0.05);
+  color: var(--text);
+}
+
+.iframe-bar-url {
+  flex: 1;
+  min-width: 0;
+  height: 22px;
+  border: 1px solid var(--border);
+  background: var(--surface-subtle, rgba(0, 0, 0, 0.02));
+  border-radius: 4px;
+  padding: 0 8px;
+  text-align: left;
+  cursor: text;
+  font-size: 11px;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  transition: border-color 0.1s, background 0.1s;
+}
+
+.iframe-bar-url:hover {
+  border-color: var(--accent-border);
+  background: var(--surface);
+  color: var(--text);
+}
+
+.iframe-bar-url-text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.iframe-frame {
+  flex: 1;
+  width: 100%;
+  border: none;
+  background: #fff;
+}
+
+/* Empty state — URL input */
+
+.iframe-body--empty {
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+
+.iframe-empty-inner {
+  width: 100%;
+  max-width: 340px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.iframe-empty-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.iframe-empty-input {
+  width: 100%;
+  height: 32px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0 10px;
+  font-size: 13px;
+  color: var(--text);
+  outline: none;
+  transition: border-color 0.1s, box-shadow 0.1s;
+  background: var(--surface);
+}
+
+.iframe-empty-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(35, 131, 226, 0.15);
+}
+
+.iframe-empty-actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+}
+
+.iframe-empty-btn {
+  height: 26px;
+  padding: 0 12px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.1s, border-color 0.1s;
+}
+
+.iframe-empty-btn:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.iframe-empty-btn--primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.iframe-empty-btn--primary:hover {
+  background: var(--accent);
+  opacity: 0.9;
+}
+
+.iframe-empty-btn--primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.iframe-empty-hint {
+  font-size: 11px;
+  color: var(--text-muted);
+}

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.tsx
@@ -1,0 +1,198 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import "./index.css";
+import type { CanvasNode, IframeNodeData } from "../../types";
+
+interface Props {
+  node: CanvasNode;
+  onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
+}
+
+/**
+ * Renders an external web page in an <iframe>.
+ *
+ * - Empty URL → show a URL input as the placeholder state.
+ * - Loaded URL → show a compact address bar + iframe. The address bar can be
+ *   toggled into edit mode to change the URL, opened externally, or reloaded.
+ *
+ * Notes:
+ * - Some sites refuse to be embedded (X-Frame-Options / CSP frame-ancestors).
+ *   The iframe will render empty in that case; the "open externally" button
+ *   is the escape hatch.
+ * - `sandbox` is intentionally permissive so common sites (docs, dashboards)
+ *   actually work. Electron's renderer still isolates the iframe from the
+ *   host via contextIsolation.
+ */
+export const IframeNodeBody = ({ node, onUpdate }: Props) => {
+  const data = node.data as IframeNodeData;
+  const url = data.url ?? "";
+  const [editing, setEditing] = useState(!url);
+  const [draft, setDraft] = useState(url);
+  const [iframeKey, setIframeKey] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Keep the draft in sync when the URL is changed externally (undo/redo,
+  // CLI edits, etc.) so the address bar doesn't show stale text.
+  useEffect(() => {
+    setDraft(url);
+  }, [url]);
+
+  // Autofocus the input whenever we enter editing mode.
+  useEffect(() => {
+    if (editing) {
+      const t = setTimeout(() => inputRef.current?.select(), 0);
+      return () => clearTimeout(t);
+    }
+    return undefined;
+  }, [editing]);
+
+  const commit = useCallback(() => {
+    const next = normalizeUrl(draft.trim());
+    if (next === url) {
+      setEditing(false);
+      return;
+    }
+    onUpdate(node.id, {
+      data: { ...data, url: next },
+      title: next ? prettyTitle(next) : node.title,
+    });
+    setEditing(false);
+  }, [draft, url, onUpdate, node.id, node.title, data]);
+
+  const cancel = useCallback(() => {
+    setDraft(url);
+    setEditing(false);
+  }, [url]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        commit();
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        cancel();
+      }
+    },
+    [commit, cancel],
+  );
+
+  const handleOpenExternal = useCallback(() => {
+    if (!url) return;
+    window.open(url, "_blank", "noopener,noreferrer");
+  }, [url]);
+
+  const handleReload = useCallback(() => {
+    setIframeKey((k) => k + 1);
+  }, []);
+
+  if (editing) {
+    return (
+      <div className="iframe-body iframe-body--empty">
+        <div className="iframe-empty-inner">
+          <div className="iframe-empty-label">Embed a web page</div>
+          <input
+            ref={inputRef}
+            className="iframe-empty-input"
+            type="url"
+            value={draft}
+            placeholder="https://example.com"
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={handleKeyDown}
+            spellCheck={false}
+          />
+          <div className="iframe-empty-actions">
+            {url && (
+              <button className="iframe-empty-btn" onClick={cancel}>
+                Cancel
+              </button>
+            )}
+            <button
+              className="iframe-empty-btn iframe-empty-btn--primary"
+              onClick={commit}
+              disabled={!draft.trim()}
+            >
+              Load
+            </button>
+          </div>
+          <div className="iframe-empty-hint">
+            Some sites block embedding — use "Open externally" to fall back to a browser.
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="iframe-body">
+      <div className="iframe-bar">
+        <button
+          className="iframe-bar-btn"
+          onClick={handleReload}
+          title="Reload"
+        >
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <path
+              d="M2 6a4 4 0 016.9-2.8L10 4M10 2v2.5H7.5M10 6a4 4 0 01-6.9 2.8L2 8M2 10V7.5h2.5"
+              stroke="currentColor"
+              strokeWidth="1.2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+        <button
+          className="iframe-bar-url"
+          onClick={() => setEditing(true)}
+          title="Edit URL"
+        >
+          <span className="iframe-bar-url-text">{url}</span>
+        </button>
+        <button
+          className="iframe-bar-btn"
+          onClick={handleOpenExternal}
+          title="Open externally"
+        >
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <path
+              d="M5 2H2.5A.5.5 0 002 2.5v7A.5.5 0 002.5 10h7a.5.5 0 00.5-.5V7M7 2h3v3M5.5 6.5L10 2"
+              stroke="currentColor"
+              strokeWidth="1.2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
+      <iframe
+        key={iframeKey}
+        className="iframe-frame"
+        src={url}
+        title={node.title}
+        sandbox="allow-scripts allow-forms allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+        referrerPolicy="no-referrer"
+      />
+    </div>
+  );
+};
+
+/**
+ * Add a protocol if the user typed a bare host, and strip any whitespace the
+ * paste picked up. We don't try to rewrite anything more aggressive — if the
+ * user typed nonsense the iframe will surface the failure.
+ */
+function normalizeUrl(input: string): string {
+  if (!input) return "";
+  if (/^[a-z]+:\/\//i.test(input)) return input;
+  if (/^\/\//.test(input)) return `https:${input}`;
+  return `https://${input}`;
+}
+
+/** Use the host as the default title so the header is meaningful at a glance. */
+function prettyTitle(url: string): string {
+  try {
+    const u = new URL(url);
+    return u.host || url;
+  } catch {
+    return url;
+  }
+}

--- a/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from "react";
 interface Props {
   x: number;
   y: number;
-  onCreate: (type: "file" | "terminal" | "frame" | "agent" | "text") => void;
+  onCreate: (type: "file" | "terminal" | "frame" | "agent" | "text" | "iframe") => void;
   onClose: () => void;
 }
 
@@ -44,6 +44,16 @@ export const NodeContextMenu = ({ x, y, onCreate, onClose }: Props) => {
       <div className="context-menu-title">Create Node</div>
       <button
         className="context-menu-item"
+        onClick={() => onCreate("text")}
+      >
+        <span className="context-menu-icon">{"\u0041"}</span>
+        <span className="context-menu-label">
+          <strong>Text</strong>
+          <small>Free-form text label</small>
+        </span>
+      </button>
+      <button
+        className="context-menu-item"
         onClick={() => onCreate("file")}
       >
         <span className="context-menu-icon">{"\u2756"}</span>
@@ -74,12 +84,12 @@ export const NodeContextMenu = ({ x, y, onCreate, onClose }: Props) => {
       </button>
       <button
         className="context-menu-item"
-        onClick={() => onCreate("text")}
+        onClick={() => onCreate("iframe")}
       >
-        <span className="context-menu-icon">{"\u0041"}</span>
+        <span className="context-menu-icon">{"\u232C"}</span>
         <span className="context-menu-label">
-          <strong>Text</strong>
-          <small>Free-form text label</small>
+          <strong>Link</strong>
+          <small>Embed a web page</small>
         </span>
       </button>
       <button

--- a/apps/canvas-workspace/src/renderer/src/components/icons/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/icons/index.tsx
@@ -199,6 +199,19 @@ export const NodeTypeIcon = ({ type, size = 14, className }: NodeTypeIconProps) 
           />
         </svg>
       );
+    case 'iframe':
+      // Globe — evokes "web page"
+      return (
+        <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className}>
+          <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.3" />
+          <path
+            d="M2 8h12M8 2c2 2 2 10 0 12M8 2c-2 2-2 10 0 12"
+            stroke="currentColor"
+            strokeWidth="1.1"
+            strokeLinecap="round"
+          />
+        </svg>
+      );
     default:
       return (
         <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className}>

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -1,6 +1,6 @@
 export interface CanvasNode {
   id: string;
-  type: "file" | "terminal" | "frame" | "agent" | "text";
+  type: "file" | "terminal" | "frame" | "agent" | "text" | "iframe";
   title: string;
   x: number;
   y: number;
@@ -11,7 +11,8 @@ export interface CanvasNode {
     | TerminalNodeData
     | FrameNodeData
     | AgentNodeData
-    | TextNodeData;
+    | TextNodeData
+    | IframeNodeData;
   /** Epoch millis of last mutation; used for cross-process merge. */
   updatedAt?: number;
 }
@@ -72,6 +73,16 @@ export interface TextNodeData {
   fontSize?: number;
   /** When false, the user has dragged a resize handle — respect width/height. */
   autoSize?: boolean;
+}
+
+/**
+ * Embeds an external web page via an <iframe>. Some sites block embedding
+ * via X-Frame-Options / CSP frame-ancestors — those will fail to render and
+ * the user can click "Open externally" to escape into the system browser.
+ */
+export interface IframeNodeData {
+  /** Full URL (including protocol) to load in the iframe. Empty = show URL input. */
+  url: string;
 }
 
 export interface CanvasTransform {

--- a/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
@@ -1,4 +1,4 @@
-import type { CanvasNode, FileNodeData, TerminalNodeData, FrameNodeData, AgentNodeData, TextNodeData } from '../types';
+import type { CanvasNode, FileNodeData, TerminalNodeData, FrameNodeData, AgentNodeData, TextNodeData, IframeNodeData } from '../types';
 
 let nodeIdCounter = 0;
 export const genId = (): string => `node-${Date.now()}-${++nodeIdCounter}`;
@@ -9,15 +9,17 @@ const NODE_DEFAULTS: Record<CanvasNode['type'], { title: string; width: number; 
   frame:    { title: 'Frame',    width: 600, height: 400 },
   agent:    { title: 'Agent',    width: 520, height: 380 },
   text:     { title: 'Text',     width: 260, height: 120 },
+  iframe:   { title: 'Web',      width: 520, height: 400 },
 };
 
-export const createNodeData = (type: CanvasNode['type']): FileNodeData | TerminalNodeData | FrameNodeData | AgentNodeData | TextNodeData => {
+export const createNodeData = (type: CanvasNode['type']): FileNodeData | TerminalNodeData | FrameNodeData | AgentNodeData | TextNodeData | IframeNodeData => {
   switch (type) {
     case 'file':     return { filePath: '', content: '', saved: false, modified: false };
     case 'terminal': return { sessionId: '' };
     case 'frame':    return { color: '#9575d4' };
     case 'agent':    return { sessionId: '', agentType: 'claude-code', status: 'idle' };
     case 'text':     return { content: '', textColor: '#1f2328', backgroundColor: 'transparent', fontSize: 18, autoSize: true };
+    case 'iframe':   return { url: '' };
   }
 };
 


### PR DESCRIPTION
## Summary
Adds a new "iframe" node type that allows users to embed external web pages directly on the canvas. This includes a full UI for managing embedded URLs with an address bar, reload functionality, and fallback options for sites that block embedding.

## Key Changes

- **New IframeNodeBody component** (`IframeNodeBody/index.tsx`): 
  - Renders an `<iframe>` with a compact address bar for managing the embedded URL
  - Shows a URL input placeholder when empty
  - Supports editing, reloading, and opening URLs externally
  - Includes URL normalization (auto-adds `https://` protocol if missing)
  - Auto-generates node titles from the host domain
  - Handles sites that block embedding via X-Frame-Options/CSP with graceful fallback

- **UI Integration**:
  - Added "Link" button to FloatingToolbar and NodeContextMenu to create iframe nodes
  - Added globe icon for iframe node type in NodeTypeIcon
  - Updated toolbar button styling to fix SVG/text alignment issues
  - Added iframe node type badge styling

- **Type System Updates**:
  - Added `IframeNodeData` interface with `url` field to `types.ts`
  - Updated all node type unions to include `"iframe"`
  - Updated node factory defaults with iframe dimensions (520×400)

- **Backend Integration**:
  - Updated canvas-agent tools to support iframe node creation
  - Added iframe node summarization in context-builder for AI agent awareness
  - Updated tool documentation to describe iframe node capabilities

- **Styling** (`IframeNodeBody/index.css`):
  - Compact address bar with reload and external open buttons
  - Empty state with centered URL input form
  - Responsive iframe container with proper flex layout
  - Consistent theming using canvas design tokens

## Implementation Details

- The iframe uses a permissive sandbox configuration (`allow-scripts allow-forms allow-same-origin allow-popups`) to support common embedded content (docs, dashboards) while still being isolated by Electron's contextIsolation
- URL normalization intelligently handles bare hosts, protocol-relative URLs, and full URLs
- The component maintains draft state separately from committed state to support cancellation
- Reload functionality uses a key-based approach to force iframe remounting
- External open uses `window.open()` with `noopener,noreferrer` for security

https://claude.ai/code/session_01UdtxjEcgR9KoV8ZzvaJjsy