### PR TITLE
Add canvas-empty-hint to context menu target exclusion list

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasContextMenu.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasContextMenu.ts
@@ -127,7 +127,7 @@ export const useCanvasContextMenu = ({
   const isBlankCanvasTarget = useCallback((target: EventTarget | null) => {
     if (!(target instanceof HTMLElement)) return false;
     return !target.closest(
-      '.canvas-node, .canvas-fullscreen-chip, .canvas-bottom-chrome, .floating-toolbar, .zoom-indicator, .context-menu, .canvas-edges, .canvas-connect-overlay, .canvas-shape-overlay, .edge-style-panel',
+      '.canvas-node, .canvas-empty-hint, .canvas-fullscreen-chip, .canvas-bottom-chrome, .floating-toolbar, .zoom-indicator, .context-menu, .canvas-edges, .canvas-connect-overlay, .canvas-shape-overlay, .edge-style-panel',
     );
   }, []);
 


### PR DESCRIPTION
## Summary
Updated the canvas context menu logic to exclude the `.canvas-empty-hint` element from triggering context menu actions on blank canvas areas.

## Changes
- Added `.canvas-empty-hint` to the selector list in `isBlankCanvasTarget()` callback within `useCanvasContextMenu` hook
- This prevents context menu interactions when the user targets the empty state hint element

## Details
The `isBlankCanvasTarget` function determines whether a right-click event occurred on a blank canvas area (as opposed to on a specific canvas node or UI element). By adding `.canvas-empty-hint` to the exclusion list, the empty state hint is now treated as a UI element rather than blank canvas space, allowing it to have its own context menu behavior or preventing unwanted context menu triggers on that element.

https://claude.ai/code/session_01XLGPXHKkePZGS2A1zGxEef