### PR TITLE
fix(canvas-workspace): migrate context menus onto the z-index layering scale

### DIFF
--- a/apps/canvas-workspace/docs/renderer-surfaces.md
+++ b/apps/canvas-workspace/docs/renderer-surfaces.md
@@ -95,11 +95,11 @@ Defined in `src/renderer/src/styles.css` (`:root`), low → high:
 | `--layer-modal` | 1900 | settings drawers |
 | `--layer-palette` | 2000 | command palette |
 | `--layer-dialog` | 2050 | app-shell confirm dialogs |
+| `--layer-context-menu` | 2075 | `NodeContextMenu` / `EdgeContextMenu`, sidebar layer context menu |
 | `--layer-toast` | 2100 | app-shell toasts |
 
 Known stragglers not yet on the scale (anchored popovers, lower risk):
-`NodeContextMenu` (1000) and various chat-internal overlays. Migrate them
-opportunistically when touched.
+various chat-internal overlays. Migrate them opportunistically when touched.
 
 ## History
 

--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;

--- a/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.css
@@ -1,6 +1,6 @@
 .context-menu {
   position: fixed;
-  z-index: 1000;
+  z-index: var(--layer-context-menu);
   min-width: 200px;
   background: var(--surface);
   border: 1px solid var(--border);

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
@@ -894,7 +894,7 @@
 
 .sidebar-layer-context-menu {
   position: fixed;
-  z-index: 1000;
+  z-index: var(--layer-context-menu);
   min-width: 168px;
   padding: 4px;
   background: var(--surface);

--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -58,6 +58,7 @@
   --layer-modal: 1900;               /* settings drawers (with backdrop) */
   --layer-palette: 2000;             /* command palette */
   --layer-dialog: 2050;              /* app-shell confirm dialogs */
+  --layer-context-menu: 2075;        /* node/edge/sidebar context menus */
   --layer-toast: 2100;               /* app-shell toasts */
 }
 


### PR DESCRIPTION
## Summary

Scanned `apps/canvas-workspace` for UI style inconsistencies against the conventions documented in `docs/conventions/frontend.md` and `docs/renderer-surfaces.md`. Found and fixed one concrete, documented gap:

- `NodeContextMenu` (`.context-menu`, also used by `EdgeContextMenu`) and the sidebar's `.sidebar-layer-context-menu` both hardcoded `z-index: 1000` instead of drawing from the app's `--layer-*` layering scale. That value **exactly collides with `--layer-fullscreen-node: 1000`**, so a right-click context menu opened while a node is fullscreened — or while the dock (1100), search bar (1500), note popovers (1550), interaction shield (1800), modal (1900), or command palette (2000) is showing — could render underneath those surfaces. `docs/renderer-surfaces.md` already called this out by name as a "known straggler... migrate opportunistically when touched," and the layering-scale comment in `styles.css` states: "never hardcode a z-index for a full-app surface."
  - Added `--layer-context-menu: 2075` (between `--layer-dialog` and `--layer-toast`) to `styles.css`.
  - Pointed both context-menu stylesheets at the new token.
  - Updated the layering-scale table and stragglers note in `docs/renderer-surfaces.md` to match.
- Also removed a redundant `export default MigrationSpinner;` left over in `MigrationSpinner/index.tsx`. The component already uses the documented named arrow-function export (`export const MigrationSpinner = (...) => {...}`), and the only importer (`App.tsx`) already uses the named import, so the default export was dead and violated the repo's "avoid default exports for components" rule for no reason.

### Other inconsistencies surveyed but intentionally left alone

A broader sweep found ~160+ places across ~30 CSS files where color literals (e.g. `#2383e2`, `#37352f`) duplicate an existing `--accent`/`--text`/etc. token instead of referencing it via `var()`. That pattern is actually the *majority* usage in the codebase today (not a minority exception), so rewriting it wholesale would be a large, speculative, high-diff refactor with no behavior change (the app is light-theme-only, so there's no visible bug) — out of scope for a targeted style-consistency fix. Flagging here as a known follow-up rather than bundling it into this PR.

## Why

Keeps the app's documented "no hardcoded z-index for full-app surfaces" invariant intact and closes the specific gap the docs already flagged, without speculative large-scale rewrites.

## Test plan

- [ ] `pnpm --filter canvas-workspace typecheck` (dependencies aren't installed in this sandbox, so this wasn't run here — please verify in CI/locally)
- [ ] `pnpm --filter canvas-workspace test`
- [ ] Manually verify: right-click a canvas node/edge, and right-click a sidebar layer, while the right dock or command palette is open — the context menu should now render on top instead of possibly being hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q54V9JKkTcy6ahAs83oDTj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q54V9JKkTcy6ahAs83oDTj)_