### PR TITLE
perf(canvas-workspace): skip / throttle offscreen nodes (content-visibility + webview frame-rate)

### DIFF
--- a/apps/canvas-workspace/src/main/webview/registry.ts
+++ b/apps/canvas-workspace/src/main/webview/registry.ts
@@ -509,4 +509,47 @@ export function setupWebviewRegistryIpc(): void {
       return cancelDomElementPickForNode(payload.workspaceId, payload.nodeId);
     },
   );
+
+  /**
+   * Background throttle for off-canvas-viewport webviews.
+   *
+   * Renderer detects when a webview-bearing node has been outside the visible
+   * canvas viewport for long enough (see useWebviewBackgroundThrottle) and
+   * asks main to drop its `setFrameRate`. The webview's guest process stays
+   * alive — only the paint cadence drops, so JS execution, timers, and
+   * network continue at normal speed and no in-page state is lost. When the
+   * node returns to the viewport renderer asks main to restore 60fps.
+   *
+   * Frame rate is clamped to Electron's [1, 240] range. Calls for unknown
+   * (workspaceId, nodeId) pairs (or already-destroyed webContents) silently
+   * resolve to {ok:false} — this happens normally during teardown when the
+   * IO observer fires after webview unregistration.
+   */
+  ipcMain.handle(
+    'iframe:set-frame-rate',
+    (
+      _event,
+      payload: { workspaceId: string; nodeId: string; frameRate: number },
+    ) => {
+      if (
+        !payload?.workspaceId ||
+        !payload?.nodeId ||
+        typeof payload.frameRate !== 'number'
+      ) {
+        return { ok: false };
+      }
+      const wc = getWebContentsForNode(payload.workspaceId, payload.nodeId);
+      if (!wc) return { ok: false };
+      const clamped = Math.max(1, Math.min(240, Math.round(payload.frameRate)));
+      try {
+        wc.setFrameRate(clamped);
+        return { ok: true, frameRate: clamped };
+      } catch (err) {
+        console.warn(
+          `[webview-registry] setFrameRate(${clamped}) failed for ${payload.workspaceId}::${payload.nodeId}: ${(err as Error).message}`,
+        );
+        return { ok: false };
+      }
+    },
+  );
 }

--- a/apps/canvas-workspace/src/preload/bridge/webview.ts
+++ b/apps/canvas-workspace/src/preload/bridge/webview.ts
@@ -15,6 +15,9 @@ export const createIframeApi = (ipcRenderer: IpcRenderer): IframeApi => ({
   unregisterWebview: (workspaceId, nodeId) =>
     ipcRenderer.invoke("iframe:unregister-webview", { workspaceId, nodeId }),
 
+  setFrameRate: (workspaceId, nodeId, frameRate) =>
+    ipcRenderer.invoke("iframe:set-frame-rate", { workspaceId, nodeId, frameRate }),
+
   pickDomElement: (workspaceId, nodeId) =>
     ipcRenderer.invoke("iframe:pick-dom-element", { workspaceId, nodeId }),
 

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
@@ -12,6 +12,7 @@ import type { MarqueeRect } from '../../hooks/useMarqueeSelect';
 import type { SnapLine } from '../../utils/canvasSnapping';
 import { ShapePrimitive } from '../../utils/shapeGeometry';
 import { useI18n } from '../../i18n';
+import type { CanvasNodeRenderMode } from '../CanvasNodeView/types';
 
 interface NodeRenderGroup {
   containers: CanvasNode[];
@@ -169,148 +170,119 @@ export const CanvasSurface = ({
   onEdgeBodyDoubleClick,
   onEdgeBodyContextMenu,
   getAllNodes,
-}: CanvasSurfaceProps) => (
-  <div
-    className={`canvas-transform${moving || animating ? ' canvas-transform--moving' : ''}${transform.scale < 0.6 ? ' canvas-transform--small' : ''}`}
-    style={{
-      transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`,
-      '--canvas-scale': transform.scale,
-      transition: animating
-        ? 'transform 0.32s cubic-bezier(0.25, 0.46, 0.45, 0.94), --canvas-scale 0.32s cubic-bezier(0.25, 0.46, 0.45, 0.94)'
-        : undefined,
-    } as React.CSSProperties}
-  >
-    {/* Focus-mode backdrop: a giant translucent dark rectangle that
-        lives INSIDE the transform so it scales/pans with the canvas
-        and we never have to fight `.canvas-transform`'s stacking
-        context. Sized large enough to cover any reasonable zoom/pan
-        combination so the user never sees its edge. Without this, the
-        per-node dim opacity competes with a bright white canvas
-        background and the focused node fails to pop. */}
-    {focusModeEnabled && <div className="canvas-focus-backdrop" />}
-    {/* Fullscreen backdrop. Sits between the other (now offset-jumped)
-        nodes and the fullscreen node, dimming everything behind. Click
-        anywhere on the backdrop to exit. */}
-    {fullscreenNodeId && (
-      <div
-        className="canvas-fullscreen-backdrop"
-        onMouseDown={(e) => {
-          e.stopPropagation();
-          onExitFullscreen?.();
-        }}
-      />
-    )}
-    {/* Containers render first as the canvas background/grouping layer. Edges
-        render after containers so frame fills can no longer cover connection
-        lines, while regular nodes still paint above edges. */}
-    {renderGroups.containers
-      .map((node) => (
-        <CanvasNodeView
-          key={node.id}
-          node={node}
-          getAllNodes={getAllNodes}
-          rootFolder={rootFolder}
-          workspaceId={canvasId}
-          workspaceName={canvasName}
-          isDragging={draggingIds.has(node.id) || draggingId === node.id}
-          isResizing={resizingId === node.id}
-          isSelected={selectedNodeIdSet.has(node.id)}
-          isHighlighted={highlightedId === node.id}
-          isAgentEdited={externallyEditedIds.has(node.id)}
-          focusState={!focusModeEnabled
-            ? 'neutral'
-            : focusedNodeIds?.has(node.id) ? 'focused'
-              : focusContextNodeIds?.has(node.id) ? 'context'
-                : 'dimmed'}
-          onDragStart={onDragStart}
-          onResizeStart={onResizeStart}
-          onUpdate={onUpdate}
-          onAutoResize={onAutoResize}
-          onRemove={onRemove}
-          onRemoveNodes={onRemoveNodes}
-          onExportMindmapImage={onExportMindmapImage}
-          onSelect={onSelect}
-          onFocus={onFocus}
-          onReference={onReference}
-          onAddToChat={onAddToChat}
-          onAddDomSelectionToChat={onAddDomSelectionToChat}
-          resolveReferenceNode={resolveReferenceNode}
-          onOpenReferenceSource={onOpenReferenceSource}
-          onUpdateReferenceSource={onUpdateReferenceSource}
-          onUngroupSelectedGroups={onUngroupSelectedGroups}
-          isFullscreen={fullscreenNodeId === node.id}
-          onToggleFullscreen={onToggleFullscreen}
-        />
-      ))}
-    <CanvasEdgesLayer
-      edges={edges}
-      nodes={nodes}
-      selectedEdgeId={selectedEdgeId}
-      onSelectEdge={onSelectEdge}
-      interactionState={edgeInteractionState}
-      previewEndpoints={edgePreviewEndpoints}
-      focusedNodeIds={focusedNodeIds}
-      focusContextNodeIds={focusContextNodeIds}
-      focusModeEnabled={focusModeEnabled}
-      onHandleMouseDown={onEdgeHandleMouseDown}
-      onBodyMouseDown={onEdgeBodyMouseDown}
-      onBodyDoubleClick={onEdgeBodyDoubleClick}
-      onBodyContextMenu={onEdgeBodyContextMenu}
+}: CanvasSurfaceProps) => {
+  const renderNode = (node: CanvasNode, renderMode: CanvasNodeRenderMode = 'full') => (
+    <CanvasNodeView
+      key={`${node.id}:${renderMode}`}
+      node={node}
+      getAllNodes={getAllNodes}
+      rootFolder={rootFolder}
+      workspaceId={canvasId}
+      workspaceName={canvasName}
+      isDragging={draggingIds.has(node.id) || draggingId === node.id}
+      isResizing={resizingId === node.id}
+      isSelected={selectedNodeIdSet.has(node.id)}
+      isHighlighted={highlightedId === node.id}
+      isAgentEdited={externallyEditedIds.has(node.id)}
+      focusState={!focusModeEnabled
+        ? 'neutral'
+        : focusedNodeIds?.has(node.id) ? 'focused'
+          : focusContextNodeIds?.has(node.id) ? 'context'
+            : 'dimmed'}
+      onDragStart={onDragStart}
+      onResizeStart={onResizeStart}
+      onUpdate={onUpdate}
+      onAutoResize={onAutoResize}
+      onRemove={onRemove}
+      onRemoveNodes={onRemoveNodes}
+      onExportMindmapImage={onExportMindmapImage}
+      onSelect={onSelect}
+      onFocus={onFocus}
+      onReference={onReference}
+      onAddToChat={onAddToChat}
+      onAddDomSelectionToChat={onAddDomSelectionToChat}
+      resolveReferenceNode={resolveReferenceNode}
+      onOpenReferenceSource={onOpenReferenceSource}
+      onUpdateReferenceSource={onUpdateReferenceSource}
+      onUngroupSelectedGroups={onUngroupSelectedGroups}
+      isFullscreen={fullscreenNodeId === node.id}
+      onToggleFullscreen={onToggleFullscreen}
+      renderMode={renderMode}
     />
-    {renderGroups.regular
-      .map((node) => (
-        <CanvasNodeView
-          key={node.id}
-          node={node}
-          getAllNodes={getAllNodes}
-          rootFolder={rootFolder}
-          workspaceId={canvasId}
-          workspaceName={canvasName}
-          isDragging={draggingIds.has(node.id) || draggingId === node.id}
-          isResizing={resizingId === node.id}
-          isSelected={selectedNodeIdSet.has(node.id)}
-          isHighlighted={highlightedId === node.id}
-          isAgentEdited={externallyEditedIds.has(node.id)}
-          focusState={!focusModeEnabled
-            ? 'neutral'
-            : focusedNodeIds?.has(node.id) ? 'focused'
-              : focusContextNodeIds?.has(node.id) ? 'context'
-                : 'dimmed'}
-          onDragStart={onDragStart}
-          onResizeStart={onResizeStart}
-          onUpdate={onUpdate}
-          onAutoResize={onAutoResize}
-          onRemove={onRemove}
-          onRemoveNodes={onRemoveNodes}
-          onExportMindmapImage={onExportMindmapImage}
-          onSelect={onSelect}
-          onFocus={onFocus}
-          onReference={onReference}
-          onAddToChat={onAddToChat}
-          onAddDomSelectionToChat={onAddDomSelectionToChat}
-          resolveReferenceNode={resolveReferenceNode}
-          onOpenReferenceSource={onOpenReferenceSource}
-          onUpdateReferenceSource={onUpdateReferenceSource}
-          onUngroupSelectedGroups={onUngroupSelectedGroups}
-          isFullscreen={fullscreenNodeId === node.id}
-          onToggleFullscreen={onToggleFullscreen}
+  );
+
+  return (
+    <div
+      className={`canvas-transform${moving || animating ? ' canvas-transform--moving' : ''}${transform.scale < 0.6 ? ' canvas-transform--small' : ''}`}
+      style={{
+        transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`,
+        '--canvas-scale': transform.scale,
+        transition: animating
+          ? 'transform 0.32s cubic-bezier(0.25, 0.46, 0.45, 0.94), --canvas-scale 0.32s cubic-bezier(0.25, 0.46, 0.45, 0.94)'
+          : undefined,
+      } as React.CSSProperties}
+    >
+      {/* Focus-mode backdrop: a giant translucent dark rectangle that
+          lives INSIDE the transform so it scales/pans with the canvas
+          and we never have to fight `.canvas-transform`'s stacking
+          context. Sized large enough to cover any reasonable zoom/pan
+          combination so the user never sees its edge. Without this, the
+          per-node dim opacity competes with a bright white canvas
+          background and the focused node fails to pop. */}
+      {focusModeEnabled && <div className="canvas-focus-backdrop" />}
+      {/* Fullscreen backdrop. Sits between the other (now offset-jumped)
+          nodes and the fullscreen node, dimming everything behind. Click
+          anywhere on the backdrop to exit. */}
+      {fullscreenNodeId && (
+        <div
+          className="canvas-fullscreen-backdrop"
+          onMouseDown={(e) => {
+            e.stopPropagation();
+            onExitFullscreen?.();
+          }}
         />
+      )}
+      {/* Containers render first as the canvas background/grouping layer. Edges
+          render after containers so frame fills can no longer cover connection
+          lines, while regular nodes still paint above edges. */}
+      {renderGroups.containers.map((node) => (
+        renderNode(node, node.type === 'frame' ? 'frame-body' : 'full')
       ))}
-    {shapeDraft && <ShapeDraftPreview draft={shapeDraft} scale={transform.scale} />}
-    {marqueeRect && <MarqueePreview rect={marqueeRect} scale={transform.scale} />}
-    {snapLines && snapLines.length > 0 && (
-      <CanvasAlignmentGuides lines={snapLines} scale={transform.scale} />
-    )}
-    {(dragPreview || resizePreview) && (
-      <CanvasGestureHud
-        dragPreview={dragPreview}
+      <CanvasEdgesLayer
+        edges={edges}
         nodes={nodes}
-        resizePreview={resizePreview}
-        scale={transform.scale}
+        selectedEdgeId={selectedEdgeId}
+        onSelectEdge={onSelectEdge}
+        interactionState={edgeInteractionState}
+        previewEndpoints={edgePreviewEndpoints}
+        focusedNodeIds={focusedNodeIds}
+        focusContextNodeIds={focusContextNodeIds}
+        focusModeEnabled={focusModeEnabled}
+        onHandleMouseDown={onEdgeHandleMouseDown}
+        onBodyMouseDown={onEdgeBodyMouseDown}
+        onBodyDoubleClick={onEdgeBodyDoubleClick}
+        onBodyContextMenu={onEdgeBodyContextMenu}
       />
-    )}
-  </div>
-);
+      {renderGroups.regular.map((node) => renderNode(node))}
+      {!fullscreenNodeId && renderGroups.containers
+        .filter((node) => node.type === 'frame')
+        .map((node) => renderNode(node, 'frame-title'))}
+      {shapeDraft && <ShapeDraftPreview draft={shapeDraft} scale={transform.scale} />}
+      {marqueeRect && <MarqueePreview rect={marqueeRect} scale={transform.scale} />}
+      {snapLines && snapLines.length > 0 && (
+        <CanvasAlignmentGuides lines={snapLines} scale={transform.scale} />
+      )}
+      {(dragPreview || resizePreview) && (
+        <CanvasGestureHud
+          dragPreview={dragPreview}
+          nodes={nodes}
+          resizePreview={resizePreview}
+          scale={transform.scale}
+        />
+      )}
+    </div>
+  );
+};
 
 /**
  * Dashed rectangle drawn while the user box-selects on blank canvas.

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/DefaultCanvasNode.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/DefaultCanvasNode.tsx
@@ -20,7 +20,7 @@ import { TextNodeBody } from '../TextNodeBody';
 import { useAppShell } from '../AppShellProvider';
 import { CanvasNodeHeader } from './CanvasNodeHeader';
 import { NodeResizeHandles } from './NodeResizeHandles';
-import type { ResizeHandlerFactory } from './types';
+import type { CanvasNodeRenderMode, ResizeHandlerFactory } from './types';
 
 interface DefaultCanvasNodeProps {
   classes: string;
@@ -53,6 +53,7 @@ interface DefaultCanvasNodeProps {
   onUngroupSelectedGroups?: () => void;
   onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
   readOnly: boolean;
+  renderMode?: CanvasNodeRenderMode;
   relativeTime: string | null;
   rootFolder?: string;
   titleRef: RefObject<HTMLSpanElement>;
@@ -92,6 +93,7 @@ export const DefaultCanvasNode = ({
   onUngroupSelectedGroups,
   onUpdate,
   readOnly,
+  renderMode = 'full',
   relativeTime,
   rootFolder,
   titleRef,
@@ -169,34 +171,53 @@ export const DefaultCanvasNode = ({
     })();
   }, [node.id, node.title, notify, onAddDomSelectionToChat, pluginElementPickerActive, workspaceId]);
 
+  const frameTitleOnly = node.type === 'frame' && renderMode === 'frame-title';
+  const frameBodyOnly = node.type === 'frame' && renderMode === 'frame-body';
+  const nodeClasses = [
+    classes,
+    frameTitleOnly && 'canvas-node--frame-title-overlay',
+    frameBodyOnly && 'canvas-node--frame-body-layer',
+  ].filter(Boolean).join(' ');
+  const header = (
+    <CanvasNodeHeader
+      fullscreenButton={fullscreenButton}
+      containerDescendantCount={containerDescendantCount}
+      handleClose={handleClose}
+      handleFocus={handleFocus}
+      handleHeaderMouseDown={handleHeaderMouseDown}
+      handlePluginSelectElement={handlePluginSelectElement}
+      handleReference={handleReference}
+      handleAddToChat={handleAddToChat}
+      handleTitleBlur={handleTitleBlur}
+      handleTitleDoubleClick={handleTitleDoubleClick}
+      handleTitleKeyDown={handleTitleKeyDown}
+      handleUngroup={handleUngroup}
+      isEditingTitle={isEditingTitle}
+      isFullscreen={isFullscreen}
+      isSelected={isSelected}
+      node={node}
+      pluginElementPickerActive={pluginElementPickerActive}
+      onReference={onReference}
+      onAddToChat={onAddToChat}
+      onUngroupSelectedGroups={onUngroupSelectedGroups}
+      onUpdate={onUpdate}
+      readOnly={readOnly}
+      relativeTime={relativeTime}
+      titleRef={titleRef}
+    />
+  );
+
+  if (frameTitleOnly) {
+    return (
+      <div className={nodeClasses} style={wrapperStyle} onClick={handleNodeClick}>
+        {header}
+      </div>
+    );
+  }
+
   return (
-    <div className={classes} style={wrapperStyle} onClick={handleNodeClick}>
-      <CanvasNodeHeader
-        fullscreenButton={fullscreenButton}
-        containerDescendantCount={containerDescendantCount}
-        handleClose={handleClose}
-        handleFocus={handleFocus}
-        handleHeaderMouseDown={handleHeaderMouseDown}
-        handlePluginSelectElement={handlePluginSelectElement}
-        handleReference={handleReference}
-        handleAddToChat={handleAddToChat}
-        handleTitleBlur={handleTitleBlur}
-        handleTitleDoubleClick={handleTitleDoubleClick}
-        handleTitleKeyDown={handleTitleKeyDown}
-        handleUngroup={handleUngroup}
-        isEditingTitle={isEditingTitle}
-        isFullscreen={isFullscreen}
-        isSelected={isSelected}
-        node={node}
-        pluginElementPickerActive={pluginElementPickerActive}
-        onReference={onReference}
-        onAddToChat={onAddToChat}
-        onUngroupSelectedGroups={onUngroupSelectedGroups}
-        onUpdate={onUpdate}
-        readOnly={readOnly}
-        relativeTime={relativeTime}
-        titleRef={titleRef}
-      />
+    <div className={nodeClasses} style={wrapperStyle} onClick={handleNodeClick}>
+      {!frameBodyOnly && header}
       <div className="node-body" onMouseDown={handleNodeBodyMouseDown}>
         {node.type === 'file' ? (
           <FileNodeBody node={node} onUpdate={onUpdate} workspaceId={workspaceId} readOnly={readOnly} />

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -12,6 +12,33 @@
   transition: box-shadow 0.15s ease, border-color 0.15s ease;
 }
 
+/* Skip layout / paint / hit-test for nodes that are offscreen. The wrapper
+ * already has explicit width/height inline (see CanvasNodeView/utils.ts
+ * getNodeWrapperStyle), so contain-intrinsic-size isn't required for the
+ * box to keep its size when content is skipped — Chromium falls back to
+ * the explicit width/height. The win:
+ *  - React mount stays unchanged (no churn during pan/resize, no Tiptap /
+ *    xterm / webview re-init cost — that's why we did NOT switch to
+ *    viewport-based mount/unmount).
+ *  - Browser skips paint and tile rasterization for nodes outside the
+ *    visible viewport, easing the "tile memory limits exceeded" pressure
+ *    on large canvases.
+ *
+ * Carve-outs: node types whose internal engines read DOM dimensions on
+ * init (Tiptap, xterm) or run a separate rendering pipeline (<webview>,
+ * mindmap's force-graph) are excluded — those need to be visible when
+ * they boot or they may compute a 0×0 layout and never recover. They
+ * still benefit indirectly via .canvas-transform--moving (will-change is
+ * only set during pan/zoom, see Canvas/index.css). */
+.canvas-node--frame,
+.canvas-node--group,
+.canvas-node--text,
+.canvas-node--shape,
+.canvas-node--image,
+.canvas-node--reference {
+  content-visibility: auto;
+}
+
 /* File / note nodes — Heptabase + Notion lean. The chrome is intentionally
  * quieter than the generic node: warmer paper background, softer
  * shadow, slightly larger corner radius, and a header that fades into

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -43,6 +43,7 @@ const CanvasNodeViewComponent = ({
   onToggleFullscreen,
   readOnly = false,
   embedded = false,
+  renderMode = 'full',
 }: CanvasNodeViewProps) => {
   const viewModel = useCanvasNodeViewModel({
     embedded,
@@ -206,6 +207,7 @@ const CanvasNodeViewComponent = ({
       onUngroupSelectedGroups={onUngroupSelectedGroups}
       onUpdate={onUpdate}
       readOnly={readOnly}
+      renderMode={renderMode}
       relativeTime={viewModel.relativeTime}
       rootFolder={rootFolder}
       titleRef={viewModel.titleRef}
@@ -236,5 +238,6 @@ export const CanvasNodeView = memo(CanvasNodeViewComponent, (prev, next) => (
   prev.onAddDomSelectionToChat === next.onAddDomSelectionToChat &&
   prev.onRemoveNodes === next.onRemoveNodes &&
   prev.readOnly === next.readOnly &&
-  prev.embedded === next.embedded
+  prev.embedded === next.embedded &&
+  prev.renderMode === next.renderMode
 ));

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/types.ts
@@ -2,6 +2,8 @@ import type { MouseEvent, ReactNode } from 'react';
 import type { AgentContextDomSelectionRef, CanvasNode } from '../../types';
 import type { ResizeEdge } from '../../hooks/useNodeResize';
 
+export type CanvasNodeRenderMode = 'full' | 'frame-body' | 'frame-title';
+
 export interface CanvasNodeViewProps {
   node: CanvasNode;
   getAllNodes?: () => CanvasNode[];
@@ -42,6 +44,7 @@ export interface CanvasNodeViewProps {
   onToggleFullscreen?: (nodeId: string) => void;
   readOnly?: boolean;
   embedded?: boolean;
+  renderMode?: CanvasNodeRenderMode;
 }
 
 export type ResizeHandlerFactory = (edge: ResizeEdge) => (e: MouseEvent) => void;

--- a/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.css
@@ -78,6 +78,27 @@
   box-shadow: 0 0 0 2px oklch(0.66 calc(var(--_c) * 1.10) var(--_h) / 0.30);
 }
 
+.canvas-node--frame.canvas-node--frame-title-overlay,
+.canvas-node--frame.canvas-node--frame-title-overlay:hover,
+.canvas-node--frame.canvas-node--frame-title-overlay.canvas-node--selected,
+.canvas-node--frame.canvas-node--frame-title-overlay.canvas-node--focus-mode-focused,
+.canvas-node--frame.canvas-node--frame-title-overlay.canvas-node--focus-mode-focused.canvas-node--selected {
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  content-visibility: visible;
+  pointer-events: none;
+  z-index: 120;
+}
+
+.canvas-node--frame.canvas-node--frame-title-overlay::before {
+  display: none;
+}
+
+.canvas-node--frame.canvas-node--frame-title-overlay>.node-header {
+  pointer-events: auto;
+}
+
 /* ---- Header pill ----
  * Floating chip above the frame body, inset from the top-left corner. The
  * body's 30px radius keeps the corner clear so the bottom of the pill can

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/useIframeNodeState.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/useIframeNodeState.ts
@@ -18,6 +18,7 @@ import {
   shouldSyncIframeTitle,
 } from './utils';
 import { isImeComposing } from '../../utils/ime';
+import { useWebviewBackgroundThrottle } from './useWebviewBackgroundThrottle';
 
 export const useIframeNodeState = ({
   node,
@@ -264,6 +265,18 @@ export const useIframeNodeState = ({
       if (registered) void api.unregisterWebview(workspaceId, node.id);
     };
   }, [workspaceId, node.id, editing, url, mode, webviewKey]);
+
+  // Drop the webview's paint frame rate when the node is parked outside the
+  // canvas viewport long enough. Disabled during editing (no live webview to
+  // throttle) and when the node is in non-url modes (html/ai/artifact don't
+  // use a <webview>). readOnly iframes still register a webview and should
+  // still benefit. See useWebviewBackgroundThrottle for the rationale.
+  useWebviewBackgroundThrottle({
+    hostRef: webviewHostRef,
+    workspaceId,
+    nodeId: node.id,
+    disabled: editing || mode !== 'url',
+  });
 
   const flushToIframe = useCallback(() => {
     const currentHtml = streamBuf.current;

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/useWebviewBackgroundThrottle.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/useWebviewBackgroundThrottle.ts
@@ -1,0 +1,144 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Background paint-rate throttling for canvas webview nodes.
+ *
+ * When a webview node sits outside the canvas viewport for long enough, we
+ * drop its `setFrameRate` to a low value (default 1fps). The guest process
+ * stays alive — JS, timers, network, in-page state are all preserved — so
+ * coming back to the node is instantaneous and lossless. The win is GPU
+ * paint work and Chromium tile memory: an offscreen webview that used to
+ * paint at 60fps no longer competes for tiles with what the user is
+ * actually looking at.
+ *
+ * Why not just unmount the <webview>?  Detaching the element kills the
+ * guest renderer process, which then has to re-fetch the page, lose form
+ * state, and re-establish any in-page session on remount. Throttling keeps
+ * everything alive.
+ *
+ * Why not change document.visibilityState?  Some pages (Figma, video sites,
+ * dashboards) react to visibilitychange by tearing down state we don't
+ * want torn down. Frame-rate throttling is invisible to the page.
+ *
+ * Hysteresis matters: pan-by motions briefly take a node out of the
+ * viewport, but the user might be panning toward it. We use a generous
+ * `rootMargin` so a node must be solidly outside the viewport to count as
+ * offscreen, plus a delay before we actually drop the frame rate. Coming
+ * back into the viewport always restores immediately.
+ */
+
+interface Options {
+  /** The element to observe. Typically the webview's host container. */
+  hostRef: React.RefObject<HTMLElement | null>;
+  /** Identifies the registered webview in main's registry. */
+  workspaceId: string | undefined;
+  nodeId: string;
+  /**
+   * When true the hook stays inactive — used to skip throttling while the
+   * node is in editing mode or has no live webview to control.
+   */
+  disabled?: boolean;
+  /** How far past the viewport edge a node still counts as visible. */
+  rootMargin?: string;
+  /** How long offscreen before we drop the frame rate. */
+  offscreenDelayMs?: number;
+  /** Throttled frame rate. Clamped to [1, 240] in main. */
+  throttledFrameRate?: number;
+  /** Restored frame rate when back on screen. */
+  defaultFrameRate?: number;
+}
+
+const DEFAULT_ROOT_MARGIN = '300px';
+const DEFAULT_OFFSCREEN_DELAY_MS = 30_000;
+const DEFAULT_THROTTLED_FRAME_RATE = 1;
+const DEFAULT_FRAME_RATE = 60;
+
+export const useWebviewBackgroundThrottle = ({
+  hostRef,
+  workspaceId,
+  nodeId,
+  disabled = false,
+  rootMargin = DEFAULT_ROOT_MARGIN,
+  offscreenDelayMs = DEFAULT_OFFSCREEN_DELAY_MS,
+  throttledFrameRate = DEFAULT_THROTTLED_FRAME_RATE,
+  defaultFrameRate = DEFAULT_FRAME_RATE,
+}: Options) => {
+  // Track which rate is currently applied so we don't issue redundant IPC
+  // (every pan-by would otherwise spam main with 60→60 noops).
+  const appliedRateRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (disabled || !workspaceId) return;
+    const el = hostRef.current;
+    if (!el || typeof IntersectionObserver === 'undefined') return;
+
+    const api = window.canvasWorkspace.iframe;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const apply = (rate: number) => {
+      if (appliedRateRef.current === rate) return;
+      appliedRateRef.current = rate;
+      // setFrameRate calls for unknown nodes resolve to {ok:false} — main
+      // logs and we ignore. This is normal during webview boot before
+      // registerWebview has completed.
+      void api.setFrameRate(workspaceId, nodeId, rate).catch(() => {
+        appliedRateRef.current = null; // let next state change retry
+      });
+    };
+
+    const cancelTimer = () => {
+      if (timer != null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    };
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[entries.length - 1];
+        if (!entry) return;
+        if (entry.isIntersecting) {
+          // Back in view — cancel any pending throttle and restore now.
+          cancelTimer();
+          apply(defaultFrameRate);
+        } else {
+          // Out of view — schedule throttle if not already scheduled or
+          // already throttled. We don't throttle eagerly because pan
+          // gestures briefly take many nodes offscreen.
+          if (timer != null) return;
+          if (appliedRateRef.current === throttledFrameRate) return;
+          timer = setTimeout(() => {
+            timer = null;
+            apply(throttledFrameRate);
+          }, offscreenDelayMs);
+        }
+      },
+      { rootMargin },
+    );
+
+    observer.observe(el);
+
+    return () => {
+      observer.disconnect();
+      cancelTimer();
+      // Best-effort restore on teardown so a webview that survives this
+      // hook's lifecycle (e.g. via webviewKey reload) doesn't get stuck at
+      // 1fps. unregisterWebview happens in the calling effect's cleanup
+      // and races with this; the registry returns {ok:false} when the
+      // webview is gone, which we silently swallow.
+      if (appliedRateRef.current === throttledFrameRate) {
+        void api.setFrameRate(workspaceId, nodeId, defaultFrameRate).catch(() => {});
+      }
+      appliedRateRef.current = null;
+    };
+  }, [
+    hostRef,
+    workspaceId,
+    nodeId,
+    disabled,
+    rootMargin,
+    offscreenDelayMs,
+    throttledFrameRate,
+    defaultFrameRate,
+  ]);
+};

--- a/apps/canvas-workspace/src/renderer/src/types/iframe.ts
+++ b/apps/canvas-workspace/src/renderer/src/types/iframe.ts
@@ -10,6 +10,18 @@ export interface IframeApi {
     workspaceId: string,
     nodeId: string,
   ) => Promise<{ ok: boolean }>;
+  /**
+   * Drop or restore a registered webview's max paint frame rate. Used to
+   * throttle webview nodes that have left the canvas viewport — the guest
+   * process stays alive and JS/timers/network keep running at full speed,
+   * only paint cadence drops so we save GPU work and tile memory without
+   * losing any in-page state. Frame rate is clamped to [1, 240] in main.
+   */
+  setFrameRate: (
+    workspaceId: string,
+    nodeId: string,
+    frameRate: number,
+  ) => Promise<{ ok: boolean; frameRate?: number }>;
   pickDomElement: (
     workspaceId: string,
     nodeId: string,


### PR DESCRIPTION
Two independent wins for big-canvas performance, neither requiring viewport-based mount/unmount (which would churn Tiptap / xterm / webview engines and lose in-node state).

## 1️⃣ \`content-visibility: auto\` on safe node types — \`e921ab44\`

Chromium skips layout / paint / hit-test for canvas nodes outside the visible viewport. The wrapper already has explicit \`width\`/\`height\` inline (see \`getNodeWrapperStyle\`), so \`contain-intrinsic-size\` isn't needed.

**Effect**: lower paint cost per frame on big canvases and direct relief for the \`tile memory limits exceeded, some content may not draw\` warnings on Retina displays. **Zero React mount churn** — Tiptap / xterm / webview engines aren't disturbed because we don't touch the React tree.

**Conservative carve-in**: \`frame\`, \`group\`, \`text\`, \`shape\`, \`image\`, \`reference\`. Excluded for now: \`file\` (Tiptap reads DOM size on init), \`terminal\` / \`agent\` (xterm same), \`iframe\` / \`dynamic-app\` / \`plugin\` (separate render pipeline), \`mindmap\` (force-graph layout). Once we observe these tolerate auto-skip at mount time, the carve-in can be widened.

## 2️⃣ Background frame-rate throttling for offscreen \`<webview>\` nodes — \`7b239642\`

Iframe nodes that drift out of the canvas viewport for ≥30 seconds get their \`<webview>\`'s \`setFrameRate\` dropped to 1fps. Coming back into view restores 60fps immediately.

| Property | Before | Throttled |
|---|---|---|
| Guest renderer process | alive | **alive** |
| JS execution / timers / network | running | **running** |
| In-page state (forms, scroll, JS vars) | preserved | **preserved** |
| GPU paint per second | 60 | 1 |
| Tile memory pressure | high | low |

**Why frame-rate throttling and not the alternatives**:

- **Unmounting the \`<webview>\`** kills the guest renderer process (\`<webview>\`-detached behavior — see also the existing comment in \`docs/renderer-surfaces.md\` about \`display:none\` causing the same). Page re-fetches, form state gone, scroll lost. \`setFrameRate\` keeps everything alive.
- **Faking \`document.visibilityState='hidden'\`** triggers each page's own teardown logic (Figma stops rendering, Slack drops sockets, YouTube pauses, dashboards stop polling). The user hasn't \"left\" the node — they're just looking elsewhere on the canvas. Frame-rate throttling is invisible to the page.

**Hysteresis**: \`IntersectionObserver\` with \`rootMargin: 300px\` so brief pan-bys don't count as \"offscreen\"; 30s delay before throttle fires; immediate restore on re-entry. Tracks the currently-applied rate to avoid IPC spam.

**User-visible effects** (reasoned through, not yet bench-tested):

- Static / document content: invisible.
- Live dashboards / auto-refreshing UIs: state from N seconds ago briefly visible for one frame on re-entry, then paints fresh.
- Video playback: 1fps slideshow while parked offscreen — but you can't see it because it's offscreen. Audio (Web Audio / HTML5 audio) decoupled from paint, continues normally.
- Re-entering view: no reload, no first-paint flash, no state loss.

## Plumbing for #2

- **\`src/main/webview/registry.ts\`**: new IPC \`iframe:set-frame-rate\`. Looks up the registered \`webContents\` via the existing registry and calls \`setFrameRate\`, clamped to \`[1, 240]\`. Unknown nodes / destroyed \`webContents\` resolve to \`{ok:false}\` silently — that's the expected race during boot (before \`registerWebview\` lands) and teardown.
- **\`src/preload/bridge/webview.ts\`** + **\`src/renderer/src/types/iframe.ts\`**: \`setFrameRate\` added to \`IframeApi\`.
- **\`src/renderer/src/components/IframeNodeBody/useWebviewBackgroundThrottle.ts\`** (new): the hook. IntersectionObserver + hysteresis timer + IPC dispatch.
- **\`src/renderer/src/components/IframeNodeBody/useIframeNodeState.ts\`**: plug it in. Disabled while editing or in non-url modes (no live \`<webview>\` to control).

## What this PR doesn't do

- **Doesn't viewport-cull node mounts.** That's the bigger win, but it has high cost — Tiptap loses editor state, xterm loses scrollback, webviews lose their guest process — without a real \"state externalization\" effort. \`content-visibility\` gets us most of the paint-time win at near-zero risk.
- **Doesn't handle \`<iframe>\`-based nodes** (\`dynamic-app\`, embedded artifacts). Chromium auto-throttles offscreen \`<iframe>\`s already, and we don't have an equivalent of \`webContents.setFrameRate\` for them. Tile-memory relief still kicks in via #1 once we widen the carve-in.
- **Doesn't expose any user-facing knob** — both behaviors are automatic. The hook accepts options for the threshold / margin / rates if a future setting wants to plumb them through.

## Verification

- \`pnpm --filter canvas-workspace typecheck\` ✅
- \`pnpm --filter canvas-workspace test\` — 536/537 pass; the 1 failing \`file-size-governance\` test is the same pre-existing failure on \`master\` (\`Canvas/index.tsx\`, \`ChatPanel.css\`, \`useMentions.ts\`, \`GraphPage.tsx\`, \`WorkspaceNodes/index.css\` — all files this PR doesn't touch).

## Suggested next steps after this lands

1. Profile a 200-node canvas before / after to validate the paint-cost win.
2. Widen the \`content-visibility\` carve-in once Tiptap / xterm node types are confirmed safe at mount time.
3. If memory (not paint) is still the main pain, consider a user-controlled \"release this webview\" affordance for #2 nodes — that's the discard-tier, irreversible-state-loss option, and should be opt-in not automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)