### PR TITLE
Add inline @ trigger and persistent button for node mentions

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentPicker.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentPicker.tsx
@@ -194,6 +194,7 @@ export const AgentPicker = ({
           nodes={mentionNodes ?? []}
           onSelect={promptMention.handleSelect}
           onClose={promptMention.handleClose}
+          triggerHint="@"
         />
       )}
       <div className="agent-card">

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTerminal.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentTerminal.tsx
@@ -3,6 +3,8 @@ import { AGENT_REGISTRY } from '../../config/agentRegistry';
 import { AgentIcon } from './AgentIcon';
 import { truncatePath } from './utils/terminal';
 import { useI18n, type I18nKey } from '../../i18n';
+import { MentionTriggerButton } from '../NodeMentionPicker/MentionTriggerButton';
+import { NODE_MENTION_SHORTCUT } from '../NodeMentionPicker';
 
 interface AgentTerminalProps {
   containerRef: React.RefObject<HTMLDivElement>;
@@ -14,6 +16,8 @@ interface AgentTerminalProps {
    *  doesn't stare at a black panel during the 1–3s Claude / Codex
    *  startup window. */
   loading?: boolean;
+  /** Opens the canvas node mention picker; omit to hide the trigger button. */
+  onMention?: () => void;
 }
 
 const FolderGlyph = () => (
@@ -39,6 +43,7 @@ export const AgentTerminal = ({
   agentType,
   cwd,
   loading = false,
+  onMention,
 }: AgentTerminalProps) => {
   const { t } = useI18n();
   const agentDef = AGENT_REGISTRY.find((a) => a.id === agentType);
@@ -93,6 +98,13 @@ export const AgentTerminal = ({
                 </span>
               </div>
             </div>
+          )}
+          {onMention && !loading && (
+            <MentionTriggerButton
+              label={t('nodeMention.triggerLabel')}
+              title={`${t('nodeMention.title')} · ${NODE_MENTION_SHORTCUT}`}
+              onClick={onMention}
+            />
           )}
         </div>
       </div>

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.tsx
@@ -147,6 +147,7 @@ export const AgentNodeBody = ({
         agentType={controller.selectedAgent || 'claude-code'}
         cwd={controller.data.cwd}
         loading={controller.loading || controller.teamAutoResumePending}
+        onMention={readOnly ? undefined : controller.openMentionPicker}
       />
     </>
   );

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/useAgentNodeController.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/useAgentNodeController.ts
@@ -1176,6 +1176,11 @@ export const useAgentNodeController = ({
     termRef.current?.focus();
   }, []);
 
+  const openMentionPicker = useCallback(() => {
+    if (readOnly) return;
+    setPickerOpen(true);
+  }, [readOnly]);
+
   const handleRestartSession = useCallback(async (options?: { skipPreflight?: boolean }) => {
     if (readOnly || isMirrorTerminal) return;
     const savedAgent = data.agentType || selectedAgent;
@@ -1253,6 +1258,7 @@ export const useAgentNodeController = ({
     handleLaunch,
     handleMentionClose,
     handleMentionSelect,
+    openMentionPicker,
     handlePickFolder,
     handleRestartSession,
     launchErrorCommand,

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
@@ -1392,6 +1392,7 @@ export const AgentTeamFrame = ({
           nodes={getAllNodes?.() ?? []}
           onSelect={commandMention.handleSelect}
           onClose={commandMention.handleClose}
+          triggerHint="@"
         />
       )}
       <div className="agent-team-command__copy">

--- a/apps/canvas-workspace/src/renderer/src/components/NodeMentionPicker/MentionTriggerButton.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeMentionPicker/MentionTriggerButton.tsx
@@ -1,0 +1,33 @@
+import './index.css';
+
+interface Props {
+  /** Short visible label, e.g. "Reference node". */
+  label: string;
+  /** Full tooltip / accessible name, including the shortcut. */
+  title: string;
+  onClick: () => void;
+}
+
+/**
+ * Persistent, compact affordance pinned to a terminal corner that opens the
+ * {@link NodeMentionPicker}. Terminals can't show an inline `@` trigger (xterm
+ * forwards keys to the PTY), so this keeps the feature discoverable without
+ * relying on the Ctrl/⌘+2 shortcut being known.
+ */
+export const MentionTriggerButton = ({ label, title, onClick }: Props) => (
+  <button
+    type="button"
+    className="node-mention-trigger"
+    title={title}
+    aria-label={title}
+    // Keep the terminal's focus/selection when launching the picker.
+    onMouseDown={(event) => event.preventDefault()}
+    onClick={(event) => {
+      event.stopPropagation();
+      onClick();
+    }}
+  >
+    <span className="node-mention-trigger__glyph" aria-hidden="true">@</span>
+    <span className="node-mention-trigger__label">{label}</span>
+  </button>
+);

--- a/apps/canvas-workspace/src/renderer/src/components/NodeMentionPicker/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeMentionPicker/index.css
@@ -155,3 +155,39 @@
   font-size: 11px;
   color: var(--text-muted);
 }
+
+/* Persistent launcher pinned to a terminal corner (MentionTriggerButton). */
+.node-mention-trigger {
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
+  z-index: 3;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 9px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  box-shadow: 0 6px 18px rgba(31, 41, 35, 0.1);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-family: var(--font);
+  line-height: 1.2;
+  cursor: pointer;
+  opacity: 0.72;
+  transition: opacity 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+
+.node-mention-trigger:hover,
+.node-mention-trigger:focus-visible {
+  opacity: 1;
+  color: var(--text);
+  border-color: var(--accent, #0f766e);
+  outline: none;
+}
+
+.node-mention-trigger__glyph {
+  font-weight: 700;
+  color: var(--accent, #0f766e);
+}

--- a/apps/canvas-workspace/src/renderer/src/components/NodeMentionPicker/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeMentionPicker/index.tsx
@@ -10,11 +10,20 @@ interface Props {
   nodes: CanvasNode[];
   onSelect: (node: CanvasNode) => void;
   onClose: () => void;
+  /**
+   * How this picker was opened, shown as the trigger hint in the header.
+   * Textarea surfaces pass `'@'` (inline trigger); terminals keep the
+   * keyboard shortcut. Defaults to {@link NODE_MENTION_SHORTCUT}.
+   */
+  triggerHint?: string;
 }
 
 const MAX_RESULTS = 20;
 
-export const NodeMentionPicker = ({ nodes, onSelect, onClose }: Props) => {
+/** Keyboard shortcut that opens the node mention picker in terminal surfaces. */
+export const NODE_MENTION_SHORTCUT = 'Ctrl/⌘+2';
+
+export const NodeMentionPicker = ({ nodes, onSelect, onClose, triggerHint = NODE_MENTION_SHORTCUT }: Props) => {
   const { t } = useI18n();
   const [query, setQuery] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -89,7 +98,7 @@ export const NodeMentionPicker = ({ nodes, onSelect, onClose }: Props) => {
       <div className="node-mention-picker" role="dialog" aria-label={t('nodeMention.title')} onClick={(e) => e.stopPropagation()}>
         <div className="node-mention-header">
           <span className="node-mention-label">{t('nodeMention.title')}</span>
-          <kbd className="node-mention-kbd">Ctrl/⌘+2</kbd>
+          <kbd className="node-mention-kbd">{triggerHint}</kbd>
         </div>
         <div className="node-mention-search">
           <input

--- a/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody/index.tsx
@@ -5,7 +5,8 @@ import { FitAddon } from '@xterm/addon-fit';
 import type { CanvasNode, TerminalNodeData } from '../../types';
 import { TERMINAL_OPTIONS } from '../../config/terminalTheme';
 import { buildNodeMentionInsertion } from '../../utils/nodeMention';
-import { NodeMentionPicker } from '../NodeMentionPicker';
+import { NodeMentionPicker, NODE_MENTION_SHORTCUT } from '../NodeMentionPicker';
+import { MentionTriggerButton } from '../NodeMentionPicker/MentionTriggerButton';
 import { fitTerminalWithCanvasScale, syncTerminalFontSizeToCanvas } from '../AgentNodeBody/utils/terminal';
 import { useI18n } from '../../i18n';
 import {
@@ -319,7 +320,7 @@ export const TerminalNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, o
       {!readOnly && mentionHintVisible && !pickerOpen && (
         <div className="terminal-mention-hint" role="status">
           <span>{t('terminal.mentionHint.prefix')}</span>
-          <kbd>Ctrl/⌘+2</kbd>
+          <kbd>{NODE_MENTION_SHORTCUT}</kbd>
           <span>{t('terminal.mentionHint.suffix')}</span>
           <button
             type="button"
@@ -330,6 +331,13 @@ export const TerminalNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, o
             ×
           </button>
         </div>
+      )}
+      {!readOnly && !pickerOpen && !mentionHintVisible && (
+        <MentionTriggerButton
+          label={t('nodeMention.triggerLabel')}
+          title={`${t('nodeMention.title')} · ${NODE_MENTION_SHORTCUT}`}
+          onClick={() => setPickerOpen(true)}
+        />
       )}
       <div
         ref={containerRef}

--- a/apps/canvas-workspace/src/renderer/src/components/WorkspaceTerminalDock/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/WorkspaceTerminalDock/index.tsx
@@ -5,7 +5,8 @@ import { FitAddon } from '@xterm/addon-fit';
 import { TERMINAL_OPTIONS } from '../../config/terminalTheme';
 import type { CanvasNode } from '../../types';
 import { buildNodeMentionInsertion } from '../../utils/nodeMention';
-import { NodeMentionPicker } from '../NodeMentionPicker';
+import { NodeMentionPicker, NODE_MENTION_SHORTCUT } from '../NodeMentionPicker';
+import { MentionTriggerButton } from '../NodeMentionPicker/MentionTriggerButton';
 import { useI18n } from '../../i18n';
 import { TERMINAL_TAB_ID } from '../RightDock/dock-store';
 import {
@@ -376,7 +377,7 @@ export const WorkspaceTerminalDock = ({
         {mentionHintVisible && !pickerOpen && (
           <div className="workspace-terminal-dock__mention-hint" role="status">
             <span>{t('terminal.mentionHint.prefix')}</span>
-            <kbd>Ctrl/⌘+2</kbd>
+            <kbd>{NODE_MENTION_SHORTCUT}</kbd>
             <span>{t('terminal.mentionHint.suffix')}</span>
             <button
               type="button"
@@ -387,6 +388,13 @@ export const WorkspaceTerminalDock = ({
               ×
             </button>
           </div>
+        )}
+        {!pickerOpen && !mentionHintVisible && (
+          <MentionTriggerButton
+            label={t('nodeMention.triggerLabel')}
+            title={`${t('nodeMention.title')} · ${NODE_MENTION_SHORTCUT}`}
+            onClick={() => setPickerOpen(true)}
+          />
         )}
         {booting && (
           <div className="workspace-terminal-dock__booting" aria-hidden="true">

--- a/apps/canvas-workspace/src/renderer/src/hooks/useTextareaMention.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useTextareaMention.ts
@@ -1,6 +1,7 @@
-import { useCallback, useState, type KeyboardEvent, type RefObject } from 'react';
+import { useCallback, useRef, useState, type KeyboardEvent, type RefObject } from 'react';
 import type { CanvasNode } from '../types';
 import { buildNodeMentionInsertion } from '../utils/nodeMention';
+import { isImeComposing } from '../utils/ime';
 
 interface Options {
   textareaRef: RefObject<HTMLTextAreaElement>;
@@ -12,26 +13,48 @@ interface Options {
 /**
  * Adds canvas "@" mention support to a plain <textarea>.
  *
- * The Terminal and the running Agent terminal open the NodeMentionPicker via
- * xterm's custom key handler and write the mention straight to the PTY. Plain
- * textareas (the Coding Agent setup prompt, the Agent Teams Team Lead brief)
- * have no PTY, so this hook wires the same Ctrl/Cmd+2 picker to instead insert
- * the mention text at the caret and keep the caret after it.
+ * Two ways to open the picker:
+ * - Type `@` at a word boundary (start of input or after whitespace). The `@`
+ *   is left in place while the picker is open and consumed when a node is
+ *   picked, so the caret text reads `… @[label](canvas:id) …`. Dismissing the
+ *   picker keeps the literal `@` (the user may have meant an address/handle).
+ * - Press Ctrl/Cmd+2 — inserts the mention at the current caret.
+ *
+ * The Terminal and the running Agent terminal can't intercept `@` (xterm
+ * forwards it straight to the PTY, where `@` is a common character), so they
+ * keep the Ctrl/Cmd+2 shortcut and a persistent trigger button instead.
  */
 export function useTextareaMention({ textareaRef, value, onChange, disabled }: Options) {
   const [pickerOpen, setPickerOpen] = useState(false);
+  // Index of the literal `@` that opened the picker via the inline trigger, or
+  // null when opened via Ctrl/Cmd+2 (insert at the caret instead).
+  const atIndexRef = useRef<number | null>(null);
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent): boolean => {
       if (disabled) return false;
+      if (isImeComposing(event)) return false;
+      // Ctrl/Cmd+2 — insert the mention at the caret.
       if (event.key === '2' && (event.metaKey || event.ctrlKey) && !event.altKey) {
         event.preventDefault();
+        atIndexRef.current = null;
         setPickerOpen(true);
         return true;
       }
+      // Inline `@` trigger at a word boundary. Let the `@` type normally; it is
+      // consumed when a node is picked.
+      if (event.key === '@' && !event.metaKey && !event.ctrlKey && !event.altKey) {
+        const caret = textareaRef.current?.selectionStart ?? value.length;
+        const prev = caret > 0 ? value[caret - 1] : '';
+        if (caret === 0 || /\s/.test(prev)) {
+          atIndexRef.current = caret;
+          setPickerOpen(true);
+        }
+        return false;
+      }
       return false;
     },
-    [disabled],
+    [disabled, textareaRef, value],
   );
 
   const handleSelect = useCallback(
@@ -39,14 +62,17 @@ export function useTextareaMention({ textareaRef, value, onChange, disabled }: O
       setPickerOpen(false);
       if (disabled) return;
       const textarea = textareaRef.current;
-      const start = textarea?.selectionStart ?? value.length;
-      const end = textarea?.selectionEnd ?? value.length;
-      const mention = buildNodeMentionInsertion(node, {
-        before: value.slice(0, start),
-        after: value.slice(end),
-      });
-      const next = `${value.slice(0, start)}${mention}${value.slice(end)}`;
-      onChange(next);
+      const atIndex = atIndexRef.current;
+      atIndexRef.current = null;
+
+      // Inline `@` trigger: replace the literal `@` at atIndex with the mention.
+      // Otherwise (Ctrl/Cmd+2) insert at the current selection.
+      const start = atIndex ?? textarea?.selectionStart ?? value.length;
+      const end = atIndex !== null ? atIndex + 1 : textarea?.selectionEnd ?? value.length;
+      const before = value.slice(0, start);
+      const after = value.slice(end);
+      const mention = buildNodeMentionInsertion(node, { before, after });
+      onChange(`${before}${mention}${after}`);
       const caret = start + mention.length;
       requestAnimationFrame(() => {
         const el = textareaRef.current;
@@ -60,6 +86,7 @@ export function useTextareaMention({ textareaRef, value, onChange, disabled }: O
 
   const handleClose = useCallback(() => {
     setPickerOpen(false);
+    atIndexRef.current = null;
     textareaRef.current?.focus();
   }, [textareaRef]);
 

--- a/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
+++ b/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
@@ -520,7 +520,8 @@ const en = {
   'chat.mention.projectFiles': 'Project Files',
   'chat.mention.projectFolders': 'Project Folders',
 
-  'nodeMention.title': '@ Reference a node',
+  'nodeMention.title': 'Reference a node',
+  'nodeMention.triggerLabel': 'Reference node',
   'nodeMention.searchPlaceholder': 'Search node names...',
   'nodeMention.empty': 'No matching nodes',
   'nodeMention.untitled': '(untitled)',
@@ -1684,7 +1685,8 @@ const zh: Record<keyof typeof en, string> = {
   'chat.mention.projectFiles': '项目文件',
   'chat.mention.projectFolders': '项目文件夹',
 
-  'nodeMention.title': '@ 引用节点',
+  'nodeMention.title': '引用节点',
+  'nodeMention.triggerLabel': '引用节点',
   'nodeMention.searchPlaceholder': '搜索节点名称...',
   'nodeMention.empty': '无匹配节点',
   'nodeMention.untitled': '（未命名）',


### PR DESCRIPTION
## Summary
Enhances the node mention picker with two new affordances: an inline `@` trigger at word boundaries (for textareas) and a persistent corner button (for terminals). This makes the feature more discoverable and aligns with common mention patterns.

## Key Changes

- **Inline `@` trigger for textareas**: Typing `@` at a word boundary (start of input or after whitespace) opens the picker while leaving the `@` in place. The `@` is consumed when a node is selected, or kept if the picker is dismissed.

- **Persistent trigger button**: Added `MentionTriggerButton` component that appears in terminal corners (TerminalNodeBody, WorkspaceTerminalDock, AgentNodeBody) when the mention hint is not visible. Provides a discoverable alternative to the Ctrl/⌘+2 shortcut.

- **IME composition handling**: Added `isImeComposing()` check to prevent triggering the picker during IME input (e.g., CJK text composition).

- **Refactored mention insertion logic**: Updated `useTextareaMention` to track whether the picker was opened via inline `@` (stored in `atIndexRef`) or Ctrl/⌘+2, then insert/replace accordingly.

- **Updated picker header**: Made `triggerHint` prop configurable on `NodeMentionPicker` to show `@` for inline triggers or `Ctrl/⌘+2` for keyboard shortcuts. Exported `NODE_MENTION_SHORTCUT` constant for reuse.

- **i18n updates**: Removed `@` from `nodeMention.title` (now just "Reference a node") and added `nodeMention.triggerLabel` for the button label.

## Implementation Details

- The inline trigger only activates at word boundaries to avoid interfering with email addresses or handles.
- `atIndexRef` is reset after picker close or selection to ensure clean state.
- The trigger button uses `onMouseDown` preventDefault to preserve terminal focus/selection.
- Terminals show the button only when the mention hint is hidden, avoiding UI clutter.

https://claude.ai/code/session_01JZ6M1HY4NeVSKab5ciUurH