### PR TITLE
feat: export mindmaps as images

### DIFF
--- a/apps/canvas-workspace/src/main/file-manager.ts
+++ b/apps/canvas-workspace/src/main/file-manager.ts
@@ -169,6 +169,36 @@ export const setupFileManagerIpc = () => {
     }
   );
 
+  // Export an image (base64) via save dialog
+  ipcMain.handle(
+    "file:exportImage",
+    async (_event, payload: { defaultName?: string; data: string; ext?: string }) => {
+      try {
+        const ext = (payload.ext ?? "png").replace(/[^a-zA-Z0-9]/g, "") || "png";
+        const defaultName = payload.defaultName?.trim()
+          ? payload.defaultName.trim()
+          : `img-${Date.now()}.${ext}`;
+        const win = BrowserWindow.getFocusedWindow();
+        const result = await dialog.showSaveDialog(win!, {
+          title: "Export Image",
+          defaultPath: defaultName,
+          filters: [
+            { name: "PNG Image", extensions: ["png"] },
+            { name: "All Files", extensions: ["*"] }
+          ]
+        });
+        if (result.canceled || !result.filePath) {
+          return { ok: false, canceled: true };
+        }
+        const buffer = Buffer.from(payload.data, "base64");
+        await fs.writeFile(result.filePath, buffer);
+        return { ok: true, filePath: result.filePath, fileName: basename(result.filePath) };
+      } catch (err) {
+        return { ok: false, error: String(err) };
+      }
+    }
+  );
+
   // Save-as dialog
   ipcMain.handle(
     "file:saveAsDialog",

--- a/apps/canvas-workspace/src/preload/index.ts
+++ b/apps/canvas-workspace/src/preload/index.ts
@@ -121,6 +121,9 @@ contextBridge.exposeInMainWorld("canvasWorkspace", {
     saveImage: (workspaceId: string | undefined, data: string, ext?: string) =>
       ipcRenderer.invoke("file:saveImage", { workspaceId, data, ext }),
 
+    exportImage: (defaultName: string, data: string, ext?: string) =>
+      ipcRenderer.invoke("file:exportImage", { defaultName, data, ext }),
+
     onChanged: (callback: (filePath: string, content: string) => void) => {
       const handler = (
         _event: Electron.IpcRendererEvent,

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
@@ -67,6 +67,7 @@ interface CanvasSurfaceProps {
    *  history stack with a paired text + resize entry. */
   onAutoResize: (id: string, width: number, height: number) => void;
   onRemove: (id: string) => void;
+  onExportMindmapImage: (id: string) => void;
   /** Selection callback that forwards optional shift/meta modifiers so
    *  the parent can honor multi-select intent. */
   onSelect: (id: string, mods?: { shift?: boolean; meta?: boolean }) => void;
@@ -112,6 +113,7 @@ export const CanvasSurface = ({
   onUpdate,
   onAutoResize,
   onRemove,
+  onExportMindmapImage,
   onSelect,
   onFocus,
   onSelectEdge,
@@ -161,6 +163,7 @@ export const CanvasSurface = ({
         onUpdate={onUpdate}
         onAutoResize={onAutoResize}
         onRemove={onRemove}
+        onExportMindmapImage={onExportMindmapImage}
         onSelect={onSelect}
         onFocus={onFocus}
       />

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -17,6 +17,7 @@ import type { CanvasNode } from '../../types';
 import type { PaletteCommand } from '../CommandPalette';
 import { computeFrameDepths } from '../../utils/frameHierarchy';
 import { getNodeDisplayLabel } from '../../utils/nodeLabel';
+import { exportMindmapNodeToPng } from '../../utils/mindmapExport';
 import type { CanvasNodeRenameRequest } from '../../types/ui-interaction';
 import { CanvasSurface } from './CanvasSurface';
 import { CanvasOverlays } from './CanvasOverlays';
@@ -524,6 +525,48 @@ export const Canvas = ({
     [addNode, contextMenu, notify]
   );
 
+  const handleExportMindmapImage = useCallback(
+    async (nodeId: string) => {
+      const node = nodes.find((item) => item.id === nodeId);
+      const api = window.canvasWorkspace?.file;
+      if (!node || node.type !== 'mindmap' || !api) return;
+
+      notify({
+        tone: 'loading',
+        title: 'Exporting mindmap...',
+        description: getNodeDisplayLabel(node),
+      });
+
+      try {
+        const image = await exportMindmapNodeToPng(node);
+        const result = await api.exportImage(image.fileName, image.data, 'png');
+        if (!result.ok) {
+          if (result.canceled) {
+            notify({
+              tone: 'info',
+              title: 'Export canceled',
+              description: getNodeDisplayLabel(node),
+            });
+            return;
+          }
+          throw new Error(result.error ?? 'The image could not be saved.');
+        }
+        notify({
+          tone: 'success',
+          title: 'Mindmap image exported',
+          description: result.filePath ?? image.fileName,
+        });
+      } catch (err) {
+        notify({
+          tone: 'error',
+          title: 'Mindmap export failed',
+          description: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+    [nodes, notify],
+  );
+
   const handleToolbarAddNode = useCallback(
     (type: 'file' | 'terminal' | 'frame' | 'agent' | 'text' | 'iframe' | 'mindmap') => {
       if (!containerRef.current) return;
@@ -862,6 +905,7 @@ export const Canvas = ({
           }
           setSelectedEdgeId(null);
         }}
+        onExportMindmapImage={handleExportMindmapImage}
         onFocus={handleFocusNode}
         onSelectEdge={(id) => {
           setSelectedEdgeId(id);

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -11,6 +11,7 @@ import { IframeNodeBody } from "../IframeNodeBody";
 import { ImageNodeBody } from "../ImageNodeBody";
 import { ShapeNodeBody, ShapeStylePicker } from "../ShapeNodeBody";
 import { MindmapNodeBody } from "../MindmapNodeBody";
+import { NodeContextMenu } from "../NodeContextMenu";
 
 interface Props {
   node: CanvasNode;
@@ -40,6 +41,7 @@ interface Props {
    *  without polluting the undo stack. */
   onAutoResize: (id: string, width: number, height: number) => void;
   onRemove: (id: string) => void;
+  onExportMindmapImage: (id: string) => void;
   /** Selection callback. The optional `mods` payload lets the caller
    *  honor shift/meta multi-select semantics — without it the click is
    *  treated as a plain replace-the-selection click. */
@@ -99,11 +101,13 @@ export const CanvasNodeView = ({
   onUpdate,
   onAutoResize,
   onRemove,
+  onExportMindmapImage,
   onSelect,
   onFocus
 }: Props) => {
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [mindmapMenu, setMindmapMenu] = useState<{ x: number; y: number } | null>(null);
   const [, setTick] = useState(0);
   const titleRef = useRef<HTMLSpanElement>(null);
 
@@ -341,6 +345,12 @@ export const CanvasNodeView = ({
           height: node.height,
         }}
         onClick={handleNodeClick}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          onSelect(node.id);
+          setMindmapMenu({ x: e.clientX, y: e.clientY });
+        }}
         onMouseDown={(e) => {
           // Same logic as handleHeaderMouseDown — only collapse the
           // selection on a plain mousedown over an unselected node.
@@ -365,6 +375,18 @@ export const CanvasNodeView = ({
             <path d="M3 3l6 6M9 3l-6 6" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
           </svg>
         </button>
+        {mindmapMenu && (
+          <NodeContextMenu
+            x={mindmapMenu.x}
+            y={mindmapMenu.y}
+            mode="mindmap"
+            onClose={() => setMindmapMenu(null)}
+            onExportImage={() => {
+              setMindmapMenu(null);
+              onExportMindmapImage(node.id);
+            }}
+          />
+        )}
       </div>
     );
   }

--- a/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
@@ -1,14 +1,17 @@
 import "./index.css";
 import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
 
 interface Props {
   x: number;
   y: number;
-  onCreate: (type: "file" | "terminal" | "frame" | "agent" | "text" | "iframe" | "mindmap") => void;
+  mode?: "create" | "mindmap";
+  onCreate?: (type: "file" | "terminal" | "frame" | "agent" | "text" | "iframe" | "mindmap") => void;
+  onExportImage?: () => void;
   onClose: () => void;
 }
 
-export const NodeContextMenu = ({ x, y, onCreate, onClose }: Props) => {
+export const NodeContextMenu = ({ x, y, mode = "create", onCreate, onExportImage, onClose }: Props) => {
   const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -34,84 +37,104 @@ export const NodeContextMenu = ({ x, y, onCreate, onClose }: Props) => {
     };
   }, [onClose]);
 
-  return (
+  const menu = (
     <div
       ref={menuRef}
       className="context-menu"
       style={{ left: x, top: y }}
       onClick={(e) => e.stopPropagation()}
     >
-      <div className="context-menu-title">Create Node</div>
-      <button
-        className="context-menu-item"
-        onClick={() => onCreate("text")}
-      >
-        <span className="context-menu-icon">{"\u0041"}</span>
-        <span className="context-menu-label">
-          <strong>Text</strong>
-          <small>Free-form text label</small>
-        </span>
-      </button>
-      <button
-        className="context-menu-item"
-        onClick={() => onCreate("file")}
-      >
-        <span className="context-menu-icon">{"\u2756"}</span>
-        <span className="context-menu-label">
-          <strong>Note</strong>
-          <small>Markdown note card</small>
-        </span>
-      </button>
-      <button
-        className="context-menu-item"
-        onClick={() => onCreate("terminal")}
-      >
-        <span className="context-menu-icon">{"\u25B6"}</span>
-        <span className="context-menu-label">
-          <strong>Terminal</strong>
-          <small>Run shell commands</small>
-        </span>
-      </button>
-      <button
-        className="context-menu-item"
-        onClick={() => onCreate("frame")}
-      >
-        <span className="context-menu-icon">{"\u25A1"}</span>
-        <span className="context-menu-label">
-          <strong>Frame</strong>
-          <small>Visual container group</small>
-        </span>
-      </button>
-      <button
-        className="context-menu-item"
-        onClick={() => onCreate("iframe")}
-      >
-        <span className="context-menu-icon">{"\u232C"}</span>
-        <span className="context-menu-label">
-          <strong>Link</strong>
-          <small>Embed a web page</small>
-        </span>
-      </button>
-      <button
-        className="context-menu-item"
-        onClick={() => onCreate("agent")}
-      >
-        <span className="context-menu-icon">{"\u2726"}</span>
-        <span className="context-menu-label">
-          <strong>Agent</strong>
-          <small>Launch a coding agent</small>
-        </span>
-      </button>
-      <button
-        className="context-menu-item"
-        onClick={() => onCreate("mindmap")}
-      >
-        <span className="context-menu-icon">{"✿"}</span>
-        <span className="context-menu-label">
-          <strong>Mindmap</strong>
-          <small>Branching topic tree</small>
-        </span>
-      </button>
+      {mode === "mindmap" ? (
+        <>
+          <div className="context-menu-title">Mindmap</div>
+          <button
+            className="context-menu-item"
+            onClick={() => onExportImage?.()}
+          >
+            <span className="context-menu-icon">{"\u21E9"}</span>
+            <span className="context-menu-label">
+              <strong>Export as image</strong>
+              <small>Save this mindmap as a PNG</small>
+            </span>
+          </button>
+        </>
+      ) : (
+        <>
+          <div className="context-menu-title">Create Node</div>
+          <button
+            className="context-menu-item"
+            onClick={() => onCreate?.("text")}
+          >
+            <span className="context-menu-icon">{"\u0041"}</span>
+            <span className="context-menu-label">
+              <strong>Text</strong>
+              <small>Free-form text label</small>
+            </span>
+          </button>
+          <button
+            className="context-menu-item"
+            onClick={() => onCreate?.("file")}
+          >
+            <span className="context-menu-icon">{"\u2756"}</span>
+            <span className="context-menu-label">
+              <strong>Note</strong>
+              <small>Markdown note card</small>
+            </span>
+          </button>
+          <button
+            className="context-menu-item"
+            onClick={() => onCreate?.("terminal")}
+          >
+            <span className="context-menu-icon">{"\u25B6"}</span>
+            <span className="context-menu-label">
+              <strong>Terminal</strong>
+              <small>Run shell commands</small>
+            </span>
+          </button>
+          <button
+            className="context-menu-item"
+            onClick={() => onCreate?.("frame")}
+          >
+            <span className="context-menu-icon">{"\u25A1"}</span>
+            <span className="context-menu-label">
+              <strong>Frame</strong>
+              <small>Visual container group</small>
+            </span>
+          </button>
+          <button
+            className="context-menu-item"
+            onClick={() => onCreate?.("iframe")}
+          >
+            <span className="context-menu-icon">{"\u232C"}</span>
+            <span className="context-menu-label">
+              <strong>Link</strong>
+              <small>Embed a web page</small>
+            </span>
+          </button>
+          <button
+            className="context-menu-item"
+            onClick={() => onCreate?.("agent")}
+          >
+            <span className="context-menu-icon">{"\u2726"}</span>
+            <span className="context-menu-label">
+              <strong>Agent</strong>
+              <small>Launch a coding agent</small>
+            </span>
+          </button>
+          <button
+            className="context-menu-item"
+            onClick={() => onCreate?.("mindmap")}
+          >
+            <span className="context-menu-icon">{"✿"}</span>
+            <span className="context-menu-label">
+              <strong>Mindmap</strong>
+              <small>Branching topic tree</small>
+            </span>
+          </button>
+        </>
+      )}
     </div>
   );
+
+  return createPortal(menu, document.body);
 };

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -288,6 +288,11 @@ export interface FileApi {
     data: string,
     ext?: string
   ) => Promise<{ ok: boolean; filePath?: string; fileName?: string; error?: string }>;
+  exportImage: (
+    defaultName: string,
+    data: string,
+    ext?: string
+  ) => Promise<{ ok: boolean; canceled?: boolean; filePath?: string; fileName?: string; error?: string }>;
   onChanged: (callback: (filePath: string, content: string) => void) => () => void;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/utils/mindmapExport.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/mindmapExport.ts
@@ -1,0 +1,104 @@
+import type { CanvasNode, MindmapNodeData } from '../types';
+import { layoutMindmap, type MindmapLayout, type LaidOutTopic } from './mindmapLayout';
+
+const EXPORT_MARGIN = 28;
+const EXPORT_SCALE = 2;
+const SVG_NS = 'http://www.w3.org/2000/svg';
+const XHTML_NS = 'http://www.w3.org/1999/xhtml';
+
+export interface MindmapImageExport {
+  data: string;
+  fileName: string;
+  width: number;
+  height: number;
+}
+
+const escapeXml = (value: string) => value
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;')
+  .replace(/'/g, '&#39;');
+
+const sanitizeFileName = (value: string) => {
+  const trimmed = value
+    .replace(/[\\/:*?"<>|]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return trimmed.length > 0 ? trimmed.slice(0, 80) : 'mindmap';
+};
+
+const getTopicLabel = (topic: LaidOutTopic) => topic.text.trim() || 'Untitled';
+
+const renderTopic = (topic: LaidOutTopic) => {
+  const isRoot = topic.depth === 0;
+  const fontSize = isRoot ? 20 : 14;
+  const fontWeight = isRoot ? 500 : 400;
+  const justify = isRoot ? 'center' : 'flex-start';
+  const padding = isRoot ? '0 10px' : '0 8px';
+  const label = escapeXml(getTopicLabel(topic));
+  const toggle = !isRoot && topic.hasChildren
+    ? `<circle cx="${topic.x + topic.width - 2}" cy="${topic.y + topic.height / 2 + 3}" r="3" fill="${escapeXml(topic.color)}" opacity="${topic.collapsed ? '0.9' : '0.18'}" stroke="${escapeXml(topic.color)}" stroke-width="1" />`
+    : '';
+
+  return `
+    <foreignObject x="${topic.x}" y="${topic.y}" width="${topic.width}" height="${topic.height}">
+      <div xmlns="${XHTML_NS}" style="box-sizing:border-box;width:100%;height:100%;display:flex;align-items:center;justify-content:${justify};padding:${padding};font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:${fontSize}px;font-weight:${fontWeight};line-height:1.3;color:#1f2328;white-space:${isRoot ? 'nowrap' : 'pre-wrap'};overflow-wrap:break-word;">
+        <span style="display:block;max-width:100%;">${label}</span>
+      </div>
+    </foreignObject>
+    ${toggle}`;
+};
+
+const renderMindmapSvg = (layout: MindmapLayout, width: number, height: number) => `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="${SVG_NS}" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+  <rect width="100%" height="100%" fill="#ffffff" />
+  <g transform="translate(${EXPORT_MARGIN} ${EXPORT_MARGIN})">
+    ${layout.branches.map((branch) => `
+      <path d="${escapeXml(branch.path)}" fill="none" stroke="${escapeXml(branch.color)}" stroke-width="2" stroke-linecap="round" opacity="0.85" />
+    `).join('')}
+    ${layout.topics.map(renderTopic).join('')}
+  </g>
+</svg>`;
+
+const loadImage = (src: string) => new Promise<HTMLImageElement>((resolve, reject) => {
+  const image = new Image();
+  image.onload = () => resolve(image);
+  image.onerror = () => reject(new Error('Failed to render mindmap SVG.'));
+  image.src = src;
+});
+
+export const exportMindmapNodeToPng = async (node: CanvasNode): Promise<MindmapImageExport> => {
+  const data = node.data as MindmapNodeData;
+  const layout = layoutMindmap(data.root);
+  const width = Math.ceil(layout.width + EXPORT_MARGIN * 2);
+  const height = Math.ceil(layout.height + EXPORT_MARGIN * 2);
+  const svg = renderMindmapSvg(layout, width, height);
+  const blob = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+
+  try {
+    const image = await loadImage(url);
+    const canvas = document.createElement('canvas');
+    canvas.width = width * EXPORT_SCALE;
+    canvas.height = height * EXPORT_SCALE;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('Canvas rendering is unavailable.');
+    ctx.scale(EXPORT_SCALE, EXPORT_SCALE);
+    ctx.drawImage(image, 0, 0, width, height);
+
+    const dataUrl = canvas.toDataURL('image/png');
+    const base64 = dataUrl.split(',')[1];
+    if (!base64) throw new Error('Failed to encode exported image.');
+
+    const name = sanitizeFileName(node.title || data.root.text || 'mindmap');
+    return {
+      data: base64,
+      fileName: `${name}.png`,
+      width,
+      height,
+    };
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+};


### PR DESCRIPTION
## Summary
- Add a mindmap right-click context menu action to export the selected mindmap as a PNG.
- Render mindmap layout to a high-resolution PNG using the existing deterministic layout data.
- Add a save-dialog-backed image export IPC API without changing existing pasted-image persistence.

## Validation
- `pnpm --filter canvas-workspace typecheck` ✅
- `pnpm --filter canvas-workspace build` ✅

## Risk
- Low; scoped to canvas-workspace mindmap export and a new file export IPC path.
