### PR TITLE
Add Heptabase-style mindmap node type to canvas

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
@@ -21,10 +21,10 @@ interface CanvasOverlaysProps {
   scale: number;
   chatPanelOpen?: boolean;
   onChatToggle?: () => void;
-  onCreateNode: (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe') => void;
+  onCreateNode: (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe' | 'mindmap') => void;
   onCloseContextMenu: () => void;
   onToolChange: (tool: string) => void;
-  onAddNode: (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe') => void;
+  onAddNode: (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe' | 'mindmap') => void;
   onResetTransform: () => void;
   onSearchSelect: (node: CanvasNode) => void;
   onCloseSearch: () => void;

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
@@ -52,6 +52,11 @@ interface CanvasSurfaceProps {
     minHeight?: number
   ) => void;
   onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
+  /** Dimension-only update that bypasses undo history. Used by nodes
+   *  whose size is derived from their content (e.g. mindmap auto-fits
+   *  to its topic tree) so every typed character doesn't spam the
+   *  history stack with a paired text + resize entry. */
+  onAutoResize: (id: string, width: number, height: number) => void;
   onRemove: (id: string) => void;
   onSelect: (id: string) => void;
   onFocus: (node: CanvasNode) => void;
@@ -92,6 +97,7 @@ export const CanvasSurface = ({
   onDragStart,
   onResizeStart,
   onUpdate,
+  onAutoResize,
   onRemove,
   onSelect,
   onFocus,
@@ -140,6 +146,7 @@ export const CanvasSurface = ({
         onDragStart={onDragStart}
         onResizeStart={onResizeStart}
         onUpdate={onUpdate}
+        onAutoResize={onAutoResize}
         onRemove={onRemove}
         onSelect={onSelect}
         onFocus={onFocus}

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -326,7 +326,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
   );
 
   const handleCreateNode = useCallback(
-    (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe') => {
+    (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe' | 'mindmap') => {
       if (!contextMenu) return;
       const node = addNode(type, contextMenu.canvasX, contextMenu.canvasY);
       setSelectedNodeIds([node.id]);
@@ -336,7 +336,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
   );
 
   const handleToolbarAddNode = useCallback(
-    (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe') => {
+    (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe' | 'mindmap') => {
       if (!containerRef.current) return;
       const rect = containerRef.current.getBoundingClientRect();
       const pos = screenToCanvas(rect.left + rect.width / 2, rect.top + rect.height / 2, containerRef.current);
@@ -346,11 +346,13 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
         : type === 'agent' ? 260
         : type === 'text' ? 130
         : type === 'iframe' ? 260
+        : type === 'mindmap' ? 320
         : 300;
       const halfH =
         type === 'frame' ? 200
         : type === 'text' ? 60
         : type === 'iframe' ? 200
+        : type === 'mindmap' ? 210
         : 150;
       const node = addNode(type, pos.x - halfW, pos.y - halfH);
       setSelectedNodeIds([node.id]);

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -450,6 +450,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
         onDragStart={onDragStart}
         onResizeStart={onResizeStart}
         onUpdate={updateNode}
+        onAutoResize={resizeNode}
         onRemove={removeNode}
         onSelect={(id) => {
           setSelectedNodeIds([id]);

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -279,35 +279,25 @@
   overflow: visible;
 }
 
-/* Mindmap nodes: chromeless like images/shapes. Heptabase-style mindmaps
- * float directly on the canvas with no surrounding card — text and
- * curves are the whole content. A soft outline appears on hover /
- * selection so the user can still find the hit box to drag/resize. */
-.canvas-node--mindmap {
-  background: transparent;
-  border: 1px solid transparent;
-  box-shadow: none;
-}
-
-.canvas-node--mindmap:hover {
-  border-color: rgba(0, 0, 0, 0.08);
-  box-shadow: none;
-}
-
-.canvas-node--mindmap.canvas-node--selected {
-  border-color: var(--accent-border);
-  box-shadow: 0 0 0 2px rgba(35, 131, 226, 0.12);
-}
-
+/* Mindmap nodes are entirely frame-less — text and curves ARE the
+ * whole node on the canvas, so even the hover / selected outlines
+ * used by image/shape nodes would feel like a surrounding box.
+ * Selection is communicated by per-topic accent bars inside the
+ * mindmap body, not by the canvas-node wrapper. */
+.canvas-node--mindmap,
+.canvas-node--mindmap:hover,
+.canvas-node--mindmap.canvas-node--selected,
 .canvas-node--mindmap.canvas-node--dragging,
 .canvas-node--mindmap.canvas-node--resizing {
-  box-shadow: var(--shadow-drag);
+  background: transparent;
+  border: none;
+  box-shadow: none;
 }
 
 .node-body--mindmap {
   padding: 0;
   height: 100%;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .node-close--floating {

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -292,6 +292,11 @@
   background: transparent;
   border: none;
   box-shadow: none;
+  /* Override .canvas-node's default overflow: hidden so SVG stroke
+   * linecaps and the close-button hover ring can render a pixel past
+   * the auto-sized bounds without getting cropped into the scrollbar
+   * flicker we saw at sub-pixel widths. */
+  overflow: visible;
 }
 
 .node-body--mindmap {

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -279,6 +279,37 @@
   overflow: visible;
 }
 
+/* Mindmap nodes: chromeless like images/shapes. Heptabase-style mindmaps
+ * float directly on the canvas with no surrounding card — text and
+ * curves are the whole content. A soft outline appears on hover /
+ * selection so the user can still find the hit box to drag/resize. */
+.canvas-node--mindmap {
+  background: transparent;
+  border: 1px solid transparent;
+  box-shadow: none;
+}
+
+.canvas-node--mindmap:hover {
+  border-color: rgba(0, 0, 0, 0.08);
+  box-shadow: none;
+}
+
+.canvas-node--mindmap.canvas-node--selected {
+  border-color: var(--accent-border);
+  box-shadow: 0 0 0 2px rgba(35, 131, 226, 0.12);
+}
+
+.canvas-node--mindmap.canvas-node--dragging,
+.canvas-node--mindmap.canvas-node--resizing {
+  box-shadow: var(--shadow-drag);
+}
+
+.node-body--mindmap {
+  padding: 0;
+  height: 100%;
+  overflow: hidden;
+}
+
 .node-close--floating {
   position: absolute;
   top: 4px;

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -231,7 +231,12 @@ export const CanvasNodeView = ({
         }}
       >
         <div className="node-body node-body--mindmap">
-          <MindmapNodeBody node={node} isSelected={isSelected} onUpdate={onUpdate} />
+          <MindmapNodeBody
+            node={node}
+            isSelected={isSelected}
+            onUpdate={onUpdate}
+            onSelectNode={onSelect}
+          />
         </div>
         <button className="node-close node-close--floating" onClick={handleClose} title="Remove">
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none">

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -212,6 +212,48 @@ export const CanvasNodeView = ({
     );
   }
 
+  if (node.type === "mindmap") {
+    return (
+      <div
+        className={classes}
+        style={{
+          transform: `translate(${node.x}px, ${node.y}px)`,
+          width: node.width,
+          height: node.height,
+        }}
+        onClick={handleNodeClick}
+        // The wrapper itself is the drag handle — topic pills inside
+        // stop propagation, so mousedown on the empty mindmap area
+        // bubbles here and starts a node drag.
+        onMouseDown={(e) => {
+          onSelect(node.id);
+          onDragStart(e, node);
+        }}
+      >
+        <div className="node-body node-body--mindmap">
+          <MindmapNodeBody node={node} isSelected={isSelected} onUpdate={onUpdate} />
+        </div>
+        <button className="node-close node-close--floating" onClick={handleClose} title="Remove">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <path d="M3 3l6 6M9 3l-6 6" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+          </svg>
+        </button>
+        <div
+          className="resize-handle resize-handle--right"
+          onMouseDown={makeResizeHandler("right")}
+        />
+        <div
+          className="resize-handle resize-handle--bottom"
+          onMouseDown={makeResizeHandler("bottom")}
+        />
+        <div
+          className="resize-handle resize-handle--corner"
+          onMouseDown={makeResizeHandler("bottom-right")}
+        />
+      </div>
+    );
+  }
+
   return (
     <div
       className={classes}
@@ -253,13 +295,6 @@ export const CanvasNodeView = ({
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
               <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.3" />
               <path d="M2 8h12M8 2c2 2 2 10 0 12M8 2c-2 2-2 10 0 12" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" />
-            </svg>
-          ) : node.type === "mindmap" ? (
-            <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
-              <circle cx="4" cy="8" r="1.8" stroke="currentColor" strokeWidth="1.3" />
-              <circle cx="12" cy="4" r="1.4" stroke="currentColor" strokeWidth="1.2" />
-              <circle cx="12" cy="12" r="1.4" stroke="currentColor" strokeWidth="1.2" />
-              <path d="M5.5 7l5 -2.5M5.5 9l5 2.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
             </svg>
           ) : (
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
@@ -320,8 +355,6 @@ export const CanvasNodeView = ({
           />
         ) : node.type === "iframe" ? (
           <IframeNodeBody node={node} workspaceId={workspaceId} onUpdate={onUpdate} />
-        ) : node.type === "mindmap" ? (
-          <MindmapNodeBody node={node} isSelected={isSelected} onUpdate={onUpdate} />
         ) : (
           <AgentNodeBody node={node} allNodes={allNodes} rootFolder={rootFolder} workspaceId={workspaceId} workspaceName={workspaceName} onUpdate={onUpdate} />
         )}

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -35,6 +35,10 @@ interface Props {
     minHeight?: number
   ) => void;
   onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
+  /** Dimension-only update that skips history. Content-sized nodes use
+   *  this to reconcile their on-canvas bounds with their rendered body
+   *  without polluting the undo stack. */
+  onAutoResize: (id: string, width: number, height: number) => void;
   onRemove: (id: string) => void;
   onSelect: (id: string) => void;
   onFocus: (node: CanvasNode) => void;
@@ -54,6 +58,7 @@ export const CanvasNodeView = ({
   onDragStart,
   onResizeStart,
   onUpdate,
+  onAutoResize,
   onRemove,
   onSelect,
   onFocus
@@ -213,6 +218,10 @@ export const CanvasNodeView = ({
   }
 
   if (node.type === "mindmap") {
+    // Mindmaps are fully chromeless and content-sized: no border, no
+    // hover/selected outline, no resize handles. MindmapNodeBody
+    // reports the rendered bounding box via `onAutoResize`, so the
+    // canvas node's width/height track the topic tree automatically.
     return (
       <div
         className={classes}
@@ -236,6 +245,7 @@ export const CanvasNodeView = ({
             isSelected={isSelected}
             onUpdate={onUpdate}
             onSelectNode={onSelect}
+            onAutoResize={onAutoResize}
           />
         </div>
         <button className="node-close node-close--floating" onClick={handleClose} title="Remove">
@@ -243,18 +253,6 @@ export const CanvasNodeView = ({
             <path d="M3 3l6 6M9 3l-6 6" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
           </svg>
         </button>
-        <div
-          className="resize-handle resize-handle--right"
-          onMouseDown={makeResizeHandler("right")}
-        />
-        <div
-          className="resize-handle resize-handle--bottom"
-          onMouseDown={makeResizeHandler("bottom")}
-        />
-        <div
-          className="resize-handle resize-handle--corner"
-          onMouseDown={makeResizeHandler("bottom-right")}
-        />
       </div>
     );
   }

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -10,6 +10,7 @@ import { TextNodeBody, TextColorPicker } from "../TextNodeBody";
 import { IframeNodeBody } from "../IframeNodeBody";
 import { ImageNodeBody } from "../ImageNodeBody";
 import { ShapeNodeBody, ShapeStylePicker } from "../ShapeNodeBody";
+import { MindmapNodeBody } from "../MindmapNodeBody";
 
 interface Props {
   node: CanvasNode;
@@ -253,6 +254,13 @@ export const CanvasNodeView = ({
               <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.3" />
               <path d="M2 8h12M8 2c2 2 2 10 0 12M8 2c-2 2-2 10 0 12" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" />
             </svg>
+          ) : node.type === "mindmap" ? (
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+              <circle cx="4" cy="8" r="1.8" stroke="currentColor" strokeWidth="1.3" />
+              <circle cx="12" cy="4" r="1.4" stroke="currentColor" strokeWidth="1.2" />
+              <circle cx="12" cy="12" r="1.4" stroke="currentColor" strokeWidth="1.2" />
+              <path d="M5.5 7l5 -2.5M5.5 9l5 2.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+            </svg>
           ) : (
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
               <circle cx="8" cy="5.5" r="3" stroke="currentColor" strokeWidth="1.3" />
@@ -312,6 +320,8 @@ export const CanvasNodeView = ({
           />
         ) : node.type === "iframe" ? (
           <IframeNodeBody node={node} workspaceId={workspaceId} onUpdate={onUpdate} />
+        ) : node.type === "mindmap" ? (
+          <MindmapNodeBody node={node} isSelected={isSelected} onUpdate={onUpdate} />
         ) : (
           <AgentNodeBody node={node} allNodes={allNodes} rootFolder={rootFolder} workspaceId={workspaceId} workspaceName={workspaceName} onUpdate={onUpdate} />
         )}

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
@@ -4,7 +4,7 @@ import { ShapeToolButton } from './ShapeToolButton';
 interface Props {
   activeTool: string;
   onToolChange: (tool: string) => void;
-  onAddNode: (type: "file" | "terminal" | "frame" | "agent" | "text" | "iframe") => void;
+  onAddNode: (type: "file" | "terminal" | "frame" | "agent" | "text" | "iframe" | "mindmap") => void;
   chatPanelOpen?: boolean;
   onChatToggle?: () => void;
 }
@@ -199,6 +199,23 @@ export const FloatingToolbar = ({
             <circle cx="10.5" cy="6" r="0.7" fill="currentColor" />
           </svg>
           <span className="toolbar-btn-label">Agent</span>
+        </button>
+        <button
+          className="toolbar-btn toolbar-btn--create"
+          onClick={() => onAddNode("mindmap")}
+          title="Add Mindmap"
+        >
+          <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+            <circle cx="4.5" cy="9" r="2" stroke="currentColor" strokeWidth="1.3" />
+            <circle cx="14" cy="4.5" r="1.5" stroke="currentColor" strokeWidth="1.2" />
+            <circle cx="14" cy="9" r="1.5" stroke="currentColor" strokeWidth="1.2" />
+            <circle cx="14" cy="13.5" r="1.5" stroke="currentColor" strokeWidth="1.2" />
+            <path
+              d="M6.5 8.2 L12.5 5 M6.5 9 L12.5 9 M6.5 9.8 L12.5 13"
+              stroke="currentColor" strokeWidth="1.2" strokeLinecap="round"
+            />
+          </svg>
+          <span className="toolbar-btn-label">Mindmap</span>
         </button>
       </div>
     </div>

--- a/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.css
@@ -40,9 +40,9 @@
   left: 0;
   box-sizing: border-box;
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   justify-content: flex-start;
-  padding: 0 8px 4px 8px;
+  padding: 0 8px;
   font-size: 14px;
   line-height: 1.3;
   color: #1f2328;
@@ -77,23 +77,28 @@
  * colored by the topic's branch. Deliberately quieter than a full
  * underline / ring — the text itself stays unmodified so selected
  * doesn't look like "something's wrong with this text".
+ *
+ * The bar is centered on the topic's vertical middle (1em-ish tall)
+ * so it sits next to the text rather than spanning the whole slot,
+ * which would look disconnected now that text is centered on the
+ * branch line.
  */
 .mindmap-topic--selected::before {
   content: "";
   position: absolute;
   left: 0;
-  top: 6px;
-  bottom: 6px;
+  top: 50%;
   width: 2px;
+  height: 1em;
+  margin-top: -0.5em;
   border-radius: 1px;
   background: var(--mindmap-topic-accent, #5b7cbf);
 }
 
 .mindmap-topic--root.mindmap-topic--selected::before {
-  /* For the root (no underline / branch track), pad the bar inwards so
-   * it doesn't crowd the text or sit outside the visual centerline. */
-  top: 10px;
-  bottom: 10px;
+  /* Root is larger; give its accent bar a bit more height to match. */
+  height: 1.1em;
+  margin-top: -0.55em;
   left: 2px;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.css
@@ -55,17 +55,32 @@
   font-weight: 500;
   padding: 0 10px;
   color: #1f2328;
+  white-space: nowrap;
 }
 
 /*
- * Selection cue: a soft dashed underline in the topic's branch color
- * (piped in via the `--mindmap-topic-accent` custom property set on
- * each pill inline). We deliberately avoid box-shadow / fill / border
- * here so the mindmap stays "text + curves" even when selected.
+ * Selection cue: a 2px accent bar on the left side of the topic,
+ * colored by the topic's branch. Deliberately quieter than a full
+ * underline / ring — the text itself stays unmodified so selected
+ * doesn't look like "something's wrong with this text".
  */
-.mindmap-topic--selected .mindmap-topic-text {
-  text-decoration: underline dotted var(--mindmap-topic-accent, #5b7cbf);
-  text-underline-offset: 4px;
+.mindmap-topic--selected::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 6px;
+  bottom: 6px;
+  width: 2px;
+  border-radius: 1px;
+  background: var(--mindmap-topic-accent, #5b7cbf);
+}
+
+.mindmap-topic--root.mindmap-topic--selected::before {
+  /* For the root (no underline / branch track), pad the bar inwards so
+   * it doesn't crowd the text or sit outside the visual centerline. */
+  top: 10px;
+  bottom: 10px;
+  left: 2px;
 }
 
 .mindmap-topic--editing {
@@ -81,6 +96,7 @@
 .mindmap-topic-text {
   flex: 0 1 auto;
   min-height: 16px;
+  min-width: 8px;
   max-width: 100%;
   padding: 1px 3px;
   outline: none;
@@ -91,39 +107,32 @@
   color: inherit;
 }
 
-/* ---- Collapse control ---- */
+/*
+ * Empty-topic placeholder. We render the placeholder via ::before so it
+ * never touches the contenteditable DOM tree — typing replaces the
+ * empty element's text normally, and the ::before disappears because
+ * the rule no longer applies (we toggle a class, not :empty, because
+ * browsers may fill empty contenteditable with a lone <br>).
+ */
+.mindmap-topic-text--empty::before {
+  content: attr(data-placeholder);
+  color: #9aa0a6;
+  opacity: 0.75;
+  font-style: italic;
+  pointer-events: none;
+}
 
 /*
- * Hidden by default; shown on hover or when the topic is selected. The
- * circle is tinted with the branch color but deliberately small so it
- * doesn't compete with the text.
+ * Collapsed-subtree hint: a small dot after the text. Signals "this
+ * topic has hidden children" without the overhead of an explicit
+ * expand/collapse button.
  */
-.mindmap-topic-collapse {
+.mindmap-topic-collapsed-dot {
   flex: 0 0 auto;
   margin-left: 6px;
-  margin-bottom: 1px;
-  width: 14px;
-  height: 14px;
-  border: 1px solid currentColor;
+  margin-bottom: 3px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
-  background: #ffffff;
-  font-size: 10px;
-  line-height: 1;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  padding: 0;
-  font-weight: 600;
-  opacity: 0;
-  transition: opacity 0.12s ease;
-}
-
-.mindmap-topic:hover .mindmap-topic-collapse,
-.mindmap-topic--selected .mindmap-topic-collapse {
-  opacity: 1;
-}
-
-.mindmap-topic-collapse:hover {
-  background: rgba(0, 0, 0, 0.04);
+  opacity: 0.9;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.css
@@ -1,0 +1,107 @@
+.mindmap-node-body {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: #fafbfc;
+}
+
+.mindmap-viewport {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  box-sizing: border-box;
+}
+
+.mindmap-content {
+  position: relative;
+}
+
+.mindmap-branches {
+  position: absolute;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+  overflow: visible;
+}
+
+/* ---- Topic pill ---- */
+
+.mindmap-topic {
+  position: absolute;
+  top: 0;
+  left: 0;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  padding: 6px 12px;
+  border: 1.5px solid #c9ccd1;
+  border-radius: 999px;
+  background: #ffffff;
+  font-size: 13px;
+  line-height: 1.3;
+  color: #1f2328;
+  cursor: pointer;
+  user-select: none;
+  outline: none;
+  transition: box-shadow 0.12s ease, transform 0.12s ease;
+}
+
+.mindmap-topic--root {
+  border-radius: 10px;
+  font-weight: 600;
+  font-size: 14px;
+  justify-content: center;
+  text-align: center;
+  padding: 8px 14px;
+}
+
+.mindmap-topic--selected {
+  box-shadow: 0 0 0 2px rgba(91, 124, 191, 0.28);
+}
+
+.mindmap-topic--editing {
+  cursor: text;
+}
+
+.mindmap-topic--collapsed {
+  opacity: 0.92;
+}
+
+.mindmap-topic-text {
+  flex: 1;
+  min-height: 16px;
+  outline: none;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  user-select: text;
+  caret-color: currentColor;
+}
+
+.mindmap-topic--editing .mindmap-topic-text {
+  cursor: text;
+  user-select: text;
+}
+
+.mindmap-topic-collapse {
+  flex: 0 0 auto;
+  margin-left: 6px;
+  width: 16px;
+  height: 16px;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  background: transparent;
+  font-size: 11px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  font-weight: 600;
+}
+
+.mindmap-topic-collapse:hover {
+  background: rgba(0, 0, 0, 0.04);
+}

--- a/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.css
@@ -3,7 +3,7 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
-  background: #ffffff;
+  background: transparent;
 }
 
 .mindmap-viewport {

--- a/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.css
@@ -113,7 +113,15 @@
  * empty element's text normally, and the ::before disappears because
  * the rule no longer applies (we toggle a class, not :empty, because
  * browsers may fill empty contenteditable with a lone <br>).
+ *
+ * `white-space: nowrap` on the empty variant keeps "Untitled" on one
+ * line; without it, the text div's flex shrink factor makes the
+ * placeholder break character-by-character inside the narrow slot.
  */
+.mindmap-topic-text--empty {
+  white-space: nowrap;
+}
+
 .mindmap-topic-text--empty::before {
   content: attr(data-placeholder);
   color: #9aa0a6;

--- a/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.css
@@ -3,7 +3,7 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
-  background: #fafbfc;
+  background: #ffffff;
 }
 
 .mindmap-viewport {
@@ -26,7 +26,7 @@
   overflow: visible;
 }
 
-/* ---- Topic pill ---- */
+/* ---- Topic ---- */
 
 .mindmap-topic {
   position: absolute;
@@ -34,65 +34,80 @@
   left: 0;
   box-sizing: border-box;
   display: flex;
-  align-items: center;
-  padding: 6px 12px;
-  border: 1.5px solid #c9ccd1;
-  border-radius: 999px;
-  background: #ffffff;
-  font-size: 13px;
+  align-items: flex-end;
+  justify-content: flex-start;
+  padding: 0 8px 4px 8px;
+  font-size: 14px;
   line-height: 1.3;
   color: #1f2328;
+  background: transparent;
+  border: none;
   cursor: pointer;
   user-select: none;
   outline: none;
-  transition: box-shadow 0.12s ease, transform 0.12s ease;
 }
 
 .mindmap-topic--root {
-  border-radius: 10px;
-  font-weight: 600;
-  font-size: 14px;
+  /* Root is large, centered plainly in its own box — Heptabase-style. */
   justify-content: center;
-  text-align: center;
-  padding: 8px 14px;
+  align-items: center;
+  font-size: 20px;
+  font-weight: 500;
+  padding: 0 10px;
+  color: #1f2328;
 }
 
-.mindmap-topic--selected {
-  box-shadow: 0 0 0 2px rgba(91, 124, 191, 0.28);
+/*
+ * Selection cue: a soft dashed underline in the topic's branch color
+ * (piped in via the `--mindmap-topic-accent` custom property set on
+ * each pill inline). We deliberately avoid box-shadow / fill / border
+ * here so the mindmap stays "text + curves" even when selected.
+ */
+.mindmap-topic--selected .mindmap-topic-text {
+  text-decoration: underline dotted var(--mindmap-topic-accent, #5b7cbf);
+  text-underline-offset: 4px;
 }
 
 .mindmap-topic--editing {
   cursor: text;
 }
 
-.mindmap-topic--collapsed {
-  opacity: 0.92;
+.mindmap-topic--editing .mindmap-topic-text {
+  background: rgba(91, 124, 191, 0.08);
+  border-radius: 3px;
+  box-shadow: 0 0 0 2px rgba(91, 124, 191, 0.2);
 }
 
 .mindmap-topic-text {
-  flex: 1;
+  flex: 0 1 auto;
   min-height: 16px;
+  max-width: 100%;
+  padding: 1px 3px;
   outline: none;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   user-select: text;
   caret-color: currentColor;
+  color: inherit;
 }
 
-.mindmap-topic--editing .mindmap-topic-text {
-  cursor: text;
-  user-select: text;
-}
+/* ---- Collapse control ---- */
 
+/*
+ * Hidden by default; shown on hover or when the topic is selected. The
+ * circle is tinted with the branch color but deliberately small so it
+ * doesn't compete with the text.
+ */
 .mindmap-topic-collapse {
   flex: 0 0 auto;
   margin-left: 6px;
-  width: 16px;
-  height: 16px;
+  margin-bottom: 1px;
+  width: 14px;
+  height: 14px;
   border: 1px solid currentColor;
   border-radius: 50%;
-  background: transparent;
-  font-size: 11px;
+  background: #ffffff;
+  font-size: 10px;
   line-height: 1;
   display: inline-flex;
   align-items: center;
@@ -100,6 +115,13 @@
   cursor: pointer;
   padding: 0;
   font-weight: 600;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+
+.mindmap-topic:hover .mindmap-topic-collapse,
+.mindmap-topic--selected .mindmap-topic-collapse {
+  opacity: 1;
 }
 
 .mindmap-topic-collapse:hover {

--- a/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.css
@@ -1,8 +1,14 @@
+/*
+ * The mindmap node is auto-sized to its content, so no inner level
+ * needs to scroll or clip. Every container uses overflow: visible so
+ * SVG stroke linecaps that extend a pixel past the bounding box don't
+ * trigger sneaky scrollbars on the viewport.
+ */
 .mindmap-node-body {
   position: relative;
   width: 100%;
   height: 100%;
-  overflow: hidden;
+  overflow: visible;
   background: transparent;
 }
 
@@ -10,7 +16,7 @@
   position: relative;
   width: 100%;
   height: 100%;
-  overflow: auto;
+  overflow: visible;
   box-sizing: border-box;
 }
 
@@ -55,6 +61,14 @@
   font-weight: 500;
   padding: 0 10px;
   color: #1f2328;
+}
+
+/* Force the root topic onto a single line even though .mindmap-topic-text
+ * defaults to pre-wrap. Without this, "Central topic" (and any other
+ * multi-word root) wraps in the 120px-minimum slot. The rule lives on the
+ * inner text div because parent-level white-space: nowrap is overridden
+ * by the more-specific text rule below. */
+.mindmap-topic--root .mindmap-topic-text {
   white-space: nowrap;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.tsx
@@ -416,20 +416,34 @@ const TopicPill = ({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      // Stop React's synthetic event AND the underlying DOM event from
+      // bubbling up to the window-level canvas keyboard listener. When
+      // a topic is selected (not editing), the pill div is focused but
+      // neither an <input> nor contentEditable, so `useCanvasKeyboard`'s
+      // `!isEditable` check wouldn't otherwise filter out Delete /
+      // Backspace / Tab / etc. — which would delete the entire mindmap
+      // instead of the focused topic. We only consume keys we actually
+      // handle below; everything else (Cmd+Z, Cmd+C, ...) falls through
+      // untouched so canvas-level shortcuts keep working.
+      const consume = () => {
+        e.preventDefault();
+        e.stopPropagation();
+      };
+
       if (isEditing) {
         if (e.key === 'Escape') {
-          e.preventDefault();
+          consume();
           cancel();
           return;
         }
         if (e.key === 'Enter' && !e.shiftKey) {
-          e.preventDefault();
+          consume();
           commit();
           onKeyAction({ kind: 'addSibling' });
           return;
         }
         if (e.key === 'Tab') {
-          e.preventDefault();
+          consume();
           commit();
           if (e.shiftKey) onKeyAction({ kind: 'unindent' });
           else onKeyAction({ kind: 'addChild' });
@@ -441,44 +455,44 @@ const TopicPill = ({
       // Selected, not editing.
       switch (e.key) {
         case 'Enter':
-          e.preventDefault();
+          consume();
           onKeyAction({ kind: 'addSibling' });
           return;
         case 'Tab':
-          e.preventDefault();
+          consume();
           if (e.shiftKey) onKeyAction({ kind: 'unindent' });
           else onKeyAction({ kind: 'addChild' });
           return;
         case 'Backspace':
         case 'Delete':
-          e.preventDefault();
+          consume();
           onKeyAction({ kind: 'delete' });
           return;
         case ' ':
           if (topic.hasChildren) {
-            e.preventDefault();
+            consume();
             onKeyAction({ kind: 'toggle' });
           }
           return;
         case 'ArrowUp':
-          e.preventDefault();
+          consume();
           onKeyAction({ kind: 'move', dir: 'up' });
           return;
         case 'ArrowDown':
-          e.preventDefault();
+          consume();
           onKeyAction({ kind: 'move', dir: 'down' });
           return;
         case 'ArrowLeft':
-          e.preventDefault();
+          consume();
           onKeyAction({ kind: 'move', dir: 'left' });
           return;
         case 'ArrowRight':
-          e.preventDefault();
+          consume();
           onKeyAction({ kind: 'move', dir: 'right' });
           return;
         case 'F2':
         case 'Escape':
-          e.preventDefault();
+          consume();
           if (e.key === 'F2') onEnterEdit();
           else onKeyAction({ kind: 'exit' });
           return;

--- a/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.tsx
@@ -24,6 +24,12 @@ interface Props {
   node: CanvasNode;
   isSelected: boolean;
   onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
+  /** Called when any topic pill inside the mindmap receives a mouse
+   *  selection. The mindmap itself is a canvas node; bubbling up this
+   *  selection keeps the outer canvas-level selection in sync (so
+   *  shortcuts like Delete that act on the selected canvas node hit
+   *  the right target). */
+  onSelectNode: (id: string) => void;
 }
 
 /**
@@ -49,7 +55,7 @@ interface Props {
  * while selected enters edit mode. Commit on blur / Enter (Enter on a
  * non-root topic also spawns a sibling); Esc cancels without saving.
  */
-export const MindmapNodeBody = ({ node, isSelected, onUpdate }: Props) => {
+export const MindmapNodeBody = ({ node, isSelected, onUpdate, onSelectNode }: Props) => {
   const data = node.data as MindmapNodeData;
   const root = data.root;
 
@@ -259,14 +265,20 @@ export const MindmapNodeBody = ({ node, isSelected, onUpdate }: Props) => {
               topic={t}
               isSelected={selectedId === t.id}
               isEditing={editingId === t.id}
-              onSelect={() => setSelectedId(t.id)}
+              onSelect={() => {
+                setSelectedId(t.id);
+                // Also mark the outer mindmap canvas node as selected so
+                // canvas-level shortcuts (Delete, copy, etc.) act on the
+                // right target.
+                onSelectNode(node.id);
+              }}
               onEnterEdit={() => {
                 setSelectedId(t.id);
                 setEditingId(t.id);
+                onSelectNode(node.id);
               }}
               onCommitText={(text) => renameTopic(t.id, text)}
               onExitEdit={() => setEditingId(null)}
-              onToggleCollapse={() => toggle(t.id)}
               onKeyAction={(action) => {
                 switch (action.kind) {
                   case 'addChild':
@@ -319,7 +331,6 @@ interface TopicPillProps {
   onEnterEdit: () => void;
   onCommitText: (text: string) => void;
   onExitEdit: () => void;
-  onToggleCollapse: () => void;
   onKeyAction: (action: KeyAction) => void;
 }
 
@@ -331,7 +342,6 @@ const TopicPill = ({
   onEnterEdit,
   onCommitText,
   onExitEdit,
-  onToggleCollapse,
   onKeyAction,
 }: TopicPillProps) => {
   const editorRef = useRef<HTMLDivElement>(null);
@@ -342,8 +352,13 @@ const TopicPill = ({
     const el = editorRef.current;
     if (!el) return;
     el.focus();
+    // Drop the caret at the end of existing text instead of selecting
+    // everything — for an empty topic this is a no-op, for an existing
+    // one it lets the user append or edit without accidentally
+    // overwriting with the next keystroke.
     const range = document.createRange();
     range.selectNodeContents(el);
+    range.collapse(false);
     const sel = window.getSelection();
     if (sel) {
       sel.removeAllRanges();
@@ -475,6 +490,8 @@ const TopicPill = ({
     ['--mindmap-topic-accent' as string]: topic.color,
   };
 
+  const isEmpty = !topic.text;
+
   return (
     <div
       ref={pillRef}
@@ -501,29 +518,31 @@ const TopicPill = ({
     >
       <div
         ref={editorRef}
-        className="mindmap-topic-text"
+        className={[
+          'mindmap-topic-text',
+          isEmpty && !isEditing && 'mindmap-topic-text--empty',
+        ]
+          .filter(Boolean)
+          .join(' ')}
         contentEditable={isEditing}
         suppressContentEditableWarning
         spellCheck={false}
+        data-placeholder="Untitled"
         onBlur={() => {
           if (isEditing) commit();
         }}
       >
         {topic.text}
       </div>
-      {topic.hasChildren && !isRoot && (
-        <button
-          className="mindmap-topic-collapse"
-          onMouseDown={(e) => e.stopPropagation()}
-          onClick={(e) => {
-            e.stopPropagation();
-            onToggleCollapse();
-          }}
-          title={topic.collapsed ? 'Expand' : 'Collapse'}
-          style={{ color: topic.color }}
-        >
-          {topic.collapsed ? '+' : '−'}
-        </button>
+      {/* Collapsed-subtree hint: a small filled dot in the branch color
+          sitting just after the text, so users can see "something is
+          hidden here" without the heavy +/- button. */}
+      {topic.collapsed && topic.hasChildren && (
+        <span
+          className="mindmap-topic-collapsed-dot"
+          style={{ background: topic.color }}
+          aria-label="collapsed"
+        />
       )}
     </div>
   );

--- a/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.tsx
@@ -211,19 +211,14 @@ export const MindmapNodeBody = ({ node, isSelected, onUpdate }: Props) => {
 
   /* ---- Render ---- */
 
-  const handleBodyMouseDown = useCallback(
-    (e: React.MouseEvent) => {
-      // Swallow the event so the canvas doesn't start a node drag when
-      // the user is interacting with the mindmap interior.
-      e.stopPropagation();
-    },
-    [],
-  );
-
+  // We deliberately do NOT stop mousedown here. Topic pills below stop
+  // their own mousedown events so clicking a topic never starts a drag,
+  // but clicking the empty mindmap background should bubble up to the
+  // canvas-node wrapper so the whole mindmap can be dragged around the
+  // canvas — just like an image or shape node.
   return (
     <div
       className={`mindmap-node-body${isSelected ? ' mindmap-node-body--selected' : ''}`}
-      onMouseDown={handleBodyMouseDown}
     >
       <div
         className="mindmap-viewport"

--- a/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.tsx
@@ -30,6 +30,12 @@ interface Props {
    *  shortcuts like Delete that act on the selected canvas node hit
    *  the right target). */
   onSelectNode: (id: string) => void;
+  /** Dimension-only update that skips history. We call this when the
+   *  rendered tree's bounding box no longer matches the canvas node's
+   *  width/height — typing a character grows the owning topic's slot,
+   *  which in turn grows the whole mindmap; we want that resize to
+   *  reconcile silently rather than spamming undo history. */
+  onAutoResize: (id: string, width: number, height: number) => void;
 }
 
 /**
@@ -55,7 +61,7 @@ interface Props {
  * while selected enters edit mode. Commit on blur / Enter (Enter on a
  * non-root topic also spawns a sibling); Esc cancels without saving.
  */
-export const MindmapNodeBody = ({ node, isSelected, onUpdate, onSelectNode }: Props) => {
+export const MindmapNodeBody = ({ node, isSelected, onUpdate, onSelectNode, onAutoResize }: Props) => {
   const data = node.data as MindmapNodeData;
   const root = data.root;
 
@@ -68,9 +74,22 @@ export const MindmapNodeBody = ({ node, isSelected, onUpdate, onSelectNode }: Pr
 
   const layout = useMemo(() => layoutMindmap(root), [root]);
 
-  const padding = 24;
+  const padding = 16;
+  const wantedWidth = Math.max(140, Math.ceil(layout.width + padding * 2));
+  const wantedHeight = Math.max(60, Math.ceil(layout.height + padding * 2));
   const viewportWidth = Math.max(0, node.width - padding * 2);
   const viewportHeight = Math.max(0, node.height - padding * 2);
+
+  // Mindmap nodes auto-size to their content. Whenever the computed
+  // bounding box disagrees with the canvas node's current dimensions
+  // (because the user typed, added, deleted, or folded a topic) we
+  // reconcile via `onAutoResize`, which bypasses the undo history so
+  // the size change rides along with whatever mutation just fired.
+  useEffect(() => {
+    if (node.width !== wantedWidth || node.height !== wantedHeight) {
+      onAutoResize(node.id, wantedWidth, wantedHeight);
+    }
+  }, [wantedWidth, wantedHeight, node.id, node.width, node.height, onAutoResize]);
 
   // Keep selection valid when the tree mutates (delete removed the
   // selected node, external update rebuilt ids, etc).

--- a/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.tsx
@@ -1,0 +1,531 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import './index.css';
+import type { CanvasNode, MindmapNodeData, MindmapTopic } from '../../types';
+import { genTopicId } from '../../utils/nodeFactory';
+import {
+  deleteTopic,
+  findParent,
+  findTopicPath,
+  insertChild,
+  layoutMindmap,
+  setTopicText,
+  toggleCollapsed,
+  type LaidOutTopic,
+} from '../../utils/mindmapLayout';
+
+interface Props {
+  node: CanvasNode;
+  isSelected: boolean;
+  onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
+}
+
+/**
+ * Heptabase-style mindmap body.
+ *
+ * Structure lives in `node.data.root` (a recursive `MindmapTopic` tree).
+ * Every render runs `layoutMindmap` to produce pill positions and branch
+ * paths in mindmap-local coords, then this component draws them in an
+ * absolutely-positioned inner canvas. The node's own width/height frames
+ * the viewport — oversized mindmaps scroll inside the node.
+ *
+ * Keyboard model (while a topic is focused):
+ *   Tab            → add child and enter edit on it
+ *   Enter          → add sibling (ignored on root — root has no siblings,
+ *                    so Enter on the root adds a child instead)
+ *   Shift+Tab      → unindent (become a sibling of the current parent)
+ *   Backspace      → delete when text is empty; otherwise normal edit
+ *   Space          → toggle collapse on a topic with children
+ *   Arrow keys     → move selection along the geometric neighbor
+ *   Esc            → exit edit mode but keep the topic selected
+ *
+ * Editing: single click selects a topic, double click or typing a char
+ * while selected enters edit mode. Commit on blur / Enter (Enter on a
+ * non-root topic also spawns a sibling); Esc cancels without saving.
+ */
+export const MindmapNodeBody = ({ node, isSelected, onUpdate }: Props) => {
+  const data = node.data as MindmapNodeData;
+  const root = data.root;
+
+  const [selectedId, setSelectedId] = useState<string>(root.id);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  // When the user creates a topic via Tab/Enter we want to jump to edit
+  // mode on the new topic as soon as it renders. We stash the id here
+  // and clear it once we've moved the focus.
+  const pendingFocusRef = useRef<string | null>(null);
+
+  const layout = useMemo(() => layoutMindmap(root), [root]);
+
+  const padding = 24;
+  const viewportWidth = Math.max(0, node.width - padding * 2);
+  const viewportHeight = Math.max(0, node.height - padding * 2);
+
+  // Keep selection valid when the tree mutates (delete removed the
+  // selected node, external update rebuilt ids, etc).
+  useEffect(() => {
+    const stillExists = findTopicPath(root, selectedId);
+    if (!stillExists) setSelectedId(root.id);
+  }, [root, selectedId]);
+
+  /* ---- Mutation helpers ---- */
+
+  const applyRoot = useCallback(
+    (nextRoot: MindmapTopic) => {
+      onUpdate(node.id, {
+        data: {
+          ...data,
+          root: nextRoot,
+          rev: (data.rev ?? 0) + 1,
+        },
+      });
+    },
+    [data, node.id, onUpdate],
+  );
+
+  const addChild = useCallback(
+    (parentId: string, afterId?: string) => {
+      const id = genTopicId();
+      const topic: MindmapTopic = { id, text: '', children: [] };
+      applyRoot(insertChild(root, parentId, topic, afterId));
+      pendingFocusRef.current = id;
+    },
+    [applyRoot, root],
+  );
+
+  const addSibling = useCallback(
+    (siblingId: string) => {
+      if (siblingId === root.id) {
+        addChild(root.id);
+        return;
+      }
+      const parent = findParent(root, siblingId);
+      if (!parent) return;
+      addChild(parent.id, siblingId);
+    },
+    [addChild, root],
+  );
+
+  const unindentTopic = useCallback(
+    (topicId: string) => {
+      if (topicId === root.id) return;
+      const parent = findParent(root, topicId);
+      if (!parent || parent.id === root.id) return; // already top level
+      const grandparent = findParent(root, parent.id);
+      if (!grandparent) return;
+
+      // Capture the topic BEFORE removing it so we can re-insert the
+      // same subtree under its grandparent.
+      const path = findTopicPath(root, topicId);
+      const original = path?.[path.length - 1];
+      if (!original) return;
+
+      const removed = deleteTopic(root, topicId);
+      if (!removed) return;
+      const next = insertChild(removed.root, grandparent.id, original, parent.id);
+      applyRoot(next);
+      pendingFocusRef.current = topicId;
+    },
+    [applyRoot, root],
+  );
+
+  const removeTopic = useCallback(
+    (topicId: string) => {
+      if (topicId === root.id) return;
+      const result = deleteTopic(root, topicId);
+      if (!result) return;
+      applyRoot(result.root);
+      setSelectedId(result.nextFocusId);
+      setEditingId(null);
+    },
+    [applyRoot, root],
+  );
+
+  const renameTopic = useCallback(
+    (topicId: string, text: string) => {
+      if (findTopicPath(root, topicId)?.slice(-1)[0].text === text) return;
+      applyRoot(setTopicText(root, topicId, text));
+    },
+    [applyRoot, root],
+  );
+
+  const toggle = useCallback(
+    (topicId: string) => {
+      applyRoot(toggleCollapsed(root, topicId));
+    },
+    [applyRoot, root],
+  );
+
+  /* ---- Focus hand-off for freshly-created topics ---- */
+
+  useLayoutEffect(() => {
+    const pendingId = pendingFocusRef.current;
+    if (!pendingId) return;
+    if (findTopicPath(root, pendingId)) {
+      setSelectedId(pendingId);
+      setEditingId(pendingId);
+      pendingFocusRef.current = null;
+    }
+  }, [root]);
+
+  /* ---- Geometric neighbor navigation ---- */
+
+  const moveSelection = useCallback(
+    (from: string, dir: 'up' | 'down' | 'left' | 'right') => {
+      const current = layout.topics.find((t) => t.id === from);
+      if (!current) return;
+      const cx = current.x + current.width / 2;
+      const cy = current.y + current.height / 2;
+
+      let best: LaidOutTopic | null = null;
+      let bestScore = Infinity;
+      for (const candidate of layout.topics) {
+        if (candidate.id === from) continue;
+        const dx = candidate.x + candidate.width / 2 - cx;
+        const dy = candidate.y + candidate.height / 2 - cy;
+        if (dir === 'left' && dx >= 0) continue;
+        if (dir === 'right' && dx <= 0) continue;
+        if (dir === 'up' && dy >= 0) continue;
+        if (dir === 'down' && dy <= 0) continue;
+        // Weight the movement axis heavier so "left" prefers candidates
+        // that are clearly to the left rather than ones that happen to be
+        // slightly diagonal.
+        const primary = dir === 'left' || dir === 'right' ? Math.abs(dx) : Math.abs(dy);
+        const secondary =
+          dir === 'left' || dir === 'right' ? Math.abs(dy) : Math.abs(dx);
+        const score = primary + secondary * 2;
+        if (score < bestScore) {
+          bestScore = score;
+          best = candidate;
+        }
+      }
+      if (best) setSelectedId(best.id);
+    },
+    [layout.topics],
+  );
+
+  /* ---- Render ---- */
+
+  const handleBodyMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      // Swallow the event so the canvas doesn't start a node drag when
+      // the user is interacting with the mindmap interior.
+      e.stopPropagation();
+    },
+    [],
+  );
+
+  return (
+    <div
+      className={`mindmap-node-body${isSelected ? ' mindmap-node-body--selected' : ''}`}
+      onMouseDown={handleBodyMouseDown}
+    >
+      <div
+        className="mindmap-viewport"
+        style={{
+          width: viewportWidth,
+          height: viewportHeight,
+          padding,
+        }}
+      >
+        <div
+          className="mindmap-content"
+          style={{
+            width: layout.width,
+            height: layout.height,
+          }}
+        >
+          <svg
+            className="mindmap-branches"
+            width={layout.width}
+            height={layout.height}
+            viewBox={`0 0 ${Math.max(1, layout.width)} ${Math.max(1, layout.height)}`}
+          >
+            {layout.branches.map((b) => (
+              <path
+                key={b.id}
+                d={b.path}
+                fill="none"
+                stroke={b.color}
+                strokeWidth={2}
+                strokeLinecap="round"
+                opacity={0.85}
+              />
+            ))}
+          </svg>
+          {layout.topics.map((t) => (
+            <TopicPill
+              key={t.id}
+              topic={t}
+              isSelected={selectedId === t.id}
+              isEditing={editingId === t.id}
+              onSelect={() => setSelectedId(t.id)}
+              onEnterEdit={() => {
+                setSelectedId(t.id);
+                setEditingId(t.id);
+              }}
+              onCommitText={(text) => renameTopic(t.id, text)}
+              onExitEdit={() => setEditingId(null)}
+              onToggleCollapse={() => toggle(t.id)}
+              onKeyAction={(action) => {
+                switch (action.kind) {
+                  case 'addChild':
+                    addChild(t.id);
+                    break;
+                  case 'addSibling':
+                    addSibling(t.id);
+                    break;
+                  case 'unindent':
+                    unindentTopic(t.id);
+                    break;
+                  case 'delete':
+                    removeTopic(t.id);
+                    break;
+                  case 'toggle':
+                    toggle(t.id);
+                    break;
+                  case 'move':
+                    moveSelection(t.id, action.dir);
+                    break;
+                  case 'exit':
+                    setEditingId(null);
+                    break;
+                }
+              }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+/* ---- Topic pill ---- */
+
+type KeyAction =
+  | { kind: 'addChild' }
+  | { kind: 'addSibling' }
+  | { kind: 'unindent' }
+  | { kind: 'delete' }
+  | { kind: 'toggle' }
+  | { kind: 'exit' }
+  | { kind: 'move'; dir: 'up' | 'down' | 'left' | 'right' };
+
+interface TopicPillProps {
+  topic: LaidOutTopic;
+  isSelected: boolean;
+  isEditing: boolean;
+  onSelect: () => void;
+  onEnterEdit: () => void;
+  onCommitText: (text: string) => void;
+  onExitEdit: () => void;
+  onToggleCollapse: () => void;
+  onKeyAction: (action: KeyAction) => void;
+}
+
+const TopicPill = ({
+  topic,
+  isSelected,
+  isEditing,
+  onSelect,
+  onEnterEdit,
+  onCommitText,
+  onExitEdit,
+  onToggleCollapse,
+  onKeyAction,
+}: TopicPillProps) => {
+  const editorRef = useRef<HTMLDivElement>(null);
+  const pillRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (!isEditing) return;
+    const el = editorRef.current;
+    if (!el) return;
+    el.focus();
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    const sel = window.getSelection();
+    if (sel) {
+      sel.removeAllRanges();
+      sel.addRange(range);
+    }
+  }, [isEditing]);
+
+  // When the selected pill isn't editing, send keyboard focus to the
+  // wrapper so arrow keys / Tab / Enter hit this component's handler
+  // instead of the canvas keyboard hook.
+  useEffect(() => {
+    if (isEditing) return;
+    if (isSelected) pillRef.current?.focus();
+  }, [isSelected, isEditing]);
+
+  // Push DOM text back in sync when the stored text changes from
+  // elsewhere (undo, external update) and we're not mid-edit.
+  useEffect(() => {
+    if (isEditing) return;
+    const el = editorRef.current;
+    if (el && el.innerText !== topic.text) el.innerText = topic.text;
+  }, [topic.text, isEditing]);
+
+  const commit = useCallback(() => {
+    const el = editorRef.current;
+    const next = el ? el.innerText.replace(/\n+$/, '') : topic.text;
+    if (next !== topic.text) onCommitText(next);
+    onExitEdit();
+  }, [onCommitText, onExitEdit, topic.text]);
+
+  const cancel = useCallback(() => {
+    const el = editorRef.current;
+    if (el) el.innerText = topic.text;
+    onExitEdit();
+  }, [onExitEdit, topic.text]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (isEditing) {
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          cancel();
+          return;
+        }
+        if (e.key === 'Enter' && !e.shiftKey) {
+          e.preventDefault();
+          commit();
+          onKeyAction({ kind: 'addSibling' });
+          return;
+        }
+        if (e.key === 'Tab') {
+          e.preventDefault();
+          commit();
+          if (e.shiftKey) onKeyAction({ kind: 'unindent' });
+          else onKeyAction({ kind: 'addChild' });
+          return;
+        }
+        return;
+      }
+
+      // Selected, not editing.
+      switch (e.key) {
+        case 'Enter':
+          e.preventDefault();
+          onKeyAction({ kind: 'addSibling' });
+          return;
+        case 'Tab':
+          e.preventDefault();
+          if (e.shiftKey) onKeyAction({ kind: 'unindent' });
+          else onKeyAction({ kind: 'addChild' });
+          return;
+        case 'Backspace':
+        case 'Delete':
+          e.preventDefault();
+          onKeyAction({ kind: 'delete' });
+          return;
+        case ' ':
+          if (topic.hasChildren) {
+            e.preventDefault();
+            onKeyAction({ kind: 'toggle' });
+          }
+          return;
+        case 'ArrowUp':
+          e.preventDefault();
+          onKeyAction({ kind: 'move', dir: 'up' });
+          return;
+        case 'ArrowDown':
+          e.preventDefault();
+          onKeyAction({ kind: 'move', dir: 'down' });
+          return;
+        case 'ArrowLeft':
+          e.preventDefault();
+          onKeyAction({ kind: 'move', dir: 'left' });
+          return;
+        case 'ArrowRight':
+          e.preventDefault();
+          onKeyAction({ kind: 'move', dir: 'right' });
+          return;
+        case 'F2':
+        case 'Escape':
+          e.preventDefault();
+          if (e.key === 'F2') onEnterEdit();
+          else onKeyAction({ kind: 'exit' });
+          return;
+        default:
+          // A printable character should drop straight into edit mode
+          // and replace the current text, mirroring Heptabase.
+          if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) {
+            onEnterEdit();
+            // Let the keydown commit into the contenteditable after
+            // edit mode mounts by NOT preventing default.
+          }
+      }
+    },
+    [cancel, commit, isEditing, onEnterEdit, onKeyAction, topic.hasChildren],
+  );
+
+  const isRoot = topic.depth === 0;
+  const style: React.CSSProperties = {
+    transform: `translate(${topic.x}px, ${topic.y}px)`,
+    width: topic.width,
+    minHeight: topic.height,
+    borderColor: topic.color,
+    color: isRoot ? '#ffffff' : topic.color,
+    background: isRoot ? topic.color : '#ffffff',
+  };
+
+  return (
+    <div
+      ref={pillRef}
+      className={[
+        'mindmap-topic',
+        isRoot && 'mindmap-topic--root',
+        isSelected && 'mindmap-topic--selected',
+        isEditing && 'mindmap-topic--editing',
+        topic.collapsed && 'mindmap-topic--collapsed',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      style={style}
+      tabIndex={0}
+      onMouseDown={(e) => {
+        e.stopPropagation();
+        onSelect();
+      }}
+      onDoubleClick={(e) => {
+        e.stopPropagation();
+        onEnterEdit();
+      }}
+      onKeyDown={handleKeyDown}
+    >
+      <div
+        ref={editorRef}
+        className="mindmap-topic-text"
+        contentEditable={isEditing}
+        suppressContentEditableWarning
+        spellCheck={false}
+        onBlur={() => {
+          if (isEditing) commit();
+        }}
+      >
+        {topic.text}
+      </div>
+      {topic.hasChildren && !isRoot && (
+        <button
+          className="mindmap-topic-collapse"
+          onMouseDown={(e) => e.stopPropagation()}
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleCollapse();
+          }}
+          title={topic.collapsed ? 'Expand' : 'Collapse'}
+          style={{ color: topic.color }}
+        >
+          {topic.collapsed ? '+' : '−'}
+        </button>
+      )}
+    </div>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.tsx
@@ -467,13 +467,17 @@ const TopicPill = ({
   );
 
   const isRoot = topic.depth === 0;
+  // Heptabase-style: the topic itself is chromeless. Color drives only
+  // the selection cue and the collapse pill — the connecting branch
+  // takes over as the primary color signal.
   const style: React.CSSProperties = {
     transform: `translate(${topic.x}px, ${topic.y}px)`,
     width: topic.width,
     minHeight: topic.height,
-    borderColor: topic.color,
-    color: isRoot ? '#ffffff' : topic.color,
-    background: isRoot ? topic.color : '#ffffff',
+    color: isRoot ? '#1f2328' : '#1f2328',
+    // Selected-state underline uses currentColor, so pipe the branch
+    // color through when selected — otherwise keep text neutral.
+    ['--mindmap-topic-accent' as string]: topic.color,
   };
 
   return (

--- a/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from "react";
 interface Props {
   x: number;
   y: number;
-  onCreate: (type: "file" | "terminal" | "frame" | "agent" | "text" | "iframe") => void;
+  onCreate: (type: "file" | "terminal" | "frame" | "agent" | "text" | "iframe" | "mindmap") => void;
   onClose: () => void;
 }
 
@@ -100,6 +100,16 @@ export const NodeContextMenu = ({ x, y, onCreate, onClose }: Props) => {
         <span className="context-menu-label">
           <strong>Agent</strong>
           <small>Launch a coding agent</small>
+        </span>
+      </button>
+      <button
+        className="context-menu-item"
+        onClick={() => onCreate("mindmap")}
+      >
+        <span className="context-menu-icon">{"✿"}</span>
+        <span className="context-menu-label">
+          <strong>Mindmap</strong>
+          <small>Branching topic tree</small>
         </span>
       </button>
     </div>

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
@@ -7,10 +7,11 @@ import type {
   FileNodeData,
   FrameNodeData,
   ImageNodeData,
+  MindmapNodeData,
   ShapeNodeData,
   TextNodeData,
 } from '../types';
-import { createDefaultNode, createNodeData, genId } from '../utils/nodeFactory';
+import { cloneMindmapTopic, createDefaultNode, createNodeData, genId } from '../utils/nodeFactory';
 import { degradeEndpointsForDeletedNode } from '../utils/edgeFactory';
 import { useNodeHistory } from './useNodeHistory';
 
@@ -429,7 +430,16 @@ export const useNodes = (
               ? { ...(source.data as ImageNodeData) }
               : source.type === 'shape'
                 ? { ...(source.data as ShapeNodeData) }
-                : createNodeData(source.type),
+                : source.type === 'mindmap'
+                  ? (() => {
+                      const src = source.data as MindmapNodeData;
+                      return {
+                        ...src,
+                        root: cloneMindmapTopic(src.root),
+                        rev: 0,
+                      } satisfies MindmapNodeData;
+                    })()
+                  : createNodeData(source.type),
         updatedAt: Date.now(),
       };
       if (newNode.type === 'file') {
@@ -474,7 +484,16 @@ export const useNodes = (
               ? { ...(source.data as ImageNodeData) }
               : source.type === 'shape'
                 ? { ...(source.data as ShapeNodeData) }
-                : createNodeData(source.type),
+                : source.type === 'mindmap'
+                  ? (() => {
+                      const src = source.data as MindmapNodeData;
+                      return {
+                        ...src,
+                        root: cloneMindmapTopic(src.root),
+                        rev: 0,
+                      } satisfies MindmapNodeData;
+                    })()
+                  : createNodeData(source.type),
         updatedAt: now,
       }));
       newNodes.forEach((newNode) => {

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -1,6 +1,6 @@
 export interface CanvasNode {
   id: string;
-  type: "file" | "terminal" | "frame" | "agent" | "text" | "iframe" | "image" | "shape";
+  type: "file" | "terminal" | "frame" | "agent" | "text" | "iframe" | "image" | "shape" | "mindmap";
   title: string;
   x: number;
   y: number;
@@ -14,7 +14,8 @@ export interface CanvasNode {
     | TextNodeData
     | IframeNodeData
     | ImageNodeData
-    | ShapeNodeData;
+    | ShapeNodeData
+    | MindmapNodeData;
   /** Epoch millis of last mutation; used for cross-process merge. */
   updatedAt?: number;
 }
@@ -130,6 +131,42 @@ export interface ShapeNodeData {
   textColor?: string;
   /** Font size in px. Defaults to 16 when unset. */
   fontSize?: number;
+}
+
+/**
+ * Heptabase-style mindmap card.
+ *
+ * The whole mindmap lives inside ONE canvas node — branches and children
+ * are stored in a recursive `MindmapTopic` tree under `data.root`, not as
+ * separate `CanvasNode`s connected by `CanvasEdge`s. This keeps the
+ * structural relationships (parent/child) distinct from free-form canvas
+ * connections drawn by the user between different nodes.
+ *
+ * Layout is deterministic: given the tree, `layoutMindmap` produces the
+ * on-screen positions, so we never persist x/y for individual topics —
+ * only the tree, which is cheap to round-trip through JSON storage.
+ */
+export interface MindmapTopic {
+  /** Stable id — unique within the containing mindmap only. */
+  id: string;
+  text: string;
+  children: MindmapTopic[];
+  /** When true, the subtree is hidden (and its descendants are skipped
+   *  by layout). Applies only to non-root topics. */
+  collapsed?: boolean;
+  /** Optional per-topic color override (hex). Defaults to a branch color
+   *  derived from the topic's root-child index. */
+  color?: string;
+}
+
+export interface MindmapNodeData {
+  root: MindmapTopic;
+  /** Layout direction. v1 supports `'right'` (root on the left, children
+   *  growing rightward); other values are reserved for future modes. */
+  layout: 'right';
+  /** Bumped on every topic add/remove/rename — lets external observers
+   *  (canvas-cli, agent) diff mindmaps without structural equality. */
+  rev?: number;
 }
 
 export interface CanvasTransform {

--- a/apps/canvas-workspace/src/renderer/src/utils/mindmapLayout.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/mindmapLayout.ts
@@ -91,6 +91,31 @@ const BRANCH_COLORS = [
 
 const ROOT_COLOR = '#1F2328';
 
+/**
+ * Estimate the rendered pixel width of a topic's text without touching
+ * the DOM. We intentionally keep this cheap rather than doing a hidden
+ * measure pass — the approximation is accurate enough for layout and
+ * stays synchronous, which matters because `layoutMindmap` runs in a
+ * `useMemo` on every tree mutation.
+ *
+ * Latin characters at the topic font size (~14px) average ~0.56em; CJK
+ * chars are ~1em. We detect CJK by scanning for Han + kana + full-width
+ * ranges and pick the wider estimate — good enough, and errs on the
+ * side of "a little too wide" which never looks broken.
+ */
+const CJK_RANGE = /[　-鿿＀-￯぀-ヿ]/;
+const estimateTextWidth = (text: string, fontSize: number): number => {
+  if (!text) return 0;
+  const hasCJK = CJK_RANGE.test(text);
+  const avg = hasCJK ? fontSize * 0.95 : fontSize * 0.56;
+  return text.length * avg;
+};
+
+const ROOT_MIN_WIDTH = 120;
+const TOPIC_MIN_WIDTH = 90;
+const TOPIC_MAX_WIDTH = 260;
+const TOPIC_HORIZONTAL_PADDING = 18;
+
 export const layoutMindmap = (
   root: MindmapTopic,
   opts: LayoutOptions = {},
@@ -98,6 +123,23 @@ export const layoutMindmap = (
   const o = { ...DEFAULT_OPTS, ...opts };
   const topics: LaidOutTopic[] = [];
   const branches: LaidOutBranch[] = [];
+
+  // Per-topic widths. The root gets a larger font + generous minimum so
+  // short "Central topic"-style labels don't awkwardly wrap at word
+  // boundaries; every other topic scales between TOPIC_MIN_WIDTH and
+  // TOPIC_MAX_WIDTH based on its text length.
+  const widthOf = new Map<string, number>();
+  const resolveWidth = (t: MindmapTopic, isRoot: boolean): number => {
+    const cached = widthOf.get(t.id);
+    if (cached !== undefined) return cached;
+    const fontSize = isRoot ? 20 : 14;
+    const text = t.text || 'Untitled';
+    const estimated = estimateTextWidth(text, fontSize) + TOPIC_HORIZONTAL_PADDING;
+    const min = isRoot ? ROOT_MIN_WIDTH : TOPIC_MIN_WIDTH;
+    const w = Math.max(min, Math.min(TOPIC_MAX_WIDTH, Math.ceil(estimated)));
+    widthOf.set(t.id, w);
+    return w;
+  };
 
   // Pass 1: compute the vertical "slot" each topic needs — the height
   // it will occupy including all visible descendants.
@@ -133,6 +175,8 @@ export const layoutMindmap = (
     yCursor: number,
     color: string,
   ) => {
+    const isRoot = depth === 0;
+    const selfWidth = resolveWidth(t, isRoot);
     const slot = slotOf.get(t.id) ?? o.topicHeight;
     const y = yCursor + (slot - o.topicHeight) / 2;
     const laidOut: LaidOutTopic = {
@@ -141,7 +185,7 @@ export const layoutMindmap = (
       depth,
       x: xLeft,
       y,
-      width: o.topicWidth,
+      width: selfWidth,
       height: o.topicHeight,
       text: t.text,
       color,
@@ -154,11 +198,12 @@ export const layoutMindmap = (
 
     // Children sit to the right of this topic, stacked vertically
     // within this topic's slot.
-    const childXLeft = xLeft + o.topicWidth + o.hGap;
+    const childXLeft = xLeft + selfWidth + o.hGap;
     let childYCursor = yCursor;
     for (let i = 0; i < t.children.length; i++) {
       const child = t.children[i];
       const childSlot = slotOf.get(child.id) ?? o.topicHeight;
+      const childWidth = resolveWidth(child, false);
 
       // Primary branches get a color from the palette; deeper topics
       // inherit their branch ancestor's color.
@@ -173,7 +218,7 @@ export const layoutMindmap = (
       // leave it at its vertical center. Every other parent branches off
       // of its own baseline, so incoming + outgoing lines share the
       // same horizontal track and read as a continuous "underline".
-      const parentRightX = xLeft + o.topicWidth;
+      const parentRightX = xLeft + selfWidth;
       const parentAnchorY =
         depth === 0 ? y + o.topicHeight / 2 : y + o.topicHeight;
       const childLeftX = childXLeft;
@@ -189,7 +234,7 @@ export const layoutMindmap = (
       // end of the curve, matching Heptabase's look.
       const childHasVisibleChildren =
         child.children.length > 0 && !child.collapsed;
-      const childRightX = childXLeft + o.topicWidth;
+      const childRightX = childXLeft + childWidth;
       const tail = childHasVisibleChildren
         ? ` L ${childRightX} ${childAnchorY}`
         : '';

--- a/apps/canvas-workspace/src/renderer/src/utils/mindmapLayout.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/mindmapLayout.ts
@@ -205,7 +205,6 @@ export const layoutMindmap = (
     for (let i = 0; i < t.children.length; i++) {
       const child = t.children[i];
       const childSlot = slotOf.get(child.id) ?? o.topicHeight;
-      const childWidth = resolveWidth(child, false);
 
       // Primary branches get a color from the palette; deeper topics
       // inherit their branch ancestor's color.
@@ -214,36 +213,23 @@ export const layoutMindmap = (
 
       walk(child, depth + 1, t.id, childXLeft, childYCursor, childColor);
 
-      // Heptabase anchors: branches enter the child at its text baseline
-      // (bottom of the topic box), which visually sits just under the
-      // text. The root is special — it has no underline, so branches
-      // leave it at its vertical center. Every other parent branches off
-      // of its own baseline, so incoming + outgoing lines share the
-      // same horizontal track and read as a continuous "underline".
+      // Branches anchor at the vertical CENTER of both parent and
+      // child so the curve reads as "line passes through the middle
+      // of the text". Anchoring at the baseline puts text visually
+      // above its branch, which felt off-axis for this chromeless
+      // layout where there's no outline to give the baseline a
+      // reason to exist.
       const parentRightX = xLeft + selfWidth;
-      const parentAnchorY =
-        depth === 0 ? y + o.topicHeight / 2 : y + o.topicHeight;
+      const parentAnchorY = y + o.topicHeight / 2;
       const childLeftX = childXLeft;
       const childAnchorY =
         childYCursor +
         (childSlot - o.topicHeight) / 2 +
-        o.topicHeight;
+        o.topicHeight / 2;
       const midX = parentRightX + (childLeftX - parentRightX) / 2;
-      // When the child itself has visible children, extend the incoming
-      // branch horizontally across the child's full width so the line
-      // reads as an "underline" that outgoing branches share with the
-      // incoming one. Leaves get no extension — their text sits at the
-      // end of the curve, matching Heptabase's look.
-      const childHasVisibleChildren =
-        child.children.length > 0 && !child.collapsed;
-      const childRightX = childXLeft + childWidth;
-      const tail = childHasVisibleChildren
-        ? ` L ${childRightX} ${childAnchorY}`
-        : '';
       const path =
         `M ${parentRightX} ${parentAnchorY} ` +
-        `C ${midX} ${parentAnchorY}, ${midX} ${childAnchorY}, ${childLeftX} ${childAnchorY}` +
-        tail;
+        `C ${midX} ${parentAnchorY}, ${midX} ${childAnchorY}, ${childLeftX} ${childAnchorY}`;
       branches.push({
         id: `${t.id}->${child.id}`,
         parentId: t.id,

--- a/apps/canvas-workspace/src/renderer/src/utils/mindmapLayout.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/mindmapLayout.ts
@@ -1,0 +1,403 @@
+import type { MindmapTopic } from '../types';
+
+/**
+ * Horizontal tree layout for a Heptabase-style mindmap.
+ *
+ * The root sits vertically centered. Children grow rightward, each at a
+ * fixed horizontal step from its parent. Vertical space is allocated
+ * bottom-up: each topic reserves a slot equal to `max(slotHeight,
+ * sum(children slots))`, so subtrees never overlap regardless of depth.
+ * This is a simplified Reingold–Tilford: good enough for Heptabase-like
+ * cards (a few dozen topics) and stable as the user edits.
+ *
+ * The returned `width`/`height` describe the bounding box of every
+ * rendered topic; callers pad by `PADDING` on every side.
+ *
+ * Collapsed topics still render themselves but skip their descendants.
+ */
+
+export interface LaidOutTopic {
+  id: string;
+  /** Parent topic id, or null for the root. Used to hit-test keyboard
+   *  navigation (Shift+Tab, ArrowLeft). */
+  parentId: string | null;
+  /** Depth from root — 0 for the root, 1 for a primary branch, etc. */
+  depth: number;
+  /** Top-left corner of the topic box in mindmap-local coords. */
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  text: string;
+  /** Resolved color — branch-colored for non-root topics, neutral for
+   *  the root. Drives both the topic pill border and the in-bound
+   *  branch line. */
+  color: string;
+  collapsed: boolean;
+  hasChildren: boolean;
+}
+
+export interface LaidOutBranch {
+  /** Parent → child connection. Bezier path in mindmap-local coords,
+   *  ready to drop into an <svg> <path d={...}> */
+  id: string;
+  parentId: string;
+  childId: string;
+  path: string;
+  color: string;
+}
+
+export interface MindmapLayout {
+  topics: LaidOutTopic[];
+  branches: LaidOutBranch[];
+  /** Bounding box of the laid-out content (excluding outer padding). */
+  width: number;
+  height: number;
+}
+
+export interface LayoutOptions {
+  /** Gap between a parent and its children on the horizontal axis. */
+  hGap?: number;
+  /** Minimum gap between sibling topic rows. */
+  vGap?: number;
+  /** Logical topic box width (used for all topics). */
+  topicWidth?: number;
+  /** Logical topic box height (used when a topic's rendered height is
+   *  unknown). In v1 every topic is a single-line pill. */
+  topicHeight?: number;
+}
+
+const DEFAULT_OPTS: Required<LayoutOptions> = {
+  hGap: 56,
+  vGap: 12,
+  topicWidth: 168,
+  topicHeight: 36,
+};
+
+/**
+ * Heptabase-ish palette for the first six primary branches. Indexing
+ * beyond the end wraps, which is fine for the rare case of >6 branches
+ * — the colors just repeat.
+ */
+const BRANCH_COLORS = [
+  '#E07B4A', // orange
+  '#3B8FD6', // blue
+  '#7A57C4', // purple
+  '#2F8F5A', // green
+  '#C94F8C', // pink
+  '#C9A31A', // yellow
+];
+
+const ROOT_COLOR = '#1F2328';
+
+export const layoutMindmap = (
+  root: MindmapTopic,
+  opts: LayoutOptions = {},
+): MindmapLayout => {
+  const o = { ...DEFAULT_OPTS, ...opts };
+  const topics: LaidOutTopic[] = [];
+  const branches: LaidOutBranch[] = [];
+
+  // Pass 1: compute the vertical "slot" each topic needs — the height
+  // it will occupy including all visible descendants.
+  const slotOf = new Map<string, number>();
+  const measure = (t: MindmapTopic): number => {
+    const kids = t.collapsed ? [] : t.children;
+    if (kids.length === 0) {
+      const s = o.topicHeight;
+      slotOf.set(t.id, s);
+      return s;
+    }
+    let total = 0;
+    for (let i = 0; i < kids.length; i++) {
+      total += measure(kids[i]);
+      if (i > 0) total += o.vGap;
+    }
+    // A parent with children still needs at least its own height so the
+    // pill doesn't collapse into a sliver when a single child lives below.
+    const s = Math.max(total, o.topicHeight);
+    slotOf.set(t.id, s);
+    return s;
+  };
+  const totalHeight = measure(root);
+
+  // Pass 2: place each topic. `yCursor` is the top of the current node's
+  // slot; we center the node vertically inside its slot, then walk
+  // children top-down.
+  const walk = (
+    t: MindmapTopic,
+    depth: number,
+    parentId: string | null,
+    xLeft: number,
+    yCursor: number,
+    color: string,
+  ) => {
+    const slot = slotOf.get(t.id) ?? o.topicHeight;
+    const y = yCursor + (slot - o.topicHeight) / 2;
+    const laidOut: LaidOutTopic = {
+      id: t.id,
+      parentId,
+      depth,
+      x: xLeft,
+      y,
+      width: o.topicWidth,
+      height: o.topicHeight,
+      text: t.text,
+      color,
+      collapsed: !!t.collapsed,
+      hasChildren: t.children.length > 0,
+    };
+    topics.push(laidOut);
+
+    if (t.collapsed || t.children.length === 0) return;
+
+    // Children sit to the right of this topic, stacked vertically
+    // within this topic's slot.
+    const childXLeft = xLeft + o.topicWidth + o.hGap;
+    let childYCursor = yCursor;
+    for (let i = 0; i < t.children.length; i++) {
+      const child = t.children[i];
+      const childSlot = slotOf.get(child.id) ?? o.topicHeight;
+
+      // Primary branches get a color from the palette; deeper topics
+      // inherit their branch ancestor's color.
+      const childColor =
+        depth === 0 ? BRANCH_COLORS[i % BRANCH_COLORS.length] : color;
+
+      walk(child, depth + 1, t.id, childXLeft, childYCursor, childColor);
+
+      // Branch line from parent right-center to child left-center.
+      const parentRightX = xLeft + o.topicWidth;
+      const parentCenterY = y + o.topicHeight / 2;
+      const childLeftX = childXLeft;
+      const childCenterY =
+        childYCursor + (childSlot - o.topicHeight) / 2 + o.topicHeight / 2;
+      const midX = parentRightX + (childLeftX - parentRightX) / 2;
+      const path =
+        `M ${parentRightX} ${parentCenterY} ` +
+        `C ${midX} ${parentCenterY}, ${midX} ${childCenterY}, ${childLeftX} ${childCenterY}`;
+      branches.push({
+        id: `${t.id}->${child.id}`,
+        parentId: t.id,
+        childId: child.id,
+        path,
+        color: childColor,
+      });
+
+      childYCursor += childSlot + o.vGap;
+    }
+  };
+
+  walk(root, 0, null, 0, 0, ROOT_COLOR);
+
+  // Normalize to a non-negative bounding box so the renderer can
+  // translate directly by (topic.x, topic.y).
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const t of topics) {
+    if (t.x < minX) minX = t.x;
+    if (t.y < minY) minY = t.y;
+    if (t.x + t.width > maxX) maxX = t.x + t.width;
+    if (t.y + t.height > maxY) maxY = t.y + t.height;
+  }
+  if (!Number.isFinite(minX)) {
+    minX = 0;
+    minY = 0;
+    maxX = o.topicWidth;
+    maxY = o.topicHeight;
+  }
+
+  // Shift so the whole tree starts at (0, 0). Update branch paths by
+  // re-running the same shift on their coordinates.
+  if (minX !== 0 || minY !== 0) {
+    for (const t of topics) {
+      t.x -= minX;
+      t.y -= minY;
+    }
+    for (const b of branches) {
+      b.path = shiftPath(b.path, -minX, -minY);
+    }
+  }
+
+  return {
+    topics,
+    branches,
+    width: maxX - minX,
+    height: Math.max(maxY - minY, totalHeight),
+  };
+};
+
+/**
+ * Shift every coordinate in an SVG path command string by (dx, dy).
+ * Only used for the M and C commands emitted above, so we can lean on
+ * a simple number-token rewrite.
+ */
+const shiftPath = (path: string, dx: number, dy: number): string => {
+  const tokens = path.split(/\s+/);
+  const out: string[] = [];
+  let numberIndex = 0;
+  for (const tok of tokens) {
+    if (tok === 'M' || tok === 'C') {
+      out.push(tok);
+      numberIndex = 0;
+      continue;
+    }
+    const cleaned = tok.replace(/,$/, '');
+    const n = Number(cleaned);
+    if (Number.isFinite(n)) {
+      const shifted = numberIndex % 2 === 0 ? n + dx : n + dy;
+      out.push(tok.endsWith(',') ? `${shifted},` : `${shifted}`);
+      numberIndex++;
+    } else {
+      out.push(tok);
+    }
+  }
+  return out.join(' ');
+};
+
+/* ---- Tree mutation helpers ---- */
+
+/**
+ * Find a topic by id and return a path from root → topic. Returns null
+ * when the id is not present. The path is used by every mutation below
+ * so the caller doesn't have to re-traverse.
+ */
+export const findTopicPath = (
+  root: MindmapTopic,
+  id: string,
+): MindmapTopic[] | null => {
+  if (root.id === id) return [root];
+  for (const child of root.children) {
+    const sub = findTopicPath(child, id);
+    if (sub) return [root, ...sub];
+  }
+  return null;
+};
+
+/**
+ * Return a new tree produced by applying `fn` to every topic. `fn` may
+ * return a new topic (replacing the input) or `null` to delete. The
+ * root is never allowed to be deleted — callers that need that case
+ * should handle it outside this helper.
+ */
+export const mapTopics = (
+  root: MindmapTopic,
+  fn: (t: MindmapTopic, parent: MindmapTopic | null) => MindmapTopic | null,
+): MindmapTopic => {
+  const walk = (t: MindmapTopic, parent: MindmapTopic | null): MindmapTopic => {
+    const mapped = fn(t, parent) ?? t;
+    return {
+      ...mapped,
+      children: mapped.children
+        .map((c) => {
+          const result = fn(c, mapped);
+          if (result === null) return null;
+          // Recurse into the returned (possibly-rewritten) child.
+          return walk(result ?? c, mapped);
+        })
+        .filter((c): c is MindmapTopic => c !== null),
+    };
+  };
+  return walk(root, null);
+};
+
+/** Insert a child topic under `parentId`. If `afterId` is provided, the
+ *  child lands directly after that sibling; otherwise it appends. */
+export const insertChild = (
+  root: MindmapTopic,
+  parentId: string,
+  child: MindmapTopic,
+  afterId?: string,
+): MindmapTopic => {
+  const walk = (t: MindmapTopic): MindmapTopic => {
+    if (t.id === parentId) {
+      const children = [...t.children];
+      if (afterId) {
+        const idx = children.findIndex((c) => c.id === afterId);
+        if (idx >= 0) {
+          children.splice(idx + 1, 0, child);
+          return { ...t, children };
+        }
+      }
+      children.push(child);
+      // Inserting children implicitly expands the parent.
+      return { ...t, children, collapsed: false };
+    }
+    return { ...t, children: t.children.map(walk) };
+  };
+  return walk(root);
+};
+
+/** Replace a topic's text. Returns the root unchanged if no match. */
+export const setTopicText = (
+  root: MindmapTopic,
+  id: string,
+  text: string,
+): MindmapTopic => {
+  const walk = (t: MindmapTopic): MindmapTopic => {
+    if (t.id === id) return { ...t, text };
+    return { ...t, children: t.children.map(walk) };
+  };
+  return walk(root);
+};
+
+/** Toggle collapsed on a topic. The root can't be collapsed. */
+export const toggleCollapsed = (
+  root: MindmapTopic,
+  id: string,
+): MindmapTopic => {
+  if (root.id === id) return root;
+  const walk = (t: MindmapTopic): MindmapTopic => {
+    if (t.id === id) return { ...t, collapsed: !t.collapsed };
+    return { ...t, children: t.children.map(walk) };
+  };
+  return walk(root);
+};
+
+/**
+ * Delete a non-root topic. Returns `{ root, nextFocusId }` where
+ * `nextFocusId` points at the sibling above (or the parent if the
+ * victim was a first child) so the caller can keep focus reasonable.
+ */
+export const deleteTopic = (
+  root: MindmapTopic,
+  id: string,
+): { root: MindmapTopic; nextFocusId: string } | null => {
+  if (root.id === id) return null;
+  let nextFocusId = root.id;
+  const walk = (t: MindmapTopic): MindmapTopic => {
+    const idx = t.children.findIndex((c) => c.id === id);
+    if (idx >= 0) {
+      const next = [...t.children];
+      next.splice(idx, 1);
+      if (next.length > 0) {
+        nextFocusId = next[Math.max(0, idx - 1)].id;
+      } else {
+        nextFocusId = t.id;
+      }
+      return { ...t, children: next };
+    }
+    return { ...t, children: t.children.map(walk) };
+  };
+  const nextRoot = walk(root);
+  return { root: nextRoot, nextFocusId };
+};
+
+/** Return the parent topic for a given id, or null for the root/missing. */
+export const findParent = (
+  root: MindmapTopic,
+  id: string,
+): MindmapTopic | null => {
+  if (root.id === id) return null;
+  const walk = (t: MindmapTopic): MindmapTopic | null => {
+    for (const c of t.children) {
+      if (c.id === id) return t;
+      const deeper = walk(c);
+      if (deeper) return deeper;
+    }
+    return null;
+  };
+  return walk(root);
+};

--- a/apps/canvas-workspace/src/renderer/src/utils/mindmapLayout.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/mindmapLayout.ts
@@ -68,24 +68,25 @@ export interface LayoutOptions {
 }
 
 const DEFAULT_OPTS: Required<LayoutOptions> = {
-  hGap: 56,
-  vGap: 12,
-  topicWidth: 168,
-  topicHeight: 36,
+  hGap: 64,
+  vGap: 14,
+  topicWidth: 180,
+  topicHeight: 34,
 };
 
 /**
  * Heptabase-ish palette for the first six primary branches. Indexing
  * beyond the end wraps, which is fine for the rare case of >6 branches
- * — the colors just repeat.
+ * — the colors just repeat. Tuned to match Heptabase's default theme:
+ * warm yellow, cool gray, warm orange, etc.
  */
 const BRANCH_COLORS = [
+  '#D9A13B', // yellow
+  '#9AA0A6', // gray
   '#E07B4A', // orange
   '#3B8FD6', // blue
   '#7A57C4', // purple
   '#2F8F5A', // green
-  '#C94F8C', // pink
-  '#C9A31A', // yellow
 ];
 
 const ROOT_COLOR = '#1F2328';
@@ -166,16 +167,36 @@ export const layoutMindmap = (
 
       walk(child, depth + 1, t.id, childXLeft, childYCursor, childColor);
 
-      // Branch line from parent right-center to child left-center.
+      // Heptabase anchors: branches enter the child at its text baseline
+      // (bottom of the topic box), which visually sits just under the
+      // text. The root is special — it has no underline, so branches
+      // leave it at its vertical center. Every other parent branches off
+      // of its own baseline, so incoming + outgoing lines share the
+      // same horizontal track and read as a continuous "underline".
       const parentRightX = xLeft + o.topicWidth;
-      const parentCenterY = y + o.topicHeight / 2;
+      const parentAnchorY =
+        depth === 0 ? y + o.topicHeight / 2 : y + o.topicHeight;
       const childLeftX = childXLeft;
-      const childCenterY =
-        childYCursor + (childSlot - o.topicHeight) / 2 + o.topicHeight / 2;
+      const childAnchorY =
+        childYCursor +
+        (childSlot - o.topicHeight) / 2 +
+        o.topicHeight;
       const midX = parentRightX + (childLeftX - parentRightX) / 2;
+      // When the child itself has visible children, extend the incoming
+      // branch horizontally across the child's full width so the line
+      // reads as an "underline" that outgoing branches share with the
+      // incoming one. Leaves get no extension — their text sits at the
+      // end of the curve, matching Heptabase's look.
+      const childHasVisibleChildren =
+        child.children.length > 0 && !child.collapsed;
+      const childRightX = childXLeft + o.topicWidth;
+      const tail = childHasVisibleChildren
+        ? ` L ${childRightX} ${childAnchorY}`
+        : '';
       const path =
-        `M ${parentRightX} ${parentCenterY} ` +
-        `C ${midX} ${parentCenterY}, ${midX} ${childCenterY}, ${childLeftX} ${childCenterY}`;
+        `M ${parentRightX} ${parentAnchorY} ` +
+        `C ${midX} ${parentAnchorY}, ${midX} ${childAnchorY}, ${childLeftX} ${childAnchorY}` +
+        tail;
       branches.push({
         id: `${t.id}->${child.id}`,
         parentId: t.id,
@@ -235,11 +256,11 @@ export const layoutMindmap = (
  * a simple number-token rewrite.
  */
 const shiftPath = (path: string, dx: number, dy: number): string => {
-  const tokens = path.split(/\s+/);
+  const tokens = path.split(/\s+/).filter((t) => t.length > 0);
   const out: string[] = [];
   let numberIndex = 0;
   for (const tok of tokens) {
-    if (tok === 'M' || tok === 'C') {
+    if (tok === 'M' || tok === 'C' || tok === 'L') {
       out.push(tok);
       numberIndex = 0;
       continue;

--- a/apps/canvas-workspace/src/renderer/src/utils/mindmapLayout.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/mindmapLayout.ts
@@ -98,16 +98,18 @@ const ROOT_COLOR = '#1F2328';
  * stays synchronous, which matters because `layoutMindmap` runs in a
  * `useMemo` on every tree mutation.
  *
- * Latin characters at the topic font size (~14px) average ~0.56em; CJK
- * chars are ~1em. We detect CJK by scanning for Han + kana + full-width
- * ranges and pick the wider estimate — good enough, and errs on the
- * side of "a little too wide" which never looks broken.
+ * The canvas app ships a monospace-leaning UI font, so Latin chars at
+ * the topic font sizes (14 / 20px) run ~0.6em wide; CJK chars are
+ * ~0.95em. We pick a slightly pessimistic multiplier so the estimated
+ * slot never ends up narrower than the rendered text — if it did, the
+ * text would either wrap (for pre-wrap) or overshoot its slot and clip
+ * into the neighbouring branch.
  */
 const CJK_RANGE = /[　-鿿＀-￯぀-ヿ]/;
 const estimateTextWidth = (text: string, fontSize: number): number => {
   if (!text) return 0;
   const hasCJK = CJK_RANGE.test(text);
-  const avg = hasCJK ? fontSize * 0.95 : fontSize * 0.56;
+  const avg = hasCJK ? fontSize * 0.98 : fontSize * 0.65;
   return text.length * avg;
 };
 

--- a/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
@@ -1,7 +1,10 @@
-import type { CanvasNode, FileNodeData, TerminalNodeData, FrameNodeData, AgentNodeData, TextNodeData, IframeNodeData, ImageNodeData, ShapeNodeData } from '../types';
+import type { CanvasNode, FileNodeData, TerminalNodeData, FrameNodeData, AgentNodeData, TextNodeData, IframeNodeData, ImageNodeData, ShapeNodeData, MindmapNodeData, MindmapTopic } from '../types';
 
 let nodeIdCounter = 0;
 export const genId = (): string => `node-${Date.now()}-${++nodeIdCounter}`;
+
+let topicIdCounter = 0;
+export const genTopicId = (): string => `topic-${Date.now()}-${++topicIdCounter}`;
 
 const NODE_DEFAULTS: Record<CanvasNode['type'], { title: string; width: number; height: number }> = {
   file:     { title: 'Untitled', width: 420, height: 360 },
@@ -12,9 +15,10 @@ const NODE_DEFAULTS: Record<CanvasNode['type'], { title: string; width: number; 
   iframe:   { title: 'Web',      width: 520, height: 400 },
   image:    { title: 'Image',    width: 320, height: 240 },
   shape:    { title: 'Shape',    width: 200, height: 140 },
+  mindmap:  { title: 'Mindmap',  width: 640, height: 420 },
 };
 
-export const createNodeData = (type: CanvasNode['type']): FileNodeData | TerminalNodeData | FrameNodeData | AgentNodeData | TextNodeData | IframeNodeData | ImageNodeData | ShapeNodeData => {
+export const createNodeData = (type: CanvasNode['type']): FileNodeData | TerminalNodeData | FrameNodeData | AgentNodeData | TextNodeData | IframeNodeData | ImageNodeData | ShapeNodeData | MindmapNodeData => {
   switch (type) {
     case 'file':     return { filePath: '', content: '', saved: false, modified: false };
     case 'terminal': return { sessionId: '' };
@@ -24,8 +28,34 @@ export const createNodeData = (type: CanvasNode['type']): FileNodeData | Termina
     case 'iframe':   return { url: '', html: '', mode: 'url', prompt: '' };
     case 'image':    return { filePath: '' };
     case 'shape':    return { kind: 'rect', fill: '#E8EEF7', stroke: '#5B7CBF', strokeWidth: 2 };
+    case 'mindmap':  return {
+      root: {
+        id: genTopicId(),
+        text: 'Central topic',
+        children: [
+          { id: genTopicId(), text: 'Idea 1', children: [] },
+          { id: genTopicId(), text: 'Idea 2', children: [] },
+          { id: genTopicId(), text: 'Idea 3', children: [] },
+        ],
+      },
+      layout: 'right',
+      rev: 0,
+    };
   }
 };
+
+/**
+ * Deep-clone a mindmap topic tree, minting fresh ids so the result can
+ * coexist with the source (duplicate / paste flows). `text`, `color`,
+ * and `collapsed` are copied verbatim.
+ */
+export const cloneMindmapTopic = (topic: MindmapTopic): MindmapTopic => ({
+  id: genTopicId(),
+  text: topic.text,
+  color: topic.color,
+  collapsed: topic.collapsed,
+  children: topic.children.map(cloneMindmapTopic),
+});
 
 export const createDefaultNode = (type: CanvasNode['type'], x: number, y: number): CanvasNode => {
   const def = NODE_DEFAULTS[type];


### PR DESCRIPTION
## Summary
Introduces a new "mindmap" canvas node type that implements a Heptabase-style hierarchical mind mapping interface. The mindmap is a self-contained node with a recursive topic tree structure, deterministic layout algorithm, and rich keyboard navigation.

## Key Changes

- **New MindmapNodeBody component** (`MindmapNodeBody/index.tsx`): 
  - Renders a hierarchical tree of topics with connecting branch lines
  - Supports single-click selection, double-click/type-to-edit, and contenteditable text editing
  - Implements geometric neighbor navigation (arrow keys find nearest topics in each direction)
  - Auto-sizes the canvas node to fit content via `onAutoResize` callback

- **Layout engine** (`mindmapLayout.ts`):
  - Deterministic horizontal tree layout algorithm (simplified Reingold–Tilford)
  - Computes topic positions, branch paths (cubic Bezier curves), and bounding boxes
  - Supports collapsible topics with visual indicators
  - Estimates text width accounting for CJK characters to prevent wrapping

- **Tree mutation helpers** (`mindmapLayout.ts`):
  - `insertChild`, `setTopicText`, `toggleCollapsed`, `deleteTopic`, `findParent`, `findTopicPath`
  - All mutations return new tree instances (immutable pattern)
  - Smart focus management (deletion focuses sibling or parent)

- **Keyboard model**:
  - Tab: add child and edit
  - Enter: add sibling (or child if on root)
  - Shift+Tab: unindent (promote to sibling of parent)
  - Space: toggle collapse
  - Arrow keys: navigate to geometric neighbors
  - Backspace/Delete: remove topic
  - Esc: exit edit mode
  - Type character: enter edit mode

- **Type system updates**:
  - Added `MindmapTopic` and `MindmapNodeData` interfaces to types
  - Added `mindmap` to `CanvasNode.type` union
  - Added `genTopicId()` factory function for stable topic IDs

- **UI integration**:
  - Added mindmap button to FloatingToolbar
  - Added mindmap option to NodeContextMenu
  - Integrated MindmapNodeBody into CanvasNodeView with frameless styling
  - Added `onAutoResize` callback throughout canvas infrastructure

- **Styling** (`MindmapNodeBody/index.css`):
  - Chromeless topic pills with branch-colored accent bars for selection
  - Contenteditable styling with focus ring
  - Empty-state placeholder text
  - Collapsed-subtree indicator dots
  - SVG branch rendering with opacity and rounded line caps

## Notable Implementation Details

- Topics are stored in a single recursive tree under `node.data.root`, not as separate canvas nodes
- Layout is fully deterministic: given the tree, positions are computed on every render (no persisted x/y)
- The mindmap auto-sizes via `onAutoResize`, which bypasses undo history so size changes ride along with mutations
- Branch colors follow a 6-color palette (Heptabase-inspired) that repeats for deeper nesting
- Text width estimation uses monospace-leaning metrics (~0.65em for Latin, ~0.98em for CJK) to avoid layout thrashing
- Geometric navigation uses weighted scoring (primary axis 1x, secondary axis 2x) to prefer aligned neighbors

https://claude.ai/code/session_01QWrgUXWKmkxrMT46nq7mpK