### PR TITLE
Add Mermaid diagram support to inline visuals and artifact drawer

### DIFF
--- a/apps/canvas-workspace/src/main/canvas-agent/tools.ts
+++ b/apps/canvas-workspace/src/main/canvas-agent/tools.ts
@@ -2291,9 +2291,10 @@ ${outline}`;
         'Use this when the user wants to UNDERSTAND something via a visual, not when they want to KEEP or iterate on it. ' +
         'For keep-and-iterate flows, call `artifact_create` instead. ' +
         'For HTML, return a SINGLE self-contained `<!DOCTYPE html>` document — it will render in a sandboxed iframe and CDN libs (Chart.js, D3, Mermaid) load fine. ' +
-        'For SVG, return a single `<svg>` element (no surrounding HTML). For Mermaid, return the Mermaid source only.',
+        'For SVG, return a single `<svg>` element (no surrounding HTML). For Mermaid, return the Mermaid source only (e.g. starting with `graph TD` / `sequenceDiagram` / `flowchart LR`) — no code fences, no surrounding HTML. ' +
+        'Pick `mermaid` for quick flowcharts, sequence/state/ER diagrams, gantt charts, and similar structural diagrams; it streams faster than full HTML and renders crisply at any zoom.',
       inputSchema: z.object({
-        type: z.enum(['html', 'svg', 'mermaid']).describe('Visual format. v1 supports html; svg and mermaid reserved.'),
+        type: z.enum(['html', 'svg', 'mermaid']).describe('Visual format. `html` renders in a sandboxed iframe; `svg` renders the element directly; `mermaid` parses the source and renders as an SVG diagram.'),
         title: z.string().optional().describe('Short label shown above the visual.'),
         content: z.string().describe('The full visual content (HTML doc, SVG element, or Mermaid source).'),
       }),
@@ -2380,7 +2381,7 @@ ${outline}`;
         'For throwaway visuals that just illustrate a point mid-explanation, use `visual_render` instead. ' +
         'Content format matches `visual_render`: a self-contained HTML doc for type=html.',
       inputSchema: z.object({
-        type: z.enum(['html', 'svg', 'mermaid']).describe('Artifact type. v1 supports html; svg and mermaid reserved.'),
+        type: z.enum(['html', 'svg', 'mermaid']).describe('Artifact type. `html` renders in a sandboxed iframe; `svg` renders the element directly; `mermaid` parses the source and renders as an SVG diagram.'),
         title: z.string().describe('Short title — appears in the artifact card and as the canvas node title once pinned.'),
         content: z.string().describe('Full content of the first version.'),
         prompt: z.string().optional().describe('Optional record of the prompt/spec that produced this version (helps diff future iterations).'),

--- a/apps/canvas-workspace/src/renderer/src/components/artifacts/ArtifactDrawer.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/artifacts/ArtifactDrawer.tsx
@@ -10,6 +10,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { Artifact, ArtifactVersion } from '../../types';
 import { useArtifactDrawer } from './ArtifactContext';
+import { renderMermaidSource, type MermaidRenderResult } from '../chat/utils/mermaid';
 
 const TYPE_LABEL: Record<string, string> = {
   html: 'HTML',
@@ -182,6 +183,14 @@ export const ArtifactDrawer = () => {
         />
       );
     }
+    if (artifact.type === 'mermaid') {
+      return (
+        <ArtifactDrawerMermaid
+          key={viewedVersion.id}
+          source={viewedVersion.content}
+        />
+      );
+    }
     return <div className="artifact-drawer__empty">Unsupported artifact type</div>;
   };
 
@@ -232,5 +241,35 @@ export const ArtifactDrawer = () => {
         <div className="artifact-drawer__body">{renderBody()}</div>
       </aside>
     </>
+  );
+};
+
+const ArtifactDrawerMermaid = ({ source }: { source: string }) => {
+  const [result, setResult] = useState<MermaidRenderResult | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    setResult(null);
+    void renderMermaidSource(source).then(r => {
+      if (!cancelled) setResult(r);
+    });
+    return () => { cancelled = true; };
+  }, [source]);
+
+  if (!result) {
+    return <div className="artifact-drawer__mermaid-host artifact-drawer__mermaid-host--loading">Rendering diagram…</div>;
+  }
+  if (!result.ok) {
+    return (
+      <div className="artifact-drawer__mermaid-host artifact-drawer__mermaid-host--error">
+        <div className="artifact-drawer__mermaid-error-title">Mermaid render failed</div>
+        <pre className="artifact-drawer__mermaid-error-detail">{result.error}</pre>
+      </div>
+    );
+  }
+  return (
+    <div
+      className="artifact-drawer__mermaid-host"
+      dangerouslySetInnerHTML={{ __html: result.svg }}
+    />
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/components/artifacts/ChatInlineVisual.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/artifacts/ChatInlineVisual.tsx
@@ -20,6 +20,7 @@ import type { ArtifactType } from '../../types';
 import { useArtifactDrawer } from './ArtifactContext';
 import { extractPartialStringField } from './partialJson';
 import { STREAMING_SHELL, withAutoHeight } from './streamingShell';
+import { renderMermaidSource, type MermaidRenderResult } from '../chat/utils/mermaid';
 
 export interface InlineVisualPayload {
   type: ArtifactType;
@@ -152,6 +153,24 @@ export const ChatInlineVisual = ({
     return () => cancelAnimationFrame(rafId.current);
   }, [isStreamingHtml, livePayload]);
 
+  // Mermaid source can't be parsed mid-stream, so we wait for the final
+  // payload before kicking off a render. Re-runs when the source changes
+  // (rare here, but cheap; mermaid.render is memoizable in practice).
+  const mermaidSource = payload?.type === 'mermaid' ? payload.content : null;
+  const [mermaidResult, setMermaidResult] = useState<MermaidRenderResult | null>(null);
+  useEffect(() => {
+    if (!mermaidSource) {
+      setMermaidResult(null);
+      return;
+    }
+    let cancelled = false;
+    setMermaidResult(null);
+    void renderMermaidSource(mermaidSource).then(result => {
+      if (!cancelled) setMermaidResult(result);
+    });
+    return () => { cancelled = true; };
+  }, [mermaidSource]);
+
   // Lazily promote the inline visual to a persistent artifact and return its
   // id. Both Open and Save funnel through this — repeated calls reuse the
   // first artifact instead of creating duplicates.
@@ -271,6 +290,36 @@ export const ChatInlineVisual = ({
         <div
           className="chat-inline-visual__svg"
           dangerouslySetInnerHTML={{ __html: livePayload.content }}
+        />
+      );
+    }
+    if (livePayload.type === 'mermaid') {
+      if (!payload) {
+        return (
+          <div className="chat-inline-visual__mermaid chat-inline-visual__mermaid--loading">
+            <span className="chat-inline-visual__loading-label">Preparing diagram</span>
+          </div>
+        );
+      }
+      if (!mermaidResult) {
+        return (
+          <div className="chat-inline-visual__mermaid chat-inline-visual__mermaid--loading">
+            <span className="chat-inline-visual__loading-label">Rendering diagram</span>
+          </div>
+        );
+      }
+      if (!mermaidResult.ok) {
+        return (
+          <div className="chat-inline-visual__mermaid chat-inline-visual__mermaid--error">
+            <div className="chat-inline-visual__mermaid-error-title">Mermaid render failed</div>
+            <pre className="chat-inline-visual__mermaid-error-detail">{mermaidResult.error}</pre>
+          </div>
+        );
+      }
+      return (
+        <div
+          className="chat-inline-visual__mermaid"
+          dangerouslySetInnerHTML={{ __html: mermaidResult.svg }}
         />
       );
     }

--- a/apps/canvas-workspace/src/renderer/src/components/artifacts/artifacts.css
+++ b/apps/canvas-workspace/src/renderer/src/components/artifacts/artifacts.css
@@ -279,6 +279,50 @@
   color: #b54040;
 }
 
+.chat-inline-visual__mermaid {
+  display: block;
+  width: 100%;
+  background: #fff;
+  padding: 12px;
+  box-sizing: border-box;
+  text-align: center;
+  overflow-x: auto;
+}
+
+.chat-inline-visual__mermaid svg {
+  max-width: 100%;
+  height: auto;
+}
+
+.chat-inline-visual__mermaid--loading {
+  text-align: left;
+  color: #94a3b8;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+.chat-inline-visual__mermaid--error {
+  text-align: left;
+  background: rgba(218, 54, 51, 0.04);
+}
+
+.chat-inline-visual__mermaid-error-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: #8b2f2a;
+  margin-bottom: 4px;
+}
+
+.chat-inline-visual__mermaid-error-detail {
+  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+  font-size: 11px;
+  color: rgba(139, 47, 42, 0.85);
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+}
+
 /* ─── Artifact card in chat (artifact_create / artifact_update result) ─ */
 
 .chat-artifact-card {
@@ -547,6 +591,49 @@
   overflow: auto;
   padding: 16px;
   background: #fff;
+}
+
+.artifact-drawer__mermaid-host {
+  flex: 1;
+  overflow: auto;
+  padding: 16px;
+  background: #fff;
+  text-align: center;
+}
+
+.artifact-drawer__mermaid-host svg {
+  max-width: 100%;
+  height: auto;
+}
+
+.artifact-drawer__mermaid-host--loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #8a8a87;
+  font-size: 13px;
+  font-style: italic;
+}
+
+.artifact-drawer__mermaid-host--error {
+  text-align: left;
+  background: rgba(218, 54, 51, 0.04);
+}
+
+.artifact-drawer__mermaid-error-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #8b2f2a;
+  margin-bottom: 6px;
+}
+
+.artifact-drawer__mermaid-error-detail {
+  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+  font-size: 12px;
+  color: rgba(139, 47, 42, 0.85);
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
 }
 
 .artifact-drawer__empty {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/utils/mermaid.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/utils/mermaid.ts
@@ -28,27 +28,42 @@ const loadMermaid = (): Promise<MermaidApi> => {
   return mermaidPromise;
 };
 
-const renderInto = async (host: HTMLElement): Promise<void> => {
-  const source = host.dataset.source ?? '';
-  if (!source.trim()) {
-    host.dataset.rendered = 'error';
-    host.innerHTML = '<div class="chat-mermaid-error">Empty diagram</div>';
-    return;
-  }
+export type MermaidRenderResult =
+  | { ok: true; svg: string }
+  | { ok: false; error: string };
 
+/**
+ * Render mermaid source to an SVG string. Used by React surfaces (inline
+ * `visual_render`, artifact drawer) that want to manage their own host
+ * element + loading state — unlike `renderMermaidIn`, this doesn't write
+ * to the DOM itself.
+ */
+export const renderMermaidSource = async (source: string): Promise<MermaidRenderResult> => {
+  const trimmed = source.trim();
+  if (!trimmed) return { ok: false, error: 'Empty diagram' };
   try {
     const mermaid = await loadMermaid();
     const id = `chat-mermaid-${++diagramIdCounter}-${Date.now().toString(36)}`;
-    const { svg } = await mermaid.render(id, source);
-    host.innerHTML = svg;
-    host.dataset.rendered = 'true';
+    const { svg } = await mermaid.render(id, trimmed);
+    return { ok: true, svg };
   } catch (err) {
-    host.dataset.rendered = 'error';
     const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+};
+
+const renderInto = async (host: HTMLElement): Promise<void> => {
+  const source = host.dataset.source ?? '';
+  const result = await renderMermaidSource(source);
+  if (result.ok) {
+    host.innerHTML = result.svg;
+    host.dataset.rendered = 'true';
+  } else {
+    host.dataset.rendered = 'error';
     host.innerHTML = (
       '<div class="chat-mermaid-error">'
       + '<div class="chat-mermaid-error-title">Mermaid render failed</div>'
-      + `<div class="chat-mermaid-error-detail">${escapeHtml(message)}</div>`
+      + `<div class="chat-mermaid-error-detail">${escapeHtml(result.error)}</div>`
       + '</div>'
     );
   }


### PR DESCRIPTION
## Summary
Adds native support for rendering Mermaid diagrams in both inline visuals (chat) and the artifact drawer. Mermaid source is now a first-class visual type alongside HTML and SVG, with proper loading and error states.

## Key Changes

- **New `renderMermaidSource` utility** (`apps/canvas-workspace/src/renderer/src/components/chat/utils/mermaid.ts`):
  - Extracted diagram rendering logic into a reusable async function that returns `MermaidRenderResult` (success with SVG or error with message)
  - Allows React components to manage their own loading/error UI without direct DOM manipulation
  - Refactored existing `renderInto` to use the new utility

- **Inline visual support** (`ChatInlineVisual.tsx`):
  - Added Mermaid rendering with proper state management (loading → rendering → success/error)
  - Shows "Preparing diagram" while streaming, "Rendering diagram" during render, and error details on failure
  - Uses `dangerouslySetInnerHTML` to inject rendered SVG

- **Artifact drawer support** (`ArtifactDrawer.tsx`):
  - New `ArtifactDrawerMermaid` component handles Mermaid artifacts
  - Same loading/error UX as inline visuals
  - Integrated into artifact type routing

- **Styling** (`artifacts.css`):
  - Added `.chat-inline-visual__mermaid*` classes for inline diagram display with responsive SVG sizing
  - Added `.artifact-drawer__mermaid-host*` classes for drawer display
  - Consistent error styling (light red background, monospace error details) across both surfaces

- **Tool documentation** (`apps/canvas-workspace/src/main/canvas-agent/tools.ts`):
  - Updated `visual_render` tool description to clarify Mermaid usage (raw source, no code fences)
  - Added guidance that Mermaid is preferred for quick structural diagrams (flowcharts, sequence/state/ER, gantt) due to faster streaming and crisp rendering

## Implementation Details

- Mermaid rendering is deferred until the full source is available (no mid-stream parsing)
- Cancellation tokens prevent state updates after unmount
- SVG output is sanitized by Mermaid's render function before injection
- Error messages from Mermaid are displayed in a monospace font for readability
- Both inline and drawer surfaces share the same rendering logic via the utility function

https://claude.ai/code/session_01GYuwqdbHfZykHSUWPpdusM