### PR TITLE
fix: improve canvas selection interactions

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
@@ -131,9 +131,34 @@ export const CanvasSurface = ({
         : undefined,
     } as React.CSSProperties}
   >
-    {/* Edges render beneath nodes so node interactions keep working and
-        so the connection line visually terminates behind the node it
-        points at rather than being covered by it. */}
+    {/* Frames render first as the canvas background/grouping layer. Edges
+        render after frames so frame fills can no longer cover connection
+        lines, while regular nodes still paint above edges. */}
+    {sortedNodes
+      .filter((node) => node.type === 'frame')
+      .map((node) => (
+        <CanvasNodeView
+          key={node.id}
+          node={node}
+          allNodes={nodes}
+          rootFolder={rootFolder}
+          workspaceId={canvasId}
+          workspaceName={canvasName}
+          isDragging={draggingIds.has(node.id) || draggingId === node.id}
+          isResizing={resizingId === node.id}
+          isSelected={selectedNodeIds.includes(node.id)}
+          isHighlighted={highlightedId === node.id}
+          isAgentEdited={externallyEditedIds.has(node.id)}
+          onDragStart={onDragStart}
+          onResizeStart={onResizeStart}
+          onUpdate={onUpdate}
+          onAutoResize={onAutoResize}
+          onRemove={onRemove}
+          onExportMindmapImage={onExportMindmapImage}
+          onSelect={onSelect}
+          onFocus={onFocus}
+        />
+      ))}
     <CanvasEdgesLayer
       edges={edges}
       nodes={nodes}
@@ -145,29 +170,31 @@ export const CanvasSurface = ({
       onBodyMouseDown={onEdgeBodyMouseDown}
       onBodyDoubleClick={onEdgeBodyDoubleClick}
     />
-    {sortedNodes.map((node) => (
-      <CanvasNodeView
-        key={node.id}
-        node={node}
-        allNodes={nodes}
-        rootFolder={rootFolder}
-        workspaceId={canvasId}
-        workspaceName={canvasName}
-        isDragging={draggingIds.has(node.id) || draggingId === node.id}
-        isResizing={resizingId === node.id}
-        isSelected={selectedNodeIds.includes(node.id)}
-        isHighlighted={highlightedId === node.id}
-        isAgentEdited={externallyEditedIds.has(node.id)}
-        onDragStart={onDragStart}
-        onResizeStart={onResizeStart}
-        onUpdate={onUpdate}
-        onAutoResize={onAutoResize}
-        onRemove={onRemove}
-        onExportMindmapImage={onExportMindmapImage}
-        onSelect={onSelect}
-        onFocus={onFocus}
-      />
-    ))}
+    {sortedNodes
+      .filter((node) => node.type !== 'frame')
+      .map((node) => (
+        <CanvasNodeView
+          key={node.id}
+          node={node}
+          allNodes={nodes}
+          rootFolder={rootFolder}
+          workspaceId={canvasId}
+          workspaceName={canvasName}
+          isDragging={draggingIds.has(node.id) || draggingId === node.id}
+          isResizing={resizingId === node.id}
+          isSelected={selectedNodeIds.includes(node.id)}
+          isHighlighted={highlightedId === node.id}
+          isAgentEdited={externallyEditedIds.has(node.id)}
+          onDragStart={onDragStart}
+          onResizeStart={onResizeStart}
+          onUpdate={onUpdate}
+          onAutoResize={onAutoResize}
+          onRemove={onRemove}
+          onExportMindmapImage={onExportMindmapImage}
+          onSelect={onSelect}
+          onFocus={onFocus}
+        />
+      ))}
     {shapeDraft && <ShapeDraftPreview draft={shapeDraft} />}
     {marqueeRect && <MarqueePreview rect={marqueeRect} />}
     {snapLines && snapLines.length > 0 && (

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.css
@@ -6,6 +6,13 @@
   background: var(--bg-canvas);
 }
 
+.canvas-container--selecting,
+.canvas-container--selecting * {
+  user-select: none !important;
+  -webkit-user-select: none !important;
+  -webkit-user-drag: none;
+}
+
 .canvas-container--hand {
   cursor: grab;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -14,6 +14,7 @@ import { useMarqueeSelect } from '../../hooks/useMarqueeSelect';
 import { useAppShell } from '../AppShellProvider';
 import { NODE_TYPE_LABELS } from '../../constants/interaction';
 import type { CanvasNode } from '../../types';
+import type { EdgeInteractionState } from '../../hooks/useEdgeInteraction';
 import type { PaletteCommand } from '../CommandPalette';
 import { computeFrameDepths } from '../../utils/frameHierarchy';
 import { getNodeDisplayLabel } from '../../utils/nodeLabel';
@@ -74,6 +75,14 @@ export const Canvas = ({
   // that fires immediately afterward doesn't fall through to the blank-
   // canvas-click handler and wipe the selection we just made.
   const suppressBlankClickRef = useRef(false);
+
+  // Node drag / resize starts inside node subtrees, but mousemove bubbles
+  // through whatever element is currently under the cursor. If that element
+  // is an editable text layer (mindmap text, ProseMirror text, etc.), the
+  // browser may select/focus text and React's canvas-level move can stop
+  // seeing a consistent stream. Track the gesture at the window level too
+  // so dragging remains uninterrupted when crossing text.
+  const isDraggingRef = useRef(false);
 
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -321,6 +330,13 @@ export const Canvas = ({
   );
 
   const getContainer = useCallback(() => containerRef.current, []);
+
+  const isEdgeDragging = useCallback((state: EdgeInteractionState | null) => {
+    return state?.kind === 'connect'
+      || state?.kind === 'move-end'
+      || state?.kind === 'move-bend'
+      || state?.kind === 'move-edge';
+  }, []);
 
   const {
     state: edgeInteractionState,
@@ -813,10 +829,16 @@ export const Canvas = ({
   const handleMouseMove = useCallback(
     (e: React.MouseEvent) => {
       canvasMouseMove(e);
-      onDragMove(e);
-      onResizeMove(e);
     },
-    [canvasMouseMove, onDragMove, onResizeMove]
+    [canvasMouseMove]
+  );
+
+  const handleWindowDragMove = useCallback(
+    (e: MouseEvent) => {
+      onDragMove(e as unknown as React.MouseEvent);
+      onResizeMove(e as unknown as React.MouseEvent);
+    },
+    [onDragMove, onResizeMove]
   );
 
   const handleMouseUp = useCallback(() => {
@@ -824,12 +846,42 @@ export const Canvas = ({
     onDragEnd();
     onResizeEnd();
     commitHistory();
+    isDraggingRef.current = false;
   }, [canvasMouseUp, onDragEnd, onResizeEnd, commitHistory]);
+
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      if (isDraggingRef.current) handleWindowDragMove(e);
+    };
+    const onUp = () => {
+      if (isDraggingRef.current) handleMouseUp();
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+    return () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+  }, [handleWindowDragMove, handleMouseUp]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return undefined;
+    const onSelectStart = (e: Event) => {
+      if (isDraggingRef.current || marquee.active || isEdgeDragging(edgeInteractionState)) {
+        e.preventDefault();
+      }
+    };
+    container.addEventListener('selectstart', onSelectStart);
+    return () => container.removeEventListener('selectstart', onSelectStart);
+  }, [edgeInteractionState, isEdgeDragging, marquee.active]);
 
   const cursorClass = activeTool === 'hand'
     ? ' canvas-container--hand'
     : shapeToolActive ? ' canvas-container--shape'
-    : resizingId ? ' canvas-container--resizing' : '';
+    : resizingId ? ' canvas-container--resizing'
+    : (marquee.active || isDraggingRef.current || isEdgeDragging(edgeInteractionState)) ? ' canvas-container--selecting'
+    : '';
 
   if (!loaded) {
     return (
@@ -850,7 +902,12 @@ export const Canvas = ({
       onMouseDown={handleRootMouseDown}
       onMouseMove={handleMouseMove}
       onMouseUp={handleMouseUp}
-      onMouseLeave={handleMouseUp}
+      onMouseLeave={() => {
+        if (!isDraggingRef.current && !isEdgeDragging(edgeInteractionState)) {
+          handleMouseUp();
+        }
+      }}
+      onDragStart={(e) => e.preventDefault()}
       onDoubleClick={handleDoubleClick}
       onContextMenu={handleContextMenu}
       onClick={handleCanvasClick}
@@ -879,8 +936,14 @@ export const Canvas = ({
         shapeDraft={shapeDraft}
         marqueeRect={marquee.rect}
         snapLines={snapLines}
-        onDragStart={onDragStart}
-        onResizeStart={onResizeStart}
+        onDragStart={(e, node) => {
+          if (e.button === 0 && !e.altKey) isDraggingRef.current = true;
+          onDragStart(e, node);
+        }}
+        onResizeStart={(e, nodeId, width, height, edge, minWidth, minHeight) => {
+          if (e.button === 0) isDraggingRef.current = true;
+          onResizeStart(e, nodeId, width, height, edge, minWidth, minHeight);
+        }}
         onUpdate={updateNode}
         onAutoResize={resizeNode}
         onRemove={(id) => {

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -365,6 +365,7 @@ export const CanvasNodeView = ({
           <MindmapNodeBody
             node={node}
             isSelected={isSelected}
+            isOuterDragging={isDragging}
             onUpdate={onUpdate}
             onSelectNode={onSelect}
             onAutoResize={onAutoResize}

--- a/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.css
@@ -12,6 +12,12 @@
   background: transparent;
 }
 
+.mindmap-node-body--outer-dragging .mindmap-topic,
+.mindmap-node-body--outer-dragging .mindmap-topic-text {
+  pointer-events: none;
+  user-select: none;
+}
+
 .mindmap-viewport {
   position: relative;
   width: 100%;

--- a/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.tsx
@@ -26,6 +26,7 @@ import {
 interface Props {
   node: CanvasNode;
   isSelected: boolean;
+  isOuterDragging?: boolean;
   onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
   /** Called when any topic pill inside the mindmap receives a mouse
    *  selection. The mindmap itself is a canvas node; bubbling up this
@@ -64,7 +65,7 @@ interface Props {
  * while selected enters edit mode. Commit on blur / Enter (Enter on a
  * non-root topic also spawns a sibling); Esc cancels without saving.
  */
-export const MindmapNodeBody = ({ node, isSelected, onUpdate, onSelectNode, onAutoResize }: Props) => {
+export const MindmapNodeBody = ({ node, isSelected, isOuterDragging = false, onUpdate, onSelectNode, onAutoResize }: Props) => {
   const data = node.data as MindmapNodeData;
   const root = data.root;
 
@@ -351,7 +352,7 @@ export const MindmapNodeBody = ({ node, isSelected, onUpdate, onSelectNode, onAu
   // canvas — just like an image or shape node.
   return (
     <div
-      className={`mindmap-node-body${isSelected ? ' mindmap-node-body--selected' : ''}`}
+      className={`mindmap-node-body${isSelected ? ' mindmap-node-body--selected' : ''}${isOuterDragging ? ' mindmap-node-body--outer-dragging' : ''}`}
     >
       <div
         className="mindmap-viewport"

--- a/apps/canvas-workspace/src/renderer/src/hooks/useMarqueeSelect.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useMarqueeSelect.ts
@@ -119,6 +119,7 @@ export const useMarqueeSelect = ({
       if (e.altKey) return;
       const el = getContainer();
       if (!el) return;
+      e.preventDefault();
       const start = screenToCanvas(e.clientX, e.clientY, el);
       snapshotRef.current = nodes;
       setMarquee({

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodeDrag.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodeDrag.ts
@@ -56,6 +56,7 @@ export const useNodeDrag = (
     (e: React.MouseEvent, node: CanvasNode) => {
       if (e.button !== 0 || e.altKey) return;
       e.stopPropagation();
+      e.preventDefault();
 
       const companionMap = new Map<string, { id: string; nodeX: number; nodeY: number }>();
 


### PR DESCRIPTION
Improve canvas layer ordering and pointer handling during drag and selection.

- Render frames behind edges so links stay visible
- Keep node dragging active when crossing text content
- Prevent native text selection and drag ghosting during marquee selection
- Disable inner mindmap topic pointer capture while moving nodes

Validation:
- git diff --check
- pnpm --filter canvas-workspace typecheck:renderer