### PR TITLE
Add session resume support and improve agent conversation UX

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentPicker.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentPicker.tsx
@@ -49,7 +49,7 @@ export const AgentPicker = ({
                 onLaunch();
               }
             }}
-            placeholder={'What should the agent do?'}
+            placeholder={'What should the agent do?  ·  Optional — press Enter to start'}
             spellCheck={false}
             autoFocus
           />
@@ -102,7 +102,7 @@ export const AgentPicker = ({
                   onChange={(e) => onCwdChange(e.target.value)}
                   placeholder={
                     rootFolder
-                      ? truncatePath(rootFolder, 32)
+                      ? `${truncatePath(rootFolder, 26)}  ·  default`
                       : 'Working directory'
                   }
                   spellCheck={false}

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTerminal.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTerminal.tsx
@@ -5,18 +5,12 @@ interface AgentTerminalProps {
   status: string;
   lastExitCode?: number;
   /** When true, the agent CLI supports id-based resume — the session-end
-   *  bar will offer a Continue/Retry primary action. Otherwise only the
-   *  Start-fresh path is shown. */
+   *  bar will offer a Continue/Retry primary action. Otherwise the user
+   *  only sees a status badge and Copy. */
   canResume?: boolean;
   onContinue: () => void;
-  onNewSession: () => void;
   onCopyOutput?: () => void;
-  onStop?: () => void;
-  onSendPrompt?: (prompt: string) => void;
 }
-
-const CONTINUE_PROMPT = 'continue';
-const SUMMARIZE_PROMPT = 'please summarize what you have done so far';
 
 export const AgentTerminal = ({
   containerRef,
@@ -24,10 +18,7 @@ export const AgentTerminal = ({
   lastExitCode,
   canResume = false,
   onContinue,
-  onNewSession,
   onCopyOutput,
-  onStop,
-  onSendPrompt,
 }: AgentTerminalProps) => (
   <div className="agent-body-wrap">
     <div
@@ -35,50 +26,12 @@ export const AgentTerminal = ({
       className="agent-xterm-container"
       onMouseDown={(e) => e.stopPropagation()}
     />
-    {status === 'running' && (
-      <div className="agent-quick-actions">
-        <button
-          type="button"
-          className="agent-quick-btn"
-          onClick={() => onSendPrompt?.(CONTINUE_PROMPT)}
-          title="Send 'continue' to agent"
-        >
-          <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
-            <path d="M5 3l6 5-6 5V3z" fill="currentColor" />
-          </svg>
-          Continue
-        </button>
-        <button
-          type="button"
-          className="agent-quick-btn"
-          onClick={() => onSendPrompt?.(SUMMARIZE_PROMPT)}
-          title="Ask agent to summarize"
-        >
-          <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
-            <path d="M3 4h10M3 7.5h7M3 11h5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
-          </svg>
-          Summarize
-        </button>
-        <button
-          type="button"
-          className="agent-quick-btn agent-quick-btn--stop"
-          onClick={onStop}
-          title="Stop agent"
-        >
-          <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
-            <rect x="3" y="3" width="10" height="10" rx="1.5" fill="currentColor" />
-          </svg>
-          Stop
-        </button>
-      </div>
-    )}
     {(status === 'done' || status === 'error') && (
       <SessionEndBar
         status={status}
         exitCode={lastExitCode}
         canResume={canResume}
         onContinue={onContinue}
-        onNewSession={onNewSession}
         onCopyOutput={onCopyOutput}
       />
     )}
@@ -86,22 +39,29 @@ export const AgentTerminal = ({
 );
 
 /**
- * Footer chrome shown after an agent exits. Replaces the old solitary
- * "Restart" button with a friendlier "the conversation is paused, here's
- * how to continue" presentation:
+ * Footer chrome shown after an agent exits. Surfaces:
  *
- *   [● Done · exit 0]  [▸ Continue]   [↻ Start fresh]  [⎘ Copy]
+ *   [● Done · exit 0]  [▸ Continue]                          [⎘ Copy]
  *
- * The primary action (Continue / Retry) is hidden when the agent doesn't
- * support id-based resume — in that case the user only sees the
- * Start-fresh and Copy escape hatches.
+ * Continue / Retry is the only path back into the conversation — the
+ * explicit "Restart / Start fresh" affordance was removed entirely so
+ * users never have to reason about throwing away the agent state. To
+ * truly start over they close the node and create a new one, which is
+ * the same mental model as "this conversation is finished, open a new
+ * one". For agents that don't support id-based resume, the Continue
+ * button is hidden and the bar only shows status + Copy.
+ *
+ * Running-state chrome (the old quick-actions bar with Continue /
+ * Summarize / Stop) was removed for similar reasons: in-flight
+ * Continue/Summarize prompts fought with the agent's own turn, and
+ * Stop overlapped with the agent's `esc to interrupt` plus the
+ * node-close button.
  */
 interface SessionEndBarProps {
   status: 'done' | 'error' | string;
   exitCode?: number;
   canResume: boolean;
   onContinue: () => void;
-  onNewSession: () => void;
   onCopyOutput?: () => void;
 }
 
@@ -110,7 +70,6 @@ const SessionEndBar = ({
   exitCode,
   canResume,
   onContinue,
-  onNewSession,
   onCopyOutput,
 }: SessionEndBarProps) => {
   // `status === 'error'` covers spawn-failure cases (no exit code).
@@ -158,14 +117,6 @@ const SessionEndBar = ({
         </button>
       )}
       <span className="agent-session-spacer" />
-      <button
-        type="button"
-        className="agent-session-secondary"
-        onClick={onNewSession}
-        title="Start a brand-new conversation (clears the resume id)"
-      >
-        Start fresh
-      </button>
       {onCopyOutput && (
         <button
           type="button"

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTerminal.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTerminal.tsx
@@ -3,7 +3,14 @@ import type React from 'react';
 interface AgentTerminalProps {
   containerRef: React.RefObject<HTMLDivElement>;
   status: string;
-  onRestart: () => void;
+  lastExitCode?: number;
+  /** When true, the agent CLI supports id-based resume — the session-end
+   *  bar will offer a Continue/Retry primary action. Otherwise only the
+   *  Start-fresh path is shown. */
+  canResume?: boolean;
+  onContinue: () => void;
+  onNewSession: () => void;
+  onCopyOutput?: () => void;
   onStop?: () => void;
   onSendPrompt?: (prompt: string) => void;
 }
@@ -14,7 +21,11 @@ const SUMMARIZE_PROMPT = 'please summarize what you have done so far';
 export const AgentTerminal = ({
   containerRef,
   status,
-  onRestart,
+  lastExitCode,
+  canResume = false,
+  onContinue,
+  onNewSession,
+  onCopyOutput,
   onStop,
   onSendPrompt,
 }: AgentTerminalProps) => (
@@ -62,23 +73,113 @@ export const AgentTerminal = ({
       </div>
     )}
     {(status === 'done' || status === 'error') && (
-      <button
-        type="button"
-        className="agent-restart-btn"
-        onClick={onRestart}
-        title="Restart agent"
-      >
-        <svg width="11" height="11" viewBox="0 0 16 16" fill="none">
-          <path
-            d="M13 8a5 5 0 1 1-1.5-3.6M13 3v2.5H10.5"
-            stroke="currentColor"
-            strokeWidth="1.4"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-        Restart
-      </button>
+      <SessionEndBar
+        status={status}
+        exitCode={lastExitCode}
+        canResume={canResume}
+        onContinue={onContinue}
+        onNewSession={onNewSession}
+        onCopyOutput={onCopyOutput}
+      />
     )}
   </div>
 );
+
+/**
+ * Footer chrome shown after an agent exits. Replaces the old solitary
+ * "Restart" button with a friendlier "the conversation is paused, here's
+ * how to continue" presentation:
+ *
+ *   [● Done · exit 0]  [▸ Continue]   [↻ Start fresh]  [⎘ Copy]
+ *
+ * The primary action (Continue / Retry) is hidden when the agent doesn't
+ * support id-based resume — in that case the user only sees the
+ * Start-fresh and Copy escape hatches.
+ */
+interface SessionEndBarProps {
+  status: 'done' | 'error' | string;
+  exitCode?: number;
+  canResume: boolean;
+  onContinue: () => void;
+  onNewSession: () => void;
+  onCopyOutput?: () => void;
+}
+
+const SessionEndBar = ({
+  status,
+  exitCode,
+  canResume,
+  onContinue,
+  onNewSession,
+  onCopyOutput,
+}: SessionEndBarProps) => {
+  // `status === 'error'` covers spawn-failure cases (no exit code).
+  // A non-zero `exitCode` covers normal-runtime failures. Either way
+  // we want the badge / button to read as a recoverable error.
+  const isError = status === 'error'
+    || (typeof exitCode === 'number' && exitCode !== 0);
+  const badgeLabel = isError
+    ? `Error${typeof exitCode === 'number' ? ` · exit ${exitCode}` : ''}`
+    : 'Done';
+  const primaryLabel = isError ? 'Retry' : 'Continue';
+  const primaryTitle = isError
+    ? 'Retry — resume the conversation in a new shell'
+    : 'Continue — resume the conversation in a new shell';
+
+  return (
+    <div className={`agent-session-end-bar${isError ? ' agent-session-end-bar--error' : ''}`}>
+      <span className={`agent-session-badge${isError ? ' agent-session-badge--error' : ''}`}>
+        <span className="agent-session-badge-dot" aria-hidden="true" />
+        {badgeLabel}
+      </span>
+      {canResume && (
+        <button
+          type="button"
+          className={`agent-session-primary${isError ? ' agent-session-primary--error' : ''}`}
+          onClick={onContinue}
+          title={primaryTitle}
+        >
+          {isError ? (
+            <svg width="11" height="11" viewBox="0 0 16 16" fill="none">
+              <path
+                d="M13 8a5 5 0 1 1-1.5-3.6M13 3v2.5H10.5"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          ) : (
+            <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
+              <path d="M5 3l6 5-6 5V3z" fill="currentColor" />
+            </svg>
+          )}
+          {primaryLabel}
+        </button>
+      )}
+      <span className="agent-session-spacer" />
+      <button
+        type="button"
+        className="agent-session-secondary"
+        onClick={onNewSession}
+        title="Start a brand-new conversation (clears the resume id)"
+      >
+        Start fresh
+      </button>
+      {onCopyOutput && (
+        <button
+          type="button"
+          className="agent-session-secondary"
+          onClick={onCopyOutput}
+          title="Copy terminal output as plain text"
+          aria-label="Copy output"
+        >
+          <svg width="11" height="11" viewBox="0 0 16 16" fill="none">
+            <rect x="5" y="2" width="9" height="11" rx="1.5" stroke="currentColor" strokeWidth="1.2" />
+            <path d="M3 5v8.5A1.5 1.5 0 0 0 4.5 15H11" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTerminal.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTerminal.tsx
@@ -41,21 +41,20 @@ export const AgentTerminal = ({
 /**
  * Footer chrome shown after an agent exits. Surfaces:
  *
- *   [● Done · exit 0]  [▸ Continue]                          [⎘ Copy]
+ *   [● Ended]  [▸ Continue]                                   [⎘ Copy]
  *
- * Continue / Retry is the only path back into the conversation — the
- * explicit "Restart / Start fresh" affordance was removed entirely so
- * users never have to reason about throwing away the agent state. To
- * truly start over they close the node and create a new one, which is
- * the same mental model as "this conversation is finished, open a new
- * one". For agents that don't support id-based resume, the Continue
- * button is hidden and the bar only shows status + Copy.
+ * Continue is the only path back into the conversation — the explicit
+ * "Restart / Start fresh" affordance was removed entirely so users
+ * never reason about throwing away agent state. To truly start over,
+ * close the node and create a new one. For agents that don't support
+ * id-based resume the Continue button is hidden and the bar only shows
+ * status + Copy.
  *
- * Running-state chrome (the old quick-actions bar with Continue /
- * Summarize / Stop) was removed for similar reasons: in-flight
- * Continue/Summarize prompts fought with the agent's own turn, and
- * Stop overlapped with the agent's `esc to interrupt` plus the
- * node-close button.
+ * Visual is deliberately monochrome: spawn failures, non-zero exits,
+ * and clean exits all render the same neutral "Ended" pill. Exit-code
+ * details surface only on hover so they don't dominate the canvas at
+ * a glance — what matters for the user is "session is over, pick up
+ * if you want", not the exit-code post-mortem.
  */
 interface SessionEndBarProps {
   status: 'done' | 'error' | string;
@@ -72,48 +71,30 @@ const SessionEndBar = ({
   onContinue,
   onCopyOutput,
 }: SessionEndBarProps) => {
-  // `status === 'error'` covers spawn-failure cases (no exit code).
-  // A non-zero `exitCode` covers normal-runtime failures. Either way
-  // we want the badge / button to read as a recoverable error.
-  const isError = status === 'error'
-    || (typeof exitCode === 'number' && exitCode !== 0);
-  const badgeLabel = isError
-    ? `Error${typeof exitCode === 'number' ? ` · exit ${exitCode}` : ''}`
-    : 'Done';
-  const primaryLabel = isError ? 'Retry' : 'Continue';
-  const primaryTitle = isError
-    ? 'Retry — resume the conversation in a new shell'
-    : 'Continue — resume the conversation in a new shell';
+  let detailTitle = 'Session ended';
+  if (status === 'error') {
+    detailTitle = 'Session failed to start';
+  } else if (typeof exitCode === 'number' && exitCode !== 0) {
+    detailTitle = `Session ended · exit ${exitCode}`;
+  }
 
   return (
-    <div className={`agent-session-end-bar${isError ? ' agent-session-end-bar--error' : ''}`}>
-      <span className={`agent-session-badge${isError ? ' agent-session-badge--error' : ''}`}>
+    <div className="agent-session-end-bar">
+      <span className="agent-session-badge" title={detailTitle}>
         <span className="agent-session-badge-dot" aria-hidden="true" />
-        {badgeLabel}
+        Ended
       </span>
       {canResume && (
         <button
           type="button"
-          className={`agent-session-primary${isError ? ' agent-session-primary--error' : ''}`}
+          className="agent-session-primary"
           onClick={onContinue}
-          title={primaryTitle}
+          title="Continue — resume the conversation in a new shell"
         >
-          {isError ? (
-            <svg width="11" height="11" viewBox="0 0 16 16" fill="none">
-              <path
-                d="M13 8a5 5 0 1 1-1.5-3.6M13 3v2.5H10.5"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          ) : (
-            <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
-              <path d="M5 3l6 5-6 5V3z" fill="currentColor" />
-            </svg>
-          )}
-          {primaryLabel}
+          <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
+            <path d="M5 3l6 5-6 5V3z" fill="currentColor" />
+          </svg>
+          Continue
         </button>
       )}
       <span className="agent-session-spacer" />

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
@@ -37,7 +37,7 @@
 
 .agent-launcher-prompt {
   flex: 1;
-  min-height: 72px;
+  min-height: 56px;
   padding: 14px 16px 12px;
   border: none;
   background: transparent;

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
@@ -333,33 +333,122 @@
   color: #e03e3e;
 }
 
-/* ── Restart button (top-right of running body) ── */
+/* ── Session-end bar (footer chrome after agent exits) ──────────────
+ *
+ * Replaces the older lone "Restart" button. Sits along the bottom of the
+ * node body and pairs a status badge with the conversation-continuation
+ * affordances (Continue / Retry as the primary path, Start-fresh and
+ * Copy as escape hatches). Background is translucent so the last lines
+ * of terminal output remain partially visible underneath. */
 
-.agent-restart-btn {
+.agent-session-end-bar {
   position: absolute;
-  top: 6px;
+  left: 8px;
   right: 8px;
+  bottom: 8px;
   z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.94);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  box-shadow: var(--shadow-sm);
+  font-family: var(--font);
+}
+
+.agent-session-end-bar--error {
+  border-color: rgba(224, 62, 62, 0.35);
+  background: rgba(255, 244, 244, 0.96);
+}
+
+.agent-session-badge {
   display: inline-flex;
   align-items: center;
+  gap: 5px;
+  padding: 0 2px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #2f8a5a; /* Done — calm green */
+  letter-spacing: 0.1px;
+  white-space: nowrap;
+}
+
+.agent-session-badge--error {
+  color: #c4322d;
+}
+
+.agent-session-badge-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 0 2px rgba(47, 138, 90, 0.18);
+}
+
+.agent-session-badge--error .agent-session-badge-dot {
+  box-shadow: 0 0 0 2px rgba(196, 50, 45, 0.18);
+}
+
+.agent-session-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 24px;
+  padding: 0 11px;
+  border: none;
+  border-radius: 6px;
+  background: var(--accent);
+  color: #ffffff;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: var(--font);
+  cursor: pointer;
+  transition: filter 0.12s, box-shadow 0.12s;
+  box-shadow: 0 1px 2px rgba(35, 131, 226, 0.25);
+}
+
+.agent-session-primary:hover {
+  filter: brightness(1.08);
+  box-shadow: 0 2px 5px rgba(35, 131, 226, 0.3);
+}
+
+.agent-session-primary--error {
+  background: #c4322d;
+  box-shadow: 0 1px 2px rgba(196, 50, 45, 0.3);
+}
+
+.agent-session-primary--error:hover {
+  box-shadow: 0 2px 5px rgba(196, 50, 45, 0.35);
+}
+
+.agent-session-spacer {
+  flex: 1;
+}
+
+.agent-session-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   gap: 4px;
-  padding: 3px 9px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.92);
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
-  color: var(--text-secondary);
+  height: 24px;
+  padding: 0 9px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
   font-size: 11px;
   font-weight: 500;
   font-family: var(--font);
   cursor: pointer;
-  box-shadow: var(--shadow-sm);
   transition: background 0.12s, border-color 0.12s, color 0.12s;
 }
 
-.agent-restart-btn:hover {
-  background: var(--surface);
-  border-color: var(--text-muted);
+.agent-session-secondary:hover {
+  background: var(--border-light);
+  border-color: var(--border);
   color: var(--text);
 }

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
@@ -312,11 +312,6 @@
   font-family: var(--font);
 }
 
-.agent-session-end-bar--error {
-  border-color: rgba(224, 62, 62, 0.35);
-  background: rgba(255, 244, 244, 0.96);
-}
-
 .agent-session-badge {
   display: inline-flex;
   align-items: center;
@@ -324,25 +319,16 @@
   padding: 0 2px;
   font-size: 11px;
   font-weight: 600;
-  color: #2f8a5a; /* Done — calm green */
+  color: var(--text-muted);
   letter-spacing: 0.1px;
   white-space: nowrap;
 }
 
-.agent-session-badge--error {
-  color: #c4322d;
-}
-
 .agent-session-badge-dot {
-  width: 7px;
-  height: 7px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
   background: currentColor;
-  box-shadow: 0 0 0 2px rgba(47, 138, 90, 0.18);
-}
-
-.agent-session-badge--error .agent-session-badge-dot {
-  box-shadow: 0 0 0 2px rgba(196, 50, 45, 0.18);
 }
 
 .agent-session-primary {
@@ -351,30 +337,21 @@
   gap: 5px;
   height: 24px;
   padding: 0 11px;
-  border: none;
+  border: 1px solid var(--border);
   border-radius: 6px;
-  background: var(--accent);
-  color: #ffffff;
+  background: var(--surface);
+  color: var(--text);
   font-size: 11px;
-  font-weight: 600;
+  font-weight: 500;
   font-family: var(--font);
   cursor: pointer;
-  transition: filter 0.12s, box-shadow 0.12s;
-  box-shadow: 0 1px 2px rgba(35, 131, 226, 0.25);
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
 }
 
 .agent-session-primary:hover {
-  filter: brightness(1.08);
-  box-shadow: 0 2px 5px rgba(35, 131, 226, 0.3);
-}
-
-.agent-session-primary--error {
-  background: #c4322d;
-  box-shadow: 0 1px 2px rgba(196, 50, 45, 0.3);
-}
-
-.agent-session-primary--error:hover {
-  box-shadow: 0 2px 5px rgba(196, 50, 45, 0.35);
+  background: var(--surface-hover);
+  border-color: var(--text-muted);
+  color: var(--text);
 }
 
 .agent-session-spacer {

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
@@ -285,54 +285,6 @@
   padding: 0 4px;
 }
 
-/* ── Quick action buttons (running state) ── */
-
-.agent-quick-actions {
-  position: absolute;
-  bottom: 8px;
-  right: 8px;
-  z-index: 10;
-  display: flex;
-  gap: 4px;
-  opacity: 0;
-  transition: opacity 0.15s;
-}
-
-.agent-body-wrap:hover .agent-quick-actions {
-  opacity: 1;
-}
-
-.agent-quick-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 3px 9px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.92);
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
-  color: var(--text-secondary);
-  font-size: 11px;
-  font-weight: 500;
-  font-family: var(--font);
-  cursor: pointer;
-  box-shadow: var(--shadow-sm);
-  transition: background 0.12s, border-color 0.12s, color 0.12s;
-}
-
-.agent-quick-btn:hover {
-  background: var(--surface);
-  border-color: var(--text-muted);
-  color: var(--text);
-}
-
-.agent-quick-btn--stop:hover {
-  background: rgba(224, 62, 62, 0.08);
-  border-color: #e03e3e;
-  color: #e03e3e;
-}
-
 /* ── Session-end bar (footer chrome after agent exits) ──────────────
  *
  * Replaces the older lone "Restart" button. Sits along the bottom of the

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -93,15 +93,6 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
   /** Tracks whether spawnAgent entered the restored (no-PTY) branch so the
    * cleanup effect knows to skip PTY-related teardown. */
   const isRestoredRef = useRef(false);
-  /**
-   * Set by handleStop right before it kills the PTY so the subsequent
-   * `onExit` handler doesn't overwrite the clean exit code we just
-   * persisted. Without this the PTY's true kill exit code (e.g. 137 for
-   * SIGKILL) leaks into `lastExitCode` and the session-end badge
-   * misleadingly shows "Error · exit 137" for a user-initiated stop.
-   * Auto-resets inside the onExit handler.
-   */
-  const userStoppedRef = useRef(false);
 
   const spawnAgent = useCallback(
     async (
@@ -299,13 +290,6 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
 
       const removeExit = api.onExit(sessionId, (code: number) => {
         term.writeln(`\r\n\x1b[2m[Agent exited with code ${code}]\x1b[0m`);
-        // If the user clicked Stop, handleStop already wrote
-        // status='done' / lastExitCode=0 — don't clobber it with the
-        // SIGKILL exit code.
-        if (userStoppedRef.current) {
-          userStoppedRef.current = false;
-          return;
-        }
         // Status stays 'done' regardless of code — the badge in
         // SessionEndBar branches on `lastExitCode` instead. `status:
         // 'error'` remains reserved for *spawn* failures (see the
@@ -443,25 +427,6 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
     setLaunched(true);
   }, [selectedAgent, cwdInput, promptInput, rootFolder, readOnly]);
 
-  const handleStop = useCallback(() => {
-    if (readOnly) return;
-    const api = window.canvasWorkspace?.pty;
-    // Signal the imminent onExit firing as user-initiated so it doesn't
-    // overwrite our `lastExitCode: 0` with the kill code.
-    userStoppedRef.current = true;
-    if (api) api.kill(sessionId);
-    onUpdateRef.current(nodeIdRef.current, {
-      data: { ...dataRef.current, status: 'done', lastExitCode: 0 },
-    });
-  }, [sessionId, readOnly]);
-
-  const handleSendPrompt = useCallback((prompt: string) => {
-    if (readOnly) return;
-    const api = window.canvasWorkspace?.pty;
-    if (!api) return;
-    api.write(sessionId, `\n${prompt}\n`);
-  }, [sessionId, readOnly]);
-
   const handleMentionSelect = useCallback((selected: CanvasNode) => {
     if (readOnly) return;
     setPickerOpen(false);
@@ -515,43 +480,6 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
       true,
     );
   }, [readOnly, spawnAgent]);
-
-  /**
-   * "Start fresh" — the explicit "throw away this conversation" path,
-   * tucked behind a secondary menu so casual users won't hit it by
-   * accident. Clears all session keys (sessionId, scrollback, resumeId,
-   * lastExitCode) so the next launch allocates a brand-new conversation.
-   *
-   * Intentionally preserves `inlinePrompt` and `cwd` so the picker
-   * pre-fills the user's last request — avoiding the "I just want to
-   * tweak my prompt and run it again" retyping tax.
-   */
-  const handleNewSession = useCallback(() => {
-    if (readOnly) return;
-    if (saveTimerRef.current) clearInterval(saveTimerRef.current);
-    cleanupRef.current?.();
-    termRef.current?.dispose();
-    termRef.current = null;
-    fitRef.current = null;
-    spawnedRef.current = false;
-    cleanupRef.current = null;
-    initialScrollback.current = '';
-    userLaunchedRef.current = false;
-    isRestoredRef.current = false;
-
-    onUpdateRef.current(nodeIdRef.current, {
-      data: {
-        ...dataRef.current,
-        status: 'idle',
-        scrollback: '',
-        sessionId: '',
-        resumeId: '',
-        lastExitCode: undefined,
-      },
-    });
-
-    setLaunched(false);
-  }, [readOnly]);
 
   /**
    * Copy the visible terminal output as plain text (ANSI escapes
@@ -618,10 +546,7 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
         lastExitCode={data.lastExitCode}
         canResume={!!getAgentDef(data.agentType)?.resume}
         onContinue={handleContinue}
-        onNewSession={handleNewSession}
         onCopyOutput={handleCopyOutput}
-        onStop={handleStop}
-        onSendPrompt={handleSendPrompt}
       />
     </div>
   );

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -87,12 +87,21 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
    * ref with `data.sessionId`/`data.scrollback` to tell the two apart.
    *
    * Stays `false` across re-renders; flipped to `true` in `handleLaunch`
-   * and reset in `handleRestart`.
+   * and reset in `handleNewSession`.
    */
   const userLaunchedRef = useRef(false);
   /** Tracks whether spawnAgent entered the restored (no-PTY) branch so the
    * cleanup effect knows to skip PTY-related teardown. */
   const isRestoredRef = useRef(false);
+  /**
+   * Set by handleStop right before it kills the PTY so the subsequent
+   * `onExit` handler doesn't overwrite the clean exit code we just
+   * persisted. Without this the PTY's true kill exit code (e.g. 137 for
+   * SIGKILL) leaks into `lastExitCode` and the session-end badge
+   * misleadingly shows "Error · exit 137" for a user-initiated stop.
+   * Auto-resets inside the onExit handler.
+   */
+  const userStoppedRef = useRef(false);
 
   const spawnAgent = useCallback(
     async (
@@ -263,11 +272,12 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
           api.write(sessionId, `${cmd}\n`);
         }
 
-        if (effectivePrompt || promptFile) {
-          onUpdateRef.current(nodeIdRef.current, {
-            data: { ...dataRef.current, inlinePrompt: '', promptFile: '' },
-          });
-        }
+        // Intentionally NOT clearing `inlinePrompt` / `promptFile` here:
+        // keeping the last prompt around lets the picker pre-fill on a
+        // Start-fresh, so users don't have to retype a similar request.
+        // The resume path skips re-passing the prompt anyway (see the
+        // `canResume` early return above), so a stale `inlinePrompt`
+        // can't double-fire during cold reload.
       };
 
       let prompted = false;
@@ -289,8 +299,19 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
 
       const removeExit = api.onExit(sessionId, (code: number) => {
         term.writeln(`\r\n\x1b[2m[Agent exited with code ${code}]\x1b[0m`);
+        // If the user clicked Stop, handleStop already wrote
+        // status='done' / lastExitCode=0 — don't clobber it with the
+        // SIGKILL exit code.
+        if (userStoppedRef.current) {
+          userStoppedRef.current = false;
+          return;
+        }
+        // Status stays 'done' regardless of code — the badge in
+        // SessionEndBar branches on `lastExitCode` instead. `status:
+        // 'error'` remains reserved for *spawn* failures (see the
+        // `if (!result.ok)` branch above).
         onUpdateRef.current(nodeIdRef.current, {
-          data: { ...dataRef.current, status: 'done' },
+          data: { ...dataRef.current, status: 'done', lastExitCode: code },
         });
       });
 
@@ -425,9 +446,12 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
   const handleStop = useCallback(() => {
     if (readOnly) return;
     const api = window.canvasWorkspace?.pty;
+    // Signal the imminent onExit firing as user-initiated so it doesn't
+    // overwrite our `lastExitCode: 0` with the kill code.
+    userStoppedRef.current = true;
     if (api) api.kill(sessionId);
     onUpdateRef.current(nodeIdRef.current, {
-      data: { ...dataRef.current, status: 'done' },
+      data: { ...dataRef.current, status: 'done', lastExitCode: 0 },
     });
   }, [sessionId, readOnly]);
 
@@ -458,7 +482,51 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
     termRef.current?.focus();
   }, []);
 
-  const handleRestart = useCallback(() => {
+  /**
+   * "Continue" — keep the conversation alive without surfacing a
+   * "restart" concept to the user. Tears down the dead PTY refs and
+   * re-invokes spawnAgent on the resume path so the agent re-attaches
+   * to the same `resumeId` and the prior scrollback is preserved as a
+   * faded preamble. Only meaningful for resume-capable agents; the
+   * caller (session-end bar) hides this action otherwise.
+   */
+  const handleContinue = useCallback(() => {
+    if (readOnly) return;
+    if (saveTimerRef.current) clearInterval(saveTimerRef.current);
+    cleanupRef.current?.();
+    termRef.current?.dispose();
+    termRef.current = null;
+    fitRef.current = null;
+    spawnedRef.current = false;
+    cleanupRef.current = null;
+    isRestoredRef.current = false;
+
+    // Use the *latest* persisted scrollback as the resume preamble.
+    // The mount-time `initialScrollback` ref would be stale after the
+    // user has continued one or more times in this session.
+    initialScrollback.current = dataRef.current.scrollback ?? '';
+
+    // Spawn on the resume path: spawnAgent reads `agentDef.resume` plus
+    // `dataRef.current.resumeId` and writes `<agent> --resume <id>`.
+    void spawnAgent(
+      dataRef.current.agentType,
+      dataRef.current.cwd ?? '',
+      undefined,
+      true,
+    );
+  }, [readOnly, spawnAgent]);
+
+  /**
+   * "Start fresh" — the explicit "throw away this conversation" path,
+   * tucked behind a secondary menu so casual users won't hit it by
+   * accident. Clears all session keys (sessionId, scrollback, resumeId,
+   * lastExitCode) so the next launch allocates a brand-new conversation.
+   *
+   * Intentionally preserves `inlinePrompt` and `cwd` so the picker
+   * pre-fills the user's last request — avoiding the "I just want to
+   * tweak my prompt and run it again" retyping tax.
+   */
+  const handleNewSession = useCallback(() => {
     if (readOnly) return;
     if (saveTimerRef.current) clearInterval(saveTimerRef.current);
     cleanupRef.current?.();
@@ -468,19 +536,45 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
     spawnedRef.current = false;
     cleanupRef.current = null;
     initialScrollback.current = '';
-    // Next Start click must be treated as a fresh user launch, not a
-    // restore — clear the flag so the mount effect won't short-circuit.
     userLaunchedRef.current = false;
     isRestoredRef.current = false;
 
     onUpdateRef.current(nodeIdRef.current, {
-      // Clearing `resumeId` ensures the next Start allocates a fresh
-      // conversation rather than re-attaching to the previous one.
-      data: { ...dataRef.current, status: 'idle', scrollback: '', sessionId: '', resumeId: '' },
+      data: {
+        ...dataRef.current,
+        status: 'idle',
+        scrollback: '',
+        sessionId: '',
+        resumeId: '',
+        lastExitCode: undefined,
+      },
     });
 
     setLaunched(false);
   }, [readOnly]);
+
+  /**
+   * Copy the visible terminal output as plain text (ANSI escapes
+   * stripped), so users can grab a result without scrolling-selecting
+   * inside xterm.
+   */
+  const handleCopyOutput = useCallback(async () => {
+    const term = termRef.current;
+    if (!term) return;
+    const buf = term.buffer.active;
+    const lines: string[] = [];
+    for (let i = 0; i < buf.length; i++) {
+      const line = buf.getLine(i);
+      if (line) lines.push(line.translateToString(true));
+    }
+    const text = lines.join('\n').replace(/\n+$/, '');
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      /* clipboard permission denied — silent fail; nothing critical */
+    }
+  }, []);
 
   const handlePickFolder = useCallback(async () => {
     if (readOnly) return;
@@ -521,7 +615,11 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
       <AgentTerminal
         containerRef={containerRef}
         status={status}
-        onRestart={handleRestart}
+        lastExitCode={data.lastExitCode}
+        canResume={!!getAgentDef(data.agentType)?.resume}
+        onContinue={handleContinue}
+        onNewSession={handleNewSession}
+        onCopyOutput={handleCopyOutput}
         onStop={handleStop}
         onSendPrompt={handleSendPrompt}
       />

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -4,7 +4,7 @@ import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import type { CanvasNode, AgentNodeData, FileNodeData } from '../../types';
 import { TERMINAL_OPTIONS } from '../../config/terminalTheme';
-import { getAgentCommand } from '../../config/agentRegistry';
+import { getAgentDef } from '../../config/agentRegistry';
 import {
   SCROLLBACK_SAVE_INTERVAL,
   loadRecentCwds,
@@ -102,6 +102,16 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
       isRestored = false,
     ) => {
       if (!containerRef.current || termRef.current || spawnedRef.current) return;
+
+      const agentDef = getAgentDef(agentType);
+      // A cold-reloaded node can re-attach to its prior conversation only
+      // when the agent CLI supports id-based resume AND we previously
+      // persisted a resumeId on first launch. Otherwise we fall back to a
+      // static replay of the saved scrollback.
+      const canResume = isRestored
+        && !!agentDef?.resume
+        && !!dataRef.current.resumeId;
+
       if (readOnly) {
         spawnedRef.current = true;
         isRestoredRef.current = true;
@@ -123,8 +133,47 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
         });
         return;
       }
+
+      // Cold reload of an agent that can't resume — show the saved output
+      // as static text and let the user explicitly Restart for a fresh run.
+      if (isRestored && !canResume) {
+        spawnedRef.current = true;
+        isRestoredRef.current = true;
+        const term = new Terminal(TERMINAL_OPTIONS);
+        const fitAddon = new FitAddon();
+        term.loadAddon(fitAddon);
+        term.open(containerRef.current);
+        termRef.current = term;
+        fitRef.current = fitAddon;
+        term.attachCustomKeyEventHandler((e: KeyboardEvent) => {
+          if (e.type === 'keydown' && e.key === '2' && (e.ctrlKey || e.metaKey) && !e.altKey) {
+            setPickerOpen(true);
+            return false;
+          }
+          return true;
+        });
+        requestAnimationFrame(() => {
+          try { fitAddon.fit(); } catch { /* ignore */ }
+        });
+        if (initialScrollback.current) {
+          term.writeln('\x1b[2m--- restored from previous session ---\x1b[0m');
+          term.write(initialScrollback.current.split('\n').join('\r\n'));
+          term.writeln('');
+        } else {
+          term.writeln('\x1b[2m--- previous session (no saved output) ---\x1b[0m');
+        }
+        if (dataRef.current.status !== 'done') {
+          onUpdateRef.current(nodeIdRef.current, {
+            data: { ...dataRef.current, status: 'done' },
+          });
+        }
+        return;
+      }
+
+      // Live PTY path — fresh user launch, OR cold reload of a resume-
+      // capable agent (we'll write the agent's resume command below).
       spawnedRef.current = true;
-      isRestoredRef.current = isRestored;
+      isRestoredRef.current = false;
 
       const term = new Terminal(TERMINAL_OPTIONS);
       const fitAddon = new FitAddon();
@@ -145,24 +194,12 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
         try { fitAddon.fit(); } catch { /* ignore */ }
       });
 
-      if (isRestored) {
-        // Cold reload: the PTY was killed on the previous unmount, so we
-        // cannot reattach. Replay the full saved scrollback as static
-        // output and mark status as 'done' so the Restart button shows.
-        // The user can click Restart to explicitly spawn a fresh session.
-        if (initialScrollback.current) {
-          term.writeln('\x1b[2m--- restored from previous session ---\x1b[0m');
-          term.write(initialScrollback.current.split('\n').join('\r\n'));
-          term.writeln('');
-        } else {
-          term.writeln('\x1b[2m--- previous session (no saved output) ---\x1b[0m');
-        }
-        if (dataRef.current.status !== 'done') {
-          onUpdateRef.current(nodeIdRef.current, {
-            data: { ...dataRef.current, status: 'done' },
-          });
-        }
-        return;
+      // On resume, surface the prior conversation as a faded preamble so
+      // the user sees history above the re-attached live session.
+      if (canResume && initialScrollback.current) {
+        term.writeln('\x1b[2m--- previous session (resuming) ---\x1b[0m');
+        term.write(initialScrollback.current.split('\n').join('\r\n'));
+        term.writeln('');
       }
 
       const api = window.canvasWorkspace?.pty;
@@ -181,24 +218,49 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
         return;
       }
 
-      // Resolve the agent command to write once the shell is ready
-      const command = getAgentCommand(agentType);
+      // Decide the resumable conversation id for this launch:
+      //   - canResume: reuse the persisted id, run `--resume <id>`
+      //   - fresh launch of a resume-capable agent: pre-allocate a UUID
+      //     and start with `--session-id <id>` so a future cold reload can
+      //     re-attach by id
+      //   - non-resumable agent: leave undefined, run the plain command
+      let resumeId: string | undefined = dataRef.current.resumeId;
+      if (!canResume && !resumeId && agentDef?.resume) {
+        resumeId = crypto.randomUUID();
+      }
+
       const writeCommand = () => {
-        if (!command) {
+        let cmd: string;
+        if (canResume && resumeId && agentDef?.resume) {
+          cmd = agentDef.resume.resume(resumeId);
+        } else if (resumeId && agentDef?.resume) {
+          cmd = agentDef.resume.startWithId(resumeId);
+        } else if (agentDef?.command) {
+          cmd = agentDef.command;
+        } else {
           term.writeln(`\x1b[33mUnknown agent type: ${agentType}\x1b[0m`);
           return;
         }
+
+        // Resuming attaches to an existing conversation that already
+        // contains the user's original prompt — re-passing it would
+        // create a duplicate turn. Just launch the resume command.
+        if (canResume) {
+          api.write(sessionId, `${cmd}\n`);
+          return;
+        }
+
         const { inlinePrompt, promptFile, agentArgs } = dataRef.current;
         const effectivePrompt = inlinePromptOverride || inlinePrompt;
         if (effectivePrompt) {
           const escaped = effectivePrompt.replace(/'/g, "'\\''");
-          api.write(sessionId, `${command} '${escaped}'\n`);
+          api.write(sessionId, `${cmd} '${escaped}'\n`);
         } else if (promptFile) {
-          api.write(sessionId, `__prompt=$(cat ${promptFile}) && ${command} "$__prompt"\n`);
+          api.write(sessionId, `__prompt=$(cat ${promptFile}) && ${cmd} "$__prompt"\n`);
         } else if (agentArgs) {
-          api.write(sessionId, `${command} ${agentArgs}\n`);
+          api.write(sessionId, `${cmd} ${agentArgs}\n`);
         } else {
-          api.write(sessionId, `${command}\n`);
+          api.write(sessionId, `${cmd}\n`);
         }
 
         if (effectivePrompt || promptFile) {
@@ -239,7 +301,14 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
       term.onResize(({ cols, rows }) => { api.resize(sessionId, cols, rows); });
 
       onUpdateRef.current(nodeIdRef.current, {
-        data: { ...dataRef.current, agentType, cwd: spawnCwd ?? '', status: 'running', sessionId },
+        data: {
+          ...dataRef.current,
+          agentType,
+          cwd: spawnCwd ?? '',
+          status: 'running',
+          sessionId,
+          ...(resumeId ? { resumeId } : {}),
+        },
       });
 
       saveTimerRef.current = setInterval(async () => {
@@ -268,7 +337,9 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
       //   a) Cold reload of a real previous session — the prior PTY had
       //      spawned (so `sessionId` was persisted by spawnAgent) or had
       //      output serialized to `scrollback`. The PTY was killed on the
-      //      previous unmount and cannot be reattached; replay scrollback.
+      //      previous unmount; if the agent CLI supports id-based resume
+      //      and a `resumeId` is persisted, spawnAgent re-attaches by id,
+      //      otherwise it falls back to a static replay of scrollback.
       //   b) A tool just created this node (e.g.
       //      `canvas_create_agent_node` with autoLaunch) and persisted
       //      `status: 'running'` without ever spawning a PTY. `sessionId`
@@ -403,7 +474,9 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
     isRestoredRef.current = false;
 
     onUpdateRef.current(nodeIdRef.current, {
-      data: { ...dataRef.current, status: 'idle', scrollback: '', sessionId: '' },
+      // Clearing `resumeId` ensures the next Start allocates a fresh
+      // conversation rather than re-attaching to the previous one.
+      data: { ...dataRef.current, status: 'idle', scrollback: '', sessionId: '', resumeId: '' },
     });
 
     setLaunched(false);

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -142,12 +142,9 @@
   animation: nodeStatusPulse 1.8s ease-in-out infinite;
 }
 
-.node-status-dot--done {
-  background: var(--text-muted);
-}
-
+.node-status-dot--done,
 .node-status-dot--error {
-  background: #e03e3e;
+  background: var(--text-muted);
 }
 
 @keyframes nodeStatusPulse {

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -208,38 +208,6 @@
   box-shadow: 0 0 0 1.5px var(--accent-border);
 }
 
-/* Agent status label pill */
-.node-status-label {
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  padding: 1px 6px;
-  border-radius: 999px;
-  flex-shrink: 0;
-  white-space: nowrap;
-  opacity: 0;
-  transition: opacity 0.1s;
-}
-
-.canvas-node:hover .node-status-label {
-  opacity: 1;
-}
-
-.node-status-label--running {
-  background: rgba(16, 185, 129, 0.12);
-  color: #059669;
-}
-
-.node-status-label--done {
-  background: rgba(0, 0, 0, 0.05);
-  color: var(--text-muted);
-}
-
-.node-status-label--error {
-  background: rgba(224, 62, 62, 0.1);
-  color: #e03e3e;
-}
-
 /* Last active time label */
 .node-time-label {
   font-size: 10px;
@@ -747,7 +715,6 @@
 .canvas-node--fullscreen .text-color-trigger,
 .canvas-node--fullscreen .group-ungroup-button,
 .canvas-node--fullscreen .group-count-label,
-.canvas-node--fullscreen .node-status-label,
 .canvas-node--fullscreen .node-close--floating,
 .canvas-node--fullscreen .node-fullscreen--floating {
   display: none !important;

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -86,13 +86,6 @@ function formatRelativeTime(epochMs: number): string {
   return `${Math.floor(diffHr / 24)}d ago`;
 }
 
-const AGENT_STATUS_LABEL: Record<string, string> = {
-  running: 'Running',
-  done: 'Done',
-  error: 'Error',
-  idle: 'Idle',
-};
-
 function isCanvasPanGesture(e: React.MouseEvent): boolean {
   const handToolActive = e.currentTarget.closest('.canvas-container--hand') != null;
   return e.button === 1 || (e.button === 0 && (e.altKey || handToolActive));
@@ -605,12 +598,7 @@ const CanvasNodeViewComponent = ({
             Ungroup
           </button>
         )}
-        {node.type === "agent" && agentStatus && agentStatus !== 'idle' && (
-          <span className={`node-status-label node-status-label--${agentStatus}`}>
-            {AGENT_STATUS_LABEL[agentStatus] ?? agentStatus}
-          </span>
-        )}
-        {relativeTime && !(node.type === "agent" && agentStatus && agentStatus !== 'idle') && (
+        {relativeTime && (
           <span className="node-time-label" title={new Date(node.updatedAt!).toLocaleString()}>
             {relativeTime}
           </span>

--- a/apps/canvas-workspace/src/renderer/src/config/agentRegistry.ts
+++ b/apps/canvas-workspace/src/renderer/src/config/agentRegistry.ts
@@ -1,15 +1,40 @@
+export interface AgentResumeSpec {
+  /** Build a fresh-start command that pre-allocates a resumable session id.
+   *  The id will be persisted on the node so a later `resume(id)` call can
+   *  reattach to the same logical conversation after an app restart. */
+  startWithId: (id: string) => string;
+  /** Build the command that resumes a previously started session by id. */
+  resume: (id: string) => string;
+}
+
 export interface AgentDef {
   id: string;
   label: string;
   command: string;
   description: string;
+  /** When set, the agent supports id-based session resume — the canvas
+   *  will pre-allocate a UUID on first launch and reuse it after restarts
+   *  instead of starting a brand-new conversation. */
+  resume?: AgentResumeSpec;
 }
 
 export const AGENT_REGISTRY: AgentDef[] = [
-  { id: 'claude-code', label: 'Claude Code', command: 'claude', description: 'Anthropic' },
+  {
+    id: 'claude-code',
+    label: 'Claude Code',
+    command: 'claude',
+    description: 'Anthropic',
+    resume: {
+      startWithId: (id) => `claude --session-id ${id}`,
+      resume: (id) => `claude --resume ${id}`,
+    },
+  },
   { id: 'codex', label: 'Codex', command: 'codex', description: 'OpenAI' },
   { id: 'pulse-coder', label: 'Pulse Coder', command: 'pulse-coder', description: 'Pulse' },
 ];
+
+export const getAgentDef = (agentType: string): AgentDef | undefined =>
+  AGENT_REGISTRY.find((a) => a.id === agentType);
 
 export const getAgentCommand = (agentType: string): string | undefined =>
   AGENT_REGISTRY.find(a => a.id === agentType)?.command;

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -60,6 +60,17 @@ export interface AgentNodeData {
   inlinePrompt?: string;
   /** Relative path to a prompt file in cwd for long prompts. */
   promptFile?: string;
+  /**
+   * Agent-specific resumable conversation id (distinct from `sessionId`,
+   * which keys the live PTY). Pre-allocated on first launch for agents
+   * whose CLI accepts a `--session-id <uuid>` style flag, then reused on
+   * cold reload via the agent's `--resume <uuid>` to re-attach to the
+   * same logical conversation rather than starting a fresh one.
+   *
+   * Stays unset for agents that don't declare `resume` in their registry
+   * entry — those fall back to static scrollback replay after a restart.
+   */
+  resumeId?: string;
 }
 
 /**

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -71,6 +71,11 @@ export interface AgentNodeData {
    * entry — those fall back to static scrollback replay after a restart.
    */
   resumeId?: string;
+  /** Last observed exit code from the agent process. Drives the session-
+   *  end badge (Done vs Error) so users see *why* the agent stopped
+   *  without having to scroll the terminal to the `[Agent exited ...]`
+   *  line. Reset to undefined on a fresh launch / Start fresh. */
+  lastExitCode?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR adds session resume capability to agent nodes in the canvas workspace, allowing users to continue conversations after app restarts instead of always starting fresh. It also improves the post-execution UX with a new session-end bar that replaces the lone "Restart" button with clearer affordances for continuing, starting fresh, or copying output.

## Key Changes

- **Session Resume Infrastructure**: Added `resumeId` and `lastExitCode` fields to `AgentNodeData` to track resumable conversation state across app restarts
- **Agent Registry Enhancement**: Extended `AgentDef` with optional `resume` spec containing `startWithId()` and `resume()` command builders, enabling agents like Claude Code to support id-based session resumption
- **Smart Restore Logic**: Refactored cold-reload path to distinguish between:
  - Resume-capable agents: re-attach to prior conversation by id with scrollback as faded preamble
  - Non-resumable agents: fall back to static scrollback replay (existing behavior)
- **Session-End Bar**: Replaced the old "Restart" button with a new footer component showing:
  - Status badge (Done/Error with exit code)
  - Primary action: "Continue" (resume) or "Retry" (on error) — only shown for resume-capable agents
  - Secondary actions: "Start fresh" (clear all session state) and "Copy" (extract terminal output as plain text)
- **Improved State Management**: 
  - Added `userStoppedRef` to prevent kill exit codes from overwriting user-initiated stop status
  - Renamed `handleRestart` → `handleNewSession` to clarify the "throw away conversation" semantics
  - Added `handleContinue` for the resume path
  - Added `handleCopyOutput` to extract terminal text without ANSI escapes
- **Prompt Preservation**: Changed behavior to keep `inlinePrompt` and `promptFile` after launch so the picker pre-fills on "Start fresh" — users no longer retype similar requests
- **Refactored Command Resolution**: Replaced `getAgentCommand()` with `getAgentDef()` to access full agent metadata including resume specs

## Implementation Details

- The resume decision logic (`canResume`) checks three conditions: `isRestored && agentDef?.resume && dataRef.current.resumeId`
- On fresh launch of a resume-capable agent, a UUID is pre-allocated and persisted so future cold reloads can reuse it
- The `onExit` handler now persists `lastExitCode` to drive the session-end badge, while `status: 'done'` remains consistent regardless of exit code (spawn failures still set `status: 'error'`)
- CSS updated to position the session-end bar at the bottom with translucent backdrop so terminal output remains partially visible
- Updated agent registry entry for Claude Code with resume command builders; other agents remain non-resumable for now

https://claude.ai/code/session_01VFLNmJRMgsHkVXKpjhNT56