### PR TITLE
style(canvas-workspace): align components with named arrow-function export convention

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/DynamicAppNodeBody/Inspector.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/DynamicAppNodeBody/Inspector.tsx
@@ -38,12 +38,12 @@ interface DynamicAppInspectorProps {
   onUrlChanged(url: string): void;
 }
 
-export function DynamicAppInspector({
+export const DynamicAppInspector = ({
   workspaceId,
   dynamicAppId,
   apiUrl,
   onUrlChanged,
-}: DynamicAppInspectorProps) {
+}: DynamicAppInspectorProps) => {
   const [tab, setTab] = useState<Tab>("spec");
   const [spec, setSpec] = useState<GetSpecOk | null>(null);
   const [specError, setSpecError] = useState<string | null>(null);
@@ -114,11 +114,11 @@ export function DynamicAppInspector({
       </div>
     </div>
   );
-}
+};
 
 // ─── Payload tab ──────────────────────────────────────────────────
 
-function PayloadTab({ apiUrl }: { apiUrl: string }) {
+const PayloadTab = ({ apiUrl }: { apiUrl: string }) => {
   const [latest, setLatest] = useState<unknown>(undefined);
   const [streamError, setStreamError] = useState<string | null>(null);
 
@@ -163,11 +163,11 @@ function PayloadTab({ apiUrl }: { apiUrl: string }) {
       {JSON.stringify(latest, null, 2)}
     </pre>
   );
-}
+};
 
 // ─── Actions tab ──────────────────────────────────────────────────
 
-function ActionsTab({
+const ActionsTab = ({
   workspaceId,
   dynamicAppId,
   kind,
@@ -177,7 +177,7 @@ function ActionsTab({
   dynamicAppId: string;
   kind: "polling" | "stateful" | undefined;
   onUrlChanged(url: string): void;
-}) {
+}) => {
   const [busy, setBusy] = useState(false);
   const [toast, setToast] = useState<{ msg: string; error?: boolean } | null>(null);
   const [confirmingReset, setConfirmingReset] = useState(false);
@@ -260,4 +260,4 @@ function ActionsTab({
       )}
     </div>
   );
-}
+};

--- a/apps/canvas-workspace/src/renderer/src/components/DynamicAppNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/DynamicAppNodeBody/index.tsx
@@ -57,12 +57,12 @@ function apiBaseFromUiUrl(uiUrl: string): string {
   return noQuery.replace(/\/ui\//, "/api/");
 }
 
-export function DynamicAppNodeBody({
+export const DynamicAppNodeBody = ({
   node,
   workspaceId,
   readOnly: _readOnly,
   isResizing: _isResizing,
-}: DynamicAppNodeBodyProps) {
+}: DynamicAppNodeBodyProps) => {
   // The dispatcher only routes `type === 'dynamic-app'` here, so
   // node.data narrows to DynamicAppNodeData. Be defensive about the
   // shape in case canvas.json was hand-edited.
@@ -161,4 +161,4 @@ export function DynamicAppNodeBody({
       </div>
     </div>
   );
-}
+};

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/PluginNodeIcon.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/PluginNodeIcon.tsx
@@ -14,7 +14,7 @@ export function inferPluginIcon(nodeType: string): string {
   return 'plugin';
 }
 
-export function PluginNodeIcon({ icon, size = 18 }: { icon?: string; size?: number }) {
+export const PluginNodeIcon = ({ icon, size = 18 }: { icon?: string; size?: number }) => {
   const normalized = (icon ?? 'plugin').trim() || 'plugin';
   const token = normalized.toLowerCase();
 
@@ -75,4 +75,4 @@ export function PluginNodeIcon({ icon, size = 18 }: { icon?: string; size?: numb
       <path d="M7.2 6.2h3.6v5.6H7.2V6.2z" fill="currentColor" opacity="0.16" />
     </svg>
   );
-}
+};

--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/BuiltInToolsSection.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/BuiltInToolsSection.tsx
@@ -253,7 +253,7 @@ export const BuiltInToolsSection = ({ onClose }: BuiltInToolsSectionProps) => {
   );
 };
 
-function CredentialBadge({ credential }: { credential: BuiltInToolCredentialStatus }) {
+const CredentialBadge = ({ credential }: { credential: BuiltInToolCredentialStatus }) => {
   const { t } = useI18n();
   const label = credential.source === 'stored'
     ? t('toolsConfig.sourceStored')
@@ -269,7 +269,7 @@ function CredentialBadge({ credential }: { credential: BuiltInToolCredentialStat
       {label}{length ? ` · ${length}` : ''}
     </span>
   );
-}
+};
 
 function formatBaseUrlSource(
   credential: BuiltInToolCredentialStatus,

--- a/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/NodesChatDock.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/NodesChatDock.tsx
@@ -137,7 +137,7 @@ interface NodesChatDockProps {
  * When collapsed it renders only a floating Pulse launcher. Layout (pushing
  * column in Nodes, overlay in Graph) is driven by page-scoped CSS.
  */
-export function NodesChatDock({
+export const NodesChatDock = ({
   open,
   rendered,
   width,
@@ -148,7 +148,7 @@ export function NodesChatDock({
   nodes,
   tags,
   onOpenAppSettings,
-}: NodesChatDockProps) {
+}: NodesChatDockProps) => {
   const { t } = useI18n();
 
   const knowledgeNodes = useMemo(
@@ -210,4 +210,4 @@ export function NodesChatDock({
       )}
     </>
   );
-}
+};

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatEmptyState.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatEmptyState.tsx
@@ -4,7 +4,7 @@ import type { QuickAction } from './types';
 import { AppLogoIcon } from '../icons';
 import { useI18n } from '../../i18n';
 
-function QuickActionIcon({ action }: { action: QuickAction }) {
+const QuickActionIcon = ({ action }: { action: QuickAction }) => {
   switch (action.key) {
     case 'summarize_canvas':
       return (
@@ -40,7 +40,7 @@ function QuickActionIcon({ action }: { action: QuickAction }) {
         </svg>
       );
   }
-}
+};
 
 interface ChatEmptyStateProps {
   selectedCount?: number;


### PR DESCRIPTION
## Summary

`apps/canvas-workspace/docs/conventions/frontend.md` states the component
style convention for the renderer:

> Export **named arrow-function components** ... Avoid `default` exports
> for components.

Scanning `apps/canvas-workspace/src/renderer/src/components/**` turned up
two categories of drift from that convention, both isolated and
mechanical to fix:

1. **`function`/`export function` components instead of arrow functions**
   (8 components across 6 files):
   - `WorkspaceNodes/NodesChatDock.tsx` — `NodesChatDock`
   - `FloatingToolbar/PluginNodeIcon.tsx` — `PluginNodeIcon`
   - `DynamicAppNodeBody/index.tsx` — `DynamicAppNodeBody`
   - `DynamicAppNodeBody/Inspector.tsx` — `DynamicAppInspector`, `PayloadTab`, `ActionsTab`
   - `chat/ChatEmptyState.tsx` — `QuickActionIcon`
   - `Settings/BuiltInToolsSection.tsx` — `CredentialBadge`

2. **Dead `export default` alongside a named export**:
   - `MigrationSpinner/index.tsx` exported both
     `export const MigrationSpinner = ...` and, at the bottom of the file,
     `export default MigrationSpinner`. Only the named export is imported
     anywhere in the codebase (`App.tsx` uses
     `import { MigrationSpinner } from './components/MigrationSpinner'`),
     so the default export was unused dead code that also violated the
     "avoid default exports for components" rule.

All 53 other components in `src/renderer/src/components/` already follow
the named-arrow-function pattern, so these were the outliers. This PR
brings them in line — no behavior change, no props/logic touched, only
the function declaration syntax and the dead export.

I also checked for hardcoded colors (hex/rgba vs. the documented oklch
token convention) and `Props`-interface naming, but those turned out to
be the prevailing pattern across nearly all component CSS/files rather
than isolated outliers — "fixing" them would mean rewriting most of the
CSS/type layer, which isn't a safe, minimal, or high-confidence change.
I left those alone.

## Why this improves consistency

- One documented, single way to declare a component in this codebase —
  no mixing of `function Foo()` and `const Foo = () =>` across files.
- Removes dead code (`MigrationSpinner`'s unused default export).

## Test plan

- [x] `pnpm --filter canvas-workspace typecheck` — renderer `tsconfig.json` project compiles with **zero errors** (the only remaining error is a pre-existing `tsconfig.node.json` TS6.0 `baseUrl` deprecation warning, unrelated to this change).
- [x] `pnpm --filter canvas-workspace test` — 558/563 tests pass; the 5 failures (and the suites that fail to even load) are pre-existing environment issues unrelated to this diff (Electron binary couldn't be downloaded in this sandbox, `pulse-coder-engine`/`pulse-coder-agent-teams` workspace packages fail to resolve, and pre-existing file-size-governance baseline drift in files this PR never touches). None of the 7 edited files appear in any failure.
- [x] Manually reviewed every diff hunk; brace-balance-checked each edited file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1qjUSe7zu2xHn32Z7rL1r


---
_Generated by [Claude Code](https://claude.ai/code/session_01G1qjUSe7zu2xHn32Z7rL1r)_