### PR TITLE
feat(remote-server): use platformKey as x-session-id for copilot proxy

### DIFF
--- a/apps/remote-server/src/core/agent-runner.ts
+++ b/apps/remote-server/src/core/agent-runner.ts
@@ -233,7 +233,7 @@ function buildChannelSystemPrompt(platformKey: string): string | null {
 
 function resolveRunProvider(
   modelType: 'openai' | 'claude' | undefined,
-  sessionId: string,
+  platformKey: string,
 ): LLMProviderFactory | undefined {
   if (modelType !== 'claude') {
     return undefined;
@@ -241,7 +241,7 @@ function resolveRunProvider(
 
   return buildProvider('claude', {
     headers: {
-      'x-session-id': sessionId,
+      'x-session-id': platformKey,
     },
   });
 }
@@ -283,7 +283,7 @@ export async function executeAgentTurn(input: ExecuteAgentTurnInput): Promise<Ex
   const callbacks = input.callbacks ?? {};
   const compactions: CompactionSnapshot[] = [];
   const { model: modelOverride, modelType } = await resolveModelForRun(input.platformKey);
-  const providerOverride = resolveRunProvider(modelType, sessionId);
+  const providerOverride = resolveRunProvider(modelType, input.platformKey);
 
   let latestAttachments = session.latestAttachments ?? [];
   if (input.attachments?.length) {


### PR DESCRIPTION
Use platform channel key as the `x-session-id` header sent to copilot-api, instead of the internal session UUID.

- Replace `sessionId` with `platformKey` in `resolveRunProvider`
- Same thread/channel consistently maps to the same `x-session-id` across all requests
- copilot-api hashes the value to UUID internally, so string format has no impact
- Note: unlike the UUID approach, `forceNewSession` no longer changes `x-session-id` on the copilot-api side