### PR TITLE
Refactor team-managed card layout to vertical flex with improved styling

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTeamManaged.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTeamManaged.tsx
@@ -51,45 +51,55 @@ export const AgentTeamManaged = ({
     ? recentActions
     : ['Waiting for team updates.'];
 
+  const statusClass = status ? `agent-team-managed--${status}` : 'agent-team-managed--idle';
+
   return (
     <div className="agent-body-wrap agent-body-wrap--team-managed">
       <div className="agent-card agent-card--team-managed">
-        <div className="agent-team-managed">
-          <div className="agent-team-managed__icon">
-            <AgentIcon id={agentType} size={22} />
+        <div className={`agent-team-managed ${statusClass}`}>
+          <div className="agent-team-managed__header">
+            <div className="agent-team-managed__icon">
+              <AgentIcon id={agentType} size={22} />
+            </div>
+            <div className="agent-team-managed__headtext">
+              <div className="agent-team-managed__eyebrow">Team Leader</div>
+              <div className="agent-team-managed__title">{leaderTitle(status)}</div>
+            </div>
           </div>
-          <div className="agent-team-managed__copy">
-            <div className="agent-team-managed__eyebrow">Team Leader</div>
-            <div className="agent-team-managed__title">{leaderTitle(status)}</div>
-            <div className="agent-team-managed__body">
-              {leaderBody(status)}
-            </div>
-            <div className="agent-team-managed__decision">
-              <span>Current decision</span>
-              <strong>{summarizePrompt(lastPrompt)}</strong>
-            </div>
-            <div className="agent-team-managed__actions">
-              <span>Recent actions</span>
-              <ul>
-                {actionItems.map((action) => (
-                  <li key={action}>{action}</li>
-                ))}
-              </ul>
-            </div>
-            <div className="agent-team-managed__meta">
-              {agentDef?.label ?? agentType} · {displayCwd}
-            </div>
-            {commandSlot && (
-              <div className="agent-team-managed__command">
-                {commandSlot}
-              </div>
-            )}
-            {onOpenTerminal && (
-              <button type="button" className="agent-team-managed__terminal-button" onClick={onOpenTerminal}>
-                Advanced terminal
-              </button>
-            )}
+
+          <div className="agent-team-managed__body">
+            {leaderBody(status)}
           </div>
+
+          <div className="agent-team-managed__decision">
+            <span>Current decision</span>
+            <strong>{summarizePrompt(lastPrompt)}</strong>
+          </div>
+
+          <div className="agent-team-managed__actions">
+            <span>Recent actions</span>
+            <ul>
+              {actionItems.map((action) => (
+                <li key={action}>{action}</li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="agent-team-managed__meta">
+            {agentDef?.label ?? agentType} · {displayCwd}
+          </div>
+
+          {commandSlot && (
+            <div className="agent-team-managed__command">
+              {commandSlot}
+            </div>
+          )}
+
+          {onOpenTerminal && (
+            <button type="button" className="agent-team-managed__terminal-button" onClick={onOpenTerminal}>
+              Advanced terminal
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
@@ -212,63 +212,112 @@
   box-shadow: 0 8px 22px rgba(31, 54, 88, 0.04);
 }
 
+/* ── Team-lead "managed" card ──────────────────────────────────────
+ * A modern, card-based summary of the team leader's latest run. The
+ * left dock column is narrow (~260px), so content flows full-width in
+ * a single column with a compact icon+title header on top. */
 .agent-team-managed {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  align-items: center;
-  align-content: center;
-  gap: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
   width: 100%;
   height: 100%;
-  padding: 34px 40px;
+  padding: 16px;
   border: none;
   border-radius: 0;
-  background:
-    linear-gradient(90deg, rgba(35, 131, 226, 0.06), transparent 46%),
-    transparent;
+  background: transparent;
   box-shadow: none;
+  overflow-y: auto;
+}
+
+.agent-team-managed__header {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  min-width: 0;
 }
 
 .agent-team-managed__icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 44px;
-  height: 44px;
-  border-radius: 12px;
+  flex: 0 0 auto;
+  width: 40px;
+  height: 40px;
+  border-radius: 13px;
   color: var(--agent-accent);
-  background: rgba(35, 131, 226, 0.08);
-  box-shadow: inset 0 0 0 1px rgba(35, 131, 226, 0.08);
+  background:
+    linear-gradient(135deg, rgba(35, 131, 226, 0.16), rgba(35, 131, 226, 0.06));
+  box-shadow:
+    inset 0 0 0 1px rgba(35, 131, 226, 0.2),
+    0 4px 12px rgba(35, 131, 226, 0.14);
 }
 
-.agent-team-managed__copy {
+.agent-team-managed__headtext {
   display: grid;
-  gap: 5px;
+  gap: 2px;
   min-width: 0;
 }
 
 .agent-team-managed__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   color: var(--agent-accent);
   font-size: 10px;
   font-weight: 900;
-  letter-spacing: 0;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
+}
+
+.agent-team-managed__eyebrow::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--agent-faint);
+}
+
+.agent-team-managed--running .agent-team-managed__eyebrow::before {
+  background: var(--agent-accent);
+  box-shadow: 0 0 0 3px rgba(35, 131, 226, 0.16);
+  animation: agent-team-managed-pulse 1.8s ease-in-out infinite;
+}
+
+.agent-team-managed--done .agent-team-managed__eyebrow::before {
+  background: var(--agent-success);
+}
+
+.agent-team-managed--error .agent-team-managed__eyebrow::before {
+  background: var(--agent-danger);
+}
+
+@keyframes agent-team-managed-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.45; }
 }
 
 .agent-team-managed__title {
   color: var(--agent-text);
-  font-size: 16px;
+  font-size: 15px;
   font-weight: 800;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
 }
 
 .agent-team-managed__body {
-  max-width: 520px;
   color: var(--agent-muted);
-  font-size: 13px;
+  font-size: 12.5px;
   line-height: 1.5;
 }
 
 .agent-team-managed__meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 2px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(15, 23, 42, 0.07);
   color: var(--agent-faint);
   font-family: var(--font-mono);
   font-size: 11px;
@@ -277,95 +326,110 @@
   white-space: nowrap;
 }
 
-.agent-team-managed__decision {
+.agent-team-managed__decision,
+.agent-team-managed__actions {
   display: grid;
-  gap: 4px;
-  max-width: 560px;
-  margin-top: 7px;
-  padding: 9px 11px;
-  border: 1px solid rgba(35, 131, 226, 0.12);
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.7);
+  gap: 6px;
+  padding: 11px 12px;
+  border: none;
+  border-radius: 12px;
+}
+
+.agent-team-managed__decision {
+  background:
+    linear-gradient(180deg, rgba(35, 131, 226, 0.08), rgba(35, 131, 226, 0.035));
+  box-shadow: inset 0 0 0 1px rgba(35, 131, 226, 0.16);
+}
+
+.agent-team-managed__actions {
+  background: rgba(15, 23, 42, 0.025);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.07);
+}
+
+.agent-team-managed__decision span,
+.agent-team-managed__actions > span {
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
 }
 
 .agent-team-managed__decision span {
   color: var(--agent-accent);
-  font-size: 10px;
-  font-weight: 900;
-  letter-spacing: 0;
-  text-transform: uppercase;
+}
+
+.agent-team-managed__actions > span {
+  color: var(--agent-muted);
 }
 
 .agent-team-managed__decision strong {
   display: -webkit-box;
   overflow: hidden;
   color: var(--agent-text);
-  font-size: 12px;
-  font-weight: 750;
-  line-height: 1.35;
+  font-size: 12.5px;
+  font-weight: 700;
+  line-height: 1.4;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
 }
 
-.agent-team-managed__actions {
-  display: grid;
-  gap: 5px;
-  max-width: 560px;
-  margin-top: 4px;
-  padding: 8px 11px;
-  border: 1px solid rgba(0, 0, 0, 0.06);
-  border-radius: 8px;
-  background: rgba(250, 251, 253, 0.68);
-}
-
-.agent-team-managed__actions > span {
-  color: var(--agent-muted);
-  font-size: 10px;
-  font-weight: 900;
-  letter-spacing: 0;
-  text-transform: uppercase;
-}
-
 .agent-team-managed__actions ul {
   display: grid;
-  gap: 3px;
+  gap: 6px;
   margin: 0;
   padding: 0;
   list-style: none;
 }
 
 .agent-team-managed__actions li {
+  position: relative;
   overflow: hidden;
+  padding-left: 15px;
   color: var(--agent-text);
   font-size: 12px;
-  font-weight: 700;
-  line-height: 1.32;
+  font-weight: 600;
+  line-height: 1.35;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.agent-team-managed__actions li::before {
+  content: '';
+  position: absolute;
+  top: 6px;
+  left: 3px;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--agent-accent);
+  opacity: 0.6;
 }
 
 .agent-team-managed__command {
   display: block;
   width: 100%;
-  max-width: 560px;
-  margin-top: 8px;
+  margin-top: 2px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
 }
 
 .agent-team-managed__terminal-button {
   justify-self: start;
   height: 30px;
-  margin-top: 4px;
-  border: 1px solid rgba(35, 131, 226, 0.18);
-  border-radius: 6px;
-  background: #f3f8ff;
+  margin-top: 2px;
+  border: 1px solid rgba(35, 131, 226, 0.22);
+  border-radius: 8px;
+  background: rgba(35, 131, 226, 0.06);
   color: var(--agent-accent);
   font: 800 12px var(--agent-sans);
   cursor: pointer;
-  padding: 0 10px;
+  padding: 0 12px;
+  transition: background 0.15s ease, border-color 0.15s ease;
 }
 
 .agent-team-managed__terminal-button:hover {
-  background: #e9f2ff;
+  background: rgba(35, 131, 226, 0.12);
+  border-color: rgba(35, 131, 226, 0.34);
 }
 
 /* Back link rendered at the top of the body when Setup is entered from

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
@@ -348,9 +348,21 @@
 }
 
 .agent-team-command--lead textarea {
-  min-height: 34px;
+  min-height: 38px;
   max-height: 72px;
   resize: none;
+  border-radius: 10px;
+  border-color: rgba(122, 167, 232, 0.4);
+  padding: 9px 11px;
+  font-size: 12.5px;
+  line-height: 1.45;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.agent-team-command--lead textarea:focus {
+  outline: none;
+  border-color: var(--agent-accent, #2383e2);
+  box-shadow: 0 0 0 3px rgba(35, 131, 226, 0.14);
 }
 
 .agent-team-frame--briefing .agent-team-command textarea {
@@ -381,18 +393,30 @@
 .agent-team-command button {
   height: 34px;
   min-width: 72px;
-  border-color: #7aa7e8;
-  background: #5f94e6;
+  border: none;
+  border-radius: 9px;
+  background: linear-gradient(180deg, #5f94e6, #4f84d8);
   color: #fff;
+  font-weight: 700;
+  box-shadow: 0 6px 14px rgba(47, 102, 184, 0.24);
+  transition: filter 0.15s ease, box-shadow 0.15s ease;
 }
 
 .agent-team-command button:hover:not(:disabled) {
-  background: #4f84d8;
+  filter: brightness(1.05);
+  box-shadow: 0 8px 18px rgba(47, 102, 184, 0.3);
+}
+
+.agent-team-command button:disabled {
+  background: #c4d4ec;
+  box-shadow: none;
+  cursor: not-allowed;
 }
 
 .agent-team-command--lead button {
   align-self: flex-end;
-  min-width: 118px;
+  min-width: 124px;
+  height: 36px;
 }
 
 .agent-team-workspace {
@@ -421,18 +445,22 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  border-radius: 12px;
+  border-color: rgba(92, 128, 183, 0.18);
   background:
-    linear-gradient(180deg, rgba(241, 247, 255, 0.92), rgba(255, 255, 255, 0.9)),
-    rgba(255, 255, 255, 0.86);
+    linear-gradient(180deg, rgba(244, 249, 255, 0.95), rgba(255, 255, 255, 0.92)),
+    rgba(255, 255, 255, 0.88);
+  box-shadow: 0 14px 30px rgba(31, 54, 88, 0.06);
 }
 
 .agent-team-lead-dock__head {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: 2px 10px;
+  gap: 3px 10px;
   align-items: center;
-  padding: 12px 14px;
-  border-bottom: 1px solid rgba(35, 131, 226, 0.12);
+  padding: 13px 15px;
+  border-bottom: 1px solid rgba(35, 131, 226, 0.1);
+  background: linear-gradient(180deg, rgba(35, 131, 226, 0.05), transparent);
 }
 
 .agent-team-lead-dock__head .agent-team-panel-heading__label {
@@ -467,8 +495,9 @@
   min-height: 0;
   overflow: hidden;
   border: 1px solid rgba(35, 131, 226, 0.12);
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.84);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 6px 16px rgba(31, 54, 88, 0.045);
 }
 
 .agent-team-frame--briefing .agent-team-lead-dock__agent-surface {


### PR DESCRIPTION
## Summary
Redesigned the team leader "managed" card component from a horizontal grid layout to a vertical flex layout optimized for the narrow left dock column (~260px). Updated styling with modern card aesthetics, status indicators, and improved visual hierarchy.

## Key Changes

**Layout & Structure:**
- Changed `.agent-team-managed` from `grid` (2-column) to `flex` (column) layout for single-column flow
- Reduced padding from `34px 40px` to `16px` and gap from `18px` to `12px` for compact spacing
- Added new `.agent-team-managed__header` flex container to group icon and title horizontally
- Reorganized component structure in `AgentTeamManaged.tsx` to match new CSS layout

**Visual Styling:**
- Updated icon styling: gradient background, enhanced shadow, and improved border
- Added status-based styling with `.agent-team-managed--{running|done|error|idle}` classes
- Implemented animated pulse indicator (`.agent-team-managed-pulse`) for running status
- Refined decision and actions boxes with gradient backgrounds and subtle borders
- Added bullet points to action list items with pseudo-element styling

**Typography & Spacing:**
- Adjusted font sizes (title: 16px → 15px, body: 13px → 12.5px)
- Improved line-height and letter-spacing for better readability
- Added visual separator (border-top) between meta and decision sections
- Enhanced eyebrow styling with status indicator dot and letter-spacing

**Interactive Elements:**
- Updated terminal button with gradient background and improved hover states
- Added transitions for smooth state changes
- Refined textarea and button styling in command input area with better focus states
- Improved button disabled state styling

**Additional Refinements:**
- Added `overflow-y: auto` to main container for scrollable content
- Enhanced card container styling with rounded corners and subtle shadows
- Improved visual consistency across decision/actions sections

https://claude.ai/code/session_01BhjccQ62BZobSuK1yVJeq3