### PR TITLE
feat: support canvas group ungrouping

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -139,6 +139,7 @@ export const Canvas = ({
     duplicateNode,
     pasteNodes,
     groupNodes,
+    ungroupNodes,
     wrapNodesInFrame,
   } = useNodes(canvasId, (savedTransform) => {
     hasAutoFitted.current = true;
@@ -354,6 +355,21 @@ export const Canvas = ({
     });
   }, [groupNodes, selectedNodeIds, notify]);
 
+  const ungroupSelectedNodes = useCallback(() => {
+    if (selectedNodeIds.length === 0) return;
+    const selectedGroups = nodesRef.current.filter((node) => selectedNodeIds.includes(node.id) && node.type === 'group');
+    if (selectedGroups.length === 0) return;
+    const releasedIds = ungroupNodes(selectedGroups.map((node) => node.id));
+    setSelectedNodeIds(releasedIds);
+    notify({
+      tone: 'success',
+      title: selectedGroups.length === 1 ? 'Group dissolved' : 'Groups dissolved',
+      description: releasedIds.length > 0
+        ? `Released ${releasedIds.length} child node${releasedIds.length === 1 ? '' : 's'}.`
+        : 'Removed empty group container.',
+    });
+  }, [selectedNodeIds, ungroupNodes, notify]);
+
   const wrapSelectedNodesInFrame = useCallback(() => {
     if (selectedNodeIds.length === 0) return;
     const frame = wrapNodesInFrame(selectedNodeIds);
@@ -369,7 +385,7 @@ export const Canvas = ({
   useCanvasKeyboard({
     undo, redo, nodes, selectedNodeIds, setSelectedNodeIds,
     selectedEdgeId, setSelectedEdgeId, removeEdge: requestRemoveEdge,
-    duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, groupSelectedNodes,
+    duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, groupSelectedNodes, ungroupSelectedNodes,
     removeNodes: requestRemoveNodes,
     moveNodes, commitHistory,
     searchOpen, setSearchOpen, contextMenu, setContextMenu,
@@ -808,6 +824,17 @@ export const Canvas = ({
         },
       },
       {
+        id: 'ungroup-selection',
+        group: 'edit',
+        title: 'Ungroup selected group',
+        shortcut: 'Cmd+Shift+G',
+        aliases: ['ungroup', 'dissolve group', 'release group'],
+        enabled: selectedNodeIds.some((id) => nodesRef.current.some((node) => node.id === id && node.type === 'group')),
+        run: () => {
+          ungroupSelectedNodes();
+        },
+      },
+      {
         id: 'wrap-selection-in-frame',
         group: 'edit',
         title: selectionCount > 1
@@ -936,6 +963,7 @@ export const Canvas = ({
     duplicateNode,
     requestRemoveNodes,
     groupSelectedNodes,
+    ungroupSelectedNodes,
     wrapSelectedNodesInFrame,
     handleToolbarAddNode,
     fitAllNodes,

--- a/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.ts
@@ -18,6 +18,8 @@ interface Options {
   pasteNodes: (nodes: CanvasNode[]) => CanvasNode[];
   /** Group the current node selection in a lightweight container. */
   groupSelectedNodes: () => void;
+  /** Dissolve selected group nodes while keeping their children on canvas. */
+  ungroupSelectedNodes: () => void;
   removeNodes: (ids: string[]) => void | Promise<void>;
   /** Batch-move nodes by deltas in canvas coordinates. Used by arrow-
    *  key nudging so a single keypress moves the whole selection in one
@@ -43,7 +45,7 @@ interface Options {
 export const useCanvasKeyboard = ({
   undo, redo, nodes, selectedNodeIds, setSelectedNodeIds,
   selectedEdgeId, setSelectedEdgeId, removeEdge,
-  duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, groupSelectedNodes, removeNodes,
+  duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, groupSelectedNodes, ungroupSelectedNodes, removeNodes,
   moveNodes, commitHistory,
   searchOpen, setSearchOpen, contextMenu, setContextMenu,
   setHighlightedId, handleFocusNode,
@@ -102,6 +104,11 @@ export const useCanvasKeyboard = ({
       if (isMod && e.key === 'c' && !isEditable) {
         const selected = nodes.filter((n) => selectedNodeIds.includes(n.id));
         if (selected.length > 0) setClipboardNodes(selected);
+        return;
+      }
+      if (isMod && (e.key === 'g' || e.key === 'G') && e.shiftKey && !isEditable) {
+        e.preventDefault();
+        if (selectedNodeIds.length > 0) ungroupSelectedNodes();
         return;
       }
       if (isMod && (e.key === 'g' || e.key === 'G') && !e.shiftKey && !isEditable) {
@@ -173,7 +180,7 @@ export const useCanvasKeyboard = ({
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [undo, redo, nodes, selectedNodeIds, setSelectedNodeIds, selectedEdgeId, setSelectedEdgeId, removeEdge, duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, groupSelectedNodes, removeNodes, moveNodes, commitHistory, searchOpen, setSearchOpen, contextMenu, setContextMenu, focusModeEnabled, canToggleFocusMode, onToggleFocusMode, onExitFocusMode, keyboardLocked]);
+  }, [undo, redo, nodes, selectedNodeIds, setSelectedNodeIds, selectedEdgeId, setSelectedEdgeId, removeEdge, duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, groupSelectedNodes, ungroupSelectedNodes, removeNodes, moveNodes, commitHistory, searchOpen, setSearchOpen, contextMenu, setContextMenu, focusModeEnabled, canToggleFocusMode, onToggleFocusMode, onExitFocusMode, keyboardLocked]);
 
   // Cmd/Ctrl+Tab to cycle through nodes (Shift reverses direction)
   useEffect(() => {

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
@@ -430,6 +430,76 @@ export const useNodes = (
     [applyState, edgesRef, nodesRef, resizeGroupsToChildren]
   );
 
+  const ungroupNodes = useCallback(
+    (ids: string[]): string[] => {
+      if (ids.length === 0) return [];
+      const idSet = new Set(ids);
+      const groups = nodesRef.current.filter((node) => idSet.has(node.id) && node.type === 'group');
+      if (groups.length === 0) return [];
+
+      const now = Date.now();
+      const groupIds = new Set(groups.map((group) => group.id));
+      const groupChildIds = new Map(
+        groups.map((group) => [
+          group.id,
+          Array.isArray((group.data as GroupNodeData).childIds)
+            ? (group.data as GroupNodeData).childIds ?? []
+            : [],
+        ] as const),
+      );
+      const existingIds = new Set(nodesRef.current.map((node) => node.id));
+      const promotedIds = new Set<string>();
+
+      const nextNodes = nodesRef.current
+        .filter((node) => !groupIds.has(node.id))
+        .map((node) => {
+          if (node.type !== 'group') return node;
+          const data = node.data as GroupNodeData;
+          const childIds = Array.isArray(data.childIds) ? data.childIds : [];
+          if (childIds.length === 0) return node;
+
+          const nextChildIds: string[] = [];
+          let changed = false;
+          for (const childId of childIds) {
+            if (!groupIds.has(childId)) {
+              nextChildIds.push(childId);
+              continue;
+            }
+
+            changed = true;
+            const promotedChildren = groupChildIds.get(childId) ?? [];
+            for (const promotedId of promotedChildren) {
+              if (groupIds.has(promotedId) || !existingIds.has(promotedId)) continue;
+              if (!nextChildIds.includes(promotedId)) nextChildIds.push(promotedId);
+              promotedIds.add(promotedId);
+            }
+          }
+
+          if (!changed) return node;
+          return {
+            ...node,
+            data: { ...data, childIds: nextChildIds },
+            updatedAt: now,
+          };
+        });
+
+      for (const childIds of groupChildIds.values()) {
+        for (const childId of childIds) {
+          if (!groupIds.has(childId) && existingIds.has(childId)) promotedIds.add(childId);
+        }
+      }
+
+      let nextEdges = edgesRef.current;
+      for (const group of groups) {
+        nextEdges = degradeEndpointsForDeletedNode(nextEdges, group);
+      }
+
+      applyState({ nodes: resizeGroupsToChildren(nextNodes), edges: nextEdges });
+      return Array.from(promotedIds);
+    },
+    [applyState, edgesRef, nodesRef, resizeGroupsToChildren]
+  );
+
   const moveNode = useCallback(
     (id: string, x: number, y: number) => {
       const movedNodes = nodesRef.current.map((n) =>
@@ -729,6 +799,7 @@ export const useNodes = (
     duplicateNode,
     pasteNodes,
     groupNodes,
+    ungroupNodes,
     wrapNodesInFrame,
   };
 };

--- a/apps/canvas-workspace/src/renderer/src/utils/frameHierarchy.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/frameHierarchy.ts
@@ -19,15 +19,43 @@ export const isInsideFrame = isInsideContainer;
 
 const containerArea = (container: CanvasNode) => container.width * container.height;
 
+const getGroupChildIds = (node: CanvasNode): string[] | null => {
+  if (node.type !== 'group') return null;
+  const childIds = (node.data as GroupNodeData).childIds;
+  return Array.isArray(childIds) ? childIds : null;
+};
+
+const isExplicitGroupChild = (node: CanvasNode, group: CanvasNode): boolean => {
+  const childIds = getGroupChildIds(group);
+  return !!childIds?.includes(node.id);
+};
+
+const isCandidateParent = (node: CanvasNode, container: CanvasNode): boolean => {
+  const explicitGroupChild = isExplicitGroupChild(node, container);
+  if (explicitGroupChild) return true;
+
+  const groupChildIds = getGroupChildIds(container);
+  if (groupChildIds) {
+    // Groups with explicit childIds intentionally own only listed regular
+    // nodes, but still allow spatial nesting of other containers. This keeps
+    // a group placed inside another group attached even when it was not part
+    // of the original childIds set.
+    return isContainerNode(node) && isInsideContainer(node, container);
+  }
+
+  return isInsideContainer(node, container);
+};
+
 /**
  * For each node, find its parent container — the smallest (by area) frame/group
  * whose bounding box contains the node's center. Returns a map of nodeId →
  * parent container id (or null for root-level nodes).
  *
- * When `n` is itself a container, a candidate container `f` can only be its
- * parent if `f` is strictly "bigger" than `n` in the total order (area desc,
- * then id asc). This guarantees acyclic parenthood even when two containers
- * share a bbox.
+ * Group childIds are treated as directed parenthood and win over purely spatial
+ * containment. For container-in-container nesting, spatial candidates still use
+ * a strict area/id ordering to avoid cycles; explicit group membership is
+ * allowed even when two group boxes have the same size, which is common after
+ * wrapping an existing group in another group.
  */
 export const computeParentContainerMap = (
   nodes: CanvasNode[]
@@ -43,34 +71,29 @@ export const computeParentContainerMap = (
 
     for (const f of containers) {
       if (f.id === n.id) continue;
-      const groupChildren = f.type === 'group'
-        ? (f.data as GroupNodeData).childIds
-        : undefined;
-      const hasExplicitGroupChildren = Array.isArray(groupChildren);
-      const isExplicitGroupChild = hasExplicitGroupChildren && groupChildren.includes(n.id);
-      const containsNode = hasExplicitGroupChildren
-        ? isExplicitGroupChild
-        : isInsideContainer(n, f);
-      if (!containsNode) continue;
+      const explicitGroupChild = isExplicitGroupChild(n, f);
+      if (!isCandidateParent(n, f)) continue;
 
       const fArea = containerArea(f);
-      // For container-in-container, require strict "bigger" ancestor to avoid cycles.
-      if (isContainerNode(n)) {
+      // For spatial container-in-container, require strict "bigger" ancestor
+      // to avoid cycles. Explicit group membership is directed data, so allow
+      // it even when the wrapper resized to the same bbox as the child group.
+      if (isContainerNode(n) && !explicitGroupChild) {
         if (fArea < nArea) continue;
         if (fArea === nArea && f.id >= n.id) continue;
       }
 
-      if (isExplicitGroupChild && !bestIsExplicitGroupChild) {
+      if (explicitGroupChild && !bestIsExplicitGroupChild) {
         best = f;
         bestArea = fArea;
         bestIsExplicitGroupChild = true;
-      } else if (isExplicitGroupChild === bestIsExplicitGroupChild && fArea < bestArea) {
+      } else if (explicitGroupChild === bestIsExplicitGroupChild && fArea < bestArea) {
         best = f;
         bestArea = fArea;
-        bestIsExplicitGroupChild = isExplicitGroupChild;
-      } else if (isExplicitGroupChild === bestIsExplicitGroupChild && fArea === bestArea && best && f.id < best.id) {
+        bestIsExplicitGroupChild = explicitGroupChild;
+      } else if (explicitGroupChild === bestIsExplicitGroupChild && fArea === bestArea && best && f.id < best.id) {
         best = f;
-        bestIsExplicitGroupChild = isExplicitGroupChild;
+        bestIsExplicitGroupChild = explicitGroupChild;
       }
     }
 


### PR DESCRIPTION
Add ungroup support for canvas group nodes.

- Add Cmd/Ctrl+Shift+G shortcut and command palette action
- Remove selected group containers while preserving and selecting child nodes
- Promote nested group children and keep container hierarchy stable
- Degrade edges attached to removed groups instead of dropping connections

Validation:
- pnpm --filter canvas-workspace typecheck:renderer
- pnpm --filter canvas-workspace typecheck