### PR TITLE
feat(canvas): add workspace memory integration

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -35,7 +35,8 @@
       "main": "dist/main/index.js"
     },
     "asarUnpack": [
-      "node_modules/node-pty/**/*"
+      "node_modules/node-pty/**/*",
+      "node_modules/better-sqlite3/**/*"
     ],
     "mac": {
       "target": [
@@ -110,6 +111,7 @@
     "markdown-it": "^14.1.0",
     "node-pty": "^1.1.0",
     "pulse-coder-engine": "workspace:*",
+    "pulse-coder-memory-plugin": "workspace:*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tiptap-markdown": "^0.9.0",

--- a/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
@@ -17,6 +17,10 @@ import {
   resolveWorkspaceNames,
 } from './context-builder';
 import { createCanvasTools } from './tools';
+import {
+  createCanvasWorkspaceMemoryIntegration,
+  createCanvasWorkspaceMemoryRunContext,
+} from './memory';
 import { SessionStore } from './session-store';
 import { formatPromptProfileForSystem, getPromptProfile } from './prompt-profile';
 import {
@@ -364,6 +368,7 @@ export interface CanvasClarificationRequest {
 
 export class CanvasAgent {
   private engine: any; // Engine type from pulse-coder-engine (no .d.ts yet)
+  private memoryIntegration: ReturnType<typeof createCanvasWorkspaceMemoryIntegration>;
   private messages: ModelMessage[] = [];
   private sessionStore: SessionStore;
   private config: CanvasAgentConfig;
@@ -378,11 +383,12 @@ export class CanvasAgent {
     this.sessionStore = new SessionStore(config.workspaceId);
 
     const canvasTools = createCanvasTools(config.workspaceId);
+    this.memoryIntegration = createCanvasWorkspaceMemoryIntegration(config.workspaceId);
 
     this.engine = new Engine({
       disableBuiltInPlugins: true,
       enginePlugins: {
-        plugins: [builtInSkillsPlugin],
+        plugins: [builtInSkillsPlugin, this.memoryIntegration.enginePlugin],
       },
       model: config.model,
       tools: canvasTools,
@@ -392,6 +398,7 @@ export class CanvasAgent {
   async initialize(): Promise<void> {
     console.info(`[canvas-agent] Initializing for workspace: ${this.config.workspaceId}`);
 
+    await this.memoryIntegration.initialize();
     await this.engine.initialize();
 
     // Start a new session
@@ -521,69 +528,75 @@ export class CanvasAgent {
         model: this.config.model ?? modelConfig.model,
         modelType: modelConfig.modelType,
       });
-      const resultText = await this.engine.run(context, {
-        provider: modelConfig.provider,
-        model: this.config.model ?? modelConfig.model,
-        modelType: modelConfig.modelType,
-        systemPrompt,
-        maxSteps: CANVAS_AGENT_MAX_STEPS,
-        abortSignal: abortController.signal,
-        onClarificationRequest: engineClarificationHandler,
-        onText,
-        onToolCall: (onToolCall || debugTrace)
-          ? (chunk: any) => {
-              // AI SDK v6 uses `input`; older versions use `args`
-              const args = chunk.input ?? chunk.args;
-              console.info('[canvas-agent] tool-call chunk keys:', Object.keys(chunk), 'input:', chunk.input, 'args:', chunk.args);
-              recordTraceToolCall(debugTrace, { name: chunk.toolName, args, toolCallId: chunk.toolCallId });
-              onToolCall?.({ name: chunk.toolName, args, toolCallId: chunk.toolCallId });
-            }
-          : undefined,
-        onToolResult: (onToolResult || debugTrace)
-          ? (chunk: any) => {
-              // AI SDK v6 uses `output`; older versions use `result`
-              const raw = chunk.output ?? chunk.result;
-              console.info('[canvas-agent] tool-result chunk keys:', Object.keys(chunk), 'output:', typeof chunk.output, 'result:', typeof chunk.result);
-              recordTraceToolResult(debugTrace, { name: chunk.toolName, rawResult: raw, toolCallId: chunk.toolCallId });
-              onToolResult?.({
-                name: chunk.toolName,
-                result: typeof raw === 'string' ? raw : JSON.stringify(raw),
-                toolCallId: chunk.toolCallId,
-              });
-            }
-          : undefined,
-        onToolInputStart: onToolInputStart
-          ? (chunk: { id: string; toolName: string }) => {
-              console.info('[canvas-agent] tool-input-start', chunk.toolName, chunk.id);
-              onToolInputStart(chunk);
-            }
-          : undefined,
-        onToolInputDelta: onToolInputDelta
-          ? (chunk: { id: string; delta: string }) => {
-              // Sample log — full delta firehose is too noisy for a long run.
-              if (Math.random() < 0.02) {
-                console.info('[canvas-agent] tool-input-delta (sampled)', chunk.id, chunk.delta.length + 'B');
+      const resultText = await this.memoryIntegration.withRunContext<string>(
+        createCanvasWorkspaceMemoryRunContext({
+          workspaceId: this.config.workspaceId,
+          userText: message,
+        }),
+        () => this.engine.run(context, {
+          provider: modelConfig.provider,
+          model: this.config.model ?? modelConfig.model,
+          modelType: modelConfig.modelType,
+          systemPrompt,
+          maxSteps: CANVAS_AGENT_MAX_STEPS,
+          abortSignal: abortController.signal,
+          onClarificationRequest: engineClarificationHandler,
+          onText,
+          onToolCall: (onToolCall || debugTrace)
+            ? (chunk: any) => {
+                // AI SDK v6 uses `input`; older versions use `args`
+                const args = chunk.input ?? chunk.args;
+                console.info('[canvas-agent] tool-call chunk keys:', Object.keys(chunk), 'input:', chunk.input, 'args:', chunk.args);
+                recordTraceToolCall(debugTrace, { name: chunk.toolName, args, toolCallId: chunk.toolCallId });
+                onToolCall?.({ name: chunk.toolName, args, toolCallId: chunk.toolCallId });
               }
-              onToolInputDelta(chunk);
+            : undefined,
+          onToolResult: (onToolResult || debugTrace)
+            ? (chunk: any) => {
+                // AI SDK v6 uses `output`; older versions use `result`
+                const raw = chunk.output ?? chunk.result;
+                console.info('[canvas-agent] tool-result chunk keys:', Object.keys(chunk), 'output:', typeof chunk.output, 'result:', typeof chunk.result);
+                recordTraceToolResult(debugTrace, { name: chunk.toolName, rawResult: raw, toolCallId: chunk.toolCallId });
+                onToolResult?.({
+                  name: chunk.toolName,
+                  result: typeof raw === 'string' ? raw : JSON.stringify(raw),
+                  toolCallId: chunk.toolCallId,
+                });
+              }
+            : undefined,
+          onToolInputStart: onToolInputStart
+            ? (chunk: { id: string; toolName: string }) => {
+                console.info('[canvas-agent] tool-input-start', chunk.toolName, chunk.id);
+                onToolInputStart(chunk);
+              }
+            : undefined,
+          onToolInputDelta: onToolInputDelta
+            ? (chunk: { id: string; delta: string }) => {
+                // Sample log — full delta firehose is too noisy for a long run.
+                if (Math.random() < 0.02) {
+                  console.info('[canvas-agent] tool-input-delta (sampled)', chunk.id, chunk.delta.length + 'B');
+                }
+                onToolInputDelta(chunk);
+              }
+            : undefined,
+          onToolInputEnd: onToolInputEnd
+            ? (chunk: { id: string }) => {
+                console.info('[canvas-agent] tool-input-end', chunk.id);
+                onToolInputEnd(chunk);
+              }
+            : undefined,
+          onResponse: (msgs: ModelMessage[]) => {
+            for (const msg of msgs) {
+              this.messages.push(msg);
+              responseMessages.push(msg);
             }
-          : undefined,
-        onToolInputEnd: onToolInputEnd
-          ? (chunk: { id: string }) => {
-              console.info('[canvas-agent] tool-input-end', chunk.id);
-              onToolInputEnd(chunk);
-            }
-          : undefined,
-        onResponse: (msgs: ModelMessage[]) => {
-          for (const msg of msgs) {
-            this.messages.push(msg);
-            responseMessages.push(msg);
-          }
-        },
-        onCompacted: (newMessages: ModelMessage[]) => {
-          this.messages = newMessages;
-          context.messages = newMessages;
-        },
-      });
+          },
+          onCompacted: (newMessages: ModelMessage[]) => {
+            this.messages = newMessages;
+            context.messages = newMessages;
+          },
+        }),
+      );
 
       const responseText = resultText || '(no response)';
       recordTraceMessageSnapshot(debugTrace, { systemPrompt, messages: context.messages });

--- a/apps/canvas-workspace/src/main/canvas-agent/memory.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/memory.ts
@@ -1,0 +1,48 @@
+import { homedir } from 'os';
+import { join } from 'path';
+import {
+  createMemoryIntegrationFromEnv,
+  type MemoryIntegration,
+  type MemoryRunContext,
+} from 'pulse-coder-memory-plugin';
+
+const CANVAS_MEMORY_PLUGIN_NAME = 'canvas-workspace-memory';
+
+/**
+ * Workspace-local memory lives alongside the workspace's canvas.json,
+ * notes, images, artifacts, and agent sessions. This keeps the initial
+ * Canvas memory rollout isolated per workspace without moving any existing
+ * Canvas storage paths.
+ */
+export function getCanvasWorkspaceMemoryDir(workspaceId: string): string {
+  return join(homedir(), '.pulse-coder', 'canvas', workspaceId, 'memory');
+}
+
+/**
+ * Reserved for a future global Canvas memory layer shared across workspaces.
+ * The MVP intentionally does not use this path yet.
+ */
+export function getCanvasGlobalMemoryDir(): string {
+  return join(homedir(), '.pulse-coder', 'canvas', 'memory');
+}
+
+export function createCanvasWorkspaceMemoryIntegration(workspaceId: string): MemoryIntegration {
+  return createMemoryIntegrationFromEnv({
+    baseDir: getCanvasWorkspaceMemoryDir(workspaceId),
+    pluginName: CANVAS_MEMORY_PLUGIN_NAME,
+  });
+}
+
+export function createCanvasWorkspaceMemoryRunContext(input: {
+  workspaceId: string;
+  userText: string;
+}): MemoryRunContext {
+  return {
+    platformKey: `canvas-workspace:${input.workspaceId}`,
+    // memory-plugin has session/user scopes but no native workspace scope.
+    // Using the workspace id as the memory session id makes session-scoped
+    // memories behave as workspace-scoped memories for Canvas.
+    sessionId: input.workspaceId,
+    userText: input.userText,
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       pulse-coder-engine:
         specifier: workspace:*
         version: link:../../packages/engine
+      pulse-coder-memory-plugin:
+        specifier: workspace:*
+        version: link:../../packages/memory-plugin
       react:
         specifier: ^18.3.1
         version: 18.3.1


### PR DESCRIPTION
Add workspace-local memory support for Canvas Agent.

- Add Canvas memory helper with workspace-local and reserved global paths
- Register pulse-coder-memory-plugin in Canvas Agent and wrap runs with workspace context
- Add canvas app dependency and unpack better-sqlite3 for Electron packaging

Validation:
- pnpm --filter canvas-workspace typecheck