### PR TITLE
Add skill mentions via `/` trigger in chat

### DIFF
--- a/apps/canvas-workspace/src/main/canvas-agent-ipc.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent-ipc.ts
@@ -6,6 +6,7 @@
  *   canvas-agent:abort             — interrupt the currently-running chat turn
  *   canvas-agent:clarify-answer    — deliver a user reply to a pending clarification
  *   canvas-agent:status            — check if agent is active
+ *   canvas-agent:list-skills       — list skills (name + description) for the / popup
  *   canvas-agent:history           — get current session messages
  *   canvas-agent:sessions          — list all sessions (current + archived)
  *   canvas-agent:new-session       — start a new session
@@ -218,6 +219,18 @@ export function setupCanvasAgentIpc(): void {
     'canvas-agent:status',
     (_event, payload: { workspaceId: string }) => {
       return svc.getStatus(payload.workspaceId);
+    },
+  );
+
+  ipcMain.handle(
+    'canvas-agent:list-skills',
+    async (_event, payload: { workspaceId: string }) => {
+      try {
+        const skills = await svc.listSkills(payload.workspaceId);
+        return { ok: true, skills };
+      } catch (err) {
+        return { ok: false, error: String(err) };
+      }
     },
   );
 

--- a/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
@@ -363,6 +363,7 @@ Set \`command\` to auto-execute a command after the shell is ready (e.g. "npm ru
 
 ## Skills
 - \`skill\`: Load a skill by name to get detailed step-by-step instructions for specialized tasks (e.g. canvas operations via pulse-canvas CLI, canvas-bootstrap for deep-research workspace creation)
+- When the user's message contains a chip like \`@[skill:<name>]\`, treat it as an explicit request to load that skill — call the \`skill\` tool with that name BEFORE doing anything else, then follow the skill's step-by-step guidance.
 
 Use these alongside canvas_* tools for full workspace control.
 
@@ -797,6 +798,19 @@ export class CanvasAgent {
    */
   getMessageCount(): number {
     return this.sessionStore.getMessages().length;
+  }
+
+  /**
+   * List all skills the engine has loaded — name + description only.
+   * Used by the ChatPanel `/`-trigger popup; the full skill body is fetched
+   * via the `skill` tool when the agent actually runs.
+   */
+  listSkills(): Array<{ name: string; description: string }> {
+    const registry = this.engine?.getService?.('skillRegistry') as
+      | { getAll: () => Array<{ name: string; description: string }> }
+      | undefined;
+    if (!registry) return [];
+    return registry.getAll().map(s => ({ name: s.name, description: s.description }));
   }
 
   /**

--- a/apps/canvas-workspace/src/main/canvas-agent/service.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/service.ts
@@ -121,6 +121,17 @@ export class CanvasAgentService {
   }
 
   /**
+   * List skills (name + description) available to the workspace's agent.
+   * Auto-activates the agent so the engine — and the skills plugin — is
+   * initialized before reading the registry.
+   */
+  async listSkills(workspaceId: string): Promise<Array<{ name: string; description: string }>> {
+    await this.activate(workspaceId);
+    const agent = this.agents.get(workspaceId)!;
+    return agent.listSkills();
+  }
+
+  /**
    * Get conversation history for the current session.
    */
   getHistory(workspaceId: string): CanvasAgentMessage[] {

--- a/apps/canvas-workspace/src/preload/index.ts
+++ b/apps/canvas-workspace/src/preload/index.ts
@@ -366,6 +366,9 @@ contextBridge.exposeInMainWorld("canvasWorkspace", {
     getStatus: (workspaceId: string) =>
       ipcRenderer.invoke("canvas-agent:status", { workspaceId }),
 
+    listSkills: (workspaceId: string) =>
+      ipcRenderer.invoke("canvas-agent:list-skills", { workspaceId }),
+
     getHistory: (workspaceId: string) =>
       ipcRenderer.invoke("canvas-agent:history", { workspaceId }),
 

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMentionPopup.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMentionPopup.tsx
@@ -41,9 +41,11 @@ export const ChatMentionPopup = ({
             }}
             onMouseEnter={() => onMentionIndexChange(index)}
           >
-            <span className="chat-mention-item-icon">
-              <MentionNodeIcon size={14} nodeType={nodeType} />
-            </span>
+            {item.type !== 'skill' && (
+              <span className="chat-mention-item-icon">
+                <MentionNodeIcon size={14} nodeType={nodeType} />
+              </span>
+            )}
             <span className="chat-mention-item-label">{item.label}</span>
             {item.type === 'skill' && item.description && (
               <span className="chat-mention-item-description">{item.description}</span>

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMentionPopup.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMentionPopup.tsx
@@ -22,9 +22,11 @@ export const ChatMentionPopup = ({
       const showHeader = previousGroupKey !== groupKey;
       const nodeType = item.type === 'workspace'
         ? 'workspace'
-        : item.type === 'node'
-          ? item.nodeType ?? 'file'
-          : 'file';
+        : item.type === 'skill'
+          ? 'skill'
+          : item.type === 'node'
+            ? item.nodeType ?? 'file'
+            : 'file';
 
       return (
         <div key={`${item.type}-${item.nodeType ?? ''}-${item.workspaceId ?? ''}-${item.label}-${index}`}>
@@ -43,6 +45,9 @@ export const ChatMentionPopup = ({
               <MentionNodeIcon size={14} nodeType={nodeType} />
             </span>
             <span className="chat-mention-item-label">{item.label}</span>
+            {item.type === 'skill' && item.description && (
+              <span className="chat-mention-item-description">{item.description}</span>
+            )}
           </button>
         </div>
       );

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
@@ -1138,6 +1138,16 @@
   text-transform: capitalize;
 }
 
+.chat-mention-item-description {
+  flex: 2;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  color: rgba(55, 53, 47, 0.45);
+}
+
 /* ─── @ Mention chips (inline in messages) ──────────────── */
 
 .chat-mention-chip {
@@ -1239,6 +1249,16 @@
 .chat-mention-chip--clickable.chat-mention-chip--workspace:hover {
   background: rgba(88, 166, 255, 0.16);
   border-color: rgba(88, 166, 255, 0.28);
+}
+
+.chat-mention-chip[data-node-type="skill"],
+.chat-mention-chip--skill {
+  background: rgba(34, 197, 94, 0.08);
+  border-color: rgba(34, 197, 94, 0.2);
+}
+.chat-mention-chip[data-node-type="skill"] .chat-mention-chip-icon,
+.chat-mention-chip--skill .chat-mention-chip-icon {
+  color: rgba(34, 197, 94, 0.85);
 }
 
 /* Input chip variant — inline non-editable mention in contentEditable */

--- a/apps/canvas-workspace/src/renderer/src/components/chat/constants.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/constants.ts
@@ -1,8 +1,10 @@
 import type { MentionItem, QuickAction } from './types';
 
 export const CANVAS_MENTION_PREFIX = 'canvas:';
+export const SKILL_MENTION_PREFIX = 'skill:';
 
 export const MENTION_GROUPS = [
+  { key: 'skill', label: 'Skills' },
   { key: 'file', label: 'File' },
   { key: 'text', label: 'Text' },
   { key: 'mindmap', label: 'Mindmap' },
@@ -50,6 +52,7 @@ export const QUICK_ACTIONS: QuickAction[] = [
 ];
 
 export function getMentionGroupKey(item: MentionItem): MentionGroupKey {
+  if (item.type === 'skill') return 'skill';
   if (item.type === 'workspace') return 'canvas';
   if (item.type === 'file') return 'proj-file';
 

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useMentions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useMentions.ts
@@ -54,6 +54,13 @@ export function useMentions({
   const [attachments, setAttachments] = useState<ChatImageAttachment[]>([]);
   const editableRef = useRef<HTMLDivElement>(null);
   const filesCacheRef = useRef<MentionItem[] | null>(null);
+  const skillsCacheRef = useRef<MentionItem[] | null>(null);
+  /**
+   * Which trigger char opened the popup — '@' lists workspaces/nodes/files,
+   * '/' lists skills. Captured at popup-open time so selectMention knows
+   * which prefix to strip when it splices the chip in.
+   */
+  const mentionTriggerRef = useRef<'@' | '/'>('@');
 
   const clearInput = useCallback(() => {
     setInput('');
@@ -70,7 +77,32 @@ export function useMentions({
     editableRef.current?.focus();
   }, []);
 
-  const buildMentionItems = useCallback(async (query: string) => {
+  const loadSkillItems = useCallback(async (): Promise<MentionItem[]> => {
+    if (skillsCacheRef.current) return skillsCacheRef.current;
+    try {
+      const result = await window.canvasWorkspace.agent.listSkills(workspaceId);
+      skillsCacheRef.current = result.ok && result.skills
+        ? result.skills.map(s => ({ type: 'skill', label: s.name, description: s.description }))
+        : [];
+    } catch {
+      skillsCacheRef.current = [];
+    }
+    return skillsCacheRef.current;
+  }, [workspaceId]);
+
+  const buildMentionItems = useCallback(async (query: string, trigger: '@' | '/') => {
+    if (trigger === '/') {
+      const skills = await loadSkillItems();
+      const normalized = query.toLowerCase();
+      const filtered = normalized
+        ? skills.filter(item =>
+            item.label.toLowerCase().includes(normalized)
+            || (item.description ?? '').toLowerCase().includes(normalized),
+          )
+        : skills;
+      return filtered.slice(0, MENTION_MAX_ITEMS);
+    }
+
     const items: MentionItem[] = [];
 
     if (allWorkspaces) {
@@ -120,7 +152,7 @@ export function useMentions({
     });
 
     return filtered.slice(0, MENTION_MAX_ITEMS);
-  }, [allWorkspaces, nodes, rootFolder, workspaceId]);
+  }, [allWorkspaces, loadSkillItems, nodes, rootFolder, workspaceId]);
 
   const handleInput = useCallback(() => {
     const element = editableRef.current;
@@ -140,15 +172,25 @@ export function useMentions({
     }
 
     const textBeforeCursor = (selection.anchorNode.textContent ?? '').slice(0, selection.anchorOffset);
-    const atMatch = textBeforeCursor.match(/@([^\s@]*)$/);
+    // Trigger on @ (mentions: workspaces/nodes/files) or / (skills). We pick
+    // whichever marker is closer to the cursor so typing "/foo @bar" still
+    // opens the @-popup once the user is past the slash query.
+    const atMatch = textBeforeCursor.match(/@([^\s@/]*)$/);
+    const slashMatch = textBeforeCursor.match(/(?:^|\s)\/([^\s@/]*)$/);
+    const match = atMatch && slashMatch
+      ? (atMatch.index! >= slashMatch.index! ? atMatch : slashMatch)
+      : atMatch ?? slashMatch;
 
-    if (!atMatch) {
+    if (!match) {
       setMentionOpen(false);
       return;
     }
 
+    const trigger: '@' | '/' = match === atMatch ? '@' : '/';
+    mentionTriggerRef.current = trigger;
+
     setMentionIndex(0);
-    void buildMentionItems(atMatch[1]).then(items => {
+    void buildMentionItems(match[1], trigger).then(items => {
       setMentionItems(items);
       setMentionOpen(items.length > 0);
     });
@@ -166,10 +208,11 @@ export function useMentions({
 
     const text = anchorNode.textContent ?? '';
     const before = text.slice(0, anchorOffset);
-    const atIndex = before.lastIndexOf('@');
-    if (atIndex < 0) return;
+    const trigger = mentionTriggerRef.current;
+    const triggerIndex = before.lastIndexOf(trigger);
+    if (triggerIndex < 0) return;
 
-    const beforeAt = text.slice(0, atIndex);
+    const beforeAt = text.slice(0, triggerIndex);
     const afterCursor = text.slice(anchorOffset);
     const chip = createMentionChipElement(item, nodes);
     const parent = anchorNode.parentNode;

--- a/apps/canvas-workspace/src/renderer/src/components/chat/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/types.ts
@@ -27,11 +27,13 @@ export type ToolCallStatus = AgentChatToolCall;
 export type { ChatImageAttachment };
 
 export interface MentionItem {
-  type: 'node' | 'file' | 'workspace';
+  type: 'node' | 'file' | 'workspace' | 'skill';
   label: string;
   nodeType?: CanvasNode['type'];
   path?: string;
   workspaceId?: string;
+  /** For type === 'skill': the skill's description, shown in the popup row. */
+  description?: string;
 }
 
 export interface PendingClarification {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/utils/mentions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/utils/mentions.ts
@@ -131,10 +131,12 @@ export function createMentionChipElement(item: MentionItem, nodes?: CanvasNode[]
     chip.dataset.workspaceId = item.workspaceId;
   }
 
-  const iconSpan = document.createElement('span');
-  iconSpan.className = 'chat-mention-chip-icon';
-  iconSpan.innerHTML = `<svg width="12" height="12" viewBox="0 0 14 14" fill="none">${mentionIconSvg(nodeType)}</svg>`;
-  chip.appendChild(iconSpan);
+  if (!isSkill) {
+    const iconSpan = document.createElement('span');
+    iconSpan.className = 'chat-mention-chip-icon';
+    iconSpan.innerHTML = `<svg width="12" height="12" viewBox="0 0 14 14" fill="none">${mentionIconSvg(nodeType)}</svg>`;
+    chip.appendChild(iconSpan);
+  }
 
   const labelSpan = document.createElement('span');
   labelSpan.className = 'chat-mention-chip-label';
@@ -188,11 +190,6 @@ export function renderUserContent(content: string, nodes?: CanvasNode[]): ReactN
             className: 'chat-mention-chip chat-mention-chip--skill',
             'data-node-type': 'skill',
           } as any,
-          createElement(
-            'span',
-            { className: 'chat-mention-chip-icon' },
-            createElement(MentionNodeIcon, { nodeType: 'skill' }),
-          ),
           createElement('span', { className: 'chat-mention-chip-label' }, skillLabel),
         ),
       );
@@ -239,7 +236,7 @@ export function renderMdWithMentions(content: string, nodes?: CanvasNode[]): str
 
     if (rawLabel.startsWith(SKILL_MENTION_PREFIX)) {
       const skillLabel = rawLabel.slice(SKILL_MENTION_PREFIX.length);
-      return `<span class="chat-mention-chip chat-mention-chip--skill" data-node-type="skill"><span class="chat-mention-chip-icon"><svg width="12" height="12" viewBox="0 0 14 14" fill="none">${mentionIconSvg('skill')}</svg></span><span class="chat-mention-chip-label">${escapeHtml(skillLabel)}</span></span>`;
+      return `<span class="chat-mention-chip chat-mention-chip--skill" data-node-type="skill"><span class="chat-mention-chip-label">${escapeHtml(skillLabel)}</span></span>`;
     }
 
     const node = nodes?.find(item => item.title === rawLabel);

--- a/apps/canvas-workspace/src/renderer/src/components/chat/utils/mentions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/utils/mentions.ts
@@ -1,6 +1,6 @@
 import { createElement, type ReactNode } from 'react';
 import type { CanvasNode } from '../../../types';
-import { CANVAS_MENTION_PREFIX } from '../constants';
+import { CANVAS_MENTION_PREFIX, SKILL_MENTION_PREFIX } from '../constants';
 import type { MentionItem, WorkspaceOption } from '../types';
 import { renderMarkdown } from './markdown';
 
@@ -33,6 +33,8 @@ export function mentionIconSvg(nodeType: string): string {
       return '<circle cx="3.5" cy="7" r="1.2" stroke="currentColor" stroke-width="1.1"/><circle cx="10.5" cy="3.5" r="1.1" stroke="currentColor" stroke-width="1.1"/><circle cx="10.5" cy="7" r="1.1" stroke="currentColor" stroke-width="1.1"/><circle cx="10.5" cy="10.5" r="1.1" stroke="currentColor" stroke-width="1.1"/><path d="M4.7 7L9.4 3.7M4.7 7H9.4M4.7 7L9.4 10.3" stroke="currentColor" stroke-width="1" stroke-linecap="round"/>';
     case 'workspace':
       return '<rect x="1.5" y="1.5" width="11" height="11" rx="1.5" stroke="currentColor" stroke-width="1.2"/><rect x="3.5" y="3.5" width="3" height="3" rx="0.5" stroke="currentColor" stroke-width="1"/><rect x="7.5" y="3.5" width="3" height="3" rx="0.5" stroke="currentColor" stroke-width="1"/><rect x="3.5" y="7.5" width="3" height="3" rx="0.5" stroke="currentColor" stroke-width="1"/>';
+    case 'skill':
+      return '<path d="M7 1.5l1.6 3.4 3.7.5-2.7 2.5.7 3.6L7 9.8l-3.3 1.7.7-3.6L1.7 5.4l3.7-.5L7 1.5z" stroke="currentColor" stroke-width="1.1" stroke-linejoin="round"/>';
     default:
       return '<rect x="2" y="1.5" width="10" height="11" rx="1.5" stroke="currentColor" stroke-width="1.2"/><path d="M4.5 5h5M4.5 7.5h3" stroke="currentColor" stroke-width="1" stroke-linecap="round"/>';
   }
@@ -49,6 +51,7 @@ export function MentionNodeIcon({ nodeType, size = 12 }: { nodeType: string; siz
 }
 
 export function getMentionNodeType(item: MentionItem, nodes?: CanvasNode[]): string {
+  if (item.type === 'skill') return 'skill';
   if (item.type === 'workspace') return 'workspace';
   if (item.type === 'node') return item.nodeType ?? 'file';
 
@@ -108,14 +111,20 @@ export function serializeEditable(element: HTMLElement): string {
 
 export function createMentionChipElement(item: MentionItem, nodes?: CanvasNode[]): HTMLSpanElement {
   const isWorkspace = item.type === 'workspace';
+  const isSkill = item.type === 'skill';
   const nodeType = getMentionNodeType(item, nodes);
   const chip = document.createElement('span');
 
-  chip.className = isWorkspace
-    ? 'chat-mention-chip chat-mention-chip--input chat-mention-chip--workspace'
-    : 'chat-mention-chip chat-mention-chip--input';
+  const classes = ['chat-mention-chip', 'chat-mention-chip--input'];
+  if (isWorkspace) classes.push('chat-mention-chip--workspace');
+  if (isSkill) classes.push('chat-mention-chip--skill');
+  chip.className = classes.join(' ');
   chip.contentEditable = 'false';
-  chip.dataset.mention = isWorkspace ? `${CANVAS_MENTION_PREFIX}${item.label}` : item.label;
+  chip.dataset.mention = isWorkspace
+    ? `${CANVAS_MENTION_PREFIX}${item.label}`
+    : isSkill
+      ? `${SKILL_MENTION_PREFIX}${item.label}`
+      : item.label;
   chip.dataset.nodeType = nodeType;
 
   if (isWorkspace && item.workspaceId) {
@@ -169,6 +178,28 @@ export function renderUserContent(content: string, nodes?: CanvasNode[]): ReactN
       continue;
     }
 
+    if (rawLabel.startsWith(SKILL_MENTION_PREFIX)) {
+      const skillLabel = rawLabel.slice(SKILL_MENTION_PREFIX.length);
+      parts.push(
+        createElement(
+          'span',
+          {
+            key: match.index,
+            className: 'chat-mention-chip chat-mention-chip--skill',
+            'data-node-type': 'skill',
+          } as any,
+          createElement(
+            'span',
+            { className: 'chat-mention-chip-icon' },
+            createElement(MentionNodeIcon, { nodeType: 'skill' }),
+          ),
+          createElement('span', { className: 'chat-mention-chip-label' }, skillLabel),
+        ),
+      );
+      lastIndex = re.lastIndex;
+      continue;
+    }
+
     const node = nodes?.find(item => item.title === rawLabel);
     parts.push(
       createElement(
@@ -204,6 +235,11 @@ export function renderMdWithMentions(content: string, nodes?: CanvasNode[]): str
     if (rawLabel.startsWith(CANVAS_MENTION_PREFIX)) {
       const workspaceLabel = rawLabel.slice(CANVAS_MENTION_PREFIX.length);
       return `<span class="chat-mention-chip chat-mention-chip--workspace" data-node-type="workspace"><span class="chat-mention-chip-icon"><svg width="12" height="12" viewBox="0 0 14 14" fill="none">${mentionIconSvg('workspace')}</svg></span><span class="chat-mention-chip-label">${escapeHtml(workspaceLabel)}</span></span>`;
+    }
+
+    if (rawLabel.startsWith(SKILL_MENTION_PREFIX)) {
+      const skillLabel = rawLabel.slice(SKILL_MENTION_PREFIX.length);
+      return `<span class="chat-mention-chip chat-mention-chip--skill" data-node-type="skill"><span class="chat-mention-chip-icon"><svg width="12" height="12" viewBox="0 0 14 14" fill="none">${mentionIconSvg('skill')}</svg></span><span class="chat-mention-chip-label">${escapeHtml(skillLabel)}</span></span>`;
     }
 
     const node = nodes?.find(item => item.title === rawLabel);

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -689,6 +689,9 @@ export interface AgentApi {
   getStatus: (
     workspaceId: string
   ) => Promise<{ ok: boolean; active: boolean; messageCount: number }>;
+  listSkills: (
+    workspaceId: string
+  ) => Promise<{ ok: boolean; skills?: Array<{ name: string; description: string }>; error?: string }>;
   getHistory: (
     workspaceId: string
   ) => Promise<{ ok: boolean; messages?: AgentChatMessage[] }>;

--- a/packages/engine/src/built-in/skills-plugin/index.ts
+++ b/packages/engine/src/built-in/skills-plugin/index.ts
@@ -130,13 +130,16 @@ export class BuiltInSkillRegistry {
   /**
    * 扫描技能文件
    *
-   * 顺序：项目级 → 用户级。同一文件（按 realpath 去重）只解析一次，避免
-   * 当 cwd === HOME 或目录互为 symlink 时把同一份 SKILL.md 收两遍。
-   * 跨工具的同名 skill 仍由 initialize() 里的 Map.set(name, …) 决定谁覆盖谁。
+   * 顺序：项目级 → 用户级，每段内部 .pulse-coder 排在最前。两层去重：
+   *   1. realpath 去重 — 同一物理文件（symlink / cwd===HOME 等）只解析一次。
+   *   2. 名字去重（大小写不敏感）— 同名 skill 以**先扫到的为准**，匹配
+   *      注释里"优先 .pulse-coder"的意图。这样 ~/.pulse-coder/foo 会盖住
+   *      ~/.codex/foo，而不是反过来。
    */
   private async scanSkills(cwd: string): Promise<SkillInfo[]> {
     const skills: SkillInfo[] = [];
     const seenPaths = new Set<string>();
+    const seenNames = new Set<string>();
 
     const scanPaths = [
       // 项目级技能（优先 .pulse-coder，兼容 .agents / .coder / .claude / .codex）
@@ -170,9 +173,17 @@ export class BuiltInSkillRegistry {
 
           try {
             const skillInfo = this.parseSkillFile(filePath);
-            if (skillInfo) {
-              skills.push(skillInfo);
+            if (!skillInfo) continue;
+
+            const nameKey = skillInfo.name.toLowerCase();
+            if (seenNames.has(nameKey)) {
+              console.debug(
+                `[Skills] Skipping ${filePath}: name "${skillInfo.name}" already loaded from a higher-priority source`
+              );
+              continue;
             }
+            seenNames.add(nameKey);
+            skills.push(skillInfo);
           } catch (error) {
             console.warn(`Failed to parse skill file ${filePath}:`, error);
           }

--- a/packages/engine/src/built-in/skills-plugin/index.ts
+++ b/packages/engine/src/built-in/skills-plugin/index.ts
@@ -5,7 +5,7 @@
 
 import { EnginePlugin, EnginePluginContext } from '../../plugin/EnginePlugin';
 import { Tool } from '../../shared/types';
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync, existsSync, realpathSync } from 'fs';
 import { globSync } from 'glob';
 import matter from 'gray-matter';
 import { homedir } from 'os';
@@ -129,20 +129,28 @@ export class BuiltInSkillRegistry {
 
   /**
    * 扫描技能文件
+   *
+   * 顺序：项目级 → 用户级。同一文件（按 realpath 去重）只解析一次，避免
+   * 当 cwd === HOME 或目录互为 symlink 时把同一份 SKILL.md 收两遍。
+   * 跨工具的同名 skill 仍由 initialize() 里的 Map.set(name, …) 决定谁覆盖谁。
    */
   private async scanSkills(cwd: string): Promise<SkillInfo[]> {
     const skills: SkillInfo[] = [];
+    const seenPaths = new Set<string>();
 
     const scanPaths = [
-      // 项目级技能（优先 .pulse-coder，兼容 .agents / 旧版 .coder 和 .claude）
+      // 项目级技能（优先 .pulse-coder，兼容 .agents / .coder / .claude / .codex）
       { base: cwd, pattern: '.pulse-coder/skills/**/SKILL.md' },
       { base: cwd, pattern: '.agents/skills/**/SKILL.md' },
       { base: cwd, pattern: '.coder/skills/**/SKILL.md' },
       { base: cwd, pattern: '.claude/skills/**/SKILL.md' },
-      // 用户级技能（优先 .pulse-coder，兼容 .agents / 旧版 .coder）
+      { base: cwd, pattern: '.codex/skills/**/SKILL.md' },
+      // 用户级技能（优先 .pulse-coder，兼容 .agents / .coder / .claude / .codex）
       { base: homedir(), pattern: '.pulse-coder/skills/**/SKILL.md' },
       { base: homedir(), pattern: '.agents/skills/**/SKILL.md' },
-      { base: homedir(), pattern: '.coder/skills/**/SKILL.md' }
+      { base: homedir(), pattern: '.coder/skills/**/SKILL.md' },
+      { base: homedir(), pattern: '.claude/skills/**/SKILL.md' },
+      { base: homedir(), pattern: '.codex/skills/**/SKILL.md' }
     ];
 
     for (const { base, pattern } of scanPaths) {
@@ -150,6 +158,16 @@ export class BuiltInSkillRegistry {
         const files = globSync(pattern, { cwd: base, absolute: true });
 
         for (const filePath of files) {
+          let canonical = filePath;
+          try {
+            canonical = realpathSync(filePath);
+          } catch {
+            // realpath can fail for dangling symlinks — fall back to the
+            // glob-returned absolute path so we still dedupe within a run.
+          }
+          if (seenPaths.has(canonical)) continue;
+          seenPaths.add(canonical);
+
           try {
             const skillInfo = this.parseSkillFile(filePath);
             if (skillInfo) {


### PR DESCRIPTION
## Summary
Extends the chat mention system to support skills via a new `/` trigger, complementing the existing `@` trigger for workspaces/nodes/files. Users can now type `/` to search and insert skill mentions, which are rendered as special chips in messages and automatically loaded by the agent when referenced.

## Key Changes

### Chat UI & Mention System
- **Dual-trigger mention popup**: Added `/` trigger alongside `@` for skills; the system picks whichever marker is closer to the cursor
- **Skill caching & filtering**: New `loadSkillItems()` hook that caches skills and filters by name/description
- **Mention trigger tracking**: `mentionTriggerRef` captures which trigger (`@` or `/`) opened the popup, enabling correct prefix stripping during chip insertion
- **Skill chip rendering**: Skills render without icons (star SVG added to icon registry) and display descriptions in the popup; styled with green accent color
- **Skill mention serialization**: Added `SKILL_MENTION_PREFIX` (`skill:`) constant; skills serialize as `@[skill:<name>]` in messages and are rendered as special chips in both user content and markdown

### Backend & IPC
- **Agent skill listing**: New `listSkills()` method on `CanvasAgent` that queries the skill registry (name + description only)
- **IPC handler**: Added `canvas-agent:list-skills` handler in main process to expose skills to the renderer
- **Service layer**: `CanvasAgentService.listSkills()` auto-activates the agent before reading the registry
- **Preload API**: Exposed `window.canvasWorkspace.agent.listSkills()` for renderer access

### Skills Plugin Improvements
- **Deduplication**: Implemented two-level deduplication in `scanSkills()`:
  1. **Path-based** (via `realpathSync`): Prevents parsing the same physical file twice (handles symlinks, cwd===HOME, etc.)
  2. **Name-based** (case-insensitive): First-seen skill wins, ensuring `.pulse-coder` sources override user-level ones
- **Extended directory support**: Added `.codex` to the list of scanned skill directories (project and user level)
- **Improved logging**: Added debug message when skipping duplicate skill names

### Type & Constant Updates
- Extended `MentionItem` type to include `'skill'` type and optional `description` field
- Added `SKILL_MENTION_PREFIX` constant and updated `MENTION_GROUPS` to include skills
- Updated `getMentionGroupKey()` to handle skill items

### Agent Prompt
- Updated agent instructions to clarify that explicit skill chips (`@[skill:<name>]`) should be loaded immediately before other actions

## Implementation Details
- Skills are fetched on-demand when the `/` popup opens and cached for the session
- The mention system uses regex matching to detect both `@` and `/` triggers, selecting the one closest to the cursor
- Skill chips are rendered without icons in the popup but include descriptions for better discoverability
- The skills plugin now uses `realpathSync` to canonicalize paths before deduplication, with fallback to the glob-returned path for dangling symlinks

https://claude.ai/code/session_01EFoYxyBo1V9B5hKxXgTQC1