### PR TITLE
Re-nudge stalled team leads until review is finalized

### DIFF
--- a/apps/canvas-workspace/src/main/agent-teams/service.ts
+++ b/apps/canvas-workspace/src/main/agent-teams/service.ts
@@ -1088,6 +1088,7 @@ export class CanvasAgentTeamsService {
     await this.repairLegacyOutputMarkerBlocks(store, teamId);
     await this.repairAnsweredHumanGateBlocks(store, teamId);
     await runtime.notifyLeadPendingGates(teamId);
+    await runtime.notifyLeadReviewIfStalled(teamId);
     const metadata = await store.getTeamMetadata(teamId);
     const runtimeSnapshot = await runtime.snapshot(teamId);
     return {
@@ -1110,6 +1111,7 @@ export class CanvasAgentTeamsService {
         await this.repairLegacyOutputMarkerBlocks(store, entry.teamId);
         await this.repairAnsweredHumanGateBlocks(store, entry.teamId);
         await runtime.notifyLeadPendingGates(entry.teamId);
+        await runtime.notifyLeadReviewIfStalled(entry.teamId);
         const runtimeSnapshot = await runtime.snapshot(entry.teamId);
         snapshots.push({
           workspaceId,

--- a/packages/agent-teams/src/runtime/__tests__/team-runtime.test.ts
+++ b/packages/agent-teams/src/runtime/__tests__/team-runtime.test.ts
@@ -350,6 +350,90 @@ describe('TeamRuntime', () => {
     expect((await runtime.snapshot(team.id)).team.status).toBe('running');
   });
 
+  it('re-nudges a stalled reviewing team until the lead finalizes it', async () => {
+    let id = 1;
+    let now = 1000;
+    const store = new InMemoryTeamRuntimeStore();
+    const adapter = new FakeAgentSessionAdapter();
+    const runtime = new TeamRuntime({
+      store,
+      agentSessions: adapter,
+      idFactory: () => `id-${id++}`,
+      now: () => now++,
+    });
+    const { team } = await runtime.createTeam({ name: 'Team', goal: 'Ship it' });
+    const lead = await runtime.addAgent({ teamId: team.id, role: 'lead', name: 'Lead' });
+    const coder = await runtime.addAgent({ teamId: team.id, role: 'teammate', name: 'Coder' });
+    const leadWithSession = await runtime.createAgentSession(lead.id);
+    await runtime.createAgentSession(coder.id);
+    const task = await runtime.createTask({
+      teamId: team.id,
+      title: 'Implement change',
+      description: 'Make the change.',
+      ownerAgentId: coder.id,
+    });
+    await runtime.dispatchReadyTasks(team.id);
+    await runtime.completeTask(task.id, 'Done', coder.id);
+    expect((await runtime.snapshot(team.id)).team.status).toBe('reviewing');
+
+    const sessionId = leadWithSession.sessionRef!.sessionId;
+    const leadInputs = () => adapter.inputs.filter((entry) => entry.sessionId === sessionId);
+    const afterInitial = leadInputs().length;
+    expect(leadInputs().at(-1)?.input).toContain('pulse-canvas team complete-team --summary');
+
+    // Within the resend window the heartbeat must not re-spam the lead.
+    await runtime.notifyLeadReviewIfStalled(team.id);
+    expect(leadInputs()).toHaveLength(afterInitial);
+
+    // After the window a still-reviewing team re-nudges the lead, which also
+    // flips it back to running so a lead whose session exited can auto-resume.
+    now += 61_000;
+    await runtime.notifyLeadReviewIfStalled(team.id);
+    expect(leadInputs()).toHaveLength(afterInitial + 1);
+    expect(leadInputs().at(-1)?.input).toContain('pulse-canvas team complete-team --summary');
+    expect((await store.getAgent(lead.id))?.status).toBe('running');
+
+    // Once the lead finalizes the team, the nudge stops for good.
+    await runtime.completeTeam(team.id, 'Shipped the work.', lead.id);
+    now += 61_000;
+    await runtime.notifyLeadReviewIfStalled(team.id);
+    expect(leadInputs()).toHaveLength(afterInitial + 1);
+  });
+
+  it('hands a team off for review when its final task fails', async () => {
+    const { runtime, adapter } = createRuntime();
+    const { team } = await runtime.createTeam({ name: 'Team', goal: 'Ship it' });
+    const lead = await runtime.addAgent({ teamId: team.id, role: 'lead', name: 'Lead' });
+    const coder = await runtime.addAgent({ teamId: team.id, role: 'teammate', name: 'Coder' });
+    const leadWithSession = await runtime.createAgentSession(lead.id);
+    await runtime.createAgentSession(coder.id);
+    const finished = await runtime.createTask({
+      teamId: team.id,
+      title: 'First',
+      description: 'Do first.',
+      ownerAgentId: coder.id,
+    });
+    const failing = await runtime.createTask({
+      teamId: team.id,
+      title: 'Second',
+      description: 'Do second.',
+      ownerAgentId: coder.id,
+    });
+
+    await runtime.completeTask(finished.id, 'Done', coder.id);
+    // Not every task is terminal yet, so no final-review handoff fires.
+    expect((await runtime.snapshot(team.id)).team.status).not.toBe('reviewing');
+
+    await runtime.failTask(failing.id, 'Build broke', coder.id);
+
+    const snapshot = await runtime.snapshot(team.id);
+    expect(snapshot.team.status).toBe('failed');
+    const leadInputs = adapter.inputs.filter(
+      (entry) => entry.sessionId === leadWithSession.sessionRef!.sessionId,
+    );
+    expect(leadInputs.at(-1)?.input).toContain('pulse-canvas team complete-team --summary');
+  });
+
   it('asks the lead to review a task when a session exits without task completion', async () => {
     const { runtime, adapter } = createRuntime();
     const { team } = await runtime.createTeam({ name: 'Team', goal: 'Ship it' });

--- a/packages/agent-teams/src/runtime/team-runtime.ts
+++ b/packages/agent-teams/src/runtime/team-runtime.ts
@@ -39,6 +39,7 @@ const MAX_TASK_RESULT_CHARS = 1_600;
 const MAX_ARTIFACT_SUMMARY_CHARS = 600;
 const TEAM_PAUSE_METADATA_KEY = 'teamPause';
 const LEAD_PENDING_DIGEST_RESEND_MS = 30_000;
+const LEAD_REVIEW_RESEND_MS = 60_000;
 const LEAD_NOTIFICATION_GUARD = [
   'Pulse Canvas team event. Handle this notification once.',
   'Do not run sleep, watch, tail, polling loops, or repeated status checks.',
@@ -147,6 +148,7 @@ export class TeamRuntime {
   private readonly handlers = new Set<EventHandler>();
   private readonly sessionAgents = new Map<string, AgentId>();
   private readonly leadPendingDigestCache = new Map<TeamId, { digest: string; sentAt: number }>();
+  private readonly leadReviewNudgeCache = new Map<TeamId, number>();
   private dispatchPaused = new Set<TeamId>();
   private unsubscribeSessionEvents?: () => void;
 
@@ -583,6 +585,10 @@ export class TeamRuntime {
       'Review the failure. You may create follow-up tasks with:',
       'pulse-canvas team create-task --title "..." --description "..." --owner "..." --dispatch',
     ].join('\n'), task.id);
+    // A failure can be the last task to settle. Without this, an all-terminal
+    // batch whose final task failed would sit in `running` forever (no ready
+    // tasks left, no review handoff). Mirror completeTask's review trigger.
+    await this.markTeamReadyForReviewIfDone(task.teamId);
     return task;
   }
 
@@ -874,6 +880,37 @@ export class TeamRuntime {
     ].join('\n'));
   }
 
+  /**
+   * Re-drive a Team Lead that is sitting on a finished team.
+   *
+   * When every task settles, `markTeamReadyForReviewIfDone` flips the team to
+   * `reviewing` and sends the lead one "run complete-team" prompt. That prompt is
+   * fire-and-forget: if the lead's session had already exited, it is only queued,
+   * and nothing else nudges the lead to finalize — so the team can sit in
+   * `reviewing` indefinitely while the UI still shows it executing.
+   *
+   * Pulse Canvas calls this on its snapshot heartbeat, alongside the pending-gate
+   * resend. We re-send the final-review prompt, throttled, until the lead actually
+   * completes the team. Re-sending also flips the lead back to `running` and
+   * re-queues its launch prompt, which lets the canvas auto-resume relaunch a lead
+   * whose session had exited.
+   */
+  async notifyLeadReviewIfStalled(teamId: TeamId): Promise<void> {
+    const team = await this.requireTeam(teamId);
+    if (team.status !== 'reviewing') {
+      this.leadReviewNudgeCache.delete(teamId);
+      return;
+    }
+    // If teammate questions are still waiting on the lead, the pending-gate digest
+    // path is already re-engaging it; don't stack a second prompt on this tick.
+    if (await this.formatLeadPendingGateDigest(teamId)) return;
+    const lastNudgedAt = this.leadReviewNudgeCache.get(teamId);
+    if (lastNudgedAt !== undefined && this.now() - lastNudgedAt < LEAD_REVIEW_RESEND_MS) {
+      return;
+    }
+    await this.sendFinalReviewPrompt(teamId);
+  }
+
   async snapshot(teamId: TeamId): Promise<RuntimeSnapshot> {
     const team = await this.requireTeam(teamId);
     const [agents, tasks, artifacts, humanGates, events, messages] = await Promise.all([
@@ -1069,8 +1106,19 @@ export class TeamRuntime {
     if (tasks.length === 0) return;
     if (tasks.every(task => task.status === 'done' || task.status === 'failed')) {
       await this.setTeamStatus(teamId, tasks.some(task => task.status === 'failed') ? 'failed' : 'reviewing');
-      await this.notifyLead(teamId, await this.formatFinalReviewPrompt(teamId));
+      await this.sendFinalReviewPrompt(teamId);
     }
+  }
+
+  /**
+   * Notify the Team Lead that all dispatched work is finished, and record when
+   * the nudge was sent. The recorded time throttles the heartbeat re-nudge
+   * (`notifyLeadReviewIfStalled`) so a lead that already saw this prompt is not
+   * spammed, while a lead that never acted still gets driven again later.
+   */
+  private async sendFinalReviewPrompt(teamId: TeamId): Promise<void> {
+    await this.notifyLead(teamId, await this.formatFinalReviewPrompt(teamId));
+    this.leadReviewNudgeCache.set(teamId, this.now());
   }
 
   private async formatTaskReviewPrompt(task: TeamTaskRecord, reason: string): Promise<string> {


### PR DESCRIPTION
## Summary
Adds a heartbeat mechanism to re-engage team leads who are sitting on completed work that needs review. When a team transitions to `reviewing` status, the lead receives a final-review prompt. If the lead's session has exited or they haven't acted on the prompt, the team can get stuck indefinitely. This change ensures the lead is periodically re-nudged until they finalize the team.

## Key Changes
- **New `notifyLeadReviewIfStalled()` method**: Called on the snapshot heartbeat to re-send the final-review prompt to leads whose teams are stuck in `reviewing` status. Throttled to once per 60 seconds to avoid spam.
- **New `sendFinalReviewPrompt()` helper**: Extracted from `markTeamReadyForReviewIfDone()` to centralize final-review notification logic and track when nudges are sent via `leadReviewNudgeCache`.
- **Task failure handling**: `failTask()` now calls `markTeamReadyForReviewIfDone()` to ensure teams with all-terminal tasks (including failed ones) transition to review, mirroring the behavior of `completeTask()`.
- **Canvas integration**: `CanvasAgentTeamsService.getTeamSnapshot()` and `listTeamSnapshots()` now call `notifyLeadReviewIfStalled()` alongside the existing pending-gate resend, ensuring the heartbeat drives stalled reviews.
- **New test coverage**: Two tests validate the re-nudge behavior and task-failure handoff scenarios.

## Implementation Details
- Uses `leadReviewNudgeCache` (Map<TeamId, number>) to track when each team's final-review prompt was last sent, enabling throttling without database changes.
- Re-sending the prompt also flips the lead back to `running` status and re-queues the launch prompt, allowing the canvas to auto-resume a lead whose session had exited.
- The pending-gate digest path takes precedence over the review nudge on the same heartbeat tick to avoid stacking duplicate prompts.

https://claude.ai/code/session_012NGVtBvsDneNxPC4fFzUZz