### PR TITLE
fix(canvas-workspace): persist URL reference iframes across switches

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/ReferencePreviews.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/ReferencePreviews.tsx
@@ -1,4 +1,5 @@
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import type { CSSProperties } from 'react';
 import type { CanvasNode } from '../../types';
 import { CanvasNodeView } from '../CanvasNodeView';
 import { IframeNodeBody } from '../IframeNodeBody';
@@ -7,6 +8,7 @@ import type { NodeReferenceEntry, ReferenceEntry, UrlReferenceEntry } from './ty
 import { createUrlPreviewNode, getReferenceId, isUrlReference } from './utils';
 
 interface ReferencePreviewPanelProps {
+  references: ReferenceEntry[];
   activeReference?: ReferenceEntry;
   activeReferenceNode?: CanvasNode;
   copyUrl: (url: string) => void;
@@ -19,7 +21,10 @@ interface ReferencePreviewPanelProps {
   workspaceNameById: Map<string, string>;
 }
 
+const HIDDEN_STYLE: CSSProperties = { display: 'none' };
+
 export const ReferencePreviewPanel = ({
+  references,
   activeReference,
   activeReferenceNode,
   copyUrl,
@@ -31,110 +36,171 @@ export const ReferencePreviewPanel = ({
   onRemoveReference,
   workspaceNameById,
 }: ReferencePreviewPanelProps) => {
-  if (activeReference && isUrlReference(activeReference)) {
-    return (
-      <div className="reference-url-card reference-url-card--preview">
-        <ReferenceUrlWebPreview reference={activeReference} drawerWidth={drawerWidth} />
-        <div className="reference-card-footer">
-          <button
-            className="reference-drawer-secondary"
-            type="button"
-            onClick={() => onOpenUrl(activeReference.url)}
-          >
-            Open
-          </button>
-          <button
-            className="reference-drawer-secondary"
-            type="button"
-            onClick={() => copyUrl(activeReference.url)}
-          >
-            Copy URL
-          </button>
-          <button
-            className="reference-drawer-secondary"
-            type="button"
-            onClick={() => onRemoveReference(activeReference.id)}
-          >
-            Unpin
-          </button>
-          <button
-            className="reference-drawer-secondary"
-            type="button"
-            onClick={onClearAll}
-            title="Remove all references"
-          >
-            Clear all
-          </button>
+  const urlReferences = useMemo(
+    () => references.filter(isUrlReference),
+    [references],
+  );
+
+  // Track which URL references have been opened at least once. Their iframes
+  // stay mounted (just hidden) when the user switches away, so they don't
+  // reload on the next visit. An entry is removed only when the reference
+  // itself disappears from `references` (Unpin / Clear all / delete).
+  const [mountedUrlIds, setMountedUrlIds] = useState<Set<string>>(() => new Set());
+
+  useEffect(() => {
+    if (activeReference && isUrlReference(activeReference)) {
+      const id = activeReference.id;
+      setMountedUrlIds((prev) => {
+        if (prev.has(id)) return prev;
+        const next = new Set(prev);
+        next.add(id);
+        return next;
+      });
+    }
+  }, [activeReference]);
+
+  useEffect(() => {
+    setMountedUrlIds((prev) => {
+      if (prev.size === 0) return prev;
+      const liveIds = new Set(urlReferences.map((ref) => ref.id));
+      let changed = false;
+      const next = new Set<string>();
+      prev.forEach((id) => {
+        if (liveIds.has(id)) next.add(id);
+        else changed = true;
+      });
+      return changed ? next : prev;
+    });
+  }, [urlReferences]);
+
+  const activeIsUrl = !!(activeReference && isUrlReference(activeReference));
+  const activeUrlReference = activeIsUrl ? (activeReference as UrlReferenceEntry) : undefined;
+  const activeReferenceId = activeReference ? getReferenceId(activeReference) : undefined;
+
+  const persistentUrlPreviews = urlReferences.filter((ref) => mountedUrlIds.has(ref.id));
+
+  return (
+    <>
+      {persistentUrlPreviews.length > 0 && (
+        <div
+          className="reference-url-card reference-url-card--preview"
+          style={activeIsUrl ? undefined : HIDDEN_STYLE}
+        >
+          {persistentUrlPreviews.map((ref) => (
+            <ReferenceUrlWebPreview
+              key={ref.id}
+              reference={ref}
+              drawerWidth={drawerWidth}
+              hidden={ref.id !== activeReferenceId}
+            />
+          ))}
+          {activeUrlReference && (
+            <div className="reference-card-footer">
+              <button
+                className="reference-drawer-secondary"
+                type="button"
+                onClick={() => onOpenUrl(activeUrlReference.url)}
+              >
+                Open
+              </button>
+              <button
+                className="reference-drawer-secondary"
+                type="button"
+                onClick={() => copyUrl(activeUrlReference.url)}
+              >
+                Copy URL
+              </button>
+              <button
+                className="reference-drawer-secondary"
+                type="button"
+                onClick={() => onRemoveReference(activeUrlReference.id)}
+              >
+                Unpin
+              </button>
+              <button
+                className="reference-drawer-secondary"
+                type="button"
+                onClick={onClearAll}
+                title="Remove all references"
+              >
+                Clear all
+              </button>
+            </div>
+          )}
         </div>
-      </div>
-    );
-  }
+      )}
 
-  if (activeReference && !isUrlReference(activeReference) && activeReferenceNode) {
-    return (
-      <div className="reference-native-card">
-        <ReferenceNativeNodePreview
-          node={activeReferenceNode}
-          drawerWidth={drawerWidth}
-          workspaceName={workspaceNameById.get(activeReference.workspaceId) ?? activeReference.workspaceNameSnapshot}
-          onFocusNode={() => onFocusNode(activeReference.workspaceId, activeReference.nodeId)}
-        />
-        <div className="reference-card-footer">
-          <button
-            className="reference-drawer-secondary"
-            type="button"
-            onClick={() => onFocusNode(activeReference.workspaceId, activeReference.nodeId)}
-            title="Open source"
-          >
-            Open source
-          </button>
-          <button
-            className="reference-drawer-secondary"
-            type="button"
-            onClick={() => onAddReferenceToCanvas(activeReference)}
-          >
-            Add to canvas
-          </button>
-          <button
-            className="reference-drawer-secondary"
-            type="button"
-            onClick={() => onRemoveReference(getReferenceId(activeReference))}
-          >
-            Unpin
-          </button>
-          <button
-            className="reference-drawer-secondary"
-            type="button"
-            onClick={onClearAll}
-            title="Remove all references"
-          >
-            Clear all
-          </button>
+      {activeReference && !isUrlReference(activeReference) && activeReferenceNode && (
+        <div className="reference-native-card">
+          <ReferenceNativeNodePreview
+            node={activeReferenceNode}
+            drawerWidth={drawerWidth}
+            workspaceName={workspaceNameById.get(activeReference.workspaceId) ?? activeReference.workspaceNameSnapshot}
+            onFocusNode={() => onFocusNode(activeReference.workspaceId, activeReference.nodeId)}
+          />
+          <div className="reference-card-footer">
+            <button
+              className="reference-drawer-secondary"
+              type="button"
+              onClick={() => onFocusNode(activeReference.workspaceId, activeReference.nodeId)}
+              title="Open source"
+            >
+              Open source
+            </button>
+            <button
+              className="reference-drawer-secondary"
+              type="button"
+              onClick={() => onAddReferenceToCanvas(activeReference)}
+            >
+              Add to canvas
+            </button>
+            <button
+              className="reference-drawer-secondary"
+              type="button"
+              onClick={() => onRemoveReference(getReferenceId(activeReference))}
+            >
+              Unpin
+            </button>
+            <button
+              className="reference-drawer-secondary"
+              type="button"
+              onClick={onClearAll}
+              title="Remove all references"
+            >
+              Clear all
+            </button>
+          </div>
         </div>
-      </div>
-    );
-  }
+      )}
 
-  if (activeReference && !isUrlReference(activeReference)) {
-    return <div className="reference-pick-hint">Source node is not loaded or no longer exists.</div>;
-  }
+      {activeReference && !isUrlReference(activeReference) && !activeReferenceNode && (
+        <div className="reference-pick-hint">Source node is not loaded or no longer exists.</div>
+      )}
 
-  return <div className="reference-pick-hint">Pick a reference above to preview it here.</div>;
+      {!activeReference && (
+        <div className="reference-pick-hint">Pick a reference above to preview it here.</div>
+      )}
+    </>
+  );
 };
 
 interface ReferenceUrlWebPreviewProps {
   reference: UrlReferenceEntry;
   drawerWidth: number;
+  hidden?: boolean;
 }
 
-const ReferenceUrlWebPreview = memo(({ reference, drawerWidth }: ReferenceUrlWebPreviewProps) => {
+const ReferenceUrlWebPreview = memo(({ reference, drawerWidth, hidden }: ReferenceUrlWebPreviewProps) => {
   const previewNode = useMemo(
     () => createUrlPreviewNode(reference, drawerWidth),
     [reference, drawerWidth],
   );
 
   return (
-    <div className="reference-url-preview">
+    <div
+      className="reference-url-preview"
+      style={hidden ? HIDDEN_STYLE : undefined}
+    >
       <IframeNodeBody
         node={previewNode}
         onUpdate={() => undefined}

--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.tsx
@@ -143,6 +143,7 @@ export const ReferenceDrawer = ({
             </div>
 
             <ReferencePreviewPanel
+              references={references}
               activeReference={activeReference}
               activeReferenceNode={activeReferenceNode}
               copyUrl={state.copyUrl}


### PR DESCRIPTION
Previously, switching to a different reference unmounted the active URL
preview's iframe, forcing a full page reload when the user navigated
back. Now URL references stay mounted once opened (toggled with
display:none) and are only unloaded when removed from the reference list
via Unpin / Clear all / the entry's delete button.