### PR TITLE
style(canvas-workspace): normalize component conventions per frontend.md

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
@@ -22,7 +22,7 @@ import type {
   FrameNodeData,
 } from '../../types';
 
-interface AgentTeamFrameProps {
+interface Props {
   node: CanvasNode;
   getAllNodes?: () => CanvasNode[];
   onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
@@ -302,7 +302,7 @@ export const AgentTeamFrame = ({
   workspaceId,
   workspaceName,
   readOnly = false,
-}: AgentTeamFrameProps) => {
+}: Props) => {
   const data = node.data as FrameNodeData;
   const teamId = data.agentTeamId;
   const workspaceActive = useWorkspaceActive();

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEmptyHint/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEmptyHint/index.tsx
@@ -6,7 +6,7 @@ import { useI18n } from '../../i18n';
 import { normalizeReferenceUrl } from '../ReferenceDrawer/utils';
 import './index.css';
 
-interface CanvasEmptyHintProps {
+interface Props {
   onCreateNode: (type: Extract<CanvasNode['type'], 'agent' | 'terminal' | 'file' | 'iframe'>) => void;
   onCreateUrl?: (url: string) => void;
   onCreateDemo?: () => void;
@@ -24,7 +24,7 @@ export const CanvasEmptyHint = ({
   onOpenChat,
   onOpenShortcuts,
   onSetRootFolder,
-}: CanvasEmptyHintProps) => {
+}: Props) => {
   const { t } = useI18n();
   const [urlComposerOpen, setUrlComposerOpen] = useState(false);
   const [urlDraft, setUrlDraft] = useState('');

--- a/apps/canvas-workspace/src/renderer/src/components/ChatFloatingButton/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatFloatingButton/index.tsx
@@ -1,7 +1,7 @@
 import './index.css';
 import { AppLogoIcon } from '../icons';
 
-interface ChatFloatingButtonProps {
+interface Props {
   active?: boolean;
   title: string;
   ariaLabel?: string;
@@ -15,7 +15,7 @@ export const ChatFloatingButton = ({
   ariaLabel,
   className,
   onClick,
-}: ChatFloatingButtonProps) => (
+}: Props) => (
   <button
     type="button"
     className={[

--- a/apps/canvas-workspace/src/renderer/src/components/DynamicAppNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/DynamicAppNodeBody/index.tsx
@@ -21,7 +21,7 @@ import "./index.css";
 import { DynamicAppInspector } from "./Inspector";
 import type { CanvasNode, DynamicAppNodeData } from "../../types";
 
-interface DynamicAppNodeBodyProps {
+interface Props {
   node: CanvasNode;
   workspaceId?: string;
   onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
@@ -62,7 +62,7 @@ export function DynamicAppNodeBody({
   workspaceId,
   readOnly: _readOnly,
   isResizing: _isResizing,
-}: DynamicAppNodeBodyProps) {
+}: Props) {
   // The dispatcher only routes `type === 'dynamic-app'` here, so
   // node.data narrows to DynamicAppNodeData. Be defensive about the
   // shape in case canvas.json was hand-edited.

--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;

--- a/apps/canvas-workspace/src/renderer/src/components/PluginNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/PluginNodeBody/index.tsx
@@ -7,7 +7,7 @@ import {
 } from '../../../../plugins/renderer';
 import './index.css';
 
-interface PluginNodeBodyProps {
+interface Props {
   node: CanvasNode;
   workspaceId?: string;
   workspaceName?: string;
@@ -44,7 +44,7 @@ export const PluginNodeBody = ({
   isSelected,
   onUpdate,
   readOnly,
-}: PluginNodeBodyProps) => {
+}: Props) => {
   useSyncExternalStore(
     subscribeRendererPluginRegistry,
     getRendererPluginRegistryVersion,

--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.tsx
@@ -10,7 +10,7 @@ import { useReferenceDrawerState } from './useReferenceDrawerState';
 import { getReferenceId } from './utils';
 import { useI18n } from '../../i18n';
 
-interface ReferenceDrawerProps {
+interface Props {
   open: boolean;
   activeWorkspaceId: string;
   workspaces: WorkspaceEntry[];
@@ -50,7 +50,7 @@ export const ReferenceDrawer = ({
   onFocusNode,
   onAddReferenceToCanvas,
   onWorkspaceNodesRequest,
-}: ReferenceDrawerProps) => {
+}: Props) => {
   const { t } = useI18n();
   const state = useReferenceDrawerState({
     open,

--- a/apps/canvas-workspace/src/renderer/src/components/Select/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Select/index.tsx
@@ -10,7 +10,7 @@ export interface SelectOption {
   disabled?: boolean;
 }
 
-interface SelectProps {
+interface Props {
   value: string;
   options: ReadonlyArray<SelectOption>;
   onChange: (value: string) => void;
@@ -52,7 +52,7 @@ export const Select = ({
   className,
   disabled,
   placeholder,
-}: SelectProps) => {
+}: Props) => {
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
   const selected = options.find((opt) => opt.value === value);

--- a/apps/canvas-workspace/src/renderer/src/components/SelectionToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/SelectionToolbar/index.tsx
@@ -2,7 +2,7 @@ import './index.css';
 import { useI18n } from '../../i18n';
 import type { KeyboardEvent } from 'react';
 
-interface SelectionToolbarProps {
+interface Props {
   selectedCount: number;
   canFocus: boolean;
   focusModeActive: boolean;
@@ -127,7 +127,7 @@ export const SelectionToolbar = ({
   onPinReference,
   onAddToChat,
   onDelete,
-}: SelectionToolbarProps) => {
+}: Props) => {
   const { t } = useI18n();
   if (selectedCount <= 0) return null;
 

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/index.tsx
@@ -103,13 +103,13 @@ const SECTIONS: SectionDef[] = [
   },
 ];
 
-interface SettingsProps {
+interface Props {
   open: boolean;
   initialSection: SettingsSection;
   onClose: () => void;
 }
 
-export const Settings = ({ open, initialSection, onClose }: SettingsProps) => {
+export const Settings = ({ open, initialSection, onClose }: Props) => {
   const { t } = useI18n();
   const [activeSection, setActiveSection] = useState<SettingsSection>(initialSection);
   const canvasModels = useCanvasModels();

--- a/apps/canvas-workspace/src/renderer/src/components/SettingsDrawer/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/SettingsDrawer/index.tsx
@@ -12,7 +12,7 @@ import { useEffect, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import './index.css';
 
-interface SettingsDrawerProps {
+interface Props {
   open: boolean;
   onClose: () => void;
   kicker: string;
@@ -33,7 +33,7 @@ export const SettingsDrawer = ({
   width = 640,
   closeAriaLabel = 'Close',
   children,
-}: SettingsDrawerProps) => {
+}: Props) => {
   useEffect(() => {
     if (!open) return;
     const handler = (e: KeyboardEvent) => {

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
@@ -26,7 +26,7 @@ export { useWorkbenchState } from './useWorkbenchState';
 export type { WorkbenchController } from './useWorkbenchState';
 
 const EMPTY_REFERENCES: ReferenceEntry[] = [];
-interface WorkbenchProps {
+interface Props {
   activeWorkspaceId: string;
   workspaces: WorkspaceEntry[];
   controller: WorkbenchController;
@@ -38,7 +38,7 @@ interface WorkbenchProps {
   onSetActiveRootFolder: () => void;
 }
 
-export const Workbench: React.FC<WorkbenchProps> = ({
+export const Workbench: React.FC<Props> = ({
   activeWorkspaceId,
   workspaces,
   controller,

--- a/apps/canvas-workspace/src/renderer/src/components/WorkspaceTerminalDock/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/WorkspaceTerminalDock/index.tsx
@@ -22,7 +22,7 @@ import {
 } from '../../utils/codingAgentCommand';
 import './index.css';
 
-interface WorkspaceTerminalDockProps {
+interface Props {
   workspaceId: string;
   terminalId?: string;
   terminalTitle?: string;
@@ -76,7 +76,7 @@ export const WorkspaceTerminalDock = ({
   open,
   onClose,
   placement = 'bottom',
-}: WorkspaceTerminalDockProps) => {
+}: Props) => {
   const { t } = useI18n();
   const [height, setHeight] = useState(() => clampHeight(readStoredHeight() ?? DEFAULT_HEIGHT));
   const heightRef = useRef(height);


### PR DESCRIPTION
## Summary

This PR's new commit ([c1f8c9b](../../commit/c1f8c9b)) fixes two UI-style-guide inconsistencies found while scanning `apps/canvas-workspace` against its documented conventions (`docs/conventions/frontend.md`, `docs/conventions/README.md`):

1. **`MigrationSpinner/index.tsx`** — dropped a dead `export default MigrationSpinner;`. The component is a named export (`export const MigrationSpinner = ...`) and is only ever imported by name (`import { MigrationSpinner } from './components/MigrationSpinner'` in `App.tsx`). This was the *only* default export among the app's 147 component files, and it directly contradicts the documented rule: "Export named arrow-function components ... Avoid default exports for components."

2. **Local `Props` interface naming** — renamed the props interface from `<ComponentName>Props` to `Props` in 12 single-component `index.tsx` files, matching `frontend.md`'s rule ("Name the props interface **`Props`** (local)") and the pattern already used by the majority of the app's `index.tsx` files:
   - `AgentTeamFrame`, `CanvasEmptyHint`, `ChatFloatingButton`, `DynamicAppNodeBody`, `PluginNodeBody`, `ReferenceDrawer`, `Select`, `SelectionToolbar`, `Settings`, `SettingsDrawer`, `Workbench`, `WorkspaceTerminalDock`.

   Folders whose `index.tsx` exports **more than one** component (`RightDock`: `RightDockProvider` + `RightDock`; `LinkDrawer`: exports `LinkTabView`, not `LinkDrawer`) were intentionally left with disambiguated names — this matches how the app already handles multi-component files (e.g. `Sidebar`'s sub-component files use disambiguated `XxxProps` names for the same reason).

Both changes are pure renames/dead-code removal — no behavior change.

## Note on branch history

This branch (`claude/blissful-carson-nmztld`) is a long-lived session branch that already carried prior, unrelated `canvas-workspace` performance-work commits from earlier sessions that are not yet merged to `master`. Those commits are unchanged by this PR; the diff of interest for this task is isolated to commit `c1f8c9b`.

## Verification

- `pnpm --filter canvas-workspace typecheck` (renderer `tsc -p tsconfig.json`) — clean, no new errors (pre-existing `tsconfig.node.json` `baseUrl` deprecation warning is unrelated and present on `master` too).
- `pnpm --filter canvas-workspace test` — ran the two conventions-enforcing suites directly: `import-boundaries.test.ts` and `file-size-governance.test.ts` — both pass.
- Verified no other file in the repo references the old `<ComponentName>Props` interface names before renaming (all were file-local).

## Test plan

- [x] Renderer typecheck passes
- [x] `import-boundaries.test.ts` passes
- [x] `file-size-governance.test.ts` passes
- [ ] Manual smoke test in the Electron app (not run — Electron binary download is blocked by the network policy in this environment)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XwoCU2JSUy3hkbWQrjfHPW)_