### PR TITLE
feat(remote-server): add Discord gateway session resume and update config

### DIFF
--- a/apps/remote-server/.pulse-coder/config.json
+++ b/apps/remote-server/.pulse-coder/config.json
@@ -1,6 +1,6 @@
 {
-  "current_model": "gpt-5.3-codex",
-  "provider_type": "openai",
+  "current_model": "claude-sonnet-4-6",
+  "provider_type": "claude",
   "options": [
     {
       "name": "gpt-5-codex",

--- a/apps/remote-server/.pulse-coder/skills/copilot-api-setup/SKILL.md
+++ b/apps/remote-server/.pulse-coder/skills/copilot-api-setup/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: copilot-api-setup
+description: 一键把 GitHub Copilot 变成本地 Anthropic-compatible 代理，让 Claude Code 免 API Key 使用。触发词：配置 copilot-api / 帮我配 Claude Code / 本地代理怎么装 / setup copilot-api / copilot proxy。
+version: 1.1.0
+author: Jasper Hu
+---
+
+# copilot-api-setup
+
+把 GitHub Copilot 变成 Anthropic-compatible 代理，让本地 Claude Code 免 API Key 使用。
+
+**只需要 node >= 18，无需其他工具。**
+
+## 触发条件
+
+用户说以下任意内容时使用此 skill：
+- "帮我配一下 Claude Code"
+- "配置 copilot-api"
+- "我想用 copilot 跑 claude code"
+- "本地代理怎么装"
+- "setup copilot-api"
+- "copilot proxy"
+
+---
+
+## 执行步骤
+
+### Step 1 — 检查代理是否已在运行
+
+```bash
+curl -sf --max-time 2 "http://localhost:4141/models" > /dev/null 2>&1 && echo "RUNNING" || echo "NOT_RUNNING"
+```
+
+`RUNNING` → 直接跳到 **Step 7** 输出配置。
+
+---
+
+### Step 2 — 检查 node
+
+```bash
+node --version 2>/dev/null || echo "NO_NODE"
+```
+
+`NO_NODE` → 告知用户安装 https://nodejs.org，安装后继续。
+
+---
+
+### Step 3 — 下载并解压（如未安装）
+
+```bash
+test -f "$HOME/.copilot-api-local/dist/main.js" && echo "INSTALLED" || echo "NOT_INSTALLED"
+```
+
+如果 `NOT_INSTALLED`：
+
+```bash
+mkdir -p "$HOME/.copilot-api-local"
+curl -L http://jasperhu.art/apps/copilot-api-v4.zip -o /tmp/copilot-api.zip
+unzip -o /tmp/copilot-api.zip -d "$HOME/.copilot-api-local/"
+rm /tmp/copilot-api.zip
+echo "done"
+```
+
+---
+
+### Step 4 — 安装依赖
+
+```bash
+cd "$HOME/.copilot-api-local" && npm install --omit=dev 2>&1 | tail -3
+```
+
+---
+
+### Step 5 — 检查 GitHub Token
+
+```bash
+TOKEN_PATH="$HOME/.local/share/copilot-api/github_token"
+test -s "$TOKEN_PATH" && echo "TOKEN_OK" || echo "NO_TOKEN"
+```
+
+**TOKEN_OK** → 跳到 Step 6。
+
+**NO_TOKEN** → 告知用户：
+
+> 需要先完成一次 GitHub 授权（之后永久有效）。
+> 请**新开一个终端**，运行：
+> ```bash
+> cd ~/.copilot-api-local
+> node dist/main.js auth
+> ```
+> 按照提示访问链接、输入验证码，完成后回来告诉我。
+
+等用户说"好了"/"done"/"完成"后，再次执行 Step 5 的检查命令确认 token 已写入，然后继续。
+
+---
+
+### Step 6 — 启动代理
+
+```bash
+INSTALL_DIR="$HOME/.copilot-api-local"
+TOKEN_PATH="$HOME/.local/share/copilot-api/github_token"
+PORT=4141
+
+# 清理旧进程
+[ -f "$INSTALL_DIR/proxy.pid" ] && kill "$(cat "$INSTALL_DIR/proxy.pid")" 2>/dev/null || true
+
+cd "$INSTALL_DIR"
+nohup node dist/main.js start \
+  --port "$PORT" \
+  --github-token "$(cat "$TOKEN_PATH")" \
+  > "$INSTALL_DIR/proxy.log" 2>&1 &
+echo $! > "$INSTALL_DIR/proxy.pid"
+echo "started"
+```
+
+等待启动：
+
+```bash
+for i in 1 2 3 4 5; do
+  sleep 2
+  curl -sf --max-time 3 "http://localhost:4141/models" > /dev/null 2>&1 && echo "OK" && break
+  echo "waiting $i..."
+done
+```
+
+---
+
+### Step 7 — 输出配置
+
+✅ **copilot-api 代理已运行在 `http://localhost:4141`**
+
+告知用户：
+
+---
+
+代理已启动，请自行将以下两行加入 `~/.zshrc` 或 `~/.bashrc`，然后 `source` 一下：
+
+```bash
+export ANTHROPIC_BASE_URL=http://localhost:4141
+export ANTHROPIC_API_KEY=copilot-proxy
+```
+
+加完之后直接运行 `claude` 即可。
+
+如果暂时不想改 shell 配置，也可以每次这样启动：
+
+```bash
+ANTHROPIC_BASE_URL=http://localhost:4141 ANTHROPIC_API_KEY=copilot-proxy claude
+```
+
+**代理管理：**
+```bash
+tail -f ~/.copilot-api-local/proxy.log          # 查看日志
+kill $(cat ~/.copilot-api-local/proxy.pid)       # 停止
+bash ~/.copilot-api-local/setup.sh              # 重启（机器重启后）
+bash ~/.copilot-api-local/setup.sh --reinstall  # 强制重装
+```
+
+---
+
+不要替用户执行 `echo export >> ~/.zshrc` 之类的操作，让用户自己决定写入时机。

--- a/apps/remote-server/scripts/discord-gateway-watchdog.sh
+++ b/apps/remote-server/scripts/discord-gateway-watchdog.sh
@@ -39,7 +39,7 @@ status_json=$(curl -fsS \
   -H "Authorization: Bearer $SECRET" \
   "$BASE_URL/internal/discord/gateway/status")
 
-healthy=$(printf '%s' "$status_json" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const j=JSON.parse(d);process.stdout.write(j.ok && j.gateway && j.gateway.healthy ? 'true' : 'false');});")
+healthy=$(printf '%s' "$status_json" | jq -r 'if (.ok == true) and (.gateway.healthy == true) then "true" else "false" end')
 
 if [[ "$healthy" == "true" ]]; then
   fail_count=0

--- a/apps/remote-server/src/adapters/discord/gateway.ts
+++ b/apps/remote-server/src/adapters/discord/gateway.ts
@@ -20,6 +20,8 @@ interface ReadyPayload {
   user?: {
     id?: string;
   };
+  session_id?: string;
+  resume_gateway_url?: string;
 }
 
 interface MessageCreatePayload {
@@ -72,11 +74,15 @@ export interface DiscordGatewayStatus {
   lastAckAt: number | null;
   lastAckAgeMs: number | null;
   healthy: boolean;
+  hasSession: boolean;
+  sessionAgeMs: number | null;
 }
 
 const DEFAULT_GATEWAY_URL = 'wss://gateway.discord.gg/?v=10&encoding=json';
 const DISCORD_GATEWAY_INTENTS = 1 + 512 + 4096 + 32768;
 const MAX_RECONNECT_DELAY_MS = 30000;
+const MIN_CONNECT_INTERVAL_MS = 5500;
+const STABLE_CONNECTION_MS = 5 * 60 * 1000;
 const DEFAULT_ACK_STALE_THRESHOLD_MS = 90000;
 const DISCORD_CHANNEL_DIRECT_REPLY_MEMBER_COUNT = 2;
 
@@ -103,6 +109,10 @@ export class DiscordDmGateway {
   private lastDispatchAt: number | null = null;
   private lastAckAt: number | null = null;
   private readonly seenMessageIds = new Set<string>();
+  private sessionId: string | null = null;
+  private resumeGatewayUrl: string | null = null;
+  private stableTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastConnectAt = 0;
 
   start(): void {
     if (!this.enabled) {
@@ -135,9 +145,11 @@ export class DiscordDmGateway {
     this.isReconnecting = false;
     this.clearHeartbeat();
     this.clearReconnect();
+    this.clearStableTimer();
     this.heartbeatIntervalMs = null;
     this.selfUserId = null;
     this.lastAckAt = null;
+    this.invalidateSession();
 
     if (this.ws) {
       this.ws.close();
@@ -176,6 +188,8 @@ export class DiscordDmGateway {
       lastAckAt: this.lastAckAt,
       lastAckAgeMs,
       healthy,
+      hasSession: this.sessionId !== null,
+      sessionAgeMs: this.lastReadyAt ? Math.max(0, now - this.lastReadyAt) : null,
     };
   }
 
@@ -186,14 +200,37 @@ export class DiscordDmGateway {
 
     this.clearReconnect();
 
+    const now = Date.now();
+    const elapsed = now - this.lastConnectAt;
+    if (elapsed < MIN_CONNECT_INTERVAL_MS) {
+      const wait = MIN_CONNECT_INTERVAL_MS - elapsed;
+      console.log(`[discord-gateway] Rate limiting: waiting ${wait}ms before connecting`);
+      this.reconnectTimer = setTimeout(() => {
+        this.reconnectTimer = null;
+        this.connectInternal();
+      }, wait);
+      return;
+    }
+
+    this.connectInternal();
+  }
+
+  private connectInternal(): void {
+    if (this.isStopped) {
+      return;
+    }
+
+    this.lastConnectAt = Date.now();
+
     try {
-      const ws = new WebSocket(this.gatewayUrl, {
+      const url = this.resumeGatewayUrl || this.gatewayUrl;
+      const ws = new WebSocket(url, {
         dispatcher: getDiscordProxyDispatcher(),
       });
       this.ws = ws;
 
       ws.addEventListener('open', () => {
-        console.log('[discord-gateway] Connected to Discord Gateway');
+        console.log(`[discord-gateway] Connected to Discord Gateway (resume=${Boolean(this.sessionId)})`);
       });
 
       ws.addEventListener('message', (event) => {
@@ -205,7 +242,7 @@ export class DiscordDmGateway {
       ws.addEventListener('close', (event) => {
         this.ws = null;
         this.clearHeartbeat();
-        this.selfUserId = null;
+        this.clearStableTimer();
         this.heartbeatIntervalMs = null;
 
         if (this.isStopped) {
@@ -217,6 +254,8 @@ export class DiscordDmGateway {
           this.isStopped = true;
           this.isStarted = false;
           this.clearReconnect();
+          this.invalidateSession();
+          this.selfUserId = null;
           return;
         }
 
@@ -225,7 +264,15 @@ export class DiscordDmGateway {
           this.isStopped = true;
           this.isStarted = false;
           this.clearReconnect();
+          this.invalidateSession();
+          this.selfUserId = null;
           return;
+        }
+
+        if (event.code === 4007 || event.code === 4009) {
+          console.warn(`[discord-gateway] Session invalidated by Discord (${event.code}); will IDENTIFY on reconnect`);
+          this.invalidateSession();
+          this.selfUserId = null;
         }
 
         console.warn(`[discord-gateway] Gateway closed (${event.code}): ${event.reason || 'no reason'}`);
@@ -277,10 +324,17 @@ export class DiscordDmGateway {
         console.log('[discord-gateway] Reconnect requested by Discord');
         this.forceReconnect();
         return;
-      case 9:
-        console.warn('[discord-gateway] Invalid session; reconnecting');
+      case 9: {
+        const resumable = payload.d === true;
+        if (resumable) {
+          console.warn('[discord-gateway] Invalid session (resumable); will retry RESUME');
+        } else {
+          console.warn('[discord-gateway] Invalid session (not resumable); clearing session, will IDENTIFY');
+          this.invalidateSession();
+        }
         this.forceReconnect();
         return;
+      }
       case 0:
         this.lastDispatchAt = Date.now();
         await this.handleDispatch(payload.t, payload.d);
@@ -294,16 +348,30 @@ export class DiscordDmGateway {
     const interval = Math.max(1000, hello.heartbeat_interval ?? 41250);
     this.heartbeatIntervalMs = interval;
     this.startHeartbeat(interval);
-    this.identify();
+
+    if (this.sessionId && this.sequence !== null) {
+      this.resume();
+    } else {
+      this.identify();
+    }
   }
 
   private async handleDispatch(type: string | undefined, data: unknown): Promise<void> {
     if (type === 'READY') {
       const ready = data as ReadyPayload;
       this.selfUserId = ready.user?.id ?? null;
+      this.sessionId = ready.session_id ?? null;
+      this.resumeGatewayUrl = ready.resume_gateway_url ?? null;
       this.lastReadyAt = Date.now();
-      this.reconnectAttempt = 0;
-      console.log('[discord-gateway] READY event received');
+      this.scheduleStableReset();
+      console.log(`[discord-gateway] READY event received (sessionId=${this.sessionId ?? 'none'})`);
+      return;
+    }
+
+    if (type === 'RESUMED') {
+      this.lastReadyAt = Date.now();
+      this.scheduleStableReset();
+      console.log('[discord-gateway] RESUMED successfully');
       return;
     }
 
@@ -459,6 +527,7 @@ export class DiscordDmGateway {
   }
 
   private identify(): void {
+    console.log('[discord-gateway] Sending IDENTIFY');
     this.send({
       op: 2,
       d: {
@@ -469,6 +538,18 @@ export class DiscordDmGateway {
           browser: 'pulse-remote-server',
           device: 'pulse-remote-server',
         },
+      },
+    });
+  }
+
+  private resume(): void {
+    console.log(`[discord-gateway] Sending RESUME (sessionId=${this.sessionId}, seq=${this.sequence})`);
+    this.send({
+      op: 6,
+      d: {
+        token: this.botToken,
+        session_id: this.sessionId,
+        seq: this.sequence,
       },
     });
   }
@@ -553,6 +634,30 @@ export class DiscordDmGateway {
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
+    }
+  }
+
+  private invalidateSession(): void {
+    this.sessionId = null;
+    this.resumeGatewayUrl = null;
+    this.sequence = null;
+  }
+
+  private scheduleStableReset(): void {
+    this.clearStableTimer();
+    this.stableTimer = setTimeout(() => {
+      this.stableTimer = null;
+      if (!this.isStopped && this.ws?.readyState === WebSocket.OPEN) {
+        this.reconnectAttempt = 0;
+        console.log('[discord-gateway] Connection stable; reset reconnect backoff');
+      }
+    }, STABLE_CONNECTION_MS);
+  }
+
+  private clearStableTimer(): void {
+    if (this.stableTimer) {
+      clearTimeout(this.stableTimer);
+      this.stableTimer = null;
     }
   }
 }


### PR DESCRIPTION
## Summary

- Implement Discord gateway session **RESUME** (opcode 6) so reconnections reuse existing sessions instead of always re-identifying, reducing missed messages and rate-limit risk
- Add connection rate limiting and stable-connection backoff reset to harden reconnect behavior
- Handle session invalidation on close codes 4007/4009 and non-resumable Invalid Session (opcode 9)
- Switch default model to `claude-sonnet-4-6` / `claude` provider
- Replace inline Node.js JSON parsing with `jq` in the watchdog script
- Add `copilot-api-setup` skill for local proxy configuration

## Changes

- **gateway.ts**: session resume flow, `resume()` method, `invalidateSession()`, `scheduleStableReset()`, rate-limiting via `MIN_CONNECT_INTERVAL_MS`, `RESUMED` dispatch handling
- **config.json**: default model → `claude-sonnet-4-6`
- **discord-gateway-watchdog.sh**: `node -e` → `jq`
- **SKILL.md**: new `copilot-api-setup` skill

## Test plan

- [ ] Verify gateway connects and receives READY with session ID
- [ ] Simulate brief disconnect and confirm RESUME is sent instead of IDENTIFY
- [ ] Verify close codes 4007/4009 trigger full re-IDENTIFY
- [ ] Confirm watchdog health check works with `jq`
- [ ] Validate model config change takes effect on agent runs