### PR TITLE
[codex] Polish right dock tabs and reference drawer

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/LinkDrawer/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/LinkDrawer/index.tsx
@@ -1,8 +1,8 @@
 /**
  * Right-dock tab content for external links intercepted from embedded
- * webviews and sandboxed iframes. The dock keeps at most ONE link tab —
- * a new link replaces this view's URL instead of stacking webviews (each
- * <webview> owns a guest renderer process). The view exposes:
+ * webviews and sandboxed iframes. Each open link preview owns its own
+ * <webview>; the dock dedupes exact URLs while allowing different links
+ * to stay open side by side. The view exposes:
  *  - open in system browser (escape hatch for X-Frame-Options-blocked
  *    sites, or when the user wants a real browser tab)
  *  - add to current canvas (creates a new iframe node bound to the URL,

--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/ReferencePicker.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/ReferencePicker.tsx
@@ -1,4 +1,4 @@
-import { useState, type Dispatch, type RefObject, type SetStateAction } from 'react';
+import { useEffect, useState, type Dispatch, type RefObject, type SetStateAction } from 'react';
 import type { CanvasNode } from '../../types';
 import type { WorkspaceEntry } from '../../hooks/useWorkspaces';
 import { getNodeDisplayLabel } from '../../utils/nodeLabel';
@@ -40,95 +40,141 @@ export const ReferencePicker = ({
   setSearchDraft,
   workspaceNameById,
   onPick,
-}: ReferencePickerProps) => (
-  <div className="reference-picker-anchor" ref={pickerRef}>
-    <button
-      className={`reference-drawer-action reference-drawer-action--ghost${pickerOpen === 'current' ? ' reference-drawer-action--open' : ''}`}
-      type="button"
-      onClick={() => {
-        setSearchDraft('');
-        setPickerOpen((prev) => prev === 'current' ? null : 'current');
-      }}
-      disabled={currentNodeCount === 0}
-      title={currentNodeCount === 0 ? 'No more current workspace nodes to pin' : 'Pick a current workspace node'}
-      aria-haspopup="dialog"
-      aria-expanded={pickerOpen === 'current'}
-    >
-      <ListIcon />
-      Current workspace
-    </button>
+}: ReferencePickerProps) => {
+  const [workspaceMenuOpen, setWorkspaceMenuOpen] = useState(false);
+  const selectedWorkspace = externalWorkspaces.find((workspace) => workspace.id === externalWorkspaceId);
 
-    <button
-      className={`reference-drawer-action reference-drawer-action--ghost${pickerOpen === 'other' ? ' reference-drawer-action--open' : ''}`}
-      type="button"
-      onClick={() => {
-        setSearchDraft('');
-        setPickerOpen((prev) => prev === 'other' ? null : 'other');
-      }}
-      disabled={externalWorkspaces.length === 0}
-      title={externalWorkspaces.length === 0 ? 'No other workspaces yet' : 'Pick a node from another workspace'}
-      aria-haspopup="dialog"
-      aria-expanded={pickerOpen === 'other'}
-    >
-      <BranchIcon />
-      Other workspace
-    </button>
+  useEffect(() => {
+    if (pickerOpen !== 'other') setWorkspaceMenuOpen(false);
+  }, [pickerOpen]);
 
-    {pickerOpen && (
-      <div className="reference-picker-popover" role="dialog" aria-label="Pick canvas reference">
-        {pickerOpen === 'other' && (
-          <div className="reference-workspace-picker">
-            <label htmlFor="reference-workspace-select">Workspace</label>
-            <select
-              id="reference-workspace-select"
-              value={externalWorkspaceId ?? ''}
-              onChange={(event) => {
-                setExternalWorkspaceId(event.target.value || undefined);
-                setSearchDraft('');
-              }}
-            >
-              {externalWorkspaces.map((workspace) => (
-                <option key={workspace.id} value={workspace.id}>{workspace.name}</option>
-              ))}
-            </select>
-          </div>
-        )}
-        <div className="reference-picker-controls">
-          <div className="reference-picker-search">
-            <SearchIcon />
-            <input
-              value={searchDraft}
-              onChange={(e) => setSearchDraft(e.target.value)}
-              placeholder={pickerOpen === 'other' ? 'Search selected workspace' : 'Search current workspace'}
-              aria-label="Search canvas nodes"
-            />
-            {searchDraft && (
+  return (
+    <div className="reference-picker-anchor" ref={pickerRef}>
+      <button
+        className={`reference-drawer-action reference-drawer-action--ghost${pickerOpen === 'current' ? ' reference-drawer-action--open' : ''}`}
+        type="button"
+        onClick={() => {
+          setWorkspaceMenuOpen(false);
+          setSearchDraft('');
+          setPickerOpen((prev) => prev === 'current' ? null : 'current');
+        }}
+        disabled={currentNodeCount === 0}
+        title={currentNodeCount === 0 ? 'No more current workspace nodes to pin' : 'Pick a current workspace node'}
+        aria-haspopup="dialog"
+        aria-expanded={pickerOpen === 'current'}
+      >
+        <ListIcon />
+        Current workspace
+      </button>
+
+      <button
+        className={`reference-drawer-action reference-drawer-action--ghost${pickerOpen === 'other' ? ' reference-drawer-action--open' : ''}`}
+        type="button"
+        onClick={() => {
+          setWorkspaceMenuOpen(false);
+          setSearchDraft('');
+          setPickerOpen((prev) => prev === 'other' ? null : 'other');
+        }}
+        disabled={externalWorkspaces.length === 0}
+        title={externalWorkspaces.length === 0 ? 'No other workspaces yet' : 'Pick a node from another workspace'}
+        aria-haspopup="dialog"
+        aria-expanded={pickerOpen === 'other'}
+      >
+        <BranchIcon />
+        Other workspace
+      </button>
+
+      {pickerOpen && (
+        <div className="reference-picker-popover" role="dialog" aria-label="Pick canvas reference">
+          {pickerOpen === 'other' && (
+            <div className="reference-workspace-picker">
+              <span className="reference-workspace-picker-label">Workspace</span>
               <button
                 type="button"
-                className="reference-search-clear"
-                onClick={() => setSearchDraft('')}
-                aria-label="Clear canvas node search"
-                title="Clear search"
+                className={`reference-workspace-select${workspaceMenuOpen ? ' reference-workspace-select--open' : ''}`}
+                onClick={() => setWorkspaceMenuOpen((prev) => !prev)}
+                aria-haspopup="listbox"
+                aria-expanded={workspaceMenuOpen}
               >
-                x
+                <span className="reference-workspace-select-name">
+                  {selectedWorkspace?.name ?? 'Choose workspace'}
+                </span>
+                <svg
+                  className="reference-workspace-select-caret"
+                  width="12"
+                  height="12"
+                  viewBox="0 0 12 12"
+                  fill="none"
+                  aria-hidden="true"
+                >
+                  <path d="M3.5 4.5L6 7l2.5-2.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
               </button>
-            )}
+              {workspaceMenuOpen && (
+                <div className="reference-workspace-options" role="listbox" aria-label="Workspace">
+                  {externalWorkspaces.map((workspace) => {
+                    const selected = workspace.id === externalWorkspaceId;
+                    return (
+                      <button
+                        key={workspace.id}
+                        type="button"
+                        role="option"
+                        aria-selected={selected}
+                        className={`reference-workspace-option${selected ? ' reference-workspace-option--selected' : ''}`}
+                        onClick={() => {
+                          setExternalWorkspaceId(workspace.id);
+                          setSearchDraft('');
+                          setWorkspaceMenuOpen(false);
+                        }}
+                      >
+                        <span className="reference-workspace-option-check" aria-hidden="true">
+                          {selected ? '✓' : ''}
+                        </span>
+                        <span className="reference-workspace-option-name">{workspace.name}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          )}
+          <div className="reference-picker-controls">
+            <div className="reference-picker-search">
+              <SearchIcon />
+              <input
+                value={searchDraft}
+                onChange={(e) => setSearchDraft(e.target.value)}
+                placeholder={pickerOpen === 'other' ? 'Search selected workspace' : 'Search current workspace'}
+                aria-label="Search canvas nodes"
+              />
+              {searchDraft && (
+                <button
+                  type="button"
+                  className="reference-search-clear"
+                  onClick={() => setSearchDraft('')}
+                  aria-label="Clear canvas node search"
+                  title="Clear search"
+                >
+                  x
+                </button>
+              )}
+            </div>
           </div>
+          <ReferencePickerList
+            allNodes={allNodes}
+            externalWorkspaceId={externalWorkspaceId}
+            pickerOpen={pickerOpen}
+            pickableNodeGroups={pickableNodeGroups}
+            pickableNodes={pickableNodes}
+            searchActive={searchActive}
+            workspaceNameById={workspaceNameById}
+            onPick={onPick}
+          />
         </div>
-        <ReferencePickerList
-          allNodes={allNodes}
-          externalWorkspaceId={externalWorkspaceId}
-          pickerOpen={pickerOpen}
-          pickableNodeGroups={pickableNodeGroups}
-          pickableNodes={pickableNodes}
-          searchActive={searchActive}
-          workspaceNameById={workspaceNameById}
-          onPick={onPick}
-        />
-      </div>
-    )}
-  </div>
-);
+      )}
+    </div>
+  );
+};
 
 interface ReferencePickerListProps {
   allNodes: Record<string, CanvasNode[]>;

--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/constants.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/constants.ts
@@ -1,7 +1,7 @@
 import type { CanvasNode } from '../../types';
 
-export const DEFAULT_REFERENCE_DRAWER_WIDTH = 420;
-export const MIN_REFERENCE_DRAWER_WIDTH = 260;
+export const DEFAULT_REFERENCE_DRAWER_WIDTH = 520;
+export const MIN_REFERENCE_DRAWER_WIDTH = 320;
 export const MAX_REFERENCE_DRAWER_WIDTH = 1000;
 export const REFERENCE_SEARCH_DEBOUNCE_MS = 180;
 

--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.css
@@ -1,8 +1,8 @@
 .reference-drawer {
-  width: var(--reference-drawer-width, 420px);
-  flex: 0 0 var(--reference-drawer-width, 420px);
+  width: var(--reference-drawer-width, 520px);
+  flex: 0 0 var(--reference-drawer-width, 520px);
   min-width: 320px;
-  max-width: 720px;
+  max-width: 1000px;
   height: 100%;
   border-right: 1px solid var(--border-light);
   background: #fbfbfa;
@@ -15,7 +15,7 @@
   transform: translateX(-18px) scaleX(0.985);
   transform-origin: left center;
   filter: saturate(0.96);
-  margin-left: calc(var(--reference-drawer-width, 420px) * -1);
+  margin-left: calc(var(--reference-drawer-width, 520px) * -1);
   transition:
     margin-left 0.24s cubic-bezier(0.22, 1, 0.36, 1),
     opacity 0.2s ease,
@@ -89,7 +89,8 @@
     filter: none;
   }
 
-  .reference-drawer-content {
+  .reference-drawer-content,
+  .reference-workspace-options {
     animation: none;
   }
 }
@@ -213,6 +214,7 @@
 }
 
 .reference-workspace-picker {
+  position: relative;
   display: grid;
   gap: 4px;
   padding: 2px 2px 6px;
@@ -220,21 +222,139 @@
   margin-bottom: 4px;
 }
 
-.reference-workspace-picker label {
+.reference-workspace-picker-label {
   color: var(--text-muted);
   font-size: 10px;
   font-weight: 650;
 }
 
-.reference-workspace-picker select {
-  height: 28px;
+.reference-workspace-select {
+  appearance: none;
+  height: 30px;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
   min-width: 0;
+  padding: 0 8px 0 10px;
   border: 1px solid var(--border-light);
   border-radius: 7px;
-  background: var(--surface);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(248, 248, 246, 0.94)),
+    var(--surface);
   color: var(--text);
   font-size: 12px;
-  padding: 0 7px;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: left;
+  transition:
+    background 0.14s ease,
+    border-color 0.14s ease,
+    box-shadow 0.14s ease,
+    color 0.14s ease;
+}
+
+.reference-workspace-select:hover,
+.reference-workspace-select--open {
+  border-color: rgba(35, 131, 226, 0.34);
+  box-shadow: 0 0 0 2px rgba(35, 131, 226, 0.08);
+  color: var(--accent);
+}
+
+.reference-workspace-select-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.reference-workspace-select-caret {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  transition:
+    color 0.14s ease,
+    transform 0.18s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.reference-workspace-select--open .reference-workspace-select-caret {
+  color: var(--accent);
+  transform: rotate(180deg);
+}
+
+.reference-workspace-options {
+  position: absolute;
+  top: calc(100% - 2px);
+  left: 2px;
+  right: 2px;
+  z-index: 2;
+  max-height: 168px;
+  overflow-y: auto;
+  padding: 5px;
+  border: 1px solid rgba(55, 53, 47, 0.1);
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.98);
+  box-shadow:
+    0 10px 26px rgba(15, 15, 15, 0.12),
+    0 1px 2px rgba(15, 15, 15, 0.06);
+  animation: reference-workspace-menu-in 0.16s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.reference-workspace-option {
+  appearance: none;
+  width: 100%;
+  min-height: 30px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  text-align: left;
+  transition:
+    background 0.12s ease,
+    color 0.12s ease;
+}
+
+.reference-workspace-option:hover {
+  background: rgba(35, 131, 226, 0.08);
+  color: var(--accent);
+}
+
+.reference-workspace-option--selected {
+  background: rgba(35, 131, 226, 0.1);
+  color: var(--accent);
+  font-weight: 650;
+}
+
+.reference-workspace-option-check {
+  width: 13px;
+  flex: 0 0 13px;
+  color: var(--accent);
+  font-size: 12px;
+}
+
+.reference-workspace-option-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@keyframes reference-workspace-menu-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }
 
 .reference-picker-controls {

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/__tests__/dock-store.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/__tests__/dock-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { CHAT_TAB_ID, DockStore, LINK_TAB_ID, artifactTabId } from '../dock-store';
+import { CHAT_TAB_ID, DockStore, artifactTabId, linkTabId } from '../dock-store';
 
 describe('DockStore', () => {
   it('starts collapsed on the pinned chat tab with no previews', () => {
@@ -32,26 +32,37 @@ describe('DockStore', () => {
     expect(activeTabId).toBe(artifactTabId('ws1', 'a1'));
   });
 
-  it('keeps a single link tab: a new URL replaces it in place', () => {
+  it('opens different URLs as separate link tabs', () => {
     const dock = new DockStore();
     dock.openLink('https://a.example');
     dock.openArtifact('ws1', 'a1');
     dock.openLink('https://b.example');
     const { tabs, activeTabId } = dock.getSnapshot();
-    expect(tabs).toHaveLength(2);
-    expect(tabs[0]).toMatchObject({ id: LINK_TAB_ID, url: 'https://b.example', title: 'https://b.example' });
-    expect(activeTabId).toBe(LINK_TAB_ID);
+    expect(tabs).toHaveLength(3);
+    expect(tabs[0]).toMatchObject({
+      id: linkTabId('https://a.example'),
+      url: 'https://a.example',
+      title: 'https://a.example',
+    });
+    expect(tabs[2]).toMatchObject({
+      id: linkTabId('https://b.example'),
+      url: 'https://b.example',
+      title: 'https://b.example',
+    });
+    expect(activeTabId).toBe(linkTabId('https://b.example'));
   });
 
-  it('re-opening the same URL just activates the link tab and keeps its title', () => {
+  it('re-opening the same URL activates the existing link tab and keeps its title', () => {
     const dock = new DockStore();
+    const id = linkTabId('https://a.example');
     dock.openLink('https://a.example');
-    dock.setTitle(LINK_TAB_ID, 'Page title');
+    dock.setTitle(id, 'Page title');
     dock.openArtifact('ws1', 'a1');
     dock.openLink('https://a.example');
     const { tabs, activeTabId } = dock.getSnapshot();
-    expect(activeTabId).toBe(LINK_TAB_ID);
-    expect(tabs.find((t) => t.kind === 'link')?.title).toBe('Page title');
+    expect(tabs).toHaveLength(2);
+    expect(activeTabId).toBe(id);
+    expect(tabs.find((t) => t.kind === 'link' && t.url === 'https://a.example')?.title).toBe('Page title');
   });
 
   it('activate switches between chat and previews and ignores unknown ids', () => {

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/dock-store.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/dock-store.ts
@@ -9,9 +9,8 @@
  *  - chat is implicit/pinned: `tabs` holds preview tabs only and
  *    `activeTabId` is either `CHAT_TAB_ID` or a preview tab id;
  *  - artifact tabs are deduped by (workspaceId, artifactId);
- *  - there is at most ONE link tab — a new link replaces its URL rather
- *    than adding a tab, because every <webview> owns a guest renderer
- *    process and stacking them per-URL would leak processes;
+ *  - link tabs are deduped by exact URL, while different URLs can stay
+ *    open side by side as separate previews;
  *  - closing the active preview activates the tab that slides into its
  *    slot (right neighbour, falling back to the last preview, then chat);
  *  - collapsing the dock keeps all tabs — expanding restores them;
@@ -37,6 +36,15 @@ export const LINK_TAB_ID = 'link';
 
 export const artifactTabId = (workspaceId: string, artifactId: string): string =>
   `artifact:${workspaceId}:${artifactId}`;
+
+export const linkTabId = (url: string): string => {
+  let hash = 2166136261;
+  for (let i = 0; i < url.length; i += 1) {
+    hash ^= url.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return `${LINK_TAB_ID}:${url.length.toString(36)}:${(hash >>> 0).toString(36)}`;
+};
 
 const INITIAL: DockState = {
   tabs: [],
@@ -74,26 +82,27 @@ export class DockStore {
   }
 
   openLink(url: string): void {
+    const trimmedUrl = url.trim();
+    if (!trimmedUrl) return;
     const existing = this.state.tabs.find(
-      (tab): tab is Extract<DockPreviewTab, { kind: 'link' }> => tab.kind === 'link',
+      (tab): tab is Extract<DockPreviewTab, { kind: 'link' }> =>
+        tab.kind === 'link' && tab.url === trimmedUrl,
     );
-    if (!existing) {
-      const tab: DockPreviewTab = { id: LINK_TAB_ID, kind: 'link', title: url, url };
-      this.commit({ tabs: [...this.state.tabs, tab], activeTabId: tab.id, expanded: true });
-      return;
-    }
-    if (existing.url === url) {
+    if (existing) {
       // Same page: keep the loaded webview (and its resolved title).
       this.commit({ expanded: true, activeTabId: existing.id });
       return;
     }
-    this.commit({
-      tabs: this.state.tabs.map((tab) =>
-        tab.kind === 'link' ? { ...tab, url, title: url } : tab,
-      ),
-      activeTabId: existing.id,
-      expanded: true,
-    });
+
+    const baseId = linkTabId(trimmedUrl);
+    let id = baseId;
+    let suffix = 2;
+    while (this.state.tabs.some((tab) => tab.id === id)) {
+      id = `${baseId}:${suffix}`;
+      suffix += 1;
+    }
+    const tab: DockPreviewTab = { id, kind: 'link', title: trimmedUrl, url: trimmedUrl };
+    this.commit({ tabs: [...this.state.tabs, tab], activeTabId: tab.id, expanded: true });
   }
 
   /** Switch to an existing tab (chat or preview). Viewing chat clears unread. */

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/index.css
@@ -69,37 +69,90 @@
  * order while collapsed. */
 
 .right-dock__tabs {
+  --tab-ease: cubic-bezier(0.22, 1, 0.36, 1);
   display: flex;
-  align-items: flex-end;
-  gap: 2px;
-  background: #fbfbfa;
+  align-items: center;
+  gap: 8px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(248, 248, 246, 0.94)),
+    rgba(250, 250, 249, 0.96);
+  backdrop-filter: blur(18px);
   flex-shrink: 0;
-  scrollbar-width: thin;
+  position: relative;
   max-height: 0;
   padding: 0 8px 0 10px;
-  border-bottom: 0 solid rgba(55, 53, 47, 0.08);
+  border-bottom: 0 solid rgba(55, 53, 47, 0.07);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.72);
   opacity: 0;
+  transform: translateY(-6px);
   visibility: hidden;
   overflow: hidden;
   transition:
-    max-height 0.2s ease,
-    padding 0.2s ease,
-    opacity 0.16s ease,
-    visibility 0s linear 0.2s;
+    max-height 0.24s var(--tab-ease),
+    padding 0.24s var(--tab-ease),
+    opacity 0.18s ease,
+    transform 0.24s var(--tab-ease),
+    visibility 0s linear 0.24s;
 }
 
 .right-dock__tabs[data-visible="true"] {
-  max-height: 42px;
-  padding: 6px 8px 0 10px;
+  max-height: 46px;
+  padding: 8px 8px 8px 10px;
   border-bottom-width: 1px;
   opacity: 1;
+  transform: none;
   visibility: visible;
+  transition:
+    max-height 0.24s var(--tab-ease),
+    padding 0.24s var(--tab-ease),
+    opacity 0.18s ease,
+    transform 0.24s var(--tab-ease);
+}
+
+.right-dock__tab-scroll {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1 1 auto;
+  min-width: 0;
   overflow-x: auto;
   overflow-y: hidden;
+  scrollbar-width: none;
+  scroll-behavior: smooth;
+  scroll-padding: 0 8px;
+  -webkit-mask-image: linear-gradient(90deg, #000 0, #000 calc(100% - 18px), transparent);
+  mask-image: linear-gradient(90deg, #000 0, #000 calc(100% - 18px), transparent);
+}
+
+.right-dock__tab-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.right-dock__tab-glider {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 0;
+  height: 30px;
+  border: 1px solid rgba(55, 53, 47, 0.12);
+  border-radius: 8px;
+  background:
+    radial-gradient(circle at 50% 0%, rgba(255, 255, 255, 0.98), transparent 58%),
+    linear-gradient(180deg, #fff, rgba(255, 255, 255, 0.92));
+  box-shadow:
+    0 1px 2px rgba(15, 15, 15, 0.06),
+    0 10px 22px rgba(15, 15, 15, 0.06);
+  opacity: 0;
+  pointer-events: none;
   transition:
-    max-height 0.2s ease,
-    padding 0.2s ease,
+    transform 0.3s var(--tab-ease),
+    width 0.3s var(--tab-ease),
     opacity 0.16s ease;
+}
+
+.right-dock__tab-glider[data-visible="true"] {
+  opacity: 1;
 }
 
 .right-dock__tab {
@@ -107,72 +160,130 @@
   font: inherit;
   display: inline-flex;
   align-items: center;
-  gap: 7px;
-  min-width: 0;
-  max-width: 200px;
-  flex: 0 1 auto;
+  gap: 8px;
+  min-width: 108px;
+  max-width: 220px;
+  flex: 0 0 auto;
   border: 1px solid transparent;
-  border-bottom: none;
   background: transparent;
-  border-radius: 7px 7px 0 0;
-  padding: 6px 7px 7px 10px;
+  border-radius: 8px;
+  padding: 0 7px 0 10px;
+  height: 30px;
   font-size: 12px;
-  color: #6b6b68;
+  color: #73716c;
   cursor: pointer;
   position: relative;
+  z-index: 1;
+  isolation: isolate;
+  overflow: hidden;
+  transform: translateY(0) scale(1);
+  transition:
+    background 0.18s ease,
+    border-color 0.18s ease,
+    box-shadow 0.2s var(--tab-ease),
+    color 0.18s ease,
+    transform 0.2s var(--tab-ease);
 }
 
-.right-dock__tab:hover {
-  background: #f1f1ef;
+.right-dock__tab::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  border-radius: inherit;
+  background:
+    radial-gradient(circle at 50% 0%, rgba(255, 255, 255, 0.92), transparent 58%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0));
+  opacity: 0;
+  transition: opacity 0.18s ease;
+}
+
+.right-dock__tab > * {
+  position: relative;
+  z-index: 1;
+}
+
+.right-dock__tab:not(.right-dock__tab--active):hover {
+  background: rgba(55, 53, 47, 0.06);
   color: #37352f;
+  transform: translateY(-1px);
 }
 
-/* Active tab fuses with the pane below by overlapping the strip's
- * bottom border. */
 .right-dock__tab--active {
-  background: #fff;
-  border-color: rgba(55, 53, 47, 0.1);
+  background: transparent;
+  border-color: transparent;
   color: #37352f;
   font-weight: 600;
-  margin-bottom: -1px;
-  padding-bottom: 8px;
+  transform: translateY(-1px);
+  animation: right-dock-tab-rise 0.22s var(--tab-ease);
+}
+
+.right-dock__tab--active::before {
+  opacity: 0.46;
 }
 
 /* The pinned chat tab has no close affordance. */
 .right-dock__tab--chat {
   flex-shrink: 0;
-  padding-right: 11px;
+  min-width: 78px;
+  padding-right: 12px;
 }
 
 .right-dock__tab-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 2px;
+  width: 8px;
+  height: 8px;
+  border-radius: 3px;
   flex-shrink: 0;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.45);
+  transition:
+    box-shadow 0.18s ease,
+    transform 0.2s var(--tab-ease);
 }
 
 .right-dock__tab-dot--chat { background: #1f7a4d; border-radius: 50%; }
 .right-dock__tab-dot--artifact { background: #a594e0; }
 .right-dock__tab-dot--link { background: #2383e2; }
 
+.right-dock__tab--active .right-dock__tab-dot {
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.58),
+    0 0 0 3px rgba(35, 131, 226, 0.1);
+  transform: scale(1.08);
+}
+
 .right-dock__tab-title {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  line-height: 1;
 }
 
 .right-dock__tab-close {
-  width: 16px;
-  height: 16px;
+  width: 18px;
+  height: 18px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 4px;
-  color: #b4b0a8;
-  font-size: 13px;
+  border-radius: 6px;
+  color: #aaa6a0;
+  font-size: 14px;
   line-height: 1;
   flex-shrink: 0;
+  margin-right: -2px;
+  opacity: 0.58;
+  transform: scale(0.96);
+  transition:
+    background 0.12s ease,
+    color 0.12s ease,
+    opacity 0.16s ease,
+    transform 0.16s ease;
+}
+
+.right-dock__tab:hover .right-dock__tab-close,
+.right-dock__tab--active .right-dock__tab-close {
+  opacity: 1;
+  transform: scale(1);
 }
 
 .right-dock__tab-close:hover {
@@ -184,20 +295,20 @@
 .right-dock__tab-unread {
   display: none;
   position: absolute;
-  top: 3px;
-  right: 4px;
+  top: 4px;
+  right: 5px;
   width: 7px;
   height: 7px;
   border-radius: 50%;
   background: #e0533d;
   border: 1.5px solid #fbfbfa;
+  box-shadow: 0 0 0 0 rgba(224, 83, 61, 0.24);
 }
 
 .right-dock__tab--chat[data-unread="true"] .right-dock__tab-unread {
   display: block;
+  animation: right-dock-unread-pulse 1.8s ease-out infinite;
 }
-
-.right-dock__tabs-spacer { flex: 1 0 8px; }
 
 .right-dock__collapse {
   appearance: none;
@@ -205,7 +316,6 @@
   background: transparent;
   width: 24px;
   height: 24px;
-  margin-bottom: 4px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -215,11 +325,63 @@
   line-height: 1;
   cursor: pointer;
   flex-shrink: 0;
+  position: relative;
+  z-index: 1;
+  box-shadow: 0 0 0 1px transparent;
+  transition:
+    background 0.14s ease,
+    color 0.14s ease,
+    box-shadow 0.14s ease,
+    transform 0.2s var(--tab-ease);
 }
 
 .right-dock__collapse:hover {
   background: rgba(55, 53, 47, 0.08);
+  box-shadow: 0 0 0 1px rgba(55, 53, 47, 0.05);
   color: #37352f;
+  transform: translateX(1px);
+}
+
+@keyframes right-dock-tab-rise {
+  from {
+    opacity: 0.82;
+    transform: translateY(1px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(-1px) scale(1);
+  }
+}
+
+@keyframes right-dock-unread-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(224, 83, 61, 0.28);
+  }
+  70% {
+    box-shadow: 0 0 0 6px rgba(224, 83, 61, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(224, 83, 61, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .right-dock__tabs,
+  .right-dock__tabs[data-visible="true"],
+  .right-dock__tab-scroll,
+  .right-dock__tab-glider,
+  .right-dock__tab,
+  .right-dock__tab::before,
+  .right-dock__tab-dot,
+  .right-dock__tab-close,
+  .right-dock__collapse {
+    transition: none;
+  }
+
+  .right-dock__tab--active,
+  .right-dock__tab--chat[data-unread="true"] .right-dock__tab-unread {
+    animation: none;
+  }
 }
 
 /* ── Tab panes ──────────────────────────────────────────────────────── */

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/index.tsx
@@ -34,6 +34,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -139,18 +140,24 @@ function clampWidth(value: number): number {
 }
 
 interface RightDockProps {
-  /** Target canvas for the link tab's "add to current canvas" action. */
+  /** Target canvas for link tabs' "add to current canvas" action. */
   activeWorkspaceId: string;
   /** True on the canvas route: shows the pinned chat tab and reserves
    * layout space (in-flow behaviour). Other routes overlay previews only. */
   chatTabEnabled: boolean;
 }
 
+interface TabIndicatorState {
+  left: number;
+  width: number;
+  visible: boolean;
+}
+
 export const RightDock = ({ activeWorkspaceId, chatTabEnabled }: RightDockProps) => {
   const { store, setChatHost } = useDockContext();
   const state = useRightDockState();
 
-  // External links intercepted by the main process land in the link tab.
+  // External links intercepted by the main process land in link preview tabs.
   useEffect(() => {
     return window.canvasWorkspace.link.onOpen(({ url }) => store.openLink(url));
   }, [store]);
@@ -167,10 +174,68 @@ export const RightDock = ({ activeWorkspaceId, chatTabEnabled }: RightDockProps)
 
   const hasPreviews = state.tabs.length > 0;
   const visible = state.expanded && (chatTabEnabled || hasPreviews);
+  // While the chat tab is unavailable a transient 'chat' active pointer
+  // (route guard hasn't run yet) should highlight nothing.
+  const activePaneId = !chatTabEnabled && state.activeTabId === CHAT_TAB_ID ? null : state.activeTabId;
 
   const [width, setWidth] = useState<number>(() => clampWidth(readStoredWidth() ?? DEFAULT_WIDTH));
   const widthRef = useRef(width);
   widthRef.current = width;
+
+  const tabsRef = useRef<HTMLDivElement | null>(null);
+  const tabRefs = useRef(new Map<string, HTMLButtonElement>());
+  const [tabIndicator, setTabIndicator] = useState<TabIndicatorState>({
+    left: 0,
+    width: 0,
+    visible: false,
+  });
+
+  const registerTab = useCallback((id: string, element: HTMLButtonElement | null) => {
+    if (element) {
+      tabRefs.current.set(id, element);
+      return;
+    }
+    tabRefs.current.delete(id);
+  }, []);
+
+  const updateTabIndicator = useCallback(() => {
+    const activeTab = activePaneId ? tabRefs.current.get(activePaneId) : null;
+    if (!hasPreviews || !activeTab) {
+      setTabIndicator((prev) => (prev.visible ? { ...prev, visible: false } : prev));
+      return;
+    }
+    const next = {
+      left: activeTab.offsetLeft,
+      width: activeTab.offsetWidth,
+      visible: true,
+    };
+    setTabIndicator((prev) => (
+      prev.left === next.left && prev.width === next.width && prev.visible === next.visible
+        ? prev
+        : next
+    ));
+  }, [activePaneId, hasPreviews]);
+
+  useLayoutEffect(() => {
+    updateTabIndicator();
+  }, [updateTabIndicator, state.tabs, chatTabEnabled, width]);
+
+  useEffect(() => {
+    if (!hasPreviews || !activePaneId) return;
+    const activeTab = tabRefs.current.get(activePaneId);
+    activeTab?.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'smooth' });
+  }, [activePaneId, hasPreviews, state.tabs]);
+
+  useEffect(() => {
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(updateTabIndicator);
+    const tabsElement = tabsRef.current;
+    if (tabsElement) observer.observe(tabsElement);
+    for (const tabElement of tabRefs.current.values()) {
+      observer.observe(tabElement);
+    }
+    return () => observer.disconnect();
+  }, [updateTabIndicator, state.tabs, chatTabEnabled]);
 
   // Re-clamp on viewport resize so a stored width wider than the new
   // viewport doesn't push the dock off-screen.
@@ -238,10 +303,6 @@ export const RightDock = ({ activeWorkspaceId, chatTabEnabled }: RightDockProps)
     document.addEventListener('mouseup', onMouseUp);
   }, []);
 
-  // While the chat tab is unavailable a transient 'chat' active pointer
-  // (route guard hasn't run yet) should highlight nothing.
-  const activePaneId = !chatTabEnabled && state.activeTabId === CHAT_TAB_ID ? null : state.activeTabId;
-
   return (
     <aside
       className="right-dock"
@@ -259,9 +320,20 @@ export const RightDock = ({ activeWorkspaceId, chatTabEnabled }: RightDockProps)
       />
       {/* Always in the DOM so its appearance/disappearance can animate;
           hidden (and out of the tab order) while chat is alone. */}
-      <div className="right-dock__tabs" role="tablist" data-visible={hasPreviews}>
+      <div className="right-dock__tabs" data-visible={hasPreviews}>
+        <div ref={tabsRef} className="right-dock__tab-scroll" role="tablist" aria-label="Dock tabs">
+          <span
+            className="right-dock__tab-glider"
+            aria-hidden="true"
+            data-visible={tabIndicator.visible}
+            style={{
+              width: tabIndicator.width,
+              transform: `translateX(${tabIndicator.left}px)`,
+            }}
+          />
           {chatTabEnabled && (
             <button
+              ref={(element) => registerTab(CHAT_TAB_ID, element)}
               type="button"
               role="tab"
               aria-selected={activePaneId === CHAT_TAB_ID}
@@ -279,6 +351,7 @@ export const RightDock = ({ activeWorkspaceId, chatTabEnabled }: RightDockProps)
             const active = tab.id === activePaneId;
             return (
               <button
+                ref={(element) => registerTab(tab.id, element)}
                 key={tab.id}
                 type="button"
                 role="tab"
@@ -303,16 +376,16 @@ export const RightDock = ({ activeWorkspaceId, chatTabEnabled }: RightDockProps)
               </button>
             );
           })}
-          <div className="right-dock__tabs-spacer" />
-          <button
-            type="button"
-            className="right-dock__collapse"
-            aria-label="Collapse panel"
-            title="Collapse panel (tabs are kept)"
-            onClick={() => store.collapse()}
-          >
-            ⇥
-          </button>
+        </div>
+        <button
+          type="button"
+          className="right-dock__collapse"
+          aria-label="Collapse panel"
+          title="Collapse panel (tabs are kept)"
+          onClick={() => store.collapse()}
+        >
+          ⇥
+        </button>
       </div>
       <div className="right-dock__panes">
         {/* Chat pane: portal outlet — always mounted so chat keeps its


### PR DESCRIPTION
## Summary

- Refine the right dock tab strip with a sliding active indicator, smoother motion, and a horizontally scrolling tab rail so many preview tabs stay readable.
- Allow multiple link preview tabs while deduping exact URLs, and keep existing titles when a URL is reopened.
- Widen the Reference drawer defaults and replace the native workspace `<select>` with an in-app dropdown that matches the drawer styling.

## Impact

This improves the canvas side-panel workflow when users open several link previews, and makes pinned reference selection feel more native to Pulse Canvas instead of falling back to platform menu chrome.

## Validation

- `pnpm --filter canvas-workspace typecheck:renderer`
- `pnpm --filter canvas-workspace test -- src/renderer/src/components/RightDock/__tests__/dock-store.test.ts`

Note: the second command currently runs the full `canvas-workspace` Vitest suite; it passed 42 test files / 486 tests.