### PR TITLE
fix: open workspace settings from chat

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -517,6 +517,7 @@ const AppContent = () => {
               controller={workbench}
               onSelectWorkspace={handleSelectWorkspace}
               onOpenAppSettings={openAppSettings}
+              onOpenWorkspaceSettings={setSettingsWorkspaceId}
               onSetActiveRootFolder={handleSetActiveRootFolder}
             />
           </PulseRouterView>
@@ -529,6 +530,7 @@ const AppContent = () => {
               onExit={exitChatView}
               onNodeFocus={handleNodeFocusFromChatPage}
               onOpenAppSettings={openAppSettings}
+              onOpenWorkspaceSettings={setSettingsWorkspaceId}
             />
           </PulseRouterView>
           {NODES_ENABLED && (

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
@@ -33,6 +33,8 @@ interface WorkbenchProps {
   onSelectWorkspace: (workspaceId: string) => void;
   /** Opens the global Settings drawer focused on the given section. */
   onOpenAppSettings: (section: SettingsSection) => void;
+  /** Opens the settings drawer for a specific workspace. */
+  onOpenWorkspaceSettings: (workspaceId: string) => void;
   onSetActiveRootFolder: () => void;
 }
 
@@ -42,6 +44,7 @@ export const Workbench: React.FC<WorkbenchProps> = ({
   controller,
   onSelectWorkspace,
   onOpenAppSettings,
+  onOpenWorkspaceSettings,
   onSetActiveRootFolder,
 }) => {
   const {
@@ -480,6 +483,7 @@ export const Workbench: React.FC<WorkbenchProps> = ({
                 onClose={dock.collapse}
                 onNodeFocus={(nodeId) => requestNodeFocus(ws.id, nodeId)}
                 onOpenAppSettings={onOpenAppSettings}
+                onOpenWorkspaceSettings={onOpenWorkspaceSettings}
                 onRegisterInsertMention={(fn) => registerInsertMention(ws.id, fn)}
                 onRegisterInsertDomSelectionMention={(fn) => registerInsertDomSelectionMention(ws.id, fn)}
                 onTurnComplete={dock.notifyChatActivity}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatHeader.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatHeader.tsx
@@ -22,7 +22,8 @@ interface ChatHeaderProps {
   onCloseSessionMenu: () => void;
   onNewSession: () => Promise<void>;
   onLoadSession: (sessionId: string, sourceWorkspaceId?: string) => Promise<void>;
-  onOpenModelSettings: () => void;
+  onOpenSettings: () => void;
+  settingsLabel: string;
   onOpenPromptSettings: () => void;
   onClose: () => void;
   /** Slot for the in-chat anchor / TOC control. */
@@ -46,7 +47,8 @@ export const ChatHeader = ({
   onCloseSessionMenu,
   onNewSession,
   onLoadSession,
-  onOpenModelSettings,
+  onOpenSettings,
+  settingsLabel,
   onOpenPromptSettings,
   onClose,
   anchors,
@@ -198,9 +200,9 @@ export const ChatHeader = ({
         </button>
         <button
           className="chat-panel-action-btn"
-          onClick={onOpenModelSettings}
-          title={t('chat.modelSettings')}
-          aria-label={t('chat.modelSettings')}
+          onClick={onOpenSettings}
+          title={settingsLabel}
+          aria-label={settingsLabel}
         >
           <SettingsIcon size={16} strokeWidth={1.25} />
         </button>

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.tsx
@@ -15,6 +15,8 @@ interface ChatPageProps {
   onNodeFocus?: (workspaceId: string, nodeId: string) => void;
   /** Opens the global Settings drawer focused on the given section. */
   onOpenAppSettings: (section: SettingsSection) => void;
+  /** Opens per-workspace settings when the chat scope is workspace-bound. */
+  onOpenWorkspaceSettings?: (workspaceId: string) => void;
 }
 
 /**
@@ -40,6 +42,7 @@ export const ChatPage = ({
   onExit,
   onNodeFocus,
   onOpenAppSettings,
+  onOpenWorkspaceSettings,
 }: ChatPageProps) => {
   const [agentScope, setAgentScope] = useState<AgentScope>({ kind: 'global' });
   const [pendingSessionId, setPendingSessionId] = useState<string | null>(null);
@@ -133,6 +136,7 @@ export const ChatPage = ({
       railCollapsed={railCollapsed}
       onToggleRail={handleToggleRail}
       onOpenAppSettings={onOpenAppSettings}
+      onOpenWorkspaceSettings={onOpenWorkspaceSettings}
     />
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageBody.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageBody.tsx
@@ -49,6 +49,8 @@ export interface ChatPageBodyProps {
   onToggleRail: () => void;
   /** Opens the global Settings drawer focused on the given section. */
   onOpenAppSettings: (section: SettingsSection) => void;
+  /** Opens per-workspace settings when the chat scope is workspace-bound. */
+  onOpenWorkspaceSettings?: (workspaceId: string) => void;
 }
 
 export const ChatPageBody = ({
@@ -73,11 +75,22 @@ export const ChatPageBody = ({
   railCollapsed,
   onToggleRail,
   onOpenAppSettings,
+  onOpenWorkspaceSettings,
 }: ChatPageBodyProps) => {
   const { t } = useI18n();
   const { notify } = useAppShell();
   const workspaceId = agentScope.kind === 'workspace' ? agentScope.workspaceId : undefined;
   const anchorScopeId = workspaceId ?? 'global';
+  const settingsButtonLabel = workspaceId && onOpenWorkspaceSettings
+    ? t('workspaceSettings.ariaLabel')
+    : t('chat.modelSettings');
+  const handleOpenScopeSettings = useCallback(() => {
+    if (workspaceId && onOpenWorkspaceSettings) {
+      onOpenWorkspaceSettings(workspaceId);
+      return;
+    }
+    onOpenAppSettings('models');
+  }, [onOpenAppSettings, onOpenWorkspaceSettings, workspaceId]);
   // Snapshot at mount: the caller might change pendingSessionId later (e.g.
   // for a same-workspace click), but on mount we only care about the value
   // we saw when this body was constructed (after a workspace switch).
@@ -393,9 +406,9 @@ export const ChatPageBody = ({
           </button>
           <button
             className="chat-panel-action-btn"
-            onClick={() => onOpenAppSettings('models')}
-            title={t('chat.modelSettings')}
-            aria-label={t('chat.modelSettings')}
+            onClick={handleOpenScopeSettings}
+            title={settingsButtonLabel}
+            aria-label={settingsButtonLabel}
           >
             <SettingsIcon size={16} strokeWidth={1.25} />
           </button>

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.tsx
@@ -31,6 +31,7 @@ export const ChatPanel = ({
   onResizeStart,
   onNodeFocus,
   onOpenAppSettings,
+  onOpenWorkspaceSettings,
   onRegisterInsertMention,
   onRegisterInsertDomSelectionMention,
   onTurnComplete,
@@ -54,6 +55,16 @@ export const ChatPanel = ({
   // Anchor element ids are namespaced per scope; global chat has no workspace
   // so it falls back to a stable 'global' namespace.
   const anchorScopeId = scopeWorkspaceId ?? 'global';
+  const settingsButtonLabel = scopeWorkspaceId && onOpenWorkspaceSettings
+    ? t('workspaceSettings.ariaLabel')
+    : t('chat.modelSettings');
+  const handleOpenScopeSettings = useCallback(() => {
+    if (scopeWorkspaceId && onOpenWorkspaceSettings) {
+      onOpenWorkspaceSettings(scopeWorkspaceId);
+      return;
+    }
+    onOpenAppSettings('models');
+  }, [onOpenAppSettings, onOpenWorkspaceSettings, scopeWorkspaceId]);
 
   const {
     abort,
@@ -366,7 +377,8 @@ export const ChatPanel = ({
           onToggleSessionMenu={openSessionMenu}
           onCloseSessionMenu={closeSessionMenu}
           onNewSession={handleNewSessionFromMenu}
-          onOpenModelSettings={() => onOpenAppSettings('models')}
+          onOpenSettings={handleOpenScopeSettings}
+          settingsLabel={settingsButtonLabel}
           onOpenPromptSettings={() => onOpenAppSettings('reply-style')}
           onLoadSession={handleLoadSessionFromMenu}
           onClose={onClose}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/types.ts
@@ -62,6 +62,8 @@ export interface ChatPanelProps {
   onNodeFocus?: (nodeId: string) => void;
   /** Opens the global Settings drawer focused on the given section. */
   onOpenAppSettings: (section: SettingsSection) => void;
+  /** Opens per-workspace settings when the chat scope is workspace-bound. */
+  onOpenWorkspaceSettings?: (workspaceId: string) => void;
   /** Called once the insert-mention function is ready; returns a cleanup fn. */
   onRegisterInsertMention?: (fn: (node: CanvasNode) => void) => () => void;
   /** Called once the DOM-selection mention inserter is ready; returns a cleanup fn. */


### PR DESCRIPTION
Update chat settings entry behavior so workspace-scoped chats open workspace settings while global chats keep opening global model settings.

- Pass the workspace settings drawer opener from App into ChatPage and Workbench chat panels
- Make the chat settings gear scope-aware in full-page chat and docked chat
- Keep reply-style and model-switcher configuration actions pointed at global settings

Validation:
- Passed: pnpm --filter canvas-workspace typecheck:renderer (Docker, after dependency install with scripts disabled)
- Full pnpm --filter canvas-workspace typecheck is blocked by existing main-side pulse-coder-engine/built-in type resolution errors