### PR TITLE
fix(canvas): make agent panel text easy to select and copy

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent, type SyntheticEvent } from 'react';
 import type { AgentChatMessage, CanvasNode } from '../../types';
 import { toFileUrl } from '../../utils/fileUrl';
-import { AvatarIcon, CheckIcon, CopyIcon, PencilIcon, RefreshIcon } from '../icons';
+import { AvatarIcon, CheckIcon, CopyIcon, PencilIcon, RefreshIcon, SparklesIcon } from '../icons';
 import type { ToolCallStatus } from './types';
 import { renderMdWithMentions } from './utils/mentions';
 import { renderMermaidIn } from './utils/mermaid';
@@ -191,11 +191,9 @@ export const ChatMessage = ({
 
   return (
     <div className={`chat-message chat-message-${message.role}`} id={anchorId}>
-    {message.role === 'assistant' && (
-      <div className="chat-message-avatar">
-        <AvatarIcon size={14} />
-      </div>
-    )}
+    <div className="chat-message-avatar">
+      {message.role === 'assistant' ? <SparklesIcon size={14} /> : <AvatarIcon size={14} />}
+    </div>
     <div className="chat-message-body">
       {message.attachments && message.attachments.length > 0 && (
         <div className="chat-message-images">

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
@@ -3,7 +3,7 @@ import type { AgentChatMessage, CanvasNode } from '../../types';
 import { toFileUrl } from '../../utils/fileUrl';
 import { AvatarIcon, CheckIcon, CopyIcon, PencilIcon, RefreshIcon } from '../icons';
 import type { ToolCallStatus } from './types';
-import { renderMdWithMentions, renderUserContent } from './utils/mentions';
+import { renderMdWithMentions } from './utils/mentions';
 import { renderMermaidIn } from './utils/mermaid';
 import { formatAbsoluteTime, formatRelativeTime } from './utils/time';
 import { ChatToolCalls } from './ChatToolCalls';
@@ -111,10 +111,15 @@ export const ChatMessage = ({
       : ''),
     [message.role, message.content, nodes],
   );
-  const userBody = useMemo(
+  // User messages used to render as raw text (mentions only), so any
+  // pasted code / SQL / markdown showed up as an unstyled, mid-word-wrapped
+  // wall. Render them through the same markdown pipeline as assistant
+  // replies so fenced code blocks, lists, etc. render properly. Mention
+  // chips still work via event delegation in ChatMessages.
+  const userHtml = useMemo(
     () => (message.role === 'user'
-      ? renderUserContent(message.content, nodes)
-      : null),
+      ? renderMdWithMentions(message.content, nodes)
+      : ''),
     [message.role, message.content, nodes],
   );
   const showCopyToolbar = message.role === 'assistant'
@@ -348,7 +353,10 @@ export const ChatMessage = ({
           </div>
         </div>
       ) : (
-        <div className="chat-message-content">{userBody}</div>
+        <div
+          className="chat-message-content chat-md"
+          dangerouslySetInnerHTML={{ __html: userHtml }}
+        />
       )}
       <PluginChatCardForMessage message={message} />
       {!isEditing && (showCopyToolbar || canEdit || canRegenerate || relativeTime) && (

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessages.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessages.tsx
@@ -139,8 +139,33 @@ export const ChatMessages = ({
 }: ChatMessagesProps) => {
   const { t } = useI18n();
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  // Whether the viewport is pinned to the bottom. Once the user scrolls up
+  // (to read or select earlier text) we stop yanking them back down on every
+  // streamed chunk — otherwise copying text mid-response is impossible.
+  const stickToBottomRef = useRef(true);
+
+  const handleScroll = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    stickToBottomRef.current = distanceFromBottom < 80;
+  }, []);
 
   useEffect(() => {
+    // Never fight an active text selection inside the chat: a smooth scroll
+    // would collapse it, so selecting + copying while the agent streams would
+    // be impossible.
+    const selection = window.getSelection();
+    if (
+      selection
+      && !selection.isCollapsed
+      && selection.anchorNode
+      && containerRef.current?.contains(selection.anchorNode)
+    ) {
+      return;
+    }
+    if (!stickToBottomRef.current) return;
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages, pendingClarify, streamingTools]);
 
@@ -181,7 +206,7 @@ export const ChatMessages = ({
     && messages[messages.length - 1].role === 'assistant';
 
   return (
-    <div className="chat-messages" onClick={handleMessageClick}>
+    <div className="chat-messages" ref={containerRef} onScroll={handleScroll} onClick={handleMessageClick}>
       {messages.map((message, index) => {
         const isStreaming = loading && message.role === 'assistant' && index === messages.length - 1;
         const tools = isStreaming ? streamingTools : (messageTools.get(index) ?? message.toolCalls);

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
@@ -1,3 +1,49 @@
+/* ─── Design tokens ───────────────────────────────────────────
+   The chat surface is built on one warm near-black "ink" plus a small
+   set of tints, surfaces, radii and spacing steps. Historically these
+   were hand-inlined (dozens of `rgba(55, 53, 47, x)`, repeated mono
+   font stacks, ad-hoc radii), which made consistent tuning hard. New
+   and migrated rules reference these tokens so spacing/colour can be
+   adjusted in one place. */
+:root {
+  /* Ink — solid + opacity tints, brightest → faintest */
+  --chat-ink: #37352f;
+  --chat-ink-strong: #2f2e2a;
+  --chat-ink-2: rgba(55, 53, 47, 0.55);
+  --chat-ink-3: rgba(55, 53, 47, 0.42);
+  --chat-ink-4: rgba(55, 53, 47, 0.3);
+
+  /* Fills & hairlines */
+  --chat-fill: rgba(55, 53, 47, 0.06);
+  --chat-fill-hover: rgba(55, 53, 47, 0.04);
+  --chat-line: rgba(55, 53, 47, 0.1);
+  --chat-line-strong: rgba(55, 53, 47, 0.16);
+  --chat-surface: #fff;
+  --chat-surface-sunken: rgba(55, 53, 47, 0.03);
+  --chat-bubble-bg: rgba(55, 53, 47, 0.06);
+
+  /* Accents */
+  --chat-accent: #2383e2;
+  --chat-accent-hover: #1f76cc;
+  --chat-success-bg: rgba(46, 160, 67, 0.12);
+  --chat-success-fg: #2f8a3d;
+  --chat-success-line: rgba(46, 160, 67, 0.2);
+
+  /* Radii */
+  --chat-radius-sm: 6px;
+  --chat-radius-md: 10px;
+  --chat-radius-lg: 12px;
+
+  /* Spacing steps */
+  --chat-space-1: 4px;
+  --chat-space-2: 8px;
+  --chat-space-3: 12px;
+  --chat-space-4: 18px;
+
+  /* Monospace stack for code / tool signatures */
+  --chat-mono: 'SF Mono', 'Fira Code', 'Fira Mono', Menlo, monospace;
+}
+
 /* ─── Panel container ─────────────────────────────────────── */
 
 .chat-panel {
@@ -903,7 +949,7 @@
 }
 
 .chat-md code {
-  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+  font-family: var(--chat-mono);
   font-size: 0.9em;
   background: rgba(55, 53, 47, 0.06);
   padding: 1px 4px;
@@ -990,7 +1036,7 @@
   border-radius: 8px;
   background: #fafaf8;
   overflow: hidden;
-  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+  font-family: var(--chat-mono);
 }
 
 .chat-code-block-header {
@@ -1267,7 +1313,7 @@
 }
 
 .chat-mermaid-error-detail {
-  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+  font-family: var(--chat-mono);
   font-size: 11px;
   color: rgba(139, 47, 42, 0.85);
   white-space: pre-wrap;
@@ -1353,6 +1399,25 @@
   padding: 4px 4px 4px 0;
 }
 
+/* Expanded tool activity reads as a timeline: a faint vertical guide
+   line runs through the step markers (the check / spinner icons), so a
+   burst of tool calls scans as one connected sequence rather than a
+   loose stack of rows. The collapsed pill variant opts out. */
+.chat-tool-calls:not(.chat-tool-calls--collapsed) {
+  position: relative;
+}
+
+.chat-tool-calls:not(.chat-tool-calls--collapsed)::before {
+  content: '';
+  position: absolute;
+  left: 7px;
+  top: 11px;
+  bottom: 11px;
+  width: 1px;
+  background: var(--chat-line);
+  pointer-events: none;
+}
+
 .chat-tool-calls--collapsed {
   max-height: none;
   overflow: visible;
@@ -1424,6 +1489,12 @@
   flex-shrink: 0;
   width: 14px;
   height: 14px;
+  /* Sit as a node on the timeline line: a panel-coloured backing masks
+     the guide line behind the marker so it reads as on the line, not
+     crossed out by it. */
+  position: relative;
+  background: #fdfcfb;
+  border-radius: 50%;
 }
 
 .chat-tool-call-spinner {
@@ -1435,7 +1506,7 @@
 }
 
 .chat-tool-call-sig {
-  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', Menlo, monospace;
+  font-family: var(--chat-mono);
   font-size: 11.5px;
   color: rgba(55, 53, 47, 0.55);
   overflow: hidden;
@@ -1485,7 +1556,7 @@
 
 .chat-tool-call-result pre {
   margin: 0;
-  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', Menlo, monospace;
+  font-family: var(--chat-mono);
   font-size: 11px;
   line-height: 1.5;
   color: rgba(55, 53, 47, 0.6);
@@ -1500,7 +1571,7 @@
 }
 
 .chat-tool-call-section-label {
-  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', Menlo, monospace;
+  font-family: var(--chat-mono);
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -2278,7 +2349,7 @@
 }
 
 .chat-model-field .chat-model-protocol-sub {
-  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', Menlo, monospace;
+  font-family: var(--chat-mono);
   font-size: 11px;
   color: rgba(55, 53, 47, 0.5);
   font-weight: 500;

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
@@ -360,16 +360,23 @@
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  /* The hover toolbar is absolutely positioned at top:100% below each
-     bubble (out of flow), so this gap IS the visible spacing between
-     messages. Toolbar overlays the gap on hover. */
-  gap: 10px;
+  /* Inter-message spacing. Each message reserves its own room for the
+     hover toolbar via `padding-bottom` (see `.chat-message`), so the gap
+     here is just the breathing room between one message's toolbar zone
+     and the next bubble. */
+  gap: 4px;
 }
 
 .chat-message {
   display: flex;
   gap: 8px;
   align-items: flex-start;
+  /* Reserve room for the hover toolbar, which is absolutely positioned at
+     `top:100%` of the body. Without this the toolbar (~24px tall) spilled
+     onto the NEXT message, so its copy / regenerate buttons looked like
+     they belonged to the following bubble. Keeping the space inside this
+     message's own box anchors the toolbar to the right message. */
+  padding-bottom: 24px;
 }
 
 .chat-message-user {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
@@ -366,24 +366,33 @@
   max-width: 310px;
 }
 
+/* Starter prompts read as tappable chips at rest (a hairline + surface),
+   not bare rows that only reveal themselves on hover — so the empty
+   state invites a first action. */
 .chat-quick-action {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 8px 6px;
-  border: none;
-  background: transparent;
-  border-radius: 7px;
+  padding: 9px 12px;
+  border: 1px solid var(--chat-line);
+  background: var(--chat-surface);
+  border-radius: var(--chat-radius-md);
   cursor: pointer;
   font-size: 14px;
   font-weight: 500;
-  color: #37352f;
+  color: var(--chat-ink);
   text-align: left;
-  transition: background 0.1s;
+  transition: background 0.12s, border-color 0.12s, transform 0.12s;
 }
 
 .chat-quick-action:hover {
-  background: rgba(55, 53, 47, 0.04);
+  background: var(--chat-fill-hover);
+  border-color: var(--chat-line-strong);
+  transform: translateY(-1px);
+}
+
+.chat-quick-action:active {
+  transform: translateY(0);
 }
 
 .chat-quick-action-icon {
@@ -392,7 +401,7 @@
   justify-content: center;
   width: 22px;
   height: 22px;
-  color: #73726e;
+  color: var(--chat-accent);
   flex-shrink: 0;
 }
 
@@ -548,15 +557,16 @@
 }
 
 .chat-input-box {
-  border: 1px solid rgba(55, 53, 47, 0.16);
-  border-radius: 10px;
-  background: #fff;
+  border: 1px solid var(--chat-line-strong);
+  border-radius: var(--chat-radius-md);
+  background: var(--chat-surface);
   overflow: hidden;
   transition: border-color 0.15s, box-shadow 0.15s;
 }
 
 .chat-input-box:focus-within {
-  border-color: rgba(55, 53, 47, 0.4);
+  border-color: var(--chat-accent);
+  box-shadow: 0 0 0 3px rgba(35, 131, 226, 0.12);
 }
 
 .chat-input {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
@@ -425,15 +425,15 @@
   padding-bottom: 24px;
 }
 
-.chat-message-user {
-  flex-direction: row-reverse;
-}
-
+/* Document-style turns: both roles flow left-aligned at full content
+   width with an avatar gutter, rather than the old right-aligned user
+   bubble. This gives code blocks and tables the panel's full width and
+   makes long turns read like a transcript. */
 .chat-message-avatar {
   width: 24px;
   height: 24px;
   border-radius: 50%;
-  background: rgba(55, 53, 47, 0.06);
+  background: var(--chat-fill);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -442,13 +442,20 @@
   margin-top: 1px;
 }
 
+/* Tint the user's gutter marker so the two speakers stay distinguishable
+   now that both turns share the same left-aligned column. */
+.chat-message-user .chat-message-avatar {
+  color: var(--chat-accent);
+  background: rgba(35, 131, 226, 0.1);
+}
+
 .chat-message-content {
   font-size: 14px;
   line-height: 1.6;
-  color: #37352f;
+  color: var(--chat-ink);
   white-space: pre-wrap;
   word-break: break-word;
-  max-width: 85%;
+  max-width: 100%;
   /* Make message text freely selectable / copyable (cursor + explicit
      user-select so it never inherits a `none` from any ancestor). */
   cursor: text;
@@ -472,19 +479,19 @@
 .chat-message-user .chat-message-body {
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
-  max-width: min(92%, 560px);
+  align-items: flex-start;
+  max-width: min(94%, 640px);
 }
 
 .chat-message-assistant .chat-message-body {
-  max-width: min(92%, 620px);
+  max-width: min(94%, 640px);
 }
 
 .chat-message-user .chat-message-content {
-  background: rgba(55, 53, 47, 0.06);
+  background: var(--chat-bubble-bg);
   padding: 8px 12px;
-  border-radius: 12px;
-  border-bottom-right-radius: 4px;
+  border-radius: var(--chat-radius-lg);
+  border-top-left-radius: 4px;
   max-width: 100%;
 }
 
@@ -1146,10 +1153,10 @@
   pointer-events: none;
 }
 
-/* Anchor the toolbar to the same side as its bubble: user messages are
-   right-aligned, assistant messages are left-aligned. */
+/* Both speakers are left-aligned now, so anchor every toolbar to the
+   left edge of the content column. */
 .chat-message-user .chat-message-toolbar {
-  right: 0;
+  left: 0;
 }
 
 .chat-message-assistant .chat-message-toolbar {
@@ -1234,11 +1241,11 @@
 
 .chat-message-edit {
   width: 100%;
-  max-width: min(92%, 560px);
-  background: #fff;
+  max-width: min(94%, 640px);
+  background: var(--chat-surface);
   border: 1px solid rgba(35, 131, 226, 0.4);
-  border-radius: 12px;
-  border-bottom-right-radius: 4px;
+  border-radius: var(--chat-radius-lg);
+  border-top-left-radius: 4px;
   padding: 8px 10px 6px;
   box-shadow: 0 0 0 3px rgba(35, 131, 226, 0.12);
   display: flex;
@@ -1904,7 +1911,7 @@
 .chat-message-user .chat-message-images {
   order: 2;
   width: 100%;
-  justify-items: end;
+  justify-items: start;
 }
 
 .chat-message-user .chat-message-content {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
@@ -396,6 +396,20 @@
   white-space: pre-wrap;
   word-break: break-word;
   max-width: 85%;
+  /* Make message text freely selectable / copyable (cursor + explicit
+     user-select so it never inherits a `none` from any ancestor). */
+  cursor: text;
+  user-select: text;
+  -webkit-user-select: text;
+}
+
+/* Rendered markdown + tool-call output are read-mostly, but users still
+   need to select and copy them. */
+.chat-md,
+.chat-tool-call-result,
+.chat-tool-call-result pre {
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 .chat-message-body {


### PR DESCRIPTION
The chat/agent panel auto-scrolled to the bottom on every messages and
streamingTools change. While the agent streamed a reply this fired many
times per second, collapsing any active text selection and yanking the
viewport — so copying text mid-response was effectively impossible.

- Make auto-scroll selection-aware: skip scrolling while there is an
  active (non-collapsed) text selection inside the chat.
- Add stick-to-bottom behavior: once the user scrolls up to read or
  select earlier text, stop force-scrolling them back to the bottom.
- Explicitly mark message content, rendered markdown, and tool-call
  output as user-select: text (with cursor: text) so selection never
  inherits a `none` and copying works reliably.