### PR TITLE
Add marquee (drag-select) gesture support to canvas

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
@@ -4,6 +4,7 @@ import { CanvasNodeView } from '../CanvasNodeView';
 import { CanvasEdgesLayer } from '../CanvasEdgesLayer';
 import type { ResizeEdge } from '../../hooks/useNodeResize';
 import type { EdgeInteractionState, Point } from '../../hooks/useEdgeInteraction';
+import type { MarqueeRect } from '../../hooks/useMarqueeSelect';
 
 interface CanvasSurfaceProps {
   transform: { x: number; y: number; scale: number };
@@ -36,6 +37,10 @@ interface CanvasSurfaceProps {
   /** Preview endpoints resolved by the interaction hook. Null when no
    *  connect/move-end drag is in flight. */
   edgePreviewEndpoints: { s: Point; t: Point } | null;
+  /** Live drag-select rectangle in canvas-space coords. Null when no marquee
+   *  is in flight. Rendered inside the transform layer so it stays aligned
+   *  with the underlying nodes under pan/zoom. */
+  marqueeRect: MarqueeRect | null;
   onDragStart: (e: React.MouseEvent, node: CanvasNode) => void;
   onResizeStart: (
     e: React.MouseEvent,
@@ -83,6 +88,7 @@ export const CanvasSurface = ({
   externallyEditedIds,
   edgeInteractionState,
   edgePreviewEndpoints,
+  marqueeRect,
   onDragStart,
   onResizeStart,
   onUpdate,
@@ -139,5 +145,20 @@ export const CanvasSurface = ({
         onFocus={onFocus}
       />
     ))}
+    {marqueeRect && (
+      // Rendered in canvas space so the rectangle tracks the content under
+      // pan/zoom. Border width is divided by the current scale so the outline
+      // reads as a constant ~1px regardless of zoom level. `pointer-events:
+      // none` keeps the rectangle from intercepting the ongoing drag.
+      <div
+        className="canvas-marquee"
+        style={{
+          left: marqueeRect.x,
+          top: marqueeRect.y,
+          width: marqueeRect.width,
+          height: marqueeRect.height,
+        }}
+      />
+    )}
   </div>
 );

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.css
@@ -43,3 +43,17 @@
 .canvas-transform--moving {
   will-change: transform;
 }
+
+/* Drag-select (marquee) rectangle. Positioned in canvas-space so it moves
+ * with pan/zoom alongside the nodes it's hit-testing. The border and radius
+ * are divided by --canvas-scale so the outline stays a roughly constant
+ * visual thickness regardless of zoom level. pointer-events: none keeps
+ * the rectangle from intercepting the drag that's drawing it. */
+.canvas-marquee {
+  position: absolute;
+  pointer-events: none;
+  background: color-mix(in srgb, var(--accent-border, #3b82f6) 12%, transparent);
+  border: calc(1px / var(--canvas-scale, 1)) solid var(--accent-border, #3b82f6);
+  border-radius: calc(2px / var(--canvas-scale, 1));
+  z-index: 2;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -8,6 +8,7 @@ import { useCanvasContext } from '../../hooks/useCanvasContext';
 import { useCanvasFit } from '../../hooks/useCanvasFit';
 import { useCanvasKeyboard } from '../../hooks/useCanvasKeyboard';
 import { useEdgeInteraction } from '../../hooks/useEdgeInteraction';
+import { useMarqueeSelect } from '../../hooks/useMarqueeSelect';
 import type { CanvasNode } from '../../types';
 import { computeFrameDepths } from '../../utils/frameHierarchy';
 import { CanvasSurface } from './CanvasSurface';
@@ -206,6 +207,25 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
     },
   });
 
+  const {
+    rect: marqueeRect,
+    begin: marqueeBegin,
+    move: marqueeMove,
+    end: marqueeEnd,
+  } = useMarqueeSelect({
+    nodes,
+    screenToCanvas,
+    getContainer,
+    setSelectedNodeIds,
+    setSelectedEdgeId,
+  });
+
+  /** True for exactly one onClick fire after a marquee commits, so the
+   *  `handleCanvasClick` deselect fallback doesn't wipe the fresh selection.
+   *  Some browsers still synthesize a click after a drag that starts+ends on
+   *  the same element, so we can't rely on the click simply not firing. */
+  const justMarqueedRef = useRef(false);
+
   const handleEdgeHandleMouseDown = useCallback(
     (
       edgeId: string,
@@ -330,6 +350,12 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
   const handleCanvasClick = useCallback(
     (e: React.MouseEvent) => {
       if (contextMenu) setContextMenu(null);
+      // A marquee just ran — swallow the trailing click so its fresh
+      // selection survives the blank-canvas deselect fallback below.
+      if (justMarqueedRef.current) {
+        justMarqueedRef.current = false;
+        return;
+      }
       const target = e.target as HTMLElement;
       if (target.closest('.canvas-node')) return;
       // Clicking inside the edges SVG (either a hit-proxy or a handle)
@@ -347,21 +373,52 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
     [contextMenu]
   );
 
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      canvasMouseDown(e);
+      // `useCanvas` sets defaultPrevented on the synthetic event when it
+      // takes over for pan (middle click, alt+left, or hand tool). Don't
+      // start a marquee when panning — the two gestures share the left
+      // button in hand mode and the user clearly wants to pan.
+      if (e.defaultPrevented) return;
+      if (e.button !== 0 || e.altKey) return;
+      if (activeTool !== 'select') return;
+      // If edge tools are mid-drag (connect/move-end/move-bend/move-edge)
+      // the canvas mousedown won't even reach us because those drags are
+      // started by the overlay or handles, but belt-and-braces: skip.
+      if (edgeInteractionState) return;
+      // `isBlankCanvasTarget` already excludes node bodies, the connect
+      // overlay, edges, toolbars and menus — so mousedown here means the
+      // pointer is on the bare canvas (grid/transform/container). This is
+      // what lets us cleanly coexist with frame nodes: clicking a frame's
+      // body/header bubbles through `.canvas-node` and is rejected here,
+      // so frame drags (via `.node-header`) keep working unchanged.
+      if (!isBlankCanvasTarget(e.target)) return;
+      marqueeBegin(e, selectedNodeIds);
+    },
+    [canvasMouseDown, activeTool, edgeInteractionState, isBlankCanvasTarget, marqueeBegin, selectedNodeIds]
+  );
+
   const handleMouseMove = useCallback(
     (e: React.MouseEvent) => {
       canvasMouseMove(e);
       onDragMove(e);
       onResizeMove(e);
+      marqueeMove(e);
     },
-    [canvasMouseMove, onDragMove, onResizeMove]
+    [canvasMouseMove, onDragMove, onResizeMove, marqueeMove]
   );
 
   const handleMouseUp = useCallback(() => {
     canvasMouseUp();
     onDragEnd();
     onResizeEnd();
+    // `marqueeEnd()` returns true when a marquee was actually drawn, so we
+    // know to suppress the trailing onClick that would otherwise wipe the
+    // selection the marquee just committed via `marqueeMove`.
+    if (marqueeEnd()) justMarqueedRef.current = true;
     commitHistory();
-  }, [canvasMouseUp, onDragEnd, onResizeEnd, commitHistory]);
+  }, [canvasMouseUp, onDragEnd, onResizeEnd, marqueeEnd, commitHistory]);
 
   const cursorClass = activeTool === 'hand'
     ? ' canvas-container--hand'
@@ -383,7 +440,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
       className={`canvas-container${cursorClass}`}
       style={hidden ? { visibility: 'hidden', pointerEvents: 'none' } : undefined}
       onWheel={handleWheel}
-      onMouseDown={canvasMouseDown}
+      onMouseDown={handleMouseDown}
       onMouseMove={handleMouseMove}
       onMouseUp={handleMouseUp}
       onMouseLeave={handleMouseUp}
@@ -412,6 +469,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
         externallyEditedIds={externallyEditedIds}
         edgeInteractionState={edgeInteractionState}
         edgePreviewEndpoints={getPreviewEndpoints()}
+        marqueeRect={marqueeRect}
         onDragStart={onDragStart}
         onResizeStart={onResizeStart}
         onUpdate={updateNode}

--- a/apps/canvas-workspace/src/renderer/src/hooks/useMarqueeSelect.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useMarqueeSelect.ts
@@ -1,0 +1,184 @@
+import { useCallback, useRef, useState } from 'react';
+import type { CanvasNode } from '../types';
+
+/** Minimum screen-pixel distance the cursor must travel after mousedown before
+ *  we promote the gesture to a marquee. Below this threshold a drag collapses
+ *  back to a plain click so the existing canvas-click deselect path still
+ *  fires. Matches the "small accidental drag" tolerance used by tldraw. */
+const DRAG_THRESHOLD_PX = 3;
+
+/** Rectangle in canvas (transformed) coordinate space. `width`/`height` are
+ *  always non-negative; the start point may be any corner of the drag. */
+export interface MarqueeRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface UseMarqueeSelectOptions {
+  nodes: CanvasNode[];
+  screenToCanvas: (sx: number, sy: number, container: HTMLElement) => { x: number; y: number };
+  getContainer: () => HTMLElement | null;
+  setSelectedNodeIds: (ids: string[]) => void;
+  /** Clear any selected edge when the marquee commits — keeps node and edge
+   *  selection mutually exclusive, matching the existing click semantics. */
+  setSelectedEdgeId: (id: string | null) => void;
+}
+
+const rectsIntersect = (
+  ax: number, ay: number, aw: number, ah: number,
+  bx: number, by: number, bw: number, bh: number,
+): boolean =>
+  ax < bx + bw && ax + aw > bx && ay < by + bh && ay + ah > by;
+
+const rectContains = (
+  outer: MarqueeRect,
+  bx: number, by: number, bw: number, bh: number,
+): boolean =>
+  bx >= outer.x &&
+  by >= outer.y &&
+  bx + bw <= outer.x + outer.width &&
+  by + bh <= outer.y + outer.height;
+
+/**
+ * Compute which nodes fall inside the marquee rectangle.
+ *
+ * Frame nodes use **full containment** — a frame only joins the selection
+ * when the marquee fully encloses its bounding box. Without this, any small
+ * drag inside a big frame would select the frame along with the nodes the
+ * user actually wanted, which is confusing (and dragging the frame then
+ * cascades to every child, quietly moving things the user didn't pick).
+ *
+ * Non-frame nodes use **bbox intersection** — any overlap with the marquee
+ * counts, matching the flow designers expect from Figma/tldraw.
+ */
+const computeHits = (rect: MarqueeRect, nodes: CanvasNode[]): string[] => {
+  const hits: string[] = [];
+  for (const n of nodes) {
+    if (n.type === 'frame') {
+      if (rectContains(rect, n.x, n.y, n.width, n.height)) hits.push(n.id);
+    } else {
+      if (rectsIntersect(rect.x, rect.y, rect.width, rect.height, n.x, n.y, n.width, n.height)) {
+        hits.push(n.id);
+      }
+    }
+  }
+  return hits;
+};
+
+/**
+ * Marquee (drag-select) gesture for the canvas.
+ *
+ * Lifecycle:
+ *  1. `begin(e, currentSelection)` on a blank-canvas mousedown — records the
+ *     start point and the base selection (used for shift+drag additive mode).
+ *     Does **not** show the rectangle yet.
+ *  2. `move(e)` on mousemove — once the cursor passes `DRAG_THRESHOLD_PX` the
+ *     rectangle becomes visible and the selection is updated live.
+ *  3. `end()` on mouseup — clears the rectangle and returns `true` if a
+ *     marquee was actually drawn, so the caller can suppress the trailing
+ *     `onClick` that would otherwise wipe the fresh selection.
+ *
+ * The hook keeps the gesture state in refs and only the rendered rectangle
+ * in React state, so mousemove doesn't rerender the Canvas for pending
+ * (sub-threshold) gestures.
+ */
+export const useMarqueeSelect = ({
+  nodes,
+  screenToCanvas,
+  getContainer,
+  setSelectedNodeIds,
+  setSelectedEdgeId,
+}: UseMarqueeSelectOptions) => {
+  const [rect, setRect] = useState<MarqueeRect | null>(null);
+
+  /** Pending gesture — set on mousedown, cleared on mouseup/cancel. A non-null
+   *  value does NOT imply the marquee is visible yet (see `active`). */
+  const pending = useRef<{
+    startX: number;
+    startY: number;
+    screenStartX: number;
+    screenStartY: number;
+    additive: boolean;
+    baseSelection: string[];
+  } | null>(null);
+
+  /** True once the drag passed the threshold and we committed to a marquee.
+   *  Used by `end()` to tell the Canvas "this was a real marquee — don't fire
+   *  the deselect-on-click fallback". */
+  const active = useRef(false);
+
+  const begin = useCallback(
+    (e: React.MouseEvent, currentSelection: string[]) => {
+      const container = getContainer();
+      if (!container) return;
+      const p = screenToCanvas(e.clientX, e.clientY, container);
+      pending.current = {
+        startX: p.x,
+        startY: p.y,
+        screenStartX: e.clientX,
+        screenStartY: e.clientY,
+        additive: e.shiftKey,
+        baseSelection: e.shiftKey ? [...currentSelection] : [],
+      };
+      active.current = false;
+    },
+    [getContainer, screenToCanvas],
+  );
+
+  const move = useCallback(
+    (e: React.MouseEvent) => {
+      const p = pending.current;
+      if (!p) return;
+      const container = getContainer();
+      if (!container) return;
+
+      if (!active.current) {
+        const dx = Math.abs(e.clientX - p.screenStartX);
+        const dy = Math.abs(e.clientY - p.screenStartY);
+        if (dx < DRAG_THRESHOLD_PX && dy < DRAG_THRESHOLD_PX) return;
+        active.current = true;
+      }
+
+      const cur = screenToCanvas(e.clientX, e.clientY, container);
+      const newRect: MarqueeRect = {
+        x: Math.min(p.startX, cur.x),
+        y: Math.min(p.startY, cur.y),
+        width: Math.abs(cur.x - p.startX),
+        height: Math.abs(cur.y - p.startY),
+      };
+      setRect(newRect);
+
+      const hits = computeHits(newRect, nodes);
+      if (p.additive) {
+        const merged = new Set(p.baseSelection);
+        for (const id of hits) merged.add(id);
+        setSelectedNodeIds(Array.from(merged));
+      } else {
+        setSelectedNodeIds(hits);
+      }
+      setSelectedEdgeId(null);
+    },
+    [getContainer, nodes, screenToCanvas, setSelectedEdgeId, setSelectedNodeIds],
+  );
+
+  /** Terminate the gesture. Returns `true` iff a marquee was actually drawn
+   *  (i.e. the drag passed the threshold), so the caller can suppress the
+   *  trailing onClick. */
+  const end = useCallback((): boolean => {
+    const wasActive = active.current;
+    pending.current = null;
+    active.current = false;
+    if (wasActive) setRect(null);
+    return wasActive;
+  }, []);
+
+  const cancel = useCallback(() => {
+    pending.current = null;
+    active.current = false;
+    setRect(null);
+  }, []);
+
+  return { rect, begin, move, end, cancel };
+};


### PR DESCRIPTION
## Summary
Implements drag-select (marquee) functionality for the canvas, allowing users to select multiple nodes by clicking and dragging across the canvas. The gesture intelligently handles frame nodes differently from regular nodes and integrates seamlessly with existing selection and interaction patterns.

## Key Changes
- **New `useMarqueeSelect` hook** (`useMarqueeSelect.ts`): Manages the complete marquee lifecycle with three phases:
  - `begin()`: Records start point and base selection on mousedown
  - `move()`: Updates selection live once cursor passes 3px threshold (prevents accidental drags from triggering marquee)
  - `end()`: Clears rectangle and signals whether a marquee was actually drawn
  
- **Smart node hit-testing**:
  - Frame nodes require **full containment** within the marquee to be selected (prevents accidentally selecting large frames when dragging inside them)
  - Non-frame nodes use **bounding box intersection** (standard Figma/tldraw behavior)
  
- **Canvas integration** (`Canvas/index.tsx`):
  - Wired marquee hooks into mouse event handlers
  - Added `justMarqueedRef` to suppress the trailing `onClick` that would otherwise wipe the fresh selection
  - Marquee only activates on blank canvas (respects existing node drag/resize, edge interactions, and tool state)
  - Shift+drag for additive selection support
  
- **Visual rendering** (`CanvasSurface.tsx` + `index.css`):
  - Marquee rectangle rendered in canvas-space coordinates so it stays aligned with nodes during pan/zoom
  - Border thickness scales inversely with zoom level to maintain consistent visual appearance
  - Semi-transparent blue background with matching border (uses CSS custom properties for theming)

## Notable Implementation Details
- Uses refs for gesture state to avoid re-rendering Canvas on every mousemove before the threshold is crossed
- Clears selected edges when marquee commits to maintain mutual exclusivity with node selection
- Respects pan gestures (middle-click, alt+left, hand tool) by checking `defaultPrevented` flag
- Properly coexists with frame node dragging via `.canvas-node` target filtering

https://claude.ai/code/session_01P9zHz3bn2xcwXPTYmCfimK