### PR TITLE
fix(image-tools): bypass global proxy for loopback OpenAI endpoints

### DIFF
--- a/apps/remote-server/src/core/tools/analyze-image.ts
+++ b/apps/remote-server/src/core/tools/analyze-image.ts
@@ -1,8 +1,46 @@
 import { promises as fs } from 'fs';
-import { fetch } from 'undici';
+import { fetch, Agent } from 'undici';
 import z from 'zod';
 import type { Tool, ToolExecutionContext } from 'pulse-coder-engine';
 import type { StoredAttachment } from '../attachments.js';
+
+const localLoopbackDispatcher = new Agent({
+  keepAliveTimeout: 5_000,
+  connect: { timeout: 10_000 },
+  headersTimeout: 30_000,
+  bodyTimeout: 0,
+});
+
+function shouldBypassProxyForUrl(url: string): boolean {
+  try {
+    const u = new URL(url);
+    const host = u.hostname.toLowerCase();
+    return host === 'localhost'
+      || host === '127.0.0.1'
+      || host === '::1'
+      || host === '[::1]'
+      || host.endsWith('.local');
+  } catch {
+    return false;
+  }
+}
+
+function isAbortLikeError(error: unknown, signal?: AbortSignal): boolean {
+  if (signal?.aborted) {
+    return true;
+  }
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  if (error.name === 'AbortError') {
+    return true;
+  }
+  const cause = (error as { cause?: unknown }).cause;
+  if (cause instanceof Error && cause.name === 'AbortError') {
+    return true;
+  }
+  return false;
+}
 
 interface AnalyzeImageRequestTarget {
   endpoint: string;
@@ -367,6 +405,7 @@ async function postOpenAIJson(
       },
       body: JSON.stringify(requestBody),
       signal: controller.signal,
+      ...(shouldBypassProxyForUrl(endpoint) ? { dispatcher: localLoopbackDispatcher } : {}),
     })) as unknown as Response;
 
     return {
@@ -376,8 +415,7 @@ async function postOpenAIJson(
       body: await response.text(),
     };
   } catch (error) {
-    const isAbort = error instanceof Error && error.name === 'AbortError';
-    if (isAbort) {
+    if (isAbortLikeError(error, controller.signal)) {
       throw new Error(`${label} request timed out after ${timeoutMs}ms`);
     }
     throw error;

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -51,6 +51,7 @@
     "gray-matter": "^4.0.3",
     "yaml": "^2.8.2",
     "pulse-coder-orchestrator": "workspace:*",
+    "undici": "^6.23.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/engine/src/tools/generate-image.ts
+++ b/packages/engine/src/tools/generate-image.ts
@@ -1,8 +1,35 @@
 import { randomUUID } from 'crypto';
 import { mkdir, writeFile } from 'fs/promises';
 import { dirname, isAbsolute, join, resolve } from 'path';
+import { Agent } from 'undici';
 import z from 'zod';
 import type { Tool } from '../shared/types';
+
+// Local-only dispatcher used to bypass the global EnvHttpProxyAgent (enabled by
+// NODE_USE_ENV_PROXY=1) when the OpenAI base URL points at a loopback host.
+// Routing requests to a local mock/proxy through an HTTP/SOCKS proxy is both
+// unnecessary and unstable for large response bodies, so we explicitly opt out
+// for those targets only. Remote endpoints continue to use the global proxy.
+const localLoopbackDispatcher = new Agent({
+  keepAliveTimeout: 5_000,
+  connect: { timeout: 10_000 },
+  headersTimeout: 30_000,
+  bodyTimeout: 0,
+});
+
+function shouldBypassProxyForUrl(url: string): boolean {
+  try {
+    const u = new URL(url);
+    const host = u.hostname.toLowerCase();
+    return host === 'localhost'
+      || host === '127.0.0.1'
+      || host === '::1'
+      || host === '[::1]'
+      || host.endsWith('.local');
+  } catch {
+    return false;
+  }
+}
 
 interface GeminiGenerateResponse {
   candidates?: Array<{
@@ -413,7 +440,8 @@ async function generateOpenAIImagesApiImage({
       },
       body: JSON.stringify(requestBody),
       signal: abortController.signal,
-    });
+      ...(shouldBypassProxyForUrl(endpoint) ? { dispatcher: localLoopbackDispatcher } : {}),
+    } as RequestInit);
   } catch (error) {
     const isAbort = error instanceof Error && error.name === 'AbortError';
     if (isAbort) {
@@ -502,7 +530,8 @@ async function generateOpenAIResponsesImage({
       },
       body: JSON.stringify(requestBody),
       signal: abortController.signal,
-    });
+      ...(shouldBypassProxyForUrl(endpoint) ? { dispatcher: localLoopbackDispatcher } : {}),
+    } as RequestInit);
 
     const responseText = await response.text();
     const data = parseJson(responseText);
@@ -591,7 +620,8 @@ async function generateOpenAIResponsesStreamImage({
       },
       body: JSON.stringify(requestBody),
       signal: abortController.signal,
-    });
+      ...(shouldBypassProxyForUrl(endpoint) ? { dispatcher: localLoopbackDispatcher } : {}),
+    } as RequestInit);
 
     if (!response.ok) {
       const errorBody = await response.text();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,6 +339,9 @@ importers:
       pulse-coder-orchestrator:
         specifier: workspace:*
         version: link:../orchestrator
+      undici:
+        specifier: ^6.23.0
+        version: 6.23.0
       yaml:
         specifier: ^2.8.2
         version: 2.8.2


### PR DESCRIPTION
Scope a direct undici dispatcher to the image generate/analyze tools so loopback OpenAI endpoints stop being routed through the global proxy.

When `NODE_USE_ENV_PROXY=1` is set process-wide (required by other tooling like Codex CLI), undici installs `EnvHttpProxyAgent` as the global dispatcher. Its `NO_PROXY` matching is inconsistent for `localhost` vs `127.0.0.1`, and routing large image responses (~3MB) through HTTP/SOCKS proxies is unstable, causing fetch to hang until timeout (observed: 5min hang on complex prompts via remote-server, while `curl` direct succeeded in ~62s).

- packages/engine: add `undici` dep; bypass proxy on the three OpenAI fetch sites in `generate-image.ts` (image API, responses sync, responses stream) when target host is loopback
- apps/remote-server: same loopback bypass in `analyze-image.ts`; normalize abort-like error detection so `AbortError` surfaces a clean timeout message instead of a generic "fetch failed"
- Bypass only triggers for `localhost` / `127.0.0.1` / `::1` / `*.local` hosts; remote endpoints continue to use the global proxy
- `NODE_USE_ENV_PROXY` is untouched, so other tools' proxy behavior is unaffected

Verified: engine + remote-server `pnpm build` both pass.