### PR TITLE
feat(canvas-workspace): mindmap 非根节点支持点击展开/折叠

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.css
@@ -155,18 +155,51 @@
 }
 
 /*
- * Collapsed-subtree hint: a small dot after the text. Signals "this
- * topic has hidden children" without the overhead of an explicit
- * expand/collapse button.
+ * Inline collapse/expand toggle for non-root topics with children.
+ *
+ * Resting visual:
+ *   - Collapsed → filled colored dot (same hint as the old static dot, so
+ *     a folded subtree still reads at-a-glance).
+ *   - Expanded  → faint hollow ring; opaque on pill hover so the
+ *     affordance shows up only when the user is reaching for it.
+ *
+ * Click toggles. We give it no border / no background outside the ring
+ * so it sits cleanly inside the chromeless pill.
  */
-.mindmap-topic-collapsed-dot {
+.mindmap-topic-toggle {
   flex: 0 0 auto;
   margin-left: 6px;
   margin-bottom: 3px;
   width: 6px;
   height: 6px;
+  padding: 0;
   border-radius: 50%;
+  border: 1px solid var(--mindmap-topic-toggle-color, currentColor);
+  background: transparent;
+  cursor: pointer;
+  opacity: 0.25;
+  transition: opacity 120ms ease, transform 120ms ease;
+}
+
+.mindmap-topic:hover .mindmap-topic-toggle {
+  opacity: 0.85;
+}
+
+.mindmap-topic-toggle:hover {
+  opacity: 1;
+  transform: scale(1.15);
+}
+
+/* Collapsed: solid filled dot in the branch color. The filled state
+ * doubles as the "subtree is hidden" cue, so it's always visible
+ * regardless of pill hover. */
+.mindmap-topic-toggle--collapsed {
+  background: var(--mindmap-topic-toggle-color, currentColor);
   opacity: 0.9;
+}
+
+.mindmap-topic-toggle--collapsed:hover {
+  opacity: 1;
 }
 
 /* ---- Drag-reorder visuals ----

--- a/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.tsx
@@ -419,6 +419,7 @@ export const MindmapNodeBody = ({ node, isSelected, onUpdate, onSelectNode, onAu
               }}
               onCommitText={(text) => renameTopic(t.id, text)}
               onExitEdit={() => setEditingId(null)}
+              onToggleCollapsed={() => toggle(t.id)}
               onKeyAction={(action) => {
                 switch (action.kind) {
                   case 'addChild':
@@ -479,6 +480,10 @@ interface TopicPillProps {
   onEnterEdit: () => void;
   onCommitText: (text: string) => void;
   onExitEdit: () => void;
+  /** Toggle this topic's `collapsed` flag. Wired to both the click
+   *  affordance rendered inside the pill and (via onKeyAction) the Space
+   *  key shortcut. */
+  onToggleCollapsed: () => void;
   onKeyAction: (action: KeyAction) => void;
 }
 
@@ -493,6 +498,7 @@ const TopicPill = ({
   onEnterEdit,
   onCommitText,
   onExitEdit,
+  onToggleCollapsed,
   onKeyAction,
 }: TopicPillProps) => {
   const editorRef = useRef<HTMLDivElement>(null);
@@ -719,14 +725,33 @@ const TopicPill = ({
       >
         {topic.text}
       </div>
-      {/* Collapsed-subtree hint: a small filled dot in the branch color
-          sitting just after the text, so users can see "something is
-          hidden here" without the heavy +/- button. */}
-      {topic.collapsed && topic.hasChildren && (
-        <span
-          className="mindmap-topic-collapsed-dot"
-          style={{ background: topic.color }}
-          aria-label="collapsed"
+      {/* Collapse/expand toggle. Renders for every non-root topic that has
+       *  children. Collapsed state reads as a filled colored dot (same
+       *  Heptabase-style hint as before) so the page still has a clean
+       *  "hidden subtree" cue at rest. Expanded state shows a faint hollow
+       *  ring that becomes opaque on hover, so the affordance only draws
+       *  attention when the user is reaching for it.
+       *
+       *  `onMouseDown` stops propagation so clicking the toggle never
+       *  starts a topic select / reorder drag on the parent pill; the
+       *  click handler then toggles. */}
+      {!isRoot && topic.hasChildren && (
+        <button
+          type="button"
+          className={[
+            'mindmap-topic-toggle',
+            topic.collapsed && 'mindmap-topic-toggle--collapsed',
+          ]
+            .filter(Boolean)
+            .join(' ')}
+          style={{ ['--mindmap-topic-toggle-color' as string]: topic.color }}
+          aria-label={topic.collapsed ? 'Expand subtree' : 'Collapse subtree'}
+          onMouseDown={(e) => e.stopPropagation()}
+          onDoubleClick={(e) => e.stopPropagation()}
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleCollapsed();
+          }}
         />
       )}
     </div>

--- a/apps/canvas-workspace/src/renderer/src/utils/mindmapLayout.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/mindmapLayout.ts
@@ -121,9 +121,11 @@ const TOPIC_MAX_WIDTH = 320;
 // (16px) and the inner `.mindmap-topic-text` adds `padding: 1px 3px` (6px),
 // for 22px total. Keep a small safety buffer for sub-pixel rounding.
 const TOPIC_HORIZONTAL_PADDING = 24;
-// Width reserved for the collapsed-state dot rendered next to the text:
-// `.mindmap-topic-collapsed-dot` is 6px wide + 6px margin-left.
-const COLLAPSED_DOT_RESERVE = 12;
+// Width reserved for the collapse/expand toggle rendered next to the text
+// of any non-root topic that has children. The toggle is always present
+// (collapsed → filled dot; expanded → hover ring) so it claims layout
+// space unconditionally, not just in the collapsed state.
+const TOGGLE_RESERVE = 12;
 
 export const layoutMindmap = (
   root: MindmapTopic,
@@ -143,12 +145,14 @@ export const layoutMindmap = (
     if (cached !== undefined) return cached;
     const fontSize = isRoot ? 20 : 14;
     const text = t.text || 'Untitled';
-    // Collapsed non-root topics render a dot next to the text inside the
-    // same flex row; reserve space for it so the text doesn't get squeezed.
-    const collapsedReserve =
-      !isRoot && t.collapsed && t.children.length > 0 ? COLLAPSED_DOT_RESERVE : 0;
+    // Non-root topics with children render an inline toggle button next
+    // to the text — reserve space for it whether expanded or collapsed,
+    // since the button is always present (the hover-only ring still
+    // claims layout width).
+    const toggleReserve =
+      !isRoot && t.children.length > 0 ? TOGGLE_RESERVE : 0;
     const estimated =
-      estimateTextWidth(text, fontSize) + TOPIC_HORIZONTAL_PADDING + collapsedReserve;
+      estimateTextWidth(text, fontSize) + TOPIC_HORIZONTAL_PADDING + toggleReserve;
     const min = isRoot ? ROOT_MIN_WIDTH : TOPIC_MIN_WIDTH;
     const w = Math.max(min, Math.min(TOPIC_MAX_WIDTH, Math.ceil(estimated)));
     widthOf.set(t.id, w);
@@ -172,11 +176,10 @@ export const layoutMindmap = (
     const fontSize = 14;
     const lineHeight = Math.ceil(fontSize * 1.3); // matches .mindmap-topic CSS
     const w = resolveWidth(t, false);
-    const collapsedReserve =
-      t.collapsed && t.children.length > 0 ? COLLAPSED_DOT_RESERVE : 0;
+    const toggleReserve = t.children.length > 0 ? TOGGLE_RESERVE : 0;
     const available = Math.max(
       lineHeight,
-      w - TOPIC_HORIZONTAL_PADDING - collapsedReserve,
+      w - TOPIC_HORIZONTAL_PADDING - toggleReserve,
     );
     const text = t.text || 'Untitled';
     const textWidth = estimateTextWidth(text, fontSize);


### PR DESCRIPTION
之前 toggleCollapsed 已支持非根节点，键盘空格可以触发；但鼠标只看到一个
不可点的小圆点（仅折叠态显示），多数用户不知道还能折叠/展开。

现在：
- 非根 + 有子节点的话题渲染一个 .mindmap-topic-toggle 按钮
  - 折叠态：实心彩色圆点（保留原 "hidden subtree" 提示）
  - 展开态：淡色描边圆环，hover pill 时变明显，自身 hover 放大
- 点击切换 collapsed；onMouseDown stopPropagation 避免触发外层 select / reorder 拖拽
- mindmapLayout 用 TOGGLE_RESERVE 取代 COLLAPSED_DOT_RESERVE，无论展开/ 折叠都为按钮预留 12px 宽度，避免展开后再折叠时文本宽度突变

根节点继续按 toggleCollapsed 的设定不展示 toggle（root 不可折叠）。