### PR TITLE
fix(feishu): verify bot mentions in groups

### DIFF
--- a/apps/remote-server/README.md
+++ b/apps/remote-server/README.md
@@ -63,6 +63,11 @@ FEISHU_ENCRYPT_KEY=
 FEISHU_VERIFICATION_TOKEN=
 FEISHU_EVENT_SOURCE=webhook  # webhook (default), long_connection, or both
 FEISHU_ENABLE_REACTIONS=     # Optional: true, false, or group; default false
+FEISHU_BOT_OPEN_ID=          # Optional fallback for group @bot filtering
+FEISHU_BOT_USER_ID=          # Optional fallback for group @bot filtering
+FEISHU_BOT_UNION_ID=         # Optional fallback for group @bot filtering
+FEISHU_BOT_NAME=             # Optional fallback for group @bot filtering
+FEISHU_BOT_MENTION_ALIASES=  # Optional comma-separated aliases for group @bot filtering
 
 # === Discord ===
 DISCORD_PUBLIC_KEY=
@@ -122,7 +127,7 @@ Users can type these as in-channel text in any connected channel:
 1. In the Feishu Developer Console, create an app and note `App ID` / `App Secret`.
 2. Subscribe to the event `im.message.receive_v1`.
 3. Grant bot permissions: `im:message:send_as_bot`, `im:message.group_at_msg` (for group chats). Message reactions are optional; set `FEISHU_ENABLE_REACTIONS=true` or `group` only after granting reaction permissions.
-4. Set `FEISHU_APP_ID` and `FEISHU_APP_SECRET` in `.env`.
+4. Set `FEISHU_APP_ID` and `FEISHU_APP_SECRET` in `.env`. Group chats only trigger when the event mention is verified as the current bot. The server resolves bot identity through `/open-apis/bot/v3/info`; set `FEISHU_BOT_OPEN_ID`, `FEISHU_BOT_USER_ID`, `FEISHU_BOT_UNION_ID`, `FEISHU_BOT_NAME`, or `FEISHU_BOT_MENTION_ALIASES` as explicit fallbacks when needed.
 5. Pick the event receiver:
    - `FEISHU_EVENT_SOURCE=long_connection`: use Feishu's persistent WebSocket connection. In the Feishu Developer Console, set event subscription mode to **Receive events through persistent connection**. The webhook route remains mounted but only returns an empty 200 response.
    - `FEISHU_EVENT_SOURCE=webhook`: use the public webhook endpoint. Set `FEISHU_ENCRYPT_KEY` and `FEISHU_VERIFICATION_TOKEN`, enable them in Event Subscription security settings, then set the webhook URL:

--- a/apps/remote-server/src/adapters/feishu/adapter.ts
+++ b/apps/remote-server/src/adapters/feishu/adapter.ts
@@ -22,6 +22,7 @@ import {
 } from './client.js';
 import { buildFeishuPlatformKey, parseFeishuPlatformKey, resolveFeishuTopicId } from './platform-key.js';
 import { parseFeishuMessageContent } from './message-content.js';
+import { isFeishuMessageMentioningCurrentBot } from './mention-filter.js';
 
 
 /**
@@ -169,10 +170,10 @@ export class FeishuAdapter implements PlatformAdapter {
     const chatType = message['chat_type'] as string | undefined; // 'p2p' | 'group'
     const isGroupChat = chatType === 'group';
 
-    // Group chats: only respond when @mentioned
+    // Group chats: only respond when this bot is @mentioned.
     if (isGroupChat) {
       const mentions = (message['mentions'] as unknown[] | undefined) ?? [];
-      if (mentions.length === 0) return null;
+      if (!await isFeishuMessageMentioningCurrentBot(mentions)) return null;
       text = removeFeishuMentions(text, mentions);
       if (!text && !hasAttachments) return null;
     }

--- a/apps/remote-server/src/adapters/feishu/client.ts
+++ b/apps/remote-server/src/adapters/feishu/client.ts
@@ -30,6 +30,13 @@ interface FeishuApiResponse<T> {
 let cachedTenantAccessToken: string | null = null;
 let tenantAccessTokenExpiresAt = 0;
 
+export interface FeishuBotInfo {
+  appName?: string;
+  openId?: string;
+}
+
+let cachedBotInfo: FeishuBotInfo | null = null;
+
 function getFeishuBaseUrl(): string {
   const envBaseUrl = process.env.FEISHU_API_BASE_URL?.trim();
   return (envBaseUrl || 'https://open.feishu.cn').replace(/\/$/, '');
@@ -115,6 +122,44 @@ async function uploadImageToFeishu(imagePath: string, mimeType?: string): Promis
   }
 
   return imageKey;
+}
+
+export async function getCurrentFeishuBotInfo(): Promise<FeishuBotInfo | null> {
+  if (cachedBotInfo) {
+    return cachedBotInfo;
+  }
+
+  const token = await getTenantAccessToken();
+  const response = await fetchFeishuWithRetry({
+    url: `${getFeishuBaseUrl()}/open-apis/bot/v3/info`,
+    init: {
+      method: 'GET',
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    },
+    action: 'get bot info',
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Failed to get Feishu bot info: ${response.status} ${response.statusText} - ${body}`);
+  }
+
+  const payload = (await response.json()) as FeishuApiResponse<{
+    app_name?: string;
+    open_id?: string;
+  }>;
+
+  if (payload.code !== 0) {
+    throw new Error(`Failed to get Feishu bot info: ${payload.msg || 'unknown error'}`);
+  }
+
+  cachedBotInfo = {
+    appName: payload.data?.app_name?.trim() || undefined,
+    openId: payload.data?.open_id?.trim() || undefined,
+  };
+  return cachedBotInfo;
 }
 
 export async function downloadMessageImageResourceFromFeishu(input: {

--- a/apps/remote-server/src/adapters/feishu/mention-filter.test.ts
+++ b/apps/remote-server/src/adapters/feishu/mention-filter.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { isFeishuMessageMentioningBot } from './mention-filter.js';
+
+describe('isFeishuMessageMentioningBot', () => {
+  it('matches a bot open_id nested under the mention id object', () => {
+    expect(isFeishuMessageMentioningBot([
+      {
+        key: '@_user_1',
+        id: {
+          open_id: 'ou_bot',
+          user_id: 'bot_user',
+        },
+        name: 'Pulse Coder',
+      },
+    ], {
+      openId: 'ou_bot',
+    })).toBe(true);
+  });
+
+  it('ignores group messages that mention another user', () => {
+    expect(isFeishuMessageMentioningBot([
+      {
+        key: '@_user_2',
+        id: {
+          open_id: 'ou_someone_else',
+          user_id: 'other_user',
+        },
+        name: 'Someone Else',
+      },
+    ], {
+      openId: 'ou_bot',
+      userId: 'bot_user',
+    })).toBe(false);
+  });
+
+  it('matches configured bot mention aliases by name', () => {
+    expect(isFeishuMessageMentioningBot([
+      {
+        key: '@Pulse',
+        name: '@Pulse',
+      },
+    ], {
+      aliases: ['pulse'],
+    })).toBe(true);
+  });
+
+  it('does not accept mentions when no bot identity is available', () => {
+    expect(isFeishuMessageMentioningBot([
+      {
+        key: '@_user_1',
+        name: 'Any Mention',
+      },
+    ], {})).toBe(false);
+  });
+});

--- a/apps/remote-server/src/adapters/feishu/mention-filter.ts
+++ b/apps/remote-server/src/adapters/feishu/mention-filter.ts
@@ -1,0 +1,204 @@
+interface FeishuBotInfo {
+  appName?: string;
+  openId?: string;
+}
+
+export interface FeishuBotMentionIdentity {
+  openId?: string;
+  userId?: string;
+  unionId?: string;
+  appId?: string;
+  appName?: string;
+  aliases?: string[];
+}
+
+let lastBotIdentityWarningAt = 0;
+
+export async function isFeishuMessageMentioningCurrentBot(mentions: unknown[]): Promise<boolean> {
+  if (mentions.length === 0) {
+    return false;
+  }
+
+  const configuredIdentity = buildFeishuBotMentionIdentity();
+  if (hasFeishuBotMentionIdentity(configuredIdentity)) {
+    return isFeishuMessageMentioningBot(mentions, configuredIdentity);
+  }
+
+  try {
+    const { getCurrentFeishuBotInfo } = await import('./client.js');
+    const botInfo = await getCurrentFeishuBotInfo();
+    const resolvedIdentity = buildFeishuBotMentionIdentity(botInfo ?? undefined);
+    if (!hasFeishuBotMentionIdentity(resolvedIdentity)) {
+      warnMissingBotIdentity('Feishu bot info did not include a usable mention identity');
+      return false;
+    }
+
+    return isFeishuMessageMentioningBot(mentions, resolvedIdentity);
+  } catch (err) {
+    warnMissingBotIdentity(`Failed to resolve Feishu bot mention identity: ${getErrorMessage(err)}`);
+    return false;
+  }
+}
+
+export function isFeishuMessageMentioningBot(
+  mentions: unknown[],
+  identity: FeishuBotMentionIdentity,
+): boolean {
+  const expectedIds = collectExpectedMentionIds(identity);
+  const expectedNames = collectExpectedMentionNames(identity);
+
+  if (expectedIds.size === 0 && expectedNames.size === 0) {
+    return false;
+  }
+
+  for (const mention of mentions) {
+    if (!isRecord(mention)) {
+      continue;
+    }
+
+    for (const candidate of collectMentionIdCandidates(mention)) {
+      if (expectedIds.has(candidate)) {
+        return true;
+      }
+    }
+
+    for (const candidate of collectMentionNameCandidates(mention)) {
+      if (expectedNames.has(candidate)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function buildFeishuBotMentionIdentity(botInfo?: FeishuBotInfo): FeishuBotMentionIdentity {
+  return {
+    openId: envString('FEISHU_BOT_OPEN_ID') ?? botInfo?.openId,
+    userId: envString('FEISHU_BOT_USER_ID'),
+    unionId: envString('FEISHU_BOT_UNION_ID'),
+    appId: envString('FEISHU_APP_ID'),
+    appName: envString('FEISHU_BOT_NAME') ?? botInfo?.appName,
+    aliases: envList('FEISHU_BOT_MENTION_ALIASES'),
+  };
+}
+
+function hasFeishuBotMentionIdentity(identity: FeishuBotMentionIdentity): boolean {
+  return collectExpectedMentionIds(identity).size > 0 || collectExpectedMentionNames(identity).size > 0;
+}
+
+function collectExpectedMentionIds(identity: FeishuBotMentionIdentity): Set<string> {
+  const values = new Set<string>();
+  for (const value of [identity.openId, identity.userId, identity.unionId, identity.appId]) {
+    const normalized = normalizeExact(value);
+    if (normalized) {
+      values.add(normalized);
+    }
+  }
+  return values;
+}
+
+function collectExpectedMentionNames(identity: FeishuBotMentionIdentity): Set<string> {
+  const values = new Set<string>();
+  for (const value of [identity.appName, ...(identity.aliases ?? [])]) {
+    const normalized = normalizeMentionName(value);
+    if (normalized) {
+      values.add(normalized);
+    }
+  }
+  return values;
+}
+
+function collectMentionIdCandidates(mention: Record<string, unknown>): Set<string> {
+  const values = new Set<string>();
+  addExact(values, mention.open_id);
+  addExact(values, mention.user_id);
+  addExact(values, mention.union_id);
+  addExact(values, mention.app_id);
+
+  const id = mention.id;
+  if (typeof id === 'string') {
+    addExact(values, id);
+  } else if (isRecord(id)) {
+    addExact(values, id.open_id);
+    addExact(values, id.user_id);
+    addExact(values, id.union_id);
+    addExact(values, id.app_id);
+  }
+
+  return values;
+}
+
+function collectMentionNameCandidates(mention: Record<string, unknown>): Set<string> {
+  const values = new Set<string>();
+  addMentionName(values, mention.name);
+  addMentionName(values, mention.key);
+  return values;
+}
+
+function envString(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value ? value : undefined;
+}
+
+function envList(name: string): string[] {
+  const value = process.env[name];
+  if (!value) {
+    return [];
+  }
+
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+function addExact(values: Set<string>, value: unknown): void {
+  const normalized = normalizeExact(value);
+  if (normalized) {
+    values.add(normalized);
+  }
+}
+
+function addMentionName(values: Set<string>, value: unknown): void {
+  const normalized = normalizeMentionName(value);
+  if (normalized) {
+    values.add(normalized);
+  }
+}
+
+function normalizeExact(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeMentionName(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim().replace(/^@+/, '').trim().toLowerCase();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function warnMissingBotIdentity(message: string): void {
+  const now = Date.now();
+  if (now - lastBotIdentityWarningAt < 60_000) {
+    return;
+  }
+
+  lastBotIdentityWarningAt = now;
+  console.warn(`[feishu] ${message}; ignoring group message because the current bot was not verified in mentions`);
+}
+
+function getErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}


### PR DESCRIPTION
Ensure Feishu group messages only trigger when they mention the current bot.

- Add bot mention identity matching for open_id, user_id, union_id, app_id, bot name, and aliases
- Resolve current bot info from Feishu with explicit env fallbacks
- Ignore unverifiable group mentions with throttled warnings
- Add mention-filter unit coverage and document fallback env vars

Validation:
- pnpm --filter @pulse-coder/remote-server build
- pnpm --filter @pulse-coder/remote-server exec vitest run src/adapters/feishu/mention-filter.test.ts