### PR TITLE
fix(canvas): polish focus mode emphasis

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
@@ -65,7 +65,6 @@ interface CanvasOverlaysProps {
   onCommitEditEdgeLabel?: (id: string, label: string) => void;
   onCancelEditEdgeLabel?: () => void;
   focusModeEnabled?: boolean;
-  canToggleFocusMode?: boolean;
   focusModeIntensity?: number;
   focusModeTargetLabel?: string;
   onFocusModeToggle?: () => void;
@@ -105,7 +104,6 @@ export const CanvasOverlays = ({
   onCommitEditEdgeLabel,
   onCancelEditEdgeLabel,
   focusModeEnabled = false,
-  canToggleFocusMode = false,
   focusModeIntensity = 0.65,
   focusModeTargetLabel,
   onFocusModeToggle,
@@ -174,9 +172,6 @@ export const CanvasOverlays = ({
       onChatToggle={onChatToggle}
       referenceDrawerOpen={referenceDrawerOpen}
       onReferenceToggle={onReferenceToggle}
-      focusModeEnabled={focusModeEnabled}
-      canToggleFocusMode={canToggleFocusMode}
-      onFocusModeToggle={onFocusModeToggle}
     />
 
     {selectedEdge && onUpdateEdge && onRemoveEdge && (

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.css
@@ -75,9 +75,9 @@
   z-index: 0;
   pointer-events: none;
   background:
-    radial-gradient(circle at 50% 42%, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, var(--focus-veil-opacity, 0.32)) 68%),
-    rgba(255, 255, 255, 0.18);
-  backdrop-filter: saturate(0.78);
+    radial-gradient(circle at 50% 42%, rgba(255, 255, 255, 0), rgba(255, 255, 255, var(--focus-veil-opacity, 0.48)) 72%),
+    rgba(255, 255, 255, 0.2);
+  backdrop-filter: saturate(0.68);
   opacity: 0;
   animation: canvas-focus-veil-in 0.18s ease forwards;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -28,7 +28,7 @@ import type { CanvasNodeRenameRequest } from '../../types/ui-interaction';
 import { CanvasSurface } from './CanvasSurface';
 import { CanvasOverlays } from './CanvasOverlays';
 
-const DEFAULT_FOCUS_MODE_INTENSITY = 0.78;
+const DEFAULT_FOCUS_MODE_INTENSITY = 0.86;
 
 interface CanvasProps {
   canvasId: string;
@@ -193,9 +193,9 @@ export const Canvas = ({
     return node ? getNodeDisplayLabel(node) : undefined;
   }, [focusModeActive, nodes, selectedNodeIds]);
 
-  const focusModeDimOpacity = 0.2 - focusModeIntensity * 0.14;
-  const focusModeDimBlur = 0.9 + focusModeIntensity * 3.4;
-  const focusModeVeilOpacity = 0.12 + focusModeIntensity * 0.26;
+  const focusModeDimOpacity = 0.13 - focusModeIntensity * 0.105;
+  const focusModeDimBlur = 1.4 + focusModeIntensity * 4.4;
+  const focusModeVeilOpacity = 0.18 + focusModeIntensity * 0.34;
 
   const exitFocusMode = useCallback(() => {
     setFocusModeEnabled(false);
@@ -1219,7 +1219,6 @@ export const Canvas = ({
         onCommitEditEdgeLabel={handleCommitEditEdgeLabel}
         onCancelEditEdgeLabel={handleCancelEditEdgeLabel}
         focusModeEnabled={focusModeActive}
-        canToggleFocusMode={focusModeAvailable}
         focusModeIntensity={focusModeIntensity}
         focusModeTargetLabel={focusModeTargetLabel}
         onFocusModeToggle={toggleFocusMode}

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
@@ -294,7 +294,7 @@ export const CanvasEdgesLayer = ({
         const targetFocused = edge.target.kind === 'node' && focusedNodeIds?.has(edge.target.nodeId);
         const isFocused = !focusModeEnabled || isSelected || (sourceFocused && targetFocused);
         const focusStyle: React.CSSProperties | undefined = focusModeEnabled && !isFocused
-          ? { opacity: Math.max(0.03, focusModeDimOpacity * 0.55) }
+          ? { opacity: Math.max(0.015, focusModeDimOpacity * 0.45) }
           : undefined;
         // While this edge's source/target is being dragged live, the
         // stored endpoint already reflects the in-progress state (we

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -37,7 +37,7 @@
   z-index: 80;
   filter: none;
   opacity: 1;
-  box-shadow: var(--shadow-card-hover), 0 0 0 2px rgba(124, 92, 255, 0.24), 0 16px 46px rgba(124, 92, 255, 0.18);
+  box-shadow: var(--shadow-card-hover), 0 0 0 2px rgba(124, 92, 255, 0.32), 0 18px 54px rgba(124, 92, 255, 0.24);
 }
 
 .canvas-node--focus-mode-focused::after {
@@ -46,7 +46,7 @@
   inset: -10px;
   border-radius: calc(var(--radius-lg) + 10px);
   pointer-events: none;
-  box-shadow: 0 0 0 1px rgba(124, 92, 255, 0.1), 0 0 38px rgba(124, 92, 255, 0.16);
+  box-shadow: 0 0 0 1px rgba(124, 92, 255, 0.18), 0 0 42px rgba(124, 92, 255, 0.24);
 }
 
 .canvas-node--focus-mode-focused.canvas-node--frame,
@@ -55,24 +55,24 @@
 }
 
 .canvas-node--focus-mode-focused.canvas-node--frame {
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--frame-color, #7c5cff) 34%, transparent), 0 18px 52px rgba(124, 92, 255, 0.18);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--frame-color, #7c5cff) 48%, transparent), 0 20px 60px rgba(124, 92, 255, 0.24);
 }
 
 .canvas-node--frame.canvas-node--focus-mode-focused.canvas-node--selected {
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--frame-color, #7c5cff) 40%, transparent), 0 18px 52px rgba(124, 92, 255, 0.2);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--frame-color, #7c5cff) 58%, transparent), 0 22px 64px rgba(124, 92, 255, 0.26);
 }
 
 .canvas-node--focus-mode-focused.canvas-node--group {
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--group-color, #A594E0) 32%, transparent), 0 18px 52px rgba(124, 92, 255, 0.17);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--group-color, #A594E0) 46%, transparent), 0 20px 58px rgba(124, 92, 255, 0.22);
 }
 
 .canvas-node--group.canvas-node--focus-mode-focused.canvas-node--selected {
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--group-color, #A594E0) 38%, transparent), 0 18px 52px rgba(124, 92, 255, 0.19);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--group-color, #A594E0) 56%, transparent), 0 22px 62px rgba(124, 92, 255, 0.25);
 }
 
 .canvas-node--focus-mode-dimmed {
-  opacity: var(--focus-dim-opacity, 0.09);
-  filter: saturate(0.42) blur(var(--focus-dim-blur, 3px));
+  opacity: var(--focus-dim-opacity, 0.04);
+  filter: grayscale(0.18) saturate(0.22) blur(var(--focus-dim-blur, 5px));
   transition: opacity 0.18s ease, filter 0.18s ease, box-shadow 0.15s ease, border-color 0.15s ease;
 }
 
@@ -466,6 +466,15 @@
   background: color-mix(in srgb, var(--group-color, #A594E0) 5%, transparent);
   border-color: color-mix(in srgb, var(--group-color, #A594E0) 82%, transparent);
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--group-color, #A594E0) 16%, transparent);
+}
+
+.canvas-node--group.canvas-node--focus-mode-focused,
+.canvas-node--group.canvas-node--focus-mode-focused.canvas-node--selected {
+  background: color-mix(in srgb, var(--group-color, #A594E0) 8%, transparent);
+  border-style: solid;
+  border-color: color-mix(in srgb, var(--group-color, #A594E0) 92%, transparent);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--group-color, #A594E0) 30%, transparent), 0 22px 62px rgba(124, 92, 255, 0.25);
+  opacity: 1;
 }
 
 .canvas-node--group .node-header {

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
@@ -9,9 +9,6 @@ interface Props {
   onChatToggle?: () => void;
   referenceDrawerOpen?: boolean;
   onReferenceToggle?: () => void;
-  focusModeEnabled?: boolean;
-  canToggleFocusMode?: boolean;
-  onFocusModeToggle?: () => void;
 }
 
 const tools = [
@@ -70,9 +67,6 @@ export const FloatingToolbar = ({
   onChatToggle,
   referenceDrawerOpen,
   onReferenceToggle,
-  focusModeEnabled = false,
-  canToggleFocusMode = false,
-  onFocusModeToggle,
 }: Props) => {
   return (
     <div className="floating-toolbar">
@@ -129,35 +123,6 @@ export const FloatingToolbar = ({
           </button>
         ))}
         <ShapeToolButton activeTool={activeTool} onToolChange={onToolChange} />
-      </div>
-
-      <div className="toolbar-divider" />
-
-      <div className="toolbar-group">
-        <button
-          className={`toolbar-btn${focusModeEnabled ? " toolbar-btn--active" : ""}`}
-          onClick={onFocusModeToggle}
-          disabled={!canToggleFocusMode}
-          title={canToggleFocusMode ? "Toggle Focus Mode (F)" : "Select a node to focus"}
-          aria-pressed={focusModeEnabled}
-        >
-          <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
-            <circle cx="9" cy="9" r="2.4" stroke="currentColor" strokeWidth="1.35" />
-            <path
-              d="M9 2.5v2.2M9 13.3v2.2M2.5 9h2.2M13.3 9h2.2"
-              stroke="currentColor"
-              strokeWidth="1.35"
-              strokeLinecap="round"
-            />
-            <path
-              d="M4.6 4.6l1.5 1.5M11.9 11.9l1.5 1.5M13.4 4.6l-1.5 1.5M6.1 11.9l-1.5 1.5"
-              stroke="currentColor"
-              strokeWidth="1.1"
-              strokeLinecap="round"
-              opacity="0.72"
-            />
-          </svg>
-        </button>
       </div>
 
       <div className="toolbar-divider" />

--- a/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.css
@@ -30,6 +30,14 @@
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--frame-color, #A8B0BD) 22%, transparent);
 }
 
+.canvas-node--frame.canvas-node--focus-mode-focused,
+.canvas-node--frame.canvas-node--focus-mode-focused.canvas-node--selected {
+  background: color-mix(in srgb, var(--frame-color, #A8B0BD) 9%, var(--surface));
+  border-style: solid;
+  border-color: color-mix(in srgb, var(--frame-color, #A8B0BD) 95%, #7c5cff);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--frame-color, #A8B0BD) 34%, transparent), 0 22px 64px rgba(124, 92, 255, 0.26);
+}
+
 /* ---- Header tab ---- */
 
 .canvas-node--frame .node-header {


### PR DESCRIPTION
## Summary
- Remove the Focus mode icon from the floating toolbar.
- Make Focus mode visually stronger by dimming/softening non-focused nodes and edges more aggressively.
- Strengthen focused frame/group borders and glow so the active focus area reads clearly.

## Tests
- pnpm --filter canvas-workspace typecheck:renderer
- pnpm --filter canvas-workspace build