### PR TITLE
refactor(canvas-workspace): extract workbench state

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation } from 'wouter';
 import './App.css';
 import { Canvas } from './components/Canvas';
@@ -6,7 +6,7 @@ import { AppShellProvider, useAppShell } from './components/AppShellProvider';
 import { ChatPage, ChatPanel } from './components/chat';
 import { ReferenceDrawer } from './components/ReferenceDrawer';
 import { Sidebar } from './components/Sidebar';
-import { useWorkspaces } from './hooks/useWorkspaces';
+import { useWorkspaces, WorkspaceEntry } from './hooks/useWorkspaces';
 import { parseCanvasLocation } from './utils/canvasLinks';
 import type { CanvasNode } from './types';
 import type { CanvasNodeRenameRequest } from './types/ui-interaction';
@@ -21,6 +21,180 @@ const ROUTE_CHAT = '/chat';
 
 type ActiveView = 'canvas' | 'chat';
 
+interface WorkbenchProps {
+  allNodes: Record<string, CanvasNode[]>
+  activeId: string;
+  activeNodes: CanvasNode[];
+  selectedNode: CanvasNode | undefined;
+  deleteNodeId: string | undefined;
+  focusNodeId: string | undefined;
+
+  onFocusComplete: () => void;
+  onDeleteComplete: () => void;
+  onRenameComplete: () => void;
+
+  onNodeFocus: (nodeId: string) => void;
+
+  workspaces: WorkspaceEntry[];
+  setAllNodes: (value: React.SetStateAction<Record<string, CanvasNode[]>>) => void;
+
+  selectedNodeIdsByWorkspace: Record<string, string[]>;
+  setSelectedNodeIdsByWorkspace: React.Dispatch<React.SetStateAction<Record<string, string[]>>>;
+  renameNodeRequest: CanvasNodeRenameRequest | undefined;
+
+  chatPanelOpen: boolean;
+  setChatPanelOpen: React.Dispatch<React.SetStateAction<boolean>>;
+
+  onExpand: () => void;
+
+}
+
+const Workbench: React.FC<WorkbenchProps> = (props) => {
+  const { allNodes, activeId, focusNodeId, activeNodes = [], selectedNode, onNodeFocus, workspaces, setAllNodes, setSelectedNodeIdsByWorkspace, chatPanelOpen, setChatPanelOpen } = props;
+  const [referenceDrawerOpen, setReferenceDrawerOpen] = useState(false);
+  const [referenceNodeIdByWorkspace, setReferenceNodeIdByWorkspace] = useState<Record<string, string | undefined>>({});
+  const [chatWidth, setChatWidth] = useState(DEFAULT_CHAT_WIDTH);
+
+  const referenceNodeId = referenceNodeIdByWorkspace[activeId];
+
+  const referenceNode = referenceNodeId
+    ? activeNodes.find((node) => node.id === referenceNodeId)
+    : undefined;
+
+  const clearReferenceNode = useCallback(() => {
+    setReferenceNodeIdByWorkspace((prev) => ({
+      ...prev,
+      [activeId]: undefined,
+    }));
+  }, [activeId]);
+
+  const handleFocusReferenceNode = useCallback((nodeId: string) => {
+    onNodeFocus(nodeId);
+  }, []);
+
+  const handleNodesChange = useCallback((canvasId: string, nodes: CanvasNode[]) => {
+    setAllNodes((prev) => {
+      if (prev[canvasId] === nodes) return prev;
+      return { ...prev, [canvasId]: nodes };
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!referenceNodeId) return;
+    if (activeNodes.some((node) => node.id === referenceNodeId)) return;
+    setReferenceNodeIdByWorkspace((prev) => ({
+      ...prev,
+      [activeId]: undefined,
+    }));
+  }, [activeId, activeNodes, referenceNodeId]);
+
+  const pinReferenceNode = useCallback((nodeId: string) => {
+    setReferenceNodeIdByWorkspace((prev) => ({
+      ...prev,
+      [activeId]: nodeId,
+    }));
+    setReferenceDrawerOpen(true);
+  }, [activeId]);
+
+  const handleSelectionChange = useCallback((canvasId: string, selectedNodeIds: string[]) => {
+    setSelectedNodeIdsByWorkspace((prev) => {
+      const existing = prev[canvasId] ?? [];
+      if (
+        existing.length === selectedNodeIds.length
+        && existing.every((id, index) => id === selectedNodeIds[index])
+      ) {
+        return prev;
+      }
+      return { ...prev, [canvasId]: selectedNodeIds };
+    });
+  }, []);
+
+  const resizing = useRef(false);
+
+  const handleResizeStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    resizing.current = true;
+    const startX = e.clientX;
+    const startWidth = chatWidth;
+
+    const onMouseMove = (ev: MouseEvent) => {
+      const delta = startX - ev.clientX;
+      const newWidth = Math.min(MAX_CHAT_WIDTH, Math.max(MIN_CHAT_WIDTH, startWidth + delta));
+      setChatWidth(newWidth);
+    };
+
+    const onMouseUp = () => {
+      resizing.current = false;
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  }, [chatWidth]);
+
+  return (
+    <>
+      <ReferenceDrawer
+        open={referenceDrawerOpen}
+        referenceNode={referenceNode}
+        selectedNode={selectedNode}
+        onOpenChange={setReferenceDrawerOpen}
+        onClear={clearReferenceNode}
+        onFocusNode={handleFocusReferenceNode}
+      />
+      <div className="canvas-viewport">
+        {workspaces
+          .filter((ws) => ws.id === activeId)
+          .map((ws) => (
+            <Canvas
+              key={ws.id}
+              canvasId={ws.id}
+              canvasName={ws.name}
+              rootFolder={ws.rootFolder}
+              onNodesChange={handleNodesChange}
+              onSelectionChange={handleSelectionChange}
+              focusNodeId={ws.id === activeId ? focusNodeId : undefined}
+              onFocusComplete={props.onFocusComplete}
+              deleteNodeId={ws.id === activeId ? props.deleteNodeId : undefined}
+              onDeleteComplete={props.onDeleteComplete}
+              renameRequest={ws.id === props.renameNodeRequest?.workspaceId ? props.renameNodeRequest : undefined}
+              onRenameComplete={props.onRenameComplete}
+              chatPanelOpen={chatPanelOpen}
+              onChatToggle={() => setChatPanelOpen((prev) => !prev)}
+              referenceDrawerOpen={referenceDrawerOpen}
+              onReferenceToggle={() => setReferenceDrawerOpen((prev) => !prev)}
+              onPinReferenceNode={pinReferenceNode}
+            />
+          ))}
+      </div>
+      {workspaces.map((ws) => (
+        <div
+          key={ws.id}
+          className={`chat-panel-wrapper${chatPanelOpen && ws.id === activeId ? ' chat-panel-wrapper--open' : ''}`}
+          style={ws.id !== activeId ? { display: 'none' } : chatPanelOpen ? { width: chatWidth } : undefined}
+        >
+          <ChatPanel
+            workspaceId={ws.id}
+            allWorkspaces={workspaces}
+            nodes={allNodes[ws.id] || []}
+            selectedNodeIds={props.selectedNodeIdsByWorkspace[ws.id] || []}
+            rootFolder={ws.rootFolder}
+            onClose={() => setChatPanelOpen(false)}
+            onResizeStart={handleResizeStart}
+            onNodeFocus={props.onNodeFocus}
+            onExpand={props.onExpand}
+          />
+        </div>
+      ))}
+    </>
+  );
+}
+
 const AppContent = () => {
   const [location, setLocation] = useLocation();
   const { path: routePath, params: routeParams } = useMemo(
@@ -34,24 +208,17 @@ const AppContent = () => {
 
   const [sidebarCollapsed, setSidebarCollapsed] = useState(true);
   const [chatPanelOpen, setChatPanelOpen] = useState(false);
-  const [referenceDrawerOpen, setReferenceDrawerOpen] = useState(false);
-  const [chatWidth, setChatWidth] = useState(DEFAULT_CHAT_WIDTH);
+
+
   const [allNodes, setAllNodes] = useState<Record<string, CanvasNode[]>>({});
   const [selectedNodeIdsByWorkspace, setSelectedNodeIdsByWorkspace] = useState<Record<string, string[]>>({});
-  const [referenceNodeIdByWorkspace, setReferenceNodeIdByWorkspace] = useState<Record<string, string | undefined>>({});
+
   const [focusNodeId, setFocusNodeId] = useState<string | undefined>();
   const [deleteNodeId, setDeleteNodeId] = useState<string | undefined>();
   const [renameNodeRequest, setRenameNodeRequest] = useState<CanvasNodeRenameRequest | undefined>();
-  const resizing = useRef(false);
+
   const allNodesRef = useRef(allNodes);
   allNodesRef.current = allNodes;
-
-  const handleNodesChange = useCallback((canvasId: string, nodes: CanvasNode[]) => {
-    setAllNodes((prev) => {
-      if (prev[canvasId] === nodes) return prev;
-      return { ...prev, [canvasId]: nodes };
-    });
-  }, []);
 
   const ensureWorkspaceNodesLoaded = useCallback((workspaceId: string) => {
     if (allNodesRef.current[workspaceId]) return;
@@ -67,18 +234,7 @@ const AppContent = () => {
     });
   }, []);
 
-  const handleSelectionChange = useCallback((canvasId: string, selectedNodeIds: string[]) => {
-    setSelectedNodeIdsByWorkspace((prev) => {
-      const existing = prev[canvasId] ?? [];
-      if (
-        existing.length === selectedNodeIds.length
-        && existing.every((id, index) => id === selectedNodeIds[index])
-      ) {
-        return prev;
-      }
-      return { ...prev, [canvasId]: selectedNodeIds };
-    });
-  }, []);
+
 
   const handleFocusComplete = useCallback(() => {
     setFocusNodeId(undefined);
@@ -373,73 +529,21 @@ const AppContent = () => {
     return () => window.removeEventListener('keydown', handler);
   }, [activeView, isOverlayOpen, openShortcuts, setLocation]);
 
-  const handleResizeStart = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    resizing.current = true;
-    const startX = e.clientX;
-    const startWidth = chatWidth;
 
-    const onMouseMove = (ev: MouseEvent) => {
-      const delta = startX - ev.clientX;
-      const newWidth = Math.min(MAX_CHAT_WIDTH, Math.max(MIN_CHAT_WIDTH, startWidth + delta));
-      setChatWidth(newWidth);
-    };
-
-    const onMouseUp = () => {
-      resizing.current = false;
-      document.removeEventListener('mousemove', onMouseMove);
-      document.removeEventListener('mouseup', onMouseUp);
-      document.body.style.cursor = '';
-      document.body.style.userSelect = '';
-    };
-
-    document.body.style.cursor = 'col-resize';
-    document.body.style.userSelect = 'none';
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
-  }, [chatWidth]);
 
   const handleNodeFocusFromChatPage = useCallback((nodeId: string) => {
     setFocusNodeId(nodeId);
     setLocation(ROUTE_CANVAS);
   }, [setLocation]);
 
-  const pinReferenceNode = useCallback((nodeId: string) => {
-    setReferenceNodeIdByWorkspace((prev) => ({
-      ...prev,
-      [activeId]: nodeId,
-    }));
-    setReferenceDrawerOpen(true);
-  }, [activeId]);
 
-  const clearReferenceNode = useCallback(() => {
-    setReferenceNodeIdByWorkspace((prev) => ({
-      ...prev,
-      [activeId]: undefined,
-    }));
-  }, [activeId]);
-
-  const handleFocusReferenceNode = useCallback((nodeId: string) => {
-    setFocusNodeId(nodeId);
-  }, []);
 
   const activeNodes = allNodes[activeId] || [];
   const selectedNodeIds = selectedNodeIdsByWorkspace[activeId] || [];
   const selectedNode = selectedNodeIds.length === 1
     ? activeNodes.find((node) => node.id === selectedNodeIds[0])
     : undefined;
-  const referenceNodeId = referenceNodeIdByWorkspace[activeId];
-  const referenceNode = referenceNodeId
-    ? activeNodes.find((node) => node.id === referenceNodeId)
-    : undefined;
-  useEffect(() => {
-    if (!referenceNodeId) return;
-    if (activeNodes.some((node) => node.id === referenceNodeId)) return;
-    setReferenceNodeIdByWorkspace((prev) => ({
-      ...prev,
-      [activeId]: undefined,
-    }));
-  }, [activeId, activeNodes, referenceNodeId]);
+
 
   const activeWorkspace = workspaces.find((ws) => ws.id === activeId);
 
@@ -473,62 +577,32 @@ const AppContent = () => {
           onEnterChat={enterChatView}
           onExitChat={exitChatView}
         />
-        <PulseRouter activeKey={activeView}>
+        <PulseRouter<ActiveView> activeKey={activeView}>
           <PulseRouterView name='canvas'>
-            <>
-              <ReferenceDrawer
-                open={referenceDrawerOpen}
-                referenceNode={referenceNode}
-                selectedNode={selectedNode}
-                onOpenChange={setReferenceDrawerOpen}
-                onClear={clearReferenceNode}
-                onFocusNode={handleFocusReferenceNode}
-              />
-              <div className="canvas-viewport">
-                {workspaces
-                  .filter((ws) => ws.id === activeId)
-                  .map((ws) => (
-                    <Canvas
-                      key={ws.id}
-                      canvasId={ws.id}
-                      canvasName={ws.name}
-                      rootFolder={ws.rootFolder}
-                      onNodesChange={handleNodesChange}
-                      onSelectionChange={handleSelectionChange}
-                      focusNodeId={ws.id === activeId ? focusNodeId : undefined}
-                      onFocusComplete={handleFocusComplete}
-                      deleteNodeId={ws.id === activeId ? deleteNodeId : undefined}
-                      onDeleteComplete={handleDeleteComplete}
-                      renameRequest={ws.id === renameNodeRequest?.workspaceId ? renameNodeRequest : undefined}
-                      onRenameComplete={handleRenameComplete}
-                      chatPanelOpen={chatPanelOpen}
-                      onChatToggle={() => setChatPanelOpen((prev) => !prev)}
-                      referenceDrawerOpen={referenceDrawerOpen}
-                      onReferenceToggle={() => setReferenceDrawerOpen((prev) => !prev)}
-                      onPinReferenceNode={pinReferenceNode}
-                    />
-                  ))}
-              </div>
-              {workspaces.map((ws) => (
-                <div
-                  key={ws.id}
-                  className={`chat-panel-wrapper${chatPanelOpen && ws.id === activeId ? ' chat-panel-wrapper--open' : ''}`}
-                  style={ws.id !== activeId ? { display: 'none' } : chatPanelOpen ? { width: chatWidth } : undefined}
-                >
-                  <ChatPanel
-                    workspaceId={ws.id}
-                    allWorkspaces={workspaces}
-                    nodes={allNodes[ws.id] || []}
-                    selectedNodeIds={selectedNodeIdsByWorkspace[ws.id] || []}
-                    rootFolder={ws.rootFolder}
-                    onClose={() => setChatPanelOpen(false)}
-                    onResizeStart={handleResizeStart}
-                    onNodeFocus={setFocusNodeId}
-                    onExpand={enterChatView}
-                  />
-                </div>
-              ))}
-            </>
+            <Workbench
+              allNodes={allNodes}
+              activeId={activeId}
+              activeNodes={activeNodes}
+              selectedNode={selectedNode}
+              deleteNodeId={deleteNodeId}
+              focusNodeId={focusNodeId}
+
+              onFocusComplete={handleFocusComplete}
+              onDeleteComplete={handleDeleteComplete}
+              onRenameComplete={handleRenameComplete}
+
+              onNodeFocus={setFocusNodeId}
+
+              workspaces={workspaces}
+              setAllNodes={setAllNodes}
+
+              selectedNodeIdsByWorkspace={selectedNodeIdsByWorkspace}
+              setSelectedNodeIdsByWorkspace={setSelectedNodeIdsByWorkspace}
+              renameNodeRequest={renameNodeRequest}
+              chatPanelOpen={chatPanelOpen}
+              setChatPanelOpen={setChatPanelOpen}
+              onExpand={enterChatView}
+            />
           </PulseRouterView>
           <PulseRouterView name="chat">
             <ChatPage

--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -10,6 +10,7 @@ import { useWorkspaces } from './hooks/useWorkspaces';
 import { parseCanvasLocation } from './utils/canvasLinks';
 import type { CanvasNode } from './types';
 import type { CanvasNodeRenameRequest } from './types/ui-interaction';
+import { PulseRouter, PulseRouterView } from './components/router';
 
 const DEFAULT_CHAT_WIDTH = 420;
 const MIN_CHAT_WIDTH = 280;
@@ -472,72 +473,74 @@ const AppContent = () => {
           onEnterChat={enterChatView}
           onExitChat={exitChatView}
         />
-        {activeView === 'canvas' && (
-          <>
-            <ReferenceDrawer
-              open={referenceDrawerOpen}
-              referenceNode={referenceNode}
-              selectedNode={selectedNode}
-              onOpenChange={setReferenceDrawerOpen}
-              onClear={clearReferenceNode}
-              onFocusNode={handleFocusReferenceNode}
-            />
-            <div className="canvas-viewport">
-              {workspaces
-                .filter((ws) => ws.id === activeId)
-                .map((ws) => (
-                  <Canvas
-                    key={ws.id}
-                    canvasId={ws.id}
-                    canvasName={ws.name}
-                    rootFolder={ws.rootFolder}
-                    onNodesChange={handleNodesChange}
-                    onSelectionChange={handleSelectionChange}
-                    focusNodeId={ws.id === activeId ? focusNodeId : undefined}
-                    onFocusComplete={handleFocusComplete}
-                    deleteNodeId={ws.id === activeId ? deleteNodeId : undefined}
-                    onDeleteComplete={handleDeleteComplete}
-                    renameRequest={ws.id === renameNodeRequest?.workspaceId ? renameNodeRequest : undefined}
-                    onRenameComplete={handleRenameComplete}
-                    chatPanelOpen={chatPanelOpen}
-                    onChatToggle={() => setChatPanelOpen((prev) => !prev)}
-                    referenceDrawerOpen={referenceDrawerOpen}
-                    onReferenceToggle={() => setReferenceDrawerOpen((prev) => !prev)}
-                    onPinReferenceNode={pinReferenceNode}
-                  />
-                ))}
-            </div>
-            {workspaces.map((ws) => (
-              <div
-                key={ws.id}
-                className={`chat-panel-wrapper${chatPanelOpen && ws.id === activeId ? ' chat-panel-wrapper--open' : ''}`}
-                style={ws.id !== activeId ? { display: 'none' } : chatPanelOpen ? { width: chatWidth } : undefined}
-              >
-                <ChatPanel
-                  workspaceId={ws.id}
-                  allWorkspaces={workspaces}
-                  nodes={allNodes[ws.id] || []}
-                  selectedNodeIds={selectedNodeIdsByWorkspace[ws.id] || []}
-                  rootFolder={ws.rootFolder}
-                  onClose={() => setChatPanelOpen(false)}
-                  onResizeStart={handleResizeStart}
-                  onNodeFocus={setFocusNodeId}
-                  onExpand={enterChatView}
-                />
+        <PulseRouter activeKey={activeView}>
+          <PulseRouterView name='canvas'>
+            <>
+              <ReferenceDrawer
+                open={referenceDrawerOpen}
+                referenceNode={referenceNode}
+                selectedNode={selectedNode}
+                onOpenChange={setReferenceDrawerOpen}
+                onClear={clearReferenceNode}
+                onFocusNode={handleFocusReferenceNode}
+              />
+              <div className="canvas-viewport">
+                {workspaces
+                  .filter((ws) => ws.id === activeId)
+                  .map((ws) => (
+                    <Canvas
+                      key={ws.id}
+                      canvasId={ws.id}
+                      canvasName={ws.name}
+                      rootFolder={ws.rootFolder}
+                      onNodesChange={handleNodesChange}
+                      onSelectionChange={handleSelectionChange}
+                      focusNodeId={ws.id === activeId ? focusNodeId : undefined}
+                      onFocusComplete={handleFocusComplete}
+                      deleteNodeId={ws.id === activeId ? deleteNodeId : undefined}
+                      onDeleteComplete={handleDeleteComplete}
+                      renameRequest={ws.id === renameNodeRequest?.workspaceId ? renameNodeRequest : undefined}
+                      onRenameComplete={handleRenameComplete}
+                      chatPanelOpen={chatPanelOpen}
+                      onChatToggle={() => setChatPanelOpen((prev) => !prev)}
+                      referenceDrawerOpen={referenceDrawerOpen}
+                      onReferenceToggle={() => setReferenceDrawerOpen((prev) => !prev)}
+                      onPinReferenceNode={pinReferenceNode}
+                    />
+                  ))}
               </div>
-            ))}
-          </>
-        )}
-        {activeView === 'chat' && (
-          <ChatPage
-            initialWorkspaceId={activeId}
-            allWorkspaces={workspaces}
-            nodes={allNodes[activeId] || []}
-            rootFolder={activeWorkspace?.rootFolder}
-            onExit={exitChatView}
-            onNodeFocus={handleNodeFocusFromChatPage}
-          />
-        )}
+              {workspaces.map((ws) => (
+                <div
+                  key={ws.id}
+                  className={`chat-panel-wrapper${chatPanelOpen && ws.id === activeId ? ' chat-panel-wrapper--open' : ''}`}
+                  style={ws.id !== activeId ? { display: 'none' } : chatPanelOpen ? { width: chatWidth } : undefined}
+                >
+                  <ChatPanel
+                    workspaceId={ws.id}
+                    allWorkspaces={workspaces}
+                    nodes={allNodes[ws.id] || []}
+                    selectedNodeIds={selectedNodeIdsByWorkspace[ws.id] || []}
+                    rootFolder={ws.rootFolder}
+                    onClose={() => setChatPanelOpen(false)}
+                    onResizeStart={handleResizeStart}
+                    onNodeFocus={setFocusNodeId}
+                    onExpand={enterChatView}
+                  />
+                </div>
+              ))}
+            </>
+          </PulseRouterView>
+          <PulseRouterView name="chat">
+            <ChatPage
+              initialWorkspaceId={activeId}
+              allWorkspaces={workspaces}
+              nodes={allNodes[activeId] || []}
+              rootFolder={activeWorkspace?.rootFolder}
+              onExit={exitChatView}
+              onNodeFocus={handleNodeFocusFromChatPage}
+            />
+          </PulseRouterView>
+        </PulseRouter>
       </div>
     </div>
   );

--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -42,15 +42,14 @@ interface WorkbenchProps {
   setSelectedNodeIdsByWorkspace: React.Dispatch<React.SetStateAction<Record<string, string[]>>>;
   renameNodeRequest: CanvasNodeRenameRequest | undefined;
 
-  chatPanelOpen: boolean;
-  setChatPanelOpen: React.Dispatch<React.SetStateAction<boolean>>;
-
   onExpand: () => void;
-
 }
 
 const Workbench: React.FC<WorkbenchProps> = (props) => {
-  const { allNodes, activeId, focusNodeId, activeNodes = [], selectedNode, onNodeFocus, workspaces, setAllNodes, setSelectedNodeIdsByWorkspace, chatPanelOpen, setChatPanelOpen } = props;
+
+
+  const { allNodes, activeId, focusNodeId, activeNodes = [], selectedNode, onNodeFocus, workspaces, setAllNodes, setSelectedNodeIdsByWorkspace } = props;
+  const [chatPanelOpen, setChatPanelOpen] = useState(false);
   const [referenceDrawerOpen, setReferenceDrawerOpen] = useState(false);
   const [referenceNodeIdByWorkspace, setReferenceNodeIdByWorkspace] = useState<Record<string, string | undefined>>({});
   const [chatWidth, setChatWidth] = useState(DEFAULT_CHAT_WIDTH);
@@ -207,7 +206,6 @@ const AppContent = () => {
   const { notify, updateToast, confirm, openShortcuts, isOverlayOpen } = useAppShell();
 
   const [sidebarCollapsed, setSidebarCollapsed] = useState(true);
-  const [chatPanelOpen, setChatPanelOpen] = useState(false);
 
 
   const [allNodes, setAllNodes] = useState<Record<string, CanvasNode[]>>({});
@@ -284,7 +282,6 @@ const AppContent = () => {
   }, [routeQuery, routeParams, activeId, workspaces, selectWorkspace, setLocation]);
 
   const enterChatView = useCallback(() => {
-    setChatPanelOpen(false);
     setLocation(ROUTE_CHAT);
   }, [setLocation]);
 
@@ -502,19 +499,11 @@ const AppContent = () => {
         return;
       }
 
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'a') {
-        if (activeView !== 'canvas') return;
-        e.preventDefault();
-        setChatPanelOpen((prev) => !prev);
-        return;
-      }
-
       if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'l') {
         e.preventDefault();
         if (activeView === 'chat') {
           setLocation(ROUTE_CANVAS);
         } else {
-          setChatPanelOpen(false);
           setLocation(ROUTE_CHAT);
         }
         return;
@@ -528,7 +517,6 @@ const AppContent = () => {
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
   }, [activeView, isOverlayOpen, openShortcuts, setLocation]);
-
 
 
   const handleNodeFocusFromChatPage = useCallback((nodeId: string) => {
@@ -581,6 +569,7 @@ const AppContent = () => {
           <PulseRouterView name='canvas'>
             <Workbench
               allNodes={allNodes}
+              setAllNodes={setAllNodes}
               activeId={activeId}
               activeNodes={activeNodes}
               selectedNode={selectedNode}
@@ -594,13 +583,10 @@ const AppContent = () => {
               onNodeFocus={setFocusNodeId}
 
               workspaces={workspaces}
-              setAllNodes={setAllNodes}
 
               selectedNodeIdsByWorkspace={selectedNodeIdsByWorkspace}
               setSelectedNodeIdsByWorkspace={setSelectedNodeIdsByWorkspace}
               renameNodeRequest={renameNodeRequest}
-              chatPanelOpen={chatPanelOpen}
-              setChatPanelOpen={setChatPanelOpen}
               onExpand={enterChatView}
             />
           </PulseRouterView>

--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -1,198 +1,18 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'wouter';
 import './App.css';
-import { Canvas } from './components/Canvas';
 import { AppShellProvider, useAppShell } from './components/AppShellProvider';
-import { ChatPage, ChatPanel } from './components/chat';
-import { ReferenceDrawer } from './components/ReferenceDrawer';
+import { ChatPage } from './components/chat';
 import { Sidebar } from './components/Sidebar';
-import { useWorkspaces, WorkspaceEntry } from './hooks/useWorkspaces';
+import { Workbench, useWorkbenchState } from './components/Workbench';
+import { useWorkspaces } from './hooks/useWorkspaces';
 import { parseCanvasLocation } from './utils/canvasLinks';
-import type { CanvasNode } from './types';
-import type { CanvasNodeRenameRequest } from './types/ui-interaction';
 import { PulseRouter, PulseRouterView } from './components/router';
-
-const DEFAULT_CHAT_WIDTH = 420;
-const MIN_CHAT_WIDTH = 280;
-const MAX_CHAT_WIDTH = 600;
 
 const ROUTE_CANVAS = '/';
 const ROUTE_CHAT = '/chat';
 
 type ActiveView = 'canvas' | 'chat';
-
-interface WorkbenchProps {
-  allNodes: Record<string, CanvasNode[]>
-  activeId: string;
-  activeNodes: CanvasNode[];
-  selectedNode: CanvasNode | undefined;
-  deleteNodeId: string | undefined;
-  focusNodeId: string | undefined;
-
-  onFocusComplete: () => void;
-  onDeleteComplete: () => void;
-  onRenameComplete: () => void;
-
-  onNodeFocus: (nodeId: string) => void;
-
-  workspaces: WorkspaceEntry[];
-  setAllNodes: (value: React.SetStateAction<Record<string, CanvasNode[]>>) => void;
-
-  selectedNodeIdsByWorkspace: Record<string, string[]>;
-  setSelectedNodeIdsByWorkspace: React.Dispatch<React.SetStateAction<Record<string, string[]>>>;
-  renameNodeRequest: CanvasNodeRenameRequest | undefined;
-
-  onExpand: () => void;
-}
-
-const Workbench: React.FC<WorkbenchProps> = (props) => {
-
-
-  const { allNodes, activeId, focusNodeId, activeNodes = [], selectedNode, onNodeFocus, workspaces, setAllNodes, setSelectedNodeIdsByWorkspace } = props;
-  const [chatPanelOpen, setChatPanelOpen] = useState(false);
-  const [referenceDrawerOpen, setReferenceDrawerOpen] = useState(false);
-  const [referenceNodeIdByWorkspace, setReferenceNodeIdByWorkspace] = useState<Record<string, string | undefined>>({});
-  const [chatWidth, setChatWidth] = useState(DEFAULT_CHAT_WIDTH);
-
-  const referenceNodeId = referenceNodeIdByWorkspace[activeId];
-
-  const referenceNode = referenceNodeId
-    ? activeNodes.find((node) => node.id === referenceNodeId)
-    : undefined;
-
-  const clearReferenceNode = useCallback(() => {
-    setReferenceNodeIdByWorkspace((prev) => ({
-      ...prev,
-      [activeId]: undefined,
-    }));
-  }, [activeId]);
-
-  const handleFocusReferenceNode = useCallback((nodeId: string) => {
-    onNodeFocus(nodeId);
-  }, []);
-
-  const handleNodesChange = useCallback((canvasId: string, nodes: CanvasNode[]) => {
-    setAllNodes((prev) => {
-      if (prev[canvasId] === nodes) return prev;
-      return { ...prev, [canvasId]: nodes };
-    });
-  }, []);
-
-  useEffect(() => {
-    if (!referenceNodeId) return;
-    if (activeNodes.some((node) => node.id === referenceNodeId)) return;
-    setReferenceNodeIdByWorkspace((prev) => ({
-      ...prev,
-      [activeId]: undefined,
-    }));
-  }, [activeId, activeNodes, referenceNodeId]);
-
-  const pinReferenceNode = useCallback((nodeId: string) => {
-    setReferenceNodeIdByWorkspace((prev) => ({
-      ...prev,
-      [activeId]: nodeId,
-    }));
-    setReferenceDrawerOpen(true);
-  }, [activeId]);
-
-  const handleSelectionChange = useCallback((canvasId: string, selectedNodeIds: string[]) => {
-    setSelectedNodeIdsByWorkspace((prev) => {
-      const existing = prev[canvasId] ?? [];
-      if (
-        existing.length === selectedNodeIds.length
-        && existing.every((id, index) => id === selectedNodeIds[index])
-      ) {
-        return prev;
-      }
-      return { ...prev, [canvasId]: selectedNodeIds };
-    });
-  }, []);
-
-  const resizing = useRef(false);
-
-  const handleResizeStart = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    resizing.current = true;
-    const startX = e.clientX;
-    const startWidth = chatWidth;
-
-    const onMouseMove = (ev: MouseEvent) => {
-      const delta = startX - ev.clientX;
-      const newWidth = Math.min(MAX_CHAT_WIDTH, Math.max(MIN_CHAT_WIDTH, startWidth + delta));
-      setChatWidth(newWidth);
-    };
-
-    const onMouseUp = () => {
-      resizing.current = false;
-      document.removeEventListener('mousemove', onMouseMove);
-      document.removeEventListener('mouseup', onMouseUp);
-      document.body.style.cursor = '';
-      document.body.style.userSelect = '';
-    };
-
-    document.body.style.cursor = 'col-resize';
-    document.body.style.userSelect = 'none';
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
-  }, [chatWidth]);
-
-  return (
-    <>
-      <ReferenceDrawer
-        open={referenceDrawerOpen}
-        referenceNode={referenceNode}
-        selectedNode={selectedNode}
-        onOpenChange={setReferenceDrawerOpen}
-        onClear={clearReferenceNode}
-        onFocusNode={handleFocusReferenceNode}
-      />
-      <div className="canvas-viewport">
-        {workspaces
-          .filter((ws) => ws.id === activeId)
-          .map((ws) => (
-            <Canvas
-              key={ws.id}
-              canvasId={ws.id}
-              canvasName={ws.name}
-              rootFolder={ws.rootFolder}
-              onNodesChange={handleNodesChange}
-              onSelectionChange={handleSelectionChange}
-              focusNodeId={ws.id === activeId ? focusNodeId : undefined}
-              onFocusComplete={props.onFocusComplete}
-              deleteNodeId={ws.id === activeId ? props.deleteNodeId : undefined}
-              onDeleteComplete={props.onDeleteComplete}
-              renameRequest={ws.id === props.renameNodeRequest?.workspaceId ? props.renameNodeRequest : undefined}
-              onRenameComplete={props.onRenameComplete}
-              chatPanelOpen={chatPanelOpen}
-              onChatToggle={() => setChatPanelOpen((prev) => !prev)}
-              referenceDrawerOpen={referenceDrawerOpen}
-              onReferenceToggle={() => setReferenceDrawerOpen((prev) => !prev)}
-              onPinReferenceNode={pinReferenceNode}
-            />
-          ))}
-      </div>
-      {workspaces.map((ws) => (
-        <div
-          key={ws.id}
-          className={`chat-panel-wrapper${chatPanelOpen && ws.id === activeId ? ' chat-panel-wrapper--open' : ''}`}
-          style={ws.id !== activeId ? { display: 'none' } : chatPanelOpen ? { width: chatWidth } : undefined}
-        >
-          <ChatPanel
-            workspaceId={ws.id}
-            allWorkspaces={workspaces}
-            nodes={allNodes[ws.id] || []}
-            selectedNodeIds={props.selectedNodeIdsByWorkspace[ws.id] || []}
-            rootFolder={ws.rootFolder}
-            onClose={() => setChatPanelOpen(false)}
-            onResizeStart={handleResizeStart}
-            onNodeFocus={props.onNodeFocus}
-            onExpand={props.onExpand}
-          />
-        </div>
-      ))}
-    </>
-  );
-}
 
 const AppContent = () => {
   const [location, setLocation] = useLocation();
@@ -207,45 +27,6 @@ const AppContent = () => {
 
   const [sidebarCollapsed, setSidebarCollapsed] = useState(true);
 
-
-  const [allNodes, setAllNodes] = useState<Record<string, CanvasNode[]>>({});
-  const [selectedNodeIdsByWorkspace, setSelectedNodeIdsByWorkspace] = useState<Record<string, string[]>>({});
-
-  const [focusNodeId, setFocusNodeId] = useState<string | undefined>();
-  const [deleteNodeId, setDeleteNodeId] = useState<string | undefined>();
-  const [renameNodeRequest, setRenameNodeRequest] = useState<CanvasNodeRenameRequest | undefined>();
-
-  const allNodesRef = useRef(allNodes);
-  allNodesRef.current = allNodes;
-
-  const ensureWorkspaceNodesLoaded = useCallback((workspaceId: string) => {
-    if (allNodesRef.current[workspaceId]) return;
-    const api = window.canvasWorkspace?.store;
-    if (!api) return;
-    void api.load(workspaceId).then((result) => {
-      if (!result.ok || !result.data) return;
-      const nodes = Array.isArray(result.data.nodes) ? result.data.nodes : [];
-      setAllNodes((prev) => {
-        if (prev[workspaceId]) return prev;
-        return { ...prev, [workspaceId]: nodes };
-      });
-    });
-  }, []);
-
-
-
-  const handleFocusComplete = useCallback(() => {
-    setFocusNodeId(undefined);
-  }, []);
-
-  const handleDeleteComplete = useCallback(() => {
-    setDeleteNodeId(undefined);
-  }, []);
-
-  const handleRenameComplete = useCallback(() => {
-    setRenameNodeRequest(undefined);
-  }, []);
-
   const {
     workspaces,
     folders,
@@ -254,7 +35,6 @@ const AppContent = () => {
     createWorkspace,
     renameWorkspace,
     deleteWorkspace,
-    setRootFolder,
     importWorkspace,
     createFolder,
     renameFolder,
@@ -263,6 +43,17 @@ const AppContent = () => {
     moveWorkspace,
     reorderFolder,
   } = useWorkspaces();
+
+  const workbench = useWorkbenchState({ activeWorkspaceId: activeId });
+  const {
+    activeNodes,
+    ensureWorkspaceNodesLoaded,
+    getWorkspaceNodes,
+    requestNodeFocus,
+    requestActiveNodeFocus,
+    requestActiveNodeDelete,
+    requestActiveNodeRename,
+  } = workbench;
 
   useEffect(() => {
     if (!routeQuery) return;
@@ -276,10 +67,10 @@ const AppContent = () => {
       selectWorkspace(targetWorkspaceId);
     }
     if (targetNodeId) {
-      setFocusNodeId(targetNodeId);
+      requestNodeFocus(targetWorkspaceId, targetNodeId);
     }
     setLocation(ROUTE_CANVAS);
-  }, [routeQuery, routeParams, activeId, workspaces, selectWorkspace, setLocation]);
+  }, [routeQuery, routeParams, activeId, workspaces, selectWorkspace, requestNodeFocus, setLocation]);
 
   const enterChatView = useCallback(() => {
     setLocation(ROUTE_CHAT);
@@ -478,10 +269,6 @@ const AppContent = () => {
     });
   }, [folders, confirm, deleteFolder, notify]);
 
-  const handleNodeRename = useCallback((nodeId: string, title: string) => {
-    setRenameNodeRequest({ workspaceId: activeId, nodeId, title });
-  }, [activeId]);
-
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement | null;
@@ -519,21 +306,17 @@ const AppContent = () => {
   }, [activeView, isOverlayOpen, openShortcuts, setLocation]);
 
 
-  const handleNodeFocusFromChatPage = useCallback((nodeId: string) => {
-    setFocusNodeId(nodeId);
+  const getWorkspaceRootFolder = useCallback((workspaceId: string) => {
+    return workspaces.find((ws) => ws.id === workspaceId)?.rootFolder;
+  }, [workspaces]);
+
+  const handleNodeFocusFromChatPage = useCallback((workspaceId: string, nodeId: string) => {
+    if (activeId !== workspaceId) {
+      selectWorkspace(workspaceId);
+    }
+    requestNodeFocus(workspaceId, nodeId);
     setLocation(ROUTE_CANVAS);
-  }, [setLocation]);
-
-
-
-  const activeNodes = allNodes[activeId] || [];
-  const selectedNodeIds = selectedNodeIdsByWorkspace[activeId] || [];
-  const selectedNode = selectedNodeIds.length === 1
-    ? activeNodes.find((node) => node.id === selectedNodeIds[0])
-    : undefined;
-
-
-  const activeWorkspace = workspaces.find((ws) => ws.id === activeId);
+  }, [activeId, selectWorkspace, requestNodeFocus, setLocation]);
 
   return (
     <div className="app">
@@ -550,17 +333,16 @@ const AppContent = () => {
           onDelete={handleDeleteWorkspace}
           onExport={handleExportWorkspace}
           onImport={handleImportWorkspace}
-          onSetRootFolder={setRootFolder}
           onCreateFolder={handleCreateFolder}
           onRenameFolder={handleRenameFolder}
           onDeleteFolder={handleDeleteFolder}
           onToggleFolder={toggleFolder}
           onMoveWorkspace={moveWorkspace}
           onReorderFolder={reorderFolder}
-          activeNodes={allNodes[activeId] || []}
-          onNodeFocus={setFocusNodeId}
-          onNodeDelete={setDeleteNodeId}
-          onNodeRename={handleNodeRename}
+          activeNodes={activeNodes}
+          onNodeFocus={requestActiveNodeFocus}
+          onNodeDelete={requestActiveNodeDelete}
+          onNodeRename={requestActiveNodeRename}
           activeView={activeView}
           onEnterChat={enterChatView}
           onExitChat={exitChatView}
@@ -568,34 +350,18 @@ const AppContent = () => {
         <PulseRouter<ActiveView> activeKey={activeView}>
           <PulseRouterView name='canvas'>
             <Workbench
-              allNodes={allNodes}
-              setAllNodes={setAllNodes}
-              activeId={activeId}
-              activeNodes={activeNodes}
-              selectedNode={selectedNode}
-              deleteNodeId={deleteNodeId}
-              focusNodeId={focusNodeId}
-
-              onFocusComplete={handleFocusComplete}
-              onDeleteComplete={handleDeleteComplete}
-              onRenameComplete={handleRenameComplete}
-
-              onNodeFocus={setFocusNodeId}
-
+              activeWorkspaceId={activeId}
               workspaces={workspaces}
-
-              selectedNodeIdsByWorkspace={selectedNodeIdsByWorkspace}
-              setSelectedNodeIdsByWorkspace={setSelectedNodeIdsByWorkspace}
-              renameNodeRequest={renameNodeRequest}
-              onExpand={enterChatView}
+              controller={workbench}
             />
           </PulseRouterView>
           <PulseRouterView name="chat">
             <ChatPage
               initialWorkspaceId={activeId}
               allWorkspaces={workspaces}
-              nodes={allNodes[activeId] || []}
-              rootFolder={activeWorkspace?.rootFolder}
+              getWorkspaceNodes={getWorkspaceNodes}
+              getWorkspaceRootFolder={getWorkspaceRootFolder}
+              onWorkspaceContextRequest={ensureWorkspaceNodesLoaded}
               onExit={exitChatView}
               onNodeFocus={handleNodeFocusFromChatPage}
             />

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
@@ -25,7 +25,6 @@ interface Props {
   onDelete: (id: string) => void;
   onExport: (id: string) => void;
   onImport: () => void;
-  onSetRootFolder: (id: string, folderPath: string) => void;
   onCreateFolder: (name: string) => void;
   onRenameFolder: (id: string, name: string) => void;
   onDeleteFolder: (id: string) => void;

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
@@ -1,0 +1,163 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Canvas } from '../Canvas';
+import { ChatPanel } from '../chat';
+import { ReferenceDrawer } from '../ReferenceDrawer';
+import type { WorkspaceEntry } from '../../hooks/useWorkspaces';
+import type { WorkbenchController } from './useWorkbenchState';
+
+export { useWorkbenchState } from './useWorkbenchState';
+export type { WorkbenchController } from './useWorkbenchState';
+
+const DEFAULT_CHAT_WIDTH = 420;
+const MIN_CHAT_WIDTH = 280;
+const MAX_CHAT_WIDTH = 600;
+
+interface WorkbenchProps {
+  activeWorkspaceId: string;
+  workspaces: WorkspaceEntry[];
+  controller: WorkbenchController;
+}
+
+export const Workbench: React.FC<WorkbenchProps> = ({
+  activeWorkspaceId,
+  workspaces,
+  controller,
+}) => {
+  const {
+    allNodes,
+    activeNodes,
+    activeSelectedNode,
+    selectedNodeIdsByWorkspace,
+    focusRequest,
+    deleteRequest,
+    renameRequest,
+    handleNodesChange,
+    handleSelectionChange,
+    requestNodeFocus,
+    clearFocusRequest,
+    clearDeleteRequest,
+    clearRenameRequest,
+  } = controller;
+
+  const [chatPanelOpen, setChatPanelOpen] = useState(false);
+  const [referenceDrawerOpen, setReferenceDrawerOpen] = useState(false);
+  const [referenceNodeIdByWorkspace, setReferenceNodeIdByWorkspace] = useState<Record<string, string | undefined>>({});
+  const [chatWidth, setChatWidth] = useState(DEFAULT_CHAT_WIDTH);
+
+  const referenceNodeId = referenceNodeIdByWorkspace[activeWorkspaceId];
+  const referenceNode = referenceNodeId
+    ? activeNodes.find((node) => node.id === referenceNodeId)
+    : undefined;
+
+  const clearReferenceNode = useCallback(() => {
+    setReferenceNodeIdByWorkspace((prev) => ({
+      ...prev,
+      [activeWorkspaceId]: undefined,
+    }));
+  }, [activeWorkspaceId]);
+
+  const handleFocusReferenceNode = useCallback((nodeId: string) => {
+    requestNodeFocus(activeWorkspaceId, nodeId);
+  }, [activeWorkspaceId, requestNodeFocus]);
+
+  useEffect(() => {
+    if (!referenceNodeId) return;
+    if (activeNodes.some((node) => node.id === referenceNodeId)) return;
+    setReferenceNodeIdByWorkspace((prev) => ({
+      ...prev,
+      [activeWorkspaceId]: undefined,
+    }));
+  }, [activeWorkspaceId, activeNodes, referenceNodeId]);
+
+  const pinReferenceNode = useCallback((nodeId: string) => {
+    setReferenceNodeIdByWorkspace((prev) => ({
+      ...prev,
+      [activeWorkspaceId]: nodeId,
+    }));
+    setReferenceDrawerOpen(true);
+  }, [activeWorkspaceId]);
+
+  const resizing = useRef(false);
+
+  const handleResizeStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    resizing.current = true;
+    const startX = e.clientX;
+    const startWidth = chatWidth;
+
+    const onMouseMove = (ev: MouseEvent) => {
+      const delta = startX - ev.clientX;
+      const newWidth = Math.min(MAX_CHAT_WIDTH, Math.max(MIN_CHAT_WIDTH, startWidth + delta));
+      setChatWidth(newWidth);
+    };
+
+    const onMouseUp = () => {
+      resizing.current = false;
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  }, [chatWidth]);
+
+  return (
+    <>
+      <ReferenceDrawer
+        open={referenceDrawerOpen}
+        referenceNode={referenceNode}
+        selectedNode={activeSelectedNode}
+        onOpenChange={setReferenceDrawerOpen}
+        onClear={clearReferenceNode}
+        onFocusNode={handleFocusReferenceNode}
+      />
+      <div className="canvas-viewport">
+        {workspaces
+          .filter((ws) => ws.id === activeWorkspaceId)
+          .map((ws) => (
+            <Canvas
+              key={ws.id}
+              canvasId={ws.id}
+              canvasName={ws.name}
+              rootFolder={ws.rootFolder}
+              onNodesChange={handleNodesChange}
+              onSelectionChange={handleSelectionChange}
+              focusNodeId={ws.id === focusRequest?.workspaceId ? focusRequest.nodeId : undefined}
+              onFocusComplete={clearFocusRequest}
+              deleteNodeId={ws.id === deleteRequest?.workspaceId ? deleteRequest.nodeId : undefined}
+              onDeleteComplete={clearDeleteRequest}
+              renameRequest={ws.id === renameRequest?.workspaceId ? renameRequest : undefined}
+              onRenameComplete={clearRenameRequest}
+              chatPanelOpen={chatPanelOpen}
+              onChatToggle={() => setChatPanelOpen((prev) => !prev)}
+              referenceDrawerOpen={referenceDrawerOpen}
+              onReferenceToggle={() => setReferenceDrawerOpen((prev) => !prev)}
+              onPinReferenceNode={pinReferenceNode}
+            />
+          ))}
+      </div>
+      {workspaces.map((ws) => (
+        <div
+          key={ws.id}
+          className={`chat-panel-wrapper${chatPanelOpen && ws.id === activeWorkspaceId ? ' chat-panel-wrapper--open' : ''}`}
+          style={ws.id !== activeWorkspaceId ? { display: 'none' } : chatPanelOpen ? { width: chatWidth } : undefined}
+        >
+          <ChatPanel
+            workspaceId={ws.id}
+            allWorkspaces={workspaces}
+            nodes={allNodes[ws.id] || []}
+            selectedNodeIds={selectedNodeIdsByWorkspace[ws.id] || []}
+            rootFolder={ws.rootFolder}
+            onClose={() => setChatPanelOpen(false)}
+            onResizeStart={handleResizeStart}
+            onNodeFocus={(nodeId) => requestNodeFocus(ws.id, nodeId)}
+          />
+        </div>
+      ))}
+    </>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/useWorkbenchState.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/useWorkbenchState.ts
@@ -1,0 +1,154 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import type { CanvasNode } from '../../types';
+import type { CanvasNodeRenameRequest } from '../../types/ui-interaction';
+
+interface WorkbenchNodeRequest {
+  workspaceId: string;
+  nodeId: string;
+}
+
+interface UseWorkbenchStateOptions {
+  activeWorkspaceId: string;
+}
+
+export interface WorkbenchController {
+  allNodes: Record<string, CanvasNode[]>;
+  activeNodes: CanvasNode[];
+  activeSelectedNode: CanvasNode | undefined;
+  selectedNodeIdsByWorkspace: Record<string, string[]>;
+  focusRequest: WorkbenchNodeRequest | undefined;
+  deleteRequest: WorkbenchNodeRequest | undefined;
+  renameRequest: CanvasNodeRenameRequest | undefined;
+  ensureWorkspaceNodesLoaded: (workspaceId: string) => void;
+  getWorkspaceNodes: (workspaceId: string) => CanvasNode[];
+  handleNodesChange: (workspaceId: string, nodes: CanvasNode[]) => void;
+  handleSelectionChange: (workspaceId: string, selectedNodeIds: string[]) => void;
+  requestNodeFocus: (workspaceId: string, nodeId: string) => void;
+  requestActiveNodeFocus: (nodeId: string) => void;
+  requestActiveNodeDelete: (nodeId: string) => void;
+  requestActiveNodeRename: (nodeId: string, title: string) => void;
+  clearFocusRequest: () => void;
+  clearDeleteRequest: () => void;
+  clearRenameRequest: () => void;
+}
+
+const EMPTY_NODES: CanvasNode[] = [];
+const EMPTY_NODE_IDS: string[] = [];
+
+const hasWorkspaceSnapshot = (
+  snapshots: Record<string, CanvasNode[]>,
+  workspaceId: string,
+) => Object.prototype.hasOwnProperty.call(snapshots, workspaceId);
+
+export function useWorkbenchState({
+  activeWorkspaceId,
+}: UseWorkbenchStateOptions): WorkbenchController {
+  const [allNodes, setAllNodes] = useState<Record<string, CanvasNode[]>>({});
+  const [selectedNodeIdsByWorkspace, setSelectedNodeIdsByWorkspace] = useState<Record<string, string[]>>({});
+  const [focusRequest, setFocusRequest] = useState<WorkbenchNodeRequest | undefined>();
+  const [deleteRequest, setDeleteRequest] = useState<WorkbenchNodeRequest | undefined>();
+  const [renameRequest, setRenameRequest] = useState<CanvasNodeRenameRequest | undefined>();
+
+  const allNodesRef = useRef(allNodes);
+  allNodesRef.current = allNodes;
+
+  const ensureWorkspaceNodesLoaded = useCallback((workspaceId: string) => {
+    if (hasWorkspaceSnapshot(allNodesRef.current, workspaceId)) return;
+    const api = window.canvasWorkspace?.store;
+    if (!api) return;
+
+    void api.load(workspaceId).then((result) => {
+      if (!result.ok || !result.data) return;
+      const nodes = Array.isArray(result.data.nodes) ? result.data.nodes : [];
+      setAllNodes((prev) => {
+        if (hasWorkspaceSnapshot(prev, workspaceId)) return prev;
+        return { ...prev, [workspaceId]: nodes };
+      });
+    });
+  }, []);
+
+  const getWorkspaceNodes = useCallback((workspaceId: string) => {
+    return allNodesRef.current[workspaceId] ?? EMPTY_NODES;
+  }, []);
+
+  const handleNodesChange = useCallback((workspaceId: string, nodes: CanvasNode[]) => {
+    setAllNodes((prev) => {
+      if (prev[workspaceId] === nodes) return prev;
+      return { ...prev, [workspaceId]: nodes };
+    });
+  }, []);
+
+  const handleSelectionChange = useCallback((workspaceId: string, selectedNodeIds: string[]) => {
+    setSelectedNodeIdsByWorkspace((prev) => {
+      const existing = prev[workspaceId] ?? EMPTY_NODE_IDS;
+      if (
+        existing.length === selectedNodeIds.length
+        && existing.every((id, index) => id === selectedNodeIds[index])
+      ) {
+        return prev;
+      }
+      return { ...prev, [workspaceId]: selectedNodeIds };
+    });
+  }, []);
+
+  const requestNodeFocus = useCallback((workspaceId: string, nodeId: string) => {
+    ensureWorkspaceNodesLoaded(workspaceId);
+    setFocusRequest({ workspaceId, nodeId });
+  }, [ensureWorkspaceNodesLoaded]);
+
+  const requestActiveNodeFocus = useCallback((nodeId: string) => {
+    requestNodeFocus(activeWorkspaceId, nodeId);
+  }, [activeWorkspaceId, requestNodeFocus]);
+
+  const requestActiveNodeDelete = useCallback((nodeId: string) => {
+    setDeleteRequest({ workspaceId: activeWorkspaceId, nodeId });
+  }, [activeWorkspaceId]);
+
+  const requestNodeRename = useCallback((workspaceId: string, nodeId: string, title: string) => {
+    setRenameRequest({ workspaceId, nodeId, title });
+  }, []);
+
+  const requestActiveNodeRename = useCallback((nodeId: string, title: string) => {
+    requestNodeRename(activeWorkspaceId, nodeId, title);
+  }, [activeWorkspaceId, requestNodeRename]);
+
+  const clearFocusRequest = useCallback(() => {
+    setFocusRequest(undefined);
+  }, []);
+
+  const clearDeleteRequest = useCallback(() => {
+    setDeleteRequest(undefined);
+  }, []);
+
+  const clearRenameRequest = useCallback(() => {
+    setRenameRequest(undefined);
+  }, []);
+
+  const activeNodes = allNodes[activeWorkspaceId] ?? EMPTY_NODES;
+  const activeSelectedNodeIds = selectedNodeIdsByWorkspace[activeWorkspaceId] ?? EMPTY_NODE_IDS;
+  const activeSelectedNode = useMemo(() => {
+    if (activeSelectedNodeIds.length !== 1) return undefined;
+    return activeNodes.find((node) => node.id === activeSelectedNodeIds[0]);
+  }, [activeNodes, activeSelectedNodeIds]);
+
+  return {
+    allNodes,
+    activeNodes,
+    activeSelectedNode,
+    selectedNodeIdsByWorkspace,
+    focusRequest,
+    deleteRequest,
+    renameRequest,
+    ensureWorkspaceNodesLoaded,
+    getWorkspaceNodes,
+    handleNodesChange,
+    handleSelectionChange,
+    requestNodeFocus,
+    requestActiveNodeFocus,
+    requestActiveNodeDelete,
+    requestActiveNodeRename,
+    clearFocusRequest,
+    clearDeleteRequest,
+    clearRenameRequest,
+  };
+}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.tsx
@@ -14,10 +14,11 @@ interface ChatPageProps {
    */
   initialWorkspaceId: string;
   allWorkspaces: WorkspaceOption[];
-  nodes?: CanvasNode[];
-  rootFolder?: string;
+  getWorkspaceNodes?: (workspaceId: string) => CanvasNode[];
+  getWorkspaceRootFolder?: (workspaceId: string) => string | undefined;
+  onWorkspaceContextRequest?: (workspaceId: string) => void;
   onExit: () => void;
-  onNodeFocus?: (nodeId: string) => void;
+  onNodeFocus?: (workspaceId: string, nodeId: string) => void;
 }
 
 /**
@@ -38,8 +39,9 @@ interface ChatPageProps {
 export const ChatPage = ({
   initialWorkspaceId,
   allWorkspaces,
-  nodes,
-  rootFolder,
+  getWorkspaceNodes,
+  getWorkspaceRootFolder,
+  onWorkspaceContextRequest,
   onExit,
   onNodeFocus,
 }: ChatPageProps) => {
@@ -68,6 +70,9 @@ export const ChatPage = ({
     setRailCollapsed((v) => !v);
   }, []);
 
+  const nodes = getWorkspaceNodes?.(workspaceId);
+  const rootFolder = getWorkspaceRootFolder?.(workspaceId);
+
   return (
     <ChatPageBody
       key={workspaceId}
@@ -76,6 +81,7 @@ export const ChatPage = ({
       pendingSessionId={pendingSessionId}
       onSessionConsumed={handleSessionConsumed}
       onSelectSession={handleSelectSession}
+      onWorkspaceContextRequest={onWorkspaceContextRequest}
       allWorkspaces={allWorkspaces}
       nodes={nodes}
       rootFolder={rootFolder}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageBody.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageBody.tsx
@@ -25,11 +25,12 @@ export interface ChatPageBodyProps {
   pendingSessionId: string | null;
   onSessionConsumed: () => void;
   onSelectSession: (session: UnifiedSession) => void;
+  onWorkspaceContextRequest?: (workspaceId: string) => void;
   allWorkspaces: WorkspaceOption[];
   nodes?: CanvasNode[];
   rootFolder?: string;
   onExit: () => void;
-  onNodeFocus?: (nodeId: string) => void;
+  onNodeFocus?: (workspaceId: string, nodeId: string) => void;
   railCollapsed: boolean;
   onToggleRail: () => void;
 }
@@ -40,6 +41,7 @@ export const ChatPageBody = ({
   pendingSessionId,
   onSessionConsumed,
   onSelectSession,
+  onWorkspaceContextRequest,
   allWorkspaces,
   nodes,
   rootFolder,
@@ -109,6 +111,10 @@ export const ChatPageBody = ({
     onSubmit: sendMessage,
   });
 
+  useEffect(() => {
+    onWorkspaceContextRequest?.(workspaceId);
+  }, [onWorkspaceContextRequest, workspaceId]);
+
   // Load the pending session whenever it's set. This uniformly handles both
   // cases:
   //   - Cross-workspace mount: body was just created with a non-null
@@ -137,9 +143,9 @@ export const ChatPageBody = ({
 
   // Clicking a mention chip should jump back to the canvas and focus the node.
   const handleNodeFocus = useCallback((nodeId: string) => {
-    onNodeFocus?.(nodeId);
+    onNodeFocus?.(workspaceId, nodeId);
     onExit();
-  }, [onExit, onNodeFocus]);
+  }, [onExit, onNodeFocus, workspaceId]);
 
   // Merge sessions from the current workspace with sessions from every other
   // workspace into a single list, sorted by date (newest first).

--- a/apps/canvas-workspace/src/renderer/src/components/chat/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/types.ts
@@ -15,7 +15,6 @@ export interface ChatPanelProps {
   onClose: () => void;
   onResizeStart?: (e: MouseEvent) => void;
   onNodeFocus?: (nodeId: string) => void;
-  onExpand?: () => void;
 }
 
 export interface OtherWorkspaceSession extends AgentSessionInfo {

--- a/apps/canvas-workspace/src/renderer/src/components/router/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/router/index.tsx
@@ -1,0 +1,61 @@
+import React, { useMemo } from "react";
+
+interface PulseRouterContextValue {
+  activeKey: string | undefined;
+}
+
+const PulseRouterContext = React.createContext<PulseRouterContextValue>({
+  activeKey: undefined
+})
+
+const usePulseRouterContext = () => React.useContext(PulseRouterContext);
+
+interface PulseRouterProps<T extends string> {
+  activeKey: T;
+  children: React.ReactNode;
+}
+
+export const PulseRouter = <T extends string>(props: PulseRouterProps<T>) => {
+  const {
+    activeKey,
+    children
+  } = props;
+
+  const contextValue = useMemo(() => {
+    return {
+      activeKey,
+    };
+  }, [activeKey]);
+
+
+  return (
+    <PulseRouterContext.Provider value={contextValue}>
+      {children}
+    </PulseRouterContext.Provider>
+  );
+}
+
+interface PulseRouterViewProps {
+  name: string;
+  children: React.ReactNode;
+
+  keepAlive?: boolean;
+}
+
+export const PulseRouterView: React.FC<PulseRouterViewProps> = (props) => {
+  const { name, children, keepAlive } = props;
+
+  const { activeKey } = usePulseRouterContext();
+
+  if (activeKey === null) {
+    throw new Error('RouterView must be used inside a <Router>');
+  }
+
+  const isActive = activeKey === name;
+
+  if (keepAlive) {
+    return <div style={{ display: isActive ? 'contents' : 'none' }}>{children}</div>;
+  }
+
+  return isActive ? children : null;
+}


### PR DESCRIPTION
## Summary
- Extract Workbench from App.tsx into components/Workbench
- Move canvas node cache, selection, and node action requests into useWorkbenchState
- Keep ChatPage context aligned with its current workspace when sessions switch

## Tests
- pnpm --filter canvas-workspace typecheck:renderer
- git diff --check