### PR TITLE
Auto-install canvas skill + CLI when Agent Teams flag is enabled

### DIFF
--- a/apps/canvas-workspace/src/main/files/skill-installer.ts
+++ b/apps/canvas-workspace/src/main/files/skill-installer.ts
@@ -1,10 +1,15 @@
-import { ipcMain } from 'electron';
-import { promises as fs } from 'fs';
-import { join } from 'path';
+import { app, ipcMain } from 'electron';
+import { execFile } from 'child_process';
+import { existsSync, promises as fs } from 'fs';
+import { dirname, join } from 'path';
 import { homedir } from 'os';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
 
 const SKILL_NAME = 'pulse-canvas';
 const LEGACY_SKILL_NAMES = ['canvas'];
+const CLI_PACKAGE = '@pulse-coder/canvas-cli';
 
 const SKILL_PARENT_DIRS = [
   join(homedir(), '.pulse-coder', 'skills'),
@@ -18,7 +23,13 @@ const LEGACY_SKILL_DIRS = SKILL_PARENT_DIRS.flatMap((dir) =>
   LEGACY_SKILL_NAMES.map((name) => join(dir, name)),
 );
 
-const SKILL_CONTENT = `---
+const MANUAL_COMMAND = `pnpm --filter ${CLI_PACKAGE} build && pnpm link --global --filter ${CLI_PACKAGE}`;
+
+// Fallback skill body used when the canonical source under
+// packages/canvas-cli/skills cannot be located (e.g. a packaged build with
+// no monorepo on disk). Kept intentionally minimal — the live source is the
+// source of truth, this only guards against a missing checkout.
+const FALLBACK_SKILL_CONTENT = `---
 name: pulse-canvas
 description: Operate Pulse Canvas workspaces — read user-curated context, write results, create nodes
 version: 1.0.0
@@ -36,7 +47,6 @@ The current workspace ID is available via \`$PULSE_CANVAS_WORKSPACE_ID\` environ
 \`\`\`bash
 pulse-canvas context --format json
 \`\`\`
-Returns all nodes with structured info: file paths, frame groups, labels.
 
 ### List nodes
 \`\`\`bash
@@ -53,36 +63,8 @@ pulse-canvas node read <nodeId> --format json
 pulse-canvas node write <nodeId> --content "..."
 \`\`\`
 
-### Create a node
-\`\`\`bash
-pulse-canvas node create --type file --title "Report" --data '{"content":"..."}'
-\`\`\`
-
-### Create an edge (connection between nodes)
-\`\`\`bash
-pulse-canvas edge create --from <nodeId> --to <nodeId> --label "depends on" --kind dependency --format json
-\`\`\`
-
-### List edges
-\`\`\`bash
-pulse-canvas edge list --format json
-\`\`\`
-
-### Delete an edge
-\`\`\`bash
-pulse-canvas edge delete <edgeId> --format json
-\`\`\`
-
-### List workspaces
-\`\`\`bash
-pulse-canvas workspace list --format json
-\`\`\`
-
 ## Usage Principles
 - Before starting a task, run \`context\` to understand the user's canvas layout and intent
-- Files on the canvas = files the user considers important — prioritize them
-- Frame groups = file associations — understand files in the same group together
-- Edges = relationships — understand how frames and nodes connect to each other
 - After completing work, write results back to the canvas for the user to review
 `;
 
@@ -92,15 +74,131 @@ export interface SkillTargetResult {
   error?: string;
 }
 
-async function installSingleTarget(dir: string): Promise<SkillTargetResult> {
+export interface CliInstallResult {
+  ok: boolean;
+  error?: string;
+}
+
+export interface SkillsInstallResult {
+  ok: boolean;
+  skillsInstalled: boolean;
+  results: SkillTargetResult[];
+  cliInstalled: boolean;
+  manualCommand: string | null;
+  cliError: string | null;
+}
+
+/**
+ * Walk up from a few candidate starting points looking for the monorepo
+ * marker (`pnpm-workspace.yaml`). In `electron-vite dev` the main bundle runs
+ * from `out/main`, so we climb out of the app directory to reach the repo
+ * root. Returns null when no checkout is on disk (e.g. a packaged build).
+ */
+function findRepoRoot(): string | null {
+  const starts = [
+    (() => {
+      try {
+        return app?.getAppPath?.();
+      } catch {
+        return undefined;
+      }
+    })(),
+    __dirname,
+    process.cwd(),
+  ].filter((p): p is string => typeof p === 'string' && p.length > 0);
+
+  for (const start of starts) {
+    let dir = start;
+    for (let i = 0; i < 10; i++) {
+      if (existsSync(join(dir, 'pnpm-workspace.yaml'))) return dir;
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  }
+  return null;
+}
+
+/** Rewrite the front-matter `name:` so the installed skill keeps the
+ *  `pulse-canvas` convention even though the source dir is named `canvas`. */
+function rewriteSkillName(content: string, name: string): string {
+  return content.replace(/^name:.*$/m, `name: ${name}`);
+}
+
+/** Read the latest skill body from the canvas-cli package, falling back to the
+ *  bundled minimal copy when the source checkout is unavailable. */
+async function loadLatestSkillContent(): Promise<string> {
+  const root = findRepoRoot();
+  if (root) {
+    const src = join(root, 'packages', 'canvas-cli', 'skills', 'canvas', 'SKILL.md');
+    try {
+      const raw = await fs.readFile(src, 'utf-8');
+      if (raw.trim()) return rewriteSkillName(raw, SKILL_NAME);
+    } catch {
+      // fall through to the bundled fallback
+    }
+  }
+  return FALLBACK_SKILL_CONTENT;
+}
+
+async function installSingleTarget(dir: string, content: string): Promise<SkillTargetResult> {
   const targetPath = join(dir, 'SKILL.md');
   try {
     await fs.mkdir(dir, { recursive: true });
-    await fs.writeFile(targetPath, SKILL_CONTENT, 'utf-8');
+    await fs.writeFile(targetPath, content, 'utf-8');
     return { path: targetPath, ok: true };
   } catch (err) {
     return { path: targetPath, ok: false, error: err instanceof Error ? err.message : String(err) };
   }
+}
+
+/**
+ * Build the canvas CLI and link it globally so agents can call `pulse-canvas`.
+ * Best-effort and dev-only by nature: it requires the monorepo source and a
+ * `pnpm` on PATH (both present when launched via `pnpm dev`). On any failure
+ * we surface the error and let the caller fall back to the manual command.
+ */
+async function installCanvasCli(): Promise<CliInstallResult> {
+  const root = findRepoRoot();
+  if (!root) {
+    return {
+      ok: false,
+      error:
+        'Could not locate the monorepo root (pnpm-workspace.yaml not found). CLI auto-install only works from a source checkout.',
+    };
+  }
+  const opts = { cwd: root, env: process.env, maxBuffer: 16 * 1024 * 1024 } as const;
+  try {
+    await execFileAsync('pnpm', ['--filter', CLI_PACKAGE, 'build'], opts);
+    await execFileAsync('pnpm', ['link', '--global', '--filter', CLI_PACKAGE], opts);
+    return { ok: true };
+  } catch (err: any) {
+    const stderr = typeof err?.stderr === 'string' ? err.stderr : err?.stderr?.toString?.();
+    const msg = (stderr || err?.message || String(err)).trim();
+    return { ok: false, error: msg };
+  }
+}
+
+/**
+ * Install the latest canvas skill into the global skill dirs and (best-effort)
+ * build + link the canvas CLI. Shared by the `skills:install` IPC handler and
+ * the experimental-flag auto-install trigger.
+ */
+export async function runInstall(): Promise<SkillsInstallResult> {
+  const content = await loadLatestSkillContent();
+  const results = await Promise.all(GLOBAL_SKILL_DIRS.map((dir) => installSingleTarget(dir, content)));
+  const skillsInstalled = results.every((r) => r.ok);
+
+  const cli = await installCanvasCli();
+
+  return {
+    ok: skillsInstalled && cli.ok,
+    skillsInstalled,
+    results,
+    cliInstalled: cli.ok,
+    cliError: cli.ok ? null : cli.error ?? null,
+    manualCommand: cli.ok ? null : MANUAL_COMMAND,
+  };
 }
 
 async function checkSingleTarget(dir: string): Promise<SkillTargetResult> {
@@ -132,19 +230,7 @@ async function removeLegacyDir(dir: string): Promise<SkillTargetResult> {
 }
 
 export function setupSkillInstallerIpc(): void {
-  ipcMain.handle('skills:install', async () => {
-    const results = await Promise.all(GLOBAL_SKILL_DIRS.map(installSingleTarget));
-    const ok = results.every((r) => r.ok);
-    return {
-      ok,
-      skillsInstalled: ok,
-      results,
-      cliInstalled: false,
-      manualCommand:
-        'cd <project-root> && pnpm --filter @pulse-coder/canvas-cli build && pnpm link --global --filter @pulse-coder/canvas-cli',
-      cliError: null,
-    };
-  });
+  ipcMain.handle('skills:install', async () => runInstall());
 
   ipcMain.handle('skills:status', async () => {
     const [results, legacy] = await Promise.all([

--- a/apps/canvas-workspace/src/main/settings/experimental-ipc.ts
+++ b/apps/canvas-workspace/src/main/settings/experimental-ipc.ts
@@ -16,8 +16,10 @@ import { homedir } from 'os';
 import { dirname, join } from 'path';
 import {
   EXPERIMENTAL_FEATURES,
+  EXPERIMENTAL_FLAG_AGENT_TEAMS,
   resolveFeatureValues,
 } from '../../shared/experimental-features';
+import { runInstall } from '../files/skill-installer';
 
 function getPath(): string {
   const envPath = process.env.PULSE_CANVAS_EXPERIMENTAL_FEATURES?.trim();
@@ -109,8 +111,38 @@ export function setupExperimentalIpc(): void {
           return { ok: false, error: `Unknown experimental feature: ${payload.id}` };
         }
         const overrides = await readOverrides();
+        const wasEnabled = resolveFeatureValues(overrides)[payload.id] === true;
         overrides[payload.id] = !!payload.enabled;
         await writeOverrides(overrides);
+
+        // When Agent Teams is turned on (off→on), install the latest canvas
+        // skill + CLI in the background. Experimental/dev-only: skill files
+        // land in the global skill dirs and the CLI is built + `pnpm link`-ed.
+        // Fire-and-forget so the toggle stays responsive; the manual
+        // Settings → Agent button re-runs the same routine with full feedback.
+        if (
+          payload.id === EXPERIMENTAL_FLAG_AGENT_TEAMS &&
+          payload.enabled &&
+          !wasEnabled
+        ) {
+          void runInstall()
+            .then((result) => {
+              if (!result.skillsInstalled) {
+                console.warn('[experimental] agent-teams skill install incomplete', result.results);
+              }
+              if (!result.cliInstalled) {
+                console.warn(
+                  `[experimental] agent-teams CLI install skipped/failed: ${result.cliError ?? 'unknown'}. Run manually: ${result.manualCommand}`,
+                );
+              } else {
+                console.log('[experimental] agent-teams skill + CLI installed');
+              }
+            })
+            .catch((err) => {
+              console.error('[experimental] agent-teams tooling install errored', err);
+            });
+        }
+
         return { ok: true, values: resolveFeatureValues(overrides) };
       } catch (err) {
         return { ok: false, error: err instanceof Error ? err.message : String(err) };

--- a/apps/canvas-workspace/src/main/settings/experimental-ipc.ts
+++ b/apps/canvas-workspace/src/main/settings/experimental-ipc.ts
@@ -102,7 +102,7 @@ export function setupExperimentalIpc(): void {
 
   ipcMain.handle(
     'experimental:set',
-    async (_event, payload: { id: string; enabled: boolean }) => {
+    async (event, payload: { id: string; enabled: boolean }) => {
       try {
         if (!payload || typeof payload.id !== 'string') {
           return { ok: false, error: 'Missing flag id' };
@@ -125,6 +125,18 @@ export function setupExperimentalIpc(): void {
           payload.enabled &&
           !wasEnabled
         ) {
+          const sender = event.sender;
+          const pushStatus = (status: {
+            ok: boolean;
+            skillsInstalled: boolean;
+            cliInstalled: boolean;
+            cliError?: string | null;
+            manualCommand?: string | null;
+          }) => {
+            if (!sender.isDestroyed()) {
+              sender.send('experimental:tooling-status', { feature: payload.id, ...status });
+            }
+          };
           void runInstall()
             .then((result) => {
               if (!result.skillsInstalled) {
@@ -137,9 +149,23 @@ export function setupExperimentalIpc(): void {
               } else {
                 console.log('[experimental] agent-teams skill + CLI installed');
               }
+              pushStatus({
+                ok: result.ok,
+                skillsInstalled: result.skillsInstalled,
+                cliInstalled: result.cliInstalled,
+                cliError: result.cliError,
+                manualCommand: result.manualCommand,
+              });
             })
             .catch((err) => {
               console.error('[experimental] agent-teams tooling install errored', err);
+              pushStatus({
+                ok: false,
+                skillsInstalled: false,
+                cliInstalled: false,
+                cliError: err instanceof Error ? err.message : String(err),
+                manualCommand: null,
+              });
             });
         }
 

--- a/apps/canvas-workspace/src/preload/bridge/settings.ts
+++ b/apps/canvas-workspace/src/preload/bridge/settings.ts
@@ -1,4 +1,4 @@
-import type { IpcRenderer } from "electron";
+import type { IpcRenderer, IpcRendererEvent } from "electron";
 import type {
   CanvasMcpApi,
   CanvasModelApi,
@@ -7,7 +7,8 @@ import type {
   DialogApi,
   ExperimentalApi,
   PromptProfileApi,
-  SkillsApi
+  SkillsApi,
+  ToolingInstallStatus
 } from "../../renderer/src/types";
 
 export const createDialogApi = (ipcRenderer: IpcRenderer): DialogApi => ({
@@ -63,7 +64,16 @@ export const createExperimentalApi = (ipcRenderer: IpcRenderer): ExperimentalApi
 
   reset: () => ipcRenderer.invoke("experimental:reset"),
 
-  reloadWindow: () => ipcRenderer.invoke("experimental:reload-window")
+  reloadWindow: () => ipcRenderer.invoke("experimental:reload-window"),
+
+  onToolingStatus: (cb: (status: ToolingInstallStatus) => void) => {
+    const channel = "experimental:tooling-status";
+    const listener = (_event: IpcRendererEvent, status: ToolingInstallStatus) => cb(status);
+    ipcRenderer.on(channel, listener);
+    return () => {
+      ipcRenderer.removeListener(channel, listener);
+    };
+  }
 });
 
 export const createChannelConfigApi = (ipcRenderer: IpcRenderer): ChannelConfigApi => ({

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/ExperimentalSection.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/ExperimentalSection.tsx
@@ -1,6 +1,9 @@
-import { Fragment, useCallback, useEffect, useState } from 'react';
+import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
 import type { ExperimentalFeatureDef } from '../../types';
-import { EXPERIMENTAL_FLAG_CHANNELS } from '../../../../shared/experimental-features';
+import {
+  EXPERIMENTAL_FLAG_AGENT_TEAMS,
+  EXPERIMENTAL_FLAG_CHANNELS,
+} from '../../../../shared/experimental-features';
 import { useAppShell } from '../AppShellProvider';
 import { useI18n } from '../../i18n';
 import { ChannelConfigPanel } from './ChannelConfigPanel';
@@ -11,8 +14,11 @@ interface ExperimentalSectionProps {
 }
 
 export const ExperimentalSection = ({ onClose }: ExperimentalSectionProps) => {
-  const { notify } = useAppShell();
+  const { notify, updateToast } = useAppShell();
   const { t } = useI18n();
+  // Id of the in-progress "installing tooling" toast, so the async
+  // tooling-status push from main can update it in place.
+  const toolingToastRef = useRef<string | null>(null);
   const [features, setFeatures] = useState<ExperimentalFeatureDef[]>([]);
   const [values, setValues] = useState<Record<string, boolean>>({});
   const [path, setPath] = useState<string>('');
@@ -45,6 +51,38 @@ export const ExperimentalSection = ({ onClose }: ExperimentalSectionProps) => {
     void load();
   }, [load]);
 
+  // Subscribe to background tooling-install results pushed from main and
+  // resolve the in-progress toast (or surface a standalone toast as fallback).
+  useEffect(() => {
+    const off = window.canvasWorkspace.experimental.onToolingStatus((status) => {
+      if (status.feature !== EXPERIMENTAL_FLAG_AGENT_TEAMS) return;
+      const patch = status.ok
+        ? {
+            tone: 'success' as const,
+            title: t('experimental.toolingReady'),
+            description: t('experimental.toolingReadyDesc'),
+            autoCloseMs: 6000,
+          }
+        : {
+            tone: 'error' as const,
+            title: t('experimental.toolingCliFailed'),
+            description: t('experimental.toolingCliFailedDesc', {
+              error: status.cliError ?? t('experimental.unknownError'),
+              command: status.manualCommand ?? '',
+            }),
+            autoCloseMs: 0,
+          };
+      const id = toolingToastRef.current;
+      if (id) {
+        updateToast(id, patch);
+        toolingToastRef.current = null;
+      } else {
+        notify(patch);
+      }
+    });
+    return off;
+  }, [notify, updateToast, t]);
+
   const toggle = useCallback(
     async (id: string, enabled: boolean) => {
       setPending((p) => ({ ...p, [id]: true }));
@@ -63,6 +101,16 @@ export const ExperimentalSection = ({ onClose }: ExperimentalSectionProps) => {
         }
         if (res.values) setValues(res.values);
         setNeedsReload(true);
+        // Turning Agent Teams on kicks off a background skill + CLI install in
+        // main. Show a persistent "installing" toast now; the tooling-status
+        // subscription updates it with the result when the install settles.
+        if (id === EXPERIMENTAL_FLAG_AGENT_TEAMS && enabled && !previous) {
+          toolingToastRef.current = notify({
+            tone: 'loading',
+            title: t('experimental.toolingInstalling'),
+            description: t('experimental.toolingInstallingDesc'),
+          });
+        }
       } catch (err) {
         setValues((v) => ({ ...v, [id]: previous ?? false }));
         notify({

--- a/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
+++ b/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
@@ -373,6 +373,14 @@ const en = {
   'experimental.toggleFeature': 'Toggle {label}',
   'experimental.resetAll': 'Reset all to defaults',
   'experimental.close': 'Close',
+  'experimental.toolingInstalling': 'Installing Agent Teams tooling…',
+  'experimental.toolingInstallingDesc':
+    'Writing the canvas skill and linking the pulse-canvas CLI in the background.',
+  'experimental.toolingReady': 'Agent Teams tooling ready',
+  'experimental.toolingReadyDesc': 'Canvas skill installed and pulse-canvas CLI linked.',
+  'experimental.toolingCliFailed': 'CLI not linked',
+  'experimental.toolingCliFailedDesc':
+    'Skill installed, but the CLI step failed: {error} Run manually: {command}',
 
   'workspaceSettings.kicker': 'Workspace Settings',
   'workspaceSettings.ariaLabel': 'Workspace settings',
@@ -936,6 +944,12 @@ const zh: Record<keyof typeof en, string> = {
   'experimental.toggleFeature': '切换 {label}',
   'experimental.resetAll': '全部恢复默认',
   'experimental.close': '关闭',
+  'experimental.toolingInstalling': '正在安装 Agent Teams 工具…',
+  'experimental.toolingInstallingDesc': '正在后台写入 canvas skill 并链接 pulse-canvas CLI。',
+  'experimental.toolingReady': 'Agent Teams 工具已就绪',
+  'experimental.toolingReadyDesc': 'canvas skill 已安装，pulse-canvas CLI 已链接。',
+  'experimental.toolingCliFailed': 'CLI 未链接',
+  'experimental.toolingCliFailedDesc': 'skill 已安装，但 CLI 步骤失败：{error} 可手动运行：{command}',
 
   'workspaceSettings.kicker': '工作区设置',
   'workspaceSettings.ariaLabel': '工作区设置',

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -1536,6 +1536,21 @@ export interface ExperimentalFeatureDef {
   defaultEnabled: boolean;
 }
 
+/**
+ * Pushed from main when a flag toggle kicks off a background tooling install
+ * (e.g. the Agent Teams skill + CLI). Delivered over the
+ * `experimental:tooling-status` channel once the install settles.
+ */
+export interface ToolingInstallStatus {
+  /** The experimental flag id that triggered the install. */
+  feature: string;
+  ok: boolean;
+  skillsInstalled: boolean;
+  cliInstalled: boolean;
+  cliError?: string | null;
+  manualCommand?: string | null;
+}
+
 export interface ExperimentalApi {
   list: () => Promise<{
     ok: boolean;
@@ -1548,6 +1563,8 @@ export interface ExperimentalApi {
     Promise<{ ok: boolean; values?: Record<string, boolean>; error?: string }>;
   reset: () => Promise<{ ok: boolean; values?: Record<string, boolean>; error?: string }>;
   reloadWindow: () => Promise<{ ok: boolean; error?: string }>;
+  /** Subscribe to background tooling-install results. Returns an unsubscribe fn. */
+  onToolingStatus: (cb: (status: ToolingInstallStatus) => void) => () => void;
 }
 
 export interface ChannelConfigStatus {


### PR DESCRIPTION
## Summary
Enhance the experimental Agent Teams feature to automatically install the canvas skill and CLI when the flag is toggled on. Previously, users had to manually run a command; now the installation happens in the background with progress feedback via toast notifications.

## Key Changes

- **skill-installer.ts**: Refactored to support dynamic skill content loading
  - Extract skill content from the live monorepo source (`packages/canvas-cli/skills/canvas/SKILL.md`) when available, falling back to a minimal bundled copy for packaged builds
  - Add `findRepoRoot()` to locate the monorepo by walking up from candidate starting points looking for `pnpm-workspace.yaml`
  - Implement `installCanvasCli()` to build and globally link the canvas CLI via `pnpm` (best-effort, dev-only)
  - Export `runInstall()` as a reusable routine that installs both skill and CLI, returning detailed status
  - Update IPC handler to use the new `runInstall()` function
  - Simplify fallback skill content (remove some documentation sections, keep it intentionally minimal)

- **experimental-ipc.ts**: Wire up background installation on flag toggle
  - When Agent Teams flag is turned on (off→on), trigger `runInstall()` in the background
  - Push installation results back to the renderer via `experimental:tooling-status` IPC channel
  - Log warnings/errors for incomplete or failed installations; surface manual command as fallback
  - Fire-and-forget pattern keeps the toggle responsive

- **ExperimentalSection.tsx**: Add UI feedback for background installation
  - Subscribe to `experimental:tooling-status` events from main
  - Show a persistent "installing" toast when Agent Teams is toggled on
  - Update the toast in-place with success/error status when installation settles
  - Display error details and manual command if CLI installation fails

- **types.ts**: Define `ToolingInstallStatus` interface for the new IPC channel
  - Includes feature id, success flags, error messages, and fallback manual command

- **settings.ts (preload bridge)**: Expose `onToolingStatus()` subscription method to renderer

- **messages.ts**: Add i18n strings for installation progress and result states (English + Chinese)

## Implementation Details

- The skill content is now loaded dynamically: the live source under `packages/canvas-cli/skills/canvas/SKILL.md` is preferred, with a fallback to a bundled minimal version for packaged builds where the monorepo is not on disk
- CLI installation is best-effort and dev-only by nature—it requires both the monorepo source and `pnpm` on PATH (both present when launched via `pnpm dev`)
- The skill name is rewritten from `canvas` to `pulse-canvas` to maintain the convention
- Installation results are surfaced to the user via toast notifications with appropriate tone (loading → success/error)
- If CLI installation fails, the manual command is provided to the user for reference

https://claude.ai/code/session_01NyTGML7U9SVaXfMYE8WsQL