### PR TITLE
release(canvas): 0.1.13

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.12",
+  "version": "0.1.13",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasDemoCanvas.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasDemoCanvas.ts
@@ -1,0 +1,209 @@
+import { useCallback, type Dispatch, type SetStateAction } from 'react';
+import type {
+  AgentNodeData,
+  CanvasEdge,
+  CanvasNode,
+  FrameNodeData,
+  IframeNodeData,
+  MindmapNodeData,
+  TextNodeData,
+} from '../../../types';
+import type { I18nKey } from '../../../i18n';
+import { createDefaultEdge } from '../../../utils/edgeFactory';
+import { genTopicId } from '../../../utils/nodeFactory';
+
+type I18nParams = Record<string, string | number | boolean | null | undefined>;
+
+interface NotifyArgs {
+  tone: 'success';
+  title: string;
+  description?: string;
+  autoCloseMs?: number;
+}
+
+interface UseCanvasDemoCanvasOptions {
+  addEdge: (edge: CanvasEdge) => void;
+  addNode: (type: CanvasNode['type'], x: number, y: number) => CanvasNode;
+  getViewportCenter: () => { x: number; y: number } | null;
+  notify: (args: NotifyArgs) => void;
+  rootFolder?: string;
+  setHighlightedId: (id: string) => void;
+  setSelectedNodeIds: Dispatch<SetStateAction<string[]>>;
+  t: (key: I18nKey, params?: I18nParams) => string;
+  updateNode: (id: string, patch: Partial<CanvasNode>) => void;
+}
+
+export const useCanvasDemoCanvas = ({
+  addEdge,
+  addNode,
+  getViewportCenter,
+  notify,
+  rootFolder,
+  setHighlightedId,
+  setSelectedNodeIds,
+  t,
+  updateNode,
+}: UseCanvasDemoCanvasOptions) => useCallback(() => {
+  const center = getViewportCenter();
+  if (!center) return;
+
+  const FRAME_W = 700;
+  const FRAME_H = 540;
+  const GAP = 80;
+  const top = center.y - FRAME_H / 2;
+  const leftA = center.x - (FRAME_W * 1.5 + GAP);
+  const leftB = leftA + FRAME_W + GAP;
+  const leftC = leftB + FRAME_W + GAP;
+
+  const makeFrame = (x: number, title: string, color: string) => {
+    const frame = addNode('frame', x, top);
+    updateNode(frame.id, {
+      title,
+      width: FRAME_W,
+      height: FRAME_H,
+      data: { color } satisfies FrameNodeData,
+    });
+    return frame;
+  };
+
+  makeFrame(leftA, t('canvas.demo.frameCodeTitle'), '#2383e2');
+  const goal = addNode('text', leftA + 34, top + 60);
+  updateNode(goal.id, {
+    title: t('canvas.demo.introTitle'),
+    width: 300,
+    height: 184,
+    data: {
+      content: t('canvas.demo.introContent'),
+      textColor: '#1f2328',
+      backgroundColor: '#ffffff',
+      fontSize: 14,
+      autoSize: false,
+    } satisfies TextNodeData,
+  });
+  const repo = addNode('iframe', leftA + 366, top + 60);
+  updateNode(repo.id, {
+    title: t('canvas.demo.webTitle'),
+    width: 300,
+    height: 184,
+    data: {
+      url: 'https://github.com/hua-bang/pulse-agent',
+      html: '',
+      mode: 'url',
+      prompt: '',
+    } satisfies IframeNodeData,
+  });
+  const agent = addNode('agent', leftA + 34, top + 320);
+  updateNode(agent.id, {
+    title: t('canvas.demo.agentTitle'),
+    width: 632,
+    height: 196,
+    data: {
+      sessionId: '',
+      ...(rootFolder ? { cwd: rootFolder } : {}),
+      agentType: 'claude-code',
+      status: 'idle',
+      viewMode: 'setup',
+      lastInitPrompt: t('canvas.demo.agentPrompt'),
+    } satisfies AgentNodeData,
+  });
+  addEdge(createDefaultEdge(
+    { kind: 'node', nodeId: goal.id, anchor: 'bottom' },
+    { kind: 'node', nodeId: agent.id, anchor: 'auto' },
+    { label: t('canvas.demo.edgeBrief'), stroke: { color: '#2383e2', width: 2.4, style: 'solid' } },
+  ));
+  addEdge(createDefaultEdge(
+    { kind: 'node', nodeId: repo.id, anchor: 'bottom' },
+    { kind: 'node', nodeId: agent.id, anchor: 'auto' },
+    { label: t('canvas.demo.edgeContext'), stroke: { color: '#10b981', width: 2.4, style: 'solid' } },
+  ));
+
+  makeFrame(leftB, t('canvas.demo.frameResearchTitle'), '#f59e0b');
+  const source = addNode('iframe', leftB + 34, top + 92);
+  updateNode(source.id, {
+    title: t('canvas.demo.researchWebTitle'),
+    width: 300,
+    height: 388,
+    data: {
+      url: 'https://github.com/hua-bang/pulse-agent/issues',
+      html: '',
+      mode: 'url',
+      prompt: '',
+    } satisfies IframeNodeData,
+  });
+  const takeaways = addNode('text', leftB + 366, top + 92);
+  updateNode(takeaways.id, {
+    title: t('canvas.demo.researchNoteTitle'),
+    width: 300,
+    height: 388,
+    data: {
+      content: t('canvas.demo.researchNoteContent'),
+      textColor: '#1f2328',
+      backgroundColor: '#ffffff',
+      fontSize: 14,
+      autoSize: false,
+    } satisfies TextNodeData,
+  });
+  addEdge(createDefaultEdge(
+    { kind: 'node', nodeId: source.id, anchor: 'right' },
+    { kind: 'node', nodeId: takeaways.id, anchor: 'left' },
+    { label: t('canvas.demo.edgeCapture'), stroke: { color: '#f59e0b', width: 2.4, style: 'solid' } },
+  ));
+
+  makeFrame(leftC, t('canvas.demo.frameBrainstormTitle'), '#9575d4');
+  const ideas = addNode('mindmap', leftC + 150, top + 80);
+  updateNode(ideas.id, {
+    title: t('canvas.demo.brainstormMapTitle'),
+    width: 400,
+    height: 220,
+    data: {
+      root: {
+        id: genTopicId(),
+        text: t('canvas.demo.mapTopicRoot'),
+        children: [
+          { id: genTopicId(), text: t('canvas.demo.mapTopicA'), children: [] },
+          { id: genTopicId(), text: t('canvas.demo.mapTopicB'), children: [] },
+          { id: genTopicId(), text: t('canvas.demo.mapTopicC'), children: [] },
+        ],
+      },
+      layout: 'right',
+      rev: 0,
+    } satisfies MindmapNodeData,
+  });
+  const plan = addNode('text', leftC + 170, top + 352);
+  updateNode(plan.id, {
+    title: t('canvas.demo.planNoteTitle'),
+    width: 360,
+    height: 162,
+    data: {
+      content: t('canvas.demo.planNoteContent'),
+      textColor: '#1f2328',
+      backgroundColor: '#ffffff',
+      fontSize: 14,
+      autoSize: false,
+    } satisfies TextNodeData,
+  });
+  addEdge(createDefaultEdge(
+    { kind: 'node', nodeId: ideas.id, anchor: 'bottom' },
+    { kind: 'node', nodeId: plan.id, anchor: 'top' },
+    { label: t('canvas.demo.edgePrioritize'), stroke: { color: '#9575d4', width: 2.4, style: 'solid' } },
+  ));
+
+  setSelectedNodeIds([goal.id]);
+  setHighlightedId(goal.id);
+  notify({
+    tone: 'success',
+    title: t('canvas.demo.createdTitle'),
+    description: t('canvas.demo.createdDescription'),
+    autoCloseMs: 2600,
+  });
+}, [
+  addEdge,
+  addNode,
+  getViewportCenter,
+  notify,
+  rootFolder,
+  setHighlightedId,
+  setSelectedNodeIds,
+  t,
+  updateNode,
+]);

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -25,14 +25,14 @@ import { useCanvasRenderOrder } from './hooks/useCanvasRenderOrder';
 import { useCanvasReferenceActions } from './hooks/useCanvasReferenceActions';
 import { useCanvasExternalNodeEvents } from './hooks/useCanvasExternalNodeEvents';
 import { useCanvasVisibility } from './hooks/useCanvasVisibility';
+import { useCanvasDemoCanvas } from './hooks/useCanvasDemoCanvas';
 import { CanvasRootView } from './CanvasRootView';
 import { useAppShell } from '../AppShellProvider';
 import { useI18n } from '../../i18n';
-import { genTopicId, getNodeDefaultSize } from '../../utils/nodeFactory';
+import { getNodeDefaultSize } from '../../utils/nodeFactory';
 import { CANVAS_NODE_TYPE_LABEL_KEY } from '../../utils/nodeTypeI18n';
-import { createDefaultEdge } from '../../utils/edgeFactory';
 import { getUrlHostname, normalizeReferenceUrl } from '../ReferenceDrawer/utils';
-import type { AgentNodeData, CanvasNode, FrameNodeData, IframeNodeData, MindmapNodeData, TextNodeData } from '../../types';
+import type { AgentNodeData, CanvasNode, IframeNodeData } from '../../types';
 import type { CanvasProps } from './types';
 import { EXPERIMENTAL_FLAG_AGENT_TEAMS } from '../../../../shared/experimental-features';
 
@@ -399,171 +399,7 @@ export const Canvas = ({
     return { ...node, ...patch };
   }, [addNode, getViewportCenter, setHighlightedId, setSelectedNodeIds, updateNode]);
 
-  const handleCreateDemoCanvas = useCallback(() => {
-    const center = getViewportCenter();
-    if (!center) return;
-
-    // Three scenario frames in a row, centered on the viewport. Frame
-    // membership is spatial, so each scenario's nodes only need their center
-    // to fall inside the matching frame box.
-    const FRAME_W = 700;
-    const FRAME_H = 540;
-    const GAP = 80;
-    const top = center.y - FRAME_H / 2;
-    const leftA = center.x - (FRAME_W * 1.5 + GAP);
-    const leftB = leftA + FRAME_W + GAP;
-    const leftC = leftB + FRAME_W + GAP;
-
-    const makeFrame = (x: number, title: string, color: string) => {
-      const frame = addNode('frame', x, top);
-      updateNode(frame.id, {
-        title,
-        width: FRAME_W,
-        height: FRAME_H,
-        data: { color } satisfies FrameNodeData,
-      });
-      return frame;
-    };
-
-    // Scenario 1 — code with an agent.
-    makeFrame(leftA, t('canvas.demo.frameCodeTitle'), '#2383e2');
-    const goal = addNode('text', leftA + 34, top + 60);
-    updateNode(goal.id, {
-      title: t('canvas.demo.introTitle'),
-      width: 300,
-      height: 184,
-      data: {
-        content: t('canvas.demo.introContent'),
-        textColor: '#1f2328',
-        backgroundColor: '#ffffff',
-        fontSize: 14,
-        autoSize: false,
-      } satisfies TextNodeData,
-    });
-    const repo = addNode('iframe', leftA + 366, top + 60);
-    updateNode(repo.id, {
-      title: t('canvas.demo.webTitle'),
-      width: 300,
-      height: 184,
-      data: {
-        url: 'https://github.com/hua-bang/pulse-agent',
-        html: '',
-        mode: 'url',
-        prompt: '',
-      } satisfies IframeNodeData,
-    });
-    // Sits lower so the two inbound edges have room. `auto` targets let the
-    // brief/context lines fan out to either side of the agent's top edge
-    // instead of stacking on the same center point.
-    const agent = addNode('agent', leftA + 34, top + 320);
-    updateNode(agent.id, {
-      title: t('canvas.demo.agentTitle'),
-      width: 632,
-      height: 196,
-      data: {
-        sessionId: '',
-        ...(rootFolder ? { cwd: rootFolder } : {}),
-        agentType: 'claude-code',
-        status: 'idle',
-        viewMode: 'setup',
-        lastInitPrompt: t('canvas.demo.agentPrompt'),
-      } satisfies AgentNodeData,
-    });
-    addEdge(createDefaultEdge(
-      { kind: 'node', nodeId: goal.id, anchor: 'bottom' },
-      { kind: 'node', nodeId: agent.id, anchor: 'auto' },
-      { label: t('canvas.demo.edgeBrief'), stroke: { color: '#2383e2', width: 2.4, style: 'solid' } },
-    ));
-    addEdge(createDefaultEdge(
-      { kind: 'node', nodeId: repo.id, anchor: 'bottom' },
-      { kind: 'node', nodeId: agent.id, anchor: 'auto' },
-      { label: t('canvas.demo.edgeContext'), stroke: { color: '#10b981', width: 2.4, style: 'solid' } },
-    ));
-
-    // Scenario 2 — research the web.
-    makeFrame(leftB, t('canvas.demo.frameResearchTitle'), '#f59e0b');
-    const source = addNode('iframe', leftB + 34, top + 92);
-    updateNode(source.id, {
-      title: t('canvas.demo.researchWebTitle'),
-      width: 300,
-      height: 388,
-      data: {
-        url: 'https://github.com/hua-bang/pulse-agent/issues',
-        html: '',
-        mode: 'url',
-        prompt: '',
-      } satisfies IframeNodeData,
-    });
-    const takeaways = addNode('text', leftB + 366, top + 92);
-    updateNode(takeaways.id, {
-      title: t('canvas.demo.researchNoteTitle'),
-      width: 300,
-      height: 388,
-      data: {
-        content: t('canvas.demo.researchNoteContent'),
-        textColor: '#1f2328',
-        backgroundColor: '#ffffff',
-        fontSize: 14,
-        autoSize: false,
-      } satisfies TextNodeData,
-    });
-    addEdge(createDefaultEdge(
-      { kind: 'node', nodeId: source.id, anchor: 'right' },
-      { kind: 'node', nodeId: takeaways.id, anchor: 'left' },
-      { label: t('canvas.demo.edgeCapture'), stroke: { color: '#f59e0b', width: 2.4, style: 'solid' } },
-    ));
-
-    // Scenario 3 — brainstorm a plan.
-    makeFrame(leftC, t('canvas.demo.frameBrainstormTitle'), '#9575d4');
-    // Centered horizontally so the auto-sized map fills the frame instead of
-    // hugging the left edge, with the plan note centered right below it.
-    const ideas = addNode('mindmap', leftC + 150, top + 80);
-    updateNode(ideas.id, {
-      title: t('canvas.demo.brainstormMapTitle'),
-      width: 400,
-      height: 220,
-      data: {
-        root: {
-          id: genTopicId(),
-          text: t('canvas.demo.mapTopicRoot'),
-          children: [
-            { id: genTopicId(), text: t('canvas.demo.mapTopicA'), children: [] },
-            { id: genTopicId(), text: t('canvas.demo.mapTopicB'), children: [] },
-            { id: genTopicId(), text: t('canvas.demo.mapTopicC'), children: [] },
-          ],
-        },
-        layout: 'right',
-        rev: 0,
-      } satisfies MindmapNodeData,
-    });
-    const plan = addNode('text', leftC + 170, top + 352);
-    updateNode(plan.id, {
-      title: t('canvas.demo.planNoteTitle'),
-      width: 360,
-      height: 162,
-      data: {
-        content: t('canvas.demo.planNoteContent'),
-        textColor: '#1f2328',
-        backgroundColor: '#ffffff',
-        fontSize: 14,
-        autoSize: false,
-      } satisfies TextNodeData,
-    });
-    addEdge(createDefaultEdge(
-      { kind: 'node', nodeId: ideas.id, anchor: 'bottom' },
-      { kind: 'node', nodeId: plan.id, anchor: 'top' },
-      { label: t('canvas.demo.edgePrioritize'), stroke: { color: '#9575d4', width: 2.4, style: 'solid' } },
-    ));
-
-    setSelectedNodeIds([goal.id]);
-    setHighlightedId(goal.id);
-    notify({
-      tone: 'success',
-      title: t('canvas.demo.createdTitle'),
-      description: t('canvas.demo.createdDescription'),
-      autoCloseMs: 2600,
-    });
-  }, [
+  const handleCreateDemoCanvas = useCanvasDemoCanvas({
     addEdge,
     addNode,
     getViewportCenter,
@@ -573,7 +409,7 @@ export const Canvas = ({
     setSelectedNodeIds,
     t,
     updateNode,
-  ]);
+  });
 
   // Zoom-chip companions: reframe around everything / the selection.
   const handleFitAll = useCallback(() => {

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/useIframeArtifact.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/useIframeArtifact.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import type { Artifact } from '../../types';
+
+interface UseIframeArtifactOptions {
+  artifactId: string | null;
+  isArtifactMode: boolean;
+  workspaceId?: string;
+}
+
+export const useIframeArtifact = ({
+  artifactId,
+  isArtifactMode,
+  workspaceId,
+}: UseIframeArtifactOptions) => {
+  const [artifact, setArtifact] = useState<Artifact | null>(null);
+
+  useEffect(() => {
+    if (!isArtifactMode || !workspaceId || !artifactId) {
+      setArtifact(null);
+      return;
+    }
+    let cancelled = false;
+    const refresh = async () => {
+      const result = await window.canvasWorkspace.artifacts.get(workspaceId, artifactId);
+      if (cancelled) return;
+      setArtifact((result?.ok ? result.artifact : null) ?? null);
+    };
+    void refresh();
+    const unsubscribe = window.canvasWorkspace.artifacts.onChange((event) => {
+      if (event.workspaceId !== workspaceId) return;
+      if (event.artifactId !== artifactId) return;
+      if (event.kind === 'delete') {
+        setArtifact(null);
+        return;
+      }
+      void refresh();
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [isArtifactMode, workspaceId, artifactId]);
+
+  const version = artifact?.versions.find((item) => item.id === artifact.currentVersionId)
+    ?? artifact?.versions[artifact.versions.length - 1];
+
+  return {
+    artifact,
+    artifactHtml: version?.content ?? '',
+  };
+};

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/useIframeNodeState.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/useIframeNodeState.ts
@@ -6,7 +6,7 @@ import {
   useState,
   type KeyboardEvent,
 } from 'react';
-import type { Artifact, IframeNodeData } from '../../types';
+import type { IframeNodeData } from '../../types';
 import type { EditMode, IframeNodeBodyProps, LoadState, WebviewTag } from './types';
 import {
   BLANK_PAGE_URL,
@@ -19,6 +19,7 @@ import {
 } from './utils';
 import { isImeComposing } from '../../utils/ime';
 import { useWebviewBackgroundThrottle } from './useWebviewBackgroundThrottle';
+import { useIframeArtifact } from './useIframeArtifact';
 
 export const useIframeNodeState = ({
   node,
@@ -32,43 +33,8 @@ export const useIframeNodeState = ({
   const html = data.html ?? '';
   const savedPrompt = data.prompt ?? '';
   const artifactId = data.artifactId ?? null;
-
-  const [artifact, setArtifact] = useState<Artifact | null>(null);
   const isArtifactMode = mode === 'artifact' && !!artifactId && !!workspaceId;
-
-  useEffect(() => {
-    if (!isArtifactMode || !workspaceId || !artifactId) {
-      setArtifact(null);
-      return;
-    }
-    let cancelled = false;
-    const refresh = async () => {
-      const result = await window.canvasWorkspace.artifacts.get(workspaceId, artifactId);
-      if (cancelled) return;
-      setArtifact((result?.ok ? result.artifact : null) ?? null);
-    };
-    void refresh();
-    const unsubscribe = window.canvasWorkspace.artifacts.onChange((event) => {
-      if (event.workspaceId !== workspaceId) return;
-      if (event.artifactId !== artifactId) return;
-      if (event.kind === 'delete') {
-        setArtifact(null);
-        return;
-      }
-      void refresh();
-    });
-    return () => {
-      cancelled = true;
-      unsubscribe();
-    };
-  }, [isArtifactMode, workspaceId, artifactId]);
-
-  const artifactHtml = (() => {
-    if (!artifact) return '';
-    const version = artifact.versions.find((item) => item.id === artifact.currentVersionId)
-      ?? artifact.versions[artifact.versions.length - 1];
-    return version?.content ?? '';
-  })();
+  const { artifact, artifactHtml } = useIframeArtifact({ artifactId, isArtifactMode, workspaceId });
 
   const hasContent = isArtifactMode ? !!artifactHtml : (mode === 'url' ? !!url : !!html);
   const [editing, setEditing] = useState(!readOnly && !isArtifactMode && !hasContent);

--- a/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/GraphPage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/WorkspaceNodes/GraphPage.tsx
@@ -56,9 +56,7 @@ interface GraphLink {
 }
 
 /** A graph search hit — either a knowledge node or a tag node currently in the graph. */
-type GraphSearchResult =
-  | { kind: 'node'; node: WorkspaceNodeListItem }
-  | { kind: 'tag'; graphId: string; label: string };
+type GraphSearchResult = { kind: 'node'; node: WorkspaceNodeListItem } | { kind: 'tag'; graphId: string; label: string };
 
 const GRAPH_COLORS = {
   node: '#2383e2',

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
@@ -1,7 +1,6 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent, type SyntheticEvent } from 'react';
 import type { AgentChatMessage, CanvasNode } from '../../types';
 import { toFileUrl } from '../../utils/fileUrl';
-import { copyTextToClipboard } from '../../utils/clipboard';
 import { BotAvatarIcon, CheckIcon, CopyIcon, PencilIcon, RefreshIcon } from '../icons';
 import type { ToolCallStatus } from './types';
 import { renderMdWithMentions } from './utils/mentions';
@@ -16,6 +15,7 @@ import {
   ChatInlineVisual,
   parseVisualToolResult,
 } from '../artifacts';
+import { CopyGeneratedImageButton, parseGeneratedImage } from './GeneratedImageActions';
 
 const CopyMessageButton = memo(({ content }: { content: string }) => {
   const [copied, setCopied] = useState(false);
@@ -41,53 +41,6 @@ const CopyMessageButton = memo(({ content }: { content: string }) => {
   );
 });
 CopyMessageButton.displayName = 'CopyMessageButton';
-
-const CopyGeneratedImageButton = memo(({ imagePath }: { imagePath: string }) => {
-  const [copied, setCopied] = useState(false);
-  const handleCopy = useCallback(async () => {
-    try {
-      const result = await window.canvasWorkspace.file.copyImage(imagePath);
-      if (!result.ok) {
-        await copyTextToClipboard(toFileUrl(imagePath));
-      }
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1200);
-    } catch {
-      /* clipboard unavailable — ignore */
-    }
-  }, [imagePath]);
-  return (
-    <button
-      type="button"
-      className="chat-generated-image-card__action"
-      onClick={() => void handleCopy()}
-      title={copied ? 'Copied!' : 'Copy image'}
-      aria-label="Copy image"
-    >
-      {copied ? 'Copied' : 'Copy'}
-    </button>
-  );
-});
-CopyGeneratedImageButton.displayName = 'CopyGeneratedImageButton';
-
-interface GeneratedImagePayload {
-  ok?: boolean;
-  type?: string;
-  title?: string;
-  outputPath?: string;
-  mimeType?: string;
-  addToCanvasAction?: { workspaceId?: string; imagePath?: string };
-}
-
-const parseGeneratedImage = (result?: string): GeneratedImagePayload | null => {
-  if (!result) return null;
-  try {
-    const parsed = JSON.parse(result) as GeneratedImagePayload;
-    return parsed?.ok && parsed?.type === 'generated_image' && parsed.outputPath ? parsed : null;
-  } catch {
-    return null;
-  }
-};
 
 interface ChatMessageProps {
   message: AgentChatMessage;

--- a/apps/canvas-workspace/src/renderer/src/components/chat/GeneratedImageActions.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/GeneratedImageActions.tsx
@@ -1,0 +1,50 @@
+import { memo, useCallback, useState } from 'react';
+import { toFileUrl } from '../../utils/fileUrl';
+import { copyTextToClipboard } from '../../utils/clipboard';
+
+export interface GeneratedImagePayload {
+  ok?: boolean;
+  type?: string;
+  title?: string;
+  outputPath?: string;
+  mimeType?: string;
+  addToCanvasAction?: { workspaceId?: string; imagePath?: string };
+}
+
+export const parseGeneratedImage = (result?: string): GeneratedImagePayload | null => {
+  if (!result) return null;
+  try {
+    const parsed = JSON.parse(result) as GeneratedImagePayload;
+    return parsed?.ok && parsed?.type === 'generated_image' && parsed.outputPath ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+export const CopyGeneratedImageButton = memo(({ imagePath }: { imagePath: string }) => {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = useCallback(async () => {
+    try {
+      const result = await window.canvasWorkspace.file.copyImage(imagePath);
+      if (!result.ok) {
+        await copyTextToClipboard(toFileUrl(imagePath));
+      }
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    } catch {
+      /* clipboard unavailable - ignore */
+    }
+  }, [imagePath]);
+  return (
+    <button
+      type="button"
+      className="chat-generated-image-card__action"
+      onClick={() => void handleCopy()}
+      title={copied ? 'Copied!' : 'Copy image'}
+      aria-label="Copy image"
+    >
+      {copied ? 'Copied' : 'Copy'}
+    </button>
+  );
+});
+CopyGeneratedImageButton.displayName = 'CopyGeneratedImageButton';

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/attachmentFileName.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/attachmentFileName.ts
@@ -1,0 +1,10 @@
+const GENERIC_CLIPBOARD_NAME = /^image\.[a-z0-9]+$/i;
+
+export const buildAttachmentFileName = (file: File, ext: string): string => {
+  if (file.name && !GENERIC_CLIPBOARD_NAME.test(file.name)) return file.name;
+  const now = new Date();
+  const pad = (value: number) => String(value).padStart(2, '0');
+  const stamp = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`
+    + ` ${pad(now.getHours())}.${pad(now.getMinutes())}.${pad(now.getSeconds())}`;
+  return `Pasted image ${stamp}.${ext}`;
+};

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useMentions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useMentions.ts
@@ -15,25 +15,7 @@ import {
 } from '../utils/mentions';
 import { appendMentionChipToEditable } from '../utils/editableMentions';
 import { getNodeDisplayLabel } from '../../../utils/nodeLabel';
-
-/**
- * Browsers label every pasted clipboard image `image.png`, so each pasted
- * screenshot lands in the transcript under the same meaningless name. Give
- * those a readable, timestamped label (Obsidian-style) while keeping real
- * names from the file picker untouched. `fileName` is display-only metadata —
- * attachments are always referenced on disk by `path` — so a friendly,
- * human-facing label is safe to synthesize here.
- */
-const GENERIC_CLIPBOARD_NAME = /^image\.[a-z0-9]+$/i;
-
-const buildAttachmentFileName = (file: File, ext: string): string => {
-  if (file.name && !GENERIC_CLIPBOARD_NAME.test(file.name)) return file.name;
-  const now = new Date();
-  const pad = (value: number) => String(value).padStart(2, '0');
-  const stamp = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`
-    + ` ${pad(now.getHours())}.${pad(now.getMinutes())}.${pad(now.getSeconds())}`;
-  return `Pasted image ${stamp}.${ext}`;
-};
+import { buildAttachmentFileName } from './attachmentFileName';
 
 interface UseMentionsOptions {
   allWorkspaces?: WorkspaceOption[];

--- a/apps/canvas-workspace/src/renderer/src/components/settings-config/McpManager.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/settings-config/McpManager.tsx
@@ -1,15 +1,4 @@
-/**
- * McpManager — CRUD UI for MCP servers at a given scope.
- * Reused by the global Settings panel and the per-workspace settings drawer.
- *
- * Health badges per row come from the engine MCP plugin's status snapshot
- * (captured during its last initialize). After a save, the IPC awaits the
- * engine reload before returning, so the statuses we display are accurate.
- *
- * When `showInherited` is true and `scope` is a workspace, also surfaces the
- * agent-loaded global servers as a read-only section — matching what we do
- * for skills, so the user can see (and override) what the agent really has.
- */
+/** MCP server CRUD for global settings and per-workspace settings drawers. */
 
 import { useCallback, useEffect, useState } from 'react';
 import type {


### PR DESCRIPTION
## Summary
- Publish Pulse Canvas 0.1.13 stable macOS arm64 artifacts to R2.
- Update the canvas workspace package version to 0.1.13.
- Extract oversized helpers so the canvas file-size governance check stays green on latest master.

## Release
- Manifest: https://downloads.jasperhu.art/pulse-canvas/stable/latest.json
- Download page: https://pulse-canvas-download.pages.dev/
- Install section: https://pulse-canvas-download.pages.dev/#install

## Public notes
ZH: 新增 MCP 服务器连接、重连与工具刷新控制；网页元素选择会保存更完整的结构化快照；改进生成图片和画布图片的复制、预览与放大体验；修复编辑带图片的聊天消息时图片保持在正文上方。

EN: Added MCP server connect, reconnect, and tool refresh controls; web element selections now keep richer structured snapshots; improved copy, preview, and zoom interactions for generated and canvas images; fixed edited chat messages so image attachments stay above the text.

## Validation
- COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm --filter canvas-workspace typecheck
- COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm --filter canvas-workspace test
- git diff --check
- Rebuilt and re-uploaded artifacts after rebasing onto origin/master
- Verified remote latest.json reports 0.1.13 with rebuilt artifact sizes
- Verified download page returns HTTP 200

## Post-merge
After this PR merges into master:
```bash
git fetch origin master --tags
git tag -a pulse-canvas-v0.1.13 origin/master -m "Pulse Canvas 0.1.13"
git push origin pulse-canvas-v0.1.13
git ls-remote --tags origin "pulse-canvas-v0.1.13*"
```