### PR TITLE
fix(remote-server): ensure .env always takes effect after pm2 restart

### DIFF
--- a/apps/remote-server/package.json
+++ b/apps/remote-server/package.json
@@ -8,7 +8,7 @@
     "build": "tsup",
     "start": "node dist/index.cjs",
     "pm2:start": "pnpm run build && pm2 start ecosystem.config.cjs --env production",
-    "pm2:restart": "pnpm run build && pm2 restart remote-server --update-env",
+    "pm2:restart": "pnpm run build && pm2 startOrRestart ecosystem.config.cjs --env production",
     "pm2:stop": "pm2 stop remote-server",
     "pm2:delete": "pm2 delete remote-server",
     "pm2:logs": "pm2 logs remote-server",

--- a/apps/remote-server/src/index.ts
+++ b/apps/remote-server/src/index.ts
@@ -1,4 +1,5 @@
-import 'dotenv/config';
+import dotenv from 'dotenv';
+dotenv.config({ override: true });
 import { serve } from '@hono/node-server';
 import { createApp } from './server.js';
 import { engine } from './core/engine-singleton.js';


### PR DESCRIPTION
## Problem

After running `pm2:restart`, environment variables from `.env` were not being picked up. Three root causes combined:

1. `pm2 restart --update-env` does **not** re-parse `ecosystem.config.cjs`, so the PM2 daemon serves stale cached config and the `env_production` block is never reloaded.
2. The old command had no `--env production` flag, causing production-only vars (e.g. `ACP_RETRY_MAX`) to silently disappear.
3. `dotenv` default behavior skips variables already present in `process.env`, so any stale vars injected by PM2's cache would always win over the `.env` file.

## Changes

- **`apps/remote-server/package.json`** — replace `pm2 restart remote-server --update-env` with `pm2 startOrRestart ecosystem.config.cjs --env production`, forcing a full re-parse of the ecosystem config on every restart.
- **`apps/remote-server/src/index.ts`** — switch from `import 'dotenv/config'` to `dotenv.config({ override: true })` so `.env` values always override whatever PM2 injects into `process.env`.

## Testing

Restart is intentionally skipped — owner will restart manually after merge.