### PR TITLE
canvas-workspace: inherit font on form elements

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -52,6 +52,13 @@ body {
   font-size: 14px;
 }
 
+button,
+input,
+select,
+textarea {
+  font-family: inherit;
+}
+
 @keyframes fadeIn {
   from { opacity: 0; }
   to { opacity: 1; }


### PR DESCRIPTION
Browser defaults do not propagate font-family into <button>, <input>, <select>, or <textarea>, which left the sidebar workspace items, the floating toolbar labels, and the Pulse Agent quick-action cards still rendering in system sans-serif after the global --font switch to SF Mono. Add a single global rule to opt those elements into inheritance so the SF Mono change reaches the whole UI.