### PR TITLE
feat(canvas-workspace): experimental webview script-injection tools

### DIFF
--- a/apps/canvas-workspace/src/main/__tests__/cdp-session.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/cdp-session.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { withCdp, type CdpHost } from '../cdp-session';
+
+function makeHost(opts: {
+  alreadyAttached?: boolean;
+  send?: (method: string, params?: unknown) => Promise<unknown>;
+  attachThrows?: Error;
+} = {}): CdpHost & {
+  attachCalls: number;
+  detachCalls: number;
+  sendCalls: Array<{ method: string; params?: unknown }>;
+} {
+  let attached = !!opts.alreadyAttached;
+  const attachCalls = { n: 0 };
+  const detachCalls = { n: 0 };
+  const sendCalls: Array<{ method: string; params?: unknown }> = [];
+  const host = {
+    debugger: {
+      isAttached: () => attached,
+      attach: (_v?: string) => {
+        attachCalls.n += 1;
+        if (opts.attachThrows) throw opts.attachThrows;
+        attached = true;
+      },
+      detach: () => {
+        detachCalls.n += 1;
+        attached = false;
+      },
+      async sendCommand(method: string, params?: Record<string, unknown>) {
+        sendCalls.push({ method, params });
+        return opts.send ? opts.send(method, params) : { method };
+      },
+    },
+    get attachCalls() {
+      return attachCalls.n;
+    },
+    get detachCalls() {
+      return detachCalls.n;
+    },
+    get sendCalls() {
+      return sendCalls;
+    },
+  };
+  return host as CdpHost & {
+    attachCalls: number;
+    detachCalls: number;
+    sendCalls: Array<{ method: string; params?: unknown }>;
+  };
+}
+
+describe('withCdp', () => {
+  it('attaches before running, detaches after', async () => {
+    const host = makeHost();
+    const result = await withCdp(host, async (send) => {
+      expect(host.attachCalls).toBe(1);
+      expect(host.detachCalls).toBe(0);
+      return await send('Test.command');
+    });
+    expect(result).toEqual({ method: 'Test.command' });
+    expect(host.attachCalls).toBe(1);
+    expect(host.detachCalls).toBe(1);
+  });
+
+  it('does not attach if something else already attached the debugger', async () => {
+    const host = makeHost({ alreadyAttached: true });
+    await withCdp(host, async () => {});
+    expect(host.attachCalls).toBe(0);
+    expect(host.detachCalls).toBe(0); // we shouldn't detach what we didn't attach
+  });
+
+  it('detaches even when the body throws', async () => {
+    const host = makeHost();
+    await expect(
+      withCdp(host, async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+    expect(host.detachCalls).toBe(1);
+  });
+
+  it('serialises overlapping callers on the same host', async () => {
+    const order: string[] = [];
+    let resolveA!: () => void;
+    const aBody = new Promise<void>((r) => {
+      resolveA = r;
+    });
+    const host = makeHost();
+    const a = withCdp(host, async () => {
+      order.push('A:start');
+      await aBody;
+      order.push('A:end');
+    });
+    const b = withCdp(host, async () => {
+      order.push('B:start');
+      order.push('B:end');
+    });
+    // B must not start until A resolves.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(order).toEqual(['A:start']);
+    resolveA();
+    await Promise.all([a, b]);
+    expect(order).toEqual(['A:start', 'A:end', 'B:start', 'B:end']);
+    // Two separate attach/detach cycles — one per body.
+    expect(host.attachCalls).toBe(2);
+    expect(host.detachCalls).toBe(2);
+  });
+
+  it('advances the queue even after a predecessor rejects', async () => {
+    const host = makeHost();
+    const a = withCdp(host, async () => {
+      throw new Error('A failed');
+    });
+    const b = withCdp(host, async () => 'B ok');
+    await expect(a).rejects.toThrow('A failed');
+    await expect(b).resolves.toBe('B ok');
+  });
+
+  it('isolates locks per host', async () => {
+    const order: string[] = [];
+    let resolveA!: () => void;
+    const aBody = new Promise<void>((r) => {
+      resolveA = r;
+    });
+    const hostA = makeHost();
+    const hostB = makeHost();
+    const a = withCdp(hostA, async () => {
+      order.push('A:start');
+      await aBody;
+      order.push('A:end');
+    });
+    const b = withCdp(hostB, async () => {
+      order.push('B');
+    });
+    // B should run independently on hostB without waiting for A.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(order).toContain('B');
+    expect(order).not.toContain('A:end');
+    resolveA();
+    await Promise.all([a, b]);
+  });
+});

--- a/apps/canvas-workspace/src/main/__tests__/webview-action-policy.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/webview-action-policy.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateActionPolicyWith } from '../webview-action-policy';
+
+describe('evaluateActionPolicyWith', () => {
+  describe('defaults', () => {
+    it('allows http and https URLs on neutral hosts', () => {
+      expect(evaluateActionPolicyWith('https://example.com/foo', {}).allow).toBe(true);
+      expect(evaluateActionPolicyWith('http://example.com', {}).allow).toBe(true);
+      expect(evaluateActionPolicyWith('https://github.com/anthropics/x', {}).allow).toBe(true);
+    });
+
+    it('allows about:blank', () => {
+      expect(evaluateActionPolicyWith('about:blank', {}).allow).toBe(true);
+    });
+
+    it('denies non-web schemes', () => {
+      const cases = [
+        'file:///etc/passwd',
+        'chrome://settings',
+        'chrome-extension://abc/foo.html',
+        'devtools://devtools/bundled/x.html',
+        'view-source:https://example.com',
+        'data:text/html,<h1>x</h1>',
+        'javascript:alert(1)',
+      ];
+      for (const url of cases) {
+        const d = evaluateActionPolicyWith(url, {});
+        expect(d.allow, `expected ${url} to be denied`).toBe(false);
+        expect(d.reason).toBeTruthy();
+      }
+    });
+
+    it('denies ws/mailto/other non-http schemes', () => {
+      expect(evaluateActionPolicyWith('mailto:foo@bar.com', {}).allow).toBe(false);
+      expect(evaluateActionPolicyWith('ws://example.com', {}).allow).toBe(false);
+    });
+
+    it('denies built-in sensitive domains', () => {
+      const cases = [
+        'https://mybank.com/login',
+        'https://www.paypal.com',
+        'https://accounts.google.com/signin',
+        'https://mail.google.com/inbox',
+        'https://login.live.com',
+        'https://appleid.apple.com',
+        'https://login.microsoftonline.com',
+      ];
+      for (const url of cases) {
+        const d = evaluateActionPolicyWith(url, {});
+        expect(d.allow, `expected ${url} to be denied`).toBe(false);
+        expect(d.reason).toMatch(/deny pattern/);
+      }
+    });
+
+    it('rejects empty / unparseable URLs', () => {
+      expect(evaluateActionPolicyWith('', {}).allow).toBe(false);
+      expect(evaluateActionPolicyWith('not a url', {}).allow).toBe(false);
+      expect(evaluateActionPolicyWith('http://', {}).allow).toBe(false);
+    });
+  });
+
+  describe('config overrides', () => {
+    it('respects custom denySchemes (overrides defaults)', () => {
+      // Empty list → no schemes blocked except the http(s)-only floor.
+      expect(evaluateActionPolicyWith('file:///x', { denySchemes: [] }).allow).toBe(false);
+      // Only http and https pass even with empty denySchemes, because we
+      // enforce http(s)-only after the scheme check.
+      expect(evaluateActionPolicyWith('ftp://example.com', { denySchemes: [] }).allow).toBe(false);
+    });
+
+    it('respects custom denyHostPatterns (overrides defaults)', () => {
+      const cfg = { denyHostPatterns: ['*evil*'] };
+      // Default-blocked host now passes because we replaced the list.
+      expect(evaluateActionPolicyWith('https://mail.google.com', cfg).allow).toBe(true);
+      expect(evaluateActionPolicyWith('https://evil.example.com', cfg).allow).toBe(false);
+      expect(evaluateActionPolicyWith('https://www.evil.com', cfg).allow).toBe(false);
+    });
+
+    it('allowHostPatterns acts as a strict allowlist when non-empty', () => {
+      const cfg = { allowHostPatterns: ['example.com', '*.allowed.org'] };
+      expect(evaluateActionPolicyWith('https://example.com/page', cfg).allow).toBe(true);
+      expect(evaluateActionPolicyWith('https://foo.allowed.org', cfg).allow).toBe(true);
+      expect(evaluateActionPolicyWith('https://github.com', cfg).allow).toBe(false);
+    });
+
+    it('allowHostPatterns is ignored when empty array', () => {
+      const cfg = { allowHostPatterns: [] };
+      expect(evaluateActionPolicyWith('https://github.com', cfg).allow).toBe(true);
+    });
+
+    it('deny patterns win over allow patterns', () => {
+      const cfg = {
+        denyHostPatterns: ['*bank*'],
+        allowHostPatterns: ['*'],
+      };
+      expect(evaluateActionPolicyWith('https://mybank.com', cfg).allow).toBe(false);
+      expect(evaluateActionPolicyWith('https://example.com', cfg).allow).toBe(true);
+    });
+  });
+
+  describe('host matching', () => {
+    it('matches case-insensitively', () => {
+      const cfg = { denyHostPatterns: ['EXAMPLE.com'] };
+      expect(evaluateActionPolicyWith('https://example.com', cfg).allow).toBe(false);
+      expect(evaluateActionPolicyWith('https://EXAMPLE.com', cfg).allow).toBe(false);
+    });
+
+    it('exact match does not catch subdomains', () => {
+      const cfg = { denyHostPatterns: ['example.com'] };
+      expect(evaluateActionPolicyWith('https://example.com', cfg).allow).toBe(false);
+      expect(evaluateActionPolicyWith('https://foo.example.com', cfg).allow).toBe(true);
+    });
+
+    it('wildcard matches subdomains', () => {
+      const cfg = { denyHostPatterns: ['*.example.com'] };
+      expect(evaluateActionPolicyWith('https://example.com', cfg).allow).toBe(true);
+      expect(evaluateActionPolicyWith('https://foo.example.com', cfg).allow).toBe(false);
+      expect(evaluateActionPolicyWith('https://a.b.example.com', cfg).allow).toBe(false);
+    });
+
+    it('regex special chars in patterns are escaped (no injection)', () => {
+      const cfg = { denyHostPatterns: ['foo.bar'] };
+      // The "." in the pattern should be matched literally, not as "any char".
+      expect(evaluateActionPolicyWith('https://fooXbar', cfg).allow).toBe(true);
+      expect(evaluateActionPolicyWith('https://foo.bar', cfg).allow).toBe(false);
+    });
+  });
+});

--- a/apps/canvas-workspace/src/main/__tests__/webview-action-policy.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/webview-action-policy.test.ts
@@ -96,6 +96,30 @@ describe('evaluateActionPolicyWith', () => {
       expect(evaluateActionPolicyWith('https://mybank.com', cfg).allow).toBe(false);
       expect(evaluateActionPolicyWith('https://example.com', cfg).allow).toBe(true);
     });
+
+    it('ignores non-string entries instead of crashing on .toLowerCase()', () => {
+      // Hand-built config bypassing the loader's normalisation. Should
+      // skip non-string entries cleanly rather than throw, so a typo in
+      // user JSON degrades to "treated as no extra rule" rather than
+      // bricking the tool entirely.
+      const cfg = {
+        denyHostPatterns: ['*bank*', 123 as unknown as string, null as unknown as string],
+        allowHostPatterns: ['example.com', 42 as unknown as string],
+      };
+      expect(() => evaluateActionPolicyWith('https://example.com', cfg)).not.toThrow();
+      expect(evaluateActionPolicyWith('https://example.com', cfg).allow).toBe(true);
+      expect(evaluateActionPolicyWith('https://mybank.com', cfg).allow).toBe(false);
+    });
+  });
+
+  describe('default-list coverage', () => {
+    it('blocks Auth0 tenant subdomains, not only the exact apex', () => {
+      // Tenant logins live on subdomains like tenant.us.auth0.com — the
+      // exact-only pattern previously let them through.
+      expect(evaluateActionPolicyWith('https://auth0.com', {}).allow).toBe(false);
+      expect(evaluateActionPolicyWith('https://tenant.us.auth0.com', {}).allow).toBe(false);
+      expect(evaluateActionPolicyWith('https://example.auth0.com/login', {}).allow).toBe(false);
+    });
   });
 
   describe('host matching', () => {

--- a/apps/canvas-workspace/src/main/__tests__/webview-action.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/webview-action.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildClickScript,
+  buildEvalScript,
+  buildFillScript,
+  buildPressScript,
+  buildProbeScript,
+  clickSelector,
+  evalInPage,
+  fillSelector,
+  pressKey,
+  resolveKeySpec,
+  waitForCondition,
+  type PageRunner,
+} from '../webview-action';
+
+/**
+ * Stub PageRunner that returns whatever the caller programs. Lets tests
+ * exercise the primitives' control flow without touching electron.
+ */
+function makeRunner(
+  responder: (code: string) => unknown | Promise<unknown>,
+): PageRunner & { calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    async executeJavaScript(code: string): Promise<unknown> {
+      calls.push(code);
+      return await responder(code);
+    },
+  };
+}
+
+describe('script builders', () => {
+  it('lit() escapes user-supplied selector strings safely', () => {
+    // A malicious selector should land inside a JSON string literal, not
+    // as bare JS. The "alert(1)" payload will appear in the script source
+    // (inside the literal) but never as parseable code.
+    const payload = 'a[href="\'"]; alert(1); //';
+    const script = buildClickScript(payload);
+    // The full payload is JSON-encoded — that's the safety guarantee.
+    expect(script).toContain(JSON.stringify(payload));
+    // And the script must actually parse as valid JS (proves no literal escape).
+    expect(() => new Function(script)).not.toThrow();
+    // Smoke check: U+2028/U+2029 chars in input are escape-encoded.
+    const lsPayload = `pre${String.fromCharCode(0x2028)}post`;
+    const lsScript = buildClickScript(lsPayload);
+    expect(lsScript).not.toContain(String.fromCharCode(0x2028));
+    expect(lsScript).toContain('\\u2028');
+    expect(() => new Function(lsScript)).not.toThrow();
+  });
+
+  it('buildEvalScript wraps user code in a result envelope', () => {
+    const script = buildEvalScript('return 1 + 2');
+    expect(script).toContain('return 1 + 2');
+    expect(script).toContain('ok: true');
+    expect(script).toContain('ok: false');
+  });
+
+  it('buildFillScript embeds the value as a JSON literal', () => {
+    const script = buildFillScript('input', 'hello "world"');
+    expect(script).toContain(JSON.stringify('hello "world"'));
+  });
+
+  it('buildPressScript embeds the key spec as a JSON literal', () => {
+    const script = buildPressScript({ key: 'Enter', code: 'Enter', keyCode: 13 }, undefined);
+    expect(script).toContain('keydown');
+    expect(script).toContain('keyup');
+    expect(script).toContain('"Enter"');
+  });
+
+  it('buildProbeScript requires a selector or predicate', () => {
+    const sel = buildProbeScript('div.ready', undefined);
+    expect(sel).toContain('querySelector');
+    const pred = buildProbeScript(undefined, 'return location.pathname === "/done"');
+    expect(pred).toContain('location.pathname');
+  });
+});
+
+describe('resolveKeySpec', () => {
+  it('maps named special keys', () => {
+    expect(resolveKeySpec('Enter')).toEqual({ key: 'Enter', code: 'Enter', keyCode: 13 });
+    expect(resolveKeySpec('Tab')).toEqual({ key: 'Tab', code: 'Tab', keyCode: 9 });
+    expect(resolveKeySpec('ArrowDown')).toEqual({ key: 'ArrowDown', code: 'ArrowDown', keyCode: 40 });
+  });
+
+  it('maps single characters', () => {
+    expect(resolveKeySpec('a')).toEqual({ key: 'a', code: 'KeyA', keyCode: 97 });
+    expect(resolveKeySpec('Z')).toEqual({ key: 'Z', code: 'KeyZ', keyCode: 90 });
+    expect(resolveKeySpec('5')).toEqual({ key: '5', code: 'Digit5', keyCode: 53 });
+  });
+
+  it('returns null for unknown multi-char keys', () => {
+    expect(resolveKeySpec('Whatever')).toBeNull();
+    expect(resolveKeySpec('F1')).toBeNull();
+  });
+});
+
+describe('evalInPage', () => {
+  it('returns the script value on success', async () => {
+    const runner = makeRunner(() => ({ ok: true, value: 42 }));
+    const result = await evalInPage(runner, 'return 42');
+    expect(result.ok).toBe(true);
+    expect(result.data?.value).toBe(42);
+  });
+
+  it('surfaces the script-side error on failure', async () => {
+    const runner = makeRunner(() => ({ ok: false, error: 'boom' }));
+    const result = await evalInPage(runner, 'throw new Error("boom")');
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('boom');
+  });
+
+  it('flags timeouts distinctly', async () => {
+    const runner = makeRunner(
+      () =>
+        new Promise(() => {
+          /* never resolves */
+        }),
+    );
+    const result = await evalInPage(runner, 'while(1){}', 50);
+    expect(result.ok).toBe(false);
+    expect(result.timedOut).toBe(true);
+  });
+});
+
+describe('clickSelector', () => {
+  it('returns tag/text on success', async () => {
+    const runner = makeRunner(() => ({ ok: true, tag: 'button', text: 'Submit' }));
+    const r = await clickSelector(runner, 'button');
+    expect(r.ok).toBe(true);
+    expect(r.data).toEqual({ tag: 'button', text: 'Submit' });
+  });
+
+  it('surfaces missing-selector errors', async () => {
+    const runner = makeRunner(() => ({ ok: false, error: 'selector not found: x' }));
+    const r = await clickSelector(runner, 'x');
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('selector not found');
+  });
+});
+
+describe('fillSelector', () => {
+  it('returns mode on success', async () => {
+    const runner = makeRunner(() => ({ ok: true, mode: 'value', tag: 'input' }));
+    const r = await fillSelector(runner, 'input[name=q]', 'hello');
+    expect(r.ok).toBe(true);
+    expect(r.data).toEqual({ tag: 'input', mode: 'value' });
+  });
+});
+
+describe('pressKey', () => {
+  it('rejects unsupported keys before talking to the runner', async () => {
+    let called = false;
+    const runner = makeRunner(() => {
+      called = true;
+      return { ok: true };
+    });
+    const r = await pressKey(runner, 'Whatever', undefined);
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('unsupported');
+    expect(called).toBe(false);
+  });
+
+  it('forwards a resolved key spec', async () => {
+    const runner = makeRunner(() => ({ ok: true, key: 'Enter' }));
+    const r = await pressKey(runner, 'Enter', undefined);
+    expect(r.ok).toBe(true);
+    expect(r.data?.key).toBe('Enter');
+    expect(runner.calls[0]).toContain('"Enter"');
+    expect(runner.calls[0]).toContain('keydown');
+  });
+});
+
+describe('waitForCondition', () => {
+  it('resolves as soon as the probe matches', async () => {
+    let calls = 0;
+    const runner = makeRunner(() => {
+      calls += 1;
+      return { ok: true, matched: calls >= 3 };
+    });
+    const r = await waitForCondition(runner, { selector: '.done', intervalMs: 5, timeoutMs: 1000 });
+    expect(r.ok).toBe(true);
+    expect(r.data?.attempts).toBe(3);
+  });
+
+  it('times out when the probe never matches', async () => {
+    const runner = makeRunner(() => ({ ok: true, matched: false }));
+    const r = await waitForCondition(runner, { selector: '.never', intervalMs: 10, timeoutMs: 50 });
+    expect(r.ok).toBe(false);
+    expect(r.timedOut).toBe(true);
+  });
+
+  it('requires selector or predicate', async () => {
+    const runner = makeRunner(() => ({ ok: true, matched: true }));
+    const r = await waitForCondition(runner, { timeoutMs: 100 });
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('selector or predicate');
+  });
+
+  it('surfaces the last probe error on timeout', async () => {
+    const runner = makeRunner(() => ({ ok: false, error: 'probe blew up' }));
+    const r = await waitForCondition(runner, { selector: '.x', intervalMs: 10, timeoutMs: 30 });
+    expect(r.ok).toBe(false);
+    expect(r.timedOut).toBe(true);
+    expect(r.error).toContain('probe blew up');
+  });
+});

--- a/apps/canvas-workspace/src/main/__tests__/webview-action.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/webview-action.test.ts
@@ -5,11 +5,13 @@ import {
   buildFillScript,
   buildPressScript,
   buildProbeScript,
+  buildScrollScript,
   clickSelector,
   evalInPage,
   fillSelector,
   pressKey,
   resolveKeySpec,
+  scrollPage,
   waitForCondition,
   type PageRunner,
 } from '../webview-action';
@@ -84,9 +86,13 @@ describe('resolveKeySpec', () => {
     expect(resolveKeySpec('ArrowDown')).toEqual({ key: 'ArrowDown', code: 'ArrowDown', keyCode: 40 });
   });
 
-  it('maps single characters', () => {
-    expect(resolveKeySpec('a')).toEqual({ key: 'a', code: 'KeyA', keyCode: 97 });
+  it('maps single characters with legacy-uppercase keyCode for letters', () => {
+    // keyCode follows the legacy physical-key convention: both 'a' and 'A'
+    // produce keyCode 65, matching what older shortcut handlers expect.
+    expect(resolveKeySpec('a')).toEqual({ key: 'a', code: 'KeyA', keyCode: 65 });
+    expect(resolveKeySpec('A')).toEqual({ key: 'A', code: 'KeyA', keyCode: 65 });
     expect(resolveKeySpec('Z')).toEqual({ key: 'Z', code: 'KeyZ', keyCode: 90 });
+    expect(resolveKeySpec('z')).toEqual({ key: 'z', code: 'KeyZ', keyCode: 90 });
     expect(resolveKeySpec('5')).toEqual({ key: '5', code: 'Digit5', keyCode: 53 });
   });
 
@@ -204,5 +210,135 @@ describe('waitForCondition', () => {
     expect(r.ok).toBe(false);
     expect(r.timedOut).toBe(true);
     expect(r.error).toContain('probe blew up');
+  });
+
+  it('enforces a per-probe timeout so a hung predicate does not block forever', async () => {
+    // First probe never resolves. With per-probe timeout enforced, the
+    // outer wait should still return within roughly timeoutMs and surface
+    // the per-probe timeout as the last error.
+    const runner = makeRunner(
+      () =>
+        new Promise(() => {
+          /* never resolves */
+        }),
+    );
+    const start = Date.now();
+    const r = await waitForCondition(runner, {
+      predicate: 'while(1){}; return false',
+      timeoutMs: 200,
+      intervalMs: 50,
+    });
+    const elapsed = Date.now() - start;
+    expect(r.ok).toBe(false);
+    expect(r.timedOut).toBe(true);
+    expect(elapsed).toBeLessThan(600); // sanity: didn't hang
+  });
+
+  it('aborts immediately when abortCheck returns a reason', async () => {
+    let calls = 0;
+    const runner = makeRunner(() => {
+      calls += 1;
+      return { ok: true, matched: false };
+    });
+    const r = await waitForCondition(runner, {
+      selector: '.x',
+      timeoutMs: 1000,
+      intervalMs: 10,
+      abortCheck: () => (calls >= 2 ? 'policy changed mid-wait' : null),
+    });
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe('policy changed mid-wait');
+    // abortCheck fires BEFORE the probe each iteration, so we abort
+    // before running probe #3.
+    expect(calls).toBe(2);
+  });
+});
+
+describe('evalInPage — non-serialisable results', () => {
+  it('rejects BigInt values with a structured error', async () => {
+    const runner = makeRunner(() => ({ ok: true, value: 1n }));
+    const r = await evalInPage(runner, 'return 1n');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/not JSON-serialisable/);
+  });
+
+  it('rejects cyclic values with a structured error', async () => {
+    const cycle: Record<string, unknown> = {};
+    cycle.self = cycle;
+    const runner = makeRunner(() => ({ ok: true, value: cycle }));
+    const r = await evalInPage(runner, 'var x={}; x.self=x; return x');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/not JSON-serialisable/);
+  });
+
+  it('accepts plain JSON-friendly values', async () => {
+    const runner = makeRunner(() => ({ ok: true, value: { a: 1, b: [2, 'three'] } }));
+    const r = await evalInPage(runner, 'return { a: 1, b: [2, "three"] }');
+    expect(r.ok).toBe(true);
+    expect(r.data?.value).toEqual({ a: 1, b: [2, 'three'] });
+  });
+});
+
+describe('scrollPage', () => {
+  it('rejects calls with no target before talking to the runner', async () => {
+    let called = false;
+    const runner = makeRunner(() => {
+      called = true;
+      return { ok: true };
+    });
+    const r = await scrollPage(runner, {});
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/top, bottom, selector/);
+    expect(called).toBe(false);
+  });
+
+  it('scrolls to top and returns the resulting position', async () => {
+    const runner = makeRunner(() => ({
+      ok: true,
+      scrollX: 0,
+      scrollY: 0,
+      scrollHeight: 5000,
+      innerHeight: 800,
+      atTop: true,
+      atBottom: false,
+    }));
+    const r = await scrollPage(runner, { top: true });
+    expect(r.ok).toBe(true);
+    expect(r.data).toMatchObject({ scrollY: 0, atTop: true, atBottom: false });
+  });
+
+  it('scrolls by a relative offset', async () => {
+    const runner = makeRunner(() => ({
+      ok: true,
+      scrollX: 0,
+      scrollY: 800,
+      scrollHeight: 5000,
+      innerHeight: 800,
+      atTop: false,
+      atBottom: false,
+    }));
+    const r = await scrollPage(runner, { by: { y: 800 } });
+    expect(r.ok).toBe(true);
+    expect(r.data?.scrollY).toBe(800);
+  });
+
+  it('reports the selector when scrollIntoView misses', async () => {
+    const runner = makeRunner(() => ({ ok: false, error: 'selector not found: .missing' }));
+    const r = await scrollPage(runner, { selector: '.missing' });
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('selector not found');
+  });
+});
+
+describe('buildScrollScript', () => {
+  it('embeds the spec as a JSON literal', () => {
+    const script = buildScrollScript({ selector: '#footer', block: 'end' });
+    expect(script).toContain(JSON.stringify({ selector: '#footer', block: 'end' }));
+    expect(script).toContain('scrollIntoView');
+  });
+
+  it('is JS-parse-clean against hostile selectors', () => {
+    const script = buildScrollScript({ selector: 'a"); alert(1); //' });
+    expect(() => new Function(script)).not.toThrow();
   });
 });

--- a/apps/canvas-workspace/src/main/__tests__/webview-cdp-actions.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/webview-cdp-actions.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect } from 'vitest';
+import {
+  cdpClickAt,
+  cdpClickSelector,
+  cdpFillSelector,
+  cdpPressKey,
+  modifierMask,
+} from '../webview-cdp-actions';
+import type { CdpHost } from '../cdp-session';
+
+interface FakeHost extends CdpHost {
+  executeJavaScript(code: string, userGesture?: boolean): Promise<unknown>;
+  cdpCalls: Array<{ method: string; params?: Record<string, unknown> }>;
+  jsCalls: string[];
+}
+
+function makeHost(opts: {
+  jsResponse?: unknown | ((code: string) => unknown);
+  cdpResponse?: (method: string, params?: Record<string, unknown>) => unknown;
+} = {}): FakeHost {
+  let attached = false;
+  const cdpCalls: Array<{ method: string; params?: Record<string, unknown> }> = [];
+  const jsCalls: string[] = [];
+  const host: FakeHost = {
+    cdpCalls,
+    jsCalls,
+    debugger: {
+      isAttached: () => attached,
+      attach: () => {
+        attached = true;
+      },
+      detach: () => {
+        attached = false;
+      },
+      async sendCommand(method: string, params?: Record<string, unknown>) {
+        cdpCalls.push({ method, params });
+        return opts.cdpResponse ? opts.cdpResponse(method, params) : {};
+      },
+    },
+    async executeJavaScript(code: string) {
+      jsCalls.push(code);
+      if (typeof opts.jsResponse === 'function') {
+        return (opts.jsResponse as (c: string) => unknown)(code);
+      }
+      return opts.jsResponse;
+    },
+  };
+  return host;
+}
+
+describe('modifierMask', () => {
+  it('combines bits per the CDP spec', () => {
+    expect(modifierMask([])).toBe(0);
+    expect(modifierMask(['alt'])).toBe(1);
+    expect(modifierMask(['ctrl'])).toBe(2);
+    expect(modifierMask(['control'])).toBe(2);
+    expect(modifierMask(['meta'])).toBe(4);
+    expect(modifierMask(['cmd'])).toBe(4);
+    expect(modifierMask(['command'])).toBe(4);
+    expect(modifierMask(['shift'])).toBe(8);
+    expect(modifierMask(['ctrl', 'shift'])).toBe(10);
+    expect(modifierMask(['meta', 'shift', 'alt'])).toBe(13);
+  });
+
+  it('ignores unknown modifier names', () => {
+    expect(modifierMask(['weird', 'shift'])).toBe(8);
+  });
+});
+
+describe('cdpClickAt', () => {
+  it('dispatches move + press + release at the given coordinates', async () => {
+    const host = makeHost();
+    const r = await cdpClickAt(host, 120, 240);
+    expect(r.ok).toBe(true);
+    expect(r.data).toEqual({ x: 120, y: 240, button: 'left' });
+    expect(host.cdpCalls.map((c) => c.method)).toEqual([
+      'Input.dispatchMouseEvent',
+      'Input.dispatchMouseEvent',
+      'Input.dispatchMouseEvent',
+    ]);
+    expect(host.cdpCalls[0].params).toMatchObject({ type: 'mouseMoved', x: 120, y: 240 });
+    expect(host.cdpCalls[1].params).toMatchObject({ type: 'mousePressed', x: 120, y: 240, button: 'left' });
+    expect(host.cdpCalls[2].params).toMatchObject({ type: 'mouseReleased', x: 120, y: 240, button: 'left' });
+  });
+
+  it('forwards button, clickCount, and modifier mask', async () => {
+    const host = makeHost();
+    await cdpClickAt(host, 10, 10, {
+      button: 'right',
+      clickCount: 2,
+      modifiers: ['shift', 'meta'],
+    });
+    expect(host.cdpCalls[1].params).toMatchObject({
+      type: 'mousePressed',
+      button: 'right',
+      clickCount: 2,
+      modifiers: 12, // shift(8) + meta(4)
+    });
+  });
+
+  it('surfaces CDP errors as structured failures', async () => {
+    const host = makeHost({
+      cdpResponse: (method) => {
+        if (method === 'Input.dispatchMouseEvent') throw new Error('bad target');
+      },
+    });
+    const r = await cdpClickAt(host, 1, 1);
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe('bad target');
+  });
+});
+
+describe('cdpClickSelector', () => {
+  it('resolves selector → centre coords via JS then clicks at centre', async () => {
+    const host = makeHost({
+      jsResponse: { ok: true, x: 50, y: 60, tag: 'button' },
+    });
+    const r = await cdpClickSelector(host, 'button.submit');
+    expect(r.ok).toBe(true);
+    expect(r.data).toMatchObject({ x: 50, y: 60, tag: 'button', selector: 'button.submit' });
+    // mousePressed at the centre point returned by the JS probe.
+    expect(host.cdpCalls[1].params).toMatchObject({ type: 'mousePressed', x: 50, y: 60 });
+  });
+
+  it('reports selector resolution failure without touching CDP', async () => {
+    const host = makeHost({
+      jsResponse: { ok: false, error: 'selector not found: .nope' },
+    });
+    const r = await cdpClickSelector(host, '.nope');
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('selector not found');
+    expect(host.cdpCalls).toHaveLength(0);
+  });
+});
+
+describe('cdpPressKey', () => {
+  it('dispatches keyDown + keyUp for a printable letter with text', async () => {
+    const host = makeHost();
+    const r = await cdpPressKey(host, 'a');
+    expect(r.ok).toBe(true);
+    expect(host.cdpCalls).toHaveLength(2);
+    // Letter 'a' uses keyDown (text-producing) — no separate rawKeyDown step.
+    expect(host.cdpCalls[0].params).toMatchObject({
+      type: 'keyDown',
+      key: 'a',
+      code: 'KeyA',
+      windowsVirtualKeyCode: 65,
+      text: 'a',
+    });
+    expect(host.cdpCalls[1].params).toMatchObject({ type: 'keyUp', key: 'a' });
+  });
+
+  it('uses rawKeyDown (no text) for special keys like Enter when no Ctrl/Meta is held', async () => {
+    const host = makeHost();
+    await cdpPressKey(host, 'Enter');
+    // Enter generates text '\r' on keyDown so it appears as keyDown, not rawKeyDown.
+    expect(host.cdpCalls[0].params).toMatchObject({
+      type: 'keyDown',
+      key: 'Enter',
+      code: 'Enter',
+      text: '\r',
+    });
+  });
+
+  it('uses rawKeyDown with empty text for chord shortcuts like Ctrl+A', async () => {
+    const host = makeHost();
+    await cdpPressKey(host, 'a', { modifiers: ['ctrl'] });
+    // ctrl is held → text must be empty so the page doesn\'t see "ctrl+a" AND a typed 'a'.
+    expect(host.cdpCalls[0].params).toMatchObject({
+      type: 'rawKeyDown',
+      key: 'a',
+      modifiers: 2,
+    });
+    expect(host.cdpCalls[0].params).not.toHaveProperty('text');
+  });
+
+  it('focuses the optional selector before pressing', async () => {
+    const host = makeHost({
+      jsResponse: (code: string) => {
+        if (code.includes('focus')) return { ok: true };
+        return { ok: false };
+      },
+    });
+    const r = await cdpPressKey(host, 'Enter', { selector: 'input#email' });
+    expect(r.ok).toBe(true);
+    expect(host.jsCalls[0]).toContain('focus');
+    expect(host.jsCalls[0]).toContain('input#email');
+  });
+
+  it('rejects unsupported keys before talking to CDP', async () => {
+    const host = makeHost();
+    const r = await cdpPressKey(host, 'Whatever');
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('unsupported');
+    expect(host.cdpCalls).toHaveLength(0);
+  });
+});
+
+describe('cdpFillSelector', () => {
+  it('focuses + clears via JS then inserts via CDP Input.insertText', async () => {
+    const host = makeHost({
+      jsResponse: { ok: true, tag: 'input', editable: true },
+    });
+    const r = await cdpFillSelector(host, 'input#q', 'hello');
+    expect(r.ok).toBe(true);
+    expect(r.data).toMatchObject({ tag: 'input', length: 5, mode: 'insertText' });
+    expect(host.cdpCalls).toEqual([
+      { method: 'Input.insertText', params: { text: 'hello' } },
+    ]);
+  });
+
+  it('rejects non-editable elements before talking to CDP', async () => {
+    const host = makeHost({
+      jsResponse: { ok: true, tag: 'div', editable: false },
+    });
+    const r = await cdpFillSelector(host, 'div.label', 'hello');
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('not editable');
+    expect(host.cdpCalls).toHaveLength(0);
+  });
+
+  it('reports JS-side selector failure without touching CDP', async () => {
+    const host = makeHost({
+      jsResponse: { ok: false, error: 'selector not found: .nope' },
+    });
+    const r = await cdpFillSelector(host, '.nope', 'x');
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('selector not found');
+    expect(host.cdpCalls).toHaveLength(0);
+  });
+});

--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -2105,10 +2105,10 @@ ${outline}`;
     },
   };
 
-  // Experimental: webview script-injection tools (page_click / page_fill /
-  // page_press / page_wait_for / page_eval). Registered ONLY when the
-  // `webview-script-injection` experimental flag is on. When off, the
-  // agent doesn't see these tool names at all.
+  // Experimental: webview page-control tools (page_click / page_click_at /
+  // page_fill / page_press / page_scroll / page_wait_for / page_eval).
+  // Registered ONLY when the `webview-page-control` experimental flag is on.
+  // When off, the agent doesn't see these tool names at all.
   const webviewActions = maybeCreateWebviewActionTools(workspaceId);
   if (webviewActions) {
     Object.assign(base, webviewActions);

--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -32,6 +32,7 @@ import {
 import { pinArtifactToCanvas } from '../artifact-ipc';
 import { getWebContentsForNode } from '../webview-registry';
 import { readDOM, readA11y, captureScreenshot } from '../webpage-reader-ipc';
+import { maybeCreateWebviewActionTools } from './webview-action-tools';
 import {
   readCanvasFull,
   writeCanvasFull,
@@ -653,7 +654,7 @@ function buildEndpoint(args: {
 // ─── Tool definitions ──────────────────────────────────────────────
 
 export function createCanvasTools(workspaceId: string): Record<string, CanvasTool> {
-  return {
+  const base: Record<string, CanvasTool> = {
     canvas_ask_user: {
       name: 'canvas_ask_user',
       description:
@@ -2103,4 +2104,15 @@ ${outline}`;
       },
     },
   };
+
+  // Experimental: webview script-injection tools (page_click / page_fill /
+  // page_press / page_wait_for / page_eval). Registered ONLY when the
+  // `webview-script-injection` experimental flag is on. When off, the
+  // agent doesn't see these tool names at all.
+  const webviewActions = maybeCreateWebviewActionTools(workspaceId);
+  if (webviewActions) {
+    Object.assign(base, webviewActions);
+  }
+
+  return base;
 }

--- a/apps/canvas-workspace/src/main/canvas-agent/webview-action-tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/webview-action-tools.ts
@@ -1,0 +1,293 @@
+/**
+ * Canvas-agent tools that **write** to webview pages — click, fill, press
+ * keys, wait for selectors, run arbitrary JS. Gated by the experimental
+ * flag {@link EXPERIMENTAL_FLAG_WEBVIEW_SCRIPT_INJECTION}; the caller
+ * decides whether to register them via {@link maybeCreateWebviewActionTools}.
+ *
+ * Every tool follows the same shape:
+ *   1. Resolve the live `WebContents` for the iframe node via the
+ *      webview registry — fail with a structured error if the node has
+ *      no mounted webview.
+ *   2. Run `evaluateActionPolicy(wc.getURL())` — fail with the policy
+ *      reason if the page isn't in scope.
+ *   3. Invoke the primitive from `webview-action.ts` and serialise the
+ *      result as a JSON string for the agent.
+ *   4. Emit one `console.info('[webview-action] …')` audit line.
+ *
+ * Returns are JSON strings (matching the existing `canvas_*` tool
+ * convention in tools.ts). Errors always have the same `{ ok: false,
+ * error }` shape so the agent can branch reliably.
+ */
+
+import { readFileSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import { z } from 'zod';
+import { getWebContentsForNode } from '../webview-registry';
+import {
+  clickSelector,
+  evalInPage,
+  fillSelector,
+  pressKey,
+  waitForCondition,
+  type PageActionResult,
+} from '../webview-action';
+import { evaluateActionPolicy } from '../webview-action-policy';
+import {
+  EXPERIMENTAL_FLAG_WEBVIEW_SCRIPT_INJECTION,
+  resolveFeatureValues,
+} from '../../shared/experimental-features';
+import type { CanvasTool } from './tools';
+
+function experimentalFlagsPath(): string {
+  const envPath = process.env.PULSE_CANVAS_EXPERIMENTAL_FEATURES?.trim();
+  return envPath || join(homedir(), '.pulse-coder', 'canvas', 'experimental-features.json');
+}
+
+function readFlagSync(id: string): boolean {
+  try {
+    const raw = readFileSync(experimentalFlagsPath(), 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const overrides: Record<string, boolean> = {};
+      for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+        if (typeof v === 'boolean') overrides[k] = v;
+      }
+      return resolveFeatureValues(overrides)[id] === true;
+    }
+  } catch {
+    // missing / unparseable file → fall through to defaults
+  }
+  return resolveFeatureValues({})[id] === true;
+}
+
+export function isWebviewScriptInjectionEnabled(): boolean {
+  return readFlagSync(EXPERIMENTAL_FLAG_WEBVIEW_SCRIPT_INJECTION);
+}
+
+interface ResolvedTarget {
+  wc: NonNullable<ReturnType<typeof getWebContentsForNode>>;
+  url: string;
+}
+
+function resolveTarget(
+  workspaceId: string,
+  nodeId: string,
+): { ok: true; target: ResolvedTarget } | { ok: false; error: string } {
+  const wc = getWebContentsForNode(workspaceId, nodeId);
+  if (!wc) {
+    return {
+      ok: false,
+      error:
+        `No active webview for node ${nodeId} in workspace ${workspaceId}. ` +
+        `Open the iframe node in URL mode and make sure it has finished loading.`,
+    };
+  }
+  const url = wc.getURL();
+  const decision = evaluateActionPolicy(url);
+  if (!decision.allow) {
+    return { ok: false, error: `policy blocked action on ${url}: ${decision.reason}` };
+  }
+  return { ok: true, target: { wc, url } };
+}
+
+function audit(action: string, nodeId: string, url: string, extra: Record<string, unknown> = {}): void {
+  let host = '';
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    host = '(invalid url)';
+  }
+  console.info(
+    `[webview-action] ${action} node=${nodeId} host=${host} ${JSON.stringify(extra)}`,
+  );
+}
+
+function serialise(action: string, nodeId: string, url: string, result: PageActionResult): string {
+  audit(action, nodeId, url, { ok: result.ok, ...(result.error ? { error: result.error } : {}) });
+  if (result.ok) {
+    return JSON.stringify({ ok: true, action, url, ...result.data });
+  }
+  return JSON.stringify({
+    ok: false,
+    action,
+    url,
+    error: result.error,
+    ...(result.timedOut ? { timedOut: true } : {}),
+  });
+}
+
+const baseDescription =
+  'Experimental — requires the `webview-script-injection` flag. ' +
+  'Operates on iframe nodes whose <webview> is mounted in URL mode. ' +
+  'Blocked on file://, chrome://, devtools://, view-source://, and a ' +
+  'built-in sensitive-domain deny list (banks, payments, mainstream auth). ' +
+  'Customize the policy via ~/.pulse-coder/canvas/webview-action-policy.json.';
+
+/**
+ * Build the webview-action tool map for a workspace. Returns `null` when
+ * the experimental flag is off — callers should treat that as "don't
+ * register these at all" so the agent doesn't even see the tool names.
+ */
+export function maybeCreateWebviewActionTools(
+  workspaceId: string,
+): Record<string, CanvasTool> | null {
+  if (!isWebviewScriptInjectionEnabled()) return null;
+
+  return {
+    page_eval: {
+      name: 'page_eval',
+      description:
+        'Run arbitrary JavaScript inside the iframe node\'s page and return its result. ' +
+        'The code body should `return` a JSON-serialisable value (or a Promise that resolves to one). ' +
+        'Use sparingly — prefer page_click / page_fill / page_press / page_wait_for for structured actions. ' +
+        baseDescription,
+      inputSchema: z.object({
+        nodeId: z.string().describe('ID of the iframe canvas node whose page to script.'),
+        code: z
+          .string()
+          .describe(
+            'JS function body to run inside the page. Use `return` to send a value back. ' +
+              'Example: "return document.querySelectorAll(\'a\').length"',
+          ),
+        timeoutMs: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe('Max time to wait for the script to settle. Default 5000.'),
+      }),
+      execute: async (input) => {
+        const r = resolveTarget(workspaceId, input.nodeId as string);
+        if (!r.ok) return JSON.stringify({ ok: false, action: 'page_eval', error: r.error });
+        const result = await evalInPage(r.target.wc, input.code as string, input.timeoutMs as number | undefined);
+        return serialise('page_eval', input.nodeId as string, r.target.url, result);
+      },
+    },
+
+    page_click: {
+      name: 'page_click',
+      description:
+        'Click an element matching a CSS selector. Scrolls the element into view first and ' +
+        'verifies it has non-zero size before dispatching a real click. ' +
+        baseDescription,
+      inputSchema: z.object({
+        nodeId: z.string().describe('ID of the iframe canvas node.'),
+        selector: z.string().describe('CSS selector for the element to click.'),
+        timeoutMs: z.number().int().positive().optional(),
+      }),
+      execute: async (input) => {
+        const r = resolveTarget(workspaceId, input.nodeId as string);
+        if (!r.ok) return JSON.stringify({ ok: false, action: 'page_click', error: r.error });
+        const result = await clickSelector(
+          r.target.wc,
+          input.selector as string,
+          input.timeoutMs as number | undefined,
+        );
+        return serialise('page_click', input.nodeId as string, r.target.url, result);
+      },
+    },
+
+    page_fill: {
+      name: 'page_fill',
+      description:
+        'Set the value of an <input>, <textarea>, <select>, or contenteditable element. ' +
+        'Uses the React-safe native value setter and dispatches input/change events so framework state tracking sees the update. ' +
+        'Does NOT submit forms — call page_press({ key: "Enter" }) or page_click on a submit button to commit. ' +
+        baseDescription,
+      inputSchema: z.object({
+        nodeId: z.string().describe('ID of the iframe canvas node.'),
+        selector: z.string().describe('CSS selector for the editable element.'),
+        value: z.string().describe('Replacement value. Replaces the entire current value.'),
+        timeoutMs: z.number().int().positive().optional(),
+      }),
+      execute: async (input) => {
+        const r = resolveTarget(workspaceId, input.nodeId as string);
+        if (!r.ok) return JSON.stringify({ ok: false, action: 'page_fill', error: r.error });
+        const result = await fillSelector(
+          r.target.wc,
+          input.selector as string,
+          input.value as string,
+          input.timeoutMs as number | undefined,
+        );
+        return serialise('page_fill', input.nodeId as string, r.target.url, result);
+      },
+    },
+
+    page_press: {
+      name: 'page_press',
+      description:
+        'Dispatch a single keyboard event (keydown + keypress + keyup) to the page. ' +
+        'Useful for Enter to submit, Tab to advance focus, Escape to close menus, arrow keys to navigate lists. ' +
+        'For multi-character text input, prefer page_fill. ' +
+        'Supported keys: Enter, Tab, Escape, Backspace, Delete, ArrowUp/Down/Left/Right, Home, End, PageUp, PageDown, Space, or any single character. ' +
+        baseDescription,
+      inputSchema: z.object({
+        nodeId: z.string().describe('ID of the iframe canvas node.'),
+        key: z.string().describe('Key name (e.g. "Enter", "ArrowDown") or a single character.'),
+        selector: z
+          .string()
+          .optional()
+          .describe('Optional element to focus before pressing. Defaults to the currently focused element.'),
+        timeoutMs: z.number().int().positive().optional(),
+      }),
+      execute: async (input) => {
+        const r = resolveTarget(workspaceId, input.nodeId as string);
+        if (!r.ok) return JSON.stringify({ ok: false, action: 'page_press', error: r.error });
+        const result = await pressKey(
+          r.target.wc,
+          input.key as string,
+          input.selector as string | undefined,
+          input.timeoutMs as number | undefined,
+        );
+        return serialise('page_press', input.nodeId as string, r.target.url, result);
+      },
+    },
+
+    page_wait_for: {
+      name: 'page_wait_for',
+      description:
+        'Poll the page until a condition is met or timeout. Provide EITHER `selector` ' +
+        '(waits for a visible element matching the CSS selector) OR `predicate` (a JS ' +
+        'function body that should `return` truthy when ready, e.g. ' +
+        '"return location.pathname === \'/dashboard\'"). ' +
+        'Use this after page_click or page_fill to wait for navigations / dynamic content. ' +
+        baseDescription,
+      inputSchema: z
+        .object({
+          nodeId: z.string().describe('ID of the iframe canvas node.'),
+          selector: z.string().optional().describe('CSS selector to wait for.'),
+          predicate: z
+            .string()
+            .optional()
+            .describe('JS function body returning a truthy value when ready.'),
+          timeoutMs: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe('Max wait time in ms. Default 5000.'),
+          intervalMs: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe('Poll interval in ms. Default 100.'),
+        })
+        .refine((v) => !!v.selector || !!v.predicate, {
+          message: 'Provide either selector or predicate.',
+        }),
+      execute: async (input) => {
+        const r = resolveTarget(workspaceId, input.nodeId as string);
+        if (!r.ok) return JSON.stringify({ ok: false, action: 'page_wait_for', error: r.error });
+        const result = await waitForCondition(r.target.wc, {
+          selector: input.selector as string | undefined,
+          predicate: input.predicate as string | undefined,
+          timeoutMs: input.timeoutMs as number | undefined,
+          intervalMs: input.intervalMs as number | undefined,
+        });
+        return serialise('page_wait_for', input.nodeId as string, r.target.url, result);
+      },
+    },
+  };
+}

--- a/apps/canvas-workspace/src/main/canvas-agent/webview-action-tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/webview-action-tools.ts
@@ -25,14 +25,17 @@ import { join } from 'path';
 import { z } from 'zod';
 import { getWebContentsForNode } from '../webview-registry';
 import {
-  clickSelector,
   evalInPage,
-  fillSelector,
-  pressKey,
   scrollPage,
   waitForCondition,
   type PageActionResult,
 } from '../webview-action';
+import {
+  cdpClickAt,
+  cdpClickSelector,
+  cdpFillSelector,
+  cdpPressKey,
+} from '../webview-cdp-actions';
 import { evaluateActionPolicy } from '../webview-action-policy';
 import {
   EXPERIMENTAL_FLAG_WEBVIEW_SCRIPT_INJECTION,
@@ -181,47 +184,104 @@ export function maybeCreateWebviewActionTools(
     page_click: {
       name: 'page_click',
       description:
-        'Click an element matching a CSS selector. Scrolls the element into view first and ' +
-        'verifies it has non-zero size before dispatching a real click. ' +
+        'Click an element matching a CSS selector via CDP — produces a real ' +
+        'mousePressed/mouseReleased pair through Chromium\'s input router (not a JS ' +
+        '`el.click()`), so hover handlers, pointer events, user-activation-gated APIs ' +
+        '(clipboard write, popup, fullscreen) all behave as if a human clicked. ' +
+        'Scrolls the element into view first. Accepts modifiers (shift / ctrl / meta / alt) ' +
+        'and button (left / middle / right). ' +
         baseDescription,
       inputSchema: z.object({
         nodeId: z.string().describe('ID of the iframe canvas node.'),
         selector: z.string().describe('CSS selector for the element to click.'),
+        button: z.enum(['left', 'middle', 'right']).optional().describe('Mouse button. Default "left".'),
+        clickCount: z.number().int().positive().optional().describe('1 for click, 2 for double-click.'),
+        modifiers: z
+          .array(z.enum(['shift', 'ctrl', 'control', 'meta', 'cmd', 'command', 'alt']))
+          .optional()
+          .describe('Keyboard modifiers held during the click.'),
         timeoutMs: z.number().int().positive().optional(),
       }),
       execute: async (input) => {
         const r = resolveTarget(workspaceId, input.nodeId as string);
         if (!r.ok) return JSON.stringify({ ok: false, action: 'page_click', error: r.error });
-        const result = await clickSelector(
-          r.target.wc,
-          input.selector as string,
-          input.timeoutMs as number | undefined,
-        );
+        const result = await cdpClickSelector(r.target.wc, input.selector as string, {
+          button: input.button as 'left' | 'middle' | 'right' | undefined,
+          clickCount: input.clickCount as number | undefined,
+          modifiers: input.modifiers as string[] | undefined,
+          timeoutMs: input.timeoutMs as number | undefined,
+        });
         return serialise('page_click', input.nodeId as string, r.target.url, result);
+      },
+    },
+
+    page_click_at: {
+      name: 'page_click_at',
+      description:
+        'Click at absolute viewport coordinates (x, y) via CDP. Use this when paired ' +
+        'with `canvas_read_webpage({ strategy: "screenshot" })` + vision — the agent ' +
+        'sees a screenshot, picks a pixel, then clicks there. Coordinates are in CSS ' +
+        'pixels relative to the visual viewport top-left. ' +
+        baseDescription,
+      inputSchema: z.object({
+        nodeId: z.string().describe('ID of the iframe canvas node.'),
+        x: z.number().describe('Viewport x coordinate (CSS pixels).'),
+        y: z.number().describe('Viewport y coordinate (CSS pixels).'),
+        button: z.enum(['left', 'middle', 'right']).optional(),
+        clickCount: z.number().int().positive().optional(),
+        modifiers: z
+          .array(z.enum(['shift', 'ctrl', 'control', 'meta', 'cmd', 'command', 'alt']))
+          .optional(),
+        timeoutMs: z.number().int().positive().optional(),
+      }),
+      execute: async (input) => {
+        const r = resolveTarget(workspaceId, input.nodeId as string);
+        if (!r.ok) return JSON.stringify({ ok: false, action: 'page_click_at', error: r.error });
+        const result = await cdpClickAt(
+          r.target.wc,
+          input.x as number,
+          input.y as number,
+          {
+            button: input.button as 'left' | 'middle' | 'right' | undefined,
+            clickCount: input.clickCount as number | undefined,
+            modifiers: input.modifiers as string[] | undefined,
+            timeoutMs: input.timeoutMs as number | undefined,
+          },
+        );
+        return serialise('page_click_at', input.nodeId as string, r.target.url, result);
       },
     },
 
     page_fill: {
       name: 'page_fill',
       description:
-        'Set the value of an <input>, <textarea>, <select>, or contenteditable element. ' +
-        'Uses the React-safe native value setter and dispatches input/change events so framework state tracking sees the update. ' +
-        'Does NOT submit forms — call page_press({ key: "Enter" }) or page_click on a submit button to commit. ' +
+        'Fill an <input>, <textarea>, or contenteditable element with `value`. ' +
+        'Focuses the element, clears the existing value (React-safe via the native ' +
+        'setter), then inserts the new value via CDP `Input.insertText` — single atomic ' +
+        'insert, like a paste. Does NOT submit forms — follow up with page_press({ key: "Enter" }) ' +
+        'or page_click on a submit button. ' +
         baseDescription,
       inputSchema: z.object({
         nodeId: z.string().describe('ID of the iframe canvas node.'),
         selector: z.string().describe('CSS selector for the editable element.'),
-        value: z.string().describe('Replacement value. Replaces the entire current value.'),
+        value: z.string().describe('Replacement value. Replaces the entire current value by default.'),
+        clearFirst: z
+          .boolean()
+          .optional()
+          .describe('If false, appends instead of replacing. Default true.'),
         timeoutMs: z.number().int().positive().optional(),
       }),
       execute: async (input) => {
         const r = resolveTarget(workspaceId, input.nodeId as string);
         if (!r.ok) return JSON.stringify({ ok: false, action: 'page_fill', error: r.error });
-        const result = await fillSelector(
+        const result = await cdpFillSelector(
           r.target.wc,
           input.selector as string,
           input.value as string,
-          input.timeoutMs as number | undefined,
+          {
+            clearFirst: input.clearFirst as boolean | undefined,
+            timeoutMs: input.timeoutMs as number | undefined,
+          },
         );
         return serialise('page_fill', input.nodeId as string, r.target.url, result);
       },
@@ -230,10 +290,13 @@ export function maybeCreateWebviewActionTools(
     page_press: {
       name: 'page_press',
       description:
-        'Dispatch a single keyboard event (keydown + keypress + keyup) to the page. ' +
-        'Useful for Enter to submit, Tab to advance focus, Escape to close menus, arrow keys to navigate lists. ' +
+        'Dispatch a keyDown + keyUp pair via CDP — real keyboard events with proper ' +
+        '`isTrusted=true` and user-activation, so React shortcuts (Cmd+K, Ctrl+S, etc.) ' +
+        'and native form-submit-on-Enter work. ' +
+        'Supports modifiers (shift / ctrl / meta / alt). ' +
+        'Supported keys: Enter, Tab, Escape, Backspace, Delete, ArrowUp/Down/Left/Right, ' +
+        'Home, End, PageUp, PageDown, Space, or any single character. ' +
         'For multi-character text input, prefer page_fill. ' +
-        'Supported keys: Enter, Tab, Escape, Backspace, Delete, ArrowUp/Down/Left/Right, Home, End, PageUp, PageDown, Space, or any single character. ' +
         baseDescription,
       inputSchema: z.object({
         nodeId: z.string().describe('ID of the iframe canvas node.'),
@@ -242,17 +305,20 @@ export function maybeCreateWebviewActionTools(
           .string()
           .optional()
           .describe('Optional element to focus before pressing. Defaults to the currently focused element.'),
+        modifiers: z
+          .array(z.enum(['shift', 'ctrl', 'control', 'meta', 'cmd', 'command', 'alt']))
+          .optional()
+          .describe('Keyboard modifiers (e.g. ["meta"] for Cmd+key, ["ctrl","shift"] for Ctrl+Shift+key).'),
         timeoutMs: z.number().int().positive().optional(),
       }),
       execute: async (input) => {
         const r = resolveTarget(workspaceId, input.nodeId as string);
         if (!r.ok) return JSON.stringify({ ok: false, action: 'page_press', error: r.error });
-        const result = await pressKey(
-          r.target.wc,
-          input.key as string,
-          input.selector as string | undefined,
-          input.timeoutMs as number | undefined,
-        );
+        const result = await cdpPressKey(r.target.wc, input.key as string, {
+          selector: input.selector as string | undefined,
+          modifiers: input.modifiers as string[] | undefined,
+          timeoutMs: input.timeoutMs as number | undefined,
+        });
         return serialise('page_press', input.nodeId as string, r.target.url, result);
       },
     },

--- a/apps/canvas-workspace/src/main/canvas-agent/webview-action-tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/webview-action-tools.ts
@@ -1,7 +1,7 @@
 /**
  * Canvas-agent tools that **write** to webview pages — click, fill, press
  * keys, wait for selectors, run arbitrary JS. Gated by the experimental
- * flag {@link EXPERIMENTAL_FLAG_WEBVIEW_SCRIPT_INJECTION}; the caller
+ * flag {@link EXPERIMENTAL_FLAG_WEBVIEW_PAGE_CONTROL}; the caller
  * decides whether to register them via {@link maybeCreateWebviewActionTools}.
  *
  * Every tool follows the same shape:
@@ -38,7 +38,7 @@ import {
 } from '../webview-cdp-actions';
 import { evaluateActionPolicy } from '../webview-action-policy';
 import {
-  EXPERIMENTAL_FLAG_WEBVIEW_SCRIPT_INJECTION,
+  EXPERIMENTAL_FLAG_WEBVIEW_PAGE_CONTROL,
   resolveFeatureValues,
 } from '../../shared/experimental-features';
 import type { CanvasTool } from './tools';
@@ -66,7 +66,7 @@ function readFlagSync(id: string): boolean {
 }
 
 export function isWebviewScriptInjectionEnabled(): boolean {
-  return readFlagSync(EXPERIMENTAL_FLAG_WEBVIEW_SCRIPT_INJECTION);
+  return readFlagSync(EXPERIMENTAL_FLAG_WEBVIEW_PAGE_CONTROL);
 }
 
 interface ResolvedTarget {
@@ -134,7 +134,7 @@ function serialise(action: string, nodeId: string, url: string, result: PageActi
 }
 
 const baseDescription =
-  'Experimental — requires the `webview-script-injection` flag. ' +
+  'Experimental — requires the `webview-page-control` flag. ' +
   'Operates on iframe nodes whose <webview> is mounted in URL mode. ' +
   'Blocked on file://, chrome://, devtools://, view-source://, and a ' +
   'built-in sensitive-domain deny list (banks, payments, mainstream auth). ' +

--- a/apps/canvas-workspace/src/main/canvas-agent/webview-action-tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/webview-action-tools.ts
@@ -29,6 +29,7 @@ import {
   evalInPage,
   fillSelector,
   pressKey,
+  scrollPage,
   waitForCondition,
   type PageActionResult,
 } from '../webview-action';
@@ -105,16 +106,28 @@ function audit(action: string, nodeId: string, url: string, extra: Record<string
 
 function serialise(action: string, nodeId: string, url: string, result: PageActionResult): string {
   audit(action, nodeId, url, { ok: result.ok, ...(result.error ? { error: result.error } : {}) });
-  if (result.ok) {
-    return JSON.stringify({ ok: true, action, url, ...result.data });
+  try {
+    if (result.ok) {
+      return JSON.stringify({ ok: true, action, url, ...result.data });
+    }
+    return JSON.stringify({
+      ok: false,
+      action,
+      url,
+      error: result.error,
+      ...(result.timedOut ? { timedOut: true } : {}),
+    });
+  } catch (e) {
+    // BigInt / cycle / Date / other non-JSON-friendly content snuck in.
+    // evalInPage normally catches this earlier; this is the last-line
+    // defense so the tool never throws into the engine.
+    return JSON.stringify({
+      ok: false,
+      action,
+      url,
+      error: `result was not JSON-serialisable: ${e instanceof Error ? e.message : String(e)}`,
+    });
   }
-  return JSON.stringify({
-    ok: false,
-    action,
-    url,
-    error: result.error,
-    ...(result.timedOut ? { timedOut: true } : {}),
-  });
 }
 
 const baseDescription =
@@ -244,6 +257,66 @@ export function maybeCreateWebviewActionTools(
       },
     },
 
+    page_scroll: {
+      name: 'page_scroll',
+      description:
+        'Scroll the page. Provide exactly one of: ' +
+        '`top: true` (scroll to start), `bottom: true` (scroll to end), ' +
+        '`selector` (scrollIntoView on the matching element), or ' +
+        '`by: { x, y }` (relative scroll in pixels — positive y scrolls down). ' +
+        'Returns the post-scroll position plus atTop / atBottom booleans so ' +
+        'the agent can decide whether to scroll again (e.g. infinite-scroll pagination). ' +
+        baseDescription,
+      inputSchema: z
+        .object({
+          nodeId: z.string().describe('ID of the iframe canvas node.'),
+          top: z.boolean().optional().describe('Scroll to the top of the page.'),
+          bottom: z.boolean().optional().describe('Scroll to the bottom of the page.'),
+          selector: z
+            .string()
+            .optional()
+            .describe('CSS selector — scrollIntoView() this element.'),
+          by: z
+            .object({
+              x: z.number().optional(),
+              y: z.number().optional(),
+            })
+            .optional()
+            .describe('Relative scroll in pixels. Positive y scrolls down.'),
+          block: z
+            .enum(['start', 'center', 'end', 'nearest'])
+            .optional()
+            .describe(
+              'scrollIntoView block alignment when using `selector`. Default "center".',
+            ),
+          timeoutMs: z.number().int().positive().optional(),
+        })
+        .refine(
+          (v) =>
+            !!v.top ||
+            !!v.bottom ||
+            !!v.selector ||
+            (!!v.by && (typeof v.by.x === 'number' || typeof v.by.y === 'number')),
+          { message: 'Provide one of: top, bottom, selector, or by{x,y}.' },
+        ),
+      execute: async (input) => {
+        const r = resolveTarget(workspaceId, input.nodeId as string);
+        if (!r.ok) return JSON.stringify({ ok: false, action: 'page_scroll', error: r.error });
+        const result = await scrollPage(
+          r.target.wc,
+          {
+            top: input.top as boolean | undefined,
+            bottom: input.bottom as boolean | undefined,
+            selector: input.selector as string | undefined,
+            by: input.by as { x?: number; y?: number } | undefined,
+            block: input.block as 'start' | 'center' | 'end' | 'nearest' | undefined,
+          },
+          input.timeoutMs as number | undefined,
+        );
+        return serialise('page_scroll', input.nodeId as string, r.target.url, result);
+      },
+    },
+
     page_wait_for: {
       name: 'page_wait_for',
       description:
@@ -285,6 +358,22 @@ export function maybeCreateWebviewActionTools(
           predicate: input.predicate as string | undefined,
           timeoutMs: input.timeoutMs as number | undefined,
           intervalMs: input.intervalMs as number | undefined,
+          // Re-validate policy on every probe — pages can redirect during
+          // a long wait (neutral page → login). If the live URL becomes
+          // blocked, abort the wait with the policy reason instead of
+          // continuing to inject probe scripts on the new origin.
+          abortCheck: () => {
+            try {
+              const liveUrl = r.target.wc.getURL();
+              const decision = evaluateActionPolicy(liveUrl);
+              if (!decision.allow) {
+                return `policy blocked action on ${liveUrl}: ${decision.reason}`;
+              }
+              return null;
+            } catch (e) {
+              return `failed to re-validate URL policy: ${e instanceof Error ? e.message : String(e)}`;
+            }
+          },
         });
         return serialise('page_wait_for', input.nodeId as string, r.target.url, result);
       },

--- a/apps/canvas-workspace/src/main/cdp-session.ts
+++ b/apps/canvas-workspace/src/main/cdp-session.ts
@@ -1,0 +1,93 @@
+/**
+ * Single-slot CDP session helper for an Electron `<webview>` WebContents.
+ *
+ * Electron's `webContents.debugger` exposes the Chrome DevTools Protocol —
+ * but a webContents can only have **one** debugger attached at a time, so
+ * concurrent callers (a screenshot read overlapping with a click action,
+ * for example) will collide on `debugger.attach()` and one of them will
+ * throw "Debugger is already attached to this target".
+ *
+ * {@link withCdp} serialises CDP usage per-webContents via a promise
+ * chain stored in a WeakMap. Each call:
+ *   1. Queues behind any in-flight CDP work on the same webContents.
+ *   2. Attaches the debugger (no-op if something already attached it
+ *      out-of-band, e.g. user opening DevTools).
+ *   3. Runs the caller's body with a typed `send(method, params)` helper.
+ *   4. Detaches if we were the attacher, always — even on rejection.
+ *
+ * Reading and writing primitives both go through this. Tests pass a
+ * stub `CdpHost` so they don't need a real webContents.
+ */
+
+const VERSION = '1.3';
+
+export interface CdpDebuggerHandle {
+  isAttached(): boolean;
+  attach(protocolVersion?: string): void;
+  detach(): void;
+  sendCommand(method: string, params?: Record<string, unknown>): Promise<unknown>;
+}
+
+export interface CdpHost {
+  debugger: CdpDebuggerHandle;
+}
+
+export type CdpSender = <T = unknown>(
+  method: string,
+  params?: Record<string, unknown>,
+) => Promise<T>;
+
+// Per-webContents lock. WeakMap so destroyed webContents drop their
+// entry automatically — no manual cleanup needed.
+const locks = new WeakMap<object, Promise<unknown>>();
+
+/**
+ * Run `fn` with exclusive CDP access to `host`. The mutex guarantees:
+ *   - No two `withCdp` calls run their bodies concurrently on the same host.
+ *   - The debugger is detached when our body finishes, even if it threw.
+ *   - The next queued caller proceeds after we resolve the chain entry,
+ *     regardless of whether our body resolved or rejected.
+ */
+export async function withCdp<T>(
+  host: CdpHost,
+  fn: (send: CdpSender) => Promise<T>,
+): Promise<T> {
+  // IMPORTANT: read prev + set new BEFORE any await, otherwise two
+  // simultaneous callers can both read the same `prev` and run in parallel.
+  const prev = locks.get(host) ?? Promise.resolve();
+  let releaseChain!: () => void;
+  const chainEntry = new Promise<void>((resolve) => {
+    releaseChain = resolve;
+  });
+  locks.set(host, chainEntry);
+
+  // Wait our turn.
+  try {
+    await prev;
+  } catch {
+    // Predecessor rejected — that's not our problem. The chain still
+    // advances; our body still runs.
+  }
+
+  let attachedByUs = false;
+  try {
+    if (!host.debugger.isAttached()) {
+      host.debugger.attach(VERSION);
+      attachedByUs = true;
+    }
+    const send: CdpSender = <R>(method: string, params?: Record<string, unknown>) =>
+      host.debugger.sendCommand(method, params) as Promise<R>;
+    return await fn(send);
+  } finally {
+    if (attachedByUs) {
+      try {
+        host.debugger.detach();
+      } catch {
+        // Detach is best-effort — if the page navigated away mid-flight,
+        // the debugger may already be gone. Swallow so we don't shadow
+        // the real error.
+      }
+    }
+    releaseChain();
+  }
+}

--- a/apps/canvas-workspace/src/main/webpage-reader-ipc.ts
+++ b/apps/canvas-workspace/src/main/webpage-reader-ipc.ts
@@ -22,6 +22,7 @@ import { tmpdir } from 'os';
 import { promises as fs } from 'fs';
 import { randomUUID } from 'crypto';
 import { getWebContentsForNode } from './webview-registry';
+import { withCdp, type CdpSender } from './cdp-session';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -120,26 +121,26 @@ export async function readA11y(
   wc: AnyWebContents,
 ): Promise<{ ok: boolean; text: string; error?: string }> {
   try {
-    wc.debugger.attach('1.3');
-    await wc.debugger.sendCommand('Accessibility.enable');
-
-    const result = await Promise.race([
-      wc.debugger.sendCommand('Accessibility.getFullAXTree') as Promise<{
-        nodes: Array<{
-          nodeId: string;
-          role?: { value?: string };
-          name?: { value?: string };
-          description?: { value?: string };
-          value?: { value?: string };
-          childIds?: string[];
-        }>;
-      }>,
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('a11y extraction timed out')), EXTRACT_TIMEOUT_MS),
-      ),
-    ]);
-
-    wc.debugger.detach();
+    // Go through the per-wc mutex so a concurrent screenshot read or
+    // CDP-based click can't race us on `debugger.attach`.
+    const result = await withCdp(wc, async (send: CdpSender) => {
+      await send('Accessibility.enable');
+      return (await Promise.race([
+        send<{
+          nodes: Array<{
+            nodeId: string;
+            role?: { value?: string };
+            name?: { value?: string };
+            description?: { value?: string };
+            value?: { value?: string };
+            childIds?: string[];
+          }>;
+        }>('Accessibility.getFullAXTree'),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('a11y extraction timed out')), EXTRACT_TIMEOUT_MS),
+        ),
+      ]));
+    });
 
     const { nodes } = result;
     const idMap = new Map(nodes.map((n) => [n.nodeId, n]));
@@ -147,8 +148,6 @@ export async function readA11y(
     const lines = root ? flattenA11yNodes(nodes, idMap, root.nodeId) : [];
     return { ok: true, text: lines.join('\n') || '(empty a11y tree)' };
   } catch (err) {
-    // Best-effort detach in case we attached before the error.
-    try { wc.debugger.detach(); } catch { /* ignore */ }
     return { ok: false, text: '', error: err instanceof Error ? err.message : String(err) };
   }
 }
@@ -159,67 +158,61 @@ export async function captureScreenshot(
   const MAX_HEIGHT_PX = 8_000;
   const DEFAULT_WIDTH_PX = 1_280;
 
-  let debuggerAttached = false;
-  let viewportOverrideSet = false;
   try {
-    wc.debugger.attach('1.3');
-    debuggerAttached = true;
+    const result = await withCdp(wc, async (send: CdpSender) => {
+      // Read both the full content size and the current visual viewport
+      // size so we can restore the exact original dimensions after.
+      const metrics = await send<{
+        contentSize: { width: number; height: number };
+        visualViewport: { clientWidth: number; clientHeight: number };
+      }>('Page.getLayoutMetrics');
 
-    // Read both the full content size and the current visual viewport size
-    // so we can restore the exact original dimensions afterwards.
-    const metrics = await wc.debugger.sendCommand('Page.getLayoutMetrics') as {
-      contentSize: { width: number; height: number };
-      visualViewport: { clientWidth: number; clientHeight: number };
-    };
+      const origWidth = metrics.visualViewport.clientWidth || DEFAULT_WIDTH_PX;
+      const origHeight = metrics.visualViewport.clientHeight || 900;
+      const fullWidth = Math.max(Math.ceil(metrics.contentSize.width), DEFAULT_WIDTH_PX);
+      const fullHeight = Math.min(Math.ceil(metrics.contentSize.height), MAX_HEIGHT_PX);
 
-    const origWidth  = metrics.visualViewport.clientWidth  || DEFAULT_WIDTH_PX;
-    const origHeight = metrics.visualViewport.clientHeight || 900;
-    const fullWidth  = Math.max(Math.ceil(metrics.contentSize.width),  DEFAULT_WIDTH_PX);
-    const fullHeight = Math.min(Math.ceil(metrics.contentSize.height), MAX_HEIGHT_PX);
+      const needsExpansion = fullHeight > origHeight;
+      let viewportOverrideSet = false;
 
-    const needsExpansion = fullHeight > origHeight;
+      try {
+        if (needsExpansion) {
+          await send('Emulation.setDeviceMetricsOverride', {
+            width: fullWidth,
+            height: fullHeight,
+            deviceScaleFactor: 1,
+            mobile: false,
+          });
+          viewportOverrideSet = true;
+        }
 
-    if (needsExpansion) {
-      await wc.debugger.sendCommand('Emulation.setDeviceMetricsOverride', {
-        width: fullWidth,
-        height: fullHeight,
-        deviceScaleFactor: 1,
-        mobile: false,
-      });
-      viewportOverrideSet = true;
-    }
-
-    const result = await wc.debugger.sendCommand('Page.captureScreenshot', {
-      format: 'png',
-      fromSurface: true,
-    }) as { data: string };
-
-    // Restore original viewport before returning — minimise visible impact.
-    if (viewportOverrideSet) {
-      await wc.debugger.sendCommand('Emulation.setDeviceMetricsOverride', {
-        width: origWidth,
-        height: origHeight,
-        deviceScaleFactor: 1,
-        mobile: false,
-      });
-      // Clear the override so the webview reverts to its natural CSS-driven size.
-      await wc.debugger.sendCommand('Emulation.clearDeviceMetricsOverride');
-      viewportOverrideSet = false;
-    }
-
-    wc.debugger.detach();
-    debuggerAttached = false;
+        return await send<{ data: string }>('Page.captureScreenshot', {
+          format: 'png',
+          fromSurface: true,
+        });
+      } finally {
+        // Always restore viewport — even on screenshot failure — so the
+        // webview doesn't stay stretched.
+        if (viewportOverrideSet) {
+          try {
+            await send('Emulation.setDeviceMetricsOverride', {
+              width: origWidth,
+              height: origHeight,
+              deviceScaleFactor: 1,
+              mobile: false,
+            });
+            await send('Emulation.clearDeviceMetricsOverride');
+          } catch {
+            /* best-effort cleanup */
+          }
+        }
+      }
+    });
 
     const imagePath = `${tmpdir()}/pulse-screenshot-${randomUUID()}.png`;
     await fs.writeFile(imagePath, Buffer.from(result.data, 'base64'));
     return { ok: true, imagePath };
   } catch (err) {
-    if (debuggerAttached) {
-      if (viewportOverrideSet) {
-        try { await wc.debugger.sendCommand('Emulation.clearDeviceMetricsOverride'); } catch { /* ignore */ }
-      }
-      try { wc.debugger.detach(); } catch { /* ignore */ }
-    }
     return { ok: false, imagePath: '', error: err instanceof Error ? err.message : String(err) };
   }
 }

--- a/apps/canvas-workspace/src/main/webview-action-policy.ts
+++ b/apps/canvas-workspace/src/main/webview-action-policy.ts
@@ -1,7 +1,7 @@
 /**
- * URL policy for the experimental webview script-injection tools.
+ * URL policy for the experimental webview page-control tools.
  *
- * The experimental flag `webview-script-injection` decides whether the
+ * The experimental flag `webview-page-control` decides whether the
  * `page_*` tools are registered at all. This module decides — per call —
  * whether the **current URL** of the target webview is one the agent is
  * allowed to touch. Tools call {@link evaluateActionPolicy} with the

--- a/apps/canvas-workspace/src/main/webview-action-policy.ts
+++ b/apps/canvas-workspace/src/main/webview-action-policy.ts
@@ -1,0 +1,176 @@
+/**
+ * URL policy for the experimental webview script-injection tools.
+ *
+ * The experimental flag `webview-script-injection` decides whether the
+ * `page_*` tools are registered at all. This module decides — per call —
+ * whether the **current URL** of the target webview is one the agent is
+ * allowed to touch. Tools call {@link evaluateActionPolicy} with the
+ * webview's `getURL()` before running any side-effecting JS.
+ *
+ * Defaults are conservative: anything that isn't `http(s):` or `about:blank`
+ * is denied (no `file://`, `chrome://`, `devtools://`, `chrome-extension://`,
+ * `view-source:`), and a handful of high-stakes domains (banks, payments,
+ * mainstream auth/email) are denied by hostname pattern. Users can adjust
+ * via `~/.pulse-coder/canvas/webview-action-policy.json` (or override the
+ * path with `PULSE_CANVAS_WEBVIEW_ACTION_POLICY`). Config file shape:
+ *
+ *     {
+ *       "denySchemes": ["file:", "chrome:"],   // overrides defaults
+ *       "denyHostPatterns": ["*bank*"],         // overrides defaults
+ *       "allowHostPatterns": ["github.com", "*.example.com"]  // when set,
+ *                                                  // ONLY these hosts pass
+ *     }
+ *
+ * Host patterns: literal hostnames, or globs containing `*` (any chars).
+ * Matching is case-insensitive against the URL hostname.
+ *
+ * Read-only — never mutated at runtime. Re-reads config on each call so
+ * that edits land without a restart.
+ */
+
+import { readFileSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+
+const DEFAULT_DENY_SCHEMES: ReadonlyArray<string> = [
+  'file:',
+  'chrome:',
+  'chrome-extension:',
+  'devtools:',
+  'view-source:',
+  'data:',
+  'javascript:',
+];
+
+/**
+ * Conservative defaults — anything financial, payment, identity, or
+ * mainstream personal email/social where session hijack is high-cost.
+ * Users can override with an empty `denyHostPatterns` array if they
+ * really want to.
+ */
+const DEFAULT_DENY_HOST_PATTERNS: ReadonlyArray<string> = [
+  '*bank*',
+  '*paypal*',
+  '*stripe*',
+  '*venmo*',
+  '*cashapp*',
+  'accounts.google.com',
+  'mail.google.com',
+  'login.live.com',
+  'outlook.live.com',
+  'outlook.office.com',
+  'login.microsoftonline.com',
+  'appleid.apple.com',
+  'icloud.com',
+  '*.icloud.com',
+  'auth0.com',
+  'okta.com',
+  '*.okta.com',
+  'id.atlassian.com',
+];
+
+export interface WebviewActionPolicyConfig {
+  denySchemes?: string[];
+  denyHostPatterns?: string[];
+  allowHostPatterns?: string[];
+}
+
+export interface PolicyDecision {
+  allow: boolean;
+  reason?: string;
+}
+
+export function getPolicyConfigPath(): string {
+  const envPath = process.env.PULSE_CANVAS_WEBVIEW_ACTION_POLICY?.trim();
+  return envPath || join(homedir(), '.pulse-coder', 'canvas', 'webview-action-policy.json');
+}
+
+function readPolicyConfig(): WebviewActionPolicyConfig {
+  try {
+    const raw = readFileSync(getPolicyConfigPath(), 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    return parsed as WebviewActionPolicyConfig;
+  } catch {
+    return {};
+  }
+}
+
+function matchHostPattern(host: string, pattern: string): boolean {
+  const h = host.toLowerCase();
+  const p = pattern.toLowerCase();
+  if (!p.includes('*')) return h === p;
+  // Escape regex special chars except '*', then turn '*' into '.*'.
+  const re = new RegExp(
+    '^' + p.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*') + '$',
+  );
+  return re.test(h);
+}
+
+/**
+ * Evaluate the action policy for a given URL. Pure function — the
+ * `config` arg is exposed so tests can inject scenarios without touching
+ * disk; production callers should use {@link evaluateActionPolicy}.
+ */
+export function evaluateActionPolicyWith(
+  url: string,
+  config: WebviewActionPolicyConfig,
+): PolicyDecision {
+  if (typeof url !== 'string' || url.length === 0) {
+    return { allow: false, reason: 'empty URL' };
+  }
+
+  // `about:blank` is the default landing page — harmless, allow.
+  if (url === 'about:blank') return { allow: true };
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { allow: false, reason: `unparseable URL: ${url}` };
+  }
+
+  const scheme = parsed.protocol.toLowerCase();
+  const denySchemes = config.denySchemes ?? DEFAULT_DENY_SCHEMES;
+  if (denySchemes.includes(scheme)) {
+    return { allow: false, reason: `scheme ${scheme} is denied by policy` };
+  }
+  // Only http(s) past this point. Anything else (ws:, mailto:, etc.) is
+  // not meaningful for a browser-style webview action.
+  if (scheme !== 'http:' && scheme !== 'https:') {
+    return { allow: false, reason: `scheme ${scheme} is not http(s)` };
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  if (!host) return { allow: false, reason: 'URL has no hostname' };
+
+  const denyPatterns = config.denyHostPatterns ?? DEFAULT_DENY_HOST_PATTERNS;
+  for (const pat of denyPatterns) {
+    if (matchHostPattern(host, pat)) {
+      return { allow: false, reason: `host ${host} matches deny pattern "${pat}"` };
+    }
+  }
+
+  const allowPatterns = config.allowHostPatterns;
+  if (Array.isArray(allowPatterns) && allowPatterns.length > 0) {
+    const hit = allowPatterns.some((pat) => matchHostPattern(host, pat));
+    if (!hit) {
+      return {
+        allow: false,
+        reason: `host ${host} is not in the configured allow list`,
+      };
+    }
+  }
+
+  return { allow: true };
+}
+
+/**
+ * Production entry point: reads policy from disk (or env override) and
+ * evaluates against the given URL. Returns `{ allow: false, reason }` on
+ * any disallowed URL — caller should surface `reason` to the agent so it
+ * knows why it can't act.
+ */
+export function evaluateActionPolicy(url: string): PolicyDecision {
+  return evaluateActionPolicyWith(url, readPolicyConfig());
+}

--- a/apps/canvas-workspace/src/main/webview-action-policy.ts
+++ b/apps/canvas-workspace/src/main/webview-action-policy.ts
@@ -64,8 +64,10 @@ const DEFAULT_DENY_HOST_PATTERNS: ReadonlyArray<string> = [
   'icloud.com',
   '*.icloud.com',
   'auth0.com',
+  '*.auth0.com',
   'okta.com',
   '*.okta.com',
+  '*.oktapreview.com',
   'id.atlassian.com',
 ];
 
@@ -85,12 +87,30 @@ export function getPolicyConfigPath(): string {
   return envPath || join(homedir(), '.pulse-coder', 'canvas', 'webview-action-policy.json');
 }
 
+/** Keep only string entries — protects matchHostPattern from numeric / null
+ *  entries that would throw on `.toLowerCase()`. */
+function filterStrings(input: unknown): string[] | undefined {
+  if (!Array.isArray(input)) return undefined;
+  return input.filter((v): v is string => typeof v === 'string' && v.length > 0);
+}
+
+function normalisePolicyConfig(parsed: unknown): WebviewActionPolicyConfig {
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+  const src = parsed as Record<string, unknown>;
+  const out: WebviewActionPolicyConfig = {};
+  const denySchemes = filterStrings(src.denySchemes);
+  if (denySchemes) out.denySchemes = denySchemes;
+  const denyHostPatterns = filterStrings(src.denyHostPatterns);
+  if (denyHostPatterns) out.denyHostPatterns = denyHostPatterns;
+  const allowHostPatterns = filterStrings(src.allowHostPatterns);
+  if (allowHostPatterns) out.allowHostPatterns = allowHostPatterns;
+  return out;
+}
+
 function readPolicyConfig(): WebviewActionPolicyConfig {
   try {
     const raw = readFileSync(getPolicyConfigPath(), 'utf8');
-    const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
-    return parsed as WebviewActionPolicyConfig;
+    return normalisePolicyConfig(JSON.parse(raw));
   } catch {
     return {};
   }
@@ -131,7 +151,12 @@ export function evaluateActionPolicyWith(
   }
 
   const scheme = parsed.protocol.toLowerCase();
-  const denySchemes = config.denySchemes ?? DEFAULT_DENY_SCHEMES;
+  // Defensively filter to strings — `config` is sometimes hand-built by
+  // tests or callers passing un-validated JSON. Production `readPolicyConfig`
+  // normalises already; this is belt-and-suspenders.
+  const denySchemes = (config.denySchemes ?? DEFAULT_DENY_SCHEMES).filter(
+    (v): v is string => typeof v === 'string',
+  );
   if (denySchemes.includes(scheme)) {
     return { allow: false, reason: `scheme ${scheme} is denied by policy` };
   }
@@ -144,15 +169,19 @@ export function evaluateActionPolicyWith(
   const host = parsed.hostname.toLowerCase();
   if (!host) return { allow: false, reason: 'URL has no hostname' };
 
-  const denyPatterns = config.denyHostPatterns ?? DEFAULT_DENY_HOST_PATTERNS;
+  const denyPatterns = (config.denyHostPatterns ?? DEFAULT_DENY_HOST_PATTERNS).filter(
+    (v): v is string => typeof v === 'string',
+  );
   for (const pat of denyPatterns) {
     if (matchHostPattern(host, pat)) {
       return { allow: false, reason: `host ${host} matches deny pattern "${pat}"` };
     }
   }
 
-  const allowPatterns = config.allowHostPatterns;
-  if (Array.isArray(allowPatterns) && allowPatterns.length > 0) {
+  const allowPatterns = Array.isArray(config.allowHostPatterns)
+    ? config.allowHostPatterns.filter((v): v is string => typeof v === 'string')
+    : undefined;
+  if (allowPatterns && allowPatterns.length > 0) {
     const hit = allowPatterns.some((pat) => matchHostPattern(host, pat));
     if (!hit) {
       return {

--- a/apps/canvas-workspace/src/main/webview-action.ts
+++ b/apps/canvas-workspace/src/main/webview-action.ts
@@ -1,0 +1,354 @@
+/**
+ * Low-level page-action primitives executed inside an iframe-node webview.
+ *
+ * These are the write side of {@link ./webpage-reader-ipc.ts}. They run
+ * inside the guest's isolated world via `webContents.executeJavaScript`,
+ * so they can't see our renderer globals and the guest can't see us. The
+ * tools layer ({@link ./canvas-agent/webview-action-tools.ts}) wraps each
+ * primitive with zod schemas, policy enforcement (see
+ * {@link ./webview-action-policy.ts}), and an audit log line.
+ *
+ * Primitives are designed to be testable: each one takes a `WebContents`-
+ * shaped object exposing just `executeJavaScript`, and returns a tagged
+ * result object. No I/O, no IPC, no electron imports — pure functions
+ * over JS source.
+ *
+ * Notes on the script approach:
+ *   - We render the JS body as a single IIFE returning a plain object;
+ *     `executeJavaScript` resolves with that object directly.
+ *   - We never string-concat untrusted values into the script. Inputs
+ *     are JSON-encoded so the guest receives them as literals.
+ *   - For React-controlled inputs we use the native setter trick
+ *     (Object.getOwnPropertyDescriptor(...).set.call(el, value)) so the
+ *     framework's value tracking sees the change.
+ */
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+const DEFAULT_WAIT_INTERVAL_MS = 100;
+
+/**
+ * Minimal `WebContents` shape used by the primitives. Production code
+ * passes an Electron `WebContents`; tests pass a stub with just
+ * `executeJavaScript`.
+ */
+export interface PageRunner {
+  executeJavaScript(code: string, userGesture?: boolean): Promise<unknown>;
+}
+
+export interface PageActionResult {
+  ok: boolean;
+  /** Free-form data per action — caller serialises to the agent. */
+  data?: Record<string, unknown>;
+  error?: string;
+  /** Set when the failure was caused by the guest-side timeout cap. */
+  timedOut?: boolean;
+}
+
+async function runWithTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  return await Promise.race([
+    p,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error(`action timed out after ${ms}ms`)), ms),
+    ),
+  ]);
+}
+
+// U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) are line
+// terminators in TS/JS source files. JSON.stringify leaves them raw, so
+// values containing them break when inlined into a JS IIFE. Build the
+// chars via fromCharCode so this source file itself contains zero
+// occurrences of the offending codepoints.
+const LS = String.fromCharCode(0x2028);
+const PS = String.fromCharCode(0x2029);
+
+/** JSON-encode a value for safe inlining into a JS source string. */
+function lit(v: unknown): string {
+  return JSON.stringify(v).split(LS).join('\\u2028').split(PS).join('\\u2029');
+}
+
+/** Build an IIFE returning a JSON-serialisable result object. */
+function asIife(body: string): string {
+  return `(function(){\n${body}\n})()`;
+}
+
+// ---------------------------------------------------------------------------
+// Script builders (exported for testing)
+// ---------------------------------------------------------------------------
+
+export function buildEvalScript(code: string): string {
+  // We wrap the user's code in another IIFE so they can `return` a value.
+  // Result is JSON-stringified to a guaranteed-serialisable string for
+  // the agent — Electron will JSON.parse() it back to plain data.
+  return asIife(`
+try {
+  var __r = (function(){ ${code} })();
+  if (__r && typeof __r.then === 'function') {
+    return __r.then(function(v){ return { ok: true, value: v }; },
+                    function(e){ return { ok: false, error: String(e && e.message || e) }; });
+  }
+  return { ok: true, value: __r };
+} catch (e) {
+  return { ok: false, error: String(e && e.message || e) };
+}
+`);
+}
+
+export function buildClickScript(selector: string): string {
+  return asIife(`
+try {
+  var el = document.querySelector(${lit(selector)});
+  if (!el) return { ok: false, error: 'selector not found: ' + ${lit(selector)} };
+  if (typeof el.scrollIntoView === 'function') {
+    el.scrollIntoView({ block: 'center', inline: 'center' });
+  }
+  var rect = el.getBoundingClientRect();
+  if (rect.width === 0 || rect.height === 0) {
+    return { ok: false, error: 'element is not visible (zero size)' };
+  }
+  el.click();
+  return { ok: true, tag: el.tagName.toLowerCase(), text: (el.innerText || '').slice(0, 200) };
+} catch (e) {
+  return { ok: false, error: String(e && e.message || e) };
+}
+`);
+}
+
+export function buildFillScript(selector: string, value: string): string {
+  return asIife(`
+try {
+  var el = document.querySelector(${lit(selector)});
+  if (!el) return { ok: false, error: 'selector not found: ' + ${lit(selector)} };
+  if (typeof el.focus === 'function') el.focus();
+  var v = ${lit(value)};
+  var tag = el.tagName ? el.tagName.toLowerCase() : '';
+  if (el.isContentEditable) {
+    el.innerText = v;
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+    return { ok: true, mode: 'contenteditable', tag: tag };
+  }
+  if (tag === 'input' || tag === 'textarea' || tag === 'select') {
+    var proto = tag === 'textarea'
+      ? window.HTMLTextAreaElement.prototype
+      : (tag === 'select' ? window.HTMLSelectElement.prototype : window.HTMLInputElement.prototype);
+    var setter = Object.getOwnPropertyDescriptor(proto, 'value');
+    if (setter && setter.set) {
+      setter.set.call(el, v);
+    } else {
+      el.value = v;
+    }
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+    return { ok: true, mode: 'value', tag: tag };
+  }
+  return { ok: false, error: 'element is not editable (tag=' + tag + ')' };
+} catch (e) {
+  return { ok: false, error: String(e && e.message || e) };
+}
+`);
+}
+
+/**
+ * Map a high-level key name like "Enter" / "ArrowDown" / "a" to the
+ * triple ({ key, code, keyCode }) most apps expect. Returns null for
+ * keys we don't have a mapping for — caller surfaces this as an error.
+ */
+export function resolveKeySpec(key: string): { key: string; code: string; keyCode: number } | null {
+  const specials: Record<string, { code: string; keyCode: number }> = {
+    Enter: { code: 'Enter', keyCode: 13 },
+    Tab: { code: 'Tab', keyCode: 9 },
+    Escape: { code: 'Escape', keyCode: 27 },
+    Backspace: { code: 'Backspace', keyCode: 8 },
+    Delete: { code: 'Delete', keyCode: 46 },
+    ArrowUp: { code: 'ArrowUp', keyCode: 38 },
+    ArrowDown: { code: 'ArrowDown', keyCode: 40 },
+    ArrowLeft: { code: 'ArrowLeft', keyCode: 37 },
+    ArrowRight: { code: 'ArrowRight', keyCode: 39 },
+    Home: { code: 'Home', keyCode: 36 },
+    End: { code: 'End', keyCode: 35 },
+    PageUp: { code: 'PageUp', keyCode: 33 },
+    PageDown: { code: 'PageDown', keyCode: 34 },
+    Space: { code: 'Space', keyCode: 32 },
+    ' ': { code: 'Space', keyCode: 32 },
+  };
+  if (specials[key]) {
+    return { key, code: specials[key].code, keyCode: specials[key].keyCode };
+  }
+  // Single printable character — treat as a literal key. Code is 'KeyX'
+  // for letters, 'DigitN' for digits, otherwise empty (apps usually
+  // care about `key` rather than `code` for typed text).
+  if (key.length === 1) {
+    const ch = key;
+    const cc = ch.charCodeAt(0);
+    let code = '';
+    if (/^[a-zA-Z]$/.test(ch)) code = 'Key' + ch.toUpperCase();
+    else if (/^[0-9]$/.test(ch)) code = 'Digit' + ch;
+    return { key: ch, code, keyCode: cc };
+  }
+  return null;
+}
+
+export function buildPressScript(
+  spec: { key: string; code: string; keyCode: number },
+  selector: string | undefined,
+): string {
+  return asIife(`
+try {
+  var target = ${selector ? `document.querySelector(${lit(selector)})` : 'document.activeElement || document.body'};
+  if (!target) return { ok: false, error: 'no target for key event' };
+  if (target.focus && typeof target.focus === 'function') target.focus();
+  var spec = ${lit(spec)};
+  var init = { key: spec.key, code: spec.code, keyCode: spec.keyCode,
+               which: spec.keyCode, bubbles: true, cancelable: true };
+  target.dispatchEvent(new KeyboardEvent('keydown', init));
+  target.dispatchEvent(new KeyboardEvent('keypress', init));
+  target.dispatchEvent(new KeyboardEvent('keyup', init));
+  return { ok: true, key: spec.key };
+} catch (e) {
+  return { ok: false, error: String(e && e.message || e) };
+}
+`);
+}
+
+export function buildProbeScript(
+  selector: string | undefined,
+  predicate: string | undefined,
+): string {
+  return asIife(`
+try {
+  ${
+    selector
+      ? `var el = document.querySelector(${lit(selector)});
+         if (!el) return { ok: true, matched: false };
+         var rect = el.getBoundingClientRect();
+         return { ok: true, matched: rect.width > 0 && rect.height > 0,
+                  text: (el.innerText || '').slice(0, 200) };`
+      : `var __r = (function(){ ${predicate ?? 'return false;'} })();
+         return { ok: true, matched: !!__r };`
+  }
+} catch (e) {
+  return { ok: false, error: String(e && e.message || e) };
+}
+`);
+}
+
+// ---------------------------------------------------------------------------
+// Primitives — run the script and shape the result
+// ---------------------------------------------------------------------------
+
+export async function evalInPage(
+  wc: PageRunner,
+  code: string,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<PageActionResult> {
+  try {
+    const raw = (await runWithTimeout(
+      wc.executeJavaScript(buildEvalScript(code), false),
+      timeoutMs,
+    )) as { ok: boolean; value?: unknown; error?: string };
+    if (!raw?.ok) return { ok: false, error: raw?.error ?? 'eval failed' };
+    return { ok: true, data: { value: raw.value } };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, error: msg, timedOut: msg.includes('timed out') };
+  }
+}
+
+export async function clickSelector(
+  wc: PageRunner,
+  selector: string,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<PageActionResult> {
+  try {
+    const raw = (await runWithTimeout(
+      wc.executeJavaScript(buildClickScript(selector), true),
+      timeoutMs,
+    )) as { ok: boolean; tag?: string; text?: string; error?: string };
+    if (!raw?.ok) return { ok: false, error: raw?.error ?? 'click failed' };
+    return { ok: true, data: { tag: raw.tag, text: raw.text } };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, error: msg, timedOut: msg.includes('timed out') };
+  }
+}
+
+export async function fillSelector(
+  wc: PageRunner,
+  selector: string,
+  value: string,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<PageActionResult> {
+  try {
+    const raw = (await runWithTimeout(
+      wc.executeJavaScript(buildFillScript(selector, value), true),
+      timeoutMs,
+    )) as { ok: boolean; mode?: string; tag?: string; error?: string };
+    if (!raw?.ok) return { ok: false, error: raw?.error ?? 'fill failed' };
+    return { ok: true, data: { tag: raw.tag, mode: raw.mode } };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, error: msg, timedOut: msg.includes('timed out') };
+  }
+}
+
+export async function pressKey(
+  wc: PageRunner,
+  key: string,
+  selector: string | undefined,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<PageActionResult> {
+  const spec = resolveKeySpec(key);
+  if (!spec) return { ok: false, error: `unsupported key: "${key}"` };
+  try {
+    const raw = (await runWithTimeout(
+      wc.executeJavaScript(buildPressScript(spec, selector), true),
+      timeoutMs,
+    )) as { ok: boolean; key?: string; error?: string };
+    if (!raw?.ok) return { ok: false, error: raw?.error ?? 'press failed' };
+    return { ok: true, data: { key: raw.key } };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, error: msg, timedOut: msg.includes('timed out') };
+  }
+}
+
+export async function waitForCondition(
+  wc: PageRunner,
+  opts: { selector?: string; predicate?: string; timeoutMs?: number; intervalMs?: number },
+): Promise<PageActionResult> {
+  const timeout = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const interval = opts.intervalMs ?? DEFAULT_WAIT_INTERVAL_MS;
+  if (!opts.selector && !opts.predicate) {
+    return { ok: false, error: 'either selector or predicate must be provided' };
+  }
+  const deadline = Date.now() + timeout;
+  const script = buildProbeScript(opts.selector, opts.predicate);
+  let lastError: string | undefined;
+  let attempts = 0;
+  while (Date.now() < deadline) {
+    attempts += 1;
+    try {
+      const raw = (await wc.executeJavaScript(script, false)) as {
+        ok: boolean;
+        matched?: boolean;
+        text?: string;
+        error?: string;
+      };
+      if (!raw?.ok) {
+        lastError = raw?.error ?? 'probe error';
+      } else if (raw.matched) {
+        return { ok: true, data: { attempts, text: raw.text } };
+      }
+    } catch (e) {
+      lastError = e instanceof Error ? e.message : String(e);
+    }
+    if (Date.now() + interval >= deadline) break;
+    await new Promise((r) => setTimeout(r, interval));
+  }
+  return {
+    ok: false,
+    timedOut: true,
+    error: lastError
+      ? `condition not met within ${timeout}ms (last error: ${lastError})`
+      : `condition not met within ${timeout}ms (${attempts} attempts)`,
+  };
+}

--- a/apps/canvas-workspace/src/main/webview-action.ts
+++ b/apps/canvas-workspace/src/main/webview-action.ts
@@ -176,13 +176,26 @@ export function resolveKeySpec(key: string): { key: string; code: string; keyCod
   // Single printable character — treat as a literal key. Code is 'KeyX'
   // for letters, 'DigitN' for digits, otherwise empty (apps usually
   // care about `key` rather than `code` for typed text).
+  //
+  // keyCode follows the legacy "physical key" convention: letters always
+  // map to their uppercase char code (a → 65), digits to their char code
+  // (5 → 53). Many older shortcut handlers branch on `keyCode`/`which`
+  // and expect 65 for both 'a' and 'A' — sending 97 for 'a' would silently
+  // miss those handlers.
   if (key.length === 1) {
     const ch = key;
-    const cc = ch.charCodeAt(0);
     let code = '';
-    if (/^[a-zA-Z]$/.test(ch)) code = 'Key' + ch.toUpperCase();
-    else if (/^[0-9]$/.test(ch)) code = 'Digit' + ch;
-    return { key: ch, code, keyCode: cc };
+    let keyCode: number;
+    if (/^[a-zA-Z]$/.test(ch)) {
+      code = 'Key' + ch.toUpperCase();
+      keyCode = ch.toUpperCase().charCodeAt(0);
+    } else if (/^[0-9]$/.test(ch)) {
+      code = 'Digit' + ch;
+      keyCode = ch.charCodeAt(0);
+    } else {
+      keyCode = ch.charCodeAt(0);
+    }
+    return { key: ch, code, keyCode };
   }
   return null;
 }
@@ -203,6 +216,53 @@ try {
   target.dispatchEvent(new KeyboardEvent('keypress', init));
   target.dispatchEvent(new KeyboardEvent('keyup', init));
   return { ok: true, key: spec.key };
+} catch (e) {
+  return { ok: false, error: String(e && e.message || e) };
+}
+`);
+}
+
+export interface ScrollSpec {
+  /** Scroll to top of page. */
+  top?: boolean;
+  /** Scroll to bottom of page (full scrollHeight). */
+  bottom?: boolean;
+  /** CSS selector for an element to scrollIntoView(). */
+  selector?: string;
+  /** Relative scroll — { x, y } in pixels. */
+  by?: { x?: number; y?: number };
+  /** scrollIntoView block alignment (only used with `selector`). */
+  block?: 'start' | 'center' | 'end' | 'nearest';
+}
+
+export function buildScrollScript(spec: ScrollSpec): string {
+  return asIife(`
+try {
+  var spec = ${lit(spec)};
+  if (spec.selector) {
+    var el = document.querySelector(spec.selector);
+    if (!el) return { ok: false, error: 'selector not found: ' + spec.selector };
+    el.scrollIntoView({ block: spec.block || 'center', inline: 'nearest', behavior: 'instant' });
+  } else if (spec.top) {
+    window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
+  } else if (spec.bottom) {
+    window.scrollTo({ top: document.documentElement.scrollHeight, left: 0, behavior: 'instant' });
+  } else if (spec.by) {
+    var dx = (spec.by && typeof spec.by.x === 'number') ? spec.by.x : 0;
+    var dy = (spec.by && typeof spec.by.y === 'number') ? spec.by.y : 0;
+    window.scrollBy({ top: dy, left: dx, behavior: 'instant' });
+  } else {
+    return { ok: false, error: 'no scroll target — provide top, bottom, selector, or by{x,y}' };
+  }
+  return {
+    ok: true,
+    scrollX: window.scrollX,
+    scrollY: window.scrollY,
+    scrollHeight: document.documentElement.scrollHeight,
+    innerHeight: window.innerHeight,
+    atTop: window.scrollY <= 1,
+    atBottom: window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 1
+  };
 } catch (e) {
   return { ok: false, error: String(e && e.message || e) };
 }
@@ -246,6 +306,20 @@ export async function evalInPage(
       timeoutMs,
     )) as { ok: boolean; value?: unknown; error?: string };
     if (!raw?.ok) return { ok: false, error: raw?.error ?? 'eval failed' };
+    // `executeJavaScript` will hand us back BigInt / cyclic graphs / DOM
+    // node wrappers depending on what the user's code returned. The
+    // outer serialise() runs JSON.stringify and that throws on BigInt /
+    // cycles — verify here so the failure surfaces as a structured tool
+    // result rather than an unhandled exception.
+    try {
+      JSON.stringify(raw.value);
+    } catch (jsonErr) {
+      const msg = jsonErr instanceof Error ? jsonErr.message : String(jsonErr);
+      return {
+        ok: false,
+        error: `eval result is not JSON-serialisable: ${msg}. Return a plain object/array/string/number/boolean instead.`,
+      };
+    }
     return { ok: true, data: { value: raw.value } };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
@@ -311,9 +385,71 @@ export async function pressKey(
   }
 }
 
+export async function scrollPage(
+  wc: PageRunner,
+  spec: ScrollSpec,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<PageActionResult> {
+  // Validate at the API surface so the agent gets a clean error before
+  // we even hit the guest.
+  const hasTarget =
+    !!spec.top ||
+    !!spec.bottom ||
+    !!spec.selector ||
+    (!!spec.by && (typeof spec.by.x === 'number' || typeof spec.by.y === 'number'));
+  if (!hasTarget) {
+    return {
+      ok: false,
+      error: 'scroll needs one of: top, bottom, selector, by{x,y}',
+    };
+  }
+  try {
+    const raw = (await runWithTimeout(
+      wc.executeJavaScript(buildScrollScript(spec), false),
+      timeoutMs,
+    )) as {
+      ok: boolean;
+      scrollX?: number;
+      scrollY?: number;
+      scrollHeight?: number;
+      innerHeight?: number;
+      atTop?: boolean;
+      atBottom?: boolean;
+      error?: string;
+    };
+    if (!raw?.ok) return { ok: false, error: raw?.error ?? 'scroll failed' };
+    return {
+      ok: true,
+      data: {
+        scrollX: raw.scrollX,
+        scrollY: raw.scrollY,
+        scrollHeight: raw.scrollHeight,
+        innerHeight: raw.innerHeight,
+        atTop: raw.atTop,
+        atBottom: raw.atBottom,
+      },
+    };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, error: msg, timedOut: msg.includes('timed out') };
+  }
+}
+
 export async function waitForCondition(
   wc: PageRunner,
-  opts: { selector?: string; predicate?: string; timeoutMs?: number; intervalMs?: number },
+  opts: {
+    selector?: string;
+    predicate?: string;
+    timeoutMs?: number;
+    intervalMs?: number;
+    /**
+     * Optional re-check called between probes. Returning a non-null string
+     * aborts the wait with that reason as the error. Used by the tool
+     * layer to revalidate the URL policy in case the page redirected to
+     * a blocked host mid-wait.
+     */
+    abortCheck?: () => string | null;
+  },
 ): Promise<PageActionResult> {
   const timeout = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const interval = opts.intervalMs ?? DEFAULT_WAIT_INTERVAL_MS;
@@ -325,9 +461,25 @@ export async function waitForCondition(
   let lastError: string | undefined;
   let attempts = 0;
   while (Date.now() < deadline) {
+    // Re-check the abort condition before every probe — covers the case
+    // where the page redirected to a now-blocked URL since the previous
+    // iteration. The first call also fires before the first probe, so a
+    // policy that becomes false between resolveTarget and waitForCondition
+    // is still caught.
+    if (opts.abortCheck) {
+      const reason = opts.abortCheck();
+      if (reason) return { ok: false, error: reason };
+    }
     attempts += 1;
     try {
-      const raw = (await wc.executeJavaScript(script, false)) as {
+      // Per-probe timeout: prevents a non-terminating predicate from
+      // blocking past the configured deadline. We cap each call at the
+      // remaining budget so a hung guest can't outlive timeoutMs.
+      const probeTimeout = Math.max(50, Math.min(interval * 5, deadline - Date.now()));
+      const raw = (await runWithTimeout(
+        wc.executeJavaScript(script, false),
+        probeTimeout,
+      )) as {
         ok: boolean;
         matched?: boolean;
         text?: string;

--- a/apps/canvas-workspace/src/main/webview-cdp-actions.ts
+++ b/apps/canvas-workspace/src/main/webview-cdp-actions.ts
@@ -20,7 +20,7 @@
  *
  * Inputs that come from outside (selectors, text, key names) are passed
  * to the guest via CDP command params — never string-concatenated into
- * JS source — so script-injection is not a concern on this path.
+ * JS source — so injection is not a concern on this path.
  */
 
 import { withCdp, type CdpHost, type CdpSender } from './cdp-session';

--- a/apps/canvas-workspace/src/main/webview-cdp-actions.ts
+++ b/apps/canvas-workspace/src/main/webview-cdp-actions.ts
@@ -1,0 +1,364 @@
+/**
+ * CDP-based input primitives for webview iframe nodes.
+ *
+ * Drop-in upgrades for the JS-based primitives in {@link ./webview-action.ts}:
+ *   - JS path: `el.click()` / `dispatchEvent(KeyboardEvent)` — fires at the
+ *     top of the JS event stack. React synthetic events see it, but browser
+ *     internals don't — `isTrusted` is false, user activation isn't set,
+ *     `pointerdown` / hover side effects fire unevenly.
+ *   - CDP path: `Input.dispatchMouseEvent` / `Input.dispatchKeyEvent` go
+ *     through Chromium's input router below the renderer, the same path
+ *     hardware events take. `isTrusted` is true, user activation is set,
+ *     so APIs gated on a user gesture (clipboard write, requestFullscreen,
+ *     popup blocker bypass) behave correctly. The OS cursor does NOT move
+ *     — the synthesis stops at Chromium's input pipeline, by design (we
+ *     don't want to hijack the user's physical cursor).
+ *
+ * All primitives go through {@link withCdp} so they share a single
+ * debugger slot with reader code (screenshot, a11y tree) without
+ * collisions.
+ *
+ * Inputs that come from outside (selectors, text, key names) are passed
+ * to the guest via CDP command params — never string-concatenated into
+ * JS source — so script-injection is not a concern on this path.
+ */
+
+import { withCdp, type CdpHost, type CdpSender } from './cdp-session';
+import { resolveKeySpec, type PageActionResult, type PageRunner } from './webview-action';
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+// ---------------------------------------------------------------------------
+// Modifier bitmask — per CDP `Input.dispatchKeyEvent` / `dispatchMouseEvent`
+// ---------------------------------------------------------------------------
+
+export type CdpModifier = 'alt' | 'ctrl' | 'control' | 'meta' | 'cmd' | 'command' | 'shift';
+
+export function modifierMask(mods?: ReadonlyArray<string>): number {
+  if (!mods || mods.length === 0) return 0;
+  let m = 0;
+  for (const raw of mods) {
+    const k = String(raw).toLowerCase();
+    if (k === 'alt') m |= 1;
+    else if (k === 'control' || k === 'ctrl') m |= 2;
+    else if (k === 'meta' || k === 'cmd' || k === 'command') m |= 4;
+    else if (k === 'shift') m |= 8;
+  }
+  return m;
+}
+
+/**
+ * Whether a key event should carry a `text` field (printable input). CDP
+ * expects `text` empty for non-printable keys and for chorded combos
+ * (Ctrl+A, Cmd+K) — otherwise the page sees Ctrl+A as both a shortcut
+ * AND a typed 'a'.
+ */
+function textFor(keySpec: { key: string; code: string }, modMask: number): string {
+  const ctrlOrMeta = (modMask & (2 | 4)) !== 0;
+  if (ctrlOrMeta) return '';
+  // Single printable char: insert it (respecting shift via the spec.key
+  // which is already 'A' vs 'a' for shift-held letters when caller asks).
+  if (keySpec.key.length === 1) return keySpec.key;
+  // A handful of special keys do generate text in textareas.
+  if (keySpec.code === 'Enter') return '\r';
+  if (keySpec.code === 'Tab') return '\t';
+  return '';
+}
+
+async function runWithTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  return await Promise.race([
+    p,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error(`CDP action timed out after ${ms}ms`)), ms),
+    ),
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// Selector → coordinate resolution (JS-side, fast, no debugger needed)
+// ---------------------------------------------------------------------------
+
+interface CdpActionHost extends CdpHost, PageRunner {}
+
+interface CenterResult {
+  ok: boolean;
+  x?: number;
+  y?: number;
+  tag?: string;
+  error?: string;
+}
+
+/**
+ * Scroll the selector into view (if it exists) and return the viewport
+ * coordinates of its centre. Runs as a single JS roundtrip so we don't
+ * pay debugger-attach overhead just to locate an element.
+ */
+async function selectorCenter(wc: PageRunner, selector: string): Promise<CenterResult> {
+  const script = `(function(){
+  try {
+    var el = document.querySelector(${JSON.stringify(selector)});
+    if (!el) return { ok: false, error: 'selector not found: ' + ${JSON.stringify(selector)} };
+    if (typeof el.scrollIntoView === 'function') {
+      el.scrollIntoView({ block: 'center', inline: 'center', behavior: 'instant' });
+    }
+    var r = el.getBoundingClientRect();
+    if (r.width === 0 || r.height === 0) {
+      return { ok: false, error: 'element has zero size (likely hidden)' };
+    }
+    var vw = window.innerWidth, vh = window.innerHeight;
+    var cx = r.left + r.width / 2, cy = r.top + r.height / 2;
+    if (cx < 0 || cy < 0 || cx > vw || cy > vh) {
+      return { ok: false, error: 'element centre is outside viewport (' + Math.round(cx) + ',' + Math.round(cy) + ' vs ' + vw + 'x' + vh + ')' };
+    }
+    return { ok: true, x: Math.round(cx), y: Math.round(cy), tag: el.tagName.toLowerCase() };
+  } catch (e) {
+    return { ok: false, error: String(e && e.message || e) };
+  }
+})()`;
+  try {
+    return (await wc.executeJavaScript(script, false)) as CenterResult;
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Primitives
+// ---------------------------------------------------------------------------
+
+export interface CdpClickOptions {
+  button?: 'left' | 'middle' | 'right';
+  clickCount?: number;
+  modifiers?: ReadonlyArray<string>;
+  timeoutMs?: number;
+}
+
+export async function cdpClickAt(
+  wc: CdpHost,
+  x: number,
+  y: number,
+  opts: CdpClickOptions = {},
+): Promise<PageActionResult> {
+  const button = opts.button ?? 'left';
+  const clickCount = opts.clickCount ?? 1;
+  const mods = modifierMask(opts.modifiers);
+  const timeout = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  try {
+    return await runWithTimeout(
+      withCdp(wc, async (send: CdpSender) => {
+        // Move the synthetic cursor first so hover handlers fire correctly
+        // before the button-down event. Without this, pages that swap a
+        // button's onClick on hover would miss the swap.
+        await send('Input.dispatchMouseEvent', {
+          type: 'mouseMoved',
+          x,
+          y,
+          modifiers: mods,
+          button: 'none',
+        });
+        await send('Input.dispatchMouseEvent', {
+          type: 'mousePressed',
+          x,
+          y,
+          modifiers: mods,
+          button,
+          clickCount,
+        });
+        await send('Input.dispatchMouseEvent', {
+          type: 'mouseReleased',
+          x,
+          y,
+          modifiers: mods,
+          button,
+          clickCount,
+        });
+        return { ok: true, data: { x, y, button } } as PageActionResult;
+      }),
+      timeout,
+    );
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, error: msg, timedOut: msg.includes('timed out') };
+  }
+}
+
+export async function cdpClickSelector(
+  wc: CdpActionHost,
+  selector: string,
+  opts: CdpClickOptions = {},
+): Promise<PageActionResult> {
+  const centre = await selectorCenter(wc, selector);
+  if (!centre.ok) return { ok: false, error: centre.error ?? 'selector resolution failed' };
+  const result = await cdpClickAt(wc, centre.x!, centre.y!, opts);
+  if (result.ok && result.data) {
+    return { ok: true, data: { ...result.data, tag: centre.tag, selector } };
+  }
+  return result;
+}
+
+export interface CdpPressOptions {
+  selector?: string;
+  modifiers?: ReadonlyArray<string>;
+  timeoutMs?: number;
+}
+
+/**
+ * Dispatch a keyDown + keyUp pair via CDP. If a selector is supplied,
+ * focus that element first (via JS — focus doesn't need the debugger).
+ */
+export async function cdpPressKey(
+  wc: CdpActionHost,
+  key: string,
+  opts: CdpPressOptions = {},
+): Promise<PageActionResult> {
+  const spec = resolveKeySpec(key);
+  if (!spec) return { ok: false, error: `unsupported key: "${key}"` };
+  const mods = modifierMask(opts.modifiers);
+  const timeout = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const text = textFor(spec, mods);
+
+  // Best-effort focus before pressing — JS focus is cheap and avoids
+  // bouncing through the debugger when the agent didn't ask for a
+  // specific target.
+  if (opts.selector) {
+    const focusScript = `(function(){
+  try {
+    var el = document.querySelector(${JSON.stringify(opts.selector)});
+    if (!el) return { ok: false, error: 'selector not found for focus' };
+    if (typeof el.focus === 'function') el.focus();
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: String(e && e.message || e) };
+  }
+})()`;
+    const focusResult = (await wc.executeJavaScript(focusScript, false)) as {
+      ok: boolean;
+      error?: string;
+    };
+    if (!focusResult?.ok) {
+      return { ok: false, error: focusResult?.error ?? 'focus failed' };
+    }
+  }
+
+  try {
+    return await runWithTimeout(
+      withCdp(wc, async (send: CdpSender) => {
+        const baseInit: Record<string, unknown> = {
+          key: spec.key,
+          code: spec.code,
+          windowsVirtualKeyCode: spec.keyCode,
+          nativeVirtualKeyCode: spec.keyCode,
+          modifiers: mods,
+        };
+        // `rawKeyDown` for non-text keys (modifiers, escape, etc.) +
+        // `char` for the actual text. For text-producing keys we send
+        // `keyDown` with text — works for normal letter input and forms.
+        if (text) {
+          await send('Input.dispatchKeyEvent', {
+            type: 'keyDown',
+            ...baseInit,
+            text,
+            unmodifiedText: text,
+          });
+        } else {
+          await send('Input.dispatchKeyEvent', { type: 'rawKeyDown', ...baseInit });
+        }
+        await send('Input.dispatchKeyEvent', { type: 'keyUp', ...baseInit });
+        return { ok: true, data: { key: spec.key, modifiers: mods } } as PageActionResult;
+      }),
+      timeout,
+    );
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, error: msg, timedOut: msg.includes('timed out') };
+  }
+}
+
+export interface CdpFillOptions {
+  /**
+   * Whether to clear the existing value before inserting. Default true —
+   * mirrors the previous fillSelector contract that fully replaced the
+   * value.
+   */
+  clearFirst?: boolean;
+  timeoutMs?: number;
+}
+
+/**
+ * Fill an input/textarea/contenteditable with `value` via CDP `Input.insertText`.
+ *
+ * Strategy:
+ *   1. JS: scrollIntoView + focus the element (and clear value if asked).
+ *      For React-controlled fields we use the native setter so framework
+ *      tracking sees the clear.
+ *   2. CDP: `Input.insertText` inserts as if pasted — no per-char keydown,
+ *      which is what you usually want for filling forms.
+ */
+export async function cdpFillSelector(
+  wc: CdpActionHost,
+  selector: string,
+  value: string,
+  opts: CdpFillOptions = {},
+): Promise<PageActionResult> {
+  const clearFirst = opts.clearFirst !== false;
+  const timeout = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const prepScript = `(function(){
+  try {
+    var el = document.querySelector(${JSON.stringify(selector)});
+    if (!el) return { ok: false, error: 'selector not found: ' + ${JSON.stringify(selector)} };
+    if (typeof el.scrollIntoView === 'function') {
+      el.scrollIntoView({ block: 'center', inline: 'center', behavior: 'instant' });
+    }
+    if (typeof el.focus === 'function') el.focus();
+    var tag = el.tagName ? el.tagName.toLowerCase() : '';
+    if (${clearFirst ? 'true' : 'false'}) {
+      if (el.isContentEditable) {
+        el.innerText = '';
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+      } else if (tag === 'input' || tag === 'textarea' || tag === 'select') {
+        var proto = tag === 'textarea'
+          ? window.HTMLTextAreaElement.prototype
+          : (tag === 'select' ? window.HTMLSelectElement.prototype : window.HTMLInputElement.prototype);
+        var setter = Object.getOwnPropertyDescriptor(proto, 'value');
+        if (setter && setter.set) {
+          setter.set.call(el, '');
+        } else {
+          el.value = '';
+        }
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+    }
+    return { ok: true, tag: tag, editable: el.isContentEditable || tag === 'input' || tag === 'textarea' };
+  } catch (e) {
+    return { ok: false, error: String(e && e.message || e) };
+  }
+})()`;
+
+  const prep = (await wc.executeJavaScript(prepScript, false)) as {
+    ok: boolean;
+    tag?: string;
+    editable?: boolean;
+    error?: string;
+  };
+  if (!prep?.ok) return { ok: false, error: prep?.error ?? 'fill prep failed' };
+  if (!prep.editable) {
+    return { ok: false, error: `element is not editable (tag=${prep.tag})` };
+  }
+
+  try {
+    return await runWithTimeout(
+      withCdp(wc, async (send: CdpSender) => {
+        await send('Input.insertText', { text: value });
+        return {
+          ok: true,
+          data: { tag: prep.tag, length: value.length, mode: 'insertText' },
+        } as PageActionResult;
+      }),
+      timeout,
+    );
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, error: msg, timedOut: msg.includes('timed out') };
+  }
+}

--- a/apps/canvas-workspace/src/shared/experimental-features.ts
+++ b/apps/canvas-workspace/src/shared/experimental-features.ts
@@ -59,9 +59,9 @@ export const EXPERIMENTAL_FEATURES: ExperimentalFeatureDef[] = [
   },
   {
     id: EXPERIMENTAL_FLAG_WEBVIEW_SCRIPT_INJECTION,
-    label: 'Webview script injection (agent)',
+    label: 'Webview page control (agent)',
     description:
-      'Lets the Canvas Agent control pages inside iframe nodes — click, fill, press keys, wait for selectors, run arbitrary JS. Blocked on file://, chrome://, devtools:// and a built-in sensitive-domain list (banks, payments, mainstream login). Customize via ~/.pulse-coder/canvas/webview-action-policy.json. Treat this as giving an LLM access to whatever you are currently logged into.',
+      'Lets the Canvas Agent control pages inside iframe nodes — click (by selector or pixel coordinates), fill, press keys, scroll, wait for selectors, run arbitrary JS. Clicks and key presses go through Chromium DevTools Protocol (real input events that fire pointer / hover / user-activation handlers) — the OS cursor does not move. Blocked on file://, chrome://, devtools:// and a built-in sensitive-domain list (banks, payments, mainstream login). Customize via ~/.pulse-coder/canvas/webview-action-policy.json. Treat this as giving an LLM access to whatever you are currently logged into.',
     defaultEnabled: false,
   },
 ];

--- a/apps/canvas-workspace/src/shared/experimental-features.ts
+++ b/apps/canvas-workspace/src/shared/experimental-features.ts
@@ -33,6 +33,7 @@ export interface ExperimentalFeatureDef {
 export const EXPERIMENTAL_FLAG_AGENT_DEBUG_TRACE = 'canvas-agent-debug-trace';
 export const EXPERIMENTAL_FLAG_WORKSPACE_NODES = 'workspace-nodes-page';
 export const EXPERIMENTAL_FLAG_WORKSPACE_GRAPH = 'workspace-graph-page';
+export const EXPERIMENTAL_FLAG_WEBVIEW_SCRIPT_INJECTION = 'webview-script-injection';
 
 export const EXPERIMENTAL_FEATURES: ExperimentalFeatureDef[] = [
   {
@@ -54,6 +55,13 @@ export const EXPERIMENTAL_FEATURES: ExperimentalFeatureDef[] = [
     label: 'Workspace Graph page',
     description:
       'A force-directed graph view of all nodes in the workspace with grouped toolbar and suggest-search. Surfaces a "Graph" entry in the sidebar.',
+    defaultEnabled: false,
+  },
+  {
+    id: EXPERIMENTAL_FLAG_WEBVIEW_SCRIPT_INJECTION,
+    label: 'Webview script injection (agent)',
+    description:
+      'Lets the Canvas Agent control pages inside iframe nodes — click, fill, press keys, wait for selectors, run arbitrary JS. Blocked on file://, chrome://, devtools:// and a built-in sensitive-domain list (banks, payments, mainstream login). Customize via ~/.pulse-coder/canvas/webview-action-policy.json. Treat this as giving an LLM access to whatever you are currently logged into.',
     defaultEnabled: false,
   },
 ];

--- a/apps/canvas-workspace/src/shared/experimental-features.ts
+++ b/apps/canvas-workspace/src/shared/experimental-features.ts
@@ -33,7 +33,7 @@ export interface ExperimentalFeatureDef {
 export const EXPERIMENTAL_FLAG_AGENT_DEBUG_TRACE = 'canvas-agent-debug-trace';
 export const EXPERIMENTAL_FLAG_WORKSPACE_NODES = 'workspace-nodes-page';
 export const EXPERIMENTAL_FLAG_WORKSPACE_GRAPH = 'workspace-graph-page';
-export const EXPERIMENTAL_FLAG_WEBVIEW_SCRIPT_INJECTION = 'webview-script-injection';
+export const EXPERIMENTAL_FLAG_WEBVIEW_PAGE_CONTROL = 'webview-page-control';
 
 export const EXPERIMENTAL_FEATURES: ExperimentalFeatureDef[] = [
   {
@@ -58,7 +58,7 @@ export const EXPERIMENTAL_FEATURES: ExperimentalFeatureDef[] = [
     defaultEnabled: false,
   },
   {
-    id: EXPERIMENTAL_FLAG_WEBVIEW_SCRIPT_INJECTION,
+    id: EXPERIMENTAL_FLAG_WEBVIEW_PAGE_CONTROL,
     label: 'Webview page control (agent)',
     description:
       'Lets the Canvas Agent control pages inside iframe nodes — click (by selector or pixel coordinates), fill, press keys, scroll, wait for selectors, run arbitrary JS. Clicks and key presses go through Chromium DevTools Protocol (real input events that fire pointer / hover / user-activation handlers) — the OS cursor does not move. Blocked on file://, chrome://, devtools:// and a built-in sensitive-domain list (banks, payments, mainstream login). Customize via ~/.pulse-coder/canvas/webview-action-policy.json. Treat this as giving an LLM access to whatever you are currently logged into.',


### PR DESCRIPTION
Adds page_eval / page_click / page_fill / page_press / page_wait_for canvas-agent tools that let the agent control pages inside iframe nodes via wc.executeJavaScript. Gated by a new default-off experimental flag `webview-script-injection`; off → the tool names are not registered at all. Every action enforces a URL policy (default-deny file://, chrome://, devtools://, view-source://, data://, javascript://, plus a sensitive- domain blocklist for banks / payments / mainstream auth) configurable via ~/.pulse-coder/canvas/webview-action-policy.json. Each call emits one audit line.