### PR TITLE
Add edge (connection) support to canvas with interactive editing

### DIFF
--- a/apps/canvas-workspace/src/main/canvas-agent/context-builder.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/context-builder.ts
@@ -8,7 +8,7 @@
 import { promises as fs } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
-import type { NodeSummary, WorkspaceSummary } from './types';
+import type { EdgeSummary, NodeSummary, WorkspaceSummary } from './types';
 import { getNodeRenderedText } from '../webview-registry';
 
 const STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
@@ -25,8 +25,29 @@ interface CanvasNode {
   updatedAt?: number;
 }
 
+type EdgeAnchor = 'top' | 'right' | 'bottom' | 'left' | 'auto';
+
+type EdgeEndpoint =
+  | { kind: 'node'; nodeId: string; anchor?: EdgeAnchor }
+  | { kind: 'point'; x: number; y: number };
+
+interface CanvasEdge {
+  id: string;
+  source: EdgeEndpoint;
+  target: EdgeEndpoint;
+  bend?: number;
+  arrowHead?: string;
+  arrowTail?: string;
+  stroke?: { color?: string; width?: number; style?: string };
+  label?: string;
+  kind?: string;
+  payload?: Record<string, unknown>;
+  updatedAt?: number;
+}
+
 interface CanvasSaveData {
   nodes: CanvasNode[];
+  edges?: CanvasEdge[];
   transform: { x: number; y: number; scale: number };
   savedAt: string;
 }
@@ -260,6 +281,44 @@ function summarizeNode(node: CanvasNode): NodeSummary {
 }
 
 /**
+ * Resolve a single endpoint into a "[nodeId] "Title"" / "point(x, y)"
+ * snippet used by the Connections block in the prompt. When the target
+ * node is missing (e.g. deleted) we fall back to the raw id so the
+ * agent can still reason about the reference.
+ */
+function describeEndpoint(
+  endpoint: CanvasEdge['source'],
+  nodesById: Map<string, CanvasNode>,
+): string {
+  if (endpoint.kind === 'point') {
+    return `point(${Math.round(endpoint.x)}, ${Math.round(endpoint.y)})`;
+  }
+  const node = nodesById.get(endpoint.nodeId);
+  if (!node) return `[${endpoint.nodeId}] (missing)`;
+  const title = node.title && node.title.trim().length > 0 ? node.title : node.type;
+  return `[${node.id}] "${title}"`;
+}
+
+/**
+ * Turn a raw edge into its prompt-facing summary. The string form is
+ * what the formatter prints; the raw node IDs are kept alongside it so
+ * the agent can invoke edge tools or `canvas_read_node` without needing
+ * to re-resolve the reference itself.
+ */
+function summarizeEdge(edge: CanvasEdge, nodesById: Map<string, CanvasNode>): EdgeSummary {
+  const summary: EdgeSummary = {
+    id: edge.id,
+    source: describeEndpoint(edge.source, nodesById),
+    target: describeEndpoint(edge.target, nodesById),
+  };
+  if (edge.source.kind === 'node') summary.sourceNodeId = edge.source.nodeId;
+  if (edge.target.kind === 'node') summary.targetNodeId = edge.target.nodeId;
+  if (edge.label) summary.label = edge.label;
+  if (edge.kind) summary.kind = edge.kind;
+  return summary;
+}
+
+/**
  * Build a lightweight workspace summary. This is cheap and always injected
  * into the Canvas Agent's system prompt so it "knows what's on the canvas".
  */
@@ -272,12 +331,16 @@ export async function buildWorkspaceSummary(workspaceId: string): Promise<Worksp
   const workspaceName = entry?.name ?? workspaceId;
   const canvasDir = join(STORE_DIR, workspaceId);
 
+  const nodesById = new Map(canvas.nodes.map((n) => [n.id, n]));
+  const edges = Array.isArray(canvas.edges) ? canvas.edges : [];
+
   return {
     workspaceId,
     workspaceName,
     canvasDir,
     nodeCount: canvas.nodes.length,
     nodes: canvas.nodes.map(summarizeNode),
+    edges: edges.length > 0 ? edges.map((e) => summarizeEdge(e, nodesById)) : undefined,
   };
 }
 
@@ -483,6 +546,20 @@ export function formatSummaryForPrompt(summary: WorkspaceSummary): string {
     lines.push('## Text Nodes');
     for (const n of byType.text) {
       lines.push(`- [${n.id}] **${n.title}**`);
+    }
+    lines.push('');
+  }
+
+  if (summary.edges?.length) {
+    lines.push('## Connections');
+    lines.push(
+      '_Arrows the user has drawn between (or around) nodes. Treat them as ' +
+      'semantic hints: "A → B" usually means A informs, depends on, or flows into B._',
+    );
+    for (const e of summary.edges) {
+      const labelHint = e.label ? ` — "${e.label}"` : '';
+      const kindHint = e.kind ? ` [${e.kind}]` : '';
+      lines.push(`- [${e.id}] ${e.source} → ${e.target}${labelHint}${kindHint}`);
     }
     lines.push('');
   }

--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -90,14 +90,39 @@ function canvasPath(workspaceId: string): string {
   return join(STORE_DIR, workspaceId, 'canvas.json');
 }
 
+function isEnoent(err: unknown): boolean {
+  return !!err && typeof err === 'object' && (err as { code?: string }).code === 'ENOENT';
+}
+
+/**
+ * Load `canvas.json` for a workspace.
+ *
+ * Returns `null` ONLY when the file is genuinely missing (ENOENT). Any
+ * other failure (I/O error, JSON parse error from catching another writer
+ * mid-flush) is rethrown so callers don't confuse "unreadable right now"
+ * with "doesn't exist" and wipe real data by bootstrapping an empty
+ * canvas. This mirrors `packages/canvas-cli/src/core/store.ts#loadCanvas`.
+ */
 async function loadCanvas(workspaceId: string): Promise<CanvasSaveData | null> {
+  let raw: string;
   try {
-    const raw = await fs.readFile(canvasPath(workspaceId), 'utf-8');
+    raw = await fs.readFile(canvasPath(workspaceId), 'utf-8');
+  } catch (err) {
+    if (isEnoent(err)) return null;
+    throw err;
+  }
+  try {
     const data = JSON.parse(raw) as CanvasSaveData;
     data.nodes = data.nodes ?? [];
     return data;
-  } catch {
-    return null;
+  } catch (err) {
+    // Parse failure almost always means another writer caught mid-flush.
+    // Do NOT return null here — the caller might treat that as "no canvas"
+    // and overwrite real user data with an empty bootstrap.
+    throw new Error(
+      `[canvas-agent] failed to parse canvas.json for workspace "${workspaceId}": ` +
+      `${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 }
 
@@ -123,10 +148,33 @@ async function saveCanvas(
   // write path into canvas.json refuses to silently clobber existing
   // nodes with an empty list.
   if (!opts.allowEmpty && Array.isArray(data.nodes) && data.nodes.length === 0) {
+    let raw: string | null = null;
     try {
-      const raw = await fs.readFile(canvasPath(workspaceId), 'utf-8');
-      const existing = JSON.parse(raw) as CanvasSaveData;
-      const existingNodes = Array.isArray(existing.nodes) ? existing.nodes : [];
+      raw = await fs.readFile(canvasPath(workspaceId), 'utf-8');
+    } catch (err) {
+      if (!isEnoent(err)) {
+        // Can't verify what's on disk — refuse rather than risk wiping a
+        // populated canvas that just happened to be unreadable this turn.
+        throw new Error(
+          `[canvas-agent] failed to read canvas.json while guarding empty write ` +
+          `for workspace "${workspaceId}": ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+      // ENOENT → nothing on disk, fall through and write.
+    }
+    if (raw !== null) {
+      let existingNodes: CanvasNode[];
+      try {
+        const existing = JSON.parse(raw) as CanvasSaveData;
+        existingNodes = Array.isArray(existing.nodes) ? existing.nodes : [];
+      } catch (err) {
+        // Parse failure mid-flight: treating "unparseable" as "nothing to
+        // protect" is exactly how silent wipes happen. Refuse the write.
+        throw new Error(
+          `[canvas-agent] failed to parse existing canvas.json while guarding empty write ` +
+          `for workspace "${workspaceId}": ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
       if (existingNodes.length > 0) {
         throw new Error(
           `[canvas-agent] refusing to overwrite ${existingNodes.length} on-disk nodes ` +
@@ -134,11 +182,6 @@ async function saveCanvas(
           `Pass { allowEmpty: true } to saveCanvas if this wipe is intentional.`,
         );
       }
-    } catch (err) {
-      if (err instanceof Error && err.message.startsWith('[canvas-agent] refusing')) {
-        throw err;
-      }
-      // File missing or unparseable — nothing to protect.
     }
   }
 

--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -40,8 +40,37 @@ interface CanvasNode {
   updatedAt?: number;
 }
 
+type EdgeAnchor = 'top' | 'right' | 'bottom' | 'left' | 'auto';
+
+type EdgeEndpoint =
+  | { kind: 'node'; nodeId: string; anchor?: EdgeAnchor }
+  | { kind: 'point'; x: number; y: number };
+
+type EdgeArrowCap = 'none' | 'triangle' | 'arrow' | 'dot' | 'bar';
+
+interface EdgeStroke {
+  color?: string;
+  width?: number;
+  style?: 'solid' | 'dashed' | 'dotted';
+}
+
+interface CanvasEdge {
+  id: string;
+  source: EdgeEndpoint;
+  target: EdgeEndpoint;
+  bend?: number;
+  arrowHead?: EdgeArrowCap;
+  arrowTail?: EdgeArrowCap;
+  stroke?: EdgeStroke;
+  label?: string;
+  kind?: string;
+  payload?: Record<string, unknown>;
+  updatedAt?: number;
+}
+
 interface CanvasSaveData {
   nodes: CanvasNode[];
+  edges?: CanvasEdge[];
   transform: { x: number; y: number; scale: number };
   savedAt: string;
 }
@@ -171,6 +200,50 @@ export interface CanvasTool {
 
 /** Prompts shorter than this are passed directly as CLI args; longer ones go to a file. */
 const INLINE_PROMPT_THRESHOLD = 256;
+
+let edgeIdCounter = 0;
+function genEdgeId(): string {
+  return `edge-${Date.now()}-${++edgeIdCounter}`;
+}
+
+/**
+ * Short human-readable title for an edge endpoint, used when describing
+ * connections back to the agent. Falls back to `point(x, y)` for free
+ * endpoints and `[id]` for unresolved nodes.
+ */
+function describeEndpoint(endpoint: EdgeEndpoint, nodesById: Map<string, CanvasNode>): string {
+  if (endpoint.kind === 'point') {
+    return `point(${Math.round(endpoint.x)}, ${Math.round(endpoint.y)})`;
+  }
+  const node = nodesById.get(endpoint.nodeId);
+  if (!node) return `[${endpoint.nodeId}] (missing)`;
+  return `[${node.id}] "${node.title || node.type}"`;
+}
+
+/**
+ * Build an EdgeEndpoint from the flat source/target fields on the tool
+ * input. Prefers `nodeId` when both a node ref and explicit x/y are
+ * supplied, and throws if neither is provided.
+ */
+function buildEndpoint(args: {
+  nodeId?: string;
+  anchor?: string;
+  x?: number;
+  y?: number;
+  which: 'source' | 'target';
+}): EdgeEndpoint {
+  if (args.nodeId) {
+    const anchor = (args.anchor as EdgeAnchor | undefined) ?? 'auto';
+    return { kind: 'node', nodeId: args.nodeId, anchor };
+  }
+  if (typeof args.x === 'number' && typeof args.y === 'number') {
+    return { kind: 'point', x: args.x, y: args.y };
+  }
+  throw new Error(
+    `canvas_create_edge: ${args.which} endpoint needs either \`${args.which}NodeId\` ` +
+      `or both \`${args.which}X\` and \`${args.which}Y\`.`,
+  );
+}
 
 // ─── Tool definitions ──────────────────────────────────────────────
 
@@ -733,6 +806,256 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
         broadcastUpdate(workspaceId, [nodeId]);
 
         return JSON.stringify({ ok: true, nodeId, title });
+      },
+    },
+
+    // ─── Edges (connections between nodes) ──────────────────────────
+
+    canvas_list_edges: {
+      name: 'canvas_list_edges',
+      description:
+        'List every edge (connection / arrow) on the canvas with resolved endpoint titles. ' +
+        'Useful when you need to understand what the user has linked together — e.g. to figure out ' +
+        'which file node backs an agent node, or to find nodes that reference each other. ' +
+        'Defaults to the current workspace; pass `workspaceId` to inspect another canvas the user @-mentioned.',
+      inputSchema: z.object({
+        workspaceId: z.string().optional().describe('Target workspace ID. Defaults to the current workspace.'),
+      }),
+      execute: async (input) => {
+        const targetWorkspaceId = (input.workspaceId as string) || workspaceId;
+        const canvas = await loadCanvas(targetWorkspaceId);
+        if (!canvas) return `Error: workspace not found: ${targetWorkspaceId}`;
+        const edges = canvas.edges ?? [];
+        if (edges.length === 0) return 'No edges on this canvas.';
+        const nodesById = new Map(canvas.nodes.map((n) => [n.id, n]));
+        return JSON.stringify(
+          edges.map((e) => ({
+            id: e.id,
+            source: describeEndpoint(e.source, nodesById),
+            target: describeEndpoint(e.target, nodesById),
+            label: e.label,
+            kind: e.kind,
+            arrowHead: e.arrowHead ?? 'triangle',
+            arrowTail: e.arrowTail ?? 'none',
+            stroke: e.stroke,
+            bend: e.bend ?? 0,
+          })),
+          null,
+          2,
+        );
+      },
+    },
+
+    canvas_create_edge: {
+      name: 'canvas_create_edge',
+      description:
+        'Connect two nodes (or free points) on the canvas with an arrow. ' +
+        'Endpoints are node-bound by default: pass `sourceNodeId` / `targetNodeId`. For a free-floating ' +
+        'endpoint (not attached to any node) pass `sourceX`/`sourceY` or `targetX`/`targetY` in canvas coords instead. ' +
+        'Use `label` to annotate the connection with text the user will see. ' +
+        'Use `kind` and `payload` to tag the edge with semantic info other tools can read later ' +
+        '(e.g. `kind: "depends-on"`, `payload: { reason: "uses the PRD" }`).',
+      inputSchema: z.object({
+        sourceNodeId: z.string().optional().describe('Source node ID (node-bound endpoint).'),
+        sourceAnchor: z.enum(['top', 'right', 'bottom', 'left', 'auto']).optional()
+          .describe('Which side of the source node to anchor to. Default: "auto" (edge-hugging).'),
+        sourceX: z.number().optional().describe('Free-point source X (canvas coords). Used if sourceNodeId is omitted.'),
+        sourceY: z.number().optional().describe('Free-point source Y (canvas coords). Used if sourceNodeId is omitted.'),
+        targetNodeId: z.string().optional().describe('Target node ID (node-bound endpoint).'),
+        targetAnchor: z.enum(['top', 'right', 'bottom', 'left', 'auto']).optional()
+          .describe('Which side of the target node to anchor to. Default: "auto".'),
+        targetX: z.number().optional().describe('Free-point target X (canvas coords).'),
+        targetY: z.number().optional().describe('Free-point target Y (canvas coords).'),
+        label: z.string().optional().describe('Optional short label displayed on the edge.'),
+        arrowHead: z.enum(['none', 'triangle', 'arrow', 'dot', 'bar']).optional()
+          .describe('Cap rendered at the target end. Default: "triangle".'),
+        arrowTail: z.enum(['none', 'triangle', 'arrow', 'dot', 'bar']).optional()
+          .describe('Cap rendered at the source end. Default: "none".'),
+        color: z.string().optional().describe('Stroke color (hex, e.g. "#1f2328").'),
+        width: z.number().optional().describe('Stroke width in px. Default 1.6.'),
+        style: z.enum(['solid', 'dashed', 'dotted']).optional().describe('Stroke dash style. Default "solid".'),
+        bend: z.number().optional().describe('Perpendicular peak offset of the curve. 0 (default) = straight line.'),
+        kind: z.string().optional().describe('Optional semantic tag (e.g. "depends-on", "references").'),
+        payload: z.record(z.string(), z.unknown()).optional().describe('Free-form extra data attached to the edge.'),
+      }),
+      execute: async (input) => {
+        let source: EdgeEndpoint;
+        let target: EdgeEndpoint;
+        try {
+          source = buildEndpoint({
+            nodeId: input.sourceNodeId as string | undefined,
+            anchor: input.sourceAnchor as string | undefined,
+            x: input.sourceX as number | undefined,
+            y: input.sourceY as number | undefined,
+            which: 'source',
+          });
+          target = buildEndpoint({
+            nodeId: input.targetNodeId as string | undefined,
+            anchor: input.targetAnchor as string | undefined,
+            x: input.targetX as number | undefined,
+            y: input.targetY as number | undefined,
+            which: 'target',
+          });
+        } catch (err) {
+          return `Error: ${err instanceof Error ? err.message : String(err)}`;
+        }
+
+        const canvas = await loadCanvas(workspaceId);
+        if (!canvas) return 'Error: workspace not found';
+
+        // Validate referenced nodes exist before committing — otherwise the
+        // agent could create a zombie edge pointing at a deleted node id.
+        if (source.kind === 'node' && !canvas.nodes.some((n) => n.id === source.nodeId)) {
+          return `Error: source node not found: ${source.nodeId}`;
+        }
+        if (target.kind === 'node' && !canvas.nodes.some((n) => n.id === target.nodeId)) {
+          return `Error: target node not found: ${target.nodeId}`;
+        }
+
+        const stroke: EdgeStroke | undefined =
+          input.color != null || input.width != null || input.style != null
+            ? {
+                color: (input.color as string | undefined) ?? '#1f2328',
+                width: (input.width as number | undefined) ?? 1.6,
+                style: (input.style as 'solid' | 'dashed' | 'dotted' | undefined) ?? 'solid',
+              }
+            : undefined;
+
+        const edge: CanvasEdge = {
+          id: genEdgeId(),
+          source,
+          target,
+          bend: (input.bend as number | undefined) ?? 0,
+          arrowHead: (input.arrowHead as EdgeArrowCap | undefined) ?? 'triangle',
+          arrowTail: (input.arrowTail as EdgeArrowCap | undefined) ?? 'none',
+          stroke,
+          label: input.label as string | undefined,
+          kind: input.kind as string | undefined,
+          payload: input.payload as Record<string, unknown> | undefined,
+          updatedAt: Date.now(),
+        };
+
+        const fresh = (await loadCanvas(workspaceId)) ?? canvas;
+        fresh.edges = [...(fresh.edges ?? []), edge];
+        await saveCanvas(workspaceId, fresh);
+
+        // Broadcast using the endpoint node IDs so the renderer highlights
+        // them as "recently changed". Edges with two free-point endpoints
+        // still trigger a reload via any existing node id on the canvas;
+        // if none exist we skip — the renderer only re-reads when at least
+        // one node id is supplied, which is fine for a canvas with zero nodes.
+        const touchedIds = [source, target]
+          .filter((ep): ep is Extract<EdgeEndpoint, { kind: 'node' }> => ep.kind === 'node')
+          .map((ep) => ep.nodeId);
+        if (touchedIds.length === 0 && fresh.nodes.length > 0) {
+          // Two free-point endpoints — nudge the renderer by referencing any
+          // node so it re-reads edges from disk.
+          touchedIds.push(fresh.nodes[0].id);
+        }
+        if (touchedIds.length > 0) broadcastUpdate(workspaceId, touchedIds);
+
+        return JSON.stringify({ ok: true, edgeId: edge.id });
+      },
+    },
+
+    canvas_update_edge: {
+      name: 'canvas_update_edge',
+      description:
+        'Update fields on an existing edge. Supports changing label, kind, payload, arrow caps, stroke, and bend. ' +
+        'Endpoint mutation is intentionally not supported — delete the edge and create a new one instead to keep the ' +
+        'semantics obvious in the undo history.',
+      inputSchema: z.object({
+        edgeId: z.string().describe('The ID of the edge to update.'),
+        label: z.string().optional(),
+        kind: z.string().optional(),
+        payload: z.record(z.string(), z.unknown()).optional(),
+        arrowHead: z.enum(['none', 'triangle', 'arrow', 'dot', 'bar']).optional(),
+        arrowTail: z.enum(['none', 'triangle', 'arrow', 'dot', 'bar']).optional(),
+        color: z.string().optional(),
+        width: z.number().optional(),
+        style: z.enum(['solid', 'dashed', 'dotted']).optional(),
+        bend: z.number().optional(),
+      }),
+      execute: async (input) => {
+        const edgeId = input.edgeId as string;
+        const canvas = await loadCanvas(workspaceId);
+        if (!canvas) return 'Error: workspace not found';
+        const edges = canvas.edges ?? [];
+        const idx = edges.findIndex((e) => e.id === edgeId);
+        if (idx === -1) return `Error: edge not found: ${edgeId}`;
+        const existing = edges[idx];
+        const nextStroke =
+          input.color != null || input.width != null || input.style != null
+            ? {
+                color: (input.color as string | undefined) ?? existing.stroke?.color ?? '#1f2328',
+                width: (input.width as number | undefined) ?? existing.stroke?.width ?? 1.6,
+                style:
+                  (input.style as 'solid' | 'dashed' | 'dotted' | undefined) ??
+                  existing.stroke?.style ??
+                  'solid',
+              }
+            : existing.stroke;
+        const next: CanvasEdge = {
+          ...existing,
+          label: input.label !== undefined ? (input.label as string) : existing.label,
+          kind: input.kind !== undefined ? (input.kind as string) : existing.kind,
+          payload:
+            input.payload !== undefined
+              ? (input.payload as Record<string, unknown>)
+              : existing.payload,
+          arrowHead: (input.arrowHead as EdgeArrowCap | undefined) ?? existing.arrowHead,
+          arrowTail: (input.arrowTail as EdgeArrowCap | undefined) ?? existing.arrowTail,
+          stroke: nextStroke,
+          bend: input.bend != null ? (input.bend as number) : existing.bend,
+          updatedAt: Date.now(),
+        };
+
+        const fresh = (await loadCanvas(workspaceId)) ?? canvas;
+        const freshEdges = [...(fresh.edges ?? [])];
+        const freshIdx = freshEdges.findIndex((e) => e.id === edgeId);
+        if (freshIdx >= 0) freshEdges[freshIdx] = next;
+        else freshEdges.push(next);
+        fresh.edges = freshEdges;
+        await saveCanvas(workspaceId, fresh);
+
+        const touchedIds = [next.source, next.target]
+          .filter((ep): ep is Extract<EdgeEndpoint, { kind: 'node' }> => ep.kind === 'node')
+          .map((ep) => ep.nodeId);
+        if (touchedIds.length === 0 && fresh.nodes.length > 0) {
+          touchedIds.push(fresh.nodes[0].id);
+        }
+        if (touchedIds.length > 0) broadcastUpdate(workspaceId, touchedIds);
+
+        return JSON.stringify({ ok: true, edgeId });
+      },
+    },
+
+    canvas_delete_edge: {
+      name: 'canvas_delete_edge',
+      description: 'Delete an edge by id.',
+      inputSchema: z.object({
+        edgeId: z.string().describe('The ID of the edge to delete.'),
+      }),
+      execute: async (input) => {
+        const edgeId = input.edgeId as string;
+        const canvas = await loadCanvas(workspaceId);
+        if (!canvas) return 'Error: workspace not found';
+        const existing = (canvas.edges ?? []).find((e) => e.id === edgeId);
+        if (!existing) return `Error: edge not found: ${edgeId}`;
+
+        const fresh = (await loadCanvas(workspaceId)) ?? canvas;
+        fresh.edges = (fresh.edges ?? []).filter((e) => e.id !== edgeId);
+        await saveCanvas(workspaceId, fresh);
+
+        const touchedIds = [existing.source, existing.target]
+          .filter((ep): ep is Extract<EdgeEndpoint, { kind: 'node' }> => ep.kind === 'node')
+          .map((ep) => ep.nodeId);
+        if (touchedIds.length === 0 && fresh.nodes.length > 0) {
+          touchedIds.push(fresh.nodes[0].id);
+        }
+        if (touchedIds.length > 0) broadcastUpdate(workspaceId, touchedIds);
+
+        return JSON.stringify({ ok: true, edgeId });
       },
     },
   };

--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -872,7 +872,7 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
         arrowTail: z.enum(['none', 'triangle', 'arrow', 'dot', 'bar']).optional()
           .describe('Cap rendered at the source end. Default: "none".'),
         color: z.string().optional().describe('Stroke color (hex, e.g. "#1f2328").'),
-        width: z.number().optional().describe('Stroke width in px. Default 1.6.'),
+        width: z.number().optional().describe('Stroke width in px. Default 2.4.'),
         style: z.enum(['solid', 'dashed', 'dotted']).optional().describe('Stroke dash style. Default "solid".'),
         bend: z.number().optional().describe('Perpendicular peak offset of the curve. 0 (default) = straight line.'),
         kind: z.string().optional().describe('Optional semantic tag (e.g. "depends-on", "references").'),
@@ -916,7 +916,7 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
           input.color != null || input.width != null || input.style != null
             ? {
                 color: (input.color as string | undefined) ?? '#1f2328',
-                width: (input.width as number | undefined) ?? 1.6,
+                width: (input.width as number | undefined) ?? 2.4,
                 style: (input.style as 'solid' | 'dashed' | 'dotted' | undefined) ?? 'solid',
               }
             : undefined;
@@ -988,7 +988,7 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
           input.color != null || input.width != null || input.style != null
             ? {
                 color: (input.color as string | undefined) ?? existing.stroke?.color ?? '#1f2328',
-                width: (input.width as number | undefined) ?? existing.stroke?.width ?? 1.6,
+                width: (input.width as number | undefined) ?? existing.stroke?.width ?? 2.4,
                 style:
                   (input.style as 'solid' | 'dashed' | 'dotted' | undefined) ??
                   existing.stroke?.style ??

--- a/apps/canvas-workspace/src/main/canvas-agent/types.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/types.ts
@@ -52,12 +52,31 @@ export interface NodeSummary {
   url?: string;
 }
 
+/**
+ * Compact description of a single edge for prompt / JSON responses.
+ * Endpoints are pre-resolved to human-readable labels so the agent
+ * doesn't need to cross-reference node IDs from the separate node list.
+ */
+export interface EdgeSummary {
+  id: string;
+  source: string;
+  target: string;
+  /** Raw node IDs when the endpoint is node-bound; useful for follow-up tool calls. */
+  sourceNodeId?: string;
+  targetNodeId?: string;
+  label?: string;
+  kind?: string;
+}
+
 export interface WorkspaceSummary {
   workspaceId: string;
   workspaceName: string;
   canvasDir: string;
   nodeCount: number;
   nodes: NodeSummary[];
+  /** Edges are optional for backwards compatibility with callers that
+   *  pre-date the connections feature. */
+  edges?: EdgeSummary[];
 }
 
 // ─── Events (main → renderer) ──────────────────────────────────────

--- a/apps/canvas-workspace/src/main/canvas-store.ts
+++ b/apps/canvas-workspace/src/main/canvas-store.ts
@@ -131,16 +131,54 @@ const knownNodeIds = new Map<string, Set<string>>();
  *      is how canvas-cli creates show up. Disk-only nodes whose IDs *are*
  *      known were deleted in the UI and must not be re-added.
  */
+const isEnoent = (err: unknown): boolean =>
+  !!err && typeof err === 'object' && (err as { code?: string }).code === 'ENOENT';
+
 const mergeExternalNodes = async (
   id: string,
   inMemoryData: CanvasSaveData,
 ): Promise<CanvasSaveData> => {
   const known = knownNodeIds.get(id) ?? new Set<string>();
 
+  let raw: string | null = null;
   try {
-    const raw = await fs.readFile(getFilePath(id), 'utf-8');
+    raw = await fs.readFile(getFilePath(id), 'utf-8');
+  } catch (err) {
+    if (isEnoent(err)) {
+      // Fresh canvas on disk — nothing to merge against; in-memory wins.
+      return inMemoryData;
+    }
+    // Transient I/O failure. If the renderer is asking us to write an
+    // empty canvas and we can't verify the disk is also empty, refuse
+    // rather than risk clobbering real data.
+    const memNodes = Array.isArray(inMemoryData.nodes) ? inMemoryData.nodes : [];
+    if (memNodes.length === 0) {
+      throw new Error(
+        `[canvas-store] cannot verify on-disk canvas for ${id} before empty write: ${String(err)}`,
+      );
+    }
+    return inMemoryData;
+  }
+
+  let diskNodes: CanvasNode[];
+  try {
     const diskData = JSON.parse(raw) as CanvasSaveData;
-    const diskNodes = Array.isArray(diskData.nodes) ? diskData.nodes : [];
+    diskNodes = Array.isArray(diskData.nodes) ? diskData.nodes : [];
+  } catch (err) {
+    // Caught another writer mid-flush. If memory is empty, we have no
+    // safe way to tell whether disk was empty too — refuse. Otherwise
+    // fall back to the memory snapshot we were given (the save handler's
+    // second-pass merge narrows this race further).
+    const memNodes = Array.isArray(inMemoryData.nodes) ? inMemoryData.nodes : [];
+    if (memNodes.length === 0) {
+      throw new Error(
+        `[canvas-store] canvas.json for ${id} was unparseable while guarding empty write: ${String(err)}`,
+      );
+    }
+    return inMemoryData;
+  }
+
+  try {
     const memoryNodes = Array.isArray(inMemoryData.nodes) ? inMemoryData.nodes : [];
 
     const memoryNodesRaw = Array.isArray(inMemoryData.nodes) ? inMemoryData.nodes : [];

--- a/apps/canvas-workspace/src/main/mcp-server.ts
+++ b/apps/canvas-workspace/src/main/mcp-server.ts
@@ -64,12 +64,32 @@ function getNodeCapabilities(type: NodeType): NodeCapability[] {
 
 // --- Canvas data access ---
 
+function isEnoent(err: unknown): boolean {
+  return !!err && typeof err === 'object' && (err as { code?: string }).code === 'ENOENT';
+}
+
+/**
+ * Returns null ONLY when canvas.json is truly missing (ENOENT). Any other
+ * failure (I/O, JSON parse error from catching another writer mid-flush)
+ * is rethrown so callers don't confuse "unreadable right now" with "doesn't
+ * exist" and overwrite real data. Mirrors canvas-cli / canvas-agent.
+ */
 async function loadCanvas(workspaceId: string): Promise<CanvasSaveData | null> {
+  const filePath = join(STORE_DIR, workspaceId, 'canvas.json');
+  let raw: string;
   try {
-    const raw = await fs.readFile(join(STORE_DIR, workspaceId, 'canvas.json'), 'utf-8');
+    raw = await fs.readFile(filePath, 'utf-8');
+  } catch (err) {
+    if (isEnoent(err)) return null;
+    throw err;
+  }
+  try {
     return JSON.parse(raw) as CanvasSaveData;
-  } catch {
-    return null;
+  } catch (err) {
+    throw new Error(
+      `[canvas-mcp] failed to parse canvas.json for workspace "${workspaceId}": ` +
+      `${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 }
 
@@ -96,10 +116,30 @@ async function saveCanvas(
   // write path into canvas.json refuses to silently clobber existing
   // nodes with an empty list.
   if (!opts.allowEmpty && Array.isArray(data.nodes) && data.nodes.length === 0) {
+    let raw: string | null = null;
     try {
-      const raw = await fs.readFile(filePath, 'utf-8');
-      const existing = JSON.parse(raw) as CanvasSaveData;
-      const existingNodes = Array.isArray(existing.nodes) ? existing.nodes : [];
+      raw = await fs.readFile(filePath, 'utf-8');
+    } catch (err) {
+      if (!isEnoent(err)) {
+        throw new Error(
+          `[canvas-mcp] failed to read canvas.json while guarding empty write ` +
+          `for workspace "${workspaceId}": ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+      // ENOENT → nothing on disk, fall through and write.
+    }
+    if (raw !== null) {
+      let existingNodes: CanvasNode[];
+      try {
+        const existing = JSON.parse(raw) as CanvasSaveData;
+        existingNodes = Array.isArray(existing.nodes) ? existing.nodes : [];
+      } catch (err) {
+        // Caught another writer mid-flush: refuse rather than wipe.
+        throw new Error(
+          `[canvas-mcp] failed to parse existing canvas.json while guarding empty write ` +
+          `for workspace "${workspaceId}": ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
       if (existingNodes.length > 0) {
         throw new Error(
           `[canvas-mcp] refusing to overwrite ${existingNodes.length} on-disk nodes ` +
@@ -107,11 +147,6 @@ async function saveCanvas(
           `Pass { allowEmpty: true } to saveCanvas if this wipe is intentional.`,
         );
       }
-    } catch (err) {
-      if (err instanceof Error && err.message.startsWith('[canvas-mcp] refusing')) {
-        throw err;
-      }
-      // File missing or unparseable — nothing to protect.
     }
   }
 

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
@@ -1,3 +1,4 @@
+import type React from 'react';
 import type { CanvasNode } from '../../types';
 import { NodeContextMenu } from '../NodeContextMenu';
 import { FloatingToolbar } from '../FloatingToolbar';
@@ -25,6 +26,9 @@ interface CanvasOverlaysProps {
   onResetTransform: () => void;
   onSearchSelect: (node: CanvasNode) => void;
   onCloseSearch: () => void;
+  /** Mousedown handler for the connect-mode overlay. Wired by the
+   *  parent Canvas component to the edge interaction hook. */
+  onConnectMouseDown?: (e: React.MouseEvent) => void;
 }
 
 export const CanvasOverlays = ({
@@ -42,6 +46,7 @@ export const CanvasOverlays = ({
   onResetTransform,
   onSearchSelect,
   onCloseSearch,
+  onConnectMouseDown,
 }: CanvasOverlaysProps) => (
   <>
     {nodes.length === 0 && !contextMenu && <CanvasEmptyHint />}
@@ -52,6 +57,28 @@ export const CanvasOverlays = ({
         y={contextMenu.screenY}
         onCreate={onCreateNode}
         onClose={onCloseContextMenu}
+      />
+    )}
+
+    {/* Full-canvas overlay active only in Connect mode. It intercepts
+        pointer events above nodes so mousedown on any location — node
+        or blank — begins an edge draft instead of a node drag. The
+        FloatingToolbar renders AFTER this element and has its own
+        position/z-index, so mode switching still works while this is
+        mounted. */}
+    {activeTool === 'connect' && (
+      <div
+        className="canvas-connect-overlay"
+        style={{
+          position: 'absolute',
+          inset: 0,
+          cursor: 'crosshair',
+          // Slightly below the zero-indexed floating toolbar
+          // (`.floating-toolbar` has its own z-index for chrome) but
+          // above nodes inside `.canvas-transform`.
+          zIndex: 5,
+        }}
+        onMouseDown={onConnectMouseDown}
       />
     )}
 

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
@@ -6,6 +6,7 @@ import { ZoomIndicator } from '../ZoomIndicator';
 import { SearchPalette } from '../SearchPalette';
 import { CanvasEmptyHint } from '../CanvasEmptyHint';
 import { EdgeStylePanel } from '../EdgeStylePanel';
+import { EdgeLabel } from '../EdgeLabel';
 
 interface CanvasOverlaysProps {
   nodes: CanvasNode[];
@@ -39,6 +40,15 @@ interface CanvasOverlaysProps {
   transform: CanvasTransform;
   onUpdateEdge?: (id: string, patch: Partial<CanvasEdge>) => void;
   onRemoveEdge?: (id: string) => void;
+  /** All edges — needed for label rendering. Labels render as DOM
+   *  overlay elements (outside .canvas-transform) so text stays crisp
+   *  and editable regardless of zoom. */
+  edges?: CanvasEdge[];
+  /** Id of the edge whose label is currently in edit mode, or null. */
+  editingEdgeLabelId?: string | null;
+  onStartEditEdgeLabel?: (id: string) => void;
+  onCommitEditEdgeLabel?: (id: string, label: string) => void;
+  onCancelEditEdgeLabel?: () => void;
 }
 
 export const CanvasOverlays = ({
@@ -61,6 +71,11 @@ export const CanvasOverlays = ({
   transform,
   onUpdateEdge,
   onRemoveEdge,
+  edges,
+  editingEdgeLabelId,
+  onStartEditEdgeLabel,
+  onCommitEditEdgeLabel,
+  onCancelEditEdgeLabel,
 }: CanvasOverlaysProps) => (
   <>
     {nodes.length === 0 && !contextMenu && <CanvasEmptyHint />}
@@ -113,6 +128,26 @@ export const CanvasOverlays = ({
         onRemove={onRemoveEdge}
       />
     )}
+
+    {/* Edge labels. Rendered for every edge that either carries a
+        non-empty label or is currently in edit mode. The edit-mode check
+        lets us open the input on a freshly-dbl-clicked unlabeled edge
+        without first persisting an empty string. */}
+    {edges && onStartEditEdgeLabel && onCommitEditEdgeLabel && onCancelEditEdgeLabel &&
+      edges
+        .filter((edge) => (edge.label && edge.label.length > 0) || editingEdgeLabelId === edge.id)
+        .map((edge) => (
+          <EdgeLabel
+            key={edge.id}
+            edge={edge}
+            nodes={nodes}
+            transform={transform}
+            isEditing={editingEdgeLabelId === edge.id}
+            onStartEdit={onStartEditEdgeLabel}
+            onCommit={onCommitEditEdgeLabel}
+            onCancel={onCancelEditEdgeLabel}
+          />
+        ))}
 
     <ZoomIndicator scale={scale} onReset={onResetTransform} />
 

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
@@ -1,10 +1,11 @@
 import type React from 'react';
-import type { CanvasNode } from '../../types';
+import type { CanvasEdge, CanvasNode, CanvasTransform } from '../../types';
 import { NodeContextMenu } from '../NodeContextMenu';
 import { FloatingToolbar } from '../FloatingToolbar';
 import { ZoomIndicator } from '../ZoomIndicator';
 import { SearchPalette } from '../SearchPalette';
 import { CanvasEmptyHint } from '../CanvasEmptyHint';
+import { EdgeStylePanel } from '../EdgeStylePanel';
 
 interface CanvasOverlaysProps {
   nodes: CanvasNode[];
@@ -29,6 +30,15 @@ interface CanvasOverlaysProps {
   /** Mousedown handler for the connect-mode overlay. Wired by the
    *  parent Canvas component to the edge interaction hook. */
   onConnectMouseDown?: (e: React.MouseEvent) => void;
+  /** Currently-selected edge (full object) — null when none or the
+   *  selection refers to a node. The overlays layer uses it to render
+   *  the floating EdgeStylePanel. */
+  selectedEdge?: CanvasEdge | null;
+  /** Canvas transform, needed by EdgeStylePanel to project the edge
+   *  midpoint from canvas space to screen space. */
+  transform: CanvasTransform;
+  onUpdateEdge?: (id: string, patch: Partial<CanvasEdge>) => void;
+  onRemoveEdge?: (id: string) => void;
 }
 
 export const CanvasOverlays = ({
@@ -47,6 +57,10 @@ export const CanvasOverlays = ({
   onSearchSelect,
   onCloseSearch,
   onConnectMouseDown,
+  selectedEdge,
+  transform,
+  onUpdateEdge,
+  onRemoveEdge,
 }: CanvasOverlaysProps) => (
   <>
     {nodes.length === 0 && !contextMenu && <CanvasEmptyHint />}
@@ -89,6 +103,16 @@ export const CanvasOverlays = ({
       chatPanelOpen={chatPanelOpen}
       onChatToggle={onChatToggle}
     />
+
+    {selectedEdge && onUpdateEdge && onRemoveEdge && (
+      <EdgeStylePanel
+        edge={selectedEdge}
+        nodes={nodes}
+        transform={transform}
+        onUpdate={onUpdateEdge}
+        onRemove={onRemoveEdge}
+      />
+    )}
 
     <ZoomIndicator scale={scale} onReset={onResetTransform} />
 

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
@@ -1,6 +1,7 @@
 import type React from 'react';
-import type { CanvasNode } from '../../types';
+import type { CanvasEdge, CanvasNode } from '../../types';
 import { CanvasNodeView } from '../CanvasNodeView';
+import { CanvasEdgesLayer } from '../CanvasEdgesLayer';
 import type { ResizeEdge } from '../../hooks/useNodeResize';
 
 interface CanvasSurfaceProps {
@@ -15,6 +16,7 @@ interface CanvasSurfaceProps {
   moving: boolean;
   sortedNodes: CanvasNode[];
   nodes: CanvasNode[];
+  edges: CanvasEdge[];
   rootFolder?: string;
   canvasId: string;
   canvasName?: string;
@@ -48,6 +50,7 @@ export const CanvasSurface = ({
   moving,
   sortedNodes,
   nodes,
+  edges,
   rootFolder,
   canvasId,
   canvasName,
@@ -74,6 +77,10 @@ export const CanvasSurface = ({
         : undefined,
     } as React.CSSProperties}
   >
+    {/* Edges render beneath nodes so node interactions keep working and
+        so the connection line visually terminates behind the node it
+        points at rather than being covered by it. */}
+    <CanvasEdgesLayer edges={edges} nodes={nodes} />
     {sortedNodes.map((node) => (
       <CanvasNodeView
         key={node.id}

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
@@ -57,6 +57,9 @@ interface CanvasSurfaceProps {
     e: React.MouseEvent,
     ctx: { s: Point; t: Point },
   ) => void;
+  /** Mousedown on the edge body (not a handle). Starts a "translate
+   *  the whole edge" drag. */
+  onEdgeBodyMouseDown: (edgeId: string, e: React.MouseEvent) => void;
 }
 
 export const CanvasSurface = ({
@@ -86,6 +89,7 @@ export const CanvasSurface = ({
   onFocus,
   onSelectEdge,
   onEdgeHandleMouseDown,
+  onEdgeBodyMouseDown,
 }: CanvasSurfaceProps) => (
   <div
     className={`canvas-transform${moving || animating ? ' canvas-transform--moving' : ''}`}
@@ -108,6 +112,7 @@ export const CanvasSurface = ({
       interactionState={edgeInteractionState}
       previewEndpoints={edgePreviewEndpoints}
       onHandleMouseDown={onEdgeHandleMouseDown}
+      onBodyMouseDown={onEdgeBodyMouseDown}
     />
     {sortedNodes.map((node) => (
       <CanvasNodeView

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
@@ -60,6 +60,8 @@ interface CanvasSurfaceProps {
   /** Mousedown on the edge body (not a handle). Starts a "translate
    *  the whole edge" drag. */
   onEdgeBodyMouseDown: (edgeId: string, e: React.MouseEvent) => void;
+  /** Double-click on the edge body. Opens the edge-label editor. */
+  onEdgeBodyDoubleClick: (edgeId: string, e: React.MouseEvent) => void;
 }
 
 export const CanvasSurface = ({
@@ -90,6 +92,7 @@ export const CanvasSurface = ({
   onSelectEdge,
   onEdgeHandleMouseDown,
   onEdgeBodyMouseDown,
+  onEdgeBodyDoubleClick,
 }: CanvasSurfaceProps) => (
   <div
     className={`canvas-transform${moving || animating ? ' canvas-transform--moving' : ''}`}
@@ -113,6 +116,7 @@ export const CanvasSurface = ({
       previewEndpoints={edgePreviewEndpoints}
       onHandleMouseDown={onEdgeHandleMouseDown}
       onBodyMouseDown={onEdgeBodyMouseDown}
+      onBodyDoubleClick={onEdgeBodyDoubleClick}
     />
     {sortedNodes.map((node) => (
       <CanvasNodeView

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
@@ -3,6 +3,7 @@ import type { CanvasEdge, CanvasNode } from '../../types';
 import { CanvasNodeView } from '../CanvasNodeView';
 import { CanvasEdgesLayer } from '../CanvasEdgesLayer';
 import type { ResizeEdge } from '../../hooks/useNodeResize';
+import type { EdgeInteractionState, Point } from '../../hooks/useEdgeInteraction';
 
 interface CanvasSurfaceProps {
   transform: { x: number; y: number; scale: number };
@@ -26,8 +27,15 @@ interface CanvasSurfaceProps {
   draggingIds: Set<string>;
   resizingId: string | null;
   selectedNodeIds: string[];
+  selectedEdgeId: string | null;
   highlightedId: string | null;
   externallyEditedIds: Set<string>;
+  /** Live edge interaction state — passed straight to the edges layer so it
+   *  can render the preview / highlight the hover target. */
+  edgeInteractionState: EdgeInteractionState | null;
+  /** Preview endpoints resolved by the interaction hook. Null when no
+   *  connect/move-end drag is in flight. */
+  edgePreviewEndpoints: { s: Point; t: Point } | null;
   onDragStart: (e: React.MouseEvent, node: CanvasNode) => void;
   onResizeStart: (
     e: React.MouseEvent,
@@ -42,6 +50,13 @@ interface CanvasSurfaceProps {
   onRemove: (id: string) => void;
   onSelect: (id: string) => void;
   onFocus: (node: CanvasNode) => void;
+  onSelectEdge: (id: string | null) => void;
+  onEdgeHandleMouseDown: (
+    edgeId: string,
+    handle: 'source' | 'target' | 'bend',
+    e: React.MouseEvent,
+    ctx: { s: Point; t: Point },
+  ) => void;
 }
 
 export const CanvasSurface = ({
@@ -58,14 +73,19 @@ export const CanvasSurface = ({
   draggingIds,
   resizingId,
   selectedNodeIds,
+  selectedEdgeId,
   highlightedId,
   externallyEditedIds,
+  edgeInteractionState,
+  edgePreviewEndpoints,
   onDragStart,
   onResizeStart,
   onUpdate,
   onRemove,
   onSelect,
   onFocus,
+  onSelectEdge,
+  onEdgeHandleMouseDown,
 }: CanvasSurfaceProps) => (
   <div
     className={`canvas-transform${moving || animating ? ' canvas-transform--moving' : ''}`}
@@ -80,7 +100,15 @@ export const CanvasSurface = ({
     {/* Edges render beneath nodes so node interactions keep working and
         so the connection line visually terminates behind the node it
         points at rather than being covered by it. */}
-    <CanvasEdgesLayer edges={edges} nodes={nodes} />
+    <CanvasEdgesLayer
+      edges={edges}
+      nodes={nodes}
+      selectedEdgeId={selectedEdgeId}
+      onSelectEdge={onSelectEdge}
+      interactionState={edgeInteractionState}
+      previewEndpoints={edgePreviewEndpoints}
+      onHandleMouseDown={onEdgeHandleMouseDown}
+    />
     {sortedNodes.map((node) => (
       <CanvasNodeView
         key={node.id}

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -45,6 +45,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
 
   const {
     nodes,
+    edges,
     loaded,
     externallyEditedIds,
     addNode,
@@ -282,6 +283,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
         moving={moving}
         sortedNodes={sortedNodes}
         nodes={nodes}
+        edges={edges}
         rootFolder={rootFolder}
         canvasId={canvasId}
         canvasName={canvasName}

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -218,7 +218,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
   const isBlankCanvasTarget = useCallback((target: EventTarget | null) => {
     if (!(target instanceof HTMLElement)) return false;
     return !target.closest(
-      '.canvas-node, .floating-toolbar, .zoom-indicator, .context-menu, .canvas-edges, .canvas-connect-overlay',
+      '.canvas-node, .floating-toolbar, .zoom-indicator, .context-menu, .canvas-edges, .canvas-connect-overlay, .edge-style-panel',
     );
   }, []);
 
@@ -286,6 +286,10 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
       // their own onMouseDown, but the click event can still arrive
       // here — ignore it so we don't wipe the selection we just set.
       if (target.closest('.canvas-edges')) return;
+      // EdgeStylePanel clicks already stopPropagation in its own handlers,
+      // but this belt-and-braces check covers any edge cases where an
+      // internal button relies on default bubbling.
+      if (target.closest('.edge-style-panel')) return;
       setSelectedNodeIds([]);
       setSelectedEdgeId(null);
     },
@@ -389,6 +393,17 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
         onSearchSelect={handleSearchSelect}
         onCloseSearch={() => setSearchOpen(false)}
         onConnectMouseDown={handleConnectOverlayMouseDown}
+        selectedEdge={edges.find((e) => e.id === selectedEdgeId) ?? null}
+        transform={transform}
+        onUpdateEdge={(id, patch) => {
+          // Style mutations are single-step edits; commit to history
+          // by default so undo reverses one color/width change at a time.
+          updateEdge(id, patch);
+        }}
+        onRemoveEdge={(id) => {
+          removeEdge(id);
+          setSelectedEdgeId(null);
+        }}
       />
     </div>
   );

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -188,6 +188,16 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
     updateEdge,
     commitHistory,
     edges,
+    // After the user commits one arrow, hop back to the select tool and
+    // auto-select the new edge so the style panel is immediately
+    // available. Matches tldraw's "draw one arrow, then edit" flow and
+    // fixes the "cursor is still in connect mode, hard to adjust the
+    // nodes around it" feedback.
+    onConnectCommitted: (edgeId) => {
+      setActiveTool('select');
+      setSelectedEdgeId(edgeId);
+      setSelectedNodeIds([]);
+    },
   });
 
   const handleEdgeHandleMouseDown = useCallback(

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -178,6 +178,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
     beginConnect,
     beginMoveEnd,
     beginMoveBend,
+    beginMoveEdge,
     getPreviewEndpoints,
   } = useEdgeInteraction({
     nodes,
@@ -223,6 +224,14 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
       beginConnect(e.clientX, e.clientY);
     },
     [beginConnect],
+  );
+
+  const handleEdgeBodyMouseDown = useCallback(
+    (edgeId: string, e: React.MouseEvent) => {
+      if (e.button !== 0) return;
+      beginMoveEdge(edgeId, e.clientX, e.clientY);
+    },
+    [beginMoveEdge],
   );
 
   const isBlankCanvasTarget = useCallback((target: EventTarget | null) => {
@@ -385,6 +394,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
           if (id) setSelectedNodeIds([]);
         }}
         onEdgeHandleMouseDown={handleEdgeHandleMouseDown}
+        onEdgeBodyMouseDown={handleEdgeBodyMouseDown}
       />
 
       <CanvasOverlays

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -7,6 +7,7 @@ import { useNodeResize } from '../../hooks/useNodeResize';
 import { useCanvasContext } from '../../hooks/useCanvasContext';
 import { useCanvasFit } from '../../hooks/useCanvasFit';
 import { useCanvasKeyboard } from '../../hooks/useCanvasKeyboard';
+import { useEdgeInteraction } from '../../hooks/useEdgeInteraction';
 import type { CanvasNode } from '../../types';
 import { computeFrameDepths } from '../../utils/frameHierarchy';
 import { CanvasSurface } from './CanvasSurface';
@@ -55,6 +56,9 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
     moveNode,
     moveNodes,
     resizeNode,
+    addEdge,
+    updateEdge,
+    removeEdge,
     setTransformForSave,
     flushSave,
     commitHistory,
@@ -63,6 +67,8 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
     duplicateNode,
     pasteNodes,
   } = useNodes(canvasId, () => {});
+
+  const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null);
 
   // Flush pending saves on window close or component unmount
   useEffect(() => {
@@ -120,6 +126,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
 
   useCanvasKeyboard({
     undo, redo, nodes, selectedNodeIds, setSelectedNodeIds,
+    selectedEdgeId, setSelectedEdgeId, removeEdge,
     duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, removeNodes,
     searchOpen, setSearchOpen, contextMenu, setContextMenu,
     setHighlightedId, handleFocusNode,
@@ -145,9 +152,74 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
   const { resizingId, onResizeStart, onResizeMove, onResizeEnd } =
     useNodeResize(resizeNode, transform.scale);
 
+  // sortedNodes is the render order (frames first, non-frames on top,
+  // deeper frames over shallower). It doubles as the hit-test stack
+  // for edge interactions — we iterate it in reverse so the topmost
+  // node under the cursor wins.
+  const sortedNodes = useMemo(
+    () => {
+      const depths = computeFrameDepths(nodes);
+      return [...nodes].sort((a, b) => {
+        if (a.type === 'frame' && b.type !== 'frame') return -1;
+        if (a.type !== 'frame' && b.type === 'frame') return 1;
+        if (a.type === 'frame' && b.type === 'frame') {
+          return (depths.get(a.id) ?? 0) - (depths.get(b.id) ?? 0);
+        }
+        return 0;
+      });
+    },
+    [nodes]
+  );
+
+  const getContainer = useCallback(() => containerRef.current, []);
+
+  const {
+    state: edgeInteractionState,
+    beginConnect,
+    beginMoveEnd,
+    beginMoveBend,
+    getPreviewEndpoints,
+  } = useEdgeInteraction({
+    nodes,
+    sortedNodes,
+    screenToCanvas,
+    getContainer,
+    addEdge,
+    updateEdge,
+    commitHistory,
+    edges,
+  });
+
+  const handleEdgeHandleMouseDown = useCallback(
+    (
+      edgeId: string,
+      handle: 'source' | 'target' | 'bend',
+      e: React.MouseEvent,
+      ctx: { s: { x: number; y: number }; t: { x: number; y: number } },
+    ) => {
+      if (handle === 'bend') {
+        beginMoveBend(edgeId, ctx.s, ctx.t, e.clientX, e.clientY);
+      } else {
+        beginMoveEnd(edgeId, handle, e.clientX, e.clientY);
+      }
+    },
+    [beginMoveBend, beginMoveEnd],
+  );
+
+  const handleConnectOverlayMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.button !== 0) return;
+      e.preventDefault();
+      beginConnect(e.clientX, e.clientY);
+    },
+    [beginConnect],
+  );
+
   const isBlankCanvasTarget = useCallback((target: EventTarget | null) => {
     if (!(target instanceof HTMLElement)) return false;
-    return !target.closest('.canvas-node, .floating-toolbar, .zoom-indicator, .context-menu');
+    return !target.closest(
+      '.canvas-node, .floating-toolbar, .zoom-indicator, .context-menu, .canvas-edges, .canvas-connect-overlay',
+    );
   }, []);
 
   const handleContextMenu = useCallback(
@@ -207,8 +279,15 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
   const handleCanvasClick = useCallback(
     (e: React.MouseEvent) => {
       if (contextMenu) setContextMenu(null);
-      if ((e.target as HTMLElement).closest('.canvas-node')) return;
+      const target = e.target as HTMLElement;
+      if (target.closest('.canvas-node')) return;
+      // Clicking inside the edges SVG (either a hit-proxy or a handle)
+      // lands on a child of .canvas-edges. Those children stopPropagate
+      // their own onMouseDown, but the click event can still arrive
+      // here — ignore it so we don't wipe the selection we just set.
+      if (target.closest('.canvas-edges')) return;
       setSelectedNodeIds([]);
+      setSelectedEdgeId(null);
     },
     [contextMenu]
   );
@@ -228,24 +307,6 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
     onResizeEnd();
     commitHistory();
   }, [canvasMouseUp, onDragEnd, onResizeEnd, commitHistory]);
-
-  const sortedNodes = useMemo(
-    () => {
-      const depths = computeFrameDepths(nodes);
-      return [...nodes].sort((a, b) => {
-        // Non-frames always render in front of frames.
-        if (a.type === 'frame' && b.type !== 'frame') return -1;
-        if (a.type !== 'frame' && b.type === 'frame') return 1;
-        // Among frames, shallower frames render first (i.e. behind deeper
-        // frames), so a nested child frame paints on top of its parent.
-        if (a.type === 'frame' && b.type === 'frame') {
-          return (depths.get(a.id) ?? 0) - (depths.get(b.id) ?? 0);
-        }
-        return 0;
-      });
-    },
-    [nodes]
-  );
 
   const cursorClass = activeTool === 'hand'
     ? ' canvas-container--hand'
@@ -291,14 +352,25 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
         draggingIds={draggingIds}
         resizingId={resizingId}
         selectedNodeIds={selectedNodeIds}
+        selectedEdgeId={selectedEdgeId}
         highlightedId={highlightedId}
         externallyEditedIds={externallyEditedIds}
+        edgeInteractionState={edgeInteractionState}
+        edgePreviewEndpoints={getPreviewEndpoints()}
         onDragStart={onDragStart}
         onResizeStart={onResizeStart}
         onUpdate={updateNode}
         onRemove={removeNode}
-        onSelect={(id) => setSelectedNodeIds([id])}
+        onSelect={(id) => {
+          setSelectedNodeIds([id]);
+          setSelectedEdgeId(null);
+        }}
         onFocus={handleFocusNode}
+        onSelectEdge={(id) => {
+          setSelectedEdgeId(id);
+          if (id) setSelectedNodeIds([]);
+        }}
+        onEdgeHandleMouseDown={handleEdgeHandleMouseDown}
       />
 
       <CanvasOverlays
@@ -316,6 +388,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
         onResetTransform={resetTransform}
         onSearchSelect={handleSearchSelect}
         onCloseSearch={() => setSearchOpen(false)}
+        onConnectMouseDown={handleConnectOverlayMouseDown}
       />
     </div>
   );

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -69,6 +69,11 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
   } = useNodes(canvasId, () => {});
 
   const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null);
+  // Which edge (if any) is in label-edit mode. Driven by dbl-click on
+  // the edge body; cleared on blur/Escape/Enter. Stored here (not inside
+  // EdgeLabel) so that selecting a different edge or deleting the edge
+  // can forcibly end the edit session.
+  const [editingEdgeLabelId, setEditingEdgeLabelId] = useState<string | null>(null);
 
   // Flush pending saves on window close or component unmount
   useEffect(() => {
@@ -234,6 +239,33 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
     [beginMoveEdge],
   );
 
+  const handleEdgeBodyDoubleClick = useCallback(
+    (edgeId: string) => {
+      // Ensure the edge is selected before editing so the style panel
+      // stays in sync with the edge the user is labeling.
+      setSelectedEdgeId(edgeId);
+      setSelectedNodeIds([]);
+      setEditingEdgeLabelId(edgeId);
+    },
+    [],
+  );
+
+  const handleCommitEditEdgeLabel = useCallback(
+    (edgeId: string, label: string) => {
+      // Normalize: empty or whitespace-only labels clear the field back
+      // to `undefined`, keeping the stored data clean (and making the
+      // label chip disappear from the overlay).
+      const trimmed = label.trim();
+      updateEdge(edgeId, { label: trimmed.length > 0 ? trimmed : undefined });
+      setEditingEdgeLabelId(null);
+    },
+    [updateEdge],
+  );
+
+  const handleCancelEditEdgeLabel = useCallback(() => {
+    setEditingEdgeLabelId(null);
+  }, []);
+
   const isBlankCanvasTarget = useCallback((target: EventTarget | null) => {
     if (!(target instanceof HTMLElement)) return false;
     return !target.closest(
@@ -395,6 +427,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
         }}
         onEdgeHandleMouseDown={handleEdgeHandleMouseDown}
         onEdgeBodyMouseDown={handleEdgeBodyMouseDown}
+        onEdgeBodyDoubleClick={handleEdgeBodyDoubleClick}
       />
 
       <CanvasOverlays
@@ -423,7 +456,13 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
         onRemoveEdge={(id) => {
           removeEdge(id);
           setSelectedEdgeId(null);
+          if (editingEdgeLabelId === id) setEditingEdgeLabelId(null);
         }}
+        edges={edges}
+        editingEdgeLabelId={editingEdgeLabelId}
+        onStartEditEdgeLabel={handleEdgeBodyDoubleClick}
+        onCommitEditEdgeLabel={handleCommitEditEdgeLabel}
+        onCancelEditEdgeLabel={handleCancelEditEdgeLabel}
       />
     </div>
   );

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
@@ -136,14 +136,21 @@ const useMarkerDefs = (edges: CanvasEdge[]) => {
 const MarkerShape = ({ cap, color }: { cap: EdgeArrowCap; color: string }) => {
   switch (cap) {
     case 'triangle':
-      return <path d="M0,0 L10,5 L0,10 z" fill={color} />;
+      // A touch slimmer than a square triangle (base 7 vs length 10)
+      // reads as more "arrow-like" than the old 10×10 triangle, which
+      // looked stubby next to longer edges.
+      return <path d="M0,1.5 L10,5 L0,8.5 z" fill={color} />;
     case 'arrow':
+      // Open chevron. strokeWidth is expressed in the marker's viewBox
+      // coord system, which — thanks to markerUnits="strokeWidth" — is
+      // proportional to the line's stroke-width. A value of 1.8 ends up
+      // ≈0.9× the line's own stroke, matching classic open-arrow weight.
       return (
         <path
-          d="M0,0 L10,5 L0,10"
+          d="M0,1.5 L10,5 L0,8.5"
           fill="none"
           stroke={color}
-          strokeWidth={1.5}
+          strokeWidth={1.8}
           strokeLinecap="round"
           strokeLinejoin="round"
         />
@@ -168,13 +175,23 @@ const Markers = ({
       <marker
         key={id}
         id={id}
-        markerWidth={12}
-        markerHeight={12}
+        // markerUnits="strokeWidth" makes the marker (and its inner
+        // geometry) scale with the line's stroke-width. A fixed 12×12
+        // marker looked undersized on thick (3.6) strokes and comically
+        // oversized on a stroke this thin — scaling keeps proportions
+        // consistent across the width ladder.
+        markerWidth={5}
+        markerHeight={5}
         viewBox="0 0 10 10"
         orient={side === 'head' ? 'auto' : 'auto-start-reverse'}
-        refX={cap === 'triangle' ? 10 : 5}
+        // 'triangle' and 'arrow' have their point at (10, 5) in the
+        // viewBox — the refPoint must sit *on* the point so that point
+        // lands exactly at the path endpoint. 'dot' and 'bar' are
+        // symmetric, so centering (refX=5) places them *over* the
+        // endpoint, which is the conventional look.
+        refX={cap === 'triangle' || cap === 'arrow' ? 10 : 5}
         refY={5}
-        markerUnits="userSpaceOnUse"
+        markerUnits="strokeWidth"
       >
         <MarkerShape cap={cap} color={color} />
       </marker>
@@ -468,19 +485,20 @@ const PreviewEdge = ({
       {/* Also register the preview's triangle-on-blue marker so
           marker-end="url(#…)" resolves. Duplicate marker defs are
           harmless; the <defs> above won't include this combo unless an
-          edge already uses blue. */}
+          edge already uses blue. Shape + sizing mirrors the committed-
+          edge markers so preview and final arrow look identical. */}
       <defs>
         <marker
           id={capId('edge-head', 'triangle', SELECTION_COLOR)}
-          markerWidth={12}
-          markerHeight={12}
+          markerWidth={5}
+          markerHeight={5}
           viewBox="0 0 10 10"
           orient="auto"
           refX={10}
           refY={5}
-          markerUnits="userSpaceOnUse"
+          markerUnits="strokeWidth"
         >
-          <path d="M0,0 L10,5 L0,10 z" fill={SELECTION_COLOR} />
+          <path d="M0,1.5 L10,5 L0,8.5 z" fill={SELECTION_COLOR} />
         </marker>
       </defs>
       {node && (

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
@@ -1,0 +1,215 @@
+import { useMemo } from 'react';
+import type { CanvasEdge, CanvasNode, EdgeArrowCap, EdgeStroke } from '../types';
+import { resolveEndpoint } from '../utils/edgeFactory';
+
+interface Props {
+  edges: CanvasEdge[];
+  nodes: CanvasNode[];
+}
+
+const DEFAULT_STROKE: Required<EdgeStroke> = {
+  color: '#1f2328',
+  width: 1.6,
+  style: 'solid',
+};
+
+const strokeDasharray = (style: EdgeStroke['style']): string | undefined => {
+  switch (style) {
+    case 'dashed': return '6 4';
+    case 'dotted': return '1.5 3';
+    case 'solid':
+    default:       return undefined;
+  }
+};
+
+/**
+ * Signed perpendicular offset → quadratic Bezier control point.
+ * The control point sits at (midpoint + normal * bend). A positive bend
+ * bows the curve to the right of the s→t direction, negative to the left.
+ * Bend of 0 produces a degenerate quadratic that renders as a straight
+ * line, which is exactly what we want.
+ */
+const bendControlPoint = (
+  sx: number, sy: number,
+  tx: number, ty: number,
+  bend: number,
+): { cx: number; cy: number } => {
+  const mx = (sx + tx) / 2;
+  const my = (sy + ty) / 2;
+  if (!bend) return { cx: mx, cy: my };
+  const dx = tx - sx;
+  const dy = ty - sy;
+  const len = Math.hypot(dx, dy) || 1;
+  // Unit perpendicular (rotate 90° CCW: (dy/len, -dx/len) points to the
+  // right when looking from source to target in screen coords).
+  const nx = dy / len;
+  const ny = -dx / len;
+  return { cx: mx + nx * bend, cy: my + ny * bend };
+};
+
+const capId = (
+  prefix: string,
+  cap: EdgeArrowCap,
+  color: string,
+): string => {
+  // One marker per (cap, color) — no per-edge markers. This keeps the
+  // SVG lean when many edges share the same style. Color is part of the
+  // id because <marker> fill inherits from the marker, not the path.
+  const hex = color.replace(/[^a-zA-Z0-9]/g, '_');
+  return `${prefix}-${cap}-${hex}`;
+};
+
+/**
+ * Emit exactly the set of <marker> defs the current edges reference.
+ * Walking the edges once and de-duplicating avoids bloating the DOM
+ * with unused caps.
+ */
+const useMarkerDefs = (edges: CanvasEdge[]) => {
+  return useMemo(() => {
+    const markers = new Map<
+      string,
+      { id: string; cap: EdgeArrowCap; color: string; side: 'head' | 'tail' }
+    >();
+    for (const edge of edges) {
+      const color = edge.stroke?.color ?? DEFAULT_STROKE.color;
+      const head = edge.arrowHead ?? 'triangle';
+      const tail = edge.arrowTail ?? 'none';
+      if (head !== 'none') {
+        const id = capId('edge-head', head, color);
+        if (!markers.has(id)) markers.set(id, { id, cap: head, color, side: 'head' });
+      }
+      if (tail !== 'none') {
+        const id = capId('edge-tail', tail, color);
+        if (!markers.has(id)) markers.set(id, { id, cap: tail, color, side: 'tail' });
+      }
+    }
+    return Array.from(markers.values());
+  }, [edges]);
+};
+
+const MarkerShape = ({ cap, color }: { cap: EdgeArrowCap; color: string }) => {
+  switch (cap) {
+    case 'triangle':
+      // Filled triangle pointing along the +x axis (tangent direction).
+      return <path d="M0,0 L10,5 L0,10 z" fill={color} />;
+    case 'arrow':
+      // Open V-shape.
+      return (
+        <path
+          d="M0,0 L10,5 L0,10"
+          fill="none"
+          stroke={color}
+          strokeWidth={1.5}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      );
+    case 'dot':
+      return <circle cx={5} cy={5} r={3.2} fill={color} />;
+    case 'bar':
+      return <rect x={4} y={0} width={2} height={10} fill={color} />;
+    case 'none':
+    default:
+      return null;
+  }
+};
+
+const Markers = ({
+  markers,
+}: {
+  markers: Array<{ id: string; cap: EdgeArrowCap; color: string; side: 'head' | 'tail' }>;
+}) => (
+  <defs>
+    {markers.map(({ id, cap, color, side }) => (
+      <marker
+        key={id}
+        id={id}
+        markerWidth={12}
+        markerHeight={12}
+        viewBox="0 0 10 10"
+        // Head caps point forward along the path's tangent; tail caps are
+        // flipped 180° so they point away from the source.
+        orient={side === 'head' ? 'auto' : 'auto-start-reverse'}
+        // Offset the reference point so the cap sits at the path end
+        // without overshooting. For triangles we put refX at the tip (10)
+        // so the tip lands exactly on the endpoint.
+        refX={cap === 'triangle' ? 10 : 5}
+        refY={5}
+        markerUnits="userSpaceOnUse"
+      >
+        <MarkerShape cap={cap} color={color} />
+      </marker>
+    ))}
+  </defs>
+);
+
+/**
+ * Renders all edges for the canvas as a single SVG layer stacked beneath
+ * the node views. Lives inside `.canvas-transform`, so panning/zooming
+ * gets it for free; `vector-effect="non-scaling-stroke"` keeps line
+ * weights visually constant through scale.
+ *
+ * Interaction is disabled in Step 1 — the layer is `pointer-events: none`
+ * end-to-end. Step 2 will add a wider transparent hit-proxy path per
+ * edge for selection/dragging.
+ */
+export const CanvasEdgesLayer = ({ edges, nodes }: Props) => {
+  const nodesById = useMemo(() => {
+    const m = new Map<string, CanvasNode>();
+    for (const n of nodes) m.set(n.id, n);
+    return m;
+  }, [nodes]);
+
+  const markers = useMarkerDefs(edges);
+
+  if (edges.length === 0) return null;
+
+  return (
+    <svg
+      className="canvas-edges"
+      // Tiny base size — we rely on overflow:visible so paths at arbitrary
+      // canvas coords (including negative) still render. The parent div
+      // does the panning/zooming via CSS transform; we just draw in its
+      // local coordinate space.
+      width={1}
+      height={1}
+      style={{
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        overflow: 'visible',
+        pointerEvents: 'none',
+      }}
+    >
+      <Markers markers={markers} />
+      {edges.map((edge) => {
+        const s = resolveEndpoint(edge.source, nodesById);
+        const t = resolveEndpoint(edge.target, nodesById);
+        const bend = edge.bend ?? 0;
+        const { cx, cy } = bendControlPoint(s.x, s.y, t.x, t.y, bend);
+        const d = bend === 0
+          ? `M ${s.x} ${s.y} L ${t.x} ${t.y}`
+          : `M ${s.x} ${s.y} Q ${cx} ${cy} ${t.x} ${t.y}`;
+
+        const stroke = { ...DEFAULT_STROKE, ...edge.stroke };
+        const head = edge.arrowHead ?? 'triangle';
+        const tail = edge.arrowTail ?? 'none';
+
+        return (
+          <path
+            key={edge.id}
+            d={d}
+            fill="none"
+            stroke={stroke.color}
+            strokeWidth={stroke.width}
+            strokeDasharray={strokeDasharray(stroke.style)}
+            strokeLinecap="round"
+            vectorEffect="non-scaling-stroke"
+            markerEnd={head !== 'none' ? `url(#${capId('edge-head', head, stroke.color)})` : undefined}
+            markerStart={tail !== 'none' ? `url(#${capId('edge-tail', tail, stroke.color)})` : undefined}
+          />
+        );
+      })}
+    </svg>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
@@ -181,12 +181,12 @@ const Markers = ({
         key={id}
         id={id}
         // markerUnits="strokeWidth" makes the marker (and its inner
-        // geometry) scale with the line's stroke-width. A fixed 12×12
-        // marker looked undersized on thick (3.6) strokes and comically
-        // oversized on a stroke this thin — scaling keeps proportions
-        // consistent across the width ladder.
-        markerWidth={5}
-        markerHeight={5}
+        // geometry) scale with the line's stroke-width so the arrow
+        // stays proportional to whichever width the user picks. 4×4
+        // keeps the rendered cap slim — length ≈ 4× stroke, which
+        // matches how tldraw/Figma size their arrow heads.
+        markerWidth={4}
+        markerHeight={4}
         viewBox="0 0 10 10"
         orient={side === 'head' ? 'auto' : 'auto-start-reverse'}
         // 'triangle' and 'arrow' have their point at (10, 5) in the
@@ -327,7 +327,11 @@ export const CanvasEdgesLayer = ({
               }}
             />
             {/* Selection underlay: soft blue tint, rendered under the
-                real stroke so the edge's own color still reads. */}
+                real stroke so the edge's own color still reads. Scales
+                with the canvas (no non-scaling-stroke) so it stays
+                visibly wider than the main stroke at every zoom — a
+                fixed-pixel underlay would get visually swallowed once
+                the zoomed-up main stroke caught up in width. */}
             {isSelected && (
               <path
                 d={d}
@@ -336,7 +340,6 @@ export const CanvasEdgesLayer = ({
                 strokeOpacity={0.35}
                 strokeWidth={(stroke.width ?? DEFAULT_STROKE.width) + 6}
                 strokeLinecap="round"
-                vectorEffect="non-scaling-stroke"
               />
             )}
             {/* Handles for the selected edge. Rendered BEFORE the visible
@@ -364,7 +367,14 @@ export const CanvasEdgesLayer = ({
                 line. Using "butt" ends the stroke flush with the path
                 endpoint so the triangle's tip becomes the exact rightmost
                 point of the arrow. Edges with no caps at all keep "round"
-                for their nicer free-end look. */}
+                for their nicer free-end look.
+
+                No vectorEffect here: content strokes should scale with
+                canvas zoom so the marker (also sized in user-space via
+                markerUnits="strokeWidth") stays proportional to the line
+                at every zoom. With non-scaling-stroke the line would
+                stay thin while the marker ballooned, producing the
+                cartoonishly oversized arrow reported earlier. */}
             <path
               d={d}
               fill="none"
@@ -372,7 +382,6 @@ export const CanvasEdgesLayer = ({
               strokeWidth={stroke.width}
               strokeDasharray={strokeDasharray(stroke.style)}
               strokeLinecap={head !== 'none' || tail !== 'none' ? 'butt' : 'round'}
-              vectorEffect="non-scaling-stroke"
               markerEnd={head !== 'none' ? `url(#${capId('edge-head', head, stroke.color)})` : undefined}
               markerStart={tail !== 'none' ? `url(#${capId('edge-tail', tail, stroke.color)})` : undefined}
             />
@@ -496,7 +505,6 @@ const PreviewEdge = ({
         // marker at the end, a rounded cap would poke past the triangle
         // tip (see the committed-edge comment for the full explanation).
         strokeLinecap="butt"
-        vectorEffect="non-scaling-stroke"
         markerEnd={`url(#${capId('edge-head', 'triangle', SELECTION_COLOR)})`}
         style={{ pointerEvents: 'none' }}
       />
@@ -508,8 +516,8 @@ const PreviewEdge = ({
       <defs>
         <marker
           id={capId('edge-head', 'triangle', SELECTION_COLOR)}
-          markerWidth={5}
-          markerHeight={5}
+          markerWidth={4}
+          markerHeight={4}
           viewBox="0 0 10 10"
           orient="auto"
           refX={10}

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
@@ -339,6 +339,23 @@ export const CanvasEdgesLayer = ({
                 vectorEffect="non-scaling-stroke"
               />
             )}
+            {/* Handles for the selected edge. Rendered BEFORE the visible
+                stroke so the stroke (and more importantly its markers)
+                paint on top — without this, the white-filled target
+                handle circle sits over the arrow-head marker and the
+                triangle visually disappears. The stroke itself passes
+                through the handle but is only a few pixels wide, so
+                the handle's ring stays clearly readable. */}
+            {isSelected && onHandleMouseDown && (
+              <EdgeHandles
+                edge={edge}
+                s={s}
+                t={t}
+                onHandleMouseDown={(handle, e) =>
+                  onHandleMouseDown(edge.id, handle, e, { s, t })
+                }
+              />
+            )}
             {/* Visible stroke. Linecap is "butt" whenever the matching
                 end has an arrow marker — SVG places the marker's refPoint
                 AT the path endpoint, so a rounded cap (radius = half
@@ -359,18 +376,6 @@ export const CanvasEdgesLayer = ({
               markerEnd={head !== 'none' ? `url(#${capId('edge-head', head, stroke.color)})` : undefined}
               markerStart={tail !== 'none' ? `url(#${capId('edge-tail', tail, stroke.color)})` : undefined}
             />
-            {/* Handles for the selected edge only. Rendered as a last
-                child so they sit visually above the stroke. */}
-            {isSelected && onHandleMouseDown && (
-              <EdgeHandles
-                edge={edge}
-                s={s}
-                t={t}
-                onHandleMouseDown={(handle, e) =>
-                  onHandleMouseDown(edge.id, handle, e, { s, t })
-                }
-              />
-            )}
           </g>
         );
       })}

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
@@ -34,6 +34,11 @@ interface Props {
    *  interaction hook translates free-point endpoints by the cursor
    *  delta while leaving node-bound endpoints anchored. */
   onBodyMouseDown?: (edgeId: string, e: React.MouseEvent) => void;
+  /** Double-click on the edge body. Used to enter edge-label edit mode.
+   *  The hit-proxy swallows the event so it doesn't bubble up to the
+   *  canvas-container's blank dbl-click handler (which spawns the
+   *  new-node context menu). */
+  onBodyDoubleClick?: (edgeId: string, e: React.MouseEvent) => void;
 }
 
 const DEFAULT_STROKE: Required<EdgeStroke> = {
@@ -220,6 +225,7 @@ export const CanvasEdgesLayer = ({
   previewEndpoints,
   onHandleMouseDown,
   onBodyMouseDown,
+  onBodyDoubleClick,
 }: Props) => {
   const nodesById = useMemo(() => {
     const m = new Map<string, CanvasNode>();
@@ -311,6 +317,13 @@ export const CanvasEdgesLayer = ({
                 e.stopPropagation();
                 onSelectEdge?.(edge.id);
                 onBodyMouseDown?.(edge.id, e);
+              }}
+              onDoubleClick={(e) => {
+                // Swallow so the canvas-container's blank-area dbl-click
+                // handler (which opens the new-node context menu) doesn't
+                // fire. The parent opens the edge-label editor instead.
+                e.stopPropagation();
+                onBodyDoubleClick?.(edge.id, e);
               }}
             />
             {/* Selection underlay: soft blue tint, rendered under the

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
@@ -33,7 +33,7 @@ interface Props {
 
 const DEFAULT_STROKE: Required<EdgeStroke> = {
   color: '#1f2328',
-  width: 1.6,
+  width: 2.4,
   style: 'solid',
 };
 
@@ -225,7 +225,14 @@ export const CanvasEdgesLayer = ({
 
         return (
           <g key={edge.id}>
-            {/* Wide transparent hit target so thin lines stay clickable. */}
+            {/* Wide transparent hit target so thin lines stay clickable.
+                A mousedown on the body both selects the edge AND starts
+                a bend drag — users reported that having to grab the
+                tiny midpoint handle to curve a line felt awkward, so
+                we now treat "grab anywhere on the stroke" as a shortcut
+                to bending it. A click that doesn't move still resolves
+                to "just select" because no bend-update fires and
+                commitHistory is a no-op when state is unchanged. */}
             <path
               d={d}
               fill="none"
@@ -234,7 +241,7 @@ export const CanvasEdgesLayer = ({
               vectorEffect="non-scaling-stroke"
               style={{
                 pointerEvents: 'stroke',
-                cursor: 'pointer',
+                cursor: 'grab',
               }}
               onMouseDown={(e) => {
                 // Selecting an edge steals the mousedown so it doesn't
@@ -242,6 +249,7 @@ export const CanvasEdgesLayer = ({
                 // deselect logic.
                 e.stopPropagation();
                 onSelectEdge?.(edge.id);
+                onHandleMouseDown?.(edge.id, 'bend', e, { s, t });
               }}
             />
             {/* Selection underlay: soft blue tint, rendered under the
@@ -252,7 +260,7 @@ export const CanvasEdgesLayer = ({
                 fill="none"
                 stroke={SELECTION_COLOR}
                 strokeOpacity={0.35}
-                strokeWidth={(stroke.width ?? 1.6) + 6}
+                strokeWidth={(stroke.width ?? DEFAULT_STROKE.width) + 6}
                 strokeLinecap="round"
                 vectorEffect="non-scaling-stroke"
               />

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
@@ -45,6 +45,11 @@ const DEFAULT_STROKE: Required<EdgeStroke> = {
 const SELECTION_COLOR = '#2a7fff';
 const HIT_PROXY_WIDTH = 10;
 const HANDLE_RADIUS = 5;
+/** Canvas-space gap between an arrow's tip and the node boundary it points
+ *  at. Without this, the arrow-head marker sits flush against the node
+ *  and gets visually swallowed by the node's background/border. tldraw
+ *  leaves similar breathing room for the same reason. */
+const ARROW_NODE_GAP = 6;
 
 const strokeDasharray = (style: EdgeStroke['style']): string | undefined => {
   switch (style) {
@@ -77,6 +82,27 @@ const buildPathData = (s: Point, t: Point, bend: number): string => {
   if (!bend) return `M ${s.x} ${s.y} L ${t.x} ${t.y}`;
   const { cx, cy } = bendControlPoint(s.x, s.y, t.x, t.y, bend);
   return `M ${s.x} ${s.y} Q ${cx} ${cy} ${t.x} ${t.y}`;
+};
+
+/**
+ * Pull the resolved `end` point back from the node boundary by `gap`
+ * canvas units along the straight line from `other` → `end`. Used when
+ * the endpoint is node-bound AND has a visible arrow cap, so the cap
+ * doesn't render flush against the node (where it visually merges into
+ * the node's border/background).
+ *
+ * Returns `end` unchanged when `gap` is 0 or the two points coincide.
+ */
+const insetTowardOther = (end: Point, other: Point, gap: number): Point => {
+  if (gap <= 0) return end;
+  const dx = end.x - other.x;
+  const dy = end.y - other.y;
+  const len = Math.hypot(dx, dy);
+  if (len === 0) return end;
+  return {
+    x: end.x - (dx / len) * gap,
+    y: end.y - (dy / len) * gap,
+  };
 };
 
 const capId = (prefix: string, cap: EdgeArrowCap, color: string): string => {
@@ -189,13 +215,24 @@ export const CanvasEdgesLayer = ({
   // Resolve each edge's endpoints into absolute canvas coords. Auto-
   // anchored node-bound endpoints are shifted to their bbox-boundary
   // point toward the opposite endpoint, so edges visually terminate at
-  // node edges rather than piercing into node centers.
+  // node edges rather than piercing into node centers. Additionally, if
+  // the endpoint carries a visible arrow cap we inset it by a small gap
+  // so the marker has clear space outside the node (otherwise the cap
+  // sits flush against the node border and visually disappears).
   const resolved = useMemo(() => {
     return edges.map((edge) => {
       const approxS = resolveEndpoint(edge.source, nodesById);
       const approxT = resolveEndpoint(edge.target, nodesById);
-      const s = resolveEndpointToward(edge.source, nodesById, approxT);
-      const t = resolveEndpointToward(edge.target, nodesById, approxS);
+      let s = resolveEndpointToward(edge.source, nodesById, approxT);
+      let t = resolveEndpointToward(edge.target, nodesById, approxS);
+      const head = edge.arrowHead ?? 'triangle';
+      const tail = edge.arrowTail ?? 'none';
+      if (edge.target.kind === 'node' && head !== 'none') {
+        t = insetTowardOther(t, s, ARROW_NODE_GAP);
+      }
+      if (edge.source.kind === 'node' && tail !== 'none') {
+        s = insetTowardOther(s, t, ARROW_NODE_GAP);
+      }
       return { edge, s, t };
     });
   }, [edges, nodesById]);

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
@@ -29,6 +29,11 @@ interface Props {
     e: React.MouseEvent,
     ctx: { s: Point; t: Point },
   ) => void;
+  /** Mousedown on the edge body (not a handle). Used to start a "move
+   *  the whole edge" drag — the hit-proxy forwards here and the
+   *  interaction hook translates free-point endpoints by the cursor
+   *  delta while leaving node-bound endpoints anchored. */
+  onBodyMouseDown?: (edgeId: string, e: React.MouseEvent) => void;
 }
 
 const DEFAULT_STROKE: Required<EdgeStroke> = {
@@ -171,6 +176,7 @@ export const CanvasEdgesLayer = ({
   interactionState,
   previewEndpoints,
   onHandleMouseDown,
+  onBodyMouseDown,
 }: Props) => {
   const nodesById = useMemo(() => {
     const m = new Map<string, CanvasNode>();
@@ -227,12 +233,13 @@ export const CanvasEdgesLayer = ({
           <g key={edge.id}>
             {/* Wide transparent hit target so thin lines stay clickable.
                 A mousedown on the body both selects the edge AND starts
-                a bend drag — users reported that having to grab the
-                tiny midpoint handle to curve a line felt awkward, so
-                we now treat "grab anywhere on the stroke" as a shortcut
-                to bending it. A click that doesn't move still resolves
-                to "just select" because no bend-update fires and
-                commitHistory is a no-op when state is unchanged. */}
+                a "move the whole edge" drag via onBodyMouseDown. Free
+                endpoints translate with the cursor; node-bound endpoints
+                stay anchored to their node. Clicks without drag resolve
+                to plain "select" because no move-update fires and
+                commitHistory is a no-op when state is unchanged. The
+                midpoint bend handle (rendered on top via EdgeHandles)
+                still captures its own mousedowns for curving. */}
             <path
               d={d}
               fill="none"
@@ -249,7 +256,7 @@ export const CanvasEdgesLayer = ({
                 // deselect logic.
                 e.stopPropagation();
                 onSelectEdge?.(edge.id);
-                onHandleMouseDown?.(edge.id, 'bend', e, { s, t });
+                onBodyMouseDown?.(edge.id, e);
               }}
             />
             {/* Selection underlay: soft blue tint, rendered under the

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
@@ -1,10 +1,34 @@
 import { useMemo } from 'react';
-import type { CanvasEdge, CanvasNode, EdgeArrowCap, EdgeStroke } from '../types';
-import { resolveEndpoint } from '../utils/edgeFactory';
+import type {
+  CanvasEdge,
+  CanvasNode,
+  EdgeArrowCap,
+  EdgeStroke,
+} from '../types';
+import {
+  bendHandlePoint,
+  resolveEndpoint,
+  resolveEndpointToward,
+} from '../utils/edgeFactory';
+import type { EdgeInteractionState, Point } from '../hooks/useEdgeInteraction';
 
 interface Props {
   edges: CanvasEdge[];
   nodes: CanvasNode[];
+  selectedEdgeId: string | null;
+  onSelectEdge?: (id: string | null) => void;
+  /** Live interaction state — renders preview / freezes the edge under
+   *  drag. Optional because Step 1 call sites don't pass it. */
+  interactionState?: EdgeInteractionState | null;
+  /** Preview endpoints resolved by the interaction hook. When set, we
+   *  draw a dashed draft line between these two points. */
+  previewEndpoints?: { s: Point; t: Point } | null;
+  onHandleMouseDown?: (
+    edgeId: string,
+    handle: 'source' | 'target' | 'bend',
+    e: React.MouseEvent,
+    ctx: { s: Point; t: Point },
+  ) => void;
 }
 
 const DEFAULT_STROKE: Required<EdgeStroke> = {
@@ -12,6 +36,10 @@ const DEFAULT_STROKE: Required<EdgeStroke> = {
   width: 1.6,
   style: 'solid',
 };
+
+const SELECTION_COLOR = '#2a7fff';
+const HIT_PROXY_WIDTH = 10;
+const HANDLE_RADIUS = 5;
 
 const strokeDasharray = (style: EdgeStroke['style']): string | undefined => {
   switch (style) {
@@ -22,13 +50,6 @@ const strokeDasharray = (style: EdgeStroke['style']): string | undefined => {
   }
 };
 
-/**
- * Signed perpendicular offset → quadratic Bezier control point.
- * The control point sits at (midpoint + normal * bend). A positive bend
- * bows the curve to the right of the s→t direction, negative to the left.
- * Bend of 0 produces a degenerate quadratic that renders as a straight
- * line, which is exactly what we want.
- */
 const bendControlPoint = (
   sx: number, sy: number,
   tx: number, ty: number,
@@ -40,30 +61,24 @@ const bendControlPoint = (
   const dx = tx - sx;
   const dy = ty - sy;
   const len = Math.hypot(dx, dy) || 1;
-  // Unit perpendicular (rotate 90° CCW: (dy/len, -dx/len) points to the
-  // right when looking from source to target in screen coords).
   const nx = dy / len;
   const ny = -dx / len;
-  return { cx: mx + nx * bend, cy: my + ny * bend };
+  // bend = peak offset of rendered curve; control point sits at 2×bend
+  // because a quadratic's t=0.5 value is (M + P1)/2 (see useEdgeInteraction).
+  return { cx: mx + nx * bend * 2, cy: my + ny * bend * 2 };
 };
 
-const capId = (
-  prefix: string,
-  cap: EdgeArrowCap,
-  color: string,
-): string => {
-  // One marker per (cap, color) — no per-edge markers. This keeps the
-  // SVG lean when many edges share the same style. Color is part of the
-  // id because <marker> fill inherits from the marker, not the path.
+const buildPathData = (s: Point, t: Point, bend: number): string => {
+  if (!bend) return `M ${s.x} ${s.y} L ${t.x} ${t.y}`;
+  const { cx, cy } = bendControlPoint(s.x, s.y, t.x, t.y, bend);
+  return `M ${s.x} ${s.y} Q ${cx} ${cy} ${t.x} ${t.y}`;
+};
+
+const capId = (prefix: string, cap: EdgeArrowCap, color: string): string => {
   const hex = color.replace(/[^a-zA-Z0-9]/g, '_');
   return `${prefix}-${cap}-${hex}`;
 };
 
-/**
- * Emit exactly the set of <marker> defs the current edges reference.
- * Walking the edges once and de-duplicating avoids bloating the DOM
- * with unused caps.
- */
 const useMarkerDefs = (edges: CanvasEdge[]) => {
   return useMemo(() => {
     const markers = new Map<
@@ -90,10 +105,8 @@ const useMarkerDefs = (edges: CanvasEdge[]) => {
 const MarkerShape = ({ cap, color }: { cap: EdgeArrowCap; color: string }) => {
   switch (cap) {
     case 'triangle':
-      // Filled triangle pointing along the +x axis (tangent direction).
       return <path d="M0,0 L10,5 L0,10 z" fill={color} />;
     case 'arrow':
-      // Open V-shape.
       return (
         <path
           d="M0,0 L10,5 L0,10"
@@ -127,12 +140,7 @@ const Markers = ({
         markerWidth={12}
         markerHeight={12}
         viewBox="0 0 10 10"
-        // Head caps point forward along the path's tangent; tail caps are
-        // flipped 180° so they point away from the source.
         orient={side === 'head' ? 'auto' : 'auto-start-reverse'}
-        // Offset the reference point so the cap sits at the path end
-        // without overshooting. For triangles we put refX at the tip (10)
-        // so the tip lands exactly on the endpoint.
         refX={cap === 'triangle' ? 10 : 5}
         refY={5}
         markerUnits="userSpaceOnUse"
@@ -144,16 +152,26 @@ const Markers = ({
 );
 
 /**
- * Renders all edges for the canvas as a single SVG layer stacked beneath
- * the node views. Lives inside `.canvas-transform`, so panning/zooming
- * gets it for free; `vector-effect="non-scaling-stroke"` keeps line
- * weights visually constant through scale.
+ * Renders every edge as SVG inside `.canvas-transform`, plus:
+ *  - a transparent thick hit-proxy stroke per edge so thin lines are
+ *    still easy to click;
+ *  - a pale highlight underneath the selected edge;
+ *  - 3 handles (start, bend midpoint, end) on the selected edge;
+ *  - a dashed preview edge while a connect/move-end drag is in flight.
  *
- * Interaction is disabled in Step 1 — the layer is `pointer-events: none`
- * end-to-end. Step 2 will add a wider transparent hit-proxy path per
- * edge for selection/dragging.
+ * The layer itself has `pointer-events: none`; individual child
+ * elements re-enable events (hit-proxies: `stroke`, handles: `all`).
+ * This keeps node drag/resize/click behaviour untouched.
  */
-export const CanvasEdgesLayer = ({ edges, nodes }: Props) => {
+export const CanvasEdgesLayer = ({
+  edges,
+  nodes,
+  selectedEdgeId,
+  onSelectEdge,
+  interactionState,
+  previewEndpoints,
+  onHandleMouseDown,
+}: Props) => {
   const nodesById = useMemo(() => {
     const m = new Map<string, CanvasNode>();
     for (const n of nodes) m.set(n.id, n);
@@ -162,15 +180,25 @@ export const CanvasEdgesLayer = ({ edges, nodes }: Props) => {
 
   const markers = useMarkerDefs(edges);
 
-  if (edges.length === 0) return null;
+  // Resolve each edge's endpoints into absolute canvas coords. Auto-
+  // anchored node-bound endpoints are shifted to their bbox-boundary
+  // point toward the opposite endpoint, so edges visually terminate at
+  // node edges rather than piercing into node centers.
+  const resolved = useMemo(() => {
+    return edges.map((edge) => {
+      const approxS = resolveEndpoint(edge.source, nodesById);
+      const approxT = resolveEndpoint(edge.target, nodesById);
+      const s = resolveEndpointToward(edge.source, nodesById, approxT);
+      const t = resolveEndpointToward(edge.target, nodesById, approxS);
+      return { edge, s, t };
+    });
+  }, [edges, nodesById]);
+
+  if (edges.length === 0 && !previewEndpoints) return null;
 
   return (
     <svg
       className="canvas-edges"
-      // Tiny base size — we rely on overflow:visible so paths at arbitrary
-      // canvas coords (including negative) still render. The parent div
-      // does the panning/zooming via CSS transform; we just draw in its
-      // local coordinate space.
       width={1}
       height={1}
       style={{
@@ -182,34 +210,231 @@ export const CanvasEdgesLayer = ({ edges, nodes }: Props) => {
       }}
     >
       <Markers markers={markers} />
-      {edges.map((edge) => {
-        const s = resolveEndpoint(edge.source, nodesById);
-        const t = resolveEndpoint(edge.target, nodesById);
-        const bend = edge.bend ?? 0;
-        const { cx, cy } = bendControlPoint(s.x, s.y, t.x, t.y, bend);
-        const d = bend === 0
-          ? `M ${s.x} ${s.y} L ${t.x} ${t.y}`
-          : `M ${s.x} ${s.y} Q ${cx} ${cy} ${t.x} ${t.y}`;
 
+      {resolved.map(({ edge, s, t }) => {
+        const bend = edge.bend ?? 0;
+        const d = buildPathData(s, t, bend);
         const stroke = { ...DEFAULT_STROKE, ...edge.stroke };
         const head = edge.arrowHead ?? 'triangle';
         const tail = edge.arrowTail ?? 'none';
+        const isSelected = edge.id === selectedEdgeId;
+        // While this edge's source/target is being dragged live, the
+        // stored endpoint already reflects the in-progress state (we
+        // push updates history-silently from useEdgeInteraction), so
+        // no special case needed here — the path re-renders naturally.
 
         return (
-          <path
-            key={edge.id}
-            d={d}
-            fill="none"
-            stroke={stroke.color}
-            strokeWidth={stroke.width}
-            strokeDasharray={strokeDasharray(stroke.style)}
-            strokeLinecap="round"
-            vectorEffect="non-scaling-stroke"
-            markerEnd={head !== 'none' ? `url(#${capId('edge-head', head, stroke.color)})` : undefined}
-            markerStart={tail !== 'none' ? `url(#${capId('edge-tail', tail, stroke.color)})` : undefined}
-          />
+          <g key={edge.id}>
+            {/* Wide transparent hit target so thin lines stay clickable. */}
+            <path
+              d={d}
+              fill="none"
+              stroke="transparent"
+              strokeWidth={HIT_PROXY_WIDTH}
+              vectorEffect="non-scaling-stroke"
+              style={{
+                pointerEvents: 'stroke',
+                cursor: 'pointer',
+              }}
+              onMouseDown={(e) => {
+                // Selecting an edge steals the mousedown so it doesn't
+                // bubble up into the canvas-container's blank-click
+                // deselect logic.
+                e.stopPropagation();
+                onSelectEdge?.(edge.id);
+              }}
+            />
+            {/* Selection underlay: soft blue tint, rendered under the
+                real stroke so the edge's own color still reads. */}
+            {isSelected && (
+              <path
+                d={d}
+                fill="none"
+                stroke={SELECTION_COLOR}
+                strokeOpacity={0.35}
+                strokeWidth={(stroke.width ?? 1.6) + 6}
+                strokeLinecap="round"
+                vectorEffect="non-scaling-stroke"
+              />
+            )}
+            {/* Visible stroke. */}
+            <path
+              d={d}
+              fill="none"
+              stroke={stroke.color}
+              strokeWidth={stroke.width}
+              strokeDasharray={strokeDasharray(stroke.style)}
+              strokeLinecap="round"
+              vectorEffect="non-scaling-stroke"
+              markerEnd={head !== 'none' ? `url(#${capId('edge-head', head, stroke.color)})` : undefined}
+              markerStart={tail !== 'none' ? `url(#${capId('edge-tail', tail, stroke.color)})` : undefined}
+            />
+            {/* Handles for the selected edge only. Rendered as a last
+                child so they sit visually above the stroke. */}
+            {isSelected && onHandleMouseDown && (
+              <EdgeHandles
+                edge={edge}
+                s={s}
+                t={t}
+                onHandleMouseDown={(handle, e) =>
+                  onHandleMouseDown(edge.id, handle, e, { s, t })
+                }
+              />
+            )}
+          </g>
         );
       })}
+
+      {previewEndpoints && (
+        <PreviewEdge
+          s={previewEndpoints.s}
+          t={previewEndpoints.t}
+          highlightNodeId={interactionState?.kind === 'connect' || interactionState?.kind === 'move-end'
+            ? interactionState.hoverNodeId
+            : null}
+          nodesById={nodesById}
+        />
+      )}
     </svg>
+  );
+};
+
+/**
+ * Three handles — start (source), bend midpoint, end (target) —
+ * rendered for the currently selected edge. Each handle intercepts
+ * mousedown so the interaction hook can begin a drag.
+ */
+const EdgeHandles = ({
+  edge,
+  s,
+  t,
+  onHandleMouseDown,
+}: {
+  edge: CanvasEdge;
+  s: Point;
+  t: Point;
+  onHandleMouseDown: (handle: 'source' | 'target' | 'bend', e: React.MouseEvent) => void;
+}) => {
+  const bend = edge.bend ?? 0;
+  const mid = bendHandlePoint(s, t, bend);
+
+  const handleStyle: React.CSSProperties = {
+    pointerEvents: 'all',
+    cursor: 'grab',
+  };
+
+  return (
+    <>
+      <circle
+        cx={s.x}
+        cy={s.y}
+        r={HANDLE_RADIUS}
+        fill="#ffffff"
+        stroke={SELECTION_COLOR}
+        strokeWidth={1.5}
+        vectorEffect="non-scaling-stroke"
+        style={handleStyle}
+        onMouseDown={(e) => {
+          e.stopPropagation();
+          onHandleMouseDown('source', e);
+        }}
+      />
+      <circle
+        cx={mid.x}
+        cy={mid.y}
+        r={HANDLE_RADIUS - 0.5}
+        fill="#ffffff"
+        stroke={SELECTION_COLOR}
+        strokeWidth={1.5}
+        vectorEffect="non-scaling-stroke"
+        style={handleStyle}
+        onMouseDown={(e) => {
+          e.stopPropagation();
+          onHandleMouseDown('bend', e);
+        }}
+      />
+      <circle
+        cx={t.x}
+        cy={t.y}
+        r={HANDLE_RADIUS}
+        fill="#ffffff"
+        stroke={SELECTION_COLOR}
+        strokeWidth={1.5}
+        vectorEffect="non-scaling-stroke"
+        style={handleStyle}
+        onMouseDown={(e) => {
+          e.stopPropagation();
+          onHandleMouseDown('target', e);
+        }}
+      />
+    </>
+  );
+};
+
+/**
+ * Dashed preview line rendered while the user is drawing a new edge
+ * or dragging an existing endpoint. A faint outline on the hover
+ * target node confirms a successful drop will bind to it.
+ */
+const PreviewEdge = ({
+  s,
+  t,
+  highlightNodeId,
+  nodesById,
+}: {
+  s: Point;
+  t: Point;
+  highlightNodeId: string | null;
+  nodesById: Map<string, CanvasNode>;
+}) => {
+  const d = `M ${s.x} ${s.y} L ${t.x} ${t.y}`;
+  const node = highlightNodeId ? nodesById.get(highlightNodeId) : null;
+  return (
+    <>
+      <path
+        d={d}
+        fill="none"
+        stroke={SELECTION_COLOR}
+        strokeWidth={1.5}
+        strokeDasharray="5 3"
+        strokeLinecap="round"
+        vectorEffect="non-scaling-stroke"
+        markerEnd={`url(#${capId('edge-head', 'triangle', SELECTION_COLOR)})`}
+        style={{ pointerEvents: 'none' }}
+      />
+      {/* Also register the preview's triangle-on-blue marker so
+          marker-end="url(#…)" resolves. Duplicate marker defs are
+          harmless; the <defs> above won't include this combo unless an
+          edge already uses blue. */}
+      <defs>
+        <marker
+          id={capId('edge-head', 'triangle', SELECTION_COLOR)}
+          markerWidth={12}
+          markerHeight={12}
+          viewBox="0 0 10 10"
+          orient="auto"
+          refX={10}
+          refY={5}
+          markerUnits="userSpaceOnUse"
+        >
+          <path d="M0,0 L10,5 L0,10 z" fill={SELECTION_COLOR} />
+        </marker>
+      </defs>
+      {node && (
+        <rect
+          x={node.x - 2}
+          y={node.y - 2}
+          width={node.width + 4}
+          height={node.height + 4}
+          fill="none"
+          stroke={SELECTION_COLOR}
+          strokeWidth={1.5}
+          strokeDasharray="4 3"
+          vectorEffect="non-scaling-stroke"
+          style={{ pointerEvents: 'none' }}
+          rx={6}
+        />
+      )}
+    </>
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
@@ -309,14 +309,22 @@ export const CanvasEdgesLayer = ({
                 vectorEffect="non-scaling-stroke"
               />
             )}
-            {/* Visible stroke. */}
+            {/* Visible stroke. Linecap is "butt" whenever the matching
+                end has an arrow marker — SVG places the marker's refPoint
+                AT the path endpoint, so a rounded cap (radius = half
+                stroke width) would poke forward *past* the triangle tip
+                and make the arrow look slightly disconnected from the
+                line. Using "butt" ends the stroke flush with the path
+                endpoint so the triangle's tip becomes the exact rightmost
+                point of the arrow. Edges with no caps at all keep "round"
+                for their nicer free-end look. */}
             <path
               d={d}
               fill="none"
               stroke={stroke.color}
               strokeWidth={stroke.width}
               strokeDasharray={strokeDasharray(stroke.style)}
-              strokeLinecap="round"
+              strokeLinecap={head !== 'none' || tail !== 'none' ? 'butt' : 'round'}
               vectorEffect="non-scaling-stroke"
               markerEnd={head !== 'none' ? `url(#${capId('edge-head', head, stroke.color)})` : undefined}
               markerStart={tail !== 'none' ? `url(#${capId('edge-tail', tail, stroke.color)})` : undefined}
@@ -449,7 +457,10 @@ const PreviewEdge = ({
         stroke={SELECTION_COLOR}
         strokeWidth={1.5}
         strokeDasharray="5 3"
-        strokeLinecap="round"
+        // "butt" to match the committed-edge rendering: since there's a
+        // marker at the end, a rounded cap would poke past the triangle
+        // tip (see the committed-edge comment for the full explanation).
+        strokeLinecap="butt"
         vectorEffect="non-scaling-stroke"
         markerEnd={`url(#${capId('edge-head', 'triangle', SELECTION_COLOR)})`}
         style={{ pointerEvents: 'none' }}

--- a/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/index.css
@@ -1,17 +1,19 @@
-/* Inline label shown above an edge.
+/* Inline label shown just below an edge.
 
    Positioned via inline left/top (screen coords computed from the
-   edge's bend-handle point), then offset UPWARD by its full height
-   plus a small gap so the label sits just above the line. This keeps
-   the edge's midpoint clear — the bend drag-handle (drawn on the line
-   at the exact same midpoint) must remain grabbable when the edge is
-   selected, and stacking the label chip on top of it hides the handle.
+   edge's bend-handle point) and then translated DOWNWARD so the
+   chip hangs below the line. This keeps both overlapping elements
+   clear of the label:
+     • the bend drag-handle, which lives on the line midpoint;
+     • the EdgeStylePanel, which floats above the midpoint when the
+       edge is selected — before this shift it stacked on top of the
+       label and made it unreadable.
 
    Sits in the overlay layer so the text isn't transformed with
    .canvas-transform — font stays crisp at any zoom. */
 .edge-label {
   position: absolute;
-  transform: translate(-50%, calc(-100% - 8px));
+  transform: translate(-50%, 10px);
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/index.css
@@ -1,0 +1,66 @@
+/* Inline label chip shown on top of an edge.
+
+   Positioned via inline left/top (screen coords computed from the edge's
+   bend-handle point). `translate(-50%, -50%)` centers the chip exactly
+   on the line midpoint.
+
+   Sits in the overlay layer so the text isn't transformed with
+   .canvas-transform — font stays crisp at any zoom. */
+.edge-label {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  max-width: 240px;
+  padding: 2px 8px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-float);
+  font-size: 12px;
+  line-height: 16px;
+  color: var(--text);
+  /* Sit above the edge stroke (inside .canvas-transform) but below the
+     floating toolbar (zIndex 500) and below the EdgeStylePanel (zIndex
+     50) so clicks on the panel still register first when the two
+     overlap. */
+  z-index: 40;
+  cursor: text;
+  user-select: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.edge-label--editing {
+  /* Accent ring while editing so it clearly reads as "active input".
+     Drops the default hover/cursor affordance — we're already focused. */
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-light), var(--shadow-float);
+  cursor: text;
+  overflow: visible;
+}
+
+.edge-label-text {
+  /* Explicit span so the view-mode layout matches the input's — keeps
+     the chip's height stable between view and edit. */
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.edge-label-input {
+  border: none;
+  outline: none;
+  background: transparent;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  width: 160px;
+  min-width: 80px;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/index.css
@@ -1,14 +1,17 @@
-/* Inline label shown on top of an edge.
+/* Inline label shown above an edge.
 
-   Positioned via inline left/top (screen coords computed from the edge's
-   bend-handle point). `translate(-50%, -50%)` centers the chip exactly
-   on the line midpoint.
+   Positioned via inline left/top (screen coords computed from the
+   edge's bend-handle point), then offset UPWARD by its full height
+   plus a small gap so the label sits just above the line. This keeps
+   the edge's midpoint clear — the bend drag-handle (drawn on the line
+   at the exact same midpoint) must remain grabbable when the edge is
+   selected, and stacking the label chip on top of it hides the handle.
 
    Sits in the overlay layer so the text isn't transformed with
    .canvas-transform — font stays crisp at any zoom. */
 .edge-label {
   position: absolute;
-  transform: translate(-50%, -50%);
+  transform: translate(-50%, calc(-100% - 8px));
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -36,16 +39,14 @@
 }
 
 .edge-label--editing {
-  /* During editing we drop the chip chrome entirely — no background,
-     no border, no shadow. The text sits directly on the canvas so the
-     user feels like they're typing onto the line itself. An accent-
-     colored caret (inherited from the browser) plus the input's own
-     focus outline are enough affordance. */
-  background: transparent;
-  border-color: transparent;
-  box-shadow: none;
+  /* Keep the white chip background while editing — typing directly on
+     the canvas (transparent bg) is too noisy against busy underlying
+     edges/nodes. The accent ring is added *around* the chip so the
+     surface stays readable. */
+  background: var(--surface);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-light), var(--shadow-float);
   overflow: visible;
-  padding: 0;
 }
 
 .edge-label-text {
@@ -62,18 +63,17 @@
   border: none;
   outline: none;
   background: transparent;
-  /* Match the view-mode chip's inner padding so the text doesn't jump
-     horizontally when flipping between modes. */
-  padding: 2px 8px;
+  /* Padding lives on the label container, not the input — otherwise
+     field-sizing would grow the input past the chip bounds. */
+  padding: 0;
   margin: 0;
   font: inherit;
   color: inherit;
   text-align: center;
   /* field-sizing: content auto-grows the <input> to fit its contents,
      so the editor expands naturally as the user types. Supported in
-     Chromium 123+, which covers modern Electron. Pairing it with a
-     small explicit min-width keeps the input clickable even when empty. */
+     Chromium 123+, which covers modern Electron. */
   field-sizing: content;
   min-width: 48px;
-  max-width: 280px;
+  max-width: 260px;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/index.css
@@ -1,4 +1,4 @@
-/* Inline label chip shown on top of an edge.
+/* Inline label shown on top of an edge.
 
    Positioned via inline left/top (screen coords computed from the edge's
    bend-handle point). `translate(-50%, -50%)` centers the chip exactly
@@ -22,6 +22,7 @@
   font-size: 12px;
   line-height: 16px;
   color: var(--text);
+  text-align: center;
   /* Sit above the edge stroke (inside .canvas-transform) but below the
      floating toolbar (zIndex 500) and below the EdgeStylePanel (zIndex
      50) so clicks on the panel still register first when the two
@@ -35,12 +36,16 @@
 }
 
 .edge-label--editing {
-  /* Accent ring while editing so it clearly reads as "active input".
-     Drops the default hover/cursor affordance — we're already focused. */
-  border-color: var(--accent);
-  box-shadow: 0 0 0 2px var(--accent-light), var(--shadow-float);
-  cursor: text;
+  /* During editing we drop the chip chrome entirely — no background,
+     no border, no shadow. The text sits directly on the canvas so the
+     user feels like they're typing onto the line itself. An accent-
+     colored caret (inherited from the browser) plus the input's own
+     focus outline are enough affordance. */
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
   overflow: visible;
+  padding: 0;
 }
 
 .edge-label-text {
@@ -57,10 +62,18 @@
   border: none;
   outline: none;
   background: transparent;
-  padding: 0;
+  /* Match the view-mode chip's inner padding so the text doesn't jump
+     horizontally when flipping between modes. */
+  padding: 2px 8px;
   margin: 0;
   font: inherit;
   color: inherit;
-  width: 160px;
-  min-width: 80px;
+  text-align: center;
+  /* field-sizing: content auto-grows the <input> to fit its contents,
+     so the editor expands naturally as the user types. Supported in
+     Chromium 123+, which covers modern Electron. Pairing it with a
+     small explicit min-width keeps the input clickable even when empty. */
+  field-sizing: content;
+  min-width: 48px;
+  max-width: 280px;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/index.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import './index.css';
+import type { CanvasEdge, CanvasNode, CanvasTransform } from '../../types';
+import {
+  bendHandlePoint,
+  resolveEndpoint,
+  resolveEndpointToward,
+} from '../../utils/edgeFactory';
+
+/**
+ * Inline label on an edge.
+ *
+ * Positioned at the edge's visual midpoint (the bend-handle point, which
+ * coincides with the curve at t=0.5 — see `bendHandlePoint`). Rendered in
+ * the overlay layer rather than inside the edges SVG so the label text is
+ * a real DOM element — easy to style, wrap, and edit via a plain <input>.
+ *
+ * Two display modes:
+ *  - view  → static text "chip" sitting on top of the line, readable at
+ *            any zoom thanks to being outside .canvas-transform.
+ *  - edit  → single-line input. Enter or blur commits, Escape cancels.
+ *
+ * Clicks are absorbed (stopPropagation) so tapping the label doesn't
+ * deselect the edge or bubble into the canvas blank-click handler.
+ */
+interface Props {
+  edge: CanvasEdge;
+  nodes: CanvasNode[];
+  transform: CanvasTransform;
+  isEditing: boolean;
+  onStartEdit: (id: string) => void;
+  onCommit: (id: string, label: string) => void;
+  onCancel: () => void;
+}
+
+export const EdgeLabel = ({
+  edge,
+  nodes,
+  transform,
+  isEditing,
+  onStartEdit,
+  onCommit,
+  onCancel,
+}: Props) => {
+  const [draft, setDraft] = useState(edge.label ?? '');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Re-seed the draft whenever we (re)enter edit mode or the stored
+  // label changes behind us. Without this, reopening after canceling a
+  // previous edit would show stale text from the aborted session.
+  useEffect(() => {
+    if (isEditing) {
+      setDraft(edge.label ?? '');
+    }
+  }, [isEditing, edge.label]);
+
+  useEffect(() => {
+    if (!isEditing) return;
+    const input = inputRef.current;
+    if (!input) return;
+    input.focus();
+    input.select();
+  }, [isEditing]);
+
+  const screenPos = useMemo(() => {
+    const nodesById = new Map(nodes.map((n) => [n.id, n]));
+    const approxS = resolveEndpoint(edge.source, nodesById);
+    const approxT = resolveEndpoint(edge.target, nodesById);
+    const s = resolveEndpointToward(edge.source, nodesById, approxT);
+    const t = resolveEndpointToward(edge.target, nodesById, approxS);
+    const mid = bendHandlePoint(s, t, edge.bend ?? 0);
+    return {
+      x: mid.x * transform.scale + transform.x,
+      y: mid.y * transform.scale + transform.y,
+    };
+  }, [edge, nodes, transform]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      onCommit(edge.id, draft);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      onCancel();
+    }
+  };
+
+  return (
+    <div
+      className={`edge-label${isEditing ? ' edge-label--editing' : ''}`}
+      style={{ left: screenPos.x, top: screenPos.y }}
+      onMouseDown={(e) => e.stopPropagation()}
+      onClick={(e) => e.stopPropagation()}
+      onContextMenu={(e) => e.stopPropagation()}
+      onDoubleClick={(e) => {
+        // Intentionally swallow the dblclick so it doesn't bubble up
+        // into the canvas-container handler (which spawns the
+        // new-node context menu on a blank-canvas dbl-click).
+        e.stopPropagation();
+        if (!isEditing) onStartEdit(edge.id);
+      }}
+    >
+      {isEditing ? (
+        <input
+          ref={inputRef}
+          className="edge-label-input"
+          value={draft}
+          // Commit empty-string labels as "no label" by handing the
+          // raw value straight through; the parent decides how to
+          // normalize (it strips empty strings so the field goes back
+          // to `undefined` on the edge).
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={() => onCommit(edge.id, draft)}
+          placeholder="Label"
+          // Avoid the browser trying to autofill edge labels.
+          autoComplete="off"
+          spellCheck={false}
+        />
+      ) : (
+        <span className="edge-label-text">{edge.label}</span>
+      )}
+    </div>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/EdgeStylePanel/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeStylePanel/index.css
@@ -1,0 +1,118 @@
+/* Floating panel shown when an edge is selected. Positioned via inline
+   left/top, centered horizontally on the anchor point and shifted up so
+   its bottom edge sits ~12px above the anchor. */
+.edge-style-panel {
+  position: absolute;
+  transform: translate(-50%, calc(-100% - 12px));
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px 6px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-float);
+  /* Sit above the connect-mode overlay (zIndex 5) but below the floating
+     toolbar chrome (zIndex 500) so the user can still switch tools. */
+  z-index: 50;
+  /* Prevent the flex row from collapsing its children and wrapping awkwardly
+     at the edge of the viewport — the whole panel is compact by design. */
+  white-space: nowrap;
+}
+
+.edge-style-row {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.edge-style-row--caps {
+  gap: 1px;
+}
+
+.edge-style-label {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  padding: 0 4px 0 2px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.edge-style-divider {
+  width: 1px;
+  height: 20px;
+  background: var(--border);
+  margin: 0 3px;
+  flex-shrink: 0;
+}
+
+.edge-style-swatch {
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.08);
+  transition: transform 0.1s, box-shadow 0.1s;
+}
+
+.edge-style-swatch:hover {
+  transform: scale(1.08);
+}
+
+.edge-style-swatch--active {
+  /* Accent ring around the chosen color so it reads as selected without
+     relying on the color value itself (which can be identical to the
+     ring). */
+  box-shadow: 0 0 0 2px var(--surface), 0 0 0 3.5px var(--accent);
+}
+
+.edge-style-btn {
+  height: 26px;
+  min-width: 26px;
+  padding: 0 4px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
+  transition: background 0.1s, color 0.1s;
+}
+
+.edge-style-btn svg {
+  display: block;
+}
+
+.edge-style-btn:hover {
+  background: rgba(0, 0, 0, 0.04);
+  color: var(--text);
+}
+
+.edge-style-btn--active {
+  background: var(--accent-light);
+  color: var(--accent);
+}
+
+.edge-style-btn--active:hover {
+  background: var(--accent-light);
+  color: var(--accent);
+}
+
+.edge-style-btn--cap {
+  min-width: 22px;
+  padding: 0 2px;
+}
+
+.edge-style-btn--danger {
+  color: var(--text-secondary);
+}
+
+.edge-style-btn--danger:hover {
+  background: rgba(229, 72, 77, 0.1);
+  color: #e5484d;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/EdgeStylePanel/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeStylePanel/index.css
@@ -1,13 +1,21 @@
 /* Floating panel shown when an edge is selected. Positioned via inline
    left/top, centered horizontally on the anchor point and shifted up so
-   its bottom edge sits ~12px above the anchor. */
+   its bottom edge sits ~12px above the anchor.
+
+   Laid out as two stacked rows:
+     row 1 — stroke appearance (color / width / style)
+     row 2 — endpoint caps + delete
+   Splitting like this keeps each row narrow enough to scan at a glance
+   instead of the earlier single-row layout that crowded 20+ controls
+   side-by-side. */
 .edge-style-panel {
   position: absolute;
   transform: translate(-50%, calc(-100% - 12px));
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 2px;
-  padding: 4px 6px;
+  gap: 4px;
+  padding: 6px 8px;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
@@ -20,6 +28,18 @@
   white-space: nowrap;
 }
 
+.edge-style-line {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.edge-style-line--caps {
+  /* The cap row is denser (2 cap groups + delete), so trim the outer
+     gap slightly to keep the panel visually balanced. */
+  gap: 1px;
+}
+
 .edge-style-row {
   display: flex;
   align-items: center;
@@ -30,20 +50,19 @@
   gap: 1px;
 }
 
-.edge-style-label {
-  font-size: 10px;
-  font-weight: 600;
+.edge-style-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   color: var(--text-secondary);
   padding: 0 4px 0 2px;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
 }
 
 .edge-style-divider {
   width: 1px;
   height: 20px;
   background: var(--border);
-  margin: 0 3px;
+  margin: 0 6px;
   flex-shrink: 0;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/EdgeStylePanel/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeStylePanel/index.css
@@ -2,18 +2,18 @@
    left/top, centered horizontally on the anchor point and shifted up so
    its bottom edge sits ~12px above the anchor.
 
-   Laid out as two stacked rows:
-     row 1 — stroke appearance (color / width / style)
-     row 2 — endpoint caps + delete
-   Splitting like this keeps each row narrow enough to scan at a glance
-   instead of the earlier single-row layout that crowded 20+ controls
-   side-by-side. */
+   Layout is a two-level "chip row + popover":
+     • chip row — one chip per property, showing its current value as a
+       mini preview. Always visible; keeps the default footprint small.
+     • popover  — opened when a chip is clicked, reveals the full option
+       list for that property. Only one section can be open at a time.
+   Selecting a value auto-collapses the popover back to the chip row. */
 .edge-style-panel {
   position: absolute;
   transform: translate(-50%, calc(-100% - 12px));
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
   gap: 4px;
   padding: 6px 8px;
   background: var(--surface);
@@ -28,16 +28,21 @@
   white-space: nowrap;
 }
 
-.edge-style-line {
+.edge-style-chip-row {
   display: flex;
   align-items: center;
   gap: 2px;
 }
 
-.edge-style-line--caps {
-  /* The cap row is denser (2 cap groups + delete), so trim the outer
-     gap slightly to keep the panel visually balanced. */
-  gap: 1px;
+.edge-style-popover {
+  /* Separate the expanded option list from the chip row with a hairline
+     so the two-level structure reads clearly without adding vertical
+     padding that would balloon the panel. */
+  border-top: 1px solid var(--border);
+  padding-top: 6px;
+  margin-top: 2px;
+  display: flex;
+  justify-content: center;
 }
 
 .edge-style-row {
@@ -50,20 +55,71 @@
   gap: 1px;
 }
 
-.edge-style-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--text-secondary);
-  padding: 0 4px 0 2px;
-}
-
 .edge-style-divider {
   width: 1px;
   height: 20px;
   background: var(--border);
   margin: 0 6px;
   flex-shrink: 0;
+}
+
+/* Chip — the always-visible summary button for one property. Shows the
+   property's current value as a mini preview inside a neutral tile, and
+   toggles the popover open/closed on click. */
+.edge-chip {
+  height: 28px;
+  min-width: 32px;
+  padding: 0 6px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
+  transition: background 0.1s, color 0.1s;
+}
+
+.edge-chip svg {
+  display: block;
+}
+
+.edge-chip:hover {
+  background: rgba(0, 0, 0, 0.04);
+  color: var(--text);
+}
+
+.edge-chip--active {
+  /* Active chip = its popover is currently open. A soft accent tint
+     makes it clear which property the popover belongs to. */
+  background: var(--accent-light);
+  color: var(--accent);
+}
+
+.edge-chip--active:hover {
+  background: var(--accent-light);
+  color: var(--accent);
+}
+
+.edge-chip--danger {
+  color: var(--text-secondary);
+}
+
+.edge-chip--danger:hover {
+  background: rgba(229, 72, 77, 0.1);
+  color: #e5484d;
+}
+
+/* Color swatch rendered inside the color chip to preview the edge's
+   current stroke color. Outlined so light colors still read on the
+   off-white surface. */
+.edge-chip-swatch {
+  display: inline-block;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.12);
 }
 
 .edge-style-swatch {
@@ -125,13 +181,4 @@
 .edge-style-btn--cap {
   min-width: 22px;
   padding: 0 2px;
-}
-
-.edge-style-btn--danger {
-  color: var(--text-secondary);
-}
-
-.edge-style-btn--danger:hover {
-  background: rgba(229, 72, 77, 0.1);
-  color: #e5484d;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/EdgeStylePanel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeStylePanel/index.tsx
@@ -45,9 +45,9 @@ const COLORS: string[] = [
 ];
 
 const WIDTHS: Array<{ label: string; value: number }> = [
-  { label: 'S', value: 1.2 },
-  { label: 'M', value: 1.6 },
-  { label: 'L', value: 2.4 },
+  { label: 'S', value: 1.6 },
+  { label: 'M', value: 2.4 },
+  { label: 'L', value: 3.6 },
 ];
 
 const STYLES: Array<NonNullable<EdgeStroke['style']>> = ['solid', 'dashed', 'dotted'];
@@ -112,7 +112,7 @@ export const EdgeStylePanel = ({
   onRemove,
 }: Props) => {
   const color = edge.stroke?.color ?? '#1f2328';
-  const width = edge.stroke?.width ?? 1.6;
+  const width = edge.stroke?.width ?? 2.4;
   const style = edge.stroke?.style ?? 'solid';
   const head: EdgeArrowCap = edge.arrowHead ?? 'triangle';
   const tail: EdgeArrowCap = edge.arrowTail ?? 'none';
@@ -148,106 +148,124 @@ export const EdgeStylePanel = ({
       onClick={(e) => e.stopPropagation()}
       onContextMenu={(e) => e.stopPropagation()}
     >
-      <div className="edge-style-row">
-        {COLORS.map((c) => (
-          <button
-            key={c}
-            className={`edge-style-swatch${c === color ? ' edge-style-swatch--active' : ''}`}
-            style={{ background: c }}
-            onClick={() => setStroke({ color: c })}
-            title={c}
-          />
-        ))}
+      {/* Row 1 — stroke appearance: color, width, dash style. */}
+      <div className="edge-style-line">
+        <div className="edge-style-row">
+          {COLORS.map((c) => (
+            <button
+              key={c}
+              className={`edge-style-swatch${c === color ? ' edge-style-swatch--active' : ''}`}
+              style={{ background: c }}
+              onClick={() => setStroke({ color: c })}
+              title={c}
+            />
+          ))}
+        </div>
+
+        <div className="edge-style-divider" />
+
+        <div className="edge-style-row">
+          {WIDTHS.map((w) => (
+            <button
+              key={w.label}
+              className={`edge-style-btn${Math.abs(width - w.value) < 0.05 ? ' edge-style-btn--active' : ''}`}
+              onClick={() => setStroke({ width: w.value })}
+              title={`Width ${w.label}`}
+            >
+              <svg width="18" height="18" viewBox="0 0 18 18">
+                <line x1={2} y1={9} x2={16} y2={9} stroke="currentColor" strokeWidth={w.value} strokeLinecap="round" />
+              </svg>
+            </button>
+          ))}
+        </div>
+
+        <div className="edge-style-divider" />
+
+        <div className="edge-style-row">
+          {STYLES.map((st) => (
+            <button
+              key={st}
+              className={`edge-style-btn${st === style ? ' edge-style-btn--active' : ''}`}
+              onClick={() => setStroke({ style: st })}
+              title={st}
+            >
+              <svg width="22" height="18" viewBox="0 0 22 18">
+                <line
+                  x1={2} y1={9} x2={20} y2={9}
+                  stroke="currentColor"
+                  strokeWidth={1.6}
+                  strokeLinecap="round"
+                  strokeDasharray={strokeDasharrayFor(st)}
+                />
+              </svg>
+            </button>
+          ))}
+        </div>
       </div>
 
-      <div className="edge-style-divider" />
-
-      <div className="edge-style-row">
-        {WIDTHS.map((w) => (
-          <button
-            key={w.label}
-            className={`edge-style-btn${Math.abs(width - w.value) < 0.05 ? ' edge-style-btn--active' : ''}`}
-            onClick={() => setStroke({ width: w.value })}
-            title={`Width ${w.label}`}
-          >
-            <svg width="18" height="18" viewBox="0 0 18 18">
-              <line x1={2} y1={9} x2={16} y2={9} stroke="currentColor" strokeWidth={w.value} strokeLinecap="round" />
+      {/* Row 2 — endpoints & actions: start-cap, end-cap, delete. Split
+          onto its own row so the five-icon cap groups don't crowd the
+          stroke controls. The leading arrow icons make "this group
+          controls the start/end of the arrow" readable at a glance
+          instead of the old cryptic "H" / "T" text labels. */}
+      <div className="edge-style-line edge-style-line--caps">
+        <div className="edge-style-row edge-style-row--caps">
+          <span className="edge-style-icon" title="Arrow end (target)" aria-hidden="true">
+            <svg width="14" height="14" viewBox="0 0 14 14">
+              <line x1={1} y1={7} x2={11} y2={7} stroke="currentColor" strokeWidth={1.4} strokeLinecap="round" />
+              <path d="M8,3 L12,7 L8,11 z" fill="currentColor" />
             </svg>
-          </button>
-        ))}
-      </div>
+          </span>
+          {CAPS.map((c) => (
+            <button
+              key={`head-${c}`}
+              className={`edge-style-btn edge-style-btn--cap${c === head ? ' edge-style-btn--active' : ''}`}
+              onClick={() => onUpdate(edge.id, { arrowHead: c })}
+              title={`End: ${c}`}
+            >
+              <CapPreview cap={c} color="currentColor" side="head" />
+            </button>
+          ))}
+        </div>
 
-      <div className="edge-style-divider" />
+        <div className="edge-style-divider" />
 
-      <div className="edge-style-row">
-        {STYLES.map((st) => (
-          <button
-            key={st}
-            className={`edge-style-btn${st === style ? ' edge-style-btn--active' : ''}`}
-            onClick={() => setStroke({ style: st })}
-            title={st}
-          >
-            <svg width="22" height="18" viewBox="0 0 22 18">
-              <line
-                x1={2} y1={9} x2={20} y2={9}
-                stroke="currentColor"
-                strokeWidth={1.6}
-                strokeLinecap="round"
-                strokeDasharray={strokeDasharrayFor(st)}
-              />
+        <div className="edge-style-row edge-style-row--caps">
+          <span className="edge-style-icon" title="Arrow start (source)" aria-hidden="true">
+            <svg width="14" height="14" viewBox="0 0 14 14">
+              <line x1={3} y1={7} x2={13} y2={7} stroke="currentColor" strokeWidth={1.4} strokeLinecap="round" />
+              <path d="M6,3 L2,7 L6,11 z" fill="currentColor" />
             </svg>
-          </button>
-        ))}
+          </span>
+          {CAPS.map((c) => (
+            <button
+              key={`tail-${c}`}
+              className={`edge-style-btn edge-style-btn--cap${c === tail ? ' edge-style-btn--active' : ''}`}
+              onClick={() => onUpdate(edge.id, { arrowTail: c })}
+              title={`Start: ${c}`}
+            >
+              <CapPreview cap={c} color="currentColor" side="tail" />
+            </button>
+          ))}
+        </div>
+
+        <div className="edge-style-divider" />
+
+        <button
+          className="edge-style-btn edge-style-btn--danger"
+          onClick={() => onRemove(edge.id)}
+          title="Delete edge"
+        >
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <path
+              d="M4 4l8 8M12 4L4 12"
+              stroke="currentColor"
+              strokeWidth="1.4"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
       </div>
-
-      <div className="edge-style-divider" />
-
-      <div className="edge-style-row edge-style-row--caps">
-        <span className="edge-style-label">H</span>
-        {CAPS.map((c) => (
-          <button
-            key={`head-${c}`}
-            className={`edge-style-btn edge-style-btn--cap${c === head ? ' edge-style-btn--active' : ''}`}
-            onClick={() => onUpdate(edge.id, { arrowHead: c })}
-            title={`Head: ${c}`}
-          >
-            <CapPreview cap={c} color="currentColor" side="head" />
-          </button>
-        ))}
-      </div>
-
-      <div className="edge-style-divider" />
-
-      <div className="edge-style-row edge-style-row--caps">
-        <span className="edge-style-label">T</span>
-        {CAPS.map((c) => (
-          <button
-            key={`tail-${c}`}
-            className={`edge-style-btn edge-style-btn--cap${c === tail ? ' edge-style-btn--active' : ''}`}
-            onClick={() => onUpdate(edge.id, { arrowTail: c })}
-            title={`Tail: ${c}`}
-          >
-            <CapPreview cap={c} color="currentColor" side="tail" />
-          </button>
-        ))}
-      </div>
-
-      <div className="edge-style-divider" />
-
-      <button
-        className="edge-style-btn edge-style-btn--danger"
-        onClick={() => onRemove(edge.id)}
-        title="Delete edge"
-      >
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-          <path
-            d="M4 4l8 8M12 4L4 12"
-            stroke="currentColor"
-            strokeWidth="1.4"
-            strokeLinecap="round"
-          />
-        </svg>
-      </button>
     </div>
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/components/EdgeStylePanel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeStylePanel/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import './index.css';
 import type {
   CanvasEdge,
@@ -19,6 +19,14 @@ import {
  * and delete it. Positioned above the edge's midpoint in screen space so
  * it tracks the edge as nodes move / the canvas pans.
  *
+ * Surface chrome is a single row of "chips" — one per property — each
+ * showing the edge's *current* value. Clicking a chip expands a second
+ * row inside the same popover with the full option list for that
+ * property. Only one section can be open at a time; selecting a value
+ * (or clicking outside the panel) collapses it back to the chip row.
+ * This keeps the panel's default footprint small so it doesn't swallow
+ * the edge it's attached to.
+ *
  * Clicks inside the panel are stopped from bubbling up into the canvas
  * click handler so changing style doesn't accidentally deselect the
  * edge we're editing.
@@ -30,6 +38,8 @@ interface Props {
   onUpdate: (id: string, patch: Partial<CanvasEdge>) => void;
   onRemove: (id: string) => void;
 }
+
+type Section = 'color' | 'width' | 'style' | 'head' | 'tail';
 
 // Palette mirrors tldraw-style defaults — 1 neutral + 6 hues that read well on the
 // off-white canvas background at both zoom extremes. First entry matches
@@ -104,6 +114,43 @@ const CapPreview = ({ cap, color, side }: { cap: EdgeArrowCap; color: string; si
   );
 };
 
+/**
+ * Inline preview for the width chip — a short line rendered at the
+ * edge's current stroke width (clamped to what the chip can display).
+ */
+const WidthPreview = ({ width }: { width: number }) => (
+  <svg width="22" height="14" viewBox="0 0 22 14">
+    <line
+      x1={3}
+      y1={7}
+      x2={19}
+      y2={7}
+      stroke="currentColor"
+      strokeWidth={Math.min(width, 4)}
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * Inline preview for the style chip — a short line rendered in the
+ * current dash pattern.
+ */
+const StylePreview = ({ style }: { style: EdgeStroke['style'] }) => (
+  <svg width="22" height="14" viewBox="0 0 22 14">
+    <line
+      x1={3}
+      y1={7}
+      x2={19}
+      y2={7}
+      stroke="currentColor"
+      strokeWidth={1.8}
+      strokeLinecap="round"
+      strokeDasharray={strokeDasharrayFor(style)}
+    />
+  </svg>
+);
+
 export const EdgeStylePanel = ({
   edge,
   nodes,
@@ -116,6 +163,14 @@ export const EdgeStylePanel = ({
   const style = edge.stroke?.style ?? 'solid';
   const head: EdgeArrowCap = edge.arrowHead ?? 'triangle';
   const tail: EdgeArrowCap = edge.arrowTail ?? 'none';
+
+  const [openSection, setOpenSection] = useState<Section | null>(null);
+  // Collapse the popover whenever the selection switches to a different
+  // edge — otherwise the old section would stay open against the fresh
+  // current values, which feels confusing.
+  useEffect(() => {
+    setOpenSection(null);
+  }, [edge.id]);
 
   // Resolve the edge's midpoint in canvas coords (accounts for bend),
   // then convert to screen coords via the current transform. The panel
@@ -138,6 +193,32 @@ export const EdgeStylePanel = ({
     onUpdate(edge.id, { stroke: { ...edge.stroke, ...patch } });
   };
 
+  const toggleSection = (section: Section) =>
+    setOpenSection((current) => (current === section ? null : section));
+
+  // Wrapper that picks a value AND collapses the popover. Selecting is
+  // always a terminal action — the user rarely wants to pick twice in
+  // a row from the same property, and auto-collapsing keeps the panel
+  // footprint minimal.
+  const choose = (fn: () => void) => {
+    fn();
+    setOpenSection(null);
+  };
+
+  const renderChip = (
+    section: Section,
+    title: string,
+    children: React.ReactNode,
+  ) => (
+    <button
+      className={`edge-chip${openSection === section ? ' edge-chip--active' : ''}`}
+      onClick={() => toggleSection(section)}
+      title={title}
+    >
+      {children}
+    </button>
+  );
+
   return (
     <div
       className="edge-style-panel"
@@ -148,111 +229,32 @@ export const EdgeStylePanel = ({
       onClick={(e) => e.stopPropagation()}
       onContextMenu={(e) => e.stopPropagation()}
     >
-      {/* Row 1 — stroke appearance: color, width, dash style. */}
-      <div className="edge-style-line">
-        <div className="edge-style-row">
-          {COLORS.map((c) => (
-            <button
-              key={c}
-              className={`edge-style-swatch${c === color ? ' edge-style-swatch--active' : ''}`}
-              style={{ background: c }}
-              onClick={() => setStroke({ color: c })}
-              title={c}
-            />
-          ))}
-        </div>
+      <div className="edge-style-chip-row">
+        {renderChip(
+          'color',
+          `Color ${color}`,
+          <span className="edge-chip-swatch" style={{ background: color }} />,
+        )}
+        {renderChip('width', `Width`, <WidthPreview width={width} />)}
+        {renderChip('style', `Style ${style ?? 'solid'}`, <StylePreview style={style} />)}
 
         <div className="edge-style-divider" />
 
-        <div className="edge-style-row">
-          {WIDTHS.map((w) => (
-            <button
-              key={w.label}
-              className={`edge-style-btn${Math.abs(width - w.value) < 0.05 ? ' edge-style-btn--active' : ''}`}
-              onClick={() => setStroke({ width: w.value })}
-              title={`Width ${w.label}`}
-            >
-              <svg width="18" height="18" viewBox="0 0 18 18">
-                <line x1={2} y1={9} x2={16} y2={9} stroke="currentColor" strokeWidth={w.value} strokeLinecap="round" />
-              </svg>
-            </button>
-          ))}
-        </div>
-
-        <div className="edge-style-divider" />
-
-        <div className="edge-style-row">
-          {STYLES.map((st) => (
-            <button
-              key={st}
-              className={`edge-style-btn${st === style ? ' edge-style-btn--active' : ''}`}
-              onClick={() => setStroke({ style: st })}
-              title={st}
-            >
-              <svg width="22" height="18" viewBox="0 0 22 18">
-                <line
-                  x1={2} y1={9} x2={20} y2={9}
-                  stroke="currentColor"
-                  strokeWidth={1.6}
-                  strokeLinecap="round"
-                  strokeDasharray={strokeDasharrayFor(st)}
-                />
-              </svg>
-            </button>
-          ))}
-        </div>
-      </div>
-
-      {/* Row 2 — endpoints & actions: start-cap, end-cap, delete. Split
-          onto its own row so the five-icon cap groups don't crowd the
-          stroke controls. The leading arrow icons make "this group
-          controls the start/end of the arrow" readable at a glance
-          instead of the old cryptic "H" / "T" text labels. */}
-      <div className="edge-style-line edge-style-line--caps">
-        <div className="edge-style-row edge-style-row--caps">
-          <span className="edge-style-icon" title="Arrow end (target)" aria-hidden="true">
-            <svg width="14" height="14" viewBox="0 0 14 14">
-              <line x1={1} y1={7} x2={11} y2={7} stroke="currentColor" strokeWidth={1.4} strokeLinecap="round" />
-              <path d="M8,3 L12,7 L8,11 z" fill="currentColor" />
-            </svg>
-          </span>
-          {CAPS.map((c) => (
-            <button
-              key={`head-${c}`}
-              className={`edge-style-btn edge-style-btn--cap${c === head ? ' edge-style-btn--active' : ''}`}
-              onClick={() => onUpdate(edge.id, { arrowHead: c })}
-              title={`End: ${c}`}
-            >
-              <CapPreview cap={c} color="currentColor" side="head" />
-            </button>
-          ))}
-        </div>
-
-        <div className="edge-style-divider" />
-
-        <div className="edge-style-row edge-style-row--caps">
-          <span className="edge-style-icon" title="Arrow start (source)" aria-hidden="true">
-            <svg width="14" height="14" viewBox="0 0 14 14">
-              <line x1={3} y1={7} x2={13} y2={7} stroke="currentColor" strokeWidth={1.4} strokeLinecap="round" />
-              <path d="M6,3 L2,7 L6,11 z" fill="currentColor" />
-            </svg>
-          </span>
-          {CAPS.map((c) => (
-            <button
-              key={`tail-${c}`}
-              className={`edge-style-btn edge-style-btn--cap${c === tail ? ' edge-style-btn--active' : ''}`}
-              onClick={() => onUpdate(edge.id, { arrowTail: c })}
-              title={`Start: ${c}`}
-            >
-              <CapPreview cap={c} color="currentColor" side="tail" />
-            </button>
-          ))}
-        </div>
+        {renderChip(
+          'head',
+          `Arrow end`,
+          <CapPreview cap={head} color="currentColor" side="head" />,
+        )}
+        {renderChip(
+          'tail',
+          `Arrow start`,
+          <CapPreview cap={tail} color="currentColor" side="tail" />,
+        )}
 
         <div className="edge-style-divider" />
 
         <button
-          className="edge-style-btn edge-style-btn--danger"
+          className="edge-chip edge-chip--danger"
           onClick={() => onRemove(edge.id)}
           title="Delete edge"
         >
@@ -260,12 +262,111 @@ export const EdgeStylePanel = ({
             <path
               d="M4 4l8 8M12 4L4 12"
               stroke="currentColor"
-              strokeWidth="1.4"
+              strokeWidth="1.5"
               strokeLinecap="round"
             />
           </svg>
         </button>
       </div>
+
+      {openSection && (
+        <div className="edge-style-popover">
+          {openSection === 'color' && (
+            <div className="edge-style-row">
+              {COLORS.map((c) => (
+                <button
+                  key={c}
+                  className={`edge-style-swatch${c === color ? ' edge-style-swatch--active' : ''}`}
+                  style={{ background: c }}
+                  onClick={() => choose(() => setStroke({ color: c }))}
+                  title={c}
+                />
+              ))}
+            </div>
+          )}
+
+          {openSection === 'width' && (
+            <div className="edge-style-row">
+              {WIDTHS.map((w) => (
+                <button
+                  key={w.label}
+                  className={`edge-style-btn${Math.abs(width - w.value) < 0.05 ? ' edge-style-btn--active' : ''}`}
+                  onClick={() => choose(() => setStroke({ width: w.value }))}
+                  title={`Width ${w.label}`}
+                >
+                  <svg width="26" height="18" viewBox="0 0 26 18">
+                    <line
+                      x1={3}
+                      y1={9}
+                      x2={23}
+                      y2={9}
+                      stroke="currentColor"
+                      strokeWidth={w.value}
+                      strokeLinecap="round"
+                    />
+                  </svg>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {openSection === 'style' && (
+            <div className="edge-style-row">
+              {STYLES.map((st) => (
+                <button
+                  key={st}
+                  className={`edge-style-btn${st === style ? ' edge-style-btn--active' : ''}`}
+                  onClick={() => choose(() => setStroke({ style: st }))}
+                  title={st}
+                >
+                  <svg width="30" height="18" viewBox="0 0 30 18">
+                    <line
+                      x1={3}
+                      y1={9}
+                      x2={27}
+                      y2={9}
+                      stroke="currentColor"
+                      strokeWidth={1.8}
+                      strokeLinecap="round"
+                      strokeDasharray={strokeDasharrayFor(st)}
+                    />
+                  </svg>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {openSection === 'head' && (
+            <div className="edge-style-row edge-style-row--caps">
+              {CAPS.map((c) => (
+                <button
+                  key={`head-${c}`}
+                  className={`edge-style-btn edge-style-btn--cap${c === head ? ' edge-style-btn--active' : ''}`}
+                  onClick={() => choose(() => onUpdate(edge.id, { arrowHead: c }))}
+                  title={`End: ${c}`}
+                >
+                  <CapPreview cap={c} color="currentColor" side="head" />
+                </button>
+              ))}
+            </div>
+          )}
+
+          {openSection === 'tail' && (
+            <div className="edge-style-row edge-style-row--caps">
+              {CAPS.map((c) => (
+                <button
+                  key={`tail-${c}`}
+                  className={`edge-style-btn edge-style-btn--cap${c === tail ? ' edge-style-btn--active' : ''}`}
+                  onClick={() => choose(() => onUpdate(edge.id, { arrowTail: c }))}
+                  title={`Start: ${c}`}
+                >
+                  <CapPreview cap={c} color="currentColor" side="tail" />
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/components/EdgeStylePanel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeStylePanel/index.tsx
@@ -1,0 +1,253 @@
+import { useMemo } from 'react';
+import './index.css';
+import type {
+  CanvasEdge,
+  CanvasNode,
+  CanvasTransform,
+  EdgeArrowCap,
+  EdgeStroke,
+} from '../../types';
+import {
+  bendHandlePoint,
+  resolveEndpoint,
+  resolveEndpointToward,
+} from '../../utils/edgeFactory';
+
+/**
+ * A compact floating panel, shown when an edge is selected, that lets
+ * the user tweak its stroke color, width, dash style, arrow head / tail,
+ * and delete it. Positioned above the edge's midpoint in screen space so
+ * it tracks the edge as nodes move / the canvas pans.
+ *
+ * Clicks inside the panel are stopped from bubbling up into the canvas
+ * click handler so changing style doesn't accidentally deselect the
+ * edge we're editing.
+ */
+interface Props {
+  edge: CanvasEdge;
+  nodes: CanvasNode[];
+  transform: CanvasTransform;
+  onUpdate: (id: string, patch: Partial<CanvasEdge>) => void;
+  onRemove: (id: string) => void;
+}
+
+// Palette mirrors tldraw-style defaults — 1 neutral + 6 hues that read well on the
+// off-white canvas background at both zoom extremes. First entry matches
+// DEFAULT_STROKE.color in CanvasEdgesLayer.
+const COLORS: string[] = [
+  '#1f2328',
+  '#e5484d',
+  '#f76808',
+  '#ffba18',
+  '#30a46c',
+  '#0091ff',
+  '#8e4ec6',
+];
+
+const WIDTHS: Array<{ label: string; value: number }> = [
+  { label: 'S', value: 1.2 },
+  { label: 'M', value: 1.6 },
+  { label: 'L', value: 2.4 },
+];
+
+const STYLES: Array<NonNullable<EdgeStroke['style']>> = ['solid', 'dashed', 'dotted'];
+
+const CAPS: EdgeArrowCap[] = ['none', 'triangle', 'arrow', 'dot', 'bar'];
+
+const strokeDasharrayFor = (style: EdgeStroke['style']): string | undefined => {
+  switch (style) {
+    case 'dashed': return '6 4';
+    case 'dotted': return '1.5 3';
+    case 'solid':
+    default:       return undefined;
+  }
+};
+
+/**
+ * Small SVG preview for a single arrow cap. Used in the head/tail
+ * picker buttons — a short line with the cap on the right-hand side.
+ */
+const CapPreview = ({ cap, color, side }: { cap: EdgeArrowCap; color: string; side: 'head' | 'tail' }) => {
+  const size = 18;
+  // For "tail" we mirror so the cap visually sits on the start of the stroke.
+  const x1 = side === 'head' ? 2 : 16;
+  const x2 = side === 'head' ? 14 : 4;
+  return (
+    <svg width={size} height={size} viewBox="0 0 18 18">
+      <line x1={x1} y1={9} x2={x2} y2={9} stroke={color} strokeWidth={1.4} strokeLinecap="round" />
+      {cap === 'triangle' && (
+        <path
+          d={side === 'head' ? 'M10,5 L16,9 L10,13 Z' : 'M8,5 L2,9 L8,13 Z'}
+          fill={color}
+        />
+      )}
+      {cap === 'arrow' && (
+        <path
+          d={side === 'head' ? 'M10,5 L16,9 L10,13' : 'M8,5 L2,9 L8,13'}
+          fill="none"
+          stroke={color}
+          strokeWidth={1.4}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      )}
+      {cap === 'dot' && (
+        <circle cx={side === 'head' ? 15 : 3} cy={9} r={2.5} fill={color} />
+      )}
+      {cap === 'bar' && (
+        <rect x={side === 'head' ? 14 : 3} y={4} width={1.6} height={10} fill={color} />
+      )}
+      {cap === 'none' && (
+        <circle cx={side === 'head' ? 15 : 3} cy={9} r={2.2} fill="none" stroke={color} strokeWidth={1} />
+      )}
+    </svg>
+  );
+};
+
+export const EdgeStylePanel = ({
+  edge,
+  nodes,
+  transform,
+  onUpdate,
+  onRemove,
+}: Props) => {
+  const color = edge.stroke?.color ?? '#1f2328';
+  const width = edge.stroke?.width ?? 1.6;
+  const style = edge.stroke?.style ?? 'solid';
+  const head: EdgeArrowCap = edge.arrowHead ?? 'triangle';
+  const tail: EdgeArrowCap = edge.arrowTail ?? 'none';
+
+  // Resolve the edge's midpoint in canvas coords (accounts for bend),
+  // then convert to screen coords via the current transform. The panel
+  // sits inside `.canvas-container`, so transform.x/y (pan offset) map
+  // directly to container-relative coordinates.
+  const screenPos = useMemo(() => {
+    const nodesById = new Map(nodes.map((n) => [n.id, n]));
+    const approxS = resolveEndpoint(edge.source, nodesById);
+    const approxT = resolveEndpoint(edge.target, nodesById);
+    const s = resolveEndpointToward(edge.source, nodesById, approxT);
+    const t = resolveEndpointToward(edge.target, nodesById, approxS);
+    const mid = bendHandlePoint(s, t, edge.bend ?? 0);
+    return {
+      x: mid.x * transform.scale + transform.x,
+      y: mid.y * transform.scale + transform.y,
+    };
+  }, [edge, nodes, transform]);
+
+  const setStroke = (patch: Partial<EdgeStroke>) => {
+    onUpdate(edge.id, { stroke: { ...edge.stroke, ...patch } });
+  };
+
+  return (
+    <div
+      className="edge-style-panel"
+      style={{ left: screenPos.x, top: screenPos.y }}
+      // Stop propagation so our own clicks don't hit the canvas-level
+      // blank-click handler (which would deselect the edge we're styling).
+      onMouseDown={(e) => e.stopPropagation()}
+      onClick={(e) => e.stopPropagation()}
+      onContextMenu={(e) => e.stopPropagation()}
+    >
+      <div className="edge-style-row">
+        {COLORS.map((c) => (
+          <button
+            key={c}
+            className={`edge-style-swatch${c === color ? ' edge-style-swatch--active' : ''}`}
+            style={{ background: c }}
+            onClick={() => setStroke({ color: c })}
+            title={c}
+          />
+        ))}
+      </div>
+
+      <div className="edge-style-divider" />
+
+      <div className="edge-style-row">
+        {WIDTHS.map((w) => (
+          <button
+            key={w.label}
+            className={`edge-style-btn${Math.abs(width - w.value) < 0.05 ? ' edge-style-btn--active' : ''}`}
+            onClick={() => setStroke({ width: w.value })}
+            title={`Width ${w.label}`}
+          >
+            <svg width="18" height="18" viewBox="0 0 18 18">
+              <line x1={2} y1={9} x2={16} y2={9} stroke="currentColor" strokeWidth={w.value} strokeLinecap="round" />
+            </svg>
+          </button>
+        ))}
+      </div>
+
+      <div className="edge-style-divider" />
+
+      <div className="edge-style-row">
+        {STYLES.map((st) => (
+          <button
+            key={st}
+            className={`edge-style-btn${st === style ? ' edge-style-btn--active' : ''}`}
+            onClick={() => setStroke({ style: st })}
+            title={st}
+          >
+            <svg width="22" height="18" viewBox="0 0 22 18">
+              <line
+                x1={2} y1={9} x2={20} y2={9}
+                stroke="currentColor"
+                strokeWidth={1.6}
+                strokeLinecap="round"
+                strokeDasharray={strokeDasharrayFor(st)}
+              />
+            </svg>
+          </button>
+        ))}
+      </div>
+
+      <div className="edge-style-divider" />
+
+      <div className="edge-style-row edge-style-row--caps">
+        <span className="edge-style-label">H</span>
+        {CAPS.map((c) => (
+          <button
+            key={`head-${c}`}
+            className={`edge-style-btn edge-style-btn--cap${c === head ? ' edge-style-btn--active' : ''}`}
+            onClick={() => onUpdate(edge.id, { arrowHead: c })}
+            title={`Head: ${c}`}
+          >
+            <CapPreview cap={c} color="currentColor" side="head" />
+          </button>
+        ))}
+      </div>
+
+      <div className="edge-style-divider" />
+
+      <div className="edge-style-row edge-style-row--caps">
+        <span className="edge-style-label">T</span>
+        {CAPS.map((c) => (
+          <button
+            key={`tail-${c}`}
+            className={`edge-style-btn edge-style-btn--cap${c === tail ? ' edge-style-btn--active' : ''}`}
+            onClick={() => onUpdate(edge.id, { arrowTail: c })}
+            title={`Tail: ${c}`}
+          >
+            <CapPreview cap={c} color="currentColor" side="tail" />
+          </button>
+        ))}
+      </div>
+
+      <div className="edge-style-divider" />
+
+      <button
+        className="edge-style-btn edge-style-btn--danger"
+        onClick={() => onRemove(edge.id)}
+        title="Delete edge"
+      >
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+          <path
+            d="M4 4l8 8M12 4L4 12"
+            stroke="currentColor"
+            strokeWidth="1.4"
+            strokeLinecap="round"
+          />
+        </svg>
+      </button>
+    </div>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
@@ -37,6 +37,22 @@ const tools = [
         />
       </svg>
     )
+  },
+  {
+    id: "connect",
+    label: "Connect",
+    icon: (
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+        <circle cx="4" cy="4" r="2" stroke="currentColor" strokeWidth="1.3" />
+        <circle cx="14" cy="14" r="2" stroke="currentColor" strokeWidth="1.3" />
+        <path
+          d="M5.5 5.5L12.5 12.5"
+          stroke="currentColor"
+          strokeWidth="1.3"
+          strokeLinecap="round"
+        />
+      </svg>
+    )
   }
 ];
 

--- a/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.ts
@@ -7,6 +7,11 @@ interface Options {
   nodes: CanvasNode[];
   selectedNodeIds: string[];
   setSelectedNodeIds: (ids: string[]) => void;
+  /** Currently selected edge (if any). Delete/Backspace removes it; Esc
+   *  deselects it before falling through to node-deselect. */
+  selectedEdgeId: string | null;
+  setSelectedEdgeId: (id: string | null) => void;
+  removeEdge: (id: string) => void;
   duplicateNode: (id: string) => CanvasNode | null;
   clipboardNodes: CanvasNode[];
   setClipboardNodes: (nodes: CanvasNode[]) => void;
@@ -22,6 +27,7 @@ interface Options {
 
 export const useCanvasKeyboard = ({
   undo, redo, nodes, selectedNodeIds, setSelectedNodeIds,
+  selectedEdgeId, setSelectedEdgeId, removeEdge,
   duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, removeNodes,
   searchOpen, setSearchOpen, contextMenu, setContextMenu,
   setHighlightedId, handleFocusNode,
@@ -80,10 +86,17 @@ export const useCanvasKeyboard = ({
       if (e.key === 'Escape') {
         if (searchOpen) { setSearchOpen(false); return; }
         if (contextMenu) { setContextMenu(null); return; }
+        if (selectedEdgeId) { setSelectedEdgeId(null); return; }
         setSelectedNodeIds([]);
         return;
       }
       if ((e.key === 'Delete' || e.key === 'Backspace') && !isEditable) {
+        if (selectedEdgeId) {
+          e.preventDefault();
+          removeEdge(selectedEdgeId);
+          setSelectedEdgeId(null);
+          return;
+        }
         if (selectedNodeIds.length > 0) {
           e.preventDefault();
           removeNodes(selectedNodeIds);
@@ -95,7 +108,7 @@ export const useCanvasKeyboard = ({
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [undo, redo, nodes, selectedNodeIds, setSelectedNodeIds, duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, removeNodes, searchOpen, setSearchOpen, contextMenu, setContextMenu]);
+  }, [undo, redo, nodes, selectedNodeIds, setSelectedNodeIds, selectedEdgeId, setSelectedEdgeId, removeEdge, duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, removeNodes, searchOpen, setSearchOpen, contextMenu, setContextMenu]);
 
   // Cmd/Ctrl+Tab to cycle through nodes (Shift reverses direction)
   useEffect(() => {

--- a/apps/canvas-workspace/src/renderer/src/hooks/useEdgeInteraction.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useEdgeInteraction.ts
@@ -63,6 +63,19 @@ export type EdgeInteractionState =
        *  drag start. Subtracted from subsequent offsets to yield a
        *  pure delta. */
       originOffset: number;
+    }
+  | {
+      kind: 'move-edge';
+      edgeId: string;
+      /** Snapshot of the edge's endpoints at drag start. Free-point
+       *  endpoints get translated by (cursor - originCursor); node-bound
+       *  endpoints are kept as-is so arrows stay anchored to the nodes
+       *  they connect. */
+      initialSource: EdgeEndpoint;
+      initialTarget: EdgeEndpoint;
+      /** Cursor position (canvas coords) at drag start. */
+      originCursor: Point;
+      cursor: Point;
     };
 
 interface UseEdgeInteractionArgs {
@@ -203,6 +216,27 @@ export const useEdgeInteraction = ({
       updateEdge(current.edgeId, { bend: newBend }, false);
       return;
     }
+
+    if (current.kind === 'move-edge') {
+      const dx = pt.x - current.originCursor.x;
+      const dy = pt.y - current.originCursor.y;
+      const translateFree = (ep: EdgeEndpoint): EdgeEndpoint =>
+        ep.kind === 'point' ? { kind: 'point', x: ep.x + dx, y: ep.y + dy } : ep;
+      const nextSource = translateFree(current.initialSource);
+      const nextTarget = translateFree(current.initialTarget);
+      setState({ ...current, cursor: pt });
+      // Only patch the endpoints that actually changed so node-bound
+      // edges (both endpoints locked) don't generate a pointless
+      // write every mousemove frame.
+      if (nextSource === current.initialSource && nextTarget === current.initialTarget) {
+        return;
+      }
+      const patch: Partial<CanvasEdge> = {};
+      if (nextSource !== current.initialSource) patch.source = nextSource;
+      if (nextTarget !== current.initialTarget) patch.target = nextTarget;
+      updateEdge(current.edgeId, patch, false);
+      return;
+    }
   }, [toCanvas, updateEdge]);
 
   const handleUp = useCallback(() => {
@@ -226,7 +260,11 @@ export const useEdgeInteraction = ({
           onConnectCommitted?.(edge.id);
         }
       }
-    } else if (current.kind === 'move-end' || current.kind === 'move-bend') {
+    } else if (
+      current.kind === 'move-end' ||
+      current.kind === 'move-bend' ||
+      current.kind === 'move-edge'
+    ) {
       // Live updates during move-* were history-silent; commit a
       // single undo step here so the whole drag is atomic.
       commitHistory();
@@ -327,6 +365,28 @@ export const useEdgeInteraction = ({
   }, [edges, toCanvas]);
 
   /**
+   * Begin translating the whole edge. Called by the hit-proxy when the
+   * user mousedowns on the edge body. We snapshot both endpoints at
+   * drag start; only free-point endpoints get translated in handleMove
+   * — node-bound endpoints stay anchored to their node so the arrow
+   * keeps binding to the shape.
+   */
+  const beginMoveEdge = useCallback((edgeId: string, clientX: number, clientY: number) => {
+    const pt = toCanvas(clientX, clientY);
+    if (!pt) return;
+    const edge = edges.find((e) => e.id === edgeId);
+    if (!edge) return;
+    setState({
+      kind: 'move-edge',
+      edgeId,
+      initialSource: edge.source,
+      initialTarget: edge.target,
+      originCursor: pt,
+      cursor: pt,
+    });
+  }, [edges, toCanvas]);
+
+  /**
    * Resolve the current preview edge's endpoints (for rendering the
    * dashed draft line). Returns null when no connect/move-end drag is
    * active. Handles both free-point endpoints and node-bound auto
@@ -354,6 +414,7 @@ export const useEdgeInteraction = ({
     beginConnect,
     beginMoveEnd,
     beginMoveBend,
+    beginMoveEdge,
     getPreviewEndpoints,
   };
 };

--- a/apps/canvas-workspace/src/renderer/src/hooks/useEdgeInteraction.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useEdgeInteraction.ts
@@ -54,6 +54,15 @@ export type EdgeInteractionState =
       s: Point;
       t: Point;
       cursor: Point;
+      /** Edge.bend at drag start. We apply cursor-offset deltas on top
+       *  of this so a drag that starts *on the curve* (not on the
+       *  midpoint handle) doesn't yank the bend to the cursor's raw
+       *  perpendicular offset. */
+      originBend: number;
+      /** Cursor's perpendicular offset from the straight line s→t at
+       *  drag start. Subtracted from subsequent offsets to yield a
+       *  pure delta. */
+      originOffset: number;
     };
 
 interface UseEdgeInteractionArgs {
@@ -73,6 +82,11 @@ interface UseEdgeInteractionArgs {
   /** Edges are needed by move-end / move-bend to look up the edge
    *  being dragged. */
   edges: CanvasEdge[];
+  /** Called once after a connect-drag successfully commits a new edge
+   *  (ignored for discarded clicks and self-drops). The Canvas wires
+   *  this to `setActiveTool('select')` so the user isn't stuck in
+   *  connect mode after drawing one arrow. */
+  onConnectCommitted?: (edgeId: string) => void;
 }
 
 /**
@@ -114,6 +128,7 @@ export const useEdgeInteraction = ({
   updateEdge,
   commitHistory,
   edges,
+  onConnectCommitted,
 }: UseEdgeInteractionArgs) => {
   const [state, setState] = useState<EdgeInteractionState | null>(null);
   // Mirror of state for use inside the stable window-level listeners,
@@ -182,7 +197,8 @@ export const useEdgeInteraction = ({
     }
 
     if (current.kind === 'move-bend') {
-      const newBend = bendFromCursor(current.s, current.t, pt);
+      const offset = bendFromCursor(current.s, current.t, pt);
+      const newBend = current.originBend + (offset - current.originOffset);
       setState({ ...current, cursor: pt });
       updateEdge(current.edgeId, { bend: newBend }, false);
       return;
@@ -204,7 +220,10 @@ export const useEdgeInteraction = ({
           target.kind === 'node' &&
           current.source.nodeId === target.nodeId;
         if (!isSelfDrop) {
-          addEdge(createDefaultEdge(current.source, target));
+          const edge = addEdge(createDefaultEdge(current.source, target));
+          // Hand control back to the caller so it can exit connect mode
+          // (tldraw-style: you draw one arrow, then you're back in select).
+          onConnectCommitted?.(edge.id);
         }
       }
     } else if (current.kind === 'move-end' || current.kind === 'move-bend') {
@@ -214,7 +233,7 @@ export const useEdgeInteraction = ({
     }
 
     setState(null);
-  }, [addEdge, commitHistory]);
+  }, [addEdge, commitHistory, onConnectCommitted]);
 
   // Window-level listeners are installed only while an interaction is
   // live. Using window (not the canvas container) means the drag keeps
@@ -290,8 +309,22 @@ export const useEdgeInteraction = ({
   ) => {
     const pt = toCanvas(clientX, clientY);
     if (!pt) return;
-    setState({ kind: 'move-bend', edgeId, s, t, cursor: pt });
-  }, [toCanvas]);
+    const edge = edges.find((e) => e.id === edgeId);
+    const originBend = edge?.bend ?? 0;
+    // Cursor's offset-from-straight-line at mousedown time — baseline
+    // for delta math in handleMove so dragging from anywhere on the
+    // curve (not just the midpoint handle) feels continuous.
+    const originOffset = bendFromCursor(s, t, pt);
+    setState({
+      kind: 'move-bend',
+      edgeId,
+      s,
+      t,
+      cursor: pt,
+      originBend,
+      originOffset,
+    });
+  }, [edges, toCanvas]);
 
   /**
    * Resolve the current preview edge's endpoints (for rendering the

--- a/apps/canvas-workspace/src/renderer/src/hooks/useEdgeInteraction.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useEdgeInteraction.ts
@@ -1,0 +1,326 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { CanvasEdge, CanvasNode, EdgeEndpoint } from '../types';
+import {
+  bendFromCursor,
+  createDefaultEdge,
+  findNodeAtCanvasPoint,
+  resolveEndpointToward,
+} from '../utils/edgeFactory';
+
+/** Minimum pixel distance between connect-drag start and end before we
+ *  commit a new edge. Clicks that don't move past this threshold are
+ *  treated as an accidental click in connect mode and discarded. */
+const CONNECT_DRAG_MIN_DISTANCE = 6;
+
+export type Point = { x: number; y: number };
+
+/**
+ * Active edge interaction. Only one can be in-flight at a time; the
+ * overlay layer reads this to render the preview line and the handle
+ * positions while the drag is live.
+ */
+export type EdgeInteractionState =
+  | {
+      kind: 'connect';
+      source: EdgeEndpoint;
+      /** Where the mouse currently is in canvas coords. */
+      cursor: Point;
+      /** Node under the cursor, if any — for preview highlighting. */
+      hoverNodeId: string | null;
+      /** Total canvas-px distance moved since start. Used to decide
+       *  whether to commit vs. discard on mouseup. */
+      distance: number;
+    }
+  | {
+      kind: 'move-end';
+      edgeId: string;
+      /** Which end of the edge is being dragged. */
+      end: 'source' | 'target';
+      /** The OTHER endpoint — kept frozen for the duration of the drag
+       *  so preview math stays stable even if its node gets moved by
+       *  some other hook. */
+      frozen: EdgeEndpoint;
+      cursor: Point;
+      hoverNodeId: string | null;
+    }
+  | {
+      kind: 'move-bend';
+      edgeId: string;
+      /** s/t are the resolved screen-space coords of the edge's two
+       *  endpoints as-of-drag-start. We freeze them so that the bend
+       *  math (perpendicular projection of cursor onto s→t) doesn't
+       *  drift if the endpoints' resolved positions would otherwise
+       *  shift mid-drag. */
+      s: Point;
+      t: Point;
+      cursor: Point;
+    };
+
+interface UseEdgeInteractionArgs {
+  /** All nodes, used for hit-testing and for resolving node-bound
+   *  endpoints' screen positions. */
+  nodes: CanvasNode[];
+  /** Same `sortedNodes` list the canvas renders — hit-test walks this
+   *  in reverse so the visually-topmost node wins. */
+  sortedNodes: CanvasNode[];
+  /** Screen → canvas coordinate conversion (from useCanvas). */
+  screenToCanvas: (screenX: number, screenY: number, container: HTMLElement) => Point;
+  /** The canvas-container DOM element, needed by screenToCanvas. */
+  getContainer: () => HTMLElement | null;
+  addEdge: (edge: CanvasEdge) => CanvasEdge;
+  updateEdge: (id: string, patch: Partial<CanvasEdge>, addToHistory?: boolean) => void;
+  commitHistory: () => void;
+  /** Edges are needed by move-end / move-bend to look up the edge
+   *  being dragged. */
+  edges: CanvasEdge[];
+}
+
+/**
+ * Resolves the current cursor position into an EdgeEndpoint:
+ *  - if it's over a node → node-bound (auto anchor, which will
+ *    render as the bbox boundary point toward the other endpoint),
+ *  - else a free point.
+ */
+const cursorToEndpoint = (
+  cursor: Point,
+  sortedNodes: CanvasNode[],
+): { endpoint: EdgeEndpoint; hoverNodeId: string | null } => {
+  const hit = findNodeAtCanvasPoint(sortedNodes, cursor.x, cursor.y);
+  if (hit) {
+    return {
+      endpoint: { kind: 'node', nodeId: hit.id, anchor: 'auto' },
+      hoverNodeId: hit.id,
+    };
+  }
+  return {
+    endpoint: { kind: 'point', x: cursor.x, y: cursor.y },
+    hoverNodeId: null,
+  };
+};
+
+/**
+ * Coordinates the three live edge interactions — drawing a new edge in
+ * connect mode, dragging an existing edge's start/end handle, and
+ * dragging a bend handle. Encapsulating the global mousemove/mouseup
+ * listeners here keeps the Canvas component from accumulating another
+ * half-dozen event handlers.
+ */
+export const useEdgeInteraction = ({
+  nodes,
+  sortedNodes,
+  screenToCanvas,
+  getContainer,
+  addEdge,
+  updateEdge,
+  commitHistory,
+  edges,
+}: UseEdgeInteractionArgs) => {
+  const [state, setState] = useState<EdgeInteractionState | null>(null);
+  // Mirror of state for use inside the stable window-level listeners,
+  // which are installed once per interaction start.
+  const stateRef = useRef<EdgeInteractionState | null>(null);
+  stateRef.current = state;
+
+  // Fresh view of nodes for the listeners to hit-test against.
+  const sortedNodesRef = useRef(sortedNodes);
+  sortedNodesRef.current = sortedNodes;
+
+  const screenToCanvasRef = useRef(screenToCanvas);
+  screenToCanvasRef.current = screenToCanvas;
+
+  const nodesById = useRef(new Map<string, CanvasNode>());
+  nodesById.current = new Map(nodes.map((n) => [n.id, n]));
+
+  /**
+   * Compute the mouse position in canvas coordinates. Returns null if
+   * the container isn't mounted (shouldn't happen during an active
+   * drag, but we defensively bail).
+   */
+  const toCanvas = useCallback((clientX: number, clientY: number): Point | null => {
+    const container = getContainer();
+    if (!container) return null;
+    return screenToCanvasRef.current(clientX, clientY, container);
+  }, [getContainer]);
+
+  const handleMove = useCallback((clientX: number, clientY: number) => {
+    const current = stateRef.current;
+    if (!current) return;
+    const pt = toCanvas(clientX, clientY);
+    if (!pt) return;
+
+    if (current.kind === 'connect') {
+      const hit = findNodeAtCanvasPoint(sortedNodesRef.current, pt.x, pt.y);
+      const dx = pt.x - current.cursor.x;
+      const dy = pt.y - current.cursor.y;
+      setState({
+        ...current,
+        cursor: pt,
+        hoverNodeId: hit?.id ?? null,
+        distance: current.distance + Math.hypot(dx, dy),
+      });
+      return;
+    }
+
+    if (current.kind === 'move-end') {
+      const hit = findNodeAtCanvasPoint(sortedNodesRef.current, pt.x, pt.y);
+      setState({
+        ...current,
+        cursor: pt,
+        hoverNodeId: hit?.id ?? null,
+      });
+      // Live preview: also push the new endpoint to the store without
+      // adding to history. We commit one history step on mouseup.
+      const newEndpoint: EdgeEndpoint = hit
+        ? { kind: 'node', nodeId: hit.id, anchor: 'auto' }
+        : { kind: 'point', x: pt.x, y: pt.y };
+      updateEdge(
+        current.edgeId,
+        current.end === 'source' ? { source: newEndpoint } : { target: newEndpoint },
+        false,
+      );
+      return;
+    }
+
+    if (current.kind === 'move-bend') {
+      const newBend = bendFromCursor(current.s, current.t, pt);
+      setState({ ...current, cursor: pt });
+      updateEdge(current.edgeId, { bend: newBend }, false);
+      return;
+    }
+  }, [toCanvas, updateEdge]);
+
+  const handleUp = useCallback(() => {
+    const current = stateRef.current;
+    if (!current) return;
+
+    if (current.kind === 'connect') {
+      if (current.distance >= CONNECT_DRAG_MIN_DISTANCE) {
+        const { endpoint: target } = cursorToEndpoint(current.cursor, sortedNodesRef.current);
+        // If the user dropped back on the same node they started
+        // from, skip — a self-loop is almost always an accident.
+        // Drops on blank space OR a different node both commit.
+        const isSelfDrop =
+          current.source.kind === 'node' &&
+          target.kind === 'node' &&
+          current.source.nodeId === target.nodeId;
+        if (!isSelfDrop) {
+          addEdge(createDefaultEdge(current.source, target));
+        }
+      }
+    } else if (current.kind === 'move-end' || current.kind === 'move-bend') {
+      // Live updates during move-* were history-silent; commit a
+      // single undo step here so the whole drag is atomic.
+      commitHistory();
+    }
+
+    setState(null);
+  }, [addEdge, commitHistory]);
+
+  // Window-level listeners are installed only while an interaction is
+  // live. Using window (not the canvas container) means the drag keeps
+  // tracking when the cursor slips off the canvas — matches the
+  // existing node-drag behaviour.
+  useEffect(() => {
+    if (!state) return;
+    const onMove = (e: MouseEvent) => handleMove(e.clientX, e.clientY);
+    const onUp = () => handleUp();
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+    return () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+  }, [state, handleMove, handleUp]);
+
+  /**
+   * Begin drawing a new edge. Called by the connect-mode overlay.
+   * `clientX/Y` are the screen coords of the mousedown event.
+   */
+  const beginConnect = useCallback((clientX: number, clientY: number) => {
+    const pt = toCanvas(clientX, clientY);
+    if (!pt) return;
+    const { endpoint: source, hoverNodeId } = cursorToEndpoint(pt, sortedNodesRef.current);
+    setState({
+      kind: 'connect',
+      source,
+      cursor: pt,
+      hoverNodeId,
+      distance: 0,
+    });
+  }, [toCanvas]);
+
+  /**
+   * Begin dragging an endpoint of an existing edge. `end === 'source'`
+   * moves the start handle, `'target'` moves the end handle.
+   */
+  const beginMoveEnd = useCallback((
+    edgeId: string,
+    end: 'source' | 'target',
+    clientX: number,
+    clientY: number,
+  ) => {
+    const pt = toCanvas(clientX, clientY);
+    if (!pt) return;
+    const edge = edges.find((e) => e.id === edgeId);
+    if (!edge) return;
+    const frozen = end === 'source' ? edge.target : edge.source;
+    const hit = findNodeAtCanvasPoint(sortedNodesRef.current, pt.x, pt.y);
+    setState({
+      kind: 'move-end',
+      edgeId,
+      end,
+      frozen,
+      cursor: pt,
+      hoverNodeId: hit?.id ?? null,
+    });
+  }, [edges, toCanvas]);
+
+  /**
+   * Begin dragging the bend handle. We snapshot the resolved endpoint
+   * positions so the perpendicular projection stays anchored even if
+   * the endpoints move slightly mid-drag (e.g. parent frame is being
+   * reflowed by something else).
+   */
+  const beginMoveBend = useCallback((
+    edgeId: string,
+    s: Point,
+    t: Point,
+    clientX: number,
+    clientY: number,
+  ) => {
+    const pt = toCanvas(clientX, clientY);
+    if (!pt) return;
+    setState({ kind: 'move-bend', edgeId, s, t, cursor: pt });
+  }, [toCanvas]);
+
+  /**
+   * Resolve the current preview edge's endpoints (for rendering the
+   * dashed draft line). Returns null when no connect/move-end drag is
+   * active. Handles both free-point endpoints and node-bound auto
+   * anchors (computed toward the opposite endpoint).
+   */
+  const getPreviewEndpoints = useCallback((): { s: Point; t: Point } | null => {
+    if (!state) return null;
+    if (state.kind === 'connect') {
+      const targetPoint: Point = { x: state.cursor.x, y: state.cursor.y };
+      const s = resolveEndpointToward(state.source, nodesById.current, targetPoint);
+      return { s, t: targetPoint };
+    }
+    if (state.kind === 'move-end') {
+      const frozenPoint = resolveEndpointToward(state.frozen, nodesById.current, state.cursor);
+      if (state.end === 'source') {
+        return { s: state.cursor, t: frozenPoint };
+      }
+      return { s: frozenPoint, t: state.cursor };
+    }
+    return null;
+  }, [state]);
+
+  return {
+    state,
+    beginConnect,
+    beginMoveEnd,
+    beginMoveBend,
+    getPreviewEndpoints,
+  };
+};

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodeHistory.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodeHistory.ts
@@ -1,58 +1,129 @@
 import { useCallback, useRef, useState } from 'react';
-import type { CanvasNode } from '../types';
+import type { CanvasEdge, CanvasNode } from '../types';
 
 const MAX_HISTORY = 100;
 
+/**
+ * Combined snapshot of everything the canvas considers undoable state.
+ * Both nodes and edges share a single history stack so one `undo` reverses
+ * e.g. "created node + auto-bent a connected edge" as a single step, and so
+ * deleting a node (which degrades bound edges to free points) can be undone
+ * atomically.
+ */
+export interface CanvasSnapshot {
+  nodes: CanvasNode[];
+  edges: CanvasEdge[];
+}
+
+const EMPTY_SNAPSHOT: CanvasSnapshot = { nodes: [], edges: [] };
+
 export const useNodeHistory = (scheduleSave: () => void) => {
-  const [nodes, setNodes] = useState<CanvasNode[]>([]);
+  const [nodes, setNodes] = useState<CanvasNode[]>(EMPTY_SNAPSHOT.nodes);
+  const [edges, setEdges] = useState<CanvasEdge[]>(EMPTY_SNAPSHOT.edges);
   const nodesRef = useRef<CanvasNode[]>(nodes);
-  const historyRef = useRef<CanvasNode[][]>([]);
+  const edgesRef = useRef<CanvasEdge[]>(edges);
+  const historyRef = useRef<CanvasSnapshot[]>([]);
   const historyIndexRef = useRef(-1);
 
-  const applyNodes = useCallback(
-    (newNodes: CanvasNode[], addToHistory = true) => {
-      if (addToHistory) {
-        const trimmed = historyRef.current.slice(0, historyIndexRef.current + 1);
-        trimmed.push(newNodes);
-        if (trimmed.length > MAX_HISTORY) trimmed.shift();
-        historyIndexRef.current = trimmed.length - 1;
-        historyRef.current = trimmed;
-      }
-      setNodes(newNodes);
-      nodesRef.current = newNodes;
-      scheduleSave();
-    },
-    [scheduleSave]
-  );
-
-  const commitHistory = useCallback(() => {
-    const current = nodesRef.current;
-    const last = historyRef.current[historyIndexRef.current];
-    if (current === last) return;
+  const pushSnapshot = useCallback((snap: CanvasSnapshot) => {
     const trimmed = historyRef.current.slice(0, historyIndexRef.current + 1);
-    trimmed.push(current);
+    trimmed.push(snap);
     if (trimmed.length > MAX_HISTORY) trimmed.shift();
     historyIndexRef.current = trimmed.length - 1;
     historyRef.current = trimmed;
   }, []);
 
+  /**
+   * Apply a partial snapshot. Any key omitted keeps its current value.
+   * `addToHistory = false` is for drag-style mutations where we only want
+   * to commit a single history slot on mouse-up (see `commitHistory`).
+   */
+  const applyState = useCallback(
+    (patch: Partial<CanvasSnapshot>, addToHistory = true) => {
+      const nextNodes = patch.nodes ?? nodesRef.current;
+      const nextEdges = patch.edges ?? edgesRef.current;
+      if (addToHistory) {
+        pushSnapshot({ nodes: nextNodes, edges: nextEdges });
+      }
+      if (patch.nodes) {
+        nodesRef.current = nextNodes;
+        setNodes(nextNodes);
+      }
+      if (patch.edges) {
+        edgesRef.current = nextEdges;
+        setEdges(nextEdges);
+      }
+      scheduleSave();
+    },
+    [pushSnapshot, scheduleSave],
+  );
+
+  // Back-compat shim: existing call sites use `applyNodes(newNodes, addToHistory?)`.
+  const applyNodes = useCallback(
+    (newNodes: CanvasNode[], addToHistory = true) => {
+      applyState({ nodes: newNodes }, addToHistory);
+    },
+    [applyState],
+  );
+
+  const applyEdges = useCallback(
+    (newEdges: CanvasEdge[], addToHistory = true) => {
+      applyState({ edges: newEdges }, addToHistory);
+    },
+    [applyState],
+  );
+
+  const commitHistory = useCallback(() => {
+    const current: CanvasSnapshot = {
+      nodes: nodesRef.current,
+      edges: edgesRef.current,
+    };
+    const last = historyRef.current[historyIndexRef.current];
+    if (
+      last &&
+      current.nodes === last.nodes &&
+      current.edges === last.edges
+    ) {
+      return;
+    }
+    pushSnapshot(current);
+  }, [pushSnapshot]);
+
+  const applySnapshot = useCallback((snap: CanvasSnapshot) => {
+    nodesRef.current = snap.nodes;
+    edgesRef.current = snap.edges;
+    setNodes(snap.nodes);
+    setEdges(snap.edges);
+  }, []);
+
   const undo = useCallback(() => {
     if (historyIndexRef.current <= 0) return;
     historyIndexRef.current--;
-    const snapshot = historyRef.current[historyIndexRef.current];
-    setNodes(snapshot);
-    nodesRef.current = snapshot;
+    applySnapshot(historyRef.current[historyIndexRef.current]);
     scheduleSave();
-  }, [scheduleSave]);
+  }, [applySnapshot, scheduleSave]);
 
   const redo = useCallback(() => {
     if (historyIndexRef.current >= historyRef.current.length - 1) return;
     historyIndexRef.current++;
-    const snapshot = historyRef.current[historyIndexRef.current];
-    setNodes(snapshot);
-    nodesRef.current = snapshot;
+    applySnapshot(historyRef.current[historyIndexRef.current]);
     scheduleSave();
-  }, [scheduleSave]);
+  }, [applySnapshot, scheduleSave]);
 
-  return { nodes, setNodes, nodesRef, historyRef, historyIndexRef, applyNodes, commitHistory, undo, redo };
+  return {
+    nodes,
+    edges,
+    setNodes,
+    setEdges,
+    nodesRef,
+    edgesRef,
+    historyRef,
+    historyIndexRef,
+    applyNodes,
+    applyEdges,
+    applyState,
+    commitHistory,
+    undo,
+    redo,
+  };
 };

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
@@ -1,6 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { CanvasNode, CanvasTransform, CanvasSaveData, FrameNodeData, FileNodeData, TextNodeData } from '../types';
-import { genId, createDefaultNode, createNodeData } from '../utils/nodeFactory';
+import type {
+  CanvasEdge,
+  CanvasNode,
+  CanvasSaveData,
+  CanvasTransform,
+  FileNodeData,
+  FrameNodeData,
+  TextNodeData,
+} from '../types';
+import { createDefaultNode, createNodeData, genId } from '../utils/nodeFactory';
+import { degradeEndpointsForDeletedNode } from '../utils/edgeFactory';
 import { useNodeHistory } from './useNodeHistory';
 
 const SAVE_DEBOUNCE_MS = 800;
@@ -46,12 +55,16 @@ export const useNodes = (
       return;
     }
     const snapshot = nodesRef.current;
+    const edgeSnapshot = edgesRef.current;
     const payload: CanvasSaveData = {
       nodes: snapshot,
+      edges: edgeSnapshot,
       transform: transformRef.current,
       savedAt: new Date().toISOString(),
     };
-    console.debug(`[canvas] saving ${canvasId}: ${payload.nodes.length} nodes`);
+    console.debug(
+      `[canvas] saving ${canvasId}: ${payload.nodes.length} nodes, ${edgeSnapshot.length} edges`,
+    );
     void api.save(canvasId, payload).then((res) => {
       if (!res.ok) {
         console.warn('[canvas] save failed:', res.error);
@@ -83,8 +96,9 @@ export const useNodes = (
   const [loaded, setLoaded] = useState(false);
 
   const {
-    nodes, setNodes, nodesRef, historyRef, historyIndexRef,
-    applyNodes, commitHistory, undo, redo,
+    nodes, edges, setNodes, setEdges, nodesRef, edgesRef,
+    historyRef, historyIndexRef,
+    applyNodes, applyEdges, applyState, commitHistory, undo, redo,
   } = useNodeHistory(scheduleSave);
 
   const setTransformForSave = useCallback(
@@ -172,6 +186,15 @@ export const useNodes = (
       nodesRef.current = nextNodes;
       setNodes(nextNodes);
 
+      // Edges for Step 1: treat disk as authoritative. CLI-side edge mutations
+      // are rare compared to node changes, and the external-update event
+      // currently carries no edge-level granularity. Replacing wholesale
+      // keeps us in sync for the common cases (CLI added/removed an edge,
+      // or a bound node was deleted elsewhere and edges were degraded).
+      const diskEdges = Array.isArray(result.data.edges) ? result.data.edges : [];
+      edgesRef.current = diskEdges;
+      setEdges(diskEdges);
+
       // Mark the affected nodes as externally-edited for 2.5s so the Canvas
       // component can render a transient highlight.
       setExternallyEditedIds((prev) => {
@@ -238,9 +261,11 @@ export const useNodes = (
     const api = window.canvasWorkspace?.store;
     if (!api) {
       const empty: CanvasNode[] = [];
-      historyRef.current = [empty];
+      const emptyEdges: CanvasEdge[] = [];
+      historyRef.current = [{ nodes: empty, edges: emptyEdges }];
       historyIndexRef.current = 0;
       setNodes(empty);
+      setEdges(emptyEdges);
       loadedRef.current = true;
       setLoaded(true);
       return;
@@ -249,24 +274,23 @@ export const useNodes = (
     void api.load(canvasId).then((result) => {
       if (result.ok && result.data) {
         const saved = result.data;
-        if (Array.isArray(saved.nodes)) {
-          setNodes(saved.nodes);
-          nodesRef.current = saved.nodes;
-          historyRef.current = [saved.nodes];
-          historyIndexRef.current = 0;
-          // Every node we loaded is on disk — seed the persisted set so
-          // the external-update handler can tell future deletes apart
-          // from locally-added unsaved nodes.
-          for (const n of saved.nodes) persistedIdsRef.current.add(n.id);
-        } else {
-          historyRef.current = [[]];
-          historyIndexRef.current = 0;
-        }
+        const loadedNodes = Array.isArray(saved.nodes) ? saved.nodes : [];
+        const loadedEdges = Array.isArray(saved.edges) ? saved.edges : [];
+        setNodes(loadedNodes);
+        setEdges(loadedEdges);
+        nodesRef.current = loadedNodes;
+        edgesRef.current = loadedEdges;
+        historyRef.current = [{ nodes: loadedNodes, edges: loadedEdges }];
+        historyIndexRef.current = 0;
+        // Every node we loaded is on disk — seed the persisted set so
+        // the external-update handler can tell future deletes apart
+        // from locally-added unsaved nodes.
+        for (const n of loadedNodes) persistedIdsRef.current.add(n.id);
         if (saved.transform && onRestoreTransformRef.current) {
           onRestoreTransformRef.current(saved.transform);
         }
       } else {
-        historyRef.current = [[]];
+        historyRef.current = [{ nodes: [], edges: [] }];
         historyIndexRef.current = 0;
       }
       loadedRef.current = true;
@@ -318,17 +342,34 @@ export const useNodes = (
 
   const removeNode = useCallback(
     (id: string) => {
-      applyNodes(nodesRef.current.filter((n) => n.id !== id));
+      const victim = nodesRef.current.find((n) => n.id === id);
+      const nextNodes = nodesRef.current.filter((n) => n.id !== id);
+      // Any edges bound to the deleted node get their endpoints degraded
+      // to free points at the node's last-known anchor — preserving the
+      // user's drawn connections instead of silently deleting them. This
+      // is one atomic history step so undo reverses both the node delete
+      // and the endpoint degradation together.
+      const nextEdges = victim
+        ? degradeEndpointsForDeletedNode(edgesRef.current, victim)
+        : edgesRef.current;
+      applyState({ nodes: nextNodes, edges: nextEdges });
     },
-    [applyNodes, nodesRef]
+    [applyState, edgesRef, nodesRef]
   );
 
   const removeNodes = useCallback(
     (ids: string[]) => {
       if (ids.length === 0) return;
-      applyNodes(nodesRef.current.filter((n) => !ids.includes(n.id)));
+      const idSet = new Set(ids);
+      const victims = nodesRef.current.filter((n) => idSet.has(n.id));
+      const nextNodes = nodesRef.current.filter((n) => !idSet.has(n.id));
+      let nextEdges = edgesRef.current;
+      for (const victim of victims) {
+        nextEdges = degradeEndpointsForDeletedNode(nextEdges, victim);
+      }
+      applyState({ nodes: nextNodes, edges: nextEdges });
     },
-    [applyNodes, nodesRef]
+    [applyState, edgesRef, nodesRef]
   );
 
   const moveNode = useCallback(
@@ -453,8 +494,45 @@ export const useNodes = (
     [applyNodes, scheduleSave, canvasId, setNodes, nodesRef]
   );
 
+  const addEdge = useCallback(
+    (edge: CanvasEdge) => {
+      applyEdges([...edgesRef.current, edge]);
+      return edge;
+    },
+    [applyEdges, edgesRef],
+  );
+
+  const updateEdge = useCallback(
+    (id: string, patch: Partial<CanvasEdge>, addToHistory = true) => {
+      applyEdges(
+        edgesRef.current.map((e) =>
+          e.id === id ? { ...e, ...patch, updatedAt: Date.now() } : e,
+        ),
+        addToHistory,
+      );
+    },
+    [applyEdges, edgesRef],
+  );
+
+  const removeEdge = useCallback(
+    (id: string) => {
+      applyEdges(edgesRef.current.filter((e) => e.id !== id));
+    },
+    [applyEdges, edgesRef],
+  );
+
+  const removeEdges = useCallback(
+    (ids: string[]) => {
+      if (ids.length === 0) return;
+      const idSet = new Set(ids);
+      applyEdges(edgesRef.current.filter((e) => !idSet.has(e.id)));
+    },
+    [applyEdges, edgesRef],
+  );
+
   return {
     nodes,
+    edges,
     loaded,
     externallyEditedIds,
     addNode,
@@ -464,6 +542,10 @@ export const useNodes = (
     moveNode,
     moveNodes,
     resizeNode,
+    addEdge,
+    updateEdge,
+    removeEdge,
+    removeEdges,
     setTransformForSave,
     flushSave,
     commitHistory,

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -91,8 +91,70 @@ export interface CanvasTransform {
   scale: number;
 }
 
+/**
+ * One end of a `CanvasEdge`.
+ *
+ * `node`  → the endpoint tracks a node's anchor; the actual screen position
+ *           is computed each render from the node's x/y/width/height.
+ * `point` → the endpoint is a free canvas coordinate (no node binding).
+ *           Used when the user drags an endpoint into empty space, or when
+ *           a bound node is deleted and we degrade instead of cascade-delete.
+ */
+export type EdgeAnchor = 'top' | 'right' | 'bottom' | 'left' | 'auto';
+
+export type EdgeEndpoint =
+  | { kind: 'node'; nodeId: string; anchor?: EdgeAnchor }
+  | { kind: 'point'; x: number; y: number };
+
+export type EdgeArrowCap = 'none' | 'triangle' | 'arrow' | 'dot' | 'bar';
+
+export interface EdgeStroke {
+  color?: string;
+  width?: number;
+  style?: 'solid' | 'dashed' | 'dotted';
+}
+
+/**
+ * A connection drawn between two endpoints on the canvas.
+ *
+ * Edges are tldraw-style: they are first-class shapes, not pure
+ * "relations between nodes". Either endpoint can be free
+ * (`{ kind: 'point', x, y }`) so users can draw arrows into empty
+ * space; when a bound node is deleted, the renderer degrades the
+ * affected endpoint to a free point rather than removing the edge.
+ *
+ * `bend` is a single signed scalar: 0 = straight, +N = pixels of
+ * perpendicular offset from the source→target midpoint (toward the
+ * normal's positive direction), -N = the other side. This keeps the
+ * geometry representable as a single-control quadratic Bezier and
+ * matches tldraw's arrow storage.
+ *
+ * `payload` is a free-form dictionary keyed by the edge's `kind` —
+ * e.g. `kind: 'context'` edges can stash prompt-injection hints for
+ * the canvas agent, `kind: 'data'` edges a transformer config, etc.
+ * Everything stored must be JSON-safe; it round-trips through
+ * canvas-store as-is.
+ */
+export interface CanvasEdge {
+  id: string;
+  source: EdgeEndpoint;
+  target: EdgeEndpoint;
+  bend?: number;
+  arrowHead?: EdgeArrowCap;
+  arrowTail?: EdgeArrowCap;
+  stroke?: EdgeStroke;
+  label?: string;
+  kind?: string;
+  payload?: Record<string, unknown>;
+  /** Epoch millis of last mutation; used for cross-process merge. */
+  updatedAt?: number;
+}
+
 export interface CanvasSaveData {
   nodes: CanvasNode[];
+  /** Connections between nodes. Optional for backwards compatibility with
+   *  older canvas.json files that pre-date connections. */
+  edges?: CanvasEdge[];
   transform: CanvasTransform;
   savedAt: string;
 }

--- a/apps/canvas-workspace/src/renderer/src/utils/edgeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/edgeFactory.ts
@@ -1,0 +1,100 @@
+import type { CanvasEdge, CanvasNode, EdgeAnchor, EdgeEndpoint } from '../types';
+
+let edgeIdCounter = 0;
+export const genEdgeId = (): string => `edge-${Date.now()}-${++edgeIdCounter}`;
+
+/**
+ * Create a new edge with sensible defaults:
+ *  - no bend (straight line),
+ *  - triangular arrow head on target, nothing on source,
+ *  - thin solid black stroke.
+ *
+ * Visual defaults mirror tldraw's default arrow. The caller decides the
+ * endpoints, kind, label, etc.
+ */
+export const createDefaultEdge = (
+  source: EdgeEndpoint,
+  target: EdgeEndpoint,
+  overrides?: Partial<Omit<CanvasEdge, 'id' | 'source' | 'target'>>,
+): CanvasEdge => ({
+  id: genEdgeId(),
+  source,
+  target,
+  bend: 0,
+  arrowHead: 'triangle',
+  arrowTail: 'none',
+  stroke: { color: '#1f2328', width: 1.6, style: 'solid' },
+  updatedAt: Date.now(),
+  ...overrides,
+});
+
+/**
+ * Compute the point on a node's bounding box that corresponds to a given
+ * anchor side. `auto` resolves to the node's center — callers that want
+ * edge-hugging visuals should compute a side-specific anchor themselves
+ * (e.g. the side closest to the other endpoint) and pass it explicitly.
+ */
+export const nodeAnchorPoint = (
+  node: Pick<CanvasNode, 'x' | 'y' | 'width' | 'height'>,
+  anchor: EdgeAnchor = 'auto',
+): { x: number; y: number } => {
+  const cx = node.x + node.width / 2;
+  const cy = node.y + node.height / 2;
+  switch (anchor) {
+    case 'top':    return { x: cx, y: node.y };
+    case 'bottom': return { x: cx, y: node.y + node.height };
+    case 'left':   return { x: node.x, y: cy };
+    case 'right':  return { x: node.x + node.width, y: cy };
+    case 'auto':
+    default:       return { x: cx, y: cy };
+  }
+};
+
+/**
+ * Resolve an endpoint into absolute canvas coordinates. Node-bound
+ * endpoints whose target no longer exists fall back to (0, 0) — callers
+ * should filter or degrade such edges before rendering; this is only a
+ * safety net so a stale reference doesn't crash the renderer.
+ */
+export const resolveEndpoint = (
+  endpoint: EdgeEndpoint,
+  nodesById: Map<string, CanvasNode>,
+): { x: number; y: number } => {
+  if (endpoint.kind === 'point') {
+    return { x: endpoint.x, y: endpoint.y };
+  }
+  const node = nodesById.get(endpoint.nodeId);
+  if (!node) return { x: 0, y: 0 };
+  return nodeAnchorPoint(node, endpoint.anchor);
+};
+
+/**
+ * Turn every node-bound endpoint that points at `deletedNodeId` into a
+ * free point at the node's last-known anchor coordinate. Edges whose
+ * endpoints don't reference the deleted node are returned unchanged (by
+ * reference, so React bail-outs stay effective).
+ */
+export const degradeEndpointsForDeletedNode = (
+  edges: CanvasEdge[],
+  deletedNode: CanvasNode,
+): CanvasEdge[] => {
+  const deletedId = deletedNode.id;
+  const now = Date.now();
+  return edges.map((edge) => {
+    const touchesSource = edge.source.kind === 'node' && edge.source.nodeId === deletedId;
+    const touchesTarget = edge.target.kind === 'node' && edge.target.nodeId === deletedId;
+    if (!touchesSource && !touchesTarget) return edge;
+    const next: CanvasEdge = { ...edge, updatedAt: now };
+    if (touchesSource) {
+      const anchor = edge.source.kind === 'node' ? edge.source.anchor : 'auto';
+      const p = nodeAnchorPoint(deletedNode, anchor);
+      next.source = { kind: 'point', x: p.x, y: p.y };
+    }
+    if (touchesTarget) {
+      const anchor = edge.target.kind === 'node' ? edge.target.anchor : 'auto';
+      const p = nodeAnchorPoint(deletedNode, anchor);
+      next.target = { kind: 'point', x: p.x, y: p.y };
+    }
+    return next;
+  });
+};

--- a/apps/canvas-workspace/src/renderer/src/utils/edgeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/edgeFactory.ts
@@ -69,6 +69,112 @@ export const resolveEndpoint = (
 };
 
 /**
+ * For a node-bound endpoint with `anchor: 'auto'`, compute the point on
+ * the node's bounding box closest to `toward` along the straight line
+ * from center to `toward`. This makes edges visually terminate at the
+ * node's edge rather than piercing into its center — the same trick
+ * tldraw uses for arrow↔shape binding.
+ *
+ * For explicit anchors (top/right/bottom/left), we still return the
+ * anchor-side midpoint so the user's choice wins.
+ *
+ * For free-point endpoints we return the point unchanged.
+ */
+export const resolveEndpointToward = (
+  endpoint: EdgeEndpoint,
+  nodesById: Map<string, CanvasNode>,
+  toward: { x: number; y: number },
+): { x: number; y: number } => {
+  if (endpoint.kind === 'point') return { x: endpoint.x, y: endpoint.y };
+  const node = nodesById.get(endpoint.nodeId);
+  if (!node) return { x: 0, y: 0 };
+  if (endpoint.anchor && endpoint.anchor !== 'auto') {
+    return nodeAnchorPoint(node, endpoint.anchor);
+  }
+  const cx = node.x + node.width / 2;
+  const cy = node.y + node.height / 2;
+  const hw = node.width / 2;
+  const hh = node.height / 2;
+  const dx = toward.x - cx;
+  const dy = toward.y - cy;
+  if (dx === 0 && dy === 0) return { x: cx, y: cy };
+  const adx = Math.abs(dx);
+  const ady = Math.abs(dy);
+  const tx = adx > 0 ? hw / adx : Infinity;
+  const ty = ady > 0 ? hh / ady : Infinity;
+  const t = Math.min(tx, ty);
+  return { x: cx + dx * t, y: cy + dy * t };
+};
+
+/**
+ * Hit-test a canvas coordinate against the node list. Iterates in
+ * reverse so later-painted (i.e. visually on-top) nodes win. Frames
+ * render under non-frames (see Canvas sortedNodes), so a click inside
+ * a frame that also contains a node correctly returns the inner node.
+ *
+ * Returns null if no node covers the point.
+ */
+export const findNodeAtCanvasPoint = (
+  sortedNodes: CanvasNode[],
+  x: number,
+  y: number,
+): CanvasNode | null => {
+  for (let i = sortedNodes.length - 1; i >= 0; i--) {
+    const n = sortedNodes[i];
+    if (x >= n.x && x <= n.x + n.width && y >= n.y && y <= n.y + n.height) {
+      return n;
+    }
+  }
+  return null;
+};
+
+/**
+ * Signed perpendicular offset of `cursor` from the straight line s→t.
+ * Positive = right-hand side of s→t (matches `bendControlPoint`'s sign
+ * convention), negative = left.
+ *
+ * `bend` in CanvasEdge semantics equals this offset directly (it's the
+ * peak-offset of the rendered curve), so this is the exact value to
+ * write back while dragging the bend handle.
+ */
+export const bendFromCursor = (
+  s: { x: number; y: number },
+  t: { x: number; y: number },
+  cursor: { x: number; y: number },
+): number => {
+  const dx = t.x - s.x;
+  const dy = t.y - s.y;
+  const len = Math.hypot(dx, dy);
+  if (len === 0) return 0;
+  const mx = (s.x + t.x) / 2;
+  const my = (s.y + t.y) / 2;
+  const px = dy / len;
+  const py = -dx / len;
+  return (cursor.x - mx) * px + (cursor.y - my) * py;
+};
+
+/**
+ * Position of the bend handle in canvas coords — i.e. where the curve
+ * visually peaks. Since `bend` is itself the peak offset, the handle
+ * sits at midpoint + normal·bend.
+ */
+export const bendHandlePoint = (
+  s: { x: number; y: number },
+  t: { x: number; y: number },
+  bend: number,
+): { x: number; y: number } => {
+  const mx = (s.x + t.x) / 2;
+  const my = (s.y + t.y) / 2;
+  if (!bend) return { x: mx, y: my };
+  const dx = t.x - s.x;
+  const dy = t.y - s.y;
+  const len = Math.hypot(dx, dy) || 1;
+  const nx = dy / len;
+  const ny = -dx / len;
+  return { x: mx + nx * bend, y: my + ny * bend };
+};
+
+/**
  * Turn every node-bound endpoint that points at `deletedNodeId` into a
  * free point at the node's last-known anchor coordinate. Edges whose
  * endpoints don't reference the deleted node are returned unchanged (by

--- a/apps/canvas-workspace/src/renderer/src/utils/edgeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/edgeFactory.ts
@@ -7,7 +7,9 @@ export const genEdgeId = (): string => `edge-${Date.now()}-${++edgeIdCounter}`;
  * Create a new edge with sensible defaults:
  *  - no bend (straight line),
  *  - triangular arrow head on target, nothing on source,
- *  - thin solid black stroke.
+ *  - medium-weight solid black stroke (sits at the middle "M" tick of
+ *    EdgeStylePanel's width ladder, so freshly-drawn lines read clearly
+ *    on the canvas without jumping out).
  *
  * Visual defaults mirror tldraw's default arrow. The caller decides the
  * endpoints, kind, label, etc.
@@ -23,7 +25,7 @@ export const createDefaultEdge = (
   bend: 0,
   arrowHead: 'triangle',
   arrowTail: 'none',
-  stroke: { color: '#1f2328', width: 1.6, style: 'solid' },
+  stroke: { color: '#1f2328', width: 2.4, style: 'solid' },
   updatedAt: Date.now(),
   ...overrides,
 });

--- a/packages/canvas-cli/src/core/__tests__/store.test.ts
+++ b/packages/canvas-cli/src/core/__tests__/store.test.ts
@@ -14,6 +14,7 @@ import {
   ensureWorkspaceDir,
   commitNodeMutation,
   CanvasWipeRefusedError,
+  CanvasReadError,
 } from '../store';
 import type { CanvasNode, CanvasSaveData } from '../types';
 
@@ -59,6 +60,15 @@ describe('store', () => {
       await saveCanvas('ws-1', emptyCanvas, testDir);
       const loaded = await loadCanvas('ws-1', testDir);
       expect(loaded).toEqual(emptyCanvas);
+    });
+
+    it('throws CanvasReadError on unparseable canvas.json (partial write)', async () => {
+      // Simulate another writer caught mid-flush: truncated JSON.
+      await ensureWorkspaceDir('ws-partial', testDir);
+      const file = join(getWorkspaceDir('ws-partial', testDir), 'canvas.json');
+      await fs.writeFile(file, '{"nodes": [{"id": "n1", "type"', 'utf-8');
+
+      await expect(loadCanvas('ws-partial', testDir)).rejects.toBeInstanceOf(CanvasReadError);
     });
   });
 
@@ -166,6 +176,38 @@ describe('store', () => {
       await saveCanvas('ws-empty', emptyCanvas, testDir, { allowEmpty: true });
       await expect(
         saveCanvas('ws-empty', emptyCanvas, testDir),
+      ).resolves.toBeUndefined();
+    });
+
+    it('refuses empty write when disk canvas.json is unparseable', async () => {
+      // A writer dumping `{nodes: []}` while another writer is mid-flush
+      // should NOT be allowed to proceed — we can't tell whether the disk
+      // had data under that partial JSON. Regression test for the silent
+      // wipe bug caused by `saveCanvas` treating "unreadable" the same
+      // as "no data to protect".
+      await ensureWorkspaceDir('ws-corrupt', testDir);
+      const file = join(getWorkspaceDir('ws-corrupt', testDir), 'canvas.json');
+      await fs.writeFile(file, '{"nodes": [{"id": "half', 'utf-8');
+
+      await expect(
+        saveCanvas('ws-corrupt', emptyCanvas, testDir),
+      ).rejects.toBeInstanceOf(CanvasReadError);
+
+      // Disk must be untouched so the next read (once the mid-flush
+      // writer finishes) recovers the real data.
+      const raw = await fs.readFile(file, 'utf-8');
+      expect(raw).toBe('{"nodes": [{"id": "half');
+    });
+
+    it('allows { allowEmpty: true } even when disk is unparseable', async () => {
+      // Explicit opt-in (e.g. fresh-workspace bootstrap) should still be
+      // honored — the caller has said "I know this is intentional".
+      await ensureWorkspaceDir('ws-corrupt-ok', testDir);
+      const file = join(getWorkspaceDir('ws-corrupt-ok', testDir), 'canvas.json');
+      await fs.writeFile(file, 'not json at all', 'utf-8');
+
+      await expect(
+        saveCanvas('ws-corrupt-ok', emptyCanvas, testDir, { allowEmpty: true }),
       ).resolves.toBeUndefined();
     });
 

--- a/packages/canvas-cli/src/core/store.ts
+++ b/packages/canvas-cli/src/core/store.ts
@@ -60,15 +60,58 @@ export async function ensureWorkspaceDir(workspaceId: string, storeDir?: string)
   }
 }
 
+/**
+ * Thrown by `loadCanvas` when the canvas file exists on disk but is
+ * unreadable — typically because another writer caught it mid-flush and
+ * `JSON.parse` failed, or because of an I/O error.
+ *
+ * This is deliberately distinct from the null-return-on-ENOENT case so
+ * callers can tell "the canvas really doesn't exist" (safe to bootstrap)
+ * apart from "we couldn't read the canvas right now" (DO NOT bootstrap —
+ * that would silently wipe real user data).
+ */
+export class CanvasReadError extends Error {
+  readonly workspaceId: string;
+  readonly cause: unknown;
+  constructor(workspaceId: string, cause: unknown) {
+    super(
+      `[canvas-cli] failed to read canvas.json for workspace "${workspaceId}": ` +
+      `${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+    this.name = 'CanvasReadError';
+    this.workspaceId = workspaceId;
+    this.cause = cause;
+  }
+}
+
+function isEnoent(err: unknown): boolean {
+  return !!err && typeof err === 'object' && (err as { code?: string }).code === 'ENOENT';
+}
+
 export async function loadCanvas(workspaceId: string, storeDir?: string): Promise<CanvasSaveData | null> {
+  let raw: string;
   try {
-    const raw = await fs.readFile(canvasPath(workspaceId, storeDir), 'utf-8');
+    raw = await fs.readFile(canvasPath(workspaceId, storeDir), 'utf-8');
+  } catch (err) {
+    // File genuinely doesn't exist — legitimate "no canvas yet" signal.
+    if (isEnoent(err)) return null;
+    // Any other read error (EACCES, EBUSY, etc.) is a transient failure.
+    // Surface it so callers don't confuse it with "no canvas" and bootstrap
+    // an empty one on top of real data.
+    throw new CanvasReadError(workspaceId, err);
+  }
+
+  try {
     const parsed = JSON.parse(raw) as CanvasSaveData;
     // Normalize: ensure nodes is always an array
     parsed.nodes = parsed.nodes ?? [];
     return parsed;
-  } catch {
-    return null;
+  } catch (err) {
+    // Parse failure almost always means we caught another writer mid-flush.
+    // Returning null here would let `createNode`'s bootstrap overwrite real
+    // on-disk data with `{ nodes: [] }` via `{ allowEmpty: true }` — the
+    // exact wipe-data-without-warning bug we're defending against.
+    throw new CanvasReadError(workspaceId, err);
   }
 }
 
@@ -119,17 +162,31 @@ export async function saveCanvas(
   // `apps/canvas-workspace/src/main/canvas-store.ts` so every write path
   // into `canvas.json` has the same protection.
   if (!opts.allowEmpty && Array.isArray(data.nodes) && data.nodes.length === 0) {
+    let raw: string | null = null;
     try {
-      const raw = await fs.readFile(canvasPath(workspaceId, storeDir), 'utf-8');
-      const existing = JSON.parse(raw) as CanvasSaveData;
-      const existingNodes = Array.isArray(existing.nodes) ? existing.nodes : [];
+      raw = await fs.readFile(canvasPath(workspaceId, storeDir), 'utf-8');
+    } catch (err) {
+      if (!isEnoent(err)) {
+        // Can't verify what's on disk — refuse rather than risk wiping
+        // a populated canvas we just happened to fail to read.
+        throw new CanvasReadError(workspaceId, err);
+      }
+      // ENOENT → nothing on disk, fall through and write.
+    }
+    if (raw !== null) {
+      let existingNodes: CanvasNode[];
+      try {
+        const existing = JSON.parse(raw) as CanvasSaveData;
+        existingNodes = Array.isArray(existing.nodes) ? existing.nodes : [];
+      } catch (err) {
+        // Parse failure mid-flight: if we assume "nothing to protect" and
+        // write `{nodes: []}` we'd be committing the exact data-loss bug
+        // this guard exists to prevent. Refuse.
+        throw new CanvasReadError(workspaceId, err);
+      }
       if (existingNodes.length > 0) {
         throw new CanvasWipeRefusedError(workspaceId, existingNodes.length);
       }
-    } catch (err) {
-      if (err instanceof CanvasWipeRefusedError) throw err;
-      // File missing, unreadable, or unparseable — nothing on disk to
-      // protect, fall through and write.
     }
   }
 

--- a/packages/canvas-cli/src/core/types.ts
+++ b/packages/canvas-cli/src/core/types.ts
@@ -38,8 +38,46 @@ export interface CanvasTransform {
   scale: number;
 }
 
+// ─── Edges (connections between / around nodes) ─────────────────────
+//
+// Edges live at the workspace level alongside nodes. They are
+// optional in `CanvasSaveData` for backwards compatibility with
+// canvas.json files written before the edge feature shipped.
+
+export type EdgeAnchor = 'top' | 'right' | 'bottom' | 'left' | 'auto';
+
+export type EdgeEndpoint =
+  | { kind: 'node'; nodeId: string; anchor?: EdgeAnchor }
+  | { kind: 'point'; x: number; y: number };
+
+export type EdgeArrowCap = 'none' | 'triangle' | 'arrow' | 'dot' | 'bar';
+
+export interface EdgeStroke {
+  color?: string;
+  width?: number;
+  style?: 'solid' | 'dashed' | 'dotted';
+}
+
+export interface CanvasEdge {
+  id: string;
+  source: EdgeEndpoint;
+  target: EdgeEndpoint;
+  /** Peak perpendicular offset of the rendered curve. 0 = straight line. */
+  bend?: number;
+  arrowHead?: EdgeArrowCap;
+  arrowTail?: EdgeArrowCap;
+  stroke?: EdgeStroke;
+  label?: string;
+  /** Optional semantic tag for downstream consumers (agent, layout, etc). */
+  kind?: string;
+  /** Free-form extension slot mirroring `CanvasNodeData`. */
+  payload?: Record<string, unknown>;
+  updatedAt?: number;
+}
+
 export interface CanvasSaveData {
   nodes: CanvasNode[];
+  edges?: CanvasEdge[];
   transform: CanvasTransform;
   savedAt: string;
 }


### PR DESCRIPTION
## Summary

This PR adds first-class edge (connection/arrow) support to the canvas, allowing users to draw and edit connections between nodes or free points. Edges are now persistent, interactive, and fully integrated with the undo/redo system.

## Key Changes

### Core Edge Types & Data Model
- Added `EdgeEndpoint`, `EdgeAnchor`, `EdgeArrowCap`, and `EdgeStroke` types to represent edge endpoints, anchor points, arrow styles, and stroke properties
- Edges are stored alongside nodes in `CanvasSaveData` and share the same history/undo stack
- Endpoints can be either node-bound (with auto or explicit anchor) or free points in canvas space

### Rendering & Interaction Layer
- **CanvasEdgesLayer**: New SVG-based component that renders all edges with:
  - Quadratic Bézier curves with bend support
  - Customizable arrow heads/tails (triangle, arrow, dot, bar, none)
  - Stroke styling (color, width, solid/dashed/dotted)
  - Hit-proxy strokes for easy clicking on thin lines
  - Selection highlighting and interactive handles
  - SVG marker definitions for arrow caps

- **EdgeStylePanel**: Floating panel for editing selected edge properties:
  - Color picker (7-color palette)
  - Stroke width selector (S/M/L)
  - Dash style toggle (solid/dashed/dotted)
  - Arrow head/tail picker with visual previews
  - Delete button

### Edge Interaction Hook
- **useEdgeInteraction**: Coordinates three live interaction modes:
  - **Connect mode**: Draw new edges by dragging from a node/point to another
  - **Move-end**: Drag an edge's source or target endpoint to a new location
  - **Move-bend**: Drag the bend handle to adjust curve shape
- Handles node hit-testing, endpoint resolution, and live preview rendering
- Integrates with canvas pan/zoom and respects node stacking order

### Utility Functions
- **edgeFactory.ts**: Helper functions for:
  - Resolving endpoints to canvas coordinates with auto-anchor edge-hugging
  - Computing bend control points for quadratic curves
  - Hit-testing nodes at canvas points
  - Degrading edges when bound nodes are deleted (converts to free points)

### Agent Tools
- **canvas_list_edges**: List all edges with resolved endpoint descriptions
- **canvas_create_edge**: Create new edges with flexible endpoint specification (node-bound or free points), customizable styling, labels, and semantic metadata

### History & State Management
- Extended `useNodeHistory` to track both nodes and edges in a unified `CanvasSnapshot`
- Single undo/redo stack for atomic operations (e.g., "create node + connect edge")
- Live mutations during drag are history-silent; committed on mouse-up

### UI Integration
- Added "Connect" tool to the floating toolbar
- Edge selection prevents canvas blank-click deselection
- Keyboard shortcuts: Delete/Backspace removes selected edge, Esc deselects
- Edge style panel positioned above edge midpoint, tracks with pan/zoom

## Notable Implementation Details

- **Endpoint resolution**: Node-bound endpoints with `anchor: 'auto'` compute the closest bbox point toward the opposite endpoint, creating edge-hugging visuals similar to tldraw
- **Bend math**: Quadratic Bézier curves use a control point at 2× the bend offset (since t=0.5 midpoint is (M + P1)/2)
- **Hit-testing**: Walks sorted nodes in reverse so visually-topmost node wins; frames render under non-frames
- **Live preview**: During drag, endpoint mutations are pushed to store without history; single history commit on mouseup
- **Marker deduplication**: SVG arrow markers are cached by (cap, color) pair to avoid redundant definitions
- **Graceful degradation**: Stale node references fall back to (0, 0); deleted nodes degrade bound edges to free points rather than cascade-deleting

https://claude.ai/code/session_015yQic3A3RSrDzzas6f1zTv