### PR TITLE
Add session_search and session_summary tools to canvas workspace agent

### DIFF
--- a/apps/canvas-workspace/src/main/agent/__tests__/session-tools.test.ts
+++ b/apps/canvas-workspace/src/main/agent/__tests__/session-tools.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+
+// Pin `os.homedir()` to a temp dir BEFORE the modules under test load it so
+// the session store reads/writes under a per-test sandbox rather than the
+// developer's real ~/.pulse-coder/canvas tree. Mirrors knowledge-tools.test.ts.
+const { sandboxHome } = vi.hoisted(() => {
+  const base = process.env.TMPDIR || process.env.TEMP || '/tmp';
+  const trailing = base.endsWith('/') ? '' : '/';
+  return {
+    sandboxHome: `${base}${trailing}session-tools-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  };
+});
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  return { ...actual, homedir: () => sandboxHome };
+});
+
+import { createSessionTools } from '../tools/sessions';
+import type { CanvasAgentMessage, CanvasAgentSession } from '../types';
+
+const CANVAS_DIR = join(sandboxHome, '.pulse-coder', 'canvas');
+const DAY_MS = 86_400_000;
+
+function msg(role: 'user' | 'assistant', content: string, timestamp: number, toolNames: string[] = []): CanvasAgentMessage {
+  return {
+    role,
+    content,
+    timestamp,
+    ...(toolNames.length
+      ? { toolCalls: toolNames.map((name, i) => ({ id: i + 1, name, status: 'done' as const })) }
+      : {}),
+  };
+}
+
+function session(workspaceId: string, sessionId: string, startedAtMs: number, messages: CanvasAgentMessage[]): CanvasAgentSession {
+  return {
+    sessionId,
+    workspaceId,
+    startedAt: new Date(startedAtMs).toISOString(),
+    messages,
+  };
+}
+
+async function writeManifest(payload: unknown): Promise<void> {
+  await fs.writeFile(join(CANVAS_DIR, '__workspaces__.json'), JSON.stringify(payload), 'utf-8');
+}
+
+async function writeCurrent(workspaceId: string, data: CanvasAgentSession): Promise<void> {
+  const dir = join(CANVAS_DIR, workspaceId, 'agent-sessions');
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(join(dir, 'current.json'), JSON.stringify(data), 'utf-8');
+}
+
+async function writeArchived(workspaceId: string, data: CanvasAgentSession): Promise<void> {
+  const dir = join(CANVAS_DIR, workspaceId, 'agent-sessions', 'archive');
+  await fs.mkdir(dir, { recursive: true });
+  const date = data.startedAt.slice(0, 10);
+  await fs.writeFile(join(dir, `${date}-${Date.parse(data.startedAt)}.json`), JSON.stringify(data), 'utf-8');
+}
+
+const now = Date.now();
+
+async function seed(): Promise<void> {
+  await writeManifest({
+    activeId: 'ws-research',
+    workspaces: [
+      { id: 'ws-research', name: '调研' },
+      { id: 'ws-weekly', name: '周报' },
+    ],
+  });
+
+  // ws-research: a current session (today) + an archived one (10 days ago).
+  await writeCurrent('ws-research', session('ws-research', 's-research-now', now - 3_600_000, [
+    msg('user', '帮我研究一下 RAG 检索增强的方案', now - 3_600_000),
+    msg('assistant', 'RAG 方案有以下几个要点……', now - 3_500_000, ['canvas_search_nodes']),
+  ]));
+  await writeArchived('ws-research', session('ws-research', 's-research-old', now - 10 * DAY_MS, [
+    msg('user', 'deploy pipeline keeps failing', now - 10 * DAY_MS),
+    msg('assistant', 'The deploy failure is caused by a missing env var.', now - 10 * DAY_MS + 60_000),
+  ]));
+
+  // ws-weekly: one archived session from yesterday.
+  await writeArchived('ws-weekly', session('ws-weekly', 's-weekly-1', now - DAY_MS, [
+    msg('user', '写一下本周周报', now - DAY_MS),
+    msg('assistant', '本周完成了 RAG 调研和部署修复。', now - DAY_MS + 30_000, ['canvas_read_node', 'canvas_update_node']),
+  ]));
+
+  // Global chat current session (today).
+  await writeCurrent('__global_chat__', session('__global_chat__', 's-global-1', now - 7_200_000, [
+    msg('user', '全局问题：RAG 和微调怎么选？', now - 7_200_000),
+    msg('assistant', '取决于数据量和时效性……', now - 7_100_000),
+  ]));
+}
+
+beforeEach(async () => {
+  await fs.mkdir(CANVAS_DIR, { recursive: true });
+  await seed();
+});
+
+afterEach(async () => {
+  await fs.rm(join(sandboxHome, '.pulse-coder'), { recursive: true, force: true });
+});
+
+describe('session_search', () => {
+  it('finds sessions across workspaces and global chat with snippets and workspace names', async () => {
+    const tools = createSessionTools();
+    const out = JSON.parse(await tools.session_search.execute({ query: 'RAG' }));
+
+    expect(out.ok).toBe(true);
+    const ids = out.sessions.map((s: { sessionId: string }) => s.sessionId);
+    expect(ids).toContain('s-research-now');
+    expect(ids).toContain('s-weekly-1');
+    expect(ids).toContain('s-global-1');
+    expect(ids).not.toContain('s-research-old');
+
+    const research = out.sessions.find((s: { sessionId: string }) => s.sessionId === 's-research-now');
+    expect(research.workspaceName).toBe('调研');
+    expect(research.isCurrent).toBe(true);
+    expect(research.matchCount).toBe(2);
+    expect(research.snippets[0].snippet).toContain('RAG');
+
+    const global = out.sessions.find((s: { sessionId: string }) => s.sessionId === 's-global-1');
+    expect(global.workspaceName).toBe('Global Chat');
+  });
+
+  it('restricts to one workspace when workspaceId is given', async () => {
+    const tools = createSessionTools();
+    const out = JSON.parse(await tools.session_search.execute({ query: 'rag', workspaceId: 'ws-weekly' }));
+    expect(out.sessions).toHaveLength(1);
+    expect(out.sessions[0].sessionId).toBe('s-weekly-1');
+  });
+
+  it('filters by message role', async () => {
+    const tools = createSessionTools();
+    // "deploy" appears in both roles of s-research-old; restrict to user.
+    const out = JSON.parse(await tools.session_search.execute({ query: 'deploy', role: 'user' }));
+    expect(out.sessions).toHaveLength(1);
+    expect(out.sessions[0].matchCount).toBe(1);
+    expect(out.sessions[0].snippets[0].role).toBe('user');
+  });
+
+  it('returns an empty result for no matches', async () => {
+    const tools = createSessionTools();
+    const out = JSON.parse(await tools.session_search.execute({ query: 'nonexistent-topic-xyz' }));
+    expect(out.ok).toBe(true);
+    expect(out.total).toBe(0);
+    expect(out.sessions).toHaveLength(0);
+  });
+});
+
+describe('session_summary', () => {
+  it('returns the transcript excerpt for an explicit sessionId', async () => {
+    const tools = createSessionTools();
+    const out = JSON.parse(await tools.session_summary.execute({ sessionId: 's-weekly-1' }));
+
+    expect(out.ok).toBe(true);
+    expect(out.matchedSessions).toBe(1);
+    const s = out.sessions[0];
+    expect(s.workspaceName).toBe('周报');
+    expect(s.excerpt).toHaveLength(2);
+    expect(s.excerpt[0]).toMatch(/^user: 写一下本周周报/);
+    expect(s.excerpt[1]).toMatch(/^assistant: 本周完成了/);
+  });
+
+  it('errors on an unknown sessionId', async () => {
+    const tools = createSessionTools();
+    const out = await tools.session_summary.execute({ sessionId: 'no-such-session' });
+    expect(out).toContain('Error: session not found');
+  });
+
+  it('selects sessions by recent-days window and excludes older ones', async () => {
+    const tools = createSessionTools();
+    const out = JSON.parse(await tools.session_summary.execute({ days: 3 }));
+
+    expect(out.ok).toBe(true);
+    const ids = out.sessions.map((s: { sessionId: string }) => s.sessionId);
+    expect(ids).toContain('s-research-now');
+    expect(ids).toContain('s-weekly-1');
+    expect(ids).toContain('s-global-1');
+    expect(ids).not.toContain('s-research-old');
+    expect(out.since).toBeDefined();
+    expect(out.until).toBeDefined();
+  });
+
+  it('respects role filters and reports tools used', async () => {
+    const tools = createSessionTools();
+    const out = JSON.parse(await tools.session_summary.execute({
+      sessionId: 's-weekly-1',
+      includeAssistantMessages: false,
+      includeToolCalls: true,
+    }));
+
+    const s = out.sessions[0];
+    expect(s.excerpt).toHaveLength(1);
+    expect(s.excerpt[0]).toMatch(/^user:/);
+    expect(s.toolsUsed).toEqual(expect.arrayContaining(['canvas_read_node', 'canvas_update_node']));
+  });
+
+  it('caps excerpt length with maxMessagesPerSession, keeping the newest', async () => {
+    const tools = createSessionTools();
+    const out = JSON.parse(await tools.session_summary.execute({
+      sessionId: 's-research-now',
+      maxMessagesPerSession: 5,
+    }));
+    // Session only has 2 messages; verify the field is honored structurally.
+    expect(out.sessions[0].excerptMessageCount).toBe(2);
+
+    const capped = JSON.parse(await tools.session_summary.execute({
+      sessionId: 's-research-now',
+      maxMessagesPerSession: 5,
+      includeUserMessages: false,
+    }));
+    expect(capped.sessions[0].excerpt.every((line: string) => line.startsWith('assistant:'))).toBe(true);
+  });
+});

--- a/apps/canvas-workspace/src/main/agent/__tests__/tools-graph.test.ts
+++ b/apps/canvas-workspace/src/main/agent/__tests__/tools-graph.test.ts
@@ -400,8 +400,6 @@ describe('deferred tool partition', () => {
       'canvas_search_nodes',
       'canvas_tag_node',
       'canvas_update_node',
-      'session_search',
-      'session_summary',
       'visual_render',
     ]);
     expect(deferred).toEqual([
@@ -422,6 +420,8 @@ describe('deferred tool partition', () => {
       'canvas_remove_from_group',
       'canvas_send_to_agent',
       'canvas_update_edge',
+      'session_search',
+      'session_summary',
       'workspace_node_get',
       'workspace_node_list',
       'workspace_node_upsert',

--- a/apps/canvas-workspace/src/main/agent/__tests__/tools-graph.test.ts
+++ b/apps/canvas-workspace/src/main/agent/__tests__/tools-graph.test.ts
@@ -203,6 +203,8 @@ describe('createGlobalCanvasTools', () => {
       'canvas_read_node',
       'canvas_search_nodes',
       'canvas_tag_node',
+      'session_search',
+      'session_summary',
       'workspace_node_get',
       'workspace_node_list',
     ]);
@@ -398,6 +400,8 @@ describe('deferred tool partition', () => {
       'canvas_search_nodes',
       'canvas_tag_node',
       'canvas_update_node',
+      'session_search',
+      'session_summary',
       'visual_render',
     ]);
     expect(deferred).toEqual([

--- a/apps/canvas-workspace/src/main/agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/agent/canvas-agent.ts
@@ -66,6 +66,12 @@ Your Pulse Canvas data (workspaces, nodes, tags) lives locally and is read throu
 - \`canvas_list_nodes\` — nodes across all workspaces (or one) with their tags; filter by \`tag\`, \`untaggedOnly\`, or \`query\`. Use it to audit tag coverage or find tagging candidates.
 - \`canvas_tag_node\` — add / remove / replace tags on one or many nodes at once (batch). The one write allowed here; it touches knowledge-layer tags only, so you can apply a tag (e.g. [AI]) across workspaces without leaving global chat. Always confirm with the user before applying tags they did not explicitly ask for.
 
+## Chat Session History (会话检索/总结)
+Past chat sessions (every workspace + this global chat) are stored locally and searchable:
+- \`session_search\` — keyword search over stored user/assistant messages; returns matching sessions with snippets. Use for "我们之前聊过 X 吗 / find the conversation about X".
+- \`session_summary\` — compact transcript excerpts for one session (pass its sessionId) or every session in the last N days; read the excerpts and write the summary yourself. Use for "总结一下今天/这周的会话 / recap that conversation".
+These read chat history, NOT canvas nodes — use the canvas tools above for nodes.
+
 ## Scope Rules
 - Do not assume there is a current canvas or selected workspace. When you need one, call \`canvas_list_workspaces\` to enumerate them and pick the right \`workspaceId\`; only ask the user when the choice is genuinely ambiguous.
 - The remaining read-only canvas tools (\`canvas_read_context\`, \`canvas_read_node\`, \`canvas_search_nodes\`, \`canvas_list_edges\`, \`workspace_node_*\`) need a concrete workspaceId on every call — get it from \`canvas_list_workspaces\` or a workspace mention.
@@ -192,6 +198,7 @@ The following tools are loaded and callable directly. Grouped by intent:
 - **Group membership**: \`canvas_add_to_group\`, \`canvas_remove_from_group\` — use when the user asks to add/remove nodes to/from a group (groups own members via \`data.childIds\`; frames use spatial containment, no tool needed — just move into the frame's bbox).
 - **Workspace-node knowledge layer**: \`workspace_node_list\`, \`workspace_node_get\`, \`workspace_node_upsert\` — use when the user is tagging nodes, building a knowledge graph, or asking "find/group/connect nodes by X". Separate metadata store with tags / properties / typed links.
 - **Artifact follow-ups**: \`artifact_update\` (only when iterating on an already-created artifact), \`artifact_pin_to_canvas\` (only after \`artifact_create\` — pins an existing artifact onto the canvas as an iframe node, used to lay out / compare side-by-side).
+- **Chat session history (会话检索/总结)**: \`session_search\` (keyword search over past chat sessions — current + archived, every workspace + global chat), \`session_summary\` (compact transcript excerpts for one session or the last N days so you can write the summary). Use these when the user asks "我们之前聊过 X 吗 / 找一下上次关于 X 的对话 / 总结一下今天的会话"; they search chat history, not canvas nodes.
 - **Webpage scraping**: \`canvas_read_webpage\` (DOM / a11y / screenshot from an open iframe node).
 - **Page control (driving an open iframe)**: \`page_eval\`, \`page_click\`, \`page_click_at\`, \`page_fill\`, \`page_press\`, \`page_scroll\`, \`page_wait_for\` — use when the user asks you to interact with the contents of an iframe node (click a button, fill a form, scroll, wait for an element). These act on the live page inside the iframe.
 

--- a/apps/canvas-workspace/src/main/agent/session-store.ts
+++ b/apps/canvas-workspace/src/main/agent/session-store.ts
@@ -29,7 +29,7 @@ interface WorkspaceManifest {
   activeId?: string;
 }
 
-interface SessionWithMeta {
+export interface SessionWithMeta {
   session: CanvasAgentSession;
   workspaceName: string;
   isCurrent: boolean;
@@ -404,7 +404,13 @@ export class SessionStore {
     return matched;
   }
 
-  private static async readAllSessionsWithMeta(): Promise<SessionWithMeta[]> {
+  /**
+   * Read every stored session (current + archive) across all workspaces and
+   * global chat, with workspace names resolved from the manifest. Sorted by
+   * recency (current sessions first). Read-only; used by the session-history
+   * tools (`session_search` / `session_summary`).
+   */
+  static async readAllSessionsWithMeta(): Promise<SessionWithMeta[]> {
     const manifest = await loadManifest();
     const workspaceNames = new Map(manifest.workspaces.map(workspace => [workspace.id, workspace.name] as const));
     const results: SessionWithMeta[] = [];

--- a/apps/canvas-workspace/src/main/agent/tools/index.ts
+++ b/apps/canvas-workspace/src/main/agent/tools/index.ts
@@ -16,6 +16,7 @@ import { createVisualTools } from './visual';
 import { createArtifactTools } from './artifacts';
 import { createWebpageTools } from './webpage';
 import { createSkillTools } from './skills';
+import { createSessionTools } from './sessions';
 
 export type { CanvasTool, CanvasToolExecutionContext } from './types';
 
@@ -70,6 +71,9 @@ export function createGlobalCanvasTools(): Record<string, CanvasTool> {
     ...createKnowledgeTools(),
     // The only allowed write in global chat: knowledge-layer tagging.
     ...createTaggingTools(),
+    // Chat-session history (检索/总结). Inherently cross-workspace (workspaceId
+    // is optional), so not wrapped with requireWorkspaceId.
+    ...createSessionTools(),
   };
 }
 
@@ -90,6 +94,7 @@ export function createCanvasTools(workspaceId: string): Record<string, CanvasToo
     ...createArtifactTools(workspaceId),
     ...createWebpageTools(workspaceId),
     ...createSkillTools(workspaceId),
+    ...createSessionTools(workspaceId),
   };
 
   // Plugin-contributed tools (see `plugins/main/registry.ts`). A plugin's

--- a/apps/canvas-workspace/src/main/agent/tools/sessions.ts
+++ b/apps/canvas-workspace/src/main/agent/tools/sessions.ts
@@ -9,6 +9,9 @@
  *
  * Both read the on-disk session store (`~/.pulse-coder/canvas/<id>/agent-sessions`)
  * via `SessionStore.readAllSessionsWithMeta()`; neither mutates anything.
+ *
+ * Both are `defer_loading` — they sit behind tool search when the engine has
+ * the tool-search plugin, and are documented in the system prompts either way.
  */
 
 import { z } from 'zod';
@@ -78,6 +81,7 @@ export function createSessionTools(currentWorkspaceId?: string): Record<string, 
   return {
     session_search: {
       name: 'session_search',
+      defer_loading: true,
       description:
         'Search past AI chat sessions (会话检索) — current and archived, across every workspace and global chat — by case-insensitive keyword over the stored user/assistant messages. ' +
         'Returns matching sessions (newest first) with workspace name, date, message count, and snippets around each hit. ' +
@@ -139,6 +143,7 @@ export function createSessionTools(currentWorkspaceId?: string): Record<string, 
 
     session_summary: {
       name: 'session_summary',
+      defer_loading: true,
       description:
         'Fetch compact transcript excerpts of past AI chat sessions (会话总结) so you can summarize them. ' +
         'Pass `sessionId` (e.g. from `session_search` or the user) to pull ONE session, or omit it to pull every session active in the last `days` days (default 3) across workspaces and global chat. ' +

--- a/apps/canvas-workspace/src/main/agent/tools/sessions.ts
+++ b/apps/canvas-workspace/src/main/agent/tools/sessions.ts
@@ -1,0 +1,219 @@
+/**
+ * Chat-session history tools.
+ *
+ * These answer "what did we talk about" questions over the agent's own chat
+ * sessions (current + archived, every workspace + global chat):
+ *   - `session_search`  — keyword retrieval across stored sessions (会话检索)
+ *   - `session_summary` — compact transcript excerpts of one session or a
+ *     recent time window so the model can write the summary itself (会话总结)
+ *
+ * Both read the on-disk session store (`~/.pulse-coder/canvas/<id>/agent-sessions`)
+ * via `SessionStore.readAllSessionsWithMeta()`; neither mutates anything.
+ */
+
+import { z } from 'zod';
+import { SessionStore, type SessionWithMeta } from '../session-store';
+import type { CanvasAgentMessage } from '../types';
+import type { CanvasTool } from './types';
+
+// ─── Shared helpers ────────────────────────────────────────────────
+
+function trimText(text: string, max = 240): string {
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  if (!normalized) return '(empty)';
+  return normalized.length > max ? `${normalized.slice(0, max)}...` : normalized;
+}
+
+/** Snippet centered on the first occurrence of `query` (already lowercased). */
+function matchSnippet(text: string, query: string, radius = 80): string {
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  const idx = normalized.toLowerCase().indexOf(query);
+  if (idx < 0) return trimText(normalized, radius * 2);
+  const start = Math.max(0, idx - radius);
+  const end = Math.min(normalized.length, idx + query.length + radius);
+  return `${start > 0 ? '...' : ''}${normalized.slice(start, end)}${end < normalized.length ? '...' : ''}`;
+}
+
+/** Millisecond timestamp of the session's last activity (for window filters). */
+function lastActivityMs(entry: SessionWithMeta): number {
+  const messages = entry.session.messages ?? [];
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const ts = messages[i]?.timestamp;
+    if (typeof ts === 'number' && Number.isFinite(ts)) return ts;
+  }
+  const started = Date.parse(entry.session.startedAt ?? '');
+  return Number.isFinite(started) ? started : entry.sortKey;
+}
+
+function previewOf(messages: CanvasAgentMessage[]): string {
+  const firstUser = messages.find((m) => m.role === 'user');
+  return firstUser ? trimText(firstUser.content, 80) : '';
+}
+
+function sessionHeader(entry: SessionWithMeta): Record<string, unknown> {
+  const { session } = entry;
+  return {
+    sessionId: session.sessionId,
+    workspaceId: session.workspaceId,
+    workspaceName: entry.workspaceName,
+    date: session.startedAt?.slice(0, 10) ?? '',
+    isCurrent: entry.isCurrent,
+    messageCount: session.messages.length,
+  };
+}
+
+async function loadSessions(workspaceId?: string): Promise<SessionWithMeta[]> {
+  const all = await SessionStore.readAllSessionsWithMeta();
+  if (!workspaceId) return all;
+  return all.filter((entry) => entry.session.workspaceId === workspaceId);
+}
+
+// ─── Tools ─────────────────────────────────────────────────────────
+
+export function createSessionTools(currentWorkspaceId?: string): Record<string, CanvasTool> {
+  const workspaceIdDescription = currentWorkspaceId
+    ? 'Restrict to one workspace\'s sessions (the session-store id; use the current workspaceId for "this workspace"). Omit to search EVERY workspace plus global chat.'
+    : 'Restrict to one workspace\'s sessions (the session-store id, from `canvas_list_workspaces`). Omit to search EVERY workspace plus global chat.';
+
+  return {
+    session_search: {
+      name: 'session_search',
+      description:
+        'Search past AI chat sessions (会话检索) — current and archived, across every workspace and global chat — by case-insensitive keyword over the stored user/assistant messages. ' +
+        'Returns matching sessions (newest first) with workspace name, date, message count, and snippets around each hit. ' +
+        'Use this when the user asks "我们之前聊过 X 吗 / 找一下上次关于 X 的对话 / when did we discuss X". ' +
+        'This searches chat history, NOT canvas nodes — use `canvas_search_nodes` for nodes. ' +
+        'Follow up with `session_summary` (pass the sessionId) to read a session in more detail.',
+      inputSchema: z.object({
+        query: z.string().min(1).describe('Case-insensitive substring matched against message text.'),
+        workspaceId: z.string().optional().describe(workspaceIdDescription),
+        role: z.enum(['user', 'assistant']).optional().describe('Only match messages from this role. Omit to match both.'),
+        limit: z.number().int().positive().max(100).optional().describe('Max sessions to return. Default 20.'),
+        snippetsPerSession: z.number().int().positive().max(10).optional().describe('Max matched-message snippets per session. Default 3.'),
+      }),
+      execute: async (input) => {
+        const query = String(input.query ?? '').trim().toLowerCase();
+        if (!query) return 'Error: query must not be empty.';
+        const limit = (input.limit as number | undefined) ?? 20;
+        const snippetsPerSession = (input.snippetsPerSession as number | undefined) ?? 3;
+        const roleFilter = input.role as 'user' | 'assistant' | undefined;
+
+        const sessions = await loadSessions(input.workspaceId as string | undefined);
+
+        const matches: Array<Record<string, unknown>> = [];
+        let total = 0;
+        for (const entry of sessions) {
+          const snippets: Array<{ role: string; snippet: string }> = [];
+          let matchCount = 0;
+          for (const message of entry.session.messages) {
+            if (roleFilter && message.role !== roleFilter) continue;
+            if (typeof message.content !== 'string') continue;
+            if (!message.content.toLowerCase().includes(query)) continue;
+            matchCount += 1;
+            if (snippets.length < snippetsPerSession) {
+              snippets.push({ role: message.role, snippet: matchSnippet(message.content, query) });
+            }
+          }
+          if (matchCount === 0) continue;
+
+          total += 1;
+          if (matches.length >= limit) continue;
+          matches.push({
+            ...sessionHeader(entry),
+            matchCount,
+            preview: previewOf(entry.session.messages),
+            snippets,
+          });
+        }
+
+        return JSON.stringify({
+          ok: true,
+          query: input.query,
+          total,
+          returned: matches.length,
+          truncated: total > matches.length,
+          sessions: matches,
+        });
+      },
+    },
+
+    session_summary: {
+      name: 'session_summary',
+      description:
+        'Fetch compact transcript excerpts of past AI chat sessions (会话总结) so you can summarize them. ' +
+        'Pass `sessionId` (e.g. from `session_search` or the user) to pull ONE session, or omit it to pull every session active in the last `days` days (default 3) across workspaces and global chat. ' +
+        'Returns per-session "role: text" excerpt lines (each line trimmed); read them and write the summary yourself — the tool does not call an LLM. ' +
+        'Use this when the user asks "总结一下今天/这周的会话 / what did we discuss in that session / recap our last conversation".',
+      inputSchema: z.object({
+        sessionId: z.string().optional().describe('Summarize this one session. Only use an id from session_search output or the user; never invent one.'),
+        workspaceId: z.string().optional().describe(workspaceIdDescription),
+        days: z.number().int().min(1).max(30).optional().describe('When no sessionId is given: include sessions active within the last N days. Default 3.'),
+        offsetDays: z.number().int().min(0).max(365).optional().describe('Shift the time window back by N days from today (0 = window ends today).'),
+        maxMessagesPerSession: z.number().int().min(5).max(500).optional().describe('Cap excerpt lines per session, keeping the newest. Default 100.'),
+        includeUserMessages: z.boolean().optional().describe('Include user messages in the excerpt. Default true.'),
+        includeAssistantMessages: z.boolean().optional().describe('Include assistant messages in the excerpt. Default true.'),
+        includeToolCalls: z.boolean().optional().describe('Also report the unique tool names each session used. Default false.'),
+      }),
+      execute: async (input) => {
+        const includeUser = input.includeUserMessages !== false;
+        const includeAssistant = input.includeAssistantMessages !== false;
+        const includeToolCalls = input.includeToolCalls === true;
+        const maxMessages = (input.maxMessagesPerSession as number | undefined) ?? 100;
+
+        const sessions = await loadSessions(input.workspaceId as string | undefined);
+
+        let selected: SessionWithMeta[];
+        let window: { since: string; until: string } | undefined;
+        if (typeof input.sessionId === 'string' && input.sessionId.trim()) {
+          const sessionId = input.sessionId.trim();
+          selected = sessions.filter((entry) => entry.session.sessionId === sessionId);
+          if (selected.length === 0) return `Error: session not found: ${sessionId}`;
+        } else {
+          const days = (input.days as number | undefined) ?? 3;
+          const offsetDays = (input.offsetDays as number | undefined) ?? 0;
+          const now = new Date();
+          const todayUtc = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+          const untilMs = todayUtc - offsetDays * 86_400_000 + 86_400_000 - 1; // end of the window's last day
+          const sinceMs = untilMs + 1 - days * 86_400_000;
+          selected = sessions.filter((entry) => {
+            const activity = lastActivityMs(entry);
+            return activity >= sinceMs && activity <= untilMs;
+          });
+          window = {
+            since: new Date(sinceMs).toISOString().slice(0, 10),
+            until: new Date(untilMs).toISOString().slice(0, 10),
+          };
+        }
+
+        const summaries = selected.map((entry) => {
+          const filtered = entry.session.messages
+            .filter((message) => (message.role === 'user' ? includeUser : includeAssistant))
+            .slice(-maxMessages);
+          const excerpt = filtered.map((message) => `${message.role}: ${trimText(message.content)}`);
+          const summary: Record<string, unknown> = {
+            ...sessionHeader(entry),
+            excerptMessageCount: filtered.length,
+            excerpt,
+          };
+          if (includeToolCalls) {
+            const toolNames = new Set<string>();
+            for (const message of entry.session.messages) {
+              for (const call of message.toolCalls ?? []) {
+                if (call.name) toolNames.add(call.name);
+              }
+            }
+            summary.toolsUsed = Array.from(toolNames);
+          }
+          return summary;
+        });
+
+        return JSON.stringify({
+          ok: true,
+          ...(window ? window : {}),
+          matchedSessions: summaries.length,
+          sessions: summaries,
+        });
+      },
+    },
+  };
+}


### PR DESCRIPTION
Adds two chat-session history tools to the Canvas Agent (workspace and
global chat scopes):

- session_search: keyword retrieval over stored user/assistant messages
  across current + archived sessions in every workspace and global chat,
  returning matching sessions with workspace names and match snippets.
- session_summary: compact "role: text" transcript excerpts for one
  session (by sessionId) or all sessions active in a recent day window,
  with optional role filters and used-tool reporting, so the agent can
  write the summary itself.

Both read the on-disk session store via a now-public
SessionStore.readAllSessionsWithMeta(). Wired into createCanvasTools /
createGlobalCanvasTools, documented in both system prompts, and covered
by a new vitest suite.

https://claude.ai/code/session_011YQUW5F8S9coGtNxPaAB2j