### PR TITLE
[codex] Add repository harness guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ release/
 
 # Pulse Canvas harness runtime artifacts
 apps/canvas-workspace/.harness/
+*.harness-bak
 
 # Gatsby files
 .cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,24 +1,41 @@
 # Repository Guidelines
 
+## Repository Harness
+
+The active repository-level harness source of truth is `harness/`. Use it as a progressive map, not as a document dump:
+
+```text
+AGENTS.md / CLAUDE.md
+-> harness/README.md
+-> harness/profile.yaml
+-> affected workspace entry
+-> workspace contracts/spec/runbook/validation as needed
+```
+
+`.pulse-coder/` is product/runtime configuration and test surface for Pulse Coder itself; do not treat it as the source of truth for this repository harness pilot.
+
 ## Project Structure & Module Organization
-This repo is a `pnpm` monorepo with workspaces in `packages/*` and `apps/*`.
+This repo is a `pnpm` monorepo with all `packages/*` workspaces plus selected app workspaces listed in `pnpm-workspace.yaml`.
 
 - `packages/engine`: core agent engine, built-in tools, plugin loading, and runtime loop.
 - `packages/cli`: interactive terminal CLI built on `pulse-coder-engine`.
 - `packages/pulse-sandbox`: sandboxed JS execution runtime and `run_js` tool adapter.
 - `packages/memory-plugin`: memory integration/service package.
 - `apps/remote-server`: optional HTTP service wrapper around the engine.
-- `apps/coder-demo`: legacy experimental app.
+- `apps/teams-cli`: CLI host for agent teams workflows.
+- `apps/canvas-workspace`: Electron canvas workbench.
+
+Other `apps/*` directories may be legacy, standalone, or auxiliary projects; do not treat them as active pnpm workspaces unless `pnpm-workspace.yaml` includes them.
 
 Primary source code lives under each package/app `src/` directory; build output goes to `dist/`.
 
 ## Build, Test, and Development Commands
 - `pnpm install`: install workspace dependencies.
-- `pnpm run build`: build all workspaces recursively.
+- `pnpm run build`: build core workspaces recursively.
 - `pnpm run dev`: watch mode for packages.
 - `pnpm start`: run the CLI (`pulse-coder-cli`).
 - `pnpm test`: run package tests (`./packages/*`).
-- `pnpm run test:apps`: run app tests (`./apps/*`).
+- `pnpm run test:apps`: run tests for app workspaces matched by pnpm filters.
 - `pnpm --filter pulse-coder-engine typecheck`: strict TS typecheck for engine.
 
 Useful package targets:
@@ -29,7 +46,7 @@ Useful package targets:
 - `pnpm --filter @pulse-coder/remote-server build`
 - `pnpm --filter @pulse-coder/remote-server dev`
 
-Note: `apps/coder-demo` uses a placeholder test script, so app-level test runs may fail until it is replaced.
+Note: legacy or standalone app directories are outside the active pnpm workspace set unless listed in `pnpm-workspace.yaml`.
 
 ## Remote server notes (`apps/remote-server`)
 - Entry point: `apps/remote-server/src/index.ts` bootstraps session store, memory integration, worktree binding, and engine.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,20 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Repository Harness
+
+The active repository-level harness source of truth is `harness/`. Use it as a progressive map when deciding what to read, where knowledge should live, and which validation to run:
+
+```text
+CLAUDE.md / AGENTS.md
+-> harness/README.md
+-> harness/profile.yaml
+-> affected workspace entry
+-> workspace contracts/spec/runbook/validation as needed
+```
+
+`.pulse-coder/` remains Pulse Coder runtime/product configuration (`mcp`, runtime `skills`, agents, model config examples, and compatibility paths). Do not use it as the source of truth for this repository harness pilot.
+
 ## Project Overview
 
 Pulse Coder is a plugin-first AI coding assistant built as a TypeScript monorepo.
@@ -14,7 +28,7 @@ Core capabilities include:
 
 ## Monorepo Structure
 
-This repo uses `pnpm` workspaces (`packages/*`, `apps/*`).
+This repo uses `pnpm` workspaces for all `packages/*` plus selected apps listed in `pnpm-workspace.yaml`.
 
 Primary packages:
 - `packages/engine` (`pulse-coder-engine`): core engine loop, tools, plugin manager, built-in plugins.
@@ -30,20 +44,21 @@ Apps:
 - `apps/remote-server`: HTTP wrapper around engine runtime (Feishu/Discord/Telegram adapters).
 - `apps/teams-cli`: CLI for multi-agent teams workflows.
 - `apps/canvas-workspace`: canvas-based workspace app.
-- `apps/coder-demo`: legacy experimental app.
+
+Other `apps/*` directories may be legacy, standalone, or auxiliary projects; do not treat them as active pnpm workspaces unless `pnpm-workspace.yaml` includes them.
 
 ## Build, Dev, and Test Commands
 
 ```bash
 pnpm install
 pnpm run build          # builds packages/* + remote-server + teams-cli (SKIP_DTS=1)
-pnpm run build:all      # builds everything including apps
+pnpm run build:all      # builds all declared pnpm workspaces
 pnpm run dev
 pnpm start              # starts pulse-coder-cli
 pnpm start:debug        # starts CLI with debug logging
 pnpm test               # alias for test:core (packages/* + remote-server + teams-cli)
 pnpm run test:packages  # packages/* only
-pnpm run test:apps      # apps/* only (may fail in coder-demo)
+pnpm run test:apps      # app workspaces matched by pnpm filters
 pnpm run test:all       # all packages and apps
 ```
 
@@ -66,7 +81,7 @@ All packages use **vitest** (`vitest run`) for tests and `tsc --noEmit` for type
 
 Notes:
 - `pnpm test` (`test:core`) covers `packages/*`, `@pulse-coder/remote-server`, and `@pulse-coder/teams-cli`.
-- `pnpm run test:apps` includes app tests and may fail due to placeholder scripts in `apps/coder-demo`.
+- `pnpm run test:apps` covers declared app workspaces matched by pnpm filters.
 
 ## Architecture Notes
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,548 @@
+---
+version: alpha
+name: Linear-design-analysis
+description: "A near-black product-focused marketing canvas built around #010102 (the deepest dark surface of any tool in this collection), light gray text (#f7f8f8), and the signature Linear lavender-blue (#5e6ad2) used as the single chromatic accent. The system reads as software-craft documentation: dense, technical, and quietly luxurious. Display type is set in the Linear custom sans (SF Pro Display fallback) at 500–700 with measured negative tracking. Cards live as charcoal panels (#0f1011) with hairline borders. The accent lavender appears on the brand mark, focus rings, and a few intentional CTAs — never decoratively. Page rhythm leans on product UI screenshots framed in dark panels rather than atmospheric color."
+
+colors:
+  primary: "#5e6ad2"
+  on-primary: "#ffffff"
+  primary-hover: "#828fff"
+  primary-focus: "#5e69d1"
+  ink: "#f7f8f8"
+  ink-muted: "#d0d6e0"
+  ink-subtle: "#8a8f98"
+  ink-tertiary: "#62666d"
+  canvas: "#010102"
+  surface-1: "#0f1011"
+  surface-2: "#141516"
+  surface-3: "#18191a"
+  surface-4: "#191a1b"
+  hairline: "#23252a"
+  hairline-strong: "#34343a"
+  hairline-tertiary: "#3e3e44"
+  inverse-canvas: "#ffffff"
+  inverse-surface-1: "#f5f6f6"
+  inverse-surface-2: "#f6f7f7"
+  inverse-ink: "#000000"
+  brand-secure: "#7a7fad"
+  semantic-success: "#27a644"
+  semantic-overlay: "#000000"
+
+typography:
+  display-xl:
+    fontFamily: Linear Display
+    fontSize: 80px
+    fontWeight: 600
+    lineHeight: 1.05
+    letterSpacing: -3.0px
+  display-lg:
+    fontFamily: Linear Display
+    fontSize: 56px
+    fontWeight: 600
+    lineHeight: 1.10
+    letterSpacing: -1.8px
+  display-md:
+    fontFamily: Linear Display
+    fontSize: 40px
+    fontWeight: 600
+    lineHeight: 1.15
+    letterSpacing: -1.0px
+  headline:
+    fontFamily: Linear Display
+    fontSize: 28px
+    fontWeight: 600
+    lineHeight: 1.20
+    letterSpacing: -0.6px
+  card-title:
+    fontFamily: Linear Display
+    fontSize: 22px
+    fontWeight: 500
+    lineHeight: 1.25
+    letterSpacing: -0.4px
+  subhead:
+    fontFamily: Linear Display
+    fontSize: 20px
+    fontWeight: 400
+    lineHeight: 1.40
+    letterSpacing: -0.2px
+  body-lg:
+    fontFamily: Linear Text
+    fontSize: 18px
+    fontWeight: 400
+    lineHeight: 1.50
+    letterSpacing: -0.1px
+  body:
+    fontFamily: Linear Text
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.50
+    letterSpacing: -0.05px
+  body-sm:
+    fontFamily: Linear Text
+    fontSize: 14px
+    fontWeight: 400
+    lineHeight: 1.50
+    letterSpacing: 0
+  caption:
+    fontFamily: Linear Text
+    fontSize: 12px
+    fontWeight: 400
+    lineHeight: 1.40
+    letterSpacing: 0
+  button:
+    fontFamily: Linear Text
+    fontSize: 14px
+    fontWeight: 500
+    lineHeight: 1.20
+    letterSpacing: 0
+  eyebrow:
+    fontFamily: Linear Text
+    fontSize: 13px
+    fontWeight: 500
+    lineHeight: 1.30
+    letterSpacing: 0.4px
+  mono:
+    fontFamily: Linear Mono
+    fontSize: 13px
+    fontWeight: 400
+    lineHeight: 1.50
+    letterSpacing: 0
+
+rounded:
+  xs: 4px
+  sm: 6px
+  md: 8px
+  lg: 12px
+  xl: 16px
+  xxl: 24px
+  pill: 9999px
+  full: 9999px
+
+spacing:
+  xxs: 4px
+  xs: 8px
+  sm: 12px
+  md: 16px
+  lg: 24px
+  xl: 32px
+  xxl: 48px
+  section: 96px
+
+components:
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.button}"
+    rounded: "{rounded.md}"
+    padding: 8px 14px
+  button-primary-pressed:
+    backgroundColor: "{colors.primary-focus}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.button}"
+    rounded: "{rounded.md}"
+  button-primary-hover:
+    backgroundColor: "{colors.primary-hover}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.button}"
+    rounded: "{rounded.md}"
+  button-secondary:
+    backgroundColor: "{colors.surface-1}"
+    textColor: "{colors.ink}"
+    typography: "{typography.button}"
+    rounded: "{rounded.md}"
+    padding: 8px 14px
+  button-tertiary:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.button}"
+    rounded: "{rounded.md}"
+    padding: 8px 14px
+  button-inverse:
+    backgroundColor: "{colors.inverse-canvas}"
+    textColor: "{colors.inverse-ink}"
+    typography: "{typography.button}"
+    rounded: "{rounded.md}"
+    padding: 8px 14px
+  pricing-card:
+    backgroundColor: "{colors.surface-1}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.lg}"
+    padding: 24px
+  pricing-card-featured:
+    backgroundColor: "{colors.surface-2}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.lg}"
+    padding: 24px
+  feature-card:
+    backgroundColor: "{colors.surface-1}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.lg}"
+    padding: 24px
+  product-screenshot-card:
+    backgroundColor: "{colors.surface-1}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.xl}"
+    padding: 24px
+  testimonial-card:
+    backgroundColor: "{colors.surface-1}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-lg}"
+    rounded: "{rounded.lg}"
+    padding: 32px
+  customer-logo-tile:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink-subtle}"
+    typography: "{typography.caption}"
+    rounded: "{rounded.xs}"
+    padding: 16px
+  text-input:
+    backgroundColor: "{colors.surface-1}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.md}"
+    padding: 8px 12px
+  text-input-focused:
+    backgroundColor: "{colors.surface-1}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.md}"
+    padding: 8px 12px
+  pricing-tab-default:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink-subtle}"
+    typography: "{typography.button}"
+    rounded: "{rounded.pill}"
+    padding: 6px 14px
+  pricing-tab-selected:
+    backgroundColor: "{colors.surface-2}"
+    textColor: "{colors.ink}"
+    typography: "{typography.button}"
+    rounded: "{rounded.pill}"
+    padding: 6px 14px
+  cta-banner:
+    backgroundColor: "{colors.surface-1}"
+    textColor: "{colors.ink}"
+    typography: "{typography.headline}"
+    rounded: "{rounded.lg}"
+    padding: 48px
+  changelog-row:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.xs}"
+    padding: 24px 0
+  status-badge:
+    backgroundColor: "{colors.surface-2}"
+    textColor: "{colors.ink-muted}"
+    typography: "{typography.caption}"
+    rounded: "{rounded.pill}"
+    padding: 2px 8px
+  top-nav:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.xs}"
+    height: 56px
+  footer:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink-subtle}"
+    typography: "{typography.caption}"
+    rounded: "{rounded.xs}"
+    padding: 64px 32px
+---
+
+## Overview
+
+Linear's marketing canvas is the deepest dark surface in this collection — `{colors.canvas}` is #010102, essentially pure black with a faint blue tint. On top sits a four-step surface ladder (`{colors.surface-1}` through `{colors.surface-4}`) for cards, panels, and lifted tiles, with hairline borders running from `{colors.hairline}` (#23252a) up through `{colors.hairline-strong}` and `{colors.hairline-tertiary}`. Light gray text (`{colors.ink}` #f7f8f8) carries the body and headlines.
+
+The single chromatic accent is **Linear lavender-blue** `{colors.primary}` (#5e6ad2) — used on the brand mark, focus rings, and the primary CTA button. A lighter hover state (`{colors.primary-hover}` #828fff) and a focus-tinted variant (`{colors.primary-focus}` #5e69d1) extend the same hue. Linear avoids saturated greens, oranges, reds, etc. on the marketing canvas — the only semantic color is `{colors.semantic-success}` (#27a644) for status pills and the rare success indicator.
+
+Display type runs Linear's custom sans (with `SF Pro Display` fallback) at weight 500–700 with negative letter-spacing scaling from -3.0px at 80px down to 0 at body. The body family is Linear's text cut, and a Linear Mono is reserved for code snippets in product screenshots.
+
+The page rhythm is **dense product screenshots** — Linear's marketing leads with high-fidelity captures of the product UI (issue list, project view, dashboard) framed in `{colors.surface-1}` panels with `{rounded.xl}` 16px corners. The chrome is intentionally minimal so the app screenshots can do the heavy lifting.
+
+**Key Characteristics:**
+- **Dark-canvas marketing system** — `{colors.canvas}` (#010102) is the deepest dark in this collection.
+- **Lavender-blue brand accent** (`{colors.primary}` #5e6ad2) — used scarcely on brand mark, focus, and the primary CTA.
+- Four-step surface ladder (canvas → surface-1 → surface-2 → surface-3 → surface-4) carries hierarchy without shadow.
+- Display tracking pulls aggressively negative (-3.0px at 80px); body holds at -0.05px.
+- Cards use `{rounded.lg}` 12px corners with 1px hairline borders — never pill, rarely 16px.
+- **Product UI screenshots** dominate the page. The marketing chrome is a dark frame for the app.
+- No second chromatic color. No atmospheric gradients. No spotlight cards.
+
+## Colors
+
+> Source pages: linear.app (home), /intake, /pricing, /contact/sales, /build.
+
+### Brand & Accent
+- **Lavender-Blue** ({colors.primary}): The signature Linear accent — primary CTA, brand mark, link emphasis.
+- **Lavender Hover** ({colors.primary-hover}): Lighter lavender (#828fff) — hovered state of the primary CTA.
+- **Lavender Focus** ({colors.primary-focus}): Focus-ring tint (#5e69d1) — focused inputs, focused buttons.
+- **Brand Secure** ({colors.brand-secure}): Muted lavender-gray (#7a7fad) — used in "Linear Security" surfaces.
+
+### Surface
+- **Canvas** ({colors.canvas}): Default page background — #010102, near-pure black with a faint blue tint.
+- **Surface 1** ({colors.surface-1}): One step above canvas — feature cards, pricing cards, product screenshot panels.
+- **Surface 2** ({colors.surface-2}): Two steps above — featured pricing card, hovered cards.
+- **Surface 3** ({colors.surface-3}): Three steps above — line-tertiary backgrounds, sub-nav.
+- **Surface 4** ({colors.surface-4}): Four steps above — bg-level-3, deepest lifted surface.
+- **Hairline** ({colors.hairline}): 1px borders on cards and dividers.
+- **Hairline Strong** ({colors.hairline-strong}): Stronger 1px borders — input focus rings.
+- **Hairline Tertiary** ({colors.hairline-tertiary}): Tertiary borders for nested surfaces.
+- **Inverse Canvas** ({colors.inverse-canvas}): Pure white — surface of the inverse pill CTA on a small set of section openers.
+- **Inverse Surface 1** ({colors.inverse-surface-1}): One step above inverse canvas.
+- **Inverse Surface 2** ({colors.inverse-surface-2}): Two steps above inverse canvas.
+
+### Text
+- **Ink** ({colors.ink}): All headlines and emphasized body type — light gray #f7f8f8.
+- **Ink Muted** ({colors.ink-muted}): Secondary type at #d0d6e0 — meta info on hero panels.
+- **Ink Subtle** ({colors.ink-subtle}): Tertiary type at #8a8f98 — deselected pricing tabs, footer columns.
+- **Ink Tertiary** ({colors.ink-tertiary}): Quaternary at #62666d — disabled, footnotes.
+
+### Semantic
+- **Success Green** ({colors.semantic-success}): Status pills, success indicators. The only semantic color on marketing.
+- **Overlay** ({colors.semantic-overlay}): Pure black overlay scrim for modals.
+
+## Typography
+
+### Font Family
+
+- **Linear Display** — Linear's custom display sans; fallback `SF Pro Display, -apple-system, system-ui, Segoe UI, Roboto`. Carries display-xl through subhead.
+- **Linear Text** — Linear's custom text sans (a slightly different cut tuned for body sizes); same fallback stack. Carries body sizes, button labels, captions.
+- **Linear Mono** — Linear's custom mono; fallback `ui-monospace, SF Mono, Menlo`. Used for code snippets in product screenshots and for status / ID tokens.
+
+The marketing surface treats Display and Text as one continuous voice; the family change is silent.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.display-xl}` | 80px | 600 | 1.05 | -3.0px | Largest hero headline |
+| `{typography.display-lg}` | 56px | 600 | 1.10 | -1.8px | Section opener headlines |
+| `{typography.display-md}` | 40px | 600 | 1.15 | -1.0px | Sub-section headlines |
+| `{typography.headline}` | 28px | 600 | 1.20 | -0.6px | Pricing tier titles, CTA banner heading |
+| `{typography.card-title}` | 22px | 500 | 1.25 | -0.4px | Feature card title |
+| `{typography.subhead}` | 20px | 400 | 1.40 | -0.2px | Lead body, intro paragraphs |
+| `{typography.body-lg}` | 18px | 400 | 1.50 | -0.1px | Hero subhead, lead paragraphs |
+| `{typography.body}` | 16px | 400 | 1.50 | -0.05px | Default body |
+| `{typography.body-sm}` | 14px | 400 | 1.50 | 0 | Card body, footer columns |
+| `{typography.caption}` | 12px | 400 | 1.40 | 0 | Captions, meta, status |
+| `{typography.button}` | 14px | 500 | 1.20 | 0 | All button labels |
+| `{typography.eyebrow}` | 13px | 500 | 1.30 | 0.4px | Section eyebrow (slight positive tracking) |
+| `{typography.mono}` | 13px | 400 | 1.50 | 0 | Linear Mono for code in product screenshots |
+
+### Principles
+
+- **Aggressive negative tracking on display** (-3.0px at 80px ≈ 4% of size).
+- **Single voice from display to body.** Display-xl at 600 → body at 400 — same family, narrower weights.
+- **Eyebrow uses positive tracking** (+0.4px) — contrast against the negative-tracked display marks the eyebrow as taxonomy.
+- **Mono only in code contexts.** Linear Mono lives inside product screenshots — not on marketing chrome.
+
+### Note on Font Substitutes
+
+Linear's custom typeface isn't publicly distributed; the documented fallback `SF Pro Display, -apple-system, system-ui` is the recommended substitute on macOS. For cross-platform implementation, **Inter** at weight 500 / 600 / 700 is the closest free substitute. **Geist Sans** is also viable. For mono, **JetBrains Mono** or **Geist Mono** at weight 400 closely approximates Linear Mono.
+
+## Layout
+
+### Spacing System
+
+- **Base unit**: 4px.
+- **Tokens (front matter)**: `{spacing.xxs}` 4px · `{spacing.xs}` 8px · `{spacing.sm}` 12px · `{spacing.md}` 16px · `{spacing.lg}` 24px · `{spacing.xl}` 32px · `{spacing.xxl}` 48px · `{spacing.section}` 96px.
+- Card interior padding: `{spacing.lg}` 24px on feature/pricing cards; `{spacing.xl}` 32px on testimonial cards; `{spacing.xxl}` 48px on CTA banners.
+- Pill button padding: 8px vertical · 14px horizontal — Linear's compact button spec.
+- Form input padding: 8px vertical · 12px horizontal.
+
+### Grid & Container
+
+- Max content width sits around 1280px.
+- Card grids are 3-up at desktop, 2-up at tablet, 1-up at mobile.
+- Pricing tier grid is 3-up; comparison strip below shows checkmarks per tier.
+- Product screenshot panels span full content width — they're the protagonist.
+
+### Whitespace Philosophy
+
+The dark canvas IS the whitespace. Sections separate by lift onto surface-1 panels, not by gaps in white. Within a panel, generous `{spacing.lg}` 24px gaps between content blocks; `{spacing.section}` 96px between sections.
+
+## Elevation & Depth
+
+| Level | Treatment | Use |
+|---|---|---|
+| 0 (flat) | No shadow, no border | Default for body type, hero text, footer |
+| 1 (charcoal lift) | `{colors.surface-1}` background on canvas, 1px `{colors.hairline}` | Default cards, product panels |
+| 2 (surface-2 lift) | `{colors.surface-2}` background, 1px `{colors.hairline-strong}` | Featured pricing card, hovered cards |
+| 3 (surface-3 lift) | `{colors.surface-3}` background | Sub-nav, dropdown menus |
+| 4 (focus ring) | 2px `{colors.primary-focus}` outline at 50% opacity | Focused input, focused button |
+
+Linear's depth is carried by surface ladder + hairline borders. The brand resists drop shadows on dark almost entirely.
+
+### Decorative Depth
+
+- **Product UI screenshots** dominate as decorative depth.
+- **No atmospheric gradients, no spotlight cards.**
+- **Subtle white edge highlight** on the top edge of lifted panels — gives the dark surface a faint "pixel rendered" feel.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.xs}` | 4px | Small chips, status badges |
+| `{rounded.sm}` | 6px | Inline tags |
+| `{rounded.md}` | 8px | All buttons, form inputs |
+| `{rounded.lg}` | 12px | Pricing cards, feature cards, testimonial cards |
+| `{rounded.xl}` | 16px | Product screenshot panels |
+| `{rounded.xxl}` | 24px | Oversized CTA banners (rare) |
+| `{rounded.pill}` | 9999px | Pricing tab toggles, status pills |
+| `{rounded.full}` | 9999px | Avatar circles |
+
+### Photography & Illustration Geometry
+
+- Product UI screenshots dominate; they sit in `{rounded.xl}` 16px tiles with `{spacing.lg}` 24px outer padding.
+- Customer logo tiles render at small sizes (~24px logo height) on `{colors.canvas}` with no border.
+- Avatar circles in testimonial cards use `{rounded.full}` at 32–40px sizes.
+
+## Components
+
+### Buttons
+
+**`button-primary`** — Lavender CTA. The default primary CTA across all pages.
+- Background `{colors.primary}`, text `{colors.on-primary}`, type `{typography.button}`, padding 8px 14px, rounded `{rounded.md}`.
+- Pressed state lives in `button-primary-pressed` (background shifts to `{colors.primary-focus}`).
+- Hover state lives in `button-primary-hover` (background shifts to `{colors.primary-hover}` lighter lavender).
+
+**`button-secondary`** — Charcoal button. Used for secondary CTAs ("Sign in", "Read changelog").
+- Background `{colors.surface-1}`, text `{colors.ink}`, type `{typography.button}`, padding 8px 14px, rounded `{rounded.md}`. 1px `{colors.hairline}` border.
+
+**`button-tertiary`** — Plain text button.
+- Background `{colors.canvas}`, text `{colors.ink}`, type `{typography.button}`, rounded `{rounded.md}`, padding 8px 14px.
+
+**`button-inverse`** — White-on-dark inverse CTA.
+- Background `{colors.inverse-canvas}`, text `{colors.inverse-ink}`, type `{typography.button}`, rounded `{rounded.md}`, padding 8px 14px.
+
+### Pricing Tabs
+
+**`pricing-tab-default`** + **`pricing-tab-selected`** — Pill-toggle on `/pricing`.
+- Default: `{colors.canvas}` background, `{colors.ink-subtle}` text, rounded `{rounded.pill}`, padding 6px 14px.
+- Selected: `{colors.surface-2}` background, `{colors.ink}` text — selected = surface lift.
+
+### Cards & Containers
+
+**`pricing-card`** — Each tier on `/pricing`.
+- Background `{colors.surface-1}`, text `{colors.ink}`, type `{typography.body}`, rounded `{rounded.lg}`, padding 24px. 1px `{colors.hairline}` border.
+
+**`pricing-card-featured`** — Recommended tier — surface lift to surface-2.
+- Background `{colors.surface-2}`, otherwise identical structure.
+
+**`feature-card`** — Generic feature highlight tile.
+- Background `{colors.surface-1}`, text `{colors.ink}`, type `{typography.body}`, rounded `{rounded.lg}`, padding 24px.
+
+**`product-screenshot-card`** — The dominant card type — frames a high-fidelity Linear app UI screenshot.
+- Background `{colors.surface-1}`, text `{colors.ink}`, type `{typography.body}`, rounded `{rounded.xl}`, padding 24px.
+
+**`testimonial-card`** — Customer quote with avatar + name + role.
+- Background `{colors.surface-1}`, text `{colors.ink}`, type `{typography.body-lg}`, rounded `{rounded.lg}`, padding 32px.
+
+**`customer-logo-tile`** — Small tile in the customer marquee.
+- Background `{colors.canvas}`, text `{colors.ink-subtle}`, type `{typography.caption}`, rounded `{rounded.xs}`, padding 16px.
+
+**`cta-banner`** — Closing CTA panel near page bottom.
+- Background `{colors.surface-1}`, text `{colors.ink}`, type `{typography.headline}`, rounded `{rounded.lg}`, padding 48px.
+
+### Inputs & Forms
+
+**`text-input`** + **`text-input-focused`** — Form fields on `/contact/sales` and signup overlays.
+- Background `{colors.surface-1}`, text `{colors.ink}`, type `{typography.body}`, rounded `{rounded.md}`, padding 8px 12px.
+- Focused state retains the same surface; the focus ring is a 2px `{colors.primary-focus}` outline at 50% opacity.
+
+### Status & Build Page
+
+**`changelog-row`** — Each row in `/build` (changelog page) listing version, date, and changes.
+- Background `{colors.canvas}`, text `{colors.ink}`, type `{typography.body}`, rounded `{rounded.xs}`, padding 24px 0. 1px `{colors.hairline}` bottom rule.
+
+**`status-badge`** — Small status pill.
+- Background `{colors.surface-2}`, text `{colors.ink-muted}`, type `{typography.caption}`, rounded `{rounded.pill}`, padding 2px 8px.
+
+### Navigation
+
+**`top-nav`** — Sticky dark bar with the Linear wordmark left, primary nav links centered, and a `button-secondary` ("Sign in") + `button-primary` ("Get started") pair right.
+- Background `{colors.canvas}`, text `{colors.ink}`, type `{typography.body-sm}`, height 56px.
+
+### Footer
+
+**`footer`** — Dense link grid on `{colors.canvas}` with the Linear wordmark left.
+- Background `{colors.canvas}`, text `{colors.ink-subtle}`, type `{typography.caption}`, padding 64px 32px.
+
+## Do's and Don'ts
+
+### Do
+
+- Reserve `{colors.canvas}` (#010102) as the system's anchor surface — the faint blue tint is intentional.
+- Use `{colors.primary}` lavender ONLY for: brand mark, primary CTA, focus ring, link emphasis.
+- Use the four-step surface ladder for hierarchy. Avoid skipping levels.
+- Pair display weight 600 with body weight 400 — Linear resists 700+ display weights.
+- Apply negative letter-spacing aggressively on display.
+- Use product UI screenshots as the protagonist of every section.
+- Compose CTAs as `{rounded.md}` 8px corners.
+
+### Don't
+
+- Don't ship a light-mode marketing page.
+- Don't use lavender as a section background or card fill.
+- Don't introduce a second chromatic accent (orange, pink, green for marketing).
+- Don't add atmospheric gradients or spotlight cards.
+- Don't pill-round CTAs.
+- Don't use `#000000` true black as the canvas.
+- Don't combine multiple bright accents in product screenshot mockups.
+
+## Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| Desktop-XL | 1440px | Default desktop layout |
+| Desktop | 1280px | Card grid 3-up maintained |
+| Tablet | 1024px | Card grid 3-up → 2-up |
+| Mobile-Lg | 768px | Pricing comparison becomes accordion; nav hamburger |
+| Mobile | 480px | Single-column; display-xl scales 80px → ~36px |
+
+### Touch Targets
+
+- CTAs hold ≥40px tap height across viewports.
+- Pricing tab pills hold ≥36px tap height; touch viewports grow to ≥44px.
+- Form inputs hold ≥44px tap target on touch.
+
+### Collapsing Strategy
+
+- **Top nav**: links collapse to hamburger below 768px.
+- **Card grids**: 3-up → 2-up at 1024px → 1-up below 768px.
+- **Pricing comparison**: per-tier accordion below 768px.
+- **Display type**: `{typography.display-xl}` 80px scales toward `{typography.display-md}` 40px on mobile.
+
+### Image Behavior
+
+- Product UI screenshots maintain aspect ratio and never crop.
+- Customer logos in the marquee may collapse from 6-up to 3-up below 768px.
+
+## Iteration Guide
+
+1. Focus on ONE component at a time and reference it by its `components:` token name.
+2. When introducing a section, decide first which surface lift it lives on.
+3. Default body to `{typography.body}` at weight 400.
+4. Run `npx @google/design.md lint DESIGN.md` after edits.
+5. Add new variants as separate component entries.
+6. Treat lavender as scarce: brand mark, primary CTA, focus, link emphasis.
+7. Lead every section with a product UI screenshot.
+
+## Known Gaps
+
+- The four-step surface ladder values are extracted directly from Linear's `--color-bg-level-3`, `--color-line-tint`, etc. CSS variables; they are Linear's canonical surface spec.
+- Form-field error and validation styling is not visible on the inspected pages.
+- Light mode is not documented because the marketing site does not ship a light theme.
+- Linear's actual product UI uses a richer color-tag palette (red, orange, yellow, green, blue, purple) for issue priorities and project labels — those colors live in the in-product surfaces shown in mockups.
+- The custom display, text, and mono families are proprietary; an open-source substitute is acceptable.

--- a/apps/canvas-workspace/AGENTS.md
+++ b/apps/canvas-workspace/AGENTS.md
@@ -1,7 +1,29 @@
-# CLAUDE.md
+# AGENTS.md - apps/canvas-workspace
 
-This file provides guidance to Claude Code (claude.ai/code) when working in
-`apps/canvas-workspace`. It complements the repo-root `CLAUDE.md`.
+> Local entry for `apps/canvas-workspace`.
+> Repository harness entry: `../../harness/README.md`.
+> Claude Code specific guidance lives in `CLAUDE.md`.
+
+## How To Use This File
+
+This file is the tool-agnostic local entry. It intentionally stays light and routes to the existing, more detailed local guidance.
+
+| Task | Read |
+|---|---|
+| Claude Code guidance and app overview | `CLAUDE.md` |
+| Runtime harness commands | `harness/README.md` |
+| Main/renderer conventions | `docs/conventions/README.md` |
+| Main process boundaries | `docs/conventions/architecture-boundaries.md` |
+| Renderer conventions | `docs/conventions/frontend.md` |
+| Main process conventions | `docs/conventions/backend.md` |
+| Repository harness map | `../../harness/profile.yaml` |
+
+## Local Constraints
+
+- Renderer reaches the main process only through `window.canvasWorkspace` exposed by preload.
+- Domain logic lives in `src/main/<domain>/`; renderer code should not reach into Electron/Node APIs directly.
+- For interaction-heavy changes, consider the app runtime harness in `harness/README.md`.
+- Keep this file as a router. Do not duplicate the detailed guidance already in `CLAUDE.md` or `docs/conventions/`.
 
 ## Overview
 

--- a/apps/remote-server/AGENTS.md
+++ b/apps/remote-server/AGENTS.md
@@ -1,49 +1,46 @@
-# Repository Guidelines
+# AGENTS.md - apps/remote-server
 
-## Project Structure & Module Organization
-This is a `pnpm` monorepo with workspaces under `packages/*` and `apps/*`. Source code lives in each workspace’s `src/` directory and build output is emitted to `dist/`. Key areas:
-- `packages/engine`: core agent engine, built-in tools, plugin loading, runtime loop.
-- `packages/cli`: interactive terminal CLI built on `pulse-coder-engine`.
-- `packages/pulse-sandbox`: sandboxed JS execution runtime and `run_js` tool adapter.
-- `packages/memory-plugin`: memory integration/service package.
-- `apps/remote-server`: optional HTTP service wrapper around the engine.
-- `apps/coder-demo`: legacy experimental app.
+> Local entry for `apps/remote-server`.
+> Repository harness entry: `../../harness/README.md`.
+> Claude Code specific local guidance also exists in `CLAUDE.md`.
 
-## Build, Test, and Development Commands
-- `pnpm install`: install all workspace dependencies.
-- `pnpm run build`: build all workspaces recursively.
-- `pnpm run dev`: watch mode for packages.
-- `pnpm start`: run the CLI (`pulse-coder-cli`).
-- `pnpm test`: run package tests (`packages/*`).
-- `pnpm run test:apps`: run app tests (`apps/*`). Note: `apps/coder-demo` has a placeholder test script and may fail.
-- `pnpm --filter @pulse-coder/remote-server dev`: run the remote server in dev mode.
-- `pnpm --filter @pulse-coder/remote-server build`: build only the remote server.
-- `pnpm --filter pulse-coder-engine typecheck`: strict TS typecheck for the engine.
+## Module Positioning
 
-Useful package targets:
-- `pnpm --filter pulse-coder-engine test`
-- `pnpm --filter pulse-coder-cli test`
-- `pnpm --filter pulse-sandbox test`
-- `pnpm --filter pulse-coder-memory-plugin test`
+`@pulse-coder/remote-server` hosts the engine behind HTTP/webhook integrations. It owns webhook dispatch, platform adapters, internal automation routes, engine singleton wiring, session persistence, memory integration, and runtime operational concerns.
 
-## Coding Style & Naming Conventions
-Use TypeScript in strict mode. Prefer 2-space indentation, semicolons, and single quotes. Naming: `PascalCase` for classes/types, `camelCase` for functions/vars, `kebab-case` for multi-word filenames, and `UPPER_SNAKE_CASE` for exported constants. No repo-wide formatter is enforced, so keep diffs minimal and follow nearby patterns.
+## Knowledge Navigation
 
-## Remote Server Notes (`apps/remote-server`)
-- Entry point: `apps/remote-server/src/index.ts` bootstraps session store, memory integration, worktree binding, and engine.
-- HTTP server: `apps/remote-server/src/server.ts` mounts `/health`, webhook routes, and `/internal/*` routes.
-- Dispatcher: `apps/remote-server/src/core/dispatcher.ts` owns signature verification, fast ack, command parsing, and streaming.
-- Sessions: stored in `~/.pulse-coder/remote-sessions` with `index.json` + `sessions/*.json`.
-- Memory logs: stored in `~/.pulse-coder/remote-memory` via `pulse-coder-memory-plugin`.
-- Worktree binding: stored in `~/.pulse-coder/worktree-state` via `pulse-coder-plugin-kit`.
-- Internal API: `/internal/agent/run` is loopback-only and requires `INTERNAL_API_SECRET`.
-- Platform adapters: Feishu and Discord are mounted; Telegram/Web adapters exist but are not enabled by default.
+| Task | Read |
+|---|---|
+| Local Claude guidance | `CLAUDE.md` |
+| Operations and smoke testing | `docs/runbook.md` |
+| Pick validation | `docs/validation.md` |
+| Bootstrap/server | `src/index.ts`, `src/server.ts` |
+| Webhook dispatch | `src/core/dispatcher.ts` |
+| Agent execution | `src/core/agent-runner.ts` |
+| Internal API | `src/routes/internal.ts` |
+| Custom tools | `src/core/engine-singleton.ts` |
 
-## Testing Guidelines
-Vitest is the primary test runner. Name tests `*.test.ts` or `*.spec.ts` and keep them near the related source. Add tests for changes to loop control, plugin hooks, CLI workflows, and memory integration boundaries.
+## Local Constraints
 
-## Commit & Pull Request Guidelines
-Use Conventional Commits (scope optional), e.g. `feat(engine): add plugin hook` or `fix(cli): handle empty input`. PRs should include a clear summary, affected packages, linked issue (if any), and test evidence (commands + results). Provide screenshots for CLI UX changes when relevant.
+- Keep route handlers thin; delegate to dispatcher, runner, or adapter modules.
+- Do not bypass platform signature verification or the active-run concurrency guard.
+- Internal routes must remain loopback-only and bearer-token protected.
+- Stream output through adapter `StreamHandle` callbacks; adapters own platform send behavior.
+- Runtime or API contract changes should update `docs/runbook.md` or validation guidance when needed.
 
-## Security & Configuration Tips
-Store secrets in local `.env` files only (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `TAVILY_API_KEY`, `GEMINI_API_KEY`). Do not commit local session or memory data under `.pulse-coder/*`. The internal API route `/internal/agent/run` is loopback-only and requires `INTERNAL_API_SECRET`.
+## Common Commands
+
+```bash
+pnpm --filter @pulse-coder/remote-server dev
+pnpm --filter @pulse-coder/remote-server build
+pnpm --filter @pulse-coder/remote-server start
+```
+
+## Key Files
+
+- `src/index.ts`: bootstrap stores, memory, worktree binding, engine, gateway, and server.
+- `src/server.ts`: Hono server and route mounting.
+- `src/core/dispatcher.ts`: webhook ack, slash commands, concurrency, streaming dispatch.
+- `src/core/agent-runner.ts`: run context, engine execution, session and memory persistence.
+- `src/routes/internal.ts`: internal automation routes.

--- a/apps/remote-server/docs/runbook.md
+++ b/apps/remote-server/docs/runbook.md
@@ -1,0 +1,71 @@
+# Remote Server Runbook
+
+## Scope
+
+This runbook covers local operation and smoke testing for `apps/remote-server`. For architecture details, start with `AGENTS.md` and `CLAUDE.md`.
+
+## Start Locally
+
+From the repository root:
+
+```bash
+pnpm --filter @pulse-coder/remote-server dev
+```
+
+Build and run compiled output:
+
+```bash
+pnpm --filter @pulse-coder/remote-server build
+pnpm --filter @pulse-coder/remote-server start
+```
+
+## Required Configuration
+
+Use local `.env` files for secrets. Do not commit secrets.
+
+Minimum runtime configuration depends on the platform being exercised:
+
+- LLM provider key/model (`OPENAI_*` or `ANTHROPIC_*`).
+- Platform credentials for Feishu or Discord when testing webhooks.
+- `INTERNAL_API_SECRET` for `/internal/*` automation routes.
+
+Model overrides are read from `.pulse-coder/config.json` or `$PULSE_CODER_MODEL_CONFIG`; this is runtime config, not repository harness source of truth.
+
+## Smoke Checks
+
+### Health
+
+```bash
+curl http://127.0.0.1:<port>/health
+```
+
+### Internal Agent Run
+
+Use only from loopback with bearer token:
+
+```bash
+curl -X POST http://127.0.0.1:<port>/internal/agent/run \
+  -H "Authorization: Bearer $INTERNAL_API_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"message":"hello"}'
+```
+
+Adjust payload to match `src/routes/internal.ts`.
+
+## Operational Boundaries
+
+- `/internal/*` routes must require loopback IP and bearer token.
+- Platform webhooks should ack quickly before long-running agent work.
+- Per-platform concurrency guard should remain active.
+- Session, memory, and worktree state are stored under user-level `~/.pulse-coder/*` directories.
+- Adapter `StreamHandle` callbacks own platform-specific output behavior.
+
+## Evidence To Capture
+
+For runtime changes, include:
+
+- command used to start the server
+- endpoint or webhook path tested
+- response status/body summary
+- relevant log excerpt if failure occurs
+- skipped platform checks and why

--- a/apps/remote-server/docs/validation.md
+++ b/apps/remote-server/docs/validation.md
@@ -1,0 +1,38 @@
+# Remote Server Validation
+
+Run commands from the repository root.
+
+## Default Check
+
+```bash
+pnpm --filter @pulse-coder/remote-server build
+```
+
+The build runs package prebuild dependencies and compiles the server with `tsup`.
+
+## Runtime Smoke
+
+When routes, dispatcher, agent runner, adapter streaming, or internal automation behavior changes, run a local smoke if credentials and environment are available:
+
+```bash
+pnpm --filter @pulse-coder/remote-server dev
+curl http://127.0.0.1:<port>/health
+```
+
+For internal automation changes, also test `/internal/agent/run` with loopback and `INTERNAL_API_SECRET`; see `docs/runbook.md`.
+
+## Escalation
+
+If engine integration, model config, memory integration, or worktree binding changes, include affected package checks when practical:
+
+```bash
+pnpm --filter pulse-coder-engine test
+pnpm --filter pulse-coder-memory-plugin test
+pnpm --filter pulse-coder-plugin-kit test
+```
+
+If platform adapter behavior changes, include manual platform evidence or explicitly state why it was not run.
+
+## Docs-only Changes
+
+If only `AGENTS.md`, `CLAUDE.md`, `docs/runbook.md`, or `docs/validation.md` changed, no build is required. Check referenced paths and commands instead.

--- a/apps/teams-cli/AGENTS.md
+++ b/apps/teams-cli/AGENTS.md
@@ -1,0 +1,43 @@
+# AGENTS.md - apps/teams-cli
+
+> Local entry for `apps/teams-cli`.
+> Repository harness entry: `../../harness/README.md`.
+
+## Module Positioning
+
+`@pulse-coder/teams-cli` is the CLI host for `pulse-coder-agent-teams`. It exposes team workflows for previewing, planning, and running multi-agent coordination from the terminal.
+
+Team protocol behavior belongs in `packages/agent-teams`; this app should stay focused on CLI entrypoints, command modes, display, and host wiring.
+
+## Knowledge Navigation
+
+| Task | Read |
+|---|---|
+| CLI entrypoint | `src/index.ts` |
+| In-process display | `src/display/in-process.ts` |
+| Package scripts | `package.json` |
+| Team runtime contracts | `../../packages/agent-teams/AGENTS.md` |
+| Agent teams roadmap | `../../docs/07-agent-teams-maturity-roadmap.md` |
+
+## Local Constraints
+
+- Do not duplicate team runtime policy that belongs in `packages/agent-teams`.
+- Keep command output and display behavior separate from team state transitions.
+- Preview modes should remain safe for local experimentation.
+
+## Common Commands
+
+```bash
+pnpm --filter @pulse-coder/teams-cli test
+pnpm --filter @pulse-coder/teams-cli typecheck
+pnpm --filter @pulse-coder/teams-cli build
+pnpm preview:teams
+pnpm preview:teams:run
+pnpm preview:teams:plan
+```
+
+## Key Files
+
+- `src/index.ts`: CLI entrypoint and command modes.
+- `src/display/in-process.ts`: in-process display implementation.
+- `package.json`: bin, scripts, and dependencies.

--- a/harness/README.md
+++ b/harness/README.md
@@ -1,0 +1,70 @@
+# Repository Harness
+
+This directory is the source of truth for the repository-level harness pilot. It is separate from `.pulse-coder/`, which remains product/runtime configuration and test data for Pulse Coder itself.
+
+The harness has four main loops:
+
+```text
+knowledge -> action -> validation -> feedback
+```
+
+`tools` are shared atomic capabilities that can be used by any loop.
+
+## Reading Path
+
+Use progressive disclosure. Do not read the whole repository by default.
+
+```text
+AGENTS.md / CLAUDE.md
+-> harness/README.md
+-> harness/profile.yaml
+-> affected workspace entry
+-> workspace contracts/spec/runbook/validation as needed
+```
+
+## Areas
+
+| Area | Path | Purpose |
+|---|---|---|
+| Repository map | `profile.yaml` | Machine-readable workspace routing table. |
+| Validation matrix | `validation.yaml` | Machine-readable validation matrix and escalation rules. |
+| Action protocols | `skills/` | Tool-agnostic agent skills for recurring work. |
+| Atomic tools | `tools/` | Reusable small capabilities used by skills, checks, reports, or humans. |
+| Feedback flow | `feedback/` | Admission, routing, proposals, and temporary inbox. |
+| Checks | `checks/` | Future mechanical gates to prevent drift. |
+| Templates | `templates/` | Starting points for new local entries and proposals. |
+
+## Knowledge Routing
+
+Keep source-of-truth routing lightweight and human-readable. Do not maintain a separate YAML rule table for this during the pilot.
+
+| Knowledge | Default target |
+|---|---|
+| Repository navigation | `AGENTS.md` |
+| Claude Code specifics | `CLAUDE.md` |
+| Workspace routing | `harness/profile.yaml` |
+| Validation matrix | `harness/validation.yaml` and workspace `docs/validation.md` |
+| Package contract | Workspace `AGENTS.md`, `README.md`, `docs/contracts.md`, types, and tests as needed |
+| App behavior | Workspace `AGENTS.md` or `CLAUDE.md`; add `docs/spec/` only when behavior needs durable product-level SSOT |
+| Runtime operation | Workspace `docs/runbook.md` or local entry file |
+| Agent action protocol | `harness/skills/*.md` |
+| Atomic tool protocol | `harness/tools/*/README.md` |
+| Feedback proposal | `harness/feedback/`, then route accepted facts to the real target |
+
+## Principles
+
+- Root entry files route; they do not duplicate workspace knowledge.
+- `profile.yaml` maps workspaces; `validation.yaml` maps checks. Keep other routing in Markdown until it proves stable enough to mechanize.
+- Workspace facts live near the workspace.
+- Feedback is not the final knowledge store. Route accepted feedback back to the right long-term target.
+- Add mechanical checks only after a rule proves stable enough to enforce.
+- Package-local harness directories are optional extension points, not required boilerplate.
+
+## First Pilot Workspaces
+
+This pilot starts with representative workspaces:
+
+- `packages/engine`: core runtime package, contract-heavy.
+- `packages/agent-teams`: coordination runtime, quality/autonomy-heavy.
+- `apps/remote-server`: operational HTTP runtime.
+- `apps/canvas-workspace`: existing app guidance and runtime harness are referenced instead of duplicated.

--- a/harness/checks/README.md
+++ b/harness/checks/README.md
@@ -1,0 +1,15 @@
+# Harness Checks
+
+This directory is reserved for future mechanical checks that keep the repository harness from drifting.
+
+No checks are enforced in the first pilot.
+
+Candidate checks:
+
+- `profile-coverage`: every `harness/profile.yaml` workspace path exists.
+- `agents-coverage`: pilot workspaces have an entry file.
+- `routing-links`: paths in `harness/README.md` and workspace entries exist or are marked as deferred.
+- `skill-frontmatter`: `harness/skills/*.md` has `name` and `description` frontmatter.
+- `validation-matrix`: commands in `harness/validation.yaml` reference known package names.
+
+When a check becomes executable, keep the protocol here and place implementation in `scripts/harness/` unless there is a strong reason to colocate code.

--- a/harness/feedback/README.md
+++ b/harness/feedback/README.md
@@ -1,0 +1,22 @@
+# Feedback
+
+Feedback is an entry point and routing flow, not a permanent knowledge base.
+
+Use `harness/skills/feedback-governance.md` to decide whether feedback should become repository knowledge or a mechanism.
+
+## What Belongs Here
+
+- `inbox.md`: under-evidenced or unresolved feedback that still needs routing.
+- `proposals/`: structured proposal records for feedback governance work.
+
+## What Does Not Belong Here Long Term
+
+- Module facts: route to workspace contracts or app spec.
+- Delivery decisions: route to workspace history.
+- Validation rules: route to workspace validation docs or `harness/validation.yaml`.
+- Agent action rules: route to `harness/skills`.
+- Stable enforceable checks: route to `harness/checks`, tests, scripts, hook, or CI.
+
+## Required Proposal Shape
+
+Use `harness/templates/feedback-proposal.md`.

--- a/harness/feedback/inbox.md
+++ b/harness/feedback/inbox.md
@@ -1,0 +1,16 @@
+# Feedback Inbox
+
+This inbox is for feedback that cannot yet be safely routed to a long-term source of truth.
+
+Each item must include:
+
+- Source:
+- Summary:
+- Evidence:
+- Suspected scope:
+- Suggested long-term target:
+- Missing evidence:
+- Admission level: A/B/C/D
+- Status:
+
+Do not keep accepted long-term rules here. Once routed, move the fact to its SSOT and keep only a proposal record if useful.

--- a/harness/profile.yaml
+++ b/harness/profile.yaml
@@ -1,0 +1,133 @@
+# Machine-readable repository map for the Coder harness pilot.
+# Keep this file structural. Put prose in AGENTS.md, workspace docs, or harness/*.md.
+# Validation commands belong in harness/validation.yaml or workspace docs/validation.md.
+
+version: 1
+sourceOfTruth: harness/profile.yaml
+runtimeConfigNote: ".pulse-coder/ is product/runtime configuration, not the source of truth for this repository harness pilot."
+profileScope:
+  mode: pilot
+  note: "The workspaces map lists curated high-touch entries, not every package directory. Unlisted pnpm workspaces use workspaceTypeDefaults plus package.json scripts."
+activeWorkspaceGlobs:
+  - packages/*
+  - apps/remote-server
+  - apps/teams-cli
+  - apps/canvas-workspace
+
+readingPath:
+  - AGENTS.md
+  - CLAUDE.md
+  - harness/README.md
+  - harness/profile.yaml
+  - affected workspace entry
+  - workspace contracts/spec/runbook/validation
+
+workspaces:
+  packages/engine:
+    type: package
+    packageName: pulse-coder-engine
+    role: core-runtime
+    entry: packages/engine/AGENTS.md
+    knowledge:
+      contracts: packages/engine/docs/contracts.md
+      validation: packages/engine/docs/validation.md
+      readme: packages/engine/README.md
+
+  packages/cli:
+    type: package
+    packageName: pulse-coder-cli
+    role: interactive-terminal-cli
+    entry: packages/cli/AGENTS.md
+    knowledge:
+      readme: packages/cli/README.md
+
+  packages/orchestrator:
+    type: package
+    packageName: pulse-coder-orchestrator
+    role: generic-multi-agent-orchestrator
+    entry: packages/orchestrator/AGENTS.md
+    knowledge:
+      readme: packages/orchestrator/README.md
+      roadmap: docs/05-orchestrator-plan.md
+
+  packages/agent-teams:
+    type: package
+    packageName: pulse-coder-agent-teams
+    role: agent-team-runtime
+    entry: packages/agent-teams/AGENTS.md
+    knowledge:
+      contracts: packages/agent-teams/docs/contracts.md
+      validation: packages/agent-teams/docs/validation.md
+      roadmap: docs/07-agent-teams-maturity-roadmap.md
+
+  packages/memory-plugin:
+    type: package
+    packageName: pulse-coder-memory-plugin
+    role: memory-service-integration
+    entry: packages/memory-plugin/AGENTS.md
+    knowledge:
+      readme: packages/memory-plugin/README.md
+      design: docs/memory-plugin/technical-design.md
+
+  packages/plugin-kit:
+    type: package
+    packageName: pulse-coder-plugin-kit
+    role: plugin-runtime-toolkit
+    entry: packages/plugin-kit/AGENTS.md
+    knowledge:
+      readme: packages/plugin-kit/README.md
+
+  packages/acp:
+    type: package
+    packageName: pulse-coder-acp
+    role: acp-client-runner
+    entry: packages/acp/AGENTS.md
+    knowledge:
+      readme: packages/acp/README.md
+
+  apps/remote-server:
+    type: app
+    packageName: "@pulse-coder/remote-server"
+    role: remote-http-runtime
+    entry: apps/remote-server/AGENTS.md
+    existingClaudeEntry: apps/remote-server/CLAUDE.md
+    knowledge:
+      runbook: apps/remote-server/docs/runbook.md
+      validation: apps/remote-server/docs/validation.md
+
+  apps/teams-cli:
+    type: app
+    packageName: "@pulse-coder/teams-cli"
+    role: agent-teams-cli-host
+    entry: apps/teams-cli/AGENTS.md
+    knowledge:
+      agentTeamsEntry: packages/agent-teams/AGENTS.md
+      roadmap: docs/07-agent-teams-maturity-roadmap.md
+
+  apps/canvas-workspace:
+    type: app
+    packageName: canvas-workspace
+    role: electron-canvas-workbench
+    entry: apps/canvas-workspace/AGENTS.md
+    existingClaudeEntry: apps/canvas-workspace/CLAUDE.md
+    knowledge:
+      conventions: apps/canvas-workspace/docs/conventions/README.md
+      runtimeHarness: apps/canvas-workspace/harness/README.md
+      harnessRoadmap: docs/06-harness-engineering-roadmap.md
+
+workspaceTypeDefaults:
+  package:
+    longTermKnowledge:
+      - AGENTS.md
+      - README.md
+      - docs/contracts.md
+      - docs/validation.md
+      - TypeScript types
+      - tests
+  app:
+    longTermKnowledge:
+      - AGENTS.md or CLAUDE.md
+      - docs/spec/ when product behavior needs a durable SSOT
+      - docs/history/ for delivery decisions
+      - docs/runbook.md
+      - docs/validation.md

--- a/harness/skills/README.md
+++ b/harness/skills/README.md
@@ -1,0 +1,23 @@
+# Harness Skills
+
+`harness/skills` is the source of truth for repository-level action protocols. These files are tool-agnostic; they are not runtime skills for `.pulse-coder` unless a future adapter explicitly references or generates them.
+
+Each skill should define:
+
+- trigger
+- boundary
+- required inputs
+- steps
+- output
+- validation
+- references
+
+## Current Skills
+
+| Skill | Use |
+|---|---|
+| `doc-governance.md` | Add or adjust repository/workspace documentation without creating duplicate facts. |
+| `feedback-governance.md` | Turn feedback into a proposal and route accepted facts to the right SSOT. |
+| `quality-workflow.md` | Pick validation depth and collect evidence for a change. |
+| `code-review.md` | Review diffs with repo-aware routing and validation expectations. |
+| `contract-coding.md` | Change package/runtime contracts without drifting from types, tests, and docs. |

--- a/harness/skills/code-review.md
+++ b/harness/skills/code-review.md
@@ -1,0 +1,38 @@
+---
+name: code-review
+description: Review changes with repository-aware context, affected workspace routing, and validation expectations.
+---
+
+# Code Review Skill
+
+## Trigger
+
+Use this when reviewing a diff, PR, MR, or local change set.
+
+## Boundary
+
+Review prioritizes correctness, regressions, security, contract drift, validation gaps, and maintainability risks. It does not apply fixes unless explicitly requested in a separate implementation task.
+
+## Steps
+
+1. Identify changed files and affected workspaces.
+2. Read root routing only as needed: `AGENTS.md`, `harness/profile.yaml`, `harness/validation.yaml`.
+3. Read the nearest workspace entry and contract/spec/runbook for changed areas.
+4. Review for:
+   - correctness and edge cases
+   - public contract drift
+   - plugin/tool/runtime boundary violations
+   - security and secret handling
+   - validation evidence gaps
+5. Keep findings specific and tied to files/lines.
+
+## Output
+
+- Must-fix findings first.
+- Suggestions second.
+- Validation gaps and residual risk.
+- No issue statement when no high-confidence bug is found.
+
+## Validation
+
+Recommended checks should match `harness/validation.yaml` and workspace `docs/validation.md`.

--- a/harness/skills/contract-coding.md
+++ b/harness/skills/contract-coding.md
@@ -1,0 +1,34 @@
+---
+name: contract-coding
+description: Make package or runtime contract changes while keeping docs, types, tests, and consumers aligned.
+---
+
+# Contract Coding Skill
+
+## Trigger
+
+Use this when changing exported APIs, tool schemas, plugin hooks, runtime protocols, internal route payloads, workspace contracts, or cross-package behavior.
+
+## Boundary
+
+This skill is for contract-level changes. Implementation-only bug fixes can proceed with normal code workflow if the existing contract remains true.
+
+## Steps
+
+1. Identify the producer workspace and affected consumer workspaces.
+2. Read producer `AGENTS.md` and `docs/contracts.md`.
+3. Check whether TypeScript types, tests, README, or runtime docs are the current SSOT.
+4. Update the contract source before or alongside implementation.
+5. Update tests and consumer usage when the contract changes.
+6. Apply `harness/validation.yaml` cross-package escalation rules.
+
+## Output
+
+- Contract changed or confirmed unchanged.
+- Producer and consumer impact.
+- Validation commands and results.
+- Any compatibility or migration note.
+
+## Validation
+
+Contract changes must run producer checks and affected consumer checks when practical.

--- a/harness/skills/doc-governance.md
+++ b/harness/skills/doc-governance.md
@@ -1,0 +1,41 @@
+---
+name: doc-governance
+description: Govern repository and workspace documentation so entries route to a single source of truth without duplicating rules.
+---
+
+# Doc Governance Skill
+
+## Trigger
+
+Use this when adding, renaming, moving, or restructuring `AGENTS.md`, `CLAUDE.md`, workspace docs, `harness/*`, or documentation indexes.
+
+## Boundary
+
+This skill governs documentation structure and routing. It does not implement code, CI, hooks, or runtime tools.
+
+## Required Inputs
+
+- The user goal or feedback that requires documentation changes.
+- Affected workspace or repository area.
+- Existing source of truth from `harness/README.md`, root entries, and the affected workspace entry.
+
+## Steps
+
+1. Read root `AGENTS.md` and `harness/README.md`.
+2. Use `harness/profile.yaml` to identify affected workspace entries.
+3. Use the `harness/README.md` knowledge routing table and affected workspace entry to choose one source of truth.
+4. Prefer updating an existing entry over creating a new one.
+5. Keep root entries as routers; put details in workspace docs or harness skill/tool files.
+6. If a rule is stable and enforceable, consider whether a future `harness/checks` item is more appropriate than more prose.
+
+## Output
+
+- Changed files and why each file is the correct SSOT.
+- Any intentionally deferred entry or check.
+- Verification performed.
+
+## Validation
+
+- Referenced paths exist or are explicitly marked deferred.
+- No rule body is copied into multiple locations.
+- YAML files remain structural, not prose-heavy.

--- a/harness/skills/feedback-governance.md
+++ b/harness/skills/feedback-governance.md
@@ -1,0 +1,45 @@
+---
+name: feedback-governance
+description: Convert user corrections, review findings, validation failures, and runtime incidents into routed repository knowledge or mechanisms.
+---
+
+# Feedback Governance Skill
+
+## Trigger
+
+Use this when someone says the agent was wrong, a rule is missing, existing docs conflict with code, validation failed in a reusable way, or a lesson should be remembered for this repository.
+
+## Boundary
+
+Feedback is a flow, not a permanent knowledge type. This skill owns admission, routing, proposal shape, and verification. Long-term facts belong in the selected SSOT.
+
+## Admission
+
+| Level | Meaning | Default action |
+|---|---|---|
+| A | Repeated, high-risk, or correctness-affecting | Propose repository change. |
+| B | Single but reusable with evidence | Propose or record with scope. |
+| C | Possibly useful, evidence or scope unclear | Put in inbox with missing evidence. |
+| D | One-off or personal preference | Do not change repo facts by default. |
+
+## Steps
+
+1. Capture source, evidence, current task context, and affected paths.
+2. Classify A/B/C/D.
+3. Use `harness/tools/feedback-router`, `harness/README.md` knowledge routing, and the affected workspace entry to pick a target.
+4. Write a feedback proposal before changing repository knowledge.
+5. Route accepted facts to the long-term source: workspace contracts, app spec/history, runbook, validation, harness skill, checks, tests, or root entry.
+6. Leave only unresolved or under-evidenced items in `harness/feedback/inbox.md`.
+
+## Output
+
+- Feedback Proposal summary.
+- Admission level and evidence.
+- Chosen target and why alternatives were not used.
+- Validation plan and remaining risk.
+
+## Validation
+
+- Long-term knowledge is not left only in `harness/feedback`.
+- Project rules are not written to personal or runtime memory.
+- Mechanizable issues identify a test/check/hook candidate.

--- a/harness/skills/quality-workflow.md
+++ b/harness/skills/quality-workflow.md
@@ -1,0 +1,40 @@
+---
+name: quality-workflow
+description: Select validation depth and collect evidence for repository changes based on affected workspaces and change type.
+---
+
+# Quality Workflow Skill
+
+## Trigger
+
+Use this when planning validation for a change, preparing a handoff, or deciding whether targeted checks are enough.
+
+## Boundary
+
+This skill chooses checks and evidence. It does not review the diff for bugs; use `code-review.md` for review behavior.
+
+## Required Inputs
+
+- Changed paths or intended change scope.
+- Whether public contracts, runtime behavior, config, or docs changed.
+- Available local environment constraints.
+
+## Steps
+
+1. Detect affected workspaces using `harness/profile.yaml`.
+2. Read the workspace `docs/validation.md` when present.
+3. Apply `harness/validation.yaml` path rules and escalation rules.
+4. Prefer targeted checks first, then cross-workspace checks when contracts or shared runtime behavior change.
+5. Clearly separate automatic checks from manual/runtime smoke checks.
+6. Record skipped checks with reason.
+
+## Output
+
+- Affected workspace list.
+- Required checks.
+- Optional/manual checks.
+- Evidence collected and remaining risk.
+
+## Validation
+
+A completed task should state what was run, the result, and why skipped checks were skipped.

--- a/harness/templates/app-spec-overview.md
+++ b/harness/templates/app-spec-overview.md
@@ -1,0 +1,26 @@
+# App Spec Overview Template
+
+## Product Surface
+
+What user-facing surface this app owns.
+
+## Module Map
+
+| Module | Responsibility | Source |
+|---|---|---|
+
+## Behavior Contracts
+
+Current behavior that code should preserve.
+
+## Runtime Boundaries
+
+Main/preload/renderer/server boundaries, external APIs, storage, and IPC rules.
+
+## Validation
+
+Link to app validation and runtime smoke checks.
+
+## History
+
+Link to delivery history or retrospectives when behavior changed.

--- a/harness/templates/feedback-proposal.md
+++ b/harness/templates/feedback-proposal.md
@@ -1,0 +1,35 @@
+# Feedback Proposal Template
+
+## Summary
+
+- Source:
+- Admission level: A/B/C/D
+- Affected scope:
+- Evidence:
+
+## Problem
+
+What went wrong or what knowledge is missing?
+
+## Proposed Target
+
+- Long-term SSOT:
+- Alternative targets considered:
+- Why this target:
+
+## Proposed Change
+
+Describe the minimal repository change.
+
+## Mechanization Candidate
+
+- Test:
+- Check:
+- Hook/CI:
+- Not mechanized because:
+
+## Validation
+
+- Commands/checks:
+- Manual verification:
+- Remaining risk:

--- a/harness/templates/package-contract.md
+++ b/harness/templates/package-contract.md
@@ -1,0 +1,28 @@
+# Package Contract Template
+
+## Scope
+
+What this package owns and does not own.
+
+## Public Contracts
+
+- Exports:
+- Tool schemas:
+- Hook/service APIs:
+- Runtime protocols:
+
+## Invariants
+
+- Rules that must remain true across changes.
+
+## Extension Boundaries
+
+Where new behavior should be added and where it should not be added.
+
+## Consumers
+
+Known workspace consumers and compatibility expectations.
+
+## Validation
+
+Link to `docs/validation.md` and list the highest-value checks.

--- a/harness/templates/workspace-agents.md
+++ b/harness/templates/workspace-agents.md
@@ -1,0 +1,34 @@
+# Workspace AGENTS.md Template
+
+> This file is the local entry for `<workspace>`.
+> Repository harness entry: `../../harness/README.md` or the correct relative path.
+
+## Module Positioning
+
+What this workspace owns and what it does not own.
+
+## Knowledge Navigation
+
+| Task | Read |
+|---|---|
+| Understand public contracts | `docs/contracts.md` |
+| Pick validation | `docs/validation.md` |
+| Understand package scripts | `package.json` |
+
+## Local Constraints
+
+- Keep facts local to the workspace unless they are repository-wide.
+- Route contract changes through `harness/skills/contract-coding.md`.
+- Route reusable feedback through `harness/skills/feedback-governance.md`.
+
+## Common Commands
+
+```bash
+pnpm --filter <package-name> test
+pnpm --filter <package-name> typecheck
+pnpm --filter <package-name> build
+```
+
+## Key Files
+
+- `src/index.ts`:

--- a/harness/tools/README.md
+++ b/harness/tools/README.md
@@ -1,0 +1,17 @@
+# Harness Tools
+
+`harness/tools` describes horizontal atomic capabilities. Tools can be used by skills, checks, feedback, reports, or humans.
+
+A tool should have stable inputs and outputs, but it does not own final decisions. Skills compose tools and make workflow decisions.
+
+## Current Tool Specs
+
+| Tool | Purpose |
+|---|---|
+| `repo-profiler` | Build or refresh the repository map used by `harness/profile.yaml`. |
+| `affected-workspace-detector` | Map changed paths or a user request to affected workspaces. |
+| `ssot-resolver` | Pick the correct long-term source of truth for a fact or rule. |
+| `feedback-router` | Route feedback to a proposal target based on evidence and scope. |
+| `validation-planner` | Produce validation commands from affected workspaces and change type. |
+
+Executable implementations may later live in `scripts/harness/`. Until then, these are protocol specs only.

--- a/harness/tools/affected-workspace-detector/README.md
+++ b/harness/tools/affected-workspace-detector/README.md
@@ -1,0 +1,23 @@
+# Affected Workspace Detector Tool
+
+## Purpose
+
+Map changed paths or a user request to the workspaces likely affected by a task.
+
+## Inputs
+
+- Changed file paths, git diff paths, or user-described target area.
+- `harness/profile.yaml` workspace map.
+- Optional package dependency hints.
+
+## Output
+
+- affected workspaces
+- producer/consumer relationships when known
+- confidence level
+- paths that could not be mapped
+
+## Non-goals
+
+- Does not decide validation by itself; use `validation-planner` for that.
+- Does not review code correctness.

--- a/harness/tools/feedback-router/README.md
+++ b/harness/tools/feedback-router/README.md
@@ -1,0 +1,27 @@
+# Feedback Router Tool
+
+## Purpose
+
+Route feedback to the right proposal target and long-term source of truth.
+
+## Inputs
+
+- Feedback text.
+- Source: user correction, review, validation failure, runtime incident, CI failure, or report.
+- Evidence paths or logs.
+- Affected workspace candidates.
+- `harness/README.md` knowledge routing rules and affected workspace entry.
+
+## Output
+
+- admission level: A, B, C, or D
+- semantic scope
+- recommended long-term target
+- proposal path suggestion
+- missing evidence
+- mechanism candidate: test, check, hook, CI, docs, or skill
+
+## Non-goals
+
+- Does not make final governance decisions.
+- Does not leave accepted long-term knowledge in `harness/feedback` only.

--- a/harness/tools/graph-viewer/README.md
+++ b/harness/tools/graph-viewer/README.md
@@ -4,7 +4,7 @@
 
 Expose the repository harness as a local dashboard that is easy to scan before changing code or docs.
 
-The dashboard derives coverage, missing items, workspace guidance, validation commands, and graph edges from existing harness files:
+The dashboard derives coverage, missing items, workspace guidance, validation commands, and relationship metadata from existing harness files:
 
 - `harness/profile.yaml`
 - `harness/validation.yaml`
@@ -27,8 +27,9 @@ Then open the printed local URL. The dashboard includes:
 - per-workspace harness detail
 - current missing harness items
 - resolved validation commands
-- a graph view for relationship debugging
 - Chinese/English language switcher for easier shared review
+
+Relationship metadata remains available at `/graph.json` for debugging, but it is not part of the main dashboard surface.
 
 For a non-server smoke check:
 
@@ -41,7 +42,7 @@ node harness/tools/graph-viewer/server.mjs --once
 The smoke check prints:
 
 - workspace coverage summary
-- graph node/edge counts
+- relationship node/edge counts
 - missing referenced files and harness gaps
 
 ## Non-goals

--- a/harness/tools/graph-viewer/README.md
+++ b/harness/tools/graph-viewer/README.md
@@ -28,7 +28,7 @@ Then open the printed local URL. The dashboard includes:
 - current missing harness items
 - resolved validation commands
 - a graph view for relationship debugging
-- bilingual Chinese/English labels for easier shared review
+- Chinese/English language switcher for easier shared review
 
 For a non-server smoke check:
 

--- a/harness/tools/graph-viewer/README.md
+++ b/harness/tools/graph-viewer/README.md
@@ -25,7 +25,7 @@ Then open the printed local URL. The dashboard includes:
 
 - overall harness health and coverage, without forcing a workspace selection
 - per-workspace harness detail with a dedicated detail rail
-- current missing harness items grouped by affected workspace, with collapsible groups and explicit workspace drill-in
+- current missing harness items grouped by affected workspace, with collapsible groups and modal workspace detail
 - resolved validation commands
 - Chinese/English language switcher for easier shared review
 

--- a/harness/tools/graph-viewer/README.md
+++ b/harness/tools/graph-viewer/README.md
@@ -1,15 +1,16 @@
-# Graph Viewer Tool
+# Harness Dashboard Tool
 
 ## Purpose
 
-Visualize the repository harness as a local graph without adding manual dependency annotations.
+Expose the repository harness as a local dashboard that is easy to scan before changing code or docs.
 
-The viewer derives nodes and edges from existing harness files:
+The dashboard derives coverage, missing items, workspace guidance, validation commands, and graph edges from existing harness files:
 
 - `harness/profile.yaml`
 - `harness/validation.yaml`
 - `harness/skills/*.md`
 - `harness/tools/*/README.md`
+- `pnpm-workspace.yaml`
 - workspace `AGENTS.md` and docs referenced by the profile
 
 ## Usage
@@ -20,7 +21,13 @@ From the repository root:
 node harness/tools/graph-viewer/server.mjs
 ```
 
-Then open the printed local URL.
+Then open the printed local URL. The dashboard includes:
+
+- overall harness health and coverage
+- per-workspace harness detail
+- current missing harness items
+- resolved validation commands
+- a graph view for relationship debugging
 
 For a non-server smoke check:
 
@@ -30,13 +37,11 @@ node harness/tools/graph-viewer/server.mjs --once
 
 ## Output
 
-The UI shows:
+The smoke check prints:
 
-- workspace coverage
-- skills and tools
-- validation rules
-- missing referenced files
-- semantic edges with confidence levels
+- workspace coverage summary
+- graph node/edge counts
+- missing referenced files and harness gaps
 
 ## Non-goals
 

--- a/harness/tools/graph-viewer/README.md
+++ b/harness/tools/graph-viewer/README.md
@@ -1,0 +1,45 @@
+# Graph Viewer Tool
+
+## Purpose
+
+Visualize the repository harness as a local graph without adding manual dependency annotations.
+
+The viewer derives nodes and edges from existing harness files:
+
+- `harness/profile.yaml`
+- `harness/validation.yaml`
+- `harness/skills/*.md`
+- `harness/tools/*/README.md`
+- workspace `AGENTS.md` and docs referenced by the profile
+
+## Usage
+
+From the repository root:
+
+```bash
+node harness/tools/graph-viewer/server.mjs
+```
+
+Then open the printed local URL.
+
+For a non-server smoke check:
+
+```bash
+node harness/tools/graph-viewer/server.mjs --once
+```
+
+## Output
+
+The UI shows:
+
+- workspace coverage
+- skills and tools
+- validation rules
+- missing referenced files
+- semantic edges with confidence levels
+
+## Non-goals
+
+- No LLM inference in the first version.
+- No edits to existing harness files.
+- No package script or CI integration yet.

--- a/harness/tools/graph-viewer/README.md
+++ b/harness/tools/graph-viewer/README.md
@@ -28,6 +28,7 @@ Then open the printed local URL. The dashboard includes:
 - current missing harness items
 - resolved validation commands
 - a graph view for relationship debugging
+- bilingual Chinese/English labels for easier shared review
 
 For a non-server smoke check:
 

--- a/harness/tools/graph-viewer/README.md
+++ b/harness/tools/graph-viewer/README.md
@@ -23,9 +23,9 @@ node harness/tools/graph-viewer/server.mjs
 
 Then open the printed local URL. The dashboard includes:
 
-- overall harness health and coverage
-- per-workspace harness detail
-- current missing harness items
+- overall harness health and coverage, without forcing a workspace selection
+- per-workspace harness detail with a dedicated detail rail
+- current missing harness items that drill into the affected workspace
 - resolved validation commands
 - Chinese/English language switcher for easier shared review
 

--- a/harness/tools/graph-viewer/README.md
+++ b/harness/tools/graph-viewer/README.md
@@ -25,7 +25,7 @@ Then open the printed local URL. The dashboard includes:
 
 - overall harness health and coverage, without forcing a workspace selection
 - per-workspace harness detail with a dedicated detail rail
-- current missing harness items grouped by affected workspace, with drill-in to workspace detail
+- current missing harness items grouped by affected workspace, with collapsible groups and explicit workspace drill-in
 - resolved validation commands
 - Chinese/English language switcher for easier shared review
 

--- a/harness/tools/graph-viewer/README.md
+++ b/harness/tools/graph-viewer/README.md
@@ -25,7 +25,7 @@ Then open the printed local URL. The dashboard includes:
 
 - overall harness health and coverage, without forcing a workspace selection
 - per-workspace harness detail with a dedicated detail rail
-- current missing harness items that drill into the affected workspace
+- current missing harness items grouped by affected workspace, with drill-in to workspace detail
 - resolved validation commands
 - Chinese/English language switcher for easier shared review
 

--- a/harness/tools/graph-viewer/README.md
+++ b/harness/tools/graph-viewer/README.md
@@ -24,8 +24,8 @@ node harness/tools/graph-viewer/server.mjs
 Then open the printed local URL. The dashboard includes:
 
 - overall harness health and coverage, without forcing a workspace selection
-- per-workspace harness detail with a dedicated detail rail
-- current missing harness items grouped by affected workspace, with collapsible groups and modal workspace detail
+- per-workspace harness detail in a right-side drawer
+- current missing harness items grouped by affected workspace, with collapsible groups and drawer workspace detail
 - resolved validation commands
 - Chinese/English language switcher for easier shared review
 

--- a/harness/tools/graph-viewer/server.mjs
+++ b/harness/tools/graph-viewer/server.mjs
@@ -455,7 +455,7 @@ function html(graph) {
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Harness 看板 / Harness Dashboard</title>
+<title>Harness 看板</title>
 <style>
 :root {
   color-scheme: dark;
@@ -488,6 +488,9 @@ h2 { margin:0 0 12px; font-size:15px; letter-spacing:0; }
 h3 { margin:0 0 8px; font-size:13px; color:var(--muted); letter-spacing:0; text-transform:uppercase; }
 .sub { color:var(--muted); margin-top:6px; max-width:880px; }
 .meta { color:var(--muted); font-size:12px; text-align:right; white-space:nowrap; }
+.meta-panel { display:grid; gap:8px; justify-items:end; }
+.language-switch { display:flex; gap:6px; justify-content:flex-end; }
+.language-switch button { min-height:30px; padding:6px 9px; font-size:12px; }
 .tabs { display:flex; gap:8px; flex-wrap:wrap; margin-top:16px; }
 button {
   border:1px solid var(--line);
@@ -564,6 +567,8 @@ svg { width:100%; height:100%; display:block; }
   .detail { border-left:0; border-top:1px solid var(--line); }
   .metrics { grid-template-columns:repeat(2, minmax(150px, 1fr)); }
   .meta { text-align:left; white-space:normal; }
+  .meta-panel { justify-items:start; }
+  .language-switch { justify-content:flex-start; }
   .topline { flex-direction:column; }
 }
 @media (max-width: 620px) {
@@ -577,16 +582,22 @@ svg { width:100%; height:100%; display:block; }
 <header class="topbar">
   <div class="topline">
     <div>
-      <h1>仓库 Harness 看板 / Repository Harness Dashboard</h1>
-      <div class="sub">快速查看 harness 覆盖、工作区指引、验证命令和当前缺失项。Operational view of harness coverage, workspace guidance, validation commands, and missing pieces.</div>
+      <h1 data-i18n="pageTitle">仓库 Harness 看板</h1>
+      <div class="sub" data-i18n="subtitle">快速查看 harness 覆盖、工作区指引、验证命令和当前缺失项。</div>
     </div>
-    <div class="meta" id="meta"></div>
+    <div class="meta-panel">
+      <div class="language-switch" aria-label="Language">
+        <button class="active" data-lang="zh">中文</button>
+        <button data-lang="en">English</button>
+      </div>
+      <div class="meta" id="meta"></div>
+    </div>
   </div>
-  <nav class="tabs" aria-label="Harness 视图 / Harness views">
-    <button class="active" data-tab="overview">总览 / Overview</button>
-    <button data-tab="workspaces">工作区 / Workspaces</button>
-    <button data-tab="gaps">缺失 / Missing</button>
-    <button data-tab="graph">关系图 / Graph</button>
+  <nav class="tabs" aria-label="Harness views">
+    <button class="active" data-tab="overview" data-i18n="tabOverview">总览</button>
+    <button data-tab="workspaces" data-i18n="tabWorkspaces">工作区</button>
+    <button data-tab="gaps" data-i18n="tabMissing">缺失</button>
+    <button data-tab="graph" data-i18n="tabGraph">关系图</button>
   </nav>
 </header>
 <div class="shell">
@@ -595,34 +606,34 @@ svg { width:100%; height:100%; display:block; }
       <div class="metrics" id="metrics"></div>
       <div class="grid-2">
         <section class="panel">
-          <h2>Harness 健康度 / Harness Health</h2>
+          <h2 data-i18n="harnessHealth">Harness 健康度</h2>
           <div id="health"></div>
         </section>
         <section class="panel">
-          <h2>优先缺失项 / Priority Missing Items</h2>
+          <h2 data-i18n="priorityMissing">优先缺失项</h2>
           <div id="priority-gaps"></div>
         </section>
       </div>
       <section class="panel">
-        <h2>渐进阅读路径 / Progressive Reading Loop</h2>
+        <h2 data-i18n="readingLoop">渐进阅读路径</h2>
         <div class="compact-list" id="reading-loop"></div>
       </section>
     </section>
 
     <section id="workspaces" class="view">
       <div class="filters">
-        <input id="workspace-search" class="search" type="search" placeholder="搜索工作区、包、角色或命令 / Search workspace, package, role, or command" />
-        <button class="active" data-filter="all">全部 / All</button>
-        <button data-filter="ready">就绪 / Ready</button>
-        <button data-filter="partial">部分 / Partial</button>
-        <button data-filter="missing">缺失 / Missing</button>
+        <input id="workspace-search" class="search" type="search" data-i18n-placeholder="workspaceSearch" placeholder="搜索工作区、包、角色或命令" />
+        <button class="active" data-filter="all" data-i18n="filterAll">全部</button>
+        <button data-filter="ready" data-i18n="filterReady">就绪</button>
+        <button data-filter="partial" data-i18n="filterPartial">部分</button>
+        <button data-filter="missing" data-i18n="filterMissing">缺失</button>
       </div>
       <div class="workspace-grid" id="workspace-grid"></div>
     </section>
 
     <section id="gaps" class="view">
       <section class="panel">
-        <h2>当前 Harness 缺失项 / Current Harness Missing Items</h2>
+        <h2 data-i18n="currentMissing">当前 Harness 缺失项</h2>
         <div id="gap-list"></div>
       </section>
     </section>
@@ -631,23 +642,23 @@ svg { width:100%; height:100%; display:block; }
       <div class="graph-layout">
         <div>
           <div class="filters">
-            <button id="toggle-graph">暂停图 / Pause graph</button>
-            <button class="active" data-node-filter="all">全部节点 / All nodes</button>
-            <button data-node-filter="workspace">工作区 / Workspaces</button>
-            <button data-node-filter="validation">验证 / Validation</button>
-            <button data-node-filter="gap">缺口 / Gaps</button>
+            <button id="toggle-graph" data-i18n="pauseGraph">暂停图</button>
+            <button class="active" data-node-filter="all" data-i18n="nodeAll">全部节点</button>
+            <button data-node-filter="workspace" data-i18n="nodeWorkspaces">工作区</button>
+            <button data-node-filter="validation" data-i18n="nodeValidation">验证</button>
+            <button data-node-filter="gap" data-i18n="nodeGaps">缺口</button>
           </div>
           <div class="graph-box"><svg id="graph-svg" role="img" aria-label="Harness graph"></svg></div>
         </div>
         <section class="panel">
-          <h2 id="graph-title">图节点选择 / Graph Selection</h2>
-          <div id="graph-detail" class="muted">选择一个节点查看关联边。Select a node to inspect connected edges.</div>
+          <h2 id="graph-title" data-i18n="graphSelection">图节点选择</h2>
+          <div id="graph-detail" class="muted" data-i18n="graphHint">选择一个节点查看关联边。</div>
         </section>
       </div>
     </section>
   </main>
   <aside class="detail">
-    <h2 id="detail-title">工作区详情 / Workspace Detail</h2>
+    <h2 id="detail-title" data-i18n="workspaceDetail">工作区详情</h2>
     <div id="detail-body"></div>
   </aside>
 </div>
@@ -661,14 +672,72 @@ const byId = new Map(nodes.map(n => [n.id, n]));
 const edges = graph.edges.map(e => ({...e, source: byId.get(e.from), target: byId.get(e.to)})).filter(e => e.source && e.target);
 const byWorkspace = new Map(reports.map(r => [r.path, r]));
 const svg = document.getElementById('graph-svg');
-const state = { selected: reports[0]?.path || '', filter: 'all', query: '', nodeFilter: 'all' };
+const messages = {
+  zh: {
+    title: 'Harness 看板',
+    pageTitle: '仓库 Harness 看板',
+    subtitle: '快速查看 harness 覆盖、工作区指引、验证命令和当前缺失项。',
+    tabOverview: '总览',
+    tabWorkspaces: '工作区',
+    tabMissing: '缺失',
+    tabGraph: '关系图',
+    harnessHealth: 'Harness 健康度',
+    priorityMissing: '优先缺失项',
+    readingLoop: '渐进阅读路径',
+    workspaceSearch: '搜索工作区、包、角色或命令',
+    filterAll: '全部',
+    filterReady: '就绪',
+    filterPartial: '部分',
+    filterMissing: '缺失',
+    currentMissing: '当前 Harness 缺失项',
+    pauseGraph: '暂停图',
+    resumeGraph: '继续图',
+    nodeAll: '全部节点',
+    nodeWorkspaces: '工作区',
+    nodeValidation: '验证',
+    nodeGaps: '缺口',
+    graphSelection: '图节点选择',
+    graphHint: '选择一个节点查看关联边。',
+    workspaceDetail: '工作区详情',
+  },
+  en: {
+    title: 'Harness Dashboard',
+    pageTitle: 'Repository Harness Dashboard',
+    subtitle: 'Operational view of harness coverage, workspace guidance, validation commands, and missing pieces.',
+    tabOverview: 'Overview',
+    tabWorkspaces: 'Workspaces',
+    tabMissing: 'Missing',
+    tabGraph: 'Graph',
+    harnessHealth: 'Harness Health',
+    priorityMissing: 'Priority Missing Items',
+    readingLoop: 'Progressive Reading Loop',
+    workspaceSearch: 'Search workspace, package, role, or command',
+    filterAll: 'All',
+    filterReady: 'Ready',
+    filterPartial: 'Partial',
+    filterMissing: 'Missing',
+    currentMissing: 'Current Harness Missing Items',
+    pauseGraph: 'Pause graph',
+    resumeGraph: 'Resume graph',
+    nodeAll: 'All nodes',
+    nodeWorkspaces: 'Workspaces',
+    nodeValidation: 'Validation',
+    nodeGaps: 'Gaps',
+    graphSelection: 'Graph Selection',
+    graphHint: 'Select a node to inspect connected edges.',
+    workspaceDetail: 'Workspace Detail',
+  },
+};
+const savedLang = localStorage.getItem('harness-dashboard-lang');
+const state = { selected: reports[0]?.path || '', filter: 'all', query: '', nodeFilter: 'all', lang: savedLang === 'en' ? 'en' : 'zh' };
 let running = true;
 
 function escapeHtml(s){ return String(s ?? '').replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
 function radius(n){ return n.type==='workspace'?10:n.type==='gap'?9:6; }
 function pct(part, total){ return total ? Math.round(part / total * 100) : 100; }
-function bi(zh, en){ return zh + ' / ' + en; }
-function countLabel(count, zhUnit, enSingular, enPlural){ return count + zhUnit + ' / ' + count + ' ' + (count === 1 ? enSingular : enPlural); }
+function t(key){ return messages[state.lang]?.[key] ?? messages.zh[key] ?? key; }
+function bi(zh, en){ return state.lang === 'en' ? en : zh; }
+function countLabel(count, zhUnit, enSingular, enPlural){ return state.lang === 'en' ? count + ' ' + (count === 1 ? enSingular : enPlural) : count + zhUnit; }
 function statusLabel(status){ return status === 'ready' ? bi('就绪', 'Ready') : status === 'missing' ? bi('缺失', 'Missing') : bi('部分', 'Partial'); }
 function statusBadge(status){ return '<span class="badge '+status+'">'+statusLabel(status)+'</span>'; }
 function severityLabel(severity){ return severity === 'high' ? bi('高', 'HIGH') : severity === 'medium' ? bi('中', 'MEDIUM') : String(severity ?? '').toUpperCase(); }
@@ -707,8 +776,23 @@ function missingText(){ return bi('未发现 harness 缺失项', 'No missing har
 function metric(label, value, sub, tone){
   return '<div class="metric '+(tone || '')+'"><b>'+escapeHtml(value)+'</b><span>'+escapeHtml(label)+'</span><div class="muted">'+escapeHtml(sub || '')+'</div></div>';
 }
+function renderStaticText(){
+  document.documentElement.lang = state.lang === 'en' ? 'en' : 'zh-Hans';
+  document.title = t('title');
+  document.querySelectorAll('[data-i18n]').forEach(element => {
+    element.textContent = t(element.dataset.i18n);
+  });
+  document.querySelectorAll('[data-i18n-placeholder]').forEach(element => {
+    element.setAttribute('placeholder', t(element.dataset.i18nPlaceholder));
+  });
+  document.querySelectorAll('[data-lang]').forEach(button => {
+    button.classList.toggle('active', button.dataset.lang === state.lang);
+  });
+  const toggle = document.getElementById('toggle-graph');
+  if (toggle) toggle.textContent = running ? t('pauseGraph') : t('resumeGraph');
+}
 function renderMeta(){
-  const scope = graph.profileScope?.mode ? graph.profileScope.mode + ' scope / ' + graph.profileScope.mode + ' 范围' : bi('profile', 'profile');
+  const scope = graph.profileScope?.mode ? (state.lang === 'en' ? graph.profileScope.mode + ' scope' : graph.profileScope.mode + ' 范围') : 'profile';
   document.getElementById('meta').innerHTML = escapeHtml(scope)+'<br><span>'+escapeHtml(new Date(graph.generatedAt).toLocaleString())+'</span>';
 }
 function renderMetrics(){
@@ -753,7 +837,8 @@ function filteredReports(){
   return reports.filter(report => {
     if (state.filter !== 'all' && report.status !== state.filter) return false;
     if (!query) return true;
-    const haystack = [report.path, report.packageName, report.role, report.type, statusLabel(report.status), ...report.commands, ...report.scripts, ...report.gaps.map(gapLabel)].join(' ').toLowerCase();
+    const gapSearch = report.gaps.flatMap(gap => [gap.label, gap.detail, gapLabel(gap), gapDetail(gap)]);
+    const haystack = [report.path, report.packageName, report.role, report.type, report.status, statusLabel(report.status), ...report.commands, ...report.scripts, ...gapSearch].join(' ').toLowerCase();
     return haystack.includes(query);
   });
 }
@@ -795,7 +880,7 @@ function renderDetail(){
   const knowledge = report.knowledge.length ? report.knowledge.map(item => '<div class="mini-row"><div>'+escapeHtml(item.kind)+'</div><div class="path">'+escapeHtml(item.path)+' '+(item.exists ? '' : '<span class="severity high">'+bi('缺失', 'missing')+'</span>')+'</div></div>').join('') : '<div class="empty">'+bi('无已配置知识引用', 'No curated knowledge refs')+'</div>';
   const missing = report.gaps.length ? report.gaps.map(renderGapRow).join('') : '<div class="empty">'+bi('该工作区无缺失项', 'No missing items for this workspace')+'</div>';
   document.getElementById('detail-body').innerHTML =
-    '<div class="badges">'+statusBadge(report.status)+'<span class="badge info">'+escapeHtml(report.type)+'</span><span class="badge">'+report.score+' 分 / '+report.score+' score</span></div>'+
+    '<div class="badges">'+statusBadge(report.status)+'<span class="badge info">'+escapeHtml(report.type)+'</span><span class="badge">'+escapeHtml(state.lang === 'en' ? report.score + ' score' : report.score + ' 分')+'</span></div>'+
     '<section class="panel"><h3>'+bi('身份信息', 'Identity')+'</h3><div class="mini-table">'+
       '<div class="mini-row"><div>'+bi('包', 'Package')+'</div><div>'+escapeHtml(report.packageName)+'</div></div>'+
       '<div class="mini-row"><div>'+bi('角色', 'Role')+'</div><div>'+escapeHtml(report.role)+'</div></div>'+
@@ -825,7 +910,13 @@ function selectGraphNode(id){
   }
 }
 function init(){
-  renderMeta(); renderMetrics(); renderHealth(); renderPriorityGaps(); renderReadingLoop(); renderWorkspaces(); renderGaps(); renderDetail(); applyNodeFilter();
+  renderStaticText(); renderMeta(); renderMetrics(); renderHealth(); renderPriorityGaps(); renderReadingLoop(); renderWorkspaces(); renderGaps(); renderDetail(); applyNodeFilter();
+  document.querySelector('.language-switch').addEventListener('click', e => {
+    const button = e.target.closest('button[data-lang]'); if(!button) return;
+    state.lang = button.dataset.lang === 'en' ? 'en' : 'zh';
+    localStorage.setItem('harness-dashboard-lang', state.lang);
+    renderStaticText(); renderMeta(); renderMetrics(); renderHealth(); renderPriorityGaps(); renderReadingLoop(); renderWorkspaces(); renderGaps(); renderDetail();
+  });
   document.querySelector('.tabs').addEventListener('click', e => { const button = e.target.closest('button[data-tab]'); if(button) showTab(button.dataset.tab); });
   document.querySelector('.filters').addEventListener('click', e => {
     const button = e.target.closest('button[data-filter]'); if(!button) return;
@@ -842,7 +933,7 @@ function init(){
     const copy = e.target.closest('button[data-copy]'); if(!copy) return;
     navigator.clipboard?.writeText(copy.dataset.copy).then(() => { copy.textContent = bi('已复制', 'Copied'); setTimeout(() => { copy.textContent = bi('复制', 'Copy'); }, 1100); });
   });
-  document.getElementById('toggle-graph').onclick = () => { running = !running; document.getElementById('toggle-graph').textContent = running ? bi('暂停图', 'Pause graph') : bi('继续图', 'Resume graph'); };
+  document.getElementById('toggle-graph').onclick = () => { running = !running; document.getElementById('toggle-graph').textContent = running ? t('pauseGraph') : t('resumeGraph'); };
   document.querySelector('#graph .filters').addEventListener('click', e => {
     const button = e.target.closest('button[data-node-filter]'); if(!button) return;
     state.nodeFilter = button.dataset.nodeFilter;

--- a/harness/tools/graph-viewer/server.mjs
+++ b/harness/tools/graph-viewer/server.mjs
@@ -503,8 +503,6 @@ button {
 }
 button:hover, button.active { border-color:var(--blue); color:var(--blue); }
 .shell { display:grid; grid-template-columns:minmax(0, 1fr) minmax(360px, 420px); gap:0; min-height:calc(100vh - 115px); }
-.shell.graph-mode { grid-template-columns:1fr; }
-.shell.graph-mode .detail { display:none; }
 main { min-width:0; padding:22px 24px 36px; }
 .detail { border-left:1px solid var(--line); background:var(--panel); padding:22px; overflow:auto; }
 .view { display:none; }
@@ -556,20 +554,9 @@ pre { white-space:pre-wrap; word-break:break-word; background:#0c0f13; border:1p
 .reading { display:grid; gap:8px; counter-reset:readstep; }
 .reading div { border:1px solid var(--line); background:var(--panel-2); border-radius:6px; padding:8px; }
 .reading div::before { counter-increment:readstep; content:counter(readstep) ". "; color:var(--blue); font-weight:700; }
-.graph-layout { display:grid; grid-template-columns:minmax(0, 1fr) 320px; gap:14px; }
-.graph-box { height:560px; border:1px solid var(--line); border-radius:8px; background:#0b0e13; position:relative; overflow:hidden; }
-.shell.graph-mode .graph-box { min-height:560px; height:min(680px, calc(100vh - 260px)); }
-svg { width:100%; height:100%; display:block; }
-.edge { stroke:#596373; stroke-width:1.1; opacity:.38; pointer-events:none; }
-.edge.high { stroke:var(--blue); opacity:.62; }
-.node { cursor:pointer; }
-.node .node-dot { stroke:#090b0e; stroke-width:2; }
-.node-label { fill:var(--text); font-size:10px; paint-order:stroke; stroke:#0b0e13; stroke-width:4px; pointer-events:all; cursor:pointer; }
-.node.selected .node-dot { stroke:var(--text); stroke-width:3; }
-.node-label.selected { fill:var(--blue); }
 .empty { color:var(--muted); border:1px dashed var(--line); border-radius:8px; padding:16px; }
 @media (max-width: 1180px) {
-  .shell, .grid-2, .graph-layout { grid-template-columns:1fr; }
+  .shell, .grid-2 { grid-template-columns:1fr; }
   .detail { border-left:0; border-top:1px solid var(--line); }
   .metrics { grid-template-columns:repeat(2, minmax(150px, 1fr)); }
   .meta { text-align:left; white-space:normal; }
@@ -603,7 +590,6 @@ svg { width:100%; height:100%; display:block; }
     <button class="active" data-tab="overview" data-i18n="tabOverview">总览</button>
     <button data-tab="workspaces" data-i18n="tabWorkspaces">工作区</button>
     <button data-tab="gaps" data-i18n="tabMissing">缺失</button>
-    <button data-tab="graph" data-i18n="tabGraph">关系图</button>
   </nav>
 </header>
 <div class="shell">
@@ -644,24 +630,6 @@ svg { width:100%; height:100%; display:block; }
       </section>
     </section>
 
-    <section id="graph" class="view">
-      <div class="graph-layout">
-        <div>
-          <div class="filters">
-            <button id="toggle-graph" data-i18n="pauseGraph">暂停图</button>
-            <button class="active" data-node-filter="all" data-i18n="nodeAll">全部节点</button>
-            <button data-node-filter="workspace" data-i18n="nodeWorkspaces">工作区</button>
-            <button data-node-filter="validation" data-i18n="nodeValidation">验证</button>
-            <button data-node-filter="gap" data-i18n="nodeGaps">缺口</button>
-          </div>
-          <div class="graph-box"><svg id="graph-svg" role="img" aria-label="Harness graph"></svg></div>
-        </div>
-        <section class="panel">
-          <h2 id="graph-title" data-i18n="graphSelection">图节点选择</h2>
-          <div id="graph-detail" class="muted" data-i18n="graphHint">选择一个节点查看关联边。</div>
-        </section>
-      </div>
-    </section>
   </main>
   <aside class="detail">
     <h2 id="detail-title" data-i18n="workspaceDetail">工作区详情</h2>
@@ -672,12 +640,7 @@ svg { width:100%; height:100%; display:block; }
 const graph = ${graphJson};
 const reports = graph.workspaceReports || [];
 const gaps = graph.harnessGaps || [];
-const colors = { root:'#f3cd6b', harness:'#7ee4df', profile:'#7ee4df', validation:'#ff8fbd', workspace:'#7db7ff', entry:'#7ee2a8', knowledge:'#9ad581', skill:'#f3cd6b', tool:'#c8a2ff', gap:'#ff7a70' };
-const nodes = graph.nodes.map((n, i) => ({...n, x: 520 + Math.cos(i)*180, y: 260 + Math.sin(i)*155, vx:0, vy:0, visible:true}));
-const byId = new Map(nodes.map(n => [n.id, n]));
-const edges = graph.edges.map(e => ({...e, source: byId.get(e.from), target: byId.get(e.to)})).filter(e => e.source && e.target);
 const byWorkspace = new Map(reports.map(r => [r.path, r]));
-const svg = document.getElementById('graph-svg');
 const messages = {
   zh: {
     title: 'Harness 看板',
@@ -686,7 +649,6 @@ const messages = {
     tabOverview: '总览',
     tabWorkspaces: '工作区',
     tabMissing: '缺失',
-    tabGraph: '关系图',
     harnessHealth: 'Harness 健康度',
     priorityMissing: '优先缺失项',
     readingLoop: '渐进阅读路径',
@@ -696,14 +658,6 @@ const messages = {
     filterPartial: '部分',
     filterMissing: '缺失',
     currentMissing: '当前 Harness 缺失项',
-    pauseGraph: '暂停图',
-    resumeGraph: '继续图',
-    nodeAll: '全部节点',
-    nodeWorkspaces: '工作区',
-    nodeValidation: '验证',
-    nodeGaps: '缺口',
-    graphSelection: '图节点选择',
-    graphHint: '选择一个节点查看关联边。',
     workspaceDetail: '工作区详情',
   },
   en: {
@@ -713,7 +667,6 @@ const messages = {
     tabOverview: 'Overview',
     tabWorkspaces: 'Workspaces',
     tabMissing: 'Missing',
-    tabGraph: 'Graph',
     harnessHealth: 'Harness Health',
     priorityMissing: 'Priority Missing Items',
     readingLoop: 'Progressive Reading Loop',
@@ -723,20 +676,11 @@ const messages = {
     filterPartial: 'Partial',
     filterMissing: 'Missing',
     currentMissing: 'Current Harness Missing Items',
-    pauseGraph: 'Pause graph',
-    resumeGraph: 'Resume graph',
-    nodeAll: 'All nodes',
-    nodeWorkspaces: 'Workspaces',
-    nodeValidation: 'Validation',
-    nodeGaps: 'Gaps',
-    graphSelection: 'Graph Selection',
-    graphHint: 'Select a node to inspect connected edges.',
     workspaceDetail: 'Workspace Detail',
   },
 };
 const savedLang = localStorage.getItem('harness-dashboard-lang');
-const state = { selected: reports[0]?.path || '', selectedNodeId: '', filter: 'all', query: '', nodeFilter: 'all', lang: savedLang === 'en' ? 'en' : 'zh' };
-let running = true;
+const state = { selected: reports[0]?.path || '', filter: 'all', query: '', lang: savedLang === 'en' ? 'en' : 'zh' };
 
 function escapeHtml(s){ return String(s ?? '').replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
 function radius(n){ return n.type==='workspace'?10:n.type==='gap'?9:6; }
@@ -794,8 +738,6 @@ function renderStaticText(){
   document.querySelectorAll('[data-lang]').forEach(button => {
     button.classList.toggle('active', button.dataset.lang === state.lang);
   });
-  const toggle = document.getElementById('toggle-graph');
-  if (toggle) toggle.textContent = running ? t('pauseGraph') : t('resumeGraph');
 }
 function renderMeta(){
   const scope = graph.profileScope?.mode ? (state.lang === 'en' ? graph.profileScope.mode + ' scope' : graph.profileScope.mode + ' 范围') : 'profile';
@@ -901,43 +843,9 @@ function renderDetail(){
 function showTab(tab){
   document.querySelectorAll('.tabs button').forEach(button => button.classList.toggle('active', button.dataset.tab === tab));
   document.querySelectorAll('.view').forEach(view => view.classList.toggle('active', view.id === tab));
-  document.querySelector('.shell').classList.toggle('graph-mode', tab === 'graph');
-}
-function applyNodeFilter(){
-  for (const node of nodes) node.visible = state.nodeFilter === 'all' || node.type === state.nodeFilter || (state.nodeFilter === 'validation' && node.type === 'profile');
-}
-function graphPointFromEvent(event){
-  const rect = svg.getBoundingClientRect();
-  return { x: event.clientX - rect.left, y: event.clientY - rect.top };
-}
-function nearestVisibleNode(point){
-  let best = null;
-  let bestDistance = Infinity;
-  for (const node of nodes) {
-    if (!node.visible) continue;
-    const distance = Math.hypot(node.x - point.x, node.y - point.y);
-    const hitRadius = Math.max(32, radius(node) + 18);
-    if (distance <= hitRadius && distance < bestDistance) {
-      best = node;
-      bestDistance = distance;
-    }
-  }
-  return best;
-}
-function selectGraphNode(id){
-  const n = byId.get(id); if(!n) return;
-  state.selectedNodeId = n.id;
-  document.getElementById('graph-title').textContent = n.label;
-  const related = graph.edges.filter(e => e.from===n.id || e.to===n.id).map(e => e.type+' '+e.confidence+'\\n  '+e.from+'\\n  -> '+e.to).join('\\n\\n');
-  document.getElementById('graph-detail').innerHTML = '<pre>'+escapeHtml(JSON.stringify(n.meta, null, 2))+'</pre><h3>'+bi('连接边', 'Edges')+'</h3><pre>'+escapeHtml(related || bi('无连接边', 'No connected edges'))+'</pre>';
-  if (n.type === 'workspace') {
-    const report = byWorkspace.get(n.label);
-    if (report) { state.selected = report.path; renderDetail(); renderWorkspaces(); }
-  }
-  render();
 }
 function init(){
-  renderStaticText(); renderMeta(); renderMetrics(); renderHealth(); renderPriorityGaps(); renderReadingLoop(); renderWorkspaces(); renderGaps(); renderDetail(); applyNodeFilter();
+  renderStaticText(); renderMeta(); renderMetrics(); renderHealth(); renderPriorityGaps(); renderReadingLoop(); renderWorkspaces(); renderGaps(); renderDetail();
   document.querySelector('.language-switch').addEventListener('click', e => {
     const button = e.target.closest('button[data-lang]'); if(!button) return;
     state.lang = button.dataset.lang === 'en' ? 'en' : 'zh';
@@ -960,57 +868,8 @@ function init(){
     const copy = e.target.closest('button[data-copy]'); if(!copy) return;
     navigator.clipboard?.writeText(copy.dataset.copy).then(() => { copy.textContent = bi('已复制', 'Copied'); setTimeout(() => { copy.textContent = bi('复制', 'Copy'); }, 1100); });
   });
-  document.getElementById('toggle-graph').onclick = () => { running = !running; document.getElementById('toggle-graph').textContent = running ? t('pauseGraph') : t('resumeGraph'); };
-  document.querySelector('#graph .filters').addEventListener('click', e => {
-    const button = e.target.closest('button[data-node-filter]'); if(!button) return;
-    state.nodeFilter = button.dataset.nodeFilter;
-    document.querySelectorAll('button[data-node-filter]').forEach(item => item.classList.toggle('active', item === button));
-    applyNodeFilter(); render();
-  });
 }
-function tick(){
-  if(running && svg){
-    const width = svg.clientWidth || 800, height = svg.clientHeight || 360;
-    for(const n of nodes){ n.vx += (width/2 - n.x)*0.0007; n.vy += (height/2 - n.y)*0.0007; }
-    for(let i=0;i<nodes.length;i++) for(let j=i+1;j<nodes.length;j++){
-      const a=nodes[i], b=nodes[j]; let dx=a.x-b.x, dy=a.y-b.y, d=Math.max(24, Math.hypot(dx,dy)); const f=1200/(d*d); a.vx+=dx/d*f; a.vy+=dy/d*f; b.vx-=dx/d*f; b.vy-=dy/d*f;
-    }
-    for(const e of edges){ const a=e.source,b=e.target; let dx=b.x-a.x, dy=b.y-a.y, d=Math.max(1, Math.hypot(dx,dy)); const f=(d-120)*0.005; a.vx+=dx/d*f; a.vy+=dy/d*f; b.vx-=dx/d*f; b.vy-=dy/d*f; }
-    for(const n of nodes){ n.vx*=.82; n.vy*=.82; n.x=Math.max(20,Math.min(width-20,n.x+n.vx)); n.y=Math.max(20,Math.min(height-20,n.y+n.vy)); }
-  }
-  render(); requestAnimationFrame(tick);
-}
-function render(){
-  if(!svg) return;
-  while(svg.firstChild) svg.removeChild(svg.firstChild);
-  const frag = document.createDocumentFragment();
-  for(const e of edges){
-    if(!e.source.visible || !e.target.visible) continue;
-    const line = document.createElementNS('http://www.w3.org/2000/svg','line'); line.setAttribute('class','edge '+e.confidence); line.setAttribute('x1',e.source.x); line.setAttribute('y1',e.source.y); line.setAttribute('x2',e.target.x); line.setAttribute('y2',e.target.y); frag.appendChild(line);
-  }
-  for(const n of nodes){
-    if(!n.visible) continue;
-    const t = document.createElementNS('http://www.w3.org/2000/svg','text'); t.setAttribute('class','node-label '+(state.selectedNodeId === n.id ? 'selected' : '')); t.dataset.nodeId=n.id; t.setAttribute('x',n.x+radius(n)+5); t.setAttribute('y',n.y+4); t.textContent=n.label;
-    frag.appendChild(t);
-  }
-  for(const n of nodes){
-    if(!n.visible) continue;
-    const g = document.createElementNS('http://www.w3.org/2000/svg','g'); g.setAttribute('class','node '+(state.selectedNodeId === n.id ? 'selected' : '')); g.dataset.nodeId=n.id; g.setAttribute('transform','translate('+n.x+','+n.y+')');
-    const c = document.createElementNS('http://www.w3.org/2000/svg','circle'); c.setAttribute('class','node-dot'); c.setAttribute('r',radius(n)); c.setAttribute('fill',colors[n.type]||'#ddd');
-    g.appendChild(c); frag.appendChild(g);
-  }
-  svg.appendChild(frag);
-}
-svg.addEventListener('click', e => {
-  const target = e.target.closest?.('[data-node-id]');
-  if(target) {
-    selectGraphNode(target.dataset.nodeId);
-    return;
-  }
-  const nearest = nearestVisibleNode(graphPointFromEvent(e));
-  if(nearest) selectGraphNode(nearest.id);
-});
-init(); tick();
+init();
 </script>
 </body>
 </html>`;
@@ -1051,13 +910,13 @@ const server = http.createServer((req, res) => {
   res.end(html(graph));
 });
 server.listen(preferredPort, '127.0.0.1', () => {
-  console.log(`Harness graph viewer: http://127.0.0.1:${preferredPort}`);
+  console.log(`Harness dashboard: http://127.0.0.1:${preferredPort}`);
 });
 server.on('error', (error) => {
   if (error.code === 'EADDRINUSE') {
     server.listen(0, '127.0.0.1', () => {
       const address = server.address();
-      console.log(`Harness graph viewer: http://127.0.0.1:${address.port}`);
+      console.log(`Harness dashboard: http://127.0.0.1:${address.port}`);
     });
     return;
   }

--- a/harness/tools/graph-viewer/server.mjs
+++ b/harness/tools/graph-viewer/server.mjs
@@ -459,124 +459,165 @@ function html(graph) {
 <style>
 :root {
   color-scheme: dark;
-  --bg:#0f1115;
-  --panel:#171a20;
-  --panel-2:#1e232b;
-  --panel-3:#242a33;
-  --line:#343b47;
-  --text:#eef2f7;
-  --muted:#9ea9b8;
-  --blue:#7db7ff;
-  --green:#7ee2a8;
-  --yellow:#f3cd6b;
-  --red:#ff7a70;
-  --purple:#c8a2ff;
-  --teal:#7ee4df;
+  --bg:#010102;
+  --panel:#0f1011;
+  --panel-2:#141516;
+  --panel-3:#18191a;
+  --panel-4:#191a1b;
+  --line:#23252a;
+  --line-strong:#34343a;
+  --text:#f7f8f8;
+  --text-secondary:#d0d6e0;
+  --muted:#8a8f98;
+  --faint:#62666d;
+  --blue:#5e6ad2;
+  --blue-active:#5e69d1;
+  --blue-hover:#828fff;
+  --blue-soft:rgba(94,106,210,0.14);
+  --green:#27a644;
+  --surface-edge:inset 0 1px 0 rgba(255,255,255,0.04);
 }
 * { box-sizing: border-box; }
 body {
   margin:0;
   background:var(--bg);
   color:var(--text);
-  font:14px/1.45 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font:14px/1.5 Inter, "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing:antialiased;
 }
 body.drawer-open { overflow:hidden; }
 button, input { font:inherit; }
-.topbar { border-bottom:1px solid var(--line); background:#12151a; padding:18px 24px; }
+.topbar {
+  position:sticky;
+  top:0;
+  z-index:10;
+  border-bottom:1px solid var(--line);
+  background:rgba(1,1,2,0.86);
+  padding:16px 28px;
+  backdrop-filter:saturate(180%) blur(14px);
+}
 .topline { display:flex; justify-content:space-between; align-items:flex-start; gap:16px; }
-h1 { margin:0; font-size:24px; line-height:1.15; letter-spacing:0; }
-h2 { margin:0 0 12px; font-size:15px; letter-spacing:0; }
-h3 { margin:0 0 8px; font-size:13px; color:var(--muted); letter-spacing:0; text-transform:uppercase; }
+h1 { margin:0; font-size:28px; line-height:1.15; letter-spacing:0; font-weight:600; }
+h2 { margin:0 0 14px; font-size:22px; line-height:1.25; letter-spacing:0; font-weight:500; }
+h3 { margin:0 0 10px; font-size:12px; color:var(--muted); letter-spacing:0; text-transform:uppercase; font-weight:500; }
 .sub { color:var(--muted); margin-top:6px; max-width:880px; }
 .meta { color:var(--muted); font-size:12px; text-align:right; white-space:nowrap; }
 .meta-panel { display:grid; gap:8px; justify-items:end; }
 .language-switch { display:flex; gap:6px; justify-content:flex-end; }
-.language-switch button { min-height:30px; padding:6px 9px; font-size:12px; }
+.language-switch button { min-height:30px; padding:5px 12px; font-size:12px; border-radius:999px; }
 .tabs { display:flex; gap:8px; flex-wrap:wrap; margin-top:16px; }
 button {
   border:1px solid var(--line);
   background:var(--panel);
   color:var(--text);
-  padding:8px 10px;
-  border-radius:6px;
+  padding:8px 14px;
+  border-radius:8px;
   cursor:pointer;
-  min-height:34px;
+  min-height:38px;
+  font-weight:500;
 }
-button:hover, button.active { border-color:var(--blue); color:var(--blue); }
+button:hover { background:var(--panel-2); border-color:var(--line-strong); color:var(--text); }
+button:focus-visible,
+.workspace-card:focus-visible,
+.gap-row.actionable:focus-visible,
+.gap-group-header:focus-visible,
+.search:focus-visible {
+  outline:0;
+  border-color:var(--blue-active);
+  box-shadow:0 0 0 3px rgba(94,106,210,0.28);
+}
+button.active,
+.tabs button.active,
+.filters button.active,
+.language-switch button.active {
+  background:var(--panel-2);
+  border-color:var(--line-strong);
+  color:var(--text);
+}
 .shell { display:grid; grid-template-columns:1fr; gap:0; min-height:calc(100vh - 115px); }
-main { min-width:0; padding:22px 24px 36px; }
+main { min-width:0; width:min(1280px, 100%); margin:0 auto; padding:28px 28px 44px; }
 .view { display:none; }
 .view.active { display:block; }
-.metrics { display:grid; grid-template-columns:repeat(4, minmax(150px, 1fr)); gap:12px; margin-bottom:18px; }
-.metric { background:var(--panel); border:1px solid var(--line); border-radius:8px; padding:14px; min-height:88px; }
-.metric b { display:block; font-size:25px; line-height:1.1; margin-bottom:7px; }
-.metric span { color:var(--muted); font-size:12px; }
+.metrics { display:grid; grid-template-columns:repeat(4, minmax(150px, 1fr)); gap:14px; margin-bottom:18px; }
+.metric { background:var(--panel); border:1px solid var(--line); border-radius:12px; padding:18px; min-height:104px; box-shadow:var(--surface-edge); }
+.metric b { display:block; font-size:30px; line-height:1.05; margin-bottom:9px; letter-spacing:0; }
+.metric span { color:var(--muted); font-size:12px; font-weight:600; line-height:1.33; }
+.metric .muted { margin-top:4px; font-size:13px; color:var(--text-secondary); }
 .metric.good b { color:var(--green); }
-.metric.warn b { color:var(--yellow); }
-.metric.bad b { color:var(--red); }
+.metric.warn b,
+.metric.bad b { color:var(--blue-hover); }
 .grid-2 { display:grid; grid-template-columns:1fr 1fr; gap:14px; }
-.panel { background:var(--panel); border:1px solid var(--line); border-radius:8px; padding:16px; margin-bottom:14px; }
-.coverage-bar { height:10px; background:#0c0f13; border:1px solid var(--line); border-radius:8px; overflow:hidden; }
-.coverage-bar span { display:block; height:100%; background:linear-gradient(90deg, var(--green), var(--blue)); }
+.panel { background:var(--panel); border:1px solid var(--line); border-radius:12px; padding:20px; margin-bottom:16px; box-shadow:var(--surface-edge); }
+.coverage-bar { height:10px; background:var(--panel-3); border:1px solid var(--line); border-radius:999px; overflow:hidden; }
+.coverage-bar span { display:block; height:100%; background:var(--blue); }
 .compact-list { display:grid; gap:8px; }
 .compact-row, .workspace-card, .gap-row {
   border:1px solid var(--line);
   background:var(--panel-2);
-  border-radius:8px;
+  border-radius:10px;
   padding:12px;
 }
-.workspace-card { cursor:pointer; min-height:158px; display:grid; gap:10px; align-content:start; }
-.workspace-card:hover, .workspace-card:focus, .workspace-card.active { border-color:var(--blue); outline:0; }
+.workspace-card { position:relative; cursor:pointer; min-height:154px; display:grid; gap:10px; align-content:start; background:var(--panel); border-radius:12px; box-shadow:var(--surface-edge); }
+.workspace-card::before { content:""; position:absolute; top:13px; left:13px; width:8px; height:8px; border-radius:999px; background:var(--faint); }
+.workspace-card.ready::before { background:var(--green); }
+.workspace-card.partial::before { background:var(--blue); }
+.workspace-card.missing::before { background:var(--blue-hover); }
+.workspace-card .row-title { padding-left:16px; }
+.workspace-card:hover, .workspace-card:focus, .workspace-card.active { background:var(--panel-2); border-color:var(--line-strong); outline:0; }
+.workspace-card.active { background:var(--blue-soft); }
 .workspace-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(280px, 1fr)); gap:12px; }
 .filters { display:flex; gap:10px; flex-wrap:wrap; align-items:center; margin-bottom:14px; }
-.search { flex:1; min-width:240px; border:1px solid var(--line); background:#101319; color:var(--text); border-radius:6px; padding:9px 10px; min-height:38px; }
+.search { flex:1; min-width:240px; border:1px solid var(--line); background:var(--panel); color:var(--text); border-radius:6px; padding:9px 10px; min-height:38px; }
+.search:focus { outline:0; border-color:var(--blue-active); box-shadow:0 0 0 3px rgba(94,106,210,0.28); }
 .badges { display:flex; flex-wrap:wrap; gap:6px; }
-.badge { border:1px solid var(--line); border-radius:999px; padding:3px 7px; color:var(--muted); font-size:12px; line-height:1.2; }
-.badge.ready { color:var(--green); border-color:#35634b; }
-.badge.partial { color:var(--yellow); border-color:#6a5730; }
-.badge.missing { color:var(--red); border-color:#703c38; }
-.badge.info { color:var(--blue); border-color:#355475; }
+.badge { border:1px solid var(--line); background:var(--panel-2); border-radius:999px; padding:3px 8px; color:var(--text-secondary); font-size:12px; line-height:1.2; font-weight:500; }
+.badge.ready { color:var(--green); border-color:rgba(39,166,68,0.34); }
+.badge.partial { color:var(--text-secondary); border-color:var(--line-strong); }
+.badge.missing { color:var(--blue-hover); border-color:rgba(94,106,210,0.46); }
+.badge.info { color:var(--blue-hover); border-color:rgba(94,106,210,0.42); }
 .path { font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; word-break:break-word; }
 .muted { color:var(--muted); }
 .row-title { display:flex; justify-content:space-between; gap:12px; align-items:flex-start; }
-.score { font-weight:700; color:var(--teal); }
+.score { font-weight:700; color:var(--blue); }
 .gap-groups { display:grid; gap:14px; }
-.gap-group { border:1px solid var(--line); border-radius:8px; overflow:hidden; background:#141922; }
-.gap-group-header { display:flex; justify-content:space-between; gap:14px; align-items:flex-start; padding:12px 14px; background:var(--panel-2); border-bottom:1px solid var(--line); }
+.gap-group { border:1px solid var(--line); border-radius:12px; overflow:hidden; background:var(--panel); box-shadow:var(--surface-edge); }
+.gap-group-header { display:flex; justify-content:space-between; gap:14px; align-items:flex-start; padding:14px 16px; background:var(--panel); border-bottom:1px solid var(--line); }
 .gap-group-header { cursor:pointer; }
-.gap-group-header:hover, .gap-group-header:focus { background:#202938; outline:0; }
+.gap-group-header:hover, .gap-group-header:focus { background:var(--panel-2); outline:0; }
 .gap-group-title { display:grid; gap:4px; min-width:0; }
 .gap-group-title strong { font-size:15px; }
 .gap-group-actions { display:grid; justify-items:end; gap:8px; }
 .gap-group-buttons { display:flex; justify-content:flex-end; gap:8px; flex-wrap:wrap; }
-.gap-group-body { padding:10px 12px 2px; }
+.gap-group-buttons [data-open-workspace] { background:var(--blue); border-color:var(--blue); color:#ffffff; border-radius:8px; }
+.gap-group-buttons [data-open-workspace]:hover { background:var(--blue-hover); border-color:var(--blue-hover); color:#ffffff; }
+.gap-group-body { padding:12px 14px 4px; background:var(--panel-2); }
 .gap-group.collapsed .gap-group-body { display:none; }
-.gap-group-body .gap-row { background:#171d26; }
+.gap-group-body .gap-row { background:var(--panel); box-shadow:var(--surface-edge); }
 .gap-row { display:grid; grid-template-columns:120px minmax(0, 1fr); gap:12px; margin-bottom:10px; }
 .gap-row.actionable { cursor:pointer; }
-.gap-row.actionable:hover, .gap-row.actionable:focus { border-color:var(--blue); background:#202938; outline:0; }
+.gap-row.actionable:hover, .gap-row.actionable:focus { border-color:var(--blue); background:var(--blue-soft); outline:0; }
 .gap-row-path { display:flex; flex-wrap:wrap; gap:6px; align-items:baseline; margin-top:2px; }
 .severity { font-weight:700; }
-.severity.high { color:var(--red); }
-.severity.medium { color:var(--yellow); }
+.severity.high { color:var(--blue-hover); }
+.severity.medium { color:var(--text-secondary); }
 .command { display:grid; grid-template-columns:minmax(0, 1fr) auto; gap:8px; align-items:center; margin-bottom:8px; }
 .command code, code, pre { font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
-.command code { display:block; background:#0c0f13; border:1px solid var(--line); border-radius:6px; padding:8px; overflow:auto; white-space:pre-wrap; word-break:break-word; }
-pre { white-space:pre-wrap; word-break:break-word; background:#0c0f13; border:1px solid var(--line); border-radius:6px; padding:10px; color:#dce5ef; margin:0; }
+.command code { display:block; background:var(--panel-2); border:1px solid var(--line); border-radius:6px; padding:8px; overflow:auto; white-space:pre-wrap; word-break:break-word; color:var(--text); }
+pre { white-space:pre-wrap; word-break:break-word; background:var(--panel-2); border:1px solid var(--line); border-radius:6px; padding:10px; color:var(--text); margin:0; }
 .mini-table { display:grid; gap:8px; }
 .mini-row { display:grid; grid-template-columns:110px minmax(0, 1fr); gap:10px; padding:8px 0; border-bottom:1px solid var(--line); }
 .mini-row:last-child { border-bottom:0; }
 .reading { display:grid; gap:8px; counter-reset:readstep; }
-.reading div { border:1px solid var(--line); background:var(--panel-2); border-radius:6px; padding:8px; }
+.reading div { border:1px solid var(--line); background:var(--panel-2); border-radius:8px; padding:8px; }
 .reading div::before { counter-increment:readstep; content:counter(readstep) ". "; color:var(--blue); font-weight:700; }
-.empty { color:var(--muted); border:1px dashed var(--line); border-radius:8px; padding:16px; }
+.empty { color:var(--muted); border:1px dashed var(--line); background:var(--panel-2); border-radius:12px; padding:18px; }
 .drawer-backdrop {
   position:fixed;
   inset:0;
   z-index:30;
   display:flex;
   justify-content:flex-end;
-  background:rgba(5, 8, 13, 0.72);
+  background:rgba(0, 0, 0, 0.72);
 }
 .drawer-backdrop[hidden] { display:none; }
 .drawer-panel {
@@ -585,7 +626,7 @@ pre { white-space:pre-wrap; word-break:break-word; background:#0c0f13; border:1p
   overflow:auto;
   border-left:1px solid var(--line);
   background:var(--panel);
-  box-shadow:-24px 0 80px rgba(0, 0, 0, 0.45);
+  box-shadow:var(--surface-edge);
 }
 .drawer-header {
   position:sticky;
@@ -597,8 +638,10 @@ pre { white-space:pre-wrap; word-break:break-word; background:#0c0f13; border:1p
   align-items:flex-start;
   padding:16px;
   border-bottom:1px solid var(--line);
-  background:var(--panel);
+  background:rgba(15,16,17,0.94);
+  backdrop-filter:saturate(180%) blur(14px);
 }
+.drawer-header h2 { margin:0; font-size:18px; word-break:break-word; }
 .drawer-body { padding:16px; }
 @media (max-width: 1180px) {
   .shell, .grid-2 { grid-template-columns:1fr; }
@@ -860,7 +903,7 @@ function filteredReports(){
 function renderWorkspaceCard(report){
   const gapText = report.gaps.length === 0 ? bi('无缺失项', 'No missing items') : countLabel(report.gaps.length, ' 个缺失项', 'missing item', 'missing items');
   const commandCount = countLabel(report.commands.length, ' 条命令', 'command', 'commands');
-  return '<article class="workspace-card '+(state.selected === report.path ? 'active' : '')+'" data-workspace="'+escapeHtml(report.path)+'" tabindex="0">'+
+  return '<article class="workspace-card '+escapeHtml(report.status)+' '+(state.selected === report.path ? 'active' : '')+'" data-workspace="'+escapeHtml(report.path)+'" tabindex="0">'+
     '<div class="row-title"><strong class="path">'+escapeHtml(report.path)+'</strong><span class="score">'+report.score+'</span></div>'+
     '<div class="muted">'+escapeHtml(report.role)+' / '+escapeHtml(report.packageName)+'</div>'+
     '<div class="badges">'+statusBadge(report.status)+'<span class="badge info">'+escapeHtml(report.type)+'</span><span class="badge">'+commandCount+'</span></div>'+

--- a/harness/tools/graph-viewer/server.mjs
+++ b/harness/tools/graph-viewer/server.mjs
@@ -503,6 +503,8 @@ button {
 }
 button:hover, button.active { border-color:var(--blue); color:var(--blue); }
 .shell { display:grid; grid-template-columns:minmax(0, 1fr) minmax(360px, 420px); gap:0; min-height:calc(100vh - 115px); }
+.shell.graph-mode { grid-template-columns:1fr; }
+.shell.graph-mode .detail { display:none; }
 main { min-width:0; padding:22px 24px 36px; }
 .detail { border-left:1px solid var(--line); background:var(--panel); padding:22px; overflow:auto; }
 .view { display:none; }
@@ -555,16 +557,16 @@ pre { white-space:pre-wrap; word-break:break-word; background:#0c0f13; border:1p
 .reading div { border:1px solid var(--line); background:var(--panel-2); border-radius:6px; padding:8px; }
 .reading div::before { counter-increment:readstep; content:counter(readstep) ". "; color:var(--blue); font-weight:700; }
 .graph-layout { display:grid; grid-template-columns:minmax(0, 1fr) 320px; gap:14px; }
-.graph-box { height:520px; border:1px solid var(--line); border-radius:8px; background:#0b0e13; position:relative; overflow:hidden; }
+.graph-box { height:560px; border:1px solid var(--line); border-radius:8px; background:#0b0e13; position:relative; overflow:hidden; }
+.shell.graph-mode .graph-box { min-height:560px; height:min(680px, calc(100vh - 260px)); }
 svg { width:100%; height:100%; display:block; }
-.edge { stroke:#596373; stroke-width:1.1; opacity:.38; }
+.edge { stroke:#596373; stroke-width:1.1; opacity:.38; pointer-events:none; }
 .edge.high { stroke:var(--blue); opacity:.62; }
 .node { cursor:pointer; }
-.node .hit { fill:transparent; stroke:transparent; pointer-events:all; }
 .node .node-dot { stroke:#090b0e; stroke-width:2; }
-.node text { fill:var(--text); font-size:10px; paint-order:stroke; stroke:#0b0e13; stroke-width:4px; pointer-events:all; cursor:pointer; }
+.node-label { fill:var(--text); font-size:10px; paint-order:stroke; stroke:#0b0e13; stroke-width:4px; pointer-events:all; cursor:pointer; }
 .node.selected .node-dot { stroke:var(--text); stroke-width:3; }
-.node.selected text { fill:var(--blue); }
+.node-label.selected { fill:var(--blue); }
 .empty { color:var(--muted); border:1px dashed var(--line); border-radius:8px; padding:16px; }
 @media (max-width: 1180px) {
   .shell, .grid-2, .graph-layout { grid-template-columns:1fr; }
@@ -899,6 +901,7 @@ function renderDetail(){
 function showTab(tab){
   document.querySelectorAll('.tabs button').forEach(button => button.classList.toggle('active', button.dataset.tab === tab));
   document.querySelectorAll('.view').forEach(view => view.classList.toggle('active', view.id === tab));
+  document.querySelector('.shell').classList.toggle('graph-mode', tab === 'graph');
 }
 function applyNodeFilter(){
   for (const node of nodes) node.visible = state.nodeFilter === 'all' || node.type === state.nodeFilter || (state.nodeFilter === 'validation' && node.type === 'profile');
@@ -987,18 +990,21 @@ function render(){
   }
   for(const n of nodes){
     if(!n.visible) continue;
-    const g = document.createElementNS('http://www.w3.org/2000/svg','g'); g.setAttribute('class','node '+(state.selectedNodeId === n.id ? 'selected' : '')); g.dataset.id=n.id; g.setAttribute('transform','translate('+n.x+','+n.y+')');
-    const hit = document.createElementNS('http://www.w3.org/2000/svg','circle'); hit.setAttribute('class','hit'); hit.setAttribute('r',Math.max(22, radius(n) + 12));
+    const t = document.createElementNS('http://www.w3.org/2000/svg','text'); t.setAttribute('class','node-label '+(state.selectedNodeId === n.id ? 'selected' : '')); t.dataset.nodeId=n.id; t.setAttribute('x',n.x+radius(n)+5); t.setAttribute('y',n.y+4); t.textContent=n.label;
+    frag.appendChild(t);
+  }
+  for(const n of nodes){
+    if(!n.visible) continue;
+    const g = document.createElementNS('http://www.w3.org/2000/svg','g'); g.setAttribute('class','node '+(state.selectedNodeId === n.id ? 'selected' : '')); g.dataset.nodeId=n.id; g.setAttribute('transform','translate('+n.x+','+n.y+')');
     const c = document.createElementNS('http://www.w3.org/2000/svg','circle'); c.setAttribute('class','node-dot'); c.setAttribute('r',radius(n)); c.setAttribute('fill',colors[n.type]||'#ddd');
-    const t = document.createElementNS('http://www.w3.org/2000/svg','text'); t.setAttribute('x',radius(n)+5); t.setAttribute('y',4); t.textContent=n.label;
-    g.appendChild(hit); g.appendChild(c); g.appendChild(t); frag.appendChild(g);
+    g.appendChild(c); frag.appendChild(g);
   }
   svg.appendChild(frag);
 }
 svg.addEventListener('click', e => {
-  const g = e.target.closest?.('.node');
-  if(g) {
-    selectGraphNode(g.dataset.id);
+  const target = e.target.closest?.('[data-node-id]');
+  if(target) {
+    selectGraphNode(target.dataset.nodeId);
     return;
   }
   const nearest = nearestVisibleNode(graphPointFromEvent(e));

--- a/harness/tools/graph-viewer/server.mjs
+++ b/harness/tools/graph-viewer/server.mjs
@@ -1,0 +1,441 @@
+#!/usr/bin/env node
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+
+function readText(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+function exists(relativePath) {
+  return fs.existsSync(path.join(repoRoot, relativePath));
+}
+
+function listFiles(relativeDir, predicate) {
+  const dir = path.join(repoRoot, relativeDir);
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => path.join(relativeDir, entry.name))
+    .filter(predicate ?? (() => true));
+}
+
+function listDirs(relativeDir) {
+  const dir = path.join(repoRoot, relativeDir);
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(relativeDir, entry.name));
+}
+
+function parseScalar(value) {
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1);
+  }
+  if (trimmed === 'true') return true;
+  if (trimmed === 'false') return false;
+  if (/^-?\d+(?:\.\d+)?$/.test(trimmed)) return Number(trimmed);
+  return trimmed;
+}
+
+function parseSimpleYaml(text) {
+  const root = {};
+  const stack = [{ indent: -1, value: root }];
+  const lines = text.split(/\r?\n/);
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const raw = lines[i];
+    if (!raw.trim() || raw.trimStart().startsWith('#')) continue;
+    const indent = raw.match(/^\s*/)[0].length;
+    const line = raw.trim();
+
+    while (stack.length > 1 && indent <= stack[stack.length - 1].indent) stack.pop();
+    const parent = stack[stack.length - 1].value;
+
+    if (line.startsWith('- ')) {
+      if (!Array.isArray(parent)) continue;
+      const itemText = line.slice(2).trim();
+      if (!itemText) {
+        const obj = {};
+        parent.push(obj);
+        stack.push({ indent, value: obj });
+      } else if (itemText.includes(': ')) {
+        const [key, ...rest] = itemText.split(':');
+        const obj = { [key.trim()]: parseScalar(rest.join(':')) };
+        parent.push(obj);
+        stack.push({ indent, value: obj });
+      } else {
+        parent.push(parseScalar(itemText));
+      }
+      continue;
+    }
+
+    const match = line.match(/^([^:]+):(.*)$/);
+    if (!match) continue;
+    const key = match[1].trim();
+    const rest = match[2].trim();
+
+    if (rest) {
+      parent[key] = parseScalar(rest);
+      continue;
+    }
+
+    const next = lines.slice(i + 1).find((candidate) => candidate.trim() && !candidate.trimStart().startsWith('#'));
+    const nextTrim = next?.trim() ?? '';
+    const container = nextTrim.startsWith('- ') ? [] : {};
+    parent[key] = container;
+    stack.push({ indent, value: container });
+  }
+
+  return root;
+}
+
+function parseFrontmatter(text) {
+  if (!text.startsWith('---')) return {};
+  const end = text.indexOf('\n---', 3);
+  if (end === -1) return {};
+  return parseSimpleYaml(text.slice(3, end));
+}
+
+function titleFromMarkdown(text) {
+  return text.split(/\r?\n/).find((line) => line.startsWith('# '))?.replace(/^#\s+/, '').trim();
+}
+
+function extractPathRefs(text) {
+  const refs = new Set();
+  const patterns = [
+    /`((?:\.\.\/|\.\/|[\w.-]+\/)[^`\n]+?)`/g,
+    /\[[^\]]+\]\(([^)]+)\)/g,
+  ];
+  for (const pattern of patterns) {
+    for (const match of text.matchAll(pattern)) {
+      const value = match[1].replace(/^\.\//, '').split('#')[0];
+      if (/^(https?:|mailto:)/.test(value)) continue;
+      if (value.includes(' ') && !value.includes('/')) continue;
+      refs.add(value);
+    }
+  }
+  return [...refs];
+}
+
+function nodeId(type, id) {
+  return `${type}:${id}`;
+}
+
+function buildGraph() {
+  const nodes = new Map();
+  const edges = [];
+
+  function addNode(id, type, label, meta = {}) {
+    if (!nodes.has(id)) nodes.set(id, { id, type, label, meta });
+    return nodes.get(id);
+  }
+
+  function addEdge(from, to, type, confidence = 'high', meta = {}) {
+    if (!nodes.has(from) || !nodes.has(to)) return;
+    edges.push({ from, to, type, confidence, meta });
+  }
+
+  addNode(nodeId('root', 'AGENTS.md'), 'root', 'AGENTS.md', { path: 'AGENTS.md' });
+  addNode(nodeId('root', 'CLAUDE.md'), 'root', 'CLAUDE.md', { path: 'CLAUDE.md' });
+  addNode(nodeId('harness', 'README.md'), 'harness', 'harness/README.md', { path: 'harness/README.md' });
+  addNode(nodeId('harness', 'profile.yaml'), 'profile', 'profile.yaml', { path: 'harness/profile.yaml' });
+  addNode(nodeId('harness', 'validation.yaml'), 'validation', 'validation.yaml', { path: 'harness/validation.yaml' });
+  addEdge(nodeId('root', 'AGENTS.md'), nodeId('harness', 'README.md'), 'routes_to');
+  addEdge(nodeId('root', 'CLAUDE.md'), nodeId('harness', 'README.md'), 'routes_to');
+  addEdge(nodeId('harness', 'README.md'), nodeId('harness', 'profile.yaml'), 'routes_to');
+  addEdge(nodeId('harness', 'README.md'), nodeId('harness', 'validation.yaml'), 'routes_to');
+
+  const profile = parseSimpleYaml(readText('harness/profile.yaml'));
+  const validation = parseSimpleYaml(readText('harness/validation.yaml'));
+
+  for (const [workspacePath, workspace] of Object.entries(profile.workspaces ?? {})) {
+    const wid = nodeId('workspace', workspacePath);
+    addNode(wid, 'workspace', workspacePath, { path: workspacePath, ...workspace });
+    addEdge(nodeId('harness', 'profile.yaml'), wid, 'maps_workspace');
+
+    if (workspace.entry) {
+      const eid = nodeId('entry', workspace.entry);
+      addNode(eid, exists(workspace.entry) ? 'entry' : 'gap', path.basename(workspace.entry), { path: workspace.entry, exists: exists(workspace.entry) });
+      addEdge(wid, eid, exists(workspace.entry) ? 'has_entry' : 'missing', exists(workspace.entry) ? 'high' : 'high');
+    }
+
+    for (const [kind, target] of Object.entries(workspace.knowledge ?? {})) {
+      if (typeof target !== 'string') continue;
+      const kid = nodeId('knowledge', target);
+      addNode(kid, exists(target) ? 'knowledge' : 'gap', `${kind}: ${path.basename(target)}`, { path: target, kind, exists: exists(target) });
+      addEdge(wid, kid, exists(target) ? 'has_knowledge' : 'missing', exists(target) ? 'high' : 'high', { kind });
+    }
+  }
+
+  for (const rule of validation.pathRules ?? []) {
+    if (!rule?.name) continue;
+    const rid = nodeId('validation-rule', rule.name);
+    addNode(rid, 'validation', rule.name, { paths: rule.paths ?? [], required: rule.required ?? [] });
+    addEdge(nodeId('harness', 'validation.yaml'), rid, 'defines_validation');
+    const workspace = Object.keys(profile.workspaces ?? {}).find((candidate) => (rule.paths ?? []).some((p) => p.startsWith(candidate)));
+    if (workspace) addEdge(rid, nodeId('workspace', workspace), 'validates');
+  }
+
+  for (const file of listFiles('harness/skills', (f) => f.endsWith('.md') && !f.endsWith('/README.md'))) {
+    const text = readText(file);
+    const fm = parseFrontmatter(text);
+    const sid = nodeId('skill', file);
+    addNode(sid, 'skill', fm.name ?? titleFromMarkdown(text) ?? path.basename(file), { path: file, description: fm.description ?? '' });
+    addEdge(nodeId('harness', 'README.md'), sid, 'defines_action');
+  }
+
+  for (const dir of listDirs('harness/tools')) {
+    const readme = path.join(dir, 'README.md');
+    if (readme.endsWith('graph-viewer/README.md')) continue;
+    if (!exists(readme)) continue;
+    const text = readText(readme);
+    const tid = nodeId('tool', dir);
+    addNode(tid, 'tool', path.basename(dir), { path: readme, title: titleFromMarkdown(text) ?? path.basename(dir) });
+    addEdge(nodeId('harness', 'README.md'), tid, 'defines_tool');
+  }
+
+  const markdownFiles = [
+    'harness/README.md',
+    ...listFiles('harness/skills', (f) => f.endsWith('.md')),
+    ...listDirs('harness/tools').map((dir) => path.join(dir, 'README.md')).filter(exists),
+  ];
+
+  const knownPaths = new Map();
+  for (const node of nodes.values()) {
+    if (node.meta?.path) knownPaths.set(node.meta.path, node.id);
+  }
+
+  for (const file of markdownFiles) {
+    const from = knownPaths.get(file) ?? [...nodes.values()].find((node) => node.meta?.path === file)?.id;
+    if (!from) continue;
+    for (const ref of extractPathRefs(readText(file))) {
+      const normalized = path.normalize(path.join(path.dirname(file), ref)).replaceAll('\\', '/');
+      const direct = knownPaths.get(ref) ?? knownPaths.get(normalized);
+      if (direct) addEdge(from, direct, 'references', 'medium', { ref });
+    }
+  }
+
+  const nodeList = [...nodes.values()];
+  const gapCount = nodeList.filter((node) => node.type === 'gap').length;
+  return {
+    generatedAt: new Date().toISOString(),
+    summary: {
+      nodes: nodeList.length,
+      edges: edges.length,
+      workspaces: nodeList.filter((node) => node.type === 'workspace').length,
+      skills: nodeList.filter((node) => node.type === 'skill').length,
+      tools: nodeList.filter((node) => node.type === 'tool').length,
+      gaps: gapCount,
+    },
+    nodes: nodeList,
+    edges,
+  };
+}
+
+function html(graph) {
+  const graphJson = JSON.stringify(graph).replaceAll('<', '\\u003c');
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Harness Map</title>
+<style>
+:root { color-scheme: dark; --bg:#10120f; --panel:#181c15; --panel2:#20251b; --line:#35402f; --text:#eef6df; --muted:#a9b69a; --accent:#d7ff5f; --blue:#7cc7ff; --green:#79e08e; --yellow:#f3d36b; --purple:#c796ff; --red:#ff6d61; }
+* { box-sizing: border-box; }
+body { margin:0; background:var(--bg); color:var(--text); font:14px/1.45 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
+.app { min-height:100vh; display:grid; grid-template-columns: 380px 1fr 340px; }
+aside, main { border-right:1px solid var(--line); }
+aside { padding:18px; overflow:auto; background:var(--panel); }
+main { padding:18px; overflow:auto; background:radial-gradient(circle at 15% 5%, #26311d 0 12%, transparent 30%), #11140f; }
+h1 { margin:0 0 4px; font-size:26px; letter-spacing:.02em; }
+h2 { margin:18px 0 10px; color:var(--accent); font-size:15px; }
+.sub { color:var(--muted); margin-bottom:16px; }
+.stats { display:grid; grid-template-columns: repeat(2, 1fr); gap:8px; }
+.stat { background:var(--panel2); border:1px solid var(--line); padding:10px; }
+.stat b { display:block; color:var(--accent); font-size:20px; }
+.row { display:grid; grid-template-columns: 1fr auto; gap:10px; align-items:center; padding:9px; border:1px solid var(--line); background:#141812; margin-bottom:7px; cursor:pointer; }
+.row:hover, .row.active { border-color:var(--accent); }
+.row small { color:var(--muted); display:block; margin-top:3px; }
+.badges { display:flex; gap:5px; flex-wrap:wrap; justify-content:flex-end; }
+.badge { border:1px solid var(--line); padding:2px 5px; color:var(--muted); font-size:11px; }
+.badge.ok { color:var(--green); border-color:#406b48; }
+.badge.warn { color:var(--red); border-color:#7a4039; }
+.flow { display:grid; gap:12px; max-width:920px; }
+.step { border:1px solid var(--line); background:rgba(24,28,21,.86); padding:14px; position:relative; }
+.step:not(:last-child)::after { content:'↓'; position:absolute; left:20px; bottom:-22px; color:var(--accent); font-size:20px; }
+.step-title { color:var(--accent); font-weight:700; margin-bottom:4px; }
+.cards { display:grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap:10px; margin-top:12px; }
+.card { border:1px solid var(--line); background:var(--panel2); padding:12px; }
+.card strong { color:var(--yellow); }
+.graph-box { height:380px; margin-top:16px; border:1px solid var(--line); background:#0d100c; position:relative; overflow:hidden; }
+svg { width:100%; height:100%; display:block; }
+.edge { stroke:#59614f; stroke-width:1.1; opacity:.45; }
+.edge.high { stroke:var(--accent); opacity:.65; }
+.node circle { stroke:#0a0c09; stroke-width:2; }
+.node text { fill:var(--text); font-size:10px; paint-order:stroke; stroke:#0d100c; stroke-width:4px; }
+pre { white-space:pre-wrap; word-break:break-word; background:#0d100c; border:1px solid var(--line); padding:10px; color:#dce8cf; }
+.kv { color:var(--muted); }
+button { border:1px solid var(--line); background:#141812; color:var(--text); padding:7px 9px; font:inherit; cursor:pointer; }
+button.active { color:var(--accent); border-color:var(--accent); }
+</style>
+</head>
+<body>
+<div class="app">
+  <aside>
+    <h1>Harness Map</h1>
+    <div class="sub">Readable view of repository harness coverage and routing.</div>
+    <div class="stats" id="stats"></div>
+    <h2>Workspaces</h2>
+    <div id="workspace-list"></div>
+  </aside>
+  <main>
+    <h2>Main Loop</h2>
+    <section class="flow">
+      <div class="step"><div class="step-title">1. Route</div><div>Root entries route to <code>harness/profile.yaml</code>, then to the affected workspace entry.</div></div>
+      <div class="step"><div class="step-title">2. Read Knowledge</div><div>Workspace entries point to README, contracts, runbook, validation, or product docs as needed.</div></div>
+      <div class="step"><div class="step-title">3. Act</div><div>Common action protocols live in <code>harness/skills</code>; reusable atomic capabilities live in <code>harness/tools</code>.</div></div>
+      <div class="step"><div class="step-title">4. Validate</div><div><code>harness/validation.yaml</code> maps paths to validation rules and escalation points.</div></div>
+      <div class="step"><div class="step-title">5. Feed Back</div><div>Feedback starts in <code>harness/feedback</code>, then accepted facts move to the right long-term target.</div></div>
+    </section>
+    <h2>Action Surface</h2>
+    <div class="cards" id="surface"></div>
+    <h2>Graph Preview</h2>
+    <div><button id="toggle-graph">Pause graph</button></div>
+    <div class="graph-box"><svg id="graph" role="img" aria-label="Harness graph preview"></svg></div>
+  </main>
+  <aside>
+    <h2 id="detail-title">Select a workspace</h2>
+    <div id="detail-body" class="kv">Click a workspace on the left or a node in the graph.</div>
+    <h2>Connected Edges</h2>
+    <pre id="edge-list">No selection</pre>
+  </aside>
+</div>
+<script>
+const graph = ${graphJson};
+const colors = { root:'#d7ff5f', harness:'#ffad57', profile:'#ffad57', validation:'#ff7ab6', workspace:'#7cc7ff', entry:'#79e08e', knowledge:'#b5d98d', skill:'#f3d36b', tool:'#c796ff', gap:'#ff6d61' };
+const nodes = graph.nodes.map((n, i) => ({...n, x: 420 + Math.cos(i)*160, y: 190 + Math.sin(i)*130, vx:0, vy:0}));
+const byId = new Map(nodes.map(n => [n.id, n]));
+const edges = graph.edges.map(e => ({...e, source: byId.get(e.from), target: byId.get(e.to)})).filter(e => e.source && e.target);
+const svg = document.getElementById('graph');
+let running = true;
+
+function escapeHtml(s){ return String(s).replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c])); }
+function radius(n){ return n.type==='workspace'?10:n.type==='gap'?9:6; }
+function workspaceStatus(w){
+  const outgoing = graph.edges.filter(e => e.from === w.id);
+  const hasEntry = outgoing.some(e => e.type === 'has_entry');
+  const hasValidation = outgoing.some(e => e.meta?.kind === 'validation');
+  const hasContract = outgoing.some(e => e.meta?.kind === 'contracts' || e.meta?.kind === 'runbook');
+  return { hasEntry, hasValidation, hasContract };
+}
+function init(){
+  document.getElementById('stats').innerHTML = [['Workspaces',graph.summary.workspaces],['Skills',graph.summary.skills],['Tools',graph.summary.tools],['Gaps',graph.summary.gaps]].map(([k,v]) => '<div class="stat"><b>'+v+'</b>'+k+'</div>').join('');
+  const workspaces = graph.nodes.filter(n => n.type === 'workspace');
+  document.getElementById('workspace-list').innerHTML = workspaces.map(w => {
+    const s = workspaceStatus(w);
+    return '<div class="row" data-id="'+w.id+'"><div>'+escapeHtml(w.label)+'<small>'+escapeHtml(w.meta.role || '')+'</small></div><div class="badges">'+
+      '<span class="badge '+(s.hasEntry?'ok':'warn')+'">entry</span>'+
+      '<span class="badge '+(s.hasValidation?'ok':'')+'">validation</span>'+
+      '<span class="badge '+(s.hasContract?'ok':'')+'">contract/runbook</span>'+
+    '</div></div>';
+  }).join('');
+  document.getElementById('workspace-list').addEventListener('click', e => {
+    const row = e.target.closest('.row'); if(!row) return;
+    selectNode(row.dataset.id);
+    document.querySelectorAll('.row').forEach(r => r.classList.toggle('active', r === row));
+  });
+  document.getElementById('surface').innerHTML = [
+    ['Skills', graph.nodes.filter(n=>n.type==='skill').map(n=>n.label)],
+    ['Tools', graph.nodes.filter(n=>n.type==='tool').map(n=>n.label)],
+    ['Validation rules', graph.nodes.filter(n=>n.type==='validation').map(n=>n.label)]
+  ].map(([title, items]) => '<div class="card"><strong>'+title+'</strong><br>'+items.map(escapeHtml).join('<br>')+'</div>').join('');
+  document.getElementById('toggle-graph').onclick = () => { running = !running; document.getElementById('toggle-graph').textContent = running ? 'Pause graph' : 'Resume graph'; };
+}
+function selectNode(id){
+  const n = byId.get(id) || graph.nodes.find(x => x.id === id); if(!n) return;
+  document.getElementById('detail-title').textContent = n.label;
+  document.getElementById('detail-body').innerHTML = '<pre>'+escapeHtml(JSON.stringify(n.meta, null, 2))+'</pre>';
+  const related = graph.edges.filter(e => e.from===n.id || e.to===n.id).map(e => e.type+' '+e.confidence+'\\n  '+e.from+'\\n  -> '+e.to).join('\\n\\n');
+  document.getElementById('edge-list').textContent = related || 'No connected edges';
+}
+function tick(){
+  if(running){
+    const width = svg.clientWidth || 800, height = svg.clientHeight || 360;
+    for(const n of nodes){ n.vx += (width/2 - n.x)*0.0007; n.vy += (height/2 - n.y)*0.0007; }
+    for(let i=0;i<nodes.length;i++) for(let j=i+1;j<nodes.length;j++){
+      const a=nodes[i], b=nodes[j]; let dx=a.x-b.x, dy=a.y-b.y, d=Math.max(24, Math.hypot(dx,dy)); const f=1200/(d*d); a.vx+=dx/d*f; a.vy+=dy/d*f; b.vx-=dx/d*f; b.vy-=dy/d*f;
+    }
+    for(const e of edges){ const a=e.source,b=e.target; let dx=b.x-a.x, dy=b.y-a.y, d=Math.max(1, Math.hypot(dx,dy)); const f=(d-120)*0.005; a.vx+=dx/d*f; a.vy+=dy/d*f; b.vx-=dx/d*f; b.vy-=dy/d*f; }
+    for(const n of nodes){ n.vx*=.82; n.vy*=.82; n.x=Math.max(20,Math.min(width-20,n.x+n.vx)); n.y=Math.max(20,Math.min(height-20,n.y+n.vy)); }
+  }
+  render(); requestAnimationFrame(tick);
+}
+function render(){
+  while(svg.firstChild) svg.removeChild(svg.firstChild);
+  const frag = document.createDocumentFragment();
+  for(const e of edges){
+    const line = document.createElementNS('http://www.w3.org/2000/svg','line'); line.setAttribute('class','edge '+e.confidence); line.setAttribute('x1',e.source.x); line.setAttribute('y1',e.source.y); line.setAttribute('x2',e.target.x); line.setAttribute('y2',e.target.y); frag.appendChild(line);
+  }
+  for(const n of nodes){
+    const g = document.createElementNS('http://www.w3.org/2000/svg','g'); g.setAttribute('class','node'); g.dataset.id=n.id; g.setAttribute('transform','translate('+n.x+','+n.y+')');
+    const c = document.createElementNS('http://www.w3.org/2000/svg','circle'); c.setAttribute('r',radius(n)); c.setAttribute('fill',colors[n.type]||'#ddd');
+    const t = document.createElementNS('http://www.w3.org/2000/svg','text'); t.setAttribute('x',radius(n)+5); t.setAttribute('y',4); t.textContent=n.label;
+    g.appendChild(c); g.appendChild(t); frag.appendChild(g);
+  }
+  svg.appendChild(frag);
+}
+svg.addEventListener('click', e => { const g=e.target.closest('.node'); if(g) selectNode(g.dataset.id); });
+init(); tick();
+</script>
+</body>
+</html>`;
+}
+
+
+function printSummary(graph) {
+  console.log(JSON.stringify(graph.summary, null, 2));
+  const gaps = graph.nodes.filter((node) => node.type === 'gap');
+  if (gaps.length) {
+    console.log('\nGaps:');
+    for (const gap of gaps) console.log(`- ${gap.meta?.path ?? gap.id}`);
+  }
+}
+
+const graph = buildGraph();
+if (process.argv.includes('--once')) {
+  printSummary(graph);
+  process.exit(0);
+}
+
+const portArg = process.argv.find((arg) => arg.startsWith('--port='));
+const preferredPort = portArg ? Number(portArg.split('=')[1]) : 4177;
+const server = http.createServer((req, res) => {
+  if (req.url === '/graph.json') {
+    res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' });
+    res.end(JSON.stringify(graph, null, 2));
+    return;
+  }
+  res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+  res.end(html(graph));
+});
+server.listen(preferredPort, '127.0.0.1', () => {
+  console.log(`Harness graph viewer: http://127.0.0.1:${preferredPort}`);
+});
+server.on('error', (error) => {
+  if (error.code === 'EADDRINUSE') {
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      console.log(`Harness graph viewer: http://127.0.0.1:${address.port}`);
+    });
+    return;
+  }
+  throw error;
+});

--- a/harness/tools/graph-viewer/server.mjs
+++ b/harness/tools/graph-viewer/server.mjs
@@ -128,6 +128,194 @@ function nodeId(type, id) {
   return `${type}:${id}`;
 }
 
+function readJson(relativePath) {
+  try {
+    return JSON.parse(readText(relativePath));
+  } catch {
+    return null;
+  }
+}
+
+function normalizePath(value) {
+  return value.replaceAll('\\', '/').replace(/\/+$/, '');
+}
+
+function expandWorkspaceGlobs(globs) {
+  const workspacePaths = new Set();
+
+  for (const raw of globs ?? []) {
+    if (typeof raw !== 'string') continue;
+    const pattern = normalizePath(raw.trim());
+    if (!pattern) continue;
+
+    if (pattern.endsWith('/*')) {
+      const base = pattern.slice(0, -2);
+      for (const dir of listDirs(base)) {
+        if (exists(path.join(dir, 'package.json'))) workspacePaths.add(normalizePath(dir));
+      }
+      continue;
+    }
+
+    if (exists(path.join(pattern, 'package.json'))) workspacePaths.add(pattern);
+  }
+
+  return [...workspacePaths].sort();
+}
+
+function readWorkspaceGlobs(profile) {
+  if (Array.isArray(profile.activeWorkspaceGlobs) && profile.activeWorkspaceGlobs.length > 0) {
+    return profile.activeWorkspaceGlobs;
+  }
+
+  if (exists('pnpm-workspace.yaml')) {
+    const workspaceConfig = parseSimpleYaml(readText('pnpm-workspace.yaml'));
+    if (Array.isArray(workspaceConfig.packages)) return workspaceConfig.packages;
+  }
+
+  return Object.keys(profile.workspaces ?? {});
+}
+
+function ruleMatchesWorkspace(rule, workspacePath) {
+  return (rule.paths ?? []).some((pattern) => {
+    if (typeof pattern !== 'string') return false;
+    const normalized = normalizePath(pattern);
+    if (normalized === workspacePath) return true;
+    if (normalized.startsWith(`${workspacePath}/`)) return true;
+    if (normalized.startsWith(`${workspacePath}/*`)) return true;
+    if (normalized.startsWith(`${workspacePath}/**`)) return true;
+    return false;
+  });
+}
+
+function workspaceKind(workspacePath) {
+  if (workspacePath.startsWith('apps/')) return 'app';
+  return 'package';
+}
+
+function packageScripts(manifest) {
+  return Object.keys(manifest?.scripts ?? {}).sort();
+}
+
+function recommendedFallbackCommands(workspacePath, manifest, kind) {
+  const name = manifest?.name;
+  if (!name) return [];
+  const scripts = packageScripts(manifest);
+  const preferred = kind === 'app' ? ['typecheck', 'test', 'build'] : ['test', 'typecheck'];
+  return preferred
+    .filter((script) => scripts.includes(script))
+    .map((script) => `pnpm --filter ${name} ${script}`);
+}
+
+function classifyWorkspaceReport(report) {
+  const high = report.gaps.filter((gap) => gap.severity === 'high').length;
+  const medium = report.gaps.filter((gap) => gap.severity === 'medium').length;
+  if (high > 0) return 'missing';
+  if (medium > 0 || !report.profileListed) return 'partial';
+  return 'ready';
+}
+
+function buildWorkspaceReports(profile, validation) {
+  const workspaceGlobs = readWorkspaceGlobs(profile);
+  const activeWorkspaces = expandWorkspaceGlobs(workspaceGlobs);
+  const profileWorkspaces = profile.workspaces ?? {};
+  const validationRules = validation.pathRules ?? [];
+  const reports = [];
+
+  for (const workspacePath of activeWorkspaces) {
+    const profileEntry = profileWorkspaces[workspacePath];
+    const manifest = readJson(path.join(workspacePath, 'package.json'));
+    const kind = profileEntry?.type ?? workspaceKind(workspacePath);
+    const entryPath = profileEntry?.entry ?? path.join(workspacePath, 'AGENTS.md');
+    const entry = { path: entryPath, exists: exists(entryPath) };
+    const knowledge = Object.entries(profileEntry?.knowledge ?? {})
+      .filter(([, target]) => typeof target === 'string')
+      .map(([kindName, target]) => ({
+        kind: kindName,
+        path: target,
+        exists: exists(target),
+      }));
+    const rules = validationRules.filter((rule) => ruleMatchesWorkspace(rule, workspacePath));
+    const commands = [
+      ...new Set(rules.flatMap((rule) => Array.isArray(rule.required) ? rule.required : [])),
+    ];
+    const fallbackCommands = recommendedFallbackCommands(workspacePath, manifest, kind);
+    const gaps = [];
+
+    if (!profileEntry) {
+      gaps.push({
+        severity: 'medium',
+        type: 'profile',
+        label: 'No explicit profile entry',
+        path: 'harness/profile.yaml',
+        detail: 'This workspace falls back to workspaceTypeDefaults instead of a curated entry.',
+      });
+    }
+    if (!entry.exists) {
+      gaps.push({
+        severity: 'high',
+        type: 'entry',
+        label: 'Missing local AGENTS entry',
+        path: entry.path,
+        detail: 'Workspace has no local harness entry for progressive reading.',
+      });
+    }
+    for (const item of knowledge) {
+      if (!item.exists) {
+        gaps.push({
+          severity: 'high',
+          type: 'knowledge',
+          label: `Missing ${item.kind}`,
+          path: item.path,
+          detail: 'Profile points to a file that does not exist.',
+        });
+      }
+    }
+    if (rules.length === 0) {
+      gaps.push({
+        severity: 'medium',
+        type: 'validation',
+        label: 'No path-specific validation rule',
+        path: 'harness/validation.yaml',
+        detail: 'Validation falls back to workspace scripts instead of a named path rule.',
+      });
+    }
+
+    const report = {
+      path: workspacePath,
+      type: kind,
+      packageName: profileEntry?.packageName ?? manifest?.name ?? path.basename(workspacePath),
+      role: profileEntry?.role ?? 'default-workspace',
+      profileListed: Boolean(profileEntry),
+      entry,
+      knowledge,
+      validationRules: rules.map((rule) => ({
+        name: rule.name,
+        paths: rule.paths ?? [],
+        required: rule.required ?? [],
+        manual: rule.manual ?? [],
+        optional: rule.optional ?? [],
+        escalateWhen: rule.escalateWhen ?? {},
+      })),
+      commands: commands.length > 0 ? commands : fallbackCommands,
+      fallbackCommands,
+      scripts: packageScripts(manifest),
+      gaps,
+      readingPath: [
+        'AGENTS.md',
+        'harness/README.md',
+        'harness/profile.yaml',
+        entry.path,
+        ...knowledge.filter((item) => item.exists).map((item) => item.path),
+      ],
+    };
+    report.status = classifyWorkspaceReport(report);
+    report.score = Math.max(0, 100 - report.gaps.reduce((sum, gap) => sum + (gap.severity === 'high' ? 35 : 18), 0));
+    reports.push(report);
+  }
+
+  return reports.sort((a, b) => a.path.localeCompare(b.path));
+}
+
 function buildGraph() {
   const nodes = new Map();
   const edges = [];
@@ -154,6 +342,7 @@ function buildGraph() {
 
   const profile = parseSimpleYaml(readText('harness/profile.yaml'));
   const validation = parseSimpleYaml(readText('harness/validation.yaml'));
+  const workspaceReports = buildWorkspaceReports(profile, validation);
 
   for (const [workspacePath, workspace] of Object.entries(profile.workspaces ?? {})) {
     const wid = nodeId('workspace', workspacePath);
@@ -224,16 +413,36 @@ function buildGraph() {
 
   const nodeList = [...nodes.values()];
   const gapCount = nodeList.filter((node) => node.type === 'gap').length;
+  const harnessGaps = workspaceReports.flatMap((report) =>
+    report.gaps.map((gap) => ({
+      workspace: report.path,
+      packageName: report.packageName,
+      ...gap,
+    })),
+  );
+  const explicitWorkspaceCount = workspaceReports.filter((report) => report.profileListed).length;
+  const validationCoverageCount = workspaceReports.filter((report) => report.validationRules.length > 0).length;
+  const entryCoverageCount = workspaceReports.filter((report) => report.entry.exists).length;
   return {
     generatedAt: new Date().toISOString(),
     summary: {
       nodes: nodeList.length,
       edges: edges.length,
       workspaces: nodeList.filter((node) => node.type === 'workspace').length,
+      activeWorkspaces: workspaceReports.length,
+      explicitWorkspaces: explicitWorkspaceCount,
+      entryCoverage: entryCoverageCount,
+      validationCoverage: validationCoverageCount,
       skills: nodeList.filter((node) => node.type === 'skill').length,
       tools: nodeList.filter((node) => node.type === 'tool').length,
-      gaps: gapCount,
+      graphGaps: gapCount,
+      harnessGaps: harnessGaps.length,
+      highSeverityGaps: harnessGaps.filter((gap) => gap.severity === 'high').length,
     },
+    profileScope: profile.profileScope ?? {},
+    activeWorkspaceGlobs: readWorkspaceGlobs(profile),
+    workspaceReports,
+    harnessGaps,
     nodes: nodeList,
     edges,
   };
@@ -246,128 +455,363 @@ function html(graph) {
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Harness Map</title>
+<title>Harness Dashboard</title>
 <style>
-:root { color-scheme: dark; --bg:#10120f; --panel:#181c15; --panel2:#20251b; --line:#35402f; --text:#eef6df; --muted:#a9b69a; --accent:#d7ff5f; --blue:#7cc7ff; --green:#79e08e; --yellow:#f3d36b; --purple:#c796ff; --red:#ff6d61; }
+:root {
+  color-scheme: dark;
+  --bg:#0f1115;
+  --panel:#171a20;
+  --panel-2:#1e232b;
+  --panel-3:#242a33;
+  --line:#343b47;
+  --text:#eef2f7;
+  --muted:#9ea9b8;
+  --blue:#7db7ff;
+  --green:#7ee2a8;
+  --yellow:#f3cd6b;
+  --red:#ff7a70;
+  --purple:#c8a2ff;
+  --teal:#7ee4df;
+}
 * { box-sizing: border-box; }
-body { margin:0; background:var(--bg); color:var(--text); font:14px/1.45 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
-.app { min-height:100vh; display:grid; grid-template-columns: 380px 1fr 340px; }
-aside, main { border-right:1px solid var(--line); }
-aside { padding:18px; overflow:auto; background:var(--panel); }
-main { padding:18px; overflow:auto; background:radial-gradient(circle at 15% 5%, #26311d 0 12%, transparent 30%), #11140f; }
-h1 { margin:0 0 4px; font-size:26px; letter-spacing:.02em; }
-h2 { margin:18px 0 10px; color:var(--accent); font-size:15px; }
-.sub { color:var(--muted); margin-bottom:16px; }
-.stats { display:grid; grid-template-columns: repeat(2, 1fr); gap:8px; }
-.stat { background:var(--panel2); border:1px solid var(--line); padding:10px; }
-.stat b { display:block; color:var(--accent); font-size:20px; }
-.row { display:grid; grid-template-columns: 1fr auto; gap:10px; align-items:center; padding:9px; border:1px solid var(--line); background:#141812; margin-bottom:7px; cursor:pointer; }
-.row:hover, .row.active { border-color:var(--accent); }
-.row small { color:var(--muted); display:block; margin-top:3px; }
-.badges { display:flex; gap:5px; flex-wrap:wrap; justify-content:flex-end; }
-.badge { border:1px solid var(--line); padding:2px 5px; color:var(--muted); font-size:11px; }
-.badge.ok { color:var(--green); border-color:#406b48; }
-.badge.warn { color:var(--red); border-color:#7a4039; }
-.flow { display:grid; gap:12px; max-width:920px; }
-.step { border:1px solid var(--line); background:rgba(24,28,21,.86); padding:14px; position:relative; }
-.step:not(:last-child)::after { content:'↓'; position:absolute; left:20px; bottom:-22px; color:var(--accent); font-size:20px; }
-.step-title { color:var(--accent); font-weight:700; margin-bottom:4px; }
-.cards { display:grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap:10px; margin-top:12px; }
-.card { border:1px solid var(--line); background:var(--panel2); padding:12px; }
-.card strong { color:var(--yellow); }
-.graph-box { height:380px; margin-top:16px; border:1px solid var(--line); background:#0d100c; position:relative; overflow:hidden; }
+body {
+  margin:0;
+  background:var(--bg);
+  color:var(--text);
+  font:14px/1.45 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+button, input { font:inherit; }
+.topbar { border-bottom:1px solid var(--line); background:#12151a; padding:18px 24px; }
+.topline { display:flex; justify-content:space-between; align-items:flex-start; gap:16px; }
+h1 { margin:0; font-size:24px; line-height:1.15; letter-spacing:0; }
+h2 { margin:0 0 12px; font-size:15px; letter-spacing:0; }
+h3 { margin:0 0 8px; font-size:13px; color:var(--muted); letter-spacing:0; text-transform:uppercase; }
+.sub { color:var(--muted); margin-top:6px; max-width:880px; }
+.meta { color:var(--muted); font-size:12px; text-align:right; white-space:nowrap; }
+.tabs { display:flex; gap:8px; flex-wrap:wrap; margin-top:16px; }
+button {
+  border:1px solid var(--line);
+  background:var(--panel);
+  color:var(--text);
+  padding:8px 10px;
+  border-radius:6px;
+  cursor:pointer;
+  min-height:34px;
+}
+button:hover, button.active { border-color:var(--blue); color:var(--blue); }
+.shell { display:grid; grid-template-columns:minmax(0, 1fr) minmax(360px, 420px); gap:0; min-height:calc(100vh - 115px); }
+main { min-width:0; padding:22px 24px 36px; }
+.detail { border-left:1px solid var(--line); background:var(--panel); padding:22px; overflow:auto; }
+.view { display:none; }
+.view.active { display:block; }
+.metrics { display:grid; grid-template-columns:repeat(4, minmax(150px, 1fr)); gap:12px; margin-bottom:18px; }
+.metric { background:var(--panel); border:1px solid var(--line); border-radius:8px; padding:14px; min-height:88px; }
+.metric b { display:block; font-size:25px; line-height:1.1; margin-bottom:7px; }
+.metric span { color:var(--muted); font-size:12px; }
+.metric.good b { color:var(--green); }
+.metric.warn b { color:var(--yellow); }
+.metric.bad b { color:var(--red); }
+.grid-2 { display:grid; grid-template-columns:1fr 1fr; gap:14px; }
+.panel { background:var(--panel); border:1px solid var(--line); border-radius:8px; padding:16px; margin-bottom:14px; }
+.coverage-bar { height:10px; background:#0c0f13; border:1px solid var(--line); border-radius:8px; overflow:hidden; }
+.coverage-bar span { display:block; height:100%; background:linear-gradient(90deg, var(--green), var(--blue)); }
+.compact-list { display:grid; gap:8px; }
+.compact-row, .workspace-card, .gap-row {
+  border:1px solid var(--line);
+  background:var(--panel-2);
+  border-radius:8px;
+  padding:12px;
+}
+.workspace-card { cursor:pointer; min-height:158px; display:grid; gap:10px; align-content:start; }
+.workspace-card:hover, .workspace-card.active { border-color:var(--blue); }
+.workspace-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(280px, 1fr)); gap:12px; }
+.filters { display:flex; gap:10px; flex-wrap:wrap; align-items:center; margin-bottom:14px; }
+.search { flex:1; min-width:240px; border:1px solid var(--line); background:#101319; color:var(--text); border-radius:6px; padding:9px 10px; min-height:38px; }
+.badges { display:flex; flex-wrap:wrap; gap:6px; }
+.badge { border:1px solid var(--line); border-radius:999px; padding:3px 7px; color:var(--muted); font-size:12px; line-height:1.2; }
+.badge.ready { color:var(--green); border-color:#35634b; }
+.badge.partial { color:var(--yellow); border-color:#6a5730; }
+.badge.missing { color:var(--red); border-color:#703c38; }
+.badge.info { color:var(--blue); border-color:#355475; }
+.path { font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; word-break:break-word; }
+.muted { color:var(--muted); }
+.row-title { display:flex; justify-content:space-between; gap:12px; align-items:flex-start; }
+.score { font-weight:700; color:var(--teal); }
+.gap-row { display:grid; grid-template-columns:120px minmax(0, 1fr); gap:12px; margin-bottom:10px; }
+.severity { font-weight:700; }
+.severity.high { color:var(--red); }
+.severity.medium { color:var(--yellow); }
+.command { display:grid; grid-template-columns:minmax(0, 1fr) auto; gap:8px; align-items:center; margin-bottom:8px; }
+.command code, code, pre { font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
+.command code { display:block; background:#0c0f13; border:1px solid var(--line); border-radius:6px; padding:8px; overflow:auto; white-space:pre-wrap; word-break:break-word; }
+pre { white-space:pre-wrap; word-break:break-word; background:#0c0f13; border:1px solid var(--line); border-radius:6px; padding:10px; color:#dce5ef; margin:0; }
+.mini-table { display:grid; gap:8px; }
+.mini-row { display:grid; grid-template-columns:110px minmax(0, 1fr); gap:10px; padding:8px 0; border-bottom:1px solid var(--line); }
+.mini-row:last-child { border-bottom:0; }
+.reading { display:grid; gap:8px; counter-reset:readstep; }
+.reading div { border:1px solid var(--line); background:var(--panel-2); border-radius:6px; padding:8px; }
+.reading div::before { counter-increment:readstep; content:counter(readstep) ". "; color:var(--blue); font-weight:700; }
+.graph-layout { display:grid; grid-template-columns:minmax(0, 1fr) 320px; gap:14px; }
+.graph-box { height:520px; border:1px solid var(--line); border-radius:8px; background:#0b0e13; position:relative; overflow:hidden; }
 svg { width:100%; height:100%; display:block; }
-.edge { stroke:#59614f; stroke-width:1.1; opacity:.45; }
-.edge.high { stroke:var(--accent); opacity:.65; }
-.node circle { stroke:#0a0c09; stroke-width:2; }
-.node text { fill:var(--text); font-size:10px; paint-order:stroke; stroke:#0d100c; stroke-width:4px; }
-pre { white-space:pre-wrap; word-break:break-word; background:#0d100c; border:1px solid var(--line); padding:10px; color:#dce8cf; }
-.kv { color:var(--muted); }
-button { border:1px solid var(--line); background:#141812; color:var(--text); padding:7px 9px; font:inherit; cursor:pointer; }
-button.active { color:var(--accent); border-color:var(--accent); }
+.edge { stroke:#596373; stroke-width:1.1; opacity:.38; }
+.edge.high { stroke:var(--blue); opacity:.62; }
+.node circle { stroke:#090b0e; stroke-width:2; cursor:pointer; }
+.node text { fill:var(--text); font-size:10px; paint-order:stroke; stroke:#0b0e13; stroke-width:4px; pointer-events:none; }
+.empty { color:var(--muted); border:1px dashed var(--line); border-radius:8px; padding:16px; }
+@media (max-width: 1180px) {
+  .shell, .grid-2, .graph-layout { grid-template-columns:1fr; }
+  .detail { border-left:0; border-top:1px solid var(--line); }
+  .metrics { grid-template-columns:repeat(2, minmax(150px, 1fr)); }
+  .meta { text-align:left; white-space:normal; }
+  .topline { flex-direction:column; }
+}
+@media (max-width: 620px) {
+  .topbar, main, .detail { padding-left:14px; padding-right:14px; }
+  .metrics { grid-template-columns:1fr; }
+  .gap-row, .mini-row { grid-template-columns:1fr; }
+}
 </style>
 </head>
 <body>
-<div class="app">
-  <aside>
-    <h1>Harness Map</h1>
-    <div class="sub">Readable view of repository harness coverage and routing.</div>
-    <div class="stats" id="stats"></div>
-    <h2>Workspaces</h2>
-    <div id="workspace-list"></div>
-  </aside>
+<header class="topbar">
+  <div class="topline">
+    <div>
+      <h1>Repository Harness Dashboard</h1>
+      <div class="sub">Operational view of harness coverage, workspace guidance, validation commands, and missing pieces.</div>
+    </div>
+    <div class="meta" id="meta"></div>
+  </div>
+  <nav class="tabs" aria-label="Harness views">
+    <button class="active" data-tab="overview">Overview</button>
+    <button data-tab="workspaces">Workspaces</button>
+    <button data-tab="gaps">Missing</button>
+    <button data-tab="graph">Graph</button>
+  </nav>
+</header>
+<div class="shell">
   <main>
-    <h2>Main Loop</h2>
-    <section class="flow">
-      <div class="step"><div class="step-title">1. Route</div><div>Root entries route to <code>harness/profile.yaml</code>, then to the affected workspace entry.</div></div>
-      <div class="step"><div class="step-title">2. Read Knowledge</div><div>Workspace entries point to README, contracts, runbook, validation, or product docs as needed.</div></div>
-      <div class="step"><div class="step-title">3. Act</div><div>Common action protocols live in <code>harness/skills</code>; reusable atomic capabilities live in <code>harness/tools</code>.</div></div>
-      <div class="step"><div class="step-title">4. Validate</div><div><code>harness/validation.yaml</code> maps paths to validation rules and escalation points.</div></div>
-      <div class="step"><div class="step-title">5. Feed Back</div><div>Feedback starts in <code>harness/feedback</code>, then accepted facts move to the right long-term target.</div></div>
+    <section id="overview" class="view active">
+      <div class="metrics" id="metrics"></div>
+      <div class="grid-2">
+        <section class="panel">
+          <h2>Harness Health</h2>
+          <div id="health"></div>
+        </section>
+        <section class="panel">
+          <h2>Priority Missing Items</h2>
+          <div id="priority-gaps"></div>
+        </section>
+      </div>
+      <section class="panel">
+        <h2>Progressive Reading Loop</h2>
+        <div class="compact-list" id="reading-loop"></div>
+      </section>
     </section>
-    <h2>Action Surface</h2>
-    <div class="cards" id="surface"></div>
-    <h2>Graph Preview</h2>
-    <div><button id="toggle-graph">Pause graph</button></div>
-    <div class="graph-box"><svg id="graph" role="img" aria-label="Harness graph preview"></svg></div>
+
+    <section id="workspaces" class="view">
+      <div class="filters">
+        <input id="workspace-search" class="search" type="search" placeholder="Search workspace, package, role, or command" />
+        <button class="active" data-filter="all">All</button>
+        <button data-filter="ready">Ready</button>
+        <button data-filter="partial">Partial</button>
+        <button data-filter="missing">Missing</button>
+      </div>
+      <div class="workspace-grid" id="workspace-grid"></div>
+    </section>
+
+    <section id="gaps" class="view">
+      <section class="panel">
+        <h2>Current Harness Missing Items</h2>
+        <div id="gap-list"></div>
+      </section>
+    </section>
+
+    <section id="graph" class="view">
+      <div class="graph-layout">
+        <div>
+          <div class="filters">
+            <button id="toggle-graph">Pause graph</button>
+            <button class="active" data-node-filter="all">All nodes</button>
+            <button data-node-filter="workspace">Workspaces</button>
+            <button data-node-filter="validation">Validation</button>
+            <button data-node-filter="gap">Gaps</button>
+          </div>
+          <div class="graph-box"><svg id="graph-svg" role="img" aria-label="Harness graph"></svg></div>
+        </div>
+        <section class="panel">
+          <h2 id="graph-title">Graph Selection</h2>
+          <div id="graph-detail" class="muted">Select a node to inspect connected edges.</div>
+        </section>
+      </div>
+    </section>
   </main>
-  <aside>
-    <h2 id="detail-title">Select a workspace</h2>
-    <div id="detail-body" class="kv">Click a workspace on the left or a node in the graph.</div>
-    <h2>Connected Edges</h2>
-    <pre id="edge-list">No selection</pre>
+  <aside class="detail">
+    <h2 id="detail-title">Workspace Detail</h2>
+    <div id="detail-body"></div>
   </aside>
 </div>
 <script>
 const graph = ${graphJson};
-const colors = { root:'#d7ff5f', harness:'#ffad57', profile:'#ffad57', validation:'#ff7ab6', workspace:'#7cc7ff', entry:'#79e08e', knowledge:'#b5d98d', skill:'#f3d36b', tool:'#c796ff', gap:'#ff6d61' };
-const nodes = graph.nodes.map((n, i) => ({...n, x: 420 + Math.cos(i)*160, y: 190 + Math.sin(i)*130, vx:0, vy:0}));
+const reports = graph.workspaceReports || [];
+const gaps = graph.harnessGaps || [];
+const colors = { root:'#f3cd6b', harness:'#7ee4df', profile:'#7ee4df', validation:'#ff8fbd', workspace:'#7db7ff', entry:'#7ee2a8', knowledge:'#9ad581', skill:'#f3cd6b', tool:'#c8a2ff', gap:'#ff7a70' };
+const nodes = graph.nodes.map((n, i) => ({...n, x: 520 + Math.cos(i)*180, y: 260 + Math.sin(i)*155, vx:0, vy:0, visible:true}));
 const byId = new Map(nodes.map(n => [n.id, n]));
 const edges = graph.edges.map(e => ({...e, source: byId.get(e.from), target: byId.get(e.to)})).filter(e => e.source && e.target);
-const svg = document.getElementById('graph');
+const byWorkspace = new Map(reports.map(r => [r.path, r]));
+const svg = document.getElementById('graph-svg');
+const state = { selected: reports[0]?.path || '', filter: 'all', query: '', nodeFilter: 'all' };
 let running = true;
 
-function escapeHtml(s){ return String(s).replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c])); }
+function escapeHtml(s){ return String(s ?? '').replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
 function radius(n){ return n.type==='workspace'?10:n.type==='gap'?9:6; }
-function workspaceStatus(w){
-  const outgoing = graph.edges.filter(e => e.from === w.id);
-  const hasEntry = outgoing.some(e => e.type === 'has_entry');
-  const hasValidation = outgoing.some(e => e.meta?.kind === 'validation');
-  const hasContract = outgoing.some(e => e.meta?.kind === 'contracts' || e.meta?.kind === 'runbook');
-  return { hasEntry, hasValidation, hasContract };
+function pct(part, total){ return total ? Math.round(part / total * 100) : 100; }
+function statusLabel(status){ return status === 'ready' ? 'Ready' : status === 'missing' ? 'Missing' : 'Partial'; }
+function statusBadge(status){ return '<span class="badge '+status+'">'+statusLabel(status)+'</span>'; }
+function metric(label, value, sub, tone){
+  return '<div class="metric '+(tone || '')+'"><b>'+escapeHtml(value)+'</b><span>'+escapeHtml(label)+'</span><div class="muted">'+escapeHtml(sub || '')+'</div></div>';
+}
+function renderMeta(){
+  const scope = graph.profileScope?.mode ? graph.profileScope.mode + ' scope' : 'profile';
+  document.getElementById('meta').innerHTML = escapeHtml(scope)+'<br><span>'+escapeHtml(new Date(graph.generatedAt).toLocaleString())+'</span>';
+}
+function renderMetrics(){
+  const total = graph.summary.activeWorkspaces || reports.length;
+  const entryPct = pct(graph.summary.entryCoverage, total);
+  const validationPct = pct(graph.summary.validationCoverage, total);
+  const explicitPct = pct(graph.summary.explicitWorkspaces, total);
+  document.getElementById('metrics').innerHTML = [
+    metric('Active workspaces', total, graph.summary.explicitWorkspaces + ' curated entries', 'good'),
+    metric('Entry coverage', entryPct + '%', graph.summary.entryCoverage + ' have local entries', entryPct === 100 ? 'good' : 'warn'),
+    metric('Validation coverage', validationPct + '%', graph.summary.validationCoverage + ' have path rules', validationPct === 100 ? 'good' : 'warn'),
+    metric('Missing items', graph.summary.harnessGaps, graph.summary.highSeverityGaps + ' high severity', graph.summary.highSeverityGaps ? 'bad' : graph.summary.harnessGaps ? 'warn' : 'good'),
+  ].join('');
+}
+function renderHealth(){
+  const total = graph.summary.activeWorkspaces || reports.length;
+  const rows = [
+    ['Profile entries', graph.summary.explicitWorkspaces, total],
+    ['Local entries', graph.summary.entryCoverage, total],
+    ['Validation rules', graph.summary.validationCoverage, total],
+  ];
+  document.getElementById('health').innerHTML = rows.map(([label, count, max]) => {
+    const value = pct(count, max);
+    return '<div class="compact-row"><div class="row-title"><strong>'+escapeHtml(label)+'</strong><span class="score">'+value+'%</span></div><div class="coverage-bar" aria-label="'+escapeHtml(label)+' coverage"><span style="width:'+value+'%"></span></div><div class="muted">'+count+' of '+max+'</div></div>';
+  }).join('');
+}
+function renderPriorityGaps(){
+  const priority = gaps.filter(g => g.severity === 'high').slice(0, 4).concat(gaps.filter(g => g.severity !== 'high').slice(0, Math.max(0, 4 - gaps.filter(g => g.severity === 'high').length)));
+  document.getElementById('priority-gaps').innerHTML = priority.length ? priority.map(renderGapRow).join('') : '<div class="empty">No missing harness items detected.</div>';
+}
+function renderReadingLoop(){
+  const loop = ['AGENTS.md / CLAUDE.md', 'harness/README.md', 'harness/profile.yaml', 'affected workspace AGENTS.md', 'workspace contracts, runbook, or validation docs'];
+  document.getElementById('reading-loop').innerHTML = loop.map((item, i) => '<div class="compact-row"><strong>'+(i + 1)+'. '+escapeHtml(item)+'</strong></div>').join('');
+}
+function filteredReports(){
+  const query = state.query.trim().toLowerCase();
+  return reports.filter(report => {
+    if (state.filter !== 'all' && report.status !== state.filter) return false;
+    if (!query) return true;
+    const haystack = [report.path, report.packageName, report.role, report.type, ...report.commands, ...report.scripts].join(' ').toLowerCase();
+    return haystack.includes(query);
+  });
+}
+function renderWorkspaceCard(report){
+  const gapText = report.gaps.length === 0 ? 'No missing items' : report.gaps.length + ' missing item' + (report.gaps.length === 1 ? '' : 's');
+  const commandCount = report.commands.length + ' command' + (report.commands.length === 1 ? '' : 's');
+  return '<article class="workspace-card '+(state.selected === report.path ? 'active' : '')+'" data-workspace="'+escapeHtml(report.path)+'">'+
+    '<div class="row-title"><strong class="path">'+escapeHtml(report.path)+'</strong><span class="score">'+report.score+'</span></div>'+
+    '<div class="muted">'+escapeHtml(report.role)+' / '+escapeHtml(report.packageName)+'</div>'+
+    '<div class="badges">'+statusBadge(report.status)+'<span class="badge info">'+escapeHtml(report.type)+'</span><span class="badge">'+commandCount+'</span></div>'+
+    '<div class="muted">'+escapeHtml(gapText)+'</div>'+
+  '</article>';
+}
+function renderWorkspaces(){
+  const items = filteredReports();
+  document.getElementById('workspace-grid').innerHTML = items.length ? items.map(renderWorkspaceCard).join('') : '<div class="empty">No workspaces match the current filter.</div>';
+}
+function renderGapRow(gap){
+  return '<div class="gap-row">'+
+    '<div><span class="severity '+escapeHtml(gap.severity)+'">'+escapeHtml(gap.severity.toUpperCase())+'</span><div class="muted">'+escapeHtml(gap.type)+'</div></div>'+
+    '<div><strong>'+escapeHtml(gap.label)+'</strong><div class="path">'+escapeHtml(gap.workspace || gap.path)+'</div><div class="muted">'+escapeHtml(gap.detail || '')+'</div></div>'+
+  '</div>';
+}
+function renderGaps(){
+  document.getElementById('gap-list').innerHTML = gaps.length ? gaps.map(renderGapRow).join('') : '<div class="empty">No missing harness items detected.</div>';
+}
+function renderCommands(commands){
+  if (!commands.length) return '<div class="empty">No validation commands resolved.</div>';
+  return commands.map(command => '<div class="command"><code>'+escapeHtml(command)+'</code><button data-copy="'+escapeHtml(command)+'">Copy</button></div>').join('');
+}
+function renderDetail(){
+  const report = byWorkspace.get(state.selected) || reports[0];
+  if (!report) {
+    document.getElementById('detail-title').textContent = 'Workspace Detail';
+    document.getElementById('detail-body').innerHTML = '<div class="empty">No workspace data found.</div>';
+    return;
+  }
+  document.getElementById('detail-title').textContent = report.path;
+  const knowledge = report.knowledge.length ? report.knowledge.map(item => '<div class="mini-row"><div>'+escapeHtml(item.kind)+'</div><div class="path">'+escapeHtml(item.path)+' '+(item.exists ? '' : '<span class="severity high">missing</span>')+'</div></div>').join('') : '<div class="empty">No curated knowledge refs.</div>';
+  const missing = report.gaps.length ? report.gaps.map(renderGapRow).join('') : '<div class="empty">No missing items for this workspace.</div>';
+  document.getElementById('detail-body').innerHTML =
+    '<div class="badges">'+statusBadge(report.status)+'<span class="badge info">'+escapeHtml(report.type)+'</span><span class="badge">'+report.score+' score</span></div>'+
+    '<section class="panel"><h3>Identity</h3><div class="mini-table">'+
+      '<div class="mini-row"><div>Package</div><div>'+escapeHtml(report.packageName)+'</div></div>'+
+      '<div class="mini-row"><div>Role</div><div>'+escapeHtml(report.role)+'</div></div>'+
+      '<div class="mini-row"><div>Entry</div><div class="path">'+escapeHtml(report.entry.path)+' '+(report.entry.exists ? '' : '<span class="severity high">missing</span>')+'</div></div>'+
+      '<div class="mini-row"><div>Profile</div><div>'+escapeHtml(report.profileListed ? 'curated' : 'default fallback')+'</div></div>'+
+    '</div></section>'+
+    '<section class="panel"><h3>Validation</h3>'+renderCommands(report.commands)+'</section>'+
+    '<section class="panel"><h3>Reading Path</h3><div class="reading">'+report.readingPath.map(item => '<div class="path">'+escapeHtml(item)+'</div>').join('')+'</div></section>'+
+    '<section class="panel"><h3>Knowledge</h3>'+knowledge+'</section>'+
+    '<section class="panel"><h3>Missing</h3>'+missing+'</section>';
+}
+function showTab(tab){
+  document.querySelectorAll('.tabs button').forEach(button => button.classList.toggle('active', button.dataset.tab === tab));
+  document.querySelectorAll('.view').forEach(view => view.classList.toggle('active', view.id === tab));
+}
+function applyNodeFilter(){
+  for (const node of nodes) node.visible = state.nodeFilter === 'all' || node.type === state.nodeFilter || (state.nodeFilter === 'validation' && node.type === 'profile');
+}
+function selectGraphNode(id){
+  const n = byId.get(id); if(!n) return;
+  document.getElementById('graph-title').textContent = n.label;
+  const related = graph.edges.filter(e => e.from===n.id || e.to===n.id).map(e => e.type+' '+e.confidence+'\\n  '+e.from+'\\n  -> '+e.to).join('\\n\\n');
+  document.getElementById('graph-detail').innerHTML = '<pre>'+escapeHtml(JSON.stringify(n.meta, null, 2))+'</pre><h3>Edges</h3><pre>'+escapeHtml(related || 'No connected edges')+'</pre>';
+  if (n.type === 'workspace') {
+    const report = byWorkspace.get(n.label);
+    if (report) { state.selected = report.path; renderDetail(); renderWorkspaces(); }
+  }
 }
 function init(){
-  document.getElementById('stats').innerHTML = [['Workspaces',graph.summary.workspaces],['Skills',graph.summary.skills],['Tools',graph.summary.tools],['Gaps',graph.summary.gaps]].map(([k,v]) => '<div class="stat"><b>'+v+'</b>'+k+'</div>').join('');
-  const workspaces = graph.nodes.filter(n => n.type === 'workspace');
-  document.getElementById('workspace-list').innerHTML = workspaces.map(w => {
-    const s = workspaceStatus(w);
-    return '<div class="row" data-id="'+w.id+'"><div>'+escapeHtml(w.label)+'<small>'+escapeHtml(w.meta.role || '')+'</small></div><div class="badges">'+
-      '<span class="badge '+(s.hasEntry?'ok':'warn')+'">entry</span>'+
-      '<span class="badge '+(s.hasValidation?'ok':'')+'">validation</span>'+
-      '<span class="badge '+(s.hasContract?'ok':'')+'">contract/runbook</span>'+
-    '</div></div>';
-  }).join('');
-  document.getElementById('workspace-list').addEventListener('click', e => {
-    const row = e.target.closest('.row'); if(!row) return;
-    selectNode(row.dataset.id);
-    document.querySelectorAll('.row').forEach(r => r.classList.toggle('active', r === row));
+  renderMeta(); renderMetrics(); renderHealth(); renderPriorityGaps(); renderReadingLoop(); renderWorkspaces(); renderGaps(); renderDetail(); applyNodeFilter();
+  document.querySelector('.tabs').addEventListener('click', e => { const button = e.target.closest('button[data-tab]'); if(button) showTab(button.dataset.tab); });
+  document.querySelector('.filters').addEventListener('click', e => {
+    const button = e.target.closest('button[data-filter]'); if(!button) return;
+    state.filter = button.dataset.filter;
+    document.querySelectorAll('button[data-filter]').forEach(item => item.classList.toggle('active', item === button));
+    renderWorkspaces();
   });
-  document.getElementById('surface').innerHTML = [
-    ['Skills', graph.nodes.filter(n=>n.type==='skill').map(n=>n.label)],
-    ['Tools', graph.nodes.filter(n=>n.type==='tool').map(n=>n.label)],
-    ['Validation rules', graph.nodes.filter(n=>n.type==='validation').map(n=>n.label)]
-  ].map(([title, items]) => '<div class="card"><strong>'+title+'</strong><br>'+items.map(escapeHtml).join('<br>')+'</div>').join('');
+  document.getElementById('workspace-search').addEventListener('input', e => { state.query = e.target.value; renderWorkspaces(); });
+  document.getElementById('workspace-grid').addEventListener('click', e => {
+    const card = e.target.closest('[data-workspace]'); if(!card) return;
+    state.selected = card.dataset.workspace; renderWorkspaces(); renderDetail();
+  });
+  document.body.addEventListener('click', e => {
+    const copy = e.target.closest('button[data-copy]'); if(!copy) return;
+    navigator.clipboard?.writeText(copy.dataset.copy).then(() => { copy.textContent = 'Copied'; setTimeout(() => { copy.textContent = 'Copy'; }, 1100); });
+  });
   document.getElementById('toggle-graph').onclick = () => { running = !running; document.getElementById('toggle-graph').textContent = running ? 'Pause graph' : 'Resume graph'; };
-}
-function selectNode(id){
-  const n = byId.get(id) || graph.nodes.find(x => x.id === id); if(!n) return;
-  document.getElementById('detail-title').textContent = n.label;
-  document.getElementById('detail-body').innerHTML = '<pre>'+escapeHtml(JSON.stringify(n.meta, null, 2))+'</pre>';
-  const related = graph.edges.filter(e => e.from===n.id || e.to===n.id).map(e => e.type+' '+e.confidence+'\\n  '+e.from+'\\n  -> '+e.to).join('\\n\\n');
-  document.getElementById('edge-list').textContent = related || 'No connected edges';
+  document.querySelector('#graph .filters').addEventListener('click', e => {
+    const button = e.target.closest('button[data-node-filter]'); if(!button) return;
+    state.nodeFilter = button.dataset.nodeFilter;
+    document.querySelectorAll('button[data-node-filter]').forEach(item => item.classList.toggle('active', item === button));
+    applyNodeFilter(); render();
+  });
 }
 function tick(){
-  if(running){
+  if(running && svg){
     const width = svg.clientWidth || 800, height = svg.clientHeight || 360;
     for(const n of nodes){ n.vx += (width/2 - n.x)*0.0007; n.vy += (height/2 - n.y)*0.0007; }
     for(let i=0;i<nodes.length;i++) for(let j=i+1;j<nodes.length;j++){
@@ -379,12 +823,15 @@ function tick(){
   render(); requestAnimationFrame(tick);
 }
 function render(){
+  if(!svg) return;
   while(svg.firstChild) svg.removeChild(svg.firstChild);
   const frag = document.createDocumentFragment();
   for(const e of edges){
+    if(!e.source.visible || !e.target.visible) continue;
     const line = document.createElementNS('http://www.w3.org/2000/svg','line'); line.setAttribute('class','edge '+e.confidence); line.setAttribute('x1',e.source.x); line.setAttribute('y1',e.source.y); line.setAttribute('x2',e.target.x); line.setAttribute('y2',e.target.y); frag.appendChild(line);
   }
   for(const n of nodes){
+    if(!n.visible) continue;
     const g = document.createElementNS('http://www.w3.org/2000/svg','g'); g.setAttribute('class','node'); g.dataset.id=n.id; g.setAttribute('transform','translate('+n.x+','+n.y+')');
     const c = document.createElementNS('http://www.w3.org/2000/svg','circle'); c.setAttribute('r',radius(n)); c.setAttribute('fill',colors[n.type]||'#ddd');
     const t = document.createElementNS('http://www.w3.org/2000/svg','text'); t.setAttribute('x',radius(n)+5); t.setAttribute('y',4); t.textContent=n.label;
@@ -392,7 +839,7 @@ function render(){
   }
   svg.appendChild(frag);
 }
-svg.addEventListener('click', e => { const g=e.target.closest('.node'); if(g) selectNode(g.dataset.id); });
+svg.addEventListener('click', e => { const g=e.target.closest('.node'); if(g) selectGraphNode(g.dataset.id); });
 init(); tick();
 </script>
 </body>
@@ -407,10 +854,16 @@ function printSummary(graph) {
     console.log('\nGaps:');
     for (const gap of gaps) console.log(`- ${gap.meta?.path ?? gap.id}`);
   }
+  if (graph.harnessGaps?.length) {
+    console.log('\nHarness gaps:');
+    for (const gap of graph.harnessGaps) {
+      console.log(`- [${gap.severity}] ${gap.workspace}: ${gap.label} (${gap.path})`);
+    }
+  }
 }
 
-const graph = buildGraph();
 if (process.argv.includes('--once')) {
+  const graph = buildGraph();
   printSummary(graph);
   process.exit(0);
 }
@@ -418,6 +871,7 @@ if (process.argv.includes('--once')) {
 const portArg = process.argv.find((arg) => arg.startsWith('--port='));
 const preferredPort = portArg ? Number(portArg.split('=')[1]) : 4177;
 const server = http.createServer((req, res) => {
+  const graph = buildGraph();
   if (req.url === '/graph.json') {
     res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' });
     res.end(JSON.stringify(graph, null, 2));

--- a/harness/tools/graph-viewer/server.mjs
+++ b/harness/tools/graph-viewer/server.mjs
@@ -502,9 +502,11 @@ button {
   min-height:34px;
 }
 button:hover, button.active { border-color:var(--blue); color:var(--blue); }
-.shell { display:grid; grid-template-columns:minmax(0, 1fr) minmax(360px, 420px); gap:0; min-height:calc(100vh - 115px); }
+.shell { display:grid; grid-template-columns:1fr; gap:0; min-height:calc(100vh - 115px); }
+.shell.workspace-mode { grid-template-columns:minmax(0, 1fr) minmax(360px, 420px); }
 main { min-width:0; padding:22px 24px 36px; }
-.detail { border-left:1px solid var(--line); background:var(--panel); padding:22px; overflow:auto; }
+.detail { display:none; border-left:1px solid var(--line); background:var(--panel); padding:22px; overflow:auto; }
+.shell.workspace-mode .detail { display:block; }
 .view { display:none; }
 .view.active { display:block; }
 .metrics { display:grid; grid-template-columns:repeat(4, minmax(150px, 1fr)); gap:12px; margin-bottom:18px; }
@@ -526,7 +528,7 @@ main { min-width:0; padding:22px 24px 36px; }
   padding:12px;
 }
 .workspace-card { cursor:pointer; min-height:158px; display:grid; gap:10px; align-content:start; }
-.workspace-card:hover, .workspace-card.active { border-color:var(--blue); }
+.workspace-card:hover, .workspace-card:focus, .workspace-card.active { border-color:var(--blue); outline:0; }
 .workspace-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(280px, 1fr)); gap:12px; }
 .filters { display:flex; gap:10px; flex-wrap:wrap; align-items:center; margin-bottom:14px; }
 .search { flex:1; min-width:240px; border:1px solid var(--line); background:#101319; color:var(--text); border-radius:6px; padding:9px 10px; min-height:38px; }
@@ -541,6 +543,8 @@ main { min-width:0; padding:22px 24px 36px; }
 .row-title { display:flex; justify-content:space-between; gap:12px; align-items:flex-start; }
 .score { font-weight:700; color:var(--teal); }
 .gap-row { display:grid; grid-template-columns:120px minmax(0, 1fr); gap:12px; margin-bottom:10px; }
+.gap-row.actionable { cursor:pointer; }
+.gap-row.actionable:hover, .gap-row.actionable:focus { border-color:var(--blue); background:#202938; outline:0; }
 .severity { font-weight:700; }
 .severity.high { color:var(--red); }
 .severity.medium { color:var(--yellow); }
@@ -556,7 +560,7 @@ pre { white-space:pre-wrap; word-break:break-word; background:#0c0f13; border:1p
 .reading div::before { counter-increment:readstep; content:counter(readstep) ". "; color:var(--blue); font-weight:700; }
 .empty { color:var(--muted); border:1px dashed var(--line); border-radius:8px; padding:16px; }
 @media (max-width: 1180px) {
-  .shell, .grid-2 { grid-template-columns:1fr; }
+  .shell, .shell.workspace-mode, .grid-2 { grid-template-columns:1fr; }
   .detail { border-left:0; border-top:1px solid var(--line); }
   .metrics { grid-template-columns:repeat(2, minmax(150px, 1fr)); }
   .meta { text-align:left; white-space:normal; }
@@ -659,6 +663,7 @@ const messages = {
     filterMissing: '缺失',
     currentMissing: '当前 Harness 缺失项',
     workspaceDetail: '工作区详情',
+    selectWorkspace: '选择一个工作区查看入口、验证命令、阅读路径和缺失项。',
   },
   en: {
     title: 'Harness Dashboard',
@@ -677,10 +682,11 @@ const messages = {
     filterMissing: 'Missing',
     currentMissing: 'Current Harness Missing Items',
     workspaceDetail: 'Workspace Detail',
+    selectWorkspace: 'Select a workspace to inspect entry, validation commands, reading path, and missing items.',
   },
 };
 const savedLang = localStorage.getItem('harness-dashboard-lang');
-const state = { selected: reports[0]?.path || '', filter: 'all', query: '', lang: savedLang === 'en' ? 'en' : 'zh' };
+const state = { selected: '', filter: 'all', query: '', lang: savedLang === 'en' ? 'en' : 'zh' };
 
 function escapeHtml(s){ return String(s ?? '').replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
 function radius(n){ return n.type==='workspace'?10:n.type==='gap'?9:6; }
@@ -793,7 +799,7 @@ function filteredReports(){
 function renderWorkspaceCard(report){
   const gapText = report.gaps.length === 0 ? bi('无缺失项', 'No missing items') : countLabel(report.gaps.length, ' 个缺失项', 'missing item', 'missing items');
   const commandCount = countLabel(report.commands.length, ' 条命令', 'command', 'commands');
-  return '<article class="workspace-card '+(state.selected === report.path ? 'active' : '')+'" data-workspace="'+escapeHtml(report.path)+'">'+
+  return '<article class="workspace-card '+(state.selected === report.path ? 'active' : '')+'" data-workspace="'+escapeHtml(report.path)+'" tabindex="0">'+
     '<div class="row-title"><strong class="path">'+escapeHtml(report.path)+'</strong><span class="score">'+report.score+'</span></div>'+
     '<div class="muted">'+escapeHtml(report.role)+' / '+escapeHtml(report.packageName)+'</div>'+
     '<div class="badges">'+statusBadge(report.status)+'<span class="badge info">'+escapeHtml(report.type)+'</span><span class="badge">'+commandCount+'</span></div>'+
@@ -805,7 +811,9 @@ function renderWorkspaces(){
   document.getElementById('workspace-grid').innerHTML = items.length ? items.map(renderWorkspaceCard).join('') : '<div class="empty">'+bi('当前筛选无匹配工作区', 'No workspaces match the current filter')+'</div>';
 }
 function renderGapRow(gap){
-  return '<div class="gap-row">'+
+  const canOpen = gap.workspace && byWorkspace.has(gap.workspace);
+  const workspaceAttr = canOpen ? ' data-workspace="'+escapeHtml(gap.workspace)+'" tabindex="0"' : '';
+  return '<div class="gap-row '+(canOpen ? 'actionable' : '')+'"'+workspaceAttr+'>'+
     '<div><span class="severity '+escapeHtml(gap.severity)+'">'+escapeHtml(severityLabel(gap.severity))+'</span><div class="muted">'+escapeHtml(typeLabel(gap.type))+'</div></div>'+
     '<div><strong>'+escapeHtml(gapLabel(gap))+'</strong><div class="path">'+escapeHtml(gap.workspace || gap.path)+'</div><div class="muted">'+escapeHtml(gapDetail(gap))+'</div></div>'+
   '</div>';
@@ -818,10 +826,10 @@ function renderCommands(commands){
   return commands.map(command => '<div class="command"><code>'+escapeHtml(command)+'</code><button data-copy="'+escapeHtml(command)+'">'+bi('复制', 'Copy')+'</button></div>').join('');
 }
 function renderDetail(){
-  const report = byWorkspace.get(state.selected) || reports[0];
+  const report = byWorkspace.get(state.selected);
   if (!report) {
-    document.getElementById('detail-title').textContent = bi('工作区详情', 'Workspace Detail');
-    document.getElementById('detail-body').innerHTML = '<div class="empty">'+bi('未找到工作区数据', 'No workspace data found')+'</div>';
+    document.getElementById('detail-title').textContent = t('workspaceDetail');
+    document.getElementById('detail-body').innerHTML = '<div class="empty">'+t('selectWorkspace')+'</div>';
     return;
   }
   document.getElementById('detail-title').textContent = report.path;
@@ -843,6 +851,18 @@ function renderDetail(){
 function showTab(tab){
   document.querySelectorAll('.tabs button').forEach(button => button.classList.toggle('active', button.dataset.tab === tab));
   document.querySelectorAll('.view').forEach(view => view.classList.toggle('active', view.id === tab));
+  document.querySelector('.shell').classList.toggle('workspace-mode', tab === 'workspaces');
+}
+function openWorkspace(path){
+  if (!byWorkspace.has(path)) return;
+  state.selected = path;
+  showTab('workspaces');
+  renderWorkspaces();
+  renderDetail();
+  requestAnimationFrame(() => {
+    document.querySelector('.workspace-card.active')?.scrollIntoView({ block: 'nearest' });
+    document.querySelector('.detail')?.scrollTo({ top: 0 });
+  });
 }
 function init(){
   renderStaticText(); renderMeta(); renderMetrics(); renderHealth(); renderPriorityGaps(); renderReadingLoop(); renderWorkspaces(); renderGaps(); renderDetail();
@@ -862,11 +882,25 @@ function init(){
   document.getElementById('workspace-search').addEventListener('input', e => { state.query = e.target.value; renderWorkspaces(); });
   document.getElementById('workspace-grid').addEventListener('click', e => {
     const card = e.target.closest('[data-workspace]'); if(!card) return;
-    state.selected = card.dataset.workspace; renderWorkspaces(); renderDetail();
+    openWorkspace(card.dataset.workspace);
+  });
+  document.getElementById('workspace-grid').addEventListener('keydown', e => {
+    const card = e.target.closest('[data-workspace]');
+    if (!card || (e.key !== 'Enter' && e.key !== ' ')) return;
+    e.preventDefault();
+    openWorkspace(card.dataset.workspace);
   });
   document.body.addEventListener('click', e => {
+    const gap = e.target.closest('.gap-row[data-workspace]');
+    if (gap) { openWorkspace(gap.dataset.workspace); return; }
     const copy = e.target.closest('button[data-copy]'); if(!copy) return;
     navigator.clipboard?.writeText(copy.dataset.copy).then(() => { copy.textContent = bi('已复制', 'Copied'); setTimeout(() => { copy.textContent = bi('复制', 'Copy'); }, 1100); });
+  });
+  document.body.addEventListener('keydown', e => {
+    const gap = e.target.closest?.('.gap-row[data-workspace]');
+    if (!gap || (e.key !== 'Enter' && e.key !== ' ')) return;
+    e.preventDefault();
+    openWorkspace(gap.dataset.workspace);
   });
 }
 init();

--- a/harness/tools/graph-viewer/server.mjs
+++ b/harness/tools/graph-viewer/server.mjs
@@ -545,15 +545,19 @@ main { min-width:0; padding:22px 24px 36px; }
 .gap-groups { display:grid; gap:14px; }
 .gap-group { border:1px solid var(--line); border-radius:8px; overflow:hidden; background:#141922; }
 .gap-group-header { display:flex; justify-content:space-between; gap:14px; align-items:flex-start; padding:12px 14px; background:var(--panel-2); border-bottom:1px solid var(--line); }
-.gap-group-header.actionable { cursor:pointer; }
-.gap-group-header.actionable:hover, .gap-group-header.actionable:focus { background:#202938; outline:0; }
+.gap-group-header { cursor:pointer; }
+.gap-group-header:hover, .gap-group-header:focus { background:#202938; outline:0; }
 .gap-group-title { display:grid; gap:4px; min-width:0; }
 .gap-group-title strong { font-size:15px; }
+.gap-group-actions { display:grid; justify-items:end; gap:8px; }
+.gap-group-buttons { display:flex; justify-content:flex-end; gap:8px; flex-wrap:wrap; }
 .gap-group-body { padding:10px 12px 2px; }
+.gap-group.collapsed .gap-group-body { display:none; }
 .gap-group-body .gap-row { background:#171d26; }
 .gap-row { display:grid; grid-template-columns:120px minmax(0, 1fr); gap:12px; margin-bottom:10px; }
 .gap-row.actionable { cursor:pointer; }
 .gap-row.actionable:hover, .gap-row.actionable:focus { border-color:var(--blue); background:#202938; outline:0; }
+.gap-row-path { display:flex; flex-wrap:wrap; gap:6px; align-items:baseline; margin-top:2px; }
 .severity { font-weight:700; }
 .severity.high { color:var(--red); }
 .severity.medium { color:var(--yellow); }
@@ -581,6 +585,8 @@ pre { white-space:pre-wrap; word-break:break-word; background:#0c0f13; border:1p
   .topbar, main, .detail { padding-left:14px; padding-right:14px; }
   .metrics { grid-template-columns:1fr; }
   .gap-group-header { display:grid; }
+  .gap-group-actions { justify-items:start; }
+  .gap-group-buttons { justify-content:flex-start; }
   .gap-row, .mini-row { grid-template-columns:1fr; }
 }
 </style>
@@ -674,6 +680,11 @@ const messages = {
     currentMissing: '当前 Harness 缺失项',
     workspaceDetail: '工作区详情',
     selectWorkspace: '选择一个工作区查看入口、验证命令、阅读路径和缺失项。',
+    viewWorkspace: '查看工作区',
+    collapse: '收起',
+    expand: '展开',
+    fixLocation: '修复位置',
+    workspaceScope: '工作区',
   },
   en: {
     title: 'Harness Dashboard',
@@ -693,10 +704,15 @@ const messages = {
     currentMissing: 'Current Harness Missing Items',
     workspaceDetail: 'Workspace Detail',
     selectWorkspace: 'Select a workspace to inspect entry, validation commands, reading path, and missing items.',
+    viewWorkspace: 'View Workspace',
+    collapse: 'Collapse',
+    expand: 'Expand',
+    fixLocation: 'Fix Location',
+    workspaceScope: 'Workspace',
   },
 };
 const savedLang = localStorage.getItem('harness-dashboard-lang');
-const state = { selected: '', filter: 'all', query: '', lang: savedLang === 'en' ? 'en' : 'zh' };
+const state = { selected: '', filter: 'all', query: '', lang: savedLang === 'en' ? 'en' : 'zh', collapsedGapGroups: new Set() };
 
 function escapeHtml(s){ return String(s ?? '').replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
 function radius(n){ return n.type==='workspace'?10:n.type==='gap'?9:6; }
@@ -822,12 +838,13 @@ function renderWorkspaces(){
 }
 function renderGapRow(gap, options = {}){
   const showWorkspace = options.showWorkspace !== false;
-  const canOpen = gap.workspace && byWorkspace.has(gap.workspace);
+  const canOpen = options.drillIn !== false && gap.workspace && byWorkspace.has(gap.workspace);
   const workspaceAttr = canOpen ? ' data-workspace="'+escapeHtml(gap.workspace)+'" tabindex="0"' : '';
   const pathLabel = showWorkspace ? (gap.workspace || gap.path) : (gap.path || gap.workspace);
+  const pathCaption = showWorkspace ? t('workspaceScope') : t('fixLocation');
   return '<div class="gap-row '+(canOpen ? 'actionable' : '')+'"'+workspaceAttr+'>'+
     '<div><span class="severity '+escapeHtml(gap.severity)+'">'+escapeHtml(severityLabel(gap.severity))+'</span><div class="muted">'+escapeHtml(typeLabel(gap.type))+'</div></div>'+
-    '<div><strong>'+escapeHtml(gapLabel(gap))+'</strong><div class="path">'+escapeHtml(pathLabel)+'</div><div class="muted">'+escapeHtml(gapDetail(gap))+'</div></div>'+
+    '<div><strong>'+escapeHtml(gapLabel(gap))+'</strong><div class="gap-row-path"><span class="muted">'+escapeHtml(pathCaption)+'</span><span class="path">'+escapeHtml(pathLabel)+'</span></div><div class="muted">'+escapeHtml(gapDetail(gap))+'</div></div>'+
   '</div>';
 }
 function gapGroups(){
@@ -844,17 +861,19 @@ function renderGapGroup(group){
   const mediumCount = group.items.filter(gap => gap.severity === 'medium').length;
   const typeBadges = [...new Set(group.items.map(gap => typeLabel(gap.type)))].map(type => '<span class="badge">'+escapeHtml(type)+'</span>').join('');
   const canOpen = group.workspace && byWorkspace.has(group.workspace);
-  const workspaceAttr = canOpen ? ' data-workspace="'+escapeHtml(group.workspace)+'" tabindex="0"' : '';
+  const collapsed = state.collapsedGapGroups.has(group.workspace);
+  const toggleAttr = ' data-toggle-gap-group="'+escapeHtml(group.workspace)+'"';
+  const workspaceAction = canOpen ? '<button data-open-workspace="'+escapeHtml(group.workspace)+'">'+t('viewWorkspace')+'</button>' : '';
   const severityBadges = [
     highCount ? '<span class="badge missing">'+escapeHtml(countLabel(highCount, ' 个高优先级', 'high priority item', 'high priority items'))+'</span>' : '',
     mediumCount ? '<span class="badge partial">'+escapeHtml(countLabel(mediumCount, ' 个中优先级', 'medium priority item', 'medium priority items'))+'</span>' : '',
   ].join('');
-  return '<section class="gap-group">'+
-    '<div class="gap-group-header '+(canOpen ? 'actionable' : '')+'"'+workspaceAttr+'>'+
+  return '<section class="gap-group '+(collapsed ? 'collapsed' : '')+'">'+
+    '<div class="gap-group-header"'+toggleAttr+' tabindex="0">'+
       '<div class="gap-group-title"><strong class="path">'+escapeHtml(group.workspace)+'</strong><div class="muted">'+escapeHtml(countLabel(group.items.length, ' 个缺失项', 'missing item', 'missing items'))+'</div></div>'+
-      '<div class="badges">'+severityBadges+typeBadges+'</div>'+
+      '<div class="gap-group-actions"><div class="badges">'+severityBadges+typeBadges+'</div><div class="gap-group-buttons">'+workspaceAction+'<button data-toggle-gap-group="'+escapeHtml(group.workspace)+'">'+(collapsed ? t('expand') : t('collapse'))+'</button></div></div>'+
     '</div>'+
-    '<div class="gap-group-body">'+group.items.map(gap => renderGapRow(gap, { showWorkspace: false })).join('')+'</div>'+
+    '<div class="gap-group-body">'+group.items.map(gap => renderGapRow(gap, { showWorkspace: false, drillIn: false })).join('')+'</div>'+
   '</section>';
 }
 function renderGaps(){
@@ -903,6 +922,11 @@ function openWorkspace(path){
     document.querySelector('.detail')?.scrollTo({ top: 0 });
   });
 }
+function toggleGapGroup(workspace){
+  if (state.collapsedGapGroups.has(workspace)) state.collapsedGapGroups.delete(workspace);
+  else state.collapsedGapGroups.add(workspace);
+  renderGaps();
+}
 function init(){
   renderStaticText(); renderMeta(); renderMetrics(); renderHealth(); renderPriorityGaps(); renderReadingLoop(); renderWorkspaces(); renderGaps(); renderDetail();
   document.querySelector('.language-switch').addEventListener('click', e => {
@@ -930,13 +954,23 @@ function init(){
     openWorkspace(card.dataset.workspace);
   });
   document.body.addEventListener('click', e => {
-    const gap = e.target.closest('.gap-row[data-workspace], .gap-group-header[data-workspace]');
+    const workspaceAction = e.target.closest('[data-open-workspace]');
+    if (workspaceAction) { openWorkspace(workspaceAction.dataset.openWorkspace); return; }
+    const gapToggle = e.target.closest('[data-toggle-gap-group]');
+    if (gapToggle) { toggleGapGroup(gapToggle.dataset.toggleGapGroup); return; }
+    const gap = e.target.closest('.gap-row[data-workspace]');
     if (gap) { openWorkspace(gap.dataset.workspace); return; }
     const copy = e.target.closest('button[data-copy]'); if(!copy) return;
     navigator.clipboard?.writeText(copy.dataset.copy).then(() => { copy.textContent = bi('已复制', 'Copied'); setTimeout(() => { copy.textContent = bi('复制', 'Copy'); }, 1100); });
   });
   document.body.addEventListener('keydown', e => {
-    const gap = e.target.closest?.('.gap-row[data-workspace], .gap-group-header[data-workspace]');
+    const gapToggle = e.target.closest?.('[data-toggle-gap-group]');
+    if (gapToggle && gapToggle.tagName !== 'BUTTON' && (e.key === 'Enter' || e.key === ' ')) {
+      e.preventDefault();
+      toggleGapGroup(gapToggle.dataset.toggleGapGroup);
+      return;
+    }
+    const gap = e.target.closest?.('.gap-row[data-workspace]');
     if (!gap || (e.key !== 'Enter' && e.key !== ' ')) return;
     e.preventDefault();
     openWorkspace(gap.dataset.workspace);

--- a/harness/tools/graph-viewer/server.mjs
+++ b/harness/tools/graph-viewer/server.mjs
@@ -559,8 +559,12 @@ pre { white-space:pre-wrap; word-break:break-word; background:#0c0f13; border:1p
 svg { width:100%; height:100%; display:block; }
 .edge { stroke:#596373; stroke-width:1.1; opacity:.38; }
 .edge.high { stroke:var(--blue); opacity:.62; }
-.node circle { stroke:#090b0e; stroke-width:2; cursor:pointer; }
-.node text { fill:var(--text); font-size:10px; paint-order:stroke; stroke:#0b0e13; stroke-width:4px; pointer-events:none; }
+.node { cursor:pointer; }
+.node .hit { fill:transparent; stroke:transparent; pointer-events:all; }
+.node .node-dot { stroke:#090b0e; stroke-width:2; }
+.node text { fill:var(--text); font-size:10px; paint-order:stroke; stroke:#0b0e13; stroke-width:4px; pointer-events:all; cursor:pointer; }
+.node.selected .node-dot { stroke:var(--text); stroke-width:3; }
+.node.selected text { fill:var(--blue); }
 .empty { color:var(--muted); border:1px dashed var(--line); border-radius:8px; padding:16px; }
 @media (max-width: 1180px) {
   .shell, .grid-2, .graph-layout { grid-template-columns:1fr; }
@@ -729,7 +733,7 @@ const messages = {
   },
 };
 const savedLang = localStorage.getItem('harness-dashboard-lang');
-const state = { selected: reports[0]?.path || '', filter: 'all', query: '', nodeFilter: 'all', lang: savedLang === 'en' ? 'en' : 'zh' };
+const state = { selected: reports[0]?.path || '', selectedNodeId: '', filter: 'all', query: '', nodeFilter: 'all', lang: savedLang === 'en' ? 'en' : 'zh' };
 let running = true;
 
 function escapeHtml(s){ return String(s ?? '').replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
@@ -899,8 +903,27 @@ function showTab(tab){
 function applyNodeFilter(){
   for (const node of nodes) node.visible = state.nodeFilter === 'all' || node.type === state.nodeFilter || (state.nodeFilter === 'validation' && node.type === 'profile');
 }
+function graphPointFromEvent(event){
+  const rect = svg.getBoundingClientRect();
+  return { x: event.clientX - rect.left, y: event.clientY - rect.top };
+}
+function nearestVisibleNode(point){
+  let best = null;
+  let bestDistance = Infinity;
+  for (const node of nodes) {
+    if (!node.visible) continue;
+    const distance = Math.hypot(node.x - point.x, node.y - point.y);
+    const hitRadius = Math.max(32, radius(node) + 18);
+    if (distance <= hitRadius && distance < bestDistance) {
+      best = node;
+      bestDistance = distance;
+    }
+  }
+  return best;
+}
 function selectGraphNode(id){
   const n = byId.get(id); if(!n) return;
+  state.selectedNodeId = n.id;
   document.getElementById('graph-title').textContent = n.label;
   const related = graph.edges.filter(e => e.from===n.id || e.to===n.id).map(e => e.type+' '+e.confidence+'\\n  '+e.from+'\\n  -> '+e.to).join('\\n\\n');
   document.getElementById('graph-detail').innerHTML = '<pre>'+escapeHtml(JSON.stringify(n.meta, null, 2))+'</pre><h3>'+bi('连接边', 'Edges')+'</h3><pre>'+escapeHtml(related || bi('无连接边', 'No connected edges'))+'</pre>';
@@ -908,6 +931,7 @@ function selectGraphNode(id){
     const report = byWorkspace.get(n.label);
     if (report) { state.selected = report.path; renderDetail(); renderWorkspaces(); }
   }
+  render();
 }
 function init(){
   renderStaticText(); renderMeta(); renderMetrics(); renderHealth(); renderPriorityGaps(); renderReadingLoop(); renderWorkspaces(); renderGaps(); renderDetail(); applyNodeFilter();
@@ -963,14 +987,23 @@ function render(){
   }
   for(const n of nodes){
     if(!n.visible) continue;
-    const g = document.createElementNS('http://www.w3.org/2000/svg','g'); g.setAttribute('class','node'); g.dataset.id=n.id; g.setAttribute('transform','translate('+n.x+','+n.y+')');
-    const c = document.createElementNS('http://www.w3.org/2000/svg','circle'); c.setAttribute('r',radius(n)); c.setAttribute('fill',colors[n.type]||'#ddd');
+    const g = document.createElementNS('http://www.w3.org/2000/svg','g'); g.setAttribute('class','node '+(state.selectedNodeId === n.id ? 'selected' : '')); g.dataset.id=n.id; g.setAttribute('transform','translate('+n.x+','+n.y+')');
+    const hit = document.createElementNS('http://www.w3.org/2000/svg','circle'); hit.setAttribute('class','hit'); hit.setAttribute('r',Math.max(22, radius(n) + 12));
+    const c = document.createElementNS('http://www.w3.org/2000/svg','circle'); c.setAttribute('class','node-dot'); c.setAttribute('r',radius(n)); c.setAttribute('fill',colors[n.type]||'#ddd');
     const t = document.createElementNS('http://www.w3.org/2000/svg','text'); t.setAttribute('x',radius(n)+5); t.setAttribute('y',4); t.textContent=n.label;
-    g.appendChild(c); g.appendChild(t); frag.appendChild(g);
+    g.appendChild(hit); g.appendChild(c); g.appendChild(t); frag.appendChild(g);
   }
   svg.appendChild(frag);
 }
-svg.addEventListener('click', e => { const g=e.target.closest('.node'); if(g) selectGraphNode(g.dataset.id); });
+svg.addEventListener('click', e => {
+  const g = e.target.closest?.('.node');
+  if(g) {
+    selectGraphNode(g.dataset.id);
+    return;
+  }
+  const nearest = nearestVisibleNode(graphPointFromEvent(e));
+  if(nearest) selectGraphNode(nearest.id);
+});
 init(); tick();
 </script>
 </body>

--- a/harness/tools/graph-viewer/server.mjs
+++ b/harness/tools/graph-viewer/server.mjs
@@ -480,7 +480,7 @@ body {
   color:var(--text);
   font:14px/1.45 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
-body.modal-open { overflow:hidden; }
+body.drawer-open { overflow:hidden; }
 button, input { font:inherit; }
 .topbar { border-bottom:1px solid var(--line); background:#12151a; padding:18px 24px; }
 .topline { display:flex; justify-content:space-between; align-items:flex-start; gap:16px; }
@@ -504,10 +504,7 @@ button {
 }
 button:hover, button.active { border-color:var(--blue); color:var(--blue); }
 .shell { display:grid; grid-template-columns:1fr; gap:0; min-height:calc(100vh - 115px); }
-.shell.workspace-mode { grid-template-columns:minmax(0, 1fr) minmax(360px, 420px); }
 main { min-width:0; padding:22px 24px 36px; }
-.detail { display:none; border-left:1px solid var(--line); background:var(--panel); padding:22px; overflow:auto; }
-.shell.workspace-mode .detail { display:block; }
 .view { display:none; }
 .view.active { display:block; }
 .metrics { display:grid; grid-template-columns:repeat(4, minmax(150px, 1fr)); gap:12px; margin-bottom:18px; }
@@ -573,26 +570,24 @@ pre { white-space:pre-wrap; word-break:break-word; background:#0c0f13; border:1p
 .reading div { border:1px solid var(--line); background:var(--panel-2); border-radius:6px; padding:8px; }
 .reading div::before { counter-increment:readstep; content:counter(readstep) ". "; color:var(--blue); font-weight:700; }
 .empty { color:var(--muted); border:1px dashed var(--line); border-radius:8px; padding:16px; }
-.modal-backdrop {
+.drawer-backdrop {
   position:fixed;
   inset:0;
   z-index:30;
-  display:grid;
-  place-items:center;
-  padding:24px;
+  display:flex;
+  justify-content:flex-end;
   background:rgba(5, 8, 13, 0.72);
 }
-.modal-backdrop[hidden] { display:none; }
-.modal-panel {
-  width:min(920px, 100%);
-  max-height:min(86vh, 920px);
+.drawer-backdrop[hidden] { display:none; }
+.drawer-panel {
+  width:min(640px, 100%);
+  height:100%;
   overflow:auto;
-  border:1px solid var(--line);
-  border-radius:8px;
+  border-left:1px solid var(--line);
   background:var(--panel);
-  box-shadow:0 24px 80px rgba(0, 0, 0, 0.45);
+  box-shadow:-24px 0 80px rgba(0, 0, 0, 0.45);
 }
-.modal-header {
+.drawer-header {
   position:sticky;
   top:0;
   z-index:1;
@@ -604,10 +599,9 @@ pre { white-space:pre-wrap; word-break:break-word; background:#0c0f13; border:1p
   border-bottom:1px solid var(--line);
   background:var(--panel);
 }
-.modal-body { padding:16px; }
+.drawer-body { padding:16px; }
 @media (max-width: 1180px) {
-  .shell, .shell.workspace-mode, .grid-2 { grid-template-columns:1fr; }
-  .detail { border-left:0; border-top:1px solid var(--line); }
+  .shell, .grid-2 { grid-template-columns:1fr; }
   .metrics { grid-template-columns:repeat(2, minmax(150px, 1fr)); }
   .meta { text-align:left; white-space:normal; }
   .meta-panel { justify-items:start; }
@@ -615,9 +609,8 @@ pre { white-space:pre-wrap; word-break:break-word; background:#0c0f13; border:1p
   .topline { flex-direction:column; }
 }
 @media (max-width: 620px) {
-  .topbar, main, .detail { padding-left:14px; padding-right:14px; }
-  .modal-backdrop { padding:12px; }
-  .modal-header, .modal-body { padding:14px; }
+  .topbar, main { padding-left:14px; padding-right:14px; }
+  .drawer-header, .drawer-body { padding:14px; }
   .metrics { grid-template-columns:1fr; }
   .gap-group-header { display:grid; }
   .gap-group-actions { justify-items:start; }
@@ -686,18 +679,14 @@ pre { white-space:pre-wrap; word-break:break-word; background:#0c0f13; border:1p
     </section>
 
   </main>
-  <aside class="detail">
-    <h2 id="detail-title" data-i18n="workspaceDetail">工作区详情</h2>
-    <div id="detail-body"></div>
-  </aside>
 </div>
-<div id="workspace-modal" class="modal-backdrop" hidden>
-  <section class="modal-panel" role="dialog" aria-modal="true" aria-labelledby="modal-title">
-    <div class="modal-header">
-      <h2 id="modal-title">工作区详情</h2>
-      <button data-close-modal data-i18n="closeModal">关闭</button>
+<div id="workspace-drawer" class="drawer-backdrop" hidden>
+  <section class="drawer-panel" role="dialog" aria-modal="true" aria-labelledby="drawer-title">
+    <div class="drawer-header">
+      <h2 id="drawer-title">工作区详情</h2>
+      <button data-close-drawer data-i18n="closeDrawer">关闭</button>
     </div>
-    <div id="modal-body" class="modal-body"></div>
+    <div id="drawer-body" class="drawer-body"></div>
   </section>
 </div>
 <script>
@@ -725,7 +714,7 @@ const messages = {
     workspaceDetail: '工作区详情',
     selectWorkspace: '选择一个工作区查看入口、验证命令、阅读路径和缺失项。',
     viewWorkspace: '查看工作区',
-    closeModal: '关闭',
+    closeDrawer: '关闭',
     collapse: '收起',
     expand: '展开',
     fixLocation: '修复位置',
@@ -750,7 +739,7 @@ const messages = {
     workspaceDetail: 'Workspace Detail',
     selectWorkspace: 'Select a workspace to inspect entry, validation commands, reading path, and missing items.',
     viewWorkspace: 'View Workspace',
-    closeModal: 'Close',
+    closeDrawer: 'Close',
     collapse: 'Collapse',
     expand: 'Expand',
     fixLocation: 'Fix Location',
@@ -758,7 +747,7 @@ const messages = {
   },
 };
 const savedLang = localStorage.getItem('harness-dashboard-lang');
-const state = { selected: '', filter: 'all', query: '', lang: savedLang === 'en' ? 'en' : 'zh', collapsedGapGroups: new Set(), modalWorkspace: '' };
+const state = { selected: '', filter: 'all', query: '', lang: savedLang === 'en' ? 'en' : 'zh', collapsedGapGroups: new Set(), drawerWorkspace: '' };
 
 function escapeHtml(s){ return String(s ?? '').replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
 function radius(n){ return n.type==='workspace'?10:n.type==='gap'?9:6; }
@@ -944,54 +933,34 @@ function workspaceDetailHtml(report){
     '<section class="panel"><h3>'+bi('知识引用', 'Knowledge')+'</h3>'+knowledge+'</section>'+
     '<section class="panel"><h3>'+bi('缺失项', 'Missing')+'</h3>'+missing+'</section>';
 }
-function renderDetail(){
-  const report = byWorkspace.get(state.selected);
-  if (!report) {
-    document.getElementById('detail-title').textContent = t('workspaceDetail');
-    document.getElementById('detail-body').innerHTML = '<div class="empty">'+t('selectWorkspace')+'</div>';
-    return;
-  }
-  document.getElementById('detail-title').textContent = report.path;
-  document.getElementById('detail-body').innerHTML = workspaceDetailHtml(report);
-}
 function showTab(tab){
   document.querySelectorAll('.tabs button').forEach(button => button.classList.toggle('active', button.dataset.tab === tab));
   document.querySelectorAll('.view').forEach(view => view.classList.toggle('active', view.id === tab));
-  document.querySelector('.shell').classList.toggle('workspace-mode', tab === 'workspaces');
 }
-function openWorkspace(path){
-  if (!byWorkspace.has(path)) return;
-  state.selected = path;
-  showTab('workspaces');
-  renderWorkspaces();
-  renderDetail();
-  requestAnimationFrame(() => {
-    document.querySelector('.workspace-card.active')?.scrollIntoView({ block: 'nearest' });
-    document.querySelector('.detail')?.scrollTo({ top: 0 });
-  });
-}
-function renderModal(){
-  const report = byWorkspace.get(state.modalWorkspace);
-  const modal = document.getElementById('workspace-modal');
+function renderDrawer(){
+  const report = byWorkspace.get(state.drawerWorkspace);
+  const drawer = document.getElementById('workspace-drawer');
   if (!report) {
-    modal.hidden = true;
-    document.body.classList.remove('modal-open');
+    drawer.hidden = true;
+    document.body.classList.remove('drawer-open');
     return;
   }
-  document.getElementById('modal-title').textContent = report.path;
-  document.getElementById('modal-body').innerHTML = workspaceDetailHtml(report);
-  modal.hidden = false;
-  document.body.classList.add('modal-open');
+  document.getElementById('drawer-title').textContent = report.path;
+  document.getElementById('drawer-body').innerHTML = workspaceDetailHtml(report);
+  drawer.hidden = false;
+  document.body.classList.add('drawer-open');
 }
-function openWorkspaceModal(path){
+function openWorkspaceDrawer(path){
   if (!byWorkspace.has(path)) return;
-  state.modalWorkspace = path;
-  renderModal();
-  requestAnimationFrame(() => document.querySelector('[data-close-modal]')?.focus());
+  state.selected = path;
+  state.drawerWorkspace = path;
+  renderWorkspaces();
+  renderDrawer();
+  requestAnimationFrame(() => document.querySelector('[data-close-drawer]')?.focus());
 }
-function closeWorkspaceModal(){
-  state.modalWorkspace = '';
-  renderModal();
+function closeWorkspaceDrawer(){
+  state.drawerWorkspace = '';
+  renderDrawer();
 }
 function toggleGapGroup(workspace){
   if (state.collapsedGapGroups.has(workspace)) state.collapsedGapGroups.delete(workspace);
@@ -999,12 +968,12 @@ function toggleGapGroup(workspace){
   renderGaps();
 }
 function init(){
-  renderStaticText(); renderMeta(); renderMetrics(); renderHealth(); renderPriorityGaps(); renderReadingLoop(); renderWorkspaces(); renderGaps(); renderDetail();
+  renderStaticText(); renderMeta(); renderMetrics(); renderHealth(); renderPriorityGaps(); renderReadingLoop(); renderWorkspaces(); renderGaps(); renderDrawer();
   document.querySelector('.language-switch').addEventListener('click', e => {
     const button = e.target.closest('button[data-lang]'); if(!button) return;
     state.lang = button.dataset.lang === 'en' ? 'en' : 'zh';
     localStorage.setItem('harness-dashboard-lang', state.lang);
-    renderStaticText(); renderMeta(); renderMetrics(); renderHealth(); renderPriorityGaps(); renderReadingLoop(); renderWorkspaces(); renderGaps(); renderDetail(); renderModal();
+    renderStaticText(); renderMeta(); renderMetrics(); renderHealth(); renderPriorityGaps(); renderReadingLoop(); renderWorkspaces(); renderGaps(); renderDrawer();
   });
   document.querySelector('.tabs').addEventListener('click', e => { const button = e.target.closest('button[data-tab]'); if(button) showTab(button.dataset.tab); });
   document.querySelector('.filters').addEventListener('click', e => {
@@ -1016,28 +985,28 @@ function init(){
   document.getElementById('workspace-search').addEventListener('input', e => { state.query = e.target.value; renderWorkspaces(); });
   document.getElementById('workspace-grid').addEventListener('click', e => {
     const card = e.target.closest('[data-workspace]'); if(!card) return;
-    openWorkspace(card.dataset.workspace);
+    openWorkspaceDrawer(card.dataset.workspace);
   });
   document.getElementById('workspace-grid').addEventListener('keydown', e => {
     const card = e.target.closest('[data-workspace]');
     if (!card || (e.key !== 'Enter' && e.key !== ' ')) return;
     e.preventDefault();
-    openWorkspace(card.dataset.workspace);
+    openWorkspaceDrawer(card.dataset.workspace);
   });
   document.body.addEventListener('click', e => {
     const workspaceAction = e.target.closest('[data-open-workspace]');
-    if (workspaceAction) { openWorkspaceModal(workspaceAction.dataset.openWorkspace); return; }
-    if (e.target.closest('[data-close-modal]') || e.target.id === 'workspace-modal') { closeWorkspaceModal(); return; }
+    if (workspaceAction) { openWorkspaceDrawer(workspaceAction.dataset.openWorkspace); return; }
+    if (e.target.closest('[data-close-drawer]') || e.target.id === 'workspace-drawer') { closeWorkspaceDrawer(); return; }
     const gapToggle = e.target.closest('[data-toggle-gap-group]');
     if (gapToggle) { toggleGapGroup(gapToggle.dataset.toggleGapGroup); return; }
     const gap = e.target.closest('.gap-row[data-workspace]');
-    if (gap) { openWorkspaceModal(gap.dataset.workspace); return; }
+    if (gap) { openWorkspaceDrawer(gap.dataset.workspace); return; }
     const copy = e.target.closest('button[data-copy]'); if(!copy) return;
     navigator.clipboard?.writeText(copy.dataset.copy).then(() => { copy.textContent = bi('已复制', 'Copied'); setTimeout(() => { copy.textContent = bi('复制', 'Copy'); }, 1100); });
   });
   document.body.addEventListener('keydown', e => {
-    if (e.key === 'Escape' && state.modalWorkspace) {
-      closeWorkspaceModal();
+    if (e.key === 'Escape' && state.drawerWorkspace) {
+      closeWorkspaceDrawer();
       return;
     }
     const gapToggle = e.target.closest?.('[data-toggle-gap-group]');
@@ -1049,7 +1018,7 @@ function init(){
     const gap = e.target.closest?.('.gap-row[data-workspace]');
     if (!gap || (e.key !== 'Enter' && e.key !== ' ')) return;
     e.preventDefault();
-    openWorkspaceModal(gap.dataset.workspace);
+    openWorkspaceDrawer(gap.dataset.workspace);
   });
 }
 init();

--- a/harness/tools/graph-viewer/server.mjs
+++ b/harness/tools/graph-viewer/server.mjs
@@ -451,11 +451,11 @@ function buildGraph() {
 function html(graph) {
   const graphJson = JSON.stringify(graph).replaceAll('<', '\\u003c');
   return `<!doctype html>
-<html lang="en">
+<html lang="zh-Hans">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Harness Dashboard</title>
+<title>Harness 看板 / Harness Dashboard</title>
 <style>
 :root {
   color-scheme: dark;
@@ -577,16 +577,16 @@ svg { width:100%; height:100%; display:block; }
 <header class="topbar">
   <div class="topline">
     <div>
-      <h1>Repository Harness Dashboard</h1>
-      <div class="sub">Operational view of harness coverage, workspace guidance, validation commands, and missing pieces.</div>
+      <h1>仓库 Harness 看板 / Repository Harness Dashboard</h1>
+      <div class="sub">快速查看 harness 覆盖、工作区指引、验证命令和当前缺失项。Operational view of harness coverage, workspace guidance, validation commands, and missing pieces.</div>
     </div>
     <div class="meta" id="meta"></div>
   </div>
-  <nav class="tabs" aria-label="Harness views">
-    <button class="active" data-tab="overview">Overview</button>
-    <button data-tab="workspaces">Workspaces</button>
-    <button data-tab="gaps">Missing</button>
-    <button data-tab="graph">Graph</button>
+  <nav class="tabs" aria-label="Harness 视图 / Harness views">
+    <button class="active" data-tab="overview">总览 / Overview</button>
+    <button data-tab="workspaces">工作区 / Workspaces</button>
+    <button data-tab="gaps">缺失 / Missing</button>
+    <button data-tab="graph">关系图 / Graph</button>
   </nav>
 </header>
 <div class="shell">
@@ -595,34 +595,34 @@ svg { width:100%; height:100%; display:block; }
       <div class="metrics" id="metrics"></div>
       <div class="grid-2">
         <section class="panel">
-          <h2>Harness Health</h2>
+          <h2>Harness 健康度 / Harness Health</h2>
           <div id="health"></div>
         </section>
         <section class="panel">
-          <h2>Priority Missing Items</h2>
+          <h2>优先缺失项 / Priority Missing Items</h2>
           <div id="priority-gaps"></div>
         </section>
       </div>
       <section class="panel">
-        <h2>Progressive Reading Loop</h2>
+        <h2>渐进阅读路径 / Progressive Reading Loop</h2>
         <div class="compact-list" id="reading-loop"></div>
       </section>
     </section>
 
     <section id="workspaces" class="view">
       <div class="filters">
-        <input id="workspace-search" class="search" type="search" placeholder="Search workspace, package, role, or command" />
-        <button class="active" data-filter="all">All</button>
-        <button data-filter="ready">Ready</button>
-        <button data-filter="partial">Partial</button>
-        <button data-filter="missing">Missing</button>
+        <input id="workspace-search" class="search" type="search" placeholder="搜索工作区、包、角色或命令 / Search workspace, package, role, or command" />
+        <button class="active" data-filter="all">全部 / All</button>
+        <button data-filter="ready">就绪 / Ready</button>
+        <button data-filter="partial">部分 / Partial</button>
+        <button data-filter="missing">缺失 / Missing</button>
       </div>
       <div class="workspace-grid" id="workspace-grid"></div>
     </section>
 
     <section id="gaps" class="view">
       <section class="panel">
-        <h2>Current Harness Missing Items</h2>
+        <h2>当前 Harness 缺失项 / Current Harness Missing Items</h2>
         <div id="gap-list"></div>
       </section>
     </section>
@@ -631,23 +631,23 @@ svg { width:100%; height:100%; display:block; }
       <div class="graph-layout">
         <div>
           <div class="filters">
-            <button id="toggle-graph">Pause graph</button>
-            <button class="active" data-node-filter="all">All nodes</button>
-            <button data-node-filter="workspace">Workspaces</button>
-            <button data-node-filter="validation">Validation</button>
-            <button data-node-filter="gap">Gaps</button>
+            <button id="toggle-graph">暂停图 / Pause graph</button>
+            <button class="active" data-node-filter="all">全部节点 / All nodes</button>
+            <button data-node-filter="workspace">工作区 / Workspaces</button>
+            <button data-node-filter="validation">验证 / Validation</button>
+            <button data-node-filter="gap">缺口 / Gaps</button>
           </div>
           <div class="graph-box"><svg id="graph-svg" role="img" aria-label="Harness graph"></svg></div>
         </div>
         <section class="panel">
-          <h2 id="graph-title">Graph Selection</h2>
-          <div id="graph-detail" class="muted">Select a node to inspect connected edges.</div>
+          <h2 id="graph-title">图节点选择 / Graph Selection</h2>
+          <div id="graph-detail" class="muted">选择一个节点查看关联边。Select a node to inspect connected edges.</div>
         </section>
       </div>
     </section>
   </main>
   <aside class="detail">
-    <h2 id="detail-title">Workspace Detail</h2>
+    <h2 id="detail-title">工作区详情 / Workspace Detail</h2>
     <div id="detail-body"></div>
   </aside>
 </div>
@@ -667,45 +667,85 @@ let running = true;
 function escapeHtml(s){ return String(s ?? '').replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
 function radius(n){ return n.type==='workspace'?10:n.type==='gap'?9:6; }
 function pct(part, total){ return total ? Math.round(part / total * 100) : 100; }
-function statusLabel(status){ return status === 'ready' ? 'Ready' : status === 'missing' ? 'Missing' : 'Partial'; }
+function bi(zh, en){ return zh + ' / ' + en; }
+function countLabel(count, zhUnit, enSingular, enPlural){ return count + zhUnit + ' / ' + count + ' ' + (count === 1 ? enSingular : enPlural); }
+function statusLabel(status){ return status === 'ready' ? bi('就绪', 'Ready') : status === 'missing' ? bi('缺失', 'Missing') : bi('部分', 'Partial'); }
 function statusBadge(status){ return '<span class="badge '+status+'">'+statusLabel(status)+'</span>'; }
+function severityLabel(severity){ return severity === 'high' ? bi('高', 'HIGH') : severity === 'medium' ? bi('中', 'MEDIUM') : String(severity ?? '').toUpperCase(); }
+function typeLabel(type){
+  const labels = {
+    profile: bi('Profile', 'profile'),
+    entry: bi('入口', 'entry'),
+    knowledge: bi('知识', 'knowledge'),
+    validation: bi('验证', 'validation'),
+  };
+  return labels[type] ?? type;
+}
+function gapLabel(gap){
+  if (gap.label === 'No explicit profile entry') return bi('未显式配置 profile 条目', 'No explicit profile entry');
+  if (gap.label === 'Missing local AGENTS entry') return bi('缺少本地 AGENTS 入口', 'Missing local AGENTS entry');
+  if (gap.label === 'No path-specific validation rule') return bi('缺少路径级验证规则', 'No path-specific validation rule');
+  if (String(gap.label).startsWith('Missing ')) return bi('缺少 ' + String(gap.label).replace(/^Missing\s+/, ''), gap.label);
+  return gap.label;
+}
+function gapDetail(gap){
+  if (gap.detail === 'This workspace falls back to workspaceTypeDefaults instead of a curated entry.') {
+    return bi('该工作区会退回 workspaceTypeDefaults，没有单独精修条目。', gap.detail);
+  }
+  if (gap.detail === 'Workspace has no local harness entry for progressive reading.') {
+    return bi('该工作区缺少用于渐进阅读的本地 harness 入口。', gap.detail);
+  }
+  if (gap.detail === 'Profile points to a file that does not exist.') {
+    return bi('profile 指向了不存在的文件。', gap.detail);
+  }
+  if (gap.detail === 'Validation falls back to workspace scripts instead of a named path rule.') {
+    return bi('验证会退回 workspace 脚本，而不是命名路径规则。', gap.detail);
+  }
+  return gap.detail || '';
+}
+function missingText(){ return bi('未发现 harness 缺失项', 'No missing harness items detected'); }
 function metric(label, value, sub, tone){
   return '<div class="metric '+(tone || '')+'"><b>'+escapeHtml(value)+'</b><span>'+escapeHtml(label)+'</span><div class="muted">'+escapeHtml(sub || '')+'</div></div>';
 }
 function renderMeta(){
-  const scope = graph.profileScope?.mode ? graph.profileScope.mode + ' scope' : 'profile';
+  const scope = graph.profileScope?.mode ? graph.profileScope.mode + ' scope / ' + graph.profileScope.mode + ' 范围' : bi('profile', 'profile');
   document.getElementById('meta').innerHTML = escapeHtml(scope)+'<br><span>'+escapeHtml(new Date(graph.generatedAt).toLocaleString())+'</span>';
 }
 function renderMetrics(){
   const total = graph.summary.activeWorkspaces || reports.length;
   const entryPct = pct(graph.summary.entryCoverage, total);
   const validationPct = pct(graph.summary.validationCoverage, total);
-  const explicitPct = pct(graph.summary.explicitWorkspaces, total);
   document.getElementById('metrics').innerHTML = [
-    metric('Active workspaces', total, graph.summary.explicitWorkspaces + ' curated entries', 'good'),
-    metric('Entry coverage', entryPct + '%', graph.summary.entryCoverage + ' have local entries', entryPct === 100 ? 'good' : 'warn'),
-    metric('Validation coverage', validationPct + '%', graph.summary.validationCoverage + ' have path rules', validationPct === 100 ? 'good' : 'warn'),
-    metric('Missing items', graph.summary.harnessGaps, graph.summary.highSeverityGaps + ' high severity', graph.summary.highSeverityGaps ? 'bad' : graph.summary.harnessGaps ? 'warn' : 'good'),
+    metric(bi('活跃工作区', 'Active workspaces'), total, countLabel(graph.summary.explicitWorkspaces, ' 个精修条目', 'curated entry', 'curated entries'), 'good'),
+    metric(bi('入口覆盖', 'Entry coverage'), entryPct + '%', countLabel(graph.summary.entryCoverage, ' 个有本地入口', 'has local entry', 'have local entries'), entryPct === 100 ? 'good' : 'warn'),
+    metric(bi('验证覆盖', 'Validation coverage'), validationPct + '%', countLabel(graph.summary.validationCoverage, ' 个有路径规则', 'has path rule', 'have path rules'), validationPct === 100 ? 'good' : 'warn'),
+    metric(bi('缺失项', 'Missing items'), graph.summary.harnessGaps, countLabel(graph.summary.highSeverityGaps, ' 个高优先级', 'high severity', 'high severity'), graph.summary.highSeverityGaps ? 'bad' : graph.summary.harnessGaps ? 'warn' : 'good'),
   ].join('');
 }
 function renderHealth(){
   const total = graph.summary.activeWorkspaces || reports.length;
   const rows = [
-    ['Profile entries', graph.summary.explicitWorkspaces, total],
-    ['Local entries', graph.summary.entryCoverage, total],
-    ['Validation rules', graph.summary.validationCoverage, total],
+    [bi('Profile 条目', 'Profile entries'), graph.summary.explicitWorkspaces, total],
+    [bi('本地入口', 'Local entries'), graph.summary.entryCoverage, total],
+    [bi('验证规则', 'Validation rules'), graph.summary.validationCoverage, total],
   ];
   document.getElementById('health').innerHTML = rows.map(([label, count, max]) => {
     const value = pct(count, max);
-    return '<div class="compact-row"><div class="row-title"><strong>'+escapeHtml(label)+'</strong><span class="score">'+value+'%</span></div><div class="coverage-bar" aria-label="'+escapeHtml(label)+' coverage"><span style="width:'+value+'%"></span></div><div class="muted">'+count+' of '+max+'</div></div>';
+    return '<div class="compact-row"><div class="row-title"><strong>'+escapeHtml(label)+'</strong><span class="score">'+value+'%</span></div><div class="coverage-bar" aria-label="'+escapeHtml(label)+' coverage"><span style="width:'+value+'%"></span></div><div class="muted">'+count+' / '+max+'</div></div>';
   }).join('');
 }
 function renderPriorityGaps(){
   const priority = gaps.filter(g => g.severity === 'high').slice(0, 4).concat(gaps.filter(g => g.severity !== 'high').slice(0, Math.max(0, 4 - gaps.filter(g => g.severity === 'high').length)));
-  document.getElementById('priority-gaps').innerHTML = priority.length ? priority.map(renderGapRow).join('') : '<div class="empty">No missing harness items detected.</div>';
+  document.getElementById('priority-gaps').innerHTML = priority.length ? priority.map(renderGapRow).join('') : '<div class="empty">'+missingText()+'</div>';
 }
 function renderReadingLoop(){
-  const loop = ['AGENTS.md / CLAUDE.md', 'harness/README.md', 'harness/profile.yaml', 'affected workspace AGENTS.md', 'workspace contracts, runbook, or validation docs'];
+  const loop = [
+    bi('根入口：AGENTS.md / CLAUDE.md', 'Root entry: AGENTS.md / CLAUDE.md'),
+    bi('Harness 总览：harness/README.md', 'Harness overview: harness/README.md'),
+    bi('机器可读地图：harness/profile.yaml', 'Machine-readable map: harness/profile.yaml'),
+    bi('受影响工作区入口：workspace AGENTS.md', 'Affected workspace entry: workspace AGENTS.md'),
+    bi('按需阅读 contracts、runbook 或 validation 文档', 'Read contracts, runbook, or validation docs as needed'),
+  ];
   document.getElementById('reading-loop').innerHTML = loop.map((item, i) => '<div class="compact-row"><strong>'+(i + 1)+'. '+escapeHtml(item)+'</strong></div>').join('');
 }
 function filteredReports(){
@@ -713,13 +753,13 @@ function filteredReports(){
   return reports.filter(report => {
     if (state.filter !== 'all' && report.status !== state.filter) return false;
     if (!query) return true;
-    const haystack = [report.path, report.packageName, report.role, report.type, ...report.commands, ...report.scripts].join(' ').toLowerCase();
+    const haystack = [report.path, report.packageName, report.role, report.type, statusLabel(report.status), ...report.commands, ...report.scripts, ...report.gaps.map(gapLabel)].join(' ').toLowerCase();
     return haystack.includes(query);
   });
 }
 function renderWorkspaceCard(report){
-  const gapText = report.gaps.length === 0 ? 'No missing items' : report.gaps.length + ' missing item' + (report.gaps.length === 1 ? '' : 's');
-  const commandCount = report.commands.length + ' command' + (report.commands.length === 1 ? '' : 's');
+  const gapText = report.gaps.length === 0 ? bi('无缺失项', 'No missing items') : countLabel(report.gaps.length, ' 个缺失项', 'missing item', 'missing items');
+  const commandCount = countLabel(report.commands.length, ' 条命令', 'command', 'commands');
   return '<article class="workspace-card '+(state.selected === report.path ? 'active' : '')+'" data-workspace="'+escapeHtml(report.path)+'">'+
     '<div class="row-title"><strong class="path">'+escapeHtml(report.path)+'</strong><span class="score">'+report.score+'</span></div>'+
     '<div class="muted">'+escapeHtml(report.role)+' / '+escapeHtml(report.packageName)+'</div>'+
@@ -729,43 +769,43 @@ function renderWorkspaceCard(report){
 }
 function renderWorkspaces(){
   const items = filteredReports();
-  document.getElementById('workspace-grid').innerHTML = items.length ? items.map(renderWorkspaceCard).join('') : '<div class="empty">No workspaces match the current filter.</div>';
+  document.getElementById('workspace-grid').innerHTML = items.length ? items.map(renderWorkspaceCard).join('') : '<div class="empty">'+bi('当前筛选无匹配工作区', 'No workspaces match the current filter')+'</div>';
 }
 function renderGapRow(gap){
   return '<div class="gap-row">'+
-    '<div><span class="severity '+escapeHtml(gap.severity)+'">'+escapeHtml(gap.severity.toUpperCase())+'</span><div class="muted">'+escapeHtml(gap.type)+'</div></div>'+
-    '<div><strong>'+escapeHtml(gap.label)+'</strong><div class="path">'+escapeHtml(gap.workspace || gap.path)+'</div><div class="muted">'+escapeHtml(gap.detail || '')+'</div></div>'+
+    '<div><span class="severity '+escapeHtml(gap.severity)+'">'+escapeHtml(severityLabel(gap.severity))+'</span><div class="muted">'+escapeHtml(typeLabel(gap.type))+'</div></div>'+
+    '<div><strong>'+escapeHtml(gapLabel(gap))+'</strong><div class="path">'+escapeHtml(gap.workspace || gap.path)+'</div><div class="muted">'+escapeHtml(gapDetail(gap))+'</div></div>'+
   '</div>';
 }
 function renderGaps(){
-  document.getElementById('gap-list').innerHTML = gaps.length ? gaps.map(renderGapRow).join('') : '<div class="empty">No missing harness items detected.</div>';
+  document.getElementById('gap-list').innerHTML = gaps.length ? gaps.map(renderGapRow).join('') : '<div class="empty">'+missingText()+'</div>';
 }
 function renderCommands(commands){
-  if (!commands.length) return '<div class="empty">No validation commands resolved.</div>';
-  return commands.map(command => '<div class="command"><code>'+escapeHtml(command)+'</code><button data-copy="'+escapeHtml(command)+'">Copy</button></div>').join('');
+  if (!commands.length) return '<div class="empty">'+bi('未解析到验证命令', 'No validation commands resolved')+'</div>';
+  return commands.map(command => '<div class="command"><code>'+escapeHtml(command)+'</code><button data-copy="'+escapeHtml(command)+'">'+bi('复制', 'Copy')+'</button></div>').join('');
 }
 function renderDetail(){
   const report = byWorkspace.get(state.selected) || reports[0];
   if (!report) {
-    document.getElementById('detail-title').textContent = 'Workspace Detail';
-    document.getElementById('detail-body').innerHTML = '<div class="empty">No workspace data found.</div>';
+    document.getElementById('detail-title').textContent = bi('工作区详情', 'Workspace Detail');
+    document.getElementById('detail-body').innerHTML = '<div class="empty">'+bi('未找到工作区数据', 'No workspace data found')+'</div>';
     return;
   }
   document.getElementById('detail-title').textContent = report.path;
-  const knowledge = report.knowledge.length ? report.knowledge.map(item => '<div class="mini-row"><div>'+escapeHtml(item.kind)+'</div><div class="path">'+escapeHtml(item.path)+' '+(item.exists ? '' : '<span class="severity high">missing</span>')+'</div></div>').join('') : '<div class="empty">No curated knowledge refs.</div>';
-  const missing = report.gaps.length ? report.gaps.map(renderGapRow).join('') : '<div class="empty">No missing items for this workspace.</div>';
+  const knowledge = report.knowledge.length ? report.knowledge.map(item => '<div class="mini-row"><div>'+escapeHtml(item.kind)+'</div><div class="path">'+escapeHtml(item.path)+' '+(item.exists ? '' : '<span class="severity high">'+bi('缺失', 'missing')+'</span>')+'</div></div>').join('') : '<div class="empty">'+bi('无已配置知识引用', 'No curated knowledge refs')+'</div>';
+  const missing = report.gaps.length ? report.gaps.map(renderGapRow).join('') : '<div class="empty">'+bi('该工作区无缺失项', 'No missing items for this workspace')+'</div>';
   document.getElementById('detail-body').innerHTML =
-    '<div class="badges">'+statusBadge(report.status)+'<span class="badge info">'+escapeHtml(report.type)+'</span><span class="badge">'+report.score+' score</span></div>'+
-    '<section class="panel"><h3>Identity</h3><div class="mini-table">'+
-      '<div class="mini-row"><div>Package</div><div>'+escapeHtml(report.packageName)+'</div></div>'+
-      '<div class="mini-row"><div>Role</div><div>'+escapeHtml(report.role)+'</div></div>'+
-      '<div class="mini-row"><div>Entry</div><div class="path">'+escapeHtml(report.entry.path)+' '+(report.entry.exists ? '' : '<span class="severity high">missing</span>')+'</div></div>'+
-      '<div class="mini-row"><div>Profile</div><div>'+escapeHtml(report.profileListed ? 'curated' : 'default fallback')+'</div></div>'+
+    '<div class="badges">'+statusBadge(report.status)+'<span class="badge info">'+escapeHtml(report.type)+'</span><span class="badge">'+report.score+' 分 / '+report.score+' score</span></div>'+
+    '<section class="panel"><h3>'+bi('身份信息', 'Identity')+'</h3><div class="mini-table">'+
+      '<div class="mini-row"><div>'+bi('包', 'Package')+'</div><div>'+escapeHtml(report.packageName)+'</div></div>'+
+      '<div class="mini-row"><div>'+bi('角色', 'Role')+'</div><div>'+escapeHtml(report.role)+'</div></div>'+
+      '<div class="mini-row"><div>'+bi('入口', 'Entry')+'</div><div class="path">'+escapeHtml(report.entry.path)+' '+(report.entry.exists ? '' : '<span class="severity high">'+bi('缺失', 'missing')+'</span>')+'</div></div>'+
+      '<div class="mini-row"><div>Profile</div><div>'+escapeHtml(report.profileListed ? bi('已精修', 'curated') : bi('默认兜底', 'default fallback'))+'</div></div>'+
     '</div></section>'+
-    '<section class="panel"><h3>Validation</h3>'+renderCommands(report.commands)+'</section>'+
-    '<section class="panel"><h3>Reading Path</h3><div class="reading">'+report.readingPath.map(item => '<div class="path">'+escapeHtml(item)+'</div>').join('')+'</div></section>'+
-    '<section class="panel"><h3>Knowledge</h3>'+knowledge+'</section>'+
-    '<section class="panel"><h3>Missing</h3>'+missing+'</section>';
+    '<section class="panel"><h3>'+bi('验证', 'Validation')+'</h3>'+renderCommands(report.commands)+'</section>'+
+    '<section class="panel"><h3>'+bi('阅读路径', 'Reading Path')+'</h3><div class="reading">'+report.readingPath.map(item => '<div class="path">'+escapeHtml(item)+'</div>').join('')+'</div></section>'+
+    '<section class="panel"><h3>'+bi('知识引用', 'Knowledge')+'</h3>'+knowledge+'</section>'+
+    '<section class="panel"><h3>'+bi('缺失项', 'Missing')+'</h3>'+missing+'</section>';
 }
 function showTab(tab){
   document.querySelectorAll('.tabs button').forEach(button => button.classList.toggle('active', button.dataset.tab === tab));
@@ -778,7 +818,7 @@ function selectGraphNode(id){
   const n = byId.get(id); if(!n) return;
   document.getElementById('graph-title').textContent = n.label;
   const related = graph.edges.filter(e => e.from===n.id || e.to===n.id).map(e => e.type+' '+e.confidence+'\\n  '+e.from+'\\n  -> '+e.to).join('\\n\\n');
-  document.getElementById('graph-detail').innerHTML = '<pre>'+escapeHtml(JSON.stringify(n.meta, null, 2))+'</pre><h3>Edges</h3><pre>'+escapeHtml(related || 'No connected edges')+'</pre>';
+  document.getElementById('graph-detail').innerHTML = '<pre>'+escapeHtml(JSON.stringify(n.meta, null, 2))+'</pre><h3>'+bi('连接边', 'Edges')+'</h3><pre>'+escapeHtml(related || bi('无连接边', 'No connected edges'))+'</pre>';
   if (n.type === 'workspace') {
     const report = byWorkspace.get(n.label);
     if (report) { state.selected = report.path; renderDetail(); renderWorkspaces(); }
@@ -800,9 +840,9 @@ function init(){
   });
   document.body.addEventListener('click', e => {
     const copy = e.target.closest('button[data-copy]'); if(!copy) return;
-    navigator.clipboard?.writeText(copy.dataset.copy).then(() => { copy.textContent = 'Copied'; setTimeout(() => { copy.textContent = 'Copy'; }, 1100); });
+    navigator.clipboard?.writeText(copy.dataset.copy).then(() => { copy.textContent = bi('已复制', 'Copied'); setTimeout(() => { copy.textContent = bi('复制', 'Copy'); }, 1100); });
   });
-  document.getElementById('toggle-graph').onclick = () => { running = !running; document.getElementById('toggle-graph').textContent = running ? 'Pause graph' : 'Resume graph'; };
+  document.getElementById('toggle-graph').onclick = () => { running = !running; document.getElementById('toggle-graph').textContent = running ? bi('暂停图', 'Pause graph') : bi('继续图', 'Resume graph'); };
   document.querySelector('#graph .filters').addEventListener('click', e => {
     const button = e.target.closest('button[data-node-filter]'); if(!button) return;
     state.nodeFilter = button.dataset.nodeFilter;

--- a/harness/tools/graph-viewer/server.mjs
+++ b/harness/tools/graph-viewer/server.mjs
@@ -480,6 +480,7 @@ body {
   color:var(--text);
   font:14px/1.45 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
+body.modal-open { overflow:hidden; }
 button, input { font:inherit; }
 .topbar { border-bottom:1px solid var(--line); background:#12151a; padding:18px 24px; }
 .topline { display:flex; justify-content:space-between; align-items:flex-start; gap:16px; }
@@ -572,6 +573,38 @@ pre { white-space:pre-wrap; word-break:break-word; background:#0c0f13; border:1p
 .reading div { border:1px solid var(--line); background:var(--panel-2); border-radius:6px; padding:8px; }
 .reading div::before { counter-increment:readstep; content:counter(readstep) ". "; color:var(--blue); font-weight:700; }
 .empty { color:var(--muted); border:1px dashed var(--line); border-radius:8px; padding:16px; }
+.modal-backdrop {
+  position:fixed;
+  inset:0;
+  z-index:30;
+  display:grid;
+  place-items:center;
+  padding:24px;
+  background:rgba(5, 8, 13, 0.72);
+}
+.modal-backdrop[hidden] { display:none; }
+.modal-panel {
+  width:min(920px, 100%);
+  max-height:min(86vh, 920px);
+  overflow:auto;
+  border:1px solid var(--line);
+  border-radius:8px;
+  background:var(--panel);
+  box-shadow:0 24px 80px rgba(0, 0, 0, 0.45);
+}
+.modal-header {
+  position:sticky;
+  top:0;
+  z-index:1;
+  display:flex;
+  justify-content:space-between;
+  gap:14px;
+  align-items:flex-start;
+  padding:16px;
+  border-bottom:1px solid var(--line);
+  background:var(--panel);
+}
+.modal-body { padding:16px; }
 @media (max-width: 1180px) {
   .shell, .shell.workspace-mode, .grid-2 { grid-template-columns:1fr; }
   .detail { border-left:0; border-top:1px solid var(--line); }
@@ -583,6 +616,8 @@ pre { white-space:pre-wrap; word-break:break-word; background:#0c0f13; border:1p
 }
 @media (max-width: 620px) {
   .topbar, main, .detail { padding-left:14px; padding-right:14px; }
+  .modal-backdrop { padding:12px; }
+  .modal-header, .modal-body { padding:14px; }
   .metrics { grid-template-columns:1fr; }
   .gap-group-header { display:grid; }
   .gap-group-actions { justify-items:start; }
@@ -656,6 +691,15 @@ pre { white-space:pre-wrap; word-break:break-word; background:#0c0f13; border:1p
     <div id="detail-body"></div>
   </aside>
 </div>
+<div id="workspace-modal" class="modal-backdrop" hidden>
+  <section class="modal-panel" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+    <div class="modal-header">
+      <h2 id="modal-title">工作区详情</h2>
+      <button data-close-modal data-i18n="closeModal">关闭</button>
+    </div>
+    <div id="modal-body" class="modal-body"></div>
+  </section>
+</div>
 <script>
 const graph = ${graphJson};
 const reports = graph.workspaceReports || [];
@@ -681,6 +725,7 @@ const messages = {
     workspaceDetail: '工作区详情',
     selectWorkspace: '选择一个工作区查看入口、验证命令、阅读路径和缺失项。',
     viewWorkspace: '查看工作区',
+    closeModal: '关闭',
     collapse: '收起',
     expand: '展开',
     fixLocation: '修复位置',
@@ -705,6 +750,7 @@ const messages = {
     workspaceDetail: 'Workspace Detail',
     selectWorkspace: 'Select a workspace to inspect entry, validation commands, reading path, and missing items.',
     viewWorkspace: 'View Workspace',
+    closeModal: 'Close',
     collapse: 'Collapse',
     expand: 'Expand',
     fixLocation: 'Fix Location',
@@ -712,7 +758,7 @@ const messages = {
   },
 };
 const savedLang = localStorage.getItem('harness-dashboard-lang');
-const state = { selected: '', filter: 'all', query: '', lang: savedLang === 'en' ? 'en' : 'zh', collapsedGapGroups: new Set() };
+const state = { selected: '', filter: 'all', query: '', lang: savedLang === 'en' ? 'en' : 'zh', collapsedGapGroups: new Set(), modalWorkspace: '' };
 
 function escapeHtml(s){ return String(s ?? '').replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
 function radius(n){ return n.type==='workspace'?10:n.type==='gap'?9:6; }
@@ -883,18 +929,10 @@ function renderCommands(commands){
   if (!commands.length) return '<div class="empty">'+bi('未解析到验证命令', 'No validation commands resolved')+'</div>';
   return commands.map(command => '<div class="command"><code>'+escapeHtml(command)+'</code><button data-copy="'+escapeHtml(command)+'">'+bi('复制', 'Copy')+'</button></div>').join('');
 }
-function renderDetail(){
-  const report = byWorkspace.get(state.selected);
-  if (!report) {
-    document.getElementById('detail-title').textContent = t('workspaceDetail');
-    document.getElementById('detail-body').innerHTML = '<div class="empty">'+t('selectWorkspace')+'</div>';
-    return;
-  }
-  document.getElementById('detail-title').textContent = report.path;
+function workspaceDetailHtml(report){
   const knowledge = report.knowledge.length ? report.knowledge.map(item => '<div class="mini-row"><div>'+escapeHtml(item.kind)+'</div><div class="path">'+escapeHtml(item.path)+' '+(item.exists ? '' : '<span class="severity high">'+bi('缺失', 'missing')+'</span>')+'</div></div>').join('') : '<div class="empty">'+bi('无已配置知识引用', 'No curated knowledge refs')+'</div>';
-  const missing = report.gaps.length ? report.gaps.map(renderGapRow).join('') : '<div class="empty">'+bi('该工作区无缺失项', 'No missing items for this workspace')+'</div>';
-  document.getElementById('detail-body').innerHTML =
-    '<div class="badges">'+statusBadge(report.status)+'<span class="badge info">'+escapeHtml(report.type)+'</span><span class="badge">'+escapeHtml(state.lang === 'en' ? report.score + ' score' : report.score + ' 分')+'</span></div>'+
+  const missing = report.gaps.length ? report.gaps.map(gap => renderGapRow(gap, { drillIn: false })).join('') : '<div class="empty">'+bi('该工作区无缺失项', 'No missing items for this workspace')+'</div>';
+  return '<div class="badges">'+statusBadge(report.status)+'<span class="badge info">'+escapeHtml(report.type)+'</span><span class="badge">'+escapeHtml(state.lang === 'en' ? report.score + ' score' : report.score + ' 分')+'</span></div>'+
     '<section class="panel"><h3>'+bi('身份信息', 'Identity')+'</h3><div class="mini-table">'+
       '<div class="mini-row"><div>'+bi('包', 'Package')+'</div><div>'+escapeHtml(report.packageName)+'</div></div>'+
       '<div class="mini-row"><div>'+bi('角色', 'Role')+'</div><div>'+escapeHtml(report.role)+'</div></div>'+
@@ -905,6 +943,16 @@ function renderDetail(){
     '<section class="panel"><h3>'+bi('阅读路径', 'Reading Path')+'</h3><div class="reading">'+report.readingPath.map(item => '<div class="path">'+escapeHtml(item)+'</div>').join('')+'</div></section>'+
     '<section class="panel"><h3>'+bi('知识引用', 'Knowledge')+'</h3>'+knowledge+'</section>'+
     '<section class="panel"><h3>'+bi('缺失项', 'Missing')+'</h3>'+missing+'</section>';
+}
+function renderDetail(){
+  const report = byWorkspace.get(state.selected);
+  if (!report) {
+    document.getElementById('detail-title').textContent = t('workspaceDetail');
+    document.getElementById('detail-body').innerHTML = '<div class="empty">'+t('selectWorkspace')+'</div>';
+    return;
+  }
+  document.getElementById('detail-title').textContent = report.path;
+  document.getElementById('detail-body').innerHTML = workspaceDetailHtml(report);
 }
 function showTab(tab){
   document.querySelectorAll('.tabs button').forEach(button => button.classList.toggle('active', button.dataset.tab === tab));
@@ -922,6 +970,29 @@ function openWorkspace(path){
     document.querySelector('.detail')?.scrollTo({ top: 0 });
   });
 }
+function renderModal(){
+  const report = byWorkspace.get(state.modalWorkspace);
+  const modal = document.getElementById('workspace-modal');
+  if (!report) {
+    modal.hidden = true;
+    document.body.classList.remove('modal-open');
+    return;
+  }
+  document.getElementById('modal-title').textContent = report.path;
+  document.getElementById('modal-body').innerHTML = workspaceDetailHtml(report);
+  modal.hidden = false;
+  document.body.classList.add('modal-open');
+}
+function openWorkspaceModal(path){
+  if (!byWorkspace.has(path)) return;
+  state.modalWorkspace = path;
+  renderModal();
+  requestAnimationFrame(() => document.querySelector('[data-close-modal]')?.focus());
+}
+function closeWorkspaceModal(){
+  state.modalWorkspace = '';
+  renderModal();
+}
 function toggleGapGroup(workspace){
   if (state.collapsedGapGroups.has(workspace)) state.collapsedGapGroups.delete(workspace);
   else state.collapsedGapGroups.add(workspace);
@@ -933,7 +1004,7 @@ function init(){
     const button = e.target.closest('button[data-lang]'); if(!button) return;
     state.lang = button.dataset.lang === 'en' ? 'en' : 'zh';
     localStorage.setItem('harness-dashboard-lang', state.lang);
-    renderStaticText(); renderMeta(); renderMetrics(); renderHealth(); renderPriorityGaps(); renderReadingLoop(); renderWorkspaces(); renderGaps(); renderDetail();
+    renderStaticText(); renderMeta(); renderMetrics(); renderHealth(); renderPriorityGaps(); renderReadingLoop(); renderWorkspaces(); renderGaps(); renderDetail(); renderModal();
   });
   document.querySelector('.tabs').addEventListener('click', e => { const button = e.target.closest('button[data-tab]'); if(button) showTab(button.dataset.tab); });
   document.querySelector('.filters').addEventListener('click', e => {
@@ -955,15 +1026,20 @@ function init(){
   });
   document.body.addEventListener('click', e => {
     const workspaceAction = e.target.closest('[data-open-workspace]');
-    if (workspaceAction) { openWorkspace(workspaceAction.dataset.openWorkspace); return; }
+    if (workspaceAction) { openWorkspaceModal(workspaceAction.dataset.openWorkspace); return; }
+    if (e.target.closest('[data-close-modal]') || e.target.id === 'workspace-modal') { closeWorkspaceModal(); return; }
     const gapToggle = e.target.closest('[data-toggle-gap-group]');
     if (gapToggle) { toggleGapGroup(gapToggle.dataset.toggleGapGroup); return; }
     const gap = e.target.closest('.gap-row[data-workspace]');
-    if (gap) { openWorkspace(gap.dataset.workspace); return; }
+    if (gap) { openWorkspaceModal(gap.dataset.workspace); return; }
     const copy = e.target.closest('button[data-copy]'); if(!copy) return;
     navigator.clipboard?.writeText(copy.dataset.copy).then(() => { copy.textContent = bi('已复制', 'Copied'); setTimeout(() => { copy.textContent = bi('复制', 'Copy'); }, 1100); });
   });
   document.body.addEventListener('keydown', e => {
+    if (e.key === 'Escape' && state.modalWorkspace) {
+      closeWorkspaceModal();
+      return;
+    }
     const gapToggle = e.target.closest?.('[data-toggle-gap-group]');
     if (gapToggle && gapToggle.tagName !== 'BUTTON' && (e.key === 'Enter' || e.key === ' ')) {
       e.preventDefault();
@@ -973,7 +1049,7 @@ function init(){
     const gap = e.target.closest?.('.gap-row[data-workspace]');
     if (!gap || (e.key !== 'Enter' && e.key !== ' ')) return;
     e.preventDefault();
-    openWorkspace(gap.dataset.workspace);
+    openWorkspaceModal(gap.dataset.workspace);
   });
 }
 init();

--- a/harness/tools/graph-viewer/server.mjs
+++ b/harness/tools/graph-viewer/server.mjs
@@ -542,6 +542,15 @@ main { min-width:0; padding:22px 24px 36px; }
 .muted { color:var(--muted); }
 .row-title { display:flex; justify-content:space-between; gap:12px; align-items:flex-start; }
 .score { font-weight:700; color:var(--teal); }
+.gap-groups { display:grid; gap:14px; }
+.gap-group { border:1px solid var(--line); border-radius:8px; overflow:hidden; background:#141922; }
+.gap-group-header { display:flex; justify-content:space-between; gap:14px; align-items:flex-start; padding:12px 14px; background:var(--panel-2); border-bottom:1px solid var(--line); }
+.gap-group-header.actionable { cursor:pointer; }
+.gap-group-header.actionable:hover, .gap-group-header.actionable:focus { background:#202938; outline:0; }
+.gap-group-title { display:grid; gap:4px; min-width:0; }
+.gap-group-title strong { font-size:15px; }
+.gap-group-body { padding:10px 12px 2px; }
+.gap-group-body .gap-row { background:#171d26; }
 .gap-row { display:grid; grid-template-columns:120px minmax(0, 1fr); gap:12px; margin-bottom:10px; }
 .gap-row.actionable { cursor:pointer; }
 .gap-row.actionable:hover, .gap-row.actionable:focus { border-color:var(--blue); background:#202938; outline:0; }
@@ -571,6 +580,7 @@ pre { white-space:pre-wrap; word-break:break-word; background:#0c0f13; border:1p
 @media (max-width: 620px) {
   .topbar, main, .detail { padding-left:14px; padding-right:14px; }
   .metrics { grid-template-columns:1fr; }
+  .gap-group-header { display:grid; }
   .gap-row, .mini-row { grid-template-columns:1fr; }
 }
 </style>
@@ -810,16 +820,45 @@ function renderWorkspaces(){
   const items = filteredReports();
   document.getElementById('workspace-grid').innerHTML = items.length ? items.map(renderWorkspaceCard).join('') : '<div class="empty">'+bi('当前筛选无匹配工作区', 'No workspaces match the current filter')+'</div>';
 }
-function renderGapRow(gap){
+function renderGapRow(gap, options = {}){
+  const showWorkspace = options.showWorkspace !== false;
   const canOpen = gap.workspace && byWorkspace.has(gap.workspace);
   const workspaceAttr = canOpen ? ' data-workspace="'+escapeHtml(gap.workspace)+'" tabindex="0"' : '';
+  const pathLabel = showWorkspace ? (gap.workspace || gap.path) : (gap.path || gap.workspace);
   return '<div class="gap-row '+(canOpen ? 'actionable' : '')+'"'+workspaceAttr+'>'+
     '<div><span class="severity '+escapeHtml(gap.severity)+'">'+escapeHtml(severityLabel(gap.severity))+'</span><div class="muted">'+escapeHtml(typeLabel(gap.type))+'</div></div>'+
-    '<div><strong>'+escapeHtml(gapLabel(gap))+'</strong><div class="path">'+escapeHtml(gap.workspace || gap.path)+'</div><div class="muted">'+escapeHtml(gapDetail(gap))+'</div></div>'+
+    '<div><strong>'+escapeHtml(gapLabel(gap))+'</strong><div class="path">'+escapeHtml(pathLabel)+'</div><div class="muted">'+escapeHtml(gapDetail(gap))+'</div></div>'+
   '</div>';
 }
+function gapGroups(){
+  const groups = new Map();
+  for (const gap of gaps) {
+    const workspace = gap.workspace || gap.path || bi('仓库级', 'Repository-level');
+    if (!groups.has(workspace)) groups.set(workspace, { workspace, items: [] });
+    groups.get(workspace).items.push(gap);
+  }
+  return [...groups.values()];
+}
+function renderGapGroup(group){
+  const highCount = group.items.filter(gap => gap.severity === 'high').length;
+  const mediumCount = group.items.filter(gap => gap.severity === 'medium').length;
+  const typeBadges = [...new Set(group.items.map(gap => typeLabel(gap.type)))].map(type => '<span class="badge">'+escapeHtml(type)+'</span>').join('');
+  const canOpen = group.workspace && byWorkspace.has(group.workspace);
+  const workspaceAttr = canOpen ? ' data-workspace="'+escapeHtml(group.workspace)+'" tabindex="0"' : '';
+  const severityBadges = [
+    highCount ? '<span class="badge missing">'+escapeHtml(countLabel(highCount, ' 个高优先级', 'high priority item', 'high priority items'))+'</span>' : '',
+    mediumCount ? '<span class="badge partial">'+escapeHtml(countLabel(mediumCount, ' 个中优先级', 'medium priority item', 'medium priority items'))+'</span>' : '',
+  ].join('');
+  return '<section class="gap-group">'+
+    '<div class="gap-group-header '+(canOpen ? 'actionable' : '')+'"'+workspaceAttr+'>'+
+      '<div class="gap-group-title"><strong class="path">'+escapeHtml(group.workspace)+'</strong><div class="muted">'+escapeHtml(countLabel(group.items.length, ' 个缺失项', 'missing item', 'missing items'))+'</div></div>'+
+      '<div class="badges">'+severityBadges+typeBadges+'</div>'+
+    '</div>'+
+    '<div class="gap-group-body">'+group.items.map(gap => renderGapRow(gap, { showWorkspace: false })).join('')+'</div>'+
+  '</section>';
+}
 function renderGaps(){
-  document.getElementById('gap-list').innerHTML = gaps.length ? gaps.map(renderGapRow).join('') : '<div class="empty">'+missingText()+'</div>';
+  document.getElementById('gap-list').innerHTML = gaps.length ? '<div class="gap-groups">'+gapGroups().map(renderGapGroup).join('')+'</div>' : '<div class="empty">'+missingText()+'</div>';
 }
 function renderCommands(commands){
   if (!commands.length) return '<div class="empty">'+bi('未解析到验证命令', 'No validation commands resolved')+'</div>';
@@ -891,13 +930,13 @@ function init(){
     openWorkspace(card.dataset.workspace);
   });
   document.body.addEventListener('click', e => {
-    const gap = e.target.closest('.gap-row[data-workspace]');
+    const gap = e.target.closest('.gap-row[data-workspace], .gap-group-header[data-workspace]');
     if (gap) { openWorkspace(gap.dataset.workspace); return; }
     const copy = e.target.closest('button[data-copy]'); if(!copy) return;
     navigator.clipboard?.writeText(copy.dataset.copy).then(() => { copy.textContent = bi('已复制', 'Copied'); setTimeout(() => { copy.textContent = bi('复制', 'Copy'); }, 1100); });
   });
   document.body.addEventListener('keydown', e => {
-    const gap = e.target.closest?.('.gap-row[data-workspace]');
+    const gap = e.target.closest?.('.gap-row[data-workspace], .gap-group-header[data-workspace]');
     if (!gap || (e.key !== 'Enter' && e.key !== ' ')) return;
     e.preventDefault();
     openWorkspace(gap.dataset.workspace);

--- a/harness/tools/repo-profiler/README.md
+++ b/harness/tools/repo-profiler/README.md
@@ -1,0 +1,30 @@
+# Repo Profiler Tool
+
+## Purpose
+
+Build or refresh the machine-readable repository map in `harness/profile.yaml`.
+
+## Inputs
+
+- Workspace manifests: `package.json`, `pnpm-workspace.yaml`, workspace `package.json` files.
+- Existing entries: root `AGENTS.md`, root `CLAUDE.md`, workspace `AGENTS.md` or `CLAUDE.md`.
+- Known docs: README, contracts, validation, runbooks, specs, history.
+
+## Output
+
+A proposed `workspaces` entry with:
+
+- path
+- type
+- package name
+- short role label
+- entry file
+- knowledge file paths
+
+Validation commands should not be emitted into `profile.yaml`; use `harness/validation.yaml` and workspace `docs/validation.md`.
+
+## Non-goals
+
+- Do not infer detailed contracts from source code.
+- Do not create docs automatically without doc governance review.
+- Do not duplicate validation matrices or long module descriptions.

--- a/harness/tools/ssot-resolver/README.md
+++ b/harness/tools/ssot-resolver/README.md
@@ -1,0 +1,25 @@
+# SSOT Resolver Tool
+
+## Purpose
+
+Choose the long-term source of truth for a piece of repository knowledge.
+
+## Inputs
+
+- Knowledge type: navigation, architecture, contract, behavior, validation, action, feedback, runbook, or history.
+- Scope: repository, workspace, app, package, runtime, single case.
+- Evidence paths.
+- `harness/README.md` knowledge routing table.
+- Affected workspace entry file.
+
+## Output
+
+- recommended target path
+- fallback target if the primary path does not exist
+- whether the information should be mechanism-backed by tests/checks/hooks
+- whether the item should remain only as a proposal or inbox item
+
+## Non-goals
+
+- Does not write the target file.
+- Does not override human ownership decisions.

--- a/harness/tools/validation-planner/README.md
+++ b/harness/tools/validation-planner/README.md
@@ -1,0 +1,26 @@
+# Validation Planner Tool
+
+## Purpose
+
+Produce a validation plan from affected workspaces and change type.
+
+## Inputs
+
+- Affected workspaces.
+- Changed paths.
+- Change type: docs-only, contract, runtime, config, test, app interaction, or release.
+- `harness/validation.yaml`.
+- Workspace `docs/validation.md` when present.
+
+## Output
+
+- required commands
+- optional commands
+- manual/runtime checks
+- escalation reason
+- skipped checks and why
+
+## Non-goals
+
+- Does not execute commands.
+- Does not decide whether failed checks can be ignored.

--- a/harness/validation.yaml
+++ b/harness/validation.yaml
@@ -1,0 +1,144 @@
+# Machine-readable validation matrix for the repository harness pilot.
+# Workspace docs may explain why; this file decides what to run.
+
+version: 1
+sourceOfTruth: harness/validation.yaml
+
+pathRules:
+  - name: engine
+    paths:
+      - packages/engine/**
+    required:
+      - pnpm --filter pulse-coder-engine test
+      - pnpm --filter pulse-coder-engine typecheck
+    escalateWhen:
+      publicApiChange:
+        - pnpm --filter pulse-coder-cli test
+        - pnpm --filter @pulse-coder/remote-server build
+      builtInPluginChange:
+        - pnpm --filter pulse-coder-engine test
+        - pnpm --filter pulse-coder-cli test
+
+  - name: agent-teams
+    paths:
+      - packages/agent-teams/**
+    required:
+      - pnpm --filter pulse-coder-agent-teams test
+      - pnpm --filter pulse-coder-agent-teams typecheck
+    escalateWhen:
+      runtimeProtocolChange:
+        - pnpm --filter @pulse-coder/teams-cli build
+        - pnpm --filter canvas-workspace typecheck
+
+  - name: cli
+    paths:
+      - packages/cli/**
+    required:
+      - pnpm --filter pulse-coder-cli test
+
+  - name: orchestrator
+    paths:
+      - packages/orchestrator/**
+    required:
+      - pnpm --filter pulse-coder-orchestrator test
+      - pnpm --filter pulse-coder-orchestrator typecheck
+
+  - name: memory-plugin
+    paths:
+      - packages/memory-plugin/**
+    required:
+      - pnpm --filter pulse-coder-memory-plugin test
+      - pnpm --filter pulse-coder-memory-plugin typecheck
+
+  - name: plugin-kit
+    paths:
+      - packages/plugin-kit/**
+    required:
+      - pnpm --filter pulse-coder-plugin-kit typecheck
+    escalateWhen:
+      publicApiChange:
+        - pnpm --filter pulse-coder-engine typecheck
+        - pnpm --filter @pulse-coder/remote-server build
+
+  - name: acp
+    paths:
+      - packages/acp/**
+    required:
+      - pnpm --filter pulse-coder-acp test
+      - pnpm --filter pulse-coder-acp typecheck
+
+  - name: pulse-sandbox
+    paths:
+      - packages/pulse-sandbox/**
+    required:
+      - pnpm --filter pulse-sandbox test
+      - pnpm --filter pulse-sandbox typecheck
+
+  - name: remote-server
+    paths:
+      - apps/remote-server/**
+    required:
+      - pnpm --filter @pulse-coder/remote-server build
+    manual:
+      - If internal routes or dispatcher behavior changes, smoke with loopback `/internal/agent/run` when secrets and local runtime are available.
+
+  - name: canvas-workspace
+    paths:
+      - apps/canvas-workspace/**
+    required:
+      - pnpm --filter canvas-workspace typecheck
+      - pnpm --filter canvas-workspace test
+    manual:
+      - Use `pnpm --filter canvas-workspace harness start --profile demo --build` for interaction-heavy changes.
+      - Use `pnpm --filter canvas-workspace harness screenshot` or `snapshot-ui` when visual evidence matters.
+
+  - name: harness-docs
+    paths:
+      - harness/**
+      - AGENTS.md
+      - CLAUDE.md
+      - "**/AGENTS.md"
+      - "**/docs/**"
+    required:
+      - path existence check for referenced files
+    optional:
+      - YAML syntax check for harness/*.yaml
+
+escalationRules:
+  rootWorkspaceConfigChange:
+    paths:
+      - package.json
+      - pnpm-workspace.yaml
+      - tsconfig.json
+    required:
+      - pnpm run build
+      - pnpm test
+
+  crossPackageContractChange:
+    required:
+      - producer workspace typecheck/test
+      - affected consumer build/typecheck
+
+  docsOnlyChange:
+    required:
+      - referenced path check
+    notRequired:
+      - pnpm test
+      - pnpm run build
+
+  runtimeHarnessChange:
+    paths:
+      - apps/canvas-workspace/harness/**
+    required:
+      - pnpm --filter canvas-workspace harness start --profile demo --build
+      - pnpm --filter canvas-workspace harness status
+      - pnpm --filter canvas-workspace harness close
+
+fallbackWorkspaceRule:
+  package:
+    required:
+      - Run the workspace-local `test` script when it exists and is not a placeholder.
+      - Run the workspace-local `typecheck` script when it exists.
+  app:
+    required:
+      - Run the workspace-local `typecheck`, `test`, or `build` script that best matches the changed surface.

--- a/packages/acp/AGENTS.md
+++ b/packages/acp/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md - packages/acp
+
+> Local entry for `packages/acp`.
+> Repository harness entry: `../../harness/README.md`.
+
+## Module Positioning
+
+`pulse-coder-acp` owns the Agent Context Protocol client, runner, typed protocol models, and state store used by Pulse Coder hosts.
+
+ACP protocol behavior is contract-heavy. Changes should preserve compatibility expectations for hosts that create ACP sessions or resume state.
+
+## Knowledge Navigation
+
+| Task | Read |
+|---|---|
+| Package overview | `README.md` |
+| Public exports | `src/index.ts` |
+| Protocol types | `src/types.ts` |
+| Client behavior | `src/client.ts` |
+| Runner behavior | `src/runner.ts` |
+| State management | `src/state.ts`, `src/state-store.ts` |
+| Tests | `src/*.test.ts` |
+
+## Local Constraints
+
+- Treat protocol types, runner behavior, and state persistence as public contracts.
+- Avoid host-specific policy in the ACP package.
+- State compatibility changes should include tests or a migration note.
+- Route protocol changes through `harness/skills/contract-coding.md`.
+
+## Common Commands
+
+```bash
+pnpm --filter pulse-coder-acp test
+pnpm --filter pulse-coder-acp typecheck
+pnpm --filter pulse-coder-acp build
+```
+
+## Key Files
+
+- `src/types.ts`: ACP protocol types.
+- `src/client.ts`: client transport behavior.
+- `src/runner.ts`: session runner behavior.
+- `src/state.ts`, `src/state-store.ts`: state model and persistence.
+- `src/index.ts`: public exports.

--- a/packages/agent-teams/AGENTS.md
+++ b/packages/agent-teams/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md - packages/agent-teams
+
+> Local entry for `packages/agent-teams`.
+> Repository harness entry: `../../harness/README.md`.
+
+## Module Positioning
+
+`pulse-coder-agent-teams` owns multi-session team coordination on top of the engine and orchestrator. It manages team lifecycle, task dispatch, review gates, checkpoints, scope controls, and runtime state for collaborative agents.
+
+It should keep team protocol behavior explicit and avoid hiding quality gates in prompts alone.
+
+## Knowledge Navigation
+
+| Task | Read |
+|---|---|
+| Understand contracts | `docs/contracts.md` |
+| Pick validation | `docs/validation.md` |
+| Maturity roadmap | `../../docs/07-agent-teams-maturity-roadmap.md` |
+| Runtime implementation | `src/runtime/team-runtime.ts` |
+| Package scripts | `package.json` |
+
+## Local Constraints
+
+- Team completion should mean deliverable evidence, not only an agent claim.
+- Verify commands, handoff material, review state, and dependency blocking are protocol-level concerns.
+- Scope and task ownership changes should stay explicit.
+- Public runtime exports are contracts; route changes through `harness/skills/contract-coding.md`.
+
+## Common Commands
+
+```bash
+pnpm --filter pulse-coder-agent-teams test
+pnpm --filter pulse-coder-agent-teams typecheck
+pnpm --filter pulse-coder-agent-teams build
+```
+
+## Key Files
+
+- `src/runtime/team-runtime.ts`: team lifecycle, dispatch, review, checkpoints, scope handling.
+- `src/index.ts`: package exports.
+- `package.json`: package scripts and runtime dependencies.

--- a/packages/agent-teams/docs/contracts.md
+++ b/packages/agent-teams/docs/contracts.md
@@ -1,0 +1,37 @@
+# Agent Teams Contracts
+
+## Scope
+
+`packages/agent-teams` coordinates multiple agents working as a team. It sits above the engine/orchestrator and below host UIs or CLIs that expose team workflows.
+
+## Public Contracts
+
+- Team lifecycle state must be observable and recoverable enough for hosts to display progress and resume work.
+- Task dispatch, completion, review, failure, and dependency blocking are protocol states, not just text conventions.
+- Verification commands and handoff artifacts are part of task quality evidence.
+- Runtime APIs exported through package entrypoints are public to consumers such as `apps/teams-cli` and `apps/canvas-workspace`.
+
+## Invariants
+
+- Lead/reviewer style decisions should not silently bypass protocol permissions.
+- Tasks that fail or are rejected should not unblock dependents until the state is resolved.
+- Checkpoint and completion behavior must preserve enough state for human review.
+- Runtime state changes should be deterministic and auditable where possible.
+
+## Extension Boundaries
+
+- Add team protocol capabilities in runtime/service boundaries, not by relying only on prompt text.
+- Host-specific UI behavior belongs in the host app or CLI.
+- Verification and reporting rules should align with `../../docs/07-agent-teams-maturity-roadmap.md`.
+
+## Consumers
+
+Known consumers include:
+
+- `apps/teams-cli`
+- `apps/canvas-workspace`
+- `packages/engine` built-in agent-teams plugin integration
+
+## Validation
+
+See `docs/validation.md`.

--- a/packages/agent-teams/docs/validation.md
+++ b/packages/agent-teams/docs/validation.md
@@ -1,0 +1,39 @@
+# Agent Teams Validation
+
+Run commands from the repository root.
+
+## Default Checks
+
+```bash
+pnpm --filter pulse-coder-agent-teams test
+pnpm --filter pulse-coder-agent-teams typecheck
+```
+
+Use build when package exports or runtime entrypoints change:
+
+```bash
+pnpm --filter pulse-coder-agent-teams build
+```
+
+## Escalation
+
+If runtime protocol, exported APIs, task state shape, or team lifecycle behavior changes, include consumers as relevant:
+
+```bash
+pnpm --filter @pulse-coder/teams-cli build
+pnpm --filter canvas-workspace typecheck
+```
+
+If engine integration behavior changes, also consider:
+
+```bash
+pnpm --filter pulse-coder-engine test
+```
+
+## Manual Evidence
+
+For checkpoint, review, handoff, or multi-agent runtime behavior that is hard to unit test, include a concise scenario note and whether the teams preview or canvas integration was exercised.
+
+## Docs-only Changes
+
+If only `AGENTS.md`, `docs/contracts.md`, or `docs/validation.md` changed, no package build/test is required. Check referenced paths and commands instead.

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md - packages/cli
+
+> Local entry for `packages/cli`.
+> Repository harness entry: `../../harness/README.md`.
+
+## Module Positioning
+
+`pulse-coder-cli` owns the interactive terminal application on top of `pulse-coder-engine`. It handles sessions, slash commands, Ink UI, input management, ACP commands, team commands, memory integration, and the CLI-only `run_js` sandbox adapter.
+
+CLI behavior should remain a host layer over the engine. Engine runtime behavior belongs in `packages/engine`; team coordination behavior belongs in `packages/agent-teams`.
+
+## Knowledge Navigation
+
+| Task | Read |
+|---|---|
+| CLI entrypoint | `src/index.ts` |
+| Ink UI app | `src/ink-app.tsx`, `src/ink-launcher.tsx` |
+| Input handling | `src/input-manager.ts` |
+| Sessions | `src/session.ts`, `src/session-commands.ts` |
+| Skills slash commands | `src/skill-commands.ts` |
+| Team commands | `src/team-commands.ts` |
+| ACP commands | `src/acp-commands.ts` |
+| Memory integration | `src/memory-integration.ts` |
+
+## Local Constraints
+
+- Keep CLI-specific state and UI behavior in this package; do not push UI concerns into the engine.
+- Slash command changes should preserve session persistence and abort/clarification behavior.
+- Prefer targeted tests for command parsing, session workflows, input handling, and UI mode behavior.
+- Contract changes with engine, ACP, teams, or memory packages should follow `harness/skills/contract-coding.md`.
+
+## Common Commands
+
+```bash
+pnpm --filter pulse-coder-cli test
+pnpm --filter pulse-coder-cli build
+pnpm start
+pnpm start:debug
+```
+
+## Key Files
+
+- `src/index.ts`: CLI entrypoint.
+- `src/ink-app.tsx`: main Ink UI application.
+- `src/input-manager.ts`: terminal input handling.
+- `src/session-commands.ts`: session command behavior.
+- `src/skill-commands.ts`: `/skills` command handling.
+- `src/team-commands.ts`: agent teams command surface.

--- a/packages/engine/AGENTS.md
+++ b/packages/engine/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md - packages/engine
+
+> Local entry for `packages/engine`.
+> Repository harness entry: `../../harness/README.md`.
+
+## Module Positioning
+
+`pulse-coder-engine` owns the reusable agent runtime: engine initialization, tool execution loop, hooks, built-in plugins, tool registration, and context management.
+
+It should stay host-agnostic. CLI, remote server, and canvas-specific behavior should integrate through options, plugins, hooks, or services rather than being hardcoded into the engine loop.
+
+## Knowledge Navigation
+
+| Task | Read |
+|---|---|
+| Understand public contracts | `docs/contracts.md` |
+| Pick validation | `docs/validation.md` |
+| Engine bootstrap | `src/Engine.ts` |
+| Execution loop | `src/core/loop.ts` |
+| Built-in plugin list | `src/built-in/index.ts` |
+| Built-in tools | `src/tools/` |
+| Plugin APIs | `src/plugin/` |
+
+## Local Constraints
+
+- Prefer plugin, hook, tool, or service extension points over engine-loop hardcoding.
+- Keep source imports ESM-style and follow package-local TypeScript strictness.
+- Public exports and tool schemas are contracts; route changes through `harness/skills/contract-coding.md`.
+- Runtime feedback that changes engine guidance should route through `harness/skills/feedback-governance.md`.
+
+## Common Commands
+
+```bash
+pnpm --filter pulse-coder-engine test
+pnpm --filter pulse-coder-engine typecheck
+pnpm --filter pulse-coder-engine build
+```
+
+## Key Files
+
+- `src/Engine.ts`: engine bootstrap and plugin/tool merge order.
+- `src/core/loop.ts`: execution loop, streaming, retries, hooks, abort, compaction.
+- `src/built-in/index.ts`: built-in plugin registration.
+- `src/tools/`: built-in tool definitions.
+- `src/plugin/`: plugin manager and context APIs.

--- a/packages/engine/docs/contracts.md
+++ b/packages/engine/docs/contracts.md
@@ -1,0 +1,47 @@
+# Engine Contracts
+
+## Scope
+
+`packages/engine` provides the reusable Pulse Coder runtime. Hosts such as the CLI, remote server, canvas workspace, and teams runtime should integrate through engine options, plugins, tools, services, and hooks.
+
+## Public Contracts
+
+- `Engine.initialize()` creates a plugin manager, loads built-in plugins unless disabled, registers plugin tools, then merges custom `EngineOptions.tools` with highest priority.
+- The core loop in `src/core/loop.ts` owns streaming text/tool events, LLM hooks, tool hooks, run hooks, retry/backoff, abort handling, and context compaction.
+- Built-in tools live under `src/tools/`.
+- Built-in plugins are registered from `src/built-in/index.ts`.
+- Plugin authors use the engine plugin context to register tools, hooks, services, config, events, and logging.
+
+## Invariants
+
+- Host-specific behavior should not be hardcoded into the core loop.
+- Tool contracts should remain explicit and schema-backed where possible.
+- Custom tools supplied via engine options remain the highest-priority override layer.
+- Hook behavior should stay composable: `beforeRun`, `afterRun`, LLM hooks, tool hooks, and compaction hooks should not assume a single host.
+- Legacy `.coder/*` compatibility should not be removed without an explicit migration plan.
+
+## Extension Boundaries
+
+Use these extension points before editing the loop:
+
+- Plugin tools for new capabilities.
+- Hooks for lifecycle behavior.
+- Services for shared runtime state.
+- Built-in plugins for repo-wide engine features.
+- Host wrappers for CLI/server/canvas-specific orchestration.
+
+## Consumers
+
+Known consumers include:
+
+- `packages/cli`
+- `apps/remote-server`
+- `apps/canvas-workspace`
+- `packages/agent-teams`
+- `packages/orchestrator`
+
+Contract changes should consider affected consumers and validation escalation in `../../harness/validation.yaml`.
+
+## Validation
+
+See `docs/validation.md`.

--- a/packages/engine/docs/validation.md
+++ b/packages/engine/docs/validation.md
@@ -1,0 +1,40 @@
+# Engine Validation
+
+Run commands from the repository root.
+
+## Default Checks
+
+```bash
+pnpm --filter pulse-coder-engine test
+pnpm --filter pulse-coder-engine typecheck
+```
+
+Use `build` when public exports, package configuration, or generated output behavior changes:
+
+```bash
+pnpm --filter pulse-coder-engine build
+```
+
+## Escalation
+
+If public APIs, exported types, built-in plugin behavior, or tool contracts change, add relevant consumer checks:
+
+```bash
+pnpm --filter pulse-coder-cli test
+pnpm --filter @pulse-coder/remote-server build
+```
+
+For changes that affect agent teams integration, also consider:
+
+```bash
+pnpm --filter pulse-coder-agent-teams test
+pnpm --filter pulse-coder-agent-teams typecheck
+```
+
+## Manual Evidence
+
+For changes to streaming, abort, clarification, tool execution, or compaction behavior, include a short note describing the scenario covered by tests or the remaining manual risk.
+
+## Docs-only Changes
+
+If only `AGENTS.md`, `docs/contracts.md`, or `docs/validation.md` changed, no package build/test is required. Check referenced paths and commands instead.

--- a/packages/memory-plugin/AGENTS.md
+++ b/packages/memory-plugin/AGENTS.md
@@ -1,0 +1,46 @@
+# AGENTS.md - packages/memory-plugin
+
+> Local entry for `packages/memory-plugin`.
+> Repository harness entry: `../../harness/README.md`.
+
+## Module Positioning
+
+`pulse-coder-memory-plugin` owns host-side memory service integration for Pulse Coder runtimes. It provides memory service models, recall/write behavior, daily logs, embeddings, state storage, and integration helpers.
+
+Memory behavior should preserve the boundary between user memory, project/repository knowledge, and runtime session logs.
+
+## Knowledge Navigation
+
+| Task | Read |
+|---|---|
+| Package overview | `README.md` |
+| Product/technical docs | `../../docs/memory-plugin/` |
+| Public exports | `src/index.ts` |
+| Integration API | `src/integration.ts` |
+| Service behavior | `src/service.ts`, `src/service/` |
+| Types | `src/types.ts` |
+| Embeddings | `src/embedding/` |
+| State/logs | `src/service/state-store.ts`, `src/service/daily-log.ts` |
+
+## Local Constraints
+
+- Do not treat non-versioned runtime memory as repository SSOT.
+- Keep secret/API-key handling environment-based and out of committed files.
+- Changes to recall/write behavior should include tests or explicit manual evidence.
+- Feedback about repository rules should route through `harness/skills/feedback-governance.md`, not silently into memory.
+
+## Common Commands
+
+```bash
+pnpm --filter pulse-coder-memory-plugin test
+pnpm --filter pulse-coder-memory-plugin typecheck
+pnpm --filter pulse-coder-memory-plugin build
+```
+
+## Key Files
+
+- `src/index.ts`: public package entry.
+- `src/integration.ts`: host integration helpers.
+- `src/service.ts` and `src/service/`: memory service implementation.
+- `src/embedding/`: embedding providers and vector storage.
+- `src/types.ts`: public types.

--- a/packages/orchestrator/AGENTS.md
+++ b/packages/orchestrator/AGENTS.md
@@ -1,0 +1,46 @@
+# AGENTS.md - packages/orchestrator
+
+> Local entry for `packages/orchestrator`.
+> Repository harness entry: `../../harness/README.md`.
+
+## Module Positioning
+
+`pulse-coder-orchestrator` owns the generic multi-agent orchestration layer: task graph modeling, routing, planning, scheduling, running, artifact storage, and aggregation.
+
+It should remain lower-level than `packages/agent-teams`. Team UX, review gates, checkpoints, and handoff conventions belong in agent-teams or host apps unless they are generic orchestration primitives.
+
+## Knowledge Navigation
+
+| Task | Read |
+|---|---|
+| Package overview | `README.md` |
+| Architecture plan | `../../docs/05-orchestrator-plan.md` |
+| Public exports | `src/index.ts` |
+| Task graph | `src/graph.ts`, `src/types.ts` |
+| Routing | `src/router.ts` |
+| Planning | `src/planner.ts` |
+| Scheduling/running | `src/scheduler.ts`, `src/runner.ts`, `src/orchestrator.ts` |
+| Engine adapter | `src/adapters/engine-agent-runner.ts` |
+
+## Local Constraints
+
+- Keep orchestration primitives generic and host-agnostic.
+- Avoid mixing team-specific review/checkpoint policy into generic graph execution.
+- Preserve deterministic DAG semantics for dependencies and scheduling.
+- Route public contract changes through `harness/skills/contract-coding.md`.
+
+## Common Commands
+
+```bash
+pnpm --filter pulse-coder-orchestrator test
+pnpm --filter pulse-coder-orchestrator typecheck
+pnpm --filter pulse-coder-orchestrator build
+```
+
+## Key Files
+
+- `src/types.ts`: orchestration types and task node shapes.
+- `src/graph.ts`: graph construction and dependency behavior.
+- `src/orchestrator.ts`: top-level orchestration flow.
+- `src/runner.ts`: agent execution abstraction.
+- `src/adapters/engine-agent-runner.ts`: adapter to `pulse-coder-engine`.

--- a/packages/plugin-kit/AGENTS.md
+++ b/packages/plugin-kit/AGENTS.md
@@ -1,0 +1,44 @@
+# AGENTS.md - packages/plugin-kit
+
+> Local entry for `packages/plugin-kit`.
+> Repository harness entry: `../../harness/README.md`.
+
+## Module Positioning
+
+`pulse-coder-plugin-kit` provides shared utilities for runtime plugins and hosts, including worktree integration, vault/secret storage, and devtools helpers.
+
+This package should expose reusable infrastructure primitives. Host-specific policy should stay in the host app or plugin using the kit.
+
+## Knowledge Navigation
+
+| Task | Read |
+|---|---|
+| Package overview | `README.md` |
+| Public exports | `src/index.ts` |
+| Worktree utilities | `src/worktree.ts`, `src/worktree/` |
+| Vault utilities | `src/vault.ts`, `src/vault/` |
+| Devtools utilities | `src/devtools.ts`, `src/devtools/` |
+| Package exports | `package.json` |
+
+## Local Constraints
+
+- Keep utilities host-neutral and reusable.
+- Do not commit secrets or host-local state.
+- Export path changes are public contract changes; coordinate with consumers.
+- Worktree behavior should be conservative around user changes and branch state.
+
+## Common Commands
+
+```bash
+pnpm --filter pulse-coder-plugin-kit test
+pnpm --filter pulse-coder-plugin-kit typecheck
+pnpm --filter pulse-coder-plugin-kit build
+```
+
+## Key Files
+
+- `src/index.ts`: public package entry.
+- `src/worktree.ts` and `src/worktree/`: worktree integration.
+- `src/vault.ts` and `src/vault/`: vault and secret helpers.
+- `src/devtools.ts` and `src/devtools/`: devtools integration.
+- `package.json`: package exports and build behavior.


### PR DESCRIPTION
## Summary

- Add `DESIGN.md` as the Linear-style design reference used by the harness dashboard UI.
- Add a repository-level harness map with progressive reading paths, workspace routing, validation guidance, reusable skills, tools, templates, and feedback flow docs.
- Add workspace-local AGENTS entries and selected contracts/validation docs for engine, agent teams, remote server, teams CLI, CLI, ACP, memory plugin, orchestrator, and plugin kit.
- Fill the remaining baseline harness coverage for `packages/canvas-cli`, `packages/canvas-nodes`, `packages/langfuse-plugin`, and `packages/pulse-sandbox` with curated profile entries, local AGENTS entrypoints, and path-specific validation rules.
- Upgrade the harness graph viewer into a local dashboard focused on the three consumption paths that matter most: overall harness health, per-workspace harness detail, and current missing items.
- Restyle the harness dashboard against the current `DESIGN.md` Linear direction: near-black canvas, charcoal surface ladder, lavender action/focus color, compact 8px buttons, and minimal non-shadow depth.
- Keep relationship metadata available at `/graph.json` for debugging, but remove the graph from the primary dashboard surface.
- Use one right-side drawer for workspace detail across Overview, Workspaces, and Missing instead of a persistent detail rail or modal.
- Group current missing harness items by affected workspace and make groups collapsible, while detail drill-in keeps the user on the current tab.
- Add a Chinese/English language switcher so reviewers can choose one UI language at a time instead of reading mixed inline labels.
- Clarify that active app workspaces are the selected apps listed in `pnpm-workspace.yaml`, not every `apps/*` directory.
- Ignore temporary `*.harness-bak` files so backup artifacts do not pollute working trees.

## Why

This gives agents and humans a single lightweight source of truth for deciding what to read, where durable knowledge belongs, which validation applies to an affected workspace, and where the harness still has missing coverage, while keeping `.pulse-coder/` reserved for product/runtime configuration. The primary dashboard is intentionally list/card/detail based because the harness job is information consumption, not graph exploration.

## Validation

- `git diff --check`
- `git diff --cached --check`
- YAML parse for `harness/profile.yaml` and `harness/validation.yaml`
- Referenced path existence check for harness profile entries
- `pnpm install --frozen-lockfile --ignore-scripts`
- `node --check harness/tools/graph-viewer/server.mjs`
- `node harness/tools/graph-viewer/server.mjs --once` now reports 14/14 explicit workspaces, 14/14 entry coverage, 14/14 validation coverage, and `harnessGaps: 0`.
- `pnpm --filter @pulse-coder/canvas-cli test && pnpm --filter @pulse-coder/canvas-cli typecheck`
- `pnpm --filter @pulse-canvas/nodes test && pnpm --filter @pulse-canvas/nodes typecheck`
- `pnpm --filter pulse-sandbox test && pnpm --filter pulse-sandbox typecheck`
- `pnpm --filter @pulse-coder/teams-cli test && pnpm --filter @pulse-coder/teams-cli build`
- `pnpm --filter pulse-coder-langfuse-plugin build`
- Browser smoke check for the harness dashboard at desktop and mobile widths using local Chrome: overview metrics, workspace cards, missing rows, and validation commands rendered successfully.
- In-app browser smoke check for the language switcher: Chinese mode renders Chinese-only UI labels and English mode renders English-only UI labels, while technical paths and commands remain unchanged.
- In-app browser smoke check after removing the graph: top-level tabs are `总览`, `工作区`, and `缺失`; no graph section or SVG is rendered; overview metrics still render.
- In-app browser smoke check for grouped missing items: Missing renders grouped workspace gaps, and gap rows have no implicit workspace navigation.
- In-app browser smoke check for drawer workspace detail: Workspaces card click opens `apps/teams-cli` in a right-side drawer with the Workspaces tab active; `查看工作区` from Missing opens the same drawer while the active tab remains `缺失`; clicking a priority gap from Overview opens the drawer while the active tab remains `总览`.
- In-app browser smoke check for Linear dark style: verified near-black canvas, charcoal panels/drawer, surface-lift tabs, 8px primary buttons, no stale light-mode colors, and no horizontal overflow at desktop or 390px mobile width.
- In-app browser mobile smoke check: the drawer uses full viewport width at 390px and does not create horizontal overflow.

Note: pnpm still warns that the root `package.json` `pnpm.onlyBuiltDependencies` field is no longer read by pnpm v11; that warning predates this harness change. `teams-cli` and `langfuse-plugin` typecheck commands still hit existing TS6059 rootDir boundaries, so their harness rules use verified build commands and document typecheck as a future promotion item.