### PR TITLE
feat(canvas-workspace): add dangerous-mode toggle to agent picker

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentPicker.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentPicker.tsx
@@ -6,6 +6,7 @@ interface AgentPickerProps {
   selectedAgent: string;
   cwdInput: string;
   promptInput: string;
+  dangerousMode: boolean;
   rootFolder?: string;
   recentCwds: string[];
   /** Optional Back button used when entering Setup from the Restart view. */
@@ -13,6 +14,7 @@ interface AgentPickerProps {
   onAgentChange: (id: string) => void;
   onCwdChange: (value: string) => void;
   onPromptChange: (value: string) => void;
+  onDangerousModeChange: (value: boolean) => void;
   onPickFolder: () => void;
   onLaunch: () => void;
 }
@@ -48,12 +50,14 @@ export const AgentPicker = ({
   selectedAgent,
   cwdInput,
   promptInput,
+  dangerousMode,
   rootFolder,
   recentCwds,
   onBack,
   onAgentChange,
   onCwdChange,
   onPromptChange,
+  onDangerousModeChange,
   onPickFolder,
   onLaunch,
 }: AgentPickerProps) => {
@@ -61,9 +65,16 @@ export const AgentPicker = ({
   const effectiveCwd = cwdInput || rootFolder || '';
   const previewCmd = agentDef?.command ?? 'agent';
   const visibleRecents = recentCwds.filter((p) => p !== cwdInput).slice(0, 3);
+  const dangerousFlag =
+    selectedAgent === 'claude-code'
+      ? '--dangerously-skip-permissions'
+      : selectedAgent === 'codex'
+        ? '--dangerously-bypass-approvals-and-sandbox'
+        : '';
+  const supportsDangerous = dangerousFlag !== '';
   const startTitle = `Start ${agentDef?.label ?? 'agent'}  —  ${previewCmd}${
-    effectiveCwd ? ` in ${effectiveCwd}` : ''
-  }`;
+    dangerousMode && supportsDangerous ? ` ${dangerousFlag}` : ''
+  }${effectiveCwd ? ` in ${effectiveCwd}` : ''}`;
 
   return (
     <div className="agent-body-wrap agent-body-wrap--setup">
@@ -174,6 +185,21 @@ export const AgentPicker = ({
               rows={3}
             />
           </div>
+
+          {supportsDangerous && (
+            <div className="agent-field">
+              <label className="agent-dangerous-toggle" title={`Adds \`${dangerousFlag}\` to the launch command`}>
+                <input
+                  type="checkbox"
+                  checked={dangerousMode}
+                  onChange={(e) => onDangerousModeChange(e.target.checked)}
+                />
+                <span className="agent-dangerous-toggle-text">
+                  跳过权限确认 <code>{dangerousFlag}</code>
+                </span>
+              </label>
+            </div>
+          )}
         </div>
 
         <div className="agent-card-footer">

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
@@ -807,3 +807,29 @@
   text-align: center;
   padding: 4px;
 }
+
+.agent-dangerous-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--agent-warning, #d97706);
+  font-family: var(--agent-sans);
+  cursor: pointer;
+  user-select: none;
+}
+
+.agent-dangerous-toggle input[type='checkbox'] {
+  accent-color: var(--agent-warning, #d97706);
+  cursor: pointer;
+}
+
+.agent-dangerous-toggle-text code {
+  font-size: 11px;
+  background: var(--agent-warning-soft, #fff4e2);
+  border: 1px solid var(--agent-warning-border, rgba(217, 119, 6, 0.32));
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  margin-left: 2px;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -31,12 +31,14 @@ export const AgentNodeBody = ({
         selectedAgent={controller.selectedAgent}
         cwdInput={controller.cwdInput}
         promptInput={controller.promptInput}
+        dangerousMode={controller.dangerousMode}
         rootFolder={rootFolder}
         recentCwds={controller.recentCwds}
         onBack={controller.fromRestart ? controller.handleBackToRestart : undefined}
         onAgentChange={controller.setSelectedAgent}
         onCwdChange={controller.setCwdInput}
         onPromptChange={controller.setPromptInput}
+        onDangerousModeChange={controller.setDangerousMode}
         onPickFolder={controller.handlePickFolder}
         onLaunch={controller.handleLaunch}
       />

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/useAgentNodeController.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/useAgentNodeController.ts
@@ -52,6 +52,7 @@ export const useAgentNodeController = ({
   const [selectedAgent, setSelectedAgent] = useState(data.agentType || 'claude-code');
   const [cwdInput, setCwdInput] = useState(data.cwd || '');
   const [promptInput, setPromptInput] = useState(data.inlinePrompt || data.lastInitPrompt || '');
+  const [dangerousMode, setDangerousMode] = useState(data.dangerousMode ?? false);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [recentCwds, setRecentCwds] = useState<string[]>(loadRecentCwds);
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
@@ -158,16 +159,23 @@ export const useAgentNodeController = ({
         }
         writeCommandTimeRef.current = Date.now();
 
-        const { inlinePrompt, promptFile, agentArgs } = dataRef.current;
+        const { inlinePrompt, promptFile, agentArgs, dangerousMode } = dataRef.current;
         const effectivePrompt = inlinePromptOverride || inlinePrompt;
+        const dangerousFlag = dangerousMode
+          ? agentType === 'claude-code'
+            ? ' --dangerously-skip-permissions'
+            : agentType === 'codex'
+              ? ' --dangerously-bypass-approvals-and-sandbox'
+              : ''
+          : '';
 
         if (agentType === 'codex' && resumeMode) {
-          api.write(sessionId, `${command} resume --last\n`);
+          api.write(sessionId, `${command}${dangerousFlag} resume --last\n`);
         } else {
           const flags =
-            agentType === 'claude-code'
+            (agentType === 'claude-code'
               ? ` ${resumeMode && canResumeClaude ? '--resume' : '--session-id'} ${cliSessionId}`
-              : '';
+              : '') + dangerousFlag;
           if (effectivePrompt) {
             const escaped = effectivePrompt.replace(/'/g, "'\\''");
             api.write(sessionId, `${command}${flags} '${escaped}'\n`);
@@ -386,6 +394,7 @@ export const useAgentNodeController = ({
         cwd: effectiveCwd,
         inlinePrompt: prompt,
         lastInitPrompt: prompt || dataRef.current.lastInitPrompt || '',
+        dangerousMode,
         status: 'running',
         sessionId: freshSessionId,
         scrollback: '',
@@ -394,7 +403,7 @@ export const useAgentNodeController = ({
     });
     setFromRestart(false);
     setViewMode('running');
-  }, [selectedAgent, cwdInput, promptInput, rootFolder, readOnly]);
+  }, [selectedAgent, cwdInput, promptInput, dangerousMode, rootFolder, readOnly]);
 
   const handleMentionSelect = useCallback((selected: CanvasNode) => {
     if (readOnly) return;
@@ -452,9 +461,10 @@ export const useAgentNodeController = ({
     setSelectedAgent(data.agentType || selectedAgent);
     setCwdInput(data.cwd || '');
     setPromptInput(data.lastInitPrompt || '');
+    setDangerousMode(data.dangerousMode ?? false);
     setFromRestart(true);
     setViewMode('setup');
-  }, [data.agentType, data.cwd, data.lastInitPrompt, selectedAgent, readOnly]);
+  }, [data.agentType, data.cwd, data.lastInitPrompt, data.dangerousMode, selectedAgent, readOnly]);
 
   const handleBackToRestart = useCallback(() => {
     setFromRestart(false);
@@ -491,6 +501,8 @@ export const useAgentNodeController = ({
     setCwdInput,
     setPromptInput,
     setSelectedAgent,
+    dangerousMode,
+    setDangerousMode,
     status: data.status ?? 'idle',
     viewMode,
     visibleNodes: getAllNodesRef.current?.() ?? [],

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -158,6 +158,13 @@ export interface AgentNodeData {
   agentType: string;
   status?: 'idle' | 'running' | 'done' | 'error';
   agentArgs?: string;
+  /**
+   * When true, launch the agent in unrestricted mode:
+   *   - claude-code → adds `--dangerously-skip-permissions`
+   *   - codex       → adds `--dangerously-bypass-approvals-and-sandbox`
+   * Other agent types ignore this flag.
+   */
+  dangerousMode?: boolean;
   /** Short prompt passed directly as a CLI argument. */
   inlinePrompt?: string;
   /** Relative path to a prompt file in cwd for long prompts. */


### PR DESCRIPTION
New optional `AgentNodeData.dangerousMode` field. When enabled, the launch command appends a CLI flag matched to the agent type:

- claude-code → --dangerously-skip-permissions
- codex       → --dangerously-bypass-approvals-and-sandbox
- pulse-coder → ignored (no flag added, toggle hidden)

UI: a warning-colored checkbox below the prompt textarea, shown only when the selected agent supports the flag. The value is persisted on the node so subsequent restarts (and codex `resume --last`) reuse it automatically; entering Edit-init from the Restart view re-syncs the checkbox from the stored value.