### PR TITLE
Add image node support with clipboard paste integration

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -7,6 +7,7 @@ import { useNodeResize } from '../../hooks/useNodeResize';
 import { useCanvasContext } from '../../hooks/useCanvasContext';
 import { useCanvasFit } from '../../hooks/useCanvasFit';
 import { useCanvasKeyboard } from '../../hooks/useCanvasKeyboard';
+import { useCanvasImagePaste } from '../../hooks/useCanvasImagePaste';
 import { useEdgeInteraction } from '../../hooks/useEdgeInteraction';
 import type { CanvasNode } from '../../types';
 import { computeFrameDepths } from '../../utils/frameHierarchy';
@@ -135,6 +136,16 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
     duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, removeNodes,
     searchOpen, setSearchOpen, contextMenu, setContextMenu,
     setHighlightedId, handleFocusNode,
+  });
+
+  useCanvasImagePaste({
+    canvasId,
+    active: !hidden,
+    containerRef,
+    screenToCanvas,
+    addNode,
+    updateNode,
+    onCreated: (node) => setSelectedNodeIds([node.id]),
   });
 
   // Clear highlight after animation

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -219,6 +219,45 @@
   opacity: 0.5;
 }
 
+/* Image nodes render chromeless — no border, no background, no shadow —
+ * so the picture is the whole node. A faint outline appears on hover /
+ * selection so users can still tell where the hit box is. The body
+ * captures mouseDown and starts a drag, matching tldraw's feel. */
+.canvas-node--image {
+  background: transparent;
+  border: 1px solid transparent;
+  box-shadow: none;
+}
+
+.canvas-node--image:hover {
+  border-color: rgba(0, 0, 0, 0.1);
+  box-shadow: none;
+}
+
+.canvas-node--image.canvas-node--selected {
+  border-color: var(--accent-border);
+  box-shadow: 0 0 0 2px rgba(35, 131, 226, 0.12);
+}
+
+.canvas-node--image.canvas-node--dragging,
+.canvas-node--image.canvas-node--resizing {
+  box-shadow: var(--shadow-drag);
+}
+
+.node-body--image {
+  padding: 0;
+  height: 100%;
+}
+
+.node-close--floating {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+  z-index: 5;
+}
+
 .canvas-node--highlighted {
   animation: nodeHighlight 1.5s ease-out;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -8,6 +8,7 @@ import { FrameNodeBody, FrameColorPicker } from "../FrameNodeBody";
 import { AgentNodeBody } from "../AgentNodeBody";
 import { TextNodeBody, TextColorPicker } from "../TextNodeBody";
 import { IframeNodeBody } from "../IframeNodeBody";
+import { ImageNodeBody } from "../ImageNodeBody";
 
 interface Props {
   node: CanvasNode;
@@ -131,6 +132,41 @@ export const CanvasNodeView = ({
   ]
     .filter(Boolean)
     .join(" ");
+
+  if (node.type === "image") {
+    return (
+      <div
+        className={classes}
+        style={{
+          transform: `translate(${node.x}px, ${node.y}px)`,
+          width: node.width,
+          height: node.height,
+        }}
+        onClick={handleNodeClick}
+      >
+        <div className="node-body node-body--image" onMouseDown={(e) => e.stopPropagation()}>
+          <ImageNodeBody node={node} onSelect={onSelect} onDragStart={onDragStart} />
+        </div>
+        <button className="node-close node-close--floating" onClick={handleClose} title="Remove">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <path d="M3 3l6 6M9 3l-6 6" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+          </svg>
+        </button>
+        <div
+          className="resize-handle resize-handle--right"
+          onMouseDown={makeResizeHandler("right")}
+        />
+        <div
+          className="resize-handle resize-handle--bottom"
+          onMouseDown={makeResizeHandler("bottom")}
+        />
+        <div
+          className="resize-handle resize-handle--corner"
+          onMouseDown={makeResizeHandler("bottom-right")}
+        />
+      </div>
+    );
+  }
 
   return (
     <div

--- a/apps/canvas-workspace/src/renderer/src/components/ImageNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ImageNodeBody/index.css
@@ -1,0 +1,28 @@
+.image-node-body {
+  width: 100%;
+  height: 100%;
+  cursor: grab;
+  user-select: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.image-node-body:active {
+  cursor: grabbing;
+}
+
+.image-node-img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  pointer-events: none;
+  display: block;
+}
+
+.image-node-empty {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-style: italic;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/ImageNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ImageNodeBody/index.tsx
@@ -1,0 +1,41 @@
+import { useCallback } from 'react';
+import './index.css';
+import type { CanvasNode, ImageNodeData } from '../../types';
+
+interface Props {
+  node: CanvasNode;
+  onSelect: (id: string) => void;
+  onDragStart: (e: React.MouseEvent, node: CanvasNode) => void;
+}
+
+/**
+ * Image node body. Renders the saved image from disk and makes the whole
+ * surface a drag handle — the outer CanvasNodeView hides the header for
+ * image nodes so there is no other grip to reach for.
+ */
+export const ImageNodeBody = ({ node, onSelect, onDragStart }: Props) => {
+  const data = node.data as ImageNodeData;
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      onSelect(node.id);
+      onDragStart(e, node);
+    },
+    [node, onSelect, onDragStart],
+  );
+
+  return (
+    <div className="image-node-body" onMouseDown={handleMouseDown}>
+      {data.filePath ? (
+        <img
+          className="image-node-img"
+          src={`file://${data.filePath}`}
+          alt={node.title}
+          draggable={false}
+        />
+      ) : (
+        <div className="image-node-empty">No image</div>
+      )}
+    </div>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/hooks/useCanvasImagePaste.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useCanvasImagePaste.ts
@@ -1,0 +1,118 @@
+import { useEffect } from 'react';
+import type { CanvasNode } from '../types';
+
+interface Options {
+  /** Current canvas workspace id — used as the saveImage target directory. */
+  canvasId: string;
+  /** True while the canvas is active / visible. Inactive canvases skip paste. */
+  active: boolean;
+  /** Container element for the canvas; used to compute a default drop position. */
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  /** Convert screen coords to canvas coords (honours pan/zoom). */
+  screenToCanvas: (x: number, y: number, container: HTMLElement) => { x: number; y: number };
+  /** Create a node on the canvas. */
+  addNode: (type: CanvasNode['type'], x: number, y: number) => CanvasNode;
+  /** Update a node after its image has been saved and measured. */
+  updateNode: (id: string, patch: Partial<CanvasNode>) => void;
+  /** Make the new image the current selection. */
+  onCreated?: (node: CanvasNode) => void;
+}
+
+/** Clamp the pasted image to a reasonable default on-canvas size while
+ *  preserving its aspect ratio. Very tall/wide images are still viewable
+ *  without filling the screen, and small icons keep their native dimensions. */
+const MAX_DEFAULT_DIM = 480;
+
+const fitDimensions = (w: number, h: number): { width: number; height: number } => {
+  if (w <= 0 || h <= 0) return { width: 320, height: 240 };
+  const largest = Math.max(w, h);
+  if (largest <= MAX_DEFAULT_DIM) return { width: w, height: h };
+  const scale = MAX_DEFAULT_DIM / largest;
+  return { width: Math.round(w * scale), height: Math.round(h * scale) };
+};
+
+const isTypingContext = (target: EventTarget | null): boolean => {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA') return true;
+  if (target.isContentEditable) return true;
+  return false;
+};
+
+/**
+ * Listens for `paste` events on the document and, when the clipboard
+ * carries an image and the focus is NOT inside an editable field, saves
+ * the image to disk and drops it onto the canvas as a new image node.
+ *
+ * We deliberately skip typing contexts (tiptap editors, inputs) so that
+ * pasting an image into a note still lands inside the note's editor via
+ * its own `handlePaste` (see `useFileNodeEditor`).
+ */
+export const useCanvasImagePaste = ({
+  canvasId,
+  active,
+  containerRef,
+  screenToCanvas,
+  addNode,
+  updateNode,
+  onCreated,
+}: Options) => {
+  useEffect(() => {
+    if (!active) return;
+
+    const handler = (e: ClipboardEvent) => {
+      if (isTypingContext(e.target)) return;
+      const items = e.clipboardData?.items;
+      if (!items) return;
+      const imageItem = Array.from(items).find((i) => i.type.startsWith('image/'));
+      if (!imageItem) return;
+      const blob = imageItem.getAsFile();
+      if (!blob) return;
+      e.preventDefault();
+
+      const reader = new FileReader();
+      reader.onload = async () => {
+        const dataUrl = reader.result as string;
+        const base64 = dataUrl.split(',')[1];
+        if (!base64) return;
+        const ext = imageItem.type.replace('image/', '').split(';')[0] ?? 'png';
+        const api = window.canvasWorkspace?.file;
+        if (!api) return;
+
+        const saved = await api.saveImage(canvasId, base64, ext);
+        if (!saved.ok || !saved.filePath) return;
+
+        // Measure natural size so the node frames the image correctly.
+        const { width, height } = await new Promise<{ width: number; height: number }>((resolve) => {
+          const img = new Image();
+          img.onload = () => resolve(fitDimensions(img.naturalWidth, img.naturalHeight));
+          img.onerror = () => resolve({ width: 320, height: 240 });
+          img.src = dataUrl;
+        });
+
+        // Drop at the viewport centre. Using a known-good anchor here
+        // beats guessing at the last mouse position (which would lag
+        // when the user pastes via keyboard shortcut only).
+        const container = containerRef.current;
+        if (!container) return;
+        const rect = container.getBoundingClientRect();
+        const centre = screenToCanvas(rect.left + rect.width / 2, rect.top + rect.height / 2, container);
+        const x = centre.x - width / 2;
+        const y = centre.y - height / 2;
+
+        const node = addNode('image', x, y);
+        updateNode(node.id, {
+          width,
+          height,
+          title: saved.fileName ?? 'Image',
+          data: { filePath: saved.filePath ?? '' },
+        });
+        onCreated?.(node);
+      };
+      reader.readAsDataURL(blob);
+    };
+
+    document.addEventListener('paste', handler);
+    return () => document.removeEventListener('paste', handler);
+  }, [active, canvasId, containerRef, screenToCanvas, addNode, updateNode, onCreated]);
+};

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
@@ -6,6 +6,7 @@ import type {
   CanvasTransform,
   FileNodeData,
   FrameNodeData,
+  ImageNodeData,
   TextNodeData,
 } from '../types';
 import { createDefaultNode, createNodeData, genId } from '../utils/nodeFactory';
@@ -423,7 +424,9 @@ export const useNodes = (
           ? { ...(source.data as FrameNodeData) }
           : source.type === 'text'
             ? { ...(source.data as TextNodeData) }
-            : createNodeData(source.type),
+            : source.type === 'image'
+              ? { ...(source.data as ImageNodeData) }
+              : createNodeData(source.type),
         updatedAt: Date.now(),
       };
       if (newNode.type === 'file') {
@@ -464,7 +467,9 @@ export const useNodes = (
           ? { ...(source.data as FrameNodeData) }
           : source.type === 'text'
             ? { ...(source.data as TextNodeData) }
-            : createNodeData(source.type),
+            : source.type === 'image'
+              ? { ...(source.data as ImageNodeData) }
+              : createNodeData(source.type),
         updatedAt: now,
       }));
       newNodes.forEach((newNode) => {

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -1,6 +1,6 @@
 export interface CanvasNode {
   id: string;
-  type: "file" | "terminal" | "frame" | "agent" | "text" | "iframe";
+  type: "file" | "terminal" | "frame" | "agent" | "text" | "iframe" | "image";
   title: string;
   x: number;
   y: number;
@@ -12,7 +12,8 @@ export interface CanvasNode {
     | FrameNodeData
     | AgentNodeData
     | TextNodeData
-    | IframeNodeData;
+    | IframeNodeData
+    | ImageNodeData;
   /** Epoch millis of last mutation; used for cross-process merge. */
   updatedAt?: number;
 }
@@ -94,6 +95,19 @@ export interface IframeNodeData {
   mode?: 'url' | 'html' | 'ai';
   /** The prompt used to generate HTML when `mode` is `'ai'`. */
   prompt?: string;
+}
+
+/**
+ * A free-form image pinned to the canvas. Created by pasting (Ctrl/Cmd+V)
+ * image data onto the canvas; the bytes are persisted to the workspace
+ * images directory via `file:saveImage` and referenced by absolute path.
+ *
+ * Rendered with no header/border chrome so the picture is the whole node.
+ * The entire body acts as the drag handle (mirroring TextNodeBody).
+ */
+export interface ImageNodeData {
+  /** Absolute path on disk to the saved image file. */
+  filePath: string;
 }
 
 export interface CanvasTransform {

--- a/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
@@ -1,4 +1,4 @@
-import type { CanvasNode, FileNodeData, TerminalNodeData, FrameNodeData, AgentNodeData, TextNodeData, IframeNodeData } from '../types';
+import type { CanvasNode, FileNodeData, TerminalNodeData, FrameNodeData, AgentNodeData, TextNodeData, IframeNodeData, ImageNodeData } from '../types';
 
 let nodeIdCounter = 0;
 export const genId = (): string => `node-${Date.now()}-${++nodeIdCounter}`;
@@ -10,9 +10,10 @@ const NODE_DEFAULTS: Record<CanvasNode['type'], { title: string; width: number; 
   agent:    { title: 'Agent',    width: 520, height: 380 },
   text:     { title: 'Text',     width: 260, height: 120 },
   iframe:   { title: 'Web',      width: 520, height: 400 },
+  image:    { title: 'Image',    width: 320, height: 240 },
 };
 
-export const createNodeData = (type: CanvasNode['type']): FileNodeData | TerminalNodeData | FrameNodeData | AgentNodeData | TextNodeData | IframeNodeData => {
+export const createNodeData = (type: CanvasNode['type']): FileNodeData | TerminalNodeData | FrameNodeData | AgentNodeData | TextNodeData | IframeNodeData | ImageNodeData => {
   switch (type) {
     case 'file':     return { filePath: '', content: '', saved: false, modified: false };
     case 'terminal': return { sessionId: '' };
@@ -20,6 +21,7 @@ export const createNodeData = (type: CanvasNode['type']): FileNodeData | Termina
     case 'agent':    return { sessionId: '', agentType: 'claude-code', status: 'idle' };
     case 'text':     return { content: '', textColor: '#1f2328', backgroundColor: 'transparent', fontSize: 18, autoSize: true };
     case 'iframe':   return { url: '', html: '', mode: 'url', prompt: '' };
+    case 'image':    return { filePath: '' };
   }
 };
 


### PR DESCRIPTION
## Summary
This PR adds support for image nodes on the canvas, allowing users to paste images directly via clipboard (Ctrl/Cmd+V). Images are automatically saved to disk and rendered as chromeless nodes that can be dragged and resized.

## Key Changes
- **New `useCanvasImagePaste` hook**: Listens for paste events and handles image clipboard data by:
  - Detecting image MIME types in clipboard
  - Skipping paste when focus is in editable fields (inputs, textareas, contentEditable)
  - Converting image data to base64 and saving via `file:saveImage` API
  - Measuring natural image dimensions and applying reasonable default sizing (max 480px)
  - Positioning pasted images at the viewport center
  
- **New `ImageNodeBody` component**: Renders saved images with:
  - Full-surface drag handle (entire body initiates drag)
  - `object-fit: contain` to preserve aspect ratio
  - Fallback "No image" placeholder for missing files
  
- **Image node styling**: Chromeless design with:
  - Transparent background and border by default
  - Subtle outline on hover/selection for hit box visibility
  - Floating close button positioned absolutely
  - Resize handles (right, bottom, corner)
  
- **Type system updates**:
  - Added `"image"` to `CanvasNode['type']` union
  - New `ImageNodeData` interface with `filePath` property
  - Updated node cloning logic in `useNodes` to preserve image data
  
- **Canvas integration**: Wired `useCanvasImagePaste` into the Canvas component with proper selection handling

## Implementation Details
- Images are clamped to a maximum dimension of 480px while preserving aspect ratio; smaller images retain native size
- Paste events are ignored when the active element is a typing context to allow normal paste behavior in editors
- Default drop position uses viewport center rather than mouse position to avoid lag with keyboard shortcuts
- Image nodes use the same drag/resize infrastructure as other node types

https://claude.ai/code/session_01Le9L9wk991CtdvdgBPj64k