### PR TITLE
feat(canvas): add channel plugin to drive the agent from Feishu

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -87,6 +87,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.21",
+    "@larksuiteoapi/node-sdk": "^1.59.0",
     "@tiptap/extension-bubble-menu": "^3.20.4",
     "@tiptap/extension-code-block-lowlight": "^3.20.4",
     "@tiptap/extension-highlight": "^3.20.4",

--- a/apps/canvas-workspace/src/main/agent/service.ts
+++ b/apps/canvas-workspace/src/main/agent/service.ts
@@ -121,6 +121,16 @@ export class CanvasAgentService {
   }
 
   /**
+   * Current session id for a workspace's active agent, or null when the
+   * agent is inactive or has no session yet. Lets callers (e.g. the channel
+   * plugin) give each external conversation its own session by swapping the
+   * current session via {@link loadSession} / {@link newSession}.
+   */
+  getCurrentSessionId(workspaceId: string): string | null {
+    return this.agents.get(workspaceId)?.getCurrentSessionId() ?? null;
+  }
+
+  /**
    * List skills (name + description) available to the workspace's agent.
    * Auto-activates the agent so the engine — and the skills plugin — is
    * initialized before reading the registry.

--- a/apps/canvas-workspace/src/main/app/bootstrap.ts
+++ b/apps/canvas-workspace/src/main/app/bootstrap.ts
@@ -40,6 +40,8 @@ import {
   teardownCanvasPlugins,
   setAgentServiceAccessor,
 } from "../../plugins/main";
+import { applyChannelConfigToEnv } from "../../plugins/main/channel/config";
+import { setupChannelConfigIpc } from "../../plugins/main/channel/config-ipc";
 import {
   createMainLogger,
   setupFatalErrorLogging,
@@ -111,6 +113,11 @@ export function bootstrap({ mainDir }: BootstrapOptions): void {
     setupShellIpc();
     setupWebpageReaderIpc();
     setupWorkspaceNodeIpc();
+    // Channel credentials: register the config IPC (independent of the
+    // plugin) and fold any stored config into process.env BEFORE plugins
+    // evaluate enabledWhen, so a UI-configured channel can activate.
+    setupChannelConfigIpc();
+    applyChannelConfigToEnv();
     // Let plugins reach the Canvas Agent service singleton (e.g. the channel
     // plugin drives conversations from external chat). Inject before
     // activation so getAgentService() is available in activate().

--- a/apps/canvas-workspace/src/main/app/bootstrap.ts
+++ b/apps/canvas-workspace/src/main/app/bootstrap.ts
@@ -13,7 +13,11 @@ import { setupFileManagerIpc } from "../files/manager";
 // import { ensureMCPRegistered } from "../runtime/mcp-registration";
 import { setupFileWatcherIpc, teardownFileWatcher } from "../files/watcher";
 import { setupSkillInstallerIpc } from "../files/skill-installer";
-import { setupCanvasAgentIpc, teardownCanvasAgent } from "../agent/ipc";
+import {
+  getCanvasAgentService,
+  setupCanvasAgentIpc,
+  teardownCanvasAgent,
+} from "../agent/ipc";
 import { setupCanvasModelIpc } from "../agent/model/ipc";
 import { setupCanvasSkillsIpc } from "../agent/skills/ipc";
 import { setupCanvasMcpIpc } from "../agent/mcp/ipc";
@@ -30,7 +34,12 @@ import {
   startRuntimeControlServer,
   stopRuntimeControlServer,
 } from "../runtime/control-server";
-import { BUILT_IN_MAIN_PLUGINS, setupCanvasPlugins } from "../../plugins/main";
+import {
+  BUILT_IN_MAIN_PLUGINS,
+  setupCanvasPlugins,
+  teardownCanvasPlugins,
+  setAgentServiceAccessor,
+} from "../../plugins/main";
 import {
   createMainLogger,
   setupFatalErrorLogging,
@@ -102,6 +111,10 @@ export function bootstrap({ mainDir }: BootstrapOptions): void {
     setupShellIpc();
     setupWebpageReaderIpc();
     setupWorkspaceNodeIpc();
+    // Let plugins reach the Canvas Agent service singleton (e.g. the channel
+    // plugin drives conversations from external chat). Inject before
+    // activation so getAgentService() is available in activate().
+    setAgentServiceAccessor(() => getCanvasAgentService());
     // Plugin activation can register canvas-agent tools; we need that done
     // BEFORE any canvas-agent is constructed (which happens when the
     // renderer first calls into canvas-agent IPC). Await so the registry
@@ -141,6 +154,7 @@ export function bootstrap({ mainDir }: BootstrapOptions): void {
     teardownFileWatcher();
     teardownCanvasWatchers();
     teardownCanvasAgent();
+    void teardownCanvasPlugins();
     void stopRuntimeControlServer();
     if (process.platform !== "darwin") {
       app.quit();

--- a/apps/canvas-workspace/src/plugins/main/built-in.ts
+++ b/apps/canvas-workspace/src/plugins/main/built-in.ts
@@ -2,10 +2,12 @@ import type { MainCanvasPlugin } from '../types';
 import { DynamicAppPlugin } from './dynamic-app';
 import { DevtoolsMainPlugin } from './devtools';
 import { WebviewPageControlPlugin } from './webview-page-control';
+import { ChannelMainPlugin } from './channel';
 
 // Main-side halves of built-in Canvas plugins.
 export const BUILT_IN_MAIN_PLUGINS: MainCanvasPlugin[] = [
   DevtoolsMainPlugin,
   WebviewPageControlPlugin,
   DynamicAppPlugin,
+  ChannelMainPlugin,
 ];

--- a/apps/canvas-workspace/src/plugins/main/channel/README.md
+++ b/apps/canvas-workspace/src/plugins/main/channel/README.md
@@ -20,7 +20,8 @@ The plugin is **inert unless explicitly opted in**. `enabledWhen` requires
 
 1. the **`Chat channels (Feishu)`** experimental toggle is on
    (Settings → Experimental), and
-2. a channel is configured (e.g. `FEISHU_APP_ID` / `FEISHU_APP_SECRET` set).
+2. a channel is configured — either via the Settings panel (stored
+   encrypted) or `FEISHU_APP_ID` / `FEISHU_APP_SECRET` env vars.
 
 Toggling the experimental flag takes effect on the next window reload /
 relaunch (the flag is read at plugin registration time).
@@ -33,19 +34,28 @@ relaunch (the flag is read at plugin registration time).
    canvas app dials out, so it works behind NAT.
 3. Grant scopes: `im:message` (receive), `im:message:send_as_bot` (send),
    and `im:resource` (image upload, optional).
-4. Set environment variables before launching Canvas:
+4. Provide credentials, either way:
 
-   ```bash
-   export FEISHU_APP_ID=cli_xxx
-   export FEISHU_APP_SECRET=xxx
-   # optional: pin the default workspace (else most-recently-modified wins)
-   export CANVAS_FEISHU_DEFAULT_WORKSPACE=<workspaceId>
-   # optional: override the API host
-   export FEISHU_API_BASE_URL=https://open.feishu.cn
-   ```
+   - **From the UI (recommended):** Settings → Experimental → turn on
+     **Chat channels (Feishu)**, then fill in App ID / App Secret (and an
+     optional default workspace) in the panel that appears. The secret is
+     stored encrypted; on the next launch it is folded into the environment.
+   - **From env vars:**
 
-5. In Canvas, open **Settings → Experimental** and turn on
-   **Chat channels (Feishu)**, then reload/relaunch so the plugin activates.
+     ```bash
+     export FEISHU_APP_ID=cli_xxx
+     export FEISHU_APP_SECRET=xxx
+     # optional: pin the default workspace (else most-recently-modified wins)
+     export CANVAS_FEISHU_DEFAULT_WORKSPACE=<workspaceId>
+     # optional: override the API host
+     export FEISHU_API_BASE_URL=https://open.feishu.cn
+     ```
+
+   Env vars take precedence over UI-stored values.
+
+5. Turn on **Chat channels (Feishu)** in Settings → Experimental (if not
+   already), then **relaunch** Canvas so the plugin activates. The config
+   panel offers a "Relaunch now" button after saving.
 
 In a **direct chat** the bot replies to every message. In a **group chat**
 it only responds when @-mentioned.

--- a/apps/canvas-workspace/src/plugins/main/channel/README.md
+++ b/apps/canvas-workspace/src/plugins/main/channel/README.md
@@ -95,10 +95,22 @@ Each conversation is bound (and addressed) independently:
 So `/bind` in one topic only affects that topic; another topic (or the DM)
 can point at a different workspace.
 
+Reply routing: direct chats get a fresh message; **group** messages (incl.
+topic groups) are sent as a **reply to the triggering message**, with
+`reply_in_thread` when the conversation is threaded — so the bot's output
+stays attached to the user's message / inside the topic rather than landing
+on the group root.
+
 Caveat: a Canvas Agent **session is per-workspace** (one current session per
 workspace). If two conversations bind to the *same* workspace, they share
 that session and run one-at-a-time (the second sees "still working"). Bind
 each conversation to its own workspace to keep histories fully separate.
+
+### Debugging
+
+Set `CANVAS_CHANNEL_DEBUG=1` before launch to log each raw inbound event
+(JSON) plus a parsed summary (`chat_type`, `thread_id`, `root_id`,
+`conversationId`). Useful for confirming what Feishu sends in topic groups.
 
 ## Architecture
 

--- a/apps/canvas-workspace/src/plugins/main/channel/README.md
+++ b/apps/canvas-workspace/src/plugins/main/channel/README.md
@@ -88,9 +88,11 @@ Each conversation is bound (and addressed) independently:
 
 - a **direct chat** keys on its `chat_id`,
 - each **group** keys on its `chat_id`, and
-- each **topic in a topic group (话题群)** keys on `chat_id:thread_id` — so
-  different topics in the same group are separate conversations, and replies
-  are sent back **into the right topic** (`reply_in_thread`).
+- each **topic in a topic group (话题群)** keys on `chat_id:<topic>` where
+  `<topic>` is `thread_id` (falling back to `root_id` so a topic's root and
+  its replies stay one conversation) — so different topics in the same group
+  are separate conversations **with separate sessions**, and replies are sent
+  back **into the right topic** (`reply_in_thread`).
 
 So `/bind` in one topic only affects that topic; another topic (or the DM)
 can point at a different workspace.

--- a/apps/canvas-workspace/src/plugins/main/channel/README.md
+++ b/apps/canvas-workspace/src/plugins/main/channel/README.md
@@ -69,14 +69,17 @@ it only responds when @-mentioned.
 | Command | Effect |
 |---|---|
 | `/help` | Show command help |
-| `/list` | List available workspaces (marks the current one) |
+| `/list` | List workspaces by name (⭐ = bound to this chat, 🖥️ = open in the app) |
 | `/ws` | Show which workspace this chat is bound to |
-| `/bind <workspaceId>` | Bind this chat to a workspace |
+| `/bind <name\|id>` | Bind this chat to a workspace (by friendly name or id) |
 | `/unbind` | Clear this chat's binding (fall back to default) |
-| `/default <workspaceId>` | Set the global default workspace |
+| `/default <name\|id>` | Set the global default workspace |
 | `/new` | Start a fresh session |
 | `/stop` | Abort the current run |
 | `/sessions` | List sessions for the bound workspace |
+
+Workspace names come from the Canvas workspace manifest, so `/list` shows
+human names (with ids) and `/bind` / `/default` accept either a name or an id.
 
 Workspace binding precedence: explicit chat binding → stored default →
 `CANVAS_FEISHU_DEFAULT_WORKSPACE` → most-recently-modified workspace.

--- a/apps/canvas-workspace/src/plugins/main/channel/README.md
+++ b/apps/canvas-workspace/src/plugins/main/channel/README.md
@@ -82,6 +82,24 @@ Workspace binding precedence: explicit chat binding → stored default →
 `CANVAS_FEISHU_DEFAULT_WORKSPACE` → most-recently-modified workspace.
 Bindings persist via the plugin's own store (`PluginStore`).
 
+## Conversations & topic groups
+
+Each conversation is bound (and addressed) independently:
+
+- a **direct chat** keys on its `chat_id`,
+- each **group** keys on its `chat_id`, and
+- each **topic in a topic group (话题群)** keys on `chat_id:thread_id` — so
+  different topics in the same group are separate conversations, and replies
+  are sent back **into the right topic** (`reply_in_thread`).
+
+So `/bind` in one topic only affects that topic; another topic (or the DM)
+can point at a different workspace.
+
+Caveat: a Canvas Agent **session is per-workspace** (one current session per
+workspace). If two conversations bind to the *same* workspace, they share
+that session and run one-at-a-time (the second sees "still working"). Bind
+each conversation to its own workspace to keep histories fully separate.
+
 ## Architecture
 
 ```

--- a/apps/canvas-workspace/src/plugins/main/channel/README.md
+++ b/apps/canvas-workspace/src/plugins/main/channel/README.md
@@ -15,9 +15,15 @@ WeCom later is a matter of implementing one interface.
   that is progressively patched; images are sent as separate messages).
 - Supports clarification round-trips, abort, and session commands.
 
-The plugin is **inert unless a channel is configured** — `enabledWhen`
-checks for channel credentials, so with no `FEISHU_*` env vars set nothing
-starts.
+The plugin is **inert unless explicitly opted in**. `enabledWhen` requires
+**both**:
+
+1. the **`Chat channels (Feishu)`** experimental toggle is on
+   (Settings → Experimental), and
+2. a channel is configured (e.g. `FEISHU_APP_ID` / `FEISHU_APP_SECRET` set).
+
+Toggling the experimental flag takes effect on the next window reload /
+relaunch (the flag is read at plugin registration time).
 
 ## Feishu setup
 
@@ -37,6 +43,9 @@ starts.
    # optional: override the API host
    export FEISHU_API_BASE_URL=https://open.feishu.cn
    ```
+
+5. In Canvas, open **Settings → Experimental** and turn on
+   **Chat channels (Feishu)**, then reload/relaunch so the plugin activates.
 
 In a **direct chat** the bot replies to every message. In a **group chat**
 it only responds when @-mentioned.

--- a/apps/canvas-workspace/src/plugins/main/channel/README.md
+++ b/apps/canvas-workspace/src/plugins/main/channel/README.md
@@ -1,0 +1,106 @@
+# Channel plugin
+
+Bridges external messaging **channels** to the workspace Canvas Agent, so a
+conversation can be driven from chat. Feishu (Lark) is the first channel;
+the orchestration core is channel-agnostic, so adding Discord / Telegram /
+WeCom later is a matter of implementing one interface.
+
+## What it does
+
+- Connects to a channel and receives inbound messages.
+- Resolves which canvas workspace a conversation talks to (**default +
+  switchable** binding).
+- Drives `CanvasAgentService.chat()` for that workspace and streams the
+  agent's output back into the channel (Feishu: a single interactive card
+  that is progressively patched; images are sent as separate messages).
+- Supports clarification round-trips, abort, and session commands.
+
+The plugin is **inert unless a channel is configured** — `enabledWhen`
+checks for channel credentials, so with no `FEISHU_*` env vars set nothing
+starts.
+
+## Feishu setup
+
+1. Create a **self-built app** in the Feishu Open Platform.
+2. Event subscription: choose **long-connection (WebSocket)** mode and
+   subscribe to `im.message.receive_v1`. No public URL is needed — the
+   canvas app dials out, so it works behind NAT.
+3. Grant scopes: `im:message` (receive), `im:message:send_as_bot` (send),
+   and `im:resource` (image upload, optional).
+4. Set environment variables before launching Canvas:
+
+   ```bash
+   export FEISHU_APP_ID=cli_xxx
+   export FEISHU_APP_SECRET=xxx
+   # optional: pin the default workspace (else most-recently-modified wins)
+   export CANVAS_FEISHU_DEFAULT_WORKSPACE=<workspaceId>
+   # optional: override the API host
+   export FEISHU_API_BASE_URL=https://open.feishu.cn
+   ```
+
+In a **direct chat** the bot replies to every message. In a **group chat**
+it only responds when @-mentioned.
+
+> Availability: the bridge runs inside the desktop app, so it responds while
+> the machine is awake (screen off / locked / app in background are all
+> fine). It does **not** respond while the machine is asleep/suspended.
+
+## Commands
+
+| Command | Effect |
+|---|---|
+| `/help` | Show command help |
+| `/list` | List available workspaces (marks the current one) |
+| `/ws` | Show which workspace this chat is bound to |
+| `/bind <workspaceId>` | Bind this chat to a workspace |
+| `/unbind` | Clear this chat's binding (fall back to default) |
+| `/default <workspaceId>` | Set the global default workspace |
+| `/new` | Start a fresh session |
+| `/stop` | Abort the current run |
+| `/sessions` | List sessions for the bound workspace |
+
+Workspace binding precedence: explicit chat binding → stored default →
+`CANVAS_FEISHU_DEFAULT_WORKSPACE` → most-recently-modified workspace.
+Bindings persist via the plugin's own store (`PluginStore`).
+
+## Architecture
+
+```
+core/                channel-agnostic orchestration
+  types.ts           Channel / InboundMessage / ChannelStream contracts
+  bridge.ts          inbound → resolve binding → service.chat() → stream out
+  binding.ts         (channelId, conversationId) → workspaceId, persisted
+  commands.ts        slash-command handling
+  dedupe.ts          message-id LRU dedupe
+  image-result.ts    detect generated-image tool results for relay
+  workspaces.ts      enumerate canvas workspaces on disk
+channels/
+  feishu/            first concrete channel
+    feishu-channel.ts  WSClient long-connection + card ChannelStream
+    feishu-client.ts   Lark SDK message/card/image helpers
+    card.ts            interactive-card builders + tool hints
+index.ts             ChannelMainPlugin (registered in built-in.ts)
+```
+
+## Adding a channel
+
+1. Implement `Channel` (`core/types.ts`): `start`, `stop`, `openStream`,
+   `sendText`, `isConfigured`. Parse the platform's events into
+   `InboundMessage` and render `ChannelStream` events however the platform
+   allows.
+2. Add it to `allChannels()` in `index.ts`.
+
+The core (`bridge.ts`, binding, commands, dedupe) needs no changes — it only
+speaks the channel-agnostic contracts.
+
+## Host integration
+
+The plugin relies on two small extension points on the canvas plugin system:
+
+- `MainCtx.getAgentService()` — drive conversations via the host's
+  `CanvasAgentService` singleton (injected by the host in `bootstrap.ts`).
+- `MainCanvasPlugin.deactivate()` — release the long-lived channel
+  connection on app shutdown (invoked from `window-all-closed`).
+
+This plugin is self-contained and does **not** depend on `apps/remote-server`;
+the Feishu helpers are copied, not imported.

--- a/apps/canvas-workspace/src/plugins/main/channel/README.md
+++ b/apps/canvas-workspace/src/plugins/main/channel/README.md
@@ -103,10 +103,23 @@ topic groups) are sent as a **reply to the triggering message**, with
 stays attached to the user's message / inside the topic rather than landing
 on the group root.
 
-Caveat: a Canvas Agent **session is per-workspace** (one current session per
-workspace). If two conversations bind to the *same* workspace, they share
-that session and run one-at-a-time (the second sees "still working"). Bind
-each conversation to its own workspace to keep histories fully separate.
+### Sessions
+
+Each conversation keeps **its own session/history**, even when several
+conversations (a DM, a group, different topics) share one workspace. Canvas
+stores a single *current* session per workspace, so the plugin maps
+`workspace::conversation → sessionId` and swaps the current session to the
+conversation's own before each turn (creating it on first contact). Runs are
+serialized per workspace, so the swap can't race another turn. The map
+persists, so histories survive restarts.
+
+Trade-offs:
+
+- The workspace's *current* session is shared with the Canvas UI, so the UI
+  for that workspace shows whichever conversation ran last (each session is
+  intact and selectable in the UI's session list).
+- Conversations bound to the same workspace still run one-at-a-time (a second
+  in-flight message sees "still working").
 
 ### Debugging
 

--- a/apps/canvas-workspace/src/plugins/main/channel/README.md
+++ b/apps/canvas-workspace/src/plugins/main/channel/README.md
@@ -45,7 +45,7 @@ relaunch (the flag is read at plugin registration time).
      ```bash
      export FEISHU_APP_ID=cli_xxx
      export FEISHU_APP_SECRET=xxx
-     # optional: pin the default workspace (else most-recently-modified wins)
+     # optional: a workspace suggested for `/bind` (not auto-applied)
      export CANVAS_FEISHU_DEFAULT_WORKSPACE=<workspaceId>
      # optional: override the API host
      export FEISHU_API_BASE_URL=https://open.feishu.cn
@@ -73,7 +73,7 @@ it only responds when @-mentioned.
 | `/ws` | Show which workspace this chat is bound to |
 | `/bind <name\|id>` | Bind this chat to a workspace (by friendly name or id) |
 | `/unbind` | Clear this chat's binding (fall back to default) |
-| `/default <name\|id>` | Set the global default workspace |
+| `/default <name\|id>` | Set the workspace suggested for `/bind` (not auto-applied) |
 | `/new` | Start a fresh session |
 | `/stop` | Abort the current run |
 | `/sessions` | List sessions for the bound workspace |
@@ -81,9 +81,14 @@ it only responds when @-mentioned.
 Workspace names come from the Canvas workspace manifest, so `/list` shows
 human names (with ids) and `/bind` / `/default` accept either a name or an id.
 
-Workspace binding precedence: explicit chat binding → stored default →
-`CANVAS_FEISHU_DEFAULT_WORKSPACE` → most-recently-modified workspace.
-Bindings persist via the plugin's own store (`PluginStore`).
+Binding is **explicit and sticky**. A conversation only talks to a workspace
+once you `/bind` it, and that choice never changes on its own — there is no
+implicit fallback, so a chat can't silently pick or switch workspaces
+mid-conversation. Until bound, the bot replies asking you to `/bind`.
+
+The stored/env default is only a **suggestion**: `/bind` with no argument
+binds it, but it is never auto-applied. Bindings persist via the plugin's own
+store (`PluginStore`).
 
 ## Conversations & topic groups
 

--- a/apps/canvas-workspace/src/plugins/main/channel/__tests__/binding.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/__tests__/binding.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { PluginStore } from '../../../types';
+import { BindingStore } from '../core/binding';
+
+// Minimal in-memory PluginStore so binding tests never touch disk.
+function memoryStore(): PluginStore {
+  const map = new Map<string, unknown>();
+  return {
+    async get<T>(key: string) {
+      return map.get(key) as T | undefined;
+    },
+    async set<T>(key: string, value: T) {
+      map.set(key, value);
+    },
+    async delete(key: string) {
+      map.delete(key);
+    },
+    async list(prefix?: string) {
+      const keys = Array.from(map.keys());
+      return prefix ? keys.filter((k) => k.startsWith(prefix)) : keys;
+    },
+  };
+}
+
+const CH = 'feishu';
+
+describe('BindingStore', () => {
+  const prev = process.env.CANVAS_FEISHU_DEFAULT_WORKSPACE;
+  beforeEach(() => {
+    delete process.env.CANVAS_FEISHU_DEFAULT_WORKSPACE;
+  });
+  afterEach(() => {
+    if (prev === undefined) delete process.env.CANVAS_FEISHU_DEFAULT_WORKSPACE;
+    else process.env.CANVAS_FEISHU_DEFAULT_WORKSPACE = prev;
+  });
+
+  it('explicit per-chat binding wins over the default', async () => {
+    const b = new BindingStore(memoryStore());
+    await b.setDefault('ws-default');
+    await b.bind(CH, 'chatA', 'ws-A');
+    expect(await b.resolve(CH, 'chatA')).toBe('ws-A');
+    // A different chat with no explicit binding falls back to the default.
+    expect(await b.resolve(CH, 'chatB')).toBe('ws-default');
+  });
+
+  it('unbind removes the override and falls back to the default', async () => {
+    const b = new BindingStore(memoryStore());
+    await b.setDefault('ws-default');
+    await b.bind(CH, 'chatA', 'ws-A');
+    await b.unbind(CH, 'chatA');
+    expect(await b.getExplicit(CH, 'chatA')).toBeUndefined();
+    expect(await b.resolve(CH, 'chatA')).toBe('ws-default');
+  });
+
+  it('env var is used when there is no explicit or stored default', async () => {
+    process.env.CANVAS_FEISHU_DEFAULT_WORKSPACE = 'ws-env';
+    const b = new BindingStore(memoryStore());
+    expect(await b.resolve(CH, 'chatX')).toBe('ws-env');
+  });
+
+  it('stored default takes precedence over the env var', async () => {
+    process.env.CANVAS_FEISHU_DEFAULT_WORKSPACE = 'ws-env';
+    const b = new BindingStore(memoryStore());
+    await b.setDefault('ws-stored');
+    expect(await b.resolve(CH, 'chatX')).toBe('ws-stored');
+  });
+
+  it('persists across instances backed by the same store', async () => {
+    const store = memoryStore();
+    const b1 = new BindingStore(store);
+    await b1.bind(CH, 'chatA', 'ws-A');
+    await b1.setDefault('ws-default');
+
+    const b2 = new BindingStore(store);
+    expect(await b2.resolve(CH, 'chatA')).toBe('ws-A');
+    expect(await b2.getDefault()).toBe('ws-default');
+  });
+});

--- a/apps/canvas-workspace/src/plugins/main/channel/__tests__/binding.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/__tests__/binding.test.ts
@@ -34,45 +34,39 @@ describe('BindingStore', () => {
     else process.env.CANVAS_FEISHU_DEFAULT_WORKSPACE = prev;
   });
 
-  it('explicit per-chat binding wins over the default', async () => {
+  it('getBound returns only the explicit per-chat binding (no implicit fallback)', async () => {
     const b = new BindingStore(memoryStore());
     await b.setDefault('ws-default');
     await b.bind(CH, 'chatA', 'ws-A');
-    expect(await b.resolve(CH, 'chatA')).toBe('ws-A');
-    // A different chat with no explicit binding falls back to the default.
-    expect(await b.resolve(CH, 'chatB')).toBe('ws-default');
+    expect(await b.getBound(CH, 'chatA')).toBe('ws-A');
+    // A different chat is NOT auto-bound to the default — it stays unbound.
+    expect(await b.getBound(CH, 'chatB')).toBeUndefined();
   });
 
-  it('unbind removes the override and falls back to the default', async () => {
+  it('unbind leaves the conversation unbound (no fallback)', async () => {
     const b = new BindingStore(memoryStore());
     await b.setDefault('ws-default');
     await b.bind(CH, 'chatA', 'ws-A');
     await b.unbind(CH, 'chatA');
-    expect(await b.getExplicit(CH, 'chatA')).toBeUndefined();
-    expect(await b.resolve(CH, 'chatA')).toBe('ws-default');
+    expect(await b.getBound(CH, 'chatA')).toBeUndefined();
   });
 
-  it('env var is used when there is no explicit or stored default', async () => {
+  it('suggested default is stored value, else the env var', async () => {
     process.env.CANVAS_FEISHU_DEFAULT_WORKSPACE = 'ws-env';
     const b = new BindingStore(memoryStore());
-    expect(await b.resolve(CH, 'chatX')).toBe('ws-env');
-  });
-
-  it('stored default takes precedence over the env var', async () => {
-    process.env.CANVAS_FEISHU_DEFAULT_WORKSPACE = 'ws-env';
-    const b = new BindingStore(memoryStore());
+    expect(await b.getSuggestedDefault()).toBe('ws-env');
     await b.setDefault('ws-stored');
-    expect(await b.resolve(CH, 'chatX')).toBe('ws-stored');
+    expect(await b.getSuggestedDefault()).toBe('ws-stored');
   });
 
-  it('persists across instances backed by the same store', async () => {
+  it('persists bindings and the default across instances', async () => {
     const store = memoryStore();
     const b1 = new BindingStore(store);
     await b1.bind(CH, 'chatA', 'ws-A');
     await b1.setDefault('ws-default');
 
     const b2 = new BindingStore(store);
-    expect(await b2.resolve(CH, 'chatA')).toBe('ws-A');
-    expect(await b2.getDefault()).toBe('ws-default');
+    expect(await b2.getBound(CH, 'chatA')).toBe('ws-A');
+    expect(await b2.getSuggestedDefault()).toBe('ws-default');
   });
 });

--- a/apps/canvas-workspace/src/plugins/main/channel/__tests__/commands.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/__tests__/commands.test.ts
@@ -44,7 +44,9 @@ function fakeService(overrides: Partial<CanvasAgentServiceRef> = {}): CanvasAgen
     abort: () => {},
     answerClarification: () => true,
     getStatus: (): AgentStatusInfo => ({ ok: true, active: false, messageCount: 0 }),
+    getCurrentSessionId: () => null,
     newSession: async () => ({ ok: true }),
+    loadSession: async () => ({ ok: true }),
     listSessions: async (): Promise<AgentSessionInfo[]> => [],
     ...overrides,
   };

--- a/apps/canvas-workspace/src/plugins/main/channel/__tests__/commands.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/__tests__/commands.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type {
+  AgentChatResult,
+  AgentSessionInfo,
+  AgentStatusInfo,
+  CanvasAgentServiceRef,
+  PluginStore,
+} from '../../../types';
+import type { InboundMessage } from '../core/types';
+
+// Mock the disk-backed workspace helpers so command tests stay hermetic.
+vi.mock('../core/workspaces', () => ({
+  listWorkspaces: vi.fn(async () => [
+    { id: 'ws-A', modifiedAt: 2 },
+    { id: 'ws-B', modifiedAt: 1 },
+  ]),
+  workspaceExists: vi.fn(async (id: string) => id === 'ws-A' || id === 'ws-B'),
+}));
+
+import { handleCommand } from '../core/commands';
+import { BindingStore } from '../core/binding';
+
+function memoryStore(): PluginStore {
+  const map = new Map<string, unknown>();
+  return {
+    async get<T>(k: string) {
+      return map.get(k) as T | undefined;
+    },
+    async set<T>(k: string, v: T) {
+      map.set(k, v);
+    },
+    async delete(k: string) {
+      map.delete(k);
+    },
+    async list() {
+      return Array.from(map.keys());
+    },
+  };
+}
+
+function fakeService(overrides: Partial<CanvasAgentServiceRef> = {}): CanvasAgentServiceRef {
+  return {
+    chat: async (): Promise<AgentChatResult> => ({ ok: true, response: 'hi' }),
+    abort: () => {},
+    answerClarification: () => true,
+    getStatus: (): AgentStatusInfo => ({ ok: true, active: false, messageCount: 0 }),
+    newSession: async () => ({ ok: true }),
+    listSessions: async (): Promise<AgentSessionInfo[]> => [],
+    ...overrides,
+  };
+}
+
+function msg(text: string): InboundMessage {
+  return {
+    channelId: 'feishu',
+    conversationId: 'chatA',
+    userId: 'u1',
+    messageId: 'm1',
+    text,
+    isMention: false,
+    isDirect: true,
+  };
+}
+
+describe('handleCommand', () => {
+  let bindings: BindingStore;
+  beforeEach(() => {
+    bindings = new BindingStore(memoryStore());
+  });
+
+  it('returns null for ordinary (non-slash) messages', async () => {
+    const out = await handleCommand(msg('hello there'), { bindings, service: fakeService() });
+    expect(out).toBeNull();
+  });
+
+  it('/bind binds the chat to an existing workspace', async () => {
+    const out = await handleCommand(msg('/bind ws-A'), { bindings, service: fakeService() });
+    expect(out).toContain('ws-A');
+    expect(await bindings.getExplicit('feishu', 'chatA')).toBe('ws-A');
+  });
+
+  it('/bind rejects an unknown workspace', async () => {
+    const out = await handleCommand(msg('/bind nope'), { bindings, service: fakeService() });
+    expect(out).toMatch(/not found/i);
+    expect(await bindings.getExplicit('feishu', 'chatA')).toBeUndefined();
+  });
+
+  it('/default sets the global default', async () => {
+    const out = await handleCommand(msg('/default ws-B'), { bindings, service: fakeService() });
+    expect(out).toContain('ws-B');
+    expect(await bindings.getDefault()).toBe('ws-B');
+  });
+
+  it('/new delegates to the service for the resolved workspace', async () => {
+    await bindings.bind('feishu', 'chatA', 'ws-A');
+    const newSession = vi.fn(async () => ({ ok: true }));
+    const out = await handleCommand(msg('/new'), { bindings, service: fakeService({ newSession }) });
+    expect(newSession).toHaveBeenCalledWith('ws-A');
+    expect(out).toMatch(/new session/i);
+  });
+
+  it('/stop aborts the resolved workspace', async () => {
+    await bindings.bind('feishu', 'chatA', 'ws-A');
+    const abort = vi.fn();
+    await handleCommand(msg('/stop'), { bindings, service: fakeService({ abort }) });
+    expect(abort).toHaveBeenCalledWith('ws-A');
+  });
+
+  it('/list marks the resolved workspace as current', async () => {
+    await bindings.bind('feishu', 'chatA', 'ws-A');
+    const out = await handleCommand(msg('/list'), { bindings, service: fakeService() });
+    expect(out).toContain('(current) ws-A');
+    expect(out).toContain('ws-B');
+  });
+
+  it('unknown command returns help text', async () => {
+    const out = await handleCommand(msg('/wat'), { bindings, service: fakeService() });
+    expect(out).toMatch(/Unknown command/i);
+  });
+});

--- a/apps/canvas-workspace/src/plugins/main/channel/__tests__/commands.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/__tests__/commands.test.ts
@@ -9,13 +9,27 @@ import type {
 import type { InboundMessage } from '../core/types';
 
 // Mock the disk-backed workspace helpers so command tests stay hermetic.
-vi.mock('../core/workspaces', () => ({
-  listWorkspaces: vi.fn(async () => [
-    { id: 'ws-A', modifiedAt: 2 },
-    { id: 'ws-B', modifiedAt: 1 },
-  ]),
-  workspaceExists: vi.fn(async (id: string) => id === 'ws-A' || id === 'ws-B'),
-}));
+vi.mock('../core/workspaces', () => {
+  const list = [
+    { id: 'ws-A', name: 'Alpha', modifiedAt: 2, isActive: false },
+    { id: 'ws-B', name: 'Beta', modifiedAt: 1, isActive: true },
+  ];
+  const label = (w: { id: string; name?: string }) => (w.name ? `${w.name} (${w.id})` : w.id);
+  return {
+    listWorkspaces: vi.fn(async () => list),
+    resolveWorkspace: vi.fn(async (ref: string) => {
+      const byId = list.find((w) => w.id === ref);
+      if (byId) return byId.id;
+      const byName = list.find((w) => w.name.toLowerCase() === ref.toLowerCase());
+      return byName?.id ?? null;
+    }),
+    workspaceLabel: label,
+    workspaceLabelById: vi.fn(async (id: string) => {
+      const found = list.find((w) => w.id === id);
+      return found ? label(found) : id;
+    }),
+  };
+});
 
 import { handleCommand } from '../core/commands';
 import { BindingStore } from '../core/binding';
@@ -76,9 +90,15 @@ describe('handleCommand', () => {
     expect(out).toBeNull();
   });
 
-  it('/bind binds the chat to an existing workspace', async () => {
+  it('/bind binds the chat to an existing workspace by id', async () => {
     const out = await handleCommand(msg('/bind ws-A'), { bindings, service: fakeService() });
     expect(out).toContain('ws-A');
+    expect(await bindings.getExplicit('feishu', 'chatA')).toBe('ws-A');
+  });
+
+  it('/bind resolves a workspace by friendly name', async () => {
+    const out = await handleCommand(msg('/bind Alpha'), { bindings, service: fakeService() });
+    expect(out).toContain('Alpha');
     expect(await bindings.getExplicit('feishu', 'chatA')).toBe('ws-A');
   });
 
@@ -109,11 +129,12 @@ describe('handleCommand', () => {
     expect(abort).toHaveBeenCalledWith('ws-A');
   });
 
-  it('/list marks the resolved workspace as current', async () => {
+  it('/list shows names and marks the bound workspace', async () => {
     await bindings.bind('feishu', 'chatA', 'ws-A');
     const out = await handleCommand(msg('/list'), { bindings, service: fakeService() });
-    expect(out).toContain('(current) ws-A');
-    expect(out).toContain('ws-B');
+    expect(out).toContain('Alpha (ws-A)');
+    expect(out).toContain('Beta (ws-B)');
+    expect(out).toContain('⭐'); // bound workspace marker
   });
 
   it('unknown command returns help text', async () => {

--- a/apps/canvas-workspace/src/plugins/main/channel/__tests__/commands.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/__tests__/commands.test.ts
@@ -93,25 +93,32 @@ describe('handleCommand', () => {
   it('/bind binds the chat to an existing workspace by id', async () => {
     const out = await handleCommand(msg('/bind ws-A'), { bindings, service: fakeService() });
     expect(out).toContain('ws-A');
-    expect(await bindings.getExplicit('feishu', 'chatA')).toBe('ws-A');
+    expect(await bindings.getBound('feishu', 'chatA')).toBe('ws-A');
   });
 
   it('/bind resolves a workspace by friendly name', async () => {
     const out = await handleCommand(msg('/bind Alpha'), { bindings, service: fakeService() });
     expect(out).toContain('Alpha');
-    expect(await bindings.getExplicit('feishu', 'chatA')).toBe('ws-A');
+    expect(await bindings.getBound('feishu', 'chatA')).toBe('ws-A');
   });
 
   it('/bind rejects an unknown workspace', async () => {
     const out = await handleCommand(msg('/bind nope'), { bindings, service: fakeService() });
     expect(out).toMatch(/not found/i);
-    expect(await bindings.getExplicit('feishu', 'chatA')).toBeUndefined();
+    expect(await bindings.getBound('feishu', 'chatA')).toBeUndefined();
   });
 
-  it('/default sets the global default', async () => {
+  it('/default sets the suggested default', async () => {
     const out = await handleCommand(msg('/default ws-B'), { bindings, service: fakeService() });
     expect(out).toContain('ws-B');
-    expect(await bindings.getDefault()).toBe('ws-B');
+    expect(await bindings.getSuggestedDefault()).toBe('ws-B');
+  });
+
+  it('/bind with no argument binds the suggested default', async () => {
+    await bindings.setDefault('ws-B');
+    const out = await handleCommand(msg('/bind'), { bindings, service: fakeService() });
+    expect(await bindings.getBound('feishu', 'chatA')).toBe('ws-B');
+    expect(out).toContain('Beta');
   });
 
   it('/new delegates to the service for the resolved workspace', async () => {

--- a/apps/canvas-workspace/src/plugins/main/channel/__tests__/commands.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/__tests__/commands.test.ts
@@ -59,6 +59,7 @@ function msg(text: string): InboundMessage {
     text,
     isMention: false,
     isDirect: true,
+    reply: null,
   };
 }
 

--- a/apps/canvas-workspace/src/plugins/main/channel/__tests__/dedupe.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/__tests__/dedupe.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { MessageDedupe } from '../core/dedupe';
+
+describe('MessageDedupe', () => {
+  it('accepts a new id once and rejects repeats', () => {
+    const d = new MessageDedupe();
+    expect(d.accept('m1')).toBe(true);
+    expect(d.accept('m1')).toBe(false);
+    expect(d.accept('m2')).toBe(true);
+  });
+
+  it('lets through empty ids (nothing to dedupe on)', () => {
+    const d = new MessageDedupe();
+    expect(d.accept('')).toBe(true);
+    expect(d.accept('')).toBe(true);
+  });
+
+  it('evicts oldest entries beyond capacity (FIFO), allowing them to re-enter', () => {
+    const d = new MessageDedupe(2);
+    expect(d.accept('a')).toBe(true); // {a}
+    expect(d.accept('b')).toBe(true); // {a,b}
+    expect(d.accept('c')).toBe(true); // size 3 > 2 → evict oldest 'a' → {b,c}
+    // 'a' was evicted, so it is treated as new again; adding it evicts 'b'.
+    expect(d.accept('a')).toBe(true); // {c,a}
+    // 'c' and 'a' are still tracked (dupes).
+    expect(d.accept('c')).toBe(false);
+    expect(d.accept('a')).toBe(false);
+    // 'b' was evicted above, so it counts as new.
+    expect(d.accept('b')).toBe(true);
+  });
+});

--- a/apps/canvas-workspace/src/plugins/main/channel/__tests__/parse-inbound.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/__tests__/parse-inbound.test.ts
@@ -8,6 +8,7 @@ interface EventOpts {
   text?: string;
   mentions?: unknown[];
   threadId?: string;
+  rootId?: string;
   messageType?: string;
 }
 
@@ -21,6 +22,7 @@ function event(opts: EventOpts): unknown {
       content: JSON.stringify({ text: opts.text ?? 'hi' }),
       mentions: opts.mentions,
       thread_id: opts.threadId,
+      root_id: opts.rootId,
     },
     sender: { sender_id: { open_id: 'user1' } },
   };
@@ -89,6 +91,21 @@ describe('parseInbound', () => {
   it('direct chat reply routing is not a group (create path)', () => {
     const out = parseInbound(event({ chatType: 'p2p', chatId: 'dmA' }));
     expect(reply(out).isGroup).toBe(false);
+  });
+
+  it('falls back to root_id so a topic root and its replies stay one conversation', () => {
+    // Topic root: no thread_id yet, but it is the thread root (root_id = its id).
+    const root = parseInbound(
+      event({ chatType: 'group', chatId: 'gT', rootId: 'rA', messageId: 'rA', mentions: [{}] }),
+    );
+    // A later reply in the same topic: carries thread_id == root_id.
+    const followUp = parseInbound(
+      event({ chatType: 'group', chatId: 'gT', threadId: 'rA', messageId: 'mC', mentions: [{}] }),
+    );
+    expect(root!.conversationId).toBe('gT:rA');
+    expect(followUp!.conversationId).toBe('gT:rA');
+    // Root and follow-up resolve to the SAME conversation → same session.
+    expect(root!.conversationId).toBe(followUp!.conversationId);
   });
 
   it('a topic-group conversation differs from the same group’s non-topic id', () => {

--- a/apps/canvas-workspace/src/plugins/main/channel/__tests__/parse-inbound.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/__tests__/parse-inbound.test.ts
@@ -28,7 +28,12 @@ function event(opts: EventOpts): unknown {
 
 // Narrow the opaque reply token for assertions.
 function reply(out: ReturnType<typeof parseInbound>) {
-  return out!.reply as { chatId: string; threadId?: string; triggerMessageId: string };
+  return out!.reply as {
+    chatId: string;
+    threadId?: string;
+    isGroup: boolean;
+    triggerMessageId: string;
+  };
 }
 
 describe('parseInbound', () => {
@@ -78,6 +83,12 @@ describe('parseInbound', () => {
     // Reply routing carries thread + the triggering message for reply_in_thread.
     expect(reply(t1).threadId).toBe('th1');
     expect(reply(t1).triggerMessageId).toBe('mA');
+    expect(reply(t1).isGroup).toBe(true);
+  });
+
+  it('direct chat reply routing is not a group (create path)', () => {
+    const out = parseInbound(event({ chatType: 'p2p', chatId: 'dmA' }));
+    expect(reply(out).isGroup).toBe(false);
   });
 
   it('a topic-group conversation differs from the same group’s non-topic id', () => {

--- a/apps/canvas-workspace/src/plugins/main/channel/__tests__/parse-inbound.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/__tests__/parse-inbound.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { parseInbound } from '../channels/feishu/feishu-channel';
+
+interface EventOpts {
+  messageId?: string;
+  chatId?: string;
+  chatType?: 'p2p' | 'group';
+  text?: string;
+  mentions?: unknown[];
+  threadId?: string;
+  messageType?: string;
+}
+
+function event(opts: EventOpts): unknown {
+  return {
+    message: {
+      message_id: opts.messageId ?? 'm1',
+      chat_id: opts.chatId ?? 'chat1',
+      chat_type: opts.chatType ?? 'p2p',
+      message_type: opts.messageType ?? 'text',
+      content: JSON.stringify({ text: opts.text ?? 'hi' }),
+      mentions: opts.mentions,
+      thread_id: opts.threadId,
+    },
+    sender: { sender_id: { open_id: 'user1' } },
+  };
+}
+
+// Narrow the opaque reply token for assertions.
+function reply(out: ReturnType<typeof parseInbound>) {
+  return out!.reply as { chatId: string; threadId?: string; triggerMessageId: string };
+}
+
+describe('parseInbound', () => {
+  it('direct chat keys on chat_id', () => {
+    const out = parseInbound(event({ chatType: 'p2p', chatId: 'dmA' }));
+    expect(out).not.toBeNull();
+    expect(out!.conversationId).toBe('dmA');
+    expect(out!.isDirect).toBe(true);
+    expect(reply(out).chatId).toBe('dmA');
+    expect(reply(out).threadId).toBeUndefined();
+  });
+
+  it('different groups produce different conversation ids', () => {
+    const a = parseInbound(event({ chatType: 'group', chatId: 'gA', mentions: [{}] }));
+    const b = parseInbound(event({ chatType: 'group', chatId: 'gB', mentions: [{}] }));
+    expect(a!.conversationId).toBe('gA');
+    expect(b!.conversationId).toBe('gB');
+    expect(a!.conversationId).not.toBe(b!.conversationId);
+  });
+
+  it('group message without @-mention is ignored', () => {
+    const out = parseInbound(event({ chatType: 'group', chatId: 'gA', mentions: [] }));
+    expect(out).toBeNull();
+  });
+
+  it('group @-mention strips the mention and marks isMention', () => {
+    const out = parseInbound(
+      event({ chatType: 'group', chatId: 'gA', mentions: [{}], text: '@bot do it' }),
+    );
+    expect(out).not.toBeNull();
+    expect(out!.text).toBe('do it');
+    expect(out!.isMention).toBe(true);
+    expect(out!.isDirect).toBe(false);
+  });
+
+  it('topic group: each thread is its own conversation, replies route in-thread', () => {
+    const t1 = parseInbound(
+      event({ chatType: 'group', chatId: 'gT', threadId: 'th1', mentions: [{}], messageId: 'mA' }),
+    );
+    const t2 = parseInbound(
+      event({ chatType: 'group', chatId: 'gT', threadId: 'th2', mentions: [{}], messageId: 'mB' }),
+    );
+    expect(t1!.conversationId).toBe('gT:th1');
+    expect(t2!.conversationId).toBe('gT:th2');
+    // Same group, different topics → distinct conversations.
+    expect(t1!.conversationId).not.toBe(t2!.conversationId);
+    // Reply routing carries thread + the triggering message for reply_in_thread.
+    expect(reply(t1).threadId).toBe('th1');
+    expect(reply(t1).triggerMessageId).toBe('mA');
+  });
+
+  it('a topic-group conversation differs from the same group’s non-topic id', () => {
+    const topic = parseInbound(
+      event({ chatType: 'group', chatId: 'gT', threadId: 'th1', mentions: [{}] }),
+    );
+    const plain = parseInbound(event({ chatType: 'group', chatId: 'gT', mentions: [{}] }));
+    expect(topic!.conversationId).toBe('gT:th1');
+    expect(plain!.conversationId).toBe('gT');
+  });
+
+  it('non-text messages are ignored', () => {
+    const out = parseInbound(event({ messageType: 'image' }));
+    expect(out).toBeNull();
+  });
+});

--- a/apps/canvas-workspace/src/plugins/main/channel/__tests__/sessions.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/__tests__/sessions.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from 'vitest';
+import type {
+  AgentChatResult,
+  AgentSessionInfo,
+  AgentStatusInfo,
+  CanvasAgentServiceRef,
+  PluginStore,
+} from '../../../types';
+import { SessionRouter } from '../core/sessions';
+
+function memoryStore(): PluginStore {
+  const map = new Map<string, unknown>();
+  return {
+    async get<T>(k: string) {
+      return map.get(k) as T | undefined;
+    },
+    async set<T>(k: string, v: T) {
+      map.set(k, v);
+    },
+    async delete(k: string) {
+      map.delete(k);
+    },
+    async list() {
+      return Array.from(map.keys());
+    },
+  };
+}
+
+/**
+ * Fake agent service that models one "current session id" per workspace, with
+ * an auto-incrementing id on newSession and a swap on loadSession — enough to
+ * exercise the router's create/swap logic.
+ */
+function fakeService() {
+  const current = new Map<string, string>();
+  let counter = 0;
+  const known = new Set<string>();
+
+  const service: CanvasAgentServiceRef = {
+    chat: async (): Promise<AgentChatResult> => ({ ok: true }),
+    abort: () => {},
+    answerClarification: () => true,
+    getStatus: (): AgentStatusInfo => ({ ok: true, active: true, messageCount: 0 }),
+    getCurrentSessionId: (ws) => current.get(ws) ?? null,
+    newSession: async (ws) => {
+      const id = `s${++counter}`;
+      known.add(id);
+      current.set(ws, id);
+      return { ok: true };
+    },
+    loadSession: async (ws, sessionId) => {
+      if (!known.has(sessionId)) return { ok: true }; // no-op when missing
+      current.set(ws, sessionId);
+      return { ok: true };
+    },
+    listSessions: async (): Promise<AgentSessionInfo[]> => [],
+  };
+
+  return { service, current };
+}
+
+describe('SessionRouter', () => {
+  it('creates a session per conversation and swaps between them', async () => {
+    const { service, current } = fakeService();
+    const router = new SessionRouter(service, memoryStore());
+    const W = 'ws1';
+
+    await router.ensureSession(W, 'convA');
+    const sa = current.get(W);
+    expect(sa).toBeTruthy();
+
+    // A different conversation gets its own fresh session.
+    await router.ensureSession(W, 'convB');
+    const sb = current.get(W);
+    expect(sb).toBeTruthy();
+    expect(sb).not.toBe(sa);
+
+    // Returning to A swaps the current session back to A's, not a new one.
+    await router.ensureSession(W, 'convA');
+    expect(current.get(W)).toBe(sa);
+
+    // And back to B.
+    await router.ensureSession(W, 'convB');
+    expect(current.get(W)).toBe(sb);
+  });
+
+  it('is a no-op when the conversation already owns the current session', async () => {
+    const { service } = fakeService();
+    const newSpy = vi.spyOn(service, 'newSession');
+    const loadSpy = vi.spyOn(service, 'loadSession');
+    const router = new SessionRouter(service, memoryStore());
+
+    await router.ensureSession('ws1', 'convA'); // creates s1
+    expect(newSpy).toHaveBeenCalledTimes(1);
+
+    await router.ensureSession('ws1', 'convA'); // already current → no work
+    expect(newSpy).toHaveBeenCalledTimes(1);
+    expect(loadSpy).not.toHaveBeenCalled();
+  });
+
+  it('keys per workspace so the same conversation id is distinct across workspaces', async () => {
+    const { service, current } = fakeService();
+    const router = new SessionRouter(service, memoryStore());
+
+    await router.ensureSession('wsX', 'conv');
+    const sx = current.get('wsX');
+    await router.ensureSession('wsY', 'conv');
+    const sy = current.get('wsY');
+
+    expect(sx).toBeTruthy();
+    expect(sy).toBeTruthy();
+    expect(sx).not.toBe(sy);
+  });
+
+  it('starts a fresh session when the mapped one no longer exists', async () => {
+    const store = memoryStore();
+    // Pre-seed a mapping pointing at a session id the service does not know.
+    await store.set('sessions', { 'ws1::convA': 'ghost' });
+    const { service, current } = fakeService();
+    const router = new SessionRouter(service, store);
+
+    await router.ensureSession('ws1', 'convA');
+    // loadSession('ghost') is a no-op, so the router creates a real session.
+    expect(current.get('ws1')).toBeTruthy();
+    expect(current.get('ws1')).not.toBe('ghost');
+  });
+});

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
@@ -1,0 +1,62 @@
+// Feishu interactive card (schema 2.0) builders for the streamed agent run.
+// One card is created on run start and progressively patched: thinking →
+// progress (accumulated text + latest tool hint) → done / error.
+
+// Feishu rejects oversized card payloads; keep the streamed body bounded.
+const MAX_CARD_TEXT = 8000;
+
+function clamp(text: string): string {
+  if (text.length <= MAX_CARD_TEXT) return text;
+  return `…${text.slice(text.length - MAX_CARD_TEXT)}`;
+}
+
+function card(content: string, forward: boolean): object {
+  return {
+    schema: '2.0',
+    config: { enable_forward: forward },
+    body: { elements: [{ tag: 'markdown', content }] },
+  };
+}
+
+export function buildThinkingCard(): object {
+  return card('Pulse is thinking…', false);
+}
+
+export function buildProgressCard(text: string, toolHint?: string, elapsedSec?: number): object {
+  const parts: string[] = [];
+  if (text.trim()) parts.push(clamp(text.trim()));
+  const footer: string[] = [];
+  if (toolHint) footer.push(toolHint);
+  if (typeof elapsedSec === 'number') footer.push(`⏱️ ${elapsedSec}s`);
+  if (footer.length === 0 && !text.trim()) footer.push('Pulse is thinking…');
+  if (footer.length > 0) parts.push(`\n---\n${footer.join('  ·  ')}`);
+  return card(parts.join('\n'), false);
+}
+
+export function buildDoneCard(text: string): object {
+  return card(clamp(text) || '✅ Done', true);
+}
+
+export function buildErrorCard(message: string): object {
+  return card(`❌ Error: ${message}`, false);
+}
+
+/** A short, human-readable hint for the latest tool call. */
+export function formatToolHint(name: string, args: unknown): string {
+  const detail = summarizeArgs(args);
+  return detail ? `🛠️ ${name} — ${detail}` : `🛠️ ${name}`;
+}
+
+function summarizeArgs(args: unknown): string {
+  if (!args || typeof args !== 'object') return '';
+  const record = args as Record<string, unknown>;
+  // Prefer a few common, meaningful fields for a compact hint.
+  for (const key of ['title', 'path', 'query', 'command', 'name', 'nodeId']) {
+    const value = record[key];
+    if (typeof value === 'string' && value.trim()) {
+      const v = value.trim();
+      return v.length > 60 ? `${v.slice(0, 60)}…` : v;
+    }
+  }
+  return '';
+}

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-channel.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-channel.ts
@@ -50,6 +50,13 @@ export class FeishuChannel implements Channel {
 
     const eventDispatcher = new lark.EventDispatcher({}).register({
       'im.message.receive_v1': async (data: unknown) => {
+        if (process.env.CANVAS_CHANNEL_DEBUG) {
+          try {
+            console.log('[channel:feishu] raw event', JSON.stringify(data));
+          } catch {
+            /* ignore serialization issues */
+          }
+        }
         const msg = parseInbound(data);
         if (msg) onInbound(msg);
       },
@@ -90,11 +97,12 @@ function toSendTarget(target: OutboundTarget): FeishuSendTarget {
     return {
       chatId: reply.chatId,
       threadId: reply.threadId,
+      isGroup: Boolean(reply.isGroup),
       triggerMessageId: reply.triggerMessageId ?? '',
     };
   }
   // Fallback: treat the conversation id as a bare chat_id (no threading).
-  return { chatId: target.conversationId, triggerMessageId: '' };
+  return { chatId: target.conversationId, isGroup: false, triggerMessageId: '' };
 }
 
 /**
@@ -229,6 +237,9 @@ interface FeishuMessageEvent {
     mentions?: unknown[];
     /** Present in topic groups (话题群) — identifies the topic/thread. */
     thread_id?: string;
+    /** Root message of the thread/topic, when applicable. */
+    root_id?: string;
+    parent_id?: string;
   };
   sender?: {
     sender_id?: { open_id?: string; user_id?: string; union_id?: string };
@@ -270,7 +281,14 @@ export function parseInbound(data: unknown): InboundMessage | null {
   // and each topic get independent bindings / sessions.
   const conversationId = threadId ? `${chatId}:${threadId}` : chatId;
 
-  const reply: FeishuSendTarget = { chatId, threadId, triggerMessageId: messageId };
+  const reply: FeishuSendTarget = { chatId, threadId, isGroup, triggerMessageId: messageId };
+
+  if (process.env.CANVAS_CHANNEL_DEBUG) {
+    console.log(
+      `[channel:feishu] inbound chat_type=${message.chat_type} thread_id=${message.thread_id ?? '-'} ` +
+        `root_id=${message.root_id ?? '-'} conv=${conversationId}`,
+    );
+  }
 
   return {
     channelId: CHANNEL_ID,

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-channel.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-channel.ts
@@ -255,6 +255,7 @@ export function parseInbound(data: unknown): InboundMessage | null {
   const messageId = message.message_id ?? '';
   const chatId = message.chat_id ?? '';
   const threadId = message.thread_id?.trim() || undefined;
+  const rootId = message.root_id?.trim() || undefined;
   const userId = event.sender?.sender_id?.open_id ?? '';
   if (!chatId) return null;
 
@@ -276,12 +277,21 @@ export function parseInbound(data: unknown): InboundMessage | null {
 
   if (!text) return null;
 
-  // Each topic in a topic group is its own conversation (chat_id + thread_id);
-  // direct chats and plain groups key on chat_id alone. So a DM, each group,
-  // and each topic get independent bindings / sessions.
-  const conversationId = threadId ? `${chatId}:${threadId}` : chatId;
+  // Each topic in a topic group is its own conversation — and thus its own
+  // session. A threaded message carries thread_id (the topic) and/or root_id
+  // (the topic's first message); we key on thread_id, falling back to root_id
+  // so a topic's root and its replies stay one conversation even if Feishu
+  // omits thread_id on the root. Plain groups (neither) key on chat_id alone,
+  // so a DM, each group, and each topic are independent.
+  const topicKey = threadId ?? rootId;
+  const conversationId = topicKey ? `${chatId}:${topicKey}` : chatId;
 
-  const reply: FeishuSendTarget = { chatId, threadId, isGroup, triggerMessageId: messageId };
+  const reply: FeishuSendTarget = {
+    chatId,
+    threadId: topicKey,
+    isGroup,
+    triggerMessageId: messageId,
+  };
 
   if (process.env.CANVAS_CHANNEL_DEBUG) {
     console.log(

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-channel.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-channel.ts
@@ -13,6 +13,7 @@ import {
   sendImageMessage,
   sendTextMessage,
   updateCardMessage,
+  type FeishuSendTarget,
 } from './feishu-client';
 import {
   buildDoneCard,
@@ -71,15 +72,29 @@ export class FeishuChannel implements Channel {
 
   async sendText(target: OutboundTarget, text: string): Promise<void> {
     if (!this.client) throw new Error('Feishu channel not started');
-    await sendTextMessage(this.client, target.conversationId, 'chat_id', text);
+    await sendTextMessage(this.client, toSendTarget(target), text);
   }
 
   async openStream(target: OutboundTarget): Promise<ChannelStream> {
     if (!this.client) throw new Error('Feishu channel not started');
-    const stream = new FeishuStream(this.client, target.conversationId);
+    const stream = new FeishuStream(this.client, toSendTarget(target));
     await stream.init();
     return stream;
   }
+}
+
+/** Recover the channel-specific reply routing from an OutboundTarget. */
+function toSendTarget(target: OutboundTarget): FeishuSendTarget {
+  const reply = target.reply as Partial<FeishuSendTarget> | undefined;
+  if (reply?.chatId) {
+    return {
+      chatId: reply.chatId,
+      threadId: reply.threadId,
+      triggerMessageId: reply.triggerMessageId ?? '',
+    };
+  }
+  // Fallback: treat the conversation id as a bare chat_id (no threading).
+  return { chatId: target.conversationId, triggerMessageId: '' };
 }
 
 /**
@@ -100,17 +115,12 @@ class FeishuStream implements ChannelStream {
 
   constructor(
     private readonly client: lark.Client,
-    private readonly chatId: string,
+    private readonly target: FeishuSendTarget,
   ) {}
 
   async init(): Promise<void> {
     try {
-      this.cardMessageId = await sendCardMessage(
-        this.client,
-        this.chatId,
-        'chat_id',
-        buildThinkingCard(),
-      );
+      this.cardMessageId = await sendCardMessage(this.client, this.target, buildThinkingCard());
     } catch (err) {
       // If the initial card cannot be sent, fall back to text messages.
       this.cardFailed = true;
@@ -130,7 +140,7 @@ class FeishuStream implements ChannelStream {
 
   async onImage(imagePath: string, mimeType?: string): Promise<void> {
     try {
-      await sendImageMessage(this.client, this.chatId, 'chat_id', imagePath, mimeType);
+      await sendImageMessage(this.client, this.target, imagePath, mimeType);
       this.toolHint = '🖼️ Image sent';
       this.scheduleFlush();
     } catch (err) {
@@ -142,7 +152,7 @@ class FeishuStream implements ChannelStream {
     // Surface the question as its own text message so it stands out from the
     // streamed card; the user's next message is routed back as the answer.
     try {
-      await sendTextMessage(this.client, this.chatId, 'chat_id', `❓ ${question}`);
+      await sendTextMessage(this.client, this.target, `❓ ${question}`);
     } catch (err) {
       console.error('[channel:feishu] failed to send clarification', err);
     }
@@ -199,7 +209,7 @@ class FeishuStream implements ChannelStream {
     // the user still sees the final answer.
     if (this.cardFailed) {
       try {
-        await sendTextMessage(this.client, this.chatId, 'chat_id', fallbackText);
+        await sendTextMessage(this.client, this.target, fallbackText);
       } catch (err) {
         console.error('[channel:feishu] fallback text send failed', err);
       }
@@ -217,6 +227,8 @@ interface FeishuMessageEvent {
     message_type?: string;
     content?: string;
     mentions?: unknown[];
+    /** Present in topic groups (话题群) — identifies the topic/thread. */
+    thread_id?: string;
   };
   sender?: {
     sender_id?: { open_id?: string; user_id?: string; union_id?: string };
@@ -224,15 +236,16 @@ interface FeishuMessageEvent {
 }
 
 /** Normalize a Feishu im.message.receive_v1 payload, or null to ignore it. */
-function parseInbound(data: unknown): InboundMessage | null {
+export function parseInbound(data: unknown): InboundMessage | null {
   const event = data as FeishuMessageEvent;
   const message = event?.message;
   if (!message || message.message_type !== 'text') return null;
 
   const messageId = message.message_id ?? '';
-  const conversationId = message.chat_id ?? '';
+  const chatId = message.chat_id ?? '';
+  const threadId = message.thread_id?.trim() || undefined;
   const userId = event.sender?.sender_id?.open_id ?? '';
-  if (!conversationId) return null;
+  if (!chatId) return null;
 
   let text = '';
   try {
@@ -245,12 +258,19 @@ function parseInbound(data: unknown): InboundMessage | null {
   const isGroup = message.chat_type === 'group';
   const mentions = (message.mentions as unknown[] | undefined) ?? [];
   if (isGroup) {
-    // In group chats, only respond when the bot is @-mentioned.
+    // In group chats (incl. topic groups), only respond when @-mentioned.
     if (mentions.length === 0) return null;
     text = text.replace(/@\S+/g, '').trim();
   }
 
   if (!text) return null;
+
+  // Each topic in a topic group is its own conversation (chat_id + thread_id);
+  // direct chats and plain groups key on chat_id alone. So a DM, each group,
+  // and each topic get independent bindings / sessions.
+  const conversationId = threadId ? `${chatId}:${threadId}` : chatId;
+
+  const reply: FeishuSendTarget = { chatId, threadId, triggerMessageId: messageId };
 
   return {
     channelId: CHANNEL_ID,
@@ -260,5 +280,6 @@ function parseInbound(data: unknown): InboundMessage | null {
     text,
     isMention: isGroup && mentions.length > 0,
     isDirect: !isGroup,
+    reply,
   };
 }

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-channel.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-channel.ts
@@ -1,0 +1,264 @@
+import * as lark from '@larksuiteoapi/node-sdk';
+import type {
+  Channel,
+  ChannelStream,
+  InboundHandler,
+  InboundMessage,
+  OutboundTarget,
+} from '../../core/types';
+import {
+  createLarkClient,
+  feishuConfigured,
+  sendCardMessage,
+  sendImageMessage,
+  sendTextMessage,
+  updateCardMessage,
+} from './feishu-client';
+import {
+  buildDoneCard,
+  buildErrorCard,
+  buildProgressCard,
+  buildThinkingCard,
+  formatToolHint,
+} from './card';
+
+const CHANNEL_ID = 'feishu';
+const PROGRESS_THROTTLE_MS = 800;
+
+/**
+ * Feishu channel using the SDK's long-connection (WSClient) event stream —
+ * the canvas app dials out to Feishu over a WebSocket, so it works behind
+ * NAT with no public webhook URL. Inbound text messages are normalized to
+ * {@link InboundMessage}; agent output is rendered into a single interactive
+ * card that is progressively patched.
+ */
+export class FeishuChannel implements Channel {
+  readonly id = CHANNEL_ID;
+  private wsClient: lark.WSClient | null = null;
+  private client: lark.Client | null = null;
+
+  isConfigured(): boolean {
+    return feishuConfigured();
+  }
+
+  async start(onInbound: InboundHandler): Promise<void> {
+    this.client = createLarkClient();
+    const appId = process.env.FEISHU_APP_ID!;
+    const appSecret = process.env.FEISHU_APP_SECRET!;
+    this.wsClient = new lark.WSClient({ appId, appSecret, domain: lark.Domain.Feishu });
+
+    const eventDispatcher = new lark.EventDispatcher({}).register({
+      'im.message.receive_v1': async (data: unknown) => {
+        const msg = parseInbound(data);
+        if (msg) onInbound(msg);
+      },
+    });
+
+    this.wsClient.start({ eventDispatcher });
+  }
+
+  async stop(): Promise<void> {
+    // WSClient teardown varies across SDK versions; call stop() if present.
+    const ws = this.wsClient as unknown as { stop?: () => void } | null;
+    try {
+      ws?.stop?.();
+    } catch (err) {
+      console.error('[channel:feishu] WSClient stop failed', err);
+    }
+    this.wsClient = null;
+    this.client = null;
+  }
+
+  async sendText(target: OutboundTarget, text: string): Promise<void> {
+    if (!this.client) throw new Error('Feishu channel not started');
+    await sendTextMessage(this.client, target.conversationId, 'chat_id', text);
+  }
+
+  async openStream(target: OutboundTarget): Promise<ChannelStream> {
+    if (!this.client) throw new Error('Feishu channel not started');
+    const stream = new FeishuStream(this.client, target.conversationId);
+    await stream.init();
+    return stream;
+  }
+}
+
+/**
+ * Renders one agent run into a single Feishu card. Text/tool events are
+ * accumulated and flushed to the card on a trailing throttle so we don't
+ * exceed Feishu's update-rate limits; images are sent as separate messages.
+ */
+class FeishuStream implements ChannelStream {
+  private cardMessageId: string | null = null;
+  private cardFailed = false;
+  private accumulated = '';
+  private toolHint: string | undefined;
+  private readonly startedAt = Date.now();
+
+  private updateChain: Promise<void> = Promise.resolve();
+  private flushTimer: NodeJS.Timeout | null = null;
+  private lastFlush = 0;
+
+  constructor(
+    private readonly client: lark.Client,
+    private readonly chatId: string,
+  ) {}
+
+  async init(): Promise<void> {
+    try {
+      this.cardMessageId = await sendCardMessage(
+        this.client,
+        this.chatId,
+        'chat_id',
+        buildThinkingCard(),
+      );
+    } catch (err) {
+      // If the initial card cannot be sent, fall back to text messages.
+      this.cardFailed = true;
+      console.error('[channel:feishu] failed to send thinking card', err);
+    }
+  }
+
+  onText(delta: string): void {
+    this.accumulated += delta;
+    this.scheduleFlush();
+  }
+
+  onToolCall(name: string, args: unknown): void {
+    this.toolHint = formatToolHint(name, args);
+    this.scheduleFlush();
+  }
+
+  async onImage(imagePath: string, mimeType?: string): Promise<void> {
+    try {
+      await sendImageMessage(this.client, this.chatId, 'chat_id', imagePath, mimeType);
+      this.toolHint = '🖼️ Image sent';
+      this.scheduleFlush();
+    } catch (err) {
+      console.error('[channel:feishu] failed to send image', err);
+    }
+  }
+
+  async onClarification(question: string): Promise<void> {
+    // Surface the question as its own text message so it stands out from the
+    // streamed card; the user's next message is routed back as the answer.
+    try {
+      await sendTextMessage(this.client, this.chatId, 'chat_id', `❓ ${question}`);
+    } catch (err) {
+      console.error('[channel:feishu] failed to send clarification', err);
+    }
+  }
+
+  async onDone(text: string): Promise<void> {
+    this.cancelFlush();
+    await this.finalize(() => buildDoneCard(text), text);
+  }
+
+  async onError(message: string): Promise<void> {
+    this.cancelFlush();
+    await this.finalize(() => buildErrorCard(message), `❌ Error: ${message}`);
+  }
+
+  private elapsedSec(): number {
+    return Math.round((Date.now() - this.startedAt) / 1000);
+  }
+
+  private scheduleFlush(): void {
+    if (this.cardFailed || this.flushTimer) return;
+    const wait = Math.max(0, PROGRESS_THROTTLE_MS - (Date.now() - this.lastFlush));
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = null;
+      this.lastFlush = Date.now();
+      this.enqueue(() => buildProgressCard(this.accumulated, this.toolHint, this.elapsedSec()));
+    }, wait);
+  }
+
+  private cancelFlush(): void {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+  }
+
+  /** Serialize card patches so concurrent updates cannot race. */
+  private enqueue(factory: () => object): Promise<void> {
+    this.updateChain = this.updateChain.then(async () => {
+      if (this.cardFailed || !this.cardMessageId) return;
+      try {
+        await updateCardMessage(this.client, this.cardMessageId, factory());
+      } catch (err) {
+        this.cardFailed = true;
+        console.error('[channel:feishu] card update failed', err);
+      }
+    });
+    return this.updateChain;
+  }
+
+  private async finalize(factory: () => object, fallbackText: string): Promise<void> {
+    await this.enqueue(factory);
+    // If the card pathway failed at any point, deliver the result as text so
+    // the user still sees the final answer.
+    if (this.cardFailed) {
+      try {
+        await sendTextMessage(this.client, this.chatId, 'chat_id', fallbackText);
+      } catch (err) {
+        console.error('[channel:feishu] fallback text send failed', err);
+      }
+    }
+  }
+}
+
+// ── Event parsing ───────────────────────────────────────────────────────────
+
+interface FeishuMessageEvent {
+  message?: {
+    message_id?: string;
+    chat_id?: string;
+    chat_type?: string;
+    message_type?: string;
+    content?: string;
+    mentions?: unknown[];
+  };
+  sender?: {
+    sender_id?: { open_id?: string; user_id?: string; union_id?: string };
+  };
+}
+
+/** Normalize a Feishu im.message.receive_v1 payload, or null to ignore it. */
+function parseInbound(data: unknown): InboundMessage | null {
+  const event = data as FeishuMessageEvent;
+  const message = event?.message;
+  if (!message || message.message_type !== 'text') return null;
+
+  const messageId = message.message_id ?? '';
+  const conversationId = message.chat_id ?? '';
+  const userId = event.sender?.sender_id?.open_id ?? '';
+  if (!conversationId) return null;
+
+  let text = '';
+  try {
+    const content = JSON.parse(message.content ?? '{}') as { text?: string };
+    text = content.text?.trim() ?? '';
+  } catch {
+    return null;
+  }
+
+  const isGroup = message.chat_type === 'group';
+  const mentions = (message.mentions as unknown[] | undefined) ?? [];
+  if (isGroup) {
+    // In group chats, only respond when the bot is @-mentioned.
+    if (mentions.length === 0) return null;
+    text = text.replace(/@\S+/g, '').trim();
+  }
+
+  if (!text) return null;
+
+  return {
+    channelId: CHANNEL_ID,
+    conversationId,
+    userId,
+    messageId,
+    text,
+    isMention: isGroup && mentions.length > 0,
+    isDirect: !isGroup,
+  };
+}

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-client.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-client.ts
@@ -115,21 +115,27 @@ async function uploadImageToFeishu(imagePath: string, mimeType?: string): Promis
 }
 
 /**
- * Where a reply goes. For a normal chat we create a message addressed to
- * `chatId`. For a **topic group** (`threadId` set) we instead reply to the
- * triggering message with `reply_in_thread`, so the message lands in the
- * right topic rather than the group root.
+ * Where a reply goes.
+ *
+ * - **Direct chat**: create a message addressed to `chatId`.
+ * - **Group** (incl. topic groups): reply to the triggering message so the
+ *   bot's output attaches to the user's message. `reply_in_thread` is set
+ *   when the conversation is threaded (topic group), keeping the reply inside
+ *   the right topic rather than landing on the group root. Using reply-to-
+ *   trigger for all group messages avoids depending on `thread_id` being
+ *   present on a topic's root message.
  */
 export interface FeishuSendTarget {
   chatId: string;
   threadId?: string;
-  /** The inbound message we reply to, to continue a topic-group thread. */
+  isGroup: boolean;
+  /** The inbound message we reply to (anchors group replies / topic threads). */
   triggerMessageId: string;
 }
 
 /**
- * Send a message to a target, choosing create-vs-reply based on whether the
- * conversation is threaded. Returns the new message_id.
+ * Send a message to a target, choosing create-vs-reply by chat kind. Returns
+ * the new message_id.
  */
 async function createOrReply(
   client: lark.Client,
@@ -137,10 +143,10 @@ async function createOrReply(
   msgType: 'text' | 'interactive' | 'image',
   content: string,
 ): Promise<string> {
-  if (target.threadId && target.triggerMessageId) {
+  if (target.isGroup && target.triggerMessageId) {
     const res = await client.im.message.reply({
       path: { message_id: target.triggerMessageId },
-      data: { content, msg_type: msgType, reply_in_thread: true },
+      data: { content, msg_type: msgType, reply_in_thread: Boolean(target.threadId) },
     });
     if (typeof res.code === 'number' && res.code !== 0) {
       throw new Error(`Feishu reply failed: ${res.code} ${res.msg ?? 'unknown error'}`);

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-client.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-client.ts
@@ -1,0 +1,197 @@
+import * as lark from '@larksuiteoapi/node-sdk';
+import { readFile } from 'fs/promises';
+import { basename } from 'path';
+
+// Self-contained Feishu (Lark) client helpers for the canvas channel plugin.
+// Logic mirrors the remote-server adapter but is copied here so the canvas
+// app carries no dependency on remote-server. Credentials come from the
+// FEISHU_APP_ID / FEISHU_APP_SECRET environment variables.
+
+export function feishuConfigured(): boolean {
+  return Boolean(process.env.FEISHU_APP_ID && process.env.FEISHU_APP_SECRET);
+}
+
+export function createLarkClient(): lark.Client {
+  const appId = process.env.FEISHU_APP_ID;
+  const appSecret = process.env.FEISHU_APP_SECRET;
+  if (!appId || !appSecret) {
+    throw new Error('FEISHU_APP_ID and FEISHU_APP_SECRET are required');
+  }
+  return new lark.Client({
+    appId,
+    appSecret,
+    appType: lark.AppType.SelfBuild,
+    domain: lark.Domain.Feishu,
+  });
+}
+
+interface FeishuApiResponse<T> {
+  code: number;
+  msg: string;
+  data?: T;
+}
+
+let cachedTenantAccessToken: string | null = null;
+let tenantAccessTokenExpiresAt = 0;
+
+function getFeishuBaseUrl(): string {
+  const envBaseUrl = process.env.FEISHU_API_BASE_URL?.trim();
+  return (envBaseUrl || 'https://open.feishu.cn').replace(/\/$/, '');
+}
+
+async function getTenantAccessToken(): Promise<string> {
+  if (cachedTenantAccessToken && Date.now() < tenantAccessTokenExpiresAt - 60_000) {
+    return cachedTenantAccessToken;
+  }
+
+  const appId = process.env.FEISHU_APP_ID?.trim();
+  const appSecret = process.env.FEISHU_APP_SECRET?.trim();
+  if (!appId || !appSecret) {
+    throw new Error('FEISHU_APP_ID and FEISHU_APP_SECRET are required');
+  }
+
+  const response = await fetch(
+    `${getFeishuBaseUrl()}/open-apis/auth/v3/tenant_access_token/internal`,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ app_id: appId, app_secret: appSecret }),
+    },
+  );
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Failed to get Feishu tenant access token: ${response.status} ${response.statusText} - ${body}`,
+    );
+  }
+
+  const payload = (await response.json()) as FeishuApiResponse<never> & {
+    tenant_access_token?: string;
+    expire?: number;
+  };
+
+  if (payload.code !== 0 || !payload.tenant_access_token) {
+    throw new Error(`Failed to get Feishu tenant access token: ${payload.msg || 'unknown error'}`);
+  }
+
+  cachedTenantAccessToken = payload.tenant_access_token;
+  tenantAccessTokenExpiresAt = Date.now() + (payload.expire ?? 7200) * 1000;
+  return cachedTenantAccessToken;
+}
+
+async function uploadImageToFeishu(imagePath: string, mimeType?: string): Promise<string> {
+  const imageBuffer = await readFile(imagePath);
+  if (imageBuffer.length === 0) {
+    throw new Error(`Image file is empty: ${imagePath}`);
+  }
+
+  const token = await getTenantAccessToken();
+  const formData = new FormData();
+  const filename = basename(imagePath);
+
+  formData.append('image_type', 'message');
+  formData.append('image', new Blob([imageBuffer], { type: mimeType || 'image/png' }), filename);
+
+  const response = await fetch(`${getFeishuBaseUrl()}/open-apis/im/v1/images`, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${token}` },
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Failed to upload image to Feishu: ${response.status} ${response.statusText} - ${body}`,
+    );
+  }
+
+  const payload = (await response.json()) as FeishuApiResponse<{ image_key?: string }>;
+  const imageKey = payload.data?.image_key;
+  if (payload.code !== 0 || !imageKey) {
+    throw new Error(`Failed to upload image to Feishu: ${payload.msg || 'unknown error'}`);
+  }
+  return imageKey;
+}
+
+type ReceiveIdType = 'open_id' | 'chat_id' | 'user_id' | 'union_id' | 'email';
+
+/** Upload a local image and send it as a Feishu image message. */
+export async function sendImageMessage(
+  client: lark.Client,
+  receiveId: string,
+  receiveIdType: ReceiveIdType,
+  imagePath: string,
+  mimeType?: string,
+): Promise<string> {
+  const imageKey = await uploadImageToFeishu(imagePath, mimeType);
+  const res = await client.im.message.create({
+    params: { receive_id_type: receiveIdType },
+    data: {
+      receive_id: receiveId,
+      msg_type: 'image',
+      content: JSON.stringify({ image_key: imageKey }),
+    },
+  });
+  if (typeof res.code === 'number' && res.code !== 0) {
+    throw new Error(`Feishu send image failed: ${res.code} ${res.msg ?? 'unknown error'}`);
+  }
+  return res.data?.message_id ?? '';
+}
+
+/** Send a plain text message. Returns the message_id. */
+export async function sendTextMessage(
+  client: lark.Client,
+  receiveId: string,
+  receiveIdType: ReceiveIdType,
+  text: string,
+): Promise<string> {
+  const res = await client.im.message.create({
+    params: { receive_id_type: receiveIdType },
+    data: {
+      receive_id: receiveId,
+      msg_type: 'text',
+      content: JSON.stringify({ text }),
+    },
+  });
+  if (typeof res.code === 'number' && res.code !== 0) {
+    throw new Error(`Feishu send text failed: ${res.code} ${res.msg ?? 'unknown error'}`);
+  }
+  return res.data?.message_id ?? '';
+}
+
+/** Send an interactive card message. Returns the message_id. */
+export async function sendCardMessage(
+  client: lark.Client,
+  receiveId: string,
+  receiveIdType: ReceiveIdType,
+  card: object,
+): Promise<string> {
+  const res = await client.im.message.create({
+    params: { receive_id_type: receiveIdType },
+    data: {
+      receive_id: receiveId,
+      msg_type: 'interactive',
+      content: JSON.stringify(card),
+    },
+  });
+  if (typeof res.code === 'number' && res.code !== 0) {
+    throw new Error(`Feishu send card failed: ${res.code} ${res.msg ?? 'unknown error'}`);
+  }
+  return res.data?.message_id ?? '';
+}
+
+/** Update (patch) an existing card message with new content. */
+export async function updateCardMessage(
+  client: lark.Client,
+  messageId: string,
+  card: object,
+): Promise<void> {
+  const res = await client.im.message.patch({
+    path: { message_id: messageId },
+    data: { content: JSON.stringify(card) },
+  });
+  if (typeof res.code === 'number' && res.code !== 0) {
+    throw new Error(`Feishu update card failed: ${res.code} ${res.msg ?? 'unknown error'}`);
+  }
+}

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-client.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-client.ts
@@ -114,71 +114,77 @@ async function uploadImageToFeishu(imagePath: string, mimeType?: string): Promis
   return imageKey;
 }
 
-type ReceiveIdType = 'open_id' | 'chat_id' | 'user_id' | 'union_id' | 'email';
+/**
+ * Where a reply goes. For a normal chat we create a message addressed to
+ * `chatId`. For a **topic group** (`threadId` set) we instead reply to the
+ * triggering message with `reply_in_thread`, so the message lands in the
+ * right topic rather than the group root.
+ */
+export interface FeishuSendTarget {
+  chatId: string;
+  threadId?: string;
+  /** The inbound message we reply to, to continue a topic-group thread. */
+  triggerMessageId: string;
+}
 
-/** Upload a local image and send it as a Feishu image message. */
+/**
+ * Send a message to a target, choosing create-vs-reply based on whether the
+ * conversation is threaded. Returns the new message_id.
+ */
+async function createOrReply(
+  client: lark.Client,
+  target: FeishuSendTarget,
+  msgType: 'text' | 'interactive' | 'image',
+  content: string,
+): Promise<string> {
+  if (target.threadId && target.triggerMessageId) {
+    const res = await client.im.message.reply({
+      path: { message_id: target.triggerMessageId },
+      data: { content, msg_type: msgType, reply_in_thread: true },
+    });
+    if (typeof res.code === 'number' && res.code !== 0) {
+      throw new Error(`Feishu reply failed: ${res.code} ${res.msg ?? 'unknown error'}`);
+    }
+    return res.data?.message_id ?? '';
+  }
+
+  const res = await client.im.message.create({
+    params: { receive_id_type: 'chat_id' },
+    data: { receive_id: target.chatId, msg_type: msgType, content },
+  });
+  if (typeof res.code === 'number' && res.code !== 0) {
+    throw new Error(`Feishu send failed: ${res.code} ${res.msg ?? 'unknown error'}`);
+  }
+  return res.data?.message_id ?? '';
+}
+
+/** Upload a local image and send it to the target. Returns the message_id. */
 export async function sendImageMessage(
   client: lark.Client,
-  receiveId: string,
-  receiveIdType: ReceiveIdType,
+  target: FeishuSendTarget,
   imagePath: string,
   mimeType?: string,
 ): Promise<string> {
   const imageKey = await uploadImageToFeishu(imagePath, mimeType);
-  const res = await client.im.message.create({
-    params: { receive_id_type: receiveIdType },
-    data: {
-      receive_id: receiveId,
-      msg_type: 'image',
-      content: JSON.stringify({ image_key: imageKey }),
-    },
-  });
-  if (typeof res.code === 'number' && res.code !== 0) {
-    throw new Error(`Feishu send image failed: ${res.code} ${res.msg ?? 'unknown error'}`);
-  }
-  return res.data?.message_id ?? '';
+  return createOrReply(client, target, 'image', JSON.stringify({ image_key: imageKey }));
 }
 
-/** Send a plain text message. Returns the message_id. */
+/** Send a plain text message to the target. Returns the message_id. */
 export async function sendTextMessage(
   client: lark.Client,
-  receiveId: string,
-  receiveIdType: ReceiveIdType,
+  target: FeishuSendTarget,
   text: string,
 ): Promise<string> {
-  const res = await client.im.message.create({
-    params: { receive_id_type: receiveIdType },
-    data: {
-      receive_id: receiveId,
-      msg_type: 'text',
-      content: JSON.stringify({ text }),
-    },
-  });
-  if (typeof res.code === 'number' && res.code !== 0) {
-    throw new Error(`Feishu send text failed: ${res.code} ${res.msg ?? 'unknown error'}`);
-  }
-  return res.data?.message_id ?? '';
+  return createOrReply(client, target, 'text', JSON.stringify({ text }));
 }
 
-/** Send an interactive card message. Returns the message_id. */
+/** Send an interactive card message to the target. Returns the message_id. */
 export async function sendCardMessage(
   client: lark.Client,
-  receiveId: string,
-  receiveIdType: ReceiveIdType,
+  target: FeishuSendTarget,
   card: object,
 ): Promise<string> {
-  const res = await client.im.message.create({
-    params: { receive_id_type: receiveIdType },
-    data: {
-      receive_id: receiveId,
-      msg_type: 'interactive',
-      content: JSON.stringify(card),
-    },
-  });
-  if (typeof res.code === 'number' && res.code !== 0) {
-    throw new Error(`Feishu send card failed: ${res.code} ${res.msg ?? 'unknown error'}`);
-  }
-  return res.data?.message_id ?? '';
+  return createOrReply(client, target, 'interactive', JSON.stringify(card));
 }
 
 /** Update (patch) an existing card message with new content. */

--- a/apps/canvas-workspace/src/plugins/main/channel/config-ipc.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/config-ipc.ts
@@ -1,0 +1,57 @@
+/**
+ * IPC for channel credentials (Settings → Experimental → Chat channels).
+ *
+ * Registered unconditionally at app startup — independent of whether the
+ * channel plugin itself activated — so the user can configure credentials
+ * even when the plugin is currently inactive (it only activates once
+ * configured + the experimental flag is on).
+ *
+ * Changes take effect on the next full app launch: the channel plugin's
+ * `enabledWhen` and `applyChannelConfigToEnv()` both run at main-process
+ * startup, so `relaunch` is offered to apply them.
+ */
+
+import { app, ipcMain } from 'electron';
+import {
+  clearFeishuConfig,
+  getChannelConfigStatus,
+  setFeishuConfig,
+  type SetFeishuConfigInput,
+} from './config';
+
+export function setupChannelConfigIpc(): void {
+  ipcMain.handle('channel-config:status', async () => {
+    try {
+      return { ok: true, status: await getChannelConfigStatus() };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  });
+
+  ipcMain.handle('channel-config:set-feishu', async (_event, payload: SetFeishuConfigInput) => {
+    try {
+      await setFeishuConfig(payload ?? {});
+      return { ok: true, status: await getChannelConfigStatus() };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  });
+
+  ipcMain.handle('channel-config:clear-feishu', async () => {
+    try {
+      await clearFeishuConfig();
+      return { ok: true, status: await getChannelConfigStatus() };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  });
+
+  // Full relaunch so the channel plugin re-evaluates enabledWhen and
+  // re-applies config to the environment (main-process restart required —
+  // a renderer reload alone does not re-run plugin activation).
+  ipcMain.handle('channel-config:relaunch', () => {
+    app.relaunch();
+    app.exit(0);
+    return { ok: true };
+  });
+}

--- a/apps/canvas-workspace/src/plugins/main/channel/config.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/config.ts
@@ -1,0 +1,186 @@
+import { safeStorage } from 'electron';
+import { promises as fs, readFileSync } from 'fs';
+import { homedir } from 'os';
+import { dirname, join } from 'path';
+
+// Persistent channel credentials, configurable from Settings → Experimental
+// instead of (or in addition to) shell env vars. The Feishu app secret is a
+// secret, so it is stored encrypted via Electron safeStorage — mirroring how
+// the model API key is handled.
+//
+// Resolution: env vars take precedence (power users / CI). On startup,
+// applyChannelConfigToEnv() populates process.env from this file ONLY for
+// keys not already set, so the rest of the channel code can keep reading
+// process.env unchanged.
+
+function configPath(): string {
+  const envPath = process.env.PULSE_CANVAS_CHANNEL_CONFIG?.trim();
+  return envPath || join(homedir(), '.pulse-coder', 'canvas', 'channel-config.json');
+}
+
+interface FeishuConfig {
+  appId?: string;
+  encryptedAppSecret?: string;
+  defaultWorkspaceId?: string;
+}
+
+interface ChannelConfigFile {
+  feishu?: FeishuConfig;
+}
+
+function trimOrUndefined(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function encryptSecret(secret: string): string {
+  try {
+    if (safeStorage.isEncryptionAvailable()) {
+      return `safe:${safeStorage.encryptString(secret).toString('base64')}`;
+    }
+  } catch {
+    // Fall through to obfuscation for dev environments without an OS keychain.
+  }
+  return `plain:${Buffer.from(secret, 'utf8').toString('base64')}`;
+}
+
+function decryptSecret(encrypted?: string): string | undefined {
+  const value = trimOrUndefined(encrypted);
+  if (!value) return undefined;
+  try {
+    if (value.startsWith('safe:')) {
+      return safeStorage.decryptString(Buffer.from(value.slice(5), 'base64'));
+    }
+    if (value.startsWith('plain:')) {
+      return Buffer.from(value.slice(6), 'base64').toString('utf8');
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function parseConfig(raw: string): ChannelConfigFile {
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as ChannelConfigFile;
+    }
+  } catch {
+    // ignore — treat as empty
+  }
+  return {};
+}
+
+function readConfigSync(): ChannelConfigFile {
+  try {
+    return parseConfig(readFileSync(configPath(), 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+async function readConfig(): Promise<ChannelConfigFile> {
+  try {
+    return parseConfig(await fs.readFile(configPath(), 'utf8'));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return {};
+    throw err;
+  }
+}
+
+async function writeConfig(cfg: ChannelConfigFile): Promise<void> {
+  const p = configPath();
+  await fs.mkdir(dirname(p), { recursive: true });
+  await fs.writeFile(p, `${JSON.stringify(cfg, null, 2)}\n`, 'utf8');
+}
+
+/**
+ * Populate process.env from the stored config for any channel var not
+ * already set in the environment (env wins). Called synchronously at app
+ * startup, before plugins evaluate `enabledWhen`.
+ */
+export function applyChannelConfigToEnv(): void {
+  const feishu = readConfigSync().feishu;
+  if (!feishu) return;
+
+  if (feishu.appId && !process.env.FEISHU_APP_ID) {
+    process.env.FEISHU_APP_ID = feishu.appId;
+  }
+  if (feishu.encryptedAppSecret && !process.env.FEISHU_APP_SECRET) {
+    const secret = decryptSecret(feishu.encryptedAppSecret);
+    if (secret) process.env.FEISHU_APP_SECRET = secret;
+  }
+  if (feishu.defaultWorkspaceId && !process.env.CANVAS_FEISHU_DEFAULT_WORKSPACE) {
+    process.env.CANVAS_FEISHU_DEFAULT_WORKSPACE = feishu.defaultWorkspaceId;
+  }
+}
+
+export interface ChannelConfigStatus {
+  path: string;
+  feishu: {
+    /** Stored App ID (safe to echo — not a secret). */
+    appId?: string;
+    /** App Secret present (stored or via env). The secret itself is never returned. */
+    secretPresent: boolean;
+    /** Stored default workspace id. */
+    defaultWorkspaceId?: string;
+    /** Whether each value is currently overridden by an env var. */
+    appIdFromEnv: boolean;
+    secretFromEnv: boolean;
+    defaultWorkspaceFromEnv: boolean;
+  };
+}
+
+export async function getChannelConfigStatus(): Promise<ChannelConfigStatus> {
+  const feishu = (await readConfig()).feishu ?? {};
+  const appIdFromEnv = Boolean(process.env.FEISHU_APP_ID);
+  const secretFromEnv = Boolean(process.env.FEISHU_APP_SECRET);
+  const defaultWorkspaceFromEnv = Boolean(process.env.CANVAS_FEISHU_DEFAULT_WORKSPACE);
+  return {
+    path: configPath(),
+    feishu: {
+      appId: feishu.appId,
+      secretPresent: Boolean(feishu.encryptedAppSecret) || secretFromEnv,
+      defaultWorkspaceId: feishu.defaultWorkspaceId,
+      appIdFromEnv,
+      secretFromEnv,
+      defaultWorkspaceFromEnv,
+    },
+  };
+}
+
+export interface SetFeishuConfigInput {
+  appId?: string;
+  /** New secret to store. Empty/omitted leaves the existing secret untouched. */
+  appSecret?: string;
+  defaultWorkspaceId?: string;
+  /** When true, remove the stored secret. */
+  clearSecret?: boolean;
+}
+
+export async function setFeishuConfig(input: SetFeishuConfigInput): Promise<void> {
+  const cfg = await readConfig();
+  const feishu: FeishuConfig = { ...(cfg.feishu ?? {}) };
+
+  if (input.appId !== undefined) feishu.appId = trimOrUndefined(input.appId);
+  if (input.defaultWorkspaceId !== undefined) {
+    feishu.defaultWorkspaceId = trimOrUndefined(input.defaultWorkspaceId);
+  }
+  if (input.clearSecret) {
+    delete feishu.encryptedAppSecret;
+  } else {
+    const secret = trimOrUndefined(input.appSecret);
+    if (secret) feishu.encryptedAppSecret = encryptSecret(secret);
+  }
+
+  cfg.feishu = feishu;
+  await writeConfig(cfg);
+}
+
+export async function clearFeishuConfig(): Promise<void> {
+  const cfg = await readConfig();
+  delete cfg.feishu;
+  await writeConfig(cfg);
+}

--- a/apps/canvas-workspace/src/plugins/main/channel/core/binding.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/core/binding.ts
@@ -1,11 +1,10 @@
 import type { PluginStore } from '../../../types';
-import { listWorkspaces } from './workspaces';
 
 // Persisted shape, stored under a single plugin-store key.
 interface BindingState {
-  /** Global fallback workspace when a conversation has no explicit binding. */
+  /** Suggested workspace for /bind without an argument (not auto-applied). */
   defaultWorkspaceId?: string;
-  /** Per-conversation overrides, keyed by `${channelId}:${conversationId}`. */
+  /** Per-conversation bindings, keyed by `${channelId}:${conversationId}`. */
   perChat: Record<string, string>;
 }
 
@@ -16,12 +15,15 @@ function chatKey(channelId: string, conversationId: string): string {
 }
 
 /**
- * Resolves which canvas workspace a given conversation talks to, with a
- * "default + switchable" model:
- *   1. explicit per-conversation binding (set via /bind)
- *   2. stored global default (set via /default)
- *   3. CANVAS_FEISHU_DEFAULT_WORKSPACE env var
- *   4. most-recently-modified workspace on disk
+ * Tracks which canvas workspace each conversation is bound to.
+ *
+ * Binding is **explicit and sticky**: a conversation only talks to a
+ * workspace once the user has bound it (via /bind), and that choice never
+ * changes on its own. There is intentionally no implicit fallback (e.g.
+ * "most-recently-modified"), so a conversation can never silently switch
+ * workspaces mid-chat. A stored/env default is offered only as a suggestion
+ * for `/bind` with no argument — it is not auto-applied.
+ *
  * State is persisted via the plugin's own {@link PluginStore}.
  */
 export class BindingStore {
@@ -43,29 +45,20 @@ export class BindingStore {
     await this.store.set(STORE_KEY, this.state);
   }
 
-  /** Resolve the workspace for a conversation, or undefined if none can be determined. */
-  async resolve(channelId: string, conversationId: string): Promise<string | undefined> {
-    await this.ensureLoaded();
-    const explicit = this.state.perChat[chatKey(channelId, conversationId)];
-    if (explicit) return explicit;
-    if (this.state.defaultWorkspaceId) return this.state.defaultWorkspaceId;
-
-    const envDefault = process.env.CANVAS_FEISHU_DEFAULT_WORKSPACE?.trim();
-    if (envDefault) return envDefault;
-
-    const [mostRecent] = await listWorkspaces();
-    return mostRecent?.id;
-  }
-
-  /** The workspace explicitly bound to this conversation, if any. */
-  async getExplicit(channelId: string, conversationId: string): Promise<string | undefined> {
+  /** The workspace this conversation is bound to, or undefined if unbound. */
+  async getBound(channelId: string, conversationId: string): Promise<string | undefined> {
     await this.ensureLoaded();
     return this.state.perChat[chatKey(channelId, conversationId)];
   }
 
-  async getDefault(): Promise<string | undefined> {
+  /**
+   * The suggested default workspace (stored value, else the
+   * CANVAS_FEISHU_DEFAULT_WORKSPACE env var). Only used to assist `/bind`;
+   * never auto-applied to a conversation.
+   */
+  async getSuggestedDefault(): Promise<string | undefined> {
     await this.ensureLoaded();
-    return this.state.defaultWorkspaceId;
+    return this.state.defaultWorkspaceId ?? (process.env.CANVAS_FEISHU_DEFAULT_WORKSPACE?.trim() || undefined);
   }
 
   /** Bind a conversation to a specific workspace. */
@@ -75,14 +68,14 @@ export class BindingStore {
     await this.persist();
   }
 
-  /** Remove a conversation's explicit binding (falls back to the default). */
+  /** Remove a conversation's binding. */
   async unbind(channelId: string, conversationId: string): Promise<void> {
     await this.ensureLoaded();
     delete this.state.perChat[chatKey(channelId, conversationId)];
     await this.persist();
   }
 
-  /** Set the global default workspace. */
+  /** Set the suggested default workspace. */
   async setDefault(workspaceId: string): Promise<void> {
     await this.ensureLoaded();
     this.state.defaultWorkspaceId = workspaceId;

--- a/apps/canvas-workspace/src/plugins/main/channel/core/binding.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/core/binding.ts
@@ -1,0 +1,91 @@
+import type { PluginStore } from '../../../types';
+import { listWorkspaces } from './workspaces';
+
+// Persisted shape, stored under a single plugin-store key.
+interface BindingState {
+  /** Global fallback workspace when a conversation has no explicit binding. */
+  defaultWorkspaceId?: string;
+  /** Per-conversation overrides, keyed by `${channelId}:${conversationId}`. */
+  perChat: Record<string, string>;
+}
+
+const STORE_KEY = 'bindings';
+
+function chatKey(channelId: string, conversationId: string): string {
+  return `${channelId}:${conversationId}`;
+}
+
+/**
+ * Resolves which canvas workspace a given conversation talks to, with a
+ * "default + switchable" model:
+ *   1. explicit per-conversation binding (set via /bind)
+ *   2. stored global default (set via /default)
+ *   3. CANVAS_FEISHU_DEFAULT_WORKSPACE env var
+ *   4. most-recently-modified workspace on disk
+ * State is persisted via the plugin's own {@link PluginStore}.
+ */
+export class BindingStore {
+  private state: BindingState = { perChat: {} };
+  private loaded = false;
+
+  constructor(private readonly store: PluginStore) {}
+
+  private async ensureLoaded(): Promise<void> {
+    if (this.loaded) return;
+    const saved = await this.store.get<BindingState>(STORE_KEY);
+    if (saved) {
+      this.state = { defaultWorkspaceId: saved.defaultWorkspaceId, perChat: saved.perChat ?? {} };
+    }
+    this.loaded = true;
+  }
+
+  private async persist(): Promise<void> {
+    await this.store.set(STORE_KEY, this.state);
+  }
+
+  /** Resolve the workspace for a conversation, or undefined if none can be determined. */
+  async resolve(channelId: string, conversationId: string): Promise<string | undefined> {
+    await this.ensureLoaded();
+    const explicit = this.state.perChat[chatKey(channelId, conversationId)];
+    if (explicit) return explicit;
+    if (this.state.defaultWorkspaceId) return this.state.defaultWorkspaceId;
+
+    const envDefault = process.env.CANVAS_FEISHU_DEFAULT_WORKSPACE?.trim();
+    if (envDefault) return envDefault;
+
+    const [mostRecent] = await listWorkspaces();
+    return mostRecent?.id;
+  }
+
+  /** The workspace explicitly bound to this conversation, if any. */
+  async getExplicit(channelId: string, conversationId: string): Promise<string | undefined> {
+    await this.ensureLoaded();
+    return this.state.perChat[chatKey(channelId, conversationId)];
+  }
+
+  async getDefault(): Promise<string | undefined> {
+    await this.ensureLoaded();
+    return this.state.defaultWorkspaceId;
+  }
+
+  /** Bind a conversation to a specific workspace. */
+  async bind(channelId: string, conversationId: string, workspaceId: string): Promise<void> {
+    await this.ensureLoaded();
+    this.state.perChat[chatKey(channelId, conversationId)] = workspaceId;
+    await this.persist();
+  }
+
+  /** Remove a conversation's explicit binding (falls back to the default). */
+  async unbind(channelId: string, conversationId: string): Promise<void> {
+    await this.ensureLoaded();
+    delete this.state.perChat[chatKey(channelId, conversationId)];
+    await this.persist();
+  }
+
+  /** Set the global default workspace. */
+  async setDefault(workspaceId: string): Promise<void> {
+    await this.ensureLoaded();
+    this.state.defaultWorkspaceId = workspaceId;
+    await this.persist();
+  }
+}

--- a/apps/canvas-workspace/src/plugins/main/channel/core/bridge.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/core/bridge.ts
@@ -4,6 +4,7 @@ import { BindingStore } from './binding';
 import { handleCommand } from './commands';
 import { MessageDedupe } from './dedupe';
 import { extractGeneratedImageResult } from './image-result';
+import { SessionRouter } from './sessions';
 import type { Channel, ChannelStream, InboundMessage } from './types';
 
 interface ActiveRun {
@@ -24,6 +25,7 @@ interface ActiveRun {
  */
 export class ChannelBridge {
   private readonly bindings: BindingStore;
+  private readonly sessions: SessionRouter;
   private readonly dedupe = new MessageDedupe();
   private readonly activeRuns = new Map<string, ActiveRun>();
   private readonly channels = new Map<string, Channel>();
@@ -33,6 +35,7 @@ export class ChannelBridge {
     store: PluginStore,
   ) {
     this.bindings = new BindingStore(store);
+    this.sessions = new SessionRouter(service, store);
   }
 
   /** Register and start a channel, wiring its inbound traffic to this bridge. */
@@ -118,6 +121,15 @@ export class ChannelBridge {
     const target = { conversationId: msg.conversationId, reply: msg.reply };
     const run: ActiveRun = { channelId: msg.channelId, conversationId: msg.conversationId };
     this.activeRuns.set(workspaceId, run);
+
+    // Give this conversation its own session so topics / chats sharing a
+    // workspace keep separate histories. Safe here: runs are serialized per
+    // workspace, so nothing else can swap the session mid-turn.
+    try {
+      await this.sessions.ensureSession(workspaceId, msg.conversationId);
+    } catch (err) {
+      console.error(`[channel:${channel.id}] failed to select session`, err);
+    }
 
     let stream: ChannelStream;
     try {

--- a/apps/canvas-workspace/src/plugins/main/channel/core/bridge.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/core/bridge.ts
@@ -1,0 +1,165 @@
+import type { CanvasAgentServiceRef } from '../../../types';
+import type { PluginStore } from '../../../types';
+import { BindingStore } from './binding';
+import { handleCommand } from './commands';
+import { MessageDedupe } from './dedupe';
+import { extractGeneratedImageResult } from './image-result';
+import type { Channel, ChannelStream, InboundMessage } from './types';
+
+interface ActiveRun {
+  channelId: string;
+  conversationId: string;
+  /** Set while the agent is awaiting an answer to a clarification request. */
+  pendingClarificationId?: string;
+}
+
+/**
+ * Channel-agnostic orchestration. Receives normalized inbound messages from
+ * any number of channels, resolves the target workspace, and drives the
+ * Canvas Agent — streaming its output back through the originating channel.
+ *
+ * Concurrency: at most one in-flight run per workspace. A follow-up message
+ * for a busy workspace either answers a pending clarification or is rejected
+ * with a "still working" notice.
+ */
+export class ChannelBridge {
+  private readonly bindings: BindingStore;
+  private readonly dedupe = new MessageDedupe();
+  private readonly activeRuns = new Map<string, ActiveRun>();
+  private readonly channels = new Map<string, Channel>();
+
+  constructor(
+    private readonly service: CanvasAgentServiceRef,
+    store: PluginStore,
+  ) {
+    this.bindings = new BindingStore(store);
+  }
+
+  /** Register and start a channel, wiring its inbound traffic to this bridge. */
+  async addChannel(channel: Channel): Promise<void> {
+    this.channels.set(channel.id, channel);
+    await channel.start((msg) => {
+      void this.handleInbound(channel, msg).catch((err) => {
+        console.error(`[channel:${channel.id}] inbound handling failed`, err);
+      });
+    });
+  }
+
+  /** Stop all channels. */
+  async stop(): Promise<void> {
+    await Promise.all(
+      Array.from(this.channels.values()).map((c) =>
+        c.stop().catch((err) => console.error(`[channel:${c.id}] stop failed`, err)),
+      ),
+    );
+    this.channels.clear();
+  }
+
+  private async handleInbound(channel: Channel, msg: InboundMessage): Promise<void> {
+    if (!this.dedupe.accept(msg.messageId)) return;
+
+    const target = { conversationId: msg.conversationId };
+
+    // Slash commands run regardless of workspace binding / busy state.
+    const commandReply = await handleCommand(msg, {
+      bindings: this.bindings,
+      service: this.service,
+    });
+    if (commandReply !== null) {
+      await channel.sendText(target, commandReply);
+      return;
+    }
+
+    if (!msg.text.trim()) return;
+
+    const workspaceId = await this.bindings.resolve(msg.channelId, msg.conversationId);
+    if (!workspaceId) {
+      await channel.sendText(
+        target,
+        'No canvas workspace is bound to this chat. Use /list then /bind <workspaceId>.',
+      );
+      return;
+    }
+
+    // Busy workspace: route the message as a clarification answer if one is
+    // pending, otherwise tell the user to wait.
+    const existing = this.activeRuns.get(workspaceId);
+    if (existing) {
+      if (existing.pendingClarificationId) {
+        const matched = this.service.answerClarification(
+          workspaceId,
+          existing.pendingClarificationId,
+          msg.text,
+        );
+        existing.pendingClarificationId = undefined;
+        if (!matched) {
+          await channel.sendText(target, '⚠️ Could not match your reply to the pending question.');
+        }
+      } else {
+        await channel.sendText(target, '⏳ Still working on the previous message. Send /stop to cancel.');
+      }
+      return;
+    }
+
+    await this.runTurn(channel, msg, workspaceId);
+  }
+
+  private async runTurn(
+    channel: Channel,
+    msg: InboundMessage,
+    workspaceId: string,
+  ): Promise<void> {
+    const target = { conversationId: msg.conversationId };
+    const run: ActiveRun = { channelId: msg.channelId, conversationId: msg.conversationId };
+    this.activeRuns.set(workspaceId, run);
+
+    let stream: ChannelStream;
+    try {
+      stream = await channel.openStream(target);
+    } catch (err) {
+      this.activeRuns.delete(workspaceId);
+      console.error(`[channel:${channel.id}] failed to open stream`, err);
+      return;
+    }
+
+    try {
+      const result = await this.service.chat(
+        workspaceId,
+        msg.text,
+        (delta) => void Promise.resolve(stream.onText(delta)).catch(noop),
+        (toolCall) => void Promise.resolve(stream.onToolCall(toolCall.name, toolCall.args)).catch(noop),
+        (toolResult) => {
+          const image = extractGeneratedImageResult(toolResult);
+          if (image && stream.onImage) {
+            void Promise.resolve(stream.onImage(image.outputPath, image.mimeType)).catch(noop);
+            return;
+          }
+          if (stream.onToolResult) {
+            void Promise.resolve(
+              stream.onToolResult({ name: toolResult.name, result: toolResult.result }),
+            ).catch(noop);
+          }
+        },
+        undefined,
+        (req) => {
+          run.pendingClarificationId = req.id;
+          void Promise.resolve(stream.onClarification(req.question)).catch(noop);
+        },
+      );
+
+      if (result.ok) {
+        await stream.onDone(result.response?.trim() || '✅ Done');
+      } else {
+        await stream.onError(result.error ?? 'Unknown error');
+      }
+    } catch (err) {
+      await stream.onError(err instanceof Error ? err.message : String(err));
+    } finally {
+      this.activeRuns.delete(workspaceId);
+    }
+  }
+}
+
+function noop(): void {
+  /* swallow streaming-callback errors; the run result is the source of truth */
+}

--- a/apps/canvas-workspace/src/plugins/main/channel/core/bridge.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/core/bridge.ts
@@ -58,7 +58,7 @@ export class ChannelBridge {
   private async handleInbound(channel: Channel, msg: InboundMessage): Promise<void> {
     if (!this.dedupe.accept(msg.messageId)) return;
 
-    const target = { conversationId: msg.conversationId };
+    const target = { conversationId: msg.conversationId, reply: msg.reply };
 
     // Slash commands run regardless of workspace binding / busy state.
     const commandReply = await handleCommand(msg, {
@@ -81,11 +81,17 @@ export class ChannelBridge {
       return;
     }
 
-    // Busy workspace: route the message as a clarification answer if one is
-    // pending, otherwise tell the user to wait.
+    // Busy workspace: if THIS conversation is the one awaiting a clarification
+    // answer, route the message as the answer. Otherwise (a different
+    // conversation bound to the same workspace, or no pending question) tell
+    // the user to wait — so a clarification can't be answered by an unrelated
+    // chat that happens to share the workspace.
     const existing = this.activeRuns.get(workspaceId);
     if (existing) {
-      if (existing.pendingClarificationId) {
+      if (
+        existing.pendingClarificationId &&
+        existing.conversationId === msg.conversationId
+      ) {
         const matched = this.service.answerClarification(
           workspaceId,
           existing.pendingClarificationId,
@@ -109,7 +115,7 @@ export class ChannelBridge {
     msg: InboundMessage,
     workspaceId: string,
   ): Promise<void> {
-    const target = { conversationId: msg.conversationId };
+    const target = { conversationId: msg.conversationId, reply: msg.reply };
     const run: ActiveRun = { channelId: msg.channelId, conversationId: msg.conversationId };
     this.activeRuns.set(workspaceId, run);
 

--- a/apps/canvas-workspace/src/plugins/main/channel/core/bridge.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/core/bridge.ts
@@ -75,11 +75,17 @@ export class ChannelBridge {
 
     if (!msg.text.trim()) return;
 
-    const workspaceId = await this.bindings.resolve(msg.channelId, msg.conversationId);
+    // Binding is explicit and sticky: refuse to run until the conversation is
+    // bound, so it never silently picks (or switches) a workspace mid-chat.
+    const workspaceId = await this.bindings.getBound(msg.channelId, msg.conversationId);
     if (!workspaceId) {
+      const suggestion = await this.bindings.getSuggestedDefault();
+      const hint = suggestion
+        ? `\nTip: /bind  (no argument) binds the default workspace.`
+        : '';
       await channel.sendText(
         target,
-        'No canvas workspace is bound to this chat. Use /list then /bind <name|id>.',
+        `🔗 This chat isn't bound to a workspace yet. Send /list to see workspaces, then /bind <name|id>.${hint}`,
       );
       return;
     }

--- a/apps/canvas-workspace/src/plugins/main/channel/core/bridge.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/core/bridge.ts
@@ -79,7 +79,7 @@ export class ChannelBridge {
     if (!workspaceId) {
       await channel.sendText(
         target,
-        'No canvas workspace is bound to this chat. Use /list then /bind <workspaceId>.',
+        'No canvas workspace is bound to this chat. Use /list then /bind <name|id>.',
       );
       return;
     }

--- a/apps/canvas-workspace/src/plugins/main/channel/core/commands.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/core/commands.ts
@@ -1,0 +1,118 @@
+import type { CanvasAgentServiceRef } from '../../../types';
+import type { InboundMessage } from './types';
+import type { BindingStore } from './binding';
+import { listWorkspaces, workspaceExists } from './workspaces';
+
+export interface CommandDeps {
+  bindings: BindingStore;
+  service: CanvasAgentServiceRef;
+}
+
+const HELP = [
+  '🛠️ Canvas channel commands:',
+  '/list — list available workspaces',
+  '/ws — show the workspace this chat is bound to',
+  '/bind <workspaceId> — bind this chat to a workspace',
+  '/unbind — clear this chat’s binding (fall back to default)',
+  '/default <workspaceId> — set the global default workspace',
+  '/new — start a fresh session',
+  '/stop — abort the current run',
+  '/sessions — list sessions for the bound workspace',
+].join('\n');
+
+/**
+ * Handle a slash command. Returns the text to reply with when `msg` is a
+ * command, or null when it is an ordinary message the bridge should route
+ * to the agent. Channel-agnostic — operates purely on the normalized
+ * {@link InboundMessage} and the shared service/binding deps.
+ */
+export async function handleCommand(
+  msg: InboundMessage,
+  deps: CommandDeps,
+): Promise<string | null> {
+  const text = msg.text.trim();
+  if (!text.startsWith('/')) return null;
+
+  const [rawCmd, ...rest] = text.slice(1).split(/\s+/);
+  const cmd = rawCmd.toLowerCase();
+  const arg = rest.join(' ').trim();
+  const { bindings, service } = deps;
+
+  switch (cmd) {
+    case 'help':
+      return HELP;
+
+    case 'list': {
+      const workspaces = await listWorkspaces();
+      if (workspaces.length === 0) return 'No canvas workspaces found yet.';
+      const current = await bindings.resolve(msg.channelId, msg.conversationId);
+      const lines = workspaces
+        .slice(0, 30)
+        .map((w) => `${w.id === current ? '• (current) ' : '• '}${w.id}`);
+      return `📋 Workspaces:\n${lines.join('\n')}`;
+    }
+
+    case 'ws':
+    case 'whoami': {
+      const explicit = await bindings.getExplicit(msg.channelId, msg.conversationId);
+      const resolved = await bindings.resolve(msg.channelId, msg.conversationId);
+      if (!resolved) return 'No workspace bound and none found on disk. Use /bind <workspaceId>.';
+      const how = explicit ? 'bound to this chat' : 'resolved (default/fallback)';
+      return `🎯 This chat → ${resolved}\n(${how})`;
+    }
+
+    case 'bind': {
+      if (!arg) return 'Usage: /bind <workspaceId>  (see /list)';
+      if (!(await workspaceExists(arg))) {
+        return `Workspace not found: ${arg}. Use /list to see available workspaces.`;
+      }
+      await bindings.bind(msg.channelId, msg.conversationId, arg);
+      return `✅ This chat is now bound to ${arg}.`;
+    }
+
+    case 'unbind': {
+      await bindings.unbind(msg.channelId, msg.conversationId);
+      const fallback = await bindings.resolve(msg.channelId, msg.conversationId);
+      return fallback
+        ? `✅ Binding cleared. This chat now falls back to ${fallback}.`
+        : '✅ Binding cleared.';
+    }
+
+    case 'default': {
+      if (!arg) return 'Usage: /default <workspaceId>  (see /list)';
+      if (!(await workspaceExists(arg))) {
+        return `Workspace not found: ${arg}. Use /list to see available workspaces.`;
+      }
+      await bindings.setDefault(arg);
+      return `✅ Default workspace set to ${arg}.`;
+    }
+
+    case 'new': {
+      const workspaceId = await bindings.resolve(msg.channelId, msg.conversationId);
+      if (!workspaceId) return 'No workspace bound. Use /bind <workspaceId> first.';
+      const res = await service.newSession(workspaceId);
+      return res.ok ? '🆕 Started a new session.' : `Failed to start a new session: ${res.error}`;
+    }
+
+    case 'stop': {
+      const workspaceId = await bindings.resolve(msg.channelId, msg.conversationId);
+      if (!workspaceId) return 'No workspace bound.';
+      service.abort(workspaceId);
+      return '🛑 Stop requested.';
+    }
+
+    case 'sessions': {
+      const workspaceId = await bindings.resolve(msg.channelId, msg.conversationId);
+      if (!workspaceId) return 'No workspace bound. Use /bind <workspaceId> first.';
+      const sessions = await service.listSessions(workspaceId);
+      if (sessions.length === 0) return 'No sessions yet.';
+      const lines = sessions
+        .slice(0, 15)
+        .map((s) => `${s.isCurrent ? '• (current) ' : '• '}${s.date} — ${s.messageCount} msgs`);
+      return `🗂️ Sessions for ${workspaceId}:\n${lines.join('\n')}`;
+    }
+
+    default:
+      return `Unknown command: /${cmd}\n\n${HELP}`;
+  }
+}

--- a/apps/canvas-workspace/src/plugins/main/channel/core/commands.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/core/commands.ts
@@ -50,40 +50,41 @@ export async function handleCommand(
     case 'list': {
       const workspaces = await listWorkspaces();
       if (workspaces.length === 0) return 'No canvas workspaces found yet.';
-      const current = await bindings.resolve(msg.channelId, msg.conversationId);
+      const bound = await bindings.getBound(msg.channelId, msg.conversationId);
       const lines = workspaces.slice(0, 30).map((w) => {
         const marks = [
-          w.id === current ? '⭐' : null,
+          w.id === bound ? '⭐' : null,
           w.isActive ? '🖥️' : null,
         ].filter(Boolean).join('');
         return `• ${workspaceLabel(w)}${marks ? ` ${marks}` : ''}`;
       });
-      return `📋 Workspaces (⭐ this chat · 🖥️ open in app):\n${lines.join('\n')}`;
+      return `📋 Workspaces (⭐ bound here · 🖥️ open in app):\n${lines.join('\n')}\n\nBind with /bind <name|id>.`;
     }
 
     case 'ws':
     case 'whoami': {
-      const explicit = await bindings.getExplicit(msg.channelId, msg.conversationId);
-      const resolved = await bindings.resolve(msg.channelId, msg.conversationId);
-      if (!resolved) return 'No workspace bound and none found on disk. Use /bind <name|id>.';
-      const how = explicit ? 'bound to this chat' : 'resolved (default/fallback)';
-      return `🎯 This chat → ${await workspaceLabelById(resolved)}\n(${how})`;
+      const bound = await bindings.getBound(msg.channelId, msg.conversationId);
+      if (bound) return `🎯 This chat is bound to ${await workspaceLabelById(bound)}.`;
+      const suggestion = await bindings.getSuggestedDefault();
+      const tip = suggestion
+        ? ` Default is ${await workspaceLabelById(suggestion)} — /bind to use it.`
+        : '';
+      return `🔗 This chat isn't bound to a workspace yet. Use /list then /bind <name|id>.${tip}`;
     }
 
     case 'bind': {
-      if (!arg) return 'Usage: /bind <name|id>  (see /list)';
-      const id = await resolveWorkspace(arg);
-      if (!id) return `Workspace not found: ${arg}. Use /list to see available workspaces.`;
+      // No argument → bind the suggested default, if one is configured.
+      const ref = arg || (await bindings.getSuggestedDefault());
+      if (!ref) return 'Usage: /bind <name|id>  (see /list). No default is set.';
+      const id = await resolveWorkspace(ref);
+      if (!id) return `Workspace not found: ${ref}. Use /list to see available workspaces.`;
       await bindings.bind(msg.channelId, msg.conversationId, id);
       return `✅ This chat is now bound to ${await workspaceLabelById(id)}.`;
     }
 
     case 'unbind': {
       await bindings.unbind(msg.channelId, msg.conversationId);
-      const fallback = await bindings.resolve(msg.channelId, msg.conversationId);
-      return fallback
-        ? `✅ Binding cleared. This chat now falls back to ${await workspaceLabelById(fallback)}.`
-        : '✅ Binding cleared.';
+      return '✅ Binding cleared. This chat is now unbound — /bind to use it again.';
     }
 
     case 'default': {
@@ -91,25 +92,25 @@ export async function handleCommand(
       const id = await resolveWorkspace(arg);
       if (!id) return `Workspace not found: ${arg}. Use /list to see available workspaces.`;
       await bindings.setDefault(id);
-      return `✅ Default workspace set to ${await workspaceLabelById(id)}.`;
+      return `✅ Default workspace set to ${await workspaceLabelById(id)} (suggested for /bind).`;
     }
 
     case 'new': {
-      const workspaceId = await bindings.resolve(msg.channelId, msg.conversationId);
+      const workspaceId = await bindings.getBound(msg.channelId, msg.conversationId);
       if (!workspaceId) return 'No workspace bound. Use /bind <name|id> first.';
       const res = await service.newSession(workspaceId);
       return res.ok ? '🆕 Started a new session.' : `Failed to start a new session: ${res.error}`;
     }
 
     case 'stop': {
-      const workspaceId = await bindings.resolve(msg.channelId, msg.conversationId);
+      const workspaceId = await bindings.getBound(msg.channelId, msg.conversationId);
       if (!workspaceId) return 'No workspace bound.';
       service.abort(workspaceId);
       return '🛑 Stop requested.';
     }
 
     case 'sessions': {
-      const workspaceId = await bindings.resolve(msg.channelId, msg.conversationId);
+      const workspaceId = await bindings.getBound(msg.channelId, msg.conversationId);
       if (!workspaceId) return 'No workspace bound. Use /bind <name|id> first.';
       const sessions = await service.listSessions(workspaceId);
       if (sessions.length === 0) return 'No sessions yet.';

--- a/apps/canvas-workspace/src/plugins/main/channel/core/commands.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/core/commands.ts
@@ -1,7 +1,12 @@
 import type { CanvasAgentServiceRef } from '../../../types';
 import type { InboundMessage } from './types';
 import type { BindingStore } from './binding';
-import { listWorkspaces, workspaceExists } from './workspaces';
+import {
+  listWorkspaces,
+  resolveWorkspace,
+  workspaceLabel,
+  workspaceLabelById,
+} from './workspaces';
 
 export interface CommandDeps {
   bindings: BindingStore;
@@ -12,9 +17,9 @@ const HELP = [
   '🛠️ Canvas channel commands:',
   '/list — list available workspaces',
   '/ws — show the workspace this chat is bound to',
-  '/bind <workspaceId> — bind this chat to a workspace',
+  '/bind <name|id> — bind this chat to a workspace',
   '/unbind — clear this chat’s binding (fall back to default)',
-  '/default <workspaceId> — set the global default workspace',
+  '/default <name|id> — set the global default workspace',
   '/new — start a fresh session',
   '/stop — abort the current run',
   '/sessions — list sessions for the bound workspace',
@@ -46,50 +51,52 @@ export async function handleCommand(
       const workspaces = await listWorkspaces();
       if (workspaces.length === 0) return 'No canvas workspaces found yet.';
       const current = await bindings.resolve(msg.channelId, msg.conversationId);
-      const lines = workspaces
-        .slice(0, 30)
-        .map((w) => `${w.id === current ? '• (current) ' : '• '}${w.id}`);
-      return `📋 Workspaces:\n${lines.join('\n')}`;
+      const lines = workspaces.slice(0, 30).map((w) => {
+        const marks = [
+          w.id === current ? '⭐' : null,
+          w.isActive ? '🖥️' : null,
+        ].filter(Boolean).join('');
+        return `• ${workspaceLabel(w)}${marks ? ` ${marks}` : ''}`;
+      });
+      return `📋 Workspaces (⭐ this chat · 🖥️ open in app):\n${lines.join('\n')}`;
     }
 
     case 'ws':
     case 'whoami': {
       const explicit = await bindings.getExplicit(msg.channelId, msg.conversationId);
       const resolved = await bindings.resolve(msg.channelId, msg.conversationId);
-      if (!resolved) return 'No workspace bound and none found on disk. Use /bind <workspaceId>.';
+      if (!resolved) return 'No workspace bound and none found on disk. Use /bind <name|id>.';
       const how = explicit ? 'bound to this chat' : 'resolved (default/fallback)';
-      return `🎯 This chat → ${resolved}\n(${how})`;
+      return `🎯 This chat → ${await workspaceLabelById(resolved)}\n(${how})`;
     }
 
     case 'bind': {
-      if (!arg) return 'Usage: /bind <workspaceId>  (see /list)';
-      if (!(await workspaceExists(arg))) {
-        return `Workspace not found: ${arg}. Use /list to see available workspaces.`;
-      }
-      await bindings.bind(msg.channelId, msg.conversationId, arg);
-      return `✅ This chat is now bound to ${arg}.`;
+      if (!arg) return 'Usage: /bind <name|id>  (see /list)';
+      const id = await resolveWorkspace(arg);
+      if (!id) return `Workspace not found: ${arg}. Use /list to see available workspaces.`;
+      await bindings.bind(msg.channelId, msg.conversationId, id);
+      return `✅ This chat is now bound to ${await workspaceLabelById(id)}.`;
     }
 
     case 'unbind': {
       await bindings.unbind(msg.channelId, msg.conversationId);
       const fallback = await bindings.resolve(msg.channelId, msg.conversationId);
       return fallback
-        ? `✅ Binding cleared. This chat now falls back to ${fallback}.`
+        ? `✅ Binding cleared. This chat now falls back to ${await workspaceLabelById(fallback)}.`
         : '✅ Binding cleared.';
     }
 
     case 'default': {
-      if (!arg) return 'Usage: /default <workspaceId>  (see /list)';
-      if (!(await workspaceExists(arg))) {
-        return `Workspace not found: ${arg}. Use /list to see available workspaces.`;
-      }
-      await bindings.setDefault(arg);
-      return `✅ Default workspace set to ${arg}.`;
+      if (!arg) return 'Usage: /default <name|id>  (see /list)';
+      const id = await resolveWorkspace(arg);
+      if (!id) return `Workspace not found: ${arg}. Use /list to see available workspaces.`;
+      await bindings.setDefault(id);
+      return `✅ Default workspace set to ${await workspaceLabelById(id)}.`;
     }
 
     case 'new': {
       const workspaceId = await bindings.resolve(msg.channelId, msg.conversationId);
-      if (!workspaceId) return 'No workspace bound. Use /bind <workspaceId> first.';
+      if (!workspaceId) return 'No workspace bound. Use /bind <name|id> first.';
       const res = await service.newSession(workspaceId);
       return res.ok ? '🆕 Started a new session.' : `Failed to start a new session: ${res.error}`;
     }
@@ -103,13 +110,13 @@ export async function handleCommand(
 
     case 'sessions': {
       const workspaceId = await bindings.resolve(msg.channelId, msg.conversationId);
-      if (!workspaceId) return 'No workspace bound. Use /bind <workspaceId> first.';
+      if (!workspaceId) return 'No workspace bound. Use /bind <name|id> first.';
       const sessions = await service.listSessions(workspaceId);
       if (sessions.length === 0) return 'No sessions yet.';
       const lines = sessions
         .slice(0, 15)
         .map((s) => `${s.isCurrent ? '• (current) ' : '• '}${s.date} — ${s.messageCount} msgs`);
-      return `🗂️ Sessions for ${workspaceId}:\n${lines.join('\n')}`;
+      return `🗂️ Sessions for ${await workspaceLabelById(workspaceId)}:\n${lines.join('\n')}`;
     }
 
     default:

--- a/apps/canvas-workspace/src/plugins/main/channel/core/dedupe.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/core/dedupe.ts
@@ -1,0 +1,29 @@
+/**
+ * Bounded LRU set for idempotent message dedupe. Channels can redeliver the
+ * same event (retries, reconnects); we drop any message whose id we have
+ * already accepted. Capacity-bounded so memory stays flat over a long run.
+ */
+export class MessageDedupe {
+  private readonly seen = new Set<string>();
+  private readonly capacity: number;
+
+  constructor(capacity = 500) {
+    this.capacity = Math.max(1, capacity);
+  }
+
+  /**
+   * Record `id` as seen. Returns true if it is new (caller should process),
+   * false if it was already seen (caller should drop).
+   */
+  accept(id: string): boolean {
+    if (!id) return true; // No id to dedupe on — let it through.
+    if (this.seen.has(id)) return false;
+    this.seen.add(id);
+    if (this.seen.size > this.capacity) {
+      // Sets preserve insertion order; evict the oldest entry.
+      const oldest = this.seen.values().next().value as string | undefined;
+      if (oldest !== undefined) this.seen.delete(oldest);
+    }
+    return true;
+  }
+}

--- a/apps/canvas-workspace/src/plugins/main/channel/core/image-result.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/core/image-result.ts
@@ -1,0 +1,66 @@
+// Detect when a Canvas Agent tool result carries a generated image so a
+// channel can relay it as a native image message. Canvas surfaces tool
+// results as `{ name, result }` where `result` is a JSON-encoded string,
+// so we parse it before inspecting. Returns null for anything that is not
+// recognizably an image payload — relay is strictly best-effort.
+
+interface GeneratedImageResult {
+  outputPath: string;
+  mimeType?: string;
+}
+
+export function extractGeneratedImageResult(toolResult: {
+  name?: string;
+  result?: string;
+}): GeneratedImageResult | null {
+  const toolName = asString(toolResult?.name);
+  const payload = parsePayload(toolResult?.result);
+
+  if (!payload || !isRecord(payload)) return null;
+
+  const outputPath = asString(payload.outputPath);
+  if (!outputPath) return null;
+
+  const mimeType = asString(payload.mimeType) ?? undefined;
+
+  // Accept known image tools; otherwise require the payload to look like a
+  // generated-image result (model + image/* mime + outputPath).
+  const KNOWN_IMAGE_TOOLS = new Set(['generate_image', 'gemini_pro_image']);
+  if (toolName && !KNOWN_IMAGE_TOOLS.has(toolName) && !looksLikeImagePayload(payload)) {
+    return null;
+  }
+  if (!toolName && !looksLikeImagePayload(payload)) {
+    return null;
+  }
+
+  return { outputPath, mimeType };
+}
+
+function parsePayload(result: unknown): unknown {
+  if (isRecord(result)) return result;
+  if (typeof result !== 'string') return null;
+  const trimmed = result.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+}
+
+function looksLikeImagePayload(payload: Record<string, unknown>): boolean {
+  return (
+    asString(payload.outputPath) !== null &&
+    asString(payload.mimeType)?.startsWith('image/') === true
+  );
+}
+
+function asString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/apps/canvas-workspace/src/plugins/main/channel/core/sessions.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/core/sessions.ts
@@ -1,0 +1,62 @@
+import type { CanvasAgentServiceRef, PluginStore } from '../../../types';
+
+const STORE_KEY = 'sessions';
+
+/**
+ * Gives each external conversation its own Canvas Agent session, even when
+ * several conversations share one workspace.
+ *
+ * Canvas keeps a single *current* session per workspace; this router maps
+ * `workspaceId::conversationId → sessionId` and, before each turn, swaps the
+ * workspace's current session to the one owned by the conversation (creating
+ * it on first contact). Because runs are serialized per workspace, the swap
+ * can't race another turn. The map is persisted so conversations keep their
+ * history across restarts.
+ *
+ * Trade-off: the workspace's *current* session is shared with the Canvas UI,
+ * so the UI for that workspace reflects whichever conversation ran last.
+ */
+export class SessionRouter {
+  private map: Record<string, string> = {};
+  private loaded = false;
+
+  constructor(
+    private readonly service: CanvasAgentServiceRef,
+    private readonly store: PluginStore,
+  ) {}
+
+  private async ensureLoaded(): Promise<void> {
+    if (this.loaded) return;
+    this.map = (await this.store.get<Record<string, string>>(STORE_KEY)) ?? {};
+    this.loaded = true;
+  }
+
+  private key(workspaceId: string, conversationId: string): string {
+    return `${workspaceId}::${conversationId}`;
+  }
+
+  /**
+   * Ensure the workspace's current session is the one owned by
+   * `conversationId`. Call inside the per-workspace run guard, before chat.
+   */
+  async ensureSession(workspaceId: string, conversationId: string): Promise<void> {
+    await this.ensureLoaded();
+    const key = this.key(workspaceId, conversationId);
+    const desired = this.map[key];
+
+    if (desired) {
+      if (this.service.getCurrentSessionId(workspaceId) === desired) return;
+      await this.service.loadSession(workspaceId, desired);
+      // loadSession is a no-op when the session no longer exists; confirm it
+      // actually became current, otherwise fall through to a fresh one.
+      if (this.service.getCurrentSessionId(workspaceId) === desired) return;
+    }
+
+    await this.service.newSession(workspaceId);
+    const fresh = this.service.getCurrentSessionId(workspaceId);
+    if (fresh) {
+      this.map[key] = fresh;
+      await this.store.set(STORE_KEY, this.map);
+    }
+  }
+}

--- a/apps/canvas-workspace/src/plugins/main/channel/core/types.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/core/types.ts
@@ -8,7 +8,12 @@
 export interface InboundMessage {
   /** Owning channel id, e.g. 'feishu'. */
   channelId: string;
-  /** Stable conversation identifier within the channel (Feishu chat_id). */
+  /**
+   * Stable *logical* conversation identifier — the unit a binding / session
+   * attaches to. A channel decides its granularity: a Feishu direct chat and
+   * each group are distinct chats, and each topic within a topic group is its
+   * own conversation (chat_id + thread_id).
+   */
   conversationId: string;
   /** Sender identity within the channel (Feishu open_id). */
   userId: string;
@@ -20,11 +25,20 @@ export interface InboundMessage {
   isMention: boolean;
   /** True for 1:1 / direct conversations. */
   isDirect: boolean;
+  /**
+   * Opaque, channel-defined routing info for replies (e.g. Feishu chat_id +
+   * thread_id + the triggering message id, so replies land in the right
+   * topic). The core shuttles this back via {@link OutboundTarget} without
+   * interpreting it.
+   */
+  reply: unknown;
 }
 
-/** Where to send output back. Mirrors the inbound conversation. */
+/** Where to send output back. Carries the inbound conversation's reply routing. */
 export interface OutboundTarget {
   conversationId: string;
+  /** Opaque channel-defined reply routing, copied from the inbound message. */
+  reply: unknown;
 }
 
 /**

--- a/apps/canvas-workspace/src/plugins/main/channel/core/types.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/core/types.ts
@@ -1,0 +1,66 @@
+// Channel-agnostic contracts. A "channel" is an external messaging surface
+// (Feishu today; Discord / Telegram / WeCom later) that delivers inbound
+// messages from a user and renders the agent's streamed output back. The
+// orchestration in `bridge.ts` speaks only this vocabulary — it has no
+// knowledge of any concrete channel.
+
+/** A normalized inbound message, produced by a channel from its raw event. */
+export interface InboundMessage {
+  /** Owning channel id, e.g. 'feishu'. */
+  channelId: string;
+  /** Stable conversation identifier within the channel (Feishu chat_id). */
+  conversationId: string;
+  /** Sender identity within the channel (Feishu open_id). */
+  userId: string;
+  /** Channel-unique message id, used for idempotent dedupe. */
+  messageId: string;
+  /** Plain-text body, already trimmed and stripped of bot @-mentions. */
+  text: string;
+  /** True when this is a group message that @-mentioned the bot. */
+  isMention: boolean;
+  /** True for 1:1 / direct conversations. */
+  isDirect: boolean;
+}
+
+/** Where to send output back. Mirrors the inbound conversation. */
+export interface OutboundTarget {
+  conversationId: string;
+}
+
+/**
+ * A live output sink for a single agent run. The channel decides how each
+ * event renders (Feishu progressively patches one interactive card). All
+ * methods may be async; callers await them so a channel can serialize its
+ * own writes.
+ */
+export interface ChannelStream {
+  onText(delta: string): void | Promise<void>;
+  onToolCall(name: string, args: unknown): void | Promise<void>;
+  onToolResult?(result: { name: string; result: string }): void | Promise<void>;
+  onImage?(imagePath: string, mimeType?: string): void | Promise<void>;
+  onClarification(question: string): void | Promise<void>;
+  onDone(text: string): void | Promise<void>;
+  onError(message: string): void | Promise<void>;
+}
+
+/** Handler the bridge installs to receive a channel's inbound traffic. */
+export type InboundHandler = (msg: InboundMessage) => void;
+
+/**
+ * A concrete messaging channel. Implementations own all platform I/O
+ * (connecting, parsing events into {@link InboundMessage}, sending replies).
+ */
+export interface Channel {
+  /** Stable id, e.g. 'feishu'. */
+  readonly id: string;
+  /** True when the channel has the credentials/config it needs to run. */
+  isConfigured(): boolean;
+  /** Begin receiving events, routing each to `onInbound`. */
+  start(onInbound: InboundHandler): Promise<void>;
+  /** Release the connection and any resources. Safe to call when stopped. */
+  stop(): Promise<void>;
+  /** Open a streaming output sink for one agent run. */
+  openStream(target: OutboundTarget): Promise<ChannelStream>;
+  /** Send a one-off plain-text reply (command output, pre-run notices). */
+  sendText(target: OutboundTarget, text: string): Promise<void>;
+}

--- a/apps/canvas-workspace/src/plugins/main/channel/core/workspaces.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/core/workspaces.ts
@@ -9,14 +9,37 @@ const STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
 
 export interface WorkspaceInfo {
   id: string;
+  /** Friendly name from the workspace manifest, when available. */
+  name?: string;
   /** Last-modified epoch ms of the workspace's canvas.json (0 if unknown). */
   modifiedAt: number;
+  /** True for the workspace currently open/active in the Canvas UI. */
+  isActive: boolean;
+}
+
+interface WorkspaceManifest {
+  workspaces: Array<{ id: string; name: string }>;
+  activeId?: string;
+}
+
+// Friendly names + the UI's active workspace live in a manifest alongside the
+// per-workspace directories. Read it to label workspaces by name (the dirs
+// themselves are random ids).
+async function readManifest(): Promise<WorkspaceManifest> {
+  try {
+    const raw = await fs.readFile(join(STORE_DIR, '__workspaces__.json'), 'utf-8');
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const workspaces = (parsed.workspaces ?? parsed.entries ?? []) as WorkspaceManifest['workspaces'];
+    return { workspaces, activeId: parsed.activeId as string | undefined };
+  } catch {
+    return { workspaces: [] };
+  }
 }
 
 /**
  * Enumerate known canvas workspaces, most-recently-modified first. A
- * directory counts as a workspace when it contains a canvas.json. Returns
- * an empty list when the store does not exist yet.
+ * directory counts as a workspace when it contains a canvas.json; names and
+ * the active marker come from the manifest. Empty when the store is absent.
  */
 export async function listWorkspaces(): Promise<WorkspaceInfo[]> {
   let entries: import('fs').Dirent[];
@@ -27,13 +50,22 @@ export async function listWorkspaces(): Promise<WorkspaceInfo[]> {
     throw err;
   }
 
+  const manifest = await readManifest();
+  const nameById = new Map(manifest.workspaces.map((w) => [w.id, w.name] as const));
+
   const infos: WorkspaceInfo[] = [];
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
+    if (entry.name.startsWith('__') || entry.name.startsWith('.')) continue;
     const canvasPath = join(STORE_DIR, entry.name, 'canvas.json');
     try {
       const stat = await fs.stat(canvasPath);
-      infos.push({ id: entry.name, modifiedAt: stat.mtimeMs });
+      infos.push({
+        id: entry.name,
+        name: nameById.get(entry.name),
+        modifiedAt: stat.mtimeMs,
+        isActive: entry.name === manifest.activeId,
+      });
     } catch {
       // No canvas.json → not a workspace dir; skip.
     }
@@ -43,13 +75,28 @@ export async function listWorkspaces(): Promise<WorkspaceInfo[]> {
   return infos;
 }
 
-/** True when a workspace directory with a canvas.json exists for `id`. */
-export async function workspaceExists(id: string): Promise<boolean> {
-  if (!id) return false;
-  try {
-    await fs.stat(join(STORE_DIR, id, 'canvas.json'));
-    return true;
-  } catch {
-    return false;
-  }
+/** A human label for a workspace: "name (id)" when named, else the id. */
+export function workspaceLabel(w: WorkspaceInfo): string {
+  return w.name ? `${w.name} (${w.id})` : w.id;
+}
+
+/**
+ * Resolve a user-typed workspace reference (id or friendly name, case-
+ * insensitive) to a workspace id, or null when nothing matches.
+ */
+export async function resolveWorkspace(ref: string): Promise<string | null> {
+  const needle = ref.trim();
+  if (!needle) return null;
+  const list = await listWorkspaces();
+  const byId = list.find((w) => w.id === needle);
+  if (byId) return byId.id;
+  const lower = needle.toLowerCase();
+  const byName = list.find((w) => w.name && w.name.toLowerCase() === lower);
+  return byName?.id ?? null;
+}
+
+/** Friendly label for a workspace id (name when known). */
+export async function workspaceLabelById(id: string): Promise<string> {
+  const found = (await listWorkspaces()).find((w) => w.id === id);
+  return found ? workspaceLabel(found) : id;
 }

--- a/apps/canvas-workspace/src/plugins/main/channel/core/workspaces.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/core/workspaces.ts
@@ -1,0 +1,55 @@
+import { promises as fs } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+
+// Canvas persists each workspace under ~/.pulse-coder/canvas/<workspaceId>/
+// with a canvas.json at its root. The main process has no workspace *name*
+// manifest (names live in the renderer), so channels bind by workspace id.
+const STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
+
+export interface WorkspaceInfo {
+  id: string;
+  /** Last-modified epoch ms of the workspace's canvas.json (0 if unknown). */
+  modifiedAt: number;
+}
+
+/**
+ * Enumerate known canvas workspaces, most-recently-modified first. A
+ * directory counts as a workspace when it contains a canvas.json. Returns
+ * an empty list when the store does not exist yet.
+ */
+export async function listWorkspaces(): Promise<WorkspaceInfo[]> {
+  let entries: import('fs').Dirent[];
+  try {
+    entries = await fs.readdir(STORE_DIR, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return [];
+    throw err;
+  }
+
+  const infos: WorkspaceInfo[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const canvasPath = join(STORE_DIR, entry.name, 'canvas.json');
+    try {
+      const stat = await fs.stat(canvasPath);
+      infos.push({ id: entry.name, modifiedAt: stat.mtimeMs });
+    } catch {
+      // No canvas.json → not a workspace dir; skip.
+    }
+  }
+
+  infos.sort((a, b) => b.modifiedAt - a.modifiedAt);
+  return infos;
+}
+
+/** True when a workspace directory with a canvas.json exists for `id`. */
+export async function workspaceExists(id: string): Promise<boolean> {
+  if (!id) return false;
+  try {
+    await fs.stat(join(STORE_DIR, id, 'canvas.json'));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/canvas-workspace/src/plugins/main/channel/index.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/index.ts
@@ -1,0 +1,49 @@
+import type { MainCanvasPlugin, MainCtx } from '../../types';
+import { ChannelBridge } from './core/bridge';
+import type { Channel } from './core/types';
+import { FeishuChannel } from './channels/feishu/feishu-channel';
+
+// Registry of all channel implementations. To add a new channel (Discord,
+// Telegram, WeCom, …) implement the `Channel` interface and add it here —
+// the orchestration in `core/` is channel-agnostic and needs no changes.
+function allChannels(): Channel[] {
+  return [new FeishuChannel()];
+}
+
+/** True when at least one channel has the configuration it needs to run. */
+function anyChannelConfigured(): boolean {
+  return allChannels().some((c) => c.isConfigured());
+}
+
+let bridge: ChannelBridge | null = null;
+
+/**
+ * The "channel" plugin: bridges external messaging channels (Feishu today)
+ * to the workspace Canvas Agent, so a conversation can be driven from chat.
+ * Gated by {@link anyChannelConfigured} so it stays fully inert until a
+ * channel is configured (e.g. FEISHU_APP_ID / FEISHU_APP_SECRET are set).
+ */
+export const ChannelMainPlugin: MainCanvasPlugin = {
+  id: 'channel',
+  enabledWhen: anyChannelConfigured,
+
+  async activate(ctx: MainCtx): Promise<void> {
+    const service = ctx.getAgentService();
+    bridge = new ChannelBridge(service, ctx.store);
+
+    for (const channel of allChannels()) {
+      if (!channel.isConfigured()) continue;
+      try {
+        await bridge.addChannel(channel);
+        console.log(`[channel] started: ${channel.id}`);
+      } catch (err) {
+        console.error(`[channel] failed to start ${channel.id}`, err);
+      }
+    }
+  },
+
+  async deactivate(): Promise<void> {
+    await bridge?.stop();
+    bridge = null;
+  },
+};

--- a/apps/canvas-workspace/src/plugins/main/channel/index.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/index.ts
@@ -1,4 +1,11 @@
+import { readFileSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
 import type { MainCanvasPlugin, MainCtx } from '../../types';
+import {
+  EXPERIMENTAL_FLAG_CHANNELS,
+  resolveFeatureValues,
+} from '../../../shared/experimental-features';
 import { ChannelBridge } from './core/bridge';
 import type { Channel } from './core/types';
 import { FeishuChannel } from './channels/feishu/feishu-channel';
@@ -15,17 +22,47 @@ function anyChannelConfigured(): boolean {
   return allChannels().some((c) => c.isConfigured());
 }
 
+function experimentalFlagsPath(): string {
+  const envPath = process.env.PULSE_CANVAS_EXPERIMENTAL_FEATURES?.trim();
+  return envPath || join(homedir(), '.pulse-coder', 'canvas', 'experimental-features.json');
+}
+
+/**
+ * Synchronous flag read — `enabledWhen` runs at plugin registration time
+ * (before the renderer is up), so we cannot round-trip through IPC. Missing
+ * / unparseable file falls through to registry defaults (flag off → plugin
+ * inactive). Mirrors the dynamic-app plugin's gating.
+ */
+function isChannelsFlagEnabled(): boolean {
+  let overrides: Record<string, boolean> = {};
+  try {
+    const raw = readFileSync(experimentalFlagsPath(), 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+        if (typeof v === 'boolean') overrides[k] = v;
+      }
+    }
+  } catch {
+    overrides = {};
+  }
+  return resolveFeatureValues(overrides)[EXPERIMENTAL_FLAG_CHANNELS] === true;
+}
+
 let bridge: ChannelBridge | null = null;
 
 /**
  * The "channel" plugin: bridges external messaging channels (Feishu today)
  * to the workspace Canvas Agent, so a conversation can be driven from chat.
- * Gated by {@link anyChannelConfigured} so it stays fully inert until a
- * channel is configured (e.g. FEISHU_APP_ID / FEISHU_APP_SECRET are set).
+ *
+ * Gated behind the `chat-channels` experimental flag AND a configured
+ * channel — it stays fully inert unless the user has opted in via
+ * Settings → Experimental and a channel's credentials are present
+ * (e.g. FEISHU_APP_ID / FEISHU_APP_SECRET).
  */
 export const ChannelMainPlugin: MainCanvasPlugin = {
   id: 'channel',
-  enabledWhen: anyChannelConfigured,
+  enabledWhen: () => isChannelsFlagEnabled() && anyChannelConfigured(),
 
   async activate(ctx: MainCtx): Promise<void> {
     const service = ctx.getAgentService();

--- a/apps/canvas-workspace/src/plugins/main/index.ts
+++ b/apps/canvas-workspace/src/plugins/main/index.ts
@@ -1,6 +1,8 @@
 export { agentBus } from './agent-bus';
 export {
   setupCanvasPlugins,
+  teardownCanvasPlugins,
   getRegisteredCanvasToolFactories,
+  setAgentServiceAccessor,
 } from './registry';
 export { BUILT_IN_MAIN_PLUGINS } from './built-in';

--- a/apps/canvas-workspace/src/plugins/main/registry.ts
+++ b/apps/canvas-workspace/src/plugins/main/registry.ts
@@ -1,9 +1,34 @@
 import { ipcMain } from 'electron';
-import type { CanvasToolFactory, MainCanvasPlugin, MainCtx } from '../types';
+import type {
+  CanvasAgentServiceRef,
+  CanvasToolFactory,
+  MainCanvasPlugin,
+  MainCtx,
+} from '../types';
 import { agentBus } from './agent-bus';
 import { createPluginStore } from './plugin-store';
 
 const loaded = new Set<string>();
+
+/**
+ * Accessor for the host's Canvas Agent service, injected by the host
+ * ({@link setAgentServiceAccessor}) before plugins activate. Kept as a lazy
+ * injection — rather than a static import of the agent module — so the
+ * registry's own import graph stays light (the agent pulls in the engine)
+ * and unit-testable in isolation.
+ */
+let agentServiceAccessor: (() => CanvasAgentServiceRef) | null = null;
+
+export function setAgentServiceAccessor(accessor: () => CanvasAgentServiceRef): void {
+  agentServiceAccessor = accessor;
+}
+
+/**
+ * Plugins that activated successfully and expose a `deactivate` hook,
+ * kept so {@link teardownCanvasPlugins} can release their resources
+ * (sockets, timers, external connections) on app shutdown.
+ */
+const deactivators: Array<{ id: string; deactivate: () => void | Promise<void> }> = [];
 
 /**
  * Registered canvas-tool factories, keyed by plugin id so a plugin
@@ -25,10 +50,32 @@ export async function setupCanvasPlugins(plugins: MainCanvasPlugin[]): Promise<v
     try {
       await plugin.activate(createMainCtx(plugin.id));
       loaded.add(plugin.id);
+      if (plugin.deactivate) {
+        deactivators.push({ id: plugin.id, deactivate: plugin.deactivate.bind(plugin) });
+      }
     } catch (err) {
       console.error(`[canvas-plugins] activate failed for ${plugin.id}`, err);
     }
   }
+}
+
+/**
+ * Tear down activated plugins that registered a `deactivate` hook. Called
+ * on app shutdown (window-all-closed). Each hook is isolated so one failing
+ * teardown does not block the others. Safe to call multiple times — the
+ * deactivator list is drained as it runs.
+ */
+export async function teardownCanvasPlugins(): Promise<void> {
+  const pending = deactivators.splice(0, deactivators.length);
+  await Promise.all(
+    pending.map(async ({ id, deactivate }) => {
+      try {
+        await deactivate();
+      } catch (err) {
+        console.error(`[canvas-plugins] deactivate failed for ${id}`, err);
+      }
+    }),
+  );
 }
 
 /**
@@ -54,6 +101,15 @@ function createMainCtx(pluginId: string): MainCtx {
       return () => {
         agentBus.off(event, handler);
       };
+    },
+    getAgentService(): CanvasAgentServiceRef {
+      if (!agentServiceAccessor) {
+        throw new Error(
+          '[canvas-plugins] agent service accessor not configured; ' +
+            'call setAgentServiceAccessor() before activating plugins',
+        );
+      }
+      return agentServiceAccessor();
     },
     registerCanvasTool(factory) {
       if (canvasToolFactories.has(pluginId)) {

--- a/apps/canvas-workspace/src/plugins/types.ts
+++ b/apps/canvas-workspace/src/plugins/types.ts
@@ -83,7 +83,11 @@ export interface CanvasAgentServiceRef {
   abort(workspaceId: string): void;
   answerClarification(workspaceId: string, requestId: string, answer: string): boolean;
   getStatus(workspaceId: string): AgentStatusInfo;
+  /** Current session id for the workspace, or null when none is active. */
+  getCurrentSessionId(workspaceId: string): string | null;
   newSession(workspaceId: string): Promise<{ ok: boolean; error?: string }>;
+  /** Swap the workspace's current session to an existing one by id. */
+  loadSession(workspaceId: string, sessionId: string): Promise<{ ok: boolean; error?: string }>;
   listSessions(workspaceId: string): Promise<AgentSessionInfo[]>;
 }
 

--- a/apps/canvas-workspace/src/plugins/types.ts
+++ b/apps/canvas-workspace/src/plugins/types.ts
@@ -25,6 +25,68 @@ export interface PluginStore {
   list(prefix?: string): Promise<string[]>;
 }
 
+// ── Canvas-agent service handle (structural) ────────────────────────────────
+//
+// A narrow, structural view of the host's `CanvasAgentService` exposed to
+// plugins via `MainCtx.getAgentService()`. Declared here (not imported from
+// main) so this shared types file stays free of host/electron imports — the
+// registry casts the real singleton to this shape at the boundary. Only the
+// methods a plugin legitimately needs to *drive* a conversation are surfaced.
+export interface AgentChatResult {
+  ok: boolean;
+  response?: string;
+  runId?: string;
+  error?: string;
+}
+
+export interface AgentClarificationRequest {
+  id: string;
+  question: string;
+  context?: string;
+}
+
+export interface AgentToolCallInfo {
+  name: string;
+  args: unknown;
+  toolCallId?: string;
+}
+
+export interface AgentToolResultInfo {
+  name: string;
+  result: string;
+  toolCallId?: string;
+}
+
+export interface AgentStatusInfo {
+  ok: boolean;
+  active: boolean;
+  messageCount: number;
+}
+
+export interface AgentSessionInfo {
+  sessionId: string;
+  date: string;
+  messageCount: number;
+  isCurrent: boolean;
+}
+
+export interface CanvasAgentServiceRef {
+  chat(
+    workspaceId: string,
+    message: string,
+    onText?: (delta: string) => void,
+    onToolCall?: (data: AgentToolCallInfo) => void,
+    onToolResult?: (data: AgentToolResultInfo) => void,
+    mentionedWorkspaceIds?: string[],
+    onClarificationRequest?: (req: AgentClarificationRequest) => void,
+  ): Promise<AgentChatResult>;
+  abort(workspaceId: string): void;
+  answerClarification(workspaceId: string, requestId: string, answer: string): boolean;
+  getStatus(workspaceId: string): AgentStatusInfo;
+  newSession(workspaceId: string): Promise<{ ok: boolean; error?: string }>;
+  listSessions(workspaceId: string): Promise<AgentSessionInfo[]>;
+}
+
 // Subset of Electron's IpcMainInvokeEvent the plugin contract needs.
 // Defined inline so the shared types file does not import 'electron',
 // which is only valid in the main tsconfig.
@@ -46,6 +108,13 @@ export interface MainCtx {
   // existing host IPC.
   handle(channel: string, handler: PluginIpcHandler): void;
   onAgent(event: AgentEvent, handler: (turn: AgentTurn) => void): () => void;
+  /**
+   * Access the host's Canvas Agent service singleton. Lets a plugin *drive*
+   * conversations (e.g. relay a chat turn from an external channel) rather
+   * than only observe them via {@link onAgent}. Returns a narrow structural
+   * view — see {@link CanvasAgentServiceRef}.
+   */
+  getAgentService(): CanvasAgentServiceRef;
   /**
    * Register a factory that contributes canvas-agent tools. The factory
    * is invoked once per workspace at canvas-agent construction time —
@@ -134,6 +203,12 @@ export interface MainCanvasPlugin {
   id: string;
   enabledWhen?: () => boolean;
   activate(ctx: MainCtx): void | Promise<void>;
+  /**
+   * Optional teardown, called on app shutdown for plugins that hold
+   * long-lived resources (sockets, timers, external connections). Only
+   * invoked for plugins that activated successfully.
+   */
+  deactivate?(): void | Promise<void>;
 }
 
 export interface RendererCanvasPlugin {

--- a/apps/canvas-workspace/src/preload/bridge/settings.ts
+++ b/apps/canvas-workspace/src/preload/bridge/settings.ts
@@ -3,6 +3,7 @@ import type {
   CanvasMcpApi,
   CanvasModelApi,
   CanvasSkillsApi,
+  ChannelConfigApi,
   DialogApi,
   ExperimentalApi,
   PromptProfileApi,
@@ -60,6 +61,16 @@ export const createExperimentalApi = (ipcRenderer: IpcRenderer): ExperimentalApi
   reset: () => ipcRenderer.invoke("experimental:reset"),
 
   reloadWindow: () => ipcRenderer.invoke("experimental:reload-window")
+});
+
+export const createChannelConfigApi = (ipcRenderer: IpcRenderer): ChannelConfigApi => ({
+  status: () => ipcRenderer.invoke("channel-config:status"),
+
+  setFeishu: (input) => ipcRenderer.invoke("channel-config:set-feishu", input),
+
+  clearFeishu: () => ipcRenderer.invoke("channel-config:clear-feishu"),
+
+  relaunch: () => ipcRenderer.invoke("channel-config:relaunch")
 });
 
 export const createPromptProfileApi = (ipcRenderer: IpcRenderer): PromptProfileApi => ({

--- a/apps/canvas-workspace/src/preload/index.ts
+++ b/apps/canvas-workspace/src/preload/index.ts
@@ -10,6 +10,7 @@ import { createPtyApi } from "./bridge/pty";
 import {
   createCanvasMcpApi,
   createCanvasSkillsApi,
+  createChannelConfigApi,
   createDialogApi,
   createExperimentalApi,
   createModelApi,
@@ -41,6 +42,7 @@ const canvasWorkspace: CanvasWorkspaceApi = {
   canvasSkills: createCanvasSkillsApi(ipcRenderer),
   canvasMcp: createCanvasMcpApi(ipcRenderer),
   experimental: createExperimentalApi(ipcRenderer),
+  channelConfig: createChannelConfigApi(ipcRenderer),
   iframe: createIframeApi(ipcRenderer),
   shell: createShellApi(ipcRenderer),
   link: createLinkApi(ipcRenderer),

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/ChannelConfigPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/ChannelConfigPanel.css
@@ -1,0 +1,115 @@
+.experimental-section-config-row {
+  display: block;
+  width: 100%;
+  list-style: none;
+}
+
+.channel-config-panel {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 14px 16px;
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.1));
+  border-radius: 10px;
+  background: var(--surface-2, rgba(255, 255, 255, 0.03));
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.channel-config-title {
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.channel-config-hint {
+  font-size: 12px;
+  opacity: 0.7;
+  line-height: 1.5;
+}
+
+.channel-config-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+}
+
+.channel-config-field > span {
+  opacity: 0.85;
+}
+
+.channel-config-optional {
+  opacity: 0.55;
+}
+
+.channel-config-field input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 7px 10px;
+  border-radius: 7px;
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.14));
+  background: var(--surface-1, rgba(0, 0, 0, 0.2));
+  color: inherit;
+  font-size: 13px;
+  font-family: inherit;
+}
+
+.channel-config-field input:focus {
+  outline: none;
+  border-color: var(--accent, #6aa3ff);
+}
+
+.channel-config-env {
+  color: var(--warning, #e0a23c);
+  font-size: 11px;
+}
+
+.channel-config-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+.channel-config-btn {
+  padding: 6px 14px;
+  border-radius: 7px;
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.18));
+  background: transparent;
+  color: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.channel-config-btn:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.channel-config-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.channel-config-btn--primary {
+  border-color: var(--accent, #6aa3ff);
+  background: var(--accent, #6aa3ff);
+  color: #fff;
+}
+
+.channel-config-relaunch {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+  padding: 8px 10px;
+  border-radius: 7px;
+  background: rgba(106, 163, 255, 0.12);
+}
+
+.channel-config-path {
+  font-size: 11px;
+  opacity: 0.55;
+}
+
+.channel-config-path code {
+  font-size: 11px;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/ChannelConfigPanel.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/ChannelConfigPanel.tsx
@@ -1,0 +1,172 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { ChannelConfigStatus } from '../../types';
+import { useAppShell } from '../AppShellProvider';
+import './ChannelConfigPanel.css';
+
+/**
+ * Feishu credential editor shown under the "Chat channels" experimental
+ * toggle. Lets the user configure FEISHU_APP_ID / FEISHU_APP_SECRET (and an
+ * optional default workspace) from the UI instead of shell env vars. The
+ * secret is stored encrypted in the main process and never echoed back.
+ * Changes require a relaunch to take effect.
+ */
+export const ChannelConfigPanel = () => {
+  const { notify } = useAppShell();
+  const [status, setStatus] = useState<ChannelConfigStatus | null>(null);
+  const [appId, setAppId] = useState('');
+  const [appSecret, setAppSecret] = useState('');
+  const [defaultWorkspaceId, setDefaultWorkspaceId] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState(false);
+  const [needsRelaunch, setNeedsRelaunch] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await window.canvasWorkspace.channelConfig.status();
+      if (res.ok && res.status) {
+        setStatus(res.status);
+        setAppId(res.status.feishu.appId ?? '');
+        setDefaultWorkspaceId(res.status.feishu.defaultWorkspaceId ?? '');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const save = useCallback(async () => {
+    setSaving(true);
+    try {
+      const res = await window.canvasWorkspace.channelConfig.setFeishu({
+        appId,
+        // Only send the secret when the user typed a new one; an empty
+        // field leaves the stored secret untouched.
+        appSecret: appSecret.trim() ? appSecret : undefined,
+        defaultWorkspaceId,
+      });
+      if (!res.ok) {
+        notify({ tone: 'error', title: 'Save failed', description: res.error ?? 'Unknown error' });
+        return;
+      }
+      if (res.status) setStatus(res.status);
+      setAppSecret('');
+      setDirty(false);
+      setNeedsRelaunch(true);
+      notify({ tone: 'success', title: 'Feishu credentials saved', description: 'Relaunch to apply.' });
+    } catch (err) {
+      notify({ tone: 'error', title: 'Save failed', description: err instanceof Error ? err.message : String(err) });
+    } finally {
+      setSaving(false);
+    }
+  }, [appId, appSecret, defaultWorkspaceId, notify]);
+
+  const clearSecret = useCallback(async () => {
+    const res = await window.canvasWorkspace.channelConfig.setFeishu({ clearSecret: true });
+    if (res.ok) {
+      if (res.status) setStatus(res.status);
+      setAppSecret('');
+      setNeedsRelaunch(true);
+      notify({ tone: 'success', title: 'Secret cleared', description: 'Relaunch to apply.' });
+    } else {
+      notify({ tone: 'error', title: 'Clear failed', description: res.error ?? 'Unknown error' });
+    }
+  }, [notify]);
+
+  const relaunch = useCallback(() => {
+    void window.canvasWorkspace.channelConfig.relaunch();
+  }, []);
+
+  const onChange = (setter: (v: string) => void) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    setter(e.target.value);
+    setDirty(true);
+  };
+
+  if (loading) {
+    return <div className="channel-config-panel">Loading…</div>;
+  }
+
+  const feishu = status?.feishu;
+  const secretPlaceholder = feishu?.secretPresent ? '•••••••• (saved — leave blank to keep)' : 'Enter app secret';
+
+  return (
+    <div className="channel-config-panel">
+      <div className="channel-config-title">Feishu credentials</div>
+      <div className="channel-config-hint">
+        Configure the Feishu app here instead of shell env vars. Stored locally; the secret is
+        encrypted. Env vars (FEISHU_APP_ID / FEISHU_APP_SECRET), if set, take precedence.
+      </div>
+
+      <label className="channel-config-field">
+        <span>App ID</span>
+        <input
+          type="text"
+          value={appId}
+          placeholder="cli_xxxxxxxx"
+          onChange={onChange(setAppId)}
+          spellCheck={false}
+          autoComplete="off"
+        />
+        {feishu?.appIdFromEnv && <small className="channel-config-env">Overridden by FEISHU_APP_ID env var</small>}
+      </label>
+
+      <label className="channel-config-field">
+        <span>App Secret</span>
+        <input
+          type="password"
+          value={appSecret}
+          placeholder={secretPlaceholder}
+          onChange={onChange(setAppSecret)}
+          spellCheck={false}
+          autoComplete="off"
+        />
+        {feishu?.secretFromEnv && <small className="channel-config-env">Overridden by FEISHU_APP_SECRET env var</small>}
+      </label>
+
+      <label className="channel-config-field">
+        <span>Default workspace id <span className="channel-config-optional">(optional)</span></span>
+        <input
+          type="text"
+          value={defaultWorkspaceId}
+          placeholder="most-recently-modified workspace if blank"
+          onChange={onChange(setDefaultWorkspaceId)}
+          spellCheck={false}
+          autoComplete="off"
+        />
+        {feishu?.defaultWorkspaceFromEnv && (
+          <small className="channel-config-env">Overridden by CANVAS_FEISHU_DEFAULT_WORKSPACE env var</small>
+        )}
+      </label>
+
+      <div className="channel-config-actions">
+        <button type="button" className="channel-config-btn channel-config-btn--primary" onClick={() => void save()} disabled={saving || !dirty}>
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+        {feishu?.secretPresent && !feishu?.secretFromEnv && (
+          <button type="button" className="channel-config-btn" onClick={() => void clearSecret()}>
+            Clear secret
+          </button>
+        )}
+      </div>
+
+      {needsRelaunch && (
+        <div className="channel-config-relaunch">
+          <span>Relaunch Canvas to apply.</span>
+          <button type="button" className="channel-config-btn channel-config-btn--primary" onClick={relaunch}>
+            Relaunch now
+          </button>
+        </div>
+      )}
+
+      {status?.path && (
+        <div className="channel-config-path">
+          Stored at <code>{status.path}</code>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/ChannelConfigPanel.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/ChannelConfigPanel.tsx
@@ -132,7 +132,7 @@ export const ChannelConfigPanel = () => {
         <input
           type="text"
           value={defaultWorkspaceId}
-          placeholder="most-recently-modified workspace if blank"
+          placeholder="suggested for /bind — not auto-applied"
           onChange={onChange(setDefaultWorkspaceId)}
           spellCheck={false}
           autoComplete="off"

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/ExperimentalSection.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/ExperimentalSection.tsx
@@ -1,7 +1,9 @@
-import { useCallback, useEffect, useState } from 'react';
+import { Fragment, useCallback, useEffect, useState } from 'react';
 import type { ExperimentalFeatureDef } from '../../types';
+import { EXPERIMENTAL_FLAG_CHANNELS } from '../../../../shared/experimental-features';
 import { useAppShell } from '../AppShellProvider';
 import { useI18n } from '../../i18n';
+import { ChannelConfigPanel } from './ChannelConfigPanel';
 import './ExperimentalSection.css';
 
 interface ExperimentalSectionProps {
@@ -156,8 +158,11 @@ export const ExperimentalSection = ({ onClose }: ExperimentalSectionProps) => {
             {features.map((feature) => {
               const enabled = !!values[feature.id];
               const busy = !!pending[feature.id];
+              const showChannelConfig =
+                feature.id === EXPERIMENTAL_FLAG_CHANNELS && enabled;
               return (
-                <li key={feature.id} className="experimental-section-item">
+                <Fragment key={feature.id}>
+                <li className="experimental-section-item">
                   <div className="experimental-section-item-body">
                     <div className="experimental-section-item-label">{feature.label}</div>
                     <div className="experimental-section-item-desc">{feature.description}</div>
@@ -183,6 +188,12 @@ export const ExperimentalSection = ({ onClose }: ExperimentalSectionProps) => {
                     </span>
                   </label>
                 </li>
+                {showChannelConfig && (
+                  <li className="experimental-section-config-row">
+                    <ChannelConfigPanel />
+                  </li>
+                )}
+                </Fragment>
               );
             })}
           </ul>

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -1133,6 +1133,7 @@ export interface CanvasWorkspaceApi {
   canvasSkills: CanvasSkillsApi;
   canvasMcp: CanvasMcpApi;
   experimental: ExperimentalApi;
+  channelConfig: ChannelConfigApi;
   model: CanvasModelApi;
   promptProfile: PromptProfileApi;
   agent: AgentApi;
@@ -1168,6 +1169,37 @@ export interface ExperimentalApi {
     Promise<{ ok: boolean; values?: Record<string, boolean>; error?: string }>;
   reset: () => Promise<{ ok: boolean; values?: Record<string, boolean>; error?: string }>;
   reloadWindow: () => Promise<{ ok: boolean; error?: string }>;
+}
+
+export interface ChannelConfigStatus {
+  path: string;
+  feishu: {
+    appId?: string;
+    secretPresent: boolean;
+    defaultWorkspaceId?: string;
+    appIdFromEnv: boolean;
+    secretFromEnv: boolean;
+    defaultWorkspaceFromEnv: boolean;
+  };
+}
+
+export interface SetFeishuConfigInput {
+  appId?: string;
+  /** New secret to store. Empty/omitted leaves the existing secret untouched. */
+  appSecret?: string;
+  defaultWorkspaceId?: string;
+  /** When true, remove the stored secret. */
+  clearSecret?: boolean;
+}
+
+export interface ChannelConfigApi {
+  status: () => Promise<{ ok: boolean; status?: ChannelConfigStatus; error?: string }>;
+  setFeishu: (
+    input: SetFeishuConfigInput,
+  ) => Promise<{ ok: boolean; status?: ChannelConfigStatus; error?: string }>;
+  clearFeishu: () => Promise<{ ok: boolean; status?: ChannelConfigStatus; error?: string }>;
+  /** Relaunch the app so credential / flag changes take effect. */
+  relaunch: () => Promise<{ ok: boolean; error?: string }>;
 }
 
 export interface LinkApi {

--- a/apps/canvas-workspace/src/shared/experimental-features.ts
+++ b/apps/canvas-workspace/src/shared/experimental-features.ts
@@ -35,6 +35,7 @@ export const EXPERIMENTAL_FLAG_WORKSPACE_NODES = 'workspace-nodes-page';
 export const EXPERIMENTAL_FLAG_WORKSPACE_GRAPH = 'workspace-graph-page';
 export const EXPERIMENTAL_FLAG_WEBVIEW_PAGE_CONTROL = 'webview-page-control';
 export const EXPERIMENTAL_FLAG_DYNAMIC_APP = 'dynamic-app';
+export const EXPERIMENTAL_FLAG_CHANNELS = 'chat-channels';
 
 export const EXPERIMENTAL_FEATURES: ExperimentalFeatureDef[] = [
   {
@@ -70,6 +71,13 @@ export const EXPERIMENTAL_FEATURES: ExperimentalFeatureDef[] = [
     label: 'Dynamic apps (agent)',
     description:
       'Lets the Canvas Agent create live, server-backed iframe nodes — either polling apps (pull an external JSON endpoint on a schedule, optionally transform, render in LLM-authored HTML) or stateful apps (own their state, accept user mutations via POST actions, persist across restarts; todos / notes / counters / small forms). Each app gets its own loopback HTTP server in the Electron main process. LLM-authored transforms and action handlers run in a vm sandbox (no fetch / require / process; 1s sync timeout). State and spec files live under ~/.pulse-coder/canvas/<workspaceId>/dynamic-apps/. Off by default because this surfaces three new agent tools and a long-running HTTP server.',
+    defaultEnabled: false,
+  },
+  {
+    id: EXPERIMENTAL_FLAG_CHANNELS,
+    label: 'Chat channels (Feishu)',
+    description:
+      'Drive a workspace’s Canvas Agent from an external chat channel. Feishu (Lark) is supported today via the SDK long-connection (works behind NAT, no public URL). Also requires FEISHU_APP_ID / FEISHU_APP_SECRET env vars set before launch; without them the channel stays inactive even when this flag is on. Inbound messages are bound to a workspace (default + switchable via /bind), the agent runs, and output streams back as an interactive card. Off by default because it opens an outbound connection to Feishu and lets a remote chat drive the agent.',
     defaultEnabled: false,
   },
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^3.0.21
         version: 3.0.21(zod@4.3.6)
+      '@larksuiteoapi/node-sdk':
+        specifier: ^1.59.0
+        version: 1.59.0
       '@tiptap/extension-bubble-menu':
         specifier: ^3.20.4
         version: 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2)
@@ -84,7 +87,7 @@ importers:
         specifier: ^6.0.57
         version: 6.0.57(zod@4.3.6)
       fflate:
-        specifier: ^0.8.3
+        specifier: ^0.8.2
         version: 0.8.3
       highlight.js:
         specifier: ^11.11.1
@@ -4053,18 +4056,6 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.19.0:
-    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
@@ -4647,7 +4638,7 @@ snapshots:
       lodash.pickby: 4.6.0
       protobufjs: 7.5.4
       qs: 6.15.0
-      ws: 8.19.0
+      ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -7978,8 +7969,6 @@ snapshots:
       strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}
-
-  ws@8.19.0: {}
 
   ws@8.20.0: {}
 


### PR DESCRIPTION
Introduce a "channel" plugin for canvas-workspace that bridges external
messaging channels to the workspace Canvas Agent, so a conversation can be
driven from chat. Feishu is the first channel; the orchestration core is
channel-agnostic so more channels can be added by implementing one interface.

How it works:
- Feishu events arrive over the SDK's long-connection (WSClient) — the app
  dials out, so it works behind NAT with no public webhook URL.
- Inbound messages are normalized, deduped, and resolved to a canvas
  workspace via a "default + switchable" binding (persisted in the plugin
  store; /bind, /default, /ws, /list, /new, /stop, /sessions commands).
- The bridge drives CanvasAgentService.chat() and streams output back as a
  progressively-patched Feishu interactive card; generated images are sent
  as separate messages; clarification round-trips and abort are supported.
- Gated by enabledWhen: stays fully inert until FEISHU_APP_ID/SECRET are set.

Canvas plugin-system extensions (small, backward-compatible):
- MainCtx.getAgentService() exposes the host agent service to plugins,
  injected by the host via setAgentServiceAccessor() in bootstrap.
- MainCanvasPlugin.deactivate() optional teardown, run on window-all-closed,
  to release the long-lived channel connection.

Self-contained: copies the Feishu helpers rather than importing or modifying
apps/remote-server. Adds unit tests for dedupe, binding, and commands.

https://claude.ai/code/session_018zHtMeZRsUqA4EQRiXookM