### PR TITLE
feat: add canvas group controls

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
@@ -81,6 +81,7 @@ interface CanvasSurfaceProps {
   onSelect: (id: string, mods?: { shift?: boolean; meta?: boolean }) => void;
   onFocus: (node: CanvasNode) => void;
   onReference?: (nodeId: string) => void;
+  onUngroupSelectedGroups?: () => void;
   onSelectEdge: (id: string | null) => void;
   onEdgeHandleMouseDown: (
     edgeId: string,
@@ -130,6 +131,7 @@ export const CanvasSurface = ({
   onSelect,
   onFocus,
   onReference,
+  onUngroupSelectedGroups,
   onSelectEdge,
   onEdgeHandleMouseDown,
   onEdgeBodyMouseDown,
@@ -185,6 +187,7 @@ export const CanvasSurface = ({
           onSelect={onSelect}
           onFocus={onFocus}
           onReference={onReference}
+          onUngroupSelectedGroups={onUngroupSelectedGroups}
         />
       ))}
     <CanvasEdgesLayer
@@ -229,6 +232,7 @@ export const CanvasSurface = ({
           onSelect={onSelect}
           onFocus={onFocus}
           onReference={onReference}
+          onUngroupSelectedGroups={onUngroupSelectedGroups}
         />
       ))}
     {shapeDraft && <ShapeDraftPreview draft={shapeDraft} />}

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -1188,6 +1188,7 @@ export const Canvas = ({
         onExportMindmapImage={handleExportMindmapImage}
         onFocus={handleNodeViewportFocus}
         onReference={onPinReferenceNode}
+        onUngroupSelectedGroups={ungroupSelectedNodes}
         onSelectEdge={(id) => {
           setSelectedEdgeId(id);
           if (id) setSelectedNodeIds([]);

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -493,6 +493,24 @@
   pointer-events: none;
 }
 
+.canvas-node--group::before {
+  content: "";
+  position: absolute;
+  inset: -6px;
+  border-radius: 12px;
+  pointer-events: auto;
+}
+
+.canvas-node--group:hover,
+.canvas-node--group.canvas-node--selected,
+.canvas-node--group.canvas-node--dragging {
+  cursor: grab;
+}
+
+.canvas-node--group.canvas-node--dragging {
+  cursor: grabbing;
+}
+
 .canvas-node--group .node-header {
   position: absolute;
   top: -28px;
@@ -543,6 +561,28 @@
 .canvas-node--group .node-header .node-close,
 .canvas-node--group .node-header .node-time-label {
   display: none;
+}
+
+.group-ungroup-button {
+  border: 0;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--group-color, #A594E0) 14%, transparent);
+  color: color-mix(in srgb, var(--group-color, #A594E0) 74%, #111111);
+  cursor: pointer;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  padding: 4px 7px;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.group-ungroup-button:hover {
+  background: color-mix(in srgb, var(--group-color, #A594E0) 24%, transparent);
+  color: color-mix(in srgb, var(--group-color, #A594E0) 86%, #111111);
+}
+
+.group-ungroup-button:active {
+  transform: translateY(1px);
 }
 
 .canvas-node--group .node-body {

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -50,6 +50,7 @@ interface Props {
   onSelect: (id: string, mods?: { shift?: boolean; meta?: boolean }) => void;
   onFocus: (node: CanvasNode) => void;
   onReference?: (nodeId: string) => void;
+  onUngroupSelectedGroups?: () => void;
   readOnly?: boolean;
 }
 
@@ -96,6 +97,7 @@ const CanvasNodeViewComponent = ({
   onSelect,
   onFocus,
   onReference,
+  onUngroupSelectedGroups,
   readOnly = false
 }: Props) => {
   const [isEditingTitle, setIsEditingTitle] = useState(false);
@@ -159,6 +161,15 @@ const CanvasNodeViewComponent = ({
       onReference?.(node.id);
     },
     [onReference, node.id, readOnly]
+  );
+
+  const handleUngroup = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (readOnly) return;
+      onUngroupSelectedGroups?.();
+    },
+    [onUngroupSelectedGroups, readOnly]
   );
 
   const handleNodeBodyMouseDown = useCallback((e: React.MouseEvent) => {
@@ -490,6 +501,17 @@ const CanvasNodeViewComponent = ({
           <span className="group-count-label">
             {groupDescendantCount}
           </span>
+        )}
+        {node.type === "group" && isSelected && !readOnly && onUngroupSelectedGroups && (
+          <button
+            className="group-ungroup-button"
+            type="button"
+            onClick={handleUngroup}
+            title="Ungroup selected group (⌘⇧G)"
+            aria-label="Ungroup selected group"
+          >
+            Ungroup
+          </button>
         )}
         {node.type === "agent" && agentStatus && agentStatus !== 'idle' && (
           <span className={`node-status-label node-status-label--${agentStatus}`}>


### PR DESCRIPTION
Improve group node discoverability and drag affordance in the canvas.

- Add an Ungroup button to the selected group header
- Wire the button to the existing ungroup selected groups action
- Expand group hit area around the border for easier hover/select/drag
- Show grab/grabbing cursors for group drag affordance

Validation:
- pnpm --filter canvas-workspace typecheck:renderer