### PR TITLE
fix(canvas-workspace): resolve CSS design-token violations in SearchBar, TextNodeBody, NodeContextMenu

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.css
@@ -1,6 +1,6 @@
 .context-menu {
   position: fixed;
-  z-index: 1000;
+  z-index: var(--layer-fullscreen-node);
   min-width: 200px;
   background: var(--surface);
   border: 1px solid var(--border);

--- a/apps/canvas-workspace/src/renderer/src/components/SearchBar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/SearchBar/index.css
@@ -10,7 +10,7 @@
   max-width: calc(100% - 32px);
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: var(--radius-md, 10px);
+  border-radius: var(--radius-lg);
   box-shadow: var(--shadow-float), 0 6px 24px rgba(0, 0, 0, 0.10);
   z-index: var(--layer-search);
   font-family: var(--font);
@@ -60,7 +60,7 @@
 }
 
 .canvas-search-bar__counter--empty {
-  color: var(--danger, #d04848);
+  color: var(--error);
 }
 
 .canvas-search-bar__toggle,
@@ -83,13 +83,13 @@
 .canvas-search-bar__toggle:hover,
 .canvas-search-bar__nav:hover:not(:disabled),
 .canvas-search-bar__close:hover {
-  background: var(--surface-hover, rgba(0, 0, 0, 0.06));
+  background: var(--surface-hover);
   color: var(--text);
 }
 
 .canvas-search-bar__toggle.is-active {
-  background: var(--accent-muted, rgba(80, 120, 220, 0.16));
-  color: var(--accent, #4a78dc);
+  background: var(--accent-light);
+  color: var(--accent);
 }
 
 .canvas-search-bar__nav:disabled {
@@ -127,12 +127,12 @@
 
 .canvas-search-bar__result:hover,
 .canvas-search-bar__result:focus-visible {
-  background: var(--surface-hover, rgba(0, 0, 0, 0.04));
+  background: var(--surface-hover);
   outline: none;
 }
 
 .canvas-search-bar__result.is-active {
-  background: var(--accent-muted, rgba(80, 120, 220, 0.16));
+  background: var(--accent-light);
 }
 
 .canvas-search-bar__badge {
@@ -141,7 +141,7 @@
   letter-spacing: 0.04em;
   padding: 1px 6px;
   border-radius: 999px;
-  background: var(--surface-alt, rgba(0, 0, 0, 0.06));
+  background: var(--border-light);
   color: var(--text-muted);
   flex-shrink: 0;
   max-width: 82px;

--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.css
@@ -112,7 +112,7 @@
    * editor grows past a fixed-height frame. Height follows content. */
   height: auto;
   overflow: visible;
-  border-radius: var(--radius-md, 6px);
+  border-radius: var(--radius-sm);
   flex: none;
 }
 
@@ -127,7 +127,7 @@
   min-width: 32px;
   min-height: 28px;
   padding: 6px 10px;
-  border-radius: var(--radius-md, 6px);
+  border-radius: var(--radius-sm);
   outline: none;
   word-break: break-word;
   overflow-wrap: anywhere;
@@ -248,7 +248,7 @@
 }
 
 .text-node-body code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 0.9em;
   padding: 0.08em 0.35em;
   border-radius: 4px;
@@ -260,7 +260,7 @@
   padding: 8px 10px;
   border-radius: 6px;
   background: rgba(0, 0, 0, 0.05);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 0.9em;
   overflow-x: auto;
 }


### PR DESCRIPTION
## Summary

Audit of `apps/canvas-workspace/src/renderer/src/` found three categories of style violations against the design-token system defined in `styles.css`. This PR fixes the highest-priority issues — undefined variable references, hardcoded font stacks, and a raw z-index on a full-app surface.

---

## Violations fixed

### 1. `SearchBar/index.css` — undefined CSS variable references

Five variable names were used that are never defined in `styles.css`, leaving them silently dependent on their fallback values:

| Original | Replacement | Reason |
|---|---|---|
| `var(--radius-md, 10px)` | `var(--radius-lg)` | `--radius-lg` is the defined 10 px token; `--radius-md` does not exist |
| `var(--danger, #d04848)` | `var(--error)` | `--error` (#c0392b) is the canonical error colour |
| `var(--accent-muted, rgba(80,120,220,0.16))` × 2 | `var(--accent-light)` | `--accent-light` is the defined subtle accent fill |
| `var(--surface-alt, rgba(0,0,0,0.06))` | `var(--border-light)` | `--border-light` is the closest neutral tint token |
| `var(--surface-hover, rgba(0,0,0,0.0x))` × 2 | `var(--surface-hover)` | `--surface-hover` is defined; fallback was redundant and inconsistent |

The wrong accent fallback in `var(--accent, #4a78dc)` was also removed — `--accent` is `#2383e2`, not `#4a78dc`.

### 2. `TextNodeBody/index.css` — undefined `--radius-md` and hardcoded font stacks

- Two uses of `var(--radius-md, 6px)` replaced with `var(--radius-sm)` — `--radius-sm` is the defined 6 px token; `--radius-md` does not exist in the design system.
- Two hardcoded `ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace` font-family declarations on `.text-node-body code` and `.text-node-body pre` replaced with `var(--font-mono)`, which expands to the same canonical stack defined in `styles.css`.

### 3. `NodeContextMenu/index.css` — hardcoded z-index on a `position: fixed` surface

`z-index: 1000` replaced with `z-index: var(--layer-fullscreen-node)` (same numeric value). The `styles.css` layering-scale comment explicitly states: *"Every surface that overlays other components takes its z-index from this scale; never hardcode a z-index for a full-app surface."* The context menu is `position: fixed` and qualifies as a full-app surface.

---

## What was not changed

- Badge colours in `CommandPalette/index.css` (e.g. `#673ab7`, `#2196f3`) — these are intentional per-badge accent colours with no matching design token; changing them requires a design-system extension PR.
- The `border-radius: 4px` chip values in `CommandPalette` — no `--radius-xs` token exists yet.
- Shadows using `rgba(15, 23, 42, …)` in `Canvas/index.css` — these use a different base colour than the shadow tokens and may be intentional for the canvas backdrop.
- `chat/ChatPanel.css` hardcoded colours — that file has extensive violations that warrant a separate, focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189p75ZZBEwH2J7BDbg1Lbi

---
_Generated by [Claude Code](https://claude.ai/code/session_0189p75ZZBEwH2J7BDbg1Lbi)_