### PR TITLE
release(canvas): 0.1.12

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.11",
+  "version": "0.1.12",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump Pulse Canvas to 0.1.12.
- Published the macOS arm64 DMG and blockmap to R2.
- Updated stable latest.json and deployed the download page.

## Release notes
- Added a Canvas note outline, richer find options, and @ mentions for linking canvas nodes from notes.
- Improved note image insertion with drag-and-drop, URL/clipboard paste, and automatic downscaling.
- Added inline selection formatting and colors for text nodes.
- Polished reference nodes, mindmap interactions, and sidebar terminal zoom, with fixes for selection, dragging, and paste workflows.

## Verification
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm --filter canvas-workspace package:mac:arm64`
- Release script `--no-build --use-proxy` uploaded R2 artifacts and deployed Pages.
- Confirmed remote manifest at `https://downloads.jasperhu.art/pulse-canvas/stable/latest.json` reports version `0.1.12`.

## Published URLs
- Manifest: https://downloads.jasperhu.art/pulse-canvas/stable/latest.json
- Download page: https://pulse-canvas-download.pages.dev/
- Pages deployment: https://af7f4e79.pulse-canvas-download.pages.dev

## Post-merge
After this PR merges into `master`, create the annotated tag `pulse-canvas-v0.1.12` on `origin/master` and push it.