### PR TITLE
fix: require bot mention in Feishu groups

### DIFF
--- a/apps/canvas-workspace/src/plugins/main/channel/README.md
+++ b/apps/canvas-workspace/src/plugins/main/channel/README.md
@@ -51,6 +51,9 @@ relaunch (the flag is read at plugin registration time).
      export CANVAS_FEISHU_DEFAULT_WORKSPACE=<workspaceId>
      # optional: override the API host
      export FEISHU_API_BASE_URL=https://open.feishu.cn
+     # optional fallback if /open-apis/bot/v3/info cannot be reached
+     export FEISHU_BOT_OPEN_ID=ou_xxx
+     export FEISHU_BOT_NAME=Pulse
      ```
 
    Env vars take precedence over UI-stored values.
@@ -60,8 +63,9 @@ relaunch (the flag is read at plugin registration time).
    panel offers a "Relaunch now" button after saving.
 
 In a **direct chat** the bot replies to every message. In a **group chat**
-it only responds when @-mentioned — a *structured* Feishu mention (the
-`mentions` array or an `<at …>` marker), not bare "@word" text a user typed,
+it only responds when the message structurally @-mentions this bot — the
+Feishu `mentions` array or `<at …>` marker must match the bot identity loaded
+from `/open-apis/bot/v3/info` (or the optional `FEISHU_BOT_*` fallback env),
 so mentioning another person never wakes the bot.
 
 > Availability: the bridge runs inside the desktop app, so it responds while

--- a/apps/canvas-workspace/src/plugins/main/channel/__tests__/parse-inbound.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/__tests__/parse-inbound.test.ts
@@ -39,6 +39,17 @@ function reply(out: ReturnType<typeof parseInbound>) {
   };
 }
 
+const BOT = {
+  appId: 'cli_bot',
+  openId: 'ou_bot',
+  userId: 'bot_user',
+  unionId: 'on_bot',
+  name: 'Pulse',
+};
+
+const BOT_MENTION = { key: '@_user_bot', id: { open_id: 'ou_bot' }, name: 'Pulse' };
+const OTHER_MENTION = { key: '@_user_other', id: { open_id: 'ou_other' }, name: 'Pulse' };
+
 describe('parseInbound', () => {
   it('direct chat keys on chat_id', () => {
     const out = parseInbound(event({ chatType: 'p2p', chatId: 'dmA' }));
@@ -50,8 +61,8 @@ describe('parseInbound', () => {
   });
 
   it('different groups produce different conversation ids', () => {
-    const a = parseInbound(event({ chatType: 'group', chatId: 'gA', mentions: [{}] }));
-    const b = parseInbound(event({ chatType: 'group', chatId: 'gB', mentions: [{}] }));
+    const a = parseInbound(event({ chatType: 'group', chatId: 'gA', mentions: [BOT_MENTION] }), BOT);
+    const b = parseInbound(event({ chatType: 'group', chatId: 'gB', mentions: [BOT_MENTION] }), BOT);
     expect(a!.conversationId).toBe('gA');
     expect(b!.conversationId).toBe('gB');
     expect(a!.conversationId).not.toBe(b!.conversationId);
@@ -62,9 +73,18 @@ describe('parseInbound', () => {
     expect(out).toBeNull();
   });
 
+  it('group message mentioning another user with the bot display name is ignored', () => {
+    const out = parseInbound(
+      event({ chatType: 'group', chatId: 'gA', mentions: [OTHER_MENTION], text: '@someone do it' }),
+      BOT,
+    );
+    expect(out).toBeNull();
+  });
+
   it('group @-mention strips the mention and marks isMention', () => {
     const out = parseInbound(
-      event({ chatType: 'group', chatId: 'gA', mentions: [{}], text: '@bot do it' }),
+      event({ chatType: 'group', chatId: 'gA', mentions: [BOT_MENTION], text: '@bot do it' }),
+      BOT,
     );
     expect(out).not.toBeNull();
     expect(out!.text).toBe('do it');
@@ -88,12 +108,27 @@ describe('parseInbound', () => {
         chatId: 'gT',
         threadId: 'th1',
         mentions: undefined,
-        text: '<at user_id="bot">Pulse</at> 晚上好',
+        text: '<at user_id="bot_user">Pulse</at> 晚上好',
       }),
+      BOT,
     );
     expect(out).not.toBeNull();
     expect(out!.conversationId).toBe('gT:th1');
     expect(out!.text).toBe('晚上好');
+  });
+
+  it('topic group text with another user at tag using the bot display name is ignored when mentions are omitted', () => {
+    const out = parseInbound(
+      event({
+        chatType: 'topic_group',
+        chatId: 'gT',
+        threadId: 'th1',
+        mentions: undefined,
+        text: '<at user_id="other_user">Pulse</at> 晚上好',
+      }),
+      BOT,
+    );
+    expect(out).toBeNull();
   });
 
   it('topic group post messages are accepted and flattened', () => {
@@ -103,7 +138,7 @@ describe('parseInbound', () => {
         chatId: 'gT',
         threadId: 'th1',
         messageType: 'post',
-        mentions: [{ name: 'Pulse' }],
+        mentions: [BOT_MENTION],
         content: {
           title: '晚上好',
           content: [
@@ -114,6 +149,7 @@ describe('parseInbound', () => {
           ],
         },
       }),
+      BOT,
     );
     expect(out).not.toBeNull();
     expect(out!.conversationId).toBe('gT:th1');
@@ -123,10 +159,12 @@ describe('parseInbound', () => {
 
   it('topic group: each thread is its own conversation, replies route in-thread', () => {
     const t1 = parseInbound(
-      event({ chatType: 'group', chatId: 'gT', threadId: 'th1', mentions: [{}], messageId: 'mA' }),
+      event({ chatType: 'group', chatId: 'gT', threadId: 'th1', mentions: [BOT_MENTION], messageId: 'mA' }),
+      BOT,
     );
     const t2 = parseInbound(
-      event({ chatType: 'group', chatId: 'gT', threadId: 'th2', mentions: [{}], messageId: 'mB' }),
+      event({ chatType: 'group', chatId: 'gT', threadId: 'th2', mentions: [BOT_MENTION], messageId: 'mB' }),
+      BOT,
     );
     expect(t1!.conversationId).toBe('gT:th1');
     expect(t2!.conversationId).toBe('gT:th2');
@@ -146,11 +184,13 @@ describe('parseInbound', () => {
   it('falls back to root_id so a topic root and its replies stay one conversation', () => {
     // Topic root: no thread_id yet, but it is the thread root (root_id = its id).
     const root = parseInbound(
-      event({ chatType: 'group', chatId: 'gT', rootId: 'rA', messageId: 'rA', mentions: [{}] }),
+      event({ chatType: 'group', chatId: 'gT', rootId: 'rA', messageId: 'rA', mentions: [BOT_MENTION] }),
+      BOT,
     );
     // A later reply in the same topic: carries thread_id == root_id.
     const followUp = parseInbound(
-      event({ chatType: 'group', chatId: 'gT', threadId: 'rA', messageId: 'mC', mentions: [{}] }),
+      event({ chatType: 'group', chatId: 'gT', threadId: 'rA', messageId: 'mC', mentions: [BOT_MENTION] }),
+      BOT,
     );
     expect(root!.conversationId).toBe('gT:rA');
     expect(followUp!.conversationId).toBe('gT:rA');
@@ -160,9 +200,10 @@ describe('parseInbound', () => {
 
   it('a topic-group conversation differs from the same group’s non-topic id', () => {
     const topic = parseInbound(
-      event({ chatType: 'group', chatId: 'gT', threadId: 'th1', mentions: [{}] }),
+      event({ chatType: 'group', chatId: 'gT', threadId: 'th1', mentions: [BOT_MENTION] }),
+      BOT,
     );
-    const plain = parseInbound(event({ chatType: 'group', chatId: 'gT', mentions: [{}] }));
+    const plain = parseInbound(event({ chatType: 'group', chatId: 'gT', mentions: [BOT_MENTION] }), BOT);
     expect(topic!.conversationId).toBe('gT:th1');
     expect(plain!.conversationId).toBe('gT');
   });

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/bot-mention.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/bot-mention.ts
@@ -1,0 +1,129 @@
+import { getFeishuBotInfo, type FeishuBotInfo } from './feishu-client';
+
+export interface FeishuBotIdentity {
+  appId?: string;
+  openId?: string;
+  userId?: string;
+  unionId?: string;
+  name?: string;
+}
+
+export async function loadBotIdentity(appId: string): Promise<FeishuBotIdentity> {
+  const envIdentity = envBotIdentity(appId);
+  try {
+    const info = await getFeishuBotInfo();
+    return mergeBotIdentity(envIdentity, info);
+  } catch (err) {
+    console.warn('[channel:feishu] failed to load bot identity; group @ filtering will use env fallback', err);
+    return envIdentity;
+  }
+}
+
+export function messageMentionsBot(
+  mentions: unknown[],
+  text: string,
+  identity: FeishuBotIdentity | undefined,
+): boolean {
+  return mentions.some((mention) => mentionMatchesBot(mention, identity))
+    || hasBotMentionMarker(text, identity);
+}
+
+function envBotIdentity(appId: string): FeishuBotIdentity {
+  return {
+    appId,
+    openId: process.env.FEISHU_BOT_OPEN_ID?.trim() || undefined,
+    userId: process.env.FEISHU_BOT_USER_ID?.trim() || undefined,
+    unionId: process.env.FEISHU_BOT_UNION_ID?.trim() || undefined,
+    name: process.env.FEISHU_BOT_NAME?.trim() || undefined,
+  };
+}
+
+function mergeBotIdentity(base: FeishuBotIdentity, info: FeishuBotInfo): FeishuBotIdentity {
+  return {
+    ...base,
+    openId: info.openId?.trim() || base.openId,
+    name: info.appName?.trim() || base.name,
+  };
+}
+
+function normalizedIdentityValues(identity: FeishuBotIdentity | undefined): Set<string> {
+  const values = [identity?.appId, identity?.openId, identity?.userId, identity?.unionId]
+    .map((value) => value?.trim().toLowerCase())
+    .filter((value): value is string => Boolean(value));
+  return new Set(values);
+}
+
+function normalizedBotName(identity: FeishuBotIdentity | undefined): string | null {
+  const name = identity?.name?.trim().toLowerCase();
+  return name || null;
+}
+
+function mentionName(mention: unknown): string | null {
+  if (!mention || typeof mention !== 'object') return null;
+  const value = (mention as Record<string, unknown>).name;
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function collectStringFields(value: unknown, out: string[]): void {
+  if (!value) return;
+  if (typeof value === 'string') {
+    if (value.trim()) out.push(value.trim());
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectStringFields(item, out);
+    return;
+  }
+  if (typeof value !== 'object') return;
+
+  for (const nested of Object.values(value as Record<string, unknown>)) {
+    collectStringFields(nested, out);
+  }
+}
+
+function collectMentionIdFields(mention: unknown): string[] {
+  if (!mention || typeof mention !== 'object') return [];
+  const record = mention as Record<string, unknown>;
+  const values: string[] = [];
+  collectStringFields(record.id, values);
+  collectStringFields(record.open_id, values);
+  collectStringFields(record.user_id, values);
+  collectStringFields(record.union_id, values);
+  return values;
+}
+
+function mentionMatchesBot(mention: unknown, identity: FeishuBotIdentity | undefined): boolean {
+  const ids = normalizedIdentityValues(identity);
+  const name = normalizedBotName(identity);
+  if (ids.size === 0 && !name) return false;
+
+  const idValues = collectMentionIdFields(mention);
+  if (ids.size > 0 && idValues.length > 0) {
+    return idValues.some((value) => ids.has(value.trim().toLowerCase()));
+  }
+
+  return Boolean(name && mentionName(mention)?.toLowerCase() === name);
+}
+
+function hasBotMentionMarker(text: string, identity: FeishuBotIdentity | undefined): boolean {
+  const ids = normalizedIdentityValues(identity);
+  const name = normalizedBotName(identity);
+  if (ids.size === 0 && !name) return false;
+
+  const markerPattern = /<at\b([^>]*)>(.*?)<\/at>/gis;
+  let match: RegExpExecArray | null;
+  while ((match = markerPattern.exec(text))) {
+    const [, attrs, label] = match;
+    const attrValues = Array.from(attrs.matchAll(/\b[\w:-]+\s*=\s*["']([^"']+)["']/g))
+      .map((attr) => attr[1].trim().toLowerCase())
+      .filter(Boolean);
+    if (ids.size > 0 && attrValues.length > 0) {
+      if (attrValues.some((value) => ids.has(value))) return true;
+      continue;
+    }
+
+    const cleanLabel = label.replace(/<[^>]*>/g, '').trim().toLowerCase();
+    if (name && cleanLabel === name) return true;
+  }
+  return false;
+}

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-channel.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-channel.ts
@@ -26,6 +26,7 @@ import {
   WORKSPACE_PICKER_SELECT_NAME,
 } from './card';
 import { downloadInboundImages, extractInboundImageKeys } from './inbound-image';
+import { loadBotIdentity, messageMentionsBot, type FeishuBotIdentity } from './bot-mention';
 
 const CHANNEL_ID = 'feishu';
 const PROGRESS_THROTTLE_MS = 800;
@@ -53,6 +54,7 @@ export class FeishuChannel implements Channel {
     this.client = createLarkClient();
     const appId = process.env.FEISHU_APP_ID!;
     const appSecret = process.env.FEISHU_APP_SECRET!;
+    const botIdentity = await loadBotIdentity(appId);
     this.wsClient = new lark.WSClient({ appId, appSecret, domain: lark.Domain.Feishu });
 
     const eventDispatcher = new lark.EventDispatcher({}).register({
@@ -64,7 +66,7 @@ export class FeishuChannel implements Channel {
             /* ignore serialization issues */
           }
         }
-        const msg = parseInbound(data);
+        const msg = parseInbound(data, botIdentity);
         if (!msg) return;
         // Download any attached images to local temp files so the agent can
         // read them with a vision tool. Best-effort: failures are logged.
@@ -535,14 +537,6 @@ function mentionString(mention: unknown, key: 'key' | 'name'): string | null {
   return typeof value === 'string' && value.trim() ? value.trim() : null;
 }
 
-function hasMentionMarker(text: string): boolean {
-  // Feishu text events normally include `mentions`, but topic groups can omit
-  // it while still leaving the structured `<at …>` marker in content. We match
-  // ONLY that marker — a bare "@word" is just literal text a user typed (e.g.
-  // "@someone-else") and must not make the bot respond in a group.
-  return /<at\b/i.test(text);
-}
-
 function stripMentionText(text: string, mentions: unknown[]): string {
   let out = text;
   for (const mention of mentions) {
@@ -629,7 +623,7 @@ interface FeishuCardActionEvent {
 }
 
 /** Normalize a Feishu im.message.receive_v1 payload, or null to ignore it. */
-export function parseInbound(data: unknown): InboundMessage | null {
+export function parseInbound(data: unknown, botIdentity?: FeishuBotIdentity): InboundMessage | null {
   const event = data as FeishuMessageEvent;
   const message = event?.message;
   if (!message || !['text', 'post', 'image'].includes(message.message_type ?? '')) return null;
@@ -652,9 +646,11 @@ export function parseInbound(data: unknown): InboundMessage | null {
   const isGroup = message.chat_type === 'group' || message.chat_type === 'topic_group';
   const mentions = asMentionList(message.mentions);
   let cleanText = text;
+  let isBotMention = false;
   if (isGroup) {
-    // In group chats (incl. topic groups), only respond when @-mentioned.
-    if (mentions.length === 0 && !hasMentionMarker(cleanText)) return null;
+    // In group chats (incl. topic groups), only respond when this bot is @-mentioned.
+    isBotMention = messageMentionsBot(mentions, cleanText, botIdentity);
+    if (!isBotMention) return null;
     cleanText = stripMentionText(cleanText, mentions);
   }
 
@@ -691,7 +687,7 @@ export function parseInbound(data: unknown): InboundMessage | null {
     userId,
     messageId,
     text: cleanText,
-    isMention: isGroup && mentions.length > 0,
+    isMention: isBotMention,
     isDirect: !isGroup,
     reply,
   };

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-client.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-client.ts
@@ -26,6 +26,11 @@ export function createLarkClient(): lark.Client {
   });
 }
 
+export interface FeishuBotInfo {
+  openId?: string;
+  appName?: string;
+}
+
 interface FeishuApiResponse<T> {
   code: number;
   msg: string;
@@ -79,6 +84,34 @@ async function getTenantAccessToken(): Promise<string> {
   cachedTenantAccessToken = payload.tenant_access_token;
   tenantAccessTokenExpiresAt = Date.now() + (payload.expire ?? 7200) * 1000;
   return cachedTenantAccessToken;
+}
+
+export async function getFeishuBotInfo(): Promise<FeishuBotInfo> {
+  const token = await getTenantAccessToken();
+  const response = await fetch(`${getFeishuBaseUrl()}/open-apis/bot/v3/info`, {
+    method: 'GET',
+    headers: { authorization: `Bearer ${token}` },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Failed to get Feishu bot info: ${response.status} ${response.statusText} - ${body}`,
+    );
+  }
+
+  const payload = (await response.json()) as FeishuApiResponse<{
+    open_id?: string;
+    app_name?: string;
+  }>;
+  if (payload.code !== 0) {
+    throw new Error(`Failed to get Feishu bot info: ${payload.msg || 'unknown error'}`);
+  }
+
+  return {
+    openId: payload.data?.open_id,
+    appName: payload.data?.app_name,
+  };
 }
 
 async function uploadImageToFeishu(imagePath: string, mimeType?: string): Promise<string> {


### PR DESCRIPTION
Fix canvas-workspace Feishu group handling so the bot only responds when the current bot is structurally mentioned.\n\n- Load bot identity from Feishu bot info with env fallback\n- Match group mentions against bot ids or mention markers before responding\n- Ignore mentions of other users, even when display names overlap\n- Add parseInbound coverage and document fallback env vars\n\nValidation:\n- pnpm --filter canvas-workspace test src/plugins/main/channel/__tests__/parse-inbound.test.ts (23 passed)\n- pnpm --filter canvas-workspace typecheck:main (blocked by existing pulse-coder-engine/built-in DTS resolution issue)