### PR TITLE
Fix frame header actions positioning at small zoom levels

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -612,6 +612,25 @@
   opacity: 1;
 }
 
+/* Frames opt out of the floating-popover treatment above. A frame's header is
+   already an absolutely-positioned, reverse-scaled tab that stays readable at
+   every zoom, so it doesn't need the detached popover. Worse: because that tab
+   is itself position:absolute, the generic rule anchors .node-header__actions
+   to the narrow tab (and inherits its scale transform) instead of the card,
+   leaving the buttons floating detached off the frame's top-left corner. Keep
+   them inline in the tab — exactly how they render at normal zoom. */
+.canvas-transform--small .canvas-node--frame .node-header__actions {
+  position: static;
+  transform: none;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
 .node-body {
   flex: 1;
   overflow: hidden;


### PR DESCRIPTION
## Summary
Fixes the positioning and styling of action buttons in frame node headers when the canvas is zoomed to small levels. Previously, the generic floating-popover treatment was being applied to frame headers, causing action buttons to detach and float incorrectly due to the frame's tab being absolutely positioned with scale transforms.

## Changes
- Added CSS rule for `.canvas-transform--small .canvas-node--frame .node-header__actions` that opts frames out of the floating-popover treatment
- Resets positioning to `static` and removes transform, padding, border, background, shadow, and backdrop-filter styles
- Keeps action buttons inline within the frame's tab header, matching their appearance at normal zoom levels

## Implementation Details
Frame headers use an absolutely-positioned, reverse-scaled tab design that remains readable at all zoom levels. The generic popover rule was anchoring action buttons to this narrow tab instead of the card, causing them to inherit the tab's scale transform and appear detached. The fix explicitly overrides these styles for frames to maintain proper inline positioning within the tab.

https://claude.ai/code/session_01J2iyKtj4d4ayG622Hs5tsX