### PR TITLE
Add infographic node type with LLM-generated HTML/SVG content

### DIFF
--- a/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
@@ -43,6 +43,7 @@ Your system prompt contains a summary of all canvas nodes. For detailed content:
 - \`canvas_create_agent_node\`: **Create and launch an AI agent node** — preferred for agent creation
 - \`canvas_send_to_agent\`: **Send a follow-up prompt to an already-running agent node** — use for any interaction AFTER the initial launch
 - \`canvas_create_terminal_node\`: **Create a terminal node** — preferred for terminal creation
+- \`canvas_create_infographic\`: **Generate a visual infographic node** (HTML/SVG) — use when the user asks for a card, diagram, flowchart, widget, or any "show me this as a visual"
 - \`canvas_update_node\`: Update existing nodes (content, title, data)
 - \`canvas_delete_node\`: Remove a node from the canvas
 - \`canvas_move_node\`: Reposition a node
@@ -77,6 +78,14 @@ After an agent node is launched, use \`canvas_send_to_agent\` to send any additi
 Use \`canvas_create_terminal_node\` to spawn an interactive shell.
 The shell starts automatically. Set \`cwd\` for the working directory.
 Set \`command\` to auto-execute a command after the shell is ready (e.g. "npm run dev", "docker compose up").
+
+### Creating Infographic Nodes
+Use \`canvas_create_infographic\` to generate a self-contained visual — weather/stat cards, recipe cards, flowcharts, comparison tables, interactive widgets, etc. — and place it on the canvas.
+
+- \`kind="html"\` (default) produces an interactive single-page document rendered in a sandboxed webview. Good for data cards, widgets, anything clickable.
+- \`kind="svg"\` produces a static inline SVG. Good for diagrams and flowcharts.
+- Bake all the content and style intent into \`prompt\` — the generator only sees that string. Include concrete data values (not placeholders), suggested palette/tone, and any layout hints.
+- Prefer this over \`canvas_create_node\` whenever the user asks to "show", "visualise", "draw", "make a card/diagram/flowchart/infographic for…".
 
 ## Filesystem Tools (built-in)
 - \`read\`: Read file contents (with offset/limit support)

--- a/apps/canvas-workspace/src/main/canvas-agent/context-builder.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/context-builder.ts
@@ -247,6 +247,12 @@ function summarizeNode(node: CanvasNode): NodeSummary {
     case 'iframe':
       summary.url = (node.data.url as string) || undefined;
       break;
+    case 'infographic':
+      summary.kind = (node.data.kind as string) || undefined;
+      summary.infographicStatus = (node.data.status as string) || undefined;
+      summary.sourcePrompt = (node.data.sourcePrompt as string) || undefined;
+      summary.path = (node.data.filePath as string) || undefined;
+      break;
     case 'text':
       // Text nodes don't have titles — fall back to a content preview so
       // the agent can refer to them by something meaningful.
@@ -347,6 +353,17 @@ export async function buildDetailedContext(workspaceId: string): Promise<Detaile
       case 'text':
         detailed.content = (node.data.content as string) ?? '';
         break;
+      case 'infographic': {
+        const filePath = (node.data.filePath as string) ?? '';
+        if (filePath) {
+          try {
+            detailed.content = await fs.readFile(filePath, 'utf-8');
+          } catch {
+            detailed.content = '';
+          }
+        }
+        break;
+      }
     }
 
     nodes.push(detailed);
@@ -412,6 +429,17 @@ export async function readNodeDetail(workspaceId: string, nodeId: string): Promi
     case 'text':
       detailed.content = (node.data.content as string) ?? '';
       break;
+    case 'infographic': {
+      const filePath = (node.data.filePath as string) ?? '';
+      if (filePath) {
+        try {
+          detailed.content = await fs.readFile(filePath, 'utf-8');
+        } catch {
+          detailed.content = '';
+        }
+      }
+      break;
+    }
   }
 
   return detailed;
@@ -483,6 +511,19 @@ export function formatSummaryForPrompt(summary: WorkspaceSummary): string {
     lines.push('## Text Nodes');
     for (const n of byType.text) {
       lines.push(`- [${n.id}] **${n.title}**`);
+    }
+    lines.push('');
+  }
+
+  if (byType.infographic?.length) {
+    lines.push('## Infographic Nodes');
+    for (const n of byType.infographic) {
+      const kindHint = n.kind ? `, ${n.kind}` : '';
+      const statusHint = n.infographicStatus ? `, ${n.infographicStatus}` : '';
+      const promptHint = n.sourcePrompt
+        ? ` — ${n.sourcePrompt.length > 60 ? n.sourcePrompt.slice(0, 60) + '…' : n.sourcePrompt}`
+        : '';
+      lines.push(`- [${n.id}] **${n.title}** (${(kindHint + statusHint).replace(/^, /, '')})${promptHint}`);
     }
     lines.push('');
   }

--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -21,12 +21,13 @@ import {
   formatSummaryForPrompt,
 } from './context-builder';
 import { hasSession, writeToSession } from '../pty-manager';
+import { generateInfographic } from '../infographic-service';
 
 const STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
 
 // ─── Types mirrored from canvas-cli ────────────────────────────────
 
-type NodeType = 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe';
+type NodeType = 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe' | 'infographic';
 
 interface CanvasNode {
   id: string;
@@ -53,6 +54,7 @@ const DEFAULT_DIMENSIONS: Record<NodeType, { title: string; width: number; heigh
   agent: { title: 'Agent', width: 520, height: 380 },
   text: { title: 'Text', width: 260, height: 120 },
   iframe: { title: 'Web', width: 520, height: 400 },
+  infographic: { title: 'Infographic', width: 560, height: 420 },
 };
 
 // ─── Helpers ───────────────────────────────────────────────────────
@@ -330,6 +332,8 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
               url: (extraData.url as string) ?? '',
             };
             break;
+          case 'infographic':
+            return 'Error: use canvas_create_infographic to create infographic nodes (it generates the HTML/SVG content in the same call).';
         }
 
         // For file nodes, create a backing notes file
@@ -692,6 +696,99 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
         broadcastUpdate(workspaceId, [nodeId]);
 
         return JSON.stringify({ ok: true, nodeId, title });
+      },
+    },
+
+    // ─── Dedicated infographic node creation ─────────────────────────
+
+    canvas_create_infographic: {
+      name: 'canvas_create_infographic',
+      description:
+        'Generate a self-contained visual infographic (HTML or SVG) and place it on the canvas as a new node. ' +
+        'Use this when the user asks for a visual — a weather/recipe/stat card, a flowchart, a diagram, a comparison table, etc. ' +
+        'The model generates the markup from `prompt` in one shot (no tools), writes it to disk, and creates a node. ' +
+        'Choose `kind="html"` (default) for interactive widgets and layouts; choose `kind="svg"` for diagrams/flowcharts. ' +
+        'Compose `prompt` to include all relevant content and styling intent — the generator has no canvas context beyond ' +
+        'this string.',
+      inputSchema: z.object({
+        prompt: z.string().describe(
+          'Full description of what to draw, including any concrete data, labels, colour hints, and layout guidance. ' +
+          'The generator sees only this string — bake in everything it needs to know.',
+        ),
+        kind: z.enum(['html', 'svg']).optional().describe(
+          'Output format. "html" (default) produces an interactive single-page document rendered in a sandboxed webview. ' +
+          '"svg" produces a static inline SVG suitable for diagrams.',
+        ),
+        title: z.string().optional().describe('Node title shown in the header. Defaults to a truncated version of the prompt.'),
+        x: z.number().optional().describe('X position (auto-placed if omitted).'),
+        y: z.number().optional().describe('Y position (auto-placed if omitted).'),
+      }),
+      execute: async (input, ctx) => {
+        const prompt = (input.prompt as string) ?? '';
+        if (!prompt.trim()) return 'Error: prompt is required and must be non-empty';
+        const kind = ((input.kind as string) ?? 'html') as 'html' | 'svg';
+
+        const canvas = await loadCanvas(workspaceId);
+        if (!canvas) return 'Error: workspace not found';
+
+        const nodeId = `node-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const def = DEFAULT_DIMENSIONS.infographic;
+        const pos = (input.x != null && input.y != null)
+          ? { x: input.x as number, y: input.y as number }
+          : autoPlace(canvas.nodes);
+
+        // Derive a readable default title from the prompt if none provided.
+        const fallbackTitle = (() => {
+          const firstLine = prompt.split(/\r?\n/).find(l => l.trim())?.trim() ?? '';
+          if (!firstLine) return def.title;
+          return firstLine.length <= 48 ? firstLine : firstLine.slice(0, 48) + '…';
+        })();
+        const title = (input.title as string) || fallbackTitle;
+
+        let filePath = '';
+        let status: 'ready' | 'error' = 'ready';
+        let error: string | undefined;
+        try {
+          const result = await generateInfographic({
+            workspaceId,
+            nodeId,
+            prompt,
+            kind,
+            abortSignal: ctx?.abortSignal,
+          });
+          filePath = result.filePath;
+        } catch (err) {
+          status = 'error';
+          error = err instanceof Error ? err.message : String(err);
+        }
+
+        const newNode: CanvasNode = {
+          id: nodeId,
+          type: 'infographic',
+          title,
+          x: pos.x,
+          y: pos.y,
+          width: def.width,
+          height: def.height,
+          data: {
+            kind,
+            filePath,
+            sourcePrompt: prompt,
+            status,
+            ...(error ? { error } : {}),
+          },
+          updatedAt: Date.now(),
+        };
+
+        const fresh = (await loadCanvas(workspaceId)) ?? canvas;
+        fresh.nodes.push(newNode);
+        await saveCanvas(workspaceId, fresh);
+        broadcastUpdate(workspaceId, [nodeId]);
+
+        if (status === 'error') {
+          return JSON.stringify({ ok: false, nodeId, title, kind, error });
+        }
+        return JSON.stringify({ ok: true, nodeId, title, kind, filePath });
       },
     },
   };

--- a/apps/canvas-workspace/src/main/canvas-agent/types.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/types.ts
@@ -50,6 +50,12 @@ export interface NodeSummary {
   label?: string;
   /** Embedded URL for iframe nodes. */
   url?: string;
+  /** Output format ("html" | "svg") for infographic nodes. */
+  kind?: string;
+  /** Generation state ("empty" | "generating" | "ready" | "error") for infographic nodes. */
+  infographicStatus?: string;
+  /** Source prompt used to generate an infographic. */
+  sourcePrompt?: string;
 }
 
 export interface WorkspaceSummary {

--- a/apps/canvas-workspace/src/main/index.ts
+++ b/apps/canvas-workspace/src/main/index.ts
@@ -12,6 +12,7 @@ import { setupFileWatcherIpc, teardownFileWatcher } from "./file-watcher";
 import { setupSkillInstallerIpc } from "./skill-installer";
 import { setupCanvasAgentIpc, teardownCanvasAgent } from "./canvas-agent-ipc";
 import { setupWebviewRegistryIpc } from "./webview-registry";
+import { setupInfographicIpc } from "./infographic-service";
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const preloadPath = join(currentDir, "../preload/index.mjs");
@@ -141,6 +142,7 @@ app.whenReady().then(() => {
   setupSkillInstallerIpc();
   setupCanvasAgentIpc();
   setupWebviewRegistryIpc();
+  setupInfographicIpc();
   // MCP server disabled — canvas-cli is the preferred agent interface now.
   // startMCPServer();
   // void ensureMCPRegistered();

--- a/apps/canvas-workspace/src/main/infographic-service.ts
+++ b/apps/canvas-workspace/src/main/infographic-service.ts
@@ -58,8 +58,23 @@ response is written to disk and loaded in a sandboxed browser view as-is.
 - Keep the document focused on the requested visual; do not add navigation
   bars, footers, or unrelated chrome.
 - Use semantic HTML and reasonable accessible colour contrast.
-- Size the layout so it looks good at roughly 560×420 px but remains
-  readable when resized.
+
+## Sizing (critical)
+The document is embedded in a canvas node whose size the user can freely
+drag. The viewport you receive *is* the node's inner area — there is no
+scrollbar, nothing above or below. You MUST fill it edge-to-edge:
+
+- Reset the page: \`html, body { margin: 0; padding: 0; width: 100%; height: 100%; }\`
+  and \`body { box-sizing: border-box; }\`.
+- Your outermost container must also be \`width: 100%; height: 100%;\`
+  (or use \`position: fixed; inset: 0;\`). Never set a fixed pixel width
+  or height on the root — that will leave white bands when the node is
+  resized.
+- Use flexbox / grid so the primary visual stretches to fill the
+  available space. Paddings are fine; fixed outer frames are not.
+- Design for a roughly 4:3 starting viewport (~560×420) but assume the
+  user will drag it wider or taller. Diagrams should scale (SVG with
+  \`viewBox\` + \`width:100%; height:100%\`); cards should reflow.
 
 ## Style guidance
 - Prefer clear hierarchy, generous whitespace, and legible type.

--- a/apps/canvas-workspace/src/main/infographic-service.ts
+++ b/apps/canvas-workspace/src/main/infographic-service.ts
@@ -1,0 +1,278 @@
+/**
+ * Infographic generation service.
+ *
+ * A thin one-shot wrapper around the same LLM stack the Canvas Agent uses,
+ * with a dedicated system prompt that asks the model to emit a single
+ * self-contained HTML document or SVG document. The output is persisted
+ * under `{workspaceDir}/infographics/{nodeId}.{html|svg}` so the node is
+ * reloadable without re-running the model.
+ *
+ * We deliberately do NOT call `Engine.run` here — infographic generation
+ * has no need for tools, compaction, or the agentic loop, and a one-shot
+ * `generateText` gives us cleaner latency + abort semantics.
+ */
+
+import { ipcMain, BrowserWindow } from "electron";
+import { promises as fs } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import { generateText } from "ai";
+import { createOpenAI } from "@ai-sdk/openai";
+
+const STORE_DIR = join(homedir(), ".pulse-coder", "canvas");
+
+const INFOGRAPHIC_DIR_NAME = "infographics";
+
+/**
+ * Maximum response budget for infographic generation. Infographic HTML can
+ * be legitimately long (lots of SVG paths, inline data, etc.) but we cap
+ * the output so a runaway model doesn't blow up disk or the UI.
+ */
+const MAX_OUTPUT_TOKENS = 8192;
+
+/** Kept in sync with CanvasAgent — same model env var resolution. */
+function resolveModel(): string {
+  return process.env.OPENAI_MODEL ?? "gpt-4o";
+}
+
+function buildProvider() {
+  return createOpenAI({
+    apiKey: process.env.OPENAI_API_KEY,
+    baseURL: process.env.OPENAI_API_URL,
+  });
+}
+
+const HTML_SYSTEM_PROMPT = `You generate self-contained, visually polished HTML infographics.
+
+## Output format
+Return **exactly one** complete HTML document, starting with \`<!DOCTYPE html>\`.
+Do not wrap the output in markdown fences, prose, or explanations — your entire
+response is written to disk and loaded in a sandboxed browser view as-is.
+
+## Constraints
+- All CSS must be inline (a single \`<style>\` block in the \`<head>\`).
+- All JavaScript must be inline (a single \`<script>\` block) — no external
+  scripts, no CDNs, no network fetches. The document must render fully
+  offline.
+- Do not load remote fonts or images. Inline SVG / base64 data-URIs are fine.
+- Keep the document focused on the requested visual; do not add navigation
+  bars, footers, or unrelated chrome.
+- Use semantic HTML and reasonable accessible colour contrast.
+- Size the layout so it looks good at roughly 560×420 px but remains
+  readable when resized.
+
+## Style guidance
+- Prefer clear hierarchy, generous whitespace, and legible type.
+- When the user asks for a diagram/flowchart, use SVG.
+- When the user asks for a data card or widget, use HTML + CSS grid/flex.
+- Interactive affordances (hover, click-to-toggle) are encouraged when they
+  aid comprehension.`;
+
+const SVG_SYSTEM_PROMPT = `You generate self-contained SVG infographics.
+
+## Output format
+Return **exactly one** complete SVG document, starting with
+\`<svg xmlns="http://www.w3.org/2000/svg" …>\` and ending with \`</svg>\`.
+Do not wrap the output in markdown fences, HTML, prose, or explanations —
+your entire response is written to disk and rendered inline as-is.
+
+## Constraints
+- Include a \`viewBox\` so the SVG scales cleanly.
+- Do not reference external files, images, or fonts.
+- Inline \`<style>\` blocks are fine; no \`<script>\` tags.
+- Keep the diagram focused on the requested content.
+
+## Style guidance
+- Prefer clean geometry, readable labels, and a restrained palette.
+- Show structure through arrows, grouping, and whitespace rather than
+  decorative fills.`;
+
+function systemPromptFor(kind: "html" | "svg"): string {
+  return kind === "svg" ? SVG_SYSTEM_PROMPT : HTML_SYSTEM_PROMPT;
+}
+
+/**
+ * Drop any accidental markdown fences the model wraps the output in, and
+ * trim leading prose before the first `<!DOCTYPE html>` / `<svg`. Most
+ * capable models ignore the "no fences" rule occasionally, especially when
+ * the user prompt uses code-fenced examples.
+ */
+function sanitizeOutput(raw: string, kind: "html" | "svg"): string {
+  let text = raw.trim();
+
+  // Strip an outer ```html / ```svg / ``` fence if present.
+  const fenceMatch = /^```(?:[a-zA-Z]+)?\n([\s\S]*?)\n```\s*$/.exec(text);
+  if (fenceMatch) {
+    text = fenceMatch[1].trim();
+  }
+
+  if (kind === "html") {
+    const docStart = text.search(/<!DOCTYPE\s+html/i);
+    if (docStart > 0) text = text.slice(docStart);
+    const htmlStart = text.search(/<html[\s>]/i);
+    if (docStart < 0 && htmlStart > 0) text = text.slice(htmlStart);
+  } else {
+    const svgStart = text.search(/<svg[\s>]/i);
+    if (svgStart > 0) text = text.slice(svgStart);
+    const svgEnd = text.lastIndexOf("</svg>");
+    if (svgEnd >= 0) text = text.slice(0, svgEnd + "</svg>".length);
+  }
+
+  return text.trim();
+}
+
+function infographicDir(workspaceId: string): string {
+  return join(STORE_DIR, workspaceId, INFOGRAPHIC_DIR_NAME);
+}
+
+function infographicPath(
+  workspaceId: string,
+  nodeId: string,
+  kind: "html" | "svg",
+): string {
+  return join(infographicDir(workspaceId), `${nodeId}.${kind}`);
+}
+
+/**
+ * Generate infographic content for a prompt and persist it to disk.
+ * Caller is responsible for updating the canvas node's data afterward
+ * (filePath, status). We intentionally do NOT mutate canvas.json here —
+ * the renderer-side `onUpdate` is the authoritative path for node state.
+ */
+export async function generateInfographic(params: {
+  workspaceId: string;
+  nodeId: string;
+  prompt: string;
+  kind: "html" | "svg";
+  abortSignal?: AbortSignal;
+}): Promise<{ kind: "html" | "svg"; content: string; filePath: string }> {
+  const { workspaceId, nodeId, prompt, kind, abortSignal } = params;
+
+  const provider = buildProvider();
+  const model = provider(resolveModel());
+
+  const { text } = await generateText({
+    model,
+    system: systemPromptFor(kind),
+    prompt,
+    maxOutputTokens: MAX_OUTPUT_TOKENS,
+    abortSignal,
+  });
+
+  const cleaned = sanitizeOutput(text, kind);
+  if (!cleaned) {
+    throw new Error("model returned empty output");
+  }
+
+  const dir = infographicDir(workspaceId);
+  await fs.mkdir(dir, { recursive: true });
+  const filePath = infographicPath(workspaceId, nodeId, kind);
+  await fs.writeFile(filePath, cleaned, "utf-8");
+
+  return { kind, content: cleaned, filePath };
+}
+
+/** Read a previously-generated infographic file. */
+export async function readInfographic(params: {
+  workspaceId: string;
+  nodeId: string;
+  kind: "html" | "svg";
+}): Promise<string> {
+  const filePath = infographicPath(
+    params.workspaceId,
+    params.nodeId,
+    params.kind,
+  );
+  return fs.readFile(filePath, "utf-8");
+}
+
+/**
+ * Track in-flight generations per node so a second "Generate" click on the
+ * same node cancels the prior run — otherwise two concurrent LLM calls
+ * would race each other to the same file path on disk.
+ */
+const inFlight = new Map<string, AbortController>();
+
+function inFlightKey(workspaceId: string, nodeId: string): string {
+  return `${workspaceId}::${nodeId}`;
+}
+
+export function setupInfographicIpc(): void {
+  ipcMain.handle(
+    "infographic:generate",
+    async (
+      _event,
+      payload: {
+        workspaceId: string;
+        nodeId: string;
+        prompt: string;
+        kind?: "html" | "svg";
+      },
+    ) => {
+      const kind = payload.kind ?? "html";
+      const key = inFlightKey(payload.workspaceId, payload.nodeId);
+      inFlight.get(key)?.abort();
+
+      const controller = new AbortController();
+      inFlight.set(key, controller);
+
+      try {
+        const result = await generateInfographic({
+          workspaceId: payload.workspaceId,
+          nodeId: payload.nodeId,
+          prompt: payload.prompt,
+          kind,
+          abortSignal: controller.signal,
+        });
+        return { ok: true, ...result };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { ok: false, error: message };
+      } finally {
+        if (inFlight.get(key) === controller) {
+          inFlight.delete(key);
+        }
+      }
+    },
+  );
+
+  ipcMain.handle(
+    "infographic:read",
+    async (
+      _event,
+      payload: { workspaceId: string; nodeId: string; kind: "html" | "svg" },
+    ) => {
+      try {
+        const content = await readInfographic(payload);
+        return { ok: true, content };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { ok: false, error: message };
+      }
+    },
+  );
+}
+
+/**
+ * Broadcast a canvas node update to every BrowserWindow.
+ *
+ * Used by the canvas-agent tool path (where generation happens server-side
+ * and the node is created without any renderer round-trip) so the canvas UI
+ * refreshes the node without the user having to re-select the workspace.
+ * Mirrors the convention used by `canvas-store.ts` and `canvas-agent/tools.ts`.
+ */
+export function broadcastInfographicUpdate(
+  workspaceId: string,
+  nodeIds: string[],
+): void {
+  const payload = {
+    type: "canvas:updated" as const,
+    workspaceId,
+    nodeIds,
+    source: "infographic-service" as const,
+  };
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (win.isDestroyed()) continue;
+    win.webContents.send("canvas:external-update", payload);
+  }
+}

--- a/apps/canvas-workspace/src/preload/index.ts
+++ b/apps/canvas-workspace/src/preload/index.ts
@@ -141,6 +141,24 @@ contextBridge.exposeInMainWorld("canvasWorkspace", {
       ipcRenderer.invoke("iframe:unregister-webview", { workspaceId, nodeId })
   },
 
+  infographic: {
+    generate: (
+      workspaceId: string,
+      nodeId: string,
+      prompt: string,
+      kind?: "html" | "svg"
+    ) =>
+      ipcRenderer.invoke("infographic:generate", {
+        workspaceId,
+        nodeId,
+        prompt,
+        kind
+      }),
+
+    read: (workspaceId: string, nodeId: string, kind: "html" | "svg") =>
+      ipcRenderer.invoke("infographic:read", { workspaceId, nodeId, kind })
+  },
+
   agent: {
     chat: (workspaceId: string, message: string, mentionedWorkspaceIds?: string[]) =>
       ipcRenderer.invoke("canvas-agent:chat", { workspaceId, message, mentionedWorkspaceIds }),

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
@@ -18,10 +18,10 @@ interface CanvasOverlaysProps {
   scale: number;
   chatPanelOpen?: boolean;
   onChatToggle?: () => void;
-  onCreateNode: (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe') => void;
+  onCreateNode: (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe' | 'infographic') => void;
   onCloseContextMenu: () => void;
   onToolChange: (tool: string) => void;
-  onAddNode: (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe') => void;
+  onAddNode: (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe' | 'infographic') => void;
   onResetTransform: () => void;
   onSearchSelect: (node: CanvasNode) => void;
   onCloseSearch: () => void;

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -171,7 +171,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
   );
 
   const handleCreateNode = useCallback(
-    (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe') => {
+    (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe' | 'infographic') => {
       if (!contextMenu) return;
       const node = addNode(type, contextMenu.canvasX, contextMenu.canvasY);
       setSelectedNodeIds([node.id]);
@@ -181,7 +181,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
   );
 
   const handleToolbarAddNode = useCallback(
-    (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe') => {
+    (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe' | 'infographic') => {
       if (!containerRef.current) return;
       const rect = containerRef.current.getBoundingClientRect();
       const pos = screenToCanvas(rect.left + rect.width / 2, rect.top + rect.height / 2, containerRef.current);
@@ -191,11 +191,13 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
         : type === 'agent' ? 260
         : type === 'text' ? 130
         : type === 'iframe' ? 260
+        : type === 'infographic' ? 280
         : 300;
       const halfH =
         type === 'frame' ? 200
         : type === 'text' ? 60
         : type === 'iframe' ? 200
+        : type === 'infographic' ? 210
         : 150;
       const node = addNode(type, pos.x - halfW, pos.y - halfH);
       setSelectedNodeIds([node.id]);

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -117,6 +117,10 @@
   color: var(--text-muted);
 }
 
+.node-type-badge--infographic {
+  color: #7c5cff;
+}
+
 .node-title {
   flex: 1;
   font-size: 13px;

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -8,6 +8,7 @@ import { FrameNodeBody, FrameColorPicker } from "../FrameNodeBody";
 import { AgentNodeBody } from "../AgentNodeBody";
 import { TextNodeBody, TextColorPicker } from "../TextNodeBody";
 import { IframeNodeBody } from "../IframeNodeBody";
+import { InfographicNodeBody } from "../InfographicNodeBody";
 
 interface Props {
   node: CanvasNode;
@@ -174,6 +175,11 @@ export const CanvasNodeView = ({
               <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.3" />
               <path d="M2 8h12M8 2c2 2 2 10 0 12M8 2c-2 2-2 10 0 12" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" />
             </svg>
+          ) : node.type === "infographic" ? (
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+              <rect x="2" y="2" width="12" height="12" rx="2" stroke="currentColor" strokeWidth="1.3" />
+              <path d="M5 11V7.5M8 11V5M11 11V9" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+            </svg>
           ) : (
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
               <circle cx="8" cy="5.5" r="3" stroke="currentColor" strokeWidth="1.3" />
@@ -233,6 +239,8 @@ export const CanvasNodeView = ({
           />
         ) : node.type === "iframe" ? (
           <IframeNodeBody node={node} workspaceId={workspaceId} onUpdate={onUpdate} />
+        ) : node.type === "infographic" ? (
+          <InfographicNodeBody node={node} workspaceId={workspaceId} onUpdate={onUpdate} />
         ) : (
           <AgentNodeBody node={node} allNodes={allNodes} rootFolder={rootFolder} workspaceId={workspaceId} workspaceName={workspaceName} onUpdate={onUpdate} />
         )}

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
@@ -3,7 +3,7 @@ import './index.css';
 interface Props {
   activeTool: string;
   onToolChange: (tool: string) => void;
-  onAddNode: (type: "file" | "terminal" | "frame" | "agent" | "text" | "iframe") => void;
+  onAddNode: (type: "file" | "terminal" | "frame" | "agent" | "text" | "iframe" | "infographic") => void;
   chatPanelOpen?: boolean;
   onChatToggle?: () => void;
 }
@@ -165,6 +165,23 @@ export const FloatingToolbar = ({
             />
           </svg>
           <span className="toolbar-btn-label">Link</span>
+        </button>
+        <button
+          className="toolbar-btn toolbar-btn--create"
+          onClick={() => onAddNode("infographic")}
+          title="Add Infographic (AI-generated visual)"
+        >
+          <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+            <rect
+              x="2.5" y="2.5" width="13" height="13" rx="2"
+              stroke="currentColor" strokeWidth="1.3"
+            />
+            <path
+              d="M6 12V8M9 12V5M12 12V9.5"
+              stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"
+            />
+          </svg>
+          <span className="toolbar-btn-label">Infographic</span>
         </button>
         <button
           className="toolbar-btn toolbar-btn--create"

--- a/apps/canvas-workspace/src/renderer/src/components/InfographicNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/InfographicNodeBody/index.css
@@ -1,0 +1,225 @@
+.infographic-body {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  background: var(--surface);
+}
+
+.infographic-body--empty,
+.infographic-body--loading {
+  justify-content: center;
+  align-items: center;
+  padding: 14px 16px;
+  gap: 8px;
+}
+
+.infographic-empty-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  max-width: 440px;
+}
+
+.infographic-empty-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.infographic-empty-input {
+  font-family: inherit;
+  font-size: 13px;
+  line-height: 1.4;
+  padding: 8px 10px;
+  border: 1px solid var(--border-light);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+  resize: vertical;
+  min-height: 72px;
+  outline: none;
+}
+
+.infographic-empty-input:focus {
+  border-color: var(--accent-border);
+  box-shadow: 0 0 0 2px rgba(35, 131, 226, 0.12);
+}
+
+.infographic-empty-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.infographic-empty-btn {
+  font-size: 12px;
+  padding: 5px 10px;
+  border: 1px solid var(--border-light);
+  border-radius: 5px;
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.infographic-empty-btn:hover:not(:disabled) {
+  background: var(--hover-bg, rgba(0, 0, 0, 0.04));
+}
+
+.infographic-empty-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.infographic-empty-btn--primary {
+  background: #7c5cff;
+  color: white;
+  border-color: #7c5cff;
+}
+
+.infographic-empty-btn--primary:hover:not(:disabled) {
+  background: #6b4bef;
+}
+
+.infographic-empty-error {
+  font-size: 11px;
+  color: #e03e3e;
+  padding: 4px 6px;
+  background: rgba(224, 62, 62, 0.08);
+  border-radius: 4px;
+}
+
+.infographic-empty-hint {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+/* Loading state */
+.infographic-spinner {
+  width: 24px;
+  height: 24px;
+  border: 2px solid var(--border-light);
+  border-top-color: #7c5cff;
+  border-radius: 50%;
+  animation: infographicSpin 0.9s linear infinite;
+}
+
+@keyframes infographicSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.infographic-loading-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.infographic-loading-prompt {
+  font-size: 11px;
+  color: var(--text-muted);
+  max-width: 440px;
+  text-align: center;
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+}
+
+/* Ready state */
+.infographic-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px;
+  border-bottom: 1px solid var(--border-light);
+  background: var(--surface);
+  flex-shrink: 0;
+}
+
+.infographic-bar-kind {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: rgba(124, 92, 255, 0.12);
+  color: #7c5cff;
+  flex-shrink: 0;
+}
+
+.infographic-bar-prompt {
+  flex: 1 1 auto;
+  min-width: 0;
+  font: inherit;
+  text-align: left;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  padding: 2px 6px;
+  color: var(--text-muted);
+  cursor: pointer;
+  overflow: hidden;
+}
+
+.infographic-bar-prompt:hover {
+  background: var(--hover-bg, rgba(0, 0, 0, 0.04));
+  color: var(--text);
+}
+
+.infographic-bar-prompt-text {
+  display: block;
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.infographic-bar-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.infographic-bar-btn:hover {
+  background: var(--hover-bg, rgba(0, 0, 0, 0.04));
+  color: var(--text);
+}
+
+.infographic-frame {
+  flex: 1 1 auto;
+  width: 100%;
+  border: none;
+  background: white;
+  min-height: 0;
+}
+
+.infographic-svg-wrap {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: auto;
+  padding: 8px;
+  background: white;
+  min-height: 0;
+}
+
+.infographic-svg-wrap svg {
+  max-width: 100%;
+  max-height: 100%;
+  height: auto;
+  width: auto;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/InfographicNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/InfographicNodeBody/index.tsx
@@ -1,0 +1,304 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import "./index.css";
+import type { CanvasNode, InfographicNodeData } from "../../types";
+
+interface Props {
+  node: CanvasNode;
+  workspaceId?: string;
+  onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
+}
+
+/**
+ * LLM-generated visual content, inspired by Claude's "Visual and Interactive
+ * Content" feature.
+ *
+ * Three UI states driven by `data.status`:
+ *   - 'empty'      → prompt input + Generate button
+ *   - 'generating' → spinner (regenerate is disabled)
+ *   - 'ready'      → rendered content (HTML in an isolated <webview>, SVG
+ *                    inline) with a Regenerate affordance
+ *
+ * Rendering rationale:
+ *  - HTML content is produced by an LLM and may include arbitrary script /
+ *    style, so we never inject it into the parent document. Instead we point
+ *    a `<webview>` at the on-disk `file://…` path, which gets its own
+ *    webContents (a proper OS-level isolation boundary) and cannot reach
+ *    into the renderer.
+ *  - SVG is static, well-understood, and inlining gives crisper rendering +
+ *    accessibility (text selection, pointer events), so we embed it directly.
+ *    We still write it to disk so the node survives reloads without
+ *    re-running the model.
+ */
+export const InfographicNodeBody = ({ node, workspaceId, onUpdate }: Props) => {
+  const data = node.data as InfographicNodeData;
+  const status = data.status ?? (data.filePath ? "ready" : "empty");
+
+  const [draft, setDraft] = useState(data.sourcePrompt ?? "");
+  const [svgContent, setSvgContent] = useState<string>("");
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  // Keep the prompt draft in sync when the node's stored prompt changes
+  // (undo/redo, external edits) so editing restarts from the persisted text.
+  useEffect(() => {
+    setDraft(data.sourcePrompt ?? "");
+  }, [data.sourcePrompt]);
+
+  // When the node is SVG and ready, pull the file contents so we can inline
+  // them. HTML loads directly via <webview src="file://…">, so no read needed.
+  useEffect(() => {
+    if (status !== "ready") return;
+    if (data.kind !== "svg") return;
+    if (!workspaceId) return;
+    const api = window.canvasWorkspace?.infographic;
+    if (!api) return;
+    let cancelled = false;
+    void api.read(workspaceId, node.id, "svg").then((res) => {
+      if (cancelled || !mountedRef.current) return;
+      if (res.ok && typeof res.content === "string") {
+        setSvgContent(res.content);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [status, data.kind, data.filePath, workspaceId, node.id]);
+
+  const runGenerate = useCallback(
+    async (prompt: string, kind: "html" | "svg") => {
+      if (!workspaceId) return;
+      const api = window.canvasWorkspace?.infographic;
+      if (!api) {
+        onUpdate(node.id, {
+          data: {
+            ...data,
+            status: "error",
+            error: "infographic API not available",
+          },
+        });
+        return;
+      }
+      onUpdate(node.id, {
+        data: {
+          ...data,
+          kind,
+          sourcePrompt: prompt,
+          status: "generating",
+          error: undefined,
+        },
+      });
+      const res = await api.generate(workspaceId, node.id, prompt, kind);
+      if (!mountedRef.current) return;
+      if (!res.ok || !res.filePath) {
+        onUpdate(node.id, {
+          data: {
+            ...data,
+            kind,
+            sourcePrompt: prompt,
+            status: "error",
+            error: res.error ?? "generation failed",
+          },
+        });
+        return;
+      }
+      if (res.kind === "svg" && typeof res.content === "string") {
+        setSvgContent(res.content);
+      }
+      onUpdate(node.id, {
+        data: {
+          ...data,
+          kind: res.kind ?? kind,
+          filePath: res.filePath,
+          sourcePrompt: prompt,
+          status: "ready",
+          error: undefined,
+        },
+        // Keep the node title in sync with the prompt so the header is
+        // meaningful even before the user renames it.
+        title:
+          node.title && node.title !== "Infographic"
+            ? node.title
+            : deriveTitle(prompt),
+      });
+    },
+    [workspaceId, node.id, node.title, data, onUpdate],
+  );
+
+  const handleGenerate = useCallback(
+    (kind: "html" | "svg") => {
+      const prompt = draft.trim();
+      if (!prompt) return;
+      void runGenerate(prompt, kind);
+    },
+    [draft, runGenerate],
+  );
+
+  const handleEdit = useCallback(() => {
+    onUpdate(node.id, {
+      data: { ...data, status: "empty", error: undefined },
+    });
+  }, [onUpdate, node.id, data]);
+
+  // ─── Empty / edit state: prompt input ───────────────────────────────
+  if (status === "empty" || status === "error") {
+    const hasExisting = !!data.filePath;
+    return (
+      <div className="infographic-body infographic-body--empty">
+        <div className="infographic-empty-inner">
+          <div className="infographic-empty-label">
+            Describe the visual you want
+          </div>
+          <textarea
+            className="infographic-empty-input"
+            value={draft}
+            placeholder="e.g. A step-by-step flowchart of OAuth2 authorization code flow with labeled actors and arrows."
+            onChange={(e) => setDraft(e.target.value)}
+            spellCheck={false}
+            rows={4}
+          />
+          <div className="infographic-empty-actions">
+            {hasExisting && (
+              <button
+                className="infographic-empty-btn"
+                onClick={() =>
+                  onUpdate(node.id, {
+                    data: { ...data, status: "ready", error: undefined },
+                  })
+                }
+              >
+                Cancel
+              </button>
+            )}
+            <button
+              className="infographic-empty-btn"
+              onClick={() => handleGenerate("svg")}
+              disabled={!draft.trim()}
+              title="Generate a static SVG"
+            >
+              SVG
+            </button>
+            <button
+              className="infographic-empty-btn infographic-empty-btn--primary"
+              onClick={() => handleGenerate("html")}
+              disabled={!draft.trim()}
+              title="Generate interactive HTML"
+            >
+              Generate
+            </button>
+          </div>
+          {status === "error" && data.error && (
+            <div className="infographic-empty-error">{data.error}</div>
+          )}
+          <div className="infographic-empty-hint">
+            HTML renders in an isolated webview. SVG renders inline.
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ─── Generating state: spinner ──────────────────────────────────────
+  if (status === "generating") {
+    return (
+      <div className="infographic-body infographic-body--loading">
+        <div className="infographic-spinner" />
+        <div className="infographic-loading-label">Generating…</div>
+        <div className="infographic-loading-prompt">{data.sourcePrompt}</div>
+      </div>
+    );
+  }
+
+  // ─── Ready state: rendered content ──────────────────────────────────
+  return (
+    <div className="infographic-body">
+      <div className="infographic-bar">
+        <span
+          className="infographic-bar-kind"
+          title={`Kind: ${data.kind}`}
+        >
+          {data.kind.toUpperCase()}
+        </span>
+        <button
+          className="infographic-bar-prompt"
+          onClick={handleEdit}
+          title="Edit prompt & regenerate"
+        >
+          <span className="infographic-bar-prompt-text">
+            {data.sourcePrompt || "(no prompt)"}
+          </span>
+        </button>
+        <button
+          className="infographic-bar-btn"
+          onClick={handleEdit}
+          title="Regenerate"
+        >
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <path
+              d="M2 6a4 4 0 016.9-2.8L10 4M10 2v2.5H7.5M10 6a4 4 0 01-6.9 2.8L2 8M2 10V7.5h2.5"
+              stroke="currentColor"
+              strokeWidth="1.2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
+      {data.kind === "html" ? (
+        <webview
+          // webview can't consume arbitrary strings the way an <iframe
+          // srcdoc> would, but pointing it at a real file URL gives us the
+          // same isolation (its own webContents) plus persistence — a
+          // canvas reload re-reads the same file without another model call.
+          // The file path is URI-encoded to survive spaces/colons in the
+          // workspace name.
+          key={data.filePath}
+          className="infographic-frame"
+          src={toFileUrl(data.filePath)}
+        />
+      ) : (
+        <div
+          className="infographic-svg-wrap"
+          dangerouslySetInnerHTML={{ __html: svgContent }}
+        />
+      )}
+    </div>
+  );
+};
+
+/**
+ * Build a short, canvas-friendly node title from a prompt — the first line,
+ * stripped of markdown punctuation, capped at 40 chars.
+ */
+function deriveTitle(prompt: string): string {
+  const firstLine = prompt
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .find((l) => l.length > 0);
+  if (!firstLine) return "Infographic";
+  const stripped = firstLine.replace(/^[#>*\-+\d.\s]+/, "").trim();
+  const source = stripped || firstLine;
+  return source.length <= 40 ? source : `${source.slice(0, 40)}…`;
+}
+
+/**
+ * Convert an absolute filesystem path to a `file://` URL safe for use in a
+ * `<webview src>` attribute. Each path segment is `encodeURIComponent`'d so
+ * that spaces, `#`, and other characters don't silently truncate the URL.
+ */
+function toFileUrl(filePath: string): string {
+  if (!filePath) return "";
+  // Normalize Windows backslashes so the URL is always forward-slash separated.
+  const normalized = filePath.replace(/\\/g, "/");
+  const encoded = normalized
+    .split("/")
+    .map((seg) => (seg ? encodeURIComponent(seg) : ""))
+    .join("/");
+  const prefix = encoded.startsWith("/") ? "file://" : "file:///";
+  return `${prefix}${encoded}`;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from "react";
 interface Props {
   x: number;
   y: number;
-  onCreate: (type: "file" | "terminal" | "frame" | "agent" | "text" | "iframe") => void;
+  onCreate: (type: "file" | "terminal" | "frame" | "agent" | "text" | "iframe" | "infographic") => void;
   onClose: () => void;
 }
 
@@ -90,6 +90,16 @@ export const NodeContextMenu = ({ x, y, onCreate, onClose }: Props) => {
         <span className="context-menu-label">
           <strong>Link</strong>
           <small>Embed a web page</small>
+        </span>
+      </button>
+      <button
+        className="context-menu-item"
+        onClick={() => onCreate("infographic")}
+      >
+        <span className="context-menu-icon">{"\u2630"}</span>
+        <span className="context-menu-label">
+          <strong>Infographic</strong>
+          <small>AI-generated HTML or SVG visual</small>
         </span>
       </button>
       <button

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -1,6 +1,6 @@
 export interface CanvasNode {
   id: string;
-  type: "file" | "terminal" | "frame" | "agent" | "text" | "iframe";
+  type: "file" | "terminal" | "frame" | "agent" | "text" | "iframe" | "infographic";
   title: string;
   x: number;
   y: number;
@@ -12,7 +12,8 @@ export interface CanvasNode {
     | FrameNodeData
     | AgentNodeData
     | TextNodeData
-    | IframeNodeData;
+    | IframeNodeData
+    | InfographicNodeData;
   /** Epoch millis of last mutation; used for cross-process merge. */
   updatedAt?: number;
 }
@@ -83,6 +84,33 @@ export interface TextNodeData {
 export interface IframeNodeData {
   /** Full URL (including protocol) to load in the iframe. Empty = show URL input. */
   url: string;
+}
+
+/**
+ * LLM-generated visual content (akin to Claude's "Visual and interactive
+ * content" feature). The node captures a short prompt, dispatches it to the
+ * Canvas Agent's generation service in the main process, and renders the
+ * result inside an isolated `<webview>` (HTML) or inline `<svg>` (SVG).
+ *
+ * Content is stored on disk under
+ * `~/.pulse-coder/canvas/{workspaceId}/infographics/{nodeId}.{svg|html}`
+ * rather than inline in canvas.json — infographic HTML can be large and we
+ * don't want it inflating every canvas snapshot.
+ */
+export interface InfographicNodeData {
+  /** 'html' → sandboxed webview via srcdoc; 'svg' → inline <svg>. */
+  kind: "html" | "svg";
+  /**
+   * Absolute path to the on-disk file holding the rendered content.
+   * Empty before the first successful generation.
+   */
+  filePath: string;
+  /** User prompt that produced the current content. */
+  sourcePrompt: string;
+  /** Generation status — drives the body's empty / loading / ready UI. */
+  status?: "empty" | "generating" | "ready" | "error";
+  /** Error message when `status === 'error'`. */
+  error?: string;
 }
 
 export interface CanvasTransform {
@@ -286,6 +314,7 @@ export interface CanvasWorkspaceApi {
   skills: SkillsApi;
   agent: AgentApi;
   iframe: IframeApi;
+  infographic: InfographicApi;
 }
 
 export interface IframeApi {
@@ -298,6 +327,33 @@ export interface IframeApi {
     workspaceId: string,
     nodeId: string,
   ) => Promise<{ ok: boolean }>;
+}
+
+export interface InfographicApi {
+  /**
+   * Run the Canvas Agent's LLM to produce HTML/SVG content from a prompt,
+   * persist it to the workspace's `infographics/` directory, and return the
+   * rendered content. The caller is responsible for updating the node's
+   * `data` (filePath, status) afterwards.
+   */
+  generate: (
+    workspaceId: string,
+    nodeId: string,
+    prompt: string,
+    kind?: "html" | "svg",
+  ) => Promise<{
+    ok: boolean;
+    kind?: "html" | "svg";
+    content?: string;
+    filePath?: string;
+    error?: string;
+  }>;
+  /** Read a previously-generated infographic file. */
+  read: (
+    workspaceId: string,
+    nodeId: string,
+    kind: "html" | "svg",
+  ) => Promise<{ ok: boolean; content?: string; error?: string }>;
 }
 
 declare global {

--- a/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
@@ -1,25 +1,45 @@
-import type { CanvasNode, FileNodeData, TerminalNodeData, FrameNodeData, AgentNodeData, TextNodeData, IframeNodeData } from '../types';
+import type {
+  CanvasNode,
+  FileNodeData,
+  TerminalNodeData,
+  FrameNodeData,
+  AgentNodeData,
+  TextNodeData,
+  IframeNodeData,
+  InfographicNodeData,
+} from '../types';
 
 let nodeIdCounter = 0;
 export const genId = (): string => `node-${Date.now()}-${++nodeIdCounter}`;
 
 const NODE_DEFAULTS: Record<CanvasNode['type'], { title: string; width: number; height: number }> = {
-  file:     { title: 'Untitled', width: 420, height: 360 },
-  terminal: { title: 'Terminal', width: 480, height: 300 },
-  frame:    { title: 'Frame',    width: 600, height: 400 },
-  agent:    { title: 'Agent',    width: 520, height: 380 },
-  text:     { title: 'Text',     width: 260, height: 120 },
-  iframe:   { title: 'Web',      width: 520, height: 400 },
+  file:        { title: 'Untitled',    width: 420, height: 360 },
+  terminal:    { title: 'Terminal',    width: 480, height: 300 },
+  frame:       { title: 'Frame',       width: 600, height: 400 },
+  agent:       { title: 'Agent',       width: 520, height: 380 },
+  text:        { title: 'Text',        width: 260, height: 120 },
+  iframe:      { title: 'Web',         width: 520, height: 400 },
+  infographic: { title: 'Infographic', width: 560, height: 420 },
 };
 
-export const createNodeData = (type: CanvasNode['type']): FileNodeData | TerminalNodeData | FrameNodeData | AgentNodeData | TextNodeData | IframeNodeData => {
+export const createNodeData = (
+  type: CanvasNode['type'],
+):
+  | FileNodeData
+  | TerminalNodeData
+  | FrameNodeData
+  | AgentNodeData
+  | TextNodeData
+  | IframeNodeData
+  | InfographicNodeData => {
   switch (type) {
-    case 'file':     return { filePath: '', content: '', saved: false, modified: false };
-    case 'terminal': return { sessionId: '' };
-    case 'frame':    return { color: '#9575d4' };
-    case 'agent':    return { sessionId: '', agentType: 'claude-code', status: 'idle' };
-    case 'text':     return { content: '', textColor: '#1f2328', backgroundColor: 'transparent', fontSize: 18, autoSize: true };
-    case 'iframe':   return { url: '' };
+    case 'file':        return { filePath: '', content: '', saved: false, modified: false };
+    case 'terminal':    return { sessionId: '' };
+    case 'frame':       return { color: '#9575d4' };
+    case 'agent':       return { sessionId: '', agentType: 'claude-code', status: 'idle' };
+    case 'text':        return { content: '', textColor: '#1f2328', backgroundColor: 'transparent', fontSize: 18, autoSize: true };
+    case 'iframe':      return { url: '' };
+    case 'infographic': return { kind: 'html', filePath: '', sourcePrompt: '', status: 'empty' };
   }
 };
 


### PR DESCRIPTION
## Summary
Introduces a new "infographic" canvas node type that generates self-contained visual content (HTML or SVG) via LLM. Users can describe a visual (flowchart, data card, diagram, etc.) and the system generates and renders it in an isolated context.

## Key Changes

### New Components & Services
- **InfographicNodeBody** (`renderer/src/components/InfographicNodeBody/`): React component managing three UI states:
  - Empty: prompt input with SVG/HTML generation buttons
  - Generating: spinner with progress feedback
  - Ready: rendered content with regenerate affordance
  - Handles HTML via isolated `<webview>` (security boundary) and SVG via inline rendering
  
- **infographic-service.ts** (`main/infographic-service.ts`): Main process service for:
  - One-shot LLM generation using `generateText` (no tools/agents)
  - Dedicated system prompts for HTML and SVG output
  - Persistence to `~/.pulse-coder/canvas/{workspaceId}/infographics/{nodeId}.{html|svg}`
  - In-flight request tracking to cancel prior generations on new requests
  - IPC handlers for `infographic:generate` and `infographic:read`

### Canvas Agent Integration
- **canvas_create_infographic** tool: Allows agents to generate infographics programmatically
  - Accepts prompt, kind (html/svg), optional title and position
  - Derives readable titles from prompts automatically
  - Broadcasts updates to all windows via `broadcastInfographicUpdate`

### Type System & Data Model
- Added `InfographicNodeData` interface capturing:
  - `kind`: "html" or "svg"
  - `filePath`: on-disk location of generated content
  - `sourcePrompt`: user's original prompt
  - `status`: "empty" | "generating" | "ready" | "error"
  - `error`: error message when generation fails
- Updated `CanvasNode` type union and all node factory/creation paths

### UI & UX
- Added infographic button to FloatingToolbar and NodeContextMenu
- Added context menu option for infographic creation
- Type badge styling (purple #7c5cff) for infographic nodes
- Integrated into node detail context for agent awareness

### Implementation Details
- **Security**: HTML content loaded via `<webview>` with `file://` URLs (OS-level isolation, no script injection)
- **Persistence**: Content written to disk so canvas survives reloads without re-running the model
- **URL encoding**: File paths URI-encoded per segment to handle spaces/special characters
- **Sanitization**: Output cleaned of markdown fences and leading prose before storage
- **Abort handling**: Concurrent generation requests on same node cancel prior in-flight calls
- **Sync**: Draft prompt stays in sync with persisted state via useEffect (undo/redo support)

## Files Modified
- New: `InfographicNodeBody/index.tsx`, `InfographicNodeBody/index.css`, `infographic-service.ts`
- Updated: types.ts, nodeFactory.ts, canvas-agent/tools.ts, canvas-agent/context-builder.ts, preload/index.ts, FloatingToolbar, NodeContextMenu, CanvasNodeView, Canvas, main/index.ts

https://claude.ai/code/session_01BZRw8hbwjtbmdnWjnfBYLm