### PR TITLE
fix(agent-teams): stop re-waking Team Lead about completed-task gates

### DIFF
--- a/apps/canvas-workspace/src/main/__tests__/agent-teams-service.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/agent-teams-service.test.ts
@@ -978,4 +978,76 @@ describe('CanvasAgentTeamsService', () => {
     expect(repaired.runtime.tasks[0].blockedReason).toBeUndefined();
     expect(repaired.runtime.agents.find((agent) => agent.id === owner.id)?.status).toBe('running');
   });
+
+  it('answers the gate for the task named by --task when a teammate has several open questions', async () => {
+    const service = new CanvasAgentTeamsService();
+    const created = await createExecutingTeam(service);
+    const teamId = created.runtime.team.id;
+    const implement = created.runtime.tasks.find((task) => task.title === 'Implement checkout refactor')!;
+    const coder = created.runtime.agents.find((agent) => agent.id === implement.ownerAgentId)!;
+
+    // Give the same teammate a second task so it can hold two open questions.
+    const withSecond = await service.createTask({
+      workspaceId: 'ws-1',
+      teamId,
+      title: 'Harden checkout retries',
+      description: 'Add retry handling to checkout.',
+      ownerName: coder.name,
+    });
+    const second = withSecond.tasks.find((task) => task.title === 'Harden checkout retries')!;
+
+    await service.openHumanGate('ws-1', teamId, {
+      taskId: implement.id,
+      agentId: coder.id,
+      reason: 'Need a decision',
+      prompt: 'Which payment provider should I wire first?',
+    });
+    const gatedTwice = await service.openHumanGate('ws-1', teamId, {
+      taskId: second.id,
+      agentId: coder.id,
+      reason: 'Need a decision',
+      prompt: 'How many retries should checkout attempt?',
+    });
+    expect(gatedTwice.runtime.humanGates.filter((gate) => gate.status === 'open')).toHaveLength(2);
+
+    // Targeting the second task answers exactly that gate and leaves the other open.
+    const answered = await service.sendInput('ws-1', teamId, coder.name, 'Use three retries with backoff.', second.id);
+    const implementGate = answered.runtime.humanGates.find((gate) => gate.taskId === implement.id)!;
+    const secondGate = answered.runtime.humanGates.find((gate) => gate.taskId === second.id)!;
+
+    expect(secondGate).toMatchObject({ status: 'answered', answer: 'Use three retries with backoff.' });
+    expect(implementGate.status).toBe('open');
+    expect(mockState.queuedInputs.at(-1)).toEqual({
+      workspaceId: 'ws-1',
+      nodeId: coder.sessionRef!.sessionId,
+      input: 'Use three retries with backoff.',
+    });
+  });
+
+  it('ignores human-input markers for a task the lead already completed', async () => {
+    const service = new CanvasAgentTeamsService();
+    const created = await createExecutingTeam(service);
+    const teamId = created.runtime.team.id;
+    const implement = created.runtime.tasks.find((task) => task.title === 'Implement checkout refactor')!;
+    const coder = created.runtime.agents.find((agent) => agent.id === implement.ownerAgentId)!;
+
+    await service.completeAgentTask({
+      workspaceId: 'ws-1',
+      teamId,
+      taskId: implement.id,
+      summary: 'Implementation is done.',
+    });
+
+    // A late human-input marker for the finished task must not reopen a gate.
+    const ignored = await service.reportAgentOutput(
+      'ws-1',
+      coder.sessionRef!.sessionId,
+      `[agent-team:human-input-needed taskId="${implement.id}"] Should I also refactor the helper?\n`,
+    );
+    expect(ignored).toBeNull();
+
+    const snapshot = await service.snapshot('ws-1', teamId);
+    expect(snapshot.runtime.humanGates).toHaveLength(0);
+    expect(snapshot.runtime.tasks.find((task) => task.id === implement.id)?.status).toBe('done');
+  });
 });

--- a/apps/canvas-workspace/src/main/agent-teams/__tests__/store.test.ts
+++ b/apps/canvas-workspace/src/main/agent-teams/__tests__/store.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const mockState = vi.hoisted(() => ({ root: '' }));
+
+vi.mock('../../canvas/storage', () => ({
+  get STORE_DIR() {
+    return mockState.root;
+  },
+}));
+
+import { CanvasAgentTeamStore } from '../store';
+import type { TeamTaskRecord } from 'pulse-coder-agent-teams/runtime';
+
+const makeTask = (id: string): TeamTaskRecord => ({
+  id,
+  teamId: 'team-1',
+  title: `Task ${id}`,
+  description: 'desc',
+  status: 'todo',
+  deps: [],
+  createdBy: 'runtime',
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+});
+
+describe('CanvasAgentTeamStore', () => {
+  beforeEach(() => {
+    mockState.root = join(tmpdir(), `canvas-store-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  });
+
+  afterEach(async () => {
+    await fs.rm(mockState.root, { recursive: true, force: true });
+  });
+
+  it('persists many concurrent writes without racing the temp-file rename', async () => {
+    const store = new CanvasAgentTeamStore('ws-1');
+    const ids = Array.from({ length: 60 }, (_, index) => `task-${index}`);
+
+    // Fire every write concurrently. With a single fixed temp filename and no
+    // write serialization, two overlapping persists raced and one rename threw
+    // `ENOENT ... rename state.json.tmp -> state.json`, dropping updates.
+    await Promise.all(ids.map((id) => store.saveTask(makeTask(id))));
+
+    const tasks = await store.listTasks('team-1');
+    expect(tasks.map((task) => task.id).sort()).toEqual([...ids].sort());
+
+    // A fresh store reads the same committed state back from disk.
+    const reloaded = new CanvasAgentTeamStore('ws-1');
+    expect((await reloaded.listTasks('team-1')).map((task) => task.id).sort()).toEqual([...ids].sort());
+
+    // No orphaned temp files are left behind.
+    const dir = join(mockState.root, 'ws-1', 'agent-teams');
+    const entries = await fs.readdir(dir);
+    expect(entries.filter((name) => name.includes('.tmp'))).toEqual([]);
+  });
+
+  it('keeps the final on-disk state valid under interleaved record types', async () => {
+    const store = new CanvasAgentTeamStore('ws-2');
+
+    await Promise.all([
+      store.saveTeam({
+        id: 'team-2',
+        name: 'Concurrent',
+        goal: 'Stay consistent',
+        status: 'running',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+      ...Array.from({ length: 20 }, (_, index) =>
+        store.appendEvent({
+          id: `event-${index}`,
+          teamId: 'team-2',
+          type: 'task_created',
+          timestamp: Date.now() + index,
+          actor: 'runtime',
+          payload: {},
+        }),
+      ),
+      ...Array.from({ length: 20 }, (_, index) => store.saveTask(makeTask(`t-${index}`))),
+    ]);
+
+    const statePath = join(mockState.root, 'ws-2', 'agent-teams', 'state.json');
+    const parsed = JSON.parse(await fs.readFile(statePath, 'utf-8'));
+    expect(parsed.teams).toHaveLength(1);
+    expect(parsed.events).toHaveLength(20);
+    expect(parsed.tasks).toHaveLength(20);
+  });
+});

--- a/apps/canvas-workspace/src/main/agent-teams/service.ts
+++ b/apps/canvas-workspace/src/main/agent-teams/service.ts
@@ -902,6 +902,7 @@ export class CanvasAgentTeamsService {
     teamId: string,
     agentRef: string,
     content: string,
+    taskRef?: string,
   ): Promise<CanvasAgentTeamSnapshot> {
     const { runtime, store } = this.getBundle(workspaceId);
     const snapshot = await runtime.snapshot(teamId);
@@ -910,9 +911,15 @@ export class CanvasAgentTeamsService {
       ? formatLeadExecutionPrompt(snapshot.team.name, snapshot.team.goal, content)
       : content;
 
+    // When the lead targets a specific task (e.g. answering one of several open
+    // teammate questions), resolve it so we can pick the exact gate instead of
+    // guessing from the agent's current/needs-input state.
+    const targetTaskId = taskRef
+      ? this.resolveTaskReferences(snapshot.tasks, [taskRef])[0]
+      : undefined;
     const openGate = agent.role === 'lead'
       ? undefined
-      : this.resolveOpenGateForAgent(snapshot, agent);
+      : this.resolveOpenGateForAgent(snapshot, agent, targetTaskId);
     if (openGate) {
       await runtime.answerHumanGate(openGate.id, input);
       await runtime.dispatchReadyTasks(teamId);
@@ -930,7 +937,10 @@ export class CanvasAgentTeamsService {
       await runtime.setTeamStatus(teamId, 'running', 'human');
     }
 
-    await runtime.sendToAgent(agent.id, input);
+    // Forward the explicit task so the runtime resolver scopes to it too: an
+    // unmatched --task must send a plain (task-tagged) message rather than fall
+    // back to answering the agent's current-task gate.
+    await runtime.sendToAgent(agent.id, input, targetTaskId);
     return this.snapshot(workspaceId, teamId);
   }
 
@@ -1162,12 +1172,19 @@ export class CanvasAgentTeamsService {
   private resolveOpenGateForAgent(
     snapshot: RuntimeSnapshot,
     agent: TeamAgentRecord,
+    taskId?: string,
   ): RuntimeSnapshot['humanGates'][number] | undefined {
     const openGates = snapshot.humanGates.filter((gate) =>
       gate.status === 'open'
       && gate.agentId === agent.id
     );
     if (openGates.length === 0) return undefined;
+
+    // An explicit task pins the answer to that task's gate, disambiguating when
+    // a teammate has several open questions across different tasks.
+    if (taskId) {
+      return openGates.find((gate) => gate.taskId === taskId);
+    }
 
     if (agent.currentTaskId) {
       const currentTaskGate = openGates.find((gate) => gate.taskId === agent.currentTaskId);
@@ -1273,6 +1290,13 @@ export class CanvasAgentTeamsService {
 
     if (marker.kind === 'human-input-needed') {
       const snapshot = await runtime.snapshot(agent.teamId);
+      // Ignore stray human-input markers for a task the Team Lead already closed.
+      // Late terminal output (the agent printing the marker after the task was
+      // completed/failed) must not resurrect a settled gate into the lead backlog.
+      const markerTask = taskId ? snapshot.tasks.find((task) => task.id === taskId) : undefined;
+      if (markerTask && (markerTask.status === 'done' || markerTask.status === 'failed')) {
+        return false;
+      }
       const duplicateGate = snapshot.humanGates.some((gate) =>
         gate.status === 'open'
         && gate.agentId === agent.id

--- a/apps/canvas-workspace/src/main/agent-teams/store.ts
+++ b/apps/canvas-workspace/src/main/agent-teams/store.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'fs';
 import { join } from 'path';
+import { randomUUID } from 'crypto';
 import { STORE_DIR } from '../canvas/storage';
 import type {
   AgentTeamRecord,
@@ -40,7 +41,15 @@ const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
 
 export class CanvasAgentTeamStore implements TeamRuntimeStore {
   private loaded = false;
+  // Shared in-flight load so concurrent first-touch operations don't each reset
+  // `this.state` to an empty object (which would drop the others' mutations).
+  private loadPromise: Promise<void> | null = null;
   private state: PersistedAgentTeamRuntimeState = emptyState();
+  // Serializes all disk writes for this store. Many runtime operations persist
+  // the full state concurrently; without a queue their temp-file renames race
+  // and one rename can fire after another already moved the temp file, throwing
+  // `ENOENT ... rename state.json.tmp -> state.json`.
+  private persistQueue: Promise<void> = Promise.resolve();
 
   constructor(private readonly workspaceId: string) {}
 
@@ -195,8 +204,17 @@ export class CanvasAgentTeamStore implements TeamRuntimeStore {
     await this.persist();
   }
 
-  private async ensureLoaded(): Promise<void> {
-    if (this.loaded) return;
+  private ensureLoaded(): Promise<void> {
+    if (this.loaded) return Promise.resolve();
+    if (!this.loadPromise) {
+      this.loadPromise = this.loadStateFile().then(() => {
+        this.loaded = true;
+      });
+    }
+    return this.loadPromise;
+  }
+
+  private async loadStateFile(): Promise<void> {
     try {
       const raw = await fs.readFile(this.statePath, 'utf-8');
       const parsed = JSON.parse(raw) as Partial<PersistedAgentTeamRuntimeState>;
@@ -211,14 +229,29 @@ export class CanvasAgentTeamStore implements TeamRuntimeStore {
       }
       this.state = emptyState();
     }
-    this.loaded = true;
   }
 
-  private async persist(): Promise<void> {
+  private persist(): Promise<void> {
+    // Chain every write onto the previous one so renames never overlap. Each
+    // write flushes the latest in-memory state (a superset of earlier pending
+    // mutations), so serializing is safe and the last write wins consistently.
+    const run = this.persistQueue.then(() => this.writeStateFile());
+    // Keep the chain alive even if one write rejects, so later persists run.
+    this.persistQueue = run.catch(() => {});
+    return run;
+  }
+
+  private async writeStateFile(): Promise<void> {
     await fs.mkdir(this.dir, { recursive: true });
-    const tmp = `${this.statePath}.tmp`;
-    await fs.writeFile(tmp, JSON.stringify(this.state, null, 2), 'utf-8');
-    await fs.rename(tmp, this.statePath);
+    // Unique per-write temp name so two writers never collide on one temp file.
+    const tmp = `${this.statePath}.${process.pid}.${randomUUID()}.tmp`;
+    try {
+      await fs.writeFile(tmp, JSON.stringify(this.state, null, 2), 'utf-8');
+      await fs.rename(tmp, this.statePath);
+    } catch (err) {
+      await fs.unlink(tmp).catch(() => {});
+      throw err;
+    }
   }
 
   private get dir(): string {

--- a/apps/canvas-workspace/src/main/runtime/control-server.ts
+++ b/apps/canvas-workspace/src/main/runtime/control-server.ts
@@ -563,6 +563,7 @@ async function handleAgentTeamSend(
   const teamId = typeof obj.teamId === 'string' ? obj.teamId : '';
   const to = typeof obj.to === 'string' ? obj.to : '';
   const content = typeof obj.content === 'string' ? obj.content : '';
+  const taskId = typeof obj.taskId === 'string' && obj.taskId.trim() ? obj.taskId.trim() : undefined;
   if (!workspaceId || !teamId || !to) {
     return reply(res, 400, { ok: false, error: 'workspaceId, teamId, and to are required' });
   }
@@ -571,7 +572,7 @@ async function handleAgentTeamSend(
   }
 
   try {
-    const snapshot = await getCanvasAgentTeamsService().sendInput(workspaceId, teamId, to, content);
+    const snapshot = await getCanvasAgentTeamsService().sendInput(workspaceId, teamId, to, content, taskId);
     return reply(res, 200, { ok: true, snapshot });
   } catch (err) {
     return reply(res, 400, { ok: false, error: err instanceof Error ? err.message : String(err) });

--- a/packages/agent-teams/src/runtime/__tests__/team-runtime.test.ts
+++ b/packages/agent-teams/src/runtime/__tests__/team-runtime.test.ts
@@ -785,4 +785,125 @@ describe('TeamRuntime', () => {
     expect(snapshot.artifacts).toEqual([artifact]);
     expect(snapshot.events.at(-1)!.type).toBe('artifact_created');
   });
+
+  it('cancels a task\'s open lead gate when the task completes', async () => {
+    const { runtime, adapter } = createRuntime();
+    const { team } = await runtime.createTeam({ name: 'Team', goal: 'Ship it' });
+    const lead = await runtime.addAgent({ teamId: team.id, role: 'lead', name: 'Lead' });
+    const coder = await runtime.addAgent({ teamId: team.id, role: 'teammate', name: 'Coder' });
+    const leadWithSession = await runtime.createAgentSession(lead.id);
+    await runtime.createAgentSession(coder.id);
+    const task = await runtime.createTask({
+      teamId: team.id,
+      title: 'Implement change',
+      description: 'Make the change.',
+      ownerAgentId: coder.id,
+    });
+    await runtime.dispatchReadyTasks(team.id);
+    await runtime.openHumanGate({
+      teamId: team.id,
+      agentId: coder.id,
+      taskId: task.id,
+      reason: 'Need a decision',
+      prompt: 'Which option should we use?',
+      metadata: { audience: 'lead' },
+    });
+    expect((await runtime.snapshot(team.id)).humanGates[0].status).toBe('open');
+
+    await runtime.completeTask(task.id, 'Done', coder.id);
+
+    const snapshot = await runtime.snapshot(team.id);
+    expect(snapshot.humanGates[0].status).toBe('cancelled');
+    expect(snapshot.tasks[0].status).toBe('done');
+
+    // The settled gate must not keep re-waking the lead about completed work:
+    // the digest is empty, so notifyLeadPendingGates sends nothing further.
+    const sessionId = leadWithSession.sessionRef!.sessionId;
+    const before = adapter.inputs.filter((entry) => entry.sessionId === sessionId).length;
+    await runtime.notifyLeadPendingGates(team.id);
+    const after = adapter.inputs.filter((entry) => entry.sessionId === sessionId);
+    expect(after).toHaveLength(before);
+    expect(after.some((entry) => entry.input.includes('still waiting for Team Lead attention'))).toBe(false);
+  });
+
+  it('does not open a human gate for an already finished task', async () => {
+    const { runtime, adapter } = createRuntime();
+    const { team } = await runtime.createTeam({ name: 'Team', goal: 'Ship it' });
+    const lead = await runtime.addAgent({ teamId: team.id, role: 'lead', name: 'Lead' });
+    const coder = await runtime.addAgent({ teamId: team.id, role: 'teammate', name: 'Coder' });
+    await runtime.createAgentSession(lead.id);
+    await runtime.createAgentSession(coder.id);
+    const task = await runtime.createTask({
+      teamId: team.id,
+      title: 'Implement change',
+      description: 'Make the change.',
+      ownerAgentId: coder.id,
+    });
+    await runtime.dispatchReadyTasks(team.id);
+    await runtime.completeTask(task.id, 'Done', coder.id);
+
+    const inputsBefore = adapter.inputs.length;
+    const gateId = await runtime.openHumanGate({
+      teamId: team.id,
+      agentId: coder.id,
+      taskId: task.id,
+      reason: 'Late question',
+      prompt: 'Should I also refactor the helper?',
+      metadata: { audience: 'lead' },
+    });
+
+    const snapshot = await runtime.snapshot(team.id);
+    expect(snapshot.humanGates.find((gate) => gate.id === gateId)?.status).toBe('cancelled');
+    expect(snapshot.tasks[0].status).toBe('done');
+    expect(snapshot.agents.find((agent) => agent.id === coder.id)?.status).not.toBe('needs_input');
+    // No mailbox question and no lead notification fire for a settled task.
+    expect(adapter.inputs).toHaveLength(inputsBefore);
+  });
+
+  it('drops pending-gate digest entries for tasks that already finished', async () => {
+    let id = 1;
+    let clock = 1000;
+    const store = new InMemoryTeamRuntimeStore();
+    const adapter = new FakeAgentSessionAdapter();
+    const runtime = new TeamRuntime({
+      store,
+      agentSessions: adapter,
+      idFactory: () => `id-${id++}`,
+      now: () => clock++,
+    });
+    const { team } = await runtime.createTeam({ name: 'Team', goal: 'Ship it' });
+    const lead = await runtime.addAgent({ teamId: team.id, role: 'lead', name: 'Lead' });
+    const coder = await runtime.addAgent({ teamId: team.id, role: 'teammate', name: 'Coder' });
+    const leadWithSession = await runtime.createAgentSession(lead.id);
+    const task = await runtime.createTask({
+      teamId: team.id,
+      title: 'Implement change',
+      description: 'Make the change.',
+      ownerAgentId: coder.id,
+    });
+    await runtime.openHumanGate({
+      teamId: team.id,
+      agentId: coder.id,
+      taskId: task.id,
+      reason: 'Need a decision',
+      prompt: 'Which option should we use?',
+      metadata: { audience: 'lead' },
+    });
+    const sessionId = leadWithSession.sessionRef!.sessionId;
+    const afterOpen = adapter.inputs.filter((entry) => entry.sessionId === sessionId).length;
+
+    // Simulate the task finishing through a path that left the gate open (e.g.
+    // legacy persisted state). The gate intentionally stays 'open'.
+    const stored = (await store.getTask(task.id))!;
+    stored.status = 'done';
+    stored.updatedAt = clock++;
+    await store.saveTask(stored);
+
+    clock += 31_000; // bypass the digest resend throttle
+    await runtime.notifyLeadPendingGates(team.id);
+
+    const snapshot = await runtime.snapshot(team.id);
+    expect(snapshot.humanGates[0].status).toBe('open');
+    expect(adapter.inputs.filter((entry) => entry.sessionId === sessionId)).toHaveLength(afterOpen);
+  });
 });

--- a/packages/agent-teams/src/runtime/team-runtime.ts
+++ b/packages/agent-teams/src/runtime/team-runtime.ts
@@ -490,6 +490,7 @@ export class TeamRuntime {
     task.result = result;
     task.updatedAt = this.now();
     await this.store.saveTask(task);
+    await this.cancelOpenGatesForTask(task.teamId, task.id);
 
     if (task.ownerAgentId) {
       const agent = await this.store.getAgent(task.ownerAgentId);
@@ -558,6 +559,7 @@ export class TeamRuntime {
     task.result = error;
     task.updatedAt = this.now();
     await this.store.saveTask(task);
+    await this.cancelOpenGatesForTask(task.teamId, task.id);
 
     if (task.ownerAgentId) {
       const agent = await this.store.getAgent(task.ownerAgentId);
@@ -625,6 +627,8 @@ export class TeamRuntime {
   async openHumanGate(input: OpenHumanGateInput): Promise<HumanGateId> {
     await this.requireTeam(input.teamId);
     const now = this.now();
+    const task = input.taskId ? await this.store.getTask(input.taskId) : undefined;
+    const taskFinished = task?.status === 'done' || task?.status === 'failed';
     const gate = {
       id: input.id ?? this.idFactory(),
       teamId: input.teamId,
@@ -632,7 +636,7 @@ export class TeamRuntime {
       agentId: input.agentId,
       reason: input.reason,
       prompt: input.prompt,
-      status: 'open' as const,
+      status: (taskFinished ? 'cancelled' : 'open') as 'cancelled' | 'open',
       createdAt: now,
       updatedAt: now,
       metadata: input.metadata,
@@ -640,14 +644,21 @@ export class TeamRuntime {
 
     await this.store.saveHumanGate(gate);
 
-    if (input.taskId) {
-      const task = await this.store.getTask(input.taskId);
-      if (task && task.status !== 'done' && task.status !== 'failed') {
-        task.status = 'needs_input';
-        task.blockedReason = input.reason;
-        task.updatedAt = now;
-        await this.store.saveTask(task);
-      }
+    // A task that already finished must never reopen the Team Lead backlog. The
+    // gate is recorded as cancelled for auditability, but we skip the task/agent
+    // transitions, the mailbox question, and the lead notification that an open
+    // gate would otherwise trigger — those would re-wake the lead about settled
+    // work (a stray late marker, a question that arrived after the lead closed
+    // the task, etc.).
+    if (taskFinished) {
+      return gate.id;
+    }
+
+    if (task && task.status !== 'done' && task.status !== 'failed') {
+      task.status = 'needs_input';
+      task.blockedReason = input.reason;
+      task.updatedAt = now;
+      await this.store.saveTask(task);
     }
 
     let requestingAgent: TeamAgentRecord | undefined;
@@ -684,7 +695,7 @@ export class TeamRuntime {
         input.taskId ? `Task ID: ${input.taskId}` : '',
         '',
         'If you can answer, send guidance to the teammate:',
-        `pulse-canvas team send --to "${requestingAgent?.name ?? 'Teammate name'}" --message "<answer or decision>"`,
+        `pulse-canvas team send --to "${requestingAgent?.name ?? 'Teammate name'}"${input.taskId ? ` --task "${input.taskId}"` : ''} --message "<answer or decision>"`,
         '',
         'Ask the human only if this requires owner input:',
         `pulse-canvas team request-human-input${input.taskId ? ` --task "${input.taskId}"` : ''} --prompt "<specific question>"`,
@@ -1127,13 +1138,19 @@ export class TeamRuntime {
       this.store.listAgents(teamId),
       this.store.listTasks(teamId),
     ]);
+    const tasksById = new Map(tasks.map((task) => [task.id, task]));
     const pending = gates
-      .filter((gate) => gate.status === 'open' && isLeadAudienceGate(gate.metadata))
+      .filter((gate) => {
+        if (gate.status !== 'open' || !isLeadAudienceGate(gate.metadata)) return false;
+        // Exclude gates whose task already finished. Their questions are settled,
+        // so they must not keep re-waking the Team Lead about completed work.
+        const task = gate.taskId ? tasksById.get(gate.taskId) : undefined;
+        return !task || (task.status !== 'done' && task.status !== 'failed');
+      })
       .sort((a, b) => a.createdAt - b.createdAt);
     if (pending.length === 0) return '';
 
     const agentsById = new Map(agents.map((agent) => [agent.id, agent]));
-    const tasksById = new Map(tasks.map((task) => [task.id, task]));
     const lines = pending.flatMap((gate, index) => {
       const agent = gate.agentId ? agentsById.get(gate.agentId) : undefined;
       const task = gate.taskId ? tasksById.get(gate.taskId) : undefined;
@@ -1142,7 +1159,7 @@ export class TeamRuntime {
       return [
         `${index + 1}. ${agentName}${taskPart}`,
         `   Question: ${truncate(gate.prompt, 500)}`,
-        `   Answer if you can: pulse-canvas team send --to "${quoteCliValue(agentName)}" --message "<answer or decision>"`,
+        `   Answer if you can: pulse-canvas team send --to "${quoteCliValue(agentName)}"${gate.taskId ? ` --task "${quoteCliValue(gate.taskId)}"` : ''} --message "<answer or decision>"`,
         `   Ask the human only if needed: pulse-canvas team request-human-input${gate.taskId ? ` --task "${quoteCliValue(gate.taskId)}"` : ''} --prompt "<specific question>"`,
       ];
     });
@@ -1183,6 +1200,23 @@ export class TeamRuntime {
     lead.status = 'running';
     lead.updatedAt = this.now();
     await this.store.saveAgent(lead);
+  }
+
+  /**
+   * Cancel any still-open human gates tied to a task. Once a task is done or
+   * failed its open questions are moot; leaving the gates open would keep
+   * feeding the Team Lead's pending backlog and re-waking the lead about
+   * already-settled work.
+   */
+  private async cancelOpenGatesForTask(teamId: TeamId, taskId: TaskId): Promise<void> {
+    const gates = await this.store.listHumanGates(teamId);
+    const now = this.now();
+    for (const gate of gates) {
+      if (gate.status !== 'open' || gate.taskId !== taskId) continue;
+      gate.status = 'cancelled';
+      gate.updatedAt = now;
+      await this.store.saveHumanGate(gate);
+    }
   }
 
   private async findOpenGateForAgent(agent: TeamAgentRecord, taskId?: TaskId) {

--- a/packages/canvas-cli/src/commands/team.ts
+++ b/packages/canvas-cli/src/commands/team.ts
@@ -398,13 +398,14 @@ export function registerTeamCommands(program: Command): void {
   team.command('send')
     .option('--team <teamId>', `Team ID (default: $${ENV_TEAM_ID})`, process.env[ENV_TEAM_ID])
     .requiredOption('--to <agent>', 'Target agent name or ID')
+    .option('--task <taskId>', 'Task ID or title to answer a specific open question from that agent')
     .option('--message <message>', 'Message content')
     .argument('[message...]', 'Message content')
     .description('Send a team message to an agent')
     .action(async function (
       this: Command,
       messageParts: string[] | undefined,
-      cmdOpts: { team?: string; to: string; message?: string },
+      cmdOpts: { team?: string; to: string; task?: string; message?: string },
     ) {
       const { format, workspace } = getOpts(this);
       const teamId = cmdOpts.team || process.env[ENV_TEAM_ID];
@@ -417,6 +418,7 @@ export function registerTeamCommands(program: Command): void {
         workspaceId: workspace,
         teamId,
         to: cmdOpts.to,
+        taskId: cmdOpts.task,
         content,
       });
 


### PR DESCRIPTION
The Pulse Canvas Team Lead was repeatedly notified about the same batch of "teammate questions waiting for Team Lead attention" for tasks that were already done, and concurrent team send / complete-task could throw `ENOENT ... rename state.json.tmp -> state.json`.

Root causes and fixes:

- Pending-gate digest listed gates whose task was already done/failed. `formatLeadPendingGateDigest` now filters those out.
- Open gates lingered after a task finished. `completeTask`/`failTask` now cancel any still-open gates for the task; `openHumanGate` no-ops (records a cancelled gate, no lead notification) when its task is already done/failed.
- Late `human-input-needed` output markers could resurrect a settled gate. `applyAgentOutputMarker` now ignores markers for finished tasks.
- The Team Lead could not target a specific open question when a teammate had several. `team send` gains `--task`, threaded through the control server and `sendInput`/gate resolution; digest and gate hints now include `--task <id>`.
- Concurrent persists raced on a fixed temp filename. `CanvasAgentTeamStore` now serializes writes, uses a unique temp file per write, and shares a single in-flight load so concurrent first-touch ops don't reset in-memory state.

Adds runtime, service, and store tests covering gate cancellation on completion, the no-op for finished tasks, digest filtering, targeted answers, marker suppression, and concurrent-write durability.