### PR TITLE
feat(canvas): inline visuals + versioned artifacts with canvas pinning

### DIFF
--- a/apps/canvas-workspace/src/main/artifact-ipc.ts
+++ b/apps/canvas-workspace/src/main/artifact-ipc.ts
@@ -1,0 +1,250 @@
+/**
+ * IPC handlers for the workspace artifact store.
+ *
+ * Channels:
+ *   artifact:list         (workspaceId)                          → Artifact[]
+ *   artifact:get          (workspaceId, artifactId)              → Artifact | null
+ *   artifact:create       (workspaceId, input)                   → Artifact
+ *   artifact:add-version  (workspaceId, artifactId, input)       → Artifact
+ *   artifact:update       (workspaceId, artifactId, patch)       → Artifact
+ *   artifact:delete       (workspaceId, artifactId)              → boolean
+ *   artifact:pin-to-canvas (workspaceId, artifactId, placement)  → { nodeId, artifact }
+ *
+ * Plus a broadcast channel `artifact:change` for renderer subscriptions
+ * (fired from artifact-store.ts directly).
+ */
+
+import { ipcMain } from 'electron';
+import { promises as fs } from 'fs';
+import { dirname, basename, join } from 'path';
+import { getWorkspaceDir } from './canvas-store';
+import {
+  addArtifactVersion,
+  createArtifact,
+  deleteArtifact,
+  getArtifact,
+  listArtifacts,
+  updateArtifact,
+  type Artifact,
+  type ArtifactType,
+} from './artifact-store';
+import { broadcastCanvasUpdate } from './canvas-broadcast';
+
+const BLANK_PAGE_URL = 'about:blank';
+
+interface PinPlacement {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  title?: string;
+}
+
+interface CanvasNode {
+  id: string;
+  type: string;
+  title: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  data: Record<string, unknown>;
+  updatedAt?: number;
+}
+
+interface CanvasSaveData {
+  nodes: CanvasNode[];
+  edges?: unknown[];
+  transform: { x: number; y: number; scale: number };
+  savedAt: string;
+}
+
+function canvasPath(workspaceId: string): string {
+  return join(getWorkspaceDir(workspaceId), 'canvas.json');
+}
+
+async function atomicWrite(finalPath: string, body: string): Promise<void> {
+  const dir = dirname(finalPath);
+  const tmp = join(dir, `${basename(finalPath)}.tmp`);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(tmp, body, 'utf-8');
+  await fs.rename(tmp, finalPath);
+}
+
+async function loadCanvas(workspaceId: string): Promise<CanvasSaveData | null> {
+  try {
+    const raw = await fs.readFile(canvasPath(workspaceId), 'utf-8');
+    const data = JSON.parse(raw) as CanvasSaveData;
+    data.nodes = data.nodes ?? [];
+    return data;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+function autoPlace(nodes: CanvasNode[]): { x: number; y: number } {
+  if (nodes.length === 0) return { x: 100, y: 100 };
+  let maxRight = 0;
+  let bestY = 100;
+  for (const n of nodes) {
+    const right = n.x + n.width;
+    if (right > maxRight) {
+      maxRight = right;
+      bestY = n.y;
+    }
+  }
+  return { x: maxRight + 40, y: bestY };
+}
+
+/**
+ * Pin an artifact to the canvas by creating an iframe node whose
+ * `data.artifactId` references it. The node renders the artifact's current
+ * version live — bumping the artifact updates the node automatically.
+ *
+ * Exported so the canvas-agent's `artifact_pin_to_canvas` tool can call
+ * the same code path as the renderer-side "Pin to Canvas" button.
+ */
+export async function pinArtifactToCanvas(
+  workspaceId: string,
+  artifactId: string,
+  placement: PinPlacement = {},
+): Promise<{ nodeId: string; artifact: Artifact } | { error: string }> {
+  const artifact = await getArtifact(workspaceId, artifactId);
+  if (!artifact) return { error: `Artifact not found: ${artifactId}` };
+
+  const canvas = await loadCanvas(workspaceId);
+  if (!canvas) {
+    // Fresh workspace — bootstrap an empty canvas. Same shape canvas-store
+    // creates on first save; safe because we're adding our node immediately.
+    const bootstrap: CanvasSaveData = {
+      nodes: [],
+      edges: [],
+      transform: { x: 0, y: 0, scale: 1 },
+      savedAt: new Date().toISOString(),
+    };
+    return await writeWithNewNode(workspaceId, bootstrap, artifact, placement);
+  }
+  return await writeWithNewNode(workspaceId, canvas, artifact, placement);
+}
+
+async function writeWithNewNode(
+  workspaceId: string,
+  canvas: CanvasSaveData,
+  artifact: Artifact,
+  placement: PinPlacement,
+): Promise<{ nodeId: string; artifact: Artifact }> {
+  const nodeId = `node-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const pos = (placement.x != null && placement.y != null)
+    ? { x: placement.x, y: placement.y }
+    : autoPlace(canvas.nodes);
+
+  const node: CanvasNode = {
+    id: nodeId,
+    type: 'iframe',
+    title: placement.title ?? artifact.title ?? 'Artifact',
+    x: pos.x,
+    y: pos.y,
+    width: placement.width ?? 520,
+    height: placement.height ?? 400,
+    data: {
+      url: BLANK_PAGE_URL,
+      mode: 'artifact',
+      artifactId: artifact.id,
+    },
+    updatedAt: Date.now(),
+  };
+
+  canvas.nodes.push(node);
+  canvas.savedAt = new Date().toISOString();
+  await atomicWrite(canvasPath(workspaceId), JSON.stringify(canvas, null, 2));
+
+  // Mark artifact as pinned (best-effort — failure here doesn't undo the node).
+  const updated = await updateArtifact(workspaceId, artifact.id, { pinnedNodeId: nodeId }) ?? artifact;
+
+  broadcastCanvasUpdate(workspaceId, [nodeId]);
+  return { nodeId, artifact: updated };
+}
+
+export function setupArtifactIpc(): void {
+  ipcMain.handle('artifact:list', async (_event, payload: { workspaceId: string }) => {
+    try {
+      const artifacts = await listArtifacts(payload.workspaceId);
+      return { ok: true, artifacts };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  });
+
+  ipcMain.handle('artifact:get', async (_event, payload: { workspaceId: string; artifactId: string }) => {
+    try {
+      const artifact = await getArtifact(payload.workspaceId, payload.artifactId);
+      return { ok: true, artifact: artifact ?? undefined };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  });
+
+  ipcMain.handle('artifact:create', async (_event, payload: {
+    workspaceId: string;
+    input: { type: ArtifactType; title: string; content: string; prompt?: string; source?: Artifact['source'] };
+  }) => {
+    try {
+      const artifact = await createArtifact(payload.workspaceId, payload.input);
+      return { ok: true, artifact };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  });
+
+  ipcMain.handle('artifact:add-version', async (_event, payload: {
+    workspaceId: string;
+    artifactId: string;
+    input: { content: string; prompt?: string };
+  }) => {
+    try {
+      const artifact = await addArtifactVersion(payload.workspaceId, payload.artifactId, payload.input);
+      if (!artifact) return { ok: false, error: 'Artifact not found' };
+      return { ok: true, artifact };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  });
+
+  ipcMain.handle('artifact:update', async (_event, payload: {
+    workspaceId: string;
+    artifactId: string;
+    patch: Partial<Pick<Artifact, 'title' | 'currentVersionId' | 'pinnedNodeId'>>;
+  }) => {
+    try {
+      const artifact = await updateArtifact(payload.workspaceId, payload.artifactId, payload.patch);
+      if (!artifact) return { ok: false, error: 'Artifact not found' };
+      return { ok: true, artifact };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  });
+
+  ipcMain.handle('artifact:delete', async (_event, payload: { workspaceId: string; artifactId: string }) => {
+    try {
+      const ok = await deleteArtifact(payload.workspaceId, payload.artifactId);
+      return { ok };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  });
+
+  ipcMain.handle('artifact:pin-to-canvas', async (_event, payload: {
+    workspaceId: string;
+    artifactId: string;
+    placement?: PinPlacement;
+  }) => {
+    try {
+      const result = await pinArtifactToCanvas(payload.workspaceId, payload.artifactId, payload.placement ?? {});
+      if ('error' in result) return { ok: false, error: result.error };
+      return { ok: true, nodeId: result.nodeId, artifact: result.artifact };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  });
+}

--- a/apps/canvas-workspace/src/main/artifact-store.ts
+++ b/apps/canvas-workspace/src/main/artifact-store.ts
@@ -1,0 +1,218 @@
+/**
+ * Artifact store — per-workspace persistence of LLM-generated visual products.
+ *
+ * Storage layout:
+ *   ~/.pulse-coder/canvas/<workspaceId>/artifacts.json
+ *
+ * Shape on disk:
+ *   { version: 1, artifacts: Artifact[] }
+ *
+ * Atomic writes via `<path>.tmp` + rename so concurrent readers never see a
+ * truncated file. No `.bak` rotation here — artifacts are losable in the
+ * worst case (regenerable from the chat), unlike canvas.json which holds
+ * the user's spatial layout.
+ */
+
+import { BrowserWindow } from 'electron';
+import { promises as fs } from 'fs';
+import { dirname, join, basename } from 'path';
+import { homedir } from 'os';
+import { randomUUID } from 'crypto';
+
+const STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
+const FILE_VERSION = 1;
+
+export type ArtifactType = 'html' | 'svg' | 'mermaid';
+
+export interface ArtifactVersion {
+  id: string;
+  content: string;
+  prompt?: string;
+  createdAt: number;
+}
+
+export interface Artifact {
+  id: string;
+  workspaceId: string;
+  type: ArtifactType;
+  title: string;
+  versions: ArtifactVersion[];
+  currentVersionId: string;
+  pinnedNodeId?: string;
+  source?: {
+    sessionId?: string;
+    messageIndex?: number;
+    origin?: 'agent_tool' | 'inline_promotion' | 'iframe_ai_tab';
+  };
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface ArtifactsFile {
+  version: number;
+  artifacts: Artifact[];
+}
+
+function artifactsPath(workspaceId: string): string {
+  return join(STORE_DIR, workspaceId, 'artifacts.json');
+}
+
+function isEnoent(err: unknown): boolean {
+  return !!err && typeof err === 'object' && (err as { code?: string }).code === 'ENOENT';
+}
+
+async function atomicWrite(finalPath: string, body: string): Promise<void> {
+  const dir = dirname(finalPath);
+  const tmp = join(dir, `${basename(finalPath)}.tmp`);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(tmp, body, 'utf-8');
+  await fs.rename(tmp, finalPath);
+}
+
+async function readArtifacts(workspaceId: string): Promise<Artifact[]> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(artifactsPath(workspaceId), 'utf-8');
+  } catch (err) {
+    if (isEnoent(err)) return [];
+    throw err;
+  }
+  try {
+    const parsed = JSON.parse(raw) as ArtifactsFile;
+    return Array.isArray(parsed.artifacts) ? parsed.artifacts : [];
+  } catch (err) {
+    console.warn(`[artifact-store] failed to parse artifacts.json for "${workspaceId}":`, err);
+    return [];
+  }
+}
+
+async function writeArtifacts(workspaceId: string, artifacts: Artifact[]): Promise<void> {
+  const file: ArtifactsFile = { version: FILE_VERSION, artifacts };
+  await atomicWrite(artifactsPath(workspaceId), JSON.stringify(file, null, 2));
+}
+
+function broadcast(event: { workspaceId: string; artifactId: string; kind: 'create' | 'update' | 'delete' }): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (win.isDestroyed()) continue;
+    win.webContents.send('artifact:change', event);
+  }
+}
+
+// ─── Public API ────────────────────────────────────────────────────
+
+export async function listArtifacts(workspaceId: string): Promise<Artifact[]> {
+  return readArtifacts(workspaceId);
+}
+
+export async function getArtifact(workspaceId: string, artifactId: string): Promise<Artifact | null> {
+  const all = await readArtifacts(workspaceId);
+  return all.find(a => a.id === artifactId) ?? null;
+}
+
+export async function createArtifact(
+  workspaceId: string,
+  input: {
+    type: ArtifactType;
+    title: string;
+    content: string;
+    prompt?: string;
+    source?: Artifact['source'];
+  },
+): Promise<Artifact> {
+  const all = await readArtifacts(workspaceId);
+  const now = Date.now();
+  const versionId = randomUUID();
+  const artifact: Artifact = {
+    id: `art-${now}-${Math.random().toString(36).slice(2, 8)}`,
+    workspaceId,
+    type: input.type,
+    title: input.title || 'Untitled artifact',
+    versions: [
+      {
+        id: versionId,
+        content: input.content,
+        prompt: input.prompt,
+        createdAt: now,
+      },
+    ],
+    currentVersionId: versionId,
+    source: input.source,
+    createdAt: now,
+    updatedAt: now,
+  };
+  all.push(artifact);
+  await writeArtifacts(workspaceId, all);
+  broadcast({ workspaceId, artifactId: artifact.id, kind: 'create' });
+  return artifact;
+}
+
+export async function addArtifactVersion(
+  workspaceId: string,
+  artifactId: string,
+  input: { content: string; prompt?: string },
+): Promise<Artifact | null> {
+  const all = await readArtifacts(workspaceId);
+  const idx = all.findIndex(a => a.id === artifactId);
+  if (idx === -1) return null;
+  const now = Date.now();
+  const versionId = randomUUID();
+  const updated: Artifact = {
+    ...all[idx],
+    versions: [...all[idx].versions, { id: versionId, content: input.content, prompt: input.prompt, createdAt: now }],
+    currentVersionId: versionId,
+    updatedAt: now,
+  };
+  all[idx] = updated;
+  await writeArtifacts(workspaceId, all);
+  broadcast({ workspaceId, artifactId, kind: 'update' });
+  return updated;
+}
+
+export async function updateArtifact(
+  workspaceId: string,
+  artifactId: string,
+  patch: Partial<Pick<Artifact, 'title' | 'currentVersionId' | 'pinnedNodeId'>>,
+): Promise<Artifact | null> {
+  const all = await readArtifacts(workspaceId);
+  const idx = all.findIndex(a => a.id === artifactId);
+  if (idx === -1) return null;
+  // If currentVersionId is patched, verify it actually exists.
+  if (patch.currentVersionId && !all[idx].versions.some(v => v.id === patch.currentVersionId)) {
+    return all[idx];
+  }
+  const updated: Artifact = {
+    ...all[idx],
+    ...patch,
+    updatedAt: Date.now(),
+  };
+  all[idx] = updated;
+  await writeArtifacts(workspaceId, all);
+  broadcast({ workspaceId, artifactId, kind: 'update' });
+  return updated;
+}
+
+export async function deleteArtifact(workspaceId: string, artifactId: string): Promise<boolean> {
+  const all = await readArtifacts(workspaceId);
+  const next = all.filter(a => a.id !== artifactId);
+  if (next.length === all.length) return false;
+  await writeArtifacts(workspaceId, next);
+  broadcast({ workspaceId, artifactId, kind: 'delete' });
+  return true;
+}
+
+/**
+ * Helper for callers (eg the agent tool) — returns the live content for the
+ * current version, or `null` if either the artifact or its current version
+ * is missing.
+ */
+export async function getCurrentVersionContent(
+  workspaceId: string,
+  artifactId: string,
+): Promise<{ content: string; type: ArtifactType; title: string } | null> {
+  const artifact = await getArtifact(workspaceId, artifactId);
+  if (!artifact) return null;
+  const version = artifact.versions.find(v => v.id === artifact.currentVersionId)
+    ?? artifact.versions[artifact.versions.length - 1];
+  if (!version) return null;
+  return { content: version.content, type: artifact.type, title: artifact.title };
+}

--- a/apps/canvas-workspace/src/main/canvas-agent-ipc.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent-ipc.ts
@@ -101,6 +101,21 @@ export function setupCanvasAgentIpc(): void {
             },
             payload.requestContext,
             payload.attachments,
+            (data) => {
+              if (!sender.isDestroyed()) {
+                sender.send(`canvas-agent:tool-input-start:${sessionId}`, data);
+              }
+            },
+            (data) => {
+              if (!sender.isDestroyed()) {
+                sender.send(`canvas-agent:tool-input-delta:${sessionId}`, data);
+              }
+            },
+            (data) => {
+              if (!sender.isDestroyed()) {
+                sender.send(`canvas-agent:tool-input-end:${sessionId}`, data);
+              }
+            },
           );
           if (!sender.isDestroyed()) {
             sender.send(`canvas-agent:chat-complete:${sessionId}`, result);

--- a/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
@@ -60,6 +60,20 @@ Your system prompt contains a summary of all canvas nodes. For detailed content:
 - \`canvas_move_node\`: Reposition a node
 - \`canvas_ask_user\`: **Ask the user a clarifying question** — use this whenever the request is ambiguous, you need a choice between options, or you need confirmation before taking a destructive action. Prefer asking over guessing.
 
+## Visualization Tools — when to use which
+You have three ways to give the user a visual answer. Pick the right level — do NOT default to the heaviest one.
+
+- \`visual_render\`: **temporary inline visual** rendered inside the current chat message. Use for explanatory diagrams, quick charts, illustrations that "aid the discussion" — the kind of thing the user wants to SEE, not necessarily KEEP. Example: "show me how compound interest works" → render an inline chart. The visual lives with the message; the user can promote it to an artifact themselves with a button if they decide to keep it.
+- \`artifact_create\`: **persistent versioned artifact**. Use when the user asks for something to keep, reuse, polish, or iterate on — dashboards, full mockups, finished diagrams, deliverables. Returns an \`artifactId\` you should remember for follow-ups. Later turns can call \`artifact_update\` with the same id to iterate.
+- \`artifact_pin_to_canvas\`: **promote an artifact onto the spatial canvas** as an iframe node. Use when the user wants to compare multiple options side-by-side, build a visual workspace, or hand-arrange the visuals. Always pin an artifact you already created — do NOT use \`canvas_create_node\` with mode=ai for this (that bypasses the artifact store and you lose version history).
+
+Decision shortcut:
+- "explain / show me / visualize" → \`visual_render\`
+- "build / make me a / design / create a [keepable thing]" → \`artifact_create\`
+- "lay out / compare / put on the canvas" → \`artifact_create\` then \`artifact_pin_to_canvas\`
+
+For HTML content in any of the three: emit a single self-contained \`<!DOCTYPE html>\` document. External CDNs (Chart.js, D3, Three.js, Mermaid) work fine. Inline all CSS in \`<head>\` and all scripts at the very end of \`<body>\` so it renders progressively.
+
 ### Delegating Tasks to Agent Nodes
 Use \`canvas_create_agent_node\` to spawn another agent (Claude Code, Codex, Pulse Coder) with context.
 

--- a/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
@@ -271,12 +271,15 @@ export class CanvasAgent {
   async chat(
     message: string,
     onText?: (delta: string) => void,
-    onToolCall?: (data: { name: string; args: any }) => void,
-    onToolResult?: (data: { name: string; result: string }) => void,
+    onToolCall?: (data: { name: string; args: any; toolCallId?: string }) => void,
+    onToolResult?: (data: { name: string; result: string; toolCallId?: string }) => void,
     mentionedWorkspaceIds?: string[],
     onClarificationRequest?: (req: CanvasClarificationRequest) => void,
     requestContext?: CanvasAgentRequestContext,
     attachments: CanvasAgentImageAttachment[] = [],
+    onToolInputStart?: (data: { id: string; toolName: string }) => void,
+    onToolInputDelta?: (data: { id: string; delta: string }) => void,
+    onToolInputEnd?: (data: { id: string }) => void,
   ): Promise<string> {
     // Refresh workspace summary for system prompt
     const summary = await buildWorkspaceSummary(this.config.workspaceId);
@@ -356,7 +359,7 @@ export class CanvasAgent {
               // AI SDK v6 uses `input`; older versions use `args`
               const args = chunk.input ?? chunk.args;
               console.info('[canvas-agent] tool-call chunk keys:', Object.keys(chunk), 'input:', chunk.input, 'args:', chunk.args);
-              onToolCall({ name: chunk.toolName, args });
+              onToolCall({ name: chunk.toolName, args, toolCallId: chunk.toolCallId });
             }
           : undefined,
         onToolResult: onToolResult
@@ -367,8 +370,18 @@ export class CanvasAgent {
               onToolResult({
                 name: chunk.toolName,
                 result: typeof raw === 'string' ? raw : JSON.stringify(raw),
+                toolCallId: chunk.toolCallId,
               });
             }
+          : undefined,
+        onToolInputStart: onToolInputStart
+          ? (chunk: { id: string; toolName: string }) => onToolInputStart(chunk)
+          : undefined,
+        onToolInputDelta: onToolInputDelta
+          ? (chunk: { id: string; delta: string }) => onToolInputDelta(chunk)
+          : undefined,
+        onToolInputEnd: onToolInputEnd
+          ? (chunk: { id: string }) => onToolInputEnd(chunk)
           : undefined,
         onResponse: (msgs: ModelMessage[]) => {
           for (const msg of msgs) {

--- a/apps/canvas-workspace/src/main/canvas-agent/service.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/service.ts
@@ -53,8 +53,8 @@ export class CanvasAgentService {
     workspaceId: string,
     message: string,
     onText?: (delta: string) => void,
-    onToolCall?: (data: { name: string; args: any }) => void,
-    onToolResult?: (data: { name: string; result: string }) => void,
+    onToolCall?: (data: { name: string; args: any; toolCallId?: string }) => void,
+    onToolResult?: (data: { name: string; result: string; toolCallId?: string }) => void,
     mentionedWorkspaceIds?: string[],
     onClarificationRequest?: (req: CanvasClarificationRequest) => void,
     requestContext?: {
@@ -64,6 +64,9 @@ export class CanvasAgentService {
       quickAction?: string;
     },
     attachments?: CanvasAgentImageAttachment[],
+    onToolInputStart?: (data: { id: string; toolName: string }) => void,
+    onToolInputDelta?: (data: { id: string; delta: string }) => void,
+    onToolInputEnd?: (data: { id: string }) => void,
   ): Promise<ChatResponse> {
     try {
       await this.activate(workspaceId);
@@ -77,6 +80,9 @@ export class CanvasAgentService {
         onClarificationRequest,
         requestContext,
         attachments,
+        onToolInputStart,
+        onToolInputDelta,
+        onToolInputEnd,
       );
       return { ok: true, response };
     } catch (err) {

--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -23,6 +23,12 @@ import {
 } from './context-builder';
 import { hasSession, writeToSession } from '../pty-manager';
 import { generateHTML } from '../html-generator';
+import {
+  addArtifactVersion as storeAddArtifactVersion,
+  createArtifact as storeCreateArtifact,
+  getArtifact as storeGetArtifact,
+} from '../artifact-store';
+import { pinArtifactToCanvas } from '../artifact-ipc';
 
 const STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
 const BLANK_PAGE_URL = 'about:blank';
@@ -1816,6 +1822,159 @@ ${outline}`;
         if (touchedIds.length > 0) broadcastUpdate(workspaceId, touchedIds);
 
         return JSON.stringify({ ok: true, edgeId });
+      },
+    },
+
+    // ─── Visual / Artifact tools ──────────────────────────────────────
+    //
+    // Three escalation levels for LLM-generated visuals:
+    //   1. visual_render        — inline, temporary, lives in the chat message
+    //   2. artifact_create      — persistent, versioned, opens in side drawer
+    //   3. artifact_pin_to_canvas — promote an artifact onto the spatial canvas
+    //
+    // The system prompt teaches the agent when to pick each.
+
+    visual_render: {
+      name: 'visual_render',
+      description:
+        'Render a transient inline visualization inside the current chat message — for explanatory diagrams, charts, or illustrations that aid the discussion. ' +
+        'The result lives only in this chat message; it does NOT get saved as an artifact. ' +
+        'Use this when the user wants to UNDERSTAND something via a visual, not when they want to KEEP or iterate on it. ' +
+        'For keep-and-iterate flows, call `artifact_create` instead. ' +
+        'For HTML, return a SINGLE self-contained `<!DOCTYPE html>` document — it will render in a sandboxed iframe and CDN libs (Chart.js, D3, Mermaid) load fine. ' +
+        'For SVG, return a single `<svg>` element (no surrounding HTML). For Mermaid, return the Mermaid source only.',
+      inputSchema: z.object({
+        type: z.enum(['html', 'svg', 'mermaid']).describe('Visual format. v1 supports html; svg and mermaid reserved.'),
+        title: z.string().optional().describe('Short label shown above the visual.'),
+        content: z.string().describe('The full visual content (HTML doc, SVG element, or Mermaid source).'),
+      }),
+      execute: async (input) => {
+        const type = input.type as 'html' | 'svg' | 'mermaid';
+        const title = (input.title as string) ?? '';
+        const content = (input.content as string) ?? '';
+        if (!content.trim()) {
+          return JSON.stringify({ ok: false, error: 'content is empty' });
+        }
+        // The renderer detects this exact payload shape and inlines the visual.
+        return JSON.stringify({
+          ok: true,
+          kind: 'visual_render',
+          type,
+          title,
+          content,
+        });
+      },
+    },
+
+    artifact_create: {
+      name: 'artifact_create',
+      description:
+        'Create a persistent, versioned visual artifact. Surfaces in chat as an artifact card with a side drawer for preview, version history, and "Pin to Canvas". ' +
+        'Use this when the user asks for something to KEEP, RE-USE, or ITERATE on (dashboards, full-page mockups, polished diagrams). ' +
+        'For throwaway visuals that just illustrate a point mid-explanation, use `visual_render` instead. ' +
+        'Content format matches `visual_render`: a self-contained HTML doc for type=html.',
+      inputSchema: z.object({
+        type: z.enum(['html', 'svg', 'mermaid']).describe('Artifact type. v1 supports html; svg and mermaid reserved.'),
+        title: z.string().describe('Short title — appears in the artifact card and as the canvas node title once pinned.'),
+        content: z.string().describe('Full content of the first version.'),
+        prompt: z.string().optional().describe('Optional record of the prompt/spec that produced this version (helps diff future iterations).'),
+      }),
+      execute: async (input) => {
+        const type = input.type as 'html' | 'svg' | 'mermaid';
+        const title = (input.title as string) ?? 'Untitled artifact';
+        const content = (input.content as string) ?? '';
+        const prompt = input.prompt as string | undefined;
+        if (!content.trim()) {
+          return JSON.stringify({ ok: false, error: 'content is empty' });
+        }
+        const artifact = await storeCreateArtifact(workspaceId, {
+          type,
+          title,
+          content,
+          prompt,
+          source: { origin: 'agent_tool' },
+        });
+        return JSON.stringify({
+          ok: true,
+          kind: 'artifact_create',
+          artifactId: artifact.id,
+          versionId: artifact.currentVersionId,
+          type: artifact.type,
+          title: artifact.title,
+        });
+      },
+    },
+
+    artifact_update: {
+      name: 'artifact_update',
+      description:
+        'Add a new version to an existing artifact. The new version becomes the current one; previous versions remain accessible in the drawer. ' +
+        'Use this when the user asks to refine, iterate on, or fix an artifact you (or a previous turn) already created. ' +
+        'Pass the same artifactId returned by `artifact_create`.',
+      inputSchema: z.object({
+        artifactId: z.string().describe('The artifact to iterate on (returned by an earlier artifact_create call).'),
+        content: z.string().describe('Full content of the new version — this replaces, not patches.'),
+        prompt: z.string().optional().describe('Optional prompt/spec that produced this iteration.'),
+      }),
+      execute: async (input) => {
+        const artifactId = input.artifactId as string;
+        const content = (input.content as string) ?? '';
+        const prompt = input.prompt as string | undefined;
+        if (!content.trim()) {
+          return JSON.stringify({ ok: false, error: 'content is empty' });
+        }
+        const existing = await storeGetArtifact(workspaceId, artifactId);
+        if (!existing) {
+          return JSON.stringify({ ok: false, error: `Artifact not found: ${artifactId}` });
+        }
+        const artifact = await storeAddArtifactVersion(workspaceId, artifactId, { content, prompt });
+        if (!artifact) {
+          return JSON.stringify({ ok: false, error: `Artifact not found: ${artifactId}` });
+        }
+        return JSON.stringify({
+          ok: true,
+          kind: 'artifact_update',
+          artifactId: artifact.id,
+          versionId: artifact.currentVersionId,
+          versionCount: artifact.versions.length,
+          type: artifact.type,
+          title: artifact.title,
+        });
+      },
+    },
+
+    artifact_pin_to_canvas: {
+      name: 'artifact_pin_to_canvas',
+      description:
+        'Pin an existing artifact onto the spatial canvas as an iframe node. The node renders the artifact\'s current version live — any future `artifact_update` ' +
+        'updates the on-canvas node too. Use this when the user asks to keep multiple visuals side by side, compare options, or build a spatial dashboard.',
+      inputSchema: z.object({
+        artifactId: z.string().describe('The artifact to pin.'),
+        x: z.number().optional().describe('Top-left x (auto-placed if omitted).'),
+        y: z.number().optional().describe('Top-left y (auto-placed if omitted).'),
+        width: z.number().optional().describe('Width in px (default 520).'),
+        height: z.number().optional().describe('Height in px (default 400).'),
+        title: z.string().optional().describe('Override the on-canvas node title (defaults to the artifact title).'),
+      }),
+      execute: async (input) => {
+        const artifactId = input.artifactId as string;
+        const result = await pinArtifactToCanvas(workspaceId, artifactId, {
+          x: input.x as number | undefined,
+          y: input.y as number | undefined,
+          width: input.width as number | undefined,
+          height: input.height as number | undefined,
+          title: input.title as string | undefined,
+        });
+        if ('error' in result) {
+          return JSON.stringify({ ok: false, error: result.error });
+        }
+        return JSON.stringify({
+          ok: true,
+          kind: 'artifact_pin_to_canvas',
+          nodeId: result.nodeId,
+          artifactId: result.artifact.id,
+          title: result.artifact.title,
+        });
       },
     },
   };

--- a/apps/canvas-workspace/src/main/canvas-broadcast.ts
+++ b/apps/canvas-workspace/src/main/canvas-broadcast.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared helper for notifying every renderer window that one or more
+ * canvas nodes were mutated outside the renderer's normal save path
+ * (e.g. by a main-process tool or by an artifact pin). Mirrors the
+ * payload shape canvas-store.ts emits on `canvas:external-update`.
+ */
+
+import { BrowserWindow } from 'electron';
+
+export function broadcastCanvasUpdate(
+  workspaceId: string,
+  nodeIds: string[],
+  kind: 'create' | 'update' | 'delete' = 'update',
+  source: string = 'main',
+): void {
+  const payload = { workspaceId, nodeIds, kind, source };
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (win.isDestroyed()) continue;
+    win.webContents.send('canvas:external-update', payload);
+  }
+}

--- a/apps/canvas-workspace/src/main/index.ts
+++ b/apps/canvas-workspace/src/main/index.ts
@@ -13,6 +13,7 @@ import { setupSkillInstallerIpc } from "./skill-installer";
 import { setupCanvasAgentIpc, teardownCanvasAgent } from "./canvas-agent-ipc";
 import { setupWebviewRegistryIpc } from "./webview-registry";
 import { setupHtmlGeneratorIpc } from "./html-generator-ipc";
+import { setupArtifactIpc } from "./artifact-ipc";
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const preloadPath = join(currentDir, "../preload/index.mjs");
@@ -143,6 +144,7 @@ app.whenReady().then(() => {
   setupCanvasAgentIpc();
   setupWebviewRegistryIpc();
   setupHtmlGeneratorIpc();
+  setupArtifactIpc();
   // MCP server disabled — canvas-cli is the preferred agent interface now.
   // startMCPServer();
   // void ensureMCPRegistered();

--- a/apps/canvas-workspace/src/preload/index.ts
+++ b/apps/canvas-workspace/src/preload/index.ts
@@ -282,5 +282,41 @@ contextBridge.exposeInMainWorld("canvasWorkspace", {
 
     addImageToCanvas: (workspaceId: string, imagePath: string, title?: string) =>
       ipcRenderer.invoke("canvas-agent:add-image-to-canvas", { workspaceId, imagePath, title }),
+  },
+
+  artifacts: {
+    list: (workspaceId: string) =>
+      ipcRenderer.invoke("artifact:list", { workspaceId }),
+
+    get: (workspaceId: string, artifactId: string) =>
+      ipcRenderer.invoke("artifact:get", { workspaceId, artifactId }),
+
+    create: (workspaceId: string, input: unknown) =>
+      ipcRenderer.invoke("artifact:create", { workspaceId, input }),
+
+    addVersion: (workspaceId: string, artifactId: string, input: unknown) =>
+      ipcRenderer.invoke("artifact:add-version", { workspaceId, artifactId, input }),
+
+    update: (workspaceId: string, artifactId: string, patch: unknown) =>
+      ipcRenderer.invoke("artifact:update", { workspaceId, artifactId, patch }),
+
+    delete: (workspaceId: string, artifactId: string) =>
+      ipcRenderer.invoke("artifact:delete", { workspaceId, artifactId }),
+
+    pinToCanvas: (workspaceId: string, artifactId: string, placement?: unknown) =>
+      ipcRenderer.invoke("artifact:pin-to-canvas", { workspaceId, artifactId, placement }),
+
+    onChange: (
+      callback: (event: { workspaceId: string; artifactId: string; kind: "create" | "update" | "delete" }) => void,
+    ) => {
+      const handler = (
+        _event: Electron.IpcRendererEvent,
+        payload: { workspaceId: string; artifactId: string; kind: "create" | "update" | "delete" },
+      ) => callback(payload);
+      ipcRenderer.on("artifact:change", handler);
+      return () => {
+        ipcRenderer.removeListener("artifact:change", handler);
+      };
+    },
   }
 });

--- a/apps/canvas-workspace/src/preload/index.ts
+++ b/apps/canvas-workspace/src/preload/index.ts
@@ -212,9 +212,39 @@ contextBridge.exposeInMainWorld("canvasWorkspace", {
       };
     },
 
-    onToolCall: (sessionId: string, callback: (data: { name: string; args: any }) => void) => {
+    onToolCall: (
+      sessionId: string,
+      callback: (data: { name: string; args: any; toolCallId?: string }) => void,
+    ) => {
       const channel = `canvas-agent:tool-call:${sessionId}`;
-      const handler = (_event: Electron.IpcRendererEvent, data: { name: string; args: any }) =>
+      const handler = (
+        _event: Electron.IpcRendererEvent,
+        data: { name: string; args: any; toolCallId?: string },
+      ) => callback(data);
+      ipcRenderer.on(channel, handler);
+      return () => {
+        ipcRenderer.removeListener(channel, handler);
+      };
+    },
+
+    onToolResult: (
+      sessionId: string,
+      callback: (data: { name: string; result: string; toolCallId?: string }) => void,
+    ) => {
+      const channel = `canvas-agent:tool-result:${sessionId}`;
+      const handler = (
+        _event: Electron.IpcRendererEvent,
+        data: { name: string; result: string; toolCallId?: string },
+      ) => callback(data);
+      ipcRenderer.on(channel, handler);
+      return () => {
+        ipcRenderer.removeListener(channel, handler);
+      };
+    },
+
+    onToolInputStart: (sessionId: string, callback: (data: { id: string; toolName: string }) => void) => {
+      const channel = `canvas-agent:tool-input-start:${sessionId}`;
+      const handler = (_event: Electron.IpcRendererEvent, data: { id: string; toolName: string }) =>
         callback(data);
       ipcRenderer.on(channel, handler);
       return () => {
@@ -222,9 +252,19 @@ contextBridge.exposeInMainWorld("canvasWorkspace", {
       };
     },
 
-    onToolResult: (sessionId: string, callback: (data: { name: string; result: string }) => void) => {
-      const channel = `canvas-agent:tool-result:${sessionId}`;
-      const handler = (_event: Electron.IpcRendererEvent, data: { name: string; result: string }) =>
+    onToolInputDelta: (sessionId: string, callback: (data: { id: string; delta: string }) => void) => {
+      const channel = `canvas-agent:tool-input-delta:${sessionId}`;
+      const handler = (_event: Electron.IpcRendererEvent, data: { id: string; delta: string }) =>
+        callback(data);
+      ipcRenderer.on(channel, handler);
+      return () => {
+        ipcRenderer.removeListener(channel, handler);
+      };
+    },
+
+    onToolInputEnd: (sessionId: string, callback: (data: { id: string }) => void) => {
+      const channel = `canvas-agent:tool-input-end:${sessionId}`;
+      const handler = (_event: Electron.IpcRendererEvent, data: { id: string }) =>
         callback(data);
       ipcRenderer.on(channel, handler);
       return () => {

--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'wouter';
 import './App.css';
 import { AppShellProvider, useAppShell } from './components/AppShellProvider';
+import { ArtifactDrawer, ArtifactDrawerProvider } from './components/artifacts';
+import './components/artifacts/artifacts.css';
 import { ChatPage } from './components/chat';
 import { Sidebar } from './components/Sidebar';
 import { Workbench, useWorkbenchState } from './components/Workbench';
@@ -374,7 +376,10 @@ const AppContent = () => {
 
 const App = () => (
   <AppShellProvider>
-    <AppContent />
+    <ArtifactDrawerProvider>
+      <AppContent />
+      <ArtifactDrawer />
+    </ArtifactDrawerProvider>
   </AppShellProvider>
 );
 

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import "./index.css";
 import type { Artifact, CanvasNode, IframeNodeData } from "../../types";
 import { useArtifactDrawer } from "../artifacts";
+import { STREAMING_SHELL } from "../artifacts/streamingShell";
 
 type EditMode = "url" | "html" | "ai";
 
@@ -18,56 +19,6 @@ interface Props {
   isResizing?: boolean;
   readOnly?: boolean;
 }
-
-// ── Streaming shell ──────────────────────────────────────────────────
-//
-// Loaded as srcdoc during AI streaming. Contains:
-//  - morphdom from CDN (with innerHTML fallback if CDN fails)
-//  - A postMessage listener that morphs the DOM on each update
-//
-// The parent sends `{ type: 'morph', html }` with accumulated HTML.
-// The shell extracts <style> → applies to <head>, extracts <body>
-// content → morphdom diffs it in, strips <script> during streaming.
-// When generation completes the parent swaps to the final srcdoc so
-// scripts run.
-
-const STREAMING_SHELL = `<!DOCTYPE html>
-<html><head><meta charset="utf-8">
-<style>*,*::before,*::after{box-sizing:border-box}body{margin:0;font-family:system-ui,-apple-system,sans-serif;background:#fff}</style>
-<script src="https://cdn.jsdelivr.net/npm/morphdom@2/dist/morphdom-umd.min.js"
-  onerror="window.morphdom=function(f,t){if(typeof t==='string'){var d=document.createElement('div');d.innerHTML=t;while(f.firstChild)f.removeChild(f.firstChild);while(d.firstChild)f.appendChild(d.firstChild)}else if(f.parentNode){f.parentNode.replaceChild(t,f)}}"></script>
-</head><body>
-<div id="__mr__"></div>
-<script>
-var root=document.getElementById("__mr__"),styleEl=null,prevCss="";
-function applyUpdate(html){
-  var css="";
-  html.replace(/<style[^>]*>([\\s\\S]*?)<\\/style>/gi,function(_,c){css+=c});
-  if(css&&css!==prevCss){
-    if(!styleEl){styleEl=document.createElement("style");styleEl.id="__sc__";document.head.appendChild(styleEl)}
-    styleEl.textContent=css;prevCss=css
-  }
-  var body,bm=html.match(/<body[^>]*>([\\s\\S]*?)(<\\/body>|$)/i);
-  if(bm){body=bm[1]}
-  else{
-    var bi=html.indexOf("<body");
-    if(bi===-1)return;
-    var gt=html.indexOf(">",bi);
-    if(gt===-1)return;
-    body=html.slice(gt+1)
-  }
-  body=body.replace(/<script[\\s\\S]*?(<\\/script>|$)/gi,"").trim();
-  if(!body)return;
-  var nx=document.createElement("div");nx.id="__mr__";nx.innerHTML=body;
-  if(typeof morphdom==="function"){try{morphdom(root,nx)}catch(e){root.innerHTML=body}}
-  else root.innerHTML=body
-}
-window.addEventListener("message",function(e){
-  if(e.data&&e.data.type==="morph")applyUpdate(e.data.html)
-});
-window.parent.postMessage({type:"morph-ready"},"*");
-</script>
-</body></html>`;
 
 // ── Component ────────────────────────────────────────────────────────
 

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import "./index.css";
-import type { CanvasNode, IframeNodeData } from "../../types";
+import type { Artifact, CanvasNode, IframeNodeData } from "../../types";
+import { useArtifactDrawer } from "../artifacts";
 
 type EditMode = "url" | "html" | "ai";
 
@@ -76,10 +77,58 @@ export const IframeNodeBody = ({ node, workspaceId, onUpdate, isResizing, readOn
   const url = data.url ?? "";
   const html = data.html ?? "";
   const savedPrompt = data.prompt ?? "";
+  const artifactId = data.artifactId ?? null;
 
-  const hasContent = mode === "url" ? !!url : !!html;
+  const { openArtifact } = useArtifactDrawer();
 
-  const [editing, setEditing] = useState(!readOnly && !hasContent);
+  // ── Artifact-backed iframe: resolve content live from the artifact store ──
+  //
+  // `mode: 'artifact'` swaps the source of truth from `data.html` (per-node)
+  // to the workspace artifact store. The iframe renders the current version
+  // of the artifact and re-renders whenever the artifact gets a new version,
+  // so iterating from chat updates pinned canvas nodes automatically.
+  const [artifact, setArtifact] = useState<Artifact | null>(null);
+  const isArtifactMode = mode === "artifact" && !!artifactId && !!workspaceId;
+
+  useEffect(() => {
+    if (!isArtifactMode || !workspaceId || !artifactId) {
+      setArtifact(null);
+      return;
+    }
+    let cancelled = false;
+    const refresh = async () => {
+      const result = await window.canvasWorkspace.artifacts.get(workspaceId, artifactId);
+      if (cancelled) return;
+      setArtifact((result?.ok ? result.artifact : null) ?? null);
+    };
+    void refresh();
+    const unsubscribe = window.canvasWorkspace.artifacts.onChange((event) => {
+      if (event.workspaceId !== workspaceId) return;
+      if (event.artifactId !== artifactId) return;
+      if (event.kind === "delete") {
+        setArtifact(null);
+        return;
+      }
+      void refresh();
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [isArtifactMode, workspaceId, artifactId]);
+
+  const artifactHtml = (() => {
+    if (!artifact) return "";
+    const version = artifact.versions.find(v => v.id === artifact.currentVersionId)
+      ?? artifact.versions[artifact.versions.length - 1];
+    return version?.content ?? "";
+  })();
+
+  const hasContent = isArtifactMode ? !!artifactHtml : (mode === "url" ? !!url : !!html);
+
+  // Artifact-backed iframes never enter editing — the artifact store is the
+  // single source of truth and the user iterates via the drawer / chat.
+  const [editing, setEditing] = useState(!readOnly && !isArtifactMode && !hasContent);
   const [draftUrl, setDraftUrl] = useState(url);
   const [draftHtml, setDraftHtml] = useState(html);
   const [draftPrompt, setDraftPrompt] = useState(savedPrompt);
@@ -107,8 +156,8 @@ export const IframeNodeBody = ({ node, workspaceId, onUpdate, isResizing, readOn
   useEffect(() => { setDraftMode(mode === "ai" ? "ai" : mode === "html" ? "html" : "url"); }, [mode]);
 
   useEffect(() => {
-    if (readOnly) setEditing(false);
-  }, [readOnly]);
+    if (readOnly || isArtifactMode) setEditing(false);
+  }, [readOnly, isArtifactMode]);
 
   useEffect(() => {
     if (mode !== "url" || editing || readOnly) return;
@@ -537,6 +586,7 @@ export const IframeNodeBody = ({ node, workspaceId, onUpdate, isResizing, readOn
   // ── Rendered state ─────────────────────────────────────────────────
 
   const renderMode = mode === "url" ? "url" : "html";
+  const renderedHtml = isArtifactMode ? artifactHtml : html;
 
   return (
     <div className="iframe-body">
@@ -558,7 +608,20 @@ export const IframeNodeBody = ({ node, workspaceId, onUpdate, isResizing, readOn
           </svg>
         </button>
 
-        {mode === "url" ? (
+        {isArtifactMode ? (
+          <button
+            className="iframe-bar-url iframe-bar-url--html"
+            onClick={() => {
+              if (workspaceId && artifactId) openArtifact(workspaceId, artifactId);
+            }}
+            title={artifact?.title ?? "Open artifact"}
+          >
+            <span className="iframe-bar-badge iframe-bar-badge--ai">Artifact</span>
+            <span className="iframe-bar-url-text">
+              {artifact?.title ?? "Loading artifact…"}
+            </span>
+          </button>
+        ) : mode === "url" ? (
           <button
             className="iframe-bar-url"
             onClick={() => {
@@ -656,11 +719,15 @@ export const IframeNodeBody = ({ node, workspaceId, onUpdate, isResizing, readOn
           />
         ) : (
           <iframe
-            key={webviewKey}
+            key={isArtifactMode ? `artifact-${artifact?.currentVersionId ?? "loading"}` : webviewKey}
             className="iframe-frame"
-            srcDoc={html}
+            srcDoc={renderedHtml}
             sandbox="allow-scripts"
-            title={mode === "ai" ? "AI-generated preview" : "HTML preview"}
+            title={
+              isArtifactMode
+                ? `Artifact: ${artifact?.title ?? "loading"}`
+                : mode === "ai" ? "AI-generated preview" : "HTML preview"
+            }
           />
         )}
       </div>

--- a/apps/canvas-workspace/src/renderer/src/components/artifacts/ArtifactContext.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/artifacts/ArtifactContext.tsx
@@ -1,0 +1,51 @@
+/**
+ * Context holding the currently-opened artifact for the right-side drawer.
+ *
+ * Any component (a chat artifact card, the iframe node body, etc.) can call
+ * `useArtifactDrawer().open(workspaceId, artifactId)` to surface an artifact
+ * in the side drawer without prop-drilling through the whole tree.
+ */
+
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
+
+interface OpenArtifactRef {
+  workspaceId: string;
+  artifactId: string;
+}
+
+interface ArtifactDrawerContextValue {
+  open: OpenArtifactRef | null;
+  openArtifact: (workspaceId: string, artifactId: string) => void;
+  close: () => void;
+}
+
+const ArtifactDrawerContext = createContext<ArtifactDrawerContextValue | null>(null);
+
+export const ArtifactDrawerProvider = ({ children }: { children: ReactNode }) => {
+  const [open, setOpen] = useState<OpenArtifactRef | null>(null);
+
+  const openArtifact = useCallback((workspaceId: string, artifactId: string) => {
+    setOpen({ workspaceId, artifactId });
+  }, []);
+
+  const close = useCallback(() => setOpen(null), []);
+
+  const value = useMemo<ArtifactDrawerContextValue>(
+    () => ({ open, openArtifact, close }),
+    [open, openArtifact, close],
+  );
+
+  return (
+    <ArtifactDrawerContext.Provider value={value}>
+      {children}
+    </ArtifactDrawerContext.Provider>
+  );
+};
+
+export const useArtifactDrawer = (): ArtifactDrawerContextValue => {
+  const ctx = useContext(ArtifactDrawerContext);
+  if (!ctx) {
+    throw new Error('useArtifactDrawer must be used within <ArtifactDrawerProvider>');
+  }
+  return ctx;
+};

--- a/apps/canvas-workspace/src/renderer/src/components/artifacts/ArtifactDrawer.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/artifacts/ArtifactDrawer.tsx
@@ -1,0 +1,179 @@
+/**
+ * Right-side drawer that previews an artifact with version history and
+ * pin-to-canvas control.
+ *
+ * Driven by `ArtifactDrawerContext` — any component that calls
+ * `openArtifact(workspaceId, artifactId)` causes this drawer to mount
+ * and load the requested artifact.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { Artifact, ArtifactVersion } from '../../types';
+import { useArtifactDrawer } from './ArtifactContext';
+
+const TYPE_LABEL: Record<string, string> = {
+  html: 'HTML',
+  svg: 'SVG',
+  mermaid: 'Mermaid',
+};
+
+export const ArtifactDrawer = () => {
+  const { open, close } = useArtifactDrawer();
+  const [artifact, setArtifact] = useState<Artifact | null>(null);
+  const [viewVersionId, setViewVersionId] = useState<string | null>(null);
+  const [pinning, setPinning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Load + subscribe whenever the opened (workspace, artifact) pair changes.
+  useEffect(() => {
+    if (!open) {
+      setArtifact(null);
+      setViewVersionId(null);
+      setError(null);
+      return;
+    }
+    let cancelled = false;
+    setError(null);
+
+    const refresh = async () => {
+      const result = await window.canvasWorkspace.artifacts.get(open.workspaceId, open.artifactId);
+      if (cancelled) return;
+      if (!result?.ok || !result.artifact) {
+        setError(result?.error ?? 'Artifact not found');
+        setArtifact(null);
+        return;
+      }
+      setArtifact(result.artifact);
+      // On first load (or when the artifact gets a new version), snap to current.
+      setViewVersionId(prev => {
+        if (!prev) return result.artifact!.currentVersionId;
+        const stillExists = result.artifact!.versions.some(v => v.id === prev);
+        return stillExists ? prev : result.artifact!.currentVersionId;
+      });
+    };
+
+    void refresh();
+
+    const unsubscribe = window.canvasWorkspace.artifacts.onChange((event) => {
+      if (event.workspaceId !== open.workspaceId) return;
+      if (event.artifactId !== open.artifactId) return;
+      if (event.kind === 'delete') {
+        setArtifact(null);
+        setError('Artifact was deleted');
+        return;
+      }
+      void refresh();
+    });
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [open]);
+
+  const viewedVersion: ArtifactVersion | null = useMemo(() => {
+    if (!artifact) return null;
+    const id = viewVersionId ?? artifact.currentVersionId;
+    return artifact.versions.find(v => v.id === id) ?? artifact.versions[artifact.versions.length - 1] ?? null;
+  }, [artifact, viewVersionId]);
+
+  const handlePin = useCallback(async () => {
+    if (!open || !artifact || artifact.pinnedNodeId || pinning) return;
+    setPinning(true);
+    try {
+      const result = await window.canvasWorkspace.artifacts.pinToCanvas(open.workspaceId, open.artifactId, {});
+      if (!result.ok) setError(result.error ?? 'Pin failed');
+    } finally {
+      setPinning(false);
+    }
+  }, [open, artifact, pinning]);
+
+  // Close on Escape.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, close]);
+
+  if (!open) return null;
+
+  const renderBody = () => {
+    if (error) {
+      return <div className="artifact-drawer__empty">{error}</div>;
+    }
+    if (!artifact || !viewedVersion) {
+      return <div className="artifact-drawer__empty">Loading…</div>;
+    }
+    if (artifact.type === 'html') {
+      return (
+        <iframe
+          key={viewedVersion.id}
+          className="artifact-drawer__frame"
+          srcDoc={viewedVersion.content}
+          sandbox="allow-scripts"
+          title={artifact.title}
+        />
+      );
+    }
+    if (artifact.type === 'svg') {
+      return (
+        <div
+          className="artifact-drawer__svg-host"
+          dangerouslySetInnerHTML={{ __html: viewedVersion.content }}
+        />
+      );
+    }
+    return <div className="artifact-drawer__empty">Unsupported artifact type</div>;
+  };
+
+  return (
+    <>
+      <div className="artifact-drawer-backdrop" onClick={close} />
+      <aside className="artifact-drawer" role="dialog" aria-label="Artifact preview">
+        <div className="artifact-drawer__header">
+          <div className="artifact-drawer__title" title={artifact?.title}>
+            {artifact?.title ?? 'Artifact'}
+          </div>
+          {artifact && (
+            <span className="artifact-drawer__type-badge">{TYPE_LABEL[artifact.type] ?? artifact.type}</span>
+          )}
+          <button type="button" className="artifact-drawer__close" onClick={close} aria-label="Close">
+            ×
+          </button>
+        </div>
+        {artifact && artifact.versions.length > 0 && (
+          <div className="artifact-drawer__toolbar">
+            <select
+              className="artifact-drawer__version-select"
+              value={viewVersionId ?? artifact.currentVersionId}
+              onChange={(e) => setViewVersionId(e.target.value)}
+            >
+              {artifact.versions.map((version, i) => (
+                <option key={version.id} value={version.id}>
+                  v{i + 1}{version.id === artifact.currentVersionId ? ' (current)' : ''}
+                </option>
+              ))}
+            </select>
+            <div className="artifact-drawer__toolbar-spacer" />
+            {artifact.pinnedNodeId ? (
+              <span className="artifact-drawer__pinned-badge">Pinned to canvas</span>
+            ) : (
+              <button
+                type="button"
+                className="artifact-drawer__action artifact-drawer__action--primary"
+                onClick={() => void handlePin()}
+                disabled={pinning}
+              >
+                {pinning ? 'Pinning…' : 'Pin to canvas'}
+              </button>
+            )}
+          </div>
+        )}
+        <div className="artifact-drawer__body">{renderBody()}</div>
+      </aside>
+    </>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/artifacts/ChatArtifactCard.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/artifacts/ChatArtifactCard.tsx
@@ -1,0 +1,111 @@
+/**
+ * Compact in-chat representation of a stored artifact.
+ *
+ * Source: `artifact_create` / `artifact_update` tool result. Clicking the
+ * card opens the side drawer; the "Pin to Canvas" shortcut promotes the
+ * artifact to a spatial canvas node in one click.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import type { Artifact, ArtifactType } from '../../types';
+import { useArtifactDrawer } from './ArtifactContext';
+
+export interface ArtifactCardPayload {
+  artifactId: string;
+  title: string;
+  type: ArtifactType;
+  /** True when this card represents an iteration (artifact_update), not the original create. */
+  isUpdate?: boolean;
+  versionCount?: number;
+}
+
+interface ChatArtifactCardProps {
+  workspaceId: string;
+  payload: ArtifactCardPayload;
+}
+
+const TYPE_ICONS: Record<ArtifactType, string> = {
+  html: '▣',
+  svg: '◇',
+  mermaid: '⇄',
+};
+
+export const ChatArtifactCard = ({ workspaceId, payload }: ChatArtifactCardProps) => {
+  const { openArtifact } = useArtifactDrawer();
+  const [pinnedNodeId, setPinnedNodeId] = useState<string | null>(null);
+  const [pinning, setPinning] = useState(false);
+
+  // Resolve initial pinned state from the artifact (in case it was pinned earlier).
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const result = await window.canvasWorkspace.artifacts.get(workspaceId, payload.artifactId);
+      if (cancelled) return;
+      const artifact = (result?.ok ? result.artifact : undefined) as Artifact | undefined;
+      if (artifact?.pinnedNodeId) setPinnedNodeId(artifact.pinnedNodeId);
+    })();
+    return () => { cancelled = true; };
+  }, [workspaceId, payload.artifactId]);
+
+  const handleOpen = useCallback(() => {
+    openArtifact(workspaceId, payload.artifactId);
+  }, [openArtifact, workspaceId, payload.artifactId]);
+
+  const handlePin = useCallback(async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (pinnedNodeId || pinning) return;
+    setPinning(true);
+    try {
+      const result = await window.canvasWorkspace.artifacts.pinToCanvas(workspaceId, payload.artifactId, {});
+      if (result.ok && result.nodeId) {
+        setPinnedNodeId(result.nodeId);
+      }
+    } finally {
+      setPinning(false);
+    }
+  }, [pinnedNodeId, pinning, workspaceId, payload.artifactId]);
+
+  const subtitle = payload.isUpdate
+    ? `Iterated · v${payload.versionCount ?? '?'}`
+    : `New artifact · ${payload.type.toUpperCase()}`;
+
+  return (
+    <div
+      className="chat-artifact-card"
+      role="button"
+      tabIndex={0}
+      onClick={handleOpen}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleOpen();
+        }
+      }}
+    >
+      <div className="chat-artifact-card__row">
+        <div className="chat-artifact-card__icon">{TYPE_ICONS[payload.type] ?? '▣'}</div>
+        <div className="chat-artifact-card__meta">
+          <div className="chat-artifact-card__title">{payload.title}</div>
+          <div className="chat-artifact-card__sub">{subtitle}{pinnedNodeId ? ' · pinned' : ''}</div>
+        </div>
+        <div className="chat-artifact-card__actions">
+          <button
+            type="button"
+            className="chat-artifact-card__action"
+            onClick={(e) => { e.stopPropagation(); handleOpen(); }}
+          >
+            Open
+          </button>
+          <button
+            type="button"
+            className="chat-artifact-card__action"
+            onClick={(e) => void handlePin(e)}
+            disabled={!!pinnedNodeId || pinning}
+          >
+            {pinnedNodeId ? 'Pinned' : pinning ? 'Pinning…' : 'Pin to canvas'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/artifacts/ChatInlineVisual.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/artifacts/ChatInlineVisual.tsx
@@ -1,14 +1,24 @@
 /**
  * Inline visual rendered directly inside an assistant message body.
  *
- * Source: `visual_render` tool result. The content is temporary — it
- * lives with the chat message and is NOT in the artifact store unless
- * the user clicks "Save as artifact" (which promotes it).
+ * Two render paths:
+ *   - **Streaming** (LLM is still emitting the tool's input JSON): we extract
+ *     `type` / `title` / `content` from the partial JSON as it grows, post
+ *     accumulated HTML into a sandboxed iframe shell, and morphdom diffs the
+ *     DOM in place. Mirrors the IframeNodeBody AI-tab UX.
+ *   - **Done** (tool execution finished, final result available): re-render
+ *     with a clean srcdoc so any <script> tags actually run.
+ *
+ * Source: `visual_render` tool. The content is temporary — it lives with the
+ * chat message and is NOT in the artifact store unless the user clicks
+ * "Save as artifact" (which promotes it).
  */
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ArtifactType } from '../../types';
 import { useArtifactDrawer } from './ArtifactContext';
+import { extractPartialStringField } from './partialJson';
+import { STREAMING_SHELL } from './streamingShell';
 
 export interface InlineVisualPayload {
   type: ArtifactType;
@@ -18,24 +28,97 @@ export interface InlineVisualPayload {
 
 interface ChatInlineVisualProps {
   workspaceId: string;
-  payload: InlineVisualPayload;
+  /** Final payload — present once the tool finishes executing. */
+  payload?: InlineVisualPayload;
+  /** Streaming raw JSON of the tool's input, accumulated so far. */
+  partialInput?: string;
+  /** True while `partialInput` is still growing. */
+  streaming?: boolean;
 }
 
 const DEFAULT_HEIGHT = 320;
 
-export const ChatInlineVisual = ({ workspaceId, payload }: ChatInlineVisualProps) => {
+/**
+ * Read whatever can be parsed from a partial JSON string the LLM is still
+ * emitting. Fields appear in declaration order, so `type` and `title`
+ * generally land before `content`.
+ */
+function parsePartial(partialInput: string | undefined): InlineVisualPayload | null {
+  if (!partialInput) return null;
+  const rawType = extractPartialStringField(partialInput, 'type');
+  const type: ArtifactType =
+    rawType === 'svg' || rawType === 'mermaid' ? rawType : 'html';
+  const title = extractPartialStringField(partialInput, 'title');
+  const content = extractPartialStringField(partialInput, 'content') ?? '';
+  return { type, title, content };
+}
+
+export const ChatInlineVisual = ({
+  workspaceId,
+  payload,
+  partialInput,
+  streaming = false,
+}: ChatInlineVisualProps) => {
   const { openArtifact } = useArtifactDrawer();
   const [savedId, setSavedId] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
+  // Resolve which payload to render: prefer the final one once done; fall back
+  // to the partial one while the LLM is still emitting.
+  const partialPayload = useMemo(() => parsePartial(partialInput), [partialInput]);
+  const livePayload: InlineVisualPayload | null = payload ?? partialPayload;
+
+  const isStreamingHtml = streaming && !payload && livePayload?.type === 'html';
+  const streamIframeRef = useRef<HTMLIFrameElement>(null);
+  const shellReady = useRef(false);
+  const pendingMorph = useRef<string | null>(null);
+
+  // The streaming iframe needs to know when its postMessage listener has
+  // installed. Until then we queue the latest accumulated HTML.
+  useEffect(() => {
+    if (!isStreamingHtml) {
+      shellReady.current = false;
+      pendingMorph.current = null;
+      return;
+    }
+    const handleReady = (e: MessageEvent) => {
+      if (e.source !== streamIframeRef.current?.contentWindow) return;
+      if (e.data?.type !== 'morph-ready') return;
+      shellReady.current = true;
+      if (pendingMorph.current != null) {
+        streamIframeRef.current?.contentWindow?.postMessage(
+          { type: 'morph', html: pendingMorph.current },
+          '*',
+        );
+        pendingMorph.current = null;
+      }
+    };
+    window.addEventListener('message', handleReady);
+    return () => {
+      window.removeEventListener('message', handleReady);
+    };
+  }, [isStreamingHtml]);
+
+  // Push the latest HTML into the streaming shell on every partial update.
+  useEffect(() => {
+    if (!isStreamingHtml || !livePayload) return;
+    const html = livePayload.content;
+    if (!html) return;
+    if (!shellReady.current) {
+      pendingMorph.current = html;
+      return;
+    }
+    streamIframeRef.current?.contentWindow?.postMessage({ type: 'morph', html }, '*');
+  }, [isStreamingHtml, livePayload]);
+
   const handleSaveAsArtifact = useCallback(async () => {
-    if (savedId || saving) return;
+    if (!livePayload || savedId || saving) return;
     setSaving(true);
     try {
       const result = await window.canvasWorkspace.artifacts.create(workspaceId, {
-        type: payload.type,
-        title: payload.title || 'Saved visual',
-        content: payload.content,
+        type: livePayload.type,
+        title: livePayload.title || 'Saved visual',
+        content: livePayload.content,
         source: { origin: 'inline_promotion' },
       });
       if (result.ok && result.artifact) {
@@ -45,47 +128,78 @@ export const ChatInlineVisual = ({ workspaceId, payload }: ChatInlineVisualProps
     } finally {
       setSaving(false);
     }
-  }, [savedId, saving, workspaceId, payload, openArtifact]);
+  }, [savedId, saving, workspaceId, livePayload, openArtifact]);
 
   const handleOpenSaved = useCallback(() => {
     if (savedId) openArtifact(workspaceId, savedId);
   }, [savedId, workspaceId, openArtifact]);
 
-  const body = useMemo(() => {
-    if (payload.type === 'html') {
+  const renderBody = () => {
+    if (!livePayload) {
+      // No type/content extractable yet — show a thin skeleton bar.
+      return (
+        <div className="chat-inline-visual__skeleton">
+          <div className="chat-inline-visual__skeleton-bar" />
+        </div>
+      );
+    }
+
+    if (livePayload.type === 'html') {
+      if (isStreamingHtml) {
+        // Streaming mode — load the shell once, push deltas via postMessage.
+        return (
+          <iframe
+            ref={streamIframeRef}
+            className="chat-inline-visual__frame"
+            srcDoc={STREAMING_SHELL}
+            sandbox="allow-scripts"
+            style={{ height: DEFAULT_HEIGHT }}
+            title={livePayload.title || 'Inline visual (streaming)'}
+          />
+        );
+      }
+      // Final mode — clean srcDoc so scripts execute.
       return (
         <iframe
           className="chat-inline-visual__frame"
-          srcDoc={payload.content}
+          srcDoc={livePayload.content}
           sandbox="allow-scripts"
           style={{ height: DEFAULT_HEIGHT }}
-          title={payload.title || 'Inline visual'}
+          title={livePayload.title || 'Inline visual'}
         />
       );
     }
-    if (payload.type === 'svg') {
+    if (livePayload.type === 'svg') {
       return (
         <div
           className="chat-inline-visual__svg"
-          dangerouslySetInnerHTML={{ __html: payload.content }}
+          dangerouslySetInnerHTML={{ __html: livePayload.content }}
         />
       );
     }
     return (
       <div className="chat-inline-visual__error">
-        Unsupported visual type: {payload.type}
+        Unsupported visual type: {livePayload.type}
       </div>
     );
-  }, [payload]);
+  };
+
+  const title = livePayload?.title;
+  const showShimmer = isStreamingHtml || (streaming && !livePayload);
 
   return (
-    <div className="chat-inline-visual">
+    <div className={`chat-inline-visual${showShimmer ? ' chat-inline-visual--streaming' : ''}`}>
+      {showShimmer && <div className="chat-inline-visual__shimmer" />}
       <div className="chat-inline-visual__header">
         <div className="chat-inline-visual__label">
-          Inline visual
-          {payload.title && <span className="chat-inline-visual__title"> · {payload.title}</span>}
+          {streaming ? 'Generating visual' : 'Inline visual'}
+          {title && <span className="chat-inline-visual__title"> · {title}</span>}
         </div>
-        {savedId ? (
+        {streaming && !payload ? (
+          <span className="chat-inline-visual__progress">
+            <span className="chat-inline-visual__spinner" />
+          </span>
+        ) : savedId ? (
           <button
             type="button"
             className="chat-inline-visual__action"
@@ -98,13 +212,13 @@ export const ChatInlineVisual = ({ workspaceId, payload }: ChatInlineVisualProps
             type="button"
             className="chat-inline-visual__action chat-inline-visual__action--primary"
             onClick={() => void handleSaveAsArtifact()}
-            disabled={saving}
+            disabled={saving || !livePayload?.content}
           >
             {saving ? 'Saving…' : 'Save as artifact'}
           </button>
         )}
       </div>
-      {body}
+      {renderBody()}
     </div>
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/components/artifacts/ChatInlineVisual.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/artifacts/ChatInlineVisual.tsx
@@ -1,24 +1,31 @@
 /**
  * Inline visual rendered directly inside an assistant message body.
  *
- * Two render paths:
- *   - **Streaming** (LLM is still emitting the tool's input JSON): we extract
- *     `type` / `title` / `content` from the partial JSON as it grows, post
- *     accumulated HTML into a sandboxed iframe shell, and morphdom diffs the
- *     DOM in place. Mirrors the IframeNodeBody AI-tab UX.
- *   - **Done** (tool execution finished, final result available): re-render
- *     with a clean srcdoc so any <script> tags actually run.
+ * Matches Claude's "in-line interactive visualizations" UX:
+ *  - No card chrome / border / header by default — the visual embeds in the
+ *    conversation flow like a paragraph would.
+ *  - Auto-sizes to content height: the iframe shell reports its
+ *    `documentElement.scrollHeight` over postMessage and we resize to fit
+ *    (clamped by a max).
+ *  - A tiny floating toolbar appears on hover with "Save" (promote into the
+ *    artifact store) and "Copy" — invisible otherwise so it doesn't
+ *    interrupt reading.
+ *  - Streaming indicator is a 1px indigo line at the top edge plus a small
+ *    pulsing cursor in the corner; no heavy shimmer or "Generating…" label.
  *
- * Source: `visual_render` tool. The content is temporary — it lives with the
- * chat message and is NOT in the artifact store unless the user clicks
- * "Save as artifact" (which promotes it).
+ * Two render paths:
+ *   - **Streaming**: extract `type` / `title` / `content` from the still-
+ *     growing partial JSON; load STREAMING_SHELL once, post the latest
+ *     accumulated HTML on every tick; morphdom diffs the DOM in place.
+ *   - **Done**: re-render with `withAutoHeight(content)` so the final
+ *     srcdoc executes <script> tags AND keeps reporting size changes.
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ArtifactType } from '../../types';
 import { useArtifactDrawer } from './ArtifactContext';
 import { extractPartialStringField } from './partialJson';
-import { STREAMING_SHELL } from './streamingShell';
+import { STREAMING_SHELL, withAutoHeight } from './streamingShell';
 
 export interface InlineVisualPayload {
   type: ArtifactType;
@@ -36,13 +43,9 @@ interface ChatInlineVisualProps {
   streaming?: boolean;
 }
 
-const DEFAULT_HEIGHT = 320;
+const MIN_HEIGHT = 120;
+const MAX_HEIGHT = 640;
 
-/**
- * Read whatever can be parsed from a partial JSON string the LLM is still
- * emitting. Fields appear in declaration order, so `type` and `title`
- * generally land before `content`.
- */
 function parsePartial(partialInput: string | undefined): InlineVisualPayload | null {
   if (!partialInput) return null;
   const rawType = extractPartialStringField(partialInput, 'type');
@@ -62,44 +65,51 @@ export const ChatInlineVisual = ({
   const { openArtifact } = useArtifactDrawer();
   const [savedId, setSavedId] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [height, setHeight] = useState(MIN_HEIGHT);
 
-  // Resolve which payload to render: prefer the final one once done; fall back
-  // to the partial one while the LLM is still emitting.
   const partialPayload = useMemo(() => parsePartial(partialInput), [partialInput]);
   const livePayload: InlineVisualPayload | null = payload ?? partialPayload;
 
   const isStreamingHtml = streaming && !payload && livePayload?.type === 'html';
-  const streamIframeRef = useRef<HTMLIFrameElement>(null);
+  const isFinalHtml = !streaming && payload?.type === 'html';
+  const iframeRef = useRef<HTMLIFrameElement>(null);
   const shellReady = useRef(false);
   const pendingMorph = useRef<string | null>(null);
 
-  // The streaming iframe needs to know when its postMessage listener has
-  // installed. Until then we queue the latest accumulated HTML.
+  // Listen for `{ type: 'height', value }` from the iframe and resize to fit.
+  // Single global listener — we filter by `event.source` to ignore other
+  // iframes on the page.
   useEffect(() => {
-    if (!isStreamingHtml) {
-      shellReady.current = false;
-      pendingMorph.current = null;
-      return;
-    }
-    const handleReady = (e: MessageEvent) => {
-      if (e.source !== streamIframeRef.current?.contentWindow) return;
-      if (e.data?.type !== 'morph-ready') return;
-      shellReady.current = true;
-      if (pendingMorph.current != null) {
-        streamIframeRef.current?.contentWindow?.postMessage(
-          { type: 'morph', html: pendingMorph.current },
-          '*',
-        );
-        pendingMorph.current = null;
+    const handle = (e: MessageEvent) => {
+      if (e.source !== iframeRef.current?.contentWindow) return;
+      const data = e.data;
+      if (!data || typeof data !== 'object') return;
+      if (data.type === 'morph-ready') {
+        shellReady.current = true;
+        if (pendingMorph.current != null) {
+          iframeRef.current?.contentWindow?.postMessage(
+            { type: 'morph', html: pendingMorph.current },
+            '*',
+          );
+          pendingMorph.current = null;
+        }
+      } else if (data.type === 'height' && typeof data.value === 'number') {
+        const clamped = Math.max(MIN_HEIGHT, Math.min(MAX_HEIGHT, data.value));
+        setHeight(prev => (Math.abs(prev - clamped) < 2 ? prev : clamped));
       }
     };
-    window.addEventListener('message', handleReady);
-    return () => {
-      window.removeEventListener('message', handleReady);
-    };
-  }, [isStreamingHtml]);
+    window.addEventListener('message', handle);
+    return () => window.removeEventListener('message', handle);
+  }, []);
 
-  // Push the latest HTML into the streaming shell on every partial update.
+  // Reset shell-ready flag whenever we switch between streaming and final iframes.
+  useEffect(() => {
+    shellReady.current = false;
+    pendingMorph.current = null;
+  }, [isStreamingHtml, isFinalHtml]);
+
+  // Push the latest accumulated HTML into the streaming shell on every tick.
   useEffect(() => {
     if (!isStreamingHtml || !livePayload) return;
     const html = livePayload.content;
@@ -108,10 +118,11 @@ export const ChatInlineVisual = ({
       pendingMorph.current = html;
       return;
     }
-    streamIframeRef.current?.contentWindow?.postMessage({ type: 'morph', html }, '*');
+    iframeRef.current?.contentWindow?.postMessage({ type: 'morph', html }, '*');
   }, [isStreamingHtml, livePayload]);
 
-  const handleSaveAsArtifact = useCallback(async () => {
+  const handleSaveAsArtifact = useCallback(async (e: React.MouseEvent) => {
+    e.stopPropagation();
     if (!livePayload || savedId || saving) return;
     setSaving(true);
     try {
@@ -130,15 +141,27 @@ export const ChatInlineVisual = ({
     }
   }, [savedId, saving, workspaceId, livePayload, openArtifact]);
 
-  const handleOpenSaved = useCallback(() => {
+  const handleCopy = useCallback(async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!livePayload?.content) return;
+    try {
+      await navigator.clipboard.writeText(livePayload.content);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch {
+      /* clipboard write failed silently */
+    }
+  }, [livePayload]);
+
+  const handleOpenSaved = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
     if (savedId) openArtifact(workspaceId, savedId);
   }, [savedId, workspaceId, openArtifact]);
 
   const renderBody = () => {
     if (!livePayload) {
-      // No type/content extractable yet — show a thin skeleton bar.
       return (
-        <div className="chat-inline-visual__skeleton">
+        <div className="chat-inline-visual__skeleton" aria-hidden="true">
           <div className="chat-inline-visual__skeleton-bar" />
         </div>
       );
@@ -146,25 +169,24 @@ export const ChatInlineVisual = ({
 
     if (livePayload.type === 'html') {
       if (isStreamingHtml) {
-        // Streaming mode — load the shell once, push deltas via postMessage.
         return (
           <iframe
-            ref={streamIframeRef}
+            ref={iframeRef}
             className="chat-inline-visual__frame"
             srcDoc={STREAMING_SHELL}
             sandbox="allow-scripts"
-            style={{ height: DEFAULT_HEIGHT }}
-            title={livePayload.title || 'Inline visual (streaming)'}
+            style={{ height }}
+            title={livePayload.title || 'Inline visual'}
           />
         );
       }
-      // Final mode — clean srcDoc so scripts execute.
       return (
         <iframe
+          ref={iframeRef}
           className="chat-inline-visual__frame"
-          srcDoc={livePayload.content}
+          srcDoc={withAutoHeight(livePayload.content)}
           sandbox="allow-scripts"
-          style={{ height: DEFAULT_HEIGHT }}
+          style={{ height }}
           title={livePayload.title || 'Inline visual'}
         />
       );
@@ -184,41 +206,51 @@ export const ChatInlineVisual = ({
     );
   };
 
-  const title = livePayload?.title;
-  const showShimmer = isStreamingHtml || (streaming && !livePayload);
+  const isStreaming = streaming && !payload;
+  const hasContent = !!livePayload?.content;
 
   return (
-    <div className={`chat-inline-visual${showShimmer ? ' chat-inline-visual--streaming' : ''}`}>
-      {showShimmer && <div className="chat-inline-visual__shimmer" />}
-      <div className="chat-inline-visual__header">
-        <div className="chat-inline-visual__label">
-          {streaming ? 'Generating visual' : 'Inline visual'}
-          {title && <span className="chat-inline-visual__title"> · {title}</span>}
-        </div>
-        {streaming && !payload ? (
-          <span className="chat-inline-visual__progress">
-            <span className="chat-inline-visual__spinner" />
-          </span>
+    <div
+      className={`chat-inline-visual${isStreaming ? ' chat-inline-visual--streaming' : ''}`}
+    >
+      {isStreaming && <div className="chat-inline-visual__stream-edge" aria-hidden="true" />}
+      {renderBody()}
+      {/* Hover toolbar — invisible until pointer enters the visual. */}
+      <div className="chat-inline-visual__toolbar" aria-hidden={!hasContent}>
+        {isStreaming ? (
+          <span className="chat-inline-visual__cursor" />
         ) : savedId ? (
           <button
             type="button"
-            className="chat-inline-visual__action"
+            className="chat-inline-visual__btn"
             onClick={handleOpenSaved}
+            title="Open in drawer"
           >
-            Open in drawer
+            Open
           </button>
         ) : (
-          <button
-            type="button"
-            className="chat-inline-visual__action chat-inline-visual__action--primary"
-            onClick={() => void handleSaveAsArtifact()}
-            disabled={saving || !livePayload?.content}
-          >
-            {saving ? 'Saving…' : 'Save as artifact'}
-          </button>
+          <>
+            <button
+              type="button"
+              className="chat-inline-visual__btn"
+              onClick={handleCopy}
+              disabled={!hasContent}
+              title="Copy source"
+            >
+              {copied ? 'Copied' : 'Copy'}
+            </button>
+            <button
+              type="button"
+              className="chat-inline-visual__btn chat-inline-visual__btn--primary"
+              onClick={(e) => void handleSaveAsArtifact(e)}
+              disabled={saving || !hasContent}
+              title="Save as artifact"
+            >
+              {saving ? 'Saving' : 'Save'}
+            </button>
+          </>
         )}
       </div>
-      {renderBody()}
     </div>
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/components/artifacts/ChatInlineVisual.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/artifacts/ChatInlineVisual.tsx
@@ -1,0 +1,110 @@
+/**
+ * Inline visual rendered directly inside an assistant message body.
+ *
+ * Source: `visual_render` tool result. The content is temporary — it
+ * lives with the chat message and is NOT in the artifact store unless
+ * the user clicks "Save as artifact" (which promotes it).
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import type { ArtifactType } from '../../types';
+import { useArtifactDrawer } from './ArtifactContext';
+
+export interface InlineVisualPayload {
+  type: ArtifactType;
+  title?: string;
+  content: string;
+}
+
+interface ChatInlineVisualProps {
+  workspaceId: string;
+  payload: InlineVisualPayload;
+}
+
+const DEFAULT_HEIGHT = 320;
+
+export const ChatInlineVisual = ({ workspaceId, payload }: ChatInlineVisualProps) => {
+  const { openArtifact } = useArtifactDrawer();
+  const [savedId, setSavedId] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const handleSaveAsArtifact = useCallback(async () => {
+    if (savedId || saving) return;
+    setSaving(true);
+    try {
+      const result = await window.canvasWorkspace.artifacts.create(workspaceId, {
+        type: payload.type,
+        title: payload.title || 'Saved visual',
+        content: payload.content,
+        source: { origin: 'inline_promotion' },
+      });
+      if (result.ok && result.artifact) {
+        setSavedId(result.artifact.id);
+        openArtifact(workspaceId, result.artifact.id);
+      }
+    } finally {
+      setSaving(false);
+    }
+  }, [savedId, saving, workspaceId, payload, openArtifact]);
+
+  const handleOpenSaved = useCallback(() => {
+    if (savedId) openArtifact(workspaceId, savedId);
+  }, [savedId, workspaceId, openArtifact]);
+
+  const body = useMemo(() => {
+    if (payload.type === 'html') {
+      return (
+        <iframe
+          className="chat-inline-visual__frame"
+          srcDoc={payload.content}
+          sandbox="allow-scripts"
+          style={{ height: DEFAULT_HEIGHT }}
+          title={payload.title || 'Inline visual'}
+        />
+      );
+    }
+    if (payload.type === 'svg') {
+      return (
+        <div
+          className="chat-inline-visual__svg"
+          dangerouslySetInnerHTML={{ __html: payload.content }}
+        />
+      );
+    }
+    return (
+      <div className="chat-inline-visual__error">
+        Unsupported visual type: {payload.type}
+      </div>
+    );
+  }, [payload]);
+
+  return (
+    <div className="chat-inline-visual">
+      <div className="chat-inline-visual__header">
+        <div className="chat-inline-visual__label">
+          Inline visual
+          {payload.title && <span className="chat-inline-visual__title"> · {payload.title}</span>}
+        </div>
+        {savedId ? (
+          <button
+            type="button"
+            className="chat-inline-visual__action"
+            onClick={handleOpenSaved}
+          >
+            Open in drawer
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="chat-inline-visual__action chat-inline-visual__action--primary"
+            onClick={() => void handleSaveAsArtifact()}
+            disabled={saving}
+          >
+            {saving ? 'Saving…' : 'Save as artifact'}
+          </button>
+        )}
+      </div>
+      {body}
+    </div>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/artifacts/artifacts.css
+++ b/apps/canvas-workspace/src/renderer/src/components/artifacts/artifacts.css
@@ -1,74 +1,157 @@
 /* ─── Inline visual in chat (visual_render tool result) ────────────── */
 
+/* ─── Inline visual: chromeless, embedded in conversation flow ───────── */
+
 .chat-inline-visual {
   position: relative;
-  margin-top: 10px;
-  border: 1px solid rgba(55, 53, 47, 0.12);
-  border-radius: 10px;
-  background: #fff;
-  overflow: hidden;
+  display: block;
+  margin: 14px 0;
+  width: 100%;
+  background: transparent;
 }
 
-.chat-inline-visual--streaming {
-  border-color: rgba(99, 102, 241, 0.35);
-}
-
-.chat-inline-visual__shimmer {
+/* Top edge accent during streaming — a thin 1px indigo line that fades in/out. */
+.chat-inline-visual__stream-edge {
   position: absolute;
-  top: 0;
+  top: -4px;
   left: 0;
   right: 0;
-  height: 2px;
+  height: 1px;
   background: linear-gradient(
     90deg,
     transparent 0%,
-    rgba(99, 102, 241, 0.65) 50%,
+    rgba(99, 102, 241, 0.5) 30%,
+    rgba(99, 102, 241, 0.75) 50%,
+    rgba(99, 102, 241, 0.5) 70%,
     transparent 100%
   );
   background-size: 200% 100%;
-  animation: chat-inline-shimmer 1.4s linear infinite;
+  animation: chat-inline-edge 1.6s linear infinite;
+  pointer-events: none;
   z-index: 1;
 }
 
-@keyframes chat-inline-shimmer {
+@keyframes chat-inline-edge {
   0% { background-position: 200% 0; }
   100% { background-position: -200% 0; }
 }
 
-.chat-inline-visual__progress {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
+.chat-inline-visual__frame {
+  display: block;
+  width: 100%;
+  border: 0;
+  background: transparent;
 }
 
-.chat-inline-visual__spinner {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  border: 1.5px solid rgba(99, 102, 241, 0.25);
-  border-top-color: #6366f1;
-  animation: chat-inline-spin 0.8s linear infinite;
+.chat-inline-visual__svg {
+  display: block;
+  width: 100%;
+  background: transparent;
 }
 
-@keyframes chat-inline-spin {
-  to { transform: rotate(360deg); }
+.chat-inline-visual__error {
+  padding: 10px 12px;
+  font-size: 12px;
+  color: #b54040;
 }
 
 .chat-inline-visual__skeleton {
+  min-height: 80px;
   display: flex;
   align-items: center;
-  justify-content: center;
-  min-height: 64px;
-  padding: 16px;
+  padding: 16px 0;
 }
 
 .chat-inline-visual__skeleton-bar {
-  width: 50%;
-  height: 8px;
-  border-radius: 4px;
+  width: 40%;
+  height: 6px;
+  border-radius: 3px;
   background: linear-gradient(90deg, #f1f1ef 0%, #e5e5e2 50%, #f1f1ef 100%);
   background-size: 200% 100%;
-  animation: chat-inline-shimmer 1.4s linear infinite;
+  animation: chat-inline-edge 1.6s linear infinite;
+}
+
+/* Hover toolbar — invisible at rest, fades in when the user points at it. */
+
+.chat-inline-visual__toolbar {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 4px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(55, 53, 47, 0.1);
+  border-radius: 6px;
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  opacity: 0;
+  transform: translateY(-2px);
+  transition: opacity 0.12s ease, transform 0.12s ease;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.chat-inline-visual:hover .chat-inline-visual__toolbar,
+.chat-inline-visual:focus-within .chat-inline-visual__toolbar {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.chat-inline-visual__btn {
+  font-size: 11px;
+  font-weight: 500;
+  color: #4b4a47;
+  background: transparent;
+  border: 0;
+  border-radius: 4px;
+  padding: 3px 7px;
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s;
+}
+
+.chat-inline-visual__btn:hover:not(:disabled) {
+  background: rgba(55, 53, 47, 0.07);
+  color: #37352f;
+}
+
+.chat-inline-visual__btn:disabled {
+  color: #b9b9b6;
+  cursor: default;
+}
+
+.chat-inline-visual__btn--primary {
+  color: #37352f;
+  font-weight: 600;
+}
+
+/* Tiny pulsing cursor shown in place of the toolbar while streaming —
+ * acts as the "thinking" indicator without a heavy header bar. */
+
+.chat-inline-visual__cursor {
+  display: inline-block;
+  width: 6px;
+  height: 12px;
+  background: #6366f1;
+  border-radius: 1px;
+  margin: 2px 4px;
+  animation: chat-inline-cursor 1s ease-in-out infinite;
+}
+
+.chat-inline-visual--streaming .chat-inline-visual__toolbar {
+  opacity: 1;
+  pointer-events: none;
+  background: transparent;
+  border: 0;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
+@keyframes chat-inline-cursor {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.25; }
 }
 
 .chat-inline-visual__header {

--- a/apps/canvas-workspace/src/renderer/src/components/artifacts/artifacts.css
+++ b/apps/canvas-workspace/src/renderer/src/components/artifacts/artifacts.css
@@ -1,0 +1,364 @@
+/* ─── Inline visual in chat (visual_render tool result) ────────────── */
+
+.chat-inline-visual {
+  margin-top: 10px;
+  border: 1px solid rgba(55, 53, 47, 0.12);
+  border-radius: 10px;
+  background: #fff;
+  overflow: hidden;
+}
+
+.chat-inline-visual__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 7px 10px 7px 12px;
+  border-bottom: 1px solid rgba(55, 53, 47, 0.08);
+  background: #fafaf9;
+}
+
+.chat-inline-visual__label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #8a8a87;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.chat-inline-visual__title {
+  text-transform: none;
+  letter-spacing: 0;
+  color: #37352f;
+  font-weight: 500;
+  margin-left: 6px;
+}
+
+.chat-inline-visual__action {
+  font-size: 11px;
+  font-weight: 500;
+  color: #37352f;
+  background: transparent;
+  border: 1px solid rgba(55, 53, 47, 0.16);
+  border-radius: 5px;
+  padding: 3px 8px;
+  cursor: pointer;
+  transition: background 0.1s, border-color 0.1s;
+  white-space: nowrap;
+}
+
+.chat-inline-visual__action:hover:not(:disabled) {
+  background: #f1f1ef;
+  border-color: rgba(55, 53, 47, 0.28);
+}
+
+.chat-inline-visual__action:disabled {
+  color: #8a8a87;
+  cursor: default;
+}
+
+.chat-inline-visual__action--primary {
+  background: #37352f;
+  color: #fff;
+  border-color: #37352f;
+}
+
+.chat-inline-visual__action--primary:hover:not(:disabled) {
+  background: #2f2e2a;
+  border-color: #2f2e2a;
+}
+
+.chat-inline-visual__frame {
+  display: block;
+  width: 100%;
+  border: 0;
+  background: #fff;
+}
+
+.chat-inline-visual__svg {
+  display: block;
+  width: 100%;
+  background: #fff;
+  padding: 12px;
+  box-sizing: border-box;
+}
+
+.chat-inline-visual__error {
+  padding: 10px 12px;
+  font-size: 12px;
+  color: #b54040;
+}
+
+/* ─── Artifact card in chat (artifact_create / artifact_update result) ─ */
+
+.chat-artifact-card {
+  margin-top: 10px;
+  border: 1px solid rgba(55, 53, 47, 0.14);
+  border-radius: 10px;
+  background: #fff;
+  cursor: pointer;
+  transition: border-color 0.12s, box-shadow 0.12s;
+}
+
+.chat-artifact-card:hover {
+  border-color: rgba(55, 53, 47, 0.28);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.chat-artifact-card__row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+}
+
+.chat-artifact-card__icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: #f1efe8;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  flex-shrink: 0;
+}
+
+.chat-artifact-card__meta {
+  flex: 1;
+  min-width: 0;
+}
+
+.chat-artifact-card__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #37352f;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-artifact-card__sub {
+  font-size: 11px;
+  color: #8a8a87;
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-artifact-card__actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.chat-artifact-card__action {
+  font-size: 11px;
+  font-weight: 500;
+  color: #37352f;
+  background: transparent;
+  border: 1px solid rgba(55, 53, 47, 0.16);
+  border-radius: 5px;
+  padding: 4px 8px;
+  cursor: pointer;
+  transition: background 0.1s, border-color 0.1s;
+  white-space: nowrap;
+}
+
+.chat-artifact-card__action:hover:not(:disabled) {
+  background: #f1f1ef;
+  border-color: rgba(55, 53, 47, 0.28);
+}
+
+.chat-artifact-card__action:disabled {
+  color: #8a8a87;
+  cursor: default;
+}
+
+/* ─── Right-side artifact drawer ────────────────────────────────────── */
+
+.artifact-drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 15, 14, 0.18);
+  z-index: 90;
+  animation: artifact-fade-in 0.12s ease-out;
+}
+
+.artifact-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(640px, 80vw);
+  background: #fff;
+  border-left: 1px solid rgba(55, 53, 47, 0.12);
+  display: flex;
+  flex-direction: column;
+  z-index: 100;
+  box-shadow: -2px 0 12px rgba(15, 15, 14, 0.08);
+  animation: artifact-slide-in 0.18s ease-out;
+}
+
+@keyframes artifact-slide-in {
+  from { transform: translateX(20px); opacity: 0; }
+  to { transform: translateX(0); opacity: 1; }
+}
+
+@keyframes artifact-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.artifact-drawer__header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border-bottom: 1px solid rgba(55, 53, 47, 0.08);
+  flex-shrink: 0;
+}
+
+.artifact-drawer__title {
+  flex: 1;
+  min-width: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: #37352f;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.artifact-drawer__type-badge {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #6b6b68;
+  background: #f1efe8;
+  padding: 2px 6px;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.artifact-drawer__close {
+  width: 26px;
+  height: 26px;
+  border: 0;
+  background: transparent;
+  color: #6b6b68;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.artifact-drawer__close:hover {
+  background: rgba(55, 53, 47, 0.08);
+  color: #37352f;
+}
+
+.artifact-drawer__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-bottom: 1px solid rgba(55, 53, 47, 0.08);
+  background: #fafaf9;
+  flex-shrink: 0;
+}
+
+.artifact-drawer__version-select {
+  font-size: 12px;
+  color: #37352f;
+  background: #fff;
+  border: 1px solid rgba(55, 53, 47, 0.16);
+  border-radius: 5px;
+  padding: 4px 8px;
+  font-family: inherit;
+}
+
+.artifact-drawer__toolbar-spacer { flex: 1; }
+
+.artifact-drawer__action {
+  font-size: 12px;
+  font-weight: 500;
+  color: #37352f;
+  background: transparent;
+  border: 1px solid rgba(55, 53, 47, 0.16);
+  border-radius: 5px;
+  padding: 5px 10px;
+  cursor: pointer;
+  transition: background 0.1s, border-color 0.1s;
+  white-space: nowrap;
+}
+
+.artifact-drawer__action:hover:not(:disabled) {
+  background: #f1f1ef;
+  border-color: rgba(55, 53, 47, 0.28);
+}
+
+.artifact-drawer__action--primary {
+  background: #37352f;
+  color: #fff;
+  border-color: #37352f;
+}
+
+.artifact-drawer__action--primary:hover:not(:disabled) {
+  background: #2f2e2a;
+  border-color: #2f2e2a;
+}
+
+.artifact-drawer__action:disabled {
+  color: #8a8a87;
+  border-color: rgba(55, 53, 47, 0.08);
+  cursor: default;
+}
+
+.artifact-drawer__body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+}
+
+.artifact-drawer__frame {
+  flex: 1;
+  width: 100%;
+  border: 0;
+  background: #fff;
+}
+
+.artifact-drawer__svg-host {
+  flex: 1;
+  overflow: auto;
+  padding: 16px;
+  background: #fff;
+}
+
+.artifact-drawer__empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #8a8a87;
+  font-size: 13px;
+}
+
+.artifact-drawer__pinned-badge {
+  font-size: 11px;
+  color: #6b6b68;
+  margin-left: 4px;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/artifacts/artifacts.css
+++ b/apps/canvas-workspace/src/renderer/src/components/artifacts/artifacts.css
@@ -1,11 +1,74 @@
 /* ─── Inline visual in chat (visual_render tool result) ────────────── */
 
 .chat-inline-visual {
+  position: relative;
   margin-top: 10px;
   border: 1px solid rgba(55, 53, 47, 0.12);
   border-radius: 10px;
   background: #fff;
   overflow: hidden;
+}
+
+.chat-inline-visual--streaming {
+  border-color: rgba(99, 102, 241, 0.35);
+}
+
+.chat-inline-visual__shimmer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(99, 102, 241, 0.65) 50%,
+    transparent 100%
+  );
+  background-size: 200% 100%;
+  animation: chat-inline-shimmer 1.4s linear infinite;
+  z-index: 1;
+}
+
+@keyframes chat-inline-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.chat-inline-visual__progress {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.chat-inline-visual__spinner {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 1.5px solid rgba(99, 102, 241, 0.25);
+  border-top-color: #6366f1;
+  animation: chat-inline-spin 0.8s linear infinite;
+}
+
+@keyframes chat-inline-spin {
+  to { transform: rotate(360deg); }
+}
+
+.chat-inline-visual__skeleton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 64px;
+  padding: 16px;
+}
+
+.chat-inline-visual__skeleton-bar {
+  width: 50%;
+  height: 8px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #f1f1ef 0%, #e5e5e2 50%, #f1f1ef 100%);
+  background-size: 200% 100%;
+  animation: chat-inline-shimmer 1.4s linear infinite;
 }
 
 .chat-inline-visual__header {

--- a/apps/canvas-workspace/src/renderer/src/components/artifacts/index.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/artifacts/index.ts
@@ -1,0 +1,5 @@
+export { ArtifactDrawerProvider, useArtifactDrawer } from './ArtifactContext';
+export { ArtifactDrawer } from './ArtifactDrawer';
+export { ChatInlineVisual, type InlineVisualPayload } from './ChatInlineVisual';
+export { ChatArtifactCard, type ArtifactCardPayload } from './ChatArtifactCard';
+export { parseVisualToolResult, type VisualToolResult } from './parseVisualToolResult';

--- a/apps/canvas-workspace/src/renderer/src/components/artifacts/parseVisualToolResult.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/artifacts/parseVisualToolResult.ts
@@ -1,0 +1,74 @@
+/**
+ * Tool-result parsers for the visual / artifact tools.
+ *
+ * The agent tools (`visual_render`, `artifact_create`, `artifact_update`)
+ * return JSON-stringified payloads that the chat renderer detects and
+ * inlines as rich UI. This module owns the recognition logic so callers
+ * don't sprinkle JSON.parse / shape checks across the codebase.
+ */
+
+import type { ArtifactType } from '../../types';
+import type { InlineVisualPayload } from './ChatInlineVisual';
+import type { ArtifactCardPayload } from './ChatArtifactCard';
+
+export type VisualToolResult =
+  | { kind: 'visual_render'; payload: InlineVisualPayload }
+  | { kind: 'artifact_create'; payload: ArtifactCardPayload }
+  | { kind: 'artifact_update'; payload: ArtifactCardPayload };
+
+interface ParsedShape {
+  ok?: boolean;
+  kind?: string;
+  type?: ArtifactType;
+  title?: string;
+  content?: string;
+  artifactId?: string;
+  versionCount?: number;
+}
+
+export function parseVisualToolResult(toolName: string, raw?: string): VisualToolResult | null {
+  if (!raw) return null;
+  let parsed: ParsedShape;
+  try {
+    parsed = JSON.parse(raw) as ParsedShape;
+  } catch {
+    return null;
+  }
+  if (parsed?.ok === false) return null;
+
+  const kind = parsed.kind;
+  const name = toolName;
+
+  if ((name === 'visual_render' || kind === 'visual_render') && parsed.type && typeof parsed.content === 'string') {
+    return {
+      kind: 'visual_render',
+      payload: { type: parsed.type, title: parsed.title, content: parsed.content },
+    };
+  }
+
+  if ((name === 'artifact_create' || kind === 'artifact_create') && parsed.artifactId && parsed.type) {
+    return {
+      kind: 'artifact_create',
+      payload: {
+        artifactId: parsed.artifactId,
+        title: parsed.title || 'Artifact',
+        type: parsed.type,
+      },
+    };
+  }
+
+  if ((name === 'artifact_update' || kind === 'artifact_update') && parsed.artifactId && parsed.type) {
+    return {
+      kind: 'artifact_update',
+      payload: {
+        artifactId: parsed.artifactId,
+        title: parsed.title || 'Artifact',
+        type: parsed.type,
+        isUpdate: true,
+        versionCount: parsed.versionCount,
+      },
+    };
+  }
+
+  return null;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/artifacts/partialJson.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/artifacts/partialJson.ts
@@ -1,0 +1,81 @@
+/**
+ * Streaming JSON helpers — extract a single string field from a JSON document
+ * that may still be in the middle of being emitted by the LLM.
+ *
+ * We can't use `JSON.parse` mid-stream: the trailing braces / quotes aren't
+ * there yet. Instead we scan for `"<field>"\s*:\s*"` and then walk character
+ * by character, honoring backslash escapes, until we hit an unescaped closing
+ * quote (string complete) or EOF (string still being emitted, return what we
+ * have so far).
+ *
+ * This is intentionally NOT a full JSON parser — it only handles the
+ * top-level fields of the `visual_render` / `artifact_create` tool inputs.
+ * Object nesting inside the target field's value is not supported (we expect
+ * `content` etc. to be plain strings).
+ */
+
+/**
+ * Return the (possibly partial) value of `"<field>": "..."` from a JSON
+ * string fragment. Returns `undefined` if the field/value-opening hasn't been
+ * emitted yet, or the (possibly partial) string content otherwise.
+ *
+ * The result is fully unescaped: `\n` becomes a real newline, `\"` becomes a
+ * literal quote, etc., so it can be passed straight to an iframe or DOM.
+ */
+export function extractPartialStringField(json: string, field: string): string | undefined {
+  // Match `"field"`<ws>`:`<ws>`"` — start of the string value.
+  // Escape the field name for the regex; field names in the tool schema are
+  // simple identifiers so this is safe.
+  const re = new RegExp(`"${field.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"\\s*:\\s*"`);
+  const match = json.match(re);
+  if (!match || match.index === undefined) return undefined;
+
+  let i = match.index + match[0].length;
+  let out = '';
+
+  while (i < json.length) {
+    const ch = json[i];
+    if (ch === '\\') {
+      // Escape sequence. If we don't have the second char yet, return what we
+      // have (the next delta will resume the scan from this position).
+      if (i + 1 >= json.length) return out;
+      const next = json[i + 1];
+      switch (next) {
+        case 'n': out += '\n'; i += 2; break;
+        case 't': out += '\t'; i += 2; break;
+        case 'r': out += '\r'; i += 2; break;
+        case '"': out += '"'; i += 2; break;
+        case '\\': out += '\\'; i += 2; break;
+        case '/': out += '/'; i += 2; break;
+        case 'b': out += '\b'; i += 2; break;
+        case 'f': out += '\f'; i += 2; break;
+        case 'u': {
+          // \uXXXX — need 4 more hex chars. If incomplete, return what we have.
+          if (i + 5 >= json.length) return out;
+          const hex = json.slice(i + 2, i + 6);
+          if (!/^[0-9a-fA-F]{4}$/.test(hex)) {
+            // Malformed escape — bail with current accumulator.
+            return out;
+          }
+          out += String.fromCharCode(parseInt(hex, 16));
+          i += 6;
+          break;
+        }
+        default:
+          // Unknown escape — emit the literal character and move on.
+          out += next;
+          i += 2;
+      }
+    } else if (ch === '"') {
+      // Unescaped quote — string is closed.
+      return out;
+    } else {
+      out += ch;
+      i += 1;
+    }
+  }
+
+  // Reached EOF mid-string. Return the accumulator; the next delta will
+  // continue from where we left off (callers re-run this each tick).
+  return out;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/artifacts/streamingShell.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/artifacts/streamingShell.ts
@@ -6,6 +6,9 @@
  *  - morphdom from CDN (with a tiny innerHTML fallback if CDN fails)
  *  - a postMessage listener that morphs the visible DOM whenever the parent
  *    posts `{ type: 'morph', html }` with the latest accumulated HTML.
+ *  - a ResizeObserver that posts `{ type: 'height', value }` to the parent
+ *    whenever the document height changes — used by the chat inline visual
+ *    to keep the iframe sized to its content (no fixed height).
  *
  * The parent (renderer component) calls `postMessage(...)` with the latest
  * accumulated HTML; the shell extracts <style> → applies to <head>,
@@ -13,18 +16,20 @@
  * streaming (so partial scripts don't crash).
  *
  * Once the LLM finishes the parent swaps the iframe's srcdoc to the final
- * HTML so any <script> tags actually run.
+ * HTML so any <script> tags actually run. The final HTML should be wrapped
+ * with `withAutoHeight()` so it continues to report height changes.
  */
 
 export const STREAMING_SHELL = `<!DOCTYPE html>
 <html><head><meta charset="utf-8">
-<style>*,*::before,*::after{box-sizing:border-box}body{margin:0;font-family:system-ui,-apple-system,sans-serif;background:#fff}</style>
+<style>*,*::before,*::after{box-sizing:border-box}html,body{margin:0;font-family:system-ui,-apple-system,sans-serif;background:#fff}body{padding:0}</style>
 <script src="https://cdn.jsdelivr.net/npm/morphdom@2/dist/morphdom-umd.min.js"
   onerror="window.morphdom=function(f,t){if(typeof t==='string'){var d=document.createElement('div');d.innerHTML=t;while(f.firstChild)f.removeChild(f.firstChild);while(d.firstChild)f.appendChild(d.firstChild)}else if(f.parentNode){f.parentNode.replaceChild(t,f)}}"></script>
 </head><body>
 <div id="__mr__"></div>
 <script>
-var root=document.getElementById("__mr__"),styleEl=null,prevCss="";
+var root=document.getElementById("__mr__"),styleEl=null,prevCss="",lastH=0;
+function reportH(){var h=document.documentElement.scrollHeight;if(h!==lastH){lastH=h;parent.postMessage({type:"height",value:h},"*")}}
 function applyUpdate(html){
   var css="";
   html.replace(/<style[^>]*>([\\s\\S]*?)<\\/style>/gi,function(_,c){css+=c});
@@ -45,11 +50,32 @@ function applyUpdate(html){
   if(!body)return;
   var nx=document.createElement("div");nx.id="__mr__";nx.innerHTML=body;
   if(typeof morphdom==="function"){try{morphdom(root,nx)}catch(e){root.innerHTML=body}}
-  else root.innerHTML=body
+  else root.innerHTML=body;
+  reportH()
 }
+if(typeof ResizeObserver==="function"){try{new ResizeObserver(reportH).observe(document.documentElement)}catch(e){}}
 window.addEventListener("message",function(e){
   if(e.data&&e.data.type==="morph")applyUpdate(e.data.html)
 });
 window.parent.postMessage({type:"morph-ready"},"*");
+reportH();
 </script>
 </body></html>`;
+
+/**
+ * Wrap the LLM's final HTML so the resulting iframe also reports its
+ * content height to the parent via `postMessage({type:'height',value})`.
+ * Used after streaming finishes to keep the iframe auto-sized once we
+ * swap from STREAMING_SHELL to the clean srcdoc that actually runs scripts.
+ *
+ * Idempotent — if the snippet is already present it leaves the HTML alone.
+ */
+export function withAutoHeight(html: string): string {
+  if (!html) return html;
+  if (html.includes('__pulse_auto_h__')) return html;
+  const probe = `<script id="__pulse_auto_h__">(function(){var lastH=0;function r(){var h=document.documentElement.scrollHeight;if(h!==lastH){lastH=h;parent.postMessage({type:"height",value:h},"*")}}if(typeof ResizeObserver==="function"){try{new ResizeObserver(r).observe(document.documentElement)}catch(e){}}window.addEventListener("load",r);setTimeout(r,0);setTimeout(r,200);setTimeout(r,800);})();</script>`;
+  // Inject just before </body> if we can find it; otherwise append.
+  if (/<\/body>/i.test(html)) return html.replace(/<\/body>/i, `${probe}</body>`);
+  return html + probe;
+}
+

--- a/apps/canvas-workspace/src/renderer/src/components/artifacts/streamingShell.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/artifacts/streamingShell.ts
@@ -1,0 +1,55 @@
+/**
+ * Streaming render shell shared by ChatInlineVisual (artifact streaming in
+ * chat) and IframeNodeBody (artifact streaming inside a pinned canvas node).
+ *
+ * The shell is loaded into a sandboxed iframe via `srcdoc`. It contains:
+ *  - morphdom from CDN (with a tiny innerHTML fallback if CDN fails)
+ *  - a postMessage listener that morphs the visible DOM whenever the parent
+ *    posts `{ type: 'morph', html }` with the latest accumulated HTML.
+ *
+ * The parent (renderer component) calls `postMessage(...)` with the latest
+ * accumulated HTML; the shell extracts <style> → applies to <head>,
+ * extracts <body> content → morphdom diffs it in, strips <script> during
+ * streaming (so partial scripts don't crash).
+ *
+ * Once the LLM finishes the parent swaps the iframe's srcdoc to the final
+ * HTML so any <script> tags actually run.
+ */
+
+export const STREAMING_SHELL = `<!DOCTYPE html>
+<html><head><meta charset="utf-8">
+<style>*,*::before,*::after{box-sizing:border-box}body{margin:0;font-family:system-ui,-apple-system,sans-serif;background:#fff}</style>
+<script src="https://cdn.jsdelivr.net/npm/morphdom@2/dist/morphdom-umd.min.js"
+  onerror="window.morphdom=function(f,t){if(typeof t==='string'){var d=document.createElement('div');d.innerHTML=t;while(f.firstChild)f.removeChild(f.firstChild);while(d.firstChild)f.appendChild(d.firstChild)}else if(f.parentNode){f.parentNode.replaceChild(t,f)}}"></script>
+</head><body>
+<div id="__mr__"></div>
+<script>
+var root=document.getElementById("__mr__"),styleEl=null,prevCss="";
+function applyUpdate(html){
+  var css="";
+  html.replace(/<style[^>]*>([\\s\\S]*?)<\\/style>/gi,function(_,c){css+=c});
+  if(css&&css!==prevCss){
+    if(!styleEl){styleEl=document.createElement("style");styleEl.id="__sc__";document.head.appendChild(styleEl)}
+    styleEl.textContent=css;prevCss=css
+  }
+  var body,bm=html.match(/<body[^>]*>([\\s\\S]*?)(<\\/body>|$)/i);
+  if(bm){body=bm[1]}
+  else{
+    var bi=html.indexOf("<body");
+    if(bi===-1)return;
+    var gt=html.indexOf(">",bi);
+    if(gt===-1)return;
+    body=html.slice(gt+1)
+  }
+  body=body.replace(/<script[\\s\\S]*?(<\\/script>|$)/gi,"").trim();
+  if(!body)return;
+  var nx=document.createElement("div");nx.id="__mr__";nx.innerHTML=body;
+  if(typeof morphdom==="function"){try{morphdom(root,nx)}catch(e){root.innerHTML=body}}
+  else root.innerHTML=body
+}
+window.addEventListener("message",function(e){
+  if(e.data&&e.data.type==="morph")applyUpdate(e.data.html)
+});
+window.parent.postMessage({type:"morph-ready"},"*");
+</script>
+</body></html>`;

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
@@ -111,6 +111,26 @@ export const ChatMessage = ({
             })}
           </div>
           {tools.map(tool => {
+            // While the LLM is still emitting the tool's input args (for
+            // either visual_render or artifact_create / _update), surface
+            // an in-flight visual driven by the partial JSON so the user
+            // sees the content materialize live, the way Claude does.
+            const isStreamingVisual =
+              !tool.result &&
+              (tool.name === 'visual_render'
+                || tool.name === 'artifact_create'
+                || tool.name === 'artifact_update');
+            if (isStreamingVisual) {
+              if (!tool.partialInput) return null;
+              return (
+                <ChatInlineVisual
+                  key={`visual-${tool.id}`}
+                  workspaceId={workspaceId}
+                  partialInput={tool.partialInput}
+                  streaming
+                />
+              );
+            }
             const visual = parseVisualToolResult(tool.name, tool.result);
             if (!visual) return null;
             if (visual.kind === 'visual_render') {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
@@ -3,6 +3,11 @@ import { AvatarIcon } from '../icons';
 import type { ToolCallStatus } from './types';
 import { renderMdWithMentions, renderUserContent } from './utils/mentions';
 import { ChatToolCalls } from './ChatToolCalls';
+import {
+  ChatArtifactCard,
+  ChatInlineVisual,
+  parseVisualToolResult,
+} from '../artifacts';
 
 interface GeneratedImagePayload {
   ok?: boolean;
@@ -31,6 +36,7 @@ interface ChatMessageProps {
   collapsed: boolean;
   expandedTools: Set<number>;
   nodes?: CanvasNode[];
+  workspaceId: string;
   onToggleSection: () => void;
   onToggleToolExpand: (toolId: number) => void;
   onAddImageToCanvas?: (imagePath: string, title?: string) => Promise<void> | void;
@@ -52,6 +58,7 @@ export const ChatMessage = ({
   collapsed,
   expandedTools,
   nodes,
+  workspaceId,
   onToggleSection,
   onToggleToolExpand,
   onAddImageToCanvas,
@@ -103,6 +110,26 @@ export const ChatMessage = ({
               );
             })}
           </div>
+          {tools.map(tool => {
+            const visual = parseVisualToolResult(tool.name, tool.result);
+            if (!visual) return null;
+            if (visual.kind === 'visual_render') {
+              return (
+                <ChatInlineVisual
+                  key={`visual-${tool.id}`}
+                  workspaceId={workspaceId}
+                  payload={visual.payload}
+                />
+              );
+            }
+            return (
+              <ChatArtifactCard
+                key={`artifact-${tool.id}`}
+                workspaceId={workspaceId}
+                payload={visual.payload}
+              />
+            );
+          })}
         </>
       )}
       {message.role === 'assistant' ? (

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessages.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessages.tsx
@@ -8,6 +8,7 @@ interface ChatMessagesProps {
   messages: AgentChatMessage[];
   loading: boolean;
   nodes?: CanvasNode[];
+  workspaceId: string;
   streamingTools: ToolCallStatus[];
   messageTools: Map<number, ToolCallStatus[]>;
   collapsedSections: Set<number>;
@@ -91,6 +92,7 @@ export const ChatMessages = ({
   messages,
   loading,
   nodes,
+  workspaceId,
   streamingTools,
   messageTools,
   collapsedSections,
@@ -138,6 +140,7 @@ export const ChatMessages = ({
             collapsed={collapsedSections.has(index)}
             expandedTools={expandedTools}
             nodes={nodes}
+            workspaceId={workspaceId}
             onToggleSection={() => onToggleSection(index)}
             onToggleToolExpand={onToggleToolExpand}
             onAddImageToCanvas={onAddImageToCanvas}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageBody.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageBody.tsx
@@ -213,6 +213,7 @@ export const ChatPageBody = ({
           className="chat-page-body"
           messages={messages}
           loading={loading}
+          workspaceId={workspaceId}
           streamingTools={streamingTools}
           messageTools={messageTools}
           collapsedSections={collapsedSections}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.tsx
@@ -150,6 +150,7 @@ export const ChatPanel = ({
       }
       messages={messages}
       loading={loading}
+      workspaceId={workspaceId}
       streamingTools={streamingTools}
       messageTools={messageTools}
       collapsedSections={collapsedSections}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatView.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatView.tsx
@@ -20,6 +20,7 @@ interface ChatViewProps {
   // Streaming + messages
   messages: AgentChatMessage[];
   loading: boolean;
+  workspaceId: string;
   streamingTools: ToolCallStatus[];
   messageTools: Map<number, ToolCallStatus[]>;
   collapsedSections: Set<number>;
@@ -75,6 +76,7 @@ export const ChatView = ({
   beforeHeader,
   messages,
   loading,
+  workspaceId,
   streamingTools,
   messageTools,
   collapsedSections,
@@ -124,6 +126,7 @@ export const ChatView = ({
           messages={messages}
           loading={loading}
           nodes={nodes}
+          workspaceId={workspaceId}
           streamingTools={streamingTools}
           messageTools={messageTools}
           collapsedSections={collapsedSections}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatStream.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatStream.ts
@@ -100,37 +100,92 @@ export function useChatStream({ workspaceId, allWorkspaces }: UseChatStreamOptio
         unsubscribeComplete();
         unsubscribeToolCall();
         unsubscribeToolResult();
+        unsubscribeToolInputStart();
+        unsubscribeToolInputDelta();
+        unsubscribeToolInputEnd();
         unsubscribeClarify();
         activeUnsubsRef.current = [];
       };
 
-      const unsubscribeToolCall = window.canvasWorkspace.agent.onToolCall(sessionId, data => {
+      const publishTools = () => {
+        const snapshot = [...toolCalls];
+        setStreamingTools(snapshot);
+        if (assistantIndex.current >= 0) {
+          setMessageTools(prev => new Map(prev).set(assistantIndex.current, snapshot));
+        }
+      };
+
+      const findTool = (toolCallId: string | undefined, name?: string) => {
+        if (toolCallId) {
+          const byId = toolCalls.find(t => t.toolCallId === toolCallId);
+          if (byId) return byId;
+        }
+        if (name) {
+          return toolCalls.find(t => t.name === name && t.status === 'running');
+        }
+        return undefined;
+      };
+
+      // Input streaming: starts BEFORE the LLM has finished emitting tool args.
+      // We create the ToolCallStatus here so the chat UI can render a
+      // progressive preview (e.g. a streaming inline visual) keyed off the
+      // toolCallId before the final tool-call chunk arrives.
+      const unsubscribeToolInputStart = window.canvasWorkspace.agent.onToolInputStart(sessionId, data => {
         ensureAssistantMessage();
         toolCalls.push({
           id: ++toolIdCounter.current,
-          name: data.name,
-          args: data.args,
+          name: data.toolName,
+          toolCallId: data.id,
           status: 'running',
+          partialInput: '',
+          inputStreaming: true,
         });
-        const snapshot = [...toolCalls];
-        setStreamingTools(snapshot);
-        if (assistantIndex.current >= 0) {
-          setMessageTools(prev => new Map(prev).set(assistantIndex.current, snapshot));
+        publishTools();
+      });
+
+      const unsubscribeToolInputDelta = window.canvasWorkspace.agent.onToolInputDelta(sessionId, data => {
+        const tool = findTool(data.id);
+        if (!tool) return;
+        tool.partialInput = (tool.partialInput ?? '') + data.delta;
+        publishTools();
+      });
+
+      const unsubscribeToolInputEnd = window.canvasWorkspace.agent.onToolInputEnd(sessionId, data => {
+        const tool = findTool(data.id);
+        if (!tool) return;
+        tool.inputStreaming = false;
+        publishTools();
+      });
+
+      const unsubscribeToolCall = window.canvasWorkspace.agent.onToolCall(sessionId, data => {
+        ensureAssistantMessage();
+        // If we already created a ToolCallStatus for this id during input
+        // streaming, merge the fully-parsed args in. Otherwise (e.g. a model
+        // that doesn't stream tool input), create one now.
+        const existing = findTool(data.toolCallId, data.name);
+        if (existing) {
+          existing.args = data.args;
+          existing.inputStreaming = false;
+        } else {
+          toolCalls.push({
+            id: ++toolIdCounter.current,
+            name: data.name,
+            args: data.args,
+            toolCallId: data.toolCallId,
+            status: 'running',
+          });
         }
+        publishTools();
       });
 
       const unsubscribeToolResult = window.canvasWorkspace.agent.onToolResult(sessionId, data => {
-        const toolCall = toolCalls.find(item => item.name === data.name && item.status === 'running');
-        if (toolCall) {
-          toolCall.status = 'done';
-          toolCall.result = data.result;
+        const tool = findTool(data.toolCallId, data.name);
+        if (tool) {
+          tool.status = 'done';
+          tool.result = data.result;
+          tool.inputStreaming = false;
         }
-
-        const snapshot = [...toolCalls];
-        setStreamingTools(snapshot);
-        if (assistantIndex.current >= 0) {
-          setMessageTools(prev => new Map(prev).set(assistantIndex.current, snapshot));
-        }
+        publishTools();
       });
 
       const unsubscribeDelta = window.canvasWorkspace.agent.onTextDelta(sessionId, delta => {
@@ -213,6 +268,9 @@ export function useChatStream({ workspaceId, allWorkspaces }: UseChatStreamOptio
       activeUnsubsRef.current.push(
         unsubscribeToolCall,
         unsubscribeToolResult,
+        unsubscribeToolInputStart,
+        unsubscribeToolInputDelta,
+        unsubscribeToolInputEnd,
         unsubscribeDelta,
         unsubscribeComplete,
         unsubscribeClarify,

--- a/apps/canvas-workspace/src/renderer/src/components/chat/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/types.ts
@@ -28,6 +28,13 @@ export interface ToolCallStatus {
   args?: any;
   status: 'running' | 'done';
   result?: string;
+  /** AI SDK toolCallId — used to correlate streaming-input deltas with the final tool-call. */
+  toolCallId?: string;
+  /** Accumulated raw JSON of tool arguments while the LLM is still emitting them.
+   *  Cleared (or kept as-is) once `inputStreaming` flips to false. */
+  partialInput?: string;
+  /** True while the LLM is still streaming this tool's input JSON. */
+  inputStreaming?: boolean;
 }
 
 export type { ChatImageAttachment };

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -91,6 +91,11 @@ export interface TextNodeData {
  * `mode: 'url'` (default) loads a remote page via Electron `<webview>`.
  * `mode: 'html'` renders user-supplied HTML in a sandboxed `<iframe srcdoc>`.
  *
+ * When `artifactId` is set, the rendered HTML is sourced from the
+ * workspace's artifact store (current version) instead of `html`. This
+ * lets the same artifact back both an in-chat preview and a pinned
+ * canvas node — iterating the artifact updates both.
+ *
  * Some sites block embedding via X-Frame-Options / CSP frame-ancestors —
  * those will fail to render and the user can click "Open externally" to
  * escape into the system browser.
@@ -100,12 +105,14 @@ export interface IframeNodeData {
   url: string;
   /** Raw HTML content to render when `mode` is `'html'` or `'ai'`. */
   html?: string;
-  /** `'url'` embeds a remote page; `'html'` renders raw HTML; `'ai'` generates HTML from a prompt. */
-  mode?: 'url' | 'html' | 'ai';
+  /** `'url'` embeds a remote page; `'html'` renders raw HTML; `'ai'` generates HTML from a prompt; `'artifact'` pulls from the artifact store. */
+  mode?: 'url' | 'html' | 'ai' | 'artifact';
   /** The prompt used to generate HTML when `mode` is `'ai'`. */
   prompt?: string;
   /** Last page title reported by the embedded webview for URL mode. */
   pageTitle?: string;
+  /** When set, content is sourced from `artifacts.get(artifactId)`. */
+  artifactId?: string;
 }
 
 /**
@@ -487,6 +494,7 @@ export interface CanvasWorkspaceApi {
   agent: AgentApi;
   iframe: IframeApi;
   llm: LlmApi;
+  artifacts: ArtifactsApi;
 }
 
 export interface LlmApi {
@@ -498,6 +506,96 @@ export interface LlmApi {
   onHTMLDelta: (requestId: string, callback: (delta: string) => void) => () => void;
   /** Subscribe to generation completion. Returns unsubscribe fn. */
   onHTMLComplete: (requestId: string, callback: (result: { ok: boolean; html?: string; error?: string }) => void) => () => void;
+}
+
+/**
+ * An LLM-generated visual product owned by a workspace.
+ *
+ * Three formation paths share the same data shape:
+ *  1. `visual_render` tool → inline-only, NOT stored here (lives in chat).
+ *  2. `artifact_create` tool → stored, versioned, surfaced via chat card + drawer.
+ *  3. User clicks "Save as artifact" on an inline visual → promoted into the store.
+ *
+ * Type values are open to extension; v1 covers `html` only.
+ */
+export type ArtifactType = 'html' | 'svg' | 'mermaid';
+
+export interface ArtifactVersion {
+  id: string;
+  content: string;
+  /** Optional prompt that produced this version — useful as a "diff" hint. */
+  prompt?: string;
+  createdAt: number;
+}
+
+export interface Artifact {
+  id: string;
+  workspaceId: string;
+  type: ArtifactType;
+  title: string;
+  versions: ArtifactVersion[];
+  /** Index into `versions`. Always `versions.length - 1` after a create/update,
+   * but a separate field so the renderer can switch views without mutating data. */
+  currentVersionId: string;
+  /** When set, the artifact is currently mirrored as this canvas node. */
+  pinnedNodeId?: string;
+  /** Origin trace — where the artifact came from. */
+  source?: {
+    sessionId?: string;
+    /** Index of the assistant message in that session that produced it. */
+    messageIndex?: number;
+    origin?: 'agent_tool' | 'inline_promotion' | 'iframe_ai_tab';
+  };
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface ArtifactsApi {
+  list: (workspaceId: string) => Promise<{ ok: boolean; artifacts?: Artifact[]; error?: string }>;
+  get: (
+    workspaceId: string,
+    artifactId: string,
+  ) => Promise<{ ok: boolean; artifact?: Artifact; error?: string }>;
+  create: (
+    workspaceId: string,
+    input: {
+      type: ArtifactType;
+      title: string;
+      content: string;
+      prompt?: string;
+      source?: Artifact['source'];
+    },
+  ) => Promise<{ ok: boolean; artifact?: Artifact; error?: string }>;
+  /** Append a new version to an existing artifact, becoming the current one. */
+  addVersion: (
+    workspaceId: string,
+    artifactId: string,
+    input: { content: string; prompt?: string },
+  ) => Promise<{ ok: boolean; artifact?: Artifact; error?: string }>;
+  /** Mutate metadata only (title, currentVersionId, pinnedNodeId). */
+  update: (
+    workspaceId: string,
+    artifactId: string,
+    patch: Partial<Pick<Artifact, 'title' | 'currentVersionId' | 'pinnedNodeId'>>,
+  ) => Promise<{ ok: boolean; artifact?: Artifact; error?: string }>;
+  delete: (
+    workspaceId: string,
+    artifactId: string,
+  ) => Promise<{ ok: boolean; error?: string }>;
+  /** Create an iframe canvas node bound to this artifact (mode='artifact'). */
+  pinToCanvas: (
+    workspaceId: string,
+    artifactId: string,
+    placement?: { x?: number; y?: number; width?: number; height?: number; title?: string },
+  ) => Promise<{ ok: boolean; nodeId?: string; artifact?: Artifact; error?: string }>;
+  /** Fires when an artifact is created, updated, or deleted in the main process. */
+  onChange: (
+    callback: (event: {
+      workspaceId: string;
+      artifactId: string;
+      kind: 'create' | 'update' | 'delete';
+    }) => void,
+  ) => () => void;
 }
 
 export interface IframeApi {

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -389,11 +389,25 @@ export interface AgentApi {
   ) => () => void;
   onToolCall: (
     sessionId: string,
-    callback: (data: { name: string; args: any }) => void
+    callback: (data: { name: string; args: any; toolCallId?: string }) => void
   ) => () => void;
   onToolResult: (
     sessionId: string,
-    callback: (data: { name: string; result: string }) => void
+    callback: (data: { name: string; result: string; toolCallId?: string }) => void
+  ) => () => void;
+  /** Tool-input streaming — fired when LLM starts emitting tool arguments. */
+  onToolInputStart: (
+    sessionId: string,
+    callback: (data: { id: string; toolName: string }) => void
+  ) => () => void;
+  /** Each chunk of raw tool argument JSON. `id` matches `toolCallId` on the final tool-call. */
+  onToolInputDelta: (
+    sessionId: string,
+    callback: (data: { id: string; delta: string }) => void
+  ) => () => void;
+  onToolInputEnd: (
+    sessionId: string,
+    callback: (data: { id: string }) => void
   ) => () => void;
   onClarifyRequest: (
     sessionId: string,

--- a/packages/engine/src/core/loop.ts
+++ b/packages/engine/src/core/loop.ts
@@ -103,6 +103,19 @@ export interface LoopOptions {
   onText?: (delta: string) => void;
   onToolCall?: (toolCall: any) => void;
   onToolResult?: (toolResult: any) => void;
+  /**
+   * Fired when the LLM starts emitting a tool's input JSON. Use this together
+   * with `onToolInputDelta` to drive progressive UIs (e.g. streaming an
+   * artifact preview in chat) before the tool actually executes.
+   */
+  onToolInputStart?: (chunk: { id: string; toolName: string }) => void;
+  /**
+   * Fired for each chunk of raw tool input JSON the LLM emits. `delta` is the
+   * incremental text appended to the accumulating JSON string (NOT pre-parsed).
+   */
+  onToolInputDelta?: (chunk: { id: string; delta: string }) => void;
+  /** Fired when the LLM finishes emitting a tool's input JSON. */
+  onToolInputEnd?: (chunk: { id: string }) => void;
   onStepFinish?: (step: StepResult<any>) => void;
   onClarificationRequest?: (request: ClarificationRequest) => Promise<string>;
   onCompacted?: (newMessages: ModelMessage[], event?: CompactionEvent) => void;
@@ -486,6 +499,19 @@ export async function loop(context: Context, options?: LoopOptions): Promise<str
             }
             if (chunk.type === 'tool-result') {
               options?.onToolResult?.(chunk);
+            }
+            // Tool-input streaming. AI SDK v6 emits these for every tool the
+            // LLM invokes; we forward them verbatim so the renderer can drive
+            // a progressive preview keyed by `chunk.id` (which matches the
+            // `toolCallId` on the final `tool-call` chunk).
+            if (chunk.type === 'tool-input-start') {
+              options?.onToolInputStart?.({ id: chunk.id, toolName: chunk.toolName });
+            }
+            if (chunk.type === 'tool-input-delta') {
+              options?.onToolInputDelta?.({ id: chunk.id, delta: chunk.delta });
+            }
+            if (chunk.type === 'tool-input-end') {
+              options?.onToolInputEnd?.({ id: chunk.id });
             }
           },
         });


### PR DESCRIPTION
Three escalation levels for LLM-generated visuals in canvas-workspace:
inline ephemeral visuals rendered in chat messages, persistent versioned
artifacts surfaced via a right-side drawer, and spatial pinning that
binds canvas iframe nodes to artifacts so iterations flow through.

- Per-workspace artifact store (artifacts.json) with version history.
- Canvas-agent tools visual_render, artifact_create, artifact_update,
  artifact_pin_to_canvas; system prompt teaches the agent which to pick.
- ChatInlineVisual / ChatArtifactCard / ArtifactDrawer renderer UI,
  driven by ArtifactDrawerContext for prop-free open from anywhere.
- IframeNodeData gains mode='artifact' + artifactId; IframeNodeBody
  sources content from the artifact store and re-renders on changes.

https://claude.ai/code/session_01QTxkdckQaFVvAtHhtjwc26