### PR TITLE
Add HTML mode to iframe nodes for rendering raw HTML

### DIFF
--- a/apps/canvas-workspace/src/main/canvas-agent/context-builder.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/context-builder.ts
@@ -265,9 +265,15 @@ function summarizeNode(node: CanvasNode): NodeSummary {
       summary.color = (node.data.color as string) || undefined;
       summary.label = (node.data.label as string) || undefined;
       break;
-    case 'iframe':
-      summary.url = (node.data.url as string) || undefined;
+    case 'iframe': {
+      const iframeMode = (node.data.mode as string) || 'url';
+      if (iframeMode === 'html') {
+        summary.url = undefined;
+      } else {
+        summary.url = (node.data.url as string) || undefined;
+      }
       break;
+    }
     case 'text':
       // Text nodes don't have titles — fall back to a content preview so
       // the agent can refer to them by something meaningful.
@@ -403,8 +409,13 @@ export async function buildDetailedContext(workspaceId: string): Promise<Detaile
         detailed.cwd = (node.data.cwd as string) ?? '';
         break;
       case 'iframe': {
-        const url = (node.data.url as string) || '';
-        detailed.content = await readIframeContent(workspaceId, node.id, url);
+        const iframeMode = (node.data.mode as string) || 'url';
+        if (iframeMode === 'html') {
+          detailed.content = (node.data.html as string) ?? '';
+        } else {
+          const url = (node.data.url as string) || '';
+          detailed.content = await readIframeContent(workspaceId, node.id, url);
+        }
         break;
       }
       case 'text':
@@ -464,12 +475,17 @@ export async function readNodeDetail(workspaceId: string, nodeId: string): Promi
       // nothing extra beyond summary
       break;
     case 'iframe': {
-      // Use the same live-webview-first path as buildDetailedContext so a
-      // single-node read (the common case for `@Link 总结`) can see the
-      // post-JS DOM — otherwise SPAs like Lark wiki come back as empty-ish
-      // shell HTML and the agent gets `content: ""`.
-      const url = (node.data.url as string) || '';
-      detailed.content = await readIframeContent(workspaceId, node.id, url);
+      const iframeMode = (node.data.mode as string) || 'url';
+      if (iframeMode === 'html') {
+        detailed.content = (node.data.html as string) ?? '';
+      } else {
+        // Use the same live-webview-first path as buildDetailedContext so a
+        // single-node read (the common case for `@Link 总结`) can see the
+        // post-JS DOM — otherwise SPAs like Lark wiki come back as empty-ish
+        // shell HTML and the agent gets `content: ""`.
+        const url = (node.data.url as string) || '';
+        detailed.content = await readIframeContent(workspaceId, node.id, url);
+      }
       break;
     }
     case 'text':
@@ -536,8 +552,8 @@ export function formatSummaryForPrompt(summary: WorkspaceSummary): string {
   if (byType.iframe?.length) {
     lines.push('## Link Nodes');
     for (const n of byType.iframe) {
-      const urlHint = n.url ? ` — ${n.url}` : ' (empty)';
-      lines.push(`- [${n.id}] **${n.title}**${urlHint}`);
+      const hint = n.url ? ` — ${n.url}` : ' (HTML)';
+      lines.push(`- [${n.id}] **${n.title}**${hint}`);
     }
     lines.push('');
   }

--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -392,8 +392,10 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
         'Optional `data.agentArgs` overrides the auto-generated CLI arguments.\n' +
         '- **text**: Creates a free-form text label (TLDRAW-style). Use `content` for the text body, ' +
         'and `data.textColor` / `data.backgroundColor` (hex or "transparent") for styling. Optional `data.fontSize`.\n' +
-        '- **iframe**: Embeds an external web page on the canvas. Pass `data.url` with the full URL (including protocol). ' +
-        'Note: some sites block embedding via X-Frame-Options / CSP.',
+        '- **iframe**: Embeds an external web page or renders raw HTML on the canvas. ' +
+        'Pass `data.url` with the full URL (including protocol) for URL mode, or ' +
+        'pass `data.html` with raw HTML content and `data.mode: "html"` for HTML mode. ' +
+        'Note: some sites block URL embedding via X-Frame-Options / CSP.',
       inputSchema: z.object({
         type: z.enum(['file', 'terminal', 'frame', 'agent', 'text', 'iframe']).describe('Node type.'),
         title: z.string().optional().describe('Node title.'),
@@ -406,7 +408,7 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
           '- agent: { agentType?: "claude-code"|"codex"|"pulse-coder", cwd?: string, status?: "idle"|"running", prompt?: string, agentArgs?: string }\n' +
           '- frame: { color?: string, label?: string }\n' +
           '- text: { textColor?: string, backgroundColor?: string, fontSize?: number }\n' +
-          '- iframe: { url: string }',
+          '- iframe: { url?: string, html?: string, mode?: "url"|"html" }',
         ),
       }),
       execute: async (input) => {
@@ -480,11 +482,15 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
               fontSize: (extraData.fontSize as number) ?? 18,
             };
             break;
-          case 'iframe':
+          case 'iframe': {
+            const iframeMode = (extraData.mode as string) === 'html' ? 'html' : 'url';
             nodeData = {
               url: (extraData.url as string) ?? '',
+              html: (extraData.html as string) ?? '',
+              mode: iframeMode,
             };
             break;
+          }
         }
 
         // For file nodes, create a backing notes file

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.css
@@ -159,3 +159,80 @@
   font-size: 11px;
   color: var(--text-muted);
 }
+
+/* ── Mode tabs (URL / HTML) ────────────────────────────────────────── */
+
+.iframe-mode-tabs {
+  display: flex;
+  gap: 2px;
+  background: rgba(0, 0, 0, 0.04);
+  border-radius: 6px;
+  padding: 2px;
+}
+
+.iframe-mode-tab {
+  flex: 1;
+  height: 26px;
+  border: none;
+  background: transparent;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.iframe-mode-tab:hover {
+  color: var(--text);
+}
+
+.iframe-mode-tab--active {
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+
+/* ── HTML textarea ─────────────────────────────────────────────────── */
+
+.iframe-empty-textarea {
+  width: 100%;
+  min-height: 120px;
+  max-height: 260px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 12px;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  color: var(--text);
+  background: var(--surface);
+  outline: none;
+  resize: vertical;
+  tab-size: 2;
+  line-height: 1.5;
+  transition: border-color 0.1s, box-shadow 0.1s;
+}
+
+.iframe-empty-textarea:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(35, 131, 226, 0.15);
+}
+
+/* ── HTML badge in the address bar ─────────────────────────────────── */
+
+.iframe-bar-badge {
+  flex-shrink: 0;
+  font-size: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: rgba(35, 131, 226, 0.12);
+  color: var(--accent);
+  margin-right: 6px;
+}
+
+.iframe-bar-url--html {
+  gap: 0;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.tsx
@@ -9,50 +9,63 @@ interface Props {
 }
 
 /**
- * Renders an external web page in an Electron `<webview>` tag.
+ * Renders an external web page in an Electron `<webview>` tag, **or** renders
+ * user-supplied HTML in a sandboxed `<iframe srcdoc>`.
  *
- * A `<webview>` hosts its own `webContents` (like an isolated mini-browser),
- * which lets us do two things a plain iframe can't:
+ * URL mode (`mode: 'url'`, default):
+ *   A `<webview>` hosts its own `webContents` (like an isolated mini-browser),
+ *   which lets us do two things a plain iframe can't:
+ *    1. **Read the rendered DOM.** When the webview attaches we register its
+ *       `webContentsId` with main. The Canvas Agent's `canvas_read_node` tool
+ *       then pulls the post-JS DOM text directly out of that webContents — so
+ *       SPAs, pages that require auth cookies, etc. all become readable.
+ *    2. **Bypass X-Frame-Options / CSP frame-ancestors.** A `<webview>` isn't
+ *       subject to those directives the way a nested browsing context is, so a
+ *       lot of sites that refuse to embed in `<iframe>` render normally here.
  *
- *  1. **Read the rendered DOM.** When the webview attaches we register its
- *     `webContentsId` with main. The Canvas Agent's `canvas_read_node` tool
- *     then pulls the post-JS DOM text directly out of that webContents — so
- *     SPAs, pages that require auth cookies, etc. all become readable.
- *  2. **Bypass X-Frame-Options / CSP frame-ancestors.** A `<webview>` isn't
- *     subject to those directives the way a nested browsing context is, so a
- *     lot of sites that refuse to embed in `<iframe>` render normally here.
+ * HTML mode (`mode: 'html'`):
+ *   Renders raw HTML the user typed into the editor via `<iframe srcdoc>`.
+ *   The iframe is sandboxed — scripts are allowed so interactive demos work,
+ *   but it cannot navigate the parent or access its origin.
  *
- * Empty URL → show a URL input. Non-empty → show an address bar + webview.
+ * Empty URL/HTML → show an input. Non-empty → show the content.
  */
 export const IframeNodeBody = ({ node, workspaceId, onUpdate }: Props) => {
   const data = node.data as IframeNodeData;
+  const mode = data.mode ?? "url";
   const url = data.url ?? "";
-  const [editing, setEditing] = useState(!url);
-  const [draft, setDraft] = useState(url);
+  const html = data.html ?? "";
+
+  const hasContent = mode === "url" ? !!url : !!html;
+
+  const [editing, setEditing] = useState(!hasContent);
+  const [draftUrl, setDraftUrl] = useState(url);
+  const [draftHtml, setDraftHtml] = useState(html);
+  const [draftMode, setDraftMode] = useState<"url" | "html">(mode);
   const [webviewKey, setWebviewKey] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const webviewRef = useRef<WebviewTag | null>(null);
 
-  // Keep the draft in sync when the URL is changed externally (undo/redo,
-  // CLI edits, etc.) so the address bar doesn't show stale text.
-  useEffect(() => {
-    setDraft(url);
-  }, [url]);
+  // Keep drafts in sync when data is changed externally (undo/redo, CLI edits).
+  useEffect(() => { setDraftUrl(url); }, [url]);
+  useEffect(() => { setDraftHtml(html); }, [html]);
+  useEffect(() => { setDraftMode(mode); }, [mode]);
 
-  // Autofocus the input whenever we enter editing mode.
+  // Autofocus the relevant input whenever we enter editing mode.
   useEffect(() => {
-    if (editing) {
-      const t = setTimeout(() => inputRef.current?.select(), 0);
-      return () => clearTimeout(t);
-    }
-    return undefined;
-  }, [editing]);
+    if (!editing) return undefined;
+    const t = setTimeout(() => {
+      if (draftMode === "url") inputRef.current?.select();
+      else textareaRef.current?.focus();
+    }, 0);
+    return () => clearTimeout(t);
+  }, [editing, draftMode]);
 
   // Register the webview's webContents with main so the Canvas Agent can
-  // pull rendered text out of it. We re-register on each load / remount so
-  // the ID is always fresh.
+  // pull rendered text out of it (URL mode only).
   useEffect(() => {
-    if (editing) return;
+    if (editing || mode !== "url") return;
     if (!workspaceId) return;
     const el = webviewRef.current;
     if (!el) return;
@@ -74,9 +87,6 @@ export const IframeNodeBody = ({ node, workspaceId, onUpdate }: Props) => {
           );
         }
       } catch (err) {
-        // If `webviewTag` is off or the guest hasn't attached yet,
-        // `getWebContentsId` throws. The event listeners below will retry;
-        // only the final mount-time error is useful, so log it quietly.
         if (via === "mount") {
           // eslint-disable-next-line no-console
           console.debug(
@@ -88,14 +98,8 @@ export const IframeNodeBody = ({ node, workspaceId, onUpdate }: Props) => {
       }
     };
 
-    // 1) Attempt synchronously. If the canvas was reloaded and the webview
-    //    had already attached by the time this effect runs, both `did-attach`
-    //    and `dom-ready` have fired and won't fire again — so this sync call
-    //    is the only chance we'd have to register.
     tryRegister("mount");
 
-    // 2) Subscribe anyway. On a fresh node insert, `did-attach` fires after
-    //    we mount; `dom-ready` catches us on manual reloads / src changes.
     const onAttach = () => tryRegister("did-attach");
     const onDomReady = () => tryRegister("dom-ready");
     el.addEventListener("did-attach", onAttach);
@@ -108,25 +112,30 @@ export const IframeNodeBody = ({ node, workspaceId, onUpdate }: Props) => {
         void api.unregisterWebview(workspaceId, node.id);
       }
     };
-  }, [workspaceId, node.id, editing, url, webviewKey]);
+  }, [workspaceId, node.id, editing, url, mode, webviewKey]);
 
   const commit = useCallback(() => {
-    const next = normalizeUrl(draft.trim());
-    if (next === url) {
-      setEditing(false);
-      return;
+    if (draftMode === "url") {
+      const next = normalizeUrl(draftUrl.trim());
+      onUpdate(node.id, {
+        data: { ...data, url: next, mode: "url" },
+        title: next ? prettyTitle(next) : node.title,
+      });
+    } else {
+      onUpdate(node.id, {
+        data: { ...data, html: draftHtml, mode: "html" },
+        title: node.title === "Web" ? "HTML" : node.title,
+      });
     }
-    onUpdate(node.id, {
-      data: { ...data, url: next },
-      title: next ? prettyTitle(next) : node.title,
-    });
     setEditing(false);
-  }, [draft, url, onUpdate, node.id, node.title, data]);
+  }, [draftMode, draftUrl, draftHtml, onUpdate, node.id, node.title, data]);
 
   const cancel = useCallback(() => {
-    setDraft(url);
+    setDraftUrl(url);
+    setDraftHtml(html);
+    setDraftMode(mode);
     setEditing(false);
-  }, [url]);
+  }, [url, html, mode]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -141,12 +150,32 @@ export const IframeNodeBody = ({ node, workspaceId, onUpdate }: Props) => {
     [commit, cancel],
   );
 
+  const handleTextareaKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // Cmd/Ctrl+Enter to confirm HTML
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        commit();
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        cancel();
+      }
+    },
+    [commit, cancel],
+  );
+
   const handleOpenExternal = useCallback(() => {
-    if (!url) return;
-    window.open(url, "_blank", "noopener,noreferrer");
-  }, [url]);
+    if (mode === "url" && url) {
+      window.open(url, "_blank", "noopener,noreferrer");
+    }
+  }, [mode, url]);
 
   const handleReload = useCallback(() => {
+    if (mode === "html") {
+      // Force re-render the srcdoc iframe
+      setWebviewKey((k) => k + 1);
+      return;
+    }
     const el = webviewRef.current;
     if (el && typeof el.reload === "function") {
       try {
@@ -157,25 +186,63 @@ export const IframeNodeBody = ({ node, workspaceId, onUpdate }: Props) => {
       }
     }
     setWebviewKey((k) => k + 1);
-  }, []);
+  }, [mode]);
+
+  // ── Editing state ──────────────────────────────────────────────────────
 
   if (editing) {
+    const canCommit = draftMode === "url" ? !!draftUrl.trim() : !!draftHtml.trim();
+
     return (
       <div className="iframe-body iframe-body--empty">
         <div className="iframe-empty-inner">
-          <div className="iframe-empty-label">Embed a web page</div>
-          <input
-            ref={inputRef}
-            className="iframe-empty-input"
-            type="url"
-            value={draft}
-            placeholder="https://example.com"
-            onChange={(e) => setDraft(e.target.value)}
-            onKeyDown={handleKeyDown}
-            spellCheck={false}
-          />
+          {/* Tab switcher */}
+          <div className="iframe-mode-tabs">
+            <button
+              className={`iframe-mode-tab${draftMode === "url" ? " iframe-mode-tab--active" : ""}`}
+              onClick={() => setDraftMode("url")}
+            >
+              URL
+            </button>
+            <button
+              className={`iframe-mode-tab${draftMode === "html" ? " iframe-mode-tab--active" : ""}`}
+              onClick={() => setDraftMode("html")}
+            >
+              HTML
+            </button>
+          </div>
+
+          {draftMode === "url" ? (
+            <>
+              <div className="iframe-empty-label">Embed a web page</div>
+              <input
+                ref={inputRef}
+                className="iframe-empty-input"
+                type="url"
+                value={draftUrl}
+                placeholder="https://example.com"
+                onChange={(e) => setDraftUrl(e.target.value)}
+                onKeyDown={handleKeyDown}
+                spellCheck={false}
+              />
+            </>
+          ) : (
+            <>
+              <div className="iframe-empty-label">Render HTML</div>
+              <textarea
+                ref={textareaRef}
+                className="iframe-empty-textarea"
+                value={draftHtml}
+                placeholder={'<h1>Hello</h1>\n<p>Type your HTML here…</p>'}
+                onChange={(e) => setDraftHtml(e.target.value)}
+                onKeyDown={handleTextareaKeyDown}
+                spellCheck={false}
+              />
+            </>
+          )}
+
           <div className="iframe-empty-actions">
-            {url && (
+            {hasContent && (
               <button className="iframe-empty-btn" onClick={cancel}>
                 Cancel
               </button>
@@ -183,18 +250,23 @@ export const IframeNodeBody = ({ node, workspaceId, onUpdate }: Props) => {
             <button
               className="iframe-empty-btn iframe-empty-btn--primary"
               onClick={commit}
-              disabled={!draft.trim()}
+              disabled={!canCommit}
             >
-              Load
+              {draftMode === "url" ? "Load" : "Render"}
             </button>
           </div>
+
           <div className="iframe-empty-hint">
-            Some sites block embedding — use "Open externally" to fall back to a browser.
+            {draftMode === "url"
+              ? 'Some sites block embedding — use "Open externally" to fall back to a browser.'
+              : "Cmd/Ctrl+Enter to confirm. Scripts are sandboxed."}
           </div>
         </div>
       </div>
     );
   }
+
+  // ── Rendered state ─────────────────────────────────────────────────────
 
   return (
     <div className="iframe-body">
@@ -214,40 +286,64 @@ export const IframeNodeBody = ({ node, workspaceId, onUpdate }: Props) => {
             />
           </svg>
         </button>
-        <button
-          className="iframe-bar-url"
-          onClick={() => setEditing(true)}
-          title="Edit URL"
-        >
-          <span className="iframe-bar-url-text">{url}</span>
-        </button>
-        <button
-          className="iframe-bar-btn"
-          onClick={handleOpenExternal}
-          title="Open externally"
-        >
-          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-            <path
-              d="M5 2H2.5A.5.5 0 002 2.5v7A.5.5 0 002.5 10h7a.5.5 0 00.5-.5V7M7 2h3v3M5.5 6.5L10 2"
-              stroke="currentColor"
-              strokeWidth="1.2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-        </button>
+
+        {mode === "url" ? (
+          <button
+            className="iframe-bar-url"
+            onClick={() => setEditing(true)}
+            title="Edit URL"
+          >
+            <span className="iframe-bar-url-text">{url}</span>
+          </button>
+        ) : (
+          <button
+            className="iframe-bar-url iframe-bar-url--html"
+            onClick={() => setEditing(true)}
+            title="Edit HTML"
+          >
+            <span className="iframe-bar-badge">HTML</span>
+            <span className="iframe-bar-url-text">
+              {html.length > 80 ? html.slice(0, 80) + "…" : html}
+            </span>
+          </button>
+        )}
+
+        {mode === "url" && (
+          <button
+            className="iframe-bar-btn"
+            onClick={handleOpenExternal}
+            title="Open externally"
+          >
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+              <path
+                d="M5 2H2.5A.5.5 0 002 2.5v7A.5.5 0 002.5 10h7a.5.5 0 00.5-.5V7M7 2h3v3M5.5 6.5L10 2"
+                stroke="currentColor"
+                strokeWidth="1.2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        )}
       </div>
-      <webview
-        // React's built-in types model <webview> as HTMLWebViewElement; we
-        // narrow that to our Electron-only shape via the ref.
-        ref={webviewRef as unknown as React.Ref<HTMLWebViewElement>}
-        key={webviewKey}
-        className="iframe-frame"
-        src={url}
-        // `allowpopups` lets target="_blank" links inside the webview open
-        // externally (they'd be dropped silently otherwise).
-        allowpopups={true as unknown as undefined}
-      />
+
+      {mode === "url" ? (
+        <webview
+          ref={webviewRef as unknown as React.Ref<HTMLWebViewElement>}
+          key={webviewKey}
+          className="iframe-frame"
+          src={url}
+          allowpopups={true as unknown as undefined}
+        />
+      ) : (
+        <iframe
+          key={webviewKey}
+          className="iframe-frame"
+          srcDoc={html}
+          sandbox="allow-scripts"
+          title="HTML preview"
+        />
+      )}
     </div>
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -76,13 +76,22 @@ export interface TextNodeData {
 }
 
 /**
- * Embeds an external web page via an <iframe>. Some sites block embedding
- * via X-Frame-Options / CSP frame-ancestors — those will fail to render and
- * the user can click "Open externally" to escape into the system browser.
+ * Embeds an external web page or renders raw HTML.
+ *
+ * `mode: 'url'` (default) loads a remote page via Electron `<webview>`.
+ * `mode: 'html'` renders user-supplied HTML in a sandboxed `<iframe srcdoc>`.
+ *
+ * Some sites block embedding via X-Frame-Options / CSP frame-ancestors —
+ * those will fail to render and the user can click "Open externally" to
+ * escape into the system browser.
  */
 export interface IframeNodeData {
   /** Full URL (including protocol) to load in the iframe. Empty = show URL input. */
   url: string;
+  /** Raw HTML content to render when `mode` is `'html'`. */
+  html?: string;
+  /** `'url'` embeds a remote page; `'html'` renders raw HTML locally. */
+  mode?: 'url' | 'html';
 }
 
 export interface CanvasTransform {

--- a/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
@@ -19,7 +19,7 @@ export const createNodeData = (type: CanvasNode['type']): FileNodeData | Termina
     case 'frame':    return { color: '#9575d4' };
     case 'agent':    return { sessionId: '', agentType: 'claude-code', status: 'idle' };
     case 'text':     return { content: '', textColor: '#1f2328', backgroundColor: 'transparent', fontSize: 18, autoSize: true };
-    case 'iframe':   return { url: '' };
+    case 'iframe':   return { url: '', html: '', mode: 'url' };
   }
 };
 


### PR DESCRIPTION
## Summary
Extended iframe nodes to support two modes: URL mode (existing behavior) for embedding external web pages, and new HTML mode for rendering user-supplied HTML in a sandboxed iframe. Users can now toggle between modes via a tab switcher in the editing UI.

## Key Changes

- **Dual-mode iframe support**: Added `mode` field to `IframeNodeData` (defaults to `'url'` for backward compatibility) and `html` field for storing raw HTML content
- **UI mode switcher**: Added tab buttons in the editing state to toggle between URL and HTML modes, with appropriate input fields (text input for URLs, textarea for HTML)
- **Rendering logic**: 
  - URL mode uses Electron `<webview>` tag (existing behavior)
  - HTML mode uses sandboxed `<iframe srcdoc>` with `allow-scripts` sandbox attribute
- **Keyboard shortcuts**: Added Cmd/Ctrl+Enter to confirm HTML edits (in addition to existing Enter for URL mode)
- **Address bar display**: Shows URL in URL mode; shows "HTML" badge + truncated content preview in HTML mode
- **Reload behavior**: HTML mode resets the iframe key to force re-render; URL mode reloads the webview
- **Canvas Agent integration**: Updated context builders to include raw HTML content for HTML mode nodes instead of attempting to read rendered DOM
- **Styling**: Added CSS for mode tabs, textarea input, and HTML badge in the address bar

## Implementation Details

- The `draftMode` state tracks which mode the user is editing, allowing mode switching without losing content
- External open button is only shown in URL mode
- Webview registration (for DOM reading) is skipped in HTML mode since the iframe is sandboxed
- HTML content is passed directly to the agent as-is, while URL mode still attempts to read the rendered post-JS DOM
- All three state variables (`draftUrl`, `draftHtml`, `draftMode`) are kept in sync with external changes via separate useEffect hooks

https://claude.ai/code/session_015kdx2yrSaa1jXpnTfmFdU1