### PR TITLE
Add resizable artifact drawer and improve inline visual promotion

### DIFF
--- a/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
@@ -46,8 +46,23 @@ interface CanvasAgentRequestContext {
 
 const CANVAS_AGENT_MAX_STEPS = 200;
 
-function stringifyToolResult(raw: unknown): string {
-  return typeof raw === 'string' ? raw : JSON.stringify(raw) ?? String(raw);
+// AI SDK v6 wraps tool execute return values into a tagged `ToolResultOutput`
+// — `{ type: 'text'|'json'|'error-text'|'error-json'|..., value }` — on the
+// `tool-result` parts of persisted ModelMessages. Stringifying the wrapper
+// loses the original payload (renderers can no longer JSON.parse the
+// tool's actual return value), so unwrap to the inner value first. Plain
+// strings and untyped objects pass through unchanged for back-compat.
+function unwrapToolOutput(raw: unknown): string {
+  if (typeof raw === 'string') return raw;
+  if (raw && typeof raw === 'object') {
+    const r = raw as { type?: unknown; value?: unknown };
+    if (typeof r.type === 'string' && 'value' in r) {
+      const v = r.value;
+      if (typeof v === 'string') return v;
+      return JSON.stringify(v) ?? String(v);
+    }
+  }
+  return JSON.stringify(raw) ?? String(raw);
 }
 
 function modelMessagesToToolCalls(messages: ModelMessage[]): CanvasAgentToolCall[] {
@@ -93,7 +108,7 @@ function modelMessagesToToolCalls(messages: ModelMessage[]): CanvasAgentToolCall
         const tool = findOrCreate(toolCallId, name);
         tool.name = name;
         tool.status = 'done';
-        tool.result = stringifyToolResult(part.output ?? part.result);
+        tool.result = unwrapToolOutput(part.output ?? part.result);
       }
     }
   }
@@ -659,7 +674,7 @@ export class CanvasAgent {
               recordTraceToolResult(debugTrace, { name: chunk.toolName, rawResult: raw, toolCallId: chunk.toolCallId });
               onToolResult?.({
                 name: chunk.toolName,
-                result: typeof raw === 'string' ? raw : JSON.stringify(raw),
+                result: unwrapToolOutput(raw),
                 toolCallId: chunk.toolCallId,
               });
             }

--- a/apps/canvas-workspace/src/renderer/src/components/artifacts/ArtifactDrawer.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/artifacts/ArtifactDrawer.tsx
@@ -7,7 +7,7 @@
  * and load the requested artifact.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { Artifact, ArtifactVersion } from '../../types';
 import { useArtifactDrawer } from './ArtifactContext';
 
@@ -17,18 +17,42 @@ const TYPE_LABEL: Record<string, string> = {
   mermaid: 'Mermaid',
 };
 
+const WIDTH_STORAGE_KEY = 'canvas-workspace:artifact-drawer-width';
+const MIN_DRAWER_WIDTH = 360;
+const DEFAULT_DRAWER_WIDTH = 640;
+
+function readStoredWidth(): number {
+  if (typeof window === 'undefined') return DEFAULT_DRAWER_WIDTH;
+  try {
+    const stored = window.localStorage.getItem(WIDTH_STORAGE_KEY);
+    if (!stored) return DEFAULT_DRAWER_WIDTH;
+    const parsed = Number(stored);
+    if (!Number.isFinite(parsed) || parsed < MIN_DRAWER_WIDTH) return DEFAULT_DRAWER_WIDTH;
+    return parsed;
+  } catch {
+    return DEFAULT_DRAWER_WIDTH;
+  }
+}
+
+function clampDrawerWidth(value: number): number {
+  const viewport = typeof window === 'undefined' ? value : window.innerWidth;
+  const max = Math.max(MIN_DRAWER_WIDTH, Math.round(viewport * 0.95));
+  return Math.min(max, Math.max(MIN_DRAWER_WIDTH, value));
+}
+
 export const ArtifactDrawer = () => {
   const { open, close } = useArtifactDrawer();
   const [artifact, setArtifact] = useState<Artifact | null>(null);
-  const [viewVersionId, setViewVersionId] = useState<string | null>(null);
   const [pinning, setPinning] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [drawerWidth, setDrawerWidth] = useState<number>(() => clampDrawerWidth(readStoredWidth()));
+  const drawerWidthRef = useRef(drawerWidth);
+  drawerWidthRef.current = drawerWidth;
 
   // Load + subscribe whenever the opened (workspace, artifact) pair changes.
   useEffect(() => {
     if (!open) {
       setArtifact(null);
-      setViewVersionId(null);
       setError(null);
       return;
     }
@@ -44,12 +68,6 @@ export const ArtifactDrawer = () => {
         return;
       }
       setArtifact(result.artifact);
-      // On first load (or when the artifact gets a new version), snap to current.
-      setViewVersionId(prev => {
-        if (!prev) return result.artifact!.currentVersionId;
-        const stillExists = result.artifact!.versions.some(v => v.id === prev);
-        return stillExists ? prev : result.artifact!.currentVersionId;
-      });
     };
 
     void refresh();
@@ -71,11 +89,49 @@ export const ArtifactDrawer = () => {
     };
   }, [open]);
 
+  // Re-clamp on viewport resize so a stored width wider than the new viewport
+  // doesn't push the drawer off-screen.
+  useEffect(() => {
+    const onResize = () => setDrawerWidth(prev => clampDrawerWidth(prev));
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  const startResize = useCallback((event: React.MouseEvent) => {
+    event.preventDefault();
+    const startX = event.clientX;
+    const startWidth = drawerWidthRef.current;
+    const onMove = (ev: MouseEvent) => {
+      // Handle sits on the LEFT edge of a right-anchored drawer, so dragging
+      // left should grow the drawer.
+      const next = clampDrawerWidth(startWidth + (startX - ev.clientX));
+      setDrawerWidth(next);
+    };
+    const onUp = () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+      document.body.style.userSelect = '';
+      document.body.style.cursor = '';
+      try {
+        window.localStorage.setItem(WIDTH_STORAGE_KEY, String(drawerWidthRef.current));
+      } catch {
+        /* localStorage may be unavailable; user preference simply won't persist. */
+      }
+    };
+    document.body.style.userSelect = 'none';
+    document.body.style.cursor = 'ew-resize';
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+  }, []);
+
   const viewedVersion: ArtifactVersion | null = useMemo(() => {
     if (!artifact) return null;
-    const id = viewVersionId ?? artifact.currentVersionId;
-    return artifact.versions.find(v => v.id === id) ?? artifact.versions[artifact.versions.length - 1] ?? null;
-  }, [artifact, viewVersionId]);
+    return (
+      artifact.versions.find(v => v.id === artifact.currentVersionId)
+      ?? artifact.versions[artifact.versions.length - 1]
+      ?? null
+    );
+  }, [artifact]);
 
   const handlePin = useCallback(async () => {
     if (!open || !artifact || artifact.pinnedNodeId || pinning) return;
@@ -132,7 +188,19 @@ export const ArtifactDrawer = () => {
   return (
     <>
       <div className="artifact-drawer-backdrop" onClick={close} />
-      <aside className="artifact-drawer" role="dialog" aria-label="Artifact preview">
+      <aside
+        className="artifact-drawer"
+        role="dialog"
+        aria-label="Artifact preview"
+        style={{ width: `${drawerWidth}px` }}
+      >
+        <div
+          className="artifact-drawer__resize-handle"
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize artifact panel"
+          onMouseDown={startResize}
+        />
         <div className="artifact-drawer__header">
           <div className="artifact-drawer__title" title={artifact?.title}>
             {artifact?.title ?? 'Artifact'}
@@ -146,17 +214,6 @@ export const ArtifactDrawer = () => {
         </div>
         {artifact && artifact.versions.length > 0 && (
           <div className="artifact-drawer__toolbar">
-            <select
-              className="artifact-drawer__version-select"
-              value={viewVersionId ?? artifact.currentVersionId}
-              onChange={(e) => setViewVersionId(e.target.value)}
-            >
-              {artifact.versions.map((version, i) => (
-                <option key={version.id} value={version.id}>
-                  v{i + 1}{version.id === artifact.currentVersionId ? ' (current)' : ''}
-                </option>
-              ))}
-            </select>
             <div className="artifact-drawer__toolbar-spacer" />
             {artifact.pinnedNodeId ? (
               <span className="artifact-drawer__pinned-badge">Pinned to canvas</span>

--- a/apps/canvas-workspace/src/renderer/src/components/artifacts/ChatInlineVisual.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/artifacts/ChatInlineVisual.tsx
@@ -67,9 +67,16 @@ export const ChatInlineVisual = ({
 }: ChatInlineVisualProps) => {
   const { openArtifact } = useArtifactDrawer();
   const [savedId, setSavedId] = useState<string | null>(null);
-  const [saving, setSaving] = useState(false);
+  const [opening, setOpening] = useState(false);
+  const [pinning, setPinning] = useState(false);
+  const [pinned, setPinned] = useState(false);
   const [copied, setCopied] = useState(false);
   const [height, setHeight] = useState(MIN_HEIGHT);
+  // Dedup concurrent promotion: Open and Save both lazily create the artifact.
+  // The first to fire owns the in-flight create; the second awaits the same
+  // promise so we never end up with two artifact rows for the same inline
+  // visual.
+  const promotionPromise = useRef<Promise<string | null> | null>(null);
 
   // Build the live payload from the highest-fidelity source available.
   // Side-channel streamedContent is preferred (already-unescaped HTML),
@@ -145,11 +152,14 @@ export const ChatInlineVisual = ({
     return () => cancelAnimationFrame(rafId.current);
   }, [isStreamingHtml, livePayload]);
 
-  const handleSaveAsArtifact = useCallback(async (e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (!livePayload || savedId || saving) return;
-    setSaving(true);
-    try {
+  // Lazily promote the inline visual to a persistent artifact and return its
+  // id. Both Open and Save funnel through this — repeated calls reuse the
+  // first artifact instead of creating duplicates.
+  const promoteToArtifact = useCallback(async (): Promise<string | null> => {
+    if (savedId) return savedId;
+    if (promotionPromise.current) return await promotionPromise.current;
+    if (!livePayload?.content) return null;
+    const pending = (async (): Promise<string | null> => {
       const result = await window.canvasWorkspace.artifacts.create(workspaceId, {
         type: livePayload.type,
         title: livePayload.title || 'Saved visual',
@@ -158,12 +168,29 @@ export const ChatInlineVisual = ({
       });
       if (result.ok && result.artifact) {
         setSavedId(result.artifact.id);
-        openArtifact(workspaceId, result.artifact.id);
+        return result.artifact.id;
       }
+      return null;
+    })();
+    promotionPromise.current = pending;
+    try {
+      return await pending;
     } finally {
-      setSaving(false);
+      promotionPromise.current = null;
     }
-  }, [savedId, saving, workspaceId, livePayload, openArtifact]);
+  }, [savedId, workspaceId, livePayload]);
+
+  const handleOpen = useCallback(async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (opening) return;
+    setOpening(true);
+    try {
+      const id = await promoteToArtifact();
+      if (id) openArtifact(workspaceId, id);
+    } finally {
+      setOpening(false);
+    }
+  }, [opening, promoteToArtifact, openArtifact, workspaceId]);
 
   const handleCopy = useCallback(async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -177,10 +204,19 @@ export const ChatInlineVisual = ({
     }
   }, [livePayload]);
 
-  const handleOpenSaved = useCallback((e: React.MouseEvent) => {
+  const handleSaveToCanvas = useCallback(async (e: React.MouseEvent) => {
     e.stopPropagation();
-    if (savedId) openArtifact(workspaceId, savedId);
-  }, [savedId, workspaceId, openArtifact]);
+    if (pinning || pinned) return;
+    setPinning(true);
+    try {
+      const id = await promoteToArtifact();
+      if (!id) return;
+      const result = await window.canvasWorkspace.artifacts.pinToCanvas(workspaceId, id, {});
+      if (result?.ok) setPinned(true);
+    } finally {
+      setPinning(false);
+    }
+  }, [pinning, pinned, promoteToArtifact, workspaceId]);
 
   // ── Render branches ──────────────────────────────────────────────────
 
@@ -252,17 +288,17 @@ export const ChatInlineVisual = ({
       <div className="chat-inline-visual__toolbar" aria-hidden={!livePayload.content}>
         {!isFinal ? (
           <span className="chat-inline-visual__cursor" aria-hidden="true" />
-        ) : savedId ? (
-          <button
-            type="button"
-            className="chat-inline-visual__btn"
-            onClick={handleOpenSaved}
-            title="Open in drawer"
-          >
-            Open
-          </button>
         ) : (
           <>
+            <button
+              type="button"
+              className="chat-inline-visual__btn"
+              onClick={(e) => void handleOpen(e)}
+              disabled={opening || !livePayload.content}
+              title="Open in side drawer"
+            >
+              {opening ? 'Opening…' : 'Open'}
+            </button>
             <button
               type="button"
               className="chat-inline-visual__btn"
@@ -275,11 +311,11 @@ export const ChatInlineVisual = ({
             <button
               type="button"
               className="chat-inline-visual__btn chat-inline-visual__btn--primary"
-              onClick={(e) => void handleSaveAsArtifact(e)}
-              disabled={saving || !livePayload.content}
-              title="Save as artifact"
+              onClick={(e) => void handleSaveToCanvas(e)}
+              disabled={pinning || pinned || !livePayload.content}
+              title="Save to canvas"
             >
-              {saving ? 'Saving' : 'Save'}
+              {pinning ? 'Saving…' : pinned ? 'Saved' : 'Save'}
             </button>
           </>
         )}

--- a/apps/canvas-workspace/src/renderer/src/components/artifacts/artifacts.css
+++ b/apps/canvas-workspace/src/renderer/src/components/artifacts/artifacts.css
@@ -381,7 +381,12 @@
   top: 0;
   right: 0;
   bottom: 0;
-  width: min(640px, 80vw);
+  /* Width is controlled inline by ArtifactDrawer.tsx so the user can drag the
+   * left-edge handle to resize. Fallback only applies when no inline style is
+   * set (e.g. SSR or stripped runtime). */
+  width: 640px;
+  min-width: 360px;
+  max-width: 95vw;
   background: #fff;
   border-left: 1px solid rgba(55, 53, 47, 0.12);
   display: flex;
@@ -389,6 +394,27 @@
   z-index: 100;
   box-shadow: -2px 0 12px rgba(15, 15, 14, 0.08);
   animation: artifact-slide-in 0.18s ease-out;
+}
+
+/* Thin draggable strip on the LEFT edge of the right-anchored drawer.
+ * Transparent at rest; the cursor hint is the only visual cue until hover,
+ * which paints a soft indigo bar so the drag target is discoverable. */
+.artifact-drawer__resize-handle {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 6px;
+  margin-left: -3px;
+  cursor: ew-resize;
+  z-index: 1;
+  background: transparent;
+  transition: background 0.12s ease;
+}
+
+.artifact-drawer__resize-handle:hover,
+.artifact-drawer__resize-handle:active {
+  background: rgba(99, 102, 241, 0.35);
 }
 
 @keyframes artifact-slide-in {
@@ -462,16 +488,6 @@
   border-bottom: 1px solid rgba(55, 53, 47, 0.08);
   background: #fafaf9;
   flex-shrink: 0;
-}
-
-.artifact-drawer__version-select {
-  font-size: 12px;
-  color: #37352f;
-  background: #fff;
-  border: 1px solid rgba(55, 53, 47, 0.16);
-  border-radius: 5px;
-  padding: 4px 8px;
-  font-family: inherit;
 }
 
 .artifact-drawer__toolbar-spacer { flex: 1; }


### PR DESCRIPTION
## Summary
This PR enhances the artifact drawer with user-resizable width and improves the inline visual promotion flow to prevent duplicate artifacts when opening and saving concurrently.

## Key Changes

### Artifact Drawer Resizing
- Added draggable resize handle on the left edge of the right-anchored drawer
- Drawer width is now persisted to localStorage and restored on reload
- Width is clamped to a reasonable range (360px–95vw) and re-clamped on viewport resize to prevent off-screen positioning
- Removed the version selector dropdown; the drawer now always displays the current artifact version
- Updated CSS to support inline width styling and added hover/active states for the resize handle

### Inline Visual Promotion
- Refactored `ChatInlineVisual` to use a shared `promoteToArtifact()` function that both "Open" and "Save to Canvas" actions funnel through
- Added deduplication logic via `promotionPromise` ref to prevent concurrent create calls from generating duplicate artifacts
- Renamed "Save" button to "Save to Canvas" and changed behavior to pin the artifact instead of just opening it
- Split state management: `opening` and `pinning` now track their respective operations independently
- The "Open" button now always appears (not just after save) and promotes the artifact on demand

### Tool Output Unwrapping
- Updated `canvas-agent.ts` to properly unwrap AI SDK v6's `ToolResultOutput` wrapper format
- New `unwrapToolOutput()` function extracts the inner value from tagged tool results, preserving JSON-parseable payloads for renderers
- Maintains backward compatibility with plain strings and untyped objects

## Implementation Details
- Drawer width state uses a ref (`drawerWidthRef`) to capture the current value during resize operations without stale closures
- Resize handle uses `ew-resize` cursor and prevents text selection during drag
- localStorage errors are silently caught to handle unavailable storage gracefully
- The promotion deduplication pattern ensures that rapid "Open" + "Save" clicks reuse the same artifact creation promise

https://claude.ai/code/session_014Cd93XCcXnsbGDNEnWWG4y