### PR TITLE
Implement virtual scrolling for nodes list with intersection observer

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/NodesPage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/NodesPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { WorkspaceEntry } from '../../hooks/useWorkspaces';
 import type { WorkspaceNodeListItem } from '../../types';
 import { NodeDetailDrawer } from './NodeDetailDrawer';
@@ -23,6 +23,8 @@ interface NodesPageProps {
   onOpenNode: (workspaceId: string, nodeId: string) => void;
   onSelectNode?: (selection: { workspaceId: string; nodeId: string } | null) => void;
 }
+
+const NODES_PAGE_SIZE = 30;
 
 function filterByType(node: WorkspaceNodeListItem, type: NodeTypeFilter): boolean {
   if (type === 'all') return true;
@@ -84,6 +86,38 @@ export const NodesPage = ({
       return true;
     });
   }, [nodes, query, typeFilter, tagFilter, activeWorkspaceIds]);
+
+  const [visibleCount, setVisibleCount] = useState(NODES_PAGE_SIZE);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setVisibleCount(NODES_PAGE_SIZE);
+    scrollRef.current?.scrollTo({ top: 0 });
+  }, [filteredNodes]);
+
+  const visibleNodes = useMemo(
+    () => filteredNodes.slice(0, visibleCount),
+    [filteredNodes, visibleCount],
+  );
+  const hasMore = visibleCount < filteredNodes.length;
+
+  useEffect(() => {
+    if (!hasMore) return;
+    const sentinel = sentinelRef.current;
+    const root = scrollRef.current;
+    if (!sentinel || !root) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setVisibleCount((current) => current + NODES_PAGE_SIZE);
+        }
+      },
+      { root, rootMargin: '600px 0px' },
+    );
+    io.observe(sentinel);
+    return () => io.disconnect();
+  }, [hasMore, filteredNodes.length]);
 
   const tagLabel = (tagId: string) => tagName(tagId, tagDefinitions);
 
@@ -168,7 +202,7 @@ export const NodesPage = ({
           </div>
         </div>
 
-        <div className="workspace-nodes-page__scroll">
+        <div className="workspace-nodes-page__scroll" ref={scrollRef}>
           {error && <div className="workspace-nodes-state workspace-nodes-state--error">{error}</div>}
           {loading && <div className="workspace-nodes-state">Loading nodes...</div>}
           {!loading && filteredNodes.length === 0 && (
@@ -178,7 +212,7 @@ export const NodesPage = ({
             </div>
           )}
           <div className="workspace-node-grid">
-            {filteredNodes.map((node) => {
+            {visibleNodes.map((node) => {
               const tagsForNode = getNodeTags(node);
               const summary = getNodeSummary(node);
               const workspaceIdForNode = getNodeWorkspaceId(node);
@@ -208,6 +242,9 @@ export const NodesPage = ({
               );
             })}
           </div>
+          {hasMore && (
+            <div ref={sentinelRef} className="workspace-nodes-sentinel" aria-hidden="true" />
+          )}
         </div>
       </section>
 

--- a/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/index.css
@@ -424,6 +424,11 @@
   padding: 28px;
 }
 
+.workspace-nodes-sentinel {
+  height: 1px;
+  width: 100%;
+}
+
 .workspace-nodes-state--error,
 .workspace-graph-state--error {
   color: var(--error);

--- a/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/index.css
@@ -320,21 +320,24 @@
 }
 
 .workspace-node-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-  gap: 12px;
+  column-width: 260px;
+  column-gap: 12px;
 }
 
 .workspace-node-card {
-  min-height: 176px;
+  width: 100%;
   border: 1px solid var(--nodes-border);
   border-radius: 6px;
   background: var(--nodes-surface);
   padding: 14px;
-  display: flex;
+  display: inline-flex;
   flex-direction: column;
   gap: 11px;
   cursor: pointer;
+  margin: 0 0 12px;
+  break-inside: avoid;
+  page-break-inside: avoid;
+  -webkit-column-break-inside: avoid;
 }
 
 .workspace-node-card:hover,
@@ -376,7 +379,7 @@
   font-size: 12px;
   line-height: 1.5;
   display: -webkit-box;
-  -webkit-line-clamp: 4;
+  -webkit-line-clamp: 10;
   -webkit-box-orient: vertical;
   overflow: hidden;
   word-break: break-word;


### PR DESCRIPTION
## Summary
Implements virtual scrolling for the NodesPage component to improve performance when rendering large lists of workspace nodes. The implementation uses an Intersection Observer to progressively load nodes as the user scrolls, rather than rendering all nodes at once.

## Key Changes
- **Virtual scrolling implementation**: Added `visibleCount` state to track how many nodes are rendered, starting with 30 nodes (configurable via `NODES_PAGE_SIZE` constant)
- **Intersection Observer**: Implemented an Intersection Observer that watches a sentinel element at the end of the list and loads 30 additional nodes when the user scrolls within 600px of the bottom
- **Layout optimization**: Changed grid layout from CSS Grid (`grid-template-columns: repeat(auto-fill, ...)`) to CSS Columns (`column-width: 260px`) for better compatibility with virtual scrolling
- **Card styling updates**: 
  - Updated `.workspace-node-card` to use `inline-flex` and added `break-inside: avoid` to prevent cards from breaking across columns
  - Increased text clamp from 4 lines to 10 lines for node descriptions
- **Scroll reset**: When filtered nodes change, the scroll position resets to the top and visible count resets to the initial page size
- **Sentinel element**: Added a hidden sentinel div that serves as the intersection observer target for detecting when to load more nodes

## Implementation Details
- Uses `useRef` to maintain references to the scroll container and sentinel element
- The Intersection Observer uses a `rootMargin` of `600px 0px` to trigger loading before the user reaches the absolute bottom
- `visibleNodes` is memoized to prevent unnecessary re-renders
- The observer is properly cleaned up on unmount and when dependencies change
- Maintains existing filtering and sorting behavior while adding progressive rendering

https://claude.ai/code/session_016qUDDpvEkBoX39VE95MpRD