### PR TITLE
feat(canvas-workspace): inline-highlight Ctrl+F matches inside file nodes

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import './index.css';
 import { EditorContent } from '@tiptap/react';
 import type { CanvasNode, FileNodeData } from '../../types';
 import { useFileNodeEditor, getMarkdown } from '../../hooks/useFileNodeEditor';
+import { useFileNodeEditorRegistry } from '../../hooks/useFileNodeEditorRegistry';
 import { filterCmds } from '../../editor/slashCommands';
 import { FileNodeToolbar } from '../FileNodeToolbar';
 import { FileNodeBubbleMenu } from '../FileNodeBubbleMenu';
@@ -77,6 +78,19 @@ export const FileNodeBody = ({ node, onUpdate, workspaceId, readOnly = false }: 
     onUpdate,
     readOnly,
   });
+
+  // Publish this node's editor to the canvas-level registry so the
+  // Ctrl/Cmd+F find bar can push its query into our NoteSearchExtension
+  // and reuse the inline match highlights (no separate decoration
+  // system for canvas-vs-note find). Re-registers if the editor
+  // identity changes (Tiptap may rebuild on extension changes).
+  const registry = useFileNodeEditorRegistry();
+  useEffect(() => {
+    if (!registry || !editor) return;
+    const id = node.id;
+    registry.register(id, editor);
+    return () => registry.unregister(id);
+  }, [registry, editor, node.id]);
 
   const handleOpenFile = useCallback(async () => {
     if (readOnly) return;

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Canvas } from '../Canvas';
+import { FileNodeEditorRegistryProvider } from '../../hooks/useFileNodeEditorRegistry';
 import { ChatPanel } from '../chat';
 import { ReferenceDrawer } from '../ReferenceDrawer';
 import type { WorkspaceEntry } from '../../hooks/useWorkspaces';
@@ -107,6 +108,7 @@ export const Workbench: React.FC<WorkbenchProps> = ({
 
   return (
     <>
+      <FileNodeEditorRegistryProvider>
       <ReferenceDrawer
         open={referenceDrawerOpen}
         referenceNode={referenceNode}
@@ -158,6 +160,7 @@ export const Workbench: React.FC<WorkbenchProps> = ({
           />
         </div>
       ))}
+      </FileNodeEditorRegistryProvider>
     </>
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/hooks/useCanvasSearch.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useCanvasSearch.ts
@@ -1,5 +1,7 @@
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
 import type { CanvasNode, FileNodeData, TextNodeData } from '../types';
+import { setNoteSearch, clearNoteSearch, noteSearchPluginKey } from '../editor/noteSearchExtension';
+import { useFileNodeEditorRegistry } from './useFileNodeEditorRegistry';
 
 /**
  * A single hit found by the Ctrl+F search.
@@ -121,6 +123,59 @@ export const useCanvasSearch = ({ nodes }: Args) => {
     if (activeIndex >= matches.length) setActiveIndex(0);
   }, [matches.length, activeIndex]);
 
+  // Inline highlight inside file nodes — reuse the existing
+  // NoteSearchExtension instead of building a parallel decoration
+  // system. The set of "nodes that have ≥1 content match" gets the
+  // query pushed in; everything else gets cleared so closed/unrelated
+  // editors don't keep stale highlights.
+  const registry = useFileNodeEditorRegistry();
+  // Track which editors we currently have highlights on so we can
+  // surgically clear only those that drop out of the set, instead of
+  // touching every registered editor on every keystroke (the latter
+  // would spam dispatches into nodes that never had a match).
+  const highlightedRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!registry) return;
+    const q = open ? deferredQuery : '';
+    const shouldHighlight = new Set<string>();
+    if (q.trim()) {
+      for (const m of matches) {
+        if (m.field === 'content') shouldHighlight.add(m.nodeId);
+      }
+    }
+
+    // Apply to newly-included editors.
+    for (const id of shouldHighlight) {
+      const editor = registry.get(id);
+      if (!editor) continue;
+      const view = editor.view;
+      if (!view) continue;
+      const current = noteSearchPluginKey.getState(view.state);
+      // Skip dispatch if the editor already shows this exact query —
+      // avoids resetting the user's per-note find state when canvas
+      // find converges on the same string.
+      if (current?.query === q) continue;
+      setNoteSearch(view, q);
+    }
+
+    // Clear editors that previously had our highlight but no longer do.
+    for (const id of highlightedRef.current) {
+      if (shouldHighlight.has(id)) continue;
+      const editor = registry.get(id);
+      if (!editor?.view) continue;
+      const current = noteSearchPluginKey.getState(editor.view.state);
+      // Only clear if the highlight still matches our pushed query —
+      // protects an active per-note find session if the user opened
+      // one after we set ours.
+      if (current && current.query === deferredQuery) {
+        clearNoteSearch(editor.view);
+      }
+    }
+
+    highlightedRef.current = shouldHighlight;
+  }, [open, deferredQuery, matches, registry]);
+
   // Capture the focused element when the bar opens so Esc can hand
   // focus back to wherever the user came from (avoids breaking the
   // mental model: "I was typing in a file node, hit Ctrl+F, looked
@@ -136,6 +191,17 @@ export const useCanvasSearch = ({ nodes }: Args) => {
     setOpen(false);
     setQuery('');
     setActiveIndex(0);
+    // Belt-and-suspenders: the effect above also reacts to `open`
+    // flipping to false, but call clear directly so the visual state
+    // updates in the same frame as the bar dismissing.
+    if (registry) {
+      for (const id of highlightedRef.current) {
+        const editor = registry.get(id);
+        if (!editor?.view) continue;
+        clearNoteSearch(editor.view);
+      }
+      highlightedRef.current = new Set();
+    }
     const prev = previousFocusRef.current;
     previousFocusRef.current = null;
     // Defer focus restoration to next tick so the SearchBar unmount
@@ -144,7 +210,7 @@ export const useCanvasSearch = ({ nodes }: Args) => {
     if (prev && typeof prev.focus === 'function') {
       requestAnimationFrame(() => prev.focus());
     }
-  }, []);
+  }, [registry]);
 
   const toggleBar = useCallback(() => {
     if (open) closeBar();

--- a/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditorRegistry.tsx
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditorRegistry.tsx
@@ -1,0 +1,71 @@
+import { createContext, useCallback, useContext, useMemo, useRef } from 'react';
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Editor = any;
+
+/**
+ * Registry that lets the canvas-level Ctrl+F find bar talk to the
+ * Tiptap editors living inside individual file nodes.
+ *
+ * Why a registry instead of prop drilling:
+ *  - File nodes mount/unmount with the canvas viewport; they manage
+ *    their own Tiptap instance via `useFileNodeEditor`. Lifting that
+ *    instance up to the Canvas component would tangle ownership.
+ *  - A `Map<nodeId, editor>` is the lightest contract — file nodes
+ *    self-register on mount, the find bar pulls the editor when it
+ *    wants to highlight a content match inline.
+ *
+ * The bar uses the existing `NoteSearchExtension` decoration plugin
+ * (already shipped for per-note Ctrl+F inside the toolbar). Pushing
+ * the query into that plugin draws inline `<mark>`-style spans and
+ * marks the active hit — no second highlight system needed.
+ */
+interface EditorRegistryApi {
+  register: (nodeId: string, editor: Editor) => void;
+  unregister: (nodeId: string) => void;
+  get: (nodeId: string) => Editor | null;
+  /** Stable snapshot of currently-registered ids. Mostly useful for
+   *  the find bar to clear stale highlights on close. */
+  getAll: () => Map<string, Editor>;
+}
+
+const FileNodeEditorRegistryContext = createContext<EditorRegistryApi | null>(null);
+
+/**
+ * Mount once at the canvas root. Children can call
+ * `useFileNodeEditorRegistry()` to grab the API.
+ */
+export const FileNodeEditorRegistryProvider = ({ children }: { children: React.ReactNode }) => {
+  // We deliberately use a ref-backed map (not state) — registrations
+  // happen during render-effect cycles and we don't want them to
+  // trigger re-renders. The find bar reads on-demand via `get()`.
+  const mapRef = useRef<Map<string, Editor>>(new Map());
+
+  const register = useCallback((nodeId: string, editor: Editor) => {
+    mapRef.current.set(nodeId, editor);
+  }, []);
+
+  const unregister = useCallback((nodeId: string) => {
+    mapRef.current.delete(nodeId);
+  }, []);
+
+  const get = useCallback((nodeId: string) => {
+    return mapRef.current.get(nodeId) ?? null;
+  }, []);
+
+  const getAll = useCallback(() => mapRef.current, []);
+
+  const api = useMemo<EditorRegistryApi>(
+    () => ({ register, unregister, get, getAll }),
+    [register, unregister, get, getAll],
+  );
+
+  return (
+    <FileNodeEditorRegistryContext.Provider value={api}>
+      {children}
+    </FileNodeEditorRegistryContext.Provider>
+  );
+};
+
+export const useFileNodeEditorRegistry = (): EditorRegistryApi | null => {
+  return useContext(FileNodeEditorRegistryContext);
+};


### PR DESCRIPTION
Builds on top of #431.

## Summary
- New `FileNodeEditorRegistryProvider` (mounted at Workbench root) lets each `FileNodeBody` self-register its Tiptap editor by node id.
- `useCanvasSearch` pushes the deferred query into every editor that has ≥1 content match and clears editors that drop out of the match set. Skips dispatches when the editor already shows the same query so per-note find sessions aren't clobbered.
- `closeBar()` proactively clears every editor we touched, so dismissing the canvas-level bar removes inline highlights in the same frame.

## Design
- **No new decoration system.** Reuses the existing `NoteSearchExtension` (the per-note Ctrl+F decoration plugin) and its `.note-search-match` / `--active` CSS — canvas-level find and per-note find now share the same visual treatment.
- Registry is ref-backed (no state) so file-node mounts don't trigger re-renders.

## Dependency
Depends on #431 (canvas find bar + useCanvasSearch hook). Merge #431 first or rebase this PR onto master after #431 lands.

## Validation
- `pnpm typecheck:renderer`: ✅
- `pnpm build`: ✅ (main / preload / renderer)

## Risk
Low — purely additive. If the registry context is absent (defensive null check) the canvas-level bar still works, just without inline highlights.