### PR TITLE
Fix node header actions positioning for text nodes at small zoom

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -613,17 +613,19 @@
   opacity: 1;
 }
 
-/* Frames and groups opt out of the floating-popover treatment above. Both
-   render their header as an absolutely-positioned, reverse-scaled tab that
-   already stays readable at every zoom, so they don't need the detached
-   popover. Worse: because that tab is itself position:absolute, the generic
-   rule anchors .node-header__actions to the narrow tab and — since the tab
-   carries its own counter-scale — the popover inherits that scale AND applies
-   its own on top, double-scaling the buttons into an oversized pill that grows
-   the further you zoom out (and floats detached off the tab's corner). Keep
-   them inline in the tab — exactly how they render at normal zoom. */
+/* Frames, groups, and text nodes opt out of the floating-popover treatment
+   above. Each renders its header as an absolutely-positioned, reverse-scaled
+   tab/toolbar that already stays readable at every zoom, so they don't need the
+   detached popover. Worse: because that tab is itself position:absolute, the
+   generic rule anchors .node-header__actions to the narrow tab and — since the
+   tab carries its own counter-scale — the popover inherits that scale AND
+   applies its own on top, double-scaling the buttons into an oversized pill
+   that grows the further you zoom out (and floats detached off the tab's
+   corner). Keep them inline in the tab — exactly how they render at normal
+   zoom. */
 .canvas-transform--small .canvas-node--frame .node-header__actions,
-.canvas-transform--small .canvas-node--group .node-header__actions {
+.canvas-transform--small .canvas-node--group .node-header__actions,
+.canvas-transform--small .canvas-node--text .node-header__actions {
   position: static;
   transform: none;
   padding: 0;


### PR DESCRIPTION
## Summary
Extends the floating-popover opt-out treatment to text nodes, ensuring their header actions render inline at small zoom levels instead of as detached popovers.

## Changes
- Updated CSS comment to include text nodes alongside frames and groups as node types that opt out of floating-popover treatment
- Added `.canvas-transform--small .canvas-node--text .node-header__actions` selector to apply `position: static`, `transform: none`, and `padding: 0` styles
- This prevents double-scaling and detached positioning of text node header actions at zoomed-out views, matching the existing behavior for frames and groups

## Details
Text nodes, like frames and groups, render their headers as absolutely-positioned, reverse-scaled elements that maintain readability at all zoom levels. Without this fix, the generic floating-popover rule would cause the header actions to inherit and apply counter-scaling twice, resulting in oversized buttons that float detached from the header at small zoom levels.

https://claude.ai/code/session_01GR5YW7DAMshwxH1ufDbi47