### PR TITLE
Add primitive shape drawing tools (rect/ellipse) to canvas

### DIFF
--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -452,7 +452,7 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
           '- frame: { color?: string, label?: string }\n' +
           '- text: { textColor?: string, backgroundColor?: string, fontSize?: number }\n' +
           '- iframe: { url?: string, html?: string, prompt?: string, mode?: "url"|"html"|"ai" }\n' +
-          '- shape: { kind?: "rect"|"ellipse", fill?: string, stroke?: string, strokeWidth?: number }',
+          '- shape: { kind?: "rect"|"ellipse", fill?: string, stroke?: string, strokeWidth?: number, text?: string, textColor?: string, fontSize?: number }',
         ),
       }),
       execute: async (input) => {
@@ -558,6 +558,9 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
               fill: (extraData.fill as string) ?? '#E8EEF7',
               stroke: (extraData.stroke as string) ?? '#5B7CBF',
               strokeWidth: (extraData.strokeWidth as number) ?? 2,
+              text: (extraData.text as string) ?? (content || ''),
+              textColor: extraData.textColor as string | undefined,
+              fontSize: extraData.fontSize as number | undefined,
             };
             break;
           }
@@ -969,6 +972,9 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
         fill: z.string().optional().describe('Fill color (hex or "transparent"). Default "#E8EEF7".'),
         stroke: z.string().optional().describe('Stroke color (hex or "transparent"). Default "#5B7CBF".'),
         strokeWidth: z.number().optional().describe('Stroke width in px. Default 2. Set 0 for no stroke.'),
+        text: z.string().optional().describe('Optional label rendered centered inside the shape.'),
+        textColor: z.string().optional().describe('Text color (hex). Defaults to the stroke color when present.'),
+        fontSize: z.number().optional().describe('Text font size in px. Default 16.'),
       }),
       execute: async (input) => {
         const canvas = await loadCanvas(workspaceId);
@@ -997,6 +1003,9 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
             fill: (input.fill as string | undefined) ?? '#E8EEF7',
             stroke: (input.stroke as string | undefined) ?? '#5B7CBF',
             strokeWidth: (input.strokeWidth as number | undefined) ?? 2,
+            text: (input.text as string | undefined) ?? '',
+            textColor: input.textColor as string | undefined,
+            fontSize: input.fontSize as number | undefined,
           },
           updatedAt: Date.now(),
         };

--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -27,7 +27,7 @@ const STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
 
 // ─── Types mirrored from canvas-cli ────────────────────────────────
 
-type NodeType = 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe';
+type NodeType = 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe' | 'shape';
 
 interface CanvasNode {
   id: string;
@@ -83,6 +83,7 @@ const DEFAULT_DIMENSIONS: Record<NodeType, { title: string; width: number; heigh
   agent: { title: 'Agent', width: 520, height: 380 },
   text: { title: 'Text', width: 260, height: 120 },
   iframe: { title: 'Web', width: 520, height: 400 },
+  shape: { title: 'Shape', width: 200, height: 140 },
 };
 
 // ─── Helpers ───────────────────────────────────────────────────────
@@ -433,9 +434,13 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
         'For HTML mode: pass `data.html` with raw HTML content and `data.mode: "html"`. ' +
         'For AI mode: pass `data.prompt` with a description and `data.mode: "ai"` — ' +
         'the LLM will generate self-contained HTML. ' +
-        'Note: some sites block URL embedding via X-Frame-Options / CSP.',
+        'Note: some sites block URL embedding via X-Frame-Options / CSP.\n' +
+        '- **shape**: Draws a primitive geometric shape (rectangle or ellipse). ' +
+        'Use `data.kind` ("rect" | "ellipse"), `data.fill` / `data.stroke` (hex or "transparent"), ' +
+        'and `data.strokeWidth` (px). For precise sizing pass explicit `x`, `y`, and set width/height ' +
+        'via the dedicated `canvas_create_shape` tool — this generic one uses default dimensions.',
       inputSchema: z.object({
-        type: z.enum(['file', 'terminal', 'frame', 'agent', 'text', 'iframe']).describe('Node type.'),
+        type: z.enum(['file', 'terminal', 'frame', 'agent', 'text', 'iframe', 'shape']).describe('Node type.'),
         title: z.string().optional().describe('Node title.'),
         content: z.string().optional().describe('Initial content (for file and text nodes).'),
         x: z.number().optional().describe('X position (auto-placed if omitted).'),
@@ -446,7 +451,8 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
           '- agent: { agentType?: "claude-code"|"codex"|"pulse-coder", cwd?: string, status?: "idle"|"running", prompt?: string, agentArgs?: string }\n' +
           '- frame: { color?: string, label?: string }\n' +
           '- text: { textColor?: string, backgroundColor?: string, fontSize?: number }\n' +
-          '- iframe: { url?: string, html?: string, prompt?: string, mode?: "url"|"html"|"ai" }',
+          '- iframe: { url?: string, html?: string, prompt?: string, mode?: "url"|"html"|"ai" }\n' +
+          '- shape: { kind?: "rect"|"ellipse", fill?: string, stroke?: string, strokeWidth?: number }',
         ),
       }),
       execute: async (input) => {
@@ -542,6 +548,17 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
                 mode: iframeMode,
               };
             }
+            break;
+          }
+          case 'shape': {
+            const rawKind = extraData.kind as string | undefined;
+            const shapeKind = rawKind === 'ellipse' ? 'ellipse' : 'rect';
+            nodeData = {
+              kind: shapeKind,
+              fill: (extraData.fill as string) ?? '#E8EEF7',
+              stroke: (extraData.stroke as string) ?? '#5B7CBF',
+              strokeWidth: (extraData.strokeWidth as number) ?? 2,
+            };
             break;
           }
         }
@@ -928,6 +945,68 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
         broadcastUpdate(workspaceId, [nodeId]);
 
         return JSON.stringify({ ok: true, nodeId, title });
+      },
+    },
+
+    // ─── Dedicated shape node creation ──────────────────────────────
+
+    canvas_create_shape: {
+      name: 'canvas_create_shape',
+      description:
+        'Create a primitive geometric shape (rectangle or ellipse) on the canvas. ' +
+        'Shapes are visual-only annotations — they render as SVG primitives with configurable ' +
+        'fill, stroke, and stroke width. Use this for diagramming, highlighting regions, or ' +
+        'building simple layouts. ' +
+        'Pass explicit width/height for precise sizing; otherwise defaults to 200×140. ' +
+        'Colors accept hex strings (e.g. "#E8EEF7") or the literal string "transparent".',
+      inputSchema: z.object({
+        kind: z.enum(['rect', 'ellipse']).optional().describe('Shape primitive. Defaults to "rect".'),
+        title: z.string().optional().describe('Node title (used in the layers panel). Defaults to "Shape".'),
+        x: z.number().optional().describe('X position (canvas coords). Auto-placed if omitted.'),
+        y: z.number().optional().describe('Y position (canvas coords). Auto-placed if omitted.'),
+        width: z.number().optional().describe('Width in canvas-px. Default 200.'),
+        height: z.number().optional().describe('Height in canvas-px. Default 140.'),
+        fill: z.string().optional().describe('Fill color (hex or "transparent"). Default "#E8EEF7".'),
+        stroke: z.string().optional().describe('Stroke color (hex or "transparent"). Default "#5B7CBF".'),
+        strokeWidth: z.number().optional().describe('Stroke width in px. Default 2. Set 0 for no stroke.'),
+      }),
+      execute: async (input) => {
+        const canvas = await loadCanvas(workspaceId);
+        if (!canvas) return 'Error: workspace not found';
+
+        const kind = (input.kind as 'rect' | 'ellipse' | undefined) ?? 'rect';
+        const title = (input.title as string) ?? DEFAULT_DIMENSIONS.shape.title;
+        const width = (input.width as number | undefined) ?? DEFAULT_DIMENSIONS.shape.width;
+        const height = (input.height as number | undefined) ?? DEFAULT_DIMENSIONS.shape.height;
+
+        const nodeId = `node-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const pos = (input.x != null && input.y != null)
+          ? { x: input.x as number, y: input.y as number }
+          : autoPlace(canvas.nodes);
+
+        const newNode: CanvasNode = {
+          id: nodeId,
+          type: 'shape',
+          title,
+          x: pos.x,
+          y: pos.y,
+          width,
+          height,
+          data: {
+            kind,
+            fill: (input.fill as string | undefined) ?? '#E8EEF7',
+            stroke: (input.stroke as string | undefined) ?? '#5B7CBF',
+            strokeWidth: (input.strokeWidth as number | undefined) ?? 2,
+          },
+          updatedAt: Date.now(),
+        };
+
+        const fresh = (await loadCanvas(workspaceId)) ?? canvas;
+        fresh.nodes.push(newNode);
+        await saveCanvas(workspaceId, fresh);
+        broadcastUpdate(workspaceId, [nodeId]);
+
+        return JSON.stringify({ ok: true, nodeId, kind, title });
       },
     },
 

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
@@ -31,6 +31,11 @@ interface CanvasOverlaysProps {
   /** Mousedown handler for the connect-mode overlay. Wired by the
    *  parent Canvas component to the edge interaction hook. */
   onConnectMouseDown?: (e: React.MouseEvent) => void;
+  /** True whenever the user has picked one of the shape-draw tools
+   *  (shape-rect / shape-ellipse). Drives the draw overlay. */
+  shapeToolActive?: boolean;
+  /** Mousedown handler for the shape-draw overlay. */
+  onShapeMouseDown?: (e: React.MouseEvent) => void;
   /** Currently-selected edge (full object) — null when none or the
    *  selection refers to a node. The overlays layer uses it to render
    *  the floating EdgeStylePanel. */
@@ -67,6 +72,8 @@ export const CanvasOverlays = ({
   onSearchSelect,
   onCloseSearch,
   onConnectMouseDown,
+  shapeToolActive,
+  onShapeMouseDown,
   selectedEdge,
   transform,
   onUpdateEdge,
@@ -108,6 +115,22 @@ export const CanvasOverlays = ({
           zIndex: 5,
         }}
         onMouseDown={onConnectMouseDown}
+      />
+    )}
+
+    {/* Drag-to-draw overlay for shape tools. Same layering trick as the
+        connect overlay so a drag that starts over an existing node still
+        creates a shape rather than selecting the node underneath. */}
+    {shapeToolActive && (
+      <div
+        className="canvas-shape-overlay"
+        style={{
+          position: 'absolute',
+          inset: 0,
+          cursor: 'crosshair',
+          zIndex: 5,
+        }}
+        onMouseDown={onShapeMouseDown}
       />
     )}
 

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
@@ -4,6 +4,7 @@ import { CanvasNodeView } from '../CanvasNodeView';
 import { CanvasEdgesLayer } from '../CanvasEdgesLayer';
 import type { ResizeEdge } from '../../hooks/useNodeResize';
 import type { EdgeInteractionState, Point } from '../../hooks/useEdgeInteraction';
+import type { ShapeDraft } from '../../hooks/useShapeDraw';
 
 interface CanvasSurfaceProps {
   transform: { x: number; y: number; scale: number };
@@ -36,6 +37,9 @@ interface CanvasSurfaceProps {
   /** Preview endpoints resolved by the interaction hook. Null when no
    *  connect/move-end drag is in flight. */
   edgePreviewEndpoints: { s: Point; t: Point } | null;
+  /** Live shape-draw draft. Null unless the user is currently dragging
+   *  out a new shape. */
+  shapeDraft?: ShapeDraft | null;
   onDragStart: (e: React.MouseEvent, node: CanvasNode) => void;
   onResizeStart: (
     e: React.MouseEvent,
@@ -83,6 +87,7 @@ export const CanvasSurface = ({
   externallyEditedIds,
   edgeInteractionState,
   edgePreviewEndpoints,
+  shapeDraft,
   onDragStart,
   onResizeStart,
   onUpdate,
@@ -139,5 +144,34 @@ export const CanvasSurface = ({
         onFocus={onFocus}
       />
     ))}
+    {shapeDraft && <ShapeDraftPreview draft={shapeDraft} />}
   </div>
 );
+
+/**
+ * Dashed outline shown while the user drags out a new shape. Lives inside
+ * `.canvas-transform`, so canvas coords render correctly at any zoom/pan.
+ * Pointer events are disabled so the overlay above it still receives the
+ * ongoing mousemove/mouseup.
+ */
+const ShapeDraftPreview = ({ draft }: { draft: ShapeDraft }) => {
+  const x = Math.min(draft.start.x, draft.current.x);
+  const y = Math.min(draft.start.y, draft.current.y);
+  const w = Math.abs(draft.current.x - draft.start.x);
+  const h = Math.abs(draft.current.y - draft.start.y);
+  const common: React.CSSProperties = {
+    position: 'absolute',
+    left: x,
+    top: y,
+    width: w,
+    height: h,
+    border: '1.5px dashed #5B7CBF',
+    background: 'rgba(91, 124, 191, 0.08)',
+    pointerEvents: 'none',
+    boxSizing: 'border-box',
+  };
+  if (draft.kind === 'ellipse') {
+    common.borderRadius = '50%';
+  }
+  return <div className="shape-draft-preview" style={common} />;
+};

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.css
@@ -18,6 +18,10 @@
   cursor: nwse-resize;
 }
 
+.canvas-container--shape {
+  cursor: crosshair;
+}
+
 .canvas-grid {
   position: absolute;
   inset: 0;

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -9,6 +9,7 @@ import { useCanvasFit } from '../../hooks/useCanvasFit';
 import { useCanvasKeyboard } from '../../hooks/useCanvasKeyboard';
 import { useCanvasImagePaste } from '../../hooks/useCanvasImagePaste';
 import { useEdgeInteraction } from '../../hooks/useEdgeInteraction';
+import { useShapeDraw } from '../../hooks/useShapeDraw';
 import type { CanvasNode } from '../../types';
 import { computeFrameDepths } from '../../utils/frameHierarchy';
 import { CanvasSurface } from './CanvasSurface';
@@ -242,6 +243,25 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
     [beginConnect],
   );
 
+  const {
+    draft: shapeDraft,
+    handleOverlayMouseDown: handleShapeOverlayMouseDown,
+    isActive: shapeToolActive,
+  } = useShapeDraw({
+    activeTool,
+    screenToCanvas,
+    getContainer,
+    addNode,
+    updateNode,
+    // Drop back to the select tool and select the committed shape so the
+    // user can immediately restyle it via the ShapeStylePicker.
+    onCommitted: (node) => {
+      setActiveTool('select');
+      setSelectedNodeIds([node.id]);
+      setSelectedEdgeId(null);
+    },
+  });
+
   const handleEdgeBodyMouseDown = useCallback(
     (edgeId: string, e: React.MouseEvent) => {
       if (e.button !== 0) return;
@@ -280,7 +300,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
   const isBlankCanvasTarget = useCallback((target: EventTarget | null) => {
     if (!(target instanceof HTMLElement)) return false;
     return !target.closest(
-      '.canvas-node, .floating-toolbar, .zoom-indicator, .context-menu, .canvas-edges, .canvas-connect-overlay, .edge-style-panel',
+      '.canvas-node, .floating-toolbar, .zoom-indicator, .context-menu, .canvas-edges, .canvas-connect-overlay, .canvas-shape-overlay, .edge-style-panel',
     );
   }, []);
 
@@ -376,6 +396,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
 
   const cursorClass = activeTool === 'hand'
     ? ' canvas-container--hand'
+    : shapeToolActive ? ' canvas-container--shape'
     : resizingId ? ' canvas-container--resizing' : '';
 
   if (!loaded) {
@@ -423,6 +444,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
         externallyEditedIds={externallyEditedIds}
         edgeInteractionState={edgeInteractionState}
         edgePreviewEndpoints={getPreviewEndpoints()}
+        shapeDraft={shapeDraft}
         onDragStart={onDragStart}
         onResizeStart={onResizeStart}
         onUpdate={updateNode}
@@ -457,6 +479,8 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
         onSearchSelect={handleSearchSelect}
         onCloseSearch={() => setSearchOpen(false)}
         onConnectMouseDown={handleConnectOverlayMouseDown}
+        shapeToolActive={shapeToolActive}
+        onShapeMouseDown={handleShapeOverlayMouseDown}
         selectedEdge={edges.find((e) => e.id === selectedEdgeId) ?? null}
         transform={transform}
         onUpdateEdge={(id, patch) => {

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -249,6 +249,36 @@
   height: 100%;
 }
 
+/* Shape nodes: chromeless like images, but we do keep the hover/selection
+ * outline so the user can still see the hit box for a transparent shape. */
+.canvas-node--shape {
+  background: transparent;
+  border: 1px solid transparent;
+  box-shadow: none;
+  overflow: visible; /* let the ShapeStylePicker poke out above */
+}
+
+.canvas-node--shape:hover {
+  border-color: rgba(0, 0, 0, 0.1);
+  box-shadow: none;
+}
+
+.canvas-node--shape.canvas-node--selected {
+  border-color: var(--accent-border);
+  box-shadow: 0 0 0 2px rgba(35, 131, 226, 0.12);
+}
+
+.canvas-node--shape.canvas-node--dragging,
+.canvas-node--shape.canvas-node--resizing {
+  box-shadow: var(--shadow-drag);
+}
+
+.node-body--shape {
+  padding: 0;
+  height: 100%;
+  overflow: visible;
+}
+
 .node-close--floating {
   position: absolute;
   top: 4px;

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -181,7 +181,13 @@ export const CanvasNodeView = ({
         onClick={handleNodeClick}
       >
         <div className="node-body node-body--shape" onMouseDown={(e) => e.stopPropagation()}>
-          <ShapeNodeBody node={node} onSelect={onSelect} onDragStart={onDragStart} />
+          <ShapeNodeBody
+            node={node}
+            isSelected={isSelected}
+            onSelect={onSelect}
+            onDragStart={onDragStart}
+            onUpdate={onUpdate}
+          />
         </div>
         {isSelected && <ShapeStylePicker node={node} onUpdate={onUpdate} />}
         <button className="node-close node-close--floating" onClick={handleClose} title="Remove">

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -9,6 +9,7 @@ import { AgentNodeBody } from "../AgentNodeBody";
 import { TextNodeBody, TextColorPicker } from "../TextNodeBody";
 import { IframeNodeBody } from "../IframeNodeBody";
 import { ImageNodeBody } from "../ImageNodeBody";
+import { ShapeNodeBody, ShapeStylePicker } from "../ShapeNodeBody";
 
 interface Props {
   node: CanvasNode;
@@ -147,6 +148,42 @@ export const CanvasNodeView = ({
         <div className="node-body node-body--image" onMouseDown={(e) => e.stopPropagation()}>
           <ImageNodeBody node={node} onSelect={onSelect} onDragStart={onDragStart} />
         </div>
+        <button className="node-close node-close--floating" onClick={handleClose} title="Remove">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <path d="M3 3l6 6M9 3l-6 6" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+          </svg>
+        </button>
+        <div
+          className="resize-handle resize-handle--right"
+          onMouseDown={makeResizeHandler("right")}
+        />
+        <div
+          className="resize-handle resize-handle--bottom"
+          onMouseDown={makeResizeHandler("bottom")}
+        />
+        <div
+          className="resize-handle resize-handle--corner"
+          onMouseDown={makeResizeHandler("bottom-right")}
+        />
+      </div>
+    );
+  }
+
+  if (node.type === "shape") {
+    return (
+      <div
+        className={classes}
+        style={{
+          transform: `translate(${node.x}px, ${node.y}px)`,
+          width: node.width,
+          height: node.height,
+        }}
+        onClick={handleNodeClick}
+      >
+        <div className="node-body node-body--shape" onMouseDown={(e) => e.stopPropagation()}>
+          <ShapeNodeBody node={node} onSelect={onSelect} onDragStart={onDragStart} />
+        </div>
+        {isSelected && <ShapeStylePicker node={node} onUpdate={onUpdate} />}
         <button className="node-close node-close--floating" onClick={handleClose} title="Remove">
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
             <path d="M3 3l6 6M9 3l-6 6" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
@@ -53,6 +53,27 @@ const tools = [
         />
       </svg>
     )
+  },
+  {
+    id: "shape-rect",
+    label: "Rectangle (drag to draw)",
+    icon: (
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+        <rect
+          x="3" y="4" width="12" height="10" rx="1"
+          stroke="currentColor" strokeWidth="1.4"
+        />
+      </svg>
+    )
+  },
+  {
+    id: "shape-ellipse",
+    label: "Ellipse (drag to draw)",
+    icon: (
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+        <ellipse cx="9" cy="9" rx="6" ry="4.5" stroke="currentColor" strokeWidth="1.4" />
+      </svg>
+    )
   }
 ];
 

--- a/apps/canvas-workspace/src/renderer/src/components/ShapeNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ShapeNodeBody/index.css
@@ -14,20 +14,28 @@
   pointer-events: none;
 }
 
-/* Centered text overlay. Non-editing: pointer-events:none so drags on
- * the label still start a shape drag. Editing: pointer-events:auto so
- * the caret can be positioned and selections made. */
-.shape-node-text {
+/* Outer wrapper is the flex container that centers the inner text
+ * block on both axes. We keep the contenteditable off this element —
+ * when contenteditable sits directly on a flex container the browser
+ * generates anonymous line boxes that ignore align-items, which breaks
+ * vertical centering as soon as the user starts typing. */
+.shape-node-text-wrap {
   position: absolute;
   inset: 0;
   display: flex;
   align-items: center;
   justify-content: center;
+  overflow: hidden;
+  box-sizing: border-box;
+  pointer-events: none;
+}
+
+.shape-node-text {
+  max-width: 100%;
+  max-height: 100%;
   text-align: center;
   white-space: pre-wrap;
   word-break: break-word;
-  overflow: hidden;
-  box-sizing: border-box;
   line-height: 1.3;
   font-weight: 500;
   letter-spacing: -0.005em;
@@ -42,18 +50,11 @@
   cursor: text;
 }
 
-.shape-node-text--empty::before {
+.shape-node-text-wrap--empty .shape-node-text::before {
   content: 'Double-click to add text';
   color: currentColor;
   opacity: 0.35;
   font-weight: 400;
-}
-
-/* Hide the placeholder as soon as the user is editing or has typed
- * something — the placeholder is a purely pre-edit hint. */
-.shape-node-text--editing.shape-node-text--empty::before,
-.shape-node-text:not(.shape-node-text--empty)::before {
-  content: none;
 }
 
 /* ---- Style picker ---- */

--- a/apps/canvas-workspace/src/renderer/src/components/ShapeNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ShapeNodeBody/index.css
@@ -1,4 +1,5 @@
 .shape-node-body {
+  position: relative;
   width: 100%;
   height: 100%;
   cursor: move;
@@ -11,6 +12,48 @@
   height: 100%;
   overflow: visible;
   pointer-events: none;
+}
+
+/* Centered text overlay. Non-editing: pointer-events:none so drags on
+ * the label still start a shape drag. Editing: pointer-events:auto so
+ * the caret can be positioned and selections made. */
+.shape-node-text {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow: hidden;
+  box-sizing: border-box;
+  line-height: 1.3;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  pointer-events: none;
+  user-select: none;
+  outline: none;
+}
+
+.shape-node-text--editing {
+  pointer-events: auto;
+  user-select: text;
+  cursor: text;
+}
+
+.shape-node-text--empty::before {
+  content: 'Double-click to add text';
+  color: currentColor;
+  opacity: 0.35;
+  font-weight: 400;
+}
+
+/* Hide the placeholder as soon as the user is editing or has typed
+ * something — the placeholder is a purely pre-edit hint. */
+.shape-node-text--editing.shape-node-text--empty::before,
+.shape-node-text:not(.shape-node-text--empty)::before {
+  content: none;
 }
 
 /* ---- Style picker ---- */

--- a/apps/canvas-workspace/src/renderer/src/components/ShapeNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ShapeNodeBody/index.css
@@ -1,0 +1,154 @@
+.shape-node-body {
+  width: 100%;
+  height: 100%;
+  cursor: move;
+  display: block;
+}
+
+.shape-node-svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+  pointer-events: none;
+}
+
+/* ---- Style picker ---- */
+
+.shape-style-trigger {
+  position: absolute;
+  top: -34px;
+  left: 0;
+  z-index: 20;
+}
+
+.shape-style-preview {
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.shape-style-preview:hover {
+  border-color: rgba(0, 0, 0, 0.2);
+}
+
+.shape-style-swatch {
+  display: block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid;
+  box-sizing: border-box;
+}
+
+.shape-style-popover {
+  position: absolute;
+  top: 32px;
+  left: 0;
+  min-width: 240px;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: var(--surface, #ffffff);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 8px;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.12);
+}
+
+.shape-style-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.shape-style-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted, #6e7681);
+}
+
+.shape-style-swatches {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.shape-style-swatch-btn {
+  position: relative;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+}
+
+.shape-style-swatch-btn:hover {
+  transform: scale(1.1);
+}
+
+.shape-style-swatch-btn--active {
+  outline: 2px solid var(--accent, #2383e2);
+  outline-offset: 1px;
+}
+
+.shape-style-widths {
+  display: flex;
+  gap: 5px;
+}
+
+.shape-style-width-btn {
+  width: 32px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 4px;
+  background: #fff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.shape-style-width-btn:hover {
+  border-color: rgba(0, 0, 0, 0.25);
+}
+
+.shape-style-width-btn--active {
+  outline: 2px solid var(--accent, #2383e2);
+  outline-offset: 1px;
+}
+
+.shape-style-width-bar {
+  display: block;
+  width: 20px;
+  background: #1f2328;
+  border-radius: 1px;
+}
+
+.shape-style-none-slash {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 1.5px;
+  background: #d7402b;
+  transform: rotate(-45deg);
+}
+
+.shape-style-none-slash--inline {
+  position: static;
+  width: 16px;
+  transform: rotate(-45deg);
+}

--- a/apps/canvas-workspace/src/renderer/src/components/ShapeNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ShapeNodeBody/index.tsx
@@ -1,40 +1,139 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import './index.css';
 import type { CanvasNode, ShapeNodeData } from '../../types';
 
 interface Props {
   node: CanvasNode;
+  isSelected: boolean;
   onSelect: (id: string) => void;
   onDragStart: (e: React.MouseEvent, node: CanvasNode) => void;
+  onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
 }
 
 /**
  * Shape node body. Renders a single SVG primitive (rect or ellipse) that
- * fills the node box. The entire surface is a drag handle, mirroring the
- * chromeless image/text bodies.
+ * fills the node box, plus an optional centered text label overlaid on
+ * top. The entire surface is a drag handle, mirroring the chromeless
+ * image/text bodies.
  *
  * The stroke is drawn inside the viewport by insetting the geometry by
  * half the stroke width — without the inset, SVG centers the stroke on
  * the edge so half of it clips outside the node bounds.
+ *
+ * Text editing: double-click enters edit mode; Escape or blur commits.
+ * While editing, the contenteditable div captures pointer events so the
+ * user can click-to-position the caret without starting a drag.
  */
-export const ShapeNodeBody = ({ node, onSelect, onDragStart }: Props) => {
+export const ShapeNodeBody = ({ node, isSelected, onSelect, onDragStart, onUpdate }: Props) => {
   const data = node.data as ShapeNodeData;
+  const [editing, setEditing] = useState(false);
+  const editorRef = useRef<HTMLDivElement>(null);
+  // Sync the editor's DOM text back to React state only on commit — while
+  // editing we let the browser own the DOM so the caret doesn't jump on
+  // every keystroke.
+  const initialTextRef = useRef<string>(data.text ?? '');
 
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {
+      if (editing) return;
       onSelect(node.id);
       onDragStart(e, node);
     },
-    [node, onSelect, onDragStart],
+    [editing, node, onSelect, onDragStart],
+  );
+
+  const handleDoubleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      initialTextRef.current = data.text ?? '';
+      setEditing(true);
+    },
+    [data.text],
+  );
+
+  const commit = useCallback(() => {
+    const el = editorRef.current;
+    if (!el) {
+      setEditing(false);
+      return;
+    }
+    const next = el.innerText.replace(/\n+$/, '');
+    setEditing(false);
+    if (next !== (data.text ?? '')) {
+      onUpdate(node.id, { data: { ...data, text: next } });
+    }
+  }, [data, node.id, onUpdate]);
+
+  const cancel = useCallback(() => {
+    // Restore the pre-edit text and exit without saving.
+    const el = editorRef.current;
+    if (el) el.innerText = initialTextRef.current;
+    setEditing(false);
+  }, []);
+
+  // Auto-focus and select-all when entering edit mode so the user can
+  // immediately type a replacement or extend existing text.
+  useLayoutEffect(() => {
+    if (!editing) return;
+    const el = editorRef.current;
+    if (!el) return;
+    el.focus();
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    const sel = window.getSelection();
+    if (sel) {
+      sel.removeAllRanges();
+      sel.addRange(range);
+    }
+  }, [editing]);
+
+  // When a non-editing update arrives from elsewhere (undo, canvas-agent),
+  // keep the DOM text in sync with the stored value.
+  useEffect(() => {
+    if (editing) return;
+    const el = editorRef.current;
+    if (el && el.innerText !== (data.text ?? '')) {
+      el.innerText = data.text ?? '';
+    }
+  }, [data.text, editing]);
+
+  // Leaving selection should exit edit mode — otherwise the node can get
+  // stuck in an "editing but not selected" state that the user can't see.
+  useEffect(() => {
+    if (editing && !isSelected) commit();
+  }, [editing, isSelected, commit]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        cancel();
+      } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+        // Cmd/Ctrl+Enter commits; plain Enter inserts a newline.
+        e.preventDefault();
+        commit();
+      }
+    },
+    [cancel, commit],
   );
 
   const w = Math.max(1, node.width);
   const h = Math.max(1, node.height);
   const sw = Math.max(0, data.strokeWidth ?? 0);
   const inset = sw / 2;
+  const fontSize = data.fontSize ?? 16;
+  const textColor =
+    data.textColor ??
+    (data.stroke && data.stroke !== 'transparent' ? data.stroke : '#1f2328');
+  // Pad the text so it doesn't crowd the shape outline. For ellipses the
+  // inscribed rectangle is (w·cos45, h·sin45) — ~70% of the bounding box —
+  // so we pull the label in harder on curved shapes.
+  const padRatio = data.kind === 'ellipse' ? 0.15 : 0.08;
+  const padX = Math.max(8, Math.round(w * padRatio));
+  const padY = Math.max(6, Math.round(h * padRatio));
 
   return (
-    <div className="shape-node-body" onMouseDown={handleMouseDown}>
+    <div className="shape-node-body" onMouseDown={handleMouseDown} onDoubleClick={handleDoubleClick}>
       <svg
         className="shape-node-svg"
         width="100%"
@@ -64,6 +163,28 @@ export const ShapeNodeBody = ({ node, onSelect, onDragStart }: Props) => {
           />
         )}
       </svg>
+      <div
+        ref={editorRef}
+        className={`shape-node-text${editing ? ' shape-node-text--editing' : ''}${!data.text && !editing ? ' shape-node-text--empty' : ''}`}
+        style={{
+          color: textColor,
+          fontSize,
+          paddingLeft: padX,
+          paddingRight: padX,
+          paddingTop: padY,
+          paddingBottom: padY,
+        }}
+        contentEditable={editing}
+        suppressContentEditableWarning
+        spellCheck={false}
+        onMouseDown={(e) => {
+          if (editing) e.stopPropagation();
+        }}
+        onBlur={commit}
+        onKeyDown={handleKeyDown}
+      >
+        {data.text ?? ''}
+      </div>
     </div>
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/components/ShapeNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ShapeNodeBody/index.tsx
@@ -164,26 +164,29 @@ export const ShapeNodeBody = ({ node, isSelected, onSelect, onDragStart, onUpdat
         )}
       </svg>
       <div
-        ref={editorRef}
-        className={`shape-node-text${editing ? ' shape-node-text--editing' : ''}${!data.text && !editing ? ' shape-node-text--empty' : ''}`}
+        className={`shape-node-text-wrap${!data.text && !editing ? ' shape-node-text-wrap--empty' : ''}`}
         style={{
-          color: textColor,
-          fontSize,
           paddingLeft: padX,
           paddingRight: padX,
           paddingTop: padY,
           paddingBottom: padY,
         }}
-        contentEditable={editing}
-        suppressContentEditableWarning
-        spellCheck={false}
-        onMouseDown={(e) => {
-          if (editing) e.stopPropagation();
-        }}
-        onBlur={commit}
-        onKeyDown={handleKeyDown}
       >
-        {data.text ?? ''}
+        <div
+          ref={editorRef}
+          className={`shape-node-text${editing ? ' shape-node-text--editing' : ''}`}
+          style={{ color: textColor, fontSize }}
+          contentEditable={editing}
+          suppressContentEditableWarning
+          spellCheck={false}
+          onMouseDown={(e) => {
+            if (editing) e.stopPropagation();
+          }}
+          onBlur={commit}
+          onKeyDown={handleKeyDown}
+        >
+          {data.text ?? ''}
+        </div>
       </div>
     </div>
   );

--- a/apps/canvas-workspace/src/renderer/src/components/ShapeNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ShapeNodeBody/index.tsx
@@ -1,0 +1,218 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import './index.css';
+import type { CanvasNode, ShapeNodeData } from '../../types';
+
+interface Props {
+  node: CanvasNode;
+  onSelect: (id: string) => void;
+  onDragStart: (e: React.MouseEvent, node: CanvasNode) => void;
+}
+
+/**
+ * Shape node body. Renders a single SVG primitive (rect or ellipse) that
+ * fills the node box. The entire surface is a drag handle, mirroring the
+ * chromeless image/text bodies.
+ *
+ * The stroke is drawn inside the viewport by insetting the geometry by
+ * half the stroke width — without the inset, SVG centers the stroke on
+ * the edge so half of it clips outside the node bounds.
+ */
+export const ShapeNodeBody = ({ node, onSelect, onDragStart }: Props) => {
+  const data = node.data as ShapeNodeData;
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      onSelect(node.id);
+      onDragStart(e, node);
+    },
+    [node, onSelect, onDragStart],
+  );
+
+  const w = Math.max(1, node.width);
+  const h = Math.max(1, node.height);
+  const sw = Math.max(0, data.strokeWidth ?? 0);
+  const inset = sw / 2;
+
+  return (
+    <div className="shape-node-body" onMouseDown={handleMouseDown}>
+      <svg
+        className="shape-node-svg"
+        width="100%"
+        height="100%"
+        viewBox={`0 0 ${w} ${h}`}
+        preserveAspectRatio="none"
+      >
+        {data.kind === 'ellipse' ? (
+          <ellipse
+            cx={w / 2}
+            cy={h / 2}
+            rx={Math.max(0, w / 2 - inset)}
+            ry={Math.max(0, h / 2 - inset)}
+            fill={data.fill}
+            stroke={data.stroke}
+            strokeWidth={sw}
+          />
+        ) : (
+          <rect
+            x={inset}
+            y={inset}
+            width={Math.max(0, w - sw)}
+            height={Math.max(0, h - sw)}
+            fill={data.fill}
+            stroke={data.stroke}
+            strokeWidth={sw}
+          />
+        )}
+      </svg>
+    </div>
+  );
+};
+
+/* ---- Style picker (floating palette for selected shape) ---- */
+
+const FILL_PRESETS: Array<{ name: string; value: string }> = [
+  { name: 'Transparent', value: 'transparent' },
+  { name: 'White', value: '#FFFFFF' },
+  { name: 'Slate', value: '#E8EEF7' },
+  { name: 'Red', value: '#FAD4CF' },
+  { name: 'Orange', value: '#FADFC1' },
+  { name: 'Yellow', value: '#F7EBC0' },
+  { name: 'Green', value: '#CFE7D9' },
+  { name: 'Teal', value: '#C9E5E8' },
+  { name: 'Blue', value: '#CFDDF3' },
+  { name: 'Purple', value: '#D9D0EE' },
+  { name: 'Pink', value: '#F2D0E0' },
+  { name: 'Gray', value: '#D9DCE2' },
+];
+
+const STROKE_PRESETS: Array<{ name: string; value: string }> = [
+  { name: 'None', value: 'transparent' },
+  { name: 'Black', value: '#1F2328' },
+  { name: 'Gray', value: '#6E7681' },
+  { name: 'Red', value: '#D7402B' },
+  { name: 'Orange', value: '#D97A1F' },
+  { name: 'Yellow', value: '#C9A31A' },
+  { name: 'Green', value: '#2F8F5A' },
+  { name: 'Teal', value: '#2E8A94' },
+  { name: 'Blue', value: '#5B7CBF' },
+  { name: 'Purple', value: '#7957C4' },
+  { name: 'Pink', value: '#C94F8C' },
+];
+
+const STROKE_WIDTHS: number[] = [0, 1, 2, 4, 6];
+
+interface StylePickerProps {
+  node: CanvasNode;
+  onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
+}
+
+export const ShapeStylePicker = ({ node, onUpdate }: StylePickerProps) => {
+  const data = node.data as ShapeNodeData;
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handle = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handle);
+    return () => document.removeEventListener('mousedown', handle);
+  }, [open]);
+
+  const patch = useCallback(
+    (next: Partial<ShapeNodeData>) => {
+      onUpdate(node.id, { data: { ...data, ...next } });
+    },
+    [data, node.id, onUpdate],
+  );
+
+  return (
+    <div
+      ref={rootRef}
+      className={`shape-style-trigger${open ? ' shape-style-trigger--open' : ''}`}
+      onMouseDown={(e) => e.stopPropagation()}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <button
+        className="shape-style-preview"
+        title="Shape style"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span
+          className="shape-style-swatch"
+          style={{
+            background: data.fill === 'transparent' ? 'none' : data.fill,
+            borderColor: data.stroke === 'transparent' ? 'rgba(0,0,0,0.15)' : data.stroke,
+            borderStyle: data.fill === 'transparent' ? 'dashed' : 'solid',
+            borderRadius: data.kind === 'ellipse' ? '50%' : '3px',
+          }}
+        />
+      </button>
+      {open && (
+        <div className="shape-style-popover">
+          <div className="shape-style-row">
+            <span className="shape-style-label">Fill</span>
+            <div className="shape-style-swatches">
+              {FILL_PRESETS.map((p) => (
+                <button
+                  key={p.name}
+                  className={`shape-style-swatch-btn${data.fill === p.value ? ' shape-style-swatch-btn--active' : ''}`}
+                  title={p.name}
+                  style={{
+                    background: p.value === 'transparent' ? 'none' : p.value,
+                  }}
+                  onClick={() => patch({ fill: p.value })}
+                >
+                  {p.value === 'transparent' && <span className="shape-style-none-slash" />}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="shape-style-row">
+            <span className="shape-style-label">Stroke</span>
+            <div className="shape-style-swatches">
+              {STROKE_PRESETS.map((p) => (
+                <button
+                  key={p.name}
+                  className={`shape-style-swatch-btn${data.stroke === p.value ? ' shape-style-swatch-btn--active' : ''}`}
+                  title={p.name}
+                  style={{
+                    background: p.value === 'transparent' ? 'none' : p.value,
+                  }}
+                  onClick={() => patch({ stroke: p.value })}
+                >
+                  {p.value === 'transparent' && <span className="shape-style-none-slash" />}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="shape-style-row">
+            <span className="shape-style-label">Width</span>
+            <div className="shape-style-widths">
+              {STROKE_WIDTHS.map((w) => (
+                <button
+                  key={w}
+                  className={`shape-style-width-btn${data.strokeWidth === w ? ' shape-style-width-btn--active' : ''}`}
+                  title={`${w}px`}
+                  onClick={() => patch({ strokeWidth: w })}
+                >
+                  {w === 0 ? (
+                    <span className="shape-style-none-slash shape-style-none-slash--inline" />
+                  ) : (
+                    <span
+                      className="shape-style-width-bar"
+                      style={{ height: Math.max(1, w) }}
+                    />
+                  )}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
@@ -7,6 +7,7 @@ import type {
   FileNodeData,
   FrameNodeData,
   ImageNodeData,
+  ShapeNodeData,
   TextNodeData,
 } from '../types';
 import { createDefaultNode, createNodeData, genId } from '../utils/nodeFactory';
@@ -426,7 +427,9 @@ export const useNodes = (
             ? { ...(source.data as TextNodeData) }
             : source.type === 'image'
               ? { ...(source.data as ImageNodeData) }
-              : createNodeData(source.type),
+              : source.type === 'shape'
+                ? { ...(source.data as ShapeNodeData) }
+                : createNodeData(source.type),
         updatedAt: Date.now(),
       };
       if (newNode.type === 'file') {
@@ -469,7 +472,9 @@ export const useNodes = (
             ? { ...(source.data as TextNodeData) }
             : source.type === 'image'
               ? { ...(source.data as ImageNodeData) }
-              : createNodeData(source.type),
+              : source.type === 'shape'
+                ? { ...(source.data as ShapeNodeData) }
+                : createNodeData(source.type),
         updatedAt: now,
       }));
       newNodes.forEach((newNode) => {

--- a/apps/canvas-workspace/src/renderer/src/hooks/useShapeDraw.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useShapeDraw.ts
@@ -1,0 +1,158 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { CanvasNode, ShapeNodeData } from '../types';
+
+type Point = { x: number; y: number };
+
+export type ShapeKind = 'rect' | 'ellipse';
+
+export type ShapeDraft = {
+  kind: ShapeKind;
+  start: Point;
+  current: Point;
+};
+
+/** Minimum diagonal distance (canvas-px) before we commit a drag-drawn
+ *  shape. A click that doesn't move past this threshold is treated as
+ *  an accidental click and discarded. */
+const DRAG_MIN_DISTANCE = 4;
+
+/** Minimum shape dimension (canvas-px) when the user clicks or only
+ *  drags a tiny distance and then lets go. */
+const MIN_DIM = 40;
+
+interface UseShapeDrawOptions {
+  activeTool: string;
+  screenToCanvas: (x: number, y: number, el: HTMLElement) => Point;
+  getContainer: () => HTMLElement | null;
+  addNode: (type: CanvasNode['type'], x: number, y: number) => CanvasNode;
+  updateNode: (id: string, patch: Partial<CanvasNode>) => void;
+  onCommitted: (node: CanvasNode) => void;
+}
+
+/**
+ * Drag-to-draw primitive shapes. Activates whenever `activeTool` is
+ * "shape-rect" or "shape-ellipse".
+ *
+ * Flow:
+ *   mousedown on overlay  → start draft (no node yet)
+ *   mousemove             → extend draft, render preview overlay
+ *   mouseup               → commit a real shape node, revert to select tool
+ *
+ * The preview is purely local state; we do not create a node until the
+ * user releases the mouse. This keeps undo/redo clean: one shape per
+ * committed drag, not one-plus-many-resize entries.
+ */
+export const useShapeDraw = ({
+  activeTool,
+  screenToCanvas,
+  getContainer,
+  addNode,
+  updateNode,
+  onCommitted,
+}: UseShapeDrawOptions) => {
+  const [draft, setDraft] = useState<ShapeDraft | null>(null);
+  const draftRef = useRef<ShapeDraft | null>(null);
+  draftRef.current = draft;
+
+  const kindFromTool = useCallback((): ShapeKind | null => {
+    if (activeTool === 'shape-rect') return 'rect';
+    if (activeTool === 'shape-ellipse') return 'ellipse';
+    return null;
+  }, [activeTool]);
+
+  // Document-level listeners so a drag that leaves the overlay doesn't
+  // get stuck — matches useEdgeInteraction's pattern.
+  useEffect(() => {
+    if (!draft) return;
+    const handleMove = (e: MouseEvent) => {
+      const el = getContainer();
+      if (!el) return;
+      const cur = screenToCanvas(e.clientX, e.clientY, el);
+      setDraft((prev) => (prev ? { ...prev, current: cur } : prev));
+    };
+    const handleUp = () => {
+      const d = draftRef.current;
+      if (!d) {
+        setDraft(null);
+        return;
+      }
+      commitDraft(d);
+      setDraft(null);
+    };
+    window.addEventListener('mousemove', handleMove);
+    window.addEventListener('mouseup', handleUp);
+    return () => {
+      window.removeEventListener('mousemove', handleMove);
+      window.removeEventListener('mouseup', handleUp);
+    };
+    // commitDraft is stable via the closed-over deps below
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draft, getContainer, screenToCanvas]);
+
+  const commitDraft = useCallback(
+    (d: ShapeDraft) => {
+      const dx = d.current.x - d.start.x;
+      const dy = d.current.y - d.start.y;
+      const dist = Math.hypot(dx, dy);
+
+      // Compute the bounding box. Swapping sign handles drags in any
+      // direction (top-left → bottom-right, bottom-right → top-left, etc).
+      let x = Math.min(d.start.x, d.current.x);
+      let y = Math.min(d.start.y, d.current.y);
+      let width = Math.abs(dx);
+      let height = Math.abs(dy);
+
+      if (dist < DRAG_MIN_DISTANCE) {
+        // Treat as a click — drop a default-sized shape centered on the
+        // click point so the user still gets something.
+        width = MIN_DIM * 2;
+        height = MIN_DIM * 1.4;
+        x = d.start.x - width / 2;
+        y = d.start.y - height / 2;
+      } else {
+        // Guard against degenerate thin strips — enforce a minimum along
+        // each axis so users don't end up with a 200×1 sliver.
+        if (width < MIN_DIM) {
+          x -= (MIN_DIM - width) / 2;
+          width = MIN_DIM;
+        }
+        if (height < MIN_DIM) {
+          y -= (MIN_DIM - height) / 2;
+          height = MIN_DIM;
+        }
+      }
+
+      const node = addNode('shape', x, y);
+      const nextData: ShapeNodeData = {
+        kind: d.kind,
+        fill: '#E8EEF7',
+        stroke: '#5B7CBF',
+        strokeWidth: 2,
+      };
+      updateNode(node.id, { width, height, data: nextData });
+      onCommitted({ ...node, x, y, width, height, data: nextData });
+    },
+    [addNode, updateNode, onCommitted],
+  );
+
+  const handleOverlayMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.button !== 0) return;
+      const kind = kindFromTool();
+      if (!kind) return;
+      const el = getContainer();
+      if (!el) return;
+      e.preventDefault();
+      e.stopPropagation();
+      const start = screenToCanvas(e.clientX, e.clientY, el);
+      setDraft({ kind, start, current: start });
+    },
+    [getContainer, kindFromTool, screenToCanvas],
+  );
+
+  return {
+    draft,
+    handleOverlayMouseDown,
+    isActive: kindFromTool() !== null,
+  };
+};

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -116,12 +116,20 @@ export interface ImageNodeData {
  * SVG that fills the node box, so the same storage powers both rect and
  * ellipse (and any future primitives). Colors are stored as hex strings
  * or "transparent"; stroke width is in CSS pixels at scale=1.
+ *
+ * `text` is an optional free-form label centered inside the shape. It
+ * is rendered via an HTML `contenteditable` overlay (not SVG text) so it
+ * wraps like any other DOM text and inherits the canvas's font stack.
  */
 export interface ShapeNodeData {
   kind: "rect" | "ellipse";
   fill: string;
   stroke: string;
   strokeWidth: number;
+  text?: string;
+  textColor?: string;
+  /** Font size in px. Defaults to 16 when unset. */
+  fontSize?: number;
 }
 
 export interface CanvasTransform {

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -1,6 +1,6 @@
 export interface CanvasNode {
   id: string;
-  type: "file" | "terminal" | "frame" | "agent" | "text" | "iframe" | "image";
+  type: "file" | "terminal" | "frame" | "agent" | "text" | "iframe" | "image" | "shape";
   title: string;
   x: number;
   y: number;
@@ -13,7 +13,8 @@ export interface CanvasNode {
     | AgentNodeData
     | TextNodeData
     | IframeNodeData
-    | ImageNodeData;
+    | ImageNodeData
+    | ShapeNodeData;
   /** Epoch millis of last mutation; used for cross-process merge. */
   updatedAt?: number;
 }
@@ -108,6 +109,19 @@ export interface IframeNodeData {
 export interface ImageNodeData {
   /** Absolute path on disk to the saved image file. */
   filePath: string;
+}
+
+/**
+ * A primitive geometric shape drawn on the canvas. Rendered as an inline
+ * SVG that fills the node box, so the same storage powers both rect and
+ * ellipse (and any future primitives). Colors are stored as hex strings
+ * or "transparent"; stroke width is in CSS pixels at scale=1.
+ */
+export interface ShapeNodeData {
+  kind: "rect" | "ellipse";
+  fill: string;
+  stroke: string;
+  strokeWidth: number;
 }
 
 export interface CanvasTransform {

--- a/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
@@ -1,4 +1,4 @@
-import type { CanvasNode, FileNodeData, TerminalNodeData, FrameNodeData, AgentNodeData, TextNodeData, IframeNodeData, ImageNodeData } from '../types';
+import type { CanvasNode, FileNodeData, TerminalNodeData, FrameNodeData, AgentNodeData, TextNodeData, IframeNodeData, ImageNodeData, ShapeNodeData } from '../types';
 
 let nodeIdCounter = 0;
 export const genId = (): string => `node-${Date.now()}-${++nodeIdCounter}`;
@@ -11,9 +11,10 @@ const NODE_DEFAULTS: Record<CanvasNode['type'], { title: string; width: number; 
   text:     { title: 'Text',     width: 260, height: 120 },
   iframe:   { title: 'Web',      width: 520, height: 400 },
   image:    { title: 'Image',    width: 320, height: 240 },
+  shape:    { title: 'Shape',    width: 200, height: 140 },
 };
 
-export const createNodeData = (type: CanvasNode['type']): FileNodeData | TerminalNodeData | FrameNodeData | AgentNodeData | TextNodeData | IframeNodeData | ImageNodeData => {
+export const createNodeData = (type: CanvasNode['type']): FileNodeData | TerminalNodeData | FrameNodeData | AgentNodeData | TextNodeData | IframeNodeData | ImageNodeData | ShapeNodeData => {
   switch (type) {
     case 'file':     return { filePath: '', content: '', saved: false, modified: false };
     case 'terminal': return { sessionId: '' };
@@ -22,6 +23,7 @@ export const createNodeData = (type: CanvasNode['type']): FileNodeData | Termina
     case 'text':     return { content: '', textColor: '#1f2328', backgroundColor: 'transparent', fontSize: 18, autoSize: true };
     case 'iframe':   return { url: '', html: '', mode: 'url', prompt: '' };
     case 'image':    return { filePath: '' };
+    case 'shape':    return { kind: 'rect', fill: '#E8EEF7', stroke: '#5B7CBF', strokeWidth: 2 };
   }
 };
 


### PR DESCRIPTION
## Summary
Adds support for drawing primitive geometric shapes (rectangles and ellipses) on the canvas. Users can now select shape tools from the toolbar and drag to create styled shapes with configurable fill, stroke, and stroke width.

## Key Changes

- **New Shape Node Type**: Added `shape` as a first-class canvas node type alongside file, terminal, frame, etc.
  - Shapes are rendered as inline SVG primitives that fill their node bounds
  - Supports both `rect` and `ellipse` kinds with independent styling

- **Shape Drawing Hook** (`useShapeDraw`):
  - Implements drag-to-draw interaction for shape tools
  - Tracks a live draft while the user drags; commits a real node on mouseup
  - Enforces minimum dimensions (40px) and drag distance threshold (4px) to prevent accidental tiny shapes
  - Automatically reverts to select tool and selects the new shape for immediate styling

- **Shape Node Component** (`ShapeNodeBody`):
  - Renders SVG rect or ellipse with proper stroke inset (half stroke width) to keep strokes inside bounds
  - Entire surface acts as a drag handle, matching the chromeless image/text node pattern
  - Includes `ShapeStylePicker` floating palette for editing fill, stroke color, and stroke width
  - Provides preset color palettes (12 fill colors, 11 stroke colors) and stroke width options (0, 1, 2, 4, 6px)

- **Toolbar Integration**:
  - Added "Rectangle (drag to draw)" and "Ellipse (drag to draw)" tools to the floating toolbar
  - Tools activate a crosshair cursor and shape-draw overlay

- **Canvas Agent Tools**:
  - Extended `canvas_create_node` to support `shape` type with data schema
  - Added dedicated `canvas_create_shape` tool for precise shape creation via agent prompts
  - Both tools accept `kind`, `fill`, `stroke`, and `strokeWidth` parameters

- **UI/UX Details**:
  - Shape nodes render with transparent background and subtle hover border (like images)
  - Selection shows accent-colored border and shadow
  - Style picker appears above the shape when selected
  - Dashed outline preview shown while dragging out a new shape
  - Shapes are resizable via corner/edge handles like other nodes

## Implementation Notes

- Stroke geometry is inset by half the stroke width to prevent SVG's default center-stroke behavior from clipping outside the node bounds
- Draft state is kept local until mouseup to keep undo/redo clean (one shape per drag, not intermediate resize steps)
- Shape tool overlay uses the same z-index layering trick as the connect-mode overlay to ensure drags over existing nodes still create shapes
- Colors stored as hex strings or the literal string `"transparent"` for consistency with existing node styling

https://claude.ai/code/session_01YQ8C8zzW2VojbRuU4TZkEn