### PR TITLE
fix: extend image analysis headers timeout

### DIFF
--- a/apps/remote-server/src/core/tools/analyze-image.test.ts
+++ b/apps/remote-server/src/core/tools/analyze-image.test.ts
@@ -137,4 +137,11 @@ describe('analyzeImageTool', () => {
     expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 300000);
     expect(setTimeoutSpy).not.toHaveBeenCalledWith(expect.any(Function), 60000);
   });
+
+  it('configures loopback requests with a 5 minute headers timeout', () => {
+    expect(vi.mocked(Agent)).toHaveBeenCalledWith(expect.objectContaining({
+      headersTimeout: 300000,
+      bodyTimeout: 0,
+    }));
+  });
 });

--- a/apps/remote-server/src/core/tools/analyze-image.ts
+++ b/apps/remote-server/src/core/tools/analyze-image.ts
@@ -7,7 +7,7 @@ import type { StoredAttachment } from '../attachments.js';
 const localLoopbackDispatcher = new Agent({
   keepAliveTimeout: 5_000,
   connect: { timeout: 10_000 },
-  headersTimeout: 30_000,
+  headersTimeout: 300_000,
   bodyTimeout: 0,
 });
 


### PR DESCRIPTION
Extend the local loopback headers timeout used by image analysis requests.

- Match undici headersTimeout to the fixed 5-minute image analysis timeout
- Prevent slow OpenAI Responses vision calls from failing after 30 seconds
- Add test coverage for the loopback dispatcher timeout configuration

Validation:
- pnpm --filter @pulse-coder/remote-server test -- analyze-image.test.ts
- pnpm exec tsx direct analyzeImageTool OpenAI responses check with previous image
- pnpm --filter @pulse-coder/remote-server build
