### PR TITLE
Make mention chips clickable to navigate to nodes

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatInput.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatInput.tsx
@@ -30,6 +30,8 @@ interface ChatInputProps {
   onSend: () => Promise<boolean>;
   onAbort: () => Promise<void>;
   onToggleExecutionMode?: () => void;
+  /** Focus/navigate to a clicked mention chip's target (node or workspace). */
+  onMentionNavigate?: (chip: HTMLElement) => void;
 }
 
 export const ChatInput = ({
@@ -55,6 +57,7 @@ export const ChatInput = ({
   onSend,
   onAbort,
   onToggleExecutionMode,
+  onMentionNavigate,
 }: ChatInputProps) => {
   const { t } = useI18n();
   const contextNodes = (selectedNodes && selectedNodes.length > 0)
@@ -102,6 +105,12 @@ export const ChatInput = ({
           onInput={onInput}
           onKeyDown={onKeyDown}
           onPaste={onPaste}
+          onClick={(event) => {
+            const chip = (event.target as HTMLElement).closest<HTMLElement>(
+              '.chat-mention-chip--clickable',
+            );
+            if (chip) onMentionNavigate?.(chip);
+          }}
         />
         <div className="chat-input-footer">
           <div className="chat-input-footer-left">

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
@@ -1582,19 +1582,21 @@
 .chat-mention-chip {
   display: inline-flex;
   align-items: center;
-  gap: 3px;
-  padding: 1px 6px 1px 4px;
-  margin: 0 1px;
-  background: rgba(55, 53, 47, 0.06);
-  border: 1px solid rgba(55, 53, 47, 0.09);
-  border-radius: 4px;
+  gap: 4px;
+  padding: 1px 7px 1px 5px;
+  /* Vertical margin gives wrapped rows breathing room (chips are taller
+     than the text line-height, so without it adjacent rows nearly touch). */
+  margin: 2px 1.5px;
+  background: rgba(55, 53, 47, 0.05);
+  border: 1px solid rgba(55, 53, 47, 0.08);
+  border-radius: 6px;
   font-size: 0.92em;
-  line-height: 1.5;
+  line-height: 1.35;
   color: rgb(55, 53, 47);
-  vertical-align: baseline;
+  vertical-align: middle;
   cursor: default;
   white-space: nowrap;
-  transition: background 0.15s;
+  transition: background 0.15s, border-color 0.15s;
 }
 
 .chat-mention-chip:hover {
@@ -1606,9 +1608,9 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  width: 16px;
-  height: 16px;
-  color: rgba(55, 53, 47, 0.45);
+  width: 14px;
+  height: 14px;
+  color: rgba(55, 53, 47, 0.5);
 }
 
 .chat-mention-chip-label {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatView.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatView.tsx
@@ -182,6 +182,10 @@ export const ChatView = ({
         onSelectAutoModel={onSelectAutoModel}
         onSelectModel={onSelectModel}
         onOpenModelSettings={onOpenModelSettings}
+        onMentionNavigate={(chip) => {
+          const nodeId = chip.dataset.nodeId;
+          if (nodeId) onNodeFocus?.(nodeId);
+        }}
         editableRef={editableRef}
         mentionPopup={mentionOpen && mentionItems.length > 0 ? (
           <ChatMentionPopup

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useMentions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useMentions.ts
@@ -70,6 +70,7 @@ export function useMentions({
 
     const item: MentionItem = {
       type: 'node',
+      nodeId: node.id,
       label: getNodeDisplayLabel(node),
       nodeType: node.type,
       path: (node.data as any)?.filePath,
@@ -152,6 +153,7 @@ export function useMentions({
       for (const node of nodes) {
         items.push({
           type: 'node',
+          nodeId: node.id,
           label: getNodeDisplayLabel(node),
           nodeType: node.type,
           path: (node.data as any)?.filePath,

--- a/apps/canvas-workspace/src/renderer/src/components/chat/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/types.ts
@@ -36,6 +36,8 @@ export interface MentionItem {
   type: 'node' | 'file' | 'folder' | 'workspace' | 'skill';
   label: string;
   nodeType?: CanvasNode['type'];
+  /** For type === 'node': the canvas node id, used to focus it when clicked. */
+  nodeId?: string;
   path?: string;
   workspaceId?: string;
   /** For type === 'skill': the skill's description, shown in the popup row. */

--- a/apps/canvas-workspace/src/renderer/src/components/chat/utils/mentions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/utils/mentions.ts
@@ -116,13 +116,20 @@ export function createMentionChipElement(item: MentionItem, nodes?: CanvasNode[]
   const isWorkspace = item.type === 'workspace';
   const isSkill = item.type === 'skill';
   const isFolder = item.type === 'folder';
+  const isNode = item.type === 'node';
   const nodeType = getMentionNodeType(item, nodes);
   const chip = document.createElement('span');
+
+  // Canvas-node mentions navigate to the node when clicked; tag them so the
+  // composer's click handler can resolve and focus the target (mirrors how
+  // node chips behave inside sent messages).
+  const isNavigable = isNode && !!item.nodeId;
 
   const classes = ['chat-mention-chip', 'chat-mention-chip--input'];
   if (isWorkspace) classes.push('chat-mention-chip--workspace');
   if (isSkill) classes.push('chat-mention-chip--skill');
   if (isFolder) classes.push('chat-mention-chip--folder');
+  if (isNavigable) classes.push('chat-mention-chip--clickable');
   chip.className = classes.join(' ');
   chip.contentEditable = 'false';
   chip.dataset.mention = isWorkspace
@@ -136,6 +143,10 @@ export function createMentionChipElement(item: MentionItem, nodes?: CanvasNode[]
 
   if (isWorkspace && item.workspaceId) {
     chip.dataset.workspaceId = item.workspaceId;
+  }
+
+  if (isNode && item.nodeId) {
+    chip.dataset.nodeId = item.nodeId;
   }
 
   if (!isSkill) {


### PR DESCRIPTION
## Summary
Enhanced mention chips in the chat input to be clickable and navigable. When users click on a node mention chip, the UI now focuses/navigates to that node, mirroring the behavior of node chips in sent messages.

## Key Changes
- **CSS refinements** (`ChatPanel.css`):
  - Improved spacing and sizing: increased gap (3px → 4px), adjusted padding, added vertical margin for wrapped rows
  - Softened appearance: reduced background opacity, lighter border, increased border-radius
  - Better vertical alignment: changed from `baseline` to `middle`, adjusted line-height
  - Enhanced transitions to include border-color changes

- **Mention chip data** (`mentions.ts`):
  - Added `nodeId` field to mention chips for node-type items
  - Tagged navigable node chips with `chat-mention-chip--clickable` class
  - Stored `nodeId` in chip's `dataset` for later retrieval

- **Type definitions** (`types.ts`):
  - Added optional `nodeId` field to `MentionItem` interface with documentation

- **Input handling** (`ChatInput.tsx`):
  - Added `onMentionNavigate` callback prop to handle mention chip clicks
  - Implemented click handler that detects and delegates clickable mention chips

- **Integration** (`ChatView.tsx`):
  - Connected `onMentionNavigate` callback to focus the target node via `onNodeFocus`

- **Data population** (`useMentions.ts`):
  - Populated `nodeId` field when creating mention items for node-type mentions

## Implementation Details
The solution uses event delegation on the chat input element to detect clicks on mention chips with the `chat-mention-chip--clickable` class, then passes the chip element up to the parent component which extracts the `nodeId` and triggers navigation. This approach keeps the mention chip creation logic self-contained while allowing flexible navigation handling at the view level.

https://claude.ai/code/session_017ph4JGxRj4W1HaFLBM7z7M