### PR TITLE
feat(canvas): polish workspace controls

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -692,13 +692,6 @@ export const Canvas = ({
         run: () => handleToolbarAddNode('file'),
       },
       {
-        id: 'create-terminal',
-        group: 'create',
-        title: 'Open terminal',
-        aliases: ['shell', 'pty', 'console', 'bash'],
-        run: () => handleToolbarAddNode('terminal'),
-      },
-      {
         id: 'create-agent',
         group: 'create',
         title: 'Create agent',

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
@@ -160,23 +160,6 @@ export const FloatingToolbar = ({
         </button>
         <button
           className="toolbar-btn toolbar-btn--create"
-          onClick={() => onAddNode("terminal")}
-          title="Add Terminal Card"
-        >
-          <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-            <rect
-              x="2" y="3" width="14" height="12" rx="2"
-              stroke="currentColor" strokeWidth="1.3"
-            />
-            <path
-              d="M5 8l2.5 2L5 12M9 12h4"
-              stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"
-            />
-          </svg>
-          <span className="toolbar-btn-label">Terminal</span>
-        </button>
-        <button
-          className="toolbar-btn toolbar-btn--create"
           onClick={() => onAddNode("frame")}
           title="Add Frame"
         >

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.tsx
@@ -108,6 +108,28 @@ export const IframeNodeBody = ({ node, workspaceId, onUpdate, isResizing, readOn
     if (readOnly) setEditing(false);
   }, [readOnly]);
 
+  useEffect(() => {
+    if (mode !== "url" || editing || readOnly) return;
+    const el = webviewRef.current;
+    if (!el) return;
+
+    const handlePageTitleUpdated = (event: Event) => {
+      const nextTitle = sanitizePageTitle((event as Event & { title?: string }).title);
+      if (!nextTitle || nextTitle === node.title) return;
+      if (!shouldSyncIframeTitle(node.title, data, url)) return;
+
+      onUpdate(node.id, {
+        title: nextTitle,
+        data: { ...data, pageTitle: nextTitle },
+      });
+    };
+
+    el.addEventListener("page-title-updated", handlePageTitleUpdated);
+    return () => {
+      el.removeEventListener("page-title-updated", handlePageTitleUpdated);
+    };
+  }, [data, editing, mode, node.id, node.title, onUpdate, readOnly, url, webviewKey]);
+
   // Autofocus the relevant input whenever we enter editing mode.
   useEffect(() => {
     if (!editing) return undefined;
@@ -214,9 +236,10 @@ export const IframeNodeBody = ({ node, workspaceId, onUpdate, isResizing, readOn
     if (readOnly) return;
     if (draftMode === "url") {
       const next = normalizeUrl(draftUrl.trim());
+      const shouldUseAutoTitle = shouldSyncIframeTitle(node.title, data, url);
       onUpdate(node.id, {
-        data: { ...data, url: next, mode: "url" },
-        title: next ? prettyTitle(next) : node.title,
+        data: { ...data, url: next, mode: "url", pageTitle: "" },
+        title: shouldUseAutoTitle && next ? prettyTitle(next) : node.title,
       });
     } else if (draftMode === "html") {
       onUpdate(node.id, {
@@ -225,7 +248,7 @@ export const IframeNodeBody = ({ node, workspaceId, onUpdate, isResizing, readOn
       });
     }
     setEditing(false);
-  }, [draftMode, draftUrl, draftHtml, onUpdate, node.id, node.title, data, readOnly]);
+  }, [draftMode, draftUrl, draftHtml, onUpdate, node.id, node.title, data, readOnly, url]);
 
   // ── Streaming AI generation ────────────────────────────────────────
 
@@ -636,6 +659,23 @@ function prettyTitle(url: string): string {
   } catch {
     return url;
   }
+}
+
+function sanitizePageTitle(title: string | undefined): string {
+  return (title ?? "").replace(/\s+/g, " ").trim();
+}
+
+function shouldSyncIframeTitle(title: string, data: IframeNodeData, url: string): boolean {
+  const currentTitle = title.trim();
+  const urlTitle = url ? prettyTitle(url) : "";
+  const previousPageTitle = sanitizePageTitle(data.pageTitle);
+
+  return (
+    !currentTitle
+    || currentTitle === "Web"
+    || currentTitle === urlTitle
+    || (!!previousPageTitle && currentTitle === previousPageTitle)
+  );
 }
 
 interface WebviewTag extends HTMLElement {

--- a/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
@@ -83,16 +83,6 @@ export const NodeContextMenu = ({ x, y, mode = "create", onCreate, onExportImage
           </button>
           <button
             className="context-menu-item"
-            onClick={() => onCreate?.("terminal")}
-          >
-            <span className="context-menu-icon">{"\u25B6"}</span>
-            <span className="context-menu-label">
-              <strong>Terminal</strong>
-              <small>Run shell commands</small>
-            </span>
-          </button>
-          <button
-            className="context-menu-item"
             onClick={() => onCreate?.("frame")}
           >
             <span className="context-menu-icon">{"\u25A1"}</span>

--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.css
@@ -88,6 +88,10 @@
     transform: none;
     filter: none;
   }
+
+  .reference-drawer-content {
+    animation: none;
+  }
 }
 
 .reference-drawer-header {
@@ -131,6 +135,23 @@
 .reference-drawer-icon-button:hover {
   color: var(--text);
   background: rgba(0, 0, 0, 0.04);
+}
+
+.reference-drawer-content {
+  min-height: 0;
+  height: calc(100% - 88px);
+  animation: reference-content-in 0.22s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes reference-content-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .reference-card-footer {
@@ -247,7 +268,7 @@
 
 .reference-native-card {
   min-height: 0;
-  height: calc(100% - 88px);
+  height: calc(100% - 32px);
   margin: 14px 18px 18px;
   display: flex;
   flex-direction: column;

--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.tsx
@@ -108,10 +108,11 @@ export const ReferenceDrawer = ({
           </button>
         </header>
 
-        {!referenceNode ? (
-          <ReferenceEmptyState selectedNode={selectedNode} />
-        ) : (
-          <div className="reference-native-card">
+        <div className="reference-drawer-content">
+          {!referenceNode ? (
+            <ReferenceEmptyState selectedNode={selectedNode} />
+          ) : (
+            <div className="reference-native-card">
             <CanvasNodeView
               node={{
                 ...referenceNode,
@@ -148,15 +149,26 @@ export const ReferenceDrawer = ({
                 Clear
               </button>
             </div>
-          </div>
-        )}
+            </div>
+          )}
+        </div>
     </aside>
   );
 };
 
 const ReferenceEmptyState = ({ selectedNode }: { selectedNode?: CanvasNode }) => (
   <div className="reference-empty">
-    <div className="reference-empty-icon">⌑</div>
+    <div className="reference-empty-icon" aria-hidden="true">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+        <path
+          d="M5.2 2.8h7.6a1.4 1.4 0 011.4 1.4v10.6L9 11.8l-5.2 3V4.2a1.4 1.4 0 011.4-1.4z"
+          stroke="currentColor"
+          strokeWidth="1.35"
+          strokeLinejoin="round"
+        />
+        <path d="M6.6 6.2h4.8M6.6 8.7h3" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" />
+      </svg>
+    </div>
     <h3>No reference pinned</h3>
     <p>Select a node, then use its Reference action to pin it here.</p>
     {selectedNode ? (

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatInput.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatInput.tsx
@@ -1,6 +1,6 @@
 import type { ClipboardEventHandler, KeyboardEventHandler, ReactNode, RefObject } from 'react';
 import type { CanvasNode, ChatImageAttachment } from '../../types';
-import { PlusIcon } from '../icons';
+import { ImageIcon, PlusIcon } from '../icons';
 import { getNodeDisplayLabel } from '../../utils/nodeLabel';
 import { MentionNodeIcon } from './utils/mentions';
 
@@ -122,7 +122,7 @@ export const ChatInput = ({
                   input.click();
                 }}
               >
-                🖼
+                <ImageIcon size={18} strokeWidth={1.35} />
               </button>
               </>
             ) : loading ? (

--- a/apps/canvas-workspace/src/renderer/src/components/icons/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/icons/index.tsx
@@ -137,6 +137,29 @@ export const ListLinesIcon = ({ size = 14, className }: IconProps) => (
   </svg>
 );
 
+/** Landscape / image attachment icon. */
+export const ImageIcon = ({ size = 16, className, strokeWidth = 1.3 }: IconProps) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className}>
+    <rect
+      x="2.5"
+      y="3"
+      width="11"
+      height="10"
+      rx="2"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+    />
+    <circle cx="6" cy="6.2" r="1.1" stroke="currentColor" strokeWidth="1.15" />
+    <path
+      d="M3.2 11.3L6.1 8.6a1 1 0 011.35-.02l1.1 1 1.45-1.45a1 1 0 011.42.02l1.38 1.45"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
 interface NodeTypeIconProps {
   type: CanvasNode['type'];
   size?: number;
@@ -231,6 +254,8 @@ export const NodeTypeIcon = ({ type, size = 14, className }: NodeTypeIconProps) 
           />
         </svg>
       );
+    case 'image':
+      return <ImageIcon size={size} className={className} />;
     case 'mindmap':
       // Root node on the left with three children branching to the right
       return (

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -97,6 +97,8 @@ export interface IframeNodeData {
   mode?: 'url' | 'html' | 'ai';
   /** The prompt used to generate HTML when `mode` is `'ai'`. */
   prompt?: string;
+  /** Last page title reported by the embedded webview for URL mode. */
+  pageTitle?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Sync iframe node default titles with the embedded page title while preserving manually edited titles.
- Replace the chat image attachment emoji with a shared line icon and add a smoother Reference drawer content entrance.
- Hide Terminal creation entry points from the toolbar, context menu, and command palette for now.

## Tests
- `pnpm --filter canvas-workspace typecheck:renderer`
- `pnpm --filter canvas-workspace build`
