### PR TITLE
fix: preserve user turns when pruning incomplete tool calls

### DIFF
--- a/packages/engine/src/core/loop.test.ts
+++ b/packages/engine/src/core/loop.test.ts
@@ -97,7 +97,17 @@ describe('loop', () => {
     expect(onResponse).toHaveBeenCalledWith([{ role: 'assistant', content: 'step response' }]);
   });
 
-  it('prunes trailing incomplete tool-call history before calling the LLM', async () => {
+  it('prunes incomplete tool-call parts before calling the LLM without dropping later user turns', async () => {
+    const cleanedMessages = [
+      { role: 'user', content: 'first' },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'I will inspect this.' },
+        ],
+      } as any,
+      { role: 'user', content: 'next turn' },
+    ];
     const context: Context = {
       messages: [
         { role: 'user', content: 'first' },
@@ -123,14 +133,57 @@ describe('loop', () => {
       const result = await loop(context);
 
       expect(result).toBe('recovered');
-      expect(context.messages).toEqual([{ role: 'user', content: 'first' }]);
+      expect(context.messages).toEqual(cleanedMessages);
       expect(streamTextAIMock).toHaveBeenCalledWith(
-        [{ role: 'user', content: 'first' }],
+        cleanedMessages,
         expect.any(Object),
         expect.any(Object),
       );
       expect(warnSpy).toHaveBeenCalledWith(
-        '[loop] Pruned 2 trailing message(s) with incomplete tool-call history before LLM call',
+        '[loop] Pruned 1 incomplete tool-call part(s) before LLM call',
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('removes assistant messages that only contain incomplete tool-call parts', async () => {
+    const cleanedMessages = [
+      { role: 'user', content: 'first' },
+      { role: 'user', content: 'next turn' },
+    ];
+    const context: Context = {
+      messages: [
+        { role: 'user', content: 'first' },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'tool-call', toolCallId: 'call_missing', toolName: 'read', input: { filePath: 'a.ts' } },
+          ],
+        } as any,
+        { role: 'user', content: 'next turn' },
+      ],
+    };
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    streamTextAIMock.mockReturnValue({
+      text: Promise.resolve('recovered'),
+      steps: Promise.resolve([]),
+      finishReason: Promise.resolve('stop'),
+    });
+
+    try {
+      const result = await loop(context);
+
+      expect(result).toBe('recovered');
+      expect(context.messages).toEqual(cleanedMessages);
+      expect(streamTextAIMock).toHaveBeenCalledWith(
+        cleanedMessages,
+        expect.any(Object),
+        expect.any(Object),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[loop] Pruned 1 incomplete tool-call part(s) before LLM call',
       );
     } finally {
       warnSpy.mockRestore();

--- a/packages/engine/src/core/loop.ts
+++ b/packages/engine/src/core/loop.ts
@@ -35,10 +35,10 @@ function getToolCallId(part: unknown): string | undefined {
   return typeof toolCallId === 'string' && toolCallId.length > 0 ? toolCallId : undefined;
 }
 
-function findFirstIncompleteToolExchangeIndex(messages: ModelMessage[]): number | undefined {
-  const pendingToolCalls = new Map<string, number>();
+function findIncompleteToolCallIds(messages: ModelMessage[]): Set<string> {
+  const pendingToolCalls = new Set<string>();
 
-  messages.forEach((message, index) => {
+  messages.forEach((message) => {
     const content = (message as { content?: unknown }).content;
     if (!Array.isArray(content)) return;
 
@@ -48,27 +48,40 @@ function findFirstIncompleteToolExchangeIndex(messages: ModelMessage[]): number 
       if (!toolCallId) continue;
 
       if (type === 'tool-call') {
-        pendingToolCalls.set(toolCallId, index);
+        pendingToolCalls.add(toolCallId);
       } else if (type === 'tool-result') {
         pendingToolCalls.delete(toolCallId);
       }
     }
   });
 
-  let firstIndex: number | undefined;
-  for (const index of pendingToolCalls.values()) {
-    firstIndex = firstIndex === undefined ? index : Math.min(firstIndex, index);
-  }
-  return firstIndex;
+  return pendingToolCalls;
 }
 
 function pruneIncompleteToolExchanges(messages: ModelMessage[]): ModelMessage[] {
-  const firstIncompleteIndex = findFirstIncompleteToolExchangeIndex(messages);
-  if (firstIncompleteIndex === undefined) return messages;
+  const incompleteToolCallIds = findIncompleteToolCallIds(messages);
+  if (incompleteToolCallIds.size === 0) return messages;
 
-  const pruned = messages.slice(0, firstIncompleteIndex);
+  let removedParts = 0;
+  const pruned = messages.flatMap((message) => {
+    const content = (message as { content?: unknown }).content;
+    if (!Array.isArray(content)) return [message];
+
+    const nextContent = content.filter((part) => {
+      const type = part && typeof part === 'object' ? (part as { type?: unknown }).type : undefined;
+      const toolCallId = getToolCallId(part);
+      const shouldRemove = type === 'tool-call' && toolCallId !== undefined && incompleteToolCallIds.has(toolCallId);
+      if (shouldRemove) removedParts += 1;
+      return !shouldRemove;
+    });
+
+    if (nextContent.length === content.length) return [message];
+    if (nextContent.length === 0) return [];
+    return [{ ...message, content: nextContent } as ModelMessage];
+  });
+
   console.warn(
-    `[loop] Pruned ${messages.length - pruned.length} trailing message(s) with incomplete tool-call history before LLM call`,
+    `[loop] Pruned ${removedParts} incomplete tool-call part(s) before LLM call`,
   );
   return pruned;
 }


### PR DESCRIPTION
## Summary
- change incomplete tool-call cleanup to remove only dangling tool-call parts instead of truncating all later messages
- preserve later user turns when recovering from missing tool-result history
- add regression coverage for mixed assistant text/tool-call messages and tool-call-only assistant messages

## Validation
- pnpm install --ignore-scripts --offline
- pnpm --filter pulse-coder-engine exec vitest run src/core/loop.test.ts
- pnpm --filter pulse-coder-orchestrator build
- pnpm --filter pulse-coder-engine build