### PR TITLE
fix(discord): make stop and final updates reliable

### DIFF
--- a/apps/remote-server/src/adapters/discord/adapter.ts
+++ b/apps/remote-server/src/adapters/discord/adapter.ts
@@ -495,10 +495,15 @@ export class DiscordAdapter implements PlatformAdapter {
 
     const sendFinalText = async (text: string) => {
       const chunks = splitDiscordText(text);
-      await enqueuePrimaryWrite(
-        () => io.updatePrimary(chunks[0]),
-        { propagate: true },
-      );
+      try {
+        await enqueuePrimaryWrite(
+          () => io.updatePrimary(chunks[0]),
+          { propagate: true },
+        );
+      } catch (err) {
+        console.error('[discord] Failed to update final response; sending followup message:', err);
+        await io.sendExtraText(chunks[0]);
+      }
 
       for (const chunk of chunks.slice(1)) {
         await io.sendExtraText(chunk);
@@ -562,7 +567,6 @@ export class DiscordAdapter implements PlatformAdapter {
         finalizing = true;
         await sendFinalText(result || 'Done.').catch(async (err) => {
           console.error('[discord] Failed to send final response:', err);
-          await io.sendExtraText(`Error: ${String(err)}`);
         });
         io.setStatusReaction?.('✅').catch(() => undefined);
       },

--- a/apps/remote-server/src/adapters/discord/application-commands.ts
+++ b/apps/remote-server/src/adapters/discord/application-commands.ts
@@ -40,6 +40,11 @@ const SKILLS_COMMAND: DiscordApplicationCommandCreate = {
   description: 'Open the Pulse skill launcher.',
 };
 
+const STOP_COMMAND: DiscordApplicationCommandCreate = {
+  name: 'stop',
+  description: 'Stop the currently running Pulse task in this channel.',
+};
+
 // Right-click message → Apps → "Ask Pulse" sends the message content as a prompt.
 const ASK_PULSE_MESSAGE_COMMAND: DiscordApplicationCommandCreate = {
   name: 'Ask Pulse',
@@ -62,7 +67,7 @@ export async function registerDiscordApplicationCommands(): Promise<void> {
   const configuredApplicationId = process.env.DISCORD_APPLICATION_ID?.trim();
   const applicationId = configuredApplicationId || await client.getApplicationId();
   const guildIds = parseGuildIds(process.env.DISCORD_COMMAND_GUILD_IDS);
-  const commands = [RESTART_COMMAND, WORKTREE_COMMAND, SKILLS_COMMAND, ASK_PULSE_MESSAGE_COMMAND];
+  const commands = [RESTART_COMMAND, WORKTREE_COMMAND, SKILLS_COMMAND, STOP_COMMAND, ASK_PULSE_MESSAGE_COMMAND];
 
   if (guildIds.length === 0) {
     for (const command of commands) {

--- a/apps/remote-server/src/adapters/discord/gateway.ts
+++ b/apps/remote-server/src/adapters/discord/gateway.ts
@@ -1,7 +1,7 @@
 import { dispatchIncoming } from '../../core/dispatcher.js';
 import type { IncomingMessage, IncomingAttachment } from '../../core/types.js';
 import { discordAdapter, DISCORD_CANCEL_REACTION, buildDiscordCancelToken } from './adapter.js';
-import { abortActiveRun, resolvePlatformKeyByCancelToken } from '../../core/active-run-store.js';
+import { abortAndClearActiveRun, resolvePlatformKeyByCancelToken } from '../../core/active-run-store.js';
 import { DiscordClient } from './client.js';
 import { getDiscordProxyDispatcher } from './proxy.js';
 import { buildDiscordMemoryKey, buildDiscordPlatformKey, isDiscordThreadChannelType } from './platform-key.js';
@@ -424,7 +424,7 @@ export class DiscordDmGateway {
       return;
     }
 
-    const result = abortActiveRun(platformKey);
+    const result = abortAndClearActiveRun(platformKey);
     if (result.aborted) {
       console.log(`[discord-gateway] Cancelled active run via ❌ reaction platformKey=${platformKey}`);
     }

--- a/apps/remote-server/src/core/active-run-store.ts
+++ b/apps/remote-server/src/core/active-run-store.ts
@@ -21,6 +21,21 @@ export function setActiveRun(platformKey: string, run: ActiveRun): void {
 
 export function clearActiveRun(platformKey: string): void {
   activeRuns.delete(platformKey);
+  clearCancelTokens(platformKey);
+}
+
+export function clearActiveRunIfMatches(platformKey: string, streamId: string): boolean {
+  const run = activeRuns.get(platformKey);
+  if (!run || run.streamId !== streamId) {
+    return false;
+  }
+
+  activeRuns.delete(platformKey);
+  clearCancelTokens(platformKey);
+  return true;
+}
+
+function clearCancelTokens(platformKey: string): void {
   const tokens = platformKeyToCancelTokens.get(platformKey);
   if (tokens) {
     for (const token of tokens) {
@@ -65,4 +80,12 @@ export function abortActiveRun(platformKey: string): { aborted: boolean; started
     aborted: true,
     startedAt: run.startedAt,
   };
+}
+
+export function abortAndClearActiveRun(platformKey: string): { aborted: boolean; startedAt?: number } {
+  const result = abortActiveRun(platformKey);
+  if (result.aborted) {
+    clearActiveRun(platformKey);
+  }
+  return result;
 }

--- a/apps/remote-server/src/core/chat-commands/handlers/session-commands.ts
+++ b/apps/remote-server/src/core/chat-commands/handlers/session-commands.ts
@@ -1,4 +1,4 @@
-import { abortActiveRun, getActiveRun } from '../../active-run-store.js';
+import { abortAndClearActiveRun, getActiveRun } from '../../active-run-store.js';
 import { engine } from '../../engine-singleton.js';
 import { memoryIntegration, recordCompactSummaryDailyLog } from '../../memory-integration.js';
 import { sessionStore } from '../../session-store.js';
@@ -193,7 +193,7 @@ export async function handleCurrentSessionCommand(platformKey: string): Promise<
 }
 
 export function handleStopCommand(platformKey: string): CommandResult {
-  const result = abortActiveRun(platformKey);
+  const result = abortAndClearActiveRun(platformKey);
   if (!result.aborted) {
     return {
       type: 'handled',
@@ -202,7 +202,8 @@ export function handleStopCommand(platformKey: string): CommandResult {
   }
 
   return {
-    type: 'handled_silent',
+    type: 'handled',
+    message: '⏹️ 已发送停止信号，当前会话已解除运行锁。',
   };
 }
 

--- a/apps/remote-server/src/core/dispatcher.ts
+++ b/apps/remote-server/src/core/dispatcher.ts
@@ -9,7 +9,7 @@ import { hasIncomingImageAttachments } from './attachments.js';
 import {
   hasActiveRun,
   setActiveRun,
-  clearActiveRun,
+  clearActiveRunIfMatches,
   getActiveStreamId as getActiveStreamIdFromStore,
 } from './active-run-store.js';
 
@@ -212,7 +212,7 @@ async function runAgentAsync(adapter: PlatformAdapter, incoming: IncomingMessage
       console.error('[dispatcher] Original run error:', runError);
     }
   } finally {
-    clearActiveRun(platformKey);
+    clearActiveRunIfMatches(platformKey, streamId);
   }
 }
 


### PR DESCRIPTION
Improve Discord stop behavior and final response delivery for unstable gateway/proxy conditions.\n\n- Register a Discord /stop application command so cancellation can use interaction webhooks instead of relying only on gateway message events\n- Abort and clear active run locks immediately for /stop and cancel reactions\n- Guard active-run cleanup by streamId so stale runs cannot clear newer runs\n- Fall back to sending a followup message when editing the final progress message fails\n\nTest: pnpm --filter @pulse-coder/remote-server build