### PR TITLE
fix(canvas): Agent Team header cleanup + styled confirm dialogs

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
@@ -99,11 +99,6 @@
   white-space: nowrap;
 }
 
-.agent-team-frame__phase-label {
-  color: var(--text-secondary);
-  font-weight: 800;
-}
-
 .agent-team-frame__mission {
   display: flex;
   align-items: center;

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
@@ -658,13 +658,6 @@ export const AgentTeamFrame = ({
     ?? metadataString(runtime?.team.metadata, ['cwd'])
     ?? rootFolder
     ?? '';
-  const phaseTitle = phase === 'briefing'
-    ? 'Briefing'
-    : runtime?.team.status === 'completed'
-      ? 'Completed'
-      : phase === 'plan_review'
-        ? 'Plan Review'
-        : 'Executing';
   const doneTaskCount = tasks.filter((task) => task.status === 'done').length;
   const activeTaskCount = tasks.filter((task) =>
     task.status === 'in_progress'
@@ -1828,10 +1821,7 @@ export const AgentTeamFrame = ({
     >
       <div className="agent-team-frame__top">
         <div className="agent-team-frame__identity">
-          <div className="agent-team-frame__title">
-            {teamTitle}
-            <span className="agent-team-frame__phase-label"> · {phaseTitle}</span>
-          </div>
+          <div className="agent-team-frame__title">{teamTitle}</div>
           <div className="agent-team-frame__mission">
             {teamCwd && (
               <code title={teamCwd}>{compactPath(teamCwd)}</code>

--- a/apps/canvas-workspace/src/renderer/src/components/WorkspaceSettings/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/WorkspaceSettings/index.tsx
@@ -19,6 +19,7 @@ import type { WorkspaceEntry } from '../../hooks/useWorkspaces';
 import { SettingsDrawer } from '../SettingsDrawer';
 import { SkillsManager } from '../settings-config/SkillsManager';
 import { McpManager } from '../settings-config/McpManager';
+import { useAppShell } from '../AppShellProvider';
 import { useI18n } from '../../i18n';
 import './index.css';
 
@@ -49,6 +50,7 @@ export const WorkspaceSettingsDrawer = ({
   onSetRootFolder,
 }: Props) => {
   const { t } = useI18n();
+  const { confirm } = useAppShell();
   const open = workspace !== null;
 
   const [nameDraft, setNameDraft] = useState('');
@@ -148,9 +150,11 @@ export const WorkspaceSettingsDrawer = ({
         notes: t('workspaceSettings.notesPlaceholder'),
       }).trim();
     if (hasUserContent) {
-      const ok = window.confirm(
-        t('workspaceSettings.replaceConfirm'),
-      );
+      const [replaceTitle, replaceBody] = t('workspaceSettings.replaceConfirm').split('\n');
+      const ok = await confirm({
+        title: replaceTitle,
+        description: replaceBody,
+      });
       if (!ok) return;
     }
 
@@ -191,7 +195,7 @@ export const WorkspaceSettingsDrawer = ({
         setAgentsDoc(result.content);
       }
     });
-  }, [agentsDoc, intent, workspace, t]);
+  }, [agentsDoc, intent, workspace, confirm, t]);
 
   if (!workspace) return null;
 

--- a/apps/canvas-workspace/src/renderer/src/components/settings-config/McpManager.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/settings-config/McpManager.tsx
@@ -180,7 +180,7 @@ const ToolsList = ({ health, readOnly, isBusy, onToggle, t }: ToolsListProps) =>
 
 export const McpManager = ({ scope, showInherited = false }: Props) => {
   const { t } = useI18n();
-  const { notify } = useAppShell();
+  const { notify, confirm } = useAppShell();
   const [servers, setServers] = useState<CanvasMcpServer[]>([]);
   const [statuses, setStatuses] = useState<Record<string, CanvasMcpServerHealth>>({});
   const [inherited, setInherited] = useState<CanvasMcpServer[]>([]);
@@ -261,12 +261,17 @@ export const McpManager = ({ scope, showInherited = false }: Props) => {
 
   const remove = useCallback(
     async (name: string) => {
-      if (!window.confirm(t('mcpConfig.deleteConfirm', { name }))) return;
+      const accepted = await confirm({
+        intent: 'danger',
+        title: t('mcpConfig.deleteConfirm', { name }),
+        confirmLabel: t('mcpConfig.delete'),
+      });
+      if (!accepted) return;
       const res = await window.canvasWorkspace.canvasMcp.remove(scope, name);
       if (res.ok && res.status) applyStatus(res.status);
       else notify({ tone: 'error', title: res.error ?? t('mcpConfig.loadFailed') });
     },
-    [scope, notify, t, applyStatus],
+    [scope, notify, confirm, t, applyStatus],
   );
 
   const toggleTool = useCallback(

--- a/apps/canvas-workspace/src/renderer/src/components/settings-config/SkillsManager.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/settings-config/SkillsManager.tsx
@@ -38,7 +38,7 @@ const EMPTY_DRAFT: Draft = { name: '', description: '', body: '' };
 
 export const SkillsManager = ({ scope, showInherited = false }: Props) => {
   const { t } = useI18n();
-  const { notify } = useAppShell();
+  const { notify, confirm } = useAppShell();
   const [skills, setSkills] = useState<CanvasSkillEntry[]>([]);
   const [inherited, setInherited] = useState<CanvasSkillEntry[]>([]);
   const [dir, setDir] = useState('');
@@ -100,12 +100,17 @@ export const SkillsManager = ({ scope, showInherited = false }: Props) => {
 
   const remove = useCallback(
     async (name: string) => {
-      if (!window.confirm(t('skillsConfig.deleteConfirm', { name }))) return;
+      const accepted = await confirm({
+        intent: 'danger',
+        title: t('skillsConfig.deleteConfirm', { name }),
+        confirmLabel: t('skillsConfig.delete'),
+      });
+      if (!accepted) return;
       const res = await window.canvasWorkspace.canvasSkills.remove(scope, name);
       if (res.ok && res.status) setSkills(res.status.skills);
       else notify({ tone: 'error', title: res.error ?? t('skillsConfig.loadFailed') });
     },
-    [scope, notify, t],
+    [scope, notify, confirm, t],
   );
 
   // Shared toast/state handlers. Both .zip and a URL that resolves to a zip


### PR DESCRIPTION
A small Canvas UI polish pass on the Agent Team frame and the app's confirm dialogs, all from screenshot feedback.

## Changes

**Agent Team frame header (declutter)**
- **Team Lead heading** – dropped the duplicate `TEAM LEAD` eyebrow label that sat right above the `Team Lead` name; the name (which still supports custom lead names) + status pill now stand alone. (`4a546fe`)
- **Mission row** – removed the verbose `Task · <goal>` brief; the compact working-directory path and task progress remain. (`4a546fe`)
- **Title** – stopped rendering `<team> · <phase>` since the colored status pill in the actions row already shows the same state (so "Completed" no longer appears twice). Kept the pill as the single source of truth. (`0943c4e`)
- Removed the now-dead `teamGoal`/`phaseTitle` bindings and orphaned CSS rules.

**Confirm dialogs (consistency)**
The Agent Team **Delete** action used the OS's unstyled `window.confirm`, which looks out of place. Routed it — and the three other remaining native confirms — through the existing `AppShellProvider` `confirm()` so they all use the in-app `ConfirmDialog` (danger intent, Esc/Enter, backdrop dismiss) like edge/node deletes already do:
- Agent Team delete (`d79e9fc`)
- MCP server delete, Skill delete, and the Workspace doc "replace draft" prompt (`422d1ae`)

After this, there are **no** native `window.confirm`/`alert` calls left in the renderer.

## Testing
UI-only changes (element removals + reusing the existing styled dialog). Verified by code review against the `ConfirmOptions` / `AppShellContextValue` types and confirmed `AppShellProvider` is an ancestor of every touched component. The Electron GUI can't be run headless in this environment, so this was **not** visually confirmed — please sanity-check the Agent Team header and a delete/replace confirm locally.

https://claude.ai/code/session_01PDhTFdfGRYeAWnNi2h7Qgd

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDhTFdfGRYeAWnNi2h7Qgd)_