### PR TITLE
Add double-click guards and Escape-cancel gestures across UI

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTerminal.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTerminal.tsx
@@ -74,6 +74,8 @@ export const AgentTerminal = ({
             ref={containerRef}
             className="agent-xterm-container"
             onMouseDown={(e) => e.stopPropagation()}
+            // Scrolling terminal output must not also pan the canvas underneath.
+            onWheel={(e) => e.stopPropagation()}
           />
           {loading && (
             <div

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
@@ -304,6 +304,13 @@ export const AgentTeamFrame = ({
   const [snapshot, setSnapshot] = useState<AgentTeamSnapshot | null>(null);
   const [loading, setLoading] = useState(false);
   const [teamAction, setTeamAction] = useState<'pause' | 'resume' | 'delete' | 'dispatch' | null>(null);
+  // In-flight guard for the plan-phase actions (Approve & Run / Continue /
+  // Finish). These fire IPC calls that re-plan or advance the team — a
+  // double-click must not submit the action twice.
+  const [planAction, setPlanAction] = useState<'confirm' | 'advance' | 'finalize' | null>(null);
+  // In-flight guard for the composer (brief / message / revise) so a second
+  // Enter during the send round-trip doesn't dispatch the same text twice.
+  const [commandSending, setCommandSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [briefDraft, setBriefDraft] = useState('');
   const [messageDraft, setMessageDraft] = useState('');
@@ -904,37 +911,52 @@ export const AgentTeamFrame = ({
   }, [api, workspaceId, teamId, briefDraft]);
 
   const handleConfirmPlan = useCallback(async () => {
-    if (!api || !workspaceId || !teamId) return;
-    const result = await api.confirmPlan(workspaceId, teamId);
-    if (result.ok && result.snapshot) {
-      setSnapshot(result.snapshot);
-      setError(null);
-    } else {
-      setError(result.error ?? 'Unable to confirm plan.');
+    if (!api || !workspaceId || !teamId || planAction) return;
+    setPlanAction('confirm');
+    try {
+      const result = await api.confirmPlan(workspaceId, teamId);
+      if (result.ok && result.snapshot) {
+        setSnapshot(result.snapshot);
+        setError(null);
+      } else {
+        setError(result.error ?? 'Unable to confirm plan.');
+      }
+    } finally {
+      setPlanAction(null);
     }
-  }, [api, workspaceId, teamId]);
+  }, [api, workspaceId, teamId, planAction]);
 
   const handleAdvanceRound = useCallback(async () => {
-    if (!api || !workspaceId || !teamId) return;
-    const result = await api.advanceRound(workspaceId, teamId);
-    if (result.ok && result.snapshot) {
-      setSnapshot(result.snapshot);
-      setError(null);
-    } else {
-      setError(result.error ?? 'Unable to advance to next round.');
+    if (!api || !workspaceId || !teamId || planAction) return;
+    setPlanAction('advance');
+    try {
+      const result = await api.advanceRound(workspaceId, teamId);
+      if (result.ok && result.snapshot) {
+        setSnapshot(result.snapshot);
+        setError(null);
+      } else {
+        setError(result.error ?? 'Unable to advance to next round.');
+      }
+    } finally {
+      setPlanAction(null);
     }
-  }, [api, workspaceId, teamId]);
+  }, [api, workspaceId, teamId, planAction]);
 
   const handleFinalizeCheckpoint = useCallback(async () => {
-    if (!api || !workspaceId || !teamId) return;
-    const result = await api.finalizeFromCheckpoint(workspaceId, teamId);
-    if (result.ok && result.snapshot) {
-      setSnapshot(result.snapshot);
-      setError(null);
-    } else {
-      setError(result.error ?? 'Unable to finalize team.');
+    if (!api || !workspaceId || !teamId || planAction) return;
+    setPlanAction('finalize');
+    try {
+      const result = await api.finalizeFromCheckpoint(workspaceId, teamId);
+      if (result.ok && result.snapshot) {
+        setSnapshot(result.snapshot);
+        setError(null);
+      } else {
+        setError(result.error ?? 'Unable to finalize team.');
+      }
+    } finally {
+      setPlanAction(null);
     }
-  }, [api, workspaceId, teamId]);
+  }, [api, workspaceId, teamId, planAction]);
 
   const handleUpdatePlanTeammate = useCallback(async (teammateName: string, agentType: string) => {
     if (!api || !workspaceId || !teamId) return;
@@ -948,28 +970,34 @@ export const AgentTeamFrame = ({
   }, [api, workspaceId, teamId]);
 
   const handleTeamCommand = useCallback(async () => {
-    if (phase === 'briefing') {
-      await handleBriefLead();
-      return;
-    }
+    if (commandSending) return;
+    setCommandSending(true);
+    try {
+      if (phase === 'briefing') {
+        await handleBriefLead();
+        return;
+      }
 
-    const content = messageDraft.trim();
-    if (!api || !workspaceId || !teamId || !lead || !content) return;
-    const revisePrefix = phase === 'plan_review'
-      ? 'The user wants to revise the current plan before approving it. Regenerate the plan incorporating this feedback:\n\n'
-      : '';
-    const taskContext = !revisePrefix && teamStatus !== 'completed' && selectedTask
-      ? `Task context: "${selectedTask.title}" (${selectedTask.status}).\n`
-      : '';
-    const result = await api.sendInput(workspaceId, teamId, lead.id, `${revisePrefix}${taskContext}${content}`);
-    if (result.ok && result.snapshot) {
-      setSnapshot(result.snapshot);
-      setMessageDraft('');
-      setError(null);
-    } else {
-      setError(result.error ?? 'Unable to send command.');
+      const content = messageDraft.trim();
+      if (!api || !workspaceId || !teamId || !lead || !content) return;
+      const revisePrefix = phase === 'plan_review'
+        ? 'The user wants to revise the current plan before approving it. Regenerate the plan incorporating this feedback:\n\n'
+        : '';
+      const taskContext = !revisePrefix && teamStatus !== 'completed' && selectedTask
+        ? `Task context: "${selectedTask.title}" (${selectedTask.status}).\n`
+        : '';
+      const result = await api.sendInput(workspaceId, teamId, lead.id, `${revisePrefix}${taskContext}${content}`);
+      if (result.ok && result.snapshot) {
+        setSnapshot(result.snapshot);
+        setMessageDraft('');
+        setError(null);
+      } else {
+        setError(result.error ?? 'Unable to send command.');
+      }
+    } finally {
+      setCommandSending(false);
     }
-  }, [api, handleBriefLead, lead, messageDraft, phase, selectedTask, teamId, teamStatus, workspaceId]);
+  }, [api, commandSending, handleBriefLead, lead, messageDraft, phase, selectedTask, teamId, teamStatus, workspaceId]);
 
   const handlePauseTeam = useCallback(async () => {
     if (!api || !workspaceId || !teamId) return;
@@ -1362,8 +1390,8 @@ export const AgentTeamFrame = ({
           rows={commandMode === 'brief' ? 8 : commandMode === 'revise' ? 3 : commandMode === 'next' ? 3 : 1}
         />
       </div>
-      <button type="button" onClick={() => void handleTeamCommand()} disabled={readOnly || !canSendCommand}>
-        {commandButtonLabel}
+      <button type="button" onClick={() => void handleTeamCommand()} disabled={readOnly || !canSendCommand || commandSending}>
+        {commandSending ? 'Sending…' : commandButtonLabel}
       </button>
     </div>
   );
@@ -1810,17 +1838,17 @@ export const AgentTeamFrame = ({
             </span>
           )}
           {phase === 'plan_review' && plan && (
-            <button type="button" className="agent-team-frame__primary-action" onClick={handleConfirmPlan} disabled={readOnly}>
-              Approve & Run
+            <button type="button" className="agent-team-frame__primary-action" onClick={handleConfirmPlan} disabled={readOnly || planAction !== null}>
+              {planAction === 'confirm' ? 'Approving…' : 'Approve & Run'}
             </button>
           )}
           {isCheckpoint && (
             <>
-              <button type="button" className="agent-team-frame__secondary-action" onClick={() => void handleFinalizeCheckpoint()} disabled={readOnly}>
-                Finish
+              <button type="button" className="agent-team-frame__secondary-action" onClick={() => void handleFinalizeCheckpoint()} disabled={readOnly || planAction !== null}>
+                {planAction === 'finalize' ? 'Finishing…' : 'Finish'}
               </button>
-              <button type="button" className="agent-team-frame__primary-action" onClick={() => void handleAdvanceRound()} disabled={readOnly}>
-                Continue to Round {(checkpointRound ?? 0) + 1}
+              <button type="button" className="agent-team-frame__primary-action" onClick={() => void handleAdvanceRound()} disabled={readOnly || planAction !== null}>
+                {planAction === 'advance' ? 'Starting…' : `Continue to Round ${(checkpointRound ?? 0) + 1}`}
               </button>
             </>
           )}
@@ -2082,17 +2110,17 @@ export const AgentTeamFrame = ({
               type="button"
               className="agent-team-frame__secondary-action"
               onClick={() => void handleFinalizeCheckpoint()}
-              disabled={readOnly}
+              disabled={readOnly || planAction !== null}
             >
-              Finish
+              {planAction === 'finalize' ? 'Finishing…' : 'Finish'}
             </button>
             <button
               type="button"
               className="agent-team-frame__primary-action"
               onClick={() => void handleAdvanceRound()}
-              disabled={readOnly}
+              disabled={readOnly || planAction !== null}
             >
-              Continue to Round {(checkpointRound ?? 0) + 1}
+              {planAction === 'advance' ? 'Starting…' : `Continue to Round ${(checkpointRound ?? 0) + 1}`}
             </button>
           </div>
         </div>

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
@@ -281,8 +281,8 @@ export const CanvasSurface = ({
           onToggleFullscreen={onToggleFullscreen}
         />
       ))}
-    {shapeDraft && <ShapeDraftPreview draft={shapeDraft} />}
-    {marqueeRect && <MarqueePreview rect={marqueeRect} />}
+    {shapeDraft && <ShapeDraftPreview draft={shapeDraft} scale={transform.scale} />}
+    {marqueeRect && <MarqueePreview rect={marqueeRect} scale={transform.scale} />}
     {snapLines && snapLines.length > 0 && (
       <CanvasAlignmentGuides lines={snapLines} scale={transform.scale} />
     )}
@@ -294,10 +294,12 @@ export const CanvasSurface = ({
  * Lives inside `.canvas-transform` so the box scales with zoom and
  * pans with the rest of the surface — matches the convention that
  * canvas-coordinate UI renders here, not in the screen-space overlay
- * layer.
+ * layer. The border width is divided by the zoom (same trick as
+ * CanvasAlignmentGuides) so it reads as ~1px on screen at any scale.
  */
-const MarqueePreview = ({ rect }: { rect: MarqueeRect }) => {
+const MarqueePreview = ({ rect, scale }: { rect: MarqueeRect; scale: number }) => {
   if (rect.width <= 0 && rect.height <= 0) return null;
+  const borderPx = 1 / Math.max(scale, 0.0001);
   return (
     <div
       className="canvas-marquee"
@@ -307,7 +309,7 @@ const MarqueePreview = ({ rect }: { rect: MarqueeRect }) => {
         top: rect.y,
         width: Math.max(1, rect.width),
         height: Math.max(1, rect.height),
-        border: '1px solid #5B7CBF',
+        border: `${borderPx}px solid #5B7CBF`,
         background: 'rgba(91, 124, 191, 0.08)',
         pointerEvents: 'none',
         boxSizing: 'border-box',
@@ -322,7 +324,7 @@ const MarqueePreview = ({ rect }: { rect: MarqueeRect }) => {
  * Pointer events are disabled so the overlay above it still receives the
  * ongoing mousemove/mouseup.
  */
-const ShapeDraftPreview = ({ draft }: { draft: ShapeDraft }) => {
+const ShapeDraftPreview = ({ draft, scale }: { draft: ShapeDraft; scale: number }) => {
   const x = Math.min(draft.start.x, draft.current.x);
   const y = Math.min(draft.start.y, draft.current.y);
   const w = Math.max(1, Math.abs(draft.current.x - draft.start.x));
@@ -348,7 +350,7 @@ const ShapeDraftPreview = ({ draft }: { draft: ShapeDraft }) => {
         height={h}
         fill="rgba(91, 124, 191, 0.08)"
         stroke="#5B7CBF"
-        strokeWidth={1.5}
+        strokeWidth={1.5 / Math.max(scale, 0.0001)}
       />
     </svg>
   );

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasMouseHandlers.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasMouseHandlers.ts
@@ -30,6 +30,10 @@ interface Options {
   onDragStart: (e: React.MouseEvent, node: CanvasNode) => void;
   onDragMove: (e: React.MouseEvent) => void;
   onDragEnd: () => void;
+  /** Abort handlers for Escape-mid-gesture: restore start positions /
+   *  dimensions without committing a history entry. */
+  onDragCancel: () => void;
+  onResizeCancel: () => void;
   resizingId: string | null;
   onResizeStart: (
     e: React.MouseEvent,
@@ -87,6 +91,8 @@ export const useCanvasMouseHandlers = ({
   onDragStart,
   onDragMove,
   onDragEnd,
+  onDragCancel,
+  onResizeCancel,
   resizingId,
   onResizeStart,
   onResizeMove,
@@ -253,15 +259,34 @@ export const useCanvasMouseHandlers = ({
     const onBlur = () => {
       if (isDraggingRef.current) handleMouseUp();
     };
+    // Escape aborts an in-flight node drag/resize: nodes snap back to where
+    // the gesture found them and no history entry is committed. Capture
+    // phase + stopPropagation so the canvas-level Escape handler doesn't
+    // also clear the selection on the same press.
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' || !isDraggingRef.current) return;
+      e.stopPropagation();
+      onDragCancel();
+      onResizeCancel();
+      isDraggingRef.current = false;
+      setNodeGestureActive(false);
+      // The trailing mouseup must not commit, sync parents, or let its
+      // click clear the selection that was just restored.
+      if (nodeGestureMovedRef.current) suppressBlankClickRef.current = true;
+      nodeGestureMovedRef.current = false;
+      pendingParentNodesRef.current = null;
+    };
     window.addEventListener('mousemove', onMove);
     window.addEventListener('mouseup', onUp);
     window.addEventListener('blur', onBlur);
+    window.addEventListener('keydown', onKeyDown, true);
     return () => {
       window.removeEventListener('mousemove', onMove);
       window.removeEventListener('mouseup', onUp);
       window.removeEventListener('blur', onBlur);
+      window.removeEventListener('keydown', onKeyDown, true);
     };
-  }, [handleWindowDragMove, handleMouseUp]);
+  }, [handleWindowDragMove, handleMouseUp, onDragCancel, onResizeCancel, suppressBlankClickRef]);
 
   useEffect(() => {
     const container = containerRef.current;

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -150,6 +150,20 @@ export const Canvas = ({
 
   useEffect(() => { nodesRef.current = nodes; }, [nodes]);
 
+  // React's root wheel listener is passive, so useCanvas.handleWheel cannot
+  // suppress Chromium's default ctrl/meta+wheel page zoom (trackpad pinch
+  // arrives as ctrl+wheel). Block it with a native non-passive listener;
+  // the zoom itself still runs through the synthetic handler.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const blockNativeZoom = (e: WheelEvent) => {
+      if (e.ctrlKey || e.metaKey) e.preventDefault();
+    };
+    el.addEventListener('wheel', blockNativeZoom, { passive: false });
+    return () => el.removeEventListener('wheel', blockNativeZoom);
+  }, [loaded]);
+
   const {
     selectedNodeIds, setSelectedNodeIds,
     selectedEdgeId, setSelectedEdgeId,

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -311,10 +311,10 @@ export const Canvas = ({
     handleNodeViewportFocus(node);
   }, [handleNodeViewportFocus]);
 
-  const { draggingId, draggingIds, snapLines, onDragStart, onDragMove, onDragEnd } = useNodeDrag(
+  const { draggingId, draggingIds, snapLines, onDragStart, onDragMove, onDragEnd, onDragCancel } = useNodeDrag(
     moveNode, moveNodes, transform.scale, nodes, selectedNodeIds,
   );
-  const { resizingId, onResizeStart, onResizeMove, onResizeEnd } =
+  const { resizingId, onResizeStart, onResizeMove, onResizeEnd, onResizeCancel } =
     useNodeResize(resizeNode, transform.scale);
 
   const { sortedNodes, renderGroups } = useCanvasRenderOrder(nodes);
@@ -444,6 +444,7 @@ export const Canvas = ({
     canvasMouseDown, canvasMouseMove, canvasMouseUp,
     moving, panning,
     onDragStart, onDragMove, onDragEnd,
+    onDragCancel, onResizeCancel,
     resizingId, onResizeStart, onResizeMove, onResizeEnd,
     edgeInteractionState, marquee, shapeToolActive, shapeDraft,
     commitHistory, onNodesChange,

--- a/apps/canvas-workspace/src/renderer/src/components/EdgeStylePanel/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeStylePanel/index.css
@@ -1,6 +1,7 @@
 /* Floating panel shown when an edge is selected. Positioned via inline
-   left/top, centered horizontally on the anchor point and shifted up so
-   its bottom edge sits ~12px above the anchor.
+   left/top/transform, centered horizontally on the anchor point and shifted
+   up so its bottom edge sits ~12px above the anchor — the component clamps
+   it into the container and flips it below the anchor near the top edge.
 
    Layout is a two-level "chip row + popover":
      • chip row — one chip per property, showing its current value as a
@@ -10,7 +11,6 @@
    Selecting a value auto-collapses the popover back to the chip row. */
 .edge-style-panel {
   position: absolute;
-  transform: translate(-50%, calc(-100% - 12px));
   display: flex;
   flex-direction: column;
   align-items: stretch;

--- a/apps/canvas-workspace/src/renderer/src/components/EdgeStylePanel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeStylePanel/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import './index.css';
 import type {
   CanvasEdge,
@@ -12,6 +12,7 @@ import {
   resolveEndpoint,
   resolveEndpointToward,
 } from '../../utils/edgeFactory';
+import { useEscapeClose } from '../../hooks/useEscapeClose';
 
 /**
  * A compact floating panel, shown when an edge is selected, that lets
@@ -171,6 +172,9 @@ export const EdgeStylePanel = ({
   useEffect(() => {
     setOpenSection(null);
   }, [edge.id]);
+  // First Escape collapses the open option list; with nothing open the press
+  // falls through to the canvas handler (deselects the edge).
+  useEscapeClose(openSection !== null, () => setOpenSection(null));
 
   // Resolve the edge's midpoint in canvas coords (accounts for bend),
   // then convert to screen coords via the current transform. The panel
@@ -188,6 +192,27 @@ export const EdgeStylePanel = ({
       y: mid.y * transform.scale + transform.y,
     };
   }, [edge, nodes, transform]);
+
+  // Keep the panel inside the canvas container: the CSS default hangs it
+  // centered above the anchor, which cuts it off when the edge sits near the
+  // top or side edges of the viewport. Measure after layout, clamp
+  // horizontally, and flip below the anchor when there's no room above.
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [placement, setPlacement] = useState<{ left: number; top: number; flipped: boolean } | null>(null);
+  useLayoutEffect(() => {
+    const el = panelRef.current;
+    if (!el) return;
+    const host = el.offsetParent as HTMLElement | null;
+    const hostW = host?.clientWidth ?? window.innerWidth;
+    const margin = 8;
+    const gap = 12;
+    const w = el.offsetWidth;
+    const h = el.offsetHeight;
+    const halfW = w / 2;
+    const left = Math.max(margin + halfW, Math.min(screenPos.x, hostW - margin - halfW));
+    const flipped = screenPos.y - h - gap < margin;
+    setPlacement({ left, top: screenPos.y, flipped });
+  }, [screenPos.x, screenPos.y, openSection]);
 
   const setStroke = (patch: Partial<EdgeStroke>) => {
     onUpdate(edge.id, { stroke: { ...edge.stroke, ...patch } });
@@ -221,8 +246,16 @@ export const EdgeStylePanel = ({
 
   return (
     <div
+      ref={panelRef}
       className="edge-style-panel"
-      style={{ left: screenPos.x, top: screenPos.y }}
+      style={{
+        left: placement?.left ?? screenPos.x,
+        top: placement?.top ?? screenPos.y,
+        // Above the anchor by default; below it when clamped at the top.
+        transform: placement?.flipped
+          ? 'translate(-50%, 12px)'
+          : 'translate(-50%, calc(-100% - 12px))',
+      }}
       // Stop propagation so our own clicks don't hit the canvas-level
       // blank-click handler (which would deselect the edge we're styling).
       onMouseDown={(e) => e.stopPropagation()}

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBubbleMenu/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBubbleMenu/index.css
@@ -1,7 +1,8 @@
 .note-bubble-menu {
   position: fixed;
   z-index: 9000;
-  transform: translate(-50%, calc(-100% - 8px));
+  /* transform (above vs below the selection) is set inline by the
+     component, which clamps the menu into the viewport. */
   display: flex;
   align-items: center;
   gap: 1px;

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBubbleMenu/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBubbleMenu/index.tsx
@@ -1,3 +1,4 @@
+import { useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import './index.css';
 import type { Editor } from '@tiptap/react';
@@ -9,10 +10,42 @@ interface Props {
   onOpenLinkPrompt: () => void;
 }
 
-export const FileNodeBubbleMenu = ({ editor, bubble, onOpenLinkPrompt }: Props) => createPortal(
+const VIEWPORT_MARGIN_PX = 8;
+const SELECTION_GAP_PX = 8;
+
+export const FileNodeBubbleMenu = ({ editor, bubble, onOpenLinkPrompt }: Props) => {
+  // The CSS default hangs the menu centered above the selection, which cuts
+  // it off for selections near the top or side edges of the window. Measure
+  // after layout, clamp horizontally, and flip below the selection when
+  // there's no room above.
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [placement, setPlacement] = useState<{ left: number; top: number; flipped: boolean } | null>(null);
+  useLayoutEffect(() => {
+    const el = menuRef.current;
+    if (!el) return;
+    const w = el.offsetWidth;
+    const h = el.offsetHeight;
+    const halfW = w / 2;
+    const left = Math.max(
+      VIEWPORT_MARGIN_PX + halfW,
+      Math.min(bubble.x, window.innerWidth - VIEWPORT_MARGIN_PX - halfW),
+    );
+    const flipped = bubble.y - h - SELECTION_GAP_PX < VIEWPORT_MARGIN_PX;
+    setPlacement({ left, top: flipped ? bubble.bottom : bubble.y, flipped });
+  }, [bubble.x, bubble.y, bubble.bottom]);
+
+  return createPortal(
   <div
+    ref={menuRef}
     className="note-bubble-menu"
-    style={{ left: bubble.x, top: bubble.y }}
+    style={{
+      left: placement?.left ?? bubble.x,
+      top: placement?.top ?? bubble.y,
+      // Above the selection by default; below it when clamped at the top.
+      transform: placement?.flipped
+        ? `translate(-50%, ${SELECTION_GAP_PX}px)`
+        : `translate(-50%, calc(-100% - ${SELECTION_GAP_PX}px))`,
+    }}
     onMouseDown={(e) => e.preventDefault()}
   >
     <button
@@ -137,4 +170,5 @@ export const FileNodeBubbleMenu = ({ editor, bubble, onOpenLinkPrompt }: Props) 
     </button>
   </div>,
   document.body,
-);
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import "./index.css";
 import type { CanvasNode, FrameNodeData } from "../../types";
 import { AgentTeamFrame } from "../AgentTeamFrame";
+import { useEscapeClose } from "../../hooks/useEscapeClose";
 
 interface Props {
   node: CanvasNode;
@@ -88,6 +89,8 @@ export const FrameColorPicker = ({ node, onUpdate }: ColorPickerProps) => {
     document.addEventListener('mousedown', handleClick);
     return () => document.removeEventListener('mousedown', handleClick);
   }, [open]);
+
+  useEscapeClose(open, () => setOpen(false));
 
   return (
     <div

--- a/apps/canvas-workspace/src/renderer/src/components/NoteFindBar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NoteFindBar/index.tsx
@@ -102,7 +102,14 @@ export const NoteFindBar = ({ editor, onClose }: Props) => {
             value={replacement}
             onChange={(e) => setReplacement(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === 'Escape') onClose();
+              if (isImeComposing(e)) return;
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                onClose();
+              } else if (e.key === 'Enter') {
+                e.preventDefault();
+                if (total > 0) replaceCurrentMatch(editor.view, replacement);
+              }
             }}
           />
           <button

--- a/apps/canvas-workspace/src/renderer/src/components/ShapeNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ShapeNodeBody/index.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react
 import './index.css';
 import type { CanvasNode, ShapeNodeData } from '../../types';
 import { ShapePrimitive } from '../../utils/shapeGeometry';
+import { isImeComposing } from '../../utils/ime';
+import { useEscapeClose } from '../../hooks/useEscapeClose';
 
 interface Props {
   node: CanvasNode;
@@ -113,6 +115,9 @@ export const ShapeNodeBody = ({ node, isSelected, onSelect, onDragStart, onUpdat
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (readOnly) return;
+      // Escape/Enter mid-IME-composition steer the candidate window —
+      // cancelling or committing there would eat the half-typed CJK input.
+      if (isImeComposing(e)) return;
       if (e.key === 'Escape') {
         e.preventDefault();
         cancel();
@@ -240,6 +245,8 @@ export const ShapeStylePicker = ({ node, onUpdate }: StylePickerProps) => {
     document.addEventListener('mousedown', handle);
     return () => document.removeEventListener('mousedown', handle);
   }, [open]);
+
+  useEscapeClose(open, () => setOpen(false));
 
   const patch = useCallback(
     (next: Partial<ShapeNodeData>) => {

--- a/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody/index.tsx
@@ -267,6 +267,8 @@ export const TerminalNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, w
         ref={containerRef}
         className="terminal-xterm-container"
         onMouseDown={(e) => e.stopPropagation()}
+        // Scrolling terminal output must not also pan the canvas underneath.
+        onWheel={(e) => e.stopPropagation()}
       />
     </div>
   );

--- a/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody/index.tsx
@@ -140,6 +140,7 @@ export const TerminalNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, w
     // If an initial command is set, wait for the shell prompt before writing it.
     // Otherwise attach the data listener immediately.
     let removeData: (() => void) | null = null;
+    let removePrompt: (() => void) | null = null;
     const cmdToRun = initialCommand.current;
 
     if (cmdToRun) {
@@ -149,12 +150,14 @@ export const TerminalNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, w
         if (!prompted) {
           prompted = true;
           promptRemove();
+          removePrompt = null;
           removeData = api.onData(sessionId, (d2: string) => { term.write(d2); });
           setTimeout(() => api.write(sessionId, `${cmdToRun}\n`), 100);
           // Clear so it doesn't re-run on session restore
           initialCommand.current = '';
         }
       });
+      removePrompt = promptRemove;
     } else {
       removeData = api.onData(sessionId, (d: string) => { term.write(d); });
     }
@@ -191,6 +194,9 @@ export const TerminalNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, w
     }, SCROLLBACK_SAVE_INTERVAL);
 
     cleanupRef.current = () => {
+      // If the node unmounts before the shell prompt ever arrived, the
+      // prompt listener is still registered — drop it too.
+      removePrompt?.();
       removeData?.();
       removeExit();
       api.kill(sessionId);

--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.tsx
@@ -6,6 +6,8 @@ import Placeholder from "@tiptap/extension-placeholder";
 import { Markdown } from "tiptap-markdown";
 import "./index.css";
 import type { CanvasNode, TextNodeData } from "../../types";
+import { isImeComposing } from "../../utils/ime";
+import { useEscapeClose } from "../../hooks/useEscapeClose";
 
 interface Props {
   node: CanvasNode;
@@ -214,6 +216,9 @@ export const TextNodeBody = ({ node, onUpdate, isSelected, onSelect, onDragStart
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (readOnly) return;
+      // Escape mid-IME-composition dismisses the candidate window — exiting
+      // edit mode there would eat the half-typed CJK input.
+      if (isImeComposing(e)) return;
       if (e.key === "Escape") {
         e.preventDefault();
         editor?.commands.blur();
@@ -306,6 +311,8 @@ const TextColorTrigger = ({
     document.addEventListener("mousedown", handleClick);
     return () => document.removeEventListener("mousedown", handleClick);
   }, [open]);
+
+  useEscapeClose(open, () => setOpen(false));
 
   const isTransparent = currentValue === "transparent";
 

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
@@ -396,9 +396,14 @@ export const Workbench: React.FC<WorkbenchProps> = ({
   }, [allNodes, mountedWorkspaceIds, patchWorkspaceNodeSnapshot]);
 
   const resizing = useRef(false);
+  // Tear-down for an in-flight resize drag — also invoked on unmount so the
+  // document can't get stuck with col-resize cursor / user-select disabled.
+  const stopResizeRef = useRef<(() => void) | null>(null);
+  useEffect(() => () => stopResizeRef.current?.(), []);
 
   const handleResizeStart = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
+    stopResizeRef.current?.();
     resizing.current = true;
     const startX = e.clientX;
     const startWidth = chatWidth;
@@ -409,7 +414,9 @@ export const Workbench: React.FC<WorkbenchProps> = ({
       setChatWidth(newWidth);
     };
 
-    const onMouseUp = () => {
+    const onMouseUp = () => stopResizeRef.current?.();
+    stopResizeRef.current = () => {
+      stopResizeRef.current = null;
       resizing.current = false;
       document.removeEventListener('mousemove', onMouseMove);
       document.removeEventListener('mouseup', onMouseUp);

--- a/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/NodesChatDock.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/NodesChatDock.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { MouseEvent as ReactMouseEvent } from 'react';
 import type { CanvasNode, KnowledgeTagDefinition, WorkspaceNodeListItem } from '../../types';
 import { ChatPanel } from '../chat';
@@ -60,15 +60,24 @@ export function useNodesChatDock() {
   const openDock = useCallback(() => setOpen(true), []);
   const closeDock = useCallback(() => setOpen(false), []);
 
+  // Tear-down for an in-flight resize drag — also invoked on unmount so a
+  // page switch mid-drag can't leak window listeners or leave the document
+  // stuck with `user-select: none`.
+  const stopResizeRef = useRef<(() => void) | null>(null);
+  useEffect(() => () => stopResizeRef.current?.(), []);
+
   const beginResize = useCallback((event: ReactMouseEvent) => {
     event.preventDefault();
+    stopResizeRef.current?.();
     const startX = event.clientX;
     const startWidth = width;
     const onMove = (move: MouseEvent) => {
       // Dock is pinned to the right edge, so dragging left widens it.
       setWidth(clampWidth(startWidth + (startX - move.clientX)));
     };
-    const onUp = () => {
+    const onUp = () => stopResizeRef.current?.();
+    stopResizeRef.current = () => {
+      stopResizeRef.current = null;
       window.removeEventListener('mousemove', onMove);
       window.removeEventListener('mouseup', onUp);
       document.body.style.userSelect = '';

--- a/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/NodesPage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/NodesPage.tsx
@@ -101,10 +101,14 @@ export const NodesPage = ({
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
 
+  // Reset pagination/scroll only when the user changes a filter — NOT on
+  // every `filteredNodes` identity change. Background reloads (live
+  // workspace-node change events, drawer edits) rebuild the array each time
+  // and would otherwise yank the list back to the top mid-browse.
   useEffect(() => {
     setVisibleCount(NODES_PAGE_SIZE);
     scrollRef.current?.scrollTo({ top: 0 });
-  }, [filteredNodes]);
+  }, [query, typeFilter, tagFilter, activeWorkspaceIds]);
 
   const visibleNodes = useMemo(
     () => filteredNodes.slice(0, visibleCount),

--- a/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/useWorkspaceNodes.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/useWorkspaceNodes.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { KnowledgeTagDefinition, WorkspaceNodeListItem, WorkspaceNodeRecord } from '../../types';
 import type { WorkspaceEntry } from '../../hooks/useWorkspaces';
 import { isKnowledgeNodeType } from './utils';
@@ -10,14 +10,19 @@ export function useWorkspaceNodeList(workspaceId: string) {
   const [tags, setTags] = useState<KnowledgeTagDefinition[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Live change events and manual refreshes can overlap; only the newest
+  // reload may apply its results.
+  const requestSeqRef = useRef(0);
 
   const reload = useCallback(async () => {
+    const seq = ++requestSeqRef.current;
     const api = window.canvasWorkspace?.workspaceNodes;
     if (!api || !workspaceId) return;
     setLoading(true);
     setError(null);
     try {
       const result = await api.list(workspaceId);
+      if (seq !== requestSeqRef.current) return;
       if (!result.ok) {
         setError(result.error ?? t('workspaceNodes.loadNodesFailed'));
         setNodes([]);
@@ -27,11 +32,12 @@ export function useWorkspaceNodeList(workspaceId: string) {
       setNodes(result.nodes ?? []);
       setTags(result.tags ?? []);
     } catch (err) {
+      if (seq !== requestSeqRef.current) return;
       setError(err instanceof Error ? err.message : String(err));
       setNodes([]);
       setTags([]);
     } finally {
-      setLoading(false);
+      if (seq === requestSeqRef.current) setLoading(false);
     }
   }, [workspaceId, t]);
 
@@ -60,8 +66,12 @@ export function useAllWorkspaceNodeList(workspaces: WorkspaceEntry[]) {
   const [tags, setTags] = useState<KnowledgeTagDefinition[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Live change events and manual refreshes can overlap; only the newest
+  // reload may apply its results.
+  const requestSeqRef = useRef(0);
 
   const reload = useCallback(async () => {
+    const seq = ++requestSeqRef.current;
     const api = window.canvasWorkspace?.workspaceNodes;
     if (!api) return;
     setLoading(true);
@@ -76,6 +86,7 @@ export function useAllWorkspaceNodeList(workspaces: WorkspaceEntry[]) {
           return { workspace, result };
         }),
       );
+      if (seq !== requestSeqRef.current) return;
       const tagMap = new Map<string, KnowledgeTagDefinition>();
       const nextNodes: WorkspaceNodeListItem[] = [];
       for (const { workspace, result } of results) {
@@ -93,11 +104,12 @@ export function useAllWorkspaceNodeList(workspaces: WorkspaceEntry[]) {
       setNodes(nextNodes);
       setTags(Array.from(tagMap.values()).sort((a, b) => a.name.localeCompare(b.name)));
     } catch (err) {
+      if (seq !== requestSeqRef.current) return;
       setError(err instanceof Error ? err.message : String(err));
       setNodes([]);
       setTags([]);
     } finally {
-      setLoading(false);
+      if (seq === requestSeqRef.current) setLoading(false);
     }
   }, [workspaces, t]);
 
@@ -124,8 +136,12 @@ export function useWorkspaceNode(workspaceId: string, nodeId: string | null) {
   const [node, setNode] = useState<WorkspaceNodeRecord | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Monotonic id of the latest read. Clicking node A then node B fires two
+  // overlapping reads; if A's resolves last it must not clobber B's record.
+  const requestSeqRef = useRef(0);
 
   const reload = useCallback(async () => {
+    const seq = ++requestSeqRef.current;
     const api = window.canvasWorkspace?.workspaceNodes;
     if (!api || !workspaceId || !nodeId) {
       setNode(null);
@@ -135,6 +151,7 @@ export function useWorkspaceNode(workspaceId: string, nodeId: string | null) {
     setError(null);
     try {
       const result = await api.read(workspaceId, nodeId);
+      if (seq !== requestSeqRef.current) return;
       if (!result.ok) {
         setError(result.error ?? t('workspaceNodes.loadNodeFailed'));
         setNode(null);
@@ -142,10 +159,11 @@ export function useWorkspaceNode(workspaceId: string, nodeId: string | null) {
       }
       setNode(result.node ?? null);
     } catch (err) {
+      if (seq !== requestSeqRef.current) return;
       setError(err instanceof Error ? err.message : String(err));
       setNode(null);
     } finally {
-      setLoading(false);
+      if (seq === requestSeqRef.current) setLoading(false);
     }
   }, [workspaceId, nodeId, t]);
 

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
@@ -4,6 +4,7 @@ import { toFileUrl } from '../../utils/fileUrl';
 import { BotAvatarIcon, CheckIcon, CopyIcon, PencilIcon, RefreshIcon } from '../icons';
 import type { ToolCallStatus } from './types';
 import { renderMdWithMentions } from './utils/mentions';
+import { isImeComposing } from '../../utils/ime';
 import { renderMermaidIn } from './utils/mermaid';
 import { formatAbsoluteTime, formatRelativeTime } from './utils/time';
 import { ChatToolCalls } from './ChatToolCalls';
@@ -150,11 +151,17 @@ export const ChatMessage = ({
     if (!onEditUserMessage) return;
     const trimmed = editValue.trim();
     if (!trimmed) return;
-    setIsEditing(false);
-    await onEditUserMessage(index, trimmed);
+    // Close the editor only when the rewind+resend actually went through —
+    // otherwise (e.g. another turn is still streaming) the user's edited
+    // text would be silently discarded.
+    const ok = await onEditUserMessage(index, trimmed);
+    if (ok !== false) setIsEditing(false);
   }, [editValue, index, onEditUserMessage]);
 
   const handleEditKeyDown = useCallback((event: KeyboardEvent<HTMLTextAreaElement>) => {
+    // Escape/Enter during IME composition dismiss/confirm the candidate
+    // text — cancelling the edit or saving there would eat CJK input.
+    if (isImeComposing(event)) return;
     if (event.key === 'Escape') {
       event.preventDefault();
       handleCancelEdit();

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageBody.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageBody.tsx
@@ -303,14 +303,23 @@ export const ChatPageBody = ({
     return unified;
   }, [sessions, otherSessions, workspaceId, allWorkspaces]);
 
+  // Session switches are blocked while a turn is streaming — swapping the
+  // message list mid-generation would let the in-flight stream write into
+  // the newly loaded session. Same rule as the session-ref chips.
   const handleRailNewSession = useCallback(async () => {
+    if (loading) return;
     onClearBackStack?.();
     if (agentScope.kind !== 'global') {
       onNewGlobalSession();
       return;
     }
     await handleNewSession();
-  }, [agentScope.kind, handleNewSession, onClearBackStack, onNewGlobalSession]);
+  }, [agentScope.kind, handleNewSession, loading, onClearBackStack, onNewGlobalSession]);
+
+  const handleRailSelectSession = useCallback((session: UnifiedSession) => {
+    if (loading) return;
+    onSelectSession(session);
+  }, [loading, onSelectSession]);
 
   return (
     <>
@@ -319,7 +328,7 @@ export const ChatPageBody = ({
         <ChatSessionsRail
           allSessions={allSessions}
           onNewSession={handleRailNewSession}
-          onSelectSession={onSelectSession}
+          onSelectSession={handleRailSelectSession}
         />
       </div>
 

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
@@ -2619,6 +2619,20 @@
   background: rgba(180, 35, 24, 0.08);
 }
 
+/* Armed state: first click expands the trash icon into an explicit
+   "click again to remove" pill; a second click actually deletes. */
+.chat-model-danger-btn--confirm {
+  width: auto;
+  padding: 0 11px;
+  color: #fff;
+  background: #b42318;
+  border-color: #b42318;
+}
+
+.chat-model-danger-btn--confirm:hover {
+  background: #9a1d13;
+}
+
 .chat-model-model-list {
   min-height: 42px;
   display: flex;

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.tsx
@@ -261,16 +261,21 @@ export const ChatPanel = ({
     await jumpToSession(entry.sessionId, entry.workspaceId);
   }, [jumpToSession, sessionBackStack]);
 
-  // Manual session switches reset the jump trail.
+  // Manual session switches reset the jump trail. Both are blocked while a
+  // turn is streaming — same rule as session-ref chips and the back bar:
+  // swapping the message list mid-generation would let the in-flight
+  // stream write into the newly loaded session.
   const handleNewSessionFromMenu = useCallback(async () => {
+    if (loading) return;
     setSessionBackStack([]);
     await handleNewSession();
-  }, [handleNewSession]);
+  }, [handleNewSession, loading]);
 
   const handleLoadSessionFromMenu = useCallback(async (sessionId: string, sourceWorkspaceId?: string) => {
+    if (loading) return;
     setSessionBackStack([]);
     await handleLoadSession(sessionId, sourceWorkspaceId);
-  }, [handleLoadSession]);
+  }, [handleLoadSession, loading]);
 
   const backEntry = sessionBackStack[sessionBackStack.length - 1];
 

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ModelSwitcher.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ModelSwitcher.tsx
@@ -5,6 +5,7 @@ import { CheckIcon } from '../icons';
 import type { ModelSelection } from './modelSettingsTypes';
 import { providerLabel } from './modelSettingsTypes';
 import { useI18n } from '../../i18n';
+import { useEscapeClose } from '../../hooks/useEscapeClose';
 
 interface ModelSwitcherProps {
   status?: CanvasModelStatus;
@@ -64,6 +65,8 @@ export const ModelSwitcher = ({
     }
     updateMenuPosition();
   }, [open, updateMenuPosition]);
+
+  useEscapeClose(open, () => setOpen(false));
 
   useEffect(() => {
     if (!open) return;

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ModelsSection.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ModelsSection.tsx
@@ -64,6 +64,20 @@ export const ModelsSection = ({
   const [saving, setSaving] = useState(false);
   const [fetching, setFetching] = useState(false);
   const [localError, setLocalError] = useState<string>();
+  // Deleting a provider discards its saved API-key config with no undo, so
+  // the trash button arms on the first click and deletes on the second.
+  // Switching providers or pausing 3s disarms it.
+  const [confirmingRemove, setConfirmingRemove] = useState(false);
+
+  useEffect(() => {
+    setConfirmingRemove(false);
+  }, [activeProviderId]);
+
+  useEffect(() => {
+    if (!confirmingRemove) return;
+    const timer = window.setTimeout(() => setConfirmingRemove(false), 3000);
+    return () => window.clearTimeout(timer);
+  }, [confirmingRemove]);
 
   const activeProviderStatus = useMemo(
     () => providers.find((item) => item.id === activeProviderId),
@@ -199,10 +213,20 @@ export const ModelsSection = ({
             {activeProviderId !== 'new' && (
               <button
                 type="button"
-                className="chat-model-danger-btn"
-                onClick={() => void onRemoveProvider(activeProviderId)}
+                className={`chat-model-danger-btn${confirmingRemove ? ' chat-model-danger-btn--confirm' : ''}`}
+                title={t('models.removeProvider')}
+                aria-label={t('models.removeProvider')}
+                onClick={() => {
+                  if (!confirmingRemove) {
+                    setConfirmingRemove(true);
+                    return;
+                  }
+                  setConfirmingRemove(false);
+                  void onRemoveProvider(activeProviderId);
+                }}
               >
                 <TrashIcon />
+                {confirmingRemove && <span>{t('models.removeProviderConfirm')}</span>}
               </button>
             )}
           </div>

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatSessions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatSessions.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { AgentChatMessage, AgentSessionInfo } from '../../../types';
 import type { AgentScope, OtherWorkspaceSession, WorkspaceOption } from '../types';
+import { useEscapeClose } from '../../../hooks/useEscapeClose';
 
 interface UseChatSessionsOptions {
   agentScope: AgentScope;
@@ -64,6 +65,8 @@ export function useChatSessions({
     document.addEventListener('mousedown', handleMouseDown);
     return () => document.removeEventListener('mousedown', handleMouseDown);
   }, [sessionMenuOpen]);
+
+  useEscapeClose(sessionMenuOpen, () => setSessionMenuOpen(false));
 
   const loadSessions = useCallback(async () => {
       setSessionsLoading(true);

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatStream.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatStream.ts
@@ -39,6 +39,13 @@ export function useChatStream({ agentScope, allWorkspaces }: UseChatStreamOption
     setActiveSessionId(null);
     setPendingClarify(null);
     setClarifyInput('');
+    // A scope switch mid-turn unsubscribes the stream events below, so the
+    // completion event that would normally reset these never arrives —
+    // without this the new scope starts with a permanently spinning
+    // composer and stale tool chips.
+    setLoading(false);
+    setStreamingTools([]);
+    streamingMsgIdx.current = -1;
 
     return cleanupSubscriptions;
   }, [cleanupSubscriptions, scopeKey]);
@@ -57,6 +64,11 @@ export function useChatStream({ agentScope, allWorkspaces }: UseChatStreamOption
         message.role === 'assistant' && message.toolCalls?.length ? [index] : []
       )),
     ));
+    // Tool ids are minted per turn; after a wholesale message swap the old
+    // ids never come back, so drop their expansion state instead of letting
+    // the set grow (and avoid stale chips from a superseded stream).
+    setExpandedTools(new Set());
+    setStreamingTools([]);
   }, []);
 
   const sendMessage = useCallback(async (rawText: string, requestContext?: AgentRequestContext, attachments: ChatImageAttachment[] = []) => {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useMentions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useMentions.ts
@@ -80,6 +80,13 @@ export function useMentions({
    * which prefix to strip when it splices the chip in.
    */
   const mentionTriggerRef = useRef<'@' | '/'>('@');
+  /**
+   * Monotonic id of the latest popup build. buildMentionItems is async (file
+   * listing, session search), so when the user types quickly an older, slower
+   * build can resolve after a newer one — or after the popup was dismissed —
+   * and must not apply its stale items / reopen the popup.
+   */
+  const mentionBuildSeqRef = useRef(0);
 
   const insertNodeMention = useCallback((node: CanvasNode) => {
     const element = editableRef.current;
@@ -118,6 +125,7 @@ export function useMentions({
 
   const clearInput = useCallback(() => {
     setInput('');
+    mentionBuildSeqRef.current++;
     setMentionOpen(false);
     setMentionItems([]);
     setMentionIndex(0);
@@ -252,6 +260,9 @@ export function useMentions({
 
     setInput(serializeEditable(element));
 
+    // Every input event supersedes any in-flight popup build.
+    const buildSeq = ++mentionBuildSeqRef.current;
+
     const selection = window.getSelection();
     if (
       !selection
@@ -283,6 +294,7 @@ export function useMentions({
 
     setMentionIndex(0);
     void buildMentionItems(match[1], trigger).then(items => {
+      if (buildSeq !== mentionBuildSeqRef.current) return;
       setMentionItems(items);
       setMentionOpen(items.length > 0);
     });
@@ -298,6 +310,7 @@ export function useMentions({
       if (!target) return;
       if (editableRef.current?.contains(target)) return;
       if (target.closest('.chat-mention-popup')) return;
+      mentionBuildSeqRef.current++;
       setMentionOpen(false);
     };
     document.addEventListener('mousedown', handleMouseDown);
@@ -344,6 +357,7 @@ export function useMentions({
     selection.addRange(range);
 
     setInput(serializeEditable(element));
+    mentionBuildSeqRef.current++;
     setMentionOpen(false);
     element.focus();
   }, [nodes]);
@@ -397,6 +411,7 @@ export function useMentions({
 
       if (event.key === 'Escape') {
         event.preventDefault();
+        mentionBuildSeqRef.current++;
         setMentionOpen(false);
         return;
       }

--- a/apps/canvas-workspace/src/renderer/src/hooks/useCanvas.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useCanvas.ts
@@ -50,10 +50,14 @@ export const useCanvas = (isHandTool = false) => {
     };
   }, []);
 
+  // NOTE: React (17+) registers root `wheel` listeners as passive, so this
+  // synthetic handler cannot preventDefault — Chromium would log an
+  // intervention error on every pinch and the default ctrl+wheel page zoom
+  // would still fire. The Canvas component attaches a native
+  // `{ passive: false }` wheel listener that does the preventDefault.
   const handleWheel = useCallback((e: React.WheelEvent) => {
     markMoving();
     if (e.ctrlKey || e.metaKey) {
-      e.preventDefault();
       e.stopPropagation();
       const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
       const mx = e.clientX - rect.left;

--- a/apps/canvas-workspace/src/renderer/src/hooks/useEdgeInteraction.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useEdgeInteraction.ts
@@ -40,6 +40,9 @@ export type EdgeInteractionState =
        *  so preview math stays stable even if its node gets moved by
        *  some other hook. */
       frozen: EdgeEndpoint;
+      /** The dragged end's endpoint at drag start — restored when the
+       *  gesture is cancelled with Escape. */
+      original: EdgeEndpoint;
       cursor: Point;
       hoverNodeId: string | null;
     }
@@ -273,6 +276,30 @@ export const useEdgeInteraction = ({
     setState(null);
   }, [addEdge, commitHistory, onConnectCommitted]);
 
+  /** Abort the gesture (Escape): undo the history-silent live updates by
+   *  restoring the drag-start endpoints/bend, then drop the state without
+   *  committing. A connect draft simply disappears. */
+  const handleCancel = useCallback(() => {
+    const current = stateRef.current;
+    if (!current) return;
+    if (current.kind === 'move-end') {
+      updateEdge(
+        current.edgeId,
+        current.end === 'source' ? { source: current.original } : { target: current.original },
+        false,
+      );
+    } else if (current.kind === 'move-bend') {
+      updateEdge(current.edgeId, { bend: current.originBend }, false);
+    } else if (current.kind === 'move-edge') {
+      updateEdge(
+        current.edgeId,
+        { source: current.initialSource, target: current.initialTarget },
+        false,
+      );
+    }
+    setState(null);
+  }, [updateEdge]);
+
   // Window-level listeners are installed only while an interaction is
   // live. Using window (not the canvas container) means the drag keeps
   // tracking when the cursor slips off the canvas — matches the
@@ -281,13 +308,27 @@ export const useEdgeInteraction = ({
     if (!state) return;
     const onMove = (e: MouseEvent) => handleMove(e.clientX, e.clientY);
     const onUp = () => handleUp();
+    // Window focus loss never delivers the mouseup — finish the gesture
+    // like the node-drag handlers do, so the edge isn't left half-dragged.
+    const onBlur = () => handleUp();
+    // Escape aborts; capture + stopPropagation keeps the canvas-level
+    // Escape handler from also deselecting on the same press.
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      e.stopPropagation();
+      handleCancel();
+    };
     window.addEventListener('mousemove', onMove);
     window.addEventListener('mouseup', onUp);
+    window.addEventListener('blur', onBlur);
+    window.addEventListener('keydown', onKeyDown, true);
     return () => {
       window.removeEventListener('mousemove', onMove);
       window.removeEventListener('mouseup', onUp);
+      window.removeEventListener('blur', onBlur);
+      window.removeEventListener('keydown', onKeyDown, true);
     };
-  }, [state, handleMove, handleUp]);
+  }, [state, handleMove, handleUp, handleCancel]);
 
   /**
    * Begin drawing a new edge. Called by the connect-mode overlay.
@@ -321,12 +362,14 @@ export const useEdgeInteraction = ({
     const edge = edges.find((e) => e.id === edgeId);
     if (!edge) return;
     const frozen = end === 'source' ? edge.target : edge.source;
+    const original = end === 'source' ? edge.source : edge.target;
     const hit = findNodeAtCanvasPoint(sortedNodesRef.current, pt.x, pt.y);
     setState({
       kind: 'move-end',
       edgeId,
       end,
       frozen,
+      original,
       cursor: pt,
       hoverNodeId: hit?.id ?? null,
     });

--- a/apps/canvas-workspace/src/renderer/src/hooks/useEscapeClose.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useEscapeClose.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from 'react';
+import { isImeComposing } from '../utils/ime';
+
+/**
+ * Escape-closes a popover/menu while it's open. Listens on `document` in the
+ * capture phase and stops propagation, so the press is consumed by the
+ * topmost open popover instead of also reaching window-level shortcut
+ * handlers (canvas deselect, drawer close, …). IME-composition Escapes are
+ * ignored — those dismiss the candidate window, not the popover.
+ */
+export const useEscapeClose = (active: boolean, onClose: () => void) => {
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    if (!active) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' || isImeComposing(e)) return;
+      e.stopPropagation();
+      onCloseRef.current();
+    };
+    document.addEventListener('keydown', handler, true);
+    return () => document.removeEventListener('keydown', handler, true);
+  }, [active]);
+};

--- a/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts
@@ -143,6 +143,9 @@ interface SlashMenuState {
 export interface BubbleState {
   x: number;
   y: number;
+  /** Bottom edge of the selection rect — anchor for flipping the bubble
+   *  below the selection when there's no room above it. */
+  bottom: number;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -319,6 +322,7 @@ export const useFileNodeEditor = ({
         setBubble({
           x: selRect.left + selRect.width / 2,
           y: selRect.top,
+          bottom: selRect.bottom,
         });
       });
     },

--- a/apps/canvas-workspace/src/renderer/src/hooks/useMarqueeSelect.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useMarqueeSelect.ts
@@ -102,11 +102,21 @@ export const useMarqueeSelect = ({
       }
       onSelect(hits, m.mods);
     };
+    // Escape aborts the marquee without touching the selection. Capture
+    // phase + stopPropagation so the canvas-level Escape handler doesn't
+    // also clear the existing selection on the same press.
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      e.stopPropagation();
+      setMarquee(null);
+    };
     window.addEventListener('mousemove', handleMove);
     window.addEventListener('mouseup', handleUp);
+    window.addEventListener('keydown', handleKey, true);
     return () => {
       window.removeEventListener('mousemove', handleMove);
       window.removeEventListener('mouseup', handleUp);
+      window.removeEventListener('keydown', handleKey, true);
     };
   }, [marquee, getContainer, screenToCanvas, onSelect]);
 

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodeDrag.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodeDrag.ts
@@ -241,6 +241,32 @@ export const useNodeDrag = (
     setSnapLines([]);
   }, [flushDragMove]);
 
+  /** Abort the gesture (Escape): put the primary node and every companion
+   *  back where the drag found them, then drop all drag state. The caller
+   *  is responsible for NOT committing history afterwards. */
+  const onDragCancel = useCallback(() => {
+    if (moveFrame.current !== null) {
+      cancelAnimationFrame(moveFrame.current);
+      moveFrame.current = null;
+    }
+    lastMoveEvent.current = null;
+    const d = dragging.current;
+    if (d && d.started) {
+      if (d.companions.length > 0) {
+        moveNodes([
+          { id: d.id, x: d.nodeX, y: d.nodeY },
+          ...d.companions.map((c) => ({ id: c.id, x: c.nodeX, y: c.nodeY })),
+        ]);
+      } else {
+        moveNode(d.id, d.nodeX, d.nodeY);
+      }
+    }
+    dragging.current = null;
+    setDraggingId(null);
+    setDraggingIds(new Set());
+    setSnapLines([]);
+  }, [moveNode, moveNodes]);
+
   useEffect(() => {
     return () => {
       if (moveFrame.current !== null) {
@@ -249,5 +275,5 @@ export const useNodeDrag = (
     };
   }, []);
 
-  return { draggingId, draggingIds, snapLines, onDragStart, onDragMove, onDragEnd };
+  return { draggingId, draggingIds, snapLines, onDragStart, onDragMove, onDragEnd, onDragCancel };
 };

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodeResize.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodeResize.ts
@@ -98,6 +98,24 @@ export const useNodeResize = (
     setResizingId(null);
   }, [flushResizeMove]);
 
+  /** Abort the gesture (Escape): restore the node's pre-drag dimensions
+   *  and drop all resize state. Skips the restore when no resize tick was
+   *  ever applied so a press-and-Escape doesn't dirty the node. */
+  const onResizeCancel = useCallback(() => {
+    if (moveFrame.current !== null) {
+      cancelAnimationFrame(moveFrame.current);
+      moveFrame.current = null;
+    }
+    const moved = lastMoveEvent.current !== null;
+    lastMoveEvent.current = null;
+    const r = resizing.current;
+    if (r && moved) {
+      resizeNode(r.id, Math.round(r.startW), Math.round(r.startH));
+    }
+    resizing.current = null;
+    setResizingId(null);
+  }, [resizeNode]);
+
   useEffect(() => {
     return () => {
       if (moveFrame.current !== null) {
@@ -106,7 +124,7 @@ export const useNodeResize = (
     };
   }, []);
 
-  return { resizingId, onResizeStart, onResizeMove, onResizeEnd };
+  return { resizingId, onResizeStart, onResizeMove, onResizeEnd, onResizeCancel };
 };
 
 export type ResizeEdge = "right" | "bottom" | "bottom-right";

--- a/apps/canvas-workspace/src/renderer/src/hooks/useShapeDraw.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useShapeDraw.ts
@@ -82,11 +82,22 @@ export const useShapeDraw = ({
       commitDraft(d);
       setDraft(null);
     };
+    // Escape aborts the draft — no shape is committed on the following
+    // mouseup. Capture phase + stopPropagation so the canvas-level Escape
+    // handler doesn't also react to the same press.
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      e.stopPropagation();
+      draftRef.current = null;
+      setDraft(null);
+    };
     window.addEventListener('mousemove', handleMove);
     window.addEventListener('mouseup', handleUp);
+    window.addEventListener('keydown', handleKey, true);
     return () => {
       window.removeEventListener('mousemove', handleMove);
       window.removeEventListener('mouseup', handleUp);
+      window.removeEventListener('keydown', handleKey, true);
     };
     // commitDraft is stable via the closed-over deps below
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
+++ b/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
@@ -301,6 +301,8 @@ const en = {
   'models.cancel': 'Cancel',
   'models.testing': 'Testing...',
   'models.testAndSave': 'Test & Save',
+  'models.removeProvider': 'Remove provider',
+  'models.removeProviderConfirm': 'Click again to remove',
 
   'prompt.loadFailed': 'Failed to load prompt profile',
   'prompt.saveFailed': 'Failed to save prompt profile',
@@ -875,6 +877,8 @@ const zh: Record<keyof typeof en, string> = {
   'models.cancel': '取消',
   'models.testing': '测试中...',
   'models.testAndSave': '测试并保存',
+  'models.removeProvider': '删除 Provider',
+  'models.removeProviderConfirm': '再点一次确认删除',
 
   'prompt.loadFailed': '加载回复风格失败',
   'prompt.saveFailed': '保存回复风格失败',


### PR DESCRIPTION
## Summary
This PR adds defensive UX patterns to prevent accidental double-submissions and enables Escape-key cancellation for in-flight gestures across the canvas workspace app. The changes focus on three main areas: blocking duplicate IPC calls during agent team actions, preventing duplicate message sends in the chat composer, and allowing users to abort drag/resize/draw operations mid-gesture.

## Key Changes

### Agent Team Frame - Double-Click Guards
- Added `planAction` state to guard plan-phase actions (Approve & Run, Continue, Finish) against double-clicks
- Added `commandSending` state to prevent duplicate message submissions during the send round-trip
- Wrapped async handlers in try/finally blocks to ensure guard state is always cleared
- Updated button UI to show loading states ("Approving…", "Sending…", etc.) and disable during in-flight operations

### Gesture Cancellation (Escape Key)
- **Edge interaction**: Added `original` endpoint tracking and `handleCancel()` to restore drag-start positions when Escape is pressed; window blur also completes the gesture
- **Node drag/resize**: Implemented `onDragCancel()` and `onResizeCancel()` to restore pre-gesture positions without committing history
- **Shape draw & marquee select**: Added Escape handlers to abort drafts/selections without applying changes
- **Canvas mouse handlers**: Integrated cancel handlers with capture-phase Escape listener to prevent conflicting deselection

### Floating Panel Positioning
- **FileNodeBubbleMenu**: Added viewport-aware positioning with horizontal clamping and vertical flip when near top edge
- **EdgeStylePanel**: Implemented similar clamping logic with `useLayoutEffect` to measure and reposition after layout
- Both panels now use `transform` for positioning to handle flipping below the anchor when space is constrained

### Chat & Session Management
- Added `useEscapeClose` hook for popover/menu Escape handling with IME composition awareness
- Blocked session switches and new-session creation while a turn is streaming (prevents mid-generation message list swaps)
- Added `mentionBuildSeqRef` to discard stale async mention popup builds
- Fixed scope-switch cleanup to reset loading/streaming state

### Provider Removal Confirmation
- Implemented two-click confirmation pattern for provider deletion (trash button arms on first click, deletes on second)
- Auto-disarms after 3 seconds or when switching providers
- Added visual feedback with "Click again to remove" pill state

### Other Improvements
- Added native wheel event listener to block Chromium's default ctrl+wheel page zoom
- Fixed marquee/shape draft preview scaling with zoom level
- Added request sequencing to workspace node list loading to discard stale results
- Improved IME composition detection across text input handlers
- Added cleanup refs for in-flight resize drags to prevent document state leaks on unmount

## Implementation Details
- All gesture cancellations use capture-phase event listeners with `stopPropagation()` to prevent conflicting handlers
- Guard states are consistently cleared in `finally` blocks to handle both success and error paths
- Floating panels measure dimensions post-layout and clamp to viewport with configurable margins
- IME composition is checked before processing Escape to avoid dismissing candidate windows
- Stale async operations are tracked with monotonic sequence numbers to discard out-of-order results

https://claude.ai/code/session_01SG8d3FPxm9GuJv11ifRp3X