### PR TITLE
feat(canvas-cli): add `agent send` to deliver input to running agent …

### DIFF
--- a/apps/canvas-workspace/src/main/__tests__/agent-session-send.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/agent-session-send.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// Mock pty-manager since node-pty / electron are not available in test env.
+const sessionWrites: Array<{ id: string; data: string }> = [];
+const liveSessions = new Set<string>();
+
+vi.mock('../pty-manager', () => ({
+  hasSession: (id: string) => liveSessions.has(id),
+  writeToSession: (id: string, data: string) => {
+    if (!liveSessions.has(id)) return false;
+    sessionWrites.push({ id, data });
+    return true;
+  },
+}));
+
+// Mock canvas-storage to load from a temp directory we control.
+let mockCanvas: { nodes: Array<Record<string, unknown>> } | null = null;
+vi.mock('../canvas-storage', () => ({
+  readCanvasFull: async () => ({ data: mockCanvas }),
+}));
+
+import { sendInputToAgentNode } from '../agent-session-send';
+
+let tmp: string;
+
+beforeEach(() => {
+  sessionWrites.length = 0;
+  liveSessions.clear();
+  mockCanvas = null;
+  tmp = join(tmpdir(), `agent-send-${Date.now()}`);
+});
+
+afterEach(async () => {
+  await fs.rm(tmp, { recursive: true, force: true }).catch(() => {});
+});
+
+describe('sendInputToAgentNode', () => {
+  it('fails when the workspace cannot be loaded', async () => {
+    mockCanvas = null;
+    const r = await sendInputToAgentNode({ workspaceId: 'ws', nodeId: 'n', input: 'hi' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('workspace_not_found');
+  });
+
+  it('fails when the node is missing', async () => {
+    mockCanvas = { nodes: [] };
+    const r = await sendInputToAgentNode({ workspaceId: 'ws', nodeId: 'missing', input: 'hi' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('node_not_found');
+  });
+
+  it('fails when the node is not an agent', async () => {
+    mockCanvas = {
+      nodes: [{ id: 'n1', type: 'file', title: 'foo', data: {} }],
+    };
+    const r = await sendInputToAgentNode({ workspaceId: 'ws', nodeId: 'n1', input: 'hi' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('wrong_node_type');
+  });
+
+  it('fails when the agent is not running', async () => {
+    mockCanvas = {
+      nodes: [{ id: 'n1', type: 'agent', title: 'foo', data: { status: 'idle' } }],
+    };
+    const r = await sendInputToAgentNode({ workspaceId: 'ws', nodeId: 'n1', input: 'hi' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('not_running');
+  });
+
+  it('fails when sessionId is missing or PTY is gone', async () => {
+    mockCanvas = {
+      nodes: [{ id: 'n1', type: 'agent', title: 'foo', data: { status: 'running', sessionId: 'sess-dead' } }],
+    };
+    // sess-dead is not in liveSessions
+    const r = await sendInputToAgentNode({ workspaceId: 'ws', nodeId: 'n1', input: 'hi' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('no_session');
+  });
+
+  it('writes body then \\r in order with a delay, and strips trailing newlines', async () => {
+    mockCanvas = {
+      nodes: [{ id: 'n1', type: 'agent', title: 'foo', data: { status: 'running', sessionId: 'sess-1' } }],
+    };
+    liveSessions.add('sess-1');
+
+    const r = await sendInputToAgentNode({
+      workspaceId: 'ws',
+      nodeId: 'n1',
+      input: 'do the thing\n',
+    });
+
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.bytesSent).toBe('do the thing'.length + 1);
+      expect(r.nodeId).toBe('n1');
+    }
+    expect(sessionWrites).toEqual([
+      { id: 'sess-1', data: 'do the thing' },
+      { id: 'sess-1', data: '\r' },
+    ]);
+  });
+
+  it('still sends Enter when the body is empty', async () => {
+    mockCanvas = {
+      nodes: [{ id: 'n1', type: 'agent', title: 'foo', data: { status: 'running', sessionId: 'sess-1' } }],
+    };
+    liveSessions.add('sess-1');
+
+    const r = await sendInputToAgentNode({ workspaceId: 'ws', nodeId: 'n1', input: '' });
+    expect(r.ok).toBe(true);
+    expect(sessionWrites).toEqual([{ id: 'sess-1', data: '\r' }]);
+  });
+});

--- a/apps/canvas-workspace/src/main/agent-session-send.ts
+++ b/apps/canvas-workspace/src/main/agent-session-send.ts
@@ -1,0 +1,109 @@
+/**
+ * Send follow-up input to a running agent node's PTY session.
+ *
+ * Used by both the in-process Canvas Agent tool (`canvas_send_to_agent`)
+ * and the loopback runtime-control HTTP server, so external CLIs can
+ * deliver input to agent nodes the same way the Canvas Agent does.
+ *
+ * The 120ms gap between body and CR is load-bearing for ratatui-style
+ * TUI editors (Codex) that distinguish paste from keystroke by timing —
+ * see the comment at the writeToSession call site for the full story.
+ */
+
+import { readCanvasFull } from './canvas-storage';
+import { hasSession, writeToSession } from './pty-manager';
+
+export interface SendInputToAgentNodeInput {
+  workspaceId: string;
+  nodeId: string;
+  input: string;
+}
+
+export type SendInputToAgentNodeResult =
+  | { ok: true; nodeId: string; bytesSent: number }
+  | { ok: false; error: string; code: SendErrorCode };
+
+export type SendErrorCode =
+  | 'workspace_not_found'
+  | 'node_not_found'
+  | 'wrong_node_type'
+  | 'not_running'
+  | 'no_session'
+  | 'write_failed';
+
+const SUBMIT_DELAY_MS = 120;
+
+export async function sendInputToAgentNode(
+  input: SendInputToAgentNodeInput,
+): Promise<SendInputToAgentNodeResult> {
+  const { workspaceId, nodeId } = input;
+  const text = input.input ?? '';
+
+  const { data: canvas } = await readCanvasFull(workspaceId);
+  if (!canvas) {
+    return { ok: false, error: `workspace not found: ${workspaceId}`, code: 'workspace_not_found' };
+  }
+
+  const nodes = canvas.nodes ?? [];
+  const node = nodes.find((n) => n.id === nodeId);
+  if (!node) {
+    return { ok: false, error: `node not found: ${nodeId}`, code: 'node_not_found' };
+  }
+  if (node.type !== 'agent') {
+    return {
+      ok: false,
+      error: `node "${nodeId}" is type "${node.type}", not "agent"`,
+      code: 'wrong_node_type',
+    };
+  }
+
+  const status = (node.data?.status as string | undefined) ?? 'idle';
+  if (status !== 'running') {
+    return {
+      ok: false,
+      error: `agent node "${node.title ?? nodeId}" is not running (status="${status}")`,
+      code: 'not_running',
+    };
+  }
+
+  const sessionId = (node.data?.sessionId as string | undefined) ?? '';
+  if (!sessionId || !hasSession(sessionId)) {
+    return {
+      ok: false,
+      error: `agent node "${node.title ?? nodeId}" has no active PTY session`,
+      code: 'no_session',
+    };
+  }
+
+  // Strip any trailing CR/LF the caller might have included so we
+  // control the submit signal ourselves.
+  const body = text.replace(/[\r\n]+$/, '');
+
+  // Write body and Enter as TWO separate writes with a small gap.
+  //
+  // Some TUI agents (Codex) distinguish "paste" from "keystroke" by
+  // timing: if the text body and the \r arrive in the same read, the \r
+  // gets absorbed into the editor buffer as a literal newline and the
+  // prompt is never submitted. Writing the body, yielding for ~120ms,
+  // then writing \r as a second call makes the Enter arrive as an
+  // independent keystroke. Claude Code is happy either way.
+  if (body) {
+    if (!writeToSession(sessionId, body)) {
+      return {
+        ok: false,
+        error: `failed to write to PTY session ${sessionId} (session disappeared)`,
+        code: 'write_failed',
+      };
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, SUBMIT_DELAY_MS));
+  }
+  if (!writeToSession(sessionId, '\r')) {
+    return {
+      ok: false,
+      error: `failed to write Enter to PTY session ${sessionId} (session disappeared)`,
+      code: 'write_failed',
+    };
+  }
+
+  return { ok: true, nodeId, bytesSent: body.length + 1 };
+}

--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -21,7 +21,7 @@ import {
   readNodeDetail,
   formatSummaryForPrompt,
 } from './context-builder';
-import { hasSession, writeToSession } from '../pty-manager';
+import { sendInputToAgentNode } from '../agent-session-send';
 import { generateHTML } from '../html-generator';
 import { readWorkspaceMeta } from './workspace-meta';
 import {
@@ -1395,61 +1395,40 @@ ${outline}`;
         const nodeId = input.nodeId as string;
         const text = (input.input as string) ?? '';
 
-        const canvas = await loadCanvas(workspaceId);
-        if (!canvas) return 'Error: workspace not found';
+        const result = await sendInputToAgentNode({
+          workspaceId,
+          nodeId,
+          input: text,
+        });
 
-        const node = canvas.nodes.find(n => n.id === nodeId);
-        if (!node) return `Error: node not found: ${nodeId}`;
-        if (node.type !== 'agent') {
-          return `Error: canvas_send_to_agent only works on agent nodes (got "${node.type}"). ` +
-            'For terminal nodes use the MCP `canvas_exec` tool; for file/frame nodes use `canvas_update_node`.';
-        }
-
-        const status = (node.data.status as string) ?? 'idle';
-        if (status !== 'running') {
-          return `Error: agent node "${node.title}" is not running (status="${status}"). ` +
-            'The agent must have been launched (status="running") before you can send follow-up input. ' +
-            'Create a new agent node with a prompt, or ask the user to launch this one.';
-        }
-
-        const sessionId = (node.data.sessionId as string) ?? '';
-        if (!sessionId || !hasSession(sessionId)) {
-          return `Error: agent node "${node.title}" has no active PTY session. ` +
-            'The agent node must be open in the canvas UI — closing or collapsing the node tears ' +
-            'down its PTY. Ask the user to reopen the node, or relaunch the agent.';
-        }
-
-        // Strip any trailing CR/LF the caller might have included so we
-        // control the submit signal ourselves.
-        const body = text.replace(/[\r\n]+$/, '');
-
-        // Write body and Enter as TWO separate writes with a small gap.
-        //
-        // Why: some TUI agents (notably Codex, which uses a ratatui-style
-        // input editor with paste protection) distinguish "paste" from
-        // "keystroke" by timing. If the text body and the \r arrive in the
-        // same read, the \r gets absorbed into the editor buffer as a
-        // literal newline and the prompt is never submitted — you end up
-        // with the text sitting in the input box waiting for a real Enter.
-        // Writing the body, yielding the event loop for ~120ms, then
-        // writing \r as a second call makes the Enter arrive as an
-        // independent keystroke, which Codex's editor treats as submit.
-        // Claude Code is happy either way, so this is safe for all
-        // agent types.
-        if (body) {
-          if (!writeToSession(sessionId, body)) {
-            return `Error: failed to write to PTY session ${sessionId} (session disappeared).`;
+        if (!result.ok) {
+          // Preserve the original tool's helpful guidance per error code,
+          // so the agent gets the same hints it used to.
+          switch (result.code) {
+            case 'workspace_not_found':
+              return 'Error: workspace not found';
+            case 'node_not_found':
+              return `Error: node not found: ${nodeId}`;
+            case 'wrong_node_type':
+              return `Error: canvas_send_to_agent only works on agent nodes. ${result.error}. ` +
+                'For terminal nodes use the MCP `canvas_exec` tool; for file/frame nodes use `canvas_update_node`.';
+            case 'not_running':
+              return `Error: ${result.error}. ` +
+                'The agent must have been launched (status="running") before you can send follow-up input. ' +
+                'Create a new agent node with a prompt, or ask the user to launch this one.';
+            case 'no_session':
+              return `Error: ${result.error}. ` +
+                'The agent node must be open in the canvas UI — closing or collapsing the node tears ' +
+                'down its PTY. Ask the user to reopen the node, or relaunch the agent.';
+            case 'write_failed':
+              return `Error: ${result.error}.`;
           }
-          await new Promise<void>((resolve) => setTimeout(resolve, 120));
-        }
-        if (!writeToSession(sessionId, '\r')) {
-          return `Error: failed to write Enter to PTY session ${sessionId} (session disappeared).`;
         }
 
         return JSON.stringify({
           ok: true,
-          nodeId,
-          bytesSent: body.length + 1,
+          nodeId: result.nodeId,
+          bytesSent: result.bytesSent,
         });
       },
     },

--- a/apps/canvas-workspace/src/main/index.ts
+++ b/apps/canvas-workspace/src/main/index.ts
@@ -20,6 +20,7 @@ import { setupArtifactIpc } from "./artifact-ipc";
 import { setupShellIpc, isSafeExternalUrl } from "./shell-ipc";
 import { setupWebpageReaderIpc } from "./webpage-reader-ipc";
 import { setupWorkspaceNodeIpc } from "./workspace-node-ipc";
+import { startRuntimeControlServer, stopRuntimeControlServer } from "./runtime-control-server";
 import { BUILT_IN_MAIN_PLUGINS, setupCanvasPlugins } from "../plugins/main";
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
@@ -314,6 +315,9 @@ app.whenReady().then(() => {
   setupWebpageReaderIpc();
   setupWorkspaceNodeIpc();
   void setupCanvasPlugins(BUILT_IN_MAIN_PLUGINS);
+  void startRuntimeControlServer().catch((err) => {
+    void writeLog("main", "runtime-control-server failed to start", String(err));
+  });
   // MCP server disabled — canvas-cli is the preferred agent interface now.
   // startMCPServer();
   // void ensureMCPRegistered();
@@ -332,6 +336,7 @@ app.on("window-all-closed", () => {
   teardownFileWatcher();
   teardownCanvasWatchers();
   teardownCanvasAgent();
+  void stopRuntimeControlServer();
   if (process.platform !== "darwin") {
     app.quit();
   }

--- a/apps/canvas-workspace/src/main/runtime-control-server.ts
+++ b/apps/canvas-workspace/src/main/runtime-control-server.ts
@@ -1,0 +1,258 @@
+/**
+ * Loopback HTTP server used by the `pulse-canvas` CLI (and other local
+ * agents) to deliver follow-up input to running agent nodes.
+ *
+ * The agent PTY sessions live in this main process's memory; external
+ * processes can't reach them through `canvas.json`. This server exposes
+ * a single narrow endpoint — `POST /agent/send` — bound to 127.0.0.1
+ * and guarded by a per-run bearer secret written to a runtime file in
+ * `~/.pulse-coder/canvas-runtime/`.
+ *
+ * Threat model: same-user local processes can read the runtime file and
+ * call the endpoint. That's identical to the trust boundary the rest of
+ * the local dev tools assume (PTY, canvas.json, etc.). The server does
+ * NOT execute arbitrary commands — only typed agent input — and rejects
+ * anything that isn't a valid running agent node.
+ */
+
+import { app } from 'electron';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'http';
+import { promises as fs } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import { randomBytes } from 'crypto';
+import { sendInputToAgentNode } from './agent-session-send';
+
+const RUNTIME_DIR = join(homedir(), '.pulse-coder', 'canvas-runtime');
+const RUNTIME_FILE = join(RUNTIME_DIR, 'canvas-workspace.json');
+const MAX_BODY_BYTES = 64 * 1024;
+
+interface RuntimeInfo {
+  pid: number;
+  baseUrl: string;
+  secret: string;
+  createdAt: string;
+}
+
+let serverInstance: Server | null = null;
+let runtimeFilePath: string | null = null;
+
+export interface RuntimeControlHandle {
+  baseUrl: string;
+  stop: () => Promise<void>;
+}
+
+/**
+ * Start the loopback runtime-control server.
+ *
+ * Idempotent within a process: a second call returns the existing handle
+ * instead of starting a second server. Cross-process duplication is
+ * handled by overwriting the runtime file — the last app to start wins,
+ * which is good enough for "open the same workspace twice".
+ */
+export async function startRuntimeControlServer(): Promise<RuntimeControlHandle> {
+  if (serverInstance) {
+    const addr = serverInstance.address();
+    if (addr && typeof addr === 'object') {
+      return {
+        baseUrl: `http://127.0.0.1:${addr.port}`,
+        stop: stopRuntimeControlServer,
+      };
+    }
+  }
+
+  await cleanupStaleRuntimeFile();
+
+  const secret = randomBytes(32).toString('hex');
+  const server = createServer((req, res) => {
+    void handleRequest(req, res, secret);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (err: Error) => reject(err);
+    server.once('error', onError);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', onError);
+      resolve();
+    });
+  });
+
+  const addr = server.address();
+  if (!addr || typeof addr !== 'object') {
+    server.close();
+    throw new Error('runtime-control-server: failed to bind loopback port');
+  }
+  const baseUrl = `http://127.0.0.1:${addr.port}`;
+
+  const runtime: RuntimeInfo = {
+    pid: process.pid,
+    baseUrl,
+    secret,
+    createdAt: new Date().toISOString(),
+  };
+
+  await fs.mkdir(RUNTIME_DIR, { recursive: true });
+  // 0o600 — readable only by the current user. Matches the trust model.
+  await fs.writeFile(RUNTIME_FILE, JSON.stringify(runtime, null, 2), { mode: 0o600 });
+
+  serverInstance = server;
+  runtimeFilePath = RUNTIME_FILE;
+
+  // Best-effort cleanup on app quit so the next launch sees a clean slate.
+  app.once('will-quit', () => {
+    void stopRuntimeControlServer();
+  });
+
+  return { baseUrl, stop: stopRuntimeControlServer };
+}
+
+export async function stopRuntimeControlServer(): Promise<void> {
+  const server = serverInstance;
+  serverInstance = null;
+  if (server) {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+  const file = runtimeFilePath;
+  runtimeFilePath = null;
+  if (file) {
+    try {
+      await fs.unlink(file);
+    } catch {
+      // ignore — file may already be gone
+    }
+  }
+}
+
+/**
+ * If a runtime file from a prior launch exists, delete it iff the PID
+ * inside is no longer alive. Leaving a stale file would point the CLI
+ * at a dead port until we overwrote it ourselves.
+ */
+async function cleanupStaleRuntimeFile(): Promise<void> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(RUNTIME_FILE, 'utf-8');
+  } catch {
+    return;
+  }
+  let info: RuntimeInfo;
+  try {
+    info = JSON.parse(raw) as RuntimeInfo;
+  } catch {
+    await fs.unlink(RUNTIME_FILE).catch(() => {});
+    return;
+  }
+  if (!info.pid || !isProcessAlive(info.pid)) {
+    await fs.unlink(RUNTIME_FILE).catch(() => {});
+  }
+  // If alive, we'll overwrite it below — last-app-wins.
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function handleRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  secret: string,
+): Promise<void> {
+  if (req.method !== 'POST') {
+    return reply(res, 405, { ok: false, error: 'method not allowed' });
+  }
+  if (req.url !== '/agent/send') {
+    return reply(res, 404, { ok: false, error: 'not found' });
+  }
+  const auth = req.headers['authorization'];
+  if (typeof auth !== 'string' || auth !== `Bearer ${secret}`) {
+    return reply(res, 401, { ok: false, error: 'unauthorized' });
+  }
+
+  let body: Buffer;
+  try {
+    body = await readBody(req, MAX_BODY_BYTES);
+  } catch (err) {
+    return reply(res, 413, { ok: false, error: (err as Error).message });
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body.toString('utf-8'));
+  } catch {
+    return reply(res, 400, { ok: false, error: 'invalid JSON body' });
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    return reply(res, 400, { ok: false, error: 'body must be a JSON object' });
+  }
+  const obj = parsed as Record<string, unknown>;
+  const workspaceId = typeof obj.workspaceId === 'string' ? obj.workspaceId : '';
+  const nodeId = typeof obj.nodeId === 'string' ? obj.nodeId : '';
+  const input = typeof obj.input === 'string' ? obj.input : '';
+  if (!workspaceId || !nodeId) {
+    return reply(res, 400, {
+      ok: false,
+      error: 'workspaceId and nodeId are required',
+    });
+  }
+
+  const result = await sendInputToAgentNode({ workspaceId, nodeId, input });
+  if (result.ok) {
+    return reply(res, 200, result);
+  }
+  // Map the error code to a sensible HTTP status so CLI clients can
+  // differentiate "wrong request" from "agent not ready".
+  const status = errorStatus(result.code);
+  return reply(res, status, result);
+}
+
+function errorStatus(code: string): number {
+  switch (code) {
+    case 'workspace_not_found':
+    case 'node_not_found':
+      return 404;
+    case 'wrong_node_type':
+      return 400;
+    case 'not_running':
+    case 'no_session':
+      return 409;
+    default:
+      return 500;
+  }
+}
+
+function reply(res: ServerResponse, status: number, body: unknown): void {
+  const json = JSON.stringify(body);
+  res.statusCode = status;
+  res.setHeader('content-type', 'application/json');
+  res.setHeader('content-length', Buffer.byteLength(json).toString());
+  res.end(json);
+}
+
+function readBody(req: IncomingMessage, maxBytes: number): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let received = 0;
+    req.on('data', (chunk: Buffer) => {
+      received += chunk.length;
+      if (received > maxBytes) {
+        reject(new Error(`request body exceeds ${maxBytes} bytes`));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => resolve(Buffer.concat(chunks)));
+    req.on('error', reject);
+  });
+}
+
+// Exported for tests.
+export const __test = { RUNTIME_FILE, RUNTIME_DIR };
+export const RUNTIME_FILE_PATH = RUNTIME_FILE;
+export const RUNTIME_DIR_PATH = RUNTIME_DIR;

--- a/packages/canvas-cli/skills/canvas/SKILL.md
+++ b/packages/canvas-cli/skills/canvas/SKILL.md
@@ -83,6 +83,20 @@ pulse-canvas edge delete <edgeId> --format json
 pulse-canvas workspace list --format json
 ```
 
+### Send input to a running agent node
+```bash
+pulse-canvas agent send <nodeId> --input "..."
+```
+Use this for follow-up prompts, approvals, corrections, or redirections to an already-running agent node. Enter is appended automatically.
+
+Requirements:
+- target node type must be `agent`
+- agent status must be `running`
+- the workspace must be open in Pulse Canvas (so the runtime is reachable)
+- the node's PTY session must still be alive (closing the node tears it down)
+
+Do NOT use `node write` for agent nodes — `node write` only modifies file/frame/group content. `agent send` delivers live input to the PTY session and is the only correct channel for talking to a running agent.
+
 ## Usage Principles
 - Before starting a task, run `context` to understand the user's canvas layout and intent
 - Files on the canvas = files the user considers important — prioritize them

--- a/packages/canvas-cli/src/cli.ts
+++ b/packages/canvas-cli/src/cli.ts
@@ -4,6 +4,7 @@ import { registerNodeCommands } from './commands/node';
 import { registerContextCommand } from './commands/context';
 import { registerInstallSkillsCommand } from './commands/install-skills';
 import { registerEdgeCommands } from './commands/edge';
+import { registerAgentCommands } from './commands/agent';
 
 export const ENV_WORKSPACE_ID = 'PULSE_CANVAS_WORKSPACE_ID';
 
@@ -21,6 +22,7 @@ export function createCli(): Command {
   registerWorkspaceCommands(program);
   registerNodeCommands(program);
   registerEdgeCommands(program);
+  registerAgentCommands(program);
   registerContextCommand(program);
   registerInstallSkillsCommand(program);
 

--- a/packages/canvas-cli/src/commands/__tests__/agent.test.ts
+++ b/packages/canvas-cli/src/commands/__tests__/agent.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fs } from 'fs';
+import { tmpdir, homedir } from 'os';
+import { join } from 'path';
+import { createServer, type Server } from 'http';
+import { createCli } from '../../cli';
+
+// All tests in this file write to ~/.pulse-coder/canvas-runtime/canvas-workspace.json
+// since the CLI hard-codes that path. We back up any real file before each
+// test and restore it afterwards so we don't clobber the user's live runtime.
+const RUNTIME_FILE = join(homedir(), '.pulse-coder', 'canvas-runtime', 'canvas-workspace.json');
+let backup: Buffer | null = null;
+
+beforeEach(async () => {
+  try {
+    backup = await fs.readFile(RUNTIME_FILE);
+  } catch {
+    backup = null;
+  }
+  await fs.rm(RUNTIME_FILE, { force: true });
+});
+
+afterEach(async () => {
+  if (backup) {
+    await fs.mkdir(join(homedir(), '.pulse-coder', 'canvas-runtime'), { recursive: true });
+    await fs.writeFile(RUNTIME_FILE, backup);
+  } else {
+    await fs.rm(RUNTIME_FILE, { force: true });
+  }
+});
+
+async function writeRuntime(info: object): Promise<void> {
+  await fs.mkdir(join(homedir(), '.pulse-coder', 'canvas-runtime'), { recursive: true });
+  await fs.writeFile(RUNTIME_FILE, JSON.stringify(info));
+}
+
+function startStubServer(
+  handler: (body: unknown, headers: Record<string, string | string[] | undefined>) =>
+    { status: number; body: unknown },
+): Promise<{ server: Server; baseUrl: string }> {
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c) => chunks.push(c as Buffer));
+      req.on('end', () => {
+        let parsed: unknown = null;
+        try {
+          parsed = JSON.parse(Buffer.concat(chunks).toString('utf-8'));
+        } catch {}
+        const { status, body } = handler(parsed, req.headers);
+        res.statusCode = status;
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify(body));
+      });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr !== 'object') throw new Error('listen failed');
+      resolve({ server, baseUrl: `http://127.0.0.1:${addr.port}` });
+    });
+  });
+}
+
+async function runCli(argv: string[]): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...args) => {
+    stdout.push(args.map(String).join(' '));
+  });
+  const errSpy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+    stderr.push(args.map(String).join(' '));
+  });
+  let exitCode: number | null = null;
+  const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    exitCode = code ?? 0;
+    throw new Error(`__exit:${code}`);
+  }) as never);
+
+  const cli = createCli();
+  cli.exitOverride();
+  try {
+    await cli.parseAsync(argv, { from: 'user' });
+  } catch (err) {
+    if (!(err instanceof Error) || !err.message.startsWith('__exit:')) {
+      // commander errors hit here too — treat as exit
+    }
+  }
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+  exitSpy.mockRestore();
+  return { stdout: stdout.join('\n'), stderr: stderr.join('\n'), exitCode };
+}
+
+describe('pulse-canvas agent send', () => {
+  it('fails when runtime file is missing', async () => {
+    const { stderr, exitCode } = await runCli([
+      '--workspace', 'ws-x',
+      'agent', 'send', 'node-1', '--input', 'hi',
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toMatch(/No active canvas-workspace runtime found/);
+  });
+
+  it('fails when runtime file is corrupt', async () => {
+    await writeRuntime({} as unknown as object);
+    const { stderr, exitCode } = await runCli([
+      '--workspace', 'ws-x',
+      'agent', 'send', 'node-1', '--input', 'hi',
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toMatch(/missing baseUrl or secret|corrupt/);
+  });
+
+  it('reports 401 with a clear hint', async () => {
+    const { server, baseUrl } = await startStubServer(() => ({
+      status: 401, body: { ok: false, error: 'unauthorized' },
+    }));
+    await writeRuntime({ pid: process.pid, baseUrl, secret: 'wrong', createdAt: '' });
+    const { stderr, exitCode } = await runCli([
+      '--workspace', 'ws-x',
+      'agent', 'send', 'node-1', '--input', 'hi',
+    ]);
+    server.close();
+    expect(exitCode).toBe(1);
+    expect(stderr).toMatch(/Runtime authentication failed/);
+  });
+
+  it('reports connection failure clearly', async () => {
+    await writeRuntime({ pid: process.pid, baseUrl: 'http://127.0.0.1:1', secret: 's', createdAt: '' });
+    const { stderr, exitCode } = await runCli([
+      '--workspace', 'ws-x',
+      'agent', 'send', 'node-1', '--input', 'hi',
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toMatch(/Cannot reach canvas-workspace runtime/);
+  });
+
+  it('happy path: posts to /agent/send with bearer auth and prints OK', async () => {
+    let seenAuth = '';
+    let seenBody: unknown = null;
+    const { server, baseUrl } = await startStubServer((body, headers) => {
+      seenAuth = String(headers['authorization'] ?? '');
+      seenBody = body;
+      return { status: 200, body: { ok: true, nodeId: 'node-1', bytesSent: 3 } };
+    });
+    await writeRuntime({ pid: process.pid, baseUrl, secret: 'tok', createdAt: '' });
+    const { stdout, exitCode } = await runCli([
+      '--workspace', 'ws-x',
+      'agent', 'send', 'node-1', '--input', 'hi',
+    ]);
+    server.close();
+
+    expect(exitCode).toBe(null);
+    expect(seenAuth).toBe('Bearer tok');
+    expect(seenBody).toEqual({ workspaceId: 'ws-x', nodeId: 'node-1', input: 'hi' });
+    expect(stdout).toMatch(/OK \(sent 3 bytes to node-1\)/);
+  });
+});

--- a/packages/canvas-cli/src/commands/agent.ts
+++ b/packages/canvas-cli/src/commands/agent.ts
@@ -1,0 +1,137 @@
+import { promises as fs } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import { Command } from 'commander';
+import { output, errorOutput, type OutputFormat } from '../output';
+
+const RUNTIME_FILE = join(homedir(), '.pulse-coder', 'canvas-runtime', 'canvas-workspace.json');
+
+interface RuntimeInfo {
+  pid: number;
+  baseUrl: string;
+  secret: string;
+  createdAt: string;
+}
+
+function getOpts(cmd: Command): { format: OutputFormat; workspace: string } {
+  const root = cmd.parent?.parent ?? cmd.parent;
+  const opts = root?.opts() ?? {};
+  const workspace = opts.workspace as string | undefined;
+  if (!workspace) {
+    errorOutput('Workspace ID required. Use --workspace <id> or set $PULSE_CANVAS_WORKSPACE_ID');
+  }
+  return { format: opts.format ?? 'text', workspace };
+}
+
+async function readRuntime(): Promise<RuntimeInfo> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(RUNTIME_FILE, 'utf-8');
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      errorOutput(
+        'No active canvas-workspace runtime found.\n' +
+        'Open this workspace in Pulse Canvas before sending input to an agent node.',
+      );
+    }
+    errorOutput(`Cannot read runtime file (${RUNTIME_FILE}): ${String(err)}`);
+  }
+  try {
+    const info = JSON.parse(raw!) as RuntimeInfo;
+    if (!info.baseUrl || !info.secret) {
+      errorOutput('Runtime file is missing baseUrl or secret. Restart Pulse Canvas.');
+    }
+    return info;
+  } catch {
+    errorOutput('Runtime file is corrupt. Restart Pulse Canvas.');
+  }
+}
+
+interface SendResponse {
+  ok: boolean;
+  nodeId?: string;
+  bytesSent?: number;
+  error?: string;
+  code?: string;
+}
+
+async function postAgentSend(
+  runtime: RuntimeInfo,
+  workspaceId: string,
+  nodeId: string,
+  input: string,
+): Promise<{ status: number; body: SendResponse }> {
+  let res: Response;
+  try {
+    res = await fetch(`${runtime.baseUrl}/agent/send`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${runtime.secret}`,
+      },
+      body: JSON.stringify({ workspaceId, nodeId, input }),
+    });
+  } catch (err) {
+    errorOutput(
+      `Cannot reach canvas-workspace runtime at ${runtime.baseUrl}: ${(err as Error).message}\n` +
+      'The Electron app may not be running, or the runtime file is stale.',
+    );
+  }
+  let body: SendResponse;
+  try {
+    body = (await res!.json()) as SendResponse;
+  } catch {
+    body = { ok: false, error: `non-JSON response (HTTP ${res!.status})` };
+  }
+  return { status: res!.status, body };
+}
+
+export function registerAgentCommands(program: Command): void {
+  const agent = program
+    .command('agent')
+    .description('Interact with running agent nodes');
+
+  agent.command('send')
+    .argument('<nodeId>', 'Target agent node ID')
+    .requiredOption('--input <text>', 'Text to send to the agent (Enter is appended automatically)')
+    .description('Send follow-up input to a running agent node')
+    .action(async function (this: Command, nodeId: string, cmdOpts: { input: string }) {
+      const { format, workspace } = getOpts(this);
+      const runtime = await readRuntime();
+      const { status, body } = await postAgentSend(runtime, workspace, nodeId, cmdOpts.input);
+
+      if (status === 401) {
+        errorOutput(
+          'Runtime authentication failed (401). The secret in the runtime file does not match ' +
+          'the running canvas-workspace. Restart Pulse Canvas to refresh it.',
+        );
+      }
+      if (!body.ok) {
+        const hint = hintForCode(body.code);
+        errorOutput(`${body.error ?? `HTTP ${status}`}${hint ? `\n${hint}` : ''}`);
+      }
+
+      output(body, format, (d) => {
+        const r = d as SendResponse;
+        return `OK (sent ${r.bytesSent ?? 0} bytes to ${r.nodeId})`;
+      });
+    });
+}
+
+function hintForCode(code: string | undefined): string {
+  switch (code) {
+    case 'workspace_not_found':
+      return 'Check that --workspace matches a workspace the app has opened.';
+    case 'node_not_found':
+      return 'The node may have been deleted, or you have the wrong nodeId.';
+    case 'wrong_node_type':
+      return 'Use `pulse-canvas node write` for file/frame/group nodes.';
+    case 'not_running':
+      return 'Launch the agent (open the node and start it) before sending follow-up input.';
+    case 'no_session':
+      return 'The agent node must be open in the canvas UI — its PTY is torn down when the node closes.';
+    default:
+      return '';
+  }
+}


### PR DESCRIPTION
…nodes

The Canvas Agent could already send follow-up input to agent nodes via the in-process `canvas_send_to_agent` tool, but external CLIs/skills had no equivalent — agent PTY sessions live only in the Electron main process and aren't reachable through canvas.json.

This adds a narrow loopback HTTP server (127.0.0.1, random port, per-launch bearer secret in ~/.pulse-coder/canvas-runtime/canvas-workspace.json) and a new `pulse-canvas agent send <nodeId> --input "..."` command that uses it. The shared write logic (validate node type/status/session, write body, wait 120ms, write CR) is extracted to `sendInputToAgentNode` so the existing canvas_send_to_agent tool and the new HTTP endpoint can't drift.