### PR TITLE
Add wipe guard to prevent accidental canvas overwrites

### DIFF
--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -72,8 +72,47 @@ async function loadCanvas(workspaceId: string): Promise<CanvasSaveData | null> {
   }
 }
 
-async function saveCanvas(workspaceId: string, data: CanvasSaveData): Promise<void> {
+interface SaveCanvasOptions {
+  /**
+   * Allow writing an empty `nodes: []` even when the on-disk canvas
+   * currently has nodes. Default false: the write is refused to protect
+   * against accidental wipes (buggy caller, partially-loaded snapshot).
+   * Opt in for flows that legitimately end up with zero nodes, such as
+   * deleting the last remaining node.
+   */
+  allowEmpty?: boolean;
+}
+
+async function saveCanvas(
+  workspaceId: string,
+  data: CanvasSaveData,
+  opts: SaveCanvasOptions = {},
+): Promise<void> {
   data.savedAt = new Date().toISOString();
+
+  // Mirror the guard in canvas-store.ts / packages/canvas-cli so every
+  // write path into canvas.json refuses to silently clobber existing
+  // nodes with an empty list.
+  if (!opts.allowEmpty && Array.isArray(data.nodes) && data.nodes.length === 0) {
+    try {
+      const raw = await fs.readFile(canvasPath(workspaceId), 'utf-8');
+      const existing = JSON.parse(raw) as CanvasSaveData;
+      const existingNodes = Array.isArray(existing.nodes) ? existing.nodes : [];
+      if (existingNodes.length > 0) {
+        throw new Error(
+          `[canvas-agent] refusing to overwrite ${existingNodes.length} on-disk nodes ` +
+          `with empty nodes for workspace "${workspaceId}". ` +
+          `Pass { allowEmpty: true } to saveCanvas if this wipe is intentional.`,
+        );
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message.startsWith('[canvas-agent] refusing')) {
+        throw err;
+      }
+      // File missing or unparseable — nothing to protect.
+    }
+  }
+
   await fs.writeFile(canvasPath(workspaceId), JSON.stringify(data, null, 2), 'utf-8');
 }
 
@@ -441,7 +480,9 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
         const fresh = (await loadCanvas(workspaceId)) ?? canvas;
         const freshIdx = fresh.nodes.findIndex(n => n.id === nodeId);
         if (freshIdx >= 0) fresh.nodes.splice(freshIdx, 1);
-        await saveCanvas(workspaceId, fresh);
+        // Deleting the last remaining node legitimately leaves nodes=[];
+        // opt in so the wipe guard doesn't refuse that case.
+        await saveCanvas(workspaceId, fresh, { allowEmpty: true });
         broadcastUpdate(workspaceId, [nodeId]);
 
         return JSON.stringify({ ok: true, nodeId });

--- a/apps/canvas-workspace/src/main/mcp-server.ts
+++ b/apps/canvas-workspace/src/main/mcp-server.ts
@@ -73,12 +73,49 @@ async function loadCanvas(workspaceId: string): Promise<CanvasSaveData | null> {
   }
 }
 
-async function saveCanvas(workspaceId: string, data: CanvasSaveData): Promise<void> {
-  await fs.writeFile(
-    join(STORE_DIR, workspaceId, 'canvas.json'),
-    JSON.stringify(data, null, 2),
-    'utf-8'
-  );
+interface SaveCanvasOptions {
+  /**
+   * Allow writing an empty `nodes: []` even when the on-disk canvas
+   * currently has nodes. Default false: the write is refused to protect
+   * against accidental wipes. Opt in for flows that legitimately end up
+   * with zero nodes (none of the current MCP tool handlers do, but the
+   * option exists so the API matches the other two saveCanvas
+   * implementations).
+   */
+  allowEmpty?: boolean;
+}
+
+async function saveCanvas(
+  workspaceId: string,
+  data: CanvasSaveData,
+  opts: SaveCanvasOptions = {},
+): Promise<void> {
+  const filePath = join(STORE_DIR, workspaceId, 'canvas.json');
+
+  // Mirror the guard in canvas-store.ts / packages/canvas-cli so every
+  // write path into canvas.json refuses to silently clobber existing
+  // nodes with an empty list.
+  if (!opts.allowEmpty && Array.isArray(data.nodes) && data.nodes.length === 0) {
+    try {
+      const raw = await fs.readFile(filePath, 'utf-8');
+      const existing = JSON.parse(raw) as CanvasSaveData;
+      const existingNodes = Array.isArray(existing.nodes) ? existing.nodes : [];
+      if (existingNodes.length > 0) {
+        throw new Error(
+          `[canvas-mcp] refusing to overwrite ${existingNodes.length} on-disk nodes ` +
+          `with empty nodes for workspace "${workspaceId}". ` +
+          `Pass { allowEmpty: true } to saveCanvas if this wipe is intentional.`,
+        );
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message.startsWith('[canvas-mcp] refusing')) {
+        throw err;
+      }
+      // File missing or unparseable — nothing to protect.
+    }
+  }
+
+  await fs.writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8');
 }
 
 async function loadWorkspaceManifest(): Promise<WorkspaceManifest> {

--- a/packages/canvas-cli/src/core/__tests__/store.test.ts
+++ b/packages/canvas-cli/src/core/__tests__/store.test.ts
@@ -12,8 +12,10 @@ import {
   deleteWorkspace,
   getWorkspaceDir,
   ensureWorkspaceDir,
+  commitNodeMutation,
+  CanvasWipeRefusedError,
 } from '../store';
-import type { CanvasSaveData } from '../types';
+import type { CanvasNode, CanvasSaveData } from '../types';
 
 let testDir: string;
 
@@ -107,6 +109,83 @@ describe('store', () => {
 
       const manifest = await loadWorkspaceManifest(testDir);
       expect(manifest.workspaces.find(e => e.id === wsId)).toBeUndefined();
+    });
+  });
+
+  describe('wipe guard', () => {
+    const makeNode = (id: string): CanvasNode => ({
+      id,
+      type: 'file',
+      title: id,
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      data: {},
+    });
+
+    it('refuses to overwrite a non-empty canvas with empty nodes by default', async () => {
+      const populated: CanvasSaveData = {
+        ...emptyCanvas,
+        nodes: [makeNode('node-a'), makeNode('node-b')],
+      };
+      await saveCanvas('ws-wipe', populated, testDir);
+
+      await expect(
+        saveCanvas('ws-wipe', emptyCanvas, testDir),
+      ).rejects.toBeInstanceOf(CanvasWipeRefusedError);
+
+      // Disk must be untouched.
+      const loaded = await loadCanvas('ws-wipe', testDir);
+      expect(loaded?.nodes).toHaveLength(2);
+    });
+
+    it('allows an empty write when { allowEmpty: true } is passed', async () => {
+      const populated: CanvasSaveData = {
+        ...emptyCanvas,
+        nodes: [makeNode('node-a')],
+      };
+      await saveCanvas('ws-wipe-ok', populated, testDir);
+
+      await saveCanvas('ws-wipe-ok', emptyCanvas, testDir, { allowEmpty: true });
+
+      const loaded = await loadCanvas('ws-wipe-ok', testDir);
+      expect(loaded?.nodes).toEqual([]);
+    });
+
+    it('allows empty writes when no canvas exists on disk', async () => {
+      // Fresh workspace: guard reads fail with ENOENT → fall through.
+      await expect(
+        saveCanvas('ws-fresh', emptyCanvas, testDir),
+      ).resolves.toBeUndefined();
+      const loaded = await loadCanvas('ws-fresh', testDir);
+      expect(loaded?.nodes).toEqual([]);
+    });
+
+    it('allows empty writes when disk canvas is also empty', async () => {
+      await saveCanvas('ws-empty', emptyCanvas, testDir, { allowEmpty: true });
+      await expect(
+        saveCanvas('ws-empty', emptyCanvas, testDir),
+      ).resolves.toBeUndefined();
+    });
+
+    it('lets commitNodeMutation delete the last remaining node', async () => {
+      const populated: CanvasSaveData = {
+        ...emptyCanvas,
+        nodes: [makeNode('node-only')],
+      };
+      await saveCanvas('ws-last', populated, testDir);
+
+      const result = await commitNodeMutation(
+        'ws-last',
+        { removeId: 'node-only' },
+        testDir,
+      );
+      expect(result).not.toBeNull();
+      expect(result?.nodes).toEqual([]);
+
+      const loaded = await loadCanvas('ws-last', testDir);
+      expect(loaded?.nodes).toEqual([]);
     });
   });
 

--- a/packages/canvas-cli/src/core/nodes.ts
+++ b/packages/canvas-cli/src/core/nodes.ts
@@ -146,7 +146,10 @@ export async function createNode(
       transform: { x: 0, y: 0, scale: 1 },
       savedAt: new Date().toISOString(),
     } satisfies CanvasSaveData;
-    await saveCanvas(workspaceId, canvas, storeDir);
+    // Bootstrap an empty canvas for a brand-new workspace. `loadCanvas`
+    // just returned null, so nothing is at risk; opt in to the wipe guard
+    // for intent-clarity.
+    await saveCanvas(workspaceId, canvas, storeDir, { allowEmpty: true });
   }
 
   const nodeId = `node-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;

--- a/packages/canvas-cli/src/core/store.ts
+++ b/packages/canvas-cli/src/core/store.ts
@@ -72,8 +72,67 @@ export async function loadCanvas(workspaceId: string, storeDir?: string): Promis
   }
 }
 
-export async function saveCanvas(workspaceId: string, data: CanvasSaveData, storeDir?: string): Promise<void> {
+export interface SaveCanvasOptions {
+  /**
+   * Allow the save to proceed even when `data.nodes` is empty and the on-disk
+   * canvas currently has nodes. Default `false`: the save throws to protect
+   * against accidental wipes (buggy caller flushing uninitialized state,
+   * partially-loaded in-memory snapshot, etc).
+   *
+   * Set to `true` for flows that legitimately may end up with an empty
+   * canvas, e.g. initializing a brand-new workspace or an explicit per-node
+   * deletion that happens to remove the last node.
+   */
+  allowEmpty?: boolean;
+}
+
+/**
+ * Thrown by `saveCanvas` when the incoming data has an empty `nodes` array
+ * but the on-disk canvas currently has nodes, and the caller did not pass
+ * `{ allowEmpty: true }`.
+ */
+export class CanvasWipeRefusedError extends Error {
+  readonly workspaceId: string;
+  readonly existingNodeCount: number;
+  constructor(workspaceId: string, existingNodeCount: number) {
+    super(
+      `[canvas-cli] refusing to overwrite ${existingNodeCount} on-disk nodes ` +
+      `with empty nodes for workspace "${workspaceId}". ` +
+      `Pass { allowEmpty: true } to saveCanvas if this wipe is intentional.`,
+    );
+    this.name = 'CanvasWipeRefusedError';
+    this.workspaceId = workspaceId;
+    this.existingNodeCount = existingNodeCount;
+  }
+}
+
+export async function saveCanvas(
+  workspaceId: string,
+  data: CanvasSaveData,
+  storeDir?: string,
+  opts: SaveCanvasOptions = {},
+): Promise<void> {
   await ensureWorkspaceDir(workspaceId, storeDir);
+
+  // Safety: don't silently overwrite a non-empty canvas with empty nodes.
+  // This mirrors the Electron main-process guard in
+  // `apps/canvas-workspace/src/main/canvas-store.ts` so every write path
+  // into `canvas.json` has the same protection.
+  if (!opts.allowEmpty && Array.isArray(data.nodes) && data.nodes.length === 0) {
+    try {
+      const raw = await fs.readFile(canvasPath(workspaceId, storeDir), 'utf-8');
+      const existing = JSON.parse(raw) as CanvasSaveData;
+      const existingNodes = Array.isArray(existing.nodes) ? existing.nodes : [];
+      if (existingNodes.length > 0) {
+        throw new CanvasWipeRefusedError(workspaceId, existingNodes.length);
+      }
+    } catch (err) {
+      if (err instanceof CanvasWipeRefusedError) throw err;
+      // File missing, unreadable, or unparseable — nothing on disk to
+      // protect, fall through and write.
+    }
+  }
+
   await fs.writeFile(canvasPath(workspaceId, storeDir), JSON.stringify(data, null, 2), 'utf-8');
 }
 
@@ -122,7 +181,9 @@ export async function commitNodeMutation(
   }
 
   fresh.savedAt = new Date().toISOString();
-  await saveCanvas(workspaceId, fresh, storeDir);
+  // `removeId` can legitimately reduce the canvas to 0 nodes when the user
+  // deletes the last one; opt in so the wipe guard doesn't reject that.
+  await saveCanvas(workspaceId, fresh, storeDir, { allowEmpty: true });
   return fresh;
 }
 
@@ -140,7 +201,9 @@ export async function createWorkspace(
       transform: { x: 0, y: 0, scale: 1 },
       savedAt: new Date().toISOString(),
     };
-    await saveCanvas(id, emptyCanvas, storeDir);
+    // Brand-new workspace: the canvas file shouldn't exist yet, but opt in
+    // explicitly so the wipe guard is never tripped by this bootstrap step.
+    await saveCanvas(id, emptyCanvas, storeDir, { allowEmpty: true });
 
     // Update manifest
     const manifest = await loadWorkspaceManifest(storeDir);


### PR DESCRIPTION
## Summary
Adds a safety mechanism across all canvas save operations to prevent accidentally overwriting a non-empty canvas with an empty one. This protects against bugs where partially-loaded or uninitialized state could silently delete all nodes.

## Key Changes

- **New `CanvasWipeRefusedError` exception** in `packages/canvas-cli/src/core/store.ts`: Thrown when attempting to save empty nodes over existing nodes without explicit opt-in.

- **`SaveCanvasOptions` interface** added to all three `saveCanvas` implementations:
  - `packages/canvas-cli/src/core/store.ts`
  - `apps/canvas-workspace/src/main/mcp-server.ts`
  - `apps/canvas-workspace/src/main/canvas-agent/tools.ts`
  
  The `allowEmpty` flag allows callers to explicitly permit empty writes when intentional.

- **Wipe guard logic** implemented in all three locations: Before writing empty nodes, the code checks if the on-disk canvas currently has nodes. If so, it throws an error unless `{ allowEmpty: true }` is passed. File-not-found errors are silently caught (nothing to protect).

- **Opt-in calls updated** where empty writes are legitimate:
  - `commitNodeMutation()`: Allows deletion of the last remaining node
  - `createWorkspace()`: Allows bootstrap of new empty canvas
  - `createNode()`: Allows bootstrap when workspace doesn't exist yet
  - Canvas agent delete tool: Allows deletion of last node

- **Comprehensive test suite** added in `packages/canvas-cli/src/core/__tests__/store.test.ts` covering:
  - Refusal to overwrite populated canvas with empty nodes
  - Allowance with `{ allowEmpty: true }` flag
  - Allowance for fresh workspaces (no file on disk)
  - Allowance when disk canvas is already empty
  - Proper handling of node deletion via `commitNodeMutation`

## Implementation Details

The guard is consistently implemented across all three save paths to ensure uniform protection regardless of which code path writes to `canvas.json`. The implementation gracefully handles missing or unparseable files by falling through to the write, since there's nothing on disk to protect in those cases.

https://claude.ai/code/session_017WQZqGjzrdbThc9y8trsZa