### PR TITLE
feat: support Feishu image attachments

### DIFF
--- a/apps/remote-server/src/adapters/feishu/adapter.ts
+++ b/apps/remote-server/src/adapters/feishu/adapter.ts
@@ -21,6 +21,7 @@ import {
   buildErrorCard,
 } from './client.js';
 import { buildFeishuPlatformKey, parseFeishuPlatformKey } from './platform-key.js';
+import { parseFeishuMessageContent } from './message-content.js';
 
 
 /**
@@ -155,16 +156,14 @@ export class FeishuAdapter implements PlatformAdapter {
 
     const openId = (sender['sender_id'] as Record<string, unknown> | undefined)?.['open_id'] as string | undefined;
     if (!openId) return null;
-    if (message['message_type'] !== 'text') return null;
+    const messageType = asNonEmptyString(message['message_type']);
+    const parsedContent = parseFeishuMessageContent(messageType, message['content'], messageId);
+    if (!parsedContent) return null;
 
-    let text: string;
-    try {
-      const content = JSON.parse(message['content'] as string ?? '{}') as { text?: string };
-      text = content.text?.trim() ?? '';
-    } catch {
-      return null;
-    }
-    if (!text) return null;
+    let text = parsedContent.text;
+    const attachments = parsedContent.attachments;
+    const hasAttachments = attachments.length > 0;
+    if (!text && !hasAttachments) return null;
 
     const chatId = message['chat_id'] as string | undefined;
     const chatType = message['chat_type'] as string | undefined; // 'p2p' | 'group'
@@ -175,7 +174,7 @@ export class FeishuAdapter implements PlatformAdapter {
       const mentions = (message['mentions'] as unknown[] | undefined) ?? [];
       if (mentions.length === 0) return null;
       text = removeFeishuMentions(text, mentions);
-      if (!text) return null;
+      if (!text && !hasAttachments) return null;
     }
 
     const topicId = isGroupChat ? resolveFeishuTopicId(message) : undefined;
@@ -230,7 +229,7 @@ export class FeishuAdapter implements PlatformAdapter {
       return null;
     }
 
-    return { platformKey, memoryKey, text, streamId: messageId };
+    return { platformKey, memoryKey, text, attachments: hasAttachments ? attachments : undefined, streamId: messageId };
   }
 
   // URL verification challenge to return in ackRequest

--- a/apps/remote-server/src/adapters/feishu/client.ts
+++ b/apps/remote-server/src/adapters/feishu/client.ts
@@ -117,6 +117,44 @@ async function uploadImageToFeishu(imagePath: string, mimeType?: string): Promis
   return imageKey;
 }
 
+export async function downloadImageFromFeishu(imageKey: string): Promise<{ buffer: Buffer; mimeType?: string; size?: number }> {
+  const normalizedImageKey = imageKey.trim();
+  if (!normalizedImageKey) {
+    throw new Error('imageKey is required');
+  }
+
+  const token = await getTenantAccessToken();
+  const response = await fetchFeishuWithRetry({
+    url: `${getFeishuBaseUrl()}/open-apis/im/v1/images/${encodeURIComponent(normalizedImageKey)}?image_type=message`,
+    init: {
+      method: 'GET',
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    },
+    action: 'download image',
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Failed to download image from Feishu: ${response.status} ${response.statusText} - ${body}`);
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+  if (buffer.length === 0) {
+    throw new Error(`Downloaded Feishu image is empty: ${normalizedImageKey}`);
+  }
+
+  const contentType = response.headers.get('content-type')?.split(';')[0]?.trim().toLowerCase() || undefined;
+  const contentLength = Number(response.headers.get('content-length') ?? '0');
+
+  return {
+    buffer,
+    mimeType: contentType,
+    size: Number.isFinite(contentLength) && contentLength > 0 ? contentLength : buffer.length,
+  };
+}
+
 type ReceiveIdType = 'open_id' | 'chat_id' | 'user_id' | 'union_id' | 'email';
 
 interface RunCardContext {

--- a/apps/remote-server/src/adapters/feishu/message-content.test.ts
+++ b/apps/remote-server/src/adapters/feishu/message-content.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseFeishuMessageContent } from './message-content.js';
+
+describe('parseFeishuMessageContent', () => {
+  it('parses direct image messages as attachments', () => {
+    const parsed = parseFeishuMessageContent('image', JSON.stringify({ image_key: 'img_v3_key' }), 'om_message');
+
+    expect(parsed).toEqual({
+      text: '',
+      attachments: [
+        {
+          id: 'img_v3_key',
+          url: 'feishu://image/img_v3_key',
+          name: 'img_v3_key.jpg',
+          mimeType: 'image/jpeg',
+          source: 'feishu',
+          messageId: 'om_message',
+        },
+      ],
+    });
+  });
+
+  it('parses post messages with text and image elements', () => {
+    const parsed = parseFeishuMessageContent('post', JSON.stringify({
+      content: [
+        [
+          { tag: 'text', text: 'please inspect' },
+          { tag: 'img', image_key: 'img_post_key' },
+        ],
+      ],
+    }), 'om_post');
+
+    expect(parsed?.text).toBe('please inspect');
+    expect(parsed?.attachments).toEqual([
+      {
+        id: 'img_post_key',
+        url: 'feishu://image/img_post_key',
+        name: 'img_post_key.jpg',
+        mimeType: 'image/jpeg',
+        source: 'feishu',
+        messageId: 'om_post',
+      },
+    ]);
+  });
+
+  it('deduplicates repeated post image elements', () => {
+    const parsed = parseFeishuMessageContent('post', JSON.stringify({
+      content: [
+        [
+          { tag: 'img', image_key: 'img_same_key' },
+          { tag: 'img', image_key: 'img_same_key' },
+        ],
+      ],
+    }), 'om_post');
+
+    expect(parsed?.attachments).toHaveLength(1);
+    expect(parsed?.attachments?.[0]?.id).toBe('img_same_key');
+  });
+
+  it('parses localized post message payloads', () => {
+    const parsed = parseFeishuMessageContent('post', JSON.stringify({
+      zh_cn: {
+        title: 'title text',
+        content: [
+          [
+            { tag: 'text', text: 'localized text' },
+            { tag: 'img', image_key: 'img_locale_key' },
+          ],
+        ],
+      },
+    }), 'om_locale');
+
+    expect(parsed?.text).toBe('title text localized text');
+    expect(parsed?.attachments?.[0]?.id).toBe('img_locale_key');
+  });
+
+  it('ignores unsupported message types', () => {
+    expect(parseFeishuMessageContent('audio', JSON.stringify({ file_key: 'file' }), 'om_message')).toBeNull();
+  });
+});

--- a/apps/remote-server/src/adapters/feishu/message-content.ts
+++ b/apps/remote-server/src/adapters/feishu/message-content.ts
@@ -1,0 +1,148 @@
+import type { IncomingAttachment } from '../../core/types.js';
+
+export function parseFeishuMessageContent(
+  messageType: string | null,
+  rawContent: unknown,
+  messageId?: string,
+): { text: string; attachments: IncomingAttachment[] } | null {
+  if (typeof rawContent !== 'string') {
+    return null;
+  }
+
+  let content: unknown;
+  try {
+    content = JSON.parse(rawContent || '{}');
+  } catch {
+    return null;
+  }
+
+  if (!isRecord(content)) {
+    return null;
+  }
+
+  if (messageType === 'text') {
+    return {
+      text: asNonEmptyString(content.text) ?? '',
+      attachments: [],
+    };
+  }
+
+  if (messageType === 'image') {
+    const imageKey = asNonEmptyString(content.image_key);
+    if (!imageKey) {
+      return null;
+    }
+
+    return {
+      text: '',
+      attachments: [buildFeishuImageAttachment(imageKey, messageId)],
+    };
+  }
+
+  if (messageType === 'post') {
+    return parseFeishuPostContent(content, messageId);
+  }
+
+  return null;
+}
+
+function parseFeishuPostContent(content: Record<string, unknown>, messageId?: string): { text: string; attachments: IncomingAttachment[] } {
+  const textParts: string[] = [];
+  const attachments: IncomingAttachment[] = [];
+  const visited = new Set<unknown>();
+
+  const visit = (value: unknown): void => {
+    if (value === null || value === undefined) {
+      return;
+    }
+
+    if (typeof value === 'string') {
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        visit(item);
+      }
+      return;
+    }
+
+    if (!isRecord(value) || visited.has(value)) {
+      return;
+    }
+    visited.add(value);
+
+    const tag = asNonEmptyString(value.tag);
+    if (tag === 'img' || tag === 'image') {
+      const imageKey = asNonEmptyString(value.image_key) ?? asNonEmptyString(value.imageKey);
+      if (imageKey) {
+        attachments.push(buildFeishuImageAttachment(imageKey, messageId));
+      }
+      return;
+    }
+
+    const text = asNonEmptyString(value.text)
+      ?? asNonEmptyString(value.content)
+      ?? asNonEmptyString(value.name)
+      ?? asNonEmptyString(value.title);
+    if (text) {
+      textParts.push(text);
+    }
+
+    for (const childKey of ['content', 'elements', 'children', 'zh_cn', 'en_us', 'ja_jp']) {
+      const child = value[childKey];
+      if (child) {
+        visit(child);
+      }
+    }
+  };
+
+  visit(content);
+
+  return {
+    text: textParts.join(' ').replace(/\s+/g, ' ').trim(),
+    attachments: dedupeFeishuImageAttachments(attachments),
+  };
+}
+
+function buildFeishuImageAttachment(imageKey: string, messageId?: string): IncomingAttachment {
+  return {
+    id: imageKey,
+    url: `feishu://image/${encodeURIComponent(imageKey)}`,
+    name: `${sanitizeFeishuImageKey(imageKey)}.jpg`,
+    mimeType: 'image/jpeg',
+    source: 'feishu',
+    messageId,
+  };
+}
+
+function dedupeFeishuImageAttachments(attachments: IncomingAttachment[]): IncomingAttachment[] {
+  const seen = new Set<string>();
+  const unique: IncomingAttachment[] = [];
+  for (const attachment of attachments) {
+    const key = attachment.id ?? attachment.url;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    unique.push(attachment);
+  }
+  return unique;
+}
+
+function sanitizeFeishuImageKey(imageKey: string): string {
+  return imageKey.replace(/[^a-zA-Z0-9._-]/g, '_') || 'feishu-image';
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/apps/remote-server/src/core/attachments.ts
+++ b/apps/remote-server/src/core/attachments.ts
@@ -4,6 +4,7 @@ import { homedir } from 'os';
 import { basename, extname, join } from 'path';
 import { fetch } from 'undici';
 import { getDiscordProxyDispatcher } from '../adapters/discord/proxy.js';
+import { downloadImageFromFeishu } from '../adapters/feishu/client.js';
 import type { IncomingAttachment } from './types.js';
 import { vaultIntegration, buildRemoteVaultRunContext } from './vault/integration.js';
 
@@ -129,6 +130,48 @@ async function downloadAttachment(attachment: IncomingAttachment, targetDir: str
     return null;
   }
 
+  const downloaded = await downloadAttachmentBuffer(attachment, url, timeoutMs, maxBytes);
+
+  const resolvedMime = normalizeMimeType(attachment.mimeType || downloaded.mimeType);
+  const extension = resolveExtension(attachment.name, resolvedMime, url);
+  const displayName = attachment.name ? sanitizeFileName(attachment.name) : undefined;
+  const fileNameBase = displayName || `${attachment.id ?? randomUUID()}${extension}`;
+  const fileName = `${Date.now()}-${fileNameBase}`;
+  const outputPath = join(targetDir, fileName);
+
+  await fs.writeFile(outputPath, downloaded.buffer);
+
+  return {
+    id: attachment.id ?? randomUUID(),
+    path: outputPath,
+    mimeType: resolvedMime ?? undefined,
+    name: displayName ?? basename(outputPath),
+    size: downloaded.buffer.length,
+    source: attachment.source,
+    messageId: attachment.messageId,
+    createdAt: Date.now(),
+    originalUrl: attachment.url,
+  };
+}
+
+async function downloadAttachmentBuffer(
+  attachment: IncomingAttachment,
+  url: string,
+  timeoutMs: number,
+  maxBytes: number,
+): Promise<{ buffer: Buffer; mimeType?: string }> {
+  const feishuImageKey = parseFeishuImageUrl(url);
+  if (feishuImageKey) {
+    const downloaded = await downloadImageFromFeishu(feishuImageKey);
+    if (downloaded.buffer.length > maxBytes) {
+      throw new Error(`Attachment exceeds size limit (${downloaded.buffer.length} > ${maxBytes})`);
+    }
+    return {
+      buffer: downloaded.buffer,
+      mimeType: downloaded.mimeType,
+    };
+  }
+
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
@@ -164,26 +207,19 @@ async function downloadAttachment(attachment: IncomingAttachment, targetDir: str
     throw new Error(`Attachment exceeds size limit (${buffer.length} > ${maxBytes})`);
   }
 
-  const resolvedMime = normalizeMimeType(attachment.mimeType || response.headers.get('content-type'));
-  const extension = resolveExtension(attachment.name, resolvedMime, url);
-  const displayName = attachment.name ? sanitizeFileName(attachment.name) : undefined;
-  const fileNameBase = displayName || `${attachment.id ?? randomUUID()}${extension}`;
-  const fileName = `${Date.now()}-${fileNameBase}`;
-  const outputPath = join(targetDir, fileName);
-
-  await fs.writeFile(outputPath, buffer);
-
   return {
-    id: attachment.id ?? randomUUID(),
-    path: outputPath,
-    mimeType: resolvedMime ?? undefined,
-    name: displayName ?? basename(outputPath),
-    size: buffer.length,
-    source: attachment.source,
-    messageId: attachment.messageId,
-    createdAt: Date.now(),
-    originalUrl: attachment.url,
+    buffer,
+    mimeType: response.headers.get('content-type') ?? undefined,
   };
+}
+
+function parseFeishuImageUrl(url: string): string | null {
+  if (!url.startsWith('feishu://image/')) {
+    return null;
+  }
+
+  const imageKey = decodeURIComponent(url.slice('feishu://image/'.length)).trim();
+  return imageKey || null;
 }
 
 export function resolveAttachmentDispatcher(attachment: IncomingAttachment) {


### PR DESCRIPTION
## Summary
- parse Feishu image and post message content into incoming image attachments
- download Feishu image resources with tenant auth via the existing attachment resolver
- keep group mention gating while allowing image-only prompts after mention
- add focused parser coverage for direct image, rich post, dedupe, localized post, and unsupported types

## Validation
- pnpm --filter @pulse-coder/remote-server exec vitest run src/adapters/feishu/message-content.test.ts
- PATH=/root/pulse-coder/node_modules/.bin:$PATH pnpm --filter @pulse-coder/remote-server exec tsup
- git diff --check

Note: full pnpm --filter @pulse-coder/remote-server build is blocked in this isolated worktree by an existing prebuild DTS environment issue in pulse-coder-orchestrator (missing Node type declarations). remote-server direct tsup build passes.