### PR TITLE
fix: keep chat image attachments above editor

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
@@ -487,6 +487,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-end;
+  gap: 8px;
   max-width: min(92%, 560px);
 }
 
@@ -2170,10 +2171,12 @@
 .chat-message-user .chat-message-images {
   order: 1;
   width: 100%;
+  margin-bottom: 0;
   justify-items: end;
 }
 
-.chat-message-user .chat-message-content {
+.chat-message-user .chat-message-content,
+.chat-message-user .chat-message-edit {
   order: 2;
   margin-bottom: 0;
 }


### PR DESCRIPTION
## Summary
- Keep user image attachments ordered above the inline edit form when editing a sent message.
- Add stable spacing between user attachment previews and the message body/editor.
- Remove the extra attachment margin in user messages so spacing is controlled by the message body gap.

## Validation
- pnpm --filter canvas-workspace typecheck
- pnpm --filter canvas-workspace build

## Risk
- Low; scoped CSS-only layout fix for user chat messages with attachments.