### PR TITLE
refactor(canvas): compact Reference panel chrome so preview dominates

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.css
@@ -99,22 +99,22 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
-  padding: 16px 18px 0;
+  padding: 10px 14px 0;
 }
 
 .reference-drawer-kicker {
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: 9px;
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: none;
 }
 
 .reference-drawer-header h2 {
-  margin-top: 2px;
-  font-size: 16px;
+  margin-top: 1px;
+  font-size: 13px;
   font-weight: 650;
-  line-height: 1.25;
+  line-height: 1.2;
   color: var(--text);
   letter-spacing: -0.01em;
 }
@@ -140,21 +140,21 @@
 .reference-drawer-toolbar {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 10px 18px 0;
+  gap: 4px;
+  padding: 6px 14px 0;
 }
 
 .reference-drawer-action {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  height: 26px;
-  padding: 0 9px;
-  border-radius: 6px;
+  height: 22px;
+  padding: 0 7px;
+  border-radius: 5px;
   border: 1px solid var(--border-light);
   background: var(--surface);
   color: var(--text);
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 600;
   cursor: pointer;
   white-space: nowrap;
@@ -251,19 +251,19 @@
 
 .reference-drawer-content {
   min-height: 0;
-  height: calc(100% - 130px);
+  height: calc(100% - 88px);
   display: flex;
   flex-direction: column;
   animation: reference-content-in 0.22s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
 .reference-group-list {
-  padding: 10px 12px 8px;
+  padding: 6px 10px 4px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
   flex: 0 0 auto;
-  max-height: 45%;
+  max-height: 30%;
   overflow-y: auto;
 }
 
@@ -277,12 +277,12 @@
   align-items: center;
   gap: 6px;
   width: 100%;
-  padding: 4px 6px;
+  padding: 2px 6px;
   border: 0;
-  border-radius: 6px;
+  border-radius: 5px;
   background: transparent;
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 600;
   text-align: left;
   cursor: pointer;
@@ -338,12 +338,12 @@
   align-items: center;
   gap: 6px;
   width: 100%;
-  padding: 5px 8px;
+  padding: 3px 6px;
   border: 0;
-  border-radius: 6px;
+  border-radius: 5px;
   background: transparent;
   color: var(--text);
-  font-size: 12px;
+  font-size: 11.5px;
   cursor: pointer;
   text-align: left;
   transition: background 0.1s ease, color 0.1s ease;
@@ -401,47 +401,25 @@
   color: var(--text);
 }
 
-.reference-card-meta {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 10px;
-  border-bottom: 1px solid var(--border-light);
-  background: #fbfbfa;
-}
-
-.reference-card-meta-type {
-  color: var(--text-muted);
-  font-size: 10px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-.reference-card-meta-title {
-  flex: 1;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .reference-card-meta-group {
   position: relative;
+  margin-right: auto;
 }
 
 .reference-group-chip {
   border: 1px dashed var(--border-light);
   background: transparent;
   border-radius: 999px;
-  padding: 2px 9px;
-  font-size: 11px;
+  padding: 1px 8px;
+  font-size: 10.5px;
   font-weight: 600;
   color: var(--text-secondary);
   cursor: pointer;
   transition: background 0.1s ease, color 0.1s ease, border-color 0.1s ease;
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .reference-group-chip:hover {
@@ -452,15 +430,15 @@
 
 .reference-group-editor {
   position: absolute;
-  top: calc(100% + 4px);
-  right: 0;
+  bottom: calc(100% + 6px);
+  left: 0;
   width: 220px;
   padding: 10px;
   background: var(--surface);
   border: 1px solid var(--border-light);
   border-radius: 8px;
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.12);
-  z-index: 5;
+  box-shadow: 0 -6px 20px rgba(0, 0, 0, 0.12);
+  z-index: 8;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -539,9 +517,9 @@
 .reference-drawer-primary,
 .reference-drawer-secondary {
   border: 0;
-  border-radius: 6px;
-  padding: 6px 9px;
-  font-size: 12px;
+  border-radius: 5px;
+  padding: 4px 7px;
+  font-size: 11px;
   font-weight: 600;
   cursor: pointer;
   white-space: nowrap;
@@ -574,10 +552,10 @@
 }
 
 .reference-empty {
-  margin: 18px;
-  padding: 28px 20px;
+  margin: 12px 14px;
+  padding: 22px 18px;
   border: 1px solid var(--border-light);
-  border-radius: 10px;
+  border-radius: 8px;
   background: transparent;
   text-align: center;
   color: var(--text-secondary);
@@ -646,12 +624,12 @@
 .reference-native-card {
   min-height: 0;
   flex: 1 1 auto;
-  margin: 8px 18px 18px;
+  margin: 4px 14px 12px;
   display: flex;
   flex-direction: column;
   overflow: hidden;
   border: 1px solid var(--border-light);
-  border-radius: 10px;
+  border-radius: 8px;
   background: var(--surface);
 }
 
@@ -664,10 +642,12 @@
 }
 
 .reference-card-footer {
+  display: flex;
+  align-items: center;
+  gap: 4px;
   margin-top: auto;
-  padding: 8px;
+  padding: 5px 6px;
   border-top: 1px solid var(--border-light);
   background: #fbfbfa;
-  justify-content: flex-end;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.tsx
@@ -310,11 +310,30 @@ export const ReferenceDrawer = ({
 
             {activeReferenceNode ? (
               <div className="reference-native-card">
-                <div className="reference-card-meta">
-                  <span className="reference-card-meta-type">{activeReferenceNode.type}</span>
-                  <span className="reference-card-meta-title" title={getNodeDisplayLabel(activeReferenceNode)}>
-                    {getNodeDisplayLabel(activeReferenceNode)}
-                  </span>
+                <CanvasNodeView
+                  node={{
+                    ...activeReferenceNode,
+                    x: 0,
+                    y: 0,
+                    width: Math.max(MIN_REFERENCE_DRAWER_WIDTH - 32, drawerWidth - 32),
+                    height: 420,
+                  }}
+                  getAllNodes={() => [activeReferenceNode]}
+                  isDragging={false}
+                  isResizing={false}
+                  isSelected={false}
+                  isHighlighted={false}
+                  onDragStart={() => undefined}
+                  onResizeStart={() => undefined}
+                  onUpdate={() => undefined}
+                  onAutoResize={() => undefined}
+                  onRemove={() => undefined}
+                  onExportMindmapImage={() => undefined}
+                  onSelect={() => undefined}
+                  onFocus={() => onFocusNode(activeReferenceNode.id)}
+                  readOnly
+                />
+                <div className="reference-card-footer">
                   <div className="reference-card-meta-group" ref={groupEditorRef}>
                     <button
                       type="button"
@@ -322,7 +341,7 @@ export const ReferenceDrawer = ({
                       onClick={openGroupEditor}
                       title="Change group"
                     >
-                      {activeReferenceGroup ?? 'Add to group'}
+                      {activeReferenceGroup ?? '+ Group'}
                     </button>
                     {groupEditorOpen && (
                       <div className="reference-group-editor" role="dialog">
@@ -384,31 +403,6 @@ export const ReferenceDrawer = ({
                       </div>
                     )}
                   </div>
-                </div>
-                <CanvasNodeView
-                  node={{
-                    ...activeReferenceNode,
-                    x: 0,
-                    y: 0,
-                    width: Math.max(MIN_REFERENCE_DRAWER_WIDTH - 32, drawerWidth - 32),
-                    height: 420,
-                  }}
-                  getAllNodes={() => [activeReferenceNode]}
-                  isDragging={false}
-                  isResizing={false}
-                  isSelected={false}
-                  isHighlighted={false}
-                  onDragStart={() => undefined}
-                  onResizeStart={() => undefined}
-                  onUpdate={() => undefined}
-                  onAutoResize={() => undefined}
-                  onRemove={() => undefined}
-                  onExportMindmapImage={() => undefined}
-                  onSelect={() => undefined}
-                  onFocus={() => onFocusNode(activeReferenceNode.id)}
-                  readOnly
-                />
-                <div className="reference-card-footer">
                   <button
                     className="reference-drawer-secondary"
                     type="button"


### PR DESCRIPTION
The list, header and toolbar were eating ~40% of the panel height; shrink them so the active reference preview gets the majority of the space.

- Drop the redundant type+title meta row above the preview — the highlighted list item already shows both.
- Move the group chip into the footer alongside Focus/Unpin/Clear all, and flip its inline editor popover to open upward.
- Tighten header (10/14px padding, 13px title), toolbar (22px buttons, 11px text) and list rows (3/6 padding, 11.5px text, 10px group headers).
- Cap the list at 30% of available height instead of 45%, and recompute reference-drawer-content height for the smaller chrome.