### PR TITLE
feat(canvas): support blank web pages

### DIFF
--- a/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
@@ -26,6 +26,8 @@ interface CanvasAgentRequestContext {
   quickAction?: string;
 }
 
+const CANVAS_AGENT_MAX_STEPS = 200;
+
 // ─── System prompt ─────────────────────────────────────────────────
 
 const BASE_SYSTEM_PROMPT = `You are the Canvas Agent — the AI Copilot for this workspace.
@@ -331,7 +333,7 @@ export class CanvasAgent {
     try {
       const resultText = await this.engine.run(context, {
         systemPrompt,
-        maxSteps: 10,
+        maxSteps: CANVAS_AGENT_MAX_STEPS,
         abortSignal: abortController.signal,
         onClarificationRequest: engineClarificationHandler,
         onText,

--- a/apps/canvas-workspace/src/main/canvas-agent/context-builder.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/context-builder.ts
@@ -72,6 +72,8 @@ const PAGE_MAX_BYTES = 200_000;
  * message to the user.
  */
 async function fetchPageText(url: string): Promise<string> {
+  if (url === 'about:blank') return '[blank web page — no content]';
+
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), PAGE_FETCH_TIMEOUT_MS);
   try {
@@ -150,6 +152,7 @@ async function readIframeContent(
   url: string,
 ): Promise<string> {
   if (!url) return '[empty link node — no URL set]';
+  if (url === 'about:blank') return '[blank web page — no content]';
 
   let liveError: string | null = null;
   try {

--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -25,6 +25,7 @@ import { hasSession, writeToSession } from '../pty-manager';
 import { generateHTML } from '../html-generator';
 
 const STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
+const BLANK_PAGE_URL = 'about:blank';
 
 // ─── Types mirrored from canvas-cli ────────────────────────────────
 
@@ -67,6 +68,15 @@ function normalizeMindmapTopic(raw: RawMindmapTopic | null | undefined): Mindmap
   if (typeof safe.color === 'string') topic.color = safe.color;
   if (safe.collapsed) topic.collapsed = true;
   return topic;
+}
+
+function normalizeIframeUrl(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  const lowered = trimmed.toLowerCase();
+  if (lowered === 'blank' || lowered === BLANK_PAGE_URL) return BLANK_PAGE_URL;
+  return trimmed;
 }
 
 interface CanvasNode {
@@ -741,7 +751,7 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
         '- **text**: Creates a free-form text label (TLDRAW-style). Use `content` for the text body, ' +
         'and `data.textColor` / `data.backgroundColor` (hex or "transparent") for styling. Optional `data.fontSize`.\n' +
         '- **iframe**: Embeds an external web page, renders raw HTML, or generates HTML from a prompt. ' +
-        'For URL mode: pass `data.url` with the full URL (including protocol). ' +
+        'For URL mode: pass `data.url` with the full URL (including protocol), or "blank"/"about:blank" for an empty page. ' +
         'For HTML mode: pass `data.html` with raw HTML content and `data.mode: "html"`. ' +
         'For AI mode: pass `data.prompt` with a description and `data.mode: "ai"` — ' +
         'the LLM will generate self-contained HTML. ' +
@@ -769,7 +779,7 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
           '- frame: { color?: string, label?: string }\n' +
           '- group: { color?: string, label?: string, childIds?: string[] }\n' +
           '- text: { textColor?: string, backgroundColor?: string, fontSize?: number }\n' +
-          '- iframe: { url?: string, html?: string, prompt?: string, mode?: "url"|"html"|"ai" }\n' +
+          '- iframe: { url?: string, html?: string, prompt?: string, mode?: "url"|"html"|"ai" }. `url: "blank"` opens about:blank.\n' +
           '- shape: { kind?: "rect"|"rounded-rect"|"ellipse"|"triangle"|"diamond"|"hexagon"|"star", fill?: string, stroke?: string, strokeWidth?: number, text?: string, textColor?: string, fontSize?: number }\n' +
           '- mindmap: { root?: { text: string, children?: Topic[], color?: string, collapsed?: boolean } } where Topic has the same recursive shape',
         ),
@@ -873,7 +883,7 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
               };
             } else {
               nodeData = {
-                url: (extraData.url as string) ?? '',
+                url: normalizeIframeUrl(extraData.url),
                 html: (extraData.html as string) ?? '',
                 prompt,
                 mode: iframeMode,

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -937,8 +937,9 @@ export const Canvas = ({
       {
         id: 'create-link',
         group: 'create',
-        title: 'Embed link',
-        aliases: ['iframe', 'web', 'url', 'browser'],
+        title: 'Web page',
+        hint: 'URL, HTML, AI, or blank page',
+        aliases: ['iframe', 'web', 'url', 'browser', 'blank', 'page', 'link'],
         run: () => handleToolbarAddNode('iframe'),
       },
       {

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEmptyHint/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEmptyHint/index.css
@@ -55,7 +55,7 @@
 
 .canvas-empty-actions {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 12px;
   margin-bottom: 16px;
 }
@@ -131,6 +131,12 @@
     padding: 22px;
   }
 
+  .canvas-empty-actions {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 460px) {
   .canvas-empty-actions {
     grid-template-columns: 1fr;
   }

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEmptyHint/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEmptyHint/index.tsx
@@ -3,7 +3,7 @@ import type { CanvasNode } from '../../types';
 import './index.css';
 
 interface CanvasEmptyHintProps {
-  onCreateNode: (type: Extract<CanvasNode['type'], 'agent' | 'terminal' | 'file'>) => void;
+  onCreateNode: (type: Extract<CanvasNode['type'], 'agent' | 'terminal' | 'file' | 'iframe'>) => void;
   onOpenShortcuts: () => void;
 }
 
@@ -23,7 +23,7 @@ export const CanvasEmptyHint = ({ onCreateNode, onOpenShortcuts }: CanvasEmptyHi
       </div>
       <div className="hint-text">Start with a lightweight node</div>
       <div className="hint-sub">
-        Create an Agent, Terminal, or Note to turn the blank canvas into a working session.
+        Create an Agent, Terminal, Note, or Web Page to turn the blank canvas into a working session.
       </div>
       <div className="canvas-empty-actions">
         {EMPTY_CANVAS_ACTIONS.map((action) => (

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
@@ -180,7 +180,7 @@ export const FloatingToolbar = ({
         <button
           className="toolbar-btn toolbar-btn--create"
           onClick={() => onAddNode("iframe")}
-          title="Add Link (embed a web page)"
+          title="Add Web Page"
         >
           <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
             <circle cx="9" cy="9" r="6.5" stroke="currentColor" strokeWidth="1.3" />
@@ -189,7 +189,7 @@ export const FloatingToolbar = ({
               stroke="currentColor" strokeWidth="1.2" strokeLinecap="round"
             />
           </svg>
-          <span className="toolbar-btn-label">Link</span>
+          <span className="toolbar-btn-label">Web</span>
         </button>
         <button
           className="toolbar-btn toolbar-btn--create"

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.css
@@ -189,6 +189,29 @@
   box-shadow: 0 0 0 2px rgba(35, 131, 226, 0.15);
 }
 
+.iframe-blank-btn {
+  align-self: flex-start;
+  height: 24px;
+  border: none;
+  border-radius: 4px;
+  padding: 0 8px;
+  background: rgba(35, 131, 226, 0.08);
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s;
+}
+
+.iframe-blank-btn:hover {
+  background: rgba(35, 131, 226, 0.14);
+}
+
+.iframe-blank-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .iframe-empty-actions {
   display: flex;
   gap: 6px;

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.tsx
@@ -4,6 +4,8 @@ import type { CanvasNode, IframeNodeData } from "../../types";
 
 type EditMode = "url" | "html" | "ai";
 
+const BLANK_PAGE_URL = "about:blank";
+
 interface Props {
   node: CanvasNode;
   workspaceId?: string;
@@ -114,7 +116,8 @@ export const IframeNodeBody = ({ node, workspaceId, onUpdate, isResizing, readOn
     if (!el) return;
 
     const handlePageTitleUpdated = (event: Event) => {
-      const nextTitle = sanitizePageTitle((event as Event & { title?: string }).title);
+      const rawTitle = sanitizePageTitle((event as Event & { title?: string }).title);
+      const nextTitle = url === BLANK_PAGE_URL && rawTitle === BLANK_PAGE_URL ? "Blank page" : rawTitle;
       if (!nextTitle || nextTitle === node.title) return;
       if (!shouldSyncIframeTitle(node.title, data, url)) return;
 
@@ -249,6 +252,18 @@ export const IframeNodeBody = ({ node, workspaceId, onUpdate, isResizing, readOn
     }
     setEditing(false);
   }, [draftMode, draftUrl, draftHtml, onUpdate, node.id, node.title, data, readOnly, url]);
+
+  const openBlankPage = useCallback(() => {
+    if (readOnly) return;
+    const shouldUseAutoTitle = shouldSyncIframeTitle(node.title, data, url);
+    onUpdate(node.id, {
+      data: { ...data, url: BLANK_PAGE_URL, mode: "url", pageTitle: "" },
+      title: shouldUseAutoTitle ? "Blank page" : node.title,
+    });
+    setDraftUrl(BLANK_PAGE_URL);
+    setDraftMode("url");
+    setEditing(false);
+  }, [data, node.id, node.title, onUpdate, readOnly, url]);
 
   // ── Streaming AI generation ────────────────────────────────────────
 
@@ -429,6 +444,14 @@ export const IframeNodeBody = ({ node, workspaceId, onUpdate, isResizing, readOn
                 onKeyDown={handleKeyDown}
                 spellCheck={false}
               />
+              <button
+                type="button"
+                className="iframe-blank-btn"
+                onClick={openBlankPage}
+                disabled={generating}
+              >
+                Open blank page
+              </button>
             </>
           ) : draftMode === "html" ? (
             <>
@@ -501,7 +524,7 @@ export const IframeNodeBody = ({ node, workspaceId, onUpdate, isResizing, readOn
 
           <div className="iframe-empty-hint">
             {draftMode === "url"
-              ? 'Some sites block embedding — use "Open externally" to fall back to a browser.'
+              ? 'Type a URL, "blank", or "about:blank". Some sites block embedding.'
               : draftMode === "html"
               ? "Cmd/Ctrl+Enter to confirm. Scripts are sandboxed."
               : "Cmd/Ctrl+Enter to generate. Describe a chart, diagram, UI, or any visual."}
@@ -647,12 +670,15 @@ export const IframeNodeBody = ({ node, workspaceId, onUpdate, isResizing, readOn
 
 function normalizeUrl(input: string): string {
   if (!input) return "";
+  const lowered = input.toLowerCase();
+  if (lowered === "blank" || lowered === BLANK_PAGE_URL) return BLANK_PAGE_URL;
   if (/^[a-z]+:\/\//i.test(input)) return input;
   if (/^\/\//.test(input)) return `https:${input}`;
   return `https://${input}`;
 }
 
 function prettyTitle(url: string): string {
+  if (url === BLANK_PAGE_URL) return "Blank page";
   try {
     const u = new URL(url);
     return u.host || url;

--- a/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
@@ -97,8 +97,8 @@ export const NodeContextMenu = ({ x, y, mode = "create", onCreate, onExportImage
           >
             <span className="context-menu-icon">{"\u232C"}</span>
             <span className="context-menu-label">
-              <strong>Link</strong>
-              <small>Embed a web page</small>
+              <strong>Web Page</strong>
+              <small>Embed a URL or open blank</small>
             </span>
           </button>
           <button

--- a/apps/canvas-workspace/src/renderer/src/constants/interaction.ts
+++ b/apps/canvas-workspace/src/renderer/src/constants/interaction.ts
@@ -1,7 +1,7 @@
 import type { CanvasNode } from '../types';
 import type { ShortcutSection } from '../types/ui-interaction';
 
-type EmptyCanvasNodeType = Extract<CanvasNode['type'], 'agent' | 'terminal' | 'file'>;
+type EmptyCanvasNodeType = Extract<CanvasNode['type'], 'agent' | 'terminal' | 'file' | 'iframe'>;
 
 export const DEFAULT_TOAST_DURATION_MS = 2800;
 
@@ -19,6 +19,7 @@ export const INTERACTION_ACTIONS = {
   emptyStateCreateAgent: 'empty-state.create-agent',
   emptyStateCreateTerminal: 'empty-state.create-terminal',
   emptyStateCreateNote: 'empty-state.create-note',
+  emptyStateCreateWeb: 'empty-state.create-web',
 } as const;
 
 export const NODE_TYPE_LABELS: Record<CanvasNode['type'], string> = {
@@ -57,6 +58,12 @@ export const EMPTY_CANVAS_ACTIONS: Array<{
     label: 'New Note',
     description: 'Capture ideas, plans, and summaries.',
     nodeType: 'file',
+  },
+  {
+    actionKey: INTERACTION_ACTIONS.emptyStateCreateWeb,
+    label: 'Web Page',
+    description: 'Embed a URL or open a blank page.',
+    nodeType: 'iframe',
   },
 ];
 

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -96,7 +96,7 @@ export interface TextNodeData {
  * escape into the system browser.
  */
 export interface IframeNodeData {
-  /** Full URL (including protocol) to load in the iframe. Empty = show URL input. */
+  /** Full URL (including protocol) to load in the iframe. Empty = show URL input. `about:blank` opens a blank page. */
   url: string;
   /** Raw HTML content to render when `mode` is `'html'` or `'ai'`. */
   html?: string;


### PR DESCRIPTION
## Summary
- Support opening blank web pages in canvas Web nodes via `blank` / `about:blank` and a dedicated button.
- Increase Canvas Agent max steps to 200.
- Add Web Page entry points in empty canvas, toolbar/menu labels, and command palette aliases.

## Test
- pnpm --filter canvas-workspace typecheck