### PR TITLE
Implement lazy keep-alive for workspace mounting

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
@@ -48,6 +48,26 @@ export const Workbench: React.FC<WorkbenchProps> = ({
   const [activeReferenceIdByWorkspace, setActiveReferenceIdByWorkspace] = useState<Record<string, string | undefined>>({});
   const [chatWidth, setChatWidth] = useState(DEFAULT_CHAT_WIDTH);
 
+  // Lazy keep-alive: a workspace is mounted the first time it becomes
+  // active and stays mounted (hidden via display:none) thereafter, so
+  // re-selecting it is instant. Workspaces the user never visits never
+  // mount their Canvas / iframe webviews — this is what keeps startup
+  // from spinning up an Electron webContents for every link node across
+  // every saved workspace.
+  const [mountedWorkspaceIds, setMountedWorkspaceIds] = useState<Set<string>>(
+    () => (activeWorkspaceId ? new Set([activeWorkspaceId]) : new Set()),
+  );
+
+  useEffect(() => {
+    if (!activeWorkspaceId) return;
+    setMountedWorkspaceIds((prev) => {
+      if (prev.has(activeWorkspaceId)) return prev;
+      const next = new Set(prev);
+      next.add(activeWorkspaceId);
+      return next;
+    });
+  }, [activeWorkspaceId]);
+
   const references = referencesByWorkspace[activeWorkspaceId] ?? EMPTY_REFERENCES;
   const activeReferenceId = activeReferenceIdByWorkspace[activeWorkspaceId];
   const activeReference = activeReferenceId
@@ -202,7 +222,7 @@ export const Workbench: React.FC<WorkbenchProps> = ({
         onFocusNode={handleFocusReferenceNode}
       />
       <div className="canvas-viewport">
-        {workspaces.map((ws) => {
+        {workspaces.filter((ws) => mountedWorkspaceIds.has(ws.id)).map((ws) => {
           const isActive = ws.id === activeWorkspaceId;
           return (
             <div
@@ -233,7 +253,7 @@ export const Workbench: React.FC<WorkbenchProps> = ({
           );
         })}
       </div>
-      {workspaces.map((ws) => (
+      {workspaces.filter((ws) => mountedWorkspaceIds.has(ws.id)).map((ws) => (
         <div
           key={ws.id}
           className={`chat-panel-wrapper${chatPanelOpen && ws.id === activeWorkspaceId ? ' chat-panel-wrapper--open' : ''}`}


### PR DESCRIPTION
## Summary
Implements lazy keep-alive for workspace mounting in the Workbench component to improve startup performance. Workspaces are now only mounted (and their Canvas/iframe webviews instantiated) when first visited by the user, and remain mounted thereafter for instant re-selection. Unvisited workspaces never mount their webviews, preventing unnecessary Electron webContents creation for every link node across saved workspaces.

## Key Changes
- Added `mountedWorkspaceIds` state to track which workspaces have been mounted at least once
- Initialize `mountedWorkspaceIds` with the currently active workspace on component mount
- Added `useEffect` hook to add workspaces to `mountedWorkspaceIds` when they become active
- Updated canvas viewport and chat panel rendering to only render workspaces that are in `mountedWorkspaceIds`

## Implementation Details
- The `mountedWorkspaceIds` Set is initialized lazily using a function to ensure the active workspace is included from the start
- The effect uses a Set comparison to avoid unnecessary state updates when re-selecting an already-mounted workspace
- Workspaces remain in the DOM (hidden via `display:none`) after first visit, enabling instant switching without remounting
- This approach significantly reduces startup time by deferring webview creation until actually needed

https://claude.ai/code/session_01KTuPvQgRKPa16reVtegiGu