### PR TITLE
Add clickable session-ref chips with jump-to-message navigation

### DIFF
--- a/apps/canvas-workspace/src/main/agent/__tests__/session-tools.test.ts
+++ b/apps/canvas-workspace/src/main/agent/__tests__/session-tools.test.ts
@@ -121,6 +121,7 @@ describe('session_search', () => {
     expect(research.isCurrent).toBe(true);
     expect(research.matchCount).toBe(2);
     expect(research.snippets[0].snippet).toContain('RAG');
+    expect(typeof research.snippets[0].messageIndex).toBe('number');
 
     const global = out.sessions.find((s: { sessionId: string }) => s.sessionId === 's-global-1');
     expect(global.workspaceName).toBe('Global Chat');

--- a/apps/canvas-workspace/src/main/agent/tools/sessions.ts
+++ b/apps/canvas-workspace/src/main/agent/tools/sessions.ts
@@ -107,15 +107,16 @@ export function createSessionTools(currentWorkspaceId?: string): Record<string, 
         const matches: Array<Record<string, unknown>> = [];
         let total = 0;
         for (const entry of sessions) {
-          const snippets: Array<{ role: string; snippet: string }> = [];
+          const snippets: Array<{ role: string; messageIndex: number; snippet: string }> = [];
           let matchCount = 0;
-          for (const message of entry.session.messages) {
+          for (let mi = 0; mi < entry.session.messages.length; mi++) {
+            const message = entry.session.messages[mi];
             if (roleFilter && message.role !== roleFilter) continue;
             if (typeof message.content !== 'string') continue;
             if (!message.content.toLowerCase().includes(query)) continue;
             matchCount += 1;
             if (snippets.length < snippetsPerSession) {
-              snippets.push({ role: message.role, snippet: matchSnippet(message.content, query) });
+              snippets.push({ role: message.role, messageIndex: mi, snippet: matchSnippet(message.content, query) });
             }
           }
           if (matchCount === 0) continue;

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
@@ -78,6 +78,8 @@ interface ChatMessageProps {
   onEditUserMessage?: (index: number, newContent: string) => Promise<boolean> | void;
   /** Re-run the user turn that produced this assistant message. */
   onRegenerate?: (index: number) => Promise<boolean> | void;
+  /** Jump to a session/message from a session_search result chip. */
+  onSessionJump?: (sessionId: string, workspaceId: string, messageIndex?: number) => void;
 }
 
 const LoadingDots = () => (
@@ -104,6 +106,7 @@ export const ChatMessage = ({
   anchorId,
   onEditUserMessage,
   onRegenerate,
+  onSessionJump,
 }: ChatMessageProps) => {
   const assistantHtml = useMemo(
     () => (message.role === 'assistant'
@@ -217,6 +220,7 @@ export const ChatMessage = ({
             showSectionHeader={!loading}
             onToggleSection={onToggleSection}
             onToggleToolExpand={onToggleToolExpand}
+            onSessionJump={onSessionJump}
           />
           <div className="chat-generated-images">
             {tools.map(tool => {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessages.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessages.tsx
@@ -25,6 +25,7 @@ interface ChatMessagesProps {
   onNodeFocus?: (nodeId: string) => void;
   onEditUserMessage?: (index: number, newContent: string) => Promise<boolean> | void;
   onRegenerate?: (index: number) => Promise<boolean> | void;
+  onSessionJump?: (sessionId: string, workspaceId: string, messageIndex?: number) => void;
 }
 
 const LoadingPlaceholder = () => (
@@ -136,6 +137,7 @@ export const ChatMessages = ({
   onNodeFocus,
   onEditUserMessage,
   onRegenerate,
+  onSessionJump,
 }: ChatMessagesProps) => {
   const { t } = useI18n();
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -167,6 +169,18 @@ export const ChatMessages = ({
       return;
     }
 
+    // Session-ref chip → load session and scroll to the matched message.
+    const sessionChip = target.closest<HTMLElement>('[data-action="session-jump"]');
+    if (sessionChip && onSessionJump) {
+      const sid = sessionChip.dataset.sessionId;
+      const wid = sessionChip.dataset.workspaceId;
+      const mi = sessionChip.dataset.messageIndex;
+      if (sid && wid) {
+        onSessionJump(sid, wid, mi !== undefined ? Number(mi) : undefined);
+      }
+      return;
+    }
+
     // Mention chip → focus the canvas node it references.
     const chip = target.closest('.chat-mention-chip--clickable') as HTMLElement | null;
     if (!chip || !onNodeFocus) return;
@@ -174,7 +188,7 @@ export const ChatMessages = ({
     if (nodeId) {
       onNodeFocus(nodeId);
     }
-  }, [onNodeFocus, t]);
+  }, [onNodeFocus, onSessionJump, t]);
 
   const hasStreamingAssistantMessage = loading
     && messages.length > 0
@@ -203,6 +217,7 @@ export const ChatMessages = ({
             anchorId={buildAnchorElementId(workspaceId, index)}
             onEditUserMessage={onEditUserMessage}
             onRegenerate={onRegenerate}
+            onSessionJump={onSessionJump}
           />
         );
       })}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageBody.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageBody.tsx
@@ -178,6 +178,36 @@ export const ChatPageBody = ({
     onExit();
   }, [onExit, onNodeFocus, workspaceId]);
 
+  const handleSessionJump = useCallback(async (sessionId: string, jumpWorkspaceId: string, messageIndex?: number) => {
+    // ChatPageBody uses onSelectSession for cross-workspace switches which
+    // remount the body with the correct workspace scope. For same-workspace
+    // sessions we can load in-place.
+    const isSameScope = jumpWorkspaceId === (workspaceId ?? '__global_chat__');
+    if (isSameScope) {
+      await handleLoadSession(sessionId);
+    } else {
+      onSelectSession({
+        sessionId,
+        workspaceId: jumpWorkspaceId,
+        workspaceName: allWorkspaces.find(w => w.id === jumpWorkspaceId)?.name ?? jumpWorkspaceId,
+        date: '',
+        messageCount: 0,
+        preview: '',
+        isCurrent: false,
+      });
+    }
+    if (messageIndex !== undefined && messageIndex >= 0) {
+      window.setTimeout(() => {
+        const id = buildAnchorElementId(anchorScopeId, messageIndex);
+        const el = document.getElementById(id);
+        if (!el) return;
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        el.classList.add('chat-message--anchor-flash');
+        window.setTimeout(() => el.classList.remove('chat-message--anchor-flash'), 1200);
+      }, 200);
+    }
+  }, [allWorkspaces, anchorScopeId, handleLoadSession, onSelectSession, workspaceId]);
+
   const anchors = useMemo(() => buildChatAnchors(messages), [messages]);
 
   const handleJumpAnchor = useCallback((messageIndex: number) => {
@@ -343,6 +373,7 @@ export const ChatPageBody = ({
           contextComposer
           onEditUserMessage={handleEditUserMessage}
           onRegenerate={handleRegenerate}
+          onSessionJump={handleSessionJump}
         />
       </div>
     </div>

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
@@ -1586,6 +1586,69 @@
   margin-bottom: 4px;
 }
 
+/* ─── Session-ref chips (session_search / session_summary) ─ */
+
+.chat-session-refs {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 4px 0 4px 19px;
+}
+
+.chat-session-ref-chip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border: 1px solid rgba(55, 53, 47, 0.09);
+  border-radius: 6px;
+  background: rgba(55, 53, 47, 0.028);
+  font-family: inherit;
+  font-size: 12px;
+  color: rgba(55, 53, 47, 0.7);
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.12s, border-color 0.12s;
+  line-height: 1.35;
+}
+
+.chat-session-ref-chip:hover {
+  background: rgba(55, 53, 47, 0.06);
+  border-color: rgba(55, 53, 47, 0.16);
+}
+
+.chat-session-ref-icon {
+  flex-shrink: 0;
+  color: rgba(55, 53, 47, 0.4);
+}
+
+.chat-session-ref-name {
+  font-weight: 600;
+  color: rgba(55, 53, 47, 0.85);
+  white-space: nowrap;
+}
+
+.chat-session-ref-date {
+  color: rgba(55, 53, 47, 0.4);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.chat-session-ref-count {
+  color: rgba(55, 53, 47, 0.35);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.chat-session-ref-preview {
+  color: rgba(55, 53, 47, 0.5);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
 /* ─── @ Mention popup ────────────────────────────────────── */
 
 .chat-mention-popup {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.tsx
@@ -213,6 +213,21 @@ export const ChatPanel = ({
     [regenerateAssistantMessage],
   );
 
+  const handleSessionJump = useCallback(async (sessionId: string, jumpWorkspaceId: string, messageIndex?: number) => {
+    await handleLoadSession(sessionId, jumpWorkspaceId !== scopeWorkspaceId ? jumpWorkspaceId : undefined);
+    if (messageIndex !== undefined && messageIndex >= 0) {
+      // Allow the DOM to settle after session load, then scroll to target.
+      window.setTimeout(() => {
+        const id = buildAnchorElementId(anchorScopeId, messageIndex);
+        const el = document.getElementById(id);
+        if (!el) return;
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        el.classList.add('chat-message--anchor-flash');
+        window.setTimeout(() => el.classList.remove('chat-message--anchor-flash'), 1200);
+      }, 120);
+    }
+  }, [anchorScopeId, handleLoadSession, scopeWorkspaceId]);
+
   const anchors = useMemo(() => buildChatAnchors(messages), [messages]);
 
   const handleJumpAnchor = useCallback((index: number) => {
@@ -292,6 +307,7 @@ export const ChatPanel = ({
       onToggleExecutionMode={scopeWorkspaceId ? handleToggleExecutionMode : undefined}
       onEditUserMessage={handleEditUserMessage}
       onRegenerate={handleRegenerate}
+      onSessionJump={handleSessionJump}
     />
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatToolCalls.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatToolCalls.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import type { ToolCallStatus } from './types';
 
 interface ChatToolCallsProps {
@@ -7,6 +8,7 @@ interface ChatToolCallsProps {
   showSectionHeader: boolean;
   onToggleSection: () => void;
   onToggleToolExpand: (toolId: number) => void;
+  onSessionJump?: (sessionId: string, workspaceId: string, messageIndex?: number) => void;
 }
 
 function truncate(value: string, max: number): string {
@@ -73,6 +75,10 @@ function formatToolLabel(name: string, status: ToolCallStatus['status']): string
       return `${prefix}查看目录`;
     case 'bash':
       return `${prefix}运行命令`;
+    case 'session_search':
+      return `${prefix}检索会话`;
+    case 'session_summary':
+      return `${prefix}获取会话摘要`;
     default:
       return status === 'running' ? '正在执行' : '已执行';
   }
@@ -88,6 +94,72 @@ function formatArgs(args: unknown): string {
   }
 }
 
+// ─── Session references from session_search / session_summary ──────
+
+interface SessionRef {
+  sessionId: string;
+  workspaceId: string;
+  workspaceName: string;
+  date: string;
+  messageCount: number;
+  preview?: string;
+  /** First matched message index — used for scroll-to on jump. */
+  firstMatchIndex?: number;
+}
+
+const SESSION_TOOL_NAMES = new Set(['session_search', 'session_summary']);
+
+function parseSessionRefs(tool: ToolCallStatus): SessionRef[] | null {
+  if (!SESSION_TOOL_NAMES.has(tool.name) || !tool.result) return null;
+  try {
+    const parsed = JSON.parse(tool.result) as { ok?: boolean; sessions?: Array<Record<string, unknown>> };
+    if (!parsed?.ok || !Array.isArray(parsed.sessions) || parsed.sessions.length === 0) return null;
+    return parsed.sessions.map((s) => {
+      // For session_search, snippets[0].messageIndex gives the first hit.
+      const snippets = Array.isArray(s.snippets) ? s.snippets as Array<{ messageIndex?: number }> : [];
+      const firstMatchIndex = snippets[0]?.messageIndex;
+      return {
+        sessionId: String(s.sessionId ?? ''),
+        workspaceId: String(s.workspaceId ?? ''),
+        workspaceName: String(s.workspaceName ?? ''),
+        date: String(s.date ?? ''),
+        messageCount: typeof s.messageCount === 'number' ? s.messageCount : 0,
+        preview: typeof s.preview === 'string' ? s.preview : undefined,
+        firstMatchIndex: typeof firstMatchIndex === 'number' ? firstMatchIndex : undefined,
+      };
+    }).filter((r) => r.sessionId && r.workspaceId);
+  } catch {
+    return null;
+  }
+}
+
+const SessionRefChips = ({ refs }: { refs: SessionRef[] }) => (
+  <div className="chat-session-refs">
+    {refs.map((ref) => (
+      <button
+        key={`${ref.workspaceId}:${ref.sessionId}`}
+        type="button"
+        className="chat-session-ref-chip"
+        data-action="session-jump"
+        data-session-id={ref.sessionId}
+        data-workspace-id={ref.workspaceId}
+        data-message-index={ref.firstMatchIndex}
+        title={ref.preview || ref.sessionId}
+      >
+        <span className="chat-session-ref-icon">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <path d="M4 2.5h5M4 6h5M4 9.5h5M2 2.5h.01M2 6h.01M2 9.5h.01" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+          </svg>
+        </span>
+        <span className="chat-session-ref-name">{ref.workspaceName}</span>
+        <span className="chat-session-ref-date">{ref.date}</span>
+        <span className="chat-session-ref-count">{ref.messageCount} msgs</span>
+        {ref.preview && <span className="chat-session-ref-preview">{ref.preview.length > 40 ? `${ref.preview.slice(0, 38)}…` : ref.preview}</span>}
+      </button>
+    ))}
+  </div>
+);
+
 export const ChatToolCalls = ({
   tools,
   collapsed,
@@ -95,7 +167,17 @@ export const ChatToolCalls = ({
   showSectionHeader,
   onToggleSection,
   onToggleToolExpand,
+  onSessionJump,
 }: ChatToolCallsProps) => {
+  const sessionRefsByToolId = useMemo(() => {
+    const map = new Map<number, SessionRef[]>();
+    for (const tool of tools) {
+      if (tool.status !== 'done') continue;
+      const refs = parseSessionRefs(tool);
+      if (refs) map.set(tool.id, refs);
+    }
+    return map;
+  }, [tools]);
   if (collapsed) {
     return (
       <div className="chat-tool-calls chat-tool-calls--collapsed" onClick={onToggleSection}>
@@ -156,6 +238,9 @@ export const ChatToolCalls = ({
               </span>
             )}
           </div>
+          {sessionRefsByToolId.has(tool.id) && (
+            <SessionRefChips refs={sessionRefsByToolId.get(tool.id)!} />
+          )}
           {expandedTools.has(tool.id) && (tool.result || tool.args !== undefined) && (
             <div className="chat-tool-call-result">
               {tool.args !== undefined && (

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatView.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatView.tsx
@@ -73,6 +73,9 @@ interface ChatViewProps {
   onEditUserMessage?: (index: number, newContent: string) => Promise<boolean> | void;
   onRegenerate?: (index: number) => Promise<boolean> | void;
 
+  // Session jump — load a session from a session_search result chip.
+  onSessionJump?: (sessionId: string, workspaceId: string, messageIndex?: number) => void;
+
   // Optional decoration
   onResizeStart?: (e: ReactMouseEvent) => void;
 }
@@ -131,6 +134,7 @@ export const ChatView = ({
   onToggleExecutionMode,
   onEditUserMessage,
   onRegenerate,
+  onSessionJump,
   onResizeStart,
 }: ChatViewProps) => {
   const hasMessages = messages.length > 0 || loading;
@@ -162,6 +166,7 @@ export const ChatView = ({
           onNodeFocus={onNodeFocus}
           onEditUserMessage={onEditUserMessage}
           onRegenerate={onRegenerate}
+          onSessionJump={onSessionJump}
         />
       ) : (
         <ChatEmptyState


### PR DESCRIPTION
When session_search or session_summary tools return results, the chat UI now renders clickable session-reference chips below the tool call header. Each chip shows workspace name, date, message count, and a preview. Clicking a chip loads the referenced session and scrolls to the first matched message with a highlight flash animation.

Backend changes:
- session_search now returns `messageIndex` on each snippet, identifying the exact message position in the session for scroll targeting.

Frontend changes:
- ChatToolCalls: parses session_search/session_summary JSON results and renders SessionRefChips with data-action="session-jump" attributes.
- ChatMessages: click delegation for session-jump chips, forwarding sessionId + workspaceId + messageIndex to the new onSessionJump prop.
- ChatPanel / ChatPageBody: handleSessionJump loads the target session (same-workspace or cross-workspace) then scrolls to the message index with the existing anchor-flash animation.
- ChatView / ChatMessage: thread onSessionJump prop through the chain.
- ChatPanel.css: styles for the session-ref chip strip.

https://claude.ai/code/session_011YQUW5F8S9coGtNxPaAB2j