### PR TITLE
feat(agent-teams): strengthen DAG parallelism hints in Lead prompts

### DIFF
--- a/apps/canvas-workspace/src/main/agent-teams/service.ts
+++ b/apps/canvas-workspace/src/main/agent-teams/service.ts
@@ -374,6 +374,7 @@ const formatLeaderBriefingPrompt = (teamName: string, goal: string, content: str
   'Use deps to encode the real execution order. Do not rely on wording like "after" or "then" in descriptions.',
   'Plan the smallest DAG that still exposes useful parallel work: usually 3-6 teammates and 4-10 tasks for normal app/repo work. Go above 10 tasks only when there are truly independent deliverables.',
   'Target 2-4 ready-to-start workstreams. Do not serialize the whole graph behind one setup/research task, and do not create one microtask per file, component, command, or tiny edit.',
+  'Aim for at least 2-3 tasks runnable in parallel at every stage of the DAG. If a task only blocks one downstream task, consider whether they can run concurrently with a shared contract instead of a hard dependency.',
   'Each teammate should usually own 1-2 meaningful tasks. Split by durable ownership or artifact boundary, not by mechanical steps.',
   'Use deps only for real handoffs: a task depends on another task only when it needs that task\'s concrete output or contract.',
   'Downstream tasks such as frontend integration, QA, testing, review, documentation, release, validation, and final summary MUST depend on the implementation or contract tasks they need.',

--- a/packages/agent-teams/src/runtime/team-runtime.ts
+++ b/packages/agent-teams/src/runtime/team-runtime.ts
@@ -1286,7 +1286,8 @@ export class TeamRuntime {
             '',
           ]
         : []),
-      `Plan the next round of work. Review what was accomplished and create new tasks for Round ${nextRound}:`,
+      `Plan the next round of work. Review what was accomplished and create new tasks for Round ${nextRound}.`,
+      'Design the DAG so at least 2-3 tasks can run in parallel — do not chain everything sequentially.',
       'pulse-canvas team create-task --title "..." --description "..." --owner "..." --dispatch',
       '',
       'When you have created all tasks for this round, they will be dispatched automatically.',


### PR DESCRIPTION
Add explicit guidance for the Lead to design at least 2-3 concurrent tasks at every stage of the DAG, and prefer shared contracts over hard sequential dependencies when possible.

https://claude.ai/code/session_01U3nvbLRf6eiJqKH25X6AE5