### PR TITLE
[codex] Fill baseline harness coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,17 +17,34 @@ AGENTS.md / CLAUDE.md
 ## Project Structure & Module Organization
 This repo is a `pnpm` monorepo with all `packages/*` workspaces plus selected app workspaces listed in `pnpm-workspace.yaml`.
 
-- `packages/engine`: core agent engine, built-in tools, plugin loading, and runtime loop.
-- `packages/cli`: interactive terminal CLI built on `pulse-coder-engine`.
-- `packages/pulse-sandbox`: sandboxed JS execution runtime and `run_js` tool adapter.
-- `packages/memory-plugin`: memory integration/service package.
-- `apps/remote-server`: optional HTTP service wrapper around the engine.
-- `apps/teams-cli`: CLI host for agent teams workflows.
-- `apps/canvas-workspace`: Electron canvas workbench.
+Root-level guidance should route work to the right local entry, then the local `AGENTS.md` should carry the package-specific map, boundaries, and validation notes. Primary source code lives under each package/app `src/` directory; build output goes to `dist/`.
 
-Other `apps/*` directories may be legacy, standalone, or auxiliary projects; do not treat them as active pnpm workspaces unless `pnpm-workspace.yaml` includes them.
+## Workspace Entry Index
 
-Primary source code lives under each package/app `src/` directory; build output goes to `dist/`.
+| Workspace | Local entry | Start there when the change touches |
+|---|---|---|
+| `packages/engine` | `packages/engine/AGENTS.md` | engine loop, providers, prompts, tools, hooks, plugins, context, or public runtime API |
+| `packages/cli` | `packages/cli/AGENTS.md` | terminal UX, sessions, slash commands, ACP/team/memory wiring, or CLI sandbox registration |
+| `packages/acp` | `packages/acp/AGENTS.md` | ACP JSON-RPC clients, child processes, external agent sessions, permissions, or file handlers |
+| `packages/pulse-sandbox` | `packages/pulse-sandbox/AGENTS.md` | sandboxed JavaScript execution or the `run_js` tool adapter |
+| `packages/agent-teams` | `packages/agent-teams/AGENTS.md` | team runtime, task state, review gates, verification metadata, handoffs, or team protocol APIs |
+| `packages/orchestrator` | `packages/orchestrator/AGENTS.md` | generic DAG planning, routing, scheduling, agent runners, artifacts, or aggregation |
+| `packages/plugin-kit` | `packages/plugin-kit/AGENTS.md` | worktree binding, vault binding, devtools timelines, or reusable plugin infrastructure |
+| `packages/memory-plugin` | `packages/memory-plugin/AGENTS.md` | memory services, recall/write policy, embeddings, daily logs, layered storage, or memory tools |
+| `packages/langfuse-plugin` | `packages/langfuse-plugin/AGENTS.md` | Langfuse traces, generations, tool spans, compaction events, or observability hooks |
+| `packages/canvas-cli` | `packages/canvas-cli/AGENTS.md` | `pulse-canvas` CLI commands, canvas store inspection/mutation, or runtime-control helpers |
+| `packages/canvas-nodes` | `packages/canvas-nodes/AGENTS.md` | external Canvas node plugins, manifests, capability providers, renderers, or webview node apps |
+| `apps/remote-server` | `apps/remote-server/AGENTS.md` | HTTP/webhook runtime, platform adapters, internal routes, devtools, or remote session wiring |
+| `apps/teams-cli` | `apps/teams-cli/AGENTS.md` | terminal host behavior for agent teams run/plan/interactive workflows |
+| `apps/canvas-workspace` | `apps/canvas-workspace/AGENTS.md` | Electron workbench, canvas persistence, Canvas Agent, teams UI, plugins, webviews, PTYs, or app harness |
+
+## Auxiliary App Directories
+
+These directories are useful context, but they are not active pnpm workspaces in the repository harness unless `pnpm-workspace.yaml` is expanded:
+
+- `apps/coder-demo`: legacy standalone experimental app; its placeholder test script is expected to fail.
+- `apps/devtools-web`: auxiliary Vite devtools UI that can be served by `apps/remote-server` when built.
+- `apps/canvas-plugin-react-mf-note-demo`: standalone Canvas external plugin demo with its own package flow.
 
 ## Build, Test, and Development Commands
 - `pnpm install`: install workspace dependencies.
@@ -36,6 +53,7 @@ Primary source code lives under each package/app `src/` directory; build output 
 - `pnpm start`: run the CLI (`pulse-coder-cli`).
 - `pnpm test`: run package tests (`./packages/*`).
 - `pnpm run test:apps`: run tests for app workspaces matched by pnpm filters.
+- `node harness/tools/graph-viewer/server.mjs --once`: validate the harness data behind the dashboard once.
 - `pnpm --filter pulse-coder-engine typecheck`: strict TS typecheck for engine.
 
 Useful package targets:
@@ -46,17 +64,7 @@ Useful package targets:
 - `pnpm --filter @pulse-coder/remote-server build`
 - `pnpm --filter @pulse-coder/remote-server dev`
 
-Note: legacy or standalone app directories are outside the active pnpm workspace set unless listed in `pnpm-workspace.yaml`.
-
-## Remote server notes (`apps/remote-server`)
-- Entry point: `apps/remote-server/src/index.ts` bootstraps session store, memory integration, worktree binding, and engine.
-- HTTP server: `apps/remote-server/src/server.ts` mounts `/health`, webhook routes, and `/internal/*` routes.
-- Dispatcher: `apps/remote-server/src/core/dispatcher.ts` owns signature verification, fast ack, command parsing, and streaming.
-- Sessions: stored in `~/.pulse-coder/remote-sessions` with `index.json` + `sessions/*.json`.
-- Memory logs: stored in `~/.pulse-coder/remote-memory` via `pulse-coder-memory-plugin`.
-- Worktree binding: stored in `~/.pulse-coder/worktree-state` via `pulse-coder-plugin-kit`.
-- Internal API: `/internal/agent/run` is loopback-only and requires `INTERNAL_API_SECRET`.
-- Platform adapters: Feishu and Discord are mounted; Telegram/Web adapters exist but are not enabled by default.
+Use the affected workspace entry and `harness/validation.yaml` before picking checks. Some local entries document package commands that are intentionally absent or currently red; do not promote those commands to root-level defaults until the package itself is cleaned up.
 
 ## Coding Style & Naming Conventions
 Use TypeScript with strict mode and keep style consistent with neighboring files:

--- a/apps/canvas-workspace/AGENTS.md
+++ b/apps/canvas-workspace/AGENTS.md
@@ -4,175 +4,137 @@
 > Repository harness entry: `../../harness/README.md`.
 > Claude Code specific guidance lives in `CLAUDE.md`.
 
-## How To Use This File
+## Module Positioning
 
-This file is the tool-agnostic local entry. It intentionally stays light and routes to the existing, more detailed local guidance.
+`canvas-workspace` owns the Pulse Canvas Electron workbench: the desktop shell,
+React renderer, preload bridge, canvas persistence and migration, Canvas Agent
+chat, agent-team flows, plugin loading, embedded webviews, terminal/agent PTYs,
+artifacts, settings, local runtime-control server, and app-specific harness.
+
+This is an active pnpm app workspace. It consumes `pulse-coder-engine` and
+`pulse-coder-agent-teams`, interoperates with `@pulse-coder/canvas-cli` through
+the canvas store and runtime-control server, and hosts external node plugins
+such as `@pulse-canvas/nodes` through manifests and plugin registries.
+
+Keep this file as the local router. Put durable implementation detail in
+`CLAUDE.md`, existing workspace docs, or tests. Add new workspace docs only
+when a behavior or operating runbook needs a durable source of truth.
+
+## Knowledge Navigation
 
 | Task | Read |
 |---|---|
-| Claude Code guidance and app overview | `CLAUDE.md` |
-| Runtime harness commands | `harness/README.md` |
-| Main/renderer conventions | `docs/conventions/README.md` |
-| Main process boundaries | `docs/conventions/architecture-boundaries.md` |
+| Repository routing and validation matrix | `../../harness/profile.yaml`, `../../harness/validation.yaml` |
+| App overview and Claude-specific notes | `README.md`, `CLAUDE.md` |
+| Runtime harness | `harness/README.md`, `skills/canvas-harness/SKILL.md`, `skills/canvas-onboard-harness/SKILL.md` |
+| Main/renderer/preload boundaries | `docs/conventions/README.md`, `docs/conventions/architecture-boundaries.md` |
 | Renderer conventions | `docs/conventions/frontend.md` |
-| Main process conventions | `docs/conventions/backend.md` |
-| Repository harness map | `../../harness/profile.yaml` |
+| Main-process conventions | `docs/conventions/backend.md` |
+| Main domain map | `docs/main-domain-modules.md`, `src/main/index.ts`, `src/main/app/bootstrap.ts` |
+| Renderer routes and full-app surfaces | `docs/renderer-surfaces.md`, `src/renderer/src/App.tsx`, `src/renderer/src/components/Workbench/`, `src/renderer/src/components/RightDock/` |
+| Cross-process API bridge | `src/preload/index.ts`, `src/preload/bridge/`, `src/renderer/src/types.ts`, `src/shared/` |
+| Canvas node/edge schema | `src/shared/canvas.ts` |
+| Canvas persistence and migration | `src/main/canvas/store.ts`, `src/main/canvas/storage.ts`, `src/main/canvas/nodes/` |
+| Canvas Agent and tools | `src/main/agent/`, `src/main/agent/tools/`, `src/renderer/src/components/chat/` |
+| Agent teams | `src/main/agent-teams/`, `src/renderer/src/components/AgentTeamFrame/` |
+| Runtime-control server | `src/main/runtime/control-server.ts` |
+| Plugin node contract | `docs/plugin-node-mf2.md`, `src/plugins/types.ts`, `src/plugins/main/`, `src/plugins/renderer/`, `src/plugins/mock-node/` |
+| Channel plugin | `src/plugins/main/channel/README.md`, `src/plugins/main/channel/` |
+| Boundary and file-size gates | `src/main/__tests__/import-boundaries.test.ts`, `src/main/__tests__/file-size-governance.test.ts` |
+| Storage/plugin/runtime tests | `src/main/__tests__/canvas-storage.test.ts`, `src/plugins/main/__tests__/registry.test.ts`, `src/main/runtime/__tests__/control-server.test.ts` |
+| Documentation routing | `../../harness/skills/doc-governance.md` |
+| Validation planning | `../../harness/skills/quality-workflow.md` |
+| Contract changes | `../../harness/skills/contract-coding.md` |
 
 ## Local Constraints
 
-- Renderer reaches the main process only through `window.canvasWorkspace` exposed by preload.
-- Domain logic lives in `src/main/<domain>/`; renderer code should not reach into Electron/Node APIs directly.
-- For interaction-heavy changes, consider the app runtime harness in `harness/README.md`.
-- Keep this file as a router. Do not duplicate the detailed guidance already in `CLAUDE.md` or `docs/conventions/`.
+- Renderer code reaches privileged behavior only through the typed
+  `window.canvasWorkspace` preload API. Do not import Electron, Node, `src/main`,
+  or `src/preload` from renderer code.
+- Cross-process contracts should move toward `src/shared/`. Existing preload
+  imports from `src/renderer/src/types.ts` are allowlisted migration debt; do
+  not add new preload-to-renderer imports.
+- Keep main-process code in domain folders under `src/main/`; preserve
+  IPC channel names and preload API shape when refactoring.
+- Follow file-size governance: new production `.ts`/`.tsx` files must stay at
+  or below 500 lines, and existing over-500 baseline files must not grow.
+- Runtime data belongs under user locations such as `~/.pulse-coder/canvas/`,
+  `~/.pulse-coder/canvas-runtime/`, and model/settings files. Do not write user
+  runtime state into the repository.
+- `harness/` launches the real Electron app. Use `temp`, `demo`, or `clone`
+  profiles by default; use `real --allow-real-writes` only after explicit user
+  intent because it can mutate real Pulse Canvas data.
+- The app owns v2 canvas storage migration, PTY sessions, runtime-control
+  endpoints, plugin activation, and UI-visible data recovery. The CLI adapts to
+  those contracts but does not own them.
+- Canvas node and edge shapes are sourced from `src/shared/canvas.ts`, not the
+  shorter README node table. Current host node types include `file`,
+  `terminal`, `frame`, `group`, `agent`, `text`, `iframe`, `image`, `shape`,
+  `mindmap`, `reference`, `dynamic-app`, and `plugin`.
+- Plugin nodes use stable host type `plugin` with plugin-owned
+  `data.payload`. Host behavior should go through renderer/main plugin
+  registries and declared capabilities.
+- The channel plugin is inert unless the experimental flag and channel config
+  are enabled; keep channel credentials in local settings/env, not source.
 
-## Overview
-
-**Pulse Canvas** (`canvas-workspace`) is an Electron desktop app that provides a
-free-form, infinite canvas workspace for AI-assisted coding. Users arrange
-**nodes** on a canvas and interact with an embedded AI agent powered by
-`pulse-coder-engine`.
-
-## Tech Stack
-
-- **Electron** (v30) + **electron-vite** — desktop shell and build pipeline
-- **React** (v18) + **wouter** — renderer UI and routing
-- **Tiptap** (v3) — rich-text editor for file nodes
-- **xterm.js** + **node-pty** — terminal emulation in terminal/agent nodes
-- **pulse-coder-engine** + **pulse-coder-agent-teams** (`workspace:*`) — power the
-  in-app AI agent and multi-agent flows
-- **zod**, **markdown-it**, **mermaid**, **react-force-graph-2d** — schema,
-  markdown, diagrams, and graph rendering
-
-## Node Types
-
-| Type | Description |
-|------|-------------|
-| `file` | Tiptap-based rich-text/markdown editor backed by a real file path |
-| `terminal` | Full PTY terminal session |
-| `agent` | Runs an external AI agent CLI (e.g. `claude`) in a PTY; accepts inline prompts or prompt files |
-| `frame` | Visual grouping rectangle with a label/color |
-
-## Views & Shortcuts
-
-- **Canvas view** (`/`) — free-form canvas with sidebar, node editing, optional right-side chat panel.
-- **Chat view** (`/chat`) — full-screen AI chat page backed by `pulse-coder-engine`.
-
-| Shortcut | Action |
-|----------|--------|
-| `Cmd/Ctrl+Shift+A` | Toggle right-side chat panel (canvas view only) |
-| `Cmd/Ctrl+Shift+L` | Toggle full-screen chat view |
-| `Esc` | Return to canvas from chat view |
-
-## Project Structure
-
-```
-src/
-  main/             # Electron main process (domain-based modules)
-    app/            # Electron bootstrap, window, protocol, logging, link policy
-    agent/          # CanvasAgent + CanvasAgentService (engine-backed AI chat)
-    agent-teams/    # Multi-agent teams integration (pulse-coder-agent-teams)
-    artifacts/      # Artifact persistence and artifact IPC
-    canvas/         # Canvas persistence, storage migration, nodes, tags, broadcast
-    files/          # File read/write/dialog IPC and filesystem watcher
-    generation/     # HTML generation and streaming IPC
-    runtime/        # Runtime control server and MCP helpers
-    settings/       # App/model settings persistence and IPC
-    terminal/       # node-pty session management
-    webview/        # Webview registry, CDP helpers, page reader
-    index.ts        # Main entry
-  preload/          # Context bridge (exposes window.canvasWorkspace API)
-  renderer/src/
-    components/     # Canvas, Sidebar, AgentNodeBody, FileNodeBody, chat/, …
-    hooks/          # useWorkspaces, canvas interaction hooks
-    editor/         # Tiptap editor setup
-    config/ constants/ i18n/ utils/
-    types.ts        # Shared types (CanvasNode, CanvasWorkspaceApi, …)
-```
-
-The renderer communicates with the main process **exclusively** through
-`window.canvasWorkspace` (typed in `types.ts`), bridged via `src/preload/`.
-Never reach into Electron/Node APIs directly from the renderer — add an IPC
-channel in the relevant `src/main/<domain>/` module and expose it through preload.
-
-See `docs/main-domain-modules.md` for the `src/main` module layout and migration
-plan, and `docs/renderer-surfaces.md` for renderer surface breakdown.
-
-## Dev & Build Commands
+## Common Commands
 
 ```bash
-pnpm install                              # also runs electron-rebuild for node-pty
-pnpm --filter canvas-workspace dev        # development (hot reload)
-pnpm --filter canvas-workspace build      # production build
-pnpm --filter canvas-workspace typecheck  # tsc --noEmit (renderer + main)
-pnpm --filter canvas-workspace test       # vitest run
-
-# Packaging (output → release/, appId com.pulse-coder.canvas-workspace)
-pnpm --filter canvas-workspace package          # current platform
-pnpm --filter canvas-workspace package:mac      # macOS dmg (arm64 + x64)
-pnpm --filter canvas-workspace package:win      # Windows nsis x64
-pnpm --filter canvas-workspace package:linux    # Linux AppImage + deb x64
+pnpm --filter canvas-workspace typecheck
+pnpm --filter canvas-workspace test
+pnpm --filter canvas-workspace build
+pnpm --filter canvas-workspace dev
+pnpm --filter canvas-workspace dev:temp-home
 ```
 
-`typecheck` runs two tsconfigs (`tsconfig.json` for renderer, `tsconfig.node.json`
-for main). `dev:temp-home` runs against a throwaway `$HOME` sandbox.
+Harness commands for interaction-heavy or visual changes:
 
-## Validation Policy
+```bash
+pnpm --filter canvas-workspace harness start --profile demo --build
+pnpm --filter canvas-workspace harness status
+pnpm --filter canvas-workspace harness snapshot-ui
+pnpm --filter canvas-workspace harness screenshot
+pnpm --filter canvas-workspace harness logs --lines 120
+pnpm --filter canvas-workspace harness close --cleanup
+```
 
-Use judgment when choosing validation depth.
+Packaging commands exist, but are slower and platform-dependent:
 
-For small renderer-only changes, prefer targeted tests and typecheck.
+```bash
+pnpm --filter canvas-workspace package
+pnpm --filter canvas-workspace package:mac
+pnpm --filter canvas-workspace package:mac:arm64
+pnpm --filter canvas-workspace package:win
+pnpm --filter canvas-workspace package:linux
+```
 
-For canvas interaction changes that affect drag/drop, selection, resize,
-keyboard shortcuts, zoom/pan, webview/iframe shielding, or multi-node behavior,
-consider running the harness when the changed behavior is hard to cover with a
-unit test or likely to regress visually.
+## Key Files
 
-When skipping the harness for an interaction change, briefly state why in the
-final response and list the validation that was run instead.
-
-## Canvas Agent & Model Config
-
-The AI chat feature is powered by `CanvasAgentService` (`src/main/agent/`), which
-wraps `pulse-coder-engine`. Each workspace keeps its own agent session, persisted
-under the workspace data directory, and receives a workspace/node summary as
-context on every turn.
-
-Model settings are read from `~/.pulse-coder/canvas/model-config.json` by default
-(override with `PULSE_CANVAS_MODEL_CONFIG`). The config supports OpenAI-compatible
-and Anthropic-compatible providers and stores only **env var names** for API keys,
-never secret values. The renderer manages the same config through
-`window.canvasWorkspace.model` (`status`, `saveConfig`, `upsertOption`,
-`setCurrent`, `removeOption`, `reset`); changes apply to new agent turns and HTML
-generation without restarting the app.
-
-## Data Persistence
-
-Canvas state (node positions, types, data) is saved per workspace as JSON via
-`src/main/canvas/`. File nodes are backed by real files on disk; the file watcher
-pushes external changes into the renderer via IPC.
-
-## Coding Conventions
-
-Detailed, reusable rules live in **[`docs/conventions/`](./docs/conventions/README.md)**.
-Read the relevant doc before writing or reviewing code:
-
-- **[`docs/conventions/README.md`](./docs/conventions/README.md)** — index + baseline rules.
-- **[`docs/conventions/architecture-boundaries.md`](./docs/conventions/architecture-boundaries.md)**
-  — process layers (`shared`/`main`/`preload`/`renderer`), import rules, and
-  file-size governance. **Enforced by tests** (`src/main/__tests__/import-boundaries.test.ts`,
-  `file-size-governance.test.ts`).
-- **[`docs/conventions/frontend.md`](./docs/conventions/frontend.md)** — renderer
-  (React) component/hook/styling/i18n/IPC-consumption conventions.
-- **[`docs/conventions/backend.md`](./docs/conventions/backend.md)** — main
-  process domain modules, IPC, services, and persistence conventions.
-
-Quick reminders (see the docs for the full rules):
-
-- TypeScript strict mode; match local file style (2 spaces, semicolons, ESM
-  imports). Keep diffs minimal and preserve existing patterns.
-- Aim **≤ 300 lines per component/module**; new files must stay **≤ 500**
-  (hard-gated). Split by responsibility rather than growing a file.
-- Renderer reaches the main process **only** through `window.canvasWorkspace`
-  (preload bridge); domain logic lives in `src/main/<domain>/`.
-- Cross-package imports use workspace package names (`pulse-coder-engine`,
-  `pulse-coder-agent-teams`).
+- `src/main/index.ts`: thin Electron main entrypoint.
+- `src/main/app/bootstrap.ts`: startup wiring for IPC, canvas storage, agent,
+  teams, plugins, runtime-control, window creation, and teardown.
+- `src/preload/index.ts`: exposes `window.canvasWorkspace` and assembles bridge
+  APIs.
+- `src/renderer/src/App.tsx`: top-level renderer routes, shell, settings, and
+  plugin route/nav integration.
+- `src/renderer/src/components/Canvas/`: canvas surface and interaction wiring.
+- `src/renderer/src/components/Workbench/`: mounted workspace state and chat
+  portal ownership.
+- `src/renderer/src/components/RightDock/`: tabbed right dock for chat and
+  previews.
+- `src/shared/canvas.ts`: canonical canvas node, edge, reference, and workspace
+  node contracts.
+- `src/main/canvas/store.ts`: workspace manifest/store IPC, watchers, export,
+  import, and migration hooks.
+- `src/main/canvas/storage.ts`: atomic JSON I/O, v2 split storage, migration,
+  recovery, and pollution detection.
+- `src/main/agent/`: Canvas Agent service, session store, prompt/model config,
+  tools, and chat IPC.
+- `src/main/agent-teams/`: agent-team service, store, IPC, PTY bridge, and
+  canvas node integration.
+- `src/main/runtime/control-server.ts`: loopback runtime server used by live
+  `pulse-canvas` commands.
+- `src/plugins/main/`, `src/plugins/renderer/`, `src/plugins/types.ts`: Canvas
+  plugin registries and shared plugin contracts.
+- `harness/`: app-specific Electron launch, CDP, screenshot, input, logs, and
+  cleanup harness.

--- a/apps/remote-server/AGENTS.md
+++ b/apps/remote-server/AGENTS.md
@@ -6,30 +6,41 @@
 
 ## Module Positioning
 
-`@pulse-coder/remote-server` hosts the engine behind HTTP/webhook integrations. It owns webhook dispatch, platform adapters, internal automation routes, engine singleton wiring, session persistence, memory integration, and runtime operational concerns.
+`@pulse-coder/remote-server` is the optional HTTP runtime around `pulse-coder-engine`. It owns platform webhook ingress, internal automation routes, adapter streaming, shared engine/plugin wiring, remote session persistence, memory/worktree/vault context, Discord gateway startup, and local devtools observability.
 
-## Knowledge Navigation
+Default mounted surface is defined in `src/server.ts`: `/health`, Feishu and Discord webhooks, `/internal/*`, `/api/devtools/*`, and static `/devtools/*`. Telegram and the generic Web chat/SSE API have source files but are not mounted by default.
+
+## Progressive Reading Path
 
 | Task | Read |
 |---|---|
-| Local Claude guidance | `CLAUDE.md` |
-| Operations and smoke testing | `docs/runbook.md` |
-| Pick validation | `docs/validation.md` |
-| Bootstrap/server | `src/index.ts`, `src/server.ts` |
-| Webhook dispatch | `src/core/dispatcher.ts` |
-| Agent execution | `src/core/agent-runner.ts` |
-| Internal API | `src/routes/internal.ts` |
-| Custom tools | `src/core/engine-singleton.ts` |
+| Repository and harness context | `../../AGENTS.md`, `../../harness/README.md`, `../../harness/profile.yaml`, `../../harness/validation.yaml` |
+| Local runtime overview | `README.md`, `CLAUDE.md`, `docs/runbook.md`, `docs/validation.md` |
+| Package scripts and build shape | `package.json`, `tsup.config.ts`, `tsconfig.json` |
+| Bootstrap and mounted routes | `src/index.ts`, `src/server.ts` |
+| Webhook lifecycle | `src/core/dispatcher.ts`, `src/core/types.ts`, `src/core/active-run-store.ts`, `src/core/clarification-queue.ts` |
+| Agent execution and run context | `src/core/agent-runner.ts`, `src/core/engine-singleton.ts` |
+| Persistence and integrations | `src/core/session-store.ts`, `src/core/memory-integration.ts`, `src/core/worktree/integration.ts`, `src/core/vault/integration.ts`, `src/core/devtools.ts` |
+| Slash commands | `src/core/chat-commands.ts`, `src/core/chat-commands/command-defs.ts`, `src/core/chat-commands/handlers/*` |
+| Internal automation | `src/routes/internal.ts` |
+| Platform behavior | `src/adapters/feishu/*`, `src/adapters/discord/*`, `src/routes/feishu.ts`, `src/routes/discord.ts` |
+| Devtools API | `src/routes/devtools.ts`; static UI is built outside this workspace in `../devtools-web` |
+| Focused helper tests | `src/core/model-config.test.ts`, `src/core/attachments.test.ts`, `src/core/tools/analyze-image.test.ts` |
 
 ## Local Constraints
 
-- Keep route handlers thin; delegate to dispatcher, runner, or adapter modules.
-- Do not bypass platform signature verification or the active-run concurrency guard.
-- Internal routes must remain loopback-only and bearer-token protected.
-- Stream output through adapter `StreamHandle` callbacks; adapters own platform send behavior.
-- Runtime or API contract changes should update `docs/runbook.md` or validation guidance when needed.
+- Keep route handlers thin; delegate lifecycle work to dispatcher, runner, adapter, or service modules.
+- Do not bypass platform signature verification, loopback checks, bearer-token checks, or the per-`platformKey` active-run guard.
+- Internal routes must remain loopback-only and protected by `INTERNAL_API_SECRET` in production.
+- Stream user-visible output only through adapter `StreamHandle` callbacks; adapters own platform send/edit behavior.
+- Keep mounted routes in `src/server.ts` and documented endpoints in sync. If a source route remains commented out, document it as implemented-but-not-mounted.
+- Session, memory, worktree, vault, and devtools state live under user-level `~/.pulse-coder/*` paths. Do not treat `.pulse-coder/` repository config as harness source of truth.
+- Runtime/API behavior changes should update `README.md`, `docs/runbook.md`, or `docs/validation.md` when they change operator expectations.
+- Never commit secrets or local runtime state.
 
 ## Common Commands
+
+Run from the repository root unless noted.
 
 ```bash
 pnpm --filter @pulse-coder/remote-server dev
@@ -37,10 +48,22 @@ pnpm --filter @pulse-coder/remote-server build
 pnpm --filter @pulse-coder/remote-server start
 ```
 
+`start` runs `dist/index.cjs`, so build first after source changes. PM2 helpers in `package.json` are operational commands, not default validation.
+
+For docs-only changes, `docs/validation.md` says no build is required; check referenced paths and command names instead. The package currently has no workspace-local `test` script. There are Vitest files under `src/`, but the ad hoc root-level targeted run is not a clean default check until existing helper-test failures are fixed.
+
+## Validation Notes
+
+- Default code check: `pnpm --filter @pulse-coder/remote-server build`.
+- Runtime smoke, when changing routes/dispatcher/runner/adapters and credentials are available: start `dev`, then call `/health`; for internal automation, also smoke `/internal/agent/run` from loopback with `INTERNAL_API_SECRET`.
+- Escalate to engine, memory-plugin, plugin-kit, ACP, or langfuse checks when changes cross those integration boundaries.
+
 ## Key Files
 
-- `src/index.ts`: bootstrap stores, memory, worktree binding, engine, gateway, and server.
-- `src/server.ts`: Hono server and route mounting.
-- `src/core/dispatcher.ts`: webhook ack, slash commands, concurrency, streaming dispatch.
-- `src/core/agent-runner.ts`: run context, engine execution, session and memory persistence.
-- `src/routes/internal.ts`: internal automation routes.
+- `src/index.ts`: initializes session, memory, worktree, vault, devtools, engine, Discord gateway, app server, and Discord commands.
+- `src/server.ts`: Hono app factory and the source of truth for mounted HTTP routes.
+- `src/core/dispatcher.ts`: signature-verified webhook flow, fast ack, slash-command handling, active-run guard, and streaming callbacks.
+- `src/core/agent-runner.ts`: session lookup, attachment context, model override resolution, ACP fallback, engine run, compaction capture, and memory logging.
+- `src/core/engine-singleton.ts`: shared engine plugins and remote custom tools.
+- `src/routes/internal.ts`: loopback-only automation and Discord gateway internal endpoints.
+- `src/routes/devtools.ts`: local devtools JSON API consumed by the optional `../devtools-web` UI.

--- a/apps/teams-cli/AGENTS.md
+++ b/apps/teams-cli/AGENTS.md
@@ -5,40 +5,65 @@
 
 ## Module Positioning
 
-`@pulse-coder/teams-cli` is the CLI host for `pulse-coder-agent-teams`. It exposes team workflows for previewing, planning, and running multi-agent coordination from the terminal.
+`@pulse-coder/teams-cli` is the terminal host for `pulse-coder-agent-teams`. It exposes three user-facing modes:
 
-Team protocol behavior belongs in `packages/agent-teams`; this app should stay focused on CLI entrypoints, command modes, display, and host wiring.
+- `run`: TeamLead-driven planning, execution, synthesis, and follow-up loop.
+- `plan`: plan-only preview through `planTeam`.
+- `interactive`: local REPL for creating a team, spawning teammates, creating/running tasks, and messaging.
 
-## Knowledge Navigation
+Team protocol behavior, task state, review gates, verification semantics, and public runtime APIs belong in `packages/agent-teams`. This app should stay focused on command parsing, terminal display, runtime host wiring, and preview ergonomics.
+
+## Progressive Reading Path
 
 | Task | Read |
 |---|---|
-| CLI entrypoint | `src/index.ts` |
-| In-process display | `src/display/in-process.ts` |
-| Package scripts | `package.json` |
-| Team runtime contracts | `../../packages/agent-teams/AGENTS.md` |
-| Agent teams roadmap | `../../docs/07-agent-teams-maturity-roadmap.md` |
+| Repository and harness context | `../../AGENTS.md`, `../../harness/README.md`, `../../harness/profile.yaml`, `../../harness/validation.yaml` |
+| Package scripts and build shape | `package.json`, `tsup.config.ts`, `tsconfig.json` |
+| CLI modes and arguments | `src/index.ts` |
+| Terminal event rendering | `src/display/in-process.ts` |
+| Team runtime entry and contracts | `../../packages/agent-teams/AGENTS.md`, `../../packages/agent-teams/docs/contracts.md` |
+| Team runtime validation | `../../packages/agent-teams/docs/validation.md` |
+| Maturity roadmap | `../../docs/07-agent-teams-maturity-roadmap.md` |
+
+There are no local `README.md`, `docs/`, or `*.test.ts`/`*.spec.ts` files in this app at the time of writing.
 
 ## Local Constraints
 
-- Do not duplicate team runtime policy that belongs in `packages/agent-teams`.
-- Keep command output and display behavior separate from team state transitions.
-- Preview modes should remain safe for local experimentation.
+- Do not duplicate or weaken protocol policy from `packages/agent-teams`; change protocol behavior in the runtime package first.
+- Keep terminal rendering separate from team state transitions. `src/display/in-process.ts` should render `TeamEvent`s, not decide lifecycle semantics.
+- Keep `run`, `plan`, and `interactive` mode behavior explicit in `src/index.ts`.
+- Preserve cleanup paths: displays should stop and teams should clean up on failures or REPL exit.
+- Current team creation passes `defaultTeammateEngineOptions: { disableBuiltInPlugins: true }`; changing that affects local preview safety and should be intentional.
+- Preview/manual runs may invoke LLM-backed planning or teammate execution; do not treat them as cheap deterministic validation.
 
 ## Common Commands
+
+Run from the repository root unless noted.
 
 ```bash
 pnpm --filter @pulse-coder/teams-cli test
 pnpm --filter @pulse-coder/teams-cli build
-pnpm preview:teams
-pnpm preview:teams:run
-pnpm preview:teams:plan
 ```
 
-`typecheck` currently hits TS6059 because the app imports workspace source from `packages/agent-teams`, `packages/engine`, and `packages/orchestrator` outside this app's `rootDir`; prefer `build` until that TypeScript boundary is fixed.
+Manual preview commands, when provider credentials and a real task are available:
+
+```bash
+pnpm preview:teams
+pnpm --filter @pulse-coder/teams-cli preview:plan -- "Plan a small repo maintenance task"
+pnpm --filter @pulse-coder/teams-cli preview:run -- "Run a small repo maintenance task"
+```
+
+`test` currently uses `vitest run --passWithNoTests`, so it verifies the test harness but not app behavior. `typecheck` is a known non-default check: it currently hits TS6059 because the app imports workspace source from `packages/agent-teams`, `packages/engine`, and `packages/orchestrator` outside this app's `rootDir`. Prefer `build` until that TypeScript boundary is fixed.
+
+## Validation Notes
+
+- Harness-required checks for app changes: `pnpm --filter @pulse-coder/teams-cli test` and `pnpm --filter @pulse-coder/teams-cli build`.
+- If a change alters team protocol, exported APIs, task lifecycle, or review/verification semantics, also run the relevant `packages/agent-teams` checks and consumer escalation from `../../packages/agent-teams/docs/validation.md`.
+- For terminal UX changes, include a short manual preview note when a preview was run, or state why it was skipped.
 
 ## Key Files
 
-- `src/index.ts`: CLI entrypoint and command modes.
-- `src/display/in-process.ts`: in-process display implementation.
-- `package.json`: bin, scripts, and dependencies.
+- `src/index.ts`: CLI entrypoint, argument parsing, run/plan/interactive modes, follow-up loop, and printed usage.
+- `src/display/in-process.ts`: terminal renderer for team events, progress, status ticker, stderr filtering, and final report.
+- `package.json`: bin path, scripts, runtime dependency on `pulse-coder-agent-teams`, and Vitest/tsup wiring.
+- `tsconfig.json`: current `rootDir: ./src` boundary that explains the known `typecheck` failure.

--- a/apps/teams-cli/AGENTS.md
+++ b/apps/teams-cli/AGENTS.md
@@ -29,12 +29,13 @@ Team protocol behavior belongs in `packages/agent-teams`; this app should stay f
 
 ```bash
 pnpm --filter @pulse-coder/teams-cli test
-pnpm --filter @pulse-coder/teams-cli typecheck
 pnpm --filter @pulse-coder/teams-cli build
 pnpm preview:teams
 pnpm preview:teams:run
 pnpm preview:teams:plan
 ```
+
+`typecheck` currently hits TS6059 because the app imports workspace source from `packages/agent-teams`, `packages/engine`, and `packages/orchestrator` outside this app's `rootDir`; prefer `build` until that TypeScript boundary is fixed.
 
 ## Key Files
 

--- a/harness/profile.yaml
+++ b/harness/profile.yaml
@@ -85,6 +85,39 @@ workspaces:
     knowledge:
       readme: packages/acp/README.md
 
+  packages/canvas-cli:
+    type: package
+    packageName: "@pulse-coder/canvas-cli"
+    role: canvas-agent-cli
+    entry: packages/canvas-cli/AGENTS.md
+    knowledge:
+      readme: packages/canvas-cli/README.md
+
+  packages/canvas-nodes:
+    type: package
+    packageName: "@pulse-canvas/nodes"
+    role: canvas-external-node-plugins
+    entry: packages/canvas-nodes/AGENTS.md
+    knowledge:
+      readme: packages/canvas-nodes/README.md
+      manifest: packages/canvas-nodes/manifest.json
+
+  packages/langfuse-plugin:
+    type: package
+    packageName: pulse-coder-langfuse-plugin
+    role: langfuse-observability-plugin
+    entry: packages/langfuse-plugin/AGENTS.md
+    knowledge:
+      source: packages/langfuse-plugin/src/index.ts
+
+  packages/pulse-sandbox:
+    type: package
+    packageName: pulse-sandbox
+    role: sandboxed-js-runtime
+    entry: packages/pulse-sandbox/AGENTS.md
+    knowledge:
+      readme: packages/pulse-sandbox/README.md
+
   apps/remote-server:
     type: app
     packageName: "@pulse-coder/remote-server"

--- a/harness/validation.yaml
+++ b/harness/validation.yaml
@@ -30,6 +30,15 @@ pathRules:
         - pnpm --filter @pulse-coder/teams-cli build
         - pnpm --filter canvas-workspace typecheck
 
+  - name: teams-cli
+    paths:
+      - apps/teams-cli/**
+    required:
+      - pnpm --filter @pulse-coder/teams-cli test
+      - pnpm --filter @pulse-coder/teams-cli build
+    manual:
+      - Promote `pnpm --filter @pulse-coder/teams-cli typecheck` after the app tsconfig no longer pulls agent-teams/engine/orchestrator source files outside its rootDir.
+
   - name: cli
     paths:
       - packages/cli/**
@@ -66,6 +75,28 @@ pathRules:
     required:
       - pnpm --filter pulse-coder-acp test
       - pnpm --filter pulse-coder-acp typecheck
+
+  - name: canvas-cli
+    paths:
+      - packages/canvas-cli/**
+    required:
+      - pnpm --filter @pulse-coder/canvas-cli test
+      - pnpm --filter @pulse-coder/canvas-cli typecheck
+
+  - name: canvas-nodes
+    paths:
+      - packages/canvas-nodes/**
+    required:
+      - pnpm --filter @pulse-canvas/nodes test
+      - pnpm --filter @pulse-canvas/nodes typecheck
+
+  - name: langfuse-plugin
+    paths:
+      - packages/langfuse-plugin/**
+    required:
+      - pnpm --filter pulse-coder-langfuse-plugin build
+    manual:
+      - Promote `pnpm --filter pulse-coder-langfuse-plugin typecheck` after the package tsconfig no longer pulls engine/orchestrator source files outside its rootDir.
 
   - name: pulse-sandbox
     paths:

--- a/packages/acp/AGENTS.md
+++ b/packages/acp/AGENTS.md
@@ -5,28 +5,33 @@
 
 ## Module Positioning
 
-`pulse-coder-acp` owns the Agent Context Protocol client, runner, typed protocol models, and state store used by Pulse Coder hosts.
+`pulse-coder-acp` owns the ACP client and runner used by Pulse Coder hosts to delegate work to external ACP-compatible agents such as Claude Code and Codex. It manages JSON-RPC over stdio, child process lifecycle, session lifecycle, permission requests, file request handlers, streaming updates, retry/timeout policy, and persisted per-channel ACP state.
 
-ACP protocol behavior is contract-heavy. Changes should preserve compatibility expectations for hosts that create ACP sessions or resume state.
+ACP protocol behavior is contract-heavy. Hosts such as the CLI and remote server depend on stable types, method names, callback shapes, session persistence, and environment behavior.
 
 ## Knowledge Navigation
 
 | Task | Read |
 |---|---|
-| Package overview | `README.md` |
+| Package overview and scripts | `README.md`, `package.json` |
 | Public exports | `src/index.ts` |
-| Protocol types | `src/types.ts` |
-| Client behavior | `src/client.ts` |
-| Runner behavior | `src/runner.ts` |
-| State management | `src/state.ts`, `src/state-store.ts` |
-| Tests | `src/*.test.ts` |
+| Protocol types and callback contracts | `src/types.ts` |
+| JSON-RPC client and child process behavior | `src/client.ts` |
+| Runner lifecycle, retry, timeout, permission, session list/close | `src/runner.ts` |
+| State model and file persistence | `src/state.ts`, `src/state-store.ts` |
+| CLI host commands | `../cli/src/acp-commands.ts` |
+| Focused behavior tests | `src/client.test.ts`, `src/runner.test.ts`, `src/state.test.ts` |
 
 ## Local Constraints
 
 - Treat protocol types, runner behavior, and state persistence as public contracts.
 - Avoid host-specific policy in the ACP package.
-- State compatibility changes should include tests or a migration note.
-- Route protocol changes through `harness/skills/contract-coding.md`.
+- Default persisted state is `~/.pulse-coder/acp-state.json`; state compatibility changes should include tests or a migration note.
+- Preserve current enable-state semantics: keep `sessionId` only when agent and cwd are unchanged; reset it when either changes.
+- Preserve default external command names (`claude-agent-acp`, `codex-acp`) and env overrides (`ACP_CLAUDE_CODE_CMD`, `ACP_CODEX_CMD`) unless host migration is planned.
+- `runAcp` strips `CLAUDECODE` from child env and can strip proxy vars when retrying or when `ACP_DISABLE_PROXY` is set; change env inheritance carefully.
+- The runner advertises fs read/write capability by default and keeps terminal capability false; update client handlers and tests before changing capabilities.
+- Route protocol changes through `../../harness/skills/contract-coding.md`.
 
 ## Common Commands
 
@@ -36,10 +41,13 @@ pnpm --filter pulse-coder-acp typecheck
 pnpm --filter pulse-coder-acp build
 ```
 
+Tests use local fakes and a short-lived Node child process; they should not require an installed external ACP agent.
+
 ## Key Files
 
-- `src/types.ts`: ACP protocol types.
-- `src/client.ts`: client transport behavior.
-- `src/runner.ts`: session runner behavior.
-- `src/state.ts`, `src/state-store.ts`: state model and persistence.
-- `src/index.ts`: public exports.
+- `src/index.ts`: public exports for client, runner, state helpers, state store, and protocol types.
+- `src/types.ts`: ACP agent, state, callback, capability, session, permission, and protocol result types.
+- `src/client.ts`: child process spawning, JSON-RPC request/response routing, notifications, permission requests, fs handlers, command/env resolution, and call timeouts.
+- `src/runner.ts`: initialize, resume/load/new session flow, prompt streaming, retry/backoff, proxy fallback, progress timeouts, permission clarification, session list, and session close.
+- `src/state.ts`, `src/state-store.ts`: default file-backed state helpers and `FileAcpStateStore`.
+- `src/*.test.ts`: current coverage for client timeouts, runner timeout/session capability helpers, and state enable semantics.

--- a/packages/agent-teams/AGENTS.md
+++ b/packages/agent-teams/AGENTS.md
@@ -5,7 +5,12 @@
 
 ## Module Positioning
 
-`pulse-coder-agent-teams` owns multi-session team coordination on top of the engine and orchestrator. It manages team lifecycle, task dispatch, review gates, checkpoints, scope controls, and runtime state for collaborative agents.
+`pulse-coder-agent-teams` owns multi-session team coordination above the engine and below host experiences such as `apps/teams-cli` and `apps/canvas-workspace`.
+
+The package currently exposes two surfaces:
+
+- Classic in-process coordination: `Team`, `TeamLead`, `Teammate`, `TaskList`, `Mailbox`, the LLM planner, and terminal display helpers.
+- Protocol runtime coordination: `src/runtime/` records teams, agents, tasks, artifacts, human gates, mailbox messages, session events, review gates, round checkpoints, scope controls, verify metadata, and handoff paths for host-driven teams.
 
 It should keep team protocol behavior explicit and avoid hiding quality gates in prompts alone.
 
@@ -13,18 +18,28 @@ It should keep team protocol behavior explicit and avoid hiding quality gates in
 
 | Task | Read |
 |---|---|
+| Package overview and classic API | `README.md` |
 | Understand contracts | `docs/contracts.md` |
 | Pick validation | `docs/validation.md` |
 | Maturity roadmap | `../../docs/07-agent-teams-maturity-roadmap.md` |
-| Runtime implementation | `src/runtime/team-runtime.ts` |
+| Runtime exports | `src/runtime.ts`, `src/runtime/index.ts` |
+| Runtime implementation | `src/runtime/team-runtime.ts`, `src/runtime/types.ts` |
+| Runtime store and DAG checks | `src/runtime/memory-store.ts`, `src/runtime/task-graph.ts` |
+| Classic team API | `src/team.ts`, `src/team-lead.ts`, `src/teammate.ts` |
+| Classic task and mailbox state | `src/task-list.ts`, `src/mailbox.ts` |
+| Planner and display | `src/planner.ts`, `src/display/in-process.ts` |
+| Tests | `src/__tests__/`, `src/runtime/__tests__/team-runtime.test.ts` |
 | Package scripts | `package.json` |
 
 ## Local Constraints
 
 - Team completion should mean deliverable evidence, not only an agent claim.
-- Verify commands, handoff material, review state, and dependency blocking are protocol-level concerns.
-- Scope and task ownership changes should stay explicit.
+- Verify commands, handoff material, review state, dependency blocking, round checkpoints, and human gates are protocol-level concerns.
+- The Team Lead coordinates and verifies; teammate task execution, ownership changes, scope edits, and revision loops must stay explicit in runtime state.
+- `TASK_METADATA_KEYS` is shared with hosts. Changes to `round`, `scope`, `verify`, `lastVerify`, or failed-dependency metadata affect consumers.
+- Classic `Team/TeamLead` state is file-backed under the configured team state directory. Runtime state is store-backed and host adapters own actual process/session behavior.
 - Public runtime exports are contracts; route changes through `harness/skills/contract-coding.md`.
+- Host-specific UI, PTY, or Canvas behavior belongs in host apps, not this package, unless it is a generic team protocol primitive.
 
 ## Common Commands
 
@@ -34,8 +49,17 @@ pnpm --filter pulse-coder-agent-teams typecheck
 pnpm --filter pulse-coder-agent-teams build
 ```
 
+Docs-only changes can use the harness docs rule: check referenced paths and commands instead of running package build/test.
+
 ## Key Files
 
-- `src/runtime/team-runtime.ts`: team lifecycle, dispatch, review, checkpoints, scope handling.
-- `src/index.ts`: package exports.
+- `src/index.ts`: classic public exports.
+- `src/runtime.ts` and `src/runtime/index.ts`: runtime public exports.
+- `src/runtime/team-runtime.ts`: protocol runtime lifecycle, dispatch, review, checkpoints, scopes, verification evidence, handoffs, gates, artifacts, and lead notifications.
+- `src/runtime/types.ts`: runtime records, statuses, adapter/store contracts, events, metadata, and verification result shapes.
+- `src/runtime/memory-store.ts`: in-memory runtime store used by tests and lightweight hosts.
+- `src/runtime/task-graph.ts`: dependency-cycle checks and topological round helpers.
+- `src/team.ts`, `src/team-lead.ts`, `src/teammate.ts`: classic in-process team orchestration.
+- `src/task-list.ts`, `src/mailbox.ts`: classic file-backed task queue and mailbox.
+- `src/__tests__/` and `src/runtime/__tests__/team-runtime.test.ts`: behavioral coverage for classic and runtime flows.
 - `package.json`: package scripts and runtime dependencies.

--- a/packages/canvas-cli/AGENTS.md
+++ b/packages/canvas-cli/AGENTS.md
@@ -5,32 +5,67 @@
 
 ## Module Positioning
 
-`@pulse-coder/canvas-cli` owns the agent-facing `pulse-canvas` CLI and programmatic core helpers for Pulse Canvas workspaces. It lets external agents inspect and mutate the local canvas store, install bundled canvas skills, and talk to a running `canvas-workspace` runtime for live agent/team commands.
+`@pulse-coder/canvas-cli` owns the `pulse-canvas` command-line surface and the
+`@pulse-coder/canvas-cli/core` helpers for external agents that need to inspect
+or mutate Pulse Canvas workspaces.
 
-This package should stay a thin bridge over canvas storage and runtime endpoints. Electron UI behavior belongs in `apps/canvas-workspace`; runtime-loadable plugin node behavior belongs in `packages/canvas-nodes`.
+Most commands operate directly on the canvas store under
+`~/.pulse-coder/canvas/`: workspace manifests, per-workspace `canvas.json`,
+edges, nodes, backups, and v2 per-node files. The `agent` and `team` command
+families are different: they require a running `apps/canvas-workspace` instance
+and call its loopback runtime-control server using the bearer secret advertised
+in `~/.pulse-coder/canvas-runtime/canvas-workspace.json`.
+
+Keep this package a thin bridge over store files and runtime endpoints. The
+Electron UI, active PTY lifecycle, storage migration, and runtime server belong
+in `apps/canvas-workspace`; runtime-loadable plugin node behavior belongs in
+`packages/canvas-nodes`.
 
 ## Knowledge Navigation
 
 | Task | Read |
 |---|---|
-| Package overview and command UX | `README.md` |
-| CLI entrypoint | `src/index.ts`, `src/cli.ts` |
-| Command implementations | `src/commands/` |
+| Repository routing and validation matrix | `../../harness/profile.yaml`, `../../harness/validation.yaml` |
+| Package overview and install flow | `README.md` |
+| Current CLI command index | `src/cli.ts` |
+| Executable entrypoint | `src/index.ts` |
+| Workspace/node/edge/context commands | `src/commands/workspace.ts`, `src/commands/node.ts`, `src/commands/edge.ts`, `src/commands/context.ts` |
+| Live runtime commands | `src/commands/agent.ts`, `src/commands/team.ts`, `src/core/runtime-control.ts` |
+| v2 recovery command | `src/commands/restore.ts` |
 | Public core exports | `src/core/index.ts` |
-| Canvas store and v2 compatibility | `src/core/store.ts`, `src/core/storage-v2.ts` |
-| Node, edge, and context behavior | `src/core/nodes.ts`, `src/core/edges.ts`, `src/core/context.ts` |
-| Live runtime calls | `src/core/runtime-control.ts`, `src/commands/agent.ts`, `src/commands/team.ts` |
-| Bundled agent skills | `skills/` |
+| Store safety and schema compatibility | `src/core/store.ts`, `src/core/storage-v2.ts`, `src/core/types.ts`, `src/core/constants.ts` |
+| Node and edge behavior | `src/core/nodes.ts`, `src/core/edges.ts` |
+| Bundled agent skills | `skills/`, `src/commands/install-skills.ts` |
+| Tests | `src/core/__tests__/`, `src/commands/__tests__/` |
 | Documentation routing | `../../harness/skills/doc-governance.md` |
 | Validation planning | `../../harness/skills/quality-workflow.md` |
+| Contract changes | `../../harness/skills/contract-coding.md` |
+
+There is no package-local documentation or harness directory here. Use the
+root harness files above, then the package source/tests.
 
 ## Local Constraints
 
-- Treat `~/.pulse-coder/canvas/` as user runtime data, not repository source of truth.
-- Preserve direct-store safety: workspace/node id validation, atomic writes, backups, manifest locking, and v2 per-node storage compatibility.
-- Do not make the CLI trigger canvas storage migrations; migration is owned by `apps/canvas-workspace`.
-- Live `agent` and `team` commands require the Electron runtime file and bearer secret; do not bypass runtime authentication.
-- Changes to command payloads, core exports, or canvas storage shape are contract changes; route them through `../../harness/skills/contract-coding.md`.
+- Treat `~/.pulse-coder/canvas/` and `~/.pulse-coder/canvas-runtime/` as user
+  runtime data, never repository source of truth.
+- Preserve store safety: workspace/node id validation, manifest locking,
+  atomic writes, rolling `.bak` recovery, v2 per-node compatibility, and the
+  guard that refuses accidental empty-node overwrites.
+- Do not make this CLI trigger v2 migrations. `canvas-workspace` owns
+  migration; the CLI adapts to the on-disk schema it finds.
+- Keep `restore` narrow: it recovers from v1 snapshots and archives live
+  `nodes/` data so the app can migrate cleanly later; it is not a general
+  migration tool.
+- `node create` supports `file`, `terminal`, `frame`, `group`, `agent`, and
+  `mindmap`. Terminal/agent nodes created by the CLI have no active PTY session.
+- `reference` is a read-compatible node shape in core types, but not a CLI
+  creation type. Plugin nodes are handled through the Canvas host/plugin tools,
+  not by this package's generic `node create`.
+- Live `agent` and `team` commands must keep using the runtime file plus bearer
+  auth. Do not bypass runtime authentication or reach into Electron memory from
+  this package.
+- Changes to command payloads, core exports, node/edge schemas, runtime routes,
+  or storage shape are contract changes; use `../../harness/skills/contract-coding.md`.
 
 ## Common Commands
 
@@ -40,12 +75,23 @@ pnpm --filter @pulse-coder/canvas-cli typecheck
 pnpm --filter @pulse-coder/canvas-cli build
 ```
 
+For runtime command smoke checks, first run/build the Electron app so the
+runtime file exists; otherwise `pulse-canvas agent ...` and
+`pulse-canvas team ...` are expected to fail with "No active
+canvas-workspace runtime found."
+
 ## Key Files
 
 - `src/index.ts`: executable entrypoint for `pulse-canvas`.
 - `src/cli.ts`: top-level command registration and global options.
-- `src/commands/`: workspace, node, edge, context, agent, team, restore, and skill-install commands.
-- `src/core/store.ts`: workspace manifest, canvas load/save, locking, backups, and mutation helpers.
-- `src/core/storage-v2.ts`: compatibility layer for layout-only canvas files plus per-node data files.
-- `src/core/runtime-control.ts`: live runtime discovery and authenticated POST helper.
+- `src/commands/`: workspace, node, edge, context, agent, team, restore, and
+  skill-install commands.
+- `src/core/store.ts`: workspace manifests, canvas load/save, locks, backups,
+  wipe guard, and node/edge mutation commits.
+- `src/core/storage-v2.ts`: compatibility layer for layout-only `canvas.json`
+  plus `nodes/<nodeId>.json`.
+- `src/core/nodes.ts`: node read/write/create/delete behavior and node
+  capability mapping.
+- `src/core/edges.ts`: edge create/list/delete behavior.
+- `src/core/runtime-control.ts`: runtime discovery and authenticated POST helper.
 - `skills/`: bundled Pulse Canvas skills copied by `install-skills`.

--- a/packages/canvas-cli/AGENTS.md
+++ b/packages/canvas-cli/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md - packages/canvas-cli
+
+> Local entry for `packages/canvas-cli`.
+> Repository harness entry: `../../harness/README.md`.
+
+## Module Positioning
+
+`@pulse-coder/canvas-cli` owns the agent-facing `pulse-canvas` CLI and programmatic core helpers for Pulse Canvas workspaces. It lets external agents inspect and mutate the local canvas store, install bundled canvas skills, and talk to a running `canvas-workspace` runtime for live agent/team commands.
+
+This package should stay a thin bridge over canvas storage and runtime endpoints. Electron UI behavior belongs in `apps/canvas-workspace`; runtime-loadable plugin node behavior belongs in `packages/canvas-nodes`.
+
+## Knowledge Navigation
+
+| Task | Read |
+|---|---|
+| Package overview and command UX | `README.md` |
+| CLI entrypoint | `src/index.ts`, `src/cli.ts` |
+| Command implementations | `src/commands/` |
+| Public core exports | `src/core/index.ts` |
+| Canvas store and v2 compatibility | `src/core/store.ts`, `src/core/storage-v2.ts` |
+| Node, edge, and context behavior | `src/core/nodes.ts`, `src/core/edges.ts`, `src/core/context.ts` |
+| Live runtime calls | `src/core/runtime-control.ts`, `src/commands/agent.ts`, `src/commands/team.ts` |
+| Bundled agent skills | `skills/` |
+| Documentation routing | `../../harness/skills/doc-governance.md` |
+| Validation planning | `../../harness/skills/quality-workflow.md` |
+
+## Local Constraints
+
+- Treat `~/.pulse-coder/canvas/` as user runtime data, not repository source of truth.
+- Preserve direct-store safety: workspace/node id validation, atomic writes, backups, manifest locking, and v2 per-node storage compatibility.
+- Do not make the CLI trigger canvas storage migrations; migration is owned by `apps/canvas-workspace`.
+- Live `agent` and `team` commands require the Electron runtime file and bearer secret; do not bypass runtime authentication.
+- Changes to command payloads, core exports, or canvas storage shape are contract changes; route them through `../../harness/skills/contract-coding.md`.
+
+## Common Commands
+
+```bash
+pnpm --filter @pulse-coder/canvas-cli test
+pnpm --filter @pulse-coder/canvas-cli typecheck
+pnpm --filter @pulse-coder/canvas-cli build
+```
+
+## Key Files
+
+- `src/index.ts`: executable entrypoint for `pulse-canvas`.
+- `src/cli.ts`: top-level command registration and global options.
+- `src/commands/`: workspace, node, edge, context, agent, team, restore, and skill-install commands.
+- `src/core/store.ts`: workspace manifest, canvas load/save, locking, backups, and mutation helpers.
+- `src/core/storage-v2.ts`: compatibility layer for layout-only canvas files plus per-node data files.
+- `src/core/runtime-control.ts`: live runtime discovery and authenticated POST helper.
+- `skills/`: bundled Pulse Canvas skills copied by `install-skills`.

--- a/packages/canvas-nodes/AGENTS.md
+++ b/packages/canvas-nodes/AGENTS.md
@@ -5,34 +5,67 @@
 
 ## Module Positioning
 
-`@pulse-canvas/nodes` owns runtime-loadable external node plugins for Pulse Canvas. The current package provides the `pulse-canvas-nodes` plugin and the `excalidraw.board` node type, including main-process capabilities, a Module Federation renderer shell, an isolated Excalidraw webview app, and agent skill guidance.
+`@pulse-canvas/nodes` owns runtime-loadable external node plugins for Pulse
+Canvas. The current package contributes the `pulse-canvas-nodes` plugin and the
+`excalidraw.board` node type, including:
 
-This package is intentionally loaded as a plugin directory. `apps/canvas-workspace` should discover it through `manifest.json` and runtime plugin loading rather than importing package internals directly.
+- an Electron-main capability provider for semantic read/write/action behavior,
+- a Module Federation renderer shell,
+- an isolated Excalidraw `<webview>` app,
+- compact scene helpers for agent-authored boards,
+- agent skill guidance for creating and modifying board nodes.
+
+This package is intentionally loaded as a plugin directory. The Canvas host
+should discover it through `manifest.json` and plugin loading, not by importing
+package internals directly.
 
 ## Knowledge Navigation
 
 | Task | Read |
 |---|---|
+| Repository routing and validation matrix | `../../harness/profile.yaml`, `../../harness/validation.yaml` |
 | Package overview and install flow | `README.md` |
-| Plugin manifest | `manifest.json` |
-| Main-process plugin capabilities | `src/main.ts` |
+| Plugin manifest and public contract | `manifest.json` |
+| Build outputs and MF settings | `vite.config.ts`, `vite.webview.config.ts`, `vite.main.config.ts` |
+| Plugin ids and node type constants | `src/constants.ts` |
+| Host/plugin TypeScript contracts | `src/types.ts` |
+| Main-process capabilities and tools | `src/main.ts` |
 | Renderer plugin registration | `src/plugin.tsx` |
-| Excalidraw node shell | `src/ExcalidrawNodeView.tsx`, `src/ExcalidrawNodeView.css` |
-| Isolated webview app | `src/webview-app.tsx`, `src/webview-app.css` |
-| Scene normalization/actions | `src/scene.ts`, `src/types.ts` |
-| Tests | `src/__tests__/` |
+| Excalidraw renderer shell | `src/ExcalidrawNodeView.tsx`, `src/ExcalidrawNodeView.css` |
+| Isolated Excalidraw webview app | `src/webview-app.tsx`, `src/webview-app.css`, `index.html` |
+| Scene normalization/actions | `src/scene.ts` |
+| Tests | `src/__tests__/main.test.ts`, `src/__tests__/scene.test.ts` |
 | Agent-facing node guidance | `skills/excalidraw-node/SKILL.md` |
-| Canvas host guidance | `../../apps/canvas-workspace/AGENTS.md` |
+| Canvas host plugin contract | `../../apps/canvas-workspace/docs/plugin-node-mf2.md`, `../../apps/canvas-workspace/AGENTS.md` |
 | Documentation routing | `../../harness/skills/doc-governance.md` |
 | Validation planning | `../../harness/skills/quality-workflow.md` |
+| Contract changes | `../../harness/skills/contract-coding.md` |
+
+There is no package-local documentation or harness directory here. Use the
+root harness files and the Canvas host docs when behavior crosses into the app.
 
 ## Local Constraints
 
-- Keep host and plugin boundaries clean: expose behavior through `manifest.json`, plugin activation, node capabilities, and registered tools.
-- Preserve the node identity `pluginId: pulse-canvas-nodes` and `nodeType: excalidraw.board` unless coordinating a contract change.
-- Keep Excalidraw scene data under `node.data.payload`; use scene helpers for normalization, skeleton conversion, summaries, and patches.
-- Renderer shell code should communicate with the isolated board through the webview bridge and host preload APIs, not by reaching into canvas app internals.
-- Contract changes to manifest shape, node actions, tool schemas, or payload shape should route through `../../harness/skills/contract-coding.md`.
+- Preserve the plugin identity `pulse-canvas-nodes` and node type
+  `excalidraw.board` unless coordinating a host/plugin contract change.
+- Keep the manifest as the public package contract: main entry
+  `dist/main.js`, renderer entry `dist/mf-manifest.json`, webview entry
+  `dist/index.html`, actions, capabilities, and skill metadata must stay in
+  sync with source.
+- Host canvas nodes stay `type: "plugin"` with `data.pluginId`,
+  `data.nodeType`, and plugin-owned `data.payload`. The host should treat
+  Excalidraw scene data as opaque except through registered capabilities.
+- Keep Excalidraw scene data under `node.data.payload`; use `src/scene.ts` for
+  normalization, skeleton conversion, summaries, replacement, and append
+  behavior.
+- Renderer shell code should communicate with the isolated board through the
+  webview bridge and host preload APIs. Do not reach into
+  `apps/canvas-workspace` internals.
+- The renderer build relies on host-provided singleton React/React DOM via
+  Module Federation. Be cautious changing shared dependency settings.
+- Contract changes to manifest shape, node actions, tool schemas, renderer
+  plugin props, or payload shape should route through
+  `../../harness/skills/contract-coding.md` and usually require host-side checks.
 
 ## Common Commands
 
@@ -42,12 +75,25 @@ pnpm --filter @pulse-canvas/nodes typecheck
 pnpm --filter @pulse-canvas/nodes build
 ```
 
+Surface-specific builds are available when narrowing a packaging issue:
+
+```bash
+pnpm --filter @pulse-canvas/nodes build:renderer
+pnpm --filter @pulse-canvas/nodes build:webview
+pnpm --filter @pulse-canvas/nodes build:main
+```
+
 ## Key Files
 
-- `manifest.json`: plugin id, main entry, node registration, renderer entry, actions, and skill metadata.
-- `src/main.ts`: main-process node read/write/action capabilities and `excalidraw_board_template` tool registration.
+- `manifest.json`: plugin id, main entry, node registration, renderer entry,
+  actions, capabilities, and skill metadata.
+- `src/main.ts`: main-process node capabilities and
+  `excalidraw_board_template` tool registration.
 - `src/plugin.tsx`: renderer-side node view registration.
-- `src/ExcalidrawNodeView.tsx`: host renderer shell that mounts and syncs the webview.
+- `src/ExcalidrawNodeView.tsx`: host renderer shell that mounts, sizes,
+  registers, and syncs the webview.
 - `src/webview-app.tsx`: isolated Excalidraw app and bridge surface.
-- `src/scene.ts`: scene normalization, skeleton conversion, patching, and summaries.
-- `skills/excalidraw-node/SKILL.md`: agent guidance for creating and modifying board nodes.
+- `src/scene.ts`: scene normalization, skeleton conversion, patching, and
+  summaries.
+- `src/types.ts`: host/plugin contracts mirrored by the Canvas workspace.
+- `skills/excalidraw-node/SKILL.md`: agent guidance for board node workflows.

--- a/packages/canvas-nodes/AGENTS.md
+++ b/packages/canvas-nodes/AGENTS.md
@@ -1,0 +1,53 @@
+# AGENTS.md - packages/canvas-nodes
+
+> Local entry for `packages/canvas-nodes`.
+> Repository harness entry: `../../harness/README.md`.
+
+## Module Positioning
+
+`@pulse-canvas/nodes` owns runtime-loadable external node plugins for Pulse Canvas. The current package provides the `pulse-canvas-nodes` plugin and the `excalidraw.board` node type, including main-process capabilities, a Module Federation renderer shell, an isolated Excalidraw webview app, and agent skill guidance.
+
+This package is intentionally loaded as a plugin directory. `apps/canvas-workspace` should discover it through `manifest.json` and runtime plugin loading rather than importing package internals directly.
+
+## Knowledge Navigation
+
+| Task | Read |
+|---|---|
+| Package overview and install flow | `README.md` |
+| Plugin manifest | `manifest.json` |
+| Main-process plugin capabilities | `src/main.ts` |
+| Renderer plugin registration | `src/plugin.tsx` |
+| Excalidraw node shell | `src/ExcalidrawNodeView.tsx`, `src/ExcalidrawNodeView.css` |
+| Isolated webview app | `src/webview-app.tsx`, `src/webview-app.css` |
+| Scene normalization/actions | `src/scene.ts`, `src/types.ts` |
+| Tests | `src/__tests__/` |
+| Agent-facing node guidance | `skills/excalidraw-node/SKILL.md` |
+| Canvas host guidance | `../../apps/canvas-workspace/AGENTS.md` |
+| Documentation routing | `../../harness/skills/doc-governance.md` |
+| Validation planning | `../../harness/skills/quality-workflow.md` |
+
+## Local Constraints
+
+- Keep host and plugin boundaries clean: expose behavior through `manifest.json`, plugin activation, node capabilities, and registered tools.
+- Preserve the node identity `pluginId: pulse-canvas-nodes` and `nodeType: excalidraw.board` unless coordinating a contract change.
+- Keep Excalidraw scene data under `node.data.payload`; use scene helpers for normalization, skeleton conversion, summaries, and patches.
+- Renderer shell code should communicate with the isolated board through the webview bridge and host preload APIs, not by reaching into canvas app internals.
+- Contract changes to manifest shape, node actions, tool schemas, or payload shape should route through `../../harness/skills/contract-coding.md`.
+
+## Common Commands
+
+```bash
+pnpm --filter @pulse-canvas/nodes test
+pnpm --filter @pulse-canvas/nodes typecheck
+pnpm --filter @pulse-canvas/nodes build
+```
+
+## Key Files
+
+- `manifest.json`: plugin id, main entry, node registration, renderer entry, actions, and skill metadata.
+- `src/main.ts`: main-process node read/write/action capabilities and `excalidraw_board_template` tool registration.
+- `src/plugin.tsx`: renderer-side node view registration.
+- `src/ExcalidrawNodeView.tsx`: host renderer shell that mounts and syncs the webview.
+- `src/webview-app.tsx`: isolated Excalidraw app and bridge surface.
+- `src/scene.ts`: scene normalization, skeleton conversion, patching, and summaries.
+- `skills/excalidraw-node/SKILL.md`: agent guidance for creating and modifying board nodes.

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -5,29 +5,37 @@
 
 ## Module Positioning
 
-`pulse-coder-cli` owns the interactive terminal application on top of `pulse-coder-engine`. It handles sessions, slash commands, Ink UI, input management, ACP commands, team commands, memory integration, and the CLI-only `run_js` sandbox adapter.
+`pulse-coder-cli` owns the interactive terminal host on top of `pulse-coder-engine`. It handles the default Ink UI, the readline fallback UI, session persistence, slash commands, clarification input, ACP mode, teams commands, memory integration, task-list binding, and registration of the `run_js` tool from `pulse-sandbox`.
 
-CLI behavior should remain a host layer over the engine. Engine runtime behavior belongs in `packages/engine`; team coordination behavior belongs in `packages/agent-teams`.
+CLI behavior should remain a host layer over the engine. Engine runtime behavior belongs in `packages/engine`; ACP protocol behavior belongs in `packages/acp`; team coordination behavior belongs in `packages/agent-teams`; sandbox execution behavior belongs in `packages/pulse-sandbox`.
 
 ## Knowledge Navigation
 
 | Task | Read |
 |---|---|
-| CLI entrypoint | `src/index.ts` |
-| Ink UI app | `src/ink-app.tsx`, `src/ink-launcher.tsx` |
+| Package overview and scripts | `README.md`, `package.json` |
+| UI mode selection | `src/ui-mode.ts` |
+| Default Ink host path | `src/ink-launcher.tsx`, `src/ink-controller.ts`, `src/ink-app.tsx`, `src/ink-ui-bridge.ts` |
+| Readline fallback host path | `src/index.ts`, `src/tui-renderer.ts` |
 | Input handling | `src/input-manager.ts` |
 | Sessions | `src/session.ts`, `src/session-commands.ts` |
-| Skills slash commands | `src/skill-commands.ts` |
-| Team commands | `src/team-commands.ts` |
-| ACP commands | `src/acp-commands.ts` |
+| Skills and worktree slash commands | `src/skill-commands.ts`, `src/index.ts`, `src/ink-controller.ts` |
+| Team commands and teams mode | `src/team-commands.ts`, `../agent-teams/AGENTS.md` |
+| ACP commands and routing | `src/acp-commands.ts`, `../acp/AGENTS.md` |
 | Memory integration | `src/memory-integration.ts` |
+| `run_js` tool registration | `src/index.ts`, `src/ink-controller.ts`, `../pulse-sandbox/AGENTS.md` |
+| Focused behavior tests | `src/*.test.ts` |
 
 ## Local Constraints
 
 - Keep CLI-specific state and UI behavior in this package; do not push UI concerns into the engine.
-- Slash command changes should preserve session persistence and abort/clarification behavior.
-- Prefer targeted tests for command parsing, session workflows, input handling, and UI mode behavior.
-- Contract changes with engine, ACP, teams, or memory packages should follow `harness/skills/contract-coding.md`.
+- Keep command behavior aligned between the Ink controller and the readline fallback unless a change is intentionally UI-specific.
+- Default startup selects Ink via `src/ui-mode.ts`; `PULSE_CODER_UI=readline` is the fallback path.
+- Session files live under `~/.pulse-coder/sessions`; keep local runtime data out of source control and preserve session task-list metadata.
+- Slash command changes should preserve session persistence, queued input, abort handling, clarification flow, and ACP passthrough behavior.
+- This package currently has no `typecheck` script; do not document or rely on `pnpm --filter pulse-coder-cli typecheck` until `package.json` adds it.
+- Current `run_js` registration imports `pulse-sandbox/src`; `src/sandbox-runner.ts` is not imported by the active CLI paths.
+- Contract changes with engine, ACP, teams, sandbox, or memory packages should follow `../../harness/skills/contract-coding.md`.
 
 ## Common Commands
 
@@ -38,11 +46,16 @@ pnpm start
 pnpm start:debug
 ```
 
+Run commands from the repository root. `pnpm start` maps to the built CLI package, so run `pnpm --filter pulse-coder-cli build` first when `dist/` may be stale. `pnpm start:debug` rebuilds the CLI before launching the debugger.
+
 ## Key Files
 
-- `src/index.ts`: CLI entrypoint.
-- `src/ink-app.tsx`: main Ink UI application.
-- `src/input-manager.ts`: terminal input handling.
-- `src/session-commands.ts`: session command behavior.
-- `src/skill-commands.ts`: `/skills` command handling.
-- `src/team-commands.ts`: agent teams command surface.
+- `src/index.ts`: readline fallback CLI entrypoint, command loop, agent run wiring, ACP routing, and session save path.
+- `src/ink-controller.ts`: default Ink-mode controller with command handling, agent/ACP routing, session sync, queued input, and shutdown.
+- `src/ink-app.tsx`: Ink rendering, input composer, command suggestions, history, and mode shortcuts.
+- `src/ink-ui-bridge.ts`: event/snapshot bridge between runtime callbacks and the Ink UI.
+- `src/ui-mode.ts`: `--ui`/`--tui` and `PULSE_CODER_UI` resolution.
+- `src/session.ts`, `src/session-commands.ts`: session storage and slash-command behavior.
+- `src/acp-commands.ts`: `/acp` state commands, platform key resolution, session listing, and session close.
+- `src/team-commands.ts`: `/team`, `/teams`, and `/solo` command surface.
+- `src/memory-integration.ts`: memory plugin setup and per-run memory context.

--- a/packages/engine/AGENTS.md
+++ b/packages/engine/AGENTS.md
@@ -5,28 +5,34 @@
 
 ## Module Positioning
 
-`pulse-coder-engine` owns the reusable agent runtime: engine initialization, tool execution loop, hooks, built-in plugins, tool registration, and context management.
+`pulse-coder-engine` owns the reusable Pulse Coder runtime: the `Engine`/`PulseAgent` public API, provider selection, prompt assembly, context compaction, the streaming/tool execution loop, plugin lifecycle, hooks, services, built-in tools, and built-in plugins.
 
-It should stay host-agnostic. CLI, remote server, and canvas-specific behavior should integrate through options, plugins, hooks, or services rather than being hardcoded into the engine loop.
+It should stay host-agnostic. CLI, remote server, canvas, ACP, and teams-specific behavior should integrate through options, plugins, hooks, tools, or services rather than being hardcoded into the core loop.
 
 ## Knowledge Navigation
 
 | Task | Read |
 |---|---|
-| Understand public contracts | `docs/contracts.md` |
-| Pick validation | `docs/validation.md` |
-| Engine bootstrap | `src/Engine.ts` |
-| Execution loop | `src/core/loop.ts` |
-| Built-in plugin list | `src/built-in/index.ts` |
-| Built-in tools | `src/tools/` |
-| Plugin APIs | `src/plugin/` |
+| Package overview and scripts | `README.md`, `package.json` |
+| Public contracts and validation | `docs/contracts.md`, `docs/validation.md` |
+| Public exports | `src/index.ts` |
+| Engine bootstrap and options | `src/Engine.ts` |
+| Execution loop, streaming, retry, abort, compaction | `src/core/loop.ts`, `src/context/` |
+| Provider, model, and prompt behavior | `src/config/index.ts`, `src/ai/index.ts`, `src/prompt/` |
+| Plugin lifecycle, hooks, services, config plugins | `src/plugin/EnginePlugin.ts`, `src/plugin/PluginManager.ts`, `src/plugin/UserConfigPlugin.ts` |
+| Built-in plugin order and exports | `src/built-in/index.ts`, `src/built-in/*/` |
+| Built-in tool registry and schemas | `src/tools/index.ts`, `src/tools/` |
+| Focused behavior tests | `src/core/loop.test.ts`, `src/plugin/plugin-manager.test.ts`, `src/built-in/**/*.test.ts`, `src/tools/*.test.ts` |
 
 ## Local Constraints
 
 - Prefer plugin, hook, tool, or service extension points over engine-loop hardcoding.
+- Preserve tool merge order: built-in tools, then plugin tools, then `EngineOptions.tools` as the highest-priority override layer.
+- Built-in plugins are loaded automatically unless `disableBuiltInPlugins` is set; adding, removing, or reordering them can affect CLI, remote server, canvas, and agent teams consumers.
 - Keep source imports ESM-style and follow package-local TypeScript strictness.
-- Public exports and tool schemas are contracts; route changes through `harness/skills/contract-coding.md`.
-- Runtime feedback that changes engine guidance should route through `harness/skills/feedback-governance.md`.
+- Public exports, `EngineOptions`, hook signatures, service names, built-in tool schemas, and built-in plugin behavior are contracts; route changes through `../../harness/skills/contract-coding.md`.
+- Preserve `.pulse-coder/*` paths and legacy `.coder/*` compatibility unless there is an explicit migration plan.
+- Runtime feedback that changes engine guidance should route through `../../harness/skills/feedback-governance.md`.
 
 ## Common Commands
 
@@ -34,12 +40,18 @@ It should stay host-agnostic. CLI, remote server, and canvas-specific behavior s
 pnpm --filter pulse-coder-engine test
 pnpm --filter pulse-coder-engine typecheck
 pnpm --filter pulse-coder-engine build
+pnpm --filter pulse-coder-cli test
+pnpm --filter @pulse-coder/remote-server build
 ```
+
+Default checks are `test` and `typecheck`. Use `build` for public exports or package configuration changes. The CLI and remote-server commands are escalation checks for public API, built-in plugin, or tool contract changes. Docs-only changes only need referenced path/command checks per `docs/validation.md`.
 
 ## Key Files
 
-- `src/Engine.ts`: engine bootstrap and plugin/tool merge order.
-- `src/core/loop.ts`: execution loop, streaming, retries, hooks, abort, compaction.
-- `src/built-in/index.ts`: built-in plugin registration.
-- `src/tools/`: built-in tool definitions.
-- `src/plugin/`: plugin manager and context APIs.
+- `src/index.ts`: public exports, including the `PulseAgent` alias and built-in plugin/type exports.
+- `src/Engine.ts`: engine bootstrap, provider/model option resolution, plugin/tool merge order, compaction helper, and plan-mode service helpers.
+- `src/core/loop.ts`: streaming loop, LLM/tool hooks, retries/backoff, abort handling, timeout handling, tool results, and context compaction.
+- `src/plugin/`: plugin manager, hook map, service/config APIs, dependency ordering, and user config plugin loading.
+- `src/built-in/index.ts`: built-in plugin registration order and public built-in plugin exports.
+- `src/tools/index.ts`: built-in tool registry for file, shell, Tavily, image generation, clarification, and deferred demo tools.
+- `docs/contracts.md`, `docs/validation.md`: package contract and validation source of truth.

--- a/packages/langfuse-plugin/AGENTS.md
+++ b/packages/langfuse-plugin/AGENTS.md
@@ -15,10 +15,12 @@ This package should remain an optional observability plugin. Core engine hook co
 |---|---|
 | Package scripts and exports | `package.json` |
 | Plugin factory and options | `src/index.ts` |
+| Build/typecheck shape | `tsup.config.ts`, `tsconfig.json` |
 | Engine plugin contracts | `../engine/AGENTS.md`, `../engine/src/plugin/` |
 | Engine runtime hooks | `../engine/src/core/loop.ts` |
-| Documentation routing | `../../harness/skills/doc-governance.md` |
-| Validation planning | `../../harness/skills/quality-workflow.md` |
+| Validation matrix | `../../harness/validation.yaml` |
+
+This package currently has no local `README.md`, `docs/`, or test files; use `src/index.ts` as the package-local source of truth until those exist.
 
 ## Local Constraints
 
@@ -26,7 +28,10 @@ This package should remain an optional observability plugin. Core engine hook co
 - Do not commit or hardcode Langfuse credentials; use `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_HOST`/`LANGFUSE_BASEURL`, and related environment-driven options.
 - Be deliberate about trace payload privacy. `saveUserText` and `saveLLMOutput` default to enabled, so host deployments may need to override them.
 - Do not block the engine loop on trace flushing during normal runs; preserve fire-and-forget behavior unless changing the contract intentionally.
-- Changes to hook usage, exported options, metadata shape, or service registration should route through `../../harness/skills/contract-coding.md`.
+- `disabled` defaults to true when keys are missing. Keep that dev-safe behavior.
+- Run IDs are shared through `runContext.runId` and `WeakMap<Context, RunState>`; keep cleanup in `afterRun`/`destroy` defensive so spans do not leak across runs.
+- Usage normalization currently handles AI SDK Anthropic cache token shapes and OpenAI-compatible token numbers; preserve cache read/write details.
+- Changes to hook usage, exported options, metadata shape, trace fields, or service registration should route through `../../harness/skills/contract-coding.md`.
 
 ## Common Commands
 
@@ -34,10 +39,11 @@ This package should remain an optional observability plugin. Core engine hook co
 pnpm --filter pulse-coder-langfuse-plugin build
 ```
 
-`test` currently has no test files and exits non-zero. `typecheck` currently hits TS6059 because the package imports workspace source from `packages/engine` and `packages/orchestrator` outside this package's `rootDir`; prefer `build` until that TypeScript boundary is fixed.
+`test` currently has no test files and exits non-zero. `typecheck` currently hits TS6059 because the package imports workspace source from `packages/engine` outside this package's `rootDir`; prefer `build` until that TypeScript boundary is fixed. Harness validation also lists `build` as the required check.
 
 ## Key Files
 
 - `src/index.ts`: `createLangfusePlugin`, option resolution, hook registration, usage normalization, trace/span lifecycle, and default export.
 - `package.json`: package exports, build scripts, and Langfuse/engine dependencies.
 - `tsup.config.ts`: build output configuration.
+- `tsconfig.json`: current package TypeScript boundary.

--- a/packages/langfuse-plugin/AGENTS.md
+++ b/packages/langfuse-plugin/AGENTS.md
@@ -1,0 +1,43 @@
+# AGENTS.md - packages/langfuse-plugin
+
+> Local entry for `packages/langfuse-plugin`.
+> Repository harness entry: `../../harness/README.md`.
+
+## Module Positioning
+
+`pulse-coder-langfuse-plugin` owns Langfuse observability integration for Pulse Coder engine runtimes. It creates an engine plugin that registers lifecycle hooks for traces, LLM generations, tool spans, compaction events, run metadata, and shutdown flushing.
+
+This package should remain an optional observability plugin. Core engine hook contracts belong in `packages/engine`; host-specific telemetry policy belongs in the host that configures this plugin.
+
+## Knowledge Navigation
+
+| Task | Read |
+|---|---|
+| Package scripts and exports | `package.json` |
+| Plugin factory and options | `src/index.ts` |
+| Engine plugin contracts | `../engine/AGENTS.md`, `../engine/src/plugin/` |
+| Engine runtime hooks | `../engine/src/core/loop.ts` |
+| Documentation routing | `../../harness/skills/doc-governance.md` |
+| Validation planning | `../../harness/skills/quality-workflow.md` |
+
+## Local Constraints
+
+- Keep the plugin optional and safe to disable when Langfuse keys are absent.
+- Do not commit or hardcode Langfuse credentials; use `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_HOST`/`LANGFUSE_BASEURL`, and related environment-driven options.
+- Be deliberate about trace payload privacy. `saveUserText` and `saveLLMOutput` default to enabled, so host deployments may need to override them.
+- Do not block the engine loop on trace flushing during normal runs; preserve fire-and-forget behavior unless changing the contract intentionally.
+- Changes to hook usage, exported options, metadata shape, or service registration should route through `../../harness/skills/contract-coding.md`.
+
+## Common Commands
+
+```bash
+pnpm --filter pulse-coder-langfuse-plugin build
+```
+
+`test` currently has no test files and exits non-zero. `typecheck` currently hits TS6059 because the package imports workspace source from `packages/engine` and `packages/orchestrator` outside this package's `rootDir`; prefer `build` until that TypeScript boundary is fixed.
+
+## Key Files
+
+- `src/index.ts`: `createLangfusePlugin`, option resolution, hook registration, usage normalization, trace/span lifecycle, and default export.
+- `package.json`: package exports, build scripts, and Langfuse/engine dependencies.
+- `tsup.config.ts`: build output configuration.

--- a/packages/memory-plugin/AGENTS.md
+++ b/packages/memory-plugin/AGENTS.md
@@ -5,42 +5,60 @@
 
 ## Module Positioning
 
-`pulse-coder-memory-plugin` owns host-side memory service integration for Pulse Coder runtimes. It provides memory service models, recall/write behavior, daily logs, embeddings, state storage, and integration helpers.
+`pulse-coder-memory-plugin` owns host-side memory service integration for Pulse Coder runtimes. It provides a file-backed memory service, engine plugin integration, memory tools, daily-log extraction, semantic/keyword recall, embeddings, and layered state storage.
 
-Memory behavior should preserve the boundary between user memory, project/repository knowledge, and runtime session logs.
+Memory behavior should preserve the boundary between user/profile memory, hidden `soul` memory, daily-log/session memory, project/repository knowledge, and runtime session logs.
 
 ## Knowledge Navigation
 
 | Task | Read |
 |---|---|
 | Package overview | `README.md` |
-| Product/technical docs | `../../docs/memory-plugin/` |
+| Background design | `../../docs/memory-plugin/technical-design.md` |
 | Public exports | `src/index.ts` |
-| Integration API | `src/integration.ts` |
-| Service behavior | `src/service.ts`, `src/service/` |
 | Types | `src/types.ts` |
-| Embeddings | `src/embedding/` |
-| State/logs | `src/service/state-store.ts`, `src/service/daily-log.ts` |
+| Engine integration and tools | `src/integration.ts` |
+| Memory service | `src/service.ts` |
+| Daily-log write policy | `src/service/daily-log.ts` |
+| Extraction rules | `src/service/extraction.ts` |
+| Recall prompt/scoring helpers | `src/service/recall.ts`, `src/service/models.ts` |
+| Layered state files | `src/service/state-store.ts` |
+| Embeddings and vector storage | `src/embedding-env.ts`, `src/embedding/` |
+| Write policy env config | `src/write-env.ts`, `src/config/env-utils.ts` |
+| Tests | `src/service.test.ts`, `src/integration.test.ts` |
+| Package scripts | `package.json` |
 
 ## Local Constraints
 
 - Do not treat non-versioned runtime memory as repository SSOT.
 - Keep secret/API-key handling environment-based and out of committed files.
-- Changes to recall/write behavior should include tests or explicit manual evidence.
+- Normal recall intentionally targets `daily-log` items; user-scope rules/facts are auto-injected in `beforeRun`, and `soul` memory is hidden unless explicitly requested through the soul/all paths.
+- Daily-log writes have quality gates, quota controls, dedupe keys, day keys, and optional shadow mode. Preserve those controls when changing extraction or write policy.
+- Semantic recall must degrade safely to keyword/recency behavior when embeddings or SQLite vector storage are disabled or unavailable.
+- Layered storage lives under `baseDir/{platformKey}/user`, `soul`, and `daily`; legacy `state.json` migration/backups are part of the compatibility contract.
+- Changes to recall/write/compaction behavior should include tests or explicit manual evidence.
 - Feedback about repository rules should route through `harness/skills/feedback-governance.md`, not silently into memory.
 
 ## Common Commands
 
 ```bash
-pnpm --filter pulse-coder-memory-plugin test
-pnpm --filter pulse-coder-memory-plugin typecheck
 pnpm --filter pulse-coder-memory-plugin build
 ```
+
+Docs-only changes can use the harness docs rule: check referenced paths and commands instead of running package build/test.
+
+`test` is part of harness validation, but in this checkout it currently fails one vector-store coverage case because the local `better-sqlite3` native binding is missing for the active Node runtime; the other memory tests pass. `typecheck` currently fails locally with TS6059 `rootDir` errors because the package imports `pulse-coder-engine` source and that pulls engine/orchestrator files outside `packages/memory-plugin/src`.
 
 ## Key Files
 
 - `src/index.ts`: public package entry.
-- `src/integration.ts`: host integration helpers.
-- `src/service.ts` and `src/service/`: memory service implementation.
-- `src/embedding/`: embedding providers and vector storage.
-- `src/types.ts`: public types.
+- `src/types.ts`: public memory item, policy, input, result, and embedding contracts.
+- `src/service.ts`: `FileMemoryPluginService`, session toggles, explicit writes, daily-log writes, soul memory, recall, pin/forget, compaction, and embedding commits.
+- `src/integration.ts`: `createMemoryIntegration`, env-based integration, engine hooks, memory tools, auto-injected user/soul prompt, and compaction writes.
+- `src/service/state-store.ts`: layered file layout and legacy migration.
+- `src/service/daily-log.ts`: daily-log quotas, quality gates, dedupe, and logging.
+- `src/service/extraction.ts`: rule-based extraction from user/assistant/compaction text.
+- `src/embedding/hash-provider.ts`: default local embeddings and cosine helpers.
+- `src/embedding/openai-provider.ts`: OpenAI-compatible embedding provider from env.
+- `src/embedding/vector-store.ts`: SQLite vector table helpers using `better-sqlite3`.
+- `src/service.test.ts`, `src/integration.test.ts`: service and engine-plugin behavior coverage.

--- a/packages/orchestrator/AGENTS.md
+++ b/packages/orchestrator/AGENTS.md
@@ -7,7 +7,9 @@
 
 `pulse-coder-orchestrator` owns the generic multi-agent orchestration layer: task graph modeling, routing, planning, scheduling, running, artifact storage, and aggregation.
 
-It should remain lower-level than `packages/agent-teams`. Team UX, review gates, checkpoints, and handoff conventions belong in agent-teams or host apps unless they are generic orchestration primitives.
+It should remain lower-level than `packages/agent-teams` and keep the core package free of engine coupling. The orchestrator executes through the `AgentRunner` interface; `EngineAgentRunner` is only an adapter for engine tool registries.
+
+Team UX, review gates, checkpoints, human handoffs, and host session policy belong in `packages/agent-teams` or host apps unless they are generic orchestration primitives.
 
 ## Knowledge Navigation
 
@@ -16,17 +18,26 @@ It should remain lower-level than `packages/agent-teams`. Team UX, review gates,
 | Package overview | `README.md` |
 | Architecture plan | `../../docs/05-orchestrator-plan.md` |
 | Public exports | `src/index.ts` |
-| Task graph | `src/graph.ts`, `src/types.ts` |
-| Routing | `src/router.ts` |
-| Planning | `src/planner.ts` |
-| Scheduling/running | `src/scheduler.ts`, `src/runner.ts`, `src/orchestrator.ts` |
-| Engine adapter | `src/adapters/engine-agent-runner.ts` |
+| Public types and inputs | `src/types.ts` |
+| Top-level run flow | `src/orchestrator.ts` |
+| Task graph validation/building | `src/graph.ts` |
+| Role routing | `src/router.ts` |
+| LLM graph planning | `src/planner.ts` |
+| DAG scheduling and retries | `src/scheduler.ts` |
+| Execution boundary and logging | `src/runner.ts` |
+| Artifact persistence | `src/artifact-store.ts` |
+| Result aggregation | `src/aggregator.ts` |
+| Engine tool adapter | `src/adapters/engine-agent-runner.ts` |
+| Package scripts | `package.json` |
 
 ## Local Constraints
 
 - Keep orchestration primitives generic and host-agnostic.
 - Avoid mixing team-specific review/checkpoint policy into generic graph execution.
-- Preserve deterministic DAG semantics for dependencies and scheduling.
+- Preserve deterministic DAG semantics for dependency readiness, optional-node skipping, retry handling, and blocked dependents.
+- Keep `runner.ts` as the execution boundary. New execution backends should implement `AgentRunner` instead of importing engine/runtime host code into the core flow.
+- `route="plan"` and `aggregate="llm"` require an injected `llmCall`; do not add hidden model/provider dependencies.
+- The default `LocalArtifactStore` writes under `.pulse-coder/agent-teams`; be careful not to treat these runtime artifacts as repository source of truth.
 - Route public contract changes through `harness/skills/contract-coding.md`.
 
 ## Common Commands
@@ -37,10 +48,17 @@ pnpm --filter pulse-coder-orchestrator typecheck
 pnpm --filter pulse-coder-orchestrator build
 ```
 
+`test` is executable but currently uses `--passWithNoTests`; add nearby specs before relying on it as behavioral coverage for scheduler, graph, planner, or aggregation changes.
+
 ## Key Files
 
-- `src/types.ts`: orchestration types and task node shapes.
-- `src/graph.ts`: graph construction and dependency behavior.
-- `src/orchestrator.ts`: top-level orchestration flow.
-- `src/runner.ts`: agent execution abstraction.
+- `src/orchestrator.ts`: run orchestration, route selection, graph validation, scheduling, and aggregation.
+- `src/types.ts`: public task graph, node result, input, and result contracts.
+- `src/scheduler.ts`: concurrent DAG execution, dependency readiness, optional failures, retries, timeouts, upstream context, and artifact writes.
+- `src/graph.ts`: static graph builder and dependency validation.
+- `src/planner.ts`: LLM-produced TaskGraph parsing and validation.
+- `src/router.ts`: keyword role routing.
+- `src/aggregator.ts`: concat, last-success, and LLM summary aggregation.
+- `src/artifact-store.ts`: artifact write/cleanup interface and local implementation.
+- `src/runner.ts`: `AgentRunner` and logger contracts.
 - `src/adapters/engine-agent-runner.ts`: adapter to `pulse-coder-engine`.

--- a/packages/plugin-kit/AGENTS.md
+++ b/packages/plugin-kit/AGENTS.md
@@ -5,7 +5,11 @@
 
 ## Module Positioning
 
-`pulse-coder-plugin-kit` provides shared utilities for runtime plugins and hosts, including worktree integration, vault/secret storage, and devtools helpers.
+`pulse-coder-plugin-kit` provides shared infrastructure for runtime plugins and hosts. It currently contains three reusable subsystems:
+
+- Worktree binding: file-backed worktree records, scope-to-worktree bindings, `AsyncLocalStorage` run context, and a prompt-injection engine plugin.
+- Vault binding: file-backed per-project/per-tenant workspace directories, vault resolution, prompt injection, and the optional `vault_inspect` tool.
+- Devtools: run, LLM, tool, compaction, hook timing, prompt snapshot, token/cost, tool-stat, error, and cache timeline diagnostics.
 
 This package should expose reusable infrastructure primitives. Host-specific policy should stay in the host app or plugin using the kit.
 
@@ -14,31 +18,41 @@ This package should expose reusable infrastructure primitives. Host-specific pol
 | Task | Read |
 |---|---|
 | Package overview | `README.md` |
-| Public exports | `src/index.ts` |
-| Worktree utilities | `src/worktree.ts`, `src/worktree/` |
-| Vault utilities | `src/vault.ts`, `src/vault/` |
-| Devtools utilities | `src/devtools.ts`, `src/devtools/` |
-| Package exports | `package.json` |
+| Public exports | `src/index.ts`, `src/worktree.ts`, `src/vault.ts`, `src/devtools.ts` |
+| Worktree contracts | `src/worktree/types.ts`, `src/worktree/service.ts`, `src/worktree/integration.ts` |
+| Vault contracts | `src/vault/types.ts`, `src/vault/service.ts`, `src/vault/integration.ts`, `src/vault/tools.ts` |
+| Devtools contracts | `src/devtools/index.ts` |
+| Build/export shape | `package.json`, `tsup.config.ts`, `tsconfig.json` |
 
 ## Local Constraints
 
 - Keep utilities host-neutral and reusable.
-- Do not commit secrets or host-local state.
+- Do not commit secrets, vault contents, worktree state, prompt snapshots, or host-local runtime data from `~/.pulse-coder/*`.
 - Export path changes are public contract changes; coordinate with consumers.
 - Worktree behavior should be conservative around user changes and branch state.
+- Vault paths are for artifacts/config/logs, not a substitute for git worktree paths.
+- Devtools may capture user text, prompts, tool inputs/outputs, and generated text. Keep redaction and `saveUserText`/prompt capture options intact when changing diagnostics.
+- Services use file-backed JSON with queued writes in-process; do not assume cross-process locking without adding it deliberately.
 
 ## Common Commands
 
+For docs-only changes, use the harness docs rule: check referenced paths and commands.
+
 ```bash
-pnpm --filter pulse-coder-plugin-kit test
-pnpm --filter pulse-coder-plugin-kit typecheck
-pnpm --filter pulse-coder-plugin-kit build
+SKIP_DTS=1 pnpm --filter pulse-coder-plugin-kit build
 ```
+
+`test` is not a routine command for this package right now: `package.json` defines it, but there are no `*.test.ts` or `*.spec.ts` files, so `vitest run` exits non-zero. `typecheck` is listed in harness validation, but currently fails locally with TS6059 `rootDir` errors from engine/orchestrator source imports plus deep Zod/FlexibleSchema type instantiation errors in `src/devtools/index.ts` and `src/vault/tools.ts`. Default `build` runs declaration generation, so use the skipped-DTS build only as a JS packaging smoke until the TypeScript boundary is fixed.
 
 ## Key Files
 
-- `src/index.ts`: public package entry.
-- `src/worktree.ts` and `src/worktree/`: worktree integration.
-- `src/vault.ts` and `src/vault/`: vault and secret helpers.
-- `src/devtools.ts` and `src/devtools/`: devtools integration.
+- `src/index.ts`: umbrella public exports.
+- `src/worktree.ts`, `src/worktree/index.ts`: worktree subpath exports.
+- `src/worktree/service.ts`: `FileWorktreePluginService`, worktree CRUD, and scope binding state.
+- `src/worktree/integration.ts`: worktree engine plugin and run context adapter.
+- `src/vault.ts`, `src/vault/index.ts`: vault subpath exports.
+- `src/vault/service.ts`: `FileVaultPluginService` and vault directory/index management.
+- `src/vault/integration.ts`: vault engine plugin, resolver, prompt injection, and inspect-tool registration.
+- `src/vault/tools.ts`: `vault_inspect` tool implementation.
+- `src/devtools.ts`, `src/devtools/index.ts`: devtools store, engine plugin, run lookup tool, stats, errors, prompt snapshots, and cache timeline analysis.
 - `package.json`: package exports and build behavior.

--- a/packages/pulse-sandbox/AGENTS.md
+++ b/packages/pulse-sandbox/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md - packages/pulse-sandbox
+
+> Local entry for `packages/pulse-sandbox`.
+> Repository harness entry: `../../harness/README.md`.
+
+## Module Positioning
+
+`pulse-sandbox` owns the sandboxed JavaScript execution runtime and `run_js` engine tool adapter. It executes user-provided code in a child process with a restricted Node `vm` context, timeout and memory limits, output capture, and structured execution results.
+
+This package should stay focused on sandbox execution and tool wrapping. CLI-specific command UX belongs in `packages/cli`; engine tool registration policy belongs in the host or engine integration layer.
+
+## Knowledge Navigation
+
+| Task | Read |
+|---|---|
+| Package overview and behavior | `README.md` |
+| Public exports | `src/index.ts` |
+| Executor process management | `src/executor.ts` |
+| VM runner behavior | `src/runner.ts` |
+| Engine tool adapter | `src/tool.ts` |
+| Public result and option types | `src/types.ts` |
+| Tests | `src/tool.test.ts` |
+| Engine tool contracts | `../engine/AGENTS.md`, `../engine/src/tools/` |
+| Documentation routing | `../../harness/skills/doc-governance.md` |
+| Validation planning | `../../harness/skills/quality-workflow.md` |
+
+## Local Constraints
+
+- Treat sandbox behavior as security-sensitive. Preserve child-process isolation, timeout handling, memory limits, output clamping, and structured error codes.
+- Keep user code execution free of filesystem and network capabilities unless an explicit contract change is approved and tested.
+- Keep runner resolution compatible with built `dist/` output and package consumers.
+- Public result types and `run_js` input schema are contracts; route changes through `../../harness/skills/contract-coding.md`.
+- Add or update tests for changes to policy blocking, timeout/OOM handling, output truncation, globals, or tool schema behavior.
+
+## Common Commands
+
+```bash
+pnpm --filter pulse-sandbox test
+pnpm --filter pulse-sandbox typecheck
+pnpm --filter pulse-sandbox build
+```
+
+## Key Files
+
+- `src/index.ts`: public exports for executor, tool adapter, and types.
+- `src/executor.ts`: child process lifecycle, limits, runner path resolution, timeout/OOM/internal error handling, and output merging.
+- `src/runner.ts`: restricted `vm` context, console capture, code wrapping, and IPC response.
+- `src/tool.ts`: Zod-validated `run_js` tool factory.
+- `src/types.ts`: execution request/result/error and tool option contracts.
+- `src/tool.test.ts`: current focused Vitest coverage for tool forwarding and policy blocking.

--- a/packages/pulse-sandbox/AGENTS.md
+++ b/packages/pulse-sandbox/AGENTS.md
@@ -5,7 +5,7 @@
 
 ## Module Positioning
 
-`pulse-sandbox` owns the sandboxed JavaScript execution runtime and `run_js` engine tool adapter. It executes user-provided code in a child process with a restricted Node `vm` context, timeout and memory limits, output capture, and structured execution results.
+`pulse-sandbox` owns the sandboxed JavaScript execution runtime and `run_js` engine tool adapter. It executes user-provided JavaScript in a forked child process, runs it inside a restricted Node `vm` context, applies timeout/memory/code/output limits, captures console output, and returns structured execution results.
 
 This package should stay focused on sandbox execution and tool wrapping. CLI-specific command UX belongs in `packages/cli`; engine tool registration policy belongs in the host or engine integration layer.
 
@@ -13,24 +13,28 @@ This package should stay focused on sandbox execution and tool wrapping. CLI-spe
 
 | Task | Read |
 |---|---|
-| Package overview and behavior | `README.md` |
+| Package overview and scripts | `README.md`, `package.json` |
 | Public exports | `src/index.ts` |
-| Executor process management | `src/executor.ts` |
-| VM runner behavior | `src/runner.ts` |
-| Engine tool adapter | `src/tool.ts` |
 | Public result and option types | `src/types.ts` |
+| Executor process management, limits, runner resolution | `src/executor.ts` |
+| VM globals, console capture, code wrapping, IPC response | `src/runner.ts` |
+| Engine tool adapter | `src/tool.ts` |
 | Tests | `src/tool.test.ts` |
-| Engine tool contracts | `../engine/AGENTS.md`, `../engine/src/tools/` |
+| CLI integration points | `../cli/src/index.ts`, `../cli/src/ink-controller.ts` |
+| Engine tool contracts | `../engine/AGENTS.md`, `../engine/src/tools/index.ts` |
 | Documentation routing | `../../harness/skills/doc-governance.md` |
 | Validation planning | `../../harness/skills/quality-workflow.md` |
 
 ## Local Constraints
 
 - Treat sandbox behavior as security-sensitive. Preserve child-process isolation, timeout handling, memory limits, output clamping, and structured error codes.
-- Keep user code execution free of filesystem and network capabilities unless an explicit contract change is approved and tested.
+- Current VM globals intentionally hide `require`, `process`, `module`, `exports`, `Buffer`, `fetch`, `WebSocket`, and `EventSource`; string and wasm code generation are disabled through `vm.createContext`.
+- Current VM globals expose `input`, a captured `console`, standard JavaScript globals, `globalThis`/`global` bound to the sandbox object, and timer functions. Do not document timers as blocked unless the runner changes.
+- Keep user code execution free of direct filesystem and network capabilities unless an explicit contract change is approved and tested.
 - Keep runner resolution compatible with built `dist/` output and package consumers.
 - Public result types and `run_js` input schema are contracts; route changes through `../../harness/skills/contract-coding.md`.
-- Add or update tests for changes to policy blocking, timeout/OOM handling, output truncation, globals, or tool schema behavior.
+- The CLI imports `createJsExecutor` and `createRunJsTool` from `pulse-sandbox/src`; coordinate CLI and sandbox changes when changing public exports or tool behavior.
+- Add or update tests for changes to policy blocking, timeout/OOM handling, output truncation, VM globals, runner path resolution, or tool schema behavior.
 
 ## Common Commands
 
@@ -44,7 +48,7 @@ pnpm --filter pulse-sandbox build
 
 - `src/index.ts`: public exports for executor, tool adapter, and types.
 - `src/executor.ts`: child process lifecycle, limits, runner path resolution, timeout/OOM/internal error handling, and output merging.
-- `src/runner.ts`: restricted `vm` context, console capture, code wrapping, and IPC response.
+- `src/runner.ts`: restricted `vm` context, sandbox global list, console capture, code wrapping, and IPC response.
 - `src/tool.ts`: Zod-validated `run_js` tool factory.
 - `src/types.ts`: execution request/result/error and tool option contracts.
 - `src/tool.test.ts`: current focused Vitest coverage for tool forwarding and policy blocking.


### PR DESCRIPTION
## Summary

- Fill baseline harness coverage for all 14 active pnpm workspaces in `harness/profile.yaml`.
- Scan each active package/app and refresh its local `AGENTS.md` with module positioning, reading paths, ownership boundaries, and validation notes.
- Update root `AGENTS.md` into a routing index that points readers to the affected workspace entry before package-specific work.
- Mark auxiliary app directories as out-of-scope for the active harness unless `pnpm-workspace.yaml` is expanded.
- Add path-specific validation rules for the previously missing harness entries and keep known non-green package commands documented locally instead of promoting them to root defaults.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `node --check harness/tools/graph-viewer/server.mjs`
- `node harness/tools/graph-viewer/server.mjs --once` reports 14/14 explicit workspaces, 14/14 entry coverage, 14/14 validation coverage, and `harnessGaps: 0`.
- `pnpm --filter pulse-coder-engine test`
- `pnpm --filter pulse-coder-acp test`
- `pnpm --filter pulse-sandbox test`
- Subagent-verified: `@pulse-coder/canvas-cli` test/typecheck, `@pulse-canvas/nodes` test/typecheck, `canvas-workspace` typecheck + harness help, `pulse-coder-agent-teams` test/typecheck, `pulse-coder-orchestrator` test/typecheck, and `@pulse-coder/teams-cli test`.

## Known Existing Caveats

- `pnpm --filter pulse-coder-cli test` currently fails one TUI capability assertion in this non-interactive environment: `src/tui-renderer.test.ts:100` expects runtime TUI enabling to succeed.
- `pulse-coder-plugin-kit`, `pulse-coder-memory-plugin`, and `pulse-coder-langfuse-plugin` still have pre-existing local validation caveats documented in their refreshed entries: no-test-file cases, TS6059 rootDir boundaries, Zod type depth issues, or local `better-sqlite3` native binding setup.
- `canvas-workspace test` still fails existing file-size governance checks in source files outside this docs-only harness refresh.
- Targeted `remote-server` Vitest still has existing failures around Discord proxy dispatcher identity and `analyze-image.test.ts` referencing `Agent` as undefined.

Note: pnpm still warns that the root `package.json` `pnpm.onlyBuiltDependencies` field is no longer read by pnpm v11; that warning predates this harness change.