### PR TITLE
fix(engine): ensure compact output ends with user message

### DIFF
--- a/packages/engine/src/ai/index.ts
+++ b/packages/engine/src/ai/index.ts
@@ -35,7 +35,7 @@ export const generateTextAI = (
   return generateText({
     model: provider(model),
     system: resolveSystemPrompt(options?.systemPrompt),
-    messages: stripTrailingAssistantMessages(messages),
+    messages,
     tools,
     providerOptions,
   }) as unknown as ReturnType<typeof generateText> & { steps: StepResult<any>[]; finishReason: string };
@@ -78,21 +78,6 @@ export const wrapToolsWithContext = (
   return wrappedTools;
 };
 
-/**
- * Strip trailing assistant messages so the conversation ends with a user (or tool) message.
- * Some providers (e.g. claude-opus-4.7 via copilot-api) do not support assistant message
- * prefill and will reject requests where the last message has role "assistant".
- */
-function stripTrailingAssistantMessages(messages: ModelMessage[]): ModelMessage[] {
-  let end = messages.length;
-  while (end > 0 && messages[end - 1].role === 'assistant') {
-    end--;
-  }
-  // Safety: never return an empty array — keep at least the original messages
-  if (end === 0) return messages;
-  return end === messages.length ? messages : messages.slice(0, end);
-}
-
 export const streamTextAI = (messages: ModelMessage[], tools: Record<string, CoderTool>, options?: StreamOptions) => {
   const provider = options?.provider ?? CoderAI;
   const model = options?.model ?? DEFAULT_MODEL;
@@ -125,14 +110,10 @@ export const streamTextAI = (messages: ModelMessage[], tools: Record<string, Cod
     ? `${baseSystemPrompt}${gptExtra}\n\n${extraSystemParts.join('\n\n')}`
     : `${baseSystemPrompt}${gptExtra}`;
 
-  // Strip trailing assistant messages to avoid "assistant message prefill not supported" errors.
-  // Some models (e.g. claude-opus-4.7 via copilot-api) reject requests ending with assistant role.
-  const sanitizedMessages = stripTrailingAssistantMessages(filteredMessages);
-
   return streamText({
     model: provider(model),
     system: finalSystemPrompt,
-    messages: sanitizedMessages,
+    messages: filteredMessages,
     tools: wrappedTools as Record<string, Tool>,
     providerOptions,
     abortSignal: options?.abortSignal,

--- a/packages/engine/src/ai/index.ts
+++ b/packages/engine/src/ai/index.ts
@@ -35,7 +35,7 @@ export const generateTextAI = (
   return generateText({
     model: provider(model),
     system: resolveSystemPrompt(options?.systemPrompt),
-    messages,
+    messages: stripTrailingAssistantMessages(messages),
     tools,
     providerOptions,
   }) as unknown as ReturnType<typeof generateText> & { steps: StepResult<any>[]; finishReason: string };
@@ -78,6 +78,21 @@ export const wrapToolsWithContext = (
   return wrappedTools;
 };
 
+/**
+ * Strip trailing assistant messages so the conversation ends with a user (or tool) message.
+ * Some providers (e.g. claude-opus-4.7 via copilot-api) do not support assistant message
+ * prefill and will reject requests where the last message has role "assistant".
+ */
+function stripTrailingAssistantMessages(messages: ModelMessage[]): ModelMessage[] {
+  let end = messages.length;
+  while (end > 0 && messages[end - 1].role === 'assistant') {
+    end--;
+  }
+  // Safety: never return an empty array — keep at least the original messages
+  if (end === 0) return messages;
+  return end === messages.length ? messages : messages.slice(0, end);
+}
+
 export const streamTextAI = (messages: ModelMessage[], tools: Record<string, CoderTool>, options?: StreamOptions) => {
   const provider = options?.provider ?? CoderAI;
   const model = options?.model ?? DEFAULT_MODEL;
@@ -110,10 +125,14 @@ export const streamTextAI = (messages: ModelMessage[], tools: Record<string, Cod
     ? `${baseSystemPrompt}${gptExtra}\n\n${extraSystemParts.join('\n\n')}`
     : `${baseSystemPrompt}${gptExtra}`;
 
+  // Strip trailing assistant messages to avoid "assistant message prefill not supported" errors.
+  // Some models (e.g. claude-opus-4.7 via copilot-api) reject requests ending with assistant role.
+  const sanitizedMessages = stripTrailingAssistantMessages(filteredMessages);
+
   return streamText({
     model: provider(model),
     system: finalSystemPrompt,
-    messages: filteredMessages,
+    messages: sanitizedMessages,
     tools: wrappedTools as Record<string, Tool>,
     providerOptions,
     abortSignal: options?.abortSignal,

--- a/packages/engine/src/context/index.ts
+++ b/packages/engine/src/context/index.ts
@@ -34,6 +34,21 @@ const ensureSummaryPrefix = (summary: string): string => {
   return `[COMPACTED_CONTEXT]\n${trimmed}`;
 };
 
+/**
+ * Ensure compacted messages end with a user-role message.
+ * Some providers (e.g. claude-opus-4.7 via copilot-api) reject requests
+ * where the last message has role "assistant" (no prefill support).
+ * Safety: never returns an empty array — falls back to original when all messages are assistant.
+ */
+const ensureEndsWithUser = (messages: ModelMessage[]): ModelMessage[] => {
+  let end = messages.length;
+  while (end > 0 && messages[end - 1].role === 'assistant') {
+    end--;
+  }
+  if (end === 0) return messages;
+  return end === messages.length ? messages : messages.slice(0, end);
+};
+
 const safeStringify = (value: unknown): string => {
   try {
     return JSON.stringify(value);
@@ -190,7 +205,7 @@ export const maybeCompactContext = async (
       const fallbackStrategy: CompactStats['strategy'] = nextEstimatedTokens > COMPACT_TARGET
         ? 'summary-too-large'
         : 'fallback';
-      const fallbackMessages = takeLastTurns(messages, KEEP_LAST_TURNS);
+      const fallbackMessages = ensureEndsWithUser(takeLastTurns(messages, KEEP_LAST_TURNS));
       return buildCompactedResult({
         reason: fallbackReason,
         strategy: fallbackStrategy,
@@ -204,7 +219,7 @@ export const maybeCompactContext = async (
     return {
       didCompact: true,
       reason: force ? 'force-summary' : 'summary',
-      newMessages: nextMessages,
+      newMessages: ensureEndsWithUser(nextMessages),
       stats: {
         forced: force,
         beforeMessageCount,
@@ -221,7 +236,7 @@ export const maybeCompactContext = async (
       toolCalls: 'all',
       emptyMessages: 'remove',
     });
-    const fallbackMessages = takeLastTurns(pruned, KEEP_LAST_TURNS);
+    const fallbackMessages = ensureEndsWithUser(takeLastTurns(pruned, KEEP_LAST_TURNS));
     return buildCompactedResult({
       reason: 'fallback',
       strategy: 'fallback',


### PR DESCRIPTION
## Problem

`claude-opus-4.7` via copilot-api rejects requests where the conversation ends with an `assistant` message:

```
400: This model does not support assistant message prefill.
     The conversation must end with a user message.
```

Happened **7 times** in production. Root cause: all failures were triggered by `compact` outputting a message array whose last item had `role: 'assistant'`.

## Fix (Plan C — fix at compact source)

Add `ensureEndsWithUser()` in `packages/engine/src/context/index.ts`, applied to all three compact output paths:

| Path | Where |
|---|---|
| summary path | `ensureEndsWithUser(nextMessages)` |
| summary-too-large fallback | `ensureEndsWithUser(takeLastTurns(...))` |
| catch/prune fallback | `ensureEndsWithUser(takeLastTurns(...))` |

Safety: never returns an empty array — falls back to original messages when all are assistant.

## Why Plan C over Plan B

Plan B (strip at LLM call site) had broader impact — affected every LLM call regardless of whether it was compact-related. Plan C fixes the actual source of the problem with minimal blast radius.

## Tests

- Build: ✅
- Tests: 15/15 ✅