### PR TITLE
fix(canvas): smooth agent team resume recovery

### DIFF
--- a/apps/canvas-workspace/src/main/__tests__/agent-team-canvas-nodes.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/agent-team-canvas-nodes.test.ts
@@ -6,6 +6,8 @@ const mockState = vi.hoisted(() => ({
   broadcasts: [] as Array<{ workspaceId: string; nodeIds: string[]; kind: string; source: string }>,
 }));
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 vi.mock('../canvas/storage', () => ({
   readCanvasFull: vi.fn(async () => ({ data: mockState.canvas })),
   writeCanvasFull: vi.fn(async (_workspaceId: string, data: CanvasSaveData) => {
@@ -77,12 +79,14 @@ describe('agent team canvas node layout', () => {
     expect(lead.y).toBe(frame.y + 412);
     expect(lead.data.agentArgs).toBe('--disallowedTools Task');
     expect(lead.data.dangerousMode).toBe(true);
+    expect(lead.data.cliSessionId).toMatch(UUID_RE);
     expect(backend.y).toBe(lead.y);
     expect(frontend.y).toBe(lead.y);
     expect(backend.x).toBeGreaterThan(lead.x);
     expect(frontend.x).toBeGreaterThan(backend.x);
     expect(backend.data.agentArgs).toBeUndefined();
     expect(backend.data.dangerousMode).toBe(true);
+    expect(backend.data.cliSessionId).toBeUndefined();
     expect(lead.y).toBeGreaterThan(frame.y + (frame.data.agentTeamPanelHeight as number));
   });
 
@@ -359,6 +363,65 @@ describe('agent team canvas node layout', () => {
     expect(mockState.broadcasts.at(-1)).toMatchObject({
       workspaceId: 'ws-1',
       nodeIds: ['frame-1', 'agent-1'],
+      kind: 'delete',
+      source: 'agent-teams',
+    });
+  });
+
+  it('removes saved team node ids even when legacy agent data is missing the team id', async () => {
+    mockState.canvas!.nodes = [
+      {
+        id: 'frame-1',
+        type: 'frame',
+        title: 'Agent Team',
+        x: 100,
+        y: 200,
+        width: 1120,
+        height: 500,
+        data: { agentTeamId: 'team-1', agentTeamPanelHeight: 388 },
+      },
+      {
+        id: 'agent-legacy',
+        type: 'agent',
+        title: 'Legacy Codex',
+        x: 124,
+        y: 370,
+        width: 480,
+        height: 260,
+        data: { agentTeamRole: 'teammate' },
+      },
+      {
+        id: 'other-agent',
+        type: 'agent',
+        title: 'Keep me',
+        x: 700,
+        y: 370,
+        width: 480,
+        height: 260,
+        data: { agentTeamId: 'team-2' },
+      },
+    ];
+    mockState.canvas!.edges = [
+      {
+        id: 'edge-1',
+        source: { kind: 'node', nodeId: 'agent-legacy' },
+        target: { kind: 'node', nodeId: 'other-agent' },
+      },
+      {
+        id: 'edge-2',
+        source: { kind: 'node', nodeId: 'other-agent' },
+        target: { kind: 'point', x: 1, y: 2 },
+      },
+    ];
+
+    const removedIds = await removeAgentTeamCanvasNodes('ws-1', 'team-1', ['frame-1', 'agent-legacy']);
+
+    expect(removedIds).toEqual(['frame-1', 'agent-legacy']);
+    expect(mockState.canvas!.nodes.map((node) => node.id)).toEqual(['other-agent']);
+    expect(mockState.canvas!.edges?.map((edge) => edge.id)).toEqual(['edge-2']);
+    expect(mockState.broadcasts.at(-1)).toMatchObject({
+      workspaceId: 'ws-1',
+      nodeIds: ['frame-1', 'agent-legacy'],
       kind: 'delete',
       source: 'agent-teams',
     });

--- a/apps/canvas-workspace/src/main/__tests__/agent-teams-service.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/agent-teams-service.test.ts
@@ -63,6 +63,7 @@ vi.mock('../agent-teams/canvas-nodes', () => ({
 }));
 
 import { CanvasAgentTeamsService } from '../agent-teams/service';
+import { removeAgentTeamCanvasNodes } from '../agent-teams/canvas-nodes';
 import type { CanvasAgentTeamSnapshot } from '../agent-teams/types';
 
 const plan = {
@@ -117,6 +118,7 @@ const createExecutingTeam = async (service: CanvasAgentTeamsService): Promise<Ca
 
 describe('CanvasAgentTeamsService', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     mockState.root = join(tmpdir(), `canvas-agent-teams-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     mockState.createdTeams.length = 0;
     mockState.createdAgents.length = 0;
@@ -463,6 +465,27 @@ describe('CanvasAgentTeamsService', () => {
       nodeId: owner.sessionRef!.sessionId,
     });
     expect(mockState.queuedInputs.at(-1)?.input).toContain(task.title);
+  });
+
+  it('passes saved canvas node ids into cleanup when deleting a team', async () => {
+    const service = new CanvasAgentTeamsService();
+    const created = await createExecutingTeam(service);
+    const teamId = created.runtime.team.id;
+    const expectedIds = [
+      created.frameNodeId,
+      ...created.runtime.agents.map((agent) => agent.sessionRef?.sessionId),
+    ].filter((nodeId): nodeId is string => !!nodeId);
+    vi.mocked(removeAgentTeamCanvasNodes).mockResolvedValueOnce(expectedIds);
+
+    const result = await service.deleteTeam('ws-1', teamId);
+
+    expect(result.deletedNodeIds).toEqual(expectedIds);
+    expect(removeAgentTeamCanvasNodes).toHaveBeenLastCalledWith(
+      'ws-1',
+      teamId,
+      expect.arrayContaining(expectedIds),
+    );
+    await expect(service.listTeams('ws-1')).resolves.toEqual([]);
   });
 
   it('treats direct teammate input as an answer to that teammate open gate', async () => {

--- a/apps/canvas-workspace/src/main/__tests__/agent-teams-service.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/agent-teams-service.test.ts
@@ -542,6 +542,45 @@ describe('CanvasAgentTeamsService', () => {
     expect(mockState.queuedInputs.at(-1)?.input).toContain('Have frontend adjust the checkout copy.');
   });
 
+  it('reopens a completed team when sending the lead a next task', async () => {
+    const service = new CanvasAgentTeamsService();
+    const created = await createExecutingTeam(service);
+    const teamId = created.runtime.team.id;
+    const lead = created.runtime.agents.find((agent) => agent.role === 'lead')!;
+    const implement = created.runtime.tasks.find((task) => task.title === 'Implement checkout refactor')!;
+    const implemented = await service.completeAgentTask({
+      workspaceId: 'ws-1',
+      teamId,
+      taskId: implement.id,
+      summary: 'Implementation is done.',
+    });
+    const review = implemented.runtime.tasks.find((task) => task.title === 'Review checkout refactor')!;
+    await service.completeAgentTask({
+      workspaceId: 'ws-1',
+      teamId,
+      taskId: review.id,
+      summary: 'Review passed.',
+    });
+    const completed = await service.completeTeam('ws-1', teamId, {
+      sourceAgentId: lead.id,
+      summary: 'Checkout refactor completed and reviewed.',
+    });
+    expect(completed.runtime.team.status).toBe('completed');
+
+    const reopened = await service.sendInput('ws-1', teamId, lead.id, 'Start the next milestone.');
+    const reopenedLead = reopened.runtime.agents.find((agent) => agent.id === lead.id)!;
+
+    expect(reopened.runtime.team.status).toBe('running');
+    expect(reopenedLead.status).toBe('running');
+    expect(mockState.queuedInputs.at(-1)).toMatchObject({
+      workspaceId: 'ws-1',
+      nodeId: lead.sessionRef!.sessionId,
+    });
+    expect(mockState.queuedInputs.at(-1)?.input).toContain('Start the next milestone.');
+    await expect(service.prepareAgentAutoResume('ws-1', teamId, lead.id))
+      .resolves.toMatchObject({ canResume: true });
+  });
+
   it('creates follow-up tasks by owner name and dependency title', async () => {
     const service = new CanvasAgentTeamsService();
     const created = await createExecutingTeam(service);

--- a/apps/canvas-workspace/src/main/agent-teams/canvas-nodes.ts
+++ b/apps/canvas-workspace/src/main/agent-teams/canvas-nodes.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from 'fs';
+import { randomUUID } from 'crypto';
 import { join } from 'path';
 import { readCanvasFull, writeCanvasFull } from '../canvas/storage';
 import { broadcastCanvasUpdate } from '../canvas/broadcast';
@@ -102,6 +103,11 @@ const withClaudeTeamLeadArgs = (agentType: string, role: 'lead' | 'teammate', ar
   return /(^|\s)--disallowed(?:Tools|-tools)(\s|=|$)/.test(trimmed) ? trimmed : `${trimmed} ${CLAUDE_TEAM_LEAD_ARGS}`;
 };
 
+const withClaudeCliSessionId = (agentType: unknown, existing: unknown): string | undefined => {
+  if (agentType !== 'claude-code') return typeof existing === 'string' ? existing : undefined;
+  return typeof existing === 'string' && existing ? existing : randomUUID();
+};
+
 const queueLaunchPrompt = async (
   node: CanvasNode,
   prompt: string,
@@ -121,6 +127,7 @@ const queueLaunchPrompt = async (
     ...data,
     status: 'running',
     viewMode: 'running',
+    cliSessionId: withClaudeCliSessionId(data.agentType, data.cliSessionId),
     inlinePrompt,
     promptFile,
     lastInitPrompt: prompt,
@@ -147,6 +154,7 @@ const makeAgentNode = async (
       agentType: input.agentType,
       agentArgs: withClaudeTeamLeadArgs(input.agentType, input.role),
       dangerousMode: true,
+      cliSessionId: withClaudeCliSessionId(input.agentType, undefined),
       status: 'idle',
       viewMode: 'setup',
       agentTeamId: input.teamId,
@@ -389,11 +397,16 @@ export async function updateAgentTeamCanvasCwd(workspaceId: string, teamId: stri
   return changedIds;
 }
 
-export async function removeAgentTeamCanvasNodes(workspaceId: string, teamId: string): Promise<string[]> {
+export async function removeAgentTeamCanvasNodes(
+  workspaceId: string,
+  teamId: string,
+  knownNodeIds: string[] = [],
+): Promise<string[]> {
   const canvas = await loadCanvasOrEmpty(workspaceId);
   const nodes = asNodes(canvas);
+  const knownNodeIdSet = new Set(knownNodeIds);
   const removedIds = nodes
-    .filter((node) => node.data?.agentTeamId === teamId)
+    .filter((node) => node.data?.agentTeamId === teamId || knownNodeIdSet.has(node.id))
     .map((node) => node.id);
   if (removedIds.length === 0) return [];
 

--- a/apps/canvas-workspace/src/main/agent-teams/service.ts
+++ b/apps/canvas-workspace/src/main/agent-teams/service.ts
@@ -344,6 +344,11 @@ const inferPhase = (
   return snapshot.team.status === 'waiting_approval' ? 'plan_review' : 'briefing';
 };
 
+const metadataCanvasNodeIds = (metadata: CanvasAgentTeamMetadata | undefined): string[] => [
+  metadata?.frameNodeId,
+  ...Object.values(metadata?.agentNodeIds ?? {}),
+].filter((nodeId): nodeId is string => typeof nodeId === 'string' && nodeId.length > 0);
+
 const formatLeaderBriefingPrompt = (teamName: string, goal: string, content: string, cwd?: string): string => [
   `You are the Team Leader for "${teamName}" in Pulse Canvas.`,
   '',
@@ -759,9 +764,19 @@ export class CanvasAgentTeamsService {
   }
 
   async deleteTeam(workspaceId: string, teamId: string): Promise<{ deletedNodeIds: string[] }> {
-    const { runtime } = this.getBundle(workspaceId);
-    await runtime.deleteTeam(teamId);
-    const deletedNodeIds = await removeAgentTeamCanvasNodes(workspaceId, teamId);
+    const { runtime, store } = this.getBundle(workspaceId);
+    const metadata = await store.getTeamMetadata(teamId);
+    const knownNodeIds = metadataCanvasNodeIds(metadata);
+
+    try {
+      await runtime.deleteTeam(teamId);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message !== `Team not found: ${teamId}`) throw err;
+      await store.deleteTeam(teamId);
+    }
+
+    const deletedNodeIds = await removeAgentTeamCanvasNodes(workspaceId, teamId, knownNodeIds);
     for (const nodeId of deletedNodeIds) {
       this.outputBuffers.delete(`${workspaceId}:${nodeId}`);
     }

--- a/apps/canvas-workspace/src/main/agent-teams/service.ts
+++ b/apps/canvas-workspace/src/main/agent-teams/service.ts
@@ -899,7 +899,7 @@ export class CanvasAgentTeamsService {
     agentRef: string,
     content: string,
   ): Promise<CanvasAgentTeamSnapshot> {
-    const { runtime } = this.getBundle(workspaceId);
+    const { runtime, store } = this.getBundle(workspaceId);
     const snapshot = await runtime.snapshot(teamId);
     const agent = this.resolveAgentReference(snapshot.agents, agentRef);
     const input = agent.role === 'lead'
@@ -913,6 +913,17 @@ export class CanvasAgentTeamsService {
       await runtime.answerHumanGate(openGate.id, input);
       await runtime.dispatchReadyTasks(teamId);
       return this.snapshot(workspaceId, teamId);
+    }
+
+    if (agent.role === 'lead' && snapshot.team.status === 'completed') {
+      const latestAgent = await store.getAgent(agent.id);
+      if (latestAgent) {
+        latestAgent.status = 'running';
+        latestAgent.currentTaskId = undefined;
+        latestAgent.updatedAt = Date.now();
+        await store.saveAgent(latestAgent);
+      }
+      await runtime.setTeamStatus(teamId, 'running', 'human');
     }
 
     await runtime.sendToAgent(agent.id, input);

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTeamManaged.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTeamManaged.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { AGENT_REGISTRY } from '../../config/agentRegistry';
 import { AgentIcon } from './AgentIcon';
 import { truncatePath } from './utils/terminal';
@@ -8,6 +9,7 @@ interface AgentTeamManagedProps {
   status?: string;
   lastPrompt?: string;
   recentActions?: string[];
+  commandSlot?: ReactNode;
   onOpenTerminal?: () => void;
 }
 
@@ -40,6 +42,7 @@ export const AgentTeamManaged = ({
   status,
   lastPrompt,
   recentActions,
+  commandSlot,
   onOpenTerminal,
 }: AgentTeamManagedProps) => {
   const agentDef = AGENT_REGISTRY.find((agent) => agent.id === agentType);
@@ -76,6 +79,11 @@ export const AgentTeamManaged = ({
             <div className="agent-team-managed__meta">
               {agentDef?.label ?? agentType} · {displayCwd}
             </div>
+            {commandSlot && (
+              <div className="agent-team-managed__command">
+                {commandSlot}
+              </div>
+            )}
             {onOpenTerminal && (
               <button type="button" className="agent-team-managed__terminal-button" onClick={onOpenTerminal}>
                 Advanced terminal

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
@@ -344,6 +344,13 @@
   white-space: nowrap;
 }
 
+.agent-team-managed__command {
+  display: block;
+  width: 100%;
+  max-width: 560px;
+  margin-top: 8px;
+}
+
 .agent-team-managed__terminal-button {
   justify-self: start;
   height: 30px;

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -134,12 +134,12 @@ export const AgentNodeBody = ({
         status={controller.status}
         agentType={controller.data.agentType || 'claude-code'}
         cwd={controller.data.cwd}
-        loading={controller.loading}
+        loading={controller.loading || controller.teamAutoResumePending}
       />
     </>
   );
 
-  if (isTeamLead && controller.viewMode === 'running') {
+  if (isTeamLead && (controller.viewMode === 'running' || controller.teamAutoResumePending)) {
     return (
       <div className="agent-team-lead-console agent-team-lead-console--bare">
         <div className="agent-team-lead-console__terminal">
@@ -147,6 +147,10 @@ export const AgentNodeBody = ({
         </div>
       </div>
     );
+  }
+
+  if (controller.teamAutoResumePending) {
+    return terminalView;
   }
 
   if (controller.viewMode === 'setup') {

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -171,6 +171,7 @@ export const AgentNodeBody = ({
         status={managedLeadStatus}
         lastPrompt={controller.data.lastInitPrompt}
         recentActions={leadRecentActions}
+        commandSlot={teamLeadBriefSlot}
       />
     );
   }
@@ -221,6 +222,7 @@ export const AgentNodeBody = ({
         status={managedLeadStatus}
         lastPrompt={controller.data.lastInitPrompt}
         recentActions={leadRecentActions}
+        commandSlot={teamLeadBriefSlot}
       />
     );
   }

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -76,6 +76,7 @@ export const AgentNodeBody = ({
   rootFolder,
   workspaceId,
   teamLeadBriefSlot,
+  agentTeamStatus,
   onUpdate,
   readOnly = false,
   terminalMode = 'owner',
@@ -92,6 +93,15 @@ export const AgentNodeBody = ({
   const [leadSnapshot, setLeadSnapshot] = useState<AgentTeamSnapshot | null>(null);
   const isTeamLead = controller.data.agentTeamRole === 'lead';
   const leadRecentActions = useMemo(() => summarizeTeamLeadActions(leadSnapshot), [leadSnapshot]);
+  const leadTeamStatus = agentTeamStatus ?? leadSnapshot?.runtime.team.status;
+  const suppressFinishedTeamLeadRestart = isTeamLead
+    && controller.viewMode === 'restart'
+    && (leadTeamStatus === 'completed' || leadTeamStatus === 'failed');
+  const managedLeadStatus = leadTeamStatus === 'completed'
+    ? 'done'
+    : leadTeamStatus === 'failed'
+      ? 'error'
+      : controller.status;
 
   useEffect(() => {
     const teamId = controller.data.agentTeamId;
@@ -153,6 +163,18 @@ export const AgentNodeBody = ({
     return terminalView;
   }
 
+  if (suppressFinishedTeamLeadRestart) {
+    return (
+      <AgentTeamManaged
+        agentType={controller.data.agentType || controller.selectedAgent || 'claude-code'}
+        cwd={controller.data.cwd || rootFolder}
+        status={managedLeadStatus}
+        lastPrompt={controller.data.lastInitPrompt}
+        recentActions={leadRecentActions}
+      />
+    );
+  }
+
   if (controller.viewMode === 'setup') {
     return (
       <AgentPicker
@@ -196,7 +218,7 @@ export const AgentNodeBody = ({
       <AgentTeamManaged
         agentType={controller.data.agentType || controller.selectedAgent || 'claude-code'}
         cwd={controller.data.cwd || rootFolder}
-        status={controller.status}
+        status={managedLeadStatus}
         lastPrompt={controller.data.lastInitPrompt}
         recentActions={leadRecentActions}
       />

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/types.ts
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import type { CanvasNode } from '../../types';
+import type { AgentTeamStatus, CanvasNode } from '../../types';
 
 export interface AgentNodeBodyProps {
   node: CanvasNode;
@@ -8,6 +8,7 @@ export interface AgentNodeBodyProps {
   workspaceId?: string;
   workspaceName?: string;
   teamLeadBriefSlot?: ReactNode;
+  agentTeamStatus?: AgentTeamStatus;
   onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
   readOnly?: boolean;
   terminalMode?: 'owner' | 'mirror';

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/useAgentNodeController.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/useAgentNodeController.ts
@@ -68,7 +68,7 @@ interface MirrorTerminalCacheEntry {
 const RETRY_MIRROR_CONNECTION_MS = 1_000;
 const MAX_MIRROR_TERMINALS = 12;
 const TEAM_AUTO_RESUME_MAX_ATTEMPTS = 2;
-const TEAM_AUTO_RESUME_RETRY_AFTER_MS = 45_000;
+const TEAM_AUTO_RESUME_RETRY_AFTER_MS = 8_000;
 const MIRROR_TERMINAL_STASH_ID = 'agent-mirror-terminal-stash';
 const mirrorTerminalCache = new Map<string, MirrorTerminalCacheEntry>();
 
@@ -933,6 +933,7 @@ export const useAgentNodeController = ({
     const retryDelay = teamAutoResumeRetryDelay(data);
     if (!canAttemptTeamAutoResume(data)) {
       if (retryDelay != null) {
+        setTeamAutoResumePending(true);
         const timer = setTimeout(() => {
           setTeamAutoResumeRetryTick((tick) => tick + 1);
         }, retryDelay);

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/useAgentNodeController.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/useAgentNodeController.ts
@@ -19,6 +19,39 @@ const shellQuote = (value: string): string =>
   `'${value.replace(/'/g, "'\\''")}'`;
 
 const CODEX_BINDING_MARKER_PREFIX = 'pulse-canvas-codex-binding';
+const CLAUDE_RESUME_FALLBACK_RE =
+  /\[Pulse Canvas\] Claude resume target was missing; starting a fresh session \((?<sessionId>[0-9a-f-]{36})\)\./;
+const CLAUDE_RESUME_FALLBACK_PROMPT_LIMIT = 14_000;
+const CLAUDE_RESUME_FALLBACK_OUTPUT_LIMIT = 4_000;
+
+const truncateTail = (value: string, limit: number): string => {
+  if (value.length <= limit) return value;
+  return `[truncated ${value.length - limit} chars]\n${value.slice(-limit)}`;
+};
+
+const buildClaudeResumeFallbackPrompt = (
+  data: AgentNodeData,
+  missingSessionId: string,
+): string => {
+  const savedPrompt = (data.lastInitPrompt || data.inlinePrompt || '').trim();
+  const recentOutput = (data.scrollback || '').trim();
+  const sections = [
+    `Pulse Canvas tried to resume Claude Code session ${missingSessionId}, but Claude reported that conversation was missing from local history.`,
+    'Start a fresh Claude Code conversation and continue the same Agent Team work from the saved context below.',
+    'Do not assume any hidden state from the missing conversation is available.',
+    '',
+    savedPrompt
+      ? `Saved task prompt:\n${truncateTail(savedPrompt, CLAUDE_RESUME_FALLBACK_PROMPT_LIMIT)}`
+      : 'Saved task prompt: unavailable.',
+  ];
+  if (recentOutput) {
+    sections.push(
+      '',
+      `Recent terminal output before recovery:\n${truncateTail(recentOutput, CLAUDE_RESUME_FALLBACK_OUTPUT_LIMIT)}`,
+    );
+  }
+  return sections.join('\n');
+};
 
 const makeCodexBindingMarker = (nodeId: string): string =>
   `${CODEX_BINDING_MARKER_PREFIX}:${nodeId}:${crypto.randomUUID()}`;
@@ -35,6 +68,7 @@ interface MirrorTerminalCacheEntry {
 const RETRY_MIRROR_CONNECTION_MS = 1_000;
 const MAX_MIRROR_TERMINALS = 12;
 const TEAM_AUTO_RESUME_MAX_ATTEMPTS = 2;
+const TEAM_AUTO_RESUME_RETRY_AFTER_MS = 45_000;
 const MIRROR_TERMINAL_STASH_ID = 'agent-mirror-terminal-stash';
 const mirrorTerminalCache = new Map<string, MirrorTerminalCacheEntry>();
 
@@ -137,22 +171,37 @@ const shouldConsiderTeamAutoResume = (data: AgentNodeData): boolean => {
   return data.viewMode !== 'setup';
 };
 
-const canAttemptTeamAutoResume = (data: AgentNodeData): boolean => {
+const teamAutoResumeRetryDelay = (data: AgentNodeData, now = Date.now()): number | null => {
+  const key = cliConversationKey(data);
+  if (!key) return null;
+  const previous = data.agentTeamAutoResume;
+  if (previous?.sessionKey !== key) return null;
+  if ((previous.attempts ?? 0) < TEAM_AUTO_RESUME_MAX_ATTEMPTS) return null;
+  if (!previous.lastAttemptAt) return 0;
+  return Math.max(0, TEAM_AUTO_RESUME_RETRY_AFTER_MS - (now - previous.lastAttemptAt));
+};
+
+const canAttemptTeamAutoResume = (data: AgentNodeData, now = Date.now()): boolean => {
   const key = cliConversationKey(data);
   if (!key) return false;
   const previous = data.agentTeamAutoResume;
   if (previous?.sessionKey !== key) return true;
-  return (previous.attempts ?? 0) < TEAM_AUTO_RESUME_MAX_ATTEMPTS;
+  if ((previous.attempts ?? 0) < TEAM_AUTO_RESUME_MAX_ATTEMPTS) return true;
+  return teamAutoResumeRetryDelay(data, now) === 0;
 };
 
 const nextTeamAutoResumeState = (data: AgentNodeData): NonNullable<AgentNodeData['agentTeamAutoResume']> => {
   const key = cliConversationKey(data);
   const previous = data.agentTeamAutoResume;
-  const attempts = previous?.sessionKey === key ? previous?.attempts ?? 0 : 0;
+  const now = Date.now();
+  const previousExpired = previous?.lastAttemptAt
+    ? now - previous.lastAttemptAt >= TEAM_AUTO_RESUME_RETRY_AFTER_MS
+    : false;
+  const attempts = previous?.sessionKey === key && !previousExpired ? previous?.attempts ?? 0 : 0;
   return {
     sessionKey: key,
     attempts: attempts + 1,
-    lastAttemptAt: Date.now(),
+    lastAttemptAt: now,
   };
 };
 
@@ -188,6 +237,8 @@ export const useAgentNodeController = ({
   });
   const [fromRestart, setFromRestart] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [teamAutoResumePending, setTeamAutoResumePending] = useState(false);
+  const [teamAutoResumeRetryTick, setTeamAutoResumeRetryTick] = useState(0);
 
   const pendingAgentRef = useRef(data.agentType || 'claude-code');
   const pendingCwdRef = useRef(data.cwd || '');
@@ -489,6 +540,14 @@ export const useAgentNodeController = ({
         : undefined;
       const cliSessionId = existingCliSessionId || crypto.randomUUID();
       const canResumeClaude = !!existingCliSessionId;
+      if (agentType === 'claude-code' && dataRef.current.cliSessionId !== cliSessionId) {
+        const nextData = {
+          ...dataRef.current,
+          cliSessionId,
+        };
+        dataRef.current = nextData;
+        onUpdateRef.current(nodeIdRef.current, { data: nextData });
+      }
       const writeCommandTimeRef = { current: 0 };
 
       const readCodexSessionBaseline = async (): Promise<Set<string> | null> => {
@@ -589,6 +648,25 @@ export const useAgentNodeController = ({
         timer = setTimeout(poll, 1_000);
       };
 
+      let claudeResumeFallbackMarkerBuffer = '';
+      let appliedClaudeResumeFallbackSessionId: string | null = null;
+      const handleClaudeResumeFallbackOutput = (chunk: string) => {
+        if (agentType !== 'claude-code' || !resumeMode) return;
+        claudeResumeFallbackMarkerBuffer = `${claudeResumeFallbackMarkerBuffer}${chunk}`.slice(-1_000);
+        const match = CLAUDE_RESUME_FALLBACK_RE.exec(claudeResumeFallbackMarkerBuffer);
+        const fallbackSessionId = match?.groups?.sessionId;
+        if (!fallbackSessionId || appliedClaudeResumeFallbackSessionId === fallbackSessionId) return;
+        appliedClaudeResumeFallbackSessionId = fallbackSessionId;
+        const nextData = {
+          ...dataRef.current,
+          cliSessionId: fallbackSessionId,
+        };
+        dataRef.current = nextData;
+        onUpdateRef.current(nodeIdRef.current, {
+          data: nextData,
+        });
+      };
+
       const writeCommand = async () => {
         if (!command) {
           term.writeln(`\x1b[33mUnknown agent type: ${agentType}\x1b[0m`);
@@ -618,7 +696,23 @@ export const useAgentNodeController = ({
           : '';
         const commonFlags = dangerousFlag + (agentArgs ? ` ${agentArgs}` : '');
 
-        if (agentType === 'codex' && resumeMode && !effectivePrompt && !promptFile) {
+        if (agentType === 'claude-code' && resumeMode && canResumeClaude && !effectivePrompt && !promptFile) {
+          const fallbackSessionId = crypto.randomUUID();
+          const fallbackNotice = `[Pulse Canvas] Claude resume target was missing; starting a fresh session (${fallbackSessionId}).`;
+          const fallbackPrompt = buildClaudeResumeFallbackPrompt(dataRef.current, cliSessionId);
+          const resumeFlags = ` --resume ${cliSessionId}${commonFlags}`;
+          const fallbackFlags = ` --session-id ${fallbackSessionId}${commonFlags}`;
+          api.write(
+            sessionId,
+            [
+              `${command}${resumeFlags}`,
+              ' || (',
+              `printf '%s\\n' ${shellQuote(fallbackNotice)}`,
+              `; ${command}${fallbackFlags} ${shellQuote(fallbackPrompt)}`,
+              ')\n',
+            ].join(''),
+          );
+        } else if (agentType === 'codex' && resumeMode && !effectivePrompt && !promptFile) {
           const codexSessionId = dataRef.current.codexSessionId;
           if (!codexSessionId) {
             term.writeln('\x1b[33mCannot resume Codex: saved session id is missing.\x1b[0m');
@@ -698,6 +792,7 @@ export const useAgentNodeController = ({
 
       const attachPermanentListener = () => {
         removeDataRef.current = api.onData(sessionId, (d: string) => {
+          handleClaudeResumeFallbackOutput(d);
           term.write(d);
           reportAgentTeamOutput(d);
           if (loadingDismissed) return;
@@ -834,16 +929,31 @@ export const useAgentNodeController = ({
     if (viewMode === 'running') return;
     if (!workspaceId || !data.agentTeamId || !data.agentTeamAgentId) return;
     if (!shouldConsiderTeamAutoResume(data)) return;
-    if (!canAttemptTeamAutoResume(data)) return;
+
+    const retryDelay = teamAutoResumeRetryDelay(data);
+    if (!canAttemptTeamAutoResume(data)) {
+      if (retryDelay != null) {
+        const timer = setTimeout(() => {
+          setTeamAutoResumeRetryTick((tick) => tick + 1);
+        }, retryDelay);
+        return () => clearTimeout(timer);
+      }
+      return;
+    }
 
     let cancelled = false;
+    setTeamAutoResumePending(true);
     void (async () => {
       const result = await window.canvasWorkspace?.agentTeams?.prepareAgentAutoResume(
         workspaceId,
         data.agentTeamId!,
         data.agentTeamAgentId!,
-      );
-      if (cancelled || !result?.ok || !result.canResume) return;
+      ).catch(() => null);
+      if (cancelled) return;
+      if (!result?.ok || !result.canResume) {
+        setTeamAutoResumePending(false);
+        return;
+      }
 
       pendingAgentRef.current = data.agentType || 'claude-code';
       pendingCwdRef.current = data.cwd || rootFolder || '';
@@ -861,11 +971,13 @@ export const useAgentNodeController = ({
       onUpdateRef.current(nodeIdRef.current, {
         data: nextData,
       });
+      setTeamAutoResumePending(false);
       setViewMode('running');
     })();
 
     return () => {
       cancelled = true;
+      setTeamAutoResumePending(false);
     };
   }, [
     data.agentTeamAgentId,
@@ -885,6 +997,7 @@ export const useAgentNodeController = ({
     isTeamManagedAgent,
     readOnly,
     rootFolder,
+    teamAutoResumeRetryTick,
     viewMode,
     workspaceId,
   ]);
@@ -980,21 +1093,23 @@ export const useAgentNodeController = ({
     if (api && oldSessionId) api.kill(oldSessionId);
     const freshSessionId = mintSessionId(nodeIdRef.current);
     const freshCliSessionId = selectedAgent === 'claude-code' ? crypto.randomUUID() : undefined;
+    const nextData = {
+      ...dataRef.current,
+      agentType: selectedAgent,
+      cwd: effectiveCwd,
+      inlinePrompt: prompt,
+      lastInitPrompt: prompt || dataRef.current.lastInitPrompt || '',
+      dangerousMode: effectiveDangerousMode,
+      status: 'running' as const,
+      sessionId: freshSessionId,
+      scrollback: '',
+      cliSessionId: freshCliSessionId,
+      codexSessionId: undefined,
+      codexSessionMarker: undefined,
+    };
+    dataRef.current = nextData;
     onUpdateRef.current(nodeIdRef.current, {
-      data: {
-        ...dataRef.current,
-        agentType: selectedAgent,
-        cwd: effectiveCwd,
-        inlinePrompt: prompt,
-        lastInitPrompt: prompt || dataRef.current.lastInitPrompt || '',
-        dangerousMode: effectiveDangerousMode,
-        status: 'running',
-        sessionId: freshSessionId,
-        scrollback: '',
-        cliSessionId: freshCliSessionId,
-        codexSessionId: undefined,
-        codexSessionMarker: undefined,
-      },
+      data: nextData,
     });
     setFromRestart(false);
     setViewMode('running');
@@ -1036,20 +1151,22 @@ export const useAgentNodeController = ({
     const oldSessionId = dataRef.current.sessionId;
     if (api && oldSessionId) api.kill(oldSessionId);
     const freshSessionId = mintSessionId(nodeIdRef.current);
+    const nextData = {
+      ...dataRef.current,
+      agentType: savedAgent,
+      cwd: savedCwd,
+      inlinePrompt: shouldResumeSavedSession ? '' : savedPrompt,
+      status: 'running' as const,
+      sessionId: freshSessionId,
+      scrollback: '',
+      codexSessionId: savedAgent === 'codex' && shouldResumeSavedSession
+        ? dataRef.current.codexSessionId
+        : undefined,
+      codexSessionMarker: undefined,
+    };
+    dataRef.current = nextData;
     onUpdateRef.current(nodeIdRef.current, {
-      data: {
-        ...dataRef.current,
-        agentType: savedAgent,
-        cwd: savedCwd,
-        inlinePrompt: shouldResumeSavedSession ? '' : savedPrompt,
-        status: 'running',
-        sessionId: freshSessionId,
-        scrollback: '',
-        codexSessionId: savedAgent === 'codex' && shouldResumeSavedSession
-          ? dataRef.current.codexSessionId
-          : undefined,
-        codexSessionMarker: undefined,
-      },
+      data: nextData,
     });
     setFromRestart(false);
     setViewMode('running');
@@ -1103,6 +1220,7 @@ export const useAgentNodeController = ({
     dangerousMode,
     setDangerousMode,
     status: data.status ?? 'idle',
+    teamAutoResumePending,
     viewMode,
     visibleNodes: getAllNodesRef.current?.() ?? [],
   };

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
@@ -392,6 +392,7 @@
 
 .agent-team-command--lead button {
   align-self: flex-end;
+  min-width: 118px;
 }
 
 .agent-team-workspace {

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
@@ -301,6 +301,9 @@ export const AgentTeamFrame = ({
   const lead = useMemo(() => agents.find((agent) => agent.role === 'lead'), [agents]);
   const teammates = useMemo(() => agents.filter((agent) => agent.role !== 'lead'), [agents]);
   const phase = inferPhase(snapshot?.phase, teammates, tasks, runtime?.team.status);
+  const teamStatus = runtime?.team.status ?? 'planning';
+  const isCompletedTeam = teamStatus === 'completed';
+  const shouldShowLeadCommandSlot = phase === 'briefing' || isCompletedTeam;
   const plan = snapshot?.pendingPlan;
   const teamAgentNodes = teamId
     ? (getAllNodes?.() ?? []).filter((candidate) => isTeamAgentNode(candidate, teamId))
@@ -751,7 +754,7 @@ export const AgentTeamFrame = ({
 
     const content = messageDraft.trim();
     if (!api || !workspaceId || !teamId || !lead || !content) return;
-    const taskContext = selectedTask
+    const taskContext = teamStatus !== 'completed' && selectedTask
       ? `Task context: "${selectedTask.title}" (${selectedTask.status}).\n`
       : '';
     const result = await api.sendInput(workspaceId, teamId, lead.id, `${taskContext}${content}`);
@@ -762,7 +765,7 @@ export const AgentTeamFrame = ({
     } else {
       setError(result.error ?? 'Unable to send command.');
     }
-  }, [api, handleBriefLead, lead, messageDraft, phase, selectedTask, teamId, workspaceId]);
+  }, [api, handleBriefLead, lead, messageDraft, phase, selectedTask, teamId, teamStatus, workspaceId]);
 
   const handlePauseTeam = useCallback(async () => {
     if (!api || !workspaceId || !teamId) return;
@@ -1040,14 +1043,30 @@ export const AgentTeamFrame = ({
     );
   };
 
-  const commandDraft = phase === 'briefing' ? briefDraft : messageDraft;
-  const commandPlaceholder = phase === 'briefing'
+  const commandMode = phase === 'briefing'
+    ? 'brief'
+    : isCompletedTeam
+      ? 'next'
+      : 'message';
+  const commandDraft = commandMode === 'brief' ? briefDraft : messageDraft;
+  const commandPlaceholder = commandMode === 'brief'
     ? 'Describe the outcome, repo path, constraints, and what this team should handle...'
-    : 'Tell Team Lead what to change...';
-  const canSendCommand = phase === 'briefing'
+    : commandMode === 'next'
+      ? 'Describe the next task or follow-up this team should handle...'
+      : 'Tell Team Lead what to change...';
+  const commandLabel = commandMode === 'brief'
+    ? 'Brief Team Lead'
+    : commandMode === 'next'
+      ? 'Next Team Task'
+      : 'Message Team Lead';
+  const commandButtonLabel = commandMode === 'brief'
+    ? 'Brief'
+    : commandMode === 'next'
+      ? 'Start next task'
+      : 'Send';
+  const canSendCommand = commandMode === 'brief'
     ? !!briefDraft.trim()
     : !!messageDraft.trim() && !!lead;
-  const teamStatus = runtime?.team.status ?? 'planning';
   const canPauseTeam = phase === 'executing'
     && teamStatus !== 'paused'
     && teamStatus !== 'completed'
@@ -1062,9 +1081,9 @@ export const AgentTeamFrame = ({
     <div className={`agent-team-command agent-team-command--${placement}`} aria-label="Team command">
       <div className="agent-team-command__copy">
         <span className="agent-team-command__label">
-          {phase === 'briefing' ? 'Brief Team Lead' : 'Message Team Lead'}
+          {commandLabel}
         </span>
-        {phase === 'executing' && selectedTask && (
+        {commandMode === 'message' && selectedTask && (
           <span className={`agent-team-command__task-chip agent-team-command__task-chip--${selectedTask.status}`}>
             Task · {selectedTask.title}
           </span>
@@ -1086,11 +1105,11 @@ export const AgentTeamFrame = ({
           }}
           placeholder={commandPlaceholder}
           disabled={readOnly}
-          rows={phase === 'briefing' ? 8 : 1}
+          rows={commandMode === 'brief' ? 8 : commandMode === 'next' ? 3 : 1}
         />
       </div>
       <button type="button" onClick={() => void handleTeamCommand()} disabled={readOnly || !canSendCommand}>
-        {phase === 'briefing' ? 'Brief' : 'Send'}
+        {commandButtonLabel}
       </button>
     </div>
   );
@@ -1114,7 +1133,7 @@ export const AgentTeamFrame = ({
               rootFolder={rootFolder}
               workspaceId={workspaceId}
               workspaceName={workspaceName}
-              teamLeadBriefSlot={phase === 'briefing' ? renderTeamCommand('lead') : undefined}
+              teamLeadBriefSlot={shouldShowLeadCommandSlot ? renderTeamCommand('lead') : undefined}
               agentTeamStatus={teamStatus}
               onUpdate={onUpdate}
               readOnly={readOnly}
@@ -1144,7 +1163,7 @@ export const AgentTeamFrame = ({
               {leadNodeId && <code>{leadNodeId}</code>}
             </div>
 
-            {phase === 'briefing' && renderTeamCommand('lead')}
+            {shouldShowLeadCommandSlot && renderTeamCommand('lead')}
           </>
         )}
       </div>

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
@@ -1115,6 +1115,7 @@ export const AgentTeamFrame = ({
               workspaceId={workspaceId}
               workspaceName={workspaceName}
               teamLeadBriefSlot={phase === 'briefing' ? renderTeamCommand('lead') : undefined}
+              agentTeamStatus={teamStatus}
               onUpdate={onUpdate}
               readOnly={readOnly}
             />

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasNodeActions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasNodeActions.ts
@@ -1,5 +1,5 @@
 import { useCallback, type MutableRefObject } from 'react';
-import type { CanvasEdge, CanvasNode } from '../../../types';
+import type { AgentNodeData, CanvasEdge, CanvasNode, FrameNodeData } from '../../../types';
 import { getNodeDisplayLabel } from '../../../utils/nodeLabel';
 import { exportMindmapNodeToPng } from '../../../utils/mindmapExport';
 
@@ -25,8 +25,9 @@ interface Options {
   setSelectedEdgeId: React.Dispatch<React.SetStateAction<string | null>>;
   editingEdgeLabelId: string | null;
   setEditingEdgeLabelId: (id: string | null) => void;
-  removeNode: (id: string) => void;
+  canvasId: string;
   removeNodes: (ids: string[]) => void;
+  syncDeletedNodes: (ids: string[]) => void;
   removeEdge: (id: string) => void;
   groupNodes: (ids: string[]) => CanvasNode | null;
   ungroupNodes: (ids: string[]) => string[];
@@ -34,6 +35,18 @@ interface Options {
   notify: (args: NotifyArgs) => void;
   confirm: (args: ConfirmArgs) => Promise<boolean>;
 }
+
+const getAgentTeamId = (node: CanvasNode): string | undefined => {
+  if (node.type === 'frame') {
+    const data = node.data as Partial<FrameNodeData>;
+    return typeof data.agentTeamId === 'string' && data.agentTeamId ? data.agentTeamId : undefined;
+  }
+  if (node.type === 'agent') {
+    const data = node.data as Partial<AgentNodeData>;
+    return typeof data.agentTeamId === 'string' && data.agentTeamId ? data.agentTeamId : undefined;
+  }
+  return undefined;
+};
 
 /**
  * Bundles the canvas's higher-level mutation callbacks — group / ungroup
@@ -50,8 +63,9 @@ export const useCanvasNodeActions = ({
   setSelectedEdgeId,
   editingEdgeLabelId,
   setEditingEdgeLabelId,
-  removeNode,
+  canvasId,
   removeNodes,
+  syncDeletedNodes,
   removeEdge,
   groupNodes,
   ungroupNodes,
@@ -62,16 +76,64 @@ export const useCanvasNodeActions = ({
   void _selectedEdgeId;
 
   const requestRemoveNodes = useCallback(
-    (ids: string[]) => {
+    async (ids: string[]) => {
       const idSet = new Set(ids);
       const victims = nodesRef.current.filter((node) => idSet.has(node.id));
       if (victims.length === 0) return;
 
-      removeNodes(victims.map((node) => node.id));
-      const removedIds = new Set(victims.map((node) => node.id));
+      const teamIds = Array.from(new Set(
+        victims
+          .map(getAgentTeamId)
+          .filter((teamId): teamId is string => !!teamId),
+      ));
+      const teamVictimIds = new Set(
+        victims
+          .filter((node) => !!getAgentTeamId(node))
+          .map((node) => node.id),
+      );
+      const normalVictimIds = victims
+        .filter((node) => !teamVictimIds.has(node.id))
+        .map((node) => node.id);
+      const removedIds = new Set<string>();
+
+      if (teamIds.length > 0) {
+        const api = window.canvasWorkspace?.agentTeams;
+        if (!api) {
+          notify({
+            tone: 'error',
+            title: 'Agent Team delete failed',
+            description: 'Agent Team API unavailable.',
+          });
+          return;
+        }
+
+        const deletedTeamNodeIds = new Set<string>();
+        for (const teamId of teamIds) {
+          const result = await api.delete(canvasId, teamId);
+          if (!result.ok) {
+            notify({
+              tone: 'error',
+              title: 'Agent Team delete failed',
+              description: result.error ?? 'Unable to delete the Agent Team.',
+            });
+            return;
+          }
+          for (const nodeId of result.deletedNodeIds ?? []) deletedTeamNodeIds.add(nodeId);
+        }
+
+        const deletedIds = Array.from(deletedTeamNodeIds);
+        syncDeletedNodes(deletedIds);
+        for (const nodeId of deletedIds) removedIds.add(nodeId);
+      }
+
+      if (normalVictimIds.length > 0) {
+        removeNodes(normalVictimIds);
+        for (const nodeId of normalVictimIds) removedIds.add(nodeId);
+      }
+
       setSelectedNodeIds((current) => current.filter((id) => !removedIds.has(id)));
     },
-    [removeNodes, nodesRef, setSelectedNodeIds],
+    [canvasId, nodesRef, notify, removeNodes, setSelectedNodeIds, syncDeletedNodes],
   );
 
   const requestRemoveEdge = useCallback(
@@ -194,11 +256,10 @@ export const useCanvasNodeActions = ({
   const handleExternalDelete = useCallback(
     (deleteNodeId: string) => {
       if (nodesRef.current.some((n) => n.id === deleteNodeId)) {
-        removeNode(deleteNodeId);
-        setSelectedNodeIds((ids) => ids.filter((id) => id !== deleteNodeId));
+        void requestRemoveNodes([deleteNodeId]);
       }
     },
-    [removeNode, nodesRef, setSelectedNodeIds],
+    [nodesRef, requestRemoveNodes],
   );
 
   return {

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -132,7 +132,7 @@ export const Canvas = ({
 
   const {
     nodes, edges, loaded, externallyEditedIds,
-    addNode, updateNode, removeNode, removeNodes,
+    addNode, updateNode, removeNodes,
     syncDeletedNodes,
     moveNode, moveNodes, resizeNode,
     addEdge, updateEdge, removeEdge,
@@ -258,7 +258,9 @@ export const Canvas = ({
     selectedNodeIds, setSelectedNodeIds,
     selectedEdgeId, setSelectedEdgeId,
     editingEdgeLabelId, setEditingEdgeLabelId,
-    removeNode, removeNodes, removeEdge,
+    canvasId,
+    removeNodes, removeEdge,
+    syncDeletedNodes,
     groupNodes, ungroupNodes, wrapNodesInFrame,
     notify, confirm,
   });


### PR DESCRIPTION
## Summary
- keep Agent Team managed nodes in an internal auto-resume state during retry cooldown instead of showing the manual resume card
- preserve Claude Code session ids from initialization and recover gracefully when Claude local history cannot resume an old id
- clean up Agent Team canvas deletion paths so frame and managed Coding Agent nodes are removed together

## Tests
- pnpm --filter canvas-workspace typecheck:renderer
- pnpm --filter canvas-workspace typecheck:main
- pnpm exec vitest run src/main/__tests__/agent-team-canvas-nodes.test.ts src/main/__tests__/agent-teams-service.test.ts