### PR TITLE
feat(canvas): support @ canvas-node mentions in textarea agent inputs

### DIFF
--- a/apps/canvas-workspace/src/main/__tests__/file-size-governance.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/file-size-governance.test.ts
@@ -8,10 +8,10 @@ const SOURCE_ROOT = 'src';
 const GOVERNED_EXTENSIONS = new Set(['.ts', '.tsx', '.css']);
 
 const CURRENT_OVER_500_BASELINE: Record<string, number> = {
-  'src/renderer/src/components/AgentTeamFrame/index.css': 2950,
+  'src/renderer/src/components/AgentTeamFrame/index.css': 2951,
   'src/renderer/src/components/chat/ChatPanel.css': 2945,
   'src/main/agent-teams/service.ts': 2569,
-  'src/renderer/src/components/AgentTeamFrame/index.tsx': 2229,
+  'src/renderer/src/components/AgentTeamFrame/index.tsx': 2243,
   'src/renderer/src/types.ts': 1861,
   'src/main/canvas/store.ts': 1606,
   'src/renderer/src/components/AgentNodeBody/index.css': 1393,

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentPicker.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentPicker.tsx
@@ -1,9 +1,12 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { AGENT_REGISTRY, type AgentDef } from '../../config/agentRegistry';
 import { AgentIcon } from './AgentIcon';
 import { truncatePath } from './utils/terminal';
 import { isImeComposing } from '../../utils/ime';
 import { useI18n } from '../../i18n';
+import { NodeMentionPicker } from '../NodeMentionPicker';
+import { useTextareaMention } from '../../hooks/useTextareaMention';
+import type { CanvasNode } from '../../types';
 
 interface AgentPickerProps {
   selectedAgent: string;
@@ -15,6 +18,8 @@ interface AgentPickerProps {
   variant?: 'default' | 'team-lead';
   launchErrorCommand?: string | null;
   teamLeadBriefSlot?: ReactNode;
+  /** Canvas nodes offered by the "@" mention picker in the prompt input. */
+  mentionNodes?: CanvasNode[];
   /** Optional Back button used when entering Setup from the Restart view. */
   onBack?: () => void;
   onAgentChange: (id: string) => void;
@@ -92,6 +97,7 @@ export const AgentPicker = ({
   variant = 'default',
   launchErrorCommand,
   teamLeadBriefSlot,
+  mentionNodes,
   onBack,
   onAgentChange,
   onCwdChange,
@@ -101,6 +107,12 @@ export const AgentPicker = ({
   onLaunch,
 }: AgentPickerProps) => {
   const { t } = useI18n();
+  const promptRef = useRef<HTMLTextAreaElement>(null);
+  const promptMention = useTextareaMention({
+    textareaRef: promptRef,
+    value: promptInput,
+    onChange: onPromptChange,
+  });
   const [commandStatusByAgent, setCommandStatusByAgent] = useState<Record<string, CommandStatus>>(() => {
     return Object.fromEntries(AGENT_REGISTRY.map((agent) => [agent.id, 'checking']));
   });
@@ -177,6 +189,13 @@ export const AgentPicker = ({
 
   return (
     <div className="agent-body-wrap agent-body-wrap--setup">
+      {!isTeamLead && promptMention.pickerOpen && (
+        <NodeMentionPicker
+          nodes={mentionNodes ?? []}
+          onSelect={promptMention.handleSelect}
+          onClose={promptMention.handleClose}
+        />
+      )}
       <div className="agent-card">
         {onBack && (
           <div className="agent-card-back">
@@ -365,10 +384,12 @@ export const AgentPicker = ({
                   <span>Initial Prompt</span>
                 </div>
                 <textarea
+                  ref={promptRef}
                   className="agent-prompt-input"
                   value={promptInput}
                   onChange={(e) => onPromptChange(e.target.value)}
                   onKeyDown={(e) => {
+                    if (promptMention.handleKeyDown(e)) return;
                     if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
                       e.preventDefault();
                       onLaunch();

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -190,6 +190,7 @@ export const AgentNodeBody = ({
         launchErrorCommand={controller.launchErrorCommand}
         variant={isTeamLead ? 'team-lead' : 'default'}
         teamLeadBriefSlot={isTeamLead ? teamLeadBriefSlot : undefined}
+        mentionNodes={controller.visibleNodes}
         onBack={controller.fromRestart ? controller.handleBackToRestart : undefined}
         onAgentChange={controller.setSelectedAgent}
         onCwdChange={controller.setCwdInput}

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/useAgentNodeController.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/useAgentNodeController.ts
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
-import type { AgentNodeData, CanvasNode, FileNodeData } from '../../types';
+import type { AgentNodeData, CanvasNode } from '../../types';
 import { getAgentCommand } from '../../config/agentRegistry';
 import { TERMINAL_OPTIONS } from '../../config/terminalTheme';
+import { buildNodeMention } from '../../utils/nodeMention';
 import type { AgentNodeBodyProps, ViewMode } from './types';
 import {
   SCROLLBACK_SAVE_INTERVAL,
@@ -1160,13 +1161,8 @@ export const useAgentNodeController = ({
     setPickerOpen(false);
     const api = window.canvasWorkspace?.pty;
     if (api) {
-      const filePath = selected.type === 'file'
-        ? (selected.data as FileNodeData).filePath
-        : undefined;
-      const label = filePath ? filePath.split('/').pop() : selected.title;
-      const mention = `@[${label}](canvas:${selected.id})`;
       const activeSessionId = dataRef.current.sessionId || nodeIdRef.current;
-      void api.write(activeSessionId, mention);
+      void api.write(activeSessionId, buildNodeMention(selected));
     }
     termRef.current?.focus();
   }, [readOnly]);

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.css
@@ -255,6 +255,7 @@
   gap: 10px;
   align-items: end;
   min-width: 0;
+  position: relative;
 }
 
 .agent-team-command--lead {

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
@@ -3,8 +3,10 @@ import './index.css';
 import { AgentNodeBody } from '../AgentNodeBody';
 import { AgentIcon } from '../AgentNodeBody/AgentIcon';
 import { AgentTypeSelect } from './AgentTypeSelect';
+import { NodeMentionPicker } from '../NodeMentionPicker';
 import { useAppShell } from '../AppShellProvider';
 import { AGENT_REGISTRY } from '../../config/agentRegistry';
+import { useTextareaMention } from '../../hooks/useTextareaMention';
 import { isImeComposing } from '../../utils/ime';
 import type {
   AgentNodeData,
@@ -1328,6 +1330,15 @@ export const AgentTeamFrame = ({
           ? 'next'
           : 'message';
   const commandDraft = commandMode === 'brief' ? briefDraft : messageDraft;
+  const commandMention = useTextareaMention({
+    textareaRef: commandRef,
+    value: commandDraft,
+    onChange: (next) => {
+      if (phase === 'briefing') setBriefDraft(next);
+      else setMessageDraft(next);
+    },
+    disabled: readOnly,
+  });
   const commandPlaceholder = commandMode === 'brief'
     ? 'Describe the outcome, repo path, constraints, and what this team should handle...'
     : commandMode === 'starting'
@@ -1376,6 +1387,13 @@ export const AgentTeamFrame = ({
 
   const renderTeamCommand = (placement: 'top' | 'lead' = 'top') => (
     <div className={`agent-team-command agent-team-command--${placement}`} aria-label="Team command">
+      {commandMention.pickerOpen && (
+        <NodeMentionPicker
+          nodes={getAllNodes?.() ?? []}
+          onSelect={commandMention.handleSelect}
+          onClose={commandMention.handleClose}
+        />
+      )}
       <div className="agent-team-command__copy">
         <span className="agent-team-command__label">
           {commandLabel}
@@ -1394,6 +1412,7 @@ export const AgentTeamFrame = ({
           }}
           onKeyDown={(event) => {
             if (isImeComposing(event)) return;
+            if (commandMention.handleKeyDown(event)) return;
             const sendBrief = phase === 'briefing' && event.key === 'Enter' && (event.metaKey || event.ctrlKey);
             const sendCommand = phase !== 'briefing' && event.key === 'Enter' && !event.shiftKey;
             if (sendBrief || sendCommand) {

--- a/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody/index.tsx
@@ -2,9 +2,10 @@ import { useEffect, useRef, useCallback, useState } from 'react';
 import './index.css';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
-import type { CanvasNode, FileNodeData, TerminalNodeData } from '../../types';
+import type { CanvasNode, TerminalNodeData } from '../../types';
 import { TERMINAL_OPTIONS } from '../../config/terminalTheme';
 import { AI_TOOL_PATTERN, writeCanvasContext } from '../../utils/canvasContextWriter';
+import { buildNodeMention } from '../../utils/nodeMention';
 import { NodeMentionPicker } from '../NodeMentionPicker';
 import { fitTerminalWithCanvasScale, syncTerminalFontSizeToCanvas } from '../AgentNodeBody/utils/terminal';
 
@@ -253,12 +254,7 @@ export const TerminalNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, w
     setPickerOpen(false);
     const api = window.canvasWorkspace?.pty;
     if (api) {
-      const filePath = selected.type === 'file'
-        ? (selected.data as FileNodeData).filePath
-        : undefined;
-      const label = filePath ? filePath.split('/').pop() : selected.title;
-      const mention = `@[${label}](canvas:${selected.id})`;
-      void api.write(sessionId, mention);
+      void api.write(sessionId, buildNodeMention(selected));
     }
     termRef.current?.focus();
   }, [sessionId, readOnly]);

--- a/apps/canvas-workspace/src/renderer/src/hooks/useTextareaMention.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useTextareaMention.ts
@@ -1,0 +1,64 @@
+import { useCallback, useState, type KeyboardEvent, type RefObject } from 'react';
+import type { CanvasNode } from '../types';
+import { buildNodeMention } from '../utils/nodeMention';
+
+interface Options {
+  textareaRef: RefObject<HTMLTextAreaElement>;
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+}
+
+/**
+ * Adds canvas "@" mention support to a plain <textarea>.
+ *
+ * The Terminal and the running Agent terminal open the NodeMentionPicker via
+ * xterm's custom key handler and write the mention straight to the PTY. Plain
+ * textareas (the Coding Agent setup prompt, the Agent Teams Team Lead brief)
+ * have no PTY, so this hook wires the same Ctrl/Cmd+2 picker to instead insert
+ * the mention text at the caret and keep the caret after it.
+ */
+export function useTextareaMention({ textareaRef, value, onChange, disabled }: Options) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent): boolean => {
+      if (disabled) return false;
+      if (event.key === '2' && (event.metaKey || event.ctrlKey) && !event.altKey) {
+        event.preventDefault();
+        setPickerOpen(true);
+        return true;
+      }
+      return false;
+    },
+    [disabled],
+  );
+
+  const handleSelect = useCallback(
+    (node: CanvasNode) => {
+      setPickerOpen(false);
+      if (disabled) return;
+      const mention = buildNodeMention(node);
+      const textarea = textareaRef.current;
+      const start = textarea?.selectionStart ?? value.length;
+      const end = textarea?.selectionEnd ?? value.length;
+      const next = `${value.slice(0, start)}${mention}${value.slice(end)}`;
+      onChange(next);
+      const caret = start + mention.length;
+      requestAnimationFrame(() => {
+        const el = textareaRef.current;
+        if (!el) return;
+        el.focus();
+        el.setSelectionRange(caret, caret);
+      });
+    },
+    [disabled, onChange, textareaRef, value],
+  );
+
+  const handleClose = useCallback(() => {
+    setPickerOpen(false);
+    textareaRef.current?.focus();
+  }, [textareaRef]);
+
+  return { pickerOpen, handleKeyDown, handleSelect, handleClose };
+}

--- a/apps/canvas-workspace/src/renderer/src/utils/nodeMention.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/nodeMention.ts
@@ -1,0 +1,14 @@
+import type { CanvasNode, FileNodeData } from '../types';
+
+/**
+ * Canonical `@[label](canvas:id)` mention string for a canvas node.
+ *
+ * Shared by every surface that lets the user "@" a node — the Terminal, the
+ * running Agent terminal, and the plain-textarea inputs (Coding Agent setup
+ * prompt, Agent Teams Team Lead brief) — so the wire format stays identical.
+ */
+export function buildNodeMention(node: CanvasNode): string {
+  const filePath = node.type === 'file' ? (node.data as FileNodeData).filePath : undefined;
+  const label = filePath ? filePath.split('/').pop() : node.title;
+  return `@[${label}](canvas:${node.id})`;
+}


### PR DESCRIPTION
## 背景

canvas-workspace 中,Terminal 和**运行中**的 Coding Agent 终端可以通过 `Ctrl/Cmd+2` 打开 `NodeMentionPicker` 来 `@` 画布节点(它们是 xterm 终端,通过自定义按键处理器把 `@[label](canvas:id)` 写入 PTY)。

但有两处用的是普通 `<textarea>`,既没有 PTY 也没接选择器,因此无法 `@` 画布节点:

- **Coding Agent 未 Start 时**的 "Initial Prompt" 输入框(`AgentPicker.tsx`)
- **Agent Teams 的 Team Leader** brief/message 输入框(`AgentTeamFrame/index.tsx`)

## 改动

新增两个可复用模块:

- `utils/nodeMention.ts` — `buildNodeMention(node)`,统一生成 `@[label](canvas:id)` 文本,保证各处线格式一致。
- `hooks/useTextareaMention.ts` — 给普通 textarea 接上同样的 `Ctrl/Cmd+2` 选择器:在光标处插入 mention 文本,并把光标保持在插入内容之后。

接入两处输入框,复用现有的 `NodeMentionPicker`;同时把 Terminal 与 Agent 控制器里两处重复的 mention 拼接逻辑收敛到新 util。交互(快捷键、`@[label](canvas:id)` 格式)与现有终端完全一致。

## 验证

- 渲染层 `tsc --noEmit -p tsconfig.json` 通过(exit 0)。
- 测试中存在的失败项均为**本分支已有的、与本次改动无关的失败**(已用 stash 对照 clean HEAD 确认):
  - 主进程报 `pulse-coder-engine/built-in` 找不到(workspace 包未构建);
  - `file-size-governance` 基线已对 11 个本次未触碰的文件过期。
- 仅对本次确实增长的两个 `AgentTeamFrame` 文件按文档约定更新了 size 基线(`index.tsx` 2229→2243、`index.css` 2950→2951),避免引入新增违规;未改动其他遗留基线。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpKBgj5rdQVAynLGye2Bun)_