### PR TITLE
chore(remote-server): add deep research skill

### DIFF
--- a/apps/remote-server/skills-lock.json
+++ b/apps/remote-server/skills-lock.json
@@ -1,6 +1,12 @@
 {
   "version": 1,
   "skills": {
+    "deep-research": {
+      "source": "199-biotechnologies/claude-deep-research-skill",
+      "sourceType": "github",
+      "skillPath": "SKILL.md",
+      "computedHash": "685efecf2091dccf219506641671acc3c0c31ecb83f54b8473b9d399ba0337b8"
+    },
     "wechat-article-search": {
       "source": "openclaw/skills",
       "sourceType": "github",


### PR DESCRIPTION
Add the 199-biotechnologies deep-research skill lock entry for the remote server.\n\n- Register the deep-research skill source in apps/remote-server/skills-lock.json\n- Pin the computed skill hash for reproducible installation\n\nValidation:\n- Installed via npx skills add from apps/remote-server\n- Confirmed apps/remote-server/.agents/skills/deep-research exists locally