### PR TITLE
fix: register deferred iframe webviews

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/useIframeNodeState.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/useIframeNodeState.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment happy-dom
+import { flushSync } from 'react-dom';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CanvasNode } from '../../types';
+import { useIframeNodeState } from './useIframeNodeState';
+
+class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+
+  readonly observe = vi.fn();
+  readonly disconnect = vi.fn();
+
+  constructor(
+    private readonly callback: IntersectionObserverCallback,
+    readonly options?: IntersectionObserverInit,
+  ) {
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  trigger(isIntersecting: boolean): void {
+    this.callback(
+      [{ isIntersecting } as IntersectionObserverEntry],
+      this as unknown as IntersectionObserver,
+    );
+  }
+}
+
+const iframeNode: CanvasNode = {
+  id: 'node-1',
+  type: 'iframe',
+  title: 'Example',
+  x: 0,
+  y: 0,
+  width: 640,
+  height: 420,
+  data: {
+    mode: 'url',
+    url: 'https://example.com/',
+  },
+};
+
+let root: Root | null = null;
+let host: HTMLDivElement | null = null;
+let registerWebview: ReturnType<typeof vi.fn>;
+let unregisterWebview: ReturnType<typeof vi.fn>;
+let setFrameRate: ReturnType<typeof vi.fn>;
+let createElementSpy: { mockRestore: () => void };
+let originalIntersectionObserver: typeof IntersectionObserver | undefined;
+
+beforeEach(() => {
+  MockIntersectionObserver.instances = [];
+  originalIntersectionObserver = globalThis.IntersectionObserver;
+  globalThis.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver;
+
+  registerWebview = vi.fn().mockResolvedValue({ ok: true });
+  unregisterWebview = vi.fn().mockResolvedValue({ ok: true });
+  setFrameRate = vi.fn().mockResolvedValue({ ok: true });
+  Object.defineProperty(window, 'canvasWorkspace', {
+    configurable: true,
+    value: {
+      iframe: {
+        registerWebview,
+        unregisterWebview,
+        setFrameRate,
+      },
+    },
+  });
+
+  const originalCreateElement = document.createElement.bind(document);
+  createElementSpy = vi.spyOn(document, 'createElement').mockImplementation(((tagName: string, options?: ElementCreationOptions) => {
+    if (tagName.toLowerCase() !== 'webview') {
+      return originalCreateElement(tagName, options);
+    }
+
+    const el = originalCreateElement('div') as unknown as HTMLElement & {
+      getWebContentsId: () => number;
+      reload: () => void;
+    };
+    el.getWebContentsId = () => 123;
+    el.reload = vi.fn();
+    return el;
+  }) as typeof document.createElement);
+});
+
+afterEach(() => {
+  if (root) {
+    flushSync(() => root?.unmount());
+  }
+  host?.remove();
+  root = null;
+  host = null;
+  createElementSpy.mockRestore();
+  if (originalIntersectionObserver) {
+    globalThis.IntersectionObserver = originalIntersectionObserver;
+  } else {
+    Reflect.deleteProperty(globalThis, 'IntersectionObserver');
+  }
+  Reflect.deleteProperty(window, 'canvasWorkspace');
+});
+
+describe('useIframeNodeState', () => {
+  it('registers the webview after deferred visible mount', async () => {
+    await renderHookHarness();
+
+    expect(registerWebview).not.toHaveBeenCalled();
+
+    flushSync(() => {
+      for (const observer of MockIntersectionObserver.instances) observer.trigger(true);
+    });
+    await flushEffects();
+
+    expect(registerWebview).toHaveBeenCalledWith('workspace-1', 'node-1', 123);
+  });
+});
+
+async function renderHookHarness(): Promise<void> {
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+
+  flushSync(() => {
+    root?.render(<IframeHookHarness />);
+  });
+  await flushEffects();
+}
+
+function IframeHookHarness() {
+  const state = useIframeNodeState({
+    node: iframeNode,
+    workspaceId: 'workspace-1',
+    onUpdate: vi.fn(),
+    readOnly: false,
+  });
+
+  return <div ref={state.webviewHostRef} />;
+}
+
+function flushEffects(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/useIframeNodeState.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/useIframeNodeState.ts
@@ -163,7 +163,7 @@ export const useIframeNodeState = ({
       el.removeEventListener('did-stop-loading', handleDidStopLoading);
       el.removeEventListener('did-fail-load', handleDidFailLoad);
     };
-  }, [data, editing, mode, node.id, node.title, onUpdate, readOnly, url, webviewKey]);
+  }, [data, editing, mode, node.id, node.title, onUpdate, readOnly, shouldMountWebview, url, webviewKey]);
 
   useEffect(() => {
     if (!editing) return undefined;
@@ -232,7 +232,7 @@ export const useIframeNodeState = ({
       el.removeEventListener('dom-ready', tryRegister);
       if (registered) void api.unregisterWebview(workspaceId, node.id);
     };
-  }, [workspaceId, node.id, editing, url, mode, webviewKey]);
+  }, [workspaceId, node.id, editing, url, mode, shouldMountWebview, webviewKey]);
 
   // Drop the webview's paint frame rate when the node is parked outside the
   // canvas viewport long enough. Disabled during editing (no live webview to


### PR DESCRIPTION
Fix DOM selection for URL iframe nodes after deferred webview mounting.\n\n- Rerun iframe page event wiring when deferred webview mount becomes visible\n- Rerun webview registry IPC registration after the live webview is created\n- Add a regression test covering deferred visible mount registration\n\nValidation:\n- pnpm --filter canvas-workspace exec vitest run src/renderer/src/components/IframeNodeBody/useIframeNodeState.test.tsx\n- pnpm --filter pulse-coder-orchestrator build && pnpm --filter pulse-coder-engine build && pnpm --filter canvas-workspace typecheck