### PR TITLE
feat(canvas-agent): add graph search, group membership, and workspace-node metadata tools

### DIFF
--- a/apps/canvas-workspace/src/main/canvas-agent/__tests__/tools-graph.test.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/__tests__/tools-graph.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// Pin `os.homedir()` to a temp dir BEFORE the modules under test load it, so
+// every default-rooted helper (canvas-storage, workspace-node-store, tag-store)
+// reads/writes under the per-test sandbox rather than the developer's real
+// ~/.pulse-coder/canvas tree. `vi.hoisted` is the only safe way to share state
+// with `vi.mock` factories, which Vitest hoists above the rest of the file.
+const { sandboxHome } = vi.hoisted(() => {
+  // `vi.hoisted` runs above all imports, so we cannot use `os.tmpdir()` /
+  // `path.join` here. Build the path with environment + string concat instead.
+  const base = process.env.TMPDIR || process.env.TEMP || '/tmp';
+  const trailing = base.endsWith('/') ? '' : '/';
+  return {
+    sandboxHome: `${base}${trailing}canvas-tools-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  };
+});
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  return {
+    ...actual,
+    homedir: () => sandboxHome,
+  };
+});
+
+// Mock electron's BrowserWindow — `broadcastUpdate` iterates the window list
+// and would crash without an Electron runtime. We don't care about the
+// broadcast in these tests; the on-disk state is what matters.
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: () => [] },
+  ipcMain: { handle: () => undefined, on: () => undefined },
+}));
+
+// node-pty fails to load without its native binding in the test env; the
+// transitive `agent-session-send` → `pty-manager` import would otherwise crash
+// the module before any test runs. Mirrors the stub in agent-session-send.test.
+vi.mock('../../pty-manager', () => ({
+  hasSession: () => false,
+  writeToSession: () => false,
+}));
+
+// Stub the engine's GenerateImageTool import — the tools module pulls it in at
+// the top level for `canvas_generate_image`, but instantiating it requires
+// API keys we don't have in unit tests.
+vi.mock('pulse-coder-engine', () => ({
+  GenerateImageTool: class StubGenerateImageTool {
+    inputSchema = { parse: (v: unknown) => v };
+    async execute() {
+      return '';
+    }
+  },
+}));
+
+// The plugin registry is loaded at tool-creation time. Stub it out so we
+// don't pick up plugin-contributed tools from the real registry.
+vi.mock('../../../plugins/main', () => ({
+  getRegisteredCanvasToolFactories: () => new Map(),
+}));
+
+import { createCanvasTools } from '../tools';
+import {
+  readCanvasFull,
+  writeCanvasFull,
+  type CanvasSaveData,
+} from '../../canvas-storage';
+import {
+  readWorkspaceNode,
+  writeWorkspaceNode,
+  WORKSPACE_NODE_SCHEMA_VERSION,
+} from '../../workspace-node-store';
+
+const wsId = 'ws-tools-test';
+
+async function setupCanvas(data: Partial<CanvasSaveData> = {}): Promise<CanvasSaveData> {
+  const canvas: CanvasSaveData = {
+    nodes: [
+      { id: 'n-file', type: 'file', title: 'README', x: 0, y: 0, width: 200, height: 100, data: { filePath: '/tmp/readme.md', content: 'Hello RAG world' } },
+      { id: 'n-text', type: 'text', title: 'Sticky', x: 220, y: 0, width: 200, height: 100, data: { content: 'a quick note about pipelines' } },
+      { id: 'n-iframe', type: 'iframe', title: 'Docs', x: 440, y: 0, width: 200, height: 100, data: { url: 'https://example.com/rag' } },
+      { id: 'n-grp', type: 'group', title: 'Cluster A', x: 0, y: 200, width: 700, height: 200, data: { label: 'Cluster A', childIds: ['n-file'] } },
+    ],
+    edges: [],
+    transform: { x: 0, y: 0, scale: 1 },
+    savedAt: new Date().toISOString(),
+    ...data,
+  };
+  await writeCanvasFull(wsId, canvas);
+  return canvas;
+}
+
+beforeEach(async () => {
+  // Each test gets a fresh sandbox subdirectory so default-rooted helpers
+  // (which use `homedir()/.pulse-coder/canvas`) don't see leftover state.
+  await fs.mkdir(join(sandboxHome, '.pulse-coder', 'canvas'), { recursive: true });
+});
+
+afterEach(async () => {
+  await fs.rm(join(sandboxHome, '.pulse-coder'), { recursive: true, force: true });
+});
+
+describe('canvas_search_nodes', () => {
+  it('filters by case-insensitive query against title / content / url', async () => {
+    await setupCanvas();
+    const tools = createCanvasTools(wsId);
+
+    const byContent = JSON.parse(await tools.canvas_search_nodes.execute({ query: 'pipeline' }));
+    expect(byContent.ok).toBe(true);
+    expect(byContent.matches.map((m: { id: string }) => m.id)).toEqual(['n-text']);
+
+    const byUrl = JSON.parse(await tools.canvas_search_nodes.execute({ query: 'RAG' }));
+    // 'RAG' shows up in file content (Hello RAG world) and iframe url path
+    expect(new Set(byUrl.matches.map((m: { id: string }) => m.id))).toEqual(new Set(['n-file', 'n-iframe']));
+  });
+
+  it('filters by node type (single + array)', async () => {
+    await setupCanvas();
+    const tools = createCanvasTools(wsId);
+
+    const single = JSON.parse(await tools.canvas_search_nodes.execute({ type: 'group' }));
+    expect(single.matches.map((m: { id: string }) => m.id)).toEqual(['n-grp']);
+
+    const multi = JSON.parse(await tools.canvas_search_nodes.execute({ type: ['file', 'text'] }));
+    expect(new Set(multi.matches.map((m: { id: string }) => m.id))).toEqual(new Set(['n-file', 'n-text']));
+  });
+
+  it('filters by workspace-node tag (AND semantics)', async () => {
+    await setupCanvas();
+    await writeWorkspaceNode(wsId, {
+      schemaVersion: WORKSPACE_NODE_SCHEMA_VERSION,
+      id: 'n-file',
+      type: 'note',
+      data: {},
+      properties: { tags: ['AI', 'RAG'] },
+    });
+    await writeWorkspaceNode(wsId, {
+      schemaVersion: WORKSPACE_NODE_SCHEMA_VERSION,
+      id: 'n-text',
+      type: 'note',
+      data: {},
+      properties: { tags: ['AI'] },
+    });
+    const tools = createCanvasTools(wsId);
+
+    const bothTags = JSON.parse(await tools.canvas_search_nodes.execute({ tag: ['AI', 'RAG'] }));
+    expect(bothTags.matches.map((m: { id: string }) => m.id)).toEqual(['n-file']);
+    // Tag info is surfaced on each match so the agent doesn't have to re-fetch.
+    expect(bothTags.matches[0].tags).toEqual(['AI', 'RAG']);
+
+    const oneTag = JSON.parse(await tools.canvas_search_nodes.execute({ tag: 'AI' }));
+    expect(new Set(oneTag.matches.map((m: { id: string }) => m.id))).toEqual(new Set(['n-file', 'n-text']));
+  });
+
+  it('respects limit and reports truncation', async () => {
+    await setupCanvas();
+    const tools = createCanvasTools(wsId);
+
+    const result = JSON.parse(await tools.canvas_search_nodes.execute({ limit: 2 }));
+    expect(result.matches.length).toBe(2);
+    expect(result.truncated).toBe(true);
+  });
+});
+
+describe('canvas_add_to_group / canvas_remove_from_group', () => {
+  it('adds new node ids to a group, dedups, and ignores self-reference', async () => {
+    await setupCanvas();
+    const tools = createCanvasTools(wsId);
+
+    const result = JSON.parse(await tools.canvas_add_to_group.execute({
+      groupId: 'n-grp',
+      nodeIds: ['n-text', 'n-iframe', 'n-file', 'n-grp', 'n-ghost'],
+    }));
+    expect(result.ok).toBe(true);
+    // 'n-file' was already a member → not in `added`. 'n-grp' is self-ref →
+    // filtered. 'n-ghost' is missing → reported separately.
+    expect(result.added).toEqual(['n-text', 'n-iframe']);
+    expect(result.childIds).toEqual(['n-file', 'n-text', 'n-iframe']);
+    expect(result.missing).toEqual(['n-ghost']);
+    expect(result.selfRef).toBe(true);
+
+    // Verify on disk.
+    const { data } = await readCanvasFull(wsId);
+    const nodes = data?.nodes ?? [];
+    const group = nodes.find((n) => n.id === 'n-grp');
+    expect(group).toBeDefined();
+    expect((group!.data as { childIds?: string[] })?.childIds).toEqual(['n-file', 'n-text', 'n-iframe']);
+  });
+
+  it('refuses to operate on a non-group node', async () => {
+    await setupCanvas();
+    const tools = createCanvasTools(wsId);
+
+    const result = await tools.canvas_add_to_group.execute({
+      groupId: 'n-file',
+      nodeIds: ['n-text'],
+    });
+    expect(result).toMatch(/not "group"/);
+  });
+
+  it('removes node ids from a group and leaves unrelated targets untouched', async () => {
+    await setupCanvas({
+      nodes: [
+        { id: 'n-file', type: 'file', title: 'F', x: 0, y: 0, width: 200, height: 100, data: {} },
+        { id: 'n-text', type: 'text', title: 'T', x: 0, y: 120, width: 200, height: 100, data: {} },
+        { id: 'n-iframe', type: 'iframe', title: 'I', x: 0, y: 240, width: 200, height: 100, data: { url: '' } },
+        { id: 'n-grp', type: 'group', title: 'G', x: 220, y: 0, width: 400, height: 400, data: { childIds: ['n-file', 'n-text', 'n-iframe'] } },
+      ],
+      edges: [],
+      transform: { x: 0, y: 0, scale: 1 },
+    });
+    const tools = createCanvasTools(wsId);
+
+    const result = JSON.parse(await tools.canvas_remove_from_group.execute({
+      groupId: 'n-grp',
+      nodeIds: ['n-text', 'n-ghost'],
+    }));
+    expect(result.ok).toBe(true);
+    expect(result.removed).toEqual(['n-text']);
+    expect(result.childIds).toEqual(['n-file', 'n-iframe']);
+  });
+});
+
+describe('workspace_node_list / get / upsert', () => {
+  it('creates a workspace-node atom with tags + properties + links on first upsert', async () => {
+    await setupCanvas();
+    const tools = createCanvasTools(wsId);
+
+    const result = JSON.parse(await tools.workspace_node_upsert.execute({
+      nodeId: 'n-file',
+      type: 'note',
+      title: 'README atom',
+      tags: ['AI', 'RAG'],
+      properties: { summary: 'Doc covering the RAG flow', kind: 'note' },
+      links: [{ relation: 'references', targetNodeId: 'n-iframe' }],
+    }));
+    expect(result.ok).toBe(true);
+    expect(result.created).toBe(true);
+    expect(result.record.properties.tags).toEqual(['AI', 'RAG']);
+    expect(result.record.properties.summary).toBe('Doc covering the RAG flow');
+    expect(result.record.links).toEqual([
+      { relation: 'references', target: { nodeId: 'n-iframe' } },
+    ]);
+
+    // Persisted on disk under the workspace-node store.
+    const onDisk = await readWorkspaceNode(wsId, 'n-file');
+    expect(onDisk?.properties?.tags).toEqual(['AI', 'RAG']);
+  });
+
+  it('merges properties on subsequent upsert; clears with explicit null', async () => {
+    await setupCanvas();
+    const tools = createCanvasTools(wsId);
+
+    await tools.workspace_node_upsert.execute({
+      nodeId: 'n-file',
+      properties: { summary: 'first', kind: 'note', sourceUrl: { type: 'url', value: 'https://example.com' } },
+    });
+    const merged = JSON.parse(await tools.workspace_node_upsert.execute({
+      nodeId: 'n-file',
+      properties: { summary: 'updated', kind: null },
+    }));
+    expect(merged.created).toBe(false);
+    expect(merged.record.properties.summary).toBe('updated');
+    expect(merged.record.properties.kind).toBeUndefined();
+    expect(merged.record.properties.sourceUrl).toEqual({ type: 'url', value: 'https://example.com' });
+  });
+
+  it('lists workspace-node atoms with tags + property keys', async () => {
+    await setupCanvas();
+    const tools = createCanvasTools(wsId);
+    await tools.workspace_node_upsert.execute({
+      nodeId: 'n-file',
+      tags: ['AI'],
+      properties: { summary: 's' },
+    });
+    await tools.workspace_node_upsert.execute({
+      nodeId: 'n-text',
+      properties: { kind: 'sticky' },
+    });
+
+    const listed = JSON.parse(await tools.workspace_node_list.execute({}));
+    expect(listed.ok).toBe(true);
+    expect(listed.total).toBe(2);
+    const fileEntry = listed.nodes.find((n: { id: string }) => n.id === 'n-file');
+    expect(fileEntry.tags).toEqual(['AI']);
+    expect(fileEntry.propertyKeys).toEqual(expect.arrayContaining(['tags', 'summary']));
+  });
+
+  it('returns null record when the atom does not exist yet', async () => {
+    await setupCanvas();
+    const tools = createCanvasTools(wsId);
+
+    const result = JSON.parse(await tools.workspace_node_get.execute({ nodeId: 'n-iframe' }));
+    expect(result.ok).toBe(true);
+    expect(result.record).toBeNull();
+  });
+});
+
+// Sanity: ensure the sandbox really pointed under /tmp (defensive — if the
+// mock ever stops working we want a loud failure, not silent pollution of
+// the developer's real ~/.pulse-coder).
+describe('homedir isolation', () => {
+  it('routes ~/.pulse-coder writes through a tmpdir-rooted sandbox', () => {
+    const tmpRoot = tmpdir(); // re-uses the mocked `os` so this is the sandbox
+    expect(sandboxHome.startsWith('/tmp') || sandboxHome.startsWith(tmpRoot)).toBe(true);
+  });
+});

--- a/apps/canvas-workspace/src/main/canvas-agent/__tests__/tools-graph.test.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/__tests__/tools-graph.test.ts
@@ -306,3 +306,53 @@ describe('homedir isolation', () => {
     expect(sandboxHome.startsWith('/tmp') || sandboxHome.startsWith(tmpRoot)).toBe(true);
   });
 });
+
+describe('deferred tool partition', () => {
+  // Locks in the eager/deferred split so a future edit to tools.ts that
+  // accidentally drops or adds a `defer_loading` flag fails loudly.
+  it('matches the documented eager / deferred sets', () => {
+    const tools = createCanvasTools(wsId);
+    const eager: string[] = [];
+    const deferred: string[] = [];
+    for (const [name, tool] of Object.entries(tools)) {
+      if (tool.defer_loading) deferred.push(name);
+      else eager.push(name);
+    }
+    eager.sort();
+    deferred.sort();
+
+    expect(eager).toEqual([
+      'artifact_create',
+      'artifact_pin_to_canvas',
+      'canvas_analyze_image',
+      'canvas_ask_user',
+      'canvas_create_agent_node',
+      'canvas_create_node',
+      'canvas_create_terminal_node',
+      'canvas_delete_node',
+      'canvas_generate_image',
+      'canvas_move_node',
+      'canvas_read_context',
+      'canvas_read_node',
+      'canvas_search_nodes',
+      'canvas_send_to_agent',
+      'canvas_update_node',
+      'visual_render',
+    ]);
+    expect(deferred).toEqual([
+      'artifact_update',
+      'canvas_add_to_group',
+      'canvas_create_edge',
+      'canvas_create_shape',
+      'canvas_delete_edge',
+      'canvas_generate_mindmap_image',
+      'canvas_list_edges',
+      'canvas_read_webpage',
+      'canvas_remove_from_group',
+      'canvas_update_edge',
+      'workspace_node_get',
+      'workspace_node_list',
+      'workspace_node_upsert',
+    ]);
+  });
+});

--- a/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
@@ -7,7 +7,7 @@
  */
 
 import { Engine } from 'pulse-coder-engine';
-import { builtInSkillsPlugin } from 'pulse-coder-engine/built-in';
+import { builtInSkillsPlugin, builtInToolSearchPlugin } from 'pulse-coder-engine/built-in';
 import type { ModelMessage } from 'ai';
 import { resolveCanvasModel } from './model-config';
 import { agentBus } from '../../plugins/main';
@@ -141,23 +141,31 @@ Your system prompt contains a summary of all canvas nodes. For detailed content:
 - Use \`canvas_read_node\` to read a specific node's full content
 - Use \`canvas_read_context\` with detail="full" for everything at once
 
-## Canvas Tools
+## Canvas Tools (always loaded)
 - \`canvas_read_context\`: Read workspace overview or full context
 - \`canvas_read_node\`: Read a single node's content in detail
+- \`canvas_search_nodes\`: Search nodes by query / type / tag — use this BEFORE \`canvas_read_node\` when the canvas has many nodes so you don't blow the context window pulling the full summary
 - \`canvas_create_node\`: Create new file/frame/text/image/iframe/mindmap nodes (generic)
 - \`canvas_analyze_image\`: Read/OCR/analyze image nodes or local image paths
 - \`canvas_generate_image\`: Generate an AI image and place it on the canvas as an image node
-- \`canvas_generate_mindmap_image\`: Generate a polished visual image from an existing mindmap node
 - \`canvas_create_agent_node\`: **Create and launch an AI agent node** — preferred for agent creation
 - \`canvas_send_to_agent\`: **Send a follow-up prompt to an already-running agent node** — use for any interaction AFTER the initial launch
 - \`canvas_create_terminal_node\`: **Create a terminal node** — preferred for terminal creation
 - \`canvas_update_node\`: Update existing nodes (content, title, data)
 - \`canvas_delete_node\`: Remove a node from the canvas
 - \`canvas_move_node\`: Reposition a node
-- \`canvas_search_nodes\`: Search nodes by query / type / tag — use this BEFORE \`canvas_read_node\` when the canvas has many nodes so you don't blow the context window pulling the full summary
-- \`canvas_add_to_group\` / \`canvas_remove_from_group\`: Manage explicit membership of group nodes (group nodes own their members via \`data.childIds\`; frames use spatial containment instead — move a node into the frame's bbox with \`canvas_move_node\`)
-- \`workspace_node_list\` / \`workspace_node_get\` / \`workspace_node_upsert\`: Read & write the **workspace-node knowledge layer** — a separate metadata store (per-workspace, on-disk) that attaches \`tags\`, \`properties\` (kind, summary, sourceUrl, custom values), and typed \`links\` (relations between nodes) to a node id. Use these whenever the user is curating a knowledge graph, tagging nodes, or asking "find/group/connect nodes by X"
 - \`canvas_ask_user\`: **Ask the user a clarifying question** — use this whenever the request is ambiguous, you need a choice between options, or you need confirmation before taking a destructive action. Prefer asking over guessing.
+
+## Deferred Tools (discover via tool_search)
+The following tools are NOT loaded by default — call \`tool_search_tool_bm25\` (natural language) or \`tool_search_tool_regex\` (regex) with a relevant query to surface them, then invoke the returned tool. Group them by intent:
+- **Edges / connections**: \`canvas_list_edges\`, \`canvas_create_edge\`, \`canvas_update_edge\`, \`canvas_delete_edge\` — load when the user asks to connect / link / draw arrows between nodes.
+- **Group membership**: \`canvas_add_to_group\`, \`canvas_remove_from_group\` — load when the user asks to add/remove nodes to/from a group (groups own members via \`data.childIds\`; frames use spatial containment, no tool needed — just \`canvas_move_node\` into the frame's bbox).
+- **Workspace-node knowledge layer**: \`workspace_node_list\`, \`workspace_node_get\`, \`workspace_node_upsert\` — load when the user is tagging nodes, building a knowledge graph, or asking "find/group/connect nodes by X". Separate metadata store with tags / properties / typed links.
+- **Visual specialties**: \`canvas_create_shape\` (precise shape sizing), \`canvas_generate_mindmap_image\` (visual export of a mindmap node).
+- **Artifact versioning**: \`artifact_update\` (only when iterating on an already-created artifact).
+- **Webpage scraping**: \`canvas_read_webpage\` (DOM/a11y/screenshot from an open iframe node).
+
+When in doubt about which tool exists for an operation, just call \`tool_search_tool_bm25\` with a description of what you want to do.
 
 ## Visualization Tools — visual_render is the DEFAULT
 
@@ -548,7 +556,13 @@ export class CanvasAgent {
     this.engine = new Engine({
       disableBuiltInPlugins: true,
       enginePlugins: {
-        plugins: [builtInSkillsPlugin],
+        // tool-search hides tools marked `defer_loading: true` from the
+        // immediate set sent to the LLM and surfaces them through
+        // `tool_search_tool_bm25` / `_regex`. The canvas agent has ~29 tools
+        // and many are domain-specialized (edges, knowledge layer, niche
+        // creators); keeping them deferred keeps the per-turn tool catalog
+        // focused on the common read/write/move/visual path.
+        plugins: [builtInSkillsPlugin, builtInToolSearchPlugin],
       },
       model: config.model,
       tools: canvasTools,

--- a/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/canvas-agent.ts
@@ -154,6 +154,9 @@ Your system prompt contains a summary of all canvas nodes. For detailed content:
 - \`canvas_update_node\`: Update existing nodes (content, title, data)
 - \`canvas_delete_node\`: Remove a node from the canvas
 - \`canvas_move_node\`: Reposition a node
+- \`canvas_search_nodes\`: Search nodes by query / type / tag — use this BEFORE \`canvas_read_node\` when the canvas has many nodes so you don't blow the context window pulling the full summary
+- \`canvas_add_to_group\` / \`canvas_remove_from_group\`: Manage explicit membership of group nodes (group nodes own their members via \`data.childIds\`; frames use spatial containment instead — move a node into the frame's bbox with \`canvas_move_node\`)
+- \`workspace_node_list\` / \`workspace_node_get\` / \`workspace_node_upsert\`: Read & write the **workspace-node knowledge layer** — a separate metadata store (per-workspace, on-disk) that attaches \`tags\`, \`properties\` (kind, summary, sourceUrl, custom values), and typed \`links\` (relations between nodes) to a node id. Use these whenever the user is curating a knowledge graph, tagging nodes, or asking "find/group/connect nodes by X"
 - \`canvas_ask_user\`: **Ask the user a clarifying question** — use this whenever the request is ambiguous, you need a choice between options, or you need confirmation before taking a destructive action. Prefer asking over guessing.
 
 ## Visualization Tools — visual_render is the DEFAULT

--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -38,6 +38,16 @@ import {
   writeCanvasFull,
   getCanvasJsonPath,
 } from '../canvas-storage';
+import {
+  listWorkspaceNodes,
+  readWorkspaceNode,
+  writeWorkspaceNode,
+  WORKSPACE_NODE_SCHEMA_VERSION,
+  type WorkspaceNodeRecord,
+  type WorkspaceNodeLink,
+  type WorkspaceNodePropertyValue,
+} from '../workspace-node-store';
+import { readKnowledgeTags, upsertKnowledgeTag } from '../tag-store';
 
 const STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
 const BLANK_PAGE_URL = 'about:blank';
@@ -1283,6 +1293,435 @@ ${outline}`;
         broadcastUpdate(workspaceId, [nodeId]);
 
         return JSON.stringify({ ok: true, nodeId });
+      },
+    },
+
+    // ─── Graph / search / grouping ──────────────────────────────────
+
+    canvas_search_nodes: {
+      name: 'canvas_search_nodes',
+      description:
+        'Search canvas nodes by query, type, or workspace-node tag. ' +
+        'Returns a compact list (id, type, title, snippet) so you can avoid pulling the whole canvas summary when you only need a few matches. ' +
+        'Use this before `canvas_read_node` to narrow down which nodes to read in detail.',
+      inputSchema: z.object({
+        query: z.string().optional().describe(
+          'Case-insensitive substring matched against node title, label, content, url, and filePath.',
+        ),
+        type: z.union([
+          z.enum(['file', 'terminal', 'frame', 'group', 'agent', 'text', 'iframe', 'image', 'shape', 'mindmap']),
+          z.array(z.enum(['file', 'terminal', 'frame', 'group', 'agent', 'text', 'iframe', 'image', 'shape', 'mindmap'])),
+        ]).optional().describe('Restrict to one or more node types.'),
+        tag: z.union([z.string(), z.array(z.string())]).optional().describe(
+          'Filter by workspace-node tag(s). A node matches when its workspace-node record has ALL provided tags in `properties.tags`. ' +
+          'Tags live in the knowledge layer (`workspace-node-store`), not on the canvas node itself.',
+        ),
+        limit: z.number().int().positive().max(200).optional().describe('Max results to return. Default 30.'),
+        workspaceId: z.string().optional().describe('Target workspace ID. Defaults to the current workspace.'),
+      }),
+      execute: async (input) => {
+        const targetWorkspaceId = (input.workspaceId as string) || workspaceId;
+        const canvas = await loadCanvas(targetWorkspaceId);
+        if (!canvas) return `Error: workspace not found: ${targetWorkspaceId}`;
+
+        const query = typeof input.query === 'string' ? input.query.trim().toLowerCase() : '';
+        const typeFilter = (() => {
+          if (!input.type) return null;
+          const arr = Array.isArray(input.type) ? input.type : [input.type];
+          return new Set(arr as string[]);
+        })();
+        const tagFilter = (() => {
+          if (!input.tag) return null;
+          const arr: unknown[] = Array.isArray(input.tag) ? input.tag : [input.tag];
+          const cleaned = arr
+            .filter((t: unknown): t is string => typeof t === 'string')
+            .map((t: string) => t.trim())
+            .filter(Boolean);
+          return cleaned.length ? cleaned : null;
+        })();
+        const limit = (input.limit as number | undefined) ?? 30;
+
+        const wsNodeById = new Map<string, WorkspaceNodeRecord>();
+        if (tagFilter) {
+          const records = await listWorkspaceNodes(targetWorkspaceId);
+          for (const record of records) wsNodeById.set(record.id, record);
+        }
+
+        const matchHaystacks = (node: CanvasNode): string[] => {
+          const fields: string[] = [node.title ?? '', node.type ?? ''];
+          const data = node.data ?? {};
+          for (const key of ['content', 'label', 'url', 'filePath', 'cwd', 'prompt', 'html']) {
+            const v = data[key];
+            if (typeof v === 'string') fields.push(v);
+          }
+          return fields;
+        };
+
+        const snippetFor = (node: CanvasNode): string => {
+          const data = node.data ?? {};
+          const candidates: Array<string | undefined> = [
+            typeof data.content === 'string' ? (data.content as string) : undefined,
+            typeof data.label === 'string' ? (data.label as string) : undefined,
+            typeof data.url === 'string' ? (data.url as string) : undefined,
+            typeof data.filePath === 'string' ? (data.filePath as string) : undefined,
+          ];
+          const first = candidates.find((c) => c && c.trim().length > 0) ?? '';
+          const normalized = first.replace(/\s+/g, ' ').trim();
+          return normalized.length > 160 ? `${normalized.slice(0, 157)}...` : normalized;
+        };
+
+        const matches: Array<{
+          id: string;
+          type: string;
+          title: string;
+          snippet: string;
+          x: number;
+          y: number;
+          tags?: string[];
+        }> = [];
+
+        for (const node of canvas.nodes) {
+          if (typeFilter && !typeFilter.has(node.type)) continue;
+
+          if (tagFilter) {
+            const record = wsNodeById.get(node.id);
+            const rawTags: unknown[] = Array.isArray(record?.properties?.tags)
+              ? (record!.properties!.tags as unknown[])
+              : [];
+            const tagSet = new Set(
+              rawTags.filter((t: unknown): t is string => typeof t === 'string'),
+            );
+            const hasAll = tagFilter.every((t: string) => tagSet.has(t));
+            if (!hasAll) continue;
+          }
+
+          if (query) {
+            const hay = matchHaystacks(node).join('\n').toLowerCase();
+            if (!hay.includes(query)) continue;
+          }
+
+          const record = wsNodeById.get(node.id);
+          const tags = Array.isArray(record?.properties?.tags)
+            ? (record!.properties!.tags as string[]).filter((t): t is string => typeof t === 'string')
+            : undefined;
+
+          matches.push({
+            id: node.id,
+            type: node.type,
+            title: node.title ?? '',
+            snippet: snippetFor(node),
+            x: node.x,
+            y: node.y,
+            ...(tags && tags.length ? { tags } : {}),
+          });
+          if (matches.length >= limit) break;
+        }
+
+        return JSON.stringify({
+          ok: true,
+          workspaceId: targetWorkspaceId,
+          total: matches.length,
+          truncated: matches.length >= limit,
+          matches,
+        });
+      },
+    },
+
+    canvas_add_to_group: {
+      name: 'canvas_add_to_group',
+      description:
+        'Add one or more nodes to a group node\'s explicit child list (`data.childIds`). ' +
+        'Use this to make grouping deterministic — frames rely on spatial bbox containment, but groups own their members explicitly via childIds. ' +
+        'Targets that are already in the group are ignored (dedup). Cannot add the group to itself.',
+      inputSchema: z.object({
+        groupId: z.string().describe('The group node id. Must reference a node of type "group".'),
+        nodeIds: z.array(z.string()).min(1).describe('Node ids to add to the group.'),
+      }),
+      execute: async (input) => {
+        const groupId = input.groupId as string;
+        const requested = (input.nodeIds as string[]).filter((id) => typeof id === 'string' && id);
+
+        const canvas = await loadCanvas(workspaceId);
+        if (!canvas) return 'Error: workspace not found';
+
+        const group = canvas.nodes.find((n) => n.id === groupId);
+        if (!group) return `Error: group not found: ${groupId}`;
+        if (group.type !== 'group') {
+          return `Error: node ${groupId} is type "${group.type}", not "group". Use canvas_update_node for frames; frame membership is spatial.`;
+        }
+
+        const validIds = new Set(canvas.nodes.map((n) => n.id));
+        const missing = requested.filter((id) => !validIds.has(id));
+        const selfRef = requested.includes(groupId);
+        const candidates = requested.filter((id) => validIds.has(id) && id !== groupId);
+
+        const existing: string[] = Array.isArray(group.data.childIds)
+          ? (group.data.childIds as unknown[]).filter((v): v is string => typeof v === 'string')
+          : [];
+        const existingSet = new Set(existing);
+        const added: string[] = [];
+        for (const id of candidates) {
+          if (existingSet.has(id)) continue;
+          existingSet.add(id);
+          added.push(id);
+        }
+
+        if (added.length === 0) {
+          return JSON.stringify({
+            ok: true,
+            groupId,
+            added: [],
+            childIds: existing,
+            note: 'No changes — all targets were already members (or invalid).',
+            ...(missing.length ? { missing } : {}),
+            ...(selfRef ? { selfRef: true } : {}),
+          });
+        }
+
+        // Re-read so concurrent edits to OTHER fields of the group survive.
+        const fresh = (await loadCanvas(workspaceId)) ?? canvas;
+        const idx = fresh.nodes.findIndex((n) => n.id === groupId);
+        if (idx === -1) return `Error: group ${groupId} was deleted concurrently; add aborted`;
+        const freshGroup = fresh.nodes[idx];
+        const freshExisting: string[] = Array.isArray(freshGroup.data.childIds)
+          ? (freshGroup.data.childIds as unknown[]).filter((v): v is string => typeof v === 'string')
+          : [];
+        const merged = [...freshExisting];
+        const mergedSet = new Set(freshExisting);
+        for (const id of added) {
+          if (mergedSet.has(id)) continue;
+          mergedSet.add(id);
+          merged.push(id);
+        }
+        freshGroup.data.childIds = merged;
+        freshGroup.updatedAt = Date.now();
+
+        await saveCanvas(workspaceId, fresh);
+        broadcastUpdate(workspaceId, [groupId]);
+
+        return JSON.stringify({
+          ok: true,
+          groupId,
+          added,
+          childIds: merged,
+          ...(missing.length ? { missing } : {}),
+          ...(selfRef ? { selfRef: true } : {}),
+        });
+      },
+    },
+
+    canvas_remove_from_group: {
+      name: 'canvas_remove_from_group',
+      description:
+        'Remove one or more nodes from a group node\'s explicit child list (`data.childIds`). ' +
+        'Targets not currently in the group are ignored. Does NOT delete the nodes themselves.',
+      inputSchema: z.object({
+        groupId: z.string().describe('The group node id.'),
+        nodeIds: z.array(z.string()).min(1).describe('Node ids to remove from the group.'),
+      }),
+      execute: async (input) => {
+        const groupId = input.groupId as string;
+        const requested = new Set(
+          (input.nodeIds as string[]).filter((id) => typeof id === 'string' && id),
+        );
+
+        const fresh = await loadCanvas(workspaceId);
+        if (!fresh) return 'Error: workspace not found';
+
+        const idx = fresh.nodes.findIndex((n) => n.id === groupId);
+        if (idx === -1) return `Error: group not found: ${groupId}`;
+        const group = fresh.nodes[idx];
+        if (group.type !== 'group') {
+          return `Error: node ${groupId} is type "${group.type}", not "group".`;
+        }
+
+        const existing: string[] = Array.isArray(group.data.childIds)
+          ? (group.data.childIds as unknown[]).filter((v): v is string => typeof v === 'string')
+          : [];
+        const next = existing.filter((id) => !requested.has(id));
+        const removed = existing.filter((id) => requested.has(id));
+
+        if (removed.length === 0) {
+          return JSON.stringify({
+            ok: true,
+            groupId,
+            removed: [],
+            childIds: existing,
+            note: 'No changes — none of the targets were group members.',
+          });
+        }
+
+        group.data.childIds = next;
+        group.updatedAt = Date.now();
+
+        await saveCanvas(workspaceId, fresh);
+        broadcastUpdate(workspaceId, [groupId]);
+
+        return JSON.stringify({
+          ok: true,
+          groupId,
+          removed,
+          childIds: next,
+        });
+      },
+    },
+
+    // ─── Workspace-node metadata layer (knowledge atoms) ────────────
+
+    workspace_node_list: {
+      name: 'workspace_node_list',
+      description:
+        'List workspace-node knowledge atoms — the separate metadata layer that stores `properties` (tags, summary, kind, sourceUrl...) and `links` (relations between nodes) alongside the visual canvas. ' +
+        'A workspace-node has the SAME id as the canvas node it annotates (when one exists), but they are stored separately. ' +
+        'Use this to surface what knowledge metadata already exists before reading or editing.',
+      inputSchema: z.object({
+        workspaceId: z.string().optional().describe('Target workspace ID. Defaults to the current workspace.'),
+      }),
+      execute: async (input) => {
+        const targetWorkspaceId = (input.workspaceId as string) || workspaceId;
+        const records = await listWorkspaceNodes(targetWorkspaceId);
+        const tags = await readKnowledgeTags();
+        const nodes = records.map((record) => {
+          const tagsArr = Array.isArray(record.properties?.tags)
+            ? (record.properties!.tags as unknown[]).filter((t): t is string => typeof t === 'string')
+            : [];
+          return {
+            id: record.id,
+            type: record.type,
+            title: record.title,
+            tags: tagsArr,
+            linkCount: Array.isArray(record.links) ? record.links.length : 0,
+            propertyKeys: record.properties ? Object.keys(record.properties) : [],
+            updatedAt: record.updatedAt,
+          };
+        });
+        return JSON.stringify({
+          ok: true,
+          workspaceId: targetWorkspaceId,
+          total: nodes.length,
+          nodes,
+          knownTags: tags.map((t) => ({ id: t.id, name: t.name, description: t.description })),
+        });
+      },
+    },
+
+    workspace_node_get: {
+      name: 'workspace_node_get',
+      description:
+        'Read the full workspace-node metadata record for a given node id (properties, links, data, tags). ' +
+        'Returns null when no metadata atom exists yet — use `workspace_node_upsert` to create one.',
+      inputSchema: z.object({
+        nodeId: z.string().describe('The node id (matches the canvas node id when annotating one).'),
+        workspaceId: z.string().optional().describe('Target workspace ID. Defaults to the current workspace.'),
+      }),
+      execute: async (input) => {
+        const targetWorkspaceId = (input.workspaceId as string) || workspaceId;
+        const nodeId = input.nodeId as string;
+        const record = await readWorkspaceNode(targetWorkspaceId, nodeId);
+        return JSON.stringify({ ok: true, workspaceId: targetWorkspaceId, nodeId, record });
+      },
+    },
+
+    workspace_node_upsert: {
+      name: 'workspace_node_upsert',
+      description:
+        'Create or merge-update a workspace-node knowledge atom (separate from the canvas layout). ' +
+        'Use this to attach `tags`, `properties` (kind, summary, sourceUrl, custom values), and `links` (typed relations to other nodes) to a node id. ' +
+        'When the record already exists, the patch is merged: `properties` are shallow-merged, `links` REPLACES the existing array when provided, and `tags` REPLACES `properties.tags` when provided. ' +
+        'Tags referenced here are auto-registered as `KnowledgeTagDefinition`s if they don\'t already exist.',
+      inputSchema: z.object({
+        nodeId: z.string().describe('Node id. Use the canvas node id when annotating an existing canvas node.'),
+        type: z.string().optional().describe('Node type. Defaults to "note" for new records; ignored for existing records unless explicitly set.'),
+        title: z.string().optional().describe('Optional display title.'),
+        tags: z.array(z.string()).optional().describe('Tag names. Replaces `properties.tags` entirely when provided. New names are auto-registered in the global tag store.'),
+        properties: z.record(z.string(), z.unknown()).optional().describe(
+          'Properties to merge into `properties`. Values may be string | number | boolean | null | string[] | number[] | { type: "date"|"url"|"file"|"node"|"workspace-node", ... }. ' +
+          'Keys not provided are left untouched. Pass `null` for a key to clear it.',
+        ),
+        links: z.array(z.object({
+          relation: z.string().describe('Relation name, e.g. "references", "implements", "depends-on".'),
+          targetNodeId: z.string().describe('The target node id.'),
+          targetWorkspaceId: z.string().optional().describe('Cross-workspace target. Omit for same-workspace links.'),
+          title: z.string().optional(),
+        })).optional().describe('When provided, REPLACES the full `links` array. Omit to keep existing links.'),
+        data: z.record(z.string(), z.unknown()).optional().describe('Optional data payload (free-form). Shallow-merged when patching.'),
+        workspaceId: z.string().optional().describe('Target workspace ID. Defaults to the current workspace.'),
+      }),
+      execute: async (input) => {
+        const targetWorkspaceId = (input.workspaceId as string) || workspaceId;
+        const nodeId = input.nodeId as string;
+
+        const existing = await readWorkspaceNode(targetWorkspaceId, nodeId);
+        const now = Date.now();
+
+        const patchProperties = input.properties as Record<string, WorkspaceNodePropertyValue | null> | undefined;
+        const mergedProperties: Record<string, WorkspaceNodePropertyValue> = { ...(existing?.properties ?? {}) };
+        if (patchProperties) {
+          for (const [k, v] of Object.entries(patchProperties)) {
+            if (v === null || v === undefined) {
+              delete mergedProperties[k];
+            } else {
+              mergedProperties[k] = v as WorkspaceNodePropertyValue;
+            }
+          }
+        }
+        if (Array.isArray(input.tags)) {
+          const cleanTags = (input.tags as unknown[])
+            .filter((t): t is string => typeof t === 'string')
+            .map((t) => t.trim())
+            .filter(Boolean);
+          const dedup = Array.from(new Set(cleanTags));
+          mergedProperties.tags = dedup;
+          // Auto-register tags so the renderer's tag picker shows them.
+          for (const name of dedup) {
+            try {
+              await upsertKnowledgeTag({ name });
+            } catch {
+              // tag-store rejects unsafe ids; skip silently rather than fail the whole upsert.
+            }
+          }
+        }
+
+        const nextLinks: WorkspaceNodeLink[] | undefined = Array.isArray(input.links)
+          ? (input.links as Array<{
+              relation: string;
+              targetNodeId: string;
+              targetWorkspaceId?: string;
+              title?: string;
+            }>).map((l) => ({
+              relation: l.relation,
+              target: l.targetWorkspaceId
+                ? { workspaceId: l.targetWorkspaceId, nodeId: l.targetNodeId }
+                : { nodeId: l.targetNodeId },
+              ...(l.title ? { title: l.title } : {}),
+            }))
+          : existing?.links;
+
+        const mergedData: Record<string, unknown> = {
+          ...(existing?.data ?? {}),
+          ...(input.data ? (input.data as Record<string, unknown>) : {}),
+        };
+
+        const next: WorkspaceNodeRecord = {
+          schemaVersion: WORKSPACE_NODE_SCHEMA_VERSION,
+          id: nodeId,
+          type: (input.type as string | undefined) ?? existing?.type ?? 'note',
+          ...(input.title !== undefined ? { title: input.title as string } : existing?.title !== undefined ? { title: existing.title } : {}),
+          data: mergedData,
+          ...(Object.keys(mergedProperties).length ? { properties: mergedProperties } : {}),
+          ...(nextLinks && nextLinks.length ? { links: nextLinks } : {}),
+          createdAt: existing?.createdAt ?? now,
+          updatedAt: now,
+        };
+
+        await writeWorkspaceNode(targetWorkspaceId, next);
+        return JSON.stringify({
+          ok: true,
+          workspaceId: targetWorkspaceId,
+          nodeId,
+          created: !existing,
+          record: next,
+        });
       },
     },
 

--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -611,6 +611,13 @@ export interface CanvasTool {
   name: string;
   description: string;
   inputSchema: z.ZodType;
+  /**
+   * When true the tool is hidden from the immediate tool list passed to the
+   * LLM and only surfaces after `tool_search_tool_bm25` / `_regex` discovers
+   * it. Engine-side this is consumed by the built-in tool-search plugin
+   * (`packages/engine/src/built-in/tool-search-plugin`).
+   */
+  defer_loading?: boolean;
   execute: (input: any, ctx?: CanvasToolExecutionContext) => Promise<string>;
 }
 
@@ -1108,6 +1115,7 @@ ${outline}`;
 
     canvas_generate_mindmap_image: {
       name: 'canvas_generate_mindmap_image',
+      defer_loading: true,
       description:
         'Generate a visual image from an existing mindmap node and return it to the chat. ' +
         'Use this for requests like "turn this mindmap into an image/poster/diagram". ' +
@@ -1429,6 +1437,7 @@ ${outline}`;
 
     canvas_add_to_group: {
       name: 'canvas_add_to_group',
+      defer_loading: true,
       description:
         'Add one or more nodes to a group node\'s explicit child list (`data.childIds`). ' +
         'Use this to make grouping deterministic — frames rely on spatial bbox containment, but groups own their members explicitly via childIds. ' +
@@ -1512,6 +1521,7 @@ ${outline}`;
 
     canvas_remove_from_group: {
       name: 'canvas_remove_from_group',
+      defer_loading: true,
       description:
         'Remove one or more nodes from a group node\'s explicit child list (`data.childIds`). ' +
         'Targets not currently in the group are ignored. Does NOT delete the nodes themselves.',
@@ -1570,6 +1580,7 @@ ${outline}`;
 
     workspace_node_list: {
       name: 'workspace_node_list',
+      defer_loading: true,
       description:
         'List workspace-node knowledge atoms — the separate metadata layer that stores `properties` (tags, summary, kind, sourceUrl...) and `links` (relations between nodes) alongside the visual canvas. ' +
         'A workspace-node has the SAME id as the canvas node it annotates (when one exists), but they are stored separately. ' +
@@ -1607,6 +1618,7 @@ ${outline}`;
 
     workspace_node_get: {
       name: 'workspace_node_get',
+      defer_loading: true,
       description:
         'Read the full workspace-node metadata record for a given node id (properties, links, data, tags). ' +
         'Returns null when no metadata atom exists yet — use `workspace_node_upsert` to create one.',
@@ -1624,6 +1636,7 @@ ${outline}`;
 
     workspace_node_upsert: {
       name: 'workspace_node_upsert',
+      defer_loading: true,
       description:
         'Create or merge-update a workspace-node knowledge atom (separate from the canvas layout). ' +
         'Use this to attach `tags`, `properties` (kind, summary, sourceUrl, custom values), and `links` (typed relations to other nodes) to a node id. ' +
@@ -1928,6 +1941,7 @@ ${outline}`;
 
     canvas_create_shape: {
       name: 'canvas_create_shape',
+      defer_loading: true,
       description:
         'Create a primitive geometric shape on the canvas. Supported kinds: ' +
         '"rect", "rounded-rect", "ellipse", "triangle", "diamond", "hexagon", "star". ' +
@@ -1999,6 +2013,7 @@ ${outline}`;
 
     canvas_list_edges: {
       name: 'canvas_list_edges',
+      defer_loading: true,
       description:
         'List every edge (connection / arrow) on the canvas with resolved endpoint titles. ' +
         'Useful when you need to understand what the user has linked together — e.g. to figure out ' +
@@ -2034,6 +2049,7 @@ ${outline}`;
 
     canvas_create_edge: {
       name: 'canvas_create_edge',
+      defer_loading: true,
       description:
         'Connect two nodes (or free points) on the canvas with an arrow. ' +
         'Endpoints are node-bound by default: pass `sourceNodeId` / `targetNodeId`. For a free-floating ' +
@@ -2146,6 +2162,7 @@ ${outline}`;
 
     canvas_update_edge: {
       name: 'canvas_update_edge',
+      defer_loading: true,
       description:
         'Update fields on an existing edge. Supports changing label, kind, payload, arrow caps, stroke, and bend. ' +
         'Endpoint mutation is intentionally not supported — delete the edge and create a new one instead to keep the ' +
@@ -2223,6 +2240,7 @@ ${outline}`;
 
     canvas_delete_edge: {
       name: 'canvas_delete_edge',
+      defer_loading: true,
       description: 'Delete an edge by id.',
       inputSchema: z.object({
         edgeId: z.string().describe('The ID of the edge to delete.'),
@@ -2389,6 +2407,7 @@ ${outline}`;
 
     artifact_update: {
       name: 'artifact_update',
+      defer_loading: true,
       description:
         'Add a new version to an existing artifact. The new version becomes the current one; previous versions remain accessible in the drawer. ' +
         'Use this when the user asks to refine, iterate on, or fix an artifact you (or a previous turn) already created. ' +
@@ -2462,6 +2481,7 @@ ${outline}`;
 
     canvas_read_webpage: {
       name: 'canvas_read_webpage',
+      defer_loading: true,
       description:
         'Read a webpage that is currently open in a canvas iframe node using the richest available strategy.\n' +
         'Requires the iframe node to be mounted and loaded in the canvas.\n\n' +


### PR DESCRIPTION
Closes three gaps in the canvas agent toolset:

- canvas_search_nodes: filter canvas nodes by query / type / workspace-node
  tag with snippets, so the agent can scope reads before pulling the full
  context summary.
- canvas_add_to_group / canvas_remove_from_group: manipulate group nodes'
  explicit data.childIds without round-tripping through canvas_update_node.
  Validates self-reference, non-group targets, and missing ids.
- workspace_node_list / workspace_node_get / workspace_node_upsert: expose
  the workspace-node knowledge layer (tags, properties, links) that was
  previously only reachable via the renderer's IPC. Upsert auto-registers
  new tag names with the global tag store.

System prompt updated to surface the new tools to the agent.