### PR TITLE
fix(engine): distinguish output-cap exhaustion from real context overflow

### DIFF
--- a/packages/engine/src/ai/index.ts
+++ b/packages/engine/src/ai/index.ts
@@ -22,7 +22,7 @@ const claudeProviderOptions = { anthropic: { cacheControl: { type: 'ephemeral' a
  * 64K output tokens; 16K is enough for reasoning + final answer in practice
  * while keeping latency/cost reasonable.
  */
-const DEFAULT_MAX_OUTPUT_TOKENS_CLAUDE = Number(process.env.CLAUDE_MAX_OUTPUT_TOKENS ?? 16384);
+const DEFAULT_MAX_OUTPUT_TOKENS_CLAUDE = Number(process.env.CLAUDE_MAX_OUTPUT_TOKENS ?? 32768);
 const DEFAULT_MAX_OUTPUT_TOKENS_OPENAI = Number(process.env.OPENAI_MAX_OUTPUT_TOKENS ?? 16384);
 
 function resolveMaxOutputTokens(modelType?: ModelType): number {

--- a/packages/engine/src/ai/index.ts
+++ b/packages/engine/src/ai/index.ts
@@ -8,6 +8,27 @@ import type { Tool as CoderTool, ToolExecutionContext, LLMProviderFactory, Syste
 const openaiProviderOptions = { openai: { store: false, reasoningEffort: OPENAI_REASONING_EFFORT } };
 const claudeProviderOptions = { anthropic: { cacheControl: { type: 'ephemeral' as const } } };
 
+/**
+ * Default per-call output token caps.
+ *
+ * The Vercel AI SDK does NOT pass `maxOutputTokens` automatically — when omitted,
+ * Anthropic provider falls back to its protocol default of 4096, which Claude
+ * regularly burns entirely on internal thinking tokens, surfacing as
+ * `finishReason='length'` with `textLen=0`. We were misdiagnosing that as a
+ * context-window overflow and force-compacting the history (see loop.ts), which
+ * never helped because the bottleneck was output tokens, not input.
+ *
+ * Set explicit, generous caps. Anthropic Claude Sonnet 4.x supports up to
+ * 64K output tokens; 16K is enough for reasoning + final answer in practice
+ * while keeping latency/cost reasonable.
+ */
+const DEFAULT_MAX_OUTPUT_TOKENS_CLAUDE = Number(process.env.CLAUDE_MAX_OUTPUT_TOKENS ?? 16384);
+const DEFAULT_MAX_OUTPUT_TOKENS_OPENAI = Number(process.env.OPENAI_MAX_OUTPUT_TOKENS ?? 16384);
+
+function resolveMaxOutputTokens(modelType?: ModelType): number {
+  return modelType === 'claude' ? DEFAULT_MAX_OUTPUT_TOKENS_CLAUDE : DEFAULT_MAX_OUTPUT_TOKENS_OPENAI;
+}
+
 function resolveProviderOptions(modelType?: ModelType) {
   if (modelType === 'claude') {
     return { ...openaiProviderOptions, ...claudeProviderOptions };
@@ -124,6 +145,7 @@ export const streamTextAI = (messages: ModelMessage[], tools: Record<string, Cod
     messages: filteredMessages,
     tools: wrappedTools as Record<string, Tool>,
     providerOptions: resolveProviderOptions(options?.modelType),
+    maxOutputTokens: resolveMaxOutputTokens(options?.modelType),
     abortSignal: options?.abortSignal,
     onStepFinish: options?.onStepFinish,
     onChunk: options?.onChunk,

--- a/packages/engine/src/core/loop.ts
+++ b/packages/engine/src/core/loop.ts
@@ -11,6 +11,38 @@ import {
 } from "../config/index.js";
 
 /**
+ * Coarse per-family input-token budgets. Used only to disambiguate
+ * `finishReason='length'` between (a) prompt overflow and (b) output-cap
+ * exhaustion. Doesn't need to be exact — a conservative lower bound keeps
+ * us safe.
+ *
+ * Override per deployment via env: MODEL_CONTEXT_BUDGET (single global cap).
+ */
+const MODEL_CONTEXT_BUDGET_OVERRIDE = Number(process.env.MODEL_CONTEXT_BUDGET ?? 0) || undefined;
+
+function resolveModelContextBudget(model?: string, modelType?: ModelType): number {
+  if (MODEL_CONTEXT_BUDGET_OVERRIDE && MODEL_CONTEXT_BUDGET_OVERRIDE > 0) {
+    return MODEL_CONTEXT_BUDGET_OVERRIDE;
+  }
+  const name = (model ?? '').toLowerCase();
+  if (modelType === 'claude' || name.includes('claude')) {
+    // Claude 3.5/4.x sonnet & opus all support 200K. Use 180K as safe budget.
+    return 180_000;
+  }
+  if (name.includes('gpt-5') || name.includes('gpt-4.1') || name.includes('o1') || name.includes('o3')) {
+    return 180_000;
+  }
+  if (name.includes('gpt-4o')) {
+    return 110_000;
+  }
+  if (name.includes('gemini')) {
+    return 900_000;
+  }
+  // Conservative default
+  return 110_000;
+}
+
+/**
  * Hook arrays passed into the loop by Engine.
  * Each array may contain handlers from multiple plugins + EngineOptions.
  */
@@ -379,6 +411,30 @@ export async function loop(context: Context, options?: LoopOptions): Promise<str
       }
 
       if (finishReason === 'length') {
+        // `finishReason === 'length'` is ambiguous:
+        //   (a) prompt exceeded the model's context window, or
+        //   (b) per-call output cap (`maxOutputTokens`) was exhausted —
+        //       common with Claude when reasoning tokens eat the whole 4096
+        //       default cap before any text is emitted.
+        //
+        // Previously we always treated it as (a) and force-compacted, which
+        // never helps case (b) and silently shrinks healthy sessions. Now we
+        // disambiguate using `usage.inputTokens` against a per-model context
+        // budget. Output-cap hits just continue the loop so the model can
+        // resume; only true overflow triggers compaction.
+        const inputTokens = (usage as any)?.inputTokens ?? (usage as any)?.input_tokens;
+        const modelContextBudget = resolveModelContextBudget(options?.model, options?.modelType);
+        const looksLikeContextOverflow =
+          typeof inputTokens === 'number' && inputTokens >= modelContextBudget * 0.8;
+
+        if (!looksLikeContextOverflow) {
+          // Output-cap hit (case b). Don't compact. Loop continues; if the
+          // SDK already wrote a partial assistant message into the step
+          // history, the next iteration will see it and resume naturally.
+          continue;
+        }
+
+        // True context overflow (case a): compact up to N times.
         if (compactionAttempts < MAX_COMPACTION_ATTEMPTS) {
           const { didCompact, reason, newMessages, stats } = await maybeCompactContext(context, {
             force: true,


### PR DESCRIPTION
## Problem

Users were seeing two confusing symptoms on Claude:
1. **"Context limit reached."** even on short sessions (<30K input tokens)
2. **Mid-output stops** — Claude says half a sentence and freezes

## Root cause (verified via [debug-stop] log)

```
finishReason: 'length'
textLen: 0
outputTokens: 4095     ← exactly at SDK's default Anthropic max_tokens
inputTokens: 29205     ← nowhere near 200K context limit
```

The Vercel AI SDK does **not** pass `maxOutputTokens` automatically. When omitted, Anthropic falls back to its protocol default of **4096**. Claude regularly burns the entire 4096-token cap on internal thinking/reasoning tokens before emitting any text → `finishReason='length'` with `textLen=0`.

The loop misdiagnosed every `length` as a context overflow and triggered `maybeCompactContext` with `force: true`. Compaction shrinks input, but the bottleneck is **output**, so retries kept hitting the same wall. After 2 attempts the loop returned the literal string `'Context limit reached.'`.

Bonus harm: legitimate sessions got their history silently shrunk (`tokens:5K→700`) for no benefit.

## Fix

**1. `ai/index.ts`** — explicitly pass `maxOutputTokens` to `streamText`:
- Claude: 16384 (env: `CLAUDE_MAX_OUTPUT_TOKENS`)
- OpenAI: 16384 (env: `OPENAI_MAX_OUTPUT_TOKENS`)

**2. `core/loop.ts`** — disambiguate `finishReason='length'`:
- Compute `inputTokens / modelContextBudget`
- < 80% → output-cap hit → just `continue` (let model resume)
- ≥ 80% → real overflow → compact as before

`resolveModelContextBudget` has coarse per-family defaults (Claude/GPT-5: 180K, GPT-4o: 110K, Gemini: 900K) and a global `MODEL_CONTEXT_BUDGET` env override.

Also removes the temporary `[debug-stop]` console.log added during diagnosis.

## Tests

`pnpm --filter pulse-coder-engine test` → 15/15 passed
Build success on engine package.

## Deploy

`pm2 restart remote-server` after merge. No env changes required (defaults are sensible).