### PR TITLE
[codex] make workspace exports portable

### DIFF
--- a/apps/canvas-workspace/src/main/__tests__/workspace-export-archive.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/workspace-export-archive.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createWorkspaceExportArchive,
+  createWorkspaceExportPayload,
+  parseWorkspaceExportFile,
+  type WorkspaceExportFile,
+} from '../canvas/workspace-export-archive';
+
+const makePayload = (files: WorkspaceExportFile[] = []) => createWorkspaceExportPayload({
+  exportedAt: '2026-06-17T00:00:00.000Z',
+  workspace: { id: 'ws-a', name: 'Research' },
+  canvas: { nodes: [] },
+  files,
+});
+
+describe('workspace export archive', () => {
+  it('writes and reads a Pulse Canvas workspace zip archive', () => {
+    const archive = createWorkspaceExportArchive(makePayload([
+      { relativePath: 'notes/readme.md', encoding: 'base64', content: Buffer.from('hello').toString('base64') },
+    ]));
+
+    expect([...archive.subarray(0, 2)]).toEqual([0x50, 0x4b]);
+    const parsed = parseWorkspaceExportFile(archive);
+    expect(parsed.workspace).toEqual({ id: 'ws-a', name: 'Research' });
+    expect(parsed.files).toHaveLength(1);
+  });
+
+  it('keeps backward compatibility with legacy JSON exports', () => {
+    const legacy = Buffer.from(JSON.stringify(makePayload()), 'utf-8');
+
+    expect(parseWorkspaceExportFile(legacy).workspace.name).toBe('Research');
+  });
+
+  it('rejects unsafe file paths from imported payloads', () => {
+    const legacy = Buffer.from(JSON.stringify(makePayload([
+      { relativePath: '../secret.txt', encoding: 'base64', content: '' },
+    ])), 'utf-8');
+
+    expect(() => parseWorkspaceExportFile(legacy)).toThrow(/unsafe file path/);
+  });
+});

--- a/apps/canvas-workspace/src/main/__tests__/workspace-export-external-files.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/workspace-export-external-files.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  collectExternalFilePaths,
+  collectExternalWorkspaceFiles,
+} from '../canvas/workspace-export-external-files';
+
+let root: string;
+let workspaceDir: string;
+let externalDir: string;
+
+beforeEach(async () => {
+  root = join(tmpdir(), `workspace-external-files-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  workspaceDir = join(root, 'workspace');
+  externalDir = join(root, 'outside');
+  await fs.mkdir(workspaceDir, { recursive: true });
+  await fs.mkdir(externalDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+describe('workspace export external files', () => {
+  it('finds absolute file paths outside the workspace only', async () => {
+    const internalPath = join(workspaceDir, 'inside.txt');
+    const externalPath = join(externalDir, 'outside.txt');
+    await fs.writeFile(internalPath, 'inside');
+    await fs.writeFile(externalPath, 'outside');
+
+    const paths = collectExternalFilePaths({
+      nodes: [
+        { data: { filePath: internalPath } },
+        { data: { nested: { filePath: externalPath } } },
+        { data: { filePath: 'pulsecanvas://workspace/notes.txt' } },
+      ],
+    }, workspaceDir);
+
+    expect(paths).toEqual([externalPath]);
+  });
+
+  it('copies readable external files into archive entries and maps their original paths', async () => {
+    const externalPath = join(externalDir, 'outside.txt');
+    await fs.writeFile(externalPath, 'portable content');
+
+    const bundle = await collectExternalWorkspaceFiles([externalPath, join(externalDir, 'missing.txt')], []);
+
+    expect(bundle.files).toHaveLength(1);
+    expect(bundle.files[0].relativePath).toBe('__external_files__/001-outside.txt');
+    expect(Buffer.from(bundle.files[0].content, 'base64').toString('utf-8')).toBe('portable content');
+    expect(bundle.pathMap.get(externalPath)).toBe('__external_files__/001-outside.txt');
+    expect(bundle.skipped).toHaveLength(1);
+  });
+});

--- a/apps/canvas-workspace/src/main/canvas/store.ts
+++ b/apps/canvas-workspace/src/main/canvas/store.ts
@@ -18,6 +18,19 @@ import {
   type MigrationProgress,
   type ReadJsonResult,
 } from "./storage";
+import {
+  createWorkspaceExportArchive,
+  createWorkspaceExportPayload,
+  isSafeRelativePath,
+  parseWorkspaceExportFile,
+  type WorkspaceExportFile,
+} from "./workspace-export-archive";
+import {
+  chooseExternalFilesExportMode,
+  collectExternalFilePaths,
+  collectExternalWorkspaceFiles,
+  confirmSkippedExternalFilesExport,
+} from "./workspace-export-external-files";
 
 /**
  * Extra fields the canvas-store side attaches to migration-progress events
@@ -89,27 +102,7 @@ const AGENTS_MD_TEMPLATE = `# Canvas Agent Config
 `;
 
 
-const EXPORT_FORMAT = 'pulse-canvas-workspace';
-const EXPORT_VERSION = 1;
 const PORTABLE_WORKSPACE_URL_PREFIX = 'pulsecanvas://workspace/';
-
-interface WorkspaceExportFile {
-  relativePath: string;
-  encoding: 'base64';
-  content: string;
-}
-
-interface WorkspaceExportPayload {
-  format: typeof EXPORT_FORMAT;
-  version: typeof EXPORT_VERSION;
-  exportedAt: string;
-  workspace: {
-    id: string;
-    name: string;
-  };
-  canvas: unknown;
-  files: WorkspaceExportFile[];
-}
 
 const sanitizeFileName = (name: string): string => {
   const safe = name.replace(/[^a-zA-Z0-9_\- .]/g, '').trim();
@@ -128,12 +121,6 @@ const portableUrlForRelativePath = (relativePath: string): string =>
 const relativePathFromPortableUrl = (value: string): string | null => {
   if (!value.startsWith(PORTABLE_WORKSPACE_URL_PREFIX)) return null;
   return decodeURI(value.slice(PORTABLE_WORKSPACE_URL_PREFIX.length));
-};
-
-const isSafeRelativePath = (relativePath: string): boolean => {
-  if (!relativePath || isAbsolute(relativePath)) return false;
-  const normalized = relativePath.replace(/\\/g, '/');
-  return !normalized.split('/').some((part) => part === '..' || part === '');
 };
 
 const rewriteCanvasFilePaths = (
@@ -215,31 +202,6 @@ const createUniqueImportedWorkspaceId = async (): Promise<string> => {
     }
   }
   return `ws-imported-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-};
-
-const parseWorkspaceExportPayload = (raw: string): WorkspaceExportPayload => {
-  const parsed = JSON.parse(raw) as Partial<WorkspaceExportPayload>;
-  if (parsed.format !== EXPORT_FORMAT) {
-    throw new Error('Selected file is not a Pulse Canvas workspace export.');
-  }
-  if (parsed.version !== EXPORT_VERSION) {
-    throw new Error(`Unsupported Pulse Canvas export version: ${String(parsed.version)}`);
-  }
-  if (!parsed.workspace || typeof parsed.workspace.name !== 'string') {
-    throw new Error('Workspace export is missing workspace metadata.');
-  }
-  if (!Array.isArray(parsed.files)) {
-    throw new Error('Workspace export is missing file payloads.');
-  }
-  for (const file of parsed.files) {
-    if (!file || typeof file.relativePath !== 'string' || file.encoding !== 'base64' || typeof file.content !== 'string') {
-      throw new Error('Workspace export contains an invalid file entry.');
-    }
-    if (!isSafeRelativePath(file.relativePath)) {
-      throw new Error(`Workspace export contains an unsafe file path: ${file.relativePath}`);
-    }
-  }
-  return parsed as WorkspaceExportPayload;
 };
 
 /** Manifest stays as a flat file; all other workspaces live in subdirectories. */
@@ -1409,27 +1371,49 @@ export const setupCanvasStoreIpc = () => {
 
         const workspaceDir = getWorkspaceDir(payload.id);
         const canvas = await readWorkspaceCanvasForExport(payload.id);
-        const portableCanvas = rewriteCanvasFilePaths(canvas, (filePath) => {
-          const relativePath = toPortableRelativePath(filePath, workspaceDir);
-          return relativePath ? portableUrlForRelativePath(relativePath) : filePath;
-        });
         const files = await collectWorkspaceFiles(workspaceDir);
 
         const win = BrowserWindow.getFocusedWindow();
+        const externalFilePaths = collectExternalFilePaths(canvas, workspaceDir);
+        let externalFilePathMap = new Map<string, string>();
+        let skippedExternalFileCount = 0;
+        if (externalFilePaths.length > 0) {
+          const mode = await chooseExternalFilesExportMode(externalFilePaths.length, win);
+          if (mode === 'cancel') {
+            return { ok: false, canceled: true };
+          }
+          if (mode === 'copy') {
+            const externalBundle = await collectExternalWorkspaceFiles(
+              externalFilePaths,
+              files.map((file) => file.relativePath),
+            );
+            files.push(...externalBundle.files);
+            externalFilePathMap = externalBundle.pathMap;
+            skippedExternalFileCount = externalBundle.skipped.length;
+            if (skippedExternalFileCount > 0 && !(await confirmSkippedExternalFilesExport(skippedExternalFileCount, win))) {
+              return { ok: false, canceled: true };
+            }
+          }
+        }
+
+        const portableCanvas = rewriteCanvasFilePaths(canvas, (filePath) => {
+          const relativePath = toPortableRelativePath(filePath, workspaceDir) ?? externalFilePathMap.get(filePath);
+          return relativePath ? portableUrlForRelativePath(relativePath) : filePath;
+        });
         const result = win
           ? await dialog.showSaveDialog(win, {
             title: 'Export Workspace',
-            defaultPath: `${sanitizeFileName(payload.name)}.pulsecanvas.json`,
+            defaultPath: `${sanitizeFileName(payload.name)}.pulsecanvas.zip`,
             filters: [
-              { name: 'Pulse Canvas Workspace', extensions: ['pulsecanvas.json', 'json'] },
+              { name: 'Pulse Canvas Workspace Archive', extensions: ['pulsecanvas.zip', 'zip'] },
               { name: 'All Files', extensions: ['*'] },
             ],
           })
           : await dialog.showSaveDialog({
             title: 'Export Workspace',
-            defaultPath: `${sanitizeFileName(payload.name)}.pulsecanvas.json`,
+            defaultPath: `${sanitizeFileName(payload.name)}.pulsecanvas.zip`,
             filters: [
-              { name: 'Pulse Canvas Workspace', extensions: ['pulsecanvas.json', 'json'] },
+              { name: 'Pulse Canvas Workspace Archive', extensions: ['pulsecanvas.zip', 'zip'] },
               { name: 'All Files', extensions: ['*'] },
             ],
           });
@@ -1437,16 +1421,20 @@ export const setupCanvasStoreIpc = () => {
           return { ok: false, canceled: true };
         }
 
-        const exportPayload: WorkspaceExportPayload = {
-          format: EXPORT_FORMAT,
-          version: EXPORT_VERSION,
+        const exportPayload = createWorkspaceExportPayload({
           exportedAt: new Date().toISOString(),
           workspace: { id: payload.id, name: payload.name },
           canvas: portableCanvas,
           files,
+        });
+        await fs.writeFile(result.filePath, createWorkspaceExportArchive(exportPayload));
+        return {
+          ok: true,
+          filePath: result.filePath,
+          fileCount: files.length,
+          externalFileCount: externalFilePathMap.size,
+          skippedExternalFileCount,
         };
-        await fs.writeFile(result.filePath, JSON.stringify(exportPayload, null, 2), 'utf-8');
-        return { ok: true, filePath: result.filePath, fileCount: files.length };
       } catch (err) {
         return { ok: false, error: err instanceof Error ? err.message : String(err) };
       }
@@ -1460,7 +1448,8 @@ export const setupCanvasStoreIpc = () => {
         ? await dialog.showOpenDialog(win, {
           title: 'Import Workspace',
           filters: [
-            { name: 'Pulse Canvas Workspace', extensions: ['pulsecanvas.json', 'json'] },
+            { name: 'Pulse Canvas Workspace Archive', extensions: ['pulsecanvas.zip', 'zip'] },
+            { name: 'Legacy Pulse Canvas Workspace JSON', extensions: ['pulsecanvas.json', 'json'] },
             { name: 'All Files', extensions: ['*'] },
           ],
           properties: ['openFile'],
@@ -1468,7 +1457,8 @@ export const setupCanvasStoreIpc = () => {
         : await dialog.showOpenDialog({
           title: 'Import Workspace',
           filters: [
-            { name: 'Pulse Canvas Workspace', extensions: ['pulsecanvas.json', 'json'] },
+            { name: 'Pulse Canvas Workspace Archive', extensions: ['pulsecanvas.zip', 'zip'] },
+            { name: 'Legacy Pulse Canvas Workspace JSON', extensions: ['pulsecanvas.json', 'json'] },
             { name: 'All Files', extensions: ['*'] },
           ],
           properties: ['openFile'],
@@ -1477,8 +1467,8 @@ export const setupCanvasStoreIpc = () => {
         return { ok: false, canceled: true };
       }
 
-      const raw = await fs.readFile(result.filePaths[0], 'utf-8');
-      const imported = parseWorkspaceExportPayload(raw);
+      const raw = await fs.readFile(result.filePaths[0]);
+      const imported = parseWorkspaceExportFile(raw);
       const workspaceId = await createUniqueImportedWorkspaceId();
       const workspaceName = imported.workspace.name.trim() || 'Imported Workspace';
       const workspaceDir = getWorkspaceDir(workspaceId);

--- a/apps/canvas-workspace/src/main/canvas/workspace-export-archive.ts
+++ b/apps/canvas-workspace/src/main/canvas/workspace-export-archive.ts
@@ -1,0 +1,94 @@
+import { strFromU8, strToU8, unzipSync, zipSync } from 'fflate';
+
+const EXPORT_FORMAT = 'pulse-canvas-workspace';
+const EXPORT_VERSION = 1;
+const EXPORT_PAYLOAD_FILENAME = 'workspace.json';
+
+export interface WorkspaceExportFile {
+  relativePath: string;
+  encoding: 'base64';
+  content: string;
+}
+
+export interface WorkspaceExportPayload {
+  format: typeof EXPORT_FORMAT;
+  version: typeof EXPORT_VERSION;
+  exportedAt: string;
+  workspace: {
+    id: string;
+    name: string;
+  };
+  canvas: unknown;
+  files: WorkspaceExportFile[];
+}
+
+export const createWorkspaceExportPayload = (payload: Omit<WorkspaceExportPayload, 'format' | 'version'>): WorkspaceExportPayload => ({
+  format: EXPORT_FORMAT,
+  version: EXPORT_VERSION,
+  ...payload,
+});
+
+export const isSafeRelativePath = (relativePath: string): boolean => {
+  if (!relativePath || relativePath.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(relativePath)) return false;
+  const normalized = relativePath.replace(/\\/g, '/');
+  return !normalized.split('/').some((part) => part === '..' || part === '');
+};
+
+const parseWorkspaceExportPayload = (raw: string): WorkspaceExportPayload => {
+  const parsed = JSON.parse(raw) as Partial<WorkspaceExportPayload>;
+  if (parsed.format !== EXPORT_FORMAT) {
+    throw new Error('Selected file is not a Pulse Canvas workspace export.');
+  }
+  if (parsed.version !== EXPORT_VERSION) {
+    throw new Error(`Unsupported Pulse Canvas export version: ${String(parsed.version)}`);
+  }
+  if (!parsed.workspace || typeof parsed.workspace.name !== 'string') {
+    throw new Error('Workspace export is missing workspace metadata.');
+  }
+  if (!Array.isArray(parsed.files)) {
+    throw new Error('Workspace export is missing file payloads.');
+  }
+  for (const file of parsed.files) {
+    if (!file || typeof file.relativePath !== 'string' || file.encoding !== 'base64' || typeof file.content !== 'string') {
+      throw new Error('Workspace export contains an invalid file entry.');
+    }
+    if (!isSafeRelativePath(file.relativePath)) {
+      throw new Error(`Workspace export contains an unsafe file path: ${file.relativePath}`);
+    }
+  }
+  return parsed as WorkspaceExportPayload;
+};
+
+const isZipArchive = (bytes: Uint8Array): boolean =>
+  bytes.length >= 4 &&
+  bytes[0] === 0x50 &&
+  bytes[1] === 0x4b &&
+  (bytes[2] === 0x03 || bytes[2] === 0x05 || bytes[2] === 0x07) &&
+  (bytes[3] === 0x04 || bytes[3] === 0x06 || bytes[3] === 0x08);
+
+export const createWorkspaceExportArchive = (payload: WorkspaceExportPayload): Buffer => {
+  const serialized = JSON.stringify(payload, null, 2);
+  const zipped = zipSync({
+    [EXPORT_PAYLOAD_FILENAME]: strToU8(serialized),
+  }, { level: 6 });
+  return Buffer.from(zipped);
+};
+
+export const parseWorkspaceExportFile = (bytes: Uint8Array): WorkspaceExportPayload => {
+  if (!isZipArchive(bytes)) {
+    return parseWorkspaceExportPayload(Buffer.from(bytes).toString('utf-8'));
+  }
+
+  let entries: Record<string, Uint8Array>;
+  try {
+    entries = unzipSync(bytes);
+  } catch (err) {
+    throw new Error(`Failed to read Pulse Canvas workspace archive: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  const payloadBytes = entries[EXPORT_PAYLOAD_FILENAME];
+  if (!payloadBytes) {
+    throw new Error(`Pulse Canvas workspace archive is missing ${EXPORT_PAYLOAD_FILENAME}.`);
+  }
+  return parseWorkspaceExportPayload(strFromU8(payloadBytes));
+};

--- a/apps/canvas-workspace/src/main/canvas/workspace-export-external-files.ts
+++ b/apps/canvas-workspace/src/main/canvas/workspace-export-external-files.ts
@@ -1,0 +1,136 @@
+import { BrowserWindow, dialog } from 'electron';
+import { promises as fs } from 'fs';
+import { basename, isAbsolute, relative } from 'path';
+import { isSafeRelativePath, type WorkspaceExportFile } from './workspace-export-archive';
+
+export interface ExternalWorkspaceFileBundle {
+  files: WorkspaceExportFile[];
+  pathMap: Map<string, string>;
+  skipped: string[];
+}
+
+const EXTERNAL_FILES_DIR = '__external_files__';
+
+const isOutsideWorkspace = (filePath: string, workspaceDir: string): boolean => {
+  if (!isAbsolute(filePath)) return false;
+  const rel = relative(workspaceDir, filePath);
+  return rel.startsWith('..') || isAbsolute(rel);
+};
+
+const collectFilePathValues = (value: unknown, workspaceDir: string, out: Set<string>): void => {
+  if (Array.isArray(value)) {
+    for (const item of value) collectFilePathValues(item, workspaceDir, out);
+    return;
+  }
+  if (!value || typeof value !== 'object') return;
+
+  for (const [key, item] of Object.entries(value)) {
+    if (key === 'filePath' && typeof item === 'string' && isOutsideWorkspace(item, workspaceDir)) {
+      out.add(item);
+      continue;
+    }
+    collectFilePathValues(item, workspaceDir, out);
+  }
+};
+
+export const collectExternalFilePaths = (canvas: unknown, workspaceDir: string): string[] => {
+  const paths = new Set<string>();
+  collectFilePathValues(canvas, workspaceDir, paths);
+  return [...paths].sort((a, b) => a.localeCompare(b));
+};
+
+export const chooseExternalFilesExportMode = async (
+  count: number,
+  win: BrowserWindow | null,
+): Promise<'copy' | 'keep' | 'cancel'> => {
+  const result = await (win ? dialog.showMessageBox(win, {
+    type: 'question',
+    buttons: ['Copy files into archive', 'Keep absolute paths', 'Cancel Export'],
+    defaultId: 0,
+    cancelId: 2,
+    title: 'External Files',
+    message: `This workspace references ${count} file${count === 1 ? '' : 's'} outside its workspace folder.`,
+    detail: 'Copying them into the archive makes the export portable. Keeping absolute paths may break after import on another machine.',
+  }) : dialog.showMessageBox({
+    type: 'question',
+    buttons: ['Copy files into archive', 'Keep absolute paths', 'Cancel Export'],
+    defaultId: 0,
+    cancelId: 2,
+    title: 'External Files',
+    message: `This workspace references ${count} file${count === 1 ? '' : 's'} outside its workspace folder.`,
+    detail: 'Copying them into the archive makes the export portable. Keeping absolute paths may break after import on another machine.',
+  }));
+  if (result.response === 0) return 'copy';
+  if (result.response === 1) return 'keep';
+  return 'cancel';
+};
+
+export const confirmSkippedExternalFilesExport = async (
+  count: number,
+  win: BrowserWindow | null,
+): Promise<boolean> => {
+  const options = {
+    type: 'warning' as const,
+    buttons: ['Continue Export', 'Cancel Export'],
+    defaultId: 0,
+    cancelId: 1,
+    title: 'External Files',
+    message: `${count} external file${count === 1 ? '' : 's'} could not be copied.`,
+    detail: 'Unreadable or missing files will remain as absolute paths in the exported workspace.',
+  };
+  const result = win
+    ? await dialog.showMessageBox(win, options)
+    : await dialog.showMessageBox(options);
+  return result.response === 0;
+};
+
+const sanitizeArchiveFileName = (filePath: string): string => {
+  const safe = basename(filePath)
+    .replace(/[<>:"|?*\x00-\x1F]/g, '')
+    .trim();
+  return safe || 'external-file';
+};
+
+const uniqueExternalRelativePath = (
+  filePath: string,
+  index: number,
+  usedRelativePaths: Set<string>,
+): string => {
+  const fileName = sanitizeArchiveFileName(filePath);
+  let relativePath = `${EXTERNAL_FILES_DIR}/${String(index + 1).padStart(3, '0')}-${fileName}`;
+  let suffix = 2;
+  while (usedRelativePaths.has(relativePath) || !isSafeRelativePath(relativePath)) {
+    relativePath = `${EXTERNAL_FILES_DIR}/${String(index + 1).padStart(3, '0')}-${suffix}-${fileName}`;
+    suffix += 1;
+  }
+  usedRelativePaths.add(relativePath);
+  return relativePath;
+};
+
+export const collectExternalWorkspaceFiles = async (
+  filePaths: string[],
+  existingRelativePaths: Iterable<string>,
+): Promise<ExternalWorkspaceFileBundle> => {
+  const usedRelativePaths = new Set(existingRelativePaths);
+  const files: WorkspaceExportFile[] = [];
+  const pathMap = new Map<string, string>();
+  const skipped: string[] = [];
+
+  for (const filePath of filePaths) {
+    try {
+      const stat = await fs.stat(filePath);
+      if (!stat.isFile()) {
+        skipped.push(filePath);
+        continue;
+      }
+      const relativePath = uniqueExternalRelativePath(filePath, files.length, usedRelativePaths);
+      const content = await fs.readFile(filePath);
+      files.push({ relativePath, encoding: 'base64', content: content.toString('base64') });
+      pathMap.set(filePath, relativePath);
+    } catch {
+      skipped.push(filePath);
+    }
+  }
+
+  return { files, pathMap, skipped };
+};

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
@@ -385,7 +385,7 @@
   top: 100%;
   right: 0;
   margin-top: 4px;
-  min-width: 160px;
+  min-width: 196px; width: max-content; max-width: calc(100vw - 32px);
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -406,10 +406,10 @@
   cursor: pointer;
   font-size: 13px;
   color: var(--text);
-  text-align: left;
+  text-align: left; white-space: nowrap;
   transition: background 0.1s;
 }
-
+.sidebar-add-menu-item span { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
 .sidebar-add-menu-item:hover {
   background: rgba(0, 0, 0, 0.04);
 }

--- a/apps/canvas-workspace/src/renderer/src/types/workspace-api.ts
+++ b/apps/canvas-workspace/src/renderer/src/types/workspace-api.ts
@@ -62,7 +62,15 @@ export interface CanvasWorkspaceApi {
     exportWorkspace: (
       id: string,
       name: string,
-    ) => Promise<{ ok: boolean; canceled?: boolean; filePath?: string; fileCount?: number; error?: string }>;
+    ) => Promise<{
+      ok: boolean;
+      canceled?: boolean;
+      filePath?: string;
+      fileCount?: number;
+      externalFileCount?: number;
+      skippedExternalFileCount?: number;
+      error?: string;
+    }>;
     importWorkspace: () => Promise<{
       ok: boolean;
       canceled?: boolean;


### PR DESCRIPTION
## Summary

- Export Pulse Canvas workspaces as `.pulsecanvas.zip` archives instead of JSON files.
- Keep legacy `.pulsecanvas.json` imports working while preferring zip archives in the import dialog.
- Offer to copy external absolute-path files into the archive under `__external_files__/` and rewrite exported `filePath` values to portable workspace URLs.
- Widen the sidebar add menu so `Import Workspace` does not wrap.

## Why

Workspace export/import was presenting a JSON file even though the product expectation is a portable archive. File nodes that referenced paths outside the workspace could also break after import on another machine because the absolute paths were preserved.

## Validation

- `pnpm --filter canvas-workspace typecheck`
- `pnpm --filter canvas-workspace exec vitest run src/main/__tests__/workspace-export-archive.test.ts src/main/__tests__/workspace-export-external-files.test.ts`
- `pnpm --filter canvas-workspace build`

## Notes

`src/main/__tests__/file-size-governance.test.ts` still fails on existing over-baseline files unrelated to this change; the failing list does not include files touched here.
