### PR TITLE
fix: focus page target before CDP input

### DIFF
--- a/apps/canvas-workspace/src/plugins/main/webview-page-control/__tests__/cdp-actions.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/webview-page-control/__tests__/cdp-actions.test.ts
@@ -144,23 +144,24 @@ describe('cdpPressKey', () => {
     const host = makeHost();
     const r = await cdpPressKey(host, 'a');
     expect(r.ok).toBe(true);
-    expect(host.cdpCalls).toHaveLength(2);
+    expect(host.cdpCalls).toHaveLength(3);
+    expect(host.cdpCalls[0]).toEqual({ method: 'Page.bringToFront', params: undefined });
     // Letter 'a' uses keyDown (text-producing) — no separate rawKeyDown step.
-    expect(host.cdpCalls[0].params).toMatchObject({
+    expect(host.cdpCalls[1].params).toMatchObject({
       type: 'keyDown',
       key: 'a',
       code: 'KeyA',
       windowsVirtualKeyCode: 65,
       text: 'a',
     });
-    expect(host.cdpCalls[1].params).toMatchObject({ type: 'keyUp', key: 'a' });
+    expect(host.cdpCalls[2].params).toMatchObject({ type: 'keyUp', key: 'a' });
   });
 
   it('uses rawKeyDown (no text) for special keys like Enter when no Ctrl/Meta is held', async () => {
     const host = makeHost();
     await cdpPressKey(host, 'Enter');
     // Enter generates text '\r' on keyDown so it appears as keyDown, not rawKeyDown.
-    expect(host.cdpCalls[0].params).toMatchObject({
+    expect(host.cdpCalls[1].params).toMatchObject({
       type: 'keyDown',
       key: 'Enter',
       code: 'Enter',
@@ -172,12 +173,12 @@ describe('cdpPressKey', () => {
     const host = makeHost();
     await cdpPressKey(host, 'a', { modifiers: ['ctrl'] });
     // ctrl is held → text must be empty so the page doesn\'t see "ctrl+a" AND a typed 'a'.
-    expect(host.cdpCalls[0].params).toMatchObject({
+    expect(host.cdpCalls[1].params).toMatchObject({
       type: 'rawKeyDown',
       key: 'a',
       modifiers: 2,
     });
-    expect(host.cdpCalls[0].params).not.toHaveProperty('text');
+    expect(host.cdpCalls[1].params).not.toHaveProperty('text');
   });
 
   it('focuses the optional selector before pressing', async () => {
@@ -217,6 +218,7 @@ describe('cdpFillSelector', () => {
     expect(r.ok).toBe(true);
     expect(r.data).toMatchObject({ tag: 'input', length: 5, mode: 'insertText' });
     expect(host.cdpCalls).toEqual([
+      { method: 'Page.bringToFront', params: undefined },
       { method: 'Input.insertText', params: { text: 'hello' } },
     ]);
   });

--- a/apps/canvas-workspace/src/plugins/main/webview-page-control/cdp-actions.ts
+++ b/apps/canvas-workspace/src/plugins/main/webview-page-control/cdp-actions.ts
@@ -74,6 +74,15 @@ async function runWithTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
   ]);
 }
 
+async function bringPageTargetToFront(send: CdpSender): Promise<void> {
+  try {
+    await send('Page.bringToFront');
+  } catch {
+    // Older/embedded targets can reject this. `wc.focus()` above remains the
+    // primary route; this CDP activation is a best-effort extra guard.
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Selector → coordinate resolution (JS-side, fast, no debugger needed)
 // ---------------------------------------------------------------------------
@@ -262,6 +271,7 @@ export async function cdpPressKey(
   try {
     return await runWithTimeout(
       withCdp(wc, async (send: CdpSender) => {
+        await bringPageTargetToFront(send);
         const baseInit: Record<string, unknown> = {
           key: spec.key,
           code: spec.code,
@@ -378,6 +388,7 @@ export async function cdpFillSelector(
   try {
     return await runWithTimeout(
       withCdp(wc, async (send: CdpSender) => {
+        await bringPageTargetToFront(send);
         await send('Input.insertText', { text: value });
         return {
           ok: true,


### PR DESCRIPTION
Ensure CDP keyboard and text input actions target the active page before dispatching input.

- Add best-effort Page.bringToFront before key press and selector fill actions
- Keep input behavior compatible when Page.bringToFront is unsupported
- Update CDP action tests for the additional activation call

Validation:
- pnpm --filter canvas-workspace exec vitest run src/plugins/main/webview-page-control/__tests__/cdp-actions.test.ts (passed: 17 tests)
- pnpm --filter canvas-workspace typecheck:main (blocked by existing local dependency/type resolution issues: missing electron/@types/node/zod and related modules)