### PR TITLE
fix: avoid duplicate restored agent sessions

### DIFF
--- a/apps/canvas-workspace/src/main/canvas-agent/session-store.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/session-store.ts
@@ -16,6 +16,20 @@ import type { CanvasAgentMessage, CanvasAgentSession } from './types';
 
 const STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
 
+function archiveFileTimestamp(file: string): number {
+  const match = file.match(/-(\d+)\.json$/);
+  return match ? Number(match[1]) : 0;
+}
+
+async function archiveSortKey(filePath: string, fileName: string): Promise<number> {
+  try {
+    const stat = await fs.stat(filePath);
+    return stat.mtimeMs;
+  } catch {
+    return archiveFileTimestamp(fileName);
+  }
+}
+
 export class SessionStore {
   private workspaceId: string;
   private sessionsDir: string;
@@ -83,26 +97,42 @@ export class SessionStore {
   async listArchivedSessions(): Promise<Array<{ sessionId: string; date: string; messageCount: number; preview: string }>> {
     try {
       const files = await fs.readdir(this.archiveDir);
-      const sessions: Array<{ sessionId: string; date: string; messageCount: number; preview: string }> = [];
+      const currentSessionId = this.session?.sessionId;
+      const sessionsById = new Map<string, { sessionId: string; date: string; messageCount: number; preview: string; sortKey: number }>();
 
       for (const file of files) {
         if (!file.endsWith('.json')) continue;
         try {
-          const raw = await fs.readFile(join(this.archiveDir, file), 'utf-8');
+          const archivePath = join(this.archiveDir, file);
+          const raw = await fs.readFile(archivePath, 'utf-8');
           const data = JSON.parse(raw) as CanvasAgentSession;
+
+          // A session restored from archive becomes current. Hide any stale
+          // archived copy so the session list does not show the same thread
+          // twice while the user continues chatting in it.
+          if (currentSessionId && data.sessionId === currentSessionId) continue;
+
           const firstUserMsg = data.messages.find(m => m.role === 'user');
-          sessions.push({
+          const sortKey = await archiveSortKey(archivePath, file);
+          const session = {
             sessionId: data.sessionId,
             date: data.startedAt?.slice(0, 10) || file.replace('.json', '').slice(0, 10),
             messageCount: data.messages.length,
             preview: firstUserMsg ? firstUserMsg.content.slice(0, 50) : '',
-          });
+            sortKey,
+          };
+          const existing = sessionsById.get(data.sessionId);
+          if (!existing || sortKey > existing.sortKey) {
+            sessionsById.set(data.sessionId, session);
+          }
         } catch {
           // skip corrupted files
         }
       }
 
-      return sessions.sort((a, b) => b.date.localeCompare(a.date));
+      return Array.from(sessionsById.values())
+        .sort((a, b) => b.sortKey - a.sortKey || b.date.localeCompare(a.date))
+        .map(({ sortKey: _sortKey, ...session }) => session);
     } catch {
       return [];
     }
@@ -132,26 +162,59 @@ export class SessionStore {
    * Archives the current session first if it has messages.
    */
   async loadSession(sessionId: string): Promise<CanvasAgentSession | null> {
-    // Find the archived session by sessionId
+    // If the requested session is already current, do not create another copy.
+    if (this.session?.sessionId === sessionId) {
+      await this.removeArchivedSessionsById(sessionId);
+      return this.session;
+    }
+
+    try {
+      const raw = await fs.readFile(this.currentPath, 'utf-8');
+      const current = JSON.parse(raw) as CanvasAgentSession;
+      if (current.sessionId === sessionId) {
+        this.session = current;
+        await this.removeArchivedSessionsById(sessionId);
+        return current;
+      }
+    } catch {
+      // No current session on disk or it is unreadable.
+    }
+
+    let matched: CanvasAgentSession | null = null;
+    let matchedSortKey = -1;
+
+    // Find the newest archived copy by sessionId. Older versions may exist
+    // from the previous restore behavior, so choose the latest and clean up
+    // all archived copies after it is promoted to current.
     try {
       const files = await fs.readdir(this.archiveDir);
       for (const file of files) {
         if (!file.endsWith('.json')) continue;
-        const raw = await fs.readFile(join(this.archiveDir, file), 'utf-8');
+        const archivePath = join(this.archiveDir, file);
+        const raw = await fs.readFile(archivePath, 'utf-8');
         const data = JSON.parse(raw) as CanvasAgentSession;
-        if (data.sessionId === sessionId) {
-          // Archive current session first
-          await this.archiveCurrentIfExists();
-          // Set as current
-          this.session = data;
-          await this.persist();
-          return data;
+        if (data.sessionId !== sessionId) continue;
+
+        const sortKey = await archiveSortKey(archivePath, file);
+        if (!matched || sortKey > matchedSortKey) {
+          matched = data;
+          matchedSortKey = sortKey;
         }
       }
     } catch {
       // ignore
     }
-    return null;
+
+    if (!matched) return null;
+
+    // Archive current session first, then promote the archived session to
+    // current and remove archived copies of the same sessionId. Without this
+    // cleanup, continuing an old conversation appears as a duplicate/new row.
+    await this.archiveCurrentIfExists();
+    this.session = matched;
+    await this.persist();
+    await this.removeArchivedSessionsById(sessionId);
+    return matched;
   }
 
   // ─── Cross-workspace scanning ────────────────────────────────
@@ -209,23 +272,40 @@ export class SessionStore {
       // Read archived sessions
       try {
         const files = await fs.readdir(archiveDir);
+        const currentSessionIds = new Set(sessions.filter(s => s.isCurrent).map(s => s.sessionId));
+        const archivedById = new Map<string, { sessionId: string; date: string; messageCount: number; preview: string; isCurrent: boolean; sortKey: number }>();
+
         for (const file of files) {
           if (!file.endsWith('.json')) continue;
           try {
-            const raw = await fs.readFile(join(archiveDir, file), 'utf-8');
+            const archivePath = join(archiveDir, file);
+            const raw = await fs.readFile(archivePath, 'utf-8');
             const data = JSON.parse(raw) as CanvasAgentSession;
+
+            // Avoid showing the same session twice when a restored archived
+            // session is also present as current.json.
+            if (currentSessionIds.has(data.sessionId)) continue;
+
             const firstUserMsg = data.messages.find(m => m.role === 'user');
-            sessions.push({
+            const sortKey = await archiveSortKey(archivePath, file);
+            const session = {
               sessionId: data.sessionId,
               date: data.startedAt?.slice(0, 10) || file.replace('.json', '').slice(0, 10),
               messageCount: data.messages.length,
               preview: firstUserMsg ? firstUserMsg.content.slice(0, 50) : '',
               isCurrent: false,
-            });
+              sortKey,
+            };
+            const existing = archivedById.get(data.sessionId);
+            if (!existing || sortKey > existing.sortKey) {
+              archivedById.set(data.sessionId, session);
+            }
           } catch {
             // skip corrupted files
           }
         }
+
+        sessions.push(...Array.from(archivedById.values()).map(({ sortKey: _sortKey, ...session }) => session));
       } catch {
         // No archive dir
       }
@@ -263,23 +343,53 @@ export class SessionStore {
       // ignore
     }
 
-    // Check archive
+    // Check archive. If duplicate archived copies exist, return the newest one.
+    let matched: CanvasAgentSession | null = null;
+    let matchedSortKey = -1;
     try {
       const files = await fs.readdir(archiveDir);
       for (const file of files) {
         if (!file.endsWith('.json')) continue;
-        const raw = await fs.readFile(join(archiveDir, file), 'utf-8');
+        const archivePath = join(archiveDir, file);
+        const raw = await fs.readFile(archivePath, 'utf-8');
         const data = JSON.parse(raw) as CanvasAgentSession;
-        if (data.sessionId === sessionId) return data;
+        if (data.sessionId !== sessionId) continue;
+
+        const sortKey = await archiveSortKey(archivePath, file);
+        if (!matched || sortKey > matchedSortKey) {
+          matched = data;
+          matchedSortKey = sortKey;
+        }
       }
     } catch {
       // ignore
     }
 
-    return null;
+    return matched;
   }
 
   // ─── Internal ────────────────────────────────────────────────
+
+  private async removeArchivedSessionsById(sessionId: string): Promise<void> {
+    try {
+      const files = await fs.readdir(this.archiveDir);
+      await Promise.all(files.map(async (file) => {
+        if (!file.endsWith('.json')) return;
+        const archivePath = join(this.archiveDir, file);
+        try {
+          const raw = await fs.readFile(archivePath, 'utf-8');
+          const data = JSON.parse(raw) as CanvasAgentSession;
+          if (data.sessionId === sessionId) {
+            await fs.unlink(archivePath).catch(() => undefined);
+          }
+        } catch {
+          // skip corrupted files
+        }
+      }));
+    } catch {
+      // No archive dir
+    }
+  }
 
   private async persist(): Promise<void> {
     if (!this.session) return;

--- a/packages/cli/src/ink-app.tsx
+++ b/packages/cli/src/ink-app.tsx
@@ -42,9 +42,14 @@ interface InkCliAppProps {
   onExit?: () => void;
 }
 
-interface ComposerState {
+export interface ComposerState {
   input: string;
   cursor: number;
+}
+
+export interface SlashCommandSuggestion {
+  command: string;
+  description: string;
 }
 
 const DEFAULT_SNAPSHOT: InkCliSnapshot = {
@@ -75,6 +80,31 @@ const KIND_COLOR: Record<InkEventKind, string> = {
   system: 'blue',
   error: 'red',
 };
+
+const SLASH_COMMANDS: SlashCommandSuggestion[] = [
+  { command: '/help', description: 'Show commands and shortcuts' },
+  { command: '/new', description: 'Create a new session' },
+  { command: '/resume', description: 'Resume a saved session' },
+  { command: '/sessions', description: 'List saved sessions' },
+  { command: '/search', description: 'Search saved sessions' },
+  { command: '/rename', description: 'Rename a session' },
+  { command: '/delete', description: 'Delete a session' },
+  { command: '/clear', description: 'Clear conversation context' },
+  { command: '/compact', description: 'Compact current context' },
+  { command: '/skills', description: 'Run a message with a selected skill' },
+  { command: '/acp', description: 'Manage ACP mode' },
+  { command: '/wt', description: 'Use worktree skill' },
+  { command: '/status', description: 'Show session status' },
+  { command: '/mode', description: 'Show plan mode' },
+  { command: '/plan', description: 'Switch to planning mode' },
+  { command: '/execute', description: 'Switch to executing mode' },
+  { command: '/team', description: 'Run a multi-agent team' },
+  { command: '/teams', description: 'Enter teams mode' },
+  { command: '/solo', description: 'Exit teams mode' },
+  { command: '/save', description: 'Save current session' },
+  { command: '/tui', description: 'Show TUI status' },
+  { command: '/exit', description: 'Save and exit' },
+];
 
 const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 const MAX_HISTORY = 100;
@@ -128,13 +158,54 @@ export function removeWordBeforeCursor(state: ComposerState): ComposerState {
 }
 
 export function renderPrompt(input: string, cursor: number, cursorVisible: boolean): string {
+  return renderPromptLines(input, cursor, cursorVisible).join('\n');
+}
+
+export function renderPromptLines(input: string, cursor: number, cursorVisible: boolean): string[] {
   const normalizedCursor = clampCursor(input, cursor);
   const cursorGlyph = cursorVisible ? '█' : ' ';
-  return `${input.slice(0, normalizedCursor)}${cursorGlyph}${input.slice(normalizedCursor)}`;
+  return `${input.slice(0, normalizedCursor)}${cursorGlyph}${input.slice(normalizedCursor)}`.split('\n');
+}
+
+export function getSlashCommandSuggestions(input: string, cursor: number, limit = 6): SlashCommandSuggestion[] {
+  const normalizedCursor = clampCursor(input, cursor);
+  const beforeCursor = input.slice(0, normalizedCursor);
+  if (!beforeCursor.startsWith('/') || beforeCursor.startsWith('//') || beforeCursor.includes('\n')) {
+    return [];
+  }
+
+  const match = beforeCursor.match(/^\/([^\s/]*)$/);
+  if (!match) {
+    return [];
+  }
+
+  const query = match[1].toLowerCase();
+  return SLASH_COMMANDS
+    .filter(item => item.command.slice(1).startsWith(query))
+    .slice(0, limit);
+}
+
+export function applySlashCommandCompletion(input: string, cursor: number, command: string): ComposerState {
+  const normalizedCursor = clampCursor(input, cursor);
+  const beforeCursor = input.slice(0, normalizedCursor);
+  if (!beforeCursor.match(/^\/([^\s/]*)$/)) {
+    return { input, cursor: normalizedCursor };
+  }
+
+  const suffix = input.slice(normalizedCursor);
+  const completed = `${command} `;
+  return {
+    input: `${completed}${suffix}`,
+    cursor: completed.length,
+  };
 }
 
 function clampCursor(input: string, cursor: number): number {
   return Math.max(0, Math.min(input.length, cursor));
+}
+
+function normalizeInputValue(value: string): string {
+  return value.replace(/\r\n?/g, '\n');
 }
 
 function recordHistory(history: string[], submitted: string): string[] {
@@ -275,6 +346,19 @@ export function InkCliApp({ controller, runtime, onExit }: InkCliAppProps) {
       return;
     }
 
+    if (key.tab || value === '\t') {
+      const [suggestion] = getSlashCommandSuggestions(input, cursor, 1);
+      if (suggestion) {
+        updateComposer(applySlashCommandCompletion(input, cursor, suggestion.command));
+      }
+      return;
+    }
+
+    if (key.ctrl && (value === 'j' || value === '\n')) {
+      updateComposer(insertAtCursor({ input, cursor }, '\n'));
+      return;
+    }
+
     if (key.return) {
       submitCurrentInput();
       return;
@@ -340,22 +424,28 @@ export function InkCliApp({ controller, runtime, onExit }: InkCliAppProps) {
     }
 
     if (value && !key.ctrl && !key.meta) {
-      updateComposer(insertAtCursor({ input, cursor }, value));
+      updateComposer(insertAtCursor({ input, cursor }, normalizeInputValue(value)));
     }
   });
 
   const terminalRows = stdout.rows ?? 30;
-  const visibleEventCount = Math.max(4, Math.min(12, terminalRows - 9));
+  const visibleEventCount = Math.max(4, Math.min(12, terminalRows - 12));
   const eventsAfterClear = snapshot.events.slice(Math.min(clearedEventCount, snapshot.events.length));
   const visibleEvents = eventsAfterClear.slice(-visibleEventCount);
   const hiddenEventCount = snapshot.events.length - visibleEvents.length;
   const spinner = snapshot.isProcessing ? SPINNER_FRAMES[spinnerIndex % SPINNER_FRAMES.length] : '●';
-  const prompt = useMemo(() => renderPrompt(input, cursor, cursorVisible), [cursor, cursorVisible, input]);
+  const promptLines = useMemo(() => renderPromptLines(input, cursor, cursorVisible), [cursor, cursorVisible, input]);
+  const slashSuggestions = useMemo(() => getSlashCommandSuggestions(input, cursor), [cursor, input]);
+  const maxPromptLines = Math.max(1, Math.min(6, terminalRows - 18));
+  const visiblePromptLines = promptLines.slice(-maxPromptLines);
+  const hiddenPromptLineCount = promptLines.length - visiblePromptLines.length;
   const keyHint = snapshot.isProcessing
-    ? 'Enter queue after Esc · Esc stop · Ctrl+C exit'
+    ? 'Running · Esc stop · after stopping, Enter queues next prompt'
     : input.length > 0
-      ? 'Enter send · Esc clear · ↑↓ history · Ctrl+A/E move · Ctrl+C exit'
-      : 'Enter send · Esc exit · ↑↓ history · Ctrl+L clear · Ctrl+C exit';
+      ? 'Editing · Enter send · Ctrl+J newline · Tab complete · Esc clear'
+      : 'Idle · type / for commands · ↑↓ history · Ctrl+L clear · Esc exit';
+  const lineCount = input.split('\n').length;
+  const composerHint = input.length > 0 ? `draft ${lineCount} line${lineCount === 1 ? '' : 's'} · ${input.length} chars` : 'ready for next prompt';
   const historyHint = history.length > 0 ? ` · history ${historyIndex === null ? history.length : `${historyIndex + 1}/${history.length}`}` : '';
   const hiddenHint = hiddenEventCount > 0 ? ` · ${hiddenEventCount} older` : '';
 
@@ -387,8 +477,25 @@ export function InkCliApp({ controller, runtime, onExit }: InkCliAppProps) {
         <Text color={snapshot.isProcessing ? 'yellow' : 'green'}>
           {spinner} {snapshot.status}{historyHint}{hiddenHint}
         </Text>
-        <Text color="gray">{keyHint}</Text>
-        <Text color="cyan">› <Text color="white">{prompt}</Text></Text>
+        <Text color="gray">{keyHint} · {composerHint}</Text>
+        {slashSuggestions.length > 0 ? (
+          <Box flexDirection="column">
+            <Text color="yellow">Commands · Tab completes first match</Text>
+            {slashSuggestions.map((suggestion, index) => (
+              <Text key={suggestion.command} color={index === 0 ? 'yellow' : 'gray'}>
+                {index === 0 ? '→ ' : '  '}{suggestion.command} <Text color="gray">{suggestion.description}</Text>
+              </Text>
+            ))}
+          </Box>
+        ) : null}
+        <Box flexDirection="column">
+          {hiddenPromptLineCount > 0 ? <Text color="gray">… {hiddenPromptLineCount} earlier draft line{hiddenPromptLineCount === 1 ? '' : 's'}</Text> : null}
+          {visiblePromptLines.map((line, index) => (
+            <Text key={`${index}-${line}`} color="cyan">
+              {index === 0 ? '› ' : '  '}<Text color="white">{line || ' '}</Text>
+            </Text>
+          ))}
+        </Box>
       </Box>
     </Box>
   );

--- a/packages/cli/src/ink-app.tsx
+++ b/packages/cli/src/ink-app.tsx
@@ -23,6 +23,7 @@ export interface InkCliSnapshot {
   mode?: string | null;
   messages: number;
   estimatedTokens: number;
+  queuedInputs: number;
   isProcessing: boolean;
   status: string;
   events: InkCliEvent[];
@@ -58,6 +59,7 @@ const DEFAULT_SNAPSHOT: InkCliSnapshot = {
   mode: null,
   messages: 0,
   estimatedTokens: 0,
+  queuedInputs: 0,
   isProcessing: false,
   status: 'Ready',
   events: [],
@@ -440,13 +442,13 @@ export function InkCliApp({ controller, runtime, onExit }: InkCliAppProps) {
   const visiblePromptLines = promptLines.slice(-maxPromptLines);
   const hiddenPromptLineCount = promptLines.length - visiblePromptLines.length;
   const keyHint = snapshot.isProcessing
-    ? 'Running · Esc stop · after stopping, Enter queues next prompt'
+    ? 'Running · Enter queues draft · Esc stop · Ctrl+C exit'
     : input.length > 0
       ? 'Editing · Enter send · Ctrl+J newline · Tab complete · Esc clear'
       : 'Idle · type / for commands · ↑↓ history · Ctrl+L clear · Esc exit';
   const lineCount = input.split('\n').length;
   const composerHint = input.length > 0 ? `draft ${lineCount} line${lineCount === 1 ? '' : 's'} · ${input.length} chars` : 'ready for next prompt';
-  const historyHint = history.length > 0 ? ` · history ${historyIndex === null ? history.length : `${historyIndex + 1}/${history.length}`}` : '';
+  const queuedHint = snapshot.queuedInputs > 0 ? ` · queued ${snapshot.queuedInputs}` : '';
   const hiddenHint = hiddenEventCount > 0 ? ` · ${hiddenEventCount} older` : '';
 
   return (
@@ -475,7 +477,7 @@ export function InkCliApp({ controller, runtime, onExit }: InkCliAppProps) {
 
       <Box borderStyle="single" borderColor={snapshot.isProcessing ? 'yellow' : 'green'} paddingX={1} flexDirection="column">
         <Text color={snapshot.isProcessing ? 'yellow' : 'green'}>
-          {spinner} {snapshot.status}{historyHint}{hiddenHint}
+          {spinner} {snapshot.status}{queuedHint}{hiddenHint}
         </Text>
         <Text color="gray">{keyHint} · {composerHint}</Text>
         {slashSuggestions.length > 0 ? (

--- a/packages/cli/src/ink-app.tsx
+++ b/packages/cli/src/ink-app.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 
 export type InkEventKind = 'user' | 'assistant' | 'tool' | 'result' | 'system' | 'error';
+export type InkEventStatus = 'running' | 'success' | 'error' | 'info';
 
 interface InkRuntime {
   Box: React.ComponentType<any>;
@@ -15,6 +16,8 @@ export interface InkCliEvent {
   kind: InkEventKind;
   title?: string;
   text: string;
+  status?: InkEventStatus;
+  summary?: string;
 }
 
 export interface InkCliSnapshot {
@@ -26,6 +29,11 @@ export interface InkCliSnapshot {
   queuedInputs: number;
   isProcessing: boolean;
   status: string;
+  phase?: string | null;
+  activeTool?: string | null;
+  toolCalls: number;
+  completedTools: number;
+  lastStep?: string | null;
   events: InkCliEvent[];
 }
 
@@ -51,6 +59,8 @@ export interface ComposerState {
 export interface SlashCommandSuggestion {
   command: string;
   description: string;
+  usage?: string;
+  group: string;
 }
 
 const DEFAULT_SNAPSHOT: InkCliSnapshot = {
@@ -62,6 +72,11 @@ const DEFAULT_SNAPSHOT: InkCliSnapshot = {
   queuedInputs: 0,
   isProcessing: false,
   status: 'Ready',
+  phase: 'Idle',
+  activeTool: null,
+  toolCalls: 0,
+  completedTools: 0,
+  lastStep: null,
   events: [],
 };
 
@@ -83,29 +98,43 @@ const KIND_COLOR: Record<InkEventKind, string> = {
   error: 'red',
 };
 
+const EVENT_STATUS_ICON: Record<InkEventStatus, string> = {
+  running: '⏳',
+  success: '✓',
+  error: '✕',
+  info: '•',
+};
+
+const EVENT_STATUS_COLOR: Record<InkEventStatus, string> = {
+  running: 'yellow',
+  success: 'green',
+  error: 'red',
+  info: 'blue',
+};
+
 const SLASH_COMMANDS: SlashCommandSuggestion[] = [
-  { command: '/help', description: 'Show commands and shortcuts' },
-  { command: '/new', description: 'Create a new session' },
-  { command: '/resume', description: 'Resume a saved session' },
-  { command: '/sessions', description: 'List saved sessions' },
-  { command: '/search', description: 'Search saved sessions' },
-  { command: '/rename', description: 'Rename a session' },
-  { command: '/delete', description: 'Delete a session' },
-  { command: '/clear', description: 'Clear conversation context' },
-  { command: '/compact', description: 'Compact current context' },
-  { command: '/skills', description: 'Run a message with a selected skill' },
-  { command: '/acp', description: 'Manage ACP mode' },
-  { command: '/wt', description: 'Use worktree skill' },
-  { command: '/status', description: 'Show session status' },
-  { command: '/mode', description: 'Show plan mode' },
-  { command: '/plan', description: 'Switch to planning mode' },
-  { command: '/execute', description: 'Switch to executing mode' },
-  { command: '/team', description: 'Run a multi-agent team' },
-  { command: '/teams', description: 'Enter teams mode' },
-  { command: '/solo', description: 'Exit teams mode' },
-  { command: '/save', description: 'Save current session' },
-  { command: '/tui', description: 'Show TUI status' },
-  { command: '/exit', description: 'Save and exit' },
+  { command: '/help', description: 'Show commands and shortcuts', usage: '/help', group: 'Core' },
+  { command: '/new', description: 'Create a new session', usage: '/new <title?>', group: 'Session' },
+  { command: '/resume', description: 'Resume a saved session', usage: '/resume <session-id>', group: 'Session' },
+  { command: '/sessions', description: 'List saved sessions', usage: '/sessions', group: 'Session' },
+  { command: '/search', description: 'Search saved sessions', usage: '/search <query>', group: 'Session' },
+  { command: '/rename', description: 'Rename a session', usage: '/rename <id> <title>', group: 'Session' },
+  { command: '/delete', description: 'Delete a session', usage: '/delete <id>', group: 'Session' },
+  { command: '/clear', description: 'Clear conversation context', usage: '/clear', group: 'Context' },
+  { command: '/compact', description: 'Compact current context', usage: '/compact', group: 'Context' },
+  { command: '/skills', description: 'Run a message with a selected skill', usage: '/skills <name|index> <message>', group: 'Agent' },
+  { command: '/acp', description: 'Manage ACP mode', usage: '/acp status|on|off|cd', group: 'Agent' },
+  { command: '/wt', description: 'Use worktree skill', usage: '/wt use <work-name>', group: 'Agent' },
+  { command: '/status', description: 'Show session status', usage: '/status', group: 'Core' },
+  { command: '/mode', description: 'Show plan mode', usage: '/mode', group: 'Mode' },
+  { command: '/plan', description: 'Switch to planning mode', usage: '/plan', group: 'Mode' },
+  { command: '/execute', description: 'Switch to executing mode', usage: '/execute', group: 'Mode' },
+  { command: '/team', description: 'Run a multi-agent team', usage: '/team <task>', group: 'Teams' },
+  { command: '/teams', description: 'Enter teams mode', usage: '/teams <task>', group: 'Teams' },
+  { command: '/solo', description: 'Exit teams mode', usage: '/solo', group: 'Teams' },
+  { command: '/save', description: 'Save current session', usage: '/save', group: 'Session' },
+  { command: '/tui', description: 'Show TUI status', usage: '/tui status', group: 'Core' },
+  { command: '/exit', description: 'Save and exit', usage: '/exit', group: 'Core' },
 ];
 
 const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
@@ -183,8 +212,56 @@ export function getSlashCommandSuggestions(input: string, cursor: number, limit 
 
   const query = match[1].toLowerCase();
   return SLASH_COMMANDS
-    .filter(item => item.command.slice(1).startsWith(query))
+    .map((item, index) => ({ item, index, score: scoreSlashCommand(item.command.slice(1), query) }))
+    .filter(match => match.score >= 0)
+    .sort((a, b) => a.score - b.score || a.index - b.index)
+    .map(match => match.item)
     .slice(0, limit);
+}
+
+export function shouldAcceptSlashSuggestion(input: string, cursor: number, suggestion?: SlashCommandSuggestion): boolean {
+  if (!suggestion) {
+    return false;
+  }
+
+  const normalizedCursor = clampCursor(input, cursor);
+  const beforeCursor = input.slice(0, normalizedCursor);
+  const match = beforeCursor.match(/^\/([^\s/]*)$/);
+  if (!match) {
+    return false;
+  }
+
+  return beforeCursor !== suggestion.command;
+}
+
+function scoreSlashCommand(commandName: string, query: string): number {
+  if (query.length === 0) {
+    return 0;
+  }
+  if (commandName.startsWith(query)) {
+    return 0;
+  }
+  const containsIndex = commandName.indexOf(query);
+  if (containsIndex >= 0) {
+    return 100 + containsIndex;
+  }
+  if (isSubsequence(query, commandName)) {
+    return 200 + commandName.length;
+  }
+  return -1;
+}
+
+function isSubsequence(query: string, value: string): boolean {
+  let queryIndex = 0;
+  for (const char of value) {
+    if (char === query[queryIndex]) {
+      queryIndex += 1;
+      if (queryIndex === query.length) {
+        return true;
+      }
+    }
+  }
+  return query.length === 0;
 }
 
 export function applySlashCommandCompletion(input: string, cursor: number, command: string): ComposerState {
@@ -233,6 +310,7 @@ export function InkCliApp({ controller, runtime, onExit }: InkCliAppProps) {
   const [clearedEventCount, setClearedEventCount] = useState(0);
   const [cursorVisible, setCursorVisible] = useState(true);
   const [spinnerIndex, setSpinnerIndex] = useState(0);
+  const [selectedSuggestionIndex, setSelectedSuggestionIndex] = useState(0);
   const app = useApp();
   const { stdout } = useStdout();
 
@@ -349,9 +427,8 @@ export function InkCliApp({ controller, runtime, onExit }: InkCliAppProps) {
     }
 
     if (key.tab || value === '\t') {
-      const [suggestion] = getSlashCommandSuggestions(input, cursor, 1);
-      if (suggestion) {
-        updateComposer(applySlashCommandCompletion(input, cursor, suggestion.command));
+      if (selectedSuggestion) {
+        updateComposer(applySlashCommandCompletion(input, cursor, selectedSuggestion.command));
       }
       return;
     }
@@ -362,16 +439,28 @@ export function InkCliApp({ controller, runtime, onExit }: InkCliAppProps) {
     }
 
     if (key.return) {
+      if (shouldAcceptSlashSuggestion(input, cursor, selectedSuggestion)) {
+        updateComposer(applySlashCommandCompletion(input, cursor, selectedSuggestion.command));
+        return;
+      }
       submitCurrentInput();
       return;
     }
 
     if (key.upArrow) {
+      if (slashSuggestions.length > 0) {
+        setSelectedSuggestionIndex(current => Math.max(0, current - 1));
+        return;
+      }
       showPreviousHistory();
       return;
     }
 
     if (key.downArrow) {
+      if (slashSuggestions.length > 0) {
+        setSelectedSuggestionIndex(current => Math.min(slashSuggestions.length - 1, current + 1));
+        return;
+      }
       showNextHistory();
       return;
     }
@@ -438,18 +527,28 @@ export function InkCliApp({ controller, runtime, onExit }: InkCliAppProps) {
   const spinner = snapshot.isProcessing ? SPINNER_FRAMES[spinnerIndex % SPINNER_FRAMES.length] : '●';
   const promptLines = useMemo(() => renderPromptLines(input, cursor, cursorVisible), [cursor, cursorVisible, input]);
   const slashSuggestions = useMemo(() => getSlashCommandSuggestions(input, cursor), [cursor, input]);
+  const normalizedSuggestionIndex = Math.min(selectedSuggestionIndex, Math.max(0, slashSuggestions.length - 1));
+  const selectedSuggestion = slashSuggestions[normalizedSuggestionIndex];
+  useEffect(() => {
+    setSelectedSuggestionIndex(current => Math.min(current, Math.max(0, slashSuggestions.length - 1)));
+  }, [slashSuggestions.length]);
+
   const maxPromptLines = Math.max(1, Math.min(6, terminalRows - 18));
   const visiblePromptLines = promptLines.slice(-maxPromptLines);
   const hiddenPromptLineCount = promptLines.length - visiblePromptLines.length;
   const keyHint = snapshot.isProcessing
     ? 'Running · Enter queues draft · Esc stop · Ctrl+C exit'
-    : input.length > 0
-      ? 'Editing · Enter send · Ctrl+J newline · Tab complete · Esc clear'
+    : slashSuggestions.length > 0
+      ? 'Palette · ↑↓ select · Tab/Enter complete · Esc clear'
+      : input.length > 0
+        ? 'Editing · Enter send · Ctrl+J newline · Tab complete · Esc clear'
       : 'Idle · type / for commands · ↑↓ history · Ctrl+L clear · Esc exit';
   const lineCount = input.split('\n').length;
   const composerHint = input.length > 0 ? `draft ${lineCount} line${lineCount === 1 ? '' : 's'} · ${input.length} chars` : 'ready for next prompt';
   const queuedHint = snapshot.queuedInputs > 0 ? ` · queued ${snapshot.queuedInputs}` : '';
   const hiddenHint = hiddenEventCount > 0 ? ` · ${hiddenEventCount} older` : '';
+  const progressColor = snapshot.isProcessing ? 'yellow' : snapshot.status === 'Cancelled' ? 'red' : 'green';
+  const toolProgress = snapshot.toolCalls > 0 ? `${snapshot.completedTools}/${snapshot.toolCalls} tools` : 'no tools yet';
 
   return (
     <Box flexDirection="column" paddingX={1}>
@@ -462,15 +561,20 @@ export function InkCliApp({ controller, runtime, onExit }: InkCliAppProps) {
         </Text>
       </Box>
 
+      <Box marginTop={1} borderStyle="single" borderColor={progressColor} paddingX={1} flexDirection="column">
+        <Text bold color={progressColor}>Progress · {snapshot.phase ?? (snapshot.isProcessing ? 'Running' : 'Idle')}</Text>
+        <Text color="gray">{toolProgress}{snapshot.activeTool ? ` · active ${snapshot.activeTool}` : ''}{snapshot.lastStep ? ` · last ${snapshot.lastStep}` : ''}{snapshot.queuedInputs > 0 ? ` · queued ${snapshot.queuedInputs}` : ''}</Text>
+      </Box>
+
       <Box marginTop={1} flexDirection="column">
         {visibleEvents.length === 0 ? (
           <Text color="gray">Type a message below. Use /help for commands.{clearedEventCount > 0 ? ' Ctrl+L cleared visible history.' : ''}</Text>
         ) : visibleEvents.map(event => (
           <Box key={event.id} flexDirection="column" marginBottom={1}>
-            <Text bold color={KIND_COLOR[event.kind]}>
-              {KIND_LABEL[event.kind]}{event.title ? ` · ${event.title}` : ''}
+            <Text bold color={event.status ? EVENT_STATUS_COLOR[event.status] : KIND_COLOR[event.kind]}>
+              {event.status ? `${EVENT_STATUS_ICON[event.status]} ` : ''}{KIND_LABEL[event.kind]}{event.title ? ` · ${event.title}` : ''}{event.summary ? ` · ${event.summary}` : ''}
             </Text>
-            <Text>{event.text}</Text>
+            <Text color={event.kind === 'tool' ? 'gray' : undefined}>{event.text}</Text>
           </Box>
         ))}
       </Box>
@@ -482,12 +586,13 @@ export function InkCliApp({ controller, runtime, onExit }: InkCliAppProps) {
         <Text color="gray">{keyHint} · {composerHint}</Text>
         {slashSuggestions.length > 0 ? (
           <Box flexDirection="column">
-            <Text color="yellow">Commands · Tab completes first match</Text>
+            <Text color="yellow">Commands · ↑↓ select · Tab/Enter completes</Text>
             {slashSuggestions.map((suggestion, index) => (
-              <Text key={suggestion.command} color={index === 0 ? 'yellow' : 'gray'}>
-                {index === 0 ? '→ ' : '  '}{suggestion.command} <Text color="gray">{suggestion.description}</Text>
+              <Text key={suggestion.command} color={index === normalizedSuggestionIndex ? 'yellow' : 'gray'}>
+                {index === normalizedSuggestionIndex ? '→ ' : '  '}{suggestion.command} <Text color="gray">[{suggestion.group}] {suggestion.description}</Text>
               </Text>
             ))}
+            {selectedSuggestion?.usage ? <Text color="gray">Hint: {selectedSuggestion.usage}</Text> : null}
           </Box>
         ) : null}
         <Box flexDirection="column">

--- a/packages/cli/src/ink-app.tsx
+++ b/packages/cli/src/ink-app.tsx
@@ -2,6 +2,9 @@ import React, { useEffect, useMemo, useState } from 'react';
 
 export type InkEventKind = 'user' | 'assistant' | 'tool' | 'result' | 'system' | 'error';
 export type InkEventStatus = 'running' | 'success' | 'error' | 'info';
+export type CliInteractionMode = 'chat' | 'plan' | 'edit' | 'auto';
+
+const CLI_INTERACTION_MODES: CliInteractionMode[] = ['chat', 'plan', 'edit', 'auto'];
 
 interface InkRuntime {
   Box: React.ComponentType<any>;
@@ -41,6 +44,7 @@ export interface InkCliController {
   getSnapshot: () => InkCliSnapshot;
   submitInput: (input: string) => void | Promise<void>;
   requestStop: () => void;
+  setInteractionMode?: (mode: CliInteractionMode, source?: string) => void | Promise<void>;
   shutdown: () => void | Promise<void>;
   subscribe: (listener: (snapshot: InkCliSnapshot) => void) => () => void;
 }
@@ -126,9 +130,12 @@ const SLASH_COMMANDS: SlashCommandSuggestion[] = [
   { command: '/acp', description: 'Manage ACP mode', usage: '/acp status|on|off|cd', group: 'Agent' },
   { command: '/wt', description: 'Use worktree skill', usage: '/wt use <work-name>', group: 'Agent' },
   { command: '/status', description: 'Show session status', usage: '/status', group: 'Core' },
-  { command: '/mode', description: 'Show plan mode', usage: '/mode', group: 'Mode' },
-  { command: '/plan', description: 'Switch to planning mode', usage: '/plan', group: 'Mode' },
-  { command: '/execute', description: 'Switch to executing mode', usage: '/execute', group: 'Mode' },
+  { command: '/mode', description: 'Show or set CLI interaction mode', usage: '/mode chat|plan|edit|auto', group: 'Mode' },
+  { command: '/chat', description: 'Switch to chat interaction mode', usage: '/chat', group: 'Mode' },
+  { command: '/plan', description: 'Switch to planning interaction mode', usage: '/plan', group: 'Mode' },
+  { command: '/edit', description: 'Switch to edit interaction mode', usage: '/edit', group: 'Mode' },
+  { command: '/auto', description: 'Switch to autonomous interaction mode', usage: '/auto', group: 'Mode' },
+  { command: '/execute', description: 'Alias for /edit', usage: '/execute', group: 'Mode' },
   { command: '/team', description: 'Run a multi-agent team', usage: '/team <task>', group: 'Teams' },
   { command: '/teams', description: 'Enter teams mode', usage: '/teams <task>', group: 'Teams' },
   { command: '/solo', description: 'Exit teams mode', usage: '/solo', group: 'Teams' },
@@ -279,6 +286,47 @@ export function applySlashCommandCompletion(input: string, cursor: number, comma
   };
 }
 
+export function nextInteractionMode(mode: string | null | undefined): CliInteractionMode {
+  const currentIndex = CLI_INTERACTION_MODES.indexOf(normalizeInteractionMode(mode));
+  return CLI_INTERACTION_MODES[(currentIndex + 1) % CLI_INTERACTION_MODES.length];
+}
+
+export function normalizeInteractionMode(mode: string | null | undefined): CliInteractionMode {
+  if (mode === 'chat' || mode === 'plan' || mode === 'edit' || mode === 'auto') {
+    return mode;
+  }
+  if (mode === 'planning') {
+    return 'plan';
+  }
+  if (mode === 'executing') {
+    return 'edit';
+  }
+  return 'chat';
+}
+
+export function formatStatusline(snapshot: InkCliSnapshot): string {
+  const mode = normalizeInteractionMode(snapshot.mode);
+  const phase = snapshot.phase ?? (snapshot.isProcessing ? 'Running' : 'Idle');
+  const active = snapshot.activeTool ? ` · active ${snapshot.activeTool}` : '';
+  const tools = `${snapshot.completedTools}/${snapshot.toolCalls}`;
+  const queue = snapshot.queuedInputs > 0 ? ` · queue ${snapshot.queuedInputs}` : '';
+  const session = snapshot.sessionId ?? 'new';
+  return `Pulse Coder · mode ${mode} · phase ${phase}${active} · tools ${tools}${queue} · session ${session}`;
+}
+
+export function describeInteractionMode(mode: CliInteractionMode): string {
+  switch (mode) {
+    case 'chat':
+      return 'free-form conversation; no extra CLI-side constraints';
+    case 'plan':
+      return 'ask for inspection and a plan before changes';
+    case 'edit':
+      return 'optimize for implementation and validation';
+    case 'auto':
+      return 'optimize for low-interaction autonomous execution';
+  }
+}
+
 function clampCursor(input: string, cursor: number): number {
   return Math.max(0, Math.min(input.length, cursor));
 }
@@ -313,6 +361,8 @@ export function InkCliApp({ controller, runtime, onExit }: InkCliAppProps) {
   const [selectedSuggestionIndex, setSelectedSuggestionIndex] = useState(0);
   const app = useApp();
   const { stdout } = useStdout();
+  const currentInteractionMode = normalizeInteractionMode(snapshot.mode);
+  const statusline = formatStatusline(snapshot);
 
   useEffect(() => controller.subscribe(setSnapshot), [controller]);
 
@@ -393,6 +443,11 @@ export function InkCliApp({ controller, runtime, onExit }: InkCliAppProps) {
     replaceComposer(history[nextIndex]);
   };
 
+  const cycleInteractionMode = () => {
+    const nextMode = nextInteractionMode(currentInteractionMode);
+    void controller.setInteractionMode?.(nextMode, 'shortcut:shift-tab');
+  };
+
   useInput((value, key) => {
     if (key.ctrl && value === 'c') {
       void controller.shutdown();
@@ -423,6 +478,11 @@ export function InkCliApp({ controller, runtime, onExit }: InkCliAppProps) {
       void controller.shutdown();
       onExit?.();
       app.exit();
+      return;
+    }
+
+    if (key.shift && (key.tab || value === '\t')) {
+      cycleInteractionMode();
       return;
     }
 
@@ -537,14 +597,15 @@ export function InkCliApp({ controller, runtime, onExit }: InkCliAppProps) {
   const visiblePromptLines = promptLines.slice(-maxPromptLines);
   const hiddenPromptLineCount = promptLines.length - visiblePromptLines.length;
   const keyHint = snapshot.isProcessing
-    ? 'Running · Enter queues draft · Esc stop · Ctrl+C exit'
+    ? 'Running · Enter queues draft · Esc stop · Shift+Tab mode · Ctrl+C exit'
     : slashSuggestions.length > 0
-      ? 'Palette · ↑↓ select · Tab/Enter complete · Esc clear'
+      ? 'Palette · ↑↓ select · Tab/Enter complete · Shift+Tab mode · Esc clear'
       : input.length > 0
-        ? 'Editing · Enter send · Ctrl+J newline · Tab complete · Esc clear'
-      : 'Idle · type / for commands · ↑↓ history · Ctrl+L clear · Esc exit';
+        ? 'Editing · Enter send · Ctrl+J newline · Shift+Tab mode · Esc clear'
+      : 'Idle · type / for commands · Shift+Tab mode · ↑↓ history · Ctrl+L clear · Esc exit';
   const lineCount = input.split('\n').length;
   const composerHint = input.length > 0 ? `draft ${lineCount} line${lineCount === 1 ? '' : 's'} · ${input.length} chars` : 'ready for next prompt';
+  const modeHint = `${currentInteractionMode}: ${describeInteractionMode(currentInteractionMode)}`;
   const queuedHint = snapshot.queuedInputs > 0 ? ` · queued ${snapshot.queuedInputs}` : '';
   const hiddenHint = hiddenEventCount > 0 ? ` · ${hiddenEventCount} older` : '';
   const progressColor = snapshot.isProcessing ? 'yellow' : snapshot.status === 'Cancelled' ? 'red' : 'green';
@@ -553,11 +614,10 @@ export function InkCliApp({ controller, runtime, onExit }: InkCliAppProps) {
   return (
     <Box flexDirection="column" paddingX={1}>
       <Box borderStyle="round" borderColor="cyan" paddingX={1} flexDirection="column">
-        <Text bold color="cyan">Pulse Coder Ink</Text>
+        <Text bold color="cyan">{statusline}</Text>
         <Text color="gray">
-          session {snapshot.sessionId ?? 'new'} · {snapshot.messages} msgs · ~{snapshot.estimatedTokens} tokens
+          {snapshot.messages} msgs · ~{snapshot.estimatedTokens} tokens
           {snapshot.taskListId ? ` · tasks ${snapshot.taskListId}` : ''}
-          {snapshot.mode ? ` · mode ${snapshot.mode}` : ''}
         </Text>
       </Box>
 
@@ -584,6 +644,7 @@ export function InkCliApp({ controller, runtime, onExit }: InkCliAppProps) {
           {spinner} {snapshot.status}{queuedHint}{hiddenHint}
         </Text>
         <Text color="gray">{keyHint} · {composerHint}</Text>
+        <Text color="gray">Mode · {modeHint}</Text>
         {slashSuggestions.length > 0 ? (
           <Box flexDirection="column">
             <Text color="yellow">Commands · ↑↓ select · Tab/Enter completes</Text>

--- a/packages/cli/src/ink-app.tsx
+++ b/packages/cli/src/ink-app.tsx
@@ -42,6 +42,11 @@ interface InkCliAppProps {
   onExit?: () => void;
 }
 
+interface ComposerState {
+  input: string;
+  cursor: number;
+}
+
 const DEFAULT_SNAPSHOT: InkCliSnapshot = {
   sessionId: null,
   taskListId: null,
@@ -72,6 +77,74 @@ const KIND_COLOR: Record<InkEventKind, string> = {
 };
 
 const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+const MAX_HISTORY = 100;
+
+export function insertAtCursor(state: ComposerState, value: string): ComposerState {
+  const cursor = clampCursor(state.input, state.cursor);
+  return {
+    input: `${state.input.slice(0, cursor)}${value}${state.input.slice(cursor)}`,
+    cursor: cursor + value.length,
+  };
+}
+
+export function removeBeforeCursor(state: ComposerState): ComposerState {
+  const cursor = clampCursor(state.input, state.cursor);
+  if (cursor === 0) {
+    return { input: state.input, cursor };
+  }
+
+  return {
+    input: `${state.input.slice(0, cursor - 1)}${state.input.slice(cursor)}`,
+    cursor: cursor - 1,
+  };
+}
+
+export function removeAtCursor(state: ComposerState): ComposerState {
+  const cursor = clampCursor(state.input, state.cursor);
+  if (cursor >= state.input.length) {
+    return { input: state.input, cursor };
+  }
+
+  return {
+    input: `${state.input.slice(0, cursor)}${state.input.slice(cursor + 1)}`,
+    cursor,
+  };
+}
+
+export function removeWordBeforeCursor(state: ComposerState): ComposerState {
+  const cursor = clampCursor(state.input, state.cursor);
+  if (cursor === 0) {
+    return { input: state.input, cursor };
+  }
+
+  const beforeCursor = state.input.slice(0, cursor);
+  const afterCursor = state.input.slice(cursor);
+  const wordStart = beforeCursor.replace(/\s+$/, '').search(/\S+$/);
+  const deleteFrom = wordStart === -1 ? 0 : wordStart;
+  return {
+    input: `${beforeCursor.slice(0, deleteFrom)}${afterCursor}`,
+    cursor: deleteFrom,
+  };
+}
+
+export function renderPrompt(input: string, cursor: number, cursorVisible: boolean): string {
+  const normalizedCursor = clampCursor(input, cursor);
+  const cursorGlyph = cursorVisible ? '█' : ' ';
+  return `${input.slice(0, normalizedCursor)}${cursorGlyph}${input.slice(normalizedCursor)}`;
+}
+
+function clampCursor(input: string, cursor: number): number {
+  return Math.max(0, Math.min(input.length, cursor));
+}
+
+function recordHistory(history: string[], submitted: string): string[] {
+  const trimmed = submitted.trim();
+  if (!trimmed || history[history.length - 1] === trimmed) {
+    return history;
+  }
+
+  return [...history, trimmed].slice(-MAX_HISTORY);
+}
 
 export function InkCliApp({ controller, runtime, onExit }: InkCliAppProps) {
   const { Box, Text, useApp, useInput, useStdout } = runtime;
@@ -80,6 +153,11 @@ export function InkCliApp({ controller, runtime, onExit }: InkCliAppProps) {
     ...controller.getSnapshot(),
   }));
   const [input, setInput] = useState('');
+  const [cursor, setCursor] = useState(0);
+  const [history, setHistory] = useState<string[]>([]);
+  const [historyIndex, setHistoryIndex] = useState<number | null>(null);
+  const [historyDraft, setHistoryDraft] = useState('');
+  const [clearedEventCount, setClearedEventCount] = useState(0);
   const [cursorVisible, setCursorVisible] = useState(true);
   const [spinnerIndex, setSpinnerIndex] = useState(0);
   const app = useApp();
@@ -101,6 +179,69 @@ export function InkCliApp({ controller, runtime, onExit }: InkCliAppProps) {
     return () => clearInterval(timer);
   }, [snapshot.isProcessing]);
 
+  const updateComposer = (next: ComposerState) => {
+    setInput(next.input);
+    setCursor(clampCursor(next.input, next.cursor));
+    setHistoryIndex(null);
+  };
+
+  const replaceComposer = (nextInput: string) => {
+    setInput(nextInput);
+    setCursor(nextInput.length);
+  };
+
+  const submitCurrentInput = () => {
+    const submitted = input;
+    setInput('');
+    setCursor(0);
+    setHistory(current => recordHistory(current, submitted));
+    setHistoryIndex(null);
+    setHistoryDraft('');
+
+    void (async () => {
+      await controller.submitInput(submitted);
+      const normalized = submitted.trim().toLowerCase();
+      if (normalized === 'exit' || normalized === '/exit') {
+        onExit?.();
+        app.exit();
+      }
+    })();
+  };
+
+  const showPreviousHistory = () => {
+    if (history.length === 0) {
+      return;
+    }
+
+    if (historyIndex === null) {
+      setHistoryDraft(input);
+      setHistoryIndex(history.length - 1);
+      replaceComposer(history[history.length - 1]);
+      return;
+    }
+
+    const nextIndex = Math.max(0, historyIndex - 1);
+    setHistoryIndex(nextIndex);
+    replaceComposer(history[nextIndex]);
+  };
+
+  const showNextHistory = () => {
+    if (historyIndex === null) {
+      return;
+    }
+
+    const nextIndex = historyIndex + 1;
+    if (nextIndex >= history.length) {
+      setHistoryIndex(null);
+      replaceComposer(historyDraft);
+      setHistoryDraft('');
+      return;
+    }
+
+    setHistoryIndex(nextIndex);
+    replaceComposer(history[nextIndex]);
+  };
+
   useInput((value, key) => {
     if (key.ctrl && value === 'c') {
       void controller.shutdown();
@@ -109,9 +250,22 @@ export function InkCliApp({ controller, runtime, onExit }: InkCliAppProps) {
       return;
     }
 
+    if (key.ctrl && value === 'l') {
+      setClearedEventCount(snapshot.events.length);
+      return;
+    }
+
     if (key.escape) {
       if (snapshot.isProcessing) {
         controller.requestStop();
+        return;
+      }
+
+      if (input.length > 0) {
+        setInput('');
+        setCursor(0);
+        setHistoryIndex(null);
+        setHistoryDraft('');
         return;
       }
 
@@ -122,42 +276,88 @@ export function InkCliApp({ controller, runtime, onExit }: InkCliAppProps) {
     }
 
     if (key.return) {
-      const submitted = input;
-      setInput('');
-      void (async () => {
-        await controller.submitInput(submitted);
-        const normalized = submitted.trim().toLowerCase();
-        if (normalized === 'exit' || normalized === '/exit') {
-          onExit?.();
-          app.exit();
-        }
-      })();
+      submitCurrentInput();
       return;
     }
 
-    if (key.backspace || key.delete) {
-      setInput(current => current.slice(0, -1));
+    if (key.upArrow) {
+      showPreviousHistory();
+      return;
+    }
+
+    if (key.downArrow) {
+      showNextHistory();
+      return;
+    }
+
+    if (key.leftArrow) {
+      setCursor(current => Math.max(0, current - 1));
+      setHistoryIndex(null);
+      return;
+    }
+
+    if (key.rightArrow) {
+      setCursor(current => Math.min(input.length, current + 1));
+      setHistoryIndex(null);
+      return;
+    }
+
+    if (key.ctrl && value === 'a') {
+      setCursor(0);
+      setHistoryIndex(null);
+      return;
+    }
+
+    if (key.ctrl && value === 'e') {
+      setCursor(input.length);
+      setHistoryIndex(null);
       return;
     }
 
     if (key.ctrl && value === 'u') {
-      setInput('');
+      updateComposer({ input: input.slice(cursor), cursor: 0 });
+      return;
+    }
+
+    if (key.ctrl && value === 'k') {
+      updateComposer({ input: input.slice(0, cursor), cursor });
+      return;
+    }
+
+    if (key.ctrl && value === 'w') {
+      updateComposer(removeWordBeforeCursor({ input, cursor }));
+      return;
+    }
+
+    if (key.backspace) {
+      updateComposer(removeBeforeCursor({ input, cursor }));
+      return;
+    }
+
+    if (key.delete) {
+      updateComposer(removeAtCursor({ input, cursor }));
       return;
     }
 
     if (value && !key.ctrl && !key.meta) {
-      setInput(current => `${current}${value}`);
+      updateComposer(insertAtCursor({ input, cursor }, value));
     }
   });
 
   const terminalRows = stdout.rows ?? 30;
-  const visibleEventCount = Math.max(4, Math.min(12, terminalRows - 8));
-  const visibleEvents = snapshot.events.slice(-visibleEventCount);
+  const visibleEventCount = Math.max(4, Math.min(12, terminalRows - 9));
+  const eventsAfterClear = snapshot.events.slice(Math.min(clearedEventCount, snapshot.events.length));
+  const visibleEvents = eventsAfterClear.slice(-visibleEventCount);
+  const hiddenEventCount = snapshot.events.length - visibleEvents.length;
   const spinner = snapshot.isProcessing ? SPINNER_FRAMES[spinnerIndex % SPINNER_FRAMES.length] : '●';
-  const prompt = useMemo(() => {
-    const cursor = cursorVisible ? '█' : ' ';
-    return `${input}${cursor}`;
-  }, [cursorVisible, input]);
+  const prompt = useMemo(() => renderPrompt(input, cursor, cursorVisible), [cursor, cursorVisible, input]);
+  const keyHint = snapshot.isProcessing
+    ? 'Enter queue after Esc · Esc stop · Ctrl+C exit'
+    : input.length > 0
+      ? 'Enter send · Esc clear · ↑↓ history · Ctrl+A/E move · Ctrl+C exit'
+      : 'Enter send · Esc exit · ↑↓ history · Ctrl+L clear · Ctrl+C exit';
+  const historyHint = history.length > 0 ? ` · history ${historyIndex === null ? history.length : `${historyIndex + 1}/${history.length}`}` : '';
+  const hiddenHint = hiddenEventCount > 0 ? ` · ${hiddenEventCount} older` : '';
 
   return (
     <Box flexDirection="column" paddingX={1}>
@@ -172,7 +372,7 @@ export function InkCliApp({ controller, runtime, onExit }: InkCliAppProps) {
 
       <Box marginTop={1} flexDirection="column">
         {visibleEvents.length === 0 ? (
-          <Text color="gray">Type a message below. Use /help for commands.</Text>
+          <Text color="gray">Type a message below. Use /help for commands.{clearedEventCount > 0 ? ' Ctrl+L cleared visible history.' : ''}</Text>
         ) : visibleEvents.map(event => (
           <Box key={event.id} flexDirection="column" marginBottom={1}>
             <Text bold color={KIND_COLOR[event.kind]}>
@@ -185,8 +385,9 @@ export function InkCliApp({ controller, runtime, onExit }: InkCliAppProps) {
 
       <Box borderStyle="single" borderColor={snapshot.isProcessing ? 'yellow' : 'green'} paddingX={1} flexDirection="column">
         <Text color={snapshot.isProcessing ? 'yellow' : 'green'}>
-          {spinner} {snapshot.status} · Enter send · Esc {snapshot.isProcessing ? 'stop' : 'exit'} · Ctrl+C exit
+          {spinner} {snapshot.status}{historyHint}{hiddenHint}
         </Text>
+        <Text color="gray">{keyHint}</Text>
         <Text color="cyan">› <Text color="white">{prompt}</Text></Text>
       </Box>
     </Box>

--- a/packages/cli/src/ink-controller.ts
+++ b/packages/cli/src/ink-controller.ts
@@ -691,6 +691,7 @@ class InkCoderController implements InkCliController {
       queuedInputs: this.queuedInputs.length,
       isProcessing: this.isProcessing,
       status,
+      ...(status === 'Ready' && !this.isProcessing ? { phase: 'Idle', activeTool: null } : {}),
     });
   }
 

--- a/packages/cli/src/ink-controller.ts
+++ b/packages/cli/src/ink-controller.ts
@@ -64,6 +64,9 @@ const HELP_ITEMS: TuiHelpItem[] = [
 
 const HELP_FOOTER = [
   'Enter - Send current input',
+  'Ctrl+J - Insert a newline into the current draft',
+  'Tab - Complete the first visible slash-command suggestion',
+  'Type / - Show slash-command suggestions',
   '↑/↓ - Recall previous/next prompt',
   '←/→, Ctrl+A/E - Move cursor',
   'Ctrl+U/K/W - Delete before cursor / after cursor / previous word',

--- a/packages/cli/src/ink-controller.ts
+++ b/packages/cli/src/ink-controller.ts
@@ -173,15 +173,11 @@ class InkCoderController implements InkCliController {
     }
 
     if (this.isProcessing) {
-      if (this.currentAbortController?.signal.aborted) {
-        if (trimmedInput) {
-          this.queuedInputs.push(trimmedInput);
-          this.ui.queued('Input queued. It will run right after the current step finishes.');
-        }
-        return;
+      if (trimmedInput) {
+        this.queuedInputs.push(trimmedInput);
+        this.publishSession('Input queued');
+        this.ui.queued(`Queued input #${this.queuedInputs.length}. It will run after the current step finishes.`);
       }
-
-      this.ui.warn('Still processing. Press Esc to stop current request first.');
       return;
     }
 
@@ -692,6 +688,7 @@ class InkCoderController implements InkCliController {
       messages: this.context.messages.length,
       estimatedTokens: this.estimateTokens(this.context.messages),
       mode: this.agent.getMode(),
+      queuedInputs: this.queuedInputs.length,
       isProcessing: this.isProcessing,
       status,
     });

--- a/packages/cli/src/ink-controller.ts
+++ b/packages/cli/src/ink-controller.ts
@@ -63,7 +63,13 @@ const HELP_ITEMS: TuiHelpItem[] = [
 ];
 
 const HELP_FOOTER = [
+  'Enter - Send current input',
+  '↑/↓ - Recall previous/next prompt',
+  '←/→, Ctrl+A/E - Move cursor',
+  'Ctrl+U/K/W - Delete before cursor / after cursor / previous word',
+  'Ctrl+L - Clear visible transcript without clearing conversation',
   'Esc (while processing) - Stop current response and accept next input',
+  'Esc (idle) - Clear current input first; exit when input is empty',
   'Ctrl+C - Save and exit CLI immediately',
 ];
 

--- a/packages/cli/src/ink-controller.ts
+++ b/packages/cli/src/ink-controller.ts
@@ -10,7 +10,7 @@ import { SkillCommands } from './skill-commands.js';
 import { runTeam, TeamsSession } from './team-commands.js';
 import type { TuiHelpItem } from './tui-renderer.js';
 import { InkUiBridge } from './ink-ui-bridge.js';
-import type { InkCliController, InkCliSnapshot } from './ink-app.js';
+import type { InkCliController, InkCliSnapshot, CliInteractionMode } from './ink-app.js';
 
 const LOCAL_COMMANDS = new Set([
   'help',
@@ -27,7 +27,10 @@ const LOCAL_COMMANDS = new Set([
   'acp',
   'status',
   'mode',
+  'chat',
   'plan',
+  'edit',
+  'auto',
   'execute',
   'team',
   'teams',
@@ -50,10 +53,13 @@ const HELP_ITEMS: TuiHelpItem[] = [
   { command: '/skills [list|<name|index> <message>]', description: 'Run one message with a selected skill' },
   { command: '/acp [status|on|off|cd]', description: 'Manage ACP mode for this CLI' },
   { command: '/wt use <work-name>', description: 'Create a worktree + branch via worktree skill' },
-  { command: '/status', description: 'Show current session status' },
-  { command: '/mode', description: 'Show current plan mode' },
-  { command: '/plan', description: 'Switch to planning mode' },
-  { command: '/execute', description: 'Switch to executing mode' },
+  { command: '/status', description: 'Show current CLI/session status' },
+  { command: '/mode [chat|plan|edit|auto]', description: 'Show or set CLI interaction mode' },
+  { command: '/chat', description: 'Switch to chat interaction mode' },
+  { command: '/plan', description: 'Switch to planning interaction mode' },
+  { command: '/edit', description: 'Switch to edit interaction mode' },
+  { command: '/auto', description: 'Switch to autonomous interaction mode' },
+  { command: '/execute', description: 'Alias for /edit' },
   { command: '/team <task>', description: 'Run a multi-agent team (LLM plans DAG by default)' },
   { command: '/teams <task>', description: 'Run agent teams (enters teams mode for follow-ups)' },
   { command: '/solo', description: 'Exit teams mode, return to normal agent' },
@@ -65,6 +71,7 @@ const HELP_ITEMS: TuiHelpItem[] = [
 const HELP_FOOTER = [
   'Enter - Send current input',
   'Ctrl+J - Insert a newline into the current draft',
+  'Shift+Tab - Cycle CLI interaction mode (chat → plan → edit → auto)',
   'Tab - Complete the first visible slash-command suggestion',
   'Type / - Show slash-command suggestions',
   '↑/↓ - Recall previous/next prompt',
@@ -84,6 +91,7 @@ class InkCoderController implements InkCliController {
   private readonly skillCommands: SkillCommands;
   private readonly acpPlatformKey: string;
   private readonly ui: InkUiBridge;
+  private interactionMode: CliInteractionMode = 'chat';
   private readonly listeners = new Set<(snapshot: InkCliSnapshot) => void>();
   private currentAbortController: AbortController | null = null;
   private isProcessing = false;
@@ -144,6 +152,17 @@ class InkCoderController implements InkCliController {
     this.listeners.add(listener);
     listener(this.getSnapshot());
     return () => this.listeners.delete(listener);
+  }
+
+  private applyInteractionMode(mode: CliInteractionMode, source = 'cli'): void {
+    this.interactionMode = mode;
+    this.ui.updateSnapshot({ mode });
+    this.ui.info(`CLI mode: ${mode} (${source})`);
+    this.publishSession('Ready');
+  }
+
+  setInteractionMode(mode: CliInteractionMode, source = 'cli'): void {
+    this.applyInteractionMode(mode, source);
   }
 
   requestStop(): void {
@@ -397,36 +416,47 @@ class InkCoderController implements InkCliController {
           break;
         }
         case 'status':
-          this.ui.section('Session Status', [
-            `Current Session: ${this.sessionCommands.getCurrentSessionId() || 'None (new session)'}`,
+          this.ui.section('CLI Status', [
+            `Session: ${this.sessionCommands.getCurrentSessionId() || 'None (new session)'}`,
             `Task List: ${this.sessionCommands.getCurrentTaskListId() || 'None'}`,
             `Messages: ${this.context.messages.length}`,
+            `Estimated tokens: ~${this.estimateTokens(this.context.messages)}`,
+            `CLI mode: ${this.interactionMode}`,
+            `Engine plan mode: ${this.agent.getMode() || 'unavailable'}`,
+            `Phase: ${this.getSnapshot().phase ?? 'Idle'}`,
+            `Active tool: ${this.getSnapshot().activeTool ?? 'None'}`,
+            `Tools: ${this.getSnapshot().completedTools}/${this.getSnapshot().toolCalls}`,
+            `Queued inputs: ${this.queuedInputs.length}`,
+            `Processing: ${this.isProcessing ? 'yes' : 'no'}`,
           ]);
           break;
         case 'mode': {
-          const currentMode = this.agent.getMode();
-          if (!currentMode) {
-            this.ui.warn('plan mode plugin unavailable');
+          const requestedMode = args[0]?.toLowerCase();
+          const nextMode = this.parseInteractionMode(requestedMode);
+          if (nextMode) {
+            this.applyInteractionMode(nextMode, 'cli:/mode');
           } else {
-            this.ui.info(`Current mode: ${currentMode}`);
+            this.ui.section('CLI Mode', [
+              `Current: ${this.interactionMode}`,
+              'Available: chat, plan, edit, auto',
+              'Shortcut: Shift+Tab cycles modes',
+              'Note: this is CLI-local UX state; engine behavior is unchanged.',
+            ]);
           }
           break;
         }
-        case 'plan':
-          if (this.agent.setMode('planning', 'cli:/plan')) {
-            this.ui.success('Switched to planning mode');
-            this.publishSession('Ready');
-          } else {
-            this.ui.error('Failed to switch mode: plan mode plugin unavailable');
-          }
+        case 'chat':
+          this.applyInteractionMode('chat', 'cli:/chat');
           break;
+        case 'plan':
+          this.applyInteractionMode('plan', 'cli:/plan');
+          break;
+        case 'edit':
         case 'execute':
-          if (this.agent.setMode('executing', 'cli:/execute')) {
-            this.ui.success('Switched to executing mode');
-            this.publishSession('Ready');
-          } else {
-            this.ui.error('Failed to switch mode: plan mode plugin unavailable');
-          }
+          this.applyInteractionMode('edit', `cli:/${command.toLowerCase()}`);
+          break;
+        case 'auto':
+          this.applyInteractionMode('auto', 'cli:/auto');
           break;
         case 'tui':
           this.ui.showTuiStatus();
@@ -449,6 +479,19 @@ class InkCoderController implements InkCliController {
     } catch (error) {
       this.ui.error(`Error executing command: ${error instanceof Error ? error.message : String(error)}`);
     }
+  }
+
+  private parseInteractionMode(value: string | undefined): CliInteractionMode | null {
+    if (value === 'chat' || value === 'plan' || value === 'edit' || value === 'auto') {
+      return value;
+    }
+    if (value === 'planning') {
+      return 'plan';
+    }
+    if (value === 'execute' || value === 'executing') {
+      return 'edit';
+    }
+    return null;
   }
 
   private async compactContext(): Promise<void> {
@@ -506,7 +549,7 @@ class InkCoderController implements InkCliController {
       taskListId: this.sessionCommands.getCurrentTaskListId(),
       messages: this.context.messages.length,
       estimatedTokens: this.estimateTokens(this.context.messages),
-      mode: this.agent.getMode(),
+      mode: this.interactionMode,
     });
 
     this.context.messages.push({
@@ -607,7 +650,7 @@ class InkCoderController implements InkCliController {
         toolCalls,
         messages: this.context.messages.length,
         estimatedTokens: this.estimateTokens(this.context.messages),
-        mode: this.agent.getMode(),
+        mode: this.interactionMode,
       });
 
       if (result) {
@@ -687,7 +730,7 @@ class InkCoderController implements InkCliController {
       taskListId: this.sessionCommands.getCurrentTaskListId(),
       messages: this.context.messages.length,
       estimatedTokens: this.estimateTokens(this.context.messages),
-      mode: this.agent.getMode(),
+      mode: this.interactionMode,
       queuedInputs: this.queuedInputs.length,
       isProcessing: this.isProcessing,
       status,

--- a/packages/cli/src/ink-ui-bridge.test.ts
+++ b/packages/cli/src/ink-ui-bridge.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
 import { InkUiBridge } from './ink-ui-bridge.js';
-import type { InkCliSnapshot } from './ink-app.js';
+import {
+  insertAtCursor,
+  removeAtCursor,
+  removeBeforeCursor,
+  removeWordBeforeCursor,
+  renderPrompt,
+  type InkCliSnapshot,
+} from './ink-app.js';
 
 describe('InkUiBridge', () => {
   it('streams assistant deltas into one assistant event', () => {
@@ -60,5 +67,19 @@ describe('InkUiBridge', () => {
     expect(last.mode).toBe('planning');
     expect(last.isProcessing).toBe(false);
     expect(last.status).toContain('Done in 1.2s');
+  });
+});
+
+describe('Ink composer editing helpers', () => {
+  it('inserts and deletes at cursor position', () => {
+    expect(insertAtCursor({ input: 'helo', cursor: 2 }, 'l')).toEqual({ input: 'hello', cursor: 3 });
+    expect(removeBeforeCursor({ input: 'hello', cursor: 3 })).toEqual({ input: 'helo', cursor: 2 });
+    expect(removeAtCursor({ input: 'hello', cursor: 1 })).toEqual({ input: 'hllo', cursor: 1 });
+  });
+
+  it('deletes the previous word and clamps prompt cursor', () => {
+    expect(removeWordBeforeCursor({ input: 'run the agent', cursor: 13 })).toEqual({ input: 'run the ', cursor: 8 });
+    expect(removeWordBeforeCursor({ input: 'run   ', cursor: 6 })).toEqual({ input: '', cursor: 0 });
+    expect(renderPrompt('abc', 99, true)).toBe('abc█');
   });
 });

--- a/packages/cli/src/ink-ui-bridge.test.ts
+++ b/packages/cli/src/ink-ui-bridge.test.ts
@@ -43,7 +43,7 @@ describe('InkUiBridge', () => {
 
     const events = snapshots[snapshots.length - 1].events;
     expect(events.map(event => event.kind)).toEqual(['assistant', 'tool', 'assistant']);
-    expect(events[1].title).toBe('Tool activity');
+    expect(events[1].title).toBe('Tools');
     expect(events[2].text).toBe('after');
   });
 
@@ -62,9 +62,9 @@ describe('InkUiBridge', () => {
     expect(last.events).toHaveLength(1);
     expect(last.events[0]).toMatchObject({
       kind: 'tool',
-      title: 'Tool activity complete',
+      title: 'Tools',
       status: 'success',
-      summary: '1 completed',
+      summary: '1 call completed',
     });
   });
   it('groups multiple tool calls into one compact activity event', () => {
@@ -83,12 +83,36 @@ describe('InkUiBridge', () => {
     expect(last.events).toHaveLength(1);
     expect(last.events[0]).toMatchObject({
       kind: 'tool',
-      title: 'Tool activity complete',
+      title: 'Tools',
       status: 'success',
-      summary: '2 completed',
+      summary: '2 calls completed',
     });
     expect(last.events[0].text).toContain('read ×1');
     expect(last.events[0].text).toContain('grep ×1');
+    expect(last.events[0].text).toContain('✓ read  packages/cli/src/ink-app.tsx');
+    expect(last.events[0].text).toContain('✓ grep  "toolCall" in packages/cli/src');
+  });
+
+  it('shows running progress in the compact tools summary', () => {
+    const snapshots: InkCliSnapshot[] = [];
+    const bridge = new InkUiBridge({ onChange: snapshot => snapshots.push(snapshot) });
+
+    bridge.startProcessing('Running agent');
+    bridge.toolCall('read', { filePath: 'packages/cli/src/ink-app.tsx' });
+    bridge.toolResult('read');
+    bridge.toolCall('bash', { command: 'pnpm --filter pulse-coder-cli test -- --runInBand' });
+
+    const last = snapshots[snapshots.length - 1];
+    expect(last.events).toHaveLength(1);
+    expect(last.events[0]).toMatchObject({
+      kind: 'tool',
+      title: 'Tools',
+      status: 'running',
+      summary: '2 calls · 1 done · running bash',
+    });
+    expect(last.events[0].text).toContain('read ×1 · bash ×1');
+    expect(last.events[0].text).toContain('latest');
+    expect(last.events[0].text).toContain('… bash  pnpm --filter pulse-coder-cli test -- --runInBand');
   });
 
   it('updates session snapshot and run summary status', () => {

--- a/packages/cli/src/ink-ui-bridge.test.ts
+++ b/packages/cli/src/ink-ui-bridge.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it } from 'vitest';
 
 import { InkUiBridge } from './ink-ui-bridge.js';
 import {
+  applySlashCommandCompletion,
+  getSlashCommandSuggestions,
   insertAtCursor,
   removeAtCursor,
   removeBeforeCursor,
   removeWordBeforeCursor,
   renderPrompt,
+  renderPromptLines,
   type InkCliSnapshot,
 } from './ink-app.js';
 
@@ -81,5 +84,15 @@ describe('Ink composer editing helpers', () => {
     expect(removeWordBeforeCursor({ input: 'run the agent', cursor: 13 })).toEqual({ input: 'run the ', cursor: 8 });
     expect(removeWordBeforeCursor({ input: 'run   ', cursor: 6 })).toEqual({ input: '', cursor: 0 });
     expect(renderPrompt('abc', 99, true)).toBe('abc█');
+  });
+
+  it('renders multiline prompts with cursor placement', () => {
+    expect(renderPromptLines('one\ntwo', 4, true)).toEqual(['one', '█two']);
+  });
+
+  it('suggests and completes slash commands', () => {
+    expect(getSlashCommandSuggestions('/s', 2).map(item => item.command)).toEqual(['/sessions', '/search', '/skills', '/status', '/solo', '/save']);
+    expect(getSlashCommandSuggestions('//', 2)).toEqual([]);
+    expect(applySlashCommandCompletion('/sta', 4, '/status')).toEqual({ input: '/status ', cursor: 8 });
   });
 });

--- a/packages/cli/src/ink-ui-bridge.test.ts
+++ b/packages/cli/src/ink-ui-bridge.test.ts
@@ -43,7 +43,7 @@ describe('InkUiBridge', () => {
 
     const events = snapshots[snapshots.length - 1].events;
     expect(events.map(event => event.kind)).toEqual(['assistant', 'tool', 'assistant']);
-    expect(events[1].title).toBe('bash');
+    expect(events[1].title).toBe('Tool activity');
     expect(events[2].text).toBe('after');
   });
 
@@ -62,11 +62,35 @@ describe('InkUiBridge', () => {
     expect(last.events).toHaveLength(1);
     expect(last.events[0]).toMatchObject({
       kind: 'tool',
-      title: 'bash',
+      title: 'Tool activity complete',
       status: 'success',
-      summary: 'completed',
+      summary: '1 completed',
     });
   });
+  it('groups multiple tool calls into one compact activity event', () => {
+    const snapshots: InkCliSnapshot[] = [];
+    const bridge = new InkUiBridge({ onChange: snapshot => snapshots.push(snapshot) });
+
+    bridge.startProcessing('Running agent');
+    bridge.toolCall('read', { filePath: 'packages/cli/src/ink-app.tsx' });
+    bridge.toolResult('read');
+    bridge.toolCall('grep', { pattern: 'toolCall', path: 'packages/cli/src' });
+    bridge.toolResult('grep');
+
+    const last = snapshots[snapshots.length - 1];
+    expect(last.toolCalls).toBe(2);
+    expect(last.completedTools).toBe(2);
+    expect(last.events).toHaveLength(1);
+    expect(last.events[0]).toMatchObject({
+      kind: 'tool',
+      title: 'Tool activity complete',
+      status: 'success',
+      summary: '2 completed',
+    });
+    expect(last.events[0].text).toContain('read ×1');
+    expect(last.events[0].text).toContain('grep ×1');
+  });
+
   it('updates session snapshot and run summary status', () => {
     const snapshots: InkCliSnapshot[] = [];
     const bridge = new InkUiBridge({ onChange: snapshot => snapshots.push(snapshot) });

--- a/packages/cli/src/ink-ui-bridge.test.ts
+++ b/packages/cli/src/ink-ui-bridge.test.ts
@@ -64,7 +64,7 @@ describe('InkUiBridge', () => {
       kind: 'tool',
       title: 'Tools',
       status: 'success',
-      summary: '1 call completed',
+      summary: '1 call · 1 done',
     });
   });
   it('groups multiple tool calls into one compact activity event', () => {
@@ -85,12 +85,12 @@ describe('InkUiBridge', () => {
       kind: 'tool',
       title: 'Tools',
       status: 'success',
-      summary: '2 calls completed',
+      summary: '2 calls · 2 done',
     });
     expect(last.events[0].text).toContain('read ×1');
     expect(last.events[0].text).toContain('grep ×1');
-    expect(last.events[0].text).toContain('✓ read  packages/cli/src/ink-app.tsx');
-    expect(last.events[0].text).toContain('✓ grep  "toolCall" in packages/cli/src');
+    expect(last.events[0].text).toContain('  ✓ read  packages/cli/src/ink-app.tsx');
+    expect(last.events[0].text).toContain('  ✓ grep  "toolCall" in packages/cli/src');
   });
 
   it('shows running progress in the compact tools summary', () => {
@@ -110,9 +110,9 @@ describe('InkUiBridge', () => {
       status: 'running',
       summary: '2 calls · 1 done · running bash',
     });
-    expect(last.events[0].text).toContain('read ×1 · bash ×1');
-    expect(last.events[0].text).toContain('latest');
-    expect(last.events[0].text).toContain('… bash  pnpm --filter pulse-coder-cli test -- --runInBand');
+    expect(last.events[0].text).toContain('  read ×1 · bash ×1');
+    expect(last.events[0].text).toContain('  latest');
+    expect(last.events[0].text).toContain('  … bash  pnpm --filter pulse-coder-cli test -- --runInBand');
   });
 
   it('updates session snapshot and run summary status', () => {

--- a/packages/cli/src/ink-ui-bridge.test.ts
+++ b/packages/cli/src/ink-ui-bridge.test.ts
@@ -3,8 +3,11 @@ import { describe, expect, it } from 'vitest';
 import { InkUiBridge } from './ink-ui-bridge.js';
 import {
   applySlashCommandCompletion,
+  formatStatusline,
   getSlashCommandSuggestions,
   insertAtCursor,
+  nextInteractionMode,
+  normalizeInteractionMode,
   removeAtCursor,
   removeBeforeCursor,
   removeWordBeforeCursor,
@@ -118,5 +121,33 @@ describe('Ink composer editing helpers', () => {
     expect(shouldAcceptSlashSuggestion('/sta', 4, getSlashCommandSuggestions('/sta', 4)[0])).toBe(true);
     expect(shouldAcceptSlashSuggestion('/status', 7, getSlashCommandSuggestions('/status', 7)[0])).toBe(false);
     expect(applySlashCommandCompletion('/sta', 4, '/status')).toEqual({ input: '/status ', cursor: 8 });
+  });
+
+  it('normalizes interaction modes and formats statusline', () => {
+    expect(normalizeInteractionMode(undefined)).toBe('chat');
+    expect(normalizeInteractionMode('planning')).toBe('plan');
+    expect(normalizeInteractionMode('executing')).toBe('edit');
+    expect(nextInteractionMode('auto')).toBe('chat');
+
+    const statusline = formatStatusline({
+      sessionId: 's1',
+      taskListId: null,
+      mode: 'plan',
+      messages: 0,
+      estimatedTokens: 0,
+      queuedInputs: 2,
+      isProcessing: true,
+      status: 'Running agent',
+      phase: 'Using tool',
+      activeTool: 'bash',
+      toolCalls: 3,
+      completedTools: 1,
+      events: [],
+    });
+
+    expect(statusline).toContain('mode plan');
+    expect(statusline).toContain('active bash');
+    expect(statusline).toContain('tools 1/3');
+    expect(statusline).toContain('queue 2');
   });
 });

--- a/packages/cli/src/ink-ui-bridge.test.ts
+++ b/packages/cli/src/ink-ui-bridge.test.ts
@@ -10,6 +10,7 @@ import {
   removeWordBeforeCursor,
   renderPrompt,
   renderPromptLines,
+  shouldAcceptSlashSuggestion,
   type InkCliSnapshot,
 } from './ink-app.js';
 
@@ -43,6 +44,26 @@ describe('InkUiBridge', () => {
     expect(events[2].text).toBe('after');
   });
 
+  it('updates one tool card through running and success lifecycle', () => {
+    const snapshots: InkCliSnapshot[] = [];
+    const bridge = new InkUiBridge({ onChange: snapshot => snapshots.push(snapshot) });
+
+    bridge.startProcessing('Running agent');
+    bridge.toolCall('bash', { command: 'echo ok' });
+    bridge.toolResult('bash');
+
+    const last = snapshots[snapshots.length - 1];
+    expect(last.toolCalls).toBe(1);
+    expect(last.completedTools).toBe(1);
+    expect(last.activeTool).toBeNull();
+    expect(last.events).toHaveLength(1);
+    expect(last.events[0]).toMatchObject({
+      kind: 'tool',
+      title: 'bash',
+      status: 'success',
+      summary: 'completed',
+    });
+  });
   it('updates session snapshot and run summary status', () => {
     const snapshots: InkCliSnapshot[] = [];
     const bridge = new InkUiBridge({ onChange: snapshot => snapshots.push(snapshot) });
@@ -90,9 +111,12 @@ describe('Ink composer editing helpers', () => {
     expect(renderPromptLines('one\ntwo', 4, true)).toEqual(['one', '█two']);
   });
 
-  it('suggests and completes slash commands', () => {
+  it('suggests, fuzzily matches, and completes slash commands', () => {
     expect(getSlashCommandSuggestions('/s', 2).map(item => item.command)).toEqual(['/sessions', '/search', '/skills', '/status', '/solo', '/save']);
+    expect(getSlashCommandSuggestions('/tm', 3).map(item => item.command)).toContain('/team');
     expect(getSlashCommandSuggestions('//', 2)).toEqual([]);
+    expect(shouldAcceptSlashSuggestion('/sta', 4, getSlashCommandSuggestions('/sta', 4)[0])).toBe(true);
+    expect(shouldAcceptSlashSuggestion('/status', 7, getSlashCommandSuggestions('/status', 7)[0])).toBe(false);
     expect(applySlashCommandCompletion('/sta', 4, '/status')).toEqual({ input: '/status ', cursor: 8 });
   });
 });

--- a/packages/cli/src/ink-ui-bridge.ts
+++ b/packages/cli/src/ink-ui-bridge.ts
@@ -209,7 +209,7 @@ export class InkUiBridge {
     const call: ToolActivityCall = {
       id: `tool-${nextToolCalls}`,
       name,
-      summary: this.summarizeToolInput(input),
+      summary: this.summarizeToolInput(name, input),
       status: 'running',
     };
     this.toolActivityCalls = [...this.toolActivityCalls, call];
@@ -273,7 +273,7 @@ export class InkUiBridge {
     }
 
     const status = this.toolActivityCalls.some(call => call.status === 'running') ? 'running' : 'success';
-    const title = status === 'running' ? 'Tool activity' : 'Tool activity complete';
+    const title = 'Tools';
     const text = this.formatToolActivityText();
     const summary = this.formatToolActivitySummary();
 
@@ -305,23 +305,25 @@ export class InkUiBridge {
     const groupedTools = Object.entries(counts)
       .map(([tool, count]) => `${tool} ×${count}`)
       .join(' · ');
-    const runningCall = [...this.toolActivityCalls].reverse().find(call => call.status === 'running');
     const latestCalls = this.toolActivityCalls.slice(-4).map(call => {
       const icon = call.status === 'success' ? '✓' : call.status === 'error' ? '✕' : '…';
-      return `${icon} ${call.name}: ${call.summary}`;
+      return `${icon} ${call.name.padEnd(5)} ${call.summary}`;
     });
-    return [
-      groupedTools || 'No tools yet',
-      runningCall ? `Running: ${runningCall.name}: ${runningCall.summary}` : 'All tools completed',
-      ...latestCalls,
-    ].join('\n');
+    const lines = [groupedTools || 'No tools yet'];
+
+    if (latestCalls.length > 0) {
+      lines.push('', 'latest', ...latestCalls);
+    }
+
+    return lines.join('\n');
   }
 
   private formatToolActivitySummary(): string {
     const total = this.toolActivityCalls.length;
     const completed = this.toolActivityCalls.filter(call => call.status === 'success').length;
     const running = this.toolActivityCalls.find(call => call.status === 'running');
-    return running ? `${completed}/${total} done · running ${running.name}` : `${total} completed`;
+    const callLabel = total === 1 ? 'call' : 'calls';
+    return running ? `${total} ${callLabel} · ${completed} done · running ${running.name}` : `${total} ${callLabel} completed`;
   }
 
   private countToolNames(): Record<string, number> {
@@ -370,18 +372,89 @@ export class InkUiBridge {
     return `${text.slice(0, MAX_EVENT_TEXT_LENGTH)}…`;
   }
 
-  private summarizeToolInput(value: unknown): string {
+  private summarizeToolInput(name: string, value: unknown): string {
+    const normalizedName = name.toLowerCase();
+    const record = this.asRecord(value);
+
+    if (record) {
+      if (this.isShellTool(normalizedName)) {
+        return this.compactText(this.pickString(record, ['command', 'cmd', 'script']) ?? this.safeStringify(record));
+      }
+
+      if (this.isReadTool(normalizedName)) {
+        return this.compactText(this.pickString(record, ['filePath', 'path', 'file']) ?? this.safeStringify(record));
+      }
+
+      if (this.isSearchTool(normalizedName)) {
+        const pattern = this.pickString(record, ['pattern', 'query', 'search']);
+        const searchPath = this.pickString(record, ['path', 'cwd', 'glob']);
+        if (pattern && searchPath) {
+          return this.compactText(`"${pattern}" in ${searchPath}`);
+        }
+        return this.compactText(pattern ?? searchPath ?? this.safeStringify(record));
+      }
+
+      if (this.isMutationTool(normalizedName)) {
+        return this.compactText(this.pickString(record, ['filePath', 'path', 'file']) ?? this.safeStringify(record));
+      }
+
+      if (this.isListTool(normalizedName)) {
+        return this.compactText(this.pickString(record, ['path', 'dir', 'cwd']) ?? this.safeStringify(record));
+      }
+
+      const keys = Object.keys(record).slice(0, 3);
+      return keys.length > 0 ? `input: ${keys.join(', ')}` : 'input object';
+    }
+
     if (value === undefined || value === null) {
       return 'no input';
     }
     if (typeof value === 'string') {
-      return value.length > 48 ? `${value.slice(0, 48)}…` : value;
+      return this.compactText(value);
     }
-    if (typeof value === 'object') {
-      const keys = Object.keys(value as Record<string, unknown>).slice(0, 3);
-      return keys.length > 0 ? `input: ${keys.join(', ')}` : 'input object';
+    return this.compactText(this.safeStringify(value));
+  }
+
+  private asRecord(value: unknown): Record<string, unknown> | null {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return null;
     }
-    return String(value);
+    return value as Record<string, unknown>;
+  }
+
+  private pickString(record: Record<string, unknown>, keys: string[]): string | null {
+    for (const key of keys) {
+      const value = record[key];
+      if (typeof value === 'string' && value.trim()) {
+        return value.trim();
+      }
+    }
+    return null;
+  }
+
+  private compactText(value: string, maxLength = 96): string {
+    const normalized = value.replace(/\s+/g, ' ').trim();
+    return normalized.length > maxLength ? `${normalized.slice(0, maxLength)}…` : normalized;
+  }
+
+  private isShellTool(name: string): boolean {
+    return name.includes('bash') || name.includes('shell') || name.includes('exec') || name.includes('command');
+  }
+
+  private isReadTool(name: string): boolean {
+    return name.includes('read') || name.includes('cat') || name.includes('open');
+  }
+
+  private isSearchTool(name: string): boolean {
+    return name.includes('grep') || name.includes('search') || name.includes('find');
+  }
+
+  private isMutationTool(name: string): boolean {
+    return name.includes('edit') || name.includes('write') || name.includes('patch');
+  }
+
+  private isListTool(name: string): boolean {
+    return name === 'ls' || name.includes('list');
   }
 
   private safeStringify(value: unknown): string {

--- a/packages/cli/src/ink-ui-bridge.ts
+++ b/packages/cli/src/ink-ui-bridge.ts
@@ -62,7 +62,7 @@ export class InkUiBridge {
   }
 
   showWelcome(): void {
-    this.addEvent('system', 'Welcome', 'Type a message and press Enter to run the agent. Use /help for commands. Esc stops the current response; Ctrl+C exits safely.');
+    this.addEvent('system', 'Welcome', 'Type a message and press Enter to run the agent. Use /help for commands. Shift+Tab cycles CLI mode. Esc stops the current response; Ctrl+C exits safely.');
   }
 
   showHelp(items: TuiHelpItem[], footer: string[] = []): void {
@@ -78,7 +78,7 @@ export class InkUiBridge {
   showTuiStatus(): void {
     this.section('TUI Status', [
       'Current UI: Ink',
-      'Discovery: type / for slash-command suggestions, Tab completes the first match',
+      'Discovery: type / for slash-command suggestions, Tab completes the first match, Shift+Tab cycles CLI mode',
       'Input: Enter send, Ctrl+J newline, ↑/↓ history, ←/→ move cursor, Ctrl+A/E jump',
       'Editing: Ctrl+U delete before cursor, Ctrl+K delete after cursor, Ctrl+W delete previous word',
       'Control: Esc stops a run; when idle it clears input first, then exits on empty input',

--- a/packages/cli/src/ink-ui-bridge.ts
+++ b/packages/cli/src/ink-ui-bridge.ts
@@ -307,12 +307,12 @@ export class InkUiBridge {
       .join(' · ');
     const latestCalls = this.toolActivityCalls.slice(-4).map(call => {
       const icon = call.status === 'success' ? '✓' : call.status === 'error' ? '✕' : '…';
-      return `${icon} ${call.name.padEnd(5)} ${call.summary}`;
+      return `  ${icon} ${call.name.padEnd(5)} ${call.summary}`;
     });
-    const lines = [groupedTools || 'No tools yet'];
+    const lines = [`  ${groupedTools || 'No tools yet'}`];
 
     if (latestCalls.length > 0) {
-      lines.push('', 'latest', ...latestCalls);
+      lines.push('', '  latest', ...latestCalls);
     }
 
     return lines.join('\n');
@@ -323,7 +323,7 @@ export class InkUiBridge {
     const completed = this.toolActivityCalls.filter(call => call.status === 'success').length;
     const running = this.toolActivityCalls.find(call => call.status === 'running');
     const callLabel = total === 1 ? 'call' : 'calls';
-    return running ? `${total} ${callLabel} · ${completed} done · running ${running.name}` : `${total} ${callLabel} completed`;
+    return running ? `${total} ${callLabel} · ${completed} done · running ${running.name}` : `${total} ${callLabel} · ${completed} done`;
   }
 
   private countToolNames(): Record<string, number> {

--- a/packages/cli/src/ink-ui-bridge.ts
+++ b/packages/cli/src/ink-ui-bridge.ts
@@ -16,6 +16,7 @@ const DEFAULT_SNAPSHOT: InkUiSnapshot = {
   mode: null,
   messages: 0,
   estimatedTokens: 0,
+  queuedInputs: 0,
   isProcessing: false,
   status: 'Ready',
 };

--- a/packages/cli/src/ink-ui-bridge.ts
+++ b/packages/cli/src/ink-ui-bridge.ts
@@ -10,6 +10,15 @@ interface InkUiBridgeOptions {
   onChange: (snapshot: InkCliSnapshot) => void;
 }
 
+type ToolActivityStatus = 'running' | 'success' | 'error';
+
+interface ToolActivityCall {
+  id: string;
+  name: string;
+  summary: string;
+  status: ToolActivityStatus;
+}
+
 const DEFAULT_SNAPSHOT: InkUiSnapshot = {
   sessionId: null,
   taskListId: null,
@@ -33,7 +42,8 @@ export class InkUiBridge {
   private events: InkCliEvent[] = [];
   private eventCounter = 0;
   private activeAssistantEventId: string | null = null;
-  private activeToolEventId: string | null = null;
+  private toolActivityEventId: string | null = null;
+  private toolActivityCalls: ToolActivityCall[] = [];
   private readonly maxEvents: number;
   private readonly onChange: (snapshot: InkCliSnapshot) => void;
 
@@ -160,6 +170,8 @@ export class InkUiBridge {
 
   startProcessing(label = 'Processing'): void {
     this.activeAssistantEventId = null;
+    this.toolActivityEventId = null;
+    this.toolActivityCalls = [];
     this.updateSnapshot({
       isProcessing: true,
       status: label,
@@ -193,12 +205,15 @@ export class InkUiBridge {
 
   toolCall(name: string, input?: unknown): void {
     this.activeAssistantEventId = null;
-    const inputText = input === undefined ? 'No input payload' : this.safeStringify(input);
     const nextToolCalls = this.snapshot.toolCalls + 1;
-    this.activeToolEventId = this.addEvent('tool', name, inputText, false, {
-      status: 'running',
+    const call: ToolActivityCall = {
+      id: `tool-${nextToolCalls}`,
+      name,
       summary: this.summarizeToolInput(input),
-    });
+      status: 'running',
+    };
+    this.toolActivityCalls = [...this.toolActivityCalls, call];
+    this.upsertToolActivityEvent();
     this.updateSnapshot({
       phase: 'Using tool',
       activeTool: name,
@@ -209,17 +224,15 @@ export class InkUiBridge {
 
   toolResult(name: string): void {
     const nextCompletedTools = Math.min(this.snapshot.toolCalls, this.snapshot.completedTools + 1);
-    if (this.activeToolEventId) {
-      this.updateEvent(this.activeToolEventId, event => ({
-        ...event,
-        title: event.title || name,
+    const runningIndex = this.findRunningToolIndex(name);
+    if (runningIndex >= 0) {
+      this.toolActivityCalls = this.toolActivityCalls.map((call, index) => index === runningIndex ? {
+        ...call,
+        name: call.name || name,
         status: 'success',
-        summary: 'completed',
-      }));
-      this.activeToolEventId = null;
-    } else {
-      this.addEvent('result', name, 'Completed', false, { status: 'success', summary: 'completed' });
+      } : call);
     }
+    this.upsertToolActivityEvent();
 
     this.updateSnapshot({
       phase: 'Tool completed',
@@ -252,6 +265,71 @@ export class InkUiBridge {
     }
     this.addEvent('system', 'Clarification needed', lines.join('\n'));
     this.updateSnapshot({ status: 'Waiting for clarification' });
+  }
+
+  private upsertToolActivityEvent(): void {
+    if (this.toolActivityCalls.length === 0) {
+      return;
+    }
+
+    const status = this.toolActivityCalls.some(call => call.status === 'running') ? 'running' : 'success';
+    const title = status === 'running' ? 'Tool activity' : 'Tool activity complete';
+    const text = this.formatToolActivityText();
+    const summary = this.formatToolActivitySummary();
+
+    if (!this.toolActivityEventId || !this.events.some(event => event.id === this.toolActivityEventId)) {
+      this.toolActivityEventId = this.addEvent('tool', title, text, false, { status, summary });
+      this.emit();
+      return;
+    }
+
+    this.updateEvent(this.toolActivityEventId, event => ({
+      ...event,
+      title,
+      text,
+      status,
+      summary,
+    }));
+  }
+
+  private findRunningToolIndex(name: string): number {
+    const sameNameIndex = this.toolActivityCalls.findIndex(call => call.status === 'running' && call.name === name);
+    if (sameNameIndex >= 0) {
+      return sameNameIndex;
+    }
+    return this.toolActivityCalls.findIndex(call => call.status === 'running');
+  }
+
+  private formatToolActivityText(): string {
+    const counts = this.countToolNames();
+    const groupedTools = Object.entries(counts)
+      .map(([tool, count]) => `${tool} ×${count}`)
+      .join(' · ');
+    const runningCall = [...this.toolActivityCalls].reverse().find(call => call.status === 'running');
+    const latestCalls = this.toolActivityCalls.slice(-4).map(call => {
+      const icon = call.status === 'success' ? '✓' : call.status === 'error' ? '✕' : '…';
+      return `${icon} ${call.name}: ${call.summary}`;
+    });
+    return [
+      groupedTools || 'No tools yet',
+      runningCall ? `Running: ${runningCall.name}: ${runningCall.summary}` : 'All tools completed',
+      ...latestCalls,
+    ].join('\n');
+  }
+
+  private formatToolActivitySummary(): string {
+    const total = this.toolActivityCalls.length;
+    const completed = this.toolActivityCalls.filter(call => call.status === 'success').length;
+    const running = this.toolActivityCalls.find(call => call.status === 'running');
+    return running ? `${completed}/${total} done · running ${running.name}` : `${total} completed`;
+  }
+
+  private countToolNames(): Record<string, number> {
+    return this.toolActivityCalls.reduce<Record<string, number>>((counts, call) => {
+      const toolName = call.name || 'tool';
+      counts[toolName] = (counts[toolName] ?? 0) + 1;
+      return counts;
+    }, {});
   }
 
   private addEvent(

--- a/packages/cli/src/ink-ui-bridge.ts
+++ b/packages/cli/src/ink-ui-bridge.ts
@@ -71,6 +71,10 @@ export class InkUiBridge {
   showTuiStatus(): void {
     this.section('TUI Status', [
       'Current UI: Ink',
+      'Input: Enter send, ↑/↓ history, ←/→ move cursor, Ctrl+A/E jump',
+      'Editing: Ctrl+U delete before cursor, Ctrl+K delete after cursor, Ctrl+W delete previous word',
+      'Control: Esc stops a run; when idle it clears input first, then exits on empty input',
+      'Display: Ctrl+L clears the visible transcript only; /clear resets conversation context',
       'Fallback: PULSE_CODER_UI=readline pulse-coder',
       'Plain fallback: PULSE_CODER_PLAIN=1 PULSE_CODER_UI=readline pulse-coder',
     ]);

--- a/packages/cli/src/ink-ui-bridge.ts
+++ b/packages/cli/src/ink-ui-bridge.ts
@@ -19,6 +19,11 @@ const DEFAULT_SNAPSHOT: InkUiSnapshot = {
   queuedInputs: 0,
   isProcessing: false,
   status: 'Ready',
+  phase: 'Idle',
+  activeTool: null,
+  toolCalls: 0,
+  completedTools: 0,
+  lastStep: null,
 };
 
 const MAX_EVENT_TEXT_LENGTH = 4000;
@@ -28,6 +33,7 @@ export class InkUiBridge {
   private events: InkCliEvent[] = [];
   private eventCounter = 0;
   private activeAssistantEventId: string | null = null;
+  private activeToolEventId: string | null = null;
   private readonly maxEvents: number;
   private readonly onChange: (snapshot: InkCliSnapshot) => void;
 
@@ -100,6 +106,10 @@ export class InkUiBridge {
       estimatedTokens: summary.estimatedTokens,
       mode: summary.mode,
       status: `Done in ${this.formatDuration(summary.elapsedMs)} · tools ${summary.toolCalls}`,
+      phase: 'Complete',
+      activeTool: null,
+      toolCalls: summary.toolCalls,
+      completedTools: summary.toolCalls,
     });
   }
 
@@ -142,6 +152,8 @@ export class InkUiBridge {
     this.updateSnapshot({
       isProcessing: false,
       status: 'Cancelled',
+      phase: 'Cancelled',
+      activeTool: null,
     });
     this.addEvent('error', 'Abort', message);
   }
@@ -151,6 +163,11 @@ export class InkUiBridge {
     this.updateSnapshot({
       isProcessing: true,
       status: label,
+      phase: label,
+      activeTool: null,
+      toolCalls: 0,
+      completedTools: 0,
+      lastStep: null,
     });
   }
 
@@ -158,6 +175,8 @@ export class InkUiBridge {
     this.updateSnapshot({
       isProcessing: false,
       status: 'Ready',
+      phase: 'Idle',
+      activeTool: null,
     });
   }
 
@@ -174,16 +193,49 @@ export class InkUiBridge {
 
   toolCall(name: string, input?: unknown): void {
     this.activeAssistantEventId = null;
-    const inputText = input === undefined ? '' : `\n${this.safeStringify(input)}`;
-    this.addEvent('tool', name, `Running${inputText}`);
+    const inputText = input === undefined ? 'No input payload' : this.safeStringify(input);
+    const nextToolCalls = this.snapshot.toolCalls + 1;
+    this.activeToolEventId = this.addEvent('tool', name, inputText, false, {
+      status: 'running',
+      summary: this.summarizeToolInput(input),
+    });
+    this.updateSnapshot({
+      phase: 'Using tool',
+      activeTool: name,
+      toolCalls: nextToolCalls,
+      status: `Running tool: ${name}`,
+    });
   }
 
   toolResult(name: string): void {
-    this.addEvent('result', name, 'Completed');
+    const nextCompletedTools = Math.min(this.snapshot.toolCalls, this.snapshot.completedTools + 1);
+    if (this.activeToolEventId) {
+      this.updateEvent(this.activeToolEventId, event => ({
+        ...event,
+        title: event.title || name,
+        status: 'success',
+        summary: 'completed',
+      }));
+      this.activeToolEventId = null;
+    } else {
+      this.addEvent('result', name, 'Completed', false, { status: 'success', summary: 'completed' });
+    }
+
+    this.updateSnapshot({
+      phase: 'Tool completed',
+      activeTool: null,
+      completedTools: nextCompletedTools,
+      status: `Completed tool: ${name}`,
+    });
   }
 
   stepFinished(reason: string): void {
-    this.addEvent('system', 'Step finished', reason);
+    this.addEvent('system', 'Step finished', reason, true, { status: 'info' });
+    this.updateSnapshot({
+      phase: 'Step finished',
+      activeTool: null,
+      lastStep: reason,
+    });
   }
 
   user(message: string): void {
@@ -202,7 +254,13 @@ export class InkUiBridge {
     this.updateSnapshot({ status: 'Waiting for clarification' });
   }
 
-  private addEvent(kind: InkCliEvent['kind'], title: string | undefined, text: string, emit = true): string {
+  private addEvent(
+    kind: InkCliEvent['kind'],
+    title: string | undefined,
+    text: string,
+    emit = true,
+    metadata: Pick<InkCliEvent, 'status' | 'summary'> = {},
+  ): string {
     const id = `event-${++this.eventCounter}`;
     this.events = [
       ...this.events,
@@ -211,6 +269,7 @@ export class InkUiBridge {
         kind,
         title,
         text: this.truncateEventText(text),
+        ...metadata,
       },
     ].slice(-this.maxEvents);
 
@@ -231,6 +290,20 @@ export class InkUiBridge {
       return text;
     }
     return `${text.slice(0, MAX_EVENT_TEXT_LENGTH)}…`;
+  }
+
+  private summarizeToolInput(value: unknown): string {
+    if (value === undefined || value === null) {
+      return 'no input';
+    }
+    if (typeof value === 'string') {
+      return value.length > 48 ? `${value.slice(0, 48)}…` : value;
+    }
+    if (typeof value === 'object') {
+      const keys = Object.keys(value as Record<string, unknown>).slice(0, 3);
+      return keys.length > 0 ? `input: ${keys.join(', ')}` : 'input object';
+    }
+    return String(value);
   }
 
   private safeStringify(value: unknown): string {

--- a/packages/cli/src/ink-ui-bridge.ts
+++ b/packages/cli/src/ink-ui-bridge.ts
@@ -71,7 +71,8 @@ export class InkUiBridge {
   showTuiStatus(): void {
     this.section('TUI Status', [
       'Current UI: Ink',
-      'Input: Enter send, ↑/↓ history, ←/→ move cursor, Ctrl+A/E jump',
+      'Discovery: type / for slash-command suggestions, Tab completes the first match',
+      'Input: Enter send, Ctrl+J newline, ↑/↓ history, ←/→ move cursor, Ctrl+A/E jump',
       'Editing: Ctrl+U delete before cursor, Ctrl+K delete after cursor, Ctrl+W delete previous word',
       'Control: Esc stops a run; when idle it clears input first, then exits on empty input',
       'Display: Ctrl+L clears the visible transcript only; /clear resets conversation context',

--- a/packages/cli/src/ui-mode.test.ts
+++ b/packages/cli/src/ui-mode.test.ts
@@ -3,12 +3,13 @@ import { describe, expect, it } from 'vitest';
 import { resolveCliUiMode } from './ui-mode.js';
 
 describe('resolveCliUiMode', () => {
-  it('defaults to readline', () => {
-    expect(resolveCliUiMode([], {})).toBe('readline');
+  it('defaults to ink', () => {
+    expect(resolveCliUiMode([], {})).toBe('ink');
   });
 
-  it('uses PULSE_CODER_UI=ink', () => {
-    expect(resolveCliUiMode([], { PULSE_CODER_UI: 'ink' })).toBe('ink');
+  it('uses PULSE_CODER_UI=readline as an escape hatch', () => {
+    expect(resolveCliUiMode([], { PULSE_CODER_UI: 'readline' })).toBe('readline');
+    expect(resolveCliUiMode([], { PULSE_CODER_UI: 'plain' })).toBe('readline');
   });
 
   it('uses --ui ink flag', () => {

--- a/packages/cli/src/ui-mode.ts
+++ b/packages/cli/src/ui-mode.ts
@@ -24,9 +24,12 @@ export function resolveCliUiMode(args = process.argv.slice(2), env: NodeJS.Proce
   }
 
   const envValue = env.PULSE_CODER_UI?.toLowerCase();
+  if (envValue === 'readline' || envValue === 'plain') {
+    return 'readline';
+  }
   if (envValue === 'ink') {
     return 'ink';
   }
 
-  return 'readline';
+  return 'ink';
 }


### PR DESCRIPTION
Fix duplicate Canvas Agent restored sessions

- Promote restored archived sessions to the current session and remove stale archived copies with the same session ID
- Deduplicate archived session listings and cross-workspace scans by session ID, preferring the newest copy
- Return the newest archived copy when duplicate session files already exist

Validation:
- pnpm --filter canvas-workspace typecheck:main
