### PR TITLE
fix: encode DOM mention labels

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/chat/utils/mentionMarkers.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/utils/mentionMarkers.ts
@@ -1,0 +1,21 @@
+export const MENTION_RE = /@\[((?:[^\]]|\](?=\]))+)\]/g;
+
+export function encodeMentionPart(value: string): string {
+  return encodeURIComponent(value);
+}
+
+export function decodeMentionPart(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+export function pipedMentionLabel(rawLabel: string, prefix: string, fallback: string): string {
+  const body = rawLabel.slice(prefix.length);
+  const pipeIndex = body.indexOf('|');
+  if (pipeIndex < 0) return fallback;
+  const label = body.slice(pipeIndex + 1);
+  return label ? decodeMentionPart(label) : fallback;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/utils/mentions.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/utils/mentions.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest';
+import { createMentionChipElement, renderMdWithMentions } from './mentions';
+import { serializeEditable } from './serializeEditable';
+
+const domLabel = 'header: Fancy Builder [...truncated]';
+
+describe('chat mention rendering', () => {
+  it('serializes DOM selection labels with bracket-safe encoding', () => {
+    const chip = createMentionChipElement({
+      type: 'dom',
+      label: domLabel,
+      nodeType: 'iframe',
+      domSelection: {
+        id: 'dom-1',
+        label: domLabel,
+        nodeId: 'node-1',
+        selector: 'header',
+      },
+    });
+    const editable = document.createElement('div');
+    editable.appendChild(chip);
+
+    expect(serializeEditable(editable)).toBe(`@[dom:dom-1|${encodeURIComponent(domLabel)}]`);
+  });
+
+  it('renders encoded DOM selection labels without leaking a closing bracket', () => {
+    const html = renderMdWithMentions(`@[dom:dom-1|${encodeURIComponent(domLabel)}] 这描述了啥`);
+
+    expect(html).toContain(domLabel);
+    expect(html).not.toContain('</span>]');
+  });
+
+  it('keeps legacy DOM labels ending in a bracketed suffix inside the chip', () => {
+    const html = renderMdWithMentions(`@[dom:dom-1|${domLabel}] 这描述了啥`);
+
+    expect(html).toContain(domLabel);
+    expect(html).not.toContain('</span>]');
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/components/chat/utils/mentions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/utils/mentions.ts
@@ -3,9 +3,8 @@ import type { AgentContextCanvasRef, AgentContextDomSelectionRef, AgentContextNo
 import { CANVAS_MENTION_PREFIX, DOM_MENTION_PREFIX, FOLDER_MENTION_PREFIX, SESSION_MENTION_PREFIX, SKILL_MENTION_PREFIX, TAG_MENTION_PREFIX } from '../constants';
 import type { MentionItem, WorkspaceOption } from '../types';
 import { renderMarkdown, type RenderMarkdownOptions } from './markdown';
+import { MENTION_RE, encodeMentionPart, pipedMentionLabel } from './mentionMarkers';
 import { readDomSelectionDataset, writeDomSelectionDataset } from './domMentionData';
-
-const MENTION_RE = /@\[([^\]]+)\]/g;
 
 function escapeHtml(value: string): string {
   return value
@@ -187,7 +186,7 @@ export function createMentionChipElement(item: MentionItem, nodes?: CanvasNode[]
         : isTag
           ? `${TAG_MENTION_PREFIX}${item.label}`
           : isDom
-            ? `${DOM_MENTION_PREFIX}${item.domSelection?.id ?? item.label}|${item.label}`
+            ? `${DOM_MENTION_PREFIX}${item.domSelection?.id ?? item.label}|${encodeMentionPart(item.label)}`
             : item.label;
   chip.dataset.nodeType = nodeType;
 
@@ -365,7 +364,7 @@ export function renderUserContent(content: string, nodes?: CanvasNode[]): ReactN
     }
 
     if (rawLabel.startsWith(DOM_MENTION_PREFIX)) {
-      const domLabel = rawLabel.slice(DOM_MENTION_PREFIX.length).split('|').slice(1).join('|') || 'DOM selection';
+      const domLabel = pipedMentionLabel(rawLabel, DOM_MENTION_PREFIX, 'DOM selection');
       parts.push(
         createElement(
           'span',
@@ -443,7 +442,7 @@ export function renderMdWithMentions(
     }
 
     if (rawLabel.startsWith(DOM_MENTION_PREFIX)) {
-      const domLabel = rawLabel.slice(DOM_MENTION_PREFIX.length).split('|').slice(1).join('|') || 'DOM selection';
+      const domLabel = pipedMentionLabel(rawLabel, DOM_MENTION_PREFIX, 'DOM selection');
       return `<span class="chat-mention-chip chat-mention-chip--dom" data-node-type="dom"><span class="chat-mention-chip-icon"><svg width="12" height="12" viewBox="0 0 14 14" fill="none">${mentionIconSvg('dom')}</svg></span><span class="chat-mention-chip-label">${escapeHtml(domLabel)}</span></span>`;
     }
 


### PR DESCRIPTION
Fix DOM selection mention rendering so bracketed labels do not leak a trailing bracket in chat messages.

- Encode DOM selection labels when serializing composer mention chips
- Decode DOM labels when rendering user and markdown chat content
- Support legacy DOM mention markers that end with bracketed suffixes like [...truncated]
- Add focused renderer tests for DOM mention serialization and rendering

Validation:
- pnpm --filter canvas-workspace exec vitest run src/renderer/src/components/chat/utils/mentions.test.ts
- pnpm --filter canvas-workspace typecheck:renderer

Note: full canvas-workspace typecheck is currently blocked by missing main-process dependency type resolution for pulse-coder-engine/built-in in this isolated worktree.