### PR TITLE
Fix terminal agent icon reset after Claude/Codex exit

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/utils/__tests__/codingAgentCommand.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/__tests__/codingAgentCommand.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { detectCodingAgentCommand, isCodingAgentCommand } from '../codingAgentCommand';
+import {
+  appendTerminalOutputTail,
+  detectCodingAgentCommand,
+  hasLikelyReturnedToShellPrompt,
+  isCodingAgentCommand,
+} from '../codingAgentCommand';
 
 describe('codingAgentCommand', () => {
   it('detects Claude and Codex commands from direct and runner invocations', () => {
@@ -12,5 +17,17 @@ describe('codingAgentCommand', () => {
   it('keeps the boolean helper behavior', () => {
     expect(isCodingAgentCommand('npm exec codex')).toBe(true);
     expect(isCodingAgentCommand('echo codex')).toBe(false);
+  });
+
+  it('detects common shell prompts after a coding agent exits', () => {
+    expect(hasLikelyReturnedToShellPrompt('Done\nroot@devbox:/repo# ')).toBe(true);
+    expect(hasLikelyReturnedToShellPrompt('Bye\njasper@macbook:~/pulse-coder$ ')).toBe(true);
+    expect(hasLikelyReturnedToShellPrompt('Bye\n(venv) jasper@macbook:~/pulse-coder$ ')).toBe(true);
+    expect(hasLikelyReturnedToShellPrompt('Bye\n[alice@workstation pulse-coder]$ ')).toBe(true);
+  });
+
+  it('strips terminal control sequences before checking returned prompts', () => {
+    const tail = appendTerminalOutputTail('', '\u001b]0;root@devbox:/repo\u0007\r\n\u001b[32mroot@devbox\u001b[0m:/repo# ');
+    expect(hasLikelyReturnedToShellPrompt(tail)).toBe(true);
   });
 });

--- a/apps/canvas-workspace/src/renderer/src/utils/codingAgentCommand.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/codingAgentCommand.ts
@@ -5,6 +5,8 @@ const TERMINAL_OUTPUT_TAIL_LIMIT = 3000;
 const SHELL_PROMPT_PATTERNS = [
   /(?:^|\n)[^\n]*(?:╰|└)[^\n]*(?:❯|➜|›|\$|%|#)\s*$/,
   /(?:^|\n)(?:➜\s+\S[^\n]*|[~/][^\n]*)(?:❯|➜|›|\$|%|#)\s*$/,
+  /(?:^|\n)(?:\([^\n)]{1,40}\)\s*)?[\w.-]+@[\w.-]+:[^\n]*(?:\$|#)\s*$/,
+  /(?:^|\n)(?:\([^\n)]{1,40}\)\s*)?\[[^\n\]]+@[\w.-]+\s+[^\n\]]+\](?:\$|#)\s*$/,
 ];
 
 export const detectCodingAgentCommand = (command: string): 'claude-code' | 'codex' | undefined => {


### PR DESCRIPTION
## Summary
- Fixed terminal tab icons not resetting after Claude/Codex exits back to a normal shell.
- Expanded shell prompt detection to cover common bash prompts like `root@host:/repo#`, `user@host:~/repo$`, virtualenv prompts, and bracketed prompts.
- Added regression tests for prompt detection and the existing dock tab agent state reset path.

## Validation
- `pnpm --filter canvas-workspace exec vitest run src/renderer/src/utils/__tests__/codingAgentCommand.test.ts src/renderer/src/components/RightDock/__tests__/dock-store.test.ts`
- `pnpm --filter canvas-workspace build`

## Note
`pnpm --filter canvas-workspace typecheck` is currently blocked by an unrelated existing master issue in `GraphPage.tsx`: implicit `any` for `nodeLabel`.