### PR TITLE
Prevent node stacking when adding via context menu or toolbar

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasContextMenu.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasContextMenu.ts
@@ -1,5 +1,7 @@
 import { useCallback, useState, type RefObject } from 'react';
 import type { CanvasNode } from '../../../types';
+import { getNodeDefaultSize, NODE_TYPE_LABELS } from '../../../utils/nodeFactory';
+import type { ToastInput } from '../../../types/ui-interaction';
 
 type CreatableNodeType =
   | 'file'
@@ -27,6 +29,12 @@ interface Options {
   ) => { x: number; y: number };
   addNode: (type: CreatableNodeType, x: number, y: number) => CanvasNode;
   setSelectedNodeIds: (ids: string[]) => void;
+  /** Brief flash on the new node so the user can spot it after a
+   *  context-menu/toolbar/palette add. Reuses the existing 1.5s
+   *  `nodeHighlight` animation. */
+  setHighlightedId: (id: string | null) => void;
+  /** Toast surface for the post-add confirmation. */
+  notify: (toast: ToastInput) => string;
 }
 
 /**
@@ -40,8 +48,28 @@ export const useCanvasContextMenu = ({
   screenToCanvas,
   addNode,
   setSelectedNodeIds,
+  setHighlightedId,
+  notify,
 }: Options) => {
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
+
+  /** Shared post-add side effects: select, flash, and toast the new node
+   *  so every entry point (right-click, toolbar, palette, empty-canvas
+   *  hint) gives the same visible confirmation. The placement hint
+   *  varies per entry point — right-click drops at cursor, toolbar
+   *  centers on viewport — so callers pass it in. */
+  const finalizeAddedNode = useCallback(
+    (node: CanvasNode, type: CreatableNodeType, placementHint: string) => {
+      setSelectedNodeIds([node.id]);
+      setHighlightedId(node.id);
+      notify({
+        tone: 'success',
+        title: `${NODE_TYPE_LABELS[type]} added`,
+        description: placementHint,
+      });
+    },
+    [notify, setHighlightedId, setSelectedNodeIds],
+  );
 
   const isBlankCanvasTarget = useCallback((target: EventTarget | null) => {
     if (!(target instanceof HTMLElement)) return false;
@@ -74,41 +102,37 @@ export const useCanvasContextMenu = ({
   const handleCreateNode = useCallback(
     (type: CreatableNodeType) => {
       if (!contextMenu) return;
+      // Right-click drop point becomes the new node's top-left so the
+      // node grows down-right from the cursor — matches typical
+      // "create here" affordances in design tools.
       const node = addNode(type, contextMenu.canvasX, contextMenu.canvasY);
-      setSelectedNodeIds([node.id]);
+      finalizeAddedNode(node, type, 'Placed at the cursor');
       setContextMenu(null);
     },
-    [addNode, contextMenu, setSelectedNodeIds],
+    [addNode, contextMenu, finalizeAddedNode],
   );
 
   const handleToolbarAddNode = useCallback(
     (type: CreatableNodeType) => {
       if (!containerRef.current) return;
+      // Center the new node on the current viewport: project the
+      // container's screen-space midpoint into canvas coordinates, then
+      // offset by half the node's default size so the node — not its
+      // top-left corner — lands at that midpoint. Half-dimensions come
+      // from `getNodeDefaultSize` (the same numbers `createDefaultNode`
+      // will write to `node.width`/`node.height`), keeping the centering
+      // honest as defaults evolve.
       const rect = containerRef.current.getBoundingClientRect();
-      const pos = screenToCanvas(
+      const center = screenToCanvas(
         rect.left + rect.width / 2,
         rect.top + rect.height / 2,
         containerRef.current,
       );
-      const halfW =
-        type === 'file' ? 210
-        : type === 'terminal' ? 240
-        : type === 'agent' ? 260
-        : type === 'text' ? 130
-        : type === 'iframe' ? 260
-        : type === 'mindmap' ? 320
-        : 300;
-      const halfH =
-        type === 'frame' ? 200
-        : type === 'group' ? 120
-        : type === 'text' ? 60
-        : type === 'iframe' ? 200
-        : type === 'mindmap' ? 210
-        : 150;
-      const node = addNode(type, pos.x - halfW, pos.y - halfH);
-      setSelectedNodeIds([node.id]);
+      const { width, height } = getNodeDefaultSize(type);
+      const node = addNode(type, center.x - width / 2, center.y - height / 2);
+      finalizeAddedNode(node, type, 'Centered on the current viewport');
     },
-    [addNode, screenToCanvas, setSelectedNodeIds, containerRef],
+    [addNode, screenToCanvas, finalizeAddedNode, containerRef],
   );
 
   const closeContextMenu = useCallback(() => setContextMenu(null), []);

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasContextMenu.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasContextMenu.ts
@@ -20,6 +20,21 @@ interface ContextMenuState {
   canvasY: number;
 }
 
+/** Diagonal step applied when a proposed slot is already occupied.
+ *  Matches the +24/+24 cascade used by `duplicateNode`/`pasteNodes`
+ *  so consecutive adds and duplicates feel the same. */
+const CASCADE_STEP = 24;
+/** Two nodes whose top-lefts differ by less than this are treated as
+ *  "the same slot". 12 is small enough that intentional partial
+ *  overlap (e.g. dropping a text label onto a frame) is preserved,
+ *  but large enough to catch the "user clicked the same toolbar
+ *  button twice" case where the math would otherwise pixel-stack. */
+const STACK_TOLERANCE = 12;
+/** Upper bound on the cascade walk so we don't loop forever on a
+ *  densely-filled diagonal. After this many tries we give up and let
+ *  the cascaded position stand — still better than perfect overlap. */
+const MAX_CASCADE_STEPS = 16;
+
 interface Options {
   containerRef: RefObject<HTMLDivElement>;
   screenToCanvas: (
@@ -28,6 +43,9 @@ interface Options {
     container: HTMLDivElement,
   ) => { x: number; y: number };
   addNode: (type: CreatableNodeType, x: number, y: number) => CanvasNode;
+  /** Live read of the current node list, used to detect stacked
+   *  positions before placing a new node. */
+  nodesRef: RefObject<CanvasNode[]>;
   setSelectedNodeIds: (ids: string[]) => void;
   /** Brief flash on the new node so the user can spot it after a
    *  context-menu/toolbar/palette add. Reuses the existing 1.5s
@@ -36,6 +54,30 @@ interface Options {
   /** Toast surface for the post-add confirmation. */
   notify: (toast: ToastInput) => string;
 }
+
+/** Walk diagonally from the desired top-left until we find a slot
+ *  whose top-left doesn't sit on top of any existing node within
+ *  `STACK_TOLERANCE` pixels. Returns whether a cascade actually
+ *  happened so callers can adjust their feedback copy. */
+const resolveNonStackingSlot = (
+  existing: readonly CanvasNode[],
+  desiredX: number,
+  desiredY: number,
+): { x: number; y: number; cascaded: boolean } => {
+  let x = desiredX;
+  let y = desiredY;
+  for (let step = 0; step < MAX_CASCADE_STEPS; step += 1) {
+    const collides = existing.some(
+      (n) =>
+        Math.abs(n.x - x) < STACK_TOLERANCE &&
+        Math.abs(n.y - y) < STACK_TOLERANCE,
+    );
+    if (!collides) return { x, y, cascaded: step > 0 };
+    x += CASCADE_STEP;
+    y += CASCADE_STEP;
+  }
+  return { x, y, cascaded: true };
+};
 
 /**
  * Owns the right-click / double-click context menu state plus the
@@ -47,6 +89,7 @@ export const useCanvasContextMenu = ({
   containerRef,
   screenToCanvas,
   addNode,
+  nodesRef,
   setSelectedNodeIds,
   setHighlightedId,
   notify,
@@ -105,11 +148,20 @@ export const useCanvasContextMenu = ({
       // Right-click drop point becomes the new node's top-left so the
       // node grows down-right from the cursor — matches typical
       // "create here" affordances in design tools.
-      const node = addNode(type, contextMenu.canvasX, contextMenu.canvasY);
-      finalizeAddedNode(node, type, 'Placed at the cursor');
+      const slot = resolveNonStackingSlot(
+        nodesRef.current ?? [],
+        contextMenu.canvasX,
+        contextMenu.canvasY,
+      );
+      const node = addNode(type, slot.x, slot.y);
+      finalizeAddedNode(
+        node,
+        type,
+        slot.cascaded ? 'Offset to avoid stacking' : 'Placed at the cursor',
+      );
       setContextMenu(null);
     },
-    [addNode, contextMenu, finalizeAddedNode],
+    [addNode, contextMenu, finalizeAddedNode, nodesRef],
   );
 
   const handleToolbarAddNode = useCallback(
@@ -121,7 +173,8 @@ export const useCanvasContextMenu = ({
       // top-left corner — lands at that midpoint. Half-dimensions come
       // from `getNodeDefaultSize` (the same numbers `createDefaultNode`
       // will write to `node.width`/`node.height`), keeping the centering
-      // honest as defaults evolve.
+      // honest as defaults evolve. The cascade walk after centering
+      // prevents repeat clicks from pixel-stacking new nodes.
       const rect = containerRef.current.getBoundingClientRect();
       const center = screenToCanvas(
         rect.left + rect.width / 2,
@@ -129,10 +182,21 @@ export const useCanvasContextMenu = ({
         containerRef.current,
       );
       const { width, height } = getNodeDefaultSize(type);
-      const node = addNode(type, center.x - width / 2, center.y - height / 2);
-      finalizeAddedNode(node, type, 'Centered on the current viewport');
+      const slot = resolveNonStackingSlot(
+        nodesRef.current ?? [],
+        center.x - width / 2,
+        center.y - height / 2,
+      );
+      const node = addNode(type, slot.x, slot.y);
+      finalizeAddedNode(
+        node,
+        type,
+        slot.cascaded
+          ? 'Offset to avoid stacking'
+          : 'Centered on the current viewport',
+      );
     },
-    [addNode, screenToCanvas, finalizeAddedNode, containerRef],
+    [addNode, screenToCanvas, finalizeAddedNode, containerRef, nodesRef],
   );
 
   const closeContextMenu = useCallback(() => setContextMenu(null), []);

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -127,6 +127,7 @@ export const Canvas = ({
 
   const ctxMenu = useCanvasContextMenu({
     containerRef, screenToCanvas, addNode, setSelectedNodeIds,
+    setHighlightedId, notify,
   });
 
   const actions = useCanvasNodeActions({

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -126,7 +126,7 @@ export const Canvas = ({
   });
 
   const ctxMenu = useCanvasContextMenu({
-    containerRef, screenToCanvas, addNode, setSelectedNodeIds,
+    containerRef, screenToCanvas, addNode, nodesRef, setSelectedNodeIds,
     setHighlightedId, notify,
   });
 

--- a/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
@@ -19,6 +19,32 @@ const NODE_DEFAULTS: Record<CanvasNode['type'], { title: string; width: number; 
   mindmap:  { title: 'Mindmap',  width: 640, height: 420 },
 };
 
+/** Default width/height for a node type — single source of truth so
+ *  callers that need to center a new node on the viewport derive the
+ *  offset from the same numbers `createDefaultNode` will assign. */
+export const getNodeDefaultSize = (
+  type: CanvasNode['type'],
+): { width: number; height: number } => {
+  const def = NODE_DEFAULTS[type];
+  return { width: def.width, height: def.height };
+};
+
+/** Human-readable type names used for toast feedback after adding a
+ *  node. Kept aligned with the FloatingToolbar button labels so the
+ *  user sees the same word in the toolbar tooltip and in the toast. */
+export const NODE_TYPE_LABELS: Record<CanvasNode['type'], string> = {
+  file:     'Note',
+  terminal: 'Terminal',
+  frame:    'Frame',
+  group:    'Group',
+  agent:    'Coding agent',
+  text:     'Text',
+  iframe:   'Web page',
+  image:    'Image',
+  shape:    'Shape',
+  mindmap:  'Mindmap',
+};
+
 export const createNodeData = (type: CanvasNode['type']): FileNodeData | TerminalNodeData | FrameNodeData | GroupNodeData | AgentNodeData | TextNodeData | IframeNodeData | ImageNodeData | ShapeNodeData | MindmapNodeData => {
   switch (type) {
     case 'file':     return { filePath: '', content: '', saved: false, modified: false };


### PR DESCRIPTION
## Summary
Improves the node creation experience by detecting and avoiding stacked node placements. When a user creates a new node via right-click context menu or toolbar button, the system now checks if the proposed position collides with existing nodes and cascades the new node diagonally if needed. This prevents nodes from being placed directly on top of each other, which was particularly problematic when users clicked the same toolbar button multiple times.

## Key Changes

- **Added collision detection and cascading logic** (`resolveNonStackingSlot`):
  - Walks diagonally from the desired position in +24/+24 steps (matching the cascade behavior of duplicate/paste operations)
  - Uses a 12-pixel tolerance to detect "stacked" positions while preserving intentional partial overlaps
  - Limits cascade attempts to 16 steps to avoid infinite loops on densely-filled areas
  - Returns both the resolved position and a flag indicating whether cascading occurred

- **Unified post-add feedback** (`finalizeAddedNode`):
  - Extracted common side effects (selection, highlight flash, toast notification) into a single callback
  - Ensures consistent user feedback across all node creation entry points (right-click, toolbar, palette, etc.)
  - Toast messages vary based on placement: "Placed at the cursor" vs "Centered on the current viewport" vs "Offset to avoid stacking"

- **Updated context menu handler** (`handleCreateNode`):
  - Now resolves non-stacking slot before adding the node
  - Provides appropriate feedback message based on whether cascading occurred

- **Refactored toolbar handler** (`handleToolbarAddNode`):
  - Extracted hardcoded node dimensions into a shared utility (`getNodeDefaultSize`)
  - Centers nodes on the current viewport by offsetting by half the node's default size
  - Applies collision detection to prevent stacking on repeated clicks

- **Extracted node metadata utilities** (`nodeFactory.ts`):
  - `getNodeDefaultSize()`: Single source of truth for node dimensions, used by both node creation and viewport centering
  - `NODE_TYPE_LABELS`: Human-readable type names for toast feedback, kept aligned with toolbar button labels

- **Updated Canvas component**:
  - Passes `nodesRef`, `setHighlightedId`, and `notify` to the context menu hook to enable the new collision detection and feedback features

## Implementation Details

The cascade step of 24 pixels matches the existing behavior in `duplicateNode`/`pasteNodes`, so consecutive adds and duplicates feel consistent. The 12-pixel stack tolerance is small enough to preserve intentional partial overlaps (e.g., dropping a text label onto a frame) but large enough to catch accidental double-clicks. The 16-step limit prevents performance issues on densely-filled canvases while still providing better placement than perfect overlap.

https://claude.ai/code/session_016bkGNi3QYmUpxW5Cs2SwXt