### PR TITLE
Improve workspace deletion UX with smart active selection

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -136,7 +136,7 @@ const AppContent = () => {
     reorderFolder,
   } = useWorkspaces();
 
-  const workbench = useWorkbenchState({ activeWorkspaceId: activeId });
+  const workbench = useWorkbenchState({ activeWorkspaceId: activeId, workspaces });
   const {
     activeNodes,
     selectedNodeIdsByWorkspace,
@@ -272,8 +272,8 @@ const AppContent = () => {
       description: workspace.name,
       autoCloseMs: 2400,
     });
-  }, [workspaces, confirm, notify, updateToast, deleteWorkspace, t]);
-
+    if (result.switchedToEmpty) enterChatView();
+  }, [workspaces, confirm, notify, updateToast, deleteWorkspace, enterChatView, t]);
 
   const handleExportWorkspace = useCallback(async (id: string) => {
     const workspace = workspaces.find((item) => item.id === id);

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
@@ -78,7 +78,7 @@ export const Workbench: React.FC<WorkbenchProps> = ({
   const [canvasClipboard, setCanvasClipboard] = useState<CanvasClipboard | null>(null);
   const [nodePatchRequest, setNodePatchRequest] = useState<CanvasNodePatchRequest | undefined>();
   const patchRequestIdRef = useRef(0);
-  const mountedWorkspaceIds = useMountedWorkspaceIds(activeWorkspaceId);
+  const mountedWorkspaceIds = useMountedWorkspaceIds(activeWorkspaceId, workspaces);
 
   useEffect(() => {
     for (const node of activeNodes) {

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/useMountedWorkspaceIds.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/useMountedWorkspaceIds.ts
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react';
 
-export const useMountedWorkspaceIds = (activeWorkspaceId: string) => {
+export const useMountedWorkspaceIds = (
+  activeWorkspaceId: string,
+  workspaces?: ReadonlyArray<{ id: string }>,
+) => {
   const [mountedWorkspaceIds, setMountedWorkspaceIds] = useState<Set<string>>(
     () => (activeWorkspaceId ? new Set([activeWorkspaceId]) : new Set()),
   );
@@ -14,6 +17,22 @@ export const useMountedWorkspaceIds = (activeWorkspaceId: string) => {
       return next;
     });
   }, [activeWorkspaceId]);
+
+  // Unmount workspaces that no longer exist so their canvases and chat panels
+  // tear down and stop holding onto state after deletion.
+  useEffect(() => {
+    if (!workspaces) return;
+    const valid = new Set(workspaces.map((w) => w.id));
+    setMountedWorkspaceIds((prev) => {
+      let changed = false;
+      const next = new Set<string>();
+      for (const id of prev) {
+        if (valid.has(id)) next.add(id);
+        else changed = true;
+      }
+      return changed ? next : prev;
+    });
+  }, [workspaces]);
 
   return mountedWorkspaceIds;
 };

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/useWorkbenchState.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/useWorkbenchState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { CanvasNode } from '../../types';
 import type { CanvasNodeRenameRequest } from '../../types/ui-interaction';
 
@@ -9,6 +9,7 @@ interface WorkbenchNodeRequest {
 
 interface UseWorkbenchStateOptions {
   activeWorkspaceId: string;
+  workspaces: ReadonlyArray<{ id: string }>;
 }
 
 export interface WorkbenchController {
@@ -43,6 +44,7 @@ const hasWorkspaceSnapshot = (
 
 export function useWorkbenchState({
   activeWorkspaceId,
+  workspaces,
 }: UseWorkbenchStateOptions): WorkbenchController {
   const [allNodes, setAllNodes] = useState<Record<string, CanvasNode[]>>({});
   const [selectedNodeIdsByWorkspace, setSelectedNodeIdsByWorkspace] = useState<Record<string, string[]>>({});
@@ -52,6 +54,26 @@ export function useWorkbenchState({
 
   const allNodesRef = useRef(allNodes);
   allNodesRef.current = allNodes;
+
+  // Drop cached state for workspaces that no longer exist (e.g. after a
+  // deletion) so their node snapshots and selections don't linger in memory.
+  useEffect(() => {
+    const valid = new Set(workspaces.map((w) => w.id));
+    setAllNodes((prev) => {
+      const keys = Object.keys(prev);
+      if (keys.every((key) => valid.has(key))) return prev;
+      const next: Record<string, CanvasNode[]> = {};
+      for (const key of keys) if (valid.has(key)) next[key] = prev[key];
+      return next;
+    });
+    setSelectedNodeIdsByWorkspace((prev) => {
+      const keys = Object.keys(prev);
+      if (keys.every((key) => valid.has(key))) return prev;
+      const next: Record<string, string[]> = {};
+      for (const key of keys) if (valid.has(key)) next[key] = prev[key];
+      return next;
+    });
+  }, [workspaces]);
 
   const ensureWorkspaceNodesLoaded = useCallback((workspaceId: string) => {
     if (hasWorkspaceSnapshot(allNodesRef.current, workspaceId)) return;

--- a/apps/canvas-workspace/src/renderer/src/hooks/useWorkspaces.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useWorkspaces.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { selectActiveAfterDeletion, type WorkspaceEntry } from './useWorkspaces';
+
+const ws = (id: string): WorkspaceEntry => ({ id, name: id });
+
+describe('selectActiveAfterDeletion', () => {
+  const list = [ws('a'), ws('b'), ws('c')];
+
+  it('keeps the active workspace when deleting a different one', () => {
+    expect(selectActiveAfterDeletion(list, 'b', 'a')).toEqual({
+      newActiveId: 'a',
+      switchedActive: false,
+    });
+  });
+
+  it('moves to the next sibling when deleting the active workspace', () => {
+    expect(selectActiveAfterDeletion(list, 'b', 'b')).toEqual({
+      newActiveId: 'c',
+      switchedActive: true,
+    });
+  });
+
+  it('falls back to the new last entry when deleting the active last workspace', () => {
+    expect(selectActiveAfterDeletion(list, 'c', 'c')).toEqual({
+      newActiveId: 'b',
+      switchedActive: true,
+    });
+  });
+
+  it('moves to the new first entry when deleting the active first workspace', () => {
+    expect(selectActiveAfterDeletion(list, 'a', 'a')).toEqual({
+      newActiveId: 'b',
+      switchedActive: true,
+    });
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/hooks/useWorkspaces.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useWorkspaces.ts
@@ -16,6 +16,15 @@ export interface FolderEntry {
 export interface WorkspaceDeleteResult {
   ok: boolean;
   error?: string;
+  /** True when the deleted workspace was active and we switched away from it. */
+  switchedActive?: boolean;
+  /** The workspace that became active (only set when `switchedActive`). */
+  newActiveId?: string;
+  /**
+   * True when the workspace we switched to has no saved nodes, so the canvas
+   * would only show the empty welcome hint. Callers may route to chat instead.
+   */
+  switchedToEmpty?: boolean;
 }
 
 export interface WorkspaceImportResult {
@@ -33,6 +42,27 @@ interface WorkspaceManifest {
 
 const MANIFEST_ID = '__workspaces__';
 const DEFAULT_WORKSPACE: WorkspaceEntry = { id: 'default', name: 'Workspace' };
+
+/**
+ * Choose which workspace becomes active after `deletedId` is removed. When the
+ * deleted workspace was the active one we move to the entry that now occupies
+ * its slot — its next sibling — and fall back to the new last entry when the
+ * last workspace was deleted. This mirrors tab-close behaviour instead of
+ * always jumping back to the first workspace.
+ */
+export const selectActiveAfterDeletion = (
+  workspaces: WorkspaceEntry[],
+  deletedId: string,
+  currentActiveId: string,
+): { newActiveId: string; switchedActive: boolean } => {
+  const remaining = workspaces.filter((w) => w.id !== deletedId);
+  if (currentActiveId !== deletedId || remaining.length === 0) {
+    return { newActiveId: currentActiveId, switchedActive: false };
+  }
+  const deletedIndex = workspaces.findIndex((w) => w.id === deletedId);
+  const adjacentIndex = Math.min(Math.max(deletedIndex, 0), remaining.length - 1);
+  return { newActiveId: remaining[adjacentIndex].id, switchedActive: true };
+};
 
 export const useWorkspaces = () => {
   const [workspaces, setWorkspaces] = useState<WorkspaceEntry[]>([DEFAULT_WORKSPACE]);
@@ -140,14 +170,27 @@ export const useWorkspaces = () => {
       }
 
       const next = current.filter((w) => w.id !== id);
-      const newActiveId =
-        activeIdRef.current === id ? next[0].id : activeIdRef.current;
+      const { newActiveId, switchedActive } = selectActiveAfterDeletion(
+        current,
+        id,
+        activeIdRef.current,
+      );
 
       setWorkspaces(next);
       saveManifest(next, newActiveId);
-      if (activeIdRef.current === id) setActiveId(newActiveId);
+      if (switchedActive) setActiveId(newActiveId);
 
-      return { ok: true };
+      // When the workspace we switched to has no saved nodes the canvas would
+      // only show the empty welcome hint, so report it back and let the caller
+      // route to AI chat instead of stranding the user on a blank canvas.
+      let switchedToEmpty = false;
+      if (switchedActive && api) {
+        const snapshot = await api.load(newActiveId);
+        const nodes = snapshot.ok ? snapshot.data?.nodes : undefined;
+        switchedToEmpty = !(Array.isArray(nodes) && nodes.length > 0);
+      }
+
+      return { ok: true, switchedActive, newActiveId, switchedToEmpty };
     },
     [saveManifest]
   );


### PR DESCRIPTION
## Summary
Enhances workspace deletion to provide better user experience by intelligently selecting which workspace becomes active after deletion, detecting when the new workspace is empty, and cleaning up stale cached state.

## Key Changes

- **Smart active workspace selection**: Introduced `selectActiveAfterDeletion()` function that mirrors tab-close behavior — when deleting the active workspace, it switches to the next sibling (or falls back to the new last entry if deleting the last workspace), rather than always jumping to the first workspace.

- **Empty workspace detection**: After switching to a new active workspace due to deletion, the code now checks if that workspace has any saved nodes. If empty, it returns `switchedToEmpty: true` to allow callers to route to chat instead of showing a blank canvas.

- **Enhanced deletion result**: `WorkspaceDeleteResult` now includes:
  - `switchedActive`: indicates if the active workspace was switched
  - `newActiveId`: the workspace that became active
  - `switchedToEmpty`: whether the new active workspace is empty

- **Memory cleanup on deletion**: 
  - `useWorkbenchState` now accepts `workspaces` prop and cleans up cached node snapshots and selections for deleted workspaces
  - `useMountedWorkspaceIds` now accepts `workspaces` prop and unmounts canvas/chat components for deleted workspaces to prevent state leakage

- **App-level routing**: `App.tsx` now calls `enterChatView()` when `switchedToEmpty` is true, automatically routing users to chat when they delete their last workspace with content.

- **Comprehensive test coverage**: Added `useWorkspaces.test.ts` with four test cases covering all deletion scenarios (deleting non-active, active middle/last/first workspaces).

## Implementation Details

The `selectActiveAfterDeletion` function uses the deleted workspace's index to find the adjacent entry in the remaining list, ensuring predictable and intuitive behavior that matches common UI patterns (like browser tab closing).

The empty workspace detection uses the existing `api.load()` mechanism to check if the snapshot contains any nodes, avoiding false positives from workspaces with only empty state.

https://claude.ai/code/session_014ugUSrch6zuZXJViZx9Nby