### PR TITLE
[codex] Release Pulse Canvas 0.1.10

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.9",
+  "version": "0.1.10",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump `apps/canvas-workspace` to `0.1.10`.
- Publish the Pulse Canvas stable macOS arm64 DMG and blockmap to R2.
- Update the stable `latest.json` manifest and deploy the download page.
- Replace the placeholder release note with generated user-facing Chinese and English notes from the `0.1.9` to `0.1.10` diff.

## Release note

### 中文

- 终端现在支持在右侧 Dock 中同时打开多个会话，可重命名标签，并按工作区独立保留会话；切到没有终端的工作区时会回到 AI Chat，不会误带旧终端。
- Frame 和普通节点的缩放更顺手：Frame 支持八方向缩放、边缘手柄更容易抓取，折叠 Frame 会显示子内容摘要，普通节点也支持从左边缘调整大小。
- 右侧 Dock 和 Web 预览更清晰：链接标签会跟随网页 favicon，Web 节点标题栏更简洁。
- 聊天与终端细节继续打磨：粘贴代码时保留换行，终端启动空白和边缘裁切问题得到修复。

### English

- Terminal tabs in the right Dock now support multiple sessions, tab renaming, and workspace-scoped persistence; switching to a workspace without terminals falls back to AI Chat instead of carrying over old terminals.
- Frames and regular nodes are easier to resize: frames support eight-direction resizing, edge handles are easier to grab, collapsed frames show child summaries, and regular nodes can be resized from the left edge.
- Right Dock and web previews are clearer: link tabs follow the page favicon, and Web node header chrome is simpler.
- Chat and terminal polish: pasted code keeps its line breaks, and terminal startup blankness plus edge clipping issues are fixed.

## Published artifacts

- Manifest: https://downloads.jasperhu.art/pulse-canvas/stable/latest.json
- Download page: https://pulse-canvas-download.pages.dev/
- Install path: https://pulse-canvas-download.pages.dev/#install

## Validation

- Published `0.1.10` with `node ~/.codex/skills/pulse-canvas-release/scripts/release-pulse-canvas.mjs --version 0.1.10 --notes "Release notes pending diff generation." --no-build --use-proxy` after the arm64 DMG had already been built.
- Uploaded refreshed `latest.json` with generated release notes via `wrangler r2 object put ... --remote` using the detected proxy environment.
- Redeployed the download page with `wrangler pages deploy apps/canvas-workspace/release/download-site-dist --project-name pulse-canvas-download --branch main --commit-dirty=true`.
- Verified both `https://downloads.jasperhu.art/pulse-canvas/stable/latest.json` and `https://pulse-canvas-download.pages.dev/latest.json` report `version: 0.1.10` with the generated bilingual release notes.

## Notes

The first publish attempt without proxy was interrupted during upload before completion. The successful publish used `--use-proxy`; wrangler confirmed proxy usage and completed uploads for the DMG, blockmap, and manifest.