### PR TITLE
fix(canvas-workspace): focus guest webContents before CDP input dispatch

### DIFF
--- a/apps/canvas-workspace/src/plugins/main/webview-page-control/__tests__/cdp-actions.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/webview-page-control/__tests__/cdp-actions.test.ts
@@ -10,6 +10,8 @@ import type { CdpHost } from '../../../../main/webview/cdp-session';
 
 interface FakeHost extends CdpHost {
   executeJavaScript(code: string, userGesture?: boolean): Promise<unknown>;
+  focus(): void;
+  focusCount: number;
   cdpCalls: Array<{ method: string; params?: Record<string, unknown> }>;
   jsCalls: string[];
 }
@@ -24,6 +26,10 @@ function makeHost(opts: {
   const host: FakeHost = {
     cdpCalls,
     jsCalls,
+    focusCount: 0,
+    focus() {
+      this.focusCount++;
+    },
     debugger: {
       isAttached: () => attached,
       attach: () => {
@@ -194,6 +200,12 @@ describe('cdpPressKey', () => {
     expect(r.error).toContain('unsupported');
     expect(host.cdpCalls).toHaveLength(0);
   });
+
+  it('steals OS-level input focus to the guest before dispatching keys', async () => {
+    const host = makeHost();
+    await cdpPressKey(host, 'a');
+    expect(host.focusCount).toBe(1);
+  });
 });
 
 describe('cdpFillSelector', () => {
@@ -217,6 +229,14 @@ describe('cdpFillSelector', () => {
     expect(r.ok).toBe(false);
     expect(r.error).toContain('not editable');
     expect(host.cdpCalls).toHaveLength(0);
+  });
+
+  it('steals OS-level input focus to the guest before inserting text', async () => {
+    const host = makeHost({
+      jsResponse: { ok: true, tag: 'input', editable: true },
+    });
+    await cdpFillSelector(host, 'input#q', 'hello');
+    expect(host.focusCount).toBe(1);
   });
 
   it('reports JS-side selector failure without touching CDP', async () => {

--- a/apps/canvas-workspace/src/plugins/main/webview-page-control/cdp-actions.ts
+++ b/apps/canvas-workspace/src/plugins/main/webview-page-control/cdp-actions.ts
@@ -78,7 +78,18 @@ async function runWithTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
 // Selector → coordinate resolution (JS-side, fast, no debugger needed)
 // ---------------------------------------------------------------------------
 
-interface CdpActionHost extends CdpHost, PageRunner {}
+interface CdpActionHost extends CdpHost, PageRunner {
+  /**
+   * Optional — grab OS-level input routing focus before CDP input dispatch.
+   * `Input.insertText` / `Input.dispatchKeyEvent` deliver to whichever widget
+   * currently owns the focused input route. In Electron, when the user is
+   * typing into the host window (e.g. the chat compose box), the guest
+   * webContents doesn't own that route — even though its DOM has `focus()`'d
+   * an element — so text would leak into the host. Calling `wc.focus()`
+   * forces the guest to become the focused widget.
+   */
+  focus?(): void;
+}
 
 interface CenterResult {
   ok: boolean;
@@ -240,6 +251,14 @@ export async function cdpPressKey(
     }
   }
 
+  // Steal OS-level input focus to the guest before dispatchKeyEvent —
+  // see the note in cdpFillSelector.
+  try {
+    wc.focus?.();
+  } catch {
+    // best-effort
+  }
+
   try {
     return await runWithTimeout(
       withCdp(wc, async (send: CdpSender) => {
@@ -344,6 +363,16 @@ export async function cdpFillSelector(
   if (!prep?.ok) return { ok: false, error: prep?.error ?? 'fill prep failed' };
   if (!prep.editable) {
     return { ok: false, error: `element is not editable (tag=${prep.tag})` };
+  }
+
+  // Steal OS-level input focus to the guest before insertText. Without
+  // this, if the host window owns the focused widget (e.g. the chat
+  // compose box), Chromium's input router delivers the text there
+  // instead of into the iframe.
+  try {
+    wc.focus?.();
+  } catch {
+    // best-effort
   }
 
   try {


### PR DESCRIPTION
page_fill / page_press were leaking text into the host window when the host owned the focused input widget (e.g. the chat compose box). Input.insertText / dispatchKeyEvent route to the OS-level focused widget, and DOM-level el.focus() in the guest doesn't change that. Call wc.focus() on the guest webContents before dispatching to force the input route into the iframe.