### PR TITLE
feat(canvas-workspace): expand shape kinds and consolidate toolbar entry

### DIFF
--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -452,7 +452,7 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
           '- frame: { color?: string, label?: string }\n' +
           '- text: { textColor?: string, backgroundColor?: string, fontSize?: number }\n' +
           '- iframe: { url?: string, html?: string, prompt?: string, mode?: "url"|"html"|"ai" }\n' +
-          '- shape: { kind?: "rect"|"ellipse", fill?: string, stroke?: string, strokeWidth?: number, text?: string, textColor?: string, fontSize?: number }',
+          '- shape: { kind?: "rect"|"rounded-rect"|"ellipse"|"triangle"|"diamond"|"hexagon"|"star", fill?: string, stroke?: string, strokeWidth?: number, text?: string, textColor?: string, fontSize?: number }',
         ),
       }),
       execute: async (input) => {
@@ -551,8 +551,9 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
             break;
           }
           case 'shape': {
+            const validKinds = ['rect', 'rounded-rect', 'ellipse', 'triangle', 'diamond', 'hexagon', 'star'];
             const rawKind = extraData.kind as string | undefined;
-            const shapeKind = rawKind === 'ellipse' ? 'ellipse' : 'rect';
+            const shapeKind = rawKind && validKinds.includes(rawKind) ? rawKind : 'rect';
             nodeData = {
               kind: shapeKind,
               fill: (extraData.fill as string) ?? '#E8EEF7',
@@ -956,14 +957,17 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
     canvas_create_shape: {
       name: 'canvas_create_shape',
       description:
-        'Create a primitive geometric shape (rectangle or ellipse) on the canvas. ' +
+        'Create a primitive geometric shape on the canvas. Supported kinds: ' +
+        '"rect", "rounded-rect", "ellipse", "triangle", "diamond", "hexagon", "star". ' +
         'Shapes are visual-only annotations — they render as SVG primitives with configurable ' +
-        'fill, stroke, and stroke width. Use this for diagramming, highlighting regions, or ' +
-        'building simple layouts. ' +
+        'fill, stroke, and stroke width, and an optional centered text label. ' +
         'Pass explicit width/height for precise sizing; otherwise defaults to 200×140. ' +
         'Colors accept hex strings (e.g. "#E8EEF7") or the literal string "transparent".',
       inputSchema: z.object({
-        kind: z.enum(['rect', 'ellipse']).optional().describe('Shape primitive. Defaults to "rect".'),
+        kind: z
+          .enum(['rect', 'rounded-rect', 'ellipse', 'triangle', 'diamond', 'hexagon', 'star'])
+          .optional()
+          .describe('Shape primitive. Defaults to "rect".'),
         title: z.string().optional().describe('Node title (used in the layers panel). Defaults to "Shape".'),
         x: z.number().optional().describe('X position (canvas coords). Auto-placed if omitted.'),
         y: z.number().optional().describe('Y position (canvas coords). Auto-placed if omitted.'),
@@ -980,7 +984,7 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
         const canvas = await loadCanvas(workspaceId);
         if (!canvas) return 'Error: workspace not found';
 
-        const kind = (input.kind as 'rect' | 'ellipse' | undefined) ?? 'rect';
+        const kind = (input.kind as string | undefined) ?? 'rect';
         const title = (input.title as string) ?? DEFAULT_DIMENSIONS.shape.title;
         const width = (input.width as number | undefined) ?? DEFAULT_DIMENSIONS.shape.width;
         const height = (input.height as number | undefined) ?? DEFAULT_DIMENSIONS.shape.height;

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
@@ -5,6 +5,7 @@ import { CanvasEdgesLayer } from '../CanvasEdgesLayer';
 import type { ResizeEdge } from '../../hooks/useNodeResize';
 import type { EdgeInteractionState, Point } from '../../hooks/useEdgeInteraction';
 import type { ShapeDraft } from '../../hooks/useShapeDraw';
+import { ShapePrimitive } from '../../utils/shapeGeometry';
 
 interface CanvasSurfaceProps {
   transform: { x: number; y: number; scale: number };
@@ -157,21 +158,31 @@ export const CanvasSurface = ({
 const ShapeDraftPreview = ({ draft }: { draft: ShapeDraft }) => {
   const x = Math.min(draft.start.x, draft.current.x);
   const y = Math.min(draft.start.y, draft.current.y);
-  const w = Math.abs(draft.current.x - draft.start.x);
-  const h = Math.abs(draft.current.y - draft.start.y);
-  const common: React.CSSProperties = {
-    position: 'absolute',
-    left: x,
-    top: y,
-    width: w,
-    height: h,
-    border: '1.5px dashed #5B7CBF',
-    background: 'rgba(91, 124, 191, 0.08)',
-    pointerEvents: 'none',
-    boxSizing: 'border-box',
-  };
-  if (draft.kind === 'ellipse') {
-    common.borderRadius = '50%';
-  }
-  return <div className="shape-draft-preview" style={common} />;
+  const w = Math.max(1, Math.abs(draft.current.x - draft.start.x));
+  const h = Math.max(1, Math.abs(draft.current.y - draft.start.y));
+  return (
+    <svg
+      className="shape-draft-preview"
+      style={{
+        position: 'absolute',
+        left: x,
+        top: y,
+        width: w,
+        height: h,
+        pointerEvents: 'none',
+        overflow: 'visible',
+      }}
+      viewBox={`0 0 ${w} ${h}`}
+      preserveAspectRatio="none"
+    >
+      <ShapePrimitive
+        kind={draft.kind}
+        width={w}
+        height={h}
+        fill="rgba(91, 124, 191, 0.08)"
+        stroke="#5B7CBF"
+        strokeWidth={1.5}
+      />
+    </svg>
+  );
 };

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/ShapeToolButton.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/ShapeToolButton.tsx
@@ -1,0 +1,129 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { SHAPE_KINDS, SHAPE_KIND_LABEL, ShapePrimitive, type ShapeKind } from '../../utils/shapeGeometry';
+
+interface Props {
+  activeTool: string;
+  onToolChange: (tool: string) => void;
+}
+
+const SHAPE_TOOL_PREFIX = 'shape-';
+
+/**
+ * Split-button toolbar entry for picking which shape to draw.
+ *
+ * Behavior:
+ *   - Main button activates the last-used shape kind (defaults to rect).
+ *     Clicking it toggles the draw tool on/off like any other tool.
+ *   - The caret next to it opens a small popover listing every shape
+ *     kind. Picking one both activates the tool and updates what the
+ *     main button remembers, so repeated draws of the same shape stay
+ *     one click away.
+ */
+export const ShapeToolButton = ({ activeTool, onToolChange }: Props) => {
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [lastKind, setLastKind] = useState<ShapeKind>('rect');
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  // Derive the kind the main button should show: if a shape tool is
+  // currently active, display it; otherwise fall back to the last one
+  // the user picked. This keeps the icon truthful without storing the
+  // kind twice.
+  const activeKind: ShapeKind | null = activeTool.startsWith(SHAPE_TOOL_PREFIX)
+    ? ((activeTool.slice(SHAPE_TOOL_PREFIX.length) as ShapeKind))
+    : null;
+  const displayKind: ShapeKind = activeKind ?? lastKind;
+  const isActive = activeKind !== null;
+
+  // Remember the active kind as the "last used" whenever it changes.
+  // This way switching tools via another path (e.g. keyboard shortcut
+  // down the road) still updates the main button.
+  useEffect(() => {
+    if (activeKind) setLastKind(activeKind);
+  }, [activeKind]);
+
+  // Close popover on outside click.
+  useEffect(() => {
+    if (!popoverOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setPopoverOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [popoverOpen]);
+
+  const handleMainClick = useCallback(() => {
+    onToolChange(`${SHAPE_TOOL_PREFIX}${displayKind}`);
+  }, [displayKind, onToolChange]);
+
+  const handleCaretClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    setPopoverOpen((v) => !v);
+  }, []);
+
+  const handlePick = useCallback(
+    (kind: ShapeKind) => {
+      setLastKind(kind);
+      onToolChange(`${SHAPE_TOOL_PREFIX}${kind}`);
+      setPopoverOpen(false);
+    },
+    [onToolChange],
+  );
+
+  return (
+    <div className="shape-tool-split" ref={rootRef}>
+      <button
+        className={`toolbar-btn shape-tool-main${isActive ? ' toolbar-btn--active' : ''}`}
+        onClick={handleMainClick}
+        title={`${SHAPE_KIND_LABEL[displayKind]} (drag to draw)`}
+      >
+        <svg width="18" height="18" viewBox="0 0 18 18">
+          <ShapePrimitive
+            kind={displayKind}
+            width={18}
+            height={18}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1.4}
+          />
+        </svg>
+      </button>
+      <button
+        className={`toolbar-btn shape-tool-caret${popoverOpen ? ' toolbar-btn--active' : ''}`}
+        onClick={handleCaretClick}
+        title="More shapes"
+      >
+        <svg width="8" height="8" viewBox="0 0 8 8" fill="none">
+          <path d="M1.5 3l2.5 2.5L6.5 3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </button>
+      {popoverOpen && (
+        <div className="shape-tool-popover">
+          {SHAPE_KINDS.map((kind) => {
+            const selected = displayKind === kind;
+            return (
+              <button
+                key={kind}
+                className={`shape-tool-option${selected ? ' shape-tool-option--active' : ''}`}
+                onClick={() => handlePick(kind)}
+                title={SHAPE_KIND_LABEL[kind]}
+              >
+                <svg width="20" height="20" viewBox="0 0 20 20">
+                  <ShapePrimitive
+                    kind={kind}
+                    width={20}
+                    height={20}
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={1.4}
+                  />
+                </svg>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.css
@@ -81,3 +81,87 @@
      brings the cap-height of the text in line with the icon midline. */
   transform: translateY(0.5px);
 }
+
+/* ---- Shape split-button ---- */
+
+.shape-tool-split {
+  position: relative;
+  display: inline-flex;
+  align-items: stretch;
+}
+
+/* The main half and the caret half read as one merged pill when they're
+ * adjacent. Individually they still respond to hover/active. */
+.shape-tool-split .shape-tool-main {
+  padding: 0 6px 0 8px;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.shape-tool-split .shape-tool-caret {
+  min-width: 18px;
+  padding: 0 4px;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  margin-left: 0;
+}
+
+.shape-tool-split .shape-tool-caret::before {
+  /* Hairline divider between the two halves so the merged pill still
+   * reads as two clickable regions. */
+  content: '';
+  position: absolute;
+  top: 6px;
+  bottom: 6px;
+  left: 0;
+  width: 1px;
+  background: rgba(0, 0, 0, 0.08);
+}
+
+.shape-tool-split .shape-tool-caret {
+  position: relative;
+}
+
+.shape-tool-popover {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 0;
+  display: grid;
+  grid-template-columns: repeat(4, 30px);
+  gap: 2px;
+  padding: 4px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-float);
+  z-index: 600;
+}
+
+.shape-tool-option {
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.1s, color 0.1s;
+}
+
+.shape-tool-option svg {
+  display: block;
+}
+
+.shape-tool-option:hover {
+  background: rgba(0, 0, 0, 0.04);
+  color: var(--text);
+}
+
+.shape-tool-option--active {
+  background: var(--accent-light);
+  color: var(--accent);
+}

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
@@ -1,4 +1,5 @@
 import './index.css';
+import { ShapeToolButton } from './ShapeToolButton';
 
 interface Props {
   activeTool: string;
@@ -53,27 +54,6 @@ const tools = [
         />
       </svg>
     )
-  },
-  {
-    id: "shape-rect",
-    label: "Rectangle (drag to draw)",
-    icon: (
-      <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-        <rect
-          x="3" y="4" width="12" height="10" rx="1"
-          stroke="currentColor" strokeWidth="1.4"
-        />
-      </svg>
-    )
-  },
-  {
-    id: "shape-ellipse",
-    label: "Ellipse (drag to draw)",
-    icon: (
-      <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-        <ellipse cx="9" cy="9" rx="6" ry="4.5" stroke="currentColor" strokeWidth="1.4" />
-      </svg>
-    )
   }
 ];
 
@@ -120,6 +100,7 @@ export const FloatingToolbar = ({
             {t.icon}
           </button>
         ))}
+        <ShapeToolButton activeTool={activeTool} onToolChange={onToolChange} />
       </div>
 
       <div className="toolbar-divider" />

--- a/apps/canvas-workspace/src/renderer/src/components/ShapeNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ShapeNodeBody/index.css
@@ -92,6 +92,10 @@
   box-sizing: border-box;
 }
 
+.shape-style-preview-svg {
+  display: block;
+}
+
 .shape-style-popover {
   position: absolute;
   top: 32px;

--- a/apps/canvas-workspace/src/renderer/src/components/ShapeNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ShapeNodeBody/index.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import './index.css';
 import type { CanvasNode, ShapeNodeData } from '../../types';
+import { ShapePrimitive } from '../../utils/shapeGeometry';
 
 interface Props {
   node: CanvasNode;
@@ -119,16 +120,15 @@ export const ShapeNodeBody = ({ node, isSelected, onSelect, onDragStart, onUpdat
 
   const w = Math.max(1, node.width);
   const h = Math.max(1, node.height);
-  const sw = Math.max(0, data.strokeWidth ?? 0);
-  const inset = sw / 2;
   const fontSize = data.fontSize ?? 16;
   const textColor =
     data.textColor ??
     (data.stroke && data.stroke !== 'transparent' ? data.stroke : '#1f2328');
-  // Pad the text so it doesn't crowd the shape outline. For ellipses the
-  // inscribed rectangle is (w·cos45, h·sin45) — ~70% of the bounding box —
-  // so we pull the label in harder on curved shapes.
-  const padRatio = data.kind === 'ellipse' ? 0.15 : 0.08;
+  // Pad the text so it doesn't crowd the shape outline. Shapes with
+  // curved or angled sides (ellipse, triangle, diamond, star) have a
+  // smaller inscribed rectangle, so we pull the label in harder on them.
+  const tightShapes: ShapeNodeData['kind'][] = ['ellipse', 'triangle', 'diamond', 'star'];
+  const padRatio = tightShapes.includes(data.kind) ? 0.15 : 0.08;
   const padX = Math.max(8, Math.round(w * padRatio));
   const padY = Math.max(6, Math.round(h * padRatio));
 
@@ -141,27 +141,14 @@ export const ShapeNodeBody = ({ node, isSelected, onSelect, onDragStart, onUpdat
         viewBox={`0 0 ${w} ${h}`}
         preserveAspectRatio="none"
       >
-        {data.kind === 'ellipse' ? (
-          <ellipse
-            cx={w / 2}
-            cy={h / 2}
-            rx={Math.max(0, w / 2 - inset)}
-            ry={Math.max(0, h / 2 - inset)}
-            fill={data.fill}
-            stroke={data.stroke}
-            strokeWidth={sw}
-          />
-        ) : (
-          <rect
-            x={inset}
-            y={inset}
-            width={Math.max(0, w - sw)}
-            height={Math.max(0, h - sw)}
-            fill={data.fill}
-            stroke={data.stroke}
-            strokeWidth={sw}
-          />
-        )}
+        <ShapePrimitive
+          kind={data.kind}
+          width={w}
+          height={h}
+          fill={data.fill}
+          stroke={data.stroke}
+          strokeWidth={data.strokeWidth ?? 0}
+        />
       </svg>
       <div
         className={`shape-node-text-wrap${!data.text && !editing ? ' shape-node-text-wrap--empty' : ''}`}
@@ -265,15 +252,16 @@ export const ShapeStylePicker = ({ node, onUpdate }: StylePickerProps) => {
         title="Shape style"
         onClick={() => setOpen((v) => !v)}
       >
-        <span
-          className="shape-style-swatch"
-          style={{
-            background: data.fill === 'transparent' ? 'none' : data.fill,
-            borderColor: data.stroke === 'transparent' ? 'rgba(0,0,0,0.15)' : data.stroke,
-            borderStyle: data.fill === 'transparent' ? 'dashed' : 'solid',
-            borderRadius: data.kind === 'ellipse' ? '50%' : '3px',
-          }}
-        />
+        <svg className="shape-style-preview-svg" viewBox="0 0 18 18" width="14" height="14">
+          <ShapePrimitive
+            kind={data.kind}
+            width={18}
+            height={18}
+            fill={data.fill === 'transparent' ? 'none' : data.fill}
+            stroke={data.stroke === 'transparent' ? 'rgba(0,0,0,0.25)' : data.stroke}
+            strokeWidth={1.8}
+          />
+        </svg>
       </button>
       {open && (
         <div className="shape-style-popover">

--- a/apps/canvas-workspace/src/renderer/src/hooks/useShapeDraw.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useShapeDraw.ts
@@ -1,15 +1,18 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { CanvasNode, ShapeNodeData } from '../types';
+import { SHAPE_KINDS, type ShapeKind } from '../utils/shapeGeometry';
 
 type Point = { x: number; y: number };
 
-export type ShapeKind = 'rect' | 'ellipse';
+export type { ShapeKind };
 
 export type ShapeDraft = {
   kind: ShapeKind;
   start: Point;
   current: Point;
 };
+
+const SHAPE_TOOL_PREFIX = 'shape-';
 
 /** Minimum diagonal distance (canvas-px) before we commit a drag-drawn
  *  shape. A click that doesn't move past this threshold is treated as
@@ -55,9 +58,9 @@ export const useShapeDraw = ({
   draftRef.current = draft;
 
   const kindFromTool = useCallback((): ShapeKind | null => {
-    if (activeTool === 'shape-rect') return 'rect';
-    if (activeTool === 'shape-ellipse') return 'ellipse';
-    return null;
+    if (!activeTool.startsWith(SHAPE_TOOL_PREFIX)) return null;
+    const kind = activeTool.slice(SHAPE_TOOL_PREFIX.length) as ShapeKind;
+    return (SHAPE_KINDS as string[]).includes(kind) ? kind : null;
   }, [activeTool]);
 
   // Document-level listeners so a drag that leaves the overlay doesn't

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -122,7 +122,7 @@ export interface ImageNodeData {
  * wraps like any other DOM text and inherits the canvas's font stack.
  */
 export interface ShapeNodeData {
-  kind: "rect" | "ellipse";
+  kind: "rect" | "rounded-rect" | "ellipse" | "triangle" | "diamond" | "hexagon" | "star";
   fill: string;
   stroke: string;
   strokeWidth: number;

--- a/apps/canvas-workspace/src/renderer/src/utils/shapeGeometry.tsx
+++ b/apps/canvas-workspace/src/renderer/src/utils/shapeGeometry.tsx
@@ -1,0 +1,160 @@
+import type { ShapeNodeData } from '../types';
+
+export type ShapeKind = ShapeNodeData['kind'];
+
+export const SHAPE_KINDS: ShapeKind[] = [
+  'rect',
+  'rounded-rect',
+  'ellipse',
+  'triangle',
+  'diamond',
+  'hexagon',
+  'star',
+];
+
+export const SHAPE_KIND_LABEL: Record<ShapeKind, string> = {
+  'rect': 'Rectangle',
+  'rounded-rect': 'Rounded rectangle',
+  'ellipse': 'Ellipse',
+  'triangle': 'Triangle',
+  'diamond': 'Diamond',
+  'hexagon': 'Hexagon',
+  'star': 'Star',
+};
+
+/**
+ * Build the SVG `points` attribute for a polygon shape inscribed in the
+ * bounding box `[inset, inset] → [w-inset, h-inset]`. The inset accounts
+ * for stroke width — SVG centers strokes on the edge, so without the
+ * inset half the stroke would clip outside the node bounds.
+ */
+function polygonPoints(kind: ShapeKind, w: number, h: number, inset: number): string {
+  const cx = w / 2;
+  const cy = h / 2;
+  const halfW = Math.max(0, w / 2 - inset);
+  const halfH = Math.max(0, h / 2 - inset);
+
+  if (kind === 'triangle') {
+    // Apex at top-center, base along the bottom.
+    return [
+      [cx, inset],
+      [w - inset, h - inset],
+      [inset, h - inset],
+    ]
+      .map((p) => p.join(','))
+      .join(' ');
+  }
+
+  if (kind === 'diamond') {
+    // Rhombus stretched to the bounding box.
+    return [
+      [cx, inset],
+      [w - inset, cy],
+      [cx, h - inset],
+      [inset, cy],
+    ]
+      .map((p) => p.join(','))
+      .join(' ');
+  }
+
+  if (kind === 'hexagon') {
+    // Flat-top hexagon; the flat sides follow the left/right edges so it
+    // scales gracefully to wide bounding boxes. `shoulder` is the x-offset
+    // of the top/bottom points from the center.
+    const shoulder = halfW / 2;
+    return [
+      [cx - shoulder, cy - halfH],
+      [cx + shoulder, cy - halfH],
+      [w - inset, cy],
+      [cx + shoulder, cy + halfH],
+      [cx - shoulder, cy + halfH],
+      [inset, cy],
+    ]
+      .map((p) => p.join(','))
+      .join(' ');
+  }
+
+  if (kind === 'star') {
+    // 5-pointed star with the top point pointing up. Inner radius is 40%
+    // of the outer radius — a conventional proportion that reads clearly
+    // at any size without looking spiky or bloated.
+    const innerRx = halfW * 0.4;
+    const innerRy = halfH * 0.4;
+    const points: string[] = [];
+    for (let i = 0; i < 10; i++) {
+      const isOuter = i % 2 === 0;
+      const angle = -Math.PI / 2 + (i * Math.PI) / 5;
+      const rx = isOuter ? halfW : innerRx;
+      const ry = isOuter ? halfH : innerRy;
+      points.push(`${cx + rx * Math.cos(angle)},${cy + ry * Math.sin(angle)}`);
+    }
+    return points.join(' ');
+  }
+
+  return '';
+}
+
+export interface ShapePrimitiveProps {
+  kind: ShapeKind;
+  width: number;
+  height: number;
+  fill: string;
+  stroke: string;
+  strokeWidth: number;
+}
+
+/**
+ * Render a single SVG primitive for a shape kind. Used by the shape node
+ * body, the drag-to-draw preview, and the toolbar icons — keeping the
+ * geometry in one place so all three views stay in sync.
+ */
+export const ShapePrimitive = ({
+  kind,
+  width,
+  height,
+  fill,
+  stroke,
+  strokeWidth,
+}: ShapePrimitiveProps) => {
+  const w = Math.max(1, width);
+  const h = Math.max(1, height);
+  const sw = Math.max(0, strokeWidth);
+  const inset = sw / 2;
+  const common = {
+    fill,
+    stroke,
+    strokeWidth: sw,
+    strokeLinejoin: 'round' as const,
+  };
+
+  if (kind === 'rect' || kind === 'rounded-rect') {
+    // Corner radius scales with the smaller dimension so a 400×50 pill
+    // still looks like a pill rather than a slightly-rounded rectangle.
+    const r = kind === 'rounded-rect' ? Math.min(w, h) * 0.18 : 0;
+    return (
+      <rect
+        x={inset}
+        y={inset}
+        width={Math.max(0, w - sw)}
+        height={Math.max(0, h - sw)}
+        rx={r}
+        ry={r}
+        {...common}
+      />
+    );
+  }
+
+  if (kind === 'ellipse') {
+    return (
+      <ellipse
+        cx={w / 2}
+        cy={h / 2}
+        rx={Math.max(0, w / 2 - inset)}
+        ry={Math.max(0, h / 2 - inset)}
+        {...common}
+      />
+    );
+  }
+
+  return <polygon points={polygonPoints(kind, w, h, inset)} {...common} />;
+};


### PR DESCRIPTION
Adds rounded-rect, triangle, diamond, hexagon, and 5-point star to the shape primitive set. All seven kinds share a single SVG renderer (utils/shapeGeometry.tsx) so the node body, drag-to-draw preview, toolbar icons, and style-picker swatch stay in sync.

FloatingToolbar now collapses the flat rect/ellipse buttons into a single split-button: the main half activates the last-used shape, and a caret opens a 2×4 popover with every kind. Picking a kind both activates the draw tool and updates what the main button remembers, so repeat draws of the same shape stay one click away.

Canvas agent enum extended to match; canvas_create_node and canvas_create_shape both accept the full seven kinds.