### PR TITLE
fix(canvas): swap Reference and Chat toolbar button positions, not icons

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
@@ -70,14 +70,13 @@ export const FloatingToolbar = ({
 }: Props) => {
   return (
     <div className="floating-toolbar">
-      {onReferenceToggle && (
+      {onChatToggle && (
         <>
           <div className="toolbar-group">
             <button
-              className={`toolbar-btn${referenceDrawerOpen ? " toolbar-btn--active" : ""}`}
-              onClick={onReferenceToggle}
-              title="Toggle Reference panel"
-              aria-label="Toggle Reference panel"
+              className={`toolbar-btn${chatPanelOpen ? " toolbar-btn--active" : ""}`}
+              onClick={onChatToggle}
+              title="Toggle AI Chat (Cmd/Ctrl+Shift+A)"
             >
               <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
                 <circle cx="9" cy="6.5" r="3.5" stroke="currentColor" strokeWidth="1.3" />
@@ -94,13 +93,14 @@ export const FloatingToolbar = ({
         </>
       )}
 
-      {onChatToggle && (
+      {onReferenceToggle && (
         <>
           <div className="toolbar-group">
             <button
-              className={`toolbar-btn${chatPanelOpen ? " toolbar-btn--active" : ""}`}
-              onClick={onChatToggle}
-              title="Toggle AI Chat (Cmd/Ctrl+Shift+A)"
+              className={`toolbar-btn${referenceDrawerOpen ? " toolbar-btn--active" : ""}`}
+              onClick={onReferenceToggle}
+              title="Toggle Reference panel"
+              aria-label="Toggle Reference panel"
             >
               <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
                 <path


### PR DESCRIPTION
Restore each button's semantically-matching icon (Reference=bookmark, Chat=person) and instead reorder so Chat comes before Reference in the toolbar — that was the original "swap their positions" request.