### PR TITLE
Route external links from sandboxed iframes to OS browser

### DIFF
--- a/apps/canvas-workspace/src/main/index.ts
+++ b/apps/canvas-workspace/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain } from "electron";
+import { app, BrowserWindow, ipcMain, shell } from "electron";
 import { existsSync, promises as fs } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
@@ -15,6 +15,7 @@ import { setupCanvasModelIpc } from "./canvas-model-ipc";
 import { setupWebviewRegistryIpc } from "./webview-registry";
 import { setupHtmlGeneratorIpc } from "./html-generator-ipc";
 import { setupArtifactIpc } from "./artifact-ipc";
+import { setupShellIpc, isSafeExternalUrl } from "./shell-ipc";
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const preloadPath = join(currentDir, "../preload/index.mjs");
@@ -64,6 +65,29 @@ const createWindow = () => {
       // webContents. Main-process code reaches into each webview via its
       // webContents ID to pull rendered DOM text for the Canvas Agent.
       webviewTag: true
+    }
+  });
+
+  // Sandboxed iframe canvas nodes (HTML / AI / artifact previews) get
+  // `allow-popups` so their `<a target="_blank">` and `window.open()` reach
+  // the parent window. Without a handler here those popups would either
+  // open a useless blank Electron window or be denied outright — route
+  // every popup through the OS browser instead.
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    if (isSafeExternalUrl(url)) {
+      void shell.openExternal(url);
+    }
+    return { action: "deny" };
+  });
+
+  // Same idea for in-place navigations: the main renderer should never
+  // navigate away from the app shell. If a sandboxed iframe somehow tries
+  // to top-navigate, push the URL to the OS browser and cancel the load.
+  win.webContents.on("will-navigate", (event, url) => {
+    if (url === win.webContents.getURL()) return;
+    event.preventDefault();
+    if (isSafeExternalUrl(url)) {
+      void shell.openExternal(url);
     }
   });
 
@@ -147,6 +171,7 @@ app.whenReady().then(() => {
   setupWebviewRegistryIpc();
   setupHtmlGeneratorIpc();
   setupArtifactIpc();
+  setupShellIpc();
   // MCP server disabled — canvas-cli is the preferred agent interface now.
   // startMCPServer();
   // void ensureMCPRegistered();

--- a/apps/canvas-workspace/src/main/shell-ipc.ts
+++ b/apps/canvas-workspace/src/main/shell-ipc.ts
@@ -1,0 +1,38 @@
+/**
+ * Shell IPC bridge.
+ *
+ * Iframe / webview canvas nodes embed third-party pages whose `<a target="_blank">`
+ * links and `window.open()` calls need to escape the embed and land in the
+ * user's real browser. The renderer captures those gestures (via the webview's
+ * `new-window` event and the main window's `setWindowOpenHandler`) and routes
+ * the URL here so we can call `shell.openExternal` from main.
+ */
+import { ipcMain, shell } from 'electron';
+
+const ALLOWED_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:']);
+
+function isSafeExternalUrl(raw: string): boolean {
+  try {
+    const u = new URL(raw);
+    return ALLOWED_PROTOCOLS.has(u.protocol);
+  } catch {
+    return false;
+  }
+}
+
+export function setupShellIpc(): void {
+  ipcMain.handle('shell:openExternal', async (_event, payload: { url?: string }) => {
+    const url = payload?.url;
+    if (!url || !isSafeExternalUrl(url)) {
+      return { ok: false, error: 'unsupported url' };
+    }
+    try {
+      await shell.openExternal(url);
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  });
+}
+
+export { isSafeExternalUrl };

--- a/apps/canvas-workspace/src/preload/index.ts
+++ b/apps/canvas-workspace/src/preload/index.ts
@@ -150,6 +150,11 @@ contextBridge.exposeInMainWorld("canvasWorkspace", {
       ipcRenderer.invoke("iframe:unregister-webview", { workspaceId, nodeId })
   },
 
+  shell: {
+    openExternal: (url: string) =>
+      ipcRenderer.invoke("shell:openExternal", { url }) as Promise<{ ok: boolean; error?: string }>
+  },
+
   llm: {
     generateHTML: (prompt: string) =>
       ipcRenderer.invoke("llm:generate-html", { prompt }) as Promise<{ ok: boolean; html?: string; error?: string }>,

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.tsx
@@ -152,15 +152,28 @@ export const IframeNodeBody = ({ node, workspaceId, onUpdate, isResizing, readOn
       setLoadError(detail.errorDescription || "This page failed to load.");
     };
 
+    // `target="_blank"` links and `window.open()` calls inside the embedded
+    // page emit `new-window` on the webview. Without a handler Electron either
+    // silently drops them (newer versions) or spawns a useless empty Electron
+    // window — both look like "links don't work" to the user. Route every
+    // popup to the OS browser instead.
+    const handleNewWindow = (event: Event) => {
+      const detail = event as Event & { url?: string };
+      event.preventDefault();
+      if (detail.url) void window.canvasWorkspace.shell.openExternal(detail.url);
+    };
+
     el.addEventListener("page-title-updated", handlePageTitleUpdated);
     el.addEventListener("did-start-loading", handleDidStartLoading);
     el.addEventListener("did-stop-loading", handleDidStopLoading);
     el.addEventListener("did-fail-load", handleDidFailLoad);
+    el.addEventListener("new-window", handleNewWindow);
     return () => {
       el.removeEventListener("page-title-updated", handlePageTitleUpdated);
       el.removeEventListener("did-start-loading", handleDidStartLoading);
       el.removeEventListener("did-stop-loading", handleDidStopLoading);
       el.removeEventListener("did-fail-load", handleDidFailLoad);
+      el.removeEventListener("new-window", handleNewWindow);
     };
   }, [data, editing, mode, node.id, node.title, onUpdate, readOnly, url, webviewKey]);
 
@@ -411,7 +424,7 @@ export const IframeNodeBody = ({ node, workspaceId, onUpdate, isResizing, readOn
 
   const handleOpenExternal = useCallback(() => {
     if (mode === "url" && url) {
-      window.open(url, "_blank", "noopener,noreferrer");
+      void window.canvasWorkspace.shell.openExternal(url);
     }
   }, [mode, url]);
 
@@ -718,7 +731,7 @@ export const IframeNodeBody = ({ node, workspaceId, onUpdate, isResizing, readOn
             key="stream-shell"
             className="iframe-frame"
             srcDoc={STREAMING_SHELL}
-            sandbox="allow-scripts"
+            sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
             title="Generating…"
           />
         ) : (
@@ -726,7 +739,7 @@ export const IframeNodeBody = ({ node, workspaceId, onUpdate, isResizing, readOn
             key={isArtifactMode ? `artifact-${artifact?.currentVersionId ?? "loading"}` : webviewKey}
             className="iframe-frame"
             srcDoc={renderedHtml}
-            sandbox="allow-scripts"
+            sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
             title={
               isArtifactMode
                 ? `Artifact: ${artifact?.title ?? "loading"}`

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -622,6 +622,11 @@ export interface CanvasWorkspaceApi {
   iframe: IframeApi;
   llm: LlmApi;
   artifacts: ArtifactsApi;
+  shell: ShellApi;
+}
+
+export interface ShellApi {
+  openExternal: (url: string) => Promise<{ ok: boolean; error?: string }>;
 }
 
 export interface LlmApi {


### PR DESCRIPTION
## Summary
Adds secure handling of external link navigation from sandboxed iframe canvas nodes (HTML/AI/artifact previews). Links and popups that would normally open in Electron windows are now routed to the user's OS browser instead.

## Key Changes
- **New `shell-ipc.ts` module**: Establishes IPC bridge for opening external URLs with protocol validation (http, https, mailto, tel only)
- **Main process handlers**: 
  - `setWindowOpenHandler` intercepts popup attempts from sandboxed iframes
  - `will-navigate` handler prevents top-level navigation away from the app shell
  - Both route safe URLs to `shell.openExternal()` and deny the Electron window action
- **Renderer-side webview handling**: Added `new-window` event listener on webview elements to capture and route popup attempts
- **Preload API exposure**: New `window.canvasWorkspace.shell.openExternal()` API for renderer process
- **Sandbox attribute updates**: Added `allow-popups allow-popups-to-escape-sandbox` to iframe sandbox policies to enable popup capture
- **Type definitions**: Added `ShellApi` interface to canvas workspace API types

## Implementation Details
- URL validation uses `URL` constructor with protocol whitelist to prevent javascript: and data: URIs
- All external navigation attempts (whether from `<a target="_blank">`, `window.open()`, or top-level navigation) are caught and safely routed
- Error handling returns structured responses (`{ ok: boolean; error?: string }`) for IPC calls
- The approach maintains security by validating URLs before opening while improving UX by preventing broken Electron window behavior

https://claude.ai/code/session_01HamX3aiocGiFLUpQKMxUWL