### PR TITLE
Allow agent type reassignment during plan review phase

### DIFF
--- a/apps/canvas-workspace/src/main/__tests__/agent-teams-service.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/agent-teams-service.test.ts
@@ -250,6 +250,44 @@ describe('CanvasAgentTeamsService', () => {
     ]);
   });
 
+  it('re-assigns a teammate coding agent while the plan is under review', async () => {
+    const service = new CanvasAgentTeamsService();
+    const created = await createTeam(service);
+    await emitPlan(service, created);
+    const teamId = created.runtime.team.id;
+
+    const updated = await service.updatePlanTeammate('ws-1', teamId, {
+      teammateName: 'Reviewer',
+      agentType: 'claude-code',
+    });
+    expect(updated.phase).toBe('plan_review');
+    expect(updated.pendingPlan?.teammates.find((teammate) => teammate.name === 'Reviewer')?.agentType)
+      .toBe('claude-code');
+    expect(updated.pendingPlan?.teammates.find((teammate) => teammate.name === 'Codex Exec')?.agentType)
+      .toBe('codex');
+
+    // The reassigned agent type flows through to the teammate node on approval.
+    const confirmed = await service.confirmPlan('ws-1', teamId);
+    expect(confirmed.phase).toBe('executing');
+    expect(mockState.createdAgents.find((input) => input.name === 'Reviewer')?.agentType).toBe('claude-code');
+    expect(mockState.createdAgents.find((input) => input.name === 'Codex Exec')?.agentType).toBe('codex');
+
+    // Editing is only allowed during plan review.
+    await expect(service.updatePlanTeammate('ws-1', teamId, { teammateName: 'Reviewer', agentType: 'codex' }))
+      .rejects.toThrow('under review');
+  });
+
+  it('rejects re-assigning an unknown teammate in the pending plan', async () => {
+    const service = new CanvasAgentTeamsService();
+    const created = await createTeam(service);
+    await emitPlan(service, created);
+
+    await expect(service.updatePlanTeammate('ws-1', created.runtime.team.id, {
+      teammateName: 'Nope',
+      agentType: 'codex',
+    })).rejects.toThrow('Teammate not found in plan');
+  });
+
   it('resolves plan task dependencies as a full graph before dispatch', async () => {
     const service = new CanvasAgentTeamsService();
     const created = await createTeam(service);

--- a/apps/canvas-workspace/src/main/agent-teams/ipc.ts
+++ b/apps/canvas-workspace/src/main/agent-teams/ipc.ts
@@ -66,6 +66,21 @@ export function setupCanvasAgentTeamsIpc(): void {
     }
   });
 
+  ipcMain.handle(
+    'agent-teams:update-plan-teammate',
+    async (_event, payload: { workspaceId: string; teamId: string; teammateName: string; agentType: string }) => {
+      try {
+        const snapshot = await service.updatePlanTeammate(payload.workspaceId, payload.teamId, {
+          teammateName: payload.teammateName,
+          agentType: payload.agentType,
+        });
+        return ok({ snapshot });
+      } catch (err) {
+        return fail(err);
+      }
+    },
+  );
+
   ipcMain.handle('agent-teams:create-task', async (_event, payload: CanvasAgentTeamCreateTaskInput) => {
     try {
       const runtime = await service.createTask(payload);

--- a/apps/canvas-workspace/src/main/agent-teams/service.ts
+++ b/apps/canvas-workspace/src/main/agent-teams/service.ts
@@ -359,7 +359,7 @@ const formatLeaderBriefingPrompt = (teamName: string, goal: string, content: str
   'Your only job in this phase is to clarify requirements and draft a Pulse Canvas Agent Team plan.',
   'Do not implement the task yourself.',
   'Do not spawn teammates yourself; Pulse Canvas will create teammate nodes only after the user approves your plan.',
-  'If there is already a pending plan and the user asks for changes, revise and resubmit the plan. Do not create execution tasks during plan review.',
+  'If there is already a pending plan and the user asks for changes — including changes requested directly in this conversation — you MUST revise and resubmit the full plan by re-running propose-plan. A chat reply alone does NOT update the plan: the task graph shown to the user and the "Approve & Run" action keep using the last submitted plan until you re-run propose-plan. So after agreeing to any change, immediately resubmit the updated plan. Do not create execution tasks during plan review.',
   '',
   'When the plan is ready for user approval, submit it through the Pulse Canvas CLI instead of writing a terminal marker.',
   'Prefer --plan-json so you do not need to edit a temporary file. Use this JSON shape:',

--- a/apps/canvas-workspace/src/main/agent-teams/service.ts
+++ b/apps/canvas-workspace/src/main/agent-teams/service.ts
@@ -641,6 +641,36 @@ export class CanvasAgentTeamsService {
     return this.snapshot(workspaceId, teamId);
   }
 
+  async updatePlanTeammate(
+    workspaceId: string,
+    teamId: string,
+    input: { teammateName: string; agentType: string },
+  ): Promise<CanvasAgentTeamSnapshot> {
+    const { store } = this.getBundle(workspaceId);
+    const metadata = await this.requireMetadata(store, teamId);
+    if (metadata.phase !== 'plan_review' || !metadata.pendingPlan) {
+      throw new Error('Teammates can only be re-assigned while the plan is under review');
+    }
+    const agentType = cleanString(input.agentType);
+    if (!agentType) throw new Error('Agent type is required');
+
+    const key = cleanString(input.teammateName).toLowerCase();
+    const teammate = metadata.pendingPlan.teammates.find(
+      (candidate) => candidate.name.trim().toLowerCase() === key,
+    );
+    if (!teammate) throw new Error(`Teammate not found in plan: ${input.teammateName}`);
+    if (teammate.agentType === agentType) return this.snapshot(workspaceId, teamId);
+
+    const now = Date.now();
+    teammate.agentType = agentType;
+    metadata.pendingPlan.updatedAt = now;
+    metadata.updatedAt = now;
+    await store.saveTeamMetadata(teamId, metadata);
+    this.broadcastTeamUpdate(workspaceId, metadata);
+
+    return this.snapshot(workspaceId, teamId);
+  }
+
   async addAgent(input: CanvasAgentTeamAddAgentInput): Promise<CanvasAgentTeamSnapshot> {
     const { runtime, store } = this.getBundle(input.workspaceId);
     const metadata = await this.requireMetadata(store, input.teamId);

--- a/apps/canvas-workspace/src/preload/bridge/agent-teams.ts
+++ b/apps/canvas-workspace/src/preload/bridge/agent-teams.ts
@@ -10,6 +10,8 @@ export const createAgentTeamsApi = (ipcRenderer: IpcRenderer): AgentTeamsApi => 
     ipcRenderer.invoke('agent-teams:brief-lead', { workspaceId, teamId, content }),
   confirmPlan: (workspaceId, teamId) =>
     ipcRenderer.invoke('agent-teams:confirm-plan', { workspaceId, teamId }),
+  updatePlanTeammate: (workspaceId, teamId, teammateName, agentType) =>
+    ipcRenderer.invoke('agent-teams:update-plan-teammate', { workspaceId, teamId, teammateName, agentType }),
   createTask: (input) => ipcRenderer.invoke('agent-teams:create-task', input),
   dispatch: (workspaceId, teamId) => ipcRenderer.invoke('agent-teams:dispatch', { workspaceId, teamId }),
   pause: (workspaceId, teamId) => ipcRenderer.invoke('agent-teams:pause', { workspaceId, teamId }),

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
@@ -1259,8 +1259,11 @@
   height: auto;
   min-height: 104px;
   padding: 10px;
-  border-color: rgba(92, 128, 183, 0.16);
+  border: 1px solid rgba(92, 128, 183, 0.16);
+  border-radius: 6px;
   background: rgba(255, 255, 255, 0.9);
+  color: var(--text);
+  cursor: pointer;
   text-align: left;
   overflow: hidden;
   box-shadow: inset 4px 0 0 #d9dee8;
@@ -1318,6 +1321,9 @@
 }
 
 .agent-team-summary-agent__name {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   min-width: 0;
   overflow: hidden;
   color: var(--text);
@@ -1325,6 +1331,54 @@
   font-weight: 900;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.agent-team-summary-agent__logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 18px;
+  height: 18px;
+  color: #3d5071;
+}
+
+.agent-team-detail__agent-type {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.agent-team-summary-agent__agent-switch {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.agent-team-frame .agent-team-summary-agent__agent-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 24px;
+  padding: 0 7px;
+  border: 1px solid rgba(92, 128, 183, 0.24);
+  border-radius: 999px;
+  background: #f4f6fa;
+  color: #3d5071;
+  font-size: 10px;
+  font-weight: 800;
+}
+
+.agent-team-frame .agent-team-summary-agent__agent-option:hover:not(:disabled) {
+  border-color: #86b7f1;
+  background: #eaf2ff;
+}
+
+.agent-team-frame .agent-team-summary-agent__agent-option.is-active {
+  border-color: #438de1;
+  background: #e2efff;
+  color: #1f4f86;
 }
 
 .agent-team-summary-agent__task {

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
@@ -1115,6 +1115,53 @@
   padding: 12px 4px;
 }
 
+.agent-team-agent-detail__viewer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 0;
+}
+
+.agent-team-subtabs {
+  display: inline-flex;
+  gap: 14px;
+  border-bottom: 1px solid rgba(92, 128, 183, 0.16);
+}
+
+.agent-team-frame .agent-team-subtab {
+  height: 26px;
+  padding: 0 2px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.agent-team-frame .agent-team-subtab:hover:not(.is-active) {
+  color: var(--text);
+}
+
+.agent-team-frame .agent-team-subtab.is-active {
+  color: #1f4f86;
+  border-bottom-color: #438de1;
+}
+
+.agent-team-agent-detail__inline-terminal {
+  height: 240px;
+  min-height: 0;
+  overflow: hidden;
+  border: 1px solid rgba(92, 128, 183, 0.16);
+  border-radius: 8px;
+  background: #0f1115;
+}
+
+.agent-team-agent-detail__inline-terminal > * {
+  height: 100%;
+}
+
 .agent-team-graph-detail__head {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
@@ -1003,6 +1003,7 @@
 .agent-team-owner-chip {
   display: inline-flex;
   align-items: center;
+  gap: 4px;
   max-width: 100%;
   overflow: hidden;
   border: 1px solid #d8e4f2;
@@ -1015,6 +1016,13 @@
   padding: 2px 6px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.agent-team-owner-chip__logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
 }
 
 .agent-team-graph-task__copy .agent-team-owner-chip,

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
@@ -663,6 +663,7 @@
   position: absolute;
   display: inline-flex;
   align-items: center;
+  transform: translateX(-50%);
   gap: 7px;
   height: 30px;
   border: 1px solid rgba(122, 167, 232, 0.24);
@@ -1293,36 +1294,36 @@
 
 .agent-team-frame .agent-team-summary-agent--running,
 .agent-team-frame .agent-team-summary-agent--in_progress {
-  border-color: #9dc8fb;
-  background: linear-gradient(90deg, #f0f7ff 0%, rgba(255, 255, 255, 0.96) 62%);
-  box-shadow: inset 4px 0 0 #438de1;
+  border-color: #d2e0f1;
+  background: #f7fafe;
+  box-shadow: inset 3px 0 0 #8fb0d6;
 }
 
 .agent-team-frame .agent-team-summary-agent--needs_input,
 .agent-team-frame .agent-team-summary-agent--blocked {
-  border-color: #e6bd58;
-  background: linear-gradient(90deg, #fff7df 0%, rgba(255, 255, 255, 0.96) 62%);
-  box-shadow: inset 4px 0 0 #d99a16;
+  border-color: #ecdcb0;
+  background: #fdfaf2;
+  box-shadow: inset 3px 0 0 #d2b066;
 }
 
 .agent-team-frame .agent-team-summary-agent--needs_review,
 .agent-team-frame .agent-team-summary-agent--todo {
-  border-color: #d9c075;
-  background: linear-gradient(90deg, #fffaf0 0%, rgba(255, 255, 255, 0.96) 62%);
-  box-shadow: inset 4px 0 0 #c4932c;
+  border-color: #e6dcbe;
+  background: #fbf9f3;
+  box-shadow: inset 3px 0 0 #cab47f;
 }
 
 .agent-team-frame .agent-team-summary-agent--done {
-  border-color: #9fcfb3;
-  background: linear-gradient(90deg, #effaf3 0%, rgba(255, 255, 255, 0.96) 62%);
-  box-shadow: inset 4px 0 0 #2fb06d;
+  border-color: #cce3d5;
+  background: #f4faf6;
+  box-shadow: inset 3px 0 0 #84bd9e;
 }
 
 .agent-team-frame .agent-team-summary-agent--failed,
 .agent-team-frame .agent-team-summary-agent--error {
-  border-color: #e6aaa3;
-  background: linear-gradient(90deg, #fff1ef 0%, rgba(255, 255, 255, 0.96) 62%);
-  box-shadow: inset 4px 0 0 #d4503f;
+  border-color: #ebcbc5;
+  background: #fdf4f2;
+  box-shadow: inset 3px 0 0 #d49a92;
 }
 
 .agent-team-summary-agent .agent-team-detail__status {

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
@@ -1210,6 +1210,9 @@
   justify-items: center;
   gap: 6px;
   min-width: 100%;
+  min-height: 100%;
+  box-sizing: border-box;
+  padding: 24px;
   color: var(--text-secondary);
   text-align: center;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
@@ -1352,36 +1352,45 @@
   gap: 5px;
 }
 
-.agent-team-summary-agent__agent-switch {
+.agent-team-summary-agent__agent-select {
   grid-column: 1 / -1;
   display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
 }
 
-.agent-team-frame .agent-team-summary-agent__agent-option {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  height: 24px;
-  padding: 0 7px;
-  border: 1px solid rgba(92, 128, 183, 0.24);
-  border-radius: 999px;
-  background: #f4f6fa;
-  color: #3d5071;
+.agent-team-summary-agent__agent-select-label {
+  flex: 0 0 auto;
+  color: var(--text-secondary);
   font-size: 10px;
   font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
 }
 
-.agent-team-frame .agent-team-summary-agent__agent-option:hover:not(:disabled) {
+.agent-team-frame .agent-team-summary-agent__agent-select select {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 26px;
+  padding: 0 8px;
+  border: 1px solid rgba(92, 128, 183, 0.24);
+  border-radius: 6px;
+  background: #f4f6fa;
+  color: #1f3a5f;
+  font-size: 11px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.agent-team-frame .agent-team-summary-agent__agent-select select:hover {
   border-color: #86b7f1;
   background: #eaf2ff;
 }
 
-.agent-team-frame .agent-team-summary-agent__agent-option.is-active {
-  border-color: #438de1;
-  background: #e2efff;
-  color: #1f4f86;
+.agent-team-frame .agent-team-summary-agent__agent-select select:focus-visible {
+  outline: 2px solid #86b7f1;
+  outline-offset: 1px;
 }
 
 .agent-team-summary-agent__task {

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
@@ -1123,9 +1123,28 @@
 }
 
 .agent-team-subtabs {
-  display: inline-flex;
+  display: flex;
+  align-items: flex-end;
   gap: 14px;
   border-bottom: 1px solid rgba(92, 128, 183, 0.16);
+}
+
+.agent-team-frame .agent-team-subtab-expand {
+  height: 24px;
+  width: 26px;
+  margin-left: auto;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1;
+}
+
+.agent-team-frame .agent-team-subtab-expand:hover {
+  color: var(--text);
+  background: rgba(92, 128, 183, 0.12);
 }
 
 .agent-team-frame .agent-team-subtab {

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
@@ -714,8 +714,8 @@
 }
 
 .agent-team-frame .agent-team-dag-node--owner-highlight:not(.agent-team-dag-node--selected) {
-  border-color: #93c9a9;
-  background: #f4fbf7;
+  border-color: #b3bdec;
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.26), 0 8px 20px rgba(31, 54, 88, 0.05);
 }
 
 .agent-team-frame .agent-team-dag-node--warning {

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
@@ -1168,6 +1168,17 @@
   border-bottom-color: #438de1;
 }
 
+.agent-team-agent-detail__activity {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.agent-team-agent-detail__viewer--terminal {
+  flex: 1 1 auto;
+  min-height: 280px;
+}
+
 .agent-team-agent-detail__inline-terminal {
   height: 240px;
   min-height: 0;
@@ -1175,6 +1186,12 @@
   border: 1px solid rgba(92, 128, 183, 0.16);
   border-radius: 8px;
   background: #0f1115;
+}
+
+.agent-team-agent-detail__viewer--terminal .agent-team-agent-detail__inline-terminal {
+  flex: 1 1 auto;
+  height: auto;
+  min-height: 240px;
 }
 
 .agent-team-agent-detail__inline-terminal > * {

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
@@ -1080,6 +1080,41 @@
   padding: 10px;
 }
 
+.agent-team-detail-tabs {
+  display: inline-flex;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid rgba(92, 128, 183, 0.18);
+  border-radius: 8px;
+  background: rgba(238, 243, 250, 0.7);
+}
+
+.agent-team-frame .agent-team-detail-tab {
+  height: 24px;
+  padding: 0 14px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.agent-team-frame .agent-team-detail-tab:hover:not(.is-active) {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.agent-team-frame .agent-team-detail-tab.is-active {
+  background: #ffffff;
+  color: #1f4f86;
+  box-shadow: 0 1px 3px rgba(31, 54, 88, 0.12);
+}
+
+.agent-team-detail__empty {
+  padding: 12px 4px;
+}
+
 .agent-team-graph-detail__head {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
@@ -1187,28 +1187,7 @@ export const AgentTeamFrame = ({
           </span>
         </div>
 
-        <div className="agent-team-agent-detail__meta">
-          <span className="agent-team-detail__agent-type">
-            <AgentIcon id={selectedGraphAgent.agentType ?? 'pulse-coder'} size={13} />
-            {agentTypeLabel(selectedGraphAgent.agentType)}
-          </span>
-          {selectedGraphAgent.nodeId && <code>{selectedGraphAgent.nodeId}</code>}
-          <span>{agentData?.cwd || rootFolder || 'No workspace'}</span>
-        </div>
-
-        <div className="agent-team-agent-detail__stats">
-          <span><strong>{selectedGraphAgent.taskCount}</strong> tasks</span>
-          <span><strong>{selectedGraphAgent.runningCount}</strong> running</span>
-          <span><strong>{selectedGraphAgent.blockedCount}</strong> blocked</span>
-          <span><strong>{selectedGraphAgent.artifactCount}</strong> artifacts</span>
-        </div>
-
-        <div className="agent-team-agent-detail__section">
-          <span className="agent-team-detail__section-title">Current task</span>
-          <strong>{selectedGraphAgent.currentTaskTitle ?? 'No active task'}</strong>
-        </div>
-
-        <div className="agent-team-agent-detail__viewer">
+        <div className={`agent-team-agent-detail__viewer${agentViewMode === 'terminal' ? ' agent-team-agent-detail__viewer--terminal' : ''}`}>
           <div className="agent-team-subtabs" role="tablist" aria-label="Agent view">
             <button
               type="button"
@@ -1242,13 +1221,70 @@ export const AgentTeamFrame = ({
             </button>
           </div>
           {agentViewMode === 'activity' ? (
-            <div className="agent-team-agent-detail__section">
-              <span className="agent-team-detail__section-title">Recent output</span>
-              {activityLines.length === 0 ? (
-                <span className="agent-team-detail__muted">No readable output yet.</span>
-              ) : activityLines.map((line, index) => (
-                <span key={`${index}-${line}`} className="agent-team-agent-detail__output">{line}</span>
-              ))}
+            <div className="agent-team-agent-detail__activity">
+              <div className="agent-team-agent-detail__meta">
+                <span className="agent-team-detail__agent-type">
+                  <AgentIcon id={selectedGraphAgent.agentType ?? 'pulse-coder'} size={13} />
+                  {agentTypeLabel(selectedGraphAgent.agentType)}
+                </span>
+                {selectedGraphAgent.nodeId && <code>{selectedGraphAgent.nodeId}</code>}
+                <span>{agentData?.cwd || rootFolder || 'No workspace'}</span>
+              </div>
+
+              <div className="agent-team-agent-detail__stats">
+                <span><strong>{selectedGraphAgent.taskCount}</strong> tasks</span>
+                <span><strong>{selectedGraphAgent.runningCount}</strong> running</span>
+                <span><strong>{selectedGraphAgent.blockedCount}</strong> blocked</span>
+                <span><strong>{selectedGraphAgent.artifactCount}</strong> artifacts</span>
+              </div>
+
+              <div className="agent-team-agent-detail__section">
+                <span className="agent-team-detail__section-title">Current task</span>
+                <strong>{selectedGraphAgent.currentTaskTitle ?? 'No active task'}</strong>
+              </div>
+
+              <div className="agent-team-agent-detail__section">
+                <span className="agent-team-detail__section-title">Assigned tasks</span>
+                {ownedTasks.length === 0 ? (
+                  <span className="agent-team-detail__muted">No assigned tasks.</span>
+                ) : ownedTasks.map((task) => (
+                  <button
+                    key={task.key}
+                    type="button"
+                    className={`agent-team-agent-detail__task agent-team-agent-detail__task--${task.status}`}
+                    onClick={() => selectGraphTask(task)}
+                  >
+                    <strong>{task.title}</strong>
+                    <span>{statusLabel(task.status)}</span>
+                  </button>
+                ))}
+              </div>
+
+              <div className="agent-team-agent-detail__section">
+                <span className="agent-team-detail__section-title">Artifacts</span>
+                {agentArtifacts.length === 0 ? (
+                  <span className="agent-team-detail__muted">None yet</span>
+                ) : agentArtifacts.map((artifact) => (
+                  <button
+                    key={artifact.id}
+                    type="button"
+                    className="agent-team-detail__pill agent-team-detail__pill--artifact agent-team-detail__artifact-button"
+                    title={artifact.summary ?? artifact.uri ?? ''}
+                    onClick={() => setSelectedArtifactId(artifact.id)}
+                  >
+                    {artifactLabel(artifact)}
+                  </button>
+                ))}
+              </div>
+
+              <div className="agent-team-agent-detail__section">
+                <span className="agent-team-detail__section-title">Recent output</span>
+                {activityLines.length === 0 ? (
+                  <span className="agent-team-detail__muted">No readable output yet.</span>
+                ) : activityLines.map((line, index) => (
+                  <span key={`${index}-${line}`} className="agent-team-agent-detail__output">{line}</span>
+                ))}
+              </div>
             </div>
           ) : agentNode ? (
             <div className="agent-team-agent-detail__inline-terminal">
@@ -1269,41 +1305,6 @@ export const AgentTeamFrame = ({
             </div>
           )}
         </div>
-
-        <div className="agent-team-agent-detail__section">
-          <span className="agent-team-detail__section-title">Assigned tasks</span>
-          {ownedTasks.length === 0 ? (
-            <span className="agent-team-detail__muted">No assigned tasks.</span>
-          ) : ownedTasks.map((task) => (
-            <button
-              key={task.key}
-              type="button"
-              className={`agent-team-agent-detail__task agent-team-agent-detail__task--${task.status}`}
-              onClick={() => selectGraphTask(task)}
-            >
-              <strong>{task.title}</strong>
-              <span>{statusLabel(task.status)}</span>
-            </button>
-          ))}
-        </div>
-
-        <div className="agent-team-agent-detail__section">
-          <span className="agent-team-detail__section-title">Artifacts</span>
-          {agentArtifacts.length === 0 ? (
-            <span className="agent-team-detail__muted">None yet</span>
-          ) : agentArtifacts.map((artifact) => (
-            <button
-              key={artifact.id}
-              type="button"
-              className="agent-team-detail__pill agent-team-detail__pill--artifact agent-team-detail__artifact-button"
-              title={artifact.summary ?? artifact.uri ?? ''}
-              onClick={() => setSelectedArtifactId(artifact.id)}
-            >
-              {artifactLabel(artifact)}
-            </button>
-          ))}
-        </div>
-
       </>
     );
   };

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import './index.css';
 import { AgentNodeBody } from '../AgentNodeBody';
+import { AgentIcon } from '../AgentNodeBody/AgentIcon';
+import { AGENT_REGISTRY } from '../../config/agentRegistry';
 import type {
   AgentNodeData,
   AgentTeamAgentRecord,
@@ -162,6 +164,9 @@ const isTeamAgentNode = (node: CanvasNode, teamId: string): node is CanvasNode &
   node.type === 'agent'
   && (node.data as AgentNodeData).agentTeamId === teamId
   && !!(node.data as AgentNodeData).agentTeamAgentId;
+
+const agentTypeLabel = (agentType?: string): string =>
+  AGENT_REGISTRY.find((def) => def.id === agentType)?.label ?? agentType ?? 'Coding Agent';
 
 const metadataNumber = (
   metadata: Record<string, unknown> | undefined,
@@ -523,7 +528,8 @@ export const AgentTeamFrame = ({
         key: `agent:${agent.id}`,
         name: agent.name,
         role: agent.role,
-        agentType: agent.sessionRef?.provider ?? agent.sessionRef?.displayName,
+        agentType: agentNodeByAgentId.get(agent.id)?.data?.agentType
+          ?? agent.sessionRef?.provider ?? agent.sessionRef?.displayName,
         status: agent.status,
         taskCount: ownedTasks.length,
         doneCount: ownedTasks.filter((task) => task.status === 'done').length,
@@ -713,6 +719,17 @@ export const AgentTeamFrame = ({
       setError(null);
     } else {
       setError(result.error ?? 'Unable to confirm plan.');
+    }
+  }, [api, workspaceId, teamId]);
+
+  const handleUpdatePlanTeammate = useCallback(async (teammateName: string, agentType: string) => {
+    if (!api || !workspaceId || !teamId) return;
+    const result = await api.updatePlanTeammate(workspaceId, teamId, teammateName, agentType);
+    if (result.ok && result.snapshot) {
+      setSnapshot(result.snapshot);
+      setError(null);
+    } else {
+      setError(result.error ?? 'Unable to update teammate agent.');
     }
   }, [api, workspaceId, teamId]);
 
@@ -1159,7 +1176,10 @@ export const AgentTeamFrame = ({
         </div>
 
         <div className="agent-team-agent-detail__meta">
-          <span>{selectedGraphAgent.agentType ?? 'Coding Agent'}</span>
+          <span className="agent-team-detail__agent-type">
+            <AgentIcon id={selectedGraphAgent.agentType ?? 'pulse-coder'} size={13} />
+            {agentTypeLabel(selectedGraphAgent.agentType)}
+          </span>
           {selectedGraphAgent.nodeId && <code>{selectedGraphAgent.nodeId}</code>}
           <span>{agentData?.cwd || rootFolder || 'No workspace'}</span>
         </div>
@@ -1310,30 +1330,67 @@ export const AgentTeamFrame = ({
           <div className="agent-team-agent-strip__empty">
             Agents appear here after the Team Lead proposes a plan.
           </div>
-        ) : graphAgents.map((agent) => (
-          <button
-            key={agent.key}
-            type="button"
-            className={`agent-team-summary-agent agent-team-summary-agent--${agent.status}${selectedAgentKey === agent.key ? ' agent-team-summary-agent--selected' : ''}${selectedGraphTask?.ownerKey === agent.key ? ' agent-team-summary-agent--task-owner' : ''}`}
-            onClick={() => {
-              setSelectedAgentKey(agent.key);
-              setDetailPanelMode('agent');
-            }}
-          >
-            <span className="agent-team-summary-agent__name">{agent.name}</span>
-            <span className={`agent-team-detail__status agent-team-detail__status--${agent.status}`}>
-              {statusLabel(agent.status)}
-            </span>
-            <span className="agent-team-summary-agent__task">
-              {agent.currentTaskTitle ?? `${agent.taskCount} task${agent.taskCount === 1 ? '' : 's'}`}
-            </span>
-            <span className="agent-team-summary-agent__stats">
-              <span>Tasks {agent.doneCount}/{agent.taskCount}</span>
-              <span>Tools {agent.toolCount ?? '—'}</span>
-              <span>Artifacts {agent.artifactCount}</span>
-            </span>
-          </button>
-        ))}
+        ) : graphAgents.map((agent) => {
+          const selectAgent = () => {
+            setSelectedAgentKey(agent.key);
+            setDetailPanelMode('agent');
+          };
+          const editable = phase === 'plan_review' && agent.role === 'teammate' && !readOnly;
+          return (
+            <div
+              key={agent.key}
+              role="button"
+              tabIndex={0}
+              className={`agent-team-summary-agent agent-team-summary-agent--${agent.status}${selectedAgentKey === agent.key ? ' agent-team-summary-agent--selected' : ''}${selectedGraphTask?.ownerKey === agent.key ? ' agent-team-summary-agent--task-owner' : ''}`}
+              onClick={selectAgent}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault();
+                  selectAgent();
+                }
+              }}
+            >
+              <span className="agent-team-summary-agent__name">
+                <span className="agent-team-summary-agent__logo">
+                  <AgentIcon id={agent.agentType ?? 'pulse-coder'} size={14} />
+                </span>
+                {agent.name}
+              </span>
+              <span className={`agent-team-detail__status agent-team-detail__status--${agent.status}`}>
+                {statusLabel(agent.status)}
+              </span>
+              {editable ? (
+                <span className="agent-team-summary-agent__agent-switch" role="group" aria-label="Coding agent">
+                  {AGENT_REGISTRY.map((def) => (
+                    <button
+                      key={def.id}
+                      type="button"
+                      title={`Use ${def.label}`}
+                      aria-pressed={agent.agentType === def.id}
+                      className={`agent-team-summary-agent__agent-option${agent.agentType === def.id ? ' is-active' : ''}`}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        void handleUpdatePlanTeammate(agent.name, def.id);
+                      }}
+                    >
+                      <AgentIcon id={def.id} size={13} />
+                      <span>{def.label}</span>
+                    </button>
+                  ))}
+                </span>
+              ) : (
+                <span className="agent-team-summary-agent__task">
+                  {agent.currentTaskTitle ?? `${agent.taskCount} task${agent.taskCount === 1 ? '' : 's'}`}
+                </span>
+              )}
+              <span className="agent-team-summary-agent__stats">
+                <span>Tasks {agent.doneCount}/{agent.taskCount}</span>
+                <span>Tools {agent.toolCount ?? '—'}</span>
+                <span>Artifacts {agent.artifactCount}</span>
+              </span>
+            </div>
+          );
+        })}
       </div>
     </div>
   );
@@ -1412,7 +1469,10 @@ export const AgentTeamFrame = ({
           <div className="agent-team-agent-inspector__body">
             <div className="agent-team-agent-inspector__summary">
               <div className="agent-team-agent-inspector__meta">
-                <span>{selectedGraphAgent.agentType ?? 'Coding Agent'}</span>
+                <span className="agent-team-detail__agent-type">
+            <AgentIcon id={selectedGraphAgent.agentType ?? 'pulse-coder'} size={13} />
+            {agentTypeLabel(selectedGraphAgent.agentType)}
+          </span>
                 <span>{statusLabel(selectedGraphAgent.status)}</span>
                 {selectedGraphAgent.nodeId && <code>{selectedGraphAgent.nodeId}</code>}
               </div>

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
@@ -430,7 +430,8 @@ export const AgentTeamFrame = ({
     const nodes: DagNodeItem[] = [];
     const stages: DagStageItem[] = graphColumns.map((_column, columnIndex) => ({
       key: `stage-${columnIndex}`,
-      x: DAG_LEFT + columnIndex * DAG_COLUMN_GAP,
+      // Center the stage header over its node column (offset compensated via translateX in CSS).
+      x: DAG_LEFT + columnIndex * DAG_COLUMN_GAP + DAG_NODE_WIDTH / 2,
       y: 24 + verticalShift,
       label: columnIndex === 0 ? 'Start' : `Stage ${columnIndex + 1}`,
       index: columnIndex + 1,

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
@@ -275,6 +275,7 @@ export const AgentTeamFrame = ({
   const [selectedArtifactId, setSelectedArtifactId] = useState('');
   const [selectedAgentKey, setSelectedAgentKey] = useState('');
   const [agentInspectorMode, setAgentInspectorMode] = useState<'activity' | 'terminal'>('terminal');
+  const [agentViewMode, setAgentViewMode] = useState<'activity' | 'terminal'>('activity');
   const [detailPanelMode, setDetailPanelMode] = useState<'task' | 'agent'>('task');
   const [agentInspectorOpen, setAgentInspectorOpen] = useState(false);
   const [selectedPlanTaskKey, setSelectedPlanTaskKey] = useState('');
@@ -605,6 +606,7 @@ export const AgentTeamFrame = ({
 
   useEffect(() => {
     setAgentInspectorMode('terminal');
+    setAgentViewMode('activity');
   }, [selectedAgentKey]);
 
   useEffect(() => {
@@ -1254,13 +1256,54 @@ export const AgentTeamFrame = ({
           ))}
         </div>
 
-        <div className="agent-team-agent-detail__section">
-          <span className="agent-team-detail__section-title">Recent output</span>
-          {activityLines.length === 0 ? (
-            <span className="agent-team-detail__muted">No readable output yet.</span>
-          ) : activityLines.map((line, index) => (
-            <span key={`${index}-${line}`} className="agent-team-agent-detail__output">{line}</span>
-          ))}
+        <div className="agent-team-agent-detail__viewer">
+          <div className="agent-team-subtabs" role="tablist" aria-label="Agent view">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={agentViewMode === 'activity'}
+              className={`agent-team-subtab${agentViewMode === 'activity' ? ' is-active' : ''}`}
+              onClick={() => setAgentViewMode('activity')}
+            >
+              Activity
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={agentViewMode === 'terminal'}
+              className={`agent-team-subtab${agentViewMode === 'terminal' ? ' is-active' : ''}`}
+              onClick={() => setAgentViewMode('terminal')}
+            >
+              Terminal
+            </button>
+          </div>
+          {agentViewMode === 'activity' ? (
+            <div className="agent-team-agent-detail__section">
+              <span className="agent-team-detail__section-title">Recent output</span>
+              {activityLines.length === 0 ? (
+                <span className="agent-team-detail__muted">No readable output yet.</span>
+              ) : activityLines.map((line, index) => (
+                <span key={`${index}-${line}`} className="agent-team-agent-detail__output">{line}</span>
+              ))}
+            </div>
+          ) : agentNode ? (
+            <div className="agent-team-agent-detail__inline-terminal">
+              <AgentNodeBody
+                node={agentNode}
+                getAllNodes={getAllNodes}
+                rootFolder={rootFolder}
+                workspaceId={workspaceId}
+                workspaceName={workspaceName}
+                onUpdate={onUpdate}
+                readOnly={readOnly}
+                terminalMode="mirror"
+              />
+            </div>
+          ) : (
+            <div className="agent-team-detail__muted agent-team-detail__empty">
+              No runtime node yet. Approve &amp; run the plan to stream the terminal.
+            </div>
+          )}
         </div>
       </>
     );

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
@@ -1187,20 +1187,6 @@ export const AgentTeamFrame = ({
           </span>
         </div>
 
-        <div className="agent-team-agent-detail__actions">
-          <button
-            type="button"
-            className="agent-team-agent-detail__terminal-button"
-            onClick={() => {
-              setAgentInspectorMode('terminal');
-              setAgentInspectorOpen(true);
-            }}
-            disabled={!agentNode}
-          >
-            Open terminal
-          </button>
-        </div>
-
         <div className="agent-team-agent-detail__meta">
           <span className="agent-team-detail__agent-type">
             <AgentIcon id={selectedGraphAgent.agentType ?? 'pulse-coder'} size={13} />
@@ -1220,6 +1206,68 @@ export const AgentTeamFrame = ({
         <div className="agent-team-agent-detail__section">
           <span className="agent-team-detail__section-title">Current task</span>
           <strong>{selectedGraphAgent.currentTaskTitle ?? 'No active task'}</strong>
+        </div>
+
+        <div className="agent-team-agent-detail__viewer">
+          <div className="agent-team-subtabs" role="tablist" aria-label="Agent view">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={agentViewMode === 'activity'}
+              className={`agent-team-subtab${agentViewMode === 'activity' ? ' is-active' : ''}`}
+              onClick={() => setAgentViewMode('activity')}
+            >
+              Activity
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={agentViewMode === 'terminal'}
+              className={`agent-team-subtab${agentViewMode === 'terminal' ? ' is-active' : ''}`}
+              onClick={() => setAgentViewMode('terminal')}
+            >
+              Terminal
+            </button>
+            <button
+              type="button"
+              className="agent-team-subtab-expand"
+              title="Open in large view"
+              aria-label="Open in large view"
+              onClick={() => {
+                setAgentInspectorMode(agentViewMode);
+                setAgentInspectorOpen(true);
+              }}
+            >
+              ⤢
+            </button>
+          </div>
+          {agentViewMode === 'activity' ? (
+            <div className="agent-team-agent-detail__section">
+              <span className="agent-team-detail__section-title">Recent output</span>
+              {activityLines.length === 0 ? (
+                <span className="agent-team-detail__muted">No readable output yet.</span>
+              ) : activityLines.map((line, index) => (
+                <span key={`${index}-${line}`} className="agent-team-agent-detail__output">{line}</span>
+              ))}
+            </div>
+          ) : agentNode ? (
+            <div className="agent-team-agent-detail__inline-terminal">
+              <AgentNodeBody
+                node={agentNode}
+                getAllNodes={getAllNodes}
+                rootFolder={rootFolder}
+                workspaceId={workspaceId}
+                workspaceName={workspaceName}
+                onUpdate={onUpdate}
+                readOnly={readOnly}
+                terminalMode="mirror"
+              />
+            </div>
+          ) : (
+            <div className="agent-team-detail__muted agent-team-detail__empty">
+              No runtime node yet. Approve &amp; run the plan to stream the terminal.
+            </div>
+          )}
         </div>
 
         <div className="agent-team-agent-detail__section">
@@ -1256,55 +1304,6 @@ export const AgentTeamFrame = ({
           ))}
         </div>
 
-        <div className="agent-team-agent-detail__viewer">
-          <div className="agent-team-subtabs" role="tablist" aria-label="Agent view">
-            <button
-              type="button"
-              role="tab"
-              aria-selected={agentViewMode === 'activity'}
-              className={`agent-team-subtab${agentViewMode === 'activity' ? ' is-active' : ''}`}
-              onClick={() => setAgentViewMode('activity')}
-            >
-              Activity
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={agentViewMode === 'terminal'}
-              className={`agent-team-subtab${agentViewMode === 'terminal' ? ' is-active' : ''}`}
-              onClick={() => setAgentViewMode('terminal')}
-            >
-              Terminal
-            </button>
-          </div>
-          {agentViewMode === 'activity' ? (
-            <div className="agent-team-agent-detail__section">
-              <span className="agent-team-detail__section-title">Recent output</span>
-              {activityLines.length === 0 ? (
-                <span className="agent-team-detail__muted">No readable output yet.</span>
-              ) : activityLines.map((line, index) => (
-                <span key={`${index}-${line}`} className="agent-team-agent-detail__output">{line}</span>
-              ))}
-            </div>
-          ) : agentNode ? (
-            <div className="agent-team-agent-detail__inline-terminal">
-              <AgentNodeBody
-                node={agentNode}
-                getAllNodes={getAllNodes}
-                rootFolder={rootFolder}
-                workspaceId={workspaceId}
-                workspaceName={workspaceName}
-                onUpdate={onUpdate}
-                readOnly={readOnly}
-                terminalMode="mirror"
-              />
-            </div>
-          ) : (
-            <div className="agent-team-detail__muted agent-team-detail__empty">
-              No runtime node yet. Approve &amp; run the plan to stream the terminal.
-            </div>
-          )}
-        </div>
       </>
     );
   };

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
@@ -551,6 +551,10 @@ export const AgentTeamFrame = ({
     });
   }, [artifacts, graphTaskByKey, graphTasks, phase, plan, teammates]);
   const selectedGraphAgent = graphAgents.find((agent) => agent.key === selectedAgentKey);
+  const agentTypeByOwnerKey = useMemo(
+    () => new Map(graphAgents.map((agent) => [agent.key, agent.agentType])),
+    [graphAgents],
+  );
 
   const teamTitle = runtime?.team.name ?? data.agentTeamName ?? node.title;
   const teamGoal = shortText(runtime?.team.goal ?? data.agentTeamGoal ?? data.label, '');
@@ -849,6 +853,20 @@ export const AgentTeamFrame = ({
   const ownerChipClass = (ownerKey?: string) =>
     `agent-team-owner-chip${ownerKey && selectedAgentKey === ownerKey ? ' agent-team-owner-chip--active' : ''}`;
 
+  const renderOwnerChip = (ownerKey: string | undefined, ownerName: string) => {
+    const agentType = ownerKey ? agentTypeByOwnerKey.get(ownerKey) : undefined;
+    return (
+      <span className={ownerChipClass(ownerKey)}>
+        {agentType && (
+          <span className="agent-team-owner-chip__logo">
+            <AgentIcon id={agentType} size={12} />
+          </span>
+        )}
+        {ownerName}
+      </span>
+    );
+  };
+
   const renderDagCanvas = (variant: 'inline' | 'fullscreen' = 'inline') => {
     if (graphColumns.length === 0) {
       return (
@@ -936,7 +954,7 @@ export const AgentTeamFrame = ({
                 <strong>{task.title}</strong>
                 <span className="agent-team-dag-node__meta">
                   <span>{statusLabel(task.status)}</span>
-                  <span className={ownerChipClass(task.ownerKey)}>{task.ownerName}</span>
+                  {renderOwnerChip(task.ownerKey, task.ownerName)}
                 </span>
               </span>
             </button>
@@ -1261,7 +1279,7 @@ export const AgentTeamFrame = ({
         <div className="agent-team-detail__facts">
           <div>
             <span className="agent-team-detail__section-title">Owner</span>
-            <span className={ownerChipClass(selectedGraphTask.ownerKey)}>{selectedGraphTask.ownerName}</span>
+            {renderOwnerChip(selectedGraphTask.ownerKey, selectedGraphTask.ownerName)}
           </div>
           <div>
             <span className="agent-team-detail__section-title">Updated</span>

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
@@ -168,6 +168,9 @@ const isTeamAgentNode = (node: CanvasNode, teamId: string): node is CanvasNode &
 const agentTypeLabel = (agentType?: string): string =>
   AGENT_REGISTRY.find((def) => def.id === agentType)?.label ?? agentType ?? 'Coding Agent';
 
+// Agent Teams currently supports only Claude Code and Codex for teammates.
+const TEAM_AGENT_OPTIONS = AGENT_REGISTRY.filter((def) => def.id === 'claude-code' || def.id === 'codex');
+
 const metadataNumber = (
   metadata: Record<string, unknown> | undefined,
   keys: string[],
@@ -1360,24 +1363,28 @@ export const AgentTeamFrame = ({
                 {statusLabel(agent.status)}
               </span>
               {editable ? (
-                <span className="agent-team-summary-agent__agent-switch" role="group" aria-label="Coding agent">
-                  {AGENT_REGISTRY.map((def) => (
-                    <button
-                      key={def.id}
-                      type="button"
-                      title={`Use ${def.label}`}
-                      aria-pressed={agent.agentType === def.id}
-                      className={`agent-team-summary-agent__agent-option${agent.agentType === def.id ? ' is-active' : ''}`}
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        void handleUpdatePlanTeammate(agent.name, def.id);
-                      }}
-                    >
-                      <AgentIcon id={def.id} size={13} />
-                      <span>{def.label}</span>
-                    </button>
-                  ))}
-                </span>
+                <label
+                  className="agent-team-summary-agent__agent-select"
+                  onClick={(event) => event.stopPropagation()}
+                >
+                  <span className="agent-team-summary-agent__agent-select-label">Coding agent</span>
+                  <select
+                    value={TEAM_AGENT_OPTIONS.some((def) => def.id === agent.agentType)
+                      ? agent.agentType
+                      : TEAM_AGENT_OPTIONS[0].id}
+                    aria-label={`Coding agent for ${agent.name}`}
+                    onClick={(event) => event.stopPropagation()}
+                    onKeyDown={(event) => event.stopPropagation()}
+                    onChange={(event) => {
+                      event.stopPropagation();
+                      void handleUpdatePlanTeammate(agent.name, event.target.value);
+                    }}
+                  >
+                    {TEAM_AGENT_OPTIONS.map((def) => (
+                      <option key={def.id} value={def.id}>{def.label}</option>
+                    ))}
+                  </select>
+                </label>
               ) : (
                 <span className="agent-team-summary-agent__task">
                   {agent.currentTaskTitle ?? `${agent.taskCount} task${agent.taskCount === 1 ? '' : 's'}`}

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
@@ -1168,11 +1168,13 @@ export const AgentTeamFrame = ({
     };
   };
 
-  const renderAgentSideDetail = () => {
-    if (!selectedGraphAgent) return null;
+  const renderAgentDetailContent = () => {
+    if (!selectedGraphAgent) {
+      return <div className="agent-team-detail__muted agent-team-detail__empty">Select an agent to see its detail.</div>;
+    }
     const { ownedTasks, agentArtifacts, agentNode, agentData, activityLines } = getAgentDetailContext(selectedGraphAgent);
     return (
-      <aside className="agent-team-graph-detail agent-team-graph-detail--agent" aria-label="Selected agent detail">
+      <>
         <div className="agent-team-graph-detail__head">
           <div>
             <span className="agent-team-panel-heading__label">Selected agent</span>
@@ -1260,14 +1262,16 @@ export const AgentTeamFrame = ({
             <span key={`${index}-${line}`} className="agent-team-agent-detail__output">{line}</span>
           ))}
         </div>
-      </aside>
+      </>
     );
   };
 
-  const renderTaskSideDetail = () => {
-    if (!selectedGraphTask) return null;
+  const renderTaskDetailContent = () => {
+    if (!selectedGraphTask) {
+      return <div className="agent-team-detail__muted agent-team-detail__empty">Select a task to see its detail.</div>;
+    }
     return (
-      <aside className="agent-team-graph-detail" aria-label="Selected task detail">
+      <>
         <div className="agent-team-graph-detail__head">
           <div>
             <span className="agent-team-panel-heading__label">Selected task</span>
@@ -1337,6 +1341,38 @@ export const AgentTeamFrame = ({
         {selectedHumanTaskGate && selectedGraphTask.sourceTask && (
           renderHumanGate(selectedHumanTaskGate, { compact: true })
         )}
+      </>
+    );
+  };
+
+  const renderDetailPanel = () => {
+    const agentActive = detailPanelMode === 'agent';
+    return (
+      <aside
+        className={`agent-team-graph-detail agent-team-graph-detail--tabbed${agentActive ? ' agent-team-graph-detail--agent' : ''}`}
+        aria-label="Selected detail"
+      >
+        <div className="agent-team-detail-tabs" role="tablist" aria-label="Detail view">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={!agentActive}
+            className={`agent-team-detail-tab${!agentActive ? ' is-active' : ''}`}
+            onClick={() => setDetailPanelMode('task')}
+          >
+            Task
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={agentActive}
+            className={`agent-team-detail-tab${agentActive ? ' is-active' : ''}`}
+            onClick={() => setDetailPanelMode('agent')}
+          >
+            Agent
+          </button>
+        </div>
+        {agentActive ? renderAgentDetailContent() : renderTaskDetailContent()}
       </aside>
     );
   };
@@ -1453,7 +1489,7 @@ export const AgentTeamFrame = ({
 
       <div
         className={`agent-team-graph-panel__main${
-          selectedGraphTask || (detailPanelMode === 'agent' && selectedGraphAgent)
+          selectedGraphTask || selectedGraphAgent
             ? ''
             : ' agent-team-graph-panel__main--graph-only'
         }`}
@@ -1466,7 +1502,7 @@ export const AgentTeamFrame = ({
           {renderDagCanvas(variant)}
         </div>
 
-        {detailPanelMode === 'agent' && selectedGraphAgent ? renderAgentSideDetail() : renderTaskSideDetail()}
+        {(selectedGraphTask || selectedGraphAgent) && renderDetailPanel()}
       </div>
 
       {renderAgentsStrip()}

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -1282,6 +1282,12 @@ export interface AgentTeamsApi {
     workspaceId: string,
     teamId: string,
   ) => Promise<{ ok: boolean; snapshot?: AgentTeamSnapshot; error?: string }>;
+  updatePlanTeammate: (
+    workspaceId: string,
+    teamId: string,
+    teammateName: string,
+    agentType: string,
+  ) => Promise<{ ok: boolean; snapshot?: AgentTeamSnapshot; error?: string }>;
   createTask: (input: {
     workspaceId: string;
     teamId: string;


### PR DESCRIPTION
## Summary
Adds the ability to reassign teammate agent types while a plan is under review, before execution begins. Users can now switch between different coding agents (e.g., `pulse-coder`, `claude-code`, `codex`) for each teammate in the pending plan.

## Key Changes

- **Service layer** (`agent-teams/service.ts`):
  - Added `updatePlanTeammate()` method to reassign agent types during `plan_review` phase
  - Validates that the plan is under review and the teammate exists
  - Updates metadata and broadcasts changes to connected clients
  - Enhanced leader briefing prompt to clarify that plan changes require re-running `propose-plan`

- **IPC bridge** (`agent-teams/ipc.ts`):
  - Registered `agent-teams:update-plan-teammate` IPC handler to expose the service method to the renderer

- **Renderer UI** (`AgentTeamFrame/index.tsx`):
  - Added agent type selector UI that appears during plan review for teammate agents
  - Displays agent icons and labels using `AgentIcon` component and `AGENT_REGISTRY`
  - Converted agent summary buttons to divs with proper keyboard navigation (Enter/Space)
  - Shows agent type with icon in both detail panel and agent strip
  - Calls `handleUpdatePlanTeammate()` when user selects a different agent type

- **Styling** (`AgentTeamFrame/index.css`):
  - Added styles for agent type display with icon alignment
  - Added agent switch button group styling with active state
  - Improved agent summary card styling (border, border-radius, cursor)
  - Added logo container for agent icons in agent names

- **Type definitions** (`types.ts`):
  - Added `updatePlanTeammate` method signature to `AgentTeamsApi` interface

- **Tests** (`agent-teams-service.test.ts`):
  - Added test verifying teammate reassignment during plan review
  - Added test verifying reassignment flows through to created agents on approval
  - Added test verifying reassignment is rejected outside plan review phase
  - Added test verifying error handling for unknown teammates

## Implementation Details

- Agent type reassignment is only allowed during the `plan_review` phase and for `teammate` role agents
- The UI conditionally shows either the agent switch buttons (during plan review) or task information (during execution)
- Agent type changes are persisted to metadata and broadcast to all connected clients
- The reassigned agent type is used when the plan is confirmed and agents are created

https://claude.ai/code/session_01TJGBcPWXfUChH7jGRuZasY