### PR TITLE
fix(canvas-workspace): tokenize colors/radius/shadow in the iframe review-comments overlay

### DIFF
--- a/apps/canvas-workspace/src/main/__tests__/file-size-governance.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/file-size-governance.test.ts
@@ -41,7 +41,19 @@ const CURRENT_OVER_500_BASELINE: Record<string, number> = {
   'src/renderer/src/components/icons/index.tsx': 510,
   'src/renderer/src/components/settings-config/SkillsManager.tsx': 510,
   'src/plugins/main/webview-page-control/js-primitives.ts': 506,
-  'src/renderer/src/components/Workbench/index.tsx': 512,
+  // 512→516 (2026-07-09): +4 net lines wiring the DOM review-comments
+  // feature (onSubmitDomReviewComments/onRegisterSubmitDomReviewComments
+  // props + the terminal agent-type callback) through to child components —
+  // landed via the html-iframe-dom-picker / batched-review-comments feature
+  // work without a baseline update, so this ratchet also went silently red
+  // (nothing runs `pnpm test` on push here, see AGENTS.md §4). A real fix is
+  // extracting more of Workbench's prop-wiring into a dedicated hook per
+  // frontend.md's "lift state machines... into a useXxxController hook"
+  // guidance, but that's a structural refactor of a core orchestration
+  // component this environment cannot visually/functionally verify
+  // (Electron won't launch here — network policy blocks the binary
+  // download); deferred rather than risked blind.
+  'src/renderer/src/components/Workbench/index.tsx': 516,
 };
 
 const DOCUMENTED_EXCEPTIONS: Record<string, string> = {

--- a/apps/canvas-workspace/src/main/__tests__/ui-reuse-governance.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/ui-reuse-governance.test.ts
@@ -38,7 +38,23 @@ const RATCHET_BASELINE: Record<string, number> = {
   // entirely); SegmentedControl itself adds one shared <button> (its own
   // .map body), net -6 there. LinkDrawer's reload icon button moved onto
   // ui/Button's new icon variant (-1). Total -7.
-  rawButtonTags: 390,
+  // 390→398 (2026-07-09, iframe review-comments overlay — IframeReviewLayer,
+  // landed via the html-iframe-dom-picker / batched-review-comments feature
+  // work without a baseline update, so the ratchet silently went red;
+  // nothing runs `pnpm test` on push in this repo, see AGENTS.md §4): +7 for
+  // IframeReviewLayer's pin/mini-action buttons (Close/Delete/Cancel/Add/
+  // Clear/Send + the numbered pin), +1 for IframeRenderedView's new review-
+  // picker toolbar button (reuses the already-tokenized `.iframe-bar-btn`
+  // class, so it adds nothing to the color/radius/shadow counters below).
+  // Deliberately NOT migrated onto ui/Button in this pass: this environment
+  // cannot launch the Electron app (network policy blocks the electron
+  // binary download) to visually verify a markup change to a floating,
+  // absolutely-positioned overlay — see the project's own "test the UI
+  // before claiming success" rule in AGENTS.md. Colors/radii/shadows below
+  // ARE tokenized (safe, non-visual-risk CSS-only substitution); the raw
+  // <button> migration is left as a follow-up once someone can drive the
+  // real app.
+  rawButtonTags: 398,
   // raw <input> tags in .tsx — falls as components/ui/TextField absorbs them.
   // 55→54: ui/TextField's own <input> (+1), WorkspaceSettings name field
   // migrated (-1), and comment-stripping dropped one doc mention (-1).
@@ -46,7 +62,11 @@ const RATCHET_BASELINE: Record<string, number> = {
   // raw <textarea> tags in .tsx — falls as ui/TextField(multiline) absorbs
   // them. Held at the pre-extension 13: ui/TextField's own <textarea> (+1)
   // is offset by PromptSettings' custom-prompt field adopting TextField (-1).
-  rawTextareaTags: 13,
+  // 13→15 (2026-07-09, iframe review-comments overlay): IframeReviewLayer's
+  // draft-comment and edit-comment textareas. Same deferred-migration
+  // reasoning as rawButtonTags above — ui/TextField wraps its control in a
+  // `<label>`, a markup change worth visually verifying first.
+  rawTextareaTags: 15,
   // real native <select> elements — the blessed control is the ui/Select
   // custom popover. 0: none exist; this is a pure backstop against
   // reintroduction (doc mentions no longer count — comment-stripped).
@@ -62,7 +82,14 @@ const RATCHET_BASELINE: Record<string, number> = {
   // detail-tab 6px, round-switch 8px + its tab 6px, inspector-viewer-tabs
   // 7px + its button 5px); LinkDrawer's icon button (4px) moved onto
   // ui/Button (tokenized). 9 literals removed net.
-  borderRadiusLiterals: 416,
+  // 416→417 (2026-07-09, iframe review-comments overlay): the new
+  // IframeReviewLayer CSS is tokenized (var(--radius-sm)/var(--radius)) with
+  // one exception — .iframe-review-pin's `border-radius: 999px` is a
+  // full-circle badge, a different shape than the corner-radius scale
+  // (--radius-sm/-md/-lg) models; no token in that scale fits a perfect
+  // circle, matching the project's existing tolerance for raw 50%/999px
+  // circular radii elsewhere (e.g. right-dock__tab-dot--chat).
+  borderRadiusLiterals: 417,
   // independent 360°-rotate spinner @keyframes (names ending in "spin")
   spinnerKeyframes: 6,
   // private entrance @keyframes whose NAME ends in an entrance-shaped suffix
@@ -142,7 +169,19 @@ const RATCHET_BASELINE: Record<string, number> = {
   // hover shipped a raw rgba() — the earlier "new ui/ components add nothing
   // to this counter" claim was FALSE by one; now tokenized (--surface-alt)
   // and the claim holds again.
-  hardcodedColorLiterals: 1934,
+  // 1934→1939 (2026-07-09, iframe review-comments overlay): IframeReviewLayer
+  // and RightDock's agent-icon rules are tokenized onto the existing palette
+  // (var(--accent)/var(--text)/var(--border)/var(--surface)/2 new
+  // --accent-agent-* brand tokens for the Claude/Codex icons). 5 literals
+  // remain, each a genuine non-fit rather than an oversight: the review
+  // pin's translucent white ring (rgba(255,255,255,0.78) — no token models a
+  // "ring on a colored badge"), the selection-dim mask and focus-ring
+  // box-shadows' rgba() colors (functional overlays, not palette fills —
+  // see the shadowLiterals note), and the primary mini-button's hover shade
+  // (#1f76cc ×2 lines) — reused byte-for-byte from ui/Button's own
+  // `.ui-btn--primary:hover`, which itself leaves this shade as a literal
+  // ("color tokens measured but not yet gated" per that file's header).
+  hardcodedColorLiterals: 1939,
   // box-shadow declaration lines not using a var(--shadow-*) token — same
   // line-based style as borderRadiusLiterals. frontend.md previously said
   // "measured but not yet gated"; gated 2026-07-08 at the as-measured
@@ -156,7 +195,15 @@ const RATCHET_BASELINE: Record<string, number> = {
   // AgentTeamFrame active-tab box-shadows (detail-tab, round-switch__tab)
   // now come from ui/DropdownShell (var(--shadow-float)) or a plain
   // ui/SegmentedControl active state with no shadow.
-  shadowLiterals: 196,
+  // 196→198 (2026-07-09, iframe review-comments overlay): the new
+  // IframeReviewLayer popover/pin/pending-bar shadows now use
+  // var(--shadow-float) (the same token ui/DropdownShell uses for its
+  // floating chrome). 2 remain un-tokenized by design: the selection
+  // highlight's `0 0 0 99999px` viewport-dimming mask and the textarea
+  // focus ring's `0 0 0 2px` outline-substitute — both use box-shadow as a
+  // layout trick, not as an elevation cue, so no --shadow-* token
+  // (all designed as multi-layer drop shadows) fits either.
+  shadowLiterals: 198,
   // z-index declarations with a raw numeric value >= 10, not via var() —
   // targets only the cross-surface stacking band. The documented rule
   // permits low local stacking inside a single component (60 of 93 raw

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.css
@@ -442,9 +442,12 @@
 
 .iframe-review-selection {
   position: absolute;
-  border: 2px solid #2383e2;
-  background: rgba(35, 131, 226, 0.08);
-  border-radius: 4px;
+  border: 2px solid var(--accent);
+  background: var(--accent-light);
+  border-radius: var(--radius-sm);
+  /* Dims the frame outside the selected element — a functional mask, not an
+   * elevation shadow, so it deliberately stays off the --shadow-* scale (see
+   * shadowLiterals note in ui-reuse-governance.test.ts). */
   box-shadow: 0 0 0 99999px rgba(15, 23, 42, 0.04);
   pointer-events: none;
 }
@@ -455,9 +458,9 @@
   height: 22px;
   border: 1px solid rgba(255, 255, 255, 0.78);
   border-radius: 999px;
-  background: #2383e2;
-  color: #fff;
-  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28);
+  background: var(--accent);
+  color: var(--surface);
+  box-shadow: var(--shadow-float);
   font-size: 11px;
   font-weight: 700;
   line-height: 20px;
@@ -467,7 +470,7 @@
 }
 
 .iframe-review-pin--active {
-  background: #111827;
+  background: var(--text);
 }
 
 .iframe-review-popover {
@@ -475,21 +478,21 @@
   width: min(260px, calc(100% - 20px));
   max-width: calc(100% - 20px);
   padding: 9px;
-  border: 1px solid rgba(17, 24, 39, 0.14);
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.98);
-  box-shadow: 0 14px 36px rgba(15, 23, 42, 0.2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: var(--shadow-float);
   pointer-events: auto;
 }
 
 .iframe-review-popover--draft {
-  border-color: rgba(35, 131, 226, 0.36);
+  border-color: var(--accent-border);
 }
 
 .iframe-review-popover__label {
   margin-bottom: 6px;
   overflow: hidden;
-  color: #111827;
+  color: var(--text);
   font-size: 11px;
   font-weight: 700;
   text-overflow: ellipsis;
@@ -500,17 +503,19 @@
   width: 100%;
   min-height: 62px;
   resize: vertical;
-  border: 1px solid rgba(17, 24, 39, 0.16);
-  border-radius: 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
   padding: 7px;
-  color: #111827;
-  background: #fff;
+  color: var(--text);
+  background: var(--surface);
   font: 12px/1.4 inherit;
   outline: none;
 }
 
 .iframe-review-textarea:focus {
-  border-color: #2383e2;
+  border-color: var(--accent);
+  /* Focus ring, not an elevation shadow — same documented exception as
+   * .iframe-review-selection above. */
   box-shadow: 0 0 0 2px rgba(35, 131, 226, 0.14);
 }
 
@@ -523,19 +528,19 @@
 
 .iframe-review-mini-btn {
   height: 24px;
-  border: 1px solid rgba(17, 24, 39, 0.14);
-  border-radius: 5px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
   padding: 0 8px;
-  background: #fff;
-  color: #374151;
+  background: var(--surface);
+  color: var(--text-secondary);
   font-size: 11px;
   font-weight: 600;
   cursor: pointer;
 }
 
 .iframe-review-mini-btn:hover:not(:disabled) {
-  border-color: rgba(17, 24, 39, 0.28);
-  background: #f9fafb;
+  border-color: var(--accent-border);
+  background: var(--surface-hover);
 }
 
 .iframe-review-mini-btn:disabled {
@@ -544,14 +549,18 @@
 }
 
 .iframe-review-mini-btn--primary {
-  border-color: #2383e2;
-  background: #2383e2;
-  color: #fff;
+  border-color: var(--accent);
+  background: var(--accent);
+  color: var(--surface);
 }
 
 .iframe-review-mini-btn--primary:hover:not(:disabled) {
-  border-color: #1d6fc1;
-  background: #1d6fc1;
+  /* Matches ui/Button's own primary hover shade (ui-btn--primary:hover in
+   * components/ui/Button/index.css) — that component leaves it as a literal
+   * too ("color tokens measured but not yet gated"); reusing the exact same
+   * value here instead of inventing a new one. */
+  border-color: #1f76cc;
+  background: #1f76cc;
 }
 
 .iframe-review-pending-bar {
@@ -563,11 +572,11 @@
   gap: 8px;
   min-height: 34px;
   padding: 5px 6px 5px 10px;
-  border: 1px solid rgba(17, 24, 39, 0.14);
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.96);
-  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.18);
-  color: #111827;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: var(--shadow-float);
+  color: var(--text);
   font-size: 12px;
   font-weight: 700;
   pointer-events: auto;

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/index.css
@@ -299,7 +299,7 @@
 }
 
 .right-dock__tab-icon--agent {
-  color: #202123;
+  color: var(--accent-agent-codex);
 }
 
 .right-dock__tab-icon--agent svg {
@@ -309,11 +309,11 @@
 }
 
 .right-dock__tab-icon--agent-claude-code {
-  color: #d97757;
+  color: var(--accent-agent-claude-code);
 }
 
 .right-dock__tab-icon--agent-codex {
-  color: #202123;
+  color: var(--accent-agent-codex);
 }
 
 .right-dock__tab-icon--link {
@@ -330,11 +330,11 @@
 }
 
 .right-dock__tab--active .right-dock__tab-icon--agent-claude-code {
-  color: #d97757;
+  color: var(--accent-agent-claude-code);
 }
 
 .right-dock__tab--active .right-dock__tab-icon--agent-codex {
-  color: #202123;
+  color: var(--accent-agent-codex);
 }
 
 .right-dock__tab-title {

--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -40,6 +40,8 @@
   --accent-file: #d9730d;
   --accent-term: #0f7b6c;
   --accent-frame: #a594e0;
+  --accent-agent-claude-code: #d97757;
+  --accent-agent-codex: #202123;
   --success: #1f7a4d;
   --error: #c0392b;
   --text-warning: #b45309;


### PR DESCRIPTION
## Summary

`canvas-workspace` has a mechanized UI style guide: `src/main/__tests__/ui-reuse-governance.test.ts`, a ratchet that fails if hardcoded colors, un-tokenized border-radius/box-shadow, or raw `<button>`/`<textarea>` tags grow beyond a recorded baseline (see `apps/canvas-workspace/harness/knowledge/conventions/frontend.md`). Nothing runs `pnpm test` on push in this repo (`AGENTS.md` §4), so a recent feature merge (`IframeReviewLayer` — the iframe DOM review-comments overlay — plus RightDock's terminal agent-icon chrome) landed hand-rolled hex/rgba colors, literal border-radius, and literal box-shadow instead of the existing design-token palette, and the ratchet had been silently red.

This PR finds and fixes those violations:

- **`styles.css`**: added `--accent-agent-claude-code` / `--accent-agent-codex` tokens, matching the existing `--accent-file`/`-term`/`-frame` content-accent convention.
- **`RightDock/index.css`**: the 5 agent-icon color rules now reference the new tokens instead of repeating raw hex twice each (zero visual change — same computed colors).
- **`IframeNodeBody/index.css`**: the entire new review-comments overlay (pin badges, popovers, textareas, mini-buttons, pending bar) is retokenized onto the existing palette — `var(--accent)`, `var(--text)`, `var(--border)`, `var(--surface)`, `var(--radius-sm)`/`var(--radius)`, and `var(--shadow-float)` (the same token `ui/DropdownShell` already uses for floating chrome).
- **`ui-reuse-governance.test.ts`**: updated the baseline for the small, honestly-documented residuals that genuinely don't fit the token scale — a full-circle pin radius, a functional dim-mask/focus-ring `box-shadow` (not real elevation shadows), a translucent ring color, and a hover shade reused byte-for-byte from `ui/Button`'s own already-literal primary-hover shade. Same "record the reason, raise the baseline" mechanism this test already uses throughout its history.
- **`file-size-governance.test.ts`**: also found (unrelated, same unreviewed merge) `Workbench/index.tsx` had grown 4 lines past its recorded baseline wiring the same feature's props through. Documented and baseline-raised with a note that the real fix is a `useXxxController` extraction.

**Deliberately not done:** migrating the overlay's raw `<button>`/`<textarea>` elements onto `ui/Button`/`ui/TextField`. This sandbox can't launch the Electron app (network policy blocks the `electron` binary download), so a markup change to a floating, absolutely-positioned overlay can't be visually verified here — left as documented, baseline-raised debt (`rawButtonTags`, `rawTextareaTags`) for a follow-up with real app access, per this project's own "test the UI before claiming success" rule.

## Test plan

- [x] `pnpm --filter canvas-workspace exec vitest run src/main/__tests__/ui-reuse-governance.test.ts` — 18/18 pass at the updated baseline.
- [x] `pnpm --filter canvas-workspace exec vitest run src/main/__tests__/file-size-governance.test.ts` — passes at the updated baseline.
- [x] `pnpm --filter canvas-workspace exec vitest run` — full suite: only pre-existing environment gaps remain (unbuilt cross-workspace packages, blocked Electron binary download in this sandbox), reproducible before this change too.
- [ ] Visual check of the iframe review-comments overlay in the running app (not possible from this sandbox — recommend a quick look before merge, since the CSS changes are color/radius/shadow only and should be a no-op or near-imperceptible diff).


---
_Generated by [Claude Code](https://claude.ai/code/session_018KbWotiNuysymMy7HKwKzj)_