### PR TITLE
feat: update ACP session support

### DIFF
--- a/apps/remote-server/src/core/chat-commands/handlers/acp-commands.ts
+++ b/apps/remote-server/src/core/chat-commands/handlers/acp-commands.ts
@@ -1,10 +1,24 @@
 import { promises as fs } from 'fs';
 import { resolve as resolvePath } from 'path';
-import { buildAcpEnableState, getAcpState, setAcpState, clearAcpState, updateAcpCwd } from 'pulse-coder-acp';
+import {
+  buildAcpEnableState,
+  clearAcpState,
+  closeAcpSession,
+  getAcpState,
+  listAcpSessions,
+  setAcpState,
+  updateAcpCwd,
+} from 'pulse-coder-acp';
 import type { AcpAgent } from 'pulse-coder-acp';
 import type { CommandResult } from '../types.js';
 
 const VALID_AGENTS: AcpAgent[] = ['claude', 'codex'];
+
+const ACP_CLIENT_INFO = {
+  name: 'pulse-remote-server',
+  title: 'Pulse Remote Server',
+  version: '1.0.0',
+};
 
 function isValidAgent(s: string): s is AcpAgent {
   return (VALID_AGENTS as string[]).includes(s);
@@ -83,8 +97,46 @@ export async function handleAcpCommand(platformKey: string, args: string[]): Pro
     if (!existing) {
       return { type: 'handled', message: 'ℹ️ ACP 本来就是关闭状态。' };
     }
+
+    const closeLine = await tryCloseAcpSession(platformKey, existing);
     await clearAcpState(platformKey);
-    return { type: 'handled', message: '✅ ACP 已关闭，恢复使用 pulse-agent。' };
+    return {
+      type: 'handled',
+      message: ['✅ ACP 已关闭，恢复使用 pulse-agent。', closeLine].filter(Boolean).join('\n'),
+    };
+  }
+
+  if (sub === 'sessions') {
+    const state = await getAcpState(platformKey);
+    if (!state) {
+      return { type: 'handled', message: '❌ ACP 未启用，请先 `/acp on <claude|codex>`。' };
+    }
+
+    try {
+      const result = await listAcpSessions({
+        platformKey,
+        agent: state.agent,
+        cwd: state.cwd,
+        sessionId: state.sessionId,
+        clientInfo: ACP_CLIENT_INFO,
+      });
+      if (result.sessions.length === 0) {
+        return { type: 'handled', message: 'ℹ️ 当前 ACP agent 未返回已有 session。' };
+      }
+      const lines = result.sessions.slice(0, 20).map((session) => {
+        const marker = session.sessionId === state.sessionId ? ' *' : '';
+        const title = session.title ? ` — ${session.title}` : '';
+        const updated = session.updatedAt ? ` (${session.updatedAt})` : '';
+        return `- ${session.sessionId}${marker}\n  cwd: ${session.cwd}${title}${updated}`;
+      });
+      const more = result.nextCursor ? '\n… 还有更多 session（当前命令暂未翻页）。' : '';
+      return { type: 'handled', message: `📚 ACP sessions\n${lines.join('\n')}${more}` };
+    } catch (err) {
+      return {
+        type: 'handled',
+        message: `❌ 当前 ACP agent 不支持或无法执行 session/list：${formatError(err)}`,
+      };
+    }
   }
 
   // /acp cd <path>
@@ -115,9 +167,30 @@ export async function handleAcpCommand(platformKey: string, args: string[]): Pro
     message: [
       '⚠️ 未知子命令。ACP 用法：',
       '`/acp on <claude|codex> [cwd]` — 开启 ACP 模式',
-      '`/acp off`                     — 关闭，恢复 pulse-agent',
+      '`/acp off`                     — 关闭，恢复 pulse-agent（支持时关闭 ACP session）',
       '`/acp cd <path>`               — 切换工作目录（重置 session）',
+      '`/acp sessions`                — 列出 agent 已知 session（若支持）',
       '`/acp status`                  — 查看当前状态',
     ].join('\n'),
   };
+}
+
+async function tryCloseAcpSession(platformKey: string, state: { agent: AcpAgent; cwd: string; sessionId?: string }): Promise<string | null> {
+  if (!state.sessionId) return null;
+  try {
+    const closed = await closeAcpSession({
+      platformKey,
+      agent: state.agent,
+      cwd: state.cwd,
+      sessionId: state.sessionId,
+      clientInfo: ACP_CLIENT_INFO,
+    });
+    return closed ? '- ACP session 已通过 session/close 关闭。' : '- ACP agent 未声明 session/close，已仅清除本地状态。';
+  } catch (err) {
+    return `- session/close 执行失败，已仅清除本地状态：${formatError(err)}`;
+  }
+}
+
+function formatError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }

--- a/packages/acp/src/index.ts
+++ b/packages/acp/src/index.ts
@@ -7,10 +7,14 @@ export type {
   AcpRunnerResult,
   AcpClientOptions,
   AcpClientCapabilities,
+  AcpMcpServer,
+  AcpSessionInfo,
   AcpInitializeInput,
   SessionUpdateNotification,
   InitializeResult,
+  ListSessionsResult,
   SessionNewResult,
+  SessionReconnectResult,
   PromptResult,
   PermissionOption,
   PermissionRequest,
@@ -19,7 +23,7 @@ export type {
 } from './types.js';
 
 export { AcpClient, AcpTimeoutError } from './client.js';
-export { runAcp } from './runner.js';
+export { closeAcpSession, listAcpSessions, runAcp } from './runner.js';
 export { FileAcpStateStore } from './state-store.js';
 export {
   buildAcpEnableState,

--- a/packages/acp/src/runner.test.ts
+++ b/packages/acp/src/runner.test.ts
@@ -4,6 +4,10 @@ import {
   __testCreatePromptProgressTimeouts,
   __testIsDefinitiveSessionInvalidError,
   __testResolveTimeoutConfig,
+  __testSelectSessionReconnectMethod,
+  __testSupportsSessionResume,
+  __testSupportsSessionClose,
+  __testSupportsSessionList,
 } from './runner.js';
 
 const ENV_KEYS = [
@@ -112,5 +116,69 @@ describe('ACP session invalid error detection', () => {
     expect(__testIsDefinitiveSessionInvalidError(new Error('session not found: abc123'))).toBe(true);
     expect(__testIsDefinitiveSessionInvalidError(new Error('ACP error 404: conversation not found'))).toBe(true);
     expect(__testIsDefinitiveSessionInvalidError({ code: -32001, message: 'unknown session' })).toBe(true);
+  });
+});
+
+describe('ACP session capability detection', () => {
+  it('prefers latest session/resume capability over legacy loadSession', () => {
+    expect(__testSelectSessionReconnectMethod({
+      protocolVersion: 1,
+      agentCapabilities: {
+        loadSession: true,
+        sessionCapabilities: { resume: {} },
+      },
+      agentInfo: { name: 'agent' },
+    })).toBe('resume');
+  });
+
+  it('falls back to legacy loadSession when resume is not advertised', () => {
+    expect(__testSelectSessionReconnectMethod({
+      protocolVersion: 1,
+      agentCapabilities: { loadSession: true },
+      agentInfo: { name: 'agent' },
+    })).toBe('load');
+  });
+
+  it('does not reconnect when neither resume nor load is advertised', () => {
+    expect(__testSelectSessionReconnectMethod({
+      protocolVersion: 1,
+      agentCapabilities: {},
+      agentInfo: { name: 'agent' },
+    })).toBe('none');
+  });
+
+  it('treats null session capabilities as unsupported', () => {
+    const initResult = {
+      protocolVersion: 1,
+      agentCapabilities: {
+        sessionCapabilities: {
+          resume: null,
+          list: null,
+          close: null,
+        },
+      },
+      agentInfo: { name: 'agent' },
+    };
+
+    expect(__testSelectSessionReconnectMethod(initResult)).toBe('none');
+    expect(__testSupportsSessionResume(initResult)).toBe(false);
+    expect(__testSupportsSessionList(initResult)).toBe(false);
+    expect(__testSupportsSessionClose(initResult)).toBe(false);
+  });
+
+  it('detects latest list and close capabilities', () => {
+    const initResult = {
+      protocolVersion: 1,
+      agentCapabilities: {
+        sessionCapabilities: {
+          list: {},
+          close: {},
+        },
+      },
+      agentInfo: { name: 'agent' },
+    };
+
+    expect(__testSupportsSessionList(initResult)).toBe(true);
+    expect(__testSupportsSessionClose(initResult)).toBe(true);
   });
 });

--- a/packages/acp/src/runner.ts
+++ b/packages/acp/src/runner.ts
@@ -2,12 +2,15 @@ import type {
   AcpRunnerInput,
   AcpRunnerResult,
   AcpRunnerCallbacks,
+  AcpMcpServer,
   InitializeResult,
   PermissionOutcome,
   PermissionOption,
   PermissionRequest,
   PromptResult,
+  ListSessionsResult,
   SessionNewResult,
+  SessionReconnectResult,
   SessionUpdateNotification,
 } from './types.js';
 import { AcpClient, AcpTimeoutError } from './client.js';
@@ -19,8 +22,14 @@ const DEFAULT_CLIENT_INFO = {
   version: '1.0.0',
 };
 
+const DEFAULT_MCP_SERVERS: AcpMcpServer[] = [];
+
 const DEFAULT_CLIENT_CAPABILITIES = {
   fs: { readTextFile: true, writeTextFile: true },
+  // Do not advertise terminal support yet; AcpClient only handles fs/* and
+  // permission requests today. Newer ACP agents must not call terminal/* unless
+  // this capability is explicitly true.
+  terminal: false,
 };
 
 type AcpPermissionMode = 'allow' | 'prompt';
@@ -114,7 +123,51 @@ function listDedupe(items: string[]): string[] {
   }
   return out;
 }
+type SessionReconnectMethod = 'resume' | 'load' | 'none';
 
+function selectSessionReconnectMethod(initResult: InitializeResult): SessionReconnectMethod {
+  if (supportsSessionResume(initResult)) return 'resume';
+  if (initResult.agentCapabilities?.loadSession === true) return 'load';
+  return 'none';
+}
+
+function hasSessionCapability(initResult: InitializeResult, key: 'resume' | 'list' | 'close'): boolean {
+  return initResult.agentCapabilities?.sessionCapabilities?.[key] != null;
+}
+
+function supportsSessionResume(initResult: InitializeResult): boolean {
+  return hasSessionCapability(initResult, 'resume');
+}
+
+function supportsSessionList(initResult: InitializeResult): boolean {
+  return hasSessionCapability(initResult, 'list');
+}
+
+function supportsSessionClose(initResult: InitializeResult): boolean {
+  return hasSessionCapability(initResult, 'close');
+}
+
+function buildSessionReconnectParams(sessionId: string, cwd: string, mcpServers: AcpMcpServer[]) {
+  return {
+    sessionId,
+    cwd,
+    mcpServers,
+  };
+}
+
+function buildSessionNewParams(cwd: string, mcpServers: AcpMcpServer[]) {
+  return {
+    cwd,
+    mcpServers,
+  };
+}
+
+function buildSessionListParams(cwd?: string, cursor?: string) {
+  return {
+    ...(cwd ? { cwd } : {}),
+    ...(cursor ? { cursor } : {}),
+  };
+}
 
 export async function runAcp(input: AcpRunnerInput): Promise<AcpRunnerResult> {
   const retryConfig = resolveRetryConfig();
@@ -198,6 +251,7 @@ async function runAcpOnce(input: AcpRunnerInput, callbacks?: AcpRunnerCallbacks)
   try {
     const clientInfo = input.clientInfo ?? DEFAULT_CLIENT_INFO;
     const clientCapabilities = input.clientCapabilities ?? DEFAULT_CLIENT_CAPABILITIES;
+    const mcpServers = input.mcpServers ?? DEFAULT_MCP_SERVERS;
     const initResult = await client.call<InitializeResult>('initialize', {
       protocolVersion: 1,
       clientCapabilities,
@@ -205,31 +259,36 @@ async function runAcpOnce(input: AcpRunnerInput, callbacks?: AcpRunnerCallbacks)
     }, timeouts.initMs);
 
     let sessionId = input.sessionId;
-    const supportsLoad = initResult.agentCapabilities?.loadSession === true;
+    const reconnectMethod = selectSessionReconnectMethod(initResult);
 
-    if (sessionId && supportsLoad) {
+    if (process.env.ACP_DEBUG === '1' || process.env.ACP_DEBUG === 'true') {
+      console.error('[acp/runner] capabilities:', JSON.stringify({
+        reconnectMethod,
+        sessionResume: supportsSessionResume(initResult),
+        sessionList: supportsSessionList(initResult),
+        sessionClose: supportsSessionClose(initResult),
+        loadSession: initResult.agentCapabilities?.loadSession === true,
+        mcpCapabilities: initResult.agentCapabilities?.mcpCapabilities,
+      }));
+    }
+
+    if (sessionId && reconnectMethod !== 'none') {
+      const method = reconnectMethod === 'resume' ? 'session/resume' : 'session/load';
       try {
-        await client.call('session/load', {
-          sessionId,
-          cwd: input.cwd,
-          mcpServers: [],
-        }, timeouts.sessionMs);
+        await client.call<SessionReconnectResult>(method, buildSessionReconnectParams(sessionId, input.cwd, mcpServers), timeouts.sessionMs);
       } catch (err) {
         if (isDefinitiveSessionInvalidError(err)) {
-          console.warn('[acp/runner] session/load found invalid saved session, starting fresh:', err);
+          console.warn(`[acp/runner] ${method} found invalid saved session, starting fresh:`, err);
           sessionId = undefined;
         } else {
-          console.warn('[acp/runner] session/load failed transiently, preserving saved session:', err);
+          console.warn(`[acp/runner] ${method} failed transiently, preserving saved session:`, err);
           throw err;
         }
       }
     }
 
     if (!sessionId) {
-      const newSession = await client.call<SessionNewResult>('session/new', {
-        cwd: input.cwd,
-        mcpServers: [],
-      }, timeouts.sessionMs);
+      const newSession = await client.call<SessionNewResult>('session/new', buildSessionNewParams(input.cwd, mcpServers), timeouts.sessionMs);
       sessionId = newSession.sessionId;
       console.warn('[acp/runner] started new ACP session:', sessionId);
     }
@@ -237,6 +296,12 @@ async function runAcpOnce(input: AcpRunnerInput, callbacks?: AcpRunnerCallbacks)
     const textChunks: string[] = [];
     let markPromptProgress = () => {};
     const unsub = client.onNotification((method, params) => {
+      if (method === 'session_info_update') {
+        if (process.env.ACP_DEBUG === '1' || process.env.ACP_DEBUG === 'true') {
+          console.error('[acp/runner] session_info_update raw:', JSON.stringify(params));
+        }
+        return;
+      }
       if (method !== 'session/update') return;
       markPromptProgress();
 
@@ -407,6 +472,85 @@ export function __testCreatePromptProgressTimeouts(input: {
 
 export function __testIsDefinitiveSessionInvalidError(err: unknown): boolean {
   return isDefinitiveSessionInvalidError(err);
+}
+
+export function __testSelectSessionReconnectMethod(initResult: InitializeResult): SessionReconnectMethod {
+  return selectSessionReconnectMethod(initResult);
+}
+
+export function __testSupportsSessionResume(initResult: InitializeResult): boolean {
+  return supportsSessionResume(initResult);
+}
+
+export function __testSupportsSessionList(initResult: InitializeResult): boolean {
+  return supportsSessionList(initResult);
+}
+
+export function __testSupportsSessionClose(initResult: InitializeResult): boolean {
+  return supportsSessionClose(initResult);
+}
+
+export async function listAcpSessions(input: Omit<AcpRunnerInput, 'userText'> & { cursor?: string }): Promise<ListSessionsResult> {
+  const timeouts = resolveTimeoutConfig();
+  const client = new AcpClient(input.agent, input.cwd, {
+    commandOverrides: input.commandOverrides,
+    envOverrides: input.envOverrides,
+    unsetEnv: mergeUnsetEnv(input.unsetEnv, ALWAYS_UNSET_ENV_KEYS),
+  });
+
+  try {
+    const initResult = await client.call<InitializeResult>('initialize', {
+      protocolVersion: 1,
+      clientCapabilities: input.clientCapabilities ?? DEFAULT_CLIENT_CAPABILITIES,
+      clientInfo: input.clientInfo ?? DEFAULT_CLIENT_INFO,
+    }, timeouts.initMs);
+
+    if (!supportsSessionList(initResult)) {
+      throw new Error('ACP agent does not support session/list');
+    }
+
+    return await client.call<ListSessionsResult>('session/list', buildSessionListParams(input.cwd, input.cursor), timeouts.sessionMs);
+  } finally {
+    client.kill();
+  }
+}
+
+export async function closeAcpSession(input: Omit<AcpRunnerInput, 'userText'>): Promise<boolean> {
+  if (!input.sessionId) return false;
+
+  const timeouts = resolveTimeoutConfig();
+  const client = new AcpClient(input.agent, input.cwd, {
+    commandOverrides: input.commandOverrides,
+    envOverrides: input.envOverrides,
+    unsetEnv: mergeUnsetEnv(input.unsetEnv, ALWAYS_UNSET_ENV_KEYS),
+  });
+
+  try {
+    const initResult = await client.call<InitializeResult>('initialize', {
+      protocolVersion: 1,
+      clientCapabilities: input.clientCapabilities ?? DEFAULT_CLIENT_CAPABILITIES,
+      clientInfo: input.clientInfo ?? DEFAULT_CLIENT_INFO,
+    }, timeouts.initMs);
+
+    if (!supportsSessionClose(initResult)) {
+      return false;
+    }
+
+    const reconnectMethod = selectSessionReconnectMethod(initResult);
+    if (reconnectMethod !== 'none') {
+      const method = reconnectMethod === 'resume' ? 'session/resume' : 'session/load';
+      await client.call<SessionReconnectResult>(
+        method,
+        buildSessionReconnectParams(input.sessionId, input.cwd, input.mcpServers ?? DEFAULT_MCP_SERVERS),
+        timeouts.sessionMs,
+      );
+    }
+
+    await client.call('session/close', { sessionId: input.sessionId }, timeouts.sessionMs);
+    return true;
+  } finally {
+    client.kill();
+  }
 }
 
 function wrapCallbacks(

--- a/packages/acp/src/types.ts
+++ b/packages/acp/src/types.ts
@@ -23,6 +23,18 @@ export interface AcpRunnerCallbacks {
   onClarificationRequest?: (request: ClarificationRequest) => Promise<string>;
 }
 
+export type AcpMcpServer =
+  | { type?: 'stdio'; name: string; command: string; args: string[]; env: Array<{ name: string; value: string }>; [key: string]: unknown }
+  | { type: 'http' | 'sse'; name: string; url: string; headers: Array<{ name: string; value: string }>; [key: string]: unknown };
+
+export interface AcpSessionInfo {
+  sessionId: string;
+  cwd: string;
+  title?: string | null;
+  updatedAt?: string | null;
+  [key: string]: unknown;
+}
+
 export interface AcpRunnerInput {
   platformKey: string;
   agent: AcpAgent;
@@ -40,6 +52,7 @@ export interface AcpRunnerInput {
     version?: string;
   };
   clientCapabilities?: AcpClientCapabilities;
+  mcpServers?: AcpMcpServer[];
   commandOverrides?: Partial<Record<AcpAgent, string>>;
 }
 
@@ -82,6 +95,7 @@ export interface AcpClientCapabilities {
     readTextFile?: boolean;
     writeTextFile?: boolean;
   };
+  terminal?: boolean;
 }
 
 export interface AcpInitializeInput {
@@ -111,13 +125,37 @@ export interface InitializeResult {
   protocolVersion: number;
   agentCapabilities: {
     loadSession?: boolean;
+    sessionCapabilities?: {
+      resume?: Record<string, unknown> | null;
+      list?: Record<string, unknown> | null;
+      close?: Record<string, unknown> | null;
+      [key: string]: unknown;
+    };
+    mcpCapabilities?: {
+      http?: boolean;
+      sse?: boolean;
+      [key: string]: unknown;
+    };
     [key: string]: unknown;
   };
-  agentInfo: { name: string; title?: string; version?: string };
+  agentInfo?: { name: string; title?: string; version?: string } | null;
+  authMethods?: unknown[];
 }
 
 export interface SessionNewResult {
   sessionId: string;
+  configOptions?: unknown[] | null;
+  modes?: unknown | null;
+}
+
+export interface SessionReconnectResult {
+  configOptions?: unknown[] | null;
+  modes?: unknown | null;
+}
+
+export interface ListSessionsResult {
+  sessions: AcpSessionInfo[];
+  nextCursor?: string | null;
 }
 
 export interface PromptResult {

--- a/packages/cli/src/acp-commands.ts
+++ b/packages/cli/src/acp-commands.ts
@@ -1,6 +1,14 @@
 import { promises as fs } from 'fs';
 import { resolve as resolvePath } from 'path';
-import { buildAcpEnableState, clearAcpState, getAcpState, setAcpState, updateAcpCwd } from 'pulse-coder-acp';
+import {
+  buildAcpEnableState,
+  clearAcpState,
+  closeAcpSession,
+  getAcpState,
+  listAcpSessions,
+  setAcpState,
+  updateAcpCwd,
+} from 'pulse-coder-acp';
 import type { AcpAgent } from 'pulse-coder-acp';
 
 const DEFAULT_ACP_USER = 'local';
@@ -78,8 +86,38 @@ export async function handleAcpCommand(platformKey: string, args: string[]): Pro
     if (!existing) {
       return 'ℹ️ ACP 本来就是关闭状态。';
     }
+
+    const closeLine = await tryCloseAcpSession(platformKey, existing);
     await clearAcpState(platformKey);
-    return '✅ ACP 已关闭，恢复使用 pulse-agent。';
+    return ['✅ ACP 已关闭，恢复使用 pulse-agent。', closeLine].filter(Boolean).join('\n');
+  }
+
+  if (sub === 'sessions') {
+    const state = await getAcpState(platformKey);
+    if (!state) {
+      return '❌ ACP 未启用，请先 `/acp on <claude|codex>`。';
+    }
+
+    try {
+      const result = await listAcpSessions({
+        platformKey,
+        agent: state.agent,
+        cwd: state.cwd,
+        sessionId: state.sessionId,
+        clientInfo: ACP_CLIENT_INFO,
+      });
+      if (result.sessions.length === 0) return 'ℹ️ 当前 ACP agent 未返回已有 session。';
+      const lines = result.sessions.slice(0, 20).map((session) => {
+        const marker = session.sessionId === state.sessionId ? ' *' : '';
+        const title = session.title ? ` — ${session.title}` : '';
+        const updated = session.updatedAt ? ` (${session.updatedAt})` : '';
+        return `- ${session.sessionId}${marker}\n  cwd: ${session.cwd}${title}${updated}`;
+      });
+      const more = result.nextCursor ? '\n… 还有更多 session（当前命令暂未翻页）。' : '';
+      return `📚 ACP sessions\n${lines.join('\n')}${more}`;
+    } catch (err) {
+      return `❌ 当前 ACP agent 不支持或无法执行 session/list：${formatError(err)}`;
+    }
   }
 
   if (sub === 'cd') {
@@ -104,8 +142,9 @@ export async function handleAcpCommand(platformKey: string, args: string[]): Pro
   return [
     '⚠️ 未知子命令。ACP 用法：',
     '`/acp on <claude|codex> [cwd]` — 开启 ACP 模式',
-    '`/acp off`                     — 关闭，恢复 pulse-agent',
+    '`/acp off`                     — 关闭，恢复 pulse-agent（支持时关闭 ACP session）',
     '`/acp cd <path>`               — 切换工作目录（重置 session）',
+    '`/acp sessions`                — 列出 agent 已知 session（若支持）',
     '`/acp status`                  — 查看当前状态',
   ].join('\n');
 }
@@ -121,4 +160,24 @@ async function dirExists(p: string): Promise<boolean> {
 
 function isValidAgent(value: string): value is AcpAgent {
   return (VALID_AGENTS as string[]).includes(value);
+}
+
+async function tryCloseAcpSession(platformKey: string, state: { agent: AcpAgent; cwd: string; sessionId?: string }): Promise<string | null> {
+  if (!state.sessionId) return null;
+  try {
+    const closed = await closeAcpSession({
+      platformKey,
+      agent: state.agent,
+      cwd: state.cwd,
+      sessionId: state.sessionId,
+      clientInfo: ACP_CLIENT_INFO,
+    });
+    return closed ? '- ACP session 已通过 session/close 关闭。' : '- ACP agent 未声明 session/close，已仅清除本地状态。';
+  } catch (err) {
+    return `- session/close 执行失败，已仅清除本地状态：${formatError(err)}`;
+  }
+}
+
+function formatError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }


### PR DESCRIPTION
Upgrade ACP session handling to support the latest protocol capabilities.

- Preserve saved ACP sessions across repeated enable and transient retry paths
- Prefer session/resume with session/load fallback for reconnects
- Add session/list and session/close helpers, plus CLI and remote commands
- Align ACP types and advertised client capabilities with current protocol
- Add tests for session preservation and capability selection

Validation:
- pnpm --filter pulse-coder-acp test
- pnpm --filter pulse-coder-acp build
- pnpm --filter pulse-coder-cli build
- pnpm --filter @pulse-coder/remote-server build
- Live codex-acp smoke test: prompt reuse, session/list, session/close