### PR TITLE
Fix text node editing: defer gesture shield, add Enter/F2 activation

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasMouseHandlers.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasMouseHandlers.ts
@@ -176,7 +176,6 @@ export const useCanvasMouseHandlers = ({
     (e: React.MouseEvent, node: CanvasNode) => {
       if (e.button === 0 && !e.altKey) {
         isDraggingRef.current = true;
-        setNodeGestureActive(true);
       }
       onDragStart(e, node);
     },
@@ -195,7 +194,6 @@ export const useCanvasMouseHandlers = ({
     ) => {
       if (e.button === 0) {
         isDraggingRef.current = true;
-        setNodeGestureActive(true);
       }
       onResizeStart(e, nodeId, width, height, edge, minWidth, minHeight);
     },
@@ -226,7 +224,18 @@ export const useCanvasMouseHandlers = ({
 
   useEffect(() => {
     const onMove = (e: MouseEvent) => {
-      if (isDraggingRef.current) handleWindowDragMove(e);
+      if (isDraggingRef.current) {
+        handleWindowDragMove(e);
+        // Defer mounting the interaction shield until we actually see drag
+        // motion. Mounting on mousedown swallows the trailing mouseup /
+        // click / dblclick on top of the originating node (the shield is
+        // the highest-z element when mouseup fires, so click and dblclick
+        // resolve on its common ancestor instead of the node) — which
+        // silently breaks "double-click a text node to edit" and similar
+        // node interactions. Idempotent setState skips re-renders past the
+        // first move.
+        setNodeGestureActive(true);
+      }
     };
     const onUp = () => {
       if (isDraggingRef.current) handleMouseUp();

--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.tsx
@@ -69,7 +69,7 @@ export const TextNodeBody = ({ node, onUpdate, isSelected, onSelect, onDragStart
       // invisible on the canvas (transparent bg, no chrome). The placeholder
       // doubles as a "there's a node here" marker at rest.
       Placeholder.configure({
-        placeholder: "Double-click to edit",
+        placeholder: "Double-click or press Enter to edit",
         showOnlyWhenEditable: false,
       }),
       // Markdown extension kept for keyboard shortcuts (`# `, `- `, etc.)
@@ -133,6 +133,32 @@ export const TextNodeBody = ({ node, onUpdate, isSelected, onSelect, onDragStart
       editor?.commands.blur();
     }
   }, [isSelected, editing, editor]);
+
+  // Enter / F2 on a selected (but not yet editing) text node → drop into edit
+  // mode with the caret at the end. Matches Figma / tldraw / Excalidraw. Without
+  // this, a user who single-clicks a populated text node and tries to type sees
+  // nothing happen: drag mode swallows the click, the "Double-click to edit"
+  // placeholder only shows on empty nodes, and no other hint exists. Capture
+  // phase + defaultPrevented dedupe means multi-select picks one winner.
+  useEffect(() => {
+    if (!editor || !isSelected || editing || readOnly) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.defaultPrevented) return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (e.key !== "Enter" && e.key !== "F2") return;
+      const active = document.activeElement as HTMLElement | null;
+      if (active && (
+        active.tagName === "INPUT" ||
+        active.tagName === "TEXTAREA" ||
+        active.isContentEditable
+      )) return;
+      e.preventDefault();
+      setEditing(true);
+      requestAnimationFrame(() => editor.commands.focus("end"));
+    };
+    window.addEventListener("keydown", handler, { capture: true });
+    return () => window.removeEventListener("keydown", handler, { capture: true });
+  }, [editor, isSelected, editing, readOnly]);
 
   // Auto-size the wrapper to fit content. Height ALWAYS tracks content so a
   // text node can never clip or scroll (prosemirror's auto-scroll-into-view


### PR DESCRIPTION
## Summary
Fixes text node editing interactions by deferring the interaction shield mount until actual drag motion occurs, and adds keyboard activation (Enter/F2) for selected text nodes to match Figma/tldraw/Excalidraw behavior.

## Changes

### TextNodeBody (`apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.tsx`)
- Updated placeholder text from "Double-click to edit" to "Double-click or press Enter to edit" to reflect new keyboard activation
- Added new `useEffect` hook that listens for Enter or F2 key presses on selected (but not editing) text nodes
  - Focuses the editor at the end of content when activated
  - Respects `readOnly` state and avoids interfering with other focused inputs
  - Uses capture phase event listener with `defaultPrevented` deduplication for multi-select scenarios

### Canvas mouse handlers (`apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasMouseHandlers.ts`)
- Removed `setNodeGestureActive(true)` calls from `onDragStart` and `onResizeStart` handlers
- Deferred `setNodeGestureActive(true)` to the window `mousemove` handler, only mounting the interaction shield when actual drag motion is detected
  - Prevents the shield from swallowing the trailing `mouseup`/`click`/`dblclick` events on the originating node
  - Fixes silent breakage of "double-click to edit" and similar node interactions
  - Uses idempotent `setState` to skip re-renders after the first move

## Implementation Details
The gesture shield (highest-z element) was previously mounted on `mousedown`, causing it to be the event target when `mouseup` fires. This prevented `click` and `dblclick` events from reaching the text node. By deferring shield mounting until actual drag motion, single-click interactions and double-click-to-edit now work correctly while still supporting drag operations.

https://claude.ai/code/session_01Gw4CXohXkdUXaY1LJP2i2F