### PR TITLE
style(canvas-workspace): rework frame node to floating-pill design (oklch Soft palette)

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/utils.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/utils.ts
@@ -63,16 +63,96 @@ export const getNodeClasses = ({
   .filter(Boolean)
   .join(' ');
 
-export const getNodeWrapperStyle = (node: CanvasNode): CSSProperties => ({
-  transform: `translate(${node.x}px, ${node.y}px)`,
-  width: node.width,
-  height: node.height,
-  ...(node.type === 'frame'
-    ? { '--frame-color': (node.data as FrameNodeData).color } as CSSProperties
-    : node.type === 'group'
-      ? { '--group-color': (node.data as GroupNodeData).color ?? '#A594E0' } as CSSProperties
-      : {}),
-});
+/* Frame palette (matches design/frame-color.html "Soft" palette).
+ *
+ * Each frame's tones (pill bg, pill text, body tint, border, dot pattern)
+ * are derived in CSS via oklch(L C var(--frame-hue)) with fixed L/C math.
+ * To support that, this helper parses the stored color into a hue number
+ * (and chroma, used to flag the low-chroma "graphite" preset).
+ *
+ * Storage compatibility:
+ *  - New presets (`COLOR_PRESETS` in FrameNodeBody/index.tsx) write
+ *    `oklch(0.66 0.155 <hue>)`; we extract <hue> directly.
+ *  - Legacy hex values (FigJam-era presets, demo workspaces) are converted
+ *    via HSL — for the warm pastel range these were drawn from, HSL hue is
+ *    within ~5–10° of oklch hue, which is good enough for the design's
+ *    soft tones.
+ *  - Anything unparseable falls back to hue 250 (a neutral indigo).
+ */
+const DEFAULT_FRAME_HUE = 250;
+const DEFAULT_FRAME_CHROMA = 0.072;
+
+const parseOklchTriple = (color: string): { hue: number; chroma: number } | null => {
+  const m = color.match(/oklch\(\s*[\d.]+\s+([\d.]+)\s+([\d.]+)/i);
+  if (!m) return null;
+  const chroma = Number(m[1]);
+  const hue = Number(m[2]);
+  if (!Number.isFinite(chroma) || !Number.isFinite(hue)) return null;
+  return { hue, chroma };
+};
+
+const hexToHue = (color: string): number | null => {
+  const m = color.match(/^#?([0-9a-f]{3}|[0-9a-f]{6})$/i);
+  if (!m) return null;
+  let hex = m[1];
+  if (hex.length === 3) hex = hex.split('').map((c) => c + c).join('');
+  const n = parseInt(hex, 16);
+  const r = ((n >> 16) & 0xff) / 255;
+  const g = ((n >> 8) & 0xff) / 255;
+  const b = (n & 0xff) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const d = max - min;
+  if (d < 0.01) return DEFAULT_FRAME_HUE; // achromatic gray
+  let h: number;
+  if (max === r) h = ((g - b) / d) % 6;
+  else if (max === g) h = (b - r) / d + 2;
+  else h = (r - g) / d + 4;
+  h *= 60;
+  if (h < 0) h += 360;
+  return h;
+};
+
+const resolveFrameHue = (color: string): { hue: number; chroma: number } => {
+  const parsed = parseOklchTriple(color);
+  if (parsed) {
+    // Stored chroma is the *saturated identity* (~0.155); we want the
+    // palette's working chroma (0.072) for derived tones, except when the
+    // preset is intentionally low-chroma (graphite, ~0.006).
+    return {
+      hue: parsed.hue,
+      chroma: parsed.chroma < 0.02 ? 0.006 : DEFAULT_FRAME_CHROMA,
+    };
+  }
+  const hue = hexToHue(color);
+  if (hue !== null) return { hue, chroma: DEFAULT_FRAME_CHROMA };
+  return { hue: DEFAULT_FRAME_HUE, chroma: DEFAULT_FRAME_CHROMA };
+};
+
+export const getNodeWrapperStyle = (node: CanvasNode): CSSProperties => {
+  const base: CSSProperties = {
+    transform: `translate(${node.x}px, ${node.y}px)`,
+    width: node.width,
+    height: node.height,
+  };
+  if (node.type === 'frame') {
+    const color = (node.data as FrameNodeData).color;
+    const { hue, chroma } = resolveFrameHue(color);
+    return {
+      ...base,
+      '--frame-color': color,
+      '--frame-hue': String(hue),
+      '--frame-chroma': String(chroma),
+    } as CSSProperties;
+  }
+  if (node.type === 'group') {
+    return {
+      ...base,
+      '--group-color': (node.data as GroupNodeData).color ?? '#A594E0',
+    } as CSSProperties;
+  }
+  return base;
+};
 
 export const sanitizeReferenceSourcePatch = (patch: Partial<CanvasNode>): Partial<CanvasNode> => {
   const { x: _x, y: _y, width: _width, height: _height, ref: _ref, ...rest } = patch;

--- a/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.css
@@ -1,29 +1,33 @@
 /* ---------------------------------------------------------------------------
- * Frame node styling
+ * Frame node styling — port of design/frame-color.html "Soft" palette.
  *
- * Visual model (matches design/frame-color.html):
- *  - Body: large rounded rectangle, very faint frame-tinted background, dashed
- *    border, and a faint radial-dot overlay for "canvas pad" texture.
- *  - Header: a *floating pill* that sits above the body's top edge, fully
- *    rounded on all four corners and inset from the top-left corner — not a
- *    tab attached to the body. Light tinted background with deep saturated
- *    text derived from the frame color, plus a soft drop shadow so it reads
- *    as floating.
- *  - Children-count badge: small rounded-square chip inside the pill, in a
- *    slightly darker tint of the frame color.
- *  - Hover/selection use the same hue family — dashed → solid border on
- *    select, with a colored outer glow.
+ * Color math: every tone is `oklch(L C var(--frame-hue))` with the design's
+ * fixed L values and C derived from `--frame-chroma` (0.072 for the regular
+ * 8 hues; 0.006 for the low-chroma graphite preset). The picker writes the
+ * stored swatch identity at L=0.66, C=0.155; CanvasNodeView/utils.ts parses
+ * the hue/chroma out of `data.color` and exposes them as CSS custom props.
  *
- * Color math:
- *  Each preset hex is mixed against `#ffffff` / `var(--surface)` / `#1a1a1a`
- *  to derive the "soft" palette tones (light pill bg ↔ deep text). Mixing in
- *  srgb keeps the math working with the existing hex-based COLOR_PRESETS in
- *  index.tsx without forcing an oklch migration.
+ *   pillBg        → L 0.935  C×0.55
+ *   pillText      → L 0.46   C×1.10   (also drives icon strokes)
+ *   countBg       → L 0.865  C×0.715  (≈ pillL − 0.07, design's countBg)
+ *   bodyTint      → L 0.986  C×0.10
+ *   bodyTintFocus → L 0.978  C×0.13
+ *   border        → L 0.90   C×0.40
+ *   borderHover   → L 0.85   C×0.55
+ *   borderFocus   → L 0.85   C×0.45
+ *   identity      → L 0.66   C×1.10  (selection ring, focus mode border)
+ *   dotPattern    → L 0.90   C×0.16
+ *
+ * --frame-color is kept as the picker dot's display value (sRGB color from
+ * the stored string, used in one place); everything else goes via hue.
  * ------------------------------------------------------------------------- */
 
 .canvas-node--frame {
-  background: color-mix(in srgb, var(--frame-color, #A8B0BD) 5%, var(--surface));
-  border: 1.5px dashed color-mix(in srgb, var(--frame-color, #A8B0BD) 40%, transparent);
+  --_c: var(--frame-chroma, 0.072);
+  --_h: var(--frame-hue, 250);
+
+  background: oklch(0.986 calc(var(--_c) * 0.10) var(--_h));
+  border: 1.5px dashed oklch(0.90 calc(var(--_c) * 0.40) var(--_h));
   border-radius: 20px;
   box-shadow: none;
   /* Header pill floats above the body via top:-22px, so we mustn't clip it. */
@@ -31,8 +35,8 @@
 }
 
 /* Faint dot pattern overlay — matches the design's "canvas pad" texture.
- * Sits behind any node-body content (z-index:0) but above the body
- * background, so child nodes inside the frame still render on top. */
+ * Sits between the body fill and the children (z-index:0); child nodes
+ * inside the frame stay on top via .canvas-node--frame > * { z-index: 1 }. */
 .canvas-node--frame::before {
   content: "";
   position: absolute;
@@ -41,11 +45,11 @@
   pointer-events: none;
   background-image: radial-gradient(
     circle,
-    color-mix(in srgb, var(--frame-color, #A8B0BD) 22%, transparent) 1px,
+    oklch(0.90 calc(var(--_c) * 0.16) var(--_h)) 1px,
     transparent 1px
   );
   background-size: 28px 28px;
-  opacity: 0.45;
+  opacity: 0.5;
   z-index: 0;
 }
 
@@ -55,30 +59,33 @@
 }
 
 .canvas-node--frame:hover {
-  border-color: color-mix(in srgb, var(--frame-color, #A8B0BD) 65%, transparent);
+  border-color: oklch(0.85 calc(var(--_c) * 0.55) var(--_h));
   box-shadow: none;
 }
 
 .canvas-node--frame.canvas-node--selected {
   border-style: solid;
-  border-color: var(--frame-color, #A8B0BD);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--frame-color, #A8B0BD) 22%, transparent);
+  border-color: oklch(0.66 calc(var(--_c) * 1.10) var(--_h));
+  box-shadow: 0 0 0 3px oklch(0.66 calc(var(--_c) * 1.10) var(--_h) / 0.22);
 }
 
 .canvas-node--frame.canvas-node--focus-mode-focused,
 .canvas-node--frame.canvas-node--focus-mode-focused.canvas-node--selected {
-  background: color-mix(in srgb, var(--frame-color, #A8B0BD) 6%, var(--surface));
+  background: oklch(0.978 calc(var(--_c) * 0.13) var(--_h));
   border-style: solid;
-  border-color: color-mix(in srgb, var(--frame-color, #A8B0BD) 80%, transparent);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--frame-color, #A8B0BD) 35%, transparent);
+  border-color: oklch(0.85 calc(var(--_c) * 0.45) var(--_h));
+  box-shadow: 0 0 0 2px oklch(0.66 calc(var(--_c) * 1.10) var(--_h) / 0.30);
 }
 
 /* ---- Header pill ----
- * Positioned as a floating chip above the frame body, inset from the
- * top-left corner. Bottom of the pill is allowed to slightly overlap the
- * body's top edge (the body's large border-radius keeps the corner clear). */
+ * Floating chip above the frame body, inset from the top-left corner. The
+ * body's 20px radius keeps the corner clear so the bottom of the pill can
+ * sit slightly inside the body. */
 
 .canvas-node--frame .node-header {
+  --_c: var(--frame-chroma, 0.072);
+  --_h: var(--frame-hue, 250);
+
   position: absolute;
   top: -22px;
   left: 16px;
@@ -88,38 +95,34 @@
   min-height: 0;
   width: auto;
   max-width: calc(100% - 32px);
-  padding: 0 10px 0 10px;
+  padding: 0 10px;
   gap: 7px;
 
-  /* Light tinted background — design's pillL≈0.94 with low chroma. */
-  background: color-mix(in srgb, var(--frame-color, #A8B0BD) 16%, #ffffff);
+  background: oklch(0.935 calc(var(--_c) * 0.55) var(--_h));
   border: none;
   border-radius: 14px;
-
-  /* Deep saturated text — design's pillText (oklch L≈0.46). */
-  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 78%, #1a1a1a);
+  color: oklch(0.46 calc(var(--_c) * 1.10) var(--_h));
 
   /* Soft tinted shadow — pill reads as floating, not glued to the body. */
   box-shadow:
-    0 2px 8px color-mix(in srgb, var(--frame-color, #A8B0BD) 18%, transparent),
-    0 0 0 1px color-mix(in srgb, var(--frame-color, #A8B0BD) 12%, transparent);
+    0 2px 8px oklch(0.46 calc(var(--_c) * 1.10) var(--_h) / 0.10),
+    0 0 0 1px oklch(0.46 calc(var(--_c) * 1.10) var(--_h) / 0.06);
 
   /* Header lives inside .canvas-transform; same scale-clamping logic as
    * before so the pill stays readable at deep zoom-out without going
-   * larger than CSS-native at zoom-in. The transform-origin moves to
-   * left top so the pill grows downward into the body, not upward off
-   * the frame entirely. */
+   * larger than CSS-native at zoom-in. transform-origin moves to left top
+   * so the pill grows downward into the body, not upward off the frame. */
   transform: scale(calc(clamp(0.6, var(--canvas-scale, 1), 1) / var(--canvas-scale, 1)));
   transform-origin: left top;
   z-index: 2;
 }
 
 .canvas-node--frame .node-header .node-type-badge--frame {
-  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 75%, #1a1a1a);
+  color: oklch(0.46 calc(var(--_c) * 1.10) var(--_h));
 }
 
 .canvas-node--frame .node-header .node-title {
-  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 78%, #1a1a1a);
+  color: oklch(0.46 calc(var(--_c) * 1.10) var(--_h));
   font-weight: 700;
   font-size: 13px;
   letter-spacing: -0.005em;
@@ -131,11 +134,14 @@
 }
 
 /* ---- Children-collapse toggle / count badge ----
- * In the design this is a compact rounded-square chip carrying the count.
- * We keep the chevron icon (still functional) but slim the chip down so it
- * matches the count badge silhouette. */
+ * Compact rounded-square chip carrying the count, in the design's countBg
+ * tone (slightly darker than the pill bg). The chevron stays for the
+ * collapse-children behavior. */
 
 .frame-children-toggle {
+  --_c: var(--frame-chroma, 0.072);
+  --_h: var(--frame-hue, 250);
+
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -146,8 +152,8 @@
   padding: 0 6px;
   border: 0;
   border-radius: 7px;
-  background: color-mix(in srgb, var(--frame-color, #A8B0BD) 26%, #ffffff);
-  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 80%, #1a1a1a);
+  background: oklch(0.865 calc(var(--_c) * 0.715) var(--_h));
+  color: oklch(0.46 calc(var(--_c) * 1.10) var(--_h));
   cursor: pointer;
   transition:
     background 0.14s ease,
@@ -157,7 +163,6 @@
 
 .frame-children-toggle svg {
   flex: 0 0 auto;
-  /* Trim the chevron icon so the chip stays compact. */
   width: 13px;
   height: 13px;
 }
@@ -198,8 +203,8 @@
 }
 
 .frame-children-toggle:hover {
-  background: color-mix(in srgb, var(--frame-color, #A8B0BD) 36%, #ffffff);
-  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 88%, #000000);
+  background: oklch(0.82 calc(var(--_c) * 0.85) var(--_h));
+  color: oklch(0.40 calc(var(--_c) * 1.20) var(--_h));
   transform: translateY(-0.5px);
 }
 
@@ -213,8 +218,8 @@
 }
 
 .frame-children-toggle:disabled:hover {
-  background: color-mix(in srgb, var(--frame-color, #A8B0BD) 26%, #ffffff);
-  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 80%, #1a1a1a);
+  background: oklch(0.865 calc(var(--_c) * 0.715) var(--_h));
+  color: oklch(0.46 calc(var(--_c) * 1.10) var(--_h));
   transform: none;
 }
 
@@ -240,12 +245,12 @@
 
 .canvas-node--frame .node-header .node-focus,
 .canvas-node--frame .node-header .node-close {
-  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 60%, #333333);
+  color: oklch(0.55 calc(var(--_c) * 0.80) var(--_h));
 }
 
 .canvas-node--frame .node-header .node-focus:hover {
-  background: color-mix(in srgb, var(--frame-color, #A8B0BD) 28%, transparent);
-  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 85%, #000000);
+  background: oklch(0.85 calc(var(--_c) * 0.85) var(--_h));
+  color: oklch(0.40 calc(var(--_c) * 1.20) var(--_h));
 }
 
 .canvas-node--frame .node-header .node-close:hover {
@@ -270,6 +275,9 @@
  * Reserve a fixed 16px slot so the pill width doesn't jump when the dot
  * fades in on hover. */
 .frame-color-trigger {
+  --_c: var(--frame-chroma, 0.072);
+  --_h: var(--frame-hue, 250);
+
   position: relative;
   display: flex;
   align-items: center;
@@ -293,7 +301,10 @@
   height: 12px;
   padding: 0;
   border-radius: 50%;
-  border: 1.5px solid color-mix(in srgb, var(--frame-color, #A8B0BD) 60%, #ffffff);
+  /* Border uses the saturated identity so the dot reads as a colored ring
+   * even before hover. The fill stays transparent — the *hue picker
+   * trigger* shouldn't masquerade as the active swatch. */
+  border: 1.5px solid oklch(0.66 calc(var(--_c) * 1.10) var(--_h));
   background: transparent;
   cursor: pointer;
   transition: border-color 0.15s ease, transform 0.1s ease;
@@ -305,7 +316,7 @@
 }
 
 .frame-color-trigger:hover .frame-color-dot {
-  border-color: color-mix(in srgb, var(--frame-color, #A8B0BD) 85%, #000000);
+  border-color: oklch(0.50 calc(var(--_c) * 1.20) var(--_h));
   transform: scale(1.15);
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.css
@@ -1,26 +1,61 @@
 /* ---------------------------------------------------------------------------
  * Frame node styling
  *
- * Design goals:
- *  - Soft, cohesive FigJam-style palette (see COLOR_PRESETS in index.tsx).
- *  - Dashed default border to signal "container" (not a solid card).
- *  - Solid border + stronger glow when selected, so selection reads clearly.
- *  - Narrow header tab with dark text derived from the frame color, so every
- *    hue stays legible (white text on mid-saturation hues looked washed out).
+ * Visual model (matches design/frame-color.html):
+ *  - Body: large rounded rectangle, very faint frame-tinted background, dashed
+ *    border, and a faint radial-dot overlay for "canvas pad" texture.
+ *  - Header: a *floating pill* that sits above the body's top edge, fully
+ *    rounded on all four corners and inset from the top-left corner — not a
+ *    tab attached to the body. Light tinted background with deep saturated
+ *    text derived from the frame color, plus a soft drop shadow so it reads
+ *    as floating.
+ *  - Children-count badge: small rounded-square chip inside the pill, in a
+ *    slightly darker tint of the frame color.
+ *  - Hover/selection use the same hue family — dashed → solid border on
+ *    select, with a colored outer glow.
+ *
+ * Color math:
+ *  Each preset hex is mixed against `#ffffff` / `var(--surface)` / `#1a1a1a`
+ *  to derive the "soft" palette tones (light pill bg ↔ deep text). Mixing in
+ *  srgb keeps the math working with the existing hex-based COLOR_PRESETS in
+ *  index.tsx without forcing an oklch migration.
  * ------------------------------------------------------------------------- */
 
 .canvas-node--frame {
-  /* Mix the tint over --surface (not transparent) so frames don't pick up the
-   * canvas background underneath and look muddy. */
-  background: color-mix(in srgb, var(--frame-color, #A8B0BD) 6%, var(--surface));
-  border: 1.5px dashed color-mix(in srgb, var(--frame-color, #A8B0BD) 50%, transparent);
+  background: color-mix(in srgb, var(--frame-color, #A8B0BD) 5%, var(--surface));
+  border: 1.5px dashed color-mix(in srgb, var(--frame-color, #A8B0BD) 40%, transparent);
+  border-radius: 20px;
   box-shadow: none;
+  /* Header pill floats above the body via top:-22px, so we mustn't clip it. */
   overflow: visible;
-  border-top-left-radius: 0px;
+}
+
+/* Faint dot pattern overlay — matches the design's "canvas pad" texture.
+ * Sits behind any node-body content (z-index:0) but above the body
+ * background, so child nodes inside the frame still render on top. */
+.canvas-node--frame::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background-image: radial-gradient(
+    circle,
+    color-mix(in srgb, var(--frame-color, #A8B0BD) 22%, transparent) 1px,
+    transparent 1px
+  );
+  background-size: 28px 28px;
+  opacity: 0.45;
+  z-index: 0;
+}
+
+.canvas-node--frame > * {
+  position: relative;
+  z-index: 1;
 }
 
 .canvas-node--frame:hover {
-  border-color: color-mix(in srgb, var(--frame-color, #A8B0BD) 75%, transparent);
+  border-color: color-mix(in srgb, var(--frame-color, #A8B0BD) 65%, transparent);
   box-shadow: none;
 }
 
@@ -32,75 +67,87 @@
 
 .canvas-node--frame.canvas-node--focus-mode-focused,
 .canvas-node--frame.canvas-node--focus-mode-focused.canvas-node--selected {
-  background: color-mix(in srgb, var(--frame-color, #A8B0BD) 7%, var(--surface));
+  background: color-mix(in srgb, var(--frame-color, #A8B0BD) 6%, var(--surface));
   border-style: solid;
   border-color: color-mix(in srgb, var(--frame-color, #A8B0BD) 80%, transparent);
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--frame-color, #A8B0BD) 35%, transparent);
 }
 
-/* ---- Header tab ---- */
+/* ---- Header pill ----
+ * Positioned as a floating chip above the frame body, inset from the
+ * top-left corner. Bottom of the pill is allowed to slightly overlap the
+ * body's top edge (the body's large border-radius keeps the corner clear). */
 
 .canvas-node--frame .node-header {
   position: absolute;
-  top: -30px;
-  left: -1.5px;
+  top: -22px;
+  left: 16px;
   height: 28px;
-  /* Override the generic .node-header min-height: 32px so the tab actually
-   * renders at its intended 24px height instead of dipping into the frame
-   * body by 6px. */
+  /* Override the generic .node-header min-height: 32px so the pill renders
+   * at its intended height. */
   min-height: 0;
-  min-width: 120px;
-  max-width: 100%;
-  /* Soft tint background: frame color mixed with white produces a label-like
-   * pastel across every hue. */
-  background: color-mix(in srgb, var(--frame-color, #A8B0BD) 22%, #ffffff);
-  border: 1px solid color-mix(in srgb, var(--frame-color, #A8B0BD) 45%, transparent);
-  border-bottom: none;
-  border-radius: 6px 6px 0 0;
-  padding: 0 8px;
-  /* Dark text derived from frame color — readable on every preset hue. */
-  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 70%, #111111);
-  /* The header lives inside .canvas-transform, so its visual screen size is
-   * (this scale) × canvas-scale. We want the *visual* size clamped to
-   * [0.6, 1] of native — readable but never bigger than CSS-native. So the
-   * CSS scale here = clamp(0.6, canvas-scale, 1) / canvas-scale:
-   *  - zoom-in  (>1): CSS scale <1 → keeps header at screen-native size.
-   *  - zoom 1×:       CSS scale = 1 → native size.
-   *  - zoom-out (<1): CSS scale >1, capped so visual size won't go below 0.6×
-   *    (otherwise the title becomes unreadable at deep zoom-out — the prior
-   *    `min(1, 1/scale)` form let it shrink all the way to 0.19× with the
-   *    canvas, which is exactly what we don't want here). */
+  width: auto;
+  max-width: calc(100% - 32px);
+  padding: 0 10px 0 10px;
+  gap: 7px;
+
+  /* Light tinted background — design's pillL≈0.94 with low chroma. */
+  background: color-mix(in srgb, var(--frame-color, #A8B0BD) 16%, #ffffff);
+  border: none;
+  border-radius: 14px;
+
+  /* Deep saturated text — design's pillText (oklch L≈0.46). */
+  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 78%, #1a1a1a);
+
+  /* Soft tinted shadow — pill reads as floating, not glued to the body. */
+  box-shadow:
+    0 2px 8px color-mix(in srgb, var(--frame-color, #A8B0BD) 18%, transparent),
+    0 0 0 1px color-mix(in srgb, var(--frame-color, #A8B0BD) 12%, transparent);
+
+  /* Header lives inside .canvas-transform; same scale-clamping logic as
+   * before so the pill stays readable at deep zoom-out without going
+   * larger than CSS-native at zoom-in. The transform-origin moves to
+   * left top so the pill grows downward into the body, not upward off
+   * the frame entirely. */
   transform: scale(calc(clamp(0.6, var(--canvas-scale, 1), 1) / var(--canvas-scale, 1)));
-  transform-origin: left bottom;
+  transform-origin: left top;
   z-index: 2;
 }
 
 .canvas-node--frame .node-header .node-type-badge--frame {
-  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 65%, #111111);
+  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 75%, #1a1a1a);
 }
 
 .canvas-node--frame .node-header .node-title {
-  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 70%, #111111);
-  font-weight: 600;
+  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 78%, #1a1a1a);
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: -0.005em;
 }
 
 .canvas-node--frame .node-header .node-title:focus {
-  background: rgba(255, 255, 255, 0.5);
+  background: rgba(255, 255, 255, 0.55);
+  border-radius: 4px;
 }
+
+/* ---- Children-collapse toggle / count badge ----
+ * In the design this is a compact rounded-square chip carrying the count.
+ * We keep the chevron icon (still functional) but slim the chip down so it
+ * matches the count badge silhouette. */
 
 .frame-children-toggle {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 2px;
+  gap: 3px;
   flex-shrink: 0;
-  height: 20px;
-  min-width: 34px;
-  padding: 0 6px 0 4px;
+  height: 19px;
+  min-width: 28px;
+  padding: 0 6px;
   border: 0;
-  border-radius: 999px;
-  background: transparent;
-  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 62%, #111111);
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--frame-color, #A8B0BD) 26%, #ffffff);
+  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 80%, #1a1a1a);
   cursor: pointer;
   transition:
     background 0.14s ease,
@@ -110,6 +157,9 @@
 
 .frame-children-toggle svg {
   flex: 0 0 auto;
+  /* Trim the chevron icon so the chip stays compact. */
+  width: 13px;
+  height: 13px;
 }
 
 .frame-children-toggle-icon__chevron,
@@ -148,8 +198,8 @@
 }
 
 .frame-children-toggle:hover {
-  background: color-mix(in srgb, var(--frame-color, #A8B0BD) 14%, transparent);
-  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 82%, #000000);
+  background: color-mix(in srgb, var(--frame-color, #A8B0BD) 36%, #ffffff);
+  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 88%, #000000);
   transform: translateY(-0.5px);
 }
 
@@ -159,12 +209,12 @@
 
 .frame-children-toggle:disabled {
   cursor: default;
-  opacity: 0.45;
+  opacity: 0.5;
 }
 
 .frame-children-toggle:disabled:hover {
-  background: transparent;
-  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 62%, #111111);
+  background: color-mix(in srgb, var(--frame-color, #A8B0BD) 26%, #ffffff);
+  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 80%, #1a1a1a);
   transform: none;
 }
 
@@ -174,8 +224,9 @@
 
 .frame-children-count {
   min-width: 6px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 11px;
-  font-weight: 650;
+  font-weight: 700;
   line-height: 1;
   text-align: center;
   transition: transform 0.18s ease;
@@ -185,14 +236,16 @@
   transform: translateX(0.5px);
 }
 
+/* ---- Header action buttons (focus / close) ---- */
+
 .canvas-node--frame .node-header .node-focus,
 .canvas-node--frame .node-header .node-close {
-  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 55%, #333333);
+  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 60%, #333333);
 }
 
 .canvas-node--frame .node-header .node-focus:hover {
-  background: color-mix(in srgb, var(--frame-color, #A8B0BD) 25%, transparent);
-  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 80%, #000000);
+  background: color-mix(in srgb, var(--frame-color, #A8B0BD) 28%, transparent);
+  color: color-mix(in srgb, var(--frame-color, #A8B0BD) 85%, #000000);
 }
 
 .canvas-node--frame .node-header .node-close:hover {
@@ -200,19 +253,21 @@
   color: #d03b3b;
 }
 
+/* ---- Body fill ---- */
+
 .canvas-node--frame .node-body {
   height: 100%;
 }
 
 .frame-body {
   height: 100%;
-  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+  border-radius: inherit;
   min-height: 60px;
   position: relative;
 }
 
-/* ---- Color trigger (in header) ----
- * Reserve a fixed 16px slot so the header width doesn't jump when the dot
+/* ---- Color trigger (in pill) ----
+ * Reserve a fixed 16px slot so the pill width doesn't jump when the dot
  * fades in on hover. */
 .frame-color-trigger {
   position: relative;
@@ -238,7 +293,7 @@
   height: 12px;
   padding: 0;
   border-radius: 50%;
-  border: 1.5px solid color-mix(in srgb, var(--frame-color, #A8B0BD) 55%, #ffffff);
+  border: 1.5px solid color-mix(in srgb, var(--frame-color, #A8B0BD) 60%, #ffffff);
   background: transparent;
   cursor: pointer;
   transition: border-color 0.15s ease, transform 0.1s ease;
@@ -250,11 +305,11 @@
 }
 
 .frame-color-trigger:hover .frame-color-dot {
-  border-color: color-mix(in srgb, var(--frame-color, #A8B0BD) 80%, #000000);
+  border-color: color-mix(in srgb, var(--frame-color, #A8B0BD) 85%, #000000);
   transform: scale(1.15);
 }
 
-/* Popover floats ABOVE the header tab (not below), so it opens into empty
+/* Popover floats ABOVE the pill (not below), so it opens into empty
  * canvas space instead of overlapping child nodes inside the frame body. */
 .frame-color-popover {
   position: absolute;

--- a/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.tsx
@@ -47,19 +47,28 @@ export const FrameNodeBody = ({
 
 /* ---- Color picker (rendered in header) ---- */
 
-// FigJam-style soft palette: L≈70, S≈55%, hues evenly distributed.
-// These read as a cohesive family and produce good dark-text contrast in the
-// narrow header tab (see FrameNodeBody/index.css).
+// "Soft" palette from design/frame-color.html.
+//
+// Each preset is one hue around the wheel (terracotta → amber → citron →
+// sage → teal → azure → indigo → plum + a low-chroma graphite slot). All
+// derived tones (pill bg, pill text, body tint, border, dot pattern) are
+// computed in CSS as `oklch(L C var(--frame-hue))` with the design's exact
+// L/C math; see CanvasNodeView/utils.ts for the parse path.
+//
+// `value` is the saturated identity at L=0.66, C=0.155 — what the picker
+// dot displays and what gets written into `data.color`. The 9th preset uses
+// near-zero chroma so the frame reads as a quiet neutral (like the design's
+// gray frame in the 3×3 grid).
 const COLOR_PRESETS = [
-  { name: "Red", value: "#F08F82" },
-  { name: "Orange", value: "#F5B36B" },
-  { name: "Yellow", value: "#E8C468" },
-  { name: "Green", value: "#7BC89B" },
-  { name: "Teal", value: "#6FBFC7" },
-  { name: "Blue", value: "#7AA7E8" },
-  { name: "Purple", value: "#A594E0" },
-  { name: "Pink", value: "#E89BBF" },
-  { name: "Gray", value: "#A8B0BD" }
+  { name: "Terracotta", hue: 32,  value: "oklch(0.66 0.155 32)"  },
+  { name: "Amber",      hue: 68,  value: "oklch(0.66 0.155 68)"  },
+  { name: "Citron",     hue: 108, value: "oklch(0.66 0.155 108)" },
+  { name: "Sage",       hue: 152, value: "oklch(0.66 0.155 152)" },
+  { name: "Teal",       hue: 195, value: "oklch(0.66 0.155 195)" },
+  { name: "Azure",      hue: 248, value: "oklch(0.66 0.155 248)" },
+  { name: "Indigo",     hue: 292, value: "oklch(0.66 0.155 292)" },
+  { name: "Plum",       hue: 328, value: "oklch(0.66 0.155 328)" },
+  { name: "Graphite",   hue: 265, value: "oklch(0.66 0.006 265)" }
 ];
 
 interface ColorPickerProps {

--- a/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
@@ -67,7 +67,7 @@ export const createNodeData = (type: CanvasNode['type']): FileNodeData | Termina
   switch (type) {
     case 'file':     return { filePath: '', content: '', saved: false, modified: false };
     case 'terminal': return { sessionId: '' };
-    case 'frame':    return { color: '#9575d4' };
+    case 'frame':    return { color: 'oklch(0.66 0.155 248)' };
     case 'group':    return { color: '#A594E0', childIds: [] };
     case 'agent':    return { sessionId: '', agentType: 'claude-code', status: 'idle' };
     case 'text':     return { content: '', textColor: '#1f2328', backgroundColor: 'transparent', fontSize: 18, autoSize: true };


### PR DESCRIPTION
Reworks the canvas frame node visuals to match `design/frame-color.html`. Two commits:

1. **`bc9d946c` — structure**: header becomes a floating pill (fully rounded, inset from the corner, deep saturated text on a soft tinted bg with a subtle drop shadow), body gets a 20px corner radius and a faint radial-dot overlay, children-count toggle becomes a compact rounded-square chip.
2. **`2637bf47` — palette**: every derived tone is now `oklch(L C var(--frame-hue))` with the design's exact L/C math. The 9 picker presets are keyed by hue around the wheel (terracotta 32, amber 68, citron 108, sage 152, teal 195, azure 248, indigo 292, plum 328, graphite 265 with low chroma).

## Color math (faithful to the design's `SYS.Soft`)

| Tone | Formula |
|---|---|
| body tint | `oklch(0.986 C×0.10 H)` |
| border default / hover | `oklch(0.90 C×0.40 H)` dashed → `oklch(0.85 C×0.55 H)` solid |
| selection ring | `oklch(0.66 C×1.10 H / 0.22)` |
| pill bg / text | `oklch(0.935 C×0.55 H)` / `oklch(0.46 C×1.10 H)` |
| count chip bg | `oklch(0.865 C×0.715 H)` |
| dot pattern | `oklch(0.90 C×0.16 H)` |

`C` is `--frame-chroma` (default 0.072; 0.006 for the graphite preset).

## How `--frame-hue` gets set

`CanvasNodeView/utils.ts` resolves `node.data.color` into `--frame-hue` + `--frame-chroma` and exposes them on the wrapper:

- New oklch strings → regex-extract hue/chroma directly.
- Legacy hex (FigJam-era presets, demo workspaces) → fall back via HSL hue. Within ~5–10° of oklch hue for the warm pastel range these were drawn from, so existing canvases keep displaying with the new palette structure.
- Anything unparseable → hue 250 / chroma 0.072.

The picker still writes a string into `data.color`, so no `FrameNodeData` schema change is needed.

## Compatibility

- `data.color` stays a `string` field; storage format unchanged.
- New default color (`createNodeData('frame')`) switches from `#9575d4` to `oklch(0.66 0.155 248)` so freshly created frames land on the new palette.
- `oklch()` needs Chrome 111+; Electron 30 ships Chromium 124+, so in-app rendering is fine.

## Verification

- `pnpm --filter canvas-workspace typecheck` ✅
- `pnpm --filter canvas-workspace test` — 536/537 pass. The 1 failing `file-size-governance` test is a pre-existing failure on master (unrelated files: `Canvas/index.tsx`, `ChatPanel.css`, `useMentions.ts`, `GraphPage.tsx`, `WorkspaceNodes/index.css`); confirmed by stashing this PR's changes and rerunning.

## Files touched

- `src/renderer/src/components/FrameNodeBody/index.tsx` — new 9-preset palette
- `src/renderer/src/components/FrameNodeBody/index.css` — full visual rewrite
- `src/renderer/src/components/CanvasNodeView/utils.ts` — `--frame-hue` / `--frame-chroma` derivation
- `src/renderer/src/utils/nodeFactory.ts` — default frame color

🤖 Generated with [Claude Code](https://claude.com/claude-code)