### PR TITLE
fix(canvas-workspace): resolve UI style inconsistencies in CSS

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/EdgeContextMenu/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeContextMenu/index.css
@@ -1,7 +1,7 @@
 .context-menu-item--danger .context-menu-label strong {
-  color: #d3382c;
+  color: var(--error);
 }
 
 .context-menu-item--danger:hover {
-  background: rgba(211, 56, 44, 0.08);
+  background: rgba(192, 57, 43, 0.08);
 }

--- a/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.css
@@ -1,6 +1,6 @@
 .context-menu {
   position: fixed;
-  z-index: 1000;
+  z-index: var(--layer-note-popover);
   min-width: 200px;
   background: var(--surface);
   border: 1px solid var(--border);

--- a/apps/canvas-workspace/src/renderer/src/components/SearchBar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/SearchBar/index.css
@@ -10,7 +10,7 @@
   max-width: calc(100% - 32px);
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: var(--radius-md, 10px);
+  border-radius: var(--radius-lg);
   box-shadow: var(--shadow-float), 0 6px 24px rgba(0, 0, 0, 0.10);
   z-index: var(--layer-search);
   font-family: var(--font);

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
@@ -894,13 +894,13 @@
 
 .sidebar-layer-context-menu {
   position: fixed;
-  z-index: 1000;
+  z-index: var(--layer-note-popover);
   min-width: 168px;
   padding: 4px;
-  background: var(--bg, #ffffff);
+  background: var(--bg);
   border: 1px solid var(--border-light);
-  border-radius: var(--radius-md, 6px);
-  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.12), 0 2px 6px rgba(0, 0, 0, 0.06);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-float);
 }
 
 .sidebar-layer-context-menu-item {
@@ -924,12 +924,12 @@
 }
 
 .sidebar-layer-context-menu-item--danger {
-  color: #c0392b;
+  color: var(--error);
 }
 
 .sidebar-layer-context-menu-item--danger:hover {
   background: rgba(192, 57, 43, 0.08);
-  color: #c0392b;
+  color: var(--error);
 }
 
 .sidebar-layer-context-menu-separator {

--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.css
@@ -112,7 +112,7 @@
    * editor grows past a fixed-height frame. Height follows content. */
   height: auto;
   overflow: visible;
-  border-radius: var(--radius-md, 6px);
+  border-radius: var(--radius-sm);
   flex: none;
 }
 
@@ -127,7 +127,7 @@
   min-width: 32px;
   min-height: 28px;
   padding: 6px 10px;
-  border-radius: var(--radius-md, 6px);
+  border-radius: var(--radius-sm);
   outline: none;
   word-break: break-word;
   overflow-wrap: anywhere;

--- a/apps/canvas-workspace/src/renderer/src/components/settings-config/settings-config.css
+++ b/apps/canvas-workspace/src/renderer/src/components/settings-config/settings-config.css
@@ -2,7 +2,7 @@
  * Designed to drop into both the global Settings panel and the per-workspace
  * settings drawer — no outer padding, no card chrome. Matches the existing
  * WorkspaceSettings vocabulary (34px controls, 8px radii, 11px uppercase
- * labels, soft #2383e2 focus ring). */
+ * labels, soft --accent focus ring). */
 
 .cfg-manager {
   display: flex;
@@ -89,8 +89,8 @@
 
 .cfg-secondary-btn {
   border: 1px solid rgba(55, 53, 47, 0.12);
-  background: #fff;
-  color: #37352f;
+  background: var(--surface);
+  color: var(--text);
 }
 
 .cfg-secondary-btn:hover:not(:disabled) {
@@ -98,8 +98,8 @@
 }
 
 .cfg-primary-btn {
-  border: 1px solid #2383e2;
-  background: #2383e2;
+  border: 1px solid var(--accent);
+  background: var(--accent);
   color: #fff;
 }
 
@@ -110,7 +110,7 @@
 
 .cfg-danger-btn {
   border: 1px solid rgba(55, 53, 47, 0.12);
-  background: #fff;
+  background: var(--surface);
   color: rgba(180, 47, 47, 0.85);
 }
 
@@ -160,9 +160,9 @@
   height: 34px;
   padding: 0 10px;
   border: 1px solid rgba(55, 53, 47, 0.12);
-  border-radius: 8px;
-  background: #fff;
-  color: #37352f;
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: var(--text);
   font: inherit;
   font-size: 13px;
   outline: none;
@@ -198,13 +198,13 @@ select.cfg-input {
   align-items: center;
   gap: 8px;
   font-size: 12.5px;
-  color: #37352f;
+  color: var(--text);
   cursor: pointer;
   user-select: none;
 }
 
 .cfg-checkbox input {
-  accent-color: #2383e2;
+  accent-color: var(--accent);
 }
 
 .cfg-form-actions {
@@ -279,7 +279,7 @@ select.cfg-input {
 .cfg-list-title {
   font-size: 13px;
   font-weight: 600;
-  color: #37352f;
+  color: var(--text);
   display: flex;
   align-items: center;
   gap: 8px;
@@ -394,7 +394,7 @@ select.cfg-input {
 
 .cfg-expander:hover {
   background: rgba(55, 53, 47, 0.07);
-  color: #37352f;
+  color: var(--text);
 }
 
 .cfg-tools {
@@ -433,7 +433,7 @@ select.cfg-input {
 }
 
 .cfg-tool-toggle input {
-  accent-color: #2383e2;
+  accent-color: var(--accent);
   cursor: pointer;
 }
 
@@ -444,7 +444,7 @@ select.cfg-input {
 .cfg-tool-name {
   font-family: var(--font-mono);
   font-size: 12px;
-  color: #37352f;
+  color: var(--text);
 }
 
 .cfg-tool--off .cfg-tool-name {

--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -31,6 +31,7 @@
   --shadow-drag: 0 8px 28px rgba(0, 0, 0, 0.1), 0 2px 8px rgba(0, 0, 0, 0.06);
   --shadow-float: 0 4px 24px rgba(0, 0, 0, 0.08), 0 0 0 1px rgba(0, 0, 0, 0.04);
   --radius: 8px;
+  --radius-md: 8px;
   --radius-lg: 10px;
   --radius-sm: 6px;
   --font: "SF Mono", "Fira Code", "Cascadia Code", Menlo, monospace;


### PR DESCRIPTION
## Summary

Scanned `apps/canvas-workspace/src/renderer/src` for violations of the design-token and layering conventions documented in `docs/conventions/frontend.md` and `docs/renderer-surfaces.md`. Found and fixed four categories of inconsistency across 7 files.

---

### 1 — Define missing `--radius-md` token (`styles.css`)

`--radius-md` was referenced in 8 component files but never defined in `styles.css`. For components that used it **without a fallback** (`NoteFindBar`, `NoteOutline`, `NoteLinkPrompt`, `NoteMentionMenu`), the `border-radius` silently resolved to `0` at computed-value time — a visual bug.

**Fix:** added `--radius-md: 8px` (same as `--radius`) to the `:root` token block. The four no-fallback usages now resolve correctly.

---

### 2 — Full-app surface z-indexes must use layer tokens (`NodeContextMenu`, `Sidebar`)

`docs/renderer-surfaces.md` explicitly lists `NodeContextMenu (1000)` as a **known straggler** to migrate. The sidebar's layer context menu had the same issue.

| File | Before | After |
|---|---|---|
| `NodeContextMenu/index.css` | `z-index: 1000` | `z-index: var(--layer-note-popover)` |
| `Sidebar/index.css` | `z-index: 1000` | `z-index: var(--layer-note-popover)` |

`--layer-note-popover: 1550` is the correct tier for anchored context/menu popovers; it sits above the fullscreen-node layer (1000) and the search bar (1500) as expected.

---

### 3 — Radius token references corrected (`SearchBar`, `TextNodeBody`, `Sidebar`)

Three files used `var(--radius-md, <fallback>)` where the fallback revealed a mismatch:

| File | Before | After | Reason |
|---|---|---|---|
| `SearchBar/index.css` | `var(--radius-md, 10px)` | `var(--radius-lg)` | fallback 10 px = `--radius-lg` |
| `TextNodeBody/index.css` ×2 | `var(--radius-md, 6px)` | `var(--radius-sm)` | fallback 6 px = `--radius-sm` |
| `Sidebar/index.css` | `var(--radius-md, 6px)` | `var(--radius-sm)` | same |

---

### 4 — Hardcoded colours replaced with design tokens

#### `EdgeContextMenu/index.css`
The danger colour `#d3382c` diverged from the canonical `--error: #c0392b`. Normalised to `var(--error)`; the hover `rgba` alpha was updated to match.

#### `Sidebar/index.css` (layer context menu)
- `color: #c0392b` → `var(--error)` (exact match, two occurrences)
- `background: var(--bg, #ffffff)` → `var(--bg)` (spurious `#ffffff` fallback removed)
- `box-shadow: 0 6px 24px rgba(...), ...` → `var(--shadow-float)` (closest design-system token)

#### `settings-config/settings-config.css`
This shared stylesheet for the Skills/MCP managers contained multiple hardcoded values that duplicate existing tokens:

| Hardcoded value | Token used |
|---|---|
| `#37352f` (×5) | `var(--text)` |
| `#2383e2` (×3 — border, background, accent-color) | `var(--accent)` |
| `background: #fff` (×3) | `var(--surface)` |
| `border-radius: 8px` | `var(--radius)` |

---

## Test plan

- [ ] Visual regression: run `pnpm --filter canvas-workspace dev` and open Settings → Skills / MCP — buttons, inputs, and list rows should look identical (tokens resolve to the same values).
- [ ] Right-click a canvas node: context menu appears above the search bar and other chrome (now at z 1550 vs 1000).
- [ ] Open a note in a FileNode: `NoteFindBar`, `NoteOutline`, `NoteLinkPrompt`, and `NoteMentionMenu` all display rounded corners (previously `border-radius: 0` due to missing `--radius-md`).
- [ ] Run `pnpm --filter canvas-workspace typecheck` — no type errors (CSS-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dvttyyg6uKNF6Hyc9RvfoS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dvttyyg6uKNF6Hyc9RvfoS)_