### PR TITLE
Optimize canvas performance by conditionally applying will-change

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
@@ -6,6 +6,13 @@ import type { ResizeEdge } from '../../hooks/useNodeResize';
 interface CanvasSurfaceProps {
   transform: { x: number; y: number; scale: number };
   animating: boolean;
+  /** True while the user is actively panning/zooming. Drives conditional
+   *  `will-change: transform` so the canvas subtree is only promoted to
+   *  its own compositor layer while it's actually moving — avoiding the
+   *  permanent tile-memory cost that otherwise trips Chromium's
+   *  "tile memory limits exceeded" warning on canvases with many
+   *  (especially nested) frames. */
+  moving: boolean;
   sortedNodes: CanvasNode[];
   nodes: CanvasNode[];
   rootFolder?: string;
@@ -38,6 +45,7 @@ interface CanvasSurfaceProps {
 export const CanvasSurface = ({
   transform,
   animating,
+  moving,
   sortedNodes,
   nodes,
   rootFolder,
@@ -57,7 +65,7 @@ export const CanvasSurface = ({
   onFocus,
 }: CanvasSurfaceProps) => (
   <div
-    className="canvas-transform"
+    className={`canvas-transform${moving || animating ? ' canvas-transform--moving' : ''}`}
     style={{
       transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`,
       '--canvas-scale': transform.scale,

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.css
@@ -32,5 +32,14 @@
   top: 0;
   left: 0;
   transform-origin: 0 0;
+}
+
+/* Only promote the canvas subtree to its own compositor layer while the
+ * user is actively panning or zooming. Leaving `will-change: transform`
+ * on permanently keeps a huge, always-allocated tile backing store for the
+ * entire canvas content — which easily blows Chromium's tile memory budget
+ * once nested frames multiply the painted surface area (emits
+ * "tile memory limits exceeded, some content may not draw" warnings). */
+.canvas-transform--moving {
   will-change: transform;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -32,6 +32,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
   const {
     transform,
     setTransform,
+    moving,
     handleWheel,
     handleMouseDown: canvasMouseDown,
     handleMouseMove: canvasMouseMove,
@@ -276,6 +277,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
       <CanvasSurface
         transform={transform}
         animating={animating}
+        moving={moving}
         sortedNodes={sortedNodes}
         nodes={nodes}
         rootFolder={rootFolder}

--- a/apps/canvas-workspace/src/renderer/src/hooks/useCanvas.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useCanvas.ts
@@ -1,9 +1,13 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { CanvasTransform } from "../types";
 
 const MIN_SCALE = 0.1;
 const MAX_SCALE = 4;
 const ZOOM_SENSITIVITY = 0.005;
+/** Idle delay after the last wheel/pan event before we drop `will-change`
+ *  off `.canvas-transform`. Short enough to feel instant, long enough to
+ *  cover the gap between two wheel events from a trackpad. */
+const MOVING_IDLE_MS = 180;
 
 const clampScale = (s: number) =>
   Math.min(MAX_SCALE, Math.max(MIN_SCALE, s));
@@ -21,7 +25,32 @@ export const useCanvas = (isHandTool = false) => {
   const isPanning = useRef(false);
   const lastMouse = useRef({ x: 0, y: 0 });
 
+  // Tracks whether the canvas is currently being panned/zoomed. Drives
+  // the conditional `will-change: transform` on `.canvas-transform` so
+  // we only promote the big canvas subtree to its own compositor layer
+  // while it's actually moving — otherwise the permanent layer consumes
+  // enough tile memory to trigger Chromium's "tile memory limits
+  // exceeded" warning once nested frames multiply the painted area.
+  const [moving, setMoving] = useState(false);
+  const movingTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const markMoving = useCallback(() => {
+    setMoving(true);
+    if (movingTimer.current) clearTimeout(movingTimer.current);
+    movingTimer.current = setTimeout(() => {
+      setMoving(false);
+      movingTimer.current = null;
+    }, MOVING_IDLE_MS);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (movingTimer.current) clearTimeout(movingTimer.current);
+    };
+  }, []);
+
   const handleWheel = useCallback((e: React.WheelEvent) => {
+    markMoving();
     if (e.ctrlKey || e.metaKey) {
       e.preventDefault();
       e.stopPropagation();
@@ -48,7 +77,7 @@ export const useCanvas = (isHandTool = false) => {
         y: safeNum(prev.y - dy)
       }));
     }
-  }, []);
+  }, [markMoving]);
 
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {
@@ -59,10 +88,11 @@ export const useCanvas = (isHandTool = false) => {
       ) {
         isPanning.current = true;
         lastMouse.current = { x: e.clientX, y: e.clientY };
+        markMoving();
         e.preventDefault();
       }
     },
-    [isHandTool]
+    [isHandTool, markMoving]
   );
 
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
@@ -70,12 +100,13 @@ export const useCanvas = (isHandTool = false) => {
     const dx = e.clientX - lastMouse.current.x;
     const dy = e.clientY - lastMouse.current.y;
     lastMouse.current = { x: e.clientX, y: e.clientY };
+    markMoving();
     setTransform((prev) => ({
       ...prev,
       x: safeNum(prev.x + dx),
       y: safeNum(prev.y + dy)
     }));
-  }, []);
+  }, [markMoving]);
 
   const handleMouseUp = useCallback(() => {
     isPanning.current = false;
@@ -99,6 +130,7 @@ export const useCanvas = (isHandTool = false) => {
   return {
     transform,
     setTransform,
+    moving,
     handleWheel,
     handleMouseDown,
     handleMouseMove,


### PR DESCRIPTION
## Summary
This PR optimizes canvas rendering performance by conditionally applying the `will-change: transform` CSS property only while the user is actively panning or zooming, rather than keeping it permanently applied.

## Problem
The canvas had `will-change: transform` permanently enabled, which caused Chromium to maintain a large tile backing store for the entire canvas content at all times. This consumed excessive tile memory and triggered "tile memory limits exceeded" warnings, especially on canvases with many nested frames.

## Solution
Implemented a motion tracking system that:
- Detects when the user is actively panning (mouse drag) or zooming (wheel events)
- Applies `will-change: transform` only during active movement
- Automatically removes the CSS class after 180ms of inactivity (long enough to cover trackpad wheel event gaps)
- Cleans up timers on component unmount to prevent memory leaks

## Key Changes
- **useCanvas hook**: Added `moving` state and `markMoving()` callback to track active pan/zoom operations with debouncing
- **CanvasSurface component**: Added `moving` prop and conditional CSS class application
- **Canvas component**: Threaded the `moving` state from hook to surface component
- **CSS**: Moved `will-change: transform` from permanent to conditional `.canvas-transform--moving` class
- **Cleanup**: Added useEffect to clear timers on unmount

## Implementation Details
- `MOVING_IDLE_MS` constant (180ms) balances responsiveness with covering trackpad event gaps
- Timer is reset on each pan/zoom event to extend the idle period
- The `moving` state is combined with existing `animating` state for the CSS class condition
- All event handlers (wheel, mouse down, mouse move) trigger `markMoving()` to maintain the active state

https://claude.ai/code/session_01WPwtdK2U4RJCUjDAHLnzgN