### PR TITLE
fix(canvas): paste markdown as note nodes

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -192,24 +192,6 @@ export const Canvas = ({
 
   useCanvasContext(rootFolder, nodes, canvasName);
 
-  const pasteMarkdownAsNote = useCallback(async (markdown: string): Promise<CanvasNode | null> => {
-    const container = containerRef.current;
-    if (!container) return null;
-
-    const rect = container.getBoundingClientRect();
-    const center = screenToCanvas(
-      rect.left + rect.width / 2,
-      rect.top + rect.height / 2,
-      container,
-    );
-    const titleMatch = markdown.match(/^#\s+(.+)$/m);
-    const title = titleMatch?.[1]?.trim() || 'Pasted Markdown';
-    return addNode('file', center.x - 210, center.y - 180, {
-      fileName: title,
-      fileContent: markdown,
-    });
-  }, [addNode, screenToCanvas]);
-
   const handleNodeViewportFocus = useCallback((node: CanvasNode) => {
     setSelectedNodeIds([node.id]);
     setHighlightedId(node.id);
@@ -287,7 +269,7 @@ export const Canvas = ({
   useCanvasKeyboard({
     undo, redo, nodes, selectedNodeIds, setSelectedNodeIds,
     selectedEdgeId, setSelectedEdgeId, removeEdge: actions.requestRemoveEdge,
-    duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, pasteMarkdownAsNote,
+    duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes,
     groupSelectedNodes: actions.groupSelectedNodes,
     ungroupSelectedNodes: actions.ungroupSelectedNodes,
     removeNodes: actions.requestRemoveNodes,

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -192,6 +192,24 @@ export const Canvas = ({
 
   useCanvasContext(rootFolder, nodes, canvasName);
 
+  const pasteMarkdownAsNote = useCallback(async (markdown: string): Promise<CanvasNode | null> => {
+    const container = containerRef.current;
+    if (!container) return null;
+
+    const rect = container.getBoundingClientRect();
+    const center = screenToCanvas(
+      rect.left + rect.width / 2,
+      rect.top + rect.height / 2,
+      container,
+    );
+    const titleMatch = markdown.match(/^#\s+(.+)$/m);
+    const title = titleMatch?.[1]?.trim() || 'Pasted Markdown';
+    return addNode('file', center.x - 210, center.y - 180, {
+      fileName: title,
+      fileContent: markdown,
+    });
+  }, [addNode, screenToCanvas]);
+
   const handleNodeViewportFocus = useCallback((node: CanvasNode) => {
     setSelectedNodeIds([node.id]);
     setHighlightedId(node.id);
@@ -269,7 +287,7 @@ export const Canvas = ({
   useCanvasKeyboard({
     undo, redo, nodes, selectedNodeIds, setSelectedNodeIds,
     selectedEdgeId, setSelectedEdgeId, removeEdge: actions.requestRemoveEdge,
-    duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes,
+    duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, pasteMarkdownAsNote,
     groupSelectedNodes: actions.groupSelectedNodes,
     ungroupSelectedNodes: actions.ungroupSelectedNodes,
     removeNodes: actions.requestRemoveNodes,

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.tsx
@@ -190,7 +190,11 @@ export const FileNodeBody = ({ node, onUpdate, workspaceId, readOnly = false }: 
         <FileNodeBubbleMenu editor={editor} bubble={bubble} onOpenLinkPrompt={openLinkPrompt} />
       )}
 
-      <div className="note-content" onWheel={(e) => e.stopPropagation()}>
+      <div
+        className="note-content"
+        onPaste={(e) => e.stopPropagation()}
+        onWheel={(e) => e.stopPropagation()}
+      >
         <EditorContent editor={editor} className="note-tiptap-editor" />
       </div>
 

--- a/apps/canvas-workspace/src/renderer/src/hooks/useCanvasImagePaste.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useCanvasImagePaste.ts
@@ -64,14 +64,28 @@ const createTextPatch = (text: string): Pick<CanvasNode, 'width' | 'height' | 't
   };
 };
 
+const TYPING_CONTEXT_SELECTOR = [
+  'input',
+  'textarea',
+  '[contenteditable="true"]',
+  '[role="textbox"]',
+  '.ProseMirror',
+  '.note-tiptap-editor',
+  '.note-content',
+].join(', ');
+
 const isTypingContext = (target: EventTarget | null): boolean => {
   if (!(target instanceof Node)) return false;
   const element = target instanceof HTMLElement ? target : target.parentElement;
   if (!element) return false;
-  if (element.closest('input, textarea, [contenteditable="true"], [role="textbox"], .ProseMirror')) {
-    return true;
-  }
-  return false;
+  return Boolean(element.closest(TYPING_CONTEXT_SELECTOR));
+};
+
+const isPasteFromTypingContext = (event: ClipboardEvent): boolean => {
+  if (isTypingContext(event.target)) return true;
+  if (isTypingContext(document.activeElement)) return true;
+  if (isTypingContext(document.getSelection()?.anchorNode ?? null)) return true;
+  return event.composedPath().some((target) => isTypingContext(target));
 };
 
 /**
@@ -96,7 +110,7 @@ export const useCanvasImagePaste = ({
     if (!active) return;
 
     const handler = (e: ClipboardEvent) => {
-      if (isTypingContext(e.target)) return;
+      if (isPasteFromTypingContext(e)) return;
       const items = e.clipboardData?.items;
       if (!items) return;
       const imageItem = Array.from(items).find((i) => i.type.startsWith('image/'));

--- a/apps/canvas-workspace/src/renderer/src/hooks/useCanvasImagePaste.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useCanvasImagePaste.ts
@@ -65,10 +65,12 @@ const createTextPatch = (text: string): Pick<CanvasNode, 'width' | 'height' | 't
 };
 
 const isTypingContext = (target: EventTarget | null): boolean => {
-  if (!(target instanceof HTMLElement)) return false;
-  const tag = target.tagName;
-  if (tag === 'INPUT' || tag === 'TEXTAREA') return true;
-  if (target.isContentEditable) return true;
+  if (!(target instanceof Node)) return false;
+  const element = target instanceof HTMLElement ? target : target.parentElement;
+  if (!element) return false;
+  if (element.closest('input, textarea, [contenteditable="true"], [role="textbox"], .ProseMirror')) {
+    return true;
+  }
   return false;
 };
 

--- a/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.ts
@@ -16,7 +16,6 @@ interface Options {
   clipboardNodes: CanvasNode[];
   setClipboardNodes: (nodes: CanvasNode[]) => void;
   pasteNodes: (nodes: CanvasNode[]) => CanvasNode[];
-  pasteMarkdownAsNote?: (markdown: string) => Promise<CanvasNode | null>;
   /** Group the current node selection in a lightweight container. */
   groupSelectedNodes: () => void;
   /** Dissolve selected group nodes while keeping their children on canvas. */
@@ -58,7 +57,7 @@ interface Options {
 export const useCanvasKeyboard = ({
   undo, redo, nodes, selectedNodeIds, setSelectedNodeIds,
   selectedEdgeId, setSelectedEdgeId, removeEdge,
-  duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, pasteMarkdownAsNote, groupSelectedNodes, ungroupSelectedNodes, removeNodes,
+  duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, groupSelectedNodes, ungroupSelectedNodes, removeNodes,
   moveNodes, commitHistory,
   searchOpen, setSearchOpen,
   findOpen, toggleFindBar, closeFindBar, findNext, findPrev, findHasMatches,
@@ -174,18 +173,6 @@ export const useCanvasKeyboard = ({
           e.preventDefault();
           const created = pasteNodes(clipboardNodes);
           setSelectedNodeIds(created.map((n) => n.id));
-          return;
-        }
-
-        if (pasteMarkdownAsNote && navigator.clipboard?.readText) {
-          e.preventDefault();
-          void navigator.clipboard.readText().then(async (text) => {
-            if (!text.trim()) return;
-            const created = await pasteMarkdownAsNote(text);
-            if (created) setSelectedNodeIds([created.id]);
-          }).catch(() => {
-            // If clipboard read permission is denied, leave the canvas unchanged.
-          });
         }
         return;
       }
@@ -250,7 +237,7 @@ export const useCanvasKeyboard = ({
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [undo, redo, nodes, selectedNodeIds, setSelectedNodeIds, selectedEdgeId, setSelectedEdgeId, removeEdge, duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, pasteMarkdownAsNote, groupSelectedNodes, ungroupSelectedNodes, removeNodes, moveNodes, commitHistory, searchOpen, setSearchOpen, findOpen, toggleFindBar, closeFindBar, findNext, findPrev, findHasMatches, contextMenu, setContextMenu, focusModeEnabled, canToggleFocusMode, onToggleFocusMode, onExitFocusMode, fullscreenActive, onExitFullscreen, keyboardLocked]);
+  }, [undo, redo, nodes, selectedNodeIds, setSelectedNodeIds, selectedEdgeId, setSelectedEdgeId, removeEdge, duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, groupSelectedNodes, ungroupSelectedNodes, removeNodes, moveNodes, commitHistory, searchOpen, setSearchOpen, findOpen, toggleFindBar, closeFindBar, findNext, findPrev, findHasMatches, contextMenu, setContextMenu, focusModeEnabled, canToggleFocusMode, onToggleFocusMode, onExitFocusMode, fullscreenActive, onExitFullscreen, keyboardLocked]);
 
   // Cmd/Ctrl+Tab to cycle through nodes (Shift reverses direction)
   useEffect(() => {

--- a/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import type { CanvasNode } from '../types';
+import type { CanvasNode, FileNodeData } from '../types';
 
 interface Options {
   undo: () => void;
@@ -16,6 +16,7 @@ interface Options {
   clipboardNodes: CanvasNode[];
   setClipboardNodes: (nodes: CanvasNode[]) => void;
   pasteNodes: (nodes: CanvasNode[]) => CanvasNode[];
+  pasteMarkdownAsNote?: (markdown: string) => Promise<CanvasNode | null>;
   /** Group the current node selection in a lightweight container. */
   groupSelectedNodes: () => void;
   /** Dissolve selected group nodes while keeping their children on canvas. */
@@ -57,7 +58,7 @@ interface Options {
 export const useCanvasKeyboard = ({
   undo, redo, nodes, selectedNodeIds, setSelectedNodeIds,
   selectedEdgeId, setSelectedEdgeId, removeEdge,
-  duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, groupSelectedNodes, ungroupSelectedNodes, removeNodes,
+  duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, pasteMarkdownAsNote, groupSelectedNodes, ungroupSelectedNodes, removeNodes,
   moveNodes, commitHistory,
   searchOpen, setSearchOpen,
   findOpen, toggleFindBar, closeFindBar, findNext, findPrev, findHasMatches,
@@ -140,7 +141,22 @@ export const useCanvasKeyboard = ({
       }
       if (isMod && e.key === 'c' && !isEditable) {
         const selected = nodes.filter((n) => selectedNodeIds.includes(n.id));
-        if (selected.length > 0) setClipboardNodes(selected);
+        if (selected.length > 0) {
+          setClipboardNodes(selected);
+          const markdownNodes = selected.filter((n): n is CanvasNode & { data: FileNodeData } => (
+            n.type === 'file' && typeof (n.data as FileNodeData).content === 'string'
+          ));
+          if (markdownNodes.length === selected.length && navigator.clipboard?.writeText) {
+            const markdown = markdownNodes
+              .map((node) => markdownNodes.length === 1
+                ? node.data.content
+                : `# ${node.title}\n\n${node.data.content}`)
+              .join('\n\n---\n\n');
+            void navigator.clipboard.writeText(markdown).catch(() => {
+              // Canvas-local clipboard still works even if the system clipboard is unavailable.
+            });
+          }
+        }
         return;
       }
       if (isMod && (e.key === 'g' || e.key === 'G') && e.shiftKey && !isEditable) {
@@ -158,6 +174,18 @@ export const useCanvasKeyboard = ({
           e.preventDefault();
           const created = pasteNodes(clipboardNodes);
           setSelectedNodeIds(created.map((n) => n.id));
+          return;
+        }
+
+        if (pasteMarkdownAsNote && navigator.clipboard?.readText) {
+          e.preventDefault();
+          void navigator.clipboard.readText().then(async (text) => {
+            if (!text.trim()) return;
+            const created = await pasteMarkdownAsNote(text);
+            if (created) setSelectedNodeIds([created.id]);
+          }).catch(() => {
+            // If clipboard read permission is denied, leave the canvas unchanged.
+          });
         }
         return;
       }
@@ -222,7 +250,7 @@ export const useCanvasKeyboard = ({
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [undo, redo, nodes, selectedNodeIds, setSelectedNodeIds, selectedEdgeId, setSelectedEdgeId, removeEdge, duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, groupSelectedNodes, ungroupSelectedNodes, removeNodes, moveNodes, commitHistory, searchOpen, setSearchOpen, findOpen, toggleFindBar, closeFindBar, findNext, findPrev, findHasMatches, contextMenu, setContextMenu, focusModeEnabled, canToggleFocusMode, onToggleFocusMode, onExitFocusMode, fullscreenActive, onExitFullscreen, keyboardLocked]);
+  }, [undo, redo, nodes, selectedNodeIds, setSelectedNodeIds, selectedEdgeId, setSelectedEdgeId, removeEdge, duplicateNode, clipboardNodes, setClipboardNodes, pasteNodes, pasteMarkdownAsNote, groupSelectedNodes, ungroupSelectedNodes, removeNodes, moveNodes, commitHistory, searchOpen, setSearchOpen, findOpen, toggleFindBar, closeFindBar, findNext, findPrev, findHasMatches, contextMenu, setContextMenu, focusModeEnabled, canToggleFocusMode, onToggleFocusMode, onExitFocusMode, fullscreenActive, onExitFullscreen, keyboardLocked]);
 
   // Cmd/Ctrl+Tab to cycle through nodes (Shift reverses direction)
   useEffect(() => {

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
@@ -19,6 +19,11 @@ import { useNodeHistory } from './useNodeHistory';
 const SAVE_DEBOUNCE_MS = 800;
 const DEFAULT_CANVAS_ID = 'default';
 
+interface AddNodeOptions {
+  fileName?: string;
+  fileContent?: string;
+}
+
 export const useNodes = (
   canvasId = DEFAULT_CANVAS_ID,
   onRestoreTransform?: (t: CanvasTransform) => void,
@@ -327,18 +332,31 @@ export const useNodes = (
   }, [canvasId]);
 
   const addNode = useCallback(
-    (type: CanvasNode['type'], x: number, y: number) => {
+    (type: CanvasNode['type'], x: number, y: number, options?: AddNodeOptions) => {
       const node = { ...createDefaultNode(type, x, y), updatedAt: Date.now() };
 
       if (type === 'file') {
         const api = window.canvasWorkspace?.file;
         if (api) {
-          void api.createNote(canvasId).then((res) => {
+          void api.createNote(canvasId, options?.fileName).then(async (res) => {
             if (res.ok && res.filePath) {
+              if (typeof options?.fileContent === 'string') {
+                await api.write(res.filePath, options.fileContent);
+              }
               setNodes((prev) => {
                 const updated = prev.map((n) =>
                   n.id === node.id
-                    ? { ...n, title: res.fileName?.replace(/\.md$/, '') || n.title, data: { ...n.data, filePath: res.filePath ?? '' } }
+                    ? {
+                        ...n,
+                        title: res.fileName?.replace(/\.md$/, '') || n.title,
+                        data: {
+                          ...n.data,
+                          filePath: res.filePath ?? '',
+                          content: options?.fileContent ?? (n.data as FileNodeData).content,
+                          saved: true,
+                          modified: false,
+                        },
+                      }
                     : n
                 );
                 nodesRef.current = updated;

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
@@ -340,8 +340,10 @@ export const useNodes = (
         if (api) {
           void api.createNote(canvasId, options?.fileName).then(async (res) => {
             if (res.ok && res.filePath) {
+              let contentWritten = false;
               if (typeof options?.fileContent === 'string') {
                 await api.write(res.filePath, options.fileContent);
+                contentWritten = true;
               }
               setNodes((prev) => {
                 const updated = prev.map((n) =>
@@ -352,7 +354,7 @@ export const useNodes = (
                         data: {
                           ...n.data,
                           filePath: res.filePath ?? '',
-                          content: options?.fileContent ?? (n.data as FileNodeData).content,
+                          content: contentWritten ? options?.fileContent ?? '' : (n.data as FileNodeData).content,
                           saved: true,
                           modified: false,
                         },
@@ -593,7 +595,9 @@ export const useNodes = (
               ? { ...(source.data as ImageNodeData) }
               : source.type === 'shape'
                 ? { ...(source.data as ShapeNodeData) }
-                : source.type === 'mindmap'
+                : source.type === 'file'
+                  ? { ...(source.data as FileNodeData), filePath: '', saved: false, modified: false }
+                  : source.type === 'mindmap'
                   ? (() => {
                       const src = source.data as MindmapNodeData;
                       return {
@@ -608,12 +612,24 @@ export const useNodes = (
       if (newNode.type === 'file') {
         const api = window.canvasWorkspace?.file;
         if (api) {
-          void api.createNote(canvasId).then((res) => {
+          void api.createNote(canvasId, newNode.title).then(async (res) => {
             if (res.ok && res.filePath) {
+              const content = (source.data as FileNodeData).content;
+              await api.write(res.filePath, content);
               setNodes((prev) => {
                 const updated = prev.map((n) =>
                   n.id === newNode.id
-                    ? { ...n, title: res.fileName?.replace(/\.md$/, '') || n.title, data: { ...n.data, filePath: res.filePath ?? '' } }
+                    ? {
+                        ...n,
+                        title: res.fileName?.replace(/\.md$/, '') || n.title,
+                        data: {
+                          ...n.data,
+                          filePath: res.filePath ?? '',
+                          content,
+                          saved: true,
+                          modified: false,
+                        },
+                      }
                     : n
                 );
                 nodesRef.current = updated;
@@ -655,7 +671,9 @@ export const useNodes = (
               ? { ...(source.data as ImageNodeData) }
               : source.type === 'shape'
                 ? { ...(source.data as ShapeNodeData) }
-                : source.type === 'mindmap'
+                : source.type === 'file'
+                  ? { ...(source.data as FileNodeData), filePath: '', saved: false, modified: false }
+                  : source.type === 'mindmap'
                   ? (() => {
                       const src = source.data as MindmapNodeData;
                       return {
@@ -667,16 +685,29 @@ export const useNodes = (
                   : createNodeData(source.type),
         updatedAt: now,
       }));
-      newNodes.forEach((newNode) => {
+      newNodes.forEach((newNode, index) => {
         if (newNode.type === 'file') {
           const api = window.canvasWorkspace?.file;
           if (api) {
-            void api.createNote(canvasId).then((res) => {
+            void api.createNote(canvasId, newNode.title).then(async (res) => {
               if (res.ok && res.filePath) {
+                const source = sources[index];
+                const content = source?.type === 'file' ? (source.data as FileNodeData).content : '';
+                await api.write(res.filePath, content);
                 setNodes((prev) => {
                   const updated = prev.map((n) =>
                     n.id === newNode.id
-                      ? { ...n, title: res.fileName?.replace(/\.md$/, '') || n.title, data: { ...n.data, filePath: res.filePath ?? '' } }
+                      ? {
+                          ...n,
+                          title: res.fileName?.replace(/\.md$/, '') || n.title,
+                          data: {
+                            ...n.data,
+                            filePath: res.filePath ?? '',
+                            content,
+                            saved: true,
+                            modified: false,
+                          },
+                        }
                       : n
                   );
                   nodesRef.current = updated;


### PR DESCRIPTION
## Summary
- Treat system clipboard markdown/text paste on a blank active canvas as a note-node creation when the canvas-local clipboard has no nodes.
- Copy selected note nodes to the system clipboard as markdown so cross-canvas paste recreates a markdown-backed note instead of falling through to a text node.
- Allow `addNode('file')` to seed note filename/content during async file creation.

Closes #516

## Validation
- `pnpm --filter canvas-workspace typecheck:renderer` ✅
- `git diff --check` ✅

## Risk
- Low/medium: touches global canvas keyboard paste behavior; gated to non-editable contexts and preserves existing canvas-local node paste priority.

<!-- pulse-ai-handler:record_id=recvk3FGB6XuEd -->
