### PR TITLE
fix(canvas): encode pasted image file urls

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/ImageNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ImageNodeBody/index.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import './index.css';
 import type { CanvasNode, ImageNodeData } from '../../types';
+import { toFileUrl } from '../../utils/fileUrl';
 
 interface Props {
   node: CanvasNode;
@@ -34,7 +35,7 @@ export const ImageNodeBody = ({ node, onSelect, onDragStart, readOnly = false }:
       {data.filePath ? (
         <img
           className="image-node-img"
-          src={`file://${data.filePath}`}
+          src={toFileUrl(data.filePath)}
           alt={node.title}
           draggable={false}
         />

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatInput.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatInput.tsx
@@ -2,6 +2,7 @@ import type { ClipboardEventHandler, KeyboardEventHandler, ReactNode, RefObject 
 import type { CanvasNode, ChatImageAttachment } from '../../types';
 import { ImageIcon, PlusIcon } from '../icons';
 import { getNodeDisplayLabel } from '../../utils/nodeLabel';
+import { toFileUrl } from '../../utils/fileUrl';
 import { MentionNodeIcon } from './utils/mentions';
 
 interface ChatInputProps {
@@ -22,8 +23,6 @@ interface ChatInputProps {
   onAbort: () => Promise<void>;
   onToggleExecutionMode?: () => void;
 }
-
-const getImageSrc = (path: string) => `file://${path}`;
 
 export const ChatInput = ({
   loading,
@@ -70,7 +69,7 @@ export const ChatInput = ({
           <div className="chat-attachment-strip" aria-label="待发送图片">
             {attachments.map(attachment => (
               <div key={attachment.id} className="chat-attachment-chip">
-                <img src={getImageSrc(attachment.path)} alt={attachment.fileName ?? 'attachment'} />
+                <img src={toFileUrl(attachment.path)} alt={attachment.fileName ?? 'attachment'} />
                 <span>{attachment.fileName ?? 'Image'}</span>
                 <button type="button" onClick={() => onRemoveAttachment?.(attachment.id)} aria-label="移除图片">×</button>
               </div>

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
@@ -1,4 +1,5 @@
 import type { AgentChatMessage, CanvasNode } from '../../types';
+import { toFileUrl } from '../../utils/fileUrl';
 import { AvatarIcon } from '../icons';
 import type { ToolCallStatus } from './types';
 import { renderMdWithMentions, renderUserContent } from './utils/mentions';
@@ -74,7 +75,7 @@ export const ChatMessage = ({
         <div className="chat-message-images">
           {message.attachments.map(attachment => (
             <figure key={attachment.id} className="chat-message-image-card">
-              <img src={`file://${attachment.path}`} alt={attachment.fileName ?? 'image'} />
+              <img src={toFileUrl(attachment.path)} alt={attachment.fileName ?? 'image'} />
               {attachment.fileName && <figcaption>{attachment.fileName}</figcaption>}
             </figure>
           ))}

--- a/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts
@@ -20,6 +20,7 @@ import type { CanvasNode, FileNodeData } from '../types';
 import type { SlashCommandDef } from '../components/SlashCommandMenu';
 import { ALL_SLASH_COMMANDS, filterCmds, type SlashCmdContext } from '../editor/slashCommands';
 import { NoteSearchExtension } from '../editor/noteSearchExtension';
+import { toFileUrl } from '../utils/fileUrl';
 
 const lowlight = createLowlight(common);
 
@@ -158,7 +159,7 @@ export const useFileNodeEditor = ({
             'default';
           const res = await api.saveImage(wsId, base64, ext);
           if (!res.ok || !res.filePath) return;
-          const src = `file://${res.filePath}`;
+          const src = toFileUrl(res.filePath);
           const { state, dispatch } = view;
           const imageNode = state.schema.nodes['image']?.create({ src });
           if (imageNode) {
@@ -352,7 +353,7 @@ export const useFileNodeEditor = ({
         editor
           .chain()
           .focus()
-          .setImage({ src: `file://${res.filePath}` })
+          .setImage({ src: toFileUrl(res.filePath) })
           .run();
       };
       reader.readAsDataURL(file);

--- a/apps/canvas-workspace/src/renderer/src/utils/fileUrl.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/fileUrl.ts
@@ -1,0 +1,21 @@
+export const toFileUrl = (filePath: string): string => {
+  const value = filePath.trim();
+  if (!value) return '';
+  if (/^file:\/\//i.test(value)) return value;
+
+  const normalized = value.replace(/\\/g, '/');
+  const isWindowsDrivePath = /^[a-zA-Z]:\//.test(normalized);
+  const withLeadingSlash = normalized.startsWith('/') ? normalized : `/${normalized}`;
+
+  const encodedPath = withLeadingSlash
+    .split('/')
+    .map((segment, index) => {
+      if (isWindowsDrivePath && index === 1 && /^[a-zA-Z]:$/.test(segment)) {
+        return segment;
+      }
+      return encodeURIComponent(segment);
+    })
+    .join('/');
+
+  return `file://${encodedPath}`;
+};


### PR DESCRIPTION
## Summary
- Add a shared renderer helper for converting local file paths into safe file:// URLs.
- Use the helper for canvas image nodes, chat image attachments/messages, and note-editor pasted images.
- Preserve Windows drive-letter paths while encoding spaces and non-ASCII path segments so pasted image previews do not break.

Closes #444

## Validation
- `pnpm --filter canvas-workspace typecheck:renderer` ✅

## Risk
- Low; scoped to local image preview URL formatting.