### PR TITLE
fix(canvas-workspace): replace hardcoded style values with design tokens

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/EdgeContextMenu/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeContextMenu/index.css
@@ -1,7 +1,7 @@
 .context-menu-item--danger .context-menu-label strong {
-  color: #d3382c;
+  color: var(--error);
 }
 
 .context-menu-item--danger:hover {
-  background: rgba(211, 56, 44, 0.08);
+  background: rgba(192, 57, 43, 0.08);
 }

--- a/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.css
@@ -1,6 +1,6 @@
 .context-menu {
   position: fixed;
-  z-index: 1000;
+  z-index: var(--layer-note-popover);
   min-width: 200px;
   background: var(--surface);
   border: 1px solid var(--border);

--- a/apps/canvas-workspace/src/renderer/src/components/SelectionToolbar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/SelectionToolbar/index.css
@@ -56,8 +56,8 @@
 
 .selection-toolbar__btn--danger:hover,
 .selection-toolbar__btn--danger:focus-visible {
-  background: rgba(224, 62, 62, 0.08);
-  color: #e03e3e;
+  background: rgba(192, 57, 43, 0.08);
+  color: var(--error);
 }
 
 .selection-toolbar__btn:disabled {

--- a/apps/canvas-workspace/src/renderer/src/components/SettingsDrawer/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/SettingsDrawer/index.css
@@ -55,7 +55,7 @@
   margin: 3px 0 0;
   font-size: 16px;
   line-height: 1.2;
-  color: #37352f;
+  color: var(--text);
   word-break: break-word;
 }
 
@@ -63,7 +63,7 @@
   width: 28px;
   height: 28px;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: #9b9a97;
   font-size: 21px;
@@ -74,5 +74,5 @@
 
 .settings-drawer-close:hover {
   background: rgba(55, 53, 47, 0.07);
-  color: #37352f;
+  color: var(--text);
 }

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
@@ -894,7 +894,7 @@
 
 .sidebar-layer-context-menu {
   position: fixed;
-  z-index: 1000;
+  z-index: var(--layer-note-popover);
   min-width: 168px;
   padding: 4px;
   background: var(--surface);
@@ -924,12 +924,12 @@
 }
 
 .sidebar-layer-context-menu-item--danger {
-  color: #c0392b;
+  color: var(--error);
 }
 
 .sidebar-layer-context-menu-item--danger:hover {
   background: rgba(192, 57, 43, 0.08);
-  color: #c0392b;
+  color: var(--error);
 }
 
 .sidebar-layer-context-menu-separator {

--- a/apps/canvas-workspace/src/renderer/src/components/WorkspaceTerminalDock/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/WorkspaceTerminalDock/index.css
@@ -90,7 +90,7 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  color: #37352f;
+  color: var(--text);
   font-size: 12px;
   line-height: 1;
 }
@@ -171,7 +171,7 @@
 .workspace-terminal-dock__close:hover,
 .workspace-terminal-dock__close:focus-visible {
   background: rgba(55, 53, 47, 0.07);
-  color: #37352f;
+  color: var(--text);
   outline: none;
 }
 
@@ -182,7 +182,7 @@
   top: 38px;
   bottom: 0;
   min-height: 0;
-  background: #fafaf9;
+  background: var(--surface-hover);
 }
 
 .workspace-terminal-dock--pane .workspace-terminal-dock__body {
@@ -192,7 +192,7 @@
   left: auto;
   right: auto;
   flex: 1 1 auto;
-  background: #fafaf9;
+  background: var(--surface-hover);
 }
 
 .workspace-terminal-dock__xterm {
@@ -200,7 +200,7 @@
   inset: 0;
   padding: 10px 10px 8px;
   overflow: hidden;
-  background: #fafaf9;
+  background: var(--surface-hover);
 }
 
 .workspace-terminal-dock--pane .workspace-terminal-dock__xterm {


### PR DESCRIPTION
## Summary

Scanned `apps/canvas-workspace` for UI style inconsistencies and migrated hardcoded style literals to the project's CSS design-token variables, following the rules in `docs/conventions/frontend.md` and `docs/renderer-surfaces.md`.

**6 files changed, 16 lines replaced.**

---

## Violations fixed

### 1. z-index — full-app surfaces must use `--layer-*` tokens

`renderer-surfaces.md` rule: *"No hardcoded z-index for full-app surfaces."* Both menus below use `position: fixed` (full-viewport overlays) and had raw integers.

| File | Was | Now |
|---|---|---|
| `NodeContextMenu/index.css` | `z-index: 1000` | `z-index: var(--layer-note-popover)` |
| `Sidebar/index.css` (`.sidebar-layer-context-menu`) | `z-index: 1000` | `z-index: var(--layer-note-popover)` |

`NodeContextMenu` was explicitly flagged as a known straggler in `renderer-surfaces.md` ("Migrate them opportunistically when touched").

---

### 2. Error/danger color — use `--error` token (`#c0392b`)

Three files used slightly different red literals for danger states instead of the single `--error` token. The tint backgrounds are aligned to the same base color.

| File | Was | Now |
|---|---|---|
| `EdgeContextMenu/index.css` | `#d3382c` | `var(--error)` |
| `SelectionToolbar/index.css` | `#e03e3e` | `var(--error)` |
| `Sidebar/index.css` (danger items ×2) | `#c0392b` | `var(--error)` |

---

### 3. Text color — use `--text` token (`#37352f`)

| File | Was | Now |
|---|---|---|
| `SettingsDrawer/index.css` (`h2`, close-hover) | `#37352f` ×2 | `var(--text)` |
| `WorkspaceTerminalDock/index.css` (title, close-hover) | `#37352f` ×2 | `var(--text)` |

---

### 4. Surface background — use `--surface-hover` token (`#fafaf9`)

| File | Was | Now |
|---|---|---|
| `WorkspaceTerminalDock/index.css` (body ×2, xterm) | `#fafaf9` ×3 | `var(--surface-hover)` |

---

### 5. Border-radius — use `--radius-sm` token (`6px`)

| File | Was | Now |
|---|---|---|
| `SettingsDrawer/index.css` (close button) | `border-radius: 6px` | `border-radius: var(--radius-sm)` |

---

## What was not changed

- Component-local z-index values (1, 2, 3, …) inside node body components — kept per conventions ("stacking that stays inside one component keeps local values").
- Custom shadow values that don't match any shadow token — left as-is to avoid visual regressions.
- Near-token colors that don't match exactly (e.g. `#9b9a97`, `#f7f7f5`) — left unchanged to avoid unintended visual drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131wwhUzkFKpCSTPSquSXmg

---
_Generated by [Claude Code](https://claude.ai/code/session_0131wwhUzkFKpCSTPSquSXmg)_