### PR TITLE
Expand resizable panel width constraints for Reference and Chat drawers

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.tsx
@@ -7,8 +7,8 @@ import { getNodeDisplayLabel } from '../../utils/nodeLabel';
 import { copyTextToClipboard } from '../../utils/clipboard';
 
 const DEFAULT_REFERENCE_DRAWER_WIDTH = 420;
-const MIN_REFERENCE_DRAWER_WIDTH = 320;
-const MAX_REFERENCE_DRAWER_WIDTH = 720;
+const MIN_REFERENCE_DRAWER_WIDTH = 260;
+const MAX_REFERENCE_DRAWER_WIDTH = 1000;
 const REFERENCE_SEARCH_DEBOUNCE_MS = 180;
 
 const NODE_TYPE_LABELS: Record<CanvasNode['type'], string> = {

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
@@ -10,8 +10,8 @@ export { useWorkbenchState } from './useWorkbenchState';
 export type { WorkbenchController } from './useWorkbenchState';
 
 const DEFAULT_CHAT_WIDTH = 420;
-const MIN_CHAT_WIDTH = 280;
-const MAX_CHAT_WIDTH = 600;
+const MIN_CHAT_WIDTH = 240;
+const MAX_CHAT_WIDTH = 900;
 
 const EMPTY_REFERENCES: ReferenceEntry[] = [];
 


### PR DESCRIPTION
## Summary
Adjusted the minimum and maximum width constraints for the Reference Drawer and Chat/Workbench panels to allow for greater flexibility in workspace layout customization.

## Changes
- **Reference Drawer** (`ReferenceDrawer/index.tsx`):
  - Reduced `MIN_REFERENCE_DRAWER_WIDTH` from 320px to 260px
  - Increased `MAX_REFERENCE_DRAWER_WIDTH` from 720px to 1000px

- **Workbench/Chat Panel** (`Workbench/index.tsx`):
  - Reduced `MIN_CHAT_WIDTH` from 280px to 240px
  - Increased `MAX_CHAT_WIDTH` from 600px to 900px

## Details
These changes expand the resizable range for both side panels in the canvas workspace, enabling users to:
- Compress panels to smaller widths for more canvas workspace area
- Expand panels to larger widths for better content visibility and interaction space

The adjustments maintain reasonable bounds while providing greater user control over the workspace layout.

https://claude.ai/code/session_019nFSorb9EcmgA3ReyuNdUi