### PR TITLE
feat(canvas-workspace): 节点内交互增强 + 全局 UX 优化

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -1,11 +1,14 @@
-import { useCallback, useState, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation } from 'wouter';
 import './App.css';
 import { Canvas } from './components/Canvas';
+import { AppShellProvider, useAppShell } from './components/AppShellProvider';
 import { ChatPage, ChatPanel } from './components/chat';
 import { Sidebar } from './components/Sidebar';
 import { useWorkspaces } from './hooks/useWorkspaces';
+import { parseCanvasLocation } from './utils/canvasLinks';
 import type { CanvasNode } from './types';
+import type { CanvasNodeRenameRequest } from './types/ui-interaction';
 
 const DEFAULT_CHAT_WIDTH = 420;
 const MIN_CHAT_WIDTH = 280;
@@ -16,9 +19,16 @@ const ROUTE_CHAT = '/chat';
 
 type ActiveView = 'canvas' | 'chat';
 
-const App = () => {
+const AppContent = () => {
   const [location, setLocation] = useLocation();
-  const activeView: ActiveView = location === ROUTE_CHAT ? 'chat' : 'canvas';
+  const { path: routePath, params: routeParams } = useMemo(
+    () => parseCanvasLocation(location),
+    [location],
+  );
+  const activeView: ActiveView = routePath === ROUTE_CHAT ? 'chat' : 'canvas';
+  const routeQuery = routeParams.toString();
+
+  const { notify, updateToast, confirm, openShortcuts, isOverlayOpen } = useAppShell();
 
   const [sidebarCollapsed, setSidebarCollapsed] = useState(true);
   const [chatPanelOpen, setChatPanelOpen] = useState(false);
@@ -26,10 +36,11 @@ const App = () => {
   const [allNodes, setAllNodes] = useState<Record<string, CanvasNode[]>>({});
   const [focusNodeId, setFocusNodeId] = useState<string | undefined>();
   const [deleteNodeId, setDeleteNodeId] = useState<string | undefined>();
+  const [renameNodeRequest, setRenameNodeRequest] = useState<CanvasNodeRenameRequest | undefined>();
   const resizing = useRef(false);
 
   const handleNodesChange = useCallback((canvasId: string, nodes: CanvasNode[]) => {
-    setAllNodes(prev => {
+    setAllNodes((prev) => {
       if (prev[canvasId] === nodes) return prev;
       return { ...prev, [canvasId]: nodes };
     });
@@ -38,9 +49,15 @@ const App = () => {
   const handleFocusComplete = useCallback(() => {
     setFocusNodeId(undefined);
   }, []);
+
   const handleDeleteComplete = useCallback(() => {
     setDeleteNodeId(undefined);
   }, []);
+
+  const handleRenameComplete = useCallback(() => {
+    setRenameNodeRequest(undefined);
+  }, []);
+
   const {
     workspaces,
     folders,
@@ -58,9 +75,24 @@ const App = () => {
     reorderFolder,
   } = useWorkspaces();
 
+  useEffect(() => {
+    if (!routeQuery) return;
+
+    const targetWorkspaceId = routeParams.get('workspaceId') ?? activeId;
+    const targetNodeId = routeParams.get('nodeId');
+    if (!targetWorkspaceId) return;
+    if (!workspaces.some((workspace) => workspace.id === targetWorkspaceId)) return;
+
+    if (activeId !== targetWorkspaceId) {
+      selectWorkspace(targetWorkspaceId);
+    }
+    if (targetNodeId) {
+      setFocusNodeId(targetNodeId);
+    }
+    setLocation(ROUTE_CANVAS);
+  }, [routeQuery, routeParams, activeId, workspaces, selectWorkspace, setLocation]);
+
   const enterChatView = useCallback(() => {
-    // When entering the full-screen page, also close the right-side panel so
-    // only one ChatView instance (and one set of IPC subscriptions) is live.
     setChatPanelOpen(false);
     setLocation(ROUTE_CHAT);
   }, [setLocation]);
@@ -69,26 +101,142 @@ const App = () => {
     setLocation(ROUTE_CANVAS);
   }, [setLocation]);
 
-  // Selecting a workspace from the sidebar also routes back to the canvas.
-  // This is the only Canvas affordance in the expanded sidebar (the explicit
-  // Canvas nav entry was intentionally removed).
   const handleSelectWorkspace = useCallback((id: string) => {
     selectWorkspace(id);
     setLocation(ROUTE_CANVAS);
   }, [selectWorkspace, setLocation]);
 
-  // Keyboard shortcuts:
-  //   Cmd/Ctrl+Shift+A → toggle right-side chat panel (canvas view only)
-  //   Cmd/Ctrl+Shift+L → toggle full-screen chat page
-  //   Esc (while on chat page) → return to canvas
+  const handleCreateWorkspace = useCallback((name: string) => {
+    const trimmed = name.trim() || 'Untitled';
+    const id = createWorkspace(name);
+    notify({
+      tone: 'success',
+      title: 'Workspace created',
+      description: trimmed,
+    });
+    return id;
+  }, [createWorkspace, notify]);
+
+  const handleRenameWorkspace = useCallback((id: string, name: string) => {
+    const workspace = workspaces.find((item) => item.id === id);
+    const trimmed = name.trim();
+    if (!workspace || !trimmed || workspace.name === trimmed) return;
+    renameWorkspace(id, trimmed);
+    notify({
+      tone: 'success',
+      title: 'Workspace renamed',
+      description: `${workspace.name} -> ${trimmed}`,
+    });
+  }, [workspaces, renameWorkspace, notify]);
+
+  const handleDeleteWorkspace = useCallback(async (id: string) => {
+    const workspace = workspaces.find((item) => item.id === id);
+    if (!workspace) return;
+
+    const accepted = await confirm({
+      intent: 'danger',
+      title: `Delete "${workspace.name}"?`,
+      description: 'This removes the workspace canvas and its saved workspace directory from disk. This action cannot be undone.',
+      confirmLabel: 'Delete workspace',
+    });
+    if (!accepted) return;
+
+    const toastId = notify({
+      tone: 'loading',
+      title: `Deleting ${workspace.name}...`,
+      description: 'Removing workspace data and saved canvas state.',
+    });
+
+    const result = await deleteWorkspace(id);
+    if (!result.ok) {
+      updateToast(toastId, {
+        tone: 'error',
+        title: 'Workspace deletion failed',
+        description: result.error ?? 'The workspace could not be deleted.',
+        autoCloseMs: 4200,
+      });
+      return;
+    }
+
+    updateToast(toastId, {
+      tone: 'success',
+      title: 'Workspace deleted',
+      description: workspace.name,
+      autoCloseMs: 2400,
+    });
+  }, [workspaces, confirm, notify, updateToast, deleteWorkspace]);
+
+  const handleCreateFolder = useCallback((name: string) => {
+    const trimmed = name.trim() || 'Untitled Folder';
+    const id = createFolder(name);
+    notify({
+      tone: 'success',
+      title: 'Folder created',
+      description: trimmed,
+    });
+    return id;
+  }, [createFolder, notify]);
+
+  const handleRenameFolder = useCallback((id: string, name: string) => {
+    const folder = folders.find((item) => item.id === id);
+    const trimmed = name.trim();
+    if (!folder || !trimmed || folder.name === trimmed) return;
+    renameFolder(id, trimmed);
+    notify({
+      tone: 'success',
+      title: 'Folder renamed',
+      description: `${folder.name} -> ${trimmed}`,
+    });
+  }, [folders, renameFolder, notify]);
+
+  const handleDeleteFolder = useCallback(async (id: string) => {
+    const folder = folders.find((item) => item.id === id);
+    if (!folder) return;
+
+    const accepted = await confirm({
+      intent: 'danger',
+      title: `Delete folder "${folder.name}"?`,
+      description: 'The folder will be removed and its workspaces will move back to the root list.',
+      confirmLabel: 'Delete folder',
+    });
+    if (!accepted) return;
+
+    deleteFolder(id);
+    notify({
+      tone: 'success',
+      title: 'Folder deleted',
+      description: `${folder.name} was removed. Nested workspaces were kept.`,
+    });
+  }, [folders, confirm, deleteFolder, notify]);
+
+  const handleNodeRename = useCallback((nodeId: string, title: string) => {
+    setRenameNodeRequest({ workspaceId: activeId, nodeId, title });
+  }, [activeId]);
+
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      const isEditable = Boolean(target) && (
+        target?.tagName === 'INPUT' ||
+        target?.tagName === 'TEXTAREA' ||
+        target?.isContentEditable
+      );
+
+      if (isOverlayOpen) return;
+
+      if (!isEditable && (e.key === '?' || (e.shiftKey && e.key === '/'))) {
+        e.preventDefault();
+        openShortcuts();
+        return;
+      }
+
       if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'a') {
         if (activeView !== 'canvas') return;
         e.preventDefault();
-        setChatPanelOpen(prev => !prev);
+        setChatPanelOpen((prev) => !prev);
         return;
       }
+
       if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'l') {
         e.preventDefault();
         if (activeView === 'chat') {
@@ -99,17 +247,15 @@ const App = () => {
         }
         return;
       }
-      if (e.key === 'Escape' && activeView === 'chat') {
-        // Don't swallow Esc if the user is typing in a text field (mention popup, etc.)
-        const target = e.target as HTMLElement | null;
-        const tag = target?.tagName;
-        if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
+
+      if (e.key === 'Escape' && activeView === 'chat' && !isEditable) {
         setLocation(ROUTE_CANVAS);
       }
     };
+
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [activeView, setLocation]);
+  }, [activeView, isOverlayOpen, openShortcuts, setLocation]);
 
   const handleResizeStart = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -137,7 +283,6 @@ const App = () => {
     document.addEventListener('mouseup', onMouseUp);
   }, [chatWidth]);
 
-  // Jumping to a node from the chat page: focus it AND return to canvas.
   const handleNodeFocusFromChatPage = useCallback((nodeId: string) => {
     setFocusNodeId(nodeId);
     setLocation(ROUTE_CANVAS);
@@ -150,24 +295,25 @@ const App = () => {
       <div className="app-body">
         <Sidebar
           collapsed={sidebarCollapsed}
-          onToggle={() => setSidebarCollapsed((c) => !c)}
+          onToggle={() => setSidebarCollapsed((collapsed) => !collapsed)}
           workspaces={workspaces}
           folders={folders}
           activeId={activeId}
           onSelect={handleSelectWorkspace}
-          onCreate={createWorkspace}
-          onRename={renameWorkspace}
-          onDelete={deleteWorkspace}
+          onCreate={handleCreateWorkspace}
+          onRename={handleRenameWorkspace}
+          onDelete={handleDeleteWorkspace}
           onSetRootFolder={setRootFolder}
-          onCreateFolder={createFolder}
-          onRenameFolder={renameFolder}
-          onDeleteFolder={deleteFolder}
+          onCreateFolder={handleCreateFolder}
+          onRenameFolder={handleRenameFolder}
+          onDeleteFolder={handleDeleteFolder}
           onToggleFolder={toggleFolder}
           onMoveWorkspace={moveWorkspace}
           onReorderFolder={reorderFolder}
           activeNodes={allNodes[activeId] || []}
           onNodeFocus={setFocusNodeId}
           onNodeDelete={setDeleteNodeId}
+          onNodeRename={handleNodeRename}
           activeView={activeView}
           onEnterChat={enterChatView}
           onExitChat={exitChatView}
@@ -187,8 +333,10 @@ const App = () => {
                   onFocusComplete={handleFocusComplete}
                   deleteNodeId={ws.id === activeId ? deleteNodeId : undefined}
                   onDeleteComplete={handleDeleteComplete}
+                  renameRequest={ws.id === renameNodeRequest?.workspaceId ? renameNodeRequest : undefined}
+                  onRenameComplete={handleRenameComplete}
                   chatPanelOpen={chatPanelOpen}
-                  onChatToggle={() => setChatPanelOpen(prev => !prev)}
+                  onChatToggle={() => setChatPanelOpen((prev) => !prev)}
                 />
               ))}
             </div>
@@ -226,5 +374,11 @@ const App = () => {
     </div>
   );
 };
+
+const App = () => (
+  <AppShellProvider>
+    <AppContent />
+  </AppShellProvider>
+);
 
 export default App;

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTerminal.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTerminal.tsx
@@ -4,15 +4,63 @@ interface AgentTerminalProps {
   containerRef: React.RefObject<HTMLDivElement>;
   status: string;
   onRestart: () => void;
+  onStop?: () => void;
+  onSendPrompt?: (prompt: string) => void;
 }
 
-export const AgentTerminal = ({ containerRef, status, onRestart }: AgentTerminalProps) => (
+const CONTINUE_PROMPT = 'continue';
+const SUMMARIZE_PROMPT = 'please summarize what you have done so far';
+
+export const AgentTerminal = ({
+  containerRef,
+  status,
+  onRestart,
+  onStop,
+  onSendPrompt,
+}: AgentTerminalProps) => (
   <div className="agent-body-wrap">
     <div
       ref={containerRef}
       className="agent-xterm-container"
       onMouseDown={(e) => e.stopPropagation()}
     />
+    {status === 'running' && (
+      <div className="agent-quick-actions">
+        <button
+          type="button"
+          className="agent-quick-btn"
+          onClick={() => onSendPrompt?.(CONTINUE_PROMPT)}
+          title="Send 'continue' to agent"
+        >
+          <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
+            <path d="M5 3l6 5-6 5V3z" fill="currentColor" />
+          </svg>
+          Continue
+        </button>
+        <button
+          type="button"
+          className="agent-quick-btn"
+          onClick={() => onSendPrompt?.(SUMMARIZE_PROMPT)}
+          title="Ask agent to summarize"
+        >
+          <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
+            <path d="M3 4h10M3 7.5h7M3 11h5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+          </svg>
+          Summarize
+        </button>
+        <button
+          type="button"
+          className="agent-quick-btn agent-quick-btn--stop"
+          onClick={onStop}
+          title="Stop agent"
+        >
+          <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
+            <rect x="3" y="3" width="10" height="10" rx="1.5" fill="currentColor" />
+          </svg>
+          Stop
+        </button>
+      </div>
+    )}
     {(status === 'done' || status === 'error') && (
       <button
         type="button"

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
@@ -285,6 +285,54 @@
   padding: 0 4px;
 }
 
+/* ── Quick action buttons (running state) ── */
+
+.agent-quick-actions {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  z-index: 10;
+  display: flex;
+  gap: 4px;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.agent-body-wrap:hover .agent-quick-actions {
+  opacity: 1;
+}
+
+.agent-quick-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 9px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 500;
+  font-family: var(--font);
+  cursor: pointer;
+  box-shadow: var(--shadow-sm);
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
+}
+
+.agent-quick-btn:hover {
+  background: var(--surface);
+  border-color: var(--text-muted);
+  color: var(--text);
+}
+
+.agent-quick-btn--stop:hover {
+  background: rgba(224, 62, 62, 0.08);
+  border-color: #e03e3e;
+  color: #e03e3e;
+}
+
 /* ── Restart button (top-right of running body) ── */
 
 .agent-restart-btn {

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -316,6 +316,20 @@ export const AgentNodeBody = ({ node, rootFolder, workspaceId, onUpdate }: Props
     setLaunched(true);
   }, [selectedAgent, cwdInput, promptInput, rootFolder]);
 
+  const handleStop = useCallback(() => {
+    const api = window.canvasWorkspace?.pty;
+    if (api) api.kill(sessionId);
+    onUpdateRef.current(nodeIdRef.current, {
+      data: { ...dataRef.current, status: 'done' },
+    });
+  }, [sessionId]);
+
+  const handleSendPrompt = useCallback((prompt: string) => {
+    const api = window.canvasWorkspace?.pty;
+    if (!api) return;
+    api.write(sessionId, `\n${prompt}\n`);
+  }, [sessionId]);
+
   const handleRestart = useCallback(() => {
     if (saveTimerRef.current) clearInterval(saveTimerRef.current);
     cleanupRef.current?.();
@@ -368,6 +382,8 @@ export const AgentNodeBody = ({ node, rootFolder, workspaceId, onUpdate }: Props
       containerRef={containerRef}
       status={status}
       onRestart={handleRestart}
+      onStop={handleStop}
+      onSendPrompt={handleSendPrompt}
     />
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/components/AppShellProvider/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AppShellProvider/index.css
@@ -1,0 +1,343 @@
+.shell-toast-region {
+  position: fixed;
+  top: 18px;
+  right: 18px;
+  z-index: 2100;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: min(360px, calc(100vw - 32px));
+  pointer-events: none;
+}
+
+.shell-toast {
+  pointer-events: auto;
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) 20px;
+  gap: 10px;
+  align-items: start;
+  padding: 12px 12px 12px 10px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: var(--shadow-float);
+  backdrop-filter: blur(14px);
+  animation: shellToastAppear 0.16s ease;
+}
+
+.shell-toast--success {
+  border-color: rgba(31, 122, 77, 0.18);
+}
+
+.shell-toast--error {
+  border-color: rgba(192, 57, 43, 0.18);
+}
+
+.shell-toast--loading {
+  border-color: rgba(35, 131, 226, 0.18);
+}
+
+.shell-toast__icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent);
+  background: rgba(35, 131, 226, 0.1);
+}
+
+.shell-toast--success .shell-toast__icon {
+  color: var(--success);
+  background: rgba(31, 122, 77, 0.12);
+}
+
+.shell-toast--error .shell-toast__icon {
+  color: var(--error);
+  background: rgba(192, 57, 43, 0.12);
+}
+
+.shell-toast__body {
+  min-width: 0;
+}
+
+.shell-toast__title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.shell-toast__description {
+  margin-top: 2px;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text-secondary);
+}
+
+.shell-toast__close {
+  width: 20px;
+  height: 20px;
+  border: none;
+  background: transparent;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--text-muted);
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.shell-toast__close:hover {
+  color: var(--text-secondary);
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.shell-spinner {
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  border: 1.6px solid rgba(35, 131, 226, 0.22);
+  border-top-color: currentColor;
+  animation: shellSpin 0.7s linear infinite;
+}
+
+.shell-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 2050;
+  background: var(--overlay-backdrop);
+  backdrop-filter: blur(6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.shell-dialog {
+  width: min(520px, 100%);
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 24px 72px rgba(28, 29, 32, 0.18);
+  animation: shellDialogAppear 0.18s ease;
+}
+
+.shell-dialog--wide {
+  width: min(760px, 100%);
+}
+
+.shell-dialog__header {
+  padding: 18px 20px 10px;
+}
+
+.shell-dialog__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  margin-bottom: 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.shell-dialog__eyebrow--danger {
+  color: var(--error);
+  background: rgba(192, 57, 43, 0.1);
+}
+
+.shell-dialog__title {
+  font-size: 18px;
+  line-height: 1.2;
+  color: var(--text);
+}
+
+.shell-dialog__description {
+  padding: 0 20px 18px;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.shell-dialog__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 14px 20px 20px;
+  border-top: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.shell-dialog__button {
+  min-width: 92px;
+  height: 36px;
+  padding: 0 14px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  transition: background 0.12s ease, border-color 0.12s ease, transform 0.12s ease;
+}
+
+.shell-dialog__button:hover {
+  background: var(--surface-hover);
+}
+
+.shell-dialog__button:active {
+  transform: translateY(1px);
+}
+
+.shell-dialog__button--danger {
+  border-color: rgba(192, 57, 43, 0.2);
+  background: var(--error);
+  color: #ffffff;
+}
+
+.shell-dialog__button--danger:hover {
+  background: #b33628;
+}
+
+.shell-dialog__button--primary {
+  border-color: rgba(35, 131, 226, 0.2);
+  background: var(--accent);
+  color: #ffffff;
+}
+
+.shell-dialog__button--primary:hover {
+  background: #1d73c8;
+}
+
+.shell-shortcuts {
+  padding: 0 20px 20px;
+}
+
+.shell-shortcuts__intro {
+  padding: 0 20px 18px;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.shell-shortcuts__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 12px;
+}
+
+.shell-shortcuts__section {
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(247, 245, 241, 0.98));
+  padding: 14px;
+}
+
+.shell-shortcuts__section-title {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 12px;
+}
+
+.shell-shortcuts__list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.shell-shortcuts__item {
+  display: grid;
+  grid-template-columns: minmax(0, auto) minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+}
+
+.shell-shortcuts__combo {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.shell-shortcuts__key {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 26px;
+  padding: 0 8px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-bottom-width: 2px;
+  border-radius: 8px;
+  background: #ffffff;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text);
+  white-space: nowrap;
+}
+
+.shell-shortcuts__item-description {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+@media (max-width: 720px) {
+  .shell-dialog-backdrop {
+    align-items: flex-end;
+    padding: 12px;
+  }
+
+  .shell-dialog,
+  .shell-dialog--wide {
+    width: 100%;
+    border-radius: 18px 18px 14px 14px;
+  }
+
+  .shell-toast-region {
+    left: 12px;
+    right: 12px;
+    width: auto;
+  }
+
+  .shell-shortcuts__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@keyframes shellSpin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes shellToastAppear {
+  from {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes shellDialogAppear {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}

--- a/apps/canvas-workspace/src/renderer/src/components/AppShellProvider/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AppShellProvider/index.tsx
@@ -1,0 +1,342 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { DEFAULT_TOAST_DURATION_MS, SHORTCUT_SECTIONS } from '../../constants/interaction';
+import type { ConfirmOptions, ToastInput, ToastRecord } from '../../types/ui-interaction';
+import './index.css';
+
+interface AppShellContextValue {
+  notify: (toast: ToastInput) => string;
+  updateToast: (id: string, patch: Partial<Omit<ToastRecord, 'id' | 'createdAt'>>) => void;
+  dismissToast: (id: string) => void;
+  confirm: (options: ConfirmOptions) => Promise<boolean>;
+  openShortcuts: () => void;
+  closeShortcuts: () => void;
+  shortcutsOpen: boolean;
+  isOverlayOpen: boolean;
+}
+
+const AppShellContext = createContext<AppShellContextValue | null>(null);
+
+export const AppShellProvider = ({ children }: { children: ReactNode }) => {
+  const [toasts, setToasts] = useState<ToastRecord[]>([]);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const [confirmState, setConfirmState] = useState<ConfirmOptions | null>(null);
+  const confirmResolverRef = useRef<((value: boolean) => void) | null>(null);
+  const toastCounterRef = useRef(0);
+  const toastTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const dismissToast = useCallback((id: string) => {
+    const timer = toastTimersRef.current.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      toastTimersRef.current.delete(id);
+    }
+    setToasts((prev) => prev.filter((toast) => toast.id !== id));
+  }, []);
+
+  const scheduleDismiss = useCallback((id: string, autoCloseMs?: number) => {
+    const existing = toastTimersRef.current.get(id);
+    if (existing) {
+      clearTimeout(existing);
+      toastTimersRef.current.delete(id);
+    }
+
+    if (!autoCloseMs || autoCloseMs <= 0) return;
+
+    const timer = setTimeout(() => {
+      dismissToast(id);
+    }, autoCloseMs);
+    toastTimersRef.current.set(id, timer);
+  }, [dismissToast]);
+
+  const notify = useCallback((toast: ToastInput) => {
+    const id = `toast-${Date.now()}-${toastCounterRef.current++}`;
+    const autoCloseMs = toast.autoCloseMs ?? (toast.tone === 'loading' ? 0 : DEFAULT_TOAST_DURATION_MS);
+    const record: ToastRecord = {
+      id,
+      createdAt: Date.now(),
+      ...toast,
+      autoCloseMs,
+    };
+    setToasts((prev) => [...prev, record]);
+    scheduleDismiss(id, autoCloseMs);
+    return id;
+  }, [scheduleDismiss]);
+
+  const updateToast = useCallback((id: string, patch: Partial<Omit<ToastRecord, 'id' | 'createdAt'>>) => {
+    setToasts((prev) => prev.map((toast) => (
+      toast.id === id
+        ? { ...toast, ...patch }
+        : toast
+    )));
+    if (Object.prototype.hasOwnProperty.call(patch, 'autoCloseMs')) {
+      scheduleDismiss(id, patch.autoCloseMs);
+    }
+  }, [scheduleDismiss]);
+
+  const confirm = useCallback((options: ConfirmOptions) => new Promise<boolean>((resolve) => {
+    if (confirmResolverRef.current) {
+      confirmResolverRef.current(false);
+    }
+    confirmResolverRef.current = resolve;
+    setConfirmState(options);
+  }), []);
+
+  const closeConfirm = useCallback((accepted: boolean) => {
+    setConfirmState(null);
+    const resolve = confirmResolverRef.current;
+    confirmResolverRef.current = null;
+    resolve?.(accepted);
+  }, []);
+
+  const openShortcuts = useCallback(() => {
+    setShortcutsOpen(true);
+  }, []);
+
+  const closeShortcuts = useCallback(() => {
+    setShortcutsOpen(false);
+  }, []);
+
+  useEffect(() => () => {
+    if (confirmResolverRef.current) {
+      confirmResolverRef.current(false);
+      confirmResolverRef.current = null;
+    }
+    for (const timer of toastTimersRef.current.values()) {
+      clearTimeout(timer);
+    }
+    toastTimersRef.current.clear();
+  }, []);
+
+  const isOverlayOpen = shortcutsOpen || Boolean(confirmState);
+
+  const value = useMemo<AppShellContextValue>(() => ({
+    notify,
+    updateToast,
+    dismissToast,
+    confirm,
+    openShortcuts,
+    closeShortcuts,
+    shortcutsOpen,
+    isOverlayOpen,
+  }), [notify, updateToast, dismissToast, confirm, openShortcuts, closeShortcuts, shortcutsOpen, isOverlayOpen]);
+
+  return (
+    <AppShellContext.Provider value={value}>
+      {children}
+      <ToastViewport toasts={toasts} onDismiss={dismissToast} />
+      {confirmState && (
+        <ConfirmDialog
+          options={confirmState}
+          onCancel={() => closeConfirm(false)}
+          onConfirm={() => closeConfirm(true)}
+        />
+      )}
+      {shortcutsOpen && (
+        <ShortcutsDialog onClose={closeShortcuts} />
+      )}
+    </AppShellContext.Provider>
+  );
+};
+
+export const useAppShell = (): AppShellContextValue => {
+  const context = useContext(AppShellContext);
+  if (!context) {
+    throw new Error('useAppShell must be used within AppShellProvider');
+  }
+  return context;
+};
+
+const ToastViewport = ({
+  toasts,
+  onDismiss,
+}: {
+  toasts: ToastRecord[];
+  onDismiss: (id: string) => void;
+}) => (
+  <div className="shell-toast-region" aria-live="polite" aria-atomic="true">
+    {toasts.map((toast) => (
+      <article key={toast.id} className={`shell-toast shell-toast--${toast.tone}`}>
+        <span className="shell-toast__icon" aria-hidden="true">
+          <ToastIcon tone={toast.tone} />
+        </span>
+        <div className="shell-toast__body">
+          <div className="shell-toast__title">{toast.title}</div>
+          {toast.description && (
+            <div className="shell-toast__description">{toast.description}</div>
+          )}
+        </div>
+        <button
+          type="button"
+          className="shell-toast__close"
+          aria-label="Dismiss notification"
+          onClick={() => onDismiss(toast.id)}
+        >
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <path d="M3 3l6 6M9 3l-6 6" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+          </svg>
+        </button>
+      </article>
+    ))}
+  </div>
+);
+
+const ToastIcon = ({ tone }: { tone: ToastRecord['tone'] }) => {
+  if (tone === 'loading') {
+    return <span className="shell-spinner" />;
+  }
+
+  if (tone === 'error') {
+    return (
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+        <circle cx="7" cy="7" r="5.5" stroke="currentColor" strokeWidth="1.2" />
+        <path d="M7 4.2v3.5M7 9.6h.01" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      </svg>
+    );
+  }
+
+  if (tone === 'success') {
+    return (
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+        <circle cx="7" cy="7" r="5.5" stroke="currentColor" strokeWidth="1.2" />
+        <path d="M4.2 7.2l1.8 1.8 3.8-4.1" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+      <circle cx="7" cy="7" r="5.5" stroke="currentColor" strokeWidth="1.2" />
+      <path d="M7 6.1v3M7 4.1h.01" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+};
+
+const ConfirmDialog = ({
+  options,
+  onCancel,
+  onConfirm,
+}: {
+  options: ConfirmOptions;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) => {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onCancel();
+        return;
+      }
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        onConfirm();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onCancel, onConfirm]);
+
+  const intent = options.intent ?? 'default';
+
+  return (
+    <div
+      className="shell-dialog-backdrop"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onCancel();
+      }}
+    >
+      <div className="shell-dialog" role="dialog" aria-modal="true" aria-labelledby="shell-confirm-title">
+        <div className="shell-dialog__header">
+          <div className={`shell-dialog__eyebrow${intent === 'danger' ? ' shell-dialog__eyebrow--danger' : ''}`}>
+            {intent === 'danger' ? 'Confirm destructive action' : 'Confirm action'}
+          </div>
+          <h2 className="shell-dialog__title" id="shell-confirm-title">{options.title}</h2>
+        </div>
+        {options.description && (
+          <div className="shell-dialog__description">{options.description}</div>
+        )}
+        <div className="shell-dialog__footer">
+          <button type="button" className="shell-dialog__button" onClick={onCancel}>
+            {options.cancelLabel ?? 'Cancel'}
+          </button>
+          <button
+            type="button"
+            className={`shell-dialog__button${intent === 'danger' ? ' shell-dialog__button--danger' : ' shell-dialog__button--primary'}`}
+            onClick={onConfirm}
+          >
+            {options.confirmLabel ?? 'Continue'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const ShortcutsDialog = ({ onClose }: { onClose: () => void }) => {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  return (
+    <div
+      className="shell-dialog-backdrop"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div className="shell-dialog shell-dialog--wide" role="dialog" aria-modal="true" aria-labelledby="shell-shortcuts-title">
+        <div className="shell-dialog__header">
+          <div className="shell-dialog__eyebrow">Keyboard shortcuts</div>
+          <h2 className="shell-dialog__title" id="shell-shortcuts-title">Move faster across the canvas</h2>
+        </div>
+        <div className="shell-shortcuts__intro">
+          The canvas supports a small set of global shortcuts. They stay intentionally lightweight so creation and navigation remain predictable.
+        </div>
+        <div className="shell-shortcuts">
+          <div className="shell-shortcuts__grid">
+            {SHORTCUT_SECTIONS.map((section) => (
+              <section key={section.title} className="shell-shortcuts__section">
+                <div className="shell-shortcuts__section-title">{section.title}</div>
+                <div className="shell-shortcuts__list">
+                  {section.items.map((item) => (
+                    <div key={`${section.title}-${item.combo}`} className="shell-shortcuts__item">
+                      <div className="shell-shortcuts__combo" aria-label={item.combo}>
+                        {item.combo.split(/\s*\+\s*/).map((part) => (
+                          <span key={`${item.combo}-${part}`} className="shell-shortcuts__key">{part}</span>
+                        ))}
+                      </div>
+                      <div className="shell-shortcuts__item-description">{item.description}</div>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        </div>
+        <div className="shell-dialog__footer">
+          <button type="button" className="shell-dialog__button shell-dialog__button--primary" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
@@ -23,6 +23,7 @@ interface CanvasOverlaysProps {
   onChatToggle?: () => void;
   onCreateNode: (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe' | 'mindmap') => void;
   onCloseContextMenu: () => void;
+  onOpenShortcuts: () => void;
   onToolChange: (tool: string) => void;
   onAddNode: (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe' | 'mindmap') => void;
   onResetTransform: () => void;
@@ -66,6 +67,7 @@ export const CanvasOverlays = ({
   onChatToggle,
   onCreateNode,
   onCloseContextMenu,
+  onOpenShortcuts,
   onToolChange,
   onAddNode,
   onResetTransform,
@@ -85,7 +87,12 @@ export const CanvasOverlays = ({
   onCancelEditEdgeLabel,
 }: CanvasOverlaysProps) => (
   <>
-    {nodes.length === 0 && !contextMenu && <CanvasEmptyHint />}
+    {nodes.length === 0 && !contextMenu && (
+      <CanvasEmptyHint
+        onCreateNode={(type) => onAddNode(type)}
+        onOpenShortcuts={onOpenShortcuts}
+      />
+    )}
 
     {contextMenu && (
       <NodeContextMenu

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -10,12 +10,47 @@ import { useCanvasKeyboard } from '../../hooks/useCanvasKeyboard';
 import { useCanvasImagePaste } from '../../hooks/useCanvasImagePaste';
 import { useEdgeInteraction } from '../../hooks/useEdgeInteraction';
 import { useShapeDraw } from '../../hooks/useShapeDraw';
+import { useAppShell } from '../AppShellProvider';
+import { NODE_TYPE_LABELS } from '../../constants/interaction';
 import type { CanvasNode } from '../../types';
 import { computeFrameDepths } from '../../utils/frameHierarchy';
+import { getNodeDisplayLabel } from '../../utils/nodeLabel';
+import type { CanvasNodeRenameRequest } from '../../types/ui-interaction';
 import { CanvasSurface } from './CanvasSurface';
 import { CanvasOverlays } from './CanvasOverlays';
 
-export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange, focusNodeId, onFocusComplete, deleteNodeId, onDeleteComplete, chatPanelOpen, onChatToggle }: { canvasId: string; canvasName?: string; rootFolder?: string; hidden?: boolean; onNodesChange?: (canvasId: string, nodes: CanvasNode[]) => void; focusNodeId?: string; onFocusComplete?: () => void; deleteNodeId?: string; onDeleteComplete?: () => void; chatPanelOpen?: boolean; onChatToggle?: () => void }) => {
+interface CanvasProps {
+  canvasId: string;
+  canvasName?: string;
+  rootFolder?: string;
+  hidden?: boolean;
+  onNodesChange?: (canvasId: string, nodes: CanvasNode[]) => void;
+  focusNodeId?: string;
+  onFocusComplete?: () => void;
+  deleteNodeId?: string;
+  onDeleteComplete?: () => void;
+  renameRequest?: CanvasNodeRenameRequest;
+  onRenameComplete?: () => void;
+  chatPanelOpen?: boolean;
+  onChatToggle?: () => void;
+}
+
+export const Canvas = ({
+  canvasId,
+  canvasName,
+  rootFolder,
+  hidden,
+  onNodesChange,
+  focusNodeId,
+  onFocusComplete,
+  deleteNodeId,
+  onDeleteComplete,
+  renameRequest,
+  onRenameComplete,
+  chatPanelOpen,
+  onChatToggle,
+}: CanvasProps) => {
+  const { confirm, notify, openShortcuts, isOverlayOpen } = useAppShell();
   const [activeTool, setActiveTool] = useState('select');
   const [selectedNodeIds, setSelectedNodeIds] = useState<string[]>([]);
   const [clipboardNodes, setClipboardNodes] = useState<CanvasNode[]>([]);
@@ -109,6 +144,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
 
   // Handle external focus request (e.g. from sidebar layers panel)
   useEffect(() => {
+    if (!loaded) return;
     if (!focusNodeId) return;
     const node = nodes.find((n) => n.id === focusNodeId);
     if (node) {
@@ -117,26 +153,90 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
       handleFocusNode(node);
     }
     onFocusComplete?.();
-  }, [focusNodeId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [focusNodeId, loaded]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Handle external delete request (e.g. from sidebar layers context menu)
   useEffect(() => {
+    if (!loaded) return;
     if (!deleteNodeId) return;
     if (nodes.some((n) => n.id === deleteNodeId)) {
       removeNode(deleteNodeId);
       setSelectedNodeIds((ids) => ids.filter((id) => id !== deleteNodeId));
     }
     onDeleteComplete?.();
-  }, [deleteNodeId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [deleteNodeId, loaded]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (!loaded) return;
+    if (!renameRequest) return;
+    if (renameRequest.workspaceId !== canvasId) return;
+
+    const node = nodes.find((item) => item.id === renameRequest.nodeId);
+    if (node && node.title !== renameRequest.title) {
+      updateNode(node.id, { title: renameRequest.title });
+    }
+    onRenameComplete?.();
+  }, [renameRequest, loaded, canvasId, nodes, updateNode, onRenameComplete]);
+
+  const requestRemoveNodes = useCallback(async (ids: string[]) => {
+    const victims = nodes.filter((node) => ids.includes(node.id));
+    if (victims.length === 0) return;
+
+    const accepted = await confirm({
+      intent: 'danger',
+      title: victims.length === 1
+        ? `Delete "${getNodeDisplayLabel(victims[0])}"?`
+        : `Delete ${victims.length} selected nodes?`,
+      description: victims.length === 1
+        ? 'Connected arrows stay on the canvas and detach from the deleted node.'
+        : 'Connected arrows stay on the canvas and detach from the deleted nodes.',
+      confirmLabel: victims.length === 1 ? 'Delete node' : 'Delete nodes',
+    });
+    if (!accepted) return;
+
+    removeNodes(victims.map((node) => node.id));
+    const removedIds = new Set(victims.map((node) => node.id));
+    setSelectedNodeIds((current) => current.filter((id) => !removedIds.has(id)));
+    notify({
+      tone: 'success',
+      title: victims.length === 1 ? 'Node deleted' : 'Nodes deleted',
+      description: victims.length === 1
+        ? getNodeDisplayLabel(victims[0])
+        : `${victims.length} items were removed from the canvas.`,
+    });
+  }, [nodes, confirm, removeNodes, notify]);
+
+  const requestRemoveEdge = useCallback(async (id: string) => {
+    const edge = edges.find((item) => item.id === id);
+    if (!edge) return;
+
+    const accepted = await confirm({
+      intent: 'danger',
+      title: 'Delete this connection?',
+      description: 'This removes the arrow and its label from the canvas.',
+      confirmLabel: 'Delete connection',
+    });
+    if (!accepted) return;
+
+    removeEdge(id);
+    setSelectedEdgeId((current) => (current === id ? null : current));
+    if (editingEdgeLabelId === id) setEditingEdgeLabelId(null);
+    notify({
+      tone: 'success',
+      title: 'Connection deleted',
+      description: edge.label?.trim() ? edge.label : 'Arrow removed from the canvas.',
+    });
+  }, [edges, confirm, removeEdge, editingEdgeLabelId, notify]);
 
   useCanvasContext(rootFolder, nodes, canvasName);
 
   useCanvasKeyboard({
     undo, redo, nodes, selectedNodeIds, setSelectedNodeIds,
-    selectedEdgeId, setSelectedEdgeId, removeEdge,
-    duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, removeNodes,
+    selectedEdgeId, setSelectedEdgeId, removeEdge: requestRemoveEdge,
+    duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, removeNodes: requestRemoveNodes,
     searchOpen, setSearchOpen, contextMenu, setContextMenu,
     setHighlightedId, handleFocusNode,
+    keyboardLocked: isOverlayOpen,
   });
 
   useCanvasImagePaste({
@@ -331,8 +431,13 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
       const node = addNode(type, contextMenu.canvasX, contextMenu.canvasY);
       setSelectedNodeIds([node.id]);
       setContextMenu(null);
+      notify({
+        tone: 'success',
+        title: `${NODE_TYPE_LABELS[type]} added`,
+        description: 'Placed on the canvas.',
+      });
     },
-    [addNode, contextMenu]
+    [addNode, contextMenu, notify]
   );
 
   const handleToolbarAddNode = useCallback(
@@ -356,8 +461,13 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
         : 150;
       const node = addNode(type, pos.x - halfW, pos.y - halfH);
       setSelectedNodeIds([node.id]);
+      notify({
+        tone: 'success',
+        title: `${NODE_TYPE_LABELS[type]} added`,
+        description: 'Centered in the current viewport.',
+      });
     },
-    [addNode, screenToCanvas]
+    [addNode, screenToCanvas, notify]
   );
 
   const handleCanvasClick = useCallback(
@@ -451,7 +561,9 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
         onResizeStart={onResizeStart}
         onUpdate={updateNode}
         onAutoResize={resizeNode}
-        onRemove={removeNode}
+        onRemove={(id) => {
+          void requestRemoveNodes([id]);
+        }}
         onSelect={(id) => {
           setSelectedNodeIds([id]);
           setSelectedEdgeId(null);
@@ -476,6 +588,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
         onChatToggle={onChatToggle}
         onCreateNode={handleCreateNode}
         onCloseContextMenu={() => setContextMenu(null)}
+        onOpenShortcuts={openShortcuts}
         onToolChange={setActiveTool}
         onAddNode={handleToolbarAddNode}
         onResetTransform={resetTransform}
@@ -492,9 +605,7 @@ export const Canvas = ({ canvasId, canvasName, rootFolder, hidden, onNodesChange
           updateEdge(id, patch);
         }}
         onRemoveEdge={(id) => {
-          removeEdge(id);
-          setSelectedEdgeId(null);
-          if (editingEdgeLabelId === id) setEditingEdgeLabelId(null);
+          void requestRemoveEdge(id);
         }}
         edges={edges}
         editingEdgeLabelId={editingEdgeLabelId}

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEmptyHint/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEmptyHint/index.css
@@ -7,6 +7,20 @@
   justify-content: center;
   pointer-events: none;
   animation: fadeIn 0.5s ease;
+  padding: 24px;
+}
+
+.canvas-empty-card {
+  pointer-events: auto;
+  width: min(560px, 100%);
+  padding: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  border-radius: 22px;
+  background:
+    radial-gradient(circle at top left, rgba(35, 131, 226, 0.08), transparent 42%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(252, 251, 249, 0.98));
+  box-shadow: 0 24px 70px rgba(27, 28, 29, 0.08), var(--shadow-float);
+  text-align: center;
 }
 
 .hint-icon {
@@ -20,15 +34,104 @@
   justify-content: center;
   color: var(--text-muted);
   margin-bottom: 14px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .hint-text {
-  font-size: 14px;
-  color: var(--text-secondary);
-  margin-bottom: 4px;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 6px;
 }
 
 .hint-sub {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  margin: 0 auto 18px;
+  max-width: 420px;
+}
+
+.canvas-empty-actions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.canvas-empty-action {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 14px;
+  border: 1px solid rgba(35, 131, 226, 0.08);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.84);
+  cursor: pointer;
+  text-align: left;
+  transition: transform 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
+}
+
+.canvas-empty-action:hover {
+  transform: translateY(-1px);
+  border-color: rgba(35, 131, 226, 0.2);
+  box-shadow: 0 10px 24px rgba(35, 131, 226, 0.08);
+}
+
+.canvas-empty-action__label {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.canvas-empty-action__description {
   font-size: 12px;
-  color: var(--text-muted);
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.canvas-empty-shortcuts {
+  margin: 0 auto;
+  height: 34px;
+  padding: 0 12px 0 10px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.04);
+  color: var(--text-secondary);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.canvas-empty-shortcuts:hover {
+  background: rgba(35, 131, 226, 0.08);
+  color: var(--accent);
+}
+
+.canvas-empty-shortcuts__key {
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+@media (max-width: 720px) {
+  .canvas-empty-card {
+    padding: 22px;
+  }
+
+  .canvas-empty-actions {
+    grid-template-columns: 1fr;
+  }
 }

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEmptyHint/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEmptyHint/index.tsx
@@ -1,23 +1,47 @@
+import { EMPTY_CANVAS_ACTIONS } from '../../constants/interaction';
+import type { CanvasNode } from '../../types';
 import './index.css';
 
-export const CanvasEmptyHint = () => (
+interface CanvasEmptyHintProps {
+  onCreateNode: (type: Extract<CanvasNode['type'], 'agent' | 'terminal' | 'file'>) => void;
+  onOpenShortcuts: () => void;
+}
+
+export const CanvasEmptyHint = ({ onCreateNode, onOpenShortcuts }: CanvasEmptyHintProps) => (
   <div className="canvas-empty-hint">
-    <div className="hint-icon">
-      <svg width="32" height="32" viewBox="0 0 512 512" fill="none" aria-hidden="true">
-        <path
-          d="M 80,268 H 188 L 228,178 L 260,370 L 292,148 L 328,268 H 432"
-          stroke="currentColor"
-          strokeWidth="22"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-      </svg>
-    </div>
-    <div className="hint-text">
-      Right-click or double-click to add a card
-    </div>
-    <div className="hint-sub">
-      Scroll to pan &middot; Ctrl+Scroll to zoom
+    <div className="canvas-empty-card">
+      <div className="hint-icon">
+        <svg width="32" height="32" viewBox="0 0 512 512" fill="none" aria-hidden="true">
+          <path
+            d="M 80,268 H 188 L 228,178 L 260,370 L 292,148 L 328,268 H 432"
+            stroke="currentColor"
+            strokeWidth="22"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </div>
+      <div className="hint-text">Start with a lightweight node</div>
+      <div className="hint-sub">
+        Create an Agent, Terminal, or Note to turn the blank canvas into a working session.
+      </div>
+      <div className="canvas-empty-actions">
+        {EMPTY_CANVAS_ACTIONS.map((action) => (
+          <button
+            key={action.actionKey}
+            type="button"
+            className="canvas-empty-action"
+            onClick={() => onCreateNode(action.nodeType)}
+          >
+            <span className="canvas-empty-action__label">{action.label}</span>
+            <span className="canvas-empty-action__description">{action.description}</span>
+          </button>
+        ))}
+      </div>
+      <button type="button" className="canvas-empty-shortcuts" onClick={onOpenShortcuts}>
+        <span className="canvas-empty-shortcuts__key">?</span>
+        <span>Show keyboard shortcuts</span>
+      </button>
     </div>
   </div>
 );

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -129,12 +129,63 @@
   border-radius: 3px;
   color: var(--text);
   letter-spacing: -0.01em;
+  cursor: default;
+  min-width: 0;
 }
 
-.node-title:focus {
+.node-title[contenteditable="true"] {
+  cursor: text;
   background: rgba(0, 0, 0, 0.03);
+  box-shadow: 0 0 0 1.5px var(--accent-border);
 }
 
+/* Agent status label pill */
+.node-status-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 1px 6px;
+  border-radius: 999px;
+  flex-shrink: 0;
+  white-space: nowrap;
+  opacity: 0;
+  transition: opacity 0.1s;
+}
+
+.canvas-node:hover .node-status-label {
+  opacity: 1;
+}
+
+.node-status-label--running {
+  background: rgba(16, 185, 129, 0.12);
+  color: #059669;
+}
+
+.node-status-label--done {
+  background: rgba(0, 0, 0, 0.05);
+  color: var(--text-muted);
+}
+
+.node-status-label--error {
+  background: rgba(224, 62, 62, 0.1);
+  color: #e03e3e;
+}
+
+/* Last active time label */
+.node-time-label {
+  font-size: 10px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+  white-space: nowrap;
+  opacity: 0;
+  transition: opacity 0.1s;
+}
+
+.canvas-node:hover .node-time-label {
+  opacity: 1;
+}
+
+.node-copy,
 .node-focus,
 .node-close {
   width: 20px;
@@ -152,9 +203,20 @@
   transition: opacity 0.1s, background 0.1s, color 0.1s;
 }
 
+.canvas-node:hover .node-copy,
 .canvas-node:hover .node-focus,
 .canvas-node:hover .node-close {
   opacity: 1;
+}
+
+.node-copy:hover {
+  background: var(--accent-light);
+  color: var(--accent);
+}
+
+.node-copy--done {
+  color: #10b981 !important;
+  opacity: 1 !important;
 }
 
 .node-focus:hover {

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -1,6 +1,6 @@
-import { useCallback } from "react";
+import { useCallback, useState, useEffect, useRef } from "react";
 import "./index.css";
-import type { CanvasNode, FrameNodeData, AgentNodeData, TextNodeData } from "../../types";
+import type { CanvasNode, FrameNodeData, AgentNodeData, TextNodeData, FileNodeData } from "../../types";
 import type { ResizeEdge } from "../../hooks/useNodeResize";
 import { FileNodeBody } from "../FileNodeBody";
 import { TerminalNodeBody } from "../TerminalNodeBody";
@@ -44,6 +44,42 @@ interface Props {
   onFocus: (node: CanvasNode) => void;
 }
 
+function formatRelativeTime(epochMs: number): string {
+  const diffSec = Math.floor((Date.now() - epochMs) / 1000);
+  if (diffSec < 60) return 'just now';
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  return `${Math.floor(diffHr / 24)}d ago`;
+}
+
+function fallbackCopy(text: string) {
+  const el = document.createElement('textarea');
+  el.value = text;
+  el.style.cssText = 'position:fixed;top:0;left:0;opacity:0;pointer-events:none';
+  document.body.appendChild(el);
+  el.select();
+  try { document.execCommand('copy'); } catch { /* ignore */ }
+  document.body.removeChild(el);
+}
+
+function getNodeCopyContent(node: CanvasNode): string {
+  switch (node.type) {
+    case 'file': return (node.data as FileNodeData).content ?? '';
+    case 'text': return (node.data as TextNodeData).content ?? '';
+    case 'agent': return (node.data as AgentNodeData).scrollback ?? '';
+    default: return node.title;
+  }
+}
+
+const AGENT_STATUS_LABEL: Record<string, string> = {
+  running: 'Running',
+  done: 'Done',
+  error: 'Error',
+  idle: 'Idle',
+};
+
 export const CanvasNodeView = ({
   node,
   allNodes,
@@ -63,6 +99,18 @@ export const CanvasNodeView = ({
   onSelect,
   onFocus
 }: Props) => {
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [, setTick] = useState(0);
+  const titleRef = useRef<HTMLSpanElement>(null);
+
+  // Re-render every 30s so relative time stays fresh
+  useEffect(() => {
+    if (!node.updatedAt) return;
+    const id = setInterval(() => setTick((t) => t + 1), 30_000);
+    return () => clearInterval(id);
+  }, [node.updatedAt]);
+
   const handleHeaderMouseDown = useCallback(
     (e: React.MouseEvent) => {
       onSelect(node.id);
@@ -95,27 +143,77 @@ export const CanvasNodeView = ({
     [onFocus, node]
   );
 
-  const handleTitleChange = useCallback(
+  const handleTitleBlur = useCallback(
     (e: React.FocusEvent<HTMLSpanElement>) => {
       const newTitle = e.currentTarget.textContent?.trim();
       if (newTitle && newTitle !== node.title) {
         onUpdate(node.id, { title: newTitle });
       }
+      setIsEditingTitle(false);
     },
     [onUpdate, node.id, node.title]
+  );
+
+  const handleTitleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLSpanElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        titleRef.current?.blur();
+      } else if (e.key === 'Escape') {
+        if (titleRef.current) titleRef.current.textContent = node.title;
+        titleRef.current?.blur();
+      }
+    },
+    [node.title]
+  );
+
+  const handleTitleDoubleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      setIsEditingTitle(true);
+      // Focus after state update renders contentEditable=true
+      requestAnimationFrame(() => {
+        if (titleRef.current) {
+          titleRef.current.focus();
+          const range = document.createRange();
+          range.selectNodeContents(titleRef.current);
+          const sel = window.getSelection();
+          sel?.removeAllRanges();
+          sel?.addRange(range);
+        }
+      });
+    },
+    []
+  );
+
+  const handleCopy = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      const content = getNodeCopyContent(node);
+      const write = () => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      };
+      if (navigator.clipboard?.writeText) {
+        navigator.clipboard.writeText(content).then(write).catch(() => {
+          fallbackCopy(content);
+          write();
+        });
+      } else {
+        fallbackCopy(content);
+        write();
+      }
+    },
+    [node]
   );
 
   const makeResizeHandler = useCallback(
     (edge: ResizeEdge) => (e: React.MouseEvent) => {
       if (node.type === "text") {
-        // Dragging a resize handle on a text node switches it out of auto-size
-        // mode so the dragged width/height becomes the authoritative frame.
         const data = node.data as TextNodeData;
         if (data.autoSize !== false) {
           onUpdate(node.id, { data: { ...data, autoSize: false } });
         }
-        // Text labels should be shrinkable well below the standard 200×120
-        // floor — a tiny tag is a valid shape.
         onResizeStart(e, node.id, node.width, node.height, edge, 40, 28);
         return;
       }
@@ -139,6 +237,12 @@ export const CanvasNodeView = ({
   ]
     .filter(Boolean)
     .join(" ");
+
+  const agentStatus = node.type === "agent"
+    ? ((node.data as AgentNodeData).status ?? 'idle')
+    : null;
+
+  const relativeTime = node.updatedAt ? formatRelativeTime(node.updatedAt) : null;
 
   if (node.type === "image") {
     return (
@@ -218,10 +322,6 @@ export const CanvasNodeView = ({
   }
 
   if (node.type === "mindmap") {
-    // Mindmaps are fully chromeless and content-sized: no border, no
-    // hover/selected outline, no resize handles. MindmapNodeBody
-    // reports the rendered bounding box via `onAutoResize`, so the
-    // canvas node's width/height track the topic tree automatically.
     return (
       <div
         className={classes}
@@ -231,9 +331,6 @@ export const CanvasNodeView = ({
           height: node.height,
         }}
         onClick={handleNodeClick}
-        // The wrapper itself is the drag handle — topic pills inside
-        // stop propagation, so mousedown on the empty mindmap area
-        // bubbles here and starts a node drag.
         onMouseDown={(e) => {
           onSelect(node.id);
           onDragStart(e, node);
@@ -307,28 +404,57 @@ export const CanvasNodeView = ({
               <circle cx="9.5" cy="5" r="0.8" fill="currentColor" />
             </svg>
           )}
-          {node.type === "agent" && (() => {
-            const agentStatus = (node.data as AgentNodeData).status;
-            if (!agentStatus || agentStatus === "idle") return null;
-            return <span className={`node-status-dot node-status-dot--${agentStatus}`} />;
-          })()}
+          {node.type === "agent" && agentStatus && agentStatus !== "idle" && (
+            <span className={`node-status-dot node-status-dot--${agentStatus}`} />
+          )}
         </span>
         <span
+          ref={titleRef}
           className="node-title"
-          contentEditable
+          contentEditable={isEditingTitle}
           suppressContentEditableWarning
           spellCheck={false}
-          onBlur={handleTitleChange}
-          onMouseDown={(e) => e.stopPropagation()}
+          onBlur={handleTitleBlur}
+          onKeyDown={isEditingTitle ? handleTitleKeyDown : undefined}
+          onDoubleClick={handleTitleDoubleClick}
+          onMouseDown={(e) => {
+            if (isEditingTitle) e.stopPropagation();
+          }}
         >
           {node.title}
         </span>
+        {node.type === "agent" && agentStatus && agentStatus !== 'idle' && (
+          <span className={`node-status-label node-status-label--${agentStatus}`}>
+            {AGENT_STATUS_LABEL[agentStatus] ?? agentStatus}
+          </span>
+        )}
+        {relativeTime && !(node.type === "agent" && agentStatus && agentStatus !== 'idle') && (
+          <span className="node-time-label" title={new Date(node.updatedAt!).toLocaleString()}>
+            {relativeTime}
+          </span>
+        )}
         {node.type === "frame" && (
           <FrameColorPicker node={node} onUpdate={onUpdate} />
         )}
         {node.type === "text" && (
           <TextColorPicker node={node} onUpdate={onUpdate} />
         )}
+        <button
+          className={`node-copy${copied ? ' node-copy--done' : ''}`}
+          onClick={handleCopy}
+          title={copied ? 'Copied!' : 'Copy content'}
+        >
+          {copied ? (
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+              <path d="M2 6l3 3 5-5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          ) : (
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+              <rect x="5" y="1" width="9" height="11" rx="1.5" stroke="currentColor" strokeWidth="1.3" />
+              <path d="M11 4H3a1 1 0 00-1 1v9a1 1 0 001 1h8a1 1 0 001-1V4z" stroke="currentColor" strokeWidth="1.3" />
+            </svg>
+          )}
+        </button>
         <button className="node-focus" onClick={handleFocus} title="Focus">
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
             <circle cx="6" cy="6" r="2" stroke="currentColor" strokeWidth="1.3" />
@@ -367,9 +493,6 @@ export const CanvasNodeView = ({
         className="resize-handle resize-handle--right"
         onMouseDown={makeResizeHandler("right")}
       />
-      {/* Text nodes grow vertically to fit content, so a bottom/corner
-          handle would either do nothing or fight the auto-height. Offer only
-          the right-edge handle as a wrap-width control. */}
       {node.type !== "text" && (
         <>
           <div

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/LayerContextMenu.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/LayerContextMenu.tsx
@@ -3,7 +3,9 @@ interface LayerContextMenuProps {
   y: number;
   nodeId: string;
   onFocus: (nodeId: string) => void;
+  onRename: (nodeId: string) => void;
   onDelete: (nodeId: string) => void;
+  onCopyLink: (nodeId: string) => void;
   onClose: () => void;
 }
 
@@ -12,7 +14,9 @@ export const LayerContextMenu = ({
   y,
   nodeId,
   onFocus,
+  onRename,
   onDelete,
+  onCopyLink,
   onClose,
 }: LayerContextMenuProps) => (
   <div
@@ -31,6 +35,26 @@ export const LayerContextMenu = ({
         <path d="M8 1.5v1.5M8 13v1.5M1.5 8h1.5M13 8h1.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
       </svg>
       <span>Focus</span>
+    </button>
+    <button
+      className="sidebar-layer-context-menu-item"
+      onClick={() => { onRename(nodeId); onClose(); }}
+    >
+      <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
+        <path d="M3.5 12.5h2.8L12.6 6.2 9.8 3.4 3.5 9.7v2.8z" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round" />
+        <path d="M8.9 4.3l2.8 2.8" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+      </svg>
+      <span>Rename</span>
+    </button>
+    <button
+      className="sidebar-layer-context-menu-item"
+      onClick={() => { onCopyLink(nodeId); onClose(); }}
+    >
+      <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
+        <path d="M6.2 9.8L9.8 6.2" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+        <path d="M6.3 12.4H4.9a2.9 2.9 0 010-5.8h1.5M9.7 3.6h1.4a2.9 2.9 0 110 5.8H9.6" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+      </svg>
+      <span>Copy link</span>
     </button>
     <div className="sidebar-layer-context-menu-separator" />
     <button

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/LayerItem.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/LayerItem.tsx
@@ -1,4 +1,4 @@
-import type { MouseEvent as ReactMouseEvent } from 'react';
+import type { MouseEvent as ReactMouseEvent, RefObject } from 'react';
 import type { LayerTreeNode } from './utils/layers';
 import { ChevronRightIcon, NodeTypeIcon } from '../icons';
 import { getNodeDisplayLabel } from '../../utils/nodeLabel';
@@ -9,6 +9,12 @@ interface LayerItemProps {
   onFocus: (nodeId: string) => void;
   onContextMenu: (e: ReactMouseEvent, nodeId: string) => void;
   onToggleCollapse: (id: string) => void;
+  renamingLayerId: string | null;
+  renameLayerValue: string;
+  renameLayerInputRef: RefObject<HTMLInputElement>;
+  onRenameChange: (value: string) => void;
+  onRenameCommit: () => void;
+  onRenameCancel: () => void;
 }
 
 export const LayerItem = ({
@@ -17,42 +23,79 @@ export const LayerItem = ({
   onFocus,
   onContextMenu,
   onToggleCollapse,
+  renamingLayerId,
+  renameLayerValue,
+  renameLayerInputRef,
+  onRenameChange,
+  onRenameCommit,
+  onRenameCancel,
 }: LayerItemProps) => {
   const { node, children } = tree;
   const isFrame = node.type === 'frame';
   const isOpen = isFrame && !collapsedLayers.has(node.id);
+  const isRenaming = renamingLayerId === node.id;
   const displayLabel = getNodeDisplayLabel(node);
 
   return (
     <div className="sidebar-layer-group">
-      <button
-        className={`sidebar-layer-item${isFrame ? ' sidebar-layer-item--frame' : ''}`}
-        onClick={() => onFocus(node.id)}
-        onContextMenu={(e) => onContextMenu(e, node.id)}
-        title={displayLabel}
-      >
-        {isFrame ? (
-          <span
-            className={`sidebar-layer-chevron${isOpen ? ' sidebar-layer-chevron--open' : ''}`}
-            onClick={(e) => { e.stopPropagation(); onToggleCollapse(node.id); }}
-          >
-            <ChevronRightIcon size={10} />
+      {isRenaming ? (
+        <div className={`sidebar-layer-item sidebar-layer-item--editing${isFrame ? ' sidebar-layer-item--frame' : ''}`}>
+          {isFrame ? (
+            <span
+              className={`sidebar-layer-chevron${isOpen ? ' sidebar-layer-chevron--open' : ''}`}
+              onClick={(e) => { e.stopPropagation(); onToggleCollapse(node.id); }}
+            >
+              <ChevronRightIcon size={10} />
+            </span>
+          ) : (
+            <span className="sidebar-layer-spacer" aria-hidden="true" />
+          )}
+          <span className="sidebar-layer-icon">
+            <NodeTypeIcon type={node.type} />
           </span>
-        ) : (
-          <span className="sidebar-layer-spacer" aria-hidden="true" />
-        )}
-        <span className="sidebar-layer-icon">
-          <NodeTypeIcon type={node.type} />
-        </span>
-        <span className="sidebar-layer-name">
-          {node.type === 'frame'
-            ? (node.title || (node.data as { label?: string }).label || 'Frame')
-            : displayLabel}
-        </span>
-        {isFrame && children.length > 0 && (
-          <span className="sidebar-layer-child-count">{children.length}</span>
-        )}
-      </button>
+          <input
+            ref={renameLayerInputRef}
+            className="sidebar-layer-rename-input"
+            value={renameLayerValue}
+            onChange={(event) => onRenameChange(event.target.value)}
+            onBlur={onRenameCommit}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') onRenameCommit();
+              if (event.key === 'Escape') onRenameCancel();
+            }}
+            onMouseDown={(event) => event.stopPropagation()}
+          />
+        </div>
+      ) : (
+        <button
+          className={`sidebar-layer-item${isFrame ? ' sidebar-layer-item--frame' : ''}`}
+          onClick={() => onFocus(node.id)}
+          onContextMenu={(e) => onContextMenu(e, node.id)}
+          title={displayLabel}
+        >
+          {isFrame ? (
+            <span
+              className={`sidebar-layer-chevron${isOpen ? ' sidebar-layer-chevron--open' : ''}`}
+              onClick={(e) => { e.stopPropagation(); onToggleCollapse(node.id); }}
+            >
+              <ChevronRightIcon size={10} />
+            </span>
+          ) : (
+            <span className="sidebar-layer-spacer" aria-hidden="true" />
+          )}
+          <span className="sidebar-layer-icon">
+            <NodeTypeIcon type={node.type} />
+          </span>
+          <span className="sidebar-layer-name">
+            {node.type === 'frame'
+              ? (node.title || (node.data as { label?: string }).label || 'Frame')
+              : displayLabel}
+          </span>
+          {isFrame && children.length > 0 && (
+            <span className="sidebar-layer-child-count">{children.length}</span>
+          )}
+        </button>
+      )}
 
       {isFrame && children.length > 0 && (
         <div
@@ -68,6 +111,12 @@ export const LayerItem = ({
                 onFocus={onFocus}
                 onContextMenu={onContextMenu}
                 onToggleCollapse={onToggleCollapse}
+                renamingLayerId={renamingLayerId}
+                renameLayerValue={renameLayerValue}
+                renameLayerInputRef={renameLayerInputRef}
+                onRenameChange={onRenameChange}
+                onRenameCommit={onRenameCommit}
+                onRenameCancel={onRenameCancel}
               />
             ))}
           </div>

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/LayersPanel.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/LayersPanel.tsx
@@ -1,4 +1,4 @@
-import type { MouseEvent as ReactMouseEvent } from 'react';
+import type { MouseEvent as ReactMouseEvent, RefObject } from 'react';
 import type { LayerTreeNode } from './utils/layers';
 import { LayerItem } from './LayerItem';
 
@@ -12,6 +12,12 @@ interface LayersPanelProps {
   onContextMenu: (e: ReactMouseEvent, nodeId: string) => void;
   onToggleCollapse: (id: string) => void;
   onToggleAll: () => void;
+  renamingLayerId: string | null;
+  renameLayerValue: string;
+  renameLayerInputRef: RefObject<HTMLInputElement>;
+  onLayerRenameChange: (value: string) => void;
+  onLayerRenameCommit: () => void;
+  onLayerRenameCancel: () => void;
 }
 
 export const LayersPanel = ({
@@ -24,6 +30,12 @@ export const LayersPanel = ({
   onContextMenu,
   onToggleCollapse,
   onToggleAll,
+  renamingLayerId,
+  renameLayerValue,
+  renameLayerInputRef,
+  onLayerRenameChange,
+  onLayerRenameCommit,
+  onLayerRenameCancel,
 }: LayersPanelProps) => (
   <div className="sidebar-layers">
     <div className="sidebar-section-header">
@@ -71,6 +83,12 @@ export const LayersPanel = ({
           onFocus={onNodeFocus}
           onContextMenu={onContextMenu}
           onToggleCollapse={onToggleCollapse}
+          renamingLayerId={renamingLayerId}
+          renameLayerValue={renameLayerValue}
+          renameLayerInputRef={renameLayerInputRef}
+          onRenameChange={onLayerRenameChange}
+          onRenameCommit={onLayerRenameCommit}
+          onRenameCancel={onLayerRenameCancel}
         />
       ))}
     </div>

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
@@ -555,6 +555,11 @@
   background: rgba(0, 0, 0, 0.04);
 }
 
+.sidebar-layer-item--editing {
+  cursor: default;
+  background: rgba(35, 131, 226, 0.08);
+}
+
 .sidebar-layer-icon {
   width: 18px;
   height: 18px;
@@ -571,6 +576,19 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.sidebar-layer-rename-input {
+  flex: 1;
+  min-width: 0;
+  height: 26px;
+  padding: 0 8px;
+  border: 1.5px solid var(--accent-border);
+  border-radius: 8px;
+  background: #ffffff;
+  font-size: 12px;
+  color: var(--text);
+  outline: none;
 }
 
 .sidebar-layer-item--frame {
@@ -736,7 +754,7 @@
 .sidebar-layer-context-menu {
   position: fixed;
   z-index: 1000;
-  min-width: 140px;
+  min-width: 168px;
   padding: 4px;
   background: var(--bg, #ffffff);
   border: 1px solid var(--border-light);

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
@@ -8,6 +8,10 @@ import { WorkspaceItem } from './WorkspaceItem';
 import { WorkspaceList } from './WorkspaceList';
 import { LayersPanel } from './LayersPanel';
 import { LayerContextMenu } from './LayerContextMenu';
+import { useAppShell } from '../AppShellProvider';
+import { getNodeDisplayLabel } from '../../utils/nodeLabel';
+import { buildCanvasNodeLink } from '../../utils/canvasLinks';
+import { copyTextToClipboard } from '../../utils/clipboard';
 
 interface Props {
   collapsed: boolean;
@@ -29,6 +33,7 @@ interface Props {
   activeNodes?: CanvasNode[];
   onNodeFocus?: (nodeId: string) => void;
   onNodeDelete?: (nodeId: string) => void;
+  onNodeRename?: (nodeId: string, title: string) => void;
   activeView: 'canvas' | 'chat';
   onEnterChat: () => void;
   onExitChat: () => void;
@@ -40,12 +45,15 @@ const FOLDER_DRAG = 'application/x-folder-id';
 export const Sidebar = ({
   collapsed, onToggle, workspaces, folders, activeId, onSelect, onCreate, onRename, onDelete,
   onCreateFolder, onRenameFolder, onDeleteFolder, onToggleFolder, onMoveWorkspace, onReorderFolder,
-  activeNodes = [], onNodeFocus, onNodeDelete, activeView, onEnterChat,
+  activeNodes = [], onNodeFocus, onNodeDelete, onNodeRename, activeView, onEnterChat,
 }: Props) => {
+  const { confirm, notify } = useAppShell();
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
   const [renamingFolderId, setRenamingFolderId] = useState<string | null>(null);
   const [renameFolderValue, setRenameFolderValue] = useState('');
+  const [renamingLayerId, setRenamingLayerId] = useState<string | null>(null);
+  const [renameLayerValue, setRenameLayerValue] = useState('');
   const [inlineCreate, setInlineCreate] = useState<'workspace' | 'folder' | null>(null);
   const [inlineCreateValue, setInlineCreateValue] = useState('');
   const [dropTarget, setDropTarget] = useState<string | null>(null);
@@ -85,11 +93,13 @@ export const Sidebar = ({
 
   const renameInputRef = useRef<HTMLInputElement>(null);
   const renameFolderInputRef = useRef<HTMLInputElement>(null);
+  const renameLayerInputRef = useRef<HTMLInputElement>(null);
   const inlineCreateRef = useRef<HTMLInputElement>(null);
   const addMenuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => { if (renamingId && renameInputRef.current) { renameInputRef.current.focus(); renameInputRef.current.select(); } }, [renamingId]);
   useEffect(() => { if (renamingFolderId && renameFolderInputRef.current) { renameFolderInputRef.current.focus(); renameFolderInputRef.current.select(); } }, [renamingFolderId]);
+  useEffect(() => { if (renamingLayerId && renameLayerInputRef.current) { renameLayerInputRef.current.focus(); renameLayerInputRef.current.select(); } }, [renamingLayerId]);
   useEffect(() => { if (inlineCreate && inlineCreateRef.current) inlineCreateRef.current.focus(); }, [inlineCreate]);
 
   useEffect(() => {
@@ -103,11 +113,71 @@ export const Sidebar = ({
   const commitRename = () => { if (renamingId && renameValue.trim()) onRename(renamingId, renameValue); setRenamingId(null); };
   const startFolderRename = (f: FolderEntry) => { setRenamingFolderId(f.id); setRenameFolderValue(f.name); };
   const commitFolderRename = () => { if (renamingFolderId && renameFolderValue.trim()) onRenameFolder(renamingFolderId, renameFolderValue); setRenamingFolderId(null); };
+  const startLayerRename = (nodeId: string) => {
+    const node = activeNodes.find((item) => item.id === nodeId);
+    if (!node) return;
+    setRenamingLayerId(nodeId);
+    setRenameLayerValue(node.title || getNodeDisplayLabel(node));
+  };
+  const commitLayerRename = () => {
+    if (!renamingLayerId) return;
+    const nextTitle = renameLayerValue.trim();
+    const node = activeNodes.find((item) => item.id === renamingLayerId);
+    setRenamingLayerId(null);
+    if (!node || !onNodeRename || !nextTitle || node.title === nextTitle) return;
+    onNodeRename(renamingLayerId, nextTitle);
+    notify({
+      tone: 'success',
+      title: 'Layer renamed',
+      description: `${getNodeDisplayLabel(node)} -> ${nextTitle}`,
+    });
+  };
   const commitInlineCreate = () => {
     const v = inlineCreateValue.trim();
     if (v) { if (inlineCreate === 'workspace') onCreate(v); else if (inlineCreate === 'folder') onCreateFolder(v); }
     setInlineCreate(null); setInlineCreateValue('');
   };
+
+  const handleLayerDelete = useCallback(async (nodeId: string) => {
+    const node = activeNodes.find((item) => item.id === nodeId);
+    if (!node || !onNodeDelete) return;
+
+    const accepted = await confirm({
+      intent: 'danger',
+      title: `Delete "${getNodeDisplayLabel(node)}"?`,
+      description: 'The node will be removed from the canvas. Connected arrows remain and detach from it.',
+      confirmLabel: 'Delete node',
+    });
+    if (!accepted) return;
+
+    onNodeDelete(nodeId);
+    notify({
+      tone: 'success',
+      title: 'Node deleted',
+      description: getNodeDisplayLabel(node),
+    });
+  }, [activeNodes, confirm, notify, onNodeDelete]);
+
+  const handleLayerCopyLink = useCallback(async (nodeId: string) => {
+    const node = activeNodes.find((item) => item.id === nodeId);
+    if (!node) return;
+
+    try {
+      await copyTextToClipboard(buildCanvasNodeLink(activeId, nodeId));
+      notify({
+        tone: 'success',
+        title: 'Node link copied',
+        description: getNodeDisplayLabel(node),
+      });
+    } catch (error) {
+      notify({
+        tone: 'error',
+        title: 'Copy failed',
+        description: error instanceof Error ? error.message : 'Unable to copy the node link.',
+        autoCloseMs: 4200,
+      });
+    }
+  }, [activeNodes, activeId, notify]);
 
   // Workspace drag
   const handleWsDragStart = (e: DragEvent, wsId: string) => {
@@ -212,6 +282,12 @@ export const Sidebar = ({
           onNodeFocus={(nodeId) => onNodeFocus?.(nodeId)}
           onContextMenu={handleLayerContextMenu} onToggleCollapse={toggleLayerCollapse}
           onToggleAll={toggleAllLayers}
+          renamingLayerId={renamingLayerId}
+          renameLayerValue={renameLayerValue}
+          renameLayerInputRef={renameLayerInputRef}
+          onLayerRenameChange={setRenameLayerValue}
+          onLayerRenameCommit={commitLayerRename}
+          onLayerRenameCancel={() => setRenamingLayerId(null)}
         />
       )}
 
@@ -219,7 +295,9 @@ export const Sidebar = ({
         <LayerContextMenu
           x={layerContextMenu.x} y={layerContextMenu.y} nodeId={layerContextMenu.nodeId}
           onFocus={(nodeId) => onNodeFocus?.(nodeId)}
-          onDelete={(nodeId) => onNodeDelete?.(nodeId)}
+          onRename={(nodeId) => startLayerRename(nodeId)}
+          onDelete={(nodeId) => { void handleLayerDelete(nodeId); }}
+          onCopyLink={(nodeId) => { void handleLayerCopyLink(nodeId); }}
           onClose={() => setLayerContextMenu(null)}
         />
       )}

--- a/apps/canvas-workspace/src/renderer/src/constants/interaction.ts
+++ b/apps/canvas-workspace/src/renderer/src/constants/interaction.ts
@@ -1,0 +1,94 @@
+import type { CanvasNode } from '../types';
+import type { ShortcutSection } from '../types/ui-interaction';
+
+type EmptyCanvasNodeType = Extract<CanvasNode['type'], 'agent' | 'terminal' | 'file'>;
+
+export const DEFAULT_TOAST_DURATION_MS = 2800;
+
+export const INTERACTION_ACTIONS = {
+  workspaceCreate: 'workspace.create',
+  workspaceRename: 'workspace.rename',
+  workspaceDelete: 'workspace.delete',
+  folderCreate: 'folder.create',
+  folderRename: 'folder.rename',
+  folderDelete: 'folder.delete',
+  nodeRename: 'node.rename',
+  nodeDelete: 'node.delete',
+  nodeLinkCopy: 'node.link.copy',
+  shortcutsOpen: 'shortcuts.open',
+  emptyStateCreateAgent: 'empty-state.create-agent',
+  emptyStateCreateTerminal: 'empty-state.create-terminal',
+  emptyStateCreateNote: 'empty-state.create-note',
+} as const;
+
+export const NODE_TYPE_LABELS: Record<CanvasNode['type'], string> = {
+  file: 'Note',
+  terminal: 'Terminal',
+  frame: 'Frame',
+  agent: 'Agent',
+  text: 'Text',
+  iframe: 'Link',
+  image: 'Image',
+  shape: 'Shape',
+  mindmap: 'Mindmap',
+};
+
+export const EMPTY_CANVAS_ACTIONS: Array<{
+  actionKey: string;
+  label: string;
+  description: string;
+  nodeType: EmptyCanvasNodeType;
+}> = [
+  {
+    actionKey: INTERACTION_ACTIONS.emptyStateCreateAgent,
+    label: 'Create Agent',
+    description: 'Start a coding agent with canvas context.',
+    nodeType: 'agent',
+  },
+  {
+    actionKey: INTERACTION_ACTIONS.emptyStateCreateTerminal,
+    label: 'Open Terminal',
+    description: 'Run commands in the workspace shell.',
+    nodeType: 'terminal',
+  },
+  {
+    actionKey: INTERACTION_ACTIONS.emptyStateCreateNote,
+    label: 'New Note',
+    description: 'Capture ideas, plans, and summaries.',
+    nodeType: 'file',
+  },
+];
+
+export const SHORTCUT_SECTIONS: ShortcutSection[] = [
+  {
+    title: 'Canvas',
+    items: [
+      { combo: 'Right-click / Double-click', description: 'Open the create menu on blank canvas.' },
+      { combo: 'Scroll', description: 'Pan the canvas.' },
+      { combo: 'Ctrl/Cmd + Scroll', description: 'Zoom in or out.' },
+      { combo: 'Ctrl/Cmd + K', description: 'Open node search.' },
+      { combo: 'Ctrl/Cmd + H', description: 'Toggle node search.' },
+      { combo: 'Ctrl/Cmd + Tab', description: 'Cycle through nodes.' },
+    ],
+  },
+  {
+    title: 'Edit',
+    items: [
+      { combo: 'Ctrl/Cmd + A', description: 'Select all nodes.' },
+      { combo: 'Ctrl/Cmd + D', description: 'Duplicate the selected node.' },
+      { combo: 'Ctrl/Cmd + C / V', description: 'Copy and paste selected nodes.' },
+      { combo: 'Delete / Backspace', description: 'Delete the current selection with confirmation.' },
+      { combo: 'Ctrl/Cmd + Z', description: 'Undo the last change.' },
+      { combo: 'Ctrl/Cmd + Shift + Z', description: 'Redo the last undone change.' },
+    ],
+  },
+  {
+    title: 'Panels',
+    items: [
+      { combo: 'Ctrl/Cmd + Shift + A', description: 'Toggle the side chat panel.' },
+      { combo: 'Ctrl/Cmd + Shift + L', description: 'Open or close the full chat page.' },
+      { combo: '?', description: 'Open this shortcuts panel.' },
+      { combo: 'Esc', description: 'Close open overlays or return from chat page.' },
+    ],
+  },
+];

--- a/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.ts
@@ -11,18 +11,19 @@ interface Options {
    *  deselects it before falling through to node-deselect. */
   selectedEdgeId: string | null;
   setSelectedEdgeId: (id: string | null) => void;
-  removeEdge: (id: string) => void;
+  removeEdge: (id: string) => void | Promise<void>;
   duplicateNode: (id: string) => CanvasNode | null;
   clipboardNodes: CanvasNode[];
   setClipboardNodes: (nodes: CanvasNode[]) => void;
   pasteNodes: (nodes: CanvasNode[]) => CanvasNode[];
-  removeNodes: (ids: string[]) => void;
+  removeNodes: (ids: string[]) => void | Promise<void>;
   searchOpen: boolean;
   setSearchOpen: (open: boolean | ((prev: boolean) => boolean)) => void;
   contextMenu: unknown;
   setContextMenu: (menu: null) => void;
   setHighlightedId: (id: string | null) => void;
   handleFocusNode: (node: CanvasNode) => void;
+  keyboardLocked?: boolean;
 }
 
 export const useCanvasKeyboard = ({
@@ -31,9 +32,12 @@ export const useCanvasKeyboard = ({
   duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, removeNodes,
   searchOpen, setSearchOpen, contextMenu, setContextMenu,
   setHighlightedId, handleFocusNode,
+  keyboardLocked = false,
 }: Options) => {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (keyboardLocked) return;
+
       const active = document.activeElement;
       const isEditable = active && (
         active.tagName === 'INPUT' ||
@@ -93,14 +97,12 @@ export const useCanvasKeyboard = ({
       if ((e.key === 'Delete' || e.key === 'Backspace') && !isEditable) {
         if (selectedEdgeId) {
           e.preventDefault();
-          removeEdge(selectedEdgeId);
-          setSelectedEdgeId(null);
+          void removeEdge(selectedEdgeId);
           return;
         }
         if (selectedNodeIds.length > 0) {
           e.preventDefault();
-          removeNodes(selectedNodeIds);
-          setSelectedNodeIds([]);
+          void removeNodes(selectedNodeIds);
         }
         return;
       }
@@ -108,11 +110,13 @@ export const useCanvasKeyboard = ({
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [undo, redo, nodes, selectedNodeIds, setSelectedNodeIds, selectedEdgeId, setSelectedEdgeId, removeEdge, duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, removeNodes, searchOpen, setSearchOpen, contextMenu, setContextMenu]);
+  }, [undo, redo, nodes, selectedNodeIds, setSelectedNodeIds, selectedEdgeId, setSelectedEdgeId, removeEdge, duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, removeNodes, searchOpen, setSearchOpen, contextMenu, setContextMenu, keyboardLocked]);
 
   // Cmd/Ctrl+Tab to cycle through nodes (Shift reverses direction)
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (keyboardLocked) return;
+
       if ((e.metaKey || e.ctrlKey) && e.key === 'Tab') {
         const activeEl = document.activeElement;
         const isEditable = activeEl && (
@@ -138,5 +142,5 @@ export const useCanvasKeyboard = ({
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [nodes, selectedNodeIds, setSelectedNodeIds, setHighlightedId, handleFocusNode]);
+  }, [nodes, selectedNodeIds, setSelectedNodeIds, setHighlightedId, handleFocusNode, keyboardLocked]);
 };

--- a/apps/canvas-workspace/src/renderer/src/hooks/useWorkspaces.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useWorkspaces.ts
@@ -13,6 +13,11 @@ export interface FolderEntry {
   collapsed?: boolean;
 }
 
+export interface WorkspaceDeleteResult {
+  ok: boolean;
+  error?: string;
+}
+
 interface WorkspaceManifest {
   workspaces: WorkspaceEntry[];
   folders?: FolderEntry[];
@@ -27,6 +32,8 @@ export const useWorkspaces = () => {
   const [activeId, setActiveId] = useState('default');
   const activeIdRef = useRef(activeId);
   activeIdRef.current = activeId;
+  const workspacesRef = useRef(workspaces);
+  workspacesRef.current = workspaces;
   const foldersRef = useRef(folders);
   foldersRef.current = folders;
 
@@ -106,18 +113,29 @@ export const useWorkspaces = () => {
   );
 
   const deleteWorkspace = useCallback(
-    (id: string) => {
+    async (id: string): Promise<WorkspaceDeleteResult> => {
       const api = window.canvasWorkspace?.store;
-      setWorkspaces((prev) => {
-        if (prev.length <= 1) return prev;
-        const next = prev.filter((w) => w.id !== id);
-        const newActiveId =
-          activeIdRef.current === id ? next[0].id : activeIdRef.current;
-        saveManifest(next, newActiveId);
-        if (activeIdRef.current === id) setActiveId(newActiveId);
-        if (api) void api.delete(id);
-        return next;
-      });
+      const current = workspacesRef.current;
+      if (current.length <= 1) {
+        return { ok: false, error: 'Cannot delete the only workspace.' };
+      }
+
+      if (api) {
+        const result = await api.delete(id);
+        if (!result.ok) {
+          return { ok: false, error: result.error };
+        }
+      }
+
+      const next = current.filter((w) => w.id !== id);
+      const newActiveId =
+        activeIdRef.current === id ? next[0].id : activeIdRef.current;
+
+      setWorkspaces(next);
+      saveManifest(next, newActiveId);
+      if (activeIdRef.current === id) setActiveId(newActiveId);
+
+      return { ok: true };
     },
     [saveManifest]
   );

--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -22,6 +22,9 @@
   --accent-file: #d9730d;
   --accent-term: #0f7b6c;
   --accent-frame: #A594E0;
+  --success: #1f7a4d;
+  --error: #c0392b;
+  --overlay-backdrop: rgba(32, 34, 37, 0.22);
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.04);
   --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.04), 0 4px 12px rgba(0, 0, 0, 0.05);
   --shadow-card-hover: 0 2px 6px rgba(0, 0, 0, 0.06), 0 8px 20px rgba(0, 0, 0, 0.07);

--- a/apps/canvas-workspace/src/renderer/src/types/ui-interaction.ts
+++ b/apps/canvas-workspace/src/renderer/src/types/ui-interaction.ts
@@ -1,0 +1,39 @@
+export type ToastTone = 'success' | 'error' | 'loading' | 'info';
+
+export interface ToastInput {
+  tone: ToastTone;
+  title: string;
+  description?: string;
+  autoCloseMs?: number;
+}
+
+export interface ToastRecord extends ToastInput {
+  id: string;
+  createdAt: number;
+}
+
+export type ConfirmIntent = 'default' | 'danger';
+
+export interface ConfirmOptions {
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  intent?: ConfirmIntent;
+}
+
+export interface ShortcutItem {
+  combo: string;
+  description: string;
+}
+
+export interface ShortcutSection {
+  title: string;
+  items: ShortcutItem[];
+}
+
+export interface CanvasNodeRenameRequest {
+  workspaceId: string;
+  nodeId: string;
+  title: string;
+}

--- a/apps/canvas-workspace/src/renderer/src/utils/canvasLinks.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/canvasLinks.ts
@@ -1,0 +1,19 @@
+const CANVAS_ROUTE = '/';
+
+export function buildCanvasNodeLink(workspaceId: string, nodeId: string): string {
+  const url = new URL(window.location.href);
+  const params = new URLSearchParams({ workspaceId, nodeId });
+  url.hash = `${CANVAS_ROUTE}?${params.toString()}`;
+  return url.toString();
+}
+
+export function parseCanvasLocation(location: string): {
+  path: string;
+  params: URLSearchParams;
+} {
+  const [rawPath, rawQuery = ''] = location.split('?');
+  return {
+    path: rawPath || CANVAS_ROUTE,
+    params: new URLSearchParams(rawQuery),
+  };
+}

--- a/apps/canvas-workspace/src/renderer/src/utils/clipboard.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/clipboard.ts
@@ -1,0 +1,23 @@
+export async function copyTextToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', 'true');
+  textarea.style.position = 'fixed';
+  textarea.style.top = '-9999px';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+
+  const copied = document.execCommand('copy');
+  document.body.removeChild(textarea);
+
+  if (!copied) {
+    throw new Error('Clipboard API is unavailable.');
+  }
+}

--- a/apps/canvas-workspace/src/renderer/src/utils/nodeLabel.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/nodeLabel.ts
@@ -16,6 +16,9 @@ const TEXT_LABEL_MAX_CHARS = 10;
  */
 export function getNodeDisplayLabel(node: CanvasNode): string {
   if (node.type === "text") {
+    const explicitTitle = node.title.trim();
+    if (explicitTitle && explicitTitle !== 'Text') return explicitTitle;
+
     const preview = textContentPreview((node.data as TextNodeData).content);
     if (preview) return preview;
     return node.title || "Text";


### PR DESCRIPTION
## Summary

- **Agent A — 节点内交互增强**：状态标签（Running/Done/Error）、最后活跃时间、双击重命名标题、节点内容 Copy 按钮、Agent 快捷操作按钮（Continue / Summarize / Stop）
- **Agent B — 全局交互增强**：删除/覆盖二次确认、统一 Toast 反馈、空状态引导、`?` 快捷键面板、Sidebar 右键菜单高频项补齐

## Test plan

- [ ] Agent 节点 hover 时显示 Running/Done/Error pill，非 hover 时只保留图标角标绿点
- [ ] 节点标题双击进入编辑，Enter 保存，Escape 取消
- [ ] Copy 按钮复制对应内容（file/agent/text），复制成功有勾选反馈
- [ ] AgentTerminal running 状态下 Continue / Summarize / Stop 按钮可用
- [ ] 删除节点弹出二次确认框
- [ ] 空白画布显示创建引导
- [ ] `?` 键打开快捷键说明面板
- [ ] Sidebar 右键菜单包含重命名/删除/复制链接

🤖 Generated with [Claude Code](https://claude.com/claude-code)