### PR TITLE
Add folder mention support to chat system

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMentionPopup.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMentionPopup.tsx
@@ -28,9 +28,11 @@ export const ChatMentionPopup = ({
           ? 'workspace'
           : item.type === 'skill'
             ? 'skill'
-            : item.type === 'node'
-              ? item.nodeType ?? 'file'
-              : 'file';
+            : item.type === 'folder'
+              ? 'folder'
+              : item.type === 'node'
+                ? item.nodeType ?? 'file'
+                : 'file';
 
         return (
           <div key={`${item.type}-${item.nodeType ?? ''}-${item.workspaceId ?? ''}-${item.label}-${index}`}>

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
@@ -1661,6 +1661,16 @@
   color: rgba(34, 197, 94, 0.85);
 }
 
+.chat-mention-chip[data-node-type="folder"],
+.chat-mention-chip--folder {
+  background: rgba(245, 158, 11, 0.08);
+  border-color: rgba(245, 158, 11, 0.2);
+}
+.chat-mention-chip[data-node-type="folder"] .chat-mention-chip-icon,
+.chat-mention-chip--folder .chat-mention-chip-icon {
+  color: rgba(245, 158, 11, 0.9);
+}
+
 /* Input chip variant — inline non-editable mention in contentEditable */
 .chat-mention-chip--input {
   font-size: inherit;

--- a/apps/canvas-workspace/src/renderer/src/components/chat/constants.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/constants.ts
@@ -3,6 +3,7 @@ import type { I18nKey } from '../../i18n';
 
 export const CANVAS_MENTION_PREFIX = 'canvas:';
 export const SKILL_MENTION_PREFIX = 'skill:';
+export const FOLDER_MENTION_PREFIX = 'folder:';
 
 export const MENTION_GROUPS = [
   { key: 'skill', label: 'Skills', labelKey: 'chat.mention.skills' },
@@ -15,6 +16,7 @@ export const MENTION_GROUPS = [
   { key: 'frame', label: 'Frame', labelKey: 'chat.mention.frame' },
   { key: 'group', label: 'Group', labelKey: 'chat.mention.group' },
   { key: 'canvas', label: 'Canvas', labelKey: 'chat.mention.canvas' },
+  { key: 'proj-folder', label: 'Project Folders', labelKey: 'chat.mention.projectFolders' },
   { key: 'proj-file', label: 'Project Files', labelKey: 'chat.mention.projectFiles' },
 ] as const;
 
@@ -67,6 +69,7 @@ export const QUICK_ACTIONS: QuickAction[] = [
 export function getMentionGroupKey(item: MentionItem): MentionGroupKey {
   if (item.type === 'skill') return 'skill';
   if (item.type === 'workspace') return 'canvas';
+  if (item.type === 'folder') return 'proj-folder';
   if (item.type === 'file') return 'proj-file';
 
   switch (item.nodeType) {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useMentions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useMentions.ts
@@ -22,21 +22,23 @@ interface UseMentionsOptions {
 }
 
 function flattenEntries(entries: DirEntry[], rootFolder: string, prefix = ''): MentionItem[] {
-  const files: MentionItem[] = [];
+  const items: MentionItem[] = [];
 
   for (const entry of entries) {
     const path = prefix ? `${prefix}/${entry.name}` : entry.name;
     if (entry.type === 'file') {
-      files.push({ type: 'file', label: path, path: `${rootFolder}/${path}` });
+      items.push({ type: 'file', label: path, path: `${rootFolder}/${path}` });
       continue;
     }
 
+    // Directory: add it as a mention candidate, then recurse into children.
+    items.push({ type: 'folder', label: `${path}/`, path: `${rootFolder}/${path}` });
     if (entry.children) {
-      files.push(...flattenEntries(entry.children, rootFolder, path));
+      items.push(...flattenEntries(entry.children, rootFolder, path));
     }
   }
 
-  return files;
+  return items;
 }
 
 export function useMentions({

--- a/apps/canvas-workspace/src/renderer/src/components/chat/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/types.ts
@@ -33,7 +33,7 @@ export type ToolCallStatus = AgentChatToolCall;
 export type { ChatImageAttachment };
 
 export interface MentionItem {
-  type: 'node' | 'file' | 'workspace' | 'skill';
+  type: 'node' | 'file' | 'folder' | 'workspace' | 'skill';
   label: string;
   nodeType?: CanvasNode['type'];
   path?: string;

--- a/apps/canvas-workspace/src/renderer/src/components/chat/utils/mentions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/utils/mentions.ts
@@ -1,6 +1,6 @@
 import { createElement, type ReactNode } from 'react';
 import type { CanvasNode } from '../../../types';
-import { CANVAS_MENTION_PREFIX, SKILL_MENTION_PREFIX } from '../constants';
+import { CANVAS_MENTION_PREFIX, FOLDER_MENTION_PREFIX, SKILL_MENTION_PREFIX } from '../constants';
 import type { MentionItem, WorkspaceOption } from '../types';
 import { renderMarkdown } from './markdown';
 
@@ -35,6 +35,8 @@ export function mentionIconSvg(nodeType: string): string {
       return '<rect x="1.5" y="1.5" width="11" height="11" rx="1.5" stroke="currentColor" stroke-width="1.2"/><rect x="3.5" y="3.5" width="3" height="3" rx="0.5" stroke="currentColor" stroke-width="1"/><rect x="7.5" y="3.5" width="3" height="3" rx="0.5" stroke="currentColor" stroke-width="1"/><rect x="3.5" y="7.5" width="3" height="3" rx="0.5" stroke="currentColor" stroke-width="1"/>';
     case 'skill':
       return '<path d="M7 1.5l1.6 3.4 3.7.5-2.7 2.5.7 3.6L7 9.8l-3.3 1.7.7-3.6L1.7 5.4l3.7-.5L7 1.5z" stroke="currentColor" stroke-width="1.1" stroke-linejoin="round"/>';
+    case 'folder':
+      return '<path d="M1.5 4.5a1 1 0 0 1 1-1H6l1.2 1.5h4.3a1 1 0 0 1 1 1v5.5a1 1 0 0 1-1 1h-9a1 1 0 0 1-1-1V4.5z" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"/>';
     default:
       return '<rect x="2" y="1.5" width="10" height="11" rx="1.5" stroke="currentColor" stroke-width="1.2"/><path d="M4.5 5h5M4.5 7.5h3" stroke="currentColor" stroke-width="1" stroke-linecap="round"/>';
   }
@@ -53,6 +55,7 @@ export function MentionNodeIcon({ nodeType, size = 12 }: { nodeType: string; siz
 export function getMentionNodeType(item: MentionItem, nodes?: CanvasNode[]): string {
   if (item.type === 'skill') return 'skill';
   if (item.type === 'workspace') return 'workspace';
+  if (item.type === 'folder') return 'folder';
   if (item.type === 'node') return item.nodeType ?? 'file';
 
   return nodes?.find(node => node.title === item.label)?.type ?? item.nodeType ?? 'file';
@@ -112,19 +115,23 @@ export function serializeEditable(element: HTMLElement): string {
 export function createMentionChipElement(item: MentionItem, nodes?: CanvasNode[]): HTMLSpanElement {
   const isWorkspace = item.type === 'workspace';
   const isSkill = item.type === 'skill';
+  const isFolder = item.type === 'folder';
   const nodeType = getMentionNodeType(item, nodes);
   const chip = document.createElement('span');
 
   const classes = ['chat-mention-chip', 'chat-mention-chip--input'];
   if (isWorkspace) classes.push('chat-mention-chip--workspace');
   if (isSkill) classes.push('chat-mention-chip--skill');
+  if (isFolder) classes.push('chat-mention-chip--folder');
   chip.className = classes.join(' ');
   chip.contentEditable = 'false';
   chip.dataset.mention = isWorkspace
     ? `${CANVAS_MENTION_PREFIX}${item.label}`
     : isSkill
       ? `${SKILL_MENTION_PREFIX}${item.label}`
-      : item.label;
+      : isFolder
+        ? `${FOLDER_MENTION_PREFIX}${item.label.replace(/\/$/, '')}`
+        : item.label;
   chip.dataset.nodeType = nodeType;
 
   if (isWorkspace && item.workspaceId) {
@@ -197,6 +204,28 @@ export function renderUserContent(content: string, nodes?: CanvasNode[]): ReactN
       continue;
     }
 
+    if (rawLabel.startsWith(FOLDER_MENTION_PREFIX)) {
+      const folderLabel = rawLabel.slice(FOLDER_MENTION_PREFIX.length);
+      parts.push(
+        createElement(
+          'span',
+          {
+            key: match.index,
+            className: 'chat-mention-chip chat-mention-chip--folder',
+            'data-node-type': 'folder',
+          } as any,
+          createElement(
+            'span',
+            { className: 'chat-mention-chip-icon' },
+            createElement(MentionNodeIcon, { nodeType: 'folder' }),
+          ),
+          createElement('span', { className: 'chat-mention-chip-label' }, `${folderLabel}/`),
+        ),
+      );
+      lastIndex = re.lastIndex;
+      continue;
+    }
+
     const node = nodes?.find(item => item.title === rawLabel);
     parts.push(
       createElement(
@@ -237,6 +266,11 @@ export function renderMdWithMentions(content: string, nodes?: CanvasNode[]): str
     if (rawLabel.startsWith(SKILL_MENTION_PREFIX)) {
       const skillLabel = rawLabel.slice(SKILL_MENTION_PREFIX.length);
       return `<span class="chat-mention-chip chat-mention-chip--skill" data-node-type="skill"><span class="chat-mention-chip-label">${escapeHtml(skillLabel)}</span></span>`;
+    }
+
+    if (rawLabel.startsWith(FOLDER_MENTION_PREFIX)) {
+      const folderLabel = rawLabel.slice(FOLDER_MENTION_PREFIX.length);
+      return `<span class="chat-mention-chip chat-mention-chip--folder" data-node-type="folder"><span class="chat-mention-chip-icon"><svg width="12" height="12" viewBox="0 0 14 14" fill="none">${mentionIconSvg('folder')}</svg></span><span class="chat-mention-chip-label">${escapeHtml(folderLabel)}/</span></span>`;
     }
 
     const node = nodes?.find(item => item.title === rawLabel);

--- a/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
+++ b/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
@@ -261,6 +261,7 @@ const en = {
   'chat.mention.group': 'Group',
   'chat.mention.canvas': 'Canvas',
   'chat.mention.projectFiles': 'Project Files',
+  'chat.mention.projectFolders': 'Project Folders',
 
   'models.addProvider': 'Add provider',
   'models.providerCount': '{count} models',
@@ -716,6 +717,7 @@ const zh: Record<keyof typeof en, string> = {
   'chat.mention.group': '编组',
   'chat.mention.canvas': '画布',
   'chat.mention.projectFiles': '项目文件',
+  'chat.mention.projectFolders': '项目文件夹',
 
   'models.addProvider': '添加 Provider',
   'models.providerCount': '{count} 个模型',


### PR DESCRIPTION
## Summary
Extends the chat mention system to support project folders as first-class mention candidates, allowing users to reference directories alongside files, skills, and canvas items.

## Key Changes

- **New mention type**: Added `'folder'` type to `MentionItem` union in `types.ts`
- **Folder prefix constant**: Introduced `FOLDER_MENTION_PREFIX = 'folder:'` in `constants.ts`
- **Folder icon**: Added SVG icon for folder mentions in `mentionIconSvg()` function
- **Folder styling**: Added CSS styles for folder mention chips with amber/orange color scheme (`rgba(245, 158, 11, ...)`)
- **Folder rendering**: Implemented folder mention rendering in both `renderUserContent()` and `renderMdWithMentions()` functions with trailing slash display
- **Folder discovery**: Modified `flattenEntries()` in `useMentions.ts` to include directories as mention candidates alongside files
- **Folder grouping**: Added `'proj-folder'` mention group to `MENTION_GROUPS` with i18n support (English: "Project Folders", Chinese: "项目文件夹")
- **Type handling**: Updated `getMentionNodeType()` and `ChatMentionPopup` to properly classify folder items
- **Mention chip creation**: Extended `createMentionChipElement()` to handle folder type with appropriate prefix and trailing slash normalization

## Implementation Details

- Folders are displayed with a trailing slash (e.g., `folder:/path/to/dir/`) for visual clarity
- Folder paths are normalized by removing trailing slashes before storing in the mention data attribute
- Folder mentions use the `folder:` prefix to distinguish them from file mentions in serialized content
- Folders appear in a separate mention group ("Project Folders") in the mention popup, organized before project files
- The folder icon uses a simple folder outline SVG matching the visual style of other mention icons

https://claude.ai/code/session_01CPH8ywzGxDrWBSZu1TacFj