### PR TITLE
fix: improve canvas attachment previews

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.css
@@ -145,8 +145,21 @@
   max-width: 600px;
 }
 
-.text-node-body--editing {
+.text-node-body--editing,
+.canvas-node--readonly .text-node-body,
+.canvas-node--fullscreen .text-node-body {
   cursor: text;
+}
+
+.text-node-body--editing .ProseMirror,
+.canvas-node--readonly .text-node-body .ProseMirror,
+.canvas-node--fullscreen .text-node-body .ProseMirror {
+  cursor: text;
+  user-select: text;
+  -webkit-user-select: text;
+}
+
+.text-node-body--editing {
   /* Subtle inset ring so the user can tell they're editing even when the
    * background is transparent. */
   box-shadow: 0 0 0 1px rgba(35, 131, 226, 0.35) inset;

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatInput.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatInput.tsx
@@ -1,4 +1,4 @@
-import type { ClipboardEventHandler, KeyboardEventHandler, ReactNode, RefObject } from 'react';
+import { useMemo, useState, type ClipboardEventHandler, type KeyboardEventHandler, type ReactNode, type RefObject } from 'react';
 import type { CanvasModelStatus, ChatImageAttachment } from '../../types';
 import { ImageIcon, PlusIcon } from '../icons';
 import { toFileUrl } from '../../utils/fileUrl';
@@ -6,6 +6,7 @@ import { MentionNodeIcon } from './utils/mentions';
 import { ModelSwitcher } from './ModelSettings';
 import type { SelectedContextChip } from './types';
 import { useI18n } from '../../i18n';
+import { ChatImageLightbox, type LightboxImage } from './ChatImageLightbox';
 
 interface ChatInputProps {
   loading: boolean;
@@ -68,6 +69,11 @@ export const ChatInput = ({
     ? selectedContext
     : [];
   const showContextChips = showContextChipsProp && contextComposer && contextChips.length > 0 && !loading;
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+  const lightboxImages = useMemo<LightboxImage[]>(() => attachments.map(attachment => ({
+    src: toFileUrl(attachment.path),
+    caption: attachment.fileName,
+  })), [attachments]);
 
   return (
     <div className="chat-input-container">
@@ -108,11 +114,34 @@ export const ChatInput = ({
         )}
         {attachments.length > 0 && (
           <div className="chat-attachment-strip" aria-label={t('chat.pendingImages')}>
-            {attachments.map(attachment => (
-              <div key={attachment.id} className="chat-attachment-chip">
+            {attachments.map((attachment, attachmentIndex) => (
+              <div
+                key={attachment.id}
+                className="chat-attachment-chip"
+                role="button"
+                tabIndex={0}
+                title={attachment.fileName ?? t('chat.imageViewer')}
+                onClick={() => setLightboxIndex(attachmentIndex)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    setLightboxIndex(attachmentIndex);
+                  }
+                }}
+              >
                 <img src={toFileUrl(attachment.path)} alt={attachment.fileName ?? t('chat.attachmentAlt')} />
                 <span>{attachment.fileName ?? t('chat.imageFallback')}</span>
-                <button type="button" onClick={() => onRemoveAttachment?.(attachment.id)} aria-label={t('chat.removeImage')}>×</button>
+                <button
+                  type="button"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onRemoveAttachment?.(attachment.id);
+                  }}
+                  onKeyDown={(event) => event.stopPropagation()}
+                  aria-label={t('chat.removeImage')}
+                >
+                  ×
+                </button>
               </div>
             ))}
           </div>
@@ -220,6 +249,13 @@ export const ChatInput = ({
           </div>
         </div>
       </div>
+      {lightboxIndex !== null && lightboxImages[lightboxIndex] && (
+        <ChatImageLightbox
+          images={lightboxImages}
+          startIndex={lightboxIndex}
+          onClose={() => setLightboxIndex(null)}
+        />
+      )}
     </div>
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
@@ -2049,6 +2049,19 @@
   background: rgba(255, 255, 255, 0.86);
   font-size: 12px;
   color: #4b5563;
+  cursor: zoom-in;
+  transition: background 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
+}
+
+.chat-attachment-chip:hover {
+  border-color: rgba(35, 131, 226, 0.28);
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.08);
+}
+
+.chat-attachment-chip:focus-visible {
+  outline: 2px solid #2383e2;
+  outline-offset: 2px;
 }
 
 .chat-attachment-chip img {


### PR DESCRIPTION
Improve pending image preview and fullscreen text selection in Canvas workspace.

- Open pending chat image attachments in the existing lightbox
- Keep remove buttons from triggering preview and add hover/focus affordances
- Allow text selection in readonly and fullscreen text nodes for copying

Validation:
- pnpm --filter canvas-workspace typecheck