### PR TITLE
fix: defer memory recall tool loading

### DIFF
--- a/packages/memory-plugin/src/integration.ts
+++ b/packages/memory-plugin/src/integration.ts
@@ -574,6 +574,7 @@ function buildMemoryRecallTool(
   return {
     name: 'memory_recall',
     description: 'Recall relevant memory items for the current user/session when needed.',
+    defer_loading: true,
     inputSchema: MEMORY_RECALL_INPUT_SCHEMA,
     execute: async ({ query, limit, scope }) => {
       const runContext = requireRunContext(getRunContext);


### PR DESCRIPTION
## Summary
- Mark memory_recall as defer_loading so it is discovered through tool search instead of being sent in the initial tool set.
- Keep defer behavior tool-owned; no env-based broad defer list is introduced.

## Validation
- pnpm --filter @pulse-coder/remote-server build