### PR TITLE
feat(canvas-channel): nicer tool-call rows in Feishu cards

### DIFF
--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/card.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/card.test.ts
@@ -36,10 +36,22 @@ describe('feishu card tool list', () => {
     expect(formatToolLabel('think', {})).toBe('think');
   });
 
+  it('formatToolLabel surfaces a readable detail for paths and urls', () => {
+    // File paths collapse to their basename so the row stays compact.
+    expect(formatToolLabel('read', { path: '/docs/space/AGENTS.MD' })).toBe('read — AGENTS.MD');
+    // URLs collapse to host/…/slug instead of a long link.
+    expect(formatToolLabel('read', { url: 'https://x.feishu.cn/docx/AbCdToken123' })).toBe(
+      'read — x.feishu.cn/…/AbCdToken123',
+    );
+    // A doc token is better than nothing when no nicer field exists.
+    expect(formatToolLabel('read', { docToken: 'doccnXyz' })).toBe('read — doccnXyz');
+  });
+
   it('progress card lists every tool with running/done status', () => {
     const body = texts(buildProgressCard('working', tools, 20)).join('\n');
-    expect(body).toContain('✅ canvas_read_node — node-1 · 18s');
-    expect(body).toContain('⏳ canvas_write_node — node-2');
+    // Tool name is bolded; detail and timing follow as secondary segments.
+    expect(body).toContain('✅ **canvas_read_node** · node-1 · 18s');
+    expect(body).toContain('⏳ **canvas_write_node** · node-2');
     expect(body).toContain('⏱️ 20s');
   });
 
@@ -53,7 +65,7 @@ describe('feishu card tool list', () => {
     const body = texts(card).join('\n');
     expect(body).toContain('the answer');
     expect(body).toContain('🛠️ 2 tool calls');
-    expect(body).toContain('canvas_read_node — node-1');
+    expect(body).toContain('**canvas_read_node** · node-1');
   });
 
   it('done card with no tools is just the answer (no panel)', () => {

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
@@ -73,10 +73,22 @@ function toolLines(tools: ToolEntry[]): string {
   return tools
     .map((t) => {
       const icon = t.done ? '✅' : '⏳';
-      const timing = t.done && typeof t.elapsedSec === 'number' ? ` · ${t.elapsedSec}s` : '';
-      return `${icon} ${t.label}${timing}`;
+      const { name, detail } = splitToolLabel(t.label);
+      // Bold the tool name so each row reads as "what" then "on what",
+      // keeping the detail (and timing) visually secondary.
+      const segs = [`${icon} **${name || 'tool'}**`];
+      if (detail) segs.push(detail);
+      if (t.done && typeof t.elapsedSec === 'number') segs.push(`${t.elapsedSec}s`);
+      return segs.join(' · ');
     })
     .join('\n');
+}
+
+/** Recover the "name" / "detail" parts of a `formatToolLabel` string. */
+function splitToolLabel(label: string): { name: string; detail: string } {
+  const i = label.indexOf(' — ');
+  if (i >= 0) return { name: label.slice(0, i), detail: label.slice(i + 3) };
+  return { name: label, detail: '' };
 }
 
 /** A collapsed panel holding the finished tool list (shown on the done card). */
@@ -202,13 +214,40 @@ export function formatToolLabel(name: string, args: unknown): string {
 function summarizeArgs(args: unknown): string {
   if (!args || typeof args !== 'object') return '';
   const record = args as Record<string, unknown>;
-  // Prefer a few common, meaningful fields for a compact hint.
-  for (const key of ['title', 'path', 'query', 'command', 'name', 'nodeId']) {
+  // Prefer a few common, meaningful fields for a compact hint. Ordered most-
+  // to least descriptive so e.g. a title wins over a bare id.
+  for (const key of [
+    'title', 'name', 'query', 'q', 'prompt', 'question',
+    'path', 'file', 'filePath', 'fileName', 'fileToken',
+    'url', 'link', 'href', 'docToken', 'documentId', 'document', 'doc', 'token',
+    'selector', 'key', 'pattern', 'command', 'cmd', 'text', 'nodeId', 'id',
+  ]) {
     const value = record[key];
     if (typeof value === 'string' && value.trim()) {
-      const v = value.trim();
-      return v.length > 60 ? `${v.slice(0, 60)}…` : v;
+      return shorten(prettyValue(key, value.trim()));
     }
   }
   return '';
+}
+
+/** Make a raw arg value compact and readable for the card (basename, host/…/slug). */
+function prettyValue(key: string, value: string): string {
+  if (key === 'url' || key === 'link' || key === 'href') {
+    try {
+      const u = new URL(value);
+      const slug = u.pathname.split('/').filter(Boolean).pop();
+      return slug ? `${u.hostname}/…/${slug}` : u.hostname;
+    } catch {
+      /* not a URL — fall through to the raw value */
+    }
+  }
+  if (key === 'path' || key === 'file' || key === 'filePath') {
+    const base = value.split(/[\\/]/).filter(Boolean).pop();
+    if (base) return base;
+  }
+  return value;
+}
+
+function shorten(value: string): string {
+  return value.length > 48 ? `${value.slice(0, 48)}…` : value;
 }


### PR DESCRIPTION
The progress/done card listed tools as a flat "✅ read · 1s", and reads with no recognised arg key showed no detail at all — so repeated calls rendered as identical, uninformative rows. Bold the tool name and keep detail/timing as secondary segments ("✅ **read** · AGENTS.MD · 1s"), and broaden arg summarisation (urls → host/…/slug, paths → basename, plus doc/file/token/ selector/query fields) so each row says what it acted on.