### PR TITLE
Make DevTools opening conditional via environment variable

### DIFF
--- a/apps/canvas-workspace/src/main/index.ts
+++ b/apps/canvas-workspace/src/main/index.ts
@@ -118,7 +118,9 @@ const createWindow = () => {
   if (process.env.ELECTRON_RENDERER_URL) {
     void writeLog("main", "loadURL", process.env.ELECTRON_RENDERER_URL);
     win.loadURL(process.env.ELECTRON_RENDERER_URL);
-    win.webContents.openDevTools({ mode: "detach" });
+    if (process.env.OPEN_DEVTOOLS === "1") {
+      win.webContents.openDevTools({ mode: "detach" });
+    }
   } else {
     const filePath = join(currentDir, "../renderer/index.html");
     void writeLog("main", "loadFile", filePath);


### PR DESCRIPTION
## Summary
Make the automatic opening of DevTools in the canvas-workspace app conditional based on an environment variable, rather than always opening them during development.

## Changes
- Wrapped the `win.webContents.openDevTools()` call in a conditional check for `process.env.OPEN_DEVTOOLS === "1"`
- DevTools will now only open automatically when the `OPEN_DEVTOOLS` environment variable is explicitly set to `"1"`
- This allows developers to control whether DevTools should be opened on app startup without modifying code

## Implementation Details
The change is minimal and non-breaking:
- Existing behavior is preserved when `OPEN_DEVTOOLS=1` is set
- By default (when the variable is not set or has a different value), DevTools will not open automatically
- This is useful for cleaner development workflows or when running the app in CI/testing environments

https://claude.ai/code/session_01ME5MiuT8nwqRZjVSsQdQV3