### PR TITLE
Remove embedded prop from ReferenceSourcePreview, always embed

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/ReferenceSourcePreview.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/ReferenceSourcePreview.tsx
@@ -3,7 +3,6 @@ import type { CanvasNodeViewProps } from './types';
 
 interface ReferenceSourcePreviewProps {
   CanvasNodeViewComponent: React.ComponentType<CanvasNodeViewProps>;
-  embedded: boolean;
   handleReferenceSourceUpdate: (sourceId: string, patch: Partial<CanvasNode>) => void;
   isSelected: boolean;
   node: CanvasNode;
@@ -16,9 +15,20 @@ interface ReferenceSourcePreviewProps {
   workspaceLabel: string;
 }
 
+/**
+ * Renders the referenced node as a preview inside the reference card.
+ *
+ * The inner node is ALWAYS `embedded`: the reference card owns the header
+ * chrome (badge, source label, open-source, close), so the preview must not
+ * draw its own close/fullscreen/resize controls. When the source is editable
+ * (`onUpdateReferenceSource` provided) the inner node would otherwise render
+ * as a normal node and float those controls over the content — duplicating
+ * the card's close button and covering the preview. `embedded` hides that
+ * chrome via CSS, fills the card, and picks up the reference's selected ring
+ * while keeping the body editable.
+ */
 export const ReferenceSourcePreview = ({
   CanvasNodeViewComponent,
-  embedded,
   handleReferenceSourceUpdate,
   isSelected,
   node,
@@ -55,6 +65,6 @@ export const ReferenceSourcePreview = ({
     onSelect={() => onSelect(node.id)}
     onFocus={() => undefined}
     readOnly={readOnly || !onUpdateReferenceSource}
-    embedded={embedded}
+    embedded
   />
 );

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -135,7 +135,6 @@ const CanvasNodeViewComponent = ({
         renderReferenceSource={(sourceNode, workspaceLabel) => (
           <ReferenceSourcePreview
             CanvasNodeViewComponent={CanvasNodeView}
-            embedded={embedded}
             handleReferenceSourceUpdate={viewModel.handleReferenceSourceUpdate}
             isSelected={isSelected}
             node={node}


### PR DESCRIPTION
## Summary
Simplifies the `ReferenceSourcePreview` component by removing the `embedded` prop and always rendering the inner node as embedded. The `embedded` state is now hardcoded since the reference card always owns the header chrome and the preview must never render its own close/fullscreen/resize controls.

## Changes
- **Removed `embedded` prop** from `ReferenceSourcePreviewProps` interface
- **Removed `embedded` parameter** from the component function signature
- **Hardcoded `embedded={true}`** when rendering the inner `CanvasNodeViewComponent`
- **Updated call site** in `CanvasNodeView/index.tsx` to no longer pass the `embedded` prop
- **Added comprehensive JSDoc comment** explaining why the inner node is always embedded:
  - The reference card owns the header chrome (badge, source label, open-source, close buttons)
  - The preview must not draw its own close/fullscreen/resize controls
  - When the source is editable, the inner node would otherwise render as a normal node and float controls over content, duplicating the card's close button
  - The `embedded` CSS class hides that chrome, fills the card, and picks up the reference's selected ring while keeping the body editable

## Implementation Details
This change reflects that embedding is not a configurable behavior for reference source previews—it's a requirement of the design. The reference card's ownership of the UI chrome means the inner node must always be in embedded mode to avoid control duplication and maintain proper visual hierarchy.

https://claude.ai/code/session_01TDTQpWtD9XEM3Fo9vZ6nQc