### PR TITLE
Remove tool-search plugin from canvas agent

### DIFF
--- a/apps/canvas-workspace/src/main/agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/agent/canvas-agent.ts
@@ -7,7 +7,7 @@
  */
 
 import { Engine } from 'pulse-coder-engine';
-import { builtInSkillsPlugin, builtInToolSearchPlugin } from 'pulse-coder-engine/built-in';
+import { builtInSkillsPlugin } from 'pulse-coder-engine/built-in';
 import type { ModelMessage } from 'ai';
 import { resolveCanvasModel } from './model/config';
 import { agentBus } from '../../plugins/main';
@@ -152,20 +152,18 @@ Your system prompt contains a summary of all canvas nodes. For detailed content:
 - \`artifact_create\`: Persistent, versioned visual artifact (only when the user explicitly asks to save / keep / iterate — see Visualization Tools below)
 - \`canvas_ask_user\`: **Ask the user a clarifying question** — use this whenever the request is ambiguous, you need a choice between options, or you need confirmation before taking a destructive action. Prefer asking over guessing.
 
-## Deferred Tools (discover via tool_search)
-The following tools are NOT loaded by default — call \`tool_search_tool_bm25\` (natural language) or \`tool_search_tool_regex\` (regex) with a relevant query to surface them, then invoke the returned tool. Grouped by intent:
-- **Node mutation (delete / move)**: \`canvas_delete_node\`, \`canvas_move_node\` — load when the user asks to remove or reposition a specific node.
+## Additional Tools (also loaded)
+The following tools are loaded and callable directly. Grouped by intent:
+- **Node mutation (delete / move)**: \`canvas_delete_node\`, \`canvas_move_node\` — use when the user asks to remove or reposition a specific node.
 - **Specialized creators**: \`canvas_create_terminal_node\` (preferred for terminal creation), \`canvas_create_shape\` (precise shape sizing).
-- **Agent follow-ups**: \`canvas_send_to_agent\` — load whenever you need to interact with an ALREADY-running agent node (after the initial launch).
+- **Agent follow-ups**: \`canvas_send_to_agent\` — use whenever you need to interact with an ALREADY-running agent node (after the initial launch).
 - **Image / vision**: \`canvas_analyze_image\` (read/OCR/analyze image nodes or local paths), \`canvas_generate_image\` (AI-generated image as a canvas image node), \`canvas_generate_mindmap_image\` (visual export of an existing mindmap node).
-- **Edges / connections**: \`canvas_list_edges\`, \`canvas_create_edge\`, \`canvas_update_edge\`, \`canvas_delete_edge\` — load when the user asks to connect / link / draw arrows between nodes.
-- **Group membership**: \`canvas_add_to_group\`, \`canvas_remove_from_group\` — load when the user asks to add/remove nodes to/from a group (groups own members via \`data.childIds\`; frames use spatial containment, no tool needed — just move into the frame's bbox).
-- **Workspace-node knowledge layer**: \`workspace_node_list\`, \`workspace_node_get\`, \`workspace_node_upsert\` — load when the user is tagging nodes, building a knowledge graph, or asking "find/group/connect nodes by X". Separate metadata store with tags / properties / typed links.
+- **Edges / connections**: \`canvas_list_edges\`, \`canvas_create_edge\`, \`canvas_update_edge\`, \`canvas_delete_edge\` — use when the user asks to connect / link / draw arrows between nodes.
+- **Group membership**: \`canvas_add_to_group\`, \`canvas_remove_from_group\` — use when the user asks to add/remove nodes to/from a group (groups own members via \`data.childIds\`; frames use spatial containment, no tool needed — just move into the frame's bbox).
+- **Workspace-node knowledge layer**: \`workspace_node_list\`, \`workspace_node_get\`, \`workspace_node_upsert\` — use when the user is tagging nodes, building a knowledge graph, or asking "find/group/connect nodes by X". Separate metadata store with tags / properties / typed links.
 - **Artifact follow-ups**: \`artifact_update\` (only when iterating on an already-created artifact), \`artifact_pin_to_canvas\` (only after \`artifact_create\` — pins an existing artifact onto the canvas as an iframe node, used to lay out / compare side-by-side).
 - **Webpage scraping**: \`canvas_read_webpage\` (DOM / a11y / screenshot from an open iframe node).
-- **Page control (driving an open iframe)**: \`page_eval\`, \`page_click\`, \`page_click_at\`, \`page_fill\`, \`page_press\`, \`page_scroll\`, \`page_wait_for\` — load when the user asks you to interact with the contents of an iframe node (click a button, fill a form, scroll, wait for an element). These act on the live page inside the iframe.
-
-When in doubt about which tool exists for an operation, just call \`tool_search_tool_bm25\` with a description of what you want to do.
+- **Page control (driving an open iframe)**: \`page_eval\`, \`page_click\`, \`page_click_at\`, \`page_fill\`, \`page_press\`, \`page_scroll\`, \`page_wait_for\` — use when the user asks you to interact with the contents of an iframe node (click a button, fill a form, scroll, wait for an element). These act on the live page inside the iframe.
 
 ## Visualization Tools — visual_render is the DEFAULT
 
@@ -556,13 +554,7 @@ export class CanvasAgent {
     this.engine = new Engine({
       disableBuiltInPlugins: true,
       enginePlugins: {
-        // tool-search hides tools marked `defer_loading: true` from the
-        // immediate set sent to the LLM and surfaces them through
-        // `tool_search_tool_bm25` / `_regex`. The canvas agent has ~29 tools
-        // and many are domain-specialized (edges, knowledge layer, niche
-        // creators); keeping them deferred keeps the per-turn tool catalog
-        // focused on the common read/write/move/visual path.
-        plugins: [builtInSkillsPlugin, builtInToolSearchPlugin],
+        plugins: [builtInSkillsPlugin],
       },
       model: config.model,
       tools: canvasTools,


### PR DESCRIPTION
## Summary
Removes the `builtInToolSearchPlugin` from the canvas agent's engine initialization and updates the system prompt documentation to reflect that all tools are now directly available rather than deferred.

## Changes
- **Removed import**: Deleted `builtInToolSearchPlugin` from the engine plugin imports
- **Simplified engine config**: Removed `builtInToolSearchPlugin` from the `enginePlugins.plugins` array, keeping only `builtInSkillsPlugin`
- **Updated system prompt**: Changed the "Deferred Tools" section to "Additional Tools (also loaded)" and updated all references from "load when" to "use when" to reflect that these tools are now directly callable without requiring tool search discovery
- **Removed tool search guidance**: Deleted the final paragraph instructing users to call `tool_search_tool_bm25` when unsure which tool to use

## Implementation Details
The canvas agent previously used the tool-search plugin to hide ~29 domain-specialized tools (edges, knowledge layer, niche creators) from the initial tool catalog and surface them through `tool_search_tool_bm25` / `_regex` queries. This change makes all tools immediately available to the agent, simplifying the interaction model and removing the need for explicit tool discovery calls.

https://claude.ai/code/session_01G7guEv4B7XuWQFezbNT3Pm