### PR TITLE
fix(remote-server): support Feishu topic platform keys

### DIFF
--- a/apps/remote-server/src/adapters/feishu/adapter.ts
+++ b/apps/remote-server/src/adapters/feishu/adapter.ts
@@ -20,6 +20,7 @@ import {
   buildDoneCard,
   buildErrorCard,
 } from './client.js';
+import { buildFeishuPlatformKey, parseFeishuPlatformKey } from './platform-key.js';
 
 
 /**
@@ -177,9 +178,13 @@ export class FeishuAdapter implements PlatformAdapter {
       if (!text) return null;
     }
 
-    const platformKey = isGroupChat && chatId
-      ? `feishu:group:${chatId}:${openId}`
-      : `feishu:${openId}`;
+    const topicId = isGroupChat ? resolveFeishuTopicId(message) : undefined;
+    const platformKey = buildFeishuPlatformKey({
+      chatId,
+      chatType,
+      openId,
+      topicId,
+    });
     const memoryKey = `feishu:user:${openId}`;
 
     if (messageId && shouldAddFeishuReactions(isGroupChat)) {
@@ -194,6 +199,7 @@ export class FeishuAdapter implements PlatformAdapter {
       chatType,
       openId,
       sourceMessageId: messageId,
+      topicId,
     });
     const chatMeta = {
       ...meta,
@@ -243,10 +249,11 @@ export class FeishuAdapter implements PlatformAdapter {
     const meta = this.chatMetaByStreamId.get(_streamId)
       ?? (incoming.streamId ? this.chatMetaByStreamId.get(incoming.streamId) : undefined)
       ?? this.chatMetaByPlatformKey.get(incoming.platformKey);
-    const chatId = meta?.chatId ?? incoming.platformKey.replace('feishu:', '');
-    const idType = meta?.chatIdType ?? 'open_id';
-    const sourceMessageId = meta?.sourceMessageId;
-    const allowReaction = meta?.allowReaction ?? false;
+    const fallbackMeta = meta ?? resolveFeishuChatMetaFromPlatformKey(incoming.platformKey);
+    const chatId = fallbackMeta.chatId;
+    const idType = fallbackMeta.chatIdType;
+    const sourceMessageId = fallbackMeta.sourceMessageId;
+    const allowReaction = fallbackMeta.allowReaction ?? false;
     const replyOptions = idType === 'chat_id' && sourceMessageId ? { replyToMessageId: sourceMessageId } : undefined;
     const { larkClient } = this;
     const activeRun = getActiveRun(incoming.platformKey);
@@ -524,7 +531,15 @@ interface FeishuChatMeta {
   chatId: string;
   chatIdType: 'open_id' | 'chat_id';
   sourceMessageId?: string;
+  topicId?: string;
   allowReaction?: boolean;
+}
+
+function resolveFeishuTopicId(message: Record<string, unknown>): string | undefined {
+  return asNonEmptyString(message.root_id)
+    ?? asNonEmptyString(message.parent_id)
+    ?? asNonEmptyString(message.thread_id)
+    ?? undefined;
 }
 
 function extractFeishuEvent(body: Record<string, unknown>): Record<string, unknown> | null {
@@ -545,12 +560,14 @@ function resolveFeishuChatMeta(input: {
   chatType?: string;
   openId: string;
   sourceMessageId?: string;
+  topicId?: string;
 }): FeishuChatMeta {
   if (input.chatType === 'group' && input.chatId) {
     return {
       chatId: input.chatId,
       chatIdType: 'chat_id',
       sourceMessageId: input.sourceMessageId,
+      topicId: input.topicId,
     };
   }
 
@@ -558,6 +575,22 @@ function resolveFeishuChatMeta(input: {
     chatId: input.openId,
     chatIdType: 'open_id',
     sourceMessageId: input.sourceMessageId,
+  };
+}
+
+function resolveFeishuChatMetaFromPlatformKey(platformKey: string): FeishuChatMeta {
+  const parsed = parseFeishuPlatformKey(platformKey);
+  if (parsed?.kind === 'group') {
+    return {
+      chatId: parsed.chatId,
+      chatIdType: 'chat_id',
+      topicId: parsed.topicId,
+    };
+  }
+
+  return {
+    chatId: parsed?.openId ?? platformKey.replace('feishu:', ''),
+    chatIdType: 'open_id',
   };
 }
 
@@ -739,9 +772,10 @@ function parseRunCardAction(data: unknown): RunCardAction | null {
   }
   const chatId = asNonEmptyString(event.context?.open_chat_id)
     ?? asNonEmptyString(event.context?.chat_id);
-  const replyTarget = platformKey.startsWith('feishu:group:')
-    ? { chatId: chatId ?? parseFeishuGroupChatId(platformKey) ?? '', chatIdType: 'chat_id' as const }
-    : { chatId: asNonEmptyString(openId) ?? parseFeishuOpenId(platformKey) ?? '', chatIdType: 'open_id' as const };
+  const parsedPlatformKey = parseFeishuPlatformKey(platformKey);
+  const replyTarget = parsedPlatformKey?.kind === 'group'
+    ? { chatId: chatId ?? parsedPlatformKey.chatId, chatIdType: 'chat_id' as const }
+    : { chatId: asNonEmptyString(openId) ?? parsedPlatformKey?.openId ?? '', chatIdType: 'open_id' as const };
 
   if (!replyTarget.chatId) {
     return null;
@@ -804,22 +838,12 @@ function asRunCardCommand(value: unknown): RunCardCommand | null {
 }
 
 function isRunCardActorAllowed(platformKey: string, actorOpenId: string): boolean {
-  const groupMatch = /^feishu:group:[^:]+:([^:]+)$/.exec(platformKey);
-  if (groupMatch) {
-    return groupMatch[1] === actorOpenId;
+  const parsed = parseFeishuPlatformKey(platformKey);
+  if (parsed) {
+    return parsed.openId === actorOpenId;
   }
-  const dmMatch = /^feishu:([^:]+)$/.exec(platformKey);
-  return !dmMatch || dmMatch[1] === actorOpenId;
-}
 
-function parseFeishuGroupChatId(platformKey: string): string | null {
-  const match = /^feishu:group:([^:]+):/.exec(platformKey);
-  return match?.[1] ?? null;
-}
-
-function parseFeishuOpenId(platformKey: string): string | null {
-  const match = /^feishu:([^:]+)$/.exec(platformKey);
-  return match?.[1] ?? null;
+  return true;
 }
 
 

--- a/apps/remote-server/src/adapters/feishu/platform-key.ts
+++ b/apps/remote-server/src/adapters/feishu/platform-key.ts
@@ -1,0 +1,66 @@
+export interface FeishuPlatformKeyInput {
+  chatId?: string;
+  chatType?: string;
+  openId: string;
+  topicId?: string;
+}
+
+export interface FeishuGroupPlatformKey {
+  kind: 'group';
+  chatId: string;
+  openId: string;
+  topicId?: string;
+}
+
+export interface FeishuDirectPlatformKey {
+  kind: 'direct';
+  openId: string;
+}
+
+export type ParsedFeishuPlatformKey = FeishuGroupPlatformKey | FeishuDirectPlatformKey;
+
+export function buildFeishuPlatformKey(input: FeishuPlatformKeyInput): string {
+  if (input.chatType === 'group' && input.chatId) {
+    const topicId = sanitizeFeishuPlatformSegment(input.topicId);
+    if (topicId) {
+      return `feishu:group:${input.chatId}:topic:${topicId}:user:${input.openId}`;
+    }
+
+    return `feishu:group:${input.chatId}:user:${input.openId}`;
+  }
+
+  return `feishu:${input.openId}`;
+}
+
+export function parseFeishuPlatformKey(platformKey: string): ParsedFeishuPlatformKey | undefined {
+  const normalized = platformKey.trim();
+
+  const group = /^feishu:group:([^:]+)(?::topic:([^:]+))?(?::user)?:([^:]+)$/.exec(normalized);
+  if (group) {
+    return {
+      kind: 'group',
+      chatId: group[1],
+      topicId: group[2],
+      openId: group[3],
+    };
+  }
+
+  const direct = /^feishu:([^:]+)$/.exec(normalized);
+  if (direct) {
+    return {
+      kind: 'direct',
+      openId: direct[1],
+    };
+  }
+
+  return undefined;
+}
+
+function sanitizeFeishuPlatformSegment(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  return trimmed.replace(/:/g, '_');
+}

--- a/apps/remote-server/src/core/agent-runner.ts
+++ b/apps/remote-server/src/core/agent-runner.ts
@@ -10,6 +10,7 @@ import { memoryIntegration, recordDailyLogFromSuccessPath } from './memory-integ
 import { buildRemoteWorktreeRunContext, worktreeIntegration } from './worktree/integration.js';
 import { buildRemoteVaultRunContext, vaultIntegration } from './vault/integration.js';
 import { resolveModelForRun } from './model-config.js';
+import { parseFeishuPlatformKey } from '../adapters/feishu/platform-key.js';
 const ACP_CLIENT_INFO = {
   name: 'pulse-remote-server',
   title: 'Pulse Remote Server',
@@ -23,6 +24,7 @@ interface RunChannelInfo {
   kind?: 'group' | 'dm' | 'thread' | 'channel' | 'chat' | 'user' | 'internal';
   channelId?: string;
   userId?: string;
+  topicId?: string;
   isThread?: boolean;
 }
 
@@ -131,23 +133,23 @@ function parseChannelInfo(platformKey: string): RunChannelInfo | undefined {
     return undefined;
   }
 
-  const feishuGroup = /^feishu:group:([^:]+):([^:]+)$/.exec(normalized);
-  if (feishuGroup) {
-    return {
-      platform: 'feishu',
-      kind: 'group',
-      channelId: feishuGroup[1],
-      userId: feishuGroup[2],
-    };
-  }
+  const feishu = parseFeishuPlatformKey(normalized);
+  if (feishu) {
+    if (feishu.kind === 'group') {
+      return {
+        platform: 'feishu',
+        kind: 'group',
+        channelId: feishu.chatId,
+        userId: feishu.openId,
+        topicId: feishu.topicId,
+      };
+    }
 
-  const feishuDm = /^feishu:([^:]+)$/.exec(normalized);
-  if (feishuDm) {
     return {
       platform: 'feishu',
       kind: 'dm',
-      channelId: feishuDm[1],
-      userId: feishuDm[1],
+      channelId: feishu.openId,
+      userId: feishu.openId,
     };
   }
 
@@ -222,6 +224,7 @@ function buildChannelSystemPrompt(platformKey: string): string | null {
     `platform=${channel.platform}`,
     channel.kind ? `kind=${channel.kind}` : '',
     channel.channelId ? `channelId=${channel.channelId}` : '',
+    channel.topicId ? `topicId=${channel.topicId}` : '',
   ].filter(Boolean);
 
   if (lines.length <= 1) {

--- a/apps/remote-server/src/core/restart-command.ts
+++ b/apps/remote-server/src/core/restart-command.ts
@@ -3,6 +3,7 @@ import { readFileSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
 import type { IncomingMessage } from './types.js';
 import type { CommandResult } from './chat-commands/types.js';
+import { parseFeishuPlatformKey } from '../adapters/feishu/platform-key.js';
 
 interface RestartNotifyTarget {
   platform: 'discord' | 'telegram' | 'feishu';
@@ -525,20 +526,19 @@ function resolveRestartNotifyTarget(platformKey: string): RestartNotifyTarget | 
     }
   }
 
-  const feishuGroupMatch = /^feishu:group:([^:]+):[^:]+$/.exec(platformKey);
-  if (feishuGroupMatch) {
+  const feishuKey = parseFeishuPlatformKey(platformKey);
+  if (feishuKey?.kind === 'group') {
     return {
       platform: 'feishu',
-      receiveId: feishuGroupMatch[1],
+      receiveId: feishuKey.chatId,
       receiveIdType: 'chat_id',
     };
   }
 
-  const feishuUserMatch = /^feishu:([^:]+)$/.exec(platformKey);
-  if (feishuUserMatch) {
+  if (feishuKey?.kind === 'direct') {
     return {
       platform: 'feishu',
-      receiveId: feishuUserMatch[1],
+      receiveId: feishuKey.openId,
       receiveIdType: 'open_id',
     };
   }

--- a/apps/remote-server/src/core/session-store.ts
+++ b/apps/remote-server/src/core/session-store.ts
@@ -4,6 +4,7 @@ import { homedir } from 'os';
 import { join } from 'path';
 import type { Context } from './types.js';
 import type { StoredAttachment } from './attachments.js';
+import { parseFeishuPlatformKey } from '../adapters/feishu/platform-key.js';
 // ModelMessage is the Vercel AI SDK type, re-exported via pulse-coder-engine
 // Context.messages is ModelMessage[] so we can use unknown[] as the storage type
 // and cast when needed — avoids adding `ai` as a direct dependency
@@ -685,14 +686,9 @@ class RemoteSessionStore {
       return `discord:user:${discordDm[1]}`;
     }
 
-    const feishuGroup = /^feishu:group:[^:]+:([^:]+)$/.exec(session.platformKey);
-    if (feishuGroup) {
-      return `feishu:user:${feishuGroup[1]}`;
-    }
-
-    const feishuDm = /^feishu:([^:]+)$/.exec(session.platformKey);
-    if (feishuDm) {
-      return `feishu:user:${feishuDm[1]}`;
+    const feishu = parseFeishuPlatformKey(session.platformKey);
+    if (feishu) {
+      return `feishu:user:${feishu.openId}`;
     }
 
     const web = /^web:(.+)$/.exec(session.platformKey);

--- a/apps/remote-server/src/core/tools/cron-job.ts
+++ b/apps/remote-server/src/core/tools/cron-job.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import z from 'zod';
 import type { Tool, ToolExecutionContext } from 'pulse-coder-engine';
 import { createLarkClient, sendTextMessage } from '../../adapters/feishu/client.js';
+import { parseFeishuPlatformKey } from '../../adapters/feishu/platform-key.js';
 import { DiscordClient } from '../../adapters/discord/client.js';
 
 const execFileAsync = promisify(execFile);
@@ -322,21 +323,20 @@ function isNotifyRequested(prompt?: string): boolean {
 }
 
 function inferNotifyFromPlatformKey(platformKey: string): NotifyTarget | undefined {
-  const feishuGroup = /^feishu:group:([^:]+):[^:]+$/.exec(platformKey);
-  if (feishuGroup) {
+  const feishuKey = parseFeishuPlatformKey(platformKey);
+  if (feishuKey?.kind === 'group') {
     return {
       feishu: {
-        receiveId: feishuGroup[1],
+        receiveId: feishuKey.chatId,
         receiveIdType: 'chat_id',
       },
     };
   }
 
-  const feishuDm = /^feishu:([^:]+)$/.exec(platformKey);
-  if (feishuDm) {
+  if (feishuKey?.kind === 'direct') {
     return {
       feishu: {
-        receiveId: feishuDm[1],
+        receiveId: feishuKey.openId,
         receiveIdType: 'open_id',
       },
     };

--- a/apps/remote-server/src/routes/internal.ts
+++ b/apps/remote-server/src/routes/internal.ts
@@ -4,6 +4,7 @@ import { Hono, type Context } from 'hono';
 import { getConnInfo } from '@hono/node-server/conninfo';
 import { createLarkClient, sendImageMessage, sendTextMessage } from '../adapters/feishu/client.js';
 import { extractGeneratedImageResult } from '../adapters/feishu/image-result.js';
+import { parseFeishuPlatformKey } from '../adapters/feishu/platform-key.js';
 import { getDiscordGatewayStatus, restartDiscordGateway } from '../adapters/discord/gateway-manager.js';
 import { DiscordClient } from '../adapters/discord/client.js';
 import { executeAgentTurn, formatCompactionEvents, type CompactionSnapshot } from '../core/agent-runner.js';
@@ -634,18 +635,17 @@ function resolveFeishuTarget(feishu: FeishuNotifyConfig | undefined, platformKey
     };
   }
 
-  const groupMatch = /^feishu:group:([^:]+):[^:]+$/.exec(platformKey);
-  if (groupMatch) {
+  const feishuKey = parseFeishuPlatformKey(platformKey);
+  if (feishuKey?.kind === 'group') {
     return {
-      receiveId: groupMatch[1],
+      receiveId: feishuKey.chatId,
       receiveIdType: 'chat_id',
     };
   }
 
-  const directMatch = /^feishu:([^:]+)$/.exec(platformKey);
-  if (directMatch) {
+  if (feishuKey?.kind === 'direct') {
     return {
-      receiveId: directMatch[1],
+      receiveId: feishuKey.openId,
       receiveIdType: 'open_id',
     };
   }


### PR DESCRIPTION
Normalize Feishu platform key handling for group topics and card actions.

- Add a shared Feishu platform key builder/parser with legacy key compatibility
- Use topic-aware group keys with explicit user segments for Feishu group sessions
- Route session ownership, notifications, restart targets, and channel context through the parser
- Update run card action reply target and actor validation to support topic keys
- Avoid using message_id as a fallback topic id for regular group messages

Validation:
- pnpm --filter @pulse-coder/remote-server build