### PR TITLE
Redesign AgentNodeBody with three-view card chrome and Restart recovery

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentIcon.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentIcon.tsx
@@ -55,22 +55,3 @@ export const AgentIcon = ({ id, size = 14 }: { id: string; size?: number }) => {
   }
 };
 
-/** Compact rounded-square avatar used in the body header. */
-export const AgentAvatar = ({ size = 36 }: { size?: number }) => (
-  <div
-    className="agent-avatar"
-    style={{ width: size, height: size }}
-    aria-hidden="true"
-  >
-    <svg width={size * 0.55} height={size * 0.55} viewBox="0 0 16 16" fill="none">
-      <circle cx="8" cy="5.5" r="2.6" stroke="currentColor" strokeWidth="1.4" />
-      <path
-        d="M3.5 13.5c0-2.2 2-3.8 4.5-3.8s4.5 1.6 4.5 3.8"
-        stroke="currentColor"
-        strokeWidth="1.4"
-        strokeLinecap="round"
-      />
-      <circle cx="11.6" cy="3.2" r="1" fill="currentColor" />
-    </svg>
-  </div>
-);

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentIcon.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentIcon.tsx
@@ -1,27 +1,76 @@
-/** Monoline SVG icon per agent, matching the app's stroke-icon style. */
-export const AgentIcon = ({ id }: { id: string }) => {
+/**
+ * Per-agent brand mark. Each glyph is sized inside a 16×16 viewBox so it
+ * can be dropped into pills, tabs, info strips, or saved-config rows with
+ * consistent visual weight.
+ */
+export const AgentIcon = ({ id, size = 14 }: { id: string; size?: number }) => {
   switch (id) {
     case 'claude-code':
       return (
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-          <path d="M5.5 6.5L7.5 8.5 5.5 10.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
-          <path d="M9 10.5h2" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
-          <rect x="1.5" y="2.5" width="13" height="11" rx="2" stroke="currentColor" strokeWidth="1.3" />
+        <svg width={size} height={size} viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <g stroke="#e07b3f" strokeWidth="1.4" strokeLinecap="round">
+            <path d="M8 1.5v13" />
+            <path d="M1.5 8h13" />
+            <path d="M3.4 3.4l9.2 9.2" />
+            <path d="M12.6 3.4l-9.2 9.2" />
+          </g>
         </svg>
       );
     case 'codex':
       return (
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-          <circle cx="8" cy="8" r="5.5" stroke="currentColor" strokeWidth="1.3" />
-          <path d="M8 5v3l2 1.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+        <svg width={size} height={size} viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <path
+            d="M8 1.5l5.6 3v6.9L8 14.5l-5.6-3.1V4.5L8 1.5z"
+            stroke="currentColor"
+            strokeWidth="1.3"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M2.6 4.7L8 7.8l5.4-3.1M8 7.8v6.6"
+            stroke="currentColor"
+            strokeWidth="1.2"
+            strokeLinejoin="round"
+          />
+        </svg>
+      );
+    case 'pulse-coder':
+      return (
+        <svg width={size} height={size} viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <path
+            d="M1.5 8h2.2l1.6-4 2 8 1.6-5 1.4 3h4.2"
+            stroke="#6366f1"
+            strokeWidth="1.4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
         </svg>
       );
     default:
       return (
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-          <path d="M4 13V8l4-5 4 5v5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
-          <path d="M7 13v-3h2v3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+        <svg width={size} height={size} viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.3" />
+          <path d="M8 5v3l2 1.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
         </svg>
       );
   }
 };
+
+/** Compact rounded-square avatar used in the body header. */
+export const AgentAvatar = ({ size = 36 }: { size?: number }) => (
+  <div
+    className="agent-avatar"
+    style={{ width: size, height: size }}
+    aria-hidden="true"
+  >
+    <svg width={size * 0.55} height={size * 0.55} viewBox="0 0 16 16" fill="none">
+      <circle cx="8" cy="5.5" r="2.6" stroke="currentColor" strokeWidth="1.4" />
+      <path
+        d="M3.5 13.5c0-2.2 2-3.8 4.5-3.8s4.5 1.6 4.5 3.8"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+      />
+      <circle cx="11.6" cy="3.2" r="1" fill="currentColor" />
+    </svg>
+  </div>
+);

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentPicker.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentPicker.tsx
@@ -1,5 +1,5 @@
 import { AGENT_REGISTRY, type AgentDef } from '../../config/agentRegistry';
-import { AgentAvatar, AgentIcon } from './AgentIcon';
+import { AgentIcon } from './AgentIcon';
 import { truncatePath } from './utils/terminal';
 
 interface AgentPickerProps {
@@ -8,8 +8,6 @@ interface AgentPickerProps {
   promptInput: string;
   rootFolder?: string;
   recentCwds: string[];
-  /** Header status label override (Setup / Restart-flow Edit). */
-  badge?: 'setup' | 'edit';
   /** Optional Back button used when entering Setup from the Restart view. */
   onBack?: () => void;
   onAgentChange: (id: string) => void;
@@ -52,7 +50,6 @@ export const AgentPicker = ({
   promptInput,
   rootFolder,
   recentCwds,
-  badge = 'setup',
   onBack,
   onAgentChange,
   onCwdChange,
@@ -67,33 +64,22 @@ export const AgentPicker = ({
   const startTitle = `Start ${agentDef?.label ?? 'agent'}  —  ${previewCmd}${
     effectiveCwd ? ` in ${effectiveCwd}` : ''
   }`;
-  const badgeLabel = badge === 'edit' ? 'Edit' : 'Setup';
 
   return (
     <div className="agent-body-wrap agent-body-wrap--setup">
       <div className="agent-card">
-        <div className="agent-card-header">
-          <div className="agent-card-header-left">
-            <AgentAvatar />
-            <span className="agent-card-title">Agent</span>
+        {onBack && (
+          <div className="agent-card-back">
+            <button
+              type="button"
+              className="agent-text-link"
+              onClick={onBack}
+              title="Back to saved configuration"
+            >
+              ← 返回
+            </button>
           </div>
-          <div className="agent-card-header-right">
-            {onBack && (
-              <button
-                type="button"
-                className="agent-text-link"
-                onClick={onBack}
-                title="Back to saved configuration"
-              >
-                Back
-              </button>
-            )}
-            <span className={`agent-status-pill agent-status-pill--${badge}`}>
-              <span className="agent-status-pill-dot" />
-              {badgeLabel}
-            </span>
-          </div>
-        </div>
+        )}
 
         <div className="agent-card-body">
           <div className="agent-tabs" role="tablist" aria-label="Coding agent">

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentPicker.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentPicker.tsx
@@ -112,8 +112,11 @@ export const AgentPicker = ({
                 className="agent-dir-input"
                 value={cwdInput}
                 onChange={(e) => onCwdChange(e.target.value)}
-                placeholder={
-                  rootFolder ? truncatePath(rootFolder, 36) : '/Users/jasper/project'
+                placeholder={rootFolder ? truncatePath(rootFolder, 36) : '~'}
+                title={
+                  rootFolder
+                    ? `Defaults to workspace root: ${rootFolder}`
+                    : 'Defaults to your home directory'
                 }
                 spellCheck={false}
                 onKeyDown={(e) => {

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentPicker.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentPicker.tsx
@@ -1,5 +1,5 @@
 import { AGENT_REGISTRY, type AgentDef } from '../../config/agentRegistry';
-import { AgentIcon } from './AgentIcon';
+import { AgentAvatar, AgentIcon } from './AgentIcon';
 import { truncatePath } from './utils/terminal';
 
 interface AgentPickerProps {
@@ -8,6 +8,10 @@ interface AgentPickerProps {
   promptInput: string;
   rootFolder?: string;
   recentCwds: string[];
+  /** Header status label override (Setup / Restart-flow Edit). */
+  badge?: 'setup' | 'edit';
+  /** Optional Back button used when entering Setup from the Restart view. */
+  onBack?: () => void;
   onAgentChange: (id: string) => void;
   onCwdChange: (value: string) => void;
   onPromptChange: (value: string) => void;
@@ -15,12 +19,41 @@ interface AgentPickerProps {
   onLaunch: () => void;
 }
 
+const FolderGlyph = () => (
+  <svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <path
+      d="M2 4.5A1.5 1.5 0 013.5 3H6l1.5 1.5h5A1.5 1.5 0 0114 6v5.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 012 11.5v-7z"
+      stroke="currentColor"
+      strokeWidth="1.25"
+    />
+  </svg>
+);
+
+const ChatGlyph = () => (
+  <svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <path
+      d="M2.5 4.5A1.5 1.5 0 014 3h8a1.5 1.5 0 011.5 1.5v5A1.5 1.5 0 0112 11H6.5L4 13.2V11A1.5 1.5 0 012.5 9.5v-5z"
+      stroke="currentColor"
+      strokeWidth="1.25"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const PlayGlyph = () => (
+  <svg width="11" height="11" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <path d="M4 3l9 5-9 5V3z" fill="currentColor" />
+  </svg>
+);
+
 export const AgentPicker = ({
   selectedAgent,
   cwdInput,
   promptInput,
   rootFolder,
   recentCwds,
+  badge = 'setup',
+  onBack,
   onAgentChange,
   onCwdChange,
   onPromptChange,
@@ -31,103 +64,89 @@ export const AgentPicker = ({
   const effectiveCwd = cwdInput || rootFolder || '';
   const previewCmd = agentDef?.command ?? 'agent';
   const visibleRecents = recentCwds.filter((p) => p !== cwdInput).slice(0, 3);
-  const startTitle = `Start ${agentDef?.label ?? 'agent'}  \u2014  ${previewCmd}${
+  const startTitle = `Start ${agentDef?.label ?? 'agent'}  —  ${previewCmd}${
     effectiveCwd ? ` in ${effectiveCwd}` : ''
   }`;
+  const badgeLabel = badge === 'edit' ? 'Edit' : 'Setup';
 
   return (
-    <div className="agent-body-wrap">
-      <div className="agent-picker">
-        <div className="agent-launcher-card">
-          <textarea
-            className="agent-launcher-prompt"
-            value={promptInput}
-            onChange={(e) => onPromptChange(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && !e.shiftKey) {
-                e.preventDefault();
-                onLaunch();
-              }
-            }}
-            placeholder={'What should the agent do?'}
-            spellCheck={false}
-            autoFocus
-          />
-
-          <div className="agent-launcher-toolbar">
-            <div
-              className="agent-pills"
-              role="tablist"
-              aria-label="Agent"
-            >
-              {AGENT_REGISTRY.map((a: AgentDef) => (
-                <button
-                  key={a.id}
-                  type="button"
-                  role="tab"
-                  aria-selected={selectedAgent === a.id}
-                  className={`agent-pill${
-                    selectedAgent === a.id ? ' agent-pill--active' : ''
-                  }`}
-                  onClick={() => onAgentChange(a.id)}
-                  title={`${a.label} \u2014 ${a.description}`}
-                >
-                  <AgentIcon id={a.id} />
-                  <span>{a.label}</span>
-                </button>
-              ))}
-            </div>
-
-            <div className="agent-toolbar-row">
-              <div className="agent-dir-field">
-                <button
-                  type="button"
-                  className="agent-dir-icon"
-                  onClick={onPickFolder}
-                  title={'Browse\u2026'}
-                  aria-label="Browse for folder"
-                >
-                  <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
-                    <path
-                      d="M2 4.5A1.5 1.5 0 013.5 3H6l1.5 1.5h5A1.5 1.5 0 0114 6v5.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 012 11.5v-7z"
-                      stroke="currentColor"
-                      strokeWidth="1.2"
-                    />
-                  </svg>
-                </button>
-                <input
-                  type="text"
-                  className="agent-dir-input"
-                  value={cwdInput}
-                  onChange={(e) => onCwdChange(e.target.value)}
-                  placeholder={
-                    rootFolder
-                      ? truncatePath(rootFolder, 32)
-                      : 'Working directory'
-                  }
-                  spellCheck={false}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') {
-                      e.preventDefault();
-                      onLaunch();
-                    }
-                  }}
-                />
-              </div>
-
+    <div className="agent-body-wrap agent-body-wrap--setup">
+      <div className="agent-card">
+        <div className="agent-card-header">
+          <div className="agent-card-header-left">
+            <AgentAvatar />
+            <span className="agent-card-title">Agent</span>
+          </div>
+          <div className="agent-card-header-right">
+            {onBack && (
               <button
                 type="button"
-                className="agent-launch-btn"
-                onClick={onLaunch}
-                title={startTitle}
+                className="agent-text-link"
+                onClick={onBack}
+                title="Back to saved configuration"
               >
-                <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
-                  <path d="M4 3l9 5-9 5V3z" fill="currentColor" />
-                </svg>
-                Start
+                Back
+              </button>
+            )}
+            <span className={`agent-status-pill agent-status-pill--${badge}`}>
+              <span className="agent-status-pill-dot" />
+              {badgeLabel}
+            </span>
+          </div>
+        </div>
+
+        <div className="agent-card-body">
+          <div className="agent-tabs" role="tablist" aria-label="Coding agent">
+            {AGENT_REGISTRY.map((a: AgentDef) => (
+              <button
+                key={a.id}
+                type="button"
+                role="tab"
+                aria-selected={selectedAgent === a.id}
+                className={`agent-tab${
+                  selectedAgent === a.id ? ' agent-tab--active' : ''
+                }`}
+                onClick={() => onAgentChange(a.id)}
+                title={`${a.label} — ${a.description}`}
+              >
+                <AgentIcon id={a.id} size={16} />
+                <span>{a.label}</span>
+              </button>
+            ))}
+          </div>
+
+          <div className="agent-field">
+            <div className="agent-field-label">
+              <FolderGlyph />
+              <span>Working Directory</span>
+            </div>
+            <div className="agent-dir-field">
+              <input
+                type="text"
+                className="agent-dir-input"
+                value={cwdInput}
+                onChange={(e) => onCwdChange(e.target.value)}
+                placeholder={
+                  rootFolder ? truncatePath(rootFolder, 36) : '/Users/jasper/project'
+                }
+                spellCheck={false}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    onLaunch();
+                  }
+                }}
+              />
+              <button
+                type="button"
+                className="agent-dir-icon"
+                onClick={onPickFolder}
+                title="Browse…"
+                aria-label="Browse for folder"
+              >
+                <FolderGlyph />
               </button>
             </div>
-
             {visibleRecents.length > 0 && (
               <div className="agent-recent">
                 <span className="agent-recent-label">Recent</span>
@@ -145,6 +164,39 @@ export const AgentPicker = ({
               </div>
             )}
           </div>
+
+          <div className="agent-field">
+            <div className="agent-field-label">
+              <ChatGlyph />
+              <span>Initial Prompt</span>
+            </div>
+            <textarea
+              className="agent-prompt-input"
+              value={promptInput}
+              onChange={(e) => onPromptChange(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                  e.preventDefault();
+                  onLaunch();
+                }
+              }}
+              placeholder="请输入初始提示..."
+              spellCheck={false}
+              rows={3}
+            />
+          </div>
+        </div>
+
+        <div className="agent-card-footer">
+          <button
+            type="button"
+            className="agent-primary-btn"
+            onClick={onLaunch}
+            title={startTitle}
+          >
+            <PlayGlyph />
+            初始化
+          </button>
         </div>
       </div>
     </div>

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentRestart.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentRestart.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { AGENT_REGISTRY } from '../../config/agentRegistry';
-import { AgentAvatar, AgentIcon } from './AgentIcon';
+import { AgentIcon } from './AgentIcon';
 import { truncatePath } from './utils/terminal';
 
 interface AgentRestartProps {
@@ -96,17 +96,6 @@ export const AgentRestart = ({
   return (
     <div className="agent-body-wrap agent-body-wrap--restart">
       <div className="agent-card">
-        <div className="agent-card-header">
-          <div className="agent-card-header-left">
-            <AgentAvatar />
-            <span className="agent-card-title">Agent</span>
-          </div>
-          <span className="agent-status-pill agent-status-pill--restart">
-            <span className="agent-status-pill-dot" />
-            Restart
-          </span>
-        </div>
-
         <div className="agent-card-body">
           <div className="agent-section-title">已保存的配置</div>
 

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentRestart.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentRestart.tsx
@@ -1,0 +1,203 @@
+import { useState } from 'react';
+import { AGENT_REGISTRY } from '../../config/agentRegistry';
+import { AgentAvatar, AgentIcon } from './AgentIcon';
+import { truncatePath } from './utils/terminal';
+
+interface AgentRestartProps {
+  agentType: string;
+  cwd?: string;
+  prompt?: string;
+  scrollback?: string;
+  onRestart: () => void;
+  onEdit: () => void;
+}
+
+const FolderGlyph = () => (
+  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <path
+      d="M2 4.5A1.5 1.5 0 013.5 3H6l1.5 1.5h5A1.5 1.5 0 0114 6v5.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 012 11.5v-7z"
+      stroke="currentColor"
+      strokeWidth="1.3"
+    />
+  </svg>
+);
+
+const ChatGlyph = () => (
+  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <path
+      d="M2.5 4.5A1.5 1.5 0 014 3h8a1.5 1.5 0 011.5 1.5v5A1.5 1.5 0 0112 11H6.5L4 13.2V11A1.5 1.5 0 012.5 9.5v-5z"
+      stroke="currentColor"
+      strokeWidth="1.3"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const CheckGlyph = () => (
+  <svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <circle cx="8" cy="8" r="6.5" stroke="currentColor" strokeWidth="1.2" />
+    <path
+      d="M5 8.2l2.1 2L11 6.5"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const WarningGlyph = () => (
+  <svg width="15" height="15" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <path
+      d="M7.1 2.5L1.5 12.5A1 1 0 002.4 14h11.2a1 1 0 00.9-1.5L8.9 2.5a1 1 0 00-1.8 0z"
+      stroke="currentColor"
+      strokeWidth="1.3"
+      strokeLinejoin="round"
+    />
+    <path d="M8 6v3.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+    <circle cx="8" cy="11.5" r="0.7" fill="currentColor" />
+  </svg>
+);
+
+const PlayGlyph = () => (
+  <svg width="11" height="11" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <path d="M4 3l9 5-9 5V3z" fill="currentColor" />
+  </svg>
+);
+
+const PencilGlyph = () => (
+  <svg width="11" height="11" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <path
+      d="M11 2.5l2.5 2.5L5 13.5H2.5V11L11 2.5z"
+      stroke="currentColor"
+      strokeWidth="1.3"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const tailLines = (text: string, count = 12): string =>
+  text.split('\n').slice(-count).join('\n').replace(/^\s+|\s+$/g, '');
+
+export const AgentRestart = ({
+  agentType,
+  cwd,
+  prompt,
+  scrollback,
+  onRestart,
+  onEdit,
+}: AgentRestartProps) => {
+  const [showDetails, setShowDetails] = useState(false);
+  const agentDef = AGENT_REGISTRY.find((a) => a.id === agentType);
+  const cwdDisplay = cwd ? truncatePath(cwd, 36) : 'Working Directory';
+  const hasPrompt = !!(prompt && prompt.trim().length > 0);
+  const promptPreview = hasPrompt ? '已保存' : '未提供';
+
+  return (
+    <div className="agent-body-wrap agent-body-wrap--restart">
+      <div className="agent-card">
+        <div className="agent-card-header">
+          <div className="agent-card-header-left">
+            <AgentAvatar />
+            <span className="agent-card-title">Agent</span>
+          </div>
+          <span className="agent-status-pill agent-status-pill--restart">
+            <span className="agent-status-pill-dot" />
+            Restart
+          </span>
+        </div>
+
+        <div className="agent-card-body">
+          <div className="agent-section-title">已保存的配置</div>
+
+          <div className="agent-saved-list">
+            <div className="agent-saved-row" title={agentDef?.label ?? agentType}>
+              <span className="agent-saved-row-left">
+                <AgentIcon id={agentType} size={16} />
+                <span className="agent-saved-row-label">
+                  {agentDef?.label ?? 'Coding Agent'}
+                </span>
+              </span>
+              <span className="agent-saved-row-check"><CheckGlyph /></span>
+            </div>
+
+            <div className="agent-saved-row" title={cwd ?? ''}>
+              <span className="agent-saved-row-left">
+                <FolderGlyph />
+                <span className="agent-saved-row-label agent-saved-row-label--mono">
+                  {cwdDisplay}
+                </span>
+              </span>
+              <span className="agent-saved-row-check"><CheckGlyph /></span>
+            </div>
+
+            <div className="agent-saved-row" title={prompt ?? ''}>
+              <span className="agent-saved-row-left">
+                <ChatGlyph />
+                <span className="agent-saved-row-label">Initial Prompt</span>
+              </span>
+              <span className="agent-saved-row-meta">{promptPreview}</span>
+            </div>
+          </div>
+
+          <div className="agent-warning">
+            <span className="agent-warning-icon"><WarningGlyph /></span>
+            <span className="agent-warning-text">应用重启后，CLI 运行状态已丢失。</span>
+          </div>
+        </div>
+
+        <div className="agent-card-footer agent-card-footer--restart">
+          <button
+            type="button"
+            className="agent-primary-btn"
+            onClick={onRestart}
+            title="Restart with saved configuration"
+          >
+            <PlayGlyph />
+            重新启动会话
+          </button>
+          <button
+            type="button"
+            className="agent-secondary-btn"
+            onClick={onEdit}
+            title="Edit initial parameters"
+          >
+            <PencilGlyph />
+            编辑初始化参数
+          </button>
+        </div>
+
+        <button
+          type="button"
+          className="agent-text-link agent-text-link--center"
+          onClick={() => setShowDetails((v) => !v)}
+          title="View last configuration"
+        >
+          {showDetails ? '收起' : '查看上次配置'}
+        </button>
+
+        {showDetails && (
+          <div className="agent-details">
+            {hasPrompt && (
+              <div className="agent-details-block">
+                <div className="agent-details-label">Initial Prompt</div>
+                <pre className="agent-details-content">{prompt}</pre>
+              </div>
+            )}
+            {scrollback && scrollback.trim().length > 0 && (
+              <div className="agent-details-block">
+                <div className="agent-details-label">Last Output</div>
+                <pre className="agent-details-content agent-details-content--scrollback">
+                  {tailLines(scrollback)}
+                </pre>
+              </div>
+            )}
+            {!hasPrompt && (!scrollback || !scrollback.trim()) && (
+              <div className="agent-details-empty">无更多保存信息。</div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentRestart.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentRestart.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { AGENT_REGISTRY } from '../../config/agentRegistry';
 import { AgentIcon } from './AgentIcon';
 import { truncatePath } from './utils/terminal';
@@ -7,7 +6,6 @@ interface AgentRestartProps {
   agentType: string;
   cwd?: string;
   prompt?: string;
-  scrollback?: string;
   onRestart: () => void;
   onEdit: () => void;
 }
@@ -76,22 +74,27 @@ const PencilGlyph = () => (
   </svg>
 );
 
-const tailLines = (text: string, count = 12): string =>
-  text.split('\n').slice(-count).join('\n').replace(/^\s+|\s+$/g, '');
-
 export const AgentRestart = ({
   agentType,
   cwd,
   prompt,
-  scrollback,
   onRestart,
   onEdit,
 }: AgentRestartProps) => {
-  const [showDetails, setShowDetails] = useState(false);
   const agentDef = AGENT_REGISTRY.find((a) => a.id === agentType);
   const cwdDisplay = cwd ? truncatePath(cwd, 36) : 'Working Directory';
   const hasPrompt = !!(prompt && prompt.trim().length > 0);
   const promptPreview = hasPrompt ? '已保存' : '未提供';
+  // Claude Code is the only agent that can actually resume the
+  // previous conversation (via `--resume <uuid>`). For the others a
+  // restart is really a fresh launch, so we keep the "编辑初始化参数"
+  // escape hatch. For Claude, the saved config is what gets resumed
+  // verbatim — no need to expose an edit affordance from here.
+  const canResume = agentType === 'claude-code';
+  const restartLabel = canResume ? '继续上次会话' : '重新启动会话';
+  const restartTitle = canResume
+    ? `Resume the previous ${agentDef?.label ?? 'agent'} conversation`
+    : 'Restart with saved configuration';
 
   return (
     <div className="agent-body-wrap agent-body-wrap--restart">
@@ -140,52 +143,23 @@ export const AgentRestart = ({
             type="button"
             className="agent-primary-btn"
             onClick={onRestart}
-            title="Restart with saved configuration"
+            title={restartTitle}
           >
             <PlayGlyph />
-            重新启动会话
+            {restartLabel}
           </button>
-          <button
-            type="button"
-            className="agent-secondary-btn"
-            onClick={onEdit}
-            title="Edit initial parameters"
-          >
-            <PencilGlyph />
-            编辑初始化参数
-          </button>
+          {!canResume && (
+            <button
+              type="button"
+              className="agent-secondary-btn"
+              onClick={onEdit}
+              title="Edit initial parameters"
+            >
+              <PencilGlyph />
+              编辑初始化参数
+            </button>
+          )}
         </div>
-
-        <button
-          type="button"
-          className="agent-text-link agent-text-link--center"
-          onClick={() => setShowDetails((v) => !v)}
-          title="View last configuration"
-        >
-          {showDetails ? '收起' : '查看上次配置'}
-        </button>
-
-        {showDetails && (
-          <div className="agent-details">
-            {hasPrompt && (
-              <div className="agent-details-block">
-                <div className="agent-details-label">Initial Prompt</div>
-                <pre className="agent-details-content">{prompt}</pre>
-              </div>
-            )}
-            {scrollback && scrollback.trim().length > 0 && (
-              <div className="agent-details-block">
-                <div className="agent-details-label">Last Output</div>
-                <pre className="agent-details-content agent-details-content--scrollback">
-                  {tailLines(scrollback)}
-                </pre>
-              </div>
-            )}
-            {!hasPrompt && (!scrollback || !scrollback.trim()) && (
-              <div className="agent-details-empty">无更多保存信息。</div>
-            )}
-          </div>
-        )}
       </div>
     </div>
   );

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTerminal.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTerminal.tsx
@@ -8,9 +8,6 @@ interface AgentTerminalProps {
   status: string;
   agentType: string;
   cwd?: string;
-  onRestart: () => void;
-  onStop?: () => void;
-  onFocusTerminal?: () => void;
 }
 
 const FolderGlyph = () => (
@@ -20,19 +17,6 @@ const FolderGlyph = () => (
       stroke="currentColor"
       strokeWidth="1.25"
     />
-  </svg>
-);
-
-const StopGlyph = () => (
-  <svg width="11" height="11" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-    <rect x="3.5" y="3.5" width="9" height="9" rx="1.3" stroke="currentColor" strokeWidth="1.4" />
-  </svg>
-);
-
-const TerminalGlyph = () => (
-  <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-    <path d="M3 5l3 3-3 3" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
-    <path d="M8 11h5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
   </svg>
 );
 
@@ -48,13 +32,9 @@ export const AgentTerminal = ({
   status,
   agentType,
   cwd,
-  onRestart,
-  onStop,
-  onFocusTerminal,
 }: AgentTerminalProps) => {
   const agentDef = AGENT_REGISTRY.find((a) => a.id === agentType);
   const statusInfo = STATUS_TEXT[status] ?? STATUS_TEXT.running;
-  const exited = status === 'done' || status === 'error';
   const displayCwd = cwd ? truncatePath(cwd, 32) : '—';
 
   return (
@@ -82,47 +62,6 @@ export const AgentTerminal = ({
           className="agent-xterm-container"
           onMouseDown={(e) => e.stopPropagation()}
         />
-
-        <div className="agent-card-footer">
-          {exited ? (
-            <button
-              type="button"
-              className="agent-secondary-btn"
-              onClick={onRestart}
-              title="Restart agent"
-            >
-              <svg width="11" height="11" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-                <path
-                  d="M13 8a5 5 0 11-1.5-3.6M13 3v2.5H10.5"
-                  stroke="currentColor"
-                  strokeWidth="1.4"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-              重启
-            </button>
-          ) : (
-            <button
-              type="button"
-              className="agent-secondary-btn agent-secondary-btn--stop"
-              onClick={onStop}
-              title="Stop agent"
-            >
-              <StopGlyph />
-              停止
-            </button>
-          )}
-          <button
-            type="button"
-            className="agent-primary-btn"
-            onClick={onFocusTerminal}
-            title="Focus terminal"
-          >
-            <TerminalGlyph />
-            打开终端
-          </button>
-        </div>
       </div>
     </div>
   );

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTerminal.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTerminal.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 import { AGENT_REGISTRY } from '../../config/agentRegistry';
-import { AgentAvatar, AgentIcon } from './AgentIcon';
+import { AgentIcon } from './AgentIcon';
 import { truncatePath } from './utils/terminal';
 
 interface AgentTerminalProps {
@@ -36,11 +36,11 @@ const TerminalGlyph = () => (
   </svg>
 );
 
-const STATUS_TEXT: Record<string, { badge: string; load: string; tone: 'running' | 'done' | 'error' }> = {
-  running: { badge: 'Running', load: '已加载', tone: 'running' },
-  done: { badge: 'Done', load: '已退出', tone: 'done' },
-  error: { badge: 'Error', load: '出错', tone: 'error' },
-  idle: { badge: 'Idle', load: '空闲', tone: 'done' },
+const STATUS_TEXT: Record<string, { load: string; tone: 'running' | 'done' | 'error' }> = {
+  running: { load: '已加载', tone: 'running' },
+  done: { load: '已退出', tone: 'done' },
+  error: { load: '出错', tone: 'error' },
+  idle: { load: '空闲', tone: 'done' },
 };
 
 export const AgentTerminal = ({
@@ -60,17 +60,6 @@ export const AgentTerminal = ({
   return (
     <div className="agent-body-wrap agent-body-wrap--running">
       <div className="agent-card">
-        <div className="agent-card-header">
-          <div className="agent-card-header-left">
-            <AgentAvatar />
-            <span className="agent-card-title">Agent</span>
-          </div>
-          <span className={`agent-status-pill agent-status-pill--${statusInfo.tone}`}>
-            <span className="agent-status-pill-dot" />
-            {statusInfo.badge}
-          </span>
-        </div>
-
         <div className="agent-info-strip">
           <span className="agent-info-cell">
             <AgentIcon id={agentType} size={14} />

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTerminal.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTerminal.tsx
@@ -1,84 +1,140 @@
 import type React from 'react';
+import { AGENT_REGISTRY } from '../../config/agentRegistry';
+import { AgentAvatar, AgentIcon } from './AgentIcon';
+import { truncatePath } from './utils/terminal';
 
 interface AgentTerminalProps {
   containerRef: React.RefObject<HTMLDivElement>;
   status: string;
+  agentType: string;
+  cwd?: string;
   onRestart: () => void;
   onStop?: () => void;
-  onSendPrompt?: (prompt: string) => void;
+  onFocusTerminal?: () => void;
 }
 
-const CONTINUE_PROMPT = 'continue';
-const SUMMARIZE_PROMPT = 'please summarize what you have done so far';
+const FolderGlyph = () => (
+  <svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <path
+      d="M2 4.5A1.5 1.5 0 013.5 3H6l1.5 1.5h5A1.5 1.5 0 0114 6v5.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 012 11.5v-7z"
+      stroke="currentColor"
+      strokeWidth="1.25"
+    />
+  </svg>
+);
+
+const StopGlyph = () => (
+  <svg width="11" height="11" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <rect x="3.5" y="3.5" width="9" height="9" rx="1.3" stroke="currentColor" strokeWidth="1.4" />
+  </svg>
+);
+
+const TerminalGlyph = () => (
+  <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <path d="M3 5l3 3-3 3" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M8 11h5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+  </svg>
+);
+
+const STATUS_TEXT: Record<string, { badge: string; load: string; tone: 'running' | 'done' | 'error' }> = {
+  running: { badge: 'Running', load: '已加载', tone: 'running' },
+  done: { badge: 'Done', load: '已退出', tone: 'done' },
+  error: { badge: 'Error', load: '出错', tone: 'error' },
+  idle: { badge: 'Idle', load: '空闲', tone: 'done' },
+};
 
 export const AgentTerminal = ({
   containerRef,
   status,
+  agentType,
+  cwd,
   onRestart,
   onStop,
-  onSendPrompt,
-}: AgentTerminalProps) => (
-  <div className="agent-body-wrap">
-    <div
-      ref={containerRef}
-      className="agent-xterm-container"
-      onMouseDown={(e) => e.stopPropagation()}
-    />
-    {status === 'running' && (
-      <div className="agent-quick-actions">
-        <button
-          type="button"
-          className="agent-quick-btn"
-          onClick={() => onSendPrompt?.(CONTINUE_PROMPT)}
-          title="Send 'continue' to agent"
-        >
-          <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
-            <path d="M5 3l6 5-6 5V3z" fill="currentColor" />
-          </svg>
-          Continue
-        </button>
-        <button
-          type="button"
-          className="agent-quick-btn"
-          onClick={() => onSendPrompt?.(SUMMARIZE_PROMPT)}
-          title="Ask agent to summarize"
-        >
-          <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
-            <path d="M3 4h10M3 7.5h7M3 11h5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
-          </svg>
-          Summarize
-        </button>
-        <button
-          type="button"
-          className="agent-quick-btn agent-quick-btn--stop"
-          onClick={onStop}
-          title="Stop agent"
-        >
-          <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
-            <rect x="3" y="3" width="10" height="10" rx="1.5" fill="currentColor" />
-          </svg>
-          Stop
-        </button>
+  onFocusTerminal,
+}: AgentTerminalProps) => {
+  const agentDef = AGENT_REGISTRY.find((a) => a.id === agentType);
+  const statusInfo = STATUS_TEXT[status] ?? STATUS_TEXT.running;
+  const exited = status === 'done' || status === 'error';
+  const displayCwd = cwd ? truncatePath(cwd, 32) : '—';
+
+  return (
+    <div className="agent-body-wrap agent-body-wrap--running">
+      <div className="agent-card">
+        <div className="agent-card-header">
+          <div className="agent-card-header-left">
+            <AgentAvatar />
+            <span className="agent-card-title">Agent</span>
+          </div>
+          <span className={`agent-status-pill agent-status-pill--${statusInfo.tone}`}>
+            <span className="agent-status-pill-dot" />
+            {statusInfo.badge}
+          </span>
+        </div>
+
+        <div className="agent-info-strip">
+          <span className="agent-info-cell">
+            <AgentIcon id={agentType} size={14} />
+            <span className="agent-info-text">{agentDef?.label ?? agentType}</span>
+          </span>
+          <span className="agent-info-sep" aria-hidden="true" />
+          <span className="agent-info-cell agent-info-cell--cwd" title={cwd ?? ''}>
+            <FolderGlyph />
+            <span className="agent-info-text agent-info-text--mono">{displayCwd}</span>
+          </span>
+          <span className="agent-info-sep" aria-hidden="true" />
+          <span className={`agent-info-cell agent-info-load agent-info-load--${statusInfo.tone}`}>
+            <span className="agent-info-load-dot" />
+            {statusInfo.load}
+          </span>
+        </div>
+
+        <div
+          ref={containerRef}
+          className="agent-xterm-container"
+          onMouseDown={(e) => e.stopPropagation()}
+        />
+
+        <div className="agent-card-footer">
+          {exited ? (
+            <button
+              type="button"
+              className="agent-secondary-btn"
+              onClick={onRestart}
+              title="Restart agent"
+            >
+              <svg width="11" height="11" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                <path
+                  d="M13 8a5 5 0 11-1.5-3.6M13 3v2.5H10.5"
+                  stroke="currentColor"
+                  strokeWidth="1.4"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+              重启
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="agent-secondary-btn agent-secondary-btn--stop"
+              onClick={onStop}
+              title="Stop agent"
+            >
+              <StopGlyph />
+              停止
+            </button>
+          )}
+          <button
+            type="button"
+            className="agent-primary-btn"
+            onClick={onFocusTerminal}
+            title="Focus terminal"
+          >
+            <TerminalGlyph />
+            打开终端
+          </button>
+        </div>
       </div>
-    )}
-    {(status === 'done' || status === 'error') && (
-      <button
-        type="button"
-        className="agent-restart-btn"
-        onClick={onRestart}
-        title="Restart agent"
-      >
-        <svg width="11" height="11" viewBox="0 0 16 16" fill="none">
-          <path
-            d="M13 8a5 5 0 1 1-1.5-3.6M13 3v2.5H10.5"
-            stroke="currentColor"
-            strokeWidth="1.4"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-        Restart
-      </button>
-    )}
-  </div>
-);
+    </div>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTerminal.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTerminal.tsx
@@ -8,6 +8,11 @@ interface AgentTerminalProps {
   status: string;
   agentType: string;
   cwd?: string;
+  /** True while the PTY + agent CLI are bootstrapping. Used to render a
+   *  loading overlay on top of the otherwise-empty terminal so the user
+   *  doesn't stare at a black panel during the 1–3s Claude / Codex
+   *  startup window. */
+  loading?: boolean;
 }
 
 const FolderGlyph = () => (
@@ -32,10 +37,16 @@ export const AgentTerminal = ({
   status,
   agentType,
   cwd,
+  loading = false,
 }: AgentTerminalProps) => {
   const agentDef = AGENT_REGISTRY.find((a) => a.id === agentType);
   const statusInfo = STATUS_TEXT[status] ?? STATUS_TEXT.running;
   const displayCwd = cwd ? truncatePath(cwd, 32) : '—';
+  const loadingLabel = loading
+    ? `正在启动 ${agentDef?.label ?? agentType}…`
+    : '';
+  const loadStripText = loading ? '启动中' : statusInfo.load;
+  const loadStripTone = loading ? 'running' : statusInfo.tone;
 
   return (
     <div className="agent-body-wrap agent-body-wrap--running">
@@ -51,17 +62,30 @@ export const AgentTerminal = ({
             <span className="agent-info-text agent-info-text--mono">{displayCwd}</span>
           </span>
           <span className="agent-info-sep" aria-hidden="true" />
-          <span className={`agent-info-cell agent-info-load agent-info-load--${statusInfo.tone}`}>
+          <span
+            className={`agent-info-cell agent-info-load agent-info-load--${loadStripTone}${
+              loading ? ' agent-info-load--pulsing' : ''
+            }`}
+          >
             <span className="agent-info-load-dot" />
-            {statusInfo.load}
+            {loadStripText}
           </span>
         </div>
 
-        <div
-          ref={containerRef}
-          className="agent-xterm-container"
-          onMouseDown={(e) => e.stopPropagation()}
-        />
+        <div className="agent-xterm-wrap">
+          <div
+            ref={containerRef}
+            className="agent-xterm-container"
+            onMouseDown={(e) => e.stopPropagation()}
+          />
+          {loading && (
+            <div className="agent-loading-overlay" aria-live="polite">
+              <div className="agent-loading-spinner" aria-hidden="true" />
+              <div className="agent-loading-text">{loadingLabel}</div>
+              <div className="agent-loading-hint">首次加载会慢一些，稍候即可</div>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTerminal.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTerminal.tsx
@@ -42,9 +42,7 @@ export const AgentTerminal = ({
   const agentDef = AGENT_REGISTRY.find((a) => a.id === agentType);
   const statusInfo = STATUS_TEXT[status] ?? STATUS_TEXT.running;
   const displayCwd = cwd ? truncatePath(cwd, 32) : '—';
-  const loadingLabel = loading
-    ? `正在启动 ${agentDef?.label ?? agentType}…`
-    : '';
+  const loadingLabel = `正在启动 ${agentDef?.label ?? agentType}`;
   const loadStripText = loading ? '启动中' : statusInfo.load;
   const loadStripTone = loading ? 'running' : statusInfo.tone;
 
@@ -79,10 +77,26 @@ export const AgentTerminal = ({
             onMouseDown={(e) => e.stopPropagation()}
           />
           {loading && (
-            <div className="agent-loading-overlay" aria-live="polite">
-              <div className="agent-loading-spinner" aria-hidden="true" />
-              <div className="agent-loading-text">{loadingLabel}</div>
-              <div className="agent-loading-hint">首次加载会慢一些，稍候即可</div>
+            <div
+              className={`agent-loading-overlay agent-loading-overlay--${agentType}`}
+              aria-live="polite"
+            >
+              <div className="agent-loading-mark" aria-hidden="true">
+                <span className="agent-loading-halo agent-loading-halo--outer" />
+                <span className="agent-loading-halo agent-loading-halo--inner" />
+                <span className="agent-loading-icon">
+                  <AgentIcon id={agentType} size={22} />
+                </span>
+              </div>
+              <div className="agent-loading-label">
+                <span>{loadingLabel}</span>
+                <span className="agent-loading-dots" aria-hidden="true">
+                  <span />
+                  <span />
+                  <span />
+                </span>
+              </div>
+              <div className="agent-loading-hint">首次启动会慢一些，稍候即可</div>
             </div>
           )}
         </div>

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTerminal.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTerminal.tsx
@@ -42,7 +42,6 @@ export const AgentTerminal = ({
   const agentDef = AGENT_REGISTRY.find((a) => a.id === agentType);
   const statusInfo = STATUS_TEXT[status] ?? STATUS_TEXT.running;
   const displayCwd = cwd ? truncatePath(cwd, 32) : '—';
-  const loadingLabel = `正在启动 ${agentDef?.label ?? agentType}`;
   const loadStripText = loading ? '启动中' : statusInfo.load;
   const loadStripTone = loading ? 'running' : statusInfo.tone;
 
@@ -79,7 +78,8 @@ export const AgentTerminal = ({
           {loading && (
             <div
               className={`agent-loading-overlay agent-loading-overlay--${agentType}`}
-              aria-live="polite"
+              role="status"
+              aria-label={`Starting ${agentDef?.label ?? agentType}`}
             >
               <div className="agent-loading-mark" aria-hidden="true">
                 <span className="agent-loading-halo agent-loading-halo--outer" />
@@ -88,15 +88,6 @@ export const AgentTerminal = ({
                   <AgentIcon id={agentType} size={22} />
                 </span>
               </div>
-              <div className="agent-loading-label">
-                <span>{loadingLabel}</span>
-                <span className="agent-loading-dots" aria-hidden="true">
-                  <span />
-                  <span />
-                  <span />
-                </span>
-              </div>
-              <div className="agent-loading-hint">首次启动会慢一些，稍候即可</div>
             </div>
           )}
         </div>

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
@@ -494,10 +494,10 @@
   flex: 1;
   min-height: 120px;
   border-radius: 10px;
-  background: #1e1f24;
-  padding: 8px 6px 6px;
+  background: #fafaf9;
+  padding: 6px 4px 4px;
   overflow: hidden;
-  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.04) inset;
+  border: 1px solid var(--border-light);
 }
 
 .agent-xterm-container .xterm {

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
@@ -11,10 +11,16 @@
  * ──────────────────────────────────────────────────────────────── */
 
 :root {
-  --agent-accent: #5b5bf2;
-  --agent-accent-hover: #4747e8;
-  --agent-accent-soft: #eef0ff;
-  --agent-accent-border: rgba(91, 91, 242, 0.35);
+  /* Align the agent UI with the global Notion-style accent (--accent =
+   * #2383e2) so its buttons, tabs and focus rings read as part of the
+   * same product instead of a separate purple sub-theme. Per-agent
+   * brand colors still live in `.agent-loading-overlay--<agent>` for
+   * the loading mark, which is the one place the agent's own identity
+   * (Claude orange, Pulse-Coder indigo) is meaningful. */
+  --agent-accent: #2383e2;
+  --agent-accent-hover: #1c6dbf;
+  --agent-accent-soft: rgba(35, 131, 226, 0.1);
+  --agent-accent-border: rgba(35, 131, 226, 0.45);
   --agent-warning: #d97706;
   --agent-warning-soft: #fff4e2;
   --agent-warning-border: rgba(217, 119, 6, 0.32);
@@ -360,12 +366,12 @@
   cursor: pointer;
   flex-shrink: 0;
   transition: background 0.12s, box-shadow 0.12s, transform 0.08s;
-  box-shadow: 0 1px 2px rgba(91, 91, 242, 0.25);
+  box-shadow: 0 1px 2px rgba(35, 131, 226, 0.22);
 }
 
 .agent-primary-btn:hover {
   background: var(--agent-accent-hover);
-  box-shadow: 0 2px 8px rgba(91, 91, 242, 0.32);
+  box-shadow: 0 2px 8px rgba(35, 131, 226, 0.28);
 }
 
 .agent-primary-btn:active {
@@ -544,8 +550,8 @@
   /* Per-agent accent — each coding agent gets its own tinted halo so
    * the loading state feels branded rather than generic. */
   --loading-accent: var(--agent-accent);
-  --loading-tint: rgba(91, 91, 242, 0.13);
-  --loading-tint-strong: rgba(91, 91, 242, 0.22);
+  --loading-tint: rgba(35, 131, 226, 0.12);
+  --loading-tint-strong: rgba(35, 131, 226, 0.22);
 
   position: absolute;
   inset: 0;

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
@@ -5,9 +5,12 @@
  *   - .agent-body-wrap--restart  : cold-reload recovery
  * The agent identity uses a local purple accent so it reads as
  * distinct from the global blue accent without leaking outward.
+ *
+ * The status-pill scope (`.agent-status-pill`) is hoisted to :root so
+ * it can also be rendered in the outer `CanvasNodeView` node-header.
  * ──────────────────────────────────────────────────────────────── */
 
-.agent-body-wrap {
+:root {
   --agent-accent: #5b5bf2;
   --agent-accent-hover: #4747e8;
   --agent-accent-soft: #eef0ff;
@@ -18,13 +21,16 @@
   --agent-success: #10b981;
   --agent-success-soft: rgba(16, 185, 129, 0.12);
   --agent-danger: #e03e3e;
-  --agent-text: var(--text);
-  --agent-muted: var(--text-secondary);
-  --agent-faint: var(--text-muted);
   --agent-sans:
     -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC",
     "Hiragino Sans", "Microsoft YaHei", Roboto, "Helvetica Neue", Arial,
     sans-serif;
+}
+
+.agent-body-wrap {
+  --agent-text: var(--text);
+  --agent-muted: var(--text-secondary);
+  --agent-faint: var(--text-muted);
   font-family: var(--agent-sans);
   position: relative;
   width: 100%;
@@ -44,46 +50,12 @@
   overflow: hidden;
 }
 
-.agent-card-header {
+/* Back link rendered at the top of the body when Setup is entered from
+ * the Restart card's Edit action. */
+.agent-card-back {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding-bottom: 10px;
-  border-bottom: 1px solid var(--border-light);
-  gap: 8px;
-}
-
-.agent-card-header-left {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  min-width: 0;
-}
-
-.agent-card-header-right {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.agent-card-title {
-  font-size: 16px;
-  font-weight: 700;
-  color: var(--agent-text);
-  letter-spacing: -0.01em;
-  font-family: var(--agent-sans);
-}
-
-.agent-avatar {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  border-radius: 9px;
-  background: var(--agent-accent-soft);
-  color: var(--agent-accent);
-  flex-shrink: 0;
+  padding-bottom: 2px;
 }
 
 /* ── Status pill (Setup / Running / Restart / Edit) ───────────── */
@@ -126,7 +98,7 @@
 
 .agent-status-pill--done {
   background: rgba(0, 0, 0, 0.06);
-  color: var(--agent-muted);
+  color: var(--text-secondary);
 }
 
 .agent-status-pill--error {

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
@@ -640,46 +640,6 @@
   50%      { transform: scale(1.06); }
 }
 
-.agent-loading-label {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 6px;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text);
-  font-family: var(--agent-sans);
-  letter-spacing: 0.01em;
-}
-
-.agent-loading-dots {
-  display: inline-flex;
-  gap: 3px;
-  align-items: center;
-  padding-bottom: 2px;
-}
-
-.agent-loading-dots > span {
-  width: 4px;
-  height: 4px;
-  border-radius: 50%;
-  background: var(--loading-accent);
-  animation: agent-dot-bounce 1.4s ease-in-out infinite;
-}
-
-.agent-loading-dots > span:nth-child(2) { animation-delay: 0.18s; }
-.agent-loading-dots > span:nth-child(3) { animation-delay: 0.36s; }
-
-@keyframes agent-dot-bounce {
-  0%, 60%, 100% { opacity: 0.28; transform: translateY(0); }
-  30%           { opacity: 1;    transform: translateY(-3px); }
-}
-
-.agent-loading-hint {
-  font-size: 11px;
-  color: var(--text-muted);
-  font-family: var(--agent-sans);
-  letter-spacing: 0.02em;
-}
 
 /* ── Restart: saved-config list ────────────────────────────────── */
 

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
@@ -1,223 +1,284 @@
+/* ────────────────────────────────────────────────────────────────
+ * AgentNodeBody — three view modes share one card chrome.
+ *   - .agent-body-wrap--setup    : configuration entry
+ *   - .agent-body-wrap--running  : live PTY with embedded xterm
+ *   - .agent-body-wrap--restart  : cold-reload recovery
+ * The agent identity uses a local purple accent so it reads as
+ * distinct from the global blue accent without leaking outward.
+ * ──────────────────────────────────────────────────────────────── */
+
 .agent-body-wrap {
+  --agent-accent: #5b5bf2;
+  --agent-accent-hover: #4747e8;
+  --agent-accent-soft: #eef0ff;
+  --agent-accent-border: rgba(91, 91, 242, 0.35);
+  --agent-warning: #d97706;
+  --agent-warning-soft: #fff4e2;
+  --agent-warning-border: rgba(217, 119, 6, 0.32);
+  --agent-success: #10b981;
+  --agent-success-soft: rgba(16, 185, 129, 0.12);
+  --agent-danger: #e03e3e;
+  --agent-text: var(--text);
+  --agent-muted: var(--text-secondary);
+  --agent-faint: var(--text-muted);
+  --agent-sans:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC",
+    "Hiragino Sans", "Microsoft YaHei", Roboto, "Helvetica Neue", Arial,
+    sans-serif;
+  font-family: var(--agent-sans);
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-/* ── Picker (idle state) ──────────────────────────────── */
+/* ── Card chrome shared by all three views ─────────────────────── */
 
-.agent-picker {
+.agent-card {
   display: flex;
   flex-direction: column;
-  padding: 12px;
   height: 100%;
+  padding: 14px;
+  gap: 12px;
   box-sizing: border-box;
-}
-
-/* Single "launcher card" that fills the body: textarea hero on top,
- * toolbar chrome at the bottom. Mirrors modern AI chat input patterns. */
-.agent-launcher-card {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
   background: var(--surface);
   overflow: hidden;
-  transition: border-color 0.15s, box-shadow 0.15s;
 }
 
-.agent-launcher-card:focus-within {
-  border-color: var(--accent-border);
-  box-shadow: 0 0 0 3px var(--accent-light);
-}
-
-/* ── Hero prompt textarea ── */
-
-.agent-launcher-prompt {
-  flex: 1;
-  min-height: 72px;
-  padding: 14px 16px 12px;
-  border: none;
-  background: transparent;
-  color: var(--text);
-  font-size: 14px;
-  font-family: var(--font);
-  line-height: 1.55;
-  resize: none;
-  outline: none;
-  box-sizing: border-box;
-}
-
-.agent-launcher-prompt::placeholder {
-  color: var(--text-muted);
-}
-
-/* ── Toolbar (bottom of the card) ── */
-
-.agent-launcher-toolbar {
+.agent-card-header {
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border-light);
   gap: 8px;
-  padding: 10px 10px 10px;
-  border-top: 1px solid var(--border-light);
-  background: var(--surface-hover);
 }
 
-/* Agent pills row */
-
-.agent-pills {
+.agent-card-header-left {
   display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
 }
 
-.agent-pill {
+.agent-card-header-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.agent-card-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--agent-text);
+  letter-spacing: -0.01em;
+  font-family: var(--agent-sans);
+}
+
+.agent-avatar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 9px;
+  background: var(--agent-accent-soft);
+  color: var(--agent-accent);
+  flex-shrink: 0;
+}
+
+/* ── Status pill (Setup / Running / Restart / Edit) ───────────── */
+
+.agent-status-pill {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  height: 26px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: var(--agent-sans);
+  white-space: nowrap;
+}
+
+.agent-status-pill-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+
+.agent-status-pill--setup,
+.agent-status-pill--edit {
+  background: var(--agent-accent-soft);
+  color: var(--agent-accent);
+}
+
+.agent-status-pill--running {
+  background: var(--agent-success-soft);
+  color: var(--agent-success);
+}
+
+.agent-status-pill--restart {
+  background: var(--agent-warning-soft);
+  color: var(--agent-warning);
+}
+
+.agent-status-pill--done {
+  background: rgba(0, 0, 0, 0.06);
+  color: var(--agent-muted);
+}
+
+.agent-status-pill--error {
+  background: rgba(224, 62, 62, 0.1);
+  color: var(--agent-danger);
+}
+
+/* ── Body & sections ───────────────────────────────────────────── */
+
+.agent-card-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.agent-section-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--agent-text);
+  font-family: var(--agent-sans);
+}
+
+.agent-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.agent-field-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--agent-muted);
+  font-family: var(--agent-sans);
+}
+
+.agent-field-label svg {
+  color: var(--agent-muted);
+  flex-shrink: 0;
+}
+
+/* ── Setup: agent tabs ─────────────────────────────────────────── */
+
+.agent-tabs {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.agent-tab {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  height: 44px;
   padding: 0 10px;
   border: 1px solid var(--border);
-  border-radius: 999px;
+  border-radius: 10px;
   background: var(--surface);
-  color: var(--text-secondary);
-  font-size: 11px;
+  color: var(--agent-text);
+  font-size: 13px;
   font-weight: 500;
-  font-family: var(--font);
+  font-family: var(--agent-sans);
   cursor: pointer;
   transition: background 0.12s, border-color 0.12s, color 0.12s,
     box-shadow 0.12s;
   white-space: nowrap;
+  min-width: 0;
 }
 
-.agent-pill svg {
-  flex-shrink: 0;
+.agent-tab span {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.agent-pill:hover {
-  color: var(--text);
-  background: var(--surface);
-  border-color: var(--text-muted);
+.agent-tab:hover {
+  border-color: var(--agent-accent-border);
 }
 
-.agent-pill--active {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: #ffffff;
-  box-shadow: 0 1px 2px rgba(35, 131, 226, 0.22);
+.agent-tab--active {
+  background: var(--agent-accent-soft);
+  border-color: var(--agent-accent-border);
+  color: var(--agent-accent);
+  box-shadow: 0 0 0 1px var(--agent-accent-border) inset;
 }
 
-.agent-pill--active:hover {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: #ffffff;
-  filter: brightness(1.06);
+.agent-tab--active:hover {
+  filter: brightness(0.98);
 }
 
-/* Directory + Start row */
-
-.agent-toolbar-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
+/* ── Setup: working directory field ────────────────────────────── */
 
 .agent-dir-field {
-  flex: 1;
   display: flex;
   align-items: center;
-  gap: 2px;
-  min-width: 0;
-  height: 28px;
-  padding: 0 2px 0 4px;
+  height: 36px;
+  padding: 0 4px 0 12px;
   border: 1px solid var(--border);
-  border-radius: 7px;
+  border-radius: 10px;
   background: var(--surface);
   transition: border-color 0.12s, box-shadow 0.12s;
 }
 
 .agent-dir-field:focus-within {
-  border-color: var(--accent-border);
-  box-shadow: 0 0 0 2px var(--accent-light);
-}
-
-.agent-dir-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 22px;
-  border: none;
-  border-radius: 4px;
-  background: transparent;
-  color: var(--text-muted);
-  cursor: pointer;
-  flex-shrink: 0;
-  transition: background 0.12s, color 0.12s;
-}
-
-.agent-dir-icon:hover {
-  background: var(--border-light);
-  color: var(--text);
+  border-color: var(--agent-accent-border);
+  box-shadow: 0 0 0 3px var(--agent-accent-soft);
 }
 
 .agent-dir-input {
   flex: 1;
   min-width: 0;
   height: 100%;
-  padding: 0 6px;
   border: none;
   background: transparent;
-  color: var(--text);
-  font-size: 11px;
+  color: var(--agent-text);
+  font-size: 13px;
   font-family: var(--font-mono);
   outline: none;
 }
 
 .agent-dir-input::placeholder {
-  color: var(--text-muted);
-  font-family: var(--font);
-  font-size: 11px;
+  color: var(--agent-faint);
+  font-family: var(--font-mono);
 }
 
-/* Primary Start button */
-
-.agent-launch-btn {
+.agent-dir-icon {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  justify-content: center;
+  width: 28px;
   height: 28px;
-  padding: 0 14px;
+  margin-left: 4px;
   border: none;
   border-radius: 7px;
-  background: var(--accent);
-  color: #ffffff;
-  font-size: 12px;
-  font-weight: 600;
-  font-family: var(--font);
+  background: transparent;
+  color: var(--agent-muted);
   cursor: pointer;
   flex-shrink: 0;
-  transition: filter 0.12s, box-shadow 0.12s, transform 0.08s;
-  box-shadow: 0 1px 2px rgba(35, 131, 226, 0.25);
+  transition: background 0.12s, color 0.12s;
 }
 
-.agent-launch-btn:hover {
-  filter: brightness(1.08);
-  box-shadow: 0 2px 6px rgba(35, 131, 226, 0.3);
+.agent-dir-icon:hover {
+  background: var(--agent-accent-soft);
+  color: var(--agent-accent);
 }
 
-.agent-launch-btn:active {
-  transform: translateY(0.5px);
-  filter: brightness(0.96);
-}
-
-.agent-launch-btn svg {
-  color: #ffffff;
-}
-
-/* Recent folders chip strip */
+/* ── Setup: recents row ────────────────────────────────────────── */
 
 .agent-recent {
   display: flex;
@@ -229,8 +290,8 @@
 
 .agent-recent-label {
   font-size: 9px;
-  font-weight: 600;
-  color: var(--text-muted);
+  font-weight: 700;
+  color: var(--agent-faint);
   letter-spacing: 0.5px;
   text-transform: uppercase;
   padding-right: 2px;
@@ -241,7 +302,7 @@
   border: 1px dashed var(--border);
   border-radius: 10px;
   background: transparent;
-  color: var(--text-secondary);
+  color: var(--agent-muted);
   font-size: 10px;
   font-family: var(--font-mono);
   cursor: pointer;
@@ -253,19 +314,218 @@
 }
 
 .agent-recent-chip:hover {
-  background: var(--accent-light);
+  background: var(--agent-accent-soft);
   border-style: solid;
-  border-color: var(--accent-border);
-  color: var(--accent);
+  border-color: var(--agent-accent-border);
+  color: var(--agent-accent);
 }
 
-/* ── Terminal (running state) ─────────────────────────── */
+/* ── Setup: prompt textarea ────────────────────────────────────── */
+
+.agent-prompt-input {
+  width: 100%;
+  min-height: 76px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface);
+  color: var(--agent-text);
+  font-size: 13px;
+  font-family: var(--agent-sans);
+  line-height: 1.5;
+  resize: vertical;
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color 0.12s, box-shadow 0.12s;
+}
+
+.agent-prompt-input:focus {
+  border-color: var(--agent-accent-border);
+  box-shadow: 0 0 0 3px var(--agent-accent-soft);
+}
+
+.agent-prompt-input::placeholder {
+  color: var(--agent-faint);
+}
+
+/* ── Card footer with primary CTA ──────────────────────────────── */
+
+.agent-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  padding-top: 6px;
+  border-top: 1px solid var(--border-light);
+}
+
+.agent-card-footer--restart {
+  justify-content: stretch;
+}
+
+.agent-card-footer--restart .agent-primary-btn {
+  flex: 1;
+}
+
+.agent-card-footer--restart .agent-secondary-btn {
+  flex: 1;
+}
+
+.agent-primary-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  height: 40px;
+  padding: 0 22px;
+  border: none;
+  border-radius: 10px;
+  background: var(--agent-accent);
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 600;
+  font-family: var(--agent-sans);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.12s, box-shadow 0.12s, transform 0.08s;
+  box-shadow: 0 1px 2px rgba(91, 91, 242, 0.25);
+}
+
+.agent-primary-btn:hover {
+  background: var(--agent-accent-hover);
+  box-shadow: 0 2px 8px rgba(91, 91, 242, 0.32);
+}
+
+.agent-primary-btn:active {
+  transform: translateY(0.5px);
+}
+
+.agent-primary-btn svg {
+  color: #ffffff;
+}
+
+.agent-secondary-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  height: 40px;
+  padding: 0 18px;
+  border: 1px solid var(--agent-accent-border);
+  border-radius: 10px;
+  background: var(--surface);
+  color: var(--agent-accent);
+  font-size: 13px;
+  font-weight: 600;
+  font-family: var(--agent-sans);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
+}
+
+.agent-secondary-btn:hover {
+  background: var(--agent-accent-soft);
+}
+
+.agent-secondary-btn--stop {
+  color: var(--agent-muted);
+  border-color: var(--border);
+}
+
+.agent-secondary-btn--stop:hover {
+  color: var(--agent-danger);
+  border-color: var(--agent-danger);
+  background: rgba(224, 62, 62, 0.06);
+}
+
+/* ── Running: info strip ───────────────────────────────────────── */
+
+.agent-info-strip {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface);
+  min-height: 36px;
+  flex-shrink: 0;
+}
+
+.agent-info-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--agent-text);
+  font-size: 12px;
+  font-family: var(--agent-sans);
+  min-width: 0;
+}
+
+.agent-info-cell--cwd {
+  flex: 1;
+  min-width: 0;
+}
+
+.agent-info-cell svg {
+  color: var(--agent-muted);
+  flex-shrink: 0;
+}
+
+.agent-info-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+.agent-info-text--mono {
+  font-family: var(--font-mono);
+  color: var(--agent-muted);
+  font-weight: 400;
+}
+
+.agent-info-sep {
+  width: 1px;
+  height: 16px;
+  background: var(--border);
+  flex-shrink: 0;
+}
+
+.agent-info-load {
+  font-weight: 600;
+}
+
+.agent-info-load-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+
+.agent-info-load--running {
+  color: var(--agent-success);
+}
+
+.agent-info-load--done {
+  color: var(--agent-muted);
+}
+
+.agent-info-load--error {
+  color: var(--agent-danger);
+}
+
+/* ── Running: terminal panel ───────────────────────────────────── */
 
 .agent-xterm-container {
-  height: 100%;
-  background: #fafaf9;
-  padding: 6px 4px 4px;
+  flex: 1;
+  min-height: 120px;
+  border-radius: 10px;
+  background: #1e1f24;
+  padding: 8px 6px 6px;
   overflow: hidden;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.04) inset;
 }
 
 .agent-xterm-container .xterm {
@@ -282,84 +542,166 @@
 }
 
 .agent-xterm-container .xterm-rows {
-  padding: 0 4px;
+  padding: 0 6px;
 }
 
-/* ── Quick action buttons (running state) ── */
+/* ── Restart: saved-config list ────────────────────────────────── */
 
-.agent-quick-actions {
-  position: absolute;
-  bottom: 8px;
-  right: 8px;
-  z-index: 10;
+.agent-saved-list {
   display: flex;
-  gap: 4px;
-  opacity: 0;
-  transition: opacity 0.15s;
+  flex-direction: column;
+  gap: 8px;
 }
 
-.agent-body-wrap:hover .agent-quick-actions {
-  opacity: 1;
+.agent-saved-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface);
+  font-family: var(--agent-sans);
 }
 
-.agent-quick-btn {
+.agent-saved-row-left {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 3px 9px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.92);
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
-  color: var(--text-secondary);
-  font-size: 11px;
+  gap: 8px;
+  min-width: 0;
+}
+
+.agent-saved-row-left svg {
+  color: var(--agent-muted);
+  flex-shrink: 0;
+}
+
+.agent-saved-row-label {
+  font-size: 13px;
   font-weight: 500;
-  font-family: var(--font);
-  cursor: pointer;
-  box-shadow: var(--shadow-sm);
-  transition: background 0.12s, border-color 0.12s, color 0.12s;
+  color: var(--agent-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 280px;
 }
 
-.agent-quick-btn:hover {
-  background: var(--surface);
-  border-color: var(--text-muted);
-  color: var(--text);
+.agent-saved-row-label--mono {
+  font-family: var(--font-mono);
+  color: var(--agent-muted);
+  font-weight: 400;
+  font-size: 12px;
 }
 
-.agent-quick-btn--stop:hover {
-  background: rgba(224, 62, 62, 0.08);
-  border-color: #e03e3e;
-  color: #e03e3e;
-}
-
-/* ── Restart button (top-right of running body) ── */
-
-.agent-restart-btn {
-  position: absolute;
-  top: 6px;
-  right: 8px;
-  z-index: 10;
+.agent-saved-row-check {
+  color: var(--agent-accent);
   display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 3px 9px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.92);
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
-  color: var(--text-secondary);
-  font-size: 11px;
-  font-weight: 500;
-  font-family: var(--font);
-  cursor: pointer;
-  box-shadow: var(--shadow-sm);
-  transition: background 0.12s, border-color 0.12s, color 0.12s;
 }
 
-.agent-restart-btn:hover {
-  background: var(--surface);
-  border-color: var(--text-muted);
-  color: var(--text);
+.agent-saved-row-meta {
+  font-size: 11px;
+  color: var(--agent-accent);
+  font-weight: 600;
+  font-family: var(--agent-sans);
+}
+
+/* ── Restart: warning banner ───────────────────────────────────── */
+
+.agent-warning {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  background: var(--agent-warning-soft);
+  border: 1px solid var(--agent-warning-border);
+  border-radius: 10px;
+}
+
+.agent-warning-icon {
+  color: var(--agent-warning);
+  display: inline-flex;
+  flex-shrink: 0;
+}
+
+.agent-warning-text {
+  font-size: 12px;
+  color: var(--agent-warning);
+  font-family: var(--agent-sans);
+  line-height: 1.4;
+}
+
+/* ── Text links ────────────────────────────────────────────────── */
+
+.agent-text-link {
+  background: none;
+  border: none;
+  padding: 4px 8px;
+  font-size: 12px;
+  font-family: var(--agent-sans);
+  color: var(--agent-accent);
+  cursor: pointer;
+  border-radius: 6px;
+  transition: background 0.12s;
+}
+
+.agent-text-link:hover {
+  background: var(--agent-accent-soft);
+}
+
+.agent-text-link--center {
+  align-self: center;
+  margin-top: 4px;
+}
+
+/* ── Restart: details panel (查看上次配置) ──────────────────────── */
+
+.agent-details {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px dashed var(--border);
+  border-radius: 10px;
+  background: var(--surface-hover);
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.agent-details-block {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.agent-details-label {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  color: var(--agent-faint);
+  font-family: var(--agent-sans);
+}
+
+.agent-details-content {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--agent-text);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.agent-details-content--scrollback {
+  color: var(--agent-muted);
+  max-height: 100px;
+  overflow-y: auto;
+}
+
+.agent-details-empty {
+  font-size: 12px;
+  color: var(--agent-faint);
+  font-family: var(--agent-sans);
+  text-align: center;
+  padding: 4px;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
@@ -488,10 +488,31 @@
   color: var(--agent-danger);
 }
 
+.agent-info-load--pulsing .agent-info-load-dot {
+  animation: agent-pulse 1.1s ease-in-out infinite;
+}
+
+@keyframes agent-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+
 /* ── Running: terminal panel ───────────────────────────────────── */
 
-.agent-xterm-container {
+/* Positioned wrapper so the loading overlay can absolutely cover the
+ * xterm canvas without bleeding into the info strip above. */
+.agent-xterm-wrap {
+  position: relative;
   flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+.agent-xterm-wrap > .agent-xterm-container {
+  flex: 1;
+}
+
+.agent-xterm-container {
   min-height: 120px;
   border-radius: 10px;
   background: #fafaf9;
@@ -515,6 +536,56 @@
 
 .agent-xterm-container .xterm-rows {
   padding: 0 6px;
+}
+
+/* ── Loading overlay shown over the terminal while CLI bootstraps ─ */
+
+.agent-loading-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  border-radius: 10px;
+  background: rgba(250, 250, 249, 0.92);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  z-index: 5;
+  pointer-events: none;
+  animation: agent-fade-in 0.18s ease-out;
+}
+
+@keyframes agent-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.agent-loading-spinner {
+  width: 24px;
+  height: 24px;
+  border: 2.5px solid var(--agent-accent-soft);
+  border-top-color: var(--agent-accent);
+  border-radius: 50%;
+  animation: agent-spin 0.8s linear infinite;
+}
+
+@keyframes agent-spin {
+  to { transform: rotate(360deg); }
+}
+
+.agent-loading-text {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--agent-accent);
+  font-family: var(--agent-sans);
+}
+
+.agent-loading-hint {
+  font-size: 11px;
+  color: var(--text-secondary);
+  font-family: var(--agent-sans);
 }
 
 /* ── Restart: saved-config list ────────────────────────────────── */

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
@@ -541,51 +541,144 @@
 /* ── Loading overlay shown over the terminal while CLI bootstraps ─ */
 
 .agent-loading-overlay {
+  /* Per-agent accent — each coding agent gets its own tinted halo so
+   * the loading state feels branded rather than generic. */
+  --loading-accent: var(--agent-accent);
+  --loading-tint: rgba(91, 91, 242, 0.13);
+  --loading-tint-strong: rgba(91, 91, 242, 0.22);
+
   position: absolute;
   inset: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 10px;
+  gap: 14px;
   border-radius: 10px;
-  background: rgba(250, 250, 249, 0.92);
-  backdrop-filter: blur(2px);
-  -webkit-backdrop-filter: blur(2px);
+  background:
+    radial-gradient(
+      circle at center,
+      var(--loading-tint) 0%,
+      rgba(250, 250, 249, 0.96) 65%
+    );
+  backdrop-filter: blur(3px);
+  -webkit-backdrop-filter: blur(3px);
   z-index: 5;
   pointer-events: none;
-  animation: agent-fade-in 0.18s ease-out;
+  animation: agent-fade-in 0.22s ease-out;
+}
+
+.agent-loading-overlay--claude-code {
+  --loading-accent: #e07b3f;
+  --loading-tint: rgba(224, 123, 63, 0.14);
+  --loading-tint-strong: rgba(224, 123, 63, 0.26);
+}
+
+.agent-loading-overlay--pulse-coder {
+  --loading-accent: #6366f1;
+  --loading-tint: rgba(99, 102, 241, 0.14);
+  --loading-tint-strong: rgba(99, 102, 241, 0.26);
 }
 
 @keyframes agent-fade-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from { opacity: 0; transform: translateY(2px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
-.agent-loading-spinner {
-  width: 24px;
-  height: 24px;
-  border: 2.5px solid var(--agent-accent-soft);
-  border-top-color: var(--agent-accent);
+/* Stacked-halo mark: two concentric circles pulsing out of phase
+ * behind the agent's own brand icon. Reads as a soft "radar ping". */
+.agent-loading-mark {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+}
+
+.agent-loading-halo {
+  position: absolute;
+  inset: 0;
   border-radius: 50%;
-  animation: agent-spin 0.8s linear infinite;
+  background: var(--loading-tint);
 }
 
-@keyframes agent-spin {
-  to { transform: rotate(360deg); }
+.agent-loading-halo--outer {
+  animation: agent-halo-ping 1.8s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 
-.agent-loading-text {
+.agent-loading-halo--inner {
+  inset: 8px;
+  background: var(--loading-tint-strong);
+  animation: agent-halo-ping 1.8s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  animation-delay: 0.4s;
+}
+
+@keyframes agent-halo-ping {
+  0%   { transform: scale(0.7); opacity: 0.85; }
+  70%  { transform: scale(1.15); opacity: 0; }
+  100% { transform: scale(1.15); opacity: 0; }
+}
+
+.agent-loading-icon {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: #ffffff;
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.06),
+    0 4px 12px rgba(0, 0, 0, 0.05);
+  animation: agent-icon-breathe 1.8s ease-in-out infinite;
+}
+
+@keyframes agent-icon-breathe {
+  0%, 100% { transform: scale(1); }
+  50%      { transform: scale(1.06); }
+}
+
+.agent-loading-label {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
   font-size: 13px;
   font-weight: 600;
-  color: var(--agent-accent);
+  color: var(--text);
   font-family: var(--agent-sans);
+  letter-spacing: 0.01em;
+}
+
+.agent-loading-dots {
+  display: inline-flex;
+  gap: 3px;
+  align-items: center;
+  padding-bottom: 2px;
+}
+
+.agent-loading-dots > span {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--loading-accent);
+  animation: agent-dot-bounce 1.4s ease-in-out infinite;
+}
+
+.agent-loading-dots > span:nth-child(2) { animation-delay: 0.18s; }
+.agent-loading-dots > span:nth-child(3) { animation-delay: 0.36s; }
+
+@keyframes agent-dot-bounce {
+  0%, 60%, 100% { opacity: 0.28; transform: translateY(0); }
+  30%           { opacity: 1;    transform: translateY(-3px); }
 }
 
 .agent-loading-hint {
   font-size: 11px;
-  color: var(--text-secondary);
+  color: var(--text-muted);
   font-family: var(--agent-sans);
+  letter-spacing: 0.02em;
 }
 
 /* ── Restart: saved-config list ────────────────────────────────── */

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -29,6 +29,54 @@ interface Props {
 type ViewMode = 'setup' | 'running' | 'restart';
 
 /**
+ * Dark terminal theme used by the agent body. The shared
+ * `TERMINAL_OPTIONS` ships with a light background that doesn't match
+ * the redesigned dark terminal panel, so we override it locally —
+ * other terminal nodes (TerminalNodeBody) continue to use the light
+ * theme.
+ */
+const AGENT_TERMINAL_OPTIONS = {
+  ...TERMINAL_OPTIONS,
+  theme: {
+    ...TERMINAL_OPTIONS.theme,
+    background: '#1e1f24',
+    foreground: '#e6e6e6',
+    cursor: '#e6e6e6',
+    cursorAccent: '#1e1f24',
+    selectionBackground: 'rgba(99, 102, 241, 0.32)',
+    selectionForeground: '#ffffff',
+    black: '#1e1f24',
+    red: '#ff6b6b',
+    green: '#4ade80',
+    yellow: '#fbbf24',
+    blue: '#60a5fa',
+    magenta: '#c084fc',
+    cyan: '#67e8f9',
+    white: '#d1d5db',
+    brightBlack: '#6b7280',
+    brightRed: '#f87171',
+    brightGreen: '#86efac',
+    brightYellow: '#fde047',
+    brightBlue: '#93c5fd',
+    brightMagenta: '#d8b4fe',
+    brightCyan: '#a5f3fc',
+    brightWhite: '#f9fafb',
+  },
+};
+
+/**
+ * Mint a fresh PTY session id for a new spawn. We deliberately avoid
+ * reusing the node id (or a stale persisted sessionId) because the
+ * backend's `pty:spawn` short-circuits with `{ reused: true }` when the
+ * id is already in its map — and `pty:kill` is a fire-and-forget IPC,
+ * so a kill+respawn on the same id races and can attach the renderer
+ * to a session that gets torn down a moment later (resulting in an
+ * empty, dead terminal).
+ */
+const mintSessionId = (nodeId: string): string =>
+  `${nodeId}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+/**
  * Read the current agent view from persisted data. The body keeps
  * `data.viewMode` in sync with its real runtime view, so this function
  * trusts that field above all else — including the presence of saved
@@ -112,7 +160,7 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
 
       if (readOnly) {
         spawnedRef.current = true;
-        const term = new Terminal(TERMINAL_OPTIONS);
+        const term = new Terminal(AGENT_TERMINAL_OPTIONS);
         const fitAddon = new FitAddon();
         term.loadAddon(fitAddon);
         term.open(containerRef.current);
@@ -133,7 +181,7 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
       }
       spawnedRef.current = true;
 
-      const term = new Terminal(TERMINAL_OPTIONS);
+      const term = new Terminal(AGENT_TERMINAL_OPTIONS);
       const fitAddon = new FitAddon();
       term.loadAddon(fitAddon);
       term.open(containerRef.current);
@@ -319,6 +367,10 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
     if (effectiveCwd) {
       setRecentCwds(pushRecentCwd(effectiveCwd));
     }
+    const api = window.canvasWorkspace?.pty;
+    const oldSessionId = dataRef.current.sessionId;
+    if (api && oldSessionId) api.kill(oldSessionId);
+    const freshSessionId = mintSessionId(nodeIdRef.current);
     // Persist the launch intent to disk immediately. If the user reloads
     // before spawnAgent's own post-spawn update commits, the node will
     // reopen in the Restart view (because sessionId/scrollback get persisted
@@ -331,6 +383,8 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
         inlinePrompt: prompt,
         lastInitPrompt: prompt || dataRef.current.lastInitPrompt || '',
         status: 'running',
+        sessionId: freshSessionId,
+        scrollback: '',
       },
     });
     setFromRestart(false);
@@ -395,8 +449,9 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
     setViewMode('restart');
   }, [readOnly]);
 
-  /** Restart with saved config from the Restart view. Clears prior session
-   * artifacts so spawnAgent starts cleanly. */
+  /** Restart with saved config from the Restart view. Mints a fresh
+   * sessionId and explicitly kills any leftover backend session so a
+   * cold-reload-leaked PTY doesn't intercept the new spawn. */
   const handleRestartSession = useCallback(() => {
     if (readOnly) return;
     const savedAgent = data.agentType || selectedAgent;
@@ -405,6 +460,10 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
     pendingAgentRef.current = savedAgent;
     pendingCwdRef.current = savedCwd;
     pendingPromptRef.current = savedPrompt;
+    const api = window.canvasWorkspace?.pty;
+    const oldSessionId = dataRef.current.sessionId;
+    if (api && oldSessionId) api.kill(oldSessionId);
+    const freshSessionId = mintSessionId(nodeIdRef.current);
     onUpdateRef.current(nodeIdRef.current, {
       data: {
         ...dataRef.current,
@@ -412,7 +471,7 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
         cwd: savedCwd,
         inlinePrompt: savedPrompt,
         status: 'running',
-        sessionId: '',
+        sessionId: freshSessionId,
         scrollback: '',
       },
     });

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -402,19 +402,6 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
     setViewMode('running');
   }, [selectedAgent, cwdInput, promptInput, rootFolder, readOnly]);
 
-  const handleStop = useCallback(() => {
-    if (readOnly) return;
-    const api = window.canvasWorkspace?.pty;
-    if (api) api.kill(sessionId);
-    onUpdateRef.current(nodeIdRef.current, {
-      data: { ...dataRef.current, status: 'done' },
-    });
-  }, [sessionId, readOnly]);
-
-  const handleFocusTerminal = useCallback(() => {
-    termRef.current?.focus();
-  }, []);
-
   const handleMentionSelect = useCallback((selected: CanvasNode) => {
     if (readOnly) return;
     setPickerOpen(false);
@@ -434,31 +421,6 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
     setPickerOpen(false);
     termRef.current?.focus();
   }, []);
-
-  /**
-   * Triggered from the in-terminal "重启" button (live session that has
-   * exited). Tears down the dead PTY and routes to the Restart card so the
-   * user can decide whether to re-launch with the same config or edit it.
-   * Snapshots the final scrollback before disposing the terminal so the
-   * Restart card's "查看上次配置" panel can replay it.
-   */
-  const handleGoToRestart = useCallback(() => {
-    if (readOnly) return;
-    if (saveTimerRef.current) clearInterval(saveTimerRef.current);
-    if (termRef.current) {
-      const finalScrollback = serializeBuffer(termRef.current);
-      onUpdateRef.current(nodeIdRef.current, {
-        data: { ...dataRef.current, scrollback: finalScrollback },
-      });
-    }
-    cleanupRef.current?.();
-    termRef.current?.dispose();
-    termRef.current = null;
-    fitRef.current = null;
-    spawnedRef.current = false;
-    cleanupRef.current = null;
-    setViewMode('restart');
-  }, [readOnly]);
 
   /** Restart with saved config from the Restart view. Mints a fresh
    * sessionId and explicitly kills any leftover backend session so a
@@ -559,9 +521,6 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
         status={status}
         agentType={data.agentType || 'claude-code'}
         cwd={data.cwd}
-        onRestart={handleGoToRestart}
-        onStop={handleStop}
-        onFocusTerminal={handleFocusTerminal}
       />
     </>
   );

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -206,16 +206,6 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
         return;
       }
 
-      const spawnCwd = cwd || rootFolder || undefined;
-      const result = await api.spawn(sessionId, term.cols, term.rows, spawnCwd, workspaceId);
-      if (!result.ok) {
-        term.writeln(`\x1b[31mFailed to spawn shell: ${result.error}\x1b[0m`);
-        onUpdateRef.current(nodeIdRef.current, {
-          data: { ...dataRef.current, status: 'error' },
-        });
-        return;
-      }
-
       // Resolve the agent command to write once the shell is ready
       const command = getAgentCommand(agentType);
       const writeCommand = () => {
@@ -251,11 +241,19 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
         }
       };
 
+      // Attach the data listener BEFORE awaiting spawn. The backend creates
+      // the PTY synchronously inside the spawn handler and the shell starts
+      // emitting its prompt almost immediately, so if we wait for the await
+      // to resolve before attaching, the first chunk of output arrives on
+      // an IPC channel with no listener and is dropped — producing a black
+      // terminal that never prints anything. Attaching first is safe: until
+      // the spawn handler runs there's no one to emit, and ipcRenderer.on
+      // happily waits for events.
       let prompted = false;
-      let removeData: (() => void) | null = null;
+      const removeDataRef: { current: (() => void) | null } = { current: null };
 
       const attachPermanentListener = () => {
-        removeData = api.onData(sessionId, (d: string) => { term.write(d); });
+        removeDataRef.current = api.onData(sessionId, (d: string) => { term.write(d); });
       };
 
       const promptRemove = api.onData(sessionId, (d: string) => {
@@ -274,6 +272,19 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
           data: { ...dataRef.current, status: 'done' },
         });
       });
+
+      const spawnCwd = cwd || rootFolder || undefined;
+      const result = await api.spawn(sessionId, term.cols, term.rows, spawnCwd, workspaceId);
+      if (!result.ok) {
+        if (!prompted) promptRemove();
+        removeDataRef.current?.();
+        removeExit();
+        term.writeln(`\x1b[31mFailed to spawn shell: ${result.error}\x1b[0m`);
+        onUpdateRef.current(nodeIdRef.current, {
+          data: { ...dataRef.current, status: 'error' },
+        });
+        return;
+      }
 
       term.onData((d: string) => {
         api.write(sessionId, d);
@@ -296,7 +307,7 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
 
       cleanupRef.current = () => {
         if (!prompted) promptRemove();
-        removeData?.();
+        removeDataRef.current?.();
         removeExit();
         api.kill(sessionId);
       };

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -29,15 +29,25 @@ interface Props {
 type ViewMode = 'setup' | 'running' | 'restart';
 
 /**
- * Decide which view to mount based on persisted node data. A node lands in
- * `restart` only when the previous session left behind enough breadcrumbs
- * (sessionId or scrollback) to make it clear the PTY was alive at some
- * point, but the current process tree no longer has it — i.e. a cold
- * reload of the renderer. Fresh `autoLaunch`-created nodes still have
- * `status: 'running'` but no breadcrumbs, so they correctly route to
- * `running` and spawn a real PTY.
+ * Read the current agent view from persisted data. The body keeps
+ * `data.viewMode` in sync with its real runtime view, so this function
+ * trusts that field above all else — including the presence of saved
+ * scrollback, which can be a legitimate live-session artifact (the save
+ * timer writes scrollback every 2s while the PTY is alive).
+ *
+ * Exported so the outer `CanvasNodeView` header can render a matching
+ * status pill from persisted data without needing a callback handshake
+ * with the body.
+ *
+ * Mount-time cold-reload detection lives in `AgentNodeBody`'s own
+ * `useState` initializer below — the body needs that nuance, the header
+ * doesn't.
  */
-const detectInitialView = (data: AgentNodeData): ViewMode => {
+export const detectAgentView = (data: AgentNodeData): ViewMode => {
+  if (data.viewMode === 'setup') return 'setup';
+  if (data.viewMode === 'running') return 'running';
+  if (data.viewMode === 'restart') return 'restart';
+  // Legacy fallback for nodes persisted before `viewMode` existed.
   const status = data.status ?? 'idle';
   const hasPriorSession =
     !!(data.sessionId && data.sessionId.length > 0)
@@ -56,7 +66,19 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
   const [promptInput, setPromptInput] = useState(data.inlinePrompt || data.lastInitPrompt || '');
   const [pickerOpen, setPickerOpen] = useState(false);
   const [recentCwds, setRecentCwds] = useState<string[]>(loadRecentCwds);
-  const [viewMode, setViewMode] = useState<ViewMode>(() => detectInitialView(data));
+  const [viewMode, setViewMode] = useState<ViewMode>(() => {
+    // Mount-time cold-reload override: if the persisted `viewMode` is
+    // `running` but the renderer just remounted (i.e. this useState
+    // initializer is firing), the PTY that backed it is gone. Saved
+    // sessionId / scrollback are the proof that a live session existed
+    // at some point. Land on Restart so the user gets a clear recovery
+    // affordance instead of a dead terminal pretending to be live.
+    const hasPriorSession =
+      !!(data.sessionId && data.sessionId.length > 0)
+      || !!(data.scrollback && data.scrollback.length > 0);
+    if (data.viewMode === 'running' && hasPriorSession) return 'restart';
+    return detectAgentView(data);
+  });
   /** True after a Setup view was entered via the Restart card's "Edit" action,
    * so we can show a Back link and route the next launch back to Restart on
    * cancel. */
@@ -276,6 +298,17 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
     return () => observer.disconnect();
   }, [viewMode]);
 
+  // Persist viewMode so the outer canvas-node header can render a matching
+  // status pill. Skipped while readOnly to avoid mutating a node opened in
+  // a viewer / shared workspace.
+  useEffect(() => {
+    if (readOnly) return;
+    if (dataRef.current.viewMode === viewMode) return;
+    onUpdateRef.current(nodeIdRef.current, {
+      data: { ...dataRef.current, viewMode },
+    });
+  }, [viewMode, readOnly]);
+
   const handleLaunch = useCallback(() => {
     if (readOnly) return;
     const effectiveCwd = cwdInput || rootFolder || '';
@@ -419,7 +452,6 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
         promptInput={promptInput}
         rootFolder={rootFolder}
         recentCwds={recentCwds}
-        badge={fromRestart ? 'edit' : 'setup'}
         onBack={fromRestart ? handleBackToRestart : undefined}
         onAgentChange={setSelectedAgent}
         onCwdChange={setCwdInput}

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -29,42 +29,6 @@ interface Props {
 type ViewMode = 'setup' | 'running' | 'restart';
 
 /**
- * Dark terminal theme used by the agent body. The shared
- * `TERMINAL_OPTIONS` ships with a light background that doesn't match
- * the redesigned dark terminal panel, so we override it locally —
- * other terminal nodes (TerminalNodeBody) continue to use the light
- * theme.
- */
-const AGENT_TERMINAL_OPTIONS = {
-  ...TERMINAL_OPTIONS,
-  theme: {
-    ...TERMINAL_OPTIONS.theme,
-    background: '#1e1f24',
-    foreground: '#e6e6e6',
-    cursor: '#e6e6e6',
-    cursorAccent: '#1e1f24',
-    selectionBackground: 'rgba(99, 102, 241, 0.32)',
-    selectionForeground: '#ffffff',
-    black: '#1e1f24',
-    red: '#ff6b6b',
-    green: '#4ade80',
-    yellow: '#fbbf24',
-    blue: '#60a5fa',
-    magenta: '#c084fc',
-    cyan: '#67e8f9',
-    white: '#d1d5db',
-    brightBlack: '#6b7280',
-    brightRed: '#f87171',
-    brightGreen: '#86efac',
-    brightYellow: '#fde047',
-    brightBlue: '#93c5fd',
-    brightMagenta: '#d8b4fe',
-    brightCyan: '#a5f3fc',
-    brightWhite: '#f9fafb',
-  },
-};
-
-/**
  * Mint a fresh PTY session id for a new spawn. We deliberately avoid
  * reusing the node id (or a stale persisted sessionId) because the
  * backend's `pty:spawn` short-circuits with `{ reused: true }` when the
@@ -160,7 +124,7 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
 
       if (readOnly) {
         spawnedRef.current = true;
-        const term = new Terminal(AGENT_TERMINAL_OPTIONS);
+        const term = new Terminal(TERMINAL_OPTIONS);
         const fitAddon = new FitAddon();
         term.loadAddon(fitAddon);
         term.open(containerRef.current);
@@ -181,7 +145,7 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
       }
       spawnedRef.current = true;
 
-      const term = new Terminal(AGENT_TERMINAL_OPTIONS);
+      const term = new Terminal(TERMINAL_OPTIONS);
       const fitAddon = new FitAddon();
       term.loadAddon(fitAddon);
       term.open(containerRef.current);

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -69,6 +69,28 @@ export const detectAgentView = (data: AgentNodeData): ViewMode => {
   return 'setup';
 };
 
+/**
+ * After a cold reload, decide whether to silently resume instead of
+ * showing the Restart card. Limited to Claude Code because only its
+ * CLI supports caller-supplied --resume <uuid> that actually picks up
+ * the prior conversation; Codex / Pulse-Coder would silently start a
+ * fresh session and confusingly lose context. Also limited to
+ * `status === 'running'`, so a node the user saw exit (status='done'
+ * or 'error') still surfaces the Restart card and waits for an
+ * explicit user action — auto-reviving an agent the user thought was
+ * stopped would be surprising.
+ */
+const shouldAutoResume = (data: AgentNodeData): boolean => {
+  if (data.agentType !== 'claude-code') return false;
+  if (!data.cliSessionId) return false;
+  if (data.status !== 'running') return false;
+  if (data.viewMode !== 'running') return false;
+  return !!(
+    (data.sessionId && data.sessionId.length > 0)
+    || (data.scrollback && data.scrollback.length > 0)
+  );
+};
+
 export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUpdate, readOnly = false }: Props) => {
   const data = node.data as AgentNodeData;
   const status = data.status ?? 'idle';
@@ -83,8 +105,14 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
     // `running` but the renderer just remounted (i.e. this useState
     // initializer is firing), the PTY that backed it is gone. Saved
     // sessionId / scrollback are the proof that a live session existed
-    // at some point. Land on Restart so the user gets a clear recovery
-    // affordance instead of a dead terminal pretending to be live.
+    // at some point. Normally we'd land on Restart so the user picks
+    // up where they left off explicitly — except Claude Code with a
+    // persisted cliSessionId can be silently resumed via `--resume
+    // <uuid>`, which is the truly seamless behavior. In that case we
+    // skip the Restart card entirely and route straight back to the
+    // running view; the spawn below picks the right flag because
+    // pendingResumeRef gets initialized to true alongside.
+    if (shouldAutoResume(data)) return 'running';
     const hasPriorSession =
       !!(data.sessionId && data.sessionId.length > 0)
       || !!(data.scrollback && data.scrollback.length > 0);
@@ -108,8 +136,11 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
   const pendingPromptRef = useRef(data.inlinePrompt || '');
   /** True when the next spawn should resume an existing CLI session
    *  instead of creating a new one. Flipped by handleRestartSession,
-   *  reset by handleLaunch. */
-  const pendingResumeRef = useRef(false);
+   *  reset by handleLaunch. Initialized to true on mount when the
+   *  cold-reload heuristic auto-routes a Claude Code node into
+   *  `running`, so the resumed spawn uses `--resume <uuid>` instead
+   *  of `--session-id <uuid>`. */
+  const pendingResumeRef = useRef(shouldAutoResume(data));
 
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -95,6 +95,11 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
    * so we can show a Back link and route the next launch back to Restart on
    * cancel. */
   const [fromRestart, setFromRestart] = useState(false);
+  /** True from the moment spawnAgent starts until the agent CLI has
+   *  printed something substantive (or a 12s fail-safe elapses).
+   *  Drives the loading overlay shown over the otherwise-empty
+   *  terminal during the multi-second CLI bootstrap. */
+  const [loading, setLoading] = useState(false);
 
   // Refs that survive across the setup→running transition so the
   // useEffect that spawns after re-render can read the user's selection.
@@ -153,6 +158,7 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
         return;
       }
       spawnedRef.current = true;
+      setLoading(true);
 
       const term = new Terminal(TERMINAL_OPTIONS);
       const fitAddon = new FitAddon();
@@ -195,11 +201,14 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
         const flag = resumeMode && canResume ? '--resume' : '--session-id';
         return ` ${flag} ${cliSessionId}`;
       };
+      const writeCommandTimeRef = { current: 0 };
       const writeCommand = () => {
         if (!command) {
           term.writeln(`\x1b[33mUnknown agent type: ${agentType}\x1b[0m`);
+          setLoading(false);
           return;
         }
+        writeCommandTimeRef.current = Date.now();
         const flags = buildClaudeFlags();
         const { inlinePrompt, promptFile, agentArgs } = dataRef.current;
         const effectivePrompt = inlinePromptOverride || inlinePrompt;
@@ -239,9 +248,32 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
       // happily waits for events.
       let prompted = false;
       const removeDataRef: { current: (() => void) | null } = { current: null };
+      // Dismiss the loading overlay on the first chunk that arrives at
+      // least ~400ms after writeCommand fires — that filters out the
+      // shell's instant echo of our launch command, so the overlay
+      // stays up through the multi-second CLI bootstrap and goes away
+      // the moment the agent itself starts emitting output.
+      let loadingDismissed = false;
+      const dismissLoading = () => {
+        if (loadingDismissed) return;
+        loadingDismissed = true;
+        setLoading(false);
+      };
+      // Fail-safe in case the agent never produces post-echo output
+      // (e.g. exits immediately, hangs on first prompt).
+      const loadingTimeout = setTimeout(dismissLoading, 12_000);
 
       const attachPermanentListener = () => {
-        removeDataRef.current = api.onData(sessionId, (d: string) => { term.write(d); });
+        removeDataRef.current = api.onData(sessionId, (d: string) => {
+          term.write(d);
+          if (
+            !loadingDismissed
+            && writeCommandTimeRef.current > 0
+            && Date.now() - writeCommandTimeRef.current > 400
+          ) {
+            dismissLoading();
+          }
+        });
       };
 
       const promptRemove = api.onData(sessionId, (d: string) => {
@@ -256,6 +288,7 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
 
       const removeExit = api.onExit(sessionId, (code: number) => {
         term.writeln(`\r\n\x1b[2m[Agent exited with code ${code}]\x1b[0m`);
+        dismissLoading();
         onUpdateRef.current(nodeIdRef.current, {
           data: { ...dataRef.current, status: 'done' },
         });
@@ -267,6 +300,8 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
         if (!prompted) promptRemove();
         removeDataRef.current?.();
         removeExit();
+        clearTimeout(loadingTimeout);
+        dismissLoading();
         term.writeln(`\x1b[31mFailed to spawn shell: ${result.error}\x1b[0m`);
         onUpdateRef.current(nodeIdRef.current, {
           data: { ...dataRef.current, status: 'error' },
@@ -304,6 +339,8 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
         if (!prompted) promptRemove();
         removeDataRef.current?.();
         removeExit();
+        clearTimeout(loadingTimeout);
+        dismissLoading();
         api.kill(sessionId);
       };
     },
@@ -340,6 +377,7 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
       fitRef.current = null;
       spawnedRef.current = false;
       cleanupRef.current = null;
+      setLoading(false);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [viewMode]);
@@ -527,6 +565,7 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
         status={status}
         agentType={data.agentType || 'claude-code'}
         cwd={data.cwd}
+        loading={loading}
       />
     </>
   );

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -13,6 +13,7 @@ import {
 } from './utils/terminal';
 import { AgentPicker } from './AgentPicker';
 import { AgentTerminal } from './AgentTerminal';
+import { AgentRestart } from './AgentRestart';
 import { NodeMentionPicker } from '../NodeMentionPicker';
 
 interface Props {
@@ -25,32 +26,43 @@ interface Props {
   readOnly?: boolean;
 }
 
+type ViewMode = 'setup' | 'running' | 'restart';
+
+/**
+ * Decide which view to mount based on persisted node data. A node lands in
+ * `restart` only when the previous session left behind enough breadcrumbs
+ * (sessionId or scrollback) to make it clear the PTY was alive at some
+ * point, but the current process tree no longer has it — i.e. a cold
+ * reload of the renderer. Fresh `autoLaunch`-created nodes still have
+ * `status: 'running'` but no breadcrumbs, so they correctly route to
+ * `running` and spawn a real PTY.
+ */
+const detectInitialView = (data: AgentNodeData): ViewMode => {
+  const status = data.status ?? 'idle';
+  const hasPriorSession =
+    !!(data.sessionId && data.sessionId.length > 0)
+    || !!(data.scrollback && data.scrollback.length > 0);
+  if (hasPriorSession) return 'restart';
+  if (status === 'running' || status === 'done' || status === 'error') return 'running';
+  return 'setup';
+};
+
 export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUpdate, readOnly = false }: Props) => {
   const data = node.data as AgentNodeData;
   const status = data.status ?? 'idle';
 
   const [selectedAgent, setSelectedAgent] = useState(data.agentType || 'claude-code');
   const [cwdInput, setCwdInput] = useState(data.cwd || '');
-  const [promptInput, setPromptInput] = useState(data.inlinePrompt || '');
+  const [promptInput, setPromptInput] = useState(data.inlinePrompt || data.lastInitPrompt || '');
   const [pickerOpen, setPickerOpen] = useState(false);
   const [recentCwds, setRecentCwds] = useState<string[]>(loadRecentCwds);
-  // Treat any of the following as evidence that the node has been launched
-  // before and should skip the picker on mount:
-  //   - an explicit running/done/error status,
-  //   - saved scrollback (the 2s interval writes this even when a status
-  //     update was lost to the debounced-save race),
-  //   - a persisted sessionId (only set after spawn succeeds).
-  // The scrollback/sessionId fallbacks rescue nodes that were launched under
-  // an earlier buggy code path where status never made it to disk.
-  const [launched, setLaunched] = useState(
-    status === 'running'
-      || status === 'done'
-      || status === 'error'
-      || !!(data.scrollback && data.scrollback.length > 0)
-      || !!(data.sessionId && data.sessionId.length > 0),
-  );
+  const [viewMode, setViewMode] = useState<ViewMode>(() => detectInitialView(data));
+  /** True after a Setup view was entered via the Restart card's "Edit" action,
+   * so we can show a Back link and route the next launch back to Restart on
+   * cancel. */
+  const [fromRestart, setFromRestart] = useState(false);
 
-  // Refs that survive across the picker→terminal transition so the
+  // Refs that survive across the setup→running transition so the
   // useEffect that spawns after re-render can read the user's selection.
   const pendingAgentRef = useRef(data.agentType || 'claude-code');
   const pendingCwdRef = useRef(data.cwd || '');
@@ -71,49 +83,23 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
   onUpdateRef.current = onUpdate;
   const getAllNodesRef = useRef(getAllNodes);
   getAllNodesRef.current = getAllNodes;
-  const initialScrollback = useRef(data.scrollback ?? '');
-  /**
-   * Distinguishes a fresh user-initiated launch (picker → Start click) from
-   * the other ways `launched` can become true on mount. On a cold reload
-   * of a previously spawned PTY the backing shell has been torn down and
-   * cannot be reattached, so we must NOT re-spawn and re-run the agent
-   * command — doing so both destroys the saved terminal output and can
-   * race with status persistence.
-   *
-   * Note: this ref alone isn't sufficient to identify a cold reload — a
-   * tool-triggered auto-launch (e.g. `canvas_create_agent_node` with
-   * `autoLaunch: true`) also mounts with `launched=true` without a Start
-   * click but has never spawned a PTY. The mount effect combines this
-   * ref with `data.sessionId`/`data.scrollback` to tell the two apart.
-   *
-   * Stays `false` across re-renders; flipped to `true` in `handleLaunch`
-   * and reset in `handleRestart`.
-   */
-  const userLaunchedRef = useRef(false);
-  /** Tracks whether spawnAgent entered the restored (no-PTY) branch so the
-   * cleanup effect knows to skip PTY-related teardown. */
-  const isRestoredRef = useRef(false);
 
   const spawnAgent = useCallback(
-    async (
-      agentType: string,
-      cwd: string,
-      inlinePromptOverride?: string,
-      isRestored = false,
-    ) => {
+    async (agentType: string, cwd: string, inlinePromptOverride?: string) => {
       if (!containerRef.current || termRef.current || spawnedRef.current) return;
+
       if (readOnly) {
         spawnedRef.current = true;
-        isRestoredRef.current = true;
         const term = new Terminal(TERMINAL_OPTIONS);
         const fitAddon = new FitAddon();
         term.loadAddon(fitAddon);
         term.open(containerRef.current);
         termRef.current = term;
         fitRef.current = fitAddon;
-        if (initialScrollback.current) {
+        const saved = dataRef.current.scrollback;
+        if (saved) {
           term.writeln('\x1b[2m--- restored agent output ---\x1b[0m');
-          term.write(initialScrollback.current.split('\n').join('\r\n'));
+          term.write(saved.split('\n').join('\r\n'));
           term.writeln('');
         } else {
           term.writeln('\x1b[2m--- no saved agent output ---\x1b[0m');
@@ -124,7 +110,6 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
         return;
       }
       spawnedRef.current = true;
-      isRestoredRef.current = isRestored;
 
       const term = new Terminal(TERMINAL_OPTIONS);
       const fitAddon = new FitAddon();
@@ -144,26 +129,6 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
       requestAnimationFrame(() => {
         try { fitAddon.fit(); } catch { /* ignore */ }
       });
-
-      if (isRestored) {
-        // Cold reload: the PTY was killed on the previous unmount, so we
-        // cannot reattach. Replay the full saved scrollback as static
-        // output and mark status as 'done' so the Restart button shows.
-        // The user can click Restart to explicitly spawn a fresh session.
-        if (initialScrollback.current) {
-          term.writeln('\x1b[2m--- restored from previous session ---\x1b[0m');
-          term.write(initialScrollback.current.split('\n').join('\r\n'));
-          term.writeln('');
-        } else {
-          term.writeln('\x1b[2m--- previous session (no saved output) ---\x1b[0m');
-        }
-        if (dataRef.current.status !== 'done') {
-          onUpdateRef.current(nodeIdRef.current, {
-            data: { ...dataRef.current, status: 'done' },
-          });
-        }
-        return;
-      }
 
       const api = window.canvasWorkspace?.pty;
       if (!api) {
@@ -202,8 +167,16 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
         }
 
         if (effectivePrompt || promptFile) {
+          // Clear `inlinePrompt`/`promptFile` so they don't re-fire on next
+          // spawn, but stash a copy in `lastInitPrompt` so the Restart view
+          // can show what the previous session was started with.
           onUpdateRef.current(nodeIdRef.current, {
-            data: { ...dataRef.current, inlinePrompt: '', promptFile: '' },
+            data: {
+              ...dataRef.current,
+              inlinePrompt: '',
+              promptFile: '',
+              lastInitPrompt: effectivePrompt || dataRef.current.lastInitPrompt || '',
+            },
           });
         }
       };
@@ -262,37 +235,19 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
   );
 
   useEffect(() => {
-    if (launched && !spawnedRef.current) {
-      // If the component is mounting with launched=true but the user did
-      // NOT click Start in this render lifecycle, there are two sub-cases:
-      //   a) Cold reload of a real previous session — the prior PTY had
-      //      spawned (so `sessionId` was persisted by spawnAgent) or had
-      //      output serialized to `scrollback`. The PTY was killed on the
-      //      previous unmount and cannot be reattached; replay scrollback.
-      //   b) A tool just created this node (e.g.
-      //      `canvas_create_agent_node` with autoLaunch) and persisted
-      //      `status: 'running'` without ever spawning a PTY. `sessionId`
-      //      and `scrollback` are both empty — we must do a FRESH spawn,
-      //      otherwise the terminal hangs showing "previous session (no
-      //      saved output)" and the agent never runs.
-      const hasPriorSession =
-        !!(data.sessionId && data.sessionId.length > 0)
-        || !!(data.scrollback && data.scrollback.length > 0);
-      const isRestored = !userLaunchedRef.current && hasPriorSession;
+    if (viewMode === 'running' && !spawnedRef.current) {
       void spawnAgent(
         pendingAgentRef.current,
         pendingCwdRef.current,
         pendingPromptRef.current,
-        isRestored,
       );
     }
     return () => {
-      const api = window.canvasWorkspace?.pty;
       // Only snapshot terminal contents back to the node when there was a
-      // live PTY to serialize. Restored nodes already hold the authoritative
-      // scrollback on disk; re-serializing the xterm buffer would round-trip
-      // through display formatting and drift the saved output over time.
-      if (termRef.current && api && !isRestoredRef.current) {
+      // live PTY. The Restart view persists its own data and shouldn't
+      // round-trip the dead xterm buffer.
+      const api = window.canvasWorkspace?.pty;
+      if (termRef.current && api && viewMode === 'running') {
         const scrollback = serializeBuffer(termRef.current);
         void api.getCwd(sessionId).then((r) => {
           const cwd = r.ok && r.cwd ? r.cwd : dataRef.current.cwd;
@@ -308,10 +263,9 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
       fitRef.current = null;
       spawnedRef.current = false;
       cleanupRef.current = null;
-      isRestoredRef.current = false;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [launched]);
+  }, [viewMode]);
 
   useEffect(() => {
     if (!fitRef.current) return;
@@ -320,7 +274,7 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
     });
     if (containerRef.current) observer.observe(containerRef.current);
     return () => observer.disconnect();
-  }, [launched]);
+  }, [viewMode]);
 
   const handleLaunch = useCallback(() => {
     if (readOnly) return;
@@ -332,23 +286,22 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
     if (effectiveCwd) {
       setRecentCwds(pushRecentCwd(effectiveCwd));
     }
-    // Mark this launch as user-initiated so the mount effect doesn't treat
-    // the upcoming render as a cold-reload restore.
-    userLaunchedRef.current = true;
     // Persist the launch intent to disk immediately. If the user reloads
     // before spawnAgent's own post-spawn update commits, the node will
-    // still reopen in launched state (terminal view) instead of regressing
-    // to the initial picker.
+    // reopen in the Restart view (because sessionId/scrollback get persisted
+    // a moment later by the save timer) instead of regressing to Setup.
     onUpdateRef.current(nodeIdRef.current, {
       data: {
         ...dataRef.current,
         agentType: selectedAgent,
         cwd: effectiveCwd,
         inlinePrompt: prompt,
+        lastInitPrompt: prompt || dataRef.current.lastInitPrompt || '',
         status: 'running',
       },
     });
-    setLaunched(true);
+    setFromRestart(false);
+    setViewMode('running');
   }, [selectedAgent, cwdInput, promptInput, rootFolder, readOnly]);
 
   const handleStop = useCallback(() => {
@@ -360,12 +313,9 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
     });
   }, [sessionId, readOnly]);
 
-  const handleSendPrompt = useCallback((prompt: string) => {
-    if (readOnly) return;
-    const api = window.canvasWorkspace?.pty;
-    if (!api) return;
-    api.write(sessionId, `\n${prompt}\n`);
-  }, [sessionId, readOnly]);
+  const handleFocusTerminal = useCallback(() => {
+    termRef.current?.focus();
+  }, []);
 
   const handleMentionSelect = useCallback((selected: CanvasNode) => {
     if (readOnly) return;
@@ -387,27 +337,69 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
     termRef.current?.focus();
   }, []);
 
-  const handleRestart = useCallback(() => {
+  /**
+   * Triggered from the in-terminal "重启" button (live session that has
+   * exited). Tears down the dead PTY and routes to the Restart card so the
+   * user can decide whether to re-launch with the same config or edit it.
+   * Snapshots the final scrollback before disposing the terminal so the
+   * Restart card's "查看上次配置" panel can replay it.
+   */
+  const handleGoToRestart = useCallback(() => {
     if (readOnly) return;
     if (saveTimerRef.current) clearInterval(saveTimerRef.current);
+    if (termRef.current) {
+      const finalScrollback = serializeBuffer(termRef.current);
+      onUpdateRef.current(nodeIdRef.current, {
+        data: { ...dataRef.current, scrollback: finalScrollback },
+      });
+    }
     cleanupRef.current?.();
     termRef.current?.dispose();
     termRef.current = null;
     fitRef.current = null;
     spawnedRef.current = false;
     cleanupRef.current = null;
-    initialScrollback.current = '';
-    // Next Start click must be treated as a fresh user launch, not a
-    // restore — clear the flag so the mount effect won't short-circuit.
-    userLaunchedRef.current = false;
-    isRestoredRef.current = false;
-
-    onUpdateRef.current(nodeIdRef.current, {
-      data: { ...dataRef.current, status: 'idle', scrollback: '', sessionId: '' },
-    });
-
-    setLaunched(false);
+    setViewMode('restart');
   }, [readOnly]);
+
+  /** Restart with saved config from the Restart view. Clears prior session
+   * artifacts so spawnAgent starts cleanly. */
+  const handleRestartSession = useCallback(() => {
+    if (readOnly) return;
+    const savedAgent = data.agentType || selectedAgent;
+    const savedCwd = data.cwd || rootFolder || '';
+    const savedPrompt = data.lastInitPrompt || '';
+    pendingAgentRef.current = savedAgent;
+    pendingCwdRef.current = savedCwd;
+    pendingPromptRef.current = savedPrompt;
+    onUpdateRef.current(nodeIdRef.current, {
+      data: {
+        ...dataRef.current,
+        agentType: savedAgent,
+        cwd: savedCwd,
+        inlinePrompt: savedPrompt,
+        status: 'running',
+        sessionId: '',
+        scrollback: '',
+      },
+    });
+    setFromRestart(false);
+    setViewMode('running');
+  }, [data.agentType, data.cwd, data.lastInitPrompt, selectedAgent, rootFolder, readOnly]);
+
+  const handleEditInit = useCallback(() => {
+    if (readOnly) return;
+    setSelectedAgent(data.agentType || selectedAgent);
+    setCwdInput(data.cwd || '');
+    setPromptInput(data.lastInitPrompt || '');
+    setFromRestart(true);
+    setViewMode('setup');
+  }, [data.agentType, data.cwd, data.lastInitPrompt, selectedAgent, readOnly]);
+
+  const handleBackToRestart = useCallback(() => {
+    setFromRestart(false);
+    setViewMode('restart');
+  }, []);
 
   const handlePickFolder = useCallback(async () => {
     if (readOnly) return;
@@ -419,7 +411,7 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
     }
   }, [readOnly]);
 
-  if (!launched) {
+  if (viewMode === 'setup') {
     return (
       <AgentPicker
         selectedAgent={selectedAgent}
@@ -427,6 +419,8 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
         promptInput={promptInput}
         rootFolder={rootFolder}
         recentCwds={recentCwds}
+        badge={fromRestart ? 'edit' : 'setup'}
+        onBack={fromRestart ? handleBackToRestart : undefined}
         onAgentChange={setSelectedAgent}
         onCwdChange={setCwdInput}
         onPromptChange={setPromptInput}
@@ -436,8 +430,21 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
     );
   }
 
+  if (viewMode === 'restart') {
+    return (
+      <AgentRestart
+        agentType={data.agentType || 'claude-code'}
+        cwd={data.cwd}
+        prompt={data.lastInitPrompt}
+        scrollback={data.scrollback}
+        onRestart={handleRestartSession}
+        onEdit={handleEditInit}
+      />
+    );
+  }
+
   return (
-    <div className="agent-body-wrap">
+    <>
       {!readOnly && pickerOpen && (
         <NodeMentionPicker
           nodes={getAllNodesRef.current?.() ?? []}
@@ -448,10 +455,12 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
       <AgentTerminal
         containerRef={containerRef}
         status={status}
-        onRestart={handleRestart}
+        agentType={data.agentType || 'claude-code'}
+        cwd={data.cwd}
+        onRestart={handleGoToRestart}
         onStop={handleStop}
-        onSendPrompt={handleSendPrompt}
+        onFocusTerminal={handleFocusTerminal}
       />
-    </div>
+    </>
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -101,6 +101,10 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
   const pendingAgentRef = useRef(data.agentType || 'claude-code');
   const pendingCwdRef = useRef(data.cwd || '');
   const pendingPromptRef = useRef(data.inlinePrompt || '');
+  /** True when the next spawn should resume an existing CLI session
+   *  instead of creating a new one. Flipped by handleRestartSession,
+   *  reset by handleLaunch. */
+  const pendingResumeRef = useRef(false);
 
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
@@ -119,7 +123,12 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
   getAllNodesRef.current = getAllNodes;
 
   const spawnAgent = useCallback(
-    async (agentType: string, cwd: string, inlinePromptOverride?: string) => {
+    async (
+      agentType: string,
+      cwd: string,
+      inlinePromptOverride?: string,
+      resumeMode = false,
+    ) => {
       if (!containerRef.current || termRef.current || spawnedRef.current) return;
 
       if (readOnly) {
@@ -170,24 +179,39 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
         return;
       }
 
-      // Resolve the agent command to write once the shell is ready
+      // Resolve the agent command to write once the shell is ready.
+      // For Claude Code we pin the conversation to a caller-supplied
+      // session uuid: `--session-id <uuid>` on the first spawn so the
+      // CLI files the conversation under our id, and `--resume <uuid>`
+      // on subsequent spawns of the same node so the conversation
+      // continues exactly where it left off. This sidesteps having to
+      // scan ~/.claude/projects or parse the terminal output.
       const command = getAgentCommand(agentType);
+      const existingCliSessionId = dataRef.current.cliSessionId;
+      const cliSessionId = existingCliSessionId || crypto.randomUUID();
+      const canResume = !!existingCliSessionId;
+      const buildClaudeFlags = (): string => {
+        if (agentType !== 'claude-code') return '';
+        const flag = resumeMode && canResume ? '--resume' : '--session-id';
+        return ` ${flag} ${cliSessionId}`;
+      };
       const writeCommand = () => {
         if (!command) {
           term.writeln(`\x1b[33mUnknown agent type: ${agentType}\x1b[0m`);
           return;
         }
+        const flags = buildClaudeFlags();
         const { inlinePrompt, promptFile, agentArgs } = dataRef.current;
         const effectivePrompt = inlinePromptOverride || inlinePrompt;
         if (effectivePrompt) {
           const escaped = effectivePrompt.replace(/'/g, "'\\''");
-          api.write(sessionId, `${command} '${escaped}'\n`);
+          api.write(sessionId, `${command}${flags} '${escaped}'\n`);
         } else if (promptFile) {
-          api.write(sessionId, `__prompt=$(cat ${promptFile}) && ${command} "$__prompt"\n`);
+          api.write(sessionId, `__prompt=$(cat ${promptFile}) && ${command}${flags} "$__prompt"\n`);
         } else if (agentArgs) {
-          api.write(sessionId, `${command} ${agentArgs}\n`);
+          api.write(sessionId, `${command}${flags} ${agentArgs}\n`);
         } else {
-          api.write(sessionId, `${command}\n`);
+          api.write(sessionId, `${command}${flags}\n`);
         }
 
         if (effectivePrompt || promptFile) {
@@ -257,7 +281,14 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
       term.onResize(({ cols, rows }) => { api.resize(sessionId, cols, rows); });
 
       onUpdateRef.current(nodeIdRef.current, {
-        data: { ...dataRef.current, agentType, cwd: spawnCwd ?? '', status: 'running', sessionId },
+        data: {
+          ...dataRef.current,
+          agentType,
+          cwd: spawnCwd ?? '',
+          status: 'running',
+          sessionId,
+          cliSessionId,
+        },
       });
 
       saveTimerRef.current = setInterval(async () => {
@@ -285,6 +316,7 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
         pendingAgentRef.current,
         pendingCwdRef.current,
         pendingPromptRef.current,
+        pendingResumeRef.current,
       );
     }
     return () => {
@@ -339,6 +371,7 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
     pendingAgentRef.current = selectedAgent;
     pendingCwdRef.current = effectiveCwd;
     pendingPromptRef.current = prompt;
+    pendingResumeRef.current = false;
     if (effectiveCwd) {
       setRecentCwds(pushRecentCwd(effectiveCwd));
     }
@@ -346,6 +379,11 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
     const oldSessionId = dataRef.current.sessionId;
     if (api && oldSessionId) api.kill(oldSessionId);
     const freshSessionId = mintSessionId(nodeIdRef.current);
+    // 初始化 always starts a brand-new conversation: mint a fresh
+    // cliSessionId so Claude Code files this run under our id (and so
+    // any orphaned id from a previously-active agent type doesn't get
+    // misinterpreted as resumable).
+    const freshCliSessionId = crypto.randomUUID();
     // Persist the launch intent to disk immediately. If the user reloads
     // before spawnAgent's own post-spawn update commits, the node will
     // reopen in the Restart view (because sessionId/scrollback get persisted
@@ -360,6 +398,7 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
         status: 'running',
         sessionId: freshSessionId,
         scrollback: '',
+        cliSessionId: freshCliSessionId,
       },
     });
     setFromRestart(false);
@@ -387,8 +426,10 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
   }, []);
 
   /** Restart with saved config from the Restart view. Mints a fresh
-   * sessionId and explicitly kills any leftover backend session so a
-   * cold-reload-leaked PTY doesn't intercept the new spawn. */
+   * PTY sessionId and explicitly kills any leftover backend session so a
+   * cold-reload-leaked PTY doesn't intercept the new spawn. The CLI-level
+   * session (cliSessionId) is preserved so Claude Code can resume the
+   * conversation in-place via `--resume <uuid>`. */
   const handleRestartSession = useCallback(() => {
     if (readOnly) return;
     const savedAgent = data.agentType || selectedAgent;
@@ -397,6 +438,7 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
     pendingAgentRef.current = savedAgent;
     pendingCwdRef.current = savedCwd;
     pendingPromptRef.current = savedPrompt;
+    pendingResumeRef.current = !!dataRef.current.cliSessionId && savedAgent === 'claude-code';
     const api = window.canvasWorkspace?.pty;
     const oldSessionId = dataRef.current.sessionId;
     if (api && oldSessionId) api.kill(oldSessionId);

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -544,7 +544,6 @@ export const AgentNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, onUp
         agentType={data.agentType || 'claude-code'}
         cwd={data.cwd}
         prompt={data.lastInitPrompt}
-        scrollback={data.scrollback}
         onRestart={handleRestartSession}
         onEdit={handleEditInit}
       />

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -179,8 +179,8 @@
 }
 
 .node-type-badge--agent {
-  color: #5b5bf2;
-  background: #eef0ff;
+  color: var(--accent);
+  background: var(--accent-light);
   border-radius: 5px;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -179,7 +179,9 @@
 }
 
 .node-type-badge--agent {
-  color: #7c5cff;
+  color: #5b5bf2;
+  background: #eef0ff;
+  border-radius: 5px;
 }
 
 .node-type-badge--iframe {

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -5,7 +5,7 @@ import type { ResizeEdge } from "../../hooks/useNodeResize";
 import { FileNodeBody } from "../FileNodeBody";
 import { TerminalNodeBody } from "../TerminalNodeBody";
 import { FrameNodeBody, FrameColorPicker } from "../FrameNodeBody";
-import { AgentNodeBody } from "../AgentNodeBody";
+import { AgentNodeBody, detectAgentView } from "../AgentNodeBody";
 import { TextNodeBody, TextColorPicker } from "../TextNodeBody";
 import { IframeNodeBody } from "../IframeNodeBody";
 import { ImageNodeBody } from "../ImageNodeBody";
@@ -86,12 +86,17 @@ function formatRelativeTime(epochMs: number): string {
   return `${Math.floor(diffHr / 24)}d ago`;
 }
 
-const AGENT_STATUS_LABEL: Record<string, string> = {
-  running: 'Running',
-  done: 'Done',
-  error: 'Error',
-  idle: 'Idle',
-};
+/** Map the body's view state to a header pill label + tone. */
+function agentHeaderBadge(data: AgentNodeData): { tone: string; label: string } {
+  const view = detectAgentView(data);
+  if (view === 'setup') return { tone: 'setup', label: 'Setup' };
+  if (view === 'restart') return { tone: 'restart', label: 'Restart' };
+  // 'running' — refine based on data.status to surface Done/Error inline
+  const status = data.status ?? 'running';
+  if (status === 'error') return { tone: 'error', label: 'Error' };
+  if (status === 'done') return { tone: 'done', label: 'Done' };
+  return { tone: 'running', label: 'Running' };
+}
 
 function isCanvasPanGesture(e: React.MouseEvent): boolean {
   const handToolActive = e.currentTarget.closest('.canvas-container--hand') != null;
@@ -605,12 +610,16 @@ const CanvasNodeViewComponent = ({
             Ungroup
           </button>
         )}
-        {node.type === "agent" && agentStatus && agentStatus !== 'idle' && (
-          <span className={`node-status-label node-status-label--${agentStatus}`}>
-            {AGENT_STATUS_LABEL[agentStatus] ?? agentStatus}
-          </span>
-        )}
-        {relativeTime && !(node.type === "agent" && agentStatus && agentStatus !== 'idle') && (
+        {node.type === "agent" && (() => {
+          const badge = agentHeaderBadge(node.data as AgentNodeData);
+          return (
+            <span className={`agent-status-pill agent-status-pill--${badge.tone}`}>
+              <span className="agent-status-pill-dot" />
+              {badge.label}
+            </span>
+          );
+        })()}
+        {relativeTime && node.type !== "agent" && (
           <span className="node-time-label" title={new Date(node.updatedAt!).toLocaleString()}>
             {relativeTime}
           </span>

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -1,11 +1,11 @@
 import { memo, useCallback, useState, useEffect, useRef } from "react";
 import "./index.css";
-import type { CanvasNode, FrameNodeData, GroupNodeData, AgentNodeData, TextNodeData } from "../../types";
+import type { CanvasNode, FrameNodeData, GroupNodeData, TextNodeData } from "../../types";
 import type { ResizeEdge } from "../../hooks/useNodeResize";
 import { FileNodeBody } from "../FileNodeBody";
 import { TerminalNodeBody } from "../TerminalNodeBody";
 import { FrameNodeBody, FrameColorPicker } from "../FrameNodeBody";
-import { AgentNodeBody, detectAgentView } from "../AgentNodeBody";
+import { AgentNodeBody } from "../AgentNodeBody";
 import { TextNodeBody, TextColorPicker } from "../TextNodeBody";
 import { IframeNodeBody } from "../IframeNodeBody";
 import { ImageNodeBody } from "../ImageNodeBody";
@@ -86,17 +86,6 @@ function formatRelativeTime(epochMs: number): string {
   return `${Math.floor(diffHr / 24)}d ago`;
 }
 
-/** Map the body's view state to a header pill label + tone. */
-function agentHeaderBadge(data: AgentNodeData): { tone: string; label: string } {
-  const view = detectAgentView(data);
-  if (view === 'setup') return { tone: 'setup', label: 'Setup' };
-  if (view === 'restart') return { tone: 'restart', label: 'Restart' };
-  // 'running' — refine based on data.status to surface Done/Error inline
-  const status = data.status ?? 'running';
-  if (status === 'error') return { tone: 'error', label: 'Error' };
-  if (status === 'done') return { tone: 'done', label: 'Done' };
-  return { tone: 'running', label: 'Running' };
-}
 
 function isCanvasPanGesture(e: React.MouseEvent): boolean {
   const handToolActive = e.currentTarget.closest('.canvas-container--hand') != null;
@@ -341,9 +330,6 @@ const CanvasNodeViewComponent = ({
     </button>
   ) : null;
 
-  const agentStatus = node.type === "agent"
-    ? ((node.data as AgentNodeData).status ?? 'idle')
-    : null;
 
   const relativeTime = node.updatedAt ? formatRelativeTime(node.updatedAt) : null;
 
@@ -575,9 +561,6 @@ const CanvasNodeViewComponent = ({
               <circle cx="9.5" cy="5" r="0.8" fill="currentColor" />
             </svg>
           )}
-          {node.type === "agent" && agentStatus && agentStatus !== "idle" && (
-            <span className={`node-status-dot node-status-dot--${agentStatus}`} />
-          )}
         </span>
         <span
           ref={titleRef}
@@ -610,16 +593,7 @@ const CanvasNodeViewComponent = ({
             Ungroup
           </button>
         )}
-        {node.type === "agent" && (() => {
-          const badge = agentHeaderBadge(node.data as AgentNodeData);
-          return (
-            <span className={`agent-status-pill agent-status-pill--${badge.tone}`}>
-              <span className="agent-status-pill-dot" />
-              {badge.label}
-            </span>
-          );
-        })()}
-        {relativeTime && node.type !== "agent" && (
+        {relativeTime && (
           <span className="node-time-label" title={new Date(node.updatedAt!).toLocaleString()}>
             {relativeTime}
           </span>

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -554,11 +554,16 @@ const CanvasNodeViewComponent = ({
               <path d="M2 8h12M8 2c2 2 2 10 0 12M8 2c-2 2-2 10 0 12" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" />
             </svg>
           ) : (
-            <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
-              <circle cx="8" cy="5.5" r="3" stroke="currentColor" strokeWidth="1.3" />
-              <path d="M4 14c0-2.2 1.8-4 4-4s4 1.8 4 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
-              <circle cx="6.5" cy="5" r="0.8" fill="currentColor" />
-              <circle cx="9.5" cy="5" r="0.8" fill="currentColor" />
+            <svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+              <path
+                d="M9.2 2.2l1.1 2.9 2.9 1.1-2.9 1.1-1.1 2.9-1.1-2.9L5.2 6.2l2.9-1.1 1.1-2.9z"
+                fill="currentColor"
+              />
+              <path
+                d="M4.3 9.8l.6 1.4 1.4.6-1.4.6-.6 1.4-.6-1.4L2.3 11.8l1.4-.6.6-1.4z"
+                fill="currentColor"
+                opacity="0.55"
+              />
             </svg>
           )}
         </span>

--- a/apps/canvas-workspace/src/renderer/src/config/agentRegistry.ts
+++ b/apps/canvas-workspace/src/renderer/src/config/agentRegistry.ts
@@ -7,8 +7,8 @@ export interface AgentDef {
 
 export const AGENT_REGISTRY: AgentDef[] = [
   { id: 'claude-code', label: 'Claude Code', command: 'claude', description: 'Anthropic' },
-  { id: 'codex', label: 'Codex', command: 'codex', description: 'OpenAI' },
-  { id: 'pulse-coder', label: 'Pulse Coder', command: 'pulse-coder', description: 'Pulse' },
+  { id: 'codex', label: 'Codex CLI', command: 'codex', description: 'OpenAI' },
+  { id: 'pulse-coder', label: 'Pulse-Coder', command: 'pulse-coder', description: 'Pulse' },
 ];
 
 export const getAgentCommand = (agentType: string): string | undefined =>

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -67,6 +67,15 @@ export interface AgentNodeData {
    * the previous session was started with.
    */
   lastInitPrompt?: string;
+  /**
+   * Current AgentNodeBody view ('setup' | 'running' | 'restart'). Persisted
+   * so the outer `CanvasNodeView` header can render the status pill that
+   * matches the body — and so a cold reload mid-running session can be
+   * distinguished from an active live PTY (the body rewrites this on
+   * mount based on the cold-reload heuristic). Optional because legacy
+   * nodes won't have it; consumers should fall back to a derived value.
+   */
+  viewMode?: 'setup' | 'running' | 'restart';
 }
 
 /**

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -76,6 +76,15 @@ export interface AgentNodeData {
    * nodes won't have it; consumers should fall back to a derived value.
    */
   viewMode?: 'setup' | 'running' | 'restart';
+  /**
+   * Caller-supplied session id for the underlying coding-agent CLI.
+   * Currently only consumed by Claude Code (via `--session-id <uuid>` on
+   * first spawn and `--resume <uuid>` on restart) so the conversation
+   * survives across PTY teardowns without us having to parse the CLI's
+   * output or scan its on-disk session store. Generated via
+   * `crypto.randomUUID()`; absent on legacy nodes and non-Claude agents.
+   */
+  cliSessionId?: string;
 }
 
 /**

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -60,6 +60,13 @@ export interface AgentNodeData {
   inlinePrompt?: string;
   /** Relative path to a prompt file in cwd for long prompts. */
   promptFile?: string;
+  /**
+   * Snapshot of the prompt the user supplied at launch time. `inlinePrompt`
+   * is cleared after being sent to the CLI to prevent re-sending on the
+   * next spawn, but the Restart view needs the original text to show what
+   * the previous session was started with.
+   */
+  lastInitPrompt?: string;
 }
 
 /**

--- a/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
@@ -11,7 +11,7 @@ const NODE_DEFAULTS: Record<CanvasNode['type'], { title: string; width: number; 
   terminal: { title: 'Terminal', width: 480, height: 300 },
   frame:    { title: 'Frame',    width: 600, height: 400 },
   group:    { title: 'Group',    width: 360, height: 240 },
-  agent:    { title: 'Agent',    width: 520, height: 380 },
+  agent:    { title: 'Coding Agent', width: 520, height: 380 },
   text:     { title: 'Text',     width: 260, height: 120 },
   iframe:   { title: 'Web',      width: 520, height: 400 },
   image:    { title: 'Image',    width: 320, height: 240 },


### PR DESCRIPTION
## Summary

Refactors the AgentNodeBody component to support three distinct view modes (Setup, Running, Restart) with unified card chrome, improved visual hierarchy, and a cold-reload recovery flow. Introduces a new `AgentRestart` view that allows users to resume interrupted CLI sessions after app restart, and adds persistent tracking of agent configuration and CLI session state.

## Key Changes

### Component Architecture
- **Three-view mode system**: Replaces the binary picker/terminal toggle with explicit `ViewMode` ('setup' | 'running' | 'restart')
- **Unified card chrome**: All three views now share `.agent-card` base styling with consistent padding, gaps, and overflow handling
- **View detection**: New `detectAgentView()` export allows the outer `CanvasNodeView` header to render matching status pills from persisted data
- **Cold-reload recovery**: Mount-time logic detects when a persisted 'running' view has lost its PTY backing (via saved sessionId/scrollback) and lands on 'restart' instead of showing a dead terminal

### New AgentRestart Component
- Displays saved configuration (agent type, working directory, initial prompt)
- Shows warning banner explaining that CLI state was lost on app restart
- Provides two CTAs: "Restart Session" (resume existing CLI session) and "Edit Initial Parameters" (return to Setup)
- Collapsible details panel showing tail of previous session's scrollback output

### Setup View Improvements (AgentPicker)
- Redesigned as tabbed interface with three agent tabs in a grid layout
- Integrated working directory field with folder picker button
- Prompt textarea with improved focus states
- Recent folders chip strip for quick navigation
- Back link when entering Setup from Restart's Edit action
- Consistent use of agent accent color (#5b5bf2) throughout

### Running View Improvements (AgentTerminal)
- Info strip showing agent type, working directory, and load status
- Removed floating quick-action buttons (Continue, Summarize, Stop)
- Cleaner terminal container with rounded corners and border
- Status indicator with color-coded load state (running/done/error)

### Data Persistence
- **`lastInitPrompt`**: Snapshot of user's prompt at launch time (preserved across spawns for Restart view)
- **`viewMode`**: Explicit tracking of current view ('setup' | 'running' | 'restart')
- **`cliSessionId`**: UUID for Claude Code CLI session continuity via `--session-id` / `--resume` flags
- **`scrollback`**: Terminal output saved every 2s during live sessions, used for Restart details panel

### Styling & Visual Design
- New CSS custom properties for agent accent (#5b5bf2), warning (#d97706), success (#10b981), danger (#e03e3e)
- Consistent border-radius (10px) and spacing (12px gaps) across all components
- Status pills with color-coded backgrounds (setup/edit: purple, running: green, restart: amber, done: gray, error: red)
- Improved focus states with 3px colored shadows on inputs
- Monospace font for paths and CLI output, sans-serif for labels

### Session Management
- **`mintSessionId()`**: Generates unique PTY session IDs to avoid race conditions on kill+respawn
- **`pendingResumeRef`**: Tracks whether next spawn should resume existing CLI session
- **Claude Code CLI integration**: Uses `--session-id <uuid>` on first spawn and `--resume <uuid>` on subsequent spawns to maintain conversation continuity

## Notable Implementation Details

- The `viewMode` field is the source of truth for current view; legacy fallback logic handles nodes persisted before this field existed
- Cold-reload detection happens in `useState` initializer to catch the mount-time transition before any effects fire
- Scrollback is saved independently of status updates (every 2s) to handle debounced-save races
- The Restart view is only shown when there's evidence of a prior session (saved sessionId or scrollback), preventing false positives
- Agent accent color is scoped to `:root` so it can be used in both the body and the outer node header's status pill
- Back link in Setup is only rendered when `onBack

https://claude.ai/code/session_01ESVELLdFLn7UKgnYMGsUzp