### PR TITLE
feat(canvas-workspace): add Agent settings tab with Install Skills

### DIFF
--- a/apps/canvas-workspace/src/main/skill-installer.ts
+++ b/apps/canvas-workspace/src/main/skill-installer.ts
@@ -77,42 +77,53 @@ pulse-canvas workspace list --format json
 - After completing work, write results back to the canvas for the user to review
 `;
 
-async function installSkillFile(): Promise<{ ok: boolean; paths: string[]; error?: string }> {
-  const installed: string[] = [];
+export interface SkillTargetResult {
+  path: string;
+  ok: boolean;
+  error?: string;
+}
+
+async function installSingleTarget(dir: string): Promise<SkillTargetResult> {
+  const targetPath = join(dir, 'SKILL.md');
   try {
-    for (const dir of GLOBAL_SKILL_DIRS) {
-      await fs.mkdir(dir, { recursive: true });
-      const targetPath = join(dir, 'SKILL.md');
-      await fs.writeFile(targetPath, SKILL_CONTENT, 'utf-8');
-      installed.push(targetPath);
-    }
-    return { ok: true, paths: installed };
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(targetPath, SKILL_CONTENT, 'utf-8');
+    return { path: targetPath, ok: true };
   } catch (err) {
-    return { ok: false, paths: installed, error: String(err) };
+    return { path: targetPath, ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+async function checkSingleTarget(dir: string): Promise<SkillTargetResult> {
+  const targetPath = join(dir, 'SKILL.md');
+  try {
+    await fs.access(targetPath);
+    return { path: targetPath, ok: true };
+  } catch {
+    return { path: targetPath, ok: false };
   }
 }
 
 export function setupSkillInstallerIpc(): void {
   ipcMain.handle('skills:install', async () => {
-    const skillResult = await installSkillFile();
-    if (!skillResult.ok) {
-      return {
-        ok: false,
-        skillsInstalled: false,
-        cliInstalled: false,
-        error: skillResult.error,
-        manualCommand: null,
-      };
-    }
-
-    // CLI is not published yet — provide local build instructions
+    const results = await Promise.all(GLOBAL_SKILL_DIRS.map(installSingleTarget));
+    const ok = results.every((r) => r.ok);
     return {
-      ok: true,
-      skillsInstalled: true,
-      skillsPaths: skillResult.paths,
+      ok,
+      skillsInstalled: ok,
+      results,
       cliInstalled: false,
-      manualCommand: 'cd <project-root> && pnpm --filter @pulse-coder/canvas-cli build && pnpm link --global --filter @pulse-coder/canvas-cli',
+      manualCommand:
+        'cd <project-root> && pnpm --filter @pulse-coder/canvas-cli build && pnpm link --global --filter @pulse-coder/canvas-cli',
       cliError: null,
+    };
+  });
+
+  ipcMain.handle('skills:status', async () => {
+    const results = await Promise.all(GLOBAL_SKILL_DIRS.map(checkSingleTarget));
+    return {
+      installed: results.every((r) => r.ok),
+      results,
     };
   });
 }

--- a/apps/canvas-workspace/src/preload/index.ts
+++ b/apps/canvas-workspace/src/preload/index.ts
@@ -187,7 +187,8 @@ contextBridge.exposeInMainWorld("canvasWorkspace", {
   },
 
   skills: {
-    install: () => ipcRenderer.invoke("skills:install")
+    install: () => ipcRenderer.invoke("skills:install"),
+    status: () => ipcRenderer.invoke("skills:status")
   },
 
   iframe: {

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.css
@@ -1,0 +1,160 @@
+.agent-section {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
+}
+
+.agent-section-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px 24px;
+}
+
+.agent-section-card {
+  border: 1px solid rgba(55, 53, 47, 0.09);
+  border-radius: 10px;
+  padding: 16px 18px;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.agent-section-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.agent-section-card-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #37352f;
+  margin-bottom: 4px;
+}
+
+.agent-section-card-desc {
+  font-size: 12px;
+  color: rgba(55, 53, 47, 0.65);
+  line-height: 1.5;
+  max-width: 540px;
+}
+
+.agent-section-card-desc code {
+  background: rgba(55, 53, 47, 0.06);
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 11.5px;
+}
+
+.agent-section-primary-btn {
+  border: none;
+  background: #2383e2;
+  color: #fff;
+  font-size: 12.5px;
+  font-weight: 600;
+  border-radius: 6px;
+  padding: 7px 14px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.agent-section-primary-btn:hover {
+  background: #1f76cc;
+}
+
+.agent-section-primary-btn:disabled {
+  background: rgba(35, 131, 226, 0.45);
+  cursor: not-allowed;
+}
+
+.agent-section-secondary-btn {
+  border: 1px solid rgba(55, 53, 47, 0.12);
+  background: #fff;
+  color: #37352f;
+  font-size: 12.5px;
+  font-weight: 500;
+  border-radius: 6px;
+  padding: 6px 14px;
+  cursor: pointer;
+}
+
+.agent-section-secondary-btn:hover {
+  background: rgba(55, 53, 47, 0.04);
+}
+
+.agent-section-error {
+  background: rgba(226, 70, 70, 0.08);
+  color: #b3261e;
+  font-size: 12px;
+  padding: 8px 10px;
+  border-radius: 6px;
+}
+
+.agent-section-results {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.agent-section-result {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: rgba(55, 53, 47, 0.03);
+}
+
+.agent-section-result-icon {
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.4;
+  flex-shrink: 0;
+  width: 16px;
+  text-align: center;
+}
+
+.agent-section-result--ok .agent-section-result-icon {
+  color: #0a8754;
+}
+
+.agent-section-result--fail .agent-section-result-icon {
+  color: #b3261e;
+}
+
+.agent-section-result--fail {
+  background: rgba(226, 70, 70, 0.06);
+}
+
+.agent-section-result-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.agent-section-result-path {
+  font-size: 11.5px;
+  color: #37352f;
+  word-break: break-all;
+  background: transparent;
+  padding: 0;
+}
+
+.agent-section-result-error {
+  font-size: 11px;
+  color: #b3261e;
+  margin-top: 3px;
+}
+
+.agent-section-footer {
+  border-top: 1px solid rgba(55, 53, 47, 0.07);
+  padding: 12px 24px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
@@ -1,0 +1,121 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { SkillsInstallResult, SkillsStatusResult, SkillTargetResult } from '../../types';
+import { useAppShell } from '../AppShellProvider';
+import './AgentSection.css';
+
+interface AgentSectionProps {
+  onClose: () => void;
+}
+
+export const AgentSection = ({ onClose }: AgentSectionProps) => {
+  const { notify } = useAppShell();
+  const [status, setStatus] = useState<SkillsStatusResult | null>(null);
+  const [lastResults, setLastResults] = useState<SkillTargetResult[] | null>(null);
+  const [installing, setInstalling] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadStatus = useCallback(async () => {
+    try {
+      const s = await window.canvasWorkspace.skills.status();
+      setStatus(s);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadStatus();
+  }, [loadStatus]);
+
+  const install = useCallback(async () => {
+    setInstalling(true);
+    setError(null);
+    try {
+      const result: SkillsInstallResult = await window.canvasWorkspace.skills.install();
+      setLastResults(result.results);
+      await loadStatus();
+      const failed = result.results.filter((r) => !r.ok);
+      if (failed.length === 0) {
+        notify({
+          tone: 'success',
+          title: 'Canvas skill installed',
+          description: `Wrote ${result.results.length} target${result.results.length === 1 ? '' : 's'}`,
+        });
+      } else {
+        notify({
+          tone: 'error',
+          title: 'Some targets failed',
+          description: `${failed.length} of ${result.results.length} target${result.results.length === 1 ? '' : 's'} failed — see details below`,
+        });
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setError(msg);
+      notify({ tone: 'error', title: 'Install failed', description: msg });
+    } finally {
+      setInstalling(false);
+    }
+  }, [loadStatus, notify]);
+
+  const displayResults = lastResults ?? status?.results ?? [];
+  const allInstalled = status?.installed ?? false;
+  const buttonLabel = installing
+    ? 'Installing…'
+    : allInstalled
+      ? 'Reinstall Canvas Skill'
+      : 'Install Canvas Skill';
+
+  return (
+    <div className="agent-section">
+      <div className="agent-section-body">
+        <div className="agent-section-card">
+          <div className="agent-section-card-header">
+            <div>
+              <div className="agent-section-card-title">Canvas Skill</div>
+              <div className="agent-section-card-desc">
+                Install the <code>canvas</code> skill into Pulse Coder, Claude Code, and Codex
+                global skill directories so each agent can read and write this workspace via the{' '}
+                <code>pulse-canvas</code> CLI.
+              </div>
+            </div>
+            <button
+              type="button"
+              className="agent-section-primary-btn"
+              onClick={() => void install()}
+              disabled={installing}
+            >
+              {buttonLabel}
+            </button>
+          </div>
+
+          {error && <div className="agent-section-error">{error}</div>}
+
+          {displayResults.length > 0 && (
+            <ul className="agent-section-results" aria-label="Skill install targets">
+              {displayResults.map((r) => (
+                <li
+                  key={r.path}
+                  className={`agent-section-result${r.ok ? ' agent-section-result--ok' : ' agent-section-result--fail'}`}
+                >
+                  <span className="agent-section-result-icon" aria-hidden>
+                    {r.ok ? '✓' : '✗'}
+                  </span>
+                  <div className="agent-section-result-body">
+                    <code className="agent-section-result-path">{r.path}</code>
+                    {r.error && <div className="agent-section-result-error">{r.error}</div>}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      <div className="agent-section-footer">
+        <button type="button" className="agent-section-secondary-btn" onClick={onClose}>
+          Close
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/index.tsx
@@ -18,9 +18,10 @@ import { useEffect, useState } from 'react';
 import { SettingsDrawer } from '../SettingsDrawer';
 import { ModelsSection, useCanvasModels } from '../chat/ModelSettings';
 import { ReplyStyleSection, usePromptProfile } from '../chat/PromptSettings';
+import { AgentSection } from './AgentSection';
 import './index.css';
 
-export type SettingsSection = 'models' | 'reply-style';
+export type SettingsSection = 'models' | 'reply-style' | 'agent';
 
 interface SectionDef {
   id: SettingsSection;
@@ -41,6 +42,12 @@ const SECTIONS: SectionDef[] = [
     label: 'Reply Style',
     description: 'Preset + custom prompt',
     title: 'Reply Style & Custom Prompt',
+  },
+  {
+    id: 'agent',
+    label: 'Agent',
+    description: 'Skills & external agent setup',
+    title: 'Agent',
   },
 ];
 
@@ -111,6 +118,7 @@ export const Settings = ({ open, initialSection, onClose }: SettingsProps) => {
               onReset={promptProfile.reset}
             />
           )}
+          {activeSection === 'agent' && <AgentSection onClose={onClose} />}
         </div>
       </div>
     </SettingsDrawer>

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -362,18 +362,30 @@ export interface DialogApi {
   openFolder: () => Promise<{ ok: boolean; canceled?: boolean; folderPath?: string; error?: string }>;
 }
 
+export interface SkillTargetResult {
+  path: string;
+  ok: boolean;
+  error?: string;
+}
+
 export interface SkillsInstallResult {
   ok: boolean;
   skillsInstalled: boolean;
-  skillsPath?: string;
+  results: SkillTargetResult[];
   cliInstalled: boolean;
   manualCommand?: string | null;
   cliError?: string | null;
   error?: string;
 }
 
+export interface SkillsStatusResult {
+  installed: boolean;
+  results: SkillTargetResult[];
+}
+
 export interface SkillsApi {
   install: () => Promise<SkillsInstallResult>;
+  status: () => Promise<SkillsStatusResult>;
 }
 
 export interface ChatImageAttachment {


### PR DESCRIPTION
Adds a new "Agent" section in Settings that installs the canvas skill into Pulse Coder, Claude Code, and Codex global skill directories. The panel detects existing installs (button toggles Install/Reinstall) and shows per-target status with the actual written paths, so users can verify where files landed.

- New skills:status IPC for install detection
- Structured per-target results from skills:install (path/ok/error)
- AgentSection panel with status list + notify-based toast summary