### PR TITLE
feat: add canvas workspace import export

### DIFF
--- a/apps/canvas-workspace/src/main/canvas-store.ts
+++ b/apps/canvas-workspace/src/main/canvas-store.ts
@@ -1,6 +1,7 @@
-import { ipcMain, BrowserWindow } from "electron";
+import type { Dirent } from "fs";
+import { ipcMain, BrowserWindow, dialog } from "electron";
 import { promises as fs, watch as fsWatch, FSWatcher } from "fs";
-import { join, basename, dirname } from "path";
+import { join, basename, dirname, relative, resolve, sep, isAbsolute } from "path";
 import { homedir } from "os";
 
 const STORE_DIR = join(homedir(), ".pulse-coder", "canvas");
@@ -120,6 +121,160 @@ const AGENTS_MD_TEMPLATE = `# Canvas Agent Config
 <!-- canvas:auto-start -->
 <!-- canvas:auto-end -->
 `;
+
+
+const EXPORT_FORMAT = 'pulse-canvas-workspace';
+const EXPORT_VERSION = 1;
+const PORTABLE_WORKSPACE_URL_PREFIX = 'pulsecanvas://workspace/';
+
+interface WorkspaceExportFile {
+  relativePath: string;
+  encoding: 'base64';
+  content: string;
+}
+
+interface WorkspaceExportPayload {
+  format: typeof EXPORT_FORMAT;
+  version: typeof EXPORT_VERSION;
+  exportedAt: string;
+  workspace: {
+    id: string;
+    name: string;
+  };
+  canvas: unknown;
+  files: WorkspaceExportFile[];
+}
+
+const sanitizeFileName = (name: string): string => {
+  const safe = name.replace(/[^a-zA-Z0-9_\- .]/g, '').trim();
+  return safe || 'workspace';
+};
+
+const toPortableRelativePath = (filePath: string, workspaceDir: string): string | null => {
+  const rel = relative(workspaceDir, filePath);
+  if (!rel || rel.startsWith('..') || isAbsolute(rel)) return null;
+  return rel.split(sep).join('/');
+};
+
+const portableUrlForRelativePath = (relativePath: string): string =>
+  `${PORTABLE_WORKSPACE_URL_PREFIX}${encodeURI(relativePath)}`;
+
+const relativePathFromPortableUrl = (value: string): string | null => {
+  if (!value.startsWith(PORTABLE_WORKSPACE_URL_PREFIX)) return null;
+  return decodeURI(value.slice(PORTABLE_WORKSPACE_URL_PREFIX.length));
+};
+
+const isSafeRelativePath = (relativePath: string): boolean => {
+  if (!relativePath || isAbsolute(relativePath)) return false;
+  const normalized = relativePath.replace(/\\/g, '/');
+  return !normalized.split('/').some((part) => part === '..' || part === '');
+};
+
+const rewriteCanvasFilePaths = (
+  value: unknown,
+  mapper: (filePath: string) => string,
+): unknown => {
+  if (Array.isArray(value)) {
+    return value.map((item) => rewriteCanvasFilePaths(item, mapper));
+  }
+  if (!value || typeof value !== 'object') return value;
+
+  const out: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (key === 'filePath' && typeof item === 'string') {
+      out[key] = mapper(item);
+    } else {
+      out[key] = rewriteCanvasFilePaths(item, mapper);
+    }
+  }
+  return out;
+};
+
+const collectWorkspaceFiles = async (workspaceDir: string): Promise<WorkspaceExportFile[]> => {
+  const files: WorkspaceExportFile[] = [];
+
+  const walk = async (dir: string): Promise<void> => {
+    let entries: Dirent[];
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return;
+      throw err;
+    }
+
+    for (const entry of entries) {
+      if (entry.name === 'canvas.json' || entry.name === 'canvas.json.bak' || entry.name === 'canvas.json.tmp') {
+        continue;
+      }
+      const fullPath = join(dir, entry.name);
+      const relativePath = toPortableRelativePath(fullPath, workspaceDir);
+      if (!relativePath || !isSafeRelativePath(relativePath)) continue;
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      const buffer = await fs.readFile(fullPath);
+      files.push({ relativePath, encoding: 'base64', content: buffer.toString('base64') });
+    }
+  };
+
+  await walk(workspaceDir);
+  files.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+  return files;
+};
+
+const readWorkspaceCanvasForExport = async (workspaceId: string): Promise<unknown> => {
+  await migrateIfNeeded(workspaceId);
+  await ensureWorkspaceDir(workspaceId);
+  const filePath = getFilePath(workspaceId);
+  const readResult = await readCanvasJsonWithRecovery(filePath);
+  if (readResult.kind === 'missing') return null;
+  if (readResult.kind === 'unrecoverable') throw readResult.err;
+  const data = readResult.data as CanvasSaveData;
+  const dirty = await migrateNotePaths(workspaceId, data);
+  if (dirty || readResult.recoveredFromBackup) {
+    await atomicWriteCanvasJson(filePath, JSON.stringify(data, null, 2));
+  }
+  return data;
+};
+
+const createUniqueImportedWorkspaceId = async (): Promise<string> => {
+  for (let i = 0; i < 100; i += 1) {
+    const id = `ws-imported-${Date.now()}${i ? `-${i}` : ''}`;
+    try {
+      await fs.access(getWorkspaceDir(id));
+    } catch {
+      return id;
+    }
+  }
+  return `ws-imported-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+};
+
+const parseWorkspaceExportPayload = (raw: string): WorkspaceExportPayload => {
+  const parsed = JSON.parse(raw) as Partial<WorkspaceExportPayload>;
+  if (parsed.format !== EXPORT_FORMAT) {
+    throw new Error('Selected file is not a Pulse Canvas workspace export.');
+  }
+  if (parsed.version !== EXPORT_VERSION) {
+    throw new Error(`Unsupported Pulse Canvas export version: ${String(parsed.version)}`);
+  }
+  if (!parsed.workspace || typeof parsed.workspace.name !== 'string') {
+    throw new Error('Workspace export is missing workspace metadata.');
+  }
+  if (!Array.isArray(parsed.files)) {
+    throw new Error('Workspace export is missing file payloads.');
+  }
+  for (const file of parsed.files) {
+    if (!file || typeof file.relativePath !== 'string' || file.encoding !== 'base64' || typeof file.content !== 'string') {
+      throw new Error('Workspace export contains an invalid file entry.');
+    }
+    if (!isSafeRelativePath(file.relativePath)) {
+      throw new Error(`Workspace export contains an unsafe file path: ${file.relativePath}`);
+    }
+  }
+  return parsed as WorkspaceExportPayload;
+};
 
 /** Manifest stays as a flat file; all other workspaces live in subdirectories. */
 const getFilePath = (id: string): string => {
@@ -763,6 +918,125 @@ export const setupCanvasStoreIpc = () => {
       return { ok: true, ids: [...new Set([...ids, ...flatIds])] };
     } catch (err) {
       return { ok: false, error: String(err) };
+    }
+  });
+
+  ipcMain.handle(
+    'canvas:exportWorkspace',
+    async (_event, payload: { id: string; name: string }) => {
+      try {
+        if (!payload.id || payload.id === MANIFEST_ID) {
+          return { ok: false, error: 'Invalid workspace id.' };
+        }
+
+        const workspaceDir = getWorkspaceDir(payload.id);
+        const canvas = await readWorkspaceCanvasForExport(payload.id);
+        const portableCanvas = rewriteCanvasFilePaths(canvas, (filePath) => {
+          const relativePath = toPortableRelativePath(filePath, workspaceDir);
+          return relativePath ? portableUrlForRelativePath(relativePath) : filePath;
+        });
+        const files = await collectWorkspaceFiles(workspaceDir);
+
+        const win = BrowserWindow.getFocusedWindow();
+        const result = win
+          ? await dialog.showSaveDialog(win, {
+            title: 'Export Workspace',
+            defaultPath: `${sanitizeFileName(payload.name)}.pulsecanvas.json`,
+            filters: [
+              { name: 'Pulse Canvas Workspace', extensions: ['pulsecanvas.json', 'json'] },
+              { name: 'All Files', extensions: ['*'] },
+            ],
+          })
+          : await dialog.showSaveDialog({
+            title: 'Export Workspace',
+            defaultPath: `${sanitizeFileName(payload.name)}.pulsecanvas.json`,
+            filters: [
+              { name: 'Pulse Canvas Workspace', extensions: ['pulsecanvas.json', 'json'] },
+              { name: 'All Files', extensions: ['*'] },
+            ],
+          });
+        if (result.canceled || !result.filePath) {
+          return { ok: false, canceled: true };
+        }
+
+        const exportPayload: WorkspaceExportPayload = {
+          format: EXPORT_FORMAT,
+          version: EXPORT_VERSION,
+          exportedAt: new Date().toISOString(),
+          workspace: { id: payload.id, name: payload.name },
+          canvas: portableCanvas,
+          files,
+        };
+        await fs.writeFile(result.filePath, JSON.stringify(exportPayload, null, 2), 'utf-8');
+        return { ok: true, filePath: result.filePath, fileCount: files.length };
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) };
+      }
+    }
+  );
+
+  ipcMain.handle('canvas:importWorkspace', async () => {
+    try {
+      const win = BrowserWindow.getFocusedWindow();
+      const result = win
+        ? await dialog.showOpenDialog(win, {
+          title: 'Import Workspace',
+          filters: [
+            { name: 'Pulse Canvas Workspace', extensions: ['pulsecanvas.json', 'json'] },
+            { name: 'All Files', extensions: ['*'] },
+          ],
+          properties: ['openFile'],
+        })
+        : await dialog.showOpenDialog({
+          title: 'Import Workspace',
+          filters: [
+            { name: 'Pulse Canvas Workspace', extensions: ['pulsecanvas.json', 'json'] },
+            { name: 'All Files', extensions: ['*'] },
+          ],
+          properties: ['openFile'],
+        });
+      if (result.canceled || result.filePaths.length === 0) {
+        return { ok: false, canceled: true };
+      }
+
+      const raw = await fs.readFile(result.filePaths[0], 'utf-8');
+      const imported = parseWorkspaceExportPayload(raw);
+      const workspaceId = await createUniqueImportedWorkspaceId();
+      const workspaceName = imported.workspace.name.trim() || 'Imported Workspace';
+      const workspaceDir = getWorkspaceDir(workspaceId);
+      await fs.mkdir(workspaceDir, { recursive: true });
+
+      for (const file of imported.files) {
+        const targetPath = resolve(workspaceDir, file.relativePath);
+        const rel = relative(workspaceDir, targetPath);
+        if (rel.startsWith('..') || isAbsolute(rel)) {
+          throw new Error(`Workspace export contains an unsafe file path: ${file.relativePath}`);
+        }
+        await fs.mkdir(dirname(targetPath), { recursive: true });
+        await fs.writeFile(targetPath, Buffer.from(file.content, 'base64'));
+      }
+
+      const restoredCanvas = rewriteCanvasFilePaths(imported.canvas, (filePath) => {
+        const relativePath = relativePathFromPortableUrl(filePath);
+        if (!relativePath) return filePath;
+        if (!isSafeRelativePath(relativePath)) return filePath;
+        return join(workspaceDir, relativePath);
+      });
+      await ensureWorkspaceDir(workspaceId);
+      await atomicWriteCanvasJson(getFilePath(workspaceId), JSON.stringify(restoredCanvas, null, 2));
+
+      const restoredData = restoredCanvas as CanvasSaveData;
+      if (Array.isArray(restoredData.nodes)) {
+        knownNodeIds.set(
+          workspaceId,
+          new Set(restoredData.nodes.map((n) => n.id).filter((id): id is string => Boolean(id))),
+        );
+        lastSnapshot.set(workspaceId, nodesToMap(restoredData.nodes));
+      }
+
+      return { ok: true, workspaceId, workspaceName, fileCount: imported.files.length };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
     }
   });
 

--- a/apps/canvas-workspace/src/preload/index.ts
+++ b/apps/canvas-workspace/src/preload/index.ts
@@ -67,6 +67,12 @@ contextBridge.exposeInMainWorld("canvasWorkspace", {
     getDir: (id: string) =>
       ipcRenderer.invoke("canvas:getDir", { id }),
 
+    exportWorkspace: (id: string, name: string) =>
+      ipcRenderer.invoke("canvas:exportWorkspace", { id, name }),
+
+    importWorkspace: () =>
+      ipcRenderer.invoke("canvas:importWorkspace"),
+
     watchWorkspace: (workspaceId: string) =>
       ipcRenderer.invoke("canvas:watchWorkspace", { workspaceId }),
 

--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -67,6 +67,7 @@ const AppContent = () => {
     renameWorkspace,
     deleteWorkspace,
     setRootFolder,
+    importWorkspace,
     createFolder,
     renameFolder,
     deleteFolder,
@@ -165,6 +166,82 @@ const AppContent = () => {
       autoCloseMs: 2400,
     });
   }, [workspaces, confirm, notify, updateToast, deleteWorkspace]);
+
+
+  const handleExportWorkspace = useCallback(async (id: string) => {
+    const workspace = workspaces.find((item) => item.id === id);
+    const api = window.canvasWorkspace?.store;
+    if (!workspace || !api) return;
+
+    const toastId = notify({
+      tone: 'loading',
+      title: `Exporting ${workspace.name}...`,
+      description: 'Packaging canvas state and workspace files.',
+    });
+
+    const result = await api.exportWorkspace(workspace.id, workspace.name);
+    if (!result.ok) {
+      if (result.canceled) {
+        updateToast(toastId, {
+          tone: 'info',
+          title: 'Export canceled',
+          description: workspace.name,
+          autoCloseMs: 1800,
+        });
+        return;
+      }
+      updateToast(toastId, {
+        tone: 'error',
+        title: 'Workspace export failed',
+        description: result.error ?? 'The workspace could not be exported.',
+        autoCloseMs: 4200,
+      });
+      return;
+    }
+
+    updateToast(toastId, {
+      tone: 'success',
+      title: 'Workspace exported',
+      description: result.filePath ?? `${workspace.name} (${result.fileCount ?? 0} files)`,
+      autoCloseMs: 3600,
+    });
+  }, [workspaces, notify, updateToast]);
+
+  const handleImportWorkspace = useCallback(async () => {
+    const toastId = notify({
+      tone: 'loading',
+      title: 'Importing workspace...',
+      description: 'Reading Pulse Canvas export file.',
+    });
+
+    const result = await importWorkspace();
+    if (!result.ok) {
+      if (result.canceled) {
+        updateToast(toastId, {
+          tone: 'info',
+          title: 'Import canceled',
+          description: 'No workspace was imported.',
+          autoCloseMs: 1800,
+        });
+        return;
+      }
+      updateToast(toastId, {
+        tone: 'error',
+        title: 'Workspace import failed',
+        description: result.error ?? 'The workspace export could not be imported.',
+        autoCloseMs: 4200,
+      });
+      return;
+    }
+
+    updateToast(toastId, {
+      tone: 'success',
+      title: 'Workspace imported',
+      description: `${result.workspace?.name ?? 'Imported Workspace'} (${result.fileCount ?? 0} files)`,
+      autoCloseMs: 3000,
+    });
+    setLocation(ROUTE_CANVAS);
+  }, [importWorkspace, notify, updateToast, setLocation]);
 
   const handleCreateFolder = useCallback((name: string) => {
     const trimmed = name.trim() || 'Untitled Folder';
@@ -303,6 +380,8 @@ const AppContent = () => {
           onCreate={handleCreateWorkspace}
           onRename={handleRenameWorkspace}
           onDelete={handleDeleteWorkspace}
+          onExport={handleExportWorkspace}
+          onImport={handleImportWorkspace}
           onSetRootFolder={setRootFolder}
           onCreateFolder={handleCreateFolder}
           onRenameFolder={handleRenameFolder}

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/SidebarHeader.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/SidebarHeader.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { PlusIcon, AvatarIcon, WorkspaceIcon, FolderIcon } from '../icons';
+import { PlusIcon, AvatarIcon, WorkspaceIcon, FolderIcon, ImportIcon } from '../icons';
 
 export const SidebarToggleIcon = ({ size = 14 }: { size?: number }) => (
   <svg width={size} height={size} viewBox="0 0 16 16" fill="none">
@@ -17,6 +17,7 @@ interface SidebarHeaderProps {
   addMenuRef: React.RefObject<HTMLDivElement>;
   onNewWorkspace: () => void;
   onNewFolder: () => void;
+  onImportWorkspace: () => void;
 }
 
 export const SidebarHeader = ({
@@ -28,6 +29,7 @@ export const SidebarHeader = ({
   addMenuRef,
   onNewWorkspace,
   onNewFolder,
+  onImportWorkspace,
 }: SidebarHeaderProps) => (
   <>
     <div className="sidebar-brand-header">
@@ -87,6 +89,13 @@ export const SidebarHeader = ({
             >
               <FolderIcon size={14} />
               <span>New Folder</span>
+            </button>
+            <button
+              className="sidebar-add-menu-item"
+              onClick={onImportWorkspace}
+            >
+              <ImportIcon size={14} />
+              <span>Import Workspace</span>
             </button>
           </div>
         )}

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/WorkspaceItem.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/WorkspaceItem.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 import type { WorkspaceEntry } from '../../hooks/useWorkspaces';
-import { CloseIcon, WorkspaceIcon } from '../icons';
+import { CloseIcon, ExportIcon, WorkspaceIcon } from '../icons';
 
 export interface WorkspaceItemProps {
   ws: WorkspaceEntry;
@@ -16,6 +16,7 @@ export interface WorkspaceItemProps {
   onRenameCommit: () => void;
   onRenameCancel: () => void;
   onDelete: (id: string) => void;
+  onExport: (id: string) => void;
   onDragStart: (e: React.DragEvent, id: string) => void;
   onDragEnd: (e: React.DragEvent) => void;
 }
@@ -34,6 +35,7 @@ export const WorkspaceItem = ({
   onRenameCommit,
   onRenameCancel,
   onDelete,
+  onExport,
   onDragStart,
   onDragEnd,
 }: WorkspaceItemProps) => (
@@ -67,6 +69,11 @@ export const WorkspaceItem = ({
             <WorkspaceIcon size={14} />
           </span>
           <span className="sidebar-item-name">{ws.name}</span>
+        </button>
+      )}
+      {!isRenaming && (
+        <button className="sidebar-item-export" onClick={() => onExport(ws.id)} title="Export workspace">
+          <ExportIcon size={12} strokeWidth={1.5} />
         </button>
       )}
       {!isOnlyWorkspace && !isRenaming && (

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
@@ -209,7 +209,8 @@
   min-width: 0;
 }
 
-.sidebar-item-delete {
+.sidebar-item-delete,
+.sidebar-item-export {
   flex-shrink: 0;
   width: 22px;
   height: 22px;
@@ -223,14 +224,23 @@
   color: var(--text-muted);
   transition: background 0.1s, color 0.1s;
   position: absolute;
+}
+
+.sidebar-item-delete {
   right: 6px;
 }
 
-.sidebar-item-row:hover .sidebar-item-delete {
+.sidebar-item-export {
+  right: 30px;
+}
+
+.sidebar-item-row:hover .sidebar-item-delete,
+.sidebar-item-row:hover .sidebar-item-export {
   display: flex;
 }
 
-.sidebar-item-delete:hover {
+.sidebar-item-delete:hover,
+.sidebar-item-export:hover {
   background: rgba(0, 0, 0, 0.06);
   color: var(--text-secondary);
 }

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
@@ -23,6 +23,8 @@ interface Props {
   onCreate: (name: string) => void;
   onRename: (id: string, name: string) => void;
   onDelete: (id: string) => void;
+  onExport: (id: string) => void;
+  onImport: () => void;
   onSetRootFolder: (id: string, folderPath: string) => void;
   onCreateFolder: (name: string) => void;
   onRenameFolder: (id: string, name: string) => void;
@@ -44,7 +46,7 @@ const FOLDER_DRAG = 'application/x-folder-id';
 
 export const Sidebar = ({
   collapsed, onToggle, workspaces, folders, activeId, onSelect, onCreate, onRename, onDelete,
-  onCreateFolder, onRenameFolder, onDeleteFolder, onToggleFolder, onMoveWorkspace, onReorderFolder,
+  onExport, onImport, onCreateFolder, onRenameFolder, onDeleteFolder, onToggleFolder, onMoveWorkspace, onReorderFolder,
   activeNodes = [], onNodeFocus, onNodeDelete, onNodeRename, activeView, onEnterChat,
 }: Props) => {
   const { confirm, notify } = useAppShell();
@@ -237,7 +239,7 @@ export const Sidebar = ({
       renameValue={renameValue} renameInputRef={renameInputRef}
       onSelect={onSelect} onStartRename={startRename} onRenameChange={setRenameValue}
       onRenameCommit={commitRename} onRenameCancel={() => setRenamingId(null)}
-      onDelete={onDelete} onDragStart={handleWsDragStart} onDragEnd={handleWsDragEnd}
+      onDelete={onDelete} onExport={onExport} onDragStart={handleWsDragStart} onDragEnd={handleWsDragEnd}
     />
   );
 
@@ -251,6 +253,7 @@ export const Sidebar = ({
             addMenuRef={addMenuRef}
             onNewWorkspace={() => { setShowAddMenu(false); setInlineCreate('workspace'); setInlineCreateValue(''); }}
             onNewFolder={() => { setShowAddMenu(false); setInlineCreate('folder'); setInlineCreateValue(''); }}
+            onImportWorkspace={() => { setShowAddMenu(false); onImport(); }}
           />
           <WorkspaceList
             folders={folders} workspaces={workspaces}

--- a/apps/canvas-workspace/src/renderer/src/components/icons/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/icons/index.tsx
@@ -68,6 +68,25 @@ export const WorkspaceIcon = ({ size = 14, className, strokeWidth = 1.3 }: IconP
   </svg>
 );
 
+
+/** Arrow leaving a tray — export current workspace. */
+export const ExportIcon = ({ size = 14, className, strokeWidth = 1.3 }: IconProps) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className}>
+    <path d="M8 10V3" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" />
+    <path d="M5.5 5.5L8 3l2.5 2.5" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M3 9v3.5A1.5 1.5 0 004.5 14h7a1.5 1.5 0 001.5-1.5V9" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" />
+  </svg>
+);
+
+/** Arrow entering a tray — import a workspace export. */
+export const ImportIcon = ({ size = 14, className, strokeWidth = 1.3 }: IconProps) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className}>
+    <path d="M8 3v7" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" />
+    <path d="M5.5 7.5L8 10l2.5-2.5" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M3 9v3.5A1.5 1.5 0 004.5 14h7a1.5 1.5 0 001.5-1.5V9" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" />
+  </svg>
+);
+
 interface FolderIconProps extends IconProps {
   open?: boolean;
 }

--- a/apps/canvas-workspace/src/renderer/src/hooks/useWorkspaces.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useWorkspaces.ts
@@ -18,6 +18,14 @@ export interface WorkspaceDeleteResult {
   error?: string;
 }
 
+export interface WorkspaceImportResult {
+  ok: boolean;
+  canceled?: boolean;
+  workspace?: WorkspaceEntry;
+  fileCount?: number;
+  error?: string;
+}
+
 interface WorkspaceManifest {
   workspaces: WorkspaceEntry[];
   folders?: FolderEntry[];
@@ -211,6 +219,32 @@ export const useWorkspaces = () => {
     [saveManifest, workspaces]
   );
 
+
+  const importWorkspace = useCallback(async (): Promise<WorkspaceImportResult> => {
+    const api = window.canvasWorkspace?.store;
+    if (!api) return { ok: false, error: 'Canvas store API is unavailable.' };
+
+    const result = await api.importWorkspace();
+    if (!result.ok) {
+      return { ok: false, canceled: result.canceled, error: result.error };
+    }
+    if (!result.workspaceId || !result.workspaceName) {
+      return { ok: false, error: 'Import completed without workspace metadata.' };
+    }
+
+    const entry: WorkspaceEntry = {
+      id: result.workspaceId,
+      name: result.workspaceName,
+    };
+    setWorkspaces((prev) => {
+      const next = [...prev, entry];
+      saveManifest(next, entry.id);
+      return next;
+    });
+    setActiveId(entry.id);
+    return { ok: true, workspace: entry, fileCount: result.fileCount };
+  }, [saveManifest]);
+
   /** Move a workspace into a folder (or to root if folderId is undefined) */
   const moveWorkspace = useCallback(
     (workspaceId: string, folderId: string | undefined) => {
@@ -256,6 +290,7 @@ export const useWorkspaces = () => {
     renameWorkspace,
     deleteWorkspace,
     setRootFolder,
+    importWorkspace,
     createFolder,
     renameFolder,
     deleteFolder,

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -417,6 +417,18 @@ export interface CanvasWorkspaceApi {
     list: () => Promise<{ ok: boolean; ids?: string[]; error?: string }>;
     delete: (id: string) => Promise<{ ok: boolean; error?: string }>;
     getDir: (id: string) => Promise<{ ok: boolean; dir?: string; error?: string }>;
+    exportWorkspace: (
+      id: string,
+      name: string
+    ) => Promise<{ ok: boolean; canceled?: boolean; filePath?: string; fileCount?: number; error?: string }>;
+    importWorkspace: () => Promise<{
+      ok: boolean;
+      canceled?: boolean;
+      workspaceId?: string;
+      workspaceName?: string;
+      fileCount?: number;
+      error?: string;
+    }>;
     watchWorkspace: (workspaceId: string) => Promise<{ ok: boolean }>;
     onExternalUpdate: (
       callback: (event: {


### PR DESCRIPTION
Add single-workspace import/export support for Pulse Canvas.

- Export a workspace as a portable `.pulsecanvas.json` package with canvas state and workspace files
- Import exported packages into a new workspace and restore portable file references to local paths
- Add preload/type bridge methods and sidebar UI actions for import/export

Validation:
- `pnpm --filter canvas-workspace typecheck` currently blocked by existing workspace package resolution: `pulse-coder-engine/built-in`
- Attempted `pnpm --filter pulse-coder-engine build`; DTS build blocked by existing missing `pulse-coder-orchestrator` declarations
