### PR TITLE
feat(canvas): add agent debug devtools

### DIFF
--- a/apps/canvas-workspace/src/main/canvas-agent-ipc.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent-ipc.ts
@@ -290,6 +290,30 @@ export function setupCanvasAgentIpc(): void {
   );
 
   ipcMain.handle(
+    'canvas-agent:debug-runs',
+    async () => {
+      try {
+        const runs = await svc.listDebugRuns();
+        return { ok: true, runs };
+      } catch (err) {
+        return { ok: false, error: String(err) };
+      }
+    },
+  );
+
+  ipcMain.handle(
+    'canvas-agent:debug-run',
+    async (_event, payload: { sessionId: string; runId: string }) => {
+      try {
+        const run = await svc.getDebugRun(payload.sessionId, payload.runId);
+        return run ? { ok: true, run } : { ok: false, error: 'Debug run not found' };
+      } catch (err) {
+        return { ok: false, error: String(err) };
+      }
+    },
+  );
+
+  ipcMain.handle(
     'canvas-agent:activate',
     async (_event, payload: { workspaceId: string }) => {
       try {

--- a/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
@@ -18,8 +18,18 @@ import {
 import { createCanvasTools } from './tools';
 import { SessionStore } from './session-store';
 import { formatPromptProfileForSystem, getPromptProfile } from './prompt-profile';
+import {
+  attachTraceModel,
+  createCanvasAgentDebugTrace,
+  finalizeCanvasAgentDebugTrace,
+  isCanvasAgentDebugTraceEnabled,
+  recordTraceMessageSnapshot,
+  recordTraceToolCall,
+  recordTraceToolResult,
+} from './debug-trace';
 import type {
   CanvasAgentConfig,
+  CanvasAgentDebugTrace,
   CanvasAgentImageAttachment,
   CanvasAgentMessage,
   CanvasAgentToolCall,
@@ -413,7 +423,7 @@ export class CanvasAgent {
     onToolInputStart?: (data: { id: string; toolName: string }) => void,
     onToolInputDelta?: (data: { id: string; delta: string }) => void,
     onToolInputEnd?: (data: { id: string }) => void,
-  ): Promise<string> {
+  ): Promise<{ response: string; debugTrace?: CanvasAgentDebugTrace }> {
     // Refresh workspace summary for system prompt
     const summary = await buildWorkspaceSummary(this.config.workspaceId);
 
@@ -437,7 +447,20 @@ export class CanvasAgent {
       console.warn('[canvas-agent] Failed to load prompt profile, using defaults:', err);
     }
 
+    const currentCanvasSummary = summary ? formatSummaryForPrompt(summary) : '(empty workspace — no nodes yet)';
     const systemPrompt = buildSystemPrompt(summary, mentionedCanvases, requestContext, promptProfileSection);
+    const debugTrace = isCanvasAgentDebugTraceEnabled()
+      ? createCanvasAgentDebugTrace({
+          sessionId: this.sessionStore.getCurrentSession()?.sessionId ?? 'unknown-session',
+          userPrompt: message,
+          attachmentCount: attachments.length,
+          requestContext,
+          mentionedCanvases,
+          summary,
+          systemPrompt,
+          currentCanvasSummary,
+        })
+      : undefined;
 
     const attachmentPrompt = attachments.length > 0
       ? [
@@ -492,6 +515,11 @@ export class CanvasAgent {
 
     try {
       const modelConfig = await resolveCanvasModel();
+      attachTraceModel(debugTrace, {
+        provider: modelConfig.providerType,
+        model: this.config.model ?? modelConfig.model,
+        modelType: modelConfig.modelType,
+      });
       const resultText = await this.engine.run(context, {
         provider: modelConfig.provider,
         model: this.config.model ?? modelConfig.model,
@@ -501,20 +529,22 @@ export class CanvasAgent {
         abortSignal: abortController.signal,
         onClarificationRequest: engineClarificationHandler,
         onText,
-        onToolCall: onToolCall
+        onToolCall: (onToolCall || debugTrace)
           ? (chunk: any) => {
               // AI SDK v6 uses `input`; older versions use `args`
               const args = chunk.input ?? chunk.args;
               console.info('[canvas-agent] tool-call chunk keys:', Object.keys(chunk), 'input:', chunk.input, 'args:', chunk.args);
-              onToolCall({ name: chunk.toolName, args, toolCallId: chunk.toolCallId });
+              recordTraceToolCall(debugTrace, { name: chunk.toolName, args, toolCallId: chunk.toolCallId });
+              onToolCall?.({ name: chunk.toolName, args, toolCallId: chunk.toolCallId });
             }
           : undefined,
-        onToolResult: onToolResult
+        onToolResult: (onToolResult || debugTrace)
           ? (chunk: any) => {
               // AI SDK v6 uses `output`; older versions use `result`
               const raw = chunk.output ?? chunk.result;
               console.info('[canvas-agent] tool-result chunk keys:', Object.keys(chunk), 'output:', typeof chunk.output, 'result:', typeof chunk.result);
-              onToolResult({
+              recordTraceToolResult(debugTrace, { name: chunk.toolName, rawResult: raw, toolCallId: chunk.toolCallId });
+              onToolResult?.({
                 name: chunk.toolName,
                 result: typeof raw === 'string' ? raw : JSON.stringify(raw),
                 toolCallId: chunk.toolCallId,
@@ -555,20 +585,23 @@ export class CanvasAgent {
       });
 
       const responseText = resultText || '(no response)';
+      recordTraceMessageSnapshot(debugTrace, { systemPrompt, messages: context.messages });
 
       // Persist assistant response together with the tool-call frames that
       // produced it so saved/restored chat sessions can render tool chips,
       // inline visuals, artifacts, and generated images instead of losing
       // them after reload.
       const toolCalls = modelMessagesToToolCalls(responseMessages);
+      const finalizedTrace = finalizeCanvasAgentDebugTrace(debugTrace);
       this.sessionStore.addMessage({
         role: 'assistant',
         content: responseText,
         timestamp: Date.now(),
         toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+        debugTrace: finalizedTrace,
       });
 
-      return responseText;
+      return { response: responseText, debugTrace: finalizedTrace };
     } finally {
       if (this.currentAbortController === abortController) {
         this.currentAbortController = null;

--- a/apps/canvas-workspace/src/main/canvas-agent/debug-trace.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/debug-trace.ts
@@ -1,0 +1,368 @@
+import { randomUUID } from 'crypto';
+import type {
+  CanvasAgentDebugTrace,
+  CanvasAgentDebugTraceContextRead,
+  CanvasAgentDebugTraceNodeRef,
+  CanvasAgentDebugTraceToolCall,
+  WorkspaceSummary,
+} from './types';
+
+const PREVIEW_CHARS = 1800;
+const RESULT_SUMMARY_CHARS = 900;
+const MESSAGE_SNAPSHOT_LIMIT_CHARS = 96_000;
+const SYSTEM_PROMPT_SNAPSHOT_LIMIT_CHARS = 40_000;
+const TRACE_JSON_LIMIT_CHARS = 180_000;
+
+interface CanvasAgentRequestContext {
+  executionMode?: 'auto' | 'ask';
+  scope?: 'current_canvas' | 'selected_nodes';
+  selectedNodes?: Array<{ id: string; title: string; type: string }>;
+  quickAction?: string;
+}
+
+interface StartTraceInput {
+  sessionId: string;
+  userPrompt: string;
+  attachmentCount: number;
+  requestContext?: CanvasAgentRequestContext;
+  mentionedCanvases: Array<{ id: string; name: string }>;
+  summary: WorkspaceSummary | null;
+  systemPrompt: string;
+  currentCanvasSummary?: string;
+}
+
+interface ToolResultInput {
+  name?: string;
+  toolCallId?: string;
+  rawResult: unknown;
+}
+
+export function isCanvasAgentDebugTraceEnabled(): boolean {
+  const override = process.env.CANVAS_AGENT_DEBUG_TRACE?.trim().toLowerCase();
+  if (override) {
+    if (['0', 'false', 'off', 'no'].includes(override)) return false;
+    if (['1', 'true', 'on', 'yes'].includes(override)) return true;
+  }
+
+  const lifecycleEvent = process.env.npm_lifecycle_event?.trim().toLowerCase();
+  if (lifecycleEvent === 'dev') return true;
+
+  const lifecycleScript = process.env.npm_lifecycle_script?.trim().toLowerCase() ?? '';
+  if (lifecycleScript.includes('electron-vite dev')) return true;
+
+  return process.env.NODE_ENV === 'development' && !!process.env.VITE_DEV_SERVER_URL;
+}
+
+export function createCanvasAgentDebugTrace(input: StartTraceInput): CanvasAgentDebugTrace {
+  const startedAt = Date.now();
+  const runId = randomUUID();
+  const selectedNodes = (input.requestContext?.selectedNodes ?? []).map(node => ({
+    id: node.id,
+    title: node.title,
+    type: node.type,
+    workspaceId: input.summary?.workspaceId,
+    workspaceName: input.summary?.workspaceName,
+    source: 'selected' as const,
+  }));
+
+  return {
+    sessionId: input.sessionId,
+    runId,
+    turnId: runId,
+    createdAt: startedAt,
+    startedAt,
+    request: {
+      userPromptPreview: preview(input.userPrompt),
+      attachmentCount: input.attachmentCount,
+      executionMode: input.requestContext?.executionMode,
+      scope: input.requestContext?.scope,
+      quickAction: input.requestContext?.quickAction,
+      selectedNodes,
+      mentionedCanvases: input.mentionedCanvases,
+      workspace: input.summary
+        ? {
+            id: input.summary.workspaceId,
+            name: input.summary.workspaceName,
+            nodeCount: input.summary.nodeCount,
+          }
+        : undefined,
+    },
+    prompt: {
+      systemPromptPreview: preview(input.systemPrompt),
+      systemPromptChars: input.systemPrompt.length,
+      currentCanvasSummaryPreview: input.currentCanvasSummary ? preview(input.currentCanvasSummary) : undefined,
+      currentCanvasSummaryChars: input.currentCanvasSummary?.length,
+    },
+    toolCalls: [],
+    readNodes: [],
+    contextReads: [],
+  };
+}
+
+export function attachTraceModel(
+  trace: CanvasAgentDebugTrace | undefined,
+  model: { provider?: string; model?: string; modelType?: string },
+): void {
+  if (!trace) return;
+  trace.model = model;
+}
+
+export function recordTraceToolCall(
+  trace: CanvasAgentDebugTrace | undefined,
+  input: { name?: string; args?: unknown; toolCallId?: string },
+): void {
+  if (!trace || !input.name) return;
+  const tool = findOrCreateTool(trace, input.name, input.toolCallId);
+  tool.status = 'running';
+  tool.startedAt ??= Date.now();
+  tool.argsPreview = previewJson(input.args, PREVIEW_CHARS);
+}
+
+export function recordTraceToolResult(trace: CanvasAgentDebugTrace | undefined, input: ToolResultInput): void {
+  if (!trace || !input.name) return;
+  const finishedAt = Date.now();
+  const tool = findOrCreateTool(trace, input.name, input.toolCallId);
+  tool.status = isErrorResult(input.rawResult) ? 'error' : 'done';
+  tool.finishedAt = finishedAt;
+  tool.startedAt ??= finishedAt;
+  tool.durationMs = finishedAt - tool.startedAt;
+  tool.resultSummary = summarizeToolResult(input.name, input.rawResult);
+
+  if (input.name === 'canvas_read_node') {
+    const readNodes = extractReadNodes(input.rawResult, 'read_node');
+    if (readNodes.length > 0) {
+      tool.readNodes = readNodes;
+      addUniqueReadNodes(trace, readNodes);
+    }
+  }
+
+  if (input.name === 'canvas_read_context') {
+    const contextRead = extractContextRead(input.rawResult);
+    if (contextRead) {
+      tool.contextRead = contextRead;
+      trace.contextReads.push(contextRead);
+    }
+
+    const readNodes = extractReadNodes(input.rawResult, 'read_context');
+    if (readNodes.length > 0) {
+      tool.readNodes = readNodes;
+      addUniqueReadNodes(trace, readNodes);
+    }
+  }
+}
+
+export function recordTraceMessageSnapshot(
+  trace: CanvasAgentDebugTrace | undefined,
+  input: { systemPrompt: string; messages: unknown[] },
+): void {
+  if (!trace) return;
+  const messagesJson = JSON.stringify(input.messages, null, 2) ?? '[]';
+  const systemPromptTruncated = input.systemPrompt.length > SYSTEM_PROMPT_SNAPSHOT_LIMIT_CHARS;
+  const messagesTruncated = messagesJson.length > MESSAGE_SNAPSHOT_LIMIT_CHARS;
+  trace.messageSnapshot = {
+    systemPrompt: systemPromptTruncated
+      ? `${input.systemPrompt.slice(0, SYSTEM_PROMPT_SNAPSHOT_LIMIT_CHARS)}\n…[system prompt truncated]`
+      : input.systemPrompt,
+    systemPromptChars: input.systemPrompt.length,
+    messagesJson: messagesTruncated
+      ? `${messagesJson.slice(0, MESSAGE_SNAPSHOT_LIMIT_CHARS)}\n…[messages snapshot truncated]`
+      : messagesJson,
+    messagesChars: messagesJson.length,
+    messageCount: input.messages.length,
+    limitChars: MESSAGE_SNAPSHOT_LIMIT_CHARS,
+    truncated: systemPromptTruncated || messagesTruncated,
+  };
+}
+
+export function finalizeCanvasAgentDebugTrace(trace: CanvasAgentDebugTrace | undefined): CanvasAgentDebugTrace | undefined {
+  if (!trace) return undefined;
+  const finishedAt = Date.now();
+  trace.finishedAt = finishedAt;
+  trace.durationMs = finishedAt - trace.startedAt;
+
+  if (JSON.stringify(trace).length <= TRACE_JSON_LIMIT_CHARS) {
+    return trace;
+  }
+
+  trace.truncated = true;
+  trace.prompt.systemPromptPreview = preview(trace.prompt.systemPromptPreview, 600);
+  trace.prompt.currentCanvasSummaryPreview = trace.prompt.currentCanvasSummaryPreview
+    ? preview(trace.prompt.currentCanvasSummaryPreview, 600)
+    : undefined;
+  trace.toolCalls = trace.toolCalls.map(tool => ({
+    ...tool,
+    argsPreview: tool.argsPreview ? preview(tool.argsPreview, 600) : undefined,
+    resultSummary: tool.resultSummary ? preview(tool.resultSummary, 600) : undefined,
+  }));
+  if (trace.messageSnapshot) {
+    trace.messageSnapshot = {
+      ...trace.messageSnapshot,
+      systemPrompt: preview(trace.messageSnapshot.systemPrompt, 12_000),
+      messagesJson: preview(trace.messageSnapshot.messagesJson, 24_000),
+      truncated: true,
+    };
+  }
+
+  return trace;
+}
+
+function findOrCreateTool(
+  trace: CanvasAgentDebugTrace,
+  name: string,
+  toolCallId?: string,
+): CanvasAgentDebugTraceToolCall {
+  const existing = toolCallId
+    ? trace.toolCalls.find(tool => tool.toolCallId === toolCallId)
+    : trace.toolCalls.find(tool => tool.name === name && tool.status === 'running');
+
+  if (existing) {
+    existing.name = name;
+    if (toolCallId) existing.toolCallId = toolCallId;
+    return existing;
+  }
+
+  const tool: CanvasAgentDebugTraceToolCall = {
+    name,
+    toolCallId,
+    status: 'running',
+    startedAt: Date.now(),
+  };
+  trace.toolCalls.push(tool);
+  return tool;
+}
+
+function preview(value: string, maxChars = PREVIEW_CHARS): string {
+  const compact = value.replace(/\s+/g, ' ').trim();
+  if (compact.length <= maxChars) return compact;
+  return `${compact.slice(0, maxChars)}…`;
+}
+
+function previewJson(value: unknown, maxChars = PREVIEW_CHARS): string | undefined {
+  if (value === undefined) return undefined;
+  const text = typeof value === 'string' ? value : JSON.stringify(value, null, 2);
+  if (!text) return undefined;
+  return preview(text, maxChars);
+}
+
+function parseJsonResult(raw: unknown): unknown {
+  if (typeof raw !== 'string') return raw;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function isErrorResult(raw: unknown): boolean {
+  return typeof raw === 'string' && raw.toLowerCase().startsWith('error:');
+}
+
+function summarizeToolResult(toolName: string, raw: unknown): string {
+  if (isErrorResult(raw)) return preview(String(raw), RESULT_SUMMARY_CHARS);
+
+  const parsed = parseJsonResult(raw);
+  if (toolName === 'canvas_read_node') {
+    const node = nodeRefFromUnknown(parsed, 'read_node');
+    if (node) {
+      const size = node.contentChars != null ? `, ${node.contentChars} chars` : '';
+      return `Read node: ${node.title} (${node.type}, ${node.id}${size})`;
+    }
+  }
+
+  if (toolName === 'canvas_read_context') {
+    const contextRead = extractContextRead(parsed);
+    if (contextRead) {
+      return `Read context: ${contextRead.workspaceName ?? contextRead.workspaceId ?? 'workspace'} (${contextRead.detail ?? 'summary'}, ${contextRead.nodeCount ?? 0} nodes)`;
+    }
+  }
+
+  return previewJson(parsed, RESULT_SUMMARY_CHARS) ?? '';
+}
+
+function extractReadNodes(raw: unknown, source: 'read_node' | 'read_context'): CanvasAgentDebugTraceNodeRef[] {
+  const parsed = parseJsonResult(raw);
+  if (source === 'read_node') {
+    const node = nodeRefFromUnknown(parsed, source);
+    return node ? [node] : [];
+  }
+
+  if (!parsed || typeof parsed !== 'object') return [];
+  const data = parsed as { workspaceId?: unknown; workspaceName?: unknown; nodes?: unknown };
+  if (!Array.isArray(data.nodes)) return [];
+  return data.nodes
+    .map(node => nodeRefFromUnknown(node, source, {
+      workspaceId: typeof data.workspaceId === 'string' ? data.workspaceId : undefined,
+      workspaceName: typeof data.workspaceName === 'string' ? data.workspaceName : undefined,
+    }))
+    .filter((node): node is CanvasAgentDebugTraceNodeRef => !!node);
+}
+
+function extractContextRead(raw: unknown): CanvasAgentDebugTraceContextRead | undefined {
+  const parsed = parseJsonResult(raw);
+  if (typeof raw === 'string' && !raw.trim().startsWith('{')) {
+    const totalMatch = raw.match(/Total nodes:\s*(\d+)/i);
+    const nameMatch = raw.match(/# Canvas Workspace:\s*(.+)/i);
+    const workspaceIdMatch = raw.match(/Workspace ID:\s*(.+)/i);
+    return {
+      workspaceName: nameMatch?.[1]?.trim(),
+      workspaceId: workspaceIdMatch?.[1]?.trim(),
+      detail: 'summary',
+      nodeCount: totalMatch ? Number(totalMatch[1]) : undefined,
+      resultChars: raw.length,
+    };
+  }
+
+  if (!parsed || typeof parsed !== 'object') return undefined;
+  const data = parsed as { workspaceId?: unknown; workspaceName?: unknown; nodes?: unknown };
+  return {
+    workspaceId: typeof data.workspaceId === 'string' ? data.workspaceId : undefined,
+    workspaceName: typeof data.workspaceName === 'string' ? data.workspaceName : undefined,
+    detail: Array.isArray(data.nodes) ? 'full' : 'summary',
+    nodeCount: Array.isArray(data.nodes) ? data.nodes.length : undefined,
+    resultChars: typeof raw === 'string' ? raw.length : (JSON.stringify(raw) ?? '').length,
+  };
+}
+
+function nodeRefFromUnknown(
+  value: unknown,
+  source: 'read_node' | 'read_context',
+  workspace?: { workspaceId?: string; workspaceName?: string },
+): CanvasAgentDebugTraceNodeRef | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const node = value as {
+    id?: unknown;
+    title?: unknown;
+    type?: unknown;
+    workspaceId?: unknown;
+    workspaceName?: unknown;
+    content?: unknown;
+    scrollback?: unknown;
+  };
+  if (typeof node.id !== 'string' || typeof node.type !== 'string') return undefined;
+
+  const content = typeof node.content === 'string'
+    ? node.content
+    : typeof node.scrollback === 'string'
+      ? node.scrollback
+      : undefined;
+
+  return {
+    id: node.id,
+    title: typeof node.title === 'string' && node.title.trim() ? node.title : node.id,
+    type: node.type,
+    workspaceId: typeof node.workspaceId === 'string' ? node.workspaceId : workspace?.workspaceId,
+    workspaceName: typeof node.workspaceName === 'string' ? node.workspaceName : workspace?.workspaceName,
+    contentChars: content?.length,
+    source,
+  };
+}
+
+function addUniqueReadNodes(trace: CanvasAgentDebugTrace, nodes: CanvasAgentDebugTraceNodeRef[]): void {
+  const seen = new Set(trace.readNodes.map(node => `${node.workspaceId ?? ''}:${node.id}:${node.source ?? ''}`));
+  for (const node of nodes) {
+    const key = `${node.workspaceId ?? ''}:${node.id}:${node.source ?? ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    trace.readNodes.push(node);
+  }
+}

--- a/apps/canvas-workspace/src/main/canvas-agent/service.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/service.ts
@@ -17,6 +17,8 @@ import type {
   AgentStatusResponse,
   SessionListResponse,
   CanvasAgentMessage,
+  CanvasAgentDebugRunDetail,
+  CanvasAgentDebugRunSummary,
   CrossWorkspaceSessionGroup,
 } from './types';
 
@@ -71,7 +73,7 @@ export class CanvasAgentService {
     try {
       await this.activate(workspaceId);
       const agent = this.agents.get(workspaceId)!;
-      const response = await agent.chat(
+      const result = await agent.chat(
         message,
         onText,
         onToolCall,
@@ -84,7 +86,7 @@ export class CanvasAgentService {
         onToolInputDelta,
         onToolInputEnd,
       );
-      return { ok: true, response };
+      return { ok: true, response: result.response, debugTrace: result.debugTrace };
     } catch (err) {
       console.error(`[canvas-agent-service] chat error for ${workspaceId}:`, err);
       return { ok: false, error: String(err) };
@@ -221,6 +223,14 @@ export class CanvasAgentService {
     } catch (err) {
       return { ok: false, error: String(err) };
     }
+  }
+
+  async listDebugRuns(): Promise<CanvasAgentDebugRunSummary[]> {
+    return SessionStore.listDebugRuns();
+  }
+
+  async getDebugRun(sessionId: string, runId: string): Promise<CanvasAgentDebugRunDetail | null> {
+    return SessionStore.readDebugRun(sessionId, runId);
   }
 
   /**

--- a/apps/canvas-workspace/src/main/canvas-agent/session-store.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/session-store.ts
@@ -12,9 +12,26 @@
 import { promises as fs } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
-import type { CanvasAgentMessage, CanvasAgentSession } from './types';
+import type {
+  CanvasAgentDebugRunDetail,
+  CanvasAgentDebugRunSummary,
+  CanvasAgentMessage,
+  CanvasAgentSession,
+} from './types';
 
 const STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
+
+interface WorkspaceManifest {
+  workspaces: Array<{ id: string; name: string }>;
+  activeId?: string;
+}
+
+interface SessionWithMeta {
+  session: CanvasAgentSession;
+  workspaceName: string;
+  isCurrent: boolean;
+  sortKey: number;
+}
 
 function archiveFileTimestamp(file: string): number {
   const match = file.match(/-(\d+)\.json$/);
@@ -368,6 +385,119 @@ export class SessionStore {
     return matched;
   }
 
+  /**
+   * List all persisted Canvas Agent turns that carry a dev debug trace.
+   */
+  static async listDebugRuns(): Promise<CanvasAgentDebugRunSummary[]> {
+    const sessions = await this.readAllSessionsWithMeta();
+    const runs = sessions.flatMap(({ session, workspaceName, isCurrent }) => (
+      session.messages.flatMap((message, index) => {
+        if (message.role !== 'assistant' || !message.debugTrace) return [];
+        return [debugRunSummaryFromMessage({
+          session,
+          workspaceName,
+          isCurrent,
+          message,
+          messageIndex: index,
+        })];
+      })
+    ));
+
+    runs.sort((a, b) => b.startedAt - a.startedAt);
+    return runs;
+  }
+
+  /**
+   * Read a single persisted debug trace by session/run id.
+   */
+  static async readDebugRun(sessionId: string, runId: string): Promise<CanvasAgentDebugRunDetail | null> {
+    const sessions = await this.readAllSessionsWithMeta();
+    for (const { session, workspaceName, isCurrent } of sessions) {
+      if (session.sessionId !== sessionId) continue;
+      const messageIndex = session.messages.findIndex(
+        message => message.role === 'assistant' && message.debugTrace?.runId === runId,
+      );
+      if (messageIndex < 0) continue;
+
+      const assistantMessage = session.messages[messageIndex];
+      const trace = assistantMessage.debugTrace;
+      if (!trace) continue;
+
+      return {
+        ...debugRunSummaryFromMessage({
+          session,
+          workspaceName,
+          isCurrent,
+          message: assistantMessage,
+          messageIndex,
+        }),
+        userMessage: findPreviousUserMessage(session.messages, messageIndex),
+        assistantMessage,
+        trace,
+      };
+    }
+
+    return null;
+  }
+
+  private static async readAllSessionsWithMeta(): Promise<SessionWithMeta[]> {
+    const manifest = await loadManifest();
+    const workspaceNames = new Map(manifest.workspaces.map(workspace => [workspace.id, workspace.name] as const));
+    const results: SessionWithMeta[] = [];
+
+    let dirs: string[];
+    try {
+      dirs = await fs.readdir(STORE_DIR);
+    } catch {
+      return results;
+    }
+
+    for (const workspaceId of dirs) {
+      if (workspaceId.startsWith('__') || workspaceId.startsWith('.')) continue;
+      const workspaceName = workspaceNames.get(workspaceId) ?? workspaceId;
+      const sessionsDir = join(STORE_DIR, workspaceId, 'agent-sessions');
+      const currentPath = join(sessionsDir, 'current.json');
+      const archiveDir = join(sessionsDir, 'archive');
+      const seen = new Set<string>();
+
+      try {
+        const raw = await fs.readFile(currentPath, 'utf-8');
+        const session = JSON.parse(raw) as CanvasAgentSession;
+        seen.add(session.sessionId);
+        results.push({ session, workspaceName, isCurrent: true, sortKey: Date.now() });
+      } catch {
+        // No current session
+      }
+
+      try {
+        const files = await fs.readdir(archiveDir);
+        for (const file of files) {
+          if (!file.endsWith('.json')) continue;
+          const archivePath = join(archiveDir, file);
+          try {
+            const raw = await fs.readFile(archivePath, 'utf-8');
+            const session = JSON.parse(raw) as CanvasAgentSession;
+            if (seen.has(session.sessionId)) continue;
+            seen.add(session.sessionId);
+            results.push({
+              session,
+              workspaceName,
+              isCurrent: false,
+              sortKey: await archiveSortKey(archivePath, file),
+            });
+          } catch {
+            // skip corrupted archive
+          }
+        }
+      } catch {
+        // No archive dir
+      }
+    }
+
+    results.sort((a, b) => b.sortKey - a.sortKey);
+    return results;
+  }
+
   // ─── Internal ────────────────────────────────────────────────
 
   private async removeArchivedSessionsById(sessionId: string): Promise<void> {
@@ -419,4 +549,50 @@ export class SessionStore {
       // No current session or corrupted — nothing to archive
     }
   }
+}
+
+async function loadManifest(): Promise<WorkspaceManifest> {
+  try {
+    const raw = await fs.readFile(join(STORE_DIR, '__workspaces__.json'), 'utf-8');
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const workspaces = (parsed.workspaces ?? parsed.entries ?? []) as WorkspaceManifest['workspaces'];
+    return { workspaces, activeId: parsed.activeId as string | undefined };
+  } catch {
+    return { workspaces: [] };
+  }
+}
+
+function findPreviousUserMessage(messages: CanvasAgentMessage[], assistantIndex: number): CanvasAgentMessage | undefined {
+  for (let index = assistantIndex - 1; index >= 0; index--) {
+    if (messages[index]?.role === 'user') return messages[index];
+  }
+  return undefined;
+}
+
+function debugRunSummaryFromMessage(input: {
+  session: CanvasAgentSession;
+  workspaceName: string;
+  isCurrent: boolean;
+  message: CanvasAgentMessage;
+  messageIndex: number;
+}): CanvasAgentDebugRunSummary {
+  const { session, workspaceName, isCurrent, message, messageIndex } = input;
+  const trace = message.debugTrace!;
+  const modelLabel = [trace.model?.provider, trace.model?.model].filter(Boolean).join(' / ') || undefined;
+  return {
+    workspaceId: session.workspaceId,
+    workspaceName,
+    sessionId: session.sessionId,
+    runId: trace.runId,
+    turnId: trace.turnId,
+    messageIndex,
+    startedAt: trace.startedAt,
+    durationMs: trace.durationMs,
+    userPromptPreview: trace.request.userPromptPreview,
+    assistantPreview: message.content.slice(0, 180),
+    toolCount: trace.toolCalls.length,
+    readNodeCount: trace.readNodes.length,
+    modelLabel,
+    isCurrent,
+  };
 }

--- a/apps/canvas-workspace/src/main/canvas-agent/types.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/types.ts
@@ -37,12 +37,95 @@ export interface CanvasAgentToolCall {
   streamedDone?: boolean;
 }
 
+export interface CanvasAgentDebugTraceNodeRef {
+  id: string;
+  title: string;
+  type: string;
+  workspaceId?: string;
+  workspaceName?: string;
+  contentChars?: number;
+  source?: 'selected' | 'read_node' | 'read_context';
+}
+
+export interface CanvasAgentDebugTraceContextRead {
+  workspaceId?: string;
+  workspaceName?: string;
+  detail?: string;
+  nodeCount?: number;
+  resultChars?: number;
+}
+
+export interface CanvasAgentDebugTraceToolCall {
+  name: string;
+  toolCallId?: string;
+  status: 'running' | 'done' | 'error';
+  argsPreview?: string;
+  resultSummary?: string;
+  startedAt?: number;
+  finishedAt?: number;
+  durationMs?: number;
+  readNodes?: CanvasAgentDebugTraceNodeRef[];
+  contextRead?: CanvasAgentDebugTraceContextRead;
+}
+
+export interface CanvasAgentDebugTraceMessageSnapshot {
+  systemPrompt: string;
+  systemPromptChars: number;
+  messagesJson: string;
+  messagesChars: number;
+  messageCount: number;
+  limitChars: number;
+  truncated?: boolean;
+}
+
+export interface CanvasAgentDebugTrace {
+  sessionId: string;
+  runId: string;
+  turnId: string;
+  createdAt: number;
+  startedAt: number;
+  finishedAt?: number;
+  durationMs?: number;
+  debugUrl?: string;
+  request: {
+    userPromptPreview: string;
+    attachmentCount: number;
+    executionMode?: 'auto' | 'ask';
+    scope?: 'current_canvas' | 'selected_nodes';
+    quickAction?: string;
+    selectedNodes: CanvasAgentDebugTraceNodeRef[];
+    mentionedCanvases: Array<{ id: string; name: string }>;
+    workspace?: {
+      id: string;
+      name: string;
+      nodeCount: number;
+    };
+  };
+  prompt: {
+    systemPromptPreview: string;
+    systemPromptChars: number;
+    currentCanvasSummaryPreview?: string;
+    currentCanvasSummaryChars?: number;
+  };
+  messageSnapshot?: CanvasAgentDebugTraceMessageSnapshot;
+  model?: {
+    provider?: string;
+    model?: string;
+    modelType?: string;
+  };
+  toolCalls: CanvasAgentDebugTraceToolCall[];
+  readNodes: CanvasAgentDebugTraceNodeRef[];
+  contextReads: CanvasAgentDebugTraceContextRead[];
+  truncated?: boolean;
+}
+
 export interface CanvasAgentMessage {
   role: 'user' | 'assistant';
   content: string;
   timestamp: number;
   attachments?: CanvasAgentImageAttachment[];
   toolCalls?: CanvasAgentToolCall[];
+  debugTrace?: CanvasAgentDebugTrace;
 }
 
 // ─── Session persistence ────────────────────────────────────────────
@@ -52,6 +135,29 @@ export interface CanvasAgentSession {
   workspaceId: string;
   startedAt: string;
   messages: CanvasAgentMessage[];
+}
+
+export interface CanvasAgentDebugRunSummary {
+  workspaceId: string;
+  workspaceName: string;
+  sessionId: string;
+  runId: string;
+  turnId: string;
+  messageIndex: number;
+  startedAt: number;
+  durationMs?: number;
+  userPromptPreview: string;
+  assistantPreview: string;
+  toolCount: number;
+  readNodeCount: number;
+  modelLabel?: string;
+  isCurrent: boolean;
+}
+
+export interface CanvasAgentDebugRunDetail extends CanvasAgentDebugRunSummary {
+  userMessage?: CanvasAgentMessage;
+  assistantMessage: CanvasAgentMessage;
+  trace: CanvasAgentDebugTrace;
 }
 
 // ─── Workspace context (lightweight summary) ────────────────────────
@@ -133,6 +239,7 @@ export interface ChatRequest {
 export interface ChatResponse {
   ok: boolean;
   response?: string;
+  debugTrace?: CanvasAgentDebugTrace;
   error?: string;
 }
 

--- a/apps/canvas-workspace/src/preload/index.ts
+++ b/apps/canvas-workspace/src/preload/index.ts
@@ -226,12 +226,12 @@ contextBridge.exposeInMainWorld("canvasWorkspace", {
 
     onChatComplete: (
       sessionId: string,
-      callback: (result: { ok: boolean; response?: string; error?: string }) => void
+      callback: (result: { ok: boolean; response?: string; debugTrace?: unknown; error?: string }) => void
     ) => {
       const channel = `canvas-agent:chat-complete:${sessionId}`;
       const handler = (
         _event: Electron.IpcRendererEvent,
-        result: { ok: boolean; response?: string; error?: string }
+        result: { ok: boolean; response?: string; debugTrace?: unknown; error?: string }
       ) => callback(result);
       ipcRenderer.on(channel, handler);
       return () => {
@@ -359,6 +359,12 @@ contextBridge.exposeInMainWorld("canvasWorkspace", {
 
     loadCrossWorkspaceSession: (targetWorkspaceId: string, sourceWorkspaceId: string, sessionId: string) =>
       ipcRenderer.invoke("canvas-agent:load-cross-workspace-session", { targetWorkspaceId, sourceWorkspaceId, sessionId }),
+
+    listDebugRuns: () =>
+      ipcRenderer.invoke("canvas-agent:debug-runs"),
+
+    getDebugRun: (sessionId: string, runId: string) =>
+      ipcRenderer.invoke("canvas-agent:debug-run", { sessionId, runId }),
 
     activate: (workspaceId: string) =>
       ipcRenderer.invoke("canvas-agent:activate", { workspaceId }),

--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -5,6 +5,7 @@ import { AppShellProvider, useAppShell } from './components/AppShellProvider';
 import { ArtifactDrawer, ArtifactDrawerProvider } from './components/artifacts';
 import './components/artifacts/artifacts.css';
 import { ChatPage } from './components/chat';
+import { AgentDebugPage } from './components/debug/AgentDebugPage';
 import { Sidebar } from './components/Sidebar';
 import { Workbench, useWorkbenchState } from './components/Workbench';
 import { useWorkspaces } from './hooks/useWorkspaces';
@@ -13,8 +14,9 @@ import { PulseRouter, PulseRouterView } from './components/router';
 
 const ROUTE_CANVAS = '/';
 const ROUTE_CHAT = '/chat';
+const ROUTE_DEBUG = '/debug';
 
-type ActiveView = 'canvas' | 'chat';
+type ActiveView = 'canvas' | 'chat' | 'debug';
 
 const AppContent = () => {
   const [location, setLocation] = useLocation();
@@ -22,7 +24,11 @@ const AppContent = () => {
     () => parseCanvasLocation(location),
     [location],
   );
-  const activeView: ActiveView = routePath === ROUTE_CHAT ? 'chat' : 'canvas';
+  const activeView: ActiveView = routePath === ROUTE_CHAT
+    ? 'chat'
+    : routePath === ROUTE_DEBUG
+      ? 'debug'
+      : 'canvas';
   const routeQuery = routeParams.toString();
 
   const { notify, updateToast, confirm, openShortcuts, isOverlayOpen } = useAppShell();
@@ -58,7 +64,7 @@ const AppContent = () => {
   } = workbench;
 
   useEffect(() => {
-    if (!routeQuery) return;
+    if (!routeQuery || routePath !== ROUTE_CANVAS) return;
 
     const targetWorkspaceId = routeParams.get('workspaceId') ?? activeId;
     const targetNodeId = routeParams.get('nodeId');
@@ -72,7 +78,7 @@ const AppContent = () => {
       requestNodeFocus(targetWorkspaceId, targetNodeId);
     }
     setLocation(ROUTE_CANVAS);
-  }, [routeQuery, routeParams, activeId, workspaces, selectWorkspace, requestNodeFocus, setLocation]);
+  }, [routePath, routeQuery, routeParams, activeId, workspaces, selectWorkspace, requestNodeFocus, setLocation]);
 
   const enterChatView = useCallback(() => {
     setLocation(ROUTE_CHAT);
@@ -80,6 +86,14 @@ const AppContent = () => {
 
   const exitChatView = useCallback(() => {
     setLocation(ROUTE_CANVAS);
+  }, [setLocation]);
+
+  const enterDebugView = useCallback((sessionId?: string, runId?: string) => {
+    const params = new URLSearchParams();
+    if (sessionId) params.set('sessionId', sessionId);
+    if (runId) params.set('runId', runId);
+    const query = params.toString();
+    setLocation(query ? `${ROUTE_DEBUG}?${query}` : ROUTE_DEBUG);
   }, [setLocation]);
 
   const handleSelectWorkspace = useCallback((id: string) => {
@@ -347,10 +361,11 @@ const AppContent = () => {
           onNodeRename={requestActiveNodeRename}
           activeView={activeView}
           onEnterChat={enterChatView}
+          onEnterDebug={() => enterDebugView()}
           onExitChat={exitChatView}
         />
         <PulseRouter<ActiveView> activeKey={activeView}>
-          <PulseRouterView name='canvas'>
+          <PulseRouterView name='canvas' keepAlive>
             <Workbench
               activeWorkspaceId={activeId}
               workspaces={workspaces}
@@ -366,6 +381,14 @@ const AppContent = () => {
               onWorkspaceContextRequest={ensureWorkspaceNodesLoaded}
               onExit={exitChatView}
               onNodeFocus={handleNodeFocusFromChatPage}
+            />
+          </PulseRouterView>
+          <PulseRouterView name="debug">
+            <AgentDebugPage
+              selectedSessionId={routeParams.get('sessionId')}
+              selectedRunId={routeParams.get('runId')}
+              onSelectRun={enterDebugView}
+              onBackToCanvas={exitChatView}
             />
           </PulseRouterView>
         </PulseRouter>

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/SidebarHeader.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/SidebarHeader.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { PlusIcon, AvatarIcon, WorkspaceIcon, FolderIcon, ImportIcon } from '../icons';
+import { PlusIcon, AvatarIcon, WorkspaceIcon, FolderIcon, ImportIcon, SettingsIcon } from '../icons';
 
 export const SidebarToggleIcon = ({ size = 14 }: { size?: number }) => (
   <svg width={size} height={size} viewBox="0 0 16 16" fill="none">
@@ -10,8 +10,9 @@ export const SidebarToggleIcon = ({ size = 14 }: { size?: number }) => (
 
 interface SidebarHeaderProps {
   onToggle: () => void;
-  activeView: 'canvas' | 'chat';
+  activeView: 'canvas' | 'chat' | 'debug';
   onEnterChat: () => void;
+  onEnterDebug: () => void;
   showAddMenu: boolean;
   onToggleAddMenu: () => void;
   addMenuRef: React.RefObject<HTMLDivElement>;
@@ -24,6 +25,7 @@ export const SidebarHeader = ({
   onToggle,
   activeView,
   onEnterChat,
+  onEnterDebug,
   showAddMenu,
   onToggleAddMenu,
   addMenuRef,
@@ -61,6 +63,16 @@ export const SidebarHeader = ({
           <AvatarIcon size={14} />
         </span>
         <span className="sidebar-nav-label">AI Chat</span>
+      </button>
+      <button
+        className={`sidebar-nav-item${activeView === 'debug' ? ' sidebar-nav-item--active' : ''}`}
+        onClick={onEnterDebug}
+        title="Canvas Agent DevTools"
+      >
+        <span className="sidebar-nav-icon">
+          <SettingsIcon size={14} />
+        </span>
+        <span className="sidebar-nav-label">DevTools</span>
       </button>
     </div>
 

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/WorkspaceItem.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/WorkspaceItem.tsx
@@ -5,7 +5,7 @@ import { CloseIcon, ExportIcon, WorkspaceIcon } from '../icons';
 export interface WorkspaceItemProps {
   ws: WorkspaceEntry;
   activeId: string;
-  activeView: 'canvas' | 'chat';
+  activeView: 'canvas' | 'chat' | 'debug';
   isOnlyWorkspace: boolean;
   isRenaming: boolean;
   renameValue: string;
@@ -60,7 +60,7 @@ export const WorkspaceItem = ({
         />
       ) : (
         <button
-          className={`sidebar-item${activeId === ws.id && activeView !== 'chat' ? ' sidebar-item--active' : ''}`}
+          className={`sidebar-item${activeId === ws.id && activeView === 'canvas' ? ' sidebar-item--active' : ''}`}
           onClick={() => onSelect(ws.id)}
           onDoubleClick={() => onStartRename(ws)}
           title="Double-click to rename"

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
@@ -35,8 +35,9 @@ interface Props {
   onNodeFocus?: (nodeId: string) => void;
   onNodeDelete?: (nodeId: string) => void;
   onNodeRename?: (nodeId: string, title: string) => void;
-  activeView: 'canvas' | 'chat';
+  activeView: 'canvas' | 'chat' | 'debug';
   onEnterChat: () => void;
+  onEnterDebug: () => void;
   onExitChat: () => void;
 }
 
@@ -46,7 +47,7 @@ const FOLDER_DRAG = 'application/x-folder-id';
 export const Sidebar = ({
   collapsed, onToggle, workspaces, folders, activeId, onSelect, onCreate, onRename, onDelete,
   onExport, onImport, onCreateFolder, onRenameFolder, onDeleteFolder, onToggleFolder, onMoveWorkspace, onReorderFolder,
-  activeNodes = [], onNodeFocus, onNodeDelete, onNodeRename, activeView, onEnterChat,
+  activeNodes = [], onNodeFocus, onNodeDelete, onNodeRename, activeView, onEnterChat, onEnterDebug,
 }: Props) => {
   const { notify } = useAppShell();
   const [renamingId, setRenamingId] = useState<string | null>(null);
@@ -234,7 +235,7 @@ export const Sidebar = ({
       {!collapsed && (
         <>
           <SidebarHeader
-            onToggle={onToggle} activeView={activeView} onEnterChat={onEnterChat}
+            onToggle={onToggle} activeView={activeView} onEnterChat={onEnterChat} onEnterDebug={onEnterDebug}
             showAddMenu={showAddMenu} onToggleAddMenu={() => setShowAddMenu((v) => !v)}
             addMenuRef={addMenuRef}
             onNewWorkspace={() => { setShowAddMenu(false); setInlineCreate('workspace'); setInlineCreateValue(''); }}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatDebugTrace.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatDebugTrace.tsx
@@ -1,0 +1,181 @@
+import { useState } from 'react';
+import type { AgentDebugTrace } from '../../types';
+
+interface ChatDebugTraceProps {
+  trace: AgentDebugTrace;
+}
+
+const shortId = (value: string, length = 8) => value.length <= length ? value : value.slice(0, length);
+
+const formatDuration = (durationMs?: number) => {
+  if (durationMs == null) return 'running';
+  if (durationMs < 1000) return `${durationMs}ms`;
+  return `${(durationMs / 1000).toFixed(1)}s`;
+};
+
+const formatTime = (timestamp?: number) => {
+  if (!timestamp) return '—';
+  return new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+};
+
+const CopyButton = ({ value, label }: { value: string; label: string }) => (
+  <button
+    type="button"
+    className="chat-debug-copy"
+    onClick={() => void navigator.clipboard?.writeText(value)}
+    title={`Copy ${label}`}
+  >
+    copy
+  </button>
+);
+
+const TraceText = ({ value }: { value?: string }) => {
+  if (!value) return <span className="chat-debug-muted">—</span>;
+  return <pre className="chat-debug-pre">{value}</pre>;
+};
+
+export const ChatDebugTrace = ({ trace }: ChatDebugTraceProps) => {
+  const [open, setOpen] = useState(false);
+  const readNodeCount = trace.readNodes.length;
+  const toolCount = trace.toolCalls.length;
+  const debugHref = `#/debug?sessionId=${encodeURIComponent(trace.sessionId)}&runId=${encodeURIComponent(trace.runId)}`;
+
+  return (
+    <div className={`chat-debug-trace${open ? ' chat-debug-trace--open' : ''}`}>
+      <button type="button" className="chat-debug-summary" onClick={() => setOpen(value => !value)}>
+        <span className="chat-debug-dot" />
+        <span className="chat-debug-title">Debug Trace</span>
+        <span className="chat-debug-pill">run {shortId(trace.runId)}</span>
+        <span className="chat-debug-pill">{toolCount} tools</span>
+        <span className="chat-debug-pill">read {readNodeCount} nodes</span>
+        <span className="chat-debug-pill">{formatDuration(trace.durationMs)}</span>
+        <span className="chat-debug-chevron">{open ? '▴' : '▾'}</span>
+      </button>
+
+      {open && (
+        <div className="chat-debug-body">
+          <section className="chat-debug-section">
+            <div className="chat-debug-section-title">Run</div>
+            <div className="chat-debug-grid">
+              <span>sessionId</span>
+              <code>{trace.sessionId}</code>
+              <CopyButton value={trace.sessionId} label="sessionId" />
+              <span>runId</span>
+              <code>{trace.runId}</code>
+              <CopyButton value={trace.runId} label="runId" />
+              <span>started</span>
+              <code>{formatTime(trace.startedAt)}</code>
+              <span />
+              <span>duration</span>
+              <code>{formatDuration(trace.durationMs)}</code>
+              <span />
+              <span>model</span>
+              <code>{[trace.model?.provider, trace.model?.model].filter(Boolean).join(' / ') || '—'}</code>
+              <span />
+            </div>
+            <a className="chat-debug-open-link" href={trace.debugUrl ?? debugHref}>
+              Open debugger
+            </a>
+          </section>
+
+          <section className="chat-debug-section">
+            <div className="chat-debug-section-title">Context</div>
+            <div className="chat-debug-meta-row">
+              <span>mode: <code>{trace.request.executionMode ?? 'auto'}</code></span>
+              <span>scope: <code>{trace.request.scope ?? 'current_canvas'}</code></span>
+              {trace.request.quickAction && <span>action: <code>{trace.request.quickAction}</code></span>}
+              {trace.request.workspace && (
+                <span>{trace.request.workspace.name} · {trace.request.workspace.nodeCount} nodes</span>
+              )}
+            </div>
+            <div className="chat-debug-subtitle">User prompt preview</div>
+            <TraceText value={trace.request.userPromptPreview} />
+
+            {trace.request.selectedNodes.length > 0 && (
+              <>
+                <div className="chat-debug-subtitle">Selected nodes</div>
+                <NodeList nodes={trace.request.selectedNodes} />
+              </>
+            )}
+
+            {trace.request.mentionedCanvases.length > 0 && (
+              <>
+                <div className="chat-debug-subtitle">Mentioned canvases</div>
+                <div className="chat-debug-list">
+                  {trace.request.mentionedCanvases.map(canvas => (
+                    <div key={canvas.id} className="chat-debug-list-item">
+                      <strong>{canvas.name}</strong>
+                      <code>{canvas.id}</code>
+                    </div>
+                  ))}
+                </div>
+              </>
+            )}
+
+            <details className="chat-debug-details">
+              <summary>System prompt preview · {trace.prompt.systemPromptChars.toLocaleString()} chars</summary>
+              <TraceText value={trace.prompt.systemPromptPreview} />
+            </details>
+          </section>
+
+          <section className="chat-debug-section">
+            <div className="chat-debug-section-title">Tools</div>
+            {trace.toolCalls.length === 0 ? (
+              <div className="chat-debug-muted">No tool calls recorded.</div>
+            ) : (
+              <div className="chat-debug-tool-list">
+                {trace.toolCalls.map((tool, index) => (
+                  <details key={`${tool.toolCallId ?? tool.name}-${index}`} className="chat-debug-tool">
+                    <summary>
+                      <span className={`chat-debug-status chat-debug-status--${tool.status}`} />
+                      <strong>{tool.name}</strong>
+                      <span>{formatDuration(tool.durationMs)}</span>
+                      {tool.readNodes?.length ? <span>{tool.readNodes.length} nodes</span> : null}
+                    </summary>
+                    {tool.argsPreview && (
+                      <>
+                        <div className="chat-debug-subtitle">Args</div>
+                        <TraceText value={tool.argsPreview} />
+                      </>
+                    )}
+                    {tool.resultSummary && (
+                      <>
+                        <div className="chat-debug-subtitle">Result</div>
+                        <TraceText value={tool.resultSummary} />
+                      </>
+                    )}
+                  </details>
+                ))}
+              </div>
+            )}
+          </section>
+
+          {trace.readNodes.length > 0 && (
+            <section className="chat-debug-section">
+              <div className="chat-debug-section-title">Read Nodes</div>
+              <NodeList nodes={trace.readNodes} />
+            </section>
+          )}
+
+          {trace.truncated && (
+            <div className="chat-debug-warning">Trace truncated to keep the dev session lightweight.</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const NodeList = ({ nodes }: { nodes: AgentDebugTrace['readNodes'] }) => (
+  <div className="chat-debug-list">
+    {nodes.map((node, index) => (
+      <div key={`${node.workspaceId ?? ''}-${node.id}-${node.source ?? ''}-${index}`} className="chat-debug-list-item">
+        <strong>{node.title}</strong>
+        <span>{node.type}</span>
+        <code>{node.id}</code>
+        {node.contentChars != null && <span>{node.contentChars.toLocaleString()} chars</span>}
+        {node.workspaceName && <span>{node.workspaceName}</span>}
+      </div>
+    ))}
+  </div>
+);

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
@@ -4,6 +4,7 @@ import { AvatarIcon } from '../icons';
 import type { ToolCallStatus } from './types';
 import { renderMdWithMentions, renderUserContent } from './utils/mentions';
 import { ChatToolCalls } from './ChatToolCalls';
+import { ChatDebugTrace } from './ChatDebugTrace';
 import {
   ChatArtifactCard,
   ChatInlineVisual,
@@ -191,6 +192,9 @@ export const ChatMessage = ({
         )
       ) : (
         <div className="chat-message-content">{renderUserContent(message.content, nodes)}</div>
+      )}
+      {message.role === 'assistant' && message.debugTrace && (
+        <ChatDebugTrace trace={message.debugTrace} />
       )}
     </div>
   </div>

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
@@ -2042,3 +2042,257 @@
   border-color: rgba(35, 131, 226, 0.45);
   box-shadow: 0 0 0 3px rgba(35, 131, 226, 0.1);
 }
+
+/* ─── Agent Debug Trace (dev-only data) ─────────────────────────── */
+
+.chat-debug-trace {
+  margin-top: 10px;
+  max-width: 100%;
+  border: 1px solid rgba(55, 53, 47, 0.09);
+  border-radius: 12px;
+  background: linear-gradient(180deg, rgba(250, 249, 246, 0.95), rgba(245, 244, 240, 0.92));
+  box-shadow: 0 8px 24px rgba(55, 53, 47, 0.04);
+  overflow: hidden;
+}
+
+.chat-debug-summary {
+  width: 100%;
+  border: none;
+  background: transparent;
+  padding: 8px 10px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: #5f5d58;
+  font-size: 11px;
+  cursor: pointer;
+  text-align: left;
+}
+
+.chat-debug-summary:hover {
+  background: rgba(55, 53, 47, 0.035);
+}
+
+.chat-debug-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: #3f8f6b;
+  box-shadow: 0 0 0 3px rgba(63, 143, 107, 0.12);
+  flex-shrink: 0;
+}
+
+.chat-debug-title {
+  color: #37352f;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.chat-debug-pill {
+  border: 1px solid rgba(55, 53, 47, 0.08);
+  border-radius: 999px;
+  padding: 2px 7px;
+  background: rgba(255, 255, 255, 0.65);
+  white-space: nowrap;
+}
+
+.chat-debug-chevron {
+  margin-left: auto;
+  color: #9b9a97;
+}
+
+.chat-debug-body {
+  border-top: 1px solid rgba(55, 53, 47, 0.08);
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.chat-debug-section {
+  border: 1px solid rgba(55, 53, 47, 0.07);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.68);
+  padding: 10px;
+}
+
+.chat-debug-section-title {
+  font-size: 11px;
+  font-weight: 800;
+  color: #37352f;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 8px;
+}
+
+.chat-debug-grid {
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr) max-content;
+  gap: 5px 8px;
+  align-items: center;
+  font-size: 11px;
+  color: #73726e;
+}
+
+.chat-debug-grid code,
+.chat-debug-list code,
+.chat-debug-meta-row code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 10px;
+  color: #37352f;
+  background: rgba(55, 53, 47, 0.055);
+  border-radius: 5px;
+  padding: 1px 5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-debug-copy {
+  border: none;
+  border-radius: 5px;
+  background: rgba(55, 53, 47, 0.06);
+  color: #73726e;
+  font-size: 10px;
+  padding: 2px 5px;
+  cursor: pointer;
+}
+
+.chat-debug-copy:hover {
+  background: rgba(55, 53, 47, 0.11);
+  color: #37352f;
+}
+
+.chat-debug-open-link {
+  display: inline-flex;
+  margin-top: 8px;
+  font-size: 11px;
+  color: #28674b;
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.chat-debug-meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+  font-size: 11px;
+  color: #73726e;
+}
+
+.chat-debug-subtitle {
+  margin: 8px 0 5px;
+  font-size: 11px;
+  font-weight: 700;
+  color: #73726e;
+}
+
+.chat-debug-pre {
+  max-height: 180px;
+  overflow: auto;
+  margin: 0;
+  padding: 8px;
+  border-radius: 8px;
+  background: rgba(32, 31, 28, 0.045);
+  color: #37352f;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 10.5px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.chat-debug-list {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.chat-debug-list-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  padding: 6px 7px;
+  border-radius: 8px;
+  background: rgba(55, 53, 47, 0.035);
+  color: #73726e;
+  font-size: 11px;
+}
+
+.chat-debug-list-item strong {
+  color: #37352f;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-debug-details,
+.chat-debug-tool {
+  margin-top: 8px;
+  font-size: 11px;
+  color: #73726e;
+}
+
+.chat-debug-details summary,
+.chat-debug-tool summary {
+  cursor: pointer;
+  color: #5f5d58;
+  font-weight: 700;
+}
+
+.chat-debug-tool-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.chat-debug-tool {
+  margin: 0;
+  border-radius: 8px;
+  background: rgba(55, 53, 47, 0.035);
+  padding: 7px;
+}
+
+.chat-debug-tool summary {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  list-style: none;
+}
+
+.chat-debug-tool summary::-webkit-details-marker {
+  display: none;
+}
+
+.chat-debug-status {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: #b4b4b0;
+}
+
+.chat-debug-status--done {
+  background: #3f8f6b;
+}
+
+.chat-debug-status--error {
+  background: #c25245;
+}
+
+.chat-debug-status--running {
+  background: #b88a2d;
+}
+
+.chat-debug-muted {
+  color: #9b9a97;
+  font-size: 11px;
+}
+
+.chat-debug-warning {
+  border-radius: 8px;
+  background: rgba(184, 138, 45, 0.12);
+  color: #7a5a16;
+  font-size: 11px;
+  padding: 7px 8px;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatStream.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatStream.ts
@@ -269,7 +269,11 @@ export function useChatStream({ workspaceId, allWorkspaces }: UseChatStreamOptio
 
         const toolSnapshot = toolCalls.length > 0 ? toolCalls.map(tool => ({ ...tool })) : undefined;
         const mergeAssistantMessage = (message: AgentChatMessage): AgentChatMessage => (
-          toolSnapshot ? { ...message, toolCalls: toolSnapshot } : message
+          {
+            ...message,
+            toolCalls: toolSnapshot ?? message.toolCalls,
+            debugTrace: completeResult.debugTrace ?? message.debugTrace,
+          }
         );
 
         if (!completeResult.ok) {

--- a/apps/canvas-workspace/src/renderer/src/components/debug/AgentDebugPage.css
+++ b/apps/canvas-workspace/src/renderer/src/components/debug/AgentDebugPage.css
@@ -1,0 +1,470 @@
+.agent-debug-page {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 360px minmax(0, 1fr);
+  background: #fbfaf8;
+  color: #37352f;
+  overflow: hidden;
+}
+
+.agent-debug-rail {
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid rgba(55, 53, 47, 0.08);
+  background: #f7f6f2;
+}
+
+.agent-debug-brand {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 22px 18px 16px;
+}
+
+.agent-debug-brand h1,
+.agent-debug-hero h2 {
+  margin: 0;
+  letter-spacing: -0.035em;
+}
+
+.agent-debug-brand h1 {
+  color: #37352f;
+  font-size: 30px;
+  line-height: 1;
+}
+
+.agent-debug-kicker {
+  color: #9b9a97;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.agent-debug-brand button,
+.agent-debug-search button,
+.agent-debug-metric button,
+.agent-debug-back-button,
+.agent-debug-card-title-row button {
+  border: 1px solid rgba(55, 53, 47, 0.1);
+  border-radius: 999px;
+  background: #ffffff;
+  color: #5f5d58;
+  font-size: 11px;
+  font-weight: 700;
+  padding: 7px 10px;
+  cursor: pointer;
+  box-shadow: 0 1px 2px rgba(55, 53, 47, 0.04);
+}
+
+.agent-debug-brand button:hover,
+.agent-debug-search button:hover,
+.agent-debug-metric button:hover,
+.agent-debug-back-button:hover,
+.agent-debug-card-title-row button:hover {
+  background: rgba(55, 53, 47, 0.045);
+  color: #37352f;
+}
+
+.agent-debug-search {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  padding: 0 14px 14px;
+}
+
+.agent-debug-search input {
+  min-width: 0;
+  border: 1px solid rgba(55, 53, 47, 0.1);
+  border-radius: 999px;
+  background: #ffffff;
+  color: #37352f;
+  padding: 9px 12px;
+  outline: none;
+  box-shadow: inset 0 1px 0 rgba(55, 53, 47, 0.025);
+}
+
+.agent-debug-search input::placeholder {
+  color: #b4b4b0;
+}
+
+.agent-debug-search input:focus {
+  border-color: rgba(47, 143, 107, 0.46);
+  box-shadow: 0 0 0 3px rgba(47, 143, 107, 0.1);
+}
+
+.agent-debug-run-groups {
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0 10px 18px;
+}
+
+.agent-debug-run-group {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  margin-bottom: 18px;
+}
+
+.agent-debug-group-title {
+  color: #9b9a97;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  padding: 0 6px;
+  text-transform: uppercase;
+}
+
+.agent-debug-run-item {
+  width: 100%;
+  border: 1px solid rgba(55, 53, 47, 0.08);
+  border-radius: 14px;
+  background: #ffffff;
+  color: #5f5d58;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 11px;
+  text-align: left;
+  cursor: pointer;
+  box-shadow: 0 5px 18px rgba(55, 53, 47, 0.035);
+}
+
+.agent-debug-run-item:hover,
+.agent-debug-run-item--active {
+  border-color: rgba(47, 143, 107, 0.38);
+  background: #f1faf5;
+}
+
+.agent-debug-run-item strong {
+  color: #37352f;
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+.agent-debug-run-item span,
+.agent-debug-run-item code {
+  color: #73726e;
+  font-size: 11px;
+}
+
+.agent-debug-run-time {
+  color: #2f8f6b !important;
+}
+
+.agent-debug-main {
+  min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 26px;
+  background:
+    radial-gradient(circle at top left, rgba(47, 143, 107, 0.08), transparent 28%),
+    #fbfaf8;
+}
+
+.agent-debug-detail {
+  max-width: 1180px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.agent-debug-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 20px;
+  align-items: end;
+  padding: 28px;
+  border: 1px solid rgba(55, 53, 47, 0.08);
+  border-radius: 24px;
+  background: linear-gradient(135deg, #ffffff, #f7f6f2);
+  box-shadow: 0 18px 52px rgba(55, 53, 47, 0.08);
+}
+
+.agent-debug-hero h2 {
+  max-width: 820px;
+  margin-top: 5px;
+  color: #37352f;
+  font-size: 34px;
+  line-height: 1.05;
+}
+
+.agent-debug-hero p {
+  max-width: 800px;
+  margin: 12px 0 0;
+  color: #73726e;
+  line-height: 1.5;
+}
+
+.agent-debug-hero-metrics,
+.agent-debug-card--ids {
+  display: grid;
+  gap: 10px;
+}
+
+.agent-debug-hero-metrics {
+  grid-template-columns: repeat(3, minmax(96px, 1fr));
+}
+
+.agent-debug-card {
+  border: 1px solid rgba(55, 53, 47, 0.08);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.92);
+  padding: 18px;
+  box-shadow: 0 10px 34px rgba(55, 53, 47, 0.045);
+}
+
+.agent-debug-card--ids {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.agent-debug-grid-layout {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.agent-debug-card-title {
+  color: #37352f;
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  margin-bottom: 12px;
+  text-transform: uppercase;
+}
+
+.agent-debug-card-title--small {
+  color: #73726e;
+  font-size: 11px;
+  margin: 12px 0 8px;
+}
+
+.agent-debug-card-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.agent-debug-card-title-row .agent-debug-card-title {
+  margin-bottom: 0;
+}
+
+.agent-debug-metric {
+  min-width: 0;
+  border: 1px solid rgba(55, 53, 47, 0.055);
+  border-radius: 14px;
+  background: #f8f7f4;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.agent-debug-metric span {
+  color: #9b9a97;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.agent-debug-metric code,
+.agent-debug-run-item code,
+.agent-debug-node-card code {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #37352f;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11px;
+}
+
+.agent-debug-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.agent-debug-tags span {
+  border: 1px solid rgba(55, 53, 47, 0.08);
+  border-radius: 999px;
+  background: #f7f6f2;
+  color: #73726e;
+  font-size: 11px;
+  padding: 5px 8px;
+}
+
+.agent-debug-code-block {
+  margin-top: 10px;
+}
+
+.agent-debug-code-block > div {
+  color: #73726e;
+  font-size: 11px;
+  font-weight: 800;
+  margin-bottom: 6px;
+  text-transform: uppercase;
+}
+
+.agent-debug-code-block pre {
+  max-height: 320px;
+  overflow: auto;
+  margin: 0;
+  border: 1px solid rgba(55, 53, 47, 0.07);
+  border-radius: 12px;
+  background: #f7f6f2;
+  color: #37352f;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11px;
+  line-height: 1.55;
+  padding: 13px;
+  white-space: pre-wrap;
+}
+
+.agent-debug-mini-list {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.agent-debug-mini-list span,
+.agent-debug-muted,
+.agent-debug-empty {
+  color: #73726e;
+  font-size: 12px;
+}
+
+.agent-debug-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.agent-debug-tool-row {
+  border: 1px solid rgba(55, 53, 47, 0.075);
+  border-radius: 14px;
+  background: #fbfaf8;
+  padding: 11px;
+}
+
+.agent-debug-tool-row summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.agent-debug-tool-row summary::-webkit-details-marker {
+  display: none;
+}
+
+.agent-debug-tool-row summary strong {
+  color: #37352f;
+  flex: 1;
+}
+
+.agent-debug-tool-row summary span:not(.agent-debug-status) {
+  color: #73726e;
+  font-size: 11px;
+}
+
+.agent-debug-status {
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: #b4b4b0;
+}
+
+.agent-debug-status--done {
+  background: #2f8f6b;
+  box-shadow: 0 0 0 4px rgba(47, 143, 107, 0.12);
+}
+
+.agent-debug-status--error {
+  background: #c25245;
+  box-shadow: 0 0 0 4px rgba(194, 82, 69, 0.12);
+}
+
+.agent-debug-status--running {
+  background: #b88a2d;
+  box-shadow: 0 0 0 4px rgba(184, 138, 45, 0.12);
+}
+
+.agent-debug-node-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 10px;
+}
+
+.agent-debug-node-card {
+  min-width: 0;
+  border: 1px solid rgba(55, 53, 47, 0.075);
+  border-radius: 14px;
+  background: #fbfaf8;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.agent-debug-node-card strong {
+  color: #37352f;
+}
+
+.agent-debug-node-card span {
+  color: #73726e;
+  font-size: 11px;
+}
+
+.agent-debug-empty {
+  padding: 18px;
+}
+
+.agent-debug-empty--main,
+.agent-debug-error {
+  margin: 20px auto;
+  max-width: 620px;
+  border-radius: 18px;
+  background: #ffffff;
+  text-align: center;
+  box-shadow: 0 10px 30px rgba(55, 53, 47, 0.05);
+}
+
+.agent-debug-error {
+  color: #9f3d32;
+  padding: 14px;
+  border: 1px solid rgba(194, 82, 69, 0.18);
+  background: #fff4f2;
+}
+
+.agent-debug-back-button {
+  width: fit-content;
+  margin: 0 0 14px;
+}
+
+@media (max-width: 980px) {
+  .agent-debug-page {
+    grid-template-columns: 1fr;
+  }
+
+  .agent-debug-rail {
+    max-height: 40vh;
+    border-right: none;
+    border-bottom: 1px solid rgba(55, 53, 47, 0.08);
+  }
+
+  .agent-debug-hero,
+  .agent-debug-card--ids,
+  .agent-debug-grid-layout {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/canvas-workspace/src/renderer/src/components/debug/AgentDebugPage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/debug/AgentDebugPage.tsx
@@ -1,0 +1,312 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { AgentDebugRunDetail, AgentDebugRunSummary, AgentDebugTrace } from '../../types';
+import './AgentDebugPage.css';
+
+interface AgentDebugPageProps {
+  selectedSessionId?: string | null;
+  selectedRunId?: string | null;
+  onSelectRun: (sessionId: string, runId: string) => void;
+  onBackToCanvas: () => void;
+}
+
+const shortId = (value: string, length = 8) => value.length <= length ? value : value.slice(0, length);
+const formatDuration = (durationMs?: number) => durationMs == null ? '—' : durationMs < 1000 ? `${durationMs}ms` : `${(durationMs / 1000).toFixed(1)}s`;
+const formatDateTime = (timestamp?: number) => timestamp ? new Date(timestamp).toLocaleString() : '—';
+
+export const AgentDebugPage = ({
+  selectedSessionId,
+  selectedRunId,
+  onSelectRun,
+  onBackToCanvas,
+}: AgentDebugPageProps) => {
+  const [runs, setRuns] = useState<AgentDebugRunSummary[]>([]);
+  const [detail, setDetail] = useState<AgentDebugRunDetail | null>(null);
+  const [loadingRuns, setLoadingRuns] = useState(true);
+  const [loadingDetail, setLoadingDetail] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+
+  const loadRuns = useCallback(async () => {
+    setLoadingRuns(true);
+    setError(null);
+    try {
+      const result = await window.canvasWorkspace.agent.listDebugRuns();
+      if (!result.ok) throw new Error(result.error ?? 'Failed to load debug runs');
+      setRuns(result.runs ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoadingRuns(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadRuns();
+  }, [loadRuns]);
+
+  useEffect(() => {
+    const firstRun = runs[0];
+    if (!selectedSessionId && !selectedRunId && firstRun) {
+      onSelectRun(firstRun.sessionId, firstRun.runId);
+    }
+  }, [onSelectRun, runs, selectedRunId, selectedSessionId]);
+
+  useEffect(() => {
+    if (!selectedSessionId || !selectedRunId) {
+      setDetail(null);
+      return;
+    }
+
+    let canceled = false;
+    setLoadingDetail(true);
+    setError(null);
+    void window.canvasWorkspace.agent.getDebugRun(selectedSessionId, selectedRunId)
+      .then(result => {
+        if (canceled) return;
+        if (!result.ok || !result.run) throw new Error(result.error ?? 'Debug run not found');
+        setDetail(result.run);
+      })
+      .catch(err => {
+        if (!canceled) {
+          setDetail(null);
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      })
+      .finally(() => {
+        if (!canceled) setLoadingDetail(false);
+      });
+
+    return () => {
+      canceled = true;
+    };
+  }, [selectedRunId, selectedSessionId]);
+
+  const filteredRuns = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return runs;
+    return runs.filter(run => [
+      run.workspaceName,
+      run.workspaceId,
+      run.sessionId,
+      run.runId,
+      run.userPromptPreview,
+      run.assistantPreview,
+      run.modelLabel,
+    ].some(value => value?.toLowerCase().includes(needle)));
+  }, [query, runs]);
+
+  const runGroups = useMemo(() => {
+    const groups = new Map<string, AgentDebugRunSummary[]>();
+    for (const run of filteredRuns) {
+      const key = `${run.workspaceName} · ${shortId(run.sessionId, 10)}`;
+      groups.set(key, [...(groups.get(key) ?? []), run]);
+    }
+    return Array.from(groups.entries());
+  }, [filteredRuns]);
+
+  return (
+    <div className="agent-debug-page">
+      <aside className="agent-debug-rail">
+        <div className="agent-debug-brand">
+          <div>
+            <div className="agent-debug-kicker">Canvas Agent</div>
+            <h1>DevTools</h1>
+          </div>
+          <button type="button" onClick={onBackToCanvas}>← Back</button>
+        </div>
+
+        <div className="agent-debug-search">
+          <input
+            value={query}
+            onChange={event => setQuery(event.target.value)}
+            placeholder="Search session, run, prompt..."
+          />
+          <button type="button" onClick={() => void loadRuns()}>Refresh</button>
+        </div>
+
+        {loadingRuns ? (
+          <div className="agent-debug-empty">Loading debug runs...</div>
+        ) : runGroups.length === 0 ? (
+          <div className="agent-debug-empty">No dev traces yet. Start Canvas in dev mode and run a chat turn.</div>
+        ) : (
+          <div className="agent-debug-run-groups">
+            {runGroups.map(([groupName, groupRuns]) => (
+              <section key={groupName} className="agent-debug-run-group">
+                <div className="agent-debug-group-title">{groupName}</div>
+                {groupRuns.map(run => {
+                  const active = run.sessionId === selectedSessionId && run.runId === selectedRunId;
+                  return (
+                    <button
+                      key={`${run.sessionId}:${run.runId}`}
+                      type="button"
+                      className={`agent-debug-run-item${active ? ' agent-debug-run-item--active' : ''}`}
+                      onClick={() => onSelectRun(run.sessionId, run.runId)}
+                    >
+                      <span className="agent-debug-run-time">{formatDateTime(run.startedAt)}</span>
+                      <strong>{run.userPromptPreview || '(empty prompt)'}</strong>
+                      <span>{run.toolCount} tools · {run.readNodeCount} reads · {formatDuration(run.durationMs)}</span>
+                      <code>run {shortId(run.runId)}</code>
+                    </button>
+                  );
+                })}
+              </section>
+            ))}
+          </div>
+        )}
+      </aside>
+
+      <main className="agent-debug-main">
+        {error && <div className="agent-debug-error">{error}</div>}
+        {loadingDetail ? (
+          <div className="agent-debug-empty agent-debug-empty--main">Loading run detail...</div>
+        ) : detail ? (
+          <RunDetail detail={detail} onBackToCanvas={onBackToCanvas} />
+        ) : (
+          <div className="agent-debug-empty agent-debug-empty--main">Select a run to inspect session/run level traces.</div>
+        )}
+      </main>
+    </div>
+  );
+};
+
+const RunDetail = ({ detail, onBackToCanvas }: { detail: AgentDebugRunDetail; onBackToCanvas: () => void }) => {
+  const trace = detail.trace;
+  return (
+    <div className="agent-debug-detail">
+      <header className="agent-debug-hero">
+        <div>
+          <button type="button" className="agent-debug-back-button" onClick={onBackToCanvas}>← Back to Canvas</button>
+          <div className="agent-debug-kicker">{detail.workspaceName}</div>
+          <h2>{detail.userPromptPreview || 'Untitled run'}</h2>
+          <p>{detail.assistantPreview}</p>
+        </div>
+        <div className="agent-debug-hero-metrics">
+          <Metric label="Duration" value={formatDuration(trace.durationMs)} />
+          <Metric label="Tools" value={String(trace.toolCalls.length)} />
+          <Metric label="Read Nodes" value={String(trace.readNodes.length)} />
+        </div>
+      </header>
+
+      <section className="agent-debug-card agent-debug-card--ids">
+        <Metric label="Session ID" value={trace.sessionId} copy />
+        <Metric label="Run ID" value={trace.runId} copy />
+        <Metric label="Turn ID" value={trace.turnId} copy />
+        <Metric label="Started" value={formatDateTime(trace.startedAt)} />
+        <Metric label="Model" value={[trace.model?.provider, trace.model?.model].filter(Boolean).join(' / ') || '—'} />
+        <Metric label="Scope" value={trace.request.scope ?? 'current_canvas'} />
+      </section>
+
+      <section className="agent-debug-grid-layout">
+        <ContextCard trace={trace} />
+        <PromptCard trace={trace} />
+      </section>
+
+      <section className="agent-debug-card">
+        <div className="agent-debug-card-title">Tool Timeline</div>
+        {trace.toolCalls.length === 0 ? (
+          <div className="agent-debug-muted">No tools recorded.</div>
+        ) : (
+          <div className="agent-debug-timeline">
+            {trace.toolCalls.map((tool, index) => (
+              <details key={`${tool.toolCallId ?? tool.name}-${index}`} className="agent-debug-tool-row">
+                <summary>
+                  <span className={`agent-debug-status agent-debug-status--${tool.status}`} />
+                  <strong>{tool.name}</strong>
+                  <span>{formatDuration(tool.durationMs)}</span>
+                  {tool.readNodes?.length ? <span>{tool.readNodes.length} nodes</span> : null}
+                </summary>
+                {tool.argsPreview && <CodeBlock title="Args" value={tool.argsPreview} />}
+                {tool.resultSummary && <CodeBlock title="Result" value={tool.resultSummary} />}
+              </details>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="agent-debug-card">
+        <div className="agent-debug-card-title">Read Nodes</div>
+        {trace.readNodes.length === 0 ? (
+          <div className="agent-debug-muted">No node reads recorded.</div>
+        ) : (
+          <div className="agent-debug-node-grid">
+            {trace.readNodes.map((node, index) => (
+              <div key={`${node.workspaceId ?? ''}-${node.id}-${node.source ?? ''}-${index}`} className="agent-debug-node-card">
+                <strong>{node.title}</strong>
+                <span>{node.type} · {node.source}</span>
+                <code>{node.id}</code>
+                {node.contentChars != null && <span>{node.contentChars.toLocaleString()} chars</span>}
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+};
+
+const ContextCard = ({ trace }: { trace: AgentDebugTrace }) => (
+  <section className="agent-debug-card">
+    <div className="agent-debug-card-title">Request Context</div>
+    <div className="agent-debug-tags">
+      <span>mode: {trace.request.executionMode ?? 'auto'}</span>
+      <span>scope: {trace.request.scope ?? 'current_canvas'}</span>
+      <span>attachments: {trace.request.attachmentCount}</span>
+      {trace.request.workspace && <span>{trace.request.workspace.nodeCount} canvas nodes</span>}
+    </div>
+    <CodeBlock title="User prompt" value={trace.request.userPromptPreview} />
+    {trace.request.selectedNodes.length > 0 && (
+      <div className="agent-debug-mini-list">
+        <div className="agent-debug-card-title agent-debug-card-title--small">Selected Nodes</div>
+        {trace.request.selectedNodes.map(node => <span key={node.id}>{node.title} · {node.type}</span>)}
+      </div>
+    )}
+  </section>
+);
+
+const PromptCard = ({ trace }: { trace: AgentDebugTrace }) => {
+  const [expanded, setExpanded] = useState(false);
+  const snapshot = trace.messageSnapshot;
+  return (
+    <section className="agent-debug-card">
+      <div className="agent-debug-card-title-row">
+        <div className="agent-debug-card-title">Prompt Snapshot</div>
+        <button type="button" onClick={() => setExpanded(value => !value)}>
+          {expanded ? 'Collapse' : 'Expand'}
+        </button>
+      </div>
+      <div className="agent-debug-tags">
+        <span>system {trace.prompt.systemPromptChars.toLocaleString()} chars</span>
+        {trace.prompt.currentCanvasSummaryChars != null && (
+          <span>canvas summary {trace.prompt.currentCanvasSummaryChars.toLocaleString()} chars</span>
+        )}
+        {snapshot && <span>{snapshot.messageCount} messages</span>}
+        {(trace.truncated || snapshot?.truncated) && <span>snapshot truncated</span>}
+      </div>
+      {expanded && snapshot ? (
+        <>
+          <CodeBlock title={`System prompt snapshot · ${snapshot.systemPromptChars.toLocaleString()} chars`} value={snapshot.systemPrompt} />
+          <CodeBlock title={`Messages snapshot · ${snapshot.messagesChars.toLocaleString()} chars`} value={snapshot.messagesJson} />
+        </>
+      ) : (
+        <CodeBlock title="System prompt preview" value={trace.prompt.systemPromptPreview} />
+      )}
+    </section>
+  );
+};
+
+const Metric = ({ label, value, copy }: { label: string; value: string; copy?: boolean }) => (
+  <div className="agent-debug-metric">
+    <span>{label}</span>
+    <code>{value}</code>
+    {copy && (
+      <button type="button" onClick={() => void navigator.clipboard?.writeText(value)}>copy</button>
+    )}
+  </div>
+);
+
+const CodeBlock = ({ title, value }: { title: string; value?: string }) => (
+  <div className="agent-debug-code-block">
+    <div>{title}</div>
+    <pre>{value || '—'}</pre>
+  </div>
+);

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -350,12 +350,118 @@ export interface AgentChatToolCall {
   streamedDone?: boolean;
 }
 
+export interface AgentDebugTraceNodeRef {
+  id: string;
+  title: string;
+  type: string;
+  workspaceId?: string;
+  workspaceName?: string;
+  contentChars?: number;
+  source?: 'selected' | 'read_node' | 'read_context';
+}
+
+export interface AgentDebugTraceContextRead {
+  workspaceId?: string;
+  workspaceName?: string;
+  detail?: string;
+  nodeCount?: number;
+  resultChars?: number;
+}
+
+export interface AgentDebugTraceToolCall {
+  name: string;
+  toolCallId?: string;
+  status: 'running' | 'done' | 'error';
+  argsPreview?: string;
+  resultSummary?: string;
+  startedAt?: number;
+  finishedAt?: number;
+  durationMs?: number;
+  readNodes?: AgentDebugTraceNodeRef[];
+  contextRead?: AgentDebugTraceContextRead;
+}
+
+export interface AgentDebugTraceMessageSnapshot {
+  systemPrompt: string;
+  systemPromptChars: number;
+  messagesJson: string;
+  messagesChars: number;
+  messageCount: number;
+  limitChars: number;
+  truncated?: boolean;
+}
+
+export interface AgentDebugTrace {
+  sessionId: string;
+  runId: string;
+  turnId: string;
+  createdAt: number;
+  startedAt: number;
+  finishedAt?: number;
+  durationMs?: number;
+  debugUrl?: string;
+  request: {
+    userPromptPreview: string;
+    attachmentCount: number;
+    executionMode?: 'auto' | 'ask';
+    scope?: 'current_canvas' | 'selected_nodes';
+    quickAction?: string;
+    selectedNodes: AgentDebugTraceNodeRef[];
+    mentionedCanvases: Array<{ id: string; name: string }>;
+    workspace?: {
+      id: string;
+      name: string;
+      nodeCount: number;
+    };
+  };
+  prompt: {
+    systemPromptPreview: string;
+    systemPromptChars: number;
+    currentCanvasSummaryPreview?: string;
+    currentCanvasSummaryChars?: number;
+  };
+  messageSnapshot?: AgentDebugTraceMessageSnapshot;
+  model?: {
+    provider?: string;
+    model?: string;
+    modelType?: string;
+  };
+  toolCalls: AgentDebugTraceToolCall[];
+  readNodes: AgentDebugTraceNodeRef[];
+  contextReads: AgentDebugTraceContextRead[];
+  truncated?: boolean;
+}
+
+export interface AgentDebugRunSummary {
+  workspaceId: string;
+  workspaceName: string;
+  sessionId: string;
+  runId: string;
+  turnId: string;
+  messageIndex: number;
+  startedAt: number;
+  durationMs?: number;
+  userPromptPreview: string;
+  assistantPreview: string;
+  toolCount: number;
+  readNodeCount: number;
+  modelLabel?: string;
+  isCurrent: boolean;
+}
+
+export interface AgentDebugRunDetail extends AgentDebugRunSummary {
+  userMessage?: AgentChatMessage;
+  assistantMessage: AgentChatMessage;
+  trace: AgentDebugTrace;
+}
+
 export interface AgentChatMessage {
   role: 'user' | 'assistant';
   content: string;
   timestamp: number;
   attachments?: ChatImageAttachment[];
   toolCalls?: AgentChatToolCall[];
+  debugTrace?: AgentDebugTrace;
 }
 
 export interface AgentContextNodeRef {
@@ -501,7 +607,7 @@ export interface AgentApi {
   ) => () => void;
   onChatComplete: (
     sessionId: string,
-    callback: (result: { ok: boolean; response?: string; error?: string }) => void
+    callback: (result: { ok: boolean; response?: string; debugTrace?: AgentDebugTrace; error?: string }) => void
   ) => () => void;
   onToolCall: (
     sessionId: string,
@@ -574,6 +680,11 @@ export interface AgentApi {
     sourceWorkspaceId: string,
     sessionId: string,
   ) => Promise<{ ok: boolean; messages?: AgentChatMessage[]; error?: string }>;
+  listDebugRuns: () => Promise<{ ok: boolean; runs?: AgentDebugRunSummary[]; error?: string }>;
+  getDebugRun: (
+    sessionId: string,
+    runId: string,
+  ) => Promise<{ ok: boolean; run?: AgentDebugRunDetail; error?: string }>;
   activate: (workspaceId: string) => Promise<{ ok: boolean; error?: string }>;
   deactivate: (workspaceId: string) => Promise<{ ok: boolean; error?: string }>;
   addImageToCanvas: (


### PR DESCRIPTION
## Summary

- Capture dev-only Canvas Agent debug traces per session/run turn
- Show inline chat Debug Trace cards with links to run details
- Add standalone Canvas Agent DevTools view at `#/debug` with run list/detail inspection
- Match DevTools styling to the existing light Canvas/Chat UI
- Keep the Canvas Workbench mounted while opening DevTools to avoid canvas reloads on return
- Add explicit back navigation and expandable Prompt Snapshot panels
- Persist bounded final message snapshots, including system prompt, for each run
- Add IPC/session APIs for debug run list and detail lookup

## Storage Notes

- Debug traces are dev-only by default and can be disabled with `CANVAS_AGENT_DEBUG_TRACE=0`
- Message snapshots are capped to avoid unbounded session growth
- System prompt snapshot is capped separately from the message snapshot

## Validation

- `pnpm --filter canvas-workspace typecheck`

Closes #457
