### PR TITLE
docs(canvas-workspace): rewrite CLAUDE.md/AGENTS.md as project guidance

### DIFF
--- a/apps/canvas-workspace/AGENTS.md
+++ b/apps/canvas-workspace/AGENTS.md
@@ -115,14 +115,28 @@ Canvas state (node positions, types, data) is saved per workspace as JSON via
 `src/main/canvas/`. File nodes are backed by real files on disk; the file watcher
 pushes external changes into the renderer via IPC.
 
-## Coding Guidance
+## Coding Conventions
 
-- TypeScript strict mode; follow the repo-root conventions (2 spaces, semicolons,
-  single quotes, ESM imports).
-- Keep components focused and single-responsibility — aim for **≤ 300 lines per
-  component**; split large components rather than growing them.
-- Keep main/renderer separation clean: all cross-boundary calls go through
-  `window.canvasWorkspace` + preload, with logic in `src/main/<domain>/`.
-- Keep diffs minimal and preserve existing architecture patterns.
+Detailed, reusable rules live in **[`docs/conventions/`](./docs/conventions/README.md)**.
+Read the relevant doc before writing or reviewing code:
+
+- **[`docs/conventions/README.md`](./docs/conventions/README.md)** — index + baseline rules.
+- **[`docs/conventions/architecture-boundaries.md`](./docs/conventions/architecture-boundaries.md)**
+  — process layers (`shared`/`main`/`preload`/`renderer`), import rules, and
+  file-size governance. **Enforced by tests** (`src/main/__tests__/import-boundaries.test.ts`,
+  `file-size-governance.test.ts`).
+- **[`docs/conventions/frontend.md`](./docs/conventions/frontend.md)** — renderer
+  (React) component/hook/styling/i18n/IPC-consumption conventions.
+- **[`docs/conventions/backend.md`](./docs/conventions/backend.md)** — main
+  process domain modules, IPC, services, and persistence conventions.
+
+Quick reminders (see the docs for the full rules):
+
+- TypeScript strict mode; match local file style (2 spaces, semicolons, ESM
+  imports). Keep diffs minimal and preserve existing patterns.
+- Aim **≤ 300 lines per component/module**; new files must stay **≤ 500**
+  (hard-gated). Split by responsibility rather than growing a file.
+- Renderer reaches the main process **only** through `window.canvasWorkspace`
+  (preload bridge); domain logic lives in `src/main/<domain>/`.
 - Cross-package imports use workspace package names (`pulse-coder-engine`,
   `pulse-coder-agent-teams`).

--- a/apps/canvas-workspace/AGENTS.md
+++ b/apps/canvas-workspace/AGENTS.md
@@ -1,11 +1,128 @@
-<!-- canvas-workspace:ws-1779593150588 -->
-## Pulse Canvas (Pulse Canvas (ws-1779593150588))
+# CLAUDE.md
 
-Canvas agent config: `/Users/jasperhu/.pulse-coder/canvas/ws-1779593150588/AGENTS.md`
+This file provides guidance to Claude Code (claude.ai/code) when working in
+`apps/canvas-workspace`. It complements the repo-root `CLAUDE.md`.
 
-> 读取上方文件获取画布结构、笔记列表和 Agent 指令。
+## Overview
 
-**Workspace Isolation:** Environment variable `PULSE_CANVAS_WORKSPACE_ID=ws-1779593150588` is injected into this terminal.
-Always use this workspace ID when calling canvas MCP tools to avoid cross-canvas reads/writes.
+**Pulse Canvas** (`canvas-workspace`) is an Electron desktop app that provides a
+free-form, infinite canvas workspace for AI-assisted coding. Users arrange
+**nodes** on a canvas and interact with an embedded AI agent powered by
+`pulse-coder-engine`.
 
-<!-- /canvas-workspace:ws-1779593150588 -->
+## Tech Stack
+
+- **Electron** (v30) + **electron-vite** — desktop shell and build pipeline
+- **React** (v18) + **wouter** — renderer UI and routing
+- **Tiptap** (v3) — rich-text editor for file nodes
+- **xterm.js** + **node-pty** — terminal emulation in terminal/agent nodes
+- **pulse-coder-engine** + **pulse-coder-agent-teams** (`workspace:*`) — power the
+  in-app AI agent and multi-agent flows
+- **zod**, **markdown-it**, **mermaid**, **react-force-graph-2d** — schema,
+  markdown, diagrams, and graph rendering
+
+## Node Types
+
+| Type | Description |
+|------|-------------|
+| `file` | Tiptap-based rich-text/markdown editor backed by a real file path |
+| `terminal` | Full PTY terminal session |
+| `agent` | Runs an external AI agent CLI (e.g. `claude`) in a PTY; accepts inline prompts or prompt files |
+| `frame` | Visual grouping rectangle with a label/color |
+
+## Views & Shortcuts
+
+- **Canvas view** (`/`) — free-form canvas with sidebar, node editing, optional right-side chat panel.
+- **Chat view** (`/chat`) — full-screen AI chat page backed by `pulse-coder-engine`.
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd/Ctrl+Shift+A` | Toggle right-side chat panel (canvas view only) |
+| `Cmd/Ctrl+Shift+L` | Toggle full-screen chat view |
+| `Esc` | Return to canvas from chat view |
+
+## Project Structure
+
+```
+src/
+  main/             # Electron main process (domain-based modules)
+    app/            # Electron bootstrap, window, protocol, logging, link policy
+    agent/          # CanvasAgent + CanvasAgentService (engine-backed AI chat)
+    agent-teams/    # Multi-agent teams integration (pulse-coder-agent-teams)
+    artifacts/      # Artifact persistence and artifact IPC
+    canvas/         # Canvas persistence, storage migration, nodes, tags, broadcast
+    files/          # File read/write/dialog IPC and filesystem watcher
+    generation/     # HTML generation and streaming IPC
+    runtime/        # Runtime control server and MCP helpers
+    settings/       # App/model settings persistence and IPC
+    terminal/       # node-pty session management
+    webview/        # Webview registry, CDP helpers, page reader
+    index.ts        # Main entry
+  preload/          # Context bridge (exposes window.canvasWorkspace API)
+  renderer/src/
+    components/     # Canvas, Sidebar, AgentNodeBody, FileNodeBody, chat/, …
+    hooks/          # useWorkspaces, canvas interaction hooks
+    editor/         # Tiptap editor setup
+    config/ constants/ i18n/ utils/
+    types.ts        # Shared types (CanvasNode, CanvasWorkspaceApi, …)
+```
+
+The renderer communicates with the main process **exclusively** through
+`window.canvasWorkspace` (typed in `types.ts`), bridged via `src/preload/`.
+Never reach into Electron/Node APIs directly from the renderer — add an IPC
+channel in the relevant `src/main/<domain>/` module and expose it through preload.
+
+See `docs/main-domain-modules.md` for the `src/main` module layout and migration
+plan, and `docs/renderer-surfaces.md` for renderer surface breakdown.
+
+## Dev & Build Commands
+
+```bash
+pnpm install                              # also runs electron-rebuild for node-pty
+pnpm --filter canvas-workspace dev        # development (hot reload)
+pnpm --filter canvas-workspace build      # production build
+pnpm --filter canvas-workspace typecheck  # tsc --noEmit (renderer + main)
+pnpm --filter canvas-workspace test       # vitest run
+
+# Packaging (output → release/, appId com.pulse-coder.canvas-workspace)
+pnpm --filter canvas-workspace package          # current platform
+pnpm --filter canvas-workspace package:mac      # macOS dmg (arm64 + x64)
+pnpm --filter canvas-workspace package:win      # Windows nsis x64
+pnpm --filter canvas-workspace package:linux    # Linux AppImage + deb x64
+```
+
+`typecheck` runs two tsconfigs (`tsconfig.json` for renderer, `tsconfig.node.json`
+for main). `dev:temp-home` runs against a throwaway `$HOME` sandbox.
+
+## Canvas Agent & Model Config
+
+The AI chat feature is powered by `CanvasAgentService` (`src/main/agent/`), which
+wraps `pulse-coder-engine`. Each workspace keeps its own agent session, persisted
+under the workspace data directory, and receives a workspace/node summary as
+context on every turn.
+
+Model settings are read from `~/.pulse-coder/canvas/model-config.json` by default
+(override with `PULSE_CANVAS_MODEL_CONFIG`). The config supports OpenAI-compatible
+and Anthropic-compatible providers and stores only **env var names** for API keys,
+never secret values. The renderer manages the same config through
+`window.canvasWorkspace.model` (`status`, `saveConfig`, `upsertOption`,
+`setCurrent`, `removeOption`, `reset`); changes apply to new agent turns and HTML
+generation without restarting the app.
+
+## Data Persistence
+
+Canvas state (node positions, types, data) is saved per workspace as JSON via
+`src/main/canvas/`. File nodes are backed by real files on disk; the file watcher
+pushes external changes into the renderer via IPC.
+
+## Coding Guidance
+
+- TypeScript strict mode; follow the repo-root conventions (2 spaces, semicolons,
+  single quotes, ESM imports).
+- Keep components focused and single-responsibility — aim for **≤ 300 lines per
+  component**; split large components rather than growing them.
+- Keep main/renderer separation clean: all cross-boundary calls go through
+  `window.canvasWorkspace` + preload, with logic in `src/main/<domain>/`.
+- Keep diffs minimal and preserve existing architecture patterns.
+- Cross-package imports use workspace package names (`pulse-coder-engine`,
+  `pulse-coder-agent-teams`).

--- a/apps/canvas-workspace/CLAUDE.md
+++ b/apps/canvas-workspace/CLAUDE.md
@@ -115,14 +115,28 @@ Canvas state (node positions, types, data) is saved per workspace as JSON via
 `src/main/canvas/`. File nodes are backed by real files on disk; the file watcher
 pushes external changes into the renderer via IPC.
 
-## Coding Guidance
+## Coding Conventions
 
-- TypeScript strict mode; follow the repo-root conventions (2 spaces, semicolons,
-  single quotes, ESM imports).
-- Keep components focused and single-responsibility — aim for **≤ 300 lines per
-  component**; split large components rather than growing them.
-- Keep main/renderer separation clean: all cross-boundary calls go through
-  `window.canvasWorkspace` + preload, with logic in `src/main/<domain>/`.
-- Keep diffs minimal and preserve existing architecture patterns.
+Detailed, reusable rules live in **[`docs/conventions/`](./docs/conventions/README.md)**.
+Read the relevant doc before writing or reviewing code:
+
+- **[`docs/conventions/README.md`](./docs/conventions/README.md)** — index + baseline rules.
+- **[`docs/conventions/architecture-boundaries.md`](./docs/conventions/architecture-boundaries.md)**
+  — process layers (`shared`/`main`/`preload`/`renderer`), import rules, and
+  file-size governance. **Enforced by tests** (`src/main/__tests__/import-boundaries.test.ts`,
+  `file-size-governance.test.ts`).
+- **[`docs/conventions/frontend.md`](./docs/conventions/frontend.md)** — renderer
+  (React) component/hook/styling/i18n/IPC-consumption conventions.
+- **[`docs/conventions/backend.md`](./docs/conventions/backend.md)** — main
+  process domain modules, IPC, services, and persistence conventions.
+
+Quick reminders (see the docs for the full rules):
+
+- TypeScript strict mode; match local file style (2 spaces, semicolons, ESM
+  imports). Keep diffs minimal and preserve existing patterns.
+- Aim **≤ 300 lines per component/module**; new files must stay **≤ 500**
+  (hard-gated). Split by responsibility rather than growing a file.
+- Renderer reaches the main process **only** through `window.canvasWorkspace`
+  (preload bridge); domain logic lives in `src/main/<domain>/`.
 - Cross-package imports use workspace package names (`pulse-coder-engine`,
   `pulse-coder-agent-teams`).

--- a/apps/canvas-workspace/CLAUDE.md
+++ b/apps/canvas-workspace/CLAUDE.md
@@ -1,11 +1,128 @@
-<!-- canvas-workspace:ws-1779593150588 -->
-## Pulse Canvas (Pulse Canvas (ws-1779593150588))
+# CLAUDE.md
 
-Canvas agent config: `/Users/jasperhu/.pulse-coder/canvas/ws-1779593150588/AGENTS.md`
+This file provides guidance to Claude Code (claude.ai/code) when working in
+`apps/canvas-workspace`. It complements the repo-root `CLAUDE.md`.
 
-> 读取上方文件获取画布结构、笔记列表和 Agent 指令。
+## Overview
 
-**Workspace Isolation:** Environment variable `PULSE_CANVAS_WORKSPACE_ID=ws-1779593150588` is injected into this terminal.
-Always use this workspace ID when calling canvas MCP tools to avoid cross-canvas reads/writes.
+**Pulse Canvas** (`canvas-workspace`) is an Electron desktop app that provides a
+free-form, infinite canvas workspace for AI-assisted coding. Users arrange
+**nodes** on a canvas and interact with an embedded AI agent powered by
+`pulse-coder-engine`.
 
-<!-- /canvas-workspace:ws-1779593150588 -->
+## Tech Stack
+
+- **Electron** (v30) + **electron-vite** — desktop shell and build pipeline
+- **React** (v18) + **wouter** — renderer UI and routing
+- **Tiptap** (v3) — rich-text editor for file nodes
+- **xterm.js** + **node-pty** — terminal emulation in terminal/agent nodes
+- **pulse-coder-engine** + **pulse-coder-agent-teams** (`workspace:*`) — power the
+  in-app AI agent and multi-agent flows
+- **zod**, **markdown-it**, **mermaid**, **react-force-graph-2d** — schema,
+  markdown, diagrams, and graph rendering
+
+## Node Types
+
+| Type | Description |
+|------|-------------|
+| `file` | Tiptap-based rich-text/markdown editor backed by a real file path |
+| `terminal` | Full PTY terminal session |
+| `agent` | Runs an external AI agent CLI (e.g. `claude`) in a PTY; accepts inline prompts or prompt files |
+| `frame` | Visual grouping rectangle with a label/color |
+
+## Views & Shortcuts
+
+- **Canvas view** (`/`) — free-form canvas with sidebar, node editing, optional right-side chat panel.
+- **Chat view** (`/chat`) — full-screen AI chat page backed by `pulse-coder-engine`.
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd/Ctrl+Shift+A` | Toggle right-side chat panel (canvas view only) |
+| `Cmd/Ctrl+Shift+L` | Toggle full-screen chat view |
+| `Esc` | Return to canvas from chat view |
+
+## Project Structure
+
+```
+src/
+  main/             # Electron main process (domain-based modules)
+    app/            # Electron bootstrap, window, protocol, logging, link policy
+    agent/          # CanvasAgent + CanvasAgentService (engine-backed AI chat)
+    agent-teams/    # Multi-agent teams integration (pulse-coder-agent-teams)
+    artifacts/      # Artifact persistence and artifact IPC
+    canvas/         # Canvas persistence, storage migration, nodes, tags, broadcast
+    files/          # File read/write/dialog IPC and filesystem watcher
+    generation/     # HTML generation and streaming IPC
+    runtime/        # Runtime control server and MCP helpers
+    settings/       # App/model settings persistence and IPC
+    terminal/       # node-pty session management
+    webview/        # Webview registry, CDP helpers, page reader
+    index.ts        # Main entry
+  preload/          # Context bridge (exposes window.canvasWorkspace API)
+  renderer/src/
+    components/     # Canvas, Sidebar, AgentNodeBody, FileNodeBody, chat/, …
+    hooks/          # useWorkspaces, canvas interaction hooks
+    editor/         # Tiptap editor setup
+    config/ constants/ i18n/ utils/
+    types.ts        # Shared types (CanvasNode, CanvasWorkspaceApi, …)
+```
+
+The renderer communicates with the main process **exclusively** through
+`window.canvasWorkspace` (typed in `types.ts`), bridged via `src/preload/`.
+Never reach into Electron/Node APIs directly from the renderer — add an IPC
+channel in the relevant `src/main/<domain>/` module and expose it through preload.
+
+See `docs/main-domain-modules.md` for the `src/main` module layout and migration
+plan, and `docs/renderer-surfaces.md` for renderer surface breakdown.
+
+## Dev & Build Commands
+
+```bash
+pnpm install                              # also runs electron-rebuild for node-pty
+pnpm --filter canvas-workspace dev        # development (hot reload)
+pnpm --filter canvas-workspace build      # production build
+pnpm --filter canvas-workspace typecheck  # tsc --noEmit (renderer + main)
+pnpm --filter canvas-workspace test       # vitest run
+
+# Packaging (output → release/, appId com.pulse-coder.canvas-workspace)
+pnpm --filter canvas-workspace package          # current platform
+pnpm --filter canvas-workspace package:mac      # macOS dmg (arm64 + x64)
+pnpm --filter canvas-workspace package:win      # Windows nsis x64
+pnpm --filter canvas-workspace package:linux    # Linux AppImage + deb x64
+```
+
+`typecheck` runs two tsconfigs (`tsconfig.json` for renderer, `tsconfig.node.json`
+for main). `dev:temp-home` runs against a throwaway `$HOME` sandbox.
+
+## Canvas Agent & Model Config
+
+The AI chat feature is powered by `CanvasAgentService` (`src/main/agent/`), which
+wraps `pulse-coder-engine`. Each workspace keeps its own agent session, persisted
+under the workspace data directory, and receives a workspace/node summary as
+context on every turn.
+
+Model settings are read from `~/.pulse-coder/canvas/model-config.json` by default
+(override with `PULSE_CANVAS_MODEL_CONFIG`). The config supports OpenAI-compatible
+and Anthropic-compatible providers and stores only **env var names** for API keys,
+never secret values. The renderer manages the same config through
+`window.canvasWorkspace.model` (`status`, `saveConfig`, `upsertOption`,
+`setCurrent`, `removeOption`, `reset`); changes apply to new agent turns and HTML
+generation without restarting the app.
+
+## Data Persistence
+
+Canvas state (node positions, types, data) is saved per workspace as JSON via
+`src/main/canvas/`. File nodes are backed by real files on disk; the file watcher
+pushes external changes into the renderer via IPC.
+
+## Coding Guidance
+
+- TypeScript strict mode; follow the repo-root conventions (2 spaces, semicolons,
+  single quotes, ESM imports).
+- Keep components focused and single-responsibility — aim for **≤ 300 lines per
+  component**; split large components rather than growing them.
+- Keep main/renderer separation clean: all cross-boundary calls go through
+  `window.canvasWorkspace` + preload, with logic in `src/main/<domain>/`.
+- Keep diffs minimal and preserve existing architecture patterns.
+- Cross-package imports use workspace package names (`pulse-coder-engine`,
+  `pulse-coder-agent-teams`).

--- a/apps/canvas-workspace/docs/conventions/README.md
+++ b/apps/canvas-workspace/docs/conventions/README.md
@@ -1,0 +1,37 @@
+# Canvas Workspace — Coding Conventions
+
+Reusable, enforced conventions for the `canvas-workspace` app. These are the
+rules `CLAUDE.md` / `AGENTS.md` point at; read the relevant file before writing
+or reviewing code in this app.
+
+| Doc | Scope |
+|-----|-------|
+| [`architecture-boundaries.md`](./architecture-boundaries.md) | Process layers (`shared` / `main` / `preload` / `renderer`), import rules, file-size governance — **enforced by tests** |
+| [`frontend.md`](./frontend.md) | Renderer (React) component, hook, styling, i18n, and IPC-consumption conventions |
+| [`backend.md`](./backend.md) | Main process (Electron) domain modules, IPC, services, persistence conventions |
+
+## Why these exist
+
+Two vitest suites in `src/main/__tests__/` turn the most important rules into CI
+gates, so they are not optional style preferences:
+
+- `import-boundaries.test.ts` — enforces the layer import rules in
+  [`architecture-boundaries.md`](./architecture-boundaries.md).
+- `file-size-governance.test.ts` — blocks new/growing files over 500 lines.
+
+When in doubt, run `pnpm --filter canvas-workspace test` — a boundary or
+file-size violation fails the build with a message pointing at the offending
+line.
+
+## Baseline rules (apply everywhere)
+
+- **TypeScript strict** mode is on. No `any` escape hatches without cause.
+- **Match the file you are editing** for quote style, import order, and spacing.
+  Observed defaults: renderer/preload tend to use double quotes; main and test
+  files use single quotes. 2-space indent, semicolons, ESM imports throughout.
+- **Keep diffs minimal** and preserve existing architecture patterns; extend
+  plugin/hook/IPC boundaries rather than hardcoding behavior.
+- **Tests live in `__tests__/`** (or `*.test.ts`) and run on **vitest**.
+- **Cross-package imports** use workspace package names
+  (`pulse-coder-engine`, `pulse-coder-agent-teams`), not relative paths into
+  `../../packages/*`.

--- a/apps/canvas-workspace/docs/conventions/architecture-boundaries.md
+++ b/apps/canvas-workspace/docs/conventions/architecture-boundaries.md
@@ -1,0 +1,66 @@
+# Architecture & Boundary Rules
+
+These rules are **enforced by tests** (`src/main/__tests__/import-boundaries.test.ts`
+and `file-size-governance.test.ts`). Violating them fails `pnpm --filter
+canvas-workspace test`.
+
+## Process layers (surfaces)
+
+The app is split into four source surfaces with a strict dependency direction:
+
+| Surface | Path(s) | Role |
+|---------|---------|------|
+| `shared` | `src/shared/**`, `src/plugins/types.ts` | Runtime-neutral, JSON-safe contracts/types shared across processes |
+| `main` | `src/main/**`, `src/plugins/main/**` | Privileged Electron main process: Node/Electron APIs, IPC handlers, services |
+| `preload` | `src/preload/**` | Context-bridge only — maps IPC channels to the typed `window.canvasWorkspace` API |
+| `renderer` | `src/renderer/src/**`, `src/plugins/renderer/**` | Browser/React UI; no privileged access |
+
+### Allowed import directions
+
+- **`shared`** must stay runtime-neutral: **no** imports of `main`, `preload`,
+  `renderer`, plugin code, Electron, or Node builtins. Put common contracts here
+  and invert dependencies toward it.
+- **`renderer`** must **not** import `main`, `preload`, Electron, or Node
+  builtins. Reach privileged capabilities only through the typed
+  `window.canvasWorkspace` API (see [`frontend.md`](./frontend.md)).
+- **`main`** must **not** import `renderer` or `preload` implementation. Share
+  cross-process types through `src/shared/*`.
+- **`preload`** is a bridge: **no** importing `renderer`/`main` implementation.
+  Cross-process API contracts belong in `src/shared/*`; policy stays in `main`.
+
+> Known debt: cross-process API contracts (`CanvasWorkspaceApi` and friends)
+> still live in `src/renderer/src/types.ts`, so preload bridges currently import
+> them via an explicit allowlist in `import-boundaries.test.ts`. The migration
+> goal is to move those contracts into `src/shared/*` and delete the allowlist
+> entries. **Do not add new preload→renderer imports** — extend the shared
+> contracts instead.
+
+## File-size governance
+
+`file-size-governance.test.ts` measures every production `.ts`/`.tsx`/`.css`
+file (excludes tests, `.d.ts`, generated, and documented data files):
+
+- **> 400 lines** — recorded as a warning (informational only).
+- **> 500 lines** — **hard fail** unless the file is in the `CURRENT_OVER_500_BASELINE`
+  map, and baseline files **must not grow** beyond their recorded size.
+
+Practical rules:
+
+- **New files must be ≤ 500 lines.** Aim much lower.
+- **Target ≤ 300 lines per component/module** — split by responsibility rather
+  than growing a file. The split playbook used in this app: a container keeps
+  state + composition; sub-components, `utils/`, `types.ts`, and a
+  `useXxxController.ts` hook carry the rest (see [`frontend.md`](./frontend.md)).
+- When you touch a baseline file, prefer to **shrink** it; never push it larger.
+
+## Refactor discipline
+
+When restructuring (from `docs/main-domain-modules.md`):
+
+- Prefer **domain folders** over technical buckets (`services/`, `utils/`,
+  global `ipc/`). Only create a shared folder when a file is genuinely shared
+  across domains.
+- **Preserve IPC channel names and the preload API shape** during structural
+  moves — move files first, split large files after imports and tests are green.
+- Keep Electron app-lifecycle code (`src/main/app/`) separate from product
+  capability domains.

--- a/apps/canvas-workspace/docs/conventions/backend.md
+++ b/apps/canvas-workspace/docs/conventions/backend.md
@@ -1,0 +1,83 @@
+# Backend (Main Process) Conventions
+
+Applies to `src/main/**` (and `src/plugins/main/**`). This is the privileged
+Electron main process. See [`architecture-boundaries.md`](./architecture-boundaries.md)
+for import rules and `docs/main-domain-modules.md` for the full module map.
+
+## Domain modules
+
+`src/main` is organized by **product domain**, not by technical layer:
+
+```
+src/main/
+  index.ts            # main entry / bootstrap wiring
+  app/                # Electron lifecycle: window, protocol, link-policy, logging, menu, updates
+  agent/              # Canvas Agent (engine-backed chat): service, ipc, sessions, context, model
+  agent-teams/        # Multi-agent teams integration (pulse-coder-agent-teams)
+  artifacts/          # Artifact persistence + IPC
+  canvas/             # Canvas persistence: store, storage, migration, broadcast, welcome workspace
+  files/              # File read/write/dialog IPC + filesystem watcher
+  generation/         # HTML generation + streaming IPC
+  runtime/            # Runtime control server, MCP helpers
+  settings/           # App/model/plugin settings persistence + IPC
+  terminal/           # node-pty session management
+  webview/            # Embedded webview registry, CDP helpers, page reader
+```
+
+Rules:
+
+- **Prefer domain folders** over `services/`, `utils/`, or a global `ipc/`
+  bucket. Create a shared folder only when a file is genuinely cross-domain.
+- **Keep IPC handlers inside the domain they expose** (`<domain>/ipc.ts`).
+- **Keep app-lifecycle code (`app/`) separate** from product capability domains.
+
+## Typical files per domain
+
+| File | Responsibility |
+|------|----------------|
+| `service.ts` | Core logic, usually a class (e.g. `CanvasAgentService`) |
+| `ipc.ts` | `ipcMain.handle`/`on` registrations for the domain's channels |
+| `store.ts` / `storage.ts` | In-memory state and on-disk persistence |
+| `types.ts` | Domain-internal types (cross-process contracts go in `src/shared/*`) |
+
+## IPC conventions
+
+- **Channel names are namespaced `domain:action`**, kebab inside segments —
+  e.g. `canvas-agent:chat`, `canvas-agent:abort`, `canvas-agent:status`.
+- **Streaming** uses a fast `invoke` that returns `{ ok, sessionId }`, then
+  pushes events on **per-session channels suffixed with the id**:
+  `canvas-agent:text-delta:{sessionId}`, `:tool-call:{sessionId}`,
+  `:chat-complete:{sessionId}`, `:clarify-request:{sessionId}`, etc.
+- **Document the channel surface** in a header comment at the top of `ipc.ts`
+  (see `src/main/agent/ipc.ts` for the canonical example).
+- **Channel names and payload shapes are a public contract** with preload +
+  renderer. Preserve them across refactors; when you change one, update the
+  matching `src/preload/bridge/<domain>.ts` and renderer types in lockstep.
+
+## Services & lifecycle
+
+- Expose domain services via a **lazy singleton accessor**
+  (`let service: Foo | null; export function getFoo() { ... }`), not a
+  module-level instance constructed at import time.
+- Persist per-workspace/session state under the user data dir (e.g.
+  `~/.pulse-coder/canvas/**`); never write into the repo tree at runtime.
+- Route aborts/clarifications back to the correct instance via explicit maps
+  (e.g. `sessionScopeMap`) rather than global mutable state.
+
+## Preload bridge
+
+`src/preload/bridge/<domain>.ts` is the **only** place IPC channels are mapped to
+the renderer-facing API. Bridge modules:
+
+- are thin: `ipcRenderer.invoke(channel, payload)` for calls, and a `subscribe`
+  helper for events that returns an unsubscribe function;
+- must **not** import `main` or `renderer` implementation (only shared/contract
+  types — currently `renderer/src/types` via the documented allowlist, pending
+  migration to `src/shared/*`).
+
+## Tests
+
+- Domain tests live in `src/main/__tests__/` on **vitest**
+  (`pnpm --filter canvas-workspace test`).
+- The boundary and file-size governance suites also live here and gate CI — keep
+  them green.

--- a/apps/canvas-workspace/docs/conventions/frontend.md
+++ b/apps/canvas-workspace/docs/conventions/frontend.md
@@ -1,0 +1,80 @@
+# Frontend (Renderer) Conventions
+
+Applies to `src/renderer/src/**`. The renderer is a React 18 + wouter app. It has
+**no privileged access** — see [`architecture-boundaries.md`](./architecture-boundaries.md).
+
+## Component layout
+
+Each non-trivial component lives in its own folder under
+`src/renderer/src/components/<ComponentName>/`:
+
+```
+<ComponentName>/
+  index.tsx                 # the component (container/composition)
+  index.css                 # colocated styles, imported via `import './index.css'`
+  types.ts                  # local prop/data types (optional)
+  useXxxController.ts       # heavy state/effect logic extracted to a hook (optional)
+  SubComponent.tsx          # focused child components, one export each
+  utils/                    # pure helpers (optional)
+  __tests__/                # vitest specs (optional)
+```
+
+Example (real): `Sidebar/` is split into `SidebarHeader.tsx`, `WorkspaceList.tsx`,
+`WorkspaceItem.tsx`, `FolderItem.tsx`, `LayersPanel.tsx`, `utils/`, with
+`index.tsx` only wiring state to children. `AgentNodeBody/` extracts logic into
+`useAgentNodeController.ts` and renders `AgentPicker` / `AgentTerminal`.
+
+## Component style
+
+- Export **named arrow-function components**:
+  `export const FrameNodeBody = ({ ... }: Props) => { ... }`. Avoid `default`
+  exports for components.
+- Name the props interface **`Props`** (local) and destructure props in the
+  signature.
+- Import the colocated stylesheet at the top: `import "./index.css";`.
+- Keep components **≤ 300 lines**; lift state machines and side effects into a
+  `useXxxController` hook or split out sub-components (see file-size governance).
+
+## Hooks
+
+- Shared hooks live in `src/renderer/src/hooks/` named `useXxx.ts`
+  (`useCanvas`, `useNodes`, `useClickOutside`, `useEscapeClose`, …).
+- Component-scoped hooks may live beside the component
+  (`useAgentNodeController.ts`, `Canvas/hooks/`, `chat/hooks/`).
+- Hooks return typed values; keep them framework-pure (no Electron/Node imports).
+
+## Talking to the main process
+
+The renderer **never** imports `main`/`preload`/Electron/Node. All privileged
+work goes through the typed bridge `window.canvasWorkspace` (typed by
+`src/renderer/src/types.ts`, which re-exports the per-domain interfaces under
+`src/renderer/src/types/*`).
+
+- Call request/response methods via `window.canvasWorkspace.<group>.<method>()`
+  (e.g. `window.canvasWorkspace.model.setCurrent(...)`).
+- Subscribe to streaming events via the `onXxx(callback)` methods exposed by the
+  bridge; they return an unsubscribe function — call it on cleanup.
+- If you need a new capability, add the IPC handler in `src/main/<domain>/ipc.ts`,
+  the bridge mapping in `src/preload/bridge/<domain>.ts`, and the type in the
+  matching `src/renderer/src/types/*` group. Keep the three in sync.
+
+## Styling
+
+- CSS is **colocated** per component as `index.css` (plus focused extras like
+  `interaction-polish.css`) and imported from the component file.
+- Follow the existing design-token usage (oklch palette, frame styles) seen in
+  `design/` and existing component CSS rather than hardcoding ad-hoc colors.
+
+## Copy & i18n
+
+- **No hardcoded user-facing strings.** Use `useI18n()` from
+  `src/renderer/src/i18n`; add keys to the message catalog
+  (`i18n/messages.ts`) rather than inlining English/Chinese text.
+
+## Types
+
+- Shared renderer types are re-exported from `src/renderer/src/types.ts`; add new
+  cross-cutting types under `src/renderer/src/types/<group>.ts`.
+- Canvas data shapes (`CanvasNode`, `FrameNodeData`, node-type data) are the
+  contract between renderer and main — keep them JSON-safe and, where they cross
+  the process boundary, prefer defining them in `src/shared/*`.


### PR DESCRIPTION
Replace the auto-generated, machine-specific workspace-isolation stubs with
real guidance for the canvas-workspace app: tech stack, node types, views,
src/main domain layout, dev/build commands, canvas agent + model config,
persistence, and coding conventions.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XYtM3d195L9ofzu25pnK61