### PR TITLE
fix(canvas-workspace): restore monochrome Pulse glyph for toolbar AI …

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/icons/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/icons/index.tsx
@@ -111,8 +111,24 @@ export const SparklesIcon = ({ size = 16, className, strokeWidth = 1.3 }: IconPr
   </svg>
 );
 
-/** Back-compatible name for older call sites that mean "Pulse Canvas logo". */
-export const PulseGlyphIcon = (props: IconProps) => <AppLogoIcon {...props} />;
+/**
+ * Pulse brand mark (the waveform), monochrome via currentColor — the canonical
+ * "Pulse assistant" glyph for toolbar buttons (FloatingToolbar + fullscreen
+ * chip). Kept monochrome so it sits cleanly among the toolbar's other line-icon
+ * buttons; the colored logo image (AppLogoIcon) is for larger branding spots.
+ * strokeWidth is in the 512-unit viewBox (≈1.3px at the 16–18px toolbar sizes).
+ */
+export const PulseGlyphIcon = ({ size = 18, className, strokeWidth = 36 }: IconProps) => (
+  <svg width={size} height={size} viewBox="0 0 512 512" fill="none" className={className}>
+    <path
+      d="M 80,268 H 188 L 228,178 L 260,370 L 292,148 L 328,268 H 432"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
 
 export const TrashIcon = ({ size = 14, className, strokeWidth = 1.3 }: IconProps) => (
   <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className}>


### PR DESCRIPTION
…toggle

PulseGlyphIcon had been pointed at AppLogoIcon (the colored icon.png <img>), which made the canvas chat toggle in the FloatingToolbar and the fullscreen chip render as an oversized colored logo wedged among the monochrome line-icons — and the <img>-based button was the odd one out in the fullscreen chip. Restore the intended monochrome waveform SVG (currentColor) so both toolbar toggles read as clean line-icons again. AppLogoIcon stays for the larger branding spots (sidebar, chat header, empty states).