### PR TITLE
fix(discord): reduce progress edit frequency

### DIFF
--- a/apps/remote-server/src/adapters/discord/adapter.ts
+++ b/apps/remote-server/src/adapters/discord/adapter.ts
@@ -91,7 +91,7 @@ export function buildDiscordCancelToken(channelId: string, messageId: string): s
 }
 
 const DISCORD_ACK_EPHEMERAL_FLAG = 1 << 6;
-const DISCORD_PROGRESS_UPDATE_INTERVAL_MS = 5000;
+const DISCORD_PROGRESS_UPDATE_INTERVAL_MS = 60000;
 const DISCORD_MESSAGE_LIMIT = 2000;
 const DISCORD_PROGRESS_FOOTER_BASE = 'Pulse Agent 努力生成中';
 const DISCORD_PROGRESS_DOT_MIN = 1;


### PR DESCRIPTION
Reduce Discord progress message edit frequency to avoid hitting Discord limits on older messages.\n\n- Increase progress update interval from 5s to 60s\n- Lower long-running task edit volume from about 720/hour to about 60/hour\n\nTest: pnpm --filter @pulse-coder/remote-server build