### PR TITLE
Improve error handling for streamed responses and transient failures

### DIFF
--- a/packages/engine/src/core/loop.test.ts
+++ b/packages/engine/src/core/loop.test.ts
@@ -233,6 +233,29 @@ describe('loop', () => {
     );
   });
 
+  it('extracts error detail from mixed JSON+SSE responseBody on no-output errors', async () => {
+    const context: Context = {
+      messages: [{ role: 'user', content: 'test' }],
+    };
+    const sseResponseBody =
+      '{"error":{"message":"Upstream request failed","type":"upstream_error"}}' +
+      'event: response.failed\n' +
+      'data: {"type":"response.failed","response":{"id":"resp_abc","object":"response","model":"gpt-5.4","status":"failed","output":[],"error":{"code":"upstream_error","message":"Upstream request failed"}}}\n';
+
+    const upstreamError = Object.assign(new Error('No output generated.'), {
+      responseBody: sseResponseBody,
+    });
+
+    streamTextAIMock.mockImplementation(() => {
+      throw upstreamError;
+    });
+
+    const result = await loop(context);
+
+    expect(result).toContain('上游模型没有产出任何输出');
+    expect(result).toContain('Upstream request failed');
+  });
+
   it('times out LLM calls that never produce a first chunk', async () => {
     vi.useFakeTimers();
 

--- a/packages/engine/src/core/loop.test.ts
+++ b/packages/engine/src/core/loop.test.ts
@@ -233,27 +233,64 @@ describe('loop', () => {
     );
   });
 
+  it('retries no-output-generated errors before giving up', async () => {
+    vi.useFakeTimers();
+    try {
+      const context: Context = {
+        messages: [{ role: 'user', content: 'test' }],
+      };
+      const noOutputError = Object.assign(new Error('No output generated.'), {
+        responseBody: '{"error":{"message":"Upstream request failed","type":"upstream_error"}}',
+      });
+      // Fail twice, then succeed on the third attempt
+      streamTextAIMock
+        .mockImplementationOnce(() => { throw noOutputError; })
+        .mockImplementationOnce(() => { throw noOutputError; })
+        .mockReturnValue({
+          text: Promise.resolve('all good'),
+          steps: Promise.resolve([{ response: { messages: [] } }]),
+          finishReason: Promise.resolve('stop'),
+        });
+
+      const resultPromise = loop(context);
+      await vi.runAllTimersAsync();
+      const result = await resultPromise;
+
+      expect(result).toBe('all good');
+      expect(streamTextAIMock).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('extracts error detail from mixed JSON+SSE responseBody on no-output errors', async () => {
-    const context: Context = {
-      messages: [{ role: 'user', content: 'test' }],
-    };
-    const sseResponseBody =
-      '{"error":{"message":"Upstream request failed","type":"upstream_error"}}' +
-      'event: response.failed\n' +
-      'data: {"type":"response.failed","response":{"id":"resp_abc","object":"response","model":"gpt-5.4","status":"failed","output":[],"error":{"code":"upstream_error","message":"Upstream request failed"}}}\n';
+    vi.useFakeTimers();
+    try {
+      const context: Context = {
+        messages: [{ role: 'user', content: 'test' }],
+      };
+      const sseResponseBody =
+        '{"error":{"message":"Upstream request failed","type":"upstream_error"}}' +
+        'event: response.failed\n' +
+        'data: {"type":"response.failed","response":{"id":"resp_abc","object":"response","model":"gpt-5.4","status":"failed","output":[],"error":{"code":"upstream_error","message":"Upstream request failed"}}}\n';
 
-    const upstreamError = Object.assign(new Error('No output generated.'), {
-      responseBody: sseResponseBody,
-    });
+      const upstreamError = Object.assign(new Error('No output generated.'), {
+        responseBody: sseResponseBody,
+      });
 
-    streamTextAIMock.mockImplementation(() => {
-      throw upstreamError;
-    });
+      streamTextAIMock.mockImplementation(() => {
+        throw upstreamError;
+      });
 
-    const result = await loop(context);
+      const resultPromise = loop(context);
+      await vi.runAllTimersAsync();
+      const result = await resultPromise;
 
-    expect(result).toContain('上游模型没有产出任何输出');
-    expect(result).toContain('Upstream request failed');
+      expect(result).toContain('上游模型没有产出任何输出');
+      expect(result).toContain('Upstream request failed');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('times out LLM calls that never produce a first chunk', async () => {

--- a/packages/engine/src/core/loop.ts
+++ b/packages/engine/src/core/loop.ts
@@ -876,7 +876,15 @@ function findJsonEnd(text: string): number {
 
 function isRetryableError(error: any): boolean {
   const status = error?.status ?? error?.statusCode;
-  return status === 429 || status === 500 || status === 502 || status === 503;
+  if (status === 429 || status === 500 || status === 502 || status === 503) {
+    return true;
+  }
+  // "No output generated" means the upstream opened a stream but produced no
+  // tokens before failing — this is a transient condition worth retrying.
+  if (typeof error?.message === 'string' && error.message.toLowerCase().includes('no output generated')) {
+    return true;
+  }
+  return false;
 }
 
 function sleep(ms: number, abortSignal?: AbortSignal): Promise<void> {

--- a/packages/engine/src/core/loop.ts
+++ b/packages/engine/src/core/loop.ts
@@ -783,7 +783,26 @@ function collectErrorMessages(value: unknown, seen = new Set<object>()): string[
       return [];
     }
     const parsed = parseJsonObject(trimmed);
-    return parsed ? [trimmed, ...collectErrorMessages(parsed, seen)] : [trimmed];
+    if (parsed) {
+      return [trimmed, ...collectErrorMessages(parsed, seen)];
+    }
+    // Parse SSE data lines so error details inside streamed responses are surfaced.
+    if (trimmed.includes('\ndata:') || trimmed.startsWith('data:')) {
+      const sseMessages: string[] = [];
+      for (const line of trimmed.split('\n')) {
+        const payload = line.startsWith('data:') ? line.slice(5).trim() : null;
+        if (payload && payload !== '[DONE]') {
+          const dataParsed = parseJsonObject(payload);
+          if (dataParsed) {
+            sseMessages.push(...collectErrorMessages(dataParsed, seen));
+          }
+        }
+      }
+      if (sseMessages.length > 0) {
+        return [trimmed, ...sseMessages];
+      }
+    }
+    return [trimmed];
   }
 
   if (typeof value !== 'object') {
@@ -812,8 +831,47 @@ function parseJsonObject(text: string): unknown | null {
   try {
     return JSON.parse(text);
   } catch {
+    // The string may be mixed content (e.g. a JSON prefix followed by SSE events).
+    // Try to extract just the leading JSON value via a balanced-delimiter scan.
+    const end = findJsonEnd(text);
+    if (end > 0 && end < text.length) {
+      try {
+        return JSON.parse(text.slice(0, end));
+      } catch {
+        // fall through
+      }
+    }
     return null;
   }
+}
+
+function findJsonEnd(text: string): number {
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (inString) {
+      if (c === '\\') escape = true;
+      else if (c === '"') inString = false;
+      continue;
+    }
+    if (c === '"') {
+      inString = true;
+      continue;
+    }
+    if (c === '{' || c === '[') {
+      depth++;
+    } else if (c === '}' || c === ']') {
+      depth--;
+      if (depth === 0) return i + 1;
+    }
+  }
+  return -1;
 }
 
 function isRetryableError(error: any): boolean {


### PR DESCRIPTION
## Summary
Enhanced error message extraction and retry logic in the engine loop to better surface error details from streamed (SSE) responses and handle transient "no output generated" failures.

## Key Changes

- **SSE error parsing**: Extended `collectErrorMessages()` to parse Server-Sent Events (SSE) format in error responses, extracting error details from `data:` lines that may be mixed with JSON prefixes.

- **Mixed JSON+SSE handling**: Added `findJsonEnd()` utility to detect and extract leading JSON values from mixed-content strings (e.g., JSON prefix followed by SSE events), allowing `parseJsonObject()` to handle hybrid response formats.

- **Transient error retry**: Updated `isRetryableError()` to treat "No output generated" errors as retryable, since these indicate the upstream opened a stream but produced no tokens before failing — a transient condition worth retrying.

- **Test coverage**: Added two new test cases:
  - Verifies retry behavior for "no output generated" errors (fails twice, succeeds on third attempt)
  - Validates error detail extraction from mixed JSON+SSE response bodies

## Implementation Details

The SSE parsing logic iterates through newline-separated lines, extracts payloads after `data:` prefixes, parses them as JSON, and recursively collects error messages. The `findJsonEnd()` function uses a balanced-delimiter scan (tracking braces/brackets and string escapes) to find the end of a complete JSON value, enabling partial extraction from mixed-content strings.

https://claude.ai/code/session_012UmT9nit4zviuf18XtwXSN