### PR TITLE
Improve tool call display with input/output sections

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
@@ -1420,10 +1420,24 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  min-width: 0;
+}
+
+.chat-tool-call-label {
+  color: inherit;
+}
+
+.chat-tool-call-name {
+  margin-left: 6px;
+  color: rgba(55, 53, 47, 0.4);
 }
 
 .chat-tool-call--done .chat-tool-call-sig {
   color: rgba(55, 53, 47, 0.4);
+}
+
+.chat-tool-call--done .chat-tool-call-name {
+  color: rgba(55, 53, 47, 0.32);
 }
 
 .chat-tool-call-chevron {
@@ -1456,6 +1470,21 @@
   color: rgba(55, 53, 47, 0.6);
   white-space: pre-wrap;
   word-break: break-all;
+}
+
+.chat-tool-call-section + .chat-tool-call-section {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid rgba(55, 53, 47, 0.06);
+}
+
+.chat-tool-call-section-label {
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', Menlo, monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: rgba(55, 53, 47, 0.45);
+  margin-bottom: 4px;
 }
 
 /* ─── @ Mention popup ────────────────────────────────────── */

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatToolCalls.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatToolCalls.tsx
@@ -74,7 +74,17 @@ function formatToolLabel(name: string, status: ToolCallStatus['status']): string
     case 'bash':
       return `${prefix}运行命令`;
     default:
-      return status === 'running' ? `正在执行 ${name}` : `已执行 ${name}`;
+      return status === 'running' ? '正在执行' : '已执行';
+  }
+}
+
+function formatArgs(args: unknown): string {
+  if (args === undefined || args === null) return '';
+  if (typeof args === 'string') return args;
+  try {
+    return JSON.stringify(args, null, 2);
+  } catch {
+    return String(args);
   }
 }
 
@@ -135,7 +145,8 @@ export const ChatToolCalls = ({
               )}
             </span>
             <span className="chat-tool-call-sig" title={formatToolSignature(tool.name, tool.args)}>
-              {formatToolLabel(tool.name, tool.status)}
+              <span className="chat-tool-call-label">{formatToolLabel(tool.name, tool.status)}</span>
+              <span className="chat-tool-call-name">{tool.name}</span>
             </span>
             {tool.status === 'done' && tool.result && (
               <span className={`chat-tool-call-chevron${expandedTools.has(tool.id) ? ' chat-tool-call-chevron--open' : ''}`}>
@@ -145,9 +156,20 @@ export const ChatToolCalls = ({
               </span>
             )}
           </div>
-          {expandedTools.has(tool.id) && tool.result && (
+          {expandedTools.has(tool.id) && (tool.result || tool.args !== undefined) && (
             <div className="chat-tool-call-result">
-              <pre>{tool.result.length > 2000 ? `${tool.result.slice(0, 2000)}\n...(truncated)` : tool.result}</pre>
+              {tool.args !== undefined && (
+                <div className="chat-tool-call-section">
+                  <div className="chat-tool-call-section-label">{tool.name} · input</div>
+                  <pre>{formatArgs(tool.args)}</pre>
+                </div>
+              )}
+              {tool.result && (
+                <div className="chat-tool-call-section">
+                  <div className="chat-tool-call-section-label">output</div>
+                  <pre>{tool.result.length > 2000 ? `${tool.result.slice(0, 2000)}\n...(truncated)` : tool.result}</pre>
+                </div>
+              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
Enhanced the chat tool calls UI to better display both input arguments and output results in separate, clearly labeled sections. This improves readability when inspecting tool execution details.

## Key Changes
- **Simplified tool labels**: Changed `formatToolLabel()` to return generic status text ("正在执行"/"已执行") instead of including the tool name, reducing redundancy
- **Added `formatArgs()` helper**: New utility function to safely format tool arguments as JSON with proper error handling
- **Restructured expanded view**: When a tool call is expanded, now displays:
  - Input section showing the tool name and formatted arguments
  - Output section showing the result (with 2000 character truncation)
  - Both sections are optional and only render if data exists
- **Updated UI layout**: 
  - Tool signature now displays both a status label and the tool name separately with distinct styling
  - Added `.chat-tool-call-label` and `.chat-tool-call-name` classes for better control
  - Introduced `.chat-tool-call-section` and `.chat-tool-call-section-label` classes for the expanded content sections
- **Improved styling**:
  - Added visual separation between input and output sections with border and margin
  - Tool name in completed calls uses reduced opacity for visual hierarchy
  - Section labels use monospace font with uppercase styling for clarity

## Implementation Details
- The expanded view now checks for both `tool.result` and `tool.args` to determine visibility
- Arguments are formatted with `JSON.stringify(args, null, 2)` for readability, with fallback to `String()` conversion
- Section labels include the tool name for input ("tool_name · input") and generic "output" for results
- CSS uses flexbox and text overflow handling to ensure proper layout with long tool names

https://claude.ai/code/session_01CP3NWUowuns1rW4MAxsVXP