### PR TITLE
fix: anchor collapsed settings button

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
@@ -421,7 +421,7 @@ export const Sidebar = ({
           </button>
           <button
             type="button"
-            className="sidebar-collapsed-btn"
+            className="sidebar-collapsed-btn sidebar-collapsed-btn--settings"
             onClick={onOpenAppSettings}
             title={t('sidebar.settings')}
             aria-label={t('sidebar.openSettings')}

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/interaction-polish.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/interaction-polish.css
@@ -1,5 +1,7 @@
 .sidebar-collapsed-rail {
-  padding: 10px 8px;
+  flex: 1;
+  min-height: 0;
+  padding: 10px 8px 12px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -25,6 +27,10 @@
   outline: none;
   background: rgba(0, 0, 0, 0.05);
   color: var(--text);
+}
+
+.sidebar-collapsed-btn--settings {
+  margin-top: auto;
 }
 
 .sidebar-collapsed-btn--active {


### PR DESCRIPTION
Fix the collapsed sidebar settings button placement.\n\n- Keep the collapsed sidebar rail stretched to the full sidebar height\n- Add a dedicated settings button class and push the gear to the bottom\n- Preserve the existing settings click handler and accessibility labels\n\nValidation:\n- git diff --check\n- pnpm --filter pulse-coder-orchestrator build && pnpm --filter pulse-coder-engine build && pnpm --filter canvas-workspace typecheck