### PR TITLE
feat: add canvas artifact nodes

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/ArtifactNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ArtifactNodeBody/index.css
@@ -1,0 +1,244 @@
+.artifact-node-body {
+  height: 100%;
+  overflow: auto;
+  padding: 14px 16px 12px;
+  box-sizing: border-box;
+  color: #1f2430;
+  background:
+    radial-gradient(circle at 12% 0%, rgba(151, 105, 255, 0.10), transparent 26%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(250, 248, 255, 0.96));
+}
+
+.artifact-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.artifact-badge {
+  display: inline-flex;
+  align-items: center;
+  height: 22px;
+  padding: 0 9px;
+  border-radius: 999px;
+  background: rgba(126, 87, 194, 0.12);
+  color: #6f42c1;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.artifact-actions {
+  display: inline-flex;
+  gap: 6px;
+}
+
+.artifact-actions button {
+  width: 24px;
+  height: 24px;
+  border: 1px solid rgba(111, 66, 193, 0.20);
+  border-radius: 7px;
+  background: rgba(255, 255, 255, 0.78);
+  color: #6f42c1;
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1;
+}
+
+.artifact-actions button:hover {
+  background: rgba(126, 87, 194, 0.10);
+}
+
+.artifact-summary {
+  margin: 0 0 12px;
+  color: #4c5568;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.artifact-widgets {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.artifact-heading {
+  margin: 5px 0 0;
+  color: #161b26;
+  font-weight: 750;
+  letter-spacing: -0.02em;
+}
+
+h1.artifact-heading { font-size: 22px; }
+h2.artifact-heading { font-size: 18px; }
+h3.artifact-heading { font-size: 15px; }
+h4.artifact-heading { font-size: 13px; }
+
+.artifact-paragraph {
+  margin: 0;
+  color: #303846;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.artifact-callout {
+  border: 1px solid rgba(99, 102, 241, 0.18);
+  border-left-width: 4px;
+  border-radius: 12px;
+  padding: 10px 12px;
+  background: rgba(99, 102, 241, 0.07);
+}
+
+.artifact-callout--warning {
+  border-color: rgba(245, 158, 11, 0.30);
+  background: rgba(245, 158, 11, 0.10);
+}
+
+.artifact-callout--success {
+  border-color: rgba(34, 197, 94, 0.30);
+  background: rgba(34, 197, 94, 0.09);
+}
+
+.artifact-callout--danger {
+  border-color: rgba(239, 68, 68, 0.30);
+  background: rgba(239, 68, 68, 0.09);
+}
+
+.artifact-callout-title {
+  margin-bottom: 4px;
+  font-size: 12px;
+  font-weight: 750;
+  color: #252b3a;
+}
+
+.artifact-callout-text {
+  color: #3f4758;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.artifact-list {
+  margin: 0;
+  padding-left: 18px;
+  color: #2f3747;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.artifact-list--checklist {
+  padding-left: 0;
+  list-style: none;
+}
+
+.artifact-list--checklist li {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 4px 0;
+}
+
+.artifact-check {
+  flex: 0 0 auto;
+  width: 15px;
+  height: 15px;
+  margin-top: 2px;
+  border-radius: 4px;
+  border: 1px solid rgba(111, 66, 193, 0.30);
+  color: white;
+  font-size: 10px;
+  line-height: 14px;
+  text-align: center;
+}
+
+.artifact-check--done {
+  background: #7c3aed;
+  border-color: #7c3aed;
+}
+
+.artifact-table-wrap {
+  overflow: auto;
+  border: 1px solid rgba(88, 96, 116, 0.13);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.artifact-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.artifact-table th,
+.artifact-table td {
+  padding: 8px 10px;
+  border-bottom: 1px solid rgba(88, 96, 116, 0.10);
+  text-align: left;
+  vertical-align: top;
+}
+
+.artifact-table th {
+  color: #596174;
+  font-weight: 750;
+  background: rgba(245, 243, 255, 0.86);
+}
+
+.artifact-table tr:last-child td {
+  border-bottom: none;
+}
+
+.artifact-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(92px, 1fr));
+  gap: 9px;
+}
+
+.artifact-stat {
+  border: 1px solid rgba(111, 66, 193, 0.16);
+  border-radius: 14px;
+  padding: 10px 11px;
+  background: rgba(255, 255, 255, 0.76);
+  box-shadow: 0 6px 18px rgba(45, 35, 80, 0.05);
+}
+
+.artifact-stat-value {
+  color: #5b21b6;
+  font-size: 22px;
+  font-weight: 800;
+  line-height: 1.05;
+}
+
+.artifact-stat-label {
+  margin-top: 5px;
+  color: #333b4d;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.artifact-stat-caption {
+  margin-top: 3px;
+  color: #697386;
+  font-size: 11px;
+}
+
+.artifact-code {
+  margin: 0;
+  padding: 11px 12px;
+  border-radius: 12px;
+  background: #171923;
+  color: #e5e7eb;
+  font-size: 12px;
+  line-height: 1.5;
+  overflow: auto;
+}
+
+.artifact-footer {
+  margin-top: 14px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(111, 66, 193, 0.14);
+  color: #747b8d;
+  font-size: 11px;
+  line-height: 1.4;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/ArtifactNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ArtifactNodeBody/index.tsx
@@ -1,0 +1,159 @@
+import type { MouseEvent } from 'react';
+import type { ArtifactNodeData, ArtifactWidget } from '../../types';
+import './index.css';
+
+interface ArtifactNodeBodyProps {
+  data: ArtifactNodeData;
+  onCopyMarkdown?: () => void;
+  onRegenerate?: () => void;
+}
+
+const escapeCell = (value: string | number | boolean | null | undefined): string => {
+  const text = value == null ? '' : String(value);
+  return text.replace(/\|/g, '\\|').replace(/\n/g, '<br>');
+};
+
+export const artifactToMarkdown = (title: string, data: ArtifactNodeData): string => {
+  const lines: string[] = [`# ${title}`, ''];
+  if (data.summary) {
+    lines.push(data.summary, '');
+  }
+
+  for (const widget of data.widgets) {
+    switch (widget.type) {
+      case 'heading':
+        lines.push(`${'#'.repeat(Math.min(Math.max(widget.level ?? 2, 1), 4))} ${widget.text}`, '');
+        break;
+      case 'paragraph':
+        lines.push(widget.text, '');
+        break;
+      case 'callout':
+        lines.push(`> **${widget.tone ?? 'note'}** ${widget.title ? `${widget.title}: ` : ''}${widget.text}`, '');
+        break;
+      case 'list':
+        for (const item of widget.items) {
+          const mark = widget.ordered ? '1.' : widget.checklist ? (item.checked ? '- [x]' : '- [ ]') : '-';
+          lines.push(`${mark} ${item.text}`);
+        }
+        lines.push('');
+        break;
+      case 'table': {
+        const headers = widget.columns.map(escapeCell);
+        lines.push(`| ${headers.join(' | ')} |`);
+        lines.push(`| ${headers.map(() => '---').join(' | ')} |`);
+        for (const row of widget.rows) {
+          lines.push(`| ${widget.columns.map((column) => escapeCell(row[column])).join(' | ')} |`);
+        }
+        lines.push('');
+        break;
+      }
+      case 'stats':
+        for (const stat of widget.items) {
+          lines.push(`- **${stat.label}:** ${stat.value}${stat.caption ? ` — ${stat.caption}` : ''}`);
+        }
+        lines.push('');
+        break;
+      case 'code':
+        lines.push(`\`\`\`${widget.language ?? ''}`, widget.code, '```', '');
+        break;
+    }
+  }
+
+  if (data.sources?.length) {
+    lines.push('---', `Generated from ${data.sources.map((source) => `@${source.title}`).join(', ')}`);
+  }
+  if (data.generatedAt) {
+    lines.push(`Generated at ${new Date(data.generatedAt).toLocaleString()}`);
+  }
+  return lines.join('\n').trimEnd();
+};
+
+const stop = (event: MouseEvent) => event.stopPropagation();
+
+const WidgetRenderer = ({ widget }: { widget: ArtifactWidget }) => {
+  switch (widget.type) {
+    case 'heading': {
+      const Tag = (`h${Math.min(Math.max(widget.level ?? 2, 1), 4)}` as keyof JSX.IntrinsicElements);
+      return <Tag className="artifact-heading">{widget.text}</Tag>;
+    }
+    case 'paragraph':
+      return <p className="artifact-paragraph">{widget.text}</p>;
+    case 'callout':
+      return (
+        <div className={`artifact-callout artifact-callout--${widget.tone ?? 'info'}`}>
+          {widget.title ? <div className="artifact-callout-title">{widget.title}</div> : null}
+          <div className="artifact-callout-text">{widget.text}</div>
+        </div>
+      );
+    case 'list':
+      return widget.ordered ? (
+        <ol className="artifact-list artifact-list--ordered">
+          {widget.items.map((item, index) => <li key={index}>{item.text}</li>)}
+        </ol>
+      ) : (
+        <ul className={`artifact-list ${widget.checklist ? 'artifact-list--checklist' : ''}`}>
+          {widget.items.map((item, index) => (
+            <li key={index}>
+              {widget.checklist ? <span className={`artifact-check ${item.checked ? 'artifact-check--done' : ''}`}>{item.checked ? '✓' : ''}</span> : null}
+              <span>{item.text}</span>
+            </li>
+          ))}
+        </ul>
+      );
+    case 'table':
+      return (
+        <div className="artifact-table-wrap">
+          <table className="artifact-table">
+            <thead>
+              <tr>{widget.columns.map((column) => <th key={column}>{column}</th>)}</tr>
+            </thead>
+            <tbody>
+              {widget.rows.map((row, rowIndex) => (
+                <tr key={rowIndex}>
+                  {widget.columns.map((column) => <td key={column}>{String(row[column] ?? '')}</td>)}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
+    case 'stats':
+      return (
+        <div className="artifact-stats">
+          {widget.items.map((stat, index) => (
+            <div className="artifact-stat" key={index}>
+              <div className="artifact-stat-value">{stat.value}</div>
+              <div className="artifact-stat-label">{stat.label}</div>
+              {stat.caption ? <div className="artifact-stat-caption">{stat.caption}</div> : null}
+            </div>
+          ))}
+        </div>
+      );
+    case 'code':
+      return (
+        <pre className="artifact-code"><code>{widget.code}</code></pre>
+      );
+  }
+};
+
+export const ArtifactNodeBody = ({ data, onCopyMarkdown, onRegenerate }: ArtifactNodeBodyProps) => {
+  return (
+    <div className="artifact-node-body" onMouseDown={stop}>
+      <div className="artifact-toolbar">
+        <span className="artifact-badge">AI Artifact</span>
+        <div className="artifact-actions">
+          {onRegenerate ? <button type="button" onClick={onRegenerate} title="Regenerate from original prompt">⟳</button> : null}
+          {onCopyMarkdown ? <button type="button" onClick={onCopyMarkdown} title="Copy as Markdown">⎘</button> : null}
+        </div>
+      </div>
+      {data.summary ? <p className="artifact-summary">{data.summary}</p> : null}
+      <div className="artifact-widgets">
+        {data.widgets.map((widget, index) => <WidgetRenderer widget={widget} key={index} />)}
+      </div>
+      <div className="artifact-footer">
+        {data.sources?.length ? <span>Generated from {data.sources.map((source) => `@${source.title}`).join(', ')}</span> : <span>Generated artifact</span>}
+        {data.generatedAt ? <span> · {new Date(data.generatedAt).toLocaleString()}</span> : null}
+      </div>
+    </div>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
@@ -28,11 +28,11 @@ interface CanvasOverlaysProps {
   onChatToggle?: () => void;
   referenceDrawerOpen?: boolean;
   onReferenceToggle?: () => void;
-  onCreateNode: (type: 'file' | 'terminal' | 'frame' | 'group' | 'agent' | 'text' | 'iframe' | 'mindmap') => void;
+  onCreateNode: (type: 'file' | 'terminal' | 'frame' | 'group' | 'agent' | 'text' | 'iframe' | 'mindmap' | 'artifact') => void;
   onCloseContextMenu: () => void;
   onOpenShortcuts: () => void;
   onToolChange: (tool: string) => void;
-  onAddNode: (type: 'file' | 'terminal' | 'frame' | 'group' | 'agent' | 'text' | 'iframe' | 'mindmap') => void;
+  onAddNode: (type: 'file' | 'terminal' | 'frame' | 'group' | 'agent' | 'text' | 'iframe' | 'mindmap' | 'artifact') => void;
   onResetTransform: () => void;
   /** Commands shown in the Cmd+K palette alongside node search results.
    *  Built by the parent so each entry can capture the latest tool /

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -716,7 +716,7 @@ export const Canvas = ({
   );
 
   const handleCreateNode = useCallback(
-    (type: 'file' | 'terminal' | 'frame' | 'group' | 'agent' | 'text' | 'iframe' | 'mindmap') => {
+    (type: 'file' | 'terminal' | 'frame' | 'group' | 'agent' | 'text' | 'iframe' | 'mindmap' | 'artifact') => {
       if (!contextMenu) return;
       const node = addNode(type, contextMenu.canvasX, contextMenu.canvasY);
       setSelectedNodeIds([node.id]);
@@ -768,7 +768,7 @@ export const Canvas = ({
   );
 
   const handleToolbarAddNode = useCallback(
-    (type: 'file' | 'terminal' | 'frame' | 'group' | 'agent' | 'text' | 'iframe' | 'mindmap') => {
+    (type: 'file' | 'terminal' | 'frame' | 'group' | 'agent' | 'text' | 'iframe' | 'mindmap' | 'artifact') => {
       if (!containerRef.current) return;
       const rect = containerRef.current.getBoundingClientRect();
       const pos = screenToCanvas(rect.left + rect.width / 2, rect.top + rect.height / 2, containerRef.current);
@@ -779,6 +779,7 @@ export const Canvas = ({
         : type === 'text' ? 130
         : type === 'iframe' ? 260
         : type === 'mindmap' ? 320
+        : type === 'artifact' ? 260
         : 300;
       const halfH =
         type === 'frame' ? 200
@@ -786,6 +787,7 @@ export const Canvas = ({
         : type === 'text' ? 60
         : type === 'iframe' ? 200
         : type === 'mindmap' ? 210
+        : type === 'artifact' ? 210
         : 150;
       const node = addNode(type, pos.x - halfW, pos.y - halfH);
       setSelectedNodeIds([node.id]);
@@ -933,6 +935,14 @@ export const Canvas = ({
         title: 'New mindmap',
         aliases: ['tree', 'topic', 'outline'],
         run: () => handleToolbarAddNode('mindmap'),
+      },
+      {
+        id: 'create-artifact',
+        group: 'create',
+        title: 'New artifact',
+        hint: 'Structured AI output card',
+        aliases: ['artifact', 'report', 'rich output', 'ai output'],
+        run: () => handleToolbarAddNode('artifact'),
       },
       // Navigate / View
       {

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, useState, useEffect, useRef } from "react";
 import "./index.css";
-import type { CanvasNode, FrameNodeData, GroupNodeData, AgentNodeData, TextNodeData } from "../../types";
+import type { ArtifactNodeData, CanvasNode, FrameNodeData, GroupNodeData, AgentNodeData, TextNodeData } from "../../types";
 import type { ResizeEdge } from "../../hooks/useNodeResize";
 import { FileNodeBody } from "../FileNodeBody";
 import { TerminalNodeBody } from "../TerminalNodeBody";
@@ -11,8 +11,10 @@ import { IframeNodeBody } from "../IframeNodeBody";
 import { ImageNodeBody } from "../ImageNodeBody";
 import { ShapeNodeBody, ShapeStylePicker } from "../ShapeNodeBody";
 import { MindmapNodeBody } from "../MindmapNodeBody";
+import { ArtifactNodeBody, artifactToMarkdown } from "../ArtifactNodeBody";
 import { NodeContextMenu } from "../NodeContextMenu";
 import { collectContainerDescendants } from "../../utils/frameHierarchy";
+import { copyTextToClipboard } from "../../utils/clipboard";
 
 interface Props {
   node: CanvasNode;
@@ -224,6 +226,22 @@ const CanvasNodeViewComponent = ({
     },
     [readOnly]
   );
+
+  const handleCopyArtifactMarkdown = useCallback(() => {
+    if (node.type !== "artifact") return;
+    void copyTextToClipboard(artifactToMarkdown(node.title, node.data as ArtifactNodeData));
+  }, [node]);
+
+  const handleRegenerateArtifact = useCallback(() => {
+    if (node.type !== "artifact" || readOnly) return;
+    const data = node.data as ArtifactNodeData;
+    onUpdate(node.id, {
+      data: {
+        ...data,
+        generatedAt: new Date().toISOString(),
+      },
+    });
+  }, [node, onUpdate, readOnly]);
 
   const makeResizeHandler = useCallback(
     (edge: ResizeEdge) => (e: React.MouseEvent) => {
@@ -470,6 +488,12 @@ const CanvasNodeViewComponent = ({
               <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.3" />
               <path d="M2 8h12M8 2c2 2 2 10 0 12M8 2c-2 2-2 10 0 12" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" />
             </svg>
+          ) : node.type === "artifact" ? (
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+              <rect x="2.5" y="2.5" width="11" height="11" rx="2" stroke="currentColor" strokeWidth="1.3" />
+              <path d="M5 6h6M5 8.5h4M5 11h5.5" stroke="currentColor" strokeWidth="1.15" strokeLinecap="round" />
+              <path d="M11.4 1.8v2.8M10 3.2h2.8" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" />
+            </svg>
           ) : (
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
               <circle cx="8" cy="5.5" r="3" stroke="currentColor" strokeWidth="1.3" />
@@ -580,6 +604,12 @@ const CanvasNodeViewComponent = ({
           />
         ) : node.type === "iframe" ? (
           <IframeNodeBody node={node} workspaceId={workspaceId} onUpdate={onUpdate} isResizing={isResizing} readOnly={readOnly} />
+        ) : node.type === "artifact" ? (
+          <ArtifactNodeBody
+            data={node.data as ArtifactNodeData}
+            onCopyMarkdown={handleCopyArtifactMarkdown}
+            onRegenerate={readOnly ? undefined : handleRegenerateArtifact}
+          />
         ) : (
           <AgentNodeBody node={node} rootFolder={rootFolder} workspaceId={workspaceId} workspaceName={workspaceName} onUpdate={onUpdate} readOnly={readOnly} />
         )}

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
@@ -4,7 +4,7 @@ import { ShapeToolButton } from './ShapeToolButton';
 interface Props {
   activeTool: string;
   onToolChange: (tool: string) => void;
-  onAddNode: (type: "file" | "terminal" | "frame" | "group" | "agent" | "text" | "iframe" | "mindmap") => void;
+  onAddNode: (type: "file" | "terminal" | "frame" | "group" | "agent" | "text" | "iframe" | "mindmap" | "artifact") => void;
   chatPanelOpen?: boolean;
   onChatToggle?: () => void;
   referenceDrawerOpen?: boolean;
@@ -223,6 +223,18 @@ export const FloatingToolbar = ({
             />
           </svg>
           <span className="toolbar-btn-label">Mindmap</span>
+        </button>
+        <button
+          className="toolbar-btn toolbar-btn--create"
+          onClick={() => onAddNode("artifact")}
+          title="Add AI Artifact"
+        >
+          <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+            <rect x="3" y="3" width="12" height="12" rx="2.5" stroke="currentColor" strokeWidth="1.3" />
+            <path d="M6 7h6M6 9.5h4M6 12h5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+            <path d="M13 2v3M11.5 3.5h3" stroke="currentColor" strokeWidth="1.15" strokeLinecap="round" />
+          </svg>
+          <span className="toolbar-btn-label">Artifact</span>
         </button>
       </div>
     </div>

--- a/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
@@ -6,7 +6,7 @@ interface Props {
   x: number;
   y: number;
   mode?: "create" | "mindmap";
-  onCreate?: (type: "file" | "terminal" | "frame" | "group" | "agent" | "text" | "iframe" | "mindmap") => void;
+  onCreate?: (type: "file" | "terminal" | "frame" | "group" | "agent" | "text" | "iframe" | "mindmap" | "artifact") => void;
   onExportImage?: () => void;
   onClose: () => void;
 }
@@ -119,6 +119,16 @@ export const NodeContextMenu = ({ x, y, mode = "create", onCreate, onExportImage
             <span className="context-menu-label">
               <strong>Mindmap</strong>
               <small>Branching topic tree</small>
+            </span>
+          </button>
+          <button
+            className="context-menu-item"
+            onClick={() => onCreate?.("artifact")}
+          >
+            <span className="context-menu-icon">{"✦"}</span>
+            <span className="context-menu-label">
+              <strong>Artifact</strong>
+              <small>Structured AI output card</small>
             </span>
           </button>
         </>

--- a/apps/canvas-workspace/src/renderer/src/constants/interaction.ts
+++ b/apps/canvas-workspace/src/renderer/src/constants/interaction.ts
@@ -32,6 +32,7 @@ export const NODE_TYPE_LABELS: Record<CanvasNode['type'], string> = {
   image: 'Image',
   shape: 'Shape',
   mindmap: 'Mindmap',
+  artifact: 'Artifact',
 };
 
 export const EMPTY_CANVAS_ACTIONS: Array<{

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
@@ -4,6 +4,7 @@ import type {
   CanvasNode,
   CanvasSaveData,
   CanvasTransform,
+  ArtifactNodeData,
   FileNodeData,
   FrameNodeData,
   GroupNodeData,
@@ -561,7 +562,16 @@ export const useNodes = (
                         rev: 0,
                       } satisfies MindmapNodeData;
                     })()
-                  : createNodeData(source.type),
+                  : source.type === 'artifact'
+                    ? (() => {
+                        const src = source.data as ArtifactNodeData;
+                        return {
+                          ...src,
+                          widgets: [...src.widgets],
+                          sources: src.sources ? [...src.sources] : undefined,
+                        } satisfies ArtifactNodeData;
+                      })()
+                    : createNodeData(source.type),
         updatedAt: Date.now(),
       };
       if (newNode.type === 'file') {
@@ -623,7 +633,16 @@ export const useNodes = (
                         rev: 0,
                       } satisfies MindmapNodeData;
                     })()
-                  : createNodeData(source.type),
+                  : source.type === 'artifact'
+                    ? (() => {
+                        const src = source.data as ArtifactNodeData;
+                        return {
+                          ...src,
+                          widgets: [...src.widgets],
+                          sources: src.sources ? [...src.sources] : undefined,
+                        } satisfies ArtifactNodeData;
+                      })()
+                    : createNodeData(source.type),
         updatedAt: now,
       }));
       newNodes.forEach((newNode) => {

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -1,6 +1,6 @@
 export interface CanvasNode {
   id: string;
-  type: "file" | "terminal" | "frame" | "group" | "agent" | "text" | "iframe" | "image" | "shape" | "mindmap";
+  type: "file" | "terminal" | "frame" | "group" | "agent" | "text" | "iframe" | "image" | "shape" | "mindmap" | "artifact";
   title: string;
   x: number;
   y: number;
@@ -16,7 +16,8 @@ export interface CanvasNode {
     | IframeNodeData
     | ImageNodeData
     | ShapeNodeData
-    | MindmapNodeData;
+    | MindmapNodeData
+    | ArtifactNodeData;
   /** Epoch millis of last mutation; used for cross-process merge. */
   updatedAt?: number;
 }
@@ -176,6 +177,34 @@ export interface MindmapNodeData {
   /** Bumped on every topic add/remove/rename — lets external observers
    *  (canvas-cli, agent) diff mindmaps without structural equality. */
   rev?: number;
+}
+
+export type ArtifactCalloutTone = 'info' | 'note' | 'success' | 'warning' | 'danger';
+
+export interface ArtifactSource {
+  title: string;
+  nodeId?: string;
+  url?: string;
+}
+
+export type ArtifactTableCell = string | number | boolean | null | undefined;
+
+export type ArtifactWidget =
+  | { type: 'heading'; text: string; level?: 1 | 2 | 3 | 4 }
+  | { type: 'paragraph'; text: string }
+  | { type: 'callout'; text: string; title?: string; tone?: ArtifactCalloutTone }
+  | { type: 'list'; items: Array<{ text: string; checked?: boolean }>; ordered?: boolean; checklist?: boolean }
+  | { type: 'table'; columns: string[]; rows: Array<Record<string, ArtifactTableCell>> }
+  | { type: 'stats'; items: Array<{ label: string; value: string | number; caption?: string }> }
+  | { type: 'code'; code: string; language?: string };
+
+export interface ArtifactNodeData {
+  summary?: string;
+  widgets: ArtifactWidget[];
+  sources?: ArtifactSource[];
+  generatedAt?: string;
+  /** Original prompt/instruction, when this artifact came from an AI generation flow. */
+  prompt?: string;
 }
 
 export interface CanvasTransform {

--- a/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
@@ -1,4 +1,4 @@
-import type { CanvasNode, FileNodeData, TerminalNodeData, FrameNodeData, GroupNodeData, AgentNodeData, TextNodeData, IframeNodeData, ImageNodeData, ShapeNodeData, MindmapNodeData, MindmapTopic } from '../types';
+import type { CanvasNode, FileNodeData, TerminalNodeData, FrameNodeData, GroupNodeData, AgentNodeData, TextNodeData, IframeNodeData, ImageNodeData, ShapeNodeData, MindmapNodeData, MindmapTopic, ArtifactNodeData } from '../types';
 
 let nodeIdCounter = 0;
 export const genId = (): string => `node-${Date.now()}-${++nodeIdCounter}`;
@@ -17,9 +17,10 @@ const NODE_DEFAULTS: Record<CanvasNode['type'], { title: string; width: number; 
   image:    { title: 'Image',    width: 320, height: 240 },
   shape:    { title: 'Shape',    width: 200, height: 140 },
   mindmap:  { title: 'Mindmap',  width: 640, height: 420 },
+  artifact: { title: 'Artifact', width: 520, height: 420 },
 };
 
-export const createNodeData = (type: CanvasNode['type']): FileNodeData | TerminalNodeData | FrameNodeData | GroupNodeData | AgentNodeData | TextNodeData | IframeNodeData | ImageNodeData | ShapeNodeData | MindmapNodeData => {
+export const createNodeData = (type: CanvasNode['type']): FileNodeData | TerminalNodeData | FrameNodeData | GroupNodeData | AgentNodeData | TextNodeData | IframeNodeData | ImageNodeData | ShapeNodeData | MindmapNodeData | ArtifactNodeData => {
   switch (type) {
     case 'file':     return { filePath: '', content: '', saved: false, modified: false };
     case 'terminal': return { sessionId: '' };
@@ -42,6 +43,18 @@ export const createNodeData = (type: CanvasNode['type']): FileNodeData | Termina
       },
       layout: 'right',
       rev: 0,
+    };
+    case 'artifact': return {
+      summary: 'A structured AI artifact. Replace this sample with generated content or use it as a reusable report card.',
+      widgets: [
+        { type: 'heading', level: 2, text: 'Artifact outline' },
+        { type: 'paragraph', text: 'Use artifact nodes for rich AI outputs such as plans, research digests, specs, tables, metrics, and code snippets.' },
+        { type: 'list', checklist: true, items: [
+          { text: 'Review generated content', checked: false },
+          { text: 'Copy as Markdown when needed', checked: false },
+        ] },
+      ],
+      generatedAt: new Date().toISOString(),
     };
   }
 };


### PR DESCRIPTION
Add structured AI artifact nodes to the canvas workspace.

- Add artifact node data types, defaults, duplication, and paste handling
- Render rich artifact widgets including headings, callouts, lists, tables, stats, and code blocks
- Add Markdown copy and regenerate timestamp actions
- Expose artifact creation from toolbar, context menu, and command palette

Validation:
- pnpm --filter canvas-workspace typecheck:renderer
- pnpm --filter canvas-workspace typecheck
- pnpm --filter canvas-workspace build