### PR TITLE
fix: support Feishu topic replies

### DIFF
--- a/apps/remote-server/src/adapters/feishu/adapter.ts
+++ b/apps/remote-server/src/adapters/feishu/adapter.ts
@@ -127,7 +127,7 @@ export class FeishuAdapter implements PlatformAdapter {
         clarificationQueue.submitAnswer(activeStreamId, pending.request.id, text);
         const sendTo = chatId ?? openId;
         const idType: 'chat_id' | 'open_id' = chatId ? 'chat_id' : 'open_id';
-        await sendTextMessage(this.larkClient, sendTo, idType, `✅ Got it: "${text}"`).catch(console.error);
+        await sendTextMessage(this.larkClient, sendTo, idType, `✅ Got it: "${text}"`, messageId ? { replyToMessageId: messageId } : undefined).catch(console.error);
       }
       return null;
     }
@@ -152,6 +152,7 @@ export class FeishuAdapter implements PlatformAdapter {
     const chatId = meta?.chatId ?? incoming.platformKey.replace('feishu:', '');
     const idType = meta?.chatIdType ?? 'open_id';
     const sourceMessageId = meta?.sourceMessageId;
+    const replyOptions = sourceMessageId ? { replyToMessageId: sourceMessageId } : undefined;
     const { larkClient } = this;
 
     // Clean up chatMeta after reading — it's only needed to bridge parseIncoming → createStreamHandle
@@ -270,7 +271,7 @@ export class FeishuAdapter implements PlatformAdapter {
 
     // Send initial "thinking" card
     try {
-      cardMessageId = await sendCardMessage(larkClient, chatId, idType, buildThinkingCard());
+      cardMessageId = await sendCardMessage(larkClient, chatId, idType, buildThinkingCard(), replyOptions);
       lastProgressUpdateAt = Date.now();
       startHeartbeat();
     } catch (err) {
@@ -304,7 +305,7 @@ export class FeishuAdapter implements PlatformAdapter {
         sentImagePaths.add(imageResult.outputPath);
 
         try {
-          await sendImageMessage(chatId, idType, imageResult.outputPath, imageResult.mimeType);
+          await sendImageMessage(chatId, idType, imageResult.outputPath, imageResult.mimeType, replyOptions);
           latestToolHint = '🖼️ Image generated and sent to Feishu';
           scheduleProgressUpdate(true);
         } catch (err) {
@@ -319,7 +320,7 @@ export class FeishuAdapter implements PlatformAdapter {
         const question = req.context
           ? `${req.question}\n\n_Context: ${req.context}_`
           : req.question;
-        await sendTextMessage(larkClient, chatId, idType, `❓ ${question}`).catch(console.error);
+        await sendTextMessage(larkClient, chatId, idType, `❓ ${question}`, replyOptions).catch(console.error);
       },
 
       async onDone(result) {
@@ -335,11 +336,11 @@ export class FeishuAdapter implements PlatformAdapter {
             }
           }
 
-          await sendCardMessage(larkClient, chatId, idType, buildDoneCard(result)).catch((err) => {
+          await sendCardMessage(larkClient, chatId, idType, buildDoneCard(result), replyOptions).catch((err) => {
             console.error('[feishu] Failed to send done card fallback:', err);
           });
         } else {
-          await sendTextMessage(larkClient, chatId, idType, result || '✅ Done').catch(console.error);
+          await sendTextMessage(larkClient, chatId, idType, result || '✅ Done', replyOptions).catch(console.error);
         }
 
         if (sourceMessageId) {
@@ -362,11 +363,11 @@ export class FeishuAdapter implements PlatformAdapter {
             }
           }
 
-          await sendCardMessage(larkClient, chatId, idType, buildErrorCard(err.message)).catch((sendErr) => {
+          await sendCardMessage(larkClient, chatId, idType, buildErrorCard(err.message), replyOptions).catch((sendErr) => {
             console.error('[feishu] Failed to send error card fallback:', sendErr);
           });
         } else {
-          await sendTextMessage(larkClient, chatId, idType, `❌ ${err.message}`).catch(console.error);
+          await sendTextMessage(larkClient, chatId, idType, `❌ ${err.message}`, replyOptions).catch(console.error);
         }
       },
     };

--- a/apps/remote-server/src/adapters/feishu/client.ts
+++ b/apps/remote-server/src/adapters/feishu/client.ts
@@ -115,6 +115,49 @@ async function uploadImageToFeishu(imagePath: string, mimeType?: string): Promis
 
 type ReceiveIdType = 'open_id' | 'chat_id' | 'user_id' | 'union_id' | 'email';
 
+interface SendMessageOptions {
+  replyToMessageId?: string;
+}
+
+function normalizeReplyToMessageId(options?: SendMessageOptions): string | undefined {
+  const replyToMessageId = options?.replyToMessageId?.trim();
+  return replyToMessageId || undefined;
+}
+
+async function replyMessage(
+  messageId: string,
+  msgType: 'text' | 'interactive' | 'image',
+  content: string,
+): Promise<string> {
+  const token = await getTenantAccessToken();
+  const response = await fetch(
+    `${getFeishuBaseUrl()}/open-apis/im/v1/messages/${encodeURIComponent(messageId)}/reply`,
+    {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        msg_type: msgType,
+        content,
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Failed to reply message in Feishu: ${response.status} ${response.statusText} - ${body}`);
+  }
+
+  const payload = (await response.json()) as FeishuApiResponse<{ message_id?: string }>;
+  if (payload.code !== 0) {
+    throw new Error(`Failed to reply message in Feishu: ${payload.msg || 'unknown error'}`);
+  }
+
+  return payload.data?.message_id ?? '';
+}
+
 /**
  * Upload a local image and send it as a Feishu image message.
  * Returns the message_id of the sent message.
@@ -124,9 +167,19 @@ export async function sendImageMessage(
   receiveIdType: ReceiveIdType,
   imagePath: string,
   mimeType?: string,
+  options?: SendMessageOptions,
 ): Promise<string> {
   const imageKey = await uploadImageToFeishu(imagePath, mimeType);
   const token = await getTenantAccessToken();
+  const replyToMessageId = normalizeReplyToMessageId(options);
+  const content = JSON.stringify({ image_key: imageKey });
+  if (replyToMessageId) {
+    try {
+      return await replyMessage(replyToMessageId, 'image', content);
+    } catch (err) {
+      console.error('[feishu] Failed to reply image message, falling back to create:', err);
+    }
+  }
 
   const response = await fetch(
     `${getFeishuBaseUrl()}/open-apis/im/v1/messages?receive_id_type=${encodeURIComponent(receiveIdType)}`,
@@ -139,7 +192,7 @@ export async function sendImageMessage(
       body: JSON.stringify({
         receive_id: receiveId,
         msg_type: 'image',
-        content: JSON.stringify({ image_key: imageKey }),
+        content,
       }),
     },
   );
@@ -201,13 +254,24 @@ export async function sendTextMessage(
   receiveId: string,
   receiveIdType: ReceiveIdType,
   text: string,
+  options?: SendMessageOptions,
 ): Promise<string> {
+  const replyToMessageId = normalizeReplyToMessageId(options);
+  const content = JSON.stringify({ text });
+  if (replyToMessageId) {
+    try {
+      return await replyMessage(replyToMessageId, 'text', content);
+    } catch (err) {
+      console.error('[feishu] Failed to reply text message, falling back to create:', err);
+    }
+  }
+
   const res = await client.im.message.create({
     params: { receive_id_type: receiveIdType },
     data: {
       receive_id: receiveId,
       msg_type: 'text',
-      content: JSON.stringify({ text }),
+      content,
     },
   });
   if (typeof res.code === 'number' && res.code !== 0) {
@@ -224,13 +288,24 @@ export async function sendCardMessage(
   receiveId: string,
   receiveIdType: ReceiveIdType,
   card: object,
+  options?: SendMessageOptions,
 ): Promise<string> {
+  const replyToMessageId = normalizeReplyToMessageId(options);
+  const content = JSON.stringify(card);
+  if (replyToMessageId) {
+    try {
+      return await replyMessage(replyToMessageId, 'interactive', content);
+    } catch (err) {
+      console.error('[feishu] Failed to reply card message, falling back to create:', err);
+    }
+  }
+
   const res = await client.im.message.create({
     params: { receive_id_type: receiveIdType },
     data: {
       receive_id: receiveId,
       msg_type: 'interactive',
-      content: JSON.stringify(card),
+      content,
     },
   });
   if (typeof res.code === 'number' && res.code !== 0) {


### PR DESCRIPTION
Support Feishu topic-group replies by preserving source message context and replying to the original message when sending bot output.

- Add optional reply target support to Feishu text, card, and image send helpers
- Route thinking, clarification, generated image, done, and error messages through reply API when a source message is available
- Fall back to normal message creation if reply delivery fails to preserve existing behavior

Validation:
- Passed: node --check apps/remote-server/src/adapters/feishu/client.ts && node --check apps/remote-server/src/adapters/feishu/adapter.ts
- Blocked: pnpm --filter @pulse-coder/remote-server build (managed worktree is missing node_modules/tsup before remote-server code is built)