### PR TITLE
fix: support copying canvas images

### DIFF
--- a/apps/canvas-workspace/src/main/files/manager.ts
+++ b/apps/canvas-workspace/src/main/files/manager.ts
@@ -1,4 +1,4 @@
-import { ipcMain, dialog, BrowserWindow } from "electron";
+import { ipcMain, dialog, BrowserWindow, clipboard, nativeImage } from "electron";
 import { promises as fs } from "fs";
 import { join, basename } from "path";
 import { homedir } from "os";
@@ -204,6 +204,27 @@ export const setupFileManagerIpc = () => {
         const buffer = Buffer.from(payload.data, "base64");
         await fs.writeFile(result.filePath, buffer);
         return { ok: true, filePath: result.filePath, fileName: basename(result.filePath) };
+      } catch (err) {
+        return { ok: false, error: String(err) };
+      }
+    }
+  );
+
+  // Copy an image file to the system clipboard as image data.
+  ipcMain.handle(
+    "file:copyImage",
+    async (_event, payload: { filePath: string }) => {
+      try {
+        if (!payload.filePath) {
+          return { ok: false, error: "Missing image path" };
+        }
+        await fs.access(payload.filePath);
+        const image = nativeImage.createFromPath(payload.filePath);
+        if (image.isEmpty()) {
+          return { ok: false, error: "Unsupported or unreadable image" };
+        }
+        clipboard.writeImage(image);
+        return { ok: true };
       } catch (err) {
         return { ok: false, error: String(err) };
       }

--- a/apps/canvas-workspace/src/preload/bridge/file.ts
+++ b/apps/canvas-workspace/src/preload/bridge/file.ts
@@ -31,6 +31,9 @@ export const createFileApi = (ipcRenderer: IpcRenderer): FileApi => ({
   exportImage: (defaultName, data, ext) =>
     ipcRenderer.invoke("file:exportImage", { defaultName, data, ext }),
 
+  copyImage: (filePath) =>
+    ipcRenderer.invoke("file:copyImage", { filePath }),
+
   onChanged: (callback) =>
     subscribe<FileChangedPayload>(ipcRenderer, "canvas:file-changed", (payload) => {
       callback(payload.filePath, payload.content);

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/ImageCanvasNode.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/ImageCanvasNode.tsx
@@ -1,7 +1,10 @@
-import type { CSSProperties, MouseEvent } from 'react';
-import type { CanvasNode } from '../../types';
+import { useCallback, type CSSProperties, type MouseEvent } from 'react';
+import type { CanvasNode, ImageNodeData } from '../../types';
+import { copyTextToClipboard } from '../../utils/clipboard';
+import { toFileUrl } from '../../utils/fileUrl';
+import { useAppShell } from '../AppShellProvider';
 import { ImageNodeBody } from '../ImageNodeBody';
-import { CloseButton, FullscreenButton } from './NodeButtons';
+import { CloseButton, CopyImageButton, FullscreenButton } from './NodeButtons';
 import { NodeResizeHandles } from './NodeResizeHandles';
 import type { ResizeHandlerFactory } from './types';
 
@@ -33,21 +36,63 @@ export const ImageCanvasNode = ({
   readOnly,
   supportsFullscreen,
   wrapperStyle,
-}: ImageCanvasNodeProps) => (
-  <div className={classes} style={wrapperStyle} onClick={handleNodeClick}>
-    <div className="node-body node-body--image" onMouseDown={(e) => e.stopPropagation()}>
-      <ImageNodeBody node={node} onSelect={onSelect} onDragStart={onDragStart} readOnly={readOnly} />
+}: ImageCanvasNodeProps) => {
+  const { notify } = useAppShell();
+  const data = node.data as ImageNodeData;
+  const imageFilePath = data.filePath;
+
+  const handleCopyImage = useCallback((e: MouseEvent) => {
+    e.stopPropagation();
+    if (!imageFilePath) {
+      notify({ tone: 'error', title: 'No image to copy' });
+      return;
+    }
+
+    void window.canvasWorkspace.file.copyImage(imageFilePath).then((result) => {
+      if (result.ok) {
+        notify({ tone: 'success', title: 'Image copied' });
+        return;
+      }
+
+      void copyTextToClipboard(toFileUrl(imageFilePath)).then(() => {
+        notify({
+          tone: 'success',
+          title: 'Image link copied',
+          description: 'Image data could not be copied, so the file link was copied instead.',
+        });
+      }).catch(() => {
+        notify({
+          tone: 'error',
+          title: 'Unable to copy image',
+          description: result.error ?? 'The image file could not be copied.',
+        });
+      });
+    }).catch((err) => {
+      notify({
+        tone: 'error',
+        title: 'Unable to copy image',
+        description: err instanceof Error ? err.message : String(err),
+      });
+    });
+  }, [imageFilePath, notify]);
+
+  return (
+    <div className={classes} style={wrapperStyle} onClick={handleNodeClick}>
+      <div className="node-body node-body--image" onMouseDown={(e) => e.stopPropagation()}>
+        <ImageNodeBody node={node} onSelect={onSelect} onDragStart={onDragStart} readOnly={readOnly} />
+      </div>
+      {imageFilePath ? <CopyImageButton onClick={handleCopyImage} /> : null}
+      {supportsFullscreen ? (
+        <FullscreenButton floating isFullscreen={isFullscreen} onClick={handleToggleFullscreen} />
+      ) : null}
+      {readOnly ? null : <CloseButton floating onClick={handleClose} />}
+      <NodeResizeHandles
+        isFullscreen={isFullscreen}
+        makeResizeHandler={makeResizeHandler}
+        nodeType={node.type}
+        readOnly={readOnly}
+        variant="floating"
+      />
     </div>
-    {supportsFullscreen ? (
-      <FullscreenButton floating isFullscreen={isFullscreen} onClick={handleToggleFullscreen} />
-    ) : null}
-    {readOnly ? null : <CloseButton floating onClick={handleClose} />}
-    <NodeResizeHandles
-      isFullscreen={isFullscreen}
-      makeResizeHandler={makeResizeHandler}
-      nodeType={node.type}
-      readOnly={readOnly}
-      variant="floating"
-    />
-  </div>
-);
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/NodeButtons.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/NodeButtons.tsx
@@ -28,6 +28,23 @@ export const FullscreenButton = ({ floating, isFullscreen, onClick }: Fullscreen
   </button>
 );
 
+export const CopyImageButton = ({ onClick }: { onClick: (e: MouseEvent) => void }) => (
+  <button
+    className="node-copy-image node-copy-image--floating"
+    type="button"
+    onClick={onClick}
+    onMouseDown={(e) => e.stopPropagation()}
+    title="Copy image"
+    aria-label="Copy image"
+  >
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+      <rect x="2" y="2" width="8" height="8" rx="1.4" stroke="currentColor" strokeWidth="1.2" />
+      <path d="M3.5 8l2-2 1.5 1.5 1-1 2 2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+      <circle cx="8" cy="4" r=".75" fill="currentColor" />
+    </svg>
+  </button>
+);
+
 interface CloseButtonProps {
   floating?: boolean;
   onClick: (e: MouseEvent) => void;

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -395,6 +395,7 @@
 .node-body--reference .node-reference,
 .node-body--reference .node-add-to-chat,
 .node-body--reference .node-plugin-select,
+.node-body--reference .node-copy-image,
 .node-body--reference .node-fullscreen,
 .node-body--reference .resize-handle,
 .node-body--reference .node-time-label {
@@ -601,6 +602,7 @@
 .node-add-to-chat,
 .node-plugin-select,
 .node-focus,
+.node-copy-image,
 .node-fullscreen,
 .node-close {
   height: 20px;
@@ -625,6 +627,7 @@
 .node-add-to-chat,
 .node-plugin-select,
 .node-focus,
+.node-copy-image,
 .node-fullscreen,
 .node-close {
   width: 20px;
@@ -634,6 +637,7 @@
 .canvas-node:hover .node-add-to-chat,
 .canvas-node:hover .node-plugin-select,
 .canvas-node:hover .node-focus,
+.canvas-node:hover .node-copy-image,
 .canvas-node:hover .node-fullscreen,
 .canvas-node:hover .node-close {
   opacity: 1;
@@ -648,6 +652,11 @@
 }
 
 .node-focus:hover {
+  background: var(--accent-light);
+  color: var(--accent);
+}
+
+.node-copy-image:hover {
   background: var(--accent-light);
   color: var(--accent);
 }
@@ -1265,6 +1274,15 @@
   position: absolute;
   top: 4px;
   right: 30px;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+  z-index: 5;
+}
+
+.node-copy-image--floating {
+  position: absolute;
+  top: 4px;
+  right: 56px;
   background: rgba(255, 255, 255, 0.88);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
   z-index: 5;

--- a/apps/canvas-workspace/src/renderer/src/types/files.ts
+++ b/apps/canvas-workspace/src/renderer/src/types/files.ts
@@ -46,6 +46,9 @@ export interface FileApi {
     data: string,
     ext?: string,
   ) => Promise<{ ok: boolean; canceled?: boolean; filePath?: string; fileName?: string; error?: string }>;
+  copyImage: (
+    filePath: string,
+  ) => Promise<{ ok: boolean; error?: string }>;
   onChanged: (callback: (filePath: string, content: string) => void) => () => void;
 }
 


### PR DESCRIPTION
Allow image nodes in Pulse Canvas to be copied from the expanded image view.

- Add a floating copy-image action to image canvas nodes
- Bridge renderer copy requests through preload to the Electron main process
- Write image data to the system clipboard, with a file-link fallback when image data copy fails

Validation:
- pnpm --filter canvas-workspace typecheck:renderer
- git diff --check

Note:
- Full canvas-workspace typecheck is currently blocked by existing main-process declaration errors for pulse-coder-engine/built-in.