### PR TITLE
fix: make Canvas tool calls scrollable

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
@@ -4,6 +4,7 @@
   width: 100%;
   min-width: 0;
   height: 100%;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   background: #fdfcfb;
@@ -303,6 +304,7 @@
 
 .chat-messages {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   padding: 18px 18px 12px;
   display: flex;
@@ -911,10 +913,17 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
-  padding: 4px 0;
+  max-height: min(360px, 42vh);
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  padding: 4px 4px 4px 0;
 }
 
 .chat-tool-calls--collapsed {
+  max-height: none;
+  overflow: visible;
   flex-direction: row;
   align-items: center;
   gap: 5px;


### PR DESCRIPTION
## Summary
- Add bounded vertical scrolling for Canvas Agent tool call panels.
- Keep collapsed tool-call summaries unbounded and visually unchanged.
- Add flex `min-height: 0` guards so nested chat content can scroll correctly.

## Validation
- `pnpm --filter canvas-workspace typecheck:renderer` ✅

## Risk
- Low; scoped CSS-only layout change for the Canvas chat tool-call area.

Closes #441
