### PR TITLE
fix(canvas-agent): expose node positions/sizes in workspace context s…

### DIFF
--- a/apps/canvas-workspace/src/main/agent/context-builder.ts
+++ b/apps/canvas-workspace/src/main/agent/context-builder.ts
@@ -291,6 +291,10 @@ function summarizeNode(node: CanvasNode): NodeSummary {
     id: node.id,
     type: node.type,
     title: node.title,
+    x: node.x,
+    y: node.y,
+    width: node.width,
+    height: node.height,
   };
 
   switch (node.type) {
@@ -690,6 +694,17 @@ export function formatSummaryForPrompt(summary: WorkspaceSummary): string {
       const labelHint = e.label ? ` — "${e.label}"` : '';
       const kindHint = e.kind ? ` [${e.kind}]` : '';
       lines.push(`- [${e.id}] ${e.source} → ${e.target}${labelHint}${kindHint}`);
+    }
+    lines.push('');
+  }
+
+  const nodesWithPos = summary.nodes.filter(n => n.x !== undefined && n.y !== undefined);
+  if (nodesWithPos.length > 0) {
+    lines.push('## Spatial Layout');
+    lines.push('_Current positions and sizes for all nodes (canvas coordinates). Use with `canvas_move_node` when arranging the layout._');
+    for (const n of nodesWithPos) {
+      const sizeHint = (n.width && n.height) ? ` size(${n.width}×${n.height})` : '';
+      lines.push(`- [${n.id}] ${n.type} "${n.title}": pos(${Math.round(n.x!)}, ${Math.round(n.y!)})${sizeHint}`);
     }
     lines.push('');
   }

--- a/apps/canvas-workspace/src/main/agent/types.ts
+++ b/apps/canvas-workspace/src/main/agent/types.ts
@@ -192,6 +192,14 @@ export interface NodeSummary {
   rootText?: string;
   /** Total topic count (including root) for mindmap nodes. */
   topicCount?: number;
+  /** Canvas X coordinate (canvas pixels). */
+  x?: number;
+  /** Canvas Y coordinate (canvas pixels). */
+  y?: number;
+  /** Node width (canvas pixels). */
+  width?: number;
+  /** Node height (canvas pixels). */
+  height?: number;
 }
 
 /**


### PR DESCRIPTION
…ummary

The agent had no spatial information when reading canvas context, making auto-layout operations (canvas_move_node) effectively blind to where nodes were and how large they were.

- Add x, y, width, height fields to NodeSummary in agent/types.ts
- Populate those fields in summarizeNode() from the raw canvas node
- Add a "Spatial Layout" section to formatSummaryForPrompt() listing each node's position and size so the agent can compute non-overlapping layouts

Fixes #446

https://claude.ai/code/session_01EYQ8bqMJAhjgHTzje6Ya1F