### PR TITLE
Change default font to monospace

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.css
@@ -334,7 +334,7 @@
   font-weight: 700;
   line-height: 1;
   color: rgba(0, 0, 0, 0.55);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  font-family: var(--font);
   pointer-events: none;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.css
@@ -6,7 +6,7 @@
   height: 100%;
   display: flex;
   background: #fff;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family: var(--font);
   overflow: hidden;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
@@ -8,7 +8,7 @@
   flex-direction: column;
   background: #fff;
   border-left: 1px solid rgba(0, 0, 0, 0.06);
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family: var(--font);
   position: relative;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -30,7 +30,7 @@
   --radius: 8px;
   --radius-lg: 10px;
   --radius-sm: 6px;
-  --font: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
+  --font: "SF Mono", "Fira Code", "Cascadia Code", Menlo, monospace;
   --font-mono: "SF Mono", "Fira Code", "Cascadia Code", Menlo, monospace;
   --sidebar-width: 240px;
   --sidebar-collapsed: 48px;


### PR DESCRIPTION
## Summary
This PR updates the default font variable used throughout the application from a system sans-serif stack to a monospace font stack.

## Key Changes
- Updated `--font` CSS variable in `styles.css` from a system sans-serif font stack (`-apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif`) to a monospace stack (`"SF Mono", "Fira Code", "Cascadia Code", Menlo, monospace`)
- Replaced hardcoded font-family declarations in three component stylesheets with the `var(--font)` CSS variable:
  - `TextNodeBody/index.css`: Updated `.text-node-body-label` class
  - `ChatPage.css`: Updated `.chat-page` class
  - `ChatPanel.css`: Updated `.chat-panel` class

## Implementation Details
This change consolidates font management by:
1. Centralizing the font definition in the CSS variables (styles.css)
2. Removing duplicate hardcoded font declarations across components
3. Ensuring consistent monospace font rendering throughout the application
4. Making future font changes easier to maintain in a single location

https://claude.ai/code/session_01C5qaJPqs9uuk2L99cnnpsC