### PR TITLE
feat(remote-server): default analyze_image to GPT vision

### DIFF
--- a/apps/remote-server/.pulse-coder/config.json
+++ b/apps/remote-server/.pulse-coder/config.json
@@ -1,6 +1,6 @@
 {
-  "current_model": "gpt-5.5",
-  "provider_type": "openai",
+  "current_model": "claude-opus-4.7",
+  "provider_type": "claude",
   "options": [
     {
       "name": "gpt-5-codex",

--- a/apps/remote-server/.pulse-coder/config.json
+++ b/apps/remote-server/.pulse-coder/config.json
@@ -1,6 +1,6 @@
 {
-  "current_model": "claude-opus-4.7",
-  "provider_type": "claude",
+  "current_model": "gpt-5.5",
+  "provider_type": "openai",
   "options": [
     {
       "name": "gpt-5-codex",

--- a/apps/remote-server/src/core/tools/analyze-image.ts
+++ b/apps/remote-server/src/core/tools/analyze-image.ts
@@ -10,7 +10,7 @@ interface AnalyzeImageRequestTarget {
   model: string;
 }
 
-interface GenerateContentResponse {
+interface GeminiGenerateContentResponse {
   candidates?: Array<{
     content?: {
       parts?: Array<{
@@ -24,17 +24,42 @@ interface GenerateContentResponse {
   };
 }
 
+interface OpenAIChatCompletionResponse {
+  choices?: Array<{
+    message?: {
+      role?: string;
+      content?: string | Array<{ type?: string; text?: string }>;
+    };
+    finish_reason?: string;
+  }>;
+  error?: {
+    message?: string;
+    type?: string;
+    code?: string;
+  };
+}
+
+type AnalysisProvider = 'openai' | 'gemini';
+type DetailLevel = 'auto' | 'low' | 'high';
+
 const toolSchema = z.object({
   prompt: z.string().optional().describe('Question or instruction for the image analysis. Defaults to a concise Chinese image analysis prompt.'),
   imagePaths: z.array(z.string().min(1)).optional().describe('Optional local image paths. When omitted, the tool uses runContext.latestAttachments.'),
   maxImages: z.number().int().positive().max(10).optional().describe('Maximum number of images to analyze. Defaults to 6.'),
   timeoutMs: z.number().int().positive().max(600000).optional().describe('Request timeout in milliseconds. Defaults to 120000.'),
+  provider: z
+    .enum(['openai', 'gpt', 'gemini'])
+    .optional()
+    .describe('Vision provider. Defaults to "openai"/"gpt". Set "gemini" to use Gemini explicitly.'),
+  model: z.string().optional().describe('Vision model name. Defaults to OPENAI_VISION_MODEL or gpt-4.1-mini for OpenAI; GEMINI_VISION_MODEL or gemini-2.5-flash for Gemini.'),
+  detail: z.enum(['auto', 'low', 'high']).optional().describe('OpenAI image detail level. Only sent for OpenAI/GPT requests. Defaults to "auto".'),
 });
 
 type AnalyzeImageInput = z.infer<typeof toolSchema>;
 
 interface AnalyzeImageResult {
   ok: boolean;
+  provider: AnalysisProvider;
   model: string;
   prompt: string;
   imageCount: number;
@@ -47,30 +72,27 @@ interface AnalyzeImageToolContext extends ToolExecutionContext {
   runContext?: Record<string, any>;
 }
 
-const DEFAULT_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta';
-const DEFAULT_MODEL = 'gemini-2.5-flash';
+const DEFAULT_GEMINI_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta';
+const DEFAULT_GEMINI_MODEL = 'gemini-2.5-flash';
+const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
+const DEFAULT_OPENAI_MODEL = 'gpt-4.1-mini';
 const DEFAULT_TIMEOUT_MS = 120000;
 const DEFAULT_MAX_IMAGES = 6;
 const DEFAULT_PROMPT = '请按图片顺序描述关键信息，识别文字，提取主体内容，并结合用户上下文回答问题。如果存在多个图片，先分别概述，再总结。';
 
-type ImageInlinePart = {
-  inlineData: {
-    mimeType: string;
-    data: string;
-  };
-};
+interface ResolvedImage {
+  path: string;
+  base64: string;
+  mimeType: string;
+}
 
 export const analyzeImageTool: Tool<AnalyzeImageInput, AnalyzeImageResult> = {
   name: 'analyze_image',
-  description: 'Analyze one or more local images with Gemini. If imagePaths are omitted, automatically uses runContext.latestAttachments from the latest image message.',
+  description:
+    'Analyze one or more local images. Defaults to OpenAI/GPT vision (uses OPENAI_API_KEY plus OPENAI_BASE_URL/OPENAI_API_BASE_URL/OPENAI_API_URL, model OPENAI_VISION_MODEL or gpt-4.1-mini). Set provider="gemini" to use Gemini instead. If imagePaths are omitted, automatically uses runContext.latestAttachments from the latest image message.',
   defer_loading: true,
   inputSchema: toolSchema,
   execute: async (input: AnalyzeImageInput, context?: AnalyzeImageToolContext): Promise<AnalyzeImageResult> => {
-    const apiKey = process.env.GEMINI_API_KEY?.trim();
-    if (!apiKey) {
-      throw new Error('GEMINI_API_KEY environment variable is not set');
-    }
-
     const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const maxImages = input.maxImages ?? DEFAULT_MAX_IMAGES;
     const prompt = input.prompt?.trim() || DEFAULT_PROMPT;
@@ -85,80 +107,295 @@ export const analyzeImageTool: Tool<AnalyzeImageInput, AnalyzeImageResult> = {
       throw new Error('No images available. Provide imagePaths or upload images so runContext.latestAttachments is populated.');
     }
 
-    const imageParts: ImageInlinePart[] = await Promise.all(
-      resolvedPaths.map(async (imagePath: string): Promise<ImageInlinePart> => {
+    const images: ResolvedImage[] = await Promise.all(
+      resolvedPaths.map(async (imagePath): Promise<ResolvedImage> => {
         const buffer = await fs.readFile(imagePath);
-        const mimeType = resolveMimeType(imagePath, runContextAttachments);
         return {
-          inlineData: {
-            mimeType,
-            data: buffer.toString('base64'),
-          },
+          path: imagePath,
+          base64: buffer.toString('base64'),
+          mimeType: resolveMimeType(imagePath, runContextAttachments),
         };
       }),
     );
 
-    const baseUrl = (process.env.GEMINI_API_BASE_URL?.trim() || DEFAULT_BASE_URL).replace(/\/$/, '');
-    const model = process.env.GEMINI_ANALYZE_IMAGE_MODEL?.trim() || process.env.GEMINI_VISION_MODEL?.trim() || DEFAULT_MODEL;
-    const requestTarget = buildGenerateRequestTarget(baseUrl, model, apiKey);
+    const provider = resolveProvider(input.provider, input.model);
+    const source = input.imagePaths?.length ? 'input.imagePaths' : 'runContext.latestAttachments';
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-
-    let response: Response;
-    try {
-      response = await fetch(requestTarget.endpoint, {
-        method: 'POST',
-        headers: requestTarget.headers,
-        body: JSON.stringify({
-          contents: [
-            {
-              role: 'user',
-              parts: [
-                { text: prompt },
-                ...imageParts,
-              ],
-            },
-          ],
-        }),
-        signal: controller.signal,
+    if (provider === 'openai') {
+      return analyzeWithOpenAI({
+        prompt,
+        images,
+        timeoutMs,
+        model: input.model,
+        detail: input.detail ?? 'auto',
+        source,
       });
-    } catch (error) {
-      const isAbort = error instanceof Error && error.name === 'AbortError';
-      if (isAbort) {
-        throw new Error(`Image analysis request timed out after ${timeoutMs}ms`);
-      }
-      throw error;
-    } finally {
-      clearTimeout(timeoutId);
     }
 
-    if (!response.ok) {
-      const body = await response.text();
-      throw new Error(`Image analysis API error: ${response.status} ${response.statusText} - ${body}`);
-    }
-
-    const data = await response.json() as GenerateContentResponse;
-    const text = extractText(data);
-    if (!text) {
-      const blockReason = data.promptFeedback?.blockReason;
-      if (blockReason) {
-        throw new Error(`Image analysis blocked the request: ${blockReason}`);
-      }
-      throw new Error('Image analysis response did not include text');
-    }
-
-    return {
-      ok: true,
-      model: requestTarget.model,
+    return analyzeWithGemini({
       prompt,
-      imageCount: resolvedPaths.length,
-      imagePaths: resolvedPaths,
-      text,
-      source: input.imagePaths?.length ? 'input.imagePaths' : 'runContext.latestAttachments',
-    };
+      images,
+      timeoutMs,
+      model: input.model,
+      source,
+    });
   },
 };
+
+async function analyzeWithOpenAI({
+  prompt,
+  images,
+  timeoutMs,
+  model,
+  detail,
+  source,
+}: {
+  prompt: string;
+  images: ResolvedImage[];
+  timeoutMs: number;
+  model?: string;
+  detail: DetailLevel;
+  source: AnalyzeImageResult['source'];
+}): Promise<AnalyzeImageResult> {
+  const apiKey = process.env.OPENAI_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error('OPENAI_API_KEY environment variable is not set');
+  }
+
+  const resolvedModel =
+    model?.trim() ||
+    process.env.OPENAI_VISION_MODEL?.trim() ||
+    process.env.OPENAI_ANALYZE_IMAGE_MODEL?.trim() ||
+    DEFAULT_OPENAI_MODEL;
+  const baseUrl = resolveOpenAIBaseUrl();
+  const endpoint = buildOpenAIChatCompletionsEndpoint(baseUrl);
+
+  const requestBody = {
+    model: resolvedModel,
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: prompt },
+          ...images.map((image) => ({
+            type: 'image_url',
+            image_url: {
+              url: `data:${image.mimeType};base64,${image.base64}`,
+              detail,
+            },
+          })),
+        ],
+      },
+    ],
+  };
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  let response: Response;
+  try {
+    response = (await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(requestBody),
+      signal: controller.signal,
+    })) as unknown as Response;
+  } catch (error) {
+    const isAbort = error instanceof Error && error.name === 'AbortError';
+    if (isAbort) {
+      throw new Error(`OpenAI image analysis request timed out after ${timeoutMs}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  const responseText = await response.text();
+  const data = parseOpenAIResponse(responseText);
+  if (!response.ok) {
+    const errorMessage = data?.error?.message || responseText;
+    throw new Error(`OpenAI image analysis API error: ${response.status} ${response.statusText} - ${errorMessage}`);
+  }
+
+  const text = extractOpenAIText(data);
+  if (!text) {
+    throw new Error('OpenAI image analysis response did not include text');
+  }
+
+  return {
+    ok: true,
+    provider: 'openai',
+    model: resolvedModel,
+    prompt,
+    imageCount: images.length,
+    imagePaths: images.map((image) => image.path),
+    text,
+    source,
+  };
+}
+
+async function analyzeWithGemini({
+  prompt,
+  images,
+  timeoutMs,
+  model,
+  source,
+}: {
+  prompt: string;
+  images: ResolvedImage[];
+  timeoutMs: number;
+  model?: string;
+  source: AnalyzeImageResult['source'];
+}): Promise<AnalyzeImageResult> {
+  const apiKey = process.env.GEMINI_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error('GEMINI_API_KEY environment variable is not set');
+  }
+
+  const baseUrl = (process.env.GEMINI_API_BASE_URL?.trim() || DEFAULT_GEMINI_BASE_URL).replace(/\/$/, '');
+  const resolvedModel =
+    model?.trim() ||
+    process.env.GEMINI_ANALYZE_IMAGE_MODEL?.trim() ||
+    process.env.GEMINI_VISION_MODEL?.trim() ||
+    DEFAULT_GEMINI_MODEL;
+  const requestTarget = buildGeminiGenerateRequestTarget(baseUrl, resolvedModel, apiKey);
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  let response: Response;
+  try {
+    response = (await fetch(requestTarget.endpoint, {
+      method: 'POST',
+      headers: requestTarget.headers,
+      body: JSON.stringify({
+        contents: [
+          {
+            role: 'user',
+            parts: [
+              { text: prompt },
+              ...images.map((image) => ({
+                inlineData: {
+                  mimeType: image.mimeType,
+                  data: image.base64,
+                },
+              })),
+            ],
+          },
+        ],
+      }),
+      signal: controller.signal,
+    })) as unknown as Response;
+  } catch (error) {
+    const isAbort = error instanceof Error && error.name === 'AbortError';
+    if (isAbort) {
+      throw new Error(`Gemini image analysis request timed out after ${timeoutMs}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Gemini image analysis API error: ${response.status} ${response.statusText} - ${body}`);
+  }
+
+  const data = (await response.json()) as GeminiGenerateContentResponse;
+  const text = extractGeminiText(data);
+  if (!text) {
+    const blockReason = data.promptFeedback?.blockReason;
+    if (blockReason) {
+      throw new Error(`Gemini image analysis blocked the request: ${blockReason}`);
+    }
+    throw new Error('Gemini image analysis response did not include text');
+  }
+
+  return {
+    ok: true,
+    provider: 'gemini',
+    model: requestTarget.model,
+    prompt,
+    imageCount: images.length,
+    imagePaths: images.map((image) => image.path),
+    text,
+    source,
+  };
+}
+
+function resolveProvider(provider: AnalyzeImageInput['provider'], model: string | undefined): AnalysisProvider {
+  if (provider === 'gpt' || provider === 'openai') {
+    return 'openai';
+  }
+  if (provider === 'gemini') {
+    return 'gemini';
+  }
+
+  const requestedModel = model?.trim().toLowerCase();
+  if (requestedModel) {
+    if (requestedModel.startsWith('gpt-') || requestedModel.startsWith('o1') || requestedModel.startsWith('o3')) {
+      return 'openai';
+    }
+    if (requestedModel.startsWith('gemini') || requestedModel.includes('/gemini')) {
+      return 'gemini';
+    }
+  }
+
+  return 'openai';
+}
+
+function resolveOpenAIBaseUrl(): string {
+  return (
+    process.env.OPENAI_BASE_URL?.trim() ||
+    process.env.OPENAI_API_BASE_URL?.trim() ||
+    process.env.OPENAI_API_URL?.trim() ||
+    DEFAULT_OPENAI_BASE_URL
+  ).replace(/\/$/, '');
+}
+
+function buildOpenAIChatCompletionsEndpoint(baseUrl: string): string {
+  if (/\/v\d+(?:\.\d+)?$/.test(baseUrl)) {
+    return `${baseUrl}/chat/completions`;
+  }
+  return `${baseUrl}/v1/chat/completions`;
+}
+
+function parseOpenAIResponse(responseText: string): OpenAIChatCompletionResponse | null {
+  try {
+    return JSON.parse(responseText) as OpenAIChatCompletionResponse;
+  } catch {
+    return null;
+  }
+}
+
+function extractOpenAIText(data: OpenAIChatCompletionResponse | null): string {
+  if (!data?.choices?.length) {
+    return '';
+  }
+
+  const chunks: string[] = [];
+  for (const choice of data.choices) {
+    const content = choice.message?.content;
+    if (typeof content === 'string') {
+      if (content.trim()) {
+        chunks.push(content.trim());
+      }
+      continue;
+    }
+    if (Array.isArray(content)) {
+      for (const part of content) {
+        if (part?.type === 'text' && typeof part.text === 'string' && part.text.trim()) {
+          chunks.push(part.text.trim());
+        }
+      }
+    }
+  }
+
+  return chunks.join('\n').trim();
+}
 
 function extractRunContextAttachments(runContext?: Record<string, any>): StoredAttachment[] {
   const raw = runContext?.latestAttachments ?? runContext?.attachments;
@@ -171,7 +408,7 @@ function extractRunContextAttachments(runContext?: Record<string, any>): StoredA
     .map((item) => ({ ...item }));
 }
 
-function extractText(data: GenerateContentResponse): string {
+function extractGeminiText(data: GeminiGenerateContentResponse): string {
   const chunks: string[] = [];
 
   for (const candidate of data.candidates ?? []) {
@@ -200,7 +437,7 @@ function resolveMimeType(imagePath: string, attachments: StoredAttachment[]): st
   return 'application/octet-stream';
 }
 
-function buildGenerateRequestTarget(baseUrl: string, model: string, apiKey: string): AnalyzeImageRequestTarget {
+function buildGeminiGenerateRequestTarget(baseUrl: string, model: string, apiKey: string): AnalyzeImageRequestTarget {
   if (isVertexBaseUrl(baseUrl)) {
     const normalizedVertexBaseUrl = baseUrl.replace(/\/v1(?:beta)?$/, '');
     const vertexModel = parseVertexModel(model);


### PR DESCRIPTION
- default provider=openai with model OPENAI_VISION_MODEL or gpt-4.1-mini\n- support OpenAI chat completions vision via OPENAI_API_KEY + OPENAI_BASE_URL\n- accept optional detail (auto/low/high) for OpenAI requests\n- keep Gemini available via provider=gemini or gemini-* model