### PR TITLE
fix(devtools): defer prompt snapshot capture

### DIFF
--- a/packages/plugin-kit/src/devtools/index.ts
+++ b/packages/plugin-kit/src/devtools/index.ts
@@ -867,10 +867,18 @@ export class DevtoolsStore {
     }
     record.llmSpans.push(span);
 
-    // Async snapshot persistence (best-effort, non-blocking).
+    // Defer snapshot persistence so prompt stringify/redaction work does not
+    // block the beforeLLMCall hook before the provider request can start.
     if (this.capturePrompts && snapshot && (snapshot.messages?.length || snapshot.systemPrompt)) {
-      void this.savePromptSnapshot(record.runId, span, snapshot).catch(() => {
-        /* swallow snapshot errors */
+      const snapshotForAsync = {
+        ...snapshot,
+        messages: snapshot.messages ? snapshot.messages.slice() : undefined,
+        toolNames: snapshot.toolNames ? snapshot.toolNames.slice() : undefined,
+      };
+      setImmediate(() => {
+        void this.savePromptSnapshot(record.runId, span, snapshotForAsync).catch(() => {
+          /* swallow snapshot errors */
+        });
       });
     }
 


### PR DESCRIPTION
## Summary
- Defer devtools prompt snapshot persistence with setImmediate so stringify/redaction work no longer blocks beforeLLMCall.
- Clone snapshot arrays before deferred execution to keep captured metadata stable.

## Validation
- `pnpm --filter pulse-coder-plugin-kit build:js` ✅
- `pnpm --filter pulse-coder-plugin-kit build` ⚠️ failed during DTS because this worktree is missing node type definitions in node_modules (TS2688: Cannot find type definition file for 'node'); JS build passed.

## Risk
- Low; scoped to devtools best-effort prompt snapshot scheduling.