### PR TITLE
fix: preserve ACP session ids

### DIFF
--- a/apps/remote-server/src/core/chat-commands/handlers/acp-commands.ts
+++ b/apps/remote-server/src/core/chat-commands/handlers/acp-commands.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs';
 import { resolve as resolvePath } from 'path';
-import { getAcpState, setAcpState, clearAcpState, updateAcpCwd } from 'pulse-coder-acp';
+import { buildAcpEnableState, getAcpState, setAcpState, clearAcpState, updateAcpCwd } from 'pulse-coder-acp';
 import type { AcpAgent } from 'pulse-coder-acp';
 import type { CommandResult } from '../types.js';
 
@@ -65,10 +65,15 @@ export async function handleAcpCommand(platformKey: string, args: string[]): Pro
       cwd = existing?.cwd ?? process.cwd();
     }
 
-    await setAcpState(platformKey, { agent: agentRaw, cwd });
+    const existing = await getAcpState(platformKey);
+    const nextState = buildAcpEnableState(existing, agentRaw, cwd);
+    await setAcpState(platformKey, nextState);
+    const sessionLine = nextState.sessionId
+      ? `\n- session: ${nextState.sessionId} (preserved)`
+      : '\n- session: (新会话)';
     return {
       type: 'handled',
-      message: `✅ ACP 已开启\n- agent: ${agentRaw}\n- cwd: ${cwd}\n下次发消息将由 ${agentRaw} 处理。`,
+      message: `✅ ACP 已开启\n- agent: ${agentRaw}\n- cwd: ${cwd}${sessionLine}\n下次发消息将由 ${agentRaw} 处理。`,
     };
   }
 

--- a/packages/acp/src/index.ts
+++ b/packages/acp/src/index.ts
@@ -22,6 +22,7 @@ export { AcpClient, AcpTimeoutError } from './client.js';
 export { runAcp } from './runner.js';
 export { FileAcpStateStore } from './state-store.js';
 export {
+  buildAcpEnableState,
   getAcpState,
   setAcpState,
   clearAcpState,

--- a/packages/acp/src/runner.test.ts
+++ b/packages/acp/src/runner.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AcpTimeoutError } from './client.js';
 import {
   __testCreatePromptProgressTimeouts,
+  __testIsDefinitiveSessionInvalidError,
   __testResolveTimeoutConfig,
 } from './runner.js';
 
@@ -97,5 +98,19 @@ describe('ACP prompt progress timeouts', () => {
     expect(String(observed.mock.calls[0]?.[0].message)).toContain('hard timed out after 250ms');
 
     timeouts.dispose();
+  });
+});
+
+describe('ACP session invalid error detection', () => {
+  it('does not treat transient transport failures as invalid sessions', () => {
+    expect(__testIsDefinitiveSessionInvalidError(new AcpTimeoutError('ACP call timed out after 1000ms: session/load'))).toBe(false);
+    expect(__testIsDefinitiveSessionInvalidError(new Error('transport error: ECONNRESET'))).toBe(false);
+    expect(__testIsDefinitiveSessionInvalidError(new Error('ACP error -32603: stream disconnected'))).toBe(false);
+  });
+
+  it('detects explicit invalid session failures', () => {
+    expect(__testIsDefinitiveSessionInvalidError(new Error('session not found: abc123'))).toBe(true);
+    expect(__testIsDefinitiveSessionInvalidError(new Error('ACP error 404: conversation not found'))).toBe(true);
+    expect(__testIsDefinitiveSessionInvalidError({ code: -32001, message: 'unknown session' })).toBe(true);
   });
 });

--- a/packages/acp/src/runner.ts
+++ b/packages/acp/src/runner.ts
@@ -151,7 +151,12 @@ export async function runAcp(input: AcpRunnerInput): Promise<AcpRunnerResult> {
         console.warn('[acp/runner] transient error detected, retrying without proxy');
         disableProxy = true;
       }
-      sessionId = undefined;
+      // Preserve the last known session across transient retries. Dropping it
+      // here turns network/timeout blips into permanent context loss.
+      if (isDefinitiveSessionInvalidError(err)) {
+        console.warn('[acp/runner] session invalid during retry, starting fresh on next attempt');
+        sessionId = undefined;
+      }
       const delayMs = retryConfig.baseDelayMs * Math.max(1, attempt + 1);
       if (delayMs > 0) {
         await sleep(delayMs);
@@ -210,8 +215,13 @@ async function runAcpOnce(input: AcpRunnerInput, callbacks?: AcpRunnerCallbacks)
           mcpServers: [],
         }, timeouts.sessionMs);
       } catch (err) {
-        console.warn('[acp/runner] session/load failed, starting fresh:', err);
-        sessionId = undefined;
+        if (isDefinitiveSessionInvalidError(err)) {
+          console.warn('[acp/runner] session/load found invalid saved session, starting fresh:', err);
+          sessionId = undefined;
+        } else {
+          console.warn('[acp/runner] session/load failed transiently, preserving saved session:', err);
+          throw err;
+        }
       }
     }
 
@@ -221,6 +231,7 @@ async function runAcpOnce(input: AcpRunnerInput, callbacks?: AcpRunnerCallbacks)
         mcpServers: [],
       }, timeouts.sessionMs);
       sessionId = newSession.sessionId;
+      console.warn('[acp/runner] started new ACP session:', sessionId);
     }
 
     const textChunks: string[] = [];
@@ -394,6 +405,10 @@ export function __testCreatePromptProgressTimeouts(input: {
   return createPromptProgressTimeouts(input);
 }
 
+export function __testIsDefinitiveSessionInvalidError(err: unknown): boolean {
+  return isDefinitiveSessionInvalidError(err);
+}
+
 function wrapCallbacks(
   callbacks: AcpRunnerCallbacks | undefined,
   markOutput: () => void,
@@ -459,6 +474,19 @@ function isTransientAcpError(err: unknown): boolean {
     || combined.includes('network error')
     || combined.includes('econnreset')
     || combined.includes('und_err_connect_timeout');
+}
+
+function isDefinitiveSessionInvalidError(err: unknown): boolean {
+  const code = extractAcpErrorCode(err);
+  const message = typeof (err as { message?: unknown })?.message === 'string'
+    ? String((err as { message?: unknown }).message)
+    : '';
+  const details = extractAcpErrorDetails(err) ?? '';
+  const combined = `${message} ${details}`.toLowerCase();
+
+  if (code === -32001 || code === 404) return true;
+  return /\b(no such|not found|unknown|invalid|expired)\b[^.\n]*(session|conversation)/.test(combined)
+    || /\b(session|conversation)\b[^.\n]*\b(no such|not found|unknown|invalid|expired)\b/.test(combined);
 }
 
 function extractAcpErrorCode(err: unknown): number | null {

--- a/packages/acp/src/state-store.ts
+++ b/packages/acp/src/state-store.ts
@@ -63,6 +63,8 @@ export class FileAcpStateStore implements AcpStateStore {
     if (data[platformKey]) {
       data[platformKey]!.sessionId = sessionId;
       await writeAll(this.statePath, data);
+    } else {
+      console.warn(`[acp/state] skip saveSessionId because ACP state is missing for ${platformKey}`);
     }
   }
 }

--- a/packages/acp/src/state.test.ts
+++ b/packages/acp/src/state.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { buildAcpEnableState } from './state.js';
+
+const CWD = '/repo';
+
+describe('buildAcpEnableState', () => {
+  it('preserves sessionId when agent and cwd are unchanged', () => {
+    expect(buildAcpEnableState({
+      agent: 'codex',
+      cwd: CWD,
+      sessionId: 'session-1',
+    }, 'codex', CWD)).toEqual({
+      agent: 'codex',
+      cwd: CWD,
+      sessionId: 'session-1',
+    });
+  });
+
+  it('resets sessionId when agent changes', () => {
+    expect(buildAcpEnableState({
+      agent: 'claude',
+      cwd: CWD,
+      sessionId: 'session-1',
+    }, 'codex', CWD)).toEqual({
+      agent: 'codex',
+      cwd: CWD,
+      sessionId: undefined,
+    });
+  });
+
+  it('resets sessionId when cwd changes', () => {
+    expect(buildAcpEnableState({
+      agent: 'codex',
+      cwd: '/old-repo',
+      sessionId: 'session-1',
+    }, 'codex', CWD)).toEqual({
+      agent: 'codex',
+      cwd: CWD,
+      sessionId: undefined,
+    });
+  });
+});

--- a/packages/acp/src/state.ts
+++ b/packages/acp/src/state.ts
@@ -1,7 +1,20 @@
-import type { AcpChannelState } from './types.js';
+import type { AcpAgent, AcpChannelState } from './types.js';
 import { FileAcpStateStore } from './state-store.js';
 
 const defaultStateStore = new FileAcpStateStore();
+
+export function buildAcpEnableState(
+  existing: AcpChannelState | undefined,
+  agent: AcpAgent,
+  cwd: string,
+): AcpChannelState {
+  const shouldPreserveSession = existing?.agent === agent && existing.cwd === cwd;
+  return {
+    agent,
+    cwd,
+    sessionId: shouldPreserveSession ? existing.sessionId : undefined,
+  };
+}
 
 export function getAcpState(platformKey: string) {
   return defaultStateStore.getState(platformKey);

--- a/packages/cli/src/acp-commands.ts
+++ b/packages/cli/src/acp-commands.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs';
 import { resolve as resolvePath } from 'path';
-import { clearAcpState, getAcpState, setAcpState, updateAcpCwd } from 'pulse-coder-acp';
+import { buildAcpEnableState, clearAcpState, getAcpState, setAcpState, updateAcpCwd } from 'pulse-coder-acp';
 import type { AcpAgent } from 'pulse-coder-acp';
 
 const DEFAULT_ACP_USER = 'local';
@@ -64,8 +64,13 @@ export async function handleAcpCommand(platformKey: string, args: string[]): Pro
       cwd = existing?.cwd ?? process.cwd();
     }
 
-    await setAcpState(platformKey, { agent: agentRaw, cwd });
-    return `✅ ACP 已开启\n- agent: ${agentRaw}\n- cwd: ${cwd}\n下次发消息将由 ${agentRaw} 处理。`;
+    const existing = await getAcpState(platformKey);
+    const nextState = buildAcpEnableState(existing, agentRaw, cwd);
+    await setAcpState(platformKey, nextState);
+    const sessionLine = nextState.sessionId
+      ? `\n- session: ${nextState.sessionId} (preserved)`
+      : '\n- session: (新会话)';
+    return `✅ ACP 已开启\n- agent: ${agentRaw}\n- cwd: ${cwd}${sessionLine}\n下次发消息将由 ${agentRaw} 处理。`;
   }
 
   if (sub === 'off') {


### PR DESCRIPTION
Preserve ACP session IDs across common lifecycle operations to reduce accidental context loss.

- Keep the existing sessionId when `/acp on` is re-run with the same agent and cwd
- Preserve sessionId across transient retry/load failures, only resetting on explicit invalid-session errors
- Add logs for new sessions and skipped sessionId saves
- Cover session preservation and invalid-session detection with tests

Validation:
- `pnpm --filter pulse-coder-acp test`
- `pnpm --filter pulse-coder-acp build`
- `pnpm --filter @pulse-coder/remote-server build`
