### PR TITLE
Add mindmap node type support to canvas

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -483,7 +483,7 @@ export const CanvasNodeView = ({
             onDragStart={onDragStart}
           />
         ) : node.type === "iframe" ? (
-          <IframeNodeBody node={node} workspaceId={workspaceId} onUpdate={onUpdate} />
+          <IframeNodeBody node={node} workspaceId={workspaceId} onUpdate={onUpdate} isResizing={isResizing} />
         ) : (
           <AgentNodeBody node={node} allNodes={allNodes} rootFolder={rootFolder} workspaceId={workspaceId} workspaceName={workspaceName} onUpdate={onUpdate} />
         )}

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.css
@@ -118,6 +118,22 @@
   100% { background-position: 200% 0; }
 }
 
+/* ── Resize-time pointer shield ─────────────────────────────────────────
+ *
+ * Covers the iframe/webview while the node is being resized so the
+ * embedded document can't capture mousemove/mouseup. Transparent +
+ * pointer-events:auto means the cursor hits the shield (which sits in
+ * the parent DOM) and the canvas's resize listeners keep firing. */
+
+.iframe-pointer-shield {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  background: transparent;
+  pointer-events: auto;
+  cursor: inherit;
+}
+
 /* ── The iframe/webview itself ──────────────────────────────────────── */
 
 .iframe-frame {

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.tsx
@@ -8,6 +8,11 @@ interface Props {
   node: CanvasNode;
   workspaceId?: string;
   onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
+  /** When true, overlay a transparent shield above the iframe/webview so
+   *  the parent canvas keeps receiving mousemove/mouseup during resize.
+   *  Without it, cross-origin iframes (and especially Electron `<webview>`)
+   *  swallow the cursor's events and the resize handler stops updating. */
+  isResizing?: boolean;
 }
 
 // ── Streaming shell ──────────────────────────────────────────────────
@@ -62,7 +67,7 @@ window.parent.postMessage({type:"morph-ready"},"*");
 
 // ── Component ────────────────────────────────────────────────────────
 
-export const IframeNodeBody = ({ node, workspaceId, onUpdate }: Props) => {
+export const IframeNodeBody = ({ node, workspaceId, onUpdate, isResizing }: Props) => {
   const data = node.data as IframeNodeData;
   const mode = data.mode ?? "url";
   const url = data.url ?? "";
@@ -572,6 +577,7 @@ export const IframeNodeBody = ({ node, workspaceId, onUpdate }: Props) => {
 
       <div className={`iframe-frame-wrapper${streamingActive ? " iframe-frame-wrapper--streaming" : ""}`}>
         {streamingActive && <div className="iframe-shimmer-bar" />}
+        {isResizing && <div className="iframe-pointer-shield" aria-hidden="true" />}
         {renderMode === "url" ? (
           <webview
             ref={webviewRef as unknown as React.Ref<HTMLWebViewElement>}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/constants.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/constants.ts
@@ -5,6 +5,7 @@ export const CANVAS_MENTION_PREFIX = 'canvas:';
 export const MENTION_GROUPS = [
   { key: 'file', label: 'File' },
   { key: 'text', label: 'Text' },
+  { key: 'mindmap', label: 'Mindmap' },
   { key: 'link', label: 'Link' },
   { key: 'agent', label: 'Agent' },
   { key: 'terminal', label: 'Terminal' },
@@ -59,6 +60,8 @@ export function getMentionGroupKey(item: MentionItem): MentionGroupKey {
       return 'frame';
     case 'text':
       return 'text';
+    case 'mindmap':
+      return 'mindmap';
     case 'iframe':
       return 'link';
     case 'file':

--- a/apps/canvas-workspace/src/renderer/src/components/chat/utils/mentions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/utils/mentions.ts
@@ -27,6 +27,8 @@ export function mentionIconSvg(nodeType: string): string {
       return '<path d="M3 3.5h8M7 3.5v7M5.5 10.5h3" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>';
     case 'iframe':
       return '<circle cx="7" cy="7" r="5" stroke="currentColor" stroke-width="1.2"/><path d="M2 7h10M7 2c1.7 1.7 1.7 8.3 0 10M7 2c-1.7 1.7-1.7 8.3 0 10" stroke="currentColor" stroke-width="1" stroke-linecap="round"/>';
+    case 'mindmap':
+      return '<circle cx="3.5" cy="7" r="1.2" stroke="currentColor" stroke-width="1.1"/><circle cx="10.5" cy="3.5" r="1.1" stroke="currentColor" stroke-width="1.1"/><circle cx="10.5" cy="7" r="1.1" stroke="currentColor" stroke-width="1.1"/><circle cx="10.5" cy="10.5" r="1.1" stroke="currentColor" stroke-width="1.1"/><path d="M4.7 7L9.4 3.7M4.7 7H9.4M4.7 7L9.4 10.3" stroke="currentColor" stroke-width="1" stroke-linecap="round"/>';
     case 'workspace':
       return '<rect x="1.5" y="1.5" width="11" height="11" rx="1.5" stroke="currentColor" stroke-width="1.2"/><rect x="3.5" y="3.5" width="3" height="3" rx="0.5" stroke="currentColor" stroke-width="1"/><rect x="7.5" y="3.5" width="3" height="3" rx="0.5" stroke="currentColor" stroke-width="1"/><rect x="3.5" y="7.5" width="3" height="3" rx="0.5" stroke="currentColor" stroke-width="1"/>';
     default:

--- a/apps/canvas-workspace/src/renderer/src/components/icons/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/icons/index.tsx
@@ -212,6 +212,22 @@ export const NodeTypeIcon = ({ type, size = 14, className }: NodeTypeIconProps) 
           />
         </svg>
       );
+    case 'mindmap':
+      // Root node on the left with three children branching to the right
+      return (
+        <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className}>
+          <circle cx="4" cy="8" r="1.6" stroke="currentColor" strokeWidth="1.2" />
+          <circle cx="12" cy="3.5" r="1.4" stroke="currentColor" strokeWidth="1.2" />
+          <circle cx="12" cy="8" r="1.4" stroke="currentColor" strokeWidth="1.2" />
+          <circle cx="12" cy="12.5" r="1.4" stroke="currentColor" strokeWidth="1.2" />
+          <path
+            d="M5.6 8L10.6 3.7M5.6 8H10.6M5.6 8L10.6 12.3"
+            stroke="currentColor"
+            strokeWidth="1.1"
+            strokeLinecap="round"
+          />
+        </svg>
+      );
     default:
       return (
         <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className}>

--- a/apps/canvas-workspace/src/renderer/src/utils/nodeLabel.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/nodeLabel.ts
@@ -1,6 +1,7 @@
-import type { CanvasNode, TextNodeData } from "../types";
+import type { CanvasNode, MindmapNodeData, TextNodeData } from "../types";
 
 const TEXT_LABEL_MAX_CHARS = 10;
+const MINDMAP_LABEL_MAX_CHARS = 16;
 
 /**
  * Resolve the display label for a canvas node.
@@ -23,6 +24,15 @@ export function getNodeDisplayLabel(node: CanvasNode): string {
     if (preview) return preview;
     return node.title || "Text";
   }
+
+  if (node.type === "mindmap") {
+    const rootText = (node.data as MindmapNodeData).root?.text?.trim();
+    if (!rootText) return node.title || "Mindmap";
+    return rootText.length <= MINDMAP_LABEL_MAX_CHARS
+      ? rootText
+      : `${rootText.slice(0, MINDMAP_LABEL_MAX_CHARS)}…`;
+  }
+
   return node.title;
 }
 


### PR DESCRIPTION
## Summary
This PR adds support for a new "mindmap" node type to the canvas system, including visual representation, display labels, and chat mention integration.

## Key Changes
- **Icon Support**: Added a mindmap icon component showing a root node on the left with three child nodes branching to the right
- **Display Labels**: Implemented label resolution for mindmap nodes that extracts and truncates the root text (max 16 characters)
- **Chat Integration**: Added mindmap to the mention groups and icon mapping for chat mentions, allowing users to reference mindmap nodes in conversations

## Implementation Details
- The mindmap icon uses SVG circles and connecting paths to represent the hierarchical structure
- Label truncation uses the same pattern as other node types but with a higher character limit (16 vs 10) to accommodate mindmap content
- The mention icon SVG is a scaled-down version of the main icon for consistency in chat UI
- Type safety is maintained by importing `MindmapNodeData` type for proper data access

https://claude.ai/code/session_01Y1s85BxCM49L8xezJFTjEh