### PR TITLE
fix: add copy actions for chat images

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatImageLightbox.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatImageLightbox.tsx
@@ -9,11 +9,14 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { CloseIcon } from '../icons';
+import { CheckIcon, CloseIcon, CopyIcon } from '../icons';
 import { useI18n } from '../../i18n';
+import { copyTextToClipboard } from '../../utils/clipboard';
+import { toFileUrl } from '../../utils/fileUrl';
 
 export interface LightboxImage {
   src: string;
+  filePath?: string;
   caption?: string;
 }
 
@@ -26,6 +29,7 @@ interface ChatImageLightboxProps {
 export const ChatImageLightbox = ({ images, startIndex, onClose }: ChatImageLightboxProps) => {
   const { t } = useI18n();
   const [index, setIndex] = useState(startIndex);
+  const [copied, setCopied] = useState(false);
   const count = images.length;
 
   // Re-sync when the caller opens a different image without unmounting (e.g.
@@ -40,6 +44,26 @@ export const ChatImageLightbox = ({ images, startIndex, onClose }: ChatImageLigh
   const goNext = useCallback(() => {
     setIndex(prev => (prev + 1) % count);
   }, [count]);
+
+  const handleCopy = useCallback(async () => {
+    const image = images[Math.min(Math.max(index, 0), Math.max(count - 1, 0))];
+    if (!image) return;
+    try {
+      if (image.filePath) {
+        const result = await window.canvasWorkspace.file.copyImage(image.filePath);
+        if (result.ok) {
+          setCopied(true);
+          window.setTimeout(() => setCopied(false), 1200);
+          return;
+        }
+      }
+      await copyTextToClipboard(image.filePath ? toFileUrl(image.filePath) : image.src);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    } catch {
+      /* clipboard unavailable — keep viewer open */
+    }
+  }, [count, images, index]);
 
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
@@ -64,6 +88,10 @@ export const ChatImageLightbox = ({ images, startIndex, onClose }: ChatImageLigh
     };
   }, [count, goPrev, goNext, onClose]);
 
+  useEffect(() => {
+    setCopied(false);
+  }, [index]);
+
   const safeIndex = Math.min(Math.max(index, 0), Math.max(count - 1, 0));
   const current = images[safeIndex];
   if (!current) return null;
@@ -82,7 +110,17 @@ export const ChatImageLightbox = ({ images, startIndex, onClose }: ChatImageLigh
     >
       <button
         type="button"
-        className="chat-image-lightbox-close"
+        className="chat-image-lightbox-action chat-image-lightbox-copy"
+        onClick={() => void handleCopy()}
+        aria-label="Copy image"
+        title={copied ? 'Copied!' : 'Copy image'}
+      >
+        {copied ? <CheckIcon size={18} strokeWidth={1.8} /> : <CopyIcon size={18} />}
+      </button>
+
+      <button
+        type="button"
+        className="chat-image-lightbox-action chat-image-lightbox-close"
         onClick={onClose}
         aria-label={t('chat.closeImage')}
         title={t('chat.closeImage')}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent, type SyntheticEvent } from 'react';
 import type { AgentChatMessage, CanvasNode } from '../../types';
 import { toFileUrl } from '../../utils/fileUrl';
+import { copyTextToClipboard } from '../../utils/clipboard';
 import { BotAvatarIcon, CheckIcon, CopyIcon, PencilIcon, RefreshIcon } from '../icons';
 import type { ToolCallStatus } from './types';
 import { renderMdWithMentions } from './utils/mentions';
@@ -40,6 +41,34 @@ const CopyMessageButton = memo(({ content }: { content: string }) => {
   );
 });
 CopyMessageButton.displayName = 'CopyMessageButton';
+
+const CopyGeneratedImageButton = memo(({ imagePath }: { imagePath: string }) => {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = useCallback(async () => {
+    try {
+      const result = await window.canvasWorkspace.file.copyImage(imagePath);
+      if (!result.ok) {
+        await copyTextToClipboard(toFileUrl(imagePath));
+      }
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    } catch {
+      /* clipboard unavailable — ignore */
+    }
+  }, [imagePath]);
+  return (
+    <button
+      type="button"
+      className="chat-generated-image-card__action"
+      onClick={() => void handleCopy()}
+      title={copied ? 'Copied!' : 'Copy image'}
+      aria-label="Copy image"
+    >
+      {copied ? 'Copied' : 'Copy'}
+    </button>
+  );
+});
+CopyGeneratedImageButton.displayName = 'CopyGeneratedImageButton';
 
 interface GeneratedImagePayload {
   ok?: boolean;
@@ -209,9 +238,14 @@ export const ChatMessage = ({
   const lightboxImages = useMemo<LightboxImage[]>(() => [
     ...(message.attachments ?? []).map(attachment => ({
       src: toFileUrl(attachment.path),
+      filePath: attachment.path,
       caption: attachment.fileName,
     })),
-    ...generatedImages.map(image => ({ src: image.src, caption: image.title })),
+    ...generatedImages.map(image => ({
+      src: image.src,
+      filePath: image.outputPath,
+      caption: image.title,
+    })),
   ], [message.attachments, generatedImages]);
 
   const handleImageKeyOpen = useCallback(
@@ -292,12 +326,16 @@ export const ChatMessage = ({
                     />
                     <figcaption>
                       <span>{image.title ?? 'Generated image'}</span>
-                      <button
-                        type="button"
-                        onClick={() => void onAddImageToCanvas?.(image.outputPath, image.title)}
-                      >
-                        Add to canvas
-                      </button>
+                      <span className="chat-generated-image-card__actions">
+                        <CopyGeneratedImageButton imagePath={image.outputPath} />
+                        <button
+                          type="button"
+                          className="chat-generated-image-card__action chat-generated-image-card__action--primary"
+                          onClick={() => void onAddImageToCanvas?.(image.outputPath, image.title)}
+                        >
+                          Add to canvas
+                        </button>
+                      </span>
                     </figcaption>
                   </figure>
                 );

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
@@ -2125,18 +2125,43 @@
   color: #4b5563;
 }
 
-.chat-generated-image-card button {
-  border: 1px solid rgba(37, 99, 235, 0.22);
+.chat-message-image-card figcaption > span:first-child,
+.chat-generated-image-card figcaption > span:first-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-generated-image-card__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.chat-generated-image-card__action {
+  border: 1px solid rgba(31, 35, 40, 0.12);
   border-radius: 999px;
-  background: rgba(37, 99, 235, 0.08);
-  color: #1d4ed8;
+  background: #fff;
+  color: #374151;
   cursor: pointer;
   font-size: 12px;
   padding: 4px 10px;
   white-space: nowrap;
 }
 
-.chat-generated-image-card button:hover {
+.chat-generated-image-card__action:hover {
+  background: rgba(31, 35, 40, 0.06);
+}
+
+.chat-generated-image-card__action--primary {
+  border-color: rgba(37, 99, 235, 0.22);
+  background: rgba(37, 99, 235, 0.08);
+  color: #1d4ed8;
+}
+
+.chat-generated-image-card__action--primary:hover {
   background: rgba(37, 99, 235, 0.14);
 }
 
@@ -2251,10 +2276,9 @@
   font-variant-numeric: tabular-nums;
 }
 
-.chat-image-lightbox-close {
+.chat-image-lightbox-action {
   position: absolute;
   top: 18px;
-  right: 18px;
   width: 38px;
   height: 38px;
   display: flex;
@@ -2268,7 +2292,15 @@
   transition: background 0.15s ease;
 }
 
-.chat-image-lightbox-close:hover {
+.chat-image-lightbox-copy {
+  right: 64px;
+}
+
+.chat-image-lightbox-close {
+  right: 18px;
+}
+
+.chat-image-lightbox-action:hover {
   background: rgba(255, 255, 255, 0.24);
 }
 


### PR DESCRIPTION
## Summary
- Add a visible Copy action to generated image cards next to Add to canvas.
- Add a Copy image control to the fullscreen chat image lightbox.
- Reuse image clipboard copy with file-link fallback for generated images and attachments.

## Validation
- `pnpm --filter canvas-workspace typecheck:renderer` ✅
- `pnpm --filter canvas-workspace build` ✅

## Risk
- Low; scoped to chat image actions and related styling.