### PR TITLE
fix(canvas-workspace): resolve CSS variable and style inconsistencies

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -375,7 +375,7 @@
   height: 100%;
   min-height: 90px;
   border: 1px dashed rgba(74, 95, 148, 0.25);
-  border-radius: 8px;
+  border-radius: var(--radius);
   background: rgba(255, 255, 255, 0.68);
   color: var(--text-secondary);
   display: flex;
@@ -441,7 +441,7 @@
 }
 
 .node-status-dot--running {
-  background: #10b981;
+  background: var(--agent-success);
   animation: nodeStatusPulse 1.8s ease-in-out infinite;
 }
 
@@ -450,7 +450,7 @@
 }
 
 .node-status-dot--error {
-  background: #e03e3e;
+  background: var(--agent-danger);
 }
 
 @keyframes nodeStatusPulse {
@@ -539,7 +539,7 @@
 }
 
 .node-status-label--running {
-  background: rgba(16, 185, 129, 0.12);
+  background: var(--agent-success-soft);
   color: #059669;
 }
 
@@ -550,7 +550,7 @@
 
 .node-status-label--error {
   background: rgba(224, 62, 62, 0.1);
-  color: #e03e3e;
+  color: var(--agent-danger);
 }
 
 /* Last active time label */

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.css
@@ -339,7 +339,7 @@
 
 .plugin-tool-empty {
   padding: 7px 9px 6px;
-  color: var(--text-tertiary);
+  color: var(--text-muted);
   font-size: 11px;
   line-height: 1.35;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
@@ -22,20 +22,20 @@
 
 .sidebar-install-message {
   font-size: 11px;
-  color: var(--text-secondary, #666);
+  color: var(--text-secondary);
   padding: 4px 12px 4px 32px;
   white-space: pre-wrap;
   line-height: 1.4;
 }
 
 .sidebar-install-message--warn {
-  color: var(--text-warning, #b45309);
+  color: var(--text-warning);
 }
 
 .sidebar-footer {
   margin-top: auto;
   padding: 8px 8px 12px;
-  border-top: 1px solid var(--border-light, rgba(55, 53, 47, 0.07));
+  border-top: 1px solid var(--border-light);
 }
 
 .sidebar-footer-btn {
@@ -47,7 +47,7 @@
   border: none;
   border-radius: 6px;
   background: transparent;
-  color: var(--text-secondary, rgba(55, 53, 47, 0.65));
+  color: var(--text-secondary);
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;
@@ -56,7 +56,7 @@
 
 .sidebar-footer-btn:hover {
   background: rgba(55, 53, 47, 0.05);
-  color: var(--text, #37352f);
+  color: var(--text);
 }
 
 /* ---- Top-level view nav (Canvas / AI Chat) ---- */
@@ -698,8 +698,8 @@
   height: 26px;
   padding: 0 8px;
   border: 1.5px solid var(--accent-border);
-  border-radius: 8px;
-  background: #ffffff;
+  border-radius: var(--radius);
+  background: var(--surface);
   font-size: 12px;
   color: var(--text);
   outline: none;
@@ -897,9 +897,9 @@
   z-index: 1000;
   min-width: 168px;
   padding: 4px;
-  background: var(--bg, #ffffff);
+  background: var(--surface);
   border: 1px solid var(--border-light);
-  border-radius: var(--radius-md, 6px);
+  border-radius: var(--radius-sm);
   box-shadow: 0 6px 24px rgba(0, 0, 0, 0.12), 0 2px 6px rgba(0, 0, 0, 0.06);
 }
 

--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -21,9 +21,10 @@
   --accent-border: rgba(35, 131, 226, 0.45);
   --accent-file: #d9730d;
   --accent-term: #0f7b6c;
-  --accent-frame: #A594E0;
+  --accent-frame: #a594e0;
   --success: #1f7a4d;
   --error: #c0392b;
+  --text-warning: #b45309;
   --overlay-backdrop: rgba(32, 34, 37, 0.22);
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.04);
   --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.04), 0 4px 12px rgba(0, 0, 0, 0.05);


### PR DESCRIPTION
## Summary

Audit of `apps/canvas-workspace` found five categories of UI style inconsistencies. This PR fixes them all in one focused commit across 4 files.

---

### Violations fixed

#### 1. Undefined CSS variables (`--text-warning`, `--radius-md`, `--text-tertiary`)
Three variables were referenced in component CSS but never declared in the global token file. When a CSS variable is undefined the property silently falls back to `initial` (or a fallback literal if one was provided — but those fallbacks were wrong in two of three cases).

| File | Usage | Fix |
|------|-------|-----|
| `Sidebar/index.css:32` | `var(--text-warning, #b45309)` | Added `--text-warning: #b45309` to `styles.css` |
| `Sidebar/index.css:902` | `var(--radius-md, 6px)` | `--radius-md` doesn't exist; 6 px matches `--radius-sm` → replaced with `var(--radius-sm)` |
| `FloatingToolbar/index.css:345` | `var(--text-tertiary)` (no fallback) | Replaced with nearest defined token `var(--text-muted)` so empty state text is visible |

#### 2. Wrong fallback literals in `var()` calls (`Sidebar/index.css`)
Four properties had the correct variable name but a fallback value that **differed** from the actual token value. A future variable load failure would silently produce a different colour than intended.

| Property | Old fallback | Actual token value |
|----------|--------------|--------------------|
| `--text-secondary` | `#666` | `#787774` |
| `--text-secondary` | `rgba(55,53,47,0.65)` | `#787774` |
| `--border-light` | `rgba(55,53,47,0.07)` | `#f0eeea` |
| `--text` | `#37352f` | `#37352f` ✓ (redundant, removed) |

All four fallbacks removed — the variables are defined globally so fallbacks serve no purpose here.

#### 3. Context menu using page background (`--bg`) instead of surface (`--surface`)
`.sidebar-layer-context-menu` had `background: var(--bg, #ffffff)`. `--bg` is the canvas page background (`#f8f8f7`, warm off-white). Menus are floating card surfaces and must use `--surface` (`#ffffff`). The `#ffffff` fallback was masking this mistake at runtime but the semantic intent was wrong.

#### 4. Hardcoded `border-radius` values not using design tokens
Two elements used literal `8px` where `var(--radius)` (= 8 px) is correct; a third used literal `#ffffff` as background.

| Selector | Before | After |
|----------|--------|-------|
| `.reference-node-missing` | `border-radius: 8px` | `var(--radius)` |
| `.sidebar-layer-rename-input` | `border-radius: 8px; background: #ffffff` | `var(--radius); var(--surface)` |

#### 5. Duplicated status colour literals in `CanvasNodeView/index.css`
Running/error status dot and label colours were hardcoded (`#10b981`, `rgba(16,185,129,0.12)`, `#e03e3e`) even though `AgentNodeBody/index.css` already declares `--agent-success`, `--agent-success-soft`, and `--agent-danger` on `:root`. The duplicated literals diverge silently if the agent palette is updated. Replaced with the existing variables.

#### 6. Inconsistent hex case in `styles.css`
`--accent-frame: #A594E0` was the only token using an uppercase hex digit. Normalised to `#a594e0` to match every other colour token in the file.

---

## Files changed

| File | Changes |
|------|---------|
| `src/renderer/src/styles.css` | Add `--text-warning`; lowercase `--accent-frame` hex |
| `src/renderer/src/components/Sidebar/index.css` | Remove wrong fallbacks; fix `--text-warning`; fix context-menu `background`; `--radius-md` → `--radius-sm`; `border-radius: 8px` → `var(--radius)`; `#ffffff` → `var(--surface)` |
| `src/renderer/src/components/FloatingToolbar/index.css` | `--text-tertiary` → `var(--text-muted)` |
| `src/renderer/src/components/CanvasNodeView/index.css` | `border-radius: 8px` → `var(--radius)`; status colour literals → CSS variables |

## Test plan

- [ ] Sidebar footer renders correctly (border matches `--border-light`)
- [ ] Warning message in sidebar agent install section renders amber (`--text-warning`)
- [ ] Layer rename input has correct radius and white surface background
- [ ] Layer context menu renders as white card (not warm off-white page background)
- [ ] Plugin empty state text in floating toolbar is visible (uses `--text-muted`)
- [ ] Node status dots (running = green, error = red) render correctly
- [ ] Node status labels (running = green bg, error = red text) render correctly
- [ ] Frame/group nodes visual unchanged (accent-frame colour value identical, only case differs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRdw8Q8bWF2ZLRG1LLNZ5f

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRdw8Q8bWF2ZLRG1LLNZ5f)_