### PR TITLE
feat(canvas): polish reference drawer interactions

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -227,10 +227,8 @@
 }
 
 .node-reference {
-  width: auto;
-  padding: 0 6px;
-  font-size: 11px;
-  font-weight: 600;
+  width: 20px;
+  padding: 0;
 }
 
 .node-focus,

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -477,8 +477,22 @@ export const CanvasNodeView = ({
           <TextColorPicker node={node} onUpdate={onUpdate} />
         )}
         {!readOnly && onReference ? (
-          <button className="node-reference" onClick={handleReference} title="Reference">
-            Reference
+          <button
+            className="node-reference"
+            type="button"
+            onClick={handleReference}
+            title="Reference"
+            aria-label={`Pin ${node.title} as reference`}
+          >
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+              <path
+                d="M3.2 2.2c0-.55.45-1 1-1h3.6c.55 0 1 .45 1 1v8.1L6 8.65 3.2 10.3V2.2z"
+                stroke="currentColor"
+                strokeWidth="1.25"
+                strokeLinejoin="round"
+              />
+              <path d="M4.8 3.6h2.4" stroke="currentColor" strokeWidth="1.15" strokeLinecap="round" />
+            </svg>
           </button>
         ) : null}
         <button className="node-focus" onClick={handleFocus} title="Focus">

--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.css
@@ -1,6 +1,6 @@
 .reference-drawer {
-  width: 420px;
-  flex: 0 0 420px;
+  width: var(--reference-drawer-width, 420px);
+  flex: 0 0 var(--reference-drawer-width, 420px);
   min-width: 320px;
   max-width: 720px;
   height: 100%;
@@ -11,10 +11,26 @@
   z-index: 10;
   flex-shrink: 0;
   isolation: isolate;
+  opacity: 0;
+  transform: translateX(-18px) scaleX(0.985);
+  transform-origin: left center;
+  filter: saturate(0.96);
+  margin-left: calc(var(--reference-drawer-width, 420px) * -1);
+  transition:
+    margin-left 0.24s cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 0.2s ease,
+    transform 0.24s cubic-bezier(0.22, 1, 0.36, 1),
+    filter 0.2s ease;
+  will-change: margin-left, opacity, transform;
+  pointer-events: none;
 }
 
 .reference-drawer--open {
-  animation: reference-drawer-enter 0.14s ease-out;
+  margin-left: 0;
+  opacity: 1;
+  transform: translateX(0) scaleX(1);
+  filter: saturate(1);
+  pointer-events: auto;
 }
 
 .reference-drawer--resizing {
@@ -66,14 +82,11 @@
   opacity: 0.34;
 }
 
-@keyframes reference-drawer-enter {
-  from {
-    opacity: 0;
-    transform: translateX(-6px);
-  }
-  to {
-    opacity: 1;
-    transform: translateX(0);
+@media (prefers-reduced-motion: reduce) {
+  .reference-drawer {
+    transition: none;
+    transform: none;
+    filter: none;
   }
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import './index.css';
 import type { CanvasNode } from '../../types';
 import { CanvasNodeView } from '../CanvasNodeView';
@@ -27,12 +27,25 @@ export const ReferenceDrawer = ({
 }: ReferenceDrawerProps) => {
   const [drawerWidth, setDrawerWidth] = useState(DEFAULT_REFERENCE_DRAWER_WIDTH);
   const [isResizing, setIsResizing] = useState(false);
+  const [shouldRender, setShouldRender] = useState(open);
+  const [isActive, setIsActive] = useState(open);
+
+  useEffect(() => {
+    if (open) {
+      setShouldRender(true);
+      const frame = window.requestAnimationFrame(() => setIsActive(true));
+      return () => window.cancelAnimationFrame(frame);
+    }
+
+    setIsActive(false);
+    const timer = window.setTimeout(() => setShouldRender(false), 240);
+    return () => window.clearTimeout(timer);
+  }, [open]);
 
   const drawerStyle = useMemo(
     () => ({
-      width: drawerWidth,
-      flexBasis: drawerWidth,
-    }),
+      '--reference-drawer-width': `${drawerWidth}px`,
+    }) as React.CSSProperties,
     [drawerWidth],
   );
 
@@ -63,12 +76,13 @@ export const ReferenceDrawer = ({
     document.addEventListener('mouseup', handleMouseUp);
   }, [drawerWidth]);
 
-  if (!open) return null;
+  if (!shouldRender) return null;
 
   return (
     <aside
-      className={`reference-drawer reference-drawer--open${isResizing ? ' reference-drawer--resizing' : ''}`}
+      className={`reference-drawer${isActive ? ' reference-drawer--open' : ''}${isResizing ? ' reference-drawer--resizing' : ''}`}
       style={drawerStyle}
+      aria-hidden={!isActive}
     >
       <div
         className="reference-drawer-resize-handle"


### PR DESCRIPTION
## Summary\n- replace the node Reference text action with an accessible icon-only button\n- add smooth open/close motion for the Reference drawer, including delayed unmount for exit animation\n- preserve resized drawer width via a CSS variable and respect reduced-motion preferences\n\n## Validation\n- pnpm --filter canvas-workspace typecheck:renderer