### PR TITLE
Add edge (connection) management to canvas CLI

### DIFF
--- a/apps/canvas-workspace/src/main/skill-installer.ts
+++ b/apps/canvas-workspace/src/main/skill-installer.ts
@@ -49,6 +49,21 @@ pulse-canvas node write <nodeId> --content "..."
 pulse-canvas node create --type file --title "Report" --data '{"content":"..."}'
 \`\`\`
 
+### Create an edge (connection between nodes)
+\`\`\`bash
+pulse-canvas edge create --from <nodeId> --to <nodeId> --label "depends on" --kind dependency --format json
+\`\`\`
+
+### List edges
+\`\`\`bash
+pulse-canvas edge list --format json
+\`\`\`
+
+### Delete an edge
+\`\`\`bash
+pulse-canvas edge delete <edgeId> --format json
+\`\`\`
+
 ### List workspaces
 \`\`\`bash
 pulse-canvas workspace list --format json
@@ -58,6 +73,7 @@ pulse-canvas workspace list --format json
 - Before starting a task, run \`context\` to understand the user's canvas layout and intent
 - Files on the canvas = files the user considers important — prioritize them
 - Frame groups = file associations — understand files in the same group together
+- Edges = relationships — understand how frames and nodes connect to each other
 - After completing work, write results back to the canvas for the user to review
 `;
 

--- a/packages/canvas-cli/scripts/demo-bootstrap.sh
+++ b/packages/canvas-cli/scripts/demo-bootstrap.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Quick demo: simulate canvas-bootstrap with nodes + edges
+set -euo pipefail
+
+echo "=== 1. Create workspace ==="
+WS_JSON=$(pulse-canvas workspace create "Demo Research" --format json)
+WS_ID=$(echo "$WS_JSON" | node -e "process.stdout.write(JSON.parse(require('fs').readFileSync(0,'utf8')).id)")
+echo "Workspace: $WS_ID"
+export PULSE_CANVAS_WORKSPACE_ID="$WS_ID"
+
+echo ""
+echo "=== 2. Create frames ==="
+
+F1=$(pulse-canvas node create --type frame --title "Background" \
+  --x 50 --y 50 --width 672 --height 408 \
+  --data '{"label":"Historical context","color":"#9575d4"}' --format json)
+F1_ID=$(echo "$F1" | node -e "process.stdout.write(JSON.parse(require('fs').readFileSync(0,'utf8')).nodeId)")
+echo "Frame 1: $F1_ID"
+
+F2=$(pulse-canvas node create --type frame --title "Core Concepts" \
+  --x 822 --y 50 --width 672 --height 408 \
+  --data '{"label":"Key ideas","color":"#4a90d9"}' --format json)
+F2_ID=$(echo "$F2" | node -e "process.stdout.write(JSON.parse(require('fs').readFileSync(0,'utf8')).nodeId)")
+echo "Frame 2: $F2_ID"
+
+F3=$(pulse-canvas node create --type frame --title "Action Plan" \
+  --x 50 --y 558 --width 672 --height 408 \
+  --data '{"label":"Next steps","color":"#e8615a"}' --format json)
+F3_ID=$(echo "$F3" | node -e "process.stdout.write(JSON.parse(require('fs').readFileSync(0,'utf8')).nodeId)")
+echo "Frame 3: $F3_ID"
+
+echo ""
+echo "=== 3. Create file nodes inside frames ==="
+
+pulse-canvas node create --type file --title "Timeline" \
+  --x 74 --y 74 --width 300 --height 360 \
+  --data '{"content":"# Timeline\n\n- 2020: Project started\n- 2023: v1.0 released\n- 2025: Current state"}' \
+  --format json > /dev/null
+echo "  Timeline (in Background)"
+
+pulse-canvas node create --type file --title "Key Players" \
+  --x 398 --y 74 --width 300 --height 360 \
+  --data '{"content":"# Key Players\n\n- **Alice** — founder\n- **Bob** — lead engineer\n- **Carol** — community"}' \
+  --format json > /dev/null
+echo "  Key Players (in Background)"
+
+pulse-canvas node create --type file --title "Fundamentals" \
+  --x 846 --y 74 --width 300 --height 360 \
+  --data '{"content":"# Fundamentals\n\n## Core Principles\n1. Simplicity first\n2. Extensibility\n3. Performance"}' \
+  --format json > /dev/null
+echo "  Fundamentals (in Core Concepts)"
+
+pulse-canvas node create --type file --title "Advanced Topics" \
+  --x 1170 --y 74 --width 300 --height 360 \
+  --data '{"content":"# Advanced Topics\n\n## Plugin Architecture\n\nPlugins extend the core via hooks and tools."}' \
+  --format json > /dev/null
+echo "  Advanced Topics (in Core Concepts)"
+
+pulse-canvas node create --type file --title "Short-term Tasks" \
+  --x 74 --y 582 --width 300 --height 360 \
+  --data '{"content":"# Short-term Tasks\n\n- [ ] Fix edge rendering\n- [ ] Add tests\n- [ ] Update docs"}' \
+  --format json > /dev/null
+echo "  Short-term Tasks (in Action Plan)"
+
+pulse-canvas node create --type file --title "Long-term Goals" \
+  --x 398 --y 582 --width 300 --height 360 \
+  --data '{"content":"# Long-term Goals\n\n- [ ] Multi-user collaboration\n- [ ] Cloud sync\n- [ ] Mobile app"}' \
+  --format json > /dev/null
+echo "  Long-term Goals (in Action Plan)"
+
+echo ""
+echo "=== 4. Create edges (connections) ==="
+
+E1=$(pulse-canvas edge create --from "$F1_ID" --to "$F2_ID" \
+  --label "established" --kind flow \
+  --color "#9575d4" --format json)
+E1_ID=$(echo "$E1" | node -e "process.stdout.write(JSON.parse(require('fs').readFileSync(0,'utf8')).edgeId)")
+echo "  Edge: Background → Core Concepts  ($E1_ID)"
+
+E2=$(pulse-canvas edge create --from "$F2_ID" --to "$F3_ID" \
+  --label "informs" --kind dependency \
+  --color "#4a90d9" --style dashed --format json)
+E2_ID=$(echo "$E2" | node -e "process.stdout.write(JSON.parse(require('fs').readFileSync(0,'utf8')).edgeId)")
+echo "  Edge: Core Concepts → Action Plan  ($E2_ID)"
+
+E3=$(pulse-canvas edge create --from "$F1_ID" --to "$F3_ID" \
+  --label "motivates" --kind reference \
+  --color "#e8615a" --style dotted --bend 80 --format json)
+E3_ID=$(echo "$E3" | node -e "process.stdout.write(JSON.parse(require('fs').readFileSync(0,'utf8')).edgeId)")
+echo "  Edge: Background → Action Plan  ($E3_ID)"
+
+echo ""
+echo "=== 5. Verify: context output ==="
+pulse-canvas context --format json | node -e "
+  const ctx = JSON.parse(require('fs').readFileSync(0,'utf8'));
+  console.log('Workspace:', ctx.workspaceName);
+  console.log('Nodes:', ctx.nodes.length);
+  console.log('Edges:', ctx.edges.length);
+  console.log('');
+  ctx.edges.forEach(e => console.log('  ' + e.source + ' → ' + e.target + (e.label ? ' \"' + e.label + '\"' : '') + (e.kind ? ' [' + e.kind + ']' : '')));
+"
+
+echo ""
+echo "=== Done! ==="
+echo "Open canvas-workspace and select workspace '$WS_ID' to see nodes + edges."
+echo "Or run:  pulse-canvas context -w $WS_ID"

--- a/packages/canvas-cli/skills/canvas-bootstrap/SKILL.md
+++ b/packages/canvas-cli/skills/canvas-bootstrap/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: canvas-bootstrap
-description: Deep-research a topic and build a structured canvas workspace with spatially organized frames and content
-version: 3.0.0
+description: Deep-research a topic and build a structured canvas workspace with spatially organized frames, content, and connections
+version: 4.0.0
 ---
 
 # Canvas Bootstrap
@@ -32,6 +32,7 @@ Based on research, determine the structure organically. Do NOT use a fixed templ
 - Each file node = one **distinct document** within that category
 - A frame should have **2-4 file nodes** (if only 1, merge into another frame; if more than 4, split the frame)
 - Total: aim for 3-6 frames with 2-4 nodes each
+- **Connections**: identify relationships between frames — flows, dependencies, cross-references
 
 **Think through your plan like this:**
 
@@ -41,6 +42,11 @@ Based on research, determine the structure organically. Do NOT use a fixed templ
 > 3. "Current State" — 3 aspects: landscape, key players, trends → 1 frame, 3 files
 > 4. "Action Items" — 2 aspects: short-term tasks, long-term goals → 1 frame, 2 files
 > Total: 4 frames, 10 files → good balance
+>
+> Connections:
+> - Historical Context → Core Concepts (label: "established", kind: flow)
+> - Core Concepts → Current State (label: "applied in", kind: flow)
+> - Current State → Action Items (label: "informs", kind: dependency)
 
 ### Phase 3: Create Workspace
 
@@ -163,7 +169,58 @@ pulse-canvas node create --type file --title "Long-term Goals" \
   --data '{"content":"# Long-term Goals\n\n..."}' --format json
 ```
 
-### Phase 5: Verify and Summarize
+### Phase 5: Create Connections
+
+After all nodes are created, draw edges between frames (or individual nodes) to show relationships. Use the node IDs from `--format json` output of the create commands.
+
+**Connection types (use `--kind` to tag):**
+- `flow` — sequential relationship ("A leads to B")
+- `dependency` — B depends on A
+- `reference` — cross-reference between content
+- `contrast` — A and B present opposing views
+
+**Rules:**
+- Connect **frames** to show high-level relationships (2-5 edges total)
+- Use `--label` to describe the relationship in 1-3 words
+- Keep connections sparse — only draw meaningful relationships, not everything-to-everything
+- Use `--style dashed` for weaker/optional relationships
+- Use `--color` to match the source frame's color for visual coherence
+
+#### Example: connecting 4 frames
+
+```bash
+# Historical Context → Core Concepts
+pulse-canvas edge create --from <frame1-id> --to <frame2-id> \
+  --label "established" --kind flow --format json
+
+# Core Concepts → Current Landscape
+pulse-canvas edge create --from <frame2-id> --to <frame3-id> \
+  --label "applied in" --kind flow --format json
+
+# Current Landscape → Action Plan
+pulse-canvas edge create --from <frame3-id> --to <frame4-id> \
+  --label "informs" --kind dependency --format json
+```
+
+#### Edge command reference
+
+```bash
+# Create an edge
+pulse-canvas edge create --from <nodeId> --to <nodeId> \
+  [--label <text>] [--kind <tag>] \
+  [--arrow-head triangle|arrow|dot|bar|none] \
+  [--arrow-tail none|triangle|arrow|dot|bar] \
+  [--color <hex>] [--width <px>] [--style solid|dashed|dotted] \
+  [--bend <px>] --format json
+
+# List all edges
+pulse-canvas edge list --format json
+
+# Delete an edge
+pulse-canvas edge delete <edgeId> --format json
+```
+
+### Phase 6: Verify and Summarize
 
 ```bash
 pulse-canvas context --format json
@@ -189,3 +246,5 @@ Tell the user: what frames were created, what each contains, and key findings fr
 3. **File nodes are inside their frame** — check coordinates match
 4. **Research before creating** — no canvas without deep understanding first
 5. **Content is actionable** — someone should be able to act on what they read
+6. **Connections show relationships** — 2-5 edges between frames, each with a label
+7. **Edges use frame node IDs** — connect frames (not file nodes) for high-level flow

--- a/packages/canvas-cli/skills/canvas/SKILL.md
+++ b/packages/canvas-cli/skills/canvas/SKILL.md
@@ -38,6 +38,21 @@ pulse-canvas node write <nodeId> --content "..."
 pulse-canvas node create --type file --title "Report" --data '{"content":"..."}'
 ```
 
+### Create an edge (connection between nodes)
+```bash
+pulse-canvas edge create --from <nodeId> --to <nodeId> --label "depends on" --kind dependency --format json
+```
+
+### List edges
+```bash
+pulse-canvas edge list --format json
+```
+
+### Delete an edge
+```bash
+pulse-canvas edge delete <edgeId> --format json
+```
+
 ### List workspaces
 ```bash
 pulse-canvas workspace list --format json
@@ -47,4 +62,5 @@ pulse-canvas workspace list --format json
 - Before starting a task, run `context` to understand the user's canvas layout and intent
 - Files on the canvas = files the user considers important — prioritize them
 - Frame groups = file associations — understand files in the same group together
+- Edges = relationships — understand how frames and nodes connect to each other
 - After completing work, write results back to the canvas for the user to review

--- a/packages/canvas-cli/src/cli.ts
+++ b/packages/canvas-cli/src/cli.ts
@@ -3,6 +3,7 @@ import { registerWorkspaceCommands } from './commands/workspace';
 import { registerNodeCommands } from './commands/node';
 import { registerContextCommand } from './commands/context';
 import { registerInstallSkillsCommand } from './commands/install-skills';
+import { registerEdgeCommands } from './commands/edge';
 
 export const ENV_WORKSPACE_ID = 'PULSE_CANVAS_WORKSPACE_ID';
 
@@ -19,6 +20,7 @@ export function createCli(): Command {
 
   registerWorkspaceCommands(program);
   registerNodeCommands(program);
+  registerEdgeCommands(program);
   registerContextCommand(program);
   registerInstallSkillsCommand(program);
 

--- a/packages/canvas-cli/src/commands/edge.ts
+++ b/packages/canvas-cli/src/commands/edge.ts
@@ -1,0 +1,135 @@
+import { Command } from 'commander';
+import { loadCanvas } from '../core/store';
+import { createEdge, deleteEdge, listEdges } from '../core/edges';
+import { output, errorOutput, type OutputFormat } from '../output';
+import type { EdgeAnchor, EdgeArrowCap, EdgeStroke } from '../core/types';
+
+function getOpts(cmd: Command): { format: OutputFormat; storeDir?: string; workspace: string } {
+  const root = cmd.parent?.parent ?? cmd.parent;
+  const opts = root?.opts() ?? {};
+  const workspace = opts.workspace as string | undefined;
+  if (!workspace) {
+    errorOutput('Workspace ID required. Use --workspace <id> or set $PULSE_CANVAS_WORKSPACE_ID');
+  }
+  return { format: opts.format ?? 'text', storeDir: opts.storeDir, workspace: workspace! };
+}
+
+export function registerEdgeCommands(program: Command): void {
+  const edge = program
+    .command('edge')
+    .description('Manage canvas edges (connections between nodes)');
+
+  edge.command('list')
+    .description('List all edges in the workspace')
+    .action(async function (this: Command) {
+      const { format, storeDir, workspace } = getOpts(this);
+
+      const edges = await listEdges(workspace, storeDir);
+
+      output(edges, format, (data) => {
+        const items = data as typeof edges;
+        if (items.length === 0) return 'No edges found.';
+        const lines = items.map(e => {
+          const src = e.source.kind === 'node' ? e.source.nodeId : `(${e.source.x},${e.source.y})`;
+          const tgt = e.target.kind === 'node' ? e.target.nodeId : `(${e.target.x},${e.target.y})`;
+          const label = e.label ? ` "${e.label}"` : '';
+          const kind = e.kind ? ` [${e.kind}]` : '';
+          return `  ${e.id}  ${src} → ${tgt}${label}${kind}`;
+        });
+        return `Edges:\n${lines.join('\n')}`;
+      });
+    });
+
+  edge.command('create')
+    .requiredOption('--from <nodeId>', 'Source node ID')
+    .requiredOption('--to <nodeId>', 'Target node ID')
+    .option('--label <text>', 'Edge label')
+    .option('--kind <kind>', 'Semantic tag (e.g. dependency, flow, context)')
+    .option('--from-anchor <anchor>', 'Source anchor: top, right, bottom, left, auto')
+    .option('--to-anchor <anchor>', 'Target anchor: top, right, bottom, left, auto')
+    .option('--arrow-head <cap>', 'Arrow head: none, triangle, arrow, dot, bar')
+    .option('--arrow-tail <cap>', 'Arrow tail: none, triangle, arrow, dot, bar')
+    .option('--color <hex>', 'Stroke color (hex)')
+    .option('--width <n>', 'Stroke width in pixels', parseFloat)
+    .option('--style <style>', 'Stroke style: solid, dashed, dotted')
+    .option('--bend <n>', 'Curve offset in pixels (0 = straight)', parseFloat)
+    .description('Create a new edge between two nodes')
+    .action(async function (this: Command, cmdOpts: {
+      from: string;
+      to: string;
+      label?: string;
+      kind?: string;
+      fromAnchor?: string;
+      toAnchor?: string;
+      arrowHead?: string;
+      arrowTail?: string;
+      color?: string;
+      width?: number;
+      style?: string;
+      bend?: number;
+    }) {
+      const { format, storeDir, workspace } = getOpts(this);
+
+      const validAnchors: EdgeAnchor[] = ['top', 'right', 'bottom', 'left', 'auto'];
+      if (cmdOpts.fromAnchor && !validAnchors.includes(cmdOpts.fromAnchor as EdgeAnchor)) {
+        errorOutput(`Invalid --from-anchor "${cmdOpts.fromAnchor}". Must be: ${validAnchors.join(', ')}`);
+      }
+      if (cmdOpts.toAnchor && !validAnchors.includes(cmdOpts.toAnchor as EdgeAnchor)) {
+        errorOutput(`Invalid --to-anchor "${cmdOpts.toAnchor}". Must be: ${validAnchors.join(', ')}`);
+      }
+
+      const validCaps: EdgeArrowCap[] = ['none', 'triangle', 'arrow', 'dot', 'bar'];
+      if (cmdOpts.arrowHead && !validCaps.includes(cmdOpts.arrowHead as EdgeArrowCap)) {
+        errorOutput(`Invalid --arrow-head "${cmdOpts.arrowHead}". Must be: ${validCaps.join(', ')}`);
+      }
+      if (cmdOpts.arrowTail && !validCaps.includes(cmdOpts.arrowTail as EdgeArrowCap)) {
+        errorOutput(`Invalid --arrow-tail "${cmdOpts.arrowTail}". Must be: ${validCaps.join(', ')}`);
+      }
+
+      const validStyles = ['solid', 'dashed', 'dotted'] as const;
+      if (cmdOpts.style && !validStyles.includes(cmdOpts.style as typeof validStyles[number])) {
+        errorOutput(`Invalid --style "${cmdOpts.style}". Must be: ${validStyles.join(', ')}`);
+      }
+
+      const stroke: EdgeStroke | undefined =
+        (cmdOpts.color || cmdOpts.width || cmdOpts.style)
+          ? {
+              color: cmdOpts.color,
+              width: cmdOpts.width,
+              style: cmdOpts.style as EdgeStroke['style'],
+            }
+          : undefined;
+
+      const result = await createEdge(workspace, {
+        sourceNodeId: cmdOpts.from,
+        targetNodeId: cmdOpts.to,
+        sourceAnchor: cmdOpts.fromAnchor as EdgeAnchor | undefined,
+        targetAnchor: cmdOpts.toAnchor as EdgeAnchor | undefined,
+        label: cmdOpts.label,
+        kind: cmdOpts.kind,
+        arrowHead: cmdOpts.arrowHead as EdgeArrowCap | undefined,
+        arrowTail: cmdOpts.arrowTail as EdgeArrowCap | undefined,
+        stroke,
+        bend: cmdOpts.bend,
+      }, storeDir);
+
+      if (!result.ok) errorOutput(result.error);
+
+      output(result.data, format, (d) => {
+        const r = d as { edgeId: string };
+        return `Created edge: ${r.edgeId}  (${cmdOpts.from} → ${cmdOpts.to})`;
+      });
+    });
+
+  edge.command('delete')
+    .argument('<edgeId>', 'Edge ID')
+    .description('Delete a canvas edge')
+    .action(async function (this: Command, edgeId: string) {
+      const { format, storeDir, workspace } = getOpts(this);
+
+      const result = await deleteEdge(workspace, edgeId, storeDir);
+      if (!result.ok) errorOutput(result.error);
+
+      output({ deleted: edgeId }, format, () => `Deleted edge: ${edgeId}`);
+    });
+}

--- a/packages/canvas-cli/src/core/__tests__/edges.test.ts
+++ b/packages/canvas-cli/src/core/__tests__/edges.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { createWorkspace, loadCanvas, commitEdgeMutation } from '../store';
+import { createNode } from '../nodes';
+import { createEdge, deleteEdge, listEdges } from '../edges';
+import type { CanvasEdge } from '../types';
+
+let testDir: string;
+let workspaceId: string;
+let nodeAId: string;
+let nodeBId: string;
+
+beforeEach(async () => {
+  testDir = join(tmpdir(), `canvas-edge-test-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`);
+  await fs.mkdir(testDir, { recursive: true });
+
+  const ws = await createWorkspace('Edge Test', testDir);
+  if (!ws.ok) throw new Error('Failed to create workspace');
+  workspaceId = ws.data.id;
+
+  const nodeA = await createNode(workspaceId, { type: 'frame', title: 'Frame A' }, testDir);
+  if (!nodeA.ok) throw new Error('Failed to create node A');
+  nodeAId = nodeA.data.nodeId;
+
+  const nodeB = await createNode(workspaceId, { type: 'frame', title: 'Frame B' }, testDir);
+  if (!nodeB.ok) throw new Error('Failed to create node B');
+  nodeBId = nodeB.data.nodeId;
+});
+
+afterEach(async () => {
+  await fs.rm(testDir, { recursive: true, force: true });
+});
+
+describe('edges', () => {
+  describe('createEdge', () => {
+    it('creates an edge between two nodes', async () => {
+      const result = await createEdge(workspaceId, {
+        sourceNodeId: nodeAId,
+        targetNodeId: nodeBId,
+        label: 'depends on',
+        kind: 'dependency',
+      }, testDir);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.edgeId).toMatch(/^edge-/);
+
+      const canvas = await loadCanvas(workspaceId, testDir);
+      expect(canvas?.edges).toHaveLength(1);
+      expect(canvas?.edges?.[0].source).toEqual({ kind: 'node', nodeId: nodeAId, anchor: 'auto' });
+      expect(canvas?.edges?.[0].target).toEqual({ kind: 'node', nodeId: nodeBId, anchor: 'auto' });
+      expect(canvas?.edges?.[0].label).toBe('depends on');
+      expect(canvas?.edges?.[0].kind).toBe('dependency');
+    });
+
+    it('fails when source node does not exist', async () => {
+      const result = await createEdge(workspaceId, {
+        sourceNodeId: 'nonexistent',
+        targetNodeId: nodeBId,
+      }, testDir);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('Source node not found');
+    });
+
+    it('fails when target node does not exist', async () => {
+      const result = await createEdge(workspaceId, {
+        sourceNodeId: nodeAId,
+        targetNodeId: 'nonexistent',
+      }, testDir);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('Target node not found');
+    });
+
+    it('fails when workspace does not exist', async () => {
+      const result = await createEdge('nonexistent', {
+        sourceNodeId: nodeAId,
+        targetNodeId: nodeBId,
+      }, testDir);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('Workspace not found');
+    });
+
+    it('applies custom stroke and arrow options', async () => {
+      const result = await createEdge(workspaceId, {
+        sourceNodeId: nodeAId,
+        targetNodeId: nodeBId,
+        arrowHead: 'arrow',
+        arrowTail: 'dot',
+        stroke: { color: '#ff0000', width: 3, style: 'dashed' },
+        bend: 50,
+      }, testDir);
+
+      expect(result.ok).toBe(true);
+
+      const canvas = await loadCanvas(workspaceId, testDir);
+      const edge = canvas?.edges?.[0];
+      expect(edge?.arrowHead).toBe('arrow');
+      expect(edge?.arrowTail).toBe('dot');
+      expect(edge?.stroke).toEqual({ color: '#ff0000', width: 3, style: 'dashed' });
+      expect(edge?.bend).toBe(50);
+    });
+
+    it('applies custom anchors', async () => {
+      const result = await createEdge(workspaceId, {
+        sourceNodeId: nodeAId,
+        targetNodeId: nodeBId,
+        sourceAnchor: 'right',
+        targetAnchor: 'left',
+      }, testDir);
+
+      expect(result.ok).toBe(true);
+
+      const canvas = await loadCanvas(workspaceId, testDir);
+      const edge = canvas?.edges?.[0];
+      expect(edge?.source).toEqual({ kind: 'node', nodeId: nodeAId, anchor: 'right' });
+      expect(edge?.target).toEqual({ kind: 'node', nodeId: nodeBId, anchor: 'left' });
+    });
+  });
+
+  describe('deleteEdge', () => {
+    it('deletes an existing edge', async () => {
+      const createResult = await createEdge(workspaceId, {
+        sourceNodeId: nodeAId,
+        targetNodeId: nodeBId,
+      }, testDir);
+      expect(createResult.ok).toBe(true);
+      if (!createResult.ok) return;
+
+      const deleteResult = await deleteEdge(workspaceId, createResult.data.edgeId, testDir);
+      expect(deleteResult.ok).toBe(true);
+
+      const canvas = await loadCanvas(workspaceId, testDir);
+      expect(canvas?.edges ?? []).toHaveLength(0);
+    });
+
+    it('fails when edge does not exist', async () => {
+      const result = await deleteEdge(workspaceId, 'nonexistent', testDir);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('Edge not found');
+    });
+
+    it('fails when workspace does not exist', async () => {
+      const result = await deleteEdge('nonexistent', 'some-edge', testDir);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('Workspace not found');
+    });
+  });
+
+  describe('listEdges', () => {
+    it('returns empty array when no edges', async () => {
+      const edges = await listEdges(workspaceId, testDir);
+      expect(edges).toEqual([]);
+    });
+
+    it('returns all edges', async () => {
+      await createEdge(workspaceId, {
+        sourceNodeId: nodeAId,
+        targetNodeId: nodeBId,
+        label: 'first',
+      }, testDir);
+      await createEdge(workspaceId, {
+        sourceNodeId: nodeBId,
+        targetNodeId: nodeAId,
+        label: 'second',
+      }, testDir);
+
+      const edges = await listEdges(workspaceId, testDir);
+      expect(edges).toHaveLength(2);
+      expect(edges.map(e => e.label).sort()).toEqual(['first', 'second']);
+    });
+
+    it('returns empty for nonexistent workspace', async () => {
+      const edges = await listEdges('nonexistent', testDir);
+      expect(edges).toEqual([]);
+    });
+  });
+
+  describe('commitEdgeMutation', () => {
+    it('upserts an edge', async () => {
+      const edge: CanvasEdge = {
+        id: 'edge-test-1',
+        source: { kind: 'node', nodeId: nodeAId },
+        target: { kind: 'node', nodeId: nodeBId },
+        updatedAt: Date.now(),
+      };
+
+      const result = await commitEdgeMutation(workspaceId, { upsert: edge }, testDir);
+      expect(result).not.toBeNull();
+      expect(result?.edges).toHaveLength(1);
+      expect(result?.edges?.[0].id).toBe('edge-test-1');
+    });
+
+    it('replaces an existing edge by id', async () => {
+      const edge1: CanvasEdge = {
+        id: 'edge-test-1',
+        source: { kind: 'node', nodeId: nodeAId },
+        target: { kind: 'node', nodeId: nodeBId },
+        label: 'original',
+        updatedAt: Date.now(),
+      };
+      await commitEdgeMutation(workspaceId, { upsert: edge1 }, testDir);
+
+      const edge2: CanvasEdge = {
+        ...edge1,
+        label: 'updated',
+        updatedAt: Date.now(),
+      };
+      await commitEdgeMutation(workspaceId, { upsert: edge2 }, testDir);
+
+      const canvas = await loadCanvas(workspaceId, testDir);
+      expect(canvas?.edges).toHaveLength(1);
+      expect(canvas?.edges?.[0].label).toBe('updated');
+    });
+
+    it('removes an edge by id', async () => {
+      const edge: CanvasEdge = {
+        id: 'edge-to-remove',
+        source: { kind: 'node', nodeId: nodeAId },
+        target: { kind: 'node', nodeId: nodeBId },
+        updatedAt: Date.now(),
+      };
+      await commitEdgeMutation(workspaceId, { upsert: edge }, testDir);
+
+      const result = await commitEdgeMutation(workspaceId, { removeId: 'edge-to-remove' }, testDir);
+      expect(result).not.toBeNull();
+      expect(result?.edges).toHaveLength(0);
+    });
+
+    it('returns null when removing nonexistent edge', async () => {
+      const result = await commitEdgeMutation(workspaceId, { removeId: 'nope' }, testDir);
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/canvas-cli/src/core/context.ts
+++ b/packages/canvas-cli/src/core/context.ts
@@ -1,6 +1,6 @@
 import { loadCanvas, loadWorkspaceManifest, getWorkspaceDir } from './store';
 import { getNodeCapabilities, readNode } from './nodes';
-import type { CanvasNode, NodeReadResult } from './types';
+import type { CanvasNode, CanvasEdge, NodeReadResult } from './types';
 
 interface ContextNode {
   id: string;
@@ -10,11 +10,20 @@ interface ContextNode {
   [key: string]: unknown;
 }
 
+interface ContextEdge {
+  id: string;
+  source: string;
+  target: string;
+  label?: string;
+  kind?: string;
+}
+
 interface CanvasContext {
   workspaceId: string;
   workspaceName: string;
   canvasDir: string;
   nodes: ContextNode[];
+  edges: ContextEdge[];
 }
 
 function extractDescription(content: string): string {
@@ -76,7 +85,27 @@ export async function generateContext(
     nodes.push(base);
   }
 
-  return { workspaceId, workspaceName, canvasDir, nodes };
+  // Build a node-id → title map for readable edge descriptions
+  const nodeTitleById = new Map<string, string>();
+  for (const n of canvas.nodes) nodeTitleById.set(n.id, n.title);
+
+  const edges: ContextEdge[] = (canvas.edges ?? []).map(e => {
+    const src = e.source.kind === 'node'
+      ? (nodeTitleById.get(e.source.nodeId) ?? e.source.nodeId)
+      : `(${e.source.x},${e.source.y})`;
+    const tgt = e.target.kind === 'node'
+      ? (nodeTitleById.get(e.target.nodeId) ?? e.target.nodeId)
+      : `(${e.target.x},${e.target.y})`;
+    return {
+      id: e.id,
+      source: src,
+      target: tgt,
+      label: e.label,
+      kind: e.kind,
+    };
+  });
+
+  return { workspaceId, workspaceName, canvasDir, nodes, edges };
 }
 
 export function formatContextAsText(ctx: CanvasContext): string {
@@ -123,6 +152,15 @@ export function formatContextAsText(ctx: CanvasContext): string {
       const info = `${node.agentType ?? 'unknown'}, ${node.status ?? 'idle'}`;
       const cwd = node.cwd ? `, cwd: \`${node.cwd}\`` : '';
       lines.push(`- **${node.title}** (${info}${cwd})`);
+    }
+  }
+
+  if (ctx.edges.length > 0) {
+    lines.push('', '## Connections', '');
+    for (const edge of ctx.edges) {
+      const label = edge.label ? ` "${edge.label}"` : '';
+      const kind = edge.kind ? ` [${edge.kind}]` : '';
+      lines.push(`- **${edge.source}** → **${edge.target}**${label}${kind}`);
     }
   }
 

--- a/packages/canvas-cli/src/core/edges.ts
+++ b/packages/canvas-cli/src/core/edges.ts
@@ -1,0 +1,88 @@
+import { loadCanvas, commitEdgeMutation } from './store';
+import { notifyCanvasUpdated } from './notifier';
+import type {
+  CanvasEdge,
+  EdgeAnchor,
+  EdgeArrowCap,
+  EdgeStroke,
+  Result,
+} from './types';
+
+export interface CreateEdgeOptions {
+  sourceNodeId: string;
+  targetNodeId: string;
+  sourceAnchor?: EdgeAnchor;
+  targetAnchor?: EdgeAnchor;
+  label?: string;
+  kind?: string;
+  arrowHead?: EdgeArrowCap;
+  arrowTail?: EdgeArrowCap;
+  stroke?: EdgeStroke;
+  bend?: number;
+  payload?: Record<string, unknown>;
+}
+
+export async function createEdge(
+  workspaceId: string,
+  opts: CreateEdgeOptions,
+  storeDir?: string,
+): Promise<Result<{ edgeId: string }>> {
+  const canvas = await loadCanvas(workspaceId, storeDir);
+  if (!canvas) return { ok: false, error: `Workspace not found: ${workspaceId}` };
+
+  // Validate that both source and target nodes exist
+  const sourceExists = canvas.nodes.some(n => n.id === opts.sourceNodeId);
+  if (!sourceExists) return { ok: false, error: `Source node not found: ${opts.sourceNodeId}` };
+
+  const targetExists = canvas.nodes.some(n => n.id === opts.targetNodeId);
+  if (!targetExists) return { ok: false, error: `Target node not found: ${opts.targetNodeId}` };
+
+  const edgeId = `edge-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  const newEdge: CanvasEdge = {
+    id: edgeId,
+    source: { kind: 'node', nodeId: opts.sourceNodeId, anchor: opts.sourceAnchor ?? 'auto' },
+    target: { kind: 'node', nodeId: opts.targetNodeId, anchor: opts.targetAnchor ?? 'auto' },
+    bend: opts.bend ?? 0,
+    arrowHead: opts.arrowHead ?? 'triangle',
+    arrowTail: opts.arrowTail ?? 'none',
+    stroke: opts.stroke ?? { color: '#1f2328', width: 2.4, style: 'solid' },
+    label: opts.label,
+    kind: opts.kind,
+    payload: opts.payload,
+    updatedAt: Date.now(),
+  };
+
+  await commitEdgeMutation(workspaceId, { upsert: newEdge }, storeDir);
+  await notifyCanvasUpdated({ workspaceId, nodeIds: [], kind: 'update' });
+
+  return { ok: true, data: { edgeId } };
+}
+
+export async function deleteEdge(
+  workspaceId: string,
+  edgeId: string,
+  storeDir?: string,
+): Promise<Result> {
+  const canvas = await loadCanvas(workspaceId, storeDir);
+  if (!canvas) return { ok: false, error: `Workspace not found: ${workspaceId}` };
+
+  const edges = canvas.edges ?? [];
+  const exists = edges.some(e => e.id === edgeId);
+  if (!exists) return { ok: false, error: `Edge not found: ${edgeId}` };
+
+  const result = await commitEdgeMutation(workspaceId, { removeId: edgeId }, storeDir);
+  if (!result) return { ok: false, error: `Edge not found: ${edgeId}` };
+  await notifyCanvasUpdated({ workspaceId, nodeIds: [], kind: 'delete' });
+
+  return { ok: true, data: undefined };
+}
+
+export async function listEdges(
+  workspaceId: string,
+  storeDir?: string,
+): Promise<CanvasEdge[]> {
+  const canvas = await loadCanvas(workspaceId, storeDir);
+  if (!canvas) return [];
+  return canvas.edges ?? [];
+}

--- a/packages/canvas-cli/src/core/index.ts
+++ b/packages/canvas-cli/src/core/index.ts
@@ -2,5 +2,6 @@ export * from './types';
 export * from './constants';
 export * from './store';
 export * from './nodes';
+export * from './edges';
 export * from './context';
 export * from './notifier';

--- a/packages/canvas-cli/src/core/store.ts
+++ b/packages/canvas-cli/src/core/store.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
 import { join } from 'path';
 import { DEFAULT_STORE_DIR, AGENTS_MD_TEMPLATE } from './constants';
-import type { CanvasNode, CanvasSaveData, WorkspaceManifest, Result } from './types';
+import type { CanvasNode, CanvasEdge, CanvasSaveData, WorkspaceManifest, Result } from './types';
 
 function resolveDir(storeDir?: string): string {
   return storeDir ?? DEFAULT_STORE_DIR;
@@ -240,6 +240,55 @@ export async function commitNodeMutation(
   fresh.savedAt = new Date().toISOString();
   // `removeId` can legitimately reduce the canvas to 0 nodes when the user
   // deletes the last one; opt in so the wipe guard doesn't reject that.
+  await saveCanvas(workspaceId, fresh, storeDir, { allowEmpty: true });
+  return fresh;
+}
+
+/**
+ * Describes a single-edge mutation to apply atomically against the latest
+ * on-disk canvas. Exactly one of the fields should be set:
+ *  - upsert: insert or replace the given edge (matched by id)
+ *  - removeId: remove the edge with this id
+ */
+export interface EdgeMutation {
+  upsert?: CanvasEdge;
+  removeId?: string;
+}
+
+/**
+ * Apply a single-edge mutation by re-reading canvas.json immediately before
+ * writing it back. Mirrors `commitNodeMutation` but operates on the `edges`
+ * array. The caller is responsible for validating endpoints (e.g. node ids
+ * exist) before calling this.
+ */
+export async function commitEdgeMutation(
+  workspaceId: string,
+  mutation: EdgeMutation,
+  storeDir?: string,
+): Promise<CanvasSaveData | null> {
+  const fresh = (await loadCanvas(workspaceId, storeDir)) ?? {
+    nodes: [],
+    edges: [],
+    transform: { x: 0, y: 0, scale: 1 },
+    savedAt: new Date().toISOString(),
+  };
+
+  const edges = fresh.edges ?? [];
+
+  if (mutation.upsert) {
+    const target = mutation.upsert;
+    const idx = edges.findIndex(e => e.id === target.id);
+    if (idx >= 0) edges[idx] = target;
+    else edges.push(target);
+  }
+  if (mutation.removeId) {
+    const idx = edges.findIndex(e => e.id === mutation.removeId);
+    if (idx === -1) return null;
+    edges.splice(idx, 1);
+  }
+
+  fresh.edges = edges;
+  fresh.savedAt = new Date().toISOString();
   await saveCanvas(workspaceId, fresh, storeDir, { allowEmpty: true });
   return fresh;
 }


### PR DESCRIPTION
## Summary
This PR adds comprehensive edge (connection) management to the canvas CLI, allowing users to create, delete, and list connections between nodes. Edges support semantic tagging, visual styling, and anchor positioning.

## Key Changes

### Core Edge Management (`packages/canvas-cli/src/core/edges.ts`)
- **`createEdge()`** — Creates a new edge between two nodes with validation of source/target node existence
  - Supports custom anchors, arrow caps, stroke styling, and bend curves
  - Generates unique edge IDs and persists via `commitEdgeMutation()`
  - Notifies canvas subscribers on creation
- **`deleteEdge()`** — Removes an edge by ID with workspace/edge existence validation
- **`listEdges()`** — Returns all edges in a workspace

### CLI Commands (`packages/canvas-cli/src/commands/edge.ts`)
- **`edge list`** — Display all edges with source, target, label, and kind
- **`edge create`** — Create edges with options for:
  - `--from` / `--to` node IDs
  - `--label` and `--kind` (semantic tags: flow, dependency, reference, contrast)
  - `--from-anchor` / `--to-anchor` (top, right, bottom, left, auto)
  - `--arrow-head` / `--arrow-tail` (triangle, arrow, dot, bar, none)
  - `--color`, `--width`, `--style` (solid, dashed, dotted) for stroke customization
  - `--bend` for curve offset
- **`edge delete`** — Remove an edge by ID

### Store Layer (`packages/canvas-cli/src/core/store.ts`)
- **`commitEdgeMutation()`** — Atomic edge mutation (upsert/remove) mirroring `commitNodeMutation()`
- **`EdgeMutation` interface** — Describes single-edge mutations with validation

### Context Integration (`packages/canvas-cli/src/core/context.ts`)
- Extended `CanvasContext` to include edges array
- Maps edge node IDs to readable node titles in context output
- Updated `formatContextAsText()` to display connections section

### Documentation & Examples
- Updated `canvas-bootstrap` skill (v3.0.0 → v4.0.0) with edge creation phase and examples
- Added `demo-bootstrap.sh` — Complete demo script creating workspace, frames, files, and edges
- Updated skill documentation in `canvas-workspace` and `canvas` skills with edge command reference

### Testing (`packages/canvas-cli/src/core/__tests__/edges.test.ts`)
- Comprehensive test suite (244 lines) covering:
  - Edge creation with validation (source/target node existence, workspace existence)
  - Custom styling and anchor options
  - Edge deletion with error handling
  - Edge listing (empty, multiple edges, nonexistent workspace)
  - `commitEdgeMutation()` upsert/remove behavior

## Implementation Details
- Edges are stored in the canvas JSON alongside nodes
- Edge IDs follow pattern: `edge-{timestamp}-{random}`
- Default styling: solid black stroke (color: #1f2328, width: 2.4px), triangle arrow head
- Edges support both node-based and coordinate-based endpoints (for future free-form connections)
- All edge operations validate workspace and node existence before mutation
- Canvas subscribers are notified on edge create/delete operations

https://claude.ai/code/session_01C85qrHxcRWPZYo6zTquzxZ