### PR TITLE
feat(cli): add lightweight tui renderer

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,17 +18,19 @@
     "dist"
   ],
   "dependencies": {
+    "ink": "^7.0.2",
     "pulse-coder-acp": "workspace:*",
     "pulse-coder-agent-teams": "workspace:*",
     "pulse-coder-engine": "workspace:*",
     "pulse-coder-memory-plugin": "workspace:*",
     "pulse-coder-orchestrator": "workspace:*",
-    "pulse-sandbox": "workspace:*"
+    "pulse-sandbox": "workspace:*",
+    "react": "^19.2.5"
   },
   "devDependencies": {
-    "typescript": "^5.0.0",
+    "@types/node": "^25.0.10",
     "tsup": "^8.0.0",
-    "vitest": "^1.0.0",
-    "@types/node": "^25.0.10"
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
   }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -818,19 +818,7 @@ class CoderCLI {
 
 async function main(): Promise<void> {
   if (resolveCliUiMode() === 'ink') {
-    await startInkTui({
-      snapshot: {
-        status: 'Ink UI is ready. Full agent loop remains available in readline mode.',
-        events: [
-          {
-            id: 'welcome',
-            kind: 'system',
-            title: 'Experimental Ink UI',
-            text: 'Ink is integrated as an experimental shell. Use PULSE_CODER_UI=readline for the classic interactive agent loop.',
-          },
-        ],
-      },
-    });
+    await startInkTui();
     return;
   }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -32,6 +32,7 @@ const LOCAL_COMMANDS = new Set([
   'teams',
   'solo',
   'save',
+  'tui',
   'exit',
 ]);
 
@@ -59,6 +60,7 @@ const HELP_ITEMS: TuiHelpItem[] = [
   { command: '/teams <task> --cwd <dir>', description: 'Set working directory for teammates' },
   { command: '/solo', description: 'Exit teams mode, return to normal agent' },
   { command: '/save', description: 'Save current session explicitly' },
+  { command: '/tui [on|off|status]', description: 'Toggle or inspect the interactive TUI renderer' },
   { command: '/exit', description: 'Exit the application' },
 ];
 
@@ -319,6 +321,25 @@ class CoderCLI {
             this.tui.error('Failed to switch mode: plan mode plugin unavailable');
           }
           break;
+
+        case 'tui': {
+          const action = (args[0] ?? 'status').toLowerCase();
+          if (action === 'on') {
+            if (this.tui.setEnabled(true)) {
+              this.tui.success('TUI enabled for this process.');
+            } else {
+              this.tui.warn('TUI is not available in this terminal. Staying in plain mode.');
+            }
+          } else if (action === 'off') {
+            this.tui.setEnabled(false);
+            this.tui.info('TUI disabled for this process.');
+          } else if (action === 'status') {
+            this.tui.showTuiStatus();
+          } else {
+            this.tui.warn('Usage: /tui [on|off|status]');
+          }
+          break;
+        }
 
         case 'save':
           if (this.sessionCommands.getCurrentSessionId()) {
@@ -596,6 +617,14 @@ class CoderCLI {
       }
 
       // Regular message processing
+      this.tui.session({
+        sessionId: this.sessionCommands.getCurrentSessionId(),
+        taskListId: this.sessionCommands.getCurrentTaskListId(),
+        messages: this.context.messages.length,
+        estimatedTokens: this.estimateTokens(this.context.messages),
+        mode: this.agent.getMode(),
+      });
+
       this.context.messages.push({
         role: 'user',
         content: messageInput,
@@ -609,6 +638,8 @@ class CoderCLI {
       isProcessing = true;
 
       let sawText = false;
+      let toolCalls = 0;
+      const runStartedAt = Date.now();
 
       const getToolInput = (toolCall: Record<string, unknown>): unknown => {
         const input = (toolCall as { input?: unknown }).input;
@@ -652,6 +683,7 @@ class CoderCLI {
             this.tui.text(delta);
           },
           onToolCall: (toolCall) => {
+            toolCalls += 1;
             const input = getToolInput(toolCall);
             this.tui.toolCall(resolveToolName(toolCall), input);
           },
@@ -690,6 +722,7 @@ class CoderCLI {
                 this.tui.text(delta);
               },
               onToolCall: (toolCall) => {
+                toolCalls += 1;
                 const input = getToolInput(toolCall);
                 this.tui.toolCall(resolveToolName(toolCall), input);
               },
@@ -715,6 +748,14 @@ class CoderCLI {
             acpState ? runAcpAgent : runAgent,
           )
           : await (acpState ? runAcpAgent() : runAgent());
+
+        this.tui.runSummary({
+          elapsedMs: Date.now() - runStartedAt,
+          toolCalls,
+          messages: this.context.messages.length,
+          estimatedTokens: this.estimateTokens(this.context.messages),
+          mode: this.agent.getMode(),
+        });
 
         if (result) {
           if (!sawText) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,6 +10,8 @@ import { runTeam, TeamsSession } from './team-commands.js';
 import { memoryIntegration, buildMemoryRunContext, recordDailyLogFromSuccessPath } from './memory-integration.js';
 import { ACP_CLIENT_INFO, handleAcpCommand, resolveAcpPlatformKey } from './acp-commands.js';
 import { TuiRenderer, type TuiHelpItem } from './tui-renderer.js';
+import { resolveCliUiMode } from './ui-mode.js';
+import { startInkTui } from './ink-launcher.js';
 
 const LOCAL_COMMANDS = new Set([
   'help',
@@ -814,9 +816,29 @@ class CoderCLI {
   }
 }
 
-// Always start the CLI when executed directly
-const cli = new CoderCLI();
-cli.start().catch(error => {
+async function main(): Promise<void> {
+  if (resolveCliUiMode() === 'ink') {
+    await startInkTui({
+      snapshot: {
+        status: 'Ink UI is ready. Full agent loop remains available in readline mode.',
+        events: [
+          {
+            id: 'welcome',
+            kind: 'system',
+            title: 'Experimental Ink UI',
+            text: 'Ink is integrated as an experimental shell. Use PULSE_CODER_UI=readline for the classic interactive agent loop.',
+          },
+        ],
+      },
+    });
+    return;
+  }
+
+  const cli = new CoderCLI();
+  await cli.start();
+}
+
+main().catch(error => {
   console.error('Failed to start CLI:', error);
   process.exit(1);
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,6 +9,7 @@ import { SkillCommands } from './skill-commands.js';
 import { runTeam, TeamsSession } from './team-commands.js';
 import { memoryIntegration, buildMemoryRunContext, recordDailyLogFromSuccessPath } from './memory-integration.js';
 import { ACP_CLIENT_INFO, handleAcpCommand, resolveAcpPlatformKey } from './acp-commands.js';
+import { TuiRenderer, type TuiHelpItem } from './tui-renderer.js';
 
 const LOCAL_COMMANDS = new Set([
   'help',
@@ -34,6 +35,38 @@ const LOCAL_COMMANDS = new Set([
   'exit',
 ]);
 
+const HELP_ITEMS: TuiHelpItem[] = [
+  { command: '/help', description: 'Show this help message' },
+  { command: '/new [title]', description: 'Create a new session' },
+  { command: '/resume <id>', description: 'Resume a saved session' },
+  { command: '/sessions', description: 'List all saved sessions' },
+  { command: '/search <query>', description: 'Search in saved sessions' },
+  { command: '/rename <id> <new-title>', description: 'Rename a session' },
+  { command: '/delete <id>', description: 'Delete a session' },
+  { command: '/clear', description: 'Clear current conversation' },
+  { command: '/compact', description: 'Force compact current conversation context' },
+  { command: '/skills [list|<name|index> <message>]', description: 'Run one message with a selected skill' },
+  { command: '/acp [status|on|off|cd]', description: 'Manage ACP mode for this CLI' },
+  { command: '/wt use <work-name>', description: 'Create a worktree + branch via worktree skill' },
+  { command: '/status', description: 'Show current session status' },
+  { command: '/mode', description: 'Show current plan mode' },
+  { command: '/plan', description: 'Switch to planning mode' },
+  { command: '/execute', description: 'Switch to executing mode' },
+  { command: '/team <task>', description: 'Run a multi-agent team (LLM plans DAG by default)' },
+  { command: '/team --route=auto <task>', description: 'Use keyword-based routing instead of LLM planning' },
+  { command: '/teams <task>', description: 'Run agent teams (enters teams mode for follow-ups)' },
+  { command: '/teams <task> --concurrency N', description: 'Limit parallel teammates' },
+  { command: '/teams <task> --cwd <dir>', description: 'Set working directory for teammates' },
+  { command: '/solo', description: 'Exit teams mode, return to normal agent' },
+  { command: '/save', description: 'Save current session explicitly' },
+  { command: '/exit', description: 'Exit the application' },
+];
+
+const HELP_FOOTER = [
+  'Esc (while processing) - Stop current response and accept next input',
+  'Ctrl+C - Exit CLI immediately',
+];
+
 class CoderCLI {
   private agent: PulseAgent;
   private context: Context;
@@ -41,6 +74,7 @@ class CoderCLI {
   private inputManager: InputManager;
   private skillCommands: SkillCommands;
   private acpPlatformKey: string;
+  private tui: TuiRenderer;
 
   constructor() {
     const runJsTool = createRunJsTool({
@@ -69,6 +103,7 @@ class CoderCLI {
     this.inputManager = new InputManager();
     this.skillCommands = new SkillCommands(this.agent);
     this.acpPlatformKey = resolveAcpPlatformKey();
+    this.tui = new TuiRenderer();
   }
 
   private safeStringify(value: unknown): string {
@@ -110,7 +145,7 @@ class CoderCLI {
       return currentId;
     }
 
-    console.warn('⚠️ No active session ID; memory tools and daily logs are skipped for this run.');
+    this.tui.warn('No active session ID; memory tools and daily logs are skipped for this run.');
     return null;
   }
 
@@ -130,10 +165,10 @@ class CoderCLI {
     try {
       const result = await service.setTaskListId(taskListId);
       if (result.switched) {
-        console.log(`🗂️ Switched task list to ${result.taskListId}`);
+        this.tui.success(`Switched task list to ${result.taskListId}`);
       }
     } catch (error: any) {
-      console.warn(`⚠️ Failed to switch task list binding: ${error?.message ?? String(error)}`);
+      this.tui.warn(`Failed to switch task list binding: ${error?.message ?? String(error)}`);
     }
   }
 
@@ -141,33 +176,7 @@ class CoderCLI {
     try {
       switch (command.toLowerCase()) {
         case 'help':
-          console.log('\n📋 Available commands:');
-          console.log('/help - Show this help message');
-          console.log('/new [title] - Create a new session');
-          console.log('/resume <id> - Resume a saved session');
-          console.log('/sessions - List all saved sessions');
-          console.log('/search <query> - Search in saved sessions');
-          console.log('/rename <id> <new-title> - Rename a session');
-          console.log('/delete <id> - Delete a session');
-          console.log('/clear - Clear current conversation');
-          console.log('/compact - Force compact current conversation context');
-          console.log('/skills [list|<name|index> <message>] - Run one message with a selected skill');
-          console.log('/acp [status|on|off|cd] - Manage ACP mode for this CLI');
-          console.log('/wt use <work-name> - Create a worktree + branch via worktree skill');
-          console.log('/status - Show current session status');
-          console.log('/mode - Show current plan mode');
-          console.log('/plan - Switch to planning mode');
-          console.log('/execute - Switch to executing mode');
-          console.log('/team <task> - Run a multi-agent team (LLM plans DAG by default)');
-          console.log('/team --route=auto <task> - Use keyword-based routing instead of LLM planning');
-          console.log('/teams <task> - Run agent teams (enters teams mode for follow-ups)');
-          console.log('/teams <task> --concurrency N - Limit parallel teammates');
-          console.log('/teams <task> --cwd <dir> - Set working directory for teammates');
-          console.log('/solo - Exit teams mode, return to normal agent');
-          console.log('/save - Save current session explicitly');
-          console.log('/exit - Exit the application');
-          console.log('Esc (while processing) - Stop current response and accept next input');
-          console.log('Ctrl+C - Exit CLI immediately');
+          this.tui.showHelp(HELP_ITEMS, HELP_FOOTER);
           break;
 
         case 'new':
@@ -179,8 +188,8 @@ class CoderCLI {
 
         case 'resume':
           if (args.length === 0) {
-            console.log('\n❌ Please provide a session ID');
-            console.log('Usage: /resume <session-id>');
+            this.tui.error('Please provide a session ID');
+            this.tui.info('Usage: /resume <session-id>');
             break;
           }
           const sessionId = args[0];
@@ -197,8 +206,8 @@ class CoderCLI {
 
         case 'search':
           if (args.length === 0) {
-            console.log('\n❌ Please provide a search query');
-            console.log('Usage: /search <query>');
+            this.tui.error('Please provide a search query');
+            this.tui.info('Usage: /search <query>');
             break;
           }
           const query = args.join(' ');
@@ -207,8 +216,8 @@ class CoderCLI {
 
         case 'rename':
           if (args.length < 2) {
-            console.log('\n❌ Please provide session ID and new title');
-            console.log('Usage: /rename <session-id> <new-title>');
+            this.tui.error('Please provide session ID and new title');
+            this.tui.info('Usage: /rename <session-id> <new-title>');
             break;
           }
           const renameId = args[0];
@@ -218,8 +227,8 @@ class CoderCLI {
 
         case 'delete':
           if (args.length === 0) {
-            console.log('\n❌ Please provide a session ID');
-            console.log('Usage: /delete <session-id>');
+            this.tui.error('Please provide a session ID');
+            this.tui.info('Usage: /delete <session-id>');
             break;
           }
           const deleteId = args[0];
@@ -228,12 +237,12 @@ class CoderCLI {
 
         case 'clear':
           this.context.messages = [];
-          console.log('\n🧹 Current conversation cleared!');
+          this.tui.success('Current conversation cleared!');
           break;
 
         case 'compact':
           if (this.context.messages.length === 0) {
-            console.log('\nℹ️ Context is empty, nothing to compact.');
+            this.tui.info('Context is empty, nothing to compact.');
             break;
           }
 
@@ -243,8 +252,8 @@ class CoderCLI {
           const compactResult = await this.agent.compactContext(this.context, { force: true });
 
           if (!compactResult.didCompact || !compactResult.newMessages) {
-            console.log('\nℹ️ No compaction was applied.');
-            console.log(`Messages: ${beforeCount}, estimated tokens: ~${beforeTokens}, KEEP_LAST_TURNS=${keepLastTurns}`);
+            this.tui.info('No compaction was applied.');
+            this.tui.plain(`Messages: ${beforeCount}, estimated tokens: ~${beforeTokens}, KEEP_LAST_TURNS=${keepLastTurns}`);
             break;
           }
 
@@ -257,91 +266,87 @@ class CoderCLI {
           const tokenDeltaText = tokenDelta >= 0 ? `-${tokenDelta}` : `+${Math.abs(tokenDelta)}`;
           const reasonSuffix = compactResult.reason ? ` (${compactResult.reason})` : '';
 
-          console.log(`\n🧩 Context compacted${reasonSuffix}`);
-          console.log(`Messages: ${beforeCount} -> ${afterCount}`);
-          console.log(`Estimated tokens: ~${beforeTokens} -> ~${afterTokens} (${tokenDeltaText})`);
-          console.log(`KEEP_LAST_TURNS=${keepLastTurns}`);
+          this.tui.section(`Context compacted${reasonSuffix}`, [
+            `Messages: ${beforeCount} -> ${afterCount}`,
+            `Estimated tokens: ~${beforeTokens} -> ~${afterTokens} (${tokenDeltaText})`,
+            `KEEP_LAST_TURNS=${keepLastTurns}`,
+          ]);
           break;
 
         case 'skills':
-          console.log('\nℹ️ Use /skills <name|index> <message> directly in input for one-shot skill execution.');
+          this.tui.info('Use /skills <name|index> <message> directly in input for one-shot skill execution.');
           break;
 
         case 'acp': {
           const message = await handleAcpCommand(this.acpPlatformKey, args);
-          console.log(`\n${message}`);
+          this.tui.plain(`\n${message}`);
           break;
         }
 
         case 'status':
           const currentId = this.sessionCommands.getCurrentSessionId();
           const currentTaskListId = this.sessionCommands.getCurrentTaskListId();
-          console.log(`\n📊 Session Status:`);
-          console.log(`Current Session: ${currentId || 'None (new session)'}`);
-          console.log(`Task List: ${currentTaskListId || 'None'}`);
-          console.log(`Messages: ${this.context.messages.length}`);
-          if (currentId) {
-            console.log(`To save this session, use: /save`);
-          }
+          this.tui.section('Session Status', [
+            `Current Session: ${currentId || 'None (new session)'}`,
+            `Task List: ${currentTaskListId || 'None'}`,
+            `Messages: ${this.context.messages.length}`,
+            ...(currentId ? ['To save this session, use: /save'] : []),
+          ]);
           break;
 
         case 'mode':
           const currentMode = this.agent.getMode();
           if (!currentMode) {
-            console.log('\n⚠️ plan mode plugin unavailable');
+            this.tui.warn('plan mode plugin unavailable');
             break;
           }
 
-          console.log(`\n🧭 Current mode: ${currentMode}`);
+          this.tui.info(`Current mode: ${currentMode}`);
           break;
 
         case 'plan':
           if (this.agent.setMode('planning', 'cli:/plan')) {
-            console.log('\n✅ Switched to planning mode');
+            this.tui.success('Switched to planning mode');
           } else {
-            console.log('\n❌ Failed to switch mode: plan mode plugin unavailable');
+            this.tui.error('Failed to switch mode: plan mode plugin unavailable');
           }
           break;
 
         case 'execute':
           if (this.agent.setMode('executing', 'cli:/execute')) {
-            console.log('\n✅ Switched to executing mode');
+            this.tui.success('Switched to executing mode');
           } else {
-            console.log('\n❌ Failed to switch mode: plan mode plugin unavailable');
+            this.tui.error('Failed to switch mode: plan mode plugin unavailable');
           }
           break;
 
         case 'save':
           if (this.sessionCommands.getCurrentSessionId()) {
             await this.sessionCommands.saveContext(this.context);
-            console.log('\n💾 Current session saved!');
+            this.tui.success('Current session saved!');
           } else {
-            console.log('\n❌ No active session. Create one with /new');
+            this.tui.error('No active session. Create one with /new');
           }
           break;
 
         case 'exit':
-          console.log('💾 Saving current session...');
+          this.tui.info('Saving current session...');
           await this.sessionCommands.saveContext(this.context);
-          console.log('Goodbye!');
+          this.tui.success('Goodbye!');
           process.exit(0);
           break;
 
         default:
-          console.log(`\n⚠️ Unknown command: ${command}`);
-          console.log('Type /help to see available commands');
+          this.tui.warn(`Unknown command: ${command}`);
+          this.tui.info('Type /help to see available commands');
       }
     } catch (error) {
-      console.error('\n❌ Error executing command:', error);
+      this.tui.error(`Error executing command: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
 
   async start() {
-    console.log('🚀 Pulse Coder CLI is running...');
-    console.log('Type your messages and press Enter. Type "exit" to quit.');
-    console.log('Press Esc to stop current response and continue with new input.');
-    console.log('Press Ctrl+C to exit CLI.');
-    console.log('Commands starting with "/" will trigger command mode.\n');
+    this.tui.showWelcome();
 
     await this.sessionCommands.initialize();
     await memoryIntegration.initialize();
@@ -349,7 +354,7 @@ class CoderCLI {
 
     // 显示插件状态
     const pluginStatus = this.agent.getPluginStatus();
-    console.log(`✅ Built-in plugins loaded: ${pluginStatus.enginePlugins.length} plugins`);
+    this.tui.showPluginStatus(pluginStatus.enginePlugins.length);
 
     // Auto-create a new session
     await this.sessionCommands.createSession();
@@ -358,7 +363,7 @@ class CoderCLI {
     const rl = readline.createInterface({
       input: process.stdin,
       output: process.stdout,
-      prompt: '> '
+      prompt: this.tui.prompt()
     });
 
     let currentAbortController: AbortController | null = null;
@@ -372,9 +377,9 @@ class CoderCLI {
       if (isProcessing) {
         if (currentAbortController && !currentAbortController.signal.aborted) {
           currentAbortController.abort();
-          console.log('\n[Abort] Request cancelled by Esc. You can type the next message now.');
+          this.tui.abort('Request cancelled by Esc. You can type the next message now.');
         } else {
-          console.log('\n[Abort] Cancellation already requested. Waiting for current step to finish...');
+          this.tui.abort('Cancellation already requested. Waiting for current step to finish...');
         }
         rl.prompt();
         return true;
@@ -382,7 +387,7 @@ class CoderCLI {
 
       if (this.inputManager.hasPendingRequest()) {
         this.inputManager.cancel('User interrupted with Esc');
-        console.log('\n[Abort] Clarification cancelled.');
+        this.tui.abort('Clarification cancelled.');
         rl.prompt();
         return true;
       }
@@ -410,10 +415,10 @@ class CoderCLI {
         this.inputManager.cancel('User interrupted with Ctrl+C');
       }
 
-      console.log('\n💾 Saving current session...');
+      this.tui.info('Saving current session...');
       const cleanupTeams = teamsSession?.active ? teamsSession.stop().catch(() => {}) : Promise.resolve();
       cleanupTeams.then(() => this.sessionCommands.saveContext(this.context)).finally(() => {
-        console.log('👋 Goodbye!');
+        this.tui.success('Goodbye!');
         process.exit(0);
       });
     });
@@ -435,20 +440,20 @@ class CoderCLI {
           }
 
           queuedInputs.push(trimmedInput);
-          console.log('\n📝 Input queued. It will run right after the current step finishes.');
+          this.tui.queued('Input queued. It will run right after the current step finishes.');
           rl.prompt();
           return;
         }
 
-        console.log('\n⏳ Still processing. Press Esc to stop current request first.');
+        this.tui.warn('Still processing. Press Esc to stop current request first.');
         rl.prompt();
         return;
       }
 
       if (trimmedInput.toLowerCase() === 'exit') {
-        console.log('💾 Saving current session...');
+        this.tui.info('Saving current session...');
         await this.sessionCommands.saveContext(this.context);
-        console.log('👋 Goodbye!');
+        this.tui.success('Goodbye!');
         rl.close();
         return;
       }
@@ -464,7 +469,7 @@ class CoderCLI {
       if (trimmedInput.startsWith('//')) {
         const acpState = await getAcpState(this.acpPlatformKey);
         if (!acpState) {
-          console.log('\n⚠️ ACP 未启用，请先使用 /acp on <claude|codex>。');
+          this.tui.warn('ACP 未启用，请先使用 /acp on <claude|codex>。');
           rl.prompt();
           return;
         }
@@ -478,7 +483,7 @@ class CoderCLI {
         const parts = commandLine.split(/\s+/).filter(part => part.length > 0);
 
         if (parts.length === 0) {
-          console.log('\n⚠️ Please provide a command after "/"');
+          this.tui.warn('Please provide a command after "/"');
           rl.prompt();
           return;
         }
@@ -498,8 +503,8 @@ class CoderCLI {
           if (acpState) {
             forceAcp = true;
           } else {
-            console.log(`\n⚠️ Unknown command: /${command}`);
-            console.log('Type /help to see available commands');
+            this.tui.warn(`Unknown command: /${command}`);
+            this.tui.info('Type /help to see available commands');
             rl.prompt();
             return;
           }
@@ -521,7 +526,7 @@ class CoderCLI {
               const session = await TeamsSession.start(args);
               if (session) {
                 teamsSession = session;
-                rl.setPrompt('teams> ');
+                rl.setPrompt(this.tui.prompt('teams'));
               }
             } finally {
               isProcessing = false;
@@ -534,12 +539,12 @@ class CoderCLI {
               try {
                 await teamsSession.stop();
                 teamsSession = null;
-                rl.setPrompt('> ');
+                rl.setPrompt(this.tui.prompt());
               } finally {
                 isProcessing = false;
               }
             } else {
-              console.log('\n⚠️ Not in teams mode. Use /teams <task> to start.');
+              this.tui.warn('Not in teams mode. Use /teams <task> to start.');
             }
             rl.prompt();
             return;
@@ -553,21 +558,21 @@ class CoderCLI {
             messageInput = transformedMessage;
           } else if (normalizedCommand === 'wt') {
             if (args.length < 2 || args[0].toLowerCase() !== 'use') {
-              console.log('\n❌ Usage: /wt use <work-name>');
+              this.tui.error('Usage: /wt use <work-name>');
               rl.prompt();
               return;
             }
 
             const workName = args.slice(1).join(' ').trim();
             if (!workName) {
-              console.log('\n❌ Worktree name cannot be empty.');
-              console.log('Usage: /wt use <work-name>');
+              this.tui.error('Worktree name cannot be empty.');
+              this.tui.info('Usage: /wt use <work-name>');
               rl.prompt();
               return;
             }
 
             messageInput = `[use skill](worktree) new ${workName}`;
-            console.log('\n✅ Worktree request prepared via skill: worktree');
+            this.tui.success('Worktree request prepared via skill: worktree');
           } else {
             await this.handleCommand(command, args);
             rl.prompt();
@@ -582,7 +587,7 @@ class CoderCLI {
         try {
           await teamsSession.followUp(messageInput);
         } catch (err: any) {
-          console.error(`\n❌ Teams follow-up error: ${err.message}`);
+          this.tui.error(`Teams follow-up error: ${err.message}`);
         } finally {
           isProcessing = false;
           rl.prompt();
@@ -597,7 +602,7 @@ class CoderCLI {
       });
 
 
-      console.log('\n🔄 Processing...\n');
+      this.tui.startProcessing(forceAcp ? 'Running ACP agent' : 'Running agent');
 
       const ac = new AbortController();
       currentAbortController = ac;
@@ -644,19 +649,18 @@ class CoderCLI {
           abortSignal: ac.signal,
           onText: (delta) => {
             sawText = true;
-            process.stdout.write(delta);
+            this.tui.text(delta);
           },
           onToolCall: (toolCall) => {
             const input = getToolInput(toolCall);
-            const inputText = input === undefined ? '' : `(${JSON.stringify(input)})`;
-            process.stdout.write(`\n🔧 ${resolveToolName(toolCall)}${inputText}\n`);
+            this.tui.toolCall(resolveToolName(toolCall), input);
           },
           onToolResult: (toolResult) => {
             const toolName = resolveToolName(toolResult as Record<string, unknown>);
-            process.stdout.write(`\n✅ ${toolName}\n`);
+            this.tui.toolResult(toolName);
           },
           onStepFinish: (step) => {
-            process.stdout.write(`\n📋 Step finished: ${step.finishReason}\n`);
+            this.tui.stepFinished(step.finishReason);
           },
           onClarificationRequest: async (request) => {
             return await this.inputManager.requestInput(request);
@@ -683,16 +687,15 @@ class CoderCLI {
             callbacks: {
               onText: (delta) => {
                 sawText = true;
-                process.stdout.write(delta);
+                this.tui.text(delta);
               },
               onToolCall: (toolCall) => {
                 const input = getToolInput(toolCall);
-                const inputText = input === undefined ? '' : `(${JSON.stringify(input)})`;
-                process.stdout.write(`\n🔧 ${resolveToolName(toolCall)}${inputText}\n`);
+                this.tui.toolCall(resolveToolName(toolCall), input);
               },
               onToolResult: (toolResult) => {
                 const toolName = resolveToolName(toolResult as Record<string, unknown>);
-                process.stdout.write(`\n✅ ${toolName}\n`);
+                this.tui.toolResult(toolName);
               },
 
               onClarificationRequest: async (request) => {
@@ -715,9 +718,9 @@ class CoderCLI {
 
         if (result) {
           if (!sawText) {
-            console.log(result);
+            this.tui.plain(result);
           } else {
-            console.log();
+            this.tui.plain();
           }
 
           await this.sessionCommands.saveContext(this.context);
@@ -732,9 +735,9 @@ class CoderCLI {
         }
       } catch (error) {
         if (error.name === 'AbortError') {
-          console.log('\n[Abort] Operation cancelled.');
+          this.tui.abort('Operation cancelled.');
         } else {
-          console.error('\n❌ Error:', error.message);
+          this.tui.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         }
       } finally {
         isProcessing = false;
@@ -743,7 +746,7 @@ class CoderCLI {
         if (queuedInputs.length > 0) {
           const nextInput = queuedInputs.shift();
           if (nextInput) {
-            console.log('\n▶️ Running queued input...');
+            this.tui.info('Running queued input...');
             setImmediate(() => {
               void handleInput(nextInput);
             });
@@ -762,9 +765,9 @@ class CoderCLI {
     // Handle terminal close
     rl.on('close', async () => {
       process.stdin.off('keypress', onKeypress);
-      console.log('\n💾 Saving current session...');
+      this.tui.info('Saving current session...');
       await this.sessionCommands.saveContext(this.context);
-      console.log('👋 Goodbye!');
+      this.tui.success('Goodbye!');
       process.exit(0);
     });
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,7 +11,6 @@ import { memoryIntegration, buildMemoryRunContext, recordDailyLogFromSuccessPath
 import { ACP_CLIENT_INFO, handleAcpCommand, resolveAcpPlatformKey } from './acp-commands.js';
 import { TuiRenderer, type TuiHelpItem } from './tui-renderer.js';
 import { resolveCliUiMode } from './ui-mode.js';
-import { startInkTui } from './ink-launcher.js';
 
 const LOCAL_COMMANDS = new Set([
   'help',
@@ -818,6 +817,7 @@ class CoderCLI {
 
 async function main(): Promise<void> {
   if (resolveCliUiMode() === 'ink') {
+    const { startInkTui } = await import('./ink-launcher.js');
     await startInkTui();
     return;
   }

--- a/packages/cli/src/ink-app.tsx
+++ b/packages/cli/src/ink-app.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { Box, Text, useApp, useInput } from 'ink';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Box, Text, useApp, useInput, useStdout } from 'ink';
 
 export type InkEventKind = 'user' | 'assistant' | 'tool' | 'result' | 'system' | 'error';
 
@@ -21,8 +21,16 @@ export interface InkCliSnapshot {
   events: InkCliEvent[];
 }
 
+export interface InkCliController {
+  getSnapshot: () => InkCliSnapshot;
+  submitInput: (input: string) => void | Promise<void>;
+  requestStop: () => void;
+  shutdown: () => void | Promise<void>;
+  subscribe: (listener: (snapshot: InkCliSnapshot) => void) => () => void;
+}
+
 interface InkCliAppProps {
-  initialSnapshot?: Partial<InkCliSnapshot>;
+  controller: InkCliController;
   onExit?: () => void;
 }
 
@@ -55,36 +63,92 @@ const KIND_COLOR: Record<InkEventKind, string> = {
   error: 'red',
 };
 
-export function InkCliApp({ initialSnapshot, onExit }: InkCliAppProps) {
-  const [snapshot, setSnapshot] = useState<InkCliSnapshot>({
-    ...DEFAULT_SNAPSHOT,
-    ...initialSnapshot,
-    events: initialSnapshot?.events ?? DEFAULT_SNAPSHOT.events,
-  });
-  const app = useApp();
+const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
-  useInput((_input, key) => {
-    if (key.escape || (key.ctrl && _input === 'c')) {
-      setSnapshot(current => ({ ...current, status: 'Exiting…' }));
-      onExit?.();
-      app.exit();
-    }
-  });
+export function InkCliApp({ controller, onExit }: InkCliAppProps) {
+  const [snapshot, setSnapshot] = useState<InkCliSnapshot>(() => ({
+    ...DEFAULT_SNAPSHOT,
+    ...controller.getSnapshot(),
+  }));
+  const [input, setInput] = useState('');
+  const [cursorVisible, setCursorVisible] = useState(true);
+  const [spinnerIndex, setSpinnerIndex] = useState(0);
+  const app = useApp();
+  const { stdout } = useStdout();
+
+  useEffect(() => controller.subscribe(setSnapshot), [controller]);
 
   useEffect(() => {
-    const timer = setInterval(() => {
-      setSnapshot(current => {
-        if (!current.isProcessing) {
-          return current;
-        }
-        return { ...current, status: current.status.endsWith('…') ? 'Running' : `${current.status}…` };
-      });
-    }, 500);
-
+    const timer = setInterval(() => setCursorVisible(current => !current), 500);
     return () => clearInterval(timer);
   }, []);
 
-  const visibleEvents = snapshot.events.slice(-8);
+  useEffect(() => {
+    if (!snapshot.isProcessing) {
+      return;
+    }
+
+    const timer = setInterval(() => setSpinnerIndex(current => current + 1), 120);
+    return () => clearInterval(timer);
+  }, [snapshot.isProcessing]);
+
+  useInput((value, key) => {
+    if (key.ctrl && value === 'c') {
+      void controller.shutdown();
+      onExit?.();
+      app.exit();
+      return;
+    }
+
+    if (key.escape) {
+      if (snapshot.isProcessing) {
+        controller.requestStop();
+        return;
+      }
+
+      void controller.shutdown();
+      onExit?.();
+      app.exit();
+      return;
+    }
+
+    if (key.return) {
+      const submitted = input;
+      setInput('');
+      void (async () => {
+        await controller.submitInput(submitted);
+        const normalized = submitted.trim().toLowerCase();
+        if (normalized === 'exit' || normalized === '/exit') {
+          onExit?.();
+          app.exit();
+        }
+      })();
+      return;
+    }
+
+    if (key.backspace || key.delete) {
+      setInput(current => current.slice(0, -1));
+      return;
+    }
+
+    if (key.ctrl && value === 'u') {
+      setInput('');
+      return;
+    }
+
+    if (value && !key.ctrl && !key.meta) {
+      setInput(current => `${current}${value}`);
+    }
+  });
+
+  const terminalRows = stdout.rows ?? 30;
+  const visibleEventCount = Math.max(4, Math.min(12, terminalRows - 8));
+  const visibleEvents = snapshot.events.slice(-visibleEventCount);
+  const spinner = snapshot.isProcessing ? SPINNER_FRAMES[spinnerIndex % SPINNER_FRAMES.length] : '●';
+  const prompt = useMemo(() => {
+    const cursor = cursorVisible ? '█' : ' ';
+    return `${input}${cursor}`;
+  }, [cursorVisible, input]);
 
   return (
     <Box flexDirection="column" paddingX={1}>
@@ -99,7 +163,7 @@ export function InkCliApp({ initialSnapshot, onExit }: InkCliAppProps) {
 
       <Box marginTop={1} flexDirection="column">
         {visibleEvents.length === 0 ? (
-          <Text color="gray">Type in the classic prompt below. Ink event cards will appear here as the agent runs.</Text>
+          <Text color="gray">Type a message below. Use /help for commands.</Text>
         ) : visibleEvents.map(event => (
           <Box key={event.id} flexDirection="column" marginBottom={1}>
             <Text bold color={KIND_COLOR[event.kind]}>
@@ -110,10 +174,11 @@ export function InkCliApp({ initialSnapshot, onExit }: InkCliAppProps) {
         ))}
       </Box>
 
-      <Box borderStyle="single" borderColor={snapshot.isProcessing ? 'yellow' : 'green'} paddingX={1}>
+      <Box borderStyle="single" borderColor={snapshot.isProcessing ? 'yellow' : 'green'} paddingX={1} flexDirection="column">
         <Text color={snapshot.isProcessing ? 'yellow' : 'green'}>
-          {snapshot.status} · Esc/Ctrl+C exits Ink shell · fallback: PULSE_CODER_UI=readline
+          {spinner} {snapshot.status} · Enter send · Esc {snapshot.isProcessing ? 'stop' : 'exit'} · Ctrl+C exit
         </Text>
+        <Text color="cyan">› <Text color="white">{prompt}</Text></Text>
       </Box>
     </Box>
   );

--- a/packages/cli/src/ink-app.tsx
+++ b/packages/cli/src/ink-app.tsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Text, useApp, useInput } from 'ink';
+
+export type InkEventKind = 'user' | 'assistant' | 'tool' | 'result' | 'system' | 'error';
+
+export interface InkCliEvent {
+  id: string;
+  kind: InkEventKind;
+  title?: string;
+  text: string;
+}
+
+export interface InkCliSnapshot {
+  sessionId?: string | null;
+  taskListId?: string | null;
+  mode?: string | null;
+  messages: number;
+  estimatedTokens: number;
+  isProcessing: boolean;
+  status: string;
+  events: InkCliEvent[];
+}
+
+interface InkCliAppProps {
+  initialSnapshot?: Partial<InkCliSnapshot>;
+  onExit?: () => void;
+}
+
+const DEFAULT_SNAPSHOT: InkCliSnapshot = {
+  sessionId: null,
+  taskListId: null,
+  mode: null,
+  messages: 0,
+  estimatedTokens: 0,
+  isProcessing: false,
+  status: 'Ready',
+  events: [],
+};
+
+const KIND_LABEL: Record<InkEventKind, string> = {
+  user: 'You',
+  assistant: 'Assistant',
+  tool: 'Tool',
+  result: 'Result',
+  system: 'System',
+  error: 'Error',
+};
+
+const KIND_COLOR: Record<InkEventKind, string> = {
+  user: 'cyan',
+  assistant: 'green',
+  tool: 'magenta',
+  result: 'green',
+  system: 'blue',
+  error: 'red',
+};
+
+export function InkCliApp({ initialSnapshot, onExit }: InkCliAppProps) {
+  const [snapshot, setSnapshot] = useState<InkCliSnapshot>({
+    ...DEFAULT_SNAPSHOT,
+    ...initialSnapshot,
+    events: initialSnapshot?.events ?? DEFAULT_SNAPSHOT.events,
+  });
+  const app = useApp();
+
+  useInput((_input, key) => {
+    if (key.escape || (key.ctrl && _input === 'c')) {
+      setSnapshot(current => ({ ...current, status: 'Exiting…' }));
+      onExit?.();
+      app.exit();
+    }
+  });
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setSnapshot(current => {
+        if (!current.isProcessing) {
+          return current;
+        }
+        return { ...current, status: current.status.endsWith('…') ? 'Running' : `${current.status}…` };
+      });
+    }, 500);
+
+    return () => clearInterval(timer);
+  }, []);
+
+  const visibleEvents = snapshot.events.slice(-8);
+
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      <Box borderStyle="round" borderColor="cyan" paddingX={1} flexDirection="column">
+        <Text bold color="cyan">Pulse Coder Ink</Text>
+        <Text color="gray">
+          session {snapshot.sessionId ?? 'new'} · {snapshot.messages} msgs · ~{snapshot.estimatedTokens} tokens
+          {snapshot.taskListId ? ` · tasks ${snapshot.taskListId}` : ''}
+          {snapshot.mode ? ` · mode ${snapshot.mode}` : ''}
+        </Text>
+      </Box>
+
+      <Box marginTop={1} flexDirection="column">
+        {visibleEvents.length === 0 ? (
+          <Text color="gray">Type in the classic prompt below. Ink event cards will appear here as the agent runs.</Text>
+        ) : visibleEvents.map(event => (
+          <Box key={event.id} flexDirection="column" marginBottom={1}>
+            <Text bold color={KIND_COLOR[event.kind]}>
+              {KIND_LABEL[event.kind]}{event.title ? ` · ${event.title}` : ''}
+            </Text>
+            <Text>{event.text}</Text>
+          </Box>
+        ))}
+      </Box>
+
+      <Box borderStyle="single" borderColor={snapshot.isProcessing ? 'yellow' : 'green'} paddingX={1}>
+        <Text color={snapshot.isProcessing ? 'yellow' : 'green'}>
+          {snapshot.status} · Esc/Ctrl+C exits Ink shell · fallback: PULSE_CODER_UI=readline
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/ink-app.tsx
+++ b/packages/cli/src/ink-app.tsx
@@ -1,7 +1,14 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Box, Text, useApp, useInput, useStdout } from 'ink';
 
 export type InkEventKind = 'user' | 'assistant' | 'tool' | 'result' | 'system' | 'error';
+
+interface InkRuntime {
+  Box: React.ComponentType<any>;
+  Text: React.ComponentType<any>;
+  useApp: () => { exit: () => void };
+  useInput: (handler: (input: string, key: any) => void) => void;
+  useStdout: () => { stdout: { rows?: number } };
+}
 
 export interface InkCliEvent {
   id: string;
@@ -31,6 +38,7 @@ export interface InkCliController {
 
 interface InkCliAppProps {
   controller: InkCliController;
+  runtime: InkRuntime;
   onExit?: () => void;
 }
 
@@ -65,7 +73,8 @@ const KIND_COLOR: Record<InkEventKind, string> = {
 
 const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
-export function InkCliApp({ controller, onExit }: InkCliAppProps) {
+export function InkCliApp({ controller, runtime, onExit }: InkCliAppProps) {
+  const { Box, Text, useApp, useInput, useStdout } = runtime;
   const [snapshot, setSnapshot] = useState<InkCliSnapshot>(() => ({
     ...DEFAULT_SNAPSHOT,
     ...controller.getSnapshot(),

--- a/packages/cli/src/ink-controller.ts
+++ b/packages/cli/src/ink-controller.ts
@@ -1,0 +1,762 @@
+import { PulseAgent, type Context, type TaskListService } from 'pulse-coder-engine';
+import { createJsExecutor, createRunJsTool } from 'pulse-sandbox/src';
+import { getAcpState, runAcp } from 'pulse-coder-acp';
+
+import { ACP_CLIENT_INFO, handleAcpCommand, resolveAcpPlatformKey } from './acp-commands.js';
+import { InputManager } from './input-manager.js';
+import { memoryIntegration, buildMemoryRunContext, recordDailyLogFromSuccessPath } from './memory-integration.js';
+import { SessionCommands } from './session-commands.js';
+import { SkillCommands } from './skill-commands.js';
+import { runTeam, TeamsSession } from './team-commands.js';
+import type { TuiHelpItem } from './tui-renderer.js';
+import { InkUiBridge } from './ink-ui-bridge.js';
+import type { InkCliController, InkCliSnapshot } from './ink-app.js';
+
+const LOCAL_COMMANDS = new Set([
+  'help',
+  'new',
+  'resume',
+  'sessions',
+  'search',
+  'rename',
+  'delete',
+  'clear',
+  'compact',
+  'skills',
+  'wt',
+  'acp',
+  'status',
+  'mode',
+  'plan',
+  'execute',
+  'team',
+  'teams',
+  'solo',
+  'save',
+  'tui',
+  'exit',
+]);
+
+const HELP_ITEMS: TuiHelpItem[] = [
+  { command: '/help', description: 'Show this help message' },
+  { command: '/new [title]', description: 'Create a new session' },
+  { command: '/resume <id>', description: 'Resume a saved session' },
+  { command: '/sessions', description: 'List all saved sessions' },
+  { command: '/search <query>', description: 'Search in saved sessions' },
+  { command: '/rename <id> <new-title>', description: 'Rename a session' },
+  { command: '/delete <id>', description: 'Delete a session' },
+  { command: '/clear', description: 'Clear current conversation' },
+  { command: '/compact', description: 'Force compact current conversation context' },
+  { command: '/skills [list|<name|index> <message>]', description: 'Run one message with a selected skill' },
+  { command: '/acp [status|on|off|cd]', description: 'Manage ACP mode for this CLI' },
+  { command: '/wt use <work-name>', description: 'Create a worktree + branch via worktree skill' },
+  { command: '/status', description: 'Show current session status' },
+  { command: '/mode', description: 'Show current plan mode' },
+  { command: '/plan', description: 'Switch to planning mode' },
+  { command: '/execute', description: 'Switch to executing mode' },
+  { command: '/team <task>', description: 'Run a multi-agent team (LLM plans DAG by default)' },
+  { command: '/teams <task>', description: 'Run agent teams (enters teams mode for follow-ups)' },
+  { command: '/solo', description: 'Exit teams mode, return to normal agent' },
+  { command: '/save', description: 'Save current session explicitly' },
+  { command: '/tui [status]', description: 'Show current Ink UI status' },
+  { command: '/exit', description: 'Exit the application' },
+];
+
+const HELP_FOOTER = [
+  'Esc (while processing) - Stop current response and accept next input',
+  'Ctrl+C - Save and exit CLI immediately',
+];
+
+class InkCoderController implements InkCliController {
+  private readonly agent: PulseAgent;
+  private readonly context: Context;
+  private readonly sessionCommands: SessionCommands;
+  private readonly inputManager: InputManager;
+  private readonly skillCommands: SkillCommands;
+  private readonly acpPlatformKey: string;
+  private readonly ui: InkUiBridge;
+  private readonly listeners = new Set<(snapshot: InkCliSnapshot) => void>();
+  private currentAbortController: AbortController | null = null;
+  private isProcessing = false;
+  private isShuttingDown = false;
+  private teamsSession: TeamsSession | null = null;
+  private readonly queuedInputs: string[] = [];
+
+  constructor() {
+    const runJsTool = createRunJsTool({
+      executor: createJsExecutor()
+    });
+
+    this.agent = new PulseAgent({
+      enginePlugins: {
+        plugins: [memoryIntegration.enginePlugin],
+        dirs: ['.pulse-coder/engine-plugins', '.coder/engine-plugins', '~/.pulse-coder/engine-plugins', '~/.coder/engine-plugins'],
+        scan: true
+      },
+      userConfigPlugins: {
+        dirs: ['.pulse-coder/config', '.coder/config', '~/.pulse-coder/config', '~/.coder/config'],
+        scan: true
+      },
+      tools: {
+        [runJsTool.name]: runJsTool
+      }
+    });
+    this.context = { messages: [] };
+    this.ui = new InkUiBridge({
+      onChange: snapshot => this.notify(snapshot),
+    });
+    this.sessionCommands = new SessionCommands(message => this.ui.info(message ?? ''));
+    this.inputManager = new InputManager({
+      onRequest: request => this.ui.clarification(request),
+    });
+    this.skillCommands = new SkillCommands(this.agent, message => this.ui.info(message ?? ''));
+    this.acpPlatformKey = resolveAcpPlatformKey();
+  }
+
+  async initialize(): Promise<void> {
+    this.ui.showWelcome();
+    await this.sessionCommands.initialize();
+    await memoryIntegration.initialize();
+    await this.agent.initialize();
+
+    const pluginStatus = this.agent.getPluginStatus();
+    this.ui.showPluginStatus(pluginStatus.enginePlugins.length);
+
+    await this.sessionCommands.createSession();
+    await this.syncSessionTaskListBinding();
+    this.publishSession('Ready');
+  }
+
+  getSnapshot(): InkCliSnapshot {
+    return this.ui.getSnapshot();
+  }
+
+  subscribe(listener: (snapshot: InkCliSnapshot) => void): () => void {
+    this.listeners.add(listener);
+    listener(this.getSnapshot());
+    return () => this.listeners.delete(listener);
+  }
+
+  requestStop(): void {
+    if (this.isProcessing) {
+      if (this.currentAbortController && !this.currentAbortController.signal.aborted) {
+        this.currentAbortController.abort();
+        this.ui.abort('Request cancelled by Esc. You can type the next message now.');
+      } else {
+        this.ui.abort('Cancellation already requested. Waiting for current step to finish...');
+      }
+      return;
+    }
+
+    if (this.inputManager.hasPendingRequest()) {
+      this.inputManager.cancel('User interrupted with Esc');
+      this.ui.abort('Clarification cancelled.');
+    }
+  }
+
+  async submitInput(input: string): Promise<void> {
+    const trimmedInput = input.trim();
+
+    if (this.inputManager.handleUserInput(trimmedInput)) {
+      this.ui.user(trimmedInput || '(empty clarification response)');
+      this.publishSession('Clarification submitted');
+      return;
+    }
+
+    if (this.isProcessing) {
+      if (this.currentAbortController?.signal.aborted) {
+        if (trimmedInput) {
+          this.queuedInputs.push(trimmedInput);
+          this.ui.queued('Input queued. It will run right after the current step finishes.');
+        }
+        return;
+      }
+
+      this.ui.warn('Still processing. Press Esc to stop current request first.');
+      return;
+    }
+
+    if (!trimmedInput) {
+      return;
+    }
+
+    if (trimmedInput.toLowerCase() === 'exit') {
+      await this.shutdown();
+      return;
+    }
+
+    await this.handleInput(trimmedInput);
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.isShuttingDown) {
+      return;
+    }
+    this.isShuttingDown = true;
+
+    if (this.isProcessing && this.currentAbortController && !this.currentAbortController.signal.aborted) {
+      this.currentAbortController.abort();
+    }
+
+    if (this.inputManager.hasPendingRequest()) {
+      this.inputManager.cancel('User interrupted with Ctrl+C');
+    }
+
+    this.ui.info('Saving current session...');
+    try {
+      if (this.teamsSession?.active) {
+        await this.teamsSession.stop();
+      }
+      await this.sessionCommands.saveContext(this.context);
+      this.ui.success('Goodbye!');
+    } catch (error) {
+      this.ui.error(`Error while shutting down: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  private async handleInput(input: string): Promise<void> {
+    let messageInput = input;
+    let forceAcp = false;
+
+    if (input.startsWith('//')) {
+      const acpState = await getAcpState(this.acpPlatformKey);
+      if (!acpState) {
+        this.ui.warn('ACP 未启用，请先使用 /acp on <claude|codex>。');
+        return;
+      }
+      messageInput = input.slice(1);
+      forceAcp = true;
+    }
+
+    if (messageInput.startsWith('/') && !forceAcp) {
+      const commandLine = messageInput.substring(1);
+      const parts = commandLine.split(/\s+/).filter(part => part.length > 0);
+
+      if (parts.length === 0) {
+        this.ui.warn('Please provide a command after "/"');
+        return;
+      }
+
+      const command = parts[0];
+      const args = parts.slice(1);
+      const normalizedCommand = command.toLowerCase();
+
+      if (normalizedCommand === 'acp') {
+        await this.handleCommand(command, args);
+        return;
+      }
+
+      if (!LOCAL_COMMANDS.has(normalizedCommand)) {
+        const acpState = await getAcpState(this.acpPlatformKey);
+        if (acpState) {
+          forceAcp = true;
+        } else {
+          this.ui.warn(`Unknown command: /${command}`);
+          this.ui.info('Type /help to see available commands');
+          return;
+        }
+      }
+
+      if (!forceAcp) {
+        if (normalizedCommand === 'team') {
+          await this.runExclusive(async () => runTeam(this.agent, args));
+          return;
+        }
+
+        if (normalizedCommand === 'teams') {
+          await this.runExclusive(async () => {
+            const session = await TeamsSession.start(args);
+            if (session) {
+              this.teamsSession = session;
+              this.ui.success('Entered teams mode. Use /solo to return to normal agent.');
+            }
+          });
+          return;
+        }
+
+        if (normalizedCommand === 'solo') {
+          if (this.teamsSession?.active) {
+            await this.runExclusive(async () => {
+              await this.teamsSession?.stop();
+              this.teamsSession = null;
+              this.ui.success('Exited teams mode.');
+            });
+          } else {
+            this.ui.warn('Not in teams mode. Use /teams <task> to start.');
+          }
+          return;
+        }
+
+        if (normalizedCommand === 'skills') {
+          const transformedMessage = await this.skillCommands.transformSkillsCommandToMessage(args);
+          if (!transformedMessage) {
+            return;
+          }
+          messageInput = transformedMessage;
+        } else if (normalizedCommand === 'wt') {
+          if (args.length < 2 || args[0].toLowerCase() !== 'use') {
+            this.ui.error('Usage: /wt use <work-name>');
+            return;
+          }
+
+          const workName = args.slice(1).join(' ').trim();
+          if (!workName) {
+            this.ui.error('Worktree name cannot be empty.');
+            this.ui.info('Usage: /wt use <work-name>');
+            return;
+          }
+
+          messageInput = `[use skill](worktree) new ${workName}`;
+          this.ui.success('Worktree request prepared via skill: worktree');
+        } else {
+          await this.handleCommand(command, args);
+          return;
+        }
+      }
+    }
+
+    if (this.teamsSession?.active && !forceAcp) {
+      await this.runExclusive(async () => this.teamsSession?.followUp(messageInput));
+      return;
+    }
+
+    await this.runMessage(messageInput, forceAcp);
+  }
+
+  private async handleCommand(command: string, args: string[]): Promise<void> {
+    try {
+      switch (command.toLowerCase()) {
+        case 'help':
+          this.ui.showHelp(HELP_ITEMS, HELP_FOOTER);
+          break;
+        case 'new':
+          await this.sessionCommands.createSession(args.join(' ') || undefined);
+          this.context.messages = [];
+          await this.syncSessionTaskListBinding();
+          this.publishSession('New session created');
+          break;
+        case 'resume':
+          if (args.length === 0) {
+            this.ui.error('Please provide a session ID');
+            this.ui.info('Usage: /resume <session-id>');
+            break;
+          }
+          if (await this.sessionCommands.resumeSession(args[0])) {
+            await this.sessionCommands.loadContext(this.context);
+            await this.syncSessionTaskListBinding();
+            this.publishSession('Session resumed');
+          }
+          break;
+        case 'sessions':
+          await this.sessionCommands.listSessions();
+          break;
+        case 'search':
+          if (args.length === 0) {
+            this.ui.error('Please provide a search query');
+            this.ui.info('Usage: /search <query>');
+            break;
+          }
+          await this.sessionCommands.searchSessions(args.join(' '));
+          break;
+        case 'rename':
+          if (args.length < 2) {
+            this.ui.error('Please provide session ID and new title');
+            this.ui.info('Usage: /rename <session-id> <new-title>');
+            break;
+          }
+          await this.sessionCommands.renameSession(args[0], args.slice(1).join(' '));
+          break;
+        case 'delete':
+          if (args.length === 0) {
+            this.ui.error('Please provide a session ID');
+            this.ui.info('Usage: /delete <session-id>');
+            break;
+          }
+          await this.sessionCommands.deleteSession(args[0]);
+          this.publishSession('Session deleted');
+          break;
+        case 'clear':
+          this.context.messages = [];
+          this.ui.success('Current conversation cleared!');
+          this.publishSession('Ready');
+          break;
+        case 'compact':
+          await this.compactContext();
+          break;
+        case 'skills':
+          this.ui.info('Use /skills <name|index> <message> directly in input for one-shot skill execution.');
+          break;
+        case 'acp': {
+          const message = await handleAcpCommand(this.acpPlatformKey, args);
+          this.ui.info(message);
+          break;
+        }
+        case 'status':
+          this.ui.section('Session Status', [
+            `Current Session: ${this.sessionCommands.getCurrentSessionId() || 'None (new session)'}`,
+            `Task List: ${this.sessionCommands.getCurrentTaskListId() || 'None'}`,
+            `Messages: ${this.context.messages.length}`,
+          ]);
+          break;
+        case 'mode': {
+          const currentMode = this.agent.getMode();
+          if (!currentMode) {
+            this.ui.warn('plan mode plugin unavailable');
+          } else {
+            this.ui.info(`Current mode: ${currentMode}`);
+          }
+          break;
+        }
+        case 'plan':
+          if (this.agent.setMode('planning', 'cli:/plan')) {
+            this.ui.success('Switched to planning mode');
+            this.publishSession('Ready');
+          } else {
+            this.ui.error('Failed to switch mode: plan mode plugin unavailable');
+          }
+          break;
+        case 'execute':
+          if (this.agent.setMode('executing', 'cli:/execute')) {
+            this.ui.success('Switched to executing mode');
+            this.publishSession('Ready');
+          } else {
+            this.ui.error('Failed to switch mode: plan mode plugin unavailable');
+          }
+          break;
+        case 'tui':
+          this.ui.showTuiStatus();
+          break;
+        case 'save':
+          if (this.sessionCommands.getCurrentSessionId()) {
+            await this.sessionCommands.saveContext(this.context);
+            this.ui.success('Current session saved!');
+          } else {
+            this.ui.error('No active session. Create one with /new');
+          }
+          break;
+        case 'exit':
+          await this.shutdown();
+          break;
+        default:
+          this.ui.warn(`Unknown command: ${command}`);
+          this.ui.info('Type /help to see available commands');
+      }
+    } catch (error) {
+      this.ui.error(`Error executing command: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  private async compactContext(): Promise<void> {
+    if (this.context.messages.length === 0) {
+      this.ui.info('Context is empty, nothing to compact.');
+      return;
+    }
+
+    const beforeCount = this.context.messages.length;
+    const beforeTokens = this.estimateTokens(this.context.messages);
+    const keepLastTurns = this.getKeepLastTurns();
+    const compactResult = await this.agent.compactContext(this.context, { force: true });
+
+    if (!compactResult.didCompact || !compactResult.newMessages) {
+      this.ui.info('No compaction was applied.');
+      this.ui.info(`Messages: ${beforeCount}, estimated tokens: ~${beforeTokens}, KEEP_LAST_TURNS=${keepLastTurns}`);
+      return;
+    }
+
+    this.context.messages = compactResult.newMessages;
+    await this.sessionCommands.saveContext(this.context);
+
+    const afterCount = this.context.messages.length;
+    const afterTokens = this.estimateTokens(this.context.messages);
+    const tokenDelta = beforeTokens - afterTokens;
+    const tokenDeltaText = tokenDelta >= 0 ? `-${tokenDelta}` : `+${Math.abs(tokenDelta)}`;
+    const reasonSuffix = compactResult.reason ? ` (${compactResult.reason})` : '';
+
+    this.ui.section(`Context compacted${reasonSuffix}`, [
+      `Messages: ${beforeCount} -> ${afterCount}`,
+      `Estimated tokens: ~${beforeTokens} -> ~${afterTokens} (${tokenDeltaText})`,
+      `KEEP_LAST_TURNS=${keepLastTurns}`,
+    ]);
+    this.publishSession('Ready');
+  }
+
+  private async runExclusive(task: () => Promise<unknown>): Promise<void> {
+    this.isProcessing = true;
+    this.ui.startProcessing('Running command');
+    try {
+      await task();
+      this.publishSession('Ready');
+    } catch (error) {
+      this.ui.error(`Command error: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      this.isProcessing = false;
+      this.ui.stopProcessing();
+    }
+  }
+
+  private async runMessage(messageInput: string, forceAcp: boolean): Promise<void> {
+    this.ui.user(messageInput);
+    this.ui.session({
+      sessionId: this.sessionCommands.getCurrentSessionId(),
+      taskListId: this.sessionCommands.getCurrentTaskListId(),
+      messages: this.context.messages.length,
+      estimatedTokens: this.estimateTokens(this.context.messages),
+      mode: this.agent.getMode(),
+    });
+
+    this.context.messages.push({
+      role: 'user',
+      content: messageInput,
+    });
+
+    this.ui.startProcessing(forceAcp ? 'Running ACP agent' : 'Running agent');
+
+    const ac = new AbortController();
+    this.currentAbortController = ac;
+    this.isProcessing = true;
+
+    let sawText = false;
+    let toolCalls = 0;
+    const runStartedAt = Date.now();
+
+    try {
+      await this.syncSessionTaskListBinding();
+      const acpState = await getAcpState(this.acpPlatformKey);
+      const currentSessionId = this.resolveCurrentSessionId();
+
+      const runAgent = async () => this.agent.run(this.context, {
+        abortSignal: ac.signal,
+        onText: (delta) => {
+          sawText = true;
+          this.ui.text(delta);
+        },
+        onToolCall: (toolCall) => {
+          toolCalls += 1;
+          const input = this.getToolInput(toolCall);
+          this.ui.toolCall(this.resolveToolName(toolCall), input);
+        },
+        onToolResult: (toolResult) => {
+          const toolName = this.resolveToolName(toolResult as Record<string, unknown>);
+          this.ui.toolResult(toolName);
+        },
+        onStepFinish: (step) => {
+          this.ui.stepFinished(step.finishReason);
+        },
+        onClarificationRequest: async (request) => {
+          return await this.inputManager.requestInput(request);
+        },
+        onCompacted: (newMessages) => {
+          this.context.messages = newMessages;
+        },
+        onResponse: (messages) => {
+          this.context.messages.push(...messages);
+        },
+      });
+
+      const runAcpAgent = async () => {
+        if (!acpState) {
+          return '';
+        }
+        const result = await runAcp({
+          platformKey: this.acpPlatformKey,
+          agent: acpState.agent,
+          cwd: acpState.cwd,
+          sessionId: acpState.sessionId,
+          userText: messageInput,
+          abortSignal: ac.signal,
+          clientInfo: ACP_CLIENT_INFO,
+          callbacks: {
+            onText: (delta) => {
+              sawText = true;
+              this.ui.text(delta);
+            },
+            onToolCall: (toolCall) => {
+              toolCalls += 1;
+              const input = this.getToolInput(toolCall);
+              this.ui.toolCall(this.resolveToolName(toolCall), input);
+            },
+            onToolResult: (toolResult) => {
+              const toolName = this.resolveToolName(toolResult as Record<string, unknown>);
+              this.ui.toolResult(toolName);
+            },
+            onClarificationRequest: async (request) => {
+              return await this.inputManager.requestInput(request);
+            },
+          },
+        });
+        return result.text;
+      };
+
+      const result = currentSessionId
+        ? await memoryIntegration.withRunContext(
+          buildMemoryRunContext({
+            sessionId: currentSessionId,
+            userText: messageInput,
+          }),
+          acpState ? runAcpAgent : runAgent,
+        )
+        : await (acpState ? runAcpAgent() : runAgent());
+
+      this.ui.runSummary({
+        elapsedMs: Date.now() - runStartedAt,
+        toolCalls,
+        messages: this.context.messages.length,
+        estimatedTokens: this.estimateTokens(this.context.messages),
+        mode: this.agent.getMode(),
+      });
+
+      if (result) {
+        if (!sawText) {
+          this.ui.plain(result);
+        }
+
+        await this.sessionCommands.saveContext(this.context);
+
+        if (currentSessionId) {
+          await recordDailyLogFromSuccessPath({
+            sessionId: currentSessionId,
+            userText: messageInput,
+            assistantText: result,
+          });
+        }
+      }
+    } catch (error: any) {
+      if (error?.name === 'AbortError') {
+        this.ui.abort('Operation cancelled.');
+      } else {
+        this.ui.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    } finally {
+      this.isProcessing = false;
+      this.currentAbortController = null;
+      this.publishSession('Ready');
+
+      if (this.queuedInputs.length > 0) {
+        const nextInput = this.queuedInputs.shift();
+        if (nextInput) {
+          this.ui.info('Running queued input...');
+          setImmediate(() => {
+            void this.submitInput(nextInput);
+          });
+        }
+      }
+    }
+  }
+
+  private async syncSessionTaskListBinding(): Promise<void> {
+    const taskListId = this.sessionCommands.getCurrentTaskListId();
+    if (!taskListId) {
+      return;
+    }
+
+    process.env.PULSE_CODER_TASK_LIST_ID = taskListId;
+
+    const service = this.agent.getService<TaskListService>('taskListService');
+    if (!service?.setTaskListId) {
+      return;
+    }
+
+    try {
+      const result = await service.setTaskListId(taskListId);
+      if (result.switched) {
+        this.ui.success(`Switched task list to ${result.taskListId}`);
+      }
+    } catch (error: any) {
+      this.ui.warn(`Failed to switch task list binding: ${error?.message ?? String(error)}`);
+    }
+  }
+
+  private resolveCurrentSessionId(): string | null {
+    const currentId = this.sessionCommands.getCurrentSessionId();
+    if (currentId) {
+      return currentId;
+    }
+
+    this.ui.warn('No active session ID; memory tools and daily logs are skipped for this run.');
+    return null;
+  }
+
+  private publishSession(status: string): void {
+    this.ui.updateSnapshot({
+      sessionId: this.sessionCommands.getCurrentSessionId(),
+      taskListId: this.sessionCommands.getCurrentTaskListId(),
+      messages: this.context.messages.length,
+      estimatedTokens: this.estimateTokens(this.context.messages),
+      mode: this.agent.getMode(),
+      isProcessing: this.isProcessing,
+      status,
+    });
+  }
+
+  private notify(snapshot: InkCliSnapshot): void {
+    for (const listener of this.listeners) {
+      listener(snapshot);
+    }
+  }
+
+  private safeStringify(value: unknown): string {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+
+  private estimateTokens(messages: Context['messages']): number {
+    let totalChars = 0;
+
+    for (const message of messages) {
+      totalChars += message.role.length;
+      if (typeof message.content === 'string') {
+        totalChars += message.content.length;
+      } else {
+        totalChars += this.safeStringify(message.content).length;
+      }
+    }
+
+    return Math.ceil(totalChars / 4);
+  }
+
+  private getKeepLastTurns(): number {
+    const value = Number(process.env.KEEP_LAST_TURNS ?? 4);
+    if (!Number.isFinite(value) || value <= 0) {
+      return 4;
+    }
+
+    return Math.floor(value);
+  }
+
+  private getToolInput(toolCall: Record<string, unknown>): unknown {
+    const input = (toolCall as { input?: unknown }).input;
+    if (input !== undefined) {
+      return input;
+    }
+    const args = (toolCall as { args?: unknown }).args;
+    if (args !== undefined) {
+      return args;
+    }
+    return undefined;
+  }
+
+  private resolveToolName(payload: Record<string, unknown>): string {
+    const name = (payload as { toolName?: unknown }).toolName
+      ?? (payload as { name?: unknown }).name
+      ?? (payload as { tool?: unknown }).tool
+      ?? (payload as { title?: unknown }).title
+      ?? (payload as { kind?: unknown }).kind;
+    if (typeof name === 'string' && name.trim()) {
+      return name;
+    }
+    const toolCallId = (payload as { toolCallId?: unknown }).toolCallId;
+    if (typeof toolCallId === 'string' && toolCallId.trim()) {
+      return toolCallId;
+    }
+    return 'tool';
+  }
+}
+
+export async function createInkCoderController(): Promise<InkCliController> {
+  const controller = new InkCoderController();
+  await controller.initialize();
+  return controller;
+}

--- a/packages/cli/src/ink-launcher.tsx
+++ b/packages/cli/src/ink-launcher.tsx
@@ -1,22 +1,12 @@
 import React from 'react';
 import { render } from 'ink';
 
-import { InkCliApp, type InkCliEvent, type InkCliSnapshot } from './ink-app.js';
+import { InkCliApp } from './ink-app.js';
+import { createInkCoderController } from './ink-controller.js';
 
-export interface InkTuiOptions {
-  snapshot?: Partial<InkCliSnapshot>;
-  events?: InkCliEvent[];
-}
-
-export async function startInkTui(options: InkTuiOptions = {}): Promise<void> {
-  const instance = render(
-    <InkCliApp
-      initialSnapshot={{
-        ...options.snapshot,
-        events: options.events ?? options.snapshot?.events,
-      }}
-    />,
-  );
+export async function startInkTui(): Promise<void> {
+  const controller = await createInkCoderController();
+  const instance = render(<InkCliApp controller={controller} />);
 
   await instance.waitUntilExit();
 }

--- a/packages/cli/src/ink-launcher.tsx
+++ b/packages/cli/src/ink-launcher.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render } from 'ink';
+
+import { InkCliApp, type InkCliEvent, type InkCliSnapshot } from './ink-app.js';
+
+export interface InkTuiOptions {
+  snapshot?: Partial<InkCliSnapshot>;
+  events?: InkCliEvent[];
+}
+
+export async function startInkTui(options: InkTuiOptions = {}): Promise<void> {
+  const instance = render(
+    <InkCliApp
+      initialSnapshot={{
+        ...options.snapshot,
+        events: options.events ?? options.snapshot?.events,
+      }}
+    />,
+  );
+
+  await instance.waitUntilExit();
+}

--- a/packages/cli/src/ink-launcher.tsx
+++ b/packages/cli/src/ink-launcher.tsx
@@ -1,12 +1,19 @@
 import React from 'react';
-import { render } from 'ink';
 
 import { InkCliApp } from './ink-app.js';
 import { createInkCoderController } from './ink-controller.js';
 
 export async function startInkTui(): Promise<void> {
+  const [{ render, Box, Text, useApp, useInput, useStdout }] = await Promise.all([
+    import('ink'),
+  ]);
   const controller = await createInkCoderController();
-  const instance = render(<InkCliApp controller={controller} />);
+  const instance = render(
+    <InkCliApp
+      controller={controller}
+      runtime={{ Box, Text, useApp, useInput, useStdout }}
+    />,
+  );
 
   await instance.waitUntilExit();
 }

--- a/packages/cli/src/ink-ui-bridge.test.ts
+++ b/packages/cli/src/ink-ui-bridge.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { InkUiBridge } from './ink-ui-bridge.js';
+import type { InkCliSnapshot } from './ink-app.js';
+
+describe('InkUiBridge', () => {
+  it('streams assistant deltas into one assistant event', () => {
+    const snapshots: InkCliSnapshot[] = [];
+    const bridge = new InkUiBridge({ onChange: snapshot => snapshots.push(snapshot) });
+
+    bridge.text('hello');
+    bridge.text(' world');
+
+    const last = snapshots[snapshots.length - 1];
+    expect(last.events).toHaveLength(1);
+    expect(last.events[0]).toMatchObject({
+      kind: 'assistant',
+      text: 'hello world',
+    });
+  });
+
+  it('resets assistant stream when a tool call is shown', () => {
+    const snapshots: InkCliSnapshot[] = [];
+    const bridge = new InkUiBridge({ onChange: snapshot => snapshots.push(snapshot) });
+
+    bridge.text('before');
+    bridge.toolCall('bash', { command: 'echo ok' });
+    bridge.text('after');
+
+    const events = snapshots[snapshots.length - 1].events;
+    expect(events.map(event => event.kind)).toEqual(['assistant', 'tool', 'assistant']);
+    expect(events[1].title).toBe('bash');
+    expect(events[2].text).toBe('after');
+  });
+
+  it('updates session snapshot and run summary status', () => {
+    const snapshots: InkCliSnapshot[] = [];
+    const bridge = new InkUiBridge({ onChange: snapshot => snapshots.push(snapshot) });
+
+    bridge.session({
+      sessionId: 's1',
+      taskListId: 'tasks-s1',
+      messages: 3,
+      estimatedTokens: 42,
+      mode: 'executing',
+    });
+    bridge.runSummary({
+      elapsedMs: 1234,
+      toolCalls: 2,
+      messages: 5,
+      estimatedTokens: 64,
+      mode: 'planning',
+    });
+
+    const last = snapshots[snapshots.length - 1];
+    expect(last.sessionId).toBe('s1');
+    expect(last.taskListId).toBe('tasks-s1');
+    expect(last.messages).toBe(5);
+    expect(last.estimatedTokens).toBe(64);
+    expect(last.mode).toBe('planning');
+    expect(last.isProcessing).toBe(false);
+    expect(last.status).toContain('Done in 1.2s');
+  });
+});

--- a/packages/cli/src/ink-ui-bridge.ts
+++ b/packages/cli/src/ink-ui-bridge.ts
@@ -1,0 +1,255 @@
+import type { ClarificationRequest } from 'pulse-coder-engine';
+
+import type { TuiHelpItem, TuiRunSummary, TuiSessionSnapshot } from './tui-renderer.js';
+import type { InkCliEvent, InkCliSnapshot } from './ink-app.js';
+
+export interface InkUiSnapshot extends Omit<InkCliSnapshot, 'events'> {}
+
+interface InkUiBridgeOptions {
+  maxEvents?: number;
+  onChange: (snapshot: InkCliSnapshot) => void;
+}
+
+const DEFAULT_SNAPSHOT: InkUiSnapshot = {
+  sessionId: null,
+  taskListId: null,
+  mode: null,
+  messages: 0,
+  estimatedTokens: 0,
+  isProcessing: false,
+  status: 'Ready',
+};
+
+const MAX_EVENT_TEXT_LENGTH = 4000;
+
+export class InkUiBridge {
+  private snapshot: InkUiSnapshot = { ...DEFAULT_SNAPSHOT };
+  private events: InkCliEvent[] = [];
+  private eventCounter = 0;
+  private activeAssistantEventId: string | null = null;
+  private readonly maxEvents: number;
+  private readonly onChange: (snapshot: InkCliSnapshot) => void;
+
+  constructor(options: InkUiBridgeOptions) {
+    this.maxEvents = options.maxEvents ?? 80;
+    this.onChange = options.onChange;
+  }
+
+  getSnapshot(): InkCliSnapshot {
+    return {
+      ...this.snapshot,
+      events: this.events,
+    };
+  }
+
+  emit(): void {
+    this.onChange(this.getSnapshot());
+  }
+
+  updateSnapshot(partial: Partial<InkUiSnapshot>): void {
+    this.snapshot = {
+      ...this.snapshot,
+      ...partial,
+    };
+    this.emit();
+  }
+
+  showWelcome(): void {
+    this.addEvent('system', 'Welcome', 'Type a message and press Enter to run the agent. Use /help for commands. Esc stops the current response; Ctrl+C exits safely.');
+  }
+
+  showHelp(items: TuiHelpItem[], footer: string[] = []): void {
+    const commandWidth = Math.max(...items.map(item => item.command.length));
+    const lines = items.map(item => `${item.command.padEnd(commandWidth)}  ${item.description}`);
+    this.addEvent('system', 'Commands', [...lines, ...footer].join('\n'));
+  }
+
+  showPluginStatus(count: number): void {
+    this.success(`Built-in plugins loaded: ${count} plugins`);
+  }
+
+  showTuiStatus(): void {
+    this.section('TUI Status', [
+      'Current UI: Ink',
+      'Fallback: PULSE_CODER_UI=readline pulse-coder',
+      'Plain fallback: PULSE_CODER_PLAIN=1 PULSE_CODER_UI=readline pulse-coder',
+    ]);
+  }
+
+  session(snapshot: TuiSessionSnapshot): void {
+    this.updateSnapshot({
+      sessionId: snapshot.sessionId,
+      taskListId: snapshot.taskListId,
+      messages: snapshot.messages,
+      estimatedTokens: snapshot.estimatedTokens,
+      mode: snapshot.mode,
+    });
+  }
+
+  runSummary(summary: TuiRunSummary): void {
+    this.activeAssistantEventId = null;
+    this.updateSnapshot({
+      isProcessing: false,
+      messages: summary.messages,
+      estimatedTokens: summary.estimatedTokens,
+      mode: summary.mode,
+      status: `Done in ${this.formatDuration(summary.elapsedMs)} · tools ${summary.toolCalls}`,
+    });
+  }
+
+  section(title: string, lines: string[]): void {
+    this.addEvent('system', title, lines.join('\n'));
+  }
+
+  plain(message = ''): void {
+    if (!message) {
+      this.activeAssistantEventId = null;
+      this.emit();
+      return;
+    }
+
+    this.addEvent('system', undefined, message);
+  }
+
+  info(message: string): void {
+    this.addEvent('system', undefined, message);
+  }
+
+  success(message: string): void {
+    this.addEvent('system', 'Success', message);
+  }
+
+  warn(message: string): void {
+    this.addEvent('system', 'Warning', message);
+  }
+
+  error(message: string): void {
+    this.addEvent('error', undefined, message);
+  }
+
+  queued(message: string): void {
+    this.addEvent('system', 'Queued', message);
+  }
+
+  abort(message: string): void {
+    this.activeAssistantEventId = null;
+    this.updateSnapshot({
+      isProcessing: false,
+      status: 'Cancelled',
+    });
+    this.addEvent('error', 'Abort', message);
+  }
+
+  startProcessing(label = 'Processing'): void {
+    this.activeAssistantEventId = null;
+    this.updateSnapshot({
+      isProcessing: true,
+      status: label,
+    });
+  }
+
+  stopProcessing(): void {
+    this.updateSnapshot({
+      isProcessing: false,
+      status: 'Ready',
+    });
+  }
+
+  text(delta: string): void {
+    if (!this.activeAssistantEventId) {
+      this.activeAssistantEventId = this.addEvent('assistant', undefined, '', false);
+    }
+
+    this.updateEvent(this.activeAssistantEventId, event => ({
+      ...event,
+      text: this.truncateEventText(`${event.text}${delta}`),
+    }));
+  }
+
+  toolCall(name: string, input?: unknown): void {
+    this.activeAssistantEventId = null;
+    const inputText = input === undefined ? '' : `\n${this.safeStringify(input)}`;
+    this.addEvent('tool', name, `Running${inputText}`);
+  }
+
+  toolResult(name: string): void {
+    this.addEvent('result', name, 'Completed');
+  }
+
+  stepFinished(reason: string): void {
+    this.addEvent('system', 'Step finished', reason);
+  }
+
+  user(message: string): void {
+    this.addEvent('user', undefined, message);
+  }
+
+  clarification(request: ClarificationRequest): void {
+    const lines = [request.question];
+    if (request.context) {
+      lines.push(request.context);
+    }
+    if (request.defaultAnswer) {
+      lines.push(`Default: ${request.defaultAnswer}`);
+    }
+    this.addEvent('system', 'Clarification needed', lines.join('\n'));
+    this.updateSnapshot({ status: 'Waiting for clarification' });
+  }
+
+  private addEvent(kind: InkCliEvent['kind'], title: string | undefined, text: string, emit = true): string {
+    const id = `event-${++this.eventCounter}`;
+    this.events = [
+      ...this.events,
+      {
+        id,
+        kind,
+        title,
+        text: this.truncateEventText(text),
+      },
+    ].slice(-this.maxEvents);
+
+    if (emit) {
+      this.emit();
+    }
+
+    return id;
+  }
+
+  private updateEvent(id: string, updater: (event: InkCliEvent) => InkCliEvent): void {
+    this.events = this.events.map(event => event.id === id ? updater(event) : event);
+    this.emit();
+  }
+
+  private truncateEventText(text: string): string {
+    if (text.length <= MAX_EVENT_TEXT_LENGTH) {
+      return text;
+    }
+    return `${text.slice(0, MAX_EVENT_TEXT_LENGTH)}…`;
+  }
+
+  private safeStringify(value: unknown): string {
+    try {
+      if (typeof value === 'string') {
+        return value;
+      }
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  }
+
+  private formatDuration(ms: number): string {
+    if (ms < 1000) {
+      return `${ms}ms`;
+    }
+
+    const seconds = ms / 1000;
+    if (seconds < 60) {
+      return `${seconds.toFixed(1)}s`;
+    }
+
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = Math.round(seconds % 60);
+    return `${minutes}m ${remainingSeconds}s`;
+  }
+}

--- a/packages/cli/src/input-manager.ts
+++ b/packages/cli/src/input-manager.ts
@@ -7,12 +7,21 @@ interface PendingRequest {
   timeoutId?: NodeJS.Timeout;
 }
 
+interface InputManagerOptions {
+  onRequest?: (request: ClarificationRequest) => void;
+}
+
 /**
  * InputManager handles asynchronous user input for clarification requests.
- * It manages pending clarification requests and coordinates with the readline interface.
+ * It manages pending clarification requests and coordinates with the active CLI interface.
  */
 export class InputManager {
   private pendingRequest: PendingRequest | null = null;
+  private readonly onRequest?: (request: ClarificationRequest) => void;
+
+  constructor(options: InputManagerOptions = {}) {
+    this.onRequest = options.onRequest ?? this.printRequest;
+  }
 
   /**
    * Request user input for a clarification
@@ -27,15 +36,7 @@ export class InputManager {
         return;
       }
 
-      // Display the question to the user
-      console.log(`\n❓ ${request.question}`);
-      if (request.context) {
-        console.log(`   ${request.context}`);
-      }
-      if (request.defaultAnswer) {
-        console.log(`   (Default: ${request.defaultAnswer})`);
-      }
-      console.log(''); // Empty line for spacing
+      this.onRequest?.(request);
 
       // Set up timeout if specified
       let timeoutId: NodeJS.Timeout | undefined;
@@ -109,5 +110,16 @@ export class InputManager {
    */
   getPendingRequest(): ClarificationRequest | null {
     return this.pendingRequest?.request || null;
+  }
+
+  private printRequest(request: ClarificationRequest): void {
+    console.log(`\n❓ ${request.question}`);
+    if (request.context) {
+      console.log(`   ${request.context}`);
+    }
+    if (request.defaultAnswer) {
+      console.log(`   (Default: ${request.defaultAnswer})`);
+    }
+    console.log('');
   }
 }

--- a/packages/cli/src/session-commands.ts
+++ b/packages/cli/src/session-commands.ts
@@ -6,7 +6,7 @@ export class SessionCommands {
   private currentSessionId: string | null = null;
   private currentTaskListId: string | null = null;
 
-  constructor() {
+  constructor(private readonly log: (message?: string) => void = console.log) {
     this.sessionManager = new SessionManager();
   }
 
@@ -47,8 +47,8 @@ export class SessionCommands {
     const session = await this.sessionManager.createSession(title);
     this.currentSessionId = session.id;
     this.currentTaskListId = await this.ensureSessionTaskListId(session);
-    console.log(`\n✅ New session created: ${session.title} (ID: ${session.id})`);
-    console.log(`🗂️ Task list: ${this.currentTaskListId}`);
+    this.log(`\n✅ New session created: ${session.title} (ID: ${session.id})`);
+    this.log(`🗂️ Task list: ${this.currentTaskListId}`);
     return session.id;
   }
 
@@ -56,25 +56,25 @@ export class SessionCommands {
   async resumeSession(id: string): Promise<boolean> {
     const session = await this.sessionManager.loadSession(id);
     if (!session) {
-      console.log(`\n❌ Session not found: ${id}`);
+      this.log(`\n❌ Session not found: ${id}`);
       return false;
     }
 
     this.currentSessionId = session.id;
     this.currentTaskListId = await this.ensureSessionTaskListId(session);
-    console.log(`\n✅ Resumed session: ${session.title} (ID: ${session.id})`);
-    console.log(`🗂️ Task list: ${this.currentTaskListId}`);
-    console.log(`📊 Loaded ${session.messages.length} messages`);
+    this.log(`\n✅ Resumed session: ${session.title} (ID: ${session.id})`);
+    this.log(`🗂️ Task list: ${this.currentTaskListId}`);
+    this.log(`📊 Loaded ${session.messages.length} messages`);
 
     // Show last few messages as context
     const recentMessages = session.messages.slice(-5);
     if (recentMessages.length > 0) {
-      console.log('\n💬 Recent conversation:');
+      this.log('\n💬 Recent conversation:');
       recentMessages.forEach((msg, index) => {
         const role = msg.role === 'user' ? '👤 You' : '🤖 Assistant';
         const contentStr = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content);
         const preview = contentStr.substring(0, 100) + (contentStr.length > 100 ? '...' : '');
-        console.log(`${index + 1}. ${role}: ${preview}`);
+        this.log(`${index + 1}. ${role}: ${preview}`);
       });
     }
 
@@ -85,24 +85,24 @@ export class SessionCommands {
     const sessions = await this.sessionManager.listSessions();
 
     if (sessions.length === 0) {
-      console.log('\n📭 No saved sessions found.');
+      this.log('\n📭 No saved sessions found.');
       return;
     }
 
-    console.log('\n📋 Saved sessions:');
-    console.log('='.repeat(80));
+    this.log('\n📋 Saved sessions:');
+    this.log('='.repeat(80));
 
     sessions.forEach((session, index) => {
       const isActive = session.id === this.currentSessionId ? '✅' : '  ';
       const date = new Date(session.updatedAt).toLocaleString();
-      console.log(`${index + 1}. ${isActive} ${session.title}`);
-      console.log(`   ID: ${session.id}`);
-      console.log(`   Messages: ${session.messageCount} | Updated: ${date}`);
+      this.log(`${index + 1}. ${isActive} ${session.title}`);
+      this.log(`   ID: ${session.id}`);
+      this.log(`   Messages: ${session.messageCount} | Updated: ${date}`);
       if (session.taskListId) {
-        console.log(`   Task List: ${session.taskListId}`);
+        this.log(`   Task List: ${session.taskListId}`);
       }
-      console.log(`   Preview: ${session.preview}`);
-      console.log();
+      this.log(`   Preview: ${session.preview}`);
+      this.log();
     });
   }
 
@@ -143,28 +143,28 @@ export class SessionCommands {
     const sessions = await this.sessionManager.searchSessions(query);
 
     if (sessions.length === 0) {
-      console.log(`\n🔍 No sessions found matching "${query}"`);
+      this.log(`\n🔍 No sessions found matching "${query}"`);
       return;
     }
 
-    console.log(`\n🔍 Search results for "${query}":`);
+    this.log(`\n🔍 Search results for "${query}":`);
     sessions.forEach((session, index) => {
-      console.log(`${index + 1}. ${session.title} (${session.id}) - ${session.messageCount} messages`);
-      console.log(`   Updated: ${new Date(session.updatedAt).toLocaleString()}`);
-      console.log(`   Preview: ${session.preview}`);
+      this.log(`${index + 1}. ${session.title} (${session.id}) - ${session.messageCount} messages`);
+      this.log(`   Updated: ${new Date(session.updatedAt).toLocaleString()}`);
+      this.log(`   Preview: ${session.preview}`);
     });
   }
 
   async deleteSession(id: string): Promise<boolean> {
     const success = await this.sessionManager.deleteSession(id);
     if (success) {
-      console.log(`\n🗑️ Session ${id} deleted`);
+      this.log(`\n🗑️ Session ${id} deleted`);
       if (this.currentSessionId === id) {
         this.currentSessionId = null;
         this.currentTaskListId = null;
       }
     } else {
-      console.log(`\n❌ Failed to delete session ${id}`);
+      this.log(`\n❌ Failed to delete session ${id}`);
     }
     return success;
   }
@@ -172,9 +172,9 @@ export class SessionCommands {
   async renameSession(id: string, newTitle: string): Promise<boolean> {
     const success = await this.sessionManager.updateSessionTitle(id, newTitle);
     if (success) {
-      console.log(`\n✅ Session ${id} renamed to "${newTitle}"`);
+      this.log(`\n✅ Session ${id} renamed to "${newTitle}"`);
     } else {
-      console.log(`\n❌ Failed to rename session ${id}`);
+      this.log(`\n❌ Failed to rename session ${id}`);
     }
     return success;
   }

--- a/packages/cli/src/skill-commands.ts
+++ b/packages/cli/src/skill-commands.ts
@@ -11,18 +11,21 @@ interface SkillRegistryService {
 }
 
 export class SkillCommands {
-  constructor(private agent: PulseAgent) {}
+  constructor(
+    private agent: PulseAgent,
+    private readonly log: (message?: string) => void = console.log,
+  ) {}
 
   async transformSkillsCommandToMessage(args: string[]): Promise<string | null> {
     const registry = this.getSkillRegistry();
     if (!registry) {
-      console.log('\n⚠️ skill registry unavailable. Ensure built-in skills plugin is enabled.');
+      this.log('\n⚠️ skill registry unavailable. Ensure built-in skills plugin is enabled.');
       return null;
     }
 
     const skills = this.getAvailableSkills();
     if (skills.length === 0) {
-      console.log('\n📭 No skills found. Add SKILL.md under .pulse-coder/skills/**/SKILL.md');
+      this.log('\n📭 No skills found. Add SKILL.md under .pulse-coder/skills/**/SKILL.md');
       return null;
     }
 
@@ -30,12 +33,12 @@ export class SkillCommands {
 
     if (!subCommand || subCommand === 'list') {
       this.printSkillList(skills);
-      console.log('\nUsage: /skills <name|index> <message>');
+      this.log('\nUsage: /skills <name|index> <message>');
       return null;
     }
 
     if (subCommand === 'current' || subCommand === 'clear' || subCommand === 'off' || subCommand === 'none') {
-      console.log('\nℹ️ Skills are single-use. Use /skills <name|index> <message> to run one prompt with a skill.');
+      this.log('\nℹ️ Skills are single-use. Use /skills <name|index> <message> to run one prompt with a skill.');
       return null;
     }
 
@@ -45,35 +48,35 @@ export class SkillCommands {
     }
 
     if (selectionTokens.length < 2) {
-      console.log('\n❌ Please provide both a skill and a message.');
-      console.log('Usage: /skills <name|index> <message>');
+      this.log('\n❌ Please provide both a skill and a message.');
+      this.log('Usage: /skills <name|index> <message>');
       return null;
     }
 
     const skillTarget = selectionTokens[0];
     const selectedSkill = this.resolveSkillSelection(skillTarget, skills);
     if (!selectedSkill) {
-      console.log(`\n❌ Skill not found: ${skillTarget}`);
-      console.log('Run /skills list to see available skills.');
+      this.log(`\n❌ Skill not found: ${skillTarget}`);
+      this.log('Run /skills list to see available skills.');
       return null;
     }
 
     const message = selectionTokens.slice(1).join(' ').trim();
     if (!message) {
-      console.log('\n❌ Message cannot be empty.');
-      console.log('Usage: /skills <name|index> <message>');
+      this.log('\n❌ Message cannot be empty.');
+      this.log('Usage: /skills <name|index> <message>');
       return null;
     }
 
     const transformed = `[use skill](${selectedSkill.name}) ${message}`;
-    console.log(`\n✅ One-shot skill message prepared with: ${selectedSkill.name}`);
+    this.log(`\n✅ One-shot skill message prepared with: ${selectedSkill.name}`);
     return transformed;
   }
 
   private printSkillList(skills: SkillSummary[]): void {
-    console.log('\n🧰 Available skills:');
+    this.log('\n🧰 Available skills:');
     skills.forEach((skill, index) => {
-      console.log(`${String(index + 1).padStart(2, ' ')}. ${skill.name} - ${skill.description}`);
+      this.log(`${String(index + 1).padStart(2, ' ')}. ${skill.name} - ${skill.description}`);
     });
   }
 

--- a/packages/cli/src/tui-renderer.test.ts
+++ b/packages/cli/src/tui-renderer.test.ts
@@ -88,7 +88,57 @@ describe('TuiRenderer', () => {
 
     const text = output.text();
     expect(text).toContain('bash');
-    expect(text).toContain('…');
+    expect(text).toContain('… truncated');
     expect(text).toContain('✅');
+  });
+
+  it('supports runtime TUI toggling when terminal capabilities allow it', () => {
+    const output = new MemoryOutput();
+    const renderer = new TuiRenderer({ output, enabled: false });
+
+    expect(renderer.isEnabled()).toBe(false);
+    expect(renderer.setEnabled(true)).toBe(true);
+    expect(renderer.isEnabled()).toBe(true);
+    expect(renderer.prompt()).toContain('›');
+
+    renderer.setEnabled(false);
+    expect(renderer.prompt()).toBe('> ');
+  });
+
+  it('refuses to enable TUI when terminal capabilities are unavailable', () => {
+    const output = new MemoryOutput();
+    output.isTTY = false;
+    const renderer = new TuiRenderer({ output, enabled: false });
+
+    expect(renderer.isAvailable()).toBe(false);
+    expect(renderer.setEnabled(true)).toBe(false);
+    expect(renderer.isEnabled()).toBe(false);
+  });
+
+  it('renders session snapshots and run summaries', () => {
+    const output = new MemoryOutput();
+    const renderer = new TuiRenderer({ output, enabled: true });
+
+    renderer.session({
+      sessionId: 'abc123',
+      taskListId: 'tasks-a',
+      messages: 4,
+      estimatedTokens: 256,
+      mode: 'planning',
+    });
+    renderer.runSummary({
+      elapsedMs: 1_250,
+      toolCalls: 2,
+      messages: 6,
+      estimatedTokens: 512,
+      mode: 'executing',
+    });
+
+    const text = output.text();
+    expect(text).toContain('session abc123');
+    expect(text).toContain('tasks tasks-a');
+    expect(text).toContain('Run Summary');
+    expect(text).toContain('Elapsed: 1.3s');
+    expect(text).toContain('Tools: 2');
   });
 });

--- a/packages/cli/src/tui-renderer.test.ts
+++ b/packages/cli/src/tui-renderer.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { TuiRenderer } from './tui-renderer.js';
+
+class MemoryOutput {
+  isTTY = true;
+  columns = 80;
+  chunks: string[] = [];
+  clearCount = 0;
+  cursorCount = 0;
+
+  write(chunk: string): boolean {
+    this.chunks.push(chunk);
+    return true;
+  }
+
+  clearLine(): boolean {
+    this.clearCount += 1;
+    return true;
+  }
+
+  cursorTo(): boolean {
+    this.cursorCount += 1;
+    return true;
+  }
+
+  text(): string {
+    return this.chunks.join('');
+  }
+}
+
+describe('TuiRenderer', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders boxed welcome and help in interactive terminals', () => {
+    const output = new MemoryOutput();
+    const renderer = new TuiRenderer({ output, enabled: true });
+
+    renderer.showWelcome();
+    renderer.showHelp([{ command: '/help', description: 'Show help' }], ['Ctrl+C - Exit']);
+
+    const text = output.text();
+    expect(text).toContain('Pulse Coder CLI');
+    expect(text).toContain('╭─');
+    expect(text).toContain('Commands');
+    expect(text).toContain('/help');
+    expect(text).toContain('Ctrl+C - Exit');
+  });
+
+  it('uses plain prompts and plain text when TUI is disabled', () => {
+    const output = new MemoryOutput();
+    output.isTTY = false;
+    const renderer = new TuiRenderer({ output, enabled: false });
+
+    expect(renderer.prompt()).toBe('> ');
+    expect(renderer.prompt('teams')).toBe('teams> ');
+
+    renderer.showWelcome();
+    renderer.showHelp([{ command: '/status', description: 'Show status' }]);
+
+    const text = output.text();
+    expect(text).toContain('🚀 Pulse Coder CLI is running');
+    expect(text).toContain('/status - Show status');
+  });
+
+  it('clears spinner status before streaming text', () => {
+    vi.useFakeTimers();
+    const output = new MemoryOutput();
+    const renderer = new TuiRenderer({ output, enabled: true, now: () => 1_000 });
+
+    renderer.startProcessing('Running agent');
+    renderer.text('hello');
+
+    expect(output.text()).toContain('Running agent');
+    expect(output.text()).toContain('hello');
+    expect(output.clearCount).toBeGreaterThan(0);
+    expect(output.cursorCount).toBeGreaterThan(0);
+  });
+
+  it('renders tool calls and results with safe, truncated input', () => {
+    const output = new MemoryOutput();
+    const renderer = new TuiRenderer({ output, enabled: true });
+
+    renderer.toolCall('bash', { command: 'x'.repeat(240) });
+    renderer.toolResult('bash');
+
+    const text = output.text();
+    expect(text).toContain('bash');
+    expect(text).toContain('…');
+    expect(text).toContain('✅');
+  });
+});

--- a/packages/cli/src/tui-renderer.ts
+++ b/packages/cli/src/tui-renderer.ts
@@ -3,6 +3,22 @@ export interface TuiHelpItem {
   description: string;
 }
 
+export interface TuiRunSummary {
+  elapsedMs: number;
+  toolCalls: number;
+  messages: number;
+  estimatedTokens: number;
+  mode?: string | null;
+}
+
+export interface TuiSessionSnapshot {
+  sessionId?: string | null;
+  taskListId?: string | null;
+  messages: number;
+  estimatedTokens: number;
+  mode?: string | null;
+}
+
 interface OutputLike {
   isTTY?: boolean;
   columns?: number;
@@ -31,7 +47,8 @@ const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', 
 
 export class TuiRenderer {
   private readonly output: OutputLike;
-  private readonly enabled: boolean;
+  private readonly canUseTui: boolean;
+  private enabled: boolean;
   private readonly now: () => number;
   private spinnerTimer: ReturnType<typeof setInterval> | null = null;
   private spinnerIndex = 0;
@@ -42,12 +59,28 @@ export class TuiRenderer {
   constructor(options: TuiRendererOptions = {}) {
     this.output = options.output ?? process.stdout;
     const env = options.env ?? process.env;
-    this.enabled = options.enabled ?? this.detectEnabled(env);
+    this.canUseTui = this.detectAvailable(env);
+    this.enabled = options.enabled ?? this.detectDefaultEnabled(env);
     this.now = options.now ?? (() => Date.now());
   }
 
   isEnabled(): boolean {
     return this.enabled;
+  }
+
+  isAvailable(): boolean {
+    return this.canUseTui;
+  }
+
+  setEnabled(enabled: boolean): boolean {
+    this.stopProcessing();
+    if (enabled && !this.canUseTui) {
+      this.enabled = false;
+      return false;
+    }
+
+    this.enabled = enabled;
+    return true;
   }
 
   prompt(mode: 'default' | 'teams' = 'default'): string {
@@ -71,7 +104,7 @@ export class TuiRenderer {
 
     this.writeLine(this.box('Pulse Coder CLI', [
       'Type a message and press Enter to run the agent.',
-      'Use /help for commands, /status for session details.',
+      'Use /help for commands, /status for session details, /tui to tune the interface.',
       'Esc stops the current response; Ctrl+C exits safely.',
     ]));
   }
@@ -98,6 +131,54 @@ export class TuiRenderer {
 
   showPluginStatus(count: number): void {
     this.success(`Built-in plugins loaded: ${count} plugins`);
+  }
+
+  showTuiStatus(): void {
+    this.section('TUI Status', [
+      `Enabled: ${this.enabled ? 'yes' : 'no'}`,
+      `Available: ${this.canUseTui ? 'yes' : 'no'}`,
+      'Use /tui on or /tui off to switch for this process.',
+      'Use PULSE_CODER_PLAIN=1 to start in plain mode.',
+    ]);
+  }
+
+  session(snapshot: TuiSessionSnapshot): void {
+    if (!this.enabled) {
+      return;
+    }
+
+    const parts = [
+      `session ${snapshot.sessionId ?? 'new'}`,
+      `${snapshot.messages} msgs`,
+      `~${snapshot.estimatedTokens} tokens`,
+    ];
+    if (snapshot.taskListId) {
+      parts.push(`tasks ${snapshot.taskListId}`);
+    }
+    if (snapshot.mode) {
+      parts.push(`mode ${snapshot.mode}`);
+    }
+
+    this.writeLine(this.color(`╭ ${parts.join(' · ')}`, DIM));
+  }
+
+  runSummary(summary: TuiRunSummary): void {
+    this.stopProcessing();
+    const elapsed = this.formatDuration(summary.elapsedMs);
+    const lines = [
+      `Elapsed: ${elapsed}`,
+      `Tools: ${summary.toolCalls}`,
+      `Messages: ${summary.messages}`,
+      `Estimated tokens: ~${summary.estimatedTokens}`,
+      ...(summary.mode ? [`Mode: ${summary.mode}`] : []),
+    ];
+
+    if (!this.enabled) {
+      this.writeLine(`\nDone in ${elapsed} · tools ${summary.toolCalls} · messages ${summary.messages} · ~${summary.estimatedTokens} tokens`);
+      return;
+    }
+
+    this.writeLine(`\n${this.box('Run Summary', lines)}`);
   }
 
   section(title: string, lines: string[]): void {
@@ -157,8 +238,23 @@ export class TuiRenderer {
 
   toolCall(name: string, input?: unknown): void {
     this.stopProcessing();
-    const inputText = input === undefined ? '' : ` ${this.color(this.truncate(this.safeJson(input), 180), DIM)}`;
-    this.writeLine(`\n${this.color('🔧', CYAN)} ${this.color(name, BOLD)}${inputText}`);
+    const preview = input === undefined ? [] : this.formatToolInput(input);
+
+    if (!this.enabled) {
+      const inputText = preview.length === 0 ? '' : ` ${preview.join(' ')}`;
+      this.writeLine(`\n🔧 ${name}${inputText}`);
+      return;
+    }
+
+    if (preview.length === 0) {
+      this.writeLine(`\n${this.color('🔧', CYAN)} ${this.color(name, BOLD)}`);
+      return;
+    }
+
+    this.writeLine(`\n${this.color('🔧', CYAN)} ${this.color(name, BOLD)}`);
+    for (const line of preview) {
+      this.writeLine(`   ${this.color(line, DIM)}`);
+    }
   }
 
   toolResult(name: string): void {
@@ -201,14 +297,12 @@ export class TuiRenderer {
     this.writeLine(`\n${this.color('📝', CYAN)} ${message}`);
   }
 
-  private detectEnabled(env: NodeJS.ProcessEnv): boolean {
-    if (!this.output.isTTY) {
-      return false;
-    }
-    if (env.PULSE_CODER_PLAIN === '1' || env.NO_COLOR || env.TERM === 'dumb') {
-      return false;
-    }
-    return true;
+  private detectAvailable(env: NodeJS.ProcessEnv): boolean {
+    return Boolean(this.output.isTTY) && !env.NO_COLOR && env.TERM !== 'dumb';
+  }
+
+  private detectDefaultEnabled(env: NodeJS.ProcessEnv): boolean {
+    return this.canUseTui && env.PULSE_CODER_PLAIN !== '1';
   }
 
   private box(title: string, lines: string[]): string {
@@ -258,6 +352,33 @@ export class TuiRenderer {
     return wrapped;
   }
 
+  private formatToolInput(value: unknown): string[] {
+    const maxLineLength = 96;
+    const maxLines = 4;
+    const json = this.safeJson(value);
+    const pretty = this.prettyJson(value) ?? json;
+    const sourceLines = pretty.split('\n');
+    const lines: string[] = [];
+
+    for (const sourceLine of sourceLines) {
+      const trimmed = sourceLine.trimEnd();
+      if (!trimmed) {
+        continue;
+      }
+      lines.push(this.truncate(trimmed, maxLineLength));
+      if (lines.length >= maxLines) {
+        break;
+      }
+    }
+
+    if (sourceLines.length > maxLines || json.length > lines.join('\n').length) {
+      const remaining = Math.max(0, json.length - lines.join('\n').length);
+      lines.push(`… truncated ${remaining} chars`);
+    }
+
+    return lines;
+  }
+
   private safeJson(value: unknown): string {
     try {
       return JSON.stringify(value);
@@ -266,11 +387,34 @@ export class TuiRenderer {
     }
   }
 
+  private prettyJson(value: unknown): string | null {
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return null;
+    }
+  }
+
   private truncate(value: string, maxLength: number): string {
     if (value.length <= maxLength) {
       return value;
     }
     return `${value.slice(0, maxLength - 1)}…`;
+  }
+
+  private formatDuration(ms: number): string {
+    if (ms < 1_000) {
+      return `${Math.max(0, Math.round(ms))}ms`;
+    }
+
+    const seconds = ms / 1_000;
+    if (seconds < 60) {
+      return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`;
+    }
+
+    const minutes = Math.floor(seconds / 60);
+    const remainder = Math.round(seconds % 60);
+    return `${minutes}m ${remainder}s`;
   }
 
   private color(value: string, code: string): string {

--- a/packages/cli/src/tui-renderer.ts
+++ b/packages/cli/src/tui-renderer.ts
@@ -1,0 +1,291 @@
+export interface TuiHelpItem {
+  command: string;
+  description: string;
+}
+
+interface OutputLike {
+  isTTY?: boolean;
+  columns?: number;
+  write(chunk: string): boolean;
+  clearLine?(dir: number): boolean;
+  cursorTo?(x: number): boolean;
+}
+
+interface TuiRendererOptions {
+  output?: OutputLike;
+  enabled?: boolean;
+  env?: NodeJS.ProcessEnv;
+  now?: () => number;
+}
+
+const RESET = '\u001b[0m';
+const DIM = '\u001b[2m';
+const BOLD = '\u001b[1m';
+const CYAN = '\u001b[36m';
+const GREEN = '\u001b[32m';
+const YELLOW = '\u001b[33m';
+const RED = '\u001b[31m';
+const MAGENTA = '\u001b[35m';
+
+const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+export class TuiRenderer {
+  private readonly output: OutputLike;
+  private readonly enabled: boolean;
+  private readonly now: () => number;
+  private spinnerTimer: ReturnType<typeof setInterval> | null = null;
+  private spinnerIndex = 0;
+  private spinnerLabel = 'Processing';
+  private spinnerStartedAt = 0;
+  private statusLineActive = false;
+
+  constructor(options: TuiRendererOptions = {}) {
+    this.output = options.output ?? process.stdout;
+    const env = options.env ?? process.env;
+    this.enabled = options.enabled ?? this.detectEnabled(env);
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  prompt(mode: 'default' | 'teams' = 'default'): string {
+    if (!this.enabled) {
+      return mode === 'teams' ? 'teams> ' : '> ';
+    }
+
+    const label = mode === 'teams' ? `${MAGENTA}teams›${RESET}` : `${CYAN}›${RESET}`;
+    return `${label} `;
+  }
+
+  showWelcome(): void {
+    if (!this.enabled) {
+      this.writeLine('🚀 Pulse Coder CLI is running...');
+      this.writeLine('Type your messages and press Enter. Type "exit" to quit.');
+      this.writeLine('Press Esc to stop current response and continue with new input.');
+      this.writeLine('Press Ctrl+C to exit CLI.');
+      this.writeLine('Commands starting with "/" will trigger command mode.\n');
+      return;
+    }
+
+    this.writeLine(this.box('Pulse Coder CLI', [
+      'Type a message and press Enter to run the agent.',
+      'Use /help for commands, /status for session details.',
+      'Esc stops the current response; Ctrl+C exits safely.',
+    ]));
+  }
+
+  showHelp(items: TuiHelpItem[], footer: string[] = []): void {
+    if (!this.enabled) {
+      this.writeLine('\n📋 Available commands:');
+      for (const item of items) {
+        this.writeLine(`${item.command} - ${item.description}`);
+      }
+      for (const line of footer) {
+        this.writeLine(line);
+      }
+      return;
+    }
+
+    const commandWidth = Math.max(...items.map(item => item.command.length));
+    const lines = items.map(item => `${this.color(item.command.padEnd(commandWidth), CYAN)}  ${item.description}`);
+    if (footer.length > 0) {
+      lines.push('', ...footer.map(line => this.color(line, DIM)));
+    }
+    this.writeLine(`\n${this.box('Commands', lines)}`);
+  }
+
+  showPluginStatus(count: number): void {
+    this.success(`Built-in plugins loaded: ${count} plugins`);
+  }
+
+  section(title: string, lines: string[]): void {
+    this.stopProcessing();
+    if (!this.enabled) {
+      this.writeLine(`\n${title}:`);
+      for (const line of lines) {
+        this.writeLine(line);
+      }
+      return;
+    }
+
+    this.writeLine(`\n${this.box(title, lines)}`);
+  }
+
+  plain(message = ''): void {
+    this.stopProcessing();
+    this.writeLine(message);
+  }
+
+  inline(message = ''): void {
+    this.stopProcessing();
+    this.write(message);
+  }
+
+  startProcessing(label = 'Processing'): void {
+    if (!this.enabled) {
+      this.writeLine('\n🔄 Processing...\n');
+      return;
+    }
+
+    this.stopProcessing();
+    this.spinnerLabel = label;
+    this.spinnerStartedAt = this.now();
+    this.spinnerIndex = 0;
+    this.write('\n');
+    this.renderSpinner();
+    this.spinnerTimer = setInterval(() => this.renderSpinner(), 120);
+  }
+
+  stopProcessing(): void {
+    if (this.spinnerTimer) {
+      clearInterval(this.spinnerTimer);
+      this.spinnerTimer = null;
+    }
+
+    if (this.statusLineActive) {
+      this.clearLine();
+      this.statusLineActive = false;
+    }
+  }
+
+  text(delta: string): void {
+    this.stopProcessing();
+    this.write(delta);
+  }
+
+  toolCall(name: string, input?: unknown): void {
+    this.stopProcessing();
+    const inputText = input === undefined ? '' : ` ${this.color(this.truncate(this.safeJson(input), 180), DIM)}`;
+    this.writeLine(`\n${this.color('🔧', CYAN)} ${this.color(name, BOLD)}${inputText}`);
+  }
+
+  toolResult(name: string): void {
+    this.stopProcessing();
+    this.writeLine(`\n${this.color('✅', GREEN)} ${name}`);
+  }
+
+  stepFinished(reason: string): void {
+    this.stopProcessing();
+    this.writeLine(`\n${this.color('📋', MAGENTA)} Step finished: ${reason}`);
+  }
+
+  info(message: string): void {
+    this.stopProcessing();
+    this.writeLine(`${this.color('ℹ', CYAN)} ${message}`);
+  }
+
+  success(message: string): void {
+    this.stopProcessing();
+    this.writeLine(`${this.color('✅', GREEN)} ${message}`);
+  }
+
+  warn(message: string): void {
+    this.stopProcessing();
+    this.writeLine(`${this.color('⚠', YELLOW)} ${message}`);
+  }
+
+  error(message: string): void {
+    this.stopProcessing();
+    this.writeLine(`${this.color('❌', RED)} ${message}`);
+  }
+
+  abort(message: string): void {
+    this.stopProcessing();
+    this.writeLine(`\n${this.color('[Abort]', YELLOW)} ${message}`);
+  }
+
+  queued(message: string): void {
+    this.stopProcessing();
+    this.writeLine(`\n${this.color('📝', CYAN)} ${message}`);
+  }
+
+  private detectEnabled(env: NodeJS.ProcessEnv): boolean {
+    if (!this.output.isTTY) {
+      return false;
+    }
+    if (env.PULSE_CODER_PLAIN === '1' || env.NO_COLOR || env.TERM === 'dumb') {
+      return false;
+    }
+    return true;
+  }
+
+  private box(title: string, lines: string[]): string {
+    const visibleLines = lines.map(line => this.stripAnsi(line));
+    const maxLineLength = Math.max(title.length + 2, ...visibleLines.map(line => line.length));
+    const maxWidth = Math.max(42, Math.min(this.output.columns ?? 80, 96) - 4);
+    const width = Math.min(Math.max(maxLineLength, 42), maxWidth);
+    const top = `╭─ ${this.color(title, BOLD)} ${'─'.repeat(Math.max(0, width - title.length - 3))}╮`;
+    const bottom = `╰${'─'.repeat(width + 2)}╯`;
+    const body = lines.flatMap(line => this.wrapVisible(line, width)).map(line => {
+      const padding = width - this.stripAnsi(line).length;
+      return `│ ${line}${' '.repeat(Math.max(0, padding))} │`;
+    });
+
+    return [top, ...body, bottom].join('\n');
+  }
+
+  private renderSpinner(): void {
+    const frame = SPINNER_FRAMES[this.spinnerIndex % SPINNER_FRAMES.length];
+    this.spinnerIndex += 1;
+    const elapsed = Math.max(0, Math.floor((this.now() - this.spinnerStartedAt) / 1000));
+    const line = `${this.color(frame, CYAN)} ${this.spinnerLabel} ${this.color(`${elapsed}s`, DIM)} ${this.color('Esc to stop', DIM)}`;
+    this.clearLine();
+    this.write(line);
+    this.statusLineActive = true;
+  }
+
+  private clearLine(): void {
+    if (!this.enabled) {
+      return;
+    }
+
+    this.output.clearLine?.(0);
+    this.output.cursorTo?.(0);
+  }
+
+  private wrapVisible(line: string, width: number): string[] {
+    if (this.stripAnsi(line).length <= width) {
+      return [line];
+    }
+
+    const plain = this.stripAnsi(line);
+    const wrapped: string[] = [];
+    for (let index = 0; index < plain.length; index += width) {
+      wrapped.push(plain.slice(index, index + width));
+    }
+    return wrapped;
+  }
+
+  private safeJson(value: unknown): string {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+
+  private truncate(value: string, maxLength: number): string {
+    if (value.length <= maxLength) {
+      return value;
+    }
+    return `${value.slice(0, maxLength - 1)}…`;
+  }
+
+  private color(value: string, code: string): string {
+    return this.enabled ? `${code}${value}${RESET}` : value;
+  }
+
+  private stripAnsi(value: string): string {
+    return value.replace(/\u001b\[[0-9;]*m/g, '');
+  }
+
+  private writeLine(line: string): void {
+    this.write(`${line}\n`);
+  }
+
+  private write(chunk: string): void {
+    this.output.write(chunk);
+  }
+}

--- a/packages/cli/src/ui-mode.test.ts
+++ b/packages/cli/src/ui-mode.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveCliUiMode } from './ui-mode.js';
+
+describe('resolveCliUiMode', () => {
+  it('defaults to readline', () => {
+    expect(resolveCliUiMode([], {})).toBe('readline');
+  });
+
+  it('uses PULSE_CODER_UI=ink', () => {
+    expect(resolveCliUiMode([], { PULSE_CODER_UI: 'ink' })).toBe('ink');
+  });
+
+  it('uses --ui ink flag', () => {
+    expect(resolveCliUiMode(['--ui', 'ink'], {})).toBe('ink');
+    expect(resolveCliUiMode(['--ui=ink'], {})).toBe('ink');
+  });
+
+  it('lets explicit readline flags override env', () => {
+    expect(resolveCliUiMode(['--ui', 'readline'], { PULSE_CODER_UI: 'ink' })).toBe('readline');
+    expect(resolveCliUiMode(['--tui=plain'], { PULSE_CODER_UI: 'ink' })).toBe('readline');
+  });
+});

--- a/packages/cli/src/ui-mode.ts
+++ b/packages/cli/src/ui-mode.ts
@@ -1,0 +1,32 @@
+export type CliUiMode = 'readline' | 'ink';
+
+export function resolveCliUiMode(args = process.argv.slice(2), env: NodeJS.ProcessEnv = process.env): CliUiMode {
+  const flagIndex = args.findIndex(arg => arg === '--ui' || arg === '--tui');
+  if (flagIndex >= 0) {
+    const value = args[flagIndex + 1]?.toLowerCase();
+    if (value === 'ink') {
+      return 'ink';
+    }
+    if (value === 'readline' || value === 'plain') {
+      return 'readline';
+    }
+  }
+
+  const inlineFlag = args.find(arg => arg.startsWith('--ui=') || arg.startsWith('--tui='));
+  if (inlineFlag) {
+    const value = inlineFlag.split('=')[1]?.toLowerCase();
+    if (value === 'ink') {
+      return 'ink';
+    }
+    if (value === 'readline' || value === 'plain') {
+      return 'readline';
+    }
+  }
+
+  const envValue = env.PULSE_CODER_UI?.toLowerCase();
+  if (envValue === 'ink') {
+    return 'ink';
+  }
+
+  return 'readline';
+}

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -20,10 +20,10 @@ export default defineConfig((options) => {
     minify: !shouldKeepDebugInfo,
     treeshake: !shouldKeepDebugInfo,
     platform: 'node',
-    // Keep workspace packages external in debug builds so breakpoints map to package sourcemaps.
-    external: isDebugBuild
-      ? ['pulse-coder-acp', 'pulse-coder-engine', 'pulse-coder-memory-plugin']
-      : [],
+    external: [
+      'ink',
+      ...(isDebugBuild ? ['pulse-coder-acp', 'pulse-coder-engine', 'pulse-coder-memory-plugin'] : []),
+    ],
     noExternal: ['pulse-sandbox'],
     outExtension: () => ({ js: '.cjs' })
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,6 +278,9 @@ importers:
 
   packages/cli:
     dependencies:
+      ink:
+        specifier: ^7.0.2
+        version: 7.0.2(react@19.2.5)
       pulse-coder-acp:
         specifier: workspace:*
         version: link:../acp
@@ -296,6 +299,9 @@ importers:
       pulse-sandbox:
         specifier: workspace:*
         version: link:../pulse-sandbox
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
     devDependencies:
       '@types/node':
         specifier: ^25.0.10
@@ -532,6 +538,10 @@ packages:
 
   '@ai-sdk/provider@3.0.8':
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
+    engines: {node: '>=18'}
+
+  '@alcalzone/ansi-tokenize@0.3.0':
+    resolution: {integrity: sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==}
     engines: {node: '>=18'}
 
   '@babel/code-frame@7.29.0':
@@ -1589,6 +1599,10 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -1652,6 +1666,10 @@ packages:
   at-least-node@1.0.0:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
+
+  auto-bind@5.0.1:
+    resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   axios@1.13.5:
     resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
@@ -1748,6 +1766,10 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
@@ -1773,9 +1795,17 @@ packages:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
 
+  cli-boxes@4.0.1:
+    resolution: {integrity: sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==}
+    engines: {node: '>=18.20 <19 || >=20.10'}
+
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
     engines: {node: '>=8'}
+
+  cli-cursor@4.0.0:
+    resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
@@ -1784,6 +1814,10 @@ packages:
   cli-truncate@2.1.0:
     resolution: {integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==}
     engines: {node: '>=8'}
+
+  cli-truncate@6.0.0:
+    resolution: {integrity: sha512-3+YKIUFsohD9MIoOFPFBldjAlnfCmCDcqe6aYGFqlDTRKg80p4wg35L+j83QQ63iOlKRccEkbn8IuM++HsgEjA==}
+    engines: {node: '>=22'}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -1795,6 +1829,10 @@ packages:
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
+
+  code-excerpt@4.0.0:
+    resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1839,6 +1877,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  convert-to-spaces@2.0.1:
+    resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
@@ -2007,6 +2049,10 @@ packages:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
 
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
@@ -2026,6 +2072,9 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.46.1:
+    resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
+
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
@@ -2042,6 +2091,10 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -2177,6 +2230,10 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+    engines: {node: '>=18'}
+
   get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
 
@@ -2306,6 +2363,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
+
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
@@ -2315,6 +2376,19 @@ packages:
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  ink@7.0.2:
+    resolution: {integrity: sha512-cnkE2SsDC/gieJ+BD8+gWpXrZPMInv7agBYN5gcKVlQZYp+IKa/FKM5bp1OIuJFp3ZIuRK7ZNxY4MZR3tUzyfQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@types/react': '>=19.2.0'
+      react: '>=19.2.0'
+      react-devtools-core: '>=6.1.2'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-devtools-core:
+        optional: true
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
@@ -2327,6 +2401,15 @@ packages:
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
+  is-in-ci@2.0.0:
+    resolution: {integrity: sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
@@ -2735,6 +2818,10 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  patch-console@2.0.0:
+    resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -2941,12 +3028,22 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-reconciler@0.33.0:
+    resolution: {integrity: sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.2.0
+
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
 
   read-binary-file-arch@1.0.6:
@@ -2990,6 +3087,10 @@ packages:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
 
+  restore-cursor@4.0.0:
+    resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
@@ -3026,6 +3127,9 @@ packages:
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   section-matter@1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
@@ -3099,6 +3203,10 @@ packages:
     resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
     engines: {node: '>=8'}
 
+  slice-ansi@9.0.0:
+    resolution: {integrity: sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==}
+    engines: {node: '>=22'}
+
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
@@ -3136,6 +3244,10 @@ packages:
     resolution: {integrity: sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -3153,6 +3265,10 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string-width@8.2.1:
+    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
+    engines: {node: '>=20'}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -3193,6 +3309,10 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
@@ -3210,6 +3330,10 @@ packages:
   temp@0.9.4:
     resolution: {integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==}
     engines: {node: '>=6.0.0'}
+
+  terminal-size@4.0.1:
+    resolution: {integrity: sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==}
+    engines: {node: '>=18'}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -3295,6 +3419,10 @@ packages:
   type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
+
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+    engines: {node: '>=20'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -3439,10 +3567,18 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  widest-line@6.0.0:
+    resolution: {integrity: sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==}
+    engines: {node: '>=20'}
+
   wouter@3.9.0:
     resolution: {integrity: sha512-sF/od/PIgqEQBQcrN7a2x3MX6MQE6nW0ygCfy9hQuUkuB28wEZuu/6M5GyqkrrEu9M6jxdkgE12yDFsQMKos4Q==}
     peerDependencies:
       react: '>=16.8.0'
+
+  wrap-ansi@10.0.0:
+    resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
+    engines: {node: '>=20'}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -3457,6 +3593,18 @@ packages:
 
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3508,6 +3656,9 @@ packages:
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
+
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -3577,6 +3728,11 @@ snapshots:
   '@ai-sdk/provider@3.0.8':
     dependencies:
       json-schema: 0.4.0
+
+  '@alcalzone/ansi-tokenize@0.3.0':
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -4588,6 +4744,10 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
@@ -4668,6 +4828,8 @@ snapshots:
   asynckit@0.4.0: {}
 
   at-least-node@1.0.0: {}
+
+  auto-bind@5.0.1: {}
 
   axios@1.13.5:
     dependencies:
@@ -4816,6 +4978,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.6.2: {}
+
   check-error@1.0.3:
     dependencies:
       get-func-name: 2.0.2
@@ -4834,9 +4998,15 @@ snapshots:
 
   ci-info@4.4.0: {}
 
+  cli-boxes@4.0.1: {}
+
   cli-cursor@3.1.0:
     dependencies:
       restore-cursor: 3.1.0
+
+  cli-cursor@4.0.0:
+    dependencies:
+      restore-cursor: 4.0.0
 
   cli-spinners@2.9.2: {}
 
@@ -4845,6 +5015,11 @@ snapshots:
       slice-ansi: 3.0.0
       string-width: 4.2.3
     optional: true
+
+  cli-truncate@6.0.0:
+    dependencies:
+      slice-ansi: 9.0.0
+      string-width: 8.2.1
 
   cliui@8.0.1:
     dependencies:
@@ -4857,6 +5032,10 @@ snapshots:
       mimic-response: 1.0.1
 
   clone@1.0.4: {}
+
+  code-excerpt@4.0.0:
+    dependencies:
+      convert-to-spaces: 2.0.1
 
   color-convert@2.0.1:
     dependencies:
@@ -4886,6 +5065,8 @@ snapshots:
   consola@3.4.2: {}
 
   convert-source-map@2.0.0: {}
+
+  convert-to-spaces@2.0.1: {}
 
   core-util-is@1.0.2:
     optional: true
@@ -5096,6 +5277,8 @@ snapshots:
 
   env-paths@2.2.1: {}
 
+  environment@1.1.0: {}
+
   err-code@2.0.3: {}
 
   es-define-property@1.0.1: {}
@@ -5112,6 +5295,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  es-toolkit@1.46.1: {}
 
   es6-error@4.1.1:
     optional: true
@@ -5172,6 +5357,8 @@ snapshots:
       '@esbuild/win32-x64': 0.27.2
 
   escalade@3.2.0: {}
+
+  escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -5304,6 +5491,8 @@ snapshots:
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.5.0: {}
 
   get-func-name@2.0.2: {}
 
@@ -5467,6 +5656,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@5.0.0: {}
+
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
@@ -5476,11 +5667,49 @@ snapshots:
 
   ini@1.3.8: {}
 
+  ink@7.0.2(react@19.2.5):
+    dependencies:
+      '@alcalzone/ansi-tokenize': 0.3.0
+      ansi-escapes: 7.3.0
+      ansi-styles: 6.2.3
+      auto-bind: 5.0.1
+      chalk: 5.6.2
+      cli-boxes: 4.0.1
+      cli-cursor: 4.0.0
+      cli-truncate: 6.0.0
+      code-excerpt: 4.0.0
+      es-toolkit: 1.46.1
+      indent-string: 5.0.0
+      is-in-ci: 2.0.0
+      patch-console: 2.0.0
+      react: 19.2.5
+      react-reconciler: 0.33.0(react@19.2.5)
+      scheduler: 0.27.0
+      signal-exit: 3.0.7
+      slice-ansi: 9.0.0
+      stack-utils: 2.0.6
+      string-width: 8.2.1
+      terminal-size: 4.0.1
+      type-fest: 5.6.0
+      widest-line: 6.0.0
+      wrap-ansi: 10.0.0
+      ws: 8.20.0
+      yoga-layout: 3.2.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   ip-address@10.1.0: {}
 
   is-extendable@0.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
+
+  is-in-ci@2.0.0: {}
 
   is-interactive@1.0.0: {}
 
@@ -5864,6 +6093,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  patch-console@2.0.0: {}
+
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
@@ -6116,11 +6347,18 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-reconciler@0.33.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      scheduler: 0.27.0
+
   react-refresh@0.17.0: {}
 
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
+
+  react@19.2.5: {}
 
   read-binary-file-arch@1.0.6:
     dependencies:
@@ -6155,6 +6393,11 @@ snapshots:
       lowercase-keys: 2.0.0
 
   restore-cursor@3.1.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+
+  restore-cursor@4.0.0:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7
@@ -6221,6 +6464,8 @@ snapshots:
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
+
+  scheduler@0.27.0: {}
 
   section-matter@1.0.0:
     dependencies:
@@ -6300,6 +6545,11 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
     optional: true
 
+  slice-ansi@9.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   smart-buffer@4.2.0: {}
 
   socks-proxy-agent@8.0.5:
@@ -6335,6 +6585,10 @@ snapshots:
     dependencies:
       minipass: 7.1.2
 
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
+
   stackback@0.0.2: {}
 
   stat-mode@1.0.0: {}
@@ -6351,6 +6605,11 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
+      strip-ansi: 7.1.2
+
+  string-width@8.2.1:
+    dependencies:
+      get-east-asian-width: 1.5.0
       strip-ansi: 7.1.2
 
   string_decoder@1.3.0:
@@ -6395,6 +6654,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  tagged-tag@1.0.0: {}
+
   tar-fs@2.1.4:
     dependencies:
       chownr: 1.1.4
@@ -6427,6 +6688,8 @@ snapshots:
     dependencies:
       mkdirp: 0.5.6
       rimraf: 2.6.3
+
+  terminal-size@4.0.1: {}
 
   thenify-all@1.6.0:
     dependencies:
@@ -6518,6 +6781,10 @@ snapshots:
 
   type-fest@0.13.1:
     optional: true
+
+  type-fest@5.6.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typescript@5.9.3: {}
 
@@ -6709,12 +6976,22 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  widest-line@6.0.0:
+    dependencies:
+      string-width: 8.2.1
+
   wouter@3.9.0(react@18.3.1):
     dependencies:
       mitt: 3.0.1
       react: 18.3.1
       regexparam: 3.0.0
       use-sync-external-store: 1.6.0(react@18.3.1)
+
+  wrap-ansi@10.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 8.2.1
+      strip-ansi: 7.1.2
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -6731,6 +7008,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.19.0: {}
+
+  ws@8.20.0: {}
 
   xmlbuilder@15.1.1: {}
 
@@ -6764,6 +7043,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.2: {}
+
+  yoga-layout@3.2.1: {}
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## Summary
- Add a lightweight TUI renderer for the CLI with boxed welcome/help/status output, colored prompts, spinner status, and plain fallback mode.
- Route CLI command feedback, abort/queue states, agent stream text, tool calls/results, and step finishes through the renderer.
- Add renderer unit tests for interactive output, plain fallback, spinner cleanup, and tool event rendering.

## Validation
- `pnpm --filter pulse-coder-cli test` ✅
- `pnpm --filter pulse-coder-cli build` ✅

## Risk
- Low; scoped to CLI presentation and preserves non-TTY / `PULSE_CODER_PLAIN=1` fallback behavior.
