### PR TITLE
style(canvas): swap Reference and Chat toolbar icons, restore Coding …

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
@@ -80,13 +80,13 @@ export const FloatingToolbar = ({
               aria-label="Toggle Reference panel"
             >
               <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+                <circle cx="9" cy="6.5" r="3.5" stroke="currentColor" strokeWidth="1.3" />
                 <path
-                  d="M6.5 5L3 9l3.5 4M11.5 5L15 9l-3.5 4M9.8 4.5l-1.6 9"
-                  stroke="currentColor"
-                  strokeWidth="1.35"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
+                  d="M4.5 16c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5"
+                  stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"
                 />
+                <circle cx="7.5" cy="6" r="0.7" fill="currentColor" />
+                <circle cx="10.5" cy="6" r="0.7" fill="currentColor" />
               </svg>
             </button>
           </div>
@@ -103,13 +103,18 @@ export const FloatingToolbar = ({
               title="Toggle AI Chat (Cmd/Ctrl+Shift+A)"
             >
               <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-                <circle cx="9" cy="6.5" r="3.5" stroke="currentColor" strokeWidth="1.3" />
                 <path
-                  d="M4.5 16c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5"
-                  stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"
+                  d="M5.2 2.8h7.6a1.4 1.4 0 011.4 1.4v10.6L9 11.8l-5.2 3V4.2a1.4 1.4 0 011.4-1.4z"
+                  stroke="currentColor"
+                  strokeWidth="1.35"
+                  strokeLinejoin="round"
                 />
-                <circle cx="7.5" cy="6" r="0.7" fill="currentColor" />
-                <circle cx="10.5" cy="6" r="0.7" fill="currentColor" />
+                <path
+                  d="M6.6 6.2h4.8M6.6 8.7h3"
+                  stroke="currentColor"
+                  strokeWidth="1.2"
+                  strokeLinecap="round"
+                />
               </svg>
             </button>
           </div>
@@ -202,16 +207,11 @@ export const FloatingToolbar = ({
         >
           <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
             <path
-              d="M5.2 2.8h7.6a1.4 1.4 0 011.4 1.4v10.6L9 11.8l-5.2 3V4.2a1.4 1.4 0 011.4-1.4z"
+              d="M6.5 5L3 9l3.5 4M11.5 5L15 9l-3.5 4M9.8 4.5l-1.6 9"
               stroke="currentColor"
               strokeWidth="1.35"
-              strokeLinejoin="round"
-            />
-            <path
-              d="M6.6 6.2h4.8M6.6 8.7h3"
-              stroke="currentColor"
-              strokeWidth="1.2"
               strokeLinecap="round"
+              strokeLinejoin="round"
             />
           </svg>
           <span className="toolbar-btn-label">Coding</span>


### PR DESCRIPTION
…glyph

Previous commit misread the request — the "agent" the user wanted swapped with Reference was the AI Chat toggle, not the Coding-agent node creator. Restore the Coding button's code-brackets icon and swap the Reference + Chat icons instead.