### PR TITLE
Fix chat history reload during streaming by stabilizing agentScope

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.tsx
@@ -6,7 +6,7 @@ import { ChatView } from './ChatView';
 import { useChatComposerState } from './hooks/useChatComposerState';
 import { getNodeDisplayLabel } from '../../utils/nodeLabel';
 import type { AgentRequestContext } from '../../types';
-import type { ChatPanelProps } from './types';
+import type { AgentScope, ChatPanelProps } from './types';
 import { buildAnchorElementId, buildChatAnchors } from './utils/anchors';
 import { useI18n } from '../../i18n';
 
@@ -25,6 +25,16 @@ export const ChatPanel = ({
   const { t } = useI18n();
   const [executionMode, setExecutionMode] = useState<'auto' | 'ask'>('auto');
   const requestContextRef = useRef<AgentRequestContext>();
+
+  // Keep a stable identity for the workspace scope. Passing a fresh
+  // `{ kind: 'workspace', workspaceId }` literal on every render would make
+  // the scope-keyed effects in useChatSessions/useChatStream re-run on each
+  // streaming setState, reloading history mid-stream and wiping the in-flight
+  // assistant message (intermediate tool/text output vanishing + flicker).
+  const agentScope = useMemo<AgentScope>(
+    () => ({ kind: 'workspace', workspaceId }),
+    [workspaceId],
+  );
 
   const {
     abort,
@@ -71,7 +81,7 @@ export const ChatPanel = ({
     toggleSection,
     toggleToolExpand,
   } = useChatComposerState({
-    agentScope: { kind: 'workspace', workspaceId },
+    agentScope,
     allWorkspaces,
     nodes,
     rootFolder,

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatSessions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatSessions.ts
@@ -31,15 +31,26 @@ export function useChatSessions({
   const workspaceId = agentScope.kind === 'workspace' ? agentScope.workspaceId : undefined;
   const scopeKey = agentScope.kind === 'global' ? 'global' : `workspace:${agentScope.workspaceId}`;
 
+  // Always read the latest scope inside the effect without making the effect
+  // depend on the object's identity (see below).
+  const agentScopeRef = useRef(agentScope);
+  agentScopeRef.current = agentScope;
+
+  // Reload history only when the scope actually changes. We key on `scopeKey`
+  // (a stable string) rather than the `agentScope` object: a caller that
+  // recreates the scope object on every render would otherwise re-fire this
+  // effect on each streaming setState, and `onMessagesLoaded` (replaceMessages)
+  // would clobber the in-flight assistant message — making intermediate tool
+  // calls / streamed text disappear and the view flicker mid-turn.
   useEffect(() => {
     if (skipInitialHistory) return;
     void (async () => {
-      const result = await window.canvasWorkspace.agent.getHistory({ scope: agentScope });
+      const result = await window.canvasWorkspace.agent.getHistory({ scope: agentScopeRef.current });
       if (result.ok && result.messages) {
         onMessagesLoaded(result.messages);
       }
     })();
-  }, [agentScope, onMessagesLoaded, skipInitialHistory, scopeKey]);
+  }, [onMessagesLoaded, skipInitialHistory, scopeKey]);
 
   useEffect(() => {
     if (!sessionMenuOpen) return;


### PR DESCRIPTION
## Summary
Fixes an issue where chat history was being reloaded mid-stream, causing in-flight assistant messages (intermediate tool calls and streamed text) to disappear and the view to flicker.

## Root Cause
When `agentScope` was passed as a fresh object literal on every render, it would trigger dependency changes in effects within `useChatSessions` and `useChatStream`. During streaming setState updates, this would cause the history-loading effect to re-run, calling `onMessagesLoaded` (which replaces all messages) and clobbering the in-flight assistant message.

## Key Changes
- **ChatPanel.tsx**: Wrap `agentScope` in `useMemo` to maintain stable object identity across renders, keyed only on `workspaceId`
- **useChatSessions.ts**: 
  - Use a `useRef` to access the latest `agentScope` without making it a dependency
  - Change effect dependency from `agentScope` to `scopeKey` (a stable string) to reload history only when the scope actually changes
  - Add detailed comments explaining the fix and the flickering issue it prevents

## Implementation Details
The fix uses a common React pattern: storing the current value in a ref while keying effects on stable identifiers. This allows the effect to access the latest scope value without re-running on every render when the scope object is recreated.

https://claude.ai/code/session_01MDFs7q4RQtdtX5DYdqfmZ8