### PR TITLE
feat(langfuse-plugin): add Langfuse observability engine plugin

### DIFF
--- a/apps/remote-server/package.json
+++ b/apps/remote-server/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "type": "module",
   "scripts": {
-    "prebuild": "pnpm --filter pulse-coder-orchestrator build && pnpm --filter pulse-coder-engine build && SKIP_DTS=1 pnpm --filter pulse-coder-acp --filter pulse-coder-memory-plugin --filter pulse-coder-plugin-kit build",
+    "prebuild": "pnpm --filter pulse-coder-orchestrator build && pnpm --filter pulse-coder-engine build && SKIP_DTS=1 pnpm --filter pulse-coder-acp --filter pulse-coder-memory-plugin --filter pulse-coder-plugin-kit --filter pulse-coder-langfuse-plugin build",
     "dev": "tsx watch src/index.ts",
     "build": "tsup",
     "start": "node dist/index.cjs",
@@ -21,6 +21,7 @@
     "hono": "^4.6.0",
     "pulse-coder-acp": "workspace:*",
     "pulse-coder-engine": "workspace:*",
+    "pulse-coder-langfuse-plugin": "workspace:*",
     "pulse-coder-memory-plugin": "workspace:*",
     "pulse-coder-plugin-kit": "workspace:*",
     "undici": "^6.23.0",

--- a/apps/remote-server/src/core/engine-singleton.ts
+++ b/apps/remote-server/src/core/engine-singleton.ts
@@ -12,6 +12,7 @@ import { twitterListTweetsTool } from './tools/twitter-list-tweets.js';
 import { ptcDemoTools } from './tools/ptc-demo.js';
 import { larkCliTool } from './tools/lark-cli.js';
 import { devtoolsPlugin } from './devtools.js';
+import { langfusePlugin } from './langfuse.js';
 
 /**
  * Single Engine instance shared across all platform adapters.
@@ -25,6 +26,7 @@ export const engine = new Engine({
       worktreeIntegration.enginePlugin,
       vaultIntegration.enginePlugin,
       devtoolsPlugin,
+      langfusePlugin,
     ],
   },
   tools: {

--- a/apps/remote-server/src/core/langfuse.ts
+++ b/apps/remote-server/src/core/langfuse.ts
@@ -1,0 +1,17 @@
+import { createLangfusePlugin } from 'pulse-coder-langfuse-plugin';
+
+/**
+ * Langfuse observability plugin.
+ *
+ * Auto-disables when LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY are missing,
+ * so it is safe to always mount.
+ *
+ * Configure via env:
+ *   LANGFUSE_PUBLIC_KEY   (required to activate)
+ *   LANGFUSE_SECRET_KEY   (required to activate)
+ *   LANGFUSE_HOST         (optional, defaults to Langfuse Cloud)
+ *   LANGFUSE_RELEASE      (optional, git sha / version tag)
+ */
+export const langfusePlugin = createLangfusePlugin({
+  tags: ['remote-server'],
+});

--- a/packages/langfuse-plugin/package.json
+++ b/packages/langfuse-plugin/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "pulse-coder-langfuse-plugin",
+  "version": "0.0.1",
+  "description": "Langfuse observability engine plugin for Pulse Coder runtimes",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./src": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "langfuse": "^3.37.0",
+    "pulse-coder-engine": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/langfuse-plugin/src/index.ts
+++ b/packages/langfuse-plugin/src/index.ts
@@ -1,0 +1,307 @@
+import { randomUUID } from 'crypto';
+import { Langfuse } from 'langfuse';
+
+import type {
+  EnginePlugin,
+  EnginePluginContext,
+} from 'pulse-coder-engine';
+import type { Context } from 'pulse-coder-engine';
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface LangfusePluginOptions {
+  /** Langfuse public key. Defaults to LANGFUSE_PUBLIC_KEY env var. */
+  publicKey?: string;
+  /** Langfuse secret key. Defaults to LANGFUSE_SECRET_KEY env var. */
+  secretKey?: string;
+  /** Langfuse host URL. Defaults to LANGFUSE_HOST env var or cloud. */
+  baseUrl?: string;
+  /** Plugin name (shown in PluginManager). Default: 'langfuse'. */
+  pluginName?: string;
+  /** Plugin version. Default: '0.1.0'. */
+  pluginVersion?: string;
+  /**
+   * Release tag attached to every trace (e.g. git sha). Defaults to
+   * LANGFUSE_RELEASE env var if set.
+   */
+  release?: string;
+  /** Environment tag (e.g. 'prod', 'dev'). Defaults to NODE_ENV. */
+  environment?: string;
+  /** Extra static tags appended to every trace. */
+  tags?: string[];
+  /**
+   * If set to true, disables the plugin entirely (useful when keys are
+   * missing in dev). Default: auto-disable when no publicKey/secretKey.
+   */
+  disabled?: boolean;
+  /**
+   * Whether to include the user's input text in trace input.
+   * Default: true. Set false for PII-sensitive deployments.
+   */
+  saveUserText?: boolean;
+  /**
+   * Whether to include full LLM output text on the generation.
+   * Default: true.
+   */
+  saveLLMOutput?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Internal state
+// ---------------------------------------------------------------------------
+
+interface RunState {
+  runId: string;
+  trace: any;
+  /** Current in-flight LLM generation, if any. */
+  currentGeneration?: any;
+  /** Active tool spans keyed by tool name (last-wins; tools rarely nest). */
+  toolSpans: Map<string, any>;
+}
+
+const stateByContext = new WeakMap<Context, RunState>();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resolveRunId(input: { runContext?: Record<string, any> }): string {
+  const existing = input.runContext?.runId;
+  if (existing) return String(existing);
+  const generated = randomUUID();
+  if (input.runContext) input.runContext.runId = generated;
+  return generated;
+}
+
+function systemPromptToString(sp: unknown): string | undefined {
+  if (!sp) return undefined;
+  if (typeof sp === 'string') return sp;
+  if (typeof sp === 'function') {
+    try { return String((sp as () => string)()); } catch { return undefined; }
+  }
+  if (typeof sp === 'object' && sp !== null) {
+    const append = (sp as any).append;
+    if (typeof append === 'string') return append;
+  }
+  return undefined;
+}
+
+function normalizeUsage(usage: any): any {
+  if (!usage || typeof usage !== 'object') return undefined;
+  // Langfuse accepts { input, output, total } or OpenAI shape.
+  return {
+    input: usage.inputTokens ?? usage.promptTokens ?? usage.input,
+    output: usage.outputTokens ?? usage.completionTokens ?? usage.output,
+    total: usage.totalTokens ?? usage.total,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createLangfusePlugin(options: LangfusePluginOptions = {}): EnginePlugin {
+  const publicKey = options.publicKey ?? process.env.LANGFUSE_PUBLIC_KEY;
+  const secretKey = options.secretKey ?? process.env.LANGFUSE_SECRET_KEY;
+  const baseUrl = options.baseUrl ?? process.env.LANGFUSE_HOST ?? process.env.LANGFUSE_BASEURL;
+  const release = options.release ?? process.env.LANGFUSE_RELEASE;
+  const environment = options.environment ?? process.env.NODE_ENV;
+  const staticTags = options.tags ?? [];
+  const saveUserText = options.saveUserText !== false;
+  const saveLLMOutput = options.saveLLMOutput !== false;
+
+  const disabled = options.disabled ?? (!publicKey || !secretKey);
+
+  const pluginName = options.pluginName ?? 'langfuse';
+  const pluginVersion = options.pluginVersion ?? '0.1.0';
+
+  let lf: Langfuse | undefined;
+
+  const plugin: EnginePlugin = {
+    name: pluginName,
+    version: pluginVersion,
+
+    async initialize(ctx: EnginePluginContext) {
+      const log = ctx.logger;
+
+      if (disabled) {
+        log.warn(
+          '[langfuse] plugin disabled (missing LANGFUSE_PUBLIC_KEY/SECRET_KEY). ' +
+          'No traces will be sent.',
+        );
+        return;
+      }
+
+      lf = new Langfuse({
+        publicKey: publicKey!,
+        secretKey: secretKey!,
+        baseUrl,
+        release,
+      });
+
+      ctx.registerService('langfuse', lf);
+
+      // -------- beforeRun: create trace --------
+      ctx.registerHook('beforeRun', (input) => {
+        if (!lf) return;
+        const runId = resolveRunId(input);
+        const runCtx = input.runContext ?? {};
+
+        const userText =
+          saveUserText && typeof runCtx.userText === 'string'
+            ? runCtx.userText
+            : undefined;
+
+        const tags = [...staticTags];
+        if (runCtx.platformKey) tags.push(`platform:${runCtx.platformKey}`);
+        if (runCtx.caller) tags.push(`caller:${runCtx.caller}`);
+
+        const trace = lf.trace({
+          id: runId,
+          name: typeof runCtx.caller === 'string' ? runCtx.caller : 'agent-run',
+          userId:
+            typeof runCtx.userId === 'string' ? runCtx.userId : undefined,
+          sessionId:
+            typeof runCtx.sessionId === 'string' ? runCtx.sessionId : undefined,
+          input: userText,
+          metadata: {
+            platformKey: runCtx.platformKey,
+            channelKind: runCtx.channelKind,
+            channelId: runCtx.channelId,
+            vaultId: runCtx.vaultId,
+            callerSelectors: runCtx.callerSelectors,
+            environment,
+          },
+          tags: tags.length ? tags : undefined,
+          release,
+        });
+
+        stateByContext.set(input.context, {
+          runId,
+          trace,
+          toolSpans: new Map(),
+        });
+      });
+
+      // -------- beforeLLMCall: start generation --------
+      ctx.registerHook('beforeLLMCall', (input) => {
+        const state = stateByContext.get(input.context);
+        if (!state) return;
+
+        const systemPrompt = systemPromptToString(input.systemPrompt);
+        const messages = input.context?.messages ?? [];
+
+        state.currentGeneration = state.trace.generation({
+          name: 'llm-call',
+          startTime: new Date(),
+          input: systemPrompt
+            ? [{ role: 'system', content: systemPrompt }, ...messages]
+            : messages,
+          metadata: {
+            toolNames: Object.keys(input.tools ?? {}),
+          },
+        });
+      });
+
+      // -------- afterLLMCall: end generation --------
+      ctx.registerHook('afterLLMCall', (input) => {
+        const state = stateByContext.get(input.context);
+        if (!state?.currentGeneration) return;
+
+        state.currentGeneration.end({
+          endTime: new Date(),
+          output: saveLLMOutput ? input.text : undefined,
+          usage: normalizeUsage(input.usage),
+          metadata: {
+            finishReason: input.finishReason,
+            timings: input.timings,
+          },
+        });
+        state.currentGeneration = undefined;
+      });
+
+      // -------- beforeToolCall: start span --------
+      ctx.registerHook('beforeToolCall', (input) => {
+        if (!input.context) return;
+        const state = stateByContext.get(input.context);
+        if (!state) return;
+
+        const span = state.trace.span({
+          name: `tool:${input.name}`,
+          startTime: new Date(),
+          input: input.input,
+        });
+        state.toolSpans.set(input.name, span);
+      });
+
+      // -------- afterToolCall: end span --------
+      ctx.registerHook('afterToolCall', (input) => {
+        if (!input.context) return;
+        const state = stateByContext.get(input.context);
+        if (!state) return;
+
+        const span = state.toolSpans.get(input.name);
+        if (!span) return;
+
+        span.end({
+          endTime: new Date(),
+          output: input.output,
+        });
+        state.toolSpans.delete(input.name);
+      });
+
+      // -------- onCompacted: record event --------
+      ctx.registerHook('onCompacted', (input) => {
+        const state = stateByContext.get(input.context);
+        if (!state) return;
+
+        state.trace.event({
+          name: 'context-compacted',
+          startTime: new Date(),
+          metadata: input.event,
+        });
+      });
+
+      // -------- afterRun: finalize trace --------
+      ctx.registerHook('afterRun', async (input) => {
+        const state = stateByContext.get(input.context);
+        if (!state) return;
+
+        // Clean up any dangling generation/spans (defensive).
+        if (state.currentGeneration) {
+          try { state.currentGeneration.end({ endTime: new Date() }); } catch {}
+        }
+        for (const span of state.toolSpans.values()) {
+          try { span.end({ endTime: new Date() }); } catch {}
+        }
+        state.toolSpans.clear();
+
+        state.trace.update({ output: input.result });
+        stateByContext.delete(input.context);
+
+        // Flush so short-lived processes (cron, serverless) don't drop data.
+        try {
+          await lf?.flushAsync();
+        } catch (err) {
+          log.warn('[langfuse] flushAsync failed', err as any);
+        }
+      });
+
+      log.info(`[langfuse] plugin initialized (baseUrl=${baseUrl ?? 'default'})`);
+    },
+
+    async destroy() {
+      try {
+        await lf?.shutdownAsync();
+      } catch {
+        // ignore
+      }
+    },
+  };
+
+  return plugin;
+}
+
+export default createLangfusePlugin;

--- a/packages/langfuse-plugin/tsconfig.json
+++ b/packages/langfuse-plugin/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/langfuse-plugin/tsup.config.ts
+++ b/packages/langfuse-plugin/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+  },
+  format: ['esm', 'cjs'],
+  dts: process.env.SKIP_DTS ? false : true,
+  clean: true,
+  splitting: false,
+  sourcemap: true,
+  target: 'es2022',
+  external: ['langfuse', 'pulse-coder-engine'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       pulse-coder-engine:
         specifier: workspace:*
         version: link:../../packages/engine
+      pulse-coder-langfuse-plugin:
+        specifier: workspace:*
+        version: link:../../packages/langfuse-plugin
       pulse-coder-memory-plugin:
         specifier: workspace:*
         version: link:../../packages/memory-plugin
@@ -358,6 +361,28 @@ importers:
       vitest:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@25.0.10)
+
+  packages/langfuse-plugin:
+    dependencies:
+      langfuse:
+        specifier: ^3.37.0
+        version: 3.38.20
+      pulse-coder-engine:
+        specifier: workspace:*
+        version: link:../engine
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.33
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.33)
 
   packages/memory-plugin:
     dependencies:
@@ -2396,6 +2421,14 @@ packages:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
 
+  langfuse-core@3.38.20:
+    resolution: {integrity: sha512-zBKVmQN/1oT5VWZUBYlWzvokIlkC/6mnpgr/2atMyTeAm+jR3ia7w2iJMjlrF5/oG8ukO1s8+LDRCzJpF1QeEA==}
+    engines: {node: '>=18'}
+
+  langfuse@3.38.20:
+    resolution: {integrity: sha512-MAmBAASSzJtmK1O9HQegA1mFsQhT8Yf+OJRGvE7FXkyv3g/eiBE0glLD0Ohg3pkxhoPdggM5SejK7ue9ctlaMA==}
+    engines: {node: '>=18'}
+
   lazy-val@1.0.5:
     resolution: {integrity: sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==}
 
@@ -2589,6 +2622,10 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -5518,6 +5555,14 @@ snapshots:
 
   kind-of@6.0.3: {}
 
+  langfuse-core@3.38.20:
+    dependencies:
+      mustache: 4.2.0
+
+  langfuse@3.38.20:
+    dependencies:
+      langfuse-core: 3.38.20
+
   lazy-val@1.0.5: {}
 
   lilconfig@3.1.3: {}
@@ -5706,6 +5751,8 @@ snapshots:
       ufo: 1.6.3
 
   ms@2.1.3: {}
+
+  mustache@4.2.0: {}
 
   mz@2.7.0:
     dependencies:
@@ -6518,6 +6565,24 @@ snapshots:
       extsprintf: 1.4.1
     optional: true
 
+  vite-node@1.6.1(@types/node@20.19.33):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 5.4.21(@types/node@20.19.33)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-node@1.6.1(@types/node@25.0.10):
     dependencies:
       cac: 6.7.14
@@ -6553,6 +6618,40 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.0.10
       fsevents: 2.3.3
+
+  vitest@1.6.1(@types/node@20.19.33):
+    dependencies:
+      '@vitest/expect': 1.6.1
+      '@vitest/runner': 1.6.1
+      '@vitest/snapshot': 1.6.1
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      acorn-walk: 8.3.4
+      chai: 4.5.0
+      debug: 4.4.3
+      execa: 8.0.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.10.0
+      strip-literal: 2.1.1
+      tinybench: 2.9.0
+      tinypool: 0.8.4
+      vite: 5.4.21(@types/node@20.19.33)
+      vite-node: 1.6.1(@types/node@20.19.33)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.33
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vitest@1.6.1(@types/node@25.0.10):
     dependencies:


### PR DESCRIPTION
Add a Langfuse observability plugin as a standalone workspace package, mounted into remote-server without touching engine internals.

## Changes

- **New package** \`packages/langfuse-plugin\` exposing \`createLangfusePlugin(opts)\`
- Registers 7 engine hooks: \`beforeRun\`, \`beforeLLMCall\`, \`afterLLMCall\`, \`beforeToolCall\`, \`afterToolCall\`, \`onCompacted\`, \`afterRun\`
- Maps engine constructs to Langfuse:
  - \`beforeRun\` → \`trace\` (reusing engine \`runId\` as Langfuse \`traceId\`)
  - \`beforeLLMCall\` / \`afterLLMCall\` → \`generation\` with usage + timings
  - \`beforeToolCall\` / \`afterToolCall\` → \`span\`
  - \`onCompacted\` → \`event\`
  - \`afterRun\` → finalize trace + \`flushAsync()\`
- Uses \`WeakMap<Context, RunState>\` to correlate state across hooks (same pattern as devtools-plugin)
- Auto-disables when \`LANGFUSE_PUBLIC_KEY\` / \`LANGFUSE_SECRET_KEY\` are missing — safe to mount unconditionally

## remote-server integration

- Add \`pulse-coder-langfuse-plugin\` workspace dep and prebuild entry
- New \`apps/remote-server/src/core/langfuse.ts\` thin wrapper (mirrors \`devtools.ts\`)
- Mount in \`engine-singleton.ts\` alongside existing plugins

## Configuration

\`\`\`bash
LANGFUSE_PUBLIC_KEY=pk-lf-...
LANGFUSE_SECRET_KEY=sk-lf-...
LANGFUSE_HOST=https://cloud.langfuse.com   # optional
LANGFUSE_RELEASE=<git-sha>                 # optional
\`\`\`

## Verification

- \`pnpm --filter pulse-coder-langfuse-plugin build\` ✅ (esm + cjs + dts)
- \`pnpm --filter @pulse-coder/remote-server build\` ✅
- Smoke test: plugin initializes without keys (auto-disable) and with keys (7 hooks registered)

## Why plugin, not OTel

- Zero engine coupling
- Works with existing \`runId\` identity
- Easy to swap/extend per observability backend