### PR TITLE
feat(discord): add skill select launcher

### DIFF
--- a/apps/remote-server/src/adapters/discord/adapter.ts
+++ b/apps/remote-server/src/adapters/discord/adapter.ts
@@ -9,6 +9,15 @@ import { getActiveStreamId, registerCancelToken } from '../../core/active-run-st
 import { extractGeneratedImageResult } from '../feishu/image-result.js';
 import { DiscordClient } from './client.js';
 import { buildDiscordMemoryKey, buildDiscordPlatformKey, isDiscordThreadChannelType } from './platform-key.js';
+import {
+  buildDiscordSkillPromptModal,
+  buildDiscordSkillsSelectMessage,
+  extractDiscordComponentTextValue,
+  getDiscordSkillsModalSkillName,
+  isDiscordSkillsSelectCustomId,
+  DISCORD_SKILLS_PROMPT_INPUT_ID,
+  type DiscordComponent,
+} from './skill-launcher.js';
 
 interface DiscordInteraction {
   id: string;
@@ -24,6 +33,9 @@ interface DiscordInteraction {
     // 1=CHAT_INPUT, 2=USER, 3=MESSAGE
     type?: number;
     target_id?: string;
+    custom_id?: string;
+    values?: string[];
+    components?: DiscordComponent[];
     options?: DiscordCommandOption[];
     resolved?: {
       messages?: Record<string, { content?: string; author?: { username?: string } }>;
@@ -39,8 +51,9 @@ interface DiscordCommandOption {
 
 type DiscordAckPayload =
   | { type: 1 }
-  | { type: 4; data: { content: string; flags?: number } }
-  | { type: 5 };
+  | { type: 4; data: { content: string; flags?: number; components?: DiscordComponent[] } }
+  | { type: 5 }
+  | { type: 9; data: unknown };
 
 interface DiscordInteractionStreamMeta {
   kind: 'interaction';
@@ -136,6 +149,14 @@ export class DiscordAdapter implements PlatformAdapter {
       return null;
     }
 
+    if (interaction.type === 3) {
+      return this.handleMessageComponentInteraction(req, interaction);
+    }
+
+    if (interaction.type === 5) {
+      return this.handleModalSubmitInteraction(req, interaction);
+    }
+
     if (interaction.type !== 2) {
       this.ackByRequest.set(req, this.buildEphemeralMessage('Unsupported interaction type.'));
       return null;
@@ -143,10 +164,72 @@ export class DiscordAdapter implements PlatformAdapter {
 
     const text = extractInteractionText(interaction);
     if (!text) {
+      const commandName = interaction.data?.name?.trim().toLowerCase() ?? '';
+      if (commandName === 'skills') {
+        this.ackByRequest.set(req, {
+          type: 4,
+          data: buildDiscordSkillsSelectMessage(DISCORD_ACK_EPHEMERAL_FLAG),
+        });
+        return null;
+      }
+
       this.ackByRequest.set(req, this.buildEphemeralMessage('Please provide text input.'));
       return null;
     }
 
+    return this.buildIncomingForInteraction(req, interaction, text);
+  }
+
+  private async handleMessageComponentInteraction(
+    req: HonoRequest,
+    interaction: DiscordInteraction,
+  ): Promise<IncomingMessage | null> {
+    const customId = interaction.data?.custom_id;
+    if (!isDiscordSkillsSelectCustomId(customId)) {
+      this.ackByRequest.set(req, this.buildEphemeralMessage('Unsupported component interaction.'));
+      return null;
+    }
+
+    const selectedSkill = interaction.data?.values?.[0]?.trim();
+    if (!selectedSkill) {
+      this.ackByRequest.set(req, this.buildEphemeralMessage('Please select a skill.'));
+      return null;
+    }
+
+    const modal = buildDiscordSkillPromptModal(selectedSkill);
+    if (!modal) {
+      this.ackByRequest.set(req, this.buildEphemeralMessage(`Skill not found: ${selectedSkill}`));
+      return null;
+    }
+
+    this.ackByRequest.set(req, { type: 9, data: modal });
+    return null;
+  }
+
+  private async handleModalSubmitInteraction(
+    req: HonoRequest,
+    interaction: DiscordInteraction,
+  ): Promise<IncomingMessage | null> {
+    const selectedSkill = getDiscordSkillsModalSkillName(interaction.data?.custom_id);
+    if (!selectedSkill) {
+      this.ackByRequest.set(req, this.buildEphemeralMessage('Unsupported modal submission.'));
+      return null;
+    }
+
+    const prompt = extractDiscordComponentTextValue(interaction.data?.components, DISCORD_SKILLS_PROMPT_INPUT_ID);
+    if (!prompt) {
+      this.ackByRequest.set(req, this.buildEphemeralMessage('Prompt 不能为空。'));
+      return null;
+    }
+
+    return this.buildIncomingForInteraction(req, interaction, `[use skill](${selectedSkill}) ${prompt}`);
+  }
+
+  private async buildIncomingForInteraction(
+    req: HonoRequest,
+    interaction: DiscordInteraction,
+    text: string,
+  ): Promise<IncomingMessage | null> {
     const channelId = interaction.channel_id;
     const userId = interaction.member?.user?.id ?? interaction.user?.id;
     if (!channelId || !userId) {
@@ -595,6 +678,10 @@ function extractInteractionText(interaction: DiscordInteraction): string {
 
   if (commandName === 'restart') {
     return buildRestartCommandText(interaction.data?.options ?? []);
+  }
+
+  if (commandName === 'skills' && !args) {
+    return '';
   }
 
   if (PASSTHROUGH_SLASH_COMMANDS.has(commandName)) {

--- a/apps/remote-server/src/adapters/discord/application-commands.ts
+++ b/apps/remote-server/src/adapters/discord/application-commands.ts
@@ -35,6 +35,11 @@ const WORKTREE_COMMAND: DiscordApplicationCommandCreate = {
   ],
 };
 
+const SKILLS_COMMAND: DiscordApplicationCommandCreate = {
+  name: 'skills',
+  description: 'Open the Pulse skill launcher.',
+};
+
 // Right-click message → Apps → "Ask Pulse" sends the message content as a prompt.
 const ASK_PULSE_MESSAGE_COMMAND: DiscordApplicationCommandCreate = {
   name: 'Ask Pulse',
@@ -57,7 +62,7 @@ export async function registerDiscordApplicationCommands(): Promise<void> {
   const configuredApplicationId = process.env.DISCORD_APPLICATION_ID?.trim();
   const applicationId = configuredApplicationId || await client.getApplicationId();
   const guildIds = parseGuildIds(process.env.DISCORD_COMMAND_GUILD_IDS);
-  const commands = [RESTART_COMMAND, WORKTREE_COMMAND, ASK_PULSE_MESSAGE_COMMAND];
+  const commands = [RESTART_COMMAND, WORKTREE_COMMAND, SKILLS_COMMAND, ASK_PULSE_MESSAGE_COMMAND];
 
   if (guildIds.length === 0) {
     for (const command of commands) {

--- a/apps/remote-server/src/adapters/discord/skill-launcher.ts
+++ b/apps/remote-server/src/adapters/discord/skill-launcher.ts
@@ -1,0 +1,185 @@
+import type { SkillSummary } from '../../core/chat-commands/types.js';
+import { getSkillRegistry } from '../../core/chat-commands/services.js';
+
+export const DISCORD_SKILLS_SELECT_CUSTOM_ID = 'pulse.skills.select';
+export const DISCORD_SKILLS_MODAL_CUSTOM_ID_PREFIX = 'pulse.skills.modal:';
+export const DISCORD_SKILLS_PROMPT_INPUT_ID = 'prompt';
+
+const DISCORD_SELECT_MENU_OPTION_LIMIT = 25;
+const DISCORD_SELECT_LABEL_LIMIT = 100;
+const DISCORD_SELECT_VALUE_LIMIT = 100;
+const DISCORD_SELECT_DESCRIPTION_LIMIT = 100;
+const DISCORD_MODAL_TITLE_LIMIT = 45;
+const DISCORD_TEXT_INPUT_LABEL_LIMIT = 45;
+const DISCORD_TEXT_INPUT_MAX_LENGTH = 1800;
+
+export interface DiscordSelectOption {
+  label: string;
+  value: string;
+  description?: string;
+}
+
+export interface DiscordComponent {
+  type: number;
+  custom_id?: string;
+  placeholder?: string;
+  min_values?: number;
+  max_values?: number;
+  options?: DiscordSelectOption[];
+  label?: string;
+  style?: number;
+  min_length?: number;
+  max_length?: number;
+  required?: boolean;
+  value?: string;
+  components?: DiscordComponent[];
+}
+
+export interface DiscordInteractionResponseMessageData {
+  content: string;
+  flags?: number;
+  components?: DiscordComponent[];
+}
+
+export interface DiscordModalResponseData {
+  custom_id: string;
+  title: string;
+  components: DiscordComponent[];
+}
+
+export function buildDiscordSkillsSelectMessage(flags?: number): DiscordInteractionResponseMessageData {
+  const registry = getSkillRegistry();
+  if (!registry) {
+    return {
+      content: '⚠️ skill registry 不可用，请确认内置 skills 插件已启用。',
+      flags,
+    };
+  }
+
+  const skills = [...registry.getAll()].sort((a, b) => a.name.localeCompare(b.name));
+  if (skills.length === 0) {
+    return {
+      content: '📭 当前未加载任何技能。请在 `.pulse-coder/skills/**/SKILL.md` 添加技能后重试。',
+      flags,
+    };
+  }
+
+  const shownSkills = skills.slice(0, DISCORD_SELECT_MENU_OPTION_LIMIT);
+  const suffix = skills.length > shownSkills.length
+    ? `\n\n-# 当前先平铺展示前 ${shownSkills.length}/${skills.length} 个技能，后续可继续做分类/分页。`
+    : '';
+
+  return {
+    content: `🧰 Skill Launcher\n请选择一个 skill，然后在弹窗里输入要交给它处理的需求。${suffix}`,
+    flags,
+    components: [
+      {
+        type: 1,
+        components: [
+          {
+            type: 3,
+            custom_id: DISCORD_SKILLS_SELECT_CUSTOM_ID,
+            placeholder: '选择一个 skill',
+            min_values: 1,
+            max_values: 1,
+            options: shownSkills.map(toSelectOption),
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export function buildDiscordSkillPromptModal(skillName: string): DiscordModalResponseData | null {
+  const skill = resolveSkillByName(skillName);
+  if (!skill) {
+    return null;
+  }
+
+  return {
+    custom_id: `${DISCORD_SKILLS_MODAL_CUSTOM_ID_PREFIX}${skill.name}`,
+    title: clip(`Use ${skill.name}`, DISCORD_MODAL_TITLE_LIMIT),
+    components: [
+      {
+        type: 1,
+        components: [
+          {
+            type: 4,
+            custom_id: DISCORD_SKILLS_PROMPT_INPUT_ID,
+            label: clip('输入要交给该 skill 的需求', DISCORD_TEXT_INPUT_LABEL_LIMIT),
+            style: 2,
+            min_length: 1,
+            max_length: DISCORD_TEXT_INPUT_MAX_LENGTH,
+            required: true,
+            placeholder: '例如：帮我整理今天的日程和待办',
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export function isDiscordSkillsSelectCustomId(customId: string | undefined): boolean {
+  return customId === DISCORD_SKILLS_SELECT_CUSTOM_ID;
+}
+
+export function getDiscordSkillsModalSkillName(customId: string | undefined): string | null {
+  if (!customId?.startsWith(DISCORD_SKILLS_MODAL_CUSTOM_ID_PREFIX)) {
+    return null;
+  }
+
+  const skillName = customId.slice(DISCORD_SKILLS_MODAL_CUSTOM_ID_PREFIX.length).trim();
+  return skillName || null;
+}
+
+export function extractDiscordComponentTextValue(
+  components: DiscordComponent[] | undefined,
+  customId: string,
+): string {
+  if (!components) {
+    return '';
+  }
+
+  for (const component of components) {
+    if (component.custom_id === customId && typeof component.value === 'string') {
+      return component.value.trim();
+    }
+
+    const nested = extractDiscordComponentTextValue(component.components, customId);
+    if (nested) {
+      return nested;
+    }
+  }
+
+  return '';
+}
+
+function resolveSkillByName(skillName: string): SkillSummary | null {
+  const registry = getSkillRegistry();
+  if (!registry) {
+    return null;
+  }
+
+  return registry.get(skillName) ?? null;
+}
+
+function toSelectOption(skill: SkillSummary): DiscordSelectOption {
+  return {
+    label: clip(skill.name, DISCORD_SELECT_LABEL_LIMIT),
+    value: clip(skill.name, DISCORD_SELECT_VALUE_LIMIT),
+    description: clip(skill.description || 'No description', DISCORD_SELECT_DESCRIPTION_LIMIT),
+  };
+}
+
+function clip(value: string, maxLength: number): string {
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+
+  if (maxLength <= 1) {
+    return normalized.slice(0, maxLength);
+  }
+
+  return `${normalized.slice(0, maxLength - 1)}…`;
+}


### PR DESCRIPTION
## Summary
- Register a Discord `/skill` slash command that opens a Skill Launcher.
- Add a flat Discord select menu backed by the loaded skill registry, capped at Discord's 25-option limit.
- Add select-to-modal flow and submit modal prompts as `[use skill](name) <prompt>` agent input.
- Keep `/skills` compatibility for existing text/pass-through command handling, while registering the new singular Discord command.

## Validation
- `pnpm --filter @pulse-coder/remote-server build` ✅

## Risk
- Low; scoped to Discord interactions. Current MVP only shows the first 25 skills and does not yet implement categories or pagination.
