### PR TITLE
Add per-tool enable/disable toggles for MCP servers

### DIFF
--- a/apps/canvas-workspace/src/main/agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/agent/canvas-agent.ts
@@ -8,6 +8,7 @@
 
 import { Engine } from 'pulse-coder-engine';
 import { createSkillsPlugin, createMcpPlugin } from 'pulse-coder-engine/built-in';
+import type { MCPServerStatus } from 'pulse-coder-engine/built-in';
 import type { ModelMessage } from 'ai';
 import { resolveCanvasModel } from './model/config';
 import { scopeMcpConfigPath, skillSourceDirs } from './config-scope';
@@ -732,9 +733,9 @@ export class CanvasAgent {
    * record if the engine hasn't yet loaded any MCP server (or the manager
    * service isn't registered yet).
    */
-  getMcpStatuses(): Record<string, { ok: true; toolCount: number } | { ok: false; error: string }> {
+  getMcpStatuses(): Record<string, MCPServerStatus> {
     const manager = this.engine?.getService?.('mcp:__manager__') as
-      | { getStatuses?: () => Record<string, { ok: true; toolCount: number } | { ok: false; error: string }> }
+      | { getStatuses?: () => Record<string, MCPServerStatus> }
       | undefined;
     return manager?.getStatuses?.() ?? {};
   }

--- a/apps/canvas-workspace/src/main/agent/mcp/__tests__/config.test.ts
+++ b/apps/canvas-workspace/src/main/agent/mcp/__tests__/config.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+
+// Sandbox `os.homedir()` to a temp dir BEFORE the modules under test load —
+// `config-scope.ts` computes `CANVAS_STORE_DIR` from `homedir()` at module
+// eval time. Mirrors the pattern in `default-skills.test.ts`.
+const { sandboxHome } = vi.hoisted(() => {
+  const base = process.env.TMPDIR || process.env.TEMP || '/tmp';
+  const trailing = base.endsWith('/') ? '' : '/';
+  return {
+    sandboxHome: `${base}${trailing}canvas-mcp-config-test-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2, 8)}`,
+  };
+});
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  return { ...actual, homedir: () => sandboxHome };
+});
+
+import {
+  getCanvasMcpStatus,
+  importCanvasMcpJson,
+  setCanvasMcpToolEnabled,
+  upsertCanvasMcpServer,
+} from '../config';
+
+const GLOBAL = { level: 'global' } as const;
+const mcpPath = join(sandboxHome, '.pulse-coder', 'canvas', 'mcp.json');
+
+async function readRaw(): Promise<any> {
+  return JSON.parse(await fs.readFile(mcpPath, 'utf8'));
+}
+
+beforeEach(async () => {
+  await fs.mkdir(join(sandboxHome, '.pulse-coder', 'canvas'), { recursive: true });
+});
+
+afterEach(async () => {
+  await fs.rm(join(sandboxHome, '.pulse-coder'), { recursive: true, force: true });
+});
+
+describe('disabledTools persistence', () => {
+  it('round-trips disabledTools through upsert and status', async () => {
+    await upsertCanvasMcpServer(GLOBAL, {
+      name: 'eido',
+      transport: 'http',
+      url: 'http://localhost:3060/mcp/server',
+      disabledTools: ['danger_tool', 'noisy_tool'],
+    });
+
+    const status = await getCanvasMcpStatus(GLOBAL);
+    const server = status.servers.find((s) => s.name === 'eido');
+    expect(server?.disabledTools).toEqual(['danger_tool', 'noisy_tool']);
+
+    // Stored on disk in the engine-compatible shape.
+    const raw = await readRaw();
+    expect(raw.servers.eido.disabledTools).toEqual(['danger_tool', 'noisy_tool']);
+  });
+
+  it('drops an empty disabledTools list rather than persisting it', async () => {
+    await upsertCanvasMcpServer(GLOBAL, {
+      name: 'eido',
+      transport: 'http',
+      url: 'http://localhost:3060/mcp/server',
+      disabledTools: [],
+    });
+    const raw = await readRaw();
+    expect('disabledTools' in raw.servers.eido).toBe(false);
+  });
+});
+
+describe('setCanvasMcpToolEnabled', () => {
+  beforeEach(async () => {
+    await upsertCanvasMcpServer(GLOBAL, {
+      name: 'eido',
+      transport: 'http',
+      url: 'http://localhost:3060/mcp/server',
+    });
+  });
+
+  it('disabling a tool adds it to disabledTools', async () => {
+    await setCanvasMcpToolEnabled(GLOBAL, 'eido', 'search', false);
+    const raw = await readRaw();
+    expect(raw.servers.eido.disabledTools).toEqual(['search']);
+  });
+
+  it('keeps the disabled set sorted and de-duplicated', async () => {
+    await setCanvasMcpToolEnabled(GLOBAL, 'eido', 'zeta', false);
+    await setCanvasMcpToolEnabled(GLOBAL, 'eido', 'alpha', false);
+    await setCanvasMcpToolEnabled(GLOBAL, 'eido', 'zeta', false);
+    const raw = await readRaw();
+    expect(raw.servers.eido.disabledTools).toEqual(['alpha', 'zeta']);
+  });
+
+  it('re-enabling the last disabled tool clears the field entirely', async () => {
+    await setCanvasMcpToolEnabled(GLOBAL, 'eido', 'search', false);
+    await setCanvasMcpToolEnabled(GLOBAL, 'eido', 'search', true);
+    const raw = await readRaw();
+    expect('disabledTools' in raw.servers.eido).toBe(false);
+  });
+
+  it('does not touch unrelated server fields', async () => {
+    await setCanvasMcpToolEnabled(GLOBAL, 'eido', 'search', false);
+    const raw = await readRaw();
+    expect(raw.servers.eido.url).toBe('http://localhost:3060/mcp/server');
+    expect(raw.servers.eido.transport).toBe('http');
+  });
+
+  it('throws when the server does not exist', async () => {
+    await expect(setCanvasMcpToolEnabled(GLOBAL, 'ghost', 'search', false)).rejects.toThrow(/not found/);
+  });
+});
+
+describe('importCanvasMcpJson', () => {
+  it('carries disabledTools through native-shape import', async () => {
+    const json = JSON.stringify({
+      servers: {
+        eido: {
+          transport: 'http',
+          url: 'http://localhost:3060/mcp/server',
+          disabledTools: ['danger_tool'],
+        },
+      },
+    });
+    await importCanvasMcpJson(GLOBAL, json);
+    const raw = await readRaw();
+    expect(raw.servers.eido.disabledTools).toEqual(['danger_tool']);
+  });
+});

--- a/apps/canvas-workspace/src/main/agent/mcp/config.ts
+++ b/apps/canvas-workspace/src/main/agent/mcp/config.ts
@@ -25,10 +25,19 @@ export interface CanvasMcpServer {
   env?: Record<string, string>;
   cwd?: string;
   deferTools?: boolean;
+  /** Bare tool names the user has turned off; the engine skips registering these. */
+  disabledTools?: string[];
+}
+
+/** One tool exposed by a connected MCP server, with its enabled state. */
+export interface CanvasMcpToolInfo {
+  name: string;
+  description?: string;
+  enabled: boolean;
 }
 
 export type CanvasMcpServerHealth =
-  | { ok: true; toolCount: number }
+  | { ok: true; toolCount: number; tools?: CanvasMcpToolInfo[] }
   | { ok: false; error: string };
 
 export interface CanvasMcpStatus {
@@ -80,6 +89,8 @@ function normalizeServer(server: CanvasMcpServer): { name: string; config: Recor
 
   const config: Record<string, unknown> = { transport };
   if (server.deferTools === true) config.deferTools = true;
+  const disabledTools = normalizeStringArray(server.disabledTools);
+  if (disabledTools) config.disabledTools = disabledTools;
 
   if (transport === 'http' || transport === 'sse') {
     const url = normalizeStr(server.url);
@@ -107,6 +118,8 @@ function readServer(name: string, raw: Record<string, unknown>): CanvasMcpServer
   const transport = (normalizeStr(raw.transport).toLowerCase() || 'http') as CanvasMcpTransport;
   const server: CanvasMcpServer = { name, transport };
   if (raw.deferTools === true) server.deferTools = true;
+  const disabledTools = normalizeStringArray(raw.disabledTools);
+  if (disabledTools) server.disabledTools = disabledTools;
   if (transport === 'stdio') {
     server.command = normalizeStr(raw.command);
     const args = normalizeStringArray(raw.args);
@@ -177,6 +190,44 @@ export async function removeCanvasMcpServer(
   return getCanvasMcpStatus(scope);
 }
 
+/**
+ * Toggle a single tool on a server by maintaining its `disabledTools` list.
+ * Enabling drops the tool from the list (clearing it entirely when empty);
+ * disabling adds it. The engine re-reads this on its next reload and skips
+ * registering disabled tools, so the agent stops seeing them.
+ */
+export async function setCanvasMcpToolEnabled(
+  scope: CanvasConfigScope,
+  serverName: string,
+  toolName: string,
+  enabled: boolean,
+): Promise<CanvasMcpStatus> {
+  const key = normalizeStr(serverName);
+  const tool = normalizeStr(toolName);
+  if (!key) throw new Error('MCP server name is required');
+  if (!tool) throw new Error('Tool name is required');
+
+  const file = await readFile(scope);
+  const servers = { ...(file.servers ?? {}) };
+  const raw = servers[key];
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error(`MCP server "${key}" not found`);
+  }
+
+  const current = normalizeStringArray((raw as Record<string, unknown>).disabledTools) ?? [];
+  const next = new Set(current);
+  if (enabled) next.delete(tool);
+  else next.add(tool);
+
+  const updated: Record<string, unknown> = { ...(raw as Record<string, unknown>) };
+  if (next.size > 0) updated.disabledTools = Array.from(next).sort();
+  else delete updated.disabledTools;
+  servers[key] = updated;
+
+  await writeFile(scope, { servers });
+  return getCanvasMcpStatus(scope);
+}
+
 // ─── JSON import ──────────────────────────────────────────────────────
 //
 // Accepts two shapes:
@@ -229,6 +280,8 @@ function rawToServer(name: string, raw: Record<string, unknown>): CanvasMcpServe
   const transport = inferTransport(raw);
   const server: CanvasMcpServer = { name, transport };
   if (raw.deferTools === true) server.deferTools = true;
+  const disabledTools = normalizeStringArray(raw.disabledTools);
+  if (disabledTools) server.disabledTools = disabledTools;
   if (transport === 'stdio') {
     if (typeof raw.command === 'string') server.command = raw.command;
     if (Array.isArray(raw.args)) {

--- a/apps/canvas-workspace/src/main/agent/mcp/ipc.ts
+++ b/apps/canvas-workspace/src/main/agent/mcp/ipc.ts
@@ -23,6 +23,7 @@ import {
   getCanvasMcpStatus,
   importCanvasMcpJson,
   removeCanvasMcpServer,
+  setCanvasMcpToolEnabled,
   upsertCanvasMcpServer,
   type CanvasMcpServer,
   type CanvasMcpStatus,
@@ -86,6 +87,20 @@ export function setupCanvasMcpIpc(): void {
         const result = await importCanvasMcpJson(scope, payload.json);
         await reloadAgents(scope);
         return { ok: true, ...result, status: withStatuses(result.status, scope) };
+      } catch (err) {
+        return { ok: false, error: String(err) };
+      }
+    },
+  );
+
+  ipcMain.handle(
+    'canvas-mcp:set-tool-enabled',
+    async (_event, payload: { scope?: unknown; name: string; tool: string; enabled: boolean }) => {
+      try {
+        const scope = parseScopePayload(payload?.scope);
+        const status = await setCanvasMcpToolEnabled(scope, payload.name, payload.tool, payload.enabled);
+        await reloadAgents(scope);
+        return { ok: true, status: withStatuses(status, scope) };
       } catch (err) {
         return { ok: false, error: String(err) };
       }

--- a/apps/canvas-workspace/src/main/agent/service.ts
+++ b/apps/canvas-workspace/src/main/agent/service.ts
@@ -10,6 +10,7 @@
 import { join } from 'path';
 import { homedir } from 'os';
 import { CanvasAgent, type CanvasClarificationRequest } from './canvas-agent';
+import type { MCPServerStatus } from 'pulse-coder-engine/built-in';
 import { GLOBAL_CHAT_SESSION_STORE_ID, GLOBAL_CHAT_WORKSPACE_NAME, SessionStore } from './session-store';
 import type {
   AgentScope,
@@ -428,7 +429,7 @@ export class CanvasAgentService {
    * fall back to "saved, not tested" copy in that case. For global edits we
    * grab whichever active agent exists since global servers are shared.
    */
-  getMcpStatuses(workspaceId?: string): Record<string, { ok: true; toolCount: number } | { ok: false; error: string }> {
+  getMcpStatuses(workspaceId?: string): Record<string, MCPServerStatus> {
     if (workspaceId) {
       return this.getAgent(workspaceScope(workspaceId))?.getMcpStatuses() ?? {};
     }

--- a/apps/canvas-workspace/src/preload/bridge/settings.ts
+++ b/apps/canvas-workspace/src/preload/bridge/settings.ts
@@ -49,7 +49,10 @@ export const createCanvasMcpApi = (ipcRenderer: IpcRenderer): CanvasMcpApi => ({
     ipcRenderer.invoke("canvas-mcp:remove", { scope, name }),
 
   importJson: (scope, json) =>
-    ipcRenderer.invoke("canvas-mcp:import-json", { scope, json })
+    ipcRenderer.invoke("canvas-mcp:import-json", { scope, json }),
+
+  setToolEnabled: (scope, name, tool, enabled) =>
+    ipcRenderer.invoke("canvas-mcp:set-tool-enabled", { scope, name, tool, enabled })
 });
 
 export const createExperimentalApi = (ipcRenderer: IpcRenderer): ExperimentalApi => ({

--- a/apps/canvas-workspace/src/renderer/src/components/settings-config/McpManager.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/settings-config/McpManager.tsx
@@ -120,16 +120,61 @@ const HealthBadge = ({ health, t }: HealthBadgeProps) => {
     return <span className="cfg-health cfg-health--unknown">{t('mcpConfig.healthUnknown')}</span>;
   }
   if (health.ok) {
-    return (
-      <span className="cfg-health cfg-health--ok">
-        ✓ {t('mcpConfig.healthOk', { count: health.toolCount })}
-      </span>
-    );
+    // When some tools are disabled, surface "enabled/total" so the count
+    // doesn't look like the server simply exposes fewer tools.
+    const total = health.tools?.length ?? health.toolCount;
+    const label =
+      health.tools && total !== health.toolCount
+        ? t('mcpConfig.healthOkPartial', { enabled: health.toolCount, total })
+        : t('mcpConfig.healthOk', { count: health.toolCount });
+    return <span className="cfg-health cfg-health--ok">✓ {label}</span>;
   }
   return (
     <span className="cfg-health cfg-health--err" title={health.error}>
       ⚠ {health.error.length > 40 ? `${health.error.slice(0, 40)}…` : health.error}
     </span>
+  );
+};
+
+interface ToolsListProps {
+  health: CanvasMcpServerHealth | undefined;
+  /** Read-only (inherited/global) rows show tools but cannot toggle them here. */
+  readOnly?: boolean;
+  /** Returns true while the given tool is mid-toggle (awaiting engine reload). */
+  isBusy?: (toolName: string) => boolean;
+  onToggle?: (toolName: string, enabled: boolean) => void;
+  t: (key: any, params?: any) => string;
+}
+
+const ToolsList = ({ health, readOnly, isBusy, onToggle, t }: ToolsListProps) => {
+  if (!health || !health.ok || !health.tools) {
+    // No snapshot yet (server not loaded) or it failed to connect — nothing to list.
+    return <div className="cfg-tools-empty">{t('mcpConfig.toolsUnavailable')}</div>;
+  }
+  if (health.tools.length === 0) {
+    return <div className="cfg-tools-empty">{t('mcpConfig.toolsNone')}</div>;
+  }
+  return (
+    <ul className="cfg-tools-list">
+      {health.tools.map((tool) => (
+        <li key={tool.name} className={`cfg-tool${tool.enabled ? '' : ' cfg-tool--off'}`}>
+          <label className="cfg-tool-toggle">
+            <input
+              type="checkbox"
+              checked={tool.enabled}
+              disabled={readOnly || isBusy?.(tool.name)}
+              onChange={(e) => onToggle?.(tool.name, e.target.checked)}
+            />
+            <span className="cfg-tool-name">{tool.name}</span>
+          </label>
+          {tool.description && (
+            <span className="cfg-tool-desc" title={tool.description}>
+              {tool.description}
+            </span>
+          )}
+        </li>
+      ))}
+    </ul>
   );
 };
 
@@ -145,6 +190,10 @@ export const McpManager = ({ scope, showInherited = false }: Props) => {
   const [saving, setSaving] = useState(false);
   const [jsonText, setJsonText] = useState<string | null>(null);
   const [importing, setImporting] = useState(false);
+  // Server names whose tool list is expanded, and the `${server}::${tool}` key
+  // currently mid-toggle (so we can disable just that one checkbox).
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const [busyTool, setBusyTool] = useState<string | null>(null);
   const scopeKey = scope.level === 'workspace' ? scope.workspaceId : 'global';
   const inheritedEnabled = showInherited && scope.level === 'workspace';
 
@@ -218,6 +267,21 @@ export const McpManager = ({ scope, showInherited = false }: Props) => {
       else notify({ tone: 'error', title: res.error ?? t('mcpConfig.loadFailed') });
     },
     [scope, notify, t, applyStatus],
+  );
+
+  const toggleTool = useCallback(
+    async (serverName: string, toolName: string, enabled: boolean) => {
+      const key = `${serverName}::${toolName}`;
+      setBusyTool(key);
+      try {
+        const res = await window.canvasWorkspace.canvasMcp.setToolEnabled(scope, serverName, toolName, enabled);
+        if (res.ok && res.status) applyStatus(res.status);
+        else notify({ tone: 'error', title: res.error ?? t('mcpConfig.toolUpdateFailed') });
+      } finally {
+        setBusyTool(null);
+      }
+    },
+    [scope, applyStatus, notify, t],
   );
 
   const importJson = useCallback(async () => {
@@ -437,25 +501,49 @@ export const McpManager = ({ scope, showInherited = false }: Props) => {
         <div className="cfg-empty">{t('mcpConfig.empty')}</div>
       ) : (
         <ul className="cfg-list">
-          {servers.map((server) => (
-            <li key={server.name} className="cfg-list-item">
-              <div className="cfg-list-main">
-                <div className="cfg-list-title">
-                  {server.name} <span className="cfg-tag">{server.transport}</span>
-                  <HealthBadge health={statuses[server.name]} t={t} />
+          {servers.map((server) => {
+            const isOpen = !!expanded[server.name];
+            return (
+              <li key={server.name} className="cfg-list-entry">
+                <div className="cfg-list-item">
+                  <button
+                    type="button"
+                    className="cfg-expander"
+                    aria-expanded={isOpen}
+                    title={t(isOpen ? 'mcpConfig.collapseTools' : 'mcpConfig.expandTools')}
+                    onClick={() => setExpanded((prev) => ({ ...prev, [server.name]: !prev[server.name] }))}
+                  >
+                    {isOpen ? '▾' : '▸'}
+                  </button>
+                  <div className="cfg-list-main">
+                    <div className="cfg-list-title">
+                      {server.name} <span className="cfg-tag">{server.transport}</span>
+                      <HealthBadge health={statuses[server.name]} t={t} />
+                    </div>
+                    <div className="cfg-list-desc">{server.transport === 'stdio' ? server.command : server.url}</div>
+                  </div>
+                  <div className="cfg-list-actions">
+                    <button type="button" className="cfg-secondary-btn" onClick={() => setDraft(serverToDraft(server))}>
+                      {t('mcpConfig.edit')}
+                    </button>
+                    <button type="button" className="cfg-danger-btn" onClick={() => void remove(server.name)}>
+                      {t('mcpConfig.delete')}
+                    </button>
+                  </div>
                 </div>
-                <div className="cfg-list-desc">{server.transport === 'stdio' ? server.command : server.url}</div>
-              </div>
-              <div className="cfg-list-actions">
-                <button type="button" className="cfg-secondary-btn" onClick={() => setDraft(serverToDraft(server))}>
-                  {t('mcpConfig.edit')}
-                </button>
-                <button type="button" className="cfg-danger-btn" onClick={() => void remove(server.name)}>
-                  {t('mcpConfig.delete')}
-                </button>
-              </div>
-            </li>
-          ))}
+                {isOpen && (
+                  <div className="cfg-tools">
+                    <ToolsList
+                      health={statuses[server.name]}
+                      isBusy={(tool) => busyTool === `${server.name}::${tool}`}
+                      onToggle={(tool, enabled) => void toggleTool(server.name, tool, enabled)}
+                      t={t}
+                    />
+                  </div>
+                )}
+              </li>
+            );
+          })}
         </ul>
       )}
 
@@ -470,25 +558,42 @@ export const McpManager = ({ scope, showInherited = false }: Props) => {
           <ul className="cfg-list cfg-list--scrollable">
             {inherited.map((server) => {
               const overridden = servers.some((s) => s.name === server.name);
+              const expandKey = `global::${server.name}`;
+              const isOpen = !!expanded[expandKey];
               return (
-                <li
-                  key={server.name}
-                  className={`cfg-list-item cfg-list-item--readonly${overridden ? ' cfg-list-item--shadowed' : ''}`}
-                >
-                  <div className="cfg-list-main">
-                    <div className="cfg-list-title">
-                      {server.name} <span className="cfg-tag">{server.transport}</span>
-                      <span className="cfg-tag">global</span>
-                      <HealthBadge health={inheritedStatuses[server.name]} t={t} />
+                <li key={server.name} className="cfg-list-entry">
+                  <div
+                    className={`cfg-list-item cfg-list-item--readonly${overridden ? ' cfg-list-item--shadowed' : ''}`}
+                  >
+                    <button
+                      type="button"
+                      className="cfg-expander"
+                      aria-expanded={isOpen}
+                      title={t(isOpen ? 'mcpConfig.collapseTools' : 'mcpConfig.expandTools')}
+                      onClick={() => setExpanded((prev) => ({ ...prev, [expandKey]: !prev[expandKey] }))}
+                    >
+                      {isOpen ? '▾' : '▸'}
+                    </button>
+                    <div className="cfg-list-main">
+                      <div className="cfg-list-title">
+                        {server.name} <span className="cfg-tag">{server.transport}</span>
+                        <span className="cfg-tag">global</span>
+                        <HealthBadge health={inheritedStatuses[server.name]} t={t} />
+                      </div>
+                      <div className="cfg-list-desc">
+                        {server.transport === 'stdio' ? server.command : server.url}
+                      </div>
                     </div>
-                    <div className="cfg-list-desc">
-                      {server.transport === 'stdio' ? server.command : server.url}
-                    </div>
+                    {overridden && (
+                      <span className="cfg-shadow-warn" title={t('mcpConfig.inheritedOverridden')}>
+                        ⚠ {t('mcpConfig.inheritedOverridden')}
+                      </span>
+                    )}
                   </div>
-                  {overridden && (
-                    <span className="cfg-shadow-warn" title={t('mcpConfig.inheritedOverridden')}>
-                      ⚠ {t('mcpConfig.inheritedOverridden')}
-                    </span>
+                  {isOpen && (
+                    <div className="cfg-tools">
+                      <ToolsList health={inheritedStatuses[server.name]} readOnly t={t} />
+                    </div>
                   )}
                 </li>
               );

--- a/apps/canvas-workspace/src/renderer/src/components/settings-config/settings-config.css
+++ b/apps/canvas-workspace/src/renderer/src/components/settings-config/settings-config.css
@@ -354,6 +354,111 @@ select.cfg-input {
   font-weight: 600;
 }
 
+/* ─── Expandable per-server tool list ─────────────────────────── */
+
+/* Each server row becomes a column: the existing `.cfg-list-item` row plus
+ * an optional `.cfg-tools` panel below it. */
+.cfg-list-entry {
+  display: flex;
+  flex-direction: column;
+}
+
+.cfg-expander {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  margin-left: -2px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  border-radius: 4px;
+  color: rgba(55, 53, 47, 0.4);
+  font-size: 10px;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: inherit;
+}
+
+.cfg-expander:hover {
+  background: rgba(55, 53, 47, 0.07);
+  color: #37352f;
+}
+
+.cfg-tools {
+  padding: 0 12px 8px 34px;
+}
+
+.cfg-tools-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.cfg-tool {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 3px 6px;
+  border-radius: 6px;
+  min-width: 0;
+}
+
+.cfg-tool:hover {
+  background: rgba(55, 53, 47, 0.03);
+}
+
+.cfg-tool-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  cursor: pointer;
+  flex-shrink: 0;
+  user-select: none;
+}
+
+.cfg-tool-toggle input {
+  accent-color: #2383e2;
+  cursor: pointer;
+}
+
+.cfg-tool-toggle input:disabled {
+  cursor: default;
+}
+
+.cfg-tool-name {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: #37352f;
+}
+
+.cfg-tool--off .cfg-tool-name {
+  color: rgba(55, 53, 47, 0.4);
+  text-decoration: line-through;
+}
+
+.cfg-tool-desc {
+  flex: 1;
+  min-width: 0;
+  font-size: 11.5px;
+  color: rgba(55, 53, 47, 0.5);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.4;
+}
+
+.cfg-tools-empty {
+  font-size: 11.5px;
+  color: rgba(55, 53, 47, 0.45);
+  padding: 2px 6px 6px;
+}
+
 /* ─── Inherited (global) skills surfaced inside a workspace panel ─ */
 
 .cfg-inherited {

--- a/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
+++ b/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
@@ -548,6 +548,7 @@ const en = {
   'mcpConfig.dirHint': 'Stored at {path}',
   'mcpConfig.loadFailed': 'Failed to load MCP servers.',
   'mcpConfig.healthOk': '{count} tools',
+  'mcpConfig.healthOkPartial': '{enabled}/{total} tools',
   'mcpConfig.healthUnknown': 'not loaded',
   'mcpConfig.savedOk': '"{name}" connected — {count} tools available.',
   'mcpConfig.savedErr': '"{name}" saved but failed to connect.',
@@ -561,6 +562,11 @@ const en = {
   'mcpConfig.importing': 'Importing...',
   'mcpConfig.importDone': 'Added {added}, replaced {replaced}, skipped {skipped}.',
   'mcpConfig.importFailed': 'Import failed',
+  'mcpConfig.expandTools': 'Show tools',
+  'mcpConfig.collapseTools': 'Hide tools',
+  'mcpConfig.toolsUnavailable': 'Connect the server to list its tools.',
+  'mcpConfig.toolsNone': 'This server exposes no tools.',
+  'mcpConfig.toolUpdateFailed': 'Failed to update tool.',
 } as const;
 
 const zh: Record<keyof typeof en, string> = {
@@ -1100,6 +1106,7 @@ const zh: Record<keyof typeof en, string> = {
   'mcpConfig.dirHint': '保存于 {path}',
   'mcpConfig.loadFailed': '加载 MCP 服务失败。',
   'mcpConfig.healthOk': '{count} 个工具',
+  'mcpConfig.healthOkPartial': '{enabled}/{total} 个工具',
   'mcpConfig.healthUnknown': '未加载',
   'mcpConfig.savedOk': '“{name}”已连接 — 提供 {count} 个工具。',
   'mcpConfig.savedErr': '“{name}”已保存但连接失败。',
@@ -1113,6 +1120,11 @@ const zh: Record<keyof typeof en, string> = {
   'mcpConfig.importing': '导入中……',
   'mcpConfig.importDone': '新增 {added} 个,覆盖 {replaced} 个,跳过 {skipped} 个。',
   'mcpConfig.importFailed': '导入失败',
+  'mcpConfig.expandTools': '显示工具',
+  'mcpConfig.collapseTools': '隐藏工具',
+  'mcpConfig.toolsUnavailable': '连接服务后可查看其工具。',
+  'mcpConfig.toolsNone': '该服务未提供任何工具。',
+  'mcpConfig.toolUpdateFailed': '更新工具失败。',
 };
 
 export const messages = {

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -890,10 +890,19 @@ export interface CanvasMcpServer {
   env?: Record<string, string>;
   cwd?: string;
   deferTools?: boolean;
+  /** Bare tool names the user has turned off; the engine skips registering these. */
+  disabledTools?: string[];
+}
+
+/** One tool exposed by a connected MCP server, with its enabled state. */
+export interface CanvasMcpToolInfo {
+  name: string;
+  description?: string;
+  enabled: boolean;
 }
 
 export type CanvasMcpServerHealth =
-  | { ok: true; toolCount: number }
+  | { ok: true; toolCount: number; tools?: CanvasMcpToolInfo[] }
   | { ok: false; error: string };
 
 export interface CanvasMcpStatus {
@@ -933,6 +942,12 @@ export interface CanvasMcpApi {
     entries?: CanvasMcpImportEntry[];
     error?: string;
   }>;
+  setToolEnabled: (
+    scope: CanvasConfigScope,
+    name: string,
+    tool: string,
+    enabled: boolean,
+  ) => Promise<{ ok: boolean; status?: CanvasMcpStatus; error?: string }>;
 }
 
 export interface AgentApi {

--- a/packages/engine/src/built-in/index.ts
+++ b/packages/engine/src/built-in/index.ts
@@ -37,7 +37,8 @@ export type {
   MCPPluginOptions,
   MCPClientManager,
   MCPPluginConfig,
-  MCPServerStatus
+  MCPServerStatus,
+  McpToolInfo
 } from './mcp-plugin';
 export { builtInSkillsPlugin, createSkillsPlugin, BuiltInSkillRegistry } from './skills-plugin';
 export type { SkillInfo, SkillScanPath, SkillsPluginOptions, SkillRegistryOptions } from './skills-plugin';

--- a/packages/engine/src/built-in/mcp-plugin/index.test.ts
+++ b/packages/engine/src/built-in/mcp-plugin/index.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+// Fake MCP client tools shared with the hoisted module mock. `plain` has no
+// description so we also cover the "description omitted" branch.
+const { fakeTools } = vi.hoisted(() => ({
+  fakeTools: {
+    search: { description: 'Search the web' },
+    danger_tool: { description: 'Dangerous operation' },
+    plain: {},
+  } as Record<string, { description?: string }>,
+}));
+
+vi.mock('@ai-sdk/mcp', () => ({
+  createMCPClient: vi.fn(async () => ({
+    tools: async () => fakeTools,
+    close: vi.fn(),
+  })),
+}));
+
+vi.mock('@ai-sdk/mcp/mcp-stdio', () => ({
+  Experimental_StdioMCPTransport: class {},
+}));
+
+import { createMcpPlugin, type MCPClientManager } from './index';
+import type { EnginePluginContext } from '../../plugin/EnginePlugin';
+
+/** Minimal EnginePluginContext that records registered tools + services. */
+function makeContext() {
+  const tools: Record<string, any> = {};
+  const services: Record<string, any> = {};
+  const ctx: EnginePluginContext = {
+    registerTool: (name, tool) => {
+      tools[name] = tool;
+    },
+    registerTools: (map) => {
+      Object.assign(tools, map);
+    },
+    getTool: (name) => tools[name],
+    getTools: () => ({ ...tools }),
+    getEngineInstance: () => ({}) as any,
+    registerHook: () => {},
+    registerService: (name, service) => {
+      services[name] = service;
+    },
+    getService: (name) => services[name],
+    getConfig: () => undefined,
+    setConfig: () => {},
+    events: { emit: () => {}, on: () => {} } as any,
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+  };
+  return { ctx, tools, services };
+}
+
+let dir: string;
+async function writeConfig(servers: Record<string, unknown>): Promise<string> {
+  const cfgPath = join(dir, 'mcp.json');
+  await fs.writeFile(cfgPath, JSON.stringify({ servers }), 'utf8');
+  return cfgPath;
+}
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(join(tmpdir(), 'mcp-plugin-test-'));
+});
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+describe('createMcpPlugin disabledTools', () => {
+  it('skips registering disabled tools but still lists them in the status', async () => {
+    const cfgPath = await writeConfig({
+      eido: {
+        transport: 'http',
+        url: 'http://localhost:3060/mcp/server',
+        disabledTools: ['danger_tool'],
+      },
+    });
+
+    const plugin = createMcpPlugin({ configPaths: [cfgPath] });
+    const { ctx, tools, services } = makeContext();
+    await plugin.initialize(ctx);
+
+    // Disabled tool is not registered with the engine; the agent can't see it.
+    expect(tools['mcp_eido_danger_tool']).toBeUndefined();
+    // Enabled tools are registered under the namespaced key.
+    expect(tools['mcp_eido_search']).toBeDefined();
+    expect(tools['mcp_eido_plain']).toBeDefined();
+
+    const manager = services['mcp:__manager__'] as MCPClientManager;
+    const status = manager.getStatuses()['eido'];
+    expect(status.ok).toBe(true);
+    if (status.ok) {
+      // toolCount reflects only the enabled (registered) tools.
+      expect(status.toolCount).toBe(2);
+      const byName = Object.fromEntries(status.tools.map((t) => [t.name, t]));
+      expect(byName.search).toMatchObject({ enabled: true, description: 'Search the web' });
+      expect(byName.danger_tool).toMatchObject({ enabled: false, description: 'Dangerous operation' });
+      expect(byName.plain).toMatchObject({ enabled: true });
+      expect(byName.plain.description).toBeUndefined();
+    }
+  });
+
+  it('registers every tool when nothing is disabled', async () => {
+    const cfgPath = await writeConfig({
+      eido: { transport: 'http', url: 'http://localhost:3060/mcp/server' },
+    });
+
+    const plugin = createMcpPlugin({ configPaths: [cfgPath] });
+    const { ctx, tools, services } = makeContext();
+    await plugin.initialize(ctx);
+
+    expect(tools['mcp_eido_search']).toBeDefined();
+    expect(tools['mcp_eido_danger_tool']).toBeDefined();
+    expect(tools['mcp_eido_plain']).toBeDefined();
+
+    const manager = services['mcp:__manager__'] as MCPClientManager;
+    const status = manager.getStatuses()['eido'];
+    expect(status.ok && status.toolCount).toBe(3);
+    if (status.ok) {
+      expect(status.tools.every((t) => t.enabled)).toBe(true);
+    }
+  });
+});

--- a/packages/engine/src/built-in/mcp-plugin/index.ts
+++ b/packages/engine/src/built-in/mcp-plugin/index.ts
@@ -17,6 +17,7 @@ interface HTTPOrSSEServerConfig {
   url: string;
   headers?: Record<string, string>;
   deferTools?: boolean;
+  disabledTools?: string[];
 }
 
 interface StdioServerConfig {
@@ -26,10 +27,13 @@ interface StdioServerConfig {
   env?: Record<string, string>;
   cwd?: string;
   deferTools?: boolean;
+  disabledTools?: string[];
 }
 
 interface NormalizedServerConfigBase {
   deferTools?: boolean;
+  /** Bare tool names (without the `mcp_<server>_` prefix) the host has turned off. */
+  disabledTools?: string[];
 }
 
 type NormalizedMCPServerConfig = (HTTPOrSSEServerConfig | StdioServerConfig) & NormalizedServerConfigBase;
@@ -106,6 +110,19 @@ function readDeferTools(raw: RawMCPServerConfig, serverName: string): boolean | 
   return undefined;
 }
 
+function readDisabledTools(raw: RawMCPServerConfig, serverName: string): string[] | undefined {
+  const value = raw.disabledTools;
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(value) || !value.every(item => typeof item === 'string')) {
+    console.warn(`[MCP] Server "${serverName}" has invalid disabledTools; expected string array, ignoring`);
+    return undefined;
+  }
+  const cleaned = value.map(item => item.trim()).filter(Boolean);
+  return cleaned.length > 0 ? cleaned : undefined;
+}
+
 
 function normalizeServerConfig(serverName: string, raw: RawMCPServerConfig): NormalizedMCPServerConfig | null {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
@@ -115,6 +132,7 @@ function normalizeServerConfig(serverName: string, raw: RawMCPServerConfig): Nor
 
   const transport = typeof raw.transport === 'string' ? raw.transport.toLowerCase() : 'http';
   const deferTools = readDeferTools(raw, serverName);
+  const disabledTools = readDisabledTools(raw, serverName);
 
   if (transport === 'http' || transport === 'sse') {
     if (typeof raw.url !== 'string' || !raw.url.trim()) {
@@ -125,7 +143,8 @@ function normalizeServerConfig(serverName: string, raw: RawMCPServerConfig): Nor
     const normalized: HTTPOrSSEServerConfig = {
       transport,
       url: raw.url,
-      deferTools
+      deferTools,
+      disabledTools
     };
 
     if (raw.headers !== undefined) {
@@ -148,7 +167,8 @@ function normalizeServerConfig(serverName: string, raw: RawMCPServerConfig): Nor
     const normalized: StdioServerConfig = {
       transport: 'stdio',
       command: raw.command,
-      deferTools
+      deferTools,
+      disabledTools
     };
 
     if (raw.args !== undefined) {
@@ -201,10 +221,22 @@ function createTransport(config: NormalizedMCPServerConfig): MCPClientConfig['tr
 }
 
 /**
+ * 单个 MCP 工具的元信息，供宿主展示与启用/禁用切换。
+ * `name` 为去除 `mcp_<server>_` 前缀后的原始工具名。
+ */
+export interface McpToolInfo {
+  name: string;
+  description?: string;
+  /** false 表示该工具被禁用，未注册进引擎工具表。 */
+  enabled: boolean;
+}
+
+/**
  * 单个 MCP server 的连接结果,供宿主在配置变更后展示给用户。
+ * `toolCount` 为实际注册（启用）的工具数；`tools` 列出全部工具及其启用状态。
  */
 export type MCPServerStatus =
-  | { ok: true; toolCount: number }
+  | { ok: true; toolCount: number; tools: McpToolInfo[] }
   | { ok: false; error: string };
 
 /**
@@ -290,21 +322,31 @@ export function createMcpPlugin(options: MCPPluginOptions = {}): EnginePlugin {
 
           const tools = await client.tools();
           const shouldDeferTools = normalizedConfig.deferTools === true;
-          const toolCount = Object.keys(tools).length;
+          const disabledTools = new Set(normalizedConfig.disabledTools ?? []);
 
-          // 注册工具到引擎，使用命名空间前缀
-          const namespacedTools = Object.fromEntries(
-            Object.entries(tools).map(([toolName, tool]) => [
-              `mcp_${serverName}_${toolName}`,
-              shouldDeferTools ? { ...(tool as any), defer_loading: true } : (tool as any)
-            ])
-          );
+          // 逐个工具决定是否注册：被禁用的工具不进引擎工具表（agent 不可见），
+          // 但仍记入 status.tools（enabled:false），供宿主展示与切换。
+          const toolInfos: McpToolInfo[] = [];
+          const namespacedTools: Record<string, any> = {};
+          for (const [toolName, tool] of Object.entries(tools)) {
+            const enabled = !disabledTools.has(toolName);
+            const description = typeof (tool as any)?.description === 'string'
+              ? ((tool as any).description as string)
+              : undefined;
+            toolInfos.push({ name: toolName, description, enabled });
+            if (!enabled) continue;
+            // 注册工具到引擎，使用命名空间前缀
+            namespacedTools[`mcp_${serverName}_${toolName}`] = shouldDeferTools
+              ? { ...(tool as any), defer_loading: true }
+              : (tool as any);
+          }
 
           context.registerTools(namespacedTools);
 
+          const toolCount = Object.keys(namespacedTools).length;
           loadedCount++;
-          statuses[serverName] = { ok: true, toolCount };
-          console.log(`[MCP] Server "${serverName}" loaded (${toolCount} tools)`);
+          statuses[serverName] = { ok: true, toolCount, tools: toolInfos };
+          console.log(`[MCP] Server "${serverName}" loaded (${toolCount}/${toolInfos.length} tools)`);
 
           // 注册服务供其他插件使用
           context.registerService(`mcp:${serverName}`, client);


### PR DESCRIPTION
## Summary
Adds UI and backend support for toggling individual MCP tools on/off without removing the entire server. Users can now expand a server row to see all available tools and disable specific ones, which prevents the engine from registering them while keeping the server connection active.

## Key Changes

**Backend (Engine & Config)**
- Added `disabledTools?: string[]` field to MCP server configs to track which tools are disabled
- Updated `MCPServerStatus` type to include `tools: McpToolInfo[]` array with per-tool metadata (name, description, enabled state)
- Modified MCP plugin to skip registering disabled tools while still listing them in status with `enabled: false`
- Added `setCanvasMcpToolEnabled()` function to toggle individual tools by updating the `disabledTools` list
- Added comprehensive tests for tool enable/disable persistence and filtering

**Frontend (Canvas Workspace)**
- Created expandable `ToolsList` component to display all tools for a server with checkboxes
- Added expand/collapse buttons to server rows (both workspace and inherited sections)
- Updated `HealthBadge` to show "enabled/total" count when some tools are disabled (e.g., "2/3 tools")
- Added state tracking for expanded servers and busy tools (mid-toggle)
- Wired up `toggleTool` callback to call backend `setToolEnabled` API
- Added comprehensive CSS styling for tool list, toggles, and disabled state indicators

**IPC & Types**
- Added `setToolEnabled` method to `CanvasMcpApi` interface
- Implemented IPC handler in `canvas-mcp:set-tool-enabled` to persist changes and reload agents
- Updated type definitions across renderer, main, and engine packages
- Added i18n strings for tool list UI (expand/collapse, unavailable, none, update failed, partial health)

## Implementation Details

- Disabled tools are stored as a sorted, deduplicated array in the config file
- Empty `disabledTools` arrays are dropped entirely to keep configs clean
- Tool toggle operations trigger an engine reload so the agent immediately sees the change
- The UI shows disabled tools with strikethrough styling and grayed-out appearance
- Tool descriptions are displayed as tooltips/secondary text when available
- Busy state prevents toggling while the engine is reloading

https://claude.ai/code/session_01TwYkG8VtMLxRY8VEyWCEd3