### PR TITLE
docs(canvas-workspace): add deep performance analysis report

### DIFF
--- a/apps/canvas-workspace/docs/performance-analysis-consolidated.md
+++ b/apps/canvas-workspace/docs/performance-analysis-consolidated.md
@@ -1,0 +1,274 @@
+# Canvas Workspace 性能分析总报告(两轮整合)
+
+> 本文档整合两轮 dynamic-workflow 深度分析的全部**经对抗式验证**的发现,去重后按统一维度编号并给出合并路线图。
+> - **第一轮**(`docs/performance-analysis.md`):9 维通用性能扫描,52 条原始 → **39 条确认**。聚焦"渲染扇出 / 状态集中 / 主进程同步 I/O"。
+> - **第二轮**(`docs/performance-analysis-round2.md`):前端资源 / 首屏渲染 / 运行时 三维,锚定真实导入图,61 条原始 → **30 条确认且全新**(已剔除 13 条与第一轮重复)。
+> 详细证据(逐条代码引用、对抗性校正)见上述两份原始报告;本总报告为权威索引 + 执行层 + 统一路线图。
+> **重要前提**:本仓为 Electron 桌面应用,renderer 从本地 `file://` 加载,**无网络下载成本**——所有"体积"类发现的真实代价是**主线程 parse/eval 时间**。依赖未安装,**全部体积/耗时数字均为估算**,需按文末「实测验证计划」用 profiling 替换。
+
+---
+
+## 执行摘要
+
+Canvas Workspace 的性能问题可归纳为 **5 个系统性根因**,贯穿两轮全部发现:
+
+1. **集中式 `nodes` 数组是最大结构放大器** —— move/resize/scrollback/cwd 自动保存全走同一 `updateNode → setNodes` 路径,任何变更替换整个数组 identity,引爆下游全量重算(A、B 维多条)。
+2. **缺失虚拟化(视口裁剪)** —— Canvas 与 GraphPage 都按**全集**而非**屏幕集**挂载/渲染重型 DOM(xterm/Tiptap/iframe),内存与挂载成本随**节点总数**线性增长(A 维)。
+3. **主进程 IPC 串行化使任何同步/重复 I/O 成为全应用停顿** —— `getCwd` 的 `execSync(lsof)`、`canvas:save` 的 ~5N 次读、`execInSession` 的 O(n²) 扫描全跑在服务所有 IPC 的同一事件循环(B、E 维)。
+4. **零代码分割 / 首屏关键路径过载** —— 全仓 **0 个 `React.lazy`**,8 种节点 body + Tiptap全家桶 + lowlight common + xterm + markdown-it 全折叠进启动 chunk;主进程 4 步串行 await 后才开窗,且默认画布在首屏挂一个**外部 URL 的 live `<webview>`**(C、D 维)。
+5. **流式热路径与稳态后台缺乏帧级合并与挂起** —— chat token / PTY chunk / tool delta 以远超显示需求的频率 setState;offscreen webview 只降帧不停 JS/timer;force-graph toggle 触发 12s 主线程物理(F、G、H 维)。
+
+**整体健康度:中等偏下** —— 无崩溃或正确性致命缺陷,但在"多终端 / 多 Agent / 多 workspace keep-alive / 大画布 / 含 chat 与 graph"的目标负载下,内存与主线程会出现明显的可扩展性天花板。
+
+---
+
+## 严重程度概览(两轮合并,去重后)
+
+| 维度 | critical | high | medium | low | 小计 |
+|---|---|---|---|---|---|
+| A. 渲染与重渲染扇出 | 0 | 2 | 4 | 3 | 9 |
+| B. 状态管理与持久化 | 0 | 2 | 5 | 1 | 8 |
+| C. 前端资源与代码分割 | 0 | 0 | 6 | 3 | 9 |
+| D. 首屏渲染与启动 | 0 | 1 | 2 | 5 | 8 |
+| E. 终端 / Agent / PTY / IPC | 0 | 2 | 4 | 4 | 10 |
+| F. 聊天流式与 Markdown / Mermaid | 0 | 1 | 5 | 2 | 8 |
+| G. Force-graph / 工作区图 | 0 | 1 | 5 | 2 | 8 |
+| H. 运行时盲区:webview / 图片 / keep-alive | 0 | 1 | 3 | 3 | 7 |
+| **合计** | **0** | **10** | **34** | **23** | **67** |
+
+> 计数为两轮去重后的近似归并(部分发现跨维度,如"无视口裁剪"同时属 A 与 D);严重度以对抗性校正后的值为准。`[R1-xx]` 指第一轮编号,`[R2-§x]` 指第二轮编号。
+
+---
+
+## 维度 A:渲染与重渲染扇出
+
+| ID | 严重度 | 标题 | 关键文件 |
+|---|---|---|---|
+| A1 `[R1-H1]` | high | Canvas 无视口裁剪,每个可见节点挂载完整实时 DOM 子树(xterm/Tiptap/iframe) | `Canvas/hooks/useCanvasVisibility.ts:40` |
+| A2 `[R1-H2]` | high | drag/resize 每 pointer-move 替换整个 nodes 数组,重跑 visibility+sort+split 流水线 | `hooks/useNodes.ts:586` / `CanvasSurface.tsx:121` |
+| A3 `[R1-M1]` | medium | `containerDescendantCount` 每次 group/frame 渲染重算 O(n×containers) 父图 | `useCanvasNodeViewModel.ts:245` |
+| A4 `[R1-M2]` | medium | `CanvasSurface.renderNode` 内联非 memo 闭包,逐节点传 ~31 props,每 pan 帧重建 | `CanvasSurface.tsx:174` |
+| A5 `[R1-M3]` | medium | scrollback 自动保存污染 undo 栈(Ctrl+Z 回放终端文本)+ 强制全数组拷贝 | `useNodes.ts:454` / `useNodeHistory.ts:28` |
+| A6 `[R1-L1]` | low | `resizeGroupsToChildren` 无 group 时也跑全 Map+map,无早退 | `useNodes.ts:399` |
+| A7 `[R1-L2]` | low | 逐节点 30s `setInterval` 相对时间 tick,`node.updatedAt` 改即重建定时器 | `useCanvasNodeViewModel.ts:81` |
+| A8 `[R1-L3]` | low | `CanvasGestureHud` 收完整 nodes 数组,每 resize tick O(n) `.find` | `CanvasSurface.tsx:275` |
+| A9 `[R2-§3.8]` | medium | `renderNode`(graph)rAF 活跃时每节点每帧 `ctx.save+measureText+roundRect+fillText` | `GraphPage.tsx:481` |
+
+**A 维核心修复**:把实时 drag/resize 几何排除出正式 `nodes` 数组(手势中 CSS overlay / position override map,pointer-up 提交);引入 `useViewportCulling`(transform+容器尺寸入参,离屏节点渲染占位、进 margin band 才懒挂载重型 body);`CanvasSurface` 包 `React.memo`,父层 memo 化父容器图与 render-order。
+
+---
+
+## 维度 B:状态管理与持久化
+
+| ID | 严重度 | 标题 | 关键文件 |
+|---|---|---|---|
+| B1 `[R1-H5]` | high | 完整 xterm scrollback 每 2s 遍历 join 成串,触发全 nodes 替换 + 防抖磁盘写 | `AgentNodeBody/utils/terminal.ts:34` |
+| B2 `[R1-H6]` | high | `canvas:save` 把读-合并-写跑两遍,为 1 个改动节点做 ~5N 次磁盘读 | `main/canvas/store.ts:1161` |
+| B3 `[R1-M-Save1]` | medium | `writeCanvasFullV2` 每次保存 read+write 每个 per-node 文件,即便未改动 | `main/canvas/storage.ts:886` |
+| B4 `[R1-M-Save2]` | medium | 终端 scrollback 自动保存(每终端每 2s)驱动全 canvas 序列化 | `TerminalNodeBody/index.tsx:234` |
+| B5 `[R1-M-Save3]` | medium | 隐藏终端节点的 2s scrollback+getCwd 自动保存 `display:none` 时不暂停 | `TerminalNodeBody/index.tsx:234` |
+| B6 `[R1-M-Keep1]` | medium | 每个挂载(隐藏)Canvas 保持 `canvas:external-update` 订阅,匹配 workspace 全盘重读重建 | `useNodes.ts:154` |
+| B7 `[R2-§1.5]` | medium | AI/HTML iframe 节点把完整生成 HTML 内联进 per-node 画布 state,每次保存来回序列化 | `IframeNodeBody/useIframeNodeState.ts:301` |
+| B8 `[R1-M-Keep2]` | low→med | 共享 `allNodes` map 每 2s churn,经不稳定 `resolveReference` 回调重渲染所有挂载 Canvas | `Workbench/useWorkbenchState.ts:98` |
+
+**B 维核心修复**:分层 state —— scrollback/cwd 等"非视觉数据"走专用 patch 路径(不 push undo、不 resize group、不全 canvas 序列化);`canvas:save` 单次 merge + 缓存 `readCanvasFull` + 只写 `updatedAt` 变化的节点;HTML 内联改 sidecar 文件 + ref;隐藏/非 active 时暂停定时器与订阅。
+
+---
+
+## 维度 C:前端资源与代码分割
+
+> 公共背景:`electron.vite.config.ts` renderer 段**无 `manualChunks`、无 `build.target`**;全仓 `React.lazy` 边界 **= 0**;唯一运行时 `import()` 代码分割点是 `chat/utils/mermaid.ts`。以下静态 import 全部折叠进同一启动 chunk。
+
+| ID | 严重度 | 标题 | 关键文件 |
+|---|---|---|---|
+| C1 `[R2-§1.1]` | medium | 全部 8 种节点 body 的依赖联合体静态拉进首屏 chunk(空画布也付) | `CanvasNodeView/DefaultCanvasNode.tsx:12` |
+| C2 `[R2-§1.2]` | medium | xterm `Terminal` 被 5 个文件静态 import——与已做对的 mermaid lazy 正相反 | `TerminalNodeBody/index.tsx:3` |
+| C3 `[R2-§1.3]` | medium | chat 面板首屏无条件挂载,经 mentions 再导出把 markdown-it + hljs/lib/common 拉进启动 chunk | `chat/utils/markdown.ts:1` |
+| C4 `[R2-§1.4]` | medium | `createLowlight(common)` 模块顶层把完整 hljs common(~35 语法)拉进首屏 | `hooks/useFileNodeEditor.ts:36` |
+| C5 `[R1-B1]` | medium | 无 `manualChunks`——整个 renderer 打成单个 eager-parse chunk | `electron.vite.config.ts:111` |
+| C6 `[R1-B2]` | medium | `DefaultCanvasNode` 静态 import xterm + tiptap 节点体进 keep-alive canvas chunk | `DefaultCanvasNode.tsx:12` |
+| C7 `[R2-§2.7]` | low | `main.tsx` 静态 import module-federation runtime 并在首渲染前触发联邦加载 | `main.tsx:7` / `plugins/renderer/federation.ts:1` |
+| C8 `[R2-§2.8]` | low | I18nProvider 首渲染 eager import 含 en+zh 双表的 2377 行 messages 模块 | `i18n/messages.ts` |
+| C9 `[R1-L8]` | low | 实验视图(GraphPage / force-graph / d3)在 flag 关闭时仍被 `App.tsx` 静态导入 | `App.tsx:14` |
+
+**C 维核心修复**(P1 主杠杆):引入**全仓第一个 `React.lazy` 边界** —— `DefaultCanvasNode` 的 8 个 body 全部 `React.lazy + Suspense`(占位框作 fallback);xterm/markdown 套用 mermaid.ts 的 `import()` memoize 模板;`createLowlight(common)` 换 curated 子集(~5-8 语言);`electron.vite.config.ts` 加 `manualChunks` 拆 xterm/tiptap/lowlight/force-graph/MF-runtime 为独立 async chunk;i18n 按语言拆分(en eager / zh lazy)。
+
+---
+
+## 维度 D:首屏渲染与启动
+
+| ID | 严重度 | 标题 | 关键文件 |
+|---|---|---|---|
+| D1 `[R2-§2.1]` | **high** | 默认首启画布在首屏关键路径挂指向外部 URL 的 live `<webview>`(guest 进程 + 网络导航) | `main/canvas/welcome-workspace.ts:205` / `IframeNodeBody/useIframeNodeState.ts:101` |
+| D2 `[R2-§2.2]` | medium | 窗口加载串行卡在 4 步 async 链(seeding+env+内建插件+外部插件)后才 `openWindow()` | `main/app/bootstrap.ts:106-191` |
+| D3 `[R2-§2.3]` | medium | 重 body 模块静态 import 进 DefaultCanvasNode 落入启动 chunk(0 lazy 边界) | `DefaultCanvasNode.tsx:12`(同 C1/C6) |
+| D4 `[R2-§2.4]` | medium | 首绘同步构造两个 Tiptap 编辑器,各 eager 注册全 common 语言 | `hooks/useFileNodeEditor.ts:16` |
+| D5 `[R2-§2.5]` | low | 插件激活 gating 论据(注释)强于首绘所需;agent service 已更早构造 | `main/app/bootstrap.ts:159` |
+| D6 `[R2-§2.6]` | low | `reloadConfiguredExternalMainPlugins` 在窗口打开前同步 await 每个外部插件 `import()` | `plugins/main/external.ts` |
+| D7 `[R2-§2.9]` | low | 首启 welcome seeding 在窗口打开前完整执行 mkdir + 2×writeFile + saveCanvas + manifest | `main/canvas/welcome-workspace.ts:270` |
+| D8 `[R1-B3]` | low→med | 窗口仅在 await 插件 setup + tools-config + welcome seeding 后才打开 | `main/app/bootstrap.ts:106`(同 D2) |
+
+**D 维核心修复**(P0):welcome 的外部 `<webview>` 延迟到首屏后/进视口后挂载(占位卡片 + IntersectionObserver/idle);重排 `bootstrap.ts` —— 先 `openWindow()`/`loadFile`,seeding+插件激活并发于 renderer 下载/绘制(以 `mainReady` promise 保序;插件工具注册延迟到首个 agent turn 前而非窗口前)。
+
+---
+
+## 维度 E:终端 / Agent / PTY / IPC
+
+| ID | 严重度 | 标题 | 关键文件 |
+|---|---|---|---|
+| E1 `[R1-H3]` | high | `getCwd` 自动保存每 2s 对每节点同步 `execSync(lsof/readlink)`,阻塞主进程事件循环 | `main/terminal/pty-manager.ts:206` |
+| E2 `[R1-H4]` | high | 每个 xterm 容器 ResizeObserver 在每缩放动画帧重 fit + 重同步字号 | `TerminalNodeBody/index.tsx:281` |
+| E3 `[R1-M-IPC]` | medium | PTY `onData` 逐 chunk 扇出到渲染端 IPC + 每个 observer,零批处理 | `main/terminal/pty-manager.ts:281` |
+| E4 `[R1-M4]` | medium | 团队 Agent 输出逐 chunk 经序列化队列 + 每会话锁 + 全量 ANSI strip 解析 | `main/agent-teams/pty-bridge.ts:52` |
+| E5 `[R1-M-Exec]` | medium | `execInSession` 累积无界 buffer,对增长串每 chunk `includes/indexOf`(O(n²)) | `main/terminal/pty-manager.ts:406` |
+| E6 `[R1-M-Mirror]` | medium | Mirror 终端 detached/离屏仍保活 `pty:data` 订阅并 `term.write`(unmount 未退订) | `useAgentNodeController.ts:415` |
+| E7 `[R2-§3.9]` | low | `execInSession` 每调注册新 onData 监听器,无界缓冲直到 marker/30s,并发调用串扰 | `main/terminal/pty-manager.ts:406`(同 E5 角度) |
+| E8 `[R2-§3.10]` | low | `pty:write`/`pty:resize` 无流控:大粘贴整块推送;拖拽 resize 每像素一次同步 IPC + 原生 resize | `main/terminal/pty-manager.ts` |
+| E9 `[R1-L4]` | low | `scheduleTerminalFit` 每 mount/restore 触发 3 rAF + 2 setTimeout(5 次 fit+refresh) | `useAgentNodeController.ts:104` |
+| E10 `[R1-L5]` | low | 渲染端 `onData` 在 coding-agent hint 激活时每 chunk 跑 ANSI-strip + 两正则 | `TerminalNodeBody/index.tsx:98` |
+
+**E 维核心修复**(P0 含 E1):`getCwd` 改异步(linux 用 `fs.promises.readlink('/proc/<pid>/cwd')` 不 fork)并从 2s tick 解耦;PTY `onData` 合并 flush(~8-16ms/帧,一条拼接 IPC + 每 flush 一次 observer);`execInSession` 只扫尾部 marker + 数组 append + 封顶;mirror detach 时 `disposeSubscriptions()`;ResizeObserver rAF 合并 + 尺寸不变跳过 fit;`pty:resize` 拖拽去重。
+
+---
+
+## 维度 F:聊天流式与 Markdown / Mermaid
+
+| ID | 严重度 | 标题 | 关键文件 |
+|---|---|---|---|
+| F1 `[R1-H7]` | high | `markdown.render` 为每个无语言提示代码块跑 `highlightAuto`,放大每 token 重解析(O(n²)) | `chat/utils/markdown.ts:18` |
+| F2 `[R1-M-Chat1]` | medium | 逐 token `onTextDelta` 整 messages 数组拷贝;`ChatMessage` 未 memo,每 token 重解析 markdown | `chat/hooks/useChatStream.ts:240` / `ChatMessage.tsx:95` |
+| F3 `[R1-M-Chat2]` | medium | `publishTools()` 每 tool-input delta 与每 `onVisualStream` 帧拷贝数组 + 克隆 Map | `chat/hooks/useChatStream.ts:142` |
+| F4 `[R2-§3.4]` | medium | `mermaid.render()` 在 renderer 主线程同步无 worker,含图回复流式完成瞬间 jank | `chat/utils/mermaid.ts` |
+| F5 `[R2-§3.5]` | medium | 首个图付多百 ms 的 `import('mermaid')` + initialize 主线程 stall | `chat/utils/mermaid.ts:15` |
+| F6 `[R2-§1.6]` | low | mermaid 渲染每次 chat re-render 用 `host.innerHTML` 写裸 SVG,无 per-message 缓存 | `chat/utils/mermaid.ts` |
+| F7 `[R2-§1.3]` | medium | chat 子树(markdown-it + hljs)首屏无条件加载(详见 C3) | `chat/utils/markdown.ts:1` |
+
+**F 维核心修复**:`ChatMessage`/`ChatToolCalls` 包 `React.memo` + rAF 合并 text delta(每帧一次 setState);在途流式消息渲染纯文本/廉价 pass,完成时才跑完整 markdown+highlight,或按代码块内容 memo 化;mermaid 图间 yield + 限并发 + 源→SVG Map 缓存 + idle 预热 import。
+
+---
+
+## 维度 G:Force-graph / 工作区图
+
+| ID | 严重度 | 标题 | 关键文件 |
+|---|---|---|---|
+| G1 `[R1-H8]` | high | `buildGraphData` 每次 toggle 产出新 graphData,layout effect 每次计数变化 reheat + zoomToFit | `GraphPage.tsx:337` |
+| G2 `[R2-§3.2]` | medium | 可见性 toggle 重启全节点/链的 12s 主线程 d3 物理仿真(无 `cooldownTicks`) | `GraphPage.tsx:409` |
+| G3 `[R2-§3.3]` | medium | 全局 `workspaceNodes` onChange 重载所有工作区节点,无关编辑也重热仿真 | `GraphPage.tsx` |
+| G4 `[R1-M-Graph1]` | medium | `renderNode` 对选中/悬停节点逐帧 `measureText` + 带 shadowBlur 的 roundRect | `GraphPage.tsx:481`(同 A9) |
+| G5 `[R1-M-Graph2]` | medium | `searchSuggestions` 每按键经 `tagName` 线性扫 O(nodes × tags) | `GraphPage.tsx:284` |
+| G6 `[R2-§3.7]` | low | `linkDirectionalParticles` 击败 autoPauseRedraw,hover/active 钉死永久 60fps rAF | `GraphPage.tsx:767` |
+| G7 `[R1-L6]` | low | `highlighted` 每悬停重算驱动 link 回调;`linkKey` 每 link 每帧建串 | `GraphPage.tsx:364` |
+| G8 `[R1-L7]` | low | 全节点经 force-graph 渲染无上限/虚拟化,每 focus O(N) 线性 find | `GraphPage.tsx:337` |
+
+**G 维核心修复**:node identity 复用以 warm-start(保留 x/y),仅 `layoutPreset`/结构变化才 reheat;设有界 `cooldownTicks`(100-200);`onChange` 加工作区过滤 + debounce + 拓扑 diff gate;`measureText` 按 (label,fontSize) 缓存 + zoom 阈值抑制 label;`tagName` 用 `Map`;移除/限 highlight particle。
+
+---
+
+## 维度 H:运行时盲区(webview / 图片 / keep-alive)
+
+| ID | 严重度 | 标题 | 关键文件 |
+|---|---|---|---|
+| H1 `[R1-H9]` | high | `useMountedWorkspaceIds` 从不驱逐已访问 workspace + Canvas 无虚拟化(keep-alive 叠加) | `Workbench/useMountedWorkspaceIds.ts:11` |
+| H2 `[R2-§3.1]` | medium | Background throttle 只降帧——offscreen webview 的 timer/fetch/WebSocket 永远全速 | `IframeNodeBody/useWebviewBackgroundThrottle.ts:84` |
+| H3 `[R1-M-Keep3]` | medium | `PulseRouter` keepAlive 让整个 canvas 路由子树保持挂载,定时器/订阅/PTY 后台运行 | `router/index.tsx:56` |
+| H4 `[R2-§3.6]` | low | iframe 类节点 body(DynamicApp/artifacts/AI-HTML 预览)无帧率限流——只有 url-mode webview 有 | `IframeNodeBody` |
+| H5 `[R2-§1.7]` | low | 大图粘贴/拖入在主线程同步 decode+re-encode,落盘前来回 base64 | `utils/noteImageInsert.ts` |
+| H6 `[R2-§1.8]` | low | `restoreLocalImageMarkdown` 每次内容加载用 TreeWalker 遍历整个编辑器 DOM | `editor`/note image |
+
+**H 维核心修复**:LRU 限定挂载集(active + K=2-3),驱逐其余并拆 Canvas/ChatPanel/终端;非 active 路由/workspace 暂停定时器与 `external-update` 订阅(保留 DOM 状态);offscreen webview 超越降帧(宽限期后导航 about:blank / unmount);iframe 节点扩展 IntersectionObserver gating;大图 downscale 移 OffscreenCanvas/worker。
+
+---
+
+## 优先修复路线图(两轮合并)
+
+### P0 — 解除线性恶化根因 + 首屏最重单项(高收益)
+
+| 修复 | 对应 ID | 预估收益 | 改动量 |
+|---|---|---|---|
+| **视口裁剪 `useViewportCulling`** | A1, H1 | 内存/挂载从 O(总节点)降到 O(屏幕节点) | 大 |
+| **`getCwd` 异步化 + 解耦 2s 自动保存** | E1 | 消除主进程每 2s fork N 子进程的同步阻塞 | 中 |
+| **`canvas:save` 单次 merge + 增量写** | B2, B3 | 单节点改动 ~5N 读+N 写 → ~1 读+1 写 | 中 |
+| **welcome 外部 `<webview>` 移出首屏关键路径** | D1 | 移除冷启最重单项(guest 进程 + 外部网络) | 小-中 |
+| **`bootstrap.ts` 先开窗、后并发 setup** | D2, D5, D6, D8 | TTFP 减去插件激活串行链耗时 | 中 |
+
+### P1 — 资源拆分 + 热路径合并(高/中收益)
+
+| 修复 | 对应 ID | 预估收益 | 改动量 |
+|---|---|---|---|
+| **引入全仓首个 `React.lazy` 边界 + `manualChunks`** | C1-C6, D3, D4, C9 | 首屏 chunk 主线程 parse/eval 主杠杆 | 中 |
+| **drag/resize 几何排除出 nodes 数组 + `CanvasSurface` memo** | A2, A3, A4, A6, A8 | 大画布拖拽 jank 消除 | 大 |
+| **scrollback 专用低优先级更新路径** | B1, A5, B4, B5 | 消除 undo 污染 + 空闲全 buffer 遍历 | 中 |
+| **Chat 流式:memo + rAF 合并 delta + 流式不跑 highlightAuto** | F1, F2, F3, F7 | 代码密集回复从 O(n²) → 完成时一次 | 中 |
+| **PTY `onData` 合并 flush** | E3, E4, E8 | 高吞吐输出 IPC/CPU 压力降一量级 | 中 |
+| **keep-alive 后台静默(LRU + 暂停定时器/订阅)** | H1, H3, B6, B8 | 多 workspace 内存停止单调增长 | 中-大 |
+| **force-graph:有界 `cooldownTicks` + onChange 过滤/debounce + warm-start** | G1, G2, G3, G4, G5 | 实验 graph 大图帧率与搜索改善 | 中 |
+| **mermaid:图间 yield + 限并发 + 缓存 + idle 预热** | F4, F5, F6 | 含图回复流末 burst jank 消除 | 中 |
+
+### P2 — 局部清理与低频盲区收尾(小改动)
+
+| 修复 | 对应 ID |
+|---|---|
+| `resizeGroupsToChildren` 无 group 早退 | A6 |
+| 相对时间提升为单共享 ticker | A7 |
+| ResizeObserver rAF 合并 + 尺寸不变跳过 fit | E2 |
+| `execInSession` 只扫尾部 + 封顶 + per-session 串行 | E5, E7 |
+| mirror detach 时 `disposeSubscriptions()` | E6 |
+| `scheduleTerminalFit` 收敛单 rAF + trailing | E9 |
+| coding-agent hint 提示符检测节流 | E10 |
+| MF runtime 延迟出 entry chunk | C7 |
+| i18n 按语言拆分 | C8 |
+| welcome seeding 并发化 | D7 |
+| AI/HTML iframe 改 sidecar 文件 + ref | B7 |
+| offscreen webview 超越降帧 + iframe 节点 IntersectionObserver | H2, H4 |
+| 大图 downscale 移 worker;TreeWalker 全文预检 | H5, H6 |
+| 移除/限 highlight particle;`linkKey` 预算 | G6, G7, G8 |
+
+---
+
+## 架构级建议(跨发现的系统性模式)
+
+1. **集中式 `nodes` 数组是最大结构放大器** —— 分层 state:几何/拖拽用 ephemeral override(ref/CSS),不入 canonical 数组;scrollback/cwd 等非视觉数据走专用 patch 路径(不 push undo、不 resize group、不全 canvas 序列化);canonical 数组只在结构性变更时替换。
+2. **缺失虚拟化是内存与挂载成本天花板** —— Canvas 与 GraphPage 统一引入视口裁剪 + 离屏占位 + 懒挂载重型 body,与 keep-alive 多 workspace 叠加后收益倍增。
+3. **主进程 IPC 串行化使任何同步/重复 I/O 都成全应用停顿** —— 原则:主进程零同步子进程(`fs.promises`/`execFile`)、增量而非全量(只写 diff、只扫尾部)、合并而非逐事件(per-id flush 窗口)。
+4. **keep-alive 应保留状态但暂停工作** —— 引入 `routeActive`/`workspaceActive` 标志,隐藏时暂停定时器与订阅、保留 DOM/组件状态,LRU 驱逐真正空闲的 workspace;offscreen webview 也需超越降帧的挂起策略。
+5. **流式热路径需要帧级合并与 memo 边界** —— chat token / tool delta / PTY chunk 统一:rAF/帧级合并 setState + 叶子组件 `React.memo` + 昂贵解析(markdown/highlight/ANSI/mermaid)缓存或延迟到静默。
+6. **Bundle 应按"首绘不需即懒加载"切分** —— 沿用仓库已有的 `import('mermaid')` 模式,把 xterm/tiptap/force-graph/markdown/MF-runtime 全部 `React.lazy` + `manualChunks`,并把窗口创建移出主进程插件 setup 关键路径。
+
+---
+
+## 实测验证计划
+
+> 依赖未安装,本报告所有体积/耗时为**估算**。安装后按下列采集真实数据替换估算,并据此重排优先级(哪条是真瓶颈需 profiling 才能定序)。
+
+**A. Bundle / chunk 体积**(验证 C1-C9、D3/D4)
+```bash
+pnpm install
+pnpm --filter canvas-workspace build
+ls -lh apps/canvas-workspace/out/renderer/assets/*.js
+```
+加 `rollup-plugin-visualizer`(或 `source-map-explorer`)出 treemap,确认 lowlight common、Tiptap、xterm、markdown-it+hljs、MF-runtime、`messages.ts` 是否在 entry chunk。指标:startup chunk min/gzip 字节、各重依赖占比、lazy 化后缩减量。
+
+**B. 首屏 / time-to-window**(验证 D1/D2/D5/D6/D7)
+在 `bootstrap.ts` 的 `app.whenReady()` 起点与 `openWindow()` 处打 `performance.now()`,分段记录 seeding/applyEnv/setupCanvasPlugins/reloadExternal(分有/无外部插件两组);renderer `main.tsx` 首 `createRoot().render()` 前后打点;用 `webContents` `did-finish-load`/`dom-ready` 测 TTFP;welcome `<webview>` `did-finish-load` 计入 TTFMP 的耗时。
+
+**C. React render / 节点 body 加载**(验证 A1/A4/D3/A9)
+React DevTools Profiler 录冷启 + 打开各类型节点,统计 DefaultCanvasNode 及各 body 的 render count 与 commit 耗时;lazy 化后用 Network/Coverage 面板确认仅实例化类型的 chunk 被 fetch;Tiptap `useEditor` 构造次数与耗时。
+
+**D. webview / PTY 进程与内存**(验证 D1/H2/E5/E8)
+`app.getAppMetrics()` 采集 guest WebContents 进程数与各自 RSS;offscreen 节点用 Chrome Task Manager 观察 CPU% 是否随降帧下降(验证 H2:JS/timer 仍跑);终端拖拽 resize 计 `pty:resize` IPC 频次;execInSession 长跑命令观察 buffer 增长与监听器数。
+
+**E. mermaid / force-graph 渲染耗时**(验证 G1/G2/G4/F4/F5)
+`mermaid.ts` 的 `loadMermaid` 与 `render` 前后 `performance.now()`,实测首遇 import 耗时与每图 layout;含 3 图回复测流末 burst 总时长。force-graph 用 DevTools Performance 录 hover(particle rAF)/toggle(12s reheat)/跨工作区 onChange,测 per-frame `measureText` 调用数与帧时长、reheat 主线程占用秒数;对比有界 `cooldownTicks` 前后。
+
+---
+
+## 方法论说明
+
+两轮均由 dynamic workflow 编排:动态侦察热点维度 → 每维度并发深度分析 → **每条发现派独立对抗式验证 agent 回真实代码逐条证伪**(默认 `isReal=false`)→ 综合。第二轮额外锚定真实导入图数据并判 `duplicateOfRound1` 去重。
+
+- 第一轮:64 agent / 52 原始 → 39 确认(淘汰 25%)。
+- 第二轮:78 agent / 61 原始 → 30 确认且全新(剔除 13 条重复 + 18 条证伪/低置信)。
+
+对抗式验证多次**下修**了夸大结论(如把 Electron 本地加载误称"下载成本"、`React.memo` 已挡住的离屏重渲、React 18 自动批处理、welcome 空写守卫实际被跳过等),这些校正记录在两份原始报告的"对抗性核验"小节。
+
+**最大残留盲区:全部 67 条均为静态代码推断,零 profiling**。需按上文「实测验证计划」跑一次 production build + React Profiler + Electron 进程指标,才能把估算换成真实数并最终定序。

--- a/apps/canvas-workspace/docs/performance-analysis-round2.md
+++ b/apps/canvas-workspace/docs/performance-analysis-round2.md
@@ -1,0 +1,331 @@
+# Canvas Workspace 性能分析报告(第二轮:前端资源 / 首屏渲染 / 运行时)
+
+## 执行摘要
+
+本轮在第一轮(节点渲染无视口裁剪 culling、keep-alive 页面 eager mount 等"渲染扇出"主题)之外,沿**前端资源 / 首屏渲染 / 运行时**三维补充了一批**非重复**的新发现。核心结论有三:(1)**前端资源**——`canvas` 路由从 `App.tsx` 到 `DefaultCanvasNode.tsx` 是一条 100% 静态 import 链且全仓 **0 个 `React.lazy` 边界**,导致 Tiptap 全家桶、lowlight `common`(~35 个 highlight.js 语法)、xterm、markdown-it+hljs 等几乎所有重依赖被折叠进启动 chunk,即使打开的是空画布;(2)**首屏渲染**——主进程 `bootstrap.ts` 把"seeding + 工具环境 + 内建插件 + 外部插件"4 步串行 `await` 全部压在 `openWindow()` 之前,且默认 welcome 工作区在首屏关键路径上挂载一个**指向外部 URL 的 live `<webview>`**(本轮唯一 high);(3)**运行时**——稳态盲区集中在 force-graph(particle 钉死 rAF、每帧 per-node `measureText`、toggle 触发 12s 物理重热、全工作区 onChange 重载)、offscreen webview 仅降帧不停 JS/timer/网络、mermaid 主线程同步渲染等,均为第一轮 culling 议题未覆盖的稳态 CPU。注意:这是 Electron 桌面应用,renderer chunk 从本地磁盘 `file://` 加载,**无网络下载成本**,以下资源类发现的真实代价是**主线程 parse+eval 时间**,所有体积/耗时数字均为**估算**(依赖未安装,本轮无法 profiling)。
+
+---
+
+## 一、前端资源 (bundle / 依赖体积 / 资源加载)
+
+> 公共背景:`apps/canvas-workspace/electron.vite.config.ts` 的 renderer 段无 `build.rollupOptions.output.manualChunks`,全仓 `React.lazy` 边界为 0(唯一的运行时 `import()` 代码分割点是 `chat/utils/mermaid.ts`)。因此下列静态 import 全部折叠进同一个启动 chunk。
+
+### 1.1 [medium] 所有 8 种节点 body 的依赖联合体被静态拉进首屏 chunk
+- **文件:行**:`apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/DefaultCanvasNode.tsx:12-19`(JSX 分发 222-261)
+- **类别**:frontend-assets / first-paint
+- **证据**:第 12-19 行静态 import 全部 8 个 body(`AgentNodeBody`、`DynamicAppNodeBody`、`FileNodeBody`、`FrameNodeBody`、`IframeNodeBody`、`PluginNodeBody`、`TerminalNodeBody`、`TextNodeBody`)。JSX 是 `node.type === ...` 运行时三元链——**类型判别是动态的,但 import 是静态的**。各 body 拖入各自重依赖:FileNodeBody→`useFileNodeEditor`(StarterKit + 14 个 `@tiptap/extension-*` + `tiptap-markdown` + `CodeBlockLowlight` + lowlight `common`);TextNodeBody→`textNodeExtensions.ts`(第二份 StarterKit/ProseMirror 配置);TerminalNodeBody→`@xterm`。DefaultCanvasNode 可从 keepAlive 的 `canvas` 路由静态到达,故即使画布只含一种节点类型(或零节点),依赖联合体也在启动时全部加载。已核对:第 12-19 行确为 8 个 body 的静态 import。
+- **影响**:首屏成本 = **每种 body 依赖权重之和**,而非画布上实际存在的 body 的成本。只含 terminal 节点的工作区仍付完整 Tiptap+lowlight 代价;空画布全付。这是收缩 canvas 启动 chunk 的主杠杆。
+- **估算**:延迟权重合计(Tiptap 栈 + lowlight common + xterm)数百 KB minified 移出关键路径(**估算**)。
+- **修复**:将每个 `*NodeBody` import 改为 `React.lazy(() => import('../FileNodeBody'))`,body switch 外包 `<Suspense fallback={…}>`(可复用 culling 占位框)。三元已经 gate 渲染哪个 body,lazy() 后只有画布上实际实例化的类型才取对应 chunk。配合在 `electron.vite.config.ts` 加 `manualChunks` 给 Tiptap/xterm/lowlight 稳定的共享 async chunk。
+- **置信度**:0.82
+
+### 1.2 [medium] xterm `Terminal` 类被 5 个 renderer 文件静态 import 进启动 chunk——与已验证的 mermaid lazy 模式正相反
+- **文件:行**:`apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody/index.tsx:3-4`
+- **类别**:frontend-assets
+- **证据**:`import { Terminal } from '@xterm/xterm';` / `import { FitAddon } from '@xterm/addon-fit';` 顶层静态。同样的静态 import 出现在 `AgentNodeBody/useAgentNodeController.ts:2-3`、`AgentNodeBody/utils/terminal.ts:1-2`、`WorkspaceTerminalDock/index.tsx:3-4`,外加 `main.tsx:5` 的 CSS 副作用 `import "@xterm/xterm/css/xterm.css"`。但 `Terminal` 只在 `initTerminal`(TerminalNodeBody:122)里 `new Terminal(TERMINAL_OPTIONS)`(126/145)按需构造,由 terminal 节点 mount 时的 useEffect 触发。对比同目录 `chat/utils/mermaid.ts:15-29` 自带注释的正确范式(`import('mermaid')` 仅首个 mermaid fence 触发)。无 manualChunks → xterm 核心 + fit addon + xterm.css 全部并入首屏前的启动 chunk。
+- **影响**:打开空/纯文件画布的用户即便从不开终端,启动时也照付完整 xterm parse+eval。`Terminal` 是带 renderer/buffer/parser 子系统的大类。这是单点价值最高的缺失 lazy 边界,且与已做对的 mermaid 形成直接不对称。
+- **估算**:~250KB min / ~80KB gzip xterm 核心 + ~5KB fit addon 从启动 chunk 移除;~30-60ms script-eval 推迟出首屏(**估算**,Electron 本地加载,真实代价为 parse/eval 而非下载)。
+- **修复**:套用 mermaid.ts 模板——引入 `loadXterm(): Promise<{Terminal, FitAddon}>`(`import('@xterm/xterm')`/`import('@xterm/addon-fit')`),模块级 promise memoize;将已是 async 的 `initTerminal` 改为 `await loadXterm()` 后再构造;把 xterm.css 从 `main.tsx` 移入该 lazy 模块(或首次 terminal mount 时注入)。保持 `terminalTheme.ts`/`utils/terminal.ts` 的 `import type` 为纯类型(零成本)。
+- **置信度**:0.85
+
+### 1.3 [medium] RightDock / Chat 面板首屏无条件挂载,经 mentions.ts 再导出把 markdown-it + highlight.js/lib/common 静态拉进启动 chunk
+- **文件:行**:`apps/canvas-workspace/src/renderer/src/components/chat/utils/markdown.ts:1-3`(再导出于 `mentions.ts:5`,消费于 `ChatMessage.tsx:6,115,121`)
+- **类别**:frontend-assets
+- **证据**:markdown.ts 第 1-3 行静态 import 全套(`highlight.js/lib/common`、`markdown-it`、`markdown-it-task-lists`),并在模块顶层 eager 实例化(`const markdown = new MarkdownIt({…})` 第 42 行,`markdown.use(taskLists,…)` 第 51 行)。`new MarkdownIt()` 构造与 ~35 个语法注册在模块 init 时跑,早于任何 chat 消息存在。隔壁 mermaid.ts 证明团队懂 lazy 范式,markdown.ts 反其道。
+- **影响**:每次冷启都 parse+eval markdown-it 核心 + hljs `lib/common`(~35 语法,每个有副作用注册)。从不打开 chat 的用户也照付。结合 xterm,这是首屏 chunk 中只在交互时才需要的 chat/terminal 库。
+- **估算**:~250KB min / ~75KB gzip(markdown-it ~100KB + hljs common ~150KB)移出启动;~20-40ms MarkdownIt 构造 + 35 语法注册移出首屏(**估算,偏高,视为粗估**)。
+- **修复**:把 renderMarkdown 改 lazy(镜像 mermaid.ts:`loadMarkdown(): Promise<(s)=>string>` 用 `Promise.all([import('markdown-it'), import('highlight.js/lib/common'), …])`)。因 `renderMdWithMentions` 在 ChatMessage 同步渲染中调用,最干净的切点是路由级动态 import:`React.lazy(() => import('./components/chat/ChatView'))`,让整个 chat 子树(含 markdown 栈)成为面板/路由首次激活时加载的独立 chunk。这可作为全仓**第一个** React.lazy 边界。
+- **置信度**:0.85
+- **校正(对抗性核验)**:finding 把 RightDock 写成挂载点,但真实静态可达性走的是 `Workbench`(`App.tsx:514` 无条件渲染),而非 RightDock(后者由 Workbench portal 注入 ChatPanels);`ChatPage` 提供第二条无 flag 静态路径。结论不变;字节/耗时估算偏高。
+
+### 1.4 [medium] `createLowlight(common)` 在模块顶层把完整 highlight.js `common`(~35 语法)拉进首屏 canvas chunk,空画布也付
+- **文件:行**:`apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts`(import 第 17 行,`const lowlight = createLowlight(common)` 第 36 行)
+- **类别**:frontend-assets / first-paint
+- **证据**:已核对——第 17 行 `import { common, createLowlight } from 'lowlight';`,第 36 行 `const lowlight = createLowlight(common);` 在**模块顶层**(非 hook/extension factory 内)执行。静态可达链:`App.tsx`(`<PulseRouterView name='canvas' keepAlive>`)→ CanvasSurface → CanvasNodeView/index.tsx → DefaultCanvasNode.tsx(第 14 行 `import { FileNodeBody }`)→ FileNodeBody/index.tsx(第 5 行 `import { useFileNodeEditor, getMarkdown }`)→ 本模块。`common` 是 lowlight 打包的 ~35 个 highlight.js 语法。Rollup 把 `createLowlight(common)` 与全部语法折进同步启动 chunk,与画布是否含 file 节点无关。`CodeBlockLowlight.configure({ lowlight })` 仅在 FileNodeBody mount 时调用,但语法表已在启动时构建并驻留。
+- **影响**:~35 语法在初始 renderer 脚本求值期间(首屏前)解析、`createLowlight(common)` 注册表建立,每次启动(含空画布)都付——首屏关键路径的主线程 JS parse+execute + 可能永不使用的语法表常驻堆。
+- **估算**:35 个 `common` 语法 ~120-180KB min;与 Tiptap core+pm+extensions 合计 ~250-400KB min,是最重的单个 renderer 启动组(**估算**)。
+- **修复**:(1)curated 子集——`createLowlight()` 空起,`lowlight.register({ javascript, typescript, python, bash, json, … })` 只注册笔记实际用到的少数语言(~5-8 个,削减 70-80% 语法 payload);(2)更彻底——把整个 Tiptap/file-editor 栈包进 `React.lazy(FileNodeBody)` + `<Suspense>`,只含 terminal/agent/frame 的画布首屏永不 parse lowlight+tiptap。
+- **置信度**:0.85
+
+### 1.5 [medium] AI/HTML iframe 节点把完整生成 HTML 内联进 per-node 画布 state,每次 read-merge-write 保存来回序列化
+- **文件:行**:`apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/useIframeNodeState.ts:301-308,366-372`
+- **类别**:state-bloat / asset-weight
+- **证据**:AI/HTML commit 时整篇文档写入 `node.data`:`onUpdate(node.id, { data: { ...data, html: result.html, prompt, mode: 'ai' } })`(stream 完成)与 `data: { ...data, html: draftHtml, mode: 'html' }`(commit)。html-mode 无 file-ref 间接层(不同于 image 节点存 `data.filePath`)。`storage.ts` `writeCanvasFullV2` 把该 data 原样写进 `nodes/<id>.json`;`store.ts` `canvas:save` 每次保存做**两遍** `mergeExternalNodes`(firstPass + merged),各自读每个 node 的磁盘 JSON、parse、再 stringify。`visibleFieldsChanged` 额外在每个 per-node watcher 触发时 `stableStringify` data。
+- **影响**:每个 AI 生成"视觉"通常是内联 CSS/JS 的自包含文档(20-200 KB),几个节点即让工作区序列化 state 达数百 KB 到低 MB。每次 autosave 在读/merge 路径解析+序列化 3-4 次;同一 html 串同时驻留 React state(`data.html`)与 iframe srcDoc DOM,per-node 内存翻倍。
+- **估算**:每节点 20-200 KB;每次保存 3-4x parse+serialize;~1MB 工作区 state 下每次保存数十 ms 主进程事件循环阻塞(**估算**)。
+- **修复**:像 artifact(只存 `artifactId` 懒解析)或 image(`filePath` ref)那样持久化——把 html 内容移入 per-node 旁路文件 `nodes/<id>.html`,data 只存 ref + hash;至少在 merge 时按 `updatedAt` 相等短路、跳过未变大 blob 的 `stableStringify`。
+- **置信度**:0.78
+- **校正(对抗性核验)**:(1)read-merge-write 放大在 **Electron 主进程**(canvas storage),非 renderer 主线程;"数十 ms 主线程阻塞"应为"主进程事件循环阻塞",且在 per-workspace 保存锁下分散于多个 await,非单次同步冻结。(2)写侧部分有界——`writeCanvasFullV2` 按 `updatedAt` 仲裁、只重写变更 node;无界全量 parse 在**读/merge 侧**(2x mergeExternalNodes + readOnDiskNodeMap + seedPerNodeContent),仍是 3-4 次全读。
+
+### 1.6 [low] mermaid 渲染在每次 chat re-render 用 `host.innerHTML` 写裸 SVG,无 per-message 已完成图缓存
+- **文件:行**:`apps/canvas-workspace/src/renderer/src/components/chat/utils/mermaid.ts:55`
+- **类别**:runtime(资源/重解析)
+- **证据**:已核对——`renderInto`(55-70)在 async `mermaid.render()` 后 `host.innerHTML = result.svg;`。防重渲仅靠 DOM 属性:`renderMermaidIn`(83-92)选 `.chat-mermaid[data-rendered="false"]` 并翻 `host.dataset.rendered = 'pending'`。`ChatMessage.tsx:233-237` 在 `[assistantHtml, userHtml, isStreaming]` 的 useEffect 调 `renderMermaidIn`。问题:`assistantHtml` 每次内容变都被 `renderMdWithMentions` 重生成,消息 body innerHTML 被替换 → 已渲 SVG host 被销毁重建为 `data-rendered="false"` → 对同一 diagram 源的 `mermaid.render()` 从头重跑。无以源字符串为 key 的缓存。keep-alive 多 mount 或任何重置 innerHTML 的 re-render 都触发每个 mermaid 块重解析。
+- **影响**:含 mermaid 的消息,任何重建 HTML 的后续 re-render(流式完成后的后续 token、主题切换、keep-alive 重 mount)对未变 diagram 触发完整 parse+layout+SVG-serialize。`mermaid.render` 是最贵操作之一(dagre/elk 布局),异步不阻首屏但落地时 jank。
+- **估算**:每次冗余重渲省 ~50-300ms(**估算**)。
+- **修复**:在 mermaid.ts 加模块级 `Map<string, string>`,key 为 trim 后源 → 渲染 SVG;`renderMermaidSource` 在 `loadMermaid()`/`render` 前查缓存。源跨重渲稳定,使重渲降为 O(1) innerHTML 赋值。
+- **置信度**:0.6
+
+### 1.7 [low] 大图粘贴/拖入在主线程同步 decode+re-encode,再落盘前来回 base64
+- **文件:行**:`apps/canvas-workspace/src/renderer/src/utils/downscaleImage.ts:19-46`
+- **类别**:runtime / 主线程阻塞
+- **证据**:`saveImageBlob`(`noteImageInsert.ts:36-46`)先 `blobToBase64`(FileReader.readAsDataURL → 内存 base64)再 `downscaleImageBase64`。downscaleImage.ts 用 `img.src = 'data:…;base64,…'` 解码、`document.createElement('canvas')` + `ctx.drawImage` 栅格、`canvas.toDataURL(type, quality)` 重编码——主线程同步 decode+raster+re-encode,仅当最长边 > 1600px 触发。
+- **影响**:大粘贴(4000×3000 截图 ≈ 5-12 MB blob → ~7-16 MB base64)时,renderer 瞬时持 base64 + 解码 bitmap + 重编码 dataURL,`toDataURL` 重编码阻主线程(jank/掉帧)。持久化形式是 file ref(良好,saveImage 落盘存 filePath),故为瞬时尖峰而非 state bloat。
+- **估算**:每次大粘贴 50-300 ms 主线程阻塞;~2-3x 源图瞬时内存(**估算**)。
+- **修复**:decode/downscale 移出主线程——`createImageBitmap` + `OffscreenCanvas`(worker 或 `convertToBlob`)替代 img+canvas+toDataURL;Blob 直传 worker,不先序列化为 base64。
+- **置信度**:0.6
+- **校正(对抗性核验)**:降为 low。decode+re-encode 仅经 **note-editor 路径** `useFileNodeEditor.ts → saveImageBlob`(`noteImageInsert.ts:40`)且仅 > 1600px 触发;`useCanvasImagePaste.ts:173-191` **不** downscale/re-encode、**不**做两遍 FileReader(只 1 次 `readAsDataURL` + 1 个复用该 dataUrl 测尺寸的 `new Image()`)。原 finding "两遍 FileReader 翻倍分配"错误。真实问题仅:大图 downscale 在主线程同步重编码(无 OffscreenCanvas/worker),用户显式手势上的一次性 per-paste 尖峰。
+
+### 1.8 [low] `restoreLocalImageMarkdown` 每次内容加载用 TreeWalker 遍历整个编辑器 DOM
+- **文件:行**:`apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts:68-106,136-138`
+- **类别**:runtime / state-bloat 向量
+- **证据**:`MarkdownSafeImage.parse.updateDOM` 调 `restoreLocalImageMarkdown(element)`(137),后者 `document.createTreeWalker(element, NodeFilter.SHOW_TEXT)` 遍历整篇笔记,对每个含 `![` + 本地提示的文本节点跑全局 `FILE_IMAGE_MARKDOWN_RE`(只匹配 `file://`/`pulse-canvas://`)并重建 DOM 片段。每次 markdown parse(即每次 load/setContent)触发。正则只匹配 file/pulse-canvas → 确认粘贴的 `data:` URI 非持久化形式(`saveImageBlob` 总落盘并插 file ref)。
+- **影响**:大笔记每次加载全文 TreeWalker + 每候选文本节点正则(数 ms),并被画布打开时多 file 节点同时 mount 的无 culling 扇出放大。low——持久化是 file ref 非内联 base64,属加载 CPU 非 state bloat。残留:外部导入的已含 `data:image/*` 的 markdown 会绕过 file-ref 路径内联存进 `node.data.content`。
+- **估算**:大笔记加载数 ms,被同时多节点 mount 放大(**估算**)。
+- **修复**:在编辑器层用 `LOCAL_IMAGE_HINT_RE` 对全文做廉价预检后再 walk,无本地图提示则整体跳过;另加守卫:加载时把入站 `data:image/*` 转存为 file ref,防导入笔记内联 base64 进 state。
+- **置信度**:0.6
+
+---
+
+## 二、首屏渲染 (启动到首个可用画面的关键路径)
+
+### 2.1 [high] 默认首启画布在首屏关键路径上挂载指向外部 URL 的 live `<webview>`(guest 进程 + 网络导航)
+- **文件:行**:`apps/canvas-workspace/src/main/canvas/welcome-workspace.ts:205-220`;`apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/useIframeNodeState.ts:101-118`
+- **类别**:first-paint
+- **证据**:welcome-workspace.ts 作为**唯一**默认工作区(`WELCOME_WORKSPACE_ID = 'default'`)seed 一个 iframe 节点 `node-welcome-download`,`data: { url: DOWNLOAD_URL, mode: 'url' }`,`DOWNLOAD_URL = 'https://pulse-canvas-download.pages.dev/'`(第 15 行),尺寸 `width: 1191, height: 1369`。mount 时 `useIframeNodeState` 的 **`useLayoutEffect`**(101)在 paint 前同步跑:`const webview = document.createElement('webview'); … webview.setAttribute('src', url); host.appendChild(webview);`——外部导航在 layout effect(阻 paint)里首次 Canvas mount 即发起。CanvasSurface 无 culling(`renderGroups.regular.map((node) => renderNode(node))`,`CanvasSurface.tsx:266`),seed 的 `scale: 0.5567` + 位置使该节点启动即在视口内,Electron 附加独立 guest WebContents 进程并开始拉取/解析/绘制外部站点,计入 time-to-first-usable-frame。
+- **影响**:全新安装的首个有意义绘制被 gate 在:(a)为 guest 起第二个 Chromium renderer 进程;(b)对外部 Cloudflare Pages 站点的 DNS+TLS+HTTP 往返(网络相关、无界——离线用户看到 load-error 卡闪现);(c)1191×1369 表面的 GPU tile 分配。这些都非用户操作画布所需的 app shell,是 onboarding chrome。这是冷启路径上最重的单项且完全外部不可控。
+- **估算**:guest 进程 spawn + 外部 fetch + 嵌入页首绘制通常给冷启 interactive 加数百 ms 到 >1s,网络相关;延迟挂载可移除几乎全部 TTFMP(**估算**)。
+- **修复**:延迟 `<webview>` 挂载到首屏之后/节点进入视口后。初始 mount 渲染轻量静态占位(下载页缩略图,或带 URL + "Load" 的卡片);首次 IntersectionObserver 命中或 `requestIdleCallback` 后再创建真 `<webview>`。现有 `webviewHostRef` + `webviewKey` 重 mount 机制已支持后挂载——在 layout effect 里用 `hasBecomeVisible` ref gate 住 `document.createElement('webview')` 而非无条件运行。
+- **置信度**:0.8
+
+### 2.2 [medium] 窗口/HTML 加载被串行卡在 4 步 async 链(seeding + 工具环境 + 内建插件 + 外部插件)之后才 `openWindow()`,无任何工作与 renderer 下载/解析/首绘重叠
+- **文件:行**:`apps/canvas-workspace/src/main/app/bootstrap.ts`(106 / 135 / 163 / 164 / 191)
+- **类别**:first-paint
+- **证据**:已核对——`app.whenReady()` 中:第 106 行 `await ensureWelcomeWorkspaceSeeded()`、第 135 行 `await applyStoredBuiltInToolsConfigToEnv()`、第 163 行 `await setupCanvasPlugins(BUILT_IN_MAIN_PLUGINS)`、第 164 行 `await reloadConfiguredExternalMainPlugins()` 顺序 resolve,之后第 191 行才 `openWindow()`(→ `createWindow` → `win.loadFile(rendererIndexPath)`)。在这些 await 完成前不构造任何 BrowserWindow,renderer 无法开始下载/解析 `main.tsx` 或绘制 `index.html` 的零-JS boot-screen(`.boot-screen` "Preparing workspace")。
+- **影响**:TTFP 被 seeding + env apply + 内建插件 activate() + 外部插件 `import()` 的总时长推后;冷启期间 OS 整段不显示任何窗口(连 boot skeleton 都没有)。
+- **估算**:内建插件激活 + 外部 import() 通常数十至数百 ms,首启 seeding 叠加磁盘 I/O;串行链是本维感知延迟的主导可避免项(**估算,负载相关**:无外部插件时近零,有外部插件或某内建 activate() 做 I/O 时显著)。
+- **修复**:**先**构造 BrowserWindow 并 `loadFile`(紧随首批 IPC 往返所需的 handler 注册之后),再**并发**跑 seeding/env/内建/外部插件,期间 renderer 下载/解析并绘制 boot-screen。renderer 首个 `canvas:load` IPC 可 `await` 单个 `mainReady` promise 以保序。
+- **置信度**:0.78
+- **校正(对抗性核验)**:第 163 行 await 部分 load-bearing(代码注释:canvas-agent 工具注册表须在 renderer 首个 canvas-agent IPC 前填好),故修复需"早构造/加载窗口、但在 agent IPC 被触发前完成插件注册",而非盲目把全部重排到 `openWindow()` 之后。
+
+### 2.3 [medium] 重节点 body 模块(xterm、Tiptap+18 扩展、highlight.js/lowlight、webview 接线)被静态 import 进 DefaultCanvasNode,落入启动 chunk——0 个 React.lazy 边界
+- **文件:行**:`apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/DefaultCanvasNode.tsx:12-19`;`hooks/useFileNodeEditor.ts:1-36`;`components/TerminalNodeBody/index.tsx:3-4`
+- **类别**:frontend-assets / first-paint
+- **证据**:见 §1.1 / §1.4。DefaultCanvasNode 从 `App.tsx` 同步 import 链可达,全 renderer 无 `React.lazy()`,故 xterm、完整 Tiptap/ProseMirror 栈、tiptap-markdown、highlight.js-common 全被拉进首屏 JS chunk 并在画布渲染前于主线程 parse+eval。
+- **影响**:即使工作区零 file/terminal 节点,启动 bundle 也须解析+求值 xterm、Tiptap 栈、highlight.js-common,均在首绘前于主线程跑。
+- **估算**:Tiptap+ProseMirror ~300-500KB min、xterm ~150-250KB min、highlight.js common ~250-400KB min,合计约 0.7-1.1MB 与纯文本/图形/图片画布无关的 JS(**估算,偏高**)。
+- **修复**:每个重 body 包 `React.lazy` + `Suspense`(占位框作 fallback),只加载实际存在节点类型的 chunk;`createLowlight(common)` 换 curated 子集;`electron.vite.config.ts` 加 `manualChunks` 拆 xterm/tiptap/lowlight/force-graph 为独立 vendor chunk。
+- **置信度**:0.8
+- **校正(对抗性核验)**:Electron 应用 renderer JS 从本地 `file://` 加载,**无网络下载**,~0.7-1.1MB 含下载的估算被高估;真实代价仅首绘前主线程 parse+eval。统计为 **8** 个静态 body(非 6)。严重度从隐含 high 降为 medium。
+
+### 2.4 [medium] 首绘时同步构造两个 Tiptap 编辑器,各 eager 拉入注册全部 `common` 语言的 lowlight/highlight.js
+- **文件:行**:`apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts:16-18,36`;`apps/canvas-workspace/src/main/canvas/welcome-workspace.ts:189-204,221-236`
+- **类别**:first-paint
+- **证据**:welcome 工作区 seed **两个** `type: 'file'` 节点(`node-welcome-note`、`node-welcome-detail`,seed transform 下均在视口)。`DefaultCanvasNode.tsx:222` 各渲为 `<FileNodeBody>`,调 `useFileNodeEditor` → `useEditor(...)`(@tiptap/react)mount 时同步。扩展集重且静态(StarterKit、Image、Table*×4、TaskList/TaskItem、Link、Underline、Highlight、Markdown、`CodeBlockLowlight`),`const lowlight = createLowlight(common)`(已核对第 36 行)在启动 chunk 求值期运行;首次 Canvas mount 中构建两次完整 Tiptap ProseMirror schema+view。无 React.lazy 边界。
+- **影响**:冷启在主线程同步:模块加载时求值 `createLowlight(common)`(~35 语法对象注册),再构造两个完整 Tiptap 实例(schema compile + EditorView mount + seed 笔记的 markdown parse)。纯主线程阻塞、无 yield,与上 §2.1 webview spawn 争同一首帧。
+- **估算**:lowlight `common` 低数百 KB 语法在启动解析;两次同步 Tiptap mount 各数十 ms 主线程(**估算**;对抗核验:`common` 注册约 37 个语法定义对象属"注册/装配"非"解析数百 KB",真实代价为注册 + 两次同步 EditorView mount + markdown parse,合计数十 ms,scoped 到首个画布绘制及后续含 file 节点的工作区加载,非全 app-shell 阻塞)。
+- **修复**:(1)`createLowlight(common)` → curated 小语言集;(2)lazy 编辑器——初始渲染笔记 markdown 为静态 HTML/纯文本,`useEditor` 仅 focus/intersection 时实例化(`React.lazy` FileNodeBody 编辑子树,或 `isActive` flag gate);(3)`manualChunks` 把 @tiptap+lowlight 拆出 entry chunk。
+- **置信度**:0.8
+
+### 2.5 [low] 插件激活 gating 论据(注释 159-162)强于首绘所需;agent service 已更早构造,工具注册只在首轮需要
+- **文件:行**:`apps/canvas-workspace/src/main/app/bootstrap.ts`(注释 159-162,await 163)
+- **类别**:first-paint
+- **证据**:已核对——注释(159-162)称须在 `openWindow` 前 await `setupCanvasPlugins`,因"插件激活可注册 canvas-agent 工具;需在任何 canvas-agent 被构造前完成(发生于 renderer 首次调 canvas-agent IPC)"。但 `CanvasAgentService` 早已构造:`setupCanvasAgentIpc()`(bootstrap:118)→ `getService()` → `getCanvasAgentService()` → `service = new CanvasAgentService()`(`agent/ipc.ts:52-54,64`)。故插件运行时单例已存在——该 await 保护的"工具先于构造"顺序并未由它达成。真正须先于的是**首个 agent turn**,仅在用户打开 chat 并发消息后,远晚于首绘。
+- **影响**:阻塞窗口创建于插件激活的最强论据不成立:在首轮前(而非窗口打开前)注册插件工具工厂即足够。把该 await 留在关键路径,是为一个已在别处满足或更晚才需要的正确性保证付首绘延迟。
+- **估算**:从首绘关键路径回收内建+外部插件激活时间(数十至数百 ms),agent turn 行为不变(**估算**)。
+- **修复**:把 `setupCanvasPlugins`/`reloadConfiguredExternalMainPlugins` 移出 pre-openWindow 路径;让 `CanvasAgentService` 在 turn-start 懒装配插件工具工厂(已按需读 `getRegisteredCanvasToolFactories()`),gate 于 plugins-ready promise。
+- **置信度**:0.7
+
+### 2.6 [low] `reloadConfiguredExternalMainPlugins` 在窗口打开前同步 await 每个外部插件的 `import()`
+- **文件:行**:`apps/canvas-workspace/src/plugins/main/external.ts`(bootstrap.ts:164)
+- **类别**:first-paint
+- **证据**:bootstrap.ts:164 `await reloadConfiguredExternalMainPlugins()` → `loadExternalMainPluginEntries` 循环 `const mod = await import(moduleUrl)`(external.ts:53)每插件,再 `await setupCanvasPlugins(plugins)`(27)逐个 `await plugin.activate(...)`(registry.ts:60)。外部插件付完整模块 parse+evaluate(不同于静态 import 的内建)。
+- **影响**:每个用户装的外部主插件把 import()+activate() 延迟直接加到 TTFP,无界扇出(每插件一额外 await 轮);N 个插件 → 启动延迟随插件数线性,首帧均不需要。
+- **估算**:每外部插件 import()+activate 加低数十 ms;N 插件 → N×该值,全串行(**估算**)。
+- **修复**:把 `reloadConfiguredExternalMainPlugins` 整体延迟到 `openWindow()` 之后,resolve 进与 agent turn await 的同一 plugins-ready promise(同 §2.5)。
+- **置信度**:0.55
+
+### 2.7 [low] main.tsx 静态 import module-federation runtime 并在 bootstrap(首次 React render 前)触发联邦插件加载
+- **文件:行**:`apps/canvas-workspace/src/renderer/src/main.tsx`(7-11,24);`src/plugins/renderer/federation.ts`(1-5,103-110,300-307)
+- **类别**:first-paint / frontend-assets
+- **证据**:main.tsx 7-11 静态 import `../../plugins/renderer`(再导出 `activateConfiguredFederatedRendererPlugins`),federation.ts 1-5 静态 import `@module-federation/runtime` + 完整命名空间 `import * as React/ReactDom/ReactDomClient/ReactJsxRuntime`,整个 MF runtime 进 entry chunk。main.tsx:24 `void activateConfiguredFederatedRendererPlugins().catch(...)` 在 bootstrap 发 async IPC `canvasWorkspace.canvasPlugins.list()` 并 `ensureFederation()` → `init({...})`——即便零联邦插件配置(内建 mock-node remote 总注册),也在主线程与首绘并发调度。
+- **影响**:MF runtime parse/eval 在 entry chunk 每次冷启付;bootstrap 还调度与首渲染争主线程的 IPC 往返 + federation init()。唯一预绘所需的内建 renderer 插件 `DevtoolsRendererPlugin` 根本不需 MF。
+- **估算**:`@module-federation/runtime` ~30-60KB min 在 entry chunk;外加首绘窗口内一次 async IPC + init()(**估算**)。
+- **修复**:延迟 federation——main.tsx 同步调 `activateCanvasPlugins(BUILT_IN_RENDERER_PLUGINS)`(廉价,无 MF),在 `createRoot().render()` **之后**于 `requestIdleCallback`/微任务里 `import('../../plugins/renderer/federation')`,让 runtime 离开 entry chunk;先判断是否配置了联邦 spec 再拉 runtime。
+- **置信度**:0.8
+
+### 2.8 [low] I18nProvider 在首渲染 eager import 含 en+zh 双表的单个 2377 行 messages 模块
+- **文件:行**:`apps/canvas-workspace/src/renderer/src/i18n/messages.ts`(`i18n/index.tsx:13,68`;`App.tsx:597`)
+- **类别**:frontend-assets / first-paint
+- **证据**:`i18n/index.tsx:13` import `messages`,I18nProvider(`App.tsx:597`,最外层 provider)读 `messages[language][key]`(index.tsx:68)。messages.ts 单文件 2377 行,含完整 `en`+`zh` 词典。`getInitialLanguage()`(36-45)只选一种语言,但两张全表都在启动 chunk,无 per-language 拆分。
+- **影响**:非激活语言整张串表每次首绘被解析(纯浪费);大对象字面量在 entry eval 时于主线程解析。
+- **估算**:非激活语言表约占 2377 行字面量一半,延迟它移除约该量串解析(**估算**)。
+- **修复**:拆 `messages.en.ts` / `messages.zh.ts`;同步加载激活语言(或内联 `en` 作 fallback),`setLanguage` 切到另一语言时才 `import()`。`en` eager(index.tsx:68 的 fallback),`zh` lazy。
+- **置信度**:0.85
+
+### 2.9 [low] 首启 welcome seeding 在窗口打开前完整执行 mkdir + 2×writeFile + saveCanvas + manifest 写
+- **文件:行**:`apps/canvas-workspace/src/main/canvas/welcome-workspace.ts`(270-289;`service.ts:39-65`)
+- **类别**:first-paint
+- **证据**:`ensureWelcomeWorkspaceSeeded`(bootstrap.ts:106 await)在冷启路径同步 await 磁盘 I/O:`await fs.mkdir(notesDir, …)`(270)、两次 `await fs.writeFile(...)`(271-272)、`await saveCanvas(...)`(274)、`await writeWelcomeManifest(...)`(289)。非首启 `listWorkspaces` 提前返回(260 `if (existing.workspaces.length > 0) return`),仅首启付。
+- **影响**:冷首启 OS 窗口被 ~4-5 串行 fs 操作延迟;warm SSD 数 ms,冷文件缓存/慢/网络 home 目录下数十 ms,且与链其余部分严格串行,renderer 期间无法绘制 boot-screen。
+- **估算**:从 pre-window 路径移除数十 ms 仅首启 fs 延迟(**估算**)。
+- **修复**:`openWindow()` 后并发跑 seeding;renderer 初始 `canvas:load` await seeding promise(本就需处理空/刚建工作区)。"Preparing workspace" boot-screen 文案正为此设计。
+- **置信度**:0.5
+- **校正(对抗性核验)**:`saveCanvas` 的"额外 readCanvasFull 空写守卫"仅当 `data.nodes.length === 0` 运行;welcome 画布 seed 了 3 个节点(WELCOME_NOTE/DOWNLOAD/DETAIL),故守卫被**跳过**,无额外读。真实成本 = 1 mkdir + 2 writeFile + 1 canvas 写 + 1 manifest 写 ≈ 4 次小写、无读。且相对同链后续更重的 `await setupCanvasPlugins/reloadConfiguredExternalMainPlugins`(163-164),seeding 占 pre-window 延迟一小部分,且 app 生命周期仅首启跑一次。
+
+---
+
+## 三、运行时 (稳态 CPU/内存/响应性,侧重第一轮 culling 议题未覆盖的盲区)
+
+### 3.1 [medium] Background throttle 只降帧——offscreen webview 的 JS/timer/fetch/WebSocket 永远全速运行
+- **文件:行**:`apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/useWebviewBackgroundThrottle.ts`(84;`registry.ts:545`)
+- **类别**:runtime-cpu
+- **证据**:hook 对 throttled webview 的**唯一**作用是 `api.setFrameRate(workspaceId, nodeId, rate)`(84)→ 主进程 `wc.setFrameRate(clamped)`(registry.ts:545)。hook 自身注释(7-10)明示:"guest 进程存活——JS、timers、网络、页内 state 全保留"。`setFrameRate` 在 Chromium 只管合成器 paint/raster tile 节奏,不暂停 guest JS 事件循环、`setInterval/setTimeout`、fetch、XHR、WebSocket。故 offscreen 的 Figma/dashboard/video 节点仍无限烧 CPU 于页内 timer 与网络轮询并持完整堆。
+- **影响**:CPU 底噪随**活动内容** link 节点数线性,与可见性无关;多个自刷新 dashboard 节点 → N 个后台 renderer 的等效主线程工作,耗电、与前台画布争核。
+- **估算**:单个自刷新 dashboard SPA 每 offscreen 节点稳态持 1-5% CPU;多个 → 多核百分点后台底噪(**估算**)。
+- **修复**:深度 offscreen 节点升级超越降帧:较长宽限期后导航 guest 至 about:blank 并持久化 URL 以恢复,或超时后整体 unmount guest(同 culling 的 mount-gating)。纯 setFrameRate 不足以回收 CPU/网络,注释亦确认此为设计取舍。
+- **置信度**:0.7
+- **校正(对抗性核验)**:机制被高估——rAF **并非**不受影响:Chromium `setFrameRate` 把 rAF 回调投递降到设定帧率(~1fps),故 rAF 驱动的动画/轮询会减慢。准确说法:`setInterval/setTimeout/fetch/XHR/WebSocket` 继续全速(timer 队列/网络驱动,与合成帧率无关)。且这是为保留 guest state 的**刻意文档化取舍**,是否应"修"存疑。
+
+### 3.2 [medium] 切换可见性 toggle(showTags/showLinks/showWorkspaceHubs/showOffCanvas/density)重启全节点/链的 12s 主线程 d3 物理仿真
+- **文件:行**:`apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/GraphPage.tsx`(409-430,424,430,776)
+- **类别**:runtime
+- **证据**:layout effect(409-430)以 `graph.d3ReheatSimulation()`(424)结尾,key 为 `[graphData.links.length, graphData.nodes.length, layoutPreset]`(430)。`cooldownTime={12000}`(776)且**无** `cooldownTicks` → reheat 后 sim 跑满 12000ms wall-clock。`graphData` 由 `buildGraphData`(108-199)在 `[showLinks, showTags, showWorkspaceHubs, tags, t, visibleNodes, workspaces]`(337-346)useMemo 重建;`visibleNodes` 依赖 `showOffCanvas`(279-282)。toggle 这些改变 node/link **计数** → 改 `graphData.{nodes,links}.length` → 重触 effect → reheat → 新 12s 力 tick。d3-force 在主线程(无 web-worker offload)。
+- **影响**:每次 toolbar toggle 最多 12 秒持续主线程物理(每 tick O(nodes+links),charge 无 Barnes-Hut 调优时 O(n²)),期间 rAF 重绘亦活;快速 toggle 叠加 reheat;此窗口内 UI 交互与 sim 争主线程,致输入卡顿/掉帧。
+- **估算**:每 toggle 12s wall-clock 物理;~500 节点下每 reheat 数秒累计主线程时间(**估算**)。
+- **修复**:设有界 `cooldownTicks`(如 100-200)替代/补充 `cooldownTime`,使 sim 在固定工作量后确定停止;debounce toggle;reheat effect 别纯以 length delta 为 key,标签/链 toggle 只增叶节点时增量 re-warm 而非全 reheat。
+- **置信度**:0.8
+
+### 3.3 [medium] 全局 workspaceNodes onChange 重载所有工作区节点,可在无关编辑上重热仿真
+- **文件:行**:`apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/useWorkspaceNodes.ts`(123-129,73-114)
+- **类别**:runtime
+- **证据**:`useAllWorkspaceNodeList` 注册 `api.onChange(() => { void reload(); })` **无工作区过滤**(123-129)——不同于 `useWorkspaceNodeList` 过滤 `event.workspaceIds.includes(workspaceId)`(50-58)。`reload`(73-114)`Promise.all(workspaces.map(...api.list...))` 重取**每个**工作区,建新身份 `nextNodes` 调 `setNodes`。GraphPage 中 `nodes` → `visibleNodes`(新数组,279-282) → `graphData` useMemo 重算(337-346);若改了 node/tag/link 计数,`length` 变 → reheat effect(430)再触 12s sim。agent 的 `canvas_tag_node` 与任何画布编辑都发此事件,**任一**工作区贴一个 tag 即重列**所有**工作区并可能重热图物理。
+- **影响**:图视图打开时,任一工作区的后台 agent 活动或编辑触发全多工作区 re-list(N 个 IPC 往返 + 全数组重建)外加可能 12s reheat,即便该工作区不贡献可见变更。由外部事件驱动的稳态 churn,非用户交互。
+- **估算**:每变更事件一次全 N 工作区 `api.list` 扇出;计数变则 reheat 加最多 12s(**估算**)。
+- **修复**:`useAllWorkspaceNodeList` 的 onChange 按 `event.workspaceIds` 与已加载 workspaces 是否相交过滤,并 debounce/coalesce 快速事件;更优:diff 新节点列表,仅拓扑实变时 `d3ReheatSimulation()`,解耦 re-fetch 与 re-warm。
+- **置信度**:0.8
+- **校正(对抗性核验)**:从隐含 high 调为 medium——仅 Graph/Nodes 视图 mount 时、仅 knowledge-tag 变更事件触发,非每次画布保存/流式 tick,属 gated/bounded 而非持续热路径。
+
+### 3.4 [medium] mermaid.render() 在 renderer 主线程同步、无 worker offload——含图回复在流式完成瞬间 jank
+- **文件:行**:`apps/canvas-workspace/src/renderer/src/components/chat/utils/mermaid.ts:41-53,55-70,83-92`;`ChatMessage.tsx:233-236`
+- **类别**:runtime
+- **证据**:已核对——`renderMermaidSource` `const { svg } = await mermaid.render(id, trimmed);`(47)。虽 await,`mermaid.render` 内部 CPU 同步:在调用(主)线程解析 DSL + 跑 dagre/ELK 布局 + SVG 串装配,**无 Web Worker**。`renderMermaidIn`(83-92)遍历每个 pending host 触发 `void renderInto(host)`,无并发上限/分块,一条消息所有图背靠背渲染。`ChatMessage` gate 于流末:`useEffect(() => { if (isStreaming) return; renderMermaidIn(bodyRef.current); }, [assistantHtml, userHtml, isStreaming])`。`isStreaming` 守卫对可解析性正确,但意味含 N 图回复在流完成瞬间把 N 个 host 一起翻转并在单串行 burst 中渲染,恰逢 token 流重渲压力 + 末次绘制落同一画布线程。
+- **影响**:每个非平凡流程图/时序图约 30-150ms 阻塞主线程布局;3 图回复 → 流完成时 ~90-450ms jank(画布掉帧、chat 滚动冻结、PTY/IPC delta 停滞)。画布、force-graph rAF、chat 共用此一 renderer 线程,故 stall 是全窗口的(**估算**)。
+- **修复**:图间 yield 摊销 burst——每图一 rAF/idle 回调(`requestAnimationFrame` 或 `scheduler.postTask`);更优把 parse+layout 移线程外(专用 Worker 跑 render 并 postMessage SVG 串回,主线程只 `host.innerHTML`);至少限并发并优先视口内 host。
+- **置信度**:0.78
+
+### 3.5 [medium] 首个图付多百 ms 的 `import('mermaid')` + initialize 主线程 stall——renderer 唯一代码分割点
+- **文件:行**:`apps/canvas-workspace/src/renderer/src/components/chat/utils/mermaid.ts:15-29`
+- **类别**:first-paint(运行时首遇)
+- **证据**:已核对——`import('mermaid').then(mod => { const m = mod.default; m.initialize({...}); return m; })`(17-26)。文件自注释:"mermaid bundle 约 1MB"。这是 renderer 唯一代码分割边界(grep 确认 renderer 源唯一运行时 `import(` 即此;`App.tsx:324` importWorkspace 与 `CanvasRootView.tsx:76` 是函数调用/类型,非模块加载)。`loadMermaid` 由 `renderMermaidSource`(45)懒触,后者为 ChatMessage `renderMermaidIn`、`ChatInlineVisual`(168)、ArtifactTabView `ArtifactMermaid`(161)共享入口。故首个 chat 图 / 首个 mermaid inline visual / 首个 artifact 抽屉图——孰先——触发一次性模块 parse+evaluate + `mermaid.initialize`。
+- **影响**:首遇图为多百 ms 主线程 stall:~1MB JS(mermaid + dagre/d3)须磁盘读取、解析、求值,再 initialize,全在首个 SVG 出现前。因懒落地于会话中段(非启动),用户感知为首次任何图浮现时的突然冻结,期间画布与 chat 无响应。懒边界本身正确(挡出启动 chunk),但无预热。
+- **估算**:~1MB bundle(注释),多百 ms parse+init 首遇(**估算**)。
+- **修复**:保留懒边界但首屏外预热——idle 时(`requestIdleCallback` 首绘后)或检测到流式部分内容已含 ` ```mermaid ` fence 时投机 `loadMermaid()`,使 import 与流重叠;考虑 tree-shake 到仅支持的图类型(flowchart/sequence)削减 ~1MB parse。
+- **置信度**:0.78
+
+### 3.6 [low] iframe 类节点 body(DynamicApp、artifacts、AI/HTML 预览)无帧率限流——只有 URL-mode `<webview>` 有
+- **文件:行**:`apps/canvas-workspace/src/renderer/src/components/DynamicAppNodeBody/index.tsx:147-152`(`useIframeNodeState.ts:274,106`;`IframeRenderedView.tsx:180-190`)
+- **类别**:runtime / 浪费 GPU
+- **证据**:`useWebviewBackgroundThrottle` 仅从 `useIframeNodeState`(274)调用且 `disabled: editing || mode !== 'url'`——它控制 Electron `<webview>`(setFrameRate),仅 URL mode 存在(`document.createElement('webview')` 于 useIframeNodeState.ts:106)。DynamicAppNodeBody 渲普通 `<iframe src=... sandbox=...>`(index.tsx:147),IframeRenderedView 经 `<iframe srcDoc=...>`(180-190)渲 html/ai/artifact。这些 `<iframe>` 路径均不调 throttle hook、不注册 webview,普通 iframe 无 setFrameRate 等价物。故 dynamic-app guest 与 AI/HTML 预览 iframe 不论视口位置始终全速绘制。
+- **影响**:带 CSS 动画/JS rAF 的 dynamic-app 或 AI 视觉即便远滚出画布仍全帧率绘制,无 IntersectionObserver gating。结合无 culling 渲染扇出(第一轮),每个此类节点是常驻、始终绘制的渲染面。
+- **估算**:每个动画 iframe 节点 ≈ 一个持续全速合成器面(**估算**)。
+- **修复**:扩展 offscreen 限流到 iframe 节点——IntersectionObserver gate,远 offscreen 时 toggle `content-visibility: hidden`/`visibility:hidden` 或 unmount iframe(srcDoc/artifact 内容从 state 重 mount 廉价);dynamic-app iframe 可 postMessage 暂停 runner。
+- **置信度**:0.7
+
+### 3.7 [low] `linkDirectionalParticles` 击败 react-force-graph 的 autoPauseRedraw,hover/active 期间钉死永久 60fps rAF
+- **文件:行**:`apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/GraphPage.tsx`(773,775,364-377,755-757)
+- **类别**:runtime
+- **证据**:773 `linkDirectionalParticles={(link) => link.kind !== 'workspace' && highlighted.linkIds.has(linkKey(link)) ? 2 : 0}` + `linkDirectionalParticleSpeed={0.005}`(775)。`highlighted`(364-377)以 `hoverNodeId || activeNodeId` 为 key,`onNodeHover`(755-757)每 pointer-over 设 `hoverNodeId`。react-force-graph-2d 默认 `autoPauseRedraw=true`(sim 冷却后停 rAF),**但** directional particles 须每帧推进重定位,故任何发射 particle 的 link 让 rAF 持续运行,即便布局已冷。未设 `autoPauseRedraw={false}`,属隐式/意外。净:hover 一节点 → 其相连 link 各得 2 动画 particle → rAF ~60fps 持续(只要光标停留),每帧重绘**整个**画布(全 node+link),非仅 particle。
+- **影响**:普通 hover 触发的稳态主线程 CPU 烧(~60fps 全画布重绘),无运动、布局已定。大跨工作区图上为装饰性 2-particle 动画持续吃 ~16ms/帧预算;与 per-node measureText 热路径(§3.8)叠加,使每次 hover 成 O(nodes) 每帧成本。
+- **估算**:hover 时 ~60fps × 全画布重绘;500 节点 + ~1000 链每帧重描全链 + 全 node renderNode,~5-15ms/帧(**估算,未 profiling**)。
+- **修复**:(a)highlight 弃用 `linkDirectionalParticles`,改静态 dashed/染色 link(`linkColor`/`linkLineDash`,不强制持续重绘);或(b)particle 后置于用户设置并适配 `autoPauseRedraw`。最干净:移除 particle,highlight 已由 `linkWidth`/`linkColor`(767-772)传达。
+- **置信度**:0.62
+- **校正(对抗性核验)**:`cooldownTime={12000}` 存在于 776("无 cooldown/autoPauseRedraw prop"说法不实;cooldownTime 管 sim 非 particle rAF,核心机制仍成立)。影响被高估为"普通 hover 永久稳态烧":须**活动 hover 或持久节点选择(activeNodeId)**,非无交互 idle。activeNodeId 持久化才是真正可虑情形。500/1000 数字为假设/未 profiling。严重度应为 low。
+
+### 3.8 [medium] renderNode 在 rAF 活跃时对每个节点每帧跑 ctx.save + measureText + roundRect + fillText
+- **文件:行**:`apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/GraphPage.tsx`(481-561,777)
+- **类别**:runtime
+- **证据**:`renderNode`(481-561)作 `nodeCanvasObject`(777),被 force-graph 对**每节点每帧**调。每节点 `ctx.save()`(503)、设字体(523)、`ctx.measureText(label).width`(524)、`ctx.roundRect(...)`(532-539)、`ctx.fillText(...)`(557)、`ctx.restore()`(560)。`shouldShowLabel` 在 `showLabels`(默认 `true`,218)时为真——故默认每节点每帧测量并绘标签。`measureText` 是公认 canvas 热路径(强制文本 shaping)。无 per-node 标签宽 memo;固定 zoom 下标签与 fontSize 极少帧间变化却每帧从头重算宽度。
+- **影响**:rAF 被 particle(§3.7)或 reheat(§3.2)钉活时,这是 O(nodes) 文本 shaping + 圆角矩形填充 @~60fps。500 节点图每帧 ~500 measureText + 500 roundRect 纯为标签,主导每帧成本并放大 §3.7/§3.2。
+- **估算**:每节点每帧 ~2 canvas 文本操作;500 节点 × 60fps ≈ 60k measureText/s 持续(**估算,未 profiling**)。
+- **修复**:per-(label, 分桶 fontSize) 在 ref-Map 缓存测量宽度跨帧复用;低于 zoom/scale 阈值跳过标签渲染(519 有部分 `globalScale > 2.3` gate 但与 `showLabels` OR,showLabels 开时永不抑制);仅对 highlighted/视口内节点渲标签。
+- **置信度**:0.7
+
+### 3.9 [low] execInSession 每调注册新 onData 监听器,把全部流输出缓进无界字符串直到 marker 或 30s 超时,并发调用间串扰
+- **文件:行**:`apps/canvas-workspace/src/main/terminal/pty-manager.ts:371-448`
+- **类别**:runtime-memory
+- **证据**:`const disposable = proc.onData((data) => { … output += data; … })`(406-441)为调用时长注册额外监听器;`capturing` 真时每 chunk `output += data` 无大小上限。终止仅 `output.includes(endMarker)`(426)或 `setTimeout(() => finish(...), timeout)`(`timeout = opts?.timeout ?? 30_000`,381,402)。若命令从不打印 end marker(长跑/流式,或 marker 被 partial-chunk 边界切断,因 `data.indexOf(marker)`(411)假设 marker 不跨 chunk),`output` 在整 30s 无界增长。Demux 仅靠 marker:`proc.write(echo ${marker}\r); proc.write(${command}\r); proc.write(echo ${endMarker}\r)` 意味同 session 多并发 `execInSession` 共享同流——每调监听器追加他调字节(串扰 + 跨 N 监听器重复增长)。
+- **影响**:单个 misbehaving harness 命令持续增长字符串(chatty 30s 命令可达多 MB)外加整 timeout 内该 session 热路径多一活监听器,加每 chunk 串拼成本。并发调用同时倍增监听器数与缓冲字节。partial-chunk marker 切分可致漏 end marker,保证最坏情形。
+- **估算**:最坏 ~ 输出速率 × 30s 持于单 JS 串(冗长命令多 MB),× 并发调用数(**估算**)。
+- **修复**:`output` 长度封顶(超 MAX_SCROLLBACK_CHARS 切尾并停追加);marker 匹配跨 chunk 边界的滚动缓冲而非 per-chunk `indexOf`;per-session 串行化 execInSession(复用 pty-bridge 的 nodeQueues),同时只挂一个 capture 监听器,消除串扰。
+- **置信度**:0.7
+
+### 3.10 [low] pty:write / pty:resize 无流控:大粘贴整块推送;拖拽 resize 每像素一次同步 IPC + 原生 resize 系统调用
+- **文件:行**:`apps/canvas-workspace/src/main/terminal/pty-manager.ts:317-334`;`apps/canvas-workspace/src/renderer/src/components/WorkspaceTerminalDock/index.tsx:124-128,318-349`
+- **类别**:runtime-main-thread
+- **证据**:`ipcMain.on("pty:write", (_e, p) => { const proc = sessions.get(p.id); if (proc) proc.write(p.data); })`(317-320)——`data` 一次性写入 pty 无分块,大粘贴/程序化写直通。`ipcMain.on("pty:resize", …)` (322-334) 每调一次原生 resize 系统调用。renderer 侧拖拽 resize 每 mousemove 调 `scheduleFit`:`handleResizeStart` onMouseMove(323-328)→ `scheduleFit()`,而 `scheduleFit`(124-128)每次 fit 扇成**三**调:`requestAnimationFrame(fitTerminal); setTimeout(fitTerminal, 80); setTimeout(fitTerminal, 240);`。`fitTerminal`(111-122)终于 `api.resize(...)` → `ipcRenderer.send("pty:resize", ...)`。故一次连续拖拽 → 多 mousemove × 各 3 调度 fit → 一串同步 resize IPC + 原生 `proc.resize`。ResizeObserver 路径(288-296)也直连 `scheduleFit` 无 debounce,画布 zoom 拖拽进一步放大。
+- **影响**:高频拖拽 resize 终端节点用同步 IPC + 原生 resize 系统调用(各可触发子进程 SIGWINCH 重绘)淹没主进程,与同一主线程上 per-chunk data 扇出争抢;大粘贴可瞬时阻塞 pty 写路径。均为 bursty 主线程争用而非稳态泄漏。
+- **估算**:1 秒拖拽 ~60 mousemove/s × 3 调度 fit ≈ 180 次 resize 尝试;按变更 cols/rows 去重 + 尾沿 debounce 降至个位数(**估算**)。
+- **修复**:debounce/throttle `scheduleFit` 与 ResizeObserver 回调到尾沿——把 rAF+80ms+240ms 三连塌缩为单尾沿 fit,仅 cols/rows 实变时发 `pty:resize`;大 `pty:write` payload 分块(有界切片写)。
+- **置信度**:0.6
+
+---
+
+## 优先修复路线图
+
+> 标注:第一轮 P0/P1/P2 聚焦"渲染扇出"——节点无视口 culling、keep-alive 页面 eager mount、DOM 节点 fan-out。本轮路线图**不重复**这些,补充资源拆分、首屏关键路径串行化、稳态 CPU 盲区。其中"为节点 body / iframe 加 culling/lazy"与第一轮 culling 议题**互补**(第一轮管"是否渲染 DOM",本轮管"是否加载/构造重依赖与 guest 进程")。
+
+**P0(高影响,本轮新增,与第一轮不重叠)**
+- §2.1 默认首启画布的 live external-URL `<webview>` 移出首屏关键路径(占位 + IntersectionObserver/idle 后挂载)。本轮唯一 high,冷启最重单项且外部不可控。
+- §2.2 + §2.5 + §2.6 重排 `bootstrap.ts`:先 `openWindow()`/`loadFile`,seeding + 插件激活并发于 renderer 下载/绘制(以 `mainReady` promise 保序;插件工具注册延迟到首个 agent turn 前而非窗口前)。
+
+**P1(高价值资源拆分 + 稳态 CPU)**
+- §1.1/§1.2/§1.4/§2.3/§2.4 引入**全仓第一个 `React.lazy` 边界**:`DefaultCanvasNode` 的 8 个 body 全部 lazy + Suspense;`createLowlight(common)` 换 curated 子集;`electron.vite.config.ts` 加 `manualChunks` 拆 xterm/tiptap/lowlight/force-graph。这是首屏 chunk 主线程 parse+eval 的主杠杆(与第一轮 culling 正交:第一轮防 DOM 渲染,本轮防依赖加载/构造)。
+- §1.3 chat 子树(markdown-it + hljs)路由级 `React.lazy(ChatView)`。
+- §3.2 + §3.3 force-graph:设有界 `cooldownTicks`;`useAllWorkspaceNodeList.onChange` 加工作区过滤 + debounce + 拓扑 diff gate reheat。
+- §3.4 + §3.5 mermaid:图间 yield/限并发;idle 预热 import。
+- §3.8 renderNode per-(label,fontSize) 宽度缓存 + 标签 zoom 阈值抑制。
+
+**P2(局部/低频/盲区收尾)**
+- §1.5 AI/HTML iframe body 改 sidecar 文件 + ref(state-bloat)。
+- §1.6 mermaid 源→SVG Map 缓存;§1.7 大图 downscale 移 OffscreenCanvas/worker;§1.8 TreeWalker 全文预检。
+- §2.7 module-federation runtime 延迟出 entry chunk;§2.8 i18n 按语言拆分;§2.9 welcome seeding 并发化。
+- §3.1 offscreen webview 超越降帧(导航 about:blank / unmount);§3.6 iframe 节点扩展 IntersectionObserver gating;§3.7 移除 highlight particle。
+- §3.9 execInSession 输出封顶 + 跨 chunk marker + per-session 串行化;§3.10 scheduleFit 尾沿 debounce + resize 去重 + pty:write 分块。
+
+---
+
+## 实测验证计划
+
+> 本轮依赖未安装,无法 profiling;所有体积/耗时为估算。安装后按下列采集真实数据并替换估算。
+
+**A. Bundle / chunk 体积(验证 §1.x、§2.3/§2.4/§2.7/§2.8)**
+```bash
+pnpm install
+pnpm --filter canvas-workspace build
+# 检视 electron-vite 输出 renderer chunk 体积(out/renderer/assets/*.js)
+ls -lh apps/canvas-workspace/out/renderer/assets/*.js
+```
+- 加 `rollup-plugin-visualizer`(或 `source-map-explorer out/renderer/assets/*.js`)出 treemap,确认 lowlight `common`、Tiptap 全家桶、xterm、markdown-it+hljs、`@module-federation/runtime`、`messages.ts` 是否在 entry/startup chunk。
+- 指标:startup chunk 总 min/gzip 字节;各重依赖占比;lazy 化后 entry chunk 缩减量、新增 async chunk 数。
+
+**B. 首屏 / time-to-window(验证 §2.1/§2.2/§2.5/§2.6/§2.9)**
+- 在 `bootstrap.ts` `app.whenReady()` 起点与 `openWindow()` 处打 `performance.now()` 时间戳,记录 seeding/applyEnv/setupCanvasPlugins/reloadExternal 各段耗时(分有/无外部插件两组)。
+- 在 renderer `main.tsx` 首 `createRoot().render()` 前后 + `index.html` boot-screen 可见时刻打点;用 Electron `webContents` `'did-finish-load'`/`'dom-ready'` 事件测 TTFP。
+- 指标:app ready → window 可见 ms;boot-screen 可见时刻;重排前后 delta;welcome `<webview>` `did-finish-load` 计入 TTFMP 的耗时;离线下 load-error 闪现时长。
+
+**C. React render / 节点 body 加载(验证 §1.1/§2.3/§3.8)**
+- React DevTools Profiler 录制冷启 + 打开各类型节点,统计 DefaultCanvasNode 及各 body 的 render count 与 commit 耗时;lazy 化后确认仅实例化类型的 chunk 被 fetch(Network/Coverage 面板)。
+- 指标:首屏各 body 是否被构造;Tiptap `useEditor` 构造次数与耗时;lazy 后 Suspense fallback → resolve 延迟。
+
+**D. webview / PTY 进程与内存(验证 §2.1/§3.1/§3.9/§3.10)**
+- `ps`/Electron `app.getAppMetrics()` 采集 guest WebContents 进程数与各自 RSS;offscreen 后台节点用 Chrome Task Manager 观察 CPU% 是否随降帧下降(验证 §3.1:JS/timer 仍跑)。
+- 终端拖拽 resize 时计 `pty:resize` IPC 频次(主进程 `ipcMain.on` 计数);execInSession 长跑命令观察 `output` 串增长与监听器数。
+- 指标:每 url-mode 节点 guest 进程数/内存;offscreen 节点稳态 CPU%;1s 拖拽 resize 的 IPC + 原生 resize 调用数;execInSession 峰值缓冲字节。
+
+**E. mermaid / force-graph 渲染耗时(验证 §3.2/§3.4/§3.5/§3.7/§3.8)**
+- 在 `mermaid.ts` `loadMermaid`(import+initialize)与 `mermaid.render` 前后 `performance.now()`,实测首遇 1MB import 耗时与每图 layout 耗时;含 3 图回复测流末 burst 总时长。
+- force-graph:DevTools Performance 录制 hover(particle rAF)、toggle(12s reheat)、跨工作区 onChange,测 per-frame `measureText` 调用数与帧时长、reheat 主线程占用秒数。
+- 指标:mermaid 首遇 import+init ms / 每图 render ms;force-graph hover 期帧时长与 measureText/frame;每 toggle reheat 主线程累计 ms;有界 `cooldownTicks` 前后对比。
+
+(以上文件路径均为绝对/仓内真实路径;所有数值均标注为估算,待 B–E 实测替换。)

--- a/apps/canvas-workspace/docs/performance-analysis.md
+++ b/apps/canvas-workspace/docs/performance-analysis.md
@@ -1,0 +1,411 @@
+# Canvas Workspace 性能深度分析报告
+
+## 执行摘要
+
+`apps/canvas-workspace` 的核心性能瓶颈集中在**三个系统性缺陷**:(1) Canvas 完全没有视口裁剪(viewport culling),所有非折叠节点无条件挂载完整的重型 DOM 子树(xterm/Tiptap/iframe),内存与挂载成本随**节点总数**而非**屏幕可见数**线性增长;(2) 节点/边状态高度集中,任何 drag/resize 的每个 rAF tick 都会替换整个 `nodes` 数组,触发完整的 visibility+sort+split 派生流水线;(3) 主进程在多处做同步/重复 I/O——`getCwd` 每 2 秒对每个终端跑同步 `execSync(lsof/readlink)`,`canvas:save` 对一个改动节点做 ~5N 次磁盘读,严重时序列化所有 IPC。整体健康度为**中等偏下**:无崩溃或正确性致命缺陷,但在"多终端 / 多 Agent / 多 workspace keep-alive"这一目标工作负载下,内存与主线程会出现明显的可扩展性天花板。最高优先级修复是**视口裁剪 + 主进程异步化 getCwd + 单节点增量保存**,这三项能解除绝大部分线性恶化。
+
+## 严重程度概览
+
+| 维度 | critical | high | medium | low |
+|---|---|---|---|---|
+| Canvas 节点 DOM 渲染与视口裁剪 | 0 | 1 | 2 | 0 |
+| 集中式节点/边状态与变更时的重渲染扇出 | 0 | 1 | 2 | 2 |
+| xterm/Tiptap 节点体生命周期、scrollback 序列化与自动保存 | 0 | 2 | 2 | 1 |
+| PTY 输出经 IPC 流式传输 | 0 | 0 | 4 | 1 |
+| Chat token 流式重渲染成本 | 0 | 1 | 3 | 0 |
+| canvas:save 读-合并-写 与双 fs.watch 比对 | 0 | 1 | 2 | 0 |
+| 多 Canvas / 多 Chat keep-alive 挂载 | 0 | 1 | 5 | 0 |
+| Workspace graph (react-force-graph-2d) 渲染与数据重建 | 0 | 1 | 2 | 1 |
+| 渲染端 bundle 体积、代码分割与 Electron 启动 | 0 | 0 | 3 | 2 |
+| **合计** | **0** | **8** | **25** | **7** |
+
+> 说明:部分发现被多个维度引用(如"无视口裁剪"在两个维度各出现一次,"containerDescendantCount"出现两次,"scrollback 2s 自动保存"贯穿三个维度)。下文**详细发现已按主题去重合并**,避免重复列举。
+
+---
+
+## 详细发现
+
+### HIGH
+
+#### H1 · Canvas 完全没有视口裁剪,每个可见节点都挂载完整的实时 DOM 子树
+- **文件**:`src/renderer/src/components/Canvas/hooks/useCanvasVisibility.ts:40-48`(另见同维度重复项 `:40-59`)
+- **类别**:missing-virtualization / layout-thrash
+- **证据**:`visibleNodes = useMemo(() => filterCollapsedFrameDescendants(nodes), [nodes])` 是唯一的过滤。`filterCollapsedFrameDescendants`(`src/renderer/src/utils/frameHierarchy.ts:187`)只丢弃折叠 frame 的后代,**从不**把节点与视口矩形相交;`transform`(pan/zoom)甚至不是该 hook 的输入。下游 `CanvasSurface.tsx:248/266/267` 对全集 `renderGroups.containers.map(renderNode)` / `regular.map(renderNode)`,`CanvasNodeView/DefaultCanvasNode.tsx:218-269` 为**每个节点**无条件挂载重型 body:`TerminalNodeBody`(`TerminalNodeBody/index.tsx:183` `api.spawn` 真实拉起 PTY+xterm)、`FileNodeBody`(Tiptap)、`IframeNodeBody`(iframe)。
+- **用户影响**:DOM 节点数、JS 堆(每节点一份 xterm buffer + 一个 PTY + 一个 Tiptap editor + 一个 iframe)、绘制成本均随**节点总数**增长。40 个终端/Agent/文件节点即便有 38 个被平移到屏幕外,仍付出 40 次完整挂载;初始加载与内存线性膨胀且不会回落。`CanvasNodeView` 已用 `React.memo`(`index.tsx:242`)挡住了"离屏节点的稳态重渲染",因此**主成本是挂载与常驻内存,而非每帧重渲染**。
+- **修复建议**:把 `transform` 与容器尺寸传入 `useCanvasVisibility`(或新建 `useViewportCulling`),计算可见 canvas 矩形,排除 bbox(加约 1 个视口的 margin band)完全落在视口外的节点。始终挂载 selected/dragging/fullscreen/边端点 节点。对需保持挂载以保留 PTY/编辑器状态的节点,先渲染占位 div,仅当进入 margin band 时再懒挂载重型 body(`content-visibility:auto` 是更廉价的部分缓解,但不释放 PTY/JS 内存)。
+- **置信度**:0.95
+
+#### H2 · 任意 drag/resize 的每个 pointer-move 都替换整个 node 数组,重跑 Canvas 派生流水线
+- **文件**:`src/renderer/src/hooks/useNodes.ts:586-617` / `src/renderer/src/components/Canvas/CanvasSurface.tsx:121-284`
+- **类别**:re-render
+- **证据**:`moveNode/moveNodes/resizeNode` 构造全新映射数组并在每个 rAF tick 调用 `applyNodes(resizeGroupsToChildren(movedNodes), false)` → `applyState` → `setNodes(nextNodes)`。`nodes` identity 改变后 `Canvas/index.tsx` 重跑 `useCanvasVisibility`(新建 Set/Map 遍历全集)→ `useCanvasRenderOrder`(`computeContainerDepths` + 全量 `[...visibleNodes].sort(...)` + 二次切分 containers/regular)→ 渲染**未 memo 化**的 `<CanvasSurface>`,其内联 `renderNode` 对整个 `renderGroups` 数组 `.map`。
+- **用户影响**:drag/resize 期间,完整 O(n) 的 visibility+sort+split 流水线与全量 `.map` 以 rAF 频率为整个 canvas 重跑,是大 canvas 拖拽卡顿的主因。**缓解事实**:`CanvasNodeView` 已 `React.memo`(`index.tsx:221-243`),只有引用真正改变的节点(被拖节点 + 同伴)才重渲染其重型 body(Tiptap/终端/iframe),未变节点在 memo 边界 bail out。因此每 tick 是 O(n) 派生 + O(n) 元素创建/协调 + O(n) 比较器调用,**但不是 O(n) 深层 body 重渲染**;`dragPreview` HUD 的目的并未被完全抵消。
+- **修复建议**:把实时 drag/resize 几何排除在正式 `nodes` 数组之外——手势进行中仅通过 CSS `translate`/`will-change` overlay(或按 id 的 position override map)驱动被拖节点,pointer-up 时一次性提交真实数组变更。另将 `CanvasSurface` 包 `React.memo`,并 memo 化 visibility/render-order 输入使其仅在节点 identity 真正改变时重算。
+- **置信度**:0.9
+
+#### H3 · `getCwd` 自动保存在主进程每 2 秒对每个 Agent/终端节点跑同步 `execSync(lsof/readlink)`
+- **文件**:`src/main/terminal/pty-manager.ts:206-311`(handler `306-311`);调用方 `AgentNodeBody/useAgentNodeController.ts:886-893`、`TerminalNodeBody/index.tsx:234-241`
+- **类别**:blocking-io
+- **证据**:2 秒自动保存间隔调用 `await api.getCwd(sessionId)`。主进程 handler `ipcMain.handle('pty:getCwd', ...)` → `getCwd(proc.pid)` **同步执行**:darwin 上 `execSync('lsof -a -d cwd -p ${pid} ...')`、linux 上 `execSync('readlink /proc/${pid}/cwd ...')`(`pty-manager.ts:210,218`)。`execSync` fork 子进程并**阻塞 Electron 主进程事件循环**直至返回(各 timeout 2000ms)。
+- **用户影响**:N 个活跃节点 → 主进程每 2 秒 fork N 个子进程仅为记录 cwd。macOS 上 lsof 常耗时数十到数百毫秒,每次调用都让主进程停顿,而主进程**串行化所有 IPC**(PTY 数据、文件写、store 保存)。表现:终端输出卡顿、打字延迟、保存延迟随终端数线性增长;单次慢 lsof(最高至 2s 超时)可冻结整个应用。
+- **修复建议**:(1) 把 `getCwd` 改异步(linux 用 `fs.promises.readlink('/proc/${pid}/cwd')` 完全不 fork 子进程;否则用 `execFile`/`exec` 回调),使其永不阻塞主循环。(2) 从 2 秒 scrollback 保存中解耦——cwd 极少变化,仅在 spawn 与 shell 提示符返回时(或最多每 ~30s)读取,2 秒 tick 仅持久化 scrollback 并复用 `dataRef` 中的 last-known cwd;unmount(`useAgentNodeController.ts:1061`、`TerminalNodeBody/index.tsx:261`)同样复用缓存 cwd。
+- **置信度**:0.92
+
+#### H4 · 每个 xterm 容器上的 ResizeObserver 在每个缩放动画帧重新 fit + 重新同步字号(逐终端)
+- **文件**:`TerminalNodeBody/index.tsx:281-293`;`AgentNodeBody/useAgentNodeController.ts:1083-1098`;成本函数 `AgentNodeBody/utils/terminal.ts:64-69,78-98`
+- **类别**:layout-thrash
+- **证据**:每个节点装 `new ResizeObserver(() => fitTerminalWithCanvasScale(...))`(终端版)/ `syncTerminalFontSizeToCanvas(...); fit.fit()`(Agent 版)。容器尺寸为 `calc(100% * var(--canvas-scale))`,缩放过渡在 0.32s 内动画化 `--canvas-scale`(`CanvasSurface.tsx:219-222`),故 observer 每动画帧触发。`fitAddon.fit()` 强制同步布局读取(`getComputedStyle` + 测量字符 cell)与回流;`syncTerminalFontSizeToCanvas` 亦调用 `getComputedStyle`。
+- **用户影响**:单次 pinch/zoom 中,每个活跃终端在 ~20 个动画帧上各跑 `getComputedStyle` + `fit()`,N 个终端 → N×~20 次强制回流,是 canvas 上有终端时缩放卡顿的主因。**更正**:`term.refresh()` **不**在任一 ResizeObserver 内运行(它在无关的 `fitAndRefreshTerminal` 中),故每帧每终端真实成本是 `getComputedStyle` + 一次 `fit()` 回流(仅当 cols/rows 改变时才会重绘 xterm),并非无条件重栅格化。
+- **修复建议**:用 rAF 合并 observer,使每帧最多一次 `fit`,缩放结束后做一次最终 fit(trailing setTimeout,每次触发清掉前一个)。当新测尺寸等于上次 fit 尺寸时跳过。可在 `canvas-transform--moving`/动画期间暂停 fit,动画结束后做一次 fit。`syncTerminalFontSizeToCanvas` 已在字号不变时早返回——以同样方式 gate `fit()`。
+- **置信度**:0.85
+
+#### H5 · 完整 xterm scrollback 每 2 秒被遍历并 join 成字符串,然后触发整个 nodes 数组替换 + 防抖磁盘写
+- **文件**:`AgentNodeBody/utils/terminal.ts:34-46`;`AgentNodeBody/useAgentNodeController.ts:886-893`;`TerminalNodeBody/index.tsx:30-42,234-241`(自带重复的 `serializeBuffer`);经 `useNodes.ts:454-462` 与 `useNodeHistory.ts:41-67`
+- **类别**:GC/CPU + 磁盘 I/O churn(原标 layout-thrash,实无强制回流)
+- **证据**:`serializeBuffer` 遍历整个 active buffer(`for i in count: translateToString(true)` 后 `lines.join('\n')`,`terminal.ts:36-42`),在 2 秒间隔与 unmount 时各跑一次。结果经 `onUpdateRef.current(...)` → `updateNode`(`nodesRef.current.map(...)`,`useNodes.ts:456`)→ `applyNodes` → `applyState` → `pushSnapshot`(新建 history 快照)→ `scheduleSave()`(800ms 防抖、全 canvas JSON 写)。
+- **用户影响**:xterm scrollback 上限为 **5000** 行,`translateToString` 每 tick 为每行分配字符串。N 个忙终端 = N 次全 buffer 遍历 + N 次全 nodes `.map` + N 次 history 快照 push,每 2 秒;外加 800ms 防抖的全 canvas 序列化/磁盘写。主线程 GC churn 与持续磁盘 I/O 随终端数增长。**额外副作用**:每个 2 秒 tick 都 push 一个 undo-history 快照(`addToHistory` 默认 true),实时终端输出持续灌满 100 项 undo 栈——属性能成本之上的 UX 正确性 bug(见 H/M 交叉项 M-Hist)。
+- **修复建议**:(1) 用 `@xterm/addon-serialize`(或 cache+diff)替代每 tick 全 buffer 遍历;仅在 buffer 真正改变(`term.onWriteParsed`/onData 设脏标志)时重序列化。(2) 从尾部切到 `MAX_SCROLLBACK_CHARS`。(3) scrollback 自动保存走**不 push undo 快照**的专用路径:加 `scrollback-only` 更新,只改 `nodesRef` + `setNodes`,不走 `applyState`/`pushSnapshot`,让现有 800ms 防抖合并磁盘写。
+- **置信度**:0.92
+
+#### H6 · `canvas:save` 把完整的 读-合并-写 流水线跑两遍,为持久化一个改动节点做 ~5N 次磁盘读
+- **文件**:`src/main/canvas/store.ts:1161-1208`
+- **类别**:blocking-io
+- **证据**:`withSaveLock` 内 `firstPass = await mergeExternalNodes(...)` 后再 `merged = await mergeExternalNodes(payload.id, firstPass)`。每次 `mergeExternalNodes` → `readDiskCanvas` → `readCanvasFull(id)`,含 `recoverInterruptedMigration`(readSentinel)+ 读 `canvas.json` + `assembleV2`(`Promise.all(layoutNodes.map(readNodeFile))`,每节点一次读)。两次 merge = 2×(canvas.json + N 次节点读)。随后 `writeCanvasFull` → `writeCanvasFullV2` 对每节点 `readNodeFile`(又 N 次读)+ 每节点一次写;再 `readOnDiskNodeMap`(1 读)+ `seedPerNodeContent`(readdir + N 读)。N 节点的单次保存约 **5N 次文件读 + N 次写**,即便只有 1 个节点改变。
+- **用户影响**:数十/数百节点的 workspace,每次自动保存(终端 scrollback 每 2s、drag-end、任意编辑)让主进程做数百次 fs round-trip。多个活跃终端各每 2s 触发时会饱和主线程/IO 并拖慢所有 IPC。**精确化**:I/O 是异步的(走 libuv 线程池,不是同步阻塞 JS 主线程整段时间),但线程池/IO 饱和 + 主进程上的 JSON parse/serialize CPU + IPC 响应性下降的实际效果成立。
+- **修复建议**:只调用一次 `mergeExternalNodes`(`writeCanvasFullV2` 内的逐节点 `updatedAt` 仲裁已防护第二遍要防的竞态);缓存 `readCanvasFull` 结果,避免 `readDiskCanvas` 与后续写各自重读每个 `nodes/<id>.json`;最关键——让 `writeCanvasFullV2` **只写数据真正改变的节点**(用单次磁盘快照 diff),而非每次保存都对每个节点 read+write。
+- **置信度**:0.9
+
+#### H7 · `markdown.render` 为每个无语言提示的代码块跑 `highlightAuto`,放大每 token 重解析成本
+- **文件**:`src/renderer/src/components/chat/utils/markdown.ts:18-40,140-142`
+- **类别**:blocking-io / CPU
+- **证据**:`renderCodeBlockHtml` → `highlightCode`:无/未知语言时 `hljs.highlightAuto(code)`(`markdown.ts:33-39`)跨所有常见语言做自动检测(已知语言走更廉价的 `hljs.highlight`)。`renderMarkdown`(`140`)被 `renderMdWithMentions` 调用,而 `ChatMessage` 的 `useMemo` 按 `[message.content]` 触发——流式时每 token 重跑。
+- **用户影响**:`highlightAuto` 是 hljs 最昂贵操作之一(尝试多种语法)。在不断增长的代码块上每 token 重跑,是大型同步主线程成本,随代码长度与 token 速率增长,是代码密集回复流式卡顿的首要贡献者。因 delta append 无节流(`useChatStream.ts:246`)且 `renderMarkdown` 无缓存,所有代码块每 token 都被重 highlight。
+- **修复建议**:在途流式消息**不**跑完整 markdown+highlightAuto——流式时渲染转义后的原文,完成时跑一次 highlight。若需增量,按代码块精确字符串 memo 化 highlight 结果,优先显式语言提示而非 `highlightAuto`。
+- **置信度**:0.9
+
+#### H8 · `buildGraphData` 每次 toggle/visibleNodes 变化产出新 graphData,layout effect 在每次 nodes/links 计数变化时 reheat 模拟 + zoomToFit
+- **文件**:`WorkspaceNodes/GraphPage.tsx:337-346,409-430`
+- **类别**:layout-thrash
+- **证据**:`graphData = useMemo(() => buildGraphData(...), [showLinks, showTags, showWorkspaceHubs, tags, t, visibleNodes, workspaces])` 重建完整 nodes/links。新引用传给 `<ForceGraph2D graphData={graphData}>` 触发全量 re-ingest。另:`useEffect(() => { graph.d3ReheatSimulation(); setTimeout(() => graph.zoomToFit(450,140), 60); }, [graphData.links.length, graphData.nodes.length, layoutPreset])`。
+- **用户影响**:toggle `showTags/showLinks/showWorkspaceHubs/showOffCanvas` 或任何 live reload 都重建数组并喂给 ForceGraph 新对象,丢弃 x/y 位置、冷启动模拟、强制 `zoomToFit`(视口跳变 + CPU 尖峰)。即便只通过 live refresh 加了一个节点,计数变化也会触发 reheat。
+- **修复建议**:ForceGraph 原地变更 node 对象以保留 x/y——按 id 复用先前 `NodeObject` 实例(拷贝 x/y/vx/vy)使模拟 warm-start;仅在 `layoutPreset` 改变或真正结构变化时 gate `d3ReheatSimulation()` + `zoomToFit`(单节点新增不 reheat);对 live `onChange` reload 做防抖。
+- **置信度**:0.85
+
+#### H9 · `useMountedWorkspaceIds` 从不驱逐已访问 workspace + Canvas 无视口虚拟化(keep-alive 叠加)
+- **文件**:`Workbench/useMountedWorkspaceIds.ts:11-37`;叠加 `Canvas/hooks/useCanvasVisibility.ts:40-59`(见 H1)
+- **类别**:memory-leak(刻意 keep-alive 设计)
+- **证据**:该 hook 只 ADD 不 evict(唯一移除路径是"workspace 已不存在"的删除剪枝),无 LRU/上限/空闲驱逐。`Workbench` 为 set 中每个 id 挂载一个完整 `<Canvas>` + 一个 `<ChatPanel>`(`index.tsx:412,468`),隐藏者仅 `display:none`。每个 Canvas 挂载整个 `useNodes/useCanvas*` hook 栈,隐藏 workspace 的活跃终端/Agent(`WorkspaceTerminalPortal`,`index.tsx:491`)保持 PTY 运行。
+- **用户影响**:一个会话访问 N 个 workspace 后,N 个完整 canvas + N 个 chat panel + 所有 PTY/编辑器保留至应用生命周期结束;内存单调增长,切换 workspace 从不回收。多个重型 workspace 时渲染端内存与稳态 CPU 持续攀升直到 reload。**限定**:这是有意的 keep-alive 设计(`index.tsx:463-466` 注释说明),增长被会话内打开的不同 workspace 数所界定(非真正无界),故 medium 倾向但与 H1 叠加后实质为 high。
+- **修复建议**:用 LRU keep-alive 限定挂载集(active + 最近 K=2-3 个),驱逐其余并拆除其 Canvas/ChatPanel/终端;始终保留 active id 与任何有运行中 Agent/终端 turn 的 id(避免杀掉在途工作)。
+
+---
+
+### MEDIUM
+
+#### M1 · `containerDescendantCount` 在每个 group/frame 的每次渲染重算 `computeParentContainerMap`(O(n×containers))
+- **文件**:`CanvasNodeView/useCanvasNodeViewModel.ts:245-247`(同一发现在两个维度各列一次,此处合并)
+- **类别**:n-plus-1
+- **证据**:`const containerDescendantCount = (node.type === 'group' || node.type === 'frame') && getAllNodes ? collectContainerDescendants(node.id, getAllNodes()).length : 0;` 在 view-model body 无 memo 运行。`getAllNodes()` 返回 `nodesRef.current`(全集);`collectContainerDescendants`(`frameHierarchy.ts:115-119`)调 `computeParentContainerMap(nodes)`(`frameHierarchy.ts:69-101` 的 O(nodes×containers) 双循环)。
+- **用户影响**:`CanvasNodeView` 的 memo(`prev.node===next.node` 等)将重渲染限于 props 真正改变的节点,**因此并非全 canvas 每帧 C 次并发**。真实成本是:每当**单个** frame/group 节点重渲染(尤其拖动该容器时每个 rAF tick,因 `moveNode` 创建新 node 对象),就从头跑一次完整 O(N×containers) 父图计算。在 container 密集 canvas 上拖一个 frame = 每动画帧一次 O(N×C) pass,导致拖拽 jank。`getAllNodes` 本身是稳定 `useCallback`,非重渲染触发源。
+- **修复建议**:在 Canvas 层 `useMemo` over `nodes` 计算一次父容器图,以 `Map<containerId, number>` 经 context/prop 暴露后代计数,view-model O(1) 读取,而非每容器重算 `computeParentContainerMap`。同样修复 `useCanvasRenderOrder` 对相同数据重算 depths。
+- **置信度**:0.85-0.9
+
+#### M2 · `CanvasSurface.renderNode` 是每次渲染重建的内联非 memo 闭包,逐节点传 ~31 个 props
+- **文件**:`Canvas/CanvasSurface.tsx:174-212`
+- **类别**:re-render
+- **证据**:`renderNode = (node, renderMode='full') => (<CanvasNodeView key=... node={node} ...~31 props... />)` 声明在 `CanvasSurface` 函数体内,每次渲染重建;`CanvasSurface` 未 `React.memo`,且在每次 `setTransform`(`hooks/useCanvas.ts:66/79/110`,每个 wheel/mousemove 事件触发)时重渲染。`.map`(`248/266/269`)随后为每个可见节点在每个 pan 帧重建 React 元素。
+- **用户影响**:每个 pan/zoom 帧分配 N 个新元素对象并对所有可见节点跑 `CanvasNodeView` memo 比较器(`index.tsx:221-243`,~20 次 prop 比较)。memo bail out 使 body 不重渲染,但元素构造 + 比较仍是每帧 O(n) 主线程成本——大 canvas 连续平移时的可测开销(故 medium 非 high)。
+- **修复建议**:把 transform 与节点渲染解耦——在 wheel/pan handler 内用 ref + 直接 style 写(或 CSS 变量)驱动 `.canvas-transform` 的 translate/scale,使 React `transform` state 离开热路径;另将 `CanvasSurface` 包 `React.memo`,把节点列表提到只依赖 renderGroups/selection/drag(不依赖 transform)的 memo 化子组件。
+- **置信度**:0.9
+
+#### M3 · scrollback 自动保存历史污染:每 2s tick 占一个 undo 槽并强制全 nodes 数组拷贝
+- **文件**:`useNodes.ts:454-462`;`useNodeHistory.ts:28-34,41-59`
+- **类别**:re-render / UX 正确性
+- **证据**:`updateNode` → `applyNodes(resizeGroupsToChildren(...))` 默认 `addToHistory=true`,每次自动保存跑 `pushSnapshot`(slice + push + 超 `MAX_HISTORY=100` 时 shift)与 `resizeGroupsToChildren`(最多 4 pass 的全 nodes `.map`)。scrollback 写走与用户编辑相同的通用路径。
+- **用户影响**:几个活跃终端时,undo 栈在数分钟内被纯 scrollback 快照填满,**Ctrl+Z 回放的是终端文本自动保存而非真实编辑**(主要、始终存在的危害);CPU 角度次要(无 group 时 `resizeGroupsToChildren` 单 pass 短路)。故 medium(UX 正确性退化)。
+- **修复建议**:为自动保存加专用低优先级节点数据更新器:(a) 跳过 `pushSnapshot`(无 undo 项),(b) 跳过 `resizeGroupsToChildren`(scrollback/cwd 不改几何)。终端/Agent 自动保存调它而非通用 `updateNode`。
+- **置信度**:0.9
+
+#### M4 · 团队 Agent 输出在主线程逐 chunk 经序列化异步队列 + 每会话锁 + 全量 ANSI strip 解析
+- **文件**:`src/main/agent-teams/pty-bridge.ts:52-61` → `src/main/agent-teams/service.ts:1566-1601`
+- **类别**:CPU(原标 blocking-io,实为内存内 store,无逐 chunk 磁盘 I/O)
+- **证据**:`pty-bridge` onData 为每个 chunk enqueue `reportAgentOutput`。`reportAgentOutputLocked` 在 `withTeamLock` + `resolveAgentNodeCached` 下做:`stripAnsi(previous+delta).slice(-MAX_AGENT_OUTPUT_BUFFER)`、`combined.split(/\r\n|\n|\r/)`、逐行 `parseAgentOutputMarker`——主进程逐 chunk。
+- **用户影响**:重团队输出时,主进程在每会话异步锁后重复 re-ANSI-strip 滚动 buffer + 重切分/扫描每行(每 chunk),与 PTY IPC 争抢事件循环。**缓解**:rolling buffer 硬上限 `MAX_AGENT_OUTPUT_BUFFER=16_000` 字符,`nodeQueues`/`withTeamLock` 异步运行(非同步阻塞)。
+- **修复建议**:用 H/M 交叉项 M-IPC 提议的合并 flush 驱动,使 `reportAgentOutput` 每 flush 窗口调一次而非每原始 chunk,把锁获取、`stripAnsi`、split 数量降一个量级。
+- **置信度**:0.85
+
+#### M-IPC · PTY `onData` 逐 chunk 扇出到渲染端 IPC + 每个 observer,零批处理
+- **文件**:`src/main/terminal/pty-manager.ts:281-287`
+- **类别**:ipc
+- **证据**:`proc.onData((data) => { if (!win.isDestroyed()) win.send(\`pty:data:${id}\`, data); notifyObservers((o) => o.onData?.(info, data)); })`——每个原始 PTY chunk 触发一次结构化克隆 + IPC send + 同步遍历所有已注册 observer。Claude/Codex 全屏重绘会发出大量小 chunk。
+- **用户影响**:高吞吐 Agent 输出(屏幕重绘、spinner)产生 IPC 洪流——主进程 CPU 尖峰、渲染端事件循环饱和。**缓解**:xterm.js 内部把实际渲染批到动画帧,故渲染端绘制部分受限;主导真实成本是逐 chunk IPC 结构化克隆、`term.write` 解析、`captureTerminalOutput` 与同步 observer 循环,随并发会话数增长(故 medium 非 high)。
+- **修复建议**:在跨 IPC 边界前按 microtask/动画节奏合并每会话输出——按 id 缓冲 chunk,`setImmediate`/~8-16ms 定时器 flush,发一条拼接 `pty:data:${id}` 并每 flush 调一次 observer;保留 max-buffer 上限以约束延迟。
+- **置信度**:0.85
+
+#### M-Exec · `execInSession` 累积无界输出 buffer 并对增长字符串每 chunk 跑 `includes/indexOf`(O(n²))
+- **文件**:`src/main/terminal/pty-manager.ts:406-441`
+- **类别**:blocking-io
+- **证据**:`let output=''; ... output += data; if (capturing && output.includes(endMarker)) { output.indexOf(endMarker) ... }`——`output` 从不截断,每个 onData chunk 做 `includes` + `indexOf`(各 O(buffer 长度))。N 字符经 K chunk = O(N×K)≈O(N²)。`finalOutput.lastIndexOf('\n')` 等只在完成时跑一次,非逐 chunk 成本。
+- **用户影响**:产出大输出(构建日志、测试、文件 dump)的命令使每个 chunk 扫描成本递增,在主线程阻塞事件循环(也服务所有 PTY/window/agent-teams IPC),受 30s 超时界定。
+- **修复建议**:只扫新到尾部:`searchTail = (searchTail + data).slice(-(endMarker.length*2))` 测 marker,或 `indexOf(endMarker, scannedUpTo)`;append 到数组、完成时 join 一次而非 `+=`;并对总捕获量加上限。
+- **置信度**:0.9
+
+#### M-Mirror · Mirror 终端在 detached/离屏时仍保持活跃 `pty:data` IPC 订阅并 `term.write`(unmount 未退订)
+- **文件**:`AgentNodeBody/useAgentNodeController.ts:415-443,67-90`
+- **类别**:memory-leak(有界)
+- **证据**:mirror unmount 清理仅 `detachMirrorTerminal(liveEntry)`(`443`),它只把 xterm DOM 移入隐藏 stash,**不**调 `entry.disposeSubscriptions()`;后者仅在 `pruneMirrorTerminalCache` 超 `MAX_MIRROR_TERMINALS=12` 驱逐时(`disposeMirrorTerminal`)调用。故最多 12 个缓存 mirror 终端持续订阅 `pty:data:${sessionId}` 并对每个 chunk 跑 `term.write`,即便节点离屏/已 unmount。
+- **用户影响**:团队视图中,每个队友的高吞吐 PTY 输出仍被 IPC 投递并写入最多 12 个隐藏、从不渲染的 xterm——纯浪费 IPC + xterm 解析/buffer 工作 + 常驻内存(12 终端 × scrollback)。**精确化**:主进程每会话发一次事件(不随订阅者数放大),成本是保留的 listener 调 `term.write`,且被 12 上限 + 有界 scrollback 界定(有界 leak)。
+- **修复建议**:detach 时也拆除离屏 mirror 的 IPC 订阅(在 `detachMirrorTerminal` 调 `disposeSubscriptions()`),reattach 时从保存的 scrollback 重订阅 + 重绘;至少 gate `term.write` 使 detached mirror 丢弃数据。保留 Terminal 对象以快速 reattach 可以,保留其活跃 PTY 订阅是 leak。
+- **置信度**:0.9
+
+#### M-Chat1 · 逐 token `onTextDelta` 做整 messages 数组拷贝 → 重渲染每个 ChatMessage;未 memo 的 ChatMessage 每 token 重解析 markdown
+- **文件**:`chat/hooks/useChatStream.ts:240-249` + `ChatMessage.tsx:95-118`
+- **类别**:re-render
+- **证据**:`onTextDelta` 每 token:`setMessages(prev => { const next=[...prev]; next[index]={...next[index], content: ...+delta}; return next; })`——每 token 新数组 + `assistantIndex` 处新对象 identity。`ChatMessages.tsx:257` 的 `.map` 对全列表重跑,`ChatMessage` 是普通函数(`95` 行,**未** `memo`),故每个兄弟消息也重渲染。`ChatMessage` 内 `assistantHtml = useMemo(() => renderMdWithMentions(message.content, nodes), [message.role, message.content, nodes])` 每 token 重解析在途消息的完整 markdown。
+- **用户影响**:流式速度下(每秒数十到数百 token),活跃消息的 markdown+语法高亮从头重跑(代码块时 `highlightAuto` 对增长 buffer 跑 = O(n²) 总 CPU)。**更正**:兄弟(非流式)消息会重渲染(函数体执行 + vdom diff),但**不**重解析 markdown(其 `useMemo` 由稳定 `message.content/nodes` 守护),故 markdown/高亮成本停留在单个流式消息——主导成本是该消息的 O(n²) 重解析。
+- **修复建议**:(1) `ChatMessage` 包 `React.memo`;(2) 节流/合并 text delta——缓冲后经 rAF flush 到 `setMessages`(每帧一次 setState);(3) 在途消息渲染纯文本/更廉价 pass,完成时才跑完整 markdown+highlight,或按代码块内容 memo 化 highlight。
+- **置信度**:0.85
+
+#### M-Chat2 · `publishTools()` 在每个 tool-input delta 与每个 `onVisualStream` 帧(~60fps)拷贝数组 + 克隆 Map,重渲染 tool chip 与流式 visual
+- **文件**:`chat/hooks/useChatStream.ts:142-148,171-212`
+- **类别**:re-render
+- **证据**:`publishTools = () => { const snapshot=[...toolCalls]; setStreamingTools(snapshot); if (assistantIndex.current>=0) setMessageTools(prev => new Map(prev).set(assistantIndex.current, snapshot)); }`,被 `onToolInputDelta`(每 arg-token,`174-176`)与 `onVisualStream`(`211`,~60fps)调用。每次分配新数组 + 新 Map 喂 setState。
+- **用户影响**:**更正**:React 18 自动批处理把单个 IPC handler 内的两次 setState 合并为一次 commit,故是 ~60 渲染/秒而非 120;且 `ChatMessage` 的 markdown `useMemo`(按 `message.content`,流式 tool-arg/visual 时不变)被跳过,churn 是随列表长度增长的 vdom diff。整体是 ~1.4s 动画期间全列表 ~60fps 重渲染,与动画争抢但通常非灾难性。
+- **修复建议**:经 rAF 调度合并 `publishTools`(置脏标志,每帧最多 flush 一次);memo 化 `ChatMessage`/`ChatToolCalls` 使只有流式消息的 chip 子树更新;在途消息不再同时维护 `streamingTools` 与 `messageTools` 条目(流式分支已读 `streamingTools`,每帧 `new Map(prev).set` 克隆冗余)。
+- **置信度**:0.88
+
+#### M-Save1 · `writeCanvasFullV2` 每次保存读写每个 per-node 文件,即便未改动
+- **文件**:`src/main/canvas/storage.ts:886-927`
+- **类别**:blocking-io
+- **证据**:`for (const node of nodes) { const existing = await readNodeFile(...); ... await writeNodeFile(...); }` 无变化检测;每个节点都 `readNodeFile` 且(除非磁盘严格更新)`writeNodeFile`(`atomicWriteJson` = tmp 写 + rename,逐文件)。移动一个节点仍重写全部 N 个 `nodes/<id>.json`。
+- **用户影响**:每次保存 O(n) tmp 创建 + rename。watcher 放大被三层 echo 抑制(精确字节、`visibleFieldsChanged`、`markSelfWrites` 时间戳)去重,故单次逻辑保存**不**产生 N 次虚假渲染端广播——净影响是浪费的磁盘 churn(O(n) 原子写 + O(n) watcher read-back),非渲染/广播风暴。这是防抖保存路径、典型数十节点,故 medium。
+- **修复建议**:跳过序列化记录字节相同(或 `updatedAt` 未变)的节点。渲染端仅对真正变更节点 bump `updatedAt`,比对 incoming `updatedAt` 与 store 已有的 `lastPerNodeContent` 快照,只写 diff——move-only 改动应写 1 个文件而非 N 个。
+- **置信度**:0.9
+
+#### M-Save2 · 终端 scrollback 自动保存(每终端每 2s)驱动整个保存流水线做全 canvas 序列化
+- **文件**:`TerminalNodeBody/index.tsx:234-241`
+- **类别**:blocking-io(实为冗余异步 I/O + JSON 序列化 CPU,无 UI 线程阻塞)
+- **证据**:`setInterval(async () => { const scrollback = serializeBuffer(term); onUpdateRef.current(nodeId, { data: {...scrollback...} }); }, 2000)`,每终端独立。`onUpdate` → `updateNode` → `scheduleSave`(800ms 防抖)。
+- **用户影响**:k 个活跃终端 → 渲染端每 ~2s/k 入队一次保存;每个幸存(防抖后)保存序列化整个 canvas(所有节点 + scrollback)经 IPC,主进程跑 H6 的 O(N) 读-合并-写。成本随终端数与节点总数增长,与实际改动多少无关。800ms 防抖摊销突发,`updatedAt` 仲裁跳过磁盘更新的写,故 medium。
+- **修复建议**:仅当序列化 scrollback 与上次持久化值不同才调度保存(跳过 no-op tick);或经只写 `nodes/<id>.json` 的专用单节点 IPC 路径持久化,而非把整个 canvas round-trip 经 `mergeExternalNodes`。
+- **置信度**:0.9
+
+#### M-Save3 · 隐藏终端节点的 2s scrollback+getCwd 自动保存间隔在 `display:none` 时从不暂停
+- **文件**:`TerminalNodeBody/index.tsx:234-241`;Agent 版 `useAgentNodeController.ts:886-893`
+- **类别**:blocking-io / 后台浪费
+- **证据**:`setInterval` 在 spawn effect 创建,无 `isActive`/visibility gate。因隐藏 workspace 保持挂载(H9),每个已访问 workspace 的每个终端/Agent 节点持续触发此定时器。
+- **用户影响**:跨所有挂载 workspace 的每个终端/Agent 节点每 2s 序列化完整 xterm buffer(CPU+GC churn)+ 发 `getCwd` IPC round-trip + `onUpdate` 写回。M 个终端 × N 个 keep-alive workspace = M 定时器 × 0.5 IPC/s 不可见后台主线程工作。隐藏 workspace 的 canvas host 为 `display:none`,故写回触发 React 协调/持久化但**不**触发那些 canvas 的视觉布局/绘制。属稳态低频后台工作(可扩展性/电量问题),故 medium。
+- **修复建议**:把间隔 gate 在 visibility 上——向 `TerminalNodeBody`/`AgentNodeBody` 传 `isActive`/`visible`,隐藏时清间隔(隐藏时做一次最终持久化,显示时恢复)。更廉价:仅当 buffer 自上 tick 真正改变(`term.onData` 脏标志)才序列化+持久化,且除非有影响 cwd 的输入否则跳过 `getCwd` IPC。
+- **置信度**:0.9
+
+#### M-Keep1 · 每个挂载(隐藏)Canvas 保持活跃 `canvas:external-update` IPC 订阅,对所有 workspace 的广播都唤醒
+- **文件**:`useNodes.ts:154-270`
+- **类别**:ipc
+- **证据**:`useNodes` 按 canvasId 订阅:`storeApi.onExternalUpdate(async (event) => { if (event.workspaceId !== canvasId) return; ... })`。主侧广播无条件扇出到每个窗口(`broadcast.ts:17` `for (const win of BrowserWindow.getAllWindows()) win.webContents.send('canvas:external-update', payload)`)。guard 在 JS 中,故每个订阅者对每个广播仍被唤醒;匹配者 `await storeApi.load(canvasId)`(全盘读 + JSON parse)并重建节点列表。
+- **用户影响**:**更正**:每个事件只有 1 个 workspace id 匹配,故是 1 次全 reload +(N-1)次 trivial 早返回(可忽略);merge/重建与 `storeApi.load` 在**渲染端**(`load()` 经 ipcRenderer.invoke,磁盘读/parse 在主进程、不在渲染端关键路径)。真实成本:每次外部变更,目标 workspace 重读+重 parse 完整 `canvas.json` 并重建节点数组 + 重渲染,即便隐藏;Agent/teams 的多次 `broadcastCanvasUpdate` 放大 reload 次数。界定于每事件一个匹配 workspace,故 medium。
+- **修复建议**:仅为 active(可见)canvas 挂载外部更新订阅,或在源头过滤(主侧维护 per-workspace 订阅者注册表而非 `getAllWindows()`);至少对 per-event `storeApi.load` 防抖,使突发 `broadcastCanvasUpdate` 合并为一次磁盘读。
+- **置信度**:0.85
+
+#### M-Keep2 · 共享 `allNodes` map 在每个隐藏终端/Agent 的 2s 自动保存时 churn,经不稳定 `resolveReference` 回调重渲染所有挂载 Canvas
+- **文件**:`Workbench/useWorkbenchState.ts:98-104`
+- **类别**:re-render
+- **证据**:隐藏终端/Agent 每 2s `onUpdate` → Canvas `updateNode` → `onNodesChange` → `handleNodesChange`:`setAllNodes((prev) => { if (prev[workspaceId]===nodes) return prev; return { ...prev, [workspaceId]: nodes }; })`——替换 `allNodes` 对象 identity。在 `Workbench/index.tsx`,`allNodes` 是 `resolveReferenceNode`(`216`)、`resolveReferenceSource`(`226`)、`createReferenceNodeFromEntry`(`270`)、`pasteReferencesIntoCanvas`(`350`)、`updateReferenceSourceNode`(`386`)的依赖,每次 `setAllNodes` 重建这些回调,作为 prop 传给**每个**挂载 `<Canvas>`(`index.tsx:442-450`)含 active 者。
+- **用户影响**:隐藏 workspace 的后台终端每 2s 强制新 `allNodes` 对象,重建引用解析回调并重渲染 active Canvas(及每个挂载 Canvas)。**根因**:`allNodes` 是 Workbench state 且 Canvas 未 `React.memo`,Workbench 重渲染本身就重渲染每个挂载 Canvas(即便回调稳定);不稳定回调是会击溃 memo 化的加重因素。属空闲协调/GC churn(非正确性 bug),随终端数增长,故 medium。
+- **修复建议**:把 per-workspace 引用解析与整 map identity 解耦——`allNodes` 存 ref,暴露稳定 `getWorkspaceNodes(id)`(`useWorkbenchState.ts:94` 已存在),使 resolve* 回调依赖稳定 getter 而非 `allNodes`,再 memo 化传入 Canvas 的回调;另节流终端 scrollback 持久化(见 M-Save3)使隐藏节点根本不写回。
+- **置信度**:0.8
+
+#### M-Keep3 · `PulseRouter` keepAlive 让整个 canvas 路由子树保持挂载,叠加多 canvas keep-alive
+- **文件**:`router/index.tsx:56-67`
+- **类别**:re-render / 后台浪费
+- **证据**:`PulseRouterView` `keepAlive` 渲染 `<div style={isActive ? {display:'flex'} : {display:'none'}}>{children}</div>`,children 从不 unmount 只隐藏。`App.tsx:513` 把 `<Workbench>` 包在 `<PulseRouterView name='canvas' keepAlive>`。叠加 Workbench 自身 per-workspace `display:none`,canvas 子树(所有 N 个挂载 canvas + 其 hook/定时器/订阅)在用户处于 /chat、/nodes、/graph 或任意插件路由时仍完全挂载。
+- **用户影响**:离开 canvas 到 chat/nodes/graph **不**静默 canvas——其 `useNodes` IPC 订阅、终端/Agent 2s 间隔、PTY 全在隐藏 div 背后运行;用户在每个其它路由也付全部 canvas 后台成本。
+- **修复建议**:此 keepAlive 对 canvas 状态保留是有意的,但不应保持后台**工作**运行。与上述驱逐/可见性 gating 结合:canvas 路由非 active 时,暂停 canvas 的定时器与外部更新订阅(传 `routeActive` 标志经 Workbench → Canvas → useNodes/终端 hook),同时保持 DOM/组件状态挂载。
+- **置信度**:0.9
+
+#### M-Graph1 · `renderNode` 对选中/悬停节点逐节点逐帧做 `ctx.save/restore` + `measureText` + 带 shadowBlur 的 `roundRect`
+- **文件**:`WorkspaceNodes/GraphPage.tsx:481-561`
+- **类别**:layout-thrash
+- **证据**:`nodeCanvasObject={renderNode}`,每个可见节点每帧 `ctx.save()` ... `ctx.measureText(label).width` ... `ctx.roundRect(...)` ... `ctx.restore()`。label 在 `showLabels`(默认 true)或 `globalScale>2.3` 时绘制。**更正**:`shadowBlur=14` 仅对 `isSelected||isHovered`(`506-509`,每帧至多 ~2 节点)设置,绘 label 前重置为 0,**非**每节点成本。
+- **用户影响**:节点多 + label 开启时,force-graph 渲染循环在模拟/pan/zoom 期间每帧每节点跑 `measureText` + fill + roundRect path。`measureText` 是已知昂贵的 canvas 调用;大图(数百+节点)主动模拟/pan/zoom 时持续高 CPU 与掉帧。工作有界且每节点廉价,故 medium。
+- **修复建议**:按 (label, fontSize bucket) 缓存测量宽度(可变 ref `Map<string, number>`,字号 bucket 变时失效),使 `measureText` 每 label 一次;缩放阈值以下完全跳过 label 绘制(force-graph 标准模式);仅重置实际触碰的属性以避免无谓 `save()/restore()`。
+- **置信度**:0.82
+
+#### M-Graph2 · `searchSuggestions` 每次按键经 `tagName` 线性扫描做 O(nodes × tagsPerNode × totalTags)
+- **文件**:`WorkspaceNodes/GraphPage.tsx:284-318`
+- **类别**:n-plus-1
+- **证据**:`visibleNodes.filter((node) => [node.id, node.workspaceName ?? '', getNodeTitle(node, ''), node.summary ?? '', ...node.tags.map((tagId) => tagName(tagId, tags))].some((value) => value.toLowerCase().includes(q)))`。`tagName` 是 `tags.find((t) => t.id===tagId)?.name`(`utils.ts:87-89`),每 tag 每 node 一次线性扫 `tags`。memo deps `[visibleNodes, query, tags, showTags]`,每按键重跑。
+- **用户影响**:每按键全量扫 `visibleNodes` 并以 O(totalTags) 解析每个 tag 名,字符串每次重新小写。节点/tag 多时是显著的每按键主线程成本,搜索框输入卡顿。
+- **修复建议**:从 `tags` 一次性 memo 化构建 `Map<tagId,name>` 传给 `tagName` 使查找 O(1);按 `visibleNodes`/`tags`(非 `query`)memo 化每节点小写化 haystack,使按键只做子串匹配;可在凑够 12 结果时早退。
+- **置信度**:0.85
+
+---
+
+### LOW
+
+#### L1 · `resizeGroupsToChildren` 每次变更运行,对无 group 节点的 canvas 无早退
+- **文件**:`useNodes.ts:399-452`
+- **类别**:layout-thrash
+- **证据**:`for (let pass=0; pass<4; pass++) { const byId = new Map(current.map(n => [n.id, n])); const resized = current.map(n => n.type !== 'group' ? n : ...); if (!changed) return current; current = resized; }`。从 `updateNode/removeNode(s)/syncDeletedNodes/ungroupNodes/moveNode(s)/resizeNode/duplicateNode/pasteNodes/groupNodes/wrapNodesInFrame` 调用,**进循环前无 group 检查**——零 group 也建 `new Map(...)` + 全 `current.map(...)`(pass 0)。
+- **用户影响**:每个 move/resize tick(与自动保存叠加,rAF 频率)至少分配一个全节点 Map + 一次全数组 map,即便零 group——纯浪费主线程工作 + 与节点总数成比的 GC 压力。空闲时不运行。
+- **修复建议**:顶部早退 `if (!nextNodes.some((n) => n.type === 'group')) return nextNodes;`;更佳:预算 group 集,传 `touchedIds` hint 使只重算 childIds 与移动 id 相交的 group。
+- **置信度**:0.88
+
+#### L2 · 逐节点 `setInterval` 相对时间 tick,每节点一个定时器
+- **文件**:`CanvasNodeView/useCanvasNodeViewModel.ts:81-85`
+- **类别**:re-render / 定时器 churn(原标 memory-leak 不准——cleanup 正确,无无界泄漏)
+- **证据**:`useEffect(() => { if (!node.updatedAt) return; const id = setInterval(() => setTick((t) => t+1), 30_000); return () => clearInterval(id); }, [node.updatedAt])`——每个 `CanvasNodeView` 装自己的 30s 间隔,dep 是 `node.updatedAt`(每次 move/resize/update 都改)。
+- **用户影响**:N 个并发 30s 定时器(每可见节点一个),每 30s 各强制一次本地状态更新 + **仅该节点**重渲染(非全 canvas)。因 dep 是 `node.updatedAt`,拖一个节点会在每次手势提交时拆/重建其间隔(定时器 churn)。净用户影响 low——许多廉价空闲 30s 唤醒 + 瞬态间隔重建,非泄漏或重渲染风暴。
+- **修复建议**:把相对时间提升为单个共享 ticker(canvas 层一个间隔经 context,bump 代际计数,节点读取);或只为时间戳足够近的节点运行间隔;从 dep 数组去掉 `node.updatedAt`(用 ref)使手势提交不重建定时器。
+- **置信度**:0.9
+
+#### L3 · `CanvasGestureHud` 接收完整 nodes 数组,每个手势 tick 做线性 `.find`
+- **文件**:`Canvas/CanvasSurface.tsx:275-282,361-378`
+- **类别**:re-render
+- **证据**:`{(dragPreview || resizePreview) && (<CanvasGestureHud dragPreview={dragPreview} nodes={nodes} resizePreview={resizePreview} scale={transform.scale} />)}`,内部 `const resizeNode = resizePreview ? nodes.find((n) => n.id === resizePreview.id) : null;`。传完整 live 数组(每 tick 改 identity)+ O(n) find。
+- **用户影响**:每个 resize tick 加一次 O(n) 扫描。drag 无害(用 `dragPreview`),resize 付扫描。**注**:memo 化 HUD 并不能阻止每 tick 重渲染(父 `CanvasSurface` 本身非 memo 且每 resize tick 收到新 `nodes`);唯一可避成本是 O(n) `.find`。净影响相对周围全树协调微不足道。
+- **修复建议**:只传所需单个节点(父中解析一次,或传 `useCanvasVisibility` 已算的 `nodesById` Map),而非整数组。
+- **置信度**:0.86
+
+#### L4 · `scheduleTerminalFit` 每个 Agent 终端 mount/restore 触发 3 rAF + 2 setTimeout(5 次 fit+refresh)
+- **文件**:`AgentNodeBody/useAgentNodeController.ts:104-116`(调用方 `356,377,413,456,510,532`)
+- **类别**:layout-thrash
+- **证据**:`scheduleTerminalFit` 立即跑 `fitAndRefreshTerminal`,再在 rAF、嵌套双 rAF、`setTimeout(...,80)`、`setTimeout(...,240)`——5 次。每次 `fitAndRefreshTerminal` 做 `syncTerminalFontSizeToCanvas`(getComputedStyle)+ `fitAddon.fit()`(回流)+ `term.refresh(0, rows-1)`(全可见行重渲染)。
+- **用户影响**:每个 Agent 终端 mount/restore 强制 5 次布局+全栅格化 pass;团队 frame 同时挂载多个 mirror 终端时倍增。**更正**:**不**随重连重试每 1s 复发(重试路径的 `scheduleTerminalFit` 被 `restoredSavedOutput` 标志 / `attachLiveMirror` 成功停定时器 守护);5 pass 跨 rAF/双 rAF/setTimeout(80/240) 分散在 ~240ms,非 5 次同步聚集回流。故 low。
+- **修复建议**:收敛为单 rAF fit + 一次 trailing settle fit,去掉冗余嵌套 rAF 与两个定时器;仅当 `fit()` 真正改变 cols/rows 时才 `term.refresh()`。
+- **置信度**:0.7
+
+#### L5 · 渲染端 `onData` handler 在 coding-agent hint 激活时每 chunk 跑 ANSI-strip + tail-slice + 两个正则
+- **文件**:`TerminalNodeBody/index.tsx:98-104`(`captureTerminalOutput`)→ `utils/codingAgentCommand.ts:14-21`
+- **类别**:CPU 微低效(原标 layout-thrash 不准——无 DOM/回流)
+- **证据**:`captureTerminalOutput` 每 `api.onData` chunk 运行,调 `appendTerminalOutputTail`(`data.replace(ANSI_PATTERN,'').replace(/\r/g,'\n')` 后 `${tail}${text}`.slice(-3000))与 `hasLikelyReturnedToShellPrompt`(`SHELL_PROMPT_PATTERNS.some(p => p.test(tail))`)。
+- **用户影响**:Claude/Codex 会话运行时(最重输出态)每个重绘 chunk 付 ANSI 正则 pass + 对 3KB tail 的两次正则测,叠加 xterm 渲染。hint 只需触发一次(返回提示符),故工作几乎全浪费;成本相对 xterm 渲染小,属低影响微低效。
+- **修复建议**:节流/防抖提示符检测——累积原始 chunk,最多每 ~150-250ms(或输出静默后 trailing 防抖)跑 `hasLikelyReturnedToShellPrompt`;chunk 无 ESC 字节时跳过 ANSI strip(`data.indexOf('\x1b') === -1`)。
+- **置信度**:0.6
+
+#### L6 · `highlighted` 每次悬停重算并驱动 `linkWidth/linkColor/linkDirectionalParticles` + `renderNode`
+- **文件**:`WorkspaceNodes/GraphPage.tsx:364-377,767-775`
+- **类别**:re-render
+- **证据**:`highlighted = useMemo(() => {...}, [activeNodeId, hoverNodeId, neighbors])` 每次 `hoverNodeId` 变(每次悬停/取消)重算;`onNodeHover` 触发每悬停 React 重渲染。link 回调读它:`linkWidth/linkColor/linkDirectionalParticles`,`linkKey(link)` 每 link 每帧建 `${source}->${target}` 字符串。
+- **用户影响**:**更正**:`highlighted` 重算廉价(memo 化,O(neighbors)),非问题;真实成本是 `linkWidth/linkColor` 内每 link 每帧 `linkKey()` 字符串分配(模拟热或 pan/zoom 时全 link 每帧两次分配)的 GC churn。directional particles 仅在悬停节点的邻居 link(小有界子集)。典型图尺寸 low,极密图升至 medium。
+- **修复建议**:把 hover/highlight 存 ref、在回调内读(或节流 `setHoverNodeId` 到 ~rAF);在 `buildGraphData` 中为每个 link 预算稳定 key 并直接读,避免每帧重建 `linkKey`;大图禁用/限 `linkDirectionalParticles`。
+- **置信度**:0.7
+
+#### L7 · `GraphPage` 经 canvas force-graph 渲染所有节点,无节点上限/虚拟化,且每次 focus 做 O(N) 线性 find
+- **文件**:`WorkspaceNodes/GraphPage.tsx:337-385`
+- **类别**:layout-thrash
+- **证据**:`buildGraphData`(`108-199`)对跨所有 workspace 的所有节点建 node+link map,带 tag 与 workspace-hub 扇出;`ForceGraph2D` 跑 `cooldownTime={12000}` 的 d3 模拟与逐节点 canvas 绘制。`focusNode` 做 `graphData.nodes.find((item) => getGraphId(item.id) === nodeId)`(`381`)——每次 focus 线性扫;无节点数上限。
+- **用户影响**:**更正**:`focusNode` 事件驱动(仅双击 + 搜索选择,setTimeout 延迟),非每渲染/每帧,O(N) 实际可忽略。真实主导成本是 graph 开启时无上限的 d3 力模拟 + 每帧 canvas 重绘每个节点(12s cooldown)。仅影响开启实验 graph flag 且节点多的用户,故 low。
+- **修复建议**:与 graphData 并行建 memo 化 `id->node` Map 使 `focusNode` O(1);对喂入模拟的节点数封顶/分页(默认限 active workspace,或超 N 时聚类/警告);降低 `cooldownTime` 或视图隐藏时暂停模拟。
+- **置信度**:0.85
+
+#### L8 · 实验视图(GraphPage / react-force-graph-2d / d3-force)在 flag 关闭时仍被 `App.tsx` 静态导入
+- **文件**:`App.tsx:14-16`
+- **类别**:bundle
+- **证据**:`App.tsx` 顶层 `import { GraphPage } from './components/WorkspaceNodes/GraphPage'`(及 `NodeDetailPage`/`NodesPage`)。`GraphPage.tsx:11` 静态 `import ForceGraph2D from 'react-force-graph-2d'`。路由在渲染时由 `GRAPH_ENABLED`/`NODES_ENABLED`(`App.tsx:60-61,555`,默认 disabled)gate,但静态导入使 force-graph + d3 在启动 chunk 中。`{GRAPH_ENABLED && (...)}` 只影响渲染不影响打包。
+- **用户影响**:**精确化**:这是从本地磁盘加载 bundle 的 Electron 桌面应用,无每用户网络"下载"成本;真实成本是更大启动 chunk + 启动时对 react-force-graph-2d 及其 d3-force 的一次性 parse/eval,即便 graph/nodes 视图 flag-disabled。故 low。
+- **修复建议**:把实验视图改 `React.lazy + dynamic import` gate 在 flag 后(镜像 `chat/utils/mermaid.ts` 已用的 `import('mermaid')` 模式),则 force-graph chunk 仅在 flag 开启且路由打开时加载。
+- **置信度**:0.92
+
+#### L-Graph-Reheat / L-Focus 等图层细节已并入 H8 与 L7,不再重复。
+
+---
+
+### 跨维度补充(bundle / 启动,均 medium)
+
+#### B1 · `electron.vite.config.ts` 无 `manualChunks` / build target——整个渲染端打成单个 eager parse chunk
+- **文件**:`electron.vite.config.ts:111-117`
+- **证据**:renderer.build 仅 `outDir: "dist/renderer"`,`plugins: [react(), localPluginRendererAssetsPlugin()]`;无 `build.rollupOptions.output.manualChunks`、无 `build.target`、无分块策略。React 树静态导入整链(`App.tsx → Workbench → Canvas → DefaultCanvasNode`),重型库(xterm、所有 `@tiptap/*`、lowlight+highlight.js、markdown-it、react-force-graph-2d 的 d3 sim)塌入 main `index` chunk。
+- **用户影响**:**精确化**:Electron 渲染端从 `file://` 加载,无"下载"成本;真实成本是窗口打开时单个大 bundle 的 JS parse/compile/eval。d3-force、xterm、tiptap starter-kit + 14 扩展、lowlight、force-graph 在启动时全被 parse,即便 canvas 首绘都不需要。故 medium。
+- **修复建议**:加 `build.rollupOptions.output.manualChunks` 拆 vendor 组(`vendor-graph`/`vendor-editor`/`vendor-term`/`markdown`),并配合 `React.lazy(() => import(...))` 使 Rollup 真正生成 async chunk 并延迟 eval(`manualChunks` 单独只去重不延迟 eval)。
+- **置信度**:0.85
+
+#### B2 · `DefaultCanvasNode` 把 xterm + tiptap 节点体静态导入 keep-alive canvas chunk
+- **文件**:`CanvasNodeView/DefaultCanvasNode.tsx:12-19`
+- **证据**:顶层静态 `import { AgentNodeBody/FileNodeBody/TerminalNodeBody/TextNodeBody }`。`TerminalNodeBody/index.tsx:3-4` 静态 `import { Terminal } from '@xterm/xterm'`、`FitAddon`;`FileNodeBody` 经 `hooks/useFileNodeEditor.ts` 静态导入 `@tiptap/starter-kit`、`extension-image`、4 个 table 扩展、`extension-code-block-lowlight` 与 `lowlight` 的 `createLowlight(common)`(拽入 highlight.js)。Canvas 在默认路由 `<PulseRouterView name='canvas' keepAlive>`(`App.tsx:513`)内,启动即挂载。
+- **用户影响**:xterm 与完整 Tiptap + lowlight/highlight.js 在 canvas 可交互前被 eval,即便 workspace 零终端零文件节点。这些 dep 仅在终端/文件节点实际挂载时才需要。属 eager 模块 eval / 初始 bundle 膨胀(启动延迟),故 medium。
+- **修复建议**:把各节点体改 lazy——`const TerminalNodeBody = React.lazy(() => import('../TerminalNodeBody'))`(File/Agent 同),各包 `<Suspense fallback={...}>`。节点体仅当该类型节点存在时渲染,故 xterm/tiptap chunk 按需加载。
+- **置信度**:0.9
+
+#### B3 · 窗口仅在 await 插件 setup + tools-config + welcome-workspace seeding 之后才打开(主进程)
+- **文件**:`src/main/app/bootstrap.ts:106-191`
+- **证据**:`app.whenReady().then(async () => {...})` 内在 `openWindow()`(`191`)前 await:`ensureWelcomeWorkspaceSeeded()`(`106`)、`applyStoredBuiltInToolsConfigToEnv()`(`135`)、`setupCanvasPlugins(BUILT_IN_MAIN_PLUGINS)`(`163`)、`reloadConfiguredExternalMainPlugins()`(`164`)。`window.ts` 创建窗口无 `show: false` + `ready-to-show` 延迟。
+- **用户影响**:Time-to-window 被磁盘 I/O(workspace seeding、读 tool config)与插件激活完成 gate;任何慢插件激活或文件系统延迟直接延迟窗口出现。**精确化**:渲染端 bundle eval 成本是窗口创建**之后**顺序发生(`loadFile/loadURL` 异步),非与 pre-window await "叠加";真实成本是窗口首绘被 await 的磁盘 I/O 与(主要)慢 `activate()` 延迟。故 medium。
+- **修复建议**:先开窗口(canvas shell 无需 agent registry 即可渲染),后台完成插件/tools setup,仅把 canvas-agent IPC handler gate 在就绪 promise 上;把 `ensureWelcomeWorkspaceSeeded`/`reloadConfiguredExternalMainPlugins` 移出关键路径;用 `app.whenReady()`→首绘计时确认哪些 await 主导。
+- **置信度**:0.9
+
+---
+
+## 优先修复路线图
+
+### P0 — 解除线性恶化的根因(高收益,中等改动)
+
+| 修复 | 对应发现 | 预估收益 | 改动量 |
+|---|---|---|---|
+| **视口裁剪 `useViewportCulling`**:`transform`+容器尺寸入参,bbox 与视口(+1 视口 margin)相交,离屏节点渲染占位 div,进 margin band 才懒挂载重型 body;selected/dragging/fullscreen/边端点 始终挂载 | H1, H9 | 内存与挂载成本从 O(总节点)降到 O(屏幕节点);40 节点 workspace 初始加载与 JS 堆数量级下降 | 大(新 hook + DefaultCanvasNode 懒挂载 + 占位)|
+| **`getCwd` 异步化 + 解耦 2s 自动保存**:linux 用 `fs.promises.readlink('/proc/<pid>/cwd')`(不 fork),仅 spawn/提示符返回/≤30s 读 cwd | H3 | 消除主进程每 2s fork N 子进程的同步阻塞;终端输出/打字延迟显著改善;消除单慢 lsof 冻结全应用 | 中(改 handler + 调用方缓存)|
+| **`canvas:save` 单次 merge + 增量写**:`mergeExternalNodes` 调一次,缓存 `readCanvasFull`,`writeCanvasFullV2` 只写 `updatedAt` 变化节点 | H6, M-Save1 | 单节点改动从 ~5N 读 + N 写 降到 ~1 读 + 1 写;消除多终端 2s 自动保存的 IO 饱和 | 中(store/storage 改 diff 逻辑)|
+
+### P1 — 削减拖拽/流式/keep-alive 热路径(高/中收益)
+
+| 修复 | 对应发现 | 预估收益 | 改动量 |
+|---|---|---|---|
+| **drag/resize 几何排除出 `nodes` 数组**:手势中用 CSS overlay / position override map 驱动被拖节点,pointer-up 提交;`CanvasSurface` 包 `React.memo`,memo 化 visibility/render-order 输入 | H2, M2, M1, L1, L3 | 大 canvas 拖拽 jank 消除;每 tick 从 O(n) 派生流水线降到 O(被拖节点)| 大(useNodes 手势路径重构)|
+| **scrollback 专用低优先级更新路径**:跳过 `pushSnapshot` 与 `resizeGroupsToChildren`;脏标志/`addon-serialize` 仅在 buffer 改变时序列化;隐藏时 gate 定时器 | H5, M3, M-Save2, M-Save3 | 消除 undo 栈污染(Ctrl+Z 正确性);消除空闲后台全 buffer 遍历 + 全 canvas 序列化 | 中 |
+| **Chat 流式:`ChatMessage`/`ChatToolCalls` 包 `React.memo` + rAF 合并 delta + 流式时不跑 highlightAuto** | H7, M-Chat1, M-Chat2 | 代码密集回复流式从 O(n²) CPU 降到完成时一次 highlight;全列表每 token 重渲染消除 | 中 |
+| **PTY `onData` 合并 flush(~8-16ms/帧)**:一条拼接 IPC + 每 flush 一次 observer;团队 Agent 解析复用同一 flush | M-IPC, M4 | 高吞吐输出的 IPC/主进程 CPU 压力降一个量级 | 中 |
+| **keep-alive 后台静默**:LRU 限定挂载集(active + K=2-3),非 active 路由/workspace 暂停定时器与 `external-update` 订阅;`allNodes` 存 ref + 稳定 getter | H9, M-Keep1, M-Keep2, M-Keep3 | 多 workspace 会话内存停止单调增长;空闲 2s 重渲染 churn 消除 | 中-大 |
+
+### P2 — 低成本清理与启动优化(中/低收益,小改动)
+
+| 修复 | 对应发现 | 预估收益 | 改动量 |
+|---|---|---|---|
+| `resizeGroupsToChildren` 无 group 早退 | L1 | 消除零 group canvas 每 tick 浪费 Map+map | 极小(一行)|
+| 相对时间提升为单共享 ticker;去 `node.updatedAt` dep | L2 | 消除每节点定时器 churn | 小 |
+| ResizeObserver rAF 合并 + 尺寸不变跳过 fit | H4 | 缩放卡顿(终端在场)消除 | 小-中 |
+| `execInSession` 只扫尾部 marker + 数组 append | M-Exec | 消除大输出 O(n²) 主线程阻塞 | 小 |
+| mirror detach 时 `disposeSubscriptions()` | M-Mirror | 消除 ≤12 隐藏 xterm 的浪费解析 + 常驻内存 | 小 |
+| 实验视图 + 节点体 `React.lazy` + `manualChunks` | B1, B2, L8 | 冷启动 parse/eval 显著下降 | 小-中 |
+| 窗口先开、插件后台 setup | B3 | time-to-window 缩短 | 中 |
+| Graph:`measureText` 缓存 + 缩放阈值跳 label;`tagName` 用 Map;`id->node` Map;node identity 复用 warm-start;`linkKey` 预算 | H8, M-Graph1, M-Graph2, L6, L7 | 实验 graph 大图帧率与搜索输入改善 | 中(仅 flag 用户)|
+| `scheduleTerminalFit` 收敛单 rAF + trailing | L4 | 团队 frame 挂载 hitch 减少 | 小 |
+| coding-agent hint 提示符检测节流 | L5 | 流式期间微 CPU 节省 | 小 |
+
+---
+
+## 架构级建议(跨发现的系统性模式)
+
+1. **集中式 `nodes` 数组是最大结构性放大器**。move/resize/scrollback/cwd 自动保存全部走同一个 `updateNode → applyNodes → applyState → setNodes` 通用路径,任何变更都替换整个数组 identity,引爆下游 visibility/render-order/keep-alive 的全量重算(H2、M1、M3、L1、M-Save2、M-Keep2)。建议**分层 state**:(a) 几何/拖拽用 ephemeral override(ref/CSS),不入 canonical 数组;(b) scrollback/cwd 等"非视觉数据"走专用 patch 路径,不 push undo、不 resize group、不全 canvas 序列化;(c) canonical 数组只在结构性变更(增删/分组)时替换。
+
+2. **缺失虚拟化是内存与挂载成本的天花板**。Canvas 与 GraphPage 都对**全集**而非**屏幕集**做挂载/渲染(H1、H9、L7)。统一引入视口裁剪 + 离屏占位 + 懒挂载重型 body,是单项收益最大的改动,且与 keep-alive 多 workspace 叠加后效果倍增。
+
+3. **主进程 IPC 串行化使任何同步/重复 I/O 都成为全应用停顿**。`getCwd` 的 `execSync`、`canvas:save` 的 ~5N 读、`execInSession` 的 O(n²) 扫描、PTY 逐 chunk 扇出全部跑在服务所有 IPC 的同一主进程事件循环上(H3、H6、M-Exec、M-IPC、M4)。系统性原则:**主进程零同步子进程**(用 `fs.promises`/`execFile`)、**增量而非全量**(只写 diff、只扫尾部)、**合并而非逐事件**(per-id flush 窗口)。
+
+4. **keep-alive 设计应保留状态但暂停工作**。多 workspace + PulseRouter 的 keep-alive 是有意的状态保留,但当前连后台**工作**(2s 定时器、PTY 订阅、external-update 订阅)一并保留(H9、M-Keep1/2/3)。引入贯穿 `routeActive`/`workspaceActive` 标志,隐藏时暂停定时器与订阅、保留 DOM/组件状态,并用 LRU 上限驱逐真正空闲的 workspace。
+
+5. **流式热路径(Chat token / tool delta / PTY chunk)需要帧级合并与 memo 边界**。三处都以远高于显示需求的频率触发 setState + 全列表协调(H7、M-Chat1、M-Chat2、M-IPC)。统一模式:**rAF/帧级合并 setState** + **叶子组件 `React.memo`** + **昂贵解析(markdown/highlight/ANSI)缓存或延迟到静默**。
+
+6. **Bundle 应按"首绘不需即懒加载"切分**。Electron 本地加载无网络下载成本,但单 eager chunk 的 parse/eval 仍是冷启动税(B1、B2、L8)。沿用仓库已有的 `import('mermaid')` 动态导入模式,把 xterm/tiptap/force-graph 等"节点/视图按需"的重型 dep 全部 `React.lazy` + `manualChunks`,并把窗口创建移出主进程插件 setup 的关键路径(B3)。
+
+> 报告基于输入的对抗性核验发现编写,未新增任何发现。所有文件路径已按 `note` 字段的核验修正(如 `DefaultCanvasNode.tsx` 位于 `CanvasNodeView/`、`frameHierarchy.ts` 位于 `utils/`、终端成本函数位于 `AgentNodeBody/utils/terminal.ts`)。
+
+---
+
+## 附:完整性批判(审计盲区)
+
+There are several node types and dimensions the audit's 9 scouted areas don't obviously cover (Iframe/webview nodes, Mermaid/Mindmap rendering, Image nodes, DynamicApp/Plugin nodes). I have enough to write the critique.
+
+- **Iframe/webview 节点完全缺席**：`IframeNodeBody`、`DynamicAppNodeBody`、`PluginNodeBody` 各自挂载独立 `<webview>`/iframe，每个都是单独的渲染进程，多开时内存/CPU 远超 xterm/Tiptap。已有 `useWebviewBackgroundThrottle`，但其节流是否真生效、被遮挡/视口外的 webview 是否仍在跑，均未审计——这可能是最大的隐藏内存吃手。
+
+- **Mermaid / Mindmap 渲染未覆盖**：`mermaid@11` 在 ChatMessage、RightDock、ArtifactCard、`MindmapNodeBody` 多处同步渲染，mermaid 初始化与 `render()` 是重型且常阻塞主线程；流式 chat 里每个 token 重渲是否触发 mermaid 重解析未验证。这是 chat token 流式成本之外的独立风险。
+
+- **Image 节点与大资源**：`ImageNodeBody`/`FileNodeBody` 的图片解码、是否走 base64 内联进 canvas state（放大 read-merge-write 体积、IPC 序列化、autosave）均未测；大图内联会同时打击 `canvas:save` 与启动加载。
+
+- **缺实测数字**：全部 39 条都是静态代码推断,没有任何 profiling——没有实际 render count（React Profiler）、没有 bundle 体积分解、没有 Electron 冷启动耗时、没有 IPC 帧率/PTY 吞吐基线。哪条是真瓶颈无法排序,需至少跑一次 production build 的 `electron-vite build` 出 chunk 体积,并用 React Profiler 抓一次典型多节点画布。
+
+- **记忆化覆盖率存疑**：全 `components` 目录仅 3 个文件用到 `memo`/`useMemo`(且含测试文件)。"state fan-out 每次 mutation 全量重渲"这条找到了,但下游节点组件普遍未 memo 化的放大效应未量化——需要确认 `CanvasNodeView` 之下各 NodeBody 是否随无关节点 mutation 一起重渲。
+
+- **未审计的写放大来源**：`localStorage` 被 8+ 处使用(terminal scrollback、RightDock、NodesChatDock 等),同步写 localStorage 在主线程,频繁写(如终端输出)可能造成卡顿,与 autosave 是两条独立的持久化路径,只审了 fs 侧。
+
+- **react-force-graph-2d 仅作"渲染"提及**:其 canvas 重绘是 requestAnimationFrame 持续循环,即便图静止/不可见(切到别的 workspace 但 keep-alive 保活)是否仍在跑动画帧未验证——与 keep-alive 多挂载维度叠加可能持续烧 CPU。
+
+- **node-pty 原生模块与 asarUnpack**:rebuild/原生绑定、PTY 后端进程数随 agent/terminal 节点线性增长的上限未探;大量并发 PTY 的 IPC 背压策略只看了流式输出,没看 resize/写入路径与进程回收。


### PR DESCRIPTION
Adds a prioritized performance audit of apps/canvas-workspace covering 9
hotspot dimensions (canvas DOM rendering/viewport culling, centralized
node/edge state re-render fan-out, xterm/Tiptap lifecycle, PTY/IPC
streaming, chat token streaming, canvas:save persistence, keep-alive
multi-mount, force-graph rendering, bundle/startup).

Findings were adversarially verified against the source; includes a
P0/P1/P2 fix roadmap, architecture-level recommendations, and an explicit
gaps section noting the report is static-analysis only (no profiling yet).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QJG82ah7hmN7V3KqvZnYyp