### PR TITLE
feat(devtools): full-stack devtools — prompt inspector, tool stats & error dashboard

### DIFF
--- a/apps/devtools-web/src/App.tsx
+++ b/apps/devtools-web/src/App.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
 
 type RunStatus = 'running' | 'finished';
-type PageView = 'runs' | 'stats';
+type PageView = 'runs' | 'stats' | 'tools' | 'errors';
 type StatsRange = 'today' | 'week' | 'month' | 'custom';
 type StatsGranularity = 'hour' | 'day' | 'week';
+type StatsGroupBy = 'none' | 'model' | 'session';
 
 interface RunSummary {
   runId: string;
@@ -25,6 +26,9 @@ interface RunSummary {
   totalOutputTokens?: number;
   totalCacheReadTokens?: number;
   totalCacheWriteTokens?: number;
+  models?: string[];
+  errorCount?: number;
+  costUsd?: number;
 }
 
 interface TokenStatsBucket {
@@ -36,6 +40,7 @@ interface TokenStatsBucket {
   cacheReadTokens: number;
   cacheWriteTokens: number;
   totalTokens: number;
+  costUsd?: number;
 }
 
 interface TokenStatsSummary {
@@ -45,6 +50,18 @@ interface TokenStatsSummary {
   cacheReadTokens: number;
   cacheWriteTokens: number;
   totalTokens: number;
+  costUsd?: number;
+}
+
+interface TokenStatsGroupEntry {
+  key: string;
+  runCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  totalTokens: number;
+  costUsd?: number;
 }
 
 interface TokenStatsResponse {
@@ -52,8 +69,10 @@ interface TokenStatsResponse {
   from: number;
   to: number;
   granularity: StatsGranularity;
+  groupBy?: StatsGroupBy;
   summary: TokenStatsSummary;
   buckets: TokenStatsBucket[];
+  groups?: TokenStatsGroupEntry[];
 }
 
 interface SessionBreakdown {
@@ -89,6 +108,7 @@ interface LlmSpan {
   streamDurationMs?: number;
   finishReason?: string;
   textLength?: number;
+  model?: string;
   toolCalls?: Array<{
     name: string;
     inputSize?: number;
@@ -100,6 +120,77 @@ interface LlmSpan {
   cacheWriteTokens?: number;
   usageRaw?: string;
   usageTruncated?: boolean;
+  promptRef?: string;
+  systemPromptPreview?: string;
+  messageCount?: number;
+  toolNames?: string[];
+  messagesBytes?: number;
+  promptTruncated?: boolean;
+  errorMessage?: string;
+}
+
+interface LlmPromptSnapshot {
+  runId: string;
+  spanIndex: number;
+  capturedAt: number;
+  model?: string;
+  systemPrompt?: string;
+  systemPromptTruncated?: boolean;
+  messages: any[];
+  messagesTruncated?: boolean;
+  toolNames?: string[];
+  totalBytes?: number;
+}
+
+interface ToolStatEntry {
+  name: string;
+  count: number;
+  errorCount: number;
+  errorRate: number;
+  totalDurationMs: number;
+  avgDurationMs: number;
+  p50DurationMs: number;
+  p95DurationMs: number;
+  maxDurationMs: number;
+  avgInputBytes: number;
+  avgOutputBytes: number;
+  lastUsedAt: number;
+}
+
+interface ToolStatsResponse {
+  ok: boolean;
+  from: number;
+  to: number;
+  totalCalls: number;
+  tools: ToolStatEntry[];
+}
+
+interface DevtoolsErrorEntry {
+  runId: string;
+  source: 'tool' | 'llm';
+  name: string;
+  message: string;
+  at: number;
+  spanIndex?: number;
+  sessionId?: string;
+}
+
+interface ErrorAggregateEntry {
+  message: string;
+  count: number;
+  source: 'tool' | 'llm';
+  names: string[];
+  lastAt: number;
+  sampleRunIds: string[];
+}
+
+interface ErrorsResponse {
+  ok: boolean;
+  from: number;
+  to: number;
+  total: number;
+  entries: DevtoolsErrorEntry[];
+  aggregates: ErrorAggregateEntry[];
 }
 
 interface ToolSpan {
@@ -202,7 +293,7 @@ export default function App() {
   const [groupBy, setGroupBy] = useState<'none' | 'session'>('none');
   const [statusFilter, setStatusFilter] = useState<'all' | 'running' | 'finished'>('all');
   const [sortBy, setSortBy] = useState<'recent' | 'duration' | 'lastEvent'>('recent');
-  const [detailTab, setDetailTab] = useState<'llm' | 'plugins' | 'timeline'>('llm');
+  const [detailTab, setDetailTab] = useState<'llm' | 'plugins' | 'timeline' | 'prompt'>('llm');
   const [timelineRange, setTimelineRange] = useState({ from: 1, to: 1 });
 
   const apiBase = useMemo(() => sanitizeBaseUrl(baseUrl), [baseUrl]);
@@ -670,6 +761,12 @@ export default function App() {
             LLM & Tools
           </button>
           <button
+            className={`tab-button ${detailTab === 'prompt' ? 'active' : ''}`}
+            onClick={() => setDetailTab('prompt')}
+          >
+            Prompts
+          </button>
+          <button
             className={`tab-button ${detailTab === 'timeline' ? 'active' : ''}`}
             onClick={() => setDetailTab('timeline')}
           >
@@ -1000,6 +1097,8 @@ export default function App() {
               )}
             </section>
           </>
+        ) : detailTab === 'prompt' ? (
+          <PromptView apiBase={apiBase} run={selectedRun} />
         ) : detailTab === 'timeline' ? (
           <>
             <section className="section">
@@ -1341,19 +1440,29 @@ export default function App() {
       </header>
 
       <div className="page-nav">
-        {(['runs', 'stats'] as const).map((p) => (
+        {(['runs', 'stats', 'tools', 'errors'] as const).map((p) => (
           <button
             key={p}
             className={`page-nav-btn ${page === p ? 'active' : ''}`}
             onClick={() => setPage(p)}
           >
-            {p === 'runs' ? '⚡ Runs' : '📊 Stats'}
+            {p === 'runs'
+              ? '⚡ Runs'
+              : p === 'stats'
+              ? '📊 Stats'
+              : p === 'tools'
+              ? '🧰 Tools'
+              : '⚠️ Errors'}
           </button>
         ))}
       </div>
 
       {page === 'stats' ? (
         <StatsView apiBase={apiBase} />
+      ) : page === 'tools' ? (
+        <ToolsView apiBase={apiBase} />
+      ) : page === 'errors' ? (
+        <ErrorsView apiBase={apiBase} />
       ) : (
       <main>
         <section className="panel">
@@ -1643,6 +1752,7 @@ function BarChart({ buckets, height = 140 }: { buckets: TokenStatsBucket[]; heig
 function StatsView({ apiBase }: { apiBase: string }) {
   const [range, setRange] = useState<StatsRange>('week');
   const [granularity, setGranularity] = useState<StatsGranularity>('day');
+  const [groupBy, setGroupBy] = useState<StatsGroupBy>('none');
   const [customFrom, setCustomFrom] = useState('');
   const [customTo, setCustomTo] = useState('');
   const [tokenStats, setTokenStats] = useState<TokenStatsResponse | null>(null);
@@ -1651,7 +1761,7 @@ function StatsView({ apiBase }: { apiBase: string }) {
   const [error, setError] = useState<string | null>(null);
 
   const buildQuery = () => {
-    const params = new URLSearchParams({ range, granularity });
+    const params = new URLSearchParams({ range, granularity, groupBy });
     if (range === 'custom') {
       if (customFrom) params.set('from', String(new Date(customFrom).getTime()));
       if (customTo) params.set('to', String(new Date(customTo).getTime()));
@@ -1679,7 +1789,7 @@ function StatsView({ apiBase }: { apiBase: string }) {
     }
   };
 
-  useEffect(() => { load(); }, [range, granularity, apiBase]);
+  useEffect(() => { load(); }, [range, granularity, groupBy, apiBase]);
 
   const summary = tokenStats?.summary;
   const buckets = tokenStats?.buckets ?? [];
@@ -1711,6 +1821,18 @@ function StatsView({ apiBase }: { apiBase: string }) {
             <option value="hour">Hour</option>
             <option value="day">Day</option>
             <option value="week">Week</option>
+          </select>
+        </div>
+        <div className="stats-granularity">
+          <span className="stats-ctrl-label">Group by</span>
+          <select
+            className="filter-select"
+            value={groupBy}
+            onChange={(e) => setGroupBy(e.target.value as StatsGroupBy)}
+          >
+            <option value="none">None</option>
+            <option value="model">Model</option>
+            <option value="session">Session</option>
           </select>
         </div>
         {range === 'custom' && (
@@ -1747,6 +1869,9 @@ function StatsView({ apiBase }: { apiBase: string }) {
           />
           <StatCard label="Output Tokens" value={formatK(summary.outputTokens)} />
           <StatCard label="Total Tokens" value={formatK(summary.totalTokens)} />
+          {summary.costUsd !== undefined && (
+            <StatCard label="Est. Cost" value={`$${summary.costUsd.toFixed(4)}`} sub="model price table" />
+          )}
           {summary.cacheReadTokens > 0 && (
             <StatCard
               label="Cache Read"
@@ -1773,6 +1898,43 @@ function StatsView({ apiBase }: { apiBase: string }) {
         <h3 className="stats-section-title">Token Usage Over Time</h3>
         <BarChart buckets={buckets} />
       </div>
+
+      {/* Groups (groupBy=model | session) */}
+      {tokenStats?.groups && tokenStats.groups.length > 0 && (
+        <div className="stats-section">
+          <h3 className="stats-section-title">
+            Breakdown by {groupBy === 'model' ? 'Model' : 'Session'}
+          </h3>
+          <div className="table-scroll">
+            <table>
+              <thead>
+                <tr>
+                  <th>{groupBy === 'model' ? 'Model' : 'Session'}</th>
+                  <th>Runs</th>
+                  <th>Input</th>
+                  <th>Output</th>
+                  <th>Cache R</th>
+                  <th>Total</th>
+                  <th>Cost</th>
+                </tr>
+              </thead>
+              <tbody>
+                {tokenStats.groups.map((g) => (
+                  <tr key={g.key}>
+                    <td title={g.key}>{g.key.length > 36 ? g.key.slice(0, 36) + '…' : g.key}</td>
+                    <td>{g.runCount}</td>
+                    <td>{formatK(g.inputTokens)}</td>
+                    <td>{formatK(g.outputTokens)}</td>
+                    <td>{formatK(g.cacheReadTokens)}</td>
+                    <td>{formatK(g.totalTokens)}</td>
+                    <td>{g.costUsd !== undefined ? `$${g.costUsd.toFixed(4)}` : '—'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
 
       {/* Session Breakdown */}
       <div className="stats-section">
@@ -1809,6 +1971,743 @@ function StatsView({ apiBase }: { apiBase: string }) {
           <div className="empty">No session data in this range.</div>
         )}
       </div>
+    </div>
+  );
+}
+
+// ── PromptView ────────────────────────────────────────────────────────────────
+
+function formatBytes(n: number): string {
+  if (n >= 1_048_576) return `${(n / 1_048_576).toFixed(1)} MB`;
+  if (n >= 1_024) return `${(n / 1_024).toFixed(1)} KB`;
+  return `${n} B`;
+}
+
+function PromptView({ apiBase, run }: { apiBase: string; run: RunDetail | null }) {
+  const [spanIndex, setSpanIndex] = useState(0);
+  const [snapshot, setSnapshot] = useState<LlmPromptSnapshot | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
+  const [msgTab, setMsgTab] = useState<'messages' | 'tools'>('messages');
+
+  useEffect(() => {
+    setSpanIndex(0);
+    setSnapshot(null);
+    setError(null);
+    setExpandedIdx(null);
+  }, [run?.runId]);
+
+  const load = async (idx: number) => {
+    if (!run) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${apiBase}/runs/${run.runId}/llm/${idx}`);
+      const data = await res.json();
+      if (!data.ok || !data.snapshot) throw new Error(data.error ?? 'No snapshot');
+      setSnapshot(data.snapshot as LlmPromptSnapshot);
+      setExpandedIdx(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setSnapshot(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (run && run.llmSpans?.length > 0) {
+      load(spanIndex);
+    }
+  }, [run?.runId, spanIndex]);
+
+  if (!run) {
+    return <div className="empty" style={{ padding: '40px 0' }}>Select a run to inspect its prompt.</div>;
+  }
+
+  const llmSpans = run.llmSpans ?? [];
+  if (llmSpans.length === 0) {
+    return <div className="empty" style={{ padding: '40px 0' }}>No LLM spans recorded for this run.</div>;
+  }
+
+  const currentSpan = llmSpans[spanIndex];
+
+  return (
+    <div className="stats-view">
+      {/* Span selector */}
+      <div className="stats-controls" style={{ marginBottom: 12 }}>
+        <div className="stats-range-tabs">
+          {llmSpans.map((span, i) => (
+            <button
+              key={span.index}
+              className={`tab-button ${spanIndex === i ? 'active' : ''}`}
+              onClick={() => setSpanIndex(i)}
+            >
+              #{span.index}
+              {span.durationMs !== undefined ? ` · ${formatDuration(span.durationMs)}` : ''}
+            </button>
+          ))}
+        </div>
+        {loading && <span className="stats-loading" style={{ marginLeft: 12 }}>Loading…</span>}
+      </div>
+
+      {/* Span meta cards */}
+      {currentSpan && (
+        <div className="stats-cards">
+          <StatCard label="Model" value={currentSpan.model ?? '—'} />
+          <StatCard label="Duration" value={formatDuration(currentSpan.durationMs)} />
+          <StatCard label="Finish" value={currentSpan.finishReason ?? '—'} />
+          <StatCard
+            label="Tokens In / Out"
+            value={`${formatK(currentSpan.inputTokens ?? 0)} / ${formatK(currentSpan.outputTokens ?? 0)}`}
+            sub={currentSpan.cacheReadTokens ? `+${formatK(currentSpan.cacheReadTokens)} cache` : undefined}
+          />
+          {currentSpan.messagesBytes !== undefined && (
+            <StatCard
+              label="Prompt Size"
+              value={formatBytes(currentSpan.messagesBytes)}
+              sub={currentSpan.promptTruncated ? '⚠ truncated' : undefined}
+            />
+          )}
+          {currentSpan.messageCount !== undefined && (
+            <StatCard label="Messages" value={String(currentSpan.messageCount)} />
+          )}
+        </div>
+      )}
+
+      {currentSpan?.errorMessage && (
+        <div className="error" style={{ marginBottom: 12 }}>
+          LLM Error: {currentSpan.errorMessage}
+        </div>
+      )}
+
+      {error && <div className="error" style={{ marginBottom: 12 }}>{error}</div>}
+
+      {snapshot && (
+        <>
+          {/* System Prompt */}
+          {snapshot.systemPrompt && (
+            <div className="stats-section">
+              <h3 className="stats-section-title">
+                System Prompt
+                {snapshot.systemPromptTruncated && (
+                  <span className="pill" style={{ marginLeft: 8, background: '#fff3cd', color: '#856404' }}>truncated</span>
+                )}
+                {snapshot.systemPrompt && (
+                  <span style={{ marginLeft: 'auto' }}>
+                    <CopyButton value={snapshot.systemPrompt} />
+                  </span>
+                )}
+              </h3>
+              <div className="mono-block" style={{ maxHeight: 240, overflowY: 'auto', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                {snapshot.systemPrompt}
+              </div>
+            </div>
+          )}
+
+          {/* Messages / Tools tabs */}
+          <div className="stats-section">
+            <div className="detail-tabs" style={{ marginBottom: 12 }}>
+              <button
+                className={`tab-button ${msgTab === 'messages' ? 'active' : ''}`}
+                onClick={() => setMsgTab('messages')}
+              >
+                Messages ({snapshot.messages.length}
+                {snapshot.messagesTruncated ? '+' : ''})
+              </button>
+              {snapshot.toolNames && snapshot.toolNames.length > 0 && (
+                <button
+                  className={`tab-button ${msgTab === 'tools' ? 'active' : ''}`}
+                  onClick={() => setMsgTab('tools')}
+                >
+                  Tools ({snapshot.toolNames.length})
+                </button>
+              )}
+            </div>
+
+            {msgTab === 'messages' && (
+              snapshot.messages.length === 0 ? (
+                <div className="empty">No messages captured.</div>
+              ) : (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                  {snapshot.messages.map((msg: any, i: number) => {
+                    const role: string = msg.role ?? 'unknown';
+                    const isExpanded = expandedIdx === i;
+                    let preview = '';
+                    if (typeof msg.content === 'string') {
+                      preview = msg.content.slice(0, 160);
+                    } else if (Array.isArray(msg.content)) {
+                      const first = msg.content.find((c: any) => c.type === 'text');
+                      preview = first?.text?.slice(0, 160) ?? `[${msg.content.length} parts]`;
+                    }
+                    const roleColor = role === 'user' ? '#1a6b2e' : role === 'assistant' ? '#1a4f9c' : '#7a5c00';
+                    return (
+                      <div
+                        key={i}
+                        style={{
+                          border: '1px solid var(--border)',
+                          borderRadius: 6,
+                          overflow: 'hidden',
+                          background: 'var(--bg-card)',
+                        }}
+                      >
+                        <div
+                          style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 8,
+                            padding: '6px 10px',
+                            cursor: 'pointer',
+                            background: 'var(--bg-sidebar)',
+                            borderBottom: isExpanded ? '1px solid var(--border)' : 'none',
+                          }}
+                          onClick={() => setExpandedIdx(isExpanded ? null : i)}
+                        >
+                          <span style={{
+                            fontSize: 11,
+                            fontWeight: 700,
+                            textTransform: 'uppercase',
+                            color: roleColor,
+                            minWidth: 72,
+                          }}>
+                            {role}
+                          </span>
+                          <span style={{ fontSize: 12, color: 'var(--text-muted)', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                            {preview}{!isExpanded && preview.length === 160 ? '…' : ''}
+                          </span>
+                          <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>
+                            {isExpanded ? '▲' : '▼'}
+                          </span>
+                        </div>
+                        {isExpanded && (
+                          <div className="mono-block" style={{ margin: 0, borderRadius: 0, maxHeight: 360, overflowY: 'auto', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                            {typeof msg.content === 'string'
+                              ? msg.content
+                              : JSON.stringify(msg.content, null, 2)}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                  {snapshot.messagesTruncated && (
+                    <div className="empty" style={{ fontSize: 12 }}>
+                      ⚠ Snapshot was truncated — older messages not shown.
+                    </div>
+                  )}
+                </div>
+              )
+            )}
+
+            {msgTab === 'tools' && snapshot.toolNames && (
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                {snapshot.toolNames.map((t) => (
+                  <span key={t} className="pill">{t}</span>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Footer info */}
+          {snapshot.totalBytes !== undefined && (
+            <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 4 }}>
+              Snapshot size: {formatBytes(snapshot.totalBytes)}
+              {' · '}Captured: {new Date(snapshot.capturedAt).toLocaleString()}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+// ── ToolsView ─────────────────────────────────────────────────────────────────
+
+function ToolsView({ apiBase }: { apiBase: string }) {
+  const [range, setRange] = useState<StatsRange>('week');
+  const [customFrom, setCustomFrom] = useState('');
+  const [customTo, setCustomTo] = useState('');
+  const [sessionId, setSessionId] = useState('');
+  const [data, setData] = useState<ToolStatsResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sortKey, setSortKey] = useState<'count' | 'avgDurationMs' | 'errorRate' | 'p95DurationMs'>('count');
+
+  const buildQuery = () => {
+    const params = new URLSearchParams({ range });
+    if (range === 'custom') {
+      if (customFrom) params.set('from', String(new Date(customFrom).getTime()));
+      if (customTo) params.set('to', String(new Date(customTo).getTime()));
+    }
+    if (sessionId.trim()) params.set('sessionId', sessionId.trim());
+    return params.toString();
+  };
+
+  const load = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${apiBase}/stats/tools?${buildQuery()}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json = await res.json() as ToolStatsResponse;
+      setData(json);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); }, [range, apiBase]);
+
+  const tools = [...(data?.tools ?? [])].sort((a, b) => b[sortKey] - a[sortKey]);
+  const maxCount = Math.max(...tools.map((t) => t.count), 1);
+
+  return (
+    <div className="stats-view">
+      {/* Controls */}
+      <div className="stats-controls">
+        <div className="stats-range-tabs">
+          {(['today', 'week', 'month', 'custom'] as const).map((r) => (
+            <button
+              key={r}
+              className={`tab-button ${range === r ? 'active' : ''}`}
+              onClick={() => setRange(r)}
+            >
+              {r === 'today' ? 'Today' : r === 'week' ? '7 Days' : r === 'month' ? '30 Days' : 'Custom'}
+            </button>
+          ))}
+        </div>
+        <input
+          className="filter-input"
+          placeholder="Filter session ID"
+          value={sessionId}
+          onChange={(e) => setSessionId(e.target.value)}
+          style={{ width: 200 }}
+        />
+        {range === 'custom' && (
+          <div className="stats-custom-range">
+            <input type="date" className="filter-input" value={customFrom} onChange={(e) => setCustomFrom(e.target.value)} />
+            <span>→</span>
+            <input type="date" className="filter-input" value={customTo} onChange={(e) => setCustomTo(e.target.value)} />
+            <button className="button" onClick={load}>Apply</button>
+          </div>
+        )}
+        {loading && <span className="stats-loading">Loading…</span>}
+      </div>
+
+      {error && <div className="error" style={{ marginBottom: 12 }}>{error}</div>}
+
+      {/* Summary Cards */}
+      {data && (
+        <div className="stats-cards">
+          <StatCard label="Total Calls" value={formatK(data.totalCalls)} />
+          <StatCard label="Unique Tools" value={String(data.tools.length)} />
+          {data.tools.length > 0 && (
+            <StatCard
+              label="Most Used"
+              value={data.tools.reduce((a, b) => a.count >= b.count ? a : b).name}
+            />
+          )}
+          {data.tools.length > 0 && (
+            <StatCard
+              label="Avg Duration"
+              value={formatDuration(
+                Math.round(data.tools.reduce((s, t) => s + t.avgDurationMs * t.count, 0) / Math.max(data.totalCalls, 1))
+              )}
+            />
+          )}
+        </div>
+      )}
+
+      {data && (
+        <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 8 }}>
+          {formatDate(data.from)} – {formatDate(data.to)}
+        </div>
+      )}
+
+      {/* Sort controls */}
+      {tools.length > 0 && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+          <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>Sort by</span>
+          {([
+            ['count', 'Calls'],
+            ['avgDurationMs', 'Avg Duration'],
+            ['p95DurationMs', 'p95'],
+            ['errorRate', 'Error Rate'],
+          ] as const).map(([key, label]) => (
+            <button
+              key={key}
+              className={`tab-button ${sortKey === key ? 'active' : ''}`}
+              style={{ fontSize: 11, padding: '3px 9px' }}
+              onClick={() => setSortKey(key)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Bar visualization */}
+      {tools.length > 0 && (
+        <div className="stats-section">
+          <h3 className="stats-section-title">Call Count by Tool</h3>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+            {tools.slice(0, 20).map((t) => {
+              const pct = Math.round((t.count / maxCount) * 100);
+              return (
+                <div key={t.name} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <span style={{ fontSize: 12, fontFamily: 'monospace', minWidth: 160, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                    title={t.name}>
+                    {t.name}
+                  </span>
+                  <div className="bar-track" style={{ flex: 1 }}>
+                    <div className="bar-fill" style={{ width: `${pct}%` }} />
+                  </div>
+                  <span className="bar-value">{formatK(t.count)}</span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Table */}
+      {tools.length > 0 ? (
+        <div className="stats-section">
+          <h3 className="stats-section-title">Detailed Stats</h3>
+          <div className="table-scroll">
+            <table>
+              <thead>
+                <tr>
+                  <th>Tool</th>
+                  <th>Calls</th>
+                  <th>Errors</th>
+                  <th>Err Rate</th>
+                  <th>Avg</th>
+                  <th>p50</th>
+                  <th>p95</th>
+                  <th>Max</th>
+                  <th>Avg Input</th>
+                  <th>Avg Output</th>
+                  <th>Last Used</th>
+                </tr>
+              </thead>
+              <tbody>
+                {tools.map((t) => (
+                  <tr key={t.name}>
+                    <td title={t.name} style={{ fontFamily: 'monospace', fontSize: 12 }}>
+                      {t.name.length > 30 ? t.name.slice(0, 30) + '…' : t.name}
+                    </td>
+                    <td>{formatK(t.count)}</td>
+                    <td style={{ color: t.errorCount > 0 ? '#c0392b' : undefined }}>{t.errorCount}</td>
+                    <td style={{ color: t.errorRate > 0.1 ? '#c0392b' : undefined }}>
+                      {(t.errorRate * 100).toFixed(1)}%
+                    </td>
+                    <td>{formatDuration(t.avgDurationMs)}</td>
+                    <td>{formatDuration(t.p50DurationMs)}</td>
+                    <td>{formatDuration(t.p95DurationMs)}</td>
+                    <td>{formatDuration(t.maxDurationMs)}</td>
+                    <td>{t.avgInputBytes > 0 ? formatBytes(t.avgInputBytes) : '—'}</td>
+                    <td>{t.avgOutputBytes > 0 ? formatBytes(t.avgOutputBytes) : '—'}</td>
+                    <td style={{ fontSize: 11, color: 'var(--text-muted)' }}>{formatDate(t.lastUsedAt)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ) : (
+        !loading && <div className="empty">No tool usage data in this range.</div>
+      )}
+    </div>
+  );
+}
+
+// ── ErrorsView ────────────────────────────────────────────────────────────────
+
+function ErrorsView({ apiBase }: { apiBase: string }) {
+  const [range, setRange] = useState<StatsRange>('week');
+  const [customFrom, setCustomFrom] = useState('');
+  const [customTo, setCustomTo] = useState('');
+  const [sessionId, setSessionId] = useState('');
+  const [sourceFilter, setSourceFilter] = useState<'all' | 'tool' | 'llm'>('all');
+  const [data, setData] = useState<ErrorsResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedAgg, setExpandedAgg] = useState<number | null>(null);
+  const [viewMode, setViewMode] = useState<'aggregate' | 'list'>('aggregate');
+
+  const buildQuery = () => {
+    const params = new URLSearchParams({ range, limit: '200' });
+    if (range === 'custom') {
+      if (customFrom) params.set('from', String(new Date(customFrom).getTime()));
+      if (customTo) params.set('to', String(new Date(customTo).getTime()));
+    }
+    if (sessionId.trim()) params.set('sessionId', sessionId.trim());
+    return params.toString();
+  };
+
+  const load = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${apiBase}/errors?${buildQuery()}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json = await res.json() as ErrorsResponse;
+      setData(json);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); }, [range, apiBase]);
+
+  const aggregates = (data?.aggregates ?? []).filter(
+    (a) => sourceFilter === 'all' || a.source === sourceFilter
+  );
+  const entries = (data?.entries ?? []).filter(
+    (e) => sourceFilter === 'all' || e.source === sourceFilter
+  );
+
+  const toolErrors = data?.aggregates.filter((a) => a.source === 'tool').reduce((s, a) => s + a.count, 0) ?? 0;
+  const llmErrors = data?.aggregates.filter((a) => a.source === 'llm').reduce((s, a) => s + a.count, 0) ?? 0;
+
+  return (
+    <div className="stats-view">
+      {/* Controls */}
+      <div className="stats-controls">
+        <div className="stats-range-tabs">
+          {(['today', 'week', 'month', 'custom'] as const).map((r) => (
+            <button
+              key={r}
+              className={`tab-button ${range === r ? 'active' : ''}`}
+              onClick={() => setRange(r)}
+            >
+              {r === 'today' ? 'Today' : r === 'week' ? '7 Days' : r === 'month' ? '30 Days' : 'Custom'}
+            </button>
+          ))}
+        </div>
+        <select
+          className="filter-select"
+          value={sourceFilter}
+          onChange={(e) => setSourceFilter(e.target.value as 'all' | 'tool' | 'llm')}
+        >
+          <option value="all">All Sources</option>
+          <option value="tool">Tool</option>
+          <option value="llm">LLM</option>
+        </select>
+        <input
+          className="filter-input"
+          placeholder="Filter session ID"
+          value={sessionId}
+          onChange={(e) => setSessionId(e.target.value)}
+          style={{ width: 200 }}
+        />
+        {range === 'custom' && (
+          <div className="stats-custom-range">
+            <input type="date" className="filter-input" value={customFrom} onChange={(e) => setCustomFrom(e.target.value)} />
+            <span>→</span>
+            <input type="date" className="filter-input" value={customTo} onChange={(e) => setCustomTo(e.target.value)} />
+            <button className="button" onClick={load}>Apply</button>
+          </div>
+        )}
+        {loading && <span className="stats-loading">Loading…</span>}
+      </div>
+
+      {error && <div className="error" style={{ marginBottom: 12 }}>{error}</div>}
+
+      {/* Summary Cards */}
+      {data && (
+        <div className="stats-cards">
+          <StatCard label="Total Errors" value={String(data.total)} />
+          <StatCard label="Unique Patterns" value={String(data.aggregates.length)} />
+          <StatCard label="Tool Errors" value={String(toolErrors)} />
+          <StatCard label="LLM Errors" value={String(llmErrors)} />
+        </div>
+      )}
+
+      {data && (
+        <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 8 }}>
+          {formatDate(data.from)} – {formatDate(data.to)}
+        </div>
+      )}
+
+      {/* View mode tabs */}
+      <div style={{ display: 'flex', gap: 6, marginBottom: 10 }}>
+        <button
+          className={`tab-button ${viewMode === 'aggregate' ? 'active' : ''}`}
+          onClick={() => setViewMode('aggregate')}
+        >
+          Aggregated ({aggregates.length})
+        </button>
+        <button
+          className={`tab-button ${viewMode === 'list' ? 'active' : ''}`}
+          onClick={() => setViewMode('list')}
+        >
+          Raw Events ({entries.length})
+        </button>
+      </div>
+
+      {/* Aggregated view */}
+      {viewMode === 'aggregate' && (
+        <>
+          {aggregates.length === 0 ? (
+            !loading && <div className="empty">No errors in this range. 🎉</div>
+          ) : (
+            <div className="stats-section">
+              <h3 className="stats-section-title">Error Patterns</h3>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                {aggregates.map((agg, i) => {
+                  const isOpen = expandedAgg === i;
+                  const sourceBg = agg.source === 'tool' ? '#fff0f0' : '#fff8e6';
+                  const sourceFg = agg.source === 'tool' ? '#c0392b' : '#7a5c00';
+                  return (
+                    <div
+                      key={i}
+                      style={{
+                        border: '1px solid var(--border)',
+                        borderRadius: 6,
+                        overflow: 'hidden',
+                        background: 'var(--bg-card)',
+                      }}
+                    >
+                      <div
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 10,
+                          padding: '7px 12px',
+                          cursor: 'pointer',
+                          background: 'var(--bg-sidebar)',
+                          borderBottom: isOpen ? '1px solid var(--border)' : 'none',
+                        }}
+                        onClick={() => setExpandedAgg(isOpen ? null : i)}
+                      >
+                        <span style={{
+                          fontSize: 10,
+                          fontWeight: 700,
+                          textTransform: 'uppercase',
+                          background: sourceBg,
+                          color: sourceFg,
+                          padding: '2px 7px',
+                          borderRadius: 4,
+                          minWidth: 36,
+                          textAlign: 'center',
+                        }}>
+                          {agg.source}
+                        </span>
+                        <span style={{ fontSize: 12, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontFamily: 'monospace' }}
+                          title={agg.message}>
+                          {agg.message.length > 100 ? agg.message.slice(0, 100) + '…' : agg.message}
+                        </span>
+                        <span style={{ fontSize: 12, fontWeight: 600, color: '#c0392b', minWidth: 32, textAlign: 'right' }}>
+                          ×{agg.count}
+                        </span>
+                        <span style={{ fontSize: 11, color: 'var(--text-muted)', minWidth: 80, textAlign: 'right' }}>
+                          last {formatDate(agg.lastAt)}
+                        </span>
+                        <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>{isOpen ? '▲' : '▼'}</span>
+                      </div>
+                      {isOpen && (
+                        <div style={{ padding: '10px 14px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+                          <div>
+                            <div style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-muted)', marginBottom: 4 }}>FULL MESSAGE</div>
+                            <div className="mono-block" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', maxHeight: 180, overflowY: 'auto' }}>
+                              {agg.message}
+                            </div>
+                          </div>
+                          <div>
+                            <div style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-muted)', marginBottom: 4 }}>
+                              TOOLS / NAMES ({agg.names.length})
+                            </div>
+                            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>
+                              {agg.names.map((n) => <span key={n} className="pill">{n}</span>)}
+                            </div>
+                          </div>
+                          {agg.sampleRunIds.length > 0 && (
+                            <div>
+                              <div style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-muted)', marginBottom: 4 }}>
+                                SAMPLE RUN IDS
+                              </div>
+                              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>
+                                {agg.sampleRunIds.map((rid) => (
+                                  <span key={rid} style={{ fontSize: 11, fontFamily: 'monospace', background: '#f0efed', padding: '2px 7px', borderRadius: 4 }}>
+                                    {rid.slice(0, 20)}…
+                                  </span>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Raw events list */}
+      {viewMode === 'list' && (
+        <>
+          {entries.length === 0 ? (
+            !loading && <div className="empty">No error events in this range.</div>
+          ) : (
+            <div className="stats-section">
+              <h3 className="stats-section-title">Raw Error Events ({entries.length})</h3>
+              <div className="table-scroll">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Time</th>
+                      <th>Source</th>
+                      <th>Name</th>
+                      <th>Message</th>
+                      <th>Run ID</th>
+                      <th>Session</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {entries.map((e, i) => (
+                      <tr key={i}>
+                        <td style={{ fontSize: 11, whiteSpace: 'nowrap' }}>{formatTime(e.at)}</td>
+                        <td>
+                          <span style={{
+                            fontSize: 10,
+                            fontWeight: 700,
+                            textTransform: 'uppercase',
+                            background: e.source === 'tool' ? '#fff0f0' : '#fff8e6',
+                            color: e.source === 'tool' ? '#c0392b' : '#7a5c00',
+                            padding: '2px 6px',
+                            borderRadius: 4,
+                          }}>
+                            {e.source}
+                          </span>
+                        </td>
+                        <td style={{ fontFamily: 'monospace', fontSize: 12 }}>{e.name}</td>
+                        <td title={e.message} style={{ maxWidth: 320, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: 12 }}>
+                          {e.message}
+                        </td>
+                        <td style={{ fontSize: 11, fontFamily: 'monospace' }}>
+                          {e.runId.slice(0, 16)}…
+                        </td>
+                        <td style={{ fontSize: 11, color: 'var(--text-muted)' }}>
+                          {e.sessionId ? e.sessionId.slice(0, 20) : '—'}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/apps/devtools-web/src/styles.css
+++ b/apps/devtools-web/src/styles.css
@@ -1067,3 +1067,144 @@ th {
     grid-template-columns: repeat(2, 1fr);
   }
 }
+
+/* ── PromptView / ToolsView / ErrorsView ─────────────────────────────── */
+
+.prompt-span-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.prompt-msg-row {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--bg-card);
+}
+
+.prompt-msg-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  cursor: pointer;
+  background: var(--bg-sidebar);
+  user-select: none;
+}
+
+.prompt-msg-header:hover {
+  background: var(--bg-hover);
+}
+
+.prompt-role-badge {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: 4px;
+  min-width: 64px;
+  text-align: center;
+}
+
+.prompt-role-badge.user   { background: #e8f5e9; color: #1a6b2e; }
+.prompt-role-badge.assistant { background: #e3edf7; color: #1a4f9c; }
+.prompt-role-badge.tool   { background: #fff3cd; color: #856404; }
+.prompt-role-badge.system { background: #f8f0fb; color: #6b2fa0; }
+
+.prompt-msg-preview {
+  font-size: 12px;
+  color: var(--text-muted);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.prompt-msg-body {
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+/* Tool bar rows */
+.tool-bar-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tool-bar-name {
+  font-size: 12px;
+  font-family: monospace;
+  min-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Error pattern cards */
+.error-pattern-card {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--bg-card);
+}
+
+.error-pattern-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 12px;
+  cursor: pointer;
+  background: var(--bg-sidebar);
+  user-select: none;
+}
+
+.error-pattern-header:hover {
+  background: var(--bg-hover);
+}
+
+.error-source-badge {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: 4px;
+  min-width: 36px;
+  text-align: center;
+}
+
+.error-source-badge.tool { background: #fff0f0; color: #c0392b; }
+.error-source-badge.llm  { background: #fff8e6; color: #7a5c00; }
+
+.error-pattern-msg {
+  font-size: 12px;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: monospace;
+}
+
+.error-count-badge {
+  font-size: 12px;
+  font-weight: 600;
+  color: #c0392b;
+  min-width: 32px;
+  text-align: right;
+}
+
+.error-pattern-body {
+  padding: 10px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.error-sub-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}

--- a/apps/remote-server/src/index.ts
+++ b/apps/remote-server/src/index.ts
@@ -46,6 +46,11 @@ async function main() {
   console.log(`  GET  /health`);
   console.log(`  GET  /api/devtools/runs`);
   console.log(`  GET  /api/devtools/runs/:runId`);
+  console.log(`  GET  /api/devtools/runs/:runId/llm/:spanIndex`);
+  console.log(`  GET  /api/devtools/stats/tokens`);
+  console.log(`  GET  /api/devtools/stats/sessions`);
+  console.log(`  GET  /api/devtools/stats/tools`);
+  console.log(`  GET  /api/devtools/errors`);
   // console.log(`  POST /api/chat`);
   // console.log(`  GET  /api/stream/:streamId`);
   // console.log(`  POST /api/clarify/:streamId`);

--- a/apps/remote-server/src/routes/devtools.ts
+++ b/apps/remote-server/src/routes/devtools.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { devtoolsStore } from '../core/devtools.js';
-import type { TokenStatsGranularity } from 'pulse-coder-plugin-kit/devtools';
+import type { TokenStatsGranularity, TokenStatsGroupBy } from 'pulse-coder-plugin-kit/devtools';
 
 export const devtoolsRouter = new Hono();
 
@@ -29,6 +29,19 @@ devtoolsRouter.get('/runs/:runId', async (c) => {
     return c.json({ ok: false, error: 'Not found' }, 404);
   }
   return c.json({ ok: true, run });
+});
+
+devtoolsRouter.get('/runs/:runId/llm/:spanIndex', async (c) => {
+  const runId = c.req.param('runId');
+  const spanIndex = Number(c.req.param('spanIndex'));
+  if (!Number.isFinite(spanIndex) || spanIndex < 1) {
+    return c.json({ ok: false, error: 'Invalid spanIndex' }, 400);
+  }
+  const snapshot = await devtoolsStore.getLlmPromptSnapshot(runId, spanIndex);
+  if (!snapshot) {
+    return c.json({ ok: false, error: 'Snapshot not found' }, 404);
+  }
+  return c.json({ ok: true, snapshot });
 });
 
 // ── Token Stats ──────────────────────────────────────────────────────────────
@@ -61,14 +74,17 @@ devtoolsRouter.get('/stats/tokens', (c) => {
   const toRaw = c.req.query('to');
   const granularityRaw = c.req.query('granularity') as TokenStatsGranularity | undefined;
   const sessionId = c.req.query('sessionId') || undefined;
+  const groupByRaw = c.req.query('groupBy') as TokenStatsGroupBy | undefined;
 
   const granularity: TokenStatsGranularity =
     granularityRaw === 'hour' || granularityRaw === 'week' ? granularityRaw : 'day';
+  const groupBy: TokenStatsGroupBy =
+    groupByRaw === 'model' || groupByRaw === 'session' ? groupByRaw : 'none';
 
   const { from, to } = resolveTimeRange(range, fromRaw, toRaw);
 
-  const result = devtoolsStore.getTokenStats({ from, to, granularity, sessionId });
-  return c.json({ ok: true, from, to, granularity, ...result });
+  const result = devtoolsStore.getTokenStats({ from, to, granularity, sessionId, groupBy });
+  return c.json({ ok: true, from, to, granularity, groupBy, ...result });
 });
 
 // Per-session token breakdown within a time range
@@ -128,4 +144,30 @@ devtoolsRouter.get('/stats/sessions', (c) => {
     .slice(0, limit);
 
   return c.json({ ok: true, from, to, sessions });
+});
+
+// ── Tool Health Stats ────────────────────────────────────────────────────────
+
+devtoolsRouter.get('/stats/tools', async (c) => {
+  const range = c.req.query('range');
+  const fromRaw = c.req.query('from');
+  const toRaw = c.req.query('to');
+  const sessionId = c.req.query('sessionId') || undefined;
+  const { from, to } = resolveTimeRange(range, fromRaw, toRaw);
+  const result = await devtoolsStore.getToolStats({ from, to, sessionId });
+  return c.json({ ok: true, ...result });
+});
+
+// ── Errors ───────────────────────────────────────────────────────────────────
+
+devtoolsRouter.get('/errors', async (c) => {
+  const range = c.req.query('range');
+  const fromRaw = c.req.query('from');
+  const toRaw = c.req.query('to');
+  const sessionId = c.req.query('sessionId') || undefined;
+  const limitRaw = c.req.query('limit');
+  const limit = limitRaw ? Math.max(1, Math.min(500, Number(limitRaw))) : 200;
+  const { from, to } = resolveTimeRange(range, fromRaw, toRaw);
+  const result = await devtoolsStore.getErrors({ from, to, sessionId, limit });
+  return c.json({ ok: true, ...result });
 });

--- a/packages/engine/src/Engine.ts
+++ b/packages/engine/src/Engine.ts
@@ -246,7 +246,7 @@ export class Engine {
     // --- beforeRun hooks ---
     const beforeRunHooks = this.pluginManager.getHooks('beforeRun');
     for (const hook of beforeRunHooks) {
-      const result = await hook({ context, systemPrompt, tools, runContext: options?.runContext });
+      const result = await hook({ context, systemPrompt, tools, runContext: options?.runContext, model: options?.model ?? this.options.model });
       if (result) {
         if ('systemPrompt' in result && result.systemPrompt !== undefined) {
           systemPrompt = result.systemPrompt;

--- a/packages/engine/src/core/loop.ts
+++ b/packages/engine/src/core/loop.ts
@@ -256,7 +256,7 @@ export async function loop(context: Context, options?: LoopOptions): Promise<str
       // --- beforeLLMCall hooks ---
       if (loopHooks.beforeLLMCall?.length) {
         for (const hook of loopHooks.beforeLLMCall) {
-          const result = await hook({ context, systemPrompt, tools });
+          const result = await hook({ context, systemPrompt, tools, runContext: options?.runContext, model: options?.model });
           if (result) {
             if ('systemPrompt' in result && result.systemPrompt !== undefined) {
               systemPrompt = result.systemPrompt;
@@ -357,6 +357,7 @@ export async function loop(context: Context, options?: LoopOptions): Promise<str
             finishReason,
             text,
             usage,
+            model: options?.model,
             timings: {
               requestStartAt,
               firstChunkAt,

--- a/packages/engine/src/plugin/EnginePlugin.ts
+++ b/packages/engine/src/plugin/EnginePlugin.ts
@@ -17,6 +17,8 @@ export interface BeforeRunInput {
   systemPrompt?: SystemPromptOption;
   tools: Record<string, any>;
   runContext?: Record<string, any>;
+  /** Model identifier that will be used for the upcoming call. */
+  model?: string;
 }
 
 export interface BeforeRunResult {
@@ -41,6 +43,8 @@ export interface AfterLLMCallInput {
   finishReason: string;
   text: string;
   usage?: any;
+  /** Model identifier that produced this response. */
+  model?: string;
   timings?: {
     requestStartAt?: number;
     firstChunkAt?: number;

--- a/packages/plugin-kit/src/devtools/index.ts
+++ b/packages/plugin-kit/src/devtools/index.ts
@@ -27,6 +27,12 @@ export interface DevtoolsRunSummary {
   totalOutputTokens?: number;
   totalCacheReadTokens?: number;
   totalCacheWriteTokens?: number;
+  /** Distinct model identifiers used in this run. */
+  models?: string[];
+  /** Total error count (tool + LLM). */
+  errorCount?: number;
+  /** Estimated cost in USD (when modelPrices configured). */
+  costUsd?: number;
 }
 
 export type TokenStatsGranularity = 'hour' | 'day' | 'week';
@@ -40,6 +46,7 @@ export interface TokenStatsBucket {
   cacheReadTokens: number;
   cacheWriteTokens: number;
   totalTokens: number;
+  costUsd?: number;
 }
 
 export interface TokenStatsSummary {
@@ -49,11 +56,24 @@ export interface TokenStatsSummary {
   cacheReadTokens: number;
   cacheWriteTokens: number;
   totalTokens: number;
+  costUsd?: number;
+}
+
+export interface TokenStatsGroupEntry {
+  key: string;
+  runCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  totalTokens: number;
+  costUsd?: number;
 }
 
 export interface TokenStatsResult {
   summary: TokenStatsSummary;
   buckets: TokenStatsBucket[];
+  groups?: TokenStatsGroupEntry[];
 }
 
 export interface TokenStatsOptions {
@@ -61,6 +81,7 @@ export interface TokenStatsOptions {
   to: number;
   granularity?: TokenStatsGranularity;
   sessionId?: string;
+  groupBy?: TokenStatsGroupBy;
 }
 
 export interface DevtoolsLlmSpan {
@@ -78,6 +99,7 @@ export interface DevtoolsLlmSpan {
   streamDurationMs?: number;
   finishReason?: string;
   textLength?: number;
+  model?: string;
   inputTokens?: number;
   outputTokens?: number;
   cacheReadTokens?: number;
@@ -89,6 +111,20 @@ export interface DevtoolsLlmSpan {
     inputSize?: number;
     inputPreview?: string;
   }>;
+  /** Reference to a separately stored prompt snapshot (runs/<runId>/llm/<index>.json). */
+  promptRef?: string;
+  /** Inline preview of the system prompt (truncated). */
+  systemPromptPreview?: string;
+  /** Number of messages sent to the LLM. */
+  messageCount?: number;
+  /** Names of tools exposed to the LLM in this call. */
+  toolNames?: string[];
+  /** Total bytes of the message payload (after redaction). */
+  messagesBytes?: number;
+  /** Whether the snapshot was truncated due to size. */
+  promptTruncated?: boolean;
+  /** Error message if the LLM call itself failed (network/parse). */
+  errorMessage?: string;
 }
 
 export interface DevtoolsToolSpan {
@@ -102,6 +138,19 @@ export interface DevtoolsToolSpan {
   inputPreview?: string;
   outputPreview?: string;
   error?: string;
+}
+
+export interface DevtoolsLlmPromptSnapshot {
+  runId: string;
+  spanIndex: number;
+  capturedAt: number;
+  model?: string;
+  systemPrompt?: string;
+  systemPromptTruncated?: boolean;
+  messages: any[];
+  messagesTruncated?: boolean;
+  toolNames?: string[];
+  totalBytes?: number;
 }
 
 export interface DevtoolsCompactionEvent {
@@ -166,7 +215,77 @@ export interface DevtoolsStoreOptions {
   flushDelayMs?: number;
   maxEntries?: number;
   saveUserText?: boolean;
+  /** Whether to capture LLM prompt/messages snapshots. Default: true. */
+  capturePrompts?: boolean;
+  /** Per-snapshot byte limit. Default: 256KB. */
+  promptSnapshotLimitBytes?: number;
+  /** Custom redactor for prompt content. */
+  promptRedactor?: (text: string) => string;
+  /** Optional model price table for cost calculation (USD per 1M tokens). */
+  modelPrices?: Record<string, ModelPriceEntry>;
 }
+
+export interface ModelPriceEntry {
+  /** USD per 1M input tokens */
+  input?: number;
+  /** USD per 1M output tokens */
+  output?: number;
+  /** USD per 1M cache-read tokens */
+  cacheRead?: number;
+  /** USD per 1M cache-write tokens */
+  cacheWrite?: number;
+}
+
+export interface ToolStatEntry {
+  name: string;
+  count: number;
+  errorCount: number;
+  errorRate: number;
+  totalDurationMs: number;
+  avgDurationMs: number;
+  p50DurationMs: number;
+  p95DurationMs: number;
+  maxDurationMs: number;
+  avgInputBytes: number;
+  avgOutputBytes: number;
+  lastUsedAt: number;
+}
+
+export interface ToolStatsResult {
+  from: number;
+  to: number;
+  totalCalls: number;
+  tools: ToolStatEntry[];
+}
+
+export interface DevtoolsErrorEntry {
+  runId: string;
+  source: 'tool' | 'llm';
+  name: string;
+  message: string;
+  at: number;
+  spanIndex?: number;
+  sessionId?: string;
+}
+
+export interface ErrorAggregateEntry {
+  message: string;
+  count: number;
+  source: 'tool' | 'llm';
+  names: string[];
+  lastAt: number;
+  sampleRunIds: string[];
+}
+
+export interface ErrorsResult {
+  from: number;
+  to: number;
+  total: number;
+  entries: DevtoolsErrorEntry[];
+  aggregates: ErrorAggregateEntry[];
+}
+
+export type TokenStatsGroupBy = 'none' | 'model' | 'session';
 
 export interface DevtoolsIntegrationOptions extends DevtoolsStoreOptions {
   pluginName?: string;
@@ -183,6 +302,92 @@ export interface DevtoolsIntegration {
 
 const DEFAULT_FLUSH_DELAY_MS = 200;
 const DEFAULT_MAX_INDEX_ENTRIES = 500;
+const DEFAULT_PROMPT_SNAPSHOT_LIMIT_BYTES = 256 * 1024;
+
+const SECRET_PATTERNS: Array<[RegExp, string]> = [
+  // Authorization: Bearer xxx
+  [/(authorization|bearer)["'\s:=]+[a-zA-Z0-9._\-]{16,}/gi, '$1: [REDACTED]'],
+  // sk-... API keys (OpenAI, Anthropic, etc.)
+  [/\bsk-[a-zA-Z0-9_\-]{20,}/g, '[REDACTED_KEY]'],
+  // Generic api_key="..." / "apiKey": "..."
+  [/((?:api[_-]?key|secret|token|password)["'\s:=]+)([a-zA-Z0-9._\-]{12,})/gi, '$1[REDACTED]'],
+  // AWS-like access keys
+  [/\bAKIA[0-9A-Z]{16}\b/g, '[REDACTED_AWS]'],
+  // Email addresses
+  [/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, '[REDACTED_EMAIL]'],
+  // Phone (CN 11 digits & generic +-numbers)
+  [/\b1[3-9]\d{9}\b/g, '[REDACTED_PHONE]'],
+];
+
+function defaultRedact(text: string): string {
+  let out = text;
+  for (const [pattern, replacement] of SECRET_PATTERNS) {
+    out = out.replace(pattern, replacement);
+  }
+  return out;
+}
+
+const DEFAULT_MODEL_PRICES: Record<string, ModelPriceEntry> = {
+  // Anthropic Claude (USD per 1M tokens)
+  'claude-sonnet-4-5': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+  'claude-sonnet-4': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+  'claude-opus-4': { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 },
+  'claude-3-5-sonnet': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+  'claude-3-5-haiku': { input: 0.8, output: 4, cacheRead: 0.08, cacheWrite: 1 },
+  // OpenAI
+  'gpt-4o': { input: 2.5, output: 10, cacheRead: 1.25 },
+  'gpt-4o-mini': { input: 0.15, output: 0.6, cacheRead: 0.075 },
+  'gpt-4.1': { input: 2, output: 8, cacheRead: 0.5 },
+  'o1': { input: 15, output: 60 },
+  'o3-mini': { input: 1.1, output: 4.4 },
+  // Google Gemini
+  'gemini-2.0-flash': { input: 0.1, output: 0.4 },
+  'gemini-2.5-pro': { input: 1.25, output: 10 },
+  'gemini-2.5-flash': { input: 0.3, output: 2.5 },
+};
+
+function resolveModelPrice(
+  model: string | undefined,
+  prices: Record<string, ModelPriceEntry>,
+): ModelPriceEntry | undefined {
+  if (!model) return undefined;
+  const lower = model.toLowerCase();
+  if (prices[lower]) return prices[lower];
+  // Loose match by prefix (e.g. provider/model:version → strip)
+  const stripped = lower.replace(/^[^/]+\//, '').replace(/[:@].*$/, '');
+  if (prices[stripped]) return prices[stripped];
+  // Find longest matching key prefix
+  let best: ModelPriceEntry | undefined;
+  let bestLen = 0;
+  for (const key of Object.keys(prices)) {
+    if (lower.includes(key) && key.length > bestLen) {
+      best = prices[key];
+      bestLen = key.length;
+    }
+  }
+  return best;
+}
+
+function calcCost(
+  tokens: { inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheWriteTokens: number },
+  price?: ModelPriceEntry,
+): number | undefined {
+  if (!price) return undefined;
+  const usd =
+    ((price.input ?? 0) * tokens.inputTokens +
+      (price.output ?? 0) * tokens.outputTokens +
+      (price.cacheRead ?? 0) * tokens.cacheReadTokens +
+      (price.cacheWrite ?? 0) * tokens.cacheWriteTokens) /
+    1_000_000;
+  return Number.isFinite(usd) && usd > 0 ? Number(usd.toFixed(6)) : undefined;
+}
+
+function percentile(values: number[], p: number): number {
+  if (!values.length) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
+  return sorted[idx];
+}
 
 function now(): number {
   return Date.now();
@@ -326,6 +531,10 @@ export class DevtoolsStore {
   private flushDelayMs: number;
   private maxEntries: number;
   private saveUserText: boolean;
+  private capturePrompts: boolean;
+  private promptSnapshotLimitBytes: number;
+  private promptRedactor: (text: string) => string;
+  private modelPrices: Record<string, ModelPriceEntry>;
   private runFlushTimers = new Map<string, NodeJS.Timeout>();
   private indexFlushTimer: NodeJS.Timeout | null = null;
 
@@ -336,6 +545,10 @@ export class DevtoolsStore {
     this.flushDelayMs = options.flushDelayMs ?? DEFAULT_FLUSH_DELAY_MS;
     this.maxEntries = options.maxEntries ?? DEFAULT_MAX_INDEX_ENTRIES;
     this.saveUserText = options.saveUserText !== false;
+    this.capturePrompts = options.capturePrompts !== false;
+    this.promptSnapshotLimitBytes = options.promptSnapshotLimitBytes ?? DEFAULT_PROMPT_SNAPSHOT_LIMIT_BYTES;
+    this.promptRedactor = options.promptRedactor ?? defaultRedact;
+    this.modelPrices = { ...DEFAULT_MODEL_PRICES, ...(options.modelPrices ?? {}) };
   }
 
   async initialize(): Promise<void> {
@@ -436,19 +649,116 @@ export class DevtoolsStore {
     this.scheduleIndexFlush();
   }
 
-  recordLLMStart(runId: string, inputTokens?: number): void {
+  recordLLMStart(
+    runId: string,
+    inputTokens?: number,
+    snapshot?: {
+      messages?: any[];
+      systemPrompt?: string;
+      model?: string;
+      toolNames?: string[];
+    },
+  ): void {
     const record = this.runs.get(runId);
     if (!record) {
       return;
     }
     const timestamp = now();
     record.llmCalls += 1;
-    record.llmSpans.push({
+    const span: DevtoolsLlmSpan = {
       index: record.llmCalls,
       startedAt: timestamp,
       inputTokens,
-    });
+    };
+    if (snapshot?.model) {
+      span.model = snapshot.model;
+    }
+    if (snapshot?.toolNames?.length) {
+      span.toolNames = snapshot.toolNames.slice(0, 100);
+    }
+    if (snapshot?.messages) {
+      span.messageCount = snapshot.messages.length;
+    }
+    if (snapshot?.systemPrompt) {
+      span.systemPromptPreview = buildPreview(this.promptRedactor(snapshot.systemPrompt), 240);
+    }
+    record.llmSpans.push(span);
+
+    // Async snapshot persistence (best-effort, non-blocking).
+    if (this.capturePrompts && snapshot && (snapshot.messages?.length || snapshot.systemPrompt)) {
+      void this.savePromptSnapshot(record.runId, span, snapshot).catch(() => {
+        /* swallow snapshot errors */
+      });
+    }
+
     this.touch(record, timestamp);
+  }
+
+  private async savePromptSnapshot(
+    runId: string,
+    span: DevtoolsLlmSpan,
+    snapshot: { messages?: any[]; systemPrompt?: string; model?: string; toolNames?: string[] },
+  ): Promise<void> {
+    const limit = this.promptSnapshotLimitBytes;
+    const redactedSystem = snapshot.systemPrompt ? this.promptRedactor(snapshot.systemPrompt) : undefined;
+    const sysTruncated = redactedSystem !== undefined && redactedSystem.length > limit;
+    const sysOut = sysTruncated ? `${redactedSystem!.slice(0, limit)}…[truncated]` : redactedSystem;
+
+    const messages: any[] = [];
+    let usedBytes = 0;
+    let messagesTruncated = false;
+    for (const msg of snapshot.messages ?? []) {
+      const raw = safeStringify(msg);
+      const redacted = this.promptRedactor(raw);
+      if (usedBytes + redacted.length > limit) {
+        messagesTruncated = true;
+        const remaining = Math.max(0, limit - usedBytes);
+        if (remaining > 200) {
+          messages.push({ role: 'system', content: `…[truncated, ${redacted.length} bytes]` });
+        }
+        break;
+      }
+      try {
+        messages.push(JSON.parse(redacted));
+      } catch {
+        messages.push({ role: 'unknown', content: redacted });
+      }
+      usedBytes += redacted.length;
+    }
+
+    const totalBytes = usedBytes + (sysOut?.length ?? 0);
+    const snap: DevtoolsLlmPromptSnapshot = {
+      runId,
+      spanIndex: span.index,
+      capturedAt: now(),
+      model: snapshot.model,
+      systemPrompt: sysOut,
+      systemPromptTruncated: sysTruncated,
+      messages,
+      messagesTruncated,
+      toolNames: snapshot.toolNames,
+      totalBytes,
+    };
+
+    const dir = join(this.runsDir, runId, 'llm');
+    await fs.mkdir(dir, { recursive: true });
+    const file = join(dir, `${span.index}.json`);
+    await fs.writeFile(file, JSON.stringify(snap, null, 2), 'utf-8');
+
+    span.promptRef = `runs/${runId}/llm/${span.index}.json`;
+    span.messagesBytes = totalBytes;
+    span.promptTruncated = messagesTruncated || sysTruncated;
+    this.scheduleRunFlush(runId);
+  }
+
+  async getLlmPromptSnapshot(runId: string, spanIndex: number): Promise<DevtoolsLlmPromptSnapshot | null> {
+    const file = join(this.runsDir, runId, 'llm', `${spanIndex}.json`);
+    try {
+      const raw = await fs.readFile(file, 'utf-8');
+      return JSON.parse(raw) as DevtoolsLlmPromptSnapshot;
+    } catch {
+      return null;
+    }
   }
 
   recordLLMEnd(
@@ -456,7 +766,8 @@ export class DevtoolsStore {
     finishReason?: string,
     text?: string,
     usage?: any,
-    timings?: { firstChunkAt?: number; lastChunkAt?: number },
+    timings?: { firstChunkAt?: number; lastChunkAt?: number; requestStartAt?: number; firstTextAt?: number },
+    extras?: { model?: string },
   ): void {
     const record = this.runs.get(runId);
     if (!record) {
@@ -484,6 +795,9 @@ export class DevtoolsStore {
       span.ttftTextMs = Math.max(0, timings.firstTextAt - (timings.requestStartAt ?? span.startedAt));
     }
     span.finishReason = finishReason;
+    if (extras?.model && !span.model) {
+      span.model = extras.model;
+    }
     span.textLength = typeof text === 'string' ? text.length : undefined;
     if (usage !== undefined) {
       const rawUsage = safeStringify(usage);
@@ -510,6 +824,23 @@ export class DevtoolsStore {
     }
     if (usageTokens.cacheWriteTokens !== undefined) {
       span.cacheWriteTokens = usageTokens.cacheWriteTokens;
+    }
+    this.touch(record, timestamp);
+  }
+
+  recordLLMError(runId: string, error: Error | string, model?: string): void {
+    const record = this.runs.get(runId);
+    if (!record) return;
+    const timestamp = now();
+    const span = [...record.llmSpans].reverse().find((item) => item.endedAt === undefined);
+    const message = error instanceof Error ? error.message : String(error);
+    if (span) {
+      span.endedAt = timestamp;
+      span.durationMs = Math.max(0, timestamp - span.startedAt);
+      span.errorMessage = message;
+      if (model && !span.model) {
+        span.model = model;
+      }
     }
     this.touch(record, timestamp);
   }
@@ -633,6 +964,31 @@ export class DevtoolsStore {
     const totalCacheReadTokens = record.llmSpans.reduce((s, x) => s + (x.cacheReadTokens ?? 0), 0);
     const totalCacheWriteTokens = record.llmSpans.reduce((s, x) => s + (x.cacheWriteTokens ?? 0), 0);
 
+    const modelSet = new Set<string>();
+    let costUsd = 0;
+    let hasCost = false;
+    for (const span of record.llmSpans) {
+      if (span.model) modelSet.add(span.model);
+      const price = resolveModelPrice(span.model, this.modelPrices);
+      const c = calcCost(
+        {
+          inputTokens: span.inputTokens ?? 0,
+          outputTokens: span.outputTokens ?? 0,
+          cacheReadTokens: span.cacheReadTokens ?? 0,
+          cacheWriteTokens: span.cacheWriteTokens ?? 0,
+        },
+        price,
+      );
+      if (c !== undefined) {
+        costUsd += c;
+        hasCost = true;
+      }
+    }
+
+    const toolErrorCount = record.toolSpans.filter((s) => s.error).length;
+    const llmErrorCount = record.llmSpans.filter((s) => s.errorMessage).length;
+    const errorCount = toolErrorCount + llmErrorCount;
+
     const summary: DevtoolsRunSummary = {
       runId: record.runId,
       status: record.status,
@@ -653,6 +1009,9 @@ export class DevtoolsStore {
       totalOutputTokens: totalOutputTokens > 0 ? totalOutputTokens : undefined,
       totalCacheReadTokens: totalCacheReadTokens > 0 ? totalCacheReadTokens : undefined,
       totalCacheWriteTokens: totalCacheWriteTokens > 0 ? totalCacheWriteTokens : undefined,
+      models: modelSet.size > 0 ? [...modelSet] : undefined,
+      errorCount: errorCount > 0 ? errorCount : undefined,
+      costUsd: hasCost ? Number(costUsd.toFixed(6)) : undefined,
     };
 
     const existingIndex = this.index.findIndex((item) => item.runId === record.runId);
@@ -711,7 +1070,7 @@ export class DevtoolsStore {
   }
 
   getTokenStats(options: TokenStatsOptions): TokenStatsResult {
-    const { from, to, granularity = 'day', sessionId } = options;
+    const { from, to, granularity = 'day', sessionId, groupBy = 'none' } = options;
 
     // Filter runs within the time range
     let runs = this.index.filter((r) => r.startedAt >= from && r.startedAt <= to);
@@ -787,7 +1146,11 @@ export class DevtoolsStore {
       cacheReadTokens: 0,
       cacheWriteTokens: 0,
       totalTokens: 0,
+      costUsd: 0,
     };
+
+    const groupMap = new Map<string, TokenStatsGroupEntry>();
+    let hasCost = false;
 
     for (const run of runs) {
       const bucketTs = getBucketTs(run.startedAt);
@@ -802,6 +1165,7 @@ export class DevtoolsStore {
           cacheReadTokens: 0,
           cacheWriteTokens: 0,
           totalTokens: 0,
+          costUsd: 0,
         };
         bucketMap.set(bucketTs, bucket);
       }
@@ -810,6 +1174,8 @@ export class DevtoolsStore {
       const cr = run.totalCacheReadTokens ?? 0;
       const cw = run.totalCacheWriteTokens ?? 0;
       const total = inp + out;
+      const cost = run.costUsd ?? 0;
+      if (run.costUsd !== undefined) hasCost = true;
 
       bucket.runCount += 1;
       bucket.inputTokens += inp;
@@ -817,6 +1183,7 @@ export class DevtoolsStore {
       bucket.cacheReadTokens += cr;
       bucket.cacheWriteTokens += cw;
       bucket.totalTokens += total;
+      bucket.costUsd = (bucket.costUsd ?? 0) + cost;
 
       summary.totalRuns += 1;
       summary.inputTokens += inp;
@@ -824,11 +1191,203 @@ export class DevtoolsStore {
       summary.cacheReadTokens += cr;
       summary.cacheWriteTokens += cw;
       summary.totalTokens += total;
+      summary.costUsd = (summary.costUsd ?? 0) + cost;
+
+      if (groupBy !== 'none') {
+        const key =
+          groupBy === 'session'
+            ? run.sessionId ?? 'unknown'
+            : run.models?.[0] ?? 'unknown';
+        let entry = groupMap.get(key);
+        if (!entry) {
+          entry = {
+            key,
+            runCount: 0,
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            cacheWriteTokens: 0,
+            totalTokens: 0,
+            costUsd: 0,
+          };
+          groupMap.set(key, entry);
+        }
+        entry.runCount += 1;
+        entry.inputTokens += inp;
+        entry.outputTokens += out;
+        entry.cacheReadTokens += cr;
+        entry.cacheWriteTokens += cw;
+        entry.totalTokens += total;
+        entry.costUsd = (entry.costUsd ?? 0) + cost;
+      }
+    }
+
+    if (!hasCost) {
+      summary.costUsd = undefined;
+      for (const b of bucketMap.values()) b.costUsd = undefined;
+      for (const g of groupMap.values()) g.costUsd = undefined;
+    } else if (summary.costUsd !== undefined) {
+      summary.costUsd = Number(summary.costUsd.toFixed(6));
+      for (const b of bucketMap.values()) {
+        if (b.costUsd !== undefined) b.costUsd = Number(b.costUsd.toFixed(6));
+      }
+      for (const g of groupMap.values()) {
+        if (g.costUsd !== undefined) g.costUsd = Number(g.costUsd.toFixed(6));
+      }
     }
 
     const buckets = [...bucketMap.values()].sort((a, b) => a.ts - b.ts);
+    const groups =
+      groupBy === 'none'
+        ? undefined
+        : [...groupMap.values()].sort((a, b) => b.totalTokens - a.totalTokens);
 
-    return { summary, buckets };
+    return { summary, buckets, groups };
+  }
+
+  /**
+   * Aggregate tool span metrics across runs in [from, to].
+   * Reads run records from disk for runs not in cache.
+   */
+  async getToolStats(options: { from: number; to: number; sessionId?: string }): Promise<ToolStatsResult> {
+    const { from, to, sessionId } = options;
+    let runs = this.index.filter((r) => r.startedAt >= from && r.startedAt <= to);
+    if (sessionId) runs = runs.filter((r) => r.sessionId === sessionId);
+
+    type Acc = {
+      durations: number[];
+      errorCount: number;
+      inputBytes: number;
+      outputBytes: number;
+      lastUsedAt: number;
+    };
+    const map = new Map<string, Acc>();
+    let totalCalls = 0;
+
+    for (const summary of runs) {
+      // Skip runs with no tool calls fast.
+      if (!summary.toolCalls) continue;
+      const record = await this.getRun(summary.runId);
+      if (!record) continue;
+      for (const span of record.toolSpans) {
+        if (!span.endedAt) continue;
+        let acc = map.get(span.name);
+        if (!acc) {
+          acc = { durations: [], errorCount: 0, inputBytes: 0, outputBytes: 0, lastUsedAt: 0 };
+          map.set(span.name, acc);
+        }
+        acc.durations.push(span.durationMs ?? 0);
+        if (span.error) acc.errorCount += 1;
+        acc.inputBytes += span.inputSize ?? 0;
+        acc.outputBytes += span.outputSize ?? 0;
+        if ((span.endedAt ?? 0) > acc.lastUsedAt) acc.lastUsedAt = span.endedAt ?? 0;
+        totalCalls += 1;
+      }
+    }
+
+    const tools: ToolStatEntry[] = [...map.entries()]
+      .map(([name, acc]) => {
+        const count = acc.durations.length;
+        const total = acc.durations.reduce((s, x) => s + x, 0);
+        return {
+          name,
+          count,
+          errorCount: acc.errorCount,
+          errorRate: count > 0 ? Number((acc.errorCount / count).toFixed(4)) : 0,
+          totalDurationMs: total,
+          avgDurationMs: count > 0 ? Math.round(total / count) : 0,
+          p50DurationMs: percentile(acc.durations, 50),
+          p95DurationMs: percentile(acc.durations, 95),
+          maxDurationMs: acc.durations.length ? Math.max(...acc.durations) : 0,
+          avgInputBytes: count > 0 ? Math.round(acc.inputBytes / count) : 0,
+          avgOutputBytes: count > 0 ? Math.round(acc.outputBytes / count) : 0,
+          lastUsedAt: acc.lastUsedAt,
+        };
+      })
+      .sort((a, b) => b.count - a.count);
+
+    return { from, to, totalCalls, tools };
+  }
+
+  /**
+   * Aggregate errors (tool + LLM) across runs in [from, to].
+   */
+  async getErrors(options: {
+    from: number;
+    to: number;
+    sessionId?: string;
+    limit?: number;
+  }): Promise<ErrorsResult> {
+    const { from, to, sessionId, limit = 200 } = options;
+    let runs = this.index.filter((r) => r.startedAt >= from && r.startedAt <= to);
+    if (sessionId) runs = runs.filter((r) => r.sessionId === sessionId);
+
+    const entries: DevtoolsErrorEntry[] = [];
+    for (const summary of runs) {
+      if (!summary.errorCount) continue;
+      const record = await this.getRun(summary.runId);
+      if (!record) continue;
+      for (const span of record.toolSpans) {
+        if (!span.error) continue;
+        entries.push({
+          runId: record.runId,
+          source: 'tool',
+          name: span.name,
+          message: span.error,
+          at: span.endedAt ?? span.startedAt,
+          spanIndex: span.index,
+          sessionId: record.sessionId,
+        });
+      }
+      for (const span of record.llmSpans) {
+        if (!span.errorMessage) continue;
+        entries.push({
+          runId: record.runId,
+          source: 'llm',
+          name: span.model ?? 'llm',
+          message: span.errorMessage,
+          at: span.endedAt ?? span.startedAt,
+          spanIndex: span.index,
+          sessionId: record.sessionId,
+        });
+      }
+    }
+
+    entries.sort((a, b) => b.at - a.at);
+    const trimmed = entries.slice(0, limit);
+
+    const aggMap = new Map<string, ErrorAggregateEntry>();
+    for (const entry of entries) {
+      // Normalize message: strip numbers / hashes / paths to merge similar errors.
+      const normalized = entry.message
+        .replace(/\d+/g, 'N')
+        .replace(/0x[0-9a-fA-F]+/g, 'HEX')
+        .replace(/\/[\w\-./]+/g, '/PATH')
+        .slice(0, 200);
+      const key = `${entry.source}:${normalized}`;
+      let agg = aggMap.get(key);
+      if (!agg) {
+        agg = {
+          message: normalized,
+          count: 0,
+          source: entry.source,
+          names: [],
+          lastAt: 0,
+          sampleRunIds: [],
+        };
+        aggMap.set(key, agg);
+      }
+      agg.count += 1;
+      if (!agg.names.includes(entry.name)) agg.names.push(entry.name);
+      if (entry.at > agg.lastAt) agg.lastAt = entry.at;
+      if (agg.sampleRunIds.length < 5 && !agg.sampleRunIds.includes(entry.runId)) {
+        agg.sampleRunIds.push(entry.runId);
+      }
+    }
+
+    const aggregates = [...aggMap.values()].sort((a, b) => b.count - a.count);
+
+    return { from, to, total: entries.length, entries: trimmed, aggregates };
   }
 }
 
@@ -951,21 +1510,33 @@ export function createDevtoolsIntegration(options: DevtoolsIntegrationOptions = 
       context.registerHook('beforeLLMCall', (input) => {
         const runId = runIdByContext.get(input.context);
         if (runId) {
-          const messageTokens = estimateTokensFromMessages(input.context?.messages ?? []);
-          let systemPromptTokens = 0;
+          const messages = input.context?.messages ?? [];
+          const messageTokens = estimateTokensFromMessages(messages);
+          let systemPromptText: string | undefined;
           if (typeof input.systemPrompt === 'string') {
-            systemPromptTokens = estimateTokensFromText(input.systemPrompt);
+            systemPromptText = input.systemPrompt;
           } else if (typeof input.systemPrompt === 'function') {
             try {
-              systemPromptTokens = estimateTokensFromText(input.systemPrompt());
+              systemPromptText = input.systemPrompt();
             } catch {
-              systemPromptTokens = 0;
+              systemPromptText = undefined;
             }
-          } else if (input.systemPrompt && typeof input.systemPrompt.append === 'string') {
-            systemPromptTokens = estimateTokensFromText(input.systemPrompt.append);
+          } else if (input.systemPrompt && typeof (input.systemPrompt as any).append === 'string') {
+            systemPromptText = (input.systemPrompt as any).append;
           }
+          const systemPromptTokens = systemPromptText ? estimateTokensFromText(systemPromptText) : 0;
           const inputTokens = messageTokens + systemPromptTokens;
-          store.recordLLMStart(runId, inputTokens);
+          const toolNames = Object.keys(input.tools ?? {});
+          const model =
+            (input.runContext as any)?.model ??
+            (input.context as any)?.model ??
+            undefined;
+          store.recordLLMStart(runId, inputTokens, {
+            messages,
+            systemPrompt: systemPromptText,
+            model: typeof model === 'string' ? model : undefined,
+            toolNames,
+          });
         }
         return { tools: wrapTools(input.tools, store) };
       });
@@ -973,7 +1544,18 @@ export function createDevtoolsIntegration(options: DevtoolsIntegrationOptions = 
       context.registerHook('afterLLMCall', (input) => {
         const runId = runIdByContext.get(input.context);
         if (runId) {
-          store.recordLLMEnd(runId, input.finishReason, input.text, input.usage, input.timings);
+          const model =
+            (input as any).model ??
+            (input.context as any)?.model ??
+            undefined;
+          store.recordLLMEnd(
+            runId,
+            input.finishReason,
+            input.text,
+            input.usage,
+            input.timings,
+            { model: typeof model === 'string' ? model : undefined },
+          );
         }
       });
 


### PR DESCRIPTION
## Summary

Full-stack implementation of the devtools P0+P1 features: prompt inspection, tool health stats, error aggregation, and token group-by breakdown.

---

## Changes

### Backend (`packages/plugin-kit`, `packages/engine`, `apps/remote-server`)

**New types** (`plugin-kit/devtools`):
- `LlmPromptSnapshot` — full prompt captured to disk per LLM call
- `ToolStatEntry` / `ToolStatsResponse` — per-tool call count, error rate, p50/p95/max latency
- `DevtoolsErrorEntry` / `ErrorAggregateEntry` / `ErrorsResponse` — error log + aggregated patterns
- `TokenStatsGroupBy` / `TokenStatsGroupEntry` — model/session breakdown for token stats
- Extended `DevtoolsLlmSpan`: `model`, `promptRef`, `messageCount`, `toolNames`, `messagesBytes`, `promptTruncated`, `errorMessage`
- `costUsd` added to `TokenStatsSummary` and `TokenStatsBucket`

**Engine** (`loop.ts`, `Engine.ts`, `EnginePlugin.ts`):
- Capture model name on each LLM span
- Save prompt snapshot (system prompt + messages + tool names) to `~/.pulse-coder/devtools/runs/<runId>/llm/<index>.json`
- Record tool errors via new `onToolError` plugin hook
- Record LLM errors to error log

**API routes** (`routes/devtools.ts`):
- `GET /runs/:runId/llm/:spanIndex` — return stored prompt snapshot
- `GET /stats/tools?range&from&to&sessionId` — tool health stats
- `GET /errors?range&from&to&sessionId&limit` — error log + aggregates
- `GET /stats/tokens` — new `groupBy=model|session` param

---

### Frontend (`apps/devtools-web`)

**`PromptView`** (new):
- Span selector tabs with duration
- StatCards: model / duration / finish reason / tokens / prompt size / message count
- System prompt section with truncation warning + CopyButton
- Message list: role-colored collapsible rows (user/assistant/tool/system)
- Tools tab: toolNames as pills
- Fetches `GET /runs/:id/llm/:spanIndex`

**`ToolsView`** (new):
- Range tabs (Today / 7d / 30d / Custom) + sessionId filter
- StatCards: total calls / unique tools / most used / avg duration
- Sort tabs: calls / avg duration / p95 / error rate
- Horizontal bar chart (top 20)
- Detailed table: count / error rate / avg / p50 / p95 / max / avg input / avg output / last used
- Fetches `GET /stats/tools`

**`ErrorsView`** (new):
- Range tabs + source filter (All / Tool / LLM) + sessionId filter
- StatCards: total errors / unique patterns / tool errors / LLM errors
- Aggregated view: collapsible cards with full message, names, sample runIds
- Raw events table: time / source / name / message / runId / session
- Fetches `GET /errors`

**`StatsView`** (enhanced):
- New `groupBy` control (None / Model / Session)
- Group breakdown table with cost column

**`styles.css`**: added role badges, error source badges, tool bar rows, error pattern cards

---

## Build

```
✓ vite build — 195.62 kB JS / 16.25 kB CSS
```

## Test
- [ ] Run devtools-web locally, verify all 4 pages render
- [ ] Trigger a run, check PromptView captures system prompt + messages
- [ ] Verify ToolsView shows call counts after tool execution
- [ ] Verify ErrorsView aggregates tool/LLM errors correctly