### PR TITLE
feat(remote-server): support full LLM provider config (baseURL/apiKey/headers)

### DIFF
--- a/apps/remote-server/src/core/agent-runner.ts
+++ b/apps/remote-server/src/core/agent-runner.ts
@@ -234,15 +234,27 @@ function buildChannelSystemPrompt(platformKey: string): string | null {
 function resolveRunProvider(
   modelType: 'openai' | 'claude' | undefined,
   platformKey: string,
+  overrides?: { baseURL?: string; apiKey?: string; headers?: Record<string, string> },
 ): LLMProviderFactory | undefined {
-  if (modelType !== 'claude') {
-    return undefined;
-  }
+  // 只要配置里给了任意 provider 级别的覆盖（含 modelType / baseURL / apiKey / headers），
+  // 就显式构造 provider；否则保持 undefined，让 engine 走 env 兜底。
+  const hasOverride =
+    !!modelType ||
+    !!overrides?.baseURL ||
+    !!overrides?.apiKey ||
+    !!(overrides?.headers && Object.keys(overrides.headers).length > 0);
+  if (!hasOverride) return undefined;
 
-  return buildProvider('claude', {
-    headers: {
-      'x-session-id': platformKey,
-    },
+  const type: 'openai' | 'claude' = modelType ?? 'openai';
+  const headers: Record<string, string> = {
+    ...(type === 'claude' ? { 'x-session-id': platformKey } : {}),
+    ...(overrides?.headers ?? {}),
+  };
+
+  return buildProvider(type, {
+    baseURL: overrides?.baseURL,
+    apiKey: overrides?.apiKey,
+    headers: Object.keys(headers).length > 0 ? headers : undefined,
   });
 }
 
@@ -276,8 +288,8 @@ export async function executeAgentTurn(input: ExecuteAgentTurnInput): Promise<Ex
   const context = session.context;
   const callbacks = input.callbacks ?? {};
   const compactions: CompactionSnapshot[] = [];
-  const { model: modelOverride, modelType } = await resolveModelForRun(input.platformKey);
-  const providerOverride = resolveRunProvider(modelType, input.platformKey);
+  const { model: modelOverride, modelType, baseURL, apiKey, headers } = await resolveModelForRun(input.platformKey);
+  const providerOverride = resolveRunProvider(modelType, input.platformKey, { baseURL, apiKey, headers });
 
   let latestAttachments = session.latestAttachments ?? [];
   if (input.attachments?.length) {

--- a/apps/remote-server/src/core/chat-commands/handlers/model-commands.ts
+++ b/apps/remote-server/src/core/chat-commands/handlers/model-commands.ts
@@ -27,14 +27,24 @@ export async function handleModelCommand(args: string[]): Promise<CommandResult>
   const model = raw;
   try {
     const option = await resolveModelOption(model);
+    // 命中 option 时，把 option 上的 provider/连接覆盖一并写入顶层，
+    // 这样 resolveModelForRun 不依赖 option 也能解析；同时 option 自身仍保留作为字典。
     const next = option
-      ? { current_model: option.name, provider_type: option.provider_type }
+      ? {
+          current_model: option.name,
+          provider_type: option.provider_type,
+          base_url: option.base_url,
+          api_key_env: option.api_key_env,
+          headers: option.headers,
+        }
       : { current_model: model };
     const result = await writeModelConfig(next);
     const providerHint = option?.provider_type ? ` (${option.provider_type})` : '';
+    const baseURLHint = option?.base_url ? `\nbaseURL: ${option.base_url}` : '';
+    const apiKeyHint = option?.api_key_env ? `\napi_key_env: ${option.api_key_env}` : '';
     return {
       type: 'handled',
-      message: `✅ 已更新模型为 ${model}${providerHint}\nConfig: ${result.path}`,
+      message: `✅ 已更新模型为 ${model}${providerHint}${baseURLHint}${apiKeyHint}\nConfig: ${result.path}`,
     };
   } catch (error) {
     console.error('[model-config] failed to update model config:', error);
@@ -67,11 +77,19 @@ async function renderModelStatus(): Promise<CommandResult> {
     } else {
       lines.push('- resolved_model: (未解析到)');
     }
+    if (status.resolvedBaseURL) {
+      lines.push(`- base_url: ${status.resolvedBaseURL}`);
+    }
+    if (status.resolvedApiKeyEnv) {
+      const present = process.env[status.resolvedApiKeyEnv]?.trim() ? '✅' : '⚠️ 未设置';
+      lines.push(`- api_key_env: ${status.resolvedApiKeyEnv} ${present}`);
+    }
     if (status.options && status.options.length > 0) {
       lines.push('- options:');
       for (const opt of status.options) {
         const providerLabel = opt.provider_type ? ` [${opt.provider_type}]` : '';
-        lines.push(`  • ${opt.name}${providerLabel}`);
+        const baseHint = opt.base_url ? ` @ ${opt.base_url}` : '';
+        lines.push(`  • ${opt.name}${providerLabel}${baseHint}`);
       }
     } else if (status.models && status.models.length > 0) {
       lines.push(`- models: ${status.models.join(', ')}`);

--- a/apps/remote-server/src/core/model-config.test.ts
+++ b/apps/remote-server/src/core/model-config.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'fs';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import {
+  clearModelOverride,
+  getModelStatus,
+  resolveModelForRun,
+  resolveModelOption,
+  writeModelConfig,
+} from './model-config.js';
+
+let tmpDir: string;
+let configPath: string;
+const ENV_KEY = 'PULSE_CODER_MODEL_CONFIG';
+const TEST_API_ENV = 'TEST_PROVIDER_API_KEY';
+
+const originalEnv = process.env[ENV_KEY];
+const originalApiKey = process.env[TEST_API_ENV];
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'pulse-model-config-'));
+  configPath = join(tmpDir, 'config.json');
+  process.env[ENV_KEY] = configPath;
+  delete process.env[TEST_API_ENV];
+});
+
+afterEach(async () => {
+  if (originalEnv === undefined) delete process.env[ENV_KEY];
+  else process.env[ENV_KEY] = originalEnv;
+  if (originalApiKey === undefined) delete process.env[TEST_API_ENV];
+  else process.env[TEST_API_ENV] = originalApiKey;
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('model-config provider overrides', () => {
+  it('returns empty when no config exists', async () => {
+    const result = await resolveModelForRun('platform-key');
+    expect(result).toEqual({});
+  });
+
+  it('writes and reads back top-level provider overrides', async () => {
+    await writeModelConfig({
+      current_model: 'gpt-4o-mini',
+      provider_type: 'openai',
+      base_url: 'https://example.com/v1',
+      api_key_env: TEST_API_ENV,
+      headers: { 'x-test': '1' },
+    });
+
+    process.env[TEST_API_ENV] = 'sk-test-123';
+
+    const resolved = await resolveModelForRun('platform-key');
+    expect(resolved.model).toBe('gpt-4o-mini');
+    expect(resolved.modelType).toBe('openai');
+    expect(resolved.baseURL).toBe('https://example.com/v1');
+    expect(resolved.apiKey).toBe('sk-test-123');
+    expect(resolved.headers).toEqual({ 'x-test': '1' });
+  });
+
+  it('option-level overrides take precedence over top-level fallbacks', async () => {
+    await writeModelConfig({
+      current_model: 'claude-fast',
+      provider_type: 'openai',
+      base_url: 'https://top.example/v1',
+      api_key_env: 'TOP_KEY',
+      options: [
+        {
+          name: 'claude-fast',
+          provider_type: 'claude',
+          base_url: 'https://opt.example/v1',
+          api_key_env: TEST_API_ENV,
+          model: 'claude-3-5-sonnet-latest',
+          headers: { 'x-opt': '1' },
+        },
+      ],
+    });
+
+    process.env[TEST_API_ENV] = 'opt-key';
+
+    const resolved = await resolveModelForRun('p');
+    expect(resolved.model).toBe('claude-3-5-sonnet-latest'); // option.model wins
+    expect(resolved.modelType).toBe('claude');
+    expect(resolved.baseURL).toBe('https://opt.example/v1');
+    expect(resolved.apiKey).toBe('opt-key');
+    expect(resolved.headers).toEqual({ 'x-opt': '1' });
+  });
+
+  it('apiKey is undefined when env var missing', async () => {
+    await writeModelConfig({
+      current_model: 'm',
+      provider_type: 'openai',
+      api_key_env: TEST_API_ENV,
+    });
+    const resolved = await resolveModelForRun('p');
+    expect(resolved.apiKey).toBeUndefined();
+  });
+
+  it('getModelStatus reflects resolved provider fields', async () => {
+    await writeModelConfig({
+      current_model: 'm',
+      provider_type: 'claude',
+      base_url: 'https://b/v1',
+      api_key_env: TEST_API_ENV,
+    });
+    const status = await getModelStatus();
+    expect(status.providerType).toBe('claude');
+    expect(status.resolvedBaseURL).toBe('https://b/v1');
+    expect(status.resolvedApiKeyEnv).toBe(TEST_API_ENV);
+    expect(status.resolvedModel).toBe('m');
+  });
+
+  it('clearModelOverride removes provider-level overrides', async () => {
+    await writeModelConfig({
+      current_model: 'm',
+      provider_type: 'claude',
+      base_url: 'https://b/v1',
+      api_key_env: TEST_API_ENV,
+      options: [{ name: 'm', provider_type: 'claude' }],
+    });
+    await clearModelOverride();
+    const status = await getModelStatus();
+    expect(status.currentModel).toBeUndefined();
+    expect(status.providerType).toBeUndefined();
+    expect(status.resolvedBaseURL).toBeUndefined();
+    expect(status.resolvedApiKeyEnv).toBeUndefined();
+    // options preserved as a dictionary
+    expect(status.options?.[0]?.name).toBe('m');
+  });
+
+  it('resolveModelOption returns option by name', async () => {
+    await writeModelConfig({
+      options: [
+        { name: 'a', provider_type: 'openai' },
+        { name: 'b', provider_type: 'claude', base_url: 'https://b' },
+      ],
+    });
+    const opt = await resolveModelOption('b');
+    expect(opt?.provider_type).toBe('claude');
+    expect(opt?.base_url).toBe('https://b');
+  });
+});

--- a/apps/remote-server/src/core/model-config.ts
+++ b/apps/remote-server/src/core/model-config.ts
@@ -2,14 +2,31 @@ import { promises as fs } from 'fs';
 import { homedir } from 'os';
 import { join, resolve, dirname } from 'path';
 
-type ModelOption = {
+export type ProviderType = 'openai' | 'claude';
+
+/**
+ * Provider-level overrides for an option / current model.
+ * - provider_type 决定走哪个 SDK family（openai / claude），保留二选一以匹配 engine。
+ * - base_url / api_key_env / headers 用于覆盖默认 env 解析的连接参数。
+ *   api_key_env 只存"环境变量名"，避免明文写入配置文件。
+ * - model 允许 option 自带模型名（current_model 不指定时也能解析）。
+ */
+export type ModelOption = {
   name: string;
-  provider_type?: 'openai' | 'claude';
+  provider_type?: ProviderType;
+  base_url?: string;
+  api_key_env?: string;
+  headers?: Record<string, string>;
+  model?: string;
 };
 
 type ModelConfig = {
   current_model?: string;
-  provider_type?: 'openai' | 'claude';
+  provider_type?: ProviderType;
+  /** 顶层也允许配 base_url / api_key_env / headers，作为 current_model 的兜底。 */
+  base_url?: string;
+  api_key_env?: string;
+  headers?: Record<string, string>;
   options?: ModelOption[];
   models?: Array<{
     name?: string;
@@ -24,8 +41,10 @@ type ModelConfigWriteResult = {
 type ModelStatus = {
   path: string | null;
   currentModel?: string;
-  providerType?: 'openai' | 'claude';
+  providerType?: ProviderType;
   resolvedModel?: string;
+  resolvedBaseURL?: string;
+  resolvedApiKeyEnv?: string;
   options?: ModelOption[];
   models?: string[];
 };
@@ -38,11 +57,8 @@ type CachedConfig = {
 
 let cachedConfig: CachedConfig | null = null;
 
-function normalizeModel(value: unknown): string | null {
-  if (typeof value !== 'string') {
-    return null;
-  }
-
+function normalizeStr(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
   const trimmed = value.trim();
   return trimmed ? trimmed : null;
 }
@@ -94,7 +110,7 @@ async function ensureConfigDir(path: string): Promise<void> {
   await fs.mkdir(dirname(path), { recursive: true });
 }
 
-export async function writeModelConfig(next: ModelConfig): Promise<ModelConfigWriteResult> {
+export async function writeModelConfig(next: Partial<ModelConfig>): Promise<ModelConfigWriteResult> {
   const envPath = process.env.PULSE_CODER_MODEL_CONFIG?.trim();
   const configPath = await findConfigPath();
   const path = envPath || configPath || resolve(process.cwd(), '.pulse-coder', 'config.json');
@@ -128,13 +144,18 @@ function selectModel(config: ModelConfig | null): string | null {
     return null;
   }
 
-  const current = normalizeModel(config.current_model);
+  const current = normalizeStr(config.current_model);
   if (current) {
+    // 如果 current_model 命中了某个 option 且 option.model 存在，优先用 option.model
+    const opt = config.options?.find((o) => o?.name === current);
+    if (opt?.model) {
+      return normalizeStr(opt.model) ?? current;
+    }
     return current;
   }
 
   const firstModel = Array.isArray(config.models) ? config.models[0] : null;
-  return normalizeModel(firstModel?.name);
+  return normalizeStr(firstModel?.name);
 }
 
 export async function clearModelOverride(): Promise<ModelConfigWriteResult> {
@@ -151,6 +172,11 @@ export async function clearModelOverride(): Promise<ModelConfigWriteResult> {
     ...(existing ?? {}),
   };
   delete merged.current_model;
+  // current model 级别的 provider 覆盖也一并清掉，避免脏状态
+  delete merged.provider_type;
+  delete merged.base_url;
+  delete merged.api_key_env;
+  delete merged.headers;
 
   const payload = `${JSON.stringify(merged, null, 2)}\n`;
   await fs.writeFile(path, payload, 'utf8');
@@ -159,95 +185,91 @@ export async function clearModelOverride(): Promise<ModelConfigWriteResult> {
   return { path, config: merged };
 }
 
-export async function getModelStatus(): Promise<ModelStatus> {
+async function loadConfigCached(): Promise<{ path: string | null; data: ModelConfig | null }> {
   const envPath = process.env.PULSE_CODER_MODEL_CONFIG?.trim();
   const configPath = await findConfigPath();
   const path = envPath || configPath || null;
   if (!path) {
-    return { path: null };
+    return { path: null, data: null };
   }
 
-  let data: ModelConfig | null = null;
   try {
     const stat = await fs.stat(path);
     if (cachedConfig && cachedConfig.path === path && cachedConfig.mtimeMs === stat.mtimeMs) {
-      data = cachedConfig.data;
-    } else {
-      data = await loadConfigFromPath(path, { warn: true });
-      if (data) {
-        cachedConfig = { path, mtimeMs: stat.mtimeMs, data };
-      }
+      return { path, data: cachedConfig.data };
     }
+    const data = await loadConfigFromPath(path, { warn: true });
+    if (data) cachedConfig = { path, mtimeMs: stat.mtimeMs, data };
+    return { path, data };
   } catch {
-    return { path };
+    return { path, data: null };
   }
+}
+
+export async function getModelStatus(): Promise<ModelStatus> {
+  const { path, data } = await loadConfigCached();
+  if (!path) return { path: null };
 
   const resolvedModel = selectModel(data);
   const models = Array.isArray(data?.models)
     ? data?.models
-        .map((item) => normalizeModel(item?.name))
+        .map((item) => normalizeStr(item?.name))
         .filter((name): name is string => Boolean(name))
     : undefined;
 
+  // 解析当前生效的 provider override（option 优先 → 顶层兜底）
+  const currentName = normalizeStr(data?.current_model);
+  const currentOption = currentName ? data?.options?.find((o) => o?.name === currentName) : undefined;
+
+  const resolvedBaseURL =
+    normalizeStr(currentOption?.base_url) ?? normalizeStr(data?.base_url) ?? undefined;
+  const resolvedApiKeyEnv =
+    normalizeStr(currentOption?.api_key_env) ?? normalizeStr(data?.api_key_env) ?? undefined;
+  const providerType =
+    currentOption?.provider_type ?? data?.provider_type ?? undefined;
+
   return {
     path,
-    currentModel: normalizeModel(data?.current_model) ?? undefined,
-    providerType: data?.provider_type,
+    currentModel: currentName ?? undefined,
+    providerType,
     resolvedModel: resolvedModel ?? undefined,
-    options: Array.isArray(data?.options) && data.options.length > 0 ? data.options : undefined,
+    resolvedBaseURL,
+    resolvedApiKeyEnv,
+    options: Array.isArray(data?.options) && data!.options!.length > 0 ? data!.options : undefined,
     models: models && models.length > 0 ? models : undefined,
   };
 }
 
 export async function resolveModelOption(name: string): Promise<ModelOption | null> {
-  const envPath = process.env.PULSE_CODER_MODEL_CONFIG?.trim();
-  const configPath = await findConfigPath();
-  const path = envPath || configPath || null;
-  if (!path) return null;
-
-  try {
-    const stat = await fs.stat(path);
-    let data: ModelConfig | null;
-    if (cachedConfig && cachedConfig.path === path && cachedConfig.mtimeMs === stat.mtimeMs) {
-      data = cachedConfig.data;
-    } else {
-      data = await loadConfigFromPath(path, { warn: true });
-      if (data) cachedConfig = { path, mtimeMs: stat.mtimeMs, data };
-    }
-    return data?.options?.find((o) => o.name === name) ?? null;
-  } catch {
-    return null;
-  }
+  const { data } = await loadConfigCached();
+  return data?.options?.find((o) => o.name === name) ?? null;
 }
 
-export async function resolveModelForRun(_platformKey: string): Promise<{ model?: string; modelType?: 'openai' | 'claude' }> {
-  const envPath = process.env.PULSE_CODER_MODEL_CONFIG?.trim();
-  const configPath = await findConfigPath();
-  const path = envPath || configPath || null;
-  if (!path) {
-    return {};
-  }
+export type ResolvedRunModel = {
+  model?: string;
+  modelType?: ProviderType;
+  baseURL?: string;
+  apiKey?: string;
+  headers?: Record<string, string>;
+};
 
-  try {
-    const stat = await fs.stat(path);
-    if (cachedConfig && cachedConfig.path === path && cachedConfig.mtimeMs === stat.mtimeMs) {
-      return {
-        model: selectModel(cachedConfig.data) ?? undefined,
-        modelType: cachedConfig.data?.provider_type,
-      };
-    }
+/**
+ * 解析当前运行该使用的 provider/model 参数。
+ * 优先级：current_model 命中的 option > 顶层配置 > undefined（让 engine 走 env fallback）。
+ */
+export async function resolveModelForRun(_platformKey: string): Promise<ResolvedRunModel> {
+  const { data } = await loadConfigCached();
+  if (!data) return {};
 
-    const data = await loadConfigFromPath(path, { warn: true });
-    if (!data) {
-      return {};
-    }
-    cachedConfig = { path, mtimeMs: stat.mtimeMs, data };
-    return {
-      model: selectModel(data) ?? undefined,
-      modelType: data.provider_type,
-    };
-  } catch {
-    return {};
-  }
+  const currentName = normalizeStr(data.current_model);
+  const option = currentName ? data.options?.find((o) => o?.name === currentName) : undefined;
+
+  const model = selectModel(data) ?? undefined;
+  const modelType = option?.provider_type ?? data.provider_type;
+  const baseURL = normalizeStr(option?.base_url) ?? normalizeStr(data.base_url) ?? undefined;
+  const apiKeyEnv = normalizeStr(option?.api_key_env) ?? normalizeStr(data.api_key_env) ?? undefined;
+  const apiKey = apiKeyEnv ? process.env[apiKeyEnv]?.trim() || undefined : undefined;
+  const headers = option?.headers ?? data.headers;
+
+  return { model, modelType, baseURL, apiKey, headers };
 }
-

--- a/packages/engine/src/config/index.ts
+++ b/packages/engine/src/config/index.ts
@@ -46,6 +46,10 @@ export const CoderAI = (USE_ANTHROPIC
 
 export interface BuildProviderOptions {
   headers?: Record<string, string>;
+  /** Override API key. Falls back to env (OPENAI_API_KEY / ANTHROPIC_API_KEY). */
+  apiKey?: string;
+  /** Override base URL. Falls back to env (OPENAI_API_URL / ANTHROPIC_API_URL). */
+  baseURL?: string;
 }
 
 /**
@@ -64,8 +68,8 @@ export interface BuildProviderOptions {
 export function buildProvider(type: ModelType, options?: BuildProviderOptions): LLMProviderFactory {
   if (type === 'claude') {
     return createAnthropic({
-      apiKey: ANTHROPIC_API_KEY,
-      baseURL: ANTHROPIC_API_URL,
+      apiKey: options?.apiKey ?? ANTHROPIC_API_KEY,
+      baseURL: options?.baseURL ?? ANTHROPIC_API_URL,
       headers: {
         'user-agent': 'claude-code/2.1.63',
         ...(options?.headers ?? {}),
@@ -73,8 +77,8 @@ export function buildProvider(type: ModelType, options?: BuildProviderOptions): 
     }) as LLMProviderFactory;
   }
   return createOpenAI({
-    apiKey: OPENAI_API_KEY,
-    baseURL: OPENAI_API_URL,
+    apiKey: options?.apiKey ?? OPENAI_API_KEY,
+    baseURL: options?.baseURL ?? OPENAI_API_URL,
     headers: options?.headers,
   }).responses as LLMProviderFactory;
 }


### PR DESCRIPTION
## Summary
让 \`apps/remote-server\` 真正支持"按配置切换 LLM provider"，不再被锁死在 openai/claude 两个硬编码分支、且只能改 \`.env\` 才能换 provider。

## Affected packages
- \`pulse-coder-engine\`：\`buildProvider\` 新增 \`apiKey/baseURL\` 入参（向后兼容）
- \`@pulse-coder/remote-server\`：\`model-config\` schema 扩展 + \`agent-runner\` provider 注入逻辑改造 + \`/model\` 命令展示更新

## Highlights
- \`~/.pulse-coder/config.json\` 现在支持 \`base_url\` / \`api_key_env\` / \`headers\`，option 级覆盖优先于顶层
- \`api_key_env\` 只存"环境变量名"，避免明文落盘
- \`/model status\` 展示 baseURL + apiKey env（含 ✅/⚠️ 状态）
- 完全向后兼容：旧配置不改也能跑

## Backward compatibility
- 所有新字段均为 optional，旧 \`config.json\` 行为不变
- \`resolveRunProvider\` 在没有任何 provider 覆盖时仍返回 \`undefined\`，让 engine 走 env 兜底
- \`buildProvider\` 新增的 \`apiKey/baseURL\` 不传时仍然 fallback 到 env

## Test evidence
- \`npx vitest run src/core/model-config.test.ts\` → **7/7 passed**
- 全量 \`npx vitest run\` → 10/10 业务用例通过（仅 \`attachments.test.ts\` 因预存在的 \`pulse-coder-plugin-kit/vault\` dts 缺失而 load fail，与本 PR 无关）

## Config 示例
\`\`\`json
{
  "current_model": "claude-via-anyrouter",
  "options": [
    {
      "name": "claude-via-anyrouter",
      "provider_type": "claude",
      "model": "claude-3-5-sonnet-latest",
      "base_url": "https://anyrouter.example/v1",
      "api_key_env": "ANYROUTER_KEY"
    }
  ]
}
\`\`\`
切换：\`/model claude-via-anyrouter\`，无需重启或改 \`.env\`。