### PR TITLE
[codex] define harness design

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,104 +1,116 @@
-# Repository Guidelines
+# AGENTS.md
 
-## Repository Harness
+This file orients agents working in the Coder repository. It is a thin routing + boundary layer; substantive knowledge lives downstream in `harness/`, per-workspace `AGENTS.md`, and `docs/`.
 
-The active repository-level harness source of truth is `harness/`. Use it as a progressive map, not as a document dump:
+## 0. Meta rules (precedence + SSOT)
 
-```text
-AGENTS.md / CLAUDE.md
--> harness/README.md
--> harness/profile.yaml
--> affected workspace entry
--> workspace contracts/spec/runbook/validation as needed
-```
+1. **Precedence**: this file > affected workspace's `AGENTS.md` > `harness/profile.yaml` (routing) + `harness/validation.yaml` (checks) > `harness/skills/*` (action protocols) > package-level `docs/`. Lower layers refine, never contradict, the upper.
+2. **SSOT, no copies**: the active workspace set lives in `pnpm-workspace.yaml` + `harness/profile.yaml` — do not re-list it here. Package metadata lives in each `package.json`. Skill content is NOT duplicated across `.pulse-coder/skills/` (runtime task skills) and `harness/skills/` (repo action protocols) — they are different layers; do not merge or copy between them.
+3. **Mechanism over doc, stated honestly**: prefer extending plugin/hook/tool boundaries over hardcoding into `packages/engine/src/core/loop.ts`. There is currently NO automated gate layer (see §4); validation commands must be run by hand. Where a spec says "enforce," verify a runner exists before relying on it.
+4. **First principles before solutions**: confirm the real problem, goal, constraints, and evidence (from current repo or reproducible behavior) before acting. Do not reverse-engineer a conclusion from an existing MR, neighboring code, or a candidate solution. If you cannot state what real problem a change solves and where the evidence is, do not implement.
+5. **Occam / reuse-first**: reuse existing entries, modules, scripts, skills, and docs before adding new ones. Add a new skill, doc, abstraction, or process only when the current system cannot carry the work AND the new asset reduces real complexity or provides an executable constraint. "Could be updated to latest" is not a reason to add.
 
-`.pulse-coder/` is product/runtime configuration and test surface for Pulse Coder itself; do not treat it as the source of truth for this repository harness pilot.
+**Pre-implementation self-check** (run mentally before coding):
+1. Is the problem real, with evidence from this repo or a reproducible case?
+2. Can an existing entry / module / skill / script carry this — if not, why?
+3. What is the minimal change that avoids parallel entries and duplicate rules?
+4. Where is the SSOT for any rule I'm touching, and how do引用方 stay in sync?
+5. Can this be a mechanism (type / lint / test / hook / script) rather than a doc line? If only doc, is the reason stated?
 
-## Project Structure & Module Organization
-This repo is a `pnpm` monorepo with all `packages/*` workspaces plus selected app workspaces listed in `pnpm-workspace.yaml`.
+## 1. Routing
 
-Root-level guidance should route work to the right local entry, then the local `AGENTS.md` should carry the package-specific map, boundaries, and validation notes. Primary source code lives under each package/app `src/` directory; build output goes to `dist/`.
+**Reading chain**: `AGENTS.md` → `harness/README.md` → `harness/profile.yaml` → affected workspace entry + its `AGENTS.md`/`docs/` → `harness/validation.yaml`.
 
-## Workspace Entry Index
+**Doc taxonomy:**
+- **L0 root entries**: `AGENTS.md` (this file), `CLAUDE.md`, `README.md` — routing, harness pilot, project intro.
+- **L1 mid-level index**: `harness/README.md`, `harness/profile.yaml` (workspace routing), `harness/validation.yaml` (path→check mapping), root `docs/` topic dirs (`harness/`, `mcp-plugin/`, `memory-plugin/`, `plan-mode/`, `plugin-system/`).
+- **L2 module entries**: each workspace's `AGENTS.md` (14 active), `harness/skills/*` (repo action protocols), `harness/templates/*`.
 
-| Workspace | Local entry | Start there when the change touches |
-|---|---|---|
-| `packages/engine` | `packages/engine/AGENTS.md` | engine loop, providers, prompts, tools, hooks, plugins, context, or public runtime API |
-| `packages/cli` | `packages/cli/AGENTS.md` | terminal UX, sessions, slash commands, ACP/team/memory wiring, or CLI sandbox registration |
-| `packages/acp` | `packages/acp/AGENTS.md` | ACP JSON-RPC clients, child processes, external agent sessions, permissions, or file handlers |
-| `packages/pulse-sandbox` | `packages/pulse-sandbox/AGENTS.md` | sandboxed JavaScript execution or the `run_js` tool adapter |
-| `packages/agent-teams` | `packages/agent-teams/AGENTS.md` | team runtime, task state, review gates, verification metadata, handoffs, or team protocol APIs |
-| `packages/orchestrator` | `packages/orchestrator/AGENTS.md` | generic DAG planning, routing, scheduling, agent runners, artifacts, or aggregation |
-| `packages/plugin-kit` | `packages/plugin-kit/AGENTS.md` | worktree binding, vault binding, devtools timelines, or reusable plugin infrastructure |
-| `packages/memory-plugin` | `packages/memory-plugin/AGENTS.md` | memory services, recall/write policy, embeddings, daily logs, layered storage, or memory tools |
-| `packages/langfuse-plugin` | `packages/langfuse-plugin/AGENTS.md` | Langfuse traces, generations, tool spans, compaction events, or observability hooks |
-| `packages/canvas-cli` | `packages/canvas-cli/AGENTS.md` | `pulse-canvas` CLI commands, canvas store inspection/mutation, or runtime-control helpers |
-| `packages/canvas-nodes` | `packages/canvas-nodes/AGENTS.md` | external Canvas node plugins, manifests, capability providers, renderers, or webview node apps |
-| `apps/remote-server` | `apps/remote-server/AGENTS.md` | HTTP/webhook runtime, platform adapters, internal routes, devtools, or remote session wiring |
-| `apps/teams-cli` | `apps/teams-cli/AGENTS.md` | terminal host behavior for agent teams run/plan/interactive workflows |
-| `apps/canvas-workspace` | `apps/canvas-workspace/AGENTS.md` | Electron workbench, canvas persistence, Canvas Agent, teams UI, plugins, webviews, PTYs, or app harness |
+**Intent navigation** (find the entry point; then read the workspace's own `AGENTS.md`):
 
-## Auxiliary App Directories
+| Intent | First file / dir |
+|---|---|
+| Add a built-in plugin | `packages/engine/src/built-in/index.ts` + new subdir |
+| Register a tool | `packages/engine/src/tools/` (built-in) or `ctx.registerTool` in a plugin |
+| Change the core loop / hooks | `packages/engine/src/core/loop.ts` |
+| Add/fix an MCP server config | `.pulse-coder/mcp.json` + `packages/engine/src/built-in/mcp-plugin/` |
+| Tune context compaction | `packages/engine/src/core/loop.ts` + env (`CONTEXT_WINDOW_TOKENS`, `COMPACT_*`, `KEEP_LAST_TURNS`) |
+| Add a runtime skill | `.pulse-coder/skills/<name>/SKILL.md` |
+| Add a sub-agent | `.pulse-coder/agents/*.md` |
+| Change an orchestration role | `packages/orchestrator/` |
+| Change a remote-server adapter | `apps/remote-server/src/adapters/` + `core/dispatcher.ts` |
+| Add a canvas node plugin | `packages/canvas-nodes/` |
+| Add/remove a workspace | `pnpm-workspace.yaml` + `harness/profile.yaml` + `harness/validation.yaml` |
+| Update what to run for a path | `harness/validation.yaml` |
+| Review changes (repo-aware) | `harness/skills/code-review.md` |
+| Inspect harness coverage | `node harness/tools/graph-viewer/server.mjs --once` |
 
-These directories are useful context, but they are not active pnpm workspaces in the repository harness unless `pnpm-workspace.yaml` is expanded:
+## 2. Hard boundaries (real values)
 
-- `apps/coder-demo`: legacy standalone experimental app; its placeholder test script is expected to fail.
-- `apps/devtools-web`: auxiliary Vite devtools UI that can be served by `apps/remote-server` when built.
-- `apps/canvas-plugin-react-mf-note-demo`: standalone Canvas external plugin demo with its own package flow.
+- **Package manager**: `pnpm@10.28.0` (`packageManager`). Never npm/yarn.
+- **Node**: unpinned (no `.nvmrc`/`engines`). Do not assume a version; adding a pin is an open gap.
+- **TypeScript**: `strict:true` from root `tsconfig.json`. Keep strict ON. `apps/teams-cli` + `apps/canvas-workspace` use standalone tsconfigs — root changes do not reach them. `plugin-kit`/`memory-plugin`/`langfuse-plugin`/`teams-cli` typecheck hits TS6059 rootDir errors locally — default to `build` as the JS smoke check there.
+- **Module format**: ESM repo-wide (`"type":"module"`). CommonJS holdouts: `packages/cli`, `packages/canvas-cli`, `apps/teams-cli` — match each package's `"type"`.
+- **Tests**: `vitest run` (sole runner, no config file — defaults apply). Honest test reality: `plugin-kit` + `langfuse-plugin` declare `vitest run` with ZERO test files and NO `--passWithNoTests` → they fail under the default command. `orchestrator`/`teams-cli` use `--passWithNoTests` with no real specs → green ≠ coverage. `remote-server` has NO test/typecheck (runtime app). `cli` has NO typecheck.
+- **Build**: `tsup`; root `build` uses `SKIP_DTS=1`.
+- **Path aliases**: only `pulse-coder-engine`, `pulse-coder-orchestrator`, `pulse-coder-plugin-kit`, `pulse-coder-acp`, `pulse-coder-agent-teams` (root `tsconfig.json`). Use `workspace:*` deps for the rest; do not invent aliases.
+- **Lint/format**: ABSENT (no eslint/prettier/biome). Self-enforce; match surrounding files (2 spaces, semicolons, single quotes).
 
-## Build, Test, and Development Commands
-- `pnpm install`: install workspace dependencies.
-- `pnpm run build`: build core workspaces recursively.
-- `pnpm run dev`: watch mode for packages.
-- `pnpm start`: run the CLI (`pulse-coder-cli`).
-- `pnpm test`: run package tests (`./packages/*`).
-- `pnpm run test:apps`: run tests for app workspaces matched by pnpm filters.
-- `node harness/tools/graph-viewer/server.mjs --once`: validate the harness data behind the dashboard once.
-- `pnpm --filter pulse-coder-engine typecheck`: strict TS typecheck for engine.
+## 3. Auxiliary-workspace boundary
 
-Useful package targets:
-- `pnpm --filter pulse-coder-engine test`
-- `pnpm --filter pulse-coder-cli test`
-- `pnpm --filter pulse-sandbox test`
-- `pnpm --filter pulse-coder-memory-plugin test`
-- `pnpm --filter @pulse-coder/remote-server build`
-- `pnpm --filter @pulse-coder/remote-server dev`
+Active pnpm workspaces = `packages/*` + `apps/remote-server` + `apps/teams-cli` + `apps/canvas-workspace`. `apps/coder-demo`, `apps/devtools-web`, `apps/canvas-plugin-react-mf-note-demo` are real but excluded (no AGENTS.md — excluded by policy). `packages/demo` is empty. Five app dirs (`canvas-plugin-figma-webview`, `frontend`, `pulse-agent-test`, `react-framework`, `todo-test-app`) are untracked stubs with no `package.json` — do not edit them expecting wiring. `apps/EXPERIMENTAL.md` is stale (claims `canvas-workspace` excluded) — trust `pnpm-workspace.yaml`, not that file.
 
-Use the affected workspace entry and `harness/validation.yaml` before picking checks. Some local entries document package commands that are intentionally absent or currently red; do not promote those commands to root-level defaults until the package itself is cleaned up.
+## 4. Prerequisite gates (honest: none are mechanical)
 
-## Coding Style & Naming Conventions
-Use TypeScript with strict mode and keep style consistent with neighboring files:
-- 2-space indentation, semicolons, and single quotes in most TS code.
-- `PascalCase` for classes/types (`Engine`, `PluginManager`).
-- `camelCase` for variables/functions.
-- `kebab-case` for multi-word file names (`session-commands.ts`).
-- `UPPER_SNAKE_CASE` for exported constants.
+There is NO CI, NO git hooks, NO husky/lint-staged/commitlint, and NO executable checks under `harness/checks/` (placeholder only). `harness/validation.yaml` is a declarative spec — nothing runs it for you. `harness/tools/*` (except `graph-viewer`) are protocol specs, not executables; `scripts/harness/` does not exist.
 
-No repository-wide ESLint/Prettier enforcement is guaranteed; keep diffs minimal and focused.
+**Skill taxonomy (two tiers — do not merge):**
 
-## Testing Guidelines
-Vitest is used across core packages. Name tests `*.test.ts` or `*.spec.ts` and keep them near related source files.
+| Tier | Location | Role | Loaded how |
+|---|---|---|---|
+| Runtime task skills | `.pulse-coder/skills/*/SKILL.md` (10) | On-demand task knowledge/procedures (git-workflow, mr-generator, refactor, …) | engine skills plugin → `skill` tool |
+| Repo action protocols | `harness/skills/*.md` (5) | Binding behavior-norm protocols | NOT loaded at runtime — carried by you |
 
-Add tests for behavior changes in:
-- loop control and compaction behavior,
-- plugin/tool registration and hook behavior,
-- CLI command handling and session workflows,
-- memory integration boundaries.
+**Action → required pre-read** (repo action protocols; manual, no runtime enforcement):
 
+| Action | Read first |
+|---|---|
+| Touch a workspace's code | that workspace's `AGENTS.md` + matching `harness/profile.yaml` entry |
+| Change crossing package contracts | `harness/skills/contract-coding.md` + relevant `docs/contracts.md` |
+| Add/adjust repo or workspace docs | `harness/skills/doc-governance.md` |
+| Propose a process / governance change | `harness/skills/feedback-governance.md` |
+| Review a diff (repo-aware) | `harness/skills/code-review.md` |
+| Quality self-check / acceptance gate | `harness/skills/quality-workflow.md` |
 
-## Commit & Pull Request Guidelines
-Follow Conventional Commits (scope optional):
-- `feat(engine): ...`
-- `fix(cli): ...`
-- `chore: ...`
+`harness/skills/*` are behavior-norm protocols, NOT runtime skills (no engine loader) — the binding rules must be carried by you, not enforced at runtime.
 
-PRs should include:
-- clear summary and affected package(s),
-- linked issue (if applicable),
-- test evidence (commands and results),
-- terminal evidence/screenshots for CLI UX changes when relevant.
+**Gap to close (aspirational, not present):** wire `harness/validation.yaml` to a real runner (CI on changed paths, or a husky pre-push) and implement the candidate checks in `harness/checks/README.md`. Do not claim these exist today.
 
-## Security & Configuration Tips
-- Keep secrets in local `.env` files only (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `TAVILY_API_KEY`, `GEMINI_API_KEY`, etc.).
-- Never commit credentials, local session data, or private memory databases.
-- Prefer `.pulse-coder/*` config paths; legacy `.coder/*` paths exist for compatibility.
+## 5. Acceptance (reproducible + verifiable)
+
+Run the commands `harness/validation.yaml` binds to your changed path:
+- Package change → `pnpm --filter <pkg-name> test` and `pnpm --filter <pkg-name> typecheck` (where they exist).
+- Cross-package / contract change → also apply the escalation rules in `harness/validation.yaml`.
+- Full local sweep → `pnpm run build` (SKIP_DTS=1), then `pnpm run test:core`.
+- `canvas-workspace` is in `test:all`/`build:all` but NOT `build:core`/`test:core` — include it explicitly when you touch it (it has the largest test suite: 97 files).
+- Harness data change → `node harness/tools/graph-viewer/server.mjs --once` must report `harnessGaps:0`.
+
+**Red command — do not promote:** `pnpm run test:apps` can exit 1 because `apps/coder-demo`'s test script is `echo Error && exit 1`. Use targeted `pnpm --filter <pkg> test`; do not treat a bare `test:apps` failure as a regression unless you've filtered out excluded apps. Likewise a green `pnpm test` is not proof for `plugin-kit`/`langfuse-plugin`/`orchestrator`/`teams-cli` (no real specs).
+
+## 6. Failure capture (named failure → guard)
+
+- **Over-pruning tool-call history dropped later user turns**: first fix sliced messages at the first incomplete tool-call, losing legitimate later user turns. Guard: `pruneIncompleteToolExchanges()` surgically filters only the incomplete part; regression tests in `packages/engine/src/core/loop.test.ts` assert later user turns survive. Any new message-history cleanup in `loop.ts` MUST add a parallel regression test.
+- **Blocking I/O froze the Electron host**: `bash` tool used `execSync`, blocking the event loop and freezing `canvas-workspace` UI. Guard: `bash.ts` now uses async `spawn` with `SIGTERM`→`SIGKILL`. Rule: never `execSync`/blocking I/O in `packages/engine/src/tools/*` — the engine runs on GUI main threads. (Two wrong-root-cause fixes — pulse-sandbox interrupt, PTY coalescing — were reverted; confirm the actual blocking call before patching adjacent paths.)
+- **UTF-8 chunk-split corruption**: async rewrite decoded each pipe chunk independently, corrupting multi-byte CJK. Guard: collect raw `Buffer`s and decode once.
+- **MCP reload stale/empty state**: reload didn't activate the target scope first. Guard: `activateScope` before reload, force fresh probe.
+- **Stale doc claimed canvas-workspace excluded**: `apps/EXPERIMENTAL.md` contradicts `pnpm-workspace.yaml:5`. Guard: `pnpm-workspace.yaml` + `harness/profile.yaml` are SSOT; run `graph-viewer --once` to detect coverage drift; do not trust prose workspace lists.
+
+Failures are captured in fix commits + regression tests (TODO/FIXME density is zero across `packages/*/src`; `harness/feedback/inbox.md` is an empty template) — debug via `git log -- <file>` and `loop.test.ts` cases, not by grepping for TODOs.
+
+## 7. Security / secrets
+
+Do not commit API keys or tokens. Runtime keys (`OPENAI_API_KEY`/`PULSE_OPENAI_API_KEY`, `ANTHROPIC_API_KEY`/`PULSE_ANTHROPIC_API_KEY`, `TAVILY_API_KEY`, `GEMINI_API_KEY`, `INTERNAL_API_SECRET`, `CLARIFICATION_*`) are env-only. Default model precedence (code at `packages/engine/src/config/index.ts`): `ANTHROPIC_MODEL` → `OPENAI_MODEL` → `PULSE_ANTHROPIC_MODEL` → `PULSE_OPENAI_MODEL` → `novita/deepseek/deepseek_v3`. `PULSE_`-prefixed fallbacks exist for every provider var. Remote-server internal routes are loopback-only and require `INTERNAL_API_SECRET`. Plugin secret storage uses the vault helpers in `pulse-coder-plugin-kit`.
+
+## 8. `.pulse-coder/` vs `.coder/`
+
+`.pulse-coder/` is the active runtime/product config root. On disk it holds `mcp.json` (3 servers: `eido_mind`, `deepwiki`, `twitter` — all `deferTools:true`), `agents/` (8 sub-agents), `skills/` (10 runtime knowledge skills). `config.json`, `engine-plugins/`, and `skills/remote.json` are ABSENT on disk but their loaders are wired in source. Legacy `.coder/*` paths remain compatible in the MCP/skills/sub-agent/engine-plugins loaders but are not preferred — write new config under `.pulse-coder/`. Runtime skills (`.pulse-coder/skills`) and repo action protocols (`harness/skills`) are different layers; the `code-review` name appears in both by design (runtime generic checklist vs repo-aware protocol) — do not merge them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,206 +1,116 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file orients agents working in the Coder repository. It is a thin routing + boundary layer; substantive knowledge lives downstream in `harness/`, per-workspace `AGENTS.md`, and `docs/`.
 
-## Repository Harness
+## 0. Meta rules (precedence + SSOT)
 
-The active repository-level harness source of truth is `harness/`. Use it as a progressive map when deciding what to read, where knowledge should live, and which validation to run:
+1. **Precedence**: this file > affected workspace's `AGENTS.md` > `harness/profile.yaml` (routing) + `harness/validation.yaml` (checks) > `harness/skills/*` (action protocols) > package-level `docs/`. Lower layers refine, never contradict, the upper.
+2. **SSOT, no copies**: the active workspace set lives in `pnpm-workspace.yaml` + `harness/profile.yaml` — do not re-list it here. Package metadata lives in each `package.json`. Skill content is NOT duplicated across `.pulse-coder/skills/` (runtime task skills) and `harness/skills/` (repo action protocols) — they are different layers; do not merge or copy between them.
+3. **Mechanism over doc, stated honestly**: prefer extending plugin/hook/tool boundaries over hardcoding into `packages/engine/src/core/loop.ts`. There is currently NO automated gate layer (see §4); validation commands must be run by hand. Where a spec says "enforce," verify a runner exists before relying on it.
+4. **First principles before solutions**: confirm the real problem, goal, constraints, and evidence (from current repo or reproducible behavior) before acting. Do not reverse-engineer a conclusion from an existing MR, neighboring code, or a candidate solution. If you cannot state what real problem a change solves and where the evidence is, do not implement.
+5. **Occam / reuse-first**: reuse existing entries, modules, scripts, skills, and docs before adding new ones. Add a new skill, doc, abstraction, or process only when the current system cannot carry the work AND the new asset reduces real complexity or provides an executable constraint. "Could be updated to latest" is not a reason to add.
 
-```text
-CLAUDE.md / AGENTS.md
--> harness/README.md
--> harness/profile.yaml
--> affected workspace entry
--> workspace contracts/spec/runbook/validation as needed
-```
+**Pre-implementation self-check** (run mentally before coding):
+1. Is the problem real, with evidence from this repo or a reproducible case?
+2. Can an existing entry / module / skill / script carry this — if not, why?
+3. What is the minimal change that avoids parallel entries and duplicate rules?
+4. Where is the SSOT for any rule I'm touching, and how do引用方 stay in sync?
+5. Can this be a mechanism (type / lint / test / hook / script) rather than a doc line? If only doc, is the reason stated?
 
-`.pulse-coder/` remains Pulse Coder runtime/product configuration (`mcp`, runtime `skills`, agents, model config examples, and compatibility paths). Do not use it as the source of truth for this repository harness pilot.
+## 1. Routing
 
-## Project Overview
+**Reading chain**: `AGENTS.md` → `harness/README.md` → `harness/profile.yaml` → affected workspace entry + its `AGENTS.md`/`docs/` → `harness/validation.yaml`.
 
-Pulse Coder is a plugin-first AI coding assistant built as a TypeScript monorepo.
+**Doc taxonomy:**
+- **L0 root entries**: `AGENTS.md` (this file), `CLAUDE.md`, `README.md` — routing, harness pilot, project intro.
+- **L1 mid-level index**: `harness/README.md`, `harness/profile.yaml` (workspace routing), `harness/validation.yaml` (path→check mapping), root `docs/` topic dirs (`harness/`, `mcp-plugin/`, `memory-plugin/`, `plan-mode/`, `plugin-system/`).
+- **L2 module entries**: each workspace's `AGENTS.md` (14 active), `harness/skills/*` (repo action protocols), `harness/templates/*`.
 
-Core capabilities include:
-- reusable `Engine` runtime,
-- interactive CLI with session/task workflows,
-- built-in MCP/skills/plan-mode/task-tracking/sub-agent plugins,
-- optional memory integration and remote HTTP runtime.
+**Intent navigation** (find the entry point; then read the workspace's own `AGENTS.md`):
 
-## Monorepo Structure
+| Intent | First file / dir |
+|---|---|
+| Add a built-in plugin | `packages/engine/src/built-in/index.ts` + new subdir |
+| Register a tool | `packages/engine/src/tools/` (built-in) or `ctx.registerTool` in a plugin |
+| Change the core loop / hooks | `packages/engine/src/core/loop.ts` |
+| Add/fix an MCP server config | `.pulse-coder/mcp.json` + `packages/engine/src/built-in/mcp-plugin/` |
+| Tune context compaction | `packages/engine/src/core/loop.ts` + env (`CONTEXT_WINDOW_TOKENS`, `COMPACT_*`, `KEEP_LAST_TURNS`) |
+| Add a runtime skill | `.pulse-coder/skills/<name>/SKILL.md` |
+| Add a sub-agent | `.pulse-coder/agents/*.md` |
+| Change an orchestration role | `packages/orchestrator/` |
+| Change a remote-server adapter | `apps/remote-server/src/adapters/` + `core/dispatcher.ts` |
+| Add a canvas node plugin | `packages/canvas-nodes/` |
+| Add/remove a workspace | `pnpm-workspace.yaml` + `harness/profile.yaml` + `harness/validation.yaml` |
+| Update what to run for a path | `harness/validation.yaml` |
+| Review changes (repo-aware) | `harness/skills/code-review.md` |
+| Inspect harness coverage | `node harness/tools/graph-viewer/server.mjs --once` |
 
-This repo uses `pnpm` workspaces for all `packages/*` plus selected apps listed in `pnpm-workspace.yaml`.
+## 2. Hard boundaries (real values)
 
-Primary packages:
-- `packages/engine` (`pulse-coder-engine`): core engine loop, tools, plugin manager, built-in plugins.
-- `packages/cli` (`pulse-coder-cli`): interactive terminal app built on the engine.
-- `packages/pulse-sandbox` (`pulse-sandbox`): sandboxed JS executor used by `run_js`.
-- `packages/memory-plugin` (`pulse-coder-memory-plugin`): memory service/integration helpers.
-- `packages/plugin-kit` (`pulse-coder-plugin-kit`): shared utilities for building plugins — exports worktree helpers, vault (secret storage), and devtools utilities.
-- `packages/orchestrator` (`pulse-coder-orchestrator`): multi-agent orchestration layer (TaskGraph, planner, scheduler, runner, aggregator).
-- `packages/agent-teams` (`pulse-coder-agent-teams`): agent teams coordination built on orchestrator.
-- `packages/acp` (`pulse-coder-acp`): Agent Context Protocol — typed client, runner, and state store for Claude's native ACP session protocol.
+- **Package manager**: `pnpm@10.28.0` (`packageManager`). Never npm/yarn.
+- **Node**: unpinned (no `.nvmrc`/`engines`). Do not assume a version; adding a pin is an open gap.
+- **TypeScript**: `strict:true` from root `tsconfig.json`. Keep strict ON. `apps/teams-cli` + `apps/canvas-workspace` use standalone tsconfigs — root changes do not reach them. `plugin-kit`/`memory-plugin`/`langfuse-plugin`/`teams-cli` typecheck hits TS6059 rootDir errors locally — default to `build` as the JS smoke check there.
+- **Module format**: ESM repo-wide (`"type":"module"`). CommonJS holdouts: `packages/cli`, `packages/canvas-cli`, `apps/teams-cli` — match each package's `"type"`.
+- **Tests**: `vitest run` (sole runner, no config file — defaults apply). Honest test reality: `plugin-kit` + `langfuse-plugin` declare `vitest run` with ZERO test files and NO `--passWithNoTests` → they fail under the default command. `orchestrator`/`teams-cli` use `--passWithNoTests` with no real specs → green ≠ coverage. `remote-server` has NO test/typecheck (runtime app). `cli` has NO typecheck.
+- **Build**: `tsup`; root `build` uses `SKIP_DTS=1`.
+- **Path aliases**: only `pulse-coder-engine`, `pulse-coder-orchestrator`, `pulse-coder-plugin-kit`, `pulse-coder-acp`, `pulse-coder-agent-teams` (root `tsconfig.json`). Use `workspace:*` deps for the rest; do not invent aliases.
+- **Lint/format**: ABSENT (no eslint/prettier/biome). Self-enforce; match surrounding files (2 spaces, semicolons, single quotes).
 
-Apps:
-- `apps/remote-server`: HTTP wrapper around engine runtime (Feishu/Discord/Telegram adapters).
-- `apps/teams-cli`: CLI for multi-agent teams workflows.
-- `apps/canvas-workspace`: canvas-based workspace app.
+## 3. Auxiliary-workspace boundary
 
-Other `apps/*` directories may be legacy, standalone, or auxiliary projects; do not treat them as active pnpm workspaces unless `pnpm-workspace.yaml` includes them.
+Active pnpm workspaces = `packages/*` + `apps/remote-server` + `apps/teams-cli` + `apps/canvas-workspace`. `apps/coder-demo`, `apps/devtools-web`, `apps/canvas-plugin-react-mf-note-demo` are real but excluded (no AGENTS.md — excluded by policy). `packages/demo` is empty. Five app dirs (`canvas-plugin-figma-webview`, `frontend`, `pulse-agent-test`, `react-framework`, `todo-test-app`) are untracked stubs with no `package.json` — do not edit them expecting wiring. `apps/EXPERIMENTAL.md` is stale (claims `canvas-workspace` excluded) — trust `pnpm-workspace.yaml`, not that file.
 
-## Build, Dev, and Test Commands
+## 4. Prerequisite gates (honest: none are mechanical)
 
-```bash
-pnpm install
-pnpm run build          # builds packages/* + remote-server + teams-cli (SKIP_DTS=1)
-pnpm run build:all      # builds all declared pnpm workspaces
-pnpm run dev
-pnpm start              # starts pulse-coder-cli
-pnpm start:debug        # starts CLI with debug logging
-pnpm test               # alias for test:core (packages/* + remote-server + teams-cli)
-pnpm run test:packages  # packages/* only
-pnpm run test:apps      # app workspaces matched by pnpm filters
-pnpm run test:all       # all packages and apps
-```
+There is NO CI, NO git hooks, NO husky/lint-staged/commitlint, and NO executable checks under `harness/checks/` (placeholder only). `harness/validation.yaml` is a declarative spec — nothing runs it for you. `harness/tools/*` (except `graph-viewer`) are protocol specs, not executables; `scripts/harness/` does not exist.
 
-Useful filtered commands:
+**Skill taxonomy (two tiers — do not merge):**
 
-```bash
-pnpm --filter pulse-coder-engine test
-pnpm --filter pulse-coder-engine typecheck
-pnpm --filter pulse-coder-cli test
-pnpm --filter pulse-sandbox test
-pnpm --filter pulse-coder-memory-plugin test
-pnpm --filter pulse-coder-plugin-kit test
-pnpm --filter pulse-coder-orchestrator test
-pnpm --filter pulse-coder-agent-teams test
-pnpm --filter @pulse-coder/remote-server build
-pnpm --filter @pulse-coder/remote-server dev
-```
+| Tier | Location | Role | Loaded how |
+|---|---|---|---|
+| Runtime task skills | `.pulse-coder/skills/*/SKILL.md` (10) | On-demand task knowledge/procedures (git-workflow, mr-generator, refactor, …) | engine skills plugin → `skill` tool |
+| Repo action protocols | `harness/skills/*.md` (5) | Binding behavior-norm protocols | NOT loaded at runtime — carried by you |
 
-All packages use **vitest** (`vitest run`) for tests and `tsc --noEmit` for typechecking.
+**Action → required pre-read** (repo action protocols; manual, no runtime enforcement):
 
-Notes:
-- `pnpm test` (`test:core`) covers `packages/*`, `@pulse-coder/remote-server`, and `@pulse-coder/teams-cli`.
-- `pnpm run test:apps` covers declared app workspaces matched by pnpm filters.
+| Action | Read first |
+|---|---|
+| Touch a workspace's code | that workspace's `AGENTS.md` + matching `harness/profile.yaml` entry |
+| Change crossing package contracts | `harness/skills/contract-coding.md` + relevant `docs/contracts.md` |
+| Add/adjust repo or workspace docs | `harness/skills/doc-governance.md` |
+| Propose a process / governance change | `harness/skills/feedback-governance.md` |
+| Review a diff (repo-aware) | `harness/skills/code-review.md` |
+| Quality self-check / acceptance gate | `harness/skills/quality-workflow.md` |
 
-## Architecture Notes
+`harness/skills/*` are behavior-norm protocols, NOT runtime skills (no engine loader) — the binding rules must be carried by you, not enforced at runtime.
 
-### Engine bootstrap
-`Engine.initialize()` (`packages/engine/src/Engine.ts`) does:
-1. plugin manager setup,
-2. built-in plugin loading (unless disabled),
-3. plugin tool registration,
-4. optional custom tool merge (`EngineOptions.tools`, highest priority).
+**Gap to close (aspirational, not present):** wire `harness/validation.yaml` to a real runner (CI on changed paths, or a husky pre-push) and implement the candidate checks in `harness/checks/README.md`. Do not claim these exist today.
 
-### Execution loop
-Core loop is `packages/engine/src/core/loop.ts`.
-It supports:
-- streaming text/tool events,
-- LLM hooks (`beforeLLMCall`, `afterLLMCall`),
-- tool hooks (`beforeToolCall`, `afterToolCall`),
-- run-level hooks (`beforeRun`, `afterRun`) — fired once per `Engine.run()` call; `beforeRun` can mutate `systemPrompt` and `tools`,
-- retry/backoff on retryable errors,
-- abort handling,
-- context compaction.
+## 5. Acceptance (reproducible + verifiable)
 
-### Built-in plugins
-Registered from `packages/engine/src/built-in/index.ts`:
-- MCP plugin (`.pulse-coder/mcp.json`, legacy `.coder/mcp.json`),
-- skills plugin (`SKILL.md` scanning + `skill` tool),
-- plan-mode plugin,
-- task-tracking plugin,
-- sub-agent plugin (`.pulse-coder/agents/*.md`),
-- tool-search plugin (deferred tool discovery),
-- role-soul plugin (persona/system prompt injection),
-- agent-teams plugin (multi-agent coordination),
-- ptc plugin (PTC workflow integration).
+Run the commands `harness/validation.yaml` binds to your changed path:
+- Package change → `pnpm --filter <pkg-name> test` and `pnpm --filter <pkg-name> typecheck` (where they exist).
+- Cross-package / contract change → also apply the escalation rules in `harness/validation.yaml`.
+- Full local sweep → `pnpm run build` (SKIP_DTS=1), then `pnpm run test:core`.
+- `canvas-workspace` is in `test:all`/`build:all` but NOT `build:core`/`test:core` — include it explicitly when you touch it (it has the largest test suite: 97 files).
+- Harness data change → `node harness/tools/graph-viewer/server.mjs --once` must report `harnessGaps:0`.
 
-### Writing a plugin
-Implement `EnginePlugin` from `pulse-coder-engine`. The `initialize(ctx: EnginePluginContext)` method receives a context with:
-- `ctx.registerTool(name, tool)` / `ctx.registerTools(map)` — add tools to the engine,
-- `ctx.registerHook(hookName, handler)` — subscribe to any hook in `EngineHookMap` (`beforeRun`, `afterRun`, `beforeLLMCall`, `afterLLMCall`, `beforeToolCall`, `afterToolCall`, `onToolCall`, `onCompacted`),
-- `ctx.registerService(name, service)` / `ctx.getService(name)` — share objects between plugins,
-- `ctx.getConfig(key)` / `ctx.setConfig(key, val)` — engine-scoped config,
-- `ctx.events` (EventEmitter), `ctx.logger`.
+**Red command — do not promote:** `pnpm run test:apps` can exit 1 because `apps/coder-demo`'s test script is `echo Error && exit 1`. Use targeted `pnpm --filter <pkg> test`; do not treat a bare `test:apps` failure as a regression unless you've filtered out excluded apps. Likewise a green `pnpm test` is not proof for `plugin-kit`/`langfuse-plugin`/`orchestrator`/`teams-cli` (no real specs).
 
-Pass custom plugins via `EngineOptions.enginePlugins.plugins` or drop `.plugin.js` files into `.pulse-coder/engine-plugins/`.
+## 6. Failure capture (named failure → guard)
 
-### Built-in tools
-Engine toolset (`packages/engine/src/tools/`):
-- `read`, `write`, `edit`, `grep`, `ls`, `bash`, `tavily`, `gemini_pro_image`, `clarify`.
+- **Over-pruning tool-call history dropped later user turns**: first fix sliced messages at the first incomplete tool-call, losing legitimate later user turns. Guard: `pruneIncompleteToolExchanges()` surgically filters only the incomplete part; regression tests in `packages/engine/src/core/loop.test.ts` assert later user turns survive. Any new message-history cleanup in `loop.ts` MUST add a parallel regression test.
+- **Blocking I/O froze the Electron host**: `bash` tool used `execSync`, blocking the event loop and freezing `canvas-workspace` UI. Guard: `bash.ts` now uses async `spawn` with `SIGTERM`→`SIGKILL`. Rule: never `execSync`/blocking I/O in `packages/engine/src/tools/*` — the engine runs on GUI main threads. (Two wrong-root-cause fixes — pulse-sandbox interrupt, PTY coalescing — were reverted; confirm the actual blocking call before patching adjacent paths.)
+- **UTF-8 chunk-split corruption**: async rewrite decoded each pipe chunk independently, corrupting multi-byte CJK. Guard: collect raw `Buffer`s and decode once.
+- **MCP reload stale/empty state**: reload didn't activate the target scope first. Guard: `activateScope` before reload, force fresh probe.
+- **Stale doc claimed canvas-workspace excluded**: `apps/EXPERIMENTAL.md` contradicts `pnpm-workspace.yaml:5`. Guard: `pnpm-workspace.yaml` + `harness/profile.yaml` are SSOT; run `graph-viewer --once` to detect coverage drift; do not trust prose workspace lists.
 
-CLI adds:
-- `run_js` (from `pulse-sandbox`).
+Failures are captured in fix commits + regression tests (TODO/FIXME density is zero across `packages/*/src`; `harness/feedback/inbox.md` is an empty template) — debug via `git log -- <file>` and `loop.test.ts` cases, not by grepping for TODOs.
 
-Task tracking adds:
-- `task_create`, `task_get`, `task_list`, `task_update`.
+## 7. Security / secrets
 
-### Orchestrator (`packages/orchestrator`)
-Runs a **TaskGraph** — a DAG of `TaskNode` objects with `{ id, role, deps[], input?, agent?, instruction? }`.
-Routing strategies (`OrchestrationInput.route`):
-- `'auto'` — keyword-based role selection,
-- `'all'` — every registered role runs,
-- `'plan'` — LLM dynamically builds the graph.
+Do not commit API keys or tokens. Runtime keys (`OPENAI_API_KEY`/`PULSE_OPENAI_API_KEY`, `ANTHROPIC_API_KEY`/`PULSE_ANTHROPIC_API_KEY`, `TAVILY_API_KEY`, `GEMINI_API_KEY`, `INTERNAL_API_SECRET`, `CLARIFICATION_*`) are env-only. Default model precedence (code at `packages/engine/src/config/index.ts`): `ANTHROPIC_MODEL` → `OPENAI_MODEL` → `PULSE_ANTHROPIC_MODEL` → `PULSE_OPENAI_MODEL` → `novita/deepseek/deepseek_v3`. `PULSE_`-prefixed fallbacks exist for every provider var. Remote-server internal routes are loopback-only and require `INTERNAL_API_SECRET`. Plugin secret storage uses the vault helpers in `pulse-coder-plugin-kit`.
 
-Built-in roles: `researcher`, `executor`, `reviewer`, `writer`, `tester`. Results are aggregated via `concat | last | llm`. The `agent-teams` plugin exposes orchestration to the engine as a tool.
+## 8. `.pulse-coder/` vs `.coder/`
 
-### Remote server runtime (`apps/remote-server`)
-Entry and server:
-- `apps/remote-server/src/index.ts` initializes session store, memory plugin, worktree binding, engine, Discord gateway, then starts the Hono server.
-- `apps/remote-server/src/server.ts` mounts `/health`, webhook routes, and `/internal/*` routes (web API routes are present but currently commented out).
-
-Dispatcher and agent execution:
-- `apps/remote-server/src/core/dispatcher.ts` verifies/acks webhooks, handles slash commands, prevents concurrent runs per `platformKey`, and streams output via adapter `StreamHandle` callbacks.
-- `apps/remote-server/src/core/agent-runner.ts` builds the per-run context, resolves model overrides, runs the engine, persists session state, and records daily memory logs.
-- `apps/remote-server/src/core/clarification-queue.ts` routes clarification prompts/answers for both webhook and gateway flows.
-
-State and configuration:
-- Sessions persist under `~/.pulse-coder/remote-sessions` (`index.json` + `sessions/*.json`).
-- Memory logs use `pulse-coder-memory-plugin` at `~/.pulse-coder/remote-memory`.
-- Worktree binding state uses `~/.pulse-coder/worktree-state`.
-- Model overrides are read from `.pulse-coder/config.json` or `$PULSE_CODER_MODEL_CONFIG` (`apps/remote-server/src/core/model-config.ts`).
-
-Platform adapters:
-- Feishu: `apps/remote-server/src/adapters/feishu/*` (event parsing, dedupe, cards, image replies).
-- Discord: webhooks in `adapters/discord/adapter.ts` and DM gateway in `adapters/discord/gateway.ts`.
-- Telegram and Web adapters exist but are not mounted by default.
-
-Internal automation:
-- `POST /internal/agent/run` runs an agent turn and can notify Feishu/Discord targets.
-- `GET /internal/discord/gateway/status` and `POST /internal/discord/gateway/restart` manage the gateway.
-- Internal routes are loopback-only and require `INTERNAL_API_SECRET`.
-
-Remote server tools:
-- Registered in `apps/remote-server/src/core/engine-singleton.ts` (cron scheduler, deferred demo, Twitter list fetcher, session summary, and PTC demo tools).
-- Some tools are `defer_loading: true` and only load after tool search discovery.
-
-## Configuration
-
-Environment variables (common):
-- `OPENAI_API_KEY`, `OPENAI_API_URL`, `OPENAI_MODEL`
-- optional Anthropic path: `USE_ANTHROPIC`, `ANTHROPIC_API_KEY`, `ANTHROPIC_API_URL`, `ANTHROPIC_MODEL`
-- optional tools: `TAVILY_API_KEY`, `GEMINI_API_KEY`
-- default model: `novita/deepseek/deepseek_v3` (override with `OPENAI_MODEL` or `ANTHROPIC_MODEL`)
-
-Context compaction tuning:
-- `CONTEXT_WINDOW_TOKENS` (default 64 000) — estimated token budget before compaction triggers.
-- `COMPACT_TRIGGER` (default 75% of window), `COMPACT_TARGET` (default 50%), `KEEP_LAST_TURNS` (default 4).
-- `COMPACT_SUMMARY_MODEL`, `COMPACT_SUMMARY_MAX_TOKENS` (default 1200), `MAX_COMPACTION_ATTEMPTS` (default 2).
-
-Clarification:
-- `CLARIFICATION_ENABLED` (default `true`), `CLARIFICATION_TIMEOUT` (default 300 000 ms).
-
-Config paths:
-- MCP: `.pulse-coder/mcp.json`
-- skills: `.pulse-coder/skills/**/SKILL.md`
-- sub-agents: `.pulse-coder/agents/*.md`
-- legacy `.coder/*` paths remain compatible in most loaders.
-
-## Coding Guidance
-
-- TypeScript strict mode is enabled.
-- Keep ESM-style imports in source where existing code uses them.
-- Follow local file style (2 spaces, semicolons, single quotes in most TS files).
-- Keep diffs minimal and preserve existing architecture patterns.
-- Prefer extending plugin/hooks/tool boundaries rather than hardcoding behavior into the loop.
-- Cross-package imports in source use path aliases defined in root `tsconfig.json` (e.g. `pulse-coder-engine`, `pulse-coder-plugin-kit`). Published packages use their npm names.
+`.pulse-coder/` is the active runtime/product config root. On disk it holds `mcp.json` (3 servers: `eido_mind`, `deepwiki`, `twitter` — all `deferTools:true`), `agents/` (8 sub-agents), `skills/` (10 runtime knowledge skills). `config.json`, `engine-plugins/`, and `skills/remote.json` are ABSENT on disk but their loaders are wired in source. Legacy `.coder/*` paths remain compatible in the MCP/skills/sub-agent/engine-plugins loaders but are not preferred — write new config under `.pulse-coder/`. Runtime skills (`.pulse-coder/skills`) and repo action protocols (`harness/skills`) are different layers; the `code-review` name appears in both by design (runtime generic checklist vs repo-aware protocol) — do not merge them.

--- a/harness/DESIGN.md
+++ b/harness/DESIGN.md
@@ -1,0 +1,141 @@
+# Harness Design
+
+This document defines the target shape for the repository harness. It is a design layer, not an implementation log. For current gaps and rollout order, see `harness/ROADMAP.md`.
+
+## Core Shape
+
+A harness module has one always-on control surface plus three expandable surfaces:
+
+```text
+AGENTS.md
+  navigation / routing
+  hard boundaries / constraints
+  prerequisite gates
+  acceptance standards
+  failure capture
+
+Know
+  facts, structure, contracts, risks, and impact relationships
+
+Tool
+  runners, graphs, scripts, detectors, generators, and other mechanisms
+
+Verify
+  validation matrix, quality gates, known gaps, and delivery evidence
+```
+
+`AGENTS.md` should stay small enough to remain active context. It tells agents what must always be true, when to load more context, and how to finish honestly. Know / Tool / Verify hold the details that are loaded only when the task needs them.
+
+## Monorepo Layering
+
+Monorepos need the same shape at two scopes:
+
+```text
+Root AGENTS.md
+  -> Global Know / Tool / Verify
+  -> affected Module AGENTS.md
+  -> Module Know / Tool / Verify
+```
+
+Global and module entries are intentionally similar. The difference is emphasis:
+
+| Layer | Owns | Does not own |
+|---|---|---|
+| Global | Cross-module consistency, repository-wide principles, shared constraints, global tools, global verification routing. | Detailed package architecture or local runbooks. |
+| Module | Local responsibilities, public contracts, directory boundaries, module tools, module verification reality, local failure guards. | Rules that contradict global constraints. |
+
+Module rules may refine global rules, but they must not contradict them.
+
+## What Belongs In `AGENTS.md`
+
+Both root and module `AGENTS.md` files use the same categories:
+
+| Category | Purpose |
+|---|---|
+| Navigation / routing | Where to read next for the current scope. |
+| Hard boundaries / constraints | Stable rules that should remain in the agent's active context. |
+| Prerequisite gates | Conditions that require reading a contract, loading a protocol, running a detector, or stopping to gather evidence. |
+| Acceptance standards | What evidence must be collected before claiming the work is done. |
+| Failure capture | Named guardrails from past failures, stated as concise rules. |
+
+`AGENTS.md` should not become the full knowledge base. If a section starts accumulating detailed facts, move those facts into Know, Tool, or Verify and keep only the trigger or summary in `AGENTS.md`.
+
+## Know / Tool / Verify
+
+Use these surfaces consistently at global and module scope:
+
+| Surface | Question | Examples |
+|---|---|---|
+| Know | What is the agent facing? | Repository map, module responsibilities, contracts, risk zones, impact relationships, runtime/config boundaries. |
+| Tool | What mechanisms can the agent use? | Harness runner, graph viewer, affected-workspace detector, local scripts, generators, debug entry points. |
+| Verify | How does the agent prove the result? | Path-to-check matrix, package commands, quality gates, known red commands, skipped-validation reporting. |
+
+Tools do not make final decisions. They provide mechanisms. Routing and gates decide when a tool should be used.
+
+## Agent Runtime Loop
+
+The expected agent behavior is:
+
+```text
+1. Start from the nearest relevant AGENTS.md.
+2. Identify the affected scope and module.
+3. Load Know only as needed to understand facts, contracts, risks, and impact.
+4. Use Tool only when a mechanism is needed to inspect, transform, or check something.
+5. Use Verify before finishing to select checks and report evidence.
+6. Feed durable discoveries back into the right surface:
+   - new fact or failure guard -> Know or AGENTS.md
+   - new mechanism -> Tool
+   - new acceptance rule or known gap -> Verify
+```
+
+## Current Repository Projection
+
+The current pilot already maps onto this design:
+
+| Design surface | Current repository location |
+|---|---|
+| Global control surface | `AGENTS.md` and `CLAUDE.md` |
+| Global Know | `harness/profile.yaml`, `harness/README.md`, workspace entries, selected `docs/` |
+| Global Tool | `harness/tools/`, especially `harness/tools/graph-viewer/server.mjs` |
+| Global Verify | `harness/validation.yaml`, `harness/checks/README.md`, known validation notes in root entries |
+| Action protocols | `harness/skills/*.md`; these are invoked by `AGENTS.md` gates and triggers |
+| Module control surface | each workspace `AGENTS.md` |
+| Module Know / Tool / Verify | module `docs/`, scripts, tests, contracts, and optional module-local harness files |
+
+Do not rename directories just to match this design. The first goal is conceptual consistency and routing clarity. Rename or split files only when the current names create real confusion.
+
+## Minimal Module Entry Template
+
+Use this shape when adding or refreshing a module `AGENTS.md`:
+
+```text
+# AGENTS.md
+
+## Role
+What this module owns and when an agent should use this entry.
+
+## Navigation / Routing
+Where local Know, Tool, and Verify details live.
+
+## Hard Boundaries / Constraints
+Stable local rules, public contracts, and files that need special care.
+
+## Prerequisite Gates
+When to load local contracts, docs, action protocols, tools, or verification rules.
+
+## Acceptance Standards
+Which local checks or evidence are expected before finishing.
+
+## Failure Capture
+Short named guards from past module failures.
+```
+
+Keep module entries local and differential. Do not copy root principles or global validation prose into every module.
+
+## Rollout Order
+
+1. Keep root `AGENTS.md` as the global control surface.
+2. Align `harness/README.md` with this design and route details to existing files.
+3. Refresh high-impact module entries first: core runtime, CLI, remote runtime, and canvas workspace.
+4. Add module Know / Tool / Verify files only when the module entry becomes too dense.
+5. Make Verify executable by adding a runner for `harness/validation.yaml`.

--- a/harness/README.md
+++ b/harness/README.md
@@ -2,13 +2,13 @@
 
 This directory is the source of truth for the repository-level harness pilot. It is separate from `.pulse-coder/`, which remains product/runtime configuration and test data for Pulse Coder itself.
 
-The harness has four main loops:
+The target harness shape is one always-on control surface plus three expandable surfaces:
 
 ```text
-knowledge -> action -> validation -> feedback
+AGENTS.md -> Know / Tool / Verify
 ```
 
-`tools` are shared atomic capabilities that can be used by any loop.
+See `harness/DESIGN.md` for the full model. In short: `AGENTS.md` carries persistent routing, constraints, gates, acceptance standards, and failure guards; Know / Tool / Verify carry the expandable facts, mechanisms, and validation evidence.
 
 ## Reading Path
 
@@ -26,6 +26,7 @@ AGENTS.md / CLAUDE.md
 
 | Area | Path | Purpose |
 |---|---|---|
+| Harness design | `DESIGN.md` | Target shape for AGENTS.md + Know / Tool / Verify across global and module scopes. |
 | Repository map | `profile.yaml` | Machine-readable workspace routing table. |
 | Validation matrix | `validation.yaml` | Machine-readable validation matrix and escalation rules. |
 | Action protocols | `skills/` | Tool-agnostic agent skills for recurring work. |

--- a/harness/ROADMAP.md
+++ b/harness/ROADMAP.md
@@ -1,0 +1,59 @@
+# Harness Roadmap
+
+> Status of the repository-level harness pilot, and what remains. This doc talks about the harness itself; for product/runtime behavior see workspace `AGENTS.md` and `docs/`.
+
+## Where we are
+
+The harness pilot has a real, populated foundation:
+
+- `harness/profile.yaml` routes 14 active workspaces (type / packageName / role / entry / knowledge).
+- `harness/validation.yaml` maps 15 `pathRules` + 4 `escalationRules` + fallback to concrete `pnpm --filter` commands — a path-keyed SSOT.
+- `harness/skills/*.md` (5) define repo action protocols (code-review, contract-coding, doc-governance, feedback-governance, quality-workflow).
+- `harness/tools/graph-viewer/server.mjs` is the one wired executable — a drift detector (`--once` smoke check, reports `harnessGaps`).
+- Root `AGENTS.md` carries the meta-rules layer (precedence + SSOT-no-copies + mechanism-over-doc + first-principles + Occam + 5-step self-check), the L0/L1/L2 doc taxonomy, the intent navigation table, hard boundaries with honest test-reality, a two-tier skill taxonomy with action→required-read table, and named failure-capture with guards.
+
+What is **honestly absent**: there is NO CI, NO git hooks, NO husky/lint-staged/commitlint, and NO executable checks under `harness/checks/` (placeholder only). `harness/validation.yaml` is declarative — nothing runs it. `harness/tools/*` (except `graph-viewer`) are spec-only READMEs. `scripts/harness/` does not exist.
+
+## The keystone gap: turn the declarative SSOT into a runnable mechanism
+
+Every constraint in this harness is currently carried by agent discipline. The single highest-value next step is to give the existing SSOT an executor.
+
+**Goal:** `scripts/harness/run-harness-check.mjs` — a runner that reads `harness/validation.yaml` and executes the check(s) bound to a changed path (or `--all`).
+
+**Why this is the keystone:**
+- It converts "honesty-about-absence" into "honesty-with-a-mechanism" (the root `AGENTS.md` §4 already admits the gap; this closes it).
+- It plays to an existing strength: `validation.yaml` is already a path→check SSOT. A is missing only the runner, not the data.
+- It is the one move that closes the largest lead the reference sample (B) has — mechanical enforcement — without copying B's domain-specifics.
+
+**Phased rollout (mechanism matures only after the rule proves stable — per `harness/README.md` principles):**
+
+1. **Manual runner first.** `node scripts/harness/run-harness-check.mjs [--path <glob>|--all]`. Reads `validation.yaml`, runs the bound `pnpm --filter` commands, prints a pass/fail report. No git integration yet. This alone makes `validation.yaml` executable and lets agents/humans verify changes without remembering the matrix.
+2. **Wire the candidate checks** listed in `harness/checks/README.md` (`profile-coverage`, `agents-coverage`, `routing-links`, `skill-frontmatter`, `validation-matrix`). Each becomes a function the runner can invoke; protocol stays in `harness/checks/README.md`, implementation in `scripts/harness/`.
+3. **Optional pre-push hook.** Only after step 1–2 are stable in manual use, add an opt-in `scripts/harness/pre-push.mjs` that runs affected-workspace checks on `git push`. Do not make it mandatory until the false-positive rate is near zero.
+4. **Optional CI.** Only if/when a CI provider is chosen for this repo. Until then the manual runner is the source of truth.
+
+**Non-goals for this phase:** full CI pipeline, lint/format enforcement (eslint/prettier are absent repo-wide and out of scope here), Node version pinning (separate concern).
+
+## Other open items (breadth, lower priority than the keystone)
+
+- **Skill governance meta-skill.** `harness/skills/` has no governance protocol for adding/renaming/retiring its own skills (the reference sample has one). Defer until the runner lands and skill churn justifies it.
+- **`harness/tools/*` execution.** Five of six tool subdirs are spec-only READMEs. Either implement them or mark them explicitly as deferred specs in their READMEs so readers do not expect executables.
+- **`harness/templates/*` usage.** Only `feedback-proposal.md` is referenced anywhere. Either wire the other three (workspace-agents, package-contract, app-spec-overview) into the skills that should use them, or remove them.
+- **`harness/feedback/inbox.md`** is an empty template. Leave as-is until real feedback arrives; do not pre-fill.
+
+## Deliberately deferred (not gaps — out of scope for this repo)
+
+The comparison against the reference sample (B / `ec_channel_lynx_x`) surfaced items that are correct for B's context but wrong here. These are NOT on the roadmap unless the repo's context changes:
+
+- Pinned Node version (B pins v22 LTS). Coder is currently unpinned; add a pin only if CI or runtime breakage forces it.
+- Spec-Driven confirmation gate, JSDoc mandate, OWNERS ≥2, 3x asset rule, Chinese-comment norm, emo/Eden toolchain. These are team/domain-specifics, not universal harness elements.
+
+## Done log
+
+- Meta-rules layer with precedence + SSOT-no-copies + mechanism-over-doc + first-principles + Occam + 5-step self-check (root `AGENTS.md` §0).
+- L0/L1/L2 doc taxonomy (root `AGENTS.md` §1).
+- Intent navigation table (root `AGENTS.md` §1).
+- Two-tier skill taxonomy + action→required-read table (root `AGENTS.md` §4).
+- Honest test-reality in hard boundaries (root `AGENTS.md` §2).
+- Named failure-capture with guards (root `AGENTS.md` §6).
+- `harness/validation.yaml` and `harness/profile.yaml` already SSOT-complete.


### PR DESCRIPTION
## Summary

- Rework the root agent entries around repository-level harness routing, constraints, gates, acceptance, and failure guards.
- Add `harness/DESIGN.md` as the target model for `AGENTS.md + Know / Tool / Verify` across global and module scopes.
- Add `harness/ROADMAP.md` to capture current harness status, gaps, and rollout order.
- Update `harness/README.md` to route readers to the new design model.

## Impact

This is documentation-only. It clarifies how agents should use root/module `AGENTS.md` files and where detailed knowledge, tools, and verification rules should live.

## Validation

- `git diff --check && git diff --cached --check`
- `node harness/tools/graph-viewer/server.mjs --once` reported `harnessGaps: 0`, `graphGaps: 0`, and `highSeverityGaps: 0`.

## Notes

- No package build or unit tests were run because `harness/validation.yaml` classifies this surface as harness/docs work, where the required check is referenced path validation.