### PR TITLE
feat(canvas-note): add interaction foundation

### DIFF
--- a/apps/canvas-workspace/docs/note-interaction-foundation.md
+++ b/apps/canvas-workspace/docs/note-interaction-foundation.md
@@ -1,0 +1,104 @@
+# Canvas Note interaction foundation
+
+PR 682 is no longer a single find-bar enhancement. It is the first pass at
+turning the file note node into a Notion-like editing surface. Keep the scope
+focused on interaction ownership and persistence reliability; avoid adding more
+block types until these foundations are predictable.
+
+## Phase 0 scope
+
+Keep these behaviors in PR 682:
+
+- Find options: match case, whole word, regex, invalid-regex feedback, and
+  replace behavior.
+- Inline authoring: slash commands, callout, date, images from paste/drop/file,
+  and node mentions.
+- Navigation: heading outline and mention-click node focus.
+- Keyboard ownership: note-local Cmd/Ctrl+S and Cmd/Ctrl+F only for the focused
+  editor.
+- Persistence safety: markdown round-trip for callouts, node links, local
+  images, and empty paragraphs.
+
+Defer these behaviors until after Phase 0:
+
+- Drag-to-reorder blocks.
+- Block handles and multi-block selection.
+- Hover previews for node mentions.
+- Backlinks or automatic reference indexes.
+- Rich callout icon pickers and color variants.
+
+## Interaction ownership
+
+The note editor has one interaction controller. New note surfaces should route
+through it instead of adding independent state in individual components.
+
+| Surface | Owner | Coexists with | Closes |
+| --- | --- | --- | --- |
+| Slash menu | `useNoteInteractionController` | Outline | Mention, bubble, link prompt |
+| Mention menu | `useNoteInteractionController` | Outline | Slash, bubble, link prompt |
+| Selection bubble | `useNoteInteractionController` | Outline | Slash, mention, link prompt, find |
+| Find bar | `useNoteInteractionController` | Outline | Slash, mention, bubble, link prompt |
+| Link prompt | `useNoteInteractionController` | Outline | Slash, mention, bubble, find |
+| Outline | `useNoteInteractionController` | Find, editor typing | Slash, mention, bubble, link prompt on toggle |
+
+Keyboard rules:
+
+- Slash and mention menus capture ArrowUp, ArrowDown, Enter, and Escape only
+  while their menu is open.
+- IME composition owns ArrowUp, ArrowDown, Enter, and Escape; note menus must not
+  intercept those keys while composing.
+- Cmd/Ctrl+S and Cmd/Ctrl+F are handled only by the focused note editor.
+- Escape should close the active note-local surface before falling through to
+  broader canvas or app surfaces.
+
+Layering rules:
+
+- Portal menus that are positioned against the viewport use
+  `--layer-note-popover`.
+- Absolute panels inside the note card use the local `--note-layer-panel`.
+- Do not add new hardcoded high z-index values for note surfaces.
+
+## Node-link semantics
+
+Node mentions are canvas-native links, not ordinary external URLs.
+
+- New mentions use `pulse-canvas://node/<nodeId>?workspace=<workspaceId>`.
+- Legacy mentions without workspace are still valid and resolve in the active
+  workspace.
+- A click on a node mention dispatches the node-focus bridge.
+- If the target is known to be missing in the current workspace, the note shows
+  a local missing-target status instead of navigating nowhere.
+
+## Manual QA path
+
+Run this path before force-pushing PR 682:
+
+1. Create or open a file note node.
+2. Type `/h1`, select Heading 1 with keyboard, and confirm the slash menu closes.
+3. Type `/callout`, add body text, then use Enter and Backspace around the block.
+4. Type `/date` and confirm the inserted date does not reopen the slash menu.
+5. Type `@`, select another canvas node, then click the mention and confirm the
+   target node is selected and focused.
+6. Delete the mentioned target node, click the old mention, and confirm the note
+   reports a missing node without opening an external URL.
+7. Paste an image from the clipboard, drag an image file into the note, and paste
+   a bare image URL.
+8. Select text, use the bubble menu for bold/link, then confirm the bubble does
+   not appear while slash, mention, find, or link prompt is open.
+9. Use Cmd/Ctrl+F in the focused note, test match case, whole word, regex,
+   invalid regex, replace current, and replace all.
+10. Open the outline, move the caret between headings, and confirm the active
+    outline row tracks the current section.
+11. Save, close/reopen the note, and confirm callouts, mentions, images, empty
+    paragraphs, and headings round-trip through markdown.
+
+## Test focus
+
+Automated tests should stay close to pure or stable seams:
+
+- search matching options and zero-width regex behavior;
+- node-link href build/parse compatibility;
+- mention detection/filtering;
+- image insert helpers;
+- markdown round-trip tests for custom nodes when the DOM test environment is
+  installed.

--- a/apps/canvas-workspace/docs/renderer-surfaces.md
+++ b/apps/canvas-workspace/docs/renderer-surfaces.md
@@ -90,6 +90,7 @@ Defined in `src/renderer/src/styles.css` (`:root`), low → high:
 | `--layer-fullscreen-chrome` | 1010 | fullscreen chip |
 | `--layer-dock` | 1100 | RightDock (artifact / link previews) |
 | `--layer-search` | 1500 | find-in-canvas bar |
+| `--layer-note-popover` | 1550 | note slash / mention / selection bubble menus |
 | `--layer-interaction-shield` | 1800 | drag shield over webviews |
 | `--layer-modal` | 1900 | settings drawers |
 | `--layer-palette` | 2000 | command palette |
@@ -97,8 +98,8 @@ Defined in `src/renderer/src/styles.css` (`:root`), low → high:
 | `--layer-toast` | 2100 | app-shell toasts |
 
 Known stragglers not yet on the scale (anchored popovers, lower risk):
-`NodeContextMenu` (1000), `FileNodeBubbleMenu` (9000), and various
-chat-internal overlays. Migrate them opportunistically when touched.
+`NodeContextMenu` (1000) and various chat-internal overlays. Migrate them
+opportunistically when touched.
 
 ## History
 

--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -138,6 +138,7 @@
     "electron": "^30.0.0",
     "electron-builder": "^26.8.1",
     "electron-vite": "^2.3.0",
+    "happy-dom": "^20.10.6",
     "picocolors": "^1.1.1",
     "typescript": "^5.6.3",
     "vitest": "^1.0.0"

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/DefaultCanvasNode.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/DefaultCanvasNode.tsx
@@ -220,7 +220,7 @@ export const DefaultCanvasNode = ({
       {!frameBodyOnly && header}
       <div className="node-body" onMouseDown={handleNodeBodyMouseDown}>
         {node.type === 'file' ? (
-          <FileNodeBody node={node} onUpdate={onUpdate} workspaceId={workspaceId} readOnly={readOnly} />
+          <FileNodeBody node={node} onUpdate={onUpdate} workspaceId={workspaceId} getAllNodes={getAllNodes} readOnly={readOnly} />
         ) : node.type === 'terminal' ? (
           <TerminalNodeBody node={node} getAllNodes={getAllNodes} rootFolder={rootFolder} workspaceId={workspaceId} workspaceName={workspaceName} onUpdate={onUpdate} readOnly={readOnly} />
         ) : node.type === 'frame' || node.type === 'group' ? (

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.css
@@ -50,6 +50,34 @@
   background: var(--accent-soft-strong, rgba(59, 130, 246, 0.22));
 }
 
+/* Callout block: an emoji badge (the data-callout attr) + quoted content. */
+.note-callout {
+  position: relative;
+  margin: 10px 0;
+  padding: 10px 14px 10px 40px;
+  border-radius: 6px;
+  background: var(--accent-soft, rgba(59, 130, 246, 0.08));
+  border: 1px solid var(--border-light);
+}
+
+.note-callout::before {
+  content: attr(data-callout);
+  position: absolute;
+  left: 13px;
+  top: 9px;
+  font-size: 16px;
+  line-height: 1.5;
+  user-select: none;
+}
+
+.note-callout > :first-child {
+  margin-top: 0;
+}
+
+.note-callout > :last-child {
+  margin-bottom: 0;
+}
+
 .note-tiptap-editor {
   flex: 1;
   overflow-y: auto;

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.css
@@ -4,6 +4,7 @@
   height: 100%;
   position: relative;
   background: var(--note-paper, #fdfcf9);
+  --note-layer-panel: 50;
 }
 
 /* The filename used to live in its own bar; in the Notion/Heptabase

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.css
@@ -33,6 +33,23 @@
   flex-direction: column;
 }
 
+/* Node-mention chips: `@`-links to other canvas nodes, rendered inline. */
+.note-tiptap-editor a[href^='pulse-canvas://node/'] {
+  padding: 1px 5px;
+  margin: 0 1px;
+  border-radius: 5px;
+  background: var(--accent-soft, rgba(59, 130, 246, 0.12));
+  color: var(--accent, #2f6df6);
+  text-decoration: none;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.note-tiptap-editor a[href^='pulse-canvas://node/']:hover {
+  background: var(--accent-soft-strong, rgba(59, 130, 246, 0.22));
+}
+
 .note-tiptap-editor {
   flex: 1;
   overflow-y: auto;

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.tsx
@@ -4,10 +4,13 @@ import { EditorContent } from '@tiptap/react';
 import type { CanvasNode, FileNodeData } from '../../types';
 import { useFileNodeEditor, getMarkdown } from '../../hooks/useFileNodeEditor';
 import { useFileNodeEditorRegistry } from '../../hooks/useFileNodeEditorRegistry';
+import { useNoteMentions } from '../../hooks/useNoteMentions';
 import { filterCmds } from '../../editor/slashCommands';
+import { dispatchOpenNode, nodeIdFromHref } from '../../utils/openNodeBridge';
 import { FileNodeToolbar } from '../FileNodeToolbar';
 import { FileNodeBubbleMenu } from '../FileNodeBubbleMenu';
 import { SlashCommandMenu } from '../SlashCommandMenu';
+import { NoteMentionMenu } from '../NoteMentionMenu';
 import { NoteFindBar } from '../NoteFindBar';
 import { NoteOutline } from '../NoteOutline';
 import { NoteLinkPrompt } from '../NoteLinkPrompt';
@@ -17,10 +20,12 @@ interface Props {
   node: CanvasNode;
   onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
   workspaceId?: string;
+  /** Snapshot accessor for the workspace's nodes, used to populate @-mentions. */
+  getAllNodes?: () => CanvasNode[];
   readOnly?: boolean;
 }
 
-export const FileNodeBody = ({ node, onUpdate, workspaceId, readOnly = false }: Props) => {
+export const FileNodeBody = ({ node, onUpdate, workspaceId, getAllNodes, readOnly = false }: Props) => {
   const data = node.data as FileNodeData;
   const { openLink } = useRightDock();
   const [modified, setModified] = useState(false);
@@ -80,6 +85,13 @@ export const FileNodeBody = ({ node, onUpdate, workspaceId, readOnly = false }: 
     setModified,
     persistToFile,
     onUpdate,
+    readOnly,
+  });
+
+  const mentionCandidates = getAllNodes ? getAllNodes().filter((n) => n.id !== node.id) : [];
+  const { mentionMenu, filteredMentions, insertMention, closeMention } = useNoteMentions({
+    editor,
+    candidates: mentionCandidates,
     readOnly,
   });
 
@@ -167,12 +179,21 @@ export const FileNodeBody = ({ node, onUpdate, workspaceId, readOnly = false }: 
     (e: React.MouseEvent<HTMLDivElement>) => {
       const anchor = (e.target as HTMLElement).closest?.('a');
       const href = anchor?.getAttribute('href')?.trim();
-      if (!href || !/^https?:\/\//i.test(href)) return;
+      if (!href) return;
+      // A node mention focuses its target node instead of opening a URL.
+      const mentionedNodeId = nodeIdFromHref(href);
+      if (mentionedNodeId) {
+        e.preventDefault();
+        e.stopPropagation();
+        dispatchOpenNode({ workspaceId: workspaceId ?? '', nodeId: mentionedNodeId });
+        return;
+      }
+      if (!/^https?:\/\//i.test(href)) return;
       e.preventDefault();
       e.stopPropagation();
       openLink(href);
     },
-    [openLink],
+    [openLink, workspaceId],
   );
 
   const filePath = data.filePath;
@@ -239,6 +260,17 @@ export const FileNodeBody = ({ node, onUpdate, workspaceId, readOnly = false }: 
           items={filterCmds(slashMenu.query)}
           onSelect={handleSlashSelect}
           onClose={() => setSlashMenu(null)}
+        />
+      )}
+
+      {!readOnly && mentionMenu && (
+        <NoteMentionMenu
+          x={mentionMenu.x}
+          y={mentionMenu.y}
+          items={filteredMentions}
+          selectedIndex={mentionMenu.index}
+          onSelect={insertMention}
+          onClose={closeMention}
         />
       )}
     </div>

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.tsx
@@ -6,7 +6,7 @@ import { useFileNodeEditor, getMarkdown } from '../../hooks/useFileNodeEditor';
 import { useFileNodeEditorRegistry } from '../../hooks/useFileNodeEditorRegistry';
 import { useNoteMentions } from '../../hooks/useNoteMentions';
 import { filterCmds } from '../../editor/slashCommands';
-import { dispatchOpenNode, nodeIdFromHref } from '../../utils/openNodeBridge';
+import { dispatchOpenNode, parseNodeLinkHref } from '../../utils/openNodeBridge';
 import { FileNodeToolbar } from '../FileNodeToolbar';
 import { FileNodeBubbleMenu } from '../FileNodeBubbleMenu';
 import { SlashCommandMenu } from '../SlashCommandMenu';
@@ -30,7 +30,7 @@ export const FileNodeBody = ({ node, onUpdate, workspaceId, getAllNodes, readOnl
   const { openLink } = useRightDock();
   const [modified, setModified] = useState(false);
   const [statusText, setStatusText] = useState('');
-  const [outlineOpen, setOutlineOpen] = useState(false);
+  const cardRef = useRef<HTMLDivElement>(null);
   const dataRef = useRef(data);
   dataRef.current = data;
   const nodeIdRef = useRef(node.id);
@@ -62,8 +62,8 @@ export const FileNodeBody = ({ node, onUpdate, workspaceId, getAllNodes, readOnl
 
   const {
     editor,
+    interactions,
     slashMenu,
-    setSlashMenu,
     bubble,
     handleSlashSelect,
     linkPrompt,
@@ -76,6 +76,9 @@ export const FileNodeBody = ({ node, onUpdate, workspaceId, getAllNodes, readOnl
     findBarOpen,
     openFindBar,
     closeFindBar,
+    outlineOpen,
+    toggleOutline,
+    closeOutline,
   } = useFileNodeEditor({
     data,
     nodeIdRef,
@@ -93,7 +96,46 @@ export const FileNodeBody = ({ node, onUpdate, workspaceId, getAllNodes, readOnl
     editor,
     candidates: mentionCandidates,
     readOnly,
+    workspaceId,
+    interactions,
   });
+
+  useEffect(() => {
+    if (
+      readOnly ||
+      !outlineOpen ||
+      slashMenu ||
+      mentionMenu ||
+      linkPrompt ||
+      findBarOpen
+    ) {
+      return;
+    }
+
+    const handler = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape' || event.defaultPrevented) return;
+      const target = event.target instanceof Node ? event.target : null;
+      const eventBelongsToThisNote =
+        (target && cardRef.current?.contains(target)) || editor?.isFocused;
+      if (!eventBelongsToThisNote) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      closeOutline();
+    };
+
+    window.addEventListener('keydown', handler, true);
+    return () => window.removeEventListener('keydown', handler, true);
+  }, [
+    editor,
+    findBarOpen,
+    linkPrompt,
+    mentionMenu,
+    outlineOpen,
+    readOnly,
+    slashMenu,
+    closeOutline,
+  ]);
 
   // Publish this node's editor to the canvas-level registry so the
   // Ctrl/Cmd+F find bar can push its query into our NoteSearchExtension
@@ -181,11 +223,17 @@ export const FileNodeBody = ({ node, onUpdate, workspaceId, getAllNodes, readOnl
       const href = anchor?.getAttribute('href')?.trim();
       if (!href) return;
       // A node mention focuses its target node instead of opening a URL.
-      const mentionedNodeId = nodeIdFromHref(href);
-      if (mentionedNodeId) {
+      const nodeLink = parseNodeLinkHref(href);
+      if (nodeLink) {
         e.preventDefault();
         e.stopPropagation();
-        dispatchOpenNode({ workspaceId: workspaceId ?? '', nodeId: mentionedNodeId });
+        const targetWorkspaceId = nodeLink.workspaceId ?? workspaceId ?? '';
+        const targetNodeKnown = !getAllNodes || getAllNodes().some((item) => item.id === nodeLink.nodeId);
+        if (!targetNodeKnown && targetWorkspaceId === (workspaceId ?? '')) {
+          showStatus('Missing node');
+          return;
+        }
+        dispatchOpenNode({ workspaceId: targetWorkspaceId, nodeId: nodeLink.nodeId });
         return;
       }
       if (!/^https?:\/\//i.test(href)) return;
@@ -193,14 +241,14 @@ export const FileNodeBody = ({ node, onUpdate, workspaceId, getAllNodes, readOnl
       e.stopPropagation();
       openLink(href);
     },
-    [openLink, workspaceId],
+    [getAllNodes, openLink, showStatus, workspaceId],
   );
 
   const filePath = data.filePath;
   const fileName = filePath ? filePath.split('/').pop() : null;
 
   return (
-    <div className="note-card">
+    <div ref={cardRef} className="note-card">
       {!readOnly && (
         <FileNodeToolbar
           onOpenFile={handleOpenFile}
@@ -208,7 +256,7 @@ export const FileNodeBody = ({ node, onUpdate, workspaceId, getAllNodes, readOnl
           onSaveAs={handleSaveAs}
           onInsertImage={openImagePicker}
           onOpenFind={openFindBar}
-          onToggleOutline={() => setOutlineOpen((v) => !v)}
+          onToggleOutline={toggleOutline}
           outlineOpen={outlineOpen}
           statusText={statusText}
           modified={modified}
@@ -220,7 +268,7 @@ export const FileNodeBody = ({ node, onUpdate, workspaceId, getAllNodes, readOnl
       {!readOnly && findBarOpen && editor && <NoteFindBar editor={editor} onClose={closeFindBar} />}
 
       {!readOnly && outlineOpen && editor && (
-        <NoteOutline editor={editor} onClose={() => setOutlineOpen(false)} />
+        <NoteOutline editor={editor} onClose={closeOutline} />
       )}
 
       {!readOnly && linkPrompt && (
@@ -259,7 +307,7 @@ export const FileNodeBody = ({ node, onUpdate, workspaceId, getAllNodes, readOnl
           selectedIndex={slashMenu.index}
           items={filterCmds(slashMenu.query)}
           onSelect={handleSlashSelect}
-          onClose={() => setSlashMenu(null)}
+          onClose={interactions.closeSlashMenu}
         />
       )}
 

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.tsx
@@ -9,6 +9,7 @@ import { FileNodeToolbar } from '../FileNodeToolbar';
 import { FileNodeBubbleMenu } from '../FileNodeBubbleMenu';
 import { SlashCommandMenu } from '../SlashCommandMenu';
 import { NoteFindBar } from '../NoteFindBar';
+import { NoteOutline } from '../NoteOutline';
 import { NoteLinkPrompt } from '../NoteLinkPrompt';
 import { useRightDock } from '../RightDock';
 
@@ -24,6 +25,7 @@ export const FileNodeBody = ({ node, onUpdate, workspaceId, readOnly = false }: 
   const { openLink } = useRightDock();
   const [modified, setModified] = useState(false);
   const [statusText, setStatusText] = useState('');
+  const [outlineOpen, setOutlineOpen] = useState(false);
   const dataRef = useRef(data);
   dataRef.current = data;
   const nodeIdRef = useRef(node.id);
@@ -185,6 +187,8 @@ export const FileNodeBody = ({ node, onUpdate, workspaceId, readOnly = false }: 
           onSaveAs={handleSaveAs}
           onInsertImage={openImagePicker}
           onOpenFind={openFindBar}
+          onToggleOutline={() => setOutlineOpen((v) => !v)}
+          outlineOpen={outlineOpen}
           statusText={statusText}
           modified={modified}
           fileName={fileName}
@@ -193,6 +197,10 @@ export const FileNodeBody = ({ node, onUpdate, workspaceId, readOnly = false }: 
       )}
 
       {!readOnly && findBarOpen && editor && <NoteFindBar editor={editor} onClose={closeFindBar} />}
+
+      {!readOnly && outlineOpen && editor && (
+        <NoteOutline editor={editor} onClose={() => setOutlineOpen(false)} />
+      )}
 
       {!readOnly && linkPrompt && (
         <NoteLinkPrompt

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBubbleMenu/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBubbleMenu/index.css
@@ -1,6 +1,6 @@
 .note-bubble-menu {
   position: fixed;
-  z-index: 9000;
+  z-index: var(--layer-note-popover);
   /* transform (above vs below the selection) is set inline by the
      component, which clamps the menu into the viewport. */
   display: flex;

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBubbleMenu/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBubbleMenu/index.tsx
@@ -2,11 +2,11 @@ import { useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import './index.css';
 import type { Editor } from '@tiptap/react';
-import type { BubbleState } from '../../hooks/useFileNodeEditor';
+import type { NoteBubbleState } from '../../hooks/useNoteInteractionController';
 
 interface Props {
   editor: Editor;
-  bubble: BubbleState;
+  bubble: NoteBubbleState;
   onOpenLinkPrompt: () => void;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeToolbar/index.tsx
@@ -6,6 +6,8 @@ interface Props {
   onSaveAs: () => void;
   onInsertImage: () => void;
   onOpenFind: () => void;
+  onToggleOutline: () => void;
+  outlineOpen: boolean;
   statusText: string;
   modified: boolean;
   fileName?: string | null;
@@ -18,6 +20,8 @@ export const FileNodeToolbar = ({
   onSaveAs,
   onInsertImage,
   onOpenFind,
+  onToggleOutline,
+  outlineOpen,
   statusText,
   modified,
   fileName,
@@ -73,6 +77,18 @@ export const FileNodeToolbar = ({
         <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
           <circle cx="7" cy="7" r="4" stroke="currentColor" strokeWidth="1.3" />
           <path d="M10 10l3.5 3.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+        </svg>
+      </button>
+      <button
+        className={`note-tool-btn${outlineOpen ? ' note-tool-btn--active' : ''}`}
+        onClick={onToggleOutline}
+        title="Outline"
+        aria-label="Toggle outline"
+        aria-pressed={outlineOpen}
+      >
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+          <path d="M3 4h2M3 8h2M3 12h2" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+          <path d="M7 4h6M7 8h6M7 12h4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
         </svg>
       </button>
     </div>

--- a/apps/canvas-workspace/src/renderer/src/components/NoteFindBar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/NoteFindBar/index.css
@@ -2,7 +2,7 @@
   position: absolute;
   top: 8px;
   right: 8px;
-  z-index: 50;
+  z-index: var(--note-layer-panel, 50);
   background: var(--surface);
   border: 1px solid var(--border-light);
   border-radius: var(--radius-md);

--- a/apps/canvas-workspace/src/renderer/src/components/NoteFindBar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/NoteFindBar/index.css
@@ -51,6 +51,47 @@
   border-color: var(--accent-border, var(--accent));
 }
 
+.note-find-input--invalid,
+.note-find-input--invalid:focus {
+  border-color: var(--danger, #e5484d);
+}
+
+.note-find-toggles {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.note-find-opt {
+  min-width: 22px;
+  height: 22px;
+  padding: 0 4px;
+  border: 1px solid transparent;
+  background: transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.note-find-opt:hover {
+  background: rgba(0, 0, 0, 0.05);
+  color: var(--text);
+}
+
+.note-find-opt--on {
+  background: var(--accent-soft, rgba(59, 130, 246, 0.14));
+  border-color: var(--accent-border, var(--accent));
+  color: var(--accent, var(--text));
+}
+
 .note-find-count {
   font-size: 10px;
   color: var(--text-muted);

--- a/apps/canvas-workspace/src/renderer/src/components/NoteFindBar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NoteFindBar/index.tsx
@@ -3,11 +3,13 @@ import './index.css';
 import type { Editor } from '@tiptap/react';
 import {
   clearNoteSearch,
+  DEFAULT_SEARCH_OPTIONS,
   getNoteSearchState,
   navigateNoteSearch,
   replaceAllMatches,
   replaceCurrentMatch,
   setNoteSearch,
+  type NoteSearchOptions,
 } from '../../editor/noteSearchExtension';
 import { isImeComposing } from '../../utils/ime';
 
@@ -20,10 +22,12 @@ export const NoteFindBar = ({ editor, onClose }: Props) => {
   const [query, setQuery] = useState('');
   const [replacement, setReplacement] = useState('');
   const [showReplace, setShowReplace] = useState(false);
+  const [options, setOptions] = useState<NoteSearchOptions>(DEFAULT_SEARCH_OPTIONS);
   const inputRef = useRef<HTMLInputElement>(null);
   const state = getNoteSearchState(editor.state);
   const total = state?.matches.length ?? 0;
   const current = state?.matches.length ? state.current + 1 : 0;
+  const invalid = state?.invalid ?? false;
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -37,7 +41,13 @@ export const NoteFindBar = ({ editor, onClose }: Props) => {
 
   const runSearch = (q: string) => {
     setQuery(q);
-    setNoteSearch(editor.view, q);
+    setNoteSearch(editor.view, q, options);
+  };
+
+  const toggleOption = (key: keyof NoteSearchOptions) => {
+    const next = { ...options, [key]: !options[key] };
+    setOptions(next);
+    setNoteSearch(editor.view, query, next);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -64,14 +74,52 @@ export const NoteFindBar = ({ editor, onClose }: Props) => {
         </button>
         <input
           ref={inputRef}
-          className="note-find-input"
+          className={`note-find-input${invalid ? ' note-find-input--invalid' : ''}`}
           placeholder="Find"
           value={query}
           onChange={(e) => runSearch(e.target.value)}
           onKeyDown={handleKeyDown}
         />
-        <span className="note-find-count">
-          {total > 0 ? `${current}/${total}` : query ? '0/0' : ''}
+        <div className="note-find-toggles" role="group" aria-label="Search options">
+          <button
+            type="button"
+            className={`note-find-opt${options.caseSensitive ? ' note-find-opt--on' : ''}`}
+            aria-pressed={options.caseSensitive}
+            aria-label="Match case"
+            title="Match case"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => toggleOption('caseSensitive')}
+          >
+            Aa
+          </button>
+          <button
+            type="button"
+            className={`note-find-opt${options.wholeWord ? ' note-find-opt--on' : ''}`}
+            aria-pressed={options.wholeWord}
+            aria-label="Whole word"
+            title="Whole word"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => toggleOption('wholeWord')}
+          >
+            W
+          </button>
+          <button
+            type="button"
+            className={`note-find-opt${options.regex ? ' note-find-opt--on' : ''}`}
+            aria-pressed={options.regex}
+            aria-label="Use regular expression"
+            title="Regular expression"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => toggleOption('regex')}
+          >
+            .*
+          </button>
+        </div>
+        <span
+          className="note-find-count"
+          title={invalid ? 'Invalid regular expression' : undefined}
+        >
+          {invalid ? '!' : total > 0 ? `${current}/${total}` : query ? '0/0' : ''}
         </span>
         <button
           className="note-find-nav"

--- a/apps/canvas-workspace/src/renderer/src/components/NoteLinkPrompt/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/NoteLinkPrompt/index.css
@@ -3,7 +3,7 @@
   top: 8px;
   left: 8px;
   right: 8px;
-  z-index: 50;
+  z-index: var(--note-layer-panel, 50);
   background: var(--surface);
   border: 1px solid var(--border-light);
   border-radius: var(--radius-md);

--- a/apps/canvas-workspace/src/renderer/src/components/NoteMentionMenu/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/NoteMentionMenu/index.css
@@ -1,0 +1,50 @@
+.note-mention-menu {
+  background: var(--surface);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-card-hover);
+  padding: 4px;
+  width: 240px;
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.note-mention-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  text-align: left;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 5px 6px;
+  border-radius: var(--radius-sm);
+}
+
+.note-mention-menu-item:hover,
+.note-mention-menu-item--active {
+  background: var(--accent-soft, rgba(59, 130, 246, 0.1));
+}
+
+.note-mention-menu-badge {
+  flex-shrink: 0;
+  font-size: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 1px 5px;
+  border-radius: 4px;
+  background: var(--surface-alt, rgba(0, 0, 0, 0.05));
+  color: var(--text-secondary);
+}
+
+.note-mention-menu-title {
+  flex: 1;
+  min-width: 0;
+  font-size: 12px;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/NoteMentionMenu/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NoteMentionMenu/index.tsx
@@ -1,0 +1,61 @@
+import { useEffect } from 'react';
+import './index.css';
+import { createPortal } from 'react-dom';
+import type { CanvasNode } from '../../types';
+import { useViewportClampedPosition } from '../../hooks/useViewportClampedPosition';
+import { useClickOutside } from '../../hooks/useClickOutside';
+import { CANVAS_NODE_TYPE_LABEL_KEY } from '../../utils/nodeTypeI18n';
+import { useI18n } from '../../i18n';
+
+interface Props {
+  x: number;
+  y: number;
+  items: CanvasNode[];
+  selectedIndex: number;
+  onSelect: (node: CanvasNode) => void;
+  onClose: () => void;
+}
+
+export const NoteMentionMenu = ({ x, y, items, selectedIndex, onSelect, onClose }: Props) => {
+  const { t } = useI18n();
+  const { ref: menuRef, pos } = useViewportClampedPosition<HTMLDivElement>(x, y + 6);
+  const activeIndex = Math.min(selectedIndex, items.length - 1);
+
+  useEffect(() => {
+    const el = menuRef.current?.querySelector('.note-mention-menu-item--active') as HTMLElement | null;
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [selectedIndex]);
+
+  useClickOutside(menuRef, onClose);
+
+  if (items.length === 0) return null;
+
+  return createPortal(
+    <div
+      ref={menuRef}
+      className="note-mention-menu"
+      role="listbox"
+      aria-label={t('nodeMention.title')}
+      style={{ position: 'fixed', left: pos.left, top: pos.top, zIndex: 9000 }}
+    >
+      {items.map((node, i) => (
+        <button
+          key={node.id}
+          className={`note-mention-menu-item${i === activeIndex ? ' note-mention-menu-item--active' : ''}`}
+          role="option"
+          aria-selected={i === activeIndex}
+          onMouseDown={(e) => {
+            e.preventDefault();
+            onSelect(node);
+          }}
+        >
+          <span className={`note-mention-menu-badge note-mention-menu-badge--${node.type}`}>
+            {t(CANVAS_NODE_TYPE_LABEL_KEY[node.type])}
+          </span>
+          <span className="note-mention-menu-title">{node.title || t('nodeMention.untitled')}</span>
+        </button>
+      ))}
+    </div>,
+    document.body,
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/NoteMentionMenu/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NoteMentionMenu/index.tsx
@@ -36,7 +36,7 @@ export const NoteMentionMenu = ({ x, y, items, selectedIndex, onSelect, onClose 
       className="note-mention-menu"
       role="listbox"
       aria-label={t('nodeMention.title')}
-      style={{ position: 'fixed', left: pos.left, top: pos.top, zIndex: 9000 }}
+      style={{ position: 'fixed', left: pos.left, top: pos.top, zIndex: 'var(--layer-note-popover)' }}
     >
       {items.map((node, i) => (
         <button

--- a/apps/canvas-workspace/src/renderer/src/components/NoteOutline/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/NoteOutline/index.css
@@ -2,7 +2,7 @@
   position: absolute;
   top: 8px;
   left: 8px;
-  z-index: 50;
+  z-index: var(--note-layer-panel, 50);
   background: var(--surface);
   border: 1px solid var(--border-light);
   border-radius: var(--radius-md);

--- a/apps/canvas-workspace/src/renderer/src/components/NoteOutline/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/NoteOutline/index.css
@@ -1,0 +1,113 @@
+.note-outline {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 50;
+  background: var(--surface);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-card-hover);
+  width: 200px;
+  max-height: calc(100% - 16px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.note-outline-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border-light);
+  flex-shrink: 0;
+}
+
+.note-outline-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.note-outline-close {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 15px;
+  line-height: 1;
+  width: 20px;
+  height: 20px;
+  border-radius: var(--radius-sm);
+}
+
+.note-outline-close:hover {
+  background: rgba(0, 0, 0, 0.05);
+  color: var(--text);
+}
+
+.note-outline-empty {
+  padding: 12px 10px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.note-outline-list {
+  list-style: none;
+  margin: 0;
+  padding: 4px;
+  overflow-y: auto;
+}
+
+.note-outline-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.3;
+  padding: 3px 6px;
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.note-outline-item:hover {
+  background: rgba(0, 0, 0, 0.05);
+  color: var(--text);
+}
+
+.note-outline-item--active {
+  background: var(--accent-soft, rgba(59, 130, 246, 0.12));
+  color: var(--accent, var(--text));
+}
+
+.note-outline-item--h1 {
+  padding-left: 6px;
+  font-weight: 600;
+}
+.note-outline-item--h2 {
+  padding-left: 16px;
+}
+.note-outline-item--h3 {
+  padding-left: 26px;
+  font-size: 11px;
+}
+.note-outline-item--h4 {
+  padding-left: 34px;
+  font-size: 11px;
+}
+.note-outline-item--h5 {
+  padding-left: 40px;
+  font-size: 11px;
+}
+.note-outline-item--h6 {
+  padding-left: 46px;
+  font-size: 11px;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/NoteOutline/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NoteOutline/index.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from 'react';
+import './index.css';
+import type { Editor } from '@tiptap/react';
+
+interface HeadingItem {
+  pos: number;
+  level: number;
+  text: string;
+}
+
+const computeHeadings = (editor: Editor): HeadingItem[] => {
+  const out: HeadingItem[] = [];
+  editor.state.doc.descendants((node, pos) => {
+    if (node.type.name === 'heading') {
+      out.push({ pos, level: (node.attrs.level as number) ?? 1, text: node.textContent.trim() });
+    }
+  });
+  return out;
+};
+
+/** The heading whose section currently contains the caret — the last heading
+ *  at or before the selection. */
+const activeHeadingPos = (headings: HeadingItem[], from: number): number | null => {
+  let active: number | null = null;
+  for (const h of headings) {
+    if (h.pos <= from) active = h.pos;
+    else break;
+  }
+  return active;
+};
+
+interface Props {
+  editor: Editor;
+  onClose: () => void;
+}
+
+export const NoteOutline = ({ editor, onClose }: Props) => {
+  const [headings, setHeadings] = useState<HeadingItem[]>(() => computeHeadings(editor));
+  const [activePos, setActivePos] = useState<number | null>(null);
+
+  useEffect(() => {
+    const recompute = () => {
+      const next = computeHeadings(editor);
+      setHeadings(next);
+      setActivePos(activeHeadingPos(next, editor.state.selection.from));
+    };
+    const trackActive = () => {
+      setActivePos(activeHeadingPos(computeHeadings(editor), editor.state.selection.from));
+    };
+    recompute();
+    editor.on('update', recompute);
+    editor.on('selectionUpdate', trackActive);
+    return () => {
+      editor.off('update', recompute);
+      editor.off('selectionUpdate', trackActive);
+    };
+  }, [editor]);
+
+  const goTo = (pos: number) => {
+    editor.chain().focus().setTextSelection(pos + 1).run();
+    try {
+      const coords = editor.view.coordsAtPos(pos + 1);
+      const container = editor.view.dom.closest<HTMLElement>('.note-tiptap-editor');
+      if (container) {
+        const rect = container.getBoundingClientRect();
+        container.scrollTop += coords.top - rect.top - 16;
+      }
+    } catch {
+      // ignore pos resolution errors (doc changed underneath us)
+    }
+  };
+
+  return (
+    <div className="note-outline" onMouseDown={(e) => e.stopPropagation()}>
+      <div className="note-outline-head">
+        <span className="note-outline-title">Outline</span>
+        <button
+          className="note-outline-close"
+          onClick={onClose}
+          title="Close outline"
+          aria-label="Close outline"
+        >
+          ×
+        </button>
+      </div>
+      {headings.length === 0 ? (
+        <div className="note-outline-empty">No headings yet</div>
+      ) : (
+        <ul className="note-outline-list">
+          {headings.map((h, i) => (
+            <li key={`${h.pos}-${i}`}>
+              <button
+                type="button"
+                className={`note-outline-item note-outline-item--h${h.level}${
+                  h.pos === activePos ? ' note-outline-item--active' : ''
+                }`}
+                onClick={() => goTo(h.pos)}
+                title={h.text || 'Untitled'}
+              >
+                {h.text || 'Untitled'}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/SlashCommandMenu/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/SlashCommandMenu/index.tsx
@@ -59,7 +59,7 @@ export const SlashCommandMenu = ({
       role="listbox"
       aria-label={t('slashCommand.label')}
       aria-activedescendant={activeItem ? `${listboxId}-${activeItem.id}` : undefined}
-      style={{ position: 'fixed', left: pos.left, top: pos.top, zIndex: 9000 }}
+      style={{ position: 'fixed', left: pos.left, top: pos.top, zIndex: 'var(--layer-note-popover)' }}
     >
       <div className="slash-menu-header">{t('slashCommand.blocks')}</div>
       {items.map((item, i) => (

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/useWorkbenchState.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/useWorkbenchState.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { CanvasNode } from '../../types';
 import type { CanvasNodeRenameRequest } from '../../types/ui-interaction';
+import { OPEN_NODE_EVENT, type OpenNodeDetail } from '../../utils/openNodeBridge';
 
 interface WorkbenchNodeRequest {
   workspaceId: string;
@@ -135,6 +136,18 @@ export function useWorkbenchState({
     ensureWorkspaceNodesLoaded(workspaceId);
     setFocusRequest({ workspaceId, nodeId });
   }, [ensureWorkspaceNodesLoaded]);
+
+  // Note mentions (and other deep node links) dispatch OPEN_NODE_EVENT on the
+  // window; focus the referenced node through the same request pipeline.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<OpenNodeDetail>).detail;
+      if (!detail?.nodeId) return;
+      requestNodeFocus(detail.workspaceId || activeWorkspaceId, detail.nodeId);
+    };
+    window.addEventListener(OPEN_NODE_EVENT, handler);
+    return () => window.removeEventListener(OPEN_NODE_EVENT, handler);
+  }, [activeWorkspaceId, requestNodeFocus]);
 
   const requestActiveNodeFocus = useCallback((nodeId: string) => {
     requestNodeFocus(activeWorkspaceId, nodeId);

--- a/apps/canvas-workspace/src/renderer/src/editor/calloutNode.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/editor/calloutNode.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest';
+import { Editor } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+import { Markdown } from 'tiptap-markdown';
+import { Callout } from './calloutNode';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const makeEditor = (content?: any) =>
+  new Editor({ extensions: [StarterKit, Markdown, Callout], content });
+
+const calloutDoc = (icon: string, text: string) => ({
+  type: 'doc',
+  content: [
+    {
+      type: 'callout',
+      attrs: { icon },
+      content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+    },
+  ],
+});
+
+describe('Callout markdown round-trip', () => {
+  it('serializes a callout to a GitHub-style alert blockquote', () => {
+    const editor = makeEditor(calloutDoc('💡', 'hello'));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const md = (editor.storage as any).markdown.getMarkdown();
+    expect(md).toContain('> [!💡]');
+    expect(md).toContain('hello');
+    editor.destroy();
+  });
+
+  it('parses an alert blockquote back into a callout node', () => {
+    const editor = makeEditor('> [!💡]\n>\n> hello');
+    expect(JSON.stringify(editor.getJSON())).toContain('"callout"');
+    editor.destroy();
+  });
+
+  it('round-trips (serialize → reload) preserving the callout, icon, and text', () => {
+    const e1 = makeEditor(calloutDoc('⚠️', 'careful'));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const md = (e1.storage as any).markdown.getMarkdown();
+    e1.destroy();
+
+    const e2 = makeEditor(md);
+    const json = JSON.stringify(e2.getJSON());
+    expect(json).toContain('"callout"');
+    expect(json).toContain('careful');
+    expect(json).toContain('⚠️');
+    e2.destroy();
+  });
+
+  it('leaves an ordinary blockquote as a blockquote', () => {
+    const editor = makeEditor('> just a quote');
+    const json = JSON.stringify(editor.getJSON());
+    expect(json).toContain('"blockquote"');
+    expect(json).not.toContain('"callout"');
+    editor.destroy();
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/editor/calloutNode.ts
+++ b/apps/canvas-workspace/src/renderer/src/editor/calloutNode.ts
@@ -1,0 +1,82 @@
+import { Node, mergeAttributes } from '@tiptap/react';
+
+export const CALLOUT_DEFAULT_ICON = '💡';
+
+const CALLOUT_MARKER_RE = /^\[!([^\]\n]+)\]$/;
+
+/**
+ * Rewrite `> [!icon]` alert blockquotes produced by markdown-it back into
+ * `div[data-callout]` so they parse as callout nodes. Best-effort: a blockquote
+ * that doesn't match is left untouched, and content is never dropped — a parse
+ * miss simply degrades a callout to a normal blockquote.
+ */
+const upgradeCalloutBlockquotes = (element: HTMLElement) => {
+  const doc = element.ownerDocument;
+  for (const bq of Array.from(element.querySelectorAll('blockquote'))) {
+    const first = bq.firstElementChild;
+    if (!first || first.tagName !== 'P') continue;
+    const marker = (first.textContent ?? '').trim().match(CALLOUT_MARKER_RE);
+    if (!marker) continue;
+
+    const div = doc.createElement('div');
+    div.setAttribute('data-callout', marker[1]);
+    first.remove();
+    while (bq.firstChild) div.appendChild(bq.firstChild);
+    if (!div.firstChild) div.appendChild(doc.createElement('p'));
+    bq.replaceWith(div);
+  }
+};
+
+/**
+ * Notion-style callout: a block container with an emoji icon and rich content.
+ * Serializes to a GitHub alert blockquote that round-trips through markdown:
+ *
+ *   > [!💡]
+ *   >
+ *   > body…
+ */
+export const Callout = Node.create({
+  name: 'callout',
+  group: 'block',
+  content: 'block+',
+  defining: true,
+
+  addAttributes() {
+    return {
+      icon: {
+        default: CALLOUT_DEFAULT_ICON,
+        parseHTML: (el) => el.getAttribute('data-callout') || CALLOUT_DEFAULT_ICON,
+        renderHTML: (attrs) => ({ 'data-callout': attrs.icon || CALLOUT_DEFAULT_ICON }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-callout]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes(HTMLAttributes, { class: 'note-callout' }), 0];
+  },
+
+  addStorage() {
+    return {
+      markdown: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        serialize(state: any, node: any) {
+          const icon = String(node.attrs.icon || CALLOUT_DEFAULT_ICON);
+          state.write(`> [!${icon}]`);
+          state.ensureNewLine();
+          state.write('>');
+          state.ensureNewLine();
+          state.wrapBlock('> ', null, node, () => state.renderContent(node));
+        },
+        parse: {
+          updateDOM(element: HTMLElement) {
+            upgradeCalloutBlockquotes(element);
+          },
+        },
+      },
+    };
+  },
+});

--- a/apps/canvas-workspace/src/renderer/src/editor/noteSearchExtension.ts
+++ b/apps/canvas-workspace/src/renderer/src/editor/noteSearchExtension.ts
@@ -4,6 +4,15 @@ import type { EditorState } from '@tiptap/pm/state';
 import type { EditorView } from '@tiptap/pm/view';
 import { Decoration, DecorationSet } from '@tiptap/pm/view';
 import type { Node as PMNode } from '@tiptap/pm/model';
+import {
+  buildSearchRegex,
+  collectMatches,
+  DEFAULT_SEARCH_OPTIONS,
+  type NoteSearchOptions,
+} from './noteSearchMatching';
+
+export { DEFAULT_SEARCH_OPTIONS } from './noteSearchMatching';
+export type { NoteSearchOptions } from './noteSearchMatching';
 
 export interface NoteSearchMatch {
   from: number;
@@ -12,6 +21,9 @@ export interface NoteSearchMatch {
 
 export interface NoteSearchState {
   query: string;
+  options: NoteSearchOptions;
+  /** True when `regex` is on and the query fails to compile. */
+  invalid: boolean;
   current: number;
   matches: NoteSearchMatch[];
   decorations: DecorationSet;
@@ -19,17 +31,18 @@ export interface NoteSearchState {
 
 export const noteSearchPluginKey = new PluginKey<NoteSearchState>('noteSearch');
 
-const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-const findMatches = (doc: PMNode, query: string): NoteSearchMatch[] => {
-  if (!query) return [];
+const findMatches = (
+  doc: PMNode,
+  query: string,
+  options: NoteSearchOptions,
+): NoteSearchMatch[] => {
+  const re = buildSearchRegex(query, options);
+  if (!re) return [];
   const matches: NoteSearchMatch[] = [];
-  const re = new RegExp(escapeRegex(query), 'gi');
   doc.descendants((node, pos) => {
     if (!node.isText || !node.text) return;
-    let m: RegExpExecArray | null;
-    while ((m = re.exec(node.text)) !== null) {
-      matches.push({ from: pos + m.index, to: pos + m.index + m[0].length });
+    for (const { index, length } of collectMatches(node.text, re)) {
+      matches.push({ from: pos + index, to: pos + index + length });
     }
   });
   return matches;
@@ -47,6 +60,8 @@ const buildDecorations = (matches: NoteSearchMatch[], current: number, doc: PMNo
 
 const emptyState = (): NoteSearchState => ({
   query: '',
+  options: DEFAULT_SEARCH_OPTIONS,
+  invalid: false,
   current: 0,
   matches: [],
   decorations: DecorationSet.empty,
@@ -62,7 +77,7 @@ export const NoteSearchExtension = Extension.create({
           init: () => emptyState(),
           apply(tr, old) {
             const meta = tr.getMeta(noteSearchPluginKey) as
-              | { type: 'set'; query: string }
+              | { type: 'set'; query: string; options: NoteSearchOptions }
               | { type: 'navigate'; direction: 1 | -1 }
               | { type: 'setCurrent'; current: number }
               | { type: 'clear' }
@@ -70,10 +85,14 @@ export const NoteSearchExtension = Extension.create({
             if (meta) {
               if (meta.type === 'clear') return emptyState();
               if (meta.type === 'set') {
-                const matches = findMatches(tr.doc, meta.query);
-                const current = matches.length === 0 ? 0 : 0;
+                const invalid =
+                  meta.options.regex && !!meta.query && buildSearchRegex(meta.query, meta.options) === null;
+                const matches = findMatches(tr.doc, meta.query, meta.options);
+                const current = 0;
                 return {
                   query: meta.query,
+                  options: meta.options,
+                  invalid,
                   current,
                   matches,
                   decorations: buildDecorations(matches, current, tr.doc),
@@ -92,10 +111,10 @@ export const NoteSearchExtension = Extension.create({
               }
             }
             if (tr.docChanged && old.query) {
-              const matches = findMatches(tr.doc, old.query);
+              const matches = findMatches(tr.doc, old.query, old.options);
               const current = matches.length === 0 ? 0 : Math.min(old.current, matches.length - 1);
               return {
-                query: old.query,
+                ...old,
                 current,
                 matches,
                 decorations: buildDecorations(matches, current, tr.doc),
@@ -117,8 +136,12 @@ export const NoteSearchExtension = Extension.create({
 export const getNoteSearchState = (state: EditorState): NoteSearchState | null =>
   noteSearchPluginKey.getState(state) ?? null;
 
-export const setNoteSearch = (view: EditorView, query: string) => {
-  view.dispatch(view.state.tr.setMeta(noteSearchPluginKey, { type: 'set', query }));
+export const setNoteSearch = (
+  view: EditorView,
+  query: string,
+  options: NoteSearchOptions = DEFAULT_SEARCH_OPTIONS,
+) => {
+  view.dispatch(view.state.tr.setMeta(noteSearchPluginKey, { type: 'set', query, options }));
 };
 
 export const clearNoteSearch = (view: EditorView) => {
@@ -157,7 +180,7 @@ export const replaceCurrentMatch = (view: EditorView, replacement: string): bool
   const target = s.matches[s.current];
   if (!target) return false;
   const tr = view.state.tr.insertText(replacement, target.from, target.to);
-  tr.setMeta(noteSearchPluginKey, { type: 'set', query: s.query });
+  tr.setMeta(noteSearchPluginKey, { type: 'set', query: s.query, options: s.options });
   view.dispatch(tr);
   return true;
 };
@@ -171,7 +194,7 @@ export const replaceAllMatches = (view: EditorView, replacement: string): number
     const m = s.matches[i];
     tr = tr.insertText(replacement, m.from, m.to);
   }
-  tr.setMeta(noteSearchPluginKey, { type: 'set', query: s.query });
+  tr.setMeta(noteSearchPluginKey, { type: 'set', query: s.query, options: s.options });
   view.dispatch(tr);
   return s.matches.length;
 };

--- a/apps/canvas-workspace/src/renderer/src/editor/noteSearchMatching.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/editor/noteSearchMatching.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSearchRegex,
+  DEFAULT_SEARCH_OPTIONS,
+  findTextMatches,
+  type NoteSearchOptions,
+} from './noteSearchMatching';
+
+const opts = (o: Partial<NoteSearchOptions> = {}): NoteSearchOptions => ({
+  ...DEFAULT_SEARCH_OPTIONS,
+  ...o,
+});
+
+describe('noteSearchMatching', () => {
+  it('returns no matches for an empty query', () => {
+    expect(findTextMatches('hello world', '', opts())).toEqual([]);
+    expect(buildSearchRegex('', opts())).toBeNull();
+  });
+
+  it('matches case-insensitively by default', () => {
+    const m = findTextMatches('Cat cat CAT', 'cat', opts());
+    expect(m.map((x) => x.index)).toEqual([0, 4, 8]);
+    expect(m.every((x) => x.length === 3)).toBe(true);
+  });
+
+  it('respects the caseSensitive option', () => {
+    const m = findTextMatches('Cat cat CAT', 'cat', opts({ caseSensitive: true }));
+    expect(m.map((x) => x.index)).toEqual([4]);
+  });
+
+  it('respects the wholeWord option', () => {
+    const m = findTextMatches('cat category scatter cat', 'cat', opts({ wholeWord: true }));
+    expect(m.map((x) => x.index)).toEqual([0, 21]);
+  });
+
+  it('escapes regex metacharacters in literal mode', () => {
+    expect(findTextMatches('abc', 'a.c', opts())).toEqual([]);
+    expect(findTextMatches('a.c', 'a.c', opts()).map((x) => x.index)).toEqual([0]);
+  });
+
+  it('treats the query as a pattern in regex mode', () => {
+    const m = findTextMatches('a1 b2 c3', '[a-z]\\d', opts({ regex: true }));
+    expect(m.map((x) => x.index)).toEqual([0, 3, 6]);
+  });
+
+  it('returns null / no matches for an invalid regex', () => {
+    expect(buildSearchRegex('(', opts({ regex: true }))).toBeNull();
+    expect(findTextMatches('whatever', '(', opts({ regex: true }))).toEqual([]);
+  });
+
+  it('terminates and drops zero-width matches (e.g. a*)', () => {
+    const m = findTextMatches('xaaax', 'a*', opts({ regex: true }));
+    expect(m).toEqual([{ index: 1, length: 3 }]);
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/editor/noteSearchMatching.ts
+++ b/apps/canvas-workspace/src/renderer/src/editor/noteSearchMatching.ts
@@ -1,0 +1,71 @@
+/**
+ * Pure (dependency-free) matching helpers shared by the note search
+ * ProseMirror plugin and the find bar. Kept free of Tiptap/DOM imports so the
+ * regex/option logic can be unit-tested in isolation.
+ */
+
+/** User-facing matching options exposed by the find bar. */
+export interface NoteSearchOptions {
+  caseSensitive: boolean;
+  wholeWord: boolean;
+  /** Treat the query as a raw regular expression rather than literal text. */
+  regex: boolean;
+}
+
+export const DEFAULT_SEARCH_OPTIONS: NoteSearchOptions = {
+  caseSensitive: false,
+  wholeWord: false,
+  regex: false,
+};
+
+const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Compile the query + options into a global RegExp, or return `null` when the
+ * query is empty or (in regex mode) syntactically invalid. The `g` flag is
+ * always set so callers can iterate every match.
+ */
+export const buildSearchRegex = (
+  query: string,
+  options: NoteSearchOptions = DEFAULT_SEARCH_OPTIONS,
+): RegExp | null => {
+  if (!query) return null;
+  const core = options.regex ? query : escapeRegex(query);
+  const pattern = options.wholeWord ? `\\b(?:${core})\\b` : core;
+  const flags = options.caseSensitive ? 'g' : 'gi';
+  try {
+    return new RegExp(pattern, flags);
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Collect every match offset within a single string. Guards against zero-width
+ * matches (e.g. `a*`, `(?=x)`) by advancing `lastIndex` so the loop always
+ * terminates; zero-length hits are dropped.
+ */
+export const collectMatches = (
+  text: string,
+  re: RegExp,
+): Array<{ index: number; length: number }> => {
+  const out: Array<{ index: number; length: number }> = [];
+  re.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    if (m[0].length > 0) out.push({ index: m.index, length: m[0].length });
+    if (m.index === re.lastIndex) re.lastIndex += 1;
+  }
+  return out;
+};
+
+/** Find every match offset within a single string for the given query/options. */
+export const findTextMatches = (
+  text: string,
+  query: string,
+  options: NoteSearchOptions = DEFAULT_SEARCH_OPTIONS,
+): Array<{ index: number; length: number }> => {
+  const re = buildSearchRegex(query, options);
+  if (!re) return [];
+  return collectMatches(text, re);
+};

--- a/apps/canvas-workspace/src/renderer/src/editor/slashCommands.ts
+++ b/apps/canvas-workspace/src/renderer/src/editor/slashCommands.ts
@@ -45,8 +45,12 @@ export const ALL_SLASH_COMMANDS: SlashCmd[] = [
     run: (e, f, t) => deleteSlash(e, f, t).toggleTaskList().run(),
   },
   {
-    id: 'quote', label: 'Blockquote', desc: 'Quote / callout block', icon: '"',
+    id: 'quote', label: 'Blockquote', desc: 'Quote block', icon: '"',
     run: (e, f, t) => deleteSlash(e, f, t).toggleBlockquote().run(),
+  },
+  {
+    id: 'callout', label: 'Callout', desc: 'Highlighted note box', icon: '💡',
+    run: (e, f, t) => deleteSlash(e, f, t).wrapIn('callout', { icon: '💡' }).run(),
   },
   {
     id: 'code', label: 'Code Block', desc: 'Code snippet with syntax highlight', icon: '</>',
@@ -98,6 +102,11 @@ export const ALL_SLASH_COMMANDS: SlashCmd[] = [
   {
     id: 'hr', label: 'Divider', desc: 'Horizontal line', icon: '—',
     run: (e, f, t) => deleteSlash(e, f, t).setHorizontalRule().run(),
+  },
+  {
+    id: 'date', label: 'Date', desc: "Insert today's date", icon: '📅',
+    run: (e, f, t) =>
+      deleteSlash(e, f, t).insertContent(new Date().toLocaleDateString()).run(),
   },
 ];
 

--- a/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { shouldHandleCanvasFindShortcut } from './useCanvasKeyboard';
+
+const modF = (overrides: Partial<Parameters<typeof shouldHandleCanvasFindShortcut>[0]> = {}) => ({
+  ctrlKey: false,
+  key: 'f',
+  metaKey: true,
+  shiftKey: false,
+  ...overrides,
+});
+
+const elementInNote = () => ({
+  tagName: 'DIV',
+  closest: (selector: string) => (selector === '.note-card' ? { tagName: 'DIV' } : null),
+});
+
+const elementOutsideNote = (tagName = 'DIV') => ({
+  tagName,
+  closest: () => null,
+});
+
+describe('shouldHandleCanvasFindShortcut', () => {
+  it('lets note-local find own Cmd/Ctrl+F while focus is inside a note card', () => {
+    expect(shouldHandleCanvasFindShortcut(modF(), elementInNote())).toBe(false);
+  });
+
+  it('handles Cmd/Ctrl+F outside note cards, including regular editable controls', () => {
+    expect(shouldHandleCanvasFindShortcut(modF(), elementOutsideNote())).toBe(true);
+    expect(shouldHandleCanvasFindShortcut(modF({ ctrlKey: true, metaKey: false }), elementOutsideNote('INPUT')))
+      .toBe(true);
+  });
+
+  it('ignores unrelated or already-handled key events', () => {
+    expect(shouldHandleCanvasFindShortcut(modF({ defaultPrevented: true }), elementOutsideNote()))
+      .toBe(false);
+    expect(shouldHandleCanvasFindShortcut(modF({ key: 'k' }), elementOutsideNote())).toBe(false);
+    expect(shouldHandleCanvasFindShortcut(modF({ shiftKey: true }), elementOutsideNote())).toBe(false);
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.ts
@@ -2,6 +2,40 @@ import { useEffect } from 'react';
 import type { CanvasNode, FileNodeData } from '../types';
 import type { CanvasClipboard } from '../types/ui-interaction';
 
+interface KeyboardShortcutLike {
+  ctrlKey: boolean;
+  defaultPrevented?: boolean;
+  key: string;
+  metaKey: boolean;
+  shiftKey: boolean;
+}
+
+interface ActiveElementLike {
+  tagName?: string;
+  isContentEditable?: boolean;
+  closest?: (selector: string) => Element | ActiveElementLike | null;
+}
+
+const isEditableElement = (active: ActiveElementLike | null): boolean => !!active && (
+  active.tagName === 'INPUT' ||
+  active.tagName === 'TEXTAREA' ||
+  active.isContentEditable === true
+);
+
+const isInsideNoteCard = (active: ActiveElementLike | null): boolean =>
+  !!active?.closest?.('.note-card');
+
+export const shouldHandleCanvasFindShortcut = (
+  event: KeyboardShortcutLike,
+  active: ActiveElementLike | null,
+): boolean => {
+  if (event.defaultPrevented) return false;
+  if (!(event.metaKey || event.ctrlKey)) return false;
+  if (event.shiftKey) return false;
+  if (event.key.toLowerCase() !== 'f') return false;
+  return !isInsideNoteCard(active);
+};
+
 interface Options {
   canvasId: string;
   undo: () => void;
@@ -78,21 +112,16 @@ export const useCanvasKeyboard = ({
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (keyboardLocked) return;
+      if (e.defaultPrevented) return;
 
       const active = document.activeElement;
-      const isEditable = active && (
-        active.tagName === 'INPUT' ||
-        active.tagName === 'TEXTAREA' ||
-        (active as HTMLElement).isContentEditable
-      );
+      const isEditable = isEditableElement(active);
       const isMod = e.metaKey || e.ctrlKey;
 
-      // Ctrl/Cmd+F — find in canvas. Intentionally works *even when*
-      // an editable element has focus: users frequently want to
-      // search from inside a file node without first clicking out.
-      // The bar's own input grabs focus on mount; we just preventDefault
-      // so the browser's native find UI doesn't compete.
-      if (isMod && !e.shiftKey && (e.key === 'f' || e.key === 'F')) {
+      // Ctrl/Cmd+F — find in canvas. Note cards own their own local find
+      // flow, so don't let the canvas-level search steal focus from note
+      // editing, note panels, or note toolbar controls.
+      if (shouldHandleCanvasFindShortcut(e, active)) {
         e.preventDefault();
         toggleFindBar();
         return;
@@ -253,14 +282,11 @@ export const useCanvasKeyboard = ({
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (keyboardLocked) return;
+      if (e.defaultPrevented) return;
 
       if ((e.metaKey || e.ctrlKey) && e.key === 'Tab') {
         const activeEl = document.activeElement;
-        const isEditable = activeEl && (
-          activeEl.tagName === 'INPUT' ||
-          activeEl.tagName === 'TEXTAREA' ||
-          (activeEl as HTMLElement).isContentEditable
-        );
+        const isEditable = isEditableElement(activeEl);
         if (!isEditable && nodes.length > 0) {
           e.preventDefault();
           const currentIndex = nodes.findIndex((n) => n.id === selectedNodeIds[0]);

--- a/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts
@@ -23,6 +23,13 @@ import { NoteSearchExtension } from '../editor/noteSearchExtension';
 import { toFileUrl } from '../utils/fileUrl';
 import { isImeComposing } from '../utils/ime';
 import { useNoteKeyboard } from './useNoteKeyboard';
+import {
+  insertImageAtPos,
+  insertImageAtSelection,
+  isImageUrl,
+  resolveWorkspaceId,
+  saveImageBlob,
+} from '../utils/noteImageInsert';
 
 const lowlight = createLowlight(common);
 
@@ -167,17 +174,6 @@ interface Options {
 
 const AUTO_SAVE_MS = 1500;
 
-const imageExtensionFromMime = (mimeType: string | undefined): string => {
-  const normalized = (mimeType ?? '')
-    .toLowerCase()
-    .replace(/^image\//, '')
-    .replace(/[^a-z0-9]/g, '');
-
-  if (!normalized) return 'png';
-  if (normalized === 'jpeg') return 'jpg';
-  return normalized;
-};
-
 export const useFileNodeEditor = ({
   data,
   nodeIdRef,
@@ -239,32 +235,39 @@ export const useFileNodeEditor = ({
         if (readOnly) return false;
         const items = Array.from(event.clipboardData?.items ?? []);
         const imageItem = items.find((i) => i.type.startsWith('image/'));
-        if (!imageItem) return false;
+        if (imageItem) {
+          const blob = imageItem.getAsFile();
+          if (!blob) return false;
+          event.preventDefault();
+          const wsId = resolveWorkspaceId(workspaceIdRef.current, dataRef.current.filePath);
+          void saveImageBlob(blob, wsId).then((src) => {
+            if (src) insertImageAtSelection(view, src);
+          });
+          return true;
+        }
+        // Paste a bare image URL → embed it directly.
+        const text = event.clipboardData?.getData('text/plain') ?? '';
+        if (isImageUrl(text)) {
+          event.preventDefault();
+          insertImageAtSelection(view, text.trim());
+          return true;
+        }
+        return false;
+      },
+      handleDrop: (view, event) => {
+        if (readOnly) return false;
+        const image = Array.from(event.dataTransfer?.files ?? []).find((f) =>
+          f.type.startsWith('image/'),
+        );
+        if (!image) return false;
         event.preventDefault();
-        const blob = imageItem.getAsFile();
-        if (!blob) return false;
-        const reader = new FileReader();
-        reader.onload = async () => {
-          const dataUrl = reader.result as string;
-          const base64 = dataUrl.split(',')[1];
-          if (!base64) return;
-          const ext = imageExtensionFromMime(imageItem.type);
-          const api = window.canvasWorkspace?.file;
-          if (!api) return;
-          const wsId =
-            workspaceIdRef.current ??
-            dataRef.current.filePath.match(/canvas[/\\]([^/\\]+)[/\\]/)?.[1] ??
-            'default';
-          const res = await api.saveImage(wsId, base64, ext);
-          if (!res.ok || !res.filePath) return;
-          const src = toFileUrl(res.filePath);
-          const { state, dispatch } = view;
-          const imageNode = state.schema.nodes['image']?.create({ src });
-          if (imageNode) {
-            dispatch(state.tr.replaceSelectionWith(imageNode));
-          }
-        };
-        reader.readAsDataURL(blob);
+        const pos = view.posAtCoords({ left: event.clientX, top: event.clientY })?.pos;
+        const wsId = resolveWorkspaceId(workspaceIdRef.current, dataRef.current.filePath);
+        void saveImageBlob(image, wsId).then((src) => {
+          if (!src) return;
+          if (typeof pos === 'number') insertImageAtPos(view, src, pos);
+          else insertImageAtSelection(view, src);
+        });
         return true;
       },
     },
@@ -433,27 +436,9 @@ export const useFileNodeEditor = ({
   const insertImageFromFile = useCallback(
     async (file: File) => {
       if (readOnly || !editor) return;
-      const reader = new FileReader();
-      reader.onload = async () => {
-        const dataUrl = reader.result as string;
-        const base64 = dataUrl.split(',')[1];
-        if (!base64) return;
-        const ext = imageExtensionFromMime(file.type);
-        const api = window.canvasWorkspace?.file;
-        if (!api) return;
-        const wsId =
-          workspaceIdRef.current ??
-          dataRef.current.filePath.match(/canvas[/\\]([^/\\]+)[/\\]/)?.[1] ??
-          'default';
-        const res = await api.saveImage(wsId, base64, ext);
-        if (!res.ok || !res.filePath) return;
-        editor
-          .chain()
-          .focus()
-          .setImage({ src: toFileUrl(res.filePath) })
-          .run();
-      };
-      reader.readAsDataURL(file);
+      const wsId = resolveWorkspaceId(workspaceIdRef.current, dataRef.current.filePath);
+      const src = await saveImageBlob(file, wsId);
+      if (src) editor.chain().focus().setImage({ src }).run();
     },
     [editor, dataRef, workspaceIdRef, readOnly],
   );

--- a/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts
@@ -22,6 +22,7 @@ import { ALL_SLASH_COMMANDS, filterCmds, type SlashCmdContext } from '../editor/
 import { NoteSearchExtension } from '../editor/noteSearchExtension';
 import { toFileUrl } from '../utils/fileUrl';
 import { isImeComposing } from '../utils/ime';
+import { useNoteKeyboard } from './useNoteKeyboard';
 
 const lowlight = createLowlight(common);
 
@@ -347,20 +348,6 @@ export const useFileNodeEditor = ({
     }
   }, [editor, readOnly]);
 
-  // Cmd+S / Ctrl+S
-  useEffect(() => {
-    if (!editor || readOnly) return;
-    const handler = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === 's') {
-        e.preventDefault();
-        const fp = dataRef.current.filePath;
-        if (fp) void persistToFile(getMarkdown(editor), fp);
-      }
-    };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, [editor, persistToFile, dataRef, readOnly]);
-
   // Slash menu keyboard navigation — capture phase so we intercept before ProseMirror
   useEffect(() => {
     if (!editor || readOnly) return;
@@ -478,18 +465,16 @@ export const useFileNodeEditor = ({
   }, [readOnly]);
   const closeFindBar = useCallback(() => setFindBarOpen(false), []);
 
-  // Cmd/Ctrl+F to open find bar — only when this editor is focused
-  useEffect(() => {
-    if (!editor || readOnly) return;
-    const handler = (e: KeyboardEvent) => {
-      if (!((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'f')) return;
-      if (!editor.isFocused) return;
-      e.preventDefault();
-      setFindBarOpen(true);
-    };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, [editor, readOnly]);
+  // Window-level note shortcuts (Cmd+S save, Cmd+F find), scoped to the focused
+  // editor so they don't fire across every mounted note.
+  useNoteKeyboard({
+    editor,
+    readOnly,
+    dataRef,
+    persistToFile,
+    getMarkdown,
+    onOpenFind: openFindBar,
+  });
 
   return {
     editor,

--- a/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts
@@ -20,6 +20,7 @@ import type { CanvasNode, FileNodeData } from '../types';
 import type { SlashCommandDef } from '../components/SlashCommandMenu';
 import { ALL_SLASH_COMMANDS, filterCmds, type SlashCmdContext } from '../editor/slashCommands';
 import { NoteSearchExtension } from '../editor/noteSearchExtension';
+import { Callout } from '../editor/calloutNode';
 import { toFileUrl } from '../utils/fileUrl';
 import { isImeComposing } from '../utils/ime';
 import { useNoteKeyboard } from './useNoteKeyboard';
@@ -207,6 +208,7 @@ export const useFileNodeEditor = ({
       }),
       EmptyLinePreservingParagraph,
       MarkdownSafeImage.configure({ inline: false }),
+      Callout,
       Placeholder.configure({ placeholder: "Type '/' for blocks, or just start writing…" }),
       TaskList,
       TaskItem.configure({ nested: true }),

--- a/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Image from '@tiptap/extension-image';
@@ -24,6 +24,7 @@ import { Callout } from '../editor/calloutNode';
 import { toFileUrl } from '../utils/fileUrl';
 import { isImeComposing } from '../utils/ime';
 import { useNoteKeyboard } from './useNoteKeyboard';
+import { useNoteInteractionController } from './useNoteInteractionController';
 import {
   insertImageAtPos,
   insertImageAtSelection,
@@ -141,22 +142,6 @@ const MarkdownSafeImage = Image.extend({
   },
 });
 
-interface SlashMenuState {
-  x: number;
-  y: number;
-  query: string;
-  index: number;
-  slashFrom: number;
-}
-
-export interface BubbleState {
-  x: number;
-  y: number;
-  /** Bottom edge of the selection rect — anchor for flipping the bubble
-   *  below the selection when there's no room above it. */
-  bottom: number;
-}
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const getMarkdown = (editor: any): string =>
   (editor?.storage?.markdown?.getMarkdown() as string | undefined) ?? '';
@@ -186,14 +171,29 @@ export const useFileNodeEditor = ({
   onUpdate,
   readOnly = false,
 }: Options) => {
-  const [bubble, setBubble] = useState<BubbleState | null>(null);
-  const [slashMenu, setSlashMenu] = useState<SlashMenuState | null>(null);
-  const slashMenuRef = useRef<SlashMenuState | null>(null);
-  slashMenuRef.current = slashMenu;
+  const interactions = useNoteInteractionController();
+  const {
+    slashMenu,
+    slashMenuRef,
+    openSlashMenu,
+    closeSlashMenu,
+    moveSlashSelection,
+    bubble,
+    openBubble,
+    closeBubble,
+    linkPrompt,
+    openLinkPrompt: openControlledLinkPrompt,
+    closeLinkPrompt,
+    findBarOpen,
+    openFindBar,
+    closeFindBar,
+    outlineOpen,
+    toggleOutline,
+    closeOutline,
+    resetForReadOnly,
+  } = interactions;
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [linkPrompt, setLinkPrompt] = useState<{ initial: string } | null>(null);
   const imageInputRef = useRef<HTMLInputElement | null>(null);
-  const [findBarOpen, setFindBarOpen] = useState(false);
 
   const editor = useEditor({
     extensions: [
@@ -304,7 +304,7 @@ export const useFileNodeEditor = ({
         const query = slashMatch[1] ?? '';
         const slashDocPos = from - query.length - 1;
         const coords = editor.view.coordsAtPos(slashDocPos);
-        setSlashMenu((prev) => ({
+        openSlashMenu((prev) => ({
           x: coords.left,
           y: coords.bottom,
           query,
@@ -312,29 +312,29 @@ export const useFileNodeEditor = ({
           slashFrom: slashDocPos,
         }));
       } else {
-        if (slashMenuRef.current) setSlashMenu(null);
+        if (slashMenuRef.current) closeSlashMenu();
       }
     },
     onSelectionUpdate: ({ editor }) => {
       if (readOnly || editor.state.selection.empty) {
-        setBubble(null);
+        closeBubble();
         return;
       }
       requestAnimationFrame(() => {
         const domSel = window.getSelection();
         if (!domSel || domSel.rangeCount === 0) {
-          setBubble(null);
+          closeBubble();
           return;
         }
         const selRect = domSel.getRangeAt(0).getBoundingClientRect();
-        setBubble({
+        openBubble({
           x: selRect.left + selRect.width / 2,
           y: selRect.top,
           bottom: selRect.bottom,
         });
       });
     },
-    onBlur: () => setBubble(null),
+    onBlur: closeBubble,
   });
 
   // Sync content when file opens externally
@@ -349,11 +349,9 @@ export const useFileNodeEditor = ({
     if (!editor) return;
     editor.setEditable(!readOnly);
     if (readOnly) {
-      setBubble(null);
-      setSlashMenu(null);
-      setFindBarOpen(false);
+      resetForReadOnly();
     }
-  }, [editor, readOnly]);
+  }, [editor, readOnly, resetForReadOnly]);
 
   // Slash menu keyboard navigation — capture phase so we intercept before ProseMirror
   useEffect(() => {
@@ -368,30 +366,30 @@ export const useFileNodeEditor = ({
       if (e.key === 'ArrowDown') {
         e.preventDefault();
         e.stopImmediatePropagation();
-        setSlashMenu((prev) => prev ? { ...prev, index: Math.min(prev.index + 1, items.length - 1) } : null);
+        moveSlashSelection(1, items.length);
       } else if (e.key === 'ArrowUp') {
         e.preventDefault();
         e.stopImmediatePropagation();
-        setSlashMenu((prev) => prev ? { ...prev, index: Math.max(prev.index - 1, 0) } : null);
+        moveSlashSelection(-1, items.length);
       } else if (e.key === 'Enter') {
         const item = items[menu.index] ?? items[0];
         if (item) {
           e.preventDefault();
           e.stopImmediatePropagation();
           item.run(editor, menu.slashFrom, editor.state.selection.from, slashCtxRef.current);
-          setSlashMenu(null);
+          closeSlashMenu();
         }
       } else if (e.key === 'Escape') {
-        setSlashMenu(null);
+        closeSlashMenu();
       }
     };
     window.addEventListener('keydown', handler, true);
     return () => window.removeEventListener('keydown', handler, true);
-  }, [editor, readOnly]);
+  }, [editor, readOnly, closeSlashMenu, moveSlashSelection]);
 
   const slashCtx: SlashCmdContext = {
     requestLink: (initial: string) => {
-      if (!readOnly) setLinkPrompt({ initial });
+      if (!readOnly) openControlledLinkPrompt(initial);
     },
     requestImage: () => {
       if (!readOnly) imageInputRef.current?.click();
@@ -405,14 +403,14 @@ export const useFileNodeEditor = ({
     const { slashFrom } = slashMenuRef.current;
     const fullCmd = ALL_SLASH_COMMANDS.find((c) => c.id === cmd.id);
     fullCmd?.run(editor, slashFrom, editor.state.selection.from, slashCtxRef.current);
-    setSlashMenu(null);
-  }, [editor, readOnly]);
+    closeSlashMenu();
+  }, [editor, readOnly, closeSlashMenu, slashMenuRef]);
 
   const openLinkPrompt = useCallback(() => {
     if (readOnly || !editor) return;
     const initial = (editor.getAttributes('link')?.href as string | undefined) ?? '';
-    setLinkPrompt({ initial });
-  }, [editor, readOnly]);
+    openControlledLinkPrompt(initial);
+  }, [editor, readOnly, openControlledLinkPrompt]);
 
   const applyLink = useCallback(
     (url: string) => {
@@ -428,12 +426,12 @@ export const useFileNodeEditor = ({
           .setLink({ href: trimmed })
           .run();
       }
-      setLinkPrompt(null);
+      closeLinkPrompt();
     },
-    [editor, readOnly],
+    [editor, readOnly, closeLinkPrompt],
   );
 
-  const cancelLink = useCallback(() => setLinkPrompt(null), []);
+  const cancelLink = closeLinkPrompt;
 
   const insertImageFromFile = useCallback(
     async (file: File) => {
@@ -449,10 +447,9 @@ export const useFileNodeEditor = ({
     if (!readOnly) imageInputRef.current?.click();
   }, [readOnly]);
 
-  const openFindBar = useCallback(() => {
-    if (!readOnly) setFindBarOpen(true);
-  }, [readOnly]);
-  const closeFindBar = useCallback(() => setFindBarOpen(false), []);
+  const openNoteFindBar = useCallback(() => {
+    if (!readOnly) openFindBar();
+  }, [readOnly, openFindBar]);
 
   // Window-level note shortcuts (Cmd+S save, Cmd+F find), scoped to the focused
   // editor so they don't fire across every mounted note.
@@ -462,13 +459,13 @@ export const useFileNodeEditor = ({
     dataRef,
     persistToFile,
     getMarkdown,
-    onOpenFind: openFindBar,
+    onOpenFind: openNoteFindBar,
   });
 
   return {
     editor,
+    interactions,
     slashMenu,
-    setSlashMenu,
     bubble,
     handleSlashSelect,
     linkPrompt,
@@ -479,7 +476,10 @@ export const useFileNodeEditor = ({
     openImagePicker,
     insertImageFromFile,
     findBarOpen,
-    openFindBar,
+    openFindBar: openNoteFindBar,
     closeFindBar,
+    outlineOpen,
+    toggleOutline,
+    closeOutline,
   };
 };

--- a/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts
@@ -220,6 +220,8 @@ export const useFileNodeEditor = ({
         openOnClick: false,
         autolink: true,
         linkOnPaste: true,
+        // Allow the internal node-mention scheme so `@` links aren't stripped.
+        protocols: ['pulse-canvas'],
         HTMLAttributes: { rel: 'noopener noreferrer', target: '_blank' },
       }),
       CodeBlockLowlight.configure({ lowlight, defaultLanguage: null }),

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNoteInteractionController.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNoteInteractionController.ts
@@ -1,0 +1,131 @@
+import { useCallback, useRef, useState } from 'react';
+import {
+  closeBubbleState,
+  closeFindBarState,
+  closeLinkPromptState,
+  closeMentionMenuState,
+  closeOutlineState,
+  closeSlashMenuState,
+  closeTransientNoteSurfaces,
+  createEmptyNoteInteractionState,
+  moveMentionMenuSelectionState,
+  moveSlashMenuSelectionState,
+  openBubbleState,
+  openFindBarState,
+  openLinkPromptState,
+  openMentionMenuState,
+  openSlashMenuState,
+  toggleOutlineState,
+  type NoteBubbleState,
+  type NoteInteractionState,
+  type NoteInteractionUpdater,
+  type NoteMentionMenuState,
+  type NoteSlashMenuState,
+} from '../utils/noteInteractionState';
+
+export type {
+  NoteBubbleState,
+  NoteInteractionState,
+  NoteInteractionUpdater,
+  NoteLinkPromptState,
+  NoteMentionMenuState,
+  NoteSlashMenuState,
+} from '../utils/noteInteractionState';
+
+/**
+ * Single owner for Note editor interaction surfaces.
+ *
+ * Notion-like editing depends less on any one feature and more on predictable
+ * ownership: a slash menu, mention menu, selection bubble, find bar, outline,
+ * and link prompt should never fight for focus or keyboard events.
+ */
+export const useNoteInteractionController = () => {
+  const [state, setState] = useState<NoteInteractionState>(createEmptyNoteInteractionState);
+  const { slashMenu, mentionMenu, bubble, linkPrompt, findBarOpen, outlineOpen } = state;
+
+  const slashMenuRef = useRef<NoteSlashMenuState | null>(slashMenu);
+  slashMenuRef.current = slashMenu;
+  const mentionMenuRef = useRef<NoteMentionMenuState | null>(mentionMenu);
+  mentionMenuRef.current = mentionMenu;
+
+  const openSlashMenu = useCallback((next: NoteInteractionUpdater<NoteSlashMenuState>) => {
+    setState((current) => openSlashMenuState(current, next));
+  }, []);
+
+  const closeSlashMenu = useCallback(() => setState(closeSlashMenuState), []);
+
+  const moveSlashSelection = useCallback((delta: number, itemCount: number) => {
+    setState((current) => moveSlashMenuSelectionState(current, delta, itemCount));
+  }, []);
+
+  const openMentionMenu = useCallback((next: NoteInteractionUpdater<NoteMentionMenuState>) => {
+    setState((current) => openMentionMenuState(current, next));
+  }, []);
+
+  const closeMentionMenu = useCallback(() => setState(closeMentionMenuState), []);
+
+  const moveMentionSelection = useCallback((delta: number, itemCount: number) => {
+    setState((current) => moveMentionMenuSelectionState(current, delta, itemCount));
+  }, []);
+
+  const openBubble = useCallback((next: NoteBubbleState) => {
+    setState((current) => openBubbleState(current, next));
+  }, []);
+
+  const closeBubble = useCallback(() => setState(closeBubbleState), []);
+
+  const openLinkPrompt = useCallback((initial: string) => {
+    setState((current) => openLinkPromptState(current, initial));
+  }, []);
+
+  const closeLinkPrompt = useCallback(() => setState(closeLinkPromptState), []);
+
+  const openFindBar = useCallback(() => {
+    setState(openFindBarState);
+  }, []);
+
+  const closeFindBar = useCallback(() => setState(closeFindBarState), []);
+
+  const toggleOutline = useCallback(() => {
+    setState(toggleOutlineState);
+  }, []);
+
+  const closeOutline = useCallback(() => setState(closeOutlineState), []);
+
+  const closeEditorTransientSurfaces = useCallback(() => {
+    setState(closeTransientNoteSurfaces);
+  }, []);
+
+  const resetForReadOnly = useCallback(() => {
+    setState(createEmptyNoteInteractionState());
+  }, []);
+
+  return {
+    slashMenu,
+    slashMenuRef,
+    openSlashMenu,
+    closeSlashMenu,
+    moveSlashSelection,
+    mentionMenu,
+    mentionMenuRef,
+    openMentionMenu,
+    closeMentionMenu,
+    moveMentionSelection,
+    bubble,
+    openBubble,
+    closeBubble,
+    linkPrompt,
+    openLinkPrompt,
+    closeLinkPrompt,
+    findBarOpen,
+    openFindBar,
+    closeFindBar,
+    outlineOpen,
+    toggleOutline,
+    closeOutline,
+    closeEditorTransientSurfaces,
+    resetForReadOnly,
+  };
+};
+
+export type NoteInteractionController = ReturnType<typeof useNoteInteractionController>;

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNoteKeyboard.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNoteKeyboard.ts
@@ -1,0 +1,49 @@
+import { useEffect } from 'react';
+import type { Editor } from '@tiptap/react';
+import type { FileNodeData } from '../types';
+
+interface Options {
+  editor: Editor | null;
+  readOnly: boolean;
+  dataRef: React.MutableRefObject<FileNodeData>;
+  persistToFile: (markdown: string, filePath: string) => Promise<void>;
+  getMarkdown: (editor: Editor) => string;
+  onOpenFind: () => void;
+}
+
+/**
+ * Window-level note shortcuts (Cmd/Ctrl+S to save, Cmd/Ctrl+F to find), scoped
+ * to the focused editor. With multiple notes mounted on the canvas every editor
+ * attaches its own listener; gating on `editor.isFocused` ensures a shortcut
+ * only acts on the note the user is actually editing — previously Cmd+S saved
+ * every open note at once.
+ */
+export const useNoteKeyboard = ({
+  editor,
+  readOnly,
+  dataRef,
+  persistToFile,
+  getMarkdown,
+  onOpenFind,
+}: Options) => {
+  useEffect(() => {
+    if (!editor || readOnly) return;
+    const handler = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey)) return;
+      const key = e.key.toLowerCase();
+      if (key !== 's' && key !== 'f') return;
+      // Only the focused note responds, so shortcuts don't fan out across
+      // every mounted editor.
+      if (!editor.isFocused) return;
+      e.preventDefault();
+      if (key === 's') {
+        const fp = dataRef.current.filePath;
+        if (fp) void persistToFile(getMarkdown(editor), fp);
+      } else {
+        onOpenFind();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [editor, readOnly, dataRef, persistToFile, getMarkdown, onOpenFind]);
+};

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNoteMentions.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNoteMentions.ts
@@ -1,21 +1,17 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { Editor } from '@tiptap/react';
 import type { CanvasNode } from '../types';
 import { isImeComposing } from '../utils/ime';
 import { detectMention, filterMentionCandidates } from '../utils/noteMention';
 import { nodeLinkHref } from '../utils/openNodeBridge';
-
-interface MentionMenuState {
-  x: number;
-  y: number;
-  query: string;
-  index: number;
-}
+import type { NoteInteractionController } from './useNoteInteractionController';
 
 interface Options {
   editor: Editor | null;
   candidates: CanvasNode[];
   readOnly: boolean;
+  workspaceId?: string;
+  interactions: NoteInteractionController;
 }
 
 /** Number of chars before the caret we inspect for an `@` trigger. */
@@ -35,10 +31,14 @@ const triggerBeforeCaret = (editor: Editor) => {
  * `pulse-canvas://node/<id>` link (which round-trips through markdown and is
  * made clickable by the note's link handler).
  */
-export const useNoteMentions = ({ editor, candidates, readOnly }: Options) => {
-  const [mentionMenu, setMentionMenu] = useState<MentionMenuState | null>(null);
-  const mentionMenuRef = useRef<MentionMenuState | null>(null);
-  mentionMenuRef.current = mentionMenu;
+export const useNoteMentions = ({ editor, candidates, readOnly, workspaceId, interactions }: Options) => {
+  const {
+    mentionMenu,
+    mentionMenuRef,
+    openMentionMenu,
+    closeMentionMenu,
+    moveMentionSelection,
+  } = interactions;
 
   const filtered = useMemo(
     () => (mentionMenu ? filterMentionCandidates(candidates, mentionMenu.query) : []),
@@ -51,7 +51,7 @@ export const useNoteMentions = ({ editor, candidates, readOnly }: Options) => {
     if (!editor || readOnly) return;
     const hit = triggerBeforeCaret(editor);
     if (!hit) {
-      if (mentionMenuRef.current) setMentionMenu(null);
+      if (mentionMenuRef.current) closeMentionMenu();
       return;
     }
     let coords: { left: number; bottom: number };
@@ -60,13 +60,13 @@ export const useNoteMentions = ({ editor, candidates, readOnly }: Options) => {
     } catch {
       return;
     }
-    setMentionMenu((prev) => ({
+    openMentionMenu((prev) => ({
       x: coords.left,
       y: coords.bottom,
       query: hit.trigger.query,
       index: prev && prev.query === hit.trigger.query ? prev.index : 0,
     }));
-  }, [editor, readOnly]);
+  }, [editor, readOnly, mentionMenuRef, openMentionMenu, closeMentionMenu]);
 
   useEffect(() => {
     if (!editor) return;
@@ -78,11 +78,11 @@ export const useNoteMentions = ({ editor, candidates, readOnly }: Options) => {
     };
   }, [editor, recompute]);
 
-  const closeMention = useCallback(() => setMentionMenu(null), []);
+  const closeMention = closeMentionMenu;
 
   const insertMention = useCallback(
     (node: CanvasNode) => {
-      setMentionMenu(null);
+      closeMentionMenu();
       if (!editor || readOnly) return;
       const hit = triggerBeforeCaret(editor);
       if (!hit) return;
@@ -95,13 +95,13 @@ export const useNoteMentions = ({ editor, candidates, readOnly }: Options) => {
           {
             type: 'text',
             text: `@${label}`,
-            marks: [{ type: 'link', attrs: { href: nodeLinkHref(node.id) } }],
+            marks: [{ type: 'link', attrs: { href: nodeLinkHref(node.id, workspaceId) } }],
           },
           { type: 'text', text: ' ' },
         ])
         .run();
     },
-    [editor, readOnly],
+    [editor, readOnly, workspaceId, closeMentionMenu],
   );
 
   // Keyboard navigation — capture phase so we steer before ProseMirror.
@@ -114,11 +114,11 @@ export const useNoteMentions = ({ editor, candidates, readOnly }: Options) => {
       if (e.key === 'ArrowDown') {
         e.preventDefault();
         e.stopImmediatePropagation();
-        setMentionMenu((prev) => (prev ? { ...prev, index: Math.min(prev.index + 1, items.length - 1) } : null));
+        moveMentionSelection(1, items.length);
       } else if (e.key === 'ArrowUp') {
         e.preventDefault();
         e.stopImmediatePropagation();
-        setMentionMenu((prev) => (prev ? { ...prev, index: Math.max(prev.index - 1, 0) } : null));
+        moveMentionSelection(-1, items.length);
       } else if (e.key === 'Enter') {
         const item = items[menu.index] ?? items[0];
         if (item) {
@@ -128,12 +128,12 @@ export const useNoteMentions = ({ editor, candidates, readOnly }: Options) => {
         }
       } else if (e.key === 'Escape') {
         e.preventDefault();
-        setMentionMenu(null);
+        closeMentionMenu();
       }
     };
     window.addEventListener('keydown', handler, true);
     return () => window.removeEventListener('keydown', handler, true);
-  }, [editor, readOnly, insertMention]);
+  }, [editor, readOnly, insertMention, mentionMenuRef, moveMentionSelection, closeMentionMenu]);
 
   return { mentionMenu, filteredMentions: filtered, insertMention, closeMention };
 };

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNoteMentions.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNoteMentions.ts
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { Editor } from '@tiptap/react';
+import type { CanvasNode } from '../types';
+import { isImeComposing } from '../utils/ime';
+import { detectMention, filterMentionCandidates } from '../utils/noteMention';
+import { nodeLinkHref } from '../utils/openNodeBridge';
+
+interface MentionMenuState {
+  x: number;
+  y: number;
+  query: string;
+  index: number;
+}
+
+interface Options {
+  editor: Editor | null;
+  candidates: CanvasNode[];
+  readOnly: boolean;
+}
+
+/** Number of chars before the caret we inspect for an `@` trigger. */
+const LOOKBEHIND = 60;
+
+const triggerBeforeCaret = (editor: Editor) => {
+  const { from } = editor.state.selection;
+  const startPos = Math.max(0, from - LOOKBEHIND);
+  const textBefore = editor.state.doc.textBetween(startPos, from, '\n', '\0');
+  const trigger = detectMention(textBefore);
+  return trigger ? { trigger, from, atDocPos: startPos + trigger.atIndex } : null;
+};
+
+/**
+ * Inline `@` node-mention picker for the note editor. Watches the caret for an
+ * `@query`, surfaces a candidate list, and inserts the picked node as a
+ * `pulse-canvas://node/<id>` link (which round-trips through markdown and is
+ * made clickable by the note's link handler).
+ */
+export const useNoteMentions = ({ editor, candidates, readOnly }: Options) => {
+  const [mentionMenu, setMentionMenu] = useState<MentionMenuState | null>(null);
+  const mentionMenuRef = useRef<MentionMenuState | null>(null);
+  mentionMenuRef.current = mentionMenu;
+
+  const filtered = useMemo(
+    () => (mentionMenu ? filterMentionCandidates(candidates, mentionMenu.query) : []),
+    [mentionMenu, candidates],
+  );
+  const filteredRef = useRef(filtered);
+  filteredRef.current = filtered;
+
+  const recompute = useCallback(() => {
+    if (!editor || readOnly) return;
+    const hit = triggerBeforeCaret(editor);
+    if (!hit) {
+      if (mentionMenuRef.current) setMentionMenu(null);
+      return;
+    }
+    let coords: { left: number; bottom: number };
+    try {
+      coords = editor.view.coordsAtPos(hit.atDocPos);
+    } catch {
+      return;
+    }
+    setMentionMenu((prev) => ({
+      x: coords.left,
+      y: coords.bottom,
+      query: hit.trigger.query,
+      index: prev && prev.query === hit.trigger.query ? prev.index : 0,
+    }));
+  }, [editor, readOnly]);
+
+  useEffect(() => {
+    if (!editor) return;
+    editor.on('update', recompute);
+    editor.on('selectionUpdate', recompute);
+    return () => {
+      editor.off('update', recompute);
+      editor.off('selectionUpdate', recompute);
+    };
+  }, [editor, recompute]);
+
+  const closeMention = useCallback(() => setMentionMenu(null), []);
+
+  const insertMention = useCallback(
+    (node: CanvasNode) => {
+      setMentionMenu(null);
+      if (!editor || readOnly) return;
+      const hit = triggerBeforeCaret(editor);
+      if (!hit) return;
+      const label = (node.title || '').trim() || 'Untitled';
+      editor
+        .chain()
+        .focus()
+        .deleteRange({ from: hit.atDocPos, to: hit.from })
+        .insertContent([
+          {
+            type: 'text',
+            text: `@${label}`,
+            marks: [{ type: 'link', attrs: { href: nodeLinkHref(node.id) } }],
+          },
+          { type: 'text', text: ' ' },
+        ])
+        .run();
+    },
+    [editor, readOnly],
+  );
+
+  // Keyboard navigation — capture phase so we steer before ProseMirror.
+  useEffect(() => {
+    if (!editor || readOnly) return;
+    const handler = (e: KeyboardEvent) => {
+      const menu = mentionMenuRef.current;
+      if (!menu || isImeComposing(e)) return;
+      const items = filteredRef.current;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        setMentionMenu((prev) => (prev ? { ...prev, index: Math.min(prev.index + 1, items.length - 1) } : null));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        setMentionMenu((prev) => (prev ? { ...prev, index: Math.max(prev.index - 1, 0) } : null));
+      } else if (e.key === 'Enter') {
+        const item = items[menu.index] ?? items[0];
+        if (item) {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          insertMention(item);
+        }
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        setMentionMenu(null);
+      }
+    };
+    window.addEventListener('keydown', handler, true);
+    return () => window.removeEventListener('keydown', handler, true);
+  }, [editor, readOnly, insertMention]);
+
+  return { mentionMenu, filteredMentions: filtered, insertMention, closeMention };
+};

--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -52,6 +52,7 @@
   --layer-fullscreen-chrome: 1010;   /* fullscreen chip */
   --layer-dock: 1100;                /* right dock: artifact / link previews */
   --layer-search: 1500;              /* find-in-canvas bar */
+  --layer-note-popover: 1550;        /* note slash, mention, and bubble menus */
   --layer-interaction-shield: 1800;  /* drag shield over webviews */
   --layer-modal: 1900;               /* settings drawers (with backdrop) */
   --layer-palette: 2000;             /* command palette */

--- a/apps/canvas-workspace/src/renderer/src/utils/downscaleImage.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/downscaleImage.ts
@@ -1,0 +1,47 @@
+/**
+ * Downscale a base64 image so its longest edge is <= maxDim, re-encoding to a
+ * web-safe format. Returns the original base64 unchanged when it's already
+ * within bounds, when the format isn't safely rasterizable (e.g. gif/svg —
+ * downscaling would drop animation/vectors), or when decoding/encoding fails —
+ * so callers can use the result unconditionally. Runs in the renderer.
+ */
+export const downscaleImageBase64 = (
+  base64: string,
+  mime: string,
+  maxDim = 1600,
+): Promise<string> =>
+  new Promise((resolve) => {
+    // Only rasterize formats where a flat resize is lossless of intent.
+    if (!/^image\/(png|jpe?g|webp)$/i.test(mime)) {
+      resolve(base64);
+      return;
+    }
+    const img = new Image();
+    img.onload = () => {
+      const longest = Math.max(img.width, img.height);
+      if (!longest || longest <= maxDim) {
+        resolve(base64);
+        return;
+      }
+      const scale = maxDim / longest;
+      const canvas = document.createElement('canvas');
+      canvas.width = Math.round(img.width * scale);
+      canvas.height = Math.round(img.height * scale);
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        resolve(base64);
+        return;
+      }
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+      try {
+        const type = /jpe?g/i.test(mime) ? 'image/jpeg' : /webp/i.test(mime) ? 'image/webp' : 'image/png';
+        const quality = type === 'image/png' ? undefined : 0.9;
+        const dataUrl = canvas.toDataURL(type, quality);
+        resolve(dataUrl.split(',')[1] || base64);
+      } catch {
+        resolve(base64);
+      }
+    };
+    img.onerror = () => resolve(base64);
+    img.src = `data:${mime};base64,${base64}`;
+  });

--- a/apps/canvas-workspace/src/renderer/src/utils/noteImageInsert.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/noteImageInsert.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { imageExtensionFromMime, isImageUrl, resolveWorkspaceId } from './noteImageInsert';
+
+describe('imageExtensionFromMime', () => {
+  it('maps jpeg to jpg', () => expect(imageExtensionFromMime('image/jpeg')).toBe('jpg'));
+  it('strips the image/ prefix', () => expect(imageExtensionFromMime('image/webp')).toBe('webp'));
+  it('defaults to png for empty/unknown', () => {
+    expect(imageExtensionFromMime(undefined)).toBe('png');
+    expect(imageExtensionFromMime('')).toBe('png');
+  });
+});
+
+describe('resolveWorkspaceId', () => {
+  it('prefers the explicit id', () => {
+    expect(resolveWorkspaceId('ws1', '/canvas/other/notes/a.md')).toBe('ws1');
+  });
+  it('derives from the file path when no explicit id', () => {
+    expect(resolveWorkspaceId(null, '/home/x/canvas/ws-7/notes/a.md')).toBe('ws-7');
+  });
+  it('falls back to default', () => {
+    expect(resolveWorkspaceId(undefined, '/tmp/a.md')).toBe('default');
+  });
+});
+
+describe('isImageUrl', () => {
+  it('accepts http(s) image urls (with query)', () => {
+    expect(isImageUrl('https://x.com/a.png')).toBe(true);
+    expect(isImageUrl('http://x.com/a/b.JPG?v=2')).toBe(true);
+  });
+  it('rejects non-image or non-url text', () => {
+    expect(isImageUrl('hello world')).toBe(false);
+    expect(isImageUrl('https://x.com/page')).toBe(false);
+    expect(isImageUrl('a.png')).toBe(false);
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/utils/noteImageInsert.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/noteImageInsert.ts
@@ -1,0 +1,66 @@
+import { downscaleImageBase64 } from './downscaleImage';
+import { toFileUrl } from './fileUrl';
+import type { EditorView } from '@tiptap/pm/view';
+
+/** Map an image mime type to a file extension (jpeg → jpg, default png). */
+export const imageExtensionFromMime = (mimeType: string | undefined): string => {
+  const normalized = (mimeType ?? '')
+    .toLowerCase()
+    .replace(/^image\//, '')
+    .replace(/[^a-z0-9]/g, '');
+
+  if (!normalized) return 'png';
+  if (normalized === 'jpeg') return 'jpg';
+  return normalized;
+};
+
+/** Derive the workspace id from an explicit value or the file path. */
+export const resolveWorkspaceId = (
+  explicit: string | null | undefined,
+  filePath: string,
+): string =>
+  explicit ?? filePath.match(/canvas[/\\]([^/\\]+)[/\\]/)?.[1] ?? 'default';
+
+const blobToBase64 = (blob: Blob): Promise<string | null> =>
+  new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve((reader.result as string).split(',')[1] || null);
+    reader.onerror = () => resolve(null);
+    reader.readAsDataURL(blob);
+  });
+
+/**
+ * Downscale, persist, and return a `file://` src for an image blob — shared by
+ * paste, drop, and the file picker. Returns null on any failure.
+ */
+export const saveImageBlob = async (blob: Blob, wsId: string): Promise<string | null> => {
+  const base64 = await blobToBase64(blob);
+  if (!base64) return null;
+  const mime = blob.type || 'image/png';
+  const scaled = await downscaleImageBase64(base64, mime);
+  const api = window.canvasWorkspace?.file;
+  if (!api) return null;
+  const res = await api.saveImage(wsId, scaled, imageExtensionFromMime(mime));
+  if (!res.ok || !res.filePath) return null;
+  return toFileUrl(res.filePath);
+};
+
+const IMAGE_URL_RE = /^https?:\/\/\S+\.(?:png|jpe?g|gif|webp|svg)(?:\?\S*)?$/i;
+
+/** True when text is a bare URL pointing at an image (for paste-to-embed). */
+export const isImageUrl = (text: string): boolean => IMAGE_URL_RE.test(text.trim());
+
+const createImageNode = (view: EditorView, src: string) =>
+  view.state.schema.nodes['image']?.create({ src }) ?? null;
+
+/** Replace the current selection with an image node. */
+export const insertImageAtSelection = (view: EditorView, src: string): void => {
+  const node = createImageNode(view, src);
+  if (node) view.dispatch(view.state.tr.replaceSelectionWith(node));
+};
+
+/** Insert an image node at a document position (used for drag-and-drop). */
+export const insertImageAtPos = (view: EditorView, src: string, pos: number): void => {
+  const node = createImageNode(view, src);
+  if (node) view.dispatch(view.state.tr.insert(pos, node));
+};

--- a/apps/canvas-workspace/src/renderer/src/utils/noteInteractionState.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/noteInteractionState.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+import {
+  closeTransientNoteSurfaces,
+  createEmptyNoteInteractionState,
+  moveMentionMenuSelectionState,
+  moveSlashMenuSelectionState,
+  openBubbleState,
+  openFindBarState,
+  openLinkPromptState,
+  openMentionMenuState,
+  openSlashMenuState,
+  toggleOutlineState,
+  type NoteBubbleState,
+  type NoteInteractionState,
+  type NoteMentionMenuState,
+  type NoteSlashMenuState,
+} from './noteInteractionState';
+
+const slashMenu: NoteSlashMenuState = {
+  x: 10,
+  y: 20,
+  query: 'h',
+  index: 0,
+  slashFrom: 5,
+};
+
+const mentionMenu: NoteMentionMenuState = {
+  x: 30,
+  y: 40,
+  query: 'road',
+  index: 1,
+};
+
+const bubble: NoteBubbleState = {
+  x: 50,
+  y: 60,
+  bottom: 72,
+};
+
+const busyState = (): NoteInteractionState => ({
+  ...createEmptyNoteInteractionState(),
+  slashMenu,
+  mentionMenu,
+  bubble,
+  linkPrompt: { initial: 'https://example.com' },
+  findBarOpen: true,
+  outlineOpen: true,
+});
+
+describe('noteInteractionState', () => {
+  it('opens slash as the active inline menu while preserving outline and find state', () => {
+    expect(openSlashMenuState(busyState(), { ...slashMenu, query: 'todo' })).toEqual({
+      slashMenu: { ...slashMenu, query: 'todo' },
+      mentionMenu: null,
+      bubble: null,
+      linkPrompt: null,
+      findBarOpen: true,
+      outlineOpen: true,
+    });
+  });
+
+  it('opens mention as the active inline menu while preserving outline and find state', () => {
+    expect(openMentionMenuState(busyState(), { ...mentionMenu, query: 'design' })).toEqual({
+      slashMenu: null,
+      mentionMenu: { ...mentionMenu, query: 'design' },
+      bubble: null,
+      linkPrompt: null,
+      findBarOpen: true,
+      outlineOpen: true,
+    });
+  });
+
+  it('opens find and clears transient authoring surfaces', () => {
+    expect(openFindBarState(busyState())).toEqual({
+      slashMenu: null,
+      mentionMenu: null,
+      bubble: null,
+      linkPrompt: null,
+      findBarOpen: true,
+      outlineOpen: true,
+    });
+  });
+
+  it('opens link prompt and gives it ownership over find and menus', () => {
+    expect(openLinkPromptState(busyState(), 'https://pulse.local')).toEqual({
+      slashMenu: null,
+      mentionMenu: null,
+      bubble: null,
+      linkPrompt: { initial: 'https://pulse.local' },
+      findBarOpen: false,
+      outlineOpen: true,
+    });
+  });
+
+  it('toggles outline without closing find', () => {
+    const state = {
+      ...busyState(),
+      outlineOpen: false,
+    };
+
+    expect(toggleOutlineState(state)).toEqual({
+      slashMenu: null,
+      mentionMenu: null,
+      bubble: null,
+      linkPrompt: null,
+      findBarOpen: true,
+      outlineOpen: true,
+    });
+  });
+
+  it('suppresses selection bubble while another surface owns keyboard or selection', () => {
+    expect(
+      openBubbleState({ ...createEmptyNoteInteractionState(), slashMenu }, bubble).bubble,
+    ).toBeNull();
+    expect(
+      openBubbleState({ ...createEmptyNoteInteractionState(), mentionMenu }, bubble).bubble,
+    ).toBeNull();
+    expect(
+      openBubbleState(
+        { ...createEmptyNoteInteractionState(), linkPrompt: { initial: '' } },
+        bubble,
+      ).bubble,
+    ).toBeNull();
+    expect(
+      openBubbleState(
+        { ...createEmptyNoteInteractionState(), findBarOpen: true },
+        bubble,
+      ).bubble,
+    ).toBeNull();
+    expect(openBubbleState(createEmptyNoteInteractionState(), bubble).bubble).toEqual(bubble);
+  });
+
+  it('clamps menu selection movement to available items', () => {
+    expect(
+      moveSlashMenuSelectionState(
+        { ...createEmptyNoteInteractionState(), slashMenu: { ...slashMenu, index: 1 } },
+        5,
+        3,
+      ).slashMenu?.index,
+    ).toBe(2);
+    expect(
+      moveMentionMenuSelectionState(
+        { ...createEmptyNoteInteractionState(), mentionMenu: { ...mentionMenu, index: 1 } },
+        -5,
+        3,
+      ).mentionMenu?.index,
+    ).toBe(0);
+  });
+
+  it('closes transient surfaces without touching find or outline', () => {
+    expect(closeTransientNoteSurfaces(busyState())).toEqual({
+      slashMenu: null,
+      mentionMenu: null,
+      bubble: null,
+      linkPrompt: null,
+      findBarOpen: true,
+      outlineOpen: true,
+    });
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/utils/noteInteractionState.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/noteInteractionState.ts
@@ -1,0 +1,179 @@
+export interface NoteSlashMenuState {
+  x: number;
+  y: number;
+  query: string;
+  index: number;
+  slashFrom: number;
+}
+
+export interface NoteMentionMenuState {
+  x: number;
+  y: number;
+  query: string;
+  index: number;
+}
+
+export interface NoteBubbleState {
+  x: number;
+  y: number;
+  /** Bottom edge of the selection rect; used to flip the bubble below. */
+  bottom: number;
+}
+
+export interface NoteLinkPromptState {
+  initial: string;
+}
+
+export interface NoteInteractionState {
+  slashMenu: NoteSlashMenuState | null;
+  mentionMenu: NoteMentionMenuState | null;
+  bubble: NoteBubbleState | null;
+  linkPrompt: NoteLinkPromptState | null;
+  findBarOpen: boolean;
+  outlineOpen: boolean;
+}
+
+export type NoteInteractionUpdater<T> = T | ((prev: T | null) => T);
+
+export const createEmptyNoteInteractionState = (): NoteInteractionState => ({
+  slashMenu: null,
+  mentionMenu: null,
+  bubble: null,
+  linkPrompt: null,
+  findBarOpen: false,
+  outlineOpen: false,
+});
+
+const nextValue = <T,>(current: T | null, value: NoteInteractionUpdater<T>): T =>
+  typeof value === 'function' ? (value as (prev: T | null) => T)(current) : value;
+
+const clampMenuIndex = (index: number, delta: number, itemCount: number) =>
+  Math.max(0, Math.min(index + delta, itemCount - 1));
+
+export const closeTransientNoteSurfaces = (
+  state: NoteInteractionState,
+): NoteInteractionState => ({
+  ...state,
+  slashMenu: null,
+  mentionMenu: null,
+  bubble: null,
+  linkPrompt: null,
+});
+
+export const openSlashMenuState = (
+  state: NoteInteractionState,
+  next: NoteInteractionUpdater<NoteSlashMenuState>,
+): NoteInteractionState => ({
+  ...state,
+  mentionMenu: null,
+  bubble: null,
+  linkPrompt: null,
+  slashMenu: nextValue(state.slashMenu, next),
+});
+
+export const closeSlashMenuState = (state: NoteInteractionState): NoteInteractionState => ({
+  ...state,
+  slashMenu: null,
+});
+
+export const moveSlashMenuSelectionState = (
+  state: NoteInteractionState,
+  delta: number,
+  itemCount: number,
+): NoteInteractionState => {
+  if (!state.slashMenu || itemCount <= 0) return state;
+  return {
+    ...state,
+    slashMenu: {
+      ...state.slashMenu,
+      index: clampMenuIndex(state.slashMenu.index, delta, itemCount),
+    },
+  };
+};
+
+export const openMentionMenuState = (
+  state: NoteInteractionState,
+  next: NoteInteractionUpdater<NoteMentionMenuState>,
+): NoteInteractionState => ({
+  ...state,
+  slashMenu: null,
+  bubble: null,
+  linkPrompt: null,
+  mentionMenu: nextValue(state.mentionMenu, next),
+});
+
+export const closeMentionMenuState = (state: NoteInteractionState): NoteInteractionState => ({
+  ...state,
+  mentionMenu: null,
+});
+
+export const moveMentionMenuSelectionState = (
+  state: NoteInteractionState,
+  delta: number,
+  itemCount: number,
+): NoteInteractionState => {
+  if (!state.mentionMenu || itemCount <= 0) return state;
+  return {
+    ...state,
+    mentionMenu: {
+      ...state.mentionMenu,
+      index: clampMenuIndex(state.mentionMenu.index, delta, itemCount),
+    },
+  };
+};
+
+export const openBubbleState = (
+  state: NoteInteractionState,
+  next: NoteBubbleState,
+): NoteInteractionState => {
+  if (state.slashMenu || state.mentionMenu || state.linkPrompt || state.findBarOpen) {
+    return { ...state, bubble: null };
+  }
+  return { ...state, bubble: next };
+};
+
+export const closeBubbleState = (state: NoteInteractionState): NoteInteractionState => ({
+  ...state,
+  bubble: null,
+});
+
+export const openLinkPromptState = (
+  state: NoteInteractionState,
+  initial: string,
+): NoteInteractionState => ({
+  ...state,
+  slashMenu: null,
+  mentionMenu: null,
+  bubble: null,
+  linkPrompt: { initial },
+  findBarOpen: false,
+});
+
+export const closeLinkPromptState = (state: NoteInteractionState): NoteInteractionState => ({
+  ...state,
+  linkPrompt: null,
+});
+
+export const openFindBarState = (state: NoteInteractionState): NoteInteractionState => ({
+  ...state,
+  slashMenu: null,
+  mentionMenu: null,
+  bubble: null,
+  linkPrompt: null,
+  findBarOpen: true,
+});
+
+export const closeFindBarState = (state: NoteInteractionState): NoteInteractionState => ({
+  ...state,
+  findBarOpen: false,
+});
+
+export const toggleOutlineState = (state: NoteInteractionState): NoteInteractionState => ({
+  ...closeTransientNoteSurfaces(state),
+  outlineOpen: !state.outlineOpen,
+});
+
+export const closeOutlineState = (state: NoteInteractionState): NoteInteractionState => ({
+  ...state,
+  outlineOpen: false,
+});

--- a/apps/canvas-workspace/src/renderer/src/utils/noteMention.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/noteMention.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import type { CanvasNode } from '../types';
+import { detectMention, filterMentionCandidates } from './noteMention';
+
+const node = (id: string, title: string): CanvasNode =>
+  ({ id, type: 'file', title, x: 0, y: 0, width: 1, height: 1, data: {} } as unknown as CanvasNode);
+
+describe('detectMention', () => {
+  it('detects a bare @ at the start', () => {
+    expect(detectMention('@')).toEqual({ query: '', atIndex: 0 });
+  });
+
+  it('detects @query after whitespace', () => {
+    expect(detectMention('hello @foo')).toEqual({ query: 'foo', atIndex: 6 });
+  });
+
+  it('reports the @ offset so the trigger range can be deleted', () => {
+    const t = detectMention('a b @plan');
+    expect(t).not.toBeNull();
+    expect('a b @plan'.slice(t!.atIndex)).toBe('@plan');
+  });
+
+  it('does not fire inside a word (e.g. emails)', () => {
+    expect(detectMention('mail me at a@b')).toBeNull();
+  });
+
+  it('stops at whitespace after the query', () => {
+    expect(detectMention('@foo bar')).toBeNull();
+  });
+});
+
+describe('filterMentionCandidates', () => {
+  const nodes = [node('1', 'Roadmap'), node('2', 'Design Notes'), node('3', 'roadside')];
+
+  it('returns all (capped) for an empty query', () => {
+    expect(filterMentionCandidates(nodes, '').map((n) => n.id)).toEqual(['1', '2', '3']);
+  });
+
+  it('matches title case-insensitively', () => {
+    expect(filterMentionCandidates(nodes, 'road').map((n) => n.id)).toEqual(['1', '3']);
+  });
+
+  it('returns nothing when no title matches', () => {
+    expect(filterMentionCandidates(nodes, 'zzz')).toEqual([]);
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/utils/noteMention.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/noteMention.ts
@@ -1,0 +1,33 @@
+import type { CanvasNode } from '../types';
+
+export interface MentionTrigger {
+  query: string;
+  /** Offset of the `@` character within the inspected text. */
+  atIndex: number;
+}
+
+// `@` must start a word (line start or after whitespace / an opening paren) so
+// it doesn't fire inside emails or `a@b`. Query stops at the next whitespace.
+const MENTION_RE = /(?:^|[\s(])@([^\s@]{0,40})$/;
+
+/** Detect an in-progress `@mention` immediately before the caret. */
+export const detectMention = (textBefore: string): MentionTrigger | null => {
+  const m = textBefore.match(MENTION_RE);
+  if (!m) return null;
+  const query = m[1] ?? '';
+  return { query, atIndex: textBefore.length - query.length - 1 };
+};
+
+export const MENTION_MAX_RESULTS = 20;
+
+/** Filter mention candidates by a case-insensitive title substring match. */
+export const filterMentionCandidates = (
+  candidates: CanvasNode[],
+  query: string,
+): CanvasNode[] => {
+  if (!query) return candidates.slice(0, MENTION_MAX_RESULTS);
+  const q = query.toLowerCase();
+  return candidates
+    .filter((n) => (n.title || '').toLowerCase().includes(q))
+    .slice(0, MENTION_MAX_RESULTS);
+};

--- a/apps/canvas-workspace/src/renderer/src/utils/openNodeBridge.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/openNodeBridge.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  nodeIdFromHref,
+  nodeLinkHref,
+  parseNodeLinkHref,
+} from './openNodeBridge';
+
+describe('openNodeBridge node links', () => {
+  it('builds and parses node links with workspace identity', () => {
+    const href = nodeLinkHref('node 1/2', 'ws-main');
+
+    expect(href).toBe('pulse-canvas://node/node%201%2F2?workspace=ws-main');
+    expect(parseNodeLinkHref(href)).toEqual({
+      nodeId: 'node 1/2',
+      workspaceId: 'ws-main',
+    });
+  });
+
+  it('round-trips encoded workspace ids without double-decoding', () => {
+    const href = nodeLinkHref('n?1', 'ws 100%');
+
+    expect(href).toBe('pulse-canvas://node/n%3F1?workspace=ws%20100%25');
+    expect(parseNodeLinkHref(href)).toEqual({
+      nodeId: 'n?1',
+      workspaceId: 'ws 100%',
+    });
+  });
+
+  it('parses legacy node links without workspace identity', () => {
+    expect(parseNodeLinkHref('pulse-canvas://node/n1')).toEqual({
+      nodeId: 'n1',
+      workspaceId: undefined,
+    });
+    expect(nodeIdFromHref('pulse-canvas://node/n1')).toBe('n1');
+  });
+
+  it('ignores non-node links and malformed ids', () => {
+    expect(parseNodeLinkHref('https://example.com')).toBeNull();
+    expect(parseNodeLinkHref('pulse-canvas://node/')).toBeNull();
+    expect(parseNodeLinkHref('pulse-canvas://node/%E0%A4%A')).toBeNull();
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/utils/openNodeBridge.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/openNodeBridge.ts
@@ -1,0 +1,32 @@
+/**
+ * Lightweight window-event bridge for "open / focus a canvas node by id".
+ *
+ * Note mentions (and any other deep node link) dispatch this instead of having
+ * a focus callback threaded down through every shared canvas component. The
+ * Workbench listens once and routes it to its existing `requestNodeFocus`.
+ */
+
+export const OPEN_NODE_EVENT = 'pulse-canvas:open-node';
+
+/** Prefix of the href used by node-mention links inside notes. */
+export const NODE_LINK_PREFIX = 'pulse-canvas://node/';
+
+export interface OpenNodeDetail {
+  /** Workspace that owns the node. Empty string → the active workspace. */
+  workspaceId: string;
+  nodeId: string;
+}
+
+export const dispatchOpenNode = (detail: OpenNodeDetail): void => {
+  window.dispatchEvent(new CustomEvent<OpenNodeDetail>(OPEN_NODE_EVENT, { detail }));
+};
+
+/** Build the href stored on a mention link for the given node id. */
+export const nodeLinkHref = (nodeId: string): string => `${NODE_LINK_PREFIX}${nodeId}`;
+
+/** Extract a node id from a mention href, or null when it isn't one. */
+export const nodeIdFromHref = (href: string | null | undefined): string | null => {
+  if (!href || !href.startsWith(NODE_LINK_PREFIX)) return null;
+  const id = href.slice(NODE_LINK_PREFIX.length).trim();
+  return id.length > 0 ? id : null;
+};

--- a/apps/canvas-workspace/src/renderer/src/utils/openNodeBridge.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/openNodeBridge.ts
@@ -17,16 +17,51 @@ export interface OpenNodeDetail {
   nodeId: string;
 }
 
+export interface NodeLinkTarget {
+  workspaceId?: string;
+  nodeId: string;
+}
+
+const safeDecode = (value: string): string | null => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+};
+
 export const dispatchOpenNode = (detail: OpenNodeDetail): void => {
   window.dispatchEvent(new CustomEvent<OpenNodeDetail>(OPEN_NODE_EVENT, { detail }));
 };
 
 /** Build the href stored on a mention link for the given node id. */
-export const nodeLinkHref = (nodeId: string): string => `${NODE_LINK_PREFIX}${nodeId}`;
+export const nodeLinkHref = (nodeId: string, workspaceId?: string): string => {
+  const href = `${NODE_LINK_PREFIX}${encodeURIComponent(nodeId)}`;
+  if (!workspaceId) return href;
+  return `${href}?workspace=${encodeURIComponent(workspaceId)}`;
+};
+
+/** Extract the canvas-node target from a mention href. */
+export const parseNodeLinkHref = (href: string | null | undefined): NodeLinkTarget | null => {
+  if (!href || !href.startsWith(NODE_LINK_PREFIX)) return null;
+  const raw = href.slice(NODE_LINK_PREFIX.length).trim();
+  if (!raw) return null;
+
+  const queryStart = raw.indexOf('?');
+  const rawNodeId = queryStart >= 0 ? raw.slice(0, queryStart) : raw;
+  const rawQuery = queryStart >= 0 ? raw.slice(queryStart + 1) : '';
+  const nodeId = safeDecode(rawNodeId ?? '')?.trim() ?? '';
+  if (!nodeId) return null;
+
+  const params = new URLSearchParams(rawQuery);
+  const workspace = params.get('workspace')?.trim();
+  return {
+    nodeId,
+    workspaceId: workspace || undefined,
+  };
+};
 
 /** Extract a node id from a mention href, or null when it isn't one. */
 export const nodeIdFromHref = (href: string | null | undefined): string | null => {
-  if (!href || !href.startsWith(NODE_LINK_PREFIX)) return null;
-  const id = href.slice(NODE_LINK_PREFIX.length).trim();
-  return id.length > 0 ? id : null;
+  return parseNodeLinkHref(href)?.nodeId ?? null;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@25.0.10)(sass@1.51.0)
+        version: 1.6.1(@types/node@25.0.10)(happy-dom@20.10.6)(sass@1.51.0)
 
   apps/canvas-workspace:
     dependencies:
@@ -162,6 +162,9 @@ importers:
       electron-vite:
         specifier: ^2.3.0
         version: 2.3.0(vite@5.4.21(@types/node@20.19.33)(sass@1.51.0))
+      happy-dom:
+        specifier: ^20.10.6
+        version: 20.10.6
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -170,7 +173,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@20.19.33)(sass@1.51.0)
+        version: 1.6.1(@types/node@20.19.33)(happy-dom@20.10.6)(sass@1.51.0)
 
   apps/remote-server:
     dependencies:
@@ -241,7 +244,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@25.0.10)(sass@1.51.0)
+        version: 1.6.1(@types/node@25.0.10)(happy-dom@20.10.6)(sass@1.51.0)
 
   packages/acp:
     dependencies:
@@ -260,7 +263,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@25.0.10)(sass@1.51.0)
+        version: 1.6.1(@types/node@25.0.10)(happy-dom@20.10.6)(sass@1.51.0)
 
   packages/agent-teams:
     dependencies:
@@ -282,7 +285,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@25.0.10)(sass@1.51.0)
+        version: 1.6.1(@types/node@25.0.10)(happy-dom@20.10.6)(sass@1.51.0)
 
   packages/canvas-cli:
     dependencies:
@@ -301,7 +304,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@25.0.10)(sass@1.51.0)
+        version: 1.6.1(@types/node@25.0.10)(happy-dom@20.10.6)(sass@1.51.0)
 
   packages/canvas-nodes:
     dependencies:
@@ -338,7 +341,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@25.0.10)(sass@1.51.0)
+        version: 1.6.1(@types/node@25.0.10)(happy-dom@20.10.6)(sass@1.51.0)
 
   packages/cli:
     dependencies:
@@ -378,7 +381,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@25.0.10)(sass@1.51.0)
+        version: 1.6.1(@types/node@25.0.10)(happy-dom@20.10.6)(sass@1.51.0)
 
   packages/engine:
     dependencies:
@@ -433,7 +436,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@25.0.10)(sass@1.51.0)
+        version: 1.6.1(@types/node@25.0.10)(happy-dom@20.10.6)(sass@1.51.0)
 
   packages/langfuse-plugin:
     dependencies:
@@ -455,7 +458,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@20.19.33)(sass@1.51.0)
+        version: 1.6.1(@types/node@20.19.33)(happy-dom@20.10.6)(sass@1.51.0)
 
   packages/memory-plugin:
     dependencies:
@@ -483,7 +486,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@25.0.10)(sass@1.51.0)
+        version: 1.6.1(@types/node@25.0.10)(happy-dom@20.10.6)(sass@1.51.0)
 
   packages/orchestrator:
     dependencies:
@@ -502,7 +505,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@25.0.10)(sass@1.51.0)
+        version: 1.6.1(@types/node@25.0.10)(happy-dom@20.10.6)(sass@1.51.0)
 
   packages/plugin-kit:
     dependencies:
@@ -524,7 +527,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@25.0.10)(sass@1.51.0)
+        version: 1.6.1(@types/node@25.0.10)(happy-dom@20.10.6)(sass@1.51.0)
 
   packages/pulse-sandbox:
     dependencies:
@@ -543,7 +546,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@25.0.10)(sass@1.51.0)
+        version: 1.6.1(@types/node@25.0.10)(happy-dom@20.10.6)(sass@1.51.0)
 
 packages:
 
@@ -2084,6 +2087,12 @@ packages:
   '@types/verror@1.10.11':
     resolution: {integrity: sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
@@ -2306,6 +2315,10 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -2865,6 +2878,10 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
@@ -3177,6 +3194,10 @@ packages:
 
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
+  happy-dom@20.10.6:
+    resolution: {integrity: sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==}
+    engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -4796,6 +4817,10 @@ packages:
 
   webworkify@1.5.0:
     resolution: {integrity: sha512-AMcUeyXAhbACL8S2hqqdqOLqvJ8ylmIbNwUIqQujRSouf4+eUFaXbG6F1Rbu+srlJMmxQWsiU7mOJi0nMBfM1g==}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
 
   which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
@@ -6496,6 +6521,12 @@ snapshots:
   '@types/verror@1.10.11':
     optional: true
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.33
+
   '@types/yauzl@2.10.3':
     dependencies:
       '@types/node': 20.19.33
@@ -6760,6 +6791,10 @@ snapshots:
   buffer-crc32@0.2.13: {}
 
   buffer-from@1.1.2: {}
+
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 20.19.33
 
   buffer@5.7.1:
     dependencies:
@@ -7416,6 +7451,8 @@ snapshots:
 
   entities@4.5.0: {}
 
+  entities@7.0.1: {}
+
   env-paths@2.2.1: {}
 
   environment@1.1.0: {}
@@ -7806,6 +7843,19 @@ snapshots:
       strip-bom-string: 1.0.0
 
   hachure-fill@0.5.2: {}
+
+  happy-dom@20.10.6:
+    dependencies:
+      '@types/node': 20.19.33
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-flag@4.0.0: {}
 
@@ -9418,7 +9468,7 @@ snapshots:
       fsevents: 2.3.3
       sass: 1.51.0
 
-  vitest@1.6.1(@types/node@20.19.33)(sass@1.51.0):
+  vitest@1.6.1(@types/node@20.19.33)(happy-dom@20.10.6)(sass@1.51.0):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -9442,6 +9492,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.33
+      happy-dom: 20.10.6
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -9452,7 +9503,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@1.6.1(@types/node@25.0.10)(sass@1.51.0):
+  vitest@1.6.1(@types/node@25.0.10)(happy-dom@20.10.6)(sass@1.51.0):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -9476,6 +9527,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.0.10
+      happy-dom: 20.10.6
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -9510,6 +9562,8 @@ snapshots:
       defaults: 1.0.4
 
   webworkify@1.5.0: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   which@1.3.1:
     dependencies:


### PR DESCRIPTION
## Summary
- Reframe PR 682 as the Phase 0 Canvas Note interaction foundation, not only note find options.
- Centralize slash, @mention, selection bubble, find, outline, and link prompt ownership through a Note interaction controller plus pure state rules.
- Add workspace-aware node mention links, missing-target feedback, note-local keyboard ownership, and documented note floating-layer tokens.
- Keep the scope bounded in docs: stabilize Notion-like editing basics before adding block drag handles, backlinks, hover previews, or richer callout variants.

## Verification
- `pnpm --filter canvas-workspace typecheck:renderer`
- `pnpm --filter canvas-workspace exec vitest run src/renderer/src/hooks/useCanvasKeyboard.test.ts src/renderer/src/editor/calloutNode.test.ts src/renderer/src/utils/openNodeBridge.test.ts src/renderer/src/utils/noteInteractionState.test.ts src/renderer/src/utils/noteMention.test.ts src/renderer/src/editor/noteSearchMatching.test.ts src/renderer/src/utils/noteImageInsert.test.ts`
- `pnpm --filter canvas-workspace build`
- `git diff --check`
- Harness demo smoke: slash `/h1`, @mention insert/click, missing-node status, note Cmd+F ownership, regex invalid state, outline Escape ownership, selection bubble suppression during find, and Cmd+S markdown persistence for workspace-aware node links.

## Known Existing Caveat
- `pnpm --filter canvas-workspace exec vitest run src/main/__tests__/file-size-governance.test.ts` still reports the pre-existing 5 oversized-file violations outside this Note change: `src/main/webview/registry.ts`, `Canvas/index.tsx`, `components/chat/hooks/useMentions.ts`, `IframeNodeBody/useIframeNodeState.ts`, and `WorkspaceNodes/GraphPage.tsx`.