### PR TITLE
fix(canvas-workspace): keep toolbar visible during panzoom

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.test.ts
@@ -1,8 +1,11 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import {
   shouldRenderEdgeLabels,
   shouldRenderEdgeStylePanel,
 } from './CanvasOverlays';
+
+const canvasCss = readFileSync(new URL('./index.css', import.meta.url), 'utf8');
 
 describe('CanvasOverlays movement gating', () => {
   it('parks edge labels during pan and zoom gestures', () => {
@@ -20,5 +23,9 @@ describe('CanvasOverlays movement gating', () => {
   it('parks the edge style panel during movement', () => {
     expect(shouldRenderEdgeStylePanel(true)).toBe(false);
     expect(shouldRenderEdgeStylePanel(false)).toBe(true);
+  });
+
+  it('keeps the bottom floating toolbar visible during movement', () => {
+    expect(canvasCss).not.toContain('.canvas-container[data-moving="on"] .floating-toolbar');
   });
 });

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.css
@@ -130,7 +130,6 @@
   will-change: transform;
 }
 
-.canvas-container[data-moving="on"] .floating-toolbar,
 .canvas-container[data-moving="on"] .edge-style-panel,
 .canvas-container[data-moving="on"] .edge-label:not(.edge-label--editing) {
   opacity: 0;


### PR DESCRIPTION
## Summary

- keep the fixed bottom `FloatingToolbar` visible while the canvas is panning or zooming
- retain movement gating for edge labels, the edge style panel, and node-header actions
- add a CSS contract regression test for toolbar visibility

## Root cause

Follow-up to #759. The movement optimization used a broad CSS selector that included `.floating-toolbar`. This toolbar lives in fixed bottom chrome outside the canvas transform and does not participate in node measurement or viewport projection, so hiding it provided no meaningful hot-path benefit and caused unnecessary visual disappearance.

## Validation

- reproduced with a failing regression test before changing production CSS
- targeted Vitest: 4 files, 14 tests passed
- renderer TypeScript check passed
- node TypeScript check passed
- Electron production build passed
