### PR TITLE
fix: persist chat agent tool calls

### DIFF
--- a/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
@@ -17,7 +17,13 @@ import {
 } from './context-builder';
 import { createCanvasTools } from './tools';
 import { SessionStore } from './session-store';
-import type { CanvasAgentConfig, CanvasAgentImageAttachment, CanvasAgentMessage, WorkspaceSummary } from './types';
+import type {
+  CanvasAgentConfig,
+  CanvasAgentImageAttachment,
+  CanvasAgentMessage,
+  CanvasAgentToolCall,
+  WorkspaceSummary,
+} from './types';
 
 interface CanvasAgentRequestContext {
   executionMode?: 'auto' | 'ask';
@@ -27,6 +33,68 @@ interface CanvasAgentRequestContext {
 }
 
 const CANVAS_AGENT_MAX_STEPS = 200;
+
+function stringifyToolResult(raw: unknown): string {
+  return typeof raw === 'string' ? raw : JSON.stringify(raw) ?? String(raw);
+}
+
+function modelMessagesToToolCalls(messages: ModelMessage[]): CanvasAgentToolCall[] {
+  const toolCalls: CanvasAgentToolCall[] = [];
+  const byToolCallId = new Map<string, CanvasAgentToolCall>();
+
+  const findOrCreate = (toolCallId: string, name: string): CanvasAgentToolCall => {
+    const existing = byToolCallId.get(toolCallId);
+    if (existing) {
+      if (!existing.name && name) existing.name = name;
+      return existing;
+    }
+
+    const tool: CanvasAgentToolCall = {
+      id: toolCalls.length + 1,
+      name,
+      toolCallId,
+      status: 'running',
+    };
+    toolCalls.push(tool);
+    byToolCallId.set(toolCallId, tool);
+    return tool;
+  };
+
+  for (const message of messages) {
+    const content = (message as any).content;
+    if (!Array.isArray(content)) continue;
+
+    for (const part of content) {
+      if (part?.type === 'tool-call') {
+        const toolCallId = typeof part.toolCallId === 'string' ? part.toolCallId : undefined;
+        const name = typeof part.toolName === 'string' ? part.toolName : '';
+        if (!toolCallId || !name) continue;
+        const tool = findOrCreate(toolCallId, name);
+        tool.name = name;
+        tool.args = part.input ?? part.args;
+      }
+
+      if (part?.type === 'tool-result') {
+        const toolCallId = typeof part.toolCallId === 'string' ? part.toolCallId : undefined;
+        const name = typeof part.toolName === 'string' ? part.toolName : '';
+        if (!toolCallId || !name) continue;
+        const tool = findOrCreate(toolCallId, name);
+        tool.name = name;
+        tool.status = 'done';
+        tool.result = stringifyToolResult(part.output ?? part.result);
+      }
+    }
+  }
+
+  return toolCalls;
+}
+
+function sessionMessageToModelMessage(message: CanvasAgentMessage): ModelMessage {
+  const content = message.attachments?.length
+    ? `${message.content}\n\nAttached image files:\n${message.attachments.map((a, i) => `${i + 1}. ${a.path}`).join('\n')}`
+    : message.content;
+  return { role: message.role, content } as ModelMessage;
+}
 
 // ─── System prompt ─────────────────────────────────────────────────
 
@@ -389,6 +457,8 @@ export class CanvasAgent {
         }
       : undefined;
 
+    const responseMessages: ModelMessage[] = [];
+
     try {
       const resultText = await this.engine.run(context, {
         systemPrompt,
@@ -440,6 +510,7 @@ export class CanvasAgent {
         onResponse: (msgs: ModelMessage[]) => {
           for (const msg of msgs) {
             this.messages.push(msg);
+            responseMessages.push(msg);
           }
         },
         onCompacted: (newMessages: ModelMessage[]) => {
@@ -450,8 +521,17 @@ export class CanvasAgent {
 
       const responseText = resultText || '(no response)';
 
-      // Persist assistant response
-      this.sessionStore.addMessage({ role: 'assistant', content: responseText, timestamp: Date.now() });
+      // Persist assistant response together with the tool-call frames that
+      // produced it so saved/restored chat sessions can render tool chips,
+      // inline visuals, artifacts, and generated images instead of losing
+      // them after reload.
+      const toolCalls = modelMessagesToToolCalls(responseMessages);
+      this.sessionStore.addMessage({
+        role: 'assistant',
+        content: responseText,
+        timestamp: Date.now(),
+        toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+      });
 
       return responseText;
     } finally {
@@ -545,13 +625,11 @@ export class CanvasAgent {
   async loadSession(sessionId: string): Promise<CanvasAgentMessage[]> {
     const session = await this.sessionStore.loadSession(sessionId);
     if (!session) return [];
-    // Rebuild in-memory messages from loaded session
-    this.messages = session.messages.map(m => ({
-      role: m.role,
-      content: m.attachments?.length
-        ? `${m.content}\n\nAttached image files:\n${m.attachments.map((a, i) => `${i + 1}. ${a.path}`).join('\n')}`
-        : m.content,
-    } as any));
+    // Rebuild in-memory model context from loaded session. Stored UI
+    // tool-call metadata is intentionally excluded here; the AI SDK response
+    // messages already carry tool frames while a run is active, but persisted
+    // sessions only need text turns for follow-up context.
+    this.messages = session.messages.map(sessionMessageToModelMessage);
     return session.messages;
   }
 
@@ -561,12 +639,7 @@ export class CanvasAgent {
    */
   async loadCrossWorkspaceSession(loadedMessages: CanvasAgentMessage[]): Promise<void> {
     await this.sessionStore.startSession();
-    this.messages = loadedMessages.map(m => ({
-      role: m.role,
-      content: m.attachments?.length
-        ? `${m.content}\n\nAttached image files:\n${m.attachments.map((a, i) => `${i + 1}. ${a.path}`).join('\n')}`
-        : m.content,
-    } as any));
+    this.messages = loadedMessages.map(sessionMessageToModelMessage);
     // Persist each message into the new current session
     for (const m of loadedMessages) {
       this.sessionStore.addMessage(m);

--- a/apps/canvas-workspace/src/main/canvas-agent/types.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/types.ts
@@ -24,11 +24,25 @@ export interface CanvasAgentImageAttachment {
   mimeType?: string;
 }
 
+export interface CanvasAgentToolCall {
+  id: number;
+  name: string;
+  args?: unknown;
+  status: 'running' | 'done';
+  result?: string;
+  toolCallId?: string;
+  partialInput?: string;
+  inputStreaming?: boolean;
+  streamedContent?: string;
+  streamedDone?: boolean;
+}
+
 export interface CanvasAgentMessage {
   role: 'user' | 'assistant';
   content: string;
   timestamp: number;
   attachments?: CanvasAgentImageAttachment[];
+  toolCalls?: CanvasAgentToolCall[];
 }
 
 // ─── Session persistence ────────────────────────────────────────────

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessages.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessages.tsx
@@ -129,7 +129,7 @@ export const ChatMessages = ({
     <div className="chat-messages" onClick={handleMessageClick}>
       {messages.map((message, index) => {
         const isStreaming = loading && message.role === 'assistant' && index === messages.length - 1;
-        const tools = isStreaming ? streamingTools : messageTools.get(index);
+        const tools = isStreaming ? streamingTools : (messageTools.get(index) ?? message.toolCalls);
         return (
           <ChatMessage
             key={index}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatStream.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatStream.ts
@@ -39,8 +39,18 @@ export function useChatStream({ workspaceId, allWorkspaces }: UseChatStreamOptio
 
   const replaceMessages = useCallback((nextMessages: AgentChatMessage[]) => {
     setMessages(nextMessages);
-    setMessageTools(new Map());
-    setCollapsedSections(new Set());
+    setMessageTools(new Map(
+      nextMessages.flatMap((message, index) => (
+        message.role === 'assistant' && message.toolCalls?.length
+          ? [[index, message.toolCalls]] as Array<[number, ToolCallStatus[]]>
+          : []
+      )),
+    ));
+    setCollapsedSections(new Set(
+      nextMessages.flatMap((message, index) => (
+        message.role === 'assistant' && message.toolCalls?.length ? [index] : []
+      )),
+    ));
   }, []);
 
   const sendMessage = useCallback(async (rawText: string, requestContext?: AgentRequestContext, attachments: ChatImageAttachment[] = []) => {
@@ -257,26 +267,31 @@ export function useChatStream({ workspaceId, allWorkspaces }: UseChatStreamOptio
         setPendingClarify(null);
         setClarifyInput('');
 
+        const toolSnapshot = toolCalls.length > 0 ? toolCalls.map(tool => ({ ...tool })) : undefined;
+        const mergeAssistantMessage = (message: AgentChatMessage): AgentChatMessage => (
+          toolSnapshot ? { ...message, toolCalls: toolSnapshot } : message
+        );
+
         if (!completeResult.ok) {
           setMessages(prev => {
             if (assistantIndex.current < 0) {
               return [
                 ...prev,
-                {
+                mergeAssistantMessage({
                   role: 'assistant',
                   content: `Error: ${completeResult.error ?? 'Unknown error'}`,
                   timestamp: Date.now(),
-                },
+                }),
               ];
             }
 
             const next = [...prev];
             const index = assistantIndex.current;
             const existingContent = next[index]?.content;
-            next[index] = {
+            next[index] = mergeAssistantMessage({
               ...next[index],
               content: existingContent || `Error: ${completeResult.error ?? 'Unknown error'}`,
-            };
+            });
             return next;
           });
         } else if (completeResult.response) {
@@ -284,19 +299,27 @@ export function useChatStream({ workspaceId, allWorkspaces }: UseChatStreamOptio
             if (assistantIndex.current < 0) {
               return [
                 ...prev,
-                {
+                mergeAssistantMessage({
                   role: 'assistant',
                   content: completeResult.response ?? '',
                   timestamp: Date.now(),
-                },
+                }),
               ];
             }
 
             const next = [...prev];
-            next[assistantIndex.current] = {
+            next[assistantIndex.current] = mergeAssistantMessage({
               ...next[assistantIndex.current],
               content: completeResult.response ?? '',
-            };
+            });
+            return next;
+          });
+        } else if (toolSnapshot && assistantIndex.current >= 0) {
+          setMessages(prev => {
+            const index = assistantIndex.current;
+            if (index < 0 || index >= prev.length) return prev;
+            const next = [...prev];
+            next[index] = mergeAssistantMessage(next[index]);
             return next;
           });
         }

--- a/apps/canvas-workspace/src/renderer/src/components/chat/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/types.ts
@@ -1,5 +1,5 @@
 import type { MouseEvent } from 'react';
-import type { AgentSessionInfo, CanvasNode, ChatImageAttachment } from '../../types';
+import type { AgentChatToolCall, AgentSessionInfo, CanvasNode, ChatImageAttachment } from '../../types';
 
 export interface WorkspaceOption {
   id: string;
@@ -22,30 +22,7 @@ export interface OtherWorkspaceSession extends AgentSessionInfo {
   workspaceName: string;
 }
 
-export interface ToolCallStatus {
-  id: number;
-  name: string;
-  args?: any;
-  status: 'running' | 'done';
-  result?: string;
-  /** AI SDK toolCallId — used to correlate streaming-input deltas with the final tool-call. */
-  toolCallId?: string;
-  /** Accumulated raw JSON of tool arguments while the LLM is still emitting them.
-   *  Cleared (or kept as-is) once `inputStreaming` flips to false. */
-  partialInput?: string;
-  /** True while the LLM is still streaming this tool's input JSON. */
-  inputStreaming?: boolean;
-  /**
-   * Already-extracted partial content that a tool is pushing via side
-   * channel (e.g. `visual_render` chunking its final HTML to drive the
-   * progressive inline preview). When set, the renderer prefers this over
-   * parsing `partialInput`'s JSON — it's the parsed/unescaped string, not
-   * a JSON fragment. `streamedContent` may also be populated AFTER the
-   * tool returns; the `streamedDone` flag signals the final frame.
-   */
-  streamedContent?: string;
-  streamedDone?: boolean;
-}
+export type ToolCallStatus = AgentChatToolCall;
 
 export type { ChatImageAttachment };
 

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -337,11 +337,25 @@ export interface ChatImageAttachment {
   mimeType?: string;
 }
 
+export interface AgentChatToolCall {
+  id: number;
+  name: string;
+  args?: unknown;
+  status: 'running' | 'done';
+  result?: string;
+  toolCallId?: string;
+  partialInput?: string;
+  inputStreaming?: boolean;
+  streamedContent?: string;
+  streamedDone?: boolean;
+}
+
 export interface AgentChatMessage {
   role: 'user' | 'assistant';
   content: string;
   timestamp: number;
   attachments?: ChatImageAttachment[];
+  toolCalls?: AgentChatToolCall[];
 }
 
 export interface AgentContextNodeRef {


### PR DESCRIPTION
Fix Chat Agent tool-call history persistence in Canvas Workspace.

- Add persisted tool-call metadata to chat session messages
- Extract tool-call and tool-result frames from engine responses before saving sessions
- Restore saved tool calls when loading chat history so tool chips, inline visuals, artifacts, and generated images remain visible

Validation:
- `pnpm --filter canvas-workspace build` ✅
- `pnpm --filter canvas-workspace typecheck` ⚠️ blocked by existing `pulse-coder-engine/built-in` module resolution error