### PR TITLE
feat(canvas): add minimal resizable reference drawer

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -397,12 +397,6 @@ const AppContent = () => {
     }));
   }, [activeId]);
 
-  const handlePinSelectedReference = useCallback(() => {
-    const selectedNodeIds = selectedNodeIdsByWorkspace[activeId] || [];
-    if (selectedNodeIds.length !== 1) return;
-    pinReferenceNode(selectedNodeIds[0]);
-  }, [activeId, selectedNodeIdsByWorkspace, pinReferenceNode]);
-
   const handleFocusReferenceNode = useCallback((nodeId: string) => {
     setFocusNodeId(nodeId);
   }, []);
@@ -464,7 +458,6 @@ const AppContent = () => {
               referenceNode={referenceNode}
               selectedNode={selectedNode}
               onOpenChange={setReferenceDrawerOpen}
-              onPinSelected={handlePinSelectedReference}
               onClear={clearReferenceNode}
               onFocusNode={handleFocusReferenceNode}
             />

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
@@ -72,6 +72,7 @@ interface CanvasSurfaceProps {
    *  the parent can honor multi-select intent. */
   onSelect: (id: string, mods?: { shift?: boolean; meta?: boolean }) => void;
   onFocus: (node: CanvasNode) => void;
+  onReference?: (nodeId: string) => void;
   onSelectEdge: (id: string | null) => void;
   onEdgeHandleMouseDown: (
     edgeId: string,
@@ -116,6 +117,7 @@ export const CanvasSurface = ({
   onExportMindmapImage,
   onSelect,
   onFocus,
+  onReference,
   onSelectEdge,
   onEdgeHandleMouseDown,
   onEdgeBodyMouseDown,
@@ -157,6 +159,7 @@ export const CanvasSurface = ({
           onExportMindmapImage={onExportMindmapImage}
           onSelect={onSelect}
           onFocus={onFocus}
+          onReference={onReference}
         />
       ))}
     <CanvasEdgesLayer
@@ -193,6 +196,7 @@ export const CanvasSurface = ({
           onExportMindmapImage={onExportMindmapImage}
           onSelect={onSelect}
           onFocus={onFocus}
+          onReference={onReference}
         />
       ))}
     {shapeDraft && <ShapeDraftPreview draft={shapeDraft} />}

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -998,6 +998,7 @@ export const Canvas = ({
         }}
         onExportMindmapImage={handleExportMindmapImage}
         onFocus={handleFocusNode}
+        onReference={onPinReferenceNode}
         onSelectEdge={(id) => {
           setSelectedEdgeId(id);
           if (id) setSelectedNodeIds([]);

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -49,7 +49,6 @@
   cursor: default;
 }
 
-.canvas-node--readonly .node-copy,
 .canvas-node--readonly .node-focus {
   opacity: 1;
 }
@@ -210,10 +209,9 @@
   opacity: 1;
 }
 
-.node-copy,
+.node-reference,
 .node-focus,
 .node-close {
-  width: 20px;
   height: 20px;
   border: none;
   background: transparent;
@@ -228,20 +226,27 @@
   transition: opacity 0.1s, background 0.1s, color 0.1s;
 }
 
-.canvas-node:hover .node-copy,
+.node-reference {
+  width: auto;
+  padding: 0 6px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.node-focus,
+.node-close {
+  width: 20px;
+}
+
+.canvas-node:hover .node-reference,
 .canvas-node:hover .node-focus,
 .canvas-node:hover .node-close {
   opacity: 1;
 }
 
-.node-copy:hover {
+.node-reference:hover {
   background: var(--accent-light);
   color: var(--accent);
-}
-
-.node-copy--done {
-  color: #10b981 !important;
-  opacity: 1 !important;
 }
 
 .node-focus:hover {

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState, useEffect, useRef } from "react";
 import "./index.css";
-import type { CanvasNode, FrameNodeData, AgentNodeData, TextNodeData, FileNodeData } from "../../types";
+import type { CanvasNode, FrameNodeData, AgentNodeData, TextNodeData } from "../../types";
 import type { ResizeEdge } from "../../hooks/useNodeResize";
 import { FileNodeBody } from "../FileNodeBody";
 import { TerminalNodeBody } from "../TerminalNodeBody";
@@ -47,6 +47,7 @@ interface Props {
    *  treated as a plain replace-the-selection click. */
   onSelect: (id: string, mods?: { shift?: boolean; meta?: boolean }) => void;
   onFocus: (node: CanvasNode) => void;
+  onReference?: (nodeId: string) => void;
   readOnly?: boolean;
 }
 
@@ -58,25 +59,6 @@ function formatRelativeTime(epochMs: number): string {
   const diffHr = Math.floor(diffMin / 60);
   if (diffHr < 24) return `${diffHr}h ago`;
   return `${Math.floor(diffHr / 24)}d ago`;
-}
-
-function fallbackCopy(text: string) {
-  const el = document.createElement('textarea');
-  el.value = text;
-  el.style.cssText = 'position:fixed;top:0;left:0;opacity:0;pointer-events:none';
-  document.body.appendChild(el);
-  el.select();
-  try { document.execCommand('copy'); } catch { /* ignore */ }
-  document.body.removeChild(el);
-}
-
-function getNodeCopyContent(node: CanvasNode): string {
-  switch (node.type) {
-    case 'file': return (node.data as FileNodeData).content ?? '';
-    case 'text': return (node.data as TextNodeData).content ?? '';
-    case 'agent': return (node.data as AgentNodeData).scrollback ?? '';
-    default: return node.title;
-  }
 }
 
 const AGENT_STATUS_LABEL: Record<string, string> = {
@@ -105,10 +87,10 @@ export const CanvasNodeView = ({
   onExportMindmapImage,
   onSelect,
   onFocus,
+  onReference,
   readOnly = false
 }: Props) => {
   const [isEditingTitle, setIsEditingTitle] = useState(false);
-  const [copied, setCopied] = useState(false);
   const [mindmapMenu, setMindmapMenu] = useState<{ x: number; y: number } | null>(null);
   const [, setTick] = useState(0);
   const titleRef = useRef<HTMLSpanElement>(null);
@@ -162,6 +144,15 @@ export const CanvasNodeView = ({
     [onFocus, node]
   );
 
+  const handleReference = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (readOnly) return;
+      onReference?.(node.id);
+    },
+    [onReference, node.id, readOnly]
+  );
+
   const handleTitleBlur = useCallback(
     (e: React.FocusEvent<HTMLSpanElement>) => {
       if (readOnly) {
@@ -208,27 +199,6 @@ export const CanvasNodeView = ({
       });
     },
     [readOnly]
-  );
-
-  const handleCopy = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation();
-      const content = getNodeCopyContent(node);
-      const write = () => {
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
-      };
-      if (navigator.clipboard?.writeText) {
-        navigator.clipboard.writeText(content).then(write).catch(() => {
-          fallbackCopy(content);
-          write();
-        });
-      } else {
-        fallbackCopy(content);
-        write();
-      }
-    },
-    [node]
   );
 
   const makeResizeHandler = useCallback(
@@ -506,24 +476,11 @@ export const CanvasNodeView = ({
         {node.type === "text" && !readOnly && (
           <TextColorPicker node={node} onUpdate={onUpdate} />
         )}
-        {readOnly ? null : (
-          <button
-            className={`node-copy${copied ? ' node-copy--done' : ''}`}
-            onClick={handleCopy}
-            title={copied ? 'Copied!' : 'Copy content'}
-          >
-            {copied ? (
-              <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-                <path d="M2 6l3 3 5-5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
-              </svg>
-            ) : (
-              <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
-                <rect x="5" y="1" width="9" height="11" rx="1.5" stroke="currentColor" strokeWidth="1.3" />
-                <path d="M11 4H3a1 1 0 00-1 1v9a1 1 0 001 1h8a1 1 0 001-1V4z" stroke="currentColor" strokeWidth="1.3" />
-              </svg>
-            )}
+        {!readOnly && onReference ? (
+          <button className="node-reference" onClick={handleReference} title="Reference">
+            Reference
           </button>
-        )}
+        ) : null}
         <button className="node-focus" onClick={handleFocus} title="Focus">
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
             <circle cx="6" cy="6" r="2" stroke="currentColor" strokeWidth="1.3" />

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -506,22 +506,24 @@ export const CanvasNodeView = ({
         {node.type === "text" && !readOnly && (
           <TextColorPicker node={node} onUpdate={onUpdate} />
         )}
-        <button
-          className={`node-copy${copied ? ' node-copy--done' : ''}`}
-          onClick={handleCopy}
-          title={copied ? 'Copied!' : 'Copy content'}
-        >
-          {copied ? (
-            <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-              <path d="M2 6l3 3 5-5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
-            </svg>
-          ) : (
-            <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
-              <rect x="5" y="1" width="9" height="11" rx="1.5" stroke="currentColor" strokeWidth="1.3" />
-              <path d="M11 4H3a1 1 0 00-1 1v9a1 1 0 001 1h8a1 1 0 001-1V4z" stroke="currentColor" strokeWidth="1.3" />
-            </svg>
-          )}
-        </button>
+        {readOnly ? null : (
+          <button
+            className={`node-copy${copied ? ' node-copy--done' : ''}`}
+            onClick={handleCopy}
+            title={copied ? 'Copied!' : 'Copy content'}
+          >
+            {copied ? (
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                <path d="M2 6l3 3 5-5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            ) : (
+              <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+                <rect x="5" y="1" width="9" height="11" rx="1.5" stroke="currentColor" strokeWidth="1.3" />
+                <path d="M11 4H3a1 1 0 00-1 1v9a1 1 0 001 1h8a1 1 0 001-1V4z" stroke="currentColor" strokeWidth="1.3" />
+              </svg>
+            )}
+          </button>
+        )}
         <button className="node-focus" onClick={handleFocus} title="Focus">
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
             <circle cx="6" cy="6" r="2" stroke="currentColor" strokeWidth="1.3" />

--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.css
@@ -8,7 +8,9 @@
   background: #fbfbfa;
   overflow: hidden;
   position: relative;
-  z-index: 4;
+  z-index: 10;
+  flex-shrink: 0;
+  isolation: isolate;
 }
 
 .reference-drawer--open {
@@ -230,12 +232,6 @@
   text-align: center;
 }
 
-.reference-selected-action {
-  width: 100%;
-  margin-top: 7px;
-  flex: 0;
-}
-
 .reference-native-card {
   min-height: 0;
   height: calc(100% - 88px);
@@ -261,4 +257,6 @@
   padding: 8px;
   border-top: 1px solid var(--border-light);
   background: #fbfbfa;
+  justify-content: flex-end;
+  flex-wrap: wrap;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.css
@@ -118,14 +118,9 @@
   background: rgba(0, 0, 0, 0.04);
 }
 
-.reference-drawer-actions,
 .reference-card-footer {
   display: flex;
   gap: 6px;
-}
-
-.reference-drawer-actions {
-  padding: 12px 18px 0;
 }
 
 .reference-drawer-primary,
@@ -136,6 +131,7 @@
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;
+  white-space: nowrap;
   transition: background 0.12s ease, color 0.12s ease, opacity 0.12s ease;
 }
 
@@ -234,9 +230,15 @@
   text-align: center;
 }
 
+.reference-selected-action {
+  width: 100%;
+  margin-top: 7px;
+  flex: 0;
+}
+
 .reference-native-card {
   min-height: 0;
-  height: calc(100% - 108px);
+  height: calc(100% - 88px);
   margin: 14px 18px 18px;
   display: flex;
   flex-direction: column;

--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.css
@@ -1,15 +1,49 @@
 .reference-drawer {
-  width: 336px;
-  flex: 0 0 336px;
+  width: 420px;
+  flex: 0 0 420px;
+  min-width: 320px;
+  max-width: 720px;
   height: 100%;
   border-right: 1px solid var(--border);
   background: var(--surface);
   overflow: hidden;
+  position: relative;
   z-index: 4;
 }
 
 .reference-drawer--open {
   animation: reference-drawer-enter 0.18s ease-out;
+}
+
+.reference-drawer--resizing {
+  user-select: none;
+}
+
+.reference-drawer-resize-handle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 8px;
+  height: 100%;
+  cursor: col-resize;
+  z-index: 6;
+}
+
+.reference-drawer-resize-handle::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 3px;
+  width: 1px;
+  height: 100%;
+  background: transparent;
+  transition: background 0.16s ease, box-shadow 0.16s ease;
+}
+
+.reference-drawer-resize-handle:hover::after,
+.reference-drawer--resizing .reference-drawer-resize-handle::after {
+  background: var(--accent-border);
+  box-shadow: 0 0 0 2px rgba(35, 131, 226, 0.12);
 }
 
 @keyframes reference-drawer-enter {

--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.css
@@ -4,15 +4,15 @@
   min-width: 320px;
   max-width: 720px;
   height: 100%;
-  border-right: 1px solid var(--border);
-  background: var(--surface);
+  border-right: 1px solid var(--border-light);
+  background: #fbfbfa;
   overflow: hidden;
   position: relative;
   z-index: 4;
 }
 
 .reference-drawer--open {
-  animation: reference-drawer-enter 0.18s ease-out;
+  animation: reference-drawer-enter 0.14s ease-out;
 }
 
 .reference-drawer--resizing {
@@ -23,33 +23,51 @@
   position: absolute;
   top: 0;
   right: 0;
-  width: 8px;
+  width: 10px;
   height: 100%;
   cursor: col-resize;
   z-index: 6;
 }
 
-.reference-drawer-resize-handle::after {
+.reference-drawer-resize-handle::before {
   content: '';
   position: absolute;
   top: 0;
-  right: 3px;
+  right: 0;
   width: 1px;
   height: 100%;
   background: transparent;
-  transition: background 0.16s ease, box-shadow 0.16s ease;
+  transition: background 0.14s ease;
+}
+
+.reference-drawer-resize-handle::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 3px;
+  width: 3px;
+  height: 28px;
+  border-radius: 999px;
+  background: var(--text-muted);
+  opacity: 0;
+  transform: translateY(-50%);
+  transition: opacity 0.14s ease;
+}
+
+.reference-drawer-resize-handle:hover::before,
+.reference-drawer--resizing .reference-drawer-resize-handle::before {
+  background: rgba(35, 131, 226, 0.28);
 }
 
 .reference-drawer-resize-handle:hover::after,
 .reference-drawer--resizing .reference-drawer-resize-handle::after {
-  background: var(--accent-border);
-  box-shadow: 0 0 0 2px rgba(35, 131, 226, 0.12);
+  opacity: 0.34;
 }
 
 @keyframes reference-drawer-enter {
   from {
     opacity: 0;
-    transform: translateX(-10px);
+    transform: translateX(-6px);
   }
   to {
     opacity: 1;
@@ -62,141 +80,149 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
-  padding: 18px 16px 0;
+  padding: 16px 18px 0;
 }
 
 .reference-drawer-kicker {
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: none;
 }
 
 .reference-drawer-header h2 {
-  margin-top: 4px;
-  font-size: 18px;
-  line-height: 1.2;
+  margin-top: 2px;
+  font-size: 16px;
+  font-weight: 650;
+  line-height: 1.25;
   color: var(--text);
+  letter-spacing: -0.01em;
 }
 
 .reference-drawer-icon-button {
-  width: 28px;
-  height: 28px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: var(--surface);
-  color: var(--text-secondary);
+  width: 24px;
+  height: 24px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
   cursor: pointer;
-  font-size: 18px;
+  font-size: 17px;
   line-height: 1;
+  transition: background 0.12s ease, color 0.12s ease;
 }
 
 .reference-drawer-icon-button:hover {
   color: var(--text);
-  background: var(--surface-hover);
+  background: rgba(0, 0, 0, 0.04);
 }
 
 .reference-drawer-actions,
 .reference-card-footer {
   display: flex;
-  gap: 8px;
+  gap: 6px;
 }
 
 .reference-drawer-actions {
-  padding: 14px 16px 0;
+  padding: 12px 18px 0;
 }
 
 .reference-drawer-primary,
 .reference-drawer-secondary {
-  border-radius: 8px;
-  padding: 8px 10px;
+  border: 0;
+  border-radius: 6px;
+  padding: 6px 9px;
   font-size: 12px;
-  font-weight: 700;
+  font-weight: 600;
   cursor: pointer;
-  transition: opacity 0.16s ease, background 0.16s ease, border-color 0.16s ease;
+  transition: background 0.12s ease, color 0.12s ease, opacity 0.12s ease;
 }
 
 .reference-drawer-primary {
-  border: 1px solid var(--accent-border);
-  background: var(--accent);
-  color: white;
+  background: rgba(35, 131, 226, 0.08);
+  color: var(--accent);
   flex: 1;
+}
+
+.reference-drawer-primary:hover:not(:disabled) {
+  background: rgba(35, 131, 226, 0.12);
 }
 
 .reference-drawer-primary:disabled {
   cursor: not-allowed;
-  opacity: 0.46;
+  opacity: 0.42;
 }
 
 .reference-drawer-secondary {
-  border: 1px solid var(--border);
-  background: var(--surface);
+  background: transparent;
   color: var(--text-secondary);
 }
 
 .reference-drawer-secondary:hover {
-  background: var(--surface-hover);
+  background: rgba(0, 0, 0, 0.04);
   color: var(--text);
 }
 
 .reference-empty {
-  margin: 14px 16px 16px;
-  padding: 22px 18px;
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  background: linear-gradient(180deg, var(--surface), rgba(250, 250, 249, 0.86));
-  box-shadow: var(--shadow-sm);
+  margin: 18px;
+  padding: 28px 20px;
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  background: transparent;
   text-align: center;
   color: var(--text-secondary);
 }
 
 .reference-empty-icon {
-  width: 42px;
-  height: 42px;
+  width: 36px;
+  height: 36px;
   margin: 0 auto 14px;
-  border-radius: 14px;
+  border-radius: 8px;
   display: grid;
   place-items: center;
-  background: var(--accent-light);
-  color: var(--accent);
-  font-size: 20px;
+  background: rgba(0, 0, 0, 0.035);
+  color: var(--text-muted);
+  font-size: 18px;
 }
 
 .reference-empty h3 {
   color: var(--text);
-  font-size: 15px;
-  margin-bottom: 8px;
+  font-size: 14px;
+  font-weight: 650;
+  margin-bottom: 7px;
 }
 
 .reference-empty p {
   font-size: 12px;
   line-height: 1.6;
+  margin: 0;
 }
 
 .reference-selected-hint {
   margin-top: 16px;
-  padding: 10px;
+  padding: 9px 10px;
   border: 1px solid var(--border-light);
-  border-radius: 10px;
-  background: rgba(255, 255, 255, 0.72);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.48);
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 3px;
   text-align: left;
 }
 
 .reference-selected-hint span {
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  font-weight: 600;
+  text-transform: none;
+  letter-spacing: 0;
 }
 
 .reference-selected-hint strong {
   color: var(--text);
   font-size: 12px;
+  font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -210,21 +236,27 @@
 
 .reference-native-card {
   min-height: 0;
-  height: calc(100% - 116px);
-  margin: 14px 16px 16px;
+  height: calc(100% - 108px);
+  margin: 14px 18px 18px;
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  background: var(--surface);
 }
 
 .reference-native-card > .canvas-node {
   flex: 1;
   min-height: 0;
+  border: 0;
+  border-radius: 10px 10px 0 0;
+  background: var(--surface);
 }
 
 .reference-card-footer {
   margin-top: auto;
-  padding: 12px;
+  padding: 8px;
   border-top: 1px solid var(--border-light);
-  background: rgba(248, 248, 247, 0.72);
+  background: #fbfbfa;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.tsx
@@ -100,24 +100,12 @@ export const ReferenceDrawer = ({
           </button>
         </header>
 
-        <div className="reference-drawer-actions">
-          <button
-            className="reference-drawer-primary"
-            type="button"
-            onClick={onPinSelected}
-            disabled={!canPinSelected || selectedIsReference}
-          >
-            {referenceNode ? 'Replace with selected' : 'Pin selected node'}
-          </button>
-          {referenceNode && (
-            <button className="reference-drawer-secondary" type="button" onClick={onClear}>
-              Clear
-            </button>
-          )}
-        </div>
-
         {!referenceNode ? (
-          <ReferenceEmptyState selectedNode={selectedNode} />
+          <ReferenceEmptyState
+            selectedNode={selectedNode}
+            canReferenceSelected={canPinSelected && !selectedIsReference}
+            onReferenceSelected={onPinSelected}
+          />
         ) : (
           <div className="reference-native-card">
             <CanvasNodeView
@@ -145,11 +133,22 @@ export const ReferenceDrawer = ({
             />
             <div className="reference-card-footer">
               <button
+                className="reference-drawer-primary"
+                type="button"
+                onClick={onPinSelected}
+                disabled={!canPinSelected || selectedIsReference}
+              >
+                Reference
+              </button>
+              <button
                 className="reference-drawer-secondary"
                 type="button"
                 onClick={() => onFocusNode(referenceNode.id)}
               >
                 Focus on canvas
+              </button>
+              <button className="reference-drawer-secondary" type="button" onClick={onClear}>
+                Clear
               </button>
             </div>
           </div>
@@ -158,19 +157,35 @@ export const ReferenceDrawer = ({
   );
 };
 
-const ReferenceEmptyState = ({ selectedNode }: { selectedNode?: CanvasNode }) => (
+const ReferenceEmptyState = ({
+  selectedNode,
+  canReferenceSelected,
+  onReferenceSelected,
+}: {
+  selectedNode?: CanvasNode;
+  canReferenceSelected: boolean;
+  onReferenceSelected: () => void;
+}) => (
   <div className="reference-empty">
     <div className="reference-empty-icon">⌑</div>
     <h3>No reference pinned</h3>
-    <p>Select one node on the canvas, then pin it here as stable context while you work elsewhere.</p>
+    <p>Select a node, then reference it here while you work elsewhere.</p>
     {selectedNode ? (
       <div className="reference-selected-hint">
         <span>Selected</span>
         <strong>{getNodeDisplayLabel(selectedNode)}</strong>
+        <button
+          className="reference-drawer-primary reference-selected-action"
+          type="button"
+          onClick={onReferenceSelected}
+          disabled={!canReferenceSelected}
+        >
+          Reference
+        </button>
       </div>
     ) : (
       <div className="reference-selected-hint reference-selected-hint--muted">
-        Select a single node to enable pinning.
+        Select a single node to enable reference.
       </div>
     )}
   </div>

--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.tsx
@@ -13,7 +13,6 @@ interface ReferenceDrawerProps {
   referenceNode?: CanvasNode;
   selectedNode?: CanvasNode;
   onOpenChange: (open: boolean) => void;
-  onPinSelected: () => void;
   onClear: () => void;
   onFocusNode: (nodeId: string) => void;
 }
@@ -23,16 +22,11 @@ export const ReferenceDrawer = ({
   referenceNode,
   selectedNode,
   onOpenChange,
-  onPinSelected,
   onClear,
   onFocusNode,
 }: ReferenceDrawerProps) => {
   const [drawerWidth, setDrawerWidth] = useState(DEFAULT_REFERENCE_DRAWER_WIDTH);
   const [isResizing, setIsResizing] = useState(false);
-  const canPinSelected = Boolean(selectedNode);
-  const selectedIsReference = Boolean(
-    selectedNode && referenceNode && selectedNode.id === referenceNode.id,
-  );
 
   const drawerStyle = useMemo(
     () => ({
@@ -101,11 +95,7 @@ export const ReferenceDrawer = ({
         </header>
 
         {!referenceNode ? (
-          <ReferenceEmptyState
-            selectedNode={selectedNode}
-            canReferenceSelected={canPinSelected && !selectedIsReference}
-            onReferenceSelected={onPinSelected}
-          />
+          <ReferenceEmptyState selectedNode={selectedNode} />
         ) : (
           <div className="reference-native-card">
             <CanvasNodeView
@@ -133,19 +123,12 @@ export const ReferenceDrawer = ({
             />
             <div className="reference-card-footer">
               <button
-                className="reference-drawer-primary"
-                type="button"
-                onClick={onPinSelected}
-                disabled={!canPinSelected || selectedIsReference}
-              >
-                Reference
-              </button>
-              <button
                 className="reference-drawer-secondary"
                 type="button"
                 onClick={() => onFocusNode(referenceNode.id)}
+                title="Focus on canvas"
               >
-                Focus on canvas
+                Focus
               </button>
               <button className="reference-drawer-secondary" type="button" onClick={onClear}>
                 Clear
@@ -157,31 +140,15 @@ export const ReferenceDrawer = ({
   );
 };
 
-const ReferenceEmptyState = ({
-  selectedNode,
-  canReferenceSelected,
-  onReferenceSelected,
-}: {
-  selectedNode?: CanvasNode;
-  canReferenceSelected: boolean;
-  onReferenceSelected: () => void;
-}) => (
+const ReferenceEmptyState = ({ selectedNode }: { selectedNode?: CanvasNode }) => (
   <div className="reference-empty">
     <div className="reference-empty-icon">⌑</div>
     <h3>No reference pinned</h3>
-    <p>Select a node, then reference it here while you work elsewhere.</p>
+    <p>Select a node, then use its Reference action to pin it here.</p>
     {selectedNode ? (
       <div className="reference-selected-hint">
         <span>Selected</span>
         <strong>{getNodeDisplayLabel(selectedNode)}</strong>
-        <button
-          className="reference-drawer-primary reference-selected-action"
-          type="button"
-          onClick={onReferenceSelected}
-          disabled={!canReferenceSelected}
-        >
-          Reference
-        </button>
       </div>
     ) : (
       <div className="reference-selected-hint reference-selected-hint--muted">

--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.tsx
@@ -1,7 +1,12 @@
+import { useCallback, useMemo, useState } from 'react';
 import './index.css';
 import type { CanvasNode } from '../../types';
 import { CanvasNodeView } from '../CanvasNodeView';
 import { getNodeDisplayLabel } from '../../utils/nodeLabel';
+
+const DEFAULT_REFERENCE_DRAWER_WIDTH = 420;
+const MIN_REFERENCE_DRAWER_WIDTH = 320;
+const MAX_REFERENCE_DRAWER_WIDTH = 720;
 
 interface ReferenceDrawerProps {
   open: boolean;
@@ -22,15 +27,63 @@ export const ReferenceDrawer = ({
   onClear,
   onFocusNode,
 }: ReferenceDrawerProps) => {
+  const [drawerWidth, setDrawerWidth] = useState(DEFAULT_REFERENCE_DRAWER_WIDTH);
+  const [isResizing, setIsResizing] = useState(false);
   const canPinSelected = Boolean(selectedNode);
   const selectedIsReference = Boolean(
     selectedNode && referenceNode && selectedNode.id === referenceNode.id,
   );
 
+  const drawerStyle = useMemo(
+    () => ({
+      width: drawerWidth,
+      flexBasis: drawerWidth,
+    }),
+    [drawerWidth],
+  );
+
+  const handleResizeStart = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const startX = e.clientX;
+    const startWidth = drawerWidth;
+    setIsResizing(true);
+
+    const handleMouseMove = (event: MouseEvent) => {
+      const nextWidth = startWidth + event.clientX - startX;
+      setDrawerWidth(Math.min(MAX_REFERENCE_DRAWER_WIDTH, Math.max(MIN_REFERENCE_DRAWER_WIDTH, nextWidth)));
+    };
+
+    const handleMouseUp = () => {
+      setIsResizing(false);
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+  }, [drawerWidth]);
+
   if (!open) return null;
 
   return (
-    <aside className="reference-drawer reference-drawer--open">
+    <aside
+      className={`reference-drawer reference-drawer--open${isResizing ? ' reference-drawer--resizing' : ''}`}
+      style={drawerStyle}
+    >
+      <div
+        className="reference-drawer-resize-handle"
+        onMouseDown={handleResizeStart}
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize reference drawer"
+        title="Drag to resize"
+      />
         <header className="reference-drawer-header">
           <div>
             <div className="reference-drawer-kicker">Pinned context</div>
@@ -68,7 +121,13 @@ export const ReferenceDrawer = ({
         ) : (
           <div className="reference-native-card">
             <CanvasNodeView
-              node={{ ...referenceNode, x: 0, y: 0, width: 300, height: 520 }}
+              node={{
+                ...referenceNode,
+                x: 0,
+                y: 0,
+                width: Math.max(MIN_REFERENCE_DRAWER_WIDTH - 32, drawerWidth - 32),
+                height: 520,
+              }}
               allNodes={[referenceNode]}
               isDragging={false}
               isResizing={false}


### PR DESCRIPTION
## Summary\n- Add a resizable reference drawer for pinned canvas context\n- Increase the default drawer width while clamping resize bounds\n- Simplify the drawer into a Notion/Linear-style minimal sidebar with low-contrast controls and preview framing\n\n## Validation\n- `pnpm --filter canvas-workspace typecheck:renderer` ✅\n\n## Risk\n- Low; scoped to reference drawer UI and resizing behavior.