### PR TITLE
fix(engine): add llm call timeouts

### DIFF
--- a/packages/engine/src/config/index.ts
+++ b/packages/engine/src/config/index.ts
@@ -97,6 +97,8 @@ export const MAX_TURNS = 100;
 export const MAX_ERROR_COUNT = 3;
 export const MAX_STEPS = 100;
 export const MAX_TOOL_OUTPUT_LENGTH = 30_000;
+export const LLM_FIRST_CHUNK_TIMEOUT_MS = Number(process.env.LLM_FIRST_CHUNK_TIMEOUT_MS ?? 180_000);
+export const LLM_CALL_TIMEOUT_MS = Number(process.env.LLM_CALL_TIMEOUT_MS ?? 600_000);
 
 export const CONTEXT_WINDOW_TOKENS = Number(process.env.CONTEXT_WINDOW_TOKENS ?? 64_000);
 export const COMPACT_TRIGGER = Number(process.env.COMPACT_TRIGGER ?? Math.floor(CONTEXT_WINDOW_TOKENS * 0.75));

--- a/packages/engine/src/core/loop.test.ts
+++ b/packages/engine/src/core/loop.test.ts
@@ -232,4 +232,79 @@ describe('loop', () => {
       }),
     );
   });
+
+  it('times out LLM calls that never produce a first chunk', async () => {
+    vi.useFakeTimers();
+
+    const context: Context = {
+      messages: [{ role: 'user', content: 'hung llm' }],
+    };
+    const afterLLMCall = vi.fn(async () => undefined);
+    let llmAbortSignal: AbortSignal | undefined;
+
+    streamTextAIMock.mockImplementation((_messages: any, _tools: Record<string, Tool>, options: any) => {
+      llmAbortSignal = options.abortSignal;
+      return {
+        text: new Promise(() => undefined),
+        steps: new Promise(() => undefined),
+        finishReason: new Promise(() => undefined),
+      };
+    });
+
+    const runPromise = loop(context, {
+      hooks: {
+        afterLLMCall: [afterLLMCall],
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(180_000);
+
+    await expect(runPromise).resolves.toContain('上游模型请求超时');
+    expect(llmAbortSignal?.aborted).toBe(true);
+    expect(afterLLMCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context,
+        finishReason: 'error',
+        text: '',
+        error: expect.objectContaining({
+          name: 'LLMTimeoutError',
+          code: 'LLM_TIMEOUT',
+          timeoutReason: 'first-chunk',
+          timeoutMs: 180_000,
+        }),
+      }),
+    );
+  });
+
+  it('returns promptly when the caller aborts a pending LLM call', async () => {
+    vi.useFakeTimers();
+
+    const context: Context = {
+      messages: [{ role: 'user', content: 'abort llm' }],
+    };
+    const ac = new AbortController();
+    let llmAbortSignal: AbortSignal | undefined;
+
+    streamTextAIMock.mockImplementation((_messages: any, _tools: Record<string, Tool>, options: any) => {
+      llmAbortSignal = options.abortSignal;
+      return {
+        text: new Promise(() => undefined),
+        steps: new Promise(() => undefined),
+        finishReason: new Promise(() => undefined),
+      };
+    });
+
+    const runPromise = loop(context, {
+      abortSignal: ac.signal,
+    });
+
+    await vi.waitFor(() => {
+      expect(streamTextAIMock).toHaveBeenCalledTimes(1);
+    });
+
+    ac.abort();
+
+    await expect(runPromise).resolves.toBe('Request aborted.');
+    expect(llmAbortSignal?.aborted).toBe(true);
+  });
 });

--- a/packages/engine/src/core/loop.ts
+++ b/packages/engine/src/core/loop.ts
@@ -4,6 +4,8 @@ import type { EngineHookMap, OnCompactedEvent } from "../plugin/EnginePlugin.js"
 import { streamTextAI } from "../ai";
 import { maybeCompactContext, type CompactStats } from "../context";
 import {
+  LLM_CALL_TIMEOUT_MS,
+  LLM_FIRST_CHUNK_TIMEOUT_MS,
   MAX_COMPACTION_ATTEMPTS,
   MAX_ERROR_COUNT,
   MAX_STEPS,
@@ -19,6 +21,8 @@ import {
  * Override per deployment via env: MODEL_CONTEXT_BUDGET (single global cap).
  */
 const MODEL_CONTEXT_BUDGET_OVERRIDE = Number(process.env.MODEL_CONTEXT_BUDGET ?? 0) || undefined;
+const LLM_TIMEOUT_CODE = 'LLM_TIMEOUT';
+type LLMTimeoutReason = 'first-chunk' | 'total';
 
 function resolveModelContextBudget(model?: string, modelType?: ModelType): number {
   if (MODEL_CONTEXT_BUDGET_OVERRIDE && MODEL_CONTEXT_BUDGET_OVERRIDE > 0) {
@@ -40,6 +44,40 @@ function resolveModelContextBudget(model?: string, modelType?: ModelType): numbe
   }
   // Conservative default
   return 110_000;
+}
+
+function normalizeTimeoutMs(value: number): number | undefined {
+  return Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function createLLMTimeoutError(reason: LLMTimeoutReason, timeoutMs: number): Error {
+  const label = reason === 'first-chunk' ? 'first response chunk' : 'total request duration';
+  const error = new Error(`LLM ${label} timed out after ${timeoutMs}ms`);
+  error.name = 'LLMTimeoutError';
+  (error as any).code = LLM_TIMEOUT_CODE;
+  (error as any).timeoutReason = reason;
+  (error as any).timeoutMs = timeoutMs;
+  return error;
+}
+
+function isLLMTimeoutError(error: any): boolean {
+  return error?.code === LLM_TIMEOUT_CODE || error?.name === 'LLMTimeoutError';
+}
+
+function formatDurationMs(ms: number): string {
+  if (!Number.isFinite(ms)) {
+    return 'unknown duration';
+  }
+  if (ms < 1000) {
+    return `${ms}ms`;
+  }
+  const seconds = ms / 1000;
+  if (seconds < 60) {
+    return `${seconds.toFixed(seconds >= 10 ? 0 : 1)}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = Math.round(seconds % 60);
+  return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`;
 }
 
 /**
@@ -329,50 +367,146 @@ export async function loop(context: Context, options?: LoopOptions): Promise<str
 
       requestStartAt = Date.now();
       llmCallStarted = true;
-      const result = streamTextAI(context.messages, tools, {
-        abortSignal: options?.abortSignal,
-        toolExecutionContext,
-        provider: options?.provider ?? (options?.modelType ? buildProvider(options.modelType) : undefined),
-        model: options?.model,
-        modelType: options?.modelType,
-        systemPrompt,
-        onStepFinish: (step) => {
-          options?.onStepFinish?.(step);
-        },
-        onChunk: ({ chunk }) => {
-          const chunkAt = Date.now();
-          if (firstChunkAt === undefined) {
-            firstChunkAt = chunkAt;
-          }
-          if (chunk.type === 'text-delta' && firstTextAt === undefined) {
-            firstTextAt = chunkAt;
-          }
-          lastChunkAt = chunkAt;
-          if (chunk.type === 'text-delta') {
-            options?.onText?.(chunk.text);
-          }
-          if (chunk.type === 'tool-call') {
-            options?.onToolCall?.(chunk);
-            const toolCallHooks = loopHooks.onToolCall ?? [];
-            if (toolCallHooks.length > 0) {
-              for (const hook of toolCallHooks) {
-                Promise.resolve(hook({ context, toolCall: chunk })).catch(() => undefined);
-              }
-            }
-          }
-          if (chunk.type === 'tool-result') {
-            options?.onToolResult?.(chunk);
-          }
-        },
+      const llmAbortController = new AbortController();
+      let timeoutError: Error | undefined;
+      let firstChunkTimeoutId: ReturnType<typeof setTimeout> | undefined;
+      let callTimeoutId: ReturnType<typeof setTimeout> | undefined;
+      let rejectLLMWait: ((error: Error) => void) | undefined;
+      const firstChunkTimeoutMs = normalizeTimeoutMs(LLM_FIRST_CHUNK_TIMEOUT_MS);
+      const callTimeoutMs = normalizeTimeoutMs(LLM_CALL_TIMEOUT_MS);
+      const llmWaitAbortPromise = new Promise<never>((_resolve, reject) => {
+        rejectLLMWait = reject;
       });
 
-      const usagePromise = (result as any).usage;
-      const [text, steps, finishReason, usage] = await Promise.all([
-        result.text,
-        result.steps,
-        result.finishReason,
-        usagePromise ? Promise.resolve(usagePromise) : Promise.resolve(undefined),
-      ]);
+      const rejectLLMWaitOnce = (error: Error) => {
+        if (!rejectLLMWait) {
+          return;
+        }
+        rejectLLMWait(error);
+        rejectLLMWait = undefined;
+      };
+
+      const abortLLM = (reason?: Error) => {
+        if (!llmAbortController.signal.aborted) {
+          llmAbortController.abort(reason);
+        }
+      };
+
+      const handleTimeout = (reason: LLMTimeoutReason, timeoutMs: number) => {
+        const error = timeoutError ?? createLLMTimeoutError(reason, timeoutMs);
+        timeoutError = error;
+        abortLLM(error);
+        rejectLLMWaitOnce(error);
+      };
+
+      const handleCallerAbort = () => {
+        const abortError = new Error('Aborted');
+        abortError.name = 'AbortError';
+        abortLLM(abortError);
+        rejectLLMWaitOnce(abortError);
+      };
+
+      const clearFirstChunkTimeout = () => {
+        if (firstChunkTimeoutId) {
+          clearTimeout(firstChunkTimeoutId);
+          firstChunkTimeoutId = undefined;
+        }
+      };
+
+      const disposeLLMTimeouts = () => {
+        clearFirstChunkTimeout();
+        if (callTimeoutId) {
+          clearTimeout(callTimeoutId);
+          callTimeoutId = undefined;
+        }
+        rejectLLMWait = undefined;
+        options?.abortSignal?.removeEventListener('abort', handleCallerAbort);
+      };
+
+      if (options?.abortSignal?.aborted) {
+        handleCallerAbort();
+      } else {
+        options?.abortSignal?.addEventListener('abort', handleCallerAbort, { once: true });
+      }
+
+      if (firstChunkTimeoutMs) {
+        firstChunkTimeoutId = setTimeout(() => {
+          if (firstChunkAt === undefined) {
+            handleTimeout('first-chunk', firstChunkTimeoutMs);
+          }
+        }, firstChunkTimeoutMs);
+      }
+
+      if (callTimeoutMs) {
+        callTimeoutId = setTimeout(() => {
+          handleTimeout('total', callTimeoutMs);
+        }, callTimeoutMs);
+      }
+
+      let text: string;
+      let steps: StepResult<any>[];
+      let finishReason: string;
+      let usage: any;
+
+      try {
+        const result = streamTextAI(context.messages, tools, {
+          abortSignal: llmAbortController.signal,
+          toolExecutionContext: {
+            ...toolExecutionContext,
+            abortSignal: llmAbortController.signal,
+          },
+          provider: options?.provider ?? (options?.modelType ? buildProvider(options.modelType) : undefined),
+          model: options?.model,
+          modelType: options?.modelType,
+          systemPrompt,
+          onStepFinish: (step) => {
+            options?.onStepFinish?.(step);
+          },
+          onChunk: ({ chunk }) => {
+            const chunkAt = Date.now();
+            if (firstChunkAt === undefined) {
+              firstChunkAt = chunkAt;
+              clearFirstChunkTimeout();
+            }
+            if (chunk.type === 'text-delta' && firstTextAt === undefined) {
+              firstTextAt = chunkAt;
+            }
+            lastChunkAt = chunkAt;
+            if (chunk.type === 'text-delta') {
+              options?.onText?.(chunk.text);
+            }
+            if (chunk.type === 'tool-call') {
+              options?.onToolCall?.(chunk);
+              const toolCallHooks = loopHooks.onToolCall ?? [];
+              if (toolCallHooks.length > 0) {
+                for (const hook of toolCallHooks) {
+                  Promise.resolve(hook({ context, toolCall: chunk })).catch(() => undefined);
+                }
+              }
+            }
+            if (chunk.type === 'tool-result') {
+              options?.onToolResult?.(chunk);
+            }
+          },
+        });
+
+        const usagePromise = (result as any).usage;
+        const llmCompletionPromise = Promise.all([
+          result.text,
+          result.steps,
+          result.finishReason,
+          usagePromise ? Promise.resolve(usagePromise) : Promise.resolve(undefined),
+        ]) as Promise<[string, StepResult<any>[], string, any]>;
+
+        [text, steps, finishReason, usage] = await Promise.race([
+          llmCompletionPromise,
+          llmWaitAbortPromise,
+        ]);
+      } catch (error) {
+        throw timeoutError ?? error;
+      } finally {
+        disposeLLMTimeouts();
+      }
 
       totalSteps += steps.length;
 
@@ -548,6 +682,16 @@ export async function loop(context: Context, options?: LoopOptions): Promise<str
 }
 
 function formatUpstreamError(error: any): string | null {
+  if (isLLMTimeoutError(error)) {
+    const timeoutMs = Number(error?.timeoutMs);
+    const timeoutReason = error?.timeoutReason === 'total' ? '完整响应' : '首个响应块';
+    return [
+      '⚠️ 上游模型请求超时。',
+      '',
+      `本次 LLM 调用在 ${formatDurationMs(timeoutMs)} 内没有收到${timeoutReason}，已主动中止以释放 remote-server 的运行锁。建议先用 \`/compact\` 压缩上下文，或用 \`/new\` 开新会话后继续；如确实需要等待更久，可调整 \`LLM_FIRST_CHUNK_TIMEOUT_MS\` / \`LLM_CALL_TIMEOUT_MS\`。`,
+    ].join('\n');
+  }
+
   const messages = collectErrorMessages(error);
   const combined = messages.join('\n').toLowerCase();
   if (


### PR DESCRIPTION
## Summary
- Add configurable first-chunk and total LLM call timeouts
- Abort hung upstream LLM calls with a local Promise.race fallback so remote-server active runs can release
- Record timeout failures through afterLLMCall/devtools and add loop tests for timeout and caller abort behavior

## Tests
- pnpm exec vitest run src/core/loop.test.ts
- git diff --check

Note: pnpm --filter pulse-coder-engine typecheck is currently blocked by existing unrelated rootDir/type errors in orchestrator/tool-search.