### PR TITLE
Replace file:// URLs with custom pulse-canvas:// scheme for local assets

### DIFF
--- a/apps/canvas-workspace/src/main/index.ts
+++ b/apps/canvas-workspace/src/main/index.ts
@@ -1,7 +1,7 @@
-import { app, BrowserWindow, ipcMain, shell } from "electron";
+import { app, BrowserWindow, ipcMain, net, protocol, shell } from "electron";
 import { existsSync, promises as fs } from "fs";
-import { dirname, join } from "path";
-import { fileURLToPath } from "url";
+import { dirname, join, normalize, isAbsolute } from "path";
+import { fileURLToPath, pathToFileURL } from "url";
 import { setupPtyIpc, killAllPty } from "./pty-manager";
 import { setupCanvasStoreIpc, teardownCanvasWatchers } from "./canvas-store";
 import { setupFileManagerIpc } from "./file-manager";
@@ -38,6 +38,27 @@ const resolvedIconPath = iconCandidates.find((p) => p && existsSync(p));
 const logDir = join(app.getPath("userData"), "logs");
 const logFile = join(logDir, "app.log");
 
+// Custom scheme for serving local image/file assets to the renderer.
+// Chromium blocks `file://` URLs in renderer-loaded pages for security
+// reasons, so any <img src="file://…"> from disk fails to load. We expose
+// the same bytes under `pulse-canvas://local/<absolute-path>` so the
+// renderer can reference local files without disabling webSecurity.
+//
+// This MUST run before `app.whenReady()` — privileged scheme registration
+// is only effective during app startup.
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: "pulse-canvas",
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
+      stream: true,
+      bypassCSP: true,
+    },
+  },
+]);
+
 const writeLog = async (level: string, message: string, details?: string) => {
   const timestamp = new Date().toISOString();
   const line = details
@@ -50,6 +71,40 @@ const writeLog = async (level: string, message: string, details?: string) => {
   } catch (error) {
     console.error("Failed to write log", error);
   }
+};
+
+const registerPulseCanvasProtocol = () => {
+  protocol.handle("pulse-canvas", async (request) => {
+    try {
+      const url = new URL(request.url);
+      if (url.hostname !== "local") {
+        return new Response("Unsupported host", { status: 400 });
+      }
+      // pathname is like "/Users/foo/.pulse-coder/canvas/ws-x/images/img.png"
+      // — percent-decode each segment, then join with the platform separator.
+      const segments = url.pathname.split("/").map((s) => {
+        try {
+          return decodeURIComponent(s);
+        } catch {
+          return s;
+        }
+      });
+      const joined = segments.join("/");
+      const normalized = normalize(joined);
+      if (!isAbsolute(normalized)) {
+        return new Response("Path must be absolute", { status: 400 });
+      }
+      // Reject path traversal attempts after normalization.
+      if (normalized.includes("..")) {
+        return new Response("Forbidden", { status: 403 });
+      }
+      // Defer existence checks to fetch — it returns the right status code.
+      return net.fetch(pathToFileURL(normalized).toString());
+    } catch (error) {
+      void writeLog("protocol", "pulse-canvas handler failed", String(error));
+      return new Response("Internal error", { status: 500 });
+    }
+  });
 };
 
 const createWindow = () => {
@@ -127,6 +182,8 @@ const createWindow = () => {
 };
 
 app.whenReady().then(() => {
+  registerPulseCanvasProtocol();
+
   // Set the macOS dock icon in dev/preview (packaged builds use the .icns
   // from electron-builder, so this is a no-op there).
   if (process.platform === "darwin" && resolvedIconPath && app.dock) {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
@@ -98,7 +98,7 @@ export const ChatMessage = ({
               if (!image?.outputPath) return null;
               return (
                 <figure key={`generated-${tool.id}`} className="chat-generated-image-card">
-                  <img src={`file://${image.outputPath}`} alt={image.title ?? 'Generated image'} />
+                  <img src={toFileUrl(image.outputPath)} alt={image.title ?? 'Generated image'} />
                   <figcaption>
                     <span>{image.title ?? 'Generated image'}</span>
                     <button

--- a/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts
@@ -51,14 +51,15 @@ const EmptyLinePreservingParagraph = Paragraph.extend({
   },
 });
 
-const FILE_IMAGE_MARKDOWN_RE = /!\[([^\]]*)\]\((file:\/\/[^\s)]+)(?:\s+"([^"]*)")?\)/g;
+const FILE_IMAGE_MARKDOWN_RE = /!\[([^\]]*)\]\(((?:file:\/\/|pulse-canvas:\/\/)[^\s)]+)(?:\s+"([^"]*)")?\)/g;
+const LOCAL_IMAGE_HINT_RE = /\]\((?:file:\/\/|pulse-canvas:\/\/)/;
 
 const restoreLocalImageMarkdown = (element: HTMLElement) => {
   const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
   const textNodes: Text[] = [];
   while (walker.nextNode()) {
     const node = walker.currentNode;
-    if (node.textContent?.includes('![') && node.textContent.includes('](file://')) {
+    if (node.textContent?.includes('![') && LOCAL_IMAGE_HINT_RE.test(node.textContent)) {
       textNodes.push(node as Text);
     }
   }
@@ -78,7 +79,9 @@ const restoreLocalImageMarkdown = (element: HTMLElement) => {
       }
 
       const img = document.createElement('img');
-      img.setAttribute('src', match[2] ?? '');
+      // Legacy notes may contain `file://…` URLs that Chromium refuses to
+      // load; route everything through the custom scheme.
+      img.setAttribute('src', toFileUrl(match[2] ?? ''));
       img.setAttribute('alt', match[1] ?? '');
       if (match[3]) img.setAttribute('title', match[3]);
       fragment.append(img);
@@ -106,14 +109,16 @@ const MarkdownSafeImage = Image.extend({
           state.write(`![${alt}](${src}${title})`);
         },
         parse: {
-          // markdown-it rejects file:// links by default, so reloading a note
-          // with a locally saved pasted image leaves literal ![](...) text.
-          // File nodes intentionally store local canvas images as file URLs.
+          // markdown-it rejects file:// and custom-scheme links by default,
+          // so reloading a note with a locally saved pasted image leaves
+          // literal ![](...) text. File nodes intentionally store local
+          // canvas images as file URLs (`pulse-canvas://` for new content,
+          // legacy `file://` for notes created before the protocol switch).
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           setup(markdownit: any) {
             const originalValidateLink = markdownit.validateLink.bind(markdownit);
             markdownit.validateLink = (url: string) => {
-              if (/^file:\/\//i.test(url)) return true;
+              if (/^(file|pulse-canvas):\/\//i.test(url)) return true;
               return originalValidateLink(url);
             };
           },

--- a/apps/canvas-workspace/src/renderer/src/utils/fileUrl.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/fileUrl.ts
@@ -1,13 +1,14 @@
-export const toFileUrl = (filePath: string): string => {
-  const value = filePath.trim();
-  if (!value) return '';
-  if (/^file:\/\//i.test(value)) return value;
+// Chromium blocks `file://` URLs loaded from renderer pages, so we serve
+// local image/file bytes through the custom `pulse-canvas://` scheme that
+// the Electron main process registers. See src/main/index.ts.
+const SCHEME = 'pulse-canvas://local';
 
-  const normalized = value.replace(/\\/g, '/');
+const encodeAbsolutePath = (absPath: string): string => {
+  const normalized = absPath.replace(/\\/g, '/');
   const isWindowsDrivePath = /^[a-zA-Z]:\//.test(normalized);
   const withLeadingSlash = normalized.startsWith('/') ? normalized : `/${normalized}`;
 
-  const encodedPath = withLeadingSlash
+  return withLeadingSlash
     .split('/')
     .map((segment, index) => {
       if (isWindowsDrivePath && index === 1 && /^[a-zA-Z]:$/.test(segment)) {
@@ -16,6 +17,26 @@ export const toFileUrl = (filePath: string): string => {
       return encodeURIComponent(segment);
     })
     .join('/');
+};
 
-  return `file://${encodedPath}`;
+export const toFileUrl = (filePath: string): string => {
+  const value = filePath.trim();
+  if (!value) return '';
+  if (value.startsWith(`${SCHEME}/`)) return value;
+
+  // Migrate legacy `file://` URLs persisted in markdown notes or returned
+  // by older tool calls — decode the percent-encoded absolute path and
+  // re-emit it under the custom scheme.
+  if (/^file:\/\//i.test(value)) {
+    const raw = value.slice('file://'.length);
+    let decoded = raw;
+    try {
+      decoded = decodeURI(raw);
+    } catch {
+      // fall through with the raw form
+    }
+    return `${SCHEME}${encodeAbsolutePath(decoded)}`;
+  }
+
+  return `${SCHEME}${encodeAbsolutePath(value)}`;
 };


### PR DESCRIPTION
## Summary
Replaces insecure `file://` URLs with a custom `pulse-canvas://` scheme for serving local image and file assets to the renderer. This addresses Chromium's security restrictions that block `file://` URLs in renderer-loaded pages while maintaining backward compatibility with legacy `file://` URLs in persisted markdown notes.

## Key Changes

- **Main process protocol registration** (`apps/canvas-workspace/src/main/index.ts`):
  - Register `pulse-canvas://` as a privileged scheme before app startup
  - Implement `registerPulseCanvasProtocol()` handler that:
    - Validates requests to `pulse-canvas://local/<absolute-path>`
    - Percent-decodes path segments and normalizes the path
    - Rejects non-absolute paths and path traversal attempts (`..`)
    - Serves files via `net.fetch()` with proper status codes

- **Renderer URL conversion** (`apps/canvas-workspace/src/renderer/src/utils/fileUrl.ts`):
  - Refactor `toFileUrl()` to emit `pulse-canvas://local/` URLs instead of `file://`
  - Add `encodeAbsolutePath()` helper for consistent percent-encoding across Windows and Unix paths
  - Migrate legacy `file://` URLs to the new scheme (handles both persisted markdown and tool outputs)

- **Markdown image handling** (`apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts`):
  - Update regex patterns to accept both `file://` and `pulse-canvas://` schemes
  - Route all image sources through `toFileUrl()` to normalize legacy URLs
  - Update markdown-it validation to accept both schemes

- **Chat message image rendering** (`apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx`):
  - Use `toFileUrl()` for generated image paths instead of hardcoded `file://` prefix

## Implementation Details

- The custom scheme is registered at app startup (before `app.whenReady()`) to ensure Chromium recognizes it as privileged
- Path validation occurs after normalization to prevent traversal attacks
- Backward compatibility is maintained: legacy `file://` URLs in markdown notes are automatically converted to the new scheme
- The scheme supports fetch API and bypasses CSP, allowing images to load in the renderer while maintaining security through path validation

https://claude.ai/code/session_018eiSoiPY68kVZu73CD5iar