### PR TITLE
release(canvas): 0.1.14

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.13",
+  "version": "0.1.14",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump Pulse Canvas app version to 0.1.14
- published macOS arm64 DMG, blockmap, latest.json, and download page

## Release notes
zh: 提升画布启动、缩放、拖拽和多工作区场景的流畅度；HTML iframe 节点支持 DOM 选取并修复工具栏布局；终端标签会展示并恢复 Agent 图标；Feishu 群聊和聊天提及渲染更稳定。

en: Improved canvas responsiveness during startup, zooming, dragging, and multi-workspace use; added DOM picking for HTML iframe nodes with toolbar layout fixes; terminal tabs now show and restore agent icons; Feishu group chats and chat mention rendering are more stable.

## Verification
- ran release-pulse-canvas.mjs --version 0.1.14
- built macOS arm64 DMG
- uploaded R2 artifacts and latest.json
- deployed Cloudflare Pages download site