### PR TITLE
docs: comprehensive README updates for orchestrator and remote-server

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -1,6 +1,6 @@
 # Pulse Agent
 
-一个以插件为核心的 Coding Agent Monorepo，包含可复用引擎、交互式 CLI，以及可选的服务端/运行时集成。
+一个以插件为核心的 Coding Agent Monorepo，包含可复用引擎、交互式 CLI、多 Agent 编排，以及可选的服务端 / 运行时集成。
 
 ## 语言
 - English docs: [`README.md`](./README.md)
@@ -8,30 +8,49 @@
 
 ## 仓库结构
 
-这是一个 `pnpm` workspace monorepo：
+`pnpm` workspace monorepo（`packages/*`、`apps/*`）。
+
+### Packages
+
+| 路径 | npm 名 | 作用 |
+| --- | --- | --- |
+| `packages/engine` | `pulse-coder-engine` | 核心运行时：循环、hooks、内置工具、插件管理 |
+| `packages/cli` | `pulse-coder-cli` | 终端交互应用 |
+| `packages/pulse-sandbox` | `pulse-sandbox` | 沙箱 JavaScript 执行器与 `run_js` 适配 |
+| `packages/memory-plugin` | `pulse-coder-memory-plugin` | memory 插件 / 集成服务 |
+| `packages/plugin-kit` | `pulse-coder-plugin-kit` | 插件公共工具：worktree 辅助、密钥 vault、devtools 等 |
+| `packages/orchestrator` | `pulse-coder-orchestrator` | 多 Agent 编排（TaskGraph、planner、scheduler、runner、aggregator） |
+| `packages/agent-teams` | `pulse-coder-agent-teams` | 基于 orchestrator 的多 Agent 协作层 |
+| `packages/acp` | `pulse-coder-acp` | Agent Context Protocol：typed client、runner、state store |
+| `packages/langfuse-plugin` | `pulse-coder-langfuse-plugin` | 可选的 Langfuse 链路追踪插件 |
+| `packages/canvas-cli` | `pulse-coder-canvas-cli` | canvas 相关 CLI 辅助 |
+
+### Apps
 
 | 路径 | 作用 |
 | --- | --- |
-| `packages/engine` | 核心运行时（`pulse-coder-engine`）：循环、hooks、内置工具、插件管理 |
-| `packages/cli` | 终端交互应用（`pulse-coder-cli`） |
-| `packages/pulse-sandbox` | 沙箱 JavaScript 执行器与 `run_js` 适配 |
-| `packages/memory-plugin` | memory 插件/集成服务 |
-| `apps/remote-server` | 可选 HTTP 服务封装 |
+| `apps/remote-server` | 引擎的 HTTP 封装（飞书 / Discord / Telegram 适配器） |
+| `apps/teams-cli` | 多 Agent 团队工作流 CLI |
+| `apps/canvas-workspace` | canvas 工作区应用 |
 | `apps/coder-demo` | 早期实验 app |
-| `docs/`, `architecture/` | 设计与架构文档 |
+| `apps/devtools-web` | 实验性 devtools Web UI |
+
+> 实验 app（`apps/coder-demo`、`apps/devtools-web`）保留在仓库中，但默认不参与 workspace 安装 / 构建，详见 `apps/EXPERIMENTAL.md`。
+
+其他目录：`docs/`、`architecture/`、`examples/`、`scripts/`。
 
 ---
 
 ## 当前架构
 
 ### 1）Engine 初始化
-`Engine.initialize()` 会创建 `PluginManager`，默认加载内置插件，然后按优先级合并工具：
+`Engine.initialize()`（`packages/engine/src/Engine.ts`）会创建 `PluginManager`，默认加载内置插件，按以下优先级合并工具：
 1. 内置工具
 2. 插件注册工具
-3. 用户传入工具（`EngineOptions.tools`，优先级最高）
+3. 用户传入工具（`EngineOptions.tools`，最高优先级）
 
 ### 2）插件系统
-支持两类插件链路：
+两类插件链路：
 - **Engine 插件**：代码级插件（生命周期 + hooks）
 - **用户配置插件**：扫描配置文件（`config.{json|yaml|yml}`）
 
@@ -41,39 +60,79 @@ Engine 插件扫描路径：
 - `~/.pulse-coder/engine-plugins`
 - `~/.coder/engine-plugins`
 
-### 3）Agent Loop 行为
+实现 `pulse-coder-engine` 中的 `EnginePlugin`，`initialize(ctx)` 提供：
+- `ctx.registerTool(name, tool)` / `ctx.registerTools(map)`
+- `ctx.registerHook(hookName, handler)`，覆盖 `EngineHookMap` 全部钩子
+- `ctx.registerService(name, service)` / `ctx.getService(name)`
+- `ctx.getConfig(key)` / `ctx.setConfig(key, val)`
+- `ctx.events`（EventEmitter）、`ctx.logger`
+
+### 3）Agent Loop
 核心循环（`packages/engine/src/core/loop.ts`）支持：
-- 文本/工具事件流式回调
-- LLM 与工具 hooks（`before*` / `after*`）
-- 可重试错误指数退避（`429/5xx`）
+- 文本 / 工具事件流式回调
+- LLM hooks（`beforeLLMCall` / `afterLLMCall`）
+- 工具 hooks（`beforeToolCall` / `afterToolCall` / `onToolCall`）
+- Run 级 hooks（`beforeRun` / `afterRun`）；`beforeRun` 可改写 `systemPrompt` 与 `tools`
+- 可重试错误的指数退避（`429/5xx`）
 - 中断信号处理
-- 自动上下文压缩
+- 自动上下文压缩（`onCompacted`）
 
 ### 4）内置插件（默认自动加载）
+来自 `packages/engine/src/built-in/index.ts`：
 - `built-in-mcp`：读取 `.pulse-coder/mcp.json`（兼容 `.coder/mcp.json`），工具命名为 `mcp_<server>_<tool>`
 - `built-in-skills`：扫描 `SKILL.md` 并暴露 `skill` 工具
-- `built-in-plan-mode`：planning/executing 模式管理
-- `built-in-task-tracking`：`task_create/task_get/task_list/task_update` 本地持久化
-- `SubAgentPlugin`：加载 Markdown 子代理定义，注册 `<name>_agent` 工具
+- `built-in-plan-mode`：planning / executing 模式管理
+- `built-in-task-tracking`：`task_create/task_get/task_list/task_update`，本地持久化
+- `SubAgentPlugin`：加载 `.pulse-coder/agents/*.md`，注册 `<name>_agent` 工具
+- `tool-search`：延迟工具发现（按需加载工具 schema）
+- `role-soul`：persona / system prompt 注入
+- `agent-teams`：把 orchestrator 的多 Agent 协作以 engine 工具暴露
+- `ptc`：PTC 工作流集成
 
 ### 5）CLI 运行模型
 `pulse-coder-cli` 在引擎之上增加：
 - 会话持久化（`~/.pulse-coder/sessions`）
-- 会话 task-list 绑定
+- 会话级 task-list 绑定
 - `/skills` 单次技能消息转换
-- Esc 中断当前响应
+- `Esc` 中断当前响应
 - `clarify` 追问交互
 - 注入来自 `pulse-sandbox` 的 `run_js` 工具
+
+### 6）Orchestrator（`packages/orchestrator`）
+执行 **TaskGraph** —— `TaskNode` 组成的 DAG：`{ id, role, deps[], input?, agent?, instruction? }`。
+
+路由策略（`OrchestrationInput.route`）：
+- `'auto'`：基于关键字的角色选择
+- `'all'`：全部已注册角色都跑
+- `'plan'`：由 LLM 动态构建图
+
+内置角色：`researcher`、`executor`、`reviewer`、`writer`、`tester`，结果通过 `concat | last | llm` 聚合。`agent-teams` 插件把编排能力作为工具暴露给引擎。
+
+### 7）Remote Server 运行时（`apps/remote-server`）
+将引擎托管在 HTTP / Webhook 之后，支持飞书与 Discord（Telegram / Web 适配器存在但默认未挂载）。
+
+关键组件：
+- 入口与服务器：`apps/remote-server/src/index.ts`、`apps/remote-server/src/server.ts`（挂载 `/health`、webhook 路由、`/internal/*`）
+- Dispatcher：`apps/remote-server/src/core/dispatcher.ts` —— 校验 / fast ack、slash 命令、按 `platformKey` 防并发、通过适配器 `StreamHandle` 流式输出
+- Agent 执行：`apps/remote-server/src/core/agent-runner.ts` —— 构建上下文、解析模型 override、持久化会话、写入每日 memory
+- Clarification：`apps/remote-server/src/core/clarification-queue.ts` —— webhook / gateway 的追问路由
+- Sessions：`~/.pulse-coder/remote-sessions`（`index.json` + `sessions/*.json`）
+- Memory：`pulse-coder-memory-plugin` 写入 `~/.pulse-coder/remote-memory`
+- Worktrees：`~/.pulse-coder/worktree-state`
+- 模型覆盖：`.pulse-coder/config.json` 或 `$PULSE_CODER_MODEL_CONFIG`（`apps/remote-server/src/core/model-config.ts`）
+- 适配器：飞书（`adapters/feishu/*`）、Discord webhook（`adapters/discord/adapter.ts`）和 DM gateway（`adapters/discord/gateway.ts`）
+- 内部 API：`POST /internal/agent/run`、`GET /internal/discord/gateway/status`、`POST /internal/discord/gateway/restart` —— 仅 loopback，需 `INTERNAL_API_SECRET`
+- 工具：在 `apps/remote-server/src/core/engine-singleton.ts` 注册（cron、deferred demo、Twitter list fetcher、session summary、PTC demo），部分使用 `defer_loading: true`，由 tool-search 触发后再加载
 
 ---
 
 ## 内置工具
 
 Engine 默认工具：
-- `read`, `write`, `edit`, `grep`, `ls`, `bash`, `tavily`, `gemini_pro_image`, `clarify`
+- `read`、`write`、`edit`、`grep`、`ls`、`bash`、`tavily`、`gemini_pro_image`、`clarify`
 
 任务跟踪插件附加：
-- `task_create`, `task_get`, `task_list`, `task_update`
+- `task_create`、`task_get`、`task_list`、`task_update`
 
 CLI 额外注入：
 - `run_js`（沙箱执行 JavaScript）
@@ -84,7 +143,7 @@ CLI 额外注入：
 
 ### 前置要求
 - Node.js `>=18`
-- `pnpm`
+- `pnpm`（`package.json` 中 pin 在 `pnpm@10.28.0`）
 
 ### 1）安装依赖
 ```bash
@@ -113,12 +172,26 @@ OPENAI_MODEL=novita/deepseek/deepseek_v3
 
 ### 3）构建
 ```bash
-pnpm run build
+pnpm run build       # 核心工作区（packages/* + remote-server + teams-cli）
+pnpm run build:all   # 全量工作区
 ```
 
 ### 4）启动 CLI
 ```bash
 pnpm start
+pnpm start:debug     # 带 debug 日志
+```
+
+### 5）Remote Server（可选）
+```bash
+pnpm --filter @pulse-coder/remote-server dev
+```
+
+### 6）多 Agent Teams 预览（可选）
+```bash
+pnpm preview:teams        # 构建 orchestrator/engine/agent-teams 后启动 teams-cli 预览
+pnpm preview:teams:run    # run 模式预览
+pnpm preview:teams:plan   # plan 模式预览
 ```
 
 ---
@@ -177,9 +250,9 @@ pnpm start
 ```
 
 说明：
-- `transport` 支持 `http`、`sse`、`stdio`。
-- 若未填写 `transport`，默认按 `http` 处理（向后兼容）。
-- `http`/`sse` 使用 `url`（可选 `headers`）；`stdio` 使用 `command`（可选 `args`、`env`、`cwd`）。
+- `transport` 支持 `http`、`sse`、`stdio`
+- 未填写时默认按 `http` 处理（向后兼容）
+- `http`/`sse` 使用 `url`（可选 `headers`）；`stdio` 使用 `command`（可选 `args`、`env`、`cwd`）
 
 ### Skills
 创建 `.pulse-coder/skills/<skill-name>/SKILL.md`：
@@ -194,8 +267,7 @@ description: 该技能用于什么场景
 ...
 ```
 
-可选远程技能配置：
-- `.pulse-coder/skills/remote.json`
+可选远程技能配置：`.pulse-coder/skills/remote.json`。
 
 ### 子代理
 创建 `.pulse-coder/agents/<agent-name>.md`：
@@ -213,19 +285,45 @@ System prompt content here.
 
 ---
 
+## 环境变量
+
+通用：
+- `OPENAI_API_KEY`、`OPENAI_API_URL`、`OPENAI_MODEL`
+- Anthropic 路径：`USE_ANTHROPIC`、`ANTHROPIC_API_KEY`、`ANTHROPIC_API_URL`、`ANTHROPIC_MODEL`
+- 可选工具：`TAVILY_API_KEY`、`GEMINI_API_KEY`
+- 默认模型：`novita/deepseek/deepseek_v3`（用 `OPENAI_MODEL` / `ANTHROPIC_MODEL` 覆盖）
+
+上下文压缩：
+- `CONTEXT_WINDOW_TOKENS`（默认 `64000`）
+- `COMPACT_TRIGGER`（默认 75%）、`COMPACT_TARGET`（默认 50%）、`KEEP_LAST_TURNS`（默认 `4`）
+- `COMPACT_SUMMARY_MODEL`、`COMPACT_SUMMARY_MAX_TOKENS`（默认 `1200`）、`MAX_COMPACTION_ATTEMPTS`（默认 `2`）
+
+Clarification：
+- `CLARIFICATION_ENABLED`（默认 `true`）
+- `CLARIFICATION_TIMEOUT`（默认 `300000` ms）
+
+Remote Server：
+- `INTERNAL_API_SECRET`：`/internal/*` 路由必填（仅 loopback）
+- `PULSE_CODER_MODEL_CONFIG`：模型覆盖配置的可选路径
+
+---
+
 ## 开发命令
 
 ### 工作区级别
 ```bash
 pnpm install
-pnpm run build        # 核心工作区
-pnpm run build:all    # 全量工作区
-pnpm run dev          # 核心工作区
-pnpm run dev:all      # 全量工作区
-pnpm start
-pnpm test             # 核心工作区
-pnpm run test:all     # 全量工作区
-pnpm run test:apps
+pnpm run build         # 核心工作区（packages/* + remote-server + teams-cli，SKIP_DTS=1）
+pnpm run build:all     # 全量工作区
+pnpm run dev           # 核心工作区
+pnpm run dev:all       # 全量工作区
+pnpm start             # pulse-coder-cli
+pnpm start:debug       # 带 debug 日志的 CLI
+pnpm test              # 等价于 test:core
+pnpm run test:core     # packages/* + remote-server + teams-cli
+pnpm run test:packages # 仅 packages/*
+pnpm run test:apps     # apps/*（coder-demo 占位脚本可能失败）
+pnpm run test:all      # 全量
 ```
 
 ### 包级别
@@ -235,16 +333,18 @@ pnpm --filter pulse-coder-engine typecheck
 pnpm --filter pulse-coder-cli test
 pnpm --filter pulse-sandbox test
 pnpm --filter pulse-coder-memory-plugin test
+pnpm --filter pulse-coder-plugin-kit test
+pnpm --filter pulse-coder-orchestrator test
+pnpm --filter pulse-coder-agent-teams test
+pnpm --filter @pulse-coder/remote-server build
+pnpm --filter @pulse-coder/remote-server dev
 ```
 
+所有包使用 **vitest**（`vitest run`）跑测试，`tsc --noEmit` 做类型检查。
+
 说明：
-- `pnpm run build` / `pnpm run dev` / `pnpm test` 默认只跑核心集合：
-  - 全部 `packages/*`
-  - `apps/remote-server`
-  - `apps/teams-cli`
-- `pnpm-workspace.yaml` 当前只纳入上述核心集合。实验 app（`apps/coder-demo`、`apps/devtools-web`、`apps/canvas-workspace`）仍保留在仓库中，但默认不参与 workspace 安装/构建（见 `apps/EXPERIMENTAL.md`）。
-- 需要全量执行时请使用 `build:all` / `dev:all` / `test:all`。
-- `pnpm run test:apps` 仍会跑 `./apps/*` 下的测试，`apps/coder-demo` 仍是占位测试脚本。
+- `pnpm-workspace.yaml` 当前仅纳入核心集合：`packages/*`、`apps/remote-server`、`apps/teams-cli`、`apps/canvas-workspace`。实验 app（`apps/coder-demo`、`apps/devtools-web`）保留在仓库但默认不参与安装 / 构建。
+- 需要全量执行时使用 `build:all` / `dev:all` / `test:all`。
 
 ---
 
@@ -256,7 +356,7 @@ pnpm release:core
 pnpm release -- --packages=engine,cli --bump=patch --tag=latest
 ```
 
-支持 `--dry-run`、`--skip-version`、`--skip-build`、`--preid`、`--packages` 等参数。
+发版脚本（`scripts/release-packages.mjs`）支持 `--dry-run`、`--skip-version`、`--skip-build`、`--preid`、`--packages=` 等参数。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pulse Agent
 
-Plugin-first coding agent monorepo with a reusable engine, an interactive CLI, and optional server/runtime integrations.
+Plugin-first coding agent monorepo with a reusable engine, an interactive CLI, multi-agent orchestration, and optional server/runtime integrations.
 
 ## Language
 - English docs (this file)
@@ -8,32 +8,51 @@ Plugin-first coding agent monorepo with a reusable engine, an interactive CLI, a
 
 ## Repository layout
 
-This repo is a `pnpm` workspace monorepo:
+This repo is a `pnpm` workspace monorepo (`packages/*`, `apps/*`).
+
+### Packages
+
+| Path | npm name | Purpose |
+| --- | --- | --- |
+| `packages/engine` | `pulse-coder-engine` | Core runtime: loop, hooks, built-in tools, plugin manager |
+| `packages/cli` | `pulse-coder-cli` | Interactive terminal app built on top of the engine |
+| `packages/pulse-sandbox` | `pulse-sandbox` | Sandboxed JavaScript executor and `run_js` tool adapter |
+| `packages/memory-plugin` | `pulse-coder-memory-plugin` | Host-side memory plugin and integration helpers |
+| `packages/plugin-kit` | `pulse-coder-plugin-kit` | Shared utilities for plugins (worktree helpers, vault, devtools) |
+| `packages/orchestrator` | `pulse-coder-orchestrator` | Multi-agent orchestration (TaskGraph, planner, scheduler, runner, aggregator) |
+| `packages/agent-teams` | `pulse-coder-agent-teams` | Agent teams coordination built on the orchestrator |
+| `packages/acp` | `pulse-coder-acp` | Agent Context Protocol — typed client, runner, and state store |
+| `packages/langfuse-plugin` | `pulse-coder-langfuse-plugin` | Optional Langfuse tracing plugin |
+| `packages/canvas-cli` | `pulse-coder-canvas-cli` | Canvas-related CLI helpers |
+
+### Apps
 
 | Path | Purpose |
 | --- | --- |
-| `packages/engine` | Core runtime (`pulse-coder-engine`): loop, hooks, built-in tools, plugin manager |
-| `packages/cli` | Interactive terminal app (`pulse-coder-cli`) built on top of the engine |
-| `packages/pulse-sandbox` | Sandboxed JavaScript executor and `run_js` tool adapter |
-| `packages/memory-plugin` | Host-side memory plugin/integration service |
-| `apps/remote-server` | Optional HTTP service wrapper around the engine |
-| `apps/coder-demo` | Older experimental app |
-| `docs/`, `architecture/` | Design and architecture documents |
+| `apps/remote-server` | HTTP service wrapping the engine (Feishu/Discord/Telegram adapters) |
+| `apps/teams-cli` | CLI for multi-agent teams workflows |
+| `apps/canvas-workspace` | Canvas-based workspace app |
+| `apps/coder-demo` | Legacy experimental app |
+| `apps/devtools-web` | Experimental devtools web UI |
+
+> Experimental apps (`apps/coder-demo`, `apps/devtools-web`) live in the repo but are excluded from the default workspace install/build. See `apps/EXPERIMENTAL.md`.
+
+Other notable folders: `docs/`, `architecture/`, `examples/`, `scripts/`.
 
 ---
 
-## Architecture (current)
+## Architecture
 
 ### 1) Engine bootstrap
-`Engine.initialize()` creates a `PluginManager`, loads built-in plugins by default, then merges tools in this order:
+`Engine.initialize()` (`packages/engine/src/Engine.ts`) creates a `PluginManager`, loads built-in plugins by default, then merges tools in this order:
 1. built-in tools,
 2. plugin-registered tools,
 3. user-supplied tools (`EngineOptions.tools`, highest priority).
 
 ### 2) Plugin system
 Two plugin tracks are supported:
-- **Engine plugins**: runtime code plugins with lifecycle + hooks
-- **User config plugins**: scanned config files (`config.{json|yaml|yml}`)
+- **Engine plugins**: runtime code plugins with lifecycle + hooks.
+- **User config plugins**: scanned config files (`config.{json|yaml|yml}`).
 
 Engine plugin scan paths:
 - `.pulse-coder/engine-plugins`
@@ -41,43 +60,69 @@ Engine plugin scan paths:
 - `~/.pulse-coder/engine-plugins`
 - `~/.coder/engine-plugins`
 
+A plugin implements `EnginePlugin` from `pulse-coder-engine`. Its `initialize(ctx)` receives a context with:
+- `ctx.registerTool(name, tool)` / `ctx.registerTools(map)`,
+- `ctx.registerHook(hookName, handler)` for any hook in `EngineHookMap`,
+- `ctx.registerService(name, service)` / `ctx.getService(name)`,
+- `ctx.getConfig(key)` / `ctx.setConfig(key, val)`,
+- `ctx.events` (EventEmitter) and `ctx.logger`.
+
 ### 3) Agent loop behavior
 Core loop (`packages/engine/src/core/loop.ts`) provides:
 - streaming text/tool events,
-- LLM/tool hook pipelines (`before*`/`after*`),
-- retry with backoff for retryable failures (`429/5xx`),
+- LLM hooks (`beforeLLMCall`, `afterLLMCall`),
+- tool hooks (`beforeToolCall`, `afterToolCall`, `onToolCall`),
+- run-level hooks (`beforeRun`, `afterRun`) — `beforeRun` can mutate `systemPrompt` and `tools`,
+- retry with exponential backoff for retryable failures (`429/5xx`),
 - abort handling,
-- automatic context compaction.
+- automatic context compaction (`onCompacted`).
 
 ### 4) Built-in plugins
-The engine auto-loads:
-- `built-in-mcp`: loads MCP servers from `.pulse-coder/mcp.json` (or `.coder/mcp.json`) and exposes tools as `mcp_<server>_<tool>`.
+Registered from `packages/engine/src/built-in/index.ts`:
+- `built-in-mcp`: loads MCP servers from `.pulse-coder/mcp.json` (or legacy `.coder/mcp.json`) and exposes tools as `mcp_<server>_<tool>`.
 - `built-in-skills`: scans `SKILL.md` files and exposes the `skill` tool.
 - `built-in-plan-mode`: planning/executing mode management.
 - `built-in-task-tracking`: `task_create/task_get/task_list/task_update` with local persistence.
-- `SubAgentPlugin`: loads Markdown agent definitions and exposes `<name>_agent` tools.
+- `SubAgentPlugin`: loads Markdown agent definitions from `.pulse-coder/agents/*.md` and registers `<name>_agent` tools.
+- `tool-search`: deferred tool discovery (loads tool schemas on demand).
+- `role-soul`: persona / system-prompt injection.
+- `agent-teams`: exposes orchestrator-driven multi-agent coordination as engine tools.
+- `ptc`: PTC workflow integration.
 
 ### 5) CLI runtime model
 `pulse-coder-cli` adds:
 - session persistence under `~/.pulse-coder/sessions`,
 - per-session task-list binding,
 - one-shot skill command transformation (`/skills ...`),
-- ESC abort for in-flight responses,
-- clarification flow via `clarify` tool,
+- `Esc` abort for in-flight responses,
+- clarification flow via the `clarify` tool,
 - built-in `run_js` tool from `pulse-sandbox`.
 
-### 6) Remote server runtime (`apps/remote-server`)
-`apps/remote-server` hosts the engine behind HTTP/webhooks for Feishu/Discord (Telegram/Web adapters exist but are not mounted by default).
+### 6) Orchestrator (`packages/orchestrator`)
+Runs a **TaskGraph** — a DAG of `TaskNode` objects with `{ id, role, deps[], input?, agent?, instruction? }`.
+
+Routing strategies (`OrchestrationInput.route`):
+- `'auto'` — keyword-based role selection,
+- `'all'` — every registered role runs,
+- `'plan'` — LLM dynamically builds the graph.
+
+Built-in roles: `researcher`, `executor`, `reviewer`, `writer`, `tester`. Results are aggregated via `concat | last | llm`. The `agent-teams` plugin exposes orchestration to the engine as a tool.
+
+### 7) Remote server runtime (`apps/remote-server`)
+Hosts the engine behind HTTP/webhooks for Feishu and Discord (Telegram/Web adapters exist but are not mounted by default).
 
 Key components:
-- Entry + server: `apps/remote-server/src/index.ts` and `apps/remote-server/src/server.ts`.
-- Dispatcher: `apps/remote-server/src/core/dispatcher.ts` handles signature verification, fast ack, slash commands, and streaming.
-- Agent runs: `apps/remote-server/src/core/agent-runner.ts` builds run context, resolves model overrides, and persists sessions.
-- Memory: `apps/remote-server/src/core/memory-integration.ts` records daily logs to `~/.pulse-coder/remote-memory`.
-- Sessions: `apps/remote-server/src/core/session-store.ts` stores sessions in `~/.pulse-coder/remote-sessions`.
-- Worktrees: `apps/remote-server/src/core/worktree/integration.ts` stores binding state in `~/.pulse-coder/worktree-state`.
-- Internal API: `apps/remote-server/src/routes/internal.ts` exposes `/internal/agent/run` plus Discord gateway status/restart (loopback-only + `INTERNAL_API_SECRET`).
-- Tools: `apps/remote-server/src/core/engine-singleton.ts` registers cron, deferred demo, Twitter list fetcher, session summary, and PTC demo tools.
+- Entry + server: `apps/remote-server/src/index.ts`, `apps/remote-server/src/server.ts` (mounts `/health`, webhook routes, and `/internal/*`).
+- Dispatcher: `apps/remote-server/src/core/dispatcher.ts` — webhook verification/ack, slash commands, per-`platformKey` concurrency, streaming via adapter `StreamHandle` callbacks.
+- Agent runs: `apps/remote-server/src/core/agent-runner.ts` — builds run context, resolves model overrides, persists sessions, records daily memory logs.
+- Clarification: `apps/remote-server/src/core/clarification-queue.ts` — routes clarification prompts/answers for webhook and gateway flows.
+- Sessions: stored in `~/.pulse-coder/remote-sessions` (`index.json` + `sessions/*.json`).
+- Memory: `pulse-coder-memory-plugin` writes daily logs to `~/.pulse-coder/remote-memory`.
+- Worktrees: binding state in `~/.pulse-coder/worktree-state`.
+- Model overrides: `.pulse-coder/config.json` or `$PULSE_CODER_MODEL_CONFIG` (`apps/remote-server/src/core/model-config.ts`).
+- Adapters: Feishu (`adapters/feishu/*`), Discord webhooks (`adapters/discord/adapter.ts`) and DM gateway (`adapters/discord/gateway.ts`).
+- Internal API: `POST /internal/agent/run`, `GET /internal/discord/gateway/status`, `POST /internal/discord/gateway/restart` — loopback-only, gated by `INTERNAL_API_SECRET`.
+- Tools: registered in `apps/remote-server/src/core/engine-singleton.ts` (cron scheduler, deferred demo, Twitter list fetcher, session summary, PTC demo). Some are `defer_loading: true` and only load after tool-search discovery.
 
 ---
 
@@ -98,7 +143,7 @@ CLI additionally injects:
 
 ### Prerequisites
 - Node.js `>=18`
-- `pnpm` (workspace manager)
+- `pnpm` (workspace manager — pinned to `pnpm@10.28.0` in `package.json`)
 
 ### 1) Install dependencies
 ```bash
@@ -106,10 +151,10 @@ pnpm install
 ```
 
 ### 2) Configure environment
-Create `.env` at repo root:
+Create `.env` at the repo root:
 
 ```env
-# OpenAI-compatible provider (default path)
+# OpenAI-compatible provider (default)
 OPENAI_API_KEY=your_key_here
 OPENAI_API_URL=https://api.openai.com/v1
 OPENAI_MODEL=novita/deepseek/deepseek_v3
@@ -127,17 +172,26 @@ OPENAI_MODEL=novita/deepseek/deepseek_v3
 
 ### 3) Build
 ```bash
-pnpm run build
+pnpm run build       # core workspace (packages/* + remote-server + teams-cli)
+pnpm run build:all   # full workspace
 ```
 
-### 4) Start CLI
+### 4) Start the CLI
 ```bash
 pnpm start
+pnpm start:debug     # with debug logging
 ```
 
 ### 5) Remote server (optional)
 ```bash
 pnpm --filter @pulse-coder/remote-server dev
+```
+
+### 6) Multi-agent teams preview (optional)
+```bash
+pnpm preview:teams        # build orchestrator/engine/agent-teams + run teams-cli preview
+pnpm preview:teams:run    # preview "run" mode
+pnpm preview:teams:plan   # preview "plan" mode
 ```
 
 ---
@@ -164,7 +218,7 @@ Inside the CLI:
 - `/exit`
 
 Interactive controls:
-- `Esc` aborts current response (or cancels pending clarification)
+- `Esc` aborts the current response (or cancels a pending clarification)
 - `Ctrl+C` exits after save
 
 ---
@@ -198,7 +252,7 @@ Create `.pulse-coder/mcp.json`:
 Notes:
 - `transport` supports `http`, `sse`, and `stdio`.
 - If `transport` is omitted, it defaults to `http` for backward compatibility.
-- `http`/`sse` use `url` (optional `headers`), while `stdio` uses `command` (+ optional `args`, `env`, `cwd`).
+- `http`/`sse` use `url` (optional `headers`); `stdio` uses `command` (+ optional `args`, `env`, `cwd`).
 
 ### Skills
 Create `.pulse-coder/skills/<skill-name>/SKILL.md`:
@@ -213,8 +267,7 @@ description: What this skill helps with
 ...
 ```
 
-Optional remote skills config:
-- `.pulse-coder/skills/remote.json`
+Optional remote skills config: `.pulse-coder/skills/remote.json`.
 
 ### Sub-agents
 Create `.pulse-coder/agents/<agent-name>.md`:
@@ -228,7 +281,30 @@ description: Specialized code review helper
 System prompt content here.
 ```
 
-> Legacy `.coder/...` paths are still supported.
+> Legacy `.coder/...` paths are still supported by most loaders.
+
+---
+
+## Environment variables
+
+Common:
+- `OPENAI_API_KEY`, `OPENAI_API_URL`, `OPENAI_MODEL`
+- Anthropic path: `USE_ANTHROPIC`, `ANTHROPIC_API_KEY`, `ANTHROPIC_API_URL`, `ANTHROPIC_MODEL`
+- Optional tools: `TAVILY_API_KEY`, `GEMINI_API_KEY`
+- Default model: `novita/deepseek/deepseek_v3` (override via `OPENAI_MODEL` or `ANTHROPIC_MODEL`)
+
+Context compaction tuning:
+- `CONTEXT_WINDOW_TOKENS` (default `64000`)
+- `COMPACT_TRIGGER` (default 75% of window), `COMPACT_TARGET` (default 50%), `KEEP_LAST_TURNS` (default `4`)
+- `COMPACT_SUMMARY_MODEL`, `COMPACT_SUMMARY_MAX_TOKENS` (default `1200`), `MAX_COMPACTION_ATTEMPTS` (default `2`)
+
+Clarification:
+- `CLARIFICATION_ENABLED` (default `true`)
+- `CLARIFICATION_TIMEOUT` (default `300000` ms)
+
+Remote server:
+- `INTERNAL_API_SECRET` — required for `/internal/*` routes (loopback only).
+- `PULSE_CODER_MODEL_CONFIG` — alternative path for model overrides.
 
 ---
 
@@ -237,14 +313,17 @@ System prompt content here.
 ### Workspace-level
 ```bash
 pnpm install
-pnpm run build        # core workspace
-pnpm run build:all    # full workspace
-pnpm run dev          # core workspace
-pnpm run dev:all      # full workspace
-pnpm start
-pnpm test             # core workspace
-pnpm run test:all     # full workspace
-pnpm run test:apps
+pnpm run build         # core workspace (packages/* + remote-server + teams-cli, SKIP_DTS=1)
+pnpm run build:all     # full workspace
+pnpm run dev           # core workspace
+pnpm run dev:all       # full workspace
+pnpm start             # pulse-coder-cli
+pnpm start:debug       # CLI with debug logging
+pnpm test              # alias for test:core
+pnpm run test:core     # packages/* + remote-server + teams-cli
+pnpm run test:packages # packages/* only
+pnpm run test:apps     # apps/* (may fail due to placeholder scripts in coder-demo)
+pnpm run test:all      # all packages and apps
 ```
 
 ### Package-level
@@ -254,17 +333,18 @@ pnpm --filter pulse-coder-engine typecheck
 pnpm --filter pulse-coder-cli test
 pnpm --filter pulse-sandbox test
 pnpm --filter pulse-coder-memory-plugin test
+pnpm --filter pulse-coder-plugin-kit test
+pnpm --filter pulse-coder-orchestrator test
+pnpm --filter pulse-coder-agent-teams test
+pnpm --filter @pulse-coder/remote-server build
 pnpm --filter @pulse-coder/remote-server dev
 ```
 
+All packages use **vitest** (`vitest run`) for tests and `tsc --noEmit` for typechecking.
+
 Notes:
-- `pnpm run build` / `pnpm run dev` / `pnpm test` target the core set by default:
-  - all `packages/*`
-  - `apps/remote-server`
-  - `apps/teams-cli`
-- `pnpm-workspace.yaml` only includes the core set above. Experimental apps (`apps/coder-demo`, `apps/devtools-web`, `apps/canvas-workspace`) stay in the repo but are excluded from default workspace install/build (see `apps/EXPERIMENTAL.md`).
+- `pnpm-workspace.yaml` only includes the core set: all `packages/*`, `apps/remote-server`, `apps/teams-cli`, `apps/canvas-workspace`. Experimental apps (`apps/coder-demo`, `apps/devtools-web`) stay in the repo but are excluded from default install/build.
 - Use `build:all` / `dev:all` / `test:all` for full-workspace runs.
-- `pnpm run test:apps` still runs tests under `./apps/*`, and `apps/coder-demo` keeps a placeholder test script.
 
 ---
 
@@ -276,7 +356,7 @@ pnpm release:core
 pnpm release -- --packages=engine,cli --bump=patch --tag=latest
 ```
 
-Release script supports `--dry-run`, `--skip-version`, `--skip-build`, `--preid`, and package filtering.
+The release script (`scripts/release-packages.mjs`) supports `--dry-run`, `--skip-version`, `--skip-build`, `--preid`, and `--packages=` filtering.
 
 ---
 


### PR DESCRIPTION
## Summary
This PR significantly expands and reorganizes the README documentation to reflect the current architecture, including the new orchestrator/agent-teams system, remote-server runtime, and clarified workspace structure.

## Key Changes

### Documentation Structure
- **Reorganized repository layout** with separate "Packages" and "Apps" tables for clarity
- Added comprehensive descriptions of all packages including new ones: `orchestrator`, `agent-teams`, `acp`, `langfuse-plugin`, `canvas-cli`
- Clarified experimental apps handling with reference to `apps/EXPERIMENTAL.md`

### Architecture Documentation
- **Expanded Engine bootstrap section** with detailed tool merge priority explanation
- **Enhanced plugin system documentation** with full context API details (`registerTool`, `registerHook`, `registerService`, etc.)
- **Detailed Agent loop behavior** with specific hook names (`beforeLLMCall`, `afterLLMCall`, `beforeToolCall`, `afterToolCall`, `onToolCall`, `beforeRun`, `afterRun`)
- **Built-in plugins section** now lists all 9 plugins with descriptions: MCP, skills, plan-mode, task-tracking, SubAgent, tool-search, role-soul, agent-teams, ptc
- **New Orchestrator section** explaining TaskGraph, routing strategies (`auto`/`all`/`plan`), and built-in roles
- **Expanded Remote Server section** with detailed component breakdown: dispatcher, agent-runner, clarification-queue, sessions, memory, worktrees, model-config, adapters, internal API, and deferred tool loading

### Setup & Development
- Added `pnpm start:debug` command documentation
- Added multi-agent teams preview commands (`pnpm preview:teams*`)
- Clarified build commands with `SKIP_DTS=1` note for core workspace
- Added comprehensive environment variables section covering:
  - OpenAI/Anthropic configuration
  - Context compaction tuning parameters
  - Clarification settings
  - Remote server secrets

### Development Commands
- Expanded workspace-level commands with clearer descriptions
- Added `test:core` and `test:packages` distinctions
- Clarified that all packages use **vitest** and `tsc --noEmit`
- Updated notes about workspace inclusion and experimental apps

### Minor Improvements
- Consistent formatting and punctuation throughout
- Clarified backward compatibility notes
- Added specific file paths for key components
- Improved readability with better section organization

## Notes
- Changes are documentation-only (README.md and README-CN.md)
- No source code modifications
- Reflects current state of codebase with orchestrator and remote-server as first-class components

https://claude.ai/code/session_01EfeDNzDK8JgfJVP9WJaaJ3