### PR TITLE
Make debug trace flag reactive to Settings toggles

### DIFF
--- a/apps/canvas-workspace/src/main/canvas-agent/debug-trace.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/debug-trace.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from 'crypto';
+import { getExperimentalFlagSync } from '../experimental-ipc';
+import { EXPERIMENTAL_FLAG_AGENT_DEBUG_TRACE } from '../../shared/experimental-features';
 import type {
   CanvasAgentDebugTrace,
   CanvasAgentDebugTraceContextRead,
@@ -38,8 +40,18 @@ interface ToolResultInput {
 }
 
 export function isCanvasAgentDebugTraceEnabled(): boolean {
+  // Two sources, OR'd together — matches preload's pluginFlags logic so
+  // main and renderer agree on whether the trace pipeline is on:
+  //   1. CANVAS_AGENT_DEBUG_TRACE env var (legacy escape hatch for CI /
+  //      scripted runs that should not touch persisted state)
+  //   2. The 'canvas-agent-debug-trace' experimental flag the user
+  //      toggles via Settings → Experimental (persisted at
+  //      ~/.pulse-coder/canvas/experimental-features.json)
+  // Read each turn so toggling + window reload takes effect without an
+  // app restart — main process keeps running across renderer reloads.
   const value = process.env.CANVAS_AGENT_DEBUG_TRACE?.trim().toLowerCase();
-  return value !== undefined && ['1', 'true', 'on', 'yes'].includes(value);
+  if (value !== undefined && ['1', 'true', 'on', 'yes'].includes(value)) return true;
+  return getExperimentalFlagSync(EXPERIMENTAL_FLAG_AGENT_DEBUG_TRACE);
 }
 
 export function createCanvasAgentDebugTrace(input: StartTraceInput): CanvasAgentDebugTrace {

--- a/apps/canvas-workspace/src/main/experimental-ipc.ts
+++ b/apps/canvas-workspace/src/main/experimental-ipc.ts
@@ -47,13 +47,27 @@ async function readOverrides(): Promise<Record<string, boolean>> {
 // Preload can't import `fs` itself in sandbox mode, so the file read has to
 // happen here. Errors swallow to defaults — preload bootstrap must never
 // throw or the renderer loses access to the entire canvasWorkspace bridge.
-function readOverridesSync(): Record<string, boolean> {
+export function readOverridesSync(): Record<string, boolean> {
   try {
     const raw = readFileSync(getPath(), 'utf8');
     return normaliseOverrides(JSON.parse(raw));
   } catch {
     return {};
   }
+}
+
+/**
+ * Synchronously resolve a single experimental flag from the persisted
+ * overrides file, falling back to the registered default. Use this from
+ * main-side modules that need to gate behaviour on a flag the user
+ * toggled in Settings, without going through the renderer.
+ *
+ * Cheap (small JSON read, swallowed on error), so callers may invoke it
+ * per-event without caching. That keeps the flag reactive to Settings
+ * toggles + window reloads, where the main process keeps running.
+ */
+export function getExperimentalFlagSync(id: string): boolean {
+  return resolveFeatureValues(readOverridesSync())[id] === true;
 }
 
 async function writeOverrides(overrides: Record<string, boolean>): Promise<void> {

--- a/apps/canvas-workspace/src/plugins/main/devtools.ts
+++ b/apps/canvas-workspace/src/plugins/main/devtools.ts
@@ -1,6 +1,3 @@
-import {
-  isCanvasAgentDebugTraceEnabled,
-} from '../../main/canvas-agent/debug-trace';
 import type {
   CanvasAgentDebugRunDetail,
   CanvasAgentDebugRunSummary,
@@ -59,9 +56,18 @@ function buildStoredRun(payload: TurnTracePayload): StoredRun {
 // and serves the renderer half via IPC. The plugin no longer reaches
 // into session-store; canvas-agent and this plugin only share the
 // event bus contract.
+//
+// Always activates — `setupCanvasPlugins` only runs once at main-process
+// startup, but the trace flag (`canvas-agent-debug-trace`) can be flipped
+// later from Settings → Experimental + window reload, with no full app
+// restart. If we gated activation on the flag's startup value we'd never
+// register the `turnEnd` listener or `list-runs`/`get-run` IPC handlers
+// for users who turned it on after launching. The plugin is inert when
+// the flag is off: canvas-agent doesn't emit `turnEnd` without a trace
+// (canvas-agent.ts) and the renderer half isn't activated, so nobody
+// invokes the IPC handlers.
 export const DevtoolsMainPlugin: MainCanvasPlugin = {
   id: 'devtools',
-  enabledWhen: isCanvasAgentDebugTraceEnabled,
   activate(ctx) {
     ctx.onAgent('turnEnd', async (turn) => {
       const payload = turn.data as TurnTracePayload | undefined;


### PR DESCRIPTION
## Summary
Refactor the canvas agent debug trace feature to be reactive to Settings toggles without requiring an app restart. The main process can now check the experimental flag at runtime, allowing users to enable/disable debug tracing via Settings → Experimental and have it take effect after a window reload.

## Key Changes

- **Export `readOverridesSync()` and add `getExperimentalFlagSync()`** in `experimental-ipc.ts`
  - Made `readOverridesSync()` public for use by main-side modules
  - Added new `getExperimentalFlagSync(id: string)` function to synchronously resolve a single experimental flag from persisted overrides, falling back to registered defaults
  - Documented that the function is cheap (small JSON read) and safe to call per-event without caching

- **Update `isCanvasAgentDebugTraceEnabled()` in `debug-trace.ts`** to check both sources
  - Now checks the `CANVAS_AGENT_DEBUG_TRACE` env var first (legacy escape hatch for CI/scripted runs)
  - Falls back to the `canvas-agent-debug-trace` experimental flag via `getExperimentalFlagSync()`
  - Reads the flag each turn so toggling + window reload takes effect without app restart
  - Added detailed comments explaining the two-source logic and reactivity behavior

- **Remove static flag gating from `DevtoolsMainPlugin` in `devtools.ts`**
  - Removed the `enabledWhen: isCanvasAgentDebugTraceEnabled` condition from plugin activation
  - Plugin now always activates at startup but remains inert when the flag is off
  - Added comprehensive comments explaining why: canvas-agent only emits `turnEnd` events when tracing is enabled, and the renderer half isn't activated when the flag is off, so IPC handlers are never invoked by inactive users
  - This allows users who toggle the flag on after launch to have the feature work without a full app restart

## Implementation Details

The change maintains the existing behavior where the debug trace pipeline is controlled by the flag, but shifts from static startup-time checking to dynamic runtime checking. The main process keeps running across renderer reloads, so checking the flag each turn allows Settings changes to take effect immediately after a window reload without requiring an app restart.

https://claude.ai/code/session_01BKhxc2dBexVNqLkabdEyFe