### PR TITLE
Add task cancellation, team status queries, and session health tracking

### DIFF
--- a/apps/canvas-workspace/src/main/__tests__/agent-session-send.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/agent-session-send.test.ts
@@ -106,6 +106,29 @@ describe('sendInputToAgentNode', () => {
     ]);
   });
 
+  it('serializes concurrent sends to the same node so their bytes never interleave', async () => {
+    mockCanvas = {
+      nodes: [{ id: 'n1', type: 'agent', title: 'foo', data: { status: 'running', sessionId: 'sess-1' } }],
+    };
+    liveSessions.add('sess-1');
+
+    const [first, second] = await Promise.all([
+      sendInputToAgentNode({ workspaceId: 'ws', nodeId: 'n1', input: 'first message' }),
+      sendInputToAgentNode({ workspaceId: 'ws', nodeId: 'n1', input: 'second message' }),
+    ]);
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    // Without per-node serialization both bodies would land inside each
+    // other's body→Enter gap: first, second, \r, \r.
+    expect(sessionWrites).toEqual([
+      { id: 'sess-1', data: 'first message' },
+      { id: 'sess-1', data: '\r' },
+      { id: 'sess-1', data: 'second message' },
+      { id: 'sess-1', data: '\r' },
+    ]);
+  });
+
   it('still sends Enter when the body is empty', async () => {
     mockCanvas = {
       nodes: [{ id: 'n1', type: 'agent', title: 'foo', data: { status: 'running', sessionId: 'sess-1' } }],

--- a/apps/canvas-workspace/src/main/__tests__/agent-team-canvas-nodes.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/agent-team-canvas-nodes.test.ts
@@ -468,14 +468,19 @@ describe('agent team canvas node layout', () => {
     const afterFirst = mockState.canvas!.nodes[0];
     const promptFile = afterFirst.data.promptFile as string;
     expect(promptFile).toBeTruthy();
+    // Every queue write bumps the main-owned queue revision: the canvas save
+    // merge uses it to shield queued prompts from stale renderer saves.
+    expect(afterFirst.data.queueRev).toBe(1);
 
     // Duplicate re-send is deduped (segment equality, not substring).
     await sendOrQueueAgentInput('ws-1', 'agent-q', longPrompt);
     let content = await realFs.readFile(join(cwdA, promptFile), 'utf-8');
     expect(content.match(/FIRST BRIEFING/g)).toHaveLength(1);
+    expect(mockState.canvas!.nodes[0].data.queueRev).toBe(2);
 
     // A short message CONTAINED in the long one must still be appended.
     await sendOrQueueAgentInput('ws-1', 'agent-q', 'FIRST BRIEFING');
+    expect(mockState.canvas!.nodes[0].data.queueRev).toBe(3);
     content = await realFs.readFile(join(cwdA, (mockState.canvas!.nodes[0].data.promptFile as string)), 'utf-8');
     expect(content.match(/FIRST BRIEFING/g)!.length).toBeGreaterThanOrEqual(2);
 

--- a/apps/canvas-workspace/src/main/__tests__/agent-teams-service.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/agent-teams-service.test.ts
@@ -846,6 +846,73 @@ describe('CanvasAgentTeamsService', () => {
     expect((await taskStatus())?.status).toBe('in_progress');
   });
 
+  it('teamStatus is read-only and reports per-agent session health', async () => {
+    const service = new CanvasAgentTeamsService();
+    const created = await createExecutingTeam(service);
+    const teamId = created.runtime.team.id;
+
+    const queuedBefore = mockState.queuedInputs.length;
+    const status = await service.teamStatus('ws-1', teamId);
+    await service.teamStatus('ws-1', teamId);
+
+    expect(status.runtime.team.id).toBe(teamId);
+    expect(status.runtime.tasks.length).toBeGreaterThan(0);
+    expect(Object.keys(status.sessions ?? {})).toHaveLength(status.runtime.agents.length);
+    for (const agent of status.runtime.agents) {
+      expect(status.sessions?.[agent.id]).toBe('live');
+    }
+    // A status query never nudges the lead or mutates team state.
+    expect(mockState.queuedInputs).toHaveLength(queuedBefore);
+
+    const summaries = await service.listTeamSummaries('ws-1');
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]).toMatchObject({
+      teamId,
+      name: 'Checkout Team',
+      status: 'running',
+      agentCount: 3,
+    });
+    expect(summaries[0].taskCounts.in_progress).toBe(1);
+  });
+
+  it('opens a human gate when the lead session dies and cancels it on recovery', async () => {
+    const service = new CanvasAgentTeamsService();
+    const created = await createExecutingTeam(service);
+    const teamId = created.runtime.team.id;
+    const leadDownGates = async () => {
+      const snapshot = await service.teamStatus('ws-1', teamId);
+      return snapshot.runtime.humanGates.filter((gate) => gate.metadata?.kind === 'lead-session-down');
+    };
+
+    // Every session dies (app restart without windows reopening the nodes).
+    // The first tick only marks the lead suspect; the second confirms.
+    mockState.ptyAlive = false;
+    mockState.queuedLaunch = false;
+    await service.heartbeatTick();
+    expect(await leadDownGates()).toHaveLength(0);
+    await service.heartbeatTick();
+    let gates = await leadDownGates();
+    expect(gates).toHaveLength(1);
+    expect(gates[0].status).toBe('open');
+    expect(gates[0].prompt).toContain('Team Lead');
+    // No agent/task attached: parking the lead would block its auto-resume.
+    expect(gates[0].agentId).toBeUndefined();
+    expect(gates[0].taskId).toBeUndefined();
+
+    // Further ticks do not stack duplicate gates.
+    await service.heartbeatTick();
+    await service.heartbeatTick();
+    gates = await leadDownGates();
+    expect(gates.filter((gate) => gate.status === 'open')).toHaveLength(1);
+
+    // The lead session comes back: the next snapshot settles the gate.
+    mockState.ptyAlive = true;
+    await service.snapshot('ws-1', teamId);
+    gates = await leadDownGates();
+    expect(gates.filter((gate) => gate.status === 'open')).toHaveLength(0);
+    expect(gates[0]?.status).toBe('cancelled');
+  });
+
   it('cancels a task via cancelAgentTask, releasing its scope to fallback work', async () => {
     const service = new CanvasAgentTeamsService();
     const created = await createTeam(service);

--- a/apps/canvas-workspace/src/main/__tests__/agent-teams-service.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/agent-teams-service.test.ts
@@ -788,7 +788,8 @@ describe('CanvasAgentTeamsService', () => {
     };
 
     // A queued launch prompt (headless dispatch waiting for the renderer) is
-    // healthy: the watchdog leaves the task alone no matter how many ticks.
+    // healthy while inside the launch grace window: the watchdog leaves the
+    // task alone.
     mockState.ptyAlive = false;
     mockState.queuedLaunch = true;
     await service.heartbeatTick();
@@ -810,6 +811,110 @@ describe('CanvasAgentTeamsService', () => {
     // with its task when the canvas next mounts the node.
     const prepared = await service.prepareAgentAutoResume('ws-1', teamId, owner.id);
     expect(prepared.canResume).toBe(true);
+  });
+
+  it('escalates a launch prompt that stays queued past the grace window', async () => {
+    const service = new CanvasAgentTeamsService();
+    const created = await createExecutingTeam(service);
+    const teamId = created.runtime.team.id;
+    const task = created.runtime.tasks.find((candidate) => candidate.title === 'Implement checkout refactor')!;
+    const owner = created.runtime.agents.find((agent) => agent.id === task.ownerAgentId)!;
+    const taskStatus = async () => {
+      const snapshot = await service.snapshot('ws-1', teamId);
+      return snapshot.runtime.tasks.find((candidate) => candidate.id === task.id);
+    };
+
+    // The agent's PTY is gone and its task prompt sits queued; windows are
+    // open but nothing mounts the node. The first tick only starts the
+    // grace clock.
+    mockState.ptyAlive = false;
+    mockState.queuedLaunch = true;
+    service.queuedLaunchGraceMs = 0;
+    await service.heartbeatTick();
+    expect((await taskStatus())?.status).toBe('in_progress');
+
+    // Past the grace the watchdog stops trusting the queue: the task goes to
+    // review instead of faking in_progress forever, and the reason matches
+    // the auto-resume pattern so mounting the node still recovers the task.
+    await service.heartbeatTick();
+    expect(await taskStatus()).toMatchObject({
+      status: 'needs_review',
+      blockedReason: 'Agent session was never relaunched to receive the dispatched task.',
+    });
+    const prepared = await service.prepareAgentAutoResume('ws-1', teamId, owner.id);
+    expect(prepared.canResume).toBe(true);
+    expect((await taskStatus())?.status).toBe('in_progress');
+  });
+
+  it('cancels a task via cancelAgentTask, releasing its scope to fallback work', async () => {
+    const service = new CanvasAgentTeamsService();
+    const created = await createTeam(service);
+    const teamId = created.runtime.team.id;
+    await service.proposePlan('ws-1', teamId, {
+      plan: {
+        summary: 'QA with a fallback lane.',
+        teammates: [
+          { name: 'QA Codex', agentType: 'codex' },
+          { name: 'Backup Codex', agentType: 'codex' },
+        ],
+        tasks: [
+          { title: 'QA regression', description: 'Run the regression checklist.', ownerName: 'QA Codex', scope: ['apps/web/src'] },
+        ],
+      },
+    });
+    const confirmed = await service.confirmPlan('ws-1', teamId);
+    const lead = confirmed.runtime.agents.find((agent) => agent.role === 'lead')!;
+    const teammate = confirmed.runtime.agents.find((agent) => agent.name === 'Backup Codex')!;
+    const original = confirmed.runtime.tasks.find((task) => task.title === 'QA regression')!;
+    expect(original.status).toBe('in_progress');
+
+    // The QA agent's node died; the human parks the task. Its scope still
+    // blocks the fallback task.
+    await service.blockAgentTask({ workspaceId: 'ws-1', teamId, taskId: original.id, reason: 'Agent node PTY no longer exists.' });
+    await service.createTask({
+      workspaceId: 'ws-1',
+      teamId,
+      title: 'QA regression fallback',
+      description: 'Re-run the regression on a healthy agent.',
+      ownerName: 'Backup Codex',
+      scope: ['apps/web/src'],
+      dispatch: true,
+    });
+    let snapshot = await service.snapshot('ws-1', teamId);
+    expect(snapshot.runtime.tasks.find((task) => task.title === 'QA regression fallback')).toMatchObject({
+      status: 'todo',
+      blockedReason: 'Waiting for overlapping file scope held by: QA regression',
+    });
+
+    // Teammates cannot withdraw work; cancellation is a lead/human decision.
+    await expect(service.cancelAgentTask({
+      workspaceId: 'ws-1',
+      teamId,
+      taskId: original.id,
+      reason: 'I give up.',
+      sourceAgentId: teammate.id,
+    })).rejects.toThrow('Only the Team Lead can cancel tasks');
+
+    // A human cancel settles the task and immediately dispatches the fallback.
+    snapshot = await service.cancelAgentTask({
+      workspaceId: 'ws-1',
+      teamId,
+      taskId: original.id,
+      reason: 'Agent session is gone; fallback takes over.',
+    });
+    expect(snapshot.runtime.tasks.find((task) => task.id === original.id)).toMatchObject({
+      status: 'failed',
+      result: 'Cancelled: Agent session is gone; fallback takes over.',
+    });
+    expect(snapshot.runtime.tasks.find((task) => task.title === 'QA regression fallback')).toMatchObject({
+      status: 'in_progress',
+    });
+    // The lead is told the scope is now free.
+    const leadNotice = mockState.queuedInputs
+      .filter((entry) => entry.nodeId === lead.sessionRef!.sessionId)
+      .map((entry) => entry.input)
+      .find((input) => input.includes('Task cancelled: QA regression'));
+    expect(leadNotice).toContain('Its file scope is released');
   });
 
   it('rejects create-task requests from teammates but allows the lead', async () => {

--- a/apps/canvas-workspace/src/main/__tests__/agent-teams-service.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/agent-teams-service.test.ts
@@ -1490,6 +1490,25 @@ describe('CanvasAgentTeamsService', () => {
     );
     expect(generic).toBeNull();
 
+    // The TUI echo of the task prompt wraps at terminal width, so the example
+    // marker also arrives with the placeholder truncated or cut off entirely.
+    const truncated = await service.reportAgentOutput(
+      'ws-1',
+      owner.sessionRef!.sessionId,
+      `[agent-team:human-input-needed taskId="${task.id}"] <ques\n`,
+    );
+    expect(truncated).toBeNull();
+    const empty = await service.reportAgentOutput(
+      'ws-1',
+      owner.sessionRef!.sessionId,
+      `[agent-team:human-input-needed taskId="${task.id}"]\n`,
+    );
+    expect(empty).toBeNull();
+    const unparked = await service.snapshot('ws-1', created.runtime.team.id);
+    expect(unparked.runtime.humanGates).toHaveLength(0);
+    expect(unparked.runtime.tasks[0].status).toBe('in_progress');
+    expect(unparked.runtime.agents.find((agent) => agent.id === owner.id)?.status).toBe('running');
+
     const gated = await service.reportAgentOutput(
       'ws-1',
       owner.sessionRef!.sessionId,
@@ -1507,6 +1526,38 @@ describe('CanvasAgentTeamsService', () => {
       `[agent-team:human-input-needed taskId="${task.id}"] Should I update the public API?\n`,
     );
     expect(duplicate).toBeNull();
+  });
+
+  it('cancels placeholder human gates and resumes the parked task and agent', async () => {
+    const service = new CanvasAgentTeamsService();
+    const created = await createExecutingTeam(service);
+    const teamId = created.runtime.team.id;
+    const task = created.runtime.tasks[0];
+    const owner = created.runtime.agents.find((agent) => agent.id === task.ownerAgentId)!;
+
+    // A junk gate recorded by an older build (the marker parser now rejects
+    // these at the source): the snapshot maintenance pass cancels it and
+    // un-parks the task and agent it froze.
+    const repaired = await service.openHumanGate('ws-1', teamId, {
+      taskId: task.id,
+      agentId: owner.id,
+      reason: 'Teammate requested Team Lead input',
+      prompt: 'Agent requested human input.',
+    });
+    expect(repaired.runtime.humanGates[0].status).toBe('cancelled');
+    expect(repaired.runtime.tasks[0].status).toBe('in_progress');
+    expect(repaired.runtime.agents.find((agent) => agent.id === owner.id)?.status).toBe('running');
+
+    // Gates with a concrete question are untouched by the repair.
+    const gated = await service.openHumanGate('ws-1', teamId, {
+      taskId: task.id,
+      agentId: owner.id,
+      reason: 'Need lead decision',
+      prompt: 'Should the checkout API stay stable?',
+    });
+    const concrete = gated.runtime.humanGates.find((gate) => gate.prompt === 'Should the checkout API stay stable?')!;
+    expect(concrete.status).toBe('open');
+    expect(gated.runtime.tasks[0].status).toBe('needs_input');
   });
 
   it('opens a human-facing gate when the team lead asks for human input', async () => {

--- a/apps/canvas-workspace/src/main/__tests__/canvas-store-merge.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/canvas-store-merge.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// store.ts pulls in Electron at module scope; the merge helper under test is
+// pure, so stub the runtime surface.
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+  BrowserWindow: { getAllWindows: vi.fn(() => []) },
+  dialog: { showMessageBox: vi.fn() },
+}));
+
+import { preserveMainOwnedQueueFields } from '../canvas/store';
+
+type MergeNode = Parameters<typeof preserveMainOwnedQueueFields>[0];
+
+const teamAgentNode = (
+  data: Record<string, unknown>,
+  updatedAt: number,
+): MergeNode => ({
+  id: 'node-1',
+  type: 'agent',
+  title: 'QA Codex',
+  x: 0,
+  y: 0,
+  width: 480,
+  height: 260,
+  data: { agentTeamId: 'team-1', agentTeamAgentId: 'agent-1', ...data },
+  updatedAt,
+});
+
+describe('preserveMainOwnedQueueFields', () => {
+  it('grafts a newer queued prompt from disk onto a stale renderer save', () => {
+    // Main queued a prompt (rev 2) after the renderer's snapshot (rev 1);
+    // the renderer node wins on updatedAt because its scrollback tick bumped
+    // it. The queue fields must survive the merge anyway.
+    const memory = teamAgentNode(
+      { status: 'done', inlinePrompt: '', promptFile: '', queueRev: 1, scrollback: 'fresh output' },
+      2_000,
+    );
+    const disk = teamAgentNode(
+      { status: 'running', viewMode: 'running', inlinePrompt: 'queued lead notification', promptFile: '', lastInitPrompt: 'queued lead notification', queueRev: 2 },
+      1_000,
+    );
+
+    const merged = preserveMainOwnedQueueFields(memory, disk);
+    expect(merged.data).toMatchObject({
+      inlinePrompt: 'queued lead notification',
+      lastInitPrompt: 'queued lead notification',
+      status: 'running',
+      viewMode: 'running',
+      queueRev: 2,
+      // Renderer-owned fields from the winning memory node are kept.
+      scrollback: 'fresh output',
+    });
+  });
+
+  it('lets a renderer that consumed the queue clear it (same queueRev)', () => {
+    // The renderer launched the agent with the queued prompt: its snapshot
+    // carries the same queueRev, so the legitimate clear passes through.
+    const memory = teamAgentNode(
+      { status: 'running', inlinePrompt: '', promptFile: '', queueRev: 2 },
+      2_000,
+    );
+    const disk = teamAgentNode(
+      { status: 'running', inlinePrompt: 'already consumed', promptFile: '', queueRev: 2 },
+      1_000,
+    );
+
+    const merged = preserveMainOwnedQueueFields(memory, disk);
+    expect(merged).toBe(memory);
+  });
+
+  it('ignores non-team agent nodes and non-agent nodes', () => {
+    const plainAgentMemory: MergeNode = {
+      ...teamAgentNode({ inlinePrompt: '' }, 2_000),
+      data: { inlinePrompt: '', queueRev: 0 },
+    };
+    const plainAgentDisk: MergeNode = {
+      ...teamAgentNode({ inlinePrompt: 'x' }, 1_000),
+      data: { inlinePrompt: 'x', queueRev: 5 },
+    };
+    expect(preserveMainOwnedQueueFields(plainAgentMemory, plainAgentDisk)).toBe(plainAgentMemory);
+
+    const fileMemory = { ...plainAgentMemory, type: 'file' as const };
+    const fileDisk = { ...plainAgentDisk, type: 'file' as const };
+    expect(preserveMainOwnedQueueFields(fileMemory, fileDisk)).toBe(fileMemory);
+  });
+});

--- a/apps/canvas-workspace/src/main/agent-teams/canvas-nodes.ts
+++ b/apps/canvas-workspace/src/main/agent-teams/canvas-nodes.ts
@@ -117,6 +117,9 @@ const withClaudeCliSessionId = (agentType: unknown, existing: unknown): string |
   return typeof existing === 'string' && existing ? existing : randomUUID();
 };
 
+const nextQueueRev = (data: Record<string, unknown>): number =>
+  (typeof data.queueRev === 'number' && Number.isFinite(data.queueRev) ? data.queueRev : 0) + 1;
+
 const queueLaunchPrompt = async (
   node: CanvasNode,
   prompt: string,
@@ -164,6 +167,12 @@ const queueLaunchPrompt = async (
     inlinePrompt,
     promptFile,
     lastInitPrompt: combined,
+    // Monotonic revision of the main-owned launch-queue fields. The canvas
+    // save merge uses it to protect a queued prompt from a renderer save
+    // built on a snapshot that predates this write (renderer saves always
+    // win the per-node updatedAt race because every renderer touch bumps
+    // updatedAt).
+    queueRev: nextQueueRev(data),
   };
   node.updatedAt = Date.now();
 };
@@ -636,7 +645,7 @@ export async function persistAgentNodeLaunchPrompt(
   const node = canvas.nodes?.find((item) => item.id === nodeId);
   if (!node || node.type !== 'agent') return;
   if (node.data?.lastInitPrompt === prompt) return;
-  node.data = { ...node.data, lastInitPrompt: prompt };
+  node.data = { ...node.data, lastInitPrompt: prompt, queueRev: nextQueueRev(node.data ?? {}) };
   node.updatedAt = Date.now();
   await writeCanvasFull(workspaceId, canvas);
   broadcastCanvasUpdate(workspaceId, [nodeId], 'update', 'agent-teams');

--- a/apps/canvas-workspace/src/main/agent-teams/service.ts
+++ b/apps/canvas-workspace/src/main/agent-teams/service.ts
@@ -26,13 +26,16 @@ import {
   removeAgentTeamCanvasNodes,
   stopAgentTeamCanvasNodes,
   updateAgentTeamCanvasCwd,
+  type CanvasAgentNodeRuntimeState,
 } from './canvas-nodes';
 import { CanvasAgentTeamStore } from './store';
 import { broadcastCanvasUpdate } from '../canvas/broadcast';
 import type {
   CanvasAgentTeamAddAgentInput,
+  CanvasAgentSessionHealth,
   CanvasAgentTeamBlockTaskInput,
   CanvasAgentTeamCancelTaskInput,
+  CanvasAgentTeamSummary,
   CanvasAgentTeamCompleteTaskInput,
   CanvasAgentTeamCreateInput,
   CanvasAgentTeamCreateTaskInput,
@@ -71,6 +74,9 @@ const ARTIFACT_KINDS = new Set<ArtifactKind>([
   'other',
 ]);
 const LEGACY_OUTPUT_BLOCK_REASON = 'Blocked by agent output marker.';
+// Marks the human gate the watchdog opens when the Team Lead's session is
+// confirmed unreachable; recovery auto-cancels gates of this kind.
+const LEAD_SESSION_DOWN_GATE_KIND = 'lead-session-down';
 // Both reasons route the task back through prepareAgentAutoResume: the canvas
 // relaunches the agent with its task when the node next mounts.
 const SESSION_EXIT_REVIEW_REASON_RE =
@@ -489,6 +495,7 @@ const formatLeadExecutionPrompt = (teamName: string, goal: string, content: stri
   'Declare --scope (repeatable) for tasks that edit files; tasks with overlapping scopes never run at the same time.',
   'Declare --verify for tasks that produce code; Pulse Canvas re-runs it at submission and shows you PASS/FAIL during acceptance.',
   '',
+  'Use pulse-canvas team status to ground yourself in the current tasks, agents, open questions, and pending reviews before deciding.',
   'Use pulse-canvas team send --to "Teammate name" --message "..." to share context with a teammate.',
   'Use pulse-canvas team propose-plan only when the change needs a new human-approved plan.',
   'Do not use Claude/Codex subagents for teammate work; Pulse Canvas owns teammate nodes and dispatch.',
@@ -1680,6 +1687,8 @@ export class CanvasAgentTeamsService {
     await runtime.notifyLeadReviewIfStalled(teamId);
     const metadata = await store.getTeamMetadata(teamId);
     const runtimeSnapshot = await runtime.snapshot(teamId);
+    const sessions = await this.collectSessionHealth(workspaceId, runtimeSnapshot.agents);
+    await this.cancelRecoveredLeadDownGates(store, runtimeSnapshot, sessions);
     return {
       workspaceId,
       frameNodeId: metadata?.frameNodeId,
@@ -1687,7 +1696,100 @@ export class CanvasAgentTeamsService {
       pendingPlan: metadata?.pendingPlan,
       approvedPlan: metadata?.approvedPlan,
       runtime: runtimeSnapshot,
+      sessions,
     };
+  }
+
+  /** A live lead session settles any open lead-session-down gate. */
+  private async cancelRecoveredLeadDownGates(
+    store: CanvasAgentTeamStore,
+    snapshot: RuntimeSnapshot,
+    sessions: Record<string, CanvasAgentSessionHealth>,
+  ): Promise<void> {
+    const leadId = snapshot.team.leadAgentId;
+    if (!leadId || sessions[leadId] !== 'live') return;
+    const now = Date.now();
+    for (const gate of snapshot.humanGates) {
+      if (gate.status !== 'open' || gate.metadata?.kind !== LEAD_SESSION_DOWN_GATE_KIND) continue;
+      gate.status = 'cancelled';
+      gate.updatedAt = now;
+      await store.saveHumanGate(gate);
+    }
+  }
+
+  /**
+   * Read-only team state for `pulse-canvas team status` (and any other
+   * inspection caller): the snapshot shape WITHOUT the maintenance passes
+   * and lead re-nudges that snapshotInternal performs. A status query must
+   * never mutate team state or wake the lead.
+   */
+  async teamStatus(workspaceId: string, teamId: string): Promise<CanvasAgentTeamSnapshot> {
+    return this.withTeamLock(workspaceId, teamId, async () => {
+      const { runtime, store } = this.getBundle(workspaceId);
+      const metadata = await store.getTeamMetadata(teamId);
+      const runtimeSnapshot = await runtime.snapshot(teamId);
+      return {
+        workspaceId,
+        frameNodeId: metadata?.frameNodeId,
+        phase: inferPhase(metadata, runtimeSnapshot),
+        pendingPlan: metadata?.pendingPlan,
+        approvedPlan: metadata?.approvedPlan,
+        runtime: runtimeSnapshot,
+        sessions: await this.collectSessionHealth(workspaceId, runtimeSnapshot.agents),
+      };
+    });
+  }
+
+  /** Read-only one-line-per-team overview for `pulse-canvas team status` without --team. */
+  async listTeamSummaries(workspaceId: string): Promise<CanvasAgentTeamSummary[]> {
+    const { runtime, store } = this.getBundle(workspaceId);
+    const entries = await store.listTeamMetadata();
+    const summaries: CanvasAgentTeamSummary[] = [];
+    for (const entry of entries) {
+      try {
+        const snapshot = await runtime.snapshot(entry.teamId);
+        const metadata = await store.getTeamMetadata(entry.teamId);
+        const taskCounts: Record<string, number> = {};
+        for (const task of snapshot.tasks) {
+          taskCounts[task.status] = (taskCounts[task.status] ?? 0) + 1;
+        }
+        summaries.push({
+          teamId: entry.teamId,
+          name: snapshot.team.name,
+          status: snapshot.team.status,
+          phase: inferPhase(metadata, snapshot),
+          taskCounts,
+          agentCount: snapshot.agents.length,
+        });
+      } catch (err) {
+        console.warn(`[agent-teams] failed to summarize team ${entry.teamId}:`, err);
+      }
+    }
+    return summaries;
+  }
+
+  private async collectSessionHealth(
+    workspaceId: string,
+    agents: TeamAgentRecord[],
+  ): Promise<Record<string, CanvasAgentSessionHealth>> {
+    const withSessions = agents.filter((agent) => agent.sessionRef);
+    const states = await getCanvasAgentNodesRuntimeState(
+      workspaceId,
+      withSessions.map((agent) => agent.sessionRef!.sessionId),
+    );
+    const health: Record<string, CanvasAgentSessionHealth> = {};
+    for (const agent of agents) {
+      if (!agent.sessionRef) {
+        health[agent.id] = 'missing';
+        continue;
+      }
+      const state = states.get(agent.sessionRef.sessionId);
+      if (!state || !state.exists) health[agent.id] = 'missing';
+      else if (state.ptyAlive) health[agent.id] = 'live';
+      else if (state.hasQueuedLaunch) health[agent.id] = 'queued';
+      else health[agent.id] = 'dead';
+    }
+    return health;
   }
 
   async listTeams(workspaceId: string): Promise<CanvasAgentTeamSnapshot[]> {
@@ -1832,10 +1934,16 @@ export class CanvasAgentTeamsService {
     const agents = await store.listAgents(teamId);
     const watched = agents.filter((agent) =>
       agent.status === 'running' && !!agent.currentTaskId && !!agent.sessionRef);
-    const states = await getCanvasAgentNodesRuntimeState(
-      workspaceId,
-      watched.map((agent) => agent.sessionRef!.sessionId),
-    );
+    const team = await store.getTeam(teamId);
+    const lead = team?.leadAgentId ? agents.find((agent) => agent.id === team.leadAgentId) : undefined;
+    const sessionIds = watched.map((agent) => agent.sessionRef!.sessionId);
+    if (lead?.sessionRef && !sessionIds.includes(lead.sessionRef.sessionId)) {
+      sessionIds.push(lead.sessionRef.sessionId);
+    }
+    const states = await getCanvasAgentNodesRuntimeState(workspaceId, sessionIds);
+    if (team && lead) {
+      await this.watchdogCheckLeadSession(workspaceId, teamId, team.status, lead, states, runtime, store);
+    }
     for (const agent of agents) {
       const suspectKey = `${workspaceId}:${agent.id}`;
       if (agent.status !== 'running' || !agent.currentTaskId || !agent.sessionRef) {
@@ -1884,6 +1992,69 @@ export class CanvasAgentTeamsService {
         agent.id,
       );
     }
+  }
+
+  /**
+   * The regular watchdog never covers the Team Lead — it has no
+   * currentTaskId — so a dead lead session stalls the whole team invisibly:
+   * teammate questions and completed-task reviews queue up with nothing
+   * processing them. When the lead's session is confirmed unreachable while
+   * the team depends on it, open a HUMAN gate (visible in the team frame)
+   * instead of notifying the lead, which would only queue onto the dead
+   * session. The gate carries no agentId/taskId: parking the lead as
+   * needs_input would block the canvas auto-resume that is the actual
+   * recovery path. Recovery is auto-detected and cancels the gate.
+   */
+  private async watchdogCheckLeadSession(
+    workspaceId: string,
+    teamId: string,
+    teamStatus: string,
+    lead: TeamAgentRecord,
+    states: Map<string, CanvasAgentNodeRuntimeState>,
+    runtime: TeamRuntime,
+    store: CanvasAgentTeamStore,
+  ): Promise<void> {
+    const suspectKey = `${workspaceId}:lead-session:${lead.id}`;
+    // The team only depends on a live lead while executing or in final
+    // review; during briefing/plan review the human is already in the loop.
+    const leadRequired = (teamStatus === 'running' || teamStatus === 'reviewing') && !!lead.sessionRef;
+    const state = lead.sessionRef ? states.get(lead.sessionRef.sessionId) : undefined;
+    if (!leadRequired || state?.ptyAlive) {
+      this.watchdogSuspects.delete(suspectKey);
+      this.queuedLaunchSince.delete(suspectKey);
+      return;
+    }
+    if (state?.hasQueuedLaunch) {
+      // Same grace as teammate queued launches: a mounted workspace drains
+      // the queue within seconds; past the grace nothing is going to.
+      this.watchdogSuspects.delete(suspectKey);
+      const now = Date.now();
+      const since = this.queuedLaunchSince.get(suspectKey);
+      if (since === undefined) {
+        this.queuedLaunchSince.set(suspectKey, now);
+        return;
+      }
+      if (now - since < this.queuedLaunchGraceMs) return;
+      this.queuedLaunchSince.delete(suspectKey);
+    } else {
+      this.queuedLaunchSince.delete(suspectKey);
+      if (!this.watchdogSuspects.has(suspectKey)) {
+        this.watchdogSuspects.add(suspectKey);
+        return;
+      }
+      this.watchdogSuspects.delete(suspectKey);
+    }
+
+    const gates = await store.listHumanGates(teamId);
+    const alreadyOpen = gates.some((gate) =>
+      gate.status === 'open' && gate.metadata?.kind === LEAD_SESSION_DOWN_GATE_KIND);
+    if (alreadyOpen) return;
+    await runtime.openHumanGate({
+      teamId,
+      reason: 'Team Lead session unreachable',
+      prompt: 'The Team Lead\'s agent session is not running, so coordination is stalled: teammate questions and completed-task reviews are queueing up with nothing processing them. Open this workspace\'s window to relaunch the lead automatically, or restart the lead agent node.',
+      metadata: { kind: LEAD_SESSION_DOWN_GATE_KIND },
+    });
   }
 
   /**

--- a/apps/canvas-workspace/src/main/agent-teams/service.ts
+++ b/apps/canvas-workspace/src/main/agent-teams/service.ts
@@ -32,6 +32,7 @@ import { broadcastCanvasUpdate } from '../canvas/broadcast';
 import type {
   CanvasAgentTeamAddAgentInput,
   CanvasAgentTeamBlockTaskInput,
+  CanvasAgentTeamCancelTaskInput,
   CanvasAgentTeamCompleteTaskInput,
   CanvasAgentTeamCreateInput,
   CanvasAgentTeamCreateTaskInput,
@@ -70,7 +71,18 @@ const ARTIFACT_KINDS = new Set<ArtifactKind>([
   'other',
 ]);
 const LEGACY_OUTPUT_BLOCK_REASON = 'Blocked by agent output marker.';
-const SESSION_EXIT_REVIEW_REASON_RE = /^Agent session exited(?: with code -?\d+)? before reporting task completion\.$/;
+// Both reasons route the task back through prepareAgentAutoResume: the canvas
+// relaunches the agent with its task when the node next mounts.
+const SESSION_EXIT_REVIEW_REASON_RE =
+  /^Agent session (?:exited(?: with code -?\d+)? before reporting task completion|was never relaunched to receive the dispatched task)\.$/;
+const QUEUED_LAUNCH_REVIEW_REASON = 'Agent session was never relaunched to receive the dispatched task.';
+// How long a dispatched task may sit as a queued launch prompt (agent PTY
+// dead, prompt waiting for the renderer to spawn the node) while windows are
+// open before the watchdog stops trusting it. Within the grace it is the
+// normal headless-dispatch state; past it, nothing is going to mount the node
+// — the workspace is not open in any window — and leaving the task
+// in_progress fakes progress forever.
+const QUEUED_LAUNCH_GRACE_MS = 2 * 60_000;
 const AGENT_TEAM_MARKER_RE =
   /^\s*\[agent-team:(?<kind>plan|human-input-needed|artifact)(?:\s+taskId="(?<taskId>[^"]+)")?(?:\s+kind="(?<artifactKind>[^"]+)")?(?:\s+title="(?<artifactTitle>[^"]+)")?\]\s*(?<text>.*)\s*$/;
 
@@ -497,6 +509,11 @@ export class CanvasAgentTeamsService {
   // long while holding a task, the lead is nudged (no state change). Public so
   // tests can shrink the window.
   softStallThresholdMs = SOFT_STALL_THRESHOLD_MS;
+  // Queued-launch grace before the watchdog escalates (public for tests).
+  queuedLaunchGraceMs = QUEUED_LAUNCH_GRACE_MS;
+  // First heartbeat tick that observed each agent's current queued launch
+  // prompt with no live PTY; cleared when the PTY appears or the queue drains.
+  private readonly queuedLaunchSince = new Map<string, number>();
   private readonly lastAgentOutputAt = new Map<string, number>();
   private readonly softStallNudgedAt = new Map<string, number>();
   // nodeId -> agent identity for the PTY hot path (one entry per team node).
@@ -1240,6 +1257,30 @@ export class CanvasAgentTeamsService {
     return this.snapshotInternal(input.workspaceId, input.teamId);
   }
 
+  async cancelAgentTask(input: CanvasAgentTeamCancelTaskInput): Promise<CanvasAgentTeamSnapshot> {
+    return this.withTeamLock(input.workspaceId, input.teamId, () => this.cancelAgentTaskLocked(input));
+  }
+
+  private async cancelAgentTaskLocked(input: CanvasAgentTeamCancelTaskInput): Promise<CanvasAgentTeamSnapshot> {
+    const { runtime } = this.getBundle(input.workspaceId);
+    const snapshot = await runtime.snapshot(input.teamId);
+    const agent = input.sourceAgentId
+      ? this.resolveAgentReference(snapshot.agents, input.sourceAgentId)
+      : undefined;
+    // Cancellation withdraws work and releases its file scope for replacement
+    // tasks — a routing decision that belongs to the lead or the human, not
+    // to the teammate holding the task (a stuck teammate blocks instead).
+    if (agent && agent.role !== 'lead') {
+      throw new Error('Only the Team Lead can cancel tasks. Use block-task to report a blocker instead.');
+    }
+    const task = this.resolveTaskForAction(snapshot.tasks, input.taskId, agent);
+    await runtime.cancelTask(task.id, input.reason, agent?.id ?? 'human');
+    // The cancelled task no longer holds its scope: dispatch immediately so
+    // an overlapping fallback task starts now instead of on the next tick.
+    await runtime.dispatchReadyTasks(input.teamId);
+    return this.snapshotInternal(input.workspaceId, input.teamId);
+  }
+
   async requestHumanInput(input: CanvasAgentTeamRequestHumanInput): Promise<CanvasAgentTeamSnapshot> {
     return this.withTeamLock(input.workspaceId, input.teamId, () => this.requestHumanInputLocked(input));
   }
@@ -1760,8 +1801,11 @@ export class CanvasAgentTeamsService {
    * Detect agents whose recorded session no longer exists — an app restart or
    * crash killed the PTY without an observed exit, or the canvas node was
    * deleted — and route their in-flight task through the session-exit review
-   * path. The reason string matches the auto-resume pattern, so the canvas
-   * relaunches the agent when its node next mounts.
+   * path. Also escalates launch prompts that stay queued past the grace
+   * window while windows are open (nothing is mounting the node, so the
+   * in_progress task is fake progress). Either reason string matches the
+   * auto-resume pattern, so the canvas relaunches the agent when its node
+   * next mounts.
    */
   private async watchdogCheckAgents(workspaceId: string, teamId: string): Promise<void> {
     // Suspended while no window is open: nothing can relaunch agents, so
@@ -1780,19 +1824,39 @@ export class CanvasAgentTeamsService {
       const suspectKey = `${workspaceId}:${agent.id}`;
       if (agent.status !== 'running' || !agent.currentTaskId || !agent.sessionRef) {
         this.watchdogSuspects.delete(suspectKey);
+        this.queuedLaunchSince.delete(suspectKey);
         continue;
       }
       const state = states.get(agent.sessionRef.sessionId)
         ?? { exists: false, status: 'missing', ptyAlive: false, hasQueuedLaunch: false };
-      // A queued launch prompt means the agent is waiting for the renderer to
-      // spawn it — healthy headless state, not a dead session.
-      if (state.ptyAlive || state.hasQueuedLaunch) {
+      if (state.ptyAlive) {
         this.watchdogSuspects.delete(suspectKey);
-        if (state.ptyAlive) {
-          await this.checkSoftStall(workspaceId, runtime, agent);
-        }
+        this.queuedLaunchSince.delete(suspectKey);
+        await this.checkSoftStall(workspaceId, runtime, agent);
         continue;
       }
+      // A queued launch prompt means the agent is waiting for the renderer to
+      // spawn it — the normal headless-dispatch state. But a renderer with
+      // the workspace open picks the queue up within seconds, so a prompt
+      // still queued long after windows opened means nothing will mount the
+      // node and the in_progress task is going nowhere. Route it through the
+      // session review path: visible to the lead and human, and the reason
+      // matches the auto-resume pattern so mounting the node still recovers
+      // the task automatically.
+      if (state.hasQueuedLaunch) {
+        this.watchdogSuspects.delete(suspectKey);
+        const now = Date.now();
+        const since = this.queuedLaunchSince.get(suspectKey);
+        if (since === undefined) {
+          this.queuedLaunchSince.set(suspectKey, now);
+          continue;
+        }
+        if (now - since < this.queuedLaunchGraceMs) continue;
+        this.queuedLaunchSince.delete(suspectKey);
+        await runtime.requestTaskReview(agent.currentTaskId, QUEUED_LAUNCH_REVIEW_REASON, agent.id);
+        continue;
+      }
+      this.queuedLaunchSince.delete(suspectKey);
       if (!this.watchdogSuspects.has(suspectKey)) {
         this.watchdogSuspects.add(suspectKey);
         continue;

--- a/apps/canvas-workspace/src/main/agent-teams/service.ts
+++ b/apps/canvas-workspace/src/main/agent-teams/service.ts
@@ -112,15 +112,28 @@ const stripAnsi = (value: string): string =>
     .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
     .replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, '');
 
+/**
+ * A human-input marker is only actionable with a concrete question. Task
+ * prompts contain the literal fallback example
+ * `[agent-team:human-input-needed taskId="..."] <question>`, and the TUI
+ * echo of that prompt re-enters the PTY output — line-wrapped at terminal
+ * width, so the placeholder arrives whole (`<question>`), truncated
+ * (`<ques`), or cut off entirely (empty text). Opening gates for those
+ * floods the Team Lead backlog with unanswerable questions and parks the
+ * task/agent in needs_input even though the agent is actually working.
+ */
+const isPlaceholderHumanInputText = (text: string): boolean =>
+  !text
+  || text.startsWith('<')
+  || /^agent requested human input\.?$/i.test(text)
+  || /^human input requested\.?$/i.test(text);
+
 const parseAgentOutputMarker = (line: string): AgentOutputMarker | null => {
   const match = AGENT_TEAM_MARKER_RE.exec(stripAnsi(line).trim());
   if (!match?.groups) return null;
   const text = match.groups.text.trim();
   if (/^<[^>]+>$/.test(text)) return null;
-  if (
-    match.groups.kind === 'human-input-needed'
-    && /^agent requested human input\.?$/i.test(text)
-  ) return null;
+  if (match.groups.kind === 'human-input-needed' && isPlaceholderHumanInputText(text)) return null;
   return {
     kind: match.groups.kind as AgentOutputMarkerKind,
     taskId: match.groups.taskId,
@@ -1584,6 +1597,7 @@ export class CanvasAgentTeamsService {
     await ensureAgentTeamCanvasLayout(workspaceId, teamId);
     await this.repairLegacyOutputMarkerBlocks(store, teamId);
     await this.repairAnsweredHumanGateBlocks(store, teamId);
+    await this.repairPlaceholderHumanGates(store, teamId);
 
     const [team, agent, tasks, metadata] = await Promise.all([
       store.getTeam(teamId),
@@ -1660,6 +1674,7 @@ export class CanvasAgentTeamsService {
     await ensureAgentTeamCanvasLayout(workspaceId, teamId);
     await this.repairLegacyOutputMarkerBlocks(store, teamId);
     await this.repairAnsweredHumanGateBlocks(store, teamId);
+    await this.repairPlaceholderHumanGates(store, teamId);
     await runtime.notifyLeadPendingGates(teamId);
     await runtime.notifyLeadPendingTaskReviews(teamId);
     await runtime.notifyLeadReviewIfStalled(teamId);
@@ -1737,6 +1752,7 @@ export class CanvasAgentTeamsService {
             await this.watchdogCheckAgents(workspaceId, entry.teamId);
             await this.repairLegacyOutputMarkerBlocks(store, entry.teamId);
             await this.repairAnsweredHumanGateBlocks(store, entry.teamId);
+            await this.repairPlaceholderHumanGates(store, entry.teamId);
             await runtime.repairCurrentRound(entry.teamId);
             await runtime.notifyLeadPendingGates(entry.teamId);
             await runtime.notifyLeadPendingTaskReviews(entry.teamId);
@@ -2184,6 +2200,56 @@ export class CanvasAgentTeamsService {
         agent.status = 'running';
         agent.updatedAt = now;
         await store.saveAgent(agent);
+      }
+    }
+  }
+
+  /**
+   * Cancel open human gates whose prompt carries no concrete question —
+   * junk recorded before the marker parser filtered echoed/wrapped prompt
+   * examples. Such gates nag the Team Lead with unanswerable digests and
+   * park their task/agent in needs_input although the agent never actually
+   * asked anything; once cancelled, the parked records resume.
+   */
+  private async repairPlaceholderHumanGates(store: CanvasAgentTeamStore, teamId: string): Promise<void> {
+    const gates = await store.listHumanGates(teamId);
+    const junk = gates.filter((gate) => gate.status === 'open' && isPlaceholderHumanInputText(gate.prompt.trim()));
+    if (junk.length === 0) return;
+
+    const now = Date.now();
+    for (const gate of junk) {
+      gate.status = 'cancelled';
+      gate.updatedAt = now;
+      await store.saveHumanGate(gate);
+    }
+
+    const [tasks, agents, refreshedGates] = await Promise.all([
+      store.listTasks(teamId),
+      store.listAgents(teamId),
+      store.listHumanGates(teamId),
+    ]);
+    const remainingOpen = refreshedGates.filter((gate) => gate.status === 'open');
+    const openTaskIds = new Set(remainingOpen.map((gate) => gate.taskId).filter(Boolean));
+    const openAgentIds = new Set(remainingOpen.map((gate) => gate.agentId).filter(Boolean));
+    const agentsById = new Map(agents.map((agent) => [agent.id, agent]));
+
+    for (const gate of junk) {
+      if (gate.taskId && !openTaskIds.has(gate.taskId)) {
+        const task = tasks.find((candidate) => candidate.id === gate.taskId);
+        if (task && task.status === 'needs_input') {
+          task.status = task.ownerAgentId ? 'in_progress' : 'todo';
+          task.blockedReason = undefined;
+          task.updatedAt = now;
+          await store.saveTask(task);
+        }
+      }
+      if (gate.agentId && !openAgentIds.has(gate.agentId)) {
+        const agent = agentsById.get(gate.agentId);
+        if (agent && agent.status === 'needs_input') {
+          agent.status = agent.currentTaskId ? 'running' : 'idle';
+          agent.updatedAt = now;
+          await store.saveAgent(agent);
+        }
       }
     }
   }

--- a/apps/canvas-workspace/src/main/agent-teams/types.ts
+++ b/apps/canvas-workspace/src/main/agent-teams/types.ts
@@ -98,6 +98,14 @@ export interface CanvasAgentTeamBlockTaskInput extends CanvasAgentTeamTaskAction
   reason: string;
 }
 
+/**
+ * Cancel (withdraw) a task so it settles as failed and releases its declared
+ * file scope for replacement work. Lead/human only.
+ */
+export interface CanvasAgentTeamCancelTaskInput extends CanvasAgentTeamTaskActionInput {
+  reason: string;
+}
+
 export interface CanvasAgentTeamRequestHumanInput extends CanvasAgentTeamTaskActionInput {
   prompt: string;
   reason?: string;

--- a/apps/canvas-workspace/src/main/agent-teams/types.ts
+++ b/apps/canvas-workspace/src/main/agent-teams/types.ts
@@ -118,6 +118,15 @@ export interface CanvasAgentTeamPublishArtifactInput extends CanvasAgentTeamTask
   summary?: string;
 }
 
+/**
+ * Liveness of an agent's PTY session as seen from the main process:
+ * - `live`: PTY is running and can receive input now.
+ * - `queued`: no PTY, but a launch prompt is queued — delivers on relaunch.
+ * - `dead`: node exists, no PTY, nothing queued.
+ * - `missing`: no session ref or the canvas node is gone.
+ */
+export type CanvasAgentSessionHealth = 'live' | 'queued' | 'dead' | 'missing';
+
 export interface CanvasAgentTeamSnapshot {
   workspaceId: string;
   frameNodeId?: string;
@@ -125,6 +134,17 @@ export interface CanvasAgentTeamSnapshot {
   pendingPlan?: CanvasAgentTeamPlanDraft;
   approvedPlan?: CanvasAgentTeamPlanDraft;
   runtime: import('pulse-coder-agent-teams/runtime').RuntimeSnapshot;
+  /** Per-agent session liveness, keyed by agent id. */
+  sessions?: Record<string, CanvasAgentSessionHealth>;
+}
+
+export interface CanvasAgentTeamSummary {
+  teamId: string;
+  name: string;
+  status: string;
+  phase: CanvasAgentTeamPhase;
+  taskCounts: Record<string, number>;
+  agentCount: number;
 }
 
 export type CanvasAgentTeamResult<T> =

--- a/apps/canvas-workspace/src/main/agent/session-send.ts
+++ b/apps/canvas-workspace/src/main/agent/session-send.ts
@@ -72,9 +72,14 @@ export async function sendInputToAgentNode(
 
   const sessionId = (node.data?.sessionId as string | undefined) ?? '';
   if (!sessionId || !hasSession(sessionId)) {
+    // Team-managed agents have a queue-based delivery path that survives a
+    // dead PTY; point callers there instead of dead-ending.
+    const teamHint = typeof node.data?.agentTeamId === 'string'
+      ? ' This is a team agent node: open its workspace window to relaunch it, or use "pulse-canvas team send", which queues the message until the agent relaunches.'
+      : '';
     return {
       ok: false,
-      error: `agent node "${node.title ?? nodeId}" has no active PTY session`,
+      error: `agent node "${node.title ?? nodeId}" has no active PTY session.${teamHint}`,
       code: 'no_session',
     };
   }

--- a/apps/canvas-workspace/src/main/agent/session-send.ts
+++ b/apps/canvas-workspace/src/main/agent/session-send.ts
@@ -37,7 +37,26 @@ const POST_SUBMIT_CONFIRM_MS = 350;
 const wait = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
-export async function sendInputToAgentNode(
+// One in-flight send per agent node. The body→Enter submit sequence spans
+// ~470ms of deliberate gaps; concurrent senders (team notifications, manual
+// `agent send`, gate answers) would interleave their bytes inside each
+// other's gaps and submit garbled half-messages.
+const nodeSendQueues = new Map<string, Promise<unknown>>();
+
+export function sendInputToAgentNode(
+  input: SendInputToAgentNodeInput,
+): Promise<SendInputToAgentNodeResult> {
+  const key = `${input.workspaceId}:${input.nodeId}`;
+  const previous = nodeSendQueues.get(key) ?? Promise.resolve();
+  const next = previous.then(
+    () => sendInputToAgentNodeSerialized(input),
+    () => sendInputToAgentNodeSerialized(input),
+  );
+  nodeSendQueues.set(key, next.catch(() => {}));
+  return next;
+}
+
+async function sendInputToAgentNodeSerialized(
   input: SendInputToAgentNodeInput,
 ): Promise<SendInputToAgentNodeResult> {
   const { workspaceId, nodeId } = input;

--- a/apps/canvas-workspace/src/main/canvas/store.ts
+++ b/apps/canvas-workspace/src/main/canvas/store.ts
@@ -542,6 +542,42 @@ const ensureMigrated = async (workspaceId: string): Promise<void> => {
   });
 };
 
+/**
+ * Launch-queue fields on team-managed agent nodes (queued prompt, replay
+ * prompt, launch status) are written by the MAIN process and carry a
+ * monotonically increasing `data.queueRev`. Renderer saves win the per-node
+ * `updatedAt` race almost by definition — every renderer touch (including
+ * pure scrollback ticks) bumps `updatedAt` — so a save built on a snapshot
+ * that predates the latest queue write would silently erase a queued prompt
+ * the agent never received. When the disk copy carries a newer queueRev,
+ * graft the queue fields onto the otherwise-winning memory node. A renderer
+ * that consumed the queue (launched the agent) has, by construction, synced
+ * the same queueRev first, so legitimate clears pass through untouched.
+ *
+ * Exported for tests.
+ */
+export const preserveMainOwnedQueueFields = (memNode: CanvasNode, diskNode: CanvasNode): CanvasNode => {
+  if (memNode.type !== 'agent') return memNode;
+  const memData = (memNode.data ?? {}) as Record<string, unknown>;
+  const diskData = (diskNode.data ?? {}) as Record<string, unknown>;
+  if (typeof diskData.agentTeamId !== 'string') return memNode;
+  const diskRev = typeof diskData.queueRev === 'number' ? diskData.queueRev : 0;
+  const memRev = typeof memData.queueRev === 'number' ? memData.queueRev : 0;
+  if (diskRev <= memRev) return memNode;
+  return {
+    ...memNode,
+    data: {
+      ...memData,
+      inlinePrompt: diskData.inlinePrompt,
+      promptFile: diskData.promptFile,
+      lastInitPrompt: diskData.lastInitPrompt,
+      status: diskData.status,
+      viewMode: diskData.viewMode,
+      queueRev: diskRev,
+    } as CanvasNode['data'],
+  };
+};
+
 const mergeExternalNodes = async (
   id: string,
   inMemoryData: CanvasSaveData,
@@ -623,7 +659,7 @@ const mergeExternalNodes = async (
     }
     const memTs = typeof memNode.updatedAt === 'number' ? memNode.updatedAt : 0;
     const diskTs = typeof diskNode.updatedAt === 'number' ? diskNode.updatedAt : 0;
-    mergedExisting.push(diskTs > memTs ? diskNode : memNode);
+    mergedExisting.push(diskTs > memTs ? diskNode : preserveMainOwnedQueueFields(memNode, diskNode));
   }
 
   // Rule 2: nodes only on disk and never-seen → CLI creates, add them.

--- a/apps/canvas-workspace/src/main/runtime/control-server.ts
+++ b/apps/canvas-workspace/src/main/runtime/control-server.ts
@@ -306,6 +306,9 @@ async function handleRequest(
   if (req.url === '/agent-team/block-task') {
     return handleAgentTeamBlockTask(res, parsed as Record<string, unknown>);
   }
+  if (req.url === '/agent-team/cancel-task') {
+    return handleAgentTeamCancelTask(res, parsed as Record<string, unknown>);
+  }
   if (req.url === '/agent-team/request-human-input') {
     return handleAgentTeamRequestHumanInput(res, parsed as Record<string, unknown>);
   }
@@ -474,6 +477,25 @@ async function handleAgentTeamBlockTask(
 
   try {
     const snapshot = await getCanvasAgentTeamsService().blockAgentTask({ ...base, reason });
+    return reply(res, 200, { ok: true, snapshot });
+  } catch (err) {
+    return reply(res, 400, { ok: false, error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+async function handleAgentTeamCancelTask(
+  res: ServerResponse,
+  obj: Record<string, unknown>,
+): Promise<void> {
+  const base = readTeamTaskAction(obj);
+  const reason = typeof obj.reason === 'string' ? obj.reason.trim() : '';
+  if (!base.workspaceId || !base.teamId) {
+    return reply(res, 400, { ok: false, error: 'workspaceId and teamId are required' });
+  }
+  if (!reason) return reply(res, 400, { ok: false, error: 'reason is required' });
+
+  try {
+    const snapshot = await getCanvasAgentTeamsService().cancelAgentTask({ ...base, reason });
     return reply(res, 200, { ok: true, snapshot });
   } catch (err) {
     return reply(res, 400, { ok: false, error: err instanceof Error ? err.message : String(err) });

--- a/apps/canvas-workspace/src/main/runtime/control-server.ts
+++ b/apps/canvas-workspace/src/main/runtime/control-server.ts
@@ -324,6 +324,9 @@ async function handleRequest(
   if (req.url === '/agent-team/send') {
     return handleAgentTeamSend(res, parsed as Record<string, unknown>);
   }
+  if (req.url === '/agent-team/status') {
+    return handleAgentTeamStatus(res, parsed as Record<string, unknown>);
+  }
 
   return reply(res, 404, { ok: false, error: 'not found' });
 }
@@ -478,6 +481,34 @@ async function handleAgentTeamBlockTask(
   try {
     const snapshot = await getCanvasAgentTeamsService().blockAgentTask({ ...base, reason });
     return reply(res, 200, { ok: true, snapshot });
+  } catch (err) {
+    return reply(res, 400, { ok: false, error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+/**
+ * Read-only status: with teamId returns the full team snapshot (including
+ * per-agent session health); without it returns one-line team summaries.
+ * Never mutates team state or wakes the lead.
+ */
+async function handleAgentTeamStatus(
+  res: ServerResponse,
+  obj: Record<string, unknown>,
+): Promise<void> {
+  const workspaceId = typeof obj.workspaceId === 'string' ? obj.workspaceId : '';
+  const teamId = typeof obj.teamId === 'string' && obj.teamId.trim() ? obj.teamId.trim() : undefined;
+  if (!workspaceId) {
+    return reply(res, 400, { ok: false, error: 'workspaceId is required' });
+  }
+
+  try {
+    const service = getCanvasAgentTeamsService();
+    if (teamId) {
+      const snapshot = await service.teamStatus(workspaceId, teamId);
+      return reply(res, 200, { ok: true, snapshot });
+    }
+    const teams = await service.listTeamSummaries(workspaceId);
+    return reply(res, 200, { ok: true, teams });
   } catch (err) {
     return reply(res, 400, { ok: false, error: err instanceof Error ? err.message : String(err) });
   }

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/useAgentNodeController.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/useAgentNodeController.ts
@@ -690,6 +690,14 @@ export const useAgentNodeController = ({
               : ''
           : '';
         const commonFlags = dangerousFlag + (agentArgs ? ` ${agentArgs}` : '');
+        // Team nodes run the CLI inside an interactive shell. If the CLI dies
+        // (crash, /quit, context exhaustion) the shell survives, so the node
+        // still reports a live "running" session — and every team
+        // notification queued for this agent gets typed INTO BASH: lost for
+        // the agent and executed as shell commands. Exiting the shell with
+        // the CLI turns CLI death into an observable PTY exit, which feeds
+        // the session-exit review path and the auto-resume relaunch.
+        const teamExitSuffix = dataRef.current.agentTeamId ? '; exit' : '';
 
         if (agentType === 'claude-code' && resumeMode && canResumeClaude && !effectivePrompt && !promptFile) {
           const fallbackSessionId = crypto.randomUUID();
@@ -704,7 +712,7 @@ export const useAgentNodeController = ({
               ' || (',
               `printf '%s\\n' ${shellQuote(fallbackNotice)}`,
               `; ${command}${fallbackFlags} ${shellQuote(fallbackPrompt)}`,
-              ')\n',
+              `)${teamExitSuffix}\n`,
             ].join(''),
           );
         } else if (agentType === 'codex' && resumeMode && !effectivePrompt && !promptFile) {
@@ -714,25 +722,25 @@ export const useAgentNodeController = ({
             setLoading(false);
             return;
           }
-          api.write(sessionId, `${command}${commonFlags} resume ${shellQuote(codexSessionId)}\n`);
+          api.write(sessionId, `${command}${commonFlags} resume ${shellQuote(codexSessionId)}${teamExitSuffix}\n`);
         } else {
           const flags =
             (agentType === 'claude-code'
               ? ` ${resumeMode && canResumeClaude ? '--resume' : '--session-id'} ${cliSessionId}`
               : '') + commonFlags;
           if (promptForCommand) {
-            api.write(sessionId, `${command}${flags} ${shellQuote(promptForCommand)}\n`);
+            api.write(sessionId, `${command}${flags} ${shellQuote(promptForCommand)}${teamExitSuffix}\n`);
           } else if (promptFile) {
             if (codexBindingMarker) {
               api.write(
                 sessionId,
-                `__prompt=$(printf '%s\\n\\n%s' "$(cat ${shellQuote(promptFile)})" ${shellQuote(codexBindingComment(codexBindingMarker))}) && ${command}${flags} "$__prompt"\n`,
+                `__prompt=$(printf '%s\\n\\n%s' "$(cat ${shellQuote(promptFile)})" ${shellQuote(codexBindingComment(codexBindingMarker))}) && ${command}${flags} "$__prompt"${teamExitSuffix}\n`,
               );
             } else {
-              api.write(sessionId, `__prompt=$(cat ${promptFile}) && ${command}${flags} "$__prompt"\n`);
+              api.write(sessionId, `__prompt=$(cat ${promptFile}) && ${command}${flags} "$__prompt"${teamExitSuffix}\n`);
             }
           } else {
-            api.write(sessionId, `${command}${flags}\n`);
+            api.write(sessionId, `${command}${flags}${teamExitSuffix}\n`);
           }
         }
 
@@ -816,6 +824,15 @@ export const useAgentNodeController = ({
         onUpdateRef.current(nodeIdRef.current, {
           data: { ...dataRef.current, status: 'done' },
         });
+        // A team-managed agent must stay relaunchable while mounted: every
+        // launch effect bails while viewMode is 'running', so keeping it
+        // there after the PTY died would strand everything the main process
+        // queues afterwards (lead notifications, redispatched tasks) until
+        // the node happens to remount. Dropping to the restart view re-arms
+        // the queued-launch and team auto-resume effects.
+        if (dataRef.current.agentTeamId) {
+          setViewMode('restart');
+        }
       });
 
       const currentData = dataRef.current;

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
@@ -56,6 +56,16 @@ const TASK_STATUS_RANK: Record<string, number> = {
 const statusLabel = (status: string) =>
   TASK_STATUS_LABELS[status] ?? status.replace(/_/g, ' ');
 
+// Appended to an agent's status chip when its PTY session cannot receive
+// input right now: 'offline' needs a relaunch (reopen/restart the node),
+// 'queued' means messages wait for the renderer to spawn it.
+const sessionHealthSuffix = (health?: string): string =>
+  health === 'dead' || health === 'missing'
+    ? ' · offline'
+    : health === 'queued'
+      ? ' · queued'
+      : '';
+
 const inferPhase = (
   explicit: AgentTeamPhase | undefined,
   teammates: AgentTeamAgentRecord[],
@@ -221,6 +231,7 @@ interface GraphAgentItem {
   currentTaskTitle?: string;
   nodeId?: string;
   sourceAgent?: AgentTeamAgentRecord;
+  sessionHealth?: string;
 }
 
 const DAG_NODE_WIDTH = 236;
@@ -686,9 +697,10 @@ export const AgentTeamFrame = ({
             ? agent.sessionRef.metadata.nodeId
             : undefined,
         sourceAgent: agent,
+        sessionHealth: snapshot?.sessions?.[agent.id],
       };
     });
-  }, [artifacts, graphTaskByKey, graphTasks, phase, plan, teammates]);
+  }, [artifacts, graphTaskByKey, graphTasks, phase, plan, teammates, snapshot?.sessions]);
   const selectedGraphAgent = graphAgents.find((agent) => agent.key === selectedAgentKey);
   const agentTypeByOwnerKey = useMemo(
     () => new Map(graphAgents.map((agent) => [agent.key, agent.agentType])),
@@ -1361,7 +1373,7 @@ export const AgentTeamFrame = ({
       <div className="agent-team-lead-dock__head">
         <strong>{lead?.name ?? 'Team Lead'}</strong>
         <span className={`agent-team-detail__status agent-team-detail__status--${lead?.status ?? 'idle'}`}>
-          {statusLabel(lead?.status ?? 'idle')}
+          {statusLabel(lead?.status ?? 'idle')}{sessionHealthSuffix(lead ? snapshot?.sessions?.[lead.id] : undefined)}
         </span>
       </div>
 
@@ -1444,7 +1456,7 @@ export const AgentTeamFrame = ({
             <strong>{selectedGraphAgent.name}</strong>
           </div>
           <span className={`agent-team-detail__status agent-team-detail__status--${selectedGraphAgent.status}`}>
-            {statusLabel(selectedGraphAgent.status)}
+            {statusLabel(selectedGraphAgent.status)}{sessionHealthSuffix(selectedGraphAgent.sessionHealth)}
           </span>
         </div>
 
@@ -1731,7 +1743,7 @@ export const AgentTeamFrame = ({
                 {agent.name}
               </span>
               <span className={`agent-team-detail__status agent-team-detail__status--${agent.status}`}>
-                {statusLabel(agent.status)}
+                {statusLabel(agent.status)}{sessionHealthSuffix(agent.sessionHealth)}
               </span>
               {editable ? (
                 <div

--- a/apps/canvas-workspace/src/renderer/src/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/types.ts
@@ -1269,6 +1269,9 @@ export interface AgentTeamPlanDraft {
   updatedAt: number;
 }
 
+/** Liveness of an agent's PTY session as reported by the main process. */
+export type AgentTeamSessionHealth = 'live' | 'queued' | 'dead' | 'missing';
+
 export interface AgentTeamSnapshot {
   workspaceId: string;
   frameNodeId?: string;
@@ -1276,6 +1279,8 @@ export interface AgentTeamSnapshot {
   pendingPlan?: AgentTeamPlanDraft;
   approvedPlan?: AgentTeamPlanDraft;
   runtime: AgentTeamRuntimeSnapshot;
+  /** Per-agent session liveness, keyed by agent id. */
+  sessions?: Record<string, AgentTeamSessionHealth>;
 }
 
 export interface AgentTeamsApi {

--- a/packages/agent-teams/src/runtime/__tests__/team-runtime.test.ts
+++ b/packages/agent-teams/src/runtime/__tests__/team-runtime.test.ts
@@ -1495,6 +1495,135 @@ describe('TeamRuntime', () => {
       });
       expect(snapshot.tasks.find((task) => task.id === docsTask.id)?.blockedReason).toBeUndefined();
     });
+
+    it('cancelTask releases a blocked task\'s scope and owner so fallback work dispatches', async () => {
+      const { runtime } = createRuntime();
+      const { team } = await runtime.createTeam({ name: 'Team', goal: 'Ship it' });
+      const lead = await runtime.addAgent({ teamId: team.id, role: 'lead', name: 'Lead' });
+      const qa = await runtime.addAgent({ teamId: team.id, role: 'teammate', name: 'QA Codex' });
+      const backup = await runtime.addAgent({ teamId: team.id, role: 'teammate', name: 'Backup Codex' });
+      await runtime.createAgentSession(lead.id);
+      await runtime.createAgentSession(qa.id);
+      await runtime.createAgentSession(backup.id);
+      const original = await runtime.createTask({
+        teamId: team.id,
+        title: 'QA regression',
+        description: 'Run the regression checklist.',
+        ownerAgentId: qa.id,
+        metadata: { scope: ['apps/web/src', 'docs/regression.md'] },
+      });
+      const report = await runtime.createTask({
+        teamId: team.id,
+        title: 'Ship report',
+        description: 'Summarize the regression results.',
+        deps: [original.id],
+      });
+      await runtime.dispatchReadyTasks(team.id);
+
+      // The agent's session died, so the human parked the task as blocked.
+      // Blocked tasks keep holding their scope: an overlapping fallback task
+      // must wait, even though its owner is idle.
+      await runtime.blockTask(original.id, 'Agent node PTY no longer exists.');
+      const fallback = await runtime.createTask({
+        teamId: team.id,
+        title: 'QA regression fallback',
+        description: 'Re-run the regression on a healthy agent.',
+        ownerAgentId: backup.id,
+        metadata: { scope: ['apps/web/src'] },
+      });
+      await runtime.dispatchReadyTasks(team.id);
+      let snapshot = await runtime.snapshot(team.id);
+      expect(snapshot.tasks.find((task) => task.id === fallback.id)).toMatchObject({
+        status: 'todo',
+        blockedReason: 'Waiting for overlapping file scope held by: QA regression',
+      });
+
+      // Cancelling settles the original as failed, frees its owner as idle
+      // (not an agent error), and parks its dependent like any failure.
+      const cancelled = await runtime.cancelTask(original.id, 'Agent session is gone; fallback takes over.');
+      expect(cancelled).toMatchObject({
+        status: 'failed',
+        result: 'Cancelled: Agent session is gone; fallback takes over.',
+      });
+      snapshot = await runtime.snapshot(team.id);
+      expect(snapshot.agents.find((agent) => agent.id === qa.id)).toMatchObject({ status: 'idle' });
+      expect(snapshot.agents.find((agent) => agent.id === qa.id)?.currentTaskId).toBeUndefined();
+      expect(snapshot.tasks.find((task) => task.id === report.id)).toMatchObject({
+        status: 'blocked',
+        blockedReason: 'Blocked by failed dependency: QA regression',
+      });
+
+      // The scope is released: the fallback dispatches and the wait note clears.
+      const result = await runtime.dispatchReadyTasks(team.id);
+      expect(result.assigned.map((task) => task.id)).toEqual([fallback.id]);
+      snapshot = await runtime.snapshot(team.id);
+      expect(snapshot.tasks.find((task) => task.id === fallback.id)).toMatchObject({
+        status: 'in_progress',
+        ownerAgentId: backup.id,
+      });
+      expect(snapshot.tasks.find((task) => task.id === fallback.id)?.blockedReason).toBeUndefined();
+
+      // Settled tasks are not re-cancelled.
+      await runtime.completeTask(fallback.id, 'Regression done.', lead.id);
+      const afterDone = await runtime.cancelTask(fallback.id, 'Too late.');
+      expect(afterDone.status).toBe('done');
+    });
+  });
+
+  it('keeps a task in todo when session delivery fails at dispatch', async () => {
+    const { runtime, adapter } = createRuntime();
+    const { team } = await runtime.createTeam({ name: 'Team', goal: 'Ship it' });
+    const lead = await runtime.addAgent({ teamId: team.id, role: 'lead', name: 'Lead' });
+    const coder = await runtime.addAgent({ teamId: team.id, role: 'teammate', name: 'Coder' });
+    await runtime.createAgentSession(lead.id);
+    await runtime.createAgentSession(coder.id);
+    const task = await runtime.createTask({
+      teamId: team.id,
+      title: 'Implement change',
+      description: 'Do the change.',
+      ownerAgentId: coder.id,
+    });
+
+    const send = adapter.sendInput.bind(adapter);
+    let deliverable = false;
+    adapter.sendInput = async (sessionId: string, input: string) => {
+      if (!deliverable) throw new Error('Agent node not found: node-1');
+      await send(sessionId, input);
+    };
+
+    // Delivery fails: no fake in_progress assignment, the failure is recorded
+    // on the task, and the lead is told once.
+    const first = await runtime.dispatchReadyTasks(team.id);
+    expect(first.assigned).toHaveLength(0);
+    let snapshot = await runtime.snapshot(team.id);
+    expect(snapshot.tasks.find((candidate) => candidate.id === task.id)).toMatchObject({
+      status: 'todo',
+      blockedReason: 'Dispatch failed: Agent node not found: node-1',
+    });
+    expect(snapshot.agents.find((agent) => agent.id === coder.id)).toMatchObject({ status: 'idle' });
+    expect(snapshot.agents.find((agent) => agent.id === coder.id)?.currentTaskId).toBeUndefined();
+    const deliveryWarnings = snapshot.messages.filter((message) =>
+      message.to === 'lead' && message.content.startsWith('Could not deliver task "Implement change"'));
+    expect(deliveryWarnings).toHaveLength(1);
+
+    // The retrying heartbeat does not re-write the task or re-ping the lead
+    // while the failure stays the same.
+    await runtime.dispatchReadyTasks(team.id);
+    snapshot = await runtime.snapshot(team.id);
+    expect(snapshot.messages.filter((message) =>
+      message.to === 'lead' && message.content.startsWith('Could not deliver task "Implement change"'))).toHaveLength(1);
+
+    // Once the target is deliverable again the task assigns and the note clears.
+    deliverable = true;
+    const second = await runtime.dispatchReadyTasks(team.id);
+    expect(second.assigned.map((candidate) => candidate.id)).toEqual([task.id]);
+    snapshot = await runtime.snapshot(team.id);
+    expect(snapshot.tasks.find((candidate) => candidate.id === task.id)).toMatchObject({ status: 'in_progress' });
+    expect(snapshot.tasks.find((candidate) => candidate.id === task.id)?.blockedReason).toBeUndefined();
+    expect(snapshot.agents.find((agent) => agent.id === coder.id)).toMatchObject({
+      status: 'running',
+      currentTaskId: task.id,
+    });
   });
 
   it('reroutes tasks owned by the lead to a teammate at dispatch', async () => {

--- a/packages/agent-teams/src/runtime/__tests__/team-runtime.test.ts
+++ b/packages/agent-teams/src/runtime/__tests__/team-runtime.test.ts
@@ -1420,6 +1420,67 @@ describe('TeamRuntime', () => {
       await runtime.notifyLeadPendingTaskReviews(team.id);
       expect(leadInputs()).toHaveLength(afterSubmit + 1);
     });
+
+    it('keeps nagging about pending reviews while teammate questions are open', async () => {
+      let id = 1;
+      let now = 1000;
+      const adapter = new FakeAgentSessionAdapter();
+      const runtime = new TeamRuntime({
+        agentSessions: adapter,
+        idFactory: () => `id-${id++}`,
+        now: () => now++,
+      });
+      const { team } = await runtime.createTeam({ name: 'Team', goal: 'Ship it' });
+      const lead = await runtime.addAgent({ teamId: team.id, role: 'lead', name: 'Lead' });
+      const coder = await runtime.addAgent({ teamId: team.id, role: 'teammate', name: 'Coder' });
+      const helper = await runtime.addAgent({ teamId: team.id, role: 'teammate', name: 'Helper' });
+      const leadWithSession = await runtime.createAgentSession(lead.id);
+      await runtime.createAgentSession(coder.id);
+      await runtime.createAgentSession(helper.id);
+      const built = await runtime.createTask({
+        teamId: team.id,
+        title: 'Build feature',
+        description: 'Build it.',
+        ownerAgentId: coder.id,
+      });
+      const styled = await runtime.createTask({
+        teamId: team.id,
+        title: 'Style feature',
+        description: 'Style it.',
+        ownerAgentId: helper.id,
+      });
+      void styled;
+      await runtime.dispatchReadyTasks(team.id);
+      const sessionId = leadWithSession.sessionRef!.sessionId;
+      const leadInputs = () => adapter.inputs.filter((entry) => entry.sessionId === sessionId);
+
+      // One completion awaits review while another teammate has an open question.
+      await runtime.submitTaskCompletion(built.id, 'Feature built.', coder.id);
+      await runtime.openHumanGate({
+        teamId: team.id,
+        agentId: helper.id,
+        taskId: styled.id,
+        reason: 'Teammate requested Team Lead input',
+        prompt: 'Which spacing scale should I use?',
+        metadata: { audience: 'lead' },
+      });
+
+      // The open gate must not starve the review nag after the resend window.
+      now += 61_000;
+      const before = leadInputs().length;
+      await runtime.notifyLeadPendingTaskReviews(team.id);
+      expect(leadInputs()).toHaveLength(before + 1);
+      const nag = leadInputs().at(-1)?.input ?? '';
+      // Both backlogs arrive in the same message.
+      expect(nag).toContain('Tasks waiting for Team Lead review (1):');
+      expect(nag).toContain('Current teammate questions waiting for Team Lead (1):');
+
+      // The review backlog also rides along on unrelated lead notifications.
+      await runtime.notifyLeadAttention(team.id, 'Heartbeat status note.');
+      const attention = leadInputs().at(-1)?.input ?? '';
+      expect(attention).toContain('Heartbeat status note.');
+      expect(attention).toContain('Tasks waiting for Team Lead review (1):');
+    });
   });
 
   describe('Scope guard', () => {

--- a/packages/agent-teams/src/runtime/team-runtime.ts
+++ b/packages/agent-teams/src/runtime/team-runtime.ts
@@ -57,6 +57,7 @@ const TASK_COMPLETION_SUBMITTED_BY_METADATA_KEY = 'completionSubmittedBy';
 const LEAD_NOTIFICATION_GUARD = [
   'Pulse Canvas team event. Handle this notification once.',
   'You are the Team Lead: coordinate, verify, and delegate. Do not create or edit project files yourself — route every change to a teammate. Reading files and quick read-only checks are fine, and writing a temporary plan JSON for propose-plan --plan-file is the one allowed exception.',
+  'If you are unsure of the current team state (task statuses, pending questions or reviews), ground yourself once with: pulse-canvas team status',
   'Do not run sleep, watch, tail, polling loops, or repeated status checks.',
   'If no immediate action is needed, briefly acknowledge and stop. Pulse Canvas will wake you again for the next required decision.',
 ].join('\n');
@@ -1687,19 +1688,15 @@ export class TeamRuntime {
       `pulse-canvas team complete-task --task "${task.id}" --summary "<short summary>"`,
       'The Team Lead reviews your reported completion before the task counts as done, and may send it back with revision feedback.',
       '',
-      'If you need human input, prefer:',
+      'If you need human input, run this command from the terminal. Do not merely print it:',
       `pulse-canvas team request-human-input --task "${task.id}" --prompt "<question>"`,
       'Teammate questions are routed to the Team Lead first. The Team Lead asks the human only if needed.',
-      'Fallback marker:',
-      `[agent-team:human-input-needed taskId="${task.id}"] <question>`,
       '',
       'If you are blocked without a human answer, run this command from the terminal. Do not merely print it:',
       `pulse-canvas team block-task --task "${task.id}" --reason "<reason>"`,
       '',
-      'If you create a notable artifact, prefer:',
+      'If you create a notable artifact, run:',
       `pulse-canvas team publish-artifact --task "${task.id}" --kind "diff" --title "filename.diff" --summary "<short summary>"`,
-      'Fallback marker:',
-      `[agent-team:artifact taskId="${task.id}" kind="diff" title="filename.diff"] <short summary>`,
     ].join('\n');
   }
 

--- a/packages/agent-teams/src/runtime/team-runtime.ts
+++ b/packages/agent-teams/src/runtime/team-runtime.ts
@@ -844,20 +844,7 @@ export class TeamRuntime {
       reason: TASK_ACCEPTANCE_PENDING_REASON,
     });
     await this.notifyLead(task.teamId, await this.formatTaskAcceptancePrompt(task, submitter, summary), task.id);
-    await this.warmPendingTaskReviewDigest(task.teamId);
     return task;
-  }
-
-  /**
-   * Pre-warm the pending-review digest cache after a review prompt was just
-   * delivered, so the snapshot heartbeat does not immediately re-send a
-   * digest covering the same backlog on the next tick.
-   */
-  private async warmPendingTaskReviewDigest(teamId: TeamId): Promise<void> {
-    this.leadTaskReviewDigestCache.set(teamId, {
-      digest: await this.formatPendingTaskReviewDigest(teamId),
-      sentAt: this.now(),
-    });
   }
 
   async completeTask(taskId: TaskId, result: string, actor?: AgentId | 'human' | 'runtime'): Promise<TeamTaskRecord> {
@@ -943,7 +930,6 @@ export class TeamRuntime {
       reason,
     });
     await this.notifyLead(task.teamId, await this.formatTaskReviewPrompt(task, reason), task.id);
-    await this.warmPendingTaskReviewDigest(task.teamId);
     return task;
   }
 
@@ -1432,7 +1418,10 @@ export class TeamRuntime {
    * session missed it, the task would sit in needs_review forever while
    * downstream work stays blocked. Pulse Canvas calls this on its snapshot
    * heartbeat, like the pending-gate digest. Throttled per digest so an
-   * unchanged backlog is not re-sent within the resend window.
+   * unchanged backlog is not re-sent within the resend window. Open teammate
+   * questions do NOT suppress this nag: a lingering unanswerable gate must
+   * never starve the review backlog (notifyLead appends both digests to one
+   * message anyway).
    */
   async notifyLeadPendingTaskReviews(teamId: TeamId): Promise<void> {
     const team = await this.requireTeam(teamId);
@@ -1440,10 +1429,6 @@ export class TeamRuntime {
       this.leadTaskReviewDigestCache.delete(teamId);
       return;
     }
-    // If teammate questions are pending, the gate digest path is already
-    // re-engaging the lead; don't stack a second prompt on the same tick.
-    if (await this.formatLeadPendingGateDigest(teamId)) return;
-
     const digest = await this.formatPendingTaskReviewDigest(teamId);
     if (!digest) {
       this.leadTaskReviewDigestCache.delete(teamId);
@@ -1453,12 +1438,13 @@ export class TeamRuntime {
     if (cached?.digest === digest && this.now() - cached.sentAt < LEAD_TASK_REVIEW_DIGEST_RESEND_MS) {
       return;
     }
+    // The digest itself rides along via notifyLead, which also re-warms the
+    // resend cache.
     await this.notifyLead(teamId, [
       'Pulse Canvas found tasks still waiting for Team Lead review.',
       '',
-      digest,
+      'Handle each review now: verify the deliverable, then accept it or send it back.',
     ].join('\n'));
-    this.leadTaskReviewDigestCache.set(teamId, { digest, sentAt: this.now() });
   }
 
   /**
@@ -1515,9 +1501,9 @@ export class TeamRuntime {
       this.leadReviewNudgeCache.delete(teamId);
       return;
     }
-    // If teammate questions are still waiting on the lead, the pending-gate digest
-    // path is already re-engaging it; don't stack a second prompt on this tick.
-    if (await this.formatLeadPendingGateDigest(teamId)) return;
+    // Open teammate questions do not suppress the nudge: they ride along on
+    // the same notifyLead message, and a lingering unanswerable gate must not
+    // stall finalization forever.
     const lastNudgedAt = this.leadReviewNudgeCache.get(teamId);
     if (lastNudgedAt !== undefined && this.now() - lastNudgedAt < LEAD_REVIEW_RESEND_MS) {
       return;
@@ -2064,18 +2050,29 @@ export class TeamRuntime {
     });
     if (!this.agentSessions || !lead.sessionRef) return;
 
+    // Both backlogs ride along on every lead notification: a lead that only
+    // reads its latest message still sees every question AND every pending
+    // review, so neither backlog depends on the lead having caught the one
+    // prompt that announced it.
     const pendingGateDigest = await this.formatLeadPendingGateDigest(teamId);
+    const pendingReviewDigest = await this.formatPendingTaskReviewDigest(teamId);
     await this.agentSessions.sendInput(lead.sessionRef.sessionId, [
       LEAD_NOTIFICATION_GUARD,
       '',
       content,
       ...(pendingGateDigest ? ['', pendingGateDigest] : []),
+      ...(pendingReviewDigest ? ['', pendingReviewDigest] : []),
     ].join('\n'));
 
     if (pendingGateDigest) {
       this.leadPendingDigestCache.set(teamId, { digest: pendingGateDigest, sentAt: this.now() });
     } else {
       this.leadPendingDigestCache.delete(teamId);
+    }
+    if (pendingReviewDigest) {
+      this.leadTaskReviewDigestCache.set(teamId, { digest: pendingReviewDigest, sentAt: this.now() });
+    } else {
+      this.leadTaskReviewDigestCache.delete(teamId);
     }
     lead.status = 'running';
     lead.updatedAt = this.now();

--- a/packages/agent-teams/src/runtime/team-runtime.ts
+++ b/packages/agent-teams/src/runtime/team-runtime.ts
@@ -678,6 +678,48 @@ export class TeamRuntime {
         : availableAgents.find(agent => agent.role === 'teammate');
       if (!owner) continue;
 
+      // Deliver the task prompt BEFORE committing the assignment. If the
+      // adapter cannot take the input (e.g. the agent's canvas node was
+      // deleted), committing first would leave a fake in_progress task whose
+      // owner never received anything — invisible to the watchdog because the
+      // agent record looks busy. The failed task stays in todo with the
+      // failure recorded on it, and this pass moves on to other ready work.
+      if (this.agentSessions && owner.sessionRef) {
+        const taskPrompt = await this.formatTaskPrompt(task, tasks, owner);
+        try {
+          await this.agentSessions.sendInput(owner.sessionRef.sessionId, taskPrompt);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          const reason = `Dispatch failed: ${message}`;
+          // The heartbeat retries every pass; only the first failure (or a
+          // changed error) is persisted and reported, so a dead target does
+          // not rewrite the task or re-ping the lead on every tick.
+          if (task.blockedReason !== reason) {
+            task.blockedReason = reason;
+            task.updatedAt = this.now();
+            await this.store.saveTask(task);
+            await this.appendMessage({
+              teamId,
+              from: 'runtime',
+              to: 'lead',
+              type: 'status_update',
+              content: `Could not deliver task "${task.title}" to ${owner.name}: ${message}. The task stays queued; restore the agent's node or reassign the work.`,
+              taskId: task.id,
+            });
+          }
+          continue;
+        }
+        // Record this as the agent's current launch prompt so a later restart
+        // replays THIS task rather than a previously finished one. Best
+        // effort: the prompt was already delivered, so a bookkeeping failure
+        // must not abort the assignment.
+        try {
+          await this.agentSessions.persistLaunchPrompt?.(owner.sessionRef.sessionId, taskPrompt);
+        } catch {
+          // Replay bookkeeping only; the live session already has the task.
+        }
+      }
+
       // An explicit assignment to the lead (or to an agent that no longer
       // exists) is being overridden — record it so the reassignment is not
       // silent.
@@ -717,14 +759,6 @@ export class TeamRuntime {
         taskId: task.id,
         agentId: owner.id,
       });
-
-      if (this.agentSessions && owner.sessionRef) {
-        const taskPrompt = await this.formatTaskPrompt(task, tasks, owner);
-        await this.agentSessions.sendInput(owner.sessionRef.sessionId, taskPrompt);
-        // Record this as the agent's current launch prompt so a later restart
-        // replays THIS task rather than a previously finished one.
-        await this.agentSessions.persistLaunchPrompt?.(owner.sessionRef.sessionId, taskPrompt);
-      }
 
       if (scope.length > 0) heldScopes.push(scope);
       assigned.push({ ...task });
@@ -913,20 +947,14 @@ export class TeamRuntime {
     return task;
   }
 
-  async failTask(taskId: TaskId, error: string, actor?: AgentId | 'runtime'): Promise<TeamTaskRecord> {
-    const task = await this.requireTask(taskId);
-    task.status = 'failed';
-    task.result = error;
-    task.updatedAt = this.now();
-    await this.store.saveTask(task);
-    await this.cancelOpenGatesForTask(task.teamId, task.id);
-
-    await this.releaseTaskOwner(task, 'error');
-
-    // A failed dependency would otherwise leave its dependents sitting in
-    // `todo` forever (they can never become ready). Park them as explicitly
-    // blocked so the stall is visible and the lead is forced to decide:
-    // fix-and-complete the failed task (which releases them) or replan.
+  /**
+   * Park a settled-as-failed task's todo dependents as explicitly blocked.
+   * A failed dependency would otherwise leave its dependents sitting in
+   * `todo` forever (they can never become ready). Parking makes the stall
+   * visible and forces the lead to decide: fix-and-complete the failed task
+   * (which releases them) or replan.
+   */
+  private async parkDependentsOnFailure(task: TeamTaskRecord): Promise<TeamTaskRecord[]> {
     const tasks = await this.store.listTasks(task.teamId);
     const blockedDependents: TeamTaskRecord[] = [];
     for (const dependent of tasks) {
@@ -947,6 +975,20 @@ export class TeamRuntime {
       });
       blockedDependents.push(dependent);
     }
+    return blockedDependents;
+  }
+
+  async failTask(taskId: TaskId, error: string, actor?: AgentId | 'runtime'): Promise<TeamTaskRecord> {
+    const task = await this.requireTask(taskId);
+    task.status = 'failed';
+    task.result = error;
+    task.updatedAt = this.now();
+    await this.store.saveTask(task);
+    await this.cancelOpenGatesForTask(task.teamId, task.id);
+
+    await this.releaseTaskOwner(task, 'error');
+
+    const blockedDependents = await this.parkDependentsOnFailure(task);
 
     await this.emit(task.teamId, 'task_failed', actor ?? task.ownerAgentId ?? 'runtime', {
       taskId: task.id,
@@ -969,6 +1011,52 @@ export class TeamRuntime {
       '',
       'Review the failure. You may create follow-up tasks with:',
       'pulse-canvas team create-task --title "..." --description "..." --owner "..." --dispatch',
+    ].join('\n'), task.id);
+    await this.checkRoundCompletion(task.teamId);
+    return task;
+  }
+
+  /**
+   * Cancel a task that should no longer run — its agent session is gone,
+   * the work was superseded by a replacement task, or the human withdrew it.
+   * The task settles as failed so it stops holding its declared file scope
+   * (a blocked task holds its scope forever otherwise, starving overlapping
+   * fallback work), and its owner is released as idle: cancellation is a
+   * routing decision, not an agent error. Dependents are parked like any
+   * other failure so the lead must explicitly re-route or close them.
+   */
+  async cancelTask(taskId: TaskId, reason: string, actor: AgentId | 'human' | 'runtime' = 'human'): Promise<TeamTaskRecord> {
+    const task = await this.requireTask(taskId);
+    if (task.status === 'done' || task.status === 'failed') return task;
+    task.status = 'failed';
+    task.result = `Cancelled: ${reason}`;
+    task.blockedReason = undefined;
+    task.updatedAt = this.now();
+    await this.store.saveTask(task);
+    await this.cancelOpenGatesForTask(task.teamId, task.id);
+
+    await this.releaseTaskOwner(task, 'idle');
+
+    const blockedDependents = await this.parkDependentsOnFailure(task);
+
+    await this.emit(task.teamId, 'task_failed', actor, {
+      taskId: task.id,
+      error: task.result,
+      cancelled: true,
+    });
+    await this.notifyLead(task.teamId, [
+      `Task cancelled: ${task.title}`,
+      '',
+      reason,
+      'Its file scope is released, so overlapping replacement tasks can now dispatch.',
+      ...(blockedDependents.length > 0
+        ? [
+          '',
+          'Dependent tasks now blocked by this cancellation:',
+          ...blockedDependents.map((dependent) => `- ${dependent.title}`),
+          'Re-route them to replacement tasks or close the ones that no longer apply.',
+        ]
+        : []),
     ].join('\n'), task.id);
     await this.checkRoundCompletion(task.teamId);
     return task;
@@ -1008,6 +1096,8 @@ export class TeamRuntime {
       reason,
       '',
       'Decide whether to answer, create a follow-up task, or ask the user for input.',
+      'A blocked task keeps holding its declared file scope. If it should be abandoned so replacement work can take over its files, cancel it:',
+      `pulse-canvas team cancel-task --task "${quoteCliValue(task.id)}" --reason "<why>"`,
     ].join('\n'), task.id);
     return task;
   }

--- a/packages/canvas-cli/src/commands/__tests__/agent.test.ts
+++ b/packages/canvas-cli/src/commands/__tests__/agent.test.ts
@@ -398,6 +398,13 @@ describe('pulse-canvas team follow-up actions', () => {
       '--task', 'Review checkout refactor',
       'Waiting for API docs.',
     ]);
+    const cancelTask = await runCli([
+      '--workspace', 'ws-x',
+      'team', 'cancel-task',
+      '--team', 'team-1',
+      '--task', 'Review checkout refactor',
+      'Agent session is gone; fallback takes over.',
+    ]);
     const requestHumanInput = await runCli([
       '--workspace', 'ws-x',
       'team', 'request-human-input',
@@ -427,6 +434,7 @@ describe('pulse-canvas team follow-up actions', () => {
 
     expect(completeTask.exitCode).toBe(null);
     expect(blockTask.exitCode).toBe(null);
+    expect(cancelTask.exitCode).toBe(null);
     expect(requestHumanInput.exitCode).toBe(null);
     expect(publishArtifact.exitCode).toBe(null);
     expect(completeTeam.exitCode).toBe(null);
@@ -449,6 +457,16 @@ describe('pulse-canvas team follow-up actions', () => {
           sourceAgentId: 'agent-blocker',
           taskId: 'Review checkout refactor',
           reason: 'Waiting for API docs.',
+        },
+      },
+      {
+        url: '/agent-team/cancel-task',
+        body: {
+          workspaceId: 'ws-x',
+          teamId: 'team-1',
+          sourceAgentId: 'agent-env',
+          taskId: 'Review checkout refactor',
+          reason: 'Agent session is gone; fallback takes over.',
         },
       },
       {

--- a/packages/canvas-cli/src/commands/__tests__/agent.test.ts
+++ b/packages/canvas-cli/src/commands/__tests__/agent.test.ts
@@ -365,6 +365,86 @@ describe('pulse-canvas team follow-up actions', () => {
     expect(stdout).toMatch(/Message sent in Agent Team to Codex Frontend\./);
   });
 
+  it('renders read-only team status with session health and pending work', async () => {
+    const requests: Array<{ url: string; body: unknown }> = [];
+    const { server, baseUrl } = await startStubServer((body, _headers, url) => {
+      requests.push({ url: url ?? '', body });
+      if ((body as { teamId?: string }).teamId) {
+        return {
+          status: 200,
+          body: {
+            ok: true,
+            snapshot: {
+              phase: 'executing',
+              sessions: { 'lead-1': 'live', 'mate-1': 'dead' },
+              runtime: {
+                team: { id: 'team-1', name: 'Agent Team', status: 'running' },
+                agents: [
+                  { id: 'lead-1', name: 'Team Lead', role: 'lead', status: 'running' },
+                  { id: 'mate-1', name: 'QA Codex', role: 'teammate', status: 'idle' },
+                ],
+                tasks: [
+                  {
+                    id: 'task-1',
+                    title: 'Focused QA regression',
+                    status: 'needs_review',
+                    ownerAgentId: 'mate-1',
+                    blockedReason: 'Awaiting Team Lead acceptance of the reported completion.',
+                  },
+                ],
+                humanGates: [
+                  { id: 'gate-1', status: 'open', prompt: 'Which API version?', agentId: 'mate-1' },
+                ],
+              },
+            },
+          },
+        };
+      }
+      return {
+        status: 200,
+        body: {
+          ok: true,
+          teams: [
+            {
+              teamId: 'team-1',
+              name: 'Agent Team',
+              status: 'running',
+              phase: 'executing',
+              taskCounts: { in_progress: 2, done: 3 },
+              agentCount: 4,
+            },
+          ],
+        },
+      };
+    });
+    await writeRuntime({ pid: process.pid, baseUrl, secret: 'tok', createdAt: '' });
+
+    const detail = await runCli(['--workspace', 'ws-x', 'team', 'status', '--team', 'team-1']);
+    const list = await runCli(['--workspace', 'ws-x', 'team', 'status']);
+    server.close();
+
+    expect(detail.exitCode).toBe(null);
+    expect(requests[0]).toEqual({
+      url: '/agent-team/status',
+      body: { workspaceId: 'ws-x', teamId: 'team-1' },
+    });
+    expect(detail.stdout).toContain('Team: Agent Team (team-1)');
+    expect(detail.stdout).toContain('Team Lead [lead] running · session live');
+    expect(detail.stdout).toContain('QA Codex [teammate] idle · session dead');
+    expect(detail.stdout).toContain('[needs_review] Focused QA regression — QA Codex (task-1)');
+    expect(detail.stdout).toContain('blocker: Awaiting Team Lead acceptance');
+    expect(detail.stdout).toContain('Open questions (1):');
+    expect(detail.stdout).toContain('Waiting for Team Lead review (1):');
+    expect(detail.stdout).toContain('Sessions needing relaunch (1): QA Codex');
+
+    expect(list.exitCode).toBe(null);
+    expect(requests[1]).toEqual({
+      url: '/agent-team/status',
+      body: { workspaceId: 'ws-x' },
+    });
+    expect(list.stdout).toContain('Agent Team (team-1) — running · executing · 4 agents');
+  });
+
   it('posts teammate lifecycle actions through team runtime endpoints', async () => {
     const oldAgent = process.env.PULSE_CANVAS_TEAM_AGENT_ID;
     process.env.PULSE_CANVAS_TEAM_AGENT_ID = 'agent-env';

--- a/packages/canvas-cli/src/commands/team.ts
+++ b/packages/canvas-cli/src/commands/team.ts
@@ -88,6 +88,7 @@ async function postTeamAction(
     | '/agent-team/create-task'
     | '/agent-team/complete-task'
     | '/agent-team/block-task'
+    | '/agent-team/cancel-task'
     | '/agent-team/request-human-input'
     | '/agent-team/publish-artifact'
     | '/agent-team/complete-team'
@@ -304,6 +305,36 @@ export function registerTeamCommands(program: Command): void {
       if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`);
 
       output(body, format, () => `Task blocked for ${teamId}.`);
+    });
+
+  team.command('cancel-task')
+    .option('--team <teamId>', `Team ID (default: $${ENV_TEAM_ID})`, process.env[ENV_TEAM_ID])
+    .option('--source-agent <agentId>', `Source agent ID (default: $${ENV_TEAM_AGENT_ID})`, process.env[ENV_TEAM_AGENT_ID])
+    .option('--task <taskId>', 'Task ID or title')
+    .option('--reason <reason>', 'Cancellation reason')
+    .argument('[reason...]', 'Cancellation reason')
+    .description('Cancel a task and release its file scope for replacement work (Team Lead or human only)')
+    .action(async function (
+      this: Command,
+      reasonParts: string[] | undefined,
+      cmdOpts: { team?: string; sourceAgent?: string; task?: string; reason?: string },
+    ) {
+      const { format, workspace } = getOpts(this);
+      const teamId = cmdOpts.team || process.env[ENV_TEAM_ID];
+      if (!teamId) errorOutput(`Team ID required. Pass --team <id> or set $${ENV_TEAM_ID}.`);
+      const reason = textFromOptionOrParts(cmdOpts.reason, reasonParts, 'Reason');
+
+      const runtime = await readRuntime();
+      const { status, body } = await postTeamAction(runtime, '/agent-team/cancel-task', addSourceAgent({
+        ...baseTeamBody(workspace, teamId),
+        taskId: cmdOpts.task,
+        reason,
+      }, cmdOpts.sourceAgent));
+
+      if (status === 401) errorOutput(runtimeAuthHint());
+      if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`);
+
+      output(body, format, () => `Task cancelled for ${teamId}; its file scope is released.`);
     });
 
   team.command('request-human-input')

--- a/packages/canvas-cli/src/commands/team.ts
+++ b/packages/canvas-cli/src/commands/team.ts
@@ -39,6 +39,118 @@ interface TeamSnapshotResponse {
   code?: string;
 }
 
+interface TeamStatusResponse {
+  ok: boolean;
+  snapshot?: {
+    phase?: string;
+    sessions?: Record<string, string>;
+    runtime?: {
+      team?: { id: string; name?: string; status?: string; goal?: string };
+      agents?: Array<{
+        id: string;
+        name: string;
+        role: string;
+        status: string;
+        currentTaskId?: string;
+      }>;
+      tasks?: Array<{
+        id: string;
+        title: string;
+        status: string;
+        ownerAgentId?: string;
+        blockedReason?: string;
+      }>;
+      humanGates?: Array<{
+        id: string;
+        status: string;
+        prompt: string;
+        agentId?: string;
+        taskId?: string;
+      }>;
+    };
+  };
+  teams?: Array<{
+    teamId: string;
+    name: string;
+    status: string;
+    phase: string;
+    taskCounts: Record<string, number>;
+    agentCount: number;
+  }>;
+  error?: string;
+  code?: string;
+}
+
+const renderTeamStatus = (response: TeamStatusResponse): string => {
+  if (response.teams) {
+    if (response.teams.length === 0) return 'No agent teams in this workspace.';
+    const lines = response.teams.map((team) => {
+      const counts = Object.entries(team.taskCounts)
+        .map(([status, count]) => `${count} ${status}`)
+        .join(', ') || 'no tasks';
+      return `${team.name} (${team.teamId}) — ${team.status} · ${team.phase} · ${team.agentCount} agents · ${counts}`;
+    });
+    return [...lines, '', 'Run with --team <id> for task, agent, and session detail.'].join('\n');
+  }
+
+  const runtime = response.snapshot?.runtime ?? {};
+  const sessions = response.snapshot?.sessions ?? {};
+  const team = runtime.team;
+  const agents = runtime.agents ?? [];
+  const tasks = runtime.tasks ?? [];
+  const agentById = new Map(agents.map((agent) => [agent.id, agent]));
+  const taskById = new Map(tasks.map((task) => [task.id, task]));
+  const lines: string[] = [];
+
+  lines.push(`Team: ${team?.name ?? 'unknown'} (${team?.id ?? '?'})`);
+  lines.push(`Status: ${team?.status ?? 'unknown'} · phase ${response.snapshot?.phase ?? 'unknown'}`);
+
+  lines.push('', `Agents (${agents.length}):`);
+  for (const agent of agents) {
+    const session = sessions[agent.id] ?? 'unknown';
+    const current = agent.currentTaskId ? taskById.get(agent.currentTaskId)?.title : undefined;
+    lines.push(
+      `- ${agent.name} [${agent.role}] ${agent.status} · session ${session}`
+      + (current ? ` · working on: ${current}` : ''),
+    );
+  }
+
+  lines.push('', `Tasks (${tasks.length}):`);
+  for (const task of tasks) {
+    const owner = task.ownerAgentId ? agentById.get(task.ownerAgentId)?.name : undefined;
+    lines.push(`- [${task.status}] ${task.title} — ${owner ?? 'unassigned'} (${task.id})`);
+    if (task.blockedReason) lines.push(`    blocker: ${task.blockedReason}`);
+  }
+
+  const openGates = (runtime.humanGates ?? []).filter((gate) => gate.status === 'open');
+  if (openGates.length > 0) {
+    lines.push('', `Open questions (${openGates.length}):`);
+    for (const gate of openGates) {
+      const from = gate.agentId ? agentById.get(gate.agentId)?.name ?? 'agent' : 'team';
+      lines.push(`- ${from}: ${gate.prompt}`);
+    }
+  }
+
+  const pendingReviews = tasks.filter((task) => task.status === 'needs_review');
+  if (pendingReviews.length > 0) {
+    lines.push('', `Waiting for Team Lead review (${pendingReviews.length}):`);
+    for (const task of pendingReviews) {
+      lines.push(`- ${task.title}: pulse-canvas team complete-task --task "${task.id}" --summary "<reviewed summary>"`);
+    }
+  }
+
+  const deadSessions = agents.filter((agent) => {
+    const session = sessions[agent.id];
+    return session === 'dead' || session === 'missing';
+  });
+  if (deadSessions.length > 0) {
+    lines.push('', `Sessions needing relaunch (${deadSessions.length}): ${deadSessions.map((agent) => agent.name).join(', ')}`);
+    lines.push('Open the workspace window to relaunch them; queued messages deliver on relaunch.');
+  }
+
+  return lines.join('\n');
+};
+
 const collectOption = (value: string, previous: string[] = []): string[] => [...previous, value];
 
 function getOpts(cmd: Command): TeamCommandOpts {
@@ -305,6 +417,25 @@ export function registerTeamCommands(program: Command): void {
       if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`);
 
       output(body, format, () => `Task blocked for ${teamId}.`);
+    });
+
+  team.command('status')
+    .option('--team <teamId>', `Team ID (default: $${ENV_TEAM_ID}; omit to list all teams)`, process.env[ENV_TEAM_ID])
+    .description('Show read-only team status: agents, session health, tasks, open questions, pending reviews')
+    .action(async function (this: Command, cmdOpts: { team?: string }) {
+      const { format, workspace } = getOpts(this);
+      const teamId = cmdOpts.team || process.env[ENV_TEAM_ID] || undefined;
+
+      const runtime = await readRuntime();
+      const { status, body } = await postRuntime(runtime, '/agent-team/status', {
+        workspaceId: workspace,
+        ...(teamId ? { teamId } : {}),
+      }) as { status: number; body: TeamStatusResponse };
+
+      if (status === 401) errorOutput(runtimeAuthHint());
+      if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`);
+
+      output(body, format, (data) => renderTeamStatus(data as TeamStatusResponse));
     });
 
   team.command('cancel-task')


### PR DESCRIPTION
## Summary

This PR adds three major features to the agent teams system:

1. **Task cancellation** — allows the Team Lead or human to withdraw a task, settling it as failed and releasing its file scope for replacement work
2. **Team status queries** — read-only inspection of team state (agents, tasks, open questions, pending reviews) without mutating state or waking the lead
3. **Session health tracking** — per-agent PTY liveness reporting (live, queued, dead, missing) and automatic recovery of lead-session-down gates

## Key Changes

### Task Cancellation
- Added `cancelAgentTask()` and `cancelAgentTaskLocked()` methods to `CanvasAgentTeamsService`
- Added `cancelTask()` to `TeamRuntime` that settles a task as failed, releases its owner and scope, and parks dependents
- Only the Team Lead can cancel tasks (teammates must use block-task to report blockers)
- Cancelled tasks immediately dispatch ready fallback work instead of waiting for the next tick

### Team Status & Inspection
- Added `teamStatus()` method for read-only full-team snapshots with per-agent session health
- Added `listTeamSummaries()` for one-line-per-team overview without mutating state
- Added `pulse-canvas team status` CLI command with `--team` option for detail or list-all mode
- Status queries never nudge the lead or trigger maintenance passes

### Session Health & Watchdog
- Added `CanvasAgentSessionHealth` type: `'live' | 'queued' | 'dead' | 'missing'`
- Added `collectSessionHealth()` to read PTY liveness from canvas nodes
- Added `queuedLaunchGraceMs` grace window (2 minutes) for queued launch prompts; past it, tasks escalate to review
- Added `LEAD_SESSION_DOWN_GATE_KIND` human gate that opens when lead session dies and auto-cancels on recovery
- Added `cancelRecoveredLeadDownGates()` to settle gates when lead session returns

### Placeholder Human Input Filtering
- Extracted `isPlaceholderHumanInputText()` helper to filter out template placeholders (`<question>`, truncated text, generic fallback messages)
- Prevents flooding the Team Lead backlog with unanswerable questions from agent prompt echoes

### Prompt & Documentation Updates
- Updated lead execution prompt to recommend `pulse-canvas team status` for grounding before decisions
- Updated lead notification guard to suggest status check when unsure of team state
- Added extensive comments on queued-launch grace window, lead-session-down gates, and placeholder filtering

### Dispatch & Queue Management
- Moved task prompt delivery BEFORE assignment commit in `dispatchReadyTasks()` so failed sends don't create fake in-progress tasks
- Added `persistLaunchPrompt()` call to record current task for replay on agent restart
- Added serialization queue in `sendInputToAgentNode()` to prevent concurrent sends from interleaving bytes
- Added `preserveMainOwnedQueueFields()` merge helper to graft newer queued prompts onto stale renderer saves

### Team Node Lifecycle
- Added `; exit` suffix to team agent shell commands so CLI death triggers observable PTY exit (feeds session-exit review and auto-resume)

### Tests
- Added test for queued-launch grace window escalation
- Added test for `teamStatus()` read-only behavior and session health reporting
- Added test for lead-session-down gate lifecycle (open on death, cancel on recovery)
- Added test for task cancellation releasing scope to fallback work
- Added test for concurrent send serialization
- Added test for placeholder human input filtering
- Added test for pending review nags while teammate questions are open
- Added test for `cancelTask()` releasing owner and parking dependents

## Implementation Details

- Session health is collected on-demand during snapshots and status queries, not cached
- Queued-launch grace tracking uses a `Map<agentId, tickNumber>` cleared when PTY appears or queue drains
- Lead-session-down gates carry no agent/taskId to avoid blocking lead auto-resume
- Task cancellation is a lead/human decision (teammates cannot withdraw work)
- Placeholder filtering prevents

https://claude.ai/code/session_01VtujWi1efKHnRaSLmRd5H6