### PR TITLE
feat(remote-server): add conversational worktree runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,9 @@ Key components:
 - Clarification: `apps/remote-server/src/core/clarification-queue.ts` — routes clarification prompts/answers for webhook and gateway flows.
 - Sessions: stored in `~/.pulse-coder/remote-sessions` (`index.json` + `sessions/*.json`).
 - Memory: `pulse-coder-memory-plugin` writes daily logs to `~/.pulse-coder/remote-memory`.
-- Worktrees: binding state in `~/.pulse-coder/worktree-state`.
+- Worktrees: binding state in `~/.pulse-coder/worktree-state`; default code checkouts in `~/.pulse-coder/worktrees/<project>/wt-<id>`.
+- Worktree command runner: `POST /internal/worktrees/:id/run` runs commands in a managed worktree with `backend: "host"` or `backend: "docker"` (default Docker image: `node:22-bookworm`, override with `PULSE_CODER_DOCKER_IMAGE`).
+- Conversational coding: remote agent runs can call `worktree_prepare` and `worktree_run`, so requests like “help me implement X” can create/bind a worktree, edit there, validate with host package-level commands first, and escalate to Docker for risky or clean-environment validation.
 - Model overrides: `.pulse-coder/config.json` or `$PULSE_CODER_MODEL_CONFIG` (`apps/remote-server/src/core/model-config.ts`).
 - Adapters: Feishu (`adapters/feishu/*`), Discord webhooks (`adapters/discord/adapter.ts`) and DM gateway (`adapters/discord/gateway.ts`).
 - Internal API: `POST /internal/agent/run`, `GET /internal/discord/gateway/status`, `POST /internal/discord/gateway/restart` — loopback-only, gated by `INTERNAL_API_SECRET`.

--- a/apps/remote-server/src/core/agent-runner.ts
+++ b/apps/remote-server/src/core/agent-runner.ts
@@ -262,6 +262,17 @@ function formatLinkedAt(ts: number): string {
   return new Date(ts).toLocaleDateString();
 }
 
+function buildRemoteCodingWorkflowPrompt(): string {
+  return [
+    '## Remote Coding Workflow',
+    'For coding-change requests, prepare an isolated worktree before editing by calling `worktree_prepare` unless a worktree is already clearly bound.',
+    'Make code changes in the managed worktree path returned by the tool.',
+    'After implementation, validate in the same worktree with `worktree_run`; use `backend: "host"` first for trusted lightweight package-level build/test commands.',
+    'Escalate to `backend: "docker"` when the user asks for Docker, when running install/unknown scripts, when dependency/build configuration changes, when the request is untrusted, or when a clean final validation is important.',
+    'Report the worktree id/path, validation backend, command, and result summary to the user.',
+  ].join('\n');
+}
+
 function buildLinkedSessionsIndex(links: SessionLink[]): string | null {
   if (links.length === 0) {
     return null;
@@ -375,7 +386,7 @@ export async function executeAgentTurn(input: ExecuteAgentTurnInput): Promise<Ex
         systemPrompt: (() => {
           const channelPrompt = buildChannelSystemPrompt(input.platformKey);
           const linkedPrompt = buildLinkedSessionsIndex(linkedSessions);
-          const parts = [channelPrompt, attachmentPrompt, linkedPrompt].filter(Boolean) as string[];
+          const parts = [channelPrompt, attachmentPrompt, linkedPrompt, buildRemoteCodingWorkflowPrompt()].filter(Boolean) as string[];
           if (parts.length === 0) {
             return undefined;
           }

--- a/apps/remote-server/src/core/engine-singleton.ts
+++ b/apps/remote-server/src/core/engine-singleton.ts
@@ -9,6 +9,7 @@ import { jinaAiReadTool } from './tools/jina-ai.js';
 import { readLinkedSessionTool } from './tools/read-linked-session.js';
 import { sessionSummaryTool } from './tools/session-summary.js';
 import { twitterListTweetsTool } from './tools/twitter-list-tweets.js';
+import { worktreeTools } from './tools/worktree-tools.js';
 import { ptcDemoTools } from './tools/ptc-demo.js';
 import { larkCliTool } from './tools/lark-cli.js';
 import { devtoolsPlugin } from './devtools.js';
@@ -37,6 +38,7 @@ export const engine = new Engine({
     read_linked_session: readLinkedSessionTool,
     session_summary: sessionSummaryTool,
     twitter_list_tweets: twitterListTweetsTool,
+    ...worktreeTools,
     lark_cli: larkCliTool,
     ...ptcDemoTools,
   },

--- a/apps/remote-server/src/core/tools/worktree-tools.ts
+++ b/apps/remote-server/src/core/tools/worktree-tools.ts
@@ -1,0 +1,133 @@
+import z from 'zod';
+import type { Tool } from 'pulse-coder-engine';
+import { createOrRegisterWorktree, getManagedWorktree, normalizeWorktreeId } from '../worktree/manager.js';
+import { buildRemoteWorktreeRunContext, worktreeService } from '../worktree/integration.js';
+import { runWorktreeCommand, type WorktreeRunBackend } from '../worktree/runner.js';
+
+const prepareSchema = z.object({
+  id: z
+    .string()
+    .optional()
+    .describe('Optional worktree id. If omitted, a stable id is derived from the current channel/session.'),
+  branch: z.string().optional().describe('Optional branch name. Defaults to feat/<id>.'),
+  baseRef: z.string().optional().describe('Optional base ref for new worktrees, such as origin/main.'),
+  repoRoot: z.string().optional().describe('Optional source repository root. Defaults to PULSE_CODER_REPO_ROOT or current git root.'),
+  worktreePath: z.string().optional().describe('Optional explicit worktree path. Defaults to ~/.pulse-coder/worktrees/<project>/wt-<id>.'),
+});
+
+const runSchema = z.object({
+  id: z.string().optional().describe('Optional worktree id. If omitted, uses the current channel binding.'),
+  backend: z.enum(['host', 'docker']).default('host').describe('Execution backend. Use host for trusted lightweight validation; use docker for risky or clean-environment validation.'),
+  command: z.string().optional().describe('Executable to run. Prefer shell for compound commands.'),
+  args: z.array(z.string()).optional().describe('Arguments for command.'),
+  shell: z.string().optional().describe('Shell command to run in the worktree, e.g. pnpm run build && pnpm test.'),
+  timeoutMs: z.number().int().positive().max(60 * 60 * 1000).optional().describe('Timeout in milliseconds. Defaults to 10 minutes.'),
+  env: z.record(z.string(), z.string()).optional().describe('Extra env vars for host backend.'),
+  docker: z
+    .object({
+      image: z.string().optional().describe('Docker image. Defaults to PULSE_CODER_DOCKER_IMAGE or node:22-bookworm.'),
+      user: z.string().optional().describe('Docker user, e.g. 1000:1000. Defaults to current uid:gid.'),
+      network: z.string().optional().describe('Docker network mode, e.g. none or host.'),
+      env: z.record(z.string(), z.string()).optional().describe('Extra env vars passed to docker container.'),
+      extraArgs: z.array(z.string()).optional().describe('Extra docker run args, such as cache volume mounts.'),
+    })
+    .optional(),
+});
+
+type PrepareInput = z.infer<typeof prepareSchema>;
+type RunInput = z.infer<typeof runSchema>;
+
+interface PrepareResult {
+  ok: boolean;
+  created: boolean;
+  id: string;
+  scope: {
+    runtimeKey: string;
+    scopeKey: string;
+  };
+  worktree: {
+    id: string;
+    repoRoot: string;
+    worktreePath: string;
+    branch?: string;
+  };
+  message: string;
+}
+
+export const worktreePrepareTool: Tool<PrepareInput, PrepareResult> = {
+  name: 'worktree_prepare',
+  description: 'Create or bind an isolated git worktree for the current conversation before modifying code.',
+  inputSchema: prepareSchema,
+  execute: async (input, context) => {
+    const scope = resolveCurrentScope(context?.runContext);
+    const id = normalizeWorktreeId(input.id ?? buildDefaultWorktreeId(scope.scopeKey));
+    if (!id) {
+      throw new Error('Unable to resolve worktree id');
+    }
+
+    const result = await createOrRegisterWorktree({
+      id,
+      repoRoot: input.repoRoot,
+      worktreePath: input.worktreePath,
+      branch: input.branch,
+      baseRef: input.baseRef,
+      bind: scope,
+    });
+
+    if (!result.ok) {
+      throw new Error(result.reason);
+    }
+
+    return {
+      ok: true,
+      created: result.created,
+      id,
+      scope,
+      worktree: result.worktree,
+      message: result.created
+        ? `Created and bound worktree ${id} at ${result.worktree.worktreePath}`
+        : `Using existing worktree ${id} at ${result.worktree.worktreePath}`,
+    };
+  },
+};
+
+export const worktreeRunTool: Tool<RunInput, Awaited<ReturnType<typeof runWorktreeCommand>>> = {
+  name: 'worktree_run',
+  description: 'Run validation commands inside the current managed worktree, using host execution by default and Docker when stronger isolation is needed.',
+  inputSchema: runSchema,
+  execute: async (input, context) => {
+    const scope = resolveCurrentScope(context?.runContext);
+    const worktree = input.id
+      ? await getManagedWorktree(input.id)
+      : (await worktreeService.getScopeBinding(scope))?.worktree;
+
+    if (!worktree) {
+      throw new Error('No worktree is bound. Call worktree_prepare first.');
+    }
+
+    const backend: WorktreeRunBackend = input.backend ?? 'host';
+    return runWorktreeCommand(worktree, {
+      ...input,
+      backend,
+    });
+  },
+};
+
+export const worktreeTools = {
+  worktree_prepare: worktreePrepareTool,
+  worktree_run: worktreeRunTool,
+};
+
+function resolveCurrentScope(runContext: unknown): { runtimeKey: string; scopeKey: string } {
+  const context = runContext && typeof runContext === 'object' ? runContext as Record<string, unknown> : {};
+  const platformKey = typeof context.platformKey === 'string' ? context.platformKey : '';
+  if (!platformKey) {
+    throw new Error('worktree tools require runContext.platformKey');
+  }
+  return buildRemoteWorktreeRunContext(platformKey);
+}
+
+function buildDefaultWorktreeId(scopeKey: string): string {
+  const channelPart = normalizeWorktreeId(scopeKey) || 'conversation';
+  return `auto-${channelPart}`;
+}

--- a/apps/remote-server/src/core/worktree/commands.ts
+++ b/apps/remote-server/src/core/worktree/commands.ts
@@ -1,13 +1,12 @@
-import { execFile } from 'child_process';
-import { promises as fs } from 'fs';
-import { join, resolve as resolvePath } from 'path';
-import { promisify } from 'util';
 import { worktreeService } from './integration.js';
+import {
+  createOrRegisterWorktree,
+  getManagedWorktree,
+  normalizeWorktreeId,
+} from './manager.js';
 
 const COMMAND_PREFIX = '/wt';
 const MAX_PATH_LENGTH = 400;
-const BRANCH_PREFIXES = ['feat', 'fix', 'docs', 'chore', 'refactor', 'test', 'hotfix'];
-const execFileAsync = promisify(execFile);
 
 export interface WorktreeCommandResult {
   handled: boolean;
@@ -104,32 +103,25 @@ export async function processWorktreeCommand(input: {
           };
         }
 
-        const existing = await findExistingWorktree(rawId, normalizedId);
+        const existing = await getManagedWorktree(rawId);
         if (!existing) {
-          const created = await createWorktreeIfMissing(normalizedId);
-          if (!created.ok) {
-            return {
-              handled: true,
-              message: created.reason,
-            };
-          }
-
-          const binding = await worktreeService.upsertAndBind(
-            {
+          const created = await createOrRegisterWorktree({
+            id: normalizedId,
+            bind: {
               runtimeKey: input.runtimeKey,
               scopeKey: input.scopeKey,
             },
-            {
-              id: created.value.id,
-              repoRoot: created.value.repoRoot,
-              worktreePath: created.value.worktreePath,
-              branch: created.value.branch,
-            },
-          );
+          });
+          if (!created.ok) {
+            return {
+              handled: true,
+              message: `❌ 创建 worktree 失败：${created.reason}`,
+            };
+          }
 
           return {
             handled: true,
-            message: buildBindingMessage(binding, true),
+            message: buildBindingMessage({ worktree: created.worktree }, created.created),
           };
         }
 
@@ -296,171 +288,6 @@ function buildHelpMessage(): string {
     '/wt use <id> <repoRoot> <worktreePath> [branch] - 绑定/更新当前会话 worktree',
     '/wt clear - 清除当前会话 worktree 绑定',
   ].join('\n');
-}
-
-async function findExistingWorktree(rawId: string, normalizedId: string) {
-  const direct = await worktreeService.getWorktree(rawId);
-  if (direct) {
-    return direct;
-  }
-
-  if (normalizedId !== rawId) {
-    return worktreeService.getWorktree(normalizedId);
-  }
-
-  return undefined;
-}
-
-async function createWorktreeIfMissing(id: string): Promise<
-  | { ok: true; value: { id: string; repoRoot: string; worktreePath: string; branch: string } }
-  | { ok: false; reason: string }
-> {
-  const repoRoot = await resolveRepoRoot();
-  if (!repoRoot) {
-    return {
-      ok: false,
-      reason: '❌ 无法解析仓库根目录，请设置 PULSE_CODER_REPO_ROOT 或使用完整参数。',
-    };
-  }
-
-  const worktreeRoot = resolveWorktreeRoot(repoRoot);
-  const worktreePath = join(worktreeRoot, `wt-${id}`);
-  if (worktreePath.length > MAX_PATH_LENGTH) {
-    return {
-      ok: false,
-      reason: '❌ 路径过长，请缩短后重试。',
-    };
-  }
-
-  const pathExists = await exists(worktreePath);
-  if (pathExists) {
-    return {
-      ok: false,
-      reason: `❌ worktree 目录已存在：${worktreePath}\n请更换 id 或手动清理。`,
-    };
-  }
-
-  const branch = resolveBranchName(id);
-  try {
-    await fs.mkdir(worktreeRoot, { recursive: true });
-    await runGit(repoRoot, ['fetch', 'origin'], true);
-
-    const branchExists = await gitRefExists(repoRoot, `refs/heads/${branch}`);
-    if (branchExists) {
-      await runGit(repoRoot, ['worktree', 'add', worktreePath, branch]);
-    } else {
-      const baseRef = await resolveBaseRef(repoRoot);
-      if (!baseRef) {
-        return {
-          ok: false,
-          reason: '❌ 无法找到 base 分支（origin/main/master 或 main/master）。',
-        };
-      }
-      await runGit(repoRoot, ['worktree', 'add', worktreePath, '-b', branch, baseRef]);
-    }
-  } catch (err) {
-    return {
-      ok: false,
-      reason: `❌ 创建 worktree 失败：${formatError(err)}`,
-    };
-  }
-
-  return {
-    ok: true,
-    value: {
-      id,
-      repoRoot,
-      worktreePath,
-      branch,
-    },
-  };
-}
-
-async function resolveRepoRoot(): Promise<string | null> {
-  const fromEnv = process.env.PULSE_CODER_REPO_ROOT?.trim();
-  if (fromEnv) {
-    return fromEnv;
-  }
-
-  try {
-    const { stdout } = await execFileAsync('git', ['-C', process.cwd(), 'rev-parse', '--show-toplevel']);
-    const root = stdout.trim();
-    return root || null;
-  } catch {
-    return null;
-  }
-}
-
-function resolveWorktreeRoot(repoRoot: string): string {
-  const fromEnv = process.env.PULSE_CODER_WORKTREE_ROOT?.trim();
-  if (fromEnv) {
-    return resolvePath(repoRoot, fromEnv);
-  }
-
-  return join(repoRoot, 'worktrees');
-}
-
-async function resolveBaseRef(repoRoot: string): Promise<string | null> {
-  const candidates = ['refs/remotes/origin/main', 'refs/remotes/origin/master', 'refs/heads/main', 'refs/heads/master'];
-  for (const ref of candidates) {
-    if (await gitRefExists(repoRoot, ref)) {
-      return ref.replace(/^refs\//, '');
-    }
-  }
-  return null;
-}
-
-function resolveBranchName(slug: string): string {
-  if (BRANCH_PREFIXES.some((prefix) => slug.startsWith(`${prefix}-`))) {
-    return slug.replace(/^([a-z0-9]+)-/, '$1/');
-  }
-  return `feat/${slug}`;
-}
-
-function normalizeWorktreeId(raw: string): string {
-  return raw
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .replace(/-+/g, '-');
-}
-
-async function gitRefExists(repoRoot: string, ref: string): Promise<boolean> {
-  try {
-    await execFileAsync('git', ['-C', repoRoot, 'show-ref', '--verify', '--quiet', ref]);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function runGit(repoRoot: string, args: string[], ignoreFailure = false): Promise<string> {
-  try {
-    const { stdout } = await execFileAsync('git', ['-C', repoRoot, ...args]);
-    return stdout.trim();
-  } catch (err) {
-    if (ignoreFailure) {
-      return '';
-    }
-    throw err;
-  }
-}
-
-async function exists(path: string): Promise<boolean> {
-  try {
-    await fs.stat(path);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function formatError(err: unknown): string {
-  if (err instanceof Error) {
-    return err.message;
-  }
-  return String(err);
 }
 
 function buildBindingMessage(

--- a/apps/remote-server/src/core/worktree/manager.ts
+++ b/apps/remote-server/src/core/worktree/manager.ts
@@ -1,0 +1,256 @@
+import { execFile } from 'child_process';
+import { promises as fs } from 'fs';
+import { homedir } from 'os';
+import { basename, join, resolve as resolvePath } from 'path';
+import { promisify } from 'util';
+import { worktreeService } from './integration.js';
+
+const MAX_PATH_LENGTH = 400;
+const BRANCH_PREFIXES = ['feat', 'fix', 'docs', 'chore', 'refactor', 'test', 'hotfix'];
+const DEFAULT_PROJECT_ID = 'pulse-coder';
+const execFileAsync = promisify(execFile);
+
+export interface WorktreeCreateInput {
+  id: string;
+  repoRoot?: string;
+  worktreePath?: string;
+  branch?: string;
+  baseRef?: string;
+  bind?: {
+    runtimeKey: string;
+    scopeKey: string;
+  };
+}
+
+export interface WorktreeRecordView {
+  id: string;
+  repoRoot: string;
+  worktreePath: string;
+  branch?: string;
+  createdAt?: number;
+  updatedAt?: number;
+}
+
+export type WorktreeCreateResult =
+  | { ok: true; created: boolean; worktree: WorktreeRecordView; binding?: unknown }
+  | { ok: false; reason: string };
+
+export async function listManagedWorktrees(): Promise<WorktreeRecordView[]> {
+  return worktreeService.listWorktrees();
+}
+
+export async function getManagedWorktree(id: string): Promise<WorktreeRecordView | undefined> {
+  const normalizedId = normalizeWorktreeId(id);
+  if (!normalizedId) {
+    return undefined;
+  }
+
+  return worktreeService.getWorktree(normalizedId);
+}
+
+export async function removeManagedWorktree(id: string, options: { removeDirectory?: boolean } = {}) {
+  const normalizedId = normalizeWorktreeId(id);
+  if (!normalizedId) {
+    return { ok: false, reason: 'worktree id is required' };
+  }
+
+  const existing = await worktreeService.getWorktree(normalizedId);
+  if (!existing) {
+    return { ok: false, reason: `worktree not found: ${normalizedId}` };
+  }
+
+  if (options.removeDirectory) {
+    try {
+      await runGit(existing.repoRoot, ['worktree', 'remove', existing.worktreePath, '--force']);
+    } catch (err) {
+      return { ok: false, reason: `failed to remove worktree directory: ${formatError(err)}` };
+    }
+  }
+
+  return worktreeService.removeWorktree(normalizedId);
+}
+
+export async function createOrRegisterWorktree(input: WorktreeCreateInput): Promise<WorktreeCreateResult> {
+  const id = normalizeWorktreeId(input.id);
+  if (!id) {
+    return { ok: false, reason: 'id is required' };
+  }
+
+  const existing = await worktreeService.getWorktree(id);
+  if (existing) {
+    const binding = input.bind
+      ? await worktreeService.upsertAndBind(input.bind, {
+        id: existing.id,
+        repoRoot: existing.repoRoot,
+        worktreePath: existing.worktreePath,
+        branch: existing.branch,
+      })
+      : undefined;
+
+    return { ok: true, created: false, worktree: existing, binding };
+  }
+
+  const repoRoot = await resolveRepoRoot(input.repoRoot);
+  if (!repoRoot) {
+    return { ok: false, reason: 'unable to resolve repo root; set PULSE_CODER_REPO_ROOT or provide repoRoot' };
+  }
+
+  const branch = normalizeBranchName(input.branch) ?? resolveBranchName(id);
+  const worktreePath = resolveWorktreePath({ id, repoRoot, explicitPath: input.worktreePath });
+  if (repoRoot.length > MAX_PATH_LENGTH || worktreePath.length > MAX_PATH_LENGTH) {
+    return { ok: false, reason: 'path is too long' };
+  }
+
+  if (await exists(worktreePath)) {
+    return { ok: false, reason: `worktree path already exists: ${worktreePath}` };
+  }
+
+  try {
+    await fs.mkdir(resolveWorktreeRoot(repoRoot), { recursive: true });
+    await runGit(repoRoot, ['fetch', 'origin'], true);
+
+    const branchExists = await gitRefExists(repoRoot, `refs/heads/${branch}`);
+    if (branchExists) {
+      await runGit(repoRoot, ['worktree', 'add', worktreePath, branch]);
+    } else {
+      const baseRef = input.baseRef?.trim() || await resolveBaseRef(repoRoot);
+      if (!baseRef) {
+        return { ok: false, reason: 'unable to find base ref (origin/main/master or main/master)' };
+      }
+      await runGit(repoRoot, ['worktree', 'add', worktreePath, '-b', branch, baseRef]);
+    }
+  } catch (err) {
+    return { ok: false, reason: `failed to create worktree: ${formatError(err)}` };
+  }
+
+  const binding = input.bind
+    ? await worktreeService.upsertAndBind(input.bind, { id, repoRoot, worktreePath, branch })
+    : undefined;
+
+  if (!input.bind) {
+    await worktreeService.upsertWorktree({ id, repoRoot, worktreePath, branch });
+  }
+
+  const worktree = await worktreeService.getWorktree(id);
+  return {
+    ok: true,
+    created: true,
+    worktree: worktree ?? { id, repoRoot, worktreePath, branch },
+    binding,
+  };
+}
+
+export async function resolveRepoRoot(explicitRoot?: string): Promise<string | null> {
+  const fromInput = explicitRoot?.trim();
+  if (fromInput) {
+    return resolvePath(fromInput);
+  }
+
+  const fromEnv = process.env.PULSE_CODER_REPO_ROOT?.trim();
+  if (fromEnv) {
+    return resolvePath(fromEnv);
+  }
+
+  try {
+    const { stdout } = await execFileAsync('git', ['-C', process.cwd(), 'rev-parse', '--show-toplevel']);
+    const root = stdout.trim();
+    return root || null;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveWorktreeRoot(repoRoot: string): string {
+  const fromEnv = process.env.PULSE_CODER_WORKTREE_ROOT?.trim();
+  if (fromEnv) {
+    return resolvePath(repoRoot, fromEnv);
+  }
+
+  return join(homedir(), '.pulse-coder', 'worktrees', resolveProjectId(repoRoot));
+}
+
+export function normalizeWorktreeId(raw: string): string {
+  return raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-+/g, '-');
+}
+
+function resolveWorktreePath(input: { id: string; repoRoot: string; explicitPath?: string }): string {
+  const explicitPath = input.explicitPath?.trim();
+  if (explicitPath) {
+    return resolvePath(input.repoRoot, explicitPath);
+  }
+
+  return join(resolveWorktreeRoot(input.repoRoot), `wt-${input.id}`);
+}
+
+async function resolveBaseRef(repoRoot: string): Promise<string | null> {
+  const candidates = ['refs/remotes/origin/main', 'refs/remotes/origin/master', 'refs/heads/main', 'refs/heads/master'];
+  for (const ref of candidates) {
+    if (await gitRefExists(repoRoot, ref)) {
+      return ref.replace(/^refs\//, '');
+    }
+  }
+  return null;
+}
+
+function resolveBranchName(slug: string): string {
+  if (BRANCH_PREFIXES.some((prefix) => slug.startsWith(`${prefix}-`))) {
+    return slug.replace(/^([a-z0-9]+)-/, '$1/');
+  }
+  return `feat/${slug}`;
+}
+
+function normalizeBranchName(raw?: string): string | undefined {
+  const branch = raw?.trim();
+  return branch || undefined;
+}
+
+function resolveProjectId(repoRoot: string): string {
+  const fromEnv = process.env.PULSE_CODER_PROJECT_ID?.trim();
+  if (fromEnv) {
+    return normalizeWorktreeId(fromEnv) || DEFAULT_PROJECT_ID;
+  }
+
+  return normalizeWorktreeId(basename(repoRoot)) || DEFAULT_PROJECT_ID;
+}
+
+async function gitRefExists(repoRoot: string, ref: string): Promise<boolean> {
+  try {
+    await execFileAsync('git', ['-C', repoRoot, 'show-ref', '--verify', '--quiet', ref]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function runGit(repoRoot: string, args: string[], ignoreFailure = false): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync('git', ['-C', repoRoot, ...args]);
+    return stdout.trim();
+  } catch (err) {
+    if (ignoreFailure) {
+      return '';
+    }
+    throw err;
+  }
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await fs.stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function formatError(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
+}

--- a/apps/remote-server/src/core/worktree/runner.ts
+++ b/apps/remote-server/src/core/worktree/runner.ts
@@ -1,0 +1,291 @@
+import { spawn } from 'child_process';
+import { cpus } from 'os';
+import type { WorktreeRecordView } from './manager.js';
+
+export type WorktreeRunBackend = 'host' | 'docker';
+
+export interface WorktreeRunDockerOptions {
+  image?: string;
+  user?: string;
+  network?: string;
+  env?: Record<string, string>;
+  extraArgs?: string[];
+}
+
+export interface WorktreeRunInput {
+  backend?: WorktreeRunBackend;
+  command?: string;
+  args?: string[];
+  shell?: string;
+  timeoutMs?: number;
+  env?: Record<string, string>;
+  docker?: WorktreeRunDockerOptions;
+}
+
+export interface WorktreeRunResult {
+  ok: boolean;
+  backend: WorktreeRunBackend;
+  cwd: string;
+  command: string;
+  args: string[];
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  timedOut: boolean;
+  durationMs: number;
+  stdout: string;
+  stderr: string;
+  error?: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
+const MAX_TIMEOUT_MS = 60 * 60 * 1000;
+const MAX_OUTPUT_BYTES = 256 * 1024;
+const DEFAULT_DOCKER_IMAGE = 'node:22-bookworm';
+const WORKSPACE_MOUNT_PATH = '/workspace';
+
+export async function runWorktreeCommand(
+  worktree: WorktreeRecordView,
+  input: WorktreeRunInput,
+): Promise<WorktreeRunResult> {
+  const backend = normalizeBackend(input.backend);
+  const timeoutMs = normalizeTimeout(input.timeoutMs);
+  const commandSpec = buildCommandSpec(worktree, backend, input);
+  const startedAt = Date.now();
+
+  try {
+    const result = await runProcess(commandSpec, timeoutMs);
+    const durationMs = Date.now() - startedAt;
+    return {
+      ok: result.exitCode === 0 && !result.timedOut,
+      backend,
+      cwd: commandSpec.cwd,
+      command: commandSpec.command,
+      args: commandSpec.args,
+      exitCode: result.exitCode,
+      signal: result.signal,
+      timedOut: result.timedOut,
+      durationMs,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
+  } catch (err) {
+    const durationMs = Date.now() - startedAt;
+    return {
+      ok: false,
+      backend,
+      cwd: commandSpec.cwd,
+      command: commandSpec.command,
+      args: commandSpec.args,
+      exitCode: null,
+      signal: null,
+      timedOut: false,
+      durationMs,
+      stdout: '',
+      stderr: '',
+      error: formatError(err),
+    };
+  }
+}
+
+interface CommandSpec {
+  command: string;
+  args: string[];
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+interface ProcessResult {
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  timedOut: boolean;
+  stdout: string;
+  stderr: string;
+}
+
+function buildCommandSpec(
+  worktree: WorktreeRecordView,
+  backend: WorktreeRunBackend,
+  input: WorktreeRunInput,
+): CommandSpec {
+  if (backend === 'docker') {
+    return buildDockerCommand(worktree, input);
+  }
+
+  if (input.shell?.trim()) {
+    return {
+      command: '/bin/bash',
+      args: ['-lc', input.shell.trim()],
+      cwd: worktree.worktreePath,
+      env: { ...process.env, ...normalizeEnv(input.env) },
+    };
+  }
+
+  const command = input.command?.trim();
+  if (!command) {
+    throw new Error('command or shell is required');
+  }
+
+  return {
+    command,
+    args: normalizeArgs(input.args),
+    cwd: worktree.worktreePath,
+    env: { ...process.env, ...normalizeEnv(input.env) },
+  };
+}
+
+function buildDockerCommand(worktree: WorktreeRecordView, input: WorktreeRunInput): CommandSpec {
+  const image = input.docker?.image?.trim() || process.env.PULSE_CODER_DOCKER_IMAGE?.trim() || DEFAULT_DOCKER_IMAGE;
+  const dockerArgs = [
+    'run',
+    '--rm',
+    '-v',
+    `${worktree.worktreePath}:${WORKSPACE_MOUNT_PATH}`,
+    '-w',
+    WORKSPACE_MOUNT_PATH,
+  ];
+
+  const user = input.docker?.user?.trim() || defaultDockerUser();
+  if (user) {
+    dockerArgs.push('--user', user);
+  }
+
+  const network = input.docker?.network?.trim() || process.env.PULSE_CODER_DOCKER_NETWORK?.trim();
+  if (network) {
+    dockerArgs.push('--network', network);
+  }
+
+  for (const [key, value] of Object.entries(normalizeEnv(input.docker?.env))) {
+    dockerArgs.push('-e', `${key}=${value}`);
+  }
+
+  dockerArgs.push(...normalizeArgs(input.docker?.extraArgs));
+  dockerArgs.push(image);
+
+  if (input.shell?.trim()) {
+    dockerArgs.push('/bin/bash', '-lc', input.shell.trim());
+  } else {
+    const command = input.command?.trim();
+    if (!command) {
+      throw new Error('command or shell is required');
+    }
+    dockerArgs.push(command, ...normalizeArgs(input.args));
+  }
+
+  return {
+    command: 'docker',
+    args: dockerArgs,
+    cwd: worktree.repoRoot,
+    env: process.env,
+  };
+}
+
+function runProcess(spec: CommandSpec, timeoutMs: number): Promise<ProcessResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(spec.command, spec.args, {
+      cwd: spec.cwd,
+      env: spec.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    let timedOut = false;
+
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGTERM');
+      setTimeout(() => {
+        if (!settled) {
+          child.kill('SIGKILL');
+        }
+      }, 5000).unref();
+    }, timeoutMs);
+    timeout.unref();
+
+    child.stdout?.on('data', (chunk) => {
+      stdout = appendOutput(stdout, chunk);
+    });
+
+    child.stderr?.on('data', (chunk) => {
+      stderr = appendOutput(stderr, chunk);
+    });
+
+    child.on('error', (err) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      reject(err);
+    });
+
+    child.on('close', (exitCode, signal) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      resolve({ exitCode, signal, timedOut, stdout, stderr });
+    });
+  });
+}
+
+function normalizeBackend(value?: WorktreeRunBackend): WorktreeRunBackend {
+  return value === 'docker' ? 'docker' : 'host';
+}
+
+function normalizeTimeout(value?: number): number {
+  if (!Number.isFinite(value) || !value || value <= 0) {
+    return DEFAULT_TIMEOUT_MS;
+  }
+  return Math.min(Math.floor(value), MAX_TIMEOUT_MS);
+}
+
+function normalizeArgs(value?: string[]): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === 'string');
+}
+
+function normalizeEnv(value?: Record<string, string>): Record<string, string> {
+  if (!value || typeof value !== 'object') {
+    return {};
+  }
+
+  const env: Record<string, string> = {};
+  for (const [key, rawValue] of Object.entries(value)) {
+    if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(key) && typeof rawValue === 'string') {
+      env[key] = rawValue;
+    }
+  }
+  return env;
+}
+
+function defaultDockerUser(): string | undefined {
+  const uid = typeof process.getuid === 'function' ? process.getuid() : undefined;
+  const gid = typeof process.getgid === 'function' ? process.getgid() : undefined;
+  if (uid === undefined || gid === undefined) {
+    return undefined;
+  }
+  return `${uid}:${gid}`;
+}
+
+function appendOutput(current: string, chunk: Buffer): string {
+  const next = current + chunk.toString('utf8');
+  if (Buffer.byteLength(next, 'utf8') <= MAX_OUTPUT_BYTES) {
+    return next;
+  }
+
+  const keepBytes = Math.max(MAX_OUTPUT_BYTES - 128, Math.floor(MAX_OUTPUT_BYTES / Math.max(cpus().length, 1)));
+  const truncated = Buffer.from(next, 'utf8').subarray(-keepBytes).toString('utf8');
+  return `[output truncated to last ${keepBytes} bytes]\n${truncated}`;
+}
+
+function formatError(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
+}

--- a/apps/remote-server/src/routes/internal.ts
+++ b/apps/remote-server/src/routes/internal.ts
@@ -7,6 +7,13 @@ import { extractGeneratedImageResult } from '../adapters/feishu/image-result.js'
 import { getDiscordGatewayStatus, restartDiscordGateway } from '../adapters/discord/gateway-manager.js';
 import { DiscordClient } from '../adapters/discord/client.js';
 import { executeAgentTurn, formatCompactionEvents, type CompactionSnapshot } from '../core/agent-runner.js';
+import {
+  createOrRegisterWorktree,
+  getManagedWorktree,
+  listManagedWorktrees,
+  removeManagedWorktree,
+} from '../core/worktree/manager.js';
+import { runWorktreeCommand, type WorktreeRunBackend } from '../core/worktree/runner.js';
 import type { ClarificationRequest } from '../core/types.js';
 
 type ReceiveIdType = 'open_id' | 'chat_id' | 'user_id' | 'union_id' | 'email';
@@ -39,6 +46,38 @@ interface AgentRunBody {
   caller?: string;
   callerSelectors?: string[];
   notify?: NotifyConfig;
+}
+
+interface WorktreeCreateBody {
+  id?: string;
+  repoRoot?: string;
+  worktreePath?: string;
+  branch?: string;
+  baseRef?: string;
+  bind?: {
+    runtimeKey?: string;
+    scopeKey?: string;
+  };
+}
+
+interface WorktreeRunBody {
+  backend?: WorktreeRunBackend;
+  command?: string;
+  args?: string[];
+  shell?: string;
+  timeoutMs?: number;
+  env?: Record<string, string>;
+  docker?: {
+    image?: string;
+    user?: string;
+    network?: string;
+    env?: Record<string, string>;
+    extraArgs?: string[];
+  };
+}
+
+interface WorktreeRemoveBody {
+  removeDirectory?: boolean;
 }
 
 interface NotifyResult {
@@ -93,6 +132,117 @@ internalRouter.post('/discord/gateway/restart', (c) => {
 
   const status = restartDiscordGateway();
   return c.json({ ok: true, restarted: true, gateway: status }, 200);
+});
+
+internalRouter.get('/worktrees', async (c) => {
+  if (!isAuthorizedInternal(c)) {
+    return c.json({ ok: false, error: 'Unauthorized' }, 401);
+  }
+
+  const worktrees = await listManagedWorktrees();
+  return c.json({ ok: true, worktrees }, 200);
+});
+
+internalRouter.get('/worktrees/:id', async (c) => {
+  if (!isAuthorizedInternal(c)) {
+    return c.json({ ok: false, error: 'Unauthorized' }, 401);
+  }
+
+  const id = c.req.param('id');
+  const worktree = await getManagedWorktree(id);
+  if (!worktree) {
+    return c.json({ ok: false, error: `worktree not found: ${id}` }, 404);
+  }
+
+  return c.json({ ok: true, worktree }, 200);
+});
+
+internalRouter.post('/worktrees', async (c) => {
+  if (!isAuthorizedInternal(c)) {
+    return c.json({ ok: false, error: 'Unauthorized' }, 401);
+  }
+
+  let body: WorktreeCreateBody;
+  try {
+    body = await c.req.json<WorktreeCreateBody>();
+  } catch {
+    return c.json({ ok: false, error: 'Invalid JSON body' }, 400);
+  }
+
+  if (!body.id?.trim()) {
+    return c.json({ ok: false, error: 'id is required' }, 400);
+  }
+
+  const bind = body.bind?.runtimeKey?.trim() && body.bind.scopeKey?.trim()
+    ? {
+      runtimeKey: body.bind.runtimeKey.trim(),
+      scopeKey: body.bind.scopeKey.trim(),
+    }
+    : undefined;
+
+  const result = await createOrRegisterWorktree({
+    id: body.id,
+    repoRoot: body.repoRoot,
+    worktreePath: body.worktreePath,
+    branch: body.branch,
+    baseRef: body.baseRef,
+    bind,
+  });
+
+  if (!result.ok) {
+    return c.json({ ok: false, error: result.reason }, 400);
+  }
+
+  return c.json({ ok: true, created: result.created, worktree: result.worktree, binding: result.binding }, 201);
+});
+
+internalRouter.post('/worktrees/:id/run', async (c) => {
+  if (!isAuthorizedInternal(c)) {
+    return c.json({ ok: false, error: 'Unauthorized' }, 401);
+  }
+
+  let body: WorktreeRunBody;
+  try {
+    body = await c.req.json<WorktreeRunBody>();
+  } catch {
+    return c.json({ ok: false, error: 'Invalid JSON body' }, 400);
+  }
+
+  const id = c.req.param('id');
+  const worktree = await getManagedWorktree(id);
+  if (!worktree) {
+    return c.json({ ok: false, error: `worktree not found: ${id}` }, 404);
+  }
+
+  const hasCommand = typeof body.command === 'string' && body.command.trim().length > 0;
+  const hasShell = typeof body.shell === 'string' && body.shell.trim().length > 0;
+  if (!hasCommand && !hasShell) {
+    return c.json({ ok: false, error: 'command or shell is required' }, 400);
+  }
+
+  const result = await runWorktreeCommand(worktree, body);
+  return c.json({ ok: result.ok, worktree, result }, result.ok ? 200 : 500);
+});
+
+internalRouter.delete('/worktrees/:id', async (c) => {
+  if (!isAuthorizedInternal(c)) {
+    return c.json({ ok: false, error: 'Unauthorized' }, 401);
+  }
+
+  let body: WorktreeRemoveBody = {};
+  try {
+    body = await c.req.json<WorktreeRemoveBody>();
+  } catch {
+    body = {};
+  }
+
+  const id = c.req.param('id');
+  const result = await removeManagedWorktree(id, { removeDirectory: body.removeDirectory ?? false });
+  if (!result.ok) {
+    return c.json({ ok: false, error: result.reason }, 400);
+  }
+
+  return c.json({ ok: true, removed: result.removed }, 200);
 });
 
 internalRouter.post('/agent/run', async (c) => {
@@ -262,6 +412,10 @@ function isLoopbackAddress(address?: string): boolean {
 
   const normalized = address.trim().toLowerCase();
   return normalized === '127.0.0.1' || normalized === '::1' || normalized === '::ffff:127.0.0.1';
+}
+
+function isAuthorizedInternal(c: Context): boolean {
+  return verifyInternalAuth(c.req.header('authorization'), c.req.header('x-internal-api-key'));
 }
 
 function verifyInternalAuth(authHeader?: string, internalApiKey?: string): boolean {


### PR DESCRIPTION
Add conversational worktree automation for remote coding tasks.

- Add managed worktree creation/binding helpers and internal APIs
- Add host/Docker worktree command runner with timeout and output capture
- Register worktree_prepare and worktree_run agent tools for pure conversational coding flows
- Update remote agent guidance to use worktree isolation with host-first validation and Docker escalation
- Document default worktree paths and validation behavior

Validation:
- pnpm --filter @pulse-coder/remote-server build