### PR TITLE
feat(devtools): add token usage stats with time-range aggregation and Stats UI

### DIFF
--- a/apps/devtools-web/src/App.tsx
+++ b/apps/devtools-web/src/App.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
 
 type RunStatus = 'running' | 'finished';
+type PageView = 'runs' | 'stats';
+type StatsRange = 'today' | 'week' | 'month' | 'custom';
+type StatsGranularity = 'hour' | 'day' | 'week';
 
 interface RunSummary {
   runId: string;
@@ -18,6 +21,57 @@ interface RunSummary {
   llmCalls: number;
   toolCalls: number;
   compactions: number;
+  totalInputTokens?: number;
+  totalOutputTokens?: number;
+  totalCacheReadTokens?: number;
+  totalCacheWriteTokens?: number;
+}
+
+interface TokenStatsBucket {
+  ts: number;
+  label: string;
+  runCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  totalTokens: number;
+}
+
+interface TokenStatsSummary {
+  totalRuns: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  totalTokens: number;
+}
+
+interface TokenStatsResponse {
+  ok: boolean;
+  from: number;
+  to: number;
+  granularity: StatsGranularity;
+  summary: TokenStatsSummary;
+  buckets: TokenStatsBucket[];
+}
+
+interface SessionBreakdown {
+  sessionId: string;
+  runCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  totalTokens: number;
+  lastRunAt: number;
+}
+
+interface SessionStatsResponse {
+  ok: boolean;
+  from: number;
+  to: number;
+  sessions: SessionBreakdown[];
 }
 
 interface LlmSpan {
@@ -137,6 +191,7 @@ export default function App() {
   const initialBaseUrl = sanitizeBaseUrl(localStorage.getItem('devtoolsBaseUrl') || DEFAULT_BASE_URL);
   const [baseUrl, setBaseUrl] = useState(initialBaseUrl);
   const [baseUrlInput, setBaseUrlInput] = useState(initialBaseUrl);
+  const [page, setPage] = useState<PageView>('runs');
   const [runs, setRuns] = useState<RunSummary[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [selectedRun, setSelectedRun] = useState<RunDetail | null>(null);
@@ -1285,6 +1340,21 @@ export default function App() {
         </div>
       </header>
 
+      <div className="page-nav">
+        {(['runs', 'stats'] as const).map((p) => (
+          <button
+            key={p}
+            className={`page-nav-btn ${page === p ? 'active' : ''}`}
+            onClick={() => setPage(p)}
+          >
+            {p === 'runs' ? '⚡ Runs' : '📊 Stats'}
+          </button>
+        ))}
+      </div>
+
+      {page === 'stats' ? (
+        <StatsView apiBase={apiBase} />
+      ) : (
       <main>
         <section className="panel">
           <div className="panel-header">
@@ -1402,6 +1472,7 @@ export default function App() {
           {renderDetail()}
         </section>
       </main>
+      )}
     </div>
   );
 }
@@ -1445,5 +1516,299 @@ function CopyButton({ value }: { value: string }) {
     <button className={`copy-button ${copied ? 'copied' : ''}`} onClick={copy} type="button">
       {copied ? 'Copied' : 'Copy'}
     </button>
+  );
+}
+
+// ── StatsView ─────────────────────────────────────────────────────────────────
+
+function formatK(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+function formatDate(ts: number): string {
+  return new Date(ts).toLocaleDateString();
+}
+
+function StatCard({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="stat-card">
+      <div className="stat-label">{label}</div>
+      <div className="stat-value">{value}</div>
+      {sub ? <div className="stat-sub">{sub}</div> : null}
+    </div>
+  );
+}
+
+function BarChart({ buckets, height = 140 }: { buckets: TokenStatsBucket[]; height?: number }) {
+  if (!buckets.length) return <div className="empty">No data in this range.</div>;
+
+  const maxVal = Math.max(...buckets.map((b) => b.totalTokens), 1);
+  const barW = Math.max(14, Math.min(48, Math.floor(560 / buckets.length) - 4));
+  const gap = 4;
+  const totalW = buckets.length * (barW + gap) - gap;
+  const chartH = height;
+  const paddingTop = 20;
+  const labelH = 38;
+  const svgH = chartH + paddingTop + labelH;
+
+  return (
+    <div className="bar-chart-wrap">
+      <svg
+        viewBox={`0 0 ${Math.max(totalW, 300)} ${svgH}`}
+        style={{ width: '100%', height: svgH, display: 'block' }}
+        aria-label="Token usage bar chart"
+      >
+        {buckets.map((b, i) => {
+          const x = i * (barW + gap);
+          const inH = b.inputTokens > 0 ? Math.max(3, Math.round((b.inputTokens / maxVal) * chartH)) : 0;
+          const outH = b.outputTokens > 0 ? Math.max(3, Math.round((b.outputTokens / maxVal) * chartH)) : 0;
+          const stackH = inH + outH;
+          const y = paddingTop + chartH - stackH;
+          const labelText = b.label.length > 8 ? b.label.slice(5) : b.label; // trim year for day/week
+
+          return (
+            <g key={b.ts}>
+              <title>{`${b.label}\nInput: ${formatK(b.inputTokens)}\nOutput: ${formatK(b.outputTokens)}\nTotal: ${formatK(b.totalTokens)}\nRuns: ${b.runCount}`}</title>
+              {/* Output (top) */}
+              {outH > 0 && (
+                <rect
+                  x={x}
+                  y={y}
+                  width={barW}
+                  height={outH}
+                  rx={3}
+                  fill="rgba(33,105,185,0.55)"
+                />
+              )}
+              {/* Input (bottom) */}
+              {inH > 0 && (
+                <rect
+                  x={x}
+                  y={y + outH}
+                  width={barW}
+                  height={inH}
+                  rx={3}
+                  fill="rgba(15,123,108,0.55)"
+                />
+              )}
+              {/* Empty bar placeholder */}
+              {stackH === 0 && (
+                <rect x={x} y={paddingTop + chartH - 3} width={barW} height={3} rx={2} fill="#e8e7e3" />
+              )}
+              {/* Label */}
+              <text
+                x={x + barW / 2}
+                y={paddingTop + chartH + 14}
+                textAnchor="middle"
+                fontSize={9}
+                fill="#9b9690"
+              >
+                {labelText}
+              </text>
+              {/* Run count */}
+              {b.runCount > 0 && (
+                <text
+                  x={x + barW / 2}
+                  y={paddingTop + chartH + 26}
+                  textAnchor="middle"
+                  fontSize={8}
+                  fill="#bbb9b4"
+                >
+                  {b.runCount}r
+                </text>
+              )}
+            </g>
+          );
+        })}
+        {/* Baseline */}
+        <line
+          x1={0}
+          y1={paddingTop + chartH}
+          x2={Math.max(totalW, 300)}
+          y2={paddingTop + chartH}
+          stroke="#e8e7e3"
+          strokeWidth={1}
+        />
+      </svg>
+      <div className="chart-legend">
+        <span className="legend-item"><span className="legend-swatch" style={{ background: 'rgba(15,123,108,0.55)' }} />Input</span>
+        <span className="legend-item"><span className="legend-swatch" style={{ background: 'rgba(33,105,185,0.55)' }} />Output</span>
+      </div>
+    </div>
+  );
+}
+
+function StatsView({ apiBase }: { apiBase: string }) {
+  const [range, setRange] = useState<StatsRange>('week');
+  const [granularity, setGranularity] = useState<StatsGranularity>('day');
+  const [customFrom, setCustomFrom] = useState('');
+  const [customTo, setCustomTo] = useState('');
+  const [tokenStats, setTokenStats] = useState<TokenStatsResponse | null>(null);
+  const [sessionStats, setSessionStats] = useState<SessionStatsResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const buildQuery = () => {
+    const params = new URLSearchParams({ range, granularity });
+    if (range === 'custom') {
+      if (customFrom) params.set('from', String(new Date(customFrom).getTime()));
+      if (customTo) params.set('to', String(new Date(customTo).getTime()));
+    }
+    return params.toString();
+  };
+
+  const load = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const q = buildQuery();
+      const [tRes, sRes] = await Promise.all([
+        fetch(`${apiBase}/stats/tokens?${q}`),
+        fetch(`${apiBase}/stats/sessions?${q}`),
+      ]);
+      if (!tRes.ok || !sRes.ok) throw new Error('Request failed');
+      const [tData, sData] = await Promise.all([tRes.json(), sRes.json()]) as [TokenStatsResponse, SessionStatsResponse];
+      setTokenStats(tData);
+      setSessionStats(sData);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); }, [range, granularity, apiBase]);
+
+  const summary = tokenStats?.summary;
+  const buckets = tokenStats?.buckets ?? [];
+  const sessions = sessionStats?.sessions ?? [];
+  const maxSessionTokens = Math.max(...sessions.map((s) => s.totalTokens), 1);
+
+  return (
+    <div className="stats-view">
+      {/* Controls */}
+      <div className="stats-controls">
+        <div className="stats-range-tabs">
+          {(['today', 'week', 'month', 'custom'] as const).map((r) => (
+            <button
+              key={r}
+              className={`tab-button ${range === r ? 'active' : ''}`}
+              onClick={() => setRange(r)}
+            >
+              {r === 'today' ? 'Today' : r === 'week' ? '7 Days' : r === 'month' ? '30 Days' : 'Custom'}
+            </button>
+          ))}
+        </div>
+        <div className="stats-granularity">
+          <span className="stats-ctrl-label">Granularity</span>
+          <select
+            className="filter-select"
+            value={granularity}
+            onChange={(e) => setGranularity(e.target.value as StatsGranularity)}
+          >
+            <option value="hour">Hour</option>
+            <option value="day">Day</option>
+            <option value="week">Week</option>
+          </select>
+        </div>
+        {range === 'custom' && (
+          <div className="stats-custom-range">
+            <input
+              type="date"
+              className="filter-input"
+              value={customFrom}
+              onChange={(e) => setCustomFrom(e.target.value)}
+            />
+            <span>→</span>
+            <input
+              type="date"
+              className="filter-input"
+              value={customTo}
+              onChange={(e) => setCustomTo(e.target.value)}
+            />
+            <button className="button" onClick={load}>Apply</button>
+          </div>
+        )}
+        {loading && <span className="stats-loading">Loading…</span>}
+      </div>
+
+      {error && <div className="error" style={{ marginBottom: 12 }}>{error}</div>}
+
+      {/* Summary Cards */}
+      {summary && (
+        <div className="stats-cards">
+          <StatCard label="Total Runs" value={String(summary.totalRuns)} />
+          <StatCard
+            label="Input Tokens"
+            value={formatK(summary.inputTokens)}
+            sub={`+${formatK(summary.cacheReadTokens)} cache hit`}
+          />
+          <StatCard label="Output Tokens" value={formatK(summary.outputTokens)} />
+          <StatCard label="Total Tokens" value={formatK(summary.totalTokens)} />
+          {summary.cacheReadTokens > 0 && (
+            <StatCard
+              label="Cache Read"
+              value={formatK(summary.cacheReadTokens)}
+              sub={`${Math.round((summary.cacheReadTokens / Math.max(summary.inputTokens, 1)) * 100)}% hit rate`}
+            />
+          )}
+          {summary.cacheWriteTokens > 0 && (
+            <StatCard label="Cache Write" value={formatK(summary.cacheWriteTokens)} />
+          )}
+        </div>
+      )}
+
+      {/* Time range label */}
+      {tokenStats && (
+        <div className="stats-range-label">
+          {formatDate(tokenStats.from)} – {formatDate(tokenStats.to)}
+          <span className="stats-grain-pill">{granularity}</span>
+        </div>
+      )}
+
+      {/* Bar Chart */}
+      <div className="stats-section">
+        <h3 className="stats-section-title">Token Usage Over Time</h3>
+        <BarChart buckets={buckets} />
+      </div>
+
+      {/* Session Breakdown */}
+      <div className="stats-section">
+        <h3 className="stats-section-title">Session Breakdown</h3>
+        {sessions.length > 0 ? (
+          <div className="stats-session-list">
+            {sessions.map((s) => {
+              const pct = Math.round((s.totalTokens / maxSessionTokens) * 100);
+              return (
+                <div key={s.sessionId} className="stats-session-row">
+                  <div className="stats-session-meta">
+                    <span className="stats-session-id" title={s.sessionId}>
+                      {s.sessionId === 'unknown' ? '(unknown)' : s.sessionId.slice(0, 24)}
+                    </span>
+                    <span className="stats-session-runs">{s.runCount} runs</span>
+                    <span className="stats-session-last">last {formatDate(s.lastRunAt)}</span>
+                  </div>
+                  <div className="stats-session-bar-row">
+                    <div className="bar-track" style={{ flex: 1 }}>
+                      <div className="bar-fill" style={{ width: `${pct}%` }} />
+                    </div>
+                    <span className="bar-value">{formatK(s.totalTokens)}</span>
+                  </div>
+                  <div className="stats-session-tokens">
+                    <span>In: {formatK(s.inputTokens)}</span>
+                    <span>Out: {formatK(s.outputTokens)}</span>
+                    {s.cacheReadTokens > 0 && <span>Cache: {formatK(s.cacheReadTokens)}</span>}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="empty">No session data in this range.</div>
+        )}
+      </div>
+    </div>
   );
 }

--- a/apps/devtools-web/src/styles.css
+++ b/apps/devtools-web/src/styles.css
@@ -803,3 +803,267 @@ th {
     text-align: left;
   }
 }
+
+/* ── Page Navigation ──────────────────────────────────────────────────────── */
+
+.page-nav {
+  display: flex;
+  gap: 6px;
+  padding: 0 2px;
+  margin-bottom: 4px;
+}
+
+.page-nav-btn {
+  border: 1px solid var(--border);
+  background: var(--panel-alt);
+  color: var(--text-muted);
+  padding: 8px 18px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.page-nav-btn:hover {
+  background: #f0efed;
+  color: var(--text);
+}
+
+.page-nav-btn.active {
+  background: var(--accent-soft);
+  border-color: rgba(15, 123, 108, 0.35);
+  color: var(--accent);
+}
+
+/* ── Stats View ───────────────────────────────────────────────────────────── */
+
+.stats-view {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.stats-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  background: var(--panel);
+  border-radius: var(--radius);
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.stats-range-tabs {
+  display: flex;
+  gap: 6px;
+}
+
+.stats-granularity {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.stats-ctrl-label {
+  font-size: 12px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.stats-custom-range {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.stats-custom-range input {
+  width: 140px;
+}
+
+.stats-loading {
+  font-size: 12px;
+  color: var(--text-muted);
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+/* Summary cards */
+
+.stats-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 12px;
+}
+
+.stat-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 14px 16px;
+  box-shadow: var(--shadow);
+}
+
+.stat-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  margin-bottom: 8px;
+}
+
+.stat-value {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.1;
+  font-family: "Newsreader", serif;
+}
+
+.stat-sub {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+
+/* Range label */
+
+.stats-range-label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.stats-grain-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  border: 1px solid rgba(15, 123, 108, 0.25);
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* Section */
+
+.stats-section {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 18px;
+  box-shadow: var(--shadow);
+}
+
+.stats-section-title {
+  margin: 0 0 14px;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+/* Bar chart */
+
+.bar-chart-wrap {
+  overflow-x: auto;
+  padding-bottom: 4px;
+}
+
+.chart-legend {
+  display: flex;
+  gap: 14px;
+  margin-top: 8px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+/* Session breakdown */
+
+.stats-session-list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.stats-session-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px;
+  background: #fcfbf9;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+}
+
+.stats-session-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.stats-session-id {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+  font-family: "Source Code Pro", monospace;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 220px;
+}
+
+.stats-session-runs {
+  font-size: 11px;
+  color: var(--text-muted);
+  background: #f0efed;
+  padding: 2px 7px;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.stats-session-last {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.stats-session-bar-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.stats-session-tokens {
+  display: flex;
+  gap: 12px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+@media (max-width: 960px) {
+  .stats-controls {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .stats-granularity {
+    margin-left: 0;
+  }
+  .stats-cards {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/apps/remote-server/src/routes/devtools.ts
+++ b/apps/remote-server/src/routes/devtools.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { devtoolsStore } from '../core/devtools.js';
+import type { TokenStatsGranularity } from 'pulse-coder-plugin-kit/devtools';
 
 export const devtoolsRouter = new Hono();
 
@@ -7,7 +8,12 @@ devtoolsRouter.get('/runs', (c) => {
   const status = c.req.query('status') as 'running' | 'finished' | undefined;
   const limitRaw = c.req.query('limit');
   const limit = limitRaw ? Math.max(1, Math.min(200, Number(limitRaw))) : 50;
-  const runs = devtoolsStore.listRuns({ status, limit });
+  const fromRaw = c.req.query('from');
+  const toRaw = c.req.query('to');
+  const sessionId = c.req.query('sessionId') || undefined;
+  const from = fromRaw ? Number(fromRaw) : undefined;
+  const to = toRaw ? Number(toRaw) : undefined;
+  const runs = devtoolsStore.listRuns({ status, limit, from, to, sessionId });
   return c.json({ ok: true, runs });
 });
 
@@ -23,4 +29,103 @@ devtoolsRouter.get('/runs/:runId', async (c) => {
     return c.json({ ok: false, error: 'Not found' }, 404);
   }
   return c.json({ ok: true, run });
+});
+
+// ── Token Stats ──────────────────────────────────────────────────────────────
+
+function resolveTimeRange(range: string | undefined, fromRaw: string | undefined, toRaw: string | undefined): { from: number; to: number } {
+  const now = Date.now();
+  if (range === 'today') {
+    const d = new Date();
+    const start = new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+    return { from: start, to: now };
+  }
+  if (range === 'week') {
+    return { from: now - 7 * 24 * 60 * 60 * 1000, to: now };
+  }
+  if (range === 'month') {
+    return { from: now - 30 * 24 * 60 * 60 * 1000, to: now };
+  }
+  if (range === 'custom' || (!range && fromRaw)) {
+    const from = fromRaw ? Number(fromRaw) : now - 7 * 24 * 60 * 60 * 1000;
+    const to = toRaw ? Number(toRaw) : now;
+    return { from, to };
+  }
+  // default: last 7 days
+  return { from: now - 7 * 24 * 60 * 60 * 1000, to: now };
+}
+
+devtoolsRouter.get('/stats/tokens', (c) => {
+  const range = c.req.query('range');
+  const fromRaw = c.req.query('from');
+  const toRaw = c.req.query('to');
+  const granularityRaw = c.req.query('granularity') as TokenStatsGranularity | undefined;
+  const sessionId = c.req.query('sessionId') || undefined;
+
+  const granularity: TokenStatsGranularity =
+    granularityRaw === 'hour' || granularityRaw === 'week' ? granularityRaw : 'day';
+
+  const { from, to } = resolveTimeRange(range, fromRaw, toRaw);
+
+  const result = devtoolsStore.getTokenStats({ from, to, granularity, sessionId });
+  return c.json({ ok: true, from, to, granularity, ...result });
+});
+
+// Per-session token breakdown within a time range
+devtoolsRouter.get('/stats/sessions', (c) => {
+  const range = c.req.query('range');
+  const fromRaw = c.req.query('from');
+  const toRaw = c.req.query('to');
+  const limitRaw = c.req.query('limit');
+  const limit = limitRaw ? Math.max(1, Math.min(100, Number(limitRaw))) : 20;
+
+  const { from, to } = resolveTimeRange(range, fromRaw, toRaw);
+
+  // Get all runs in range (no session filter) with a large limit from index
+  const runs = devtoolsStore.listRuns({ from, to, limit: 500 });
+
+  // Group by sessionId
+  const sessionMap = new Map<string, {
+    sessionId: string;
+    runCount: number;
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheWriteTokens: number;
+    totalTokens: number;
+    lastRunAt: number;
+  }>();
+
+  for (const run of runs) {
+    const key = run.sessionId ?? 'unknown';
+    let entry = sessionMap.get(key);
+    if (!entry) {
+      entry = {
+        sessionId: key,
+        runCount: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        totalTokens: 0,
+        lastRunAt: 0,
+      };
+      sessionMap.set(key, entry);
+    }
+    entry.runCount += 1;
+    entry.inputTokens += run.totalInputTokens ?? 0;
+    entry.outputTokens += run.totalOutputTokens ?? 0;
+    entry.cacheReadTokens += run.totalCacheReadTokens ?? 0;
+    entry.cacheWriteTokens += run.totalCacheWriteTokens ?? 0;
+    entry.totalTokens += (run.totalInputTokens ?? 0) + (run.totalOutputTokens ?? 0);
+    if (run.lastEventAt > entry.lastRunAt) {
+      entry.lastRunAt = run.lastEventAt;
+    }
+  }
+
+  const sessions = [...sessionMap.values()]
+    .sort((a, b) => b.totalTokens - a.totalTokens)
+    .slice(0, limit);
+
+  return c.json({ ok: true, from, to, sessions });
 });

--- a/packages/plugin-kit/src/devtools/index.ts
+++ b/packages/plugin-kit/src/devtools/index.ts
@@ -23,6 +23,44 @@ export interface DevtoolsRunSummary {
   llmCalls: number;
   toolCalls: number;
   compactions: number;
+  totalInputTokens?: number;
+  totalOutputTokens?: number;
+  totalCacheReadTokens?: number;
+  totalCacheWriteTokens?: number;
+}
+
+export type TokenStatsGranularity = 'hour' | 'day' | 'week';
+
+export interface TokenStatsBucket {
+  ts: number;
+  label: string;
+  runCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  totalTokens: number;
+}
+
+export interface TokenStatsSummary {
+  totalRuns: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  totalTokens: number;
+}
+
+export interface TokenStatsResult {
+  summary: TokenStatsSummary;
+  buckets: TokenStatsBucket[];
+}
+
+export interface TokenStatsOptions {
+  from: number;
+  to: number;
+  granularity?: TokenStatsGranularity;
+  sessionId?: string;
 }
 
 export interface DevtoolsLlmSpan {
@@ -111,6 +149,9 @@ interface DevtoolsRunCreateInput {
 interface DevtoolsRunListOptions {
   status?: RunStatus;
   limit?: number;
+  from?: number;
+  to?: number;
+  sessionId?: string;
 }
 
 interface DevtoolsRunUpdate {
@@ -315,8 +356,17 @@ export class DevtoolsStore {
 
   listRuns(options: DevtoolsRunListOptions = {}): DevtoolsRunSummary[] {
     const limit = Math.min(options.limit ?? 50, this.maxEntries);
-    const status = options.status;
-    const runs = status ? this.index.filter((item) => item.status === status) : this.index;
+    const { status, from, to, sessionId } = options;
+    let runs = status ? this.index.filter((item) => item.status === status) : this.index;
+    if (from !== undefined) {
+      runs = runs.filter((item) => item.startedAt >= from);
+    }
+    if (to !== undefined) {
+      runs = runs.filter((item) => item.startedAt <= to);
+    }
+    if (sessionId) {
+      runs = runs.filter((item) => item.sessionId === sessionId);
+    }
     return runs.slice(0, limit);
   }
 
@@ -578,6 +628,11 @@ export class DevtoolsStore {
   }
 
   private upsertSummary(record: DevtoolsRunRecord): void {
+    const totalInputTokens = record.llmSpans.reduce((s, x) => s + (x.inputTokens ?? 0), 0);
+    const totalOutputTokens = record.llmSpans.reduce((s, x) => s + (x.outputTokens ?? 0), 0);
+    const totalCacheReadTokens = record.llmSpans.reduce((s, x) => s + (x.cacheReadTokens ?? 0), 0);
+    const totalCacheWriteTokens = record.llmSpans.reduce((s, x) => s + (x.cacheWriteTokens ?? 0), 0);
+
     const summary: DevtoolsRunSummary = {
       runId: record.runId,
       status: record.status,
@@ -594,6 +649,10 @@ export class DevtoolsStore {
       llmCalls: record.llmCalls,
       toolCalls: record.toolCalls,
       compactions: record.compactions,
+      totalInputTokens: totalInputTokens > 0 ? totalInputTokens : undefined,
+      totalOutputTokens: totalOutputTokens > 0 ? totalOutputTokens : undefined,
+      totalCacheReadTokens: totalCacheReadTokens > 0 ? totalCacheReadTokens : undefined,
+      totalCacheWriteTokens: totalCacheWriteTokens > 0 ? totalCacheWriteTokens : undefined,
     };
 
     const existingIndex = this.index.findIndex((item) => item.runId === record.runId);
@@ -649,6 +708,127 @@ export class DevtoolsStore {
       JSON.stringify({ updatedAt: now(), runs: this.index }, null, 2),
       'utf-8',
     );
+  }
+
+  getTokenStats(options: TokenStatsOptions): TokenStatsResult {
+    const { from, to, granularity = 'day', sessionId } = options;
+
+    // Filter runs within the time range
+    let runs = this.index.filter((r) => r.startedAt >= from && r.startedAt <= to);
+    if (sessionId) {
+      runs = runs.filter((r) => r.sessionId === sessionId);
+    }
+
+    // Build bucket boundaries
+    const bucketMap = new Map<number, TokenStatsBucket>();
+
+    const getBucketTs = (ts: number): number => {
+      const d = new Date(ts);
+      if (granularity === 'hour') {
+        return new Date(d.getFullYear(), d.getMonth(), d.getDate(), d.getHours()).getTime();
+      }
+      if (granularity === 'week') {
+        const day = d.getDay(); // 0=Sun
+        const diff = day === 0 ? -6 : 1 - day; // align to Monday
+        const monday = new Date(d.getFullYear(), d.getMonth(), d.getDate() + diff);
+        return monday.getTime();
+      }
+      // default: day
+      return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+    };
+
+    const formatBucketLabel = (ts: number): string => {
+      const d = new Date(ts);
+      if (granularity === 'hour') {
+        const mm = String(d.getMonth() + 1).padStart(2, '0');
+        const dd = String(d.getDate()).padStart(2, '0');
+        const hh = String(d.getHours()).padStart(2, '0');
+        return `${d.getFullYear()}-${mm}-${dd} ${hh}:00`;
+      }
+      if (granularity === 'week') {
+        const mm = String(d.getMonth() + 1).padStart(2, '0');
+        const dd = String(d.getDate()).padStart(2, '0');
+        return `${d.getFullYear()}-${mm}-${dd}`;
+      }
+      const mm = String(d.getMonth() + 1).padStart(2, '0');
+      const dd = String(d.getDate()).padStart(2, '0');
+      return `${d.getFullYear()}-${mm}-${dd}`;
+    };
+
+    // Pre-fill all bucket slots so gaps show as zero
+    let cursor = getBucketTs(from);
+    const endTs = getBucketTs(to);
+    while (cursor <= endTs) {
+      bucketMap.set(cursor, {
+        ts: cursor,
+        label: formatBucketLabel(cursor),
+        runCount: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        totalTokens: 0,
+      });
+      // Advance by granularity
+      if (granularity === 'hour') {
+        cursor += 60 * 60 * 1000;
+      } else if (granularity === 'week') {
+        cursor += 7 * 24 * 60 * 60 * 1000;
+      } else {
+        cursor += 24 * 60 * 60 * 1000;
+      }
+    }
+
+    // Accumulate per run into buckets
+    const summary: TokenStatsSummary = {
+      totalRuns: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      totalTokens: 0,
+    };
+
+    for (const run of runs) {
+      const bucketTs = getBucketTs(run.startedAt);
+      let bucket = bucketMap.get(bucketTs);
+      if (!bucket) {
+        bucket = {
+          ts: bucketTs,
+          label: formatBucketLabel(bucketTs),
+          runCount: 0,
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+          totalTokens: 0,
+        };
+        bucketMap.set(bucketTs, bucket);
+      }
+      const inp = run.totalInputTokens ?? 0;
+      const out = run.totalOutputTokens ?? 0;
+      const cr = run.totalCacheReadTokens ?? 0;
+      const cw = run.totalCacheWriteTokens ?? 0;
+      const total = inp + out;
+
+      bucket.runCount += 1;
+      bucket.inputTokens += inp;
+      bucket.outputTokens += out;
+      bucket.cacheReadTokens += cr;
+      bucket.cacheWriteTokens += cw;
+      bucket.totalTokens += total;
+
+      summary.totalRuns += 1;
+      summary.inputTokens += inp;
+      summary.outputTokens += out;
+      summary.cacheReadTokens += cr;
+      summary.cacheWriteTokens += cw;
+      summary.totalTokens += total;
+    }
+
+    const buckets = [...bucketMap.values()].sort((a, b) => a.ts - b.ts);
+
+    return { summary, buckets };
   }
 }
 


### PR DESCRIPTION
Add token usage analytics to devtools, including backend aggregation and a new Stats page in the web UI.

## Changes

- **plugin-kit**: Extend `DevtoolsRunSummary` with `totalInputTokens`, `totalOutputTokens`, `totalCacheReadTokens`, `totalCacheWriteTokens` fields auto-computed from `llmSpans` on every upsert
- **plugin-kit**: Add `listRuns()` time-range filtering via `from` / `to` / `sessionId` params
- **plugin-kit**: Add `getTokenStats({ from, to, granularity, sessionId })` method — buckets runs by hour/day/week and returns summary + per-bucket totals
- **remote-server**: Add `GET /api/devtools/stats/tokens` — supports `range=today|week|month|custom` and `granularity=hour|day|week`
- **remote-server**: Add `GET /api/devtools/stats/sessions` — per-session token breakdown sorted by total tokens
- **remote-server**: Extend `GET /api/devtools/runs` with `from` / `to` / `sessionId` query params
- **devtools-web**: Add top-level page nav (⚡ Runs / 📊 Stats)
- **devtools-web**: New `StatsView` component with summary cards, stacked SVG bar chart (Input/Output), session breakdown list
- **devtools-web**: Add all `stats-*` CSS classes to `styles.css` (zero new dependencies)