### PR TITLE
Redesign note editor UI to match Heptabase/Notion aesthetic

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -12,6 +12,71 @@
   transition: box-shadow 0.15s ease, border-color 0.15s ease;
 }
 
+/* File / note nodes — Heptabase + Notion lean. The chrome is intentionally
+ * quieter than the generic node: warmer paper background, softer
+ * shadow, slightly larger corner radius, and a header that fades into
+ * the body instead of sitting on a hard divider. The toolbar (when
+ * selected) and the editor share the same paper colour so the whole
+ * card reads as one document surface. */
+.canvas-node--file {
+  background: #fdfcf9;
+  border-color: rgba(55, 53, 47, 0.06);
+  border-radius: 12px;
+  box-shadow:
+    0 1px 2px rgba(55, 53, 47, 0.04),
+    0 6px 18px rgba(55, 53, 47, 0.05);
+}
+
+.canvas-node--file:hover {
+  box-shadow:
+    0 1px 3px rgba(55, 53, 47, 0.05),
+    0 10px 26px rgba(55, 53, 47, 0.08);
+  border-color: rgba(55, 53, 47, 0.09);
+}
+
+.canvas-node--file.canvas-node--selected {
+  border-color: rgba(35, 131, 226, 0.32);
+  box-shadow:
+    0 1px 3px rgba(55, 53, 47, 0.05),
+    0 10px 26px rgba(55, 53, 47, 0.08),
+    0 0 0 2px rgba(35, 131, 226, 0.1);
+}
+
+/* The header for a note becomes a thin, almost-invisible strip. The
+ * type badge / title / buttons remain functional, but the bottom rule
+ * dissolves so the header and the editor read as the same page rather
+ * than two stacked surfaces (which is what makes the current node feel
+ * "boxy"). The hard surface colour is swapped for transparent so the
+ * paper tone from .canvas-node--file shows through. */
+.canvas-node--file > .node-header {
+  background: transparent;
+  border-bottom: 1px solid transparent;
+  min-height: 30px;
+  padding: 6px 12px 4px 14px;
+  transition: border-color 0.15s ease;
+}
+
+.canvas-node--file.canvas-node--selected > .node-header {
+  border-bottom-color: rgba(55, 53, 47, 0.05);
+}
+
+.canvas-node--file > .node-header .node-title {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--text-secondary);
+  letter-spacing: 0.005em;
+  transition: color 0.12s ease;
+}
+
+.canvas-node--file:hover > .node-header .node-title,
+.canvas-node--file.canvas-node--selected > .node-header .node-title {
+  color: var(--text);
+}
+
+.canvas-node--file > .node-header .node-type-badge--file {
+  color: rgba(55, 53, 47, 0.45);
+}
+
 .canvas-node:hover {
   box-shadow: var(--shadow-card-hover);
   border-color: rgba(0, 0, 0, 0.08);

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.css
@@ -3,26 +3,27 @@
   flex-direction: column;
   height: 100%;
   position: relative;
+  background: var(--note-paper, #fdfcf9);
 }
 
+/* The filename used to live in its own bar; in the Notion/Heptabase
+ * redesign we want a single thin chrome strip, so the hint now floats
+ * inline next to the toolbar status (rendered in JSX). The standalone
+ * strip is kept hidden as a fallback for any legacy callers. */
 .note-file-hint {
-  height: 0;
-  overflow: hidden;
-  flex-shrink: 0;
+  display: none;
+}
+
+.note-file-hint-inline {
   font-family: var(--font-mono);
   font-size: 10px;
   color: var(--text-muted);
-  background: rgba(0, 0, 0, 0.015);
-  border-bottom: none;
   white-space: nowrap;
+  overflow: hidden;
   text-overflow: ellipsis;
-  transition: height 0.15s ease, padding 0.15s ease, border-color 0.15s ease;
-}
-
-.canvas-node--selected .note-file-hint {
-  height: 22px;
-  padding: 2px 10px 3px;
-  border-bottom: 1px solid var(--border-light);
+  max-width: 220px;
+  letter-spacing: 0.01em;
+  opacity: 0.75;
 }
 
 .note-content {
@@ -36,52 +37,71 @@
   flex: 1;
   overflow-y: auto;
   height: 100%;
+  /* Scoped paper colour driven by the card root so colour-mode swaps
+   * or per-node tints can override in one place. */
 }
 
+/* Generous reading column inspired by Notion/Heptabase pages.
+ * Slightly off-black text, increased line-height, more vertical
+ * breathing room. The bottom padding is intentionally large so the
+ * caret never sits flush with the resize handle while typing. */
 .note-tiptap-editor .ProseMirror {
   min-height: 100%;
-  padding: 14px 18px 28px;
-  font-family: var(--font);
-  font-size: 14px;
-  line-height: 1.8;
+  padding: 22px 32px 56px;
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI",
+    "Inter", "Helvetica Neue", Arial, sans-serif;
+  font-size: 14.5px;
+  line-height: 1.7;
   color: var(--text);
   outline: none;
+  caret-color: var(--accent);
 }
 
+/* Inviting empty-state hint — Heptabase shows a dim "Type your
+ * thoughts..." prompt; we mirror that and reference the slash
+ * affordance so first-time users know what to do. */
 .note-tiptap-editor .ProseMirror p.is-editor-empty:first-child::before {
   content: attr(data-placeholder);
   color: var(--text-muted);
-  font-style: italic;
+  font-style: normal;
   pointer-events: none;
   float: left;
   height: 0;
+  opacity: 0.55;
 }
 
 .note-tiptap-editor .ProseMirror h1 {
-  font-size: 1.6em;
+  font-size: 1.75em;
   font-weight: 700;
-  margin: 0.8em 0 0.3em;
+  margin: 0.9em 0 0.3em;
   color: var(--text);
-  line-height: 1.3;
+  line-height: 1.25;
+  letter-spacing: -0.02em;
+}
+
+.note-tiptap-editor .ProseMirror h1:first-child {
+  margin-top: 0.1em;
 }
 
 .note-tiptap-editor .ProseMirror h2 {
-  font-size: 1.3em;
+  font-size: 1.35em;
   font-weight: 600;
-  margin: 0.7em 0 0.25em;
+  margin: 0.85em 0 0.25em;
   color: var(--text);
-  line-height: 1.35;
+  line-height: 1.3;
+  letter-spacing: -0.015em;
 }
 
 .note-tiptap-editor .ProseMirror h3 {
   font-size: 1.1em;
   font-weight: 600;
-  margin: 0.6em 0 0.2em;
+  margin: 0.7em 0 0.2em;
   color: var(--text);
+  letter-spacing: -0.01em;
 }
 
 .note-tiptap-editor .ProseMirror p {
-  margin: 0.2em 0;
+  margin: 0.25em 0;
 }
 
 .note-tiptap-editor .ProseMirror strong {
@@ -94,12 +114,12 @@
 
 .note-tiptap-editor .ProseMirror ul,
 .note-tiptap-editor .ProseMirror ol {
-  padding-left: 1.4em;
-  margin: 0.3em 0;
+  padding-left: 1.5em;
+  margin: 0.35em 0;
 }
 
 .note-tiptap-editor .ProseMirror li {
-  margin: 0.15em 0;
+  margin: 0.18em 0;
 }
 
 .note-tiptap-editor .ProseMirror ul[data-type="taskList"] {
@@ -110,15 +130,15 @@
 .note-tiptap-editor .ProseMirror ul[data-type="taskList"] li {
   display: flex;
   align-items: flex-start;
-  gap: 8px;
-  margin: 0.15em 0;
+  gap: 10px;
+  margin: 0.18em 0;
 }
 
 .note-tiptap-editor .ProseMirror ul[data-type="taskList"] li > label {
   flex-shrink: 0;
   display: inline-flex;
   align-items: center;
-  height: 1.8em;
+  height: 1.7em;
   margin: 0;
 }
 
@@ -139,12 +159,14 @@
   margin: 0;
 }
 
+/* Heptabase callout-style blockquote: warmer beige fill, thicker
+ * accent rail, no harsh radius mismatch. */
 .note-tiptap-editor .ProseMirror blockquote {
   border-left: 3px solid var(--accent-file);
-  padding: 3px 12px;
-  margin: 0.4em 0;
+  padding: 6px 14px;
+  margin: 0.5em 0;
   color: var(--text-secondary);
-  background: rgba(217, 115, 13, 0.04);
+  background: rgba(217, 115, 13, 0.05);
   border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
 }
 
@@ -152,24 +174,25 @@
   border: none;
   height: 1px;
   background: var(--border);
-  margin: 1em 0;
+  margin: 1.1em 0;
 }
 
 .note-tiptap-editor .ProseMirror code {
   font-family: var(--font-mono);
-  font-size: 0.88em;
-  background: rgba(0, 0, 0, 0.05);
+  font-size: 0.86em;
+  background: rgba(55, 53, 47, 0.07);
   padding: 1px 5px;
   border-radius: 3px;
   color: #c0392b;
+  letter-spacing: 0;
 }
 
 .note-tiptap-editor .ProseMirror pre {
-  background: rgba(0, 0, 0, 0.04);
+  background: rgba(55, 53, 47, 0.045);
   border: 1px solid var(--border-light);
   border-radius: var(--radius-sm);
-  padding: 10px 14px;
-  margin: 0.5em 0;
+  padding: 12px 16px;
+  margin: 0.6em 0;
   overflow-x: auto;
 }
 
@@ -177,15 +200,16 @@
   background: none;
   padding: 0;
   color: var(--text);
-  font-size: 0.85em;
+  font-size: 0.86em;
 }
 
 .note-tiptap-editor .ProseMirror img {
   max-width: 100%;
   height: auto;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   display: block;
-  margin: 8px 0;
+  margin: 12px 0;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
 }
 
 .note-tiptap-editor .ProseMirror img.ProseMirror-selectednode {
@@ -227,7 +251,7 @@
   border-collapse: collapse;
   table-layout: fixed;
   width: 100%;
-  margin: 0.6em 0;
+  margin: 0.7em 0;
   overflow: hidden;
   border: 1px solid var(--border-light);
   border-radius: var(--radius-sm);
@@ -236,7 +260,7 @@
 .note-tiptap-editor .ProseMirror th,
 .note-tiptap-editor .ProseMirror td {
   border: 1px solid var(--border-light);
-  padding: 6px 8px;
+  padding: 7px 10px;
   vertical-align: top;
   position: relative;
   min-width: 40px;
@@ -244,7 +268,7 @@
 }
 
 .note-tiptap-editor .ProseMirror th {
-  background: rgba(0, 0, 0, 0.03);
+  background: rgba(55, 53, 47, 0.035);
   font-weight: 600;
   text-align: left;
 }
@@ -279,8 +303,8 @@
   padding: 0;
   border-radius: 0;
   font-family: var(--font-mono);
-  font-size: 0.85em;
-  line-height: 1.55;
+  font-size: 0.86em;
+  line-height: 1.6;
 }
 
 .note-tiptap-editor .ProseMirror .hljs-comment,
@@ -336,4 +360,27 @@
 
 .note-tiptap-editor .ProseMirror .hljs-emphasis {
   font-style: italic;
+}
+
+/* Soften scrollbar inside the note so it doesn't compete with the
+ * paper background while reading. */
+.note-tiptap-editor::-webkit-scrollbar {
+  width: 8px;
+}
+
+.note-tiptap-editor::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.note-tiptap-editor::-webkit-scrollbar-thumb {
+  background: rgba(55, 53, 47, 0.12);
+  border-radius: 4px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+
+.note-tiptap-editor::-webkit-scrollbar-thumb:hover {
+  background: rgba(55, 53, 47, 0.22);
+  background-clip: padding-box;
+  border: 2px solid transparent;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.tsx
@@ -167,13 +167,9 @@ export const FileNodeBody = ({ node, onUpdate, workspaceId, readOnly = false }: 
           onOpenFind={openFindBar}
           statusText={statusText}
           modified={modified}
+          fileName={fileName}
+          filePath={filePath ?? undefined}
         />
-      )}
-
-      {fileName && (
-        <div className="note-file-hint" title={filePath ?? undefined}>
-          {fileName}
-        </div>
       )}
 
       {!readOnly && findBarOpen && editor && <NoteFindBar editor={editor} onClose={closeFindBar} />}

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeToolbar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeToolbar/index.css
@@ -1,26 +1,31 @@
+/* Heptabase/Notion-style: at rest the toolbar collapses to 0 so the
+ * note reads as paper. Selection slides it open as a slim, almost
+ * borderless strip that blends into the page above the content. */
 .note-toolbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 6px;
+  padding: 0 14px;
   gap: 2px;
   height: 0;
   overflow: hidden;
   flex-shrink: 0;
   border-bottom: none;
-  transition: height 0.15s ease, padding 0.15s ease, border-color 0.15s ease;
+  background: transparent;
+  transition: height 0.18s ease, padding 0.18s ease, opacity 0.18s ease;
+  opacity: 0;
 }
 
 .canvas-node--selected .note-toolbar {
-  height: 30px;
-  padding: 3px 6px;
-  border-bottom: 1px solid var(--border-light);
+  height: 28px;
+  padding: 0 14px;
+  opacity: 1;
 }
 
 .note-toolbar-left {
   display: flex;
   align-items: center;
-  gap: 1px;
+  gap: 0;
 }
 
 .note-toolbar-right {
@@ -31,49 +36,76 @@
 
 .note-toolbar-divider {
   width: 1px;
-  height: 16px;
-  background: var(--border);
-  margin: 0 4px;
+  height: 12px;
+  background: var(--border-light);
+  margin: 0 6px;
+  flex-shrink: 0;
+  opacity: 0.7;
 }
 
 .note-tool-btn {
-  width: 26px;
-  height: 26px;
+  width: 24px;
+  height: 22px;
   border: none;
   background: transparent;
-  border-radius: var(--radius-sm);
+  border-radius: 5px;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--text-secondary);
-  transition: background 0.1s, color 0.1s;
+  color: var(--text-muted);
+  transition: background 0.12s ease, color 0.12s ease;
   flex-shrink: 0;
+  padding: 0;
 }
 
 .note-tool-btn:hover {
-  background: rgba(0, 0, 0, 0.05);
+  background: rgba(55, 53, 47, 0.06);
   color: var(--text);
 }
 
+.note-tool-btn:active {
+  background: rgba(55, 53, 47, 0.1);
+}
+
 .note-tool-btn--active {
-  background: var(--accent-light);
+  background: rgba(35, 131, 226, 0.1);
   color: var(--accent);
 }
 
 .note-tool-btn--active:hover {
-  background: var(--accent-light);
+  background: rgba(35, 131, 226, 0.14);
   color: var(--accent);
 }
 
+/* Slim status pill that feels like Notion's "Synced/Edited" hint —
+ * mono-weight, low contrast, no border. The colored dot does the
+ * work of communicating state without taking horizontal space. */
 .note-status {
-  font-size: 10px;
-  color: var(--accent-term);
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  color: var(--text-muted);
   font-weight: 500;
   white-space: nowrap;
+  letter-spacing: 0.01em;
   animation: fadeIn 0.2s ease;
+}
+
+.note-status::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent-term);
+  flex-shrink: 0;
 }
 
 .note-status--modified {
   color: var(--accent-file);
+}
+
+.note-status--modified::before {
+  background: var(--accent-file);
 }

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeToolbar/index.tsx
@@ -8,6 +8,8 @@ interface Props {
   onOpenFind: () => void;
   statusText: string;
   modified: boolean;
+  fileName?: string | null;
+  filePath?: string;
 }
 
 export const FileNodeToolbar = ({
@@ -18,6 +20,8 @@ export const FileNodeToolbar = ({
   onOpenFind,
   statusText,
   modified,
+  fileName,
+  filePath,
 }: Props) => (
   <div className="note-toolbar">
     <div className="note-toolbar-left">
@@ -73,6 +77,11 @@ export const FileNodeToolbar = ({
       </button>
     </div>
     <div className="note-toolbar-right">
+      {fileName && !statusText && !modified && (
+        <span className="note-file-hint-inline" title={filePath}>
+          {fileName}
+        </span>
+      )}
       {statusText && <span className="note-status">{statusText}</span>}
       {modified && !statusText && (
         <span className="note-status note-status--modified">Edited</span>

--- a/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts
@@ -206,7 +206,7 @@ export const useFileNodeEditor = ({
       }),
       EmptyLinePreservingParagraph,
       MarkdownSafeImage.configure({ inline: false }),
-      Placeholder.configure({ placeholder: 'Start writing…' }),
+      Placeholder.configure({ placeholder: "Type '/' for blocks, or just start writing…" }),
       TaskList,
       TaskItem.configure({ nested: true }),
       Underline,


### PR DESCRIPTION
## Summary
Refactors the file node (note editor) UI to adopt a cleaner, more paper-like design inspired by Heptabase and Notion. The changes focus on improving readability, reducing visual clutter, and creating a cohesive document-like experience.

## Key Changes

### FileNodeBody styling (`index.css`)
- Added warm paper background color (`#fdfcf9`) to the root container
- Converted the filename hint from a collapsible bar to an inline element that floats next to the toolbar status
- Increased editor padding (22px 32px 56px) for a more generous reading column
- Updated typography: improved font stack, adjusted font sizes (14.5px), refined line-height (1.7), and added letter-spacing to headings
- Enhanced empty-state placeholder styling with reduced opacity and normal font-style
- Refined heading sizes and margins (h1: 1.75em, h2: 1.35em, h3: 1.1em) with negative letter-spacing for tighter appearance
- Improved list and task list spacing and alignment
- Updated blockquote styling with warmer beige background and adjusted padding
- Refined code block backgrounds to use a softer dark tone (`rgba(55, 53, 47, ...)`)
- Added subtle box-shadow to images and adjusted border-radius consistency
- Improved table cell padding and header background
- Added custom webkit scrollbar styling with soft, semi-transparent appearance

### FileNodeToolbar styling (`index.css`)
- Redesigned toolbar to collapse to 0 height at rest and slide open on selection (opacity-based animation)
- Removed hard border-bottom in favor of transparent background that blends with paper
- Adjusted button sizing (24px × 22px) and spacing
- Updated button colors to use muted text and softer hover states
- Added active state styling for buttons
- Redesigned status indicator as a slim pill with a colored dot prefix (no border)
- Added support for inline filename display in the toolbar right section

### FileNodeToolbar component (`index.tsx`)
- Added `fileName` and `filePath` props to the component
- Conditionally render filename hint inline in the toolbar right section when available and no status/modified state is present

### FileNodeBody component (`index.tsx`)
- Removed standalone filename hint div
- Pass `fileName` and `filePath` to the toolbar component

### CanvasNodeView styling (`index.css`)
- Added dedicated `.canvas-node--file` styles for note/file nodes with:
  - Warm paper background (`#fdfcf9`)
  - Softer border color and larger border-radius (12px)
  - Refined shadow with multiple layers for depth
  - Improved hover and selected states with blue accent border
- Styled `.node-header` for file nodes with transparent background and subtle bottom border on selection
- Adjusted header title styling with reduced font-weight and muted color that transitions on hover/selection
- Styled type badge with muted color

### Editor configuration (`useFileNodeEditor.ts`)
- Updated placeholder text from "Start writing…" to a more inviting prompt (truncated in diff)

## Notable Implementation Details
- The filename hint transitions from a dedicated bar (shown on selection) to an inline element in the toolbar, reducing visual complexity
- All color values use CSS variables or semantic RGBA values based on `rgba(55, 53, 47, ...)` for consistency with the Notion/Heptabase palette
- Animations use consistent timing (0.15s–0.18s ease) for smooth transitions
- The paper background is scoped to the card root so color-mode swaps or per-node tints can override in one place
- Scrollbar styling uses webkit-specific rules to soften the appearance without affecting functionality

https://claude.ai/code/session_01KCeGk8xnRx7FBvCPwNeiHD