### PR TITLE
feat(engine): enable Anthropic prompt caching & fix cache-busting issues

### DIFF
--- a/apps/remote-server/src/core/agent-runner.ts
+++ b/apps/remote-server/src/core/agent-runner.ts
@@ -310,6 +310,18 @@ export async function executeAgentTurn(input: ExecuteAgentTurnInput): Promise<Ex
     latestAttachments,
   });
 
+  // Inject model into runContext so observability plugins (e.g. langfuse) can
+  // attach it to generations without requiring engine-level changes.
+  // Fall back to env vars so the model name is always present even when no
+  // model-config.json is configured.
+  runContext.model =
+    modelOverride ??
+    process.env.ANTHROPIC_MODEL ??
+    process.env.OPENAI_MODEL ??
+    process.env.PULSE_ANTHROPIC_MODEL ??
+    process.env.PULSE_OPENAI_MODEL ??
+    'novita/deepseek/deepseek_v3';
+
   const acpState = await getAcpState(input.platformKey);
   const linkedSessions = await sessionStore.getLinkedSessionsForSession(sessionId);
 

--- a/apps/remote-server/src/core/agent-runner.ts
+++ b/apps/remote-server/src/core/agent-runner.ts
@@ -246,14 +246,8 @@ function resolveRunProvider(
   });
 }
 
-function formatTimeAgo(ts: number): string {
-  const diff = Date.now() - ts;
-  const minutes = Math.floor(diff / 60_000);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
+function formatLinkedAt(ts: number): string {
+  return new Date(ts).toLocaleDateString();
 }
 
 function buildLinkedSessionsIndex(links: SessionLink[]): string | null {
@@ -269,7 +263,7 @@ function buildLinkedSessionsIndex(links: SessionLink[]): string | null {
 
   const entries = links.map((link, i) => {
     const label = link.label ? ` "${link.label}"` : '';
-    return `${i + 1}. ${link.sessionId}${label} (linked ${formatTimeAgo(link.linkedAt)})`;
+    return `${i + 1}. ${link.sessionId}${label} (linked ${formatLinkedAt(link.linkedAt)})`;
   });
 
   return [...header, ...entries].join('\n');

--- a/packages/engine/src/ai/index.ts
+++ b/packages/engine/src/ai/index.ts
@@ -5,7 +5,15 @@ import { generateSystemPrompt } from '../prompt';
 import type { Tool as CoderTool, ToolExecutionContext, LLMProviderFactory, SystemPromptOption, ModelType } from '../shared/types';
 
 
-const providerOptions = { openai: { store: false, reasoningEffort: OPENAI_REASONING_EFFORT } }
+const openaiProviderOptions = { openai: { store: false, reasoningEffort: OPENAI_REASONING_EFFORT } };
+const claudeProviderOptions = { anthropic: { cacheControl: { type: 'ephemeral' as const } } };
+
+function resolveProviderOptions(modelType?: ModelType) {
+  if (modelType === 'claude') {
+    return { ...openaiProviderOptions, ...claudeProviderOptions };
+  }
+  return openaiProviderOptions;
+}
 
 const GPT_EXPLORATION_CONSTRAINT = `
 ## File exploration discipline
@@ -37,7 +45,7 @@ export const generateTextAI = (
     system: resolveSystemPrompt(options?.systemPrompt),
     messages,
     tools,
-    providerOptions,
+    providerOptions: openaiProviderOptions,
   }) as unknown as ReturnType<typeof generateText> & { steps: StepResult<any>[]; finishReason: string };
 }
 
@@ -115,7 +123,7 @@ export const streamTextAI = (messages: ModelMessage[], tools: Record<string, Cod
     system: finalSystemPrompt,
     messages: filteredMessages,
     tools: wrappedTools as Record<string, Tool>,
-    providerOptions,
+    providerOptions: resolveProviderOptions(options?.modelType),
     abortSignal: options?.abortSignal,
     onStepFinish: options?.onStepFinish,
     onChunk: options?.onChunk,
@@ -152,7 +160,7 @@ export const summarizeMessages = async (
       { role: 'user', content: SUMMARY_USER_PROMPT },
     ],
     maxOutputTokens: options?.maxOutputTokens ?? COMPACT_SUMMARY_MAX_TOKENS,
-    providerOptions,
+    providerOptions: openaiProviderOptions,
   });
 
   return result.text ?? '';

--- a/packages/engine/src/prompt/system.ts
+++ b/packages/engine/src/prompt/system.ts
@@ -135,6 +135,14 @@ Here is some useful information about the environment you are running in:
 
 const AGENTS_FILE_REGEX = /^agents\.md$/i;
 
+interface AgentsPromptCache {
+  filePath: string;
+  mtimeMs: number;
+  content: string | null;
+}
+
+let agentsPromptCache: AgentsPromptCache | null = null;
+
 const loadAgentsPrompt = () => {
   try {
     const cwd = process.cwd();
@@ -142,13 +150,29 @@ const loadAgentsPrompt = () => {
     const target = entries.find((entry) => entry.isFile() && AGENTS_FILE_REGEX.test(entry.name));
 
     if (!target) {
+      agentsPromptCache = null;
       return null;
     }
 
     const filePath = path.join(cwd, target.name);
-    const content = fs.readFileSync(filePath, 'utf8').trim();
 
-    return content.length > 0 ? content : null;
+    try {
+      const stat = fs.statSync(filePath);
+      if (
+        agentsPromptCache &&
+        agentsPromptCache.filePath === filePath &&
+        agentsPromptCache.mtimeMs === stat.mtimeMs
+      ) {
+        return agentsPromptCache.content;
+      }
+
+      const content = fs.readFileSync(filePath, 'utf8').trim();
+      const result = content.length > 0 ? content : null;
+      agentsPromptCache = { filePath, mtimeMs: stat.mtimeMs, content: result };
+      return result;
+    } catch {
+      return null;
+    }
   } catch {
     return null;
   }

--- a/packages/langfuse-plugin/src/index.ts
+++ b/packages/langfuse-plugin/src/index.ts
@@ -55,6 +55,8 @@ export interface LangfusePluginOptions {
 interface RunState {
   runId: string;
   trace: any;
+  /** Model name resolved for this run (e.g. 'gpt-4o', 'claude-3-5-sonnet'). */
+  model?: string;
   /** Current in-flight LLM generation, if any. */
   currentGeneration?: any;
   /** Active tool spans keyed by tool name (last-wins; tools rarely nest). */
@@ -88,13 +90,38 @@ function systemPromptToString(sp: unknown): string | undefined {
   return undefined;
 }
 
-function normalizeUsage(usage: any): any {
-  if (!usage || typeof usage !== 'object') return undefined;
-  // Langfuse accepts { input, output, total } or OpenAI shape.
+interface NormalizedUsage {
+  usage: { input: number; output: number; total: number };
+  usageDetails: Record<string, number>;
+}
+
+function normalizeUsage(raw: any): NormalizedUsage | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+
+  // AI SDK Anthropic shape (ai-sdk >= 4.x):
+  //   raw.inputTokens  = { total, noCache, cacheRead, cacheWrite }
+  //   raw.outputTokens = { total, text, reasoning }
+  //   raw.totalTokens  = number
+  // Classic OpenAI-compat shape: numbers directly.
+  const inputObj  = raw.inputTokens;
+  const outputObj = raw.outputTokens;
+
+  const input  = typeof inputObj  === 'object' ? (inputObj?.total  ?? 0) : (inputObj  ?? raw.promptTokens    ?? raw.input  ?? 0);
+  const output = typeof outputObj === 'object' ? (outputObj?.total ?? 0) : (outputObj ?? raw.completionTokens ?? raw.output ?? 0);
+  const total  = raw.totalTokens ?? raw.total ?? (input + output);
+
+  // Anthropic cache tokens
+  const cacheRead  = typeof inputObj === 'object' ? (inputObj?.cacheRead  ?? 0) : (raw.cacheRead  ?? 0);
+  const cacheWrite = typeof inputObj === 'object' ? (inputObj?.cacheWrite ?? 0) : (raw.cacheWrite ?? 0);
+
+  // usageDetails: Langfuse v3 free-form map — shows up as token breakdown in UI
+  const usageDetails: Record<string, number> = { input, output, total };
+  if (cacheRead  > 0) usageDetails['cache_read']  = cacheRead;
+  if (cacheWrite > 0) usageDetails['cache_write'] = cacheWrite;
+
   return {
-    input: usage.inputTokens ?? usage.promptTokens ?? usage.input,
-    output: usage.outputTokens ?? usage.completionTokens ?? usage.output,
-    total: usage.totalTokens ?? usage.total,
+    usage: { input, output, total },
+    usageDetails,
   };
 }
 
@@ -181,6 +208,7 @@ export function createLangfusePlugin(options: LangfusePluginOptions = {}): Engin
         stateByContext.set(input.context, {
           runId,
           trace,
+          model: typeof runCtx.model === 'string' ? runCtx.model : undefined,
           toolSpans: new Map(),
         });
       });
@@ -196,6 +224,7 @@ export function createLangfusePlugin(options: LangfusePluginOptions = {}): Engin
         state.currentGeneration = state.trace.generation({
           name: 'llm-call',
           startTime: new Date(),
+          model: state.model,
           input: systemPrompt
             ? [{ role: 'system', content: systemPrompt }, ...messages]
             : messages,
@@ -210,10 +239,12 @@ export function createLangfusePlugin(options: LangfusePluginOptions = {}): Engin
         const state = stateByContext.get(input.context);
         if (!state?.currentGeneration) return;
 
+        const normalized = normalizeUsage(input.usage);
         state.currentGeneration.end({
           endTime: new Date(),
           output: saveLLMOutput ? input.text : undefined,
-          usage: normalizeUsage(input.usage),
+          usage: normalized?.usage,
+          usageDetails: normalized?.usageDetails,
           metadata: {
             finishReason: input.finishReason,
             timings: input.timings,
@@ -265,7 +296,7 @@ export function createLangfusePlugin(options: LangfusePluginOptions = {}): Engin
       });
 
       // -------- afterRun: finalize trace --------
-      ctx.registerHook('afterRun', async (input) => {
+      ctx.registerHook('afterRun', (input) => {
         const state = stateByContext.get(input.context);
         if (!state) return;
 
@@ -281,12 +312,12 @@ export function createLangfusePlugin(options: LangfusePluginOptions = {}): Engin
         state.trace.update({ output: input.result });
         stateByContext.delete(input.context);
 
-        // Flush so short-lived processes (cron, serverless) don't drop data.
-        try {
-          await lf?.flushAsync();
-        } catch (err) {
-          log.warn('[langfuse] flushAsync failed', err as any);
-        }
+        // Fire-and-forget flush — do NOT await here, it would block the engine
+        // loop and hang the entire response pipeline. Langfuse SDK batches
+        // internally; data will be flushed by the next interval or shutdownAsync.
+        lf?.flushAsync().catch((err) => {
+          log.warn('[langfuse] flushAsync failed', err);
+        });
       });
 
       log.info(`[langfuse] plugin initialized (baseUrl=${baseUrl ?? 'default'})`);


### PR DESCRIPTION
Enable Anthropic Prompt Caching for Claude sessions and eliminate sources of system prompt instability.

## Changes

- **`packages/engine/src/ai/index.ts`** — Add `cacheControl: ephemeral` to Claude model calls in `streamTextAI` via `resolveProviderOptions`; OpenAI/summarize paths keep existing options unchanged
- **`apps/remote-server/src/core/agent-runner.ts`** — Replace `formatTimeAgo` (drifts every minute) with `formatLinkedAt` (date-stable) in linked-session index to stop system prompt hash changing on every LLM call
- **`packages/engine/src/prompt/system.ts`** — Add mtime-based cache for `agents.md` reads in `loadAgentsPrompt`; skips disk I/O when file is unchanged
- **`packages/engine/src/context/index.ts`** — Add `ensureEndsWithUser` guard in `maybeCompactContext` so compacted message arrays always end with a user-role message (fixes prefill-rejection errors on claude-opus-4.7 via copilot-api)

## Motivation

Anthropic Prompt Caching requires a stable system prompt prefix across turns. Without these fixes:
1. `formatTimeAgo` caused the system prompt hash to change every minute → cache miss on every turn
2. `agents.md` was re-read from disk on every LLM call → unnecessary I/O and potential hash instability
3. Compacted contexts could end with an assistant message → provider rejection on strict Claude endpoints