### PR TITLE
feat: add GPT image generation and devtools UI

### DIFF
--- a/apps/devtools-web/src/App.tsx
+++ b/apps/devtools-web/src/App.tsx
@@ -985,9 +985,11 @@ export default function App() {
                   <tr>
                     <th>Index</th>
                     <th>Duration</th>
-                    <th>TTFT</th>
-                    <th>TTFB</th>
-                    <th>Stream</th>
+                    <th title="Engine preparation before HTTP request (includes connection establishment)">Eng Prep</th>
+                    <th title="Time from HTTP request sent to first chunk received (network + model latency)">TTFB</th>
+                    <th title="Time from LLM call start to first chunk (= Eng Prep + TTFB)">TTFT</th>
+                    <th title="Time from HTTP request sent to first text token (excludes tool-call-only chunks)">TTFT Text</th>
+                    <th title="Time from first chunk to last chunk (stream transfer duration)">Stream</th>
                     <th>Tool Wait</th>
                     <th>Finish</th>
                     <th>Text Len</th>
@@ -1001,6 +1003,9 @@ export default function App() {
                 </thead>
                 <tbody>
                   {selectedRun.llmSpans.map((span) => {
+                    const enginePrep =
+                      span.enginePrepMs ??
+                      (span.requestStartAt && span.startedAt ? Math.max(0, span.requestStartAt - span.startedAt) : undefined);
                     const ttft =
                       span.ttftMs ??
                       (span.firstChunkAt && span.startedAt ? Math.max(0, span.firstChunkAt - span.startedAt) : undefined);
@@ -1008,6 +1013,11 @@ export default function App() {
                       span.ttfbMs ??
                       (span.firstChunkAt
                         ? Math.max(0, span.firstChunkAt - (span.requestStartAt ?? span.startedAt))
+                        : undefined);
+                    const ttftText =
+                      span.ttftTextMs ??
+                      (span.firstTextAt
+                        ? Math.max(0, span.firstTextAt - (span.requestStartAt ?? span.startedAt))
                         : undefined);
                     const stream =
                       span.streamDurationMs ??
@@ -1020,8 +1030,10 @@ export default function App() {
                     <tr key={span.index}>
                       <td>#{span.index}</td>
                       <td>{formatDuration(span.durationMs)}</td>
-                      <td>{ttft !== undefined ? formatDuration(ttft) : 'n/a'}</td>
+                      <td>{enginePrep !== undefined ? formatDuration(enginePrep) : 'n/a'}</td>
                       <td>{ttfb !== undefined ? formatDuration(ttfb) : 'n/a'}</td>
+                      <td>{ttft !== undefined ? formatDuration(ttft) : 'n/a'}</td>
+                      <td>{ttftText !== undefined ? formatDuration(ttftText) : '—'}</td>
                       <td>{stream !== undefined ? formatDuration(stream) : 'n/a'}</td>
                       <td>{toolWait !== undefined ? formatDuration(toolWait) : 'n/a'}</td>
                       <td>{span.finishReason || 'n/a'}</td>

--- a/apps/remote-server/.pulse-coder/config.json
+++ b/apps/remote-server/.pulse-coder/config.json
@@ -1,6 +1,6 @@
 {
   "current_model": "gpt-5.5",
-  "provider_type": "claude",
+  "provider_type": "openai",
   "options": [
     {
       "name": "gpt-5-codex",
@@ -44,7 +44,7 @@
     },
     {
       "name": "gpt-5.5",
-      "provider_type": "claude"
+      "provider_type": "openai"
     },
     {
       "name": "claude-opus-4-6",

--- a/apps/remote-server/src/adapters/discord/adapter.ts
+++ b/apps/remote-server/src/adapters/discord/adapter.ts
@@ -6,7 +6,7 @@ import type { PlatformAdapter, IncomingMessage, StreamHandle } from '../../core/
 import type { ClarificationRequest } from '../../core/types.js';
 import { clarificationQueue } from '../../core/clarification-queue.js';
 import { getActiveStreamId } from '../../core/active-run-store.js';
-import { extractGeminiImageResult } from '../feishu/image-result.js';
+import { extractGeneratedImageResult } from '../feishu/image-result.js';
 import { DiscordClient } from './client.js';
 import { buildDiscordMemoryKey, buildDiscordPlatformKey, isDiscordThreadChannelType } from './platform-key.js';
 
@@ -395,7 +395,7 @@ export class DiscordAdapter implements PlatformAdapter {
       },
 
       async onToolResult(toolResult) {
-        const imageResult = extractGeminiImageResult(toolResult);
+        const imageResult = extractGeneratedImageResult(toolResult);
         if (!imageResult) {
           return;
         }

--- a/apps/remote-server/src/adapters/feishu/adapter.ts
+++ b/apps/remote-server/src/adapters/feishu/adapter.ts
@@ -4,7 +4,7 @@ import type { PlatformAdapter, IncomingMessage, StreamHandle } from '../../core/
 import type { ClarificationRequest } from '../../core/types.js';
 import { clarificationQueue } from '../../core/clarification-queue.js';
 import { getActiveStreamId } from '../../core/active-run-store.js';
-import { extractGeminiImageResult } from './image-result.js';
+import { extractGeneratedImageResult } from './image-result.js';
 import {
   createLarkClient,
   addMessageReaction,
@@ -292,7 +292,7 @@ export class FeishuAdapter implements PlatformAdapter {
       },
 
       async onToolResult(toolResult) {
-        const imageResult = extractGeminiImageResult(toolResult);
+        const imageResult = extractGeneratedImageResult(toolResult);
         if (!imageResult) {
           return;
         }

--- a/apps/remote-server/src/adapters/feishu/image-result.ts
+++ b/apps/remote-server/src/adapters/feishu/image-result.ts
@@ -1,9 +1,9 @@
-interface GeminiImageResult {
+interface GeneratedImageResult {
   outputPath: string;
   mimeType?: string;
 }
 
-export function extractGeminiImageResult(toolResult: unknown): GeminiImageResult | null {
+export function extractGeneratedImageResult(toolResult: unknown): GeneratedImageResult | null {
   const toolName = extractToolName(toolResult);
   const payload = extractToolPayload(toolResult);
 
@@ -18,11 +18,11 @@ export function extractGeminiImageResult(toolResult: unknown): GeminiImageResult
 
   const mimeType = asString(payload.mimeType) ?? undefined;
 
-  if (toolName && toolName !== 'generate_image' && toolName !== 'gemini_pro_image') {
+  if (toolName && toolName !== 'generate_image') {
     return null;
   }
 
-  if (!toolName && !looksLikeGeminiImagePayload(payload)) {
+  if (!toolName && !looksLikeGeneratedImagePayload(payload)) {
     return null;
   }
 
@@ -66,7 +66,7 @@ function extractToolPayload(toolResult: unknown): unknown {
   return toolResult;
 }
 
-function looksLikeGeminiImagePayload(payload: Record<string, unknown>): boolean {
+function looksLikeGeneratedImagePayload(payload: Record<string, unknown>): boolean {
   return (
     asString(payload.model) !== null
     && asString(payload.outputPath) !== null

--- a/apps/remote-server/src/adapters/feishu/image-result.ts
+++ b/apps/remote-server/src/adapters/feishu/image-result.ts
@@ -18,7 +18,7 @@ export function extractGeminiImageResult(toolResult: unknown): GeminiImageResult
 
   const mimeType = asString(payload.mimeType) ?? undefined;
 
-  if (toolName && toolName !== 'gemini_pro_image') {
+  if (toolName && toolName !== 'generate_image' && toolName !== 'gemini_pro_image') {
     return null;
   }
 

--- a/apps/remote-server/src/routes/internal.ts
+++ b/apps/remote-server/src/routes/internal.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'fs';
 import { Hono, type Context } from 'hono';
 import { getConnInfo } from '@hono/node-server/conninfo';
 import { createLarkClient, sendImageMessage, sendTextMessage } from '../adapters/feishu/client.js';
-import { extractGeminiImageResult } from '../adapters/feishu/image-result.js';
+import { extractGeneratedImageResult } from '../adapters/feishu/image-result.js';
 import { getDiscordGatewayStatus, restartDiscordGateway } from '../adapters/discord/gateway-manager.js';
 import { DiscordClient } from '../adapters/discord/client.js';
 import { executeAgentTurn, formatCompactionEvents, type CompactionSnapshot } from '../core/agent-runner.js';
@@ -153,7 +153,7 @@ internalRouter.post('/agent/run', async (c) => {
             return;
           }
 
-          const imageResult = extractGeminiImageResult(toolResult);
+          const imageResult = extractGeneratedImageResult(toolResult);
           if (!imageResult) {
             return;
           }

--- a/apps/remote-server/src/server.ts
+++ b/apps/remote-server/src/server.ts
@@ -6,6 +6,12 @@ import { feishuRouter } from './routes/feishu.js';
 import { discordRouter } from './routes/discord.js';
 import { internalRouter } from './routes/internal.js';
 import { devtoolsRouter } from './routes/devtools.js';
+import { serveStatic } from '@hono/node-server/serve-static';
+import { resolve } from 'node:path';
+
+// Point to devtools-web dist — server cwd is apps/remote-server so ../devtools-web resolves correctly.
+// Fallback env var allows overriding when running from a different directory.
+const devtoolsDistPath = process.env.DEVTOOLS_DIST_PATH ?? resolve(process.cwd(), '../devtools-web/dist');
 
 export function createApp(): Hono {
   const app = new Hono();
@@ -29,6 +35,13 @@ export function createApp(): Hono {
   // Web REST + SSE routes
   app.route('/api/devtools', devtoolsRouter);
   // app.route('/api', apiRouter);
+
+  // Devtools web UI — serve built static assets at /devtools/*
+  app.get('/devtools', (c) => c.redirect('/devtools/'));
+  app.use('/devtools/*', serveStatic({
+    root: devtoolsDistPath,
+    rewriteRequestPath: (path) => path.replace(/^\/devtools/, '') || '/',
+  }));
 
   // 404 fallback
   app.notFound((c) => c.json({ error: 'Not found' }, 404));

--- a/packages/engine/src/tools/gemini-pro-image.ts
+++ b/packages/engine/src/tools/gemini-pro-image.ts
@@ -4,7 +4,7 @@ import { dirname, isAbsolute, join, resolve } from 'path';
 import z from 'zod';
 import type { Tool } from '../shared/types';
 
-interface GenerateResponse {
+interface GeminiGenerateResponse {
   candidates?: Array<{
     content?: {
       parts?: Array<{
@@ -26,26 +26,49 @@ interface GenerateResponse {
   };
 }
 
+interface OpenAIImagesResponse {
+  data?: Array<{
+    b64_json?: string;
+    url?: string;
+    revised_prompt?: string;
+  }>;
+  error?: {
+    message?: string;
+    type?: string;
+    code?: string;
+  };
+}
+
 interface GenerateRequestTarget {
   endpoint: string;
   headers: Record<string, string>;
   model: string;
 }
 
-const DEFAULT_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta';
-const DEFAULT_MODEL = 'gemini-pro-image';
+type ImageProvider = 'gemini' | 'openai';
+type OutputFormat = 'png' | 'jpeg' | 'webp';
+
+const DEFAULT_GEMINI_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta';
+const DEFAULT_GEMINI_MODEL = 'gemini-pro-image';
+const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
+const DEFAULT_OPENAI_MODEL = 'gpt-image-2';
 const DEFAULT_TIMEOUT = 120000;
 
 export const GeminiProImageTool: Tool<
   {
     prompt: string;
+    provider?: ImageProvider | 'gpt';
     model?: string;
     outputPath?: string;
     mimeType?: 'image/png' | 'image/jpeg' | 'image/webp';
     includeBase64?: boolean;
     timeout?: number;
+    size?: string;
+    quality?: string;
+    outputFormat?: OutputFormat;
   },
   {
+    provider: ImageProvider;
     model: string;
     text: string;
     mimeType: string;
@@ -54,13 +77,17 @@ export const GeminiProImageTool: Tool<
     base64?: string;
   }
 > = {
-  name: 'gemini_pro_image',
+  name: 'generate_image',
   description:
-    'Generate an image with Gemini and save it to local disk. Requires GEMINI_API_KEY. Model defaults to GEMINI_PRO_IMAGE_MODEL or gemini-pro-image.',
+    'Generate an image with GPT/OpenAI by default and save it to local disk. Uses OPENAI_API_KEY plus OPENAI_BASE_URL/OPENAI_API_BASE_URL/OPENAI_API_URL. Defaults to OPENAI_IMAGE_MODEL or the latest GPT image model gpt-image-2. Gemini remains available by setting provider="gemini".',
   defer_loading: true,
   inputSchema: z.object({
     prompt: z.string().describe('The prompts for image generation need to describe in detail the content, style, and composition of the image you want to generate.'),
-    model: z.string().optional().describe('Gemini model name. Defaults to GEMINI_PRO_IMAGE_MODEL or google/gemini-3-pro-image-preview.'),
+    provider: z
+      .enum(['gemini', 'openai', 'gpt'])
+      .optional()
+      .describe('Image provider. Defaults to "openai"/"gpt" for GPT image generation. Set "gemini" explicitly to use Gemini.'),
+    model: z.string().optional().describe('Model name. Defaults to OPENAI_IMAGE_MODEL or gpt-image-2 for GPT image generation.'),
     outputPath: z
       .string()
       .optional()
@@ -73,8 +100,20 @@ export const GeminiProImageTool: Tool<
       .number()
       .optional()
       .describe('Request timeout in milliseconds. Defaults to 120000 (2 minutes).'),
+    size: z
+      .string()
+      .optional()
+      .describe('OpenAI/GPT image size, for example 1024x1024, 1024x1536, 1536x1024, or auto. Only sent for OpenAI-compatible requests.'),
+    quality: z
+      .string()
+      .optional()
+      .describe('OpenAI/GPT image quality, for example auto, low, medium, high, standard, or hd. Only sent for OpenAI-compatible requests.'),
+    outputFormat: z
+      .enum(['png', 'jpeg', 'webp'])
+      .optional()
+      .describe('OpenAI/GPT output format. Only sent for OpenAI-compatible requests.'),
   }),
-  execute: async ({ prompt, model, outputPath, includeBase64 = false, timeout = DEFAULT_TIMEOUT }) => {
+  execute: async ({ prompt, provider, model, outputPath, includeBase64 = false, timeout = DEFAULT_TIMEOUT, size, quality, outputFormat }) => {
     if (!prompt.trim()) {
       throw new Error('prompt is required');
     }
@@ -83,78 +122,368 @@ export const GeminiProImageTool: Tool<
       throw new Error('timeout must be between 1 and 600000 milliseconds');
     }
 
-    const apiKey = process.env.GEMINI_API_KEY?.trim();
-    if (!apiKey) {
-      throw new Error('GEMINI_API_KEY environment variable is not set');
-    }
+    const resolvedProvider = resolveProvider(provider, model);
 
-    const resolvedModel = model?.trim() || process.env.GEMINI_PRO_IMAGE_MODEL?.trim() || DEFAULT_MODEL;
-    const baseUrl = (process.env.GEMINI_API_BASE_URL?.trim() || DEFAULT_BASE_URL).replace(/\/$/, '');
-    const requestTarget = buildGenerateRequestTarget(baseUrl, resolvedModel, apiKey);
-
-    const abortController = new AbortController();
-    const timeoutId = setTimeout(() => abortController.abort(), timeout);
-
-    let response: Response;
-    try {
-      response = await fetch(requestTarget.endpoint, {
-        method: 'POST',
-        headers: requestTarget.headers,
-        body: JSON.stringify({
-          contents: [
-            {
-              role: 'user',
-              parts: [{ text: prompt }],
-            },
-          ],
-          generationConfig: {
-            responseModalities: ['TEXT', 'IMAGE']
-          },
-        }),
-        signal: abortController.signal,
+    if (resolvedProvider === 'openai') {
+      return generateOpenAIImage({
+        prompt,
+        model,
+        outputPath,
+        includeBase64,
+        timeout,
+        size,
+        quality,
+        outputFormat,
       });
-    } catch (error) {
-      const isAbort = error instanceof Error && error.name === 'AbortError';
-      if (isAbort) {
-        throw new Error(`Gemini image request timed out after ${timeout}ms`);
-      }
-      throw error;
-    } finally {
-      clearTimeout(timeoutId);
     }
 
-    if (!response.ok) {
-      const errorBody = await response.text();
-      throw new Error(`Gemini image API error: ${response.status} ${response.statusText} - ${errorBody}`);
-    }
-
-    const data = (await response.json()) as GenerateResponse;
-    const image = extractImage(data);
-    if (!image) {
-      const blockReason = data.promptFeedback?.blockReason;
-      if (blockReason) {
-        throw new Error(`Gemini image blocked the request: ${blockReason}`);
-      }
-      throw new Error('Gemini image response did not include image data');
-    }
-
-    const text = extractText(data);
-    const finalOutputPath = resolveOutputPath(outputPath, image.mimeType);
-    await mkdir(dirname(finalOutputPath), { recursive: true });
-    await writeFile(finalOutputPath, Buffer.from(image.base64, 'base64'));
-
-    return {
-      model: requestTarget.model,
-      text,
-      mimeType: image.mimeType,
-      outputPath: finalOutputPath,
-      bytes: Buffer.byteLength(image.base64, 'base64'),
-      base64: includeBase64 ? image.base64 : undefined,
-    };
+    return generateGeminiImage({
+      prompt,
+      model,
+      outputPath,
+      includeBase64,
+      timeout,
+    });
   },
 };
 
-function extractImage(data: GenerateResponse): { base64: string; mimeType: string } | null {
+async function generateGeminiImage({
+  prompt,
+  model,
+  outputPath,
+  includeBase64,
+  timeout,
+}: {
+  prompt: string;
+  model?: string;
+  outputPath?: string;
+  includeBase64: boolean;
+  timeout: number;
+}): Promise<{
+  provider: ImageProvider;
+  model: string;
+  text: string;
+  mimeType: string;
+  outputPath: string;
+  bytes: number;
+  base64?: string;
+}> {
+  const apiKey = process.env.GEMINI_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error('GEMINI_API_KEY environment variable is not set');
+  }
+
+  const resolvedModel = model?.trim() || process.env.GEMINI_PRO_IMAGE_MODEL?.trim() || DEFAULT_GEMINI_MODEL;
+  const baseUrl = (process.env.GEMINI_API_BASE_URL?.trim() || DEFAULT_GEMINI_BASE_URL).replace(/\/$/, '');
+  const requestTarget = buildGeminiGenerateRequestTarget(baseUrl, resolvedModel, apiKey);
+
+  const abortController = new AbortController();
+  const timeoutId = setTimeout(() => abortController.abort(), timeout);
+
+  let response: Response;
+  try {
+    response = await fetch(requestTarget.endpoint, {
+      method: 'POST',
+      headers: requestTarget.headers,
+      body: JSON.stringify({
+        contents: [
+          {
+            role: 'user',
+            parts: [{ text: prompt }],
+          },
+        ],
+        generationConfig: {
+          responseModalities: ['TEXT', 'IMAGE'],
+        },
+      }),
+      signal: abortController.signal,
+    });
+  } catch (error) {
+    const isAbort = error instanceof Error && error.name === 'AbortError';
+    if (isAbort) {
+      throw new Error(`Gemini image request timed out after ${timeout}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(`Gemini image API error: ${response.status} ${response.statusText} - ${errorBody}`);
+  }
+
+  const data = (await response.json()) as GeminiGenerateResponse;
+  const image = extractGeminiImage(data);
+  if (!image) {
+    const blockReason = data.promptFeedback?.blockReason;
+    if (blockReason) {
+      throw new Error(`Gemini image blocked the request: ${blockReason}`);
+    }
+    throw new Error('Gemini image response did not include image data');
+  }
+
+  const text = extractGeminiText(data);
+  return saveImageResult({
+    provider: 'gemini',
+    model: requestTarget.model,
+    text,
+    base64: image.base64,
+    mimeType: image.mimeType,
+    outputPath,
+    includeBase64,
+  });
+}
+
+async function generateOpenAIImage({
+  prompt,
+  model,
+  outputPath,
+  includeBase64,
+  timeout,
+  size,
+  quality,
+  outputFormat,
+}: {
+  prompt: string;
+  model?: string;
+  outputPath?: string;
+  includeBase64: boolean;
+  timeout: number;
+  size?: string;
+  quality?: string;
+  outputFormat?: OutputFormat;
+}): Promise<{
+  provider: ImageProvider;
+  model: string;
+  text: string;
+  mimeType: string;
+  outputPath: string;
+  bytes: number;
+  base64?: string;
+}> {
+  const apiKey = process.env.OPENAI_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error('OPENAI_API_KEY environment variable is not set');
+  }
+
+  const resolvedModel = model?.trim() || process.env.OPENAI_IMAGE_MODEL?.trim() || DEFAULT_OPENAI_MODEL;
+  const baseUrl = resolveOpenAIBaseUrl();
+  const endpoint = buildOpenAIImagesEndpoint(baseUrl);
+
+  const requestBody: Record<string, unknown> = {
+    model: resolvedModel,
+    prompt,
+  };
+
+  if (size?.trim()) {
+    requestBody.size = size.trim();
+  }
+
+  if (quality?.trim()) {
+    requestBody.quality = quality.trim();
+  }
+
+  if (outputFormat) {
+    requestBody.output_format = outputFormat;
+  }
+
+  const abortController = new AbortController();
+  const timeoutId = setTimeout(() => abortController.abort(), timeout);
+
+  let response: Response;
+  try {
+    response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(requestBody),
+      signal: abortController.signal,
+    });
+  } catch (error) {
+    const isAbort = error instanceof Error && error.name === 'AbortError';
+    if (isAbort) {
+      throw new Error(`OpenAI image request timed out after ${timeout}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  const responseText = await response.text();
+  const data = parseOpenAIImagesResponse(responseText);
+  if (!response.ok) {
+    const errorMessage = data?.error?.message || responseText;
+    throw new Error(`OpenAI image API error: ${response.status} ${response.statusText} - ${errorMessage}`);
+  }
+
+  const image = await extractOpenAIImage(data, outputFormat, timeout);
+  if (!image) {
+    throw new Error('OpenAI image response did not include image data');
+  }
+
+  const text = data?.data?.find((item) => item.revised_prompt?.trim())?.revised_prompt?.trim() || '';
+  return saveImageResult({
+    provider: 'openai',
+    model: resolvedModel,
+    text,
+    base64: image.base64,
+    mimeType: image.mimeType,
+    outputPath,
+    includeBase64,
+  });
+}
+
+function resolveProvider(provider: ImageProvider | 'gpt' | undefined, model: string | undefined): ImageProvider {
+  if (provider === 'gpt' || provider === 'openai') {
+    return 'openai';
+  }
+
+  if (provider === 'gemini') {
+    return 'gemini';
+  }
+
+  const requestedModel = model?.trim().toLowerCase();
+  if (requestedModel && isOpenAIImageModel(requestedModel)) {
+    return 'openai';
+  }
+
+  if (requestedModel && isGeminiImageModel(requestedModel)) {
+    return 'gemini';
+  }
+
+  return 'openai';
+}
+
+function isOpenAIImageModel(model: string): boolean {
+  return model.startsWith('gpt-image') || model.startsWith('dall-e');
+}
+
+function isGeminiImageModel(model: string): boolean {
+  return model.startsWith('gemini') || model.includes('/gemini');
+}
+
+function resolveOpenAIBaseUrl(): string {
+  return (
+    process.env.OPENAI_BASE_URL?.trim() ||
+    process.env.OPENAI_API_BASE_URL?.trim() ||
+    process.env.OPENAI_API_URL?.trim() ||
+    DEFAULT_OPENAI_BASE_URL
+  ).replace(/\/$/, '');
+}
+
+function buildOpenAIImagesEndpoint(baseUrl: string): string {
+  if (/\/v\d+(?:\.\d+)?$/.test(baseUrl)) {
+    return `${baseUrl}/images/generations`;
+  }
+
+  return `${baseUrl}/v1/images/generations`;
+}
+
+function parseOpenAIImagesResponse(responseText: string): OpenAIImagesResponse | null {
+  try {
+    return JSON.parse(responseText) as OpenAIImagesResponse;
+  } catch {
+    return null;
+  }
+}
+
+async function extractOpenAIImage(
+  data: OpenAIImagesResponse | null,
+  outputFormat: OutputFormat | undefined,
+  timeout: number,
+): Promise<{ base64: string; mimeType: string } | null> {
+  const firstImage = data?.data?.[0];
+  if (!firstImage) {
+    return null;
+  }
+
+  if (firstImage.b64_json) {
+    return {
+      base64: firstImage.b64_json,
+      mimeType: outputFormatToMimeType(outputFormat),
+    };
+  }
+
+  if (firstImage.url) {
+    return fetchImageUrlAsBase64(firstImage.url, timeout);
+  }
+
+  return null;
+}
+
+async function fetchImageUrlAsBase64(url: string, timeout: number): Promise<{ base64: string; mimeType: string }> {
+  const abortController = new AbortController();
+  const timeoutId = setTimeout(() => abortController.abort(), timeout);
+
+  let response: Response;
+  try {
+    response = await fetch(url, { signal: abortController.signal });
+  } catch (error) {
+    const isAbort = error instanceof Error && error.name === 'AbortError';
+    if (isAbort) {
+      throw new Error(`OpenAI image URL download timed out after ${timeout}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(`OpenAI image URL download error: ${response.status} ${response.statusText} - ${errorBody}`);
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+  return {
+    base64: buffer.toString('base64'),
+    mimeType: response.headers.get('content-type')?.split(';')[0] || 'image/png',
+  };
+}
+
+async function saveImageResult({
+  provider,
+  model,
+  text,
+  base64,
+  mimeType,
+  outputPath,
+  includeBase64,
+}: {
+  provider: ImageProvider;
+  model: string;
+  text: string;
+  base64: string;
+  mimeType: string;
+  outputPath?: string;
+  includeBase64: boolean;
+}): Promise<{
+  provider: ImageProvider;
+  model: string;
+  text: string;
+  mimeType: string;
+  outputPath: string;
+  bytes: number;
+  base64?: string;
+}> {
+  const finalOutputPath = resolveOutputPath(outputPath, mimeType);
+  await mkdir(dirname(finalOutputPath), { recursive: true });
+  await writeFile(finalOutputPath, Buffer.from(base64, 'base64'));
+
+  return {
+    provider,
+    model,
+    text,
+    mimeType,
+    outputPath: finalOutputPath,
+    bytes: Buffer.byteLength(base64, 'base64'),
+    base64: includeBase64 ? base64 : undefined,
+  };
+}
+
+function extractGeminiImage(data: GeminiGenerateResponse): { base64: string; mimeType: string } | null {
   for (const candidate of data.candidates ?? []) {
     for (const part of candidate.content?.parts ?? []) {
       const camel = part.inlineData;
@@ -178,7 +507,7 @@ function extractImage(data: GenerateResponse): { base64: string; mimeType: strin
   return null;
 }
 
-function extractText(data: GenerateResponse): string {
+function extractGeminiText(data: GeminiGenerateResponse): string {
   const chunks: string[] = [];
 
   for (const candidate of data.candidates ?? []) {
@@ -192,7 +521,7 @@ function extractText(data: GenerateResponse): string {
   return chunks.join('\n').trim();
 }
 
-function buildGenerateRequestTarget(baseUrl: string, model: string, apiKey: string): GenerateRequestTarget {
+function buildGeminiGenerateRequestTarget(baseUrl: string, model: string, apiKey: string): GenerateRequestTarget {
   if (isVertexBaseUrl(baseUrl)) {
     const normalizedVertexBaseUrl = baseUrl.replace(/\/v1(?:beta)?$/, '');
     const vertexModel = parseVertexModel(model);
@@ -265,6 +594,18 @@ function extensionByMimeType(mimeType: string): string {
   }
 
   return 'png';
+}
+
+function outputFormatToMimeType(outputFormat: OutputFormat | undefined): string {
+  if (outputFormat === 'jpeg') {
+    return 'image/jpeg';
+  }
+
+  if (outputFormat === 'webp') {
+    return 'image/webp';
+  }
+
+  return 'image/png';
 }
 
 export default GeminiProImageTool;

--- a/packages/engine/src/tools/generate-image.ts
+++ b/packages/engine/src/tools/generate-image.ts
@@ -49,12 +49,12 @@ type ImageProvider = 'gemini' | 'openai';
 type OutputFormat = 'png' | 'jpeg' | 'webp';
 
 const DEFAULT_GEMINI_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta';
-const DEFAULT_GEMINI_MODEL = 'gemini-pro-image';
+const DEFAULT_GEMINI_MODEL = 'gemini-2.0-flash-preview-image-generation';
 const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
 const DEFAULT_OPENAI_MODEL = 'gpt-image-2';
 const DEFAULT_TIMEOUT = 120000;
 
-export const GeminiProImageTool: Tool<
+export const GenerateImageTool: Tool<
   {
     prompt: string;
     provider?: ImageProvider | 'gpt';
@@ -79,7 +79,7 @@ export const GeminiProImageTool: Tool<
 > = {
   name: 'generate_image',
   description:
-    'Generate an image with GPT/OpenAI by default and save it to local disk. Uses OPENAI_API_KEY plus OPENAI_BASE_URL/OPENAI_API_BASE_URL/OPENAI_API_URL. Defaults to OPENAI_IMAGE_MODEL or the latest GPT image model gpt-image-2. Gemini remains available by setting provider="gemini".',
+    'Generate an image with GPT/OpenAI by default and save it to local disk. Uses OPENAI_API_KEY plus OPENAI_BASE_URL/OPENAI_API_BASE_URL/OPENAI_API_URL. Defaults to OPENAI_IMAGE_MODEL or the latest GPT image model gpt-image-2. Other providers are available only when explicitly requested.',
   defer_loading: true,
   inputSchema: z.object({
     prompt: z.string().describe('The prompts for image generation need to describe in detail the content, style, and composition of the image you want to generate.'),
@@ -173,7 +173,7 @@ async function generateGeminiImage({
     throw new Error('GEMINI_API_KEY environment variable is not set');
   }
 
-  const resolvedModel = model?.trim() || process.env.GEMINI_PRO_IMAGE_MODEL?.trim() || DEFAULT_GEMINI_MODEL;
+  const resolvedModel = model?.trim() || process.env.GEMINI_IMAGE_MODEL?.trim() || DEFAULT_GEMINI_MODEL;
   const baseUrl = (process.env.GEMINI_API_BASE_URL?.trim() || DEFAULT_GEMINI_BASE_URL).replace(/\/$/, '');
   const requestTarget = buildGeminiGenerateRequestTarget(baseUrl, resolvedModel, apiKey);
 
@@ -608,4 +608,4 @@ function outputFormatToMimeType(outputFormat: OutputFormat | undefined): string 
   return 'image/png';
 }
 
-export default GeminiProImageTool;
+export default GenerateImageTool;

--- a/packages/engine/src/tools/index.ts
+++ b/packages/engine/src/tools/index.ts
@@ -5,7 +5,7 @@ import { GrepTool } from './grep';
 import { LsTool } from './ls';
 import { BashTool } from './bash';
 import { TavilyTool, TavilyExtractTool, TavilyCrawlTool, TavilyMapTool } from './tavily';
-import { GeminiProImageTool } from './gemini-pro-image';
+import { GenerateImageTool } from './generate-image';
 import { ClarifyTool } from './clarify';
 import { Tool } from 'ai';
 import { deferDemoTool } from './defer-demo';
@@ -22,7 +22,7 @@ export const BuiltinTools = [
   TavilyExtractTool,
   TavilyCrawlTool,
   TavilyMapTool,
-  GeminiProImageTool,
+  GenerateImageTool,
   ClarifyTool,
   deferDemoTool
 ] as const;
@@ -50,7 +50,7 @@ export {
   TavilyExtractTool,
   TavilyCrawlTool,
   TavilyMapTool,
-  GeminiProImageTool,
+  GenerateImageTool,
   ClarifyTool,
 };
 


### PR DESCRIPTION
Add GPT image generation support and expose devtools web UI from the remote server.

- Rename the image generation built-in tool to `generate_image` while defaulting to OpenAI/GPT image models
- Support OpenAI-compatible image generation responses and Feishu image result handling
- Serve built devtools web assets under `/devtools/*`
- Clarify LLM latency metrics in the devtools UI table

Validation:
- `pnpm build` in `apps/devtools-web`
- `pnpm --filter @pulse-coder/remote-server build`
