### PR TITLE
feat: show agent icons on terminal tabs

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/TerminalDockTab.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/TerminalDockTab.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
 import { useI18n } from '../../i18n';
+import { AgentIcon } from '../AgentNodeBody/AgentIcon';
 import { NodeTypeIcon } from '../icons';
 import type { DockTerminalTab } from './dock-store';
 
@@ -23,6 +24,9 @@ export const TerminalDockTab = ({
   const { t } = useI18n();
   const defaultTitle = t('rightDock.terminalNumber', { number: tab.ordinal });
   const title = tab.title ?? defaultTitle;
+  const agentIconModifier = tab.agentType === 'claude-code' || tab.agentType === 'codex'
+    ? ` right-dock__tab-icon--agent-${tab.agentType}`
+    : '';
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(title);
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -90,8 +94,13 @@ export const TerminalDockTab = ({
           }
         }}
       >
-        <span className="right-dock__tab-icon right-dock__tab-icon--terminal">
-          <NodeTypeIcon type="terminal" size={14} />
+        <span
+          className={`right-dock__tab-icon right-dock__tab-icon--terminal${
+            tab.agentType ? ` right-dock__tab-icon--agent${agentIconModifier}` : ''
+          }`}
+          aria-hidden="true"
+        >
+          {tab.agentType ? <AgentIcon id={tab.agentType} size={14} /> : <NodeTypeIcon type="terminal" size={14} />}
         </span>
         <span className={`right-dock__tab-title${editing ? ' right-dock__tab-title--editing' : ''}`}>
           {title}

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/__tests__/dock-store.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/__tests__/dock-store.test.ts
@@ -251,6 +251,25 @@ describe('DockStore', () => {
     expect(dock.getSnapshot().terminalTabs.map((tab) => tab.title)).toEqual(['Claude', 'Codex']);
   });
 
+  it('stores terminal agent type per workspace tab', () => {
+    const dock = new DockStore();
+    dock.setActiveWorkspace('ws-a');
+    dock.openTerminal();
+    dock.setTerminalAgentType(TERMINAL_TAB_ID, 'claude-code', 'ws-a');
+    dock.newTerminal();
+    dock.setTerminalAgentType(terminalTabId(2), 'codex', 'ws-a');
+
+    expect(dock.getSnapshot().terminalTabs.map((tab) => tab.agentType)).toEqual(['claude-code', 'codex']);
+
+    dock.setActiveWorkspace('ws-b');
+    dock.openTerminal();
+    dock.setTerminalAgentType(TERMINAL_TAB_ID, 'codex', 'ws-b');
+    expect(dock.getSnapshot().terminalTabs[0]).toMatchObject({ agentType: 'codex' });
+
+    dock.setActiveWorkspace('ws-a');
+    expect(dock.getSnapshot().terminalTabs.map((tab) => tab.agentType)).toEqual(['claude-code', 'codex']);
+  });
+
   it('renames terminal tabs and ignores blanks or non-terminal ids', () => {
     const dock = new DockStore();
     dock.openTerminal();

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/__tests__/dock-store.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/__tests__/dock-store.test.ts
@@ -268,6 +268,8 @@ describe('DockStore', () => {
 
     dock.setActiveWorkspace('ws-a');
     expect(dock.getSnapshot().terminalTabs.map((tab) => tab.agentType)).toEqual(['claude-code', 'codex']);
+    dock.setTerminalAgentType(terminalTabId(2), undefined, 'ws-a');
+    expect(dock.getSnapshot().terminalTabs.map((tab) => tab.agentType)).toEqual(['claude-code', undefined]);
   });
 
   it('renames terminal tabs and ignores blanks or non-terminal ids', () => {

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/dock-store.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/dock-store.ts
@@ -26,6 +26,7 @@ export interface DockTerminalTab {
   id: string;
   title?: string;
   ordinal: number;
+  agentType?: string;
 }
 
 export interface DockTerminalWorkspaceState {
@@ -333,6 +334,19 @@ export class DockStore {
       ...workspace,
       tabs: workspace.tabs.map((item) =>
         (item.id === id ? { ...item, title: trimmed } : item)),
+    });
+  }
+
+  setTerminalAgentType(id: string, agentType: string, workspaceId = this.state.activeTerminalWorkspaceId): void {
+    const trimmed = agentType.trim();
+    if (!trimmed) return;
+    const workspace = this.getTerminalWorkspace(workspaceId);
+    const tab = workspace.tabs.find((item) => item.id === id);
+    if (!tab || tab.agentType === trimmed) return;
+    this.commitTerminalWorkspace(workspaceId, {
+      ...workspace,
+      tabs: workspace.tabs.map((item) =>
+        (item.id === id ? { ...item, agentType: trimmed } : item)),
     });
   }
 

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/dock-store.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/dock-store.ts
@@ -337,16 +337,22 @@ export class DockStore {
     });
   }
 
-  setTerminalAgentType(id: string, agentType: string, workspaceId = this.state.activeTerminalWorkspaceId): void {
-    const trimmed = agentType.trim();
-    if (!trimmed) return;
+  setTerminalAgentType(id: string, agentType?: string, workspaceId = this.state.activeTerminalWorkspaceId): void {
+    const trimmed = agentType?.trim();
     const workspace = this.getTerminalWorkspace(workspaceId);
     const tab = workspace.tabs.find((item) => item.id === id);
     if (!tab || tab.agentType === trimmed) return;
     this.commitTerminalWorkspace(workspaceId, {
       ...workspace,
-      tabs: workspace.tabs.map((item) =>
-        (item.id === id ? { ...item, agentType: trimmed } : item)),
+      tabs: workspace.tabs.map((item) => {
+        if (item.id !== id) return item;
+        if (!trimmed) {
+          const next = { ...item };
+          delete next.agentType;
+          return next;
+        }
+        return { ...item, agentType: trimmed };
+      }),
     });
   }
 

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/index.css
@@ -298,6 +298,24 @@
   color: #0f766e;
 }
 
+.right-dock__tab-icon--agent {
+  color: #202123;
+}
+
+.right-dock__tab-icon--agent svg {
+  width: 14px;
+  height: 14px;
+  display: block;
+}
+
+.right-dock__tab-icon--agent-claude-code {
+  color: #d97757;
+}
+
+.right-dock__tab-icon--agent-codex {
+  color: #202123;
+}
+
 .right-dock__tab-icon--link {
   color: #2383e2;
 }
@@ -309,6 +327,14 @@
 
 .right-dock__tab--active .right-dock__tab-icon--link {
   color: #2383e2;
+}
+
+.right-dock__tab--active .right-dock__tab-icon--agent-claude-code {
+  color: #d97757;
+}
+
+.right-dock__tab--active .right-dock__tab-icon--agent-codex {
+  color: #202123;
 }
 
 .right-dock__tab-title {

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/index.tsx
@@ -106,7 +106,7 @@ export function useRightDock(): {
   newTerminal: () => void;
   toggleTerminal: () => void;
   closeTerminal: (id?: string) => void;
-  setTerminalAgentType: (id: string, agentType: string, workspaceId?: string) => void;
+  setTerminalAgentType: (id: string, agentType?: string, workspaceId?: string) => void;
   collapse: () => void;
   notifyChatActivity: () => void;
 } {
@@ -121,7 +121,7 @@ export function useRightDock(): {
       newTerminal: () => store.newTerminal(),
       toggleTerminal: () => store.toggleTerminal(),
       closeTerminal: (id?: string) => store.closeTerminal(id),
-      setTerminalAgentType: (id: string, agentType: string, workspaceId?: string) =>
+      setTerminalAgentType: (id: string, agentType?: string, workspaceId?: string) =>
         store.setTerminalAgentType(id, agentType, workspaceId),
       collapse: () => store.collapse(),
       notifyChatActivity: () => store.notifyChatActivity(),

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/index.tsx
@@ -106,6 +106,7 @@ export function useRightDock(): {
   newTerminal: () => void;
   toggleTerminal: () => void;
   closeTerminal: (id?: string) => void;
+  setTerminalAgentType: (id: string, agentType: string, workspaceId?: string) => void;
   collapse: () => void;
   notifyChatActivity: () => void;
 } {
@@ -120,6 +121,8 @@ export function useRightDock(): {
       newTerminal: () => store.newTerminal(),
       toggleTerminal: () => store.toggleTerminal(),
       closeTerminal: (id?: string) => store.closeTerminal(id),
+      setTerminalAgentType: (id: string, agentType: string, workspaceId?: string) =>
+        store.setTerminalAgentType(id, agentType, workspaceId),
       collapse: () => store.collapse(),
       notifyChatActivity: () => store.notifyChatActivity(),
     }),

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/WorkspaceTerminalPortal.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/WorkspaceTerminalPortal.tsx
@@ -22,6 +22,7 @@ interface WorkspaceTerminalPortalProps {
   activeTerminalTabId?: string;
   open: boolean;
   onClose: (id?: string) => void;
+  onAgentTypeDetected: (id: string, agentType: string, workspaceId: string) => void;
 }
 
 export const WorkspaceTerminalPortal = ({
@@ -33,6 +34,7 @@ export const WorkspaceTerminalPortal = ({
   activeTerminalTabId,
   open,
   onClose,
+  onAgentTypeDetected,
 }: WorkspaceTerminalPortalProps) => {
   const terminalHost = useRightDockTerminalHost();
   if (!terminalHost) return null;
@@ -58,6 +60,7 @@ export const WorkspaceTerminalPortal = ({
               nodes={allNodes[ws.id] || []}
               open={visible && open}
               onClose={() => onClose(tab.id)}
+              onAgentTypeDetected={(agentType) => onAgentTypeDetected(tab.id, agentType, ws.id)}
               placement="pane"
             />
             </Suspense>

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/WorkspaceTerminalPortal.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/WorkspaceTerminalPortal.tsx
@@ -22,7 +22,7 @@ interface WorkspaceTerminalPortalProps {
   activeTerminalTabId?: string;
   open: boolean;
   onClose: (id?: string) => void;
-  onAgentTypeDetected: (id: string, agentType: string, workspaceId: string) => void;
+  onAgentTypeChange: (id: string, agentType: string | undefined, workspaceId: string) => void;
 }
 
 export const WorkspaceTerminalPortal = ({
@@ -34,7 +34,7 @@ export const WorkspaceTerminalPortal = ({
   activeTerminalTabId,
   open,
   onClose,
-  onAgentTypeDetected,
+  onAgentTypeChange,
 }: WorkspaceTerminalPortalProps) => {
   const terminalHost = useRightDockTerminalHost();
   if (!terminalHost) return null;
@@ -60,7 +60,7 @@ export const WorkspaceTerminalPortal = ({
               nodes={allNodes[ws.id] || []}
               open={visible && open}
               onClose={() => onClose(tab.id)}
-              onAgentTypeDetected={(agentType) => onAgentTypeDetected(tab.id, agentType, ws.id)}
+              onAgentTypeChange={(agentType) => onAgentTypeChange(tab.id, agentType, ws.id)}
               placement="pane"
             />
             </Suspense>

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
@@ -504,7 +504,7 @@ export const Workbench: React.FC<WorkbenchProps> = ({
         activeTerminalTabId={dockState.activeTerminalTabId}
         open={terminalDockOpen}
         onClose={dock.closeTerminal}
-        onAgentTypeDetected={dock.setTerminalAgentType}
+        onAgentTypeChange={dock.setTerminalAgentType}
       />
       </FileNodeEditorRegistryProvider>
     </>

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
@@ -86,7 +86,6 @@ export const Workbench: React.FC<WorkbenchProps> = ({
     workspaces,
     dockState.terminalTabsByWorkspace,
   );
-
   useEffect(() => {
     for (const node of activeNodes) {
       const ref = node.ref;
@@ -505,6 +504,7 @@ export const Workbench: React.FC<WorkbenchProps> = ({
         activeTerminalTabId={dockState.activeTerminalTabId}
         open={terminalDockOpen}
         onClose={dock.closeTerminal}
+        onAgentTypeDetected={dock.setTerminalAgentType}
       />
       </FileNodeEditorRegistryProvider>
     </>

--- a/apps/canvas-workspace/src/renderer/src/components/WorkspaceTerminalDock/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/WorkspaceTerminalDock/index.tsx
@@ -17,8 +17,8 @@ import { useI18n } from '../../i18n';
 import { TERMINAL_TAB_ID } from '../RightDock/dock-store';
 import {
   appendTerminalOutputTail,
+  detectCodingAgentCommand,
   hasLikelyReturnedToShellPrompt,
-  isCodingAgentCommand,
 } from '../../utils/codingAgentCommand';
 import './index.css';
 
@@ -31,6 +31,7 @@ interface WorkspaceTerminalDockProps {
   nodes: CanvasNode[];
   open: boolean;
   onClose: () => void;
+  onAgentTypeDetected?: (agentType: string) => void;
   placement?: 'bottom' | 'pane';
 }
 
@@ -75,6 +76,7 @@ export const WorkspaceTerminalDock = ({
   nodes,
   open,
   onClose,
+  onAgentTypeDetected,
   placement = 'bottom',
 }: WorkspaceTerminalDockProps) => {
   const { t } = useI18n();
@@ -178,7 +180,11 @@ export const WorkspaceTerminalDock = ({
       if (ch === '\r' || ch === '\n') {
         const command = commandInputRef.current;
         commandInputRef.current = '';
-        if (isCodingAgentCommand(command)) startCodingAgentHint();
+        const agentType = detectCodingAgentCommand(command);
+        if (agentType) {
+          onAgentTypeDetected?.(agentType);
+          startCodingAgentHint();
+        }
       } else if (ch === '\x7f' || ch === '\b') {
         commandInputRef.current = commandInputRef.current.slice(0, -1);
       } else if (ch === '\x15') {
@@ -187,7 +193,7 @@ export const WorkspaceTerminalDock = ({
         commandInputRef.current += ch;
       }
     }
-  }, [startCodingAgentHint]);
+  }, [onAgentTypeDetected, startCodingAgentHint]);
 
   const initTerminal = useCallback(async () => {
     if (!containerRef.current || termRef.current || spawnedRef.current) return;

--- a/apps/canvas-workspace/src/renderer/src/components/WorkspaceTerminalDock/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/WorkspaceTerminalDock/index.tsx
@@ -31,7 +31,7 @@ interface WorkspaceTerminalDockProps {
   nodes: CanvasNode[];
   open: boolean;
   onClose: () => void;
-  onAgentTypeDetected?: (agentType: string) => void;
+  onAgentTypeChange?: (agentType?: string) => void;
   placement?: 'bottom' | 'pane';
 }
 
@@ -76,7 +76,7 @@ export const WorkspaceTerminalDock = ({
   nodes,
   open,
   onClose,
-  onAgentTypeDetected,
+  onAgentTypeChange,
   placement = 'bottom',
 }: WorkspaceTerminalDockProps) => {
   const { t } = useI18n();
@@ -158,7 +158,8 @@ export const WorkspaceTerminalDock = ({
     codingAgentActiveRef.current = false;
     terminalOutputTailRef.current = '';
     setMentionHintVisible(false);
-  }, []);
+    onAgentTypeChange?.(undefined);
+  }, [onAgentTypeChange]);
 
   const startCodingAgentHint = useCallback(() => {
     if (codingAgentActiveRef.current) return;
@@ -182,7 +183,7 @@ export const WorkspaceTerminalDock = ({
         commandInputRef.current = '';
         const agentType = detectCodingAgentCommand(command);
         if (agentType) {
-          onAgentTypeDetected?.(agentType);
+          onAgentTypeChange?.(agentType);
           startCodingAgentHint();
         }
       } else if (ch === '\x7f' || ch === '\b') {
@@ -193,7 +194,7 @@ export const WorkspaceTerminalDock = ({
         commandInputRef.current += ch;
       }
     }
-  }, [onAgentTypeDetected, startCodingAgentHint]);
+  }, [onAgentTypeChange, startCodingAgentHint]);
 
   const initTerminal = useCallback(async () => {
     if (!containerRef.current || termRef.current || spawnedRef.current) return;

--- a/apps/canvas-workspace/src/renderer/src/utils/__tests__/codingAgentCommand.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/__tests__/codingAgentCommand.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { detectCodingAgentCommand, isCodingAgentCommand } from '../codingAgentCommand';
+
+describe('codingAgentCommand', () => {
+  it('detects Claude and Codex commands from direct and runner invocations', () => {
+    expect(detectCodingAgentCommand('claude')).toBe('claude-code');
+    expect(detectCodingAgentCommand('codex --model gpt-5')).toBe('codex');
+    expect(detectCodingAgentCommand('env FOO=bar npx -y @anthropic-ai/claude-code')).toBe('claude-code');
+    expect(detectCodingAgentCommand('pnpm exec -- @openai/codex resume abc')).toBe('codex');
+  });
+
+  it('keeps the boolean helper behavior', () => {
+    expect(isCodingAgentCommand('npm exec codex')).toBe(true);
+    expect(isCodingAgentCommand('echo codex')).toBe(false);
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/utils/codingAgentCommand.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/codingAgentCommand.ts
@@ -1,4 +1,4 @@
-const CODING_AGENT_COMMAND_PATTERN = /^(?:env\s+)?(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*(?:(?:npx|bunx)\s+|(?:pnpm|npm|yarn)\s+(?:dlx|exec)\s+)?(?:claude|codex)(?:\s|$)/;
+const CODING_AGENT_COMMAND_PATTERN = /^(?:env\s+)?(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*(?:(?:npx|bunx)(?:\s+(?:-y|--yes))?\s+|(?:pnpm|npm|yarn)\s+(?:dlx|exec)\s+(?:--\s+)?)?(claude|codex|@anthropic-ai\/claude-code|@openai\/codex)(?:\s|$)/;
 const ANSI_PATTERN = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1B\\))/g;
 const TERMINAL_OUTPUT_TAIL_LIMIT = 3000;
 
@@ -7,8 +7,14 @@ const SHELL_PROMPT_PATTERNS = [
   /(?:^|\n)(?:➜\s+\S[^\n]*|[~/][^\n]*)(?:❯|➜|›|\$|%|#)\s*$/,
 ];
 
+export const detectCodingAgentCommand = (command: string): 'claude-code' | 'codex' | undefined => {
+  const match = CODING_AGENT_COMMAND_PATTERN.exec(command.trim());
+  if (!match) return undefined;
+  return match[1].includes('claude') ? 'claude-code' : 'codex';
+};
+
 export const isCodingAgentCommand = (command: string): boolean => (
-  CODING_AGENT_COMMAND_PATTERN.test(command.trim())
+  detectCodingAgentCommand(command) !== undefined
 );
 
 export const appendTerminalOutputTail = (tail: string, data: string): string => {


### PR DESCRIPTION
Show Claude/Codex identity directly in terminal dock tabs.

- Detect Claude Code and Codex CLI commands typed in workspace terminals
- Store detected agent type on per-workspace terminal tabs
- Render existing Claude/Codex brand glyphs in terminal tab icons with fallback to the generic terminal icon
- Add tests for command detection and dock tab agent metadata