### PR TITLE
feat(canvas-workspace): visual agent teams (claude/codex/pulse coordination)

### DIFF
--- a/apps/canvas-workspace/docs/agent-teams/prd.md
+++ b/apps/canvas-workspace/docs/agent-teams/prd.md
@@ -1,0 +1,426 @@
+# Agent Teams on Canvas — 产品需求文档 (PRD)
+
+**Status**: Draft v0.1
+**Owner**: Jasper
+**Last updated**: 2026-04-25
+
+---
+
+## 1. 背景与动机
+
+### 1.1 问题描述
+
+当前 canvas-workspace 已经支持在画布上创建多个 agent 节点（claude-code / codex / pulse-coder），每个节点是独立的 PTY 进程。但这些 agent 之间是**完全孤立**的：
+
+- 没有共享上下文 — 每个 agent 只知道自己的初始 prompt
+- 没有任务协调 — 用户必须手动把任务拆给每个 agent
+- 没有进度同步 — 每个 agent 独立结束，结果分散在各自终端
+- 没有协作语义 — 画布只是"多个 agent 的收纳盒"，没有体现它们应该一起做事
+
+与此同时，Claude Code 在 v2.1.32 引入了原生的 **Agent Teams** 概念：team lead 协调 teammates、共享任务列表、agent 间互相通信。但它有两个限制：
+1. **只覆盖 claude-code**，不能协调跨厂商的 agent
+2. **没有可视化** — team 拓扑、任务流、agent 状态全在终端里，不直观
+
+### 1.2 机会
+
+canvas-workspace 已经具备的基础设施恰好覆盖了 Agent Teams 缺失的可视化层：
+
+- **Frame 节点** + 几何归属算法 → 天然的"团队边界"
+- **Edge 节点** + 语义标签 → 天然的"任务流/依赖关系"
+- **MCP server** 已自动注册到 claude-code 和 codex → agent 天生有画布操作能力
+- **canvas-agent**（chat panel）→ 现成的高层指挥入口
+
+把这些组合起来，canvas-workspace 可以成为**第一个跨 agent 厂商、可视化的 agent 协作平台**。
+
+### 1.3 目标用户
+
+主要面向：
+- **AI 工程师 / 资深开发者** — 已经熟悉 claude-code / codex / pulse-coder 单 agent 工作流，想要扩展到多 agent 协作
+- **画布工作流爱好者** — 习惯 Heptabase / FigJam 这种空间组织思维，希望 agent 协作也能"看得见"
+
+不针对：
+- 完全新手（多 agent 协作本身需要一定经验门槛）
+- CI/CD / 自动化场景（这是交互式画布工具，不是流水线）
+
+---
+
+## 2. 用户故事
+
+### 2.1 核心故事
+
+**S1：研究并对比方案**
+> 我在做技术选型，要在三个 ORM 库之间选一个。我把 PRD 拖进画布，让 canvas agent 创建一个 team：3 个 teammate 各自调研一个库（Drizzle / Prisma / Kysely），最后由 lead 综合输出对比报告。我可以在画布上看到每个 teammate 的进展，需要时直接干预某一个。
+
+**S2：跨层协调实现新功能**
+> 我要给应用加"邀请同事"功能。我创建一个 team，包含 1 个 lead + 3 个 teammate（前端 / 后端 / 测试）。Lead 拆分任务到 tasks.md，每个 teammate 认领自己专长的任务。前后端 teammate 边做边在画布上互相参考对方的输出，测试 teammate 在两者完成后跟进。
+
+**S3：并行调试**
+> 一个偶发 bug 不知道根因。我让 canvas agent 起 4 个 teammate，每人测试一个假设（数据库 / 网络 / 缓存 / 时序）。它们各自在终端里跑实验，把结论写进共享 tasks.md，最后由 lead 综合判断哪个假设成立。
+
+**S4：跨 agent 协作（独有价值）**
+> 我用 claude-code 做架构设计，用 codex 写实际代码（不同模型擅长不同事）。在画布上把它们放进一个 team frame：claude-code 作为 lead 出方案，codex 作为 teammate 实现。Lead 通过共享文件传递设计文档给 codex。
+
+### 2.2 反向故事（明确不做）
+
+**N1：完全自主长跑**
+> 我不希望"创建 team 然后离开几小时回来看结果"。这版本明确要求人在场。
+
+**N2：team 之间互相调用**
+> 不支持"team A 主动 RPC 调用 team B"的程序化调度。多个 team 可以共存于同一画布，但它们之间不直接通信 — 用户作为人类协调者在团队间传递信息（或借助共享 file 节点）。
+
+**N3：跨 workspace team**
+> Team 的成员必须在同一个 canvas workspace 内。
+
+### 2.3 多 Team 并行（关键约束）
+
+**单个 workspace 必须支持任意数量的 team 同时存在与并行运行。**
+
+这是画布产品的核心特性 — 用户会很自然地在同一个 workspace 里组织多个 team，例如：
+
+- 一个 team 在做"前端调研"，另一个 team 在做"后端调研"，互不打扰但都对当前项目有贡献
+- 一个长跑的"PRD 讨论 team"挂在画布角落，旁边临时起一个"快速调试 team"
+- 主线工作 team 之外，单独建一个"实验沙盒 team" 跑高风险尝试
+
+**派生需求**（影响后续设计）：
+
+- **每个 team 有独立身份**：`teamMeta` 自带稳定 `teamId`，不能假设"画布上只有一个 team"
+- **每个 team 有独立 tasks.md**：放在各自 team frame 内，不共用全局任务列表
+- **每个 team 有独立的 lead 协调循环**：多个 lead agent 可同时在跑，互不干扰
+- **MCP 工具必须 team 范围化**：`canvas_list_agents` 等工具应支持按 `teamId` 过滤，避免一个 team 的 lead 看到/操作另一个 team 的成员
+- **Agent 节点最多归属一个 team**：通过 frame 的几何归属算法天然保证（最近的 team frame 优先）；交叉摆放需要给出明确归属规则
+- **视觉差异化要可区分多个 team**：不同 team 用不同 frame 颜色 / 不同 lead icon 颜色，避免画布上多个 team 视觉混淆
+
+---
+
+## 3. 范围
+
+### 3.1 In Scope（MVP 必做）
+
+| ID | 功能 | 说明 |
+|----|------|------|
+| F1 | Team Frame | Frame 节点扩展 `teamMeta`，标识为 team 容器 |
+| F2 | Lead Agent | 一个普通 agent 节点被指定为 lead，使用专门的 system prompt |
+| F3 | 共享任务板 | Team frame 内的 `tasks.md` 文件节点，所有成员读写 |
+| F4 | 三种 agent 互通 | claude-code / codex / pulse-coder 都能担任 lead 或 teammate |
+| F5 | MCP 工具扩展 | 新增 `canvas_create_agent` / `canvas_send_to_agent` / `canvas_list_agents` 等 |
+| F6 | 视觉化拓扑 | Team frame header 显示 team 名 / 成员数；lead 节点有专属标记；分配关系用 edge 表达 |
+| F7 | 从 Chat Panel 创建 team | canvas agent 提供 `canvas_create_team` 工具，一句话起一个 team |
+| F8 | 状态可观测 | 用户在画布上能看到：哪些 teammate 在跑、哪些任务在进行/完成 |
+| F9 | 多 team 并行 & 隔离 | 同一 workspace 多个 team 并存；MCP 工具按 `teamId` 范围化；agent 只属一个 team |
+
+### 3.2 Should Have（优先级高，可推迟到 v1.1）
+
+| ID | 功能 | 说明 |
+|----|------|------|
+| F10 | Lead 主动监控 | Lead agent 周期性读取 teammate 输出，判断完成 / 卡住 / 需要干预 |
+| F11 | 任务依赖 | tasks.md 支持 `blockedBy` 字段，未解锁的任务不能被认领 |
+| F12 | 优雅清理 | "解散 team" 操作：关闭所有 PTY、归档对话、清理临时文件 |
+| F13 | Team 模板 | 预定义几种常见 team 结构（research-3 / debug-5 / fullstack-4）一键创建 |
+
+### 3.3 Could Have（v2+）
+
+- C1：Claude Code 原生 agent teams 协议集成（读 `~/.claude/teams/{name}/config.json` 反射到画布）
+- C2：跨 workspace team
+- C3：Team 嵌套（大 team 内含子 team，小 team 各自有 lead）
+- C4：Hooks 集成（TaskCreated / TaskCompleted / TeammateIdle）
+- C5：Team 录制回放（导出整个协作过程为可回放的 timeline）
+
+### 3.4 Out of Scope（明确不做）
+
+- ❌ Peer-to-peer 直接消息（teammate 之间不直接 IPC，统一通过 lead 或共享文件）
+- ❌ 自动 agent 选型（不会"AI 帮你决定 lead 用哪种 agent"）
+- ❌ 持久化跨会话的 team 状态（关闭 workspace 后 team 终止）
+- ❌ 移动端支持
+
+---
+
+## 4. 功能需求详述
+
+### 4.1 创建 Team
+
+**触发方式**：
+
+1. **从 Chat Panel**（推荐入口）
+   - 用户对 canvas agent 说："创建一个 team 来调研三个 ORM"
+   - canvas agent 调用 `canvas_create_team` 工具
+   - 自动在画布上创建：1 个 team frame + 1 个 lead agent + N 个 teammate + 1 个 tasks.md + 必要的 edge
+
+2. **从画布右键菜单**（次要入口）
+   - 框选若干 agent 节点 → 右键 "Group as Team"
+   - 自动外套 team frame，提示用户指定 lead
+
+3. **手动**（高级用户）
+   - 用户自己创建 frame，在 inspector 里勾选 "This is a team"
+   - 拖 agent 节点进 frame 自动成为成员
+
+**默认行为**：
+- 新 team 自动生成名字：`Team-{timestamp}` 或基于任务关键词
+- 默认创建一个空的 `tasks.md` 在 team frame 内
+- 默认 lead = 第一个加入的 agent；可手动改
+
+### 4.2 任务分配与执行
+
+**Tasks.md 格式**（约定，非强 schema）：
+
+```markdown
+# Team Tasks
+
+## ☐ T1: 调研 Drizzle ORM
+- assignee: codex-1
+- status: pending
+- output: notes/drizzle.md
+
+## ☐ T2: 调研 Prisma ORM
+- assignee: claude-1
+- status: in_progress
+- output: notes/prisma.md
+- blockedBy: []
+
+## ☑ T3: 综合对比
+- assignee: lead
+- status: completed
+- blockedBy: [T1, T2]
+```
+
+**Lead 的协调循环**（关键流程）：
+1. 读 tasks.md
+2. 找出 unassigned 任务，根据 teammate 类型/能力分配（写回 tasks.md + 通过 `canvas_send_to_agent` 通知 teammate）
+3. 周期性轮询 teammate 状态（PTY 输出 + 节点 status 字段）
+4. 任务完成 → 更新 tasks.md → 解锁依赖任务
+5. 全部完成 → 综合输出，停止循环
+
+**Teammate 的执行模式**：
+- 收到 lead 通过 `canvas_send_to_agent` 发来的初始 prompt
+- prompt 中包含：任务 ID、任务描述、相关文件路径、约定的产出位置
+- 完成后写产出文件 + 在 PTY 中输出标记（如 `=== TASK T1 DONE ===`）便于 lead 解析
+
+### 4.3 跨 Agent 兼容
+
+| Agent | Lead 角色 | Teammate 角色 | 备注 |
+|-------|-----------|--------------|------|
+| claude-code | ✅ 完整支持 | ✅ 完整支持 | 自带 todo 工具，能很好地处理 tasks.md |
+| codex | ⚠️ 受限支持 | ✅ 完整支持 | TUI 输入需 120ms 延迟（已有处理）;监控其状态较难 |
+| pulse-coder | ✅ 完整支持 | ✅ 完整支持 | 内部产品，可针对性优化 |
+
+**推荐组合**：
+- 默认 lead = claude-code 或 pulse-coder（更可靠的协调能力）
+- teammate 可任意混用
+
+### 4.4 可观测性
+
+**画布上必须能看到**：
+- Team frame：队名、成员数、整体进度（X/Y 任务完成）
+- Lead 节点：皇冠图标 / 不同边框颜色
+- Teammate 节点：当前任务 ID 显示在 header
+- Edge：lead → teammate 的分配关系（kind: `assigned`），任务依赖关系（kind: `depends-on`）
+- Tasks.md：作为普通 file 节点直接展示，实时刷新
+
+**不需要新增**：
+- 单独的"team 仪表盘" — 画布本身就是仪表盘
+- 进度条小部件 — frame label 文字够用
+
+### 4.5 错误处理
+
+| 场景 | 行为 |
+|------|------|
+| Teammate PTY 退出 | 节点 status → `error`，lead 收到通知（通过 `canvas_list_agents` 轮询发现），决定重启或重分配 |
+| Lead 自身崩溃 | Team frame 进入"无主"状态，画布上提示用户接管或选新 lead |
+| MCP server 不可达 | Agent 退化为孤立节点，team 协调暂停；恢复后 lead 重新读 tasks.md 继续 |
+| tasks.md 被并发写坏 | 走 canvas-store 已有的 `.bak` 备份机制；agent 操作失败时让 lead 重试 |
+| Agent 误删 team frame | 删除前必须二次确认（UI 弹窗）；删除后所有成员 PTY 关闭 |
+
+---
+
+## 5. 非功能需求
+
+### 5.1 性能
+
+- **创建 team 延迟**：< 3 秒（不算 agent 自身启动时间）
+- **MCP 工具调用延迟**：单次 < 500ms
+- **画布渲染**：team frame + 10 个 teammate 同时活跃时不卡顿（≥ 30 FPS）
+
+### 5.2 资源占用
+
+- 单 team 通常 3-5 个 teammate（参考 Claude docs 推荐）
+- 每个 teammate 是一个独立的 CLI 进程 + PTY，约 100-300 MB 内存
+- 用户应能在画布上看到资源占用提示（成员数 ≥ 6 时给警告）
+
+### 5.3 可观测性 / 调试
+
+- 所有 MCP 工具调用记录到 main process 日志，带 team_id / node_id
+- Lead agent 的协调决策（分配/重分配）写入 team frame 关联的 `team-log.md`（可选，便于事后复盘）
+
+### 5.4 兼容性
+
+- 不破坏现有 frame 节点行为：没有 `teamMeta` 的 frame 还是普通分组
+- 不破坏现有 agent 节点：未加入 team 的 agent 还是单独运行
+- canvas.json schema 向前兼容：旧版本读到带 `teamMeta` 的 frame 时降级为普通 frame
+
+---
+
+## 6. 成功标准
+
+### 6.1 验收 Demo
+
+**Demo 1：调研对比**（最小可行 demo）
+1. 用户在 chat panel 输入："创建一个 team 调研 Drizzle / Prisma / Kysely 三个 ORM，最后给我对比报告"
+2. 画布上自动出现：team frame "ORM Research" + 1 个 lead (claude-code) + 3 个 teammate (codex × 3) + tasks.md
+3. 3 个 teammate 并行跑调研，PTY 上能看见各自进度
+4. 任务全部完成后，lead 在 frame 内创建一个 `report.md` 文件节点
+5. 用户在画布上一眼看到整个流程，可点开任一 teammate terminal 看细节
+
+**Demo 2：手动组队**
+1. 用户已经手动开了 2 个 agent 节点在画布上
+2. 框选 → 右键 "Group as Team"
+3. 弹窗选择哪个是 lead
+4. team frame 自动生成包裹两个节点
+5. 用户对 lead 节点直接发消息，lead 开始协调另一个 teammate
+
+### 6.2 量化指标
+
+- ✅ 上述两个 demo 用户能在 5 分钟内独立完成（无需文档辅助）
+- ✅ 三种 agent 类型都至少有一种 lead 配置 + 一种 teammate 配置可工作
+- ✅ Team frame 在画布上的视觉差异化让用户一眼能区分 vs 普通 frame
+- ✅ 关闭并重新打开 workspace，team 拓扑（frame + 成员归属）能正确恢复（PTY 不强求恢复）
+
+### 6.3 反指标（要避免）
+
+- ❌ 用户必须先读文档才能开始用 → 失败
+- ❌ Lead agent 经常 hang 住不前进 → 失败
+- ❌ team 创建后用户找不到该看哪里 → 失败（说明视觉表达不够）
+
+---
+
+## 7. 风险与缓解
+
+| 风险 | 影响 | 缓解策略 |
+|------|------|---------|
+| 跨 agent 行为差异（输出格式、状态信号）让 lead 难以可靠监控 | 高 | MVP 先约定标记协议（`=== TASK X DONE ===`），后续再考虑更鲁棒的方案 |
+| Token 成本爆炸（多个 teammate 并行） | 中 | UI 显示成员数预警；文档教育用户 3-5 人为佳 |
+| Lead agent 决策失误浪费 teammate 工作 | 中 | 强制人在场；用户可随时干预任一节点 |
+| MCP server 单点故障 | 中 | 已有 health check；agent 失联时画面给出明确提示 |
+| 用户混淆 team frame 和普通 frame | 低 | 显著的视觉差异（皇冠图标 + 特殊边框 + label 前缀） |
+
+---
+
+---
+
+## 8. 复用策略（与 `packages/` 的关系）
+
+仓库里已有 `packages/agent-teams`（约 2300 行），其类型与目录约定与 Claude Code Agent Teams 文档高度对齐。但其默认假设 **teammate = in-process `pulse-coder-engine` 实例**，与本项目"画布上跑真实 claude/codex/pulse-coder CLI 进程"的目标不一致。
+
+经过权衡，本项目采取 **部分复用** 策略：
+
+### 8.1 明确复用（不重造）
+
+| 复用对象 | 来源 | 复用理由 |
+|---------|------|---------|
+| `TaskList` 类 | `packages/agent-teams/src/task-list.ts` | 纯文件协议（JSON），语言/进程无关；自带 work-stealing 守卫与并发安全；任务依赖 / hooks 已实现 |
+| `Mailbox` 类 | `packages/agent-teams/src/mailbox.ts` | 纯文件协议，agent 间消息队列；CLI 进程也可读写 |
+| 状态目录约定 | `~/.pulse-coder/teams/{name}/` | 与 `packages/agent-teams` 共用同一目录结构（`config.json` / `tasks/` / `mailbox/`），未来引入 in-process teammate 可平滑共存 |
+| 类型定义 | `Task` / `TaskStatus` / `TeamMessage` / `TeamHooks` 等 | 直接 import；避免双份类型 |
+
+### 8.2 不复用（自建画布层）
+
+| 不复用对象 | 原因 | 替代方案 |
+|-----------|------|---------|
+| `Team` 类 | 强依赖 in-process Teammate 实例 | 自建 `CanvasTeam`：以 team frame 为载体，成员 = 画布 agent 节点 |
+| `TeamLead` 类 | 假设 Lead 是 Engine loop 内的特定 agent | Lead 是画布上的一个普通 agent 节点（claude-code / pulse-coder），通过 system prompt 约定其角色 |
+| `Teammate` 类 | 是 Engine 实例的封装 | Teammate 是画布上的 PTY agent 节点；通过现有 `pty-manager` + `canvas_send_to_agent` 沟通 |
+| `planner.ts` | 输出的是 `TeammateOptions[]`（Engine 配置） | 在 canvas-agent 工具层重新实现，输出"画布上要创建哪些 agent 节点"的指令 |
+| `display/in-process.ts` | 终端 UI（Shift+Down 切换） | 不需要 — 画布本身就是显示层 |
+
+### 8.3 长期演进（v2+）
+
+未来可在画布上引入 **第二种 teammate 类型** —— "Engine Teammate"：
+- 不开 PTY，直接在 main process 内跑 `Engine` 实例
+- 资源更轻、状态更可观测、可使用更多 engine 工具
+- 与 PTY teammate 共存于同一 team frame
+- 两种 teammate 类型走同一份 `TaskList` / `Mailbox` 协议，对 Lead 透明
+
+这样既守住了 MVP 的核心价值（画布上跑真实 CLI），又为长期能力扩展留了无缝路径。
+
+### 8.4 对实现工作量的影响
+
+| 模块 | 自建（不复用）成本 | 部分复用后的实际成本 |
+|------|-------------------|---------------------|
+| 任务列表（依赖图、work stealing、并发） | ~3-5 天 | 0（直接 import） |
+| 消息队列（持久化、未读标记） | ~2 天 | 0（直接 import） |
+| 类型定义维护 | 持续小成本 | 0 |
+| Team 容器 / Lead 协调循环（PTY 编排） | 必须自建 | 必须自建（不变） |
+| CLI 子命令暴露（`pulse-canvas team ...`） | 必须自建 | 必须自建（不变） |
+| 视觉化 / Frame 集成 | 必须自建 | 必须自建（不变） |
+
+**净收益**：节省 ~5-7 天底层基础设施工作，把精力集中在"画布特有"的部分。
+
+### 8.5 暴露给 agent 的方式
+
+复用的 `TaskList` / `Mailbox` 是 **类**，需要在 Node.js 进程里实例化才能用。Agent 是独立 CLI 进程（claude / codex / pulse-coder），不能直接 `import`。
+
+中间通过 `pulse-canvas team` 子命令组桥接：
+- `packages/canvas-cli/src/core/team.ts` 在 CLI 进程内 `import { TaskList, Mailbox } from 'pulse-coder-agent-teams'`
+- `packages/canvas-cli/src/commands/team.ts` 暴露为子命令
+- Agent 通过 bash 工具调 `pulse-canvas team task claim ...`，每次是新的短命进程
+- 跨进程一致性靠 `TaskList` 自带的 `O_EXCL` 文件锁
+
+技术细节见 `tech-design.md` §4。
+
+---
+
+## 9. 阶段拆分
+
+### Milestone 1: MVP（2-3 周）
+- F1 Team Frame 数据模型
+- F2 Lead Agent system prompt
+- F3 tasks.md 约定
+- F4 三种 agent 兼容（基础场景）
+- F5 MCP 工具扩展（核心 3 个）
+- F6 基础视觉差异化
+- F7 Chat Panel 创建 team 入口
+- F8 基础状态展示
+- F9 多 team 并行 & 隔离
+- 通过 Demo 1（包含同 workspace 起两个 team 的轻量验证）
+
+### Milestone 2: 完整体验（2 周）
+- F10 Lead 主动监控
+- F11 任务依赖
+- F12 优雅清理
+- 完成 Demo 2
+- 完善错误处理 / 边界情况
+
+### Milestone 3: 进阶（按需）
+- F13 Team 模板
+- C1 Claude 原生 teams 协议集成
+- C4 Hooks 集成
+
+---
+
+## 10. 开放问题
+
+需要在技术方案阶段或后续讨论中澄清：
+
+- **Q1**：lead 的协调循环是"事件驱动"还是"轮询"？事件驱动需要 PTY 输出解析，轮询简单但有延迟。
+- **Q2**：teammate 完成任务的信号怎么传？标记字符串容易误判，专用 MCP 工具（teammate 主动调）更可靠但需要 agent 配合。
+- **Q3**：`canvas_send_to_agent` 要求目标节点 PTY 还活着。当 lead 想让一个已退出的 teammate 接新任务时，需要"重启 agent"语义 — 是 lead 的责任还是用户的？
+- **Q4**：tasks.md 被多个 agent 同时编辑的并发安全 — 依赖 canvas-store 现有的原子写已经够了吗？还是需要更明确的 lock？
+- **Q5**：Team frame 是否应该限制 lead 节点的位置（必须在 frame 内的固定区域）？还是让用户自由摆放？
+- **Q6**：多 team 并行时，画布层面是否需要给资源占用预警？例如 3 个 team × 4 个 teammate = 12 个 CLI 进程。是否设软上限（如 ≥ 10 个活跃 teammate 时给提示），还是只看单 team 的 6+ 阈值？
+
+---
+
+## 11. 附录
+
+### 11.1 术语表
+
+- **Team Frame**：带有 `teamMeta` 字段的 frame 节点，作为 team 的可视化容器
+- **Lead Agent**：team 中负责协调的 agent 节点，由 `teamMeta.leadNodeId` 指定
+- **Teammate**：team frame 内除 lead 外的 agent 节点
+- **Tasks.md**：team frame 内约定命名的 markdown 文件节点，作为共享任务板
+- **MCP Tools**：通过 `localhost:3333/mcp` 暴露给 agent 的画布操作工具集
+
+### 11.2 参考资料
+
+- Claude Code Agent Teams 官方文档（已存档至 `docs.md`）
+- canvas-workspace 现有架构：`apps/canvas-workspace/src/main/canvas-agent/`、`mcp-server.ts`
+- pulse-coder-orchestrator 包：作为 engine 层 multi-agent 协调的对照参考
+- **被复用的底层包**：`packages/agent-teams`（`TaskList` / `Mailbox` / 类型定义）— 详见 §8

--- a/apps/canvas-workspace/docs/agent-teams/tech-design.md
+++ b/apps/canvas-workspace/docs/agent-teams/tech-design.md
@@ -1,0 +1,682 @@
+# Agent Teams on Canvas — 技术方案 (Tech Design)
+
+**Status**: Draft v0.2
+**Owner**: Jasper
+**Last updated**: 2026-04-25
+**对应 PRD**: [`prd.md`](./prd.md)
+
+> **v0.2 修订**：实现路线从 MCP HTTP server 改为 `pulse-canvas` CLI 子命令。
+> 原因：canvas-workspace 主进程已注释禁用 MCP server (`apps/canvas-workspace/src/main/index.ts:8-10, 146-148`)，
+> 当前 agent 接入方式是 canvas-cli 直接读写 JSON store。Skills 系统已经在教 agent 用 CLI，
+> 团队工具延续这个模式更自然。详见 §0 决策对比。
+
+---
+
+## 0. TL;DR
+
+把 `packages/agent-teams` 的 `TaskList` + `Mailbox` 文件协议直接复用，把 PTY agent 节点通过 frame 包成 team，让 lead agent 通过 **`pulse-canvas team` 子命令**协调画布上的 teammates（agent 用 bash 工具调 CLI，所有状态走 `~/.pulse-coder/teams/{teamId}/`）。所有 teammates 都是 PTY 节点；canvas chat panel 是创建 team 的入口，**不是** team 成员。
+
+### 0.1 为什么用 CLI 不是 MCP
+
+| 维度 | MCP HTTP server | `pulse-canvas` CLI |
+|------|----------------|---------------------|
+| 项目方向 | 已被注释禁用 | 已是 agent 接入主路径 |
+| Agent 调用方式 | 必须支持 MCP + 注册 | 任何能跑 bash 的 agent 都行 |
+| 协议本质 | HTTP RPC 包装文件 IO | 直接文件 IO |
+| 部署复杂度 | 启动顺序 / 端口 / 注册 | 单二进制，无 server |
+| 教 agent 学会用 | 工具描述 + 客户端支持 | Skills 文档已成熟 |
+| 进程数 | +1 server | 0 |
+
+唯一相对劣势：MCP 的 streaming 比 CLI 轮询优雅 — 但这是 v1.1 优化项，MVP 用 5s 轮询足够（§3.2）。
+
+---
+
+## 1. 架构总览
+
+### 1.1 进程拓扑
+
+```
+┌─ Electron Main Process ─────────────────────────────────────────────┐
+│                                                                       │
+│  ┌─ Canvas Chat Panel (in-process Engine) ─┐                          │
+│  │  - 用户的指挥入口                          │                          │
+│  │  - 不属于任何 team                          │                          │
+│  │  - 通过 child_process spawn pulse-canvas  │                          │
+│  └────────────────────────┬──────────────────┘                          │
+│                            │                                             │
+└────────────────────────────┼─────────────────────────────────────────────┘
+                             │
+   ┌─────────────────────────┴─────────────────────────────────┐
+   │                                                             │
+   ▼                                                             ▼
+┌──────────────┐  ┌──────────────┐  ┌──────────────┐    每个 PTY 进程都
+│ Lead PTY     │  │ Teammate PTY │  │ Teammate PTY │    在自己 cwd 调用
+│ (claude)     │  │ (codex)      │  │ (pulse-coder)│    pulse-canvas team ...
+└──────┬───────┘  └──────┬───────┘  └──────┬───────┘
+       │                  │                  │
+       │ pulse-canvas    │ pulse-canvas    │ pulse-canvas
+       │ team msg ...    │ team task ...   │ team task ...
+       ▼                  ▼                  ▼
+┌──────────────────────────────────────────────────────────────┐
+│  packages/canvas-cli/dist/index.cjs (binary: pulse-canvas)   │
+│   ├─ commands/team.ts   (10 个 team 子命令)                   │
+│   └─ core/team.ts       (TeamRuntime 缓存 + 文件协议)         │
+└─────────────────────────┬────────────────────────────────────┘
+                          │ 文件 IO
+                          ▼
+┌──────────────────────────────────────────────────────────────┐
+│  ~/.pulse-coder/teams/{teamId}/                              │
+│   ├── config.json    (team 元数据)                            │
+│   ├── tasks/tasks.json + tasks.lock                          │  ← 复用 TaskList
+│   └── mailbox/{memberId}.json                                │  ← 复用 Mailbox
+└──────────────────────────────────────────────────────────────┘
+```
+
+### 1.2 关键观察
+
+每次 `pulse-canvas team` 调用是**独立短命进程**（< 50ms），没有常驻 server。这意味着：
+
+- **TeamRuntime 缓存只活在单次调用内** — `core/team.ts` 里 `runtimes: Map<teamId, TeamRuntime>` 只在一次进程生命周期里有效
+- **跨进程一致性靠文件锁** — `TaskList` 已经实现 `O_EXCL` 锁，多个并发的 `pulse-canvas team task claim` 不会互相覆盖
+- **Electron app 的 fs.watch** 自动感知 `~/.pulse-coder/canvas/{wsId}/canvas.json` 变化（已存在的机制），team 状态变化的实时反映靠**画布上 tasks-view file 节点**指向 team 状态目录里的派生 markdown
+- **Lead 的协调循环**通过 PTY 跑 `bash sleep 5 && pulse-canvas team status ...` 这种简单循环，由 lead agent 自己驱动
+
+### 1.2 实体定义
+
+| 实体 | 形态 | 寿命 | 标识 |
+|------|------|------|------|
+| **CanvasTeam** | Frame 节点 + `teamMeta` 字段 | 用户显式删除 frame 才结束 | `teamMeta.teamId`（UUID，与 frame.id 解耦） |
+| **Lead Agent** | PTY 节点（`agent` 类型）| PTY 关闭即 lead 离线，team 进入"无主"状态 | `teamMeta.leadNodeId` |
+| **Teammate** | PTY 节点（`agent` 类型）| PTY 关闭即 teammate 离队 | `AgentNodeData.teamMembership.{teamId, memberId}` |
+| **Tasks** | `~/.pulse-coder/teams/{teamId}/tasks/tasks.json` | 与 team frame 共生 | Task 自身的 UUID |
+| **Mailbox** | `~/.pulse-coder/teams/{teamId}/mailbox/{memberId}.json` | 与 team frame 共生 | `memberId`（teammate 内部 ID） |
+| **Tasks 视图节点** | `file` 节点，filePath 指向上面 tasks.json 的人类可读镜像 | 自动随 tasks 变化重渲染 | 普通 nodeId |
+
+**关键澄清（与 PRD F3 的措辞统一）**：
+
+PRD 把"共享任务板"描述为 `tasks.md`，但复用的 `TaskList` 使用 JSON 作为 source of truth。设计上**两者都要有，分工明确**：
+
+- **`tasks.json`**（source of truth）：`packages/agent-teams` 的 `TaskList` 写入；agent 通过 `pulse-canvas team task ...` 操作；不直接显示给用户
+- **`tasks.md`**（派生视图）：JSON → markdown 的渲染产物；作为 file 节点显示在画布；只读（用户编辑会被覆盖）
+
+这样既复用了底层并发安全的 JSON 协议，又满足了 PRD 要求的"画布上看得见任务板"。
+
+---
+
+## 2. 数据模型
+
+### 2.1 `FrameNodeData` 扩展
+
+```ts
+// 现有
+export interface FrameNodeData {
+  color: string;
+  label?: string;
+}
+
+// 扩展后
+export interface FrameNodeData {
+  color: string;
+  label?: string;
+  /** 存在 → 这是个 Team Frame；不存在 → 普通 frame */
+  teamMeta?: TeamMeta;
+}
+
+export interface TeamMeta {
+  /** 全局唯一 team id（UUID）。和 frame.id 解耦：frame 被复制/移动时 teamId 不变 */
+  teamId: string;
+  /** 用户可见的 team 名 */
+  teamName: string;
+  /** 哪个 agent 节点是 lead（nodeId） */
+  leadNodeId?: string;
+  /** 状态目录，默认 ~/.pulse-coder/teams/{teamId}/ */
+  stateDir: string;
+  /** Tasks 视图节点 id（file node），用于 lead 知道往哪个节点广播任务变化 */
+  tasksViewNodeId?: string;
+  createdAt: number;
+}
+```
+
+### 2.2 `AgentNodeData` 扩展
+
+```ts
+export interface AgentNodeData {
+  // ... 现有字段
+  sessionId: string;
+  cwd?: string;
+  agentType: string;
+  status?: 'idle' | 'running' | 'done' | 'error';
+  agentArgs?: string;
+  inlinePrompt?: string;
+  promptFile?: string;
+
+  // 新增
+  /** 该节点的 team 归属。null/undefined = 不在任何 team 中 */
+  teamMembership?: {
+    teamId: string;
+    /** 在 team 内的稳定 ID（写入 mailbox 路径），独立于 nodeId 以便重启可保持身份 */
+    memberId: string;
+    /** 是否 lead */
+    isLead: boolean;
+    /** 加入时间，用于审计 */
+    joinedAt: number;
+  };
+}
+```
+
+**关键设计点**：
+
+- **`teamMembership` 显式存储**，不是每次靠 frame 几何重算。理由：用户拖动 agent 节点出 frame 时，应该弹窗确认"是否离队"而不是静默离队。几何归属只用于"创建时自动加入"和"UI 可视化"。
+- **`memberId` ≠ `nodeId`**：memberId 一旦分配就不变（即使节点被复制、PTY 重启），保证 mailbox 文件的连续性。
+
+### 2.3 `tasks.json` 格式（直接复用 `Task` 类型）
+
+```ts
+// 来自 packages/agent-teams/src/types.ts
+export interface Task {
+  id: string;              // UUID
+  title: string;
+  description: string;
+  status: 'pending' | 'in_progress' | 'completed' | 'failed';
+  deps: string[];          // 依赖的 task id 列表
+  assignee: string | null; // memberId
+  createdBy: string;       // memberId
+  createdAt: number;
+  updatedAt: number;
+  result?: string;
+}
+```
+
+**直接 import**，不重定义。
+
+### 2.4 `tasks.md` 派生视图格式
+
+```markdown
+# {{teamName}} — Tasks
+
+> Auto-generated from tasks.json. Do not edit manually — changes will be overwritten.
+> Last sync: {{ISO timestamp}}
+
+## Stats
+- Total: {{n}} | Pending: {{n}} | In Progress: {{n}} | Completed: {{n}} | Failed: {{n}}
+
+## Tasks
+
+### ☐ T1 [pending] {{title}}
+- ID: `{{uuid}}`
+- Assignee: {{memberName}} or _unassigned_
+- Deps: T2, T3
+- Description: {{description}}
+
+### ▶ T2 [in_progress] {{title}}
+...
+
+### ☑ T3 [completed] {{title}}
+- Result: {{result}}
+```
+
+由 `TaskListMarkdownRenderer`（新增模块）负责生成；监听 `tasks.json` 变化时自动重写到 `tasks.md` 路径。
+
+---
+
+## 3. 关键流程
+
+### 3.1 创建 Team（从 Chat Panel）
+
+```
+用户："创建一个 team 调研 Drizzle / Prisma / Kysely 三个 ORM"
+  │
+  ▼
+canvas-agent.ts 调用 canvas_create_team({
+  name: "ORM Research",
+  leadAgentType: "claude-code",
+  teammates: [
+    { agentType: "codex", initialTask: "调研 Drizzle..." },
+    { agentType: "codex", initialTask: "调研 Prisma..." },
+    { agentType: "codex", initialTask: "调研 Kysely..." }
+  ]
+})
+  │
+  ▼
+工具 handler：
+  1. 生成 teamId = UUID
+  2. 创建状态目录 ~/.pulse-coder/teams/{teamId}/
+  3. new TaskList(stateDir) → 初始化空 tasks.json
+  4. new Mailbox(stateDir)  → 初始化 mailbox 目录
+  5. 在画布上创建 frame 节点 + teamMeta
+  6. 在 frame 内创建 lead agent 节点（写入 spawnPrompt = team lead system prompt）
+  7. 在 frame 内创建 N 个 teammate agent 节点（带 initialTask 作为 inlinePrompt）
+  8. 创建 tasks.md 视图节点（filePath 指向状态目录的镜像 md 文件）
+  9. 创建 edge：lead → 每个 teammate（kind: 'team-member'）
+ 10. 启动 tasks.json 文件 watcher，每次变化触发 markdown 重渲染
+  │
+  ▼
+返回画布的 nodeIds 列表
+```
+
+### 3.2 Lead 协调循环（核心算法）
+
+Lead agent 的 system prompt 指示它执行如下循环（用 bash 调 `pulse-canvas team` 子命令实现，不需要画布管它定时跑）：
+
+```
+LOOP:
+  1. read tasks.json
+  2. read mailbox/{leadMemberId}.json （收信）
+  3. 决策：
+     - 有未读消息？→ 处理（回信、新建任务、重新分配）
+     - 有 unassigned 且 unblocked 的任务？→ 选择合适的 teammate，写入 assignee + 通过 mailbox 发任务通知
+     - 所有任务都 completed？→ 综合输出 + 标记 team 完成 + exit loop
+     - 否则：sleep 5s + 继续
+  4. （可选）通过 canvas_get_team_status 查询 teammate PTY 是否还活着；死掉的 → 重启或重分配
+  5. goto LOOP
+```
+
+**关键实现细节**：
+
+- Lead 不直接调用 `canvas_send_to_agent` 给 teammate 发指令 —— **它通过 mailbox 写消息**，让 teammate 自己读。这样：
+  - 即使 teammate PTY 暂时关闭，消息也不丢
+  - teammate 重启后从 mailbox 自然恢复上下文
+  - 与 `packages/agent-teams` 文件协议对齐
+- 但**初次启动 teammate** 时，需要 lead 通过 `canvas_send_to_agent` 写入 PTY 一条引导消息（"请读 ~/.pulse-coder/teams/{teamId}/mailbox/{你的 memberId}.json 收任务"），否则 teammate CLI 不知道 mailbox 在哪
+- Lead 的 sleep 用 `bash sleep 5`，避免阻塞 PTY；v1.1 可考虑加 `pulse-canvas team wait` 子命令用 `fs.watch` 阻塞到文件变化（见 §12 O1）
+
+### 3.3 Teammate 工作循环
+
+Teammate system prompt（通过初始 prompt 注入）：
+
+```
+你在一个 agent team 中工作。Team ID: {teamId}, Member ID: {memberId}
+共享状态目录：~/.pulse-coder/teams/{teamId}/
+
+工作流：
+1. 读 mailbox/{memberId}.json 看有没有新消息
+2. 读 tasks/tasks.json，找到 assignee=={memberId} && status=='in_progress' 的任务
+3. 执行任务（使用 read/edit/bash 等工具）
+4. 完成后：
+   a. 把产出写到任务描述里指定的文件路径
+   b. 调用 canvas_complete_task({ taskId, result }) 更新任务状态
+   c. 给 lead 发消息："T1 完成，结果在 X"
+5. 回到第 1 步等下一个任务，或在没有任务时退出
+```
+
+### 3.4 多 Team 并行（PRD F9）
+
+每个 team 完全隔离：
+- 独立 `teamId` → 独立状态目录 → 独立 TaskList / Mailbox 实例
+- CLI 子命令签名都带 `teamId`，无歧义
+- Agent 节点的 `teamMembership.teamId` 唯一指明归属
+- 视觉差异：每个 team frame 自动分配 hash(teamId) → 颜色，header 显示 team name
+
+### 3.5 清理 Team
+
+```
+用户右键 team frame → "Disband Team"
+  │
+  ▼
+弹窗确认（列出会发生什么：N 个 PTY 关闭、状态目录归档）
+  │
+  ▼
+1. 给所有 teammate mailbox 发 shutdown_request
+2. 等待 5s 让 teammate 自然结束当前任务
+3. 强制 kill 所有 PTY
+4. 归档状态目录到 ~/.pulse-coder/teams-archive/{teamId}-{timestamp}/
+5. 删除画布上的所有 team 成员节点 + tasks 视图节点
+6. 删除 team frame
+```
+
+---
+
+## 4. `pulse-canvas` CLI 扩展
+
+现有 CLI 子命令组（`packages/canvas-cli/src/commands/`）：
+`workspace / node / edge / context / install-skills`
+
+新增子命令组：`team`（10 个子命令），实现在 `packages/canvas-cli/src/commands/team.ts`，依赖 `core/team.ts`。
+
+### 4.1 新增子命令清单
+
+| 子命令 | 调用方 | 用途 |
+|--------|--------|------|
+| `pulse-canvas team create <name>` | chat panel / 用户 | 创建新 team，分配 UUID，写状态目录 |
+| `pulse-canvas team list` | 任何 agent | 按 workspace 列出 team |
+| `pulse-canvas team status <teamId>` | 任何 agent | 聚合视图：成员 + 任务统计 |
+| `pulse-canvas team add-member <teamId>` | chat panel / lead | 给 team 注册一个成员（关联到 canvas node） |
+| `pulse-canvas team destroy <teamId>` | chat panel / 用户 | 归档状态目录到 teams-archive |
+| `pulse-canvas team task create <teamId>` | lead | 包装 `TaskList.create` |
+| `pulse-canvas team task list <teamId>` | 任何 agent | 包装 `TaskList.getAll/getByStatus` |
+| `pulse-canvas team task claim <teamId>` | teammate | 包装 `TaskList.claim`（auto-claim 优先级见下） |
+| `pulse-canvas team task complete <teamId>` | teammate | 包装 `TaskList.complete`，解锁依赖任务 |
+| `pulse-canvas team msg send <teamId>` | 任何成员 | 包装 `Mailbox.send`（支持 `--to "*"` 广播） |
+| `pulse-canvas team msg read <teamId>` | 任何成员 | 包装 `Mailbox.readUnread` |
+
+> **注**：原方案中的 `canvas_create_agent`（在 team 内 spawn agent 节点）和 `canvas_send_to_agent`（写 PTY）**不在 CLI 中实现** — 前者需要写 canvas.json，留给 chat panel 的 canvas-agent 工具完成；后者需要访问 main process 的 `pty-manager`，CLI 跑在独立进程里访问不到。Lead 通过 mailbox 协调 teammate，不需要直接写 PTY。
+
+### 4.2 关键签名（已落地）
+
+```bash
+# team-scoped: 所有需要 memberId 的命令都校验它在 team 的 config.json 里
+pulse-canvas team task claim <teamId> --member-id <id> [--task-id <id>] --format json
+# 返回: claimed Task | { ok: true, claimed: null }
+# auto-claim 优先级（来自 TaskList 实现）:
+#   1. 预分配给 me 的任务
+#   2. 未分配的任务
+#   3. work-stealing：从已不活跃的 teammate 那里偷（基于 isTeammateActive 回调）
+
+pulse-canvas team msg send <teamId> --from <id> --to <id|*> --content <text> [--type message|broadcast|shutdown_request]
+# from 必须是 team 成员；to 必须是成员或 "*"
+
+pulse-canvas team task create <teamId> --member-id <id> --title <t> --description <d> [--deps a,b] [--assignee <id>]
+# member-id 记录为 createdBy；deps 用 CSV
+```
+
+### 4.3 实现要点
+
+- **TeamRuntime 缓存只在单进程内有效**：每次 `pulse-canvas` 调用都是新进程，缓存随进程死亡。跨进程一致性靠 `TaskList` 自带的 `O_EXCL` 文件锁（实测 50 retry + 20ms 间隔，已经够用）。
+- **身份校验**：`hasMember(teamId, memberId)` 在每个 `--member-id` 命令的入口检查，错则 `errorOutput()` 退出 1。
+- **CLI 沿用现有风格**：commander + `output()`（json/text 双格式）+ `errorOutput()`（exit 1）— 完全跟 `commands/edge.ts` 一致。
+- **跨子命令依赖路径解析**：`team task create` 嵌套两层 commander，`getRootOpts` 用 `while (cur.parent)` 循环上溯找根 program，而不是硬编码 `parent.parent`。
+- **不破坏现有 CLI**：注册到 `cli.ts` 末尾，原命令零改动。
+
+### 4.4 已完成与已验证
+
+✅ 已实现并端到端测试通过（截至 v0.2 草案）：
+- create / list / status / add-member / destroy
+- task create / list / claim（含 auto-claim 优先级）/ complete（含 result）
+- msg send / read（含 read-once 语义）
+- 跨 team 身份校验（错 teamId 拒绝，exit 1）
+- 多 team 并存于同 workspace、跨 workspace 隔离
+- typecheck / build 通过
+
+---
+
+## 5. Lead 系统提示词设计
+
+### 5.1 注入方式
+
+通过节点创建时的 `inlinePrompt` 字段注入。例如对 claude-code lead：
+
+```bash
+claude '<<< Lead Agent Bootstrap Prompt >>>'
+```
+
+prompt 内容（伪文本，实际放 `apps/canvas-workspace/src/main/canvas-agent/prompts/lead-agent.md`）：
+
+```markdown
+你是一个 agent team 的 Team Lead。
+
+## 你的身份
+- Team ID: {teamId}
+- Your Member ID: {leadMemberId}
+- Team State Dir: ~/.pulse-coder/teams/{teamId}/
+- Your Teammates: [memberId-1: codex, memberId-2: codex, ...]
+
+## 共享资源
+- Tasks: ~/.pulse-coder/teams/{teamId}/tasks/tasks.json
+- Your Mailbox: ~/.pulse-coder/teams/{teamId}/mailbox/{leadMemberId}.json
+
+## 工作流（请严格遵循）
+1. `bash pulse-canvas team status $PULSE_TEAM_ID` 看整体状态
+2. `bash pulse-canvas team msg read $PULSE_TEAM_ID --member-id $PULSE_TEAM_MEMBER` 看收件箱
+3. 决策（详见决策矩阵）
+4. 执行决策（`pulse-canvas team task create / msg send` 等）
+5. 用 `bash sleep 5` 等待
+6. 回到第 1 步
+
+## 决策矩阵
+- 有 teammate 报告任务完成 → 之前 teammate 已自调 `task complete`，无需你做；只需检查依赖任务能否解锁
+- 有 unassigned 任务且有空闲 teammate → `task create --assignee` 或让 teammate auto-claim
+- 所有任务都 completed → 综合输出到 frame 内的 file 节点 → `msg send --to "*" --type shutdown_request` → 退出
+- teammate PTY 死了但任务未完成 → `team status` 能看到任务还在 in_progress，可让其他 teammate work-steal（auto-claim 第三优先级），或人工干预
+
+## 禁止
+- 不要自己执行 teammate 的任务（即使你能做）—— 你的职责是协调
+- 不要直接编辑 ~/.pulse-coder/teams/ 下的 JSON 文件 —— 一定走 CLI（有文件锁）
+- 不要短间隔轮询（< 5s）—— 浪费 token，阻塞其他 agent 的文件锁竞争
+```
+
+### 5.2 环境变量注入
+
+Lead/teammate 启动时，初始 prompt 里需要 `export` 三个变量供后续 bash 调用使用：
+
+```bash
+export PULSE_TEAM_ID=<uuid>
+export PULSE_TEAM_MEMBER=<memberId>     # lead 或 teammate 自己的 memberId
+export PULSE_TEAM_LEAD=<leadMemberId>   # 给 teammate 发消息回 lead 用
+export PULSE_TEAM_ROLE=lead             # 或 'teammate'
+```
+
+这些环境变量被 `skills/team/SKILL.md` 文档引用 — 见 [`packages/canvas-cli/skills/team/SKILL.md`](../../../../packages/canvas-cli/skills/team/SKILL.md)。
+
+### 5.3 跨 agent 适配
+
+| Agent | Lead 适配 | Teammate 适配 |
+|-------|----------|---------------|
+| claude-code | 完整 prompt 即可，自带 todo 工具会主动用 | 同上 |
+| codex | 简化 prompt（codex 不擅长长指令）；强调 mailbox/tasks.json 路径 | 同上；注意 PTY 写入需 120ms 延迟 |
+| pulse-coder | 完整 prompt；引擎工具丰富，可调用更多 | 同上 |
+
+**MVP 默认配置**：lead = claude-code 或 pulse-coder；teammates 任意。
+
+---
+
+## 6. UI / 视觉设计
+
+### 6.1 Team Frame 视觉差异
+
+| 元素 | 普通 Frame | Team Frame |
+|------|-----------|-----------|
+| Header label | `Untitled` | `🤝 ORM Research · 3 members · 2/5 tasks` |
+| Border | 实线 | 双线 / 加粗 |
+| Color | 用户选择 | hash(teamId) 自动分配，避免多 team 撞色 |
+| Header 操作按钮 | 颜色选择器 | + Disband / Add Member / View Tasks |
+
+### 6.2 Lead 节点标记
+
+```
+┌─ Agent Node Header ──────────┐
+│ 👑 [Lead] codex · running    │  ← 皇冠 + Lead 标签
+└──────────────────────────────┘
+```
+
+### 6.3 Teammate 节点标记
+
+```
+┌─ Agent Node Header ──────────┐
+│ codex · 🏃 Working on T2     │  ← 当前任务 ID
+└──────────────────────────────┘
+```
+
+### 6.4 Edge 样式
+
+- **lead → teammate**（`kind: 'team-member'`）：细虚线，浅灰色，无箭头
+- **task 依赖**（`kind: 'depends-on'`）：实线 + 三角箭头（v1.1）
+
+### 6.5 Tasks 视图节点
+
+普通 file 节点，但 header 上加一个 "🔄 Auto-synced" 徽标提示用户不要直接编辑。
+
+---
+
+## 7. 关键文件改动清单
+
+### 7.1 已完成（v0.2 落地）
+
+| 文件 | 改动 | 状态 |
+|------|------|------|
+| `apps/canvas-workspace/src/renderer/src/types.ts` | `FrameNodeData.teamMeta` + `AgentNodeData.teamMembership` | ✅ |
+| `apps/canvas-workspace/package.json` | 添加 `pulse-coder-agent-teams: workspace:*` 依赖 | ✅ |
+| `packages/canvas-cli/package.json` | 添加 `pulse-coder-agent-teams: workspace:*` 依赖 | ✅ |
+| `packages/canvas-cli/tsconfig.json` | 加 paths 把 `pulse-coder-agent-teams` 指向 dist `.d.ts`，避免源码传染 | ✅ |
+| `packages/canvas-cli/src/core/team.ts` | **新建**：TeamRuntime 缓存 + 文件协议封装 | ✅ |
+| `packages/canvas-cli/src/core/index.ts` | barrel export `team.ts` | ✅ |
+| `packages/canvas-cli/src/commands/team.ts` | **新建**：10 个 team 子命令 | ✅ |
+| `packages/canvas-cli/src/cli.ts` | 注册 `registerTeamCommands` | ✅ |
+| `packages/canvas-cli/skills/team/SKILL.md` | **新建**：教 agent 用 team 子命令的 SKILL 文档 | ✅ |
+
+### 7.2 待做（剩余 MVP 工作）
+
+| 文件 | 改动 | 估算 |
+|------|------|------|
+| `apps/canvas-workspace/src/main/canvas-agent/tools.ts` | 新增 `canvas_create_team` 工具：spawn 一个 frame + N 个 agent 节点，调 CLI 注册成员，注入环境变量 | 1d |
+| `apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.tsx` | Team frame 视觉差异化（皇冠 / 双线边框 / 进度计数） | 1d |
+| `apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx` | Lead/teammate 标记 + 当前任务显示 | 0.5d |
+| `apps/canvas-workspace/src/main/canvas-store.ts` | Disband team 时的级联清理（关 PTY、调 `pulse-canvas team destroy`） | 0.5d |
+| `apps/canvas-workspace/src/main/team/markdown-renderer.ts` | **新建**：tasks.json → tasks.md 派生 + 文件 watcher（让画布上的 tasks-view file 节点自动刷新） | 0.5d |
+
+**MVP 剩余工作量估计**：约 3-4 个工作日（基础设施层已完成，剩余都是 UI / 集成）
+
+---
+
+## 8. 阶段拆分（与 PRD §9 对齐）
+
+### Milestone 1（MVP, 约 2-3 周）
+
+按依赖顺序：
+
+1. **数据模型 + 复用接入** ✅ 已完成
+   - 加 `pulse-coder-agent-teams` 依赖到 canvas-workspace 和 canvas-cli
+   - 扩展 `FrameNodeData` / `AgentNodeData` 类型
+   - `packages/canvas-cli/src/core/team.ts` 管理 TaskList/Mailbox
+
+2. **CLI 子命令扩展** ✅ 已完成（原计划 MCP 工具，现已转 CLI 路线）
+   - `packages/canvas-cli/src/commands/team.ts` 实现 §4.1 的 10 个子命令
+   - 端到端 e2e 测试通过（create/list/status/add-member/destroy + task/msg 全套）
+
+3. **Skill 文档** ✅ 已完成
+   - `packages/canvas-cli/skills/team/SKILL.md` 教 agent 用法
+
+4. **Lead 引导 + Markdown 派生**（1 天，待做）
+   - Lead system prompt 模板（已在 §5 定义，待落地为代码模板文件）
+   - 实现 tasks.json → tasks.md 派生 + watcher（让画布上的 tasks-view file 节点自动刷新）
+
+5. **画布节点改动**（2 天，待做）
+   - canvas-agent 加 `canvas_create_team` 工具：spawn frame + N 个 agent 节点 + 注入环境变量 + 调 CLI 注册成员
+   - Frame / Agent 节点视觉差异化
+
+6. **集成 + Demo 1 验收**（1-2 天，待做）
+   - 端到端跑 PRD §6.1 Demo 1（ORM 调研）
+   - 跑多 team 并行验证（同 workspace 起两个 team）
+   - 调试 cross-agent 适配（claude/codex/pulse 各自的 quirks）
+
+### Milestone 2（约 2 周）
+
+- Lead 主动监控（PTY 心跳检测）
+- 任务依赖 UI（depends-on edges）
+- Disband team 流程
+- Demo 2（手动组队）
+
+### Milestone 3（按需）
+
+- Team 模板（research-3 / debug-5 / fullstack-4）
+- Claude Code 原生 teams 协议适配
+- Hooks 集成
+
+---
+
+## 9. 决策记录（回应 PRD §10 开放问题）
+
+| 问题 | 决策 | 理由 |
+|------|------|------|
+| **Q1**：协调循环 = 事件驱动 vs 轮询？ | **MVP 用轮询（5s）+ mailbox** | 简单可靠；事件驱动需要文件 watcher 跨进程通知，复杂度溢价不值得；后续可改 |
+| **Q2**：完成信号怎么传？ | **专用 CLI 子命令 `pulse-canvas team task complete`** | 比"输出标记字符串"鲁棒得多；跨 agent 一致；teammate prompt + SKILL 文档中明示 |
+| **Q3**：Teammate PTY 退出后谁负责重启？ | **Lead 责任** | Lead 通过 `pulse-canvas team status` 检测；可选择重建 agent 节点（让 chat panel 介入）或让其他 teammate work-steal；用户只负责异常情况干预 |
+| **Q4**：tasks.json 并发安全？ | **复用 TaskList 自带的 file lock** | `withLock(O_EXCL)` 已经处理好；不需要额外机制 |
+| **Q5**：Lead 节点摆放约束？ | **不约束位置，但要求在 team frame 内** | 用户拖出 frame → 弹窗确认是否解除 lead 身份 |
+| **Q6**：多 team 资源预警？ | **按"活跃 teammate 总数"算** | 单 team ≥ 6 警告（PRD 已定）；workspace 总数 ≥ 12 给二级警告 |
+
+---
+
+## 10. 风险与缓解（技术层面）
+
+| 风险 | 影响 | 缓解 |
+|------|------|------|
+| Lead PTY 关闭后 team 进入"无主" | 高 | UI 上显式标记"Lead Offline"；提供"Reassign Lead"操作 |
+| 多个 lead 实例同时启动（用户误操作多开） | 中 | `teamMeta.leadNodeId` 唯一字段；新 lead 启动时检测并提示已有 lead |
+| `tasks.json` 文件锁残留（进程崩溃） | 中 | TaskList 已有 50 retry + force-remove fallback |
+| Lead system prompt 太长导致 codex 截断 | 中 | 准备简化版 prompt 给 codex；MVP 默认 lead = claude/pulse |
+| Mailbox 无限增长 | 低 | 加定期 truncate（保留最近 100 条）；MVP 阶段不做 |
+| 跨 workspace 误用 teamId | 中 | `core/team.ts` 的 `listTeams(workspaceId)` 按 workspaceId 过滤；CLI 子命令在 `--member-id` 参数上做身份校验 |
+
+---
+
+## 11. 测试策略
+
+### 11.1 单元测试
+
+- `team-manager.ts`：teamId 隔离、并发创建
+- `markdown-renderer.ts`：JSON → markdown 渲染快照
+- CLI 子命令：每个命令的 happy path + 边界（teamId 不存在、memberId 错配等）
+
+### 11.2 集成测试
+
+- 完整生命周期：create team → spawn members → claim/complete tasks → disband
+- 并发：多个 teammate 同时 claim 同一任务，只能一个成功
+- 多 team：同 workspace 起 2 个 team，互不影响
+
+### 11.3 端到端 Demo 验收
+
+- Demo 1（ORM 调研，3 teammates 并行）
+- Demo 2（手动组队，2 agents → group as team）
+- 多 team 场景：调研 team + 调试 team 同时跑
+
+### 11.4 跨 Agent 兼容矩阵
+
+| 配置 | 必须验证 |
+|------|---------|
+| claude-code lead + 3 codex teammates | ✅ |
+| pulse-coder lead + mixed teammates | ✅ |
+| codex lead + 2 pulse teammates | ⚠️ best-effort（codex 协调能力受限） |
+
+---
+
+## 12. 开放技术问题（需要后续讨论）
+
+- **O1**：Lead 周期性轮询用 `bash sleep 5` 简单但有几秒延迟。v1.1 是否加一个 `pulse-canvas team wait <teamId> [--timeout 60s]` 子命令，用 `fs.watch` 阻塞直到 tasks/mailbox 变化？
+- **O2**：teammate 退出时是否自动归档其 mailbox？还是保留以便重启后接回？
+- **O3**：UI 上是否需要一个全局"Team Inspector"侧边栏，列出所有 team 状态？还是完全靠画布上的 frame 视觉？倾向后者，但需要用户测试验证。
+- **O4**：派生的 `tasks.md` 路径放哪？方案 A：状态目录内（`~/.pulse-coder/teams/{teamId}/tasks.md`）；方案 B：workspace notes 目录内（与其他 file 节点一致）。倾向 A，避免污染 workspace 文件。
+- **O5**：第一版是否需要 Hook 集成？倾向不要，留到 Milestone 3。
+
+---
+
+## 13. 附录
+
+### 13.1 与 `packages/agent-teams` 的接口边界
+
+**复用的 API**（在 `packages/canvas-cli/src/core/team.ts`）：
+
+```ts
+import { TaskList, Mailbox } from 'pulse-coder-agent-teams';
+// 类型也来自同一包（透传给 commands/team.ts）：
+//   Task, TeamMessage, TaskStatus, MessageType
+```
+
+**不使用的导出**（自建 CLI 版替代）：
+- `Team` / `TeamLead` / `Teammate` 类（强依赖 in-process Engine 实例）
+- `planTeam` / `buildTeammateOptionsFromPlan`（输出 Engine 配置，画布不需要）
+- `InProcessDisplay`（终端 UI，画布本身就是显示层）
+
+**特殊注意**：`packages/canvas-cli/tsconfig.json` 把 `pulse-coder-agent-teams` path-alias 到 `dist/index.d.ts`，避免根 tsconfig 的"指向源码"路径把 engine/orchestrator 源码传染进 canvas-cli 的 typecheck 范围。
+
+### 13.2 状态目录布局对比
+
+```
+~/.pulse-coder/teams/
+└── {teamId}/                  ← canvas 用
+    ├── config.json            ← canvas 自建（与 packages/agent-teams 的 PersistedTeamConfig schema 对齐）
+    ├── tasks/
+    │   ├── tasks.json         ← 复用 TaskList 写入
+    │   ├── tasks.lock         ← TaskList 文件锁
+    │   └── tasks.md           ← canvas 自建派生视图
+    └── mailbox/
+        ├── {leadMemberId}.json    ← 复用 Mailbox
+        ├── {teammate1MemberId}.json
+        └── _broadcast.json
+```
+
+### 13.3 命名约定
+
+- `teamId`：UUID（如 `550e8400-e29b-41d4-a716-446655440000`）
+- `memberId`：`{teamId}-m{n}` 形式，便于人工 debug（如 `550e...440000-m1`）
+- `taskId`：UUID（由 TaskList 自分配）
+- 状态目录名 = `teamId` 全字符（含 dash），与 `packages/agent-teams` 的 `name` 字段对齐

--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -111,6 +111,7 @@
     "node-pty": "^1.1.0",
     "pulse-coder-engine": "workspace:*",
     "pulse-coder-agent-teams": "workspace:*",
+    "@pulse-coder/canvas-cli": "workspace:*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tiptap-markdown": "^0.9.0",

--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -110,6 +110,7 @@
     "markdown-it": "^14.1.0",
     "node-pty": "^1.1.0",
     "pulse-coder-engine": "workspace:*",
+    "pulse-coder-agent-teams": "workspace:*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tiptap-markdown": "^0.9.0",

--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -22,6 +22,11 @@ import {
 } from './context-builder';
 import { hasSession, writeToSession } from '../pty-manager';
 import { generateHTML } from '../html-generator';
+import {
+  createTeam as createTeamRuntime,
+  addMember as addTeamMember,
+} from '@pulse-coder/canvas-cli/core';
+import { watchTeam } from '../team/markdown-renderer';
 
 const STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
 
@@ -250,6 +255,37 @@ function autoPlace(nodes: CanvasNode[]): { x: number; y: number } {
     }
   }
   return { x: maxRight + 40, y: bestY };
+}
+
+/**
+ * Render the env-var preamble that prefixes every team agent's initial
+ * prompt. The teammate's CLI loop reads these via `$PULSE_TEAM_*` (see
+ * `packages/canvas-cli/skills/team/SKILL.md`). Keeping this in one place
+ * means the lead and teammate prompts can never drift on variable names
+ * or quoting.
+ */
+function buildTeamEnvBlock(args: {
+  teamId: string;
+  teamName: string;
+  memberId: string;
+  leadMemberId: string;
+  role: 'lead' | 'teammate';
+}): string {
+  const escape = (v: string) => v.replace(/'/g, "'\\''");
+  return [
+    '# Team coordination context (auto-injected — do NOT edit)',
+    `export PULSE_TEAM_ID='${escape(args.teamId)}'`,
+    `export PULSE_TEAM_NAME='${escape(args.teamName)}'`,
+    `export PULSE_TEAM_MEMBER='${escape(args.memberId)}'`,
+    `export PULSE_TEAM_LEAD='${escape(args.leadMemberId)}'`,
+    `export PULSE_TEAM_ROLE='${args.role}'`,
+    '# Read the team SKILL doc for your coordination protocol:',
+    '#   ~/.pulse-coder/skills/team/SKILL.md  (or your CLI\'s skills dir)',
+    '# Quick refs:',
+    '#   pulse-canvas team status $PULSE_TEAM_ID',
+    '#   pulse-canvas team msg read $PULSE_TEAM_ID --member-id $PULSE_TEAM_MEMBER',
+    '#   pulse-canvas team task claim $PULSE_TEAM_ID --member-id $PULSE_TEAM_MEMBER',
+  ].join('\n');
 }
 
 // ─── Canvas Tool type (matches Engine's Tool interface) ────────────
@@ -814,6 +850,200 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
         broadcastUpdate(workspaceId, [nodeId]);
 
         return JSON.stringify({ ok: true, nodeId, agentType, title, autoLaunch });
+      },
+    },
+
+    // ─── Spawn a coordinated agent team (frame + lead + teammates) ──
+
+    canvas_create_team: {
+      name: 'canvas_create_team',
+      description:
+        'Create an agent team on the canvas. Spawns a Team Frame node, then 1 lead + N teammate ' +
+        'agent nodes inside it (claude-code / codex / pulse-coder), and registers everyone with the ' +
+        'shared task list & mailbox under ~/.pulse-coder/teams/{teamId}/. Each agent\'s initial prompt ' +
+        'is prefixed with environment variables ($PULSE_TEAM_ID etc.) and a pointer to the team SKILL ' +
+        'document so the CLI loop "Just Works".\n\n' +
+        'Use this when the user asks for parallel work that benefits from coordination — research with ' +
+        'multiple angles, debug with competing hypotheses, cross-layer feature implementation, etc. ' +
+        'For one-off delegation, prefer `canvas_create_agent_node` instead.',
+      inputSchema: z.object({
+        teamName: z.string().describe('Human-readable team name; shown in the frame header.'),
+        cwd: z.string().describe('Working directory for ALL agents in the team.'),
+        lead: z.object({
+          agentType: z.enum(['claude-code', 'codex', 'pulse-coder']).describe('Lead agent type. Recommend claude-code or pulse-coder.'),
+          prompt: z.string().describe('Lead bootstrap prompt — what the team is for, success criteria, etc.'),
+        }).describe('Lead agent configuration.'),
+        teammates: z.array(z.object({
+          agentType: z.enum(['claude-code', 'codex', 'pulse-coder']),
+          prompt: z.string().describe('Bootstrap prompt for this teammate — its role, what files to look at, what output is expected.'),
+        })).min(1).describe('Teammate configurations (1 or more).'),
+      }),
+      execute: async (input) => {
+        const teamName = input.teamName as string;
+        const cwd = input.cwd as string;
+        const leadCfg = input.lead as { agentType: string; prompt: string };
+        const teammates = input.teammates as Array<{ agentType: string; prompt: string }>;
+
+        const canvas = await loadCanvas(workspaceId);
+        if (!canvas) return 'Error: workspace not found';
+
+        // ─── 1. Create the team's state directory + TaskList/Mailbox ──
+        const teamRuntime = createTeamRuntime({ workspaceId, teamName });
+        const teamId = teamRuntime.config.teamId;
+        const stateDir = teamRuntime.stateDir;
+
+        // Start watching tasks.json so the derived tasks.md updates as
+        // teammates claim/complete tasks. Re-entrant — safe to call again.
+        watchTeam(stateDir);
+
+        // ─── 2. Layout: frame on the right of the canvas, members in a row inside ──
+        const framePos = autoPlace(canvas.nodes);
+        const FRAME_WIDTH = Math.max(640, 280 + (teammates.length + 1) * 280);
+        const FRAME_HEIGHT = 520;
+        const AGENT_WIDTH = 240;
+        const AGENT_HEIGHT = 360;
+        const AGENT_PAD_X = 20;
+        const AGENT_Y = framePos.y + 80; // leave room for the frame header
+
+        const frameNodeId = `node-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const newNodes: CanvasNode[] = [];
+
+        // Allocate the lead first so it gets memberId-m1 (matches the SKILL convention).
+        const leadNodeId = `node-${Date.now() + 1}-${Math.random().toString(36).slice(2, 8)}`;
+        const leadMember = addTeamMember(teamId, {
+          nodeId: leadNodeId,
+          agentType: leadCfg.agentType,
+          isLead: true,
+        });
+        if (!leadMember) return `Error: failed to register lead in team ${teamId}`;
+
+        // ─── 3. Build the lead agent node ─────────────────────────────
+        const leadEnvBlock = buildTeamEnvBlock({
+          teamId,
+          teamName,
+          memberId: leadMember.memberId,
+          leadMemberId: leadMember.memberId,
+          role: 'lead',
+        });
+        const leadInline = `${leadEnvBlock}\n\n${leadCfg.prompt}`;
+        const leadNode: CanvasNode = {
+          id: leadNodeId,
+          type: 'agent',
+          title: `👑 Lead (${leadCfg.agentType})`,
+          x: framePos.x + AGENT_PAD_X,
+          y: AGENT_Y,
+          width: AGENT_WIDTH,
+          height: AGENT_HEIGHT,
+          data: {
+            sessionId: '',
+            cwd,
+            agentType: leadCfg.agentType,
+            status: 'running',
+            agentArgs: '',
+            inlinePrompt: leadInline,
+            promptFile: '',
+            teamMembership: {
+              teamId,
+              memberId: leadMember.memberId,
+              isLead: true,
+              joinedAt: leadMember.joinedAt,
+            },
+          } as Record<string, unknown>,
+          updatedAt: Date.now(),
+        };
+        newNodes.push(leadNode);
+
+        // ─── 4. Build the teammate agent nodes ────────────────────────
+        const teammateNodeIds: string[] = [];
+        for (let i = 0; i < teammates.length; i++) {
+          const tCfg = teammates[i];
+          const tNodeId = `node-${Date.now() + 2 + i}-${Math.random().toString(36).slice(2, 8)}`;
+          const tMember = addTeamMember(teamId, {
+            nodeId: tNodeId,
+            agentType: tCfg.agentType,
+            isLead: false,
+          });
+          if (!tMember) return `Error: failed to register teammate #${i + 1} in team ${teamId}`;
+
+          const tEnvBlock = buildTeamEnvBlock({
+            teamId,
+            teamName,
+            memberId: tMember.memberId,
+            leadMemberId: leadMember.memberId,
+            role: 'teammate',
+          });
+          const tInline = `${tEnvBlock}\n\n${tCfg.prompt}`;
+          newNodes.push({
+            id: tNodeId,
+            type: 'agent',
+            title: `${tCfg.agentType} (${tMember.memberId.split('-').pop()})`,
+            x: framePos.x + AGENT_PAD_X + (i + 1) * (AGENT_WIDTH + AGENT_PAD_X),
+            y: AGENT_Y,
+            width: AGENT_WIDTH,
+            height: AGENT_HEIGHT,
+            data: {
+              sessionId: '',
+              cwd,
+              agentType: tCfg.agentType,
+              status: 'running',
+              agentArgs: '',
+              inlinePrompt: tInline,
+              promptFile: '',
+              teamMembership: {
+                teamId,
+                memberId: tMember.memberId,
+                isLead: false,
+                joinedAt: tMember.joinedAt,
+              },
+            } as Record<string, unknown>,
+            updatedAt: Date.now(),
+          });
+          teammateNodeIds.push(tNodeId);
+        }
+
+        // ─── 5. Build the team frame (after agents so it knows its size) ──
+        const frameNode: CanvasNode = {
+          id: frameNodeId,
+          type: 'frame',
+          title: teamName,
+          x: framePos.x,
+          y: framePos.y,
+          width: FRAME_WIDTH,
+          height: FRAME_HEIGHT,
+          data: {
+            color: '#7AA7E8', // FigJam-style blue; deterministic dye comes in v1.1
+            label: teamName,
+            teamMeta: {
+              teamId,
+              teamName,
+              leadNodeId,
+              stateDir,
+              createdAt: teamRuntime.config.createdAt,
+            },
+          } as Record<string, unknown>,
+          updatedAt: Date.now(),
+        };
+        // Put frame BEFORE agents in the array so it renders behind them
+        // (frame stacking is z-index by array order in canvas-render).
+        newNodes.unshift(frameNode);
+
+        // ─── 6. Persist + broadcast ───────────────────────────────────
+        const fresh = (await loadCanvas(workspaceId)) ?? canvas;
+        fresh.nodes.push(...newNodes);
+        await saveCanvas(workspaceId, fresh);
+        broadcastUpdate(workspaceId, newNodes.map((n) => n.id));
+
+        return JSON.stringify({
+          ok: true,
+          teamId,
+          teamName,
+          stateDir,
+          frameNodeId,
+          leadNodeId,
+          leadMemberId: leadMember.memberId,
+          teammateNodeIds,
+          memberCount: 1 + teammates.length,
+        });
       },
     },
 

--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -317,6 +317,18 @@ export interface CanvasTool {
 /** Prompts shorter than this are passed directly as CLI args; longer ones go to a file. */
 const INLINE_PROMPT_THRESHOLD = 256;
 
+/**
+ * Per-agent CLI flag(s) that put the agent into "no permission prompts"
+ * mode. Mirrors `getUnattendedFlags` in renderer's `agentRegistry.ts` —
+ * we duplicate rather than cross the main↔renderer boundary because
+ * canvas-agent runs in main and the registry is renderer-side.
+ */
+const UNATTENDED_FLAGS: Record<string, string> = {
+  'claude-code': '--permission-mode bypassPermissions',
+  codex: '--full-auto',
+  'pulse-coder': '',
+};
+
 let edgeIdCounter = 0;
 function genEdgeId(): string {
   return `edge-${Date.now()}-${++edgeIdCounter}`;
@@ -939,7 +951,7 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
             cwd,
             agentType: leadCfg.agentType,
             status: 'running',
-            agentArgs: '',
+            agentArgs: UNATTENDED_FLAGS[leadCfg.agentType] ?? '',
             inlinePrompt: leadInline,
             promptFile: '',
             teamMembership: {
@@ -986,7 +998,7 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
               cwd,
               agentType: tCfg.agentType,
               status: 'running',
-              agentArgs: '',
+              agentArgs: UNATTENDED_FLAGS[tCfg.agentType] ?? '',
               inlinePrompt: tInline,
               promptFile: '',
               teamMembership: {

--- a/apps/canvas-workspace/src/main/index.ts
+++ b/apps/canvas-workspace/src/main/index.ts
@@ -13,6 +13,8 @@ import { setupSkillInstallerIpc } from "./skill-installer";
 import { setupCanvasAgentIpc, teardownCanvasAgent } from "./canvas-agent-ipc";
 import { setupWebviewRegistryIpc } from "./webview-registry";
 import { setupHtmlGeneratorIpc } from "./html-generator-ipc";
+import { stopAllTeamWatchers, watchAllExistingTeams } from "./team/markdown-renderer";
+import { setupTeamIpc } from "./team/team-ipc";
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const preloadPath = join(currentDir, "../preload/index.mjs");
@@ -147,6 +149,12 @@ app.whenReady().then(() => {
   // startMCPServer();
   // void ensureMCPRegistered();
 
+  // Hydrate per-team tasks.md views for any teams already on disk so the
+  // canvas can render them as plain file nodes. New teams created via
+  // `canvas_create_team` invoke `watchTeam` directly inside the tool.
+  watchAllExistingTeams();
+  setupTeamIpc();
+
   createWindow();
 
   app.on("activate", () => {
@@ -161,6 +169,7 @@ app.on("window-all-closed", () => {
   teardownFileWatcher();
   teardownCanvasWatchers();
   teardownCanvasAgent();
+  stopAllTeamWatchers();
   if (process.platform !== "darwin") {
     app.quit();
   }

--- a/apps/canvas-workspace/src/main/pty-manager.ts
+++ b/apps/canvas-workspace/src/main/pty-manager.ts
@@ -235,6 +235,20 @@ export function hasSession(sessionId: string): boolean {
 }
 
 /**
+ * Kill a PTY session by id and drop it from the registry.
+ * Returns true if a session was killed, false if no such session existed.
+ * Mirrors the `pty:kill` IPC handler so main-process callers (like the
+ * team disband flow) can release a PTY without going through IPC.
+ */
+export function killSession(sessionId: string): boolean {
+  const proc = sessions.get(sessionId);
+  if (!proc) return false;
+  proc.kill();
+  sessions.delete(sessionId);
+  return true;
+}
+
+/**
  * Write raw data to an existing PTY session (as if the user typed it).
  * Does NOT capture output — for command+output capture use execInSession.
  * Returns false if the session does not exist.

--- a/apps/canvas-workspace/src/main/skill-installer.ts
+++ b/apps/canvas-workspace/src/main/skill-installer.ts
@@ -3,13 +3,13 @@ import { promises as fs } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 
-const GLOBAL_SKILL_DIRS = [
-  join(homedir(), '.pulse-coder', 'skills', 'canvas'),
-  join(homedir(), '.claude', 'skills', 'canvas'),
-  join(homedir(), '.codex', 'skills', 'canvas'),
+const SKILL_ROOTS = [
+  join(homedir(), '.pulse-coder', 'skills'),
+  join(homedir(), '.claude', 'skills'),
+  join(homedir(), '.codex', 'skills'),
 ];
 
-const SKILL_CONTENT = `---
+const CANVAS_SKILL_CONTENT = `---
 name: canvas
 description: Operate Pulse Canvas workspaces — read user-curated context, write results, create nodes
 version: 1.0.0
@@ -77,13 +77,135 @@ pulse-canvas workspace list --format json
 - After completing work, write results back to the canvas for the user to review
 `;
 
-async function installSkillFile(): Promise<{ ok: boolean; paths: string[]; error?: string }> {
+// Mirror of packages/canvas-cli/skills/team/SKILL.md. Kept inline (rather
+// than read from the package's skills/ dir at runtime) for the same
+// reason CANVAS_SKILL_CONTENT is inline: packaged Electron builds don't
+// give the main process direct fs access to bundled package resources,
+// and shipping the file twice — once in the canvas-cli package, once
+// here — is the simplest fix until we wire up an asset pipeline. If
+// you edit one, edit the other.
+const TEAM_SKILL_CONTENT = `---
+name: team
+description: Coordinate as part of an agent team — claim tasks, send messages, report completion
+version: 1.0.0
+---
+
+# Pulse Canvas — Agent Team Coordination
+
+You are working as part of an agent team on a shared canvas. Multiple agents (yourself included) coordinate through file-backed task lists and mailboxes managed by \`pulse-canvas team\` subcommands.
+
+## Your team identity (always set before starting)
+
+If you were spawned as a team member, your initial prompt told you your team identity. Confirm it:
+
+\`\`\`
+$PULSE_TEAM_ID      → the team UUID
+$PULSE_TEAM_MEMBER  → your member id (e.g. "abc123-m2")
+$PULSE_TEAM_ROLE    → "lead" or "teammate"
+\`\`\`
+
+If any are missing, you are NOT a team member yet — STOP and ask the user how you should fit into the team. Do not invent member ids.
+
+## Core protocol
+
+Every team has two persistent stores under \`~/.pulse-coder/teams/{teamId}/\`:
+
+| Store | What | Who reads | Who writes |
+|-------|------|-----------|-----------|
+| \`tasks/tasks.json\` | Shared task list (with deps, status, assignee) | All members | All members (file-locked) |
+| \`mailbox/{memberId}.json\` | Per-member inbox | The owning member | Anyone in the team |
+
+**Always operate via the CLI, never edit these JSON files directly** — the CLI applies file locks and validates membership; raw edits will corrupt state and may be rejected by other members' next read.
+
+## Commands
+
+### See team state
+\`\`\`bash
+pulse-canvas team status $PULSE_TEAM_ID
+\`\`\`
+
+### Read your inbox (do this every loop iteration)
+\`\`\`bash
+pulse-canvas team msg read $PULSE_TEAM_ID --member-id $PULSE_TEAM_MEMBER --format json
+\`\`\`
+
+### Send a message to a teammate
+\`\`\`bash
+pulse-canvas team msg send $PULSE_TEAM_ID --from $PULSE_TEAM_MEMBER --to <other-member-id> --content "T2 done"
+\`\`\`
+Use \`--to "*"\` to broadcast.
+
+### List / claim / complete tasks
+\`\`\`bash
+pulse-canvas team task list $PULSE_TEAM_ID --status pending --format json
+pulse-canvas team task claim $PULSE_TEAM_ID --member-id $PULSE_TEAM_MEMBER --format json
+pulse-canvas team task complete $PULSE_TEAM_ID --task-id <id> --result "..."
+\`\`\`
+
+### Lead-only: create tasks
+\`\`\`bash
+pulse-canvas team task create $PULSE_TEAM_ID --member-id $PULSE_TEAM_MEMBER \\
+  --title "..." --description "..." --assignee <id> --deps a,b
+\`\`\`
+
+## Workflow — TEAMMATE
+
+\`\`\`
+loop:
+  1. msg read           → handle messages first
+  2. task claim         → grab next available task
+     - null + all done → broadcast "I'm done", exit
+     - null + others working → sleep 5s, retry
+  3. do the work        → use file tools (read, edit, bash)
+  4. task complete      → mark done with a short result
+  5. msg send to lead   → "T<x> done"
+  6. goto 1
+\`\`\`
+
+## Workflow — LEAD
+
+\`\`\`
+loop:
+  1. team status        → dashboard
+  2. msg read           → handle teammate updates
+  3. decide:
+     - new task? → task create
+     - all done? → synthesize, broadcast shutdown_request, exit
+  4. sleep 5s, goto 1
+\`\`\`
+
+DO NOT do teammates' work yourself. Coordinate.
+
+## Anti-patterns
+
+- ❌ Polling tighter than 5s (waste + lock contention)
+- ❌ Editing ~/.pulse-coder/teams/ files directly (use CLI for locks)
+- ❌ Sending broadcast status updates ("Starting T1!") — task list shows that
+- ❌ Ignoring shutdown_request mailbox messages
+`;
+
+interface SkillSpec {
+  /** Subdirectory name under each skill root (e.g. "canvas", "team"). */
+  name: string;
+  /** SKILL.md body to write. */
+  content: string;
+}
+
+const SKILLS: SkillSpec[] = [
+  { name: 'canvas', content: CANVAS_SKILL_CONTENT },
+  { name: 'team', content: TEAM_SKILL_CONTENT },
+];
+
+/** Install one SKILL.md into every per-host skill root. Aggregates the
+ *  written paths and reports the first error encountered. */
+async function installSkill(spec: SkillSpec): Promise<{ ok: boolean; paths: string[]; error?: string }> {
   const installed: string[] = [];
   try {
-    for (const dir of GLOBAL_SKILL_DIRS) {
+    for (const root of SKILL_ROOTS) {
+      const dir = join(root, spec.name);
       await fs.mkdir(dir, { recursive: true });
       const targetPath = join(dir, 'SKILL.md');
-      await fs.writeFile(targetPath, SKILL_CONTENT, 'utf-8');
+      await fs.writeFile(targetPath, spec.content, 'utf-8');
       installed.push(targetPath);
     }
     return { ok: true, paths: installed };
@@ -94,24 +216,32 @@ async function installSkillFile(): Promise<{ ok: boolean; paths: string[]; error
 
 export function setupSkillInstallerIpc(): void {
   ipcMain.handle('skills:install', async () => {
-    const skillResult = await installSkillFile();
-    if (!skillResult.ok) {
-      return {
-        ok: false,
-        skillsInstalled: false,
-        cliInstalled: false,
-        error: skillResult.error,
-        manualCommand: null,
-      };
+    const results: Array<{ ok: boolean; paths: string[]; error?: string; name: string }> = [];
+    for (const spec of SKILLS) {
+      const r = await installSkill(spec);
+      results.push({ ...r, name: spec.name });
+      if (!r.ok) {
+        // Bail on first failure — we don't want to half-install and
+        // leave the user wondering which skills are real.
+        return {
+          ok: false,
+          skillsInstalled: false,
+          cliInstalled: false,
+          error: `Failed installing skill "${spec.name}": ${r.error}`,
+          manualCommand: null,
+        };
+      }
     }
 
-    // CLI is not published yet — provide local build instructions
+    // CLI is not published yet — provide local build instructions.
     return {
       ok: true,
       skillsInstalled: true,
-      skillsPaths: skillResult.paths,
+      skillsPaths: results.flatMap((r) => r.paths),
+      installedSkills: results.map((r) => r.name),
       cliInstalled: false,
-      manualCommand: 'cd <project-root> && pnpm --filter @pulse-coder/canvas-cli build && pnpm link --global --filter @pulse-coder/canvas-cli',
+      manualCommand:
+        'cd <project-root> && pnpm --filter @pulse-coder/canvas-cli build && pnpm link --global --filter @pulse-coder/canvas-cli',
       cliError: null,
     };
   });

--- a/apps/canvas-workspace/src/main/team/markdown-renderer.ts
+++ b/apps/canvas-workspace/src/main/team/markdown-renderer.ts
@@ -1,0 +1,223 @@
+/**
+ * Tasks markdown renderer & watcher.
+ *
+ * Each team has a `tasks/tasks.json` (TaskList's source of truth, locked
+ * via O_EXCL). Agents shouldn't have to read JSON to understand the team
+ * state, and the user definitely shouldn't — so we maintain a sibling
+ * `tasks.md` rendered from the JSON whenever it changes. The renderer
+ * is run on:
+ *   1. Main process startup (one pass for every team in `~/.pulse-coder/teams/`)
+ *   2. A long-lived `fs.watch` per state directory (so subsequent
+ *      changes from any agent CLI invocation flow through automatically)
+ *
+ * The markdown is intentionally minimal — agents and users both should
+ * be able to skim it. Detailed task fields (createdAt, updatedAt) live
+ * in the JSON for tooling that needs precision.
+ */
+import { existsSync, mkdirSync, readdirSync, readFileSync, watch, writeFileSync } from 'node:fs';
+import type { FSWatcher } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const TEAMS_ROOT = join(homedir(), '.pulse-coder', 'teams');
+
+interface MinimalTask {
+  id: string;
+  title: string;
+  description: string;
+  status: 'pending' | 'in_progress' | 'completed' | 'failed';
+  deps: string[];
+  assignee: string | null;
+  createdBy: string;
+  result?: string;
+}
+
+interface MinimalConfig {
+  teamId: string;
+  teamName: string;
+  members?: Array<{ memberId: string; agentType: string; isLead: boolean }>;
+  leadMemberId?: string;
+}
+
+const watchers = new Map<string, FSWatcher>();
+/** Coalesce bursts of fs.watch events from a single TaskList write. The
+ *  TaskList does write → rename → notify-listeners, which on macOS can
+ *  fire 2-3 events for one logical change. */
+const debounceTimers = new Map<string, NodeJS.Timeout>();
+
+/** Render JSON state to markdown, writing if (and only if) the result
+ *  differs from what's already on disk. Skipping no-op writes keeps the
+ *  watcher from feeding itself a loop. */
+function renderTasksMd(stateDir: string): void {
+  const tasksJsonPath = join(stateDir, 'tasks', 'tasks.json');
+  const tasksMdPath = join(stateDir, 'tasks.md');
+  const configPath = join(stateDir, 'config.json');
+
+  if (!existsSync(tasksJsonPath)) return;
+
+  let tasks: MinimalTask[] = [];
+  try {
+    tasks = JSON.parse(readFileSync(tasksJsonPath, 'utf-8'));
+  } catch {
+    // The TaskList writes are atomic via rename, but a watcher firing
+    // mid-write is theoretically possible on some filesystems. Skip this
+    // tick — we'll catch up on the next event.
+    return;
+  }
+
+  let config: MinimalConfig | null = null;
+  if (existsSync(configPath)) {
+    try {
+      config = JSON.parse(readFileSync(configPath, 'utf-8')) as MinimalConfig;
+    } catch {
+      // Same reasoning as above.
+    }
+  }
+
+  const md = renderMarkdown(tasks, config);
+  let existing = '';
+  try {
+    existing = readFileSync(tasksMdPath, 'utf-8');
+  } catch {
+    // First write — fall through.
+  }
+  if (existing === md) return;
+  writeFileSync(tasksMdPath, md, 'utf-8');
+}
+
+function renderMarkdown(tasks: MinimalTask[], config: MinimalConfig | null): string {
+  const counts = {
+    total: tasks.length,
+    pending: tasks.filter((t) => t.status === 'pending').length,
+    in_progress: tasks.filter((t) => t.status === 'in_progress').length,
+    completed: tasks.filter((t) => t.status === 'completed').length,
+    failed: tasks.filter((t) => t.status === 'failed').length,
+  };
+
+  const memberById = new Map<string, { agentType: string; isLead: boolean }>();
+  for (const m of config?.members ?? []) {
+    memberById.set(m.memberId, { agentType: m.agentType, isLead: m.isLead });
+  }
+
+  const formatMember = (memberId: string | null): string => {
+    if (!memberId) return '_unassigned_';
+    const m = memberById.get(memberId);
+    if (!m) return memberId;
+    return `${m.agentType}${m.isLead ? ' (lead)' : ''} \`${memberId}\``;
+  };
+
+  const out: string[] = [];
+  const teamLabel = config ? `${config.teamName} (${config.teamId})` : '(unknown team)';
+  out.push(`# Team Tasks — ${teamLabel}`);
+  out.push('');
+  out.push('> Auto-generated from `tasks/tasks.json` — do NOT edit manually; changes will be overwritten.');
+  out.push(`> Last sync: ${new Date().toISOString()}`);
+  out.push('');
+  out.push('## Stats');
+  out.push(`- Total: **${counts.total}** | ☐ Pending: ${counts.pending} | ▶ In progress: ${counts.in_progress} | ☑ Completed: ${counts.completed} | ✗ Failed: ${counts.failed}`);
+  out.push('');
+
+  if (tasks.length === 0) {
+    out.push('## Tasks');
+    out.push('');
+    out.push('_No tasks yet._');
+    return out.join('\n') + '\n';
+  }
+
+  // Group by status for human readability; in-progress on top so the
+  // "what's happening right now" answer is the first thing on screen.
+  const order: Array<MinimalTask['status']> = ['in_progress', 'pending', 'completed', 'failed'];
+  const glyph = (s: MinimalTask['status']) =>
+    s === 'in_progress' ? '▶' : s === 'pending' ? '☐' : s === 'completed' ? '☑' : '✗';
+
+  for (const status of order) {
+    const group = tasks.filter((t) => t.status === status);
+    if (group.length === 0) continue;
+    out.push(`## ${capitalize(status.replace('_', ' '))} (${group.length})`);
+    out.push('');
+    for (const t of group) {
+      out.push(`### ${glyph(t.status)} ${t.title}`);
+      out.push(`- ID: \`${t.id}\``);
+      out.push(`- Assignee: ${formatMember(t.assignee)}`);
+      if (t.deps.length > 0) {
+        out.push(`- Depends on: ${t.deps.map((d) => `\`${d}\``).join(', ')}`);
+      }
+      if (t.description) {
+        out.push(`- Description: ${oneLine(t.description)}`);
+      }
+      if (t.result) {
+        out.push(`- Result: ${oneLine(t.result)}`);
+      }
+      out.push('');
+    }
+  }
+  return out.join('\n') + '\n';
+}
+
+function capitalize(s: string): string {
+  return s.length === 0 ? s : s[0].toUpperCase() + s.slice(1);
+}
+
+function oneLine(s: string): string {
+  // Collapse newlines so each task stays a single bullet line. Long
+  // descriptions belong in linked files, not embedded in tasks.md.
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+/** Start watching a single team's `tasks/tasks.json` and re-render on
+ *  every change. Re-entrant: if a watcher already exists for the dir
+ *  it's a no-op. Returns immediately after performing one initial render. */
+export function watchTeam(stateDir: string): void {
+  if (watchers.has(stateDir)) return;
+
+  // Initial render — covers both "freshly created team" and "main
+  // process restart found existing teams" paths.
+  renderTasksMd(stateDir);
+
+  const tasksDir = join(stateDir, 'tasks');
+  if (!existsSync(tasksDir)) {
+    mkdirSync(tasksDir, { recursive: true });
+  }
+
+  // Watch the `tasks/` directory rather than tasks.json directly: the
+  // TaskList writes go through `writeFileSync` (truncate-then-write),
+  // and watching the file handle on macOS sometimes loses the watch
+  // when the inode is replaced. Watching the parent dir is bulletproof.
+  const watcher = watch(tasksDir, { persistent: false }, (_event, filename) => {
+    if (filename !== 'tasks.json' && filename !== null) return;
+    const existing = debounceTimers.get(stateDir);
+    if (existing) clearTimeout(existing);
+    debounceTimers.set(
+      stateDir,
+      setTimeout(() => {
+        debounceTimers.delete(stateDir);
+        try {
+          renderTasksMd(stateDir);
+        } catch (err) {
+          // Swallow — the next change event will retry. Logging would
+          // be noisy because the same write often fires twice.
+          void err;
+        }
+      }, 50),
+    );
+  });
+  watchers.set(stateDir, watcher);
+}
+
+/** Bootstrap: scan TEAMS_ROOT and start a watcher for every team
+ *  directory. Called once from the main process startup. */
+export function watchAllExistingTeams(): void {
+  if (!existsSync(TEAMS_ROOT)) return;
+  for (const entry of readdirSync(TEAMS_ROOT, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    watchTeam(join(TEAMS_ROOT, entry.name));
+  }
+}
+
+/** Stop all watchers (Electron app quit hook). */
+export function stopAllTeamWatchers(): void {
+  for (const w of watchers.values()) w.close();
+  watchers.clear();
+  for (const t of debounceTimers.values()) clearTimeout(t);
+  debounceTimers.clear();
+}

--- a/apps/canvas-workspace/src/main/team/team-ipc.ts
+++ b/apps/canvas-workspace/src/main/team/team-ipc.ts
@@ -1,0 +1,150 @@
+/**
+ * IPC for tearing down a team — wraps the multi-step disband flow that
+ * the renderer can't safely orchestrate by itself:
+ *   1. Find every team-member node inside the frame
+ *   2. Kill any live PTYs they're attached to
+ *   3. Remove those nodes from canvas.json
+ *   4. Remove the team frame itself
+ *   5. Archive the team's state directory via canvas-cli's destroyTeam
+ *
+ * Steps 1-4 must happen in the main process so we can release PTYs
+ * before the canvas write removes the nodes that owned them. The
+ * renderer just sends a single `team:disband` request and re-fetches
+ * the canvas afterwards.
+ */
+import { BrowserWindow, ipcMain } from 'electron';
+import { promises as fs } from 'fs';
+import { join, dirname, basename } from 'path';
+import { homedir } from 'os';
+import { destroyTeam } from '@pulse-coder/canvas-cli/core';
+import { hasSession, killSession } from '../pty-manager';
+
+const STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
+
+interface CanvasNode {
+  id: string;
+  type: string;
+  data: Record<string, unknown>;
+}
+
+interface CanvasSaveData {
+  nodes: CanvasNode[];
+  edges?: unknown[];
+  transform?: unknown;
+  savedAt: string;
+}
+
+function canvasPath(workspaceId: string): string {
+  return join(STORE_DIR, workspaceId, 'canvas.json');
+}
+
+async function loadCanvas(workspaceId: string): Promise<CanvasSaveData | null> {
+  try {
+    const raw = await fs.readFile(canvasPath(workspaceId), 'utf-8');
+    return JSON.parse(raw) as CanvasSaveData;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+/** Atomic-rename write mirrors what canvas-store.ts does — see its
+ *  rationale comment. We can't import its private helper, so the
+ *  duplication is the lesser evil compared to making it public. */
+async function saveCanvas(workspaceId: string, data: CanvasSaveData): Promise<void> {
+  data.savedAt = new Date().toISOString();
+  const finalPath = canvasPath(workspaceId);
+  const dir = dirname(finalPath);
+  const base = basename(finalPath);
+  const tmpPath = join(dir, `${base}.tmp`);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(tmpPath, JSON.stringify(data, null, 2), 'utf-8');
+  await fs.rename(tmpPath, finalPath);
+}
+
+function broadcastUpdate(workspaceId: string, nodeIds: string[]): void {
+  const payload = {
+    type: 'canvas:updated' as const,
+    workspaceId,
+    nodeIds,
+    source: 'team-disband' as const,
+  };
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (win.isDestroyed()) continue;
+    win.webContents.send('canvas:external-update', payload);
+  }
+}
+
+interface DisbandRequest {
+  workspaceId: string;
+  /** Node id of the team's FrameNode (the one with `data.teamMeta`). */
+  frameNodeId: string;
+}
+
+interface DisbandResult {
+  ok: boolean;
+  removedNodeIds?: string[];
+  archivedTo?: string;
+  error?: string;
+}
+
+export function setupTeamIpc(): void {
+  ipcMain.handle('team:disband', async (_event, req: DisbandRequest): Promise<DisbandResult> => {
+    try {
+      const canvas = await loadCanvas(req.workspaceId);
+      if (!canvas) return { ok: false, error: `Workspace not found: ${req.workspaceId}` };
+
+      const frame = canvas.nodes.find((n) => n.id === req.frameNodeId);
+      if (!frame) return { ok: false, error: `Frame node not found: ${req.frameNodeId}` };
+      if (frame.type !== 'frame') {
+        return { ok: false, error: `Node ${req.frameNodeId} is not a frame (got "${frame.type}")` };
+      }
+      const teamMeta = frame.data.teamMeta as { teamId: string } | undefined;
+      if (!teamMeta) {
+        return { ok: false, error: `Frame ${req.frameNodeId} is not a team frame (no teamMeta)` };
+      }
+      const teamId = teamMeta.teamId;
+
+      // Find all member nodes belonging to this team. We match on
+      // `teamMembership.teamId` (the durable link) rather than geometric
+      // containment so that nodes the user has moved temporarily out of
+      // the frame still get cleaned up.
+      const memberNodeIds: string[] = [];
+      for (const n of canvas.nodes) {
+        if (n.type !== 'agent') continue;
+        const tm = n.data.teamMembership as { teamId: string } | undefined;
+        if (tm?.teamId === teamId) memberNodeIds.push(n.id);
+      }
+
+      // Kill any PTY sessions owned by the member nodes. We use
+      // sessionId (the field actually wired into the PTY manager)
+      // rather than nodeId because PTYs are sometimes spawned with a
+      // distinct sessionId.
+      for (const nodeId of memberNodeIds) {
+        const node = canvas.nodes.find((n) => n.id === nodeId);
+        const sessionId = (node?.data.sessionId as string | undefined) ?? '';
+        if (sessionId && hasSession(sessionId)) {
+          killSession(sessionId);
+        }
+      }
+
+      // Remove the frame and member nodes from the canvas.
+      const idsToRemove = new Set<string>([req.frameNodeId, ...memberNodeIds]);
+      canvas.nodes = canvas.nodes.filter((n) => !idsToRemove.has(n.id));
+      await saveCanvas(req.workspaceId, canvas);
+      broadcastUpdate(req.workspaceId, Array.from(idsToRemove));
+
+      // Archive the team's state directory. Done last so a failure here
+      // doesn't leave the canvas with phantom nodes.
+      const archive = await destroyTeam(teamId);
+
+      return {
+        ok: true,
+        removedNodeIds: Array.from(idsToRemove),
+        archivedTo: archive?.archivedTo,
+      };
+    } catch (err) {
+      return { ok: false, error: String(err) };
+    }
+  });
+}

--- a/apps/canvas-workspace/src/preload/index.ts
+++ b/apps/canvas-workspace/src/preload/index.ts
@@ -133,6 +133,11 @@ contextBridge.exposeInMainWorld("canvasWorkspace", {
     install: () => ipcRenderer.invoke("skills:install")
   },
 
+  team: {
+    disband: (workspaceId: string, frameNodeId: string) =>
+      ipcRenderer.invoke("team:disband", { workspaceId, frameNodeId })
+  },
+
   iframe: {
     registerWebview: (workspaceId: string, nodeId: string, webContentsId: number) =>
       ipcRenderer.invoke("iframe:register-webview", { workspaceId, nodeId, webContentsId }),

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -156,11 +156,18 @@ export const AgentNodeBody = ({ node, rootFolder, workspaceId, onUpdate }: Props
         }
         const { inlinePrompt, promptFile, agentArgs } = dataRef.current;
         const effectivePrompt = inlinePromptOverride || inlinePrompt;
+        // `agentArgs` is always prepended (between the binary and any
+        // prompt arg) so that flags like `--dangerously-skip-permissions`
+        // / `--full-auto` survive even when the agent is launched with a
+        // prompt. Previously agentArgs was treated as an alternative to
+        // the prompt — that lost any flags the team coordinator wanted
+        // to bake in.
+        const argsPrefix = agentArgs ? `${agentArgs} ` : '';
         if (effectivePrompt) {
           const escaped = effectivePrompt.replace(/'/g, "'\\''");
-          api.write(sessionId, `${command} '${escaped}'\n`);
+          api.write(sessionId, `${command} ${argsPrefix}'${escaped}'\n`);
         } else if (promptFile) {
-          api.write(sessionId, `__prompt=$(cat ${promptFile}) && ${command} "$__prompt"\n`);
+          api.write(sessionId, `__prompt=$(cat ${promptFile}) && ${command} ${argsPrefix}"$__prompt"\n`);
         } else if (agentArgs) {
           api.write(sessionId, `${command} ${agentArgs}\n`);
         } else {

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -365,3 +365,46 @@
     box-shadow: var(--shadow-card), 0 0 0 3px var(--accent), 0 0 20px rgba(35, 131, 226, 0.3);
   }
 }
+
+/* ─── Team frame & team agent badges ───────────────────────────────
+ *
+ * `canvas-node--team-frame` lifts a frame visually so users can spot it
+ * in a workspace cluttered with normal frames. The double border + soft
+ * outer glow mimics how Figma highlights live components.
+ *
+ * Lead/teammate agent badges share the same `node-team-badge` class so
+ * they line up consistently with the existing icon row in the header.
+ */
+.canvas-node--team-frame {
+  outline: 2px solid rgba(122, 167, 232, 0.55);
+  outline-offset: 4px;
+  box-shadow: var(--shadow-card), 0 0 24px rgba(122, 167, 232, 0.18);
+}
+.canvas-node--team-frame.canvas-node--selected {
+  outline-color: rgba(122, 167, 232, 0.95);
+}
+
+.canvas-node--team-lead {
+  box-shadow: var(--shadow-card), 0 0 0 2px rgba(245, 179, 107, 0.6);
+}
+.canvas-node--team-member {
+  box-shadow: var(--shadow-card), 0 0 0 1.5px rgba(122, 167, 232, 0.45);
+}
+
+.node-team-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  margin-right: 4px;
+  user-select: none;
+}
+.node-team-badge--lead {
+  filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.2));
+}
+.node-team-badge--member {
+  color: #6c757d;
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 1;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -82,9 +82,40 @@ export const CanvasNodeView = ({
   const handleClose = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
+      // Special path for team frames: instead of just removing the
+      // frame node, ask main to disband the team (kill teammate PTYs +
+      // remove member nodes + archive team state). Plain frames and
+      // non-team agent nodes fall through to the normal `onRemove`.
+      if (
+        node.type === "frame" &&
+        (node.data as FrameNodeData).teamMeta &&
+        workspaceId
+      ) {
+        const teamName =
+          (node.data as FrameNodeData).teamMeta?.teamName ?? node.title;
+        const ok = window.confirm(
+          `Disband team "${teamName}"?\n\n` +
+            `This will close all teammate terminals, remove the team's ` +
+            `agent nodes from the canvas, and archive the team's state ` +
+            `directory. Tasks and messages will be preserved in the archive.`,
+        );
+        if (!ok) return;
+        void window.canvasWorkspace?.team?.disband(workspaceId, node.id).then((res) => {
+          if (!res.ok) {
+            // Fall back to a simple delete if the disband path fails —
+            // better to leave a clean canvas than half a team behind.
+            console.error("[team] disband failed:", res.error);
+            onRemove(node.id);
+          }
+          // On success: main has already broadcast canvas:external-update,
+          // which the canvas hook will pick up and re-render. No further
+          // action needed here.
+        });
+        return;
+      }
       onRemove(node.id);
     },
-    [onRemove, node.id]
+    [node.id, node.type, node.data, node.title, workspaceId, onRemove]
   );
 
   const handleFocus = useCallback(
@@ -127,6 +158,17 @@ export const CanvasNodeView = ({
   const textAutoSize =
     node.type === "text" && (node.data as TextNodeData).autoSize !== false;
 
+  // Team membership / team frame badges. Picked off the same `data` blob
+  // we'd render anyway, so there's no extra prop drilling — `teamMeta` on
+  // a frame and `teamMembership` on an agent are documented in
+  // `apps/canvas-workspace/src/renderer/src/types.ts`.
+  const isTeamFrame =
+    node.type === "frame" && (node.data as FrameNodeData).teamMeta !== undefined;
+  const teamMembership =
+    node.type === "agent" ? (node.data as AgentNodeData).teamMembership : undefined;
+  const isTeamLead = teamMembership?.isLead === true;
+  const isTeamMember = teamMembership !== undefined && !isTeamLead;
+
   const classes = [
     "canvas-node",
     `canvas-node--${node.type}`,
@@ -135,7 +177,10 @@ export const CanvasNodeView = ({
     isSelected && "canvas-node--selected",
     isHighlighted && "canvas-node--highlighted",
     isAgentEdited && "canvas-node--agent-edited",
-    textAutoSize && "canvas-node--text-auto"
+    textAutoSize && "canvas-node--text-auto",
+    isTeamFrame && "canvas-node--team-frame",
+    isTeamLead && "canvas-node--team-lead",
+    isTeamMember && "canvas-node--team-member"
   ]
     .filter(Boolean)
     .join(" ");
@@ -313,6 +358,15 @@ export const CanvasNodeView = ({
             return <span className={`node-status-dot node-status-dot--${agentStatus}`} />;
           })()}
         </span>
+        {isTeamFrame && (
+          <span className="node-team-badge" title="Team frame">🤝</span>
+        )}
+        {isTeamLead && (
+          <span className="node-team-badge node-team-badge--lead" title="Team lead">👑</span>
+        )}
+        {isTeamMember && (
+          <span className="node-team-badge node-team-badge--member" title="Teammate">·</span>
+        )}
         <span
           className="node-title"
           contentEditable

--- a/apps/canvas-workspace/src/renderer/src/config/agentRegistry.ts
+++ b/apps/canvas-workspace/src/renderer/src/config/agentRegistry.ts
@@ -3,13 +3,56 @@ export interface AgentDef {
   label: string;
   command: string;
   description: string;
+  /**
+   * CLI flag string that puts the agent into "no permission prompts"
+   * mode — used by team workflows where pausing for every shell action
+   * would block the coordination loop. Empty string for agents that have
+   * no equivalent (and don't need one).
+   *
+   * Note these bypass guardrails the agent vendors put in for a reason:
+   * only inject them when the user explicitly asked for unattended team
+   * execution (e.g. via `canvas_create_team`).
+   */
+  unattendedFlags: string;
 }
 
 export const AGENT_REGISTRY: AgentDef[] = [
-  { id: 'claude-code', label: 'Claude Code', command: 'claude', description: 'Anthropic' },
-  { id: 'codex', label: 'Codex', command: 'codex', description: 'OpenAI' },
-  { id: 'pulse-coder', label: 'Pulse Coder', command: 'pulse-coder', description: 'Pulse' },
+  {
+    id: 'claude-code',
+    label: 'Claude Code',
+    command: 'claude',
+    description: 'Anthropic',
+    // `--permission-mode bypassPermissions` is the modern, single-flag
+    // way to silence per-tool prompts. Newer Claude Code versions
+    // require `--allow-dangerously-skip-permissions` BEFORE the legacy
+    // `--dangerously-skip-permissions` would take effect, so the legacy
+    // flag alone no longer works.
+    unattendedFlags: '--permission-mode bypassPermissions',
+  },
+  {
+    id: 'codex',
+    label: 'Codex',
+    command: 'codex',
+    description: 'OpenAI',
+    // --full-auto = "-a on-request --sandbox workspace-write" per
+    // `codex --help`. Lets the agent execute shell + edit files in
+    // its cwd without asking, while keeping it sandboxed away from
+    // the rest of the disk.
+    unattendedFlags: '--full-auto',
+  },
+  {
+    id: 'pulse-coder',
+    label: 'Pulse Coder',
+    command: 'pulse-coder',
+    description: 'Pulse',
+    // pulse-coder doesn't gate tool use behind an interactive prompt,
+    // so no flag is needed.
+    unattendedFlags: '',
+  },
 ];
 
 export const getAgentCommand = (agentType: string): string | undefined =>
   AGENT_REGISTRY.find(a => a.id === agentType)?.command;
+
+export const getUnattendedFlags = (agentType: string): string =>
+  AGENT_REGISTRY.find(a => a.id === agentType)?.unattendedFlags ?? '';

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -347,6 +347,22 @@ export interface SkillsApi {
   install: () => Promise<SkillsInstallResult>;
 }
 
+/** Tear down a team that's been spawned via canvas_create_team:
+ *  kills member PTYs, removes the frame + member nodes from the canvas,
+ *  and archives the team's `~/.pulse-coder/teams/{teamId}/` state dir.
+ *  Implemented in `apps/canvas-workspace/src/main/team/team-ipc.ts`. */
+export interface TeamApi {
+  disband: (
+    workspaceId: string,
+    frameNodeId: string,
+  ) => Promise<{
+    ok: boolean;
+    removedNodeIds?: string[];
+    archivedTo?: string;
+    error?: string;
+  }>;
+}
+
 export interface AgentChatMessage {
   role: 'user' | 'assistant';
   content: string;
@@ -468,6 +484,7 @@ export interface CanvasWorkspaceApi {
   file: FileApi;
   dialog: DialogApi;
   skills: SkillsApi;
+  team: TeamApi;
   agent: AgentApi;
   iframe: IframeApi;
   llm: LlmApi;

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -38,6 +38,28 @@ export interface TerminalNodeData {
 export interface FrameNodeData {
   color: string;
   label?: string;
+  /**
+   * Marks this frame as a Team container. Presence of this field is the
+   * sole signal that the frame coordinates an agent team — frames without
+   * it remain plain visual groups. The `teamId` is independent of frame.id
+   * so that copying/moving the frame does not disturb the team's state
+   * directory under `~/.pulse-coder/teams/{teamId}/`.
+   */
+  teamMeta?: TeamMeta;
+}
+
+export interface TeamMeta {
+  /** Globally-unique team id (UUID). Stable across frame copy/move. */
+  teamId: string;
+  /** Human-readable name shown in the frame header. */
+  teamName: string;
+  /** Node id of the agent node currently acting as Lead. */
+  leadNodeId?: string;
+  /** Absolute path to the team's state directory (tasks/, mailbox/, config.json). */
+  stateDir: string;
+  /** Node id of the auto-generated tasks.md view file node. */
+  tasksViewNodeId?: string;
+  createdAt: number;
 }
 
 export interface AgentNodeData {
@@ -51,6 +73,22 @@ export interface AgentNodeData {
   inlinePrompt?: string;
   /** Relative path to a prompt file in cwd for long prompts. */
   promptFile?: string;
+  /**
+   * Team membership. When set, this agent participates in the named team
+   * and its mailbox lives at `<team stateDir>/mailbox/{memberId}.json`.
+   * `memberId` is intentionally distinct from the canvas `nodeId` so that
+   * a teammate keeps the same mailbox file across PTY restarts and node
+   * duplications. Absence of this field means the agent is standalone.
+   */
+  teamMembership?: AgentTeamMembership;
+}
+
+export interface AgentTeamMembership {
+  teamId: string;
+  /** Stable id within the team; used as mailbox filename. */
+  memberId: string;
+  isLead: boolean;
+  joinedAt: number;
 }
 
 /**

--- a/packages/canvas-cli/package.json
+++ b/packages/canvas-cli/package.json
@@ -14,6 +14,7 @@
     },
     "./core": {
       "types": "./dist/core/index.d.ts",
+      "import": "./dist/core/index.mjs",
       "require": "./dist/core/index.cjs"
     }
   },

--- a/packages/canvas-cli/package.json
+++ b/packages/canvas-cli/package.json
@@ -28,7 +28,8 @@
     "skills"
   ],
   "dependencies": {
-    "commander": "^13.0.0"
+    "commander": "^13.0.0",
+    "pulse-coder-agent-teams": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^25.0.10",

--- a/packages/canvas-cli/skills/team/SKILL.md
+++ b/packages/canvas-cli/skills/team/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: team
+description: Coordinate as part of an agent team — claim tasks, send messages, report completion
+version: 1.0.0
+---
+
+# Pulse Canvas — Agent Team Coordination
+
+You are working as part of an agent team on a shared canvas. Multiple agents (yourself included) coordinate through file-backed task lists and mailboxes managed by `pulse-canvas team` subcommands.
+
+## Your team identity (always set before starting)
+
+If you were spawned as a team member, your initial prompt told you your team identity. Confirm it:
+
+```
+$PULSE_TEAM_ID      → the team UUID
+$PULSE_TEAM_MEMBER  → your member id (e.g. "abc123-m2")
+$PULSE_TEAM_ROLE    → "lead" or "teammate"
+```
+
+If any are missing, you are NOT a team member yet — STOP and ask the user how you should fit into the team. Do not invent member ids.
+
+## Core protocol
+
+Every team has two persistent stores under `~/.pulse-coder/teams/{teamId}/`:
+
+| Store | What | Who reads | Who writes |
+|-------|------|-----------|-----------|
+| `tasks/tasks.json` | Shared task list (with deps, status, assignee) | All members | All members (file-locked) |
+| `mailbox/{memberId}.json` | Per-member inbox | The owning member | Anyone in the team |
+
+**Always operate via the CLI, never edit these JSON files directly** — the CLI applies file locks and validates membership; raw edits will corrupt state and may be rejected by other members' next read.
+
+## Commands
+
+### See team state
+```bash
+pulse-canvas team status $PULSE_TEAM_ID
+```
+Shows members, lead, and task statistics. Use this as a heartbeat.
+
+### Read your inbox (do this every loop iteration)
+```bash
+pulse-canvas team msg read $PULSE_TEAM_ID --member-id $PULSE_TEAM_MEMBER --format json
+```
+Returns unread messages and marks them read. Empty result means nothing new.
+
+### Send a message to a teammate
+```bash
+pulse-canvas team msg send $PULSE_TEAM_ID \
+  --from $PULSE_TEAM_MEMBER \
+  --to <other-member-id> \
+  --content "T2 done — output at notes/drizzle.md"
+```
+Use `--to "*"` to broadcast to everyone in the team.
+
+### List tasks
+```bash
+pulse-canvas team task list $PULSE_TEAM_ID --status pending --format json
+```
+
+### Claim a task (auto-pick or specific)
+```bash
+# Auto-claim: priority is pre-assigned-to-me → unassigned → work-stealing
+pulse-canvas team task claim $PULSE_TEAM_ID --member-id $PULSE_TEAM_MEMBER --format json
+
+# Or claim a specific task
+pulse-canvas team task claim $PULSE_TEAM_ID --member-id $PULSE_TEAM_MEMBER --task-id <id>
+```
+Returns `null` if nothing claimable. Tasks blocked by uncompleted deps are not returned.
+
+### Mark a task complete
+```bash
+pulse-canvas team task complete $PULSE_TEAM_ID \
+  --task-id <id> \
+  --result "Drizzle wins — see notes/drizzle.md"
+```
+This unblocks any tasks that depend on yours.
+
+### Lead-only: create tasks
+```bash
+pulse-canvas team task create $PULSE_TEAM_ID \
+  --member-id $PULSE_TEAM_MEMBER \
+  --title "Investigate Drizzle ORM" \
+  --description "Read docs, build a 50-line POC, write findings to notes/drizzle.md" \
+  --assignee <teammate-member-id> \
+  --deps task-id-a,task-id-b
+```
+Pre-assign with `--assignee` or leave unassigned to let teammates auto-claim. Use `--deps` for ordering (e.g. "synthesis depends on the three research tasks").
+
+## Workflow — if you are a TEAMMATE
+
+```
+loop:
+  1. msg read           → handle any incoming messages first
+  2. task claim         → grab next available task
+     - if null and "all tasks completed", broadcast "I'm done" and exit
+     - if null but tasks still in_progress, sleep 5s and retry (others working)
+  3. do the work        → use file tools (read, edit, bash) to actually do it
+  4. task complete      → mark done with a short result string
+  5. msg send to lead   → "T<x> done"
+  6. goto 1
+```
+
+## Workflow — if you are the LEAD
+
+```
+loop:
+  1. team status        → look at the dashboard
+  2. msg read           → handle teammate progress reports / questions
+  3. decide:
+     - new task should be created? → task create
+     - task waiting on a teammate? → continue
+     - all tasks completed? → synthesize results, broadcast shutdown_request, exit
+  4. sleep 5s, goto 1
+```
+
+DO NOT do the teammates' work yourself, even if you could. Your job is to coordinate. If a teammate is stuck, message them or reassign the task.
+
+## Coordination guidelines
+
+- **One submission per command.** The CLI is non-interactive — each invocation is one atomic action. Don't try to chain via shell pipes.
+- **Status drives behavior.** `task list --status in_progress` tells you what others are working on. Respect their assignments unless they're clearly stuck.
+- **Use the mailbox, not the canvas chat.** Other team members can't see canvas chat messages — only mailbox messages.
+- **Keep results small.** The `--result` field on task complete should be 1-2 sentences pointing at the actual output (file path, summary line). Long output goes in files.
+- **Never edit `~/.pulse-coder/teams/` files directly.** Always use the CLI — it handles concurrency.
+- **If a CLI command exits non-zero, READ THE ERROR.** Common ones: invalid member id (you mistyped), team not found (wrong teamId), task not in_progress (someone else completed it first — that's fine, move on).
+
+## Coordination anti-patterns
+
+- ❌ Polling `task list` every 100ms in a tight loop (waste of cycles, sleep 5s minimum)
+- ❌ Claiming tasks you can't actually do "to be helpful" (leave them for the right specialist)
+- ❌ Sending broadcast messages with status updates ("I'm starting T1!") — the task list already shows that
+- ❌ Acting on stale information — always re-read `team status` before making coordination decisions
+- ❌ Ignoring `shutdown_request` mailbox messages — when the lead sends one, finish the current step and exit
+
+## Quick example (teammate doing one task)
+
+```bash
+# Wake up, check inbox
+pulse-canvas team msg read $PULSE_TEAM_ID --member-id $PULSE_TEAM_MEMBER --format json
+
+# Claim something to work on
+pulse-canvas team task claim $PULSE_TEAM_ID --member-id $PULSE_TEAM_MEMBER --format json
+# → got task abc-123: "Investigate Drizzle ORM"
+
+# Do the actual work (use read/edit/bash here)
+echo "Drizzle is type-safe but ..." > notes/drizzle.md
+
+# Report completion
+pulse-canvas team task complete $PULSE_TEAM_ID --task-id abc-123 \
+  --result "Findings in notes/drizzle.md — type-safe, fast, smaller community"
+
+# Notify the lead
+pulse-canvas team msg send $PULSE_TEAM_ID \
+  --from $PULSE_TEAM_MEMBER --to $PULSE_TEAM_LEAD \
+  --content "T abc-123 done. notes/drizzle.md"
+```

--- a/packages/canvas-cli/src/cli.ts
+++ b/packages/canvas-cli/src/cli.ts
@@ -4,6 +4,7 @@ import { registerNodeCommands } from './commands/node';
 import { registerContextCommand } from './commands/context';
 import { registerInstallSkillsCommand } from './commands/install-skills';
 import { registerEdgeCommands } from './commands/edge';
+import { registerTeamCommands } from './commands/team';
 
 export const ENV_WORKSPACE_ID = 'PULSE_CANVAS_WORKSPACE_ID';
 
@@ -23,6 +24,7 @@ export function createCli(): Command {
   registerEdgeCommands(program);
   registerContextCommand(program);
   registerInstallSkillsCommand(program);
+  registerTeamCommands(program);
 
   return program;
 }

--- a/packages/canvas-cli/src/commands/__tests__/team.test.ts
+++ b/packages/canvas-cli/src/commands/__tests__/team.test.ts
@@ -1,0 +1,327 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'fs';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { createCli } from '../../cli';
+import { _resetTeamCache } from '../../core/team';
+
+/**
+ * Integration tests for `pulse-canvas team ...` subcommands.
+ *
+ * We invoke the commander program in-process via `createCli().parseAsync`
+ * so we exercise the full args → handler → core → file IO path that an
+ * agent would hit when shelling out to the binary. Console output is
+ * captured per-test so we can assert on stdout / exit codes without the
+ * test runner output getting polluted.
+ *
+ * State is isolated per-test by pointing PULSE_TEAMS_ROOT at a fresh
+ * tmpdir, plus calling `_resetTeamCache()` between runs (the runtime
+ * cache lives in module scope and would otherwise leak across tests).
+ */
+
+let teamsRoot: string;
+let archiveRoot: string;
+let stdoutLines: string[];
+let stderrLines: string[];
+let originalConsoleLog: typeof console.log;
+let originalConsoleError: typeof console.error;
+let originalExit: typeof process.exit;
+
+beforeEach(async () => {
+  teamsRoot = join(tmpdir(), `team-cli-test-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`);
+  archiveRoot = `${teamsRoot}-archive`;
+  process.env.PULSE_TEAMS_ROOT = teamsRoot;
+  process.env.PULSE_TEAMS_ARCHIVE_ROOT = archiveRoot;
+  await fs.mkdir(teamsRoot, { recursive: true });
+
+  _resetTeamCache();
+
+  // The output helper writes via console.log / console.error, which
+  // vitest intercepts at a higher level than process.stdout.write — so
+  // monkey-patching the underlying writes wouldn't capture anything.
+  // Patch the console methods directly instead.
+  stdoutLines = [];
+  stderrLines = [];
+  originalConsoleLog = console.log;
+  originalConsoleError = console.error;
+  console.log = (...args: unknown[]) => {
+    stdoutLines.push(args.map((a) => (typeof a === 'string' ? a : String(a))).join(' '));
+  };
+  console.error = (...args: unknown[]) => {
+    stderrLines.push(args.map((a) => (typeof a === 'string' ? a : String(a))).join(' '));
+  };
+
+  // errorOutput() calls process.exit(1). In tests we'd rather throw a
+  // typed sentinel so individual test cases can `expect(...).rejects`.
+  originalExit = process.exit;
+  process.exit = ((code?: number) => {
+    throw new ExitCalled(code ?? 0);
+  }) as typeof process.exit;
+});
+
+afterEach(async () => {
+  console.log = originalConsoleLog;
+  console.error = originalConsoleError;
+  process.exit = originalExit;
+  delete process.env.PULSE_TEAMS_ROOT;
+  delete process.env.PULSE_TEAMS_ARCHIVE_ROOT;
+  await fs.rm(teamsRoot, { recursive: true, force: true });
+  await fs.rm(archiveRoot, { recursive: true, force: true });
+});
+
+class ExitCalled extends Error {
+  constructor(public code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+/** Run the CLI with `argv` (excluding the leading "node binary" pair).
+ *  Returns the captured stdout/stderr; throws ExitCalled on errorOutput. */
+async function runCli(argv: string[]): Promise<{ stdout: string; stderr: string }> {
+  // commander's parseAsync expects the full argv shape (binary, script, ...).
+  // The actual values for the leading two slots don't matter to commander.
+  await createCli().parseAsync(['node', 'pulse-canvas', ...argv]);
+  return { stdout: stdoutLines.join('\n'), stderr: stderrLines.join('\n') };
+}
+
+/** Convenience: run with --format json and parse the captured stdout
+ *  as a single JSON value. The `output` helper makes one console.log
+ *  call per command, so stdoutLines[0] is exactly that JSON document. */
+async function runJson<T = unknown>(argv: string[]): Promise<T> {
+  await runCli([...argv, '--format', 'json']);
+  if (stdoutLines.length === 0) {
+    throw new Error(`runJson: no stdout captured for ${argv.join(' ')}`);
+  }
+  // Pick the LAST line — every test invocation runs in a fresh stdout
+  // buffer (cleared in beforeEach), but if a single test calls runJson
+  // multiple times the buffer accumulates, so the most recent log is
+  // what the caller wants.
+  return JSON.parse(stdoutLines[stdoutLines.length - 1]) as T;
+}
+
+describe('pulse-canvas team', () => {
+  describe('create + list + status', () => {
+    it('creates a team with a valid uuid and persists config.json', async () => {
+      const created = await runJson<{ teamId: string; teamName: string; stateDir: string }>([
+        '--workspace', 'ws-1', 'team', 'create', 'My Team',
+      ]);
+      expect(created.teamName).toBe('My Team');
+      expect(created.teamId).toMatch(/^[0-9a-f-]{36}$/);
+      expect(created.stateDir).toBe(join(teamsRoot, created.teamId));
+
+      const cfgPath = join(created.stateDir, 'config.json');
+      expect(existsSync(cfgPath)).toBe(true);
+      const cfg = JSON.parse(readFileSync(cfgPath, 'utf-8'));
+      expect(cfg).toMatchObject({
+        teamId: created.teamId,
+        teamName: 'My Team',
+        workspaceId: 'ws-1',
+        members: [],
+      });
+    });
+
+    it('lists teams scoped to the requested workspace and ignores others', async () => {
+      const a1 = await runJson<{ teamId: string }>(['-w', 'ws-A', 'team', 'create', 'A1']);
+      const a2 = await runJson<{ teamId: string }>(['-w', 'ws-A', 'team', 'create', 'A2']);
+      await runJson(['-w', 'ws-B', 'team', 'create', 'B-only']);
+
+      const listed = await runJson<Array<{ teamId: string }>>(['-w', 'ws-A', 'team', 'list']);
+      const ids = listed.map((t) => t.teamId).sort();
+      expect(ids).toEqual([a1.teamId, a2.teamId].sort());
+    });
+
+    it('refuses to create without a workspace', async () => {
+      await expect(runCli(['team', 'create', 'No-ws'])).rejects.toThrow(ExitCalled);
+      expect(stderrLines.join('')).toMatch(/Workspace ID required/);
+    });
+
+    it('status returns members + task stats', async () => {
+      const team = await runJson<{ teamId: string }>(['-w', 'ws-1', 'team', 'create', 'T']);
+      await runJson([
+        'team', 'add-member', team.teamId,
+        '--node-id', 'node-l', '--agent-type', 'claude-code', '--lead',
+      ]);
+      const status = await runJson<{
+        members: Array<{ memberId: string; isLead: boolean }>;
+        leadMemberId: string;
+        tasks: { total: number };
+      }>(['team', 'status', team.teamId]);
+      expect(status.members).toHaveLength(1);
+      expect(status.members[0].isLead).toBe(true);
+      expect(status.leadMemberId).toBe(status.members[0].memberId);
+      expect(status.tasks.total).toBe(0);
+    });
+  });
+
+  describe('add-member', () => {
+    it('rejects unknown agent types', async () => {
+      const team = await runJson<{ teamId: string }>(['-w', 'ws-1', 'team', 'create', 'T']);
+      await expect(
+        runCli(['team', 'add-member', team.teamId, '--node-id', 'n1', '--agent-type', 'gpt-2']),
+      ).rejects.toThrow(ExitCalled);
+      expect(stderrLines.join('')).toMatch(/Invalid --agent-type/);
+    });
+
+    it('allocates predictable memberIds in order', async () => {
+      const team = await runJson<{ teamId: string }>(['-w', 'ws-1', 'team', 'create', 'T']);
+      const m1 = await runJson<{ memberId: string }>([
+        'team', 'add-member', team.teamId, '--node-id', 'n1', '--agent-type', 'codex',
+      ]);
+      const m2 = await runJson<{ memberId: string }>([
+        'team', 'add-member', team.teamId, '--node-id', 'n2', '--agent-type', 'codex',
+      ]);
+      expect(m1.memberId).toBe(`${team.teamId}-m1`);
+      expect(m2.memberId).toBe(`${team.teamId}-m2`);
+    });
+  });
+
+  describe('task lifecycle', () => {
+    async function setupTeamWithMembers() {
+      const team = await runJson<{ teamId: string }>(['-w', 'ws-1', 'team', 'create', 'T']);
+      const lead = await runJson<{ memberId: string }>([
+        'team', 'add-member', team.teamId, '--node-id', 'n-lead', '--agent-type', 'claude-code', '--lead',
+      ]);
+      const tm = await runJson<{ memberId: string }>([
+        'team', 'add-member', team.teamId, '--node-id', 'n-tm', '--agent-type', 'codex',
+      ]);
+      return { teamId: team.teamId, leadId: lead.memberId, tmId: tm.memberId };
+    }
+
+    it('runs a full create → claim → complete cycle', async () => {
+      const { teamId, leadId, tmId } = await setupTeamWithMembers();
+
+      const task = await runJson<{ id: string; status: string }>([
+        'team', 'task', 'create', teamId,
+        '--member-id', leadId,
+        '--title', 'Investigate ORM',
+        '--description', 'Compare three options',
+      ]);
+      expect(task.status).toBe('pending');
+
+      const claimed = await runJson<{ id: string; status: string; assignee: string }>([
+        'team', 'task', 'claim', teamId, '--member-id', tmId,
+      ]);
+      expect(claimed.id).toBe(task.id);
+      expect(claimed.status).toBe('in_progress');
+      expect(claimed.assignee).toBe(tmId);
+
+      const completed = await runJson<{ status: string; result: string }>([
+        'team', 'task', 'complete', teamId, '--task-id', task.id, '--result', 'Done',
+      ]);
+      expect(completed.status).toBe('completed');
+      expect(completed.result).toBe('Done');
+    });
+
+    it('blocks dependent tasks until prerequisites complete', async () => {
+      const { teamId, leadId, tmId } = await setupTeamWithMembers();
+
+      const t1 = await runJson<{ id: string }>([
+        'team', 'task', 'create', teamId,
+        '--member-id', leadId, '--title', 'Step 1', '--description', 'first',
+      ]);
+      const t2 = await runJson<{ id: string }>([
+        'team', 'task', 'create', teamId,
+        '--member-id', leadId, '--title', 'Step 2', '--description', 'second',
+        '--deps', t1.id,
+      ]);
+
+      // Auto-claim from teammate should pick up T1 (T2 is blocked).
+      const claim1 = await runJson<{ id: string }>([
+        'team', 'task', 'claim', teamId, '--member-id', tmId,
+      ]);
+      expect(claim1.id).toBe(t1.id);
+
+      // Second auto-claim returns null because T2 is still blocked.
+      const claim2 = await runJson<{ claimed: null | { id: string } }>([
+        'team', 'task', 'claim', teamId, '--member-id', tmId,
+      ]);
+      expect(claim2.claimed ?? null).toBeNull();
+
+      // Complete T1 → T2 unblocks → claim succeeds.
+      await runJson(['team', 'task', 'complete', teamId, '--task-id', t1.id]);
+      const claim3 = await runJson<{ id: string }>([
+        'team', 'task', 'claim', teamId, '--member-id', tmId,
+      ]);
+      expect(claim3.id).toBe(t2.id);
+    });
+
+    it('rejects task ops with cross-team member ids', async () => {
+      const a = await runJson<{ teamId: string }>(['-w', 'ws-1', 'team', 'create', 'A']);
+      const b = await runJson<{ teamId: string }>(['-w', 'ws-1', 'team', 'create', 'B']);
+      const aMember = await runJson<{ memberId: string }>([
+        'team', 'add-member', a.teamId, '--node-id', 'n-a', '--agent-type', 'codex',
+      ]);
+
+      // aMember is valid in team A but should be rejected in team B.
+      await expect(
+        runCli([
+          'team', 'task', 'create', b.teamId,
+          '--member-id', aMember.memberId, '--title', 'X', '--description', 'Y',
+        ]),
+      ).rejects.toThrow(ExitCalled);
+      expect(stderrLines.join('')).toMatch(/does not belong to team/);
+    });
+  });
+
+  describe('mailbox', () => {
+    it('round-trips a message and read marks it consumed', async () => {
+      const team = await runJson<{ teamId: string }>(['-w', 'ws-1', 'team', 'create', 'T']);
+      const m1 = await runJson<{ memberId: string }>([
+        'team', 'add-member', team.teamId, '--node-id', 'n1', '--agent-type', 'claude-code', '--lead',
+      ]);
+      const m2 = await runJson<{ memberId: string }>([
+        'team', 'add-member', team.teamId, '--node-id', 'n2', '--agent-type', 'codex',
+      ]);
+
+      await runJson([
+        'team', 'msg', 'send', team.teamId,
+        '--from', m2.memberId, '--to', m1.memberId, '--content', 'hello lead',
+      ]);
+
+      const first = await runJson<{ count: number; messages: Array<{ content: string; from: string }> }>([
+        'team', 'msg', 'read', team.teamId, '--member-id', m1.memberId,
+      ]);
+      expect(first.count).toBe(1);
+      expect(first.messages[0]).toMatchObject({ content: 'hello lead', from: m2.memberId });
+
+      const second = await runJson<{ count: number }>([
+        'team', 'msg', 'read', team.teamId, '--member-id', m1.memberId,
+      ]);
+      expect(second.count).toBe(0);
+    });
+
+    it('rejects sender that does not belong to the team', async () => {
+      const team = await runJson<{ teamId: string }>(['-w', 'ws-1', 'team', 'create', 'T']);
+      const m1 = await runJson<{ memberId: string }>([
+        'team', 'add-member', team.teamId, '--node-id', 'n1', '--agent-type', 'codex',
+      ]);
+      await expect(
+        runCli([
+          'team', 'msg', 'send', team.teamId,
+          '--from', 'ghost', '--to', m1.memberId, '--content', 'x',
+        ]),
+      ).rejects.toThrow(ExitCalled);
+      expect(stderrLines.join('')).toMatch(/Sender ghost does not belong to team/);
+    });
+  });
+
+  describe('destroy', () => {
+    it('renames the state dir into the archive root', async () => {
+      const team = await runJson<{ teamId: string; stateDir: string }>([
+        '-w', 'ws-1', 'team', 'create', 'T',
+      ]);
+      const result = await runJson<{ archivedTo: string }>([
+        'team', 'destroy', team.teamId,
+      ]);
+      expect(existsSync(team.stateDir)).toBe(false);
+      expect(existsSync(result.archivedTo)).toBe(true);
+      expect(result.archivedTo.startsWith(archiveRoot)).toBe(true);
+    });
+
+    it('reports an error when team does not exist', async () => {
+      await expect(runCli(['team', 'destroy', 'nonexistent-team-id'])).rejects.toThrow(ExitCalled);
+      expect(stderrLines.join('')).toMatch(/Team not found/);
+    });
+  });
+});

--- a/packages/canvas-cli/src/commands/team.ts
+++ b/packages/canvas-cli/src/commands/team.ts
@@ -1,0 +1,383 @@
+/**
+ * `pulse-canvas team` — coordinate agent teams via the file-backed
+ * TaskList / Mailbox protocol from `pulse-coder-agent-teams`.
+ *
+ * All state lives under `~/.pulse-coder/teams/{teamId}/`. Agents (lead
+ * and teammates) call these subcommands via their bash tool to claim
+ * tasks, exchange messages, and report progress; nothing in the loop
+ * needs an HTTP server or IPC channel.
+ *
+ * Every team-scoped subcommand requires a `teamId` positional and (where
+ * relevant) a `--member-id`. The `--member-id` is verified against the
+ * team's persisted members so one team's lead cannot accidentally write
+ * into another team's mailbox or claim its tasks.
+ */
+import { Command } from 'commander';
+import {
+  addMember,
+  createTeam,
+  destroyTeam,
+  getTeam,
+  hasMember,
+  listTeams,
+} from '../core/team';
+import { errorOutput, output, type OutputFormat } from '../output';
+
+interface RootOpts {
+  format: OutputFormat;
+  storeDir?: string;
+  workspace?: string;
+}
+
+/** Walk up to the root program to read global flags (`--format`,
+ *  `--workspace`, `--store-dir`). Subcommands nested two levels deep
+ *  (`team task create`) need to skip TWO parents to reach root, so we
+ *  loop instead of hardcoding `parent.parent`. */
+function getRootOpts(cmd: Command): RootOpts {
+  let cur: Command | null = cmd;
+  while (cur && cur.parent) cur = cur.parent;
+  const opts = cur?.opts() ?? {};
+  return {
+    format: (opts.format as OutputFormat) ?? 'text',
+    storeDir: opts.storeDir as string | undefined,
+    workspace: opts.workspace as string | undefined,
+  };
+}
+
+function requireWorkspace(rootOpts: RootOpts): string {
+  if (!rootOpts.workspace) {
+    errorOutput('Workspace ID required. Use --workspace <id> or set $PULSE_CANVAS_WORKSPACE_ID');
+  }
+  return rootOpts.workspace!;
+}
+
+/** Parse a comma-separated list option (e.g. `--deps a,b,c`). Returns an
+ *  empty array for undefined or empty inputs so callers can spread it
+ *  unconditionally. */
+function parseList(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+export function registerTeamCommands(program: Command): void {
+  const team = program
+    .command('team')
+    .description('Manage agent teams (lead/teammate coordination on the canvas)');
+
+  // ─── team create ──────────────────────────────────────────────────
+  team.command('create')
+    .argument('<name>', 'Human-readable team name')
+    .description('Create a new team. Generates a UUID and bootstraps the state directory.')
+    .action(async function (this: Command, name: string) {
+      const rootOpts = getRootOpts(this);
+      const workspace = requireWorkspace(rootOpts);
+
+      const runtime = createTeam({ workspaceId: workspace, teamName: name });
+
+      output(
+        { teamId: runtime.config.teamId, teamName: name, stateDir: runtime.stateDir },
+        rootOpts.format,
+        (d) => {
+          const r = d as { teamId: string; teamName: string; stateDir: string };
+          return `Created team "${r.teamName}"\n  teamId: ${r.teamId}\n  state:  ${r.stateDir}`;
+        },
+      );
+    });
+
+  // ─── team list ────────────────────────────────────────────────────
+  team.command('list')
+    .description('List teams scoped to the current workspace')
+    .action(async function (this: Command) {
+      const rootOpts = getRootOpts(this);
+      const workspace = requireWorkspace(rootOpts);
+
+      const teams = await listTeams(workspace);
+      output(teams, rootOpts.format, (d) => {
+        const items = d as typeof teams;
+        if (items.length === 0) return 'No teams in this workspace.';
+        const lines = items.map((t) => {
+          const lead = t.leadMemberId ? ` lead=${t.leadMemberId}` : '';
+          return `  ${t.teamId}  "${t.teamName}"  members=${t.members.length}${lead}`;
+        });
+        return `Teams:\n${lines.join('\n')}`;
+      });
+    });
+
+  // ─── team status ──────────────────────────────────────────────────
+  team.command('status')
+    .argument('<teamId>', 'Team ID')
+    .description('Aggregate snapshot: members + task statistics')
+    .action(async function (this: Command, teamId: string) {
+      const rootOpts = getRootOpts(this);
+      const runtime = getTeam(teamId);
+      if (!runtime) errorOutput(`Team not found: ${teamId}`);
+
+      const stats = runtime!.taskList.stats();
+      const status = {
+        teamId,
+        teamName: runtime!.config.teamName,
+        leadMemberId: runtime!.config.leadMemberId ?? null,
+        members: runtime!.config.members,
+        tasks: stats,
+      };
+      output(status, rootOpts.format, (d) => {
+        const s = d as typeof status;
+        const memberLines = s.members.map(
+          (m) => `  ${m.memberId}  ${m.agentType}${m.isLead ? ' [LEAD]' : ''}  node=${m.nodeId}`,
+        );
+        return [
+          `Team: ${s.teamName} (${s.teamId})`,
+          `Lead: ${s.leadMemberId ?? '(none)'}`,
+          `Members (${s.members.length}):`,
+          memberLines.length > 0 ? memberLines.join('\n') : '  (none)',
+          `Tasks: ${s.tasks.total} total | ${s.tasks.pending} pending | ${s.tasks.in_progress} in_progress | ${s.tasks.completed} completed | ${s.tasks.failed} failed`,
+        ].join('\n');
+      });
+    });
+
+  // ─── team add-member ──────────────────────────────────────────────
+  team.command('add-member')
+    .argument('<teamId>', 'Team ID')
+    .requiredOption('--node-id <id>', 'Canvas agent node id this member is backed by')
+    .requiredOption('--agent-type <type>', 'Agent type: claude-code | codex | pulse-coder')
+    .option('--lead', 'Mark this member as the team lead')
+    .description('Register a member in a team. Caller is responsible for the canvas node itself.')
+    .action(async function (
+      this: Command,
+      teamId: string,
+      cmdOpts: { nodeId: string; agentType: string; lead?: boolean },
+    ) {
+      const rootOpts = getRootOpts(this);
+      const valid = ['claude-code', 'codex', 'pulse-coder'];
+      if (!valid.includes(cmdOpts.agentType)) {
+        errorOutput(`Invalid --agent-type "${cmdOpts.agentType}". Must be: ${valid.join(', ')}`);
+      }
+
+      const member = addMember(teamId, {
+        nodeId: cmdOpts.nodeId,
+        agentType: cmdOpts.agentType,
+        isLead: cmdOpts.lead === true,
+      });
+      if (!member) errorOutput(`Team not found: ${teamId}`);
+
+      output(member!, rootOpts.format, (d) => {
+        const m = d as typeof member;
+        return `Added member ${m!.memberId}${m!.isLead ? ' [LEAD]' : ''}  type=${m!.agentType}  node=${m!.nodeId}`;
+      });
+    });
+
+  // ─── team destroy ─────────────────────────────────────────────────
+  team.command('destroy')
+    .argument('<teamId>', 'Team ID')
+    .description('Archive the team state directory. Does NOT close PTYs or remove canvas nodes.')
+    .action(async function (this: Command, teamId: string) {
+      const rootOpts = getRootOpts(this);
+      const result = await destroyTeam(teamId);
+      if (!result) errorOutput(`Team not found: ${teamId}`);
+
+      output(result!, rootOpts.format, (d) => {
+        const r = d as { archivedTo: string };
+        return `Team ${teamId} archived to:\n  ${r.archivedTo}`;
+      });
+    });
+
+  // ─── team task <subcommand> ───────────────────────────────────────
+  const task = team.command('task').description('Shared task list (file-locked, dependency-aware)');
+
+  task.command('create')
+    .argument('<teamId>', 'Team ID')
+    .requiredOption('--member-id <id>', 'Member id of the creator (recorded as createdBy)')
+    .requiredOption('--title <title>', 'Short task title')
+    .requiredOption('--description <desc>', 'Detailed description')
+    .option('--deps <ids>', 'Comma-separated task ids this task depends on')
+    .option('--assignee <memberId>', 'Pre-assign to a specific member')
+    .description('Create a task in the shared list')
+    .action(async function (
+      this: Command,
+      teamId: string,
+      cmdOpts: { memberId: string; title: string; description: string; deps?: string; assignee?: string },
+    ) {
+      const rootOpts = getRootOpts(this);
+      if (!hasMember(teamId, cmdOpts.memberId)) {
+        errorOutput(`Member ${cmdOpts.memberId} does not belong to team ${teamId}`);
+      }
+      const runtime = getTeam(teamId)!;
+
+      const created = await runtime.taskList.create(
+        {
+          title: cmdOpts.title,
+          description: cmdOpts.description,
+          deps: parseList(cmdOpts.deps),
+          assignee: cmdOpts.assignee,
+        },
+        cmdOpts.memberId,
+      );
+
+      output(created, rootOpts.format, (d) => {
+        const t = d as typeof created;
+        const deps = t.deps.length > 0 ? ` deps=[${t.deps.join(',')}]` : '';
+        const assn = t.assignee ? ` assignee=${t.assignee}` : '';
+        return `Created task ${t.id}\n  title: ${t.title}${deps}${assn}`;
+      });
+    });
+
+  task.command('claim')
+    .argument('<teamId>', 'Team ID')
+    .requiredOption('--member-id <id>', 'Member claiming the task')
+    .option('--task-id <id>', 'Specific task to claim. Omit for auto-claim.')
+    .description('Claim a pending, unblocked task. Auto-claim picks: pre-assigned-to-me → unassigned → work-stealing.')
+    .action(async function (
+      this: Command,
+      teamId: string,
+      cmdOpts: { memberId: string; taskId?: string },
+    ) {
+      const rootOpts = getRootOpts(this);
+      if (!hasMember(teamId, cmdOpts.memberId)) {
+        errorOutput(`Member ${cmdOpts.memberId} does not belong to team ${teamId}`);
+      }
+      const runtime = getTeam(teamId)!;
+
+      const task = await runtime.taskList.claim(cmdOpts.memberId, cmdOpts.taskId);
+      if (!task) {
+        output({ ok: true, claimed: null }, rootOpts.format, () => 'No claimable task right now.');
+        return;
+      }
+      output(task, rootOpts.format, (d) => {
+        const t = d as typeof task;
+        return `Claimed task ${t!.id}\n  title: ${t!.title}\n  description: ${t!.description}`;
+      });
+    });
+
+  task.command('complete')
+    .argument('<teamId>', 'Team ID')
+    .requiredOption('--task-id <id>', 'Task ID')
+    .option('--result <text>', 'Optional output / summary string')
+    .description('Mark a task as completed. Dependent tasks become unblocked on next claim.')
+    .action(async function (
+      this: Command,
+      teamId: string,
+      cmdOpts: { taskId: string; result?: string },
+    ) {
+      const rootOpts = getRootOpts(this);
+      const runtime = getTeam(teamId);
+      if (!runtime) errorOutput(`Team not found: ${teamId}`);
+
+      const task = await runtime!.taskList.complete(cmdOpts.taskId, cmdOpts.result);
+      if (!task) {
+        errorOutput(`Task ${cmdOpts.taskId} could not be completed (not in_progress, or not found)`);
+      }
+      output(task!, rootOpts.format, (d) => {
+        const t = d as typeof task;
+        return `Completed task ${t!.id}: ${t!.title}`;
+      });
+    });
+
+  task.command('list')
+    .argument('<teamId>', 'Team ID')
+    .option('--status <status>', 'Filter: pending | in_progress | completed | failed')
+    .description('List tasks in the team')
+    .action(async function (
+      this: Command,
+      teamId: string,
+      cmdOpts: { status?: 'pending' | 'in_progress' | 'completed' | 'failed' },
+    ) {
+      const rootOpts = getRootOpts(this);
+      const runtime = getTeam(teamId);
+      if (!runtime) errorOutput(`Team not found: ${teamId}`);
+
+      const tasks = cmdOpts.status
+        ? runtime!.taskList.getByStatus(cmdOpts.status)
+        : runtime!.taskList.getAll();
+
+      output(tasks, rootOpts.format, (d) => {
+        const items = d as typeof tasks;
+        if (items.length === 0) return 'No tasks.';
+        const lines = items.map((t) => {
+          const assn = t.assignee ?? '-';
+          const deps = t.deps.length > 0 ? ` deps=[${t.deps.join(',')}]` : '';
+          return `  ${statusGlyph(t.status)} ${t.id}  ${t.status}  assignee=${assn}  ${t.title}${deps}`;
+        });
+        return `Tasks (${items.length}):\n${lines.join('\n')}`;
+      });
+    });
+
+  // ─── team msg <subcommand> ────────────────────────────────────────
+  const msg = team.command('msg').description('Inter-member mailbox (persists across PTY restarts)');
+
+  msg.command('send')
+    .argument('<teamId>', 'Team ID')
+    .requiredOption('--from <memberId>', 'Sender member id')
+    .requiredOption('--to <memberId>', 'Recipient member id, or "*" to broadcast')
+    .requiredOption('--content <text>', 'Message body')
+    .option('--type <type>', 'Message type: message | broadcast | shutdown_request', 'message')
+    .description('Append a message to a member\'s inbox (or broadcast to the team).')
+    .action(async function (
+      this: Command,
+      teamId: string,
+      cmdOpts: { from: string; to: string; content: string; type: string },
+    ) {
+      const rootOpts = getRootOpts(this);
+      if (!hasMember(teamId, cmdOpts.from)) {
+        errorOutput(`Sender ${cmdOpts.from} does not belong to team ${teamId}`);
+      }
+      if (cmdOpts.to !== '*' && !hasMember(teamId, cmdOpts.to)) {
+        errorOutput(`Recipient ${cmdOpts.to} does not belong to team ${teamId}`);
+      }
+      const validTypes = ['message', 'broadcast', 'shutdown_request'];
+      if (!validTypes.includes(cmdOpts.type)) {
+        errorOutput(`Invalid --type "${cmdOpts.type}". Must be: ${validTypes.join(', ')}`);
+      }
+      const runtime = getTeam(teamId)!;
+
+      const sent = runtime.mailbox.send(
+        cmdOpts.from,
+        cmdOpts.to,
+        cmdOpts.type as 'message' | 'broadcast' | 'shutdown_request',
+        cmdOpts.content,
+      );
+      output({ ok: true, messageId: sent.id }, rootOpts.format, (d) => {
+        const r = d as { messageId: string };
+        return `Sent message ${r.messageId}`;
+      });
+    });
+
+  msg.command('read')
+    .argument('<teamId>', 'Team ID')
+    .requiredOption('--member-id <id>', 'Member whose inbox to drain')
+    .description('Read and mark-as-read all unread messages for a member.')
+    .action(async function (this: Command, teamId: string, cmdOpts: { memberId: string }) {
+      const rootOpts = getRootOpts(this);
+      if (!hasMember(teamId, cmdOpts.memberId)) {
+        errorOutput(`Member ${cmdOpts.memberId} does not belong to team ${teamId}`);
+      }
+      const runtime = getTeam(teamId)!;
+
+      const messages = runtime.mailbox.readUnread(cmdOpts.memberId);
+      output({ count: messages.length, messages }, rootOpts.format, (d) => {
+        const r = d as { count: number; messages: typeof messages };
+        if (r.count === 0) return 'No unread messages.';
+        const lines = r.messages.map(
+          (m) => `  [${new Date(m.timestamp).toISOString()}] ${m.from} → ${m.to} (${m.type}): ${m.content}`,
+        );
+        return `Unread messages (${r.count}):\n${lines.join('\n')}`;
+      });
+    });
+}
+
+function statusGlyph(status: string): string {
+  switch (status) {
+    case 'pending':
+      return '☐';
+    case 'in_progress':
+      return '▶';
+    case 'completed':
+      return '☑';
+    case 'failed':
+      return '✗';
+    default:
+      return '·';
+  }
+}

--- a/packages/canvas-cli/src/core/index.ts
+++ b/packages/canvas-cli/src/core/index.ts
@@ -5,3 +5,4 @@ export * from './nodes';
 export * from './edges';
 export * from './context';
 export * from './notifier';
+export * from './team';

--- a/packages/canvas-cli/src/core/team.ts
+++ b/packages/canvas-cli/src/core/team.ts
@@ -23,8 +23,17 @@ import { join } from 'path';
 import { randomUUID } from 'crypto';
 import { Mailbox, TaskList } from 'pulse-coder-agent-teams';
 
-const TEAMS_ROOT = join(homedir(), '.pulse-coder', 'teams');
-const ARCHIVE_ROOT = join(homedir(), '.pulse-coder', 'teams-archive');
+/**
+ * Roots can be overridden via `PULSE_TEAMS_ROOT` / `PULSE_TEAMS_ARCHIVE_ROOT`
+ * for tests and isolated CLI runs. We resolve these per call (not at
+ * module load) so tests can flip the env mid-process via `process.env`.
+ */
+function teamsRoot(): string {
+  return process.env.PULSE_TEAMS_ROOT || join(homedir(), '.pulse-coder', 'teams');
+}
+function archiveRoot(): string {
+  return process.env.PULSE_TEAMS_ARCHIVE_ROOT || join(homedir(), '.pulse-coder', 'teams-archive');
+}
 
 /**
  * Persisted team metadata. Stored at `{stateDir}/config.json`.
@@ -80,7 +89,7 @@ const runtimes = new Map<string, TeamRuntime>();
  *  TaskList / Mailbox bootstrap files. */
 export function createTeam(args: CreateTeamArgs): TeamRuntime {
   const teamId = randomUUID();
-  const stateDir = join(TEAMS_ROOT, teamId);
+  const stateDir = join(teamsRoot(), teamId);
   mkdirSync(stateDir, { recursive: true });
 
   const config: TeamConfigFile = {
@@ -108,7 +117,7 @@ export function getTeam(teamId: string): TeamRuntime | null {
   const cached = runtimes.get(teamId);
   if (cached) return cached;
 
-  const stateDir = join(TEAMS_ROOT, teamId);
+  const stateDir = join(teamsRoot(), teamId);
   if (!existsSync(stateDir)) return null;
 
   const config = readConfig(stateDir);
@@ -127,12 +136,12 @@ export function getTeam(teamId: string): TeamRuntime | null {
 /** All teams scoped to a workspace. Always reads disk so listings stay
  *  fresh after restarts. */
 export async function listTeams(workspaceId: string): Promise<TeamConfigFile[]> {
-  if (!existsSync(TEAMS_ROOT)) return [];
-  const entries = await fsAsync.readdir(TEAMS_ROOT, { withFileTypes: true });
+  if (!existsSync(teamsRoot())) return [];
+  const entries = await fsAsync.readdir(teamsRoot(), { withFileTypes: true });
   const out: TeamConfigFile[] = [];
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
-    const config = readConfig(join(TEAMS_ROOT, entry.name));
+    const config = readConfig(join(teamsRoot(), entry.name));
     if (config && config.workspaceId === workspaceId) out.push(config);
   }
   return out;
@@ -186,11 +195,11 @@ export function findMemberByNodeId(teamId: string, nodeId: string): TeamMemberRe
  *  removing canvas nodes. */
 export async function destroyTeam(teamId: string): Promise<{ archivedTo: string } | null> {
   const cached = runtimes.get(teamId);
-  const stateDir = cached?.stateDir ?? join(TEAMS_ROOT, teamId);
+  const stateDir = cached?.stateDir ?? join(teamsRoot(), teamId);
   if (!existsSync(stateDir)) return null;
 
-  await fsAsync.mkdir(ARCHIVE_ROOT, { recursive: true });
-  const archivedTo = join(ARCHIVE_ROOT, `${teamId}-${Date.now()}`);
+  await fsAsync.mkdir(archiveRoot(), { recursive: true });
+  const archivedTo = join(archiveRoot(), `${teamId}-${Date.now()}`);
   await fsAsync.rename(stateDir, archivedTo);
 
   runtimes.delete(teamId);

--- a/packages/canvas-cli/src/core/team.ts
+++ b/packages/canvas-cli/src/core/team.ts
@@ -1,0 +1,224 @@
+/**
+ * Team operations — file-backed agent team coordination on top of
+ * `~/.pulse-coder/teams/{teamId}/`.
+ *
+ * The directory layout deliberately mirrors `pulse-coder-agent-teams`'s
+ * own `Team` class so that future in-process teammates (added in v2+) can
+ * share the same on-disk protocol. We only reuse the two leaf primitives —
+ * `TaskList` (tasks/tasks.json + lock) and `Mailbox` (mailbox/*.json) —
+ * because those are pure file IO, language- and process-agnostic. The
+ * `Team` / `TeamLead` / `Teammate` classes from that package assume
+ * in-process Engine instances, which doesn't match canvas (PTY CLIs).
+ *
+ * Style note: this module exports plain functions to match the rest of
+ * `canvas-cli/core/`. State (live `TaskList` / `Mailbox` instances) lives
+ * in a module-private cache because both classes wrap a stateful directory
+ * handle and re-instantiating them on every call would bypass their
+ * write-lock retry counters.
+ */
+import { promises as fsAsync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import { randomUUID } from 'crypto';
+import { Mailbox, TaskList } from 'pulse-coder-agent-teams';
+
+const TEAMS_ROOT = join(homedir(), '.pulse-coder', 'teams');
+const ARCHIVE_ROOT = join(homedir(), '.pulse-coder', 'teams-archive');
+
+/**
+ * Persisted team metadata. Stored at `{stateDir}/config.json`.
+ *
+ * The shape is intentionally close to `pulse-coder-agent-teams`'s
+ * `PersistedTeamConfig` so the two protocols stay aligned, with a
+ * `workspaceId` field added for canvas's per-workspace listings.
+ */
+export interface TeamConfigFile {
+  teamId: string;
+  teamName: string;
+  workspaceId: string;
+  createdAt: number;
+  members: TeamMemberRecord[];
+  /** memberId of the current lead, if any. Stored separately from
+   *  `members[].isLead` so leadership can be rotated without rewriting
+   *  the full member array. */
+  leadMemberId?: string;
+}
+
+export interface TeamMemberRecord {
+  memberId: string;
+  /** Canvas node id of the agent — links a mailbox file back to a
+   *  picture-on-the-canvas. */
+  nodeId: string;
+  /** "claude-code" | "codex" | "pulse-coder" */
+  agentType: string;
+  isLead: boolean;
+  joinedAt: number;
+}
+
+export interface TeamRuntime {
+  config: TeamConfigFile;
+  taskList: TaskList;
+  mailbox: Mailbox;
+  stateDir: string;
+}
+
+interface CreateTeamArgs {
+  workspaceId: string;
+  teamName: string;
+}
+
+interface AddMemberArgs {
+  nodeId: string;
+  agentType: string;
+  isLead?: boolean;
+}
+
+const runtimes = new Map<string, TeamRuntime>();
+
+/** Brand-new team. Generates a UUID and persists an empty config + the
+ *  TaskList / Mailbox bootstrap files. */
+export function createTeam(args: CreateTeamArgs): TeamRuntime {
+  const teamId = randomUUID();
+  const stateDir = join(TEAMS_ROOT, teamId);
+  mkdirSync(stateDir, { recursive: true });
+
+  const config: TeamConfigFile = {
+    teamId,
+    teamName: args.teamName,
+    workspaceId: args.workspaceId,
+    createdAt: Date.now(),
+    members: [],
+  };
+  writeConfig(stateDir, config);
+
+  const runtime: TeamRuntime = {
+    config,
+    stateDir,
+    taskList: new TaskList(stateDir),
+    mailbox: new Mailbox(stateDir),
+  };
+  runtimes.set(teamId, runtime);
+  return runtime;
+}
+
+/** Look up an existing team. Hydrates from disk on cache miss. Returns
+ *  `null` when the state directory is gone (destroyed or never existed). */
+export function getTeam(teamId: string): TeamRuntime | null {
+  const cached = runtimes.get(teamId);
+  if (cached) return cached;
+
+  const stateDir = join(TEAMS_ROOT, teamId);
+  if (!existsSync(stateDir)) return null;
+
+  const config = readConfig(stateDir);
+  if (!config) return null;
+
+  const runtime: TeamRuntime = {
+    config,
+    stateDir,
+    taskList: new TaskList(stateDir),
+    mailbox: new Mailbox(stateDir),
+  };
+  runtimes.set(teamId, runtime);
+  return runtime;
+}
+
+/** All teams scoped to a workspace. Always reads disk so listings stay
+ *  fresh after restarts. */
+export async function listTeams(workspaceId: string): Promise<TeamConfigFile[]> {
+  if (!existsSync(TEAMS_ROOT)) return [];
+  const entries = await fsAsync.readdir(TEAMS_ROOT, { withFileTypes: true });
+  const out: TeamConfigFile[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const config = readConfig(join(TEAMS_ROOT, entry.name));
+    if (config && config.workspaceId === workspaceId) out.push(config);
+  }
+  return out;
+}
+
+/** Register a member. Caller is responsible for creating the actual
+ *  canvas agent node and stamping the matching `teamMembership` field on
+ *  it; this function only updates the team's config.json. */
+export function addMember(teamId: string, args: AddMemberArgs): TeamMemberRecord | null {
+  const runtime = getTeam(teamId);
+  if (!runtime) return null;
+
+  // Counter-based memberId (rather than UUID) keeps mailbox file
+  // listings ordered and human-readable when debugging.
+  const nextIdx = runtime.config.members.length + 1;
+  const memberId = `${teamId}-m${nextIdx}`;
+
+  const record: TeamMemberRecord = {
+    memberId,
+    nodeId: args.nodeId,
+    agentType: args.agentType,
+    isLead: args.isLead === true,
+    joinedAt: Date.now(),
+  };
+  runtime.config.members.push(record);
+  if (record.isLead) runtime.config.leadMemberId = memberId;
+  writeConfig(runtime.stateDir, runtime.config);
+  return record;
+}
+
+/** Confirm a memberId actually belongs to a team. Used by every
+ *  `--member-id`-taking subcommand to reject cross-team requests where
+ *  one team's member tries to act on another team's mailbox. */
+export function hasMember(teamId: string, memberId: string): boolean {
+  const runtime = getTeam(teamId);
+  if (!runtime) return false;
+  return runtime.config.members.some((m) => m.memberId === memberId);
+}
+
+/** Find the member backing a canvas node id. Useful when only the PTY
+ *  node is known (e.g. when an agent's PTY exits and we need to figure
+ *  out which team to notify). */
+export function findMemberByNodeId(teamId: string, nodeId: string): TeamMemberRecord | null {
+  const runtime = getTeam(teamId);
+  if (!runtime) return null;
+  return runtime.config.members.find((m) => m.nodeId === nodeId) ?? null;
+}
+
+/** Tear down a team: rename its state dir into the archive root and drop
+ *  the in-memory cache entry. Caller is responsible for closing PTYs and
+ *  removing canvas nodes. */
+export async function destroyTeam(teamId: string): Promise<{ archivedTo: string } | null> {
+  const cached = runtimes.get(teamId);
+  const stateDir = cached?.stateDir ?? join(TEAMS_ROOT, teamId);
+  if (!existsSync(stateDir)) return null;
+
+  await fsAsync.mkdir(ARCHIVE_ROOT, { recursive: true });
+  const archivedTo = join(ARCHIVE_ROOT, `${teamId}-${Date.now()}`);
+  await fsAsync.rename(stateDir, archivedTo);
+
+  runtimes.delete(teamId);
+  return { archivedTo };
+}
+
+/** Test-only: drop the runtime cache. Production callers should never
+ *  need this — getTeam re-hydrates on demand. */
+export function _resetTeamCache(): void {
+  runtimes.clear();
+}
+
+// ─── Internal config helpers ──────────────────────────────────────────
+
+function configPath(stateDir: string): string {
+  return join(stateDir, 'config.json');
+}
+
+function writeConfig(stateDir: string, config: TeamConfigFile): void {
+  writeFileSync(configPath(stateDir), JSON.stringify(config, null, 2), 'utf-8');
+}
+
+function readConfig(stateDir: string): TeamConfigFile | null {
+  const path = configPath(stateDir);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as TeamConfigFile;
+  } catch {
+    return null;
+  }
+}

--- a/packages/canvas-cli/tsconfig.json
+++ b/packages/canvas-cli/tsconfig.json
@@ -2,8 +2,12 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
-    "types": ["node"]
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "pulse-coder-agent-teams": ["../agent-teams/dist/index.d.ts"],
+      "pulse-coder-agent-teams/*": ["../agent-teams/dist/*"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts", "**/*.spec.ts"]

--- a/packages/canvas-cli/tsup.config.ts
+++ b/packages/canvas-cli/tsup.config.ts
@@ -1,17 +1,33 @@
 import { defineConfig } from 'tsup';
 
-export default defineConfig({
-  entry: {
-    index: 'src/index.ts',
-    'core/index': 'src/core/index.ts',
+export default defineConfig([
+  // CLI binary entry — only ever loaded by Node as CJS via the bin
+  // shebang. Keeping this CJS-only avoids dual-package hazards on the
+  // commander / dotenv stack.
+  {
+    entry: { index: 'src/index.ts' },
+    format: ['cjs'],
+    dts: true,
+    clean: true,
+    splitting: false,
+    sourcemap: true,
+    target: 'es2022',
+    platform: 'node',
+    banner: { js: '#!/usr/bin/env node' },
+    outExtension: () => ({ js: '.cjs' }),
   },
-  format: ['cjs'],
-  dts: true,
-  clean: true,
-  splitting: false,
-  sourcemap: true,
-  target: 'es2022',
-  platform: 'node',
-  banner: { js: '#!/usr/bin/env node' },
-  outExtension: () => ({ js: '.cjs' }),
-});
+  // Library entry — consumed by canvas-workspace's Electron main process
+  // (ESM) and by anything else that wants to import team primitives.
+  // Build BOTH .cjs and .mjs so each importer picks the right one via
+  // the conditional `exports` map in package.json.
+  {
+    entry: { 'core/index': 'src/core/index.ts' },
+    format: ['cjs', 'esm'],
+    dts: true,
+    splitting: false,
+    sourcemap: true,
+    target: 'es2022',
+    platform: 'node',
+    outExtension: ({ format }) => ({ js: format === 'esm' ? '.mjs' : '.cjs' }),
+  },
+]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^3.0.21
         version: 3.0.21(zod@4.3.6)
+      '@pulse-coder/canvas-cli':
+        specifier: workspace:*
+        version: link:../../packages/canvas-cli
       '@tiptap/extension-bubble-menu':
         specifier: ^3.20.4
         version: 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0
+      pulse-coder-agent-teams:
+        specifier: workspace:*
+        version: link:../../packages/agent-teams
       pulse-coder-engine:
         specifier: workspace:*
         version: link:../../packages/engine
@@ -262,6 +265,9 @@ importers:
       commander:
         specifier: ^13.0.0
         version: 13.1.0
+      pulse-coder-agent-teams:
+        specifier: workspace:*
+        version: link:../agent-teams
     devDependencies:
       '@types/node':
         specifier: ^25.0.10


### PR DESCRIPTION
## Summary

Brings Claude Code-style **Agent Teams** to canvas-workspace, working across all three supported CLIs (claude-code / codex / pulse-coder). Lead + N teammates coordinate through a shared file-backed task list and mailbox under \`~/.pulse-coder/teams/{teamId}/\`, all visualised on the canvas as a Team Frame containing \`👑\` lead + \`·\` teammate agent nodes.

- **CLI primitives** (\`packages/canvas-cli\`): new \`pulse-canvas team\` subcommand group (10 commands) reusing \`TaskList\` + \`Mailbox\` from \`pulse-coder-agent-teams\`. 13 vitest integration tests; cross-team membership validation prevents one team's lead from poking another team's mailbox.
- **Canvas integration** (\`apps/canvas-workspace\`): \`canvas_create_team\` tool spawns the frame + agents + persistent state in one call; injects \`PULSE_TEAM_*\` env vars into each agent's prompt; auto-derives \`tasks.md\` from \`tasks.json\` via \`fs.watch\`; team frames render with double outline + emoji badges; close-button on a team frame triggers a confirm-and-disband flow that kills PTYs and archives state.
- **Skills** (\`packages/canvas-cli/skills/team/SKILL.md\`): teaches lead/teammate agents the loop (msg read → task claim → do work → task complete). Auto-installed alongside the canvas SKILL into \`~/.pulse-coder\`, \`~/.claude\`, \`~/.codex\`.
- **Unattended execution**: team-spawned agents get \`--permission-mode bypassPermissions\` (claude) / \`--full-auto\` (codex) so the coordination loop isn't blocked by per-tool prompts. Manual picker-created agents are unaffected.
- **Docs**: PRD + tech design under \`apps/canvas-workspace/docs/agent-teams/\` cover architecture, multi-team isolation, cross-agent compatibility, and remaining MVP work.

## Architecture

\`\`\`
Chat Panel (in-process Engine)
       │ canvas_create_team
       ▼
Team Frame (FrameNodeData.teamMeta = { teamId, leadNodeId, stateDir })
       │
       ├── 👑 Lead Agent Node    (agent PTY: claude-code / pulse-coder)
       └── · Teammate Agent Nodes (agent PTY × N)
       │
       │ all use bash → \`pulse-canvas team task|msg ...\`
       ▼
~/.pulse-coder/teams/{teamId}/
       ├── config.json    (members, lead, workspaceId)
       ├── tasks/tasks.json + tasks.lock   ← reused TaskList
       ├── tasks.md  (auto-derived view)
       └── mailbox/{memberId}.json         ← reused Mailbox
\`\`\`

Multi-team isolation: every CLI subcommand is teamId-scoped and validates \`--member-id\` against \`config.json\`. \`teamId\` is independent of \`frame.id\` so copying/moving the frame doesn't disturb state.

## Test plan

Static / unit:
- [x] \`pnpm --filter @pulse-coder/canvas-cli test\` — 68 tests pass (13 new in \`commands/__tests__/team.test.ts\`)
- [x] \`pnpm --filter pulse-coder-agent-teams test\` — 58 tests pass (upstream)
- [x] \`pnpm --filter canvas-workspace typecheck\` — clean
- [x] \`pnpm --filter @pulse-coder/canvas-cli build\` — emits both CJS (CLI bin) and ESM+CJS (\`./core\` consumer entry)

End-to-end (manual):
- [x] Off-app simulation script: createTeam + addMember + watcher + tasks.md derivation + mailbox round-trip — all assertions green
- [x] \`electron-vite dev\` boots cleanly with team-ipc + markdown watcher wired in
- [ ] **In-app demo (REQUIRES REVIEWER)**: Chat panel → "create a team to research three ORMs" → observe frame + 1 lead + 3 teammates spawn, lead creates tasks, teammates auto-claim, tasks.md updates live, disband button cleans everything up. Real-LLM coordination quality is the only thing automated tests can't cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)