### PR TITLE
fix: prevent remote server MCP startup block

### DIFF
--- a/apps/remote-server/src/core/engine-singleton.ts
+++ b/apps/remote-server/src/core/engine-singleton.ts
@@ -1,4 +1,15 @@
 import { Engine } from 'pulse-coder-engine';
+import {
+  SubAgentPlugin,
+  builtInAgentTeamsPlugin,
+  builtInMCPPlugin,
+  builtInPlanModePlugin,
+  builtInPtcPlugin,
+  builtInRoleSoulPlugin,
+  builtInSkillsPlugin,
+  builtInTaskTrackingPlugin,
+  builtInToolSearchPlugin,
+} from 'pulse-coder-engine/built-in';
 import { memoryIntegration } from './memory-integration.js';
 import { worktreeIntegration } from './worktree/integration.js';
 import { vaultIntegration } from './vault/integration.js';
@@ -15,14 +26,41 @@ import { larkCliTool } from './tools/lark-cli.js';
 import { devtoolsPlugin } from './devtools.js';
 import { langfusePlugin } from './langfuse.js';
 
+function isRemoteMcpEnabled(): boolean {
+  const value = process.env.REMOTE_SERVER_MCP_ENABLED?.trim().toLowerCase();
+  return value === '1' || value === 'true' || value === 'yes' || value === 'on';
+}
+
+function buildRemoteServerBuiltInPlugins() {
+  const plugins = [
+    builtInSkillsPlugin,
+    builtInToolSearchPlugin,
+    builtInPlanModePlugin,
+    builtInTaskTrackingPlugin,
+    new SubAgentPlugin(),
+    builtInAgentTeamsPlugin,
+    builtInRoleSoulPlugin,
+    builtInPtcPlugin,
+  ];
+
+  if (isRemoteMcpEnabled()) {
+    return [builtInMCPPlugin, ...plugins];
+  }
+
+  console.warn('[remote-server] Built-in MCP plugin disabled; set REMOTE_SERVER_MCP_ENABLED=1 to enable it.');
+  return plugins;
+}
+
 /**
  * Single Engine instance shared across all platform adapters.
  * engine.run(context, options) is stateless per-call - each invocation
  * receives its own Context object, so concurrent runs from different users are safe.
  */
 export const engine = new Engine({
+  disableBuiltInPlugins: true,
   enginePlugins: {
     plugins: [
+      ...buildRemoteServerBuiltInPlugins(),
       memoryIntegration.enginePlugin,
       worktreeIntegration.enginePlugin,
       vaultIntegration.enginePlugin,


### PR DESCRIPTION
Disable the built-in MCP plugin by default for remote-server startup.

- Rebuild the remote-server built-in plugin list without MCP unless REMOTE_SERVER_MCP_ENABLED is enabled
- Keep skills, tool search, plan mode, task tracking, sub-agents, teams, role souls, and PTC plugins enabled
- Avoid blocking service startup on broken MCP, npx, or remote integrations

Validation:
- pnpm --filter @pulse-coder/remote-server build
- pm2 restart remote-server
- curl http://127.0.0.1:3000/health