### PR TITLE
Add reference node support to canvas context builder

### DIFF
--- a/apps/canvas-workspace/src/main/agent/__tests__/reference-nodes.test.ts
+++ b/apps/canvas-workspace/src/main/agent/__tests__/reference-nodes.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+
+// Pin `os.homedir()` to a temp dir BEFORE the modules under test load it so
+// every default-rooted helper (canvas-storage, context-builder) reads/writes
+// under the per-test sandbox instead of the developer's real ~/.pulse-coder.
+const { sandboxHome } = vi.hoisted(() => {
+  const base = process.env.TMPDIR || process.env.TEMP || '/tmp';
+  const trailing = base.endsWith('/') ? '' : '/';
+  return {
+    sandboxHome: `${base}${trailing}canvas-ref-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  };
+});
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  return { ...actual, homedir: () => sandboxHome };
+});
+
+// context-builder → webview/registry imports electron. Stub it so the live
+// webview lookup degrades to "not registered" rather than crashing the suite.
+vi.mock('electron', () => ({
+  ipcMain: { handle: () => undefined, on: () => undefined },
+  webContents: { getAllWebContents: () => [] },
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+
+import {
+  readNodeDetail,
+  buildDetailedContext,
+  buildWorkspaceSummary,
+  formatSummaryForPrompt,
+} from '../context-builder';
+import { writeCanvasFull, type CanvasSaveData } from '../../canvas/storage';
+
+const SOURCE_WS = 'ws-source';
+const MAIN_WS = 'ws-main';
+const SOURCE_CONTENT = 'From static software lego to AI-native software lego.';
+
+async function writeManifest(): Promise<void> {
+  const dir = join(sandboxHome, '.pulse-coder', 'canvas');
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(
+    join(dir, '__workspaces__.json'),
+    JSON.stringify({
+      workspaces: [
+        { id: SOURCE_WS, name: 'Source Canvas' },
+        { id: MAIN_WS, name: 'Main Canvas' },
+      ],
+      activeId: MAIN_WS,
+    }),
+    'utf-8',
+  );
+}
+
+async function setupSource(): Promise<void> {
+  const canvas: CanvasSaveData = {
+    nodes: [
+      {
+        id: 'src-text',
+        type: 'text',
+        title: 'Lego Plan',
+        x: 0,
+        y: 0,
+        width: 200,
+        height: 100,
+        data: { content: SOURCE_CONTENT },
+      },
+    ],
+    edges: [],
+    transform: { x: 0, y: 0, scale: 1 },
+    savedAt: new Date().toISOString(),
+  };
+  await writeCanvasFull(SOURCE_WS, canvas);
+}
+
+async function setupMainWithReference(nodeId = 'src-text'): Promise<void> {
+  const canvas: CanvasSaveData = {
+    nodes: [
+      {
+        id: 'ref-1',
+        type: 'reference',
+        title: 'Ref: Lego Plan',
+        x: 0,
+        y: 0,
+        width: 200,
+        height: 100,
+        ref: { kind: 'workspace-node', workspaceId: SOURCE_WS, nodeId },
+        data: { titleSnapshot: 'Lego Plan', typeSnapshot: 'text', workspaceNameSnapshot: 'Source Canvas' },
+      },
+    ],
+    edges: [],
+    transform: { x: 0, y: 0, scale: 1 },
+    savedAt: new Date().toISOString(),
+  };
+  await writeCanvasFull(MAIN_WS, canvas);
+}
+
+beforeEach(async () => {
+  await fs.mkdir(join(sandboxHome, '.pulse-coder', 'canvas'), { recursive: true });
+  await writeManifest();
+});
+
+afterEach(async () => {
+  await fs.rm(join(sandboxHome, '.pulse-coder'), { recursive: true, force: true });
+});
+
+describe('readNodeDetail — reference nodes', () => {
+  it('follows the ref to a source node in another workspace and returns its content', async () => {
+    await setupSource();
+    await setupMainWithReference();
+
+    const detail = await readNodeDetail(MAIN_WS, 'ref-1');
+    expect(detail).not.toBeNull();
+    // The real body comes through instead of an empty shell.
+    expect(detail!.content).toBe(SOURCE_CONTENT);
+    // The on-canvas reference node's own identity is preserved...
+    expect(detail!.id).toBe('ref-1');
+    expect(detail!.type).toBe('reference');
+    // ...annotated with where the content was actually read from.
+    expect(detail!.refType).toBe('text');
+    expect(detail!.refNodeId).toBe('src-text');
+    expect(detail!.refWorkspaceId).toBe(SOURCE_WS);
+    expect(detail!.refWorkspaceName).toBe('Source Canvas');
+  });
+
+  it('degrades to a diagnostic (not an empty shell) when the source is gone', async () => {
+    // Source workspace exists but the referenced node id does not.
+    await setupSource();
+    await setupMainWithReference('does-not-exist');
+
+    const detail = await readNodeDetail(MAIN_WS, 'ref-1');
+    expect(detail).not.toBeNull();
+    expect(detail!.content).toContain('source content unavailable');
+    // Falls back to the persisted snapshot so the agent can still explain it.
+    expect(detail!.content).toContain('Lego Plan');
+    expect(detail!.content).toContain('Source Canvas');
+    // No false resolution metadata when nothing resolved.
+    expect(detail!.refNodeId).toBe('does-not-exist');
+  });
+});
+
+describe('buildDetailedContext — reference nodes', () => {
+  it('resolves reference content in the full workspace context', async () => {
+    await setupSource();
+    await setupMainWithReference();
+
+    const ctx = await buildDetailedContext(MAIN_WS);
+    expect(ctx).not.toBeNull();
+    const refNode = ctx!.nodes.find((n) => n.id === 'ref-1');
+    expect(refNode).toBeDefined();
+    expect(refNode!.content).toBe(SOURCE_CONTENT);
+    expect(refNode!.refNodeId).toBe('src-text');
+  });
+});
+
+describe('formatSummaryForPrompt — reference nodes', () => {
+  it('lists reference nodes with their resolved target so the agent knows they resolve', async () => {
+    await setupSource();
+    await setupMainWithReference();
+
+    const summary = await buildWorkspaceSummary(MAIN_WS);
+    expect(summary).not.toBeNull();
+    const prompt = formatSummaryForPrompt(summary!);
+
+    expect(prompt).toContain('## Reference Nodes');
+    // The reference id and its source pointer both surface in the prompt.
+    expect(prompt).toContain('[ref-1]');
+    expect(prompt).toContain('[src-text]');
+    expect(prompt).toContain('Source Canvas');
+  });
+});

--- a/apps/canvas-workspace/src/main/agent/context-builder.ts
+++ b/apps/canvas-workspace/src/main/agent/context-builder.ts
@@ -9,6 +9,7 @@ import { promises as fs } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import type { EdgeSummary, NodeSummary, WorkspaceSummary } from './types';
+import type { CanvasNodeRef } from '../../shared/canvas';
 import { getNodeRenderedText } from '../webview/registry';
 import { readCanvasFull } from '../canvas/storage';
 
@@ -22,6 +23,8 @@ interface CanvasNode {
   y: number;
   width: number;
   height: number;
+  /** Set on `type: 'reference'` nodes; points at the source node. */
+  ref?: CanvasNodeRef;
   data: Record<string, unknown>;
   updatedAt?: number;
 }
@@ -345,6 +348,26 @@ function summarizeNode(node: CanvasNode): NodeSummary {
       }
       break;
     }
+    case 'reference': {
+      // A reference is a shell that mirrors a source node (usually in another
+      // canvas). The lightweight summary stays cheap — it surfaces where the
+      // node points from the persisted snapshot, without loading the source
+      // workspace. `canvas_read_node` resolves the real content on demand.
+      const typeSnapshot = node.data.typeSnapshot as string | undefined;
+      const titleSnapshot = node.data.titleSnapshot as string | undefined;
+      const workspaceNameSnapshot = node.data.workspaceNameSnapshot as string | undefined;
+      if (typeSnapshot) summary.refType = typeSnapshot;
+      if (titleSnapshot && !summary.title) summary.title = titleSnapshot;
+      const ref = node.ref;
+      if (ref?.kind === 'workspace-node') {
+        summary.refNodeId = ref.nodeId;
+        summary.refWorkspaceId = ref.workspaceId;
+        summary.refWorkspaceName = workspaceNameSnapshot;
+      } else if (ref?.kind === 'global-node') {
+        summary.refNodeId = ref.nodeId;
+      }
+      break;
+    }
   }
 
   return summary;
@@ -431,95 +454,112 @@ interface DetailedWorkspaceContext {
 }
 
 /**
- * Build a full detailed context including file contents and terminal
- * scrollback. This is expensive and only loaded via the canvas_read_context
- * tool when the agent needs deep context.
+ * Guard against pathological reference chains (A → B → A). The normal
+ * creation flow can't produce ref→ref links — references only target
+ * "referenceable" content types — but a hand-edited canvas could, so cap
+ * the recursion cheaply rather than risk an infinite loop.
  */
-export async function buildDetailedContext(workspaceId: string): Promise<DetailedWorkspaceContext | null> {
-  const canvas = await loadCanvasJson(workspaceId);
-  if (!canvas) return null;
+const MAX_REFERENCE_DEPTH = 4;
 
-  const manifest = await loadManifest();
-  const entry = manifest.workspaces.find(e => e.id === workspaceId);
-  const workspaceName = entry?.name ?? workspaceId;
-  const canvasDir = join(STORE_DIR, workspaceId);
-
-  const nodes: DetailedNodeContext[] = [];
-
-  for (const node of canvas.nodes) {
-    const base = summarizeNode(node);
-    const detailed: DetailedNodeContext = { ...base };
-
-    switch (node.type) {
-      case 'file': {
-        const filePath = node.data.filePath as string;
-        if (filePath) {
-          try {
-            detailed.content = await fs.readFile(filePath, 'utf-8');
-          } catch {
-            detailed.content = (node.data.content as string) ?? '';
-          }
-        } else {
-          detailed.content = (node.data.content as string) ?? '';
-        }
-        break;
-      }
-      case 'terminal':
-        detailed.scrollback = (node.data.scrollback as string) ?? '';
-        detailed.cwd = (node.data.cwd as string) ?? '';
-        break;
-      case 'agent':
-        detailed.scrollback = (node.data.scrollback as string) ?? '';
-        detailed.cwd = (node.data.cwd as string) ?? '';
-        break;
-      case 'image':
-        detailed.content = node.data.filePath ? `[image file: ${node.data.filePath as string}]` : '[image node has no filePath]';
-        break;
-      case 'iframe': {
-        const iframeMode = (node.data.mode as string) || 'url';
-        if (iframeMode === 'html' || iframeMode === 'ai') {
-          detailed.content = (node.data.html as string) ?? '';
-        } else {
-          const url = (node.data.url as string) || '';
-          detailed.content = await readIframeContent(workspaceId, node.id, url);
-        }
-        break;
-      }
-      case 'text':
-        detailed.content = (node.data.content as string) ?? '';
-        break;
-      case 'mindmap': {
-        const root = node.data.root as MindmapTopic | undefined;
-        detailed.content = root ? flattenMindmapTopics(root) : '';
-        break;
-      }
-    }
-
-    nodes.push(detailed);
-  }
-
-  // Read AGENTS.md if present
-  let agentsMd: string | undefined;
-  try {
-    agentsMd = await fs.readFile(join(canvasDir, 'AGENTS.md'), 'utf-8');
-  } catch {
-    // not present
-  }
-
-  return { workspaceId, workspaceName, canvasDir, nodes, agentsMd };
+/**
+ * Resolve a reference node to its source node. A reference is a lightweight
+ * shell whose real content lives in another node — usually in a different
+ * workspace. We follow `node.ref` to load the target workspace's canvas and
+ * locate the source by id. Mirrors the renderer's `resolveReferenceNode`.
+ *
+ * Returns null when the node isn't a resolvable reference (unsupported ref
+ * kind, missing source, or removed workspace) so callers fall back to the
+ * persisted snapshot.
+ */
+async function resolveReferenceSource(
+  node: CanvasNode,
+): Promise<{ node: CanvasNode; workspaceId: string; workspaceName: string } | null> {
+  const ref = node.ref;
+  // Only workspace-node references resolve to a concrete source today; this
+  // matches what the renderer can open. Other kinds fall through to snapshot.
+  if (!ref || ref.kind !== 'workspace-node') return null;
+  const canvas = await loadCanvasJson(ref.workspaceId);
+  const source = canvas?.nodes.find((n) => n.id === ref.nodeId);
+  if (!source) return null;
+  const [resolved] = await resolveWorkspaceNames([ref.workspaceId]);
+  return {
+    node: source,
+    workspaceId: ref.workspaceId,
+    workspaceName: resolved?.name ?? ref.workspaceId,
+  };
 }
 
-// ─── Read a single node in detail ──────────────────────────────────
+/** Human-readable description of where a reference node points, for diagnostics. */
+function describeRefTarget(node: CanvasNode): string {
+  const ref = node.ref;
+  if (ref?.kind === 'workspace-node') {
+    const wsName = (node.data.workspaceNameSnapshot as string | undefined) ?? ref.workspaceId;
+    return `node "${ref.nodeId}" in workspace "${wsName}"`;
+  }
+  if (ref?.kind === 'global-node') {
+    return `global node "${ref.nodeId}"`;
+  }
+  return 'an unknown source';
+}
 
-export async function readNodeDetail(workspaceId: string, nodeId: string): Promise<DetailedNodeContext | null> {
-  const canvas = await loadCanvasJson(workspaceId);
-  if (!canvas) return null;
+/**
+ * Fill a reference node's detail by resolving its source and copying the
+ * source's content + metadata up. Keeps the reference node's own id/title so
+ * the agent can still refer to the on-canvas node the user mentioned, but
+ * annotates `ref*` fields with the resolved truth. When the source can't be
+ * resolved, surface the snapshot so the agent can explain it instead of
+ * returning an empty shell.
+ */
+async function populateReferenceDetail(
+  detailed: DetailedNodeContext,
+  node: CanvasNode,
+  depth: number,
+): Promise<void> {
+  const resolved = depth < MAX_REFERENCE_DEPTH ? await resolveReferenceSource(node) : null;
 
-  const node = canvas.nodes.find(n => n.id === nodeId);
-  if (!node) return null;
+  if (!resolved) {
+    const titleSnapshot = node.data.titleSnapshot as string | undefined;
+    const typeSnapshot = node.data.typeSnapshot as string | undefined;
+    detailed.content = [
+      '[reference node — source content unavailable]',
+      `This is a reference shell pointing to ${describeRefTarget(node)}.`,
+      titleSnapshot ? `Snapshot title: ${titleSnapshot}` : '',
+      typeSnapshot ? `Snapshot type: ${typeSnapshot}` : '',
+      'The source node may have been deleted, or its workspace is no longer available.',
+    ].filter(Boolean).join('\n');
+    return;
+  }
 
-  const base = summarizeNode(node);
-  const detailed: DetailedNodeContext = { ...base };
+  const sourceDetail = await populateNodeDetail(resolved.node, resolved.workspaceId, depth + 1);
+  // Carry the source's body + type-specific metadata up onto the reference,
+  // but keep `id`/`title`/`type` as the reference node so the agent knows it
+  // read a reference (and can still address the on-canvas node).
+  detailed.content = sourceDetail.content;
+  detailed.scrollback = sourceDetail.scrollback;
+  detailed.cwd = sourceDetail.cwd;
+  detailed.path = sourceDetail.path;
+  detailed.url = sourceDetail.url;
+  detailed.imagePath = sourceDetail.imagePath;
+  detailed.rootText = sourceDetail.rootText;
+  detailed.topicCount = sourceDetail.topicCount;
+  detailed.refType = resolved.node.type;
+  detailed.refNodeId = resolved.node.id;
+  detailed.refWorkspaceId = resolved.workspaceId;
+  detailed.refWorkspaceName = resolved.workspaceName;
+}
+
+/**
+ * Read the type-specific detail (content / scrollback / cwd) for a single
+ * node. Shared by `readNodeDetail` (single-node `canvas_read_node`) and
+ * `buildDetailedContext` (full `canvas_read_context`) so the two stay in
+ * lockstep. `depth` is only used to bound reference recursion.
+ */
+async function populateNodeDetail(
+  node: CanvasNode,
+  workspaceId: string,
+  depth = 0,
+): Promise<DetailedNodeContext> {
+  const detailed: DetailedNodeContext = { ...summarizeNode(node) };
 
   switch (node.type) {
     case 'file': {
@@ -555,10 +595,10 @@ export async function readNodeDetail(workspaceId: string, nodeId: string): Promi
       if (iframeMode === 'html' || iframeMode === 'ai') {
         detailed.content = (node.data.html as string) ?? '';
       } else {
-        // Use the same live-webview-first path as buildDetailedContext so a
-        // single-node read (the common case for `@Link 总结`) can see the
-        // post-JS DOM — otherwise SPAs like Lark wiki come back as empty-ish
-        // shell HTML and the agent gets `content: ""`.
+        // Use the live-webview-first path so a single-node read (the common
+        // case for `@Link 总结`) can see the post-JS DOM — otherwise SPAs like
+        // Lark wiki come back as empty-ish shell HTML and the agent gets
+        // `content: ""`.
         const url = (node.data.url as string) || '';
         detailed.content = await readIframeContent(workspaceId, node.id, url);
       }
@@ -572,9 +612,55 @@ export async function readNodeDetail(workspaceId: string, nodeId: string): Promi
       detailed.content = root ? flattenMindmapTopics(root) : '';
       break;
     }
+    case 'reference':
+      await populateReferenceDetail(detailed, node, depth);
+      break;
   }
 
   return detailed;
+}
+
+/**
+ * Build a full detailed context including file contents and terminal
+ * scrollback. This is expensive and only loaded via the canvas_read_context
+ * tool when the agent needs deep context.
+ */
+export async function buildDetailedContext(workspaceId: string): Promise<DetailedWorkspaceContext | null> {
+  const canvas = await loadCanvasJson(workspaceId);
+  if (!canvas) return null;
+
+  const manifest = await loadManifest();
+  const entry = manifest.workspaces.find(e => e.id === workspaceId);
+  const workspaceName = entry?.name ?? workspaceId;
+  const canvasDir = join(STORE_DIR, workspaceId);
+
+  const nodes: DetailedNodeContext[] = [];
+
+  for (const node of canvas.nodes) {
+    nodes.push(await populateNodeDetail(node, workspaceId));
+  }
+
+  // Read AGENTS.md if present
+  let agentsMd: string | undefined;
+  try {
+    agentsMd = await fs.readFile(join(canvasDir, 'AGENTS.md'), 'utf-8');
+  } catch {
+    // not present
+  }
+
+  return { workspaceId, workspaceName, canvasDir, nodes, agentsMd };
+}
+
+// ─── Read a single node in detail ──────────────────────────────────
+
+export async function readNodeDetail(workspaceId: string, nodeId: string): Promise<DetailedNodeContext | null> {
+  const canvas = await loadCanvasJson(workspaceId);
+  if (!canvas) return null;
+
+  const node = canvas.nodes.find(n => n.id === nodeId);
+  if (!node) return null;
+
+  return populateNodeDetail(node, workspaceId);
 }
 
 // ─── Format summary as system prompt section ───────────────────────
@@ -676,6 +762,22 @@ export function formatSummaryForPrompt(summary: WorkspaceSummary): string {
     for (const n of byType.mindmap) {
       const countHint = n.topicCount ? ` (${n.topicCount} topics)` : '';
       lines.push(`- [${n.id}] **${n.title}**${countHint}`);
+    }
+    lines.push('');
+  }
+
+  if (byType.reference?.length) {
+    lines.push('## Reference Nodes');
+    lines.push(
+      '_Shells that mirror a node from another canvas. `canvas_read_node` on a ' +
+      'reference returns the SOURCE node\'s content (not an empty shell). The ' +
+      'source id/workspace is shown so you can also read it directly._',
+    );
+    for (const n of byType.reference) {
+      const typeHint = n.refType ? ` (${n.refType})` : '';
+      const wsHint = n.refWorkspaceName ? ` — in "${n.refWorkspaceName}"` : '';
+      const idHint = n.refNodeId ? ` → [${n.refNodeId}]` : '';
+      lines.push(`- [${n.id}] **${n.title}**${typeHint}${wsHint}${idHint}`);
     }
     lines.push('');
   }

--- a/apps/canvas-workspace/src/main/agent/tools/nodes.ts
+++ b/apps/canvas-workspace/src/main/agent/tools/nodes.ts
@@ -89,6 +89,7 @@ export function createNodeTools(workspaceId: string): Record<string, CanvasTool>
       description:
         'Read the full content of a specific canvas node. For file nodes, returns the file content. For terminal/agent nodes, returns scrollback output. ' +
         'For iframe/link nodes, fetches the URL and returns the page text (HTML stripped, capped at ~200KB). ' +
+        'For reference nodes (shells that mirror a node from another canvas), follows the reference and returns the SOURCE node\'s content, with `refNodeId`/`refWorkspaceId` pointing at the original. ' +
         'Defaults to the current workspace; pass `workspaceId` to read a node from another canvas the user `@`-mentioned.',
       inputSchema: z.object({
         nodeId: z.string().describe('The ID of the node to read.'),

--- a/apps/canvas-workspace/src/main/agent/types.ts
+++ b/apps/canvas-workspace/src/main/agent/types.ts
@@ -207,6 +207,14 @@ export interface NodeSummary {
   rootText?: string;
   /** Total topic count (including root) for mindmap nodes. */
   topicCount?: number;
+  /** For reference nodes: type of the source node (from snapshot or resolved). */
+  refType?: string;
+  /** For reference nodes: id of the source node this points to. */
+  refNodeId?: string;
+  /** For reference nodes: workspace id holding the source node. */
+  refWorkspaceId?: string;
+  /** For reference nodes: human-readable name of the source workspace. */
+  refWorkspaceName?: string;
 }
 
 /**

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/AgentTypeSelect.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/AgentTypeSelect.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { AgentIcon } from '../AgentNodeBody/AgentIcon';
 import type { AgentDef } from '../../config/agentRegistry';
+import { useClickOutside } from '../../hooks/useClickOutside';
+import { useEscapeClose } from '../../hooks/useEscapeClose';
 
 interface AgentTypeSelectProps {
   value: string;
@@ -33,21 +35,8 @@ export const AgentTypeSelect = ({ value, options, ariaLabel, disabled, onChange 
   const rootRef = useRef<HTMLDivElement>(null);
   const selected = options.find((opt) => opt.id === value) ?? options[0];
 
-  useEffect(() => {
-    if (!open) return;
-    const onPointerDown = (event: MouseEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
-    };
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setOpen(false);
-    };
-    window.addEventListener('mousedown', onPointerDown);
-    window.addEventListener('keydown', onKeyDown);
-    return () => {
-      window.removeEventListener('mousedown', onPointerDown);
-      window.removeEventListener('keydown', onKeyDown);
-    };
-  }, [open]);
+  useClickOutside(rootRef, () => setOpen(false), open);
+  useEscapeClose(open, () => setOpen(false));
 
   const pick = (id: string) => {
     setOpen(false);

--- a/apps/canvas-workspace/src/renderer/src/components/EdgeContextMenu/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeContextMenu/index.tsx
@@ -1,9 +1,9 @@
-import { useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import '../NodeContextMenu/index.css';
 import './index.css';
 import { useViewportClampedPosition } from '../../hooks/useViewportClampedPosition';
 import { useMenuKeyboardNav } from '../../hooks/useMenuKeyboardNav';
+import { useClickOutside } from '../../hooks/useClickOutside';
 import { useI18n } from '../../i18n';
 
 interface Props {
@@ -26,23 +26,7 @@ export const EdgeContextMenu = ({ x, y, edgeId, onEditLabel, onEditStyle, onDele
   const { t } = useI18n();
   const { ref: menuRef, pos } = useViewportClampedPosition<HTMLDivElement>(x, y);
   useMenuKeyboardNav(menuRef, onClose);
-
-  useEffect(() => {
-    const handleClick = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        onClose();
-      }
-    };
-    // Deferred so the opening right-click's own click event doesn't
-    // immediately dismiss the menu.
-    const timer = setTimeout(() => {
-      window.addEventListener('mousedown', handleClick);
-    }, 0);
-    return () => {
-      clearTimeout(timer);
-      window.removeEventListener('mousedown', handleClick);
-    };
-  }, [menuRef, onClose]);
+  useClickOutside(menuRef, onClose);
 
   const menu = (
     <div

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.tsx
@@ -10,6 +10,7 @@ import { FileNodeBubbleMenu } from '../FileNodeBubbleMenu';
 import { SlashCommandMenu } from '../SlashCommandMenu';
 import { NoteFindBar } from '../NoteFindBar';
 import { NoteLinkPrompt } from '../NoteLinkPrompt';
+import { useRightDock } from '../RightDock';
 
 interface Props {
   node: CanvasNode;
@@ -20,6 +21,7 @@ interface Props {
 
 export const FileNodeBody = ({ node, onUpdate, workspaceId, readOnly = false }: Props) => {
   const data = node.data as FileNodeData;
+  const { openLink } = useRightDock();
   const [modified, setModified] = useState(false);
   const [statusText, setStatusText] = useState('');
   const dataRef = useRef(data);
@@ -153,6 +155,24 @@ export const FileNodeBody = ({ node, onUpdate, workspaceId, readOnly = false }: 
     [insertImageFromFile, readOnly],
   );
 
+  // Clicking a link inside the note opens it in the right-dock preview
+  // drawer — the same surface webview/iframe link clicks use. The Tiptap Link
+  // extension is configured with `openOnClick: false`, so without this a click
+  // just places the caret (in edit mode) or escapes to the system browser
+  // (read-only); neither previews the page. Capture phase intercepts before
+  // ProseMirror's own click handling.
+  const handleLinkClickCapture = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      const anchor = (e.target as HTMLElement).closest?.('a');
+      const href = anchor?.getAttribute('href')?.trim();
+      if (!href || !/^https?:\/\//i.test(href)) return;
+      e.preventDefault();
+      e.stopPropagation();
+      openLink(href);
+    },
+    [openLink],
+  );
+
   const filePath = data.filePath;
   const fileName = filePath ? filePath.split('/').pop() : null;
 
@@ -190,6 +210,7 @@ export const FileNodeBody = ({ node, onUpdate, workspaceId, readOnly = false }: 
         className="note-content"
         onPaste={(e) => e.stopPropagation()}
         onWheel={(e) => e.stopPropagation()}
+        onClickCapture={handleLinkClickCapture}
       >
         <EditorContent editor={editor} className="note-tiptap-editor" />
       </div>

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/ShapeToolButton.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/ShapeToolButton.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { SHAPE_KINDS, ShapePrimitive, type ShapeKind } from '../../utils/shapeGeometry';
+import { useClickOutside } from '../../hooks/useClickOutside';
+import { useEscapeClose } from '../../hooks/useEscapeClose';
 import { useI18n, type I18nKey } from '../../i18n';
 
 interface Props {
@@ -53,17 +55,10 @@ export const ShapeToolButton = ({ activeTool, onToolChange }: Props) => {
     if (activeKind) setLastKind(activeKind);
   }, [activeKind]);
 
-  // Close popover on outside click.
-  useEffect(() => {
-    if (!popoverOpen) return;
-    const handleClick = (e: MouseEvent) => {
-      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
-        setPopoverOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
-  }, [popoverOpen]);
+  // Close the popover on outside click or Escape, matching every other
+  // canvas overlay.
+  useClickOutside(rootRef, () => setPopoverOpen(false), popoverOpen);
+  useEscapeClose(popoverOpen, () => setPopoverOpen(false));
 
   const handleMainClick = useCallback(() => {
     onToolChange(`${SHAPE_TOOL_PREFIX}${displayKind}`);

--- a/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
+import { useCallback, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
 import "./index.css";
 import type { CanvasNode, FrameNodeData } from "../../types";
 import { AgentTeamFrame } from "../AgentTeamFrame";
 import { useEscapeClose } from "../../hooks/useEscapeClose";
+import { useClickOutside } from "../../hooks/useClickOutside";
 
 interface Props {
   node: CanvasNode;
@@ -163,18 +164,8 @@ export const FrameColorPicker = ({ node, onUpdate }: ColorPickerProps) => {
     [node.id, data, onUpdate]
   );
 
-  // Close popover on outside click
-  useEffect(() => {
-    if (!open) return;
-    const handleClick = (e: MouseEvent) => {
-      if (triggerRef.current && !triggerRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
-  }, [open]);
-
+  // Close popover on outside click or Escape
+  useClickOutside(triggerRef, () => setOpen(false), open);
   useEscapeClose(open, () => setOpen(false));
 
   return (

--- a/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
@@ -1,8 +1,8 @@
 import "./index.css";
-import { useEffect } from "react";
 import { createPortal } from "react-dom";
 import { useViewportClampedPosition } from "../../hooks/useViewportClampedPosition";
 import { useMenuKeyboardNav } from "../../hooks/useMenuKeyboardNav";
+import { useClickOutside } from "../../hooks/useClickOutside";
 import { useI18n } from "../../i18n";
 
 interface Props {
@@ -21,21 +21,7 @@ export const NodeContextMenu = ({ x, y, mode = "create", onCreate, onExportImage
   // Arrow-key navigation + Escape; replaces the old window Escape
   // listener so the menu is fully operable without a mouse.
   useMenuKeyboardNav(menuRef, onClose);
-
-  useEffect(() => {
-    const handleClick = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        onClose();
-      }
-    };
-    const timer = setTimeout(() => {
-      window.addEventListener("click", handleClick);
-    }, 0);
-    return () => {
-      clearTimeout(timer);
-      window.removeEventListener("click", handleClick);
-    };
-  }, [onClose]);
+  useClickOutside(menuRef, onClose);
 
   const menu = (
     <div

--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/useReferenceDrawerState.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/useReferenceDrawerState.ts
@@ -9,6 +9,7 @@ import {
 } from 'react';
 import type { CanvasNode } from '../../types';
 import type { WorkspaceEntry } from '../../hooks/useWorkspaces';
+import { useClickOutside } from '../../hooks/useClickOutside';
 import { copyTextToClipboard } from '../../utils/clipboard';
 import { getNodeDisplayLabel } from '../../utils/nodeLabel';
 import { isReferenceableNode } from '../../utils/referenceNodes';
@@ -86,27 +87,8 @@ export const useReferenceDrawerState = ({
     return () => window.clearTimeout(timer);
   }, [searchDraft]);
 
-  useEffect(() => {
-    if (!pickerOpen) return;
-    const handleClickOutside = (event: MouseEvent) => {
-      if (!pickerRef.current?.contains(event.target as Node)) {
-        setPickerOpen(null);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [pickerOpen]);
-
-  useEffect(() => {
-    if (!urlEditorOpen) return;
-    const handleClickOutside = (event: MouseEvent) => {
-      if (!urlEditorRef.current?.contains(event.target as Node)) {
-        setUrlEditorOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [urlEditorOpen]);
+  useClickOutside(pickerRef, () => setPickerOpen(null), !!pickerOpen);
+  useClickOutside(urlEditorRef, () => setUrlEditorOpen(false), urlEditorOpen);
 
   useEffect(() => {
     if (!externalWorkspaceId || externalWorkspaceId === activeWorkspaceId) return;

--- a/apps/canvas-workspace/src/renderer/src/components/ShapeNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ShapeNodeBody/index.tsx
@@ -4,6 +4,7 @@ import type { CanvasNode, ShapeNodeData } from '../../types';
 import { ShapePrimitive } from '../../utils/shapeGeometry';
 import { isImeComposing } from '../../utils/ime';
 import { useEscapeClose } from '../../hooks/useEscapeClose';
+import { useClickOutside } from '../../hooks/useClickOutside';
 
 interface Props {
   node: CanvasNode;
@@ -235,17 +236,7 @@ export const ShapeStylePicker = ({ node, onUpdate }: StylePickerProps) => {
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!open) return;
-    const handle = (e: MouseEvent) => {
-      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handle);
-    return () => document.removeEventListener('mousedown', handle);
-  }, [open]);
-
+  useClickOutside(rootRef, () => setOpen(false), open);
   useEscapeClose(open, () => setOpen(false));
 
   const patch = useCallback(

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useRef, useState, useCallback, type DragEvent, type MouseEvent as ReactMouseEvent } from 'react';
+import { useClickOutside } from '../../hooks/useClickOutside';
+import { useEscapeClose } from '../../hooks/useEscapeClose';
 import type { NavItem } from '../../../../plugins/types';
 import type { WorkspaceEntry, FolderEntry } from '../../hooks/useWorkspaces';
 import type { CanvasNode } from '../../types';
@@ -103,14 +105,16 @@ export const Sidebar = ({
     setLayerContextMenu({ x: e.clientX, y: e.clientY, nodeId });
   }, []);
 
+  // A right-click context menu dismisses on the next press anywhere (no ref
+  // containment — clicking an item runs its handler, then this closes it).
+  // Escape goes through the shared IME-aware hook like every other overlay.
   useEffect(() => {
     if (!layerContextMenu) return;
     const close = () => setLayerContextMenu(null);
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setLayerContextMenu(null); };
     document.addEventListener('mousedown', close);
-    document.addEventListener('keydown', onKey);
-    return () => { document.removeEventListener('mousedown', close); document.removeEventListener('keydown', onKey); };
+    return () => document.removeEventListener('mousedown', close);
   }, [layerContextMenu]);
+  useEscapeClose(!!layerContextMenu, () => setLayerContextMenu(null));
 
   const toggleLayerCollapse = useCallback((id: string) => {
     setCollapsedLayers((prev) => { const next = new Set(prev); if (next.has(id)) next.delete(id); else next.add(id); return next; });
@@ -127,12 +131,8 @@ export const Sidebar = ({
   useEffect(() => { if (renamingLayerId && renameLayerInputRef.current) { renameLayerInputRef.current.focus(); renameLayerInputRef.current.select(); } }, [renamingLayerId]);
   useEffect(() => { if (inlineCreate && inlineCreateRef.current) inlineCreateRef.current.focus(); }, [inlineCreate]);
 
-  useEffect(() => {
-    if (!showAddMenu) return;
-    const handler = (e: MouseEvent) => { if (addMenuRef.current && !addMenuRef.current.contains(e.target as Node)) setShowAddMenu(false); };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [showAddMenu]);
+  useClickOutside(addMenuRef, () => setShowAddMenu(false), showAddMenu);
+  useEscapeClose(showAddMenu, () => setShowAddMenu(false));
 
   const startRename = (ws: WorkspaceEntry) => { setRenamingId(ws.id); setRenameValue(ws.name); };
   const commitRename = () => { if (renamingId && renameValue.trim()) onRename(renamingId, renameValue); setRenamingId(null); };

--- a/apps/canvas-workspace/src/renderer/src/components/SlashCommandMenu/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/SlashCommandMenu/index.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import './index.css';
 import { createPortal } from 'react-dom';
 import { useViewportClampedPosition } from '../../hooks/useViewportClampedPosition';
+import { useClickOutside } from '../../hooks/useClickOutside';
 
 export interface SlashCommandDef {
   id: string;
@@ -38,15 +39,7 @@ export const SlashCommandMenu = ({
   }, [selectedIndex]);
 
   // Close on outside click
-  useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        onClose();
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [onClose]);
+  useClickOutside(menuRef, onClose);
 
   if (items.length === 0) return null;
 

--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.tsx
@@ -8,6 +8,7 @@ import "./index.css";
 import type { CanvasNode, TextNodeData } from "../../types";
 import { isImeComposing } from "../../utils/ime";
 import { useEscapeClose } from "../../hooks/useEscapeClose";
+import { useClickOutside } from "../../hooks/useClickOutside";
 import { useI18n } from "../../i18n";
 
 interface Props {
@@ -305,17 +306,7 @@ const TextColorTrigger = ({
     [kind, node.id, data, onUpdate]
   );
 
-  useEffect(() => {
-    if (!open) return;
-    const handleClick = (e: MouseEvent) => {
-      if (triggerRef.current && !triggerRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [open]);
-
+  useClickOutside(triggerRef, () => setOpen(false), open);
   useEscapeClose(open, () => setOpen(false));
 
   const isTransparent = currentValue === "transparent";

--- a/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/GraphPage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/GraphPage.tsx
@@ -21,6 +21,8 @@ import { useAllWorkspaceNodeList } from './useWorkspaceNodes';
 import { getNodeTags, getNodeTitle, getNodeWorkspaceId, tagName } from './utils';
 import { useI18n } from '../../i18n';
 import { isImeComposing } from '../../utils/ime';
+import { useClickOutside } from '../../hooks/useClickOutside';
+import { useEscapeClose } from '../../hooks/useEscapeClose';
 
 interface GraphPageProps {
   workspaces: WorkspaceEntry[];
@@ -241,14 +243,8 @@ export const GraphPage = ({
     return () => window.removeEventListener('keydown', handler);
   }, [searchOpen]);
 
-  useEffect(() => {
-    if (!overflowOpen) return;
-    const handler = (event: MouseEvent) => {
-      if (!overflowRef.current?.contains(event.target as Node)) setOverflowOpen(false);
-    };
-    window.addEventListener('mousedown', handler);
-    return () => window.removeEventListener('mousedown', handler);
-  }, [overflowOpen]);
+  useClickOutside(overflowRef, () => setOverflowOpen(false), overflowOpen);
+  useEscapeClose(overflowOpen, () => setOverflowOpen(false));
 
   useEffect(() => {
     setActiveNodeId(selectedGraphId(selectedNode));

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatAnchors.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatAnchors.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ListLinesIcon } from '../icons';
+import { useClickOutside } from '../../hooks/useClickOutside';
+import { useEscapeClose } from '../../hooks/useEscapeClose';
 import type { ChatAnchor } from './utils/anchors';
 
 interface ChatAnchorsProps {
@@ -31,17 +33,8 @@ export const ChatAnchors = ({ anchors, onJump }: ChatAnchorsProps) => {
 
   useEffect(() => () => cancelClose(), [cancelClose]);
 
-  useEffect(() => {
-    if (!open) return;
-    const onDocMouseDown = (event: MouseEvent) => {
-      const target = event.target as Node | null;
-      if (wrapperRef.current && target && !wrapperRef.current.contains(target)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', onDocMouseDown);
-    return () => document.removeEventListener('mousedown', onDocMouseDown);
-  }, [open]);
+  useClickOutside(wrapperRef, () => setOpen(false), open);
+  useEscapeClose(open, () => setOpen(false));
 
   const handleSelect = useCallback((index: number) => {
     cancelClose();

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ModelSwitcher.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ModelSwitcher.tsx
@@ -6,6 +6,7 @@ import type { ModelSelection } from './modelSettingsTypes';
 import { providerLabel } from './modelSettingsTypes';
 import { useI18n } from '../../i18n';
 import { useEscapeClose } from '../../hooks/useEscapeClose';
+import { useClickOutside } from '../../hooks/useClickOutside';
 
 interface ModelSwitcherProps {
   status?: CanvasModelStatus;
@@ -67,24 +68,18 @@ export const ModelSwitcher = ({
   }, [open, updateMenuPosition]);
 
   useEscapeClose(open, () => setOpen(false));
+  // Trigger + menu both count as "inside" so clicking the trigger toggles
+  // rather than double-firing a close.
+  useClickOutside([triggerRef, menuRef], () => setOpen(false), open);
 
   useEffect(() => {
     if (!open) return;
-    const onPointerDown = (event: MouseEvent) => {
-      const target = event.target as Node;
-      if (triggerRef.current?.contains(target)) return;
-      if (menuRef.current?.contains(target)) return;
-      setOpen(false);
-    };
-    const onResize = () => updateMenuPosition();
-    const onScroll = () => updateMenuPosition();
-    document.addEventListener('mousedown', onPointerDown);
-    window.addEventListener('resize', onResize);
-    window.addEventListener('scroll', onScroll, true);
+    const reposition = () => updateMenuPosition();
+    window.addEventListener('resize', reposition);
+    window.addEventListener('scroll', reposition, true);
     return () => {
-      document.removeEventListener('mousedown', onPointerDown);
-      window.removeEventListener('resize', onResize);
-      window.removeEventListener('scroll', onScroll, true);
+      window.removeEventListener('resize', reposition);
+      window.removeEventListener('scroll', reposition, true);
     };
   }, [open, updateMenuPosition]);
 

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatSessions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatSessions.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { AgentChatMessage, AgentSessionInfo } from '../../../types';
 import type { AgentScope, OtherWorkspaceSession, WorkspaceOption } from '../types';
 import { useEscapeClose } from '../../../hooks/useEscapeClose';
+import { useClickOutside } from '../../../hooks/useClickOutside';
 
 interface UseChatSessionsOptions {
   agentScope: AgentScope;
@@ -53,19 +54,7 @@ export function useChatSessions({
     })();
   }, [onMessagesLoaded, skipInitialHistory, scopeKey]);
 
-  useEffect(() => {
-    if (!sessionMenuOpen) return;
-
-    const handleMouseDown = (event: MouseEvent) => {
-      if (sessionMenuRef.current && !sessionMenuRef.current.contains(event.target as Node)) {
-        setSessionMenuOpen(false);
-      }
-    };
-
-    document.addEventListener('mousedown', handleMouseDown);
-    return () => document.removeEventListener('mousedown', handleMouseDown);
-  }, [sessionMenuOpen]);
-
+  useClickOutside(sessionMenuRef, () => setSessionMenuOpen(false), sessionMenuOpen);
   useEscapeClose(sessionMenuOpen, () => setSessionMenuOpen(false));
 
   const loadSessions = useCallback(async () => {

--- a/apps/canvas-workspace/src/renderer/src/hooks/useClickOutside.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useClickOutside.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef, type RefObject } from 'react';
+
+type MaybeRefs = RefObject<HTMLElement> | ReadonlyArray<RefObject<HTMLElement>>;
+
+/**
+ * Dismiss-on-outside-press for overlays (menus, dropdowns, pickers, popovers).
+ *
+ * Consolidates the dozen ad-hoc `addEventListener('mousedown', …)` +
+ * `ref.contains(target)` blocks that were scattered across the canvas
+ * overlays, each subtly different (window vs document, click vs mousedown,
+ * capture phase, `setTimeout` defers). One canonical behavior:
+ *
+ *  - listens on `document` for `mousedown` in the CAPTURE phase, so an inner
+ *    `stopPropagation` can't suppress it and the press is evaluated before
+ *    focus/click side effects run;
+ *  - calls `onOutside` only when the press lands outside EVERY ref — pass the
+ *    trigger AND the popover for trigger/popover pairs so clicking the trigger
+ *    doesn't count as "outside";
+ *  - gated by `active`, so it only listens while the overlay is open;
+ *  - attaches inside an effect, which React runs after the event that opened
+ *    the overlay — so the opening press never dismisses it (no `setTimeout`
+ *    hack needed).
+ */
+export const useClickOutside = (
+  refs: MaybeRefs,
+  onOutside: () => void,
+  active = true,
+): void => {
+  const onOutsideRef = useRef(onOutside);
+  onOutsideRef.current = onOutside;
+
+  // Callers commonly pass a fresh array/ref literal each render. Keep the live
+  // list in a ref so the listener effect depends only on `active` and isn't
+  // re-subscribed on every render.
+  const refsRef = useRef<ReadonlyArray<RefObject<HTMLElement>>>([]);
+  refsRef.current = Array.isArray(refs) ? refs : [refs as RefObject<HTMLElement>];
+
+  useEffect(() => {
+    if (!active) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node | null;
+      if (!target) return;
+      for (const ref of refsRef.current) {
+        if (ref.current?.contains(target)) return;
+      }
+      onOutsideRef.current();
+    };
+    document.addEventListener('mousedown', handler, true);
+    return () => document.removeEventListener('mousedown', handler, true);
+  }, [active]);
+};

--- a/apps/canvas-workspace/src/renderer/src/hooks/useMenuKeyboardNav.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useMenuKeyboardNav.ts
@@ -1,10 +1,16 @@
 import { useEffect, type RefObject } from 'react';
+import { useEscapeClose } from './useEscapeClose';
 
 /**
  * Keyboard navigation for popup menus (context menus, dropdowns). Moves
  * focus into the first item on mount, lets ArrowUp/ArrowDown (and
  * Home/End) cycle through the menu's buttons, and closes on Escape.
  * Enter/Space activate the focused item via native button behavior.
+ *
+ * Escape is delegated to the shared `useEscapeClose` so every overlay
+ * dismisses on Escape identically: capture phase, `stopPropagation` (so it
+ * doesn't also fire window-level shortcuts like canvas deselect), and
+ * IME-aware (the Escape that dismisses a CJK candidate window is ignored).
  */
 export const useMenuKeyboardNav = (
   ref: RefObject<HTMLElement>,
@@ -19,13 +25,10 @@ export const useMenuKeyboardNav = (
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEscapeClose(true, () => onClose?.());
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        onClose?.();
-        return;
-      }
       if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp' && e.key !== 'Home' && e.key !== 'End') {
         return;
       }


### PR DESCRIPTION
## Summary

Implements full support for reference nodes in the canvas workspace context builder. Reference nodes are lightweight shells that mirror content from source nodes (usually in other workspaces). This change enables the agent to resolve references to their source content and understand where they point.

## Key Changes

- **Reference node type support in context builder**: Added `ref?: CanvasNodeRef` field to `CanvasNode` interface and implemented reference case in `summarizeNode()` to extract snapshot metadata (type, title, workspace name) and reference target information.

- **Reference resolution logic**: Implemented `resolveReferenceSource()` to follow `node.ref` pointers and load the target workspace's canvas, with `MAX_REFERENCE_DEPTH = 4` guard against pathological reference chains (A → B → A).

- **Detailed reference population**: Created `populateReferenceDetail()` to recursively resolve reference sources and copy their content/metadata up to the reference node while preserving the reference's own identity (id/title/type) for agent awareness. Falls back to persisted snapshots with diagnostic messages when sources are unavailable.

- **Refactored node detail population**: Extracted `populateNodeDetail()` as a shared helper used by both `buildDetailedContext()` (full workspace context) and `readNodeDetail()` (single-node reads) to keep them in lockstep. Both now handle reference resolution identically.

- **Summary formatting for references**: Added "Reference Nodes" section to `formatSummaryForPrompt()` that lists reference nodes with their resolved target information (source type, node id, workspace name) so the agent knows they resolve.

- **Comprehensive test suite**: Added `reference-nodes.test.ts` with tests covering:
  - Reference resolution to source content in another workspace
  - Graceful degradation with diagnostic messages when sources are unavailable
  - Full workspace context building with references
  - Prompt formatting with reference metadata

- **Consolidated click-outside behavior**: Extracted `useClickOutside()` hook to replace a dozen ad-hoc `addEventListener('mousedown', …)` + `ref.contains(target)` blocks scattered across overlay components (menus, dropdowns, pickers, popovers). Uses capture phase to prevent `stopPropagation` suppression and supports multiple refs for trigger/popover pairs.

- **Updated overlay components**: Migrated `ModelSwitcher`, `AgentTypeSelect`, `ShapeToolButton`, `FrameColorPicker`, `ChatAnchors`, `useChatSessions`, `ShapeStylePicker`, `TextColorTrigger`, `ReferenceDrawer`, `EdgeContextMenu`, `NodeContextMenu`, `Sidebar`, `GraphPage`, and `SlashCommandMenu` to use the new `useClickOutside()` hook.

- **Enhanced menu keyboard navigation**: Updated `useMenuKeyboardNav()` to delegate Escape handling to the shared `useEscapeClose()` hook for consistent IME-aware dismissal across all overlays.

- **File node link preview**: Added link click handling in `FileNodeBody` to open links in the right-dock preview drawer (same surface as webview/iframe links) instead of placing caret or opening system browser.

## Notable Implementation Details

- Reference nodes preserve their on-canvas identity (id/title/type) while annotating `ref*` fields with resolved source information, enabling agents to refer to the canvas node users mentioned while understanding its actual content source.

- The `useClickOutside()` hook uses capture phase (`addEventListener(..., true)`) to intercept before ProseMirror/React's own click handling, ensuring overlays dismiss reliably even with `stopPropagation()` calls.

- Snapshot data (titleSnapshot, typeSnapshot, workspaceNameSnapshot) is persisted on reference nodes to provide fallback diagnostics when sources become unavailable, preventing empty shells.

- Reference resolution respects workspace boundaries and only resolves `workspace-node` kind references to concrete sources (matching renderer capabilities); other kinds fall through to snapshot.

https://claude.ai/code/session_01Ed9rPxsAzCUMoMFaS9dcLa