### PR TITLE
feat(canvas-workspace): Ctrl/Cmd+F find-in-canvas bar

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
@@ -4,6 +4,8 @@ import { NodeContextMenu } from '../NodeContextMenu';
 import { FloatingToolbar } from '../FloatingToolbar';
 import { ZoomIndicator } from '../ZoomIndicator';
 import { CommandPalette, type PaletteCommand } from '../CommandPalette';
+import { SearchBar } from '../SearchBar';
+import type { UseCanvasSearchReturn } from '../../hooks/useCanvasSearch';
 import { CanvasEmptyHint } from '../CanvasEmptyHint';
 import { EdgeStylePanel } from '../EdgeStylePanel';
 import { EdgeLabel } from '../EdgeLabel';
@@ -38,6 +40,11 @@ interface CanvasOverlaysProps {
   paletteCommands: PaletteCommand[];
   onSearchSelect: (node: CanvasNode) => void;
   onCloseSearch: () => void;
+  /** Find-in-canvas (Ctrl/Cmd+F) state, owned by the parent so the
+   *  keyboard hook and the bar share one source of truth. */
+  findSearch: UseCanvasSearchReturn;
+  findNodesById: Map<string, CanvasNode>;
+  onFindMatchActivate: (node: CanvasNode) => void;
   /** Mousedown handler for the connect-mode overlay. Wired by the
    *  parent Canvas component to the edge interaction hook. */
   onConnectMouseDown?: (e: React.MouseEvent) => void;
@@ -87,6 +94,9 @@ export const CanvasOverlays = ({
   paletteCommands,
   onSearchSelect,
   onCloseSearch,
+  findSearch,
+  findNodesById,
+  onFindMatchActivate,
   onConnectMouseDown,
   shapeToolActive,
   onShapeMouseDown,
@@ -212,6 +222,14 @@ export const CanvasOverlays = ({
         commands={paletteCommands}
         onSelectNode={onSearchSelect}
         onClose={onCloseSearch}
+      />
+    )}
+
+    {findSearch.open && (
+      <SearchBar
+        search={findSearch}
+        nodesById={findNodesById}
+        onActivateMatch={onFindMatchActivate}
       />
     )}
   </>

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -7,6 +7,7 @@ import { useNodeResize, type ResizeEdge } from '../../hooks/useNodeResize';
 import { useCanvasContext } from '../../hooks/useCanvasContext';
 import { useCanvasFit } from '../../hooks/useCanvasFit';
 import { useCanvasKeyboard } from '../../hooks/useCanvasKeyboard';
+import { useCanvasSearch } from '../../hooks/useCanvasSearch';
 import { useCanvasImagePaste } from '../../hooks/useCanvasImagePaste';
 import { useEdgeInteraction } from '../../hooks/useEdgeInteraction';
 import { useShapeDraw } from '../../hooks/useShapeDraw';
@@ -385,13 +386,46 @@ export const Canvas = ({
     });
   }, [wrapNodesInFrame, selectedNodeIds, notify]);
 
+  const handleNodeViewportFocus = useCallback((node: CanvasNode) => {
+    setSelectedNodeIds([node.id]);
+    setHighlightedId(node.id);
+    // In focus mode the dedicated reframe effect handles the zoom with
+    // tighter padding/maxScale — calling handleFocusNode here too would
+    // produce a double reframe at different scales (visible jitter).
+    if (!focusModeActive) handleFocusNode(node);
+  }, [handleFocusNode, focusModeActive]);
+
+  // Ctrl/Cmd+F "find in canvas". Kept separate from the Cmd+K palette
+  // (searchOpen) because Find is iterative — the bar stays open while
+  // the user pages through matches. See useCanvasSearch for details.
+  const search = useCanvasSearch({ nodes });
+  const nodesById = useMemo(() => {
+    const m = new Map<string, CanvasNode>();
+    for (const n of nodes) m.set(n.id, n);
+    return m;
+  }, [nodes]);
+  const handleSearchMatchActivate = useCallback((node: CanvasNode) => {
+    // Reuse the existing viewport-focus pipeline so the camera pans
+    // and the node gets the brief highlight ring. The active match
+    // changes via next/prev or query edits — each transition focuses
+    // the canvas on that node.
+    handleNodeViewportFocus(node);
+  }, [handleNodeViewportFocus]);
+
   useCanvasKeyboard({
     undo, redo, nodes, selectedNodeIds, setSelectedNodeIds,
     selectedEdgeId, setSelectedEdgeId, removeEdge: requestRemoveEdge,
     duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, groupSelectedNodes, ungroupSelectedNodes,
     removeNodes: requestRemoveNodes,
     moveNodes, commitHistory,
-    searchOpen, setSearchOpen, contextMenu, setContextMenu,
+    searchOpen, setSearchOpen,
+    findOpen: search.open,
+    toggleFindBar: search.toggleBar,
+    closeFindBar: search.closeBar,
+    findNext: search.next,
+    findPrev: search.prev,
+    findHasMatches: search.matches.length > 0,
+    contextMenu, setContextMenu,
     setHighlightedId, handleFocusNode,
     focusModeEnabled: focusModeActive,
     canToggleFocusMode: focusModeAvailable,
@@ -417,15 +451,6 @@ export const Canvas = ({
       highlightTimerRef.current = setTimeout(() => setHighlightedId(null), 1500);
     }
   }, [highlightedId]);
-
-  const handleNodeViewportFocus = useCallback((node: CanvasNode) => {
-    setSelectedNodeIds([node.id]);
-    setHighlightedId(node.id);
-    // In focus mode the dedicated reframe effect handles the zoom with
-    // tighter padding/maxScale — calling handleFocusNode here too would
-    // produce a double reframe at different scales (visible jitter).
-    if (!focusModeActive) handleFocusNode(node);
-  }, [handleFocusNode, focusModeActive]);
 
   const handleSearchSelect = handleNodeViewportFocus;
 
@@ -1219,6 +1244,9 @@ export const Canvas = ({
         paletteCommands={paletteCommands}
         onSearchSelect={handleSearchSelect}
         onCloseSearch={() => setSearchOpen(false)}
+        findSearch={search}
+        findNodesById={nodesById}
+        onFindMatchActivate={handleSearchMatchActivate}
         onConnectMouseDown={handleConnectOverlayMouseDown}
         shapeToolActive={shapeToolActive}
         onShapeMouseDown={handleShapeOverlayMouseDown}

--- a/apps/canvas-workspace/src/renderer/src/components/SearchBar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/SearchBar/index.css
@@ -1,0 +1,165 @@
+/* Find-in-canvas bar — anchored top-center, narrower than CommandPalette
+ * so the canvas behind it stays visible while paging through matches. */
+
+.canvas-search-bar {
+  position: absolute;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 480px;
+  max-width: calc(100% - 32px);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md, 10px);
+  box-shadow: var(--shadow-float), 0 6px 24px rgba(0, 0, 0, 0.10);
+  z-index: 1500;
+  font-family: var(--font);
+  color: var(--text);
+  animation: searchBarFadeIn 0.12s ease;
+}
+
+@keyframes searchBarFadeIn {
+  from { opacity: 0; transform: translate(-50%, -4px); }
+  to   { opacity: 1; transform: translate(-50%, 0); }
+}
+
+.canvas-search-bar__row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+}
+
+.canvas-search-bar__icon {
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.canvas-search-bar__input {
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-size: 14px;
+  font-family: var(--font);
+  color: var(--text);
+  min-width: 0;
+}
+
+.canvas-search-bar__input::placeholder {
+  color: var(--text-muted);
+}
+
+.canvas-search-bar__counter {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  min-width: 44px;
+  text-align: right;
+  user-select: none;
+}
+
+.canvas-search-bar__counter--empty {
+  color: var(--danger, #d04848);
+}
+
+.canvas-search-bar__toggle,
+.canvas-search-bar__nav,
+.canvas-search-bar__close {
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: var(--radius-sm, 6px);
+  width: 26px;
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.1s ease, color 0.1s ease;
+}
+
+.canvas-search-bar__toggle:hover,
+.canvas-search-bar__nav:hover:not(:disabled),
+.canvas-search-bar__close:hover {
+  background: var(--surface-hover, rgba(0, 0, 0, 0.06));
+  color: var(--text);
+}
+
+.canvas-search-bar__toggle.is-active {
+  background: var(--accent-muted, rgba(80, 120, 220, 0.16));
+  color: var(--accent, #4a78dc);
+}
+
+.canvas-search-bar__nav:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.canvas-search-bar__close {
+  font-size: 18px;
+  line-height: 1;
+}
+
+.canvas-search-bar__results {
+  border-top: 1px solid var(--border-light, var(--border));
+  max-height: 280px;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.canvas-search-bar__result {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  cursor: pointer;
+  font-size: 12.5px;
+  line-height: 1.4;
+}
+
+.canvas-search-bar__result:hover {
+  background: var(--surface-hover, rgba(0, 0, 0, 0.04));
+}
+
+.canvas-search-bar__result.is-active {
+  background: var(--accent-muted, rgba(80, 120, 220, 0.16));
+}
+
+.canvas-search-bar__badge {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--surface-alt, rgba(0, 0, 0, 0.06));
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.canvas-search-bar__title {
+  font-weight: 500;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 0;
+  max-width: 180px;
+}
+
+.canvas-search-bar__snippet {
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+
+.canvas-search-bar__overflow {
+  padding: 6px 12px;
+  font-size: 11.5px;
+  color: var(--text-muted);
+  font-style: italic;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/SearchBar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/SearchBar/index.tsx
@@ -1,0 +1,191 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import './index.css';
+import type { CanvasNode } from '../../types';
+import type { UseCanvasSearchReturn } from '../../hooks/useCanvasSearch';
+
+interface Props {
+  search: UseCanvasSearchReturn;
+  /** Lookup by id so we can render node titles/types in result rows
+   *  without forcing the parent to re-pass the whole nodes array
+   *  alongside the search return. */
+  nodesById: Map<string, CanvasNode>;
+  /** Called whenever the active match changes (open, query, next/prev).
+   *  The Canvas wires this to its viewport-focus helper so the camera
+   *  follows the find cursor. */
+  onActivateMatch: (node: CanvasNode) => void;
+}
+
+/**
+ * Ctrl/Cmd+F "find in canvas" bar.
+ *
+ * UX intent:
+ *  - Stays open while the user pages through matches (Enter / Shift+Enter).
+ *  - Shows a "3 / 12" counter so users can tell whether to keep paging
+ *    or refine the query.
+ *  - Results list is collapsible — most users will use just the counter
+ *    + next/prev, but the list is there for cross-canvas surveying.
+ *  - Esc closes and returns focus to where the user came from
+ *    (handled by `useCanvasSearch.closeBar`).
+ *
+ * Why a separate overlay (vs. reusing CommandPalette):
+ *  - The palette dismisses on Enter — incompatible with iterative find.
+ *  - The bar is anchored top-center small, palette is modal large.
+ *  - Different shortcuts (Ctrl+F vs Ctrl+K) and different mental models.
+ */
+export const SearchBar = ({ search, nodesById, onActivateMatch }: Props) => {
+  const { query, setQuery, matches, activeIndex, setActiveIndex,
+    activeMatch, caseSensitive, setCaseSensitive, closeBar, next, prev } = search;
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  // When the active match changes, ask the canvas to focus it. We
+  // depend on `nodeId` (not the match object reference) so a query
+  // that yields a different match-for-the-same-node doesn't trigger
+  // a redundant camera nudge.
+  const activeNodeId = activeMatch?.nodeId ?? null;
+  useEffect(() => {
+    if (!activeNodeId) return;
+    const node = nodesById.get(activeNodeId);
+    if (node) onActivateMatch(node);
+    // onActivateMatch identity is intentionally not in the deps — the
+    // parent passes a fresh closure each render and we only want to
+    // run when the active match itself moves.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeNodeId]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        closeBar();
+        return;
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        if (e.shiftKey) prev();
+        else next();
+        return;
+      }
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        next();
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        prev();
+        return;
+      }
+    },
+    [closeBar, next, prev],
+  );
+
+  const counter = useMemo(() => {
+    if (!query.trim()) return '';
+    if (matches.length === 0) return '0 / 0';
+    return `${activeIndex + 1} / ${matches.length}`;
+  }, [query, activeIndex, matches.length]);
+
+  const empty = query.trim().length > 0 && matches.length === 0;
+
+  return (
+    <div
+      className="canvas-search-bar"
+      // Block bubbling so clicks on the bar don't deselect nodes or
+      // trigger canvas-level handlers behind it.
+      onMouseDown={(e) => e.stopPropagation()}
+      onClick={(e) => e.stopPropagation()}
+      onWheel={(e) => e.stopPropagation()}
+    >
+      <div className="canvas-search-bar__row">
+        <svg className="canvas-search-bar__icon" width="14" height="14" viewBox="0 0 16 16" fill="none">
+          <circle cx="7" cy="7" r="5" stroke="currentColor" strokeWidth="1.5" />
+          <path d="M11 11l3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        </svg>
+        <input
+          ref={inputRef}
+          type="text"
+          className="canvas-search-bar__input"
+          placeholder="Find in canvas…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          spellCheck={false}
+        />
+        <span className={`canvas-search-bar__counter${empty ? ' canvas-search-bar__counter--empty' : ''}`}>
+          {counter}
+        </span>
+        <button
+          type="button"
+          className={`canvas-search-bar__toggle${caseSensitive ? ' is-active' : ''}`}
+          title="Match case"
+          aria-pressed={caseSensitive}
+          onClick={() => setCaseSensitive(!caseSensitive)}
+        >
+          Aa
+        </button>
+        <button
+          type="button"
+          className="canvas-search-bar__nav"
+          title="Previous match (Shift+Enter)"
+          onClick={prev}
+          disabled={matches.length === 0}
+        >
+          ↑
+        </button>
+        <button
+          type="button"
+          className="canvas-search-bar__nav"
+          title="Next match (Enter)"
+          onClick={next}
+          disabled={matches.length === 0}
+        >
+          ↓
+        </button>
+        <button
+          type="button"
+          className="canvas-search-bar__close"
+          title="Close (Esc)"
+          onClick={closeBar}
+        >
+          ×
+        </button>
+      </div>
+
+      {matches.length > 0 && (
+        <div className="canvas-search-bar__results">
+          {matches.slice(0, 30).map((m, idx) => {
+            const node = nodesById.get(m.nodeId);
+            if (!node) return null;
+            const isActive = idx === activeIndex;
+            return (
+              <div
+                key={`${m.nodeId}:${m.field}:${idx}`}
+                className={`canvas-search-bar__result${isActive ? ' is-active' : ''}`}
+                onClick={() => setActiveIndex(idx)}
+              >
+                <span className={`canvas-search-bar__badge canvas-search-bar__badge--${node.type}`}>
+                  {node.type}
+                </span>
+                <span className="canvas-search-bar__title">{node.title || '(untitled)'}</span>
+                {m.field !== 'title' && (
+                  <span className="canvas-search-bar__snippet">{m.snippet}</span>
+                )}
+              </div>
+            );
+          })}
+          {matches.length > 30 && (
+            <div className="canvas-search-bar__overflow">
+              + {matches.length - 30} more — refine the query to narrow down
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.ts
@@ -31,6 +31,16 @@ interface Options {
   commitHistory: () => void;
   searchOpen: boolean;
   setSearchOpen: (open: boolean | ((prev: boolean) => boolean)) => void;
+  /** Find-in-canvas bar (Ctrl/Cmd+F). Kept separate from the Cmd+K
+   *  command palette because the two have incompatible mental models:
+   *  the palette closes after a single Enter, while find stays open
+   *  for iterative next/prev. */
+  findOpen: boolean;
+  toggleFindBar: () => void;
+  closeFindBar: () => void;
+  findNext: () => void;
+  findPrev: () => void;
+  findHasMatches: boolean;
   contextMenu: unknown;
   setContextMenu: (menu: null) => void;
   setHighlightedId: (id: string | null) => void;
@@ -47,7 +57,9 @@ export const useCanvasKeyboard = ({
   selectedEdgeId, setSelectedEdgeId, removeEdge,
   duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, groupSelectedNodes, ungroupSelectedNodes, removeNodes,
   moveNodes, commitHistory,
-  searchOpen, setSearchOpen, contextMenu, setContextMenu,
+  searchOpen, setSearchOpen,
+  findOpen, toggleFindBar, closeFindBar, findNext, findPrev, findHasMatches,
+  contextMenu, setContextMenu,
   setHighlightedId, handleFocusNode,
   focusModeEnabled = false,
   canToggleFocusMode = false,
@@ -66,6 +78,27 @@ export const useCanvasKeyboard = ({
         (active as HTMLElement).isContentEditable
       );
       const isMod = e.metaKey || e.ctrlKey;
+
+      // Ctrl/Cmd+F — find in canvas. Intentionally works *even when*
+      // an editable element has focus: users frequently want to
+      // search from inside a file node without first clicking out.
+      // The bar's own input grabs focus on mount; we just preventDefault
+      // so the browser's native find UI doesn't compete.
+      if (isMod && !e.shiftKey && (e.key === 'f' || e.key === 'F')) {
+        e.preventDefault();
+        toggleFindBar();
+        return;
+      }
+
+      // F3 / Shift+F3 — page through matches without re-opening the
+      // bar. Only meaningful while results exist; otherwise let the
+      // key fall through.
+      if (e.key === 'F3' && findHasMatches) {
+        e.preventDefault();
+        if (e.shiftKey) findPrev();
+        else findNext();
+        return;
+      }
 
       if (isMod && (e.key === 'k' || e.key === 'h') && !isEditable) {
         e.preventDefault();
@@ -157,6 +190,7 @@ export const useCanvasKeyboard = ({
         return;
       }
       if (e.key === 'Escape') {
+        if (findOpen) { closeFindBar(); return; }
         if (searchOpen) { setSearchOpen(false); return; }
         if (contextMenu) { setContextMenu(null); return; }
         if (focusModeEnabled) { onExitFocusMode?.(); return; }
@@ -180,7 +214,7 @@ export const useCanvasKeyboard = ({
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [undo, redo, nodes, selectedNodeIds, setSelectedNodeIds, selectedEdgeId, setSelectedEdgeId, removeEdge, duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, groupSelectedNodes, ungroupSelectedNodes, removeNodes, moveNodes, commitHistory, searchOpen, setSearchOpen, contextMenu, setContextMenu, focusModeEnabled, canToggleFocusMode, onToggleFocusMode, onExitFocusMode, keyboardLocked]);
+  }, [undo, redo, nodes, selectedNodeIds, setSelectedNodeIds, selectedEdgeId, setSelectedEdgeId, removeEdge, duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, groupSelectedNodes, ungroupSelectedNodes, removeNodes, moveNodes, commitHistory, searchOpen, setSearchOpen, findOpen, toggleFindBar, closeFindBar, findNext, findPrev, findHasMatches, contextMenu, setContextMenu, focusModeEnabled, canToggleFocusMode, onToggleFocusMode, onExitFocusMode, keyboardLocked]);
 
   // Cmd/Ctrl+Tab to cycle through nodes (Shift reverses direction)
   useEffect(() => {

--- a/apps/canvas-workspace/src/renderer/src/hooks/useCanvasSearch.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useCanvasSearch.ts
@@ -1,0 +1,184 @@
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
+import type { CanvasNode, FileNodeData, TextNodeData } from '../types';
+
+/**
+ * A single hit found by the Ctrl+F search.
+ *
+ * `field` distinguishes where the match lives so the UI can render
+ * different snippets (a path vs a content excerpt vs the title).
+ */
+export interface SearchMatch {
+  nodeId: string;
+  field: 'title' | 'filePath' | 'content';
+  /** Display snippet for the result row. */
+  snippet: string;
+}
+
+export interface SearchOptions {
+  caseSensitive?: boolean;
+}
+
+interface Args {
+  nodes: CanvasNode[];
+}
+
+const SNIPPET_RADIUS = 24;
+
+/**
+ * Find-in-canvas state machine.
+ *
+ * Why a dedicated hook (instead of folding it into CommandPalette):
+ *  - Different mental model: Ctrl+F is *iterative* — the bar stays
+ *    open while the user pages through matches.
+ *  - Needs `activeIndex` + `next/prev` + `total` semantics that the
+ *    palette (which closes after Enter) does not.
+ *  - Lets us share the same matches list between SearchBar (rendering
+ *    "3/12" + result rows) and the canvas (drawing the highlight ring
+ *    on the active node).
+ *
+ * Performance: with ≤ ~100 nodes and short text content, a full re-scan
+ * per keystroke is well under a millisecond. We use `useDeferredValue`
+ * on the query just to keep the input frame from blocking on huge
+ * file-node content.
+ */
+export const useCanvasSearch = ({ nodes }: Args) => {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [caseSensitive, setCaseSensitive] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const deferredQuery = useDeferredValue(query);
+
+  const matches = useMemo<SearchMatch[]>(() => {
+    const raw = deferredQuery;
+    if (!raw.trim()) return [];
+    const q = caseSensitive ? raw : raw.toLowerCase();
+    const out: SearchMatch[] = [];
+
+    // Stable, geometry-based ordering: top-to-bottom, then left-to-right.
+    // This matches how a user scans a canvas, so next/prev feels
+    // predictable instead of following whatever insertion order the
+    // store happens to hold.
+    const ordered = [...nodes].sort((a, b) => {
+      if (a.y !== b.y) return a.y - b.y;
+      return a.x - b.x;
+    });
+
+    const norm = (s: string) => (caseSensitive ? s : s.toLowerCase());
+    const snippetAround = (text: string, idx: number) => {
+      const start = Math.max(0, idx - SNIPPET_RADIUS);
+      const end = Math.min(text.length, idx + q.length + SNIPPET_RADIUS);
+      const prefix = start > 0 ? '…' : '';
+      const suffix = end < text.length ? '…' : '';
+      return prefix + text.slice(start, end).replace(/\s+/g, ' ') + suffix;
+    };
+
+    for (const node of ordered) {
+      // 1) Title — every node has one.
+      if (norm(node.title).includes(q)) {
+        out.push({ nodeId: node.id, field: 'title', snippet: node.title });
+      }
+
+      // 2) Type-specific fields.
+      if (node.type === 'file') {
+        const data = node.data as FileNodeData;
+        const fp = data.filePath ?? '';
+        if (fp && norm(fp).includes(q)) {
+          out.push({ nodeId: node.id, field: 'filePath', snippet: fp });
+        }
+        const content = data.content ?? '';
+        if (content) {
+          // Tiptap stores HTML in `content`. Strip tags cheaply for the
+          // text search — we don't need ProseMirror-level accuracy at
+          // the find-bar level (that lives in the future MR2 inline-
+          // highlight extension).
+          const text = content.replace(/<[^>]+>/g, ' ');
+          const hay = norm(text);
+          const idx = hay.indexOf(q);
+          if (idx !== -1) {
+            out.push({ nodeId: node.id, field: 'content', snippet: snippetAround(text, idx) });
+          }
+        }
+      } else if (node.type === 'text') {
+        const content = (node.data as TextNodeData).content ?? '';
+        if (content) {
+          const hay = norm(content);
+          const idx = hay.indexOf(q);
+          if (idx !== -1) {
+            out.push({ nodeId: node.id, field: 'content', snippet: snippetAround(content, idx) });
+          }
+        }
+      }
+    }
+
+    return out;
+  }, [deferredQuery, caseSensitive, nodes]);
+
+  // Reset cursor whenever the result set shape changes. We don't reset
+  // on every keystroke — only when match count actually drops below
+  // the current index (e.g. results shrink as the user types more).
+  useEffect(() => {
+    if (activeIndex >= matches.length) setActiveIndex(0);
+  }, [matches.length, activeIndex]);
+
+  // Capture the focused element when the bar opens so Esc can hand
+  // focus back to wherever the user came from (avoids breaking the
+  // mental model: "I was typing in a file node, hit Ctrl+F, looked
+  // around, hit Esc — cursor should be back in my node").
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  const openBar = useCallback(() => {
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    setOpen(true);
+  }, []);
+
+  const closeBar = useCallback(() => {
+    setOpen(false);
+    setQuery('');
+    setActiveIndex(0);
+    const prev = previousFocusRef.current;
+    previousFocusRef.current = null;
+    // Defer focus restoration to next tick so the SearchBar unmount
+    // (which itself touches focus on cleanup) doesn't immediately
+    // re-steal it.
+    if (prev && typeof prev.focus === 'function') {
+      requestAnimationFrame(() => prev.focus());
+    }
+  }, []);
+
+  const toggleBar = useCallback(() => {
+    if (open) closeBar();
+    else openBar();
+  }, [open, openBar, closeBar]);
+
+  const next = useCallback(() => {
+    if (matches.length === 0) return;
+    setActiveIndex((i) => (i + 1) % matches.length);
+  }, [matches.length]);
+
+  const prev = useCallback(() => {
+    if (matches.length === 0) return;
+    setActiveIndex((i) => (i - 1 + matches.length) % matches.length);
+  }, [matches.length]);
+
+  const activeMatch = matches[activeIndex] ?? null;
+
+  return {
+    open,
+    query,
+    setQuery,
+    caseSensitive,
+    setCaseSensitive,
+    matches,
+    activeIndex,
+    setActiveIndex,
+    activeMatch,
+    openBar,
+    closeBar,
+    toggleBar,
+    next,
+    prev,
+  };
+};
+
+export type UseCanvasSearchReturn = ReturnType<typeof useCanvasSearch>;


### PR DESCRIPTION
## Summary
- New `useCanvasSearch` hook: searches node titles, file paths, file content (Tiptap HTML stripped), and text-node content. Top-to-bottom geometric ordering, optional case sensitivity.
- New `SearchBar` overlay (top-center): input, `3 / 12` counter, case toggle (`Aa`), up/down nav, collapsible results list. Stays open while paging.
- Keyboard: `Ctrl/Cmd+F` toggles bar (works in editable contexts); `Enter` / `Shift+Enter` and `F3` / `Shift+F3` step through matches; `Esc` closes and restores focus.
- Camera follows the active match by reusing the existing `handleNodeViewportFocus` pipeline — gets the brief highlight ring for free.
- Intentionally kept separate from `Cmd+K` CommandPalette: palette closes on Enter (goto), find stays open (iterative).

## Design notes
- Inline Tiptap range highlighting (mark current match inside file-node content) is deferred to MR2 so this slice stays reviewable. Today the node-level highlight ring + camera focus is the cue.
- 100-node assumption: full re-scan per keystroke + `useDeferredValue` is plenty; no Fuse/MiniSearch dependency added.

## Validation
- `pnpm typecheck:renderer`: ✅ clean (with workspace deps linked from master)
- `pnpm build`: ✅ electron-vite build succeeds (main / preload / renderer)

## Risk
Low — purely additive. New overlay only mounts when `search.open` is true; new key bindings preempt only `Ctrl/Cmd+F` and `F3` which had no prior handler.