### PR TITLE
feat: add actionable Feishu run cards

### DIFF
--- a/apps/remote-server/src/adapters/feishu/adapter.ts
+++ b/apps/remote-server/src/adapters/feishu/adapter.ts
@@ -3,7 +3,10 @@ import { existsSync } from 'fs';
 import type { PlatformAdapter, IncomingMessage, StreamHandle } from '../../core/types.js';
 import type { ClarificationRequest } from '../../core/types.js';
 import { clarificationQueue } from '../../core/clarification-queue.js';
-import { getActiveStreamId } from '../../core/active-run-store.js';
+import { getActiveRun, getActiveStreamId } from '../../core/active-run-store.js';
+import { dispatchIncoming } from '../../core/dispatcher.js';
+import { processIncomingCommand } from '../../core/chat-commands.js';
+import type { CommandResult } from '../../core/chat-commands/types.js';
 import { extractGeneratedImageResult } from './image-result.js';
 import {
   createLarkClient,
@@ -58,6 +61,69 @@ export class FeishuAdapter implements PlatformAdapter {
     }
 
     return this.parseEventBody(body);
+  }
+
+  async handleCardActionBody(body: Record<string, unknown>): Promise<boolean> {
+    const action = parseRunCardAction(body);
+    if (!action) return false;
+
+    const text = textForRunCardAction(action);
+    if (!text) return true;
+
+    if (action.command === 'runId') {
+      await this.sendCardActionText(action, text);
+      return true;
+    }
+
+    const incoming: IncomingMessage = {
+      platformKey: action.platformKey,
+      memoryKey: action.memoryKey,
+      text,
+      streamId: action.syntheticStreamId,
+    };
+
+    this.chatMetaByPlatformKey.set(action.platformKey, {
+      chatId: action.replyTarget.chatId,
+      chatIdType: action.replyTarget.chatIdType,
+      allowReaction: false,
+    });
+
+    if (action.command === 'retry') {
+      dispatchIncoming(this, incoming);
+      return true;
+    }
+
+    const result = await processIncomingCommand(incoming);
+    await this.sendCardActionResult(action, result);
+    return true;
+  }
+
+  private async sendCardActionText(action: RunCardAction, text: string): Promise<void> {
+    const target = action.replyTarget;
+    await sendTextMessage(
+      this.larkClient,
+      target.chatId,
+      target.chatIdType,
+      text,
+    ).catch((err) => {
+      console.error('[feishu] Failed to send card action text:', getErrorMessage(err));
+    });
+  }
+
+  private async sendCardActionResult(action: RunCardAction, result: CommandResult): Promise<void> {
+    if (result.type !== 'handled') {
+      return;
+    }
+
+    const target = action.replyTarget;
+    await sendTextMessage(
+      this.larkClient,
+      target.chatId,
+      target.chatIdType,
+      result.message,
+    ).catch((err) => {
+      console.error('[feishu] Failed to send card action result:', getErrorMessage(err));
+    });
   }
 
   async parseEventBody(body: Record<string, unknown>): Promise<IncomingMessage | null> {
@@ -183,6 +249,7 @@ export class FeishuAdapter implements PlatformAdapter {
     const allowReaction = meta?.allowReaction ?? false;
     const replyOptions = idType === 'chat_id' && sourceMessageId ? { replyToMessageId: sourceMessageId } : undefined;
     const { larkClient } = this;
+    const activeRun = getActiveRun(incoming.platformKey);
 
     // Clean up chatMeta after reading — it's only needed to bridge parseIncoming → createStreamHandle
     this.chatMetaByStreamId.delete(_streamId);
@@ -200,7 +267,6 @@ export class FeishuAdapter implements PlatformAdapter {
 
     const PROGRESS_UPDATE_INTERVAL_MS = 800;
     const HEARTBEAT_INTERVAL_MS = 12000;
-    const DOT_ANIMATION_STEP_MS = 4000;
     const runStartedAt = Date.now();
 
     let throttleHandle: ReturnType<typeof setTimeout> | null = null;
@@ -258,17 +324,23 @@ export class FeishuAdapter implements PlatformAdapter {
       return minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`;
     };
 
-    const renderProgressText = (): string => {
-      const dotCount = 2 + Math.floor((Date.now() - runStartedAt) / DOT_ANIMATION_STEP_MS) % 3;
-      const loadingTitle = `Pulse 努力生成中${'.'.repeat(dotCount)}`;
-      const detailText = accumulatedText
-        ? (latestToolHint ? `${latestToolHint}\n\n${accumulatedText}` : accumulatedText)
-        : latestToolHint;
-
-      return detailText
-        ? `${loadingTitle}\n\n${detailText}\n\n⏱️ Elapsed: ${formatElapsed()}`
-        : `${loadingTitle}\n\n⏱️ Elapsed: ${formatElapsed()}`;
-    };
+    const buildRunCardContext = (overrides: Partial<{
+      elapsed: string;
+      detailText: string;
+      latestToolHint: string;
+      toolCalls: string[];
+    }> = {}) => ({
+      platformKey: incoming.platformKey,
+      memoryKey: incoming.memoryKey,
+      streamId: _streamId,
+      runId: activeRun?.runId,
+      prompt: incoming.text,
+      elapsed: formatElapsed(),
+      detailText: accumulatedText,
+      latestToolHint,
+      toolCalls: toolCallSummaries,
+      ...overrides,
+    });
 
     const clearScheduledProgress = () => {
       if (throttleHandle) {
@@ -300,7 +372,7 @@ export class FeishuAdapter implements PlatformAdapter {
       }
 
       lastProgressUpdateAt = now;
-      queueCardUpdate(() => buildProgressCard(renderProgressText()), 'progress');
+      queueCardUpdate(() => buildProgressCard(buildRunCardContext()), 'progress');
     };
 
     const startHeartbeat = () => {
@@ -316,7 +388,7 @@ export class FeishuAdapter implements PlatformAdapter {
     };
 
     // Send the initial progress card without blocking model startup.
-    updateChain = sendCardMessage(larkClient, chatId, idType, buildThinkingCard(), replyOptions)
+    updateChain = sendCardMessage(larkClient, chatId, idType, buildThinkingCard(buildRunCardContext()), replyOptions)
       .then((messageId) => {
         cardMessageId = messageId;
         lastProgressUpdateAt = Date.now();
@@ -382,7 +454,7 @@ export class FeishuAdapter implements PlatformAdapter {
         finalized = true;
         await updateChain;
 
-        const doneCard = () => buildDoneCard(result, { toolCalls: toolCallSummaries });
+        const doneCard = () => buildDoneCard(result, { toolCalls: toolCallSummaries, context: buildRunCardContext() });
 
         if (cardMessageId) {
           if (!isCardUpdateDisabled()) {
@@ -413,13 +485,13 @@ export class FeishuAdapter implements PlatformAdapter {
 
         if (cardMessageId) {
           if (!isCardUpdateDisabled()) {
-            const ok = await tryUpdateCard(() => buildErrorCard(err.message), 'error', { allowFinal: true });
+            const ok = await tryUpdateCard(() => buildErrorCard(err.message, buildRunCardContext()), 'error', { allowFinal: true });
             if (ok) {
               return;
             }
           }
 
-          await sendCardMessage(larkClient, chatId, idType, buildErrorCard(err.message), replyOptions).catch((sendErr) => {
+          await sendCardMessage(larkClient, chatId, idType, buildErrorCard(err.message, buildRunCardContext()), replyOptions).catch((sendErr) => {
             console.error('[feishu] Failed to send error card fallback:', sendErr);
           });
         } else {
@@ -598,6 +670,156 @@ function trimFeishuToolInput(value: string): string {
   }
 
   return `${singleLine.slice(0, maxLength - 3)}...`;
+}
+type RunCardCommand = 'status' | 'stop' | 'retry' | 'new' | 'runId';
+
+interface RunCardAction {
+  command: RunCardCommand;
+  platformKey: string;
+  memoryKey?: string;
+  streamId?: string;
+  runId?: string;
+  prompt?: string;
+  syntheticStreamId: string;
+  replyTarget: {
+    chatId: string;
+    chatIdType: 'open_id' | 'chat_id';
+  };
+}
+
+interface FeishuCardActionEvent {
+  open_id?: string;
+  user_id?: string;
+  open_message_id?: string;
+  message_id?: string;
+  operator?: {
+    open_id?: string;
+    user_id?: string;
+    operator_id?: {
+      open_id?: string;
+      user_id?: string;
+    };
+  };
+  context?: {
+    open_message_id?: string;
+    message_id?: string;
+    open_chat_id?: string;
+    chat_id?: string;
+  };
+  action?: {
+    value?: Record<string, unknown>;
+    form_value?: Record<string, unknown>;
+    behaviors?: Array<{ value?: Record<string, unknown> }>;
+  };
+  event?: FeishuCardActionEvent;
+}
+
+function parseRunCardAction(data: unknown): RunCardAction | null {
+  const event = unwrapCardActionEvent(data);
+  const value = cardActionValue(event);
+  if (!value || value.action !== 'pulse.run_card') {
+    return null;
+  }
+
+  const command = asRunCardCommand(value.command);
+  const platformKey = asNonEmptyString(value.platformKey);
+  if (!command || !platformKey) {
+    return null;
+  }
+
+  const openId = event.open_id
+    ?? event.user_id
+    ?? event.operator?.open_id
+    ?? event.operator?.user_id
+    ?? event.operator?.operator_id?.open_id
+    ?? event.operator?.operator_id?.user_id;
+  const actorId = asNonEmptyString(openId);
+  if (actorId && !isRunCardActorAllowed(platformKey, actorId)) {
+    return null;
+  }
+  const chatId = asNonEmptyString(event.context?.open_chat_id)
+    ?? asNonEmptyString(event.context?.chat_id);
+  const replyTarget = platformKey.startsWith('feishu:group:')
+    ? { chatId: chatId ?? parseFeishuGroupChatId(platformKey) ?? '', chatIdType: 'chat_id' as const }
+    : { chatId: asNonEmptyString(openId) ?? parseFeishuOpenId(platformKey) ?? '', chatIdType: 'open_id' as const };
+
+  if (!replyTarget.chatId) {
+    return null;
+  }
+
+  const cardMessageId = event.open_message_id
+    ?? event.message_id
+    ?? event.context?.open_message_id
+    ?? event.context?.message_id
+    ?? 'card';
+  const streamId = asNonEmptyString(value.streamId);
+  const runId = asNonEmptyString(value.runId);
+
+  return {
+    command,
+    platformKey,
+    memoryKey: asNonEmptyString(value.memoryKey) ?? undefined,
+    streamId: streamId ?? undefined,
+    runId: runId ?? undefined,
+    prompt: asNonEmptyString(value.prompt) ?? undefined,
+    syntheticStreamId: `feishu-card:${cardMessageId}:${actorId ?? 'unknown'}:${command}:${streamId ?? runId ?? Date.now()}`,
+    replyTarget,
+  };
+}
+
+function textForRunCardAction(action: RunCardAction): string | null {
+  switch (action.command) {
+    case 'status':
+      return '/status';
+    case 'stop':
+      return '/stop';
+    case 'new':
+      return '/new';
+    case 'retry':
+      return action.prompt?.trim() || null;
+    case 'runId':
+      return action.runId
+        ? `Run ID: ${action.runId}\nStream ID: ${action.streamId ?? '-'}`
+        : `Stream ID: ${action.streamId ?? '-'}`;
+  }
+}
+
+function unwrapCardActionEvent(data: unknown): FeishuCardActionEvent {
+  const event = data as FeishuCardActionEvent;
+  return event.event ?? event;
+}
+
+function cardActionValue(event: FeishuCardActionEvent): Record<string, unknown> | null {
+  const direct = event.action?.value;
+  if (direct && typeof direct === 'object') return direct;
+  const behaviorValue = event.action?.behaviors?.find((behavior) => behavior.value)?.value;
+  return behaviorValue && typeof behaviorValue === 'object' ? behaviorValue : null;
+}
+
+function asRunCardCommand(value: unknown): RunCardCommand | null {
+  if (value === 'status' || value === 'stop' || value === 'retry' || value === 'new' || value === 'runId') {
+    return value;
+  }
+  return null;
+}
+
+function isRunCardActorAllowed(platformKey: string, actorOpenId: string): boolean {
+  const groupMatch = /^feishu:group:[^:]+:([^:]+)$/.exec(platformKey);
+  if (groupMatch) {
+    return groupMatch[1] === actorOpenId;
+  }
+  const dmMatch = /^feishu:([^:]+)$/.exec(platformKey);
+  return !dmMatch || dmMatch[1] === actorOpenId;
+}
+
+function parseFeishuGroupChatId(platformKey: string): string | null {
+  const match = /^feishu:group:([^:]+):/.exec(platformKey);
+  return match?.[1] ?? null;
+}
+
+function parseFeishuOpenId(platformKey: string): string | null {
+  const match = /^feishu:([^:]+)$/.exec(platformKey);
+  return match?.[1] ?? null;
 }
 
 

--- a/apps/remote-server/src/adapters/feishu/client.ts
+++ b/apps/remote-server/src/adapters/feishu/client.ts
@@ -119,8 +119,21 @@ async function uploadImageToFeishu(imagePath: string, mimeType?: string): Promis
 
 type ReceiveIdType = 'open_id' | 'chat_id' | 'user_id' | 'union_id' | 'email';
 
+interface RunCardContext {
+  platformKey: string;
+  memoryKey?: string;
+  streamId: string;
+  runId?: string;
+  prompt?: string;
+  elapsed?: string;
+  detailText?: string;
+  latestToolHint?: string;
+  toolCalls?: string[];
+}
+
 interface DoneCardOptions {
   toolCalls?: string[];
+  context?: RunCardContext;
 }
 
 interface SendMessageOptions {
@@ -453,28 +466,129 @@ function getErrorMessage(err: unknown): string {
 
 // ─── Card builders ────────────────────────────────────────────────────────────
 
-export function buildThinkingCard(): object {
+const MAX_CARD_TEXT_LENGTH = 7000;
+const FEISHU_RUN_CARD_ACTION = 'pulse.run_card';
+
+function clampCardText(text: string, maxLength = MAX_CARD_TEXT_LENGTH): string {
+  if (text.length <= maxLength) return text;
+  return `...${text.slice(text.length - maxLength)}`;
+}
+
+function md(content: string): object {
+  return { tag: 'markdown', content };
+}
+
+function plainText(content: string): object {
+  return { tag: 'plain_text', content };
+}
+
+function buildCard(title: string, template: string, elements: object[], enableForward: boolean): object {
   return {
     schema: '2.0',
-    config: { enable_forward: false },
-    body: {
-      elements: [{ tag: 'markdown', content: 'Pulse is thinking...' }],
+    config: { enable_forward: enableForward, wide_screen_mode: true },
+    header: {
+      template,
+      title: plainText(title),
     },
+    body: { elements },
   };
 }
 
-export function buildProgressCard(text: string): object {
-  return {
-    schema: '2.0',
-    config: { enable_forward: false },
-    body: {
-      elements: [{ tag: 'markdown', content: text || 'Pulse is thinking...' }],
-    },
+function runActionButton(
+  command: 'status' | 'stop' | 'retry' | 'new' | 'runId',
+  text: string,
+  context: RunCardContext,
+  type: 'default' | 'primary' | 'danger' = 'default',
+): object {
+  const value = {
+    action: FEISHU_RUN_CARD_ACTION,
+    command,
+    platformKey: context.platformKey,
+    memoryKey: context.memoryKey,
+    streamId: context.streamId,
+    runId: context.runId,
+    prompt: context.prompt,
   };
+  return {
+    tag: 'button',
+    text: plainText(text),
+    type,
+    width: 'fill',
+    value,
+    behaviors: [{ type: 'callback', value }],
+  };
+}
+
+function buttonRow(buttons: object[]): object {
+  return {
+    tag: 'column_set',
+    flex_mode: 'bisect',
+    horizontal_spacing: '8px',
+    columns: buttons.map((button) => ({
+      tag: 'column',
+      width: 'weighted',
+      weight: 1,
+      elements: [button],
+    })),
+  };
+}
+
+function buildRunMeta(context: RunCardContext, status: string): string {
+  const lines = [`**状态**: ${status}`];
+  if (context.elapsed) lines.push(`**耗时**: ${context.elapsed}`);
+  if (context.runId) lines.push(`**runId**: \`${context.runId}\``);
+  lines.push(`**streamId**: \`${context.streamId}\``);
+  if (context.prompt) lines.push(`**请求**: ${clampCardText(context.prompt, 300)}`);
+  return lines.join('\n');
+}
+
+function buildProgressElements(context: RunCardContext): object[] {
+  const elements: object[] = [md(buildRunMeta(context, '运行中'))];
+  const detailParts = [context.latestToolHint, context.detailText].filter(Boolean) as string[];
+  if (detailParts.length > 0) {
+    elements.push(md(clampCardText(detailParts.join('\n\n'))));
+  }
+  elements.push(buttonRow([
+    runActionButton('status', '状态', context, 'primary'),
+    runActionButton('stop', '停止', context, 'danger'),
+  ]));
+  elements.push(buttonRow([
+    runActionButton('runId', '查看 runId', context),
+    runActionButton('new', '新会话', context),
+  ]));
+  return elements;
+}
+
+function buildCompletionActionElements(context: RunCardContext): object[] {
+  return [
+    buttonRow([
+      runActionButton('retry', '重试', context, 'primary'),
+      runActionButton('new', '新会话', context),
+    ]),
+    buttonRow([
+      runActionButton('status', '状态', context),
+      runActionButton('runId', '查看 runId', context),
+    ]),
+  ];
+}
+
+export function buildThinkingCard(context: RunCardContext): object {
+  return buildCard('Pulse 正在处理', 'blue', buildProgressElements({
+    ...context,
+    detailText: '已收到请求，正在准备运行环境...',
+  }), false);
+}
+
+export function buildProgressCard(context: RunCardContext): object {
+  return buildCard('Pulse 正在处理', 'blue', buildProgressElements(context), false);
 }
 
 export function buildDoneCard(text: string, options: DoneCardOptions = {}): object {
-  const elements: object[] = [{ tag: 'markdown', content: text || '✅ Done' }];
+  const context = options.context;
+  const elements: object[] = [md(clampCardText(text || '✅ Done'))];
+  if (context) {
+    elements.unshift(md(buildRunMeta(context, '已完成')));
+  }
   const toolCalls = options.toolCalls?.filter(Boolean) ?? [];
 
   if (toolCalls.length > 0) {
@@ -482,35 +596,27 @@ export function buildDoneCard(text: string, options: DoneCardOptions = {}): obje
       tag: 'collapsible_panel',
       expanded: false,
       header: {
-        title: {
-          tag: 'plain_text',
-          content: `工具调用明细 (${toolCalls.length})`,
-        },
+        title: plainText(`工具调用明细 (${toolCalls.length})`),
       },
-      elements: [
-        {
-          tag: 'markdown',
-          content: toolCalls.map((toolCall, index) => `${index + 1}. ${toolCall}`).join('\n'),
-        },
-      ],
+      elements: [md(toolCalls.map((toolCall, index) => `${index + 1}. ${toolCall}`).join('\n'))],
     });
   }
 
-  return {
-    schema: '2.0',
-    config: { enable_forward: true },
-    body: {
-      elements,
-    },
-  };
+  if (context) {
+    elements.push(...buildCompletionActionElements(context));
+  }
+
+  return buildCard('Pulse 已完成', 'green', elements, true);
 }
 
-export function buildErrorCard(message: string): object {
-  return {
-    schema: '2.0',
-    config: { enable_forward: false },
-    body: {
-      elements: [{ tag: 'markdown', content: `❌ Error: ${message}` }],
-    },
-  };
+export function buildErrorCard(message: string, context?: RunCardContext): object {
+  const elements: object[] = [];
+  if (context) {
+    elements.push(md(buildRunMeta(context, '出错')));
+  }
+  elements.push(md(`❌ Error: ${clampCardText(message || 'unknown error', 3000)}`));
+  if (context) {
+    elements.push(...buildCompletionActionElements(context));
+  }
+  return buildCard('Pulse 运行出错', 'red', elements, false);
 }

--- a/apps/remote-server/src/adapters/feishu/gateway.ts
+++ b/apps/remote-server/src/adapters/feishu/gateway.ts
@@ -56,6 +56,12 @@ export function startFeishuLongConnection(): void {
 
       dispatchIncoming(feishuAdapter, incoming);
     },
+    'card.action.trigger': async (data) => {
+      await feishuAdapter.handleCardActionBody(data as Record<string, unknown>);
+    },
+    'interactive_card.action.trigger': async (data) => {
+      await feishuAdapter.handleCardActionBody(data as Record<string, unknown>);
+    },
   });
 
   wsClient = new lark.WSClient({

--- a/apps/remote-server/src/core/chat-commands/handlers/session-commands.ts
+++ b/apps/remote-server/src/core/chat-commands/handlers/session-commands.ts
@@ -144,6 +144,9 @@ export async function handleStatusCommand(platformKey: string): Promise<CommandR
 
   if (activeRun) {
     lines.push(`- 运行状态：处理中（已运行 ${formatDuration(Date.now() - activeRun.startedAt)}）`);
+    if (activeRun.runId) {
+      lines.push(`- Run ID: ${activeRun.runId}`);
+    }
     lines.push(`- Stream ID: ${activeRun.streamId}`);
   } else {
     lines.push('- 运行状态：空闲');

--- a/apps/remote-server/src/core/dispatcher.ts
+++ b/apps/remote-server/src/core/dispatcher.ts
@@ -126,7 +126,7 @@ async function runAgentAsync(adapter: PlatformAdapter, incoming: IncomingMessage
   const streamId = incoming.streamId ?? randomUUID();
   const runId = randomUUID();
   const ac = new AbortController();
-  setActiveRun(platformKey, { streamId, ac, startedAt: Date.now() });
+  setActiveRun(platformKey, { streamId, runId, ac, startedAt: Date.now() });
 
   let handle: StreamHandle | null = null;
 

--- a/apps/remote-server/src/core/types.ts
+++ b/apps/remote-server/src/core/types.ts
@@ -99,6 +99,7 @@ export interface PlatformAdapter {
 
 export interface ActiveRun {
   streamId: string;
+  runId?: string;
   ac: AbortController;
   startedAt: number;
 }

--- a/apps/remote-server/src/routes/feishu.ts
+++ b/apps/remote-server/src/routes/feishu.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { dispatch } from '../core/dispatcher.js';
+import { dispatchIncoming } from '../core/dispatcher.js';
 import { feishuAdapter } from '../adapters/feishu/adapter.js';
 import { getFeishuEventSource } from '../adapters/feishu/gateway.js';
 
@@ -13,11 +13,36 @@ export const feishuRouter = new Hono();
  *   Event subscription URL: https://your-server/webhooks/feishu
  *   Events to subscribe: im.message.receive_v1
  */
-feishuRouter.post('/', (c) => {
+feishuRouter.post('/', async (c) => {
   const source = getFeishuEventSource();
   if (source === 'long_connection') {
     return c.json({}, 200);
   }
 
-  return dispatch(feishuAdapter, c);
+  const valid = await feishuAdapter.verifyRequest(c.req);
+  if (!valid) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  let body: Record<string, unknown> | null = null;
+  try {
+    body = await c.req.json() as Record<string, unknown>;
+  } catch {
+    body = null;
+  }
+
+  if (body && await feishuAdapter.handleCardActionBody(body)) {
+    return c.json({}, 200);
+  }
+
+  if (body) {
+    const incoming = await feishuAdapter.parseEventBody(body);
+    const response = feishuAdapter.ackRequest(c, incoming);
+    if (incoming) {
+      dispatchIncoming(feishuAdapter, incoming);
+    }
+    return response;
+  }
+
+  return c.json({}, 200);
 });


### PR DESCRIPTION
Add interactive Feishu run cards for remote-server runs.

- Replace text-only progress cards with structured status panels
- Add Feishu card actions for status, stop, retry, new session, and runId lookup
- Route webhook and websocket card actions through existing command/run handling
- Track runId in active run status for card and /status output

Validation:
- git diff --check
- PATH=/root/pulse-coder/node_modules/.bin:$PATH pnpm --filter @pulse-coder/remote-server exec tsup