### PR TITLE
fix: stabilize iframe canvas resizing

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasMouseHandlers.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasMouseHandlers.ts
@@ -223,11 +223,16 @@ export const useCanvasMouseHandlers = ({
     const onUp = () => {
       if (isDraggingRef.current) handleMouseUp();
     };
+    const onBlur = () => {
+      if (isDraggingRef.current) handleMouseUp();
+    };
     window.addEventListener('mousemove', onMove);
     window.addEventListener('mouseup', onUp);
+    window.addEventListener('blur', onBlur);
     return () => {
       window.removeEventListener('mousemove', onMove);
       window.removeEventListener('mouseup', onUp);
+      window.removeEventListener('blur', onBlur);
     };
   }, [handleWindowDragMove, handleMouseUp]);
 

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.css
@@ -34,6 +34,8 @@
   pointer-events: auto;
 }
 
+.canvas-container--iframe-shielding iframe,
+.canvas-container--iframe-shielding webview,
 .canvas-container--iframe-shielding .iframe-frame {
   pointer-events: none;
 }


### PR DESCRIPTION
## Summary
- Disable pointer events on iframe and Electron webview embeds while the canvas is shielding interactions.
- Add a window blur fallback so active drag/resize gestures are cleaned up if focus leaves the renderer.

## Validation
- `pnpm --filter canvas-workspace typecheck:renderer` ✅

## Risk
- Low; scoped CSS/event fallback for active canvas interactions only.
