### PR TITLE
fix(canvas): make focus mode more visible

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.css
@@ -74,8 +74,10 @@
   inset: 0;
   z-index: 0;
   pointer-events: none;
-  background: rgba(255, 255, 255, var(--focus-veil-opacity, 0.22));
-  backdrop-filter: saturate(0.88);
+  background:
+    radial-gradient(circle at 50% 42%, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, var(--focus-veil-opacity, 0.32)) 68%),
+    rgba(255, 255, 255, 0.18);
+  backdrop-filter: saturate(0.78);
   opacity: 0;
   animation: canvas-focus-veil-in 0.18s ease forwards;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -28,7 +28,7 @@ import type { CanvasNodeRenameRequest } from '../../types/ui-interaction';
 import { CanvasSurface } from './CanvasSurface';
 import { CanvasOverlays } from './CanvasOverlays';
 
-const DEFAULT_FOCUS_MODE_INTENSITY = 0.66;
+const DEFAULT_FOCUS_MODE_INTENSITY = 0.78;
 
 interface CanvasProps {
   canvasId: string;
@@ -193,9 +193,9 @@ export const Canvas = ({
     return node ? getNodeDisplayLabel(node) : undefined;
   }, [focusModeActive, nodes, selectedNodeIds]);
 
-  const focusModeDimOpacity = 0.32 - focusModeIntensity * 0.24;
-  const focusModeDimBlur = 0.3 + focusModeIntensity * 1.8;
-  const focusModeVeilOpacity = 0.08 + focusModeIntensity * 0.22;
+  const focusModeDimOpacity = 0.2 - focusModeIntensity * 0.14;
+  const focusModeDimBlur = 0.9 + focusModeIntensity * 3.4;
+  const focusModeVeilOpacity = 0.12 + focusModeIntensity * 0.26;
 
   const exitFocusMode = useCallback(() => {
     setFocusModeEnabled(false);

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
@@ -294,7 +294,7 @@ export const CanvasEdgesLayer = ({
         const targetFocused = edge.target.kind === 'node' && focusedNodeIds?.has(edge.target.nodeId);
         const isFocused = !focusModeEnabled || isSelected || (sourceFocused && targetFocused);
         const focusStyle: React.CSSProperties | undefined = focusModeEnabled && !isFocused
-          ? { opacity: Math.max(0.06, focusModeDimOpacity * 0.85) }
+          ? { opacity: Math.max(0.03, focusModeDimOpacity * 0.55) }
           : undefined;
         // While this edge's source/target is being dragged live, the
         // stored endpoint already reflects the in-progress state (we

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -37,7 +37,16 @@
   z-index: 80;
   filter: none;
   opacity: 1;
-  box-shadow: var(--shadow-card-hover), 0 0 0 2px rgba(124, 92, 255, 0.18), 0 10px 36px rgba(124, 92, 255, 0.12);
+  box-shadow: var(--shadow-card-hover), 0 0 0 2px rgba(124, 92, 255, 0.24), 0 16px 46px rgba(124, 92, 255, 0.18);
+}
+
+.canvas-node--focus-mode-focused::after {
+  content: "";
+  position: absolute;
+  inset: -10px;
+  border-radius: calc(var(--radius-lg) + 10px);
+  pointer-events: none;
+  box-shadow: 0 0 0 1px rgba(124, 92, 255, 0.1), 0 0 38px rgba(124, 92, 255, 0.16);
 }
 
 .canvas-node--focus-mode-focused.canvas-node--frame,
@@ -46,24 +55,24 @@
 }
 
 .canvas-node--focus-mode-focused.canvas-node--frame {
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--frame-color, #7c5cff) 26%, transparent), 0 14px 42px rgba(124, 92, 255, 0.13);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--frame-color, #7c5cff) 34%, transparent), 0 18px 52px rgba(124, 92, 255, 0.18);
 }
 
 .canvas-node--frame.canvas-node--focus-mode-focused.canvas-node--selected {
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--frame-color, #7c5cff) 32%, transparent), 0 14px 42px rgba(124, 92, 255, 0.15);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--frame-color, #7c5cff) 40%, transparent), 0 18px 52px rgba(124, 92, 255, 0.2);
 }
 
 .canvas-node--focus-mode-focused.canvas-node--group {
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--group-color, #A594E0) 24%, transparent), 0 14px 42px rgba(124, 92, 255, 0.12);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--group-color, #A594E0) 32%, transparent), 0 18px 52px rgba(124, 92, 255, 0.17);
 }
 
 .canvas-node--group.canvas-node--focus-mode-focused.canvas-node--selected {
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--group-color, #A594E0) 30%, transparent), 0 14px 42px rgba(124, 92, 255, 0.14);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--group-color, #A594E0) 38%, transparent), 0 18px 52px rgba(124, 92, 255, 0.19);
 }
 
 .canvas-node--focus-mode-dimmed {
-  opacity: var(--focus-dim-opacity, 0.18);
-  filter: saturate(0.55) blur(var(--focus-dim-blur, 1px));
+  opacity: var(--focus-dim-opacity, 0.09);
+  filter: saturate(0.42) blur(var(--focus-dim-blur, 3px));
   transition: opacity 0.18s ease, filter 0.18s ease, box-shadow 0.15s ease, border-color 0.15s ease;
 }
 


### PR DESCRIPTION
Make canvas Focus Mode easier to perceive by increasing separation between focused and non-focused content.\n\n- Increase default focus intensity and stronger dim/blur formulas\n- Add clearer glow treatment for focused nodes, frames, and groups\n- Fade non-focused edges further so they do not compete visually\n\nValidation:\n- git diff --check\n- pnpm --filter canvas-workspace typecheck:renderer attempted, but node_modules are missing in this worktree