### PR TITLE
feat(discord): lightweight chat UX — reactions, context menu, progress stats

### DIFF
--- a/apps/remote-server/src/adapters/discord/adapter.ts
+++ b/apps/remote-server/src/adapters/discord/adapter.ts
@@ -5,7 +5,7 @@ import type { HonoRequest, Context as HonoContext } from 'hono';
 import type { PlatformAdapter, IncomingMessage, StreamHandle } from '../../core/types.js';
 import type { ClarificationRequest } from '../../core/types.js';
 import { clarificationQueue } from '../../core/clarification-queue.js';
-import { getActiveStreamId } from '../../core/active-run-store.js';
+import { getActiveStreamId, registerCancelToken } from '../../core/active-run-store.js';
 import { extractGeneratedImageResult } from '../feishu/image-result.js';
 import { DiscordClient } from './client.js';
 import { buildDiscordMemoryKey, buildDiscordPlatformKey, isDiscordThreadChannelType } from './platform-key.js';
@@ -21,7 +21,13 @@ interface DiscordInteraction {
   user?: { id?: string };
   data?: {
     name?: string;
+    // 1=CHAT_INPUT, 2=USER, 3=MESSAGE
+    type?: number;
+    target_id?: string;
     options?: DiscordCommandOption[];
+    resolved?: {
+      messages?: Record<string, { content?: string; author?: { username?: string } }>;
+    };
   };
 }
 
@@ -60,7 +66,16 @@ type DiscordStreamIo = {
     mimeType?: string,
     content?: string,
   ) => Promise<void>;
+  setStatusReaction?: (emoji: StatusReaction) => Promise<void>;
 };
+
+type StatusReaction = '👀' | '⚙️' | '✅' | '⚠️' | '⏸️';
+
+export const DISCORD_CANCEL_REACTION = '❌';
+
+export function buildDiscordCancelToken(channelId: string, messageId: string): string {
+  return `discord:${channelId}:${messageId}`;
+}
 
 const DISCORD_ACK_EPHEMERAL_FLAG = 1 << 6;
 const DISCORD_PROGRESS_UPDATE_INTERVAL_MS = 5000;
@@ -198,6 +213,10 @@ export class DiscordAdapter implements PlatformAdapter {
 
     this.streamMetaByStreamId.set(streamId, streamMeta);
     this.streamMetaByPlatformKey.set(platformKey, streamMeta);
+
+    if (replyToMessageId) {
+      registerCancelToken(buildDiscordCancelToken(channelId, replyToMessageId), platformKey);
+    }
   }
 
   async tryHandleChannelClarification(
@@ -261,6 +280,25 @@ export class DiscordAdapter implements PlatformAdapter {
       replyToMessageId: meta.replyToMessageId,
     });
 
+    let currentReaction: StatusReaction | null = null;
+    const setStatusReaction = async (emoji: StatusReaction): Promise<void> => {
+      if (!meta.replyToMessageId || currentReaction === emoji) {
+        return;
+      }
+      const previous = currentReaction;
+      currentReaction = emoji;
+      try {
+        await this.client.addReaction(meta.channelId, meta.replyToMessageId, emoji);
+      } catch (err) {
+        console.warn('[discord] Failed to add status reaction:', err);
+      }
+      if (previous && previous !== emoji) {
+        this.client
+          .removeOwnReaction(meta.channelId, meta.replyToMessageId, previous)
+          .catch((err) => console.warn('[discord] Failed to remove status reaction:', err));
+      }
+    };
+
     return this.createStreamingHandle({
       updatePrimary: (content) => this.client.editChannelMessage(meta.channelId, initial.id, content, {
         assumeThread: meta.isThread,
@@ -276,6 +314,7 @@ export class DiscordAdapter implements PlatformAdapter {
         content,
         { assumeThread: meta.isThread },
       ),
+      setStatusReaction,
     });
   }
 
@@ -288,6 +327,8 @@ export class DiscordAdapter implements PlatformAdapter {
     let finalizing = false;
     let progressFrame = 0;
     let primaryWriteChain: Promise<void> = Promise.resolve();
+    const progressStartedAt = Date.now();
+    let toolCallCount = 0;
 
     const enqueuePrimaryWrite = (
       write: () => Promise<void>,
@@ -305,7 +346,10 @@ export class DiscordAdapter implements PlatformAdapter {
         ? (latestToolHint || 'Working on it...')
         : (latestToolHint ? `${latestToolHint}\n\n${accumulatedText}` : accumulatedText);
 
-      const rendered = renderDiscordProgressWithFooter(body, progressFrame);
+      const rendered = renderDiscordProgressWithFooter(body, progressFrame, {
+        elapsedMs: Date.now() - progressStartedAt,
+        toolCount: toolCallCount,
+      });
       const frameCount = DISCORD_PROGRESS_DOT_MAX - DISCORD_PROGRESS_DOT_MIN + 1;
       progressFrame = (progressFrame + 1) % frameCount;
       return rendered;
@@ -380,6 +424,7 @@ export class DiscordAdapter implements PlatformAdapter {
 
     scheduleProgress();
     ensureProgressAnimation();
+    io.setStatusReaction?.('👀').catch(() => undefined);
 
     return {
       async onText(delta) {
@@ -390,6 +435,10 @@ export class DiscordAdapter implements PlatformAdapter {
 
       async onToolCall(name, input) {
         latestToolHint = formatDiscordToolHint(name, input);
+        toolCallCount += 1;
+        if (toolCallCount === 1) {
+          io.setStatusReaction?.('⚙️').catch(() => undefined);
+        }
         scheduleProgress();
         ensureProgressAnimation();
       },
@@ -422,6 +471,7 @@ export class DiscordAdapter implements PlatformAdapter {
       async onClarification(req: ClarificationRequest) {
         const question = req.context ? `${req.question}\n\nContext: ${req.context}` : req.question;
         await io.sendExtraText(`Question: ${question}`);
+        io.setStatusReaction?.('⏸️').catch(() => undefined);
       },
 
       async onDone(result) {
@@ -431,6 +481,7 @@ export class DiscordAdapter implements PlatformAdapter {
           console.error('[discord] Failed to send final response:', err);
           await io.sendExtraText(`Error: ${String(err)}`);
         });
+        io.setStatusReaction?.('✅').catch(() => undefined);
       },
 
       async onError(err) {
@@ -440,6 +491,7 @@ export class DiscordAdapter implements PlatformAdapter {
           console.error('[discord] Failed to send error response:', followErr);
           await io.sendExtraText(`Error: ${err.message}`);
         });
+        io.setStatusReaction?.('⚠️').catch(() => undefined);
       },
     };
   }
@@ -516,8 +568,22 @@ const PASSTHROUGH_SLASH_COMMANDS = new Set([
 ]);
 
 function extractInteractionText(interaction: DiscordInteraction): string {
-  const commandName = interaction.data?.name?.trim().toLowerCase() ?? '';
-  const args = collectOptionTokens(interaction.data?.options ?? []).join(' ').trim();
+  const data = interaction.data;
+  // Message context menu (Apps → "Ask Pulse")
+  if (data?.type === 3) {
+    const targetId = data.target_id?.trim();
+    const message = targetId ? data.resolved?.messages?.[targetId] : undefined;
+    const content = message?.content?.trim() ?? '';
+    if (!content) {
+      return '';
+    }
+    const author = message?.author?.username?.trim();
+    const header = author ? `Quoted message from @${author}:` : 'Quoted message:';
+    return `${header}\n${content}`;
+  }
+
+  const commandName = data?.name?.trim().toLowerCase() ?? '';
+  const args = collectOptionTokens(data?.options ?? []).join(' ').trim();
 
   if (!commandName) {
     return '';
@@ -673,8 +739,17 @@ function trimDiscordToolInput(value: string): string {
   return `${singleLine.slice(0, maxLength - 3)}...`;
 }
 
-function renderDiscordProgressWithFooter(content: string, frame: number): string {
-  const footer = buildDiscordProgressFooter(frame);
+interface ProgressFooterStats {
+  elapsedMs: number;
+  toolCount: number;
+}
+
+function renderDiscordProgressWithFooter(
+  content: string,
+  frame: number,
+  stats: ProgressFooterStats,
+): string {
+  const footer = buildDiscordProgressFooter(frame, stats);
   const normalizedContent = content.trim() || 'Working on it...';
   const separator = '\n\n';
   const reservedLength = separator.length + footer.length;
@@ -691,10 +766,23 @@ function renderDiscordProgressWithFooter(content: string, frame: number): string
   return `${clippedContent}${separator}${footer}`;
 }
 
-function buildDiscordProgressFooter(frame: number): string {
+function buildDiscordProgressFooter(frame: number, stats: ProgressFooterStats): string {
   const dotRange = DISCORD_PROGRESS_DOT_MAX - DISCORD_PROGRESS_DOT_MIN + 1;
   const dotCount = DISCORD_PROGRESS_DOT_MIN + (Math.abs(frame) % dotRange);
-  return `${DISCORD_PROGRESS_FOOTER_BASE}${'.'.repeat(dotCount)}`;
+  const dots = '.'.repeat(dotCount);
+  // Discord small text ("-#") on its own line keeps the stats visually quiet.
+  const stat = `-# ${formatElapsed(stats.elapsedMs)} · ${stats.toolCount} tool${stats.toolCount === 1 ? '' : 's'} · react ❌ to cancel`;
+  return `${DISCORD_PROGRESS_FOOTER_BASE}${dots}\n${stat}`;
+}
+
+function formatElapsed(elapsedMs: number): string {
+  const seconds = Math.max(0, Math.floor(elapsedMs / 1000));
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  return remainder === 0 ? `${minutes}m` : `${minutes}m${remainder}s`;
 }
 
 function splitDiscordText(text: string): string[] {

--- a/apps/remote-server/src/adapters/discord/application-commands.ts
+++ b/apps/remote-server/src/adapters/discord/application-commands.ts
@@ -35,6 +35,12 @@ const WORKTREE_COMMAND: DiscordApplicationCommandCreate = {
   ],
 };
 
+// Right-click message → Apps → "Ask Pulse" sends the message content as a prompt.
+const ASK_PULSE_MESSAGE_COMMAND: DiscordApplicationCommandCreate = {
+  name: 'Ask Pulse',
+  type: 3,
+};
+
 export async function registerDiscordApplicationCommands(): Promise<void> {
   if (!parseEnabledFlag(process.env.DISCORD_COMMAND_REGISTER_ENABLED, true)) {
     console.log('[discord] Skip app command registration: DISCORD_COMMAND_REGISTER_ENABLED=false');
@@ -51,7 +57,7 @@ export async function registerDiscordApplicationCommands(): Promise<void> {
   const configuredApplicationId = process.env.DISCORD_APPLICATION_ID?.trim();
   const applicationId = configuredApplicationId || await client.getApplicationId();
   const guildIds = parseGuildIds(process.env.DISCORD_COMMAND_GUILD_IDS);
-  const commands = [RESTART_COMMAND, WORKTREE_COMMAND];
+  const commands = [RESTART_COMMAND, WORKTREE_COMMAND, ASK_PULSE_MESSAGE_COMMAND];
 
   if (guildIds.length === 0) {
     for (const command of commands) {

--- a/apps/remote-server/src/adapters/discord/client.ts
+++ b/apps/remote-server/src/adapters/discord/client.ts
@@ -66,7 +66,9 @@ export interface DiscordApplicationCommandOption {
 
 export interface DiscordApplicationCommandCreate {
   name: string;
-  description: string;
+  description?: string;
+  // 1=CHAT_INPUT (default), 2=USER, 3=MESSAGE
+  type?: 1 | 2 | 3;
   options?: DiscordApplicationCommandOption[];
 }
 
@@ -367,6 +369,42 @@ export class DiscordClient {
           method: 'PATCH',
           headers: { 'content-type': 'application/json' },
           body: JSON.stringify({ content: limitDiscordContent(content) }),
+        },
+        true,
+      ),
+    );
+  }
+
+  async addReaction(channelId: string, messageId: string, emoji: string): Promise<void> {
+    this.ensureBotToken();
+    if (!channelId || !messageId || !emoji) {
+      return;
+    }
+
+    const encodedEmoji = encodeURIComponent(emoji);
+    await this.retryOnceOnTransient('add_reaction', () =>
+      this.request<void>(
+        `/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(messageId)}/reactions/${encodedEmoji}/@me`,
+        {
+          method: 'PUT',
+        },
+        true,
+      ),
+    );
+  }
+
+  async removeOwnReaction(channelId: string, messageId: string, emoji: string): Promise<void> {
+    this.ensureBotToken();
+    if (!channelId || !messageId || !emoji) {
+      return;
+    }
+
+    const encodedEmoji = encodeURIComponent(emoji);
+    await this.retryOnceOnTransient('remove_own_reaction', () =>
+      this.request<void>(
+        `/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(messageId)}/reactions/${encodedEmoji}/@me`,
+        {
+          method: 'DELETE',
         },
         true,
       ),

--- a/apps/remote-server/src/adapters/discord/gateway.ts
+++ b/apps/remote-server/src/adapters/discord/gateway.ts
@@ -1,6 +1,7 @@
 import { dispatchIncoming } from '../../core/dispatcher.js';
 import type { IncomingMessage, IncomingAttachment } from '../../core/types.js';
-import { discordAdapter } from './adapter.js';
+import { discordAdapter, DISCORD_CANCEL_REACTION, buildDiscordCancelToken } from './adapter.js';
+import { abortActiveRun, resolvePlatformKeyByCancelToken } from '../../core/active-run-store.js';
 import { DiscordClient } from './client.js';
 import { getDiscordProxyDispatcher } from './proxy.js';
 import { buildDiscordMemoryKey, buildDiscordPlatformKey, isDiscordThreadChannelType } from './platform-key.js';
@@ -57,6 +58,13 @@ interface ThreadCreatePayload {
   member?: unknown;
 }
 
+interface ReactionAddPayload {
+  user_id?: string;
+  channel_id?: string;
+  message_id?: string;
+  emoji?: { name?: string | null };
+}
+
 export interface DiscordGatewayStatus {
   enabled: boolean;
   configured: boolean;
@@ -79,7 +87,9 @@ export interface DiscordGatewayStatus {
 }
 
 const DEFAULT_GATEWAY_URL = 'wss://gateway.discord.gg/?v=10&encoding=json';
-const DISCORD_GATEWAY_INTENTS = 1 + 512 + 4096 + 32768;
+// GUILDS(1) + GUILD_MESSAGES(512) + GUILD_MESSAGE_REACTIONS(1024)
+// + DIRECT_MESSAGES(4096) + DIRECT_MESSAGE_REACTIONS(8192) + MESSAGE_CONTENT(32768)
+const DISCORD_GATEWAY_INTENTS = 1 + 512 + 1024 + 4096 + 8192 + 32768;
 const MAX_RECONNECT_DELAY_MS = 30000;
 const MIN_CONNECT_INTERVAL_MS = 5500;
 const STABLE_CONNECTION_MS = 5 * 60 * 1000;
@@ -382,6 +392,41 @@ export class DiscordDmGateway {
 
     if (type === 'MESSAGE_CREATE') {
       await this.handleMessageCreate(data as MessageCreatePayload);
+      return;
+    }
+
+    if (type === 'MESSAGE_REACTION_ADD') {
+      this.handleReactionAdd(data as ReactionAddPayload);
+    }
+  }
+
+  private handleReactionAdd(reaction: ReactionAddPayload): void {
+    const channelId = reaction.channel_id?.trim();
+    const messageId = reaction.message_id?.trim();
+    const userId = reaction.user_id?.trim();
+    const emoji = reaction.emoji?.name?.trim();
+
+    if (!channelId || !messageId || !emoji) {
+      return;
+    }
+
+    if (this.selfUserId && userId === this.selfUserId) {
+      return;
+    }
+
+    if (emoji !== DISCORD_CANCEL_REACTION) {
+      return;
+    }
+
+    const token = buildDiscordCancelToken(channelId, messageId);
+    const platformKey = resolvePlatformKeyByCancelToken(token);
+    if (!platformKey) {
+      return;
+    }
+
+    const result = abortActiveRun(platformKey);
+    if (result.aborted) {
+      console.log(`[discord-gateway] Cancelled active run via ❌ reaction platformKey=${platformKey}`);
     }
   }
 

--- a/apps/remote-server/src/core/active-run-store.ts
+++ b/apps/remote-server/src/core/active-run-store.ts
@@ -1,6 +1,11 @@
 import type { ActiveRun } from './types.js';
 
 const activeRuns = new Map<string, ActiveRun>();
+// Reverse index: a "cancel token" (e.g. Discord channelId:messageId) → platformKey,
+// so platform-specific signals (reactions, button clicks) can abort the run
+// without having to remember the platformKey themselves.
+const cancelTokenToPlatformKey = new Map<string, string>();
+const platformKeyToCancelTokens = new Map<string, Set<string>>();
 
 export function hasActiveRun(platformKey: string): boolean {
   return activeRuns.has(platformKey);
@@ -16,6 +21,30 @@ export function setActiveRun(platformKey: string, run: ActiveRun): void {
 
 export function clearActiveRun(platformKey: string): void {
   activeRuns.delete(platformKey);
+  const tokens = platformKeyToCancelTokens.get(platformKey);
+  if (tokens) {
+    for (const token of tokens) {
+      cancelTokenToPlatformKey.delete(token);
+    }
+    platformKeyToCancelTokens.delete(platformKey);
+  }
+}
+
+export function registerCancelToken(token: string, platformKey: string): void {
+  if (!token || !platformKey) {
+    return;
+  }
+  cancelTokenToPlatformKey.set(token, platformKey);
+  let bucket = platformKeyToCancelTokens.get(platformKey);
+  if (!bucket) {
+    bucket = new Set<string>();
+    platformKeyToCancelTokens.set(platformKey, bucket);
+  }
+  bucket.add(token);
+}
+
+export function resolvePlatformKeyByCancelToken(token: string): string | undefined {
+  return cancelTokenToPlatformKey.get(token);
 }
 
 export function getActiveStreamId(platformKey: string): string | undefined {


### PR DESCRIPTION
Add three lightweight Discord interactions to make remote-server runs easier to follow and control, without introducing button/modal interaction handlers or persisted UI state.

## Changes

### 1. Status reactions on the user's original message
- `adapter.ts`: streaming handle now drives a small status state machine on the **user's own message** via reactions:
  - 👀 received → ⚙️ first tool call → ✅ done / ⚠️ error / ⏸️ waiting on clarification
- `client.ts`: add `addReaction` / `removeOwnReaction`.
- Pure cosmetic, never edits message content; safe to ignore on the user side.

### 2. ❌ reaction to cancel an active run
- `active-run-store.ts`: introduce a generic cancel-token registry (`registerCancelToken` / `resolvePlatformKeyByCancelToken`) so any platform signal can abort a run without needing to know the platformKey.
- `adapter.ts`: register the user's source message id as a cancel token when starting a channel run.
- `gateway.ts`: subscribe `GUILD_MESSAGE_REACTIONS` + `DIRECT_MESSAGE_REACTIONS` intents and abort the matching active run on ❌.

### 3. "Ask Pulse" message context menu
- `application-commands.ts`: register a `type: 3` (MESSAGE) application command named **Ask Pulse**.
- `adapter.ts::extractInteractionText`: handle `data.type === 3`, pulling the target message content from `resolved.messages` and feeding it as a quoted prompt (`Quoted message from @user:\n<content>`).

### 4. Progress footer stats
- `adapter.ts`: progress footer now appends a small-text line with elapsed time, tool-call count, and a `react ❌ to cancel` hint, e.g. `-# 12s · 3 tools · react ❌ to cancel`.

## Notes
- No new persisted state, no message components, no interaction-handler routing required.
- Context menu path goes through the existing webhook flow; reactions/cancel rely on the existing gateway listener.
- Type-checked: zero errors in the affected files.