### PR TITLE
Enable line breaks in Markdown editor for TextNodeBody

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.tsx
@@ -66,7 +66,7 @@ export const TextNodeBody = ({ node, onUpdate, isSelected, onSelect, onDragStart
         placeholder: "Double-click to edit",
         showOnlyWhenEditable: false,
       }),
-      Markdown.configure({ html: false, transformPastedText: true }),
+      Markdown.configure({ html: false, transformPastedText: true, breaks: true }),
     ],
     content: data.content || "",
     editable: false,


### PR DESCRIPTION
## Summary
Updated the Markdown editor configuration in TextNodeBody to properly handle line breaks when rendering content.

## Key Changes
- Added `breaks: true` option to the Markdown.configure() call in TextNodeBody component
- This enables the conversion of soft line breaks (single newlines) into `<br>` tags in the rendered output

## Implementation Details
The change modifies the TipTap Markdown extension configuration to treat newline characters as hard breaks, allowing users to create multi-line text with proper line break rendering. This is particularly useful for maintaining text formatting when pasting or editing content that contains line breaks.

https://claude.ai/code/session_016HgmJbuom2YLQXja7wNtuc