### PR TITLE
fix(canvas-agent): rescue pre-fix agent nodes via scrollback/sessionI…

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -31,7 +31,21 @@ export const AgentNodeBody = ({ node, rootFolder, workspaceId, onUpdate }: Props
   const [cwdInput, setCwdInput] = useState(data.cwd || '');
   const [promptInput, setPromptInput] = useState(data.inlinePrompt || '');
   const [recentCwds, setRecentCwds] = useState<string[]>(loadRecentCwds);
-  const [launched, setLaunched] = useState(status === 'running' || status === 'done');
+  // Treat any of the following as evidence that the node has been launched
+  // before and should skip the picker on mount:
+  //   - an explicit running/done/error status,
+  //   - saved scrollback (the 2s interval writes this even when a status
+  //     update was lost to the debounced-save race),
+  //   - a persisted sessionId (only set after spawn succeeds).
+  // The scrollback/sessionId fallbacks rescue nodes that were launched under
+  // an earlier buggy code path where status never made it to disk.
+  const [launched, setLaunched] = useState(
+    status === 'running'
+      || status === 'done'
+      || status === 'error'
+      || !!(data.scrollback && data.scrollback.length > 0)
+      || !!(data.sessionId && data.sessionId.length > 0),
+  );
 
   // Refs that survive across the picker→terminal transition so the
   // useEffect that spawns after re-render can read the user's selection.


### PR DESCRIPTION
…d fallback

Nodes launched before the previous commit could end up on disk with status='idle' (the launch-time status write was lost to the 800ms save debounce) while still carrying saved scrollback and sessionId from the 2s interval. Those nodes continued to render the empty picker after reload because `launched` was keyed solely on status.

Broaden the initial `launched` check to also fire on:
- status='error' (previously fell through to the picker, losing history),
- non-empty scrollback (2s interval persists this independently),
- non-empty sessionId (only ever assigned post-spawn).

This recovers historically-broken nodes on the first reload after the fix ships: spawnAgent's restored branch then replays the scrollback, normalizes status to 'done', and surfaces the Restart button.

https://claude.ai/code/session_017s2gWk2BSYQ8GFdo2RHanK