### PR TITLE
fix: use responses endpoint for image tools

### DIFF
--- a/apps/remote-server/src/core/tools/analyze-image.test.ts
+++ b/apps/remote-server/src/core/tools/analyze-image.test.ts
@@ -24,16 +24,19 @@ describe('analyzeImageTool', () => {
     explicitPath = join(tempDir, 'explicit.jpg');
     await writeFile(attachmentPath, 'attachment-image');
     await writeFile(explicitPath, 'explicit-image');
-    process.env.GEMINI_API_KEY = 'test-key';
+    process.env.OPENAI_API_KEY = 'test-key';
+    process.env.OPENAI_API_URL = 'http://localhost:18080';
+    delete process.env.GEMINI_API_KEY;
     mockFetch.mockReset();
     mockFetch.mockResolvedValue({
       ok: true,
-      json: async () => ({
-        candidates: [
+      status: 200,
+      statusText: 'OK',
+      text: async () => JSON.stringify({
+        output: [
           {
-            content: {
-              parts: [{ text: 'analysis result' }],
-            },
+            type: 'message',
+            content: [{ type: 'output_text', text: 'analysis result' }],
           },
         ],
       }),
@@ -41,6 +44,8 @@ describe('analyzeImageTool', () => {
   });
 
   afterEach(async () => {
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_URL;
     delete process.env.GEMINI_API_KEY;
     await rm(tempDir, { recursive: true, force: true });
     vi.restoreAllMocks();
@@ -65,13 +70,16 @@ describe('analyzeImageTool', () => {
 
     expect(result.source).toBe('runContext.latestAttachments');
     expect(result.imagePaths).toEqual([attachmentPath]);
-    expect(result.text).toBe('analysis result');
     expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const requestUrl = String(mockFetch.mock.calls[0]?.[0]);
+    expect(requestUrl).toBe('http://localhost:18080/responses');
 
     const request = mockFetch.mock.calls[0]?.[1];
     const body = JSON.parse(String(request?.body));
-    expect(body.contents[0].parts[0].text).toBe('describe it');
-    expect(body.contents[0].parts[1].inlineData.mimeType).toBe('image/png');
+    expect(body.input[0].content[0].text).toBe('describe it');
+    expect(body.input[0].content[1].type).toBe('input_image');
+    expect(body.input[0].content[1].image_url).toContain('data:image/png;base64,');
   });
 
   it('prefers explicit imagePaths over runContext attachments', async () => {
@@ -96,7 +104,7 @@ describe('analyzeImageTool', () => {
 
     const request = mockFetch.mock.calls[0]?.[1];
     const body = JSON.parse(String(request?.body));
-    expect(body.contents[0].parts[1].inlineData.mimeType).toBe('image/jpeg');
+    expect(body.input[0].content[1].image_url).toContain('data:image/jpeg;base64,');
   });
 
   it('throws when neither imagePaths nor latestAttachments are available', async () => {

--- a/apps/remote-server/src/core/tools/analyze-image.ts
+++ b/apps/remote-server/src/core/tools/analyze-image.ts
@@ -39,8 +39,25 @@ interface OpenAIChatCompletionResponse {
   };
 }
 
+interface OpenAIResponsesResponse {
+  output?: Array<{
+    type?: string;
+    role?: string;
+    content?: Array<{
+      type?: string;
+      text?: string;
+    }>;
+  }>;
+  error?: {
+    message?: string;
+    type?: string;
+    code?: string;
+  };
+}
+
 type AnalysisProvider = 'openai' | 'gemini';
 type DetailLevel = 'auto' | 'low' | 'high';
+type OpenAIVisionApiMode = 'responses' | 'chat_completions' | 'auto';
 
 const toolSchema = z.object({
   prompt: z.string().optional().describe('Question or instruction for the image analysis. Defaults to a concise Chinese image analysis prompt.'),
@@ -51,8 +68,12 @@ const toolSchema = z.object({
     .enum(['openai', 'gpt', 'gemini'])
     .optional()
     .describe('Vision provider. Defaults to "openai"/"gpt". Set "gemini" to use Gemini explicitly.'),
-  model: z.string().optional().describe('Vision model name. Defaults to OPENAI_VISION_MODEL or gpt-4.1-mini for OpenAI; GEMINI_VISION_MODEL or gemini-2.5-flash for Gemini.'),
+  model: z.string().optional().describe('Vision model name. Defaults to OPENAI_VISION_MODEL or gpt-5.4 for OpenAI; GEMINI_VISION_MODEL or gemini-2.5-flash for Gemini.'),
   detail: z.enum(['auto', 'low', 'high']).optional().describe('OpenAI image detail level. Only sent for OpenAI/GPT requests. Defaults to "auto".'),
+  visionApiMode: z
+    .enum(['responses', 'chat_completions', 'auto'])
+    .optional()
+    .describe('OpenAI/GPT vision API mode. "responses" uses {baseUrl}/responses input_image, "chat_completions" uses {baseUrl}/chat/completions image_url, and "auto" falls back to chat_completions if responses fails. Defaults to OPENAI_VISION_API_MODE or responses.'),
 });
 
 type AnalyzeImageInput = z.infer<typeof toolSchema>;
@@ -75,7 +96,7 @@ interface AnalyzeImageToolContext extends ToolExecutionContext {
 const DEFAULT_GEMINI_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta';
 const DEFAULT_GEMINI_MODEL = 'gemini-2.5-flash';
 const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
-const DEFAULT_OPENAI_MODEL = 'gpt-4.1-mini';
+const DEFAULT_OPENAI_MODEL = 'gpt-5.4';
 const DEFAULT_TIMEOUT_MS = 120000;
 const DEFAULT_MAX_IMAGES = 6;
 const DEFAULT_PROMPT = '请按图片顺序描述关键信息，识别文字，提取主体内容，并结合用户上下文回答问题。如果存在多个图片，先分别概述，再总结。';
@@ -89,7 +110,7 @@ interface ResolvedImage {
 export const analyzeImageTool: Tool<AnalyzeImageInput, AnalyzeImageResult> = {
   name: 'analyze_image',
   description:
-    'Analyze one or more local images. Defaults to OpenAI/GPT vision (uses OPENAI_API_KEY plus OPENAI_BASE_URL/OPENAI_API_BASE_URL/OPENAI_API_URL, model OPENAI_VISION_MODEL or gpt-4.1-mini). Set provider="gemini" to use Gemini instead. If imagePaths are omitted, automatically uses runContext.latestAttachments from the latest image message.',
+    'Analyze one or more local images. Defaults to OpenAI/GPT vision (uses OPENAI_API_KEY plus OPENAI_BASE_URL/OPENAI_API_BASE_URL/OPENAI_API_URL, model OPENAI_VISION_MODEL or gpt-5.4) via {baseUrl}/responses input_image. Set provider="gemini" to use Gemini instead. If imagePaths are omitted, automatically uses runContext.latestAttachments from the latest image message.',
   defer_loading: true,
   inputSchema: toolSchema,
   execute: async (input: AnalyzeImageInput, context?: AnalyzeImageToolContext): Promise<AnalyzeImageResult> => {
@@ -128,6 +149,7 @@ export const analyzeImageTool: Tool<AnalyzeImageInput, AnalyzeImageResult> = {
         timeoutMs,
         model: input.model,
         detail: input.detail ?? 'auto',
+        visionApiMode: input.visionApiMode,
         source,
       });
     }
@@ -148,6 +170,7 @@ async function analyzeWithOpenAI({
   timeoutMs,
   model,
   detail,
+  visionApiMode,
   source,
 }: {
   prompt: string;
@@ -155,6 +178,7 @@ async function analyzeWithOpenAI({
   timeoutMs: number;
   model?: string;
   detail: DetailLevel;
+  visionApiMode?: OpenAIVisionApiMode;
   source: AnalyzeImageResult['source'];
 }): Promise<AnalyzeImageResult> {
   const apiKey = process.env.OPENAI_API_KEY?.trim();
@@ -168,10 +192,121 @@ async function analyzeWithOpenAI({
     process.env.OPENAI_ANALYZE_IMAGE_MODEL?.trim() ||
     DEFAULT_OPENAI_MODEL;
   const baseUrl = resolveOpenAIBaseUrl();
-  const endpoint = buildOpenAIChatCompletionsEndpoint(baseUrl);
-
-  const requestBody = {
+  const mode = resolveOpenAIVisionApiMode(visionApiMode);
+  const options = {
+    prompt,
+    images,
+    timeoutMs,
     model: resolvedModel,
+    detail,
+    source,
+    apiKey,
+    baseUrl,
+  };
+
+  if (mode === 'chat_completions') {
+    return analyzeWithOpenAIChatCompletions(options);
+  }
+
+  if (mode === 'auto') {
+    try {
+      return await analyzeWithOpenAIResponses(options);
+    } catch (error) {
+      return analyzeWithOpenAIChatCompletions({
+        ...options,
+        previousError: error,
+      });
+    }
+  }
+
+  return analyzeWithOpenAIResponses(options);
+}
+
+async function analyzeWithOpenAIResponses({
+  prompt,
+  images,
+  timeoutMs,
+  model,
+  detail,
+  source,
+  apiKey,
+  baseUrl,
+}: {
+  prompt: string;
+  images: ResolvedImage[];
+  timeoutMs: number;
+  model: string;
+  detail: DetailLevel;
+  source: AnalyzeImageResult['source'];
+  apiKey: string;
+  baseUrl: string;
+}): Promise<AnalyzeImageResult> {
+  const endpoint = buildOpenAIResponsesEndpoint(baseUrl);
+  const requestBody = {
+    model,
+    input: [
+      {
+        role: 'user',
+        content: [
+          { type: 'input_text', text: prompt },
+          ...images.map((image) => ({
+            type: 'input_image',
+            image_url: `data:${image.mimeType};base64,${image.base64}`,
+            detail,
+          })),
+        ],
+      },
+    ],
+  };
+
+  const responseText = await postOpenAIJson(endpoint, apiKey, requestBody, timeoutMs, 'OpenAI responses image analysis');
+  const data = parseOpenAIResponsesResponse(responseText.body);
+  if (!responseText.ok) {
+    const errorMessage = data?.error?.message || responseText.body;
+    throw new Error(`OpenAI responses image analysis API error: ${responseText.status} ${responseText.statusText} - ${errorMessage}`);
+  }
+
+  const text = extractOpenAIResponsesText(data);
+  if (!text) {
+    throw new Error('OpenAI responses image analysis response did not include text');
+  }
+
+  return {
+    ok: true,
+    provider: 'openai',
+    model,
+    prompt,
+    imageCount: images.length,
+    imagePaths: images.map((image) => image.path),
+    text,
+    source,
+  };
+}
+
+async function analyzeWithOpenAIChatCompletions({
+  prompt,
+  images,
+  timeoutMs,
+  model,
+  detail,
+  source,
+  apiKey,
+  baseUrl,
+  previousError,
+}: {
+  prompt: string;
+  images: ResolvedImage[];
+  timeoutMs: number;
+  model: string;
+  detail: DetailLevel;
+  source: AnalyzeImageResult['source'];
+  apiKey: string;
+  baseUrl: string;
+  previousError?: unknown;
+}): Promise<AnalyzeImageResult> {
+  const endpoint = buildOpenAIChatCompletionsEndpoint(baseUrl);
+  const requestBody = {
+    model,
     messages: [
       {
         role: 'user',
@@ -189,12 +324,42 @@ async function analyzeWithOpenAI({
     ],
   };
 
+  const responseText = await postOpenAIJson(endpoint, apiKey, requestBody, timeoutMs, 'OpenAI chat completions image analysis');
+  const data = parseOpenAIChatCompletionResponse(responseText.body);
+  if (!responseText.ok) {
+    const errorMessage = data?.error?.message || responseText.body;
+    throw new Error(`OpenAI chat completions image analysis API error: ${responseText.status} ${responseText.statusText} - ${errorMessage}${formatPreviousOpenAIError(previousError)}`);
+  }
+
+  const text = extractOpenAIChatCompletionText(data);
+  if (!text) {
+    throw new Error(`OpenAI chat completions image analysis response did not include text${formatPreviousOpenAIError(previousError)}`);
+  }
+
+  return {
+    ok: true,
+    provider: 'openai',
+    model,
+    prompt,
+    imageCount: images.length,
+    imagePaths: images.map((image) => image.path),
+    text,
+    source,
+  };
+}
+
+async function postOpenAIJson(
+  endpoint: string,
+  apiKey: string,
+  requestBody: unknown,
+  timeoutMs: number,
+  label: string,
+): Promise<{ ok: boolean; status: number; statusText: string; body: string }> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
-  let response: Response;
   try {
-    response = (await fetch(endpoint, {
+    const response = (await fetch(endpoint, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${apiKey}`,
@@ -203,38 +368,22 @@ async function analyzeWithOpenAI({
       body: JSON.stringify(requestBody),
       signal: controller.signal,
     })) as unknown as Response;
+
+    return {
+      ok: response.ok,
+      status: response.status,
+      statusText: response.statusText,
+      body: await response.text(),
+    };
   } catch (error) {
     const isAbort = error instanceof Error && error.name === 'AbortError';
     if (isAbort) {
-      throw new Error(`OpenAI image analysis request timed out after ${timeoutMs}ms`);
+      throw new Error(`${label} request timed out after ${timeoutMs}ms`);
     }
     throw error;
   } finally {
     clearTimeout(timeoutId);
   }
-
-  const responseText = await response.text();
-  const data = parseOpenAIResponse(responseText);
-  if (!response.ok) {
-    const errorMessage = data?.error?.message || responseText;
-    throw new Error(`OpenAI image analysis API error: ${response.status} ${response.statusText} - ${errorMessage}`);
-  }
-
-  const text = extractOpenAIText(data);
-  if (!text) {
-    throw new Error('OpenAI image analysis response did not include text');
-  }
-
-  return {
-    ok: true,
-    provider: 'openai',
-    model: resolvedModel,
-    prompt,
-    imageCount: images.length,
-    imagePaths: images.map((image) => image.path),
-    text,
-    source,
-  };
 }
 
 async function analyzeWithGemini({
@@ -356,11 +505,64 @@ function resolveOpenAIBaseUrl(): string {
   ).replace(/\/$/, '');
 }
 
+function buildOpenAIResponsesEndpoint(baseUrl: string): string {
+  return `${baseUrl}/responses`;
+}
+
 function buildOpenAIChatCompletionsEndpoint(baseUrl: string): string {
   if (/\/v\d+(?:\.\d+)?$/.test(baseUrl)) {
     return `${baseUrl}/chat/completions`;
   }
   return `${baseUrl}/v1/chat/completions`;
+}
+
+function parseOpenAIResponsesResponse(responseText: string): OpenAIResponsesResponse | null {
+  try {
+    return JSON.parse(responseText) as OpenAIResponsesResponse;
+  } catch {
+    return null;
+  }
+}
+
+function parseOpenAIChatCompletionResponse(responseText: string): OpenAIChatCompletionResponse | null {
+  return parseOpenAIResponse(responseText);
+}
+
+function extractOpenAIResponsesText(data: OpenAIResponsesResponse | null): string {
+  if (!data?.output?.length) {
+    return '';
+  }
+
+  const chunks: string[] = [];
+  for (const output of data.output) {
+    for (const content of output.content ?? []) {
+      if ((content.type === 'output_text' || content.type === 'text') && content.text?.trim()) {
+        chunks.push(content.text.trim());
+      }
+    }
+  }
+
+  return chunks.join('\n').trim();
+}
+
+function extractOpenAIChatCompletionText(data: OpenAIChatCompletionResponse | null): string {
+  return extractOpenAIText(data);
+}
+
+function resolveOpenAIVisionApiMode(input?: OpenAIVisionApiMode): OpenAIVisionApiMode {
+  const raw = input || process.env.OPENAI_VISION_API_MODE?.trim();
+  if (raw === 'responses' || raw === 'chat_completions' || raw === 'auto') {
+    return raw;
+  }
+  return 'responses';
+}
+
+function formatPreviousOpenAIError(error: unknown): string {
+  if (!error) {
+    return '';
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  return ` (previous responses error: ${message})`;
 }
 
 function parseOpenAIResponse(responseText: string): OpenAIChatCompletionResponse | null {

--- a/packages/engine/src/tools/generate-image.ts
+++ b/packages/engine/src/tools/generate-image.ts
@@ -61,7 +61,19 @@ const DEFAULT_GEMINI_BASE_URL = 'https://generativelanguage.googleapis.com/v1bet
 const DEFAULT_GEMINI_MODEL = 'gemini-2.0-flash-preview-image-generation';
 const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
 const DEFAULT_OPENAI_MODEL = 'gpt-image-2';
-const DEFAULT_TIMEOUT = 120000;
+const DEFAULT_TIMEOUT = 300000;
+
+function resolveDefaultTimeout(): number {
+  const raw = process.env.OPENAI_IMAGE_TIMEOUT_MS?.trim();
+  if (!raw) {
+    return DEFAULT_TIMEOUT;
+  }
+  const parsed = Number(raw);
+  if (Number.isFinite(parsed) && parsed > 0 && parsed <= 600_000) {
+    return parsed;
+  }
+  return DEFAULT_TIMEOUT;
+}
 
 export const GenerateImageTool: Tool<
   {
@@ -109,7 +121,7 @@ export const GenerateImageTool: Tool<
     timeout: z
       .number()
       .optional()
-      .describe('Request timeout in milliseconds. Defaults to 120000 (2 minutes).'),
+      .describe('Request timeout in milliseconds. Defaults to OPENAI_IMAGE_TIMEOUT_MS or 300000 (5 minutes).'),
     size: z
       .string()
       .optional()
@@ -127,12 +139,13 @@ export const GenerateImageTool: Tool<
       .optional()
       .describe('OpenAI/GPT image API mode. "responses" uses synchronous {baseUrl}/responses image_generation, "responses_stream" uses streaming {baseUrl}/responses image_generation, "images" uses {baseUrl}/images/generations, and "auto" falls back to responses if images fails. Defaults to OPENAI_IMAGE_API_MODE or responses.'),
   }),
-  execute: async ({ prompt, provider, model, outputPath, includeBase64 = false, timeout = DEFAULT_TIMEOUT, size, quality, outputFormat, imageApiMode }) => {
+  execute: async ({ prompt, provider, model, outputPath, includeBase64 = false, timeout, size, quality, outputFormat, imageApiMode }) => {
     if (!prompt.trim()) {
       throw new Error('prompt is required');
     }
 
-    if (timeout <= 0 || timeout > 600000) {
+    const resolvedTimeout = timeout ?? resolveDefaultTimeout();
+    if (resolvedTimeout <= 0 || resolvedTimeout > 600000) {
       throw new Error('timeout must be between 1 and 600000 milliseconds');
     }
 
@@ -144,7 +157,7 @@ export const GenerateImageTool: Tool<
         model,
         outputPath,
         includeBase64,
-        timeout,
+        timeout: resolvedTimeout,
         size,
         quality,
         outputFormat,
@@ -157,7 +170,7 @@ export const GenerateImageTool: Tool<
       model,
       outputPath,
       includeBase64,
-      timeout,
+      timeout: resolvedTimeout,
     });
   },
 };

--- a/packages/engine/src/tools/generate-image.ts
+++ b/packages/engine/src/tools/generate-image.ts
@@ -47,7 +47,7 @@ interface GenerateRequestTarget {
 
 type ImageProvider = 'gemini' | 'openai';
 type OutputFormat = 'png' | 'jpeg' | 'webp';
-type OpenAIImageApiMode = 'images' | 'responses_stream' | 'auto';
+type OpenAIImageApiMode = 'images' | 'responses' | 'responses_stream' | 'auto';
 
 interface OpenAIResponsesImageCandidate {
   base64?: string;
@@ -89,7 +89,7 @@ export const GenerateImageTool: Tool<
 > = {
   name: 'generate_image',
   description:
-    'Generate an image with GPT/OpenAI by default and save it to local disk. Uses OPENAI_API_KEY plus OPENAI_BASE_URL/OPENAI_API_BASE_URL/OPENAI_API_URL. Defaults to OPENAI_IMAGE_MODEL or the latest GPT image model gpt-image-2. For OpenAI-compatible providers, image API mode defaults to responses streaming at {baseUrl}/responses. Other providers are available only when explicitly requested.',
+    'Generate an image with GPT/OpenAI by default and save it to local disk. Uses OPENAI_API_KEY plus OPENAI_BASE_URL/OPENAI_API_BASE_URL/OPENAI_API_URL. Defaults to OPENAI_IMAGE_MODEL or the latest GPT image model gpt-image-2. For OpenAI-compatible providers, image API mode defaults to synchronous Responses image generation at {baseUrl}/responses. Other providers are available only when explicitly requested.',
   defer_loading: true,
   inputSchema: z.object({
     prompt: z.string().describe('The prompts for image generation need to describe in detail the content, style, and composition of the image you want to generate.'),
@@ -123,9 +123,9 @@ export const GenerateImageTool: Tool<
       .optional()
       .describe('OpenAI/GPT output format. Only sent for OpenAI-compatible requests.'),
     imageApiMode: z
-      .enum(['images', 'responses_stream', 'auto'])
+      .enum(['images', 'responses', 'responses_stream', 'auto'])
       .optional()
-      .describe('OpenAI/GPT image API mode. "images" uses {baseUrl}/images/generations, "responses_stream" uses {baseUrl}/responses with image_generation streaming, and "auto" falls back to responses_stream if images fails. Defaults to OPENAI_IMAGE_API_MODE or responses_stream.'),
+      .describe('OpenAI/GPT image API mode. "responses" uses synchronous {baseUrl}/responses image_generation, "responses_stream" uses streaming {baseUrl}/responses image_generation, "images" uses {baseUrl}/images/generations, and "auto" falls back to responses if images fails. Defaults to OPENAI_IMAGE_API_MODE or responses.'),
   }),
   execute: async ({ prompt, provider, model, outputPath, includeBase64 = false, timeout = DEFAULT_TIMEOUT, size, quality, outputFormat, imageApiMode }) => {
     if (!prompt.trim()) {
@@ -302,6 +302,13 @@ async function generateOpenAIImage({
     baseUrl,
   };
 
+  if (mode === 'responses') {
+    return generateOpenAIResponsesImage({
+      ...options,
+      model: responsesModel,
+    });
+  }
+
   if (mode === 'responses_stream') {
     return generateOpenAIResponsesStreamImage({
       ...options,
@@ -316,7 +323,7 @@ async function generateOpenAIImage({
         model: imageModel,
       });
     } catch (error) {
-      return generateOpenAIResponsesStreamImage({
+      return generateOpenAIResponsesImage({
         ...options,
         model: responsesModel,
         previousError: error,
@@ -426,6 +433,93 @@ async function generateOpenAIImagesApiImage({
     outputPath,
     includeBase64,
   });
+}
+
+async function generateOpenAIResponsesImage({
+  prompt,
+  model,
+  outputPath,
+  includeBase64,
+  timeout,
+  size,
+  quality,
+  outputFormat,
+  apiKey,
+  baseUrl,
+  previousError,
+}: {
+  prompt: string;
+  model: string;
+  outputPath?: string;
+  includeBase64: boolean;
+  timeout: number;
+  size?: string;
+  quality?: string;
+  outputFormat?: OutputFormat;
+  apiKey: string;
+  baseUrl: string;
+  previousError?: unknown;
+}): Promise<{
+  provider: ImageProvider;
+  model: string;
+  text: string;
+  mimeType: string;
+  outputPath: string;
+  bytes: number;
+  base64?: string;
+}> {
+  const endpoint = buildOpenAIResponsesEndpoint(baseUrl);
+  const requestBody: Record<string, unknown> = {
+    model,
+    input: prompt,
+    tools: [buildResponsesImageGenerationTool({ size, quality, outputFormat })],
+    tool_choice: { type: 'image_generation' },
+    stream: false,
+  };
+
+  const abortController = new AbortController();
+  const timeoutId = setTimeout(() => abortController.abort(), timeout);
+
+  try {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(requestBody),
+      signal: abortController.signal,
+    });
+
+    const responseText = await response.text();
+    const data = parseJson(responseText);
+    if (!response.ok) {
+      throw new Error(`OpenAI responses image API error: ${response.status} ${response.statusText} - ${extractErrorMessage(data) || responseText}${formatPreviousError(previousError)}`);
+    }
+
+    const imageResult = findImageGenerationResult(data);
+    if (!imageResult?.result) {
+      throw new Error(`OpenAI responses image response did not include image data${formatPreviousError(previousError)}`);
+    }
+
+    return saveImageResult({
+      provider: 'openai',
+      model,
+      text: imageResult.revisedPrompt || findResponsesOutputText(data),
+      base64: imageResult.result,
+      mimeType: outputFormatToMimeType(imageResult.outputFormat || outputFormat),
+      outputPath,
+      includeBase64,
+    });
+  } catch (error) {
+    const isAbort = error instanceof Error && error.name === 'AbortError';
+    if (isAbort) {
+      throw new Error(`OpenAI responses image request timed out after ${timeout}ms${formatPreviousError(previousError)}`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }
 
 async function generateOpenAIResponsesStreamImage({
@@ -541,10 +635,10 @@ function resolveProvider(provider: ImageProvider | 'gpt' | undefined, model: str
 function resolveOpenAIImageApiMode(mode: OpenAIImageApiMode | undefined): OpenAIImageApiMode {
   const fromEnv = process.env.OPENAI_IMAGE_API_MODE?.trim().toLowerCase();
   const value = mode || fromEnv;
-  if (value === 'responses_stream' || value === 'images' || value === 'auto') {
+  if (value === 'responses' || value === 'responses_stream' || value === 'images' || value === 'auto') {
     return value;
   }
-  return 'responses_stream';
+  return 'responses';
 }
 
 function isOpenAIImageModel(model: string): boolean {
@@ -581,6 +675,56 @@ function parseOpenAIImagesResponse(responseText: string): OpenAIImagesResponse |
     return JSON.parse(responseText) as OpenAIImagesResponse;
   } catch {
     return null;
+  }
+}
+
+function parseJson(responseText: string): unknown {
+  try {
+    return JSON.parse(responseText);
+  } catch {
+    return null;
+  }
+}
+
+function extractErrorMessage(value: unknown): string {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return '';
+  }
+
+  const error = (value as Record<string, unknown>).error;
+  if (!error || typeof error !== 'object' || Array.isArray(error)) {
+    return '';
+  }
+
+  const message = (error as Record<string, unknown>).message;
+  return typeof message === 'string' ? message : '';
+}
+
+function findResponsesOutputText(value: unknown): string {
+  const chunks: string[] = [];
+  collectResponsesOutputText(value, chunks);
+  return chunks.join('\n').trim();
+}
+
+function collectResponsesOutputText(value: unknown, chunks: string[]): void {
+  if (!value || typeof value !== 'object') {
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectResponsesOutputText(item, chunks);
+    }
+    return;
+  }
+
+  const record = value as Record<string, unknown>;
+  if ((record.type === 'output_text' || record.type === 'text') && typeof record.text === 'string' && record.text.trim()) {
+    chunks.push(record.text.trim());
+  }
+
+  for (const child of Object.values(record)) {
+    collectResponsesOutputText(child, chunks);
   }
 }
 

--- a/packages/engine/src/tools/generate-image.ts
+++ b/packages/engine/src/tools/generate-image.ts
@@ -47,6 +47,15 @@ interface GenerateRequestTarget {
 
 type ImageProvider = 'gemini' | 'openai';
 type OutputFormat = 'png' | 'jpeg' | 'webp';
+type OpenAIImageApiMode = 'images' | 'responses_stream' | 'auto';
+
+interface OpenAIResponsesImageCandidate {
+  base64?: string;
+  resultBase64?: string;
+  revisedPrompt?: string;
+  outputFormat?: OutputFormat;
+  textChunks: string[];
+}
 
 const DEFAULT_GEMINI_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta';
 const DEFAULT_GEMINI_MODEL = 'gemini-2.0-flash-preview-image-generation';
@@ -66,6 +75,7 @@ export const GenerateImageTool: Tool<
     size?: string;
     quality?: string;
     outputFormat?: OutputFormat;
+    imageApiMode?: OpenAIImageApiMode;
   },
   {
     provider: ImageProvider;
@@ -79,7 +89,7 @@ export const GenerateImageTool: Tool<
 > = {
   name: 'generate_image',
   description:
-    'Generate an image with GPT/OpenAI by default and save it to local disk. Uses OPENAI_API_KEY plus OPENAI_BASE_URL/OPENAI_API_BASE_URL/OPENAI_API_URL. Defaults to OPENAI_IMAGE_MODEL or the latest GPT image model gpt-image-2. Other providers are available only when explicitly requested.',
+    'Generate an image with GPT/OpenAI by default and save it to local disk. Uses OPENAI_API_KEY plus OPENAI_BASE_URL/OPENAI_API_BASE_URL/OPENAI_API_URL. Defaults to OPENAI_IMAGE_MODEL or the latest GPT image model gpt-image-2. For OpenAI-compatible providers, image API mode defaults to responses streaming at {baseUrl}/responses. Other providers are available only when explicitly requested.',
   defer_loading: true,
   inputSchema: z.object({
     prompt: z.string().describe('The prompts for image generation need to describe in detail the content, style, and composition of the image you want to generate.'),
@@ -112,8 +122,12 @@ export const GenerateImageTool: Tool<
       .enum(['png', 'jpeg', 'webp'])
       .optional()
       .describe('OpenAI/GPT output format. Only sent for OpenAI-compatible requests.'),
+    imageApiMode: z
+      .enum(['images', 'responses_stream', 'auto'])
+      .optional()
+      .describe('OpenAI/GPT image API mode. "images" uses {baseUrl}/images/generations, "responses_stream" uses {baseUrl}/responses with image_generation streaming, and "auto" falls back to responses_stream if images fails. Defaults to OPENAI_IMAGE_API_MODE or responses_stream.'),
   }),
-  execute: async ({ prompt, provider, model, outputPath, includeBase64 = false, timeout = DEFAULT_TIMEOUT, size, quality, outputFormat }) => {
+  execute: async ({ prompt, provider, model, outputPath, includeBase64 = false, timeout = DEFAULT_TIMEOUT, size, quality, outputFormat, imageApiMode }) => {
     if (!prompt.trim()) {
       throw new Error('prompt is required');
     }
@@ -134,6 +148,7 @@ export const GenerateImageTool: Tool<
         size,
         quality,
         outputFormat,
+        imageApiMode,
       });
     }
 
@@ -244,6 +259,7 @@ async function generateOpenAIImage({
   size,
   quality,
   outputFormat,
+  imageApiMode,
 }: {
   prompt: string;
   model?: string;
@@ -253,6 +269,7 @@ async function generateOpenAIImage({
   size?: string;
   quality?: string;
   outputFormat?: OutputFormat;
+  imageApiMode?: OpenAIImageApiMode;
 }): Promise<{
   provider: ImageProvider;
   model: string;
@@ -267,12 +284,87 @@ async function generateOpenAIImage({
     throw new Error('OPENAI_API_KEY environment variable is not set');
   }
 
-  const resolvedModel = model?.trim() || process.env.OPENAI_IMAGE_MODEL?.trim() || DEFAULT_OPENAI_MODEL;
+  const requestedModel = model?.trim();
+  const imageModel = requestedModel || process.env.OPENAI_IMAGE_MODEL?.trim() || DEFAULT_OPENAI_MODEL;
+  const responsesModel = requestedModel || process.env.OPENAI_IMAGE_RESPONSES_MODEL?.trim() || process.env.OPENAI_RESPONSES_MODEL?.trim() || imageModel;
   const baseUrl = resolveOpenAIBaseUrl();
+  const mode = resolveOpenAIImageApiMode(imageApiMode);
+
+  const options = {
+    prompt,
+    outputPath,
+    includeBase64,
+    timeout,
+    size,
+    quality,
+    outputFormat,
+    apiKey,
+    baseUrl,
+  };
+
+  if (mode === 'responses_stream') {
+    return generateOpenAIResponsesStreamImage({
+      ...options,
+      model: responsesModel,
+    });
+  }
+
+  if (mode === 'auto') {
+    try {
+      return await generateOpenAIImagesApiImage({
+        ...options,
+        model: imageModel,
+      });
+    } catch (error) {
+      return generateOpenAIResponsesStreamImage({
+        ...options,
+        model: responsesModel,
+        previousError: error,
+      });
+    }
+  }
+
+  return generateOpenAIImagesApiImage({
+    ...options,
+    model: imageModel,
+  });
+}
+
+async function generateOpenAIImagesApiImage({
+  prompt,
+  model,
+  outputPath,
+  includeBase64,
+  timeout,
+  size,
+  quality,
+  outputFormat,
+  apiKey,
+  baseUrl,
+}: {
+  prompt: string;
+  model: string;
+  outputPath?: string;
+  includeBase64: boolean;
+  timeout: number;
+  size?: string;
+  quality?: string;
+  outputFormat?: OutputFormat;
+  apiKey: string;
+  baseUrl: string;
+}): Promise<{
+  provider: ImageProvider;
+  model: string;
+  text: string;
+  mimeType: string;
+  outputPath: string;
+  bytes: number;
+  base64?: string;
+}> {
   const endpoint = buildOpenAIImagesEndpoint(baseUrl);
 
   const requestBody: Record<string, unknown> = {
-    model: resolvedModel,
+    model,
     prompt,
   };
 
@@ -327,13 +419,102 @@ async function generateOpenAIImage({
   const text = data?.data?.find((item) => item.revised_prompt?.trim())?.revised_prompt?.trim() || '';
   return saveImageResult({
     provider: 'openai',
-    model: resolvedModel,
+    model,
     text,
     base64: image.base64,
     mimeType: image.mimeType,
     outputPath,
     includeBase64,
   });
+}
+
+async function generateOpenAIResponsesStreamImage({
+  prompt,
+  model,
+  outputPath,
+  includeBase64,
+  timeout,
+  size,
+  quality,
+  outputFormat,
+  apiKey,
+  baseUrl,
+  previousError,
+}: {
+  prompt: string;
+  model: string;
+  outputPath?: string;
+  includeBase64: boolean;
+  timeout: number;
+  size?: string;
+  quality?: string;
+  outputFormat?: OutputFormat;
+  apiKey: string;
+  baseUrl: string;
+  previousError?: unknown;
+}): Promise<{
+  provider: ImageProvider;
+  model: string;
+  text: string;
+  mimeType: string;
+  outputPath: string;
+  bytes: number;
+  base64?: string;
+}> {
+  const endpoint = buildOpenAIResponsesEndpoint(baseUrl);
+  const requestBody: Record<string, unknown> = {
+    model,
+    input: prompt,
+    tools: [buildResponsesImageGenerationTool({ size, quality, outputFormat })],
+    tool_choice: { type: 'image_generation' },
+    stream: true,
+  };
+
+  const abortController = new AbortController();
+  const timeoutId = setTimeout(() => abortController.abort(), timeout);
+
+  let response: Response;
+  try {
+    response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+        Accept: 'text/event-stream',
+      },
+      body: JSON.stringify(requestBody),
+      signal: abortController.signal,
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`OpenAI responses image stream API error: ${response.status} ${response.statusText} - ${errorBody}${formatPreviousError(previousError)}`);
+    }
+
+    const candidate = await parseOpenAIResponsesImageStream(response.body);
+    const base64 = candidate.resultBase64 || candidate.base64;
+    if (!base64) {
+      throw new Error(`OpenAI responses image stream did not include image data${formatPreviousError(previousError)}`);
+    }
+
+    return saveImageResult({
+      provider: 'openai',
+      model,
+      text: candidate.revisedPrompt || candidate.textChunks.join('').trim(),
+      base64,
+      mimeType: outputFormatToMimeType(candidate.outputFormat || outputFormat),
+      outputPath,
+      includeBase64,
+    });
+  } catch (error) {
+    const isAbort = error instanceof Error && error.name === 'AbortError';
+    if (isAbort) {
+      throw new Error(`OpenAI responses image stream request timed out after ${timeout}ms${formatPreviousError(previousError)}`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }
 
 function resolveProvider(provider: ImageProvider | 'gpt' | undefined, model: string | undefined): ImageProvider {
@@ -355,6 +536,15 @@ function resolveProvider(provider: ImageProvider | 'gpt' | undefined, model: str
   }
 
   return 'openai';
+}
+
+function resolveOpenAIImageApiMode(mode: OpenAIImageApiMode | undefined): OpenAIImageApiMode {
+  const fromEnv = process.env.OPENAI_IMAGE_API_MODE?.trim().toLowerCase();
+  const value = mode || fromEnv;
+  if (value === 'responses_stream' || value === 'images' || value === 'auto') {
+    return value;
+  }
+  return 'responses_stream';
 }
 
 function isOpenAIImageModel(model: string): boolean {
@@ -382,12 +572,237 @@ function buildOpenAIImagesEndpoint(baseUrl: string): string {
   return `${baseUrl}/v1/images/generations`;
 }
 
+function buildOpenAIResponsesEndpoint(baseUrl: string): string {
+  return `${baseUrl}/responses`;
+}
+
 function parseOpenAIImagesResponse(responseText: string): OpenAIImagesResponse | null {
   try {
     return JSON.parse(responseText) as OpenAIImagesResponse;
   } catch {
     return null;
   }
+}
+
+function buildResponsesImageGenerationTool({
+  size,
+  quality,
+  outputFormat,
+}: {
+  size?: string;
+  quality?: string;
+  outputFormat?: OutputFormat;
+}): Record<string, unknown> {
+  const tool: Record<string, unknown> = { type: 'image_generation' };
+  if (size?.trim()) {
+    tool.size = size.trim();
+  }
+  if (quality?.trim()) {
+    tool.quality = quality.trim();
+  }
+  if (outputFormat) {
+    tool.output_format = outputFormat;
+  }
+  return tool;
+}
+
+async function parseOpenAIResponsesImageStream(body: Response['body']): Promise<OpenAIResponsesImageCandidate> {
+  if (!body) {
+    throw new Error('OpenAI responses image stream response did not include a body');
+  }
+
+  const candidate: OpenAIResponsesImageCandidate = { textChunks: [] };
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  for await (const chunk of body as AsyncIterable<Uint8Array>) {
+    buffer += decoder.decode(chunk, { stream: true });
+    buffer = consumeOpenAIResponsesSseBuffer(buffer, candidate);
+  }
+
+  buffer += decoder.decode();
+  consumeOpenAIResponsesSseBuffer(buffer, candidate, true);
+  return candidate;
+}
+
+function consumeOpenAIResponsesSseBuffer(
+  buffer: string,
+  candidate: OpenAIResponsesImageCandidate,
+  consumeAll = false,
+): string {
+  let separatorIndex = findSseEventSeparator(buffer);
+  while (separatorIndex !== -1) {
+    const rawEvent = buffer.slice(0, separatorIndex);
+    buffer = buffer.slice(buffer[separatorIndex] === '\r' ? separatorIndex + 4 : separatorIndex + 2);
+    consumeOpenAIResponsesSseEvent(rawEvent, candidate);
+    separatorIndex = findSseEventSeparator(buffer);
+  }
+
+  if (consumeAll && buffer.trim()) {
+    consumeOpenAIResponsesSseEvent(buffer, candidate);
+    return '';
+  }
+
+  return buffer;
+}
+
+function findSseEventSeparator(buffer: string): number {
+  const crlf = buffer.indexOf('\r\n\r\n');
+  const lf = buffer.indexOf('\n\n');
+  if (crlf === -1) {
+    return lf;
+  }
+  if (lf === -1) {
+    return crlf;
+  }
+  return Math.min(crlf, lf);
+}
+
+function consumeOpenAIResponsesSseEvent(rawEvent: string, candidate: OpenAIResponsesImageCandidate): void {
+  const dataLines = rawEvent
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith('data:'))
+    .map((line) => line.slice(5).trimStart());
+
+  if (dataLines.length === 0) {
+    return;
+  }
+
+  const payload = dataLines.join('\n').trim();
+  if (!payload || payload === '[DONE]') {
+    return;
+  }
+
+  let event: unknown;
+  try {
+    event = JSON.parse(payload);
+  } catch {
+    return;
+  }
+
+  updateOpenAIResponsesImageCandidate(event, candidate);
+}
+
+function updateOpenAIResponsesImageCandidate(event: unknown, candidate: OpenAIResponsesImageCandidate): void {
+  const partial = findStringByKey(event, 'partial_image_b64');
+  if (partial) {
+    candidate.base64 = partial;
+  }
+
+  const imageResult = findImageGenerationResult(event);
+  if (imageResult?.result) {
+    candidate.resultBase64 = imageResult.result;
+  }
+  if (imageResult?.revisedPrompt) {
+    candidate.revisedPrompt = imageResult.revisedPrompt;
+  }
+  if (imageResult?.outputFormat) {
+    candidate.outputFormat = imageResult.outputFormat;
+  }
+
+  const partialOutputFormat = normalizeOutputFormat(findStringByKey(event, 'output_format'));
+  if (partialOutputFormat) {
+    candidate.outputFormat = partialOutputFormat;
+  }
+
+  const textDelta = findTextDelta(event);
+  if (textDelta) {
+    candidate.textChunks.push(textDelta);
+  }
+}
+
+function findImageGenerationResult(value: unknown): { result: string; revisedPrompt?: string; outputFormat?: OutputFormat } | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = findImageGenerationResult(item);
+      if (found) {
+        return found;
+      }
+    }
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (record.type === 'image_generation_call' && typeof record.result === 'string') {
+    return {
+      result: record.result,
+      revisedPrompt: typeof record.revised_prompt === 'string' ? record.revised_prompt : undefined,
+      outputFormat: normalizeOutputFormat(record.output_format),
+    };
+  }
+
+  for (const child of Object.values(record)) {
+    const found = findImageGenerationResult(child);
+    if (found) {
+      return found;
+    }
+  }
+
+  return null;
+}
+
+function findStringByKey(value: unknown, key: string): string | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = findStringByKey(item, key);
+      if (found) {
+        return found;
+      }
+    }
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (typeof record[key] === 'string') {
+    return record[key];
+  }
+
+  for (const child of Object.values(record)) {
+    const found = findStringByKey(child, key);
+    if (found) {
+      return found;
+    }
+  }
+
+  return undefined;
+}
+
+function findTextDelta(event: unknown): string | undefined {
+  if (!event || typeof event !== 'object' || Array.isArray(event)) {
+    return undefined;
+  }
+
+  const record = event as Record<string, unknown>;
+  if (record.type === 'response.output_text.delta' && typeof record.delta === 'string') {
+    return record.delta;
+  }
+
+  return undefined;
+}
+
+function normalizeOutputFormat(value: unknown): OutputFormat | undefined {
+  if (value === 'png' || value === 'jpeg' || value === 'webp') {
+    return value;
+  }
+  return undefined;
+}
+
+function formatPreviousError(error: unknown): string {
+  if (!error) {
+    return '';
+  }
+  if (error instanceof Error) {
+    return ` (after /v1/images/generations failed: ${error.message})`;
+  }
+  return ' (after /v1/images/generations failed)';
 }
 
 async function extractOpenAIImage(


### PR DESCRIPTION
Update OpenAI-compatible image tooling to use the Responses endpoint by default.

- Route `analyze_image` through `{OPENAI_API_URL}/responses` with `input_image` payloads and keep chat-completions as an explicit/auto fallback mode
- Route `generate_image` through streaming Responses image generation by default, while preserving the legacy images API mode
- Default OpenAI vision model to `gpt-5.4` and add focused tests that assert `http://localhost:18080/responses` is used

Validation:
- `pnpm --filter @pulse-coder/remote-server test -- src/core/tools/analyze-image.test.ts`
- `pnpm --filter pulse-coder-engine exec tsc --noEmit --skipLibCheck --target ES2022 --module commonjs --moduleResolution node --types node --esModuleInterop src/tools/generate-image.ts`
