### PR TITLE
refactor(canvas-workspace): rename skill from canvas to pulse-canvas

### DIFF
--- a/apps/canvas-workspace/src/main/skill-installer.ts
+++ b/apps/canvas-workspace/src/main/skill-installer.ts
@@ -3,14 +3,23 @@ import { promises as fs } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 
-const GLOBAL_SKILL_DIRS = [
-  join(homedir(), '.pulse-coder', 'skills', 'canvas'),
-  join(homedir(), '.claude', 'skills', 'canvas'),
-  join(homedir(), '.codex', 'skills', 'canvas'),
+const SKILL_NAME = 'pulse-canvas';
+const LEGACY_SKILL_NAMES = ['canvas'];
+
+const SKILL_PARENT_DIRS = [
+  join(homedir(), '.pulse-coder', 'skills'),
+  join(homedir(), '.claude', 'skills'),
+  join(homedir(), '.codex', 'skills'),
 ];
 
+const GLOBAL_SKILL_DIRS = SKILL_PARENT_DIRS.map((dir) => join(dir, SKILL_NAME));
+
+const LEGACY_SKILL_DIRS = SKILL_PARENT_DIRS.flatMap((dir) =>
+  LEGACY_SKILL_NAMES.map((name) => join(dir, name)),
+);
+
 const SKILL_CONTENT = `---
-name: canvas
+name: pulse-canvas
 description: Operate Pulse Canvas workspaces — read user-curated context, write results, create nodes
 version: 1.0.0
 ---
@@ -104,6 +113,24 @@ async function checkSingleTarget(dir: string): Promise<SkillTargetResult> {
   }
 }
 
+async function checkLegacyDir(dir: string): Promise<{ dir: string; exists: boolean }> {
+  try {
+    await fs.access(dir);
+    return { dir, exists: true };
+  } catch {
+    return { dir, exists: false };
+  }
+}
+
+async function removeLegacyDir(dir: string): Promise<SkillTargetResult> {
+  try {
+    await fs.rm(dir, { recursive: true, force: true });
+    return { path: dir, ok: true };
+  } catch (err) {
+    return { path: dir, ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
 export function setupSkillInstallerIpc(): void {
   ipcMain.handle('skills:install', async () => {
     const results = await Promise.all(GLOBAL_SKILL_DIRS.map(installSingleTarget));
@@ -120,9 +147,26 @@ export function setupSkillInstallerIpc(): void {
   });
 
   ipcMain.handle('skills:status', async () => {
-    const results = await Promise.all(GLOBAL_SKILL_DIRS.map(checkSingleTarget));
+    const [results, legacy] = await Promise.all([
+      Promise.all(GLOBAL_SKILL_DIRS.map(checkSingleTarget)),
+      Promise.all(LEGACY_SKILL_DIRS.map(checkLegacyDir)),
+    ]);
     return {
       installed: results.every((r) => r.ok),
+      results,
+      legacyDirs: legacy.filter((l) => l.exists).map((l) => l.dir),
+    };
+  });
+
+  ipcMain.handle('skills:cleanup-legacy', async () => {
+    const present = (
+      await Promise.all(LEGACY_SKILL_DIRS.map(checkLegacyDir))
+    )
+      .filter((l) => l.exists)
+      .map((l) => l.dir);
+    const results = await Promise.all(present.map(removeLegacyDir));
+    return {
+      ok: results.every((r) => r.ok),
       results,
     };
   });

--- a/apps/canvas-workspace/src/preload/index.ts
+++ b/apps/canvas-workspace/src/preload/index.ts
@@ -188,7 +188,8 @@ contextBridge.exposeInMainWorld("canvasWorkspace", {
 
   skills: {
     install: () => ipcRenderer.invoke("skills:install"),
-    status: () => ipcRenderer.invoke("skills:status")
+    status: () => ipcRenderer.invoke("skills:status"),
+    cleanupLegacy: () => ipcRenderer.invoke("skills:cleanup-legacy")
   },
 
   iframe: {

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.css
@@ -93,6 +93,59 @@
   border-radius: 6px;
 }
 
+.agent-section-warning {
+  background: rgba(217, 119, 6, 0.07);
+  border: 1px solid rgba(217, 119, 6, 0.22);
+  border-radius: 8px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.agent-section-warning-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.agent-section-warning-title {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: #92400e;
+  margin-bottom: 3px;
+}
+
+.agent-section-warning-title code,
+.agent-section-warning-desc code {
+  background: rgba(217, 119, 6, 0.12);
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 11.5px;
+}
+
+.agent-section-warning-desc {
+  font-size: 11.5px;
+  color: #78350f;
+  line-height: 1.5;
+}
+
+.agent-section-warning-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.agent-section-warning-list code {
+  font-size: 11px;
+  color: #78350f;
+  word-break: break-all;
+}
+
 .agent-section-results {
   list-style: none;
   margin: 0;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
@@ -12,6 +12,7 @@ export const AgentSection = ({ onClose }: AgentSectionProps) => {
   const [status, setStatus] = useState<SkillsStatusResult | null>(null);
   const [lastResults, setLastResults] = useState<SkillTargetResult[] | null>(null);
   const [installing, setInstalling] = useState(false);
+  const [cleaningLegacy, setCleaningLegacy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const loadStatus = useCallback(async () => {
@@ -38,7 +39,7 @@ export const AgentSection = ({ onClose }: AgentSectionProps) => {
       if (failed.length === 0) {
         notify({
           tone: 'success',
-          title: 'Canvas skill installed',
+          title: 'Pulse Canvas skill installed',
           description: `Wrote ${result.results.length} target${result.results.length === 1 ? '' : 's'}`,
         });
       } else {
@@ -57,13 +58,41 @@ export const AgentSection = ({ onClose }: AgentSectionProps) => {
     }
   }, [loadStatus, notify]);
 
+  const cleanupLegacy = useCallback(async () => {
+    setCleaningLegacy(true);
+    try {
+      const result = await window.canvasWorkspace.skills.cleanupLegacy();
+      await loadStatus();
+      const failed = result.results.filter((r) => !r.ok);
+      if (failed.length === 0) {
+        notify({
+          tone: 'success',
+          title: 'Legacy skill dirs removed',
+          description: `Cleaned ${result.results.length} director${result.results.length === 1 ? 'y' : 'ies'}`,
+        });
+      } else {
+        notify({
+          tone: 'error',
+          title: 'Cleanup partially failed',
+          description: `${failed.length} of ${result.results.length} could not be removed`,
+        });
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      notify({ tone: 'error', title: 'Cleanup failed', description: msg });
+    } finally {
+      setCleaningLegacy(false);
+    }
+  }, [loadStatus, notify]);
+
   const displayResults = lastResults ?? status?.results ?? [];
   const allInstalled = status?.installed ?? false;
+  const legacyDirs = status?.legacyDirs ?? [];
   const buttonLabel = installing
     ? 'Installing…'
     : allInstalled
-      ? 'Reinstall Canvas Skill'
-      : 'Install Canvas Skill';
+      ? 'Reinstall Pulse Canvas Skill'
+      : 'Install Pulse Canvas Skill';
 
   return (
     <div className="agent-section">
@@ -71,9 +100,9 @@ export const AgentSection = ({ onClose }: AgentSectionProps) => {
         <div className="agent-section-card">
           <div className="agent-section-card-header">
             <div>
-              <div className="agent-section-card-title">Canvas Skill</div>
+              <div className="agent-section-card-title">Pulse Canvas Skill</div>
               <div className="agent-section-card-desc">
-                Install the <code>canvas</code> skill into Pulse Coder, Claude Code, and Codex
+                Install the <code>pulse-canvas</code> skill into Pulse Coder, Claude Code, and Codex
                 global skill directories so each agent can read and write this workspace via the{' '}
                 <code>pulse-canvas</code> CLI.
               </div>
@@ -89,6 +118,37 @@ export const AgentSection = ({ onClose }: AgentSectionProps) => {
           </div>
 
           {error && <div className="agent-section-error">{error}</div>}
+
+          {legacyDirs.length > 0 && (
+            <div className="agent-section-warning">
+              <div className="agent-section-warning-header">
+                <div>
+                  <div className="agent-section-warning-title">
+                    Legacy <code>canvas</code> skill detected
+                  </div>
+                  <div className="agent-section-warning-desc">
+                    The skill was renamed to <code>pulse-canvas</code>. Remove the old directories
+                    to avoid agents loading both versions.
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  className="agent-section-secondary-btn"
+                  onClick={() => void cleanupLegacy()}
+                  disabled={cleaningLegacy}
+                >
+                  {cleaningLegacy ? 'Removing…' : 'Remove legacy dirs'}
+                </button>
+              </div>
+              <ul className="agent-section-warning-list">
+                {legacyDirs.map((dir) => (
+                  <li key={dir}>
+                    <code>{dir}</code>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
 
           {displayResults.length > 0 && (
             <ul className="agent-section-results" aria-label="Skill install targets">

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -381,11 +381,18 @@ export interface SkillsInstallResult {
 export interface SkillsStatusResult {
   installed: boolean;
   results: SkillTargetResult[];
+  legacyDirs: string[];
+}
+
+export interface SkillsCleanupResult {
+  ok: boolean;
+  results: SkillTargetResult[];
 }
 
 export interface SkillsApi {
   install: () => Promise<SkillsInstallResult>;
   status: () => Promise<SkillsStatusResult>;
+  cleanupLegacy: () => Promise<SkillsCleanupResult>;
 }
 
 export interface ChatImageAttachment {


### PR DESCRIPTION
- Install target is now skills/pulse-canvas/ (was skills/canvas/)
- Frontmatter name updated to pulse-canvas
- skills:status now reports legacy canvas/ dirs
- New skills:cleanup-legacy IPC + warning banner with one-click cleanup in AgentSection so users can remove the old skill safely