### PR TITLE
refactor(tools): defer low-frequency tools to reduce system prompt size

### DIFF
--- a/apps/remote-server/src/core/tools/analyze-image.ts
+++ b/apps/remote-server/src/core/tools/analyze-image.ts
@@ -63,6 +63,7 @@ type ImageInlinePart = {
 export const analyzeImageTool: Tool<AnalyzeImageInput, AnalyzeImageResult> = {
   name: 'analyze_image',
   description: 'Analyze one or more local images with Gemini. If imagePaths are omitted, automatically uses runContext.latestAttachments from the latest image message.',
+  defer_loading: true,
   inputSchema: toolSchema,
   execute: async (input: AnalyzeImageInput, context?: AnalyzeImageToolContext): Promise<AnalyzeImageResult> => {
     const apiKey = process.env.GEMINI_API_KEY?.trim();

--- a/apps/remote-server/src/core/tools/ptc-demo.ts
+++ b/apps/remote-server/src/core/tools/ptc-demo.ts
@@ -33,12 +33,14 @@ function buildDemoTool(
   description: string,
   note: string,
   allowedCallers?: string[],
+  deferLoading?: boolean,
 ): Tool<DemoInput, DemoResult> {
   return {
     name,
     description,
     inputSchema: toolSchema,
     allowed_callers: allowedCallers,
+    ...(deferLoading ? { defer_loading: true } : {}),
     execute: async (input, context) => {
       const callerSelectors = resolveSelectors(context);
       const caller = typeof context?.runContext?.caller === 'string' ? context.runContext.caller : undefined;
@@ -61,6 +63,8 @@ export const ptcDemoCallerProbeTool = buildDemoTool(
   'ptc_demo_caller_probe',
   'Inspect caller selectors in runContext for PTC demo.',
   'Unrestricted tool. Always callable if exposed by normal tool registration.',
+  undefined,
+  true,
 );
 
 export const ptcDemoCallerOnlyTool = buildDemoTool(

--- a/apps/remote-server/src/core/tools/session-summary.ts
+++ b/apps/remote-server/src/core/tools/session-summary.ts
@@ -53,6 +53,7 @@ const DEFAULT_MAX_MESSAGES = 200;
 export const sessionSummaryTool: Tool<ToolInput, ToolResult> = {
   name: 'session_summary',
   description: 'Summarize recent sessions for the current user by reading stored session messages.',
+  defer_loading: true,
   inputSchema: toolSchema,
   execute: async (input, context) => {
     const runContext = context?.runContext || {};

--- a/packages/engine/src/built-in/role-soul-plugin/index.ts
+++ b/packages/engine/src/built-in/role-soul-plugin/index.ts
@@ -634,6 +634,7 @@ function buildSoulListTool(service: BuiltInSoulService): Tool {
   return {
     name: 'soul_list',
     description: 'List available souls.',
+    defer_loading: true,
     inputSchema: SOUL_LIST_INPUT_SCHEMA,
     execute: async (input) => {
       const format = input.format ?? 'summary';
@@ -649,6 +650,7 @@ function buildSoulStatusTool(service: BuiltInSoulService): Tool {
   return {
     name: 'soul_status',
     description: 'Get soul state for the current session.',
+    defer_loading: true,
     inputSchema: SOUL_STATUS_INPUT_SCHEMA,
     execute: async (input, context) => {
       const sessionId = resolveSessionId(input, context?.runContext);
@@ -669,6 +671,7 @@ function buildSoulUseTool(service: BuiltInSoulService): Tool {
   return {
     name: 'soul_use',
     description: 'Replace active souls with the specified soul.',
+    defer_loading: true,
     inputSchema: SOUL_USE_INPUT_SCHEMA,
     execute: async (input, context) => {
       const sessionId = resolveSessionId(input, context?.runContext);
@@ -685,6 +688,7 @@ function buildSoulAddTool(service: BuiltInSoulService): Tool {
   return {
     name: 'soul_add',
     description: 'Add a soul to the active list for the current session.',
+    defer_loading: true,
     inputSchema: SOUL_ADD_INPUT_SCHEMA,
     execute: async (input, context) => {
       const sessionId = resolveSessionId(input, context?.runContext);
@@ -701,6 +705,7 @@ function buildSoulRemoveTool(service: BuiltInSoulService): Tool {
   return {
     name: 'soul_remove',
     description: 'Remove a soul from the active list for the current session.',
+    defer_loading: true,
     inputSchema: SOUL_REMOVE_INPUT_SCHEMA,
     execute: async (input, context) => {
       const sessionId = resolveSessionId(input, context?.runContext);
@@ -717,6 +722,7 @@ function buildSoulClearTool(service: BuiltInSoulService): Tool {
   return {
     name: 'soul_clear',
     description: 'Clear soul state for the current session.',
+    defer_loading: true,
     inputSchema: SOUL_CLEAR_INPUT_SCHEMA,
     execute: async (input, context) => {
       const sessionId = resolveSessionId(input, context?.runContext);
@@ -733,6 +739,7 @@ function buildSoulRegisterTool(service: BuiltInSoulService): Tool {
   return {
     name: 'soul_register',
     description: 'Register or replace a soul definition. Persists to ~/.pulse-coder/souls/<id>/SOUL.md when enabled.',
+    defer_loading: true,
     inputSchema: SOUL_REGISTER_INPUT_SCHEMA,
     execute: async (input) => {
       const soul = await service.registerSoul({

--- a/packages/memory-plugin/src/integration.ts
+++ b/packages/memory-plugin/src/integration.ts
@@ -640,6 +640,7 @@ function buildMemoryGetDailyLogByDayTool(
   return {
     name: 'memory_get_daily_log_by_day',
     description: 'Get daily-log memory items for a specific day (YYYY-MM-DD) in current session.',
+    defer_loading: true,
     inputSchema: MEMORY_GET_DAILY_LOG_BY_DAY_INPUT_SCHEMA,
     execute: async ({ dayKey, limit, types }) => {
       const runContext = requireRunContext(getRunContext);
@@ -667,6 +668,7 @@ function buildMemoryRecordTool(
   return {
     name: 'memory_record',
     description: 'Persist an important preference/rule/fix/profile/soul into memory when explicitly useful.',
+    defer_loading: true,
     inputSchema: MEMORY_RECORD_INPUT_SCHEMA,
     execute: async ({ content, kind }) => {
       const runContext = requireRunContext(getRunContext);

--- a/packages/plugin-kit/src/devtools/index.ts
+++ b/packages/plugin-kit/src/devtools/index.ts
@@ -726,6 +726,7 @@ function createRunGetTool(store: DevtoolsStore, name: string): Tool {
   return {
     name,
     description: 'Fetch devtools run details by runId for diagnostics.',
+    defer_loading: true,
     inputSchema: schema,
     execute: async (input: { runId: string; includeUserText?: boolean }) => {
       const run = await store.getRun(input.runId);


### PR DESCRIPTION
Mark 13 low-frequency tools as `defer_loading: true` to reduce system prompt token cost.

**Deferred tools:**
- `analyze_image` — image analysis, only needed on demand
- `session_summary` — typically invoked by cron/skill, not user directly
- `devtools_run_get` — diagnostic tool, rarely needed
- `ptc_demo_caller_probe` — demo/test tool
- `soul_list / soul_status / soul_use / soul_add / soul_remove / soul_clear / soul_register` (all 7)
- `memory_get_daily_log_by_day` — low-frequency date lookup
- `memory_record` — write path, triggered only on explicit save

**Not deferred (kept immediate):**
- `memory_recall` — still immediate, used on most turns for context injection

**Also:** refactor `buildDemoTool()` in `ptc-demo.ts` to accept optional `deferLoading` parameter instead of using `Object.assign`.