### PR TITLE
fix(engine): append placeholder user when compact strips to all-assistant

### DIFF
--- a/packages/engine/src/context/index.ts
+++ b/packages/engine/src/context/index.ts
@@ -38,14 +38,29 @@ const ensureSummaryPrefix = (summary: string): string => {
  * Ensure compacted messages end with a user-role message.
  * Some providers (e.g. claude-opus-4.7 via copilot-api) reject requests
  * where the last message has role "assistant" (no prefill support).
- * Safety: never returns an empty array — falls back to original when all messages are assistant.
+ *
+ * Strategy:
+ *   1. Strip trailing assistant messages.
+ *   2. If everything is stripped (all-assistant input, e.g. summary-only
+ *      compact result), append a placeholder user message so the
+ *      conversation still ends with a user turn — never returns the
+ *      original all-assistant array, which would re-trigger the same 400.
  */
+const PLACEHOLDER_USER_MESSAGE: ModelMessage = {
+  role: 'user',
+  content: 'Please continue based on the context above.',
+};
+
 const ensureEndsWithUser = (messages: ModelMessage[]): ModelMessage[] => {
   let end = messages.length;
   while (end > 0 && messages[end - 1].role === 'assistant') {
     end--;
   }
-  if (end === 0) return messages;
+  if (end === 0) {
+    // All messages are assistant — keep them and append a placeholder user
+    // message so the request is well-formed for providers without prefill support.
+    return [...messages, PLACEHOLDER_USER_MESSAGE];
+  }
   return end === messages.length ? messages : messages.slice(0, end);
 };
 


### PR DESCRIPTION
## Problem

Even after PR #346 merged, prod still hit the **same** 400 error from `claude-opus-4.7`:

```
400: This model does not support assistant message prefill.
     The conversation must end with a user message.
```

Forensic from logs (`messages: [ [Object] ]` — only **1** message in the request):

```
09:51:53  compacted msgs:25→17 → msgs:21→2  (compact reduced to ~2)
09:51:52  400 (request had only 1 msg, role=assistant)
```

## Root Cause

`ensureEndsWithUser()` from PR #346 had this safety branch:

```ts
if (end === 0) return messages;  // ← all assistant → return as-is
```

When compact summary path produced `nextMessages = [{ role: 'assistant', summary }]` with empty `recentMessages`, stripping all assistants left an empty array. The safety fallback returned the original all-assistant array → re-triggered the same 400.

## Fix

When stripping leaves zero non-assistant messages, **append a placeholder user message** instead of returning the original:

```ts
return [...messages, { role: 'user', content: 'Please continue based on the context above.' }];
```

This:
- preserves the summary content (model still sees the assistant summary)
- guarantees the conversation ends with a user turn
- works for all providers (those with or without prefill support)

## Tests

- Build: ✅
- Tests: 15/15 ✅