### PR TITLE
fix(canvas-workspace): strip query before matching dynamic-app routes

### DIFF
--- a/apps/canvas-workspace/src/plugins/main/dynamic-app/__tests__/utils.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/dynamic-app/__tests__/utils.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { stripRequestQuery } from "../utils";
+
+describe("stripRequestQuery", () => {
+  it("returns the path unchanged when no query or hash is present", () => {
+    expect(stripRequestQuery("/ui/app-x")).toBe("/ui/app-x");
+    expect(stripRequestQuery("/api/app-x/stream")).toBe("/api/app-x/stream");
+    expect(stripRequestQuery("/")).toBe("/");
+  });
+
+  it("drops `?query` (regression for the update cache-buster)", () => {
+    expect(stripRequestQuery("/ui/app-x?v=123")).toBe("/ui/app-x");
+    expect(stripRequestQuery("/ui/app-x?v=123&foo=bar")).toBe("/ui/app-x");
+    expect(stripRequestQuery("/api/app-x/stream?token=abc")).toBe(
+      "/api/app-x/stream",
+    );
+  });
+
+  it("drops `#fragment`", () => {
+    expect(stripRequestQuery("/ui/app-x#section")).toBe("/ui/app-x");
+  });
+
+  it("drops both, picking whichever comes first", () => {
+    expect(stripRequestQuery("/ui/app-x?v=1#section")).toBe("/ui/app-x");
+    expect(stripRequestQuery("/ui/app-x#section?v=1")).toBe("/ui/app-x");
+  });
+});

--- a/apps/canvas-workspace/src/plugins/main/dynamic-app/manager.ts
+++ b/apps/canvas-workspace/src/plugins/main/dynamic-app/manager.ts
@@ -43,6 +43,7 @@ import type {
   StatefulSpec,
   UiSpec,
 } from "./types";
+import { stripRequestQuery } from "./utils";
 
 interface BaseRunner {
   id: string;
@@ -117,6 +118,7 @@ const UI_RE = /^\/ui\/([^/?#]+)\/?$/;
 const API_SNAPSHOT_RE = /^\/api\/([^/?#]+)\/?$/;
 const API_STREAM_RE = /^\/api\/([^/?#]+)\/stream\/?$/;
 const API_ACTION_RE = /^\/api\/([^/?#]+)\/actions\/([^/?#]+)\/?$/;
+
 
 const MAX_POST_BODY_BYTES = 1 << 20; // 1 MB
 
@@ -209,7 +211,7 @@ export class DynamicAppManager {
   // ─── Request routing ─────────────────────────────────────────────
 
   private handleRequest(req: IncomingMessage, res: ServerResponse): void {
-    const url = req.url ?? "/";
+    const url = stripRequestQuery(req.url ?? "/");
 
     let m = UI_RE.exec(url);
     if (m) {

--- a/apps/canvas-workspace/src/plugins/main/dynamic-app/utils.ts
+++ b/apps/canvas-workspace/src/plugins/main/dynamic-app/utils.ts
@@ -1,0 +1,12 @@
+/**
+ * Strip `?query` / `#fragment` from a request URL before route matching.
+ *
+ * Manager's route regexes (`/ui/<id>`, `/api/<id>`, …) anchor on `$`,
+ * and `dynamic_app_update` appends a `?v=<timestamp>` cache-buster so
+ * the iframe reloads. The raw `req.url` therefore wouldn't match unless
+ * we trim the suffix first.
+ */
+export function stripRequestQuery(rawUrl: string): string {
+  const at = rawUrl.search(/[?#]/);
+  return at === -1 ? rawUrl : rawUrl.slice(0, at);
+}


### PR DESCRIPTION
\`dynamic_app_update\` appends a \`?v=<timestamp>\` cache-buster to the iframe URL so the webview actually reloads. But the manager's route regexes (\`/ui/<id>\`, \`/api/<id>\`, \`/api/<id>/stream\`, \`/api/<id>/actions/<name>\`) anchor on \`$\`, and Node's \`req.url\` includes the query — so every post-update request to /ui/<id>?v=… fell through to 404 "not found". The iframe was rendering the manager's plain-text 404 body instead of the page.

Strip query / fragment from \`req.url\` before matching. Factored into a 3-line \`stripRequestQuery\` helper in its own \`utils.ts\` so it can be unit-tested without dragging the electron import through vitest.

Reproduction (pre-fix):
  1. dynamic_app_create → iframe loads /ui/app-x → 200 OK.
  2. dynamic_app_update → tool sets data.url = /ui/app-x?v=<ts>.
  3. Webview reloads → GET /ui/app-x?v=<ts> → 404.

4 new utils tests cover query / hash / both stripping. 47 dynamic-app tests green; typecheck clean.

https://claude.ai/code/session_01Mkycs3aphXLzepftgy7XvZ