### PR TITLE
feat: add devtools cache timeline

### DIFF
--- a/apps/devtools-web/src/App.tsx
+++ b/apps/devtools-web/src/App.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
+import { CacheTimeline, type CacheTimelineSpan } from './CacheTimeline';
 
 type RunStatus = 'running' | 'finished';
-type PageView = 'runs' | 'stats' | 'tools' | 'errors';
+type PageView = 'runs' | 'stats' | 'tools' | 'errors' | 'cache';
 type StatsRange = 'today' | 'week' | 'month' | 'custom';
 type StatsGranularity = 'hour' | 'day' | 'week';
 type StatsGroupBy = 'none' | 'model' | 'session';
@@ -293,7 +294,7 @@ export default function App() {
   const [groupBy, setGroupBy] = useState<'none' | 'session'>('none');
   const [statusFilter, setStatusFilter] = useState<'all' | 'running' | 'finished'>('all');
   const [sortBy, setSortBy] = useState<'recent' | 'duration' | 'lastEvent'>('recent');
-  const [detailTab, setDetailTab] = useState<'llm' | 'plugins' | 'timeline' | 'prompt'>('llm');
+  const [detailTab, setDetailTab] = useState<'llm' | 'plugins' | 'timeline' | 'prompt' | 'cache'>('llm');
   const [timelineRange, setTimelineRange] = useState({ from: 1, to: 1 });
 
   const apiBase = useMemo(() => sanitizeBaseUrl(baseUrl), [baseUrl]);
@@ -778,6 +779,12 @@ export default function App() {
           >
             Engine Plugins
           </button>
+          <button
+            className={`tab-button ${detailTab === 'cache' ? 'active' : ''}`}
+            onClick={() => setDetailTab('cache')}
+          >
+            Cache
+          </button>
         </div>
 
         {detailTab === 'llm' ? (
@@ -1228,6 +1235,26 @@ export default function App() {
               )}
             </section>
           </>
+        ) : detailTab === 'cache' ? (
+          <section className="section">
+            <h2>Cache Timeline (this run)</h2>
+            <p className="muted" style={{ marginTop: 0 }}>
+              Each bar = one LLM call. Green = cache read (hit), blue = cache write (new), gray = fresh input.
+              ⚡ marks where consecutive cache contents shrank significantly (likely cache breakpoint).
+            </p>
+            <CacheTimeline
+              spans={selectedRun.llmSpans.map<CacheTimelineSpan>((span) => ({
+                spanIndex: span.index,
+                runId: selectedRun.runId,
+                startedAt: span.startedAt,
+                model: span.model,
+                inputTokens: span.inputTokens,
+                cacheReadTokens: span.cacheReadTokens,
+                cacheWriteTokens: span.cacheWriteTokens,
+              }))}
+              emptyHint="No LLM calls in this run yet."
+            />
+          </section>
         ) : (
           <>
             <section className="section">
@@ -1452,7 +1479,7 @@ export default function App() {
       </header>
 
       <div className="page-nav">
-        {(['runs', 'stats', 'tools', 'errors'] as const).map((p) => (
+        {(['runs', 'stats', 'cache', 'tools', 'errors'] as const).map((p) => (
           <button
             key={p}
             className={`page-nav-btn ${page === p ? 'active' : ''}`}
@@ -1462,6 +1489,8 @@ export default function App() {
               ? '⚡ Runs'
               : p === 'stats'
               ? '📊 Stats'
+              : p === 'cache'
+              ? '🧊 Cache'
               : p === 'tools'
               ? '🧰 Tools'
               : '⚠️ Errors'}
@@ -1471,6 +1500,8 @@ export default function App() {
 
       {page === 'stats' ? (
         <StatsView apiBase={apiBase} />
+      ) : page === 'cache' ? (
+        <CacheView apiBase={apiBase} />
       ) : page === 'tools' ? (
         <ToolsView apiBase={apiBase} />
       ) : page === 'errors' ? (
@@ -3067,5 +3098,217 @@ function ErrorsView({ apiBase }: { apiBase: string }) {
         </>
       )}
     </div>
+  );
+}
+
+// ── Cache View (per session / per run lookup) ─────────────────────────────
+
+interface SessionDetailLlmCall {
+  runId: string;
+  runStartedAt: number;
+  spanIndex: number;
+  startedAt: number;
+  model?: string;
+  inputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+}
+
+interface SessionDetailResponse {
+  ok: boolean;
+  sessionId: string;
+  aggregate?: {
+    sessionId: string;
+    runCount: number;
+    llmCallCount: number;
+    inputTokens: number;
+    cacheReadTokens: number;
+    cacheWriteTokens: number;
+    cacheHitRate: number;
+    firstRunAt: number;
+    lastRunAt: number;
+    models: string[];
+  };
+  runs?: Array<{
+    runId: string;
+    startedAt: number;
+    userTextPreview?: string;
+    llmCalls: number;
+    totalCacheReadTokens?: number;
+  }>;
+  llmCalls?: SessionDetailLlmCall[];
+  error?: string;
+}
+
+interface RunDetailResponse {
+  ok: boolean;
+  run?: {
+    runId: string;
+    sessionId?: string;
+    llmSpans: Array<{
+      index: number;
+      startedAt: number;
+      model?: string;
+      inputTokens?: number;
+      cacheReadTokens?: number;
+      cacheWriteTokens?: number;
+    }>;
+  };
+  error?: string;
+}
+
+function CacheView({ apiBase }: { apiBase: string }) {
+  const [mode, setMode] = useState<'session' | 'run'>('session');
+  const [sessionId, setSessionId] = useState('');
+  const [runId, setRunId] = useState('');
+  const [range, setRange] = useState<'today' | 'week' | 'month'>('week');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sessionData, setSessionData] = useState<SessionDetailResponse | null>(null);
+  const [runData, setRunData] = useState<RunDetailResponse | null>(null);
+
+  const submit = async (event?: React.FormEvent) => {
+    event?.preventDefault();
+    setError(null);
+    setLoading(true);
+    setSessionData(null);
+    setRunData(null);
+    try {
+      if (mode === 'session') {
+        const id = sessionId.trim();
+        if (!id) {
+          setError('Please input a sessionId');
+          return;
+        }
+        const res = await fetch(`${apiBase}/sessions/${encodeURIComponent(id)}?range=${range}`);
+        const data: SessionDetailResponse = await res.json();
+        if (!data.ok) {
+          setError(data.error || 'Failed to load session');
+          return;
+        }
+        setSessionData(data);
+      } else {
+        const id = runId.trim();
+        if (!id) {
+          setError('Please input a runId');
+          return;
+        }
+        const res = await fetch(`${apiBase}/runs/${encodeURIComponent(id)}`);
+        const data: RunDetailResponse = await res.json();
+        if (!data.ok) {
+          setError(data.error || 'Failed to load run');
+          return;
+        }
+        setRunData(data);
+      }
+    } catch (e: any) {
+      setError(String(e?.message ?? e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const sessionSpans = useMemo<CacheTimelineSpan[]>(() => {
+    if (!sessionData?.llmCalls) return [];
+    return sessionData.llmCalls
+      .slice()
+      .sort((a, b) => a.startedAt - b.startedAt)
+      .map((call) => ({
+        spanIndex: call.spanIndex,
+        runId: call.runId,
+        startedAt: call.startedAt,
+        model: call.model,
+        inputTokens: call.inputTokens,
+        cacheReadTokens: call.cacheReadTokens,
+        cacheWriteTokens: call.cacheWriteTokens,
+      }));
+  }, [sessionData]);
+
+  const runSpans = useMemo<CacheTimelineSpan[]>(() => {
+    if (!runData?.run?.llmSpans) return [];
+    return runData.run.llmSpans.map((s) => ({
+      spanIndex: s.index,
+      runId: runData.run!.runId,
+      startedAt: s.startedAt,
+      model: s.model,
+      inputTokens: s.inputTokens,
+      cacheReadTokens: s.cacheReadTokens,
+      cacheWriteTokens: s.cacheWriteTokens,
+    }));
+  }, [runData]);
+
+  return (
+    <main style={{ padding: 20 }}>
+      <div className="panel" style={{ padding: 20 }}>
+        <h2 style={{ marginTop: 0 }}>Cache Inspector</h2>
+        <p className="muted" style={{ marginTop: 0 }}>
+          Inspect prompt-cache behavior across a session or within a single run, and locate where
+          the cache "broke" between consecutive LLM calls.
+        </p>
+
+        <form onSubmit={submit} style={{ display: 'flex', flexWrap: 'wrap', gap: 10, alignItems: 'center', marginBottom: 16 }}>
+          <select value={mode} onChange={(e) => setMode(e.target.value as 'session' | 'run')}>
+            <option value="session">By sessionId</option>
+            <option value="run">By runId</option>
+          </select>
+          {mode === 'session' ? (
+            <>
+              <input
+                type="text"
+                placeholder="sessionId"
+                value={sessionId}
+                onChange={(e) => setSessionId(e.target.value)}
+                style={{ flex: '1 1 240px', minWidth: 240, padding: '6px 10px' }}
+              />
+              <select value={range} onChange={(e) => setRange(e.target.value as any)}>
+                <option value="today">Today</option>
+                <option value="week">7 days</option>
+                <option value="month">30 days</option>
+              </select>
+            </>
+          ) : (
+            <input
+              type="text"
+              placeholder="runId"
+              value={runId}
+              onChange={(e) => setRunId(e.target.value)}
+              style={{ flex: '1 1 320px', minWidth: 320, padding: '6px 10px' }}
+            />
+          )}
+          <button type="submit" className="primary" disabled={loading}>
+            {loading ? 'Loading…' : 'Inspect'}
+          </button>
+        </form>
+
+        {error ? <div className="error">{error}</div> : null}
+      </div>
+
+      {sessionData?.aggregate ? (
+        <div className="panel" style={{ padding: 20, marginTop: 16 }}>
+          <h3 style={{ marginTop: 0 }}>Session: {sessionData.sessionId}</h3>
+          <div className="muted" style={{ fontSize: 12, marginBottom: 12 }}>
+            {sessionData.aggregate.runCount} runs · {sessionData.aggregate.llmCallCount} LLM calls ·
+            {' '}models: {sessionData.aggregate.models.join(', ') || 'n/a'}
+          </div>
+          <CacheTimeline
+            spans={sessionSpans}
+            showRunBands
+            emptyHint="No LLM calls in this session within the selected range."
+          />
+        </div>
+      ) : null}
+
+      {runData?.run ? (
+        <div className="panel" style={{ padding: 20, marginTop: 16 }}>
+          <h3 style={{ marginTop: 0 }}>Run: {runData.run.runId}</h3>
+          {runData.run.sessionId ? (
+            <div className="muted" style={{ fontSize: 12, marginBottom: 12 }}>
+              Session: {runData.run.sessionId}
+            </div>
+          ) : null}
+          <CacheTimeline spans={runSpans} emptyHint="No LLM calls in this run." />
+        </div>
+      ) : null}
+    </main>
   );
 }

--- a/apps/devtools-web/src/CacheTimeline.tsx
+++ b/apps/devtools-web/src/CacheTimeline.tsx
@@ -1,0 +1,341 @@
+import { useMemo } from 'react';
+
+export interface CacheTimelineSpan {
+  spanIndex: number;
+  runId?: string;
+  startedAt?: number;
+  model?: string;
+  inputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+}
+
+interface Point {
+  position: number;
+  spanIndex: number;
+  runId?: string;
+  startedAt?: number;
+  model?: string;
+  freshInput: number;
+  cacheRead: number;
+  cacheWrite: number;
+  total: number;
+  hitRate: number;
+  missing: boolean;
+}
+
+interface Breakpoint {
+  position: number;
+  spanIndex: number;
+  runId?: string;
+  prevPosition: number;
+  prevSpanIndex: number;
+  prevRunId?: string;
+  expected: number;
+  actual: number;
+  lostTokens: number;
+  severity: 'partial' | 'full';
+  crossRun: boolean;
+}
+
+interface Result {
+  points: Point[];
+  breakpoints: Breakpoint[];
+  summary: {
+    callCount: number;
+    freshInput: number;
+    cacheRead: number;
+    cacheWrite: number;
+    hitRate: number;
+    breakpointCount: number;
+    fullBreakpointCount: number;
+    totalLostTokens: number;
+  };
+}
+
+// Inlined to avoid coupling devtools-web with plugin-kit deps; mirrors plugin-kit/devtools.analyzeCacheTimeline.
+function analyze(spans: CacheTimelineSpan[], minLost = 1000, minRatio = 0.05): Result {
+  const points: Point[] = spans.map((span, idx) => {
+    const cacheRead = span.cacheReadTokens ?? 0;
+    const cacheWrite = span.cacheWriteTokens ?? 0;
+    // The devtools API treats inputTokens as fresh/non-cache input tokens.
+    const freshInput = span.inputTokens ?? 0;
+    const denom = freshInput + cacheRead;
+    return {
+      position: idx + 1,
+      spanIndex: span.spanIndex,
+      runId: span.runId,
+      startedAt: span.startedAt,
+      model: span.model,
+      freshInput,
+      cacheRead,
+      cacheWrite,
+      total: freshInput + cacheRead + cacheWrite,
+      hitRate: denom > 0 ? cacheRead / denom : 0,
+      missing:
+        span.inputTokens === undefined &&
+        span.cacheReadTokens === undefined &&
+        span.cacheWriteTokens === undefined,
+    };
+  });
+
+  const breakpoints: Breakpoint[] = [];
+  for (let i = 1; i < points.length; i += 1) {
+    const prev = points[i - 1];
+    const curr = points[i];
+    if (prev.missing || curr.missing) continue;
+    const expected = prev.cacheRead + prev.cacheWrite;
+    if (expected <= 0) continue;
+    const actual = curr.cacheRead;
+    const lost = Math.max(0, expected - actual);
+    const threshold = Math.max(minLost, expected * minRatio);
+    if (lost < threshold) continue;
+    breakpoints.push({
+      position: curr.position,
+      spanIndex: curr.spanIndex,
+      runId: curr.runId,
+      prevPosition: prev.position,
+      prevSpanIndex: prev.spanIndex,
+      prevRunId: prev.runId,
+      expected,
+      actual,
+      lostTokens: lost,
+      severity: actual === 0 ? 'full' : 'partial',
+      crossRun: !!(prev.runId && curr.runId && prev.runId !== curr.runId),
+    });
+  }
+
+  let freshInput = 0;
+  let cacheRead = 0;
+  let cacheWrite = 0;
+  let lost = 0;
+  for (const p of points) {
+    freshInput += p.freshInput;
+    cacheRead += p.cacheRead;
+    cacheWrite += p.cacheWrite;
+  }
+  for (const b of breakpoints) lost += b.lostTokens;
+  const denom = freshInput + cacheRead;
+
+  return {
+    points,
+    breakpoints,
+    summary: {
+      callCount: points.length,
+      freshInput,
+      cacheRead,
+      cacheWrite,
+      hitRate: denom > 0 ? cacheRead / denom : 0,
+      breakpointCount: breakpoints.length,
+      fullBreakpointCount: breakpoints.filter((b) => b.severity === 'full').length,
+      totalLostTokens: lost,
+    },
+  };
+}
+
+function formatK(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) return `${(n / 1000).toFixed(1)}k`;
+  return `${(n / 1_000_000).toFixed(2)}M`;
+}
+
+interface Props {
+  spans: CacheTimelineSpan[];
+  /** When true, color-band by runId at the bottom (cross-run / session view). */
+  showRunBands?: boolean;
+  onSpanClick?: (point: Point) => void;
+  emptyHint?: string;
+}
+
+export function CacheTimeline({ spans, showRunBands, onSpanClick, emptyHint }: Props) {
+  const result = useMemo(() => analyze(spans), [spans]);
+  const { points, breakpoints, summary } = result;
+
+  if (!points.length) {
+    return <div className="empty">{emptyHint ?? 'No LLM calls.'}</div>;
+  }
+
+  const maxTotal = Math.max(...points.map((p) => p.total), 1);
+  const breakpointMap = new Map<number, Breakpoint>();
+  for (const b of breakpoints) breakpointMap.set(b.position, b);
+
+  // Build run color bands
+  const runColors = new Map<string, string>();
+  if (showRunBands) {
+    const palette = ['#3b82f6', '#a855f7', '#10b981', '#f59e0b', '#ef4444', '#06b6d4', '#ec4899', '#84cc16'];
+    let idx = 0;
+    for (const p of points) {
+      const key = p.runId ?? 'unknown';
+      if (!runColors.has(key)) {
+        runColors.set(key, palette[idx % palette.length]);
+        idx += 1;
+      }
+    }
+  }
+
+  const allHaveData = summary.cacheRead + summary.cacheWrite + summary.freshInput > 0;
+
+  return (
+    <div className="cache-timeline">
+      <div className="cache-summary-row">
+        <SummaryStat label="Calls" value={String(summary.callCount)} />
+        <SummaryStat label="Hit Rate" value={`${(summary.hitRate * 100).toFixed(1)}%`} />
+        <SummaryStat label="Cache Read" value={formatK(summary.cacheRead)} accent="green" />
+        <SummaryStat label="Cache Write" value={formatK(summary.cacheWrite)} accent="blue" />
+        <SummaryStat label="Fresh Input" value={formatK(summary.freshInput)} accent="gray" />
+        <SummaryStat
+          label="Breakpoints"
+          value={`${summary.breakpointCount}${summary.fullBreakpointCount > 0 ? ` (${summary.fullBreakpointCount} full)` : ''}`}
+          accent={summary.breakpointCount > 0 ? 'red' : undefined}
+        />
+        <SummaryStat
+          label="Lost Tokens"
+          value={formatK(summary.totalLostTokens)}
+          accent={summary.totalLostTokens > 0 ? 'red' : undefined}
+        />
+      </div>
+
+      {!allHaveData ? (
+        <div className="cache-empty-note">
+          ⚠️ All cache fields are 0. Either prompt caching is not enabled upstream, or no qualifying LLM call has run yet.
+        </div>
+      ) : null}
+
+      <div className="cache-bars-container">
+        {points.map((p, i) => {
+          const bp = breakpointMap.get(p.position);
+          const heightPct = (p.total / maxTotal) * 100;
+          const readPct = p.total > 0 ? (p.cacheRead / p.total) * 100 : 0;
+          const writePct = p.total > 0 ? (p.cacheWrite / p.total) * 100 : 0;
+          const freshPct = p.total > 0 ? (p.freshInput / p.total) * 100 : 0;
+          const tooltip = [
+            `#${p.spanIndex}${p.runId ? ` (run ${p.runId.slice(0, 8)})` : ''}`,
+            p.model ? `model: ${p.model}` : null,
+            `fresh: ${formatK(p.freshInput)}`,
+            `cacheRead: ${formatK(p.cacheRead)}`,
+            `cacheWrite: ${formatK(p.cacheWrite)}`,
+            `hit rate: ${(p.hitRate * 100).toFixed(1)}%`,
+            bp
+              ? `⚡ ${bp.severity === 'full' ? 'FULL BREAK' : 'partial break'}: lost ${formatK(bp.lostTokens)} (expected ${formatK(bp.expected)}, got ${formatK(bp.actual)})${bp.crossRun ? ' [cross-run]' : ''}`
+              : null,
+          ]
+            .filter(Boolean)
+            .join('\n');
+
+          return (
+            <div
+              key={`${p.runId ?? 'r'}-${p.spanIndex}-${i}`}
+              className="cache-bar-cell"
+              title={tooltip}
+              onClick={onSpanClick ? () => onSpanClick(p) : undefined}
+              style={{ cursor: onSpanClick ? 'pointer' : 'default' }}
+            >
+              {bp ? (
+                <div className={`cache-break-marker ${bp.severity}`} title={tooltip}>
+                  ⚡{formatK(bp.lostTokens)}
+                </div>
+              ) : (
+                <div className="cache-break-marker placeholder" />
+              )}
+              <div className="cache-bar-stack" style={{ height: `${Math.max(heightPct, 2)}%` }}>
+                {p.cacheRead > 0 ? (
+                  <div className="cache-seg seg-read" style={{ height: `${readPct}%` }} />
+                ) : null}
+                {p.cacheWrite > 0 ? (
+                  <div className="cache-seg seg-write" style={{ height: `${writePct}%` }} />
+                ) : null}
+                {p.freshInput > 0 ? (
+                  <div className="cache-seg seg-fresh" style={{ height: `${freshPct}%` }} />
+                ) : null}
+                {p.total === 0 ? <div className="cache-seg seg-empty" /> : null}
+              </div>
+              {showRunBands ? (
+                <div
+                  className="cache-runband"
+                  style={{ background: runColors.get(p.runId ?? 'unknown') ?? '#888' }}
+                />
+              ) : null}
+              <div className="cache-bar-label">#{p.spanIndex}</div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="cache-legend">
+        <LegendDot color="#10b981" label="Cache Read (hit)" />
+        <LegendDot color="#3b82f6" label="Cache Write (new)" />
+        <LegendDot color="#9ca3af" label="Fresh Input (uncached)" />
+        <LegendDot color="#ef4444" label="⚡ breakpoint" />
+        {showRunBands ? <span className="legend-note">color band = runId</span> : null}
+      </div>
+
+      {breakpoints.length > 0 ? (
+        <details className="cache-break-details" open>
+          <summary>
+            {breakpoints.length} breakpoint{breakpoints.length > 1 ? 's' : ''} detected
+          </summary>
+          <table className="cache-break-table">
+            <thead>
+              <tr>
+                <th>At</th>
+                <th>Prev</th>
+                <th>Expected ≥</th>
+                <th>Actual</th>
+                <th>Lost</th>
+                <th>Severity</th>
+                <th>Note</th>
+              </tr>
+            </thead>
+            <tbody>
+              {breakpoints.map((b) => (
+                <tr key={`${b.runId ?? ''}-${b.spanIndex}`} className={`break-row ${b.severity}`}>
+                  <td>
+                    #{b.spanIndex}
+                    {b.runId ? ` (${b.runId.slice(0, 6)})` : ''}
+                  </td>
+                  <td>
+                    #{b.prevSpanIndex}
+                    {b.prevRunId ? ` (${b.prevRunId.slice(0, 6)})` : ''}
+                  </td>
+                  <td>{formatK(b.expected)}</td>
+                  <td>{formatK(b.actual)}</td>
+                  <td>
+                    <strong>{formatK(b.lostTokens)}</strong>
+                  </td>
+                  <td>{b.severity === 'full' ? 'FULL' : 'partial'}</td>
+                  <td>{b.crossRun ? 'cross-run boundary' : ''}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </details>
+      ) : null}
+    </div>
+  );
+}
+
+function SummaryStat({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: string;
+  accent?: 'green' | 'blue' | 'red' | 'gray';
+}) {
+  return (
+    <div className={`cache-summary-stat ${accent ? `accent-${accent}` : ''}`}>
+      <div className="cache-summary-label">{label}</div>
+      <div className="cache-summary-value">{value}</div>
+    </div>
+  );
+}
+
+function LegendDot({ color, label }: { color: string; label: string }) {
+  return (
+    <span className="legend-item">
+      <span className="legend-dot" style={{ background: color }} />
+      {label}
+    </span>
+  );
+}

--- a/apps/devtools-web/src/styles.css
+++ b/apps/devtools-web/src/styles.css
@@ -1208,3 +1208,138 @@ th {
   color: var(--text-muted);
   margin-bottom: 4px;
 }
+
+/* ── Cache Timeline ──────────────────────────────────────────────────────── */
+.cache-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px;
+  background: var(--surface, #fff);
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 10px;
+}
+.cache-summary-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+.cache-summary-stat {
+  flex: 0 0 auto;
+  min-width: 90px;
+  padding: 8px 12px;
+  background: #f8fafc;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+}
+.cache-summary-stat.accent-green { border-color: #10b981; background: #ecfdf5; }
+.cache-summary-stat.accent-blue  { border-color: #3b82f6; background: #eff6ff; }
+.cache-summary-stat.accent-red   { border-color: #ef4444; background: #fef2f2; }
+.cache-summary-stat.accent-gray  { border-color: #9ca3af; background: #f3f4f6; }
+.cache-summary-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  color: var(--text-muted, #6b7280);
+  letter-spacing: 0.04em;
+}
+.cache-summary-value {
+  font-size: 16px;
+  font-weight: 700;
+  margin-top: 2px;
+}
+.cache-empty-note {
+  font-size: 12px;
+  color: #92400e;
+  background: #fffbeb;
+  border: 1px dashed #f59e0b;
+  border-radius: 6px;
+  padding: 8px 12px;
+}
+.cache-bars-container {
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+  height: 220px;
+  padding: 8px;
+  background: #fafafa;
+  border-radius: 8px;
+  overflow-x: auto;
+}
+.cache-bar-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  height: 100%;
+  min-width: 28px;
+  flex: 1 0 28px;
+}
+.cache-break-marker {
+  font-size: 10px;
+  font-weight: 700;
+  color: #ef4444;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+}
+.cache-break-marker.full { color: #b91c1c; background: #fee2e2; padding: 0 4px; border-radius: 4px; }
+.cache-break-marker.placeholder { color: transparent; }
+.cache-bar-stack {
+  display: flex;
+  flex-direction: column-reverse; /* fresh bottom, write middle, read top */
+  width: 100%;
+  min-height: 4px;
+  background: transparent;
+  border-radius: 3px 3px 0 0;
+  overflow: hidden;
+}
+.cache-seg { width: 100%; }
+.cache-seg.seg-fresh { background: #9ca3af; }
+.cache-seg.seg-write { background: #3b82f6; }
+.cache-seg.seg-read  { background: #10b981; }
+.cache-seg.seg-empty { background: #e5e7eb; height: 100%; }
+.cache-runband {
+  width: 100%;
+  height: 3px;
+  margin-top: 2px;
+  border-radius: 2px;
+}
+.cache-bar-label {
+  font-size: 10px;
+  color: var(--text-muted, #6b7280);
+  margin-top: 2px;
+}
+.cache-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 12px;
+  color: var(--text-muted, #6b7280);
+}
+.legend-item { display: inline-flex; align-items: center; gap: 6px; }
+.legend-dot { width: 10px; height: 10px; border-radius: 2px; display: inline-block; }
+.legend-note { font-style: italic; }
+
+.cache-break-details {
+  border-top: 1px dashed #e5e7eb;
+  padding-top: 10px;
+}
+.cache-break-details summary {
+  cursor: pointer;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+.cache-break-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+.cache-break-table th,
+.cache-break-table td {
+  padding: 4px 8px;
+  border-bottom: 1px solid #f3f4f6;
+  text-align: left;
+}
+.cache-break-table tr.full { background: #fef2f2; }
+.cache-break-table tr.partial { background: #fffbeb; }

--- a/packages/plugin-kit/src/devtools/index.ts
+++ b/packages/plugin-kit/src/devtools/index.ts
@@ -305,6 +305,184 @@ export interface DevtoolsIntegration {
   initialize(): Promise<void>;
 }
 
+// ── Cache Timeline Analysis ─────────────────────────────────────────────────
+
+export interface CacheTimelinePoint {
+  /** Sequential position along the timeline (1-based). */
+  position: number;
+  /** Original spanIndex within its run. */
+  spanIndex: number;
+  /** Run identifier (useful for cross-run / session views). */
+  runId?: string;
+  startedAt?: number;
+  model?: string;
+  /** Fresh (non-cached) input tokens. */
+  freshInput: number;
+  /** Tokens served from prompt cache. */
+  cacheRead: number;
+  /** Tokens newly written to prompt cache by this call. */
+  cacheWrite: number;
+  /** Sum of the three above (best-effort total input volume). */
+  total: number;
+  /** Cache hit ratio for this single call: cacheRead / (freshInput + cacheRead). */
+  hitRate: number;
+  /** Whether usage data was missing (fields all undefined). */
+  missing: boolean;
+}
+
+export interface CacheBreakpoint {
+  /** Position of the call where the breakpoint was detected (the "current" call). */
+  position: number;
+  spanIndex: number;
+  runId?: string;
+  /** Position of the previous call used for comparison. */
+  prevPosition: number;
+  prevSpanIndex: number;
+  prevRunId?: string;
+  /** Expected minimum cacheRead = prev.cacheRead + prev.cacheWrite. */
+  expected: number;
+  /** Actual cacheRead observed. */
+  actual: number;
+  /** max(0, expected - actual) — tokens that "should have" been cached but weren't. */
+  lostTokens: number;
+  /** 'full' when actual=0 while expected>0; otherwise 'partial'. */
+  severity: 'partial' | 'full';
+  /** True when prev and current belong to different runs (cross-run boundary). */
+  crossRun: boolean;
+}
+
+export interface CacheTimelineSummary {
+  callCount: number;
+  freshInput: number;
+  cacheRead: number;
+  cacheWrite: number;
+  hitRate: number;
+  breakpointCount: number;
+  fullBreakpointCount: number;
+  totalLostTokens: number;
+}
+
+export interface CacheTimelineResult {
+  points: CacheTimelinePoint[];
+  breakpoints: CacheBreakpoint[];
+  summary: CacheTimelineSummary;
+}
+
+export interface CacheTimelineOptions {
+  /** Absolute lost-tokens threshold to flag as a breakpoint. Default: 1000. */
+  minLostTokens?: number;
+  /** Relative threshold vs prev (cacheRead+cacheWrite). Default: 0.05 (5%). */
+  minLostRatio?: number;
+}
+
+export interface CacheTimelineSpanInput {
+  spanIndex: number;
+  runId?: string;
+  startedAt?: number;
+  model?: string;
+  inputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+}
+
+/**
+ * Build a cache-aware timeline across one run or many runs (already ordered).
+ *
+ * Breakpoint semantics: for two consecutive calls (prev, curr):
+ *   expected = prev.cacheRead + prev.cacheWrite
+ *   actual   = curr.cacheRead
+ *   lost     = max(0, expected - actual)
+ * lost is flagged when it exceeds max(minLostTokens, expected * minLostRatio).
+ * If actual=0 && expected>0 the severity is 'full' (cache fully invalidated).
+ */
+export function analyzeCacheTimeline(
+  spans: CacheTimelineSpanInput[],
+  options: CacheTimelineOptions = {},
+): CacheTimelineResult {
+  const minLostTokens = options.minLostTokens ?? 1000;
+  const minLostRatio = options.minLostRatio ?? 0.05;
+
+  const points: CacheTimelinePoint[] = spans.map((span, idx) => {
+    const cacheRead = span.cacheReadTokens ?? 0;
+    const cacheWrite = span.cacheWriteTokens ?? 0;
+    // The devtools store treats inputTokens as fresh/non-cache input tokens.
+    // Current providers we observed expose cache read/write in separate fields.
+    const freshInput = span.inputTokens ?? 0;
+    const denom = freshInput + cacheRead;
+    const hitRate = denom > 0 ? cacheRead / denom : 0;
+    const missing =
+      span.inputTokens === undefined &&
+      span.cacheReadTokens === undefined &&
+      span.cacheWriteTokens === undefined;
+    return {
+      position: idx + 1,
+      spanIndex: span.spanIndex,
+      runId: span.runId,
+      startedAt: span.startedAt,
+      model: span.model,
+      freshInput,
+      cacheRead,
+      cacheWrite,
+      total: freshInput + cacheRead + cacheWrite,
+      hitRate,
+      missing,
+    };
+  });
+
+  const breakpoints: CacheBreakpoint[] = [];
+  for (let i = 1; i < points.length; i += 1) {
+    const prev = points[i - 1];
+    const curr = points[i];
+    if (prev.missing || curr.missing) continue;
+    const expected = prev.cacheRead + prev.cacheWrite;
+    if (expected <= 0) continue;
+    const actual = curr.cacheRead;
+    const lost = Math.max(0, expected - actual);
+    const threshold = Math.max(minLostTokens, expected * minLostRatio);
+    if (lost < threshold) continue;
+    breakpoints.push({
+      position: curr.position,
+      spanIndex: curr.spanIndex,
+      runId: curr.runId,
+      prevPosition: prev.position,
+      prevSpanIndex: prev.spanIndex,
+      prevRunId: prev.runId,
+      expected,
+      actual,
+      lostTokens: lost,
+      severity: actual === 0 ? 'full' : 'partial',
+      crossRun: !!(prev.runId && curr.runId && prev.runId !== curr.runId),
+    });
+  }
+
+  let freshInput = 0;
+  let cacheRead = 0;
+  let cacheWrite = 0;
+  let totalLost = 0;
+  for (const p of points) {
+    freshInput += p.freshInput;
+    cacheRead += p.cacheRead;
+    cacheWrite += p.cacheWrite;
+  }
+  for (const b of breakpoints) totalLost += b.lostTokens;
+  const denom = freshInput + cacheRead;
+
+  return {
+    points,
+    breakpoints,
+    summary: {
+      callCount: points.length,
+      freshInput,
+      cacheRead,
+      cacheWrite,
+      hitRate: denom > 0 ? cacheRead / denom : 0,
+      breakpointCount: breakpoints.length,
+      fullBreakpointCount: breakpoints.filter((b) => b.severity === 'full').length,
+      totalLostTokens: totalLost,
+    },
+  };
+}
+
 const DEFAULT_FLUSH_DELAY_MS = 200;
 const DEFAULT_MAX_INDEX_ENTRIES = 500;
 const DEFAULT_PROMPT_SNAPSHOT_LIMIT_BYTES = 256 * 1024;


### PR DESCRIPTION
Add cache-focused inspection to devtools for run and session analysis.

- Add reusable cache timeline analysis with breakpoint detection
- Add Cache tab to run details for per-run LLM cache visibility
- Add Cache Inspector page for sessionId/runId lookup across LLM calls
- Render stacked cache read/write/fresh-input bars and breakpoint details

Validation:
- pnpm build in apps/devtools-web: passed
- SKIP_DTS=1 pnpm --filter pulse-coder-plugin-kit build: passed