### PR TITLE
Keep all canvas instances mounted to preserve state across workspace switches

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/App.css
+++ b/apps/canvas-workspace/src/renderer/src/App.css
@@ -23,6 +23,11 @@
   min-height: 0;
 }
 
+.canvas-host {
+  position: absolute;
+  inset: 0;
+}
+
 .chat-panel-wrapper {
   width: 0;
   overflow: hidden;

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -33,6 +33,12 @@ interface CanvasProps {
   canvasId: string;
   canvasName?: string;
   rootFolder?: string;
+  /** False while this canvas is mounted-but-hidden (workspace not in
+   *  focus). Lets the component stay alive so transform/selection/tool
+   *  state survives a workspace switch, while suppressing global
+   *  side-effects (window-level keyboard shortcuts, clipboard paste)
+   *  that would otherwise fire from every mounted canvas at once. */
+  isActive?: boolean;
   onNodesChange?: (canvasId: string, nodes: CanvasNode[]) => void;
   onSelectionChange?: (canvasId: string, selectedNodeIds: string[]) => void;
   focusNodeId?: string;
@@ -52,6 +58,7 @@ export const Canvas = ({
   canvasId,
   canvasName,
   rootFolder,
+  isActive = true,
   onNodesChange,
   onSelectionChange,
   focusNodeId,
@@ -283,11 +290,14 @@ export const Canvas = ({
     onExitFocusMode: focus.exitFocusMode,
     fullscreenActive: focus.fullscreenNodeId != null,
     onExitFullscreen: focus.exitFullscreen,
-    keyboardLocked: isOverlayOpen,
+    // Hidden canvases stay mounted to preserve their UI state across
+    // workspace switches; gate global keyboard shortcuts so only the
+    // visible one reacts.
+    keyboardLocked: !isActive || isOverlayOpen,
   });
 
   useCanvasImagePaste({
-    canvasId, active: true, containerRef, screenToCanvas,
+    canvasId, active: isActive, containerRef, screenToCanvas,
     addNode, updateNode,
     onCreated: (node) => setSelectedNodeIds([node.id]),
   });

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
@@ -184,29 +184,36 @@ export const Workbench: React.FC<WorkbenchProps> = ({
         onFocusNode={handleFocusReferenceNode}
       />
       <div className="canvas-viewport">
-        {workspaces
-          .filter((ws) => ws.id === activeWorkspaceId)
-          .map((ws) => (
-            <Canvas
+        {workspaces.map((ws) => {
+          const isActive = ws.id === activeWorkspaceId;
+          return (
+            <div
               key={ws.id}
-              canvasId={ws.id}
-              canvasName={ws.name}
-              rootFolder={ws.rootFolder}
-              onNodesChange={handleNodesChange}
-              onSelectionChange={handleSelectionChange}
-              focusNodeId={ws.id === focusRequest?.workspaceId ? focusRequest.nodeId : undefined}
-              onFocusComplete={clearFocusRequest}
-              deleteNodeId={ws.id === deleteRequest?.workspaceId ? deleteRequest.nodeId : undefined}
-              onDeleteComplete={clearDeleteRequest}
-              renameRequest={ws.id === renameRequest?.workspaceId ? renameRequest : undefined}
-              onRenameComplete={clearRenameRequest}
-              chatPanelOpen={chatPanelOpen}
-              onChatToggle={() => setChatPanelOpen((prev) => !prev)}
-              referenceDrawerOpen={referenceDrawerOpen}
-              onReferenceToggle={() => setReferenceDrawerOpen((prev) => !prev)}
-              onPinReferenceNode={pinReferenceNode}
-            />
-          ))}
+              className="canvas-host"
+              style={isActive ? undefined : { display: 'none' }}
+            >
+              <Canvas
+                canvasId={ws.id}
+                canvasName={ws.name}
+                rootFolder={ws.rootFolder}
+                isActive={isActive}
+                onNodesChange={handleNodesChange}
+                onSelectionChange={handleSelectionChange}
+                focusNodeId={ws.id === focusRequest?.workspaceId ? focusRequest.nodeId : undefined}
+                onFocusComplete={clearFocusRequest}
+                deleteNodeId={ws.id === deleteRequest?.workspaceId ? deleteRequest.nodeId : undefined}
+                onDeleteComplete={clearDeleteRequest}
+                renameRequest={ws.id === renameRequest?.workspaceId ? renameRequest : undefined}
+                onRenameComplete={clearRenameRequest}
+                chatPanelOpen={chatPanelOpen}
+                onChatToggle={() => setChatPanelOpen((prev) => !prev)}
+                referenceDrawerOpen={referenceDrawerOpen}
+                onReferenceToggle={() => setReferenceDrawerOpen((prev) => !prev)}
+                onPinReferenceNode={pinReferenceNode}
+              />
+            </div>
+          );
+        })}
       </div>
       {workspaces.map((ws) => (
         <div


### PR DESCRIPTION
## Summary
Refactored the canvas rendering logic to keep all workspace canvases mounted in the DOM simultaneously, rather than only rendering the active one. Hidden canvases are visually hidden with `display: none` but remain alive to preserve their internal state (transform, selection, tool state) across workspace switches.

## Key Changes
- **Workbench component**: Changed from filtering workspaces to render only the active one, to rendering all workspaces and conditionally hiding inactive ones with a wrapper div and inline style
- **Canvas component**: Added `isActive` prop to gate global side-effects (keyboard shortcuts, clipboard paste) so only the visible canvas responds to user input
- **Keyboard handling**: Modified `keyboardLocked` logic to lock keyboard input when canvas is not active, preventing multiple mounted canvases from responding to the same shortcuts
- **Image paste**: Gated the `useCanvasImagePaste` hook to only be active when the canvas is visible
- **Styling**: Added `.canvas-host` CSS class with `position: absolute; inset: 0` to properly position hidden canvas containers

## Implementation Details
- All canvases remain mounted but hidden, preserving their React component state, canvas transform matrices, and selection state
- The `isActive` prop serves as a feature flag to suppress global side-effects while keeping the component tree alive
- Hidden canvases are positioned absolutely with full viewport coverage but hidden from view, allowing them to maintain their internal state without affecting the visible UI

https://claude.ai/code/session_01SB9xe9Hg8LAhPUH8e8XgAv