### PR TITLE
fix(canvas-workspace): replace ad-hoc theme colors with design tokens

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;

--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.css
@@ -493,7 +493,7 @@
 }
 
 .reference-url-error {
-  color: #c0392b;
+  color: var(--error);
   font-size: 11px;
 }
 
@@ -613,7 +613,7 @@
 
 .reference-group--type-missing .reference-group-type-icon {
   background: rgba(192, 57, 43, 0.1);
-  color: #c0392b;
+  color: var(--error);
 }
 
 .reference-group-name {

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
@@ -313,7 +313,7 @@
 }
 
 .sidebar-item-folder:hover {
-  background: rgba(15, 123, 108, 0.08);
+  background: var(--accent-term-light);
   color: var(--accent-term);
 }
 
@@ -450,7 +450,7 @@
 }
 
 .sidebar-folder--drop-target {
-  background: rgba(35, 131, 226, 0.04);
+  background: var(--accent-subtle);
 }
 
 .sidebar-folder-header {
@@ -657,7 +657,7 @@
 }
 
 .sidebar-layer-item--selected:hover {
-  background: rgba(35, 131, 226, 0.12);
+  background: var(--accent-hover);
 }
 
 .sidebar-layer-item--primary-selected {
@@ -671,7 +671,7 @@
 
 .sidebar-layer-item--editing {
   cursor: default;
-  background: rgba(35, 131, 226, 0.08);
+  background: var(--accent-light);
 }
 
 .sidebar-layer-icon {
@@ -924,12 +924,12 @@
 }
 
 .sidebar-layer-context-menu-item--danger {
-  color: #c0392b;
+  color: var(--error);
 }
 
 .sidebar-layer-context-menu-item--danger:hover {
-  background: rgba(192, 57, 43, 0.08);
-  color: #c0392b;
+  background: var(--error-light);
+  color: var(--error);
 }
 
 .sidebar-layer-context-menu-separator {

--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -17,13 +17,17 @@
   --text-secondary: #787774;
   --text-muted: #b4b0a8;
   --accent: #2383e2;
+  --accent-subtle: rgba(35, 131, 226, 0.04);
   --accent-light: rgba(35, 131, 226, 0.08);
+  --accent-hover: rgba(35, 131, 226, 0.12);
   --accent-border: rgba(35, 131, 226, 0.45);
   --accent-file: #d9730d;
   --accent-term: #0f7b6c;
+  --accent-term-light: rgba(15, 123, 108, 0.08);
   --accent-frame: #a594e0;
   --success: #1f7a4d;
   --error: #c0392b;
+  --error-light: rgba(192, 57, 43, 0.08);
   --text-warning: #b45309;
   --overlay-backdrop: rgba(32, 34, 37, 0.22);
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.04);


### PR DESCRIPTION
## Summary

Audited `apps/canvas-workspace` against its documented style guide (`docs/conventions/frontend.md`, which requires following existing design-token usage rather than hardcoding ad-hoc colors, and named exports for components) and fixed the concrete violations found:

- **`src/renderer/src/components/Sidebar/index.css`**: five rules used raw `rgba(...)`/hex color literals that exactly duplicated (or were a missing variant of) tokens already defined in `styles.css` — e.g. `rgba(35, 131, 226, 0.08)` instead of `var(--accent-light)`, `#c0392b` instead of `var(--error)`. Introduced the missing token variants (`--accent-subtle`, `--accent-hover`, `--accent-term-light`, `--error-light`) in `styles.css` alongside the existing `--accent-light`/`--accent-border` tokens, and pointed all five rules at tokens.
- **`src/renderer/src/components/ReferenceDrawer/index.css`**: two error-state rules hardcoded `#c0392b`, which is exactly `--error` — switched to `var(--error)`.
- **`src/renderer/src/components/MigrationSpinner/index.tsx`**: dropped a redundant `export default MigrationSpinner` left over alongside the named export. The file already exports `export const MigrationSpinner`, which is the only form imported anywhere in the app (`App.tsx` does `import { MigrationSpinner } from './components/MigrationSpinner'`) — the convention doc requires named exports for components and the default export was unused dead code.

All value substitutions use the exact same computed color as before (verified against `styles.css` token definitions), so there is no visual change — this is a pure consistency/maintainability cleanup.

Scope note: `rgba(35, 131, 226, <alpha>)`-style literals are used pervasively (100+ occurrences) across many other component CSS files at many different, purpose-specific alphas (focus rings, gradients, shadows). That is this codebase's established pattern for one-off accent-tinted effects, not itself a violation, so this PR intentionally does not touch those — only the cases in `Sidebar`/`ReferenceDrawer` where the literal was an exact duplicate of an existing/necessary token were changed, to avoid unscoped churn.

## Test plan

- [x] Manually verified via `grep` that `MigrationSpinner`'s default export had no importers before removing it.
- [x] Manually diffed every changed color literal against `styles.css` token values to confirm zero visual change.
- [ ] `pnpm --filter canvas-workspace typecheck` / `pnpm --filter canvas-workspace test` — could not run in this environment (dependency install failed downloading the Electron binary due to network restrictions in the sandbox); no other errors were introduced by this diff (CSS-only + a dead-code removal already verified safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01H5wH3uXpMxSHpDQqKC9KUd)_