### PR TITLE
[codex] Support workspace-scoped terminal tabs

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasPaletteCommands.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasPaletteCommands.ts
@@ -206,7 +206,7 @@ export const useCanvasPaletteCommands = ({
         title: t('canvas.palette.command.newTerminal'),
         hint: t('canvas.palette.command.newTerminalHint'),
         aliases: ['shell', 'pty', 'command', 'run'],
-        run: () => dock.toggleTerminal(),
+        run: () => dock.newTerminal(),
       },
       {
         id: 'create-mindmap',

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/TerminalToolSplitButton.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/TerminalToolSplitButton.tsx
@@ -1,0 +1,64 @@
+import { useI18n } from '../../i18n';
+
+interface TerminalToolSplitButtonProps {
+  open: boolean;
+  showAdd: boolean;
+  onToggle: () => void;
+  onNewTerminal: () => void;
+}
+
+export const TerminalToolSplitButton = ({
+  open,
+  showAdd,
+  onToggle,
+  onNewTerminal,
+}: TerminalToolSplitButtonProps) => {
+  const { t } = useI18n();
+  const toggleLabel = open ? t('canvas.toolbar.hideTerminal') : t('canvas.toolbar.showTerminal');
+
+  return (
+    <div className={[
+      'terminal-tool-split',
+      open ? 'terminal-tool-split--active' : '',
+      showAdd ? 'terminal-tool-split--with-add' : '',
+    ].filter(Boolean).join(' ')}>
+      <button
+        className={`toolbar-btn toolbar-btn--create terminal-tool-main${open ? ' toolbar-btn--active' : ''}`}
+        onClick={onToggle}
+        aria-label={toggleLabel}
+        title={toggleLabel}
+        data-tooltip={t('canvas.toolbar.terminal')}
+        aria-pressed={open}
+      >
+        <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+          <rect
+            x="2.5" y="3" width="13" height="12" rx="2"
+            stroke="currentColor" strokeWidth="1.3"
+          />
+          <path
+            d="M5.5 8l2 1.5-2 1.5M9 11h3.5"
+            stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"
+          />
+        </svg>
+        <span className="toolbar-btn-label">{t('canvas.toolbar.terminal')}</span>
+      </button>
+      {showAdd && (
+        <button
+          className="toolbar-btn terminal-tool-add"
+          onClick={onNewTerminal}
+          aria-label={t('canvas.toolbar.newTerminal')}
+          title={t('canvas.toolbar.newTerminal')}
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+            <path
+              d="M7 3.2v7.6M3.2 7h7.6"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.css
@@ -206,6 +206,52 @@
   color: var(--accent);
 }
 
+/* ---- Terminal split-button ---- */
+
+.terminal-tool-split {
+  position: relative;
+  display: inline-flex;
+  align-items: stretch;
+  flex: 0 0 auto;
+}
+
+.terminal-tool-split--with-add .terminal-tool-main {
+  padding-right: 6px;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.terminal-tool-split .terminal-tool-add {
+  position: relative;
+  min-width: 22px;
+  width: 22px;
+  padding: 0 4px;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  margin-left: 0;
+}
+
+.terminal-tool-split .terminal-tool-add::before {
+  content: '';
+  position: absolute;
+  top: 6px;
+  bottom: 6px;
+  left: 0;
+  width: 1px;
+  background: rgba(0, 0, 0, 0.08);
+}
+
+.terminal-tool-split--active .terminal-tool-add {
+  background: var(--accent-light);
+  color: var(--accent);
+}
+
+.terminal-tool-split--active .terminal-tool-add:hover,
+.terminal-tool-split--active .terminal-tool-add:focus-visible {
+  background: var(--accent-light);
+  color: var(--accent);
+}
+
 /* ---- Plugin node menu ---- */
 
 .plugin-tool-menu {

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import './index.css';
 import { inferPluginIcon, PluginNodeIcon } from './PluginNodeIcon';
 import { ShapeToolButton } from './ShapeToolButton';
+import { TerminalToolSplitButton } from './TerminalToolSplitButton';
 import { AppLogoIcon, CodingAgentIcon } from '../icons';
 import { useClickOutside } from '../../hooks/useClickOutside';
 import { useMenuKeyboardNav } from '../../hooks/useMenuKeyboardNav';
@@ -14,7 +15,7 @@ import type {
   CanvasPluginsStatus,
 } from '../../types/settings-config';
 import { CANVAS_PLUGINS_CHANGED_EVENT } from '../../constants/canvasPlugins';
-import { TERMINAL_TAB_ID, useRightDock, useRightDockState } from '../RightDock';
+import { useRightDock, useRightDockState } from '../RightDock';
 
 interface AddNodeUiOptions {
   label?: string;
@@ -168,8 +169,7 @@ export const FloatingToolbar = ({
   const dock = useRightDock();
   const dockState = useRightDockState();
   const terminalDockOpen = dockState.expanded
-    && dockState.terminalOpen
-    && dockState.activeTabId === TERMINAL_TAB_ID;
+    && dockState.terminalTabs.some((tab) => tab.id === dockState.activeTabId);
   const pluginMenuRef = useRef<HTMLDivElement | null>(null);
   const pluginPopoverRef = useRef<HTMLDivElement | null>(null);
   const [pluginMenuOpen, setPluginMenuOpen] = useState(false);
@@ -374,25 +374,12 @@ export const FloatingToolbar = ({
           </svg>
           <span className="toolbar-btn-label">{t('canvas.toolbar.web')}</span>
         </button>
-        <button
-          className={`toolbar-btn toolbar-btn--create${terminalDockOpen ? " toolbar-btn--active" : ""}`}
-          onClick={dock.toggleTerminal}
-          aria-label={t('canvas.toolbar.addTerminal')}
-          data-tooltip={t('canvas.toolbar.terminal')}
-          aria-pressed={terminalDockOpen}
-        >
-          <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-            <rect
-              x="2.5" y="3" width="13" height="12" rx="2"
-              stroke="currentColor" strokeWidth="1.3"
-            />
-            <path
-              d="M5.5 8l2 1.5-2 1.5M9 11h3.5"
-              stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"
-            />
-          </svg>
-          <span className="toolbar-btn-label">{t('canvas.toolbar.terminal')}</span>
-        </button>
+        <TerminalToolSplitButton
+          open={terminalDockOpen}
+          showAdd={dockState.terminalTabs.length > 0}
+          onToggle={dock.toggleTerminal}
+          onNewTerminal={dock.newTerminal}
+        />
         <button
           className="toolbar-btn toolbar-btn--create"
           onClick={() => onAddNode("mindmap")}

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/TerminalDockTab.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/TerminalDockTab.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
+import { useI18n } from '../../i18n';
+import { NodeTypeIcon } from '../icons';
+import type { DockTerminalTab } from './dock-store';
+
+interface TerminalDockTabProps {
+  tab: DockTerminalTab;
+  active: boolean;
+  registerTab: (id: string, element: HTMLButtonElement | null) => void;
+  onActivate: (id: string) => void;
+  onClose: (id: string) => void;
+  onRename: (id: string, title: string) => void;
+}
+
+export const TerminalDockTab = ({
+  tab,
+  active,
+  registerTab,
+  onActivate,
+  onClose,
+  onRename,
+}: TerminalDockTabProps) => {
+  const { t } = useI18n();
+  const defaultTitle = t('rightDock.terminalNumber', { number: tab.ordinal });
+  const title = tab.title ?? defaultTitle;
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(title);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const cancelingRef = useRef(false);
+
+  useEffect(() => {
+    if (!editing) setDraft(title);
+  }, [editing, title]);
+
+  useEffect(() => {
+    if (!editing) return;
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, [editing]);
+
+  const startRename = () => {
+    cancelingRef.current = false;
+    setDraft(title);
+    setEditing(true);
+    onActivate(tab.id);
+  };
+
+  const commitRename = () => {
+    if (cancelingRef.current) {
+      cancelingRef.current = false;
+      return;
+    }
+    const nextTitle = draft.trim();
+    if (nextTitle && nextTitle !== title) onRename(tab.id, nextTitle);
+    setEditing(false);
+  };
+
+  const cancelRename = () => {
+    cancelingRef.current = true;
+    setDraft(title);
+    setEditing(false);
+  };
+
+  const handleInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    event.stopPropagation();
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      commitRename();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      cancelRename();
+    }
+  };
+
+  return (
+    <span className="right-dock__tab-shell">
+      <button
+        ref={(element) => registerTab(tab.id, element)}
+        type="button"
+        role="tab"
+        aria-selected={active}
+        className={`right-dock__tab right-dock__tab--with-close${active ? ' right-dock__tab--active' : ''}`}
+        title={`${title} - ${t('rightDock.renameTerminalHint')}`}
+        onClick={() => onActivate(tab.id)}
+        onDoubleClick={startRename}
+        onKeyDown={(event) => {
+          if (event.key === 'F2') {
+            event.preventDefault();
+            startRename();
+          }
+        }}
+      >
+        <span className="right-dock__tab-icon right-dock__tab-icon--terminal">
+          <NodeTypeIcon type="terminal" size={14} />
+        </span>
+        <span className={`right-dock__tab-title${editing ? ' right-dock__tab-title--editing' : ''}`}>
+          {title}
+        </span>
+      </button>
+      {editing && (
+        <input
+          ref={inputRef}
+          className="right-dock__tab-rename-input"
+          value={draft}
+          maxLength={64}
+          aria-label={t('rightDock.terminalNameInput')}
+          onChange={(event) => setDraft(event.target.value)}
+          onBlur={commitRename}
+          onClick={(event) => event.stopPropagation()}
+          onDoubleClick={(event) => event.stopPropagation()}
+          onKeyDown={handleInputKeyDown}
+        />
+      )}
+      <button
+        type="button"
+        aria-label={t('rightDock.closeTab', { title })}
+        title={t('rightDock.closeTab', { title })}
+        className="right-dock__tab-close"
+        onClick={(e) => {
+          e.stopPropagation();
+          onClose(tab.id);
+        }}
+      >
+        ×
+      </button>
+    </span>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/__tests__/dock-store.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/__tests__/dock-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { CHAT_TAB_ID, TERMINAL_TAB_ID, DockStore, artifactTabId, linkTabId } from '../dock-store';
+import { CHAT_TAB_ID, TERMINAL_TAB_ID, DockStore, artifactTabId, linkTabId, terminalTabId } from '../dock-store';
 
 describe('DockStore', () => {
   it('starts collapsed on the pinned chat tab with no previews', () => {
@@ -9,6 +9,11 @@ describe('DockStore', () => {
       activeTabId: CHAT_TAB_ID,
       expanded: false,
       chatUnread: false,
+      terminalTabsByWorkspace: {},
+      activeTerminalWorkspaceId: '__default__',
+      terminalTabs: [],
+      activeTerminalTabId: undefined,
+      nextTerminalOrdinal: 1,
       terminalOpen: false,
     });
   });
@@ -130,8 +135,13 @@ describe('DockStore', () => {
     dock.openTerminal();
     expect(dock.getSnapshot()).toMatchObject({
       activeTabId: TERMINAL_TAB_ID,
+      activeTerminalTabId: TERMINAL_TAB_ID,
       expanded: true,
       terminalOpen: true,
+    });
+    expect(dock.getSnapshot().terminalTabs[0]).toMatchObject({
+      id: TERMINAL_TAB_ID,
+      ordinal: 1,
     });
     dock.closeTerminal();
     expect(dock.getSnapshot()).toMatchObject({
@@ -151,6 +161,110 @@ describe('DockStore', () => {
       expanded: true,
       terminalOpen: false,
     });
+  });
+
+  it('toggleTerminal hides and restores the active terminal without closing it', () => {
+    const dock = new DockStore();
+    dock.openTerminal();
+    dock.toggleTerminal();
+    expect(dock.getSnapshot()).toMatchObject({
+      activeTabId: TERMINAL_TAB_ID,
+      activeTerminalTabId: TERMINAL_TAB_ID,
+      expanded: false,
+      terminalOpen: true,
+    });
+    expect(dock.getSnapshot().terminalTabs).toHaveLength(1);
+    dock.toggleTerminal();
+    expect(dock.getSnapshot()).toMatchObject({
+      activeTabId: TERMINAL_TAB_ID,
+      expanded: true,
+      terminalOpen: true,
+    });
+  });
+
+  it('creates multiple terminal tabs and closes only the requested one', () => {
+    const dock = new DockStore();
+    dock.openTerminal();
+    dock.newTerminal();
+    expect(dock.getSnapshot()).toMatchObject({
+      activeTabId: terminalTabId(2),
+      activeTerminalTabId: terminalTabId(2),
+      expanded: true,
+      terminalOpen: true,
+    });
+    expect(dock.getSnapshot().terminalTabs.map((tab) => tab.id)).toEqual([
+      TERMINAL_TAB_ID,
+      terminalTabId(2),
+    ]);
+    dock.closeTerminal(terminalTabId(2));
+    expect(dock.getSnapshot()).toMatchObject({
+      activeTabId: TERMINAL_TAB_ID,
+      activeTerminalTabId: TERMINAL_TAB_ID,
+      terminalOpen: true,
+    });
+    dock.closeTerminal(TERMINAL_TAB_ID);
+    expect(dock.getSnapshot()).toMatchObject({
+      activeTabId: CHAT_TAB_ID,
+      activeTerminalTabId: undefined,
+      expanded: false,
+      terminalOpen: false,
+    });
+  });
+
+  it('keeps terminal tabs scoped to the active workspace', () => {
+    const dock = new DockStore();
+    dock.setActiveWorkspace('ws-a');
+    dock.openTerminal();
+    dock.renameTerminal(TERMINAL_TAB_ID, 'Claude');
+    dock.newTerminal();
+    dock.renameTerminal(terminalTabId(2), 'Codex');
+
+    expect(dock.getSnapshot()).toMatchObject({
+      activeTerminalWorkspaceId: 'ws-a',
+      activeTabId: terminalTabId(2),
+      activeTerminalTabId: terminalTabId(2),
+      terminalOpen: true,
+    });
+    expect(dock.getSnapshot().terminalTabs.map((tab) => tab.title)).toEqual(['Claude', 'Codex']);
+
+    dock.setActiveWorkspace('ws-b');
+    expect(dock.getSnapshot()).toMatchObject({
+      activeTerminalWorkspaceId: 'ws-b',
+      activeTabId: CHAT_TAB_ID,
+      activeTerminalTabId: undefined,
+      expanded: true,
+      terminalOpen: false,
+      terminalTabs: [],
+      nextTerminalOrdinal: 1,
+    });
+
+    dock.openTerminal();
+    expect(dock.getSnapshot().terminalTabs).toEqual([{ id: TERMINAL_TAB_ID, ordinal: 1 }]);
+
+    dock.setActiveWorkspace('ws-a');
+    expect(dock.getSnapshot()).toMatchObject({
+      activeTerminalWorkspaceId: 'ws-a',
+      activeTabId: terminalTabId(2),
+      activeTerminalTabId: terminalTabId(2),
+      terminalOpen: true,
+    });
+    expect(dock.getSnapshot().terminalTabs.map((tab) => tab.title)).toEqual(['Claude', 'Codex']);
+  });
+
+  it('renames terminal tabs and ignores blanks or non-terminal ids', () => {
+    const dock = new DockStore();
+    dock.openTerminal();
+    dock.renameTerminal(TERMINAL_TAB_ID, ' server ');
+    expect(dock.getSnapshot().terminalTabs[0]).toMatchObject({
+      id: TERMINAL_TAB_ID,
+      title: 'server',
+      ordinal: 1,
+    });
+    dock.renameTerminal(TERMINAL_TAB_ID, '   ');
+    expect(dock.getSnapshot().terminalTabs[0].title).toBe('server');
+    dock.openArtifact('ws1', 'a1');
+    dock.renameTerminal(artifactTabId('ws1', 'a1'), 'artifact title');
+    expect(dock.getSnapshot().tabs[0].title).toBe('Artifact');
   });
 
   it('chat activity sets unread only while chat is not the visible tab', () => {

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/dock-store.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/dock-store.ts
@@ -22,19 +22,45 @@ export type DockPreviewTab =
   | { id: string; kind: 'artifact'; title: string; workspaceId: string; artifactId: string }
   | { id: string; kind: 'link'; title: string; url: string; faviconUrl?: string };
 
+export interface DockTerminalTab {
+  id: string;
+  title?: string;
+  ordinal: number;
+}
+
+export interface DockTerminalWorkspaceState {
+  tabs: DockTerminalTab[];
+  activeTabId?: string;
+  nextOrdinal: number;
+}
+
 export interface DockState {
   /** Preview tabs only — chat is pinned and implicit. */
   tabs: DockPreviewTab[];
-  /** `CHAT_TAB_ID`, `TERMINAL_TAB_ID`, or a preview tab id. */
+  /** `CHAT_TAB_ID`, a terminal tab id, or a preview tab id. */
   activeTabId: string;
   expanded: boolean;
   chatUnread: boolean;
+  terminalTabsByWorkspace: Record<string, DockTerminalWorkspaceState>;
+  activeTerminalWorkspaceId: string;
+  terminalTabs: DockTerminalTab[];
+  activeTerminalTabId?: string;
+  nextTerminalOrdinal: number;
+  /** Compatibility flag for callers that only need to know whether any terminal exists. */
   terminalOpen: boolean;
 }
 
 export const CHAT_TAB_ID = 'chat';
 export const TERMINAL_TAB_ID = 'terminal';
 export const LINK_TAB_ID = 'link';
+const DEFAULT_TERMINAL_WORKSPACE_ID = '__default__';
+const EMPTY_TERMINAL_TABS: DockTerminalTab[] = [];
+
+export const terminalTabId = (ordinal: number): string =>
+  ordinal === 1 ? TERMINAL_TAB_ID : `${TERMINAL_TAB_ID}:${ordinal}`;
+
+export const isTerminalTabId = (id: string): boolean =>
+  id === TERMINAL_TAB_ID || id.startsWith(`${TERMINAL_TAB_ID}:`);
 
 export const artifactTabId = (workspaceId: string, artifactId: string): string =>
   `artifact:${workspaceId}:${artifactId}`;
@@ -53,6 +79,11 @@ const INITIAL: DockState = {
   activeTabId: CHAT_TAB_ID,
   expanded: false,
   chatUnread: false,
+  terminalTabsByWorkspace: {},
+  activeTerminalWorkspaceId: DEFAULT_TERMINAL_WORKSPACE_ID,
+  terminalTabs: [],
+  activeTerminalTabId: undefined,
+  nextTerminalOrdinal: 1,
   terminalOpen: false,
 };
 
@@ -72,6 +103,48 @@ export class DockStore {
   private commit(next: Partial<DockState>): void {
     this.state = { ...this.state, ...next };
     for (const listener of [...this.listeners]) listener();
+  }
+
+  private getTerminalWorkspace(workspaceId = this.state.activeTerminalWorkspaceId): DockTerminalWorkspaceState {
+    return this.state.terminalTabsByWorkspace[workspaceId] ?? {
+      tabs: EMPTY_TERMINAL_TABS,
+      activeTabId: undefined,
+      nextOrdinal: 1,
+    };
+  }
+
+  private projectTerminalWorkspace(
+    workspaceId = this.state.activeTerminalWorkspaceId,
+    workspaces = this.state.terminalTabsByWorkspace,
+  ): Pick<DockState, 'terminalTabs' | 'activeTerminalTabId' | 'nextTerminalOrdinal' | 'terminalOpen'> {
+    const workspace = workspaces[workspaceId];
+    const tabs = workspace?.tabs ?? EMPTY_TERMINAL_TABS;
+    const activeTerminalTabId = workspace?.activeTabId && tabs.some((tab) => tab.id === workspace.activeTabId)
+      ? workspace.activeTabId
+      : tabs[0]?.id;
+    return {
+      terminalTabs: tabs,
+      activeTerminalTabId,
+      nextTerminalOrdinal: workspace?.nextOrdinal ?? 1,
+      terminalOpen: tabs.length > 0,
+    };
+  }
+
+  private commitTerminalWorkspace(
+    workspaceId: string,
+    workspace: DockTerminalWorkspaceState,
+    next: Partial<DockState> = {},
+  ): void {
+    const terminalTabsByWorkspace = { ...this.state.terminalTabsByWorkspace };
+    if (workspace.tabs.length > 0) {
+      terminalTabsByWorkspace[workspaceId] = workspace;
+    } else {
+      delete terminalTabsByWorkspace[workspaceId];
+    }
+    const projection = workspaceId === this.state.activeTerminalWorkspaceId
+      ? this.projectTerminalWorkspace(workspaceId, terminalTabsByWorkspace)
+      : {};
+    this.commit({ terminalTabsByWorkspace, ...projection, ...next });
   }
 
   openArtifact(workspaceId: string, artifactId: string): void {
@@ -110,14 +183,24 @@ export class DockStore {
 
   /** Switch to an existing tab (chat, workspace terminal, or preview). Viewing chat clears unread. */
   activate(id: string): void {
+    const activatingTerminal = this.state.terminalTabs.some((tab) => tab.id === id);
     if (
       id !== CHAT_TAB_ID
-      && !(id === TERMINAL_TAB_ID && this.state.terminalOpen)
+      && !activatingTerminal
       && !this.state.tabs.some((tab) => tab.id === id)
     ) {
       return;
     }
     if (this.state.activeTabId === id && (id !== CHAT_TAB_ID || !this.state.chatUnread)) return;
+    if (activatingTerminal) {
+      const workspaceId = this.state.activeTerminalWorkspaceId;
+      const workspace = this.getTerminalWorkspace(workspaceId);
+      this.commitTerminalWorkspace(workspaceId, { ...workspace, activeTabId: id }, {
+        expanded: true,
+        activeTabId: id,
+      });
+      return;
+    }
     this.commit({
       expanded: true,
       activeTabId: id,
@@ -139,30 +222,117 @@ export class DockStore {
     this.openChat();
   }
 
+  setActiveWorkspace(workspaceId: string): void {
+    if (!workspaceId || workspaceId === this.state.activeTerminalWorkspaceId) return;
+    const projection = this.projectTerminalWorkspace(workspaceId);
+    const switchingFromTerminal = isTerminalTabId(this.state.activeTabId);
+    const activeTabId = switchingFromTerminal
+      ? (projection.activeTerminalTabId ?? this.state.tabs[0]?.id ?? CHAT_TAB_ID)
+      : this.state.activeTabId;
+    this.commit({
+      activeTerminalWorkspaceId: workspaceId,
+      ...projection,
+      activeTabId,
+      expanded: this.state.expanded,
+      ...(activeTabId === CHAT_TAB_ID ? { chatUnread: false } : {}),
+    });
+  }
+
+  private createTerminalTab(workspace: DockTerminalWorkspaceState): DockTerminalTab {
+    const ordinal = workspace.nextOrdinal;
+    return {
+      id: terminalTabId(ordinal),
+      ordinal,
+    };
+  }
+
   openTerminal(): void {
-    if (this.state.expanded && this.state.activeTabId === TERMINAL_TAB_ID && this.state.terminalOpen) return;
-    this.commit({ expanded: true, activeTabId: TERMINAL_TAB_ID, terminalOpen: true });
+    const workspaceId = this.state.activeTerminalWorkspaceId;
+    const workspace = this.getTerminalWorkspace(workspaceId);
+    const currentTerminalId = workspace.activeTabId
+      && workspace.tabs.some((tab) => tab.id === workspace.activeTabId)
+      ? workspace.activeTabId
+      : workspace.tabs[0]?.id;
+
+    if (currentTerminalId) {
+      if (this.state.expanded && this.state.activeTabId === currentTerminalId) return;
+      this.commitTerminalWorkspace(workspaceId, { ...workspace, activeTabId: currentTerminalId }, {
+        expanded: true,
+        activeTabId: currentTerminalId,
+      });
+      return;
+    }
+
+    const tab = this.createTerminalTab(workspace);
+    this.commitTerminalWorkspace(workspaceId, {
+      tabs: [tab],
+      activeTabId: tab.id,
+      nextOrdinal: workspace.nextOrdinal + 1,
+    }, {
+      activeTabId: tab.id,
+      expanded: true,
+    });
+  }
+
+  newTerminal(): void {
+    const workspaceId = this.state.activeTerminalWorkspaceId;
+    const workspace = this.getTerminalWorkspace(workspaceId);
+    const tab = this.createTerminalTab(workspace);
+    this.commitTerminalWorkspace(workspaceId, {
+      tabs: [...workspace.tabs, tab],
+      activeTabId: tab.id,
+      nextOrdinal: workspace.nextOrdinal + 1,
+    }, {
+      activeTabId: tab.id,
+      expanded: true,
+    });
   }
 
   toggleTerminal(): void {
-    if (this.state.expanded && this.state.activeTabId === TERMINAL_TAB_ID && this.state.terminalOpen) {
-      this.closeTerminal();
+    if (this.state.expanded && this.state.terminalTabs.some((tab) => tab.id === this.state.activeTabId)) {
+      this.collapse();
       return;
     }
     this.openTerminal();
   }
 
-  closeTerminal(): void {
-    if (!this.state.terminalOpen) return;
-    const closingActiveTerminal = this.state.activeTabId === TERMINAL_TAB_ID;
+  closeTerminal(id = this.state.activeTerminalTabId): void {
+    if (!id) return;
+    const workspaceId = this.state.activeTerminalWorkspaceId;
+    const workspace = this.getTerminalWorkspace(workspaceId);
+    const index = workspace.tabs.findIndex((tab) => tab.id === id);
+    if (index === -1) return;
+    const terminalTabs = workspace.tabs.filter((tab) => tab.id !== id);
+    const closingActiveTerminal = this.state.activeTabId === id;
+    const activeTerminalTabId = terminalTabs[Math.min(index, terminalTabs.length - 1)]?.id
+      ?? terminalTabs[terminalTabs.length - 1]?.id;
     const activeTabId = closingActiveTerminal
-      ? (this.state.tabs[0]?.id ?? CHAT_TAB_ID)
+      ? (activeTerminalTabId ?? this.state.tabs[0]?.id ?? CHAT_TAB_ID)
       : this.state.activeTabId;
-    this.commit({
-      terminalOpen: false,
+    this.commitTerminalWorkspace(workspaceId, {
+      tabs: terminalTabs,
+      activeTabId: activeTerminalTabId,
+      nextOrdinal: workspace.nextOrdinal,
+    }, {
       activeTabId,
-      expanded: closingActiveTerminal && this.state.tabs.length === 0 ? false : this.state.expanded,
+      expanded: closingActiveTerminal && terminalTabs.length === 0 && this.state.tabs.length === 0
+        ? false
+        : this.state.expanded,
       ...(activeTabId === CHAT_TAB_ID ? { chatUnread: false } : {}),
+    });
+  }
+
+  renameTerminal(id: string, title: string): void {
+    const trimmed = title.trim();
+    if (!trimmed) return;
+    const workspaceId = this.state.activeTerminalWorkspaceId;
+    const workspace = this.getTerminalWorkspace(workspaceId);
+    const tab = workspace.tabs.find((item) => item.id === id);
+    if (!tab || tab.title === trimmed) return;
+    this.commitTerminalWorkspace(workspaceId, {
+      ...workspace,
+      tabs: workspace.tabs.map((item) =>
+        (item.id === id ? { ...item, title: trimmed } : item)),
     });
   }
 

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/index.tsx
@@ -47,13 +47,15 @@ import {
 import { ArtifactTabView } from '../artifacts/ArtifactTabView';
 import { useI18n } from '../../i18n';
 import { LinkTabView } from '../LinkDrawer';
-import { AppLogoIcon, NodeTypeIcon } from '../icons';
-import { CHAT_TAB_ID, TERMINAL_TAB_ID, DockStore, type DockState } from './dock-store';
+import { AppLogoIcon } from '../icons';
+import { CHAT_TAB_ID, DockStore, isTerminalTabId, type DockState } from './dock-store';
 import { LinkTabIcon } from './LinkTabIcon';
+import { TerminalDockTab } from './TerminalDockTab';
 import './index.css';
 import './terminal-tab.css';
 
-export { CHAT_TAB_ID, TERMINAL_TAB_ID } from './dock-store';
+export { CHAT_TAB_ID, TERMINAL_TAB_ID, isTerminalTabId } from './dock-store';
+export type { DockTerminalTab, DockTerminalWorkspaceState } from './dock-store';
 
 const WIDTH_STORAGE_KEY = 'canvas-workspace:right-dock-width';
 const DEFAULT_WIDTH = 480;
@@ -101,8 +103,9 @@ export function useRightDock(): {
   openChat: () => void;
   toggleChat: () => void;
   openTerminal: () => void;
+  newTerminal: () => void;
   toggleTerminal: () => void;
-  closeTerminal: () => void;
+  closeTerminal: (id?: string) => void;
   collapse: () => void;
   notifyChatActivity: () => void;
 } {
@@ -114,8 +117,9 @@ export function useRightDock(): {
       openChat: () => store.openChat(),
       toggleChat: () => store.toggleChat(),
       openTerminal: () => store.openTerminal(),
+      newTerminal: () => store.newTerminal(),
       toggleTerminal: () => store.toggleTerminal(),
-      closeTerminal: () => store.closeTerminal(),
+      closeTerminal: (id?: string) => store.closeTerminal(id),
       collapse: () => store.collapse(),
       notifyChatActivity: () => store.notifyChatActivity(),
     }),
@@ -176,38 +180,41 @@ export const RightDock = ({ activeWorkspaceId, chatTabEnabled }: RightDockProps)
   const state = useRightDockState();
   const { t } = useI18n();
 
-  // External links intercepted by the main process land in link preview tabs.
+  useLayoutEffect(() => {
+    store.setActiveWorkspace(activeWorkspaceId);
+  }, [activeWorkspaceId, store]);
+
   useEffect(() => {
     return window.canvasWorkspace.link.onOpen(({ url }) => store.openLink(url));
   }, [store]);
 
-  // Route guard: while the chat tab is unavailable, an active 'chat'
-  // pointer falls forward to the first preview so the dock never shows an
-  // empty pane.
   useEffect(() => {
     if (chatTabEnabled) return;
     if (
-      (state.activeTabId === CHAT_TAB_ID || state.activeTabId === TERMINAL_TAB_ID)
+      (state.activeTabId === CHAT_TAB_ID || isTerminalTabId(state.activeTabId))
       && state.tabs.length > 0
     ) {
       store.activate(state.tabs[0].id);
       return;
     }
-    if (state.activeTabId === CHAT_TAB_ID || state.activeTabId === TERMINAL_TAB_ID) {
+    if (state.activeTabId === CHAT_TAB_ID || isTerminalTabId(state.activeTabId)) {
       store.collapse();
     }
   }, [chatTabEnabled, state.activeTabId, state.tabs, store]);
 
   const hasPreviews = state.tabs.length > 0;
-  const terminalTabVisible = chatTabEnabled && state.terminalOpen;
-  const tabStripVisible = hasPreviews || terminalTabVisible;
+  const terminalTabsVisible = chatTabEnabled && state.terminalTabs.length > 0;
+  const terminalHostMounted = chatTabEnabled
+    && Object.values(state.terminalTabsByWorkspace).some((workspace) => workspace.tabs.length > 0);
+  const tabStripVisible = hasPreviews || terminalTabsVisible;
   const visible = state.expanded && (chatTabEnabled || hasPreviews);
   // While the chat tab is unavailable a transient 'chat' active pointer
   // (route guard hasn't run yet) should highlight nothing.
   const activePaneId = !chatTabEnabled
-    && (state.activeTabId === CHAT_TAB_ID || state.activeTabId === TERMINAL_TAB_ID)
+    && (state.activeTabId === CHAT_TAB_ID || isTerminalTabId(state.activeTabId))
     ? null
     : state.activeTabId;
+  const terminalPaneActive = state.terminalTabs.some((tab) => tab.id === activePaneId);
 
   const [width, setWidth] = useState<number>(() => clampWidth(readStoredWidth() ?? DEFAULT_WIDTH));
   const widthRef = useRef(width);
@@ -252,13 +259,13 @@ export const RightDock = ({ activeWorkspaceId, chatTabEnabled }: RightDockProps)
 
   useLayoutEffect(() => {
     updateTabIndicator();
-  }, [updateTabIndicator, state.tabs, state.terminalOpen, chatTabEnabled, width]);
+  }, [updateTabIndicator, state.tabs, state.terminalTabs, chatTabEnabled, width]);
 
   useEffect(() => {
     if (!tabStripVisible || !activePaneId) return;
     const activeTab = tabRefs.current.get(activePaneId);
     activeTab?.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'smooth' });
-  }, [activePaneId, tabStripVisible, state.tabs, state.terminalOpen]);
+  }, [activePaneId, tabStripVisible, state.tabs, state.terminalTabs]);
 
   useEffect(() => {
     if (typeof ResizeObserver === 'undefined') return;
@@ -269,7 +276,7 @@ export const RightDock = ({ activeWorkspaceId, chatTabEnabled }: RightDockProps)
       observer.observe(tabElement);
     }
     return () => observer.disconnect();
-  }, [updateTabIndicator, state.tabs, state.terminalOpen, chatTabEnabled]);
+  }, [updateTabIndicator, state.tabs, state.terminalTabs, chatTabEnabled]);
 
   // Re-clamp on viewport resize so a stored width wider than the new
   // viewport doesn't push the dock off-screen.
@@ -296,9 +303,9 @@ export const RightDock = ({ activeWorkspaceId, chatTabEnabled }: RightDockProps)
     if (!visible) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return;
-      const { activeTabId } = store.getSnapshot();
-      if (activeTabId === TERMINAL_TAB_ID) {
-        store.closeTerminal();
+      const { activeTabId, terminalTabs } = store.getSnapshot();
+      if (terminalTabs.some((tab) => tab.id === activeTabId)) {
+        store.closeTerminal(activeTabId);
         return;
       }
       if (activeTabId !== CHAT_TAB_ID) store.close(activeTabId);
@@ -356,8 +363,6 @@ export const RightDock = ({ activeWorkspaceId, chatTabEnabled }: RightDockProps)
         aria-orientation="vertical"
         aria-label={t('rightDock.resizePanel')}
       />
-      {/* Always in the DOM so its appearance/disappearance can animate;
-          hidden (and out of the tab order) while chat is alone. */}
       <div className="right-dock__tabs" data-visible={tabStripVisible}>
         <div
           ref={tabsRef}
@@ -393,36 +398,17 @@ export const RightDock = ({ activeWorkspaceId, chatTabEnabled }: RightDockProps)
               <span className="right-dock__tab-unread" aria-hidden="true" />
             </button>
           )}
-          {terminalTabVisible && (
-            <span className="right-dock__tab-shell">
-              <button
-                ref={(element) => registerTab(TERMINAL_TAB_ID, element)}
-                type="button"
-                role="tab"
-                aria-selected={activePaneId === TERMINAL_TAB_ID}
-                className={`right-dock__tab right-dock__tab--with-close${activePaneId === TERMINAL_TAB_ID ? ' right-dock__tab--active' : ''}`}
-                title={t('rightDock.terminal')}
-                onClick={() => store.activate(TERMINAL_TAB_ID)}
-              >
-                <span className="right-dock__tab-icon right-dock__tab-icon--terminal">
-                  <NodeTypeIcon type="terminal" size={14} />
-                </span>
-                <span className="right-dock__tab-title">{t('rightDock.terminal')}</span>
-              </button>
-              <button
-                type="button"
-                aria-label={t('rightDock.closeTab', { title: t('rightDock.terminal') })}
-                title={t('rightDock.closeTab', { title: t('rightDock.terminal') })}
-                className="right-dock__tab-close"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  store.closeTerminal();
-                }}
-              >
-                ×
-              </button>
-            </span>
-          )}
+          {terminalTabsVisible && state.terminalTabs.map((tab) => (
+            <TerminalDockTab
+              key={tab.id}
+              tab={tab}
+              active={tab.id === activePaneId}
+              registerTab={registerTab}
+              onActivate={(id) => store.activate(id)}
+              onClose={(id) => store.closeTerminal(id)}
+              onRename={(id, title) => store.renameTerminal(id, title)}
+            />
+          ))}
           {state.tabs.map((tab) => {
             const active = tab.id === activePaneId;
             return (
@@ -472,15 +458,13 @@ export const RightDock = ({ activeWorkspaceId, chatTabEnabled }: RightDockProps)
         </button>
       </div>
       <div className="right-dock__panes">
-        {/* Chat pane: portal outlet — always mounted so chat keeps its
-            state across collapse, tab switches and route changes. */}
         <div
           ref={setChatHost}
           className={`right-dock__pane right-dock__pane--chat${activePaneId === CHAT_TAB_ID ? ' right-dock__pane--active' : ''}`}
         />
-        {terminalTabVisible && (
+        {terminalHostMounted && (
           <div
-            className={`right-dock__pane right-dock__pane--terminal${activePaneId === TERMINAL_TAB_ID ? ' right-dock__pane--active' : ''}`}
+            className={`right-dock__pane right-dock__pane--terminal${terminalPaneActive ? ' right-dock__pane--active' : ''}`}
           >
             <div ref={setTerminalHost} className="right-dock__terminal-host" />
           </div>

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/terminal-tab.css
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/terminal-tab.css
@@ -10,3 +10,34 @@
   min-width: 0;
   min-height: 0;
 }
+
+.right-dock__tab-title--editing {
+  visibility: hidden;
+}
+
+.right-dock__tab-rename-input {
+  position: absolute;
+  z-index: 3;
+  top: 4px;
+  left: 33px;
+  right: 29px;
+  height: 22px;
+  min-width: 54px;
+  border: 1px solid rgba(35, 131, 226, 0.45);
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.96);
+  color: #37352f;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 20px;
+  padding: 0 5px;
+  outline: none;
+  box-shadow:
+    0 0 0 2px rgba(35, 131, 226, 0.12),
+    0 4px 10px rgba(15, 15, 15, 0.08);
+}
+
+.right-dock__tab-rename-input::selection {
+  background: rgba(35, 131, 226, 0.22);
+}

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/WorkspaceTerminalPortal.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/WorkspaceTerminalPortal.tsx
@@ -3,14 +3,17 @@ import { useRightDockTerminalHost } from '../RightDock';
 import { WorkspaceTerminalDock } from '../WorkspaceTerminalDock';
 import type { WorkspaceEntry } from '../../hooks/useWorkspaces';
 import type { CanvasNode } from '../../types';
+import type { DockTerminalWorkspaceState } from '../RightDock';
 
 interface WorkspaceTerminalPortalProps {
   activeWorkspaceId: string;
   workspaces: WorkspaceEntry[];
   mountedWorkspaceIds: Set<string>;
   allNodes: Record<string, CanvasNode[]>;
+  terminalTabsByWorkspace: Record<string, DockTerminalWorkspaceState>;
+  activeTerminalTabId?: string;
   open: boolean;
-  onClose: () => void;
+  onClose: (id?: string) => void;
 }
 
 export const WorkspaceTerminalPortal = ({
@@ -18,6 +21,8 @@ export const WorkspaceTerminalPortal = ({
   workspaces,
   mountedWorkspaceIds,
   allNodes,
+  terminalTabsByWorkspace,
+  activeTerminalTabId,
   open,
   onClose,
 }: WorkspaceTerminalPortalProps) => {
@@ -25,23 +30,31 @@ export const WorkspaceTerminalPortal = ({
   if (!terminalHost) return null;
 
   return createPortal(
-    workspaces.filter((ws) => mountedWorkspaceIds.has(ws.id)).map((ws) => (
-      <div
-        key={ws.id}
-        className="right-dock__terminal-instance"
-        style={ws.id !== activeWorkspaceId ? { display: 'none' } : undefined}
-      >
-        <WorkspaceTerminalDock
-          workspaceId={ws.id}
-          workspaceName={ws.name}
-          rootFolder={ws.rootFolder}
-          nodes={allNodes[ws.id] || []}
-          open={ws.id === activeWorkspaceId && open}
-          onClose={onClose}
-          placement="pane"
-        />
-      </div>
-    )),
+    workspaces.filter((ws) => mountedWorkspaceIds.has(ws.id)).flatMap((ws) => {
+      const terminalTabs = terminalTabsByWorkspace[ws.id]?.tabs ?? [];
+      return terminalTabs.map((tab) => {
+        const visible = ws.id === activeWorkspaceId && tab.id === activeTerminalTabId;
+        return (
+          <div
+            key={`${ws.id}:${tab.id}`}
+            className="right-dock__terminal-instance"
+            style={visible ? undefined : { display: 'none' }}
+          >
+            <WorkspaceTerminalDock
+              workspaceId={ws.id}
+              terminalId={tab.id}
+              terminalTitle={tab.title}
+              workspaceName={ws.name}
+              rootFolder={ws.rootFolder}
+              nodes={allNodes[ws.id] || []}
+              open={visible && open}
+              onClose={() => onClose(tab.id)}
+              placement="pane"
+            />
+          </div>
+        );
+      });
+    }),
     terminalHost,
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import { Canvas } from '../Canvas';
 import { FileNodeEditorRegistryProvider } from '../../hooks/useFileNodeEditorRegistry';
 import { ChatPanel } from '../chat';
-import { CHAT_TAB_ID, TERMINAL_TAB_ID, useRightDock, useRightDockChatHost, useRightDockState } from '../RightDock';
+import { CHAT_TAB_ID, useRightDock, useRightDockChatHost, useRightDockState } from '../RightDock';
 import {
   createReferenceNodeDataSnapshot,
   ReferenceDrawer,
@@ -70,8 +70,7 @@ export const Workbench: React.FC<WorkbenchProps> = ({
   const chatHost = useRightDockChatHost();
   const chatPanelOpen = dockState.expanded && dockState.activeTabId === CHAT_TAB_ID;
   const terminalDockOpen = dockState.expanded
-    && dockState.terminalOpen
-    && dockState.activeTabId === TERMINAL_TAB_ID;
+    && dockState.terminalTabs.some((tab) => tab.id === dockState.activeTabId);
 
   const [referenceDrawerOpen, setReferenceDrawerOpen] = useState(false);
   const [referencesByWorkspace, setReferencesByWorkspace] = useState<Record<string, ReferenceEntry[]>>({});
@@ -489,14 +488,16 @@ export const Workbench: React.FC<WorkbenchProps> = ({
           )),
           chatHost,
         )}
-        <WorkspaceTerminalPortal
-          activeWorkspaceId={activeWorkspaceId}
-          workspaces={workspaces}
-          mountedWorkspaceIds={mountedWorkspaceIds}
-          allNodes={allNodes}
-          open={terminalDockOpen}
-          onClose={dock.closeTerminal}
-        />
+      <WorkspaceTerminalPortal
+        activeWorkspaceId={activeWorkspaceId}
+        workspaces={workspaces}
+        mountedWorkspaceIds={mountedWorkspaceIds}
+        allNodes={allNodes}
+        terminalTabsByWorkspace={dockState.terminalTabsByWorkspace}
+        activeTerminalTabId={dockState.activeTerminalTabId}
+        open={terminalDockOpen}
+        onClose={dock.closeTerminal}
+      />
       </FileNodeEditorRegistryProvider>
     </>
   );

--- a/apps/canvas-workspace/src/renderer/src/components/WorkspaceTerminalDock/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/WorkspaceTerminalDock/index.tsx
@@ -7,10 +7,13 @@ import type { CanvasNode, FileNodeData } from '../../types';
 import { AI_TOOL_PATTERN, writeCanvasContext } from '../../utils/canvasContextWriter';
 import { NodeMentionPicker } from '../NodeMentionPicker';
 import { useI18n } from '../../i18n';
+import { TERMINAL_TAB_ID } from '../RightDock/dock-store';
 import './index.css';
 
 interface WorkspaceTerminalDockProps {
   workspaceId: string;
+  terminalId?: string;
+  terminalTitle?: string;
   workspaceName?: string;
   rootFolder?: string;
   nodes: CanvasNode[];
@@ -53,6 +56,8 @@ function compactPath(value: string): string {
 
 export const WorkspaceTerminalDock = ({
   workspaceId,
+  terminalId = TERMINAL_TAB_ID,
+  terminalTitle,
   workspaceName,
   rootFolder,
   nodes,
@@ -81,7 +86,12 @@ export const WorkspaceTerminalDock = ({
   workspaceNameRef.current = workspaceName;
   heightRef.current = height;
 
-  const sessionId = useMemo(() => `workspace-terminal:${workspaceId}`, [workspaceId]);
+  const sessionId = useMemo(
+    () => terminalId === TERMINAL_TAB_ID
+      ? `workspace-terminal:${workspaceId}`
+      : `workspace-terminal:${workspaceId}:${terminalId}`,
+    [terminalId, workspaceId],
+  );
 
   const fitTerminal = useCallback(() => {
     const term = termRef.current;
@@ -292,7 +302,7 @@ export const WorkspaceTerminalDock = ({
 
   const displayedCwd = compactPath(cwd || '~');
   const title = placement === 'pane'
-    ? (workspaceName || t('workspaceTerminal.title'))
+    ? (terminalTitle || workspaceName || t('workspaceTerminal.title'))
     : t('workspaceTerminal.title');
 
   return (

--- a/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
+++ b/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
@@ -7,9 +7,9 @@ export const LANGUAGE_OPTIONS: Array<{
   label: string;
   nativeLabel: string;
 }> = [
-  { code: 'en', label: 'English', nativeLabel: 'English' },
-  { code: 'zh', label: 'Chinese', nativeLabel: '中文' },
-];
+    { code: 'en', label: 'English', nativeLabel: 'English' },
+    { code: 'zh', label: 'Chinese', nativeLabel: '中文' },
+  ];
 
 const en = {
   'app.untitledWorkspace': 'Untitled',
@@ -280,6 +280,9 @@ const en = {
   'canvas.toolbar.addWeb': 'Add Web Page',
   'canvas.toolbar.web': 'Web',
   'canvas.toolbar.addTerminal': 'Add Terminal',
+  'canvas.toolbar.showTerminal': 'Show Terminal',
+  'canvas.toolbar.hideTerminal': 'Hide Terminal',
+  'canvas.toolbar.newTerminal': 'New Terminal',
   'canvas.toolbar.terminal': 'Terminal',
   'canvas.toolbar.addCodingAgent': 'Add Coding Agent',
   'canvas.toolbar.coding': 'Coding',
@@ -425,8 +428,11 @@ const en = {
   'rightDock.ariaLabel': 'Chat and preview panel',
   'rightDock.resizePanel': 'Resize panel',
   'rightDock.tabs': 'Dock tabs',
-  'rightDock.chat': 'Chat',
+  'rightDock.chat': 'Pulse AI',
   'rightDock.terminal': 'Terminal',
+  'rightDock.terminalNumber': 'Terminal {number}',
+  'rightDock.renameTerminalHint': 'Double-click or press F2 to rename',
+  'rightDock.terminalNameInput': 'Terminal name',
   'rightDock.terminalDockHint': 'Open below the canvas as this workspace terminal.',
   'rightDock.closeTerminal': 'Close',
   'rightDock.closeTab': 'Close {title}',
@@ -1435,6 +1441,9 @@ const zh: Record<keyof typeof en, string> = {
   'canvas.toolbar.addWeb': '添加网页',
   'canvas.toolbar.web': '网页',
   'canvas.toolbar.addTerminal': '添加终端',
+  'canvas.toolbar.showTerminal': '显示终端',
+  'canvas.toolbar.hideTerminal': '隐藏终端',
+  'canvas.toolbar.newTerminal': '新建终端',
   'canvas.toolbar.terminal': '终端',
   'canvas.toolbar.addCodingAgent': '添加编码 Agent',
   'canvas.toolbar.coding': '编码',
@@ -1580,8 +1589,11 @@ const zh: Record<keyof typeof en, string> = {
   'rightDock.ariaLabel': '聊天与预览面板',
   'rightDock.resizePanel': '调整面板宽度',
   'rightDock.tabs': 'Dock 标签页',
-  'rightDock.chat': '聊天',
+  'rightDock.chat': 'Pulse AI',
   'rightDock.terminal': '终端',
+  'rightDock.terminalNumber': '终端 {number}',
+  'rightDock.renameTerminalHint': '双击或按 F2 重命名',
+  'rightDock.terminalNameInput': '终端名称',
   'rightDock.terminalDockHint': '已在画布下方作为当前工作区终端打开。',
   'rightDock.closeTerminal': '关闭',
   'rightDock.closeTab': '关闭 {title}',


### PR DESCRIPTION
## Summary

- Turn the bottom Terminal toolbar control into a split button that can open the current terminal area or create additional terminals once a terminal exists.
- Add multiple right-dock terminal tabs with close and inline rename support for terminal tabs only.
- Scope terminal tabs and active terminal state per workspace so switching workspaces does not leak terminal tabs, while keeping hidden terminal instances mounted so switching back preserves the running shell.

## Root cause

The earlier terminal dock state was global. That made terminal tabs appear in unrelated workspaces, and hiding the terminal host while switching to a workspace without terminals could unmount and clean up existing terminal sessions.

## Validation

- `pnpm --filter canvas-workspace exec vitest run src/renderer/src/components/RightDock/__tests__/dock-store.test.ts`
- `pnpm --filter canvas-workspace typecheck`
- `git diff --check`