### PR TITLE
fix(canvas-workspace): resolve UI style-guide inconsistencies

### DIFF
--- a/apps/canvas-workspace/src/main/__tests__/file-size-governance.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/file-size-governance.test.ts
@@ -41,7 +41,6 @@ const CURRENT_OVER_500_BASELINE: Record<string, number> = {
   'src/renderer/src/components/icons/index.tsx': 510,
   'src/renderer/src/components/settings-config/SkillsManager.tsx': 510,
   'src/plugins/main/webview-page-control/js-primitives.ts': 506,
-  'src/renderer/src/components/Workbench/index.tsx': 512,
 };
 
 const DOCUMENTED_EXCEPTIONS: Record<string, string> = {

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
@@ -22,7 +22,7 @@ import type {
   FrameNodeData,
 } from '../../types';
 
-interface AgentTeamFrameProps {
+interface Props {
   node: CanvasNode;
   getAllNodes?: () => CanvasNode[];
   onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
@@ -302,7 +302,7 @@ export const AgentTeamFrame = ({
   workspaceId,
   workspaceName,
   readOnly = false,
-}: AgentTeamFrameProps) => {
+}: Props) => {
   const data = node.data as FrameNodeData;
   const teamId = data.agentTeamId;
   const workspaceActive = useWorkspaceActive();

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEmptyHint/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEmptyHint/index.tsx
@@ -6,7 +6,7 @@ import { useI18n } from '../../i18n';
 import { normalizeReferenceUrl } from '../ReferenceDrawer/utils';
 import './index.css';
 
-interface CanvasEmptyHintProps {
+interface Props {
   onCreateNode: (type: Extract<CanvasNode['type'], 'agent' | 'terminal' | 'file' | 'iframe'>) => void;
   onCreateUrl?: (url: string) => void;
   onCreateDemo?: () => void;
@@ -24,7 +24,7 @@ export const CanvasEmptyHint = ({
   onOpenChat,
   onOpenShortcuts,
   onSetRootFolder,
-}: CanvasEmptyHintProps) => {
+}: Props) => {
   const { t } = useI18n();
   const [urlComposerOpen, setUrlComposerOpen] = useState(false);
   const [urlDraft, setUrlDraft] = useState('');

--- a/apps/canvas-workspace/src/renderer/src/components/ChatFloatingButton/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatFloatingButton/index.tsx
@@ -1,7 +1,7 @@
 import './index.css';
 import { AppLogoIcon } from '../icons';
 
-interface ChatFloatingButtonProps {
+interface Props {
   active?: boolean;
   title: string;
   ariaLabel?: string;
@@ -15,7 +15,7 @@ export const ChatFloatingButton = ({
   ariaLabel,
   className,
   onClick,
-}: ChatFloatingButtonProps) => (
+}: Props) => (
   <button
     type="button"
     className={[

--- a/apps/canvas-workspace/src/renderer/src/components/DynamicAppNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/DynamicAppNodeBody/index.tsx
@@ -21,7 +21,7 @@ import "./index.css";
 import { DynamicAppInspector } from "./Inspector";
 import type { CanvasNode, DynamicAppNodeData } from "../../types";
 
-interface DynamicAppNodeBodyProps {
+interface Props {
   node: CanvasNode;
   workspaceId?: string;
   onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
@@ -62,7 +62,7 @@ export function DynamicAppNodeBody({
   workspaceId,
   readOnly: _readOnly,
   isResizing: _isResizing,
-}: DynamicAppNodeBodyProps) {
+}: Props) {
   // The dispatcher only routes `type === 'dynamic-app'` here, so
   // node.data narrows to DynamicAppNodeData. Be defensive about the
   // shape in case canvas.json was hand-edited.

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.css
@@ -229,7 +229,7 @@
   background: rgba(55, 53, 47, 0.07);
   padding: 1px 5px;
   border-radius: 3px;
-  color: #c0392b;
+  color: var(--error, #c0392b);
   letter-spacing: 0;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/LinkDrawer/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/LinkDrawer/index.tsx
@@ -22,7 +22,7 @@ interface WebviewTag extends HTMLElement {
   reload(): void;
 }
 
-interface LinkTabViewProps {
+interface Props {
   url: string;
   /** Active workspace id, used as the target for "add to current canvas". */
   activeWorkspaceId: string;
@@ -34,7 +34,7 @@ interface LinkTabViewProps {
   onRequestClose: () => void;
 }
 
-export const LinkTabView = ({ url, activeWorkspaceId, onTitleChange, onFaviconChange, onRequestClose }: LinkTabViewProps) => {
+export const LinkTabView = ({ url, activeWorkspaceId, onTitleChange, onFaviconChange, onRequestClose }: Props) => {
   const { t } = useI18n();
   const hostRef = useRef<HTMLDivElement>(null);
   const webviewRef = useRef<WebviewTag | null>(null);

--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;

--- a/apps/canvas-workspace/src/renderer/src/components/PluginNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/PluginNodeBody/index.tsx
@@ -7,7 +7,7 @@ import {
 } from '../../../../plugins/renderer';
 import './index.css';
 
-interface PluginNodeBodyProps {
+interface Props {
   node: CanvasNode;
   workspaceId?: string;
   workspaceName?: string;
@@ -44,7 +44,7 @@ export const PluginNodeBody = ({
   isSelected,
   onUpdate,
   readOnly,
-}: PluginNodeBodyProps) => {
+}: Props) => {
   useSyncExternalStore(
     subscribeRendererPluginRegistry,
     getRendererPluginRegistryVersion,

--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.css
@@ -493,7 +493,7 @@
 }
 
 .reference-url-error {
-  color: #c0392b;
+  color: var(--error, #c0392b);
   font-size: 11px;
 }
 
@@ -613,7 +613,7 @@
 
 .reference-group--type-missing .reference-group-type-icon {
   background: rgba(192, 57, 43, 0.1);
-  color: #c0392b;
+  color: var(--error, #c0392b);
 }
 
 .reference-group-name {

--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.tsx
@@ -10,7 +10,7 @@ import { useReferenceDrawerState } from './useReferenceDrawerState';
 import { getReferenceId } from './utils';
 import { useI18n } from '../../i18n';
 
-interface ReferenceDrawerProps {
+interface Props {
   open: boolean;
   activeWorkspaceId: string;
   workspaces: WorkspaceEntry[];
@@ -50,7 +50,7 @@ export const ReferenceDrawer = ({
   onFocusNode,
   onAddReferenceToCanvas,
   onWorkspaceNodesRequest,
-}: ReferenceDrawerProps) => {
+}: Props) => {
   const { t } = useI18n();
   const state = useReferenceDrawerState({
     open,

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/index.tsx
@@ -164,7 +164,7 @@ function clampWidth(value: number): number {
   return Math.min(max, Math.max(MIN_WIDTH, value));
 }
 
-interface RightDockProps {
+interface Props {
   /** Target canvas for link tabs' "add to current canvas" action. */
   activeWorkspaceId: string;
   /** True on the canvas route: shows the pinned chat tab and reserves
@@ -178,7 +178,7 @@ interface TabIndicatorState {
   visible: boolean;
 }
 
-export const RightDock = ({ activeWorkspaceId, chatTabEnabled }: RightDockProps) => {
+export const RightDock = ({ activeWorkspaceId, chatTabEnabled }: Props) => {
   const { store, setChatHost, setTerminalHost } = useDockContext();
   const state = useRightDockState();
   const { t } = useI18n();

--- a/apps/canvas-workspace/src/renderer/src/components/Select/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Select/index.tsx
@@ -10,7 +10,7 @@ export interface SelectOption {
   disabled?: boolean;
 }
 
-interface SelectProps {
+interface Props {
   value: string;
   options: ReadonlyArray<SelectOption>;
   onChange: (value: string) => void;
@@ -52,7 +52,7 @@ export const Select = ({
   className,
   disabled,
   placeholder,
-}: SelectProps) => {
+}: Props) => {
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
   const selected = options.find((opt) => opt.value === value);

--- a/apps/canvas-workspace/src/renderer/src/components/SelectionToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/SelectionToolbar/index.tsx
@@ -2,7 +2,7 @@ import './index.css';
 import { useI18n } from '../../i18n';
 import type { KeyboardEvent } from 'react';
 
-interface SelectionToolbarProps {
+interface Props {
   selectedCount: number;
   canFocus: boolean;
   focusModeActive: boolean;
@@ -127,7 +127,7 @@ export const SelectionToolbar = ({
   onPinReference,
   onAddToChat,
   onDelete,
-}: SelectionToolbarProps) => {
+}: Props) => {
   const { t } = useI18n();
   if (selectedCount <= 0) return null;
 

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/index.tsx
@@ -103,13 +103,13 @@ const SECTIONS: SectionDef[] = [
   },
 ];
 
-interface SettingsProps {
+interface Props {
   open: boolean;
   initialSection: SettingsSection;
   onClose: () => void;
 }
 
-export const Settings = ({ open, initialSection, onClose }: SettingsProps) => {
+export const Settings = ({ open, initialSection, onClose }: Props) => {
   const { t } = useI18n();
   const [activeSection, setActiveSection] = useState<SettingsSection>(initialSection);
   const canvasModels = useCanvasModels();

--- a/apps/canvas-workspace/src/renderer/src/components/SettingsDrawer/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/SettingsDrawer/index.tsx
@@ -12,7 +12,7 @@ import { useEffect, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import './index.css';
 
-interface SettingsDrawerProps {
+interface Props {
   open: boolean;
   onClose: () => void;
   kicker: string;
@@ -33,7 +33,7 @@ export const SettingsDrawer = ({
   width = 640,
   closeAriaLabel = 'Close',
   children,
-}: SettingsDrawerProps) => {
+}: Props) => {
   useEffect(() => {
     if (!open) return;
     const handler = (e: KeyboardEvent) => {

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
@@ -924,12 +924,12 @@
 }
 
 .sidebar-layer-context-menu-item--danger {
-  color: #c0392b;
+  color: var(--error, #c0392b);
 }
 
 .sidebar-layer-context-menu-item--danger:hover {
   background: rgba(192, 57, 43, 0.08);
-  color: #c0392b;
+  color: var(--error, #c0392b);
 }
 
 .sidebar-layer-context-menu-separator {

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
@@ -1,32 +1,23 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Canvas } from '../Canvas';
 import { FileNodeEditorRegistryProvider } from '../../hooks/useFileNodeEditorRegistry';
 import { ChatPanelLazy as ChatPanel } from '../chat/lazy';
 import { CHAT_TAB_ID, useRightDock, useRightDockChatHost, useRightDockState } from '../RightDock';
-import {
-  createReferenceNodeDataSnapshot,
-  ReferenceDrawer,
-  type NodeReferenceEntryForCanvas,
-  type ReferenceEntry,
-} from '../ReferenceDrawer';
+import { ReferenceDrawer } from '../ReferenceDrawer';
 import type { SettingsSection } from '../Settings';
 import type { WorkspaceEntry } from '../../hooks/useWorkspaces';
 import type { WorkbenchController } from './useWorkbenchState';
-import type { CanvasNode, ReferenceNodeData } from '../../types';
-import { createDefaultNode } from '../../utils/nodeFactory';
-import { getNodeDisplayLabel } from '../../utils/nodeLabel';
-import type { CanvasClipboard, CanvasNodePatchRequest } from '../../types/ui-interaction';
-import { isReferenceableNode, isReferenceableNodeType } from '../../utils/referenceNodes';
+import type { CanvasClipboard } from '../../types/ui-interaction';
 import { useMountedWorkspaceIds } from './useMountedWorkspaceIds';
 import { useChatInsertionBridge } from './useChatInsertionBridge';
+import { useReferenceManagement } from './useReferenceManagement';
 import { WorkspaceTerminalPortal } from './WorkspaceTerminalPortal';
 
 export { useWorkbenchState } from './useWorkbenchState';
 export type { WorkbenchController } from './useWorkbenchState';
 
-const EMPTY_REFERENCES: ReferenceEntry[] = [];
-interface WorkbenchProps {
+interface Props {
   activeWorkspaceId: string;
   workspaces: WorkspaceEntry[];
   controller: WorkbenchController;
@@ -38,7 +29,7 @@ interface WorkbenchProps {
   onSetActiveRootFolder: () => void;
 }
 
-export const Workbench: React.FC<WorkbenchProps> = ({
+export const Workbench: React.FC<Props> = ({
   activeWorkspaceId,
   workspaces,
   controller,
@@ -56,13 +47,13 @@ export const Workbench: React.FC<WorkbenchProps> = ({
     deleteRequest,
     renameRequest,
     handleNodesChange,
-    patchNodeSnapshot,
     handleSelectionChange,
     ensureWorkspaceNodesLoaded,
     requestNodeFocus,
     clearFocusRequest,
     clearDeleteRequest,
     clearRenameRequest,
+    patchNodeSnapshot,
   } = controller;
 
   // Chat lives in the right dock as its pinned tab; Workbench keeps owning
@@ -75,12 +66,7 @@ export const Workbench: React.FC<WorkbenchProps> = ({
   const terminalDockOpen = dockState.expanded
     && dockState.terminalTabs.some((tab) => tab.id === dockState.activeTabId);
 
-  const [referenceDrawerOpen, setReferenceDrawerOpen] = useState(false);
-  const [referencesByWorkspace, setReferencesByWorkspace] = useState<Record<string, ReferenceEntry[]>>({});
-  const [activeReferenceIdByWorkspace, setActiveReferenceIdByWorkspace] = useState<Record<string, string | undefined>>({});
   const [canvasClipboard, setCanvasClipboard] = useState<CanvasClipboard | null>(null);
-  const [nodePatchRequest, setNodePatchRequest] = useState<CanvasNodePatchRequest | undefined>();
-  const patchRequestIdRef = useRef(0);
   const mountedWorkspaceIds = useMountedWorkspaceIds(
     activeWorkspaceId,
     workspaces,
@@ -93,112 +79,38 @@ export const Workbench: React.FC<WorkbenchProps> = ({
     }
   }, [activeNodes, ensureWorkspaceNodesLoaded]);
 
-  const references = referencesByWorkspace[activeWorkspaceId] ?? EMPTY_REFERENCES;
-  const activeReferenceId = activeReferenceIdByWorkspace[activeWorkspaceId];
-  const activeReference = activeReferenceId
-    ? references.find((entry) => (entry.kind === 'url' ? entry.id : `${entry.workspaceId}:${entry.nodeId}`) === activeReferenceId)
-    : undefined;
-  const activeReferenceNode = activeReference && activeReference.kind === 'node'
-    ? (allNodes[activeReference.workspaceId] ?? []).find((node) => node.id === activeReference.nodeId)
-    : undefined;
-
-  const removeReference = useCallback((referenceId: string) => {
-    setReferencesByWorkspace((prev) => {
-      const current = prev[activeWorkspaceId] ?? [];
-      const next = current.filter((entry) => (entry.kind === 'url' ? entry.id : `${entry.workspaceId}:${entry.nodeId}`) !== referenceId);
-      if (next.length === current.length) return prev;
-      return { ...prev, [activeWorkspaceId]: next };
-    });
-    setActiveReferenceIdByWorkspace((prev) => {
-      if (prev[activeWorkspaceId] !== referenceId) return prev;
-      return { ...prev, [activeWorkspaceId]: undefined };
-    });
-  }, [activeWorkspaceId]);
-
-  const clearAllReferences = useCallback(() => {
-    setReferencesByWorkspace((prev) => {
-      if (!prev[activeWorkspaceId]?.length) return prev;
-      return { ...prev, [activeWorkspaceId]: [] };
-    });
-    setActiveReferenceIdByWorkspace((prev) => ({
-      ...prev,
-      [activeWorkspaceId]: undefined,
-    }));
-  }, [activeWorkspaceId]);
-
-  const setActiveReference = useCallback((nodeId: string | undefined) => {
-    setActiveReferenceIdByWorkspace((prev) => ({
-      ...prev,
-      [activeWorkspaceId]: nodeId,
-    }));
-  }, [activeWorkspaceId]);
-
-  const handleFocusReferenceNode = useCallback((workspaceId: string, nodeId: string) => {
-    if (workspaceId !== activeWorkspaceId) onSelectWorkspace(workspaceId);
-    requestNodeFocus(workspaceId, nodeId);
-  }, [activeWorkspaceId, onSelectWorkspace, requestNodeFocus]);
-
-  useEffect(() => {
-    const current = referencesByWorkspace[activeWorkspaceId];
-    if (!current?.length) return;
-    const knownByWorkspace = new Map<string, Set<string>>();
-    for (const [workspaceId, snapshot] of Object.entries(allNodes)) {
-      knownByWorkspace.set(workspaceId, new Set(snapshot.map((node) => node.id)));
-    }
-    const filtered = current.filter((entry) => (
-      entry.kind === 'url'
-      || knownByWorkspace.get(entry.workspaceId)?.has(entry.nodeId)
-      || !Object.prototype.hasOwnProperty.call(allNodes, entry.workspaceId)
-    ));
-    if (filtered.length === current.length) return;
-    setReferencesByWorkspace((prev) => ({ ...prev, [activeWorkspaceId]: filtered }));
-    setActiveReferenceIdByWorkspace((prev) => {
-      const currentActive = prev[activeWorkspaceId];
-      if (currentActive && filtered.some((entry) => (entry.kind === 'url' ? entry.id : `${entry.workspaceId}:${entry.nodeId}`) === currentActive)) return prev;
-      const nextActive = filtered[0] ? (filtered[0].kind === 'url' ? filtered[0].id : `${filtered[0].workspaceId}:${filtered[0].nodeId}`) : undefined;
-      return { ...prev, [activeWorkspaceId]: nextActive };
-    });
-  }, [activeWorkspaceId, allNodes, referencesByWorkspace]);
-
-  const pinReferenceNode = useCallback((workspaceId: string, nodeId: string) => {
-    setReferencesByWorkspace((prev) => {
-      const current = prev[activeWorkspaceId] ?? [];
-      const exists = current.some((entry) => entry.kind === 'node' && entry.workspaceId === workspaceId && entry.nodeId === nodeId);
-      if (exists) return prev;
-      const workspace = workspaces.find((item) => item.id === workspaceId);
-      const node = (allNodes[workspaceId] ?? []).find((item) => item.id === nodeId);
-      const entry: ReferenceEntry = {
-        kind: 'node',
-        workspaceId,
-        nodeId,
-        titleSnapshot: node ? getNodeDisplayLabel(node) : undefined,
-        typeSnapshot: node?.type,
-        workspaceNameSnapshot: workspace?.name,
-      };
-      return { ...prev, [activeWorkspaceId]: [...current, entry] };
-    });
-    setActiveReferenceIdByWorkspace((prev) => ({
-      ...prev,
-      [activeWorkspaceId]: `${workspaceId}:${nodeId}`,
-    }));
-    setReferenceDrawerOpen(true);
-  }, [activeWorkspaceId, allNodes, workspaces]);
-
-  const pinReferenceUrl = useCallback((url: string, title?: string) => {
-    const id = `url:${url}`;
-    setReferencesByWorkspace((prev) => {
-      const current = prev[activeWorkspaceId] ?? [];
-      const exists = current.some((entry) => 'kind' in entry && entry.kind === 'url' && entry.url === url);
-      if (exists) return prev;
-      const entry: ReferenceEntry = { kind: 'url', id, url, title };
-      return { ...prev, [activeWorkspaceId]: [...current, entry] };
-    });
-    setActiveReferenceIdByWorkspace((prev) => ({
-      ...prev,
-      [activeWorkspaceId]: id,
-    }));
-    setReferenceDrawerOpen(true);
-  }, [activeWorkspaceId]);
+  const {
+    referenceDrawerOpen,
+    setReferenceDrawerOpen,
+    references,
+    activeReference,
+    activeReferenceNode,
+    removeReference,
+    clearAllReferences,
+    setActiveReference,
+    handleFocusReferenceNode,
+    pinReferenceNode,
+    pinReferenceUrl,
+    resolveReferenceNode,
+    handleOpenReferenceSource,
+    referencePlacementRequest,
+    addReferenceToCanvas,
+    consumeReferencePlacementRequest,
+    createReferenceNodeFromEntry,
+    pasteReferencesIntoCanvas,
+    updateReferenceSourceNode,
+    nodePatchRequest,
+    consumeNodePatchRequest,
+  } = useReferenceManagement({
+    activeWorkspaceId,
+    workspaces,
+    allNodes,
+    mountedWorkspaceIds,
+    ensureWorkspaceNodesLoaded,
+    requestNodeFocus,
+    onSelectWorkspace,
+    patchNodeSnapshot,
+  });
 
   const {
     handleAddDomSelectionToChat,
@@ -208,190 +120,6 @@ export const Workbench: React.FC<WorkbenchProps> = ({
     registerInsertMention,
     registerSubmitDomReviewComments,
   } = useChatInsertionBridge({ allNodes, openChat: dock.openChat });
-
-  const workspaceNameById = useCallback(
-    (workspaceId: string) => workspaces.find((workspace) => workspace.id === workspaceId)?.name,
-    [workspaces],
-  );
-
-  const resolveReferenceNode = useCallback((node: CanvasNode) => {
-    const ref = node.ref;
-    if (!ref || ref.kind !== 'workspace-node') return {};
-    return {
-      node: (allNodes[ref.workspaceId] ?? []).find((item) => item.id === ref.nodeId),
-      workspaceName: workspaceNameById(ref.workspaceId),
-    };
-  }, [allNodes, workspaceNameById]);
-
-  const resolveReferenceSource = useCallback((node: CanvasNode, fallbackWorkspaceId: string) => {
-    if (node.type === 'reference' && node.ref?.kind === 'workspace-node') {
-      const sourceNode = (allNodes[node.ref.workspaceId] ?? []).find((item) => item.id === node.ref?.nodeId);
-      return sourceNode
-        ? { workspaceId: node.ref.workspaceId, node: sourceNode }
-        : undefined;
-    }
-    return { workspaceId: fallbackWorkspaceId, node };
-  }, [allNodes]);
-
-  const handleOpenReferenceSource = useCallback((node: CanvasNode) => {
-    const ref = node.ref;
-    if (!ref || ref.kind !== 'workspace-node') return;
-    if (ref.workspaceId !== activeWorkspaceId) onSelectWorkspace(ref.workspaceId);
-    requestNodeFocus(ref.workspaceId, ref.nodeId);
-  }, [activeWorkspaceId, onSelectWorkspace, requestNodeFocus]);
-
-  const [referencePlacementRequest, setReferencePlacementRequest] = useState<NodeReferenceEntryForCanvas | null>(null);
-
-  const addReferenceToCanvas = useCallback((entry: NodeReferenceEntryForCanvas) => {
-    ensureWorkspaceNodesLoaded(entry.workspaceId);
-    setReferencePlacementRequest(entry);
-    setReferenceDrawerOpen(false);
-  }, [ensureWorkspaceNodesLoaded]);
-
-  const consumeReferencePlacementRequest = useCallback(() => {
-    setReferencePlacementRequest(null);
-  }, []);
-
-  const createReferenceNodeFromEntry = useCallback((entry: NodeReferenceEntryForCanvas, x: number, y: number): CanvasNode | null => {
-    const sourceNode = (allNodes[entry.workspaceId] ?? []).find((node) => node.id === entry.nodeId);
-    const workspaceName = workspaceNameById(entry.workspaceId) ?? entry.workspaceNameSnapshot;
-    const snapshot = sourceNode
-      ? createReferenceNodeDataSnapshot(sourceNode, workspaceName)
-      : {
-          titleSnapshot: entry.titleSnapshot,
-          typeSnapshot: entry.typeSnapshot === 'reference' ? undefined : entry.typeSnapshot,
-          workspaceNameSnapshot: workspaceName,
-        };
-    const node = {
-      ...createDefaultNode('reference', x, y),
-      ...(sourceNode ? { width: sourceNode.width, height: sourceNode.height } : {}),
-      title: snapshot.titleSnapshot ? `Ref: ${snapshot.titleSnapshot}` : 'Reference',
-      ref: {
-        kind: 'workspace-node' as const,
-        workspaceId: entry.workspaceId,
-        nodeId: entry.nodeId,
-      },
-      data: snapshot,
-      updatedAt: Date.now(),
-    };
-    return node;
-  }, [allNodes, workspaceNameById]);
-
-  const createReferenceNodeFromSource = useCallback((sourceNode: CanvasNode, sourceWorkspaceId: string, x: number, y: number): CanvasNode | null => {
-    if (!isReferenceableNode(sourceNode)) return null;
-    const workspaceName = workspaceNameById(sourceWorkspaceId);
-    const snapshot = createReferenceNodeDataSnapshot(sourceNode, workspaceName);
-    return {
-      ...createDefaultNode('reference', x, y),
-      width: sourceNode.width,
-      height: sourceNode.height,
-      title: snapshot.titleSnapshot ? `Ref: ${snapshot.titleSnapshot}` : 'Reference',
-      ref: {
-        kind: 'workspace-node' as const,
-        workspaceId: sourceWorkspaceId,
-        nodeId: sourceNode.id,
-      },
-      data: snapshot,
-      updatedAt: Date.now(),
-    };
-  }, [workspaceNameById]);
-
-  const pasteReferencesIntoCanvas = useCallback((targetWorkspaceId: string, clipboard: CanvasClipboard): CanvasNode[] => {
-    if (clipboard.sourceWorkspaceId === targetWorkspaceId || clipboard.nodes.length === 0) return [];
-
-    const created: CanvasNode[] = [];
-    let skipped = 0;
-    for (const source of clipboard.nodes) {
-      const pasteX = source.x + 24;
-      const pasteY = source.y + 24;
-      const resolved = resolveReferenceSource(source, clipboard.sourceWorkspaceId);
-
-      if (source.type === 'reference' && source.ref?.kind === 'workspace-node' && !resolved) {
-        const sourceSnapshot = source.data as ReferenceNodeData;
-        if (sourceSnapshot.typeSnapshot && !isReferenceableNodeType(sourceSnapshot.typeSnapshot)) {
-          skipped += 1;
-          continue;
-        }
-        const snapshot: ReferenceNodeData = {
-          titleSnapshot: sourceSnapshot.titleSnapshot,
-          typeSnapshot: sourceSnapshot.typeSnapshot,
-          workspaceNameSnapshot: sourceSnapshot.workspaceNameSnapshot ?? workspaceNameById(source.ref.workspaceId),
-        };
-        created.push({
-          ...createDefaultNode('reference', pasteX, pasteY),
-          width: source.width,
-          height: source.height,
-          title: snapshot.titleSnapshot ? `Ref: ${snapshot.titleSnapshot}` : source.title,
-          ref: {
-            kind: 'workspace-node',
-            workspaceId: source.ref.workspaceId,
-            nodeId: source.ref.nodeId,
-          },
-          data: snapshot,
-          updatedAt: Date.now(),
-        });
-        continue;
-      }
-
-      const sourceWorkspaceId = resolved?.workspaceId ?? clipboard.sourceWorkspaceId;
-      const sourceNode = resolved?.node ?? source;
-      const refNode = createReferenceNodeFromSource(
-        sourceNode,
-        sourceWorkspaceId,
-        pasteX,
-        pasteY,
-      );
-      if (!refNode) {
-        skipped += 1;
-        continue;
-      }
-      created.push(refNode);
-    }
-
-    if (skipped > 0) {
-      // Keep this quiet for now; unsupported nodes are simply ignored so
-      // mixed selections can still paste the useful references.
-      console.debug(`[canvas] skipped ${skipped} unsupported cross-workspace reference paste node(s)`);
-    }
-
-    return created;
-  }, [createReferenceNodeFromSource, resolveReferenceSource, workspaceNameById]);
-
-  const savePatchedWorkspaceSnapshot = useCallback((workspaceId: string, nodes: CanvasNode[]) => {
-    const api = window.canvasWorkspace?.store;
-    if (!api) return;
-    void api.load(workspaceId).then((result) => {
-      const current = result.ok && result.data
-        ? result.data
-        : { nodes: [], edges: [], transform: { x: 0, y: 0, scale: 1 }, savedAt: new Date().toISOString() };
-      void api.save(workspaceId, {
-        ...current,
-        nodes,
-        savedAt: new Date().toISOString(),
-      });
-    });
-  }, []);
-
-  const patchWorkspaceNodeSnapshot = useCallback((workspaceId: string, nodeId: string, patch: Partial<CanvasNode>) => {
-    const patched = patchNodeSnapshot(workspaceId, nodeId, patch);
-    if (patched) savePatchedWorkspaceSnapshot(workspaceId, patched);
-  }, [patchNodeSnapshot, savePatchedWorkspaceSnapshot]);
-
-  const updateReferenceSourceNode = useCallback((referenceNode: CanvasNode, patch: Partial<CanvasNode>) => {
-    const ref = referenceNode.ref;
-    if (!ref || ref.kind !== 'workspace-node') return;
-    const source = (allNodes[ref.workspaceId] ?? []).find((item) => item.id === ref.nodeId);
-    const sourceType = source?.type ?? (referenceNode.data as { typeSnapshot?: CanvasNode['type'] }).typeSnapshot;
-    if (sourceType && !isReferenceableNodeType(sourceType)) return;
-
-    if (mountedWorkspaceIds.has(ref.workspaceId)) {
-      const requestId = ++patchRequestIdRef.current;
-      setNodePatchRequest({ workspaceId: ref.workspaceId, nodeId: ref.nodeId, patch, requestId });
-      return;
-    }
-
-    patchWorkspaceNodeSnapshot(ref.workspaceId, ref.nodeId, patch);
-  }, [allNodes, mountedWorkspaceIds, patchWorkspaceNodeSnapshot]);
 
   return (
     <>
@@ -458,9 +186,7 @@ export const Workbench: React.FC<WorkbenchProps> = ({
                     onClipboardChange={setCanvasClipboard}
                     onPasteReferences={pasteReferencesIntoCanvas}
                     nodePatchRequest={nodePatchRequest?.workspaceId === ws.id ? nodePatchRequest : undefined}
-                    onNodePatchComplete={(requestId) => {
-                      if (nodePatchRequest?.requestId === requestId) setNodePatchRequest(undefined);
-                    }}
+                    onNodePatchComplete={consumeNodePatchRequest}
                     onOpenAppSettings={onOpenAppSettings}
                     onSetRootFolder={onSetActiveRootFolder}
                   />

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/useReferenceManagement.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/useReferenceManagement.ts
@@ -1,0 +1,363 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  createReferenceNodeDataSnapshot,
+  type NodeReferenceEntryForCanvas,
+  type ReferenceEntry,
+} from '../ReferenceDrawer';
+import type { WorkspaceEntry } from '../../hooks/useWorkspaces';
+import type { CanvasNode, ReferenceNodeData } from '../../types';
+import type { CanvasClipboard, CanvasNodePatchRequest } from '../../types/ui-interaction';
+import { createDefaultNode } from '../../utils/nodeFactory';
+import { getNodeDisplayLabel } from '../../utils/nodeLabel';
+import { isReferenceableNode, isReferenceableNodeType } from '../../utils/referenceNodes';
+
+const EMPTY_REFERENCES: ReferenceEntry[] = [];
+
+interface UseReferenceManagementArgs {
+  activeWorkspaceId: string;
+  workspaces: WorkspaceEntry[];
+  allNodes: Record<string, CanvasNode[]>;
+  mountedWorkspaceIds: Set<string>;
+  ensureWorkspaceNodesLoaded: (workspaceId: string) => void;
+  requestNodeFocus: (workspaceId: string, nodeId: string) => void;
+  onSelectWorkspace: (workspaceId: string) => void;
+  patchNodeSnapshot: (workspaceId: string, nodeId: string, patch: Partial<CanvasNode>) => CanvasNode[] | undefined;
+}
+
+// Extracted from Workbench/index.tsx to keep it under the file-size gate;
+// owns every piece of state and logic dedicated to the reference drawer /
+// cross-workspace reference nodes.
+export const useReferenceManagement = ({
+  activeWorkspaceId,
+  workspaces,
+  allNodes,
+  mountedWorkspaceIds,
+  ensureWorkspaceNodesLoaded,
+  requestNodeFocus,
+  onSelectWorkspace,
+  patchNodeSnapshot,
+}: UseReferenceManagementArgs) => {
+  const [referenceDrawerOpen, setReferenceDrawerOpen] = useState(false);
+  const [referencesByWorkspace, setReferencesByWorkspace] = useState<Record<string, ReferenceEntry[]>>({});
+  const [activeReferenceIdByWorkspace, setActiveReferenceIdByWorkspace] = useState<Record<string, string | undefined>>({});
+  const [referencePlacementRequest, setReferencePlacementRequest] = useState<NodeReferenceEntryForCanvas | null>(null);
+  const [nodePatchRequest, setNodePatchRequest] = useState<CanvasNodePatchRequest | undefined>();
+  const patchRequestIdRef = useRef(0);
+
+  const references = referencesByWorkspace[activeWorkspaceId] ?? EMPTY_REFERENCES;
+  const activeReferenceId = activeReferenceIdByWorkspace[activeWorkspaceId];
+  const activeReference = activeReferenceId
+    ? references.find((entry) => (entry.kind === 'url' ? entry.id : `${entry.workspaceId}:${entry.nodeId}`) === activeReferenceId)
+    : undefined;
+  const activeReferenceNode = activeReference && activeReference.kind === 'node'
+    ? (allNodes[activeReference.workspaceId] ?? []).find((node) => node.id === activeReference.nodeId)
+    : undefined;
+
+  const removeReference = useCallback((referenceId: string) => {
+    setReferencesByWorkspace((prev) => {
+      const current = prev[activeWorkspaceId] ?? [];
+      const next = current.filter((entry) => (entry.kind === 'url' ? entry.id : `${entry.workspaceId}:${entry.nodeId}`) !== referenceId);
+      if (next.length === current.length) return prev;
+      return { ...prev, [activeWorkspaceId]: next };
+    });
+    setActiveReferenceIdByWorkspace((prev) => {
+      if (prev[activeWorkspaceId] !== referenceId) return prev;
+      return { ...prev, [activeWorkspaceId]: undefined };
+    });
+  }, [activeWorkspaceId]);
+
+  const clearAllReferences = useCallback(() => {
+    setReferencesByWorkspace((prev) => {
+      if (!prev[activeWorkspaceId]?.length) return prev;
+      return { ...prev, [activeWorkspaceId]: [] };
+    });
+    setActiveReferenceIdByWorkspace((prev) => ({
+      ...prev,
+      [activeWorkspaceId]: undefined,
+    }));
+  }, [activeWorkspaceId]);
+
+  const setActiveReference = useCallback((nodeId: string | undefined) => {
+    setActiveReferenceIdByWorkspace((prev) => ({
+      ...prev,
+      [activeWorkspaceId]: nodeId,
+    }));
+  }, [activeWorkspaceId]);
+
+  const handleFocusReferenceNode = useCallback((workspaceId: string, nodeId: string) => {
+    if (workspaceId !== activeWorkspaceId) onSelectWorkspace(workspaceId);
+    requestNodeFocus(workspaceId, nodeId);
+  }, [activeWorkspaceId, onSelectWorkspace, requestNodeFocus]);
+
+  useEffect(() => {
+    const current = referencesByWorkspace[activeWorkspaceId];
+    if (!current?.length) return;
+    const knownByWorkspace = new Map<string, Set<string>>();
+    for (const [workspaceId, snapshot] of Object.entries(allNodes)) {
+      knownByWorkspace.set(workspaceId, new Set(snapshot.map((node) => node.id)));
+    }
+    const filtered = current.filter((entry) => (
+      entry.kind === 'url'
+      || knownByWorkspace.get(entry.workspaceId)?.has(entry.nodeId)
+      || !Object.prototype.hasOwnProperty.call(allNodes, entry.workspaceId)
+    ));
+    if (filtered.length === current.length) return;
+    setReferencesByWorkspace((prev) => ({ ...prev, [activeWorkspaceId]: filtered }));
+    setActiveReferenceIdByWorkspace((prev) => {
+      const currentActive = prev[activeWorkspaceId];
+      if (currentActive && filtered.some((entry) => (entry.kind === 'url' ? entry.id : `${entry.workspaceId}:${entry.nodeId}`) === currentActive)) return prev;
+      const nextActive = filtered[0] ? (filtered[0].kind === 'url' ? filtered[0].id : `${filtered[0].workspaceId}:${filtered[0].nodeId}`) : undefined;
+      return { ...prev, [activeWorkspaceId]: nextActive };
+    });
+  }, [activeWorkspaceId, allNodes, referencesByWorkspace]);
+
+  const pinReferenceNode = useCallback((workspaceId: string, nodeId: string) => {
+    setReferencesByWorkspace((prev) => {
+      const current = prev[activeWorkspaceId] ?? [];
+      const exists = current.some((entry) => entry.kind === 'node' && entry.workspaceId === workspaceId && entry.nodeId === nodeId);
+      if (exists) return prev;
+      const workspace = workspaces.find((item) => item.id === workspaceId);
+      const node = (allNodes[workspaceId] ?? []).find((item) => item.id === nodeId);
+      const entry: ReferenceEntry = {
+        kind: 'node',
+        workspaceId,
+        nodeId,
+        titleSnapshot: node ? getNodeDisplayLabel(node) : undefined,
+        typeSnapshot: node?.type,
+        workspaceNameSnapshot: workspace?.name,
+      };
+      return { ...prev, [activeWorkspaceId]: [...current, entry] };
+    });
+    setActiveReferenceIdByWorkspace((prev) => ({
+      ...prev,
+      [activeWorkspaceId]: `${workspaceId}:${nodeId}`,
+    }));
+    setReferenceDrawerOpen(true);
+  }, [activeWorkspaceId, allNodes, workspaces]);
+
+  const pinReferenceUrl = useCallback((url: string, title?: string) => {
+    const id = `url:${url}`;
+    setReferencesByWorkspace((prev) => {
+      const current = prev[activeWorkspaceId] ?? [];
+      const exists = current.some((entry) => 'kind' in entry && entry.kind === 'url' && entry.url === url);
+      if (exists) return prev;
+      const entry: ReferenceEntry = { kind: 'url', id, url, title };
+      return { ...prev, [activeWorkspaceId]: [...current, entry] };
+    });
+    setActiveReferenceIdByWorkspace((prev) => ({
+      ...prev,
+      [activeWorkspaceId]: id,
+    }));
+    setReferenceDrawerOpen(true);
+  }, [activeWorkspaceId]);
+
+  const workspaceNameById = useCallback(
+    (workspaceId: string) => workspaces.find((workspace) => workspace.id === workspaceId)?.name,
+    [workspaces],
+  );
+
+  const resolveReferenceNode = useCallback((node: CanvasNode) => {
+    const ref = node.ref;
+    if (!ref || ref.kind !== 'workspace-node') return {};
+    return {
+      node: (allNodes[ref.workspaceId] ?? []).find((item) => item.id === ref.nodeId),
+      workspaceName: workspaceNameById(ref.workspaceId),
+    };
+  }, [allNodes, workspaceNameById]);
+
+  const resolveReferenceSource = useCallback((node: CanvasNode, fallbackWorkspaceId: string) => {
+    if (node.type === 'reference' && node.ref?.kind === 'workspace-node') {
+      const sourceNode = (allNodes[node.ref.workspaceId] ?? []).find((item) => item.id === node.ref?.nodeId);
+      return sourceNode
+        ? { workspaceId: node.ref.workspaceId, node: sourceNode }
+        : undefined;
+    }
+    return { workspaceId: fallbackWorkspaceId, node };
+  }, [allNodes]);
+
+  const handleOpenReferenceSource = useCallback((node: CanvasNode) => {
+    const ref = node.ref;
+    if (!ref || ref.kind !== 'workspace-node') return;
+    if (ref.workspaceId !== activeWorkspaceId) onSelectWorkspace(ref.workspaceId);
+    requestNodeFocus(ref.workspaceId, ref.nodeId);
+  }, [activeWorkspaceId, onSelectWorkspace, requestNodeFocus]);
+
+  const addReferenceToCanvas = useCallback((entry: NodeReferenceEntryForCanvas) => {
+    ensureWorkspaceNodesLoaded(entry.workspaceId);
+    setReferencePlacementRequest(entry);
+    setReferenceDrawerOpen(false);
+  }, [ensureWorkspaceNodesLoaded]);
+
+  const consumeReferencePlacementRequest = useCallback(() => {
+    setReferencePlacementRequest(null);
+  }, []);
+
+  const createReferenceNodeFromEntry = useCallback((entry: NodeReferenceEntryForCanvas, x: number, y: number): CanvasNode | null => {
+    const sourceNode = (allNodes[entry.workspaceId] ?? []).find((node) => node.id === entry.nodeId);
+    const workspaceName = workspaceNameById(entry.workspaceId) ?? entry.workspaceNameSnapshot;
+    const snapshot = sourceNode
+      ? createReferenceNodeDataSnapshot(sourceNode, workspaceName)
+      : {
+          titleSnapshot: entry.titleSnapshot,
+          typeSnapshot: entry.typeSnapshot === 'reference' ? undefined : entry.typeSnapshot,
+          workspaceNameSnapshot: workspaceName,
+        };
+    const node = {
+      ...createDefaultNode('reference', x, y),
+      ...(sourceNode ? { width: sourceNode.width, height: sourceNode.height } : {}),
+      title: snapshot.titleSnapshot ? `Ref: ${snapshot.titleSnapshot}` : 'Reference',
+      ref: {
+        kind: 'workspace-node' as const,
+        workspaceId: entry.workspaceId,
+        nodeId: entry.nodeId,
+      },
+      data: snapshot,
+      updatedAt: Date.now(),
+    };
+    return node;
+  }, [allNodes, workspaceNameById]);
+
+  const createReferenceNodeFromSource = useCallback((sourceNode: CanvasNode, sourceWorkspaceId: string, x: number, y: number): CanvasNode | null => {
+    if (!isReferenceableNode(sourceNode)) return null;
+    const workspaceName = workspaceNameById(sourceWorkspaceId);
+    const snapshot = createReferenceNodeDataSnapshot(sourceNode, workspaceName);
+    return {
+      ...createDefaultNode('reference', x, y),
+      width: sourceNode.width,
+      height: sourceNode.height,
+      title: snapshot.titleSnapshot ? `Ref: ${snapshot.titleSnapshot}` : 'Reference',
+      ref: {
+        kind: 'workspace-node' as const,
+        workspaceId: sourceWorkspaceId,
+        nodeId: sourceNode.id,
+      },
+      data: snapshot,
+      updatedAt: Date.now(),
+    };
+  }, [workspaceNameById]);
+
+  const pasteReferencesIntoCanvas = useCallback((targetWorkspaceId: string, clipboard: CanvasClipboard): CanvasNode[] => {
+    if (clipboard.sourceWorkspaceId === targetWorkspaceId || clipboard.nodes.length === 0) return [];
+
+    const created: CanvasNode[] = [];
+    let skipped = 0;
+    for (const source of clipboard.nodes) {
+      const pasteX = source.x + 24;
+      const pasteY = source.y + 24;
+      const resolved = resolveReferenceSource(source, clipboard.sourceWorkspaceId);
+
+      if (source.type === 'reference' && source.ref?.kind === 'workspace-node' && !resolved) {
+        const sourceSnapshot = source.data as ReferenceNodeData;
+        if (sourceSnapshot.typeSnapshot && !isReferenceableNodeType(sourceSnapshot.typeSnapshot)) {
+          skipped += 1;
+          continue;
+        }
+        const snapshot: ReferenceNodeData = {
+          titleSnapshot: sourceSnapshot.titleSnapshot,
+          typeSnapshot: sourceSnapshot.typeSnapshot,
+          workspaceNameSnapshot: sourceSnapshot.workspaceNameSnapshot ?? workspaceNameById(source.ref.workspaceId),
+        };
+        created.push({
+          ...createDefaultNode('reference', pasteX, pasteY),
+          width: source.width,
+          height: source.height,
+          title: snapshot.titleSnapshot ? `Ref: ${snapshot.titleSnapshot}` : source.title,
+          ref: {
+            kind: 'workspace-node',
+            workspaceId: source.ref.workspaceId,
+            nodeId: source.ref.nodeId,
+          },
+          data: snapshot,
+          updatedAt: Date.now(),
+        });
+        continue;
+      }
+
+      const sourceWorkspaceId = resolved?.workspaceId ?? clipboard.sourceWorkspaceId;
+      const sourceNode = resolved?.node ?? source;
+      const refNode = createReferenceNodeFromSource(
+        sourceNode,
+        sourceWorkspaceId,
+        pasteX,
+        pasteY,
+      );
+      if (!refNode) {
+        skipped += 1;
+        continue;
+      }
+      created.push(refNode);
+    }
+
+    if (skipped > 0) {
+      // Keep this quiet for now; unsupported nodes are simply ignored so
+      // mixed selections can still paste the useful references.
+      console.debug(`[canvas] skipped ${skipped} unsupported cross-workspace reference paste node(s)`);
+    }
+
+    return created;
+  }, [createReferenceNodeFromSource, resolveReferenceSource, workspaceNameById]);
+
+  const savePatchedWorkspaceSnapshot = useCallback((workspaceId: string, nodes: CanvasNode[]) => {
+    const api = window.canvasWorkspace?.store;
+    if (!api) return;
+    void api.load(workspaceId).then((result) => {
+      const current = result.ok && result.data
+        ? result.data
+        : { nodes: [], edges: [], transform: { x: 0, y: 0, scale: 1 }, savedAt: new Date().toISOString() };
+      void api.save(workspaceId, {
+        ...current,
+        nodes,
+        savedAt: new Date().toISOString(),
+      });
+    });
+  }, []);
+
+  const patchWorkspaceNodeSnapshot = useCallback((workspaceId: string, nodeId: string, patch: Partial<CanvasNode>) => {
+    const patched = patchNodeSnapshot(workspaceId, nodeId, patch);
+    if (patched) savePatchedWorkspaceSnapshot(workspaceId, patched);
+  }, [patchNodeSnapshot, savePatchedWorkspaceSnapshot]);
+
+  const updateReferenceSourceNode = useCallback((referenceNode: CanvasNode, patch: Partial<CanvasNode>) => {
+    const ref = referenceNode.ref;
+    if (!ref || ref.kind !== 'workspace-node') return;
+    const source = (allNodes[ref.workspaceId] ?? []).find((item) => item.id === ref.nodeId);
+    const sourceType = source?.type ?? (referenceNode.data as { typeSnapshot?: CanvasNode['type'] }).typeSnapshot;
+    if (sourceType && !isReferenceableNodeType(sourceType)) return;
+
+    if (mountedWorkspaceIds.has(ref.workspaceId)) {
+      const requestId = ++patchRequestIdRef.current;
+      setNodePatchRequest({ workspaceId: ref.workspaceId, nodeId: ref.nodeId, patch, requestId });
+      return;
+    }
+
+    patchWorkspaceNodeSnapshot(ref.workspaceId, ref.nodeId, patch);
+  }, [allNodes, mountedWorkspaceIds, patchWorkspaceNodeSnapshot]);
+
+  const consumeNodePatchRequest = useCallback((requestId: number) => {
+    setNodePatchRequest((prev) => (prev?.requestId === requestId ? undefined : prev));
+  }, []);
+
+  return {
+    referenceDrawerOpen,
+    setReferenceDrawerOpen,
+    references,
+    activeReference,
+    activeReferenceNode,
+    removeReference,
+    clearAllReferences,
+    setActiveReference,
+    handleFocusReferenceNode,
+    pinReferenceNode,
+    pinReferenceUrl,
+    resolveReferenceNode,
+    handleOpenReferenceSource,
+    referencePlacementRequest,
+    addReferenceToCanvas,
+    consumeReferencePlacementRequest,
+    createReferenceNodeFromEntry,
+    pasteReferencesIntoCanvas,
+    updateReferenceSourceNode,
+    nodePatchRequest,
+    consumeNodePatchRequest,
+  };
+};

--- a/apps/canvas-workspace/src/renderer/src/components/WorkspaceTerminalDock/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/WorkspaceTerminalDock/index.tsx
@@ -22,7 +22,7 @@ import {
 } from '../../utils/codingAgentCommand';
 import './index.css';
 
-interface WorkspaceTerminalDockProps {
+interface Props {
   workspaceId: string;
   terminalId?: string;
   terminalTitle?: string;
@@ -78,7 +78,7 @@ export const WorkspaceTerminalDock = ({
   onClose,
   onAgentTypeChange,
   placement = 'bottom',
-}: WorkspaceTerminalDockProps) => {
+}: Props) => {
   const { t } = useI18n();
   const [height, setHeight] = useState(() => clampHeight(readStoredHeight() ?? DEFAULT_HEIGHT));
   const heightRef = useRef(height);


### PR DESCRIPTION
## Summary

Scanned `apps/canvas-workspace/src/renderer/src/**` against the documented conventions in `harness/knowledge/conventions/frontend.md` / `README.md` and fixed the violations that were real, mechanical, and verifiable (typecheck + test suite), leaving out anything that would require visual verification I couldn't perform in this environment (Electron doesn't launch here — binary download is network-blocked).

### 1. Currently-failing file-size governance gate
`src/main/__tests__/file-size-governance.test.ts` was **red**: `Workbench/index.tsx` had grown from its recorded baseline of 512 lines to 516, tripping the hard 500-line ceiling. Per the documented convention ("lift state machines and side effects into a `useXxxController` hook"), extracted all reference-drawer / cross-workspace-reference state and handlers into a new `Workbench/useReferenceManagement.ts`, mirroring the existing `useChatInsertionBridge.ts` / `useMountedWorkspaceIds.ts` pattern already used in that folder. `Workbench/index.tsx` is now 242 lines; removed the now-stale baseline entry.

### 2. `Props` interface naming convention
`frontend.md`: *"Name the props interface **`Props`** (local)."* 13 single-component `index.tsx` files used `FooProps` instead, inconsistent with sibling components in the same folders (e.g. `NodeContextMenu`, `FileNodeBody`) that already follow the convention:

`PluginNodeBody`, `DynamicAppNodeBody`, `Select`, `RightDock`, `ReferenceDrawer`, `WorkspaceTerminalDock`, `SelectionToolbar`, `ChatFloatingButton`, `SettingsDrawer`, `Settings`, `AgentTeamFrame`, `LinkDrawer`, `CanvasEmptyHint`.

Each rename is file-local (verified no other file imports the old interface name) and confirmed with `pnpm --filter canvas-workspace typecheck`.

**Deliberately left alone:** `icons/index.tsx` and `router/index.tsx` legitimately export multiple components per file, so distinct `*Props` names are required there. `CommandPalette`/`ShapeNodeBody` already use `Props` for their main export, with `FooProps` only on secondary sub-components — matching the majority convention for non-`index.tsx` files.

### 3. Dead `export default`
`frontend.md`: *"Export named arrow-function components... Avoid `default` exports."* `MigrationSpinner/index.tsx` had a redundant `export default` alongside its named export; only the named import (`App.tsx`) is used anywhere. Removed the dead default export.

### 4. Hardcoded color duplicating an existing design token
`FileNodeBody`, `ReferenceDrawer`, and `Sidebar` hardcoded the raw error color (`#c0392b`) instead of the `--error` token already defined in `styles.css`, unlike sibling stylesheets that consume tokens via `var(--accent, ...)` / `var(--surface, ...)`. Swapped to `var(--error, #c0392b)` — identical fallback value, so no visual change today, but it now tracks the token if it's ever retuned.

## Explicitly out of scope

A larger sweep of `#2383e2`/`#37352f`/`#ffffff` literals that duplicate the `--accent`/`--text`/`--surface` tokens exists (worst offenders: `chat/ChatPanel.css`, `Settings/*.css`, dozens of files/hundreds of occurrences), as does a set of hardcoded English strings that should go through `useI18n()` (`NoteFindBar`, `ImageNodeBody`, `FileNodeToolbar`, `NoteLinkPrompt`). Both are real, but touch far more surface area than I could visually verify without a working Electron build in this sandbox (network-blocked binary download). Flagging as good follow-up work rather than pushing an unverified wide-reaching diff.

## Test plan

- [x] `pnpm --filter canvas-workspace test` — `file-size-governance` now passes (was failing before this PR); 620/624 tests pass, same 4 pre-existing failures as on `master` (Electron binary unavailable / `pulse-coder-engine` resolution in this sandbox — verified identical on base branch via `git stash`)
- [x] `pnpm --filter canvas-workspace typecheck` — identical error set to `master` (pre-existing, unrelated `pulse-coder-engine/built-in` resolution issues), zero new errors introduced
- [ ] Visual smoke test in the running app (not possible in this sandbox — Electron postinstall is network-blocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTi668gn22zg7HuRZTgW6g

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTi668gn22zg7HuRZTgW6g)_