### PR TITLE
release(canvas): 0.1.11

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.10",
+  "version": "0.1.11",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump Pulse Canvas to 0.1.11.
- Published the macOS arm64 DMG, blockmap, and latest.json to R2.
- Deployed the download page for the stable channel.

## Release notes
中文：飞书机器人现在可以读取用户发送的图片，并支持把画布、窗口或应用截图回传到聊天。参考卡片选中后仍可拖拽，预览内容不再被遮挡，来源标识更清晰。优化删除工作区后的跳转、图层名称显示和存储提示。

English: The Feishu bot can now read images users send and deliver canvas, window, or app screenshots back to chat. Reference cards remain draggable when selected, preview content is no longer covered, and source labels are clearer. Workspace deletion flow, layer name display, and storage notices were polished.

## Verification
- Ran release script for 0.1.11 with macOS arm64 packaging.
- Direct R2 upload failed with Cloudflare fetch failure; retried with --no-build --use-proxy and completed upload/deploy.
- Verified remote manifest: https://downloads.jasperhu.art/pulse-canvas/stable/latest.json reports version 0.1.11 and preserves release history.
- Verified download page returns 200: https://pulse-canvas-download.pages.dev/

## Post-merge
- After this PR is merged into master, create and push the annotated tag: pulse-canvas-v0.1.11.