### PR TITLE
feat(canvas-workspace): redesign agent panel

### DIFF
--- a/apps/canvas-workspace/src/main/canvas-agent-ipc.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent-ipc.ts
@@ -50,7 +50,17 @@ export function setupCanvasAgentIpc(): void {
     'canvas-agent:chat',
     async (
       event,
-      payload: { workspaceId: string; message: string; mentionedWorkspaceIds?: string[] },
+      payload: {
+        workspaceId: string;
+        message: string;
+        mentionedWorkspaceIds?: string[];
+        requestContext?: {
+          executionMode?: 'auto' | 'ask';
+          scope?: 'current_canvas' | 'selected_nodes';
+          selectedNodes?: Array<{ id: string; title: string; type: string }>;
+          quickAction?: string;
+        };
+      },
     ) => {
       const sessionId = randomUUID();
       const sender = event.sender;
@@ -83,6 +93,7 @@ export function setupCanvasAgentIpc(): void {
                 sender.send(`canvas-agent:clarify-request:${sessionId}`, req);
               }
             },
+            payload.requestContext,
           );
           if (!sender.isDestroyed()) {
             sender.send(`canvas-agent:chat-complete:${sessionId}`, result);

--- a/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
@@ -19,6 +19,13 @@ import { createCanvasTools } from './tools';
 import { SessionStore } from './session-store';
 import type { CanvasAgentConfig, CanvasAgentMessage, WorkspaceSummary } from './types';
 
+interface CanvasAgentRequestContext {
+  executionMode?: 'auto' | 'ask';
+  scope?: 'current_canvas' | 'selected_nodes';
+  selectedNodes?: Array<{ id: string; title: string; type: string }>;
+  quickAction?: string;
+}
+
 // ─── System prompt ─────────────────────────────────────────────────
 
 const BASE_SYSTEM_PROMPT = `You are the Canvas Agent — the AI Copilot for this workspace.
@@ -103,10 +110,47 @@ Use these alongside canvas_* tools for full workspace control.
 function buildSystemPrompt(
   summary: WorkspaceSummary | null,
   mentionedCanvases: Array<{ id: string; name: string }> = [],
+  requestContext?: CanvasAgentRequestContext,
 ): string {
-  const base = summary
+  let base = summary
     ? BASE_SYSTEM_PROMPT + '\n## Current Canvas\n' + formatSummaryForPrompt(summary)
     : BASE_SYSTEM_PROMPT + '\n## Current Canvas\n(empty workspace — no nodes yet)\n';
+
+  if (requestContext) {
+    const mode = requestContext.executionMode ?? 'auto';
+    const scope = requestContext.scope ?? 'current_canvas';
+    const selectedNodes = requestContext.selectedNodes ?? [];
+    const lines: string[] = [
+      '',
+      '## Current Request Context',
+      `- Execution mode: ${mode}`,
+      `- Context scope: ${scope}`,
+    ];
+
+    if (requestContext.quickAction) {
+      lines.push(`- Suggested action the user invoked: ${requestContext.quickAction}`);
+    }
+
+    if (selectedNodes.length > 0) {
+      lines.push('- Selected canvas nodes:');
+      for (const node of selectedNodes) {
+        lines.push(`  - ${node.title} — nodeId: \`${node.id}\`, type: \`${node.type}\``);
+      }
+      lines.push('When the user says "these nodes", "the selection", or similar, use the selected canvas nodes above.');
+    }
+
+    if (mode === 'auto') {
+      lines.push(
+        'Auto mode policy: when the user intent is clear and non-destructive, you may directly use canvas tools to read context and create or update nodes. Keep the visible response concise and avoid exposing raw node IDs, file paths, or tool signatures unless the user asks.',
+      );
+    } else {
+      lines.push(
+        'Ask mode policy: you may read context, but before creating, updating, deleting, or moving canvas nodes, ask the user for confirmation.',
+      );
+    }
+
+    base += lines.join('\n') + '\n';
+  }
 
   if (mentionedCanvases.length === 0) return base;
 
@@ -210,6 +254,7 @@ export class CanvasAgent {
     onToolResult?: (data: { name: string; result: string }) => void,
     mentionedWorkspaceIds?: string[],
     onClarificationRequest?: (req: CanvasClarificationRequest) => void,
+    requestContext?: CanvasAgentRequestContext,
   ): Promise<string> {
     // Refresh workspace summary for system prompt
     const summary = await buildWorkspaceSummary(this.config.workspaceId);
@@ -226,7 +271,7 @@ export class CanvasAgent {
       mentionedCanvases = await resolveWorkspaceNames(unique);
     }
 
-    const systemPrompt = buildSystemPrompt(summary, mentionedCanvases);
+    const systemPrompt = buildSystemPrompt(summary, mentionedCanvases, requestContext);
 
     // Add user message
     this.messages.push({ role: 'user', content: message } as ModelMessage);

--- a/apps/canvas-workspace/src/main/canvas-agent/service.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/service.ts
@@ -56,6 +56,12 @@ export class CanvasAgentService {
     onToolResult?: (data: { name: string; result: string }) => void,
     mentionedWorkspaceIds?: string[],
     onClarificationRequest?: (req: CanvasClarificationRequest) => void,
+    requestContext?: {
+      executionMode?: 'auto' | 'ask';
+      scope?: 'current_canvas' | 'selected_nodes';
+      selectedNodes?: Array<{ id: string; title: string; type: string }>;
+      quickAction?: string;
+    },
   ): Promise<ChatResponse> {
     try {
       await this.activate(workspaceId);
@@ -67,6 +73,7 @@ export class CanvasAgentService {
         onToolResult,
         mentionedWorkspaceIds,
         onClarificationRequest,
+        requestContext,
       );
       return { ok: true, response };
     } catch (err) {

--- a/apps/canvas-workspace/src/preload/index.ts
+++ b/apps/canvas-workspace/src/preload/index.ts
@@ -164,8 +164,18 @@ contextBridge.exposeInMainWorld("canvasWorkspace", {
   },
 
   agent: {
-    chat: (workspaceId: string, message: string, mentionedWorkspaceIds?: string[]) =>
-      ipcRenderer.invoke("canvas-agent:chat", { workspaceId, message, mentionedWorkspaceIds }),
+    chat: (
+      workspaceId: string,
+      message: string,
+      mentionedWorkspaceIds?: string[],
+      requestContext?: {
+        executionMode?: 'auto' | 'ask';
+        scope?: 'current_canvas' | 'selected_nodes';
+        selectedNodes?: Array<{ id: string; title: string; type: string }>;
+        quickAction?: string;
+      },
+    ) =>
+      ipcRenderer.invoke("canvas-agent:chat", { workspaceId, message, mentionedWorkspaceIds, requestContext }),
 
     onTextDelta: (sessionId: string, callback: (delta: string) => void) => {
       const channel = `canvas-agent:text-delta:${sessionId}`;

--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -34,6 +34,7 @@ const AppContent = () => {
   const [chatPanelOpen, setChatPanelOpen] = useState(false);
   const [chatWidth, setChatWidth] = useState(DEFAULT_CHAT_WIDTH);
   const [allNodes, setAllNodes] = useState<Record<string, CanvasNode[]>>({});
+  const [selectedNodeIdsByWorkspace, setSelectedNodeIdsByWorkspace] = useState<Record<string, string[]>>({});
   const [focusNodeId, setFocusNodeId] = useState<string | undefined>();
   const [deleteNodeId, setDeleteNodeId] = useState<string | undefined>();
   const [renameNodeRequest, setRenameNodeRequest] = useState<CanvasNodeRenameRequest | undefined>();
@@ -43,6 +44,19 @@ const AppContent = () => {
     setAllNodes((prev) => {
       if (prev[canvasId] === nodes) return prev;
       return { ...prev, [canvasId]: nodes };
+    });
+  }, []);
+
+  const handleSelectionChange = useCallback((canvasId: string, selectedNodeIds: string[]) => {
+    setSelectedNodeIdsByWorkspace((prev) => {
+      const existing = prev[canvasId] ?? [];
+      if (
+        existing.length === selectedNodeIds.length
+        && existing.every((id, index) => id === selectedNodeIds[index])
+      ) {
+        return prev;
+      }
+      return { ...prev, [canvasId]: selectedNodeIds };
     });
   }, []);
 
@@ -329,6 +343,7 @@ const AppContent = () => {
                   rootFolder={ws.rootFolder}
                   hidden={ws.id !== activeId}
                   onNodesChange={handleNodesChange}
+                  onSelectionChange={handleSelectionChange}
                   focusNodeId={ws.id === activeId ? focusNodeId : undefined}
                   onFocusComplete={handleFocusComplete}
                   deleteNodeId={ws.id === activeId ? deleteNodeId : undefined}
@@ -350,6 +365,7 @@ const AppContent = () => {
                   workspaceId={ws.id}
                   allWorkspaces={workspaces}
                   nodes={allNodes[ws.id] || []}
+                  selectedNodeIds={selectedNodeIdsByWorkspace[ws.id] || []}
                   rootFolder={ws.rootFolder}
                   onClose={() => setChatPanelOpen(false)}
                   onResizeStart={handleResizeStart}

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -27,6 +27,7 @@ interface CanvasProps {
   rootFolder?: string;
   hidden?: boolean;
   onNodesChange?: (canvasId: string, nodes: CanvasNode[]) => void;
+  onSelectionChange?: (canvasId: string, selectedNodeIds: string[]) => void;
   focusNodeId?: string;
   onFocusComplete?: () => void;
   deleteNodeId?: string;
@@ -43,6 +44,7 @@ export const Canvas = ({
   rootFolder,
   hidden,
   onNodesChange,
+  onSelectionChange,
   focusNodeId,
   onFocusComplete,
   deleteNodeId,
@@ -149,6 +151,13 @@ export const Canvas = ({
     if (!loaded) return;
     onNodesChange?.(canvasId, nodes);
   }, [canvasId, nodes, loaded, onNodesChange]);
+
+  // Report selection so adjacent UI, such as the Agent panel, can scope work
+  // to the same nodes the user has visually selected.
+  useEffect(() => {
+    if (!loaded) return;
+    onSelectionChange?.(canvasId, selectedNodeIds);
+  }, [canvasId, loaded, onSelectionChange, selectedNodeIds]);
 
   // Handle external focus request (e.g. from sidebar layers panel)
   useEffect(() => {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatEmptyState.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatEmptyState.tsx
@@ -3,59 +3,68 @@ import type { QuickAction } from './types';
 
 function QuickActionIcon({ action }: { action: QuickAction }) {
   switch (action.key) {
-    case 'overview':
+    case 'summarize_canvas':
       return (
         <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-          <circle cx="7" cy="7" r="5.5" stroke="currentColor" strokeWidth="1.3" />
-          <path d="M11 11l3 3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+          <path d="M2.5 4h11M2.5 8h7.5M2.5 12h9" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" />
         </svg>
       );
-    case 'note':
+    case 'analyze_relations':
       return (
         <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-          <rect x="2" y="2" width="12" height="12" rx="2" stroke="currentColor" strokeWidth="1.3" />
-          <path d="M6 8h4M8 6v4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+          <circle cx="4" cy="8" r="1.7" stroke="currentColor" strokeWidth="1.25" />
+          <circle cx="12" cy="4" r="1.7" stroke="currentColor" strokeWidth="1.25" />
+          <circle cx="12" cy="12" r="1.7" stroke="currentColor" strokeWidth="1.25" />
+          <path d="M5.6 7.4l4.8-2.6M5.6 8.6l4.8 2.6" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
         </svg>
       );
-    case 'summarize':
+    case 'create_mindmap':
       return (
         <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-          <path d="M2 4h12M2 8h8M2 12h10" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+          <circle cx="4" cy="8" r="1.6" stroke="currentColor" strokeWidth="1.25" />
+          <circle cx="12" cy="3.8" r="1.4" stroke="currentColor" strokeWidth="1.25" />
+          <circle cx="12" cy="8" r="1.4" stroke="currentColor" strokeWidth="1.25" />
+          <circle cx="12" cy="12.2" r="1.4" stroke="currentColor" strokeWidth="1.25" />
+          <path d="M5.5 8l5-4M5.6 8h4.8M5.5 8l5 4" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" />
         </svg>
       );
-    case 'command':
+    case 'organize_selection':
     default:
       return (
         <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-          <path d="M4 6l2.5 2L4 10M8 10h4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
-          <rect x="1.5" y="2" width="13" height="12" rx="2" stroke="currentColor" strokeWidth="1.3" />
+          <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.25" />
+          <path d="M5 8.2l2 2 4-4.4" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" strokeLinejoin="round" />
         </svg>
       );
   }
 }
 
 interface ChatEmptyStateProps {
-  onQuickAction: (prompt: string) => void;
+  selectedCount?: number;
+  onQuickAction: (prompt: string, quickAction?: string) => void;
 }
 
-export const ChatEmptyState = ({ onQuickAction }: ChatEmptyStateProps) => (
+export const ChatEmptyState = ({ selectedCount = 0, onQuickAction }: ChatEmptyStateProps) => (
   <div className="chat-empty-state">
     <div className="chat-empty-icon">
-      <svg width="32" height="32" viewBox="0 0 32 32" fill="none">
-        <circle cx="16" cy="12" r="6" stroke="currentColor" strokeWidth="1.5" />
-        <path d="M8 28c0-4.4 3.6-8 8-8s8 3.6 8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-        <circle cx="13.5" cy="11" r="1" fill="currentColor" />
-        <circle cx="18.5" cy="11" r="1" fill="currentColor" />
-        <path d="M13.5 14c0 0 1 1.5 2.5 1.5s2.5-1.5 2.5-1.5" stroke="currentColor" strokeWidth="1" strokeLinecap="round" />
+      <svg width="34" height="34" viewBox="0 0 512 512" fill="none">
+        <rect x="32" y="32" width="448" height="448" rx="96" ry="96" fill="currentColor" opacity="0.06" />
+        <path
+          d="M80 268H188L228 178L260 370L292 148L328 268H432"
+          stroke="currentColor"
+          strokeWidth="22"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
       </svg>
     </div>
-    <div className="chat-empty-greeting">Hi, how can I help?</div>
+    <div className="chat-empty-greeting">想怎么处理这张画布？</div>
     <div className="chat-quick-actions">
-      {QUICK_ACTIONS.map(action => (
+      {QUICK_ACTIONS.filter(action => !action.requiresSelection || selectedCount > 0).map(action => (
         <button
           key={action.key}
           className="chat-quick-action"
-          onClick={() => onQuickAction(action.prompt)}
+          onClick={() => onQuickAction(action.prompt, action.key)}
         >
           <span className="chat-quick-action-icon">
             <QuickActionIcon action={action} />

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatHeader.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatHeader.tsx
@@ -1,7 +1,8 @@
-import { AvatarIcon, CloseIcon, ListLinesIcon, PlusIcon } from '../icons';
+import { CloseIcon, ListLinesIcon, PlusIcon } from '../icons';
 import type { OtherWorkspaceSession } from './types';
 
 interface ChatHeaderProps {
+  title: string;
   sessionMenuOpen: boolean;
   sessionMenuRef: React.RefObject<HTMLDivElement>;
   sessions: Array<{
@@ -16,22 +17,25 @@ interface ChatHeaderProps {
   onNewSession: () => Promise<void>;
   onLoadSession: (sessionId: string, sourceWorkspaceId?: string) => Promise<void>;
   onClose: () => void;
-  onExpand?: () => void;
 }
 
-const ExpandIcon = ({ size = 16 }: { size?: number }) => (
-  <svg width={size} height={size} viewBox="0 0 16 16" fill="none">
-    <path
-      d="M9.5 2.5h4v4M13.5 2.5L9 7M6.5 13.5h-4v-4M2.5 13.5L7 9"
-      stroke="currentColor"
-      strokeWidth="1.4"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </svg>
+const PulseCanvasMark = () => (
+  <span className="chat-panel-brand-mark" aria-hidden="true">
+    <svg width="20" height="20" viewBox="0 0 512 512" fill="none">
+      <rect x="32" y="32" width="448" height="448" rx="96" ry="96" fill="#fff" />
+      <path
+        d="M80 268H188L228 178L260 370L292 148L328 268H432"
+        stroke="currentColor"
+        strokeWidth="22"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  </span>
 );
 
 export const ChatHeader = ({
+  title,
   sessionMenuOpen,
   sessionMenuRef,
   sessions,
@@ -40,13 +44,12 @@ export const ChatHeader = ({
   onNewSession,
   onLoadSession,
   onClose,
-  onExpand,
 }: ChatHeaderProps) => (
   <div className="chat-panel-header">
     <div className="chat-panel-title-wrapper" ref={sessionMenuRef}>
       <button className="chat-panel-title-btn" onClick={() => void onToggleSessionMenu()}>
-        <AvatarIcon size={16} />
-        <span>Pulse Agent</span>
+        <PulseCanvasMark />
+        <span className="chat-panel-title-text">{title}</span>
         <svg className="chat-panel-title-chevron" width="12" height="12" viewBox="0 0 12 12" fill="none">
           <path d="M3 4.5l3 3 3-3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
         </svg>
@@ -55,7 +58,7 @@ export const ChatHeader = ({
         <div className="chat-session-menu">
           <button className="chat-session-menu-new" onClick={() => void onNewSession()}>
             <PlusIcon size={14} strokeWidth={1.3} />
-            <span>New chat</span>
+            <span>New AI chat</span>
           </button>
           {sessions.length > 0 && (
             <>
@@ -76,7 +79,7 @@ export const ChatHeader = ({
                   >
                     <ListLinesIcon size={14} />
                     <span className="chat-session-menu-item-text">
-                      {session.isCurrent ? 'Current chat' : (session.preview || session.date)}
+                      {session.preview || (session.isCurrent ? 'Current chat' : session.date)}
                     </span>
                     <span className="chat-session-menu-item-count">{session.messageCount}</span>
                   </button>
@@ -113,21 +116,12 @@ export const ChatHeader = ({
       <button
         className="chat-panel-action-btn"
         onClick={() => void onNewSession()}
-        title="New chat"
+        title="New AI chat"
+        aria-label="New AI chat"
       >
         <PlusIcon size={16} strokeWidth={1.3} />
       </button>
-      {/* {onExpand && (
-        <button
-          className="chat-panel-action-btn"
-          onClick={onExpand}
-          title="Open full screen"
-          aria-label="Open full screen"
-        >
-          <ExpandIcon size={14} />
-        </button>
-      )} */}
-      <button className="chat-panel-action-btn" onClick={onClose} title="Close panel">
+      <button className="chat-panel-action-btn" onClick={onClose} title="收起面板" aria-label="收起面板">
         <CloseIcon size={16} strokeWidth={1.3} />
       </button>
     </div>

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatInput.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatInput.tsx
@@ -1,8 +1,14 @@
 import type { ClipboardEventHandler, KeyboardEventHandler, ReactNode, RefObject } from 'react';
+import type { CanvasNode } from '../../types';
+import { PlusIcon } from '../icons';
+import { getNodeDisplayLabel } from '../../utils/nodeLabel';
+import { MentionNodeIcon } from './utils/mentions';
 
 interface ChatInputProps {
   loading: boolean;
   input: string;
+  selectedNodes?: CanvasNode[];
+  contextComposer?: boolean;
   editableRef: RefObject<HTMLDivElement>;
   mentionPopup?: ReactNode;
   onInput: () => void;
@@ -15,6 +21,8 @@ interface ChatInputProps {
 export const ChatInput = ({
   loading,
   input,
+  selectedNodes,
+  contextComposer = false,
   editableRef,
   mentionPopup,
   onInput,
@@ -22,55 +30,97 @@ export const ChatInput = ({
   onPaste,
   onSend,
   onAbort,
-}: ChatInputProps) => (
-  <div className="chat-input-container">
-    {mentionPopup}
-    <div className={`chat-input-box${loading ? ' chat-input-box--generating' : ''}`}>
-      <div
-        ref={editableRef}
-        className="chat-input"
-        contentEditable={true}
-        role="textbox"
-        data-placeholder={loading ? 'Generating… you can type your next message' : 'Ask anything...'}
-        onInput={onInput}
-        onKeyDown={onKeyDown}
-        onPaste={onPaste}
-      />
-      <div className="chat-input-footer">
-        <div className="chat-input-footer-left">
-          {loading && (
-            <div className="chat-generating-indicator" aria-live="polite">
-              <div className="chat-loading-dot" />
-              <div className="chat-loading-dot" />
-              <div className="chat-loading-dot" />
-              <span className="chat-generating-label">Generating…</span>
-            </div>
-          )}
-        </div>
-        {loading ? (
-          <button
-            className="chat-send-btn chat-send-btn--stop"
-            onClick={() => void onAbort()}
-            title="Stop generating"
-            aria-label="Stop generating"
-          >
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-              <rect x="3" y="3" width="8" height="8" rx="1.5" fill="currentColor" />
-            </svg>
-          </button>
-        ) : (
-          <button
-            className={`chat-send-btn${input.trim() ? ' chat-send-btn--active' : ''}`}
-            onClick={() => void onSend()}
-            disabled={!input.trim()}
-            title="Send message"
-          >
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-              <path d="M8 12V4M8 4l-3.5 3.5M8 4l3.5 3.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-            </svg>
-          </button>
+}: ChatInputProps) => {
+  const contextNodes = (selectedNodes && selectedNodes.length > 0)
+    ? selectedNodes
+    : [];
+
+  return (
+    <div className="chat-input-container">
+      {mentionPopup}
+      {contextComposer && loading && (
+        <div className="chat-generating-status" aria-live="polite">正在生成，可继续输入</div>
+      )}
+      <div className={`chat-input-box${loading ? ' chat-input-box--generating' : ''}`}>
+        {contextComposer && contextNodes.length > 0 && (
+          <div className="chat-context-chips" aria-label="当前上下文">
+            {contextNodes.map(node => (
+              <span key={node.id} className="chat-context-chip" data-node-type={node.type}>
+                <span className="chat-context-chip-icon">
+                  <MentionNodeIcon nodeType={node.type} size={13} />
+                </span>
+                <span className="chat-context-chip-label">{getNodeDisplayLabel(node)}</span>
+              </span>
+            ))}
+          </div>
         )}
+        <div
+          ref={editableRef}
+          className="chat-input"
+          contentEditable={true}
+          role="textbox"
+          data-placeholder={contextComposer
+            ? (contextNodes.length > 0 ? '问问这些节点…' : '问问当前画布…')
+            : (loading ? 'Generating… you can type your next message' : 'Ask anything...')}
+          onInput={onInput}
+          onKeyDown={onKeyDown}
+          onPaste={onPaste}
+        />
+        <div className="chat-input-footer">
+          <div className="chat-input-footer-left">
+            {contextComposer ? (
+              <button
+                type="button"
+                className="chat-input-icon-btn"
+                title="添加上下文"
+                aria-label="添加上下文"
+                onClick={() => {
+                  editableRef.current?.focus();
+                  document.execCommand('insertText', false, '@');
+                  onInput();
+                }}
+              >
+                <PlusIcon size={18} strokeWidth={1.35} />
+              </button>
+            ) : loading ? (
+              <div className="chat-generating-indicator" aria-live="polite">
+                <div className="chat-loading-dot" />
+                <div className="chat-loading-dot" />
+                <div className="chat-loading-dot" />
+                <span className="chat-generating-label">Generating…</span>
+              </div>
+            ) : null}
+          </div>
+          <div className="chat-input-footer-right">
+            {contextComposer && (
+              <span className="chat-auto-mode" title="Auto: 意图明确时可直接操作画布">Auto</span>
+            )}
+            {loading ? (
+              <button
+                className="chat-send-btn chat-send-btn--stop"
+                onClick={() => void onAbort()}
+                title="Stop generating"
+                aria-label="Stop generating"
+              >
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                  <rect x="3" y="3" width="8" height="8" rx="1.5" fill="currentColor" />
+                </svg>
+              </button>
+            ) : (
+              <button
+                className={`chat-send-btn${input.trim() ? ' chat-send-btn--active' : ''}`}
+                onClick={() => void onSend()}
+                disabled={!input.trim()}
+                title="Send message"
+              >
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                  <path d="M8 12V4M8 4l-3.5 3.5M8 4l3.5 3.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              </button>
+            )}
+          </div>
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
@@ -6,8 +6,8 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  background: #fff;
-  border-left: 1px solid rgba(0, 0, 0, 0.06);
+  background: #fdfcfb;
+  border-left: 1px solid rgba(55, 53, 47, 0.08);
   font-family: var(--font);
   position: relative;
 }
@@ -18,26 +18,30 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 12px;
+  min-height: 58px;
+  padding: 10px 14px 10px 18px;
   flex-shrink: 0;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.04);
+  border-bottom: 1px solid rgba(55, 53, 47, 0.06);
+  background: rgba(253, 252, 251, 0.96);
 }
 
 .chat-panel-title-wrapper {
   position: relative;
+  min-width: 0;
 }
 
 .chat-panel-title-btn {
   display: flex;
   align-items: center;
-  gap: 6px;
-  font-size: 14px;
-  font-weight: 500;
+  gap: 8px;
+  max-width: 280px;
+  font-size: 15px;
+  font-weight: 600;
   color: #37352f;
   border: none;
   background: transparent;
-  border-radius: 4px;
-  padding: 4px 6px;
+  border-radius: 6px;
+  padding: 5px 7px;
   cursor: pointer;
   transition: background 0.1s;
 }
@@ -47,7 +51,29 @@
 }
 
 .chat-panel-title-btn svg {
-  color: #9b9a97;
+  color: inherit;
+}
+
+.chat-panel-brand-mark {
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: #1d1d1f;
+}
+
+.chat-panel-brand-mark svg {
+  display: block;
+  filter: drop-shadow(0 1px 1px rgba(55, 53, 47, 0.08));
+}
+
+.chat-panel-title-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .chat-panel-title-chevron {
@@ -206,49 +232,54 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 32px 24px;
+  align-items: flex-start;
+  justify-content: flex-end;
+  padding: 32px 34px 44px;
   gap: 0;
 }
 
 .chat-empty-icon {
-  width: 56px;
-  height: 56px;
-  border-radius: 50%;
-  background: rgba(55, 53, 47, 0.04);
+  width: 54px;
+  height: 54px;
+  border-radius: 16px;
+  background: #fff;
+  border: 1px solid rgba(55, 53, 47, 0.1);
+  box-shadow: 0 8px 24px rgba(55, 53, 47, 0.06);
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #9b9a97;
-  margin-bottom: 12px;
+  color: #2f2e2a;
+  margin-bottom: 18px;
 }
 
 .chat-empty-greeting {
-  font-size: 16px;
-  font-weight: 500;
+  font-size: 22px;
+  line-height: 1.25;
+  font-weight: 700;
   color: #37352f;
-  margin-bottom: 20px;
+  margin-bottom: 22px;
+  letter-spacing: 0;
 }
 
 .chat-quick-actions {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 6px;
   width: 100%;
-  max-width: 280px;
+  max-width: 310px;
 }
 
 .chat-quick-action {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 8px 12px;
+  gap: 12px;
+  padding: 8px 6px;
   border: none;
   background: transparent;
-  border-radius: 6px;
+  border-radius: 7px;
   cursor: pointer;
-  font-size: 14px;
+  font-size: 15px;
+  font-weight: 500;
   color: #37352f;
   text-align: left;
   transition: background 0.1s;
@@ -262,9 +293,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 20px;
-  height: 20px;
-  color: #9b9a97;
+  width: 22px;
+  height: 22px;
+  color: #73726e;
   flex-shrink: 0;
 }
 
@@ -372,7 +403,7 @@
 
 .chat-input-container {
   position: relative;
-  padding: 8px 12px 12px;
+  padding: 8px 14px 14px;
   flex-shrink: 0;
 }
 
@@ -381,7 +412,7 @@
   border-radius: 10px;
   background: #fff;
   overflow: hidden;
-  transition: border-color 0.15s;
+  transition: border-color 0.15s, box-shadow 0.15s;
 }
 
 .chat-input-box:focus-within {
@@ -424,6 +455,40 @@
   display: flex;
   align-items: center;
   gap: 4px;
+}
+
+.chat-input-footer-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.chat-input-icon-btn {
+  width: 30px;
+  height: 30px;
+  border: none;
+  border-radius: 7px;
+  background: transparent;
+  color: #8a8986;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s;
+}
+
+.chat-input-icon-btn:hover {
+  background: rgba(55, 53, 47, 0.06);
+  color: #37352f;
+}
+
+.chat-auto-mode {
+  font-size: 13px;
+  font-weight: 600;
+  color: #6f6e69;
+  line-height: 1;
+  padding: 4px 2px;
+  user-select: none;
 }
 
 .chat-send-btn {
@@ -491,6 +556,109 @@
 
 .chat-generating-label {
   margin-left: 2px;
+}
+
+.chat-generating-status {
+  margin: 0 4px 6px;
+  color: #8a8986;
+  font-size: 12px;
+  line-height: 1.2;
+}
+
+.chat-context-chips {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 12px 12px 4px;
+  min-height: 28px;
+}
+
+.chat-context-chip {
+  min-width: 0;
+  max-width: 100%;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  padding: 0 11px 0 9px;
+  border-radius: 999px;
+  border: 1px solid rgba(55, 53, 47, 0.12);
+  background: rgba(55, 53, 47, 0.04);
+  color: #595853;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1;
+}
+
+.chat-context-chip-icon {
+  width: 16px;
+  height: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #73726e;
+  flex-shrink: 0;
+}
+
+.chat-context-chip-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-context-chip--count {
+  flex-shrink: 0;
+  padding: 0 10px;
+  color: #73726e;
+}
+
+.chat-panel .chat-input-container {
+  padding: 8px 24px 24px;
+}
+
+.chat-panel .chat-input-box {
+  border-radius: 18px;
+  border-color: rgba(35, 131, 226, 0.78);
+  background: #fff;
+  box-shadow: 0 0 0 2px rgba(35, 131, 226, 0.16), 0 16px 42px rgba(55, 53, 47, 0.08);
+}
+
+.chat-panel .chat-input-box:focus-within {
+  border-color: #2383e2;
+  box-shadow: 0 0 0 3px rgba(35, 131, 226, 0.18), 0 18px 48px rgba(55, 53, 47, 0.1);
+}
+
+.chat-panel .chat-input {
+  padding: 14px 18px 10px;
+  min-height: 42px;
+  max-height: 128px;
+  font-size: 15px;
+}
+
+.chat-panel .chat-input:empty::before {
+  color: #9b9a97;
+}
+
+.chat-panel .chat-input-footer {
+  padding: 6px 14px 12px;
+}
+
+.chat-panel .chat-send-btn {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+}
+
+.chat-panel .chat-send-btn--active,
+.chat-panel .chat-send-btn--stop {
+  background: #2383e2;
+}
+
+.chat-panel .chat-send-btn--active:hover,
+.chat-panel .chat-send-btn--stop:hover {
+  background: #1f76cc;
 }
 
 /* ─── Clarification card ──────────────────────────────────── */

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.tsx
@@ -1,21 +1,23 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { ChatHeader } from './ChatHeader';
 import './ChatPanel.css';
 import { ChatView } from './ChatView';
 import { useChatSessions } from './hooks/useChatSessions';
 import { useChatStream } from './hooks/useChatStream';
 import { useMentions } from './hooks/useMentions';
+import { getNodeDisplayLabel } from '../../utils/nodeLabel';
+import type { AgentRequestContext } from '../../types';
 import type { ChatPanelProps } from './types';
 
 export const ChatPanel = ({
   workspaceId,
   allWorkspaces,
   nodes,
+  selectedNodeIds,
   rootFolder,
   onClose,
   onResizeStart,
   onNodeFocus,
-  onExpand,
 }: ChatPanelProps) => {
   const {
     abort,
@@ -49,6 +51,8 @@ export const ChatPanel = ({
     onMessagesLoaded: replaceMessages,
   });
 
+  const requestContextRef = useRef<AgentRequestContext>();
+
   const {
     clearInput,
     editableRef,
@@ -69,19 +73,53 @@ export const ChatPanel = ({
     nodes,
     rootFolder,
     onSubmit: sendMessage,
+    getRequestContext: () => requestContextRef.current,
   });
 
-  const handleQuickAction = useCallback(async (prompt: string) => {
+  const selectedNodes = useMemo(() => {
+    const ids = new Set(selectedNodeIds ?? []);
+    return (nodes ?? []).filter(node => ids.has(node.id));
+  }, [nodes, selectedNodeIds]);
+
+  const requestContext = useMemo<AgentRequestContext>(() => ({
+    executionMode: 'auto',
+    scope: selectedNodes.length > 0 ? 'selected_nodes' : 'current_canvas',
+    selectedNodes: selectedNodes.map(node => ({
+      id: node.id,
+      title: getNodeDisplayLabel(node),
+      type: node.type,
+    })),
+  }), [selectedNodes]);
+
+  requestContextRef.current = requestContext;
+
+  const sessionTitle = useMemo(() => {
+    const firstUserMessage = messages.find(message => message.role === 'user')?.content.trim();
+    if (!firstUserMessage) return 'New AI chat';
+    const cleaned = firstUserMessage
+      .replace(/@\[[^\]]+\]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+    const fallback = requestContext.scope === 'selected_nodes' ? '整理选中节点' : '分析当前画布';
+    const title = cleaned || fallback;
+    return title.length > 24 ? `${title.slice(0, 23)}…` : title;
+  }, [messages, requestContext.scope]);
+
+  const handleQuickAction = useCallback(async (prompt: string, quickAction?: string) => {
     if (!prompt) {
       focusInput();
       return;
     }
 
-    const ok = await sendMessage(prompt);
+    const ok = await sendMessage(prompt, { ...requestContext, quickAction });
     if (ok) {
       clearInput();
     }
-  }, [clearInput, focusInput, sendMessage]);
+  }, [clearInput, focusInput, requestContext, sendMessage]);
+
+  const handleSubmit = useCallback(async () => {
+    return await submitCurrentInput(requestContext);
+  }, [requestContext, submitCurrentInput]);
 
   return (
     <ChatView
@@ -93,11 +131,11 @@ export const ChatPanel = ({
           sessionMenuRef={sessionMenuRef}
           sessions={sessions}
           otherSessions={otherSessions}
+          title={sessionTitle}
           onToggleSessionMenu={openSessionMenu}
           onNewSession={handleNewSession}
           onLoadSession={handleLoadSession}
           onClose={onClose}
-          onExpand={onExpand}
         />
       }
       messages={messages}
@@ -113,6 +151,7 @@ export const ChatPanel = ({
       onToggleSection={toggleSection}
       onToggleToolExpand={toggleToolExpand}
       nodes={nodes}
+      selectedNodes={selectedNodes}
       onNodeFocus={onNodeFocus}
       onQuickAction={handleQuickAction}
       input={input}
@@ -125,8 +164,9 @@ export const ChatPanel = ({
       onInput={handleInput}
       onKeyDown={handleKeyDown}
       onPaste={handlePaste}
-      onSubmit={submitCurrentInput}
+      onSubmit={handleSubmit}
       onAbort={abort}
+      contextComposer
     />
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatToolCalls.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatToolCalls.tsx
@@ -40,6 +40,44 @@ function formatToolSignature(name: string, args: any): string {
   return `${name}(${parts.join(', ')})`;
 }
 
+function formatToolLabel(name: string, status: ToolCallStatus['status']): string {
+  const prefix = status === 'running' ? '正在' : '已';
+  switch (name) {
+    case 'canvas_read_context':
+      return `${prefix}读取画布上下文`;
+    case 'canvas_read_node':
+      return `${prefix}读取节点内容`;
+    case 'canvas_create_node':
+      return `${prefix}创建画布节点`;
+    case 'canvas_create_agent_node':
+      return `${prefix}创建 Agent 节点`;
+    case 'canvas_create_terminal_node':
+      return `${prefix}创建 Terminal 节点`;
+    case 'canvas_update_node':
+      return `${prefix}更新画布节点`;
+    case 'canvas_delete_node':
+      return `${prefix}删除画布节点`;
+    case 'canvas_move_node':
+      return `${prefix}移动画布节点`;
+    case 'canvas_send_to_agent':
+      return `${prefix}发送给 Agent`;
+    case 'read':
+      return `${prefix}读取文件`;
+    case 'write':
+      return `${prefix}写入文件`;
+    case 'edit':
+      return `${prefix}编辑文件`;
+    case 'grep':
+      return `${prefix}搜索内容`;
+    case 'ls':
+      return `${prefix}查看目录`;
+    case 'bash':
+      return `${prefix}运行命令`;
+    default:
+      return status === 'running' ? `正在执行 ${name}` : `已执行 ${name}`;
+  }
+}
+
 export const ChatToolCalls = ({
   tools,
   collapsed,
@@ -56,7 +94,7 @@ export const ChatToolCalls = ({
             <path d="M3 6l2 2 4-4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
           </svg>
         </span>
-        <span className="chat-tool-calls-summary">{tools.length} tool call{tools.length > 1 ? 's' : ''}</span>
+        <span className="chat-tool-calls-summary">已完成 {tools.length} 个操作</span>
         <span className="chat-tool-call-chevron">
           <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
             <path d="M3 4l2 2 2-2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
@@ -70,7 +108,7 @@ export const ChatToolCalls = ({
     <div className="chat-tool-calls">
       {showSectionHeader && tools.length > 0 && (
         <div className="chat-tool-calls-section-header" onClick={onToggleSection}>
-          <span className="chat-tool-calls-summary">{tools.length} tool call{tools.length > 1 ? 's' : ''}</span>
+          <span className="chat-tool-calls-summary">已完成 {tools.length} 个操作</span>
           <span className="chat-tool-call-chevron chat-tool-call-chevron--open">
             <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
               <path d="M3 4l2 2 2-2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
@@ -96,7 +134,9 @@ export const ChatToolCalls = ({
                 </svg>
               )}
             </span>
-            <span className="chat-tool-call-sig">{formatToolSignature(tool.name, tool.args)}</span>
+            <span className="chat-tool-call-sig" title={formatToolSignature(tool.name, tool.args)}>
+              {formatToolLabel(tool.name, tool.status)}
+            </span>
             {tool.status === 'done' && tool.result && (
               <span className={`chat-tool-call-chevron${expandedTools.has(tool.id) ? ' chat-tool-call-chevron--open' : ''}`}>
                 <svg width="10" height="10" viewBox="0 0 10 10" fill="none">

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatView.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatView.tsx
@@ -33,10 +33,11 @@ interface ChatViewProps {
 
   // Canvas context
   nodes?: CanvasNode[];
+  selectedNodes?: CanvasNode[];
   onNodeFocus?: (nodeId: string) => void;
 
   // Quick actions (empty state)
-  onQuickAction: (prompt: string) => Promise<void> | void;
+  onQuickAction: (prompt: string, quickAction?: string) => Promise<void> | void;
 
   // Input
   input: string;
@@ -51,6 +52,7 @@ interface ChatViewProps {
   onPaste: ClipboardEventHandler<HTMLDivElement>;
   onSubmit: () => Promise<boolean>;
   onAbort: () => Promise<void>;
+  contextComposer?: boolean;
 
   // Optional decoration
   onResizeStart?: (e: ReactMouseEvent) => void;
@@ -78,6 +80,7 @@ export const ChatView = ({
   onToggleSection,
   onToggleToolExpand,
   nodes,
+  selectedNodes,
   onNodeFocus,
   onQuickAction,
   input,
@@ -92,6 +95,7 @@ export const ChatView = ({
   onPaste,
   onSubmit,
   onAbort,
+  contextComposer = false,
   onResizeStart,
 }: ChatViewProps) => {
   const hasMessages = messages.length > 0 || loading;
@@ -121,11 +125,13 @@ export const ChatView = ({
           onNodeFocus={onNodeFocus}
         />
       ) : (
-        <ChatEmptyState onQuickAction={onQuickAction} />
+        <ChatEmptyState selectedCount={selectedNodes?.length ?? 0} onQuickAction={onQuickAction} />
       )}
       <ChatInput
         loading={loading}
         input={input}
+        selectedNodes={selectedNodes}
+        contextComposer={contextComposer}
         editableRef={editableRef}
         mentionPopup={mentionOpen && mentionItems.length > 0 ? (
           <ChatMentionPopup

--- a/apps/canvas-workspace/src/renderer/src/components/chat/constants.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/constants.ts
@@ -26,24 +26,25 @@ export const MENTION_MAX_ITEMS = 30;
 
 export const QUICK_ACTIONS: QuickAction[] = [
   {
-    key: 'overview',
-    label: 'What’s on the canvas?',
-    prompt: 'What’s on the canvas? Give me an overview.',
+    key: 'summarize_canvas',
+    label: '总结当前画布',
+    prompt: '总结当前画布。',
   },
   {
-    key: 'note',
-    label: 'Create a new note',
-    prompt: 'Create a new note on the canvas.',
+    key: 'analyze_relations',
+    label: '分析节点关系',
+    prompt: '分析当前画布中节点之间的关系。',
   },
   {
-    key: 'summarize',
-    label: 'Summarize my notes',
-    prompt: 'Summarize all the notes on my canvas.',
+    key: 'create_mindmap',
+    label: '生成思维导图',
+    prompt: '基于当前画布生成一个思维导图。',
   },
   {
-    key: 'command',
-    label: 'Run a command',
-    prompt: '',
+    key: 'organize_selection',
+    label: '整理选中内容',
+    prompt: '整理当前选中的节点内容。',
+    requiresSelection: true,
   },
 ];
 

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatStream.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatStream.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { AgentChatMessage } from '../../../types';
+import type { AgentChatMessage, AgentRequestContext } from '../../../types';
 import type { PendingClarification, ToolCallStatus, WorkspaceOption } from '../types';
 import { extractMentionedWorkspaceIds } from '../utils/mentions';
 
@@ -43,7 +43,7 @@ export function useChatStream({ workspaceId, allWorkspaces }: UseChatStreamOptio
     setCollapsedSections(new Set());
   }, []);
 
-  const sendMessage = useCallback(async (rawText: string) => {
+  const sendMessage = useCallback(async (rawText: string, requestContext?: AgentRequestContext) => {
     const text = rawText.trim();
     if (!text || loading) return false;
 
@@ -62,6 +62,7 @@ export function useChatStream({ workspaceId, allWorkspaces }: UseChatStreamOptio
         workspaceId,
         text,
         mentionedWorkspaceIds.length > 0 ? mentionedWorkspaceIds : undefined,
+        requestContext,
       );
 
       if (!result.ok || !result.sessionId) {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useMentions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useMentions.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState } from 'react';
-import type { CanvasNode, DirEntry } from '../../../types';
+import type { AgentRequestContext, CanvasNode, DirEntry } from '../../../types';
 import {
   MENTION_GROUP_ORDER,
   MENTION_MAX_ITEMS,
@@ -17,7 +17,8 @@ interface UseMentionsOptions {
   workspaceId: string;
   nodes?: CanvasNode[];
   rootFolder?: string;
-  onSubmit: (text: string) => Promise<boolean>;
+  onSubmit: (text: string, requestContext?: AgentRequestContext) => Promise<boolean>;
+  getRequestContext?: () => AgentRequestContext | undefined;
 }
 
 function flattenEntries(entries: DirEntry[], rootFolder: string, prefix = ''): MentionItem[] {
@@ -44,6 +45,7 @@ export function useMentions({
   nodes,
   rootFolder,
   onSubmit,
+  getRequestContext,
 }: UseMentionsOptions) {
   const [input, setInput] = useState('');
   const [mentionOpen, setMentionOpen] = useState(false);
@@ -193,13 +195,13 @@ export function useMentions({
     element.focus();
   }, [nodes]);
 
-  const submitCurrentInput = useCallback(async () => {
-    const ok = await onSubmit(input);
+  const submitCurrentInput = useCallback(async (requestContext?: AgentRequestContext) => {
+    const ok = await onSubmit(input, requestContext ?? getRequestContext?.());
     if (ok) {
       clearInput();
     }
     return ok;
-  }, [clearInput, input, onSubmit]);
+  }, [clearInput, getRequestContext, input, onSubmit]);
 
   const handleKeyDown = useCallback((event: React.KeyboardEvent) => {
     if (mentionOpen && mentionItems.length > 0) {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/types.ts
@@ -10,6 +10,7 @@ export interface ChatPanelProps {
   workspaceId: string;
   allWorkspaces?: WorkspaceOption[];
   nodes?: CanvasNode[];
+  selectedNodeIds?: string[];
   rootFolder?: string;
   onClose: () => void;
   onResizeStart?: (e: MouseEvent) => void;
@@ -45,7 +46,8 @@ export interface PendingClarification {
 }
 
 export interface QuickAction {
-  key: 'overview' | 'note' | 'summarize' | 'command';
+  key: 'summarize_canvas' | 'analyze_relations' | 'create_mindmap' | 'organize_selection';
   label: string;
   prompt: string;
+  requiresSelection?: boolean;
 }

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -315,6 +315,19 @@ export interface AgentChatMessage {
   timestamp: number;
 }
 
+export interface AgentContextNodeRef {
+  id: string;
+  title: string;
+  type: CanvasNode['type'];
+}
+
+export interface AgentRequestContext {
+  executionMode?: 'auto' | 'ask';
+  scope?: 'current_canvas' | 'selected_nodes';
+  selectedNodes?: AgentContextNodeRef[];
+  quickAction?: string;
+}
+
 export interface AgentSessionInfo {
   sessionId: string;
   date: string;
@@ -333,7 +346,8 @@ export interface AgentApi {
   chat: (
     workspaceId: string,
     message: string,
-    mentionedWorkspaceIds?: string[]
+    mentionedWorkspaceIds?: string[],
+    requestContext?: AgentRequestContext
   ) => Promise<{ ok: boolean; sessionId?: string; error?: string }>;
   onTextDelta: (
     sessionId: string,


### PR DESCRIPTION
Implement a Notion-inspired Agent panel for Canvas Workspace.

- Redesign the side-panel header around AI chat history with Pulse Canvas branding.
- Add a quieter empty state with canvas-focused quick actions.
- Show explicitly selected canvas nodes as context chips in the composer.
- Add Auto / Ask execution mode switching and pass it into agent request context.
- Simplify tool-call display into readable operation statuses instead of raw signatures.

## Test Evidence
- `pnpm --filter canvas-workspace typecheck`