### PR TITLE
fix: friendlier content-filter message + runId tag for diagnostics

### DIFF
--- a/apps/remote-server/src/core/dispatcher.ts
+++ b/apps/remote-server/src/core/dispatcher.ts
@@ -175,7 +175,15 @@ async function runAgentAsync(adapter: PlatformAdapter, incoming: IncomingMessage
       },
     });
 
-    await handle.onDone(turn.resultText);
+    // If the engine returned a synthetic warning (e.g. content-filter, context
+    // overflow, max-steps), tag the runId so users can pull full context from
+    // devtools / pm2 logs.
+    let finalText = turn.resultText;
+    if (typeof finalText === 'string' && finalText.startsWith('⚠️')) {
+      finalText = `${finalText}\n\n_runId: \`${turn.runId}\` (use this to look up the full request/response in devtools or pm2 logs)_`;
+    }
+
+    await handle.onDone(finalText);
 
     if (turn.compactions.length > 0) {
       console.info(

--- a/packages/engine/src/core/loop.ts
+++ b/packages/engine/src/core/loop.ts
@@ -462,10 +462,29 @@ export async function loop(context: Context, options?: LoopOptions): Promise<str
       }
 
       if (finishReason === 'content-filter') {
-        return text || 'Content filtered.';
+        // Provider's safety/policy layer rejected the response. Surface a more
+        // actionable message so users know it's not an internal bug. Log the
+        // event with usage details so operators can correlate by timestamp.
+        console.warn('[loop] content-filter finishReason', {
+          textLen: text?.length ?? 0,
+          textTail: typeof text === 'string' ? text.slice(-200) : undefined,
+          inputTokens: (usage as any)?.inputTokens,
+          outputTokens: (usage as any)?.outputTokens,
+          model: options?.model,
+          modelType: options?.modelType,
+          msgCount: context.messages.length,
+        });
+        return text || '⚠️ Upstream content filter blocked this response (provider safety policy). Try rephrasing, splitting the request, or switching model.';
       }
 
       if (finishReason === 'error') {
+        console.warn('[loop] error finishReason', {
+          textLen: text?.length ?? 0,
+          inputTokens: (usage as any)?.inputTokens,
+          outputTokens: (usage as any)?.outputTokens,
+          model: options?.model,
+          modelType: options?.modelType,
+        });
         return text || 'Task failed.';
       }
 


### PR DESCRIPTION
## Problem

When upstream provider (e.g. copilot-api) blocks a response via its safety filter, users see only a cryptic `Content filtered.` with no way to diagnose. We also currently emit zero log lines for these cases, so operators can't correlate either.

## Fix

**engine/loop.ts**
- `console.warn` on `finishReason='content-filter'` and `'error'` with usage / model / msgCount details (timestamp-correlatable)
- Replace user-facing string with: `⚠️ Upstream content filter blocked this response (provider safety policy). Try rephrasing, splitting the request, or switching model.`

**remote-server/dispatcher.ts**
- If `resultText` starts with `⚠️`, append `_runId: \`...\`_` so users can look up the run in devtools or grep pm2 logs

## Test
- engine 15/15 tests passing
- engine + remote-server build OK

## Deploy
`pm2 restart remote-server`