### PR TITLE
feat(canvas-cli): pulse-canvas node create 支持 mindmap 类型

### DIFF
--- a/packages/canvas-cli/skills/canvas/SKILL.md
+++ b/packages/canvas-cli/skills/canvas/SKILL.md
@@ -38,6 +38,31 @@ pulse-canvas node write <nodeId> --content "..."
 pulse-canvas node create --type file --title "Report" --data '{"content":"..."}'
 ```
 
+Supported `--type` values: `file`, `terminal`, `frame`, `agent`, `mindmap`.
+
+#### Mindmap
+
+For mindmaps, pass the recursive topic tree under `data.root`. Topic ids are auto-generated — do NOT supply them yourself. If `--data` is omitted a placeholder root is inserted.
+
+```bash
+pulse-canvas node create --type mindmap --title "Roadmap" --data '{
+  "root": {
+    "text": "Roadmap",
+    "children": [
+      { "text": "Q1", "children": [
+        { "text": "Ship MVP" },
+        { "text": "Onboard 10 users" }
+      ]},
+      { "text": "Q2", "children": [
+        { "text": "Public beta" }
+      ]}
+    ]
+  }
+}'
+```
+
+Topic shape: `{ text: string, children?: Topic[], color?: string, collapsed?: boolean }` (recursive). Use this whenever the user asks for a mindmap / brainstorm / outline that should be laid out radially rather than as a flat text node.
+
 ### Create an edge (connection between nodes)
 ```bash
 pulse-canvas edge create --from <nodeId> --to <nodeId> --label "depends on" --kind dependency --format json

--- a/packages/canvas-cli/src/commands/node.ts
+++ b/packages/canvas-cli/src/commands/node.ts
@@ -141,7 +141,7 @@ export function registerNodeCommands(program: Command): void {
     });
 
   node.command('create')
-    .requiredOption('--type <type>', 'Node type: file, terminal, frame, agent')
+    .requiredOption('--type <type>', 'Node type: file, terminal, frame, agent, mindmap')
     .option('--title <title>', 'Node title')
     .option('--x <n>', 'X position on canvas', parseFloat)
     .option('--y <n>', 'Y position on canvas', parseFloat)
@@ -152,7 +152,7 @@ export function registerNodeCommands(program: Command): void {
     .action(async function (this: Command, cmdOpts: { type: string; title?: string; x?: number; y?: number; width?: number; height?: number; data?: string }) {
       const { format, storeDir, workspace } = getOpts(this);
 
-      const validTypes: NodeType[] = ['file', 'terminal', 'frame', 'agent'];
+      const validTypes: NodeType[] = ['file', 'terminal', 'frame', 'agent', 'mindmap'];
       if (!validTypes.includes(cmdOpts.type as NodeType)) {
         errorOutput(`Invalid type "${cmdOpts.type}". Must be: ${validTypes.join(', ')}`);
       }

--- a/packages/canvas-cli/src/core/constants.ts
+++ b/packages/canvas-cli/src/core/constants.ts
@@ -9,6 +9,7 @@ export const NODE_CAPABILITIES: Record<NodeType, NodeCapability[]> = {
   terminal: ['read', 'exec'],
   frame: ['read', 'write'],
   agent: ['read', 'exec'],
+  mindmap: ['read', 'write'],
 };
 
 export const DEFAULT_NODE_DIMENSIONS: Record<NodeType, { title: string; width: number; height: number }> = {
@@ -16,6 +17,7 @@ export const DEFAULT_NODE_DIMENSIONS: Record<NodeType, { title: string; width: n
   terminal: { title: 'Terminal', width: 480, height: 300 },
   frame: { title: 'Frame', width: 600, height: 400 },
   agent: { title: 'Agent', width: 520, height: 380 },
+  mindmap: { title: 'Mindmap', width: 640, height: 420 },
 };
 
 export const AGENTS_MD_TEMPLATE = `# Canvas Agent Config

--- a/packages/canvas-cli/src/core/nodes.ts
+++ b/packages/canvas-cli/src/core/nodes.ts
@@ -8,9 +8,57 @@ import type {
   NodeCapability,
   CanvasNode,
   CanvasSaveData,
+  MindmapTopic,
   NodeReadResult,
   Result,
 } from './types';
+
+// ─── Mindmap helpers ───────────────────────────────────────────────
+
+interface RawMindmapTopic {
+  id?: string;
+  text?: string;
+  children?: RawMindmapTopic[];
+  color?: string;
+  collapsed?: boolean;
+}
+
+let topicIdCounter = 0;
+function genTopicId(): string {
+  return `topic-${Date.now()}-${++topicIdCounter}`;
+}
+
+/**
+ * Normalize a topic tree supplied by the agent (via `--data` JSON) into
+ * the canonical `MindmapTopic` shape: every topic gets a stable id, a
+ * string `text`, and a real `children` array. Recursively walks the tree
+ * so the entire subtree is renderer-ready before it lands on disk.
+ */
+function normalizeMindmapTopic(raw: RawMindmapTopic | null | undefined): MindmapTopic {
+  const safe = raw ?? {};
+  const topic: MindmapTopic = {
+    id: typeof safe.id === 'string' && safe.id ? safe.id : genTopicId(),
+    text: typeof safe.text === 'string' ? safe.text : '',
+    children: Array.isArray(safe.children) ? safe.children.map(normalizeMindmapTopic) : [],
+  };
+  if (typeof safe.color === 'string') topic.color = safe.color;
+  if (safe.collapsed) topic.collapsed = true;
+  return topic;
+}
+
+/** Indent a topic tree as a bullet list. Used by `node read` output. */
+function flattenMindmapTopics(topic: MindmapTopic | undefined, depth = 0): string {
+  if (!topic) return '';
+  const lines: string[] = [];
+  const indent = '  '.repeat(depth);
+  const text = topic.text?.trim() || '(empty topic)';
+  const collapsedHint = topic.collapsed ? ' [collapsed in UI]' : '';
+  lines.push(`${indent}- ${text}${collapsedHint}`);
+  for (const child of topic.children ?? []) {
+    lines.push(flattenMindmapTopics(child, depth + 1));
+  }
+  return lines.join('\n');
+}
 
 export function getNodeCapabilities(type: NodeType): NodeCapability[] {
   return NODE_CAPABILITIES[type] ?? ['read'];
@@ -55,6 +103,15 @@ export async function readNode(node: CanvasNode): Promise<NodeReadResult> {
         agentType: node.data.agentType ?? 'claude-code',
         status: node.data.status ?? 'idle',
       };
+    case 'mindmap': {
+      const root = node.data.root as MindmapTopic | undefined;
+      return {
+        type: 'mindmap',
+        capabilities,
+        root,
+        text: flattenMindmapTopics(root),
+      };
+    }
     default:
       return { type: node.type, capabilities };
   }
@@ -175,6 +232,18 @@ export async function createNode(
     case 'agent':
       nodeData = { sessionId: '', cwd: (inputData as Record<string, string>).cwd ?? '', agentType: (inputData as Record<string, string>).agentType ?? 'claude-code', status: 'idle' };
       break;
+    case 'mindmap': {
+      const rawRoot = (inputData as { root?: RawMindmapTopic }).root;
+      const root = rawRoot
+        ? normalizeMindmapTopic(rawRoot)
+        : {
+            id: genTopicId(),
+            text: opts.title ?? 'Central topic',
+            children: [],
+          };
+      nodeData = { root, layout: 'right', rev: 0 };
+      break;
+    }
   }
 
   // For file nodes, always create a notes file so the node has a valid filePath

--- a/packages/canvas-cli/src/core/types.ts
+++ b/packages/canvas-cli/src/core/types.ts
@@ -1,5 +1,18 @@
-export type NodeType = 'file' | 'terminal' | 'frame' | 'agent';
+export type NodeType = 'file' | 'terminal' | 'frame' | 'agent' | 'mindmap';
 export type NodeCapability = 'read' | 'write' | 'exec';
+
+/**
+ * Recursive topic tree carried inside a mindmap node's `data.root`.
+ * Mirrors the renderer's `MindmapTopic` shape so canvas.json round-trips
+ * cleanly between the CLI, the Electron main process, and the UI.
+ */
+export interface MindmapTopic {
+  id: string;
+  text: string;
+  children: MindmapTopic[];
+  color?: string;
+  collapsed?: boolean;
+}
 
 export interface CanvasNodeData {
   filePath?: string;


### PR DESCRIPTION
之前 CLI 的 NodeType 只覆盖 file/terminal/frame/agent，canvas skill 又把 agent 引导到 bash CLI 路径，结果 agent 想生成思维导图
时会去查 `pulse-canvas node create --help`，发现 mindmap 不在 合法 type 列表里，直接放弃。

补齐：
- core/types.ts：NodeType 加 'mindmap'，新增 MindmapTopic 类型。
- core/constants.ts：NODE_CAPABILITIES + DEFAULT_NODE_DIMENSIONS 补 mindmap 条目。
- core/nodes.ts：normalizeMindmapTopic 递归补 id / 默认 children=[]， createNode 新增 mindmap 分支生成 { root, layout, rev }； readNode 返回 root 树 + 缩进 bullet 文本，方便 LLM 直接读。
- commands/node.ts：--type 帮助文本与 validTypes 加入 mindmap。
- skills/canvas/SKILL.md：列出全部支持的 type，加一段 mindmap 使用示例（递归 data.root JSON），告知 topic id 自动生成。