### PR TITLE
feat(feishu): add long-connection events

### DIFF
--- a/apps/remote-server/.env.example
+++ b/apps/remote-server/.env.example
@@ -56,8 +56,12 @@ FEISHU_APP_ID=
 FEISHU_APP_SECRET=
 FEISHU_ENCRYPT_KEY=
 FEISHU_VERIFICATION_TOKEN=
+# webhook (default) | long_connection | both
+FEISHU_EVENT_SOURCE=webhook
 # Optional custom Feishu Open API base URL (default: https://open.feishu.cn)
 FEISHU_API_BASE_URL=
+# Optional: true, false, or group. Default false because reactions need extra permissions.
+FEISHU_ENABLE_REACTIONS=
 
 # === Discord ===
 DISCORD_PUBLIC_KEY=

--- a/apps/remote-server/README.md
+++ b/apps/remote-server/README.md
@@ -14,7 +14,7 @@ HTTP server that wraps `pulse-coder-engine` and exposes it to messaging platform
 | Method | Path | Access |
 |--------|------|--------|
 | `GET` | `/health` | Public |
-| `POST` | `/webhooks/feishu` | Public (HMAC-verified) |
+| `POST` | `/webhooks/feishu` | Public Feishu event webhook |
 | `POST` | `/webhooks/discord` | Public (ED25519-verified) |
 | `POST` | `/internal/agent/run` | Loopback + Bearer token |
 | `GET` | `/internal/discord/gateway/status` | Loopback + Bearer token |
@@ -56,6 +56,8 @@ FEISHU_APP_ID=
 FEISHU_APP_SECRET=
 FEISHU_ENCRYPT_KEY=
 FEISHU_VERIFICATION_TOKEN=
+FEISHU_EVENT_SOURCE=webhook  # webhook (default), long_connection, or both
+FEISHU_ENABLE_REACTIONS=     # Optional: true, false, or group; default false
 
 # === Discord ===
 DISCORD_PUBLIC_KEY=
@@ -98,14 +100,16 @@ Users can type these in any connected channel:
 ## Feishu Setup
 
 1. In the Feishu Developer Console, create an app and note `App ID` / `App Secret`.
-2. Enable **Encrypt Key** and **Verification Token** (Event Subscription → Security Settings).
-3. Set the webhook URL:
+2. Subscribe to the event `im.message.receive_v1`.
+3. Grant bot permissions: `im:message:send_as_bot`, `im:message.group_at_msg` (for group chats). Message reactions are optional; set `FEISHU_ENABLE_REACTIONS=true` or `group` only after granting reaction permissions.
+4. Set `FEISHU_APP_ID` and `FEISHU_APP_SECRET` in `.env`.
+5. Pick the event receiver:
+   - `FEISHU_EVENT_SOURCE=long_connection`: use Feishu's persistent WebSocket connection. In the Feishu Developer Console, set event subscription mode to **Receive events through persistent connection**. The webhook route remains mounted but only returns an empty 200 response.
+   - `FEISHU_EVENT_SOURCE=webhook`: use the public webhook endpoint. Set `FEISHU_ENCRYPT_KEY` and `FEISHU_VERIFICATION_TOKEN`, enable them in Event Subscription security settings, then set the webhook URL:
    ```
    https://your-server/webhooks/feishu
    ```
-4. Subscribe to the event `im.message.receive_v1`.
-5. Grant bot permissions: `im:message:send_as_bot`, `im:message.group_at_msg` (for group chats).
-6. Set `FEISHU_APP_ID`, `FEISHU_APP_SECRET`, `FEISHU_ENCRYPT_KEY`, `FEISHU_VERIFICATION_TOKEN` in `.env`.
+   - `FEISHU_EVENT_SOURCE=both`: start the long-connection client while keeping webhook ingestion active for migration. Duplicate events with the same `message_id` are ignored in-process.
 
 ## Discord Setup
 

--- a/apps/remote-server/docs/runbook.md
+++ b/apps/remote-server/docs/runbook.md
@@ -31,6 +31,16 @@ Minimum runtime configuration depends on the platform being exercised:
 
 Model overrides are read from `.pulse-coder/config.json` or `$PULSE_CODER_MODEL_CONFIG`; this is runtime config, not repository harness source of truth.
 
+## Feishu Event Receiver
+
+`FEISHU_EVENT_SOURCE` controls how Feishu events enter the process:
+
+- `webhook` (default): Feishu posts events to `/webhooks/feishu`.
+- `long_connection`: the process starts the Feishu SDK `WSClient` and receives events over a persistent WebSocket connection; `/webhooks/feishu` stays mounted but only returns an empty 200 response.
+- `both`: both receivers are enabled for migration; duplicate `message_id` values are ignored in-process.
+
+When using `long_connection`, set the Feishu Developer Console event subscription mode to persistent connection. The process needs outbound network access to Feishu, but no public inbound webhook URL. Feishu long-connection delivery is clustered, so only run one active receiver per app unless random distribution across instances is acceptable.
+
 ## Smoke Checks
 
 ### Health
@@ -56,6 +66,7 @@ Adjust payload to match `src/routes/internal.ts`.
 
 - `/internal/*` routes must require loopback IP and bearer token.
 - Platform webhooks should ack quickly before long-running agent work.
+- Feishu long-connection handlers should return quickly; parsed messages must still enter the shared dispatcher asynchronously.
 - Per-platform concurrency guard should remain active.
 - Session, memory, and worktree state are stored under user-level `~/.pulse-coder/*` directories.
 - Adapter `StreamHandle` callbacks own platform-specific output behavior.

--- a/apps/remote-server/ecosystem.config.cjs
+++ b/apps/remote-server/ecosystem.config.cjs
@@ -29,6 +29,7 @@ module.exports = {
         NO_PROXY: '127.0.0.1,localhost,::1,156.238.254.16',
         ACP_RETRY_MAX: '3',
         ACP_RETRY_BASE_DELAY_MS: '1000',
+        FEISHU_EVENT_SOURCE: 'long_connection',
       },
     },
   ],

--- a/apps/remote-server/src/adapters/feishu/adapter.ts
+++ b/apps/remote-server/src/adapters/feishu/adapter.ts
@@ -34,9 +34,13 @@ export class FeishuAdapter implements PlatformAdapter {
   // SDK Client — handles token refresh, retries, domain routing
   private larkClient = createLarkClient();
 
-  // Map from platformKey -> { chatId, chatIdType }
+  // Map from stream/message id -> message target metadata.
+  // Set during parseIncoming, read in createStreamHandle.
+  private chatMetaByStreamId = new Map<string, FeishuChatMeta>();
+
+  // Fallback map for payloads without message_id.
   // Set during parseIncoming, read in createStreamHandle
-  private chatMeta = new Map<string, { chatId: string; chatIdType: 'open_id' | 'chat_id'; sourceMessageId?: string }>();
+  private chatMetaByPlatformKey = new Map<string, FeishuChatMeta>();
 
   // Dedup cache — prevent processing the same message_id twice
   private seenMessageIds = new Set<string>();
@@ -53,14 +57,19 @@ export class FeishuAdapter implements PlatformAdapter {
       return null;
     }
 
+    return this.parseEventBody(body);
+  }
+
+  async parseEventBody(body: Record<string, unknown>): Promise<IncomingMessage | null> {
     // URL verification
     if (body['type'] === 'url_verification') {
       this.pendingChallenge = body['challenge'] as string;
       return null;
     }
 
-    // Extract event — supports both v1 (type: "event_callback") and v2 (schema: "2.0")
-    const event = body['event'] as Record<string, unknown> | undefined;
+    // Extract event. Webhook payloads wrap it in `event`; SDK long-connection
+    // handlers receive the event object directly after EventDispatcher parsing.
+    const event = extractFeishuEvent(body);
     if (!event) return null;
 
     const message = event['message'] as Record<string, unknown> | undefined;
@@ -92,32 +101,43 @@ export class FeishuAdapter implements PlatformAdapter {
 
     const chatId = message['chat_id'] as string | undefined;
     const chatType = message['chat_type'] as string | undefined; // 'p2p' | 'group'
+    const isGroupChat = chatType === 'group';
 
     // Group chats: only respond when @mentioned
-    if (chatType === 'group') {
+    if (isGroupChat) {
       const mentions = (message['mentions'] as unknown[] | undefined) ?? [];
       if (mentions.length === 0) return null;
-      text = text.replace(/@\S+/g, '').trim();
+      text = removeFeishuMentions(text, mentions);
       if (!text) return null;
     }
 
-    const platformKey = chatType === 'group' && chatId
+    const platformKey = isGroupChat && chatId
       ? `feishu:group:${chatId}:${openId}`
       : `feishu:${openId}`;
     const memoryKey = `feishu:user:${openId}`;
 
-    if (messageId) {
+    if (messageId && shouldAddFeishuReactions(isGroupChat)) {
       // Best-effort acknowledgement reaction for accepted user messages.
       addMessageReaction(messageId, 'Get').catch((err) => {
-        console.error('[feishu] Failed to add Get reaction:', err);
+        console.warn('[feishu] Failed to add Get reaction:', getErrorMessage(err));
       });
     }
 
-    this.chatMeta.set(platformKey, {
-      chatId: chatId ?? openId,
-      chatIdType: chatId ? 'chat_id' : 'open_id',
+    const meta = resolveFeishuChatMeta({
+      chatId,
+      chatType,
+      openId,
       sourceMessageId: messageId,
     });
+    const chatMeta = {
+      ...meta,
+      allowReaction: shouldAddFeishuReactions(isGroupChat),
+    };
+    this.chatMetaByPlatformKey.set(platformKey, chatMeta);
+    if (messageId) {
+      this.chatMetaByStreamId.set(messageId, chatMeta);
+      pruneMap(this.chatMetaByStreamId, 500);
+    }
 
     // Route to pending clarification if one is waiting
     const activeStreamId = getActiveStreamId(platformKey);
@@ -125,14 +145,20 @@ export class FeishuAdapter implements PlatformAdapter {
       const pending = clarificationQueue.getPending(activeStreamId);
       if (pending) {
         clarificationQueue.submitAnswer(activeStreamId, pending.request.id, text);
-        const sendTo = chatId ?? openId;
-        const idType: 'chat_id' | 'open_id' = chatId ? 'chat_id' : 'open_id';
-        await sendTextMessage(this.larkClient, sendTo, idType, `✅ Got it: "${text}"`, messageId ? { replyToMessageId: messageId } : undefined).catch(console.error);
+        await sendTextMessage(
+          this.larkClient,
+          meta.chatId,
+          meta.chatIdType,
+          `✅ Got it: "${text}"`,
+          meta.chatIdType === 'chat_id' && messageId ? { replyToMessageId: messageId } : undefined,
+        ).catch((err) => {
+          console.error('[feishu] Failed to send clarification ack:', getErrorMessage(err));
+        });
       }
       return null;
     }
 
-    return { platformKey, memoryKey, text };
+    return { platformKey, memoryKey, text, streamId: messageId };
   }
 
   // URL verification challenge to return in ackRequest
@@ -148,15 +174,24 @@ export class FeishuAdapter implements PlatformAdapter {
   }
 
   async createStreamHandle(incoming: IncomingMessage, _streamId: string): Promise<StreamHandle> {
-    const meta = this.chatMeta.get(incoming.platformKey);
+    const meta = this.chatMetaByStreamId.get(_streamId)
+      ?? (incoming.streamId ? this.chatMetaByStreamId.get(incoming.streamId) : undefined)
+      ?? this.chatMetaByPlatformKey.get(incoming.platformKey);
     const chatId = meta?.chatId ?? incoming.platformKey.replace('feishu:', '');
     const idType = meta?.chatIdType ?? 'open_id';
     const sourceMessageId = meta?.sourceMessageId;
-    const replyOptions = sourceMessageId ? { replyToMessageId: sourceMessageId } : undefined;
+    const allowReaction = meta?.allowReaction ?? false;
+    const replyOptions = idType === 'chat_id' && sourceMessageId ? { replyToMessageId: sourceMessageId } : undefined;
     const { larkClient } = this;
 
     // Clean up chatMeta after reading — it's only needed to bridge parseIncoming → createStreamHandle
-    this.chatMeta.delete(incoming.platformKey);
+    this.chatMetaByStreamId.delete(_streamId);
+    if (incoming.streamId && incoming.streamId !== _streamId) {
+      this.chatMetaByStreamId.delete(incoming.streamId);
+    }
+    if (meta && this.chatMetaByPlatformKey.get(incoming.platformKey) === meta) {
+      this.chatMetaByPlatformKey.delete(incoming.platformKey);
+    }
 
     let cardMessageId: string | null = null;
     let accumulatedText = '';
@@ -280,14 +315,21 @@ export class FeishuAdapter implements PlatformAdapter {
       clearHeartbeat();
     };
 
-    // Send initial "thinking" card
-    try {
-      cardMessageId = await sendCardMessage(larkClient, chatId, idType, buildThinkingCard(), replyOptions);
-      lastProgressUpdateAt = Date.now();
-      startHeartbeat();
-    } catch (err) {
-      console.error('[feishu] Failed to send thinking card:', err);
-    }
+    // Send the initial progress card without blocking model startup.
+    updateChain = sendCardMessage(larkClient, chatId, idType, buildThinkingCard(), replyOptions)
+      .then((messageId) => {
+        cardMessageId = messageId;
+        lastProgressUpdateAt = Date.now();
+        if (!finalized) {
+          startHeartbeat();
+          if (accumulatedText || latestToolHint) {
+            scheduleProgressUpdate(true);
+          }
+        }
+      })
+      .catch((err) => {
+        console.error('[feishu] Failed to send thinking card:', getErrorMessage(err));
+      });
 
 
     const sentImagePaths = new Set<string>();
@@ -357,9 +399,9 @@ export class FeishuAdapter implements PlatformAdapter {
           await sendTextMessage(larkClient, chatId, idType, result || '✅ Done', replyOptions).catch(console.error);
         }
 
-        if (sourceMessageId) {
+        if (sourceMessageId && allowReaction) {
           addMessageReaction(sourceMessageId, 'DONE').catch((reactionErr) => {
-            console.error('[feishu] Failed to add DONE reaction:', reactionErr);
+            console.warn('[feishu] Failed to add DONE reaction:', getErrorMessage(reactionErr));
           });
         }
       },
@@ -398,6 +440,122 @@ function rememberToolCall(toolCallSummaries: string[], summary: string): void {
   if (toolCallSummaries.length > maxToolCalls) {
     toolCallSummaries.splice(0, toolCallSummaries.length - maxToolCalls);
   }
+}
+
+function pruneMap<K, V>(map: Map<K, V>, maxSize: number): void {
+  while (map.size > maxSize) {
+    map.delete(map.keys().next().value!);
+  }
+}
+
+interface FeishuChatMeta {
+  chatId: string;
+  chatIdType: 'open_id' | 'chat_id';
+  sourceMessageId?: string;
+  allowReaction?: boolean;
+}
+
+function extractFeishuEvent(body: Record<string, unknown>): Record<string, unknown> | null {
+  const wrappedEvent = body['event'];
+  if (isRecord(wrappedEvent)) {
+    return wrappedEvent;
+  }
+
+  if (isRecord(body['message']) && isRecord(body['sender'])) {
+    return body;
+  }
+
+  return null;
+}
+
+function resolveFeishuChatMeta(input: {
+  chatId?: string;
+  chatType?: string;
+  openId: string;
+  sourceMessageId?: string;
+}): FeishuChatMeta {
+  if (input.chatType === 'group' && input.chatId) {
+    return {
+      chatId: input.chatId,
+      chatIdType: 'chat_id',
+      sourceMessageId: input.sourceMessageId,
+    };
+  }
+
+  return {
+    chatId: input.openId,
+    chatIdType: 'open_id',
+    sourceMessageId: input.sourceMessageId,
+  };
+}
+
+function shouldAddFeishuReactions(isGroupChat: boolean): boolean {
+  const value = process.env.FEISHU_ENABLE_REACTIONS?.trim().toLowerCase();
+  if (value === 'true' || value === '1' || value === 'yes') {
+    return true;
+  }
+  if (value === 'group' || value === 'groups') {
+    return isGroupChat;
+  }
+  if (value === 'false' || value === '0' || value === 'no') {
+    return false;
+  }
+
+  return false;
+}
+
+function getErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function removeFeishuMentions(text: string, mentions: unknown[]): string {
+  const mentionTexts = collectFeishuMentionTexts(mentions);
+  let normalized = text;
+
+  for (const mentionText of mentionTexts) {
+    normalized = normalized.replace(new RegExp(escapeRegExp(mentionText), 'g'), ' ');
+  }
+
+  return normalized.replace(/\s+/g, ' ').trim();
+}
+
+function collectFeishuMentionTexts(mentions: unknown[]): string[] {
+  const values = new Set<string>();
+
+  for (const mention of mentions) {
+    if (!isRecord(mention)) {
+      continue;
+    }
+
+    const key = asNonEmptyString(mention.key);
+    if (key) {
+      values.add(key);
+    }
+
+    const name = asNonEmptyString(mention.name);
+    if (name) {
+      values.add(name.startsWith('@') ? name : `@${name}`);
+    }
+  }
+
+  return [...values].sort((a, b) => b.length - a.length);
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function formatFeishuToolHint(name: string, input: unknown): string {

--- a/apps/remote-server/src/adapters/feishu/client.ts
+++ b/apps/remote-server/src/adapters/feishu/client.ts
@@ -90,12 +90,16 @@ async function uploadImageToFeishu(imagePath: string, mimeType?: string): Promis
   formData.append('image_type', 'message');
   formData.append('image', new Blob([imageBuffer], { type: mimeType || 'image/png' }), filename);
 
-  const response = await fetch(`${getFeishuBaseUrl()}/open-apis/im/v1/images`, {
-    method: 'POST',
-    headers: {
-      authorization: `Bearer ${token}`,
+  const response = await fetchFeishuWithRetry({
+    url: `${getFeishuBaseUrl()}/open-apis/im/v1/images`,
+    init: {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+      body: formData,
     },
-    body: formData,
+    action: 'upload image',
   });
 
   if (!response.ok) {
@@ -123,6 +127,8 @@ interface SendMessageOptions {
   replyToMessageId?: string;
 }
 
+const FEISHU_API_MAX_ATTEMPTS = 3;
+
 function normalizeReplyToMessageId(options?: SendMessageOptions): string | undefined {
   const replyToMessageId = options?.replyToMessageId?.trim();
   return replyToMessageId || undefined;
@@ -134,9 +140,9 @@ async function replyMessage(
   content: string,
 ): Promise<string> {
   const token = await getTenantAccessToken();
-  const response = await fetch(
-    `${getFeishuBaseUrl()}/open-apis/im/v1/messages/${encodeURIComponent(messageId)}/reply`,
-    {
+  const response = await fetchFeishuWithRetry({
+    url: `${getFeishuBaseUrl()}/open-apis/im/v1/messages/${encodeURIComponent(messageId)}/reply`,
+    init: {
       method: 'POST',
       headers: {
         authorization: `Bearer ${token}`,
@@ -147,7 +153,8 @@ async function replyMessage(
         content,
       }),
     },
-  );
+    action: 'reply message',
+  });
 
   if (!response.ok) {
     const body = await response.text();
@@ -185,9 +192,9 @@ export async function sendImageMessage(
     }
   }
 
-  const response = await fetch(
-    `${getFeishuBaseUrl()}/open-apis/im/v1/messages?receive_id_type=${encodeURIComponent(receiveIdType)}`,
-    {
+  const response = await fetchFeishuWithRetry({
+    url: `${getFeishuBaseUrl()}/open-apis/im/v1/messages?receive_id_type=${encodeURIComponent(receiveIdType)}`,
+    init: {
       method: 'POST',
       headers: {
         authorization: `Bearer ${token}`,
@@ -199,7 +206,8 @@ export async function sendImageMessage(
         content,
       }),
     },
-  );
+    action: 'send image message',
+  });
 
   if (!response.ok) {
     const body = await response.text();
@@ -224,9 +232,9 @@ export async function addMessageReaction(messageId: string, emojiType: string): 
     throw new Error('emojiType is required');
   }
 
-  const response = await fetch(
-    `${getFeishuBaseUrl()}/open-apis/im/v1/messages/${encodeURIComponent(messageId)}/reactions`,
-    {
+  const response = await fetchFeishuWithRetry({
+    url: `${getFeishuBaseUrl()}/open-apis/im/v1/messages/${encodeURIComponent(messageId)}/reactions`,
+    init: {
       method: 'POST',
       headers: {
         authorization: `Bearer ${token}`,
@@ -236,7 +244,8 @@ export async function addMessageReaction(messageId: string, emojiType: string): 
         reaction_type: { emoji_type: normalizedEmojiType },
       }),
     },
-  );
+    action: 'add message reaction',
+  });
 
   if (!response.ok) {
     const body = await response.text();
@@ -270,14 +279,14 @@ export async function sendTextMessage(
     }
   }
 
-  const res = await client.im.message.create({
+  const res = await retryFeishuOperation('send text message', () => client.im.message.create({
     params: { receive_id_type: receiveIdType },
     data: {
       receive_id: receiveId,
       msg_type: 'text',
       content,
     },
-  });
+  }));
   if (typeof res.code === 'number' && res.code !== 0) {
     throw new Error(`Feishu send text failed: ${res.code} ${res.msg ?? 'unknown error'}`);
   }
@@ -305,14 +314,14 @@ export async function sendCardMessage(
     }
   }
 
-  const res = await client.im.message.create({
+  const res = await retryFeishuOperation('send card message', () => client.im.message.create({
     params: { receive_id_type: receiveIdType },
     data: {
       receive_id: receiveId,
       msg_type: 'interactive',
       content,
     },
-  });
+  }));
   if (typeof res.code === 'number' && res.code !== 0) {
     throw new Error(`Feishu send card failed: ${res.code} ${res.msg ?? 'unknown error'}`);
   }
@@ -327,13 +336,119 @@ export async function updateCardMessage(
   messageId: string,
   card: object,
 ): Promise<void> {
-  const res = await client.im.message.patch({
+  const res = await retryFeishuOperation('update card message', () => client.im.message.patch({
     path: { message_id: messageId },
     data: { content: JSON.stringify(card) },
-  });
+  }));
   if (typeof res.code === 'number' && res.code !== 0) {
     throw new Error(`Feishu update card failed: ${res.code} ${res.msg ?? 'unknown error'}`);
   }
+}
+
+async function fetchFeishuWithRetry(input: {
+  url: string;
+  init: RequestInit;
+  action: string;
+}): Promise<Response> {
+  return retryFeishuOperation(input.action, async () => {
+    const response = await fetch(input.url, input.init);
+    if (isRetriableStatus(response.status)) {
+      throw new RetriableFeishuResponseError(input.action, response.status, response.statusText);
+    }
+    return response;
+  });
+}
+
+async function retryFeishuOperation<T>(action: string, operation: () => Promise<T>): Promise<T> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= FEISHU_API_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      return await operation();
+    } catch (err) {
+      lastError = err;
+      if (attempt >= FEISHU_API_MAX_ATTEMPTS || !isRetriableFeishuError(err)) {
+        throw err;
+      }
+
+      const delayMs = getRetryDelayMs(attempt);
+      console.warn(
+        `[feishu] ${action} failed transiently; retrying ${attempt + 1}/${FEISHU_API_MAX_ATTEMPTS} in ${delayMs}ms: ${getErrorMessage(err)}`,
+      );
+      await sleep(delayMs);
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+class RetriableFeishuResponseError extends Error {
+  constructor(
+    action: string,
+    readonly status: number,
+    statusText: string,
+  ) {
+    super(`Feishu ${action} failed transiently: ${status} ${statusText}`);
+  }
+}
+
+function isRetriableFeishuError(err: unknown): boolean {
+  if (err instanceof RetriableFeishuResponseError) {
+    return true;
+  }
+
+  const status = readNumericPath(err, 'response', 'status') ?? readNumericPath(err, 'status');
+  if (typeof status === 'number') {
+    return isRetriableStatus(status);
+  }
+
+  const code = readStringPath(err, 'code');
+  if (code && ['ECONNRESET', 'ETIMEDOUT', 'EAI_AGAIN', 'ENOTFOUND', 'ECONNREFUSED'].includes(code)) {
+    return true;
+  }
+
+  const message = getErrorMessage(err).toLowerCase();
+  return message.includes('socket hang up')
+    || message.includes('fetch failed')
+    || message.includes('network')
+    || message.includes('timeout');
+}
+
+function isRetriableStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+function getRetryDelayMs(attempt: number): number {
+  return 350 * 2 ** (attempt - 1);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function readNumericPath(value: unknown, ...path: string[]): number | undefined {
+  const found = readPath(value, ...path);
+  return typeof found === 'number' ? found : undefined;
+}
+
+function readStringPath(value: unknown, ...path: string[]): string | undefined {
+  const found = readPath(value, ...path);
+  return typeof found === 'string' ? found : undefined;
+}
+
+function readPath(value: unknown, ...path: string[]): unknown {
+  let current = value;
+  for (const key of path) {
+    if (typeof current !== 'object' || current === null) {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}
+
+function getErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 // ─── Card builders ────────────────────────────────────────────────────────────

--- a/apps/remote-server/src/adapters/feishu/gateway.ts
+++ b/apps/remote-server/src/adapters/feishu/gateway.ts
@@ -1,0 +1,80 @@
+import * as lark from '@larksuiteoapi/node-sdk';
+import { dispatchIncoming } from '../../core/dispatcher.js';
+import { feishuAdapter } from './adapter.js';
+
+type FeishuEventSource = 'webhook' | 'long_connection' | 'both';
+
+let wsClient: lark.WSClient | null = null;
+let started = false;
+
+export function getFeishuEventSource(): FeishuEventSource {
+  const value = process.env.FEISHU_EVENT_SOURCE?.trim().toLowerCase();
+
+  if (value === 'long_connection' || value === 'long-connection' || value === 'ws' || value === 'websocket') {
+    return 'long_connection';
+  }
+
+  if (value === 'both') {
+    return 'both';
+  }
+
+  return 'webhook';
+}
+
+export function shouldStartFeishuLongConnection(source = getFeishuEventSource()): boolean {
+  return source === 'long_connection' || source === 'both';
+}
+
+export function startFeishuLongConnection(): void {
+  if (started) {
+    return;
+  }
+
+  const source = getFeishuEventSource();
+  if (!shouldStartFeishuLongConnection(source)) {
+    console.log('[feishu-ws] Long-connection listener disabled by FEISHU_EVENT_SOURCE=webhook');
+    return;
+  }
+
+  const appId = process.env.FEISHU_APP_ID?.trim();
+  const appSecret = process.env.FEISHU_APP_SECRET?.trim();
+  if (!appId || !appSecret) {
+    console.log('[feishu-ws] Long-connection listener disabled: FEISHU_APP_ID/FEISHU_APP_SECRET are not set');
+    return;
+  }
+
+  started = true;
+
+  const eventDispatcher = new lark.EventDispatcher({
+    loggerLevel: lark.LoggerLevel.info,
+  }).register({
+    'im.message.receive_v1': async (data) => {
+      const incoming = await feishuAdapter.parseEventBody(data as Record<string, unknown>);
+      if (!incoming) {
+        return;
+      }
+
+      dispatchIncoming(feishuAdapter, incoming);
+    },
+  });
+
+  wsClient = new lark.WSClient({
+    appId,
+    appSecret,
+    domain: lark.Domain.Feishu,
+    loggerLevel: lark.LoggerLevel.info,
+  });
+
+  void wsClient.start({ eventDispatcher }).catch((err) => {
+    started = false;
+    console.error('[feishu-ws] Failed to start long-connection listener:', err);
+  });
+
+  console.log(`[feishu-ws] Long-connection listener starting (FEISHU_EVENT_SOURCE=${source})`);
+}
+
+export function stopFeishuLongConnection(): void {
+  wsClient?.close({ force: true });
+  wsClient = null;
+  started = false;
+}

--- a/apps/remote-server/src/index.ts
+++ b/apps/remote-server/src/index.ts
@@ -10,6 +10,7 @@ import { vaultIntegration } from './core/vault/integration.js';
 import { devtoolsStore } from './core/devtools.js';
 import { startDiscordGateway } from './adapters/discord/gateway-manager.js';
 import { registerDiscordApplicationCommands } from './adapters/discord/application-commands.js';
+import { getFeishuEventSource, startFeishuLongConnection } from './adapters/feishu/gateway.js';
 
 async function main() {
   // Initialize session store (creates directories if needed, loads index)
@@ -28,6 +29,7 @@ async function main() {
 
   await engine.initialize();
 
+  startFeishuLongConnection();
   startDiscordGateway();
 
   const app = createApp();
@@ -54,7 +56,7 @@ async function main() {
   // console.log(`  POST /api/chat`);
   // console.log(`  GET  /api/stream/:streamId`);
   // console.log(`  POST /api/clarify/:streamId`);
-  console.log(`  POST /webhooks/feishu`);
+  console.log(`  POST /webhooks/feishu (FEISHU_EVENT_SOURCE=${getFeishuEventSource()})`);
   console.log(`  POST /webhooks/discord`);
   console.log(`  GET  /internal/discord/gateway/status`);
   console.log(`  POST /internal/discord/gateway/restart`);

--- a/apps/remote-server/src/routes/feishu.ts
+++ b/apps/remote-server/src/routes/feishu.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { dispatch } from '../core/dispatcher.js';
 import { feishuAdapter } from '../adapters/feishu/adapter.js';
+import { getFeishuEventSource } from '../adapters/feishu/gateway.js';
 
 export const feishuRouter = new Hono();
 
@@ -12,4 +13,11 @@ export const feishuRouter = new Hono();
  *   Event subscription URL: https://your-server/webhooks/feishu
  *   Events to subscribe: im.message.receive_v1
  */
-feishuRouter.post('/', (c) => dispatch(feishuAdapter, c));
+feishuRouter.post('/', (c) => {
+  const source = getFeishuEventSource();
+  if (source === 'long_connection') {
+    return c.json({}, 200);
+  }
+
+  return dispatch(feishuAdapter, c);
+});


### PR DESCRIPTION
Add Feishu persistent WebSocket event ingestion for remote-server.\n\n- Add a Feishu WSClient/EventDispatcher gateway for im.message.receive_v1\n- Reuse Feishu adapter parsing, dedup, reply metadata, and dispatcher flow across webhook and long-connection events\n- Gate webhook processing by FEISHU_EVENT_SOURCE and set production PM2 config to long_connection\n- Document webhook, long_connection, and migration modes\n\nValidation:\n- pnpm --filter @pulse-coder/remote-server build\n- PM2 restart with FEISHU_EVENT_SOURCE=long_connection\n- /health returned OK\n- Feishu SDK logged ws client ready