### PR TITLE
[codex] unify canvas chat launcher chrome

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
@@ -9,7 +9,8 @@ import type { UseCanvasSearchReturn } from '../../hooks/useCanvasSearch';
 import { CanvasEmptyHint } from '../CanvasEmptyHint';
 import { EdgeStylePanel } from '../EdgeStylePanel';
 import { EdgeLabel } from '../EdgeLabel';
-import { SelectionToolbar } from '../SelectionToolbar';
+import { ChatFloatingButton } from '../ChatFloatingButton';
+import { useI18n } from '../../i18n';
 import type { CreatableCanvasNodeType } from '../../utils/nodeFactory';
 import type { AddNodeOptions } from '../../hooks/useNodes';
 
@@ -147,6 +148,8 @@ export const CanvasOverlays = ({
   onCommitEditEdgeLabel,
   onCancelEditEdgeLabel,
 }: CanvasOverlaysProps) => {
+  const { t } = useI18n();
+
   return (
     <>
       {nodes.length === 0 && !contextMenu && (
@@ -239,39 +242,31 @@ export const CanvasOverlays = ({
           ))}
 
       <div className="canvas-bottom-chrome">
-        <SelectionToolbar
-          selectedCount={selectedNodeIds.length}
-          canFocus={selectedNodeIds.length === 1 && !!focusModeAvailable}
-          focusModeActive={!!focusModeActive}
-          canGroup={selectedNodeIds.length > 1}
-          canPinReference={selectedNodeIds.length === 1 && !!onPinReferenceSelection}
-          canAddToChat={selectedNodeIds.length === 1 && !!onAddSelectionToChat}
-          showPinReference={!!onPinReferenceSelection}
-          showAddToChat={!!onAddSelectionToChat}
-          onFitSelection={onFitSelection ?? (() => undefined)}
-          onDuplicate={onDuplicateSelection ?? (() => undefined)}
-          onToggleFocus={onToggleFocusMode ?? (() => undefined)}
-          onGroup={onGroupSelection ?? (() => undefined)}
-          onWrapFrame={onWrapSelectionInFrame ?? (() => undefined)}
-          onPinReference={onPinReferenceSelection ?? (() => undefined)}
-          onAddToChat={onAddSelectionToChat ?? (() => undefined)}
-          onDelete={onDeleteSelection ?? (() => undefined)}
-        />
         <FloatingToolbar
           activeTool={activeTool}
           onToolChange={onToolChange}
           onAddNode={onAddNode}
           onCreateAgentTeam={onCreateAgentTeam}
-          chatPanelOpen={chatPanelOpen}
-          onChatToggle={onChatToggle}
           referenceDrawerOpen={referenceDrawerOpen}
           onReferenceToggle={onReferenceToggle}
         />
-        <ZoomIndicator
-          scale={scale}
-          onReset={onResetTransform}
-          onFitAll={onFitAll}
-        />
+        <div className="canvas-bottom-chrome__left">
+          <ZoomIndicator
+            scale={scale}
+            onReset={onResetTransform}
+            onFitAll={onFitAll}
+          />
+        </div>
+        <div className="canvas-bottom-chrome__right">
+          {onChatToggle && (
+            <ChatFloatingButton
+              active={chatPanelOpen}
+              onClick={onChatToggle}
+              title={t('canvas.toolbar.toggleChat')}
+              ariaLabel={t('canvas.toolbar.toggleChat')}
+            />
+          )}
+        </div>
       </div>
 
       {searchOpen && (

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasContextMenu.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasContextMenu.ts
@@ -127,7 +127,7 @@ export const useCanvasContextMenu = ({
   const isBlankCanvasTarget = useCallback((target: EventTarget | null) => {
     if (!(target instanceof HTMLElement)) return false;
     return !target.closest(
-      '.canvas-node, .canvas-fullscreen-chip, .floating-toolbar, .zoom-indicator, .context-menu, .canvas-edges, .canvas-connect-overlay, .canvas-shape-overlay, .edge-style-panel',
+      '.canvas-node, .canvas-fullscreen-chip, .canvas-bottom-chrome, .floating-toolbar, .zoom-indicator, .context-menu, .canvas-edges, .canvas-connect-overlay, .canvas-shape-overlay, .edge-style-panel',
     );
   }, []);
 

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasMouseHandlers.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasMouseHandlers.ts
@@ -132,6 +132,7 @@ export const useCanvasMouseHandlers = ({
       const target = e.target as HTMLElement;
       if (target.closest('.canvas-node')) return;
       if (target.closest('.canvas-fullscreen-chip')) return;
+      if (target.closest('.canvas-bottom-chrome')) return;
       // Clicking inside the edges SVG (either a hit-proxy or a handle)
       // lands on a child of .canvas-edges. Those children stopPropagate
       // their own onMouseDown, but the click event can still arrive

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.css
@@ -82,6 +82,36 @@
   container-type: inline-size;
 }
 
+.canvas-bottom-chrome__left {
+  grid-column: 1;
+  grid-row: 1;
+  justify-self: start;
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  pointer-events: auto;
+}
+
+.canvas-bottom-chrome__right {
+  grid-column: 3;
+  grid-row: 1;
+  justify-self: end;
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  min-width: 0;
+  pointer-events: auto;
+}
+
+.canvas-bottom-chrome__left .zoom-indicator-group,
+.canvas-bottom-chrome__right .zoom-indicator-group {
+  grid-column: auto;
+  justify-self: auto;
+}
+
 .canvas-transform {
   position: absolute;
   top: 0;

--- a/apps/canvas-workspace/src/renderer/src/components/ChatFloatingButton/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatFloatingButton/index.css
@@ -1,0 +1,36 @@
+.chat-floating-button {
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--text-secondary);
+  box-shadow: var(--shadow-float);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  transition: background 0.1s, border-color 0.1s, color 0.1s, transform 0.1s;
+}
+
+.chat-floating-button:hover,
+.chat-floating-button:focus-visible {
+  outline: none;
+  background: var(--surface-hover);
+  color: var(--text);
+  transform: translateY(-1px);
+}
+
+.chat-floating-button--active {
+  border-color: rgba(35, 131, 226, 0.28);
+  background: var(--accent-light);
+  color: var(--accent);
+}
+
+.chat-floating-button--active:hover,
+.chat-floating-button--active:focus-visible {
+  background: var(--accent-light);
+  color: var(--accent);
+}

--- a/apps/canvas-workspace/src/renderer/src/components/ChatFloatingButton/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatFloatingButton/index.tsx
@@ -1,0 +1,37 @@
+import './index.css';
+import { AppLogoIcon } from '../icons';
+
+interface ChatFloatingButtonProps {
+  active?: boolean;
+  title: string;
+  ariaLabel?: string;
+  className?: string;
+  onClick: () => void;
+}
+
+export const ChatFloatingButton = ({
+  active,
+  title,
+  ariaLabel,
+  className,
+  onClick,
+}: ChatFloatingButtonProps) => (
+  <button
+    type="button"
+    className={[
+      'chat-floating-button',
+      active ? 'chat-floating-button--active' : '',
+      className ?? '',
+    ].filter(Boolean).join(' ')}
+    onMouseDown={(event) => event.stopPropagation()}
+    onClick={(event) => {
+      event.stopPropagation();
+      onClick();
+    }}
+    title={title}
+    aria-label={ariaLabel ?? title}
+    aria-pressed={active}
+  >
+    <AppLogoIcon size={22} />
+  </button>
+);

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.css
@@ -20,7 +20,9 @@
   bottom: auto;
   left: auto;
   grid-column: 2;
+  grid-row: 1;
   justify-self: center;
+  align-self: center;
   max-width: 100%;
   transform: none;
   pointer-events: auto;

--- a/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/GraphPage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/GraphPage.tsx
@@ -562,7 +562,7 @@ export const GraphPage = ({
 
   return (
     <main
-      className={`workspace-graph-page${showDock && dock.open ? ' has-chat-dock' : ''}`}
+      className={`workspace-graph-page${showDock && dock.rendered ? ' has-chat-dock' : ''}`}
       ref={containerRef}
       style={showDock ? dock.rootStyle : undefined}
     >
@@ -797,6 +797,7 @@ export const GraphPage = ({
       {showDock && onOpenAppSettings && (
         <NodesChatDock
           open={dock.open}
+          rendered={dock.rendered}
           width={dock.width}
           onOpen={dock.openDock}
           onClose={dock.closeDock}

--- a/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/NodesChatDock.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/NodesChatDock.tsx
@@ -4,7 +4,7 @@ import type { CanvasNode, KnowledgeTagDefinition, WorkspaceNodeListItem } from '
 import { ChatPanel } from '../chat';
 import type { AgentScope, WorkspaceOption } from '../chat/types';
 import type { SettingsSection } from '../Settings';
-import { AppLogoIcon } from '../icons';
+import { ChatFloatingButton } from '../ChatFloatingButton';
 import { useI18n } from '../../i18n';
 import { getNodeTags, getNodeTitle, getNodeWorkspaceId } from './utils';
 
@@ -13,6 +13,7 @@ const MIN_DOCK_WIDTH = 300;
 const MAX_DOCK_WIDTH = 760;
 const OPEN_STORAGE_KEY = 'pulse-canvas.nodes-chat.open';
 const WIDTH_STORAGE_KEY = 'pulse-canvas.nodes-chat.width';
+const DOCK_TRANSITION_MS = 260;
 
 const GLOBAL_SCOPE: AgentScope = { kind: 'global' };
 
@@ -32,6 +33,7 @@ export function useNodesChatDock() {
       return false;
     }
   });
+  const [rendered, setRendered] = useState(open);
   const [width, setWidth] = useState<number>(() => {
     try {
       const raw = Number(localStorage.getItem(WIDTH_STORAGE_KEY));
@@ -50,6 +52,16 @@ export function useNodesChatDock() {
   }, [open]);
 
   useEffect(() => {
+    if (open) {
+      setRendered(true);
+      return undefined;
+    }
+    if (!rendered) return undefined;
+    const timeout = window.setTimeout(() => setRendered(false), DOCK_TRANSITION_MS);
+    return () => window.clearTimeout(timeout);
+  }, [open, rendered]);
+
+  useEffect(() => {
     try {
       localStorage.setItem(WIDTH_STORAGE_KEY, String(width));
     } catch {
@@ -57,7 +69,10 @@ export function useNodesChatDock() {
     }
   }, [width]);
 
-  const openDock = useCallback(() => setOpen(true), []);
+  const openDock = useCallback(() => {
+    setRendered(true);
+    window.requestAnimationFrame(() => setOpen(true));
+  }, []);
   const closeDock = useCallback(() => setOpen(false), []);
 
   // Tear-down for an in-flight resize drag — also invoked on unmount so a
@@ -88,15 +103,16 @@ export function useNodesChatDock() {
   }, [width]);
 
   const rootStyle = useMemo(
-    () => ({ '--chat-dock-w': open ? `${width}px` : '0px' } as React.CSSProperties),
-    [open, width],
+    () => ({ '--chat-dock-w': rendered ? `${width}px` : '0px' } as React.CSSProperties),
+    [rendered, width],
   );
 
-  return { open, width, openDock, closeDock, beginResize, rootStyle };
+  return { open, rendered, width, openDock, closeDock, beginResize, rootStyle };
 }
 
 interface NodesChatDockProps {
   open: boolean;
+  rendered: boolean;
   width: number;
   onOpen: () => void;
   onClose: () => void;
@@ -123,6 +139,7 @@ interface NodesChatDockProps {
  */
 export function NodesChatDock({
   open,
+  rendered,
   width,
   onOpen,
   onClose,
@@ -167,31 +184,30 @@ export function NodesChatDock({
     }));
   }, [nodes, tags]);
 
-  if (!open) {
-    return (
-      <button
-        type="button"
-        className="nodes-chat-dock__launcher"
-        onClick={onOpen}
-        title={t('workspaceNodes.chat.openHint')}
-        aria-label={t('workspaceNodes.chat.openHint')}
-      >
-        <AppLogoIcon size={28} />
-      </button>
-    );
-  }
+  const launcherTitle = open ? t('chat.closePanel') : t('workspaceNodes.chat.openHint');
 
   return (
-    <div className="nodes-chat-dock" style={{ width }}>
-      <ChatPanel
-        agentScope={GLOBAL_SCOPE}
-        allWorkspaces={workspaces}
-        knowledgeNodes={knowledgeNodes}
-        knowledgeTags={knowledgeTags}
-        onClose={onClose}
-        onResizeStart={onBeginResize}
-        onOpenAppSettings={onOpenAppSettings}
+    <>
+      <ChatFloatingButton
+        active={open}
+        className="nodes-chat-dock__launcher"
+        onClick={open ? onClose : onOpen}
+        title={launcherTitle}
+        ariaLabel={launcherTitle}
       />
-    </div>
+      {rendered && (
+        <div className={`nodes-chat-dock${open ? ' is-open' : ' is-closing'}`} style={{ width }}>
+          <ChatPanel
+            agentScope={GLOBAL_SCOPE}
+            allWorkspaces={workspaces}
+            knowledgeNodes={knowledgeNodes}
+            knowledgeTags={knowledgeTags}
+            onClose={onClose}
+            onResizeStart={onBeginResize}
+            onOpenAppSettings={onOpenAppSettings}
+          />
+        </div>
+      )}
+    </>
   );
 }

--- a/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/NodesPage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/NodesPage.tsx
@@ -137,7 +137,7 @@ export const NodesPage = ({
 
   return (
     <main
-      className={`workspace-nodes-page${showDock && dock.open ? ' has-chat-dock' : ''}`}
+      className={`workspace-nodes-page${showDock && dock.rendered ? ' has-chat-dock' : ''}`}
       style={showDock ? dock.rootStyle : undefined}
     >
       <section className="workspace-nodes-page__main">
@@ -281,6 +281,7 @@ export const NodesPage = ({
       {showDock && onOpenAppSettings && (
         <NodesChatDock
           open={dock.open}
+          rendered={dock.rendered}
           width={dock.width}
           onOpen={dock.openDock}
           onClose={dock.closeDock}

--- a/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/index.css
@@ -968,6 +968,27 @@
   flex-direction: column;
   background: var(--nodes-surface);
   box-shadow: -8px 0 24px rgba(15, 15, 15, 0.05);
+  transform: translateX(102%);
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    transform 0.26s cubic-bezier(0.22, 1, 0.36, 1),
+    visibility 0s linear 0.26s;
+  will-change: transform;
+}
+
+.nodes-chat-dock.is-open {
+  transform: none;
+  visibility: visible;
+  pointer-events: auto;
+  transition: transform 0.26s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.nodes-chat-dock.is-closing {
+  transform: translateX(102%);
+  visibility: visible;
+  pointer-events: none;
+  transition: transform 0.26s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 /* Nodes page is a flex row, so the dock is a pushing column sitting to the
@@ -994,33 +1015,29 @@
   right: var(--chat-dock-w, 0);
 }
 
-.nodes-chat-dock__launcher {
+.chat-floating-button.nodes-chat-dock__launcher {
   position: absolute;
-  right: 20px;
-  bottom: 20px;
+  right: 16px;
+  bottom: 16px;
   z-index: 6;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 48px;
-  height: 48px;
-  padding: 0;
-  border: 1px solid var(--nodes-border);
-  border-radius: 50%;
-  background: var(--nodes-surface);
-  cursor: pointer;
-  box-shadow: var(--nodes-shadow);
-  transition: box-shadow 140ms ease, transform 140ms ease;
+  transition:
+    right 0.26s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.1s,
+    border-color 0.1s,
+    color 0.1s,
+    transform 0.1s;
 }
 
-.nodes-chat-dock__launcher:hover {
-  box-shadow: 0 3px 8px rgba(15, 15, 15, 0.1), 0 12px 28px rgba(15, 15, 15, 0.12);
-  transform: translateY(-1px);
+.workspace-nodes-page.has-chat-dock .nodes-chat-dock__launcher,
+.workspace-graph-page.has-chat-dock .nodes-chat-dock__launcher {
+  right: calc(var(--chat-dock-w, 0px) + 16px);
 }
 
-.nodes-chat-dock__launcher svg,
-.nodes-chat-dock__launcher img {
-  width: 30px;
-  height: 30px;
-  display: block;
+@media (prefers-reduced-motion: reduce) {
+  .nodes-chat-dock,
+  .nodes-chat-dock.is-open,
+  .nodes-chat-dock.is-closing,
+  .chat-floating-button.nodes-chat-dock__launcher {
+    transition: none;
+  }
 }


### PR DESCRIPTION
## Summary

- Move the canvas AI Chat entry into a shared floating launcher and keep Fit/zoom in the lower-left chrome.
- Reuse the same launcher on Nodes and Graph pages so size, active state, hover behavior, and event handling match Canvas.
- Add right-side slide-in/out behavior for the Nodes/Graph knowledge chat dock, including reduced-motion handling.

## Validation

- `pnpm --filter canvas-workspace typecheck:renderer`

## Notes

- Draft PR for review of the UI interaction polish before marking ready.