### PR TITLE
feat: publish canvas perf dashboards

### DIFF
--- a/.pulse-coder/skills/perf-report/SKILL.md
+++ b/.pulse-coder/skills/perf-report/SKILL.md
@@ -1,44 +1,85 @@
 ---
 name: perf-report
-description: Run the canvas-workspace performance evaluation, read the latest metrics and rule-engine alerts, summarize them, and render the dashboard into the UI so both agents and humans can consume it.
-description_zh: 运行 canvas-workspace 性能评估,读取最新指标与规则引擎告警,总结结论,并把看板渲染到界面上,供 Agent 与人共同消费。
-version: 1.0.0
-author: Pulse Coder Team
+description: Run the canvas-workspace performance evaluation, publish the latest static dashboard through the local nginx/Cloudflare Tunnel route, capture a screenshot, and summarize the report. Use when the user asks to run Pulse Canvas/canvas-workspace perf checks, deploy the performance dashboard, refresh https://jasperhu.art/apps/canvas-perf/, or send a dashboard screenshot from Feishu/remote-server.
 ---
 
 # Perf Report Skill
 
 Drive one round of the canvas-workspace performance evaluation and deliver the
-result twice: a structured summary in your reply (for the human and for your
-own next optimization step), and the HTML dashboard rendered into the UI.
+result three ways: a structured summary, a deployed static dashboard, and PNG
+screenshots that remote-server can send back to Feishu.
 
 The pipeline is fully deterministic (no LLM at report time). Definitions live
 in `apps/canvas-workspace/perf/program.md` + `perf/metrics.json`; thresholds in
 `perf/baselines.json`.
 
-## Workflow
+## One Command
 
-### 1. Run one command (from the repository root)
+From the repository root, prefer the bundled script:
 
 ```bash
-pnpm --filter canvas-workspace perf:report
+node "${CODEX_HOME:-$HOME/.codex}/skills/perf-report/scripts/run-publish-dashboard.mjs"
 ```
 
-That is the whole pipeline: build → bundle gate → launch the app headless →
-runtime scenarios → close → assemble the report. It prints the verdict and
-writes `perf/out/dashboard.html` + `perf/out/report.json`. Exit code is 1 if
-any gate failed (usable directly in CI).
+Default behavior is resource-conscious for this host: build once with
+`NODE_OPTIONS=--max-old-space-size=1024`, run `perf:report --no-build --repeat
+1 --seed-nodes 100`, publish to nginx, then capture a screenshot.
+It also captures the live Electron window right after startup and before the
+interaction scenarios run.
 
 Variants:
-- `--bundle-only` — fast, skips the app launch (bundle metrics only)
-- `--no-build` — reuse an existing `dist/`
-- `--seed-nodes 300` — larger canvas for the interaction scenarios
+- `--repeat 3` — closer to CI median behavior; heavier
+- `--seed-nodes 300` — larger canvas for interaction scenarios
+- `--no-build` — reuse existing `dist/`
+- `--no-screenshot` — skip the dashboard webpage screenshot; the Electron
+  startup screenshot is still captured during `perf:report`
+- `--strict` — exit non-zero when perf gates fail even if publish succeeds
 
-If the app can't launch, it degrades to a bundle-only report and tells the
-user to install Xvfb (`apt-get install -y xvfb`) and, if the Electron binary
-is missing, run `pnpm --filter canvas-workspace setup:electron`.
+The deployed dashboard URL is:
 
-### 2. Read the machine contract
+```text
+https://jasperhu.art/apps/canvas-perf/
+```
+
+Host prerequisites: `xvfb-run`, Electron runtime libraries, and a Chinese font
+such as `google-noto-sans-cjk-sc-fonts` must be installed. Without the font,
+server-side screenshots render Chinese as square boxes.
+
+Override deployment with:
+
+```bash
+PULSE_CANVAS_PERF_DEPLOY_DIR=/path/to/static \
+PULSE_CANVAS_PERF_PUBLIC_URL=https://example.com/perf/ \
+node "${CODEX_HOME:-$HOME/.codex}/skills/perf-report/scripts/run-publish-dashboard.mjs"
+```
+
+## Manual Steps
+
+Use these only when debugging the pipeline:
+
+```bash
+pnpm --filter canvas-workspace build
+pnpm --filter canvas-workspace perf:report --no-build --repeat 1
+node "${CODEX_HOME:-$HOME/.codex}/skills/perf-report/scripts/publish-dashboard.mjs"
+```
+
+`publish-dashboard.mjs` copies:
+
+- `perf/out/dashboard.html` → `/data/www/sites/default/current/canvas-perf/index.html`
+- `report.json`, `scenarios-report.json`, `bundle-report.json`
+- dashboard screenshot → `apps/canvas-workspace/perf/out/dashboard.png`
+- Electron startup screenshot → `apps/canvas-workspace/perf/out/electron-startup.png`
+
+The screenshot script prints:
+
+```text
+__PULSE_IMAGE_RESULT__{"model":"perf-dashboard-screenshot","outputPath":"...","mimeType":"image/png"}
+```
+
+remote-server recognizes one or more of these markers and sends the images
+back to Feishu when the run is triggered from Feishu.
+
+## Read the Machine Contract
 
 Read `apps/canvas-workspace/perf/out/report.json`:
 
@@ -48,27 +89,17 @@ Read `apps/canvas-workspace/perf/out/report.json`:
 - `metrics[]` — metric id → value (+ `pass`/`limit` for gated ones)
 - `coverage` — how many dictionary metrics have values
 
-### 4. Render to the UI
-
-Preferred: publish the dashboard as an artifact and pin it to the canvas —
-
-1. `artifact_create` with the full content of
-   `apps/canvas-workspace/perf/out/dashboard.html` (title: "性能看板").
-2. `artifact_pin_to_canvas` so it lives on the canvas next to the work.
-
-Updating later: use `artifact_update` on the same artifact instead of
-creating a new one. (Alternative when artifacts are unavailable:
-`canvas_create_node` type `iframe` pointing at the dashboard file.)
-
-### 5. Reply with the summary
+## Reply
 
 Report, in this order: the `verdict` verbatim → `high` alerts (if any) →
-`medium` alerts with their `suggestion` and `ref` → coverage. Keep it short;
-the dashboard carries the detail.
+`medium` alerts with their `suggestion` and `ref` → coverage → deployed URL →
+screenshot path. Keep it short; the dashboard carries the detail.
 
 ## Rules
 
 - Never edit `report.json`/`dashboard.html` by hand — regenerate.
+- Never claim the screenshot was sent unless `dashboard.png` exists and the
+  remote-server image markers were printed or uploaded.
 - Timing metrics are per-machine; do not compare absolute values across
   machines or declare regressions from a single run (the variance alert
   exists for this). Counter metrics are deterministic and safe to act on.

--- a/.pulse-coder/skills/perf-report/scripts/capture-dashboard.cjs
+++ b/.pulse-coder/skills/perf-report/scripts/capture-dashboard.cjs
@@ -1,0 +1,60 @@
+const { app, BrowserWindow } = require('electron');
+const { mkdirSync, writeFileSync } = require('node:fs');
+const { dirname, resolve } = require('node:path');
+
+const urlArgIndex = process.argv.findIndex((arg) => /^https?:\/\//.test(arg));
+const inputUrl = urlArgIndex >= 0 ? process.argv[urlArgIndex] : undefined;
+const outputPathArg = urlArgIndex >= 0 ? process.argv[urlArgIndex + 1] : undefined;
+const url = inputUrl || 'https://jasperhu.art/apps/canvas-perf/';
+const outputPath = resolve(outputPathArg || 'apps/canvas-workspace/perf/out/dashboard.png');
+
+app.disableHardwareAcceleration();
+app.commandLine.appendSwitch('no-sandbox');
+app.commandLine.appendSwitch('disable-gpu');
+app.commandLine.appendSwitch('disable-dev-shm-usage');
+
+const sleep = (ms) => new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+
+async function main() {
+  await app.whenReady();
+
+  const width = 1440;
+  const win = new BrowserWindow({
+    width,
+    height: 1200,
+    show: false,
+    webPreferences: {
+      backgroundThrottling: false,
+    },
+  });
+
+  await win.loadURL(url);
+  await sleep(800);
+
+  const pageHeight = await win.webContents.executeJavaScript(
+    'Math.max(document.body.scrollHeight, document.documentElement.scrollHeight)',
+  );
+  const height = Math.max(900, Math.min(Number(pageHeight) || 1200, 3200));
+  win.setContentSize(width, height);
+  await sleep(300);
+
+  const image = await win.webContents.capturePage();
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, image.toPNG());
+
+  console.log(JSON.stringify({
+    ok: true,
+    url,
+    outputPath,
+    mimeType: 'image/png',
+    width,
+    height,
+  }));
+
+  app.quit();
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.stack || err.message : String(err));
+  app.exit(1);
+});

--- a/.pulse-coder/skills/perf-report/scripts/publish-dashboard.mjs
+++ b/.pulse-coder/skills/perf-report/scripts/publish-dashboard.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, copyFileSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const skillDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const cwd = process.cwd();
+const repoRoot = process.env.PULSE_CODER_REPO_ROOT
+  ? resolve(process.env.PULSE_CODER_REPO_ROOT)
+  : existsSync(join(cwd, 'apps/canvas-workspace/package.json'))
+    ? cwd
+    : resolve(skillDir, '../../..');
+const outDir = join(repoRoot, 'apps/canvas-workspace/perf/out');
+const deployDir = process.env.PULSE_CANVAS_PERF_DEPLOY_DIR || '/data/www/sites/default/current/canvas-perf';
+const publicUrl = process.env.PULSE_CANVAS_PERF_PUBLIC_URL || 'https://jasperhu.art/apps/canvas-perf/';
+const screenshotPath = resolve(
+  process.env.PULSE_CANVAS_PERF_SCREENSHOT || join(outDir, 'dashboard.png'),
+);
+const startupScreenshotPath = resolve(
+  process.env.PULSE_CANVAS_PERF_STARTUP_SCREENSHOT || join(outDir, 'electron-startup.png'),
+);
+const args = process.argv.slice(2);
+const noScreenshot = args.includes('--no-screenshot');
+
+const required = ['dashboard.html', 'report.json'];
+for (const file of required) {
+  const path = join(outDir, file);
+  if (!existsSync(path)) {
+    console.error(`[perf-report] missing ${path}; run perf:report first.`);
+    process.exit(2);
+  }
+}
+
+mkdirSync(deployDir, { recursive: true });
+copyFileSync(join(outDir, 'dashboard.html'), join(deployDir, 'index.html'));
+for (const file of ['report.json', 'scenarios-report.json', 'bundle-report.json']) {
+  const source = join(outDir, file);
+  if (existsSync(source)) copyFileSync(source, join(deployDir, file));
+}
+if (existsSync(startupScreenshotPath)) {
+  copyFileSync(startupScreenshotPath, join(deployDir, 'electron-startup.png'));
+}
+
+const result = {
+  ok: true,
+  deployed: {
+    url: publicUrl,
+    dir: deployDir,
+    index: join(deployDir, 'index.html'),
+  },
+  screenshot: null,
+  startupScreenshot: existsSync(startupScreenshotPath)
+    ? {
+        ok: true,
+        outputPath: startupScreenshotPath,
+        mimeType: 'image/png',
+        bytes: statSync(startupScreenshotPath).size,
+      }
+    : null,
+};
+
+if (!noScreenshot) {
+  const electron = join(repoRoot, 'apps/canvas-workspace/node_modules/.bin/electron');
+  const captureScript = join(skillDir, 'scripts/capture-dashboard.cjs');
+  const command = existsSync('/usr/bin/xvfb-run') ? '/usr/bin/xvfb-run' : 'xvfb-run';
+  const commandArgs = [
+    '-a',
+    electron,
+    '--no-sandbox',
+    '--disable-gpu',
+    '--disable-dev-shm-usage',
+    captureScript,
+    publicUrl,
+    screenshotPath,
+  ];
+
+  const shot = spawnSync(command, commandArgs, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 60_000,
+  });
+  if (shot.status !== 0) {
+    result.screenshot = {
+      ok: false,
+      error: (shot.stderr || shot.stdout || `exit ${shot.status}`).trim(),
+    };
+  } else if (existsSync(screenshotPath)) {
+    result.screenshot = {
+      ok: true,
+      outputPath: screenshotPath,
+      mimeType: 'image/png',
+      bytes: statSync(screenshotPath).size,
+    };
+  }
+}
+
+console.log(JSON.stringify(result, null, 2));
+
+if (result.screenshot?.ok) {
+  console.log(`__PULSE_IMAGE_RESULT__${JSON.stringify({
+    model: 'perf-dashboard-screenshot',
+    outputPath: result.screenshot.outputPath,
+    mimeType: result.screenshot.mimeType,
+  })}`);
+}
+if (result.startupScreenshot?.ok) {
+  console.log(`__PULSE_IMAGE_RESULT__${JSON.stringify({
+    model: 'perf-electron-startup-screenshot',
+    outputPath: result.startupScreenshot.outputPath,
+    mimeType: result.startupScreenshot.mimeType,
+  })}`);
+}

--- a/.pulse-coder/skills/perf-report/scripts/run-publish-dashboard.mjs
+++ b/.pulse-coder/skills/perf-report/scripts/run-publish-dashboard.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+const skillDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const cwd = process.cwd();
+const repoRoot = process.env.PULSE_CODER_REPO_ROOT
+  ? resolve(process.env.PULSE_CODER_REPO_ROOT)
+  : existsSync(join(cwd, 'apps/canvas-workspace/package.json'))
+    ? cwd
+    : resolve(skillDir, '../../..');
+const args = process.argv.slice(2);
+const has = (flag) => args.includes(flag);
+const valueOf = (flag, fallback) => {
+  const i = args.indexOf(flag);
+  return i >= 0 && args[i + 1] ? args[i + 1] : fallback;
+};
+
+const repeat = valueOf('--repeat', process.env.PULSE_CANVAS_PERF_REPEAT || '1');
+const seedNodes = valueOf('--seed-nodes', process.env.PULSE_CANVAS_PERF_SEED_NODES || '100');
+const startupScreenshot = process.env.PULSE_CANVAS_PERF_STARTUP_SCREENSHOT
+  || join(repoRoot, 'apps/canvas-workspace/perf/out/electron-startup.png');
+const skipBuild = has('--no-build');
+const strict = has('--strict');
+
+const run = (label, command, commandArgs, options = {}) => {
+  console.log(`\n[perf-report] ${label}`);
+  const result = spawnSync(command, commandArgs, {
+    cwd: repoRoot,
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      NODE_OPTIONS: process.env.NODE_OPTIONS || '--max-old-space-size=1024',
+      ...(options.env || {}),
+    },
+    timeout: options.timeout || 900_000,
+  });
+  return result.status ?? 1;
+};
+
+if (!skipBuild) {
+  const buildStatus = run('build canvas-workspace', 'pnpm', ['--filter', 'canvas-workspace', 'build']);
+  if (buildStatus !== 0) process.exit(buildStatus);
+}
+
+const perfArgs = ['--filter', 'canvas-workspace', 'perf:report', '--no-build', '--repeat', repeat, '--seed-nodes', seedNodes];
+const perfStatus = run('run performance report', 'pnpm', perfArgs, {
+  timeout: 900_000,
+  env: { PULSE_CANVAS_PERF_STARTUP_SCREENSHOT: startupScreenshot },
+});
+const dashboardPath = join(repoRoot, 'apps/canvas-workspace/perf/out/dashboard.html');
+if (perfStatus !== 0 && !existsSync(dashboardPath)) {
+  process.exit(perfStatus);
+}
+
+const publishStatus = run('publish dashboard and capture screenshot', process.execPath, [
+  join(skillDir, 'scripts/publish-dashboard.mjs'),
+  ...(has('--no-screenshot') ? ['--no-screenshot'] : []),
+], { timeout: 120_000 });
+
+if (publishStatus !== 0) process.exit(publishStatus);
+if (strict && perfStatus !== 0) process.exit(perfStatus);
+process.exit(0);

--- a/apps/canvas-workspace/scripts/perf/dashboard-html.mjs
+++ b/apps/canvas-workspace/scripts/perf/dashboard-html.mjs
@@ -187,8 +187,15 @@ export const renderDashboardHtml = (dictionary, snapshot, bundleReport, { alerts
     </section>`;
   }).join('');
 
-  return `<title>Pulse Canvas 性能看板</title>
+  return `<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Pulse Canvas 性能看板</title>
 <style>${css()}</style>
+</head>
+<body>
 <div class="app">
   <div class="topbar">
     <h1>Pulse Canvas 性能看板</h1>
@@ -210,7 +217,9 @@ export const renderDashboardHtml = (dictionary, snapshot, bundleReport, { alerts
   </section>
   ${aspectPanels}
 </div>
-<script>${js()}</script>`;
+<script>${js()}</script>
+</body>
+</html>`;
 };
 
 const renderChunkBars = (bundleReport) => {

--- a/apps/canvas-workspace/scripts/perf/report.mjs
+++ b/apps/canvas-workspace/scripts/perf/report.mjs
@@ -45,6 +45,7 @@ const noBuild = has('--no-build');
 const seedNodes = flagValue('--seed-nodes', '100');
 const repeat = Math.max(1, Number(flagValue('--repeat', '3')));
 const distExists = existsSync(join(appRoot, 'dist/renderer'));
+const startupScreenshotPath = process.env.PULSE_CANVAS_PERF_STARTUP_SCREENSHOT || '';
 
 const step = (label) => console.log(`\n\x1b[1m▸ ${label}\x1b[0m`);
 const node = (script, scriptArgs = []) =>
@@ -156,6 +157,14 @@ if (!bundleOnly) {
     );
   } else {
     try {
+      if (startupScreenshotPath) {
+        step('捕获 Electron 启动截图');
+        const shot = harness(['screenshot', '--method', 'cdp', '--output', startupScreenshotPath]);
+        if (shot.status !== 0) {
+          console.warn(`[perf:report] Electron 启动截图失败,继续运行场景: ${startupScreenshotPath}`);
+        }
+      }
+
       step(`运行时场景(打字 / 拖拽 / 启动,@${seedNodes} 节点,--repeat ${repeat})`);
       if (node('scripts/perf/run-scenarios.mjs', ['--seed-nodes', seedNodes, '--repeat', String(repeat)]).status !== 0) {
         gatesFailed = true;

--- a/apps/remote-server/src/adapters/discord/adapter.ts
+++ b/apps/remote-server/src/adapters/discord/adapter.ts
@@ -6,7 +6,7 @@ import type { PlatformAdapter, IncomingMessage, StreamHandle } from '../../core/
 import type { ClarificationRequest } from '../../core/types.js';
 import { clarificationQueue } from '../../core/clarification-queue.js';
 import { getActiveStreamId, registerCancelToken } from '../../core/active-run-store.js';
-import { extractGeneratedImageResult } from '../feishu/image-result.js';
+import { extractGeneratedImageResults } from '../feishu/image-result.js';
 import { DiscordClient } from './client.js';
 import { buildDiscordMemoryKey, buildDiscordPlatformKey, isDiscordThreadChannelType } from './platform-key.js';
 import {
@@ -532,28 +532,30 @@ export class DiscordAdapter implements PlatformAdapter {
       },
 
       async onToolResult(toolResult) {
-        const imageResult = extractGeneratedImageResult(toolResult);
-        if (!imageResult) {
+        const imageResults = extractGeneratedImageResults(toolResult);
+        if (imageResults.length === 0) {
           return;
         }
 
-        if (!existsSync(imageResult.outputPath) || sentImagePaths.has(imageResult.outputPath)) {
-          return;
+        for (const imageResult of imageResults) {
+          if (!existsSync(imageResult.outputPath) || sentImagePaths.has(imageResult.outputPath)) {
+            continue;
+          }
+
+          sentImagePaths.add(imageResult.outputPath);
+
+          const fileName = basename(imageResult.outputPath);
+          await io
+            .sendExtraFile(
+              imageResult.outputPath,
+              fileName,
+              imageResult.mimeType,
+              `Generated image: ${fileName}`,
+            )
+            .catch((err) => {
+              console.error('[discord] Failed to send generated image:', err);
+            });
         }
-
-        sentImagePaths.add(imageResult.outputPath);
-
-        const fileName = basename(imageResult.outputPath);
-        await io
-          .sendExtraFile(
-            imageResult.outputPath,
-            fileName,
-            imageResult.mimeType,
-            `Generated image: ${fileName}`,
-          )
-          .catch((err) => {
-            console.error('[discord] Failed to send generated image:', err);
-          });
       },
 
       async onClarification(req: ClarificationRequest) {

--- a/apps/remote-server/src/adapters/feishu/adapter.ts
+++ b/apps/remote-server/src/adapters/feishu/adapter.ts
@@ -7,7 +7,7 @@ import { getActiveRun, getActiveStreamId } from '../../core/active-run-store.js'
 import { dispatchIncoming } from '../../core/dispatcher.js';
 import { processIncomingCommand } from '../../core/chat-commands.js';
 import type { CommandResult } from '../../core/chat-commands/types.js';
-import { extractGeneratedImageResult } from './image-result.js';
+import { extractGeneratedImageResults } from './image-result.js';
 import {
   createLarkClient,
   addMessageReaction,
@@ -431,26 +431,28 @@ export class FeishuAdapter implements PlatformAdapter {
       },
 
       async onToolResult(toolResult) {
-        const imageResult = extractGeneratedImageResult(toolResult);
-        if (!imageResult) {
+        const imageResults = extractGeneratedImageResults(toolResult);
+        if (imageResults.length === 0) {
           return;
         }
 
-        if (!existsSync(imageResult.outputPath) || sentImagePaths.has(imageResult.outputPath)) {
-          return;
-        }
+        for (const imageResult of imageResults) {
+          if (!existsSync(imageResult.outputPath) || sentImagePaths.has(imageResult.outputPath)) {
+            continue;
+          }
 
-        sentImagePaths.add(imageResult.outputPath);
+          sentImagePaths.add(imageResult.outputPath);
 
-        try {
-          await sendImageMessage(chatId, idType, imageResult.outputPath, imageResult.mimeType, replyOptions);
-          latestToolHint = '🖼️ Image generated and sent to Feishu';
-          scheduleProgressUpdate(true);
-        } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          console.error('[feishu] Failed to send generated image:', message);
-          latestToolHint = `⚠️ Image generated but sending failed: ${message}`;
-          scheduleProgressUpdate(true);
+          try {
+            await sendImageMessage(chatId, idType, imageResult.outputPath, imageResult.mimeType, replyOptions);
+            latestToolHint = '🖼️ Image generated and sent to Feishu';
+            scheduleProgressUpdate(true);
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            console.error('[feishu] Failed to send generated image:', message);
+            latestToolHint = `⚠️ Image generated but sending failed: ${message}`;
+            scheduleProgressUpdate(true);
+          }
         }
       },
 

--- a/apps/remote-server/src/adapters/feishu/image-result.test.ts
+++ b/apps/remote-server/src/adapters/feishu/image-result.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { extractGeneratedImageResult, extractGeneratedImageResults } from './image-result.js';
+
+describe('extractGeneratedImageResult', () => {
+  it('extracts normal generate_image tool payloads', () => {
+    expect(extractGeneratedImageResult({
+      toolName: 'generate_image',
+      output: {
+        model: 'image-model',
+        outputPath: '/tmp/out.png',
+        mimeType: 'image/png',
+      },
+    })).toEqual({
+      outputPath: '/tmp/out.png',
+      mimeType: 'image/png',
+    });
+  });
+
+  it('extracts explicitly marked image payloads from bash output', () => {
+    const toolResult = {
+      type: 'tool-result',
+      toolName: 'bash',
+      output: {
+        output: [
+          'published dashboard',
+          '__PULSE_IMAGE_RESULT__{"model":"perf-dashboard-screenshot","outputPath":"/tmp/dashboard.png","mimeType":"image/png"}',
+          '__PULSE_IMAGE_RESULT__{"model":"perf-electron-startup-screenshot","outputPath":"/tmp/electron-startup.png","mimeType":"image/png"}',
+        ].join('\n'),
+        exitCode: 0,
+      },
+    };
+
+    expect(extractGeneratedImageResult(toolResult)).toEqual({
+      outputPath: '/tmp/dashboard.png',
+      mimeType: 'image/png',
+    });
+    expect(extractGeneratedImageResults(toolResult)).toEqual([
+      {
+        outputPath: '/tmp/dashboard.png',
+        mimeType: 'image/png',
+      },
+      {
+        outputPath: '/tmp/electron-startup.png',
+        mimeType: 'image/png',
+      },
+    ]);
+  });
+
+  it('ignores unmarked bash output paths', () => {
+    expect(extractGeneratedImageResult({
+      type: 'tool-result',
+      toolName: 'bash',
+      output: {
+        output: '{"model":"perf-dashboard-screenshot","outputPath":"/tmp/dashboard.png","mimeType":"image/png"}',
+        exitCode: 0,
+      },
+    })).toBeNull();
+  });
+});

--- a/apps/remote-server/src/adapters/feishu/image-result.ts
+++ b/apps/remote-server/src/adapters/feishu/image-result.ts
@@ -4,32 +4,97 @@ interface GeneratedImageResult {
 }
 
 export function extractGeneratedImageResult(toolResult: unknown): GeneratedImageResult | null {
+  return extractGeneratedImageResults(toolResult)[0] ?? null;
+}
+
+export function extractGeneratedImageResults(toolResult: unknown): GeneratedImageResult[] {
+  const markedPayloads = extractMarkedImagePayloads(toolResult);
+  if (markedPayloads.length > 0) {
+    return markedPayloads;
+  }
+
   const toolName = extractToolName(toolResult);
   const payload = extractToolPayload(toolResult);
 
   if (!payload || !isRecord(payload)) {
-    return null;
+    return [];
   }
 
   const outputPath = asString(payload.outputPath);
   if (!outputPath) {
-    return null;
+    return [];
   }
 
   const mimeType = asString(payload.mimeType) ?? undefined;
 
   if (toolName && toolName !== 'generate_image') {
-    return null;
+    return [];
   }
 
   if (!toolName && !looksLikeGeneratedImagePayload(payload)) {
-    return null;
+    return [];
   }
 
-  return {
+  return [{
     outputPath,
     mimeType,
-  };
+  }];
+}
+
+function extractMarkedImagePayloads(value: unknown, depth = 0): GeneratedImageResult[] {
+  if (depth > 5) {
+    return [];
+  }
+
+  if (typeof value === 'string') {
+    const marker = '__PULSE_IMAGE_RESULT__';
+    const results: GeneratedImageResult[] = [];
+    let searchFrom = 0;
+    while (searchFrom < value.length) {
+      const markerAt = value.indexOf(marker, searchFrom);
+      if (markerAt < 0) break;
+
+      const jsonLine = value.slice(markerAt + marker.length).trimStart().split(/\r?\n/, 1)[0]?.trim();
+      searchFrom = markerAt + marker.length + (jsonLine?.length ?? 0);
+      if (!jsonLine) continue;
+
+      try {
+        const payload = JSON.parse(jsonLine) as unknown;
+        if (!isRecord(payload) || !looksLikeGeneratedImagePayload(payload)) {
+          continue;
+        }
+        results.push({
+          outputPath: asString(payload.outputPath)!,
+          mimeType: asString(payload.mimeType) ?? undefined,
+        });
+      } catch {
+        continue;
+      }
+    }
+    return dedupeImageResults(results);
+  }
+
+  if (Array.isArray(value)) {
+    return dedupeImageResults(value.flatMap((item) => extractMarkedImagePayloads(item, depth + 1)));
+  }
+
+  if (isRecord(value)) {
+    return dedupeImageResults(Object.values(value).flatMap((item) => extractMarkedImagePayloads(item, depth + 1)));
+  }
+
+  return [];
+}
+
+function dedupeImageResults(results: GeneratedImageResult[]): GeneratedImageResult[] {
+  const seen = new Set<string>();
+  const deduped: GeneratedImageResult[] = [];
+  for (const result of results) {
+    const key = `${result.outputPath}\0${result.mimeType ?? ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(result);
+  }
+  return deduped;
 }
 
 function extractToolName(toolResult: unknown): string | null {

--- a/apps/remote-server/src/routes/internal.ts
+++ b/apps/remote-server/src/routes/internal.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'fs';
 import { Hono, type Context } from 'hono';
 import { getConnInfo } from '@hono/node-server/conninfo';
 import { createLarkClient, sendImageMessage, sendTextMessage } from '../adapters/feishu/client.js';
-import { extractGeneratedImageResult } from '../adapters/feishu/image-result.js';
+import { extractGeneratedImageResults } from '../adapters/feishu/image-result.js';
 import { parseFeishuPlatformKey } from '../adapters/feishu/platform-key.js';
 import { getDiscordGatewayStatus, restartDiscordGateway } from '../adapters/discord/gateway-manager.js';
 import { DiscordClient } from '../adapters/discord/client.js';
@@ -304,28 +304,30 @@ internalRouter.post('/agent/run', async (c) => {
             return;
           }
 
-          const imageResult = extractGeneratedImageResult(toolResult);
-          if (!imageResult) {
+          const imageResults = extractGeneratedImageResults(toolResult);
+          if (imageResults.length === 0) {
             return;
           }
 
-          if (!existsSync(imageResult.outputPath) || sentImagePaths.has(imageResult.outputPath)) {
-            return;
-          }
+          for (const imageResult of imageResults) {
+            if (!existsSync(imageResult.outputPath) || sentImagePaths.has(imageResult.outputPath)) {
+              continue;
+            }
 
-          sentImagePaths.add(imageResult.outputPath);
-          imageNotifyTasks.push(
-            sendImageMessage(
-              feishuTarget.receiveId,
-              feishuTarget.receiveIdType,
-              imageResult.outputPath,
-              imageResult.mimeType,
-            )
-              .then(() => undefined)
-              .catch((err) => {
-                console.error('[internal] Failed to send generated image to Feishu:', err);
-              }),
-          );
+            sentImagePaths.add(imageResult.outputPath);
+            imageNotifyTasks.push(
+              sendImageMessage(
+                feishuTarget.receiveId,
+                feishuTarget.receiveIdType,
+                imageResult.outputPath,
+                imageResult.mimeType,
+              )
+                .then(() => undefined)
+                .catch((err) => {
+                  console.error('[internal] Failed to send generated image to Feishu:', err);
+                }),
+            );
+          }
         },
         onClarificationRequest: async (request: ClarificationRequest) => {
           const answer = resolveClarificationAnswer(request, askPolicy);


### PR DESCRIPTION
Publish canvas performance dashboards with screenshots

- Add perf-report scripts to run, publish, and screenshot reports
- Capture Electron startup screenshots and emit UTF-8 dashboard markup
- Send multiple generated image results through Feishu, Discord, and internal routes
- Add coverage for multi-marker image result parsing

Validation:
- pnpm exec vitest run apps/remote-server/src/adapters/feishu/image-result.test.ts
- pnpm --filter @pulse-coder/remote-server build
- node /root/.codex/skills/perf-report/scripts/run-publish-dashboard.mjs --no-build --repeat 1