### PR TITLE
Add workspace reordering and folder-scoped creation UI

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -57,6 +57,7 @@ const AppContent = () => {
     deleteFolder,
     toggleFolder,
     moveWorkspace,
+    reorderWorkspace,
     reorderFolder,
   } = useWorkspaces();
 
@@ -112,9 +113,9 @@ const AppContent = () => {
     ensureWorkspaceNodesLoaded(activeId);
   }, [activeId, ensureWorkspaceNodesLoaded]);
 
-  const handleCreateWorkspace = useCallback((name: string) => {
+  const handleCreateWorkspace = useCallback((name: string, folderId?: string) => {
     const trimmed = name.trim() || 'Untitled';
-    const id = createWorkspace(name);
+    const id = createWorkspace(name, folderId);
     notify({
       tone: 'success',
       title: 'Workspace created',
@@ -360,6 +361,7 @@ const AppContent = () => {
           onDeleteFolder={handleDeleteFolder}
           onToggleFolder={toggleFolder}
           onMoveWorkspace={moveWorkspace}
+          onReorderWorkspace={reorderWorkspace}
           onReorderFolder={reorderFolder}
           activeNodes={activeNodes}
           onNodeFocus={requestActiveNodeFocus}

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/FolderItem.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/FolderItem.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 import type { FolderEntry, WorkspaceEntry } from '../../hooks/useWorkspaces';
-import { CloseIcon, ChevronRightIcon, FolderIcon } from '../icons';
+import { CloseIcon, ChevronRightIcon, FolderIcon, PencilIcon, PlusIcon } from '../icons';
 
 interface FolderItemProps {
   folder: FolderEntry;
@@ -21,7 +21,9 @@ interface FolderItemProps {
   onRenameCommit: () => void;
   onRenameCancel: () => void;
   onDelete: () => void;
+  onCreateWorkspace: () => void;
   renderWorkspace: (ws: WorkspaceEntry) => React.ReactNode;
+  inlineCreateSlot?: React.ReactNode;
 }
 
 export const FolderItem = ({
@@ -43,7 +45,9 @@ export const FolderItem = ({
   onRenameCommit,
   onRenameCancel,
   onDelete,
+  onCreateWorkspace,
   renderWorkspace,
+  inlineCreateSlot,
 }: FolderItemProps) => {
   const isOpen = !folder.collapsed;
 
@@ -74,8 +78,7 @@ export const FolderItem = ({
           <button
             className="sidebar-folder-toggle"
             onClick={onToggle}
-            onDoubleClick={onStartRename}
-            title="Click to toggle · Double-click to rename"
+            title="Toggle"
           >
             <span className={`sidebar-folder-chevron${isOpen ? ' sidebar-folder-chevron--open' : ''}`}>
               <ChevronRightIcon size={10} />
@@ -87,13 +90,32 @@ export const FolderItem = ({
           </button>
         )}
         {!isRenaming && (
-          <button
-            className="sidebar-folder-delete"
-            onClick={onDelete}
-            title="Delete folder"
-          >
-            <CloseIcon size={12} strokeWidth={1.5} />
-          </button>
+          <div className="sidebar-folder-actions">
+            <button
+              className="sidebar-folder-action"
+              onClick={(e) => { e.stopPropagation(); onCreateWorkspace(); }}
+              title="New workspace in folder"
+              aria-label="New workspace in folder"
+            >
+              <PlusIcon size={12} strokeWidth={1.5} />
+            </button>
+            <button
+              className="sidebar-folder-action"
+              onClick={(e) => { e.stopPropagation(); onStartRename(); }}
+              title="Rename folder"
+              aria-label="Rename folder"
+            >
+              <PencilIcon size={12} strokeWidth={1.4} />
+            </button>
+            <button
+              className="sidebar-folder-action sidebar-folder-action--danger"
+              onClick={(e) => { e.stopPropagation(); onDelete(); }}
+              title="Delete folder"
+              aria-label="Delete folder"
+            >
+              <CloseIcon size={12} strokeWidth={1.5} />
+            </button>
+          </div>
         )}
       </div>
 
@@ -103,7 +125,8 @@ export const FolderItem = ({
       >
         <div className="sidebar-folder-children-inner">
           {folderWorkspaces.map(renderWorkspace)}
-          {folderWorkspaces.length === 0 && (
+          {inlineCreateSlot}
+          {folderWorkspaces.length === 0 && !inlineCreateSlot && (
             <div className="sidebar-folder-empty">Drop workspaces here</div>
           )}
         </div>

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/WorkspaceItem.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/WorkspaceItem.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 import type { WorkspaceEntry } from '../../hooks/useWorkspaces';
-import { CloseIcon, ExportIcon, WorkspaceIcon } from '../icons';
+import { CloseIcon, ExportIcon, PencilIcon, WorkspaceIcon } from '../icons';
 
 export interface WorkspaceItemProps {
   ws: WorkspaceEntry;
@@ -10,6 +10,7 @@ export interface WorkspaceItemProps {
   isRenaming: boolean;
   renameValue: string;
   renameInputRef: React.RefObject<HTMLInputElement>;
+  isDropBefore: boolean;
   onSelect: (id: string) => void;
   onStartRename: (ws: WorkspaceEntry) => void;
   onRenameChange: (value: string) => void;
@@ -19,6 +20,9 @@ export interface WorkspaceItemProps {
   onExport: (id: string) => void;
   onDragStart: (e: React.DragEvent, id: string) => void;
   onDragEnd: (e: React.DragEvent) => void;
+  onReorderDragOver: (e: React.DragEvent) => void;
+  onReorderDragLeave: (e: React.DragEvent) => void;
+  onReorderDrop: (e: React.DragEvent) => void;
 }
 
 export const WorkspaceItem = ({
@@ -29,6 +33,7 @@ export const WorkspaceItem = ({
   isRenaming,
   renameValue,
   renameInputRef,
+  isDropBefore,
   onSelect,
   onStartRename,
   onRenameChange,
@@ -38,12 +43,18 @@ export const WorkspaceItem = ({
   onExport,
   onDragStart,
   onDragEnd,
+  onReorderDragOver,
+  onReorderDragLeave,
+  onReorderDrop,
 }: WorkspaceItemProps) => (
   <div
-    className="sidebar-workspace-entry"
+    className={`sidebar-workspace-entry${isDropBefore ? ' sidebar-workspace-entry--drop-before' : ''}`}
     draggable
     onDragStart={(e) => onDragStart(e, ws.id)}
     onDragEnd={onDragEnd}
+    onDragOver={onReorderDragOver}
+    onDragLeave={onReorderDragLeave}
+    onDrop={onReorderDrop}
   >
     <div className="sidebar-item-row">
       {isRenaming ? (
@@ -62,13 +73,22 @@ export const WorkspaceItem = ({
         <button
           className={`sidebar-item${activeId === ws.id && activeView === 'canvas' ? ' sidebar-item--active' : ''}`}
           onClick={() => onSelect(ws.id)}
-          onDoubleClick={() => onStartRename(ws)}
-          title="Double-click to rename"
+          title={ws.name}
         >
           <span className="sidebar-item-icon">
             <WorkspaceIcon size={14} />
           </span>
           <span className="sidebar-item-name">{ws.name}</span>
+        </button>
+      )}
+      {!isRenaming && (
+        <button
+          className="sidebar-item-rename"
+          onClick={() => onStartRename(ws)}
+          title="Rename"
+          aria-label="Rename workspace"
+        >
+          <PencilIcon size={12} strokeWidth={1.4} />
         </button>
       )}
       {!isRenaming && (

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/WorkspaceList.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/WorkspaceList.tsx
@@ -14,6 +14,7 @@ interface WorkspaceListProps {
   inlineCreate: 'workspace' | 'folder' | null;
   inlineCreateValue: string;
   inlineCreateRef: React.RefObject<HTMLInputElement>;
+  inlineCreateFolderId: string | null;
   onFolderDragStart: (e: React.DragEvent, folderId: string) => void;
   onFolderDragEnd: (e: React.DragEvent) => void;
   onFolderCombinedDragOver: (e: React.DragEvent, folderId: string) => void;
@@ -28,6 +29,7 @@ interface WorkspaceListProps {
   onFolderRenameCommit: () => void;
   onFolderRenameCancel: () => void;
   onDeleteFolder: (id: string) => void;
+  onCreateWorkspaceInFolder: (folderId: string) => void;
   renderWorkspace: (ws: WorkspaceEntry) => React.ReactNode;
   onInlineCreateChange: (value: string) => void;
   onInlineCreateCommit: () => void;
@@ -45,6 +47,7 @@ export const WorkspaceList = ({
   inlineCreate,
   inlineCreateValue,
   inlineCreateRef,
+  inlineCreateFolderId,
   onFolderDragStart,
   onFolderDragEnd,
   onFolderCombinedDragOver,
@@ -59,17 +62,30 @@ export const WorkspaceList = ({
   onFolderRenameCommit,
   onFolderRenameCancel,
   onDeleteFolder,
+  onCreateWorkspaceInFolder,
   renderWorkspace,
   onInlineCreateChange,
   onInlineCreateCommit,
   onInlineCreateCancel,
 }: WorkspaceListProps) => {
   const rootWorkspaces = workspaces.filter((ws) => !ws.folderId);
+  const showRootInlineCreate = !!inlineCreate && inlineCreateFolderId === null;
 
   return (
     <div className="sidebar-scroll">
       {folders.map((folder) => {
         const folderWorkspaces = workspaces.filter((ws) => ws.folderId === folder.id);
+        const folderInlineCreate =
+          inlineCreate === 'workspace' && inlineCreateFolderId === folder.id ? (
+            <InlineCreateRow
+              type="workspace"
+              value={inlineCreateValue}
+              inputRef={inlineCreateRef}
+              onChange={onInlineCreateChange}
+              onCommit={onInlineCreateCommit}
+              onCancel={onInlineCreateCancel}
+            />
+          ) : null;
         return (
           <FolderItem
             key={folder.id}
@@ -91,7 +107,9 @@ export const WorkspaceList = ({
             onRenameCommit={onFolderRenameCommit}
             onRenameCancel={onFolderRenameCancel}
             onDelete={() => onDeleteFolder(folder.id)}
+            onCreateWorkspace={() => onCreateWorkspaceInFolder(folder.id)}
             renderWorkspace={renderWorkspace}
+            inlineCreateSlot={folderInlineCreate}
           />
         );
       })}
@@ -105,7 +123,7 @@ export const WorkspaceList = ({
         {rootWorkspaces.map(renderWorkspace)}
       </div>
 
-      {inlineCreate && (
+      {showRootInlineCreate && inlineCreate && (
         <InlineCreateRow
           type={inlineCreate}
           value={inlineCreateValue}

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
@@ -231,11 +231,11 @@
   right: 6px;
 }
 
-.sidebar-item-export {
+.sidebar-item-rename {
   right: 30px;
 }
 
-.sidebar-item-rename {
+.sidebar-item-export {
   right: 54px;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
@@ -210,7 +210,8 @@
 }
 
 .sidebar-item-delete,
-.sidebar-item-export {
+.sidebar-item-export,
+.sidebar-item-rename {
   flex-shrink: 0;
   width: 22px;
   height: 22px;
@@ -234,13 +235,19 @@
   right: 30px;
 }
 
+.sidebar-item-rename {
+  right: 54px;
+}
+
 .sidebar-item-row:hover .sidebar-item-delete,
-.sidebar-item-row:hover .sidebar-item-export {
+.sidebar-item-row:hover .sidebar-item-export,
+.sidebar-item-row:hover .sidebar-item-rename {
   display: flex;
 }
 
 .sidebar-item-delete:hover,
-.sidebar-item-export:hover {
+.sidebar-item-export:hover,
+.sidebar-item-rename:hover {
   background: rgba(0, 0, 0, 0.06);
   color: var(--text-secondary);
 }
@@ -671,30 +678,43 @@
   border-left-color: transparent;
 }
 
-.sidebar-folder-delete {
+.sidebar-folder-actions {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: none;
+  align-items: center;
+  gap: 1px;
+  pointer-events: auto;
+}
+
+.sidebar-folder-header:hover .sidebar-folder-actions {
+  display: flex;
+}
+
+.sidebar-folder-action {
   flex-shrink: 0;
-  width: 22px;
-  height: 22px;
+  width: 20px;
+  height: 20px;
   border: none;
   background: transparent;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  display: none;
+  display: flex;
   align-items: center;
   justify-content: center;
   color: var(--text-muted);
   transition: background 0.1s, color 0.1s;
-  position: absolute;
-  right: 12px;
 }
 
-.sidebar-folder-header:hover .sidebar-folder-delete {
-  display: flex;
-}
-
-.sidebar-folder-delete:hover {
+.sidebar-folder-action:hover {
   background: rgba(0, 0, 0, 0.06);
   color: var(--text-secondary);
+}
+
+.sidebar-folder-action--danger:hover {
+  color: var(--text);
 }
 
 .sidebar-folder-children {
@@ -734,10 +754,24 @@
 .sidebar-workspace-entry {
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 
 .sidebar-workspace-entry[draggable="true"] {
   transition: opacity 0.15s;
+}
+
+.sidebar-workspace-entry--drop-before::before {
+  content: '';
+  position: absolute;
+  top: -1px;
+  left: 4px;
+  right: 4px;
+  height: 2px;
+  background: var(--accent, #2383e2);
+  border-radius: 1px;
+  pointer-events: none;
+  z-index: 1;
 }
 
 .sidebar-dragging {

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
@@ -21,7 +21,7 @@ interface Props {
   folders: FolderEntry[];
   activeId: string;
   onSelect: (id: string) => void;
-  onCreate: (name: string) => void;
+  onCreate: (name: string, folderId?: string) => void;
   onRename: (id: string, name: string) => void;
   onDelete: (id: string) => void;
   onExport: (id: string) => void;
@@ -31,6 +31,11 @@ interface Props {
   onDeleteFolder: (id: string) => void;
   onToggleFolder: (id: string) => void;
   onMoveWorkspace: (workspaceId: string, folderId: string | undefined) => void;
+  onReorderWorkspace: (
+    workspaceId: string,
+    beforeWorkspaceId: string | null,
+    folderId: string | undefined,
+  ) => void;
   onReorderFolder: (folderId: string, beforeFolderId: string | null) => void;
   activeNodes?: CanvasNode[];
   onNodeFocus?: (nodeId: string) => void;
@@ -48,7 +53,8 @@ const FOLDER_DRAG = 'application/x-folder-id';
 
 export const Sidebar = ({
   collapsed, onToggle, workspaces, folders, activeId, onSelect, onCreate, onRename, onDelete,
-  onExport, onImport, onCreateFolder, onRenameFolder, onDeleteFolder, onToggleFolder, onMoveWorkspace, onReorderFolder,
+  onExport, onImport, onCreateFolder, onRenameFolder, onDeleteFolder, onToggleFolder, onMoveWorkspace,
+  onReorderWorkspace, onReorderFolder,
   activeNodes = [], onNodeFocus, onNodeDelete, onNodeRename, activeView, onEnterChat, pluginNavItems, onNavigate,
 }: Props) => {
   const { notify } = useAppShell();
@@ -60,8 +66,10 @@ export const Sidebar = ({
   const [renameLayerValue, setRenameLayerValue] = useState('');
   const [inlineCreate, setInlineCreate] = useState<'workspace' | 'folder' | null>(null);
   const [inlineCreateValue, setInlineCreateValue] = useState('');
+  const [inlineCreateFolderId, setInlineCreateFolderId] = useState<string | null>(null);
   const [dropTarget, setDropTarget] = useState<string | null>(null);
   const [folderDropTarget, setFolderDropTarget] = useState<string | null>(null);
+  const [wsDropBeforeId, setWsDropBeforeId] = useState<string | null>(null);
   const [showAddMenu, setShowAddMenu] = useState(false);
   const [collapsedLayers, setCollapsedLayers] = useState<Set<string>>(new Set());
   const [layerContextMenu, setLayerContextMenu] = useState<{ x: number; y: number; nodeId: string } | null>(null);
@@ -138,8 +146,22 @@ export const Sidebar = ({
   };
   const commitInlineCreate = () => {
     const v = inlineCreateValue.trim();
-    if (v) { if (inlineCreate === 'workspace') onCreate(v); else if (inlineCreate === 'folder') onCreateFolder(v); }
-    setInlineCreate(null); setInlineCreateValue('');
+    if (v) {
+      if (inlineCreate === 'workspace') onCreate(v, inlineCreateFolderId ?? undefined);
+      else if (inlineCreate === 'folder') onCreateFolder(v);
+    }
+    setInlineCreate(null); setInlineCreateValue(''); setInlineCreateFolderId(null);
+  };
+  const cancelInlineCreate = () => {
+    setInlineCreate(null); setInlineCreateValue(''); setInlineCreateFolderId(null);
+  };
+  const startCreateInFolder = (folderId: string) => {
+    const folder = folders.find((f) => f.id === folderId);
+    if (folder?.collapsed) onToggleFolder(folderId);
+    setShowAddMenu(false);
+    setInlineCreate('workspace');
+    setInlineCreateValue('');
+    setInlineCreateFolderId(folderId);
   };
 
   const handleLayerDelete = useCallback((nodeId: string) => {
@@ -176,7 +198,8 @@ export const Sidebar = ({
     (e.currentTarget as HTMLElement).classList.add('sidebar-dragging');
   };
   const handleWsDragEnd = (e: DragEvent) => {
-    (e.currentTarget as HTMLElement).classList.remove('sidebar-dragging'); setDropTarget(null);
+    (e.currentTarget as HTMLElement).classList.remove('sidebar-dragging');
+    setDropTarget(null); setWsDropBeforeId(null);
   };
   const handleWsDragOver = (e: DragEvent, targetId: string) => {
     if (!e.dataTransfer.types.includes(WS_DRAG)) return;
@@ -188,7 +211,32 @@ export const Sidebar = ({
     if (dropTarget === targetId) setDropTarget(null);
   };
   const handleWsDrop = (e: DragEvent, folderId: string | undefined) => {
-    e.preventDefault(); const wsId = e.dataTransfer.getData(WS_DRAG); if (wsId) onMoveWorkspace(wsId, folderId); setDropTarget(null);
+    e.preventDefault(); const wsId = e.dataTransfer.getData(WS_DRAG);
+    if (wsId) onMoveWorkspace(wsId, folderId);
+    setDropTarget(null); setWsDropBeforeId(null);
+  };
+
+  // Workspace-on-workspace reorder (drop A before B)
+  const handleWsReorderDragOver = (e: DragEvent, targetWsId: string) => {
+    if (!e.dataTransfer.types.includes(WS_DRAG)) return;
+    e.preventDefault(); e.stopPropagation();
+    e.dataTransfer.dropEffect = 'move';
+    setWsDropBeforeId(targetWsId);
+    setDropTarget(null);
+  };
+  const handleWsReorderDragLeave = (e: DragEvent, targetWsId: string) => {
+    const rel = e.relatedTarget as HTMLElement | null;
+    if (rel && (e.currentTarget as HTMLElement).contains(rel)) return;
+    if (wsDropBeforeId === targetWsId) setWsDropBeforeId(null);
+  };
+  const handleWsReorderDrop = (e: DragEvent, targetWs: WorkspaceEntry) => {
+    if (!e.dataTransfer.types.includes(WS_DRAG)) return;
+    e.preventDefault(); e.stopPropagation();
+    const wsId = e.dataTransfer.getData(WS_DRAG);
+    if (wsId && wsId !== targetWs.id) {
+      onReorderWorkspace(wsId, targetWs.id, targetWs.folderId);
+    }
+    setWsDropBeforeId(null); setDropTarget(null);
   };
 
   // Folder drag
@@ -226,9 +274,14 @@ export const Sidebar = ({
       key={ws.id} ws={ws} activeId={activeId} activeView={activeView}
       isOnlyWorkspace={workspaces.length <= 1} isRenaming={renamingId === ws.id}
       renameValue={renameValue} renameInputRef={renameInputRef}
+      isDropBefore={wsDropBeforeId === ws.id}
       onSelect={onSelect} onStartRename={startRename} onRenameChange={setRenameValue}
       onRenameCommit={commitRename} onRenameCancel={() => setRenamingId(null)}
-      onDelete={onDelete} onExport={onExport} onDragStart={handleWsDragStart} onDragEnd={handleWsDragEnd}
+      onDelete={onDelete} onExport={onExport}
+      onDragStart={handleWsDragStart} onDragEnd={handleWsDragEnd}
+      onReorderDragOver={(e) => handleWsReorderDragOver(e, ws.id)}
+      onReorderDragLeave={(e) => handleWsReorderDragLeave(e, ws.id)}
+      onReorderDrop={(e) => handleWsReorderDrop(e, ws)}
     />
   );
 
@@ -241,8 +294,8 @@ export const Sidebar = ({
             pluginNavItems={pluginNavItems} onNavigate={onNavigate}
             showAddMenu={showAddMenu} onToggleAddMenu={() => setShowAddMenu((v) => !v)}
             addMenuRef={addMenuRef}
-            onNewWorkspace={() => { setShowAddMenu(false); setInlineCreate('workspace'); setInlineCreateValue(''); }}
-            onNewFolder={() => { setShowAddMenu(false); setInlineCreate('folder'); setInlineCreateValue(''); }}
+            onNewWorkspace={() => { setShowAddMenu(false); setInlineCreate('workspace'); setInlineCreateValue(''); setInlineCreateFolderId(null); }}
+            onNewFolder={() => { setShowAddMenu(false); setInlineCreate('folder'); setInlineCreateValue(''); setInlineCreateFolderId(null); }}
             onImportWorkspace={() => { setShowAddMenu(false); onImport(); }}
           />
           <WorkspaceList
@@ -251,6 +304,7 @@ export const Sidebar = ({
             renamingFolderId={renamingFolderId} renameFolderValue={renameFolderValue}
             renameFolderInputRef={renameFolderInputRef}
             inlineCreate={inlineCreate} inlineCreateValue={inlineCreateValue} inlineCreateRef={inlineCreateRef}
+            inlineCreateFolderId={inlineCreateFolderId}
             onFolderDragStart={handleFolderDragStart} onFolderDragEnd={handleFolderDragEnd}
             onFolderCombinedDragOver={onFolderCombinedDragOver}
             onFolderCombinedDragLeave={onFolderCombinedDragLeave}
@@ -261,9 +315,11 @@ export const Sidebar = ({
             onToggleFolder={onToggleFolder} onStartFolderRename={startFolderRename}
             onFolderRenameChange={setRenameFolderValue} onFolderRenameCommit={commitFolderRename}
             onFolderRenameCancel={() => setRenamingFolderId(null)}
-            onDeleteFolder={onDeleteFolder} renderWorkspace={renderWorkspaceItem}
+            onDeleteFolder={onDeleteFolder}
+            onCreateWorkspaceInFolder={startCreateInFolder}
+            renderWorkspace={renderWorkspaceItem}
             onInlineCreateChange={setInlineCreateValue} onInlineCreateCommit={commitInlineCreate}
-            onInlineCreateCancel={() => { setInlineCreate(null); setInlineCreateValue(''); }}
+            onInlineCreateCancel={cancelInlineCreate}
           />
         </>
       )}

--- a/apps/canvas-workspace/src/renderer/src/components/icons/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/icons/index.tsx
@@ -73,6 +73,24 @@ export const TrashIcon = ({ size = 14, className, strokeWidth = 1.3 }: IconProps
   </svg>
 );
 
+export const PencilIcon = ({ size = 14, className, strokeWidth = 1.3 }: IconProps) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className}>
+    <path
+      d="M11.2 2.8l2 2-7.4 7.4-2.5.5.5-2.5 7.4-7.4z"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M9.8 4.2l2 2"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
 
 export const CloseIcon = ({ size = 16, className, strokeWidth = 1.3 }: IconProps) => (
   <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className}>

--- a/apps/canvas-workspace/src/renderer/src/hooks/useWorkspaces.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useWorkspaces.ts
@@ -93,9 +93,13 @@ export const useWorkspaces = () => {
   );
 
   const createWorkspace = useCallback(
-    (name: string) => {
+    (name: string, folderId?: string) => {
       const id = `ws-${Date.now()}`;
-      const entry: WorkspaceEntry = { id, name: name.trim() || 'Untitled' };
+      const entry: WorkspaceEntry = {
+        id,
+        name: name.trim() || 'Untitled',
+        ...(folderId ? { folderId } : {}),
+      };
       setWorkspaces((prev) => {
         const next = [...prev, entry];
         saveManifest(next, id);
@@ -259,6 +263,36 @@ export const useWorkspaces = () => {
     [saveManifest]
   );
 
+  /**
+   * Reorder a workspace by moving it before another workspace (or to end of the target container).
+   * `folderId` is the target container — `undefined` means root, a string means inside that folder.
+   */
+  const reorderWorkspace = useCallback(
+    (
+      workspaceId: string,
+      beforeWorkspaceId: string | null,
+      folderId: string | undefined,
+    ) => {
+      setWorkspaces((prev) => {
+        const moving = prev.find((w) => w.id === workspaceId);
+        if (!moving) return prev;
+        const updatedMoving: WorkspaceEntry = { ...moving, folderId };
+        const without = prev.filter((w) => w.id !== workspaceId);
+        let next: WorkspaceEntry[];
+        if (beforeWorkspaceId === null) {
+          next = [...without, updatedMoving];
+        } else {
+          const idx = without.findIndex((w) => w.id === beforeWorkspaceId);
+          if (idx === -1) return prev;
+          next = [...without.slice(0, idx), updatedMoving, ...without.slice(idx)];
+        }
+        saveManifest(next);
+        return next;
+      });
+    },
+    [saveManifest],
+  );
+
   /** Reorder a folder by moving it before another folder (or to end) */
   const reorderFolder = useCallback(
     (folderId: string, beforeFolderId: string | null) => {
@@ -296,6 +330,7 @@ export const useWorkspaces = () => {
     deleteFolder,
     toggleFolder,
     moveWorkspace,
+    reorderWorkspace,
     reorderFolder,
   };
 };


### PR DESCRIPTION
## Summary
Enhance the sidebar with workspace reordering capabilities and improve the folder management UX by adding folder-scoped workspace creation and explicit rename/action buttons.

## Key Changes

### Workspace Reordering
- Added `onReorderWorkspace` callback to support drag-and-drop reordering of workspaces within and across folders
- Implemented `reorderWorkspace` hook in `useWorkspaces` that moves a workspace before a target workspace in the same or different folder
- Added visual drop-before indicator (blue line) when dragging a workspace over another
- Workspace drag handlers now distinguish between folder-move (existing) and workspace-reorder (new) operations

### Folder-Scoped Workspace Creation
- Extended `onCreate` signature to accept optional `folderId` parameter for creating workspaces directly within folders
- Added `onCreateWorkspaceInFolder` callback and `startCreateInFolder` handler to initiate inline creation in a specific folder
- Folder items now display a "+" button to create workspaces within that folder
- Inline create state now tracks `inlineCreateFolderId` to support folder-scoped creation

### UI/UX Improvements
- **Workspace items**: Added explicit pencil icon button for rename (removed double-click rename)
- **Folder items**: Replaced single delete button with action group containing:
  - "+" button to create workspace in folder
  - Pencil icon to rename folder
  - Delete button (danger state)
- Updated CSS to support multiple action buttons with proper spacing and hover states
- Improved accessibility with explicit aria-labels and title attributes

### Implementation Details
- `WorkspaceItem` now accepts `isDropBefore` prop and reorder drag handlers (`onReorderDragOver`, `onReorderDragLeave`, `onReorderDrop`)
- `FolderItem` receives `onCreateWorkspace` callback and optional `inlineCreateSlot` for rendering inline creation UI
- `WorkspaceList` manages folder-scoped inline creation state and passes it to `FolderItem`
- CSS refactored folder actions into a flex container (`.sidebar-folder-actions`) for better layout control
- Added `.sidebar-workspace-entry--drop-before` pseudo-element for visual feedback during reordering

https://claude.ai/code/session_018xnoTQYee8t1BzhH4wutvi