### PR TITLE
Fix agent view mode to show terminal on agent selection

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
@@ -697,7 +697,7 @@ export const AgentTeamFrame = ({
 
   useEffect(() => {
     setAgentInspectorMode('terminal');
-    setAgentViewMode('activity');
+    setAgentViewMode('terminal');
   }, [selectedAgentKey]);
 
   useEffect(() => {
@@ -1632,15 +1632,6 @@ export const AgentTeamFrame = ({
           <strong>{graphSubtitle}</strong>
         </div>
         <div className="agent-team-graph-panel__actions">
-          {variant === 'inline' && graphRounds.length > 0 && (
-            <button
-              type="button"
-              className="agent-team-graph-panel__fullscreen"
-              onClick={() => setGraphFullscreenOpen(true)}
-            >
-              Full screen
-            </button>
-          )}
           {phase === 'plan_review' && plan && (
             <button type="button" className="agent-team-frame__primary-action" onClick={handleConfirmPlan} disabled={readOnly}>
               Approve & Run


### PR DESCRIPTION
## Summary
Updates the AgentTeamFrame component to display the terminal view when an agent is selected, and removes the fullscreen button from the graph panel actions.

## Changes
- **Agent view mode initialization**: Changed `setAgentViewMode('activity')` to `setAgentViewMode('terminal')` in the `selectedAgentKey` effect, ensuring the terminal view is displayed when switching between agents
- **Removed fullscreen button**: Deleted the "Full screen" button from the graph panel actions that was only shown in inline variant mode

## Details
The agent view mode now consistently shows the terminal interface when an agent is selected, providing a better user experience for monitoring agent activity. The fullscreen graph button has been removed as part of UI simplification.

https://claude.ai/code/session_01SFRUpUSwtS7vEfndfnZaQD