### PR TITLE
fix(canvas-workspace): remove dead default export, dedupe agent accent color

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/index.css
@@ -17,7 +17,7 @@
    * brand colors still live in `.agent-loading-overlay--<agent>` for
    * the loading mark, which is the one place the agent's own identity
    * is meaningful. */
-  --agent-accent: #2383e2;
+  --agent-accent: var(--accent);
   --agent-accent-hover: #1c6dbf;
   --agent-accent-soft: rgba(35, 131, 226, 0.1);
   --agent-accent-border: rgba(35, 131, 226, 0.45);

--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;


### PR DESCRIPTION
## Summary

Scanned `apps/canvas-workspace`'s renderer against the documented UI conventions in `harness/knowledge/conventions/frontend.md` and fixed the two clear-cut, mechanically-safe violations found:

- **`MigrationSpinner`** exported both a named arrow-function component and a redundant `export default MigrationSpinner`. The convention says to "avoid default exports for components," and the only consumer (`App.tsx`) already used the named import — the default export was dead code. Removed it.
- **`AgentNodeBody/index.css`** hardcoded `--agent-accent: #2383e2`, duplicating the exact hex value of the global `--accent` token in `styles.css`. The file's own comment already states the intent ("Align the agent UI with the global Notion-style accent... so its buttons, tabs and focus rings read as part of the same product"), so this replaces the duplicated literal with `var(--accent)` per the documented design-token convention.

## Other findings not fixed here (scoped out, flagged for follow-up)

A broader scan turned up several more issues, but they're either large-scale refactors or judgment calls that shouldn't be pushed through unsupervised:

- **`Props` naming convention** (frontend.md says the props interface should be named `Props`) is the *minority* pattern — the majority of ~150+ interfaces across the tree use `<Component>Props` instead. This is repo-wide unenforced convention debt, not a handful of outliers; a blanket rename would be a large, mechanical-but-risky diff better done deliberately (or the doc rule reconsidered against actual practice).
- **Hardcoded user-facing strings bypassing `useI18n()`**, e.g. `AgentTeamFrame/index.tsx` (no `useI18n` import at all despite dozens of literal strings), `NoteOutline/index.tsx`, `ImageNodeBody/index.tsx`, `IframeNodeBody/IframeEditor.tsx`, `NoteFindBar/index.tsx`. Fixing these requires adding catalog keys to `i18n/messages.ts` and touches user-visible copy — better done with product review than as a blind automated pass.
- **File-size ceiling breaches** with no test coverage for the renderer (the 500-line governance test only covers `src/main`): `AgentTeamFrame/index.tsx` (2253 lines), `AgentNodeBody/useAgentNodeController.ts` (1281 lines), `hooks/useNodes.ts` (866 lines), `WorkspaceNodes/GraphPage.tsx` (811 lines), `settings-config/McpManager.tsx` (780 lines). Splitting these needs real structural decomposition (per the `Sidebar/`/`AgentNodeBody/` reference pattern), not a mechanical fix.
- **oklch-token doc/reality mismatch**: frontend.md points at oklch-based tokens, but only one component CSS file actually uses `oklch()` — the real global tokens in `styles.css` (and 45+ component CSS files) are plain hex/rgba. Worth reconciling the doc with actual practice rather than converting dozens of files.

Bridge-isolation rule (renderer never imports Electron/Node/`src/main`/`src/preload`) was fully respected — no violations found there.

## Test plan

- [x] `pnpm --filter canvas-workspace typecheck` — renderer `tsconfig.json` project passes cleanly with these changes (the only failure is a pre-existing, unrelated `tsconfig.node.json` `baseUrl` deprecation warning, present before this change).
- [x] Confirmed `MigrationSpinner` has no other default-import consumers (`grep` across `src/renderer/src`).
- [ ] No visual/UI testing was performed (this is a CSS variable substitution to an identical color value and dead-code removal, not a behavior change).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01F6aKQxjXTRcbDURoUU8owx)_