### PR TITLE
Improve label scaling at different zoom levels

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/index.css
@@ -13,7 +13,13 @@
    .canvas-transform — font stays crisp at any zoom. */
 .edge-label {
   position: absolute;
-  transform: translate(-50%, 10px);
+  /* The scale factor is supplied as --edge-label-scale by EdgeLabel.tsx,
+     clamped to [0.6, 1] against the canvas zoom so the chip shrinks with
+     the (also-shrinking) edge stroke at low zoom but never grows past
+     native size when zoomed in. translate-then-scale order keeps the
+     chip's anchor (top-center) aligned with the edge midpoint. */
+  transform: translate(-50%, 10px) scale(var(--edge-label-scale, 1));
+  transform-origin: top center;
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/index.tsx
@@ -85,10 +85,19 @@ export const EdgeLabel = ({
     }
   };
 
+  // Shrink the chip with the canvas when zoomed out so it doesn't dwarf the
+  // (also-shrinking) edge stroke. Cap at 1 so it never grows past native size
+  // when zoomed in, and floor at 0.6 so deep zoom-out keeps the text legible.
+  const labelScale = Math.min(1, Math.max(0.6, transform.scale));
+
   return (
     <div
       className={`edge-label${isEditing ? ' edge-label--editing' : ''}`}
-      style={{ left: screenPos.x, top: screenPos.y }}
+      style={{
+        left: screenPos.x,
+        top: screenPos.y,
+        ['--edge-label-scale' as string]: labelScale,
+      }}
       onMouseDown={(e) => e.stopPropagation()}
       onClick={(e) => e.stopPropagation()}
       onContextMenu={(e) => e.stopPropagation()}

--- a/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.css
@@ -52,7 +52,11 @@
   padding: 0 8px;
   /* Dark text derived from frame color — readable on every preset hue. */
   color: color-mix(in srgb, var(--frame-color, #A8B0BD) 70%, #111111);
-  transform: scale(calc(1 / var(--canvas-scale, 1)));
+  /* Counter-scale the header so it stays roughly screen-native when zoomed in,
+   * but cap at 1 so it never grows larger than its CSS size when zoomed out
+   * (otherwise the header dwarfs the frame body). Floor at 0.6 so it stays
+   * readable even at heavy zoom-out. */
+  transform: scale(clamp(0.6, 1 / var(--canvas-scale, 1), 1));
   transform-origin: left bottom;
   z-index: 2;
 }


### PR DESCRIPTION
## Summary
This PR improves the visual consistency of edge labels and frame headers when zooming in and out of the canvas by implementing intelligent scaling that keeps UI elements legible and proportional to the canvas content.

## Key Changes
- **EdgeLabel scaling**: Added dynamic scaling to edge labels based on canvas zoom level, clamped between 0.6x and 1x to ensure labels shrink with the edge stroke at low zoom but never grow larger than native size when zoomed in
- **FrameNodeBody header scaling**: Updated the frame header counter-scaling logic to use `clamp()` instead of a simple inverse calculation, preventing headers from becoming oversized when zoomed out while maintaining readability at extreme zoom levels
- **CSS improvements**: Added detailed comments explaining the scaling behavior and transform-origin positioning to maintain proper anchor alignment

## Implementation Details
- Edge labels now receive a `--edge-label-scale` CSS variable calculated in TypeScript and clamped to [0.6, 1]
- Frame headers use CSS `clamp(0.6, 1 / var(--canvas-scale, 1), 1)` to achieve similar behavior
- Both implementations use `transform-origin` to ensure elements scale from the correct anchor point (top-center for labels, left-bottom for headers)
- The 0.6 minimum scale ensures text remains legible even at heavy zoom-out levels

https://claude.ai/code/session_015BRuXi1XsDJ4zM5vfYv1SJ