### PR TITLE
Add group nodes feature with Ctrl+G keyboard shortcut

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -103,6 +103,7 @@ export const Canvas = ({
     redo,
     duplicateNode,
     pasteNodes,
+    groupNodes,
   } = useNodes(canvasId, () => {});
 
   const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null);
@@ -230,10 +231,23 @@ export const Canvas = ({
 
   useCanvasContext(rootFolder, nodes, canvasName);
 
+  const groupSelectedNodes = useCallback(() => {
+    if (selectedNodeIds.length === 0) return;
+    const frame = groupNodes(selectedNodeIds);
+    if (!frame) return;
+    setSelectedNodeIds([frame.id]);
+    notify({
+      tone: 'success',
+      title: 'Nodes grouped',
+      description: `Wrapped ${selectedNodeIds.length} node${selectedNodeIds.length === 1 ? '' : 's'} in a new frame.`,
+    });
+  }, [groupNodes, selectedNodeIds, notify]);
+
   useCanvasKeyboard({
     undo, redo, nodes, selectedNodeIds, setSelectedNodeIds,
     selectedEdgeId, setSelectedEdgeId, removeEdge: requestRemoveEdge,
-    duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, removeNodes: requestRemoveNodes,
+    duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, groupSelectedNodes,
+    removeNodes: requestRemoveNodes,
     searchOpen, setSearchOpen, contextMenu, setContextMenu,
     setHighlightedId, handleFocusNode,
     keyboardLocked: isOverlayOpen,

--- a/apps/canvas-workspace/src/renderer/src/constants/interaction.ts
+++ b/apps/canvas-workspace/src/renderer/src/constants/interaction.ts
@@ -77,6 +77,7 @@ export const SHORTCUT_SECTIONS: ShortcutSection[] = [
       { combo: 'Ctrl/Cmd + A', description: 'Select all nodes.' },
       { combo: 'Ctrl/Cmd + D', description: 'Duplicate the selected node.' },
       { combo: 'Ctrl/Cmd + C / V', description: 'Copy and paste selected nodes.' },
+      { combo: 'Ctrl/Cmd + G', description: 'Wrap the selected nodes in a new frame.' },
       { combo: 'Delete / Backspace', description: 'Delete the current selection with confirmation.' },
       { combo: 'Ctrl/Cmd + Z', description: 'Undo the last change.' },
       { combo: 'Ctrl/Cmd + Shift + Z', description: 'Redo the last undone change.' },

--- a/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.ts
@@ -16,6 +16,8 @@ interface Options {
   clipboardNodes: CanvasNode[];
   setClipboardNodes: (nodes: CanvasNode[]) => void;
   pasteNodes: (nodes: CanvasNode[]) => CanvasNode[];
+  /** Wrap the current node selection in a new frame. */
+  groupSelectedNodes: () => void;
   removeNodes: (ids: string[]) => void | Promise<void>;
   searchOpen: boolean;
   setSearchOpen: (open: boolean | ((prev: boolean) => boolean)) => void;
@@ -29,7 +31,7 @@ interface Options {
 export const useCanvasKeyboard = ({
   undo, redo, nodes, selectedNodeIds, setSelectedNodeIds,
   selectedEdgeId, setSelectedEdgeId, removeEdge,
-  duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, removeNodes,
+  duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, groupSelectedNodes, removeNodes,
   searchOpen, setSearchOpen, contextMenu, setContextMenu,
   setHighlightedId, handleFocusNode,
   keyboardLocked = false,
@@ -79,6 +81,11 @@ export const useCanvasKeyboard = ({
         if (selected.length > 0) setClipboardNodes(selected);
         return;
       }
+      if (isMod && (e.key === 'g' || e.key === 'G') && !e.shiftKey && !isEditable) {
+        e.preventDefault();
+        if (selectedNodeIds.length > 0) groupSelectedNodes();
+        return;
+      }
       if (isMod && e.key === 'v' && !isEditable) {
         if (clipboardNodes.length > 0) {
           e.preventDefault();
@@ -110,7 +117,7 @@ export const useCanvasKeyboard = ({
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [undo, redo, nodes, selectedNodeIds, setSelectedNodeIds, selectedEdgeId, setSelectedEdgeId, removeEdge, duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, removeNodes, searchOpen, setSearchOpen, contextMenu, setContextMenu, keyboardLocked]);
+  }, [undo, redo, nodes, selectedNodeIds, setSelectedNodeIds, selectedEdgeId, setSelectedEdgeId, removeEdge, duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, groupSelectedNodes, removeNodes, searchOpen, setSearchOpen, contextMenu, setContextMenu, keyboardLocked]);
 
   // Cmd/Ctrl+Tab to cycle through nodes (Shift reverses direction)
   useEffect(() => {

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
@@ -523,6 +523,50 @@ export const useNodes = (
     [applyNodes, scheduleSave, canvasId, setNodes, nodesRef]
   );
 
+  /**
+   * Wrap the given nodes in a new frame sized to their bounding box plus
+   * a uniform padding. Frame parent/child relationships are positional
+   * (see `frameHierarchy.ts`), so the resulting frame automatically
+   * "owns" anything whose center sits inside the new bbox. Returns the
+   * created frame, or null when the selection resolves to no nodes.
+   */
+  const groupNodes = useCallback(
+    (ids: string[]): CanvasNode | null => {
+      if (ids.length === 0) return null;
+      const idSet = new Set(ids);
+      const targets = nodesRef.current.filter((n) => idSet.has(n.id));
+      if (targets.length === 0) return null;
+
+      const PADDING = 40;
+      let minX = Infinity;
+      let minY = Infinity;
+      let maxX = -Infinity;
+      let maxY = -Infinity;
+      for (const n of targets) {
+        if (n.x < minX) minX = n.x;
+        if (n.y < minY) minY = n.y;
+        if (n.x + n.width > maxX) maxX = n.x + n.width;
+        if (n.y + n.height > maxY) maxY = n.y + n.height;
+      }
+
+      const frame: CanvasNode = {
+        id: genId(),
+        type: 'frame',
+        title: 'Group',
+        x: minX - PADDING,
+        y: minY - PADDING,
+        width: maxX - minX + PADDING * 2,
+        height: maxY - minY + PADDING * 2,
+        data: createNodeData('frame'),
+        updatedAt: Date.now(),
+      };
+
+      applyNodes([...nodesRef.current, frame]);
+      return frame;
+    },
+    [applyNodes, nodesRef]
+  );
+
   const addEdge = useCallback(
     (edge: CanvasEdge) => {
       applyEdges([...edgesRef.current, edge]);
@@ -582,5 +626,6 @@ export const useNodes = (
     redo,
     duplicateNode,
     pasteNodes,
+    groupNodes,
   };
 };


### PR DESCRIPTION
## Summary
This PR adds a new "group nodes" feature that allows users to wrap selected nodes in a new frame. The frame is automatically sized to fit all selected nodes with uniform padding, and the feature is accessible via the Ctrl/Cmd+G keyboard shortcut.

## Key Changes
- **Added `groupNodes` hook** in `useNodes.ts`: Creates a new frame that wraps selected nodes, calculating the bounding box with 40px padding on all sides. Returns the created frame or null if no valid nodes are selected.
- **Integrated grouping into Canvas component**: Added `groupSelectedNodes` callback that wraps the current selection and provides user feedback via notification.
- **Added keyboard shortcut**: Implemented Ctrl/Cmd+G binding in `useCanvasKeyboard.ts` to trigger node grouping when nodes are selected.
- **Updated keyboard shortcuts documentation**: Added the new Ctrl/Cmd+G shortcut to the interaction constants for display in the help menu.

## Implementation Details
- The `groupNodes` function uses positional frame hierarchy (as noted in comments referencing `frameHierarchy.ts`), meaning the new frame automatically "owns" any nodes whose centers fall within its bounding box.
- The frame is created with a unique ID, default title "Group", and current timestamp.
- After grouping, the newly created frame becomes the selected node, providing immediate visual feedback.
- The feature respects the existing keyboard lock state and only activates when not in an editable context.

https://claude.ai/code/session_017qqqoi7pHgCb7CzQVgQrWy