### PR TITLE
Set app name and process title in canvas-workspace bootstrap

### DIFF
--- a/apps/canvas-workspace/src/main/app/bootstrap.ts
+++ b/apps/canvas-workspace/src/main/app/bootstrap.ts
@@ -52,6 +52,13 @@ interface AppPaths {
 }
 
 export function bootstrap({ mainDir }: BootstrapOptions): void {
+  // Without this, dev runs inherit the Electron binary's identity — dock label,
+  // About panel, userData path, and `ps`/Activity Monitor all read "Electron".
+  // Packaged builds get this from electron-builder's productName, but dev does
+  // not, so set it explicitly before any other Electron API touches app.name.
+  app.setName("Pulse Canvas");
+  process.title = "Pulse Canvas";
+
   const paths = resolveAppPaths(mainDir);
   const { writeLog } = createMainLogger();
 


### PR DESCRIPTION
## Summary
Configure the Electron app identity explicitly during bootstrap to ensure the canvas-workspace application displays correctly in system UI (dock, About panel, Activity Monitor, etc.) during development runs.

## Changes
- Added `app.setName("Pulse Canvas")` and `process.title = "Pulse Canvas"` at the start of the bootstrap function
- These calls are placed before any other Electron API usage to ensure the app identity is set before the system reads it
- Includes explanatory comment documenting why this is necessary (packaged builds get the name from electron-builder's productName, but dev runs need explicit configuration)

## Details
Without this change, development runs inherit the generic "Electron" identity from the Electron binary, affecting:
- Dock label on macOS
- About panel display
- userData path resolution
- Process name in `ps` and Activity Monitor

This ensures consistent branding and user experience during development.

https://claude.ai/code/session_01EiXNwxYX6M8vrnUvhmLHDb