### PR TITLE
Fix flex layout overflow issues in canvas viewport

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/App.css
+++ b/apps/canvas-workspace/src/renderer/src/App.css
@@ -12,12 +12,15 @@
   flex: 1;
   display: flex;
   overflow: hidden;
+  min-height: 0;
 }
 
 .canvas-viewport {
   flex: 1;
   position: relative;
   overflow: hidden;
+  height: 100%;
+  min-height: 0;
 }
 
 .chat-panel-wrapper {


### PR DESCRIPTION
## Summary
Fixed flexbox layout issues in the canvas workspace that were causing overflow and sizing problems in the viewport and chat panel wrapper.

## Key Changes
- Added `min-height: 0` to `.canvas-workspace` to allow flex children to shrink below their content size
- Added `height: 100%` to `.canvas-viewport` to ensure it fills available vertical space
- Added `min-height: 0` to `.canvas-viewport` to prevent it from overflowing its flex container

## Implementation Details
These CSS changes address a common flexbox gotcha where flex items don't properly shrink below their content size. By explicitly setting `min-height: 0` on flex containers and `height: 100%` on flex children, we ensure proper layout behavior and prevent unwanted overflow in the canvas viewport and chat panel areas.

https://claude.ai/code/session_01Dy1dqZxo9Ldtgr2k8Br1oG