### PR TITLE
fix(engine): prune incomplete tool call history

### DIFF
--- a/packages/engine/src/core/loop.test.ts
+++ b/packages/engine/src/core/loop.test.ts
@@ -97,6 +97,77 @@ describe('loop', () => {
     expect(onResponse).toHaveBeenCalledWith([{ role: 'assistant', content: 'step response' }]);
   });
 
+  it('prunes trailing incomplete tool-call history before calling the LLM', async () => {
+    const context: Context = {
+      messages: [
+        { role: 'user', content: 'first' },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'I will inspect this.' },
+            { type: 'tool-call', toolCallId: 'call_missing', toolName: 'read', input: { filePath: 'a.ts' } },
+          ],
+        } as any,
+        { role: 'user', content: 'next turn' },
+      ],
+    };
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    streamTextAIMock.mockReturnValue({
+      text: Promise.resolve('recovered'),
+      steps: Promise.resolve([]),
+      finishReason: Promise.resolve('stop'),
+    });
+
+    try {
+      const result = await loop(context);
+
+      expect(result).toBe('recovered');
+      expect(context.messages).toEqual([{ role: 'user', content: 'first' }]);
+      expect(streamTextAIMock).toHaveBeenCalledWith(
+        [{ role: 'user', content: 'first' }],
+        expect.any(Object),
+        expect.any(Object),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[loop] Pruned 2 trailing message(s) with incomplete tool-call history before LLM call',
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('keeps complete tool-call history intact before calling the LLM', async () => {
+    const messages = [
+      { role: 'user', content: 'first' },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool-call', toolCallId: 'call_done', toolName: 'read', input: { filePath: 'a.ts' } },
+          { type: 'tool-result', toolCallId: 'call_done', toolName: 'read', output: 'ok' },
+        ],
+      } as any,
+      { role: 'user', content: 'next turn' },
+    ];
+    const context: Context = { messages };
+
+    streamTextAIMock.mockReturnValue({
+      text: Promise.resolve('ok'),
+      steps: Promise.resolve([]),
+      finishReason: Promise.resolve('stop'),
+    });
+
+    const result = await loop(context);
+
+    expect(result).toBe('ok');
+    expect(context.messages).toBe(messages);
+    expect(streamTextAIMock).toHaveBeenCalledWith(
+      messages,
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
   it('retries retryable errors with backoff and eventually succeeds', async () => {
     vi.useFakeTimers();
 

--- a/packages/engine/src/core/loop.ts
+++ b/packages/engine/src/core/loop.ts
@@ -29,6 +29,50 @@ type ActiveToolExecution = {
   inputPreview?: string;
 };
 
+function getToolCallId(part: unknown): string | undefined {
+  if (!part || typeof part !== 'object') return undefined;
+  const toolCallId = (part as { toolCallId?: unknown }).toolCallId;
+  return typeof toolCallId === 'string' && toolCallId.length > 0 ? toolCallId : undefined;
+}
+
+function findFirstIncompleteToolExchangeIndex(messages: ModelMessage[]): number | undefined {
+  const pendingToolCalls = new Map<string, number>();
+
+  messages.forEach((message, index) => {
+    const content = (message as { content?: unknown }).content;
+    if (!Array.isArray(content)) return;
+
+    for (const part of content) {
+      const type = part && typeof part === 'object' ? (part as { type?: unknown }).type : undefined;
+      const toolCallId = getToolCallId(part);
+      if (!toolCallId) continue;
+
+      if (type === 'tool-call') {
+        pendingToolCalls.set(toolCallId, index);
+      } else if (type === 'tool-result') {
+        pendingToolCalls.delete(toolCallId);
+      }
+    }
+  });
+
+  let firstIndex: number | undefined;
+  for (const index of pendingToolCalls.values()) {
+    firstIndex = firstIndex === undefined ? index : Math.min(firstIndex, index);
+  }
+  return firstIndex;
+}
+
+function pruneIncompleteToolExchanges(messages: ModelMessage[]): ModelMessage[] {
+  const firstIncompleteIndex = findFirstIncompleteToolExchangeIndex(messages);
+  if (firstIncompleteIndex === undefined) return messages;
+
+  const pruned = messages.slice(0, firstIncompleteIndex);
+  console.warn(
+    `[loop] Pruned ${messages.length - pruned.length} trailing message(s) with incomplete tool-call history before LLM call`,
+  );
+  return pruned;
+}
+
 function resolveModelContextBudget(model?: string, modelType?: ModelType): number {
   if (MODEL_CONTEXT_BUDGET_OVERRIDE && MODEL_CONTEXT_BUDGET_OVERRIDE > 0) {
     return MODEL_CONTEXT_BUDGET_OVERRIDE;
@@ -525,7 +569,12 @@ export async function loop(context: Context, options?: LoopOptions): Promise<str
       let usage: any;
 
       try {
-        const result = streamTextAI(context.messages, tools, {
+        const messagesForLLM = pruneIncompleteToolExchanges(context.messages);
+        if (messagesForLLM !== context.messages) {
+          context.messages = messagesForLLM;
+        }
+
+        const result = streamTextAI(messagesForLLM, tools, {
           abortSignal: llmAbortController.signal,
           toolExecutionContext: {
             ...toolExecutionContext,


### PR DESCRIPTION
## Summary
- prune trailing message history when it contains tool-call parts without matching tool-result parts before calling the LLM
- preserve complete tool-call/tool-result exchanges unchanged
- add loop tests covering recovery from incomplete tool history and intact complete history

## Validation
- pnpm --filter pulse-coder-engine test -- src/core/loop.test.ts
- pnpm --filter pulse-coder-engine build