### PR TITLE
feat(harness): add interactive visualization skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ This file orients agents working in the Coder repository. It is a thin routing +
 | Review changes (repo-aware) | affected workspace `AGENTS.md` + `node scripts/harness/run-harness-check.mjs` |
 | Inspect harness coverage | `node scripts/harness/check-harness.mjs` |
 | Run bound checks for a change | `node scripts/harness/run-harness-check.mjs` |
+| Visualize root/package/app harness | `harness/skills/visualize-harness/SKILL.md` |
 
 ## 2. Hard boundaries (real values)
 
@@ -70,7 +71,7 @@ The only CI is `.github/workflows/perf.yml` — canvas-workspace bundle-size rat
 | Tier | Location | Role | Loaded how |
 |---|---|---|---|
 | Runtime task skills | `.pulse-coder/skills/*/SKILL.md` | On-demand task knowledge/procedures for the product runtime | engine skills plugin → `skill` tool |
-| Repo action protocols | Not currently materialized | Future stable workflow docs only when the workflow justifies a file | Manual, if added later |
+| Repo action protocols | `harness/skills/*/SKILL.md` when present | Stable workflows for agents maintaining this repository | Manual from the owning `AGENTS.md` route |
 
 **Action → required pre-read** (manual, no runtime enforcement):
 
@@ -83,9 +84,9 @@ The only CI is `.github/workflows/perf.yml` — canvas-workspace bundle-size rat
 | Review a diff (repo-aware) | affected workspace `AGENTS.md`, local validation, and root impact overlay when relevant |
 | Quality self-check / acceptance gate | local validation first, then root overlay for root/cross-workspace impact |
 
-Do not route required work to nonexistent `harness/skills/*` files. Add a repo action protocol only when the workflow is stable enough and the file removes real ambiguity.
+Route only to repo action protocols that exist on disk. Add one only when the workflow is stable enough and the file removes real ambiguity.
 
-**Gap to close (aspirational, not present):** the manual runner exists; still missing are candidate mechanical checks (add only when their rules are stable enough to mechanize) and any automatic trigger (opt-in pre-push, CI) — defer those until the runner's false-positive rate is proven near zero. Do not claim these exist today.
+**Gap to close:** the manual runner and structural drift checks exist; still missing are semantic checks for contradictions/test effectiveness and any automatic trigger (opt-in pre-push, CI). Defer automatic enforcement until the runner's false-positive rate is proven near zero.
 
 ## 5. Acceptance (reproducible + verifiable)
 

--- a/harness/DESIGN.md
+++ b/harness/DESIGN.md
@@ -244,5 +244,5 @@ Keep workspace entries local and differential. Do not copy root principles or ro
 4. Use workspace-local `harness/` as the preferred container when local Knowledge, Tool, Validate, or Skills assets need a home.
 5. Keep root Validate minimal while migrating detailed validation into workspace-local `harness/validate/`.
 6. Keep `scripts/harness/` tools consuming workspace-local validation files as the primary source (done for the runner and drift check).
-7. Make Validate executable by adding a runner for `harness/validate/validation.yaml` plus workspace-local validation files.
+7. Keep Validate executable through the runner for `harness/validate/validation.yaml` plus workspace-local validation files (implemented in `scripts/harness/run-harness-check.mjs`).
 8. Add Spec only when a concrete feature, protocol, or migration needs normative design and history.

--- a/harness/README.md
+++ b/harness/README.md
@@ -26,12 +26,13 @@ AGENTS.md / CLAUDE.md
 | Area | Path | Purpose |
 |---|---|---|
 | Harness design | `DESIGN.md` | Target shape for AGENTS.md + Knowledge / Tool / Validate / Skills across global and module scopes. |
-| Pilot status | `ROADMAP.md` | Current pilot status, honest gaps (no CI / no git hooks / no executable checks), and the keystone rollout plan. |
+| Pilot status | `ROADMAP.md` | Current pilot status, honest gaps (no automatic trigger or semantic checks), and the keystone rollout plan. |
 | Workspace membership | `../pnpm-workspace.yaml` | Machine-readable active workspace set. |
 | Root validation rules | `validate/validation.yaml` | Machine-readable root validation routing and escalation rules. |
 | Knowledge index | `knowledge/` | Index for the Knowledge surface — routes to existing knowledge SSOTs (root AGENTS, workspace AGENTS, workspace docs/contracts). |
 | Validate index | `validate/` | Index for the Validate surface — routes to root validation rules, workspace validation, checks, and run evidence. |
 | Tools | `tools/` | Harness tool index; wired executables live in `scripts/harness/` (runner + drift check). |
+| Skills | `skills/` | Stable repo action protocols; currently includes interactive harness visualization for root/package/app scopes. |
 
 ## Knowledge Routing
 

--- a/harness/ROADMAP.md
+++ b/harness/ROADMAP.md
@@ -13,17 +13,17 @@ The harness pilot has a real, populated foundation:
 - `scripts/harness/run-harness-check.mjs` is the validation runner (keystone phase 1, landed 2026-07-07): resolves changed paths (or `--since <ref>` / `--path` / `--all`) to the bound workspace-local + root-overlay commands and executes them with a pass/fail report; escalation rules are printed as reminders, never auto-run.
 - Root `AGENTS.md` carries the meta-rules layer (precedence + SSOT-no-copies + mechanism-over-doc + first-principles + Occam + 5-step self-check), the L0/L1/L2 doc taxonomy, the intent navigation table, hard boundaries with honest test-reality, workspace-local validation routing, and named failure-capture with guards.
 
-What is **honestly absent**: apart from `.github/workflows/perf.yml` (canvas-workspace perf gates), there is NO CI for tests/typecheck, NO git hooks, NO husky/lint-staged/commitlint, and NO automatic trigger for the runner — invoking it is still discipline. Candidate mechanical checks (`workspace-coverage`, `routing-links`, …) are not implemented. `harness/skills/`, `harness/feedback/`, `harness/templates/`, and `harness/checks/` do not exist today.
+What is **honestly absent**: apart from `.github/workflows/perf.yml` (canvas-workspace perf gates), there is NO CI for tests/typecheck, NO git hooks, NO husky/lint-staged/commitlint, and NO automatic trigger for the runner — invoking it is still discipline. Structural checks (`workspace-coverage`, `routing-links`, …) exist, but semantic contradiction and test-effectiveness checks do not. `harness/feedback/`, `harness/templates/`, and `harness/checks/` do not exist today.
 
 ## The keystone: turn the declarative SSOT into a runnable mechanism (phase 1 DONE)
 
-Every constraint in this harness is currently carried by agent discipline. The single highest-value next step is to give the existing SSOT an executor.
+The keystone was to move validation-command selection from agent memory into an executor. Phase 1 is complete; qualification of reminder-only escalation rules and invocation of the manual runner still rely on agent discipline.
 
 **Goal:** `scripts/harness/run-harness-check.mjs` — a runner that reads workspace-local `harness/validate/validation.yaml` files plus the root overlay and executes the check(s) bound to a changed path (or `--all`).
 
 **Why this is the keystone:**
 - It converts "honesty-about-absence" into "honesty-with-a-mechanism" (the root `AGENTS.md` §4 already admits the gap; this closes it).
-- It plays to an existing strength: validation YAML is already a path→check SSOT. The missing layer is the runner, not the data.
+- It played to an existing strength: validation YAML was already a path→check SSOT. The missing layer was the runner, not the data.
 - It is the one move that closes the largest lead the reference sample (B) has — mechanical enforcement — without copying B's domain-specifics.
 
 **Phased rollout (mechanism matures only after the rule proves stable — per `harness/README.md` principles):**
@@ -38,7 +38,7 @@ Every constraint in this harness is currently carried by agent discipline. The s
 
 ## Other open items (breadth, lower priority than the keystone)
 
-- **Repo action protocols.** Root `harness/skills/` does not exist today (add only when a recurring workflow is stable enough). Note: the first WORKSPACE-local surfaces now exist — `packages/engine/harness/tools/describe-engine.mjs` (structure snapshot) and `packages/engine/harness/skills/add-builtin-plugin.md` (safe-change procedure) — covering engine's orient/iterate needs that the repo runner does not.
+- **Repo action protocols.** Root `harness/skills/visualize-harness/` now owns the recurring workflow for turning root/package/app harness evidence into an interactive reading graph. Add further protocols only when a workflow is equally stable and repeated. Workspace-local surfaces include `packages/engine/harness/tools/describe-engine.mjs` and its safe-change skills.
 - **Candidate harness tools.** `harness/tools/README.md` lists remaining tool ideas (repo-profiler, ssot-resolver, feedback-router). Implement candidates only when they become useful enough to run.
 
 ## Deliberately deferred (not gaps — out of scope for this repo)
@@ -62,3 +62,4 @@ The comparison against the reference sample (B / `ec_channel_lynx_x`) surfaced i
 - Keystone phase 1: manual validation runner `scripts/harness/run-harness-check.mjs` (git-status/`--since`/`--path`/`--all` modes, dry-run, escalation reminders; verified against the remote-server change replay and a full `--all --dry-run` plan).
 - Knowledge/Validate surface alignment with the finalized `Harness = AGENTS.md + Knowledge + Tool + Validate + Skills` model: elevated Skills to an explicit fourth surface, renamed Know -> Knowledge, renamed Verify -> Validate, and added `harness/knowledge/README.md` + `harness/validate/README.md` as routing indexes.
 - canvas-workspace governance pass (2026-07-07): the five surfaces had all grown ORGANICALLY there (docs/ = Knowledge, product `harness/` CLI = Tool, boundary/size tests + perf CI = Validate, `skills/*/SKILL.md` = Skills) — the work was governance, not construction: a ~105-claim two-scanner drift audit (all drift concentrated in the duplicated CLAUDE.md → thinned to an @AGENTS.md shell; two docs falsely claimed tests "gate CI"), a docs metabolism pass (7 zero-reference dead records deleted), one validation binding gap closed (product-harness rule), and the overloaded local terms "harness"/"skills" pinned in the workspace AGENTS.md. Lesson: for doc-rich workspaces the harness playbook inverts — audit-and-metabolize before building anything new.
+- First root repo action skill: `harness/skills/visualize-harness/` combines agent-led progressive evidence gathering with a tested, schema-driven standalone HTML renderer for root/package/app scopes.

--- a/harness/skills/visualize-harness/SKILL.md
+++ b/harness/skills/visualize-harness/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: visualize-harness
+description: Use when a maintainer asks to visualize, map, inspect, explain, or compare the repository harness for root, a package, or an app as an interactive HTML reading graph.
+---
+
+# Visualize Harness
+
+Generate a standalone graph showing how an agent progressively reads a scope: entry rules, task-triggered sources, concrete evidence, and boundaries.
+
+## Workflow
+
+1. Resolve the requested scope.
+   - Root: repository root.
+   - Workspace: confirm membership from `pnpm-workspace.yaml` and require its `AGENTS.md`.
+2. Read root `AGENTS.md` and `harness/README.md`; then read the scope's `AGENTS.md` and `harness/validate/validation.yaml` when present.
+3. Follow only task-relevant routes into Knowledge, Spec, Skills, Source, Types, Tests, and Tools. Do not recursively load every referenced file.
+4. Separate evidence honestly:
+   - Direct: literal content from loaded entries/files.
+   - Progressive: content obtained by following a task-triggered route.
+   - Mechanical: current output from tests, scripts, or structure tools.
+   - Runtime: behavior observed by running the real app/service.
+5. Never read `.env`, secrets, credentials, or real user data for the visualization. Label unexecuted tests and unverified runtime claims explicitly.
+6. For a standard root, Engine, or Canvas Workspace map, use the bundled scope scan. For a custom map, build a temporary JSON input and render it with the bundled script.
+7. Open the output, click every branch, and report the absolute HTML path plus checks actually run.
+
+## Input
+
+Use this shape; every array must be non-empty and branch IDs must be unique lowercase hyphen-case:
+
+```json
+{
+  "title": "Engine Harness Reading Graph",
+  "subtitle": "How task intent expands into evidence.",
+  "scope": "packages/engine",
+  "metrics": [{ "value": "9", "label": "built-in plugins" }],
+  "entryNodes": [{ "title": "Root AGENTS.md", "detail": "Find the local owner." }],
+  "branches": [{
+    "id": "public-api",
+    "label": "Public API",
+    "intent": ["Inspect exported contracts"],
+    "sources": ["harness/knowledge/contracts.md", "src/index.ts"],
+    "reads": ["Two public barrels"],
+    "evidence": ["Four main-barrel omissions"],
+    "level": 4
+  }],
+  "evidenceLevels": [
+    { "title": "Entry", "detail": "Rules" },
+    { "title": "Knowledge", "detail": "Facts" },
+    { "title": "Source", "detail": "Implementation" },
+    { "title": "Checks", "detail": "Behavior" }
+  ],
+  "boundary": "Do not infer unrun checks or read secrets."
+}
+```
+
+Metrics must come from current commands or files, not copied historical prose. Prefer an existing scope tool such as `describe-engine.mjs` or `describe-canvas.mjs`; otherwise use focused `rg`, file counts, and validation dry-runs.
+
+## Render
+
+Built-in scopes collect current filesystem metrics and provide bilingual reading paths. Choose `en` (default) or `zh`:
+
+```bash
+node harness/skills/visualize-harness/scripts/render-harness-graph.mjs \
+  --scope canvas-workspace \
+  --locale zh \
+  --output /tmp/canvas-workspace-harness.html
+```
+
+Supported scopes: `root`, `engine`, `canvas-workspace`, and `all`. `all` puts the three built-in scopes into one HTML page with internal tabs:
+
+```bash
+node harness/skills/visualize-harness/scripts/render-harness-graph.mjs \
+  --scope all \
+  --locale zh \
+  --output /tmp/harness-all.html
+```
+
+The `all` page includes an in-page English/中文 switch. `--locale` sets its initial language; switching keeps the currently selected scope tab.
+
+For a custom map, preserve the original input mode:
+
+```bash
+node harness/skills/visualize-harness/scripts/render-harness-graph.mjs \
+  --input /tmp/<scope>-harness.json \
+  --locale en \
+  --output /tmp/<scope>-harness.html
+```
+
+The renderer validates the schema, escapes embedded content, creates parent directories, and writes one dependency-free interactive HTML file.

--- a/harness/skills/visualize-harness/agents/openai.yaml
+++ b/harness/skills/visualize-harness/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Visualize Harness"
+  short_description: "Generate progressive harness reading graphs"
+  default_prompt: "Use $visualize-harness to map the requested root, package, or app harness as an interactive reading graph."

--- a/harness/skills/visualize-harness/scripts/render-harness-graph.mjs
+++ b/harness/skills/visualize-harness/scripts/render-harness-graph.mjs
@@ -1,0 +1,557 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createAllScopeGraphs, createScopeGraph } from './scope-graphs.mjs';
+
+function fail(message) {
+  throw new Error(`Invalid harness graph: ${message}`);
+}
+
+function requireObject(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) fail(`${label} must be an object`);
+}
+
+function requireString(value, label) {
+  if (typeof value !== 'string' || !value.trim()) fail(`${label} must be a non-empty string`);
+}
+
+function requireStringArray(value, label) {
+  if (!Array.isArray(value) || value.length === 0) fail(`${label} must contain at least one item`);
+  value.forEach((item, index) => requireString(item, `${label}[${index}]`));
+}
+
+export function validateHarnessData(data) {
+  requireObject(data, 'input');
+  requireString(data.title, 'title');
+  requireString(data.subtitle, 'subtitle');
+  requireString(data.scope, 'scope');
+  requireString(data.boundary, 'boundary');
+  if (data.locale !== undefined && !['en', 'zh'].includes(data.locale)) {
+    fail('locale must be en or zh');
+  }
+
+  if (!Array.isArray(data.metrics) || data.metrics.length === 0) fail('metrics must contain at least one item');
+  data.metrics.forEach((metric, index) => {
+    requireObject(metric, `metrics[${index}]`);
+    requireString(metric.value, `metrics[${index}].value`);
+    requireString(metric.label, `metrics[${index}].label`);
+  });
+
+  if (!Array.isArray(data.entryNodes) || data.entryNodes.length === 0) {
+    fail('entryNodes must contain at least one item');
+  }
+  data.entryNodes.forEach((node, index) => {
+    requireObject(node, `entryNodes[${index}]`);
+    requireString(node.title, `entryNodes[${index}].title`);
+    requireString(node.detail, `entryNodes[${index}].detail`);
+  });
+
+  if (!Array.isArray(data.evidenceLevels) || data.evidenceLevels.length === 0) {
+    fail('evidenceLevels must contain at least one item');
+  }
+  data.evidenceLevels.forEach((level, index) => {
+    requireObject(level, `evidenceLevels[${index}]`);
+    requireString(level.title, `evidenceLevels[${index}].title`);
+    requireString(level.detail, `evidenceLevels[${index}].detail`);
+  });
+
+  if (!Array.isArray(data.branches) || data.branches.length === 0) {
+    fail('branches must contain at least one item');
+  }
+  const ids = new Set();
+  data.branches.forEach((branch, index) => {
+    const label = `branches[${index}]`;
+    requireObject(branch, label);
+    requireString(branch.id, `${label}.id`);
+    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(branch.id)) {
+      fail(`${label}.id must use lowercase hyphen-case`);
+    }
+    if (ids.has(branch.id)) fail(`${label}.id must be unique`);
+    ids.add(branch.id);
+    requireString(branch.label, `${label}.label`);
+    requireStringArray(branch.intent, `${label}.intent`);
+    requireStringArray(branch.sources, `${label}.sources`);
+    requireStringArray(branch.reads, `${label}.reads`);
+    requireStringArray(branch.evidence, `${label}.evidence`);
+    if (!Number.isInteger(branch.level) || branch.level < 1 || branch.level > data.evidenceLevels.length) {
+      fail(`${label}.level must be between 1 and ${data.evidenceLevels.length}`);
+    }
+  });
+
+  return data;
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function serializeForScript(value) {
+  return JSON.stringify(value)
+    .replaceAll('<', '\\u003c')
+    .replaceAll('>', '\\u003e')
+    .replaceAll('&', '\\u0026')
+    .replaceAll('\u2028', '\\u2028')
+    .replaceAll('\u2029', '\\u2029');
+}
+
+export function renderHarnessGraph(rawData) {
+  const data = validateHarnessData(rawData);
+  const locale = data.locale === 'zh' ? 'zh' : 'en';
+  const copy = locale === 'zh'
+    ? {
+        direct: '直接入口', progressive: '渐进阅读', evidence: '证据', select: '选择任务意图以展开阅读路径',
+        empty: '选择一个分支，查看 Agent 会阅读什么以及获得哪些证据。', taskIntent: '任务意图',
+        continueReading: '继续阅读', becomesKnown: '可获得的知识', concreteEvidence: '具体证据', boundary: '边界：',
+      }
+    : {
+        direct: 'Direct entry', progressive: 'Progressive read', evidence: 'Evidence', select: 'Select a task intent to expand its reading path',
+        empty: 'Select a branch to see what the agent reads and what evidence it obtains.', taskIntent: 'Task intent',
+        continueReading: 'Continue reading', becomesKnown: 'What becomes known', concreteEvidence: 'Concrete evidence', boundary: 'Boundary:',
+      };
+  const metrics = data.metrics.map((metric) => `
+      <div class="metric">
+        <strong>${escapeHtml(metric.value)}</strong>
+        <span>${escapeHtml(metric.label)}</span>
+      </div>`).join('');
+  const entries = data.entryNodes.map((entry, index) => `
+      <div class="entry-node">
+        <strong>${escapeHtml(entry.title)}</strong>
+        <small>${escapeHtml(entry.detail)}</small>
+      </div>${index === data.entryNodes.length - 1 ? '' : '<div class="edge-down" aria-hidden="true"></div>'}`).join('');
+  const levels = data.evidenceLevels.map((level, index) => `
+      <div class="evidence-step${index === 0 ? ' active' : ''}">
+        <strong>${escapeHtml(level.title)}</strong>
+        <span>${escapeHtml(level.detail)}</span>
+      </div>`).join('');
+
+  return `<!doctype html>
+<html lang="${locale === 'zh' ? 'zh-CN' : 'en'}">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(data.title)}</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #f7f8fa;
+      --surface: #ffffff;
+      --direct: #eef4ff;
+      --route: #edf8f1;
+      --proof: #f5f1ff;
+      --text: #1d2430;
+      --muted: #647084;
+      --border: #d7dce5;
+      --line: #aeb7c5;
+      --blue: #2563a8;
+      --green: #217a4a;
+      --purple: #6c4bb6;
+      --danger: #a63d3d;
+      --shadow: 0 6px 20px rgba(28, 39, 54, 0.08);
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #15181d;
+        --surface: #1d2128;
+        --direct: #18283d;
+        --route: #172d22;
+        --proof: #28213a;
+        --text: #e8ebf0;
+        --muted: #a7b0be;
+        --border: #343b46;
+        --line: #586273;
+        --blue: #70a8e8;
+        --green: #6fc794;
+        --purple: #ae91eb;
+        --danger: #ed8585;
+        --shadow: 0 8px 24px rgba(0, 0, 0, 0.24);
+      }
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-width: 320px;
+      background: var(--bg);
+      color: var(--text);
+      font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      letter-spacing: 0;
+    }
+    main { width: min(1120px, calc(100% - 32px)); margin: 0 auto; padding: 28px 0 40px; }
+    h1 { margin: 0; font-size: 24px; line-height: 1.3; font-weight: 600; }
+    .subtitle { margin: 7px 0 18px; color: var(--muted); line-height: 1.55; }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; overflow-wrap: anywhere; }
+    .scope { color: var(--blue); font-weight: 600; }
+    .snapshot {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 8px;
+      margin-bottom: 22px;
+    }
+    .metric { padding: 10px 12px; border-bottom: 2px solid var(--border); }
+    .metric strong { display: block; font-size: 20px; font-weight: 600; }
+    .metric span { display: block; margin-top: 3px; color: var(--muted); font-size: 13px; }
+    .legend { display: flex; flex-wrap: wrap; gap: 8px 18px; margin-bottom: 18px; color: var(--muted); font-size: 13px; }
+    .legend span { display: inline-flex; align-items: center; gap: 7px; }
+    .dot { width: 9px; height: 9px; border-radius: 50%; background: var(--blue); }
+    .dot.route { background: var(--green); }
+    .dot.proof { background: var(--purple); }
+    .entry-flow { display: grid; justify-items: center; }
+    .entry-node {
+      width: min(520px, 100%);
+      padding: 13px 16px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--direct);
+      box-shadow: var(--shadow);
+      text-align: center;
+    }
+    .entry-node strong { display: block; font-size: 15px; font-weight: 600; }
+    .entry-node small { display: block; margin-top: 5px; color: var(--muted); font-size: 13px; line-height: 1.45; }
+    .edge-down { width: 1px; height: 24px; background: var(--line); position: relative; }
+    .edge-down::after {
+      content: "";
+      position: absolute;
+      left: -3px;
+      bottom: 0;
+      width: 7px;
+      height: 7px;
+      border-right: 1px solid var(--line);
+      border-bottom: 1px solid var(--line);
+      transform: rotate(45deg);
+    }
+    .intent-label { margin: 24px 0 10px; font-size: 14px; font-weight: 600; text-align: center; }
+    .intent-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(110px, 1fr)); gap: 8px; }
+    .intent-button {
+      min-height: 58px;
+      padding: 8px 7px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--surface);
+      color: var(--text);
+      font: inherit;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: border-color 150ms ease, background 150ms ease, transform 150ms ease;
+    }
+    .intent-button:hover { border-color: var(--green); background: var(--route); }
+    .intent-button:focus-visible { outline: 3px solid color-mix(in srgb, var(--green) 35%, transparent); outline-offset: 2px; }
+    .intent-button[aria-pressed="true"] { border-color: var(--green); background: var(--route); color: var(--green); transform: translateY(-2px); }
+    .detail-region { margin-top: 18px; min-height: 290px; }
+    .empty-state {
+      display: grid;
+      min-height: 240px;
+      place-items: center;
+      border-top: 1px dashed var(--border);
+      border-bottom: 1px dashed var(--border);
+      color: var(--muted);
+      text-align: center;
+    }
+    .reading-path {
+      display: grid;
+      grid-template-columns: minmax(0, .68fr) 36px minmax(0, 1fr) 36px minmax(0, 1.32fr);
+      align-items: stretch;
+      animation: reveal 180ms ease-out;
+    }
+    @keyframes reveal { from { opacity: 0; transform: translateY(5px); } to { opacity: 1; transform: translateY(0); } }
+    @media (prefers-reduced-motion: reduce) { .reading-path { animation: none; } .intent-button { transition: none; } }
+    .path-node { min-width: 0; padding: 15px; border: 1px solid var(--border); border-radius: 6px; background: var(--surface); }
+    .path-node.route-node { background: var(--route); border-color: color-mix(in srgb, var(--green) 45%, var(--border)); }
+    .path-node.proof-node { background: var(--proof); border-color: color-mix(in srgb, var(--purple) 45%, var(--border)); }
+    .path-node h2 { margin: 0 0 10px; font-size: 15px; line-height: 1.35; font-weight: 600; }
+    .path-node h3 { margin: 12px 0 5px; font-size: 13px; line-height: 1.35; font-weight: 600; }
+    .path-node ul { margin: 0; padding-left: 18px; }
+    .path-node li { margin: 5px 0; color: var(--muted); line-height: 1.45; }
+    .path-arrow { display: grid; place-items: center; color: var(--line); font-size: 22px; }
+    .evidence-footer {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+      gap: 8px;
+      margin-top: 18px;
+      padding-top: 14px;
+      border-top: 1px solid var(--border);
+    }
+    .evidence-step { position: relative; padding: 18px 8px 8px; color: var(--muted); font-size: 13px; text-align: center; }
+    .evidence-step::before {
+      content: "";
+      position: absolute;
+      top: 3px;
+      left: calc(50% - 5px);
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: var(--bg);
+      border: 2px solid var(--line);
+    }
+    .evidence-step.active::before { border-color: var(--purple); background: var(--proof); }
+    .evidence-step strong, .evidence-step span { display: block; }
+    .evidence-step strong { color: var(--text); font-weight: 600; }
+    .evidence-step span { margin-top: 2px; }
+    .boundary {
+      margin-top: 20px;
+      padding: 12px 0 0 12px;
+      border-top: 1px dashed var(--border);
+      border-left: 3px solid var(--danger);
+      color: var(--muted);
+      line-height: 1.55;
+    }
+    .boundary strong { color: var(--text); }
+    @media (max-width: 860px) {
+      .reading-path { grid-template-columns: 1fr; gap: 8px; }
+      .path-arrow { transform: rotate(90deg); min-height: 24px; }
+    }
+    @media (max-width: 560px) {
+      main { width: min(100% - 20px, 1120px); padding-top: 18px; }
+      h1 { font-size: 20px; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>${escapeHtml(data.title)}</h1>
+    <p class="subtitle"><span class="scope">${escapeHtml(data.scope)}</span> · ${escapeHtml(data.subtitle)}</p>
+    <div class="snapshot" aria-label="Harness snapshot">${metrics}
+    </div>
+    <div class="legend" aria-label="Node legend">
+      <span><i class="dot" aria-hidden="true"></i>${copy.direct}</span>
+      <span><i class="dot route" aria-hidden="true"></i>${copy.progressive}</span>
+      <span><i class="dot proof" aria-hidden="true"></i>${copy.evidence}</span>
+    </div>
+    <section class="entry-flow" aria-label="Reading entries">${entries}
+    </section>
+    <div class="intent-label">${copy.select}</div>
+    <div class="intent-grid" id="intent-grid" aria-label="Task intents"></div>
+    <section class="detail-region" id="detail-region" aria-live="polite">
+      <div class="empty-state">${copy.empty}</div>
+    </section>
+    <div class="evidence-footer" aria-label="Evidence levels">${levels}
+    </div>
+    <div class="boundary"><strong>${copy.boundary}</strong> ${escapeHtml(data.boundary)}</div>
+  </main>
+  <script>
+    const branches = ${serializeForScript(data.branches)};
+    const copy = ${serializeForScript(copy)};
+    const intentGrid = document.getElementById('intent-grid');
+    const detailRegion = document.getElementById('detail-region');
+    const evidenceSteps = Array.from(document.querySelectorAll('.evidence-step'));
+    let selectedId = null;
+
+    function appendList(parent, items, useCode = false) {
+      const list = document.createElement('ul');
+      items.forEach((item) => {
+        const row = document.createElement('li');
+        if (useCode) {
+          const code = document.createElement('code');
+          code.textContent = item;
+          row.appendChild(code);
+        } else {
+          row.textContent = item;
+        }
+        list.appendChild(row);
+      });
+      parent.appendChild(list);
+    }
+
+    function createPathNode(className, heading) {
+      const node = document.createElement('section');
+      node.className = className;
+      const title = document.createElement('h2');
+      title.textContent = heading;
+      node.appendChild(title);
+      return node;
+    }
+
+    function createArrow() {
+      const arrow = document.createElement('div');
+      arrow.className = 'path-arrow';
+      arrow.setAttribute('aria-hidden', 'true');
+      arrow.textContent = '→';
+      return arrow;
+    }
+
+    function renderBranch(branch) {
+      const path = document.createElement('div');
+      path.className = 'reading-path';
+
+      const intent = createPathNode('path-node', copy.taskIntent);
+      appendList(intent, [branch.label, ...branch.intent]);
+
+      const route = createPathNode('path-node route-node', copy.continueReading);
+      appendList(route, branch.sources, true);
+      const readsTitle = document.createElement('h3');
+      readsTitle.textContent = copy.becomesKnown;
+      route.appendChild(readsTitle);
+      appendList(route, branch.reads);
+
+      const proof = createPathNode('path-node proof-node', copy.concreteEvidence);
+      appendList(proof, branch.evidence);
+
+      path.append(intent, createArrow(), route, createArrow(), proof);
+      detailRegion.replaceChildren(path);
+      evidenceSteps.forEach((step, index) => step.classList.toggle('active', index < branch.level));
+    }
+
+    function selectBranch(id) {
+      selectedId = selectedId === id ? null : id;
+      document.querySelectorAll('.intent-button').forEach((button) => {
+        button.setAttribute('aria-pressed', String(button.dataset.id === selectedId));
+      });
+      if (!selectedId) {
+        const empty = document.createElement('div');
+        empty.className = 'empty-state';
+        empty.textContent = copy.empty;
+        detailRegion.replaceChildren(empty);
+        evidenceSteps.forEach((step, index) => step.classList.toggle('active', index === 0));
+        return;
+      }
+      renderBranch(branches.find((branch) => branch.id === selectedId));
+    }
+
+    branches.forEach((branch) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'intent-button';
+      button.dataset.id = branch.id;
+      button.setAttribute('aria-pressed', 'false');
+      button.textContent = branch.label;
+      button.addEventListener('click', () => selectBranch(branch.id));
+      intentGrid.appendChild(button);
+    });
+  </script>
+</body>
+</html>
+`;
+}
+
+function renderGraphTabSet(graphs, locale, hidden = false) {
+  if (!Array.isArray(graphs) || graphs.length === 0) throw new Error('graphs must contain at least one item');
+  const labels = locale === 'zh'
+    ? { title: 'Harness 阅读图', root: '仓库根目录', engine: 'Engine', canvas: 'Canvas Workspace' }
+    : { title: 'Harness Reading Graphs', root: 'Repository root', engine: 'Engine', canvas: 'Canvas Workspace' };
+  const tabs = graphs.map((graph, index) => {
+    const label = graph.scope === 'root' ? labels.root : graph.scope === 'packages/engine' ? labels.engine : labels.canvas;
+    return `<button class="tab" data-scope="${graph.scope}" type="button" role="tab" aria-selected="${index === 0}" aria-controls="${locale}-panel-${index}" id="${locale}-tab-${index}">${label}</button>`;
+  }).join('');
+  const panels = graphs.map((graph, index) => `
+    <section class="panel" data-scope="${graph.scope}" id="${locale}-panel-${index}" role="tabpanel" aria-labelledby="${locale}-tab-${index}"${index === 0 ? '' : ' hidden'}>
+      <iframe title="${escapeHtml(graph.title)}" srcdoc="${escapeHtml(renderHarnessGraph(graph))}"></iframe>
+    </section>`).join('');
+  return `<section class="locale-set" data-locale="${locale}"${hidden ? ' hidden' : ''}>
+    <nav class="tabs" role="tablist" aria-label="${labels.title}">${tabs}</nav>${panels}
+  </section>`;
+}
+
+function graphTabsDocument(body, locale, bilingual = false) {
+  const language = locale === 'zh' ? 'zh-CN' : 'en';
+  const title = locale === 'zh' ? 'Harness 阅读图' : 'Harness Reading Graphs';
+  const languageSwitch = bilingual ? `<div class="language-switch" aria-label="Language">
+    <button class="language-button" data-language="en" type="button" aria-pressed="${locale !== 'zh'}">English</button>
+    <button class="language-button" data-language="zh" type="button" aria-pressed="${locale === 'zh'}">中文</button>
+  </div>` : '';
+
+  return `<!doctype html>
+<html lang="${language}">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${title}</title>
+  <style>
+    :root { color-scheme: light dark; --bg: #f7f8fa; --surface: #ffffff; --text: #1d2430; --border: #d7dce5; --active: #2563a8; }
+    @media (prefers-color-scheme: dark) { :root { --bg: #15181d; --surface: #1d2128; --text: #e8ebf0; --border: #343b46; --active: #70a8e8; } }
+    * { box-sizing: border-box; } body { margin: 0; background: var(--bg); color: var(--text); font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .language-switch { display: flex; justify-content: flex-end; gap: 6px; padding: 8px 16px 0; background: var(--surface); }
+    .language-button { padding: 5px 9px; border: 1px solid var(--border); border-radius: 5px; background: transparent; color: var(--text); font: inherit; cursor: pointer; }
+    .language-button[aria-pressed="true"] { border-color: var(--active); color: var(--active); font-weight: 600; }
+    .tabs { display: flex; gap: 6px; padding: 12px 16px 0; border-bottom: 1px solid var(--border); background: var(--surface); }
+    .tab { padding: 9px 13px; border: 1px solid transparent; border-bottom: 0; border-radius: 6px 6px 0 0; background: transparent; color: var(--text); font: inherit; cursor: pointer; }
+    .tab[aria-selected="true"] { border-color: var(--border); background: var(--bg); color: var(--active); font-weight: 600; }
+    .tab:focus-visible { outline: 3px solid color-mix(in srgb, var(--active) 35%, transparent); outline-offset: 2px; }
+    .panel { height: calc(100vh - ${bilingual ? '96px' : '55px'}); } iframe { display: block; width: 100%; height: 100%; border: 0; }
+  </style>
+</head>
+<body>
+  ${languageSwitch}${body}
+  <script>
+    let selectedScope = 'root';
+    function selectScope(locale, scope) {
+      selectedScope = scope;
+      const container = document.querySelector('.locale-set[data-locale="' + locale + '"]');
+      container.querySelectorAll('.tab').forEach((tab) => tab.setAttribute('aria-selected', String(tab.dataset.scope === scope)));
+      container.querySelectorAll('.panel').forEach((panel) => { panel.hidden = panel.dataset.scope !== scope; });
+    }
+    document.querySelectorAll('.locale-set').forEach((container) => {
+      container.querySelectorAll('.tab').forEach((tab) => tab.addEventListener('click', () => selectScope(container.dataset.locale, tab.dataset.scope)));
+    });
+    document.querySelectorAll('.language-button').forEach((button) => button.addEventListener('click', () => {
+      const locale = button.dataset.language;
+      document.querySelectorAll('.locale-set').forEach((container) => { container.hidden = container.dataset.locale !== locale; });
+      document.querySelectorAll('.language-button').forEach((item) => item.setAttribute('aria-pressed', String(item === button)));
+      selectScope(locale, selectedScope);
+    }));
+  </script>
+</body>
+</html>`;
+}
+
+export function renderHarnessGraphTabs(graphs, locale = 'en') {
+  return graphTabsDocument(renderGraphTabSet(graphs, locale), locale);
+}
+
+export function renderBilingualHarnessGraphTabs(graphsByLocale, initialLocale = 'en') {
+  const locale = initialLocale === 'zh' ? 'zh' : 'en';
+  if (!graphsByLocale || !graphsByLocale.en || !graphsByLocale.zh) {
+    throw new Error('graphsByLocale must include en and zh graphs');
+  }
+  return graphTabsDocument(
+    `${renderGraphTabSet(graphsByLocale.en, 'en', locale !== 'en')}${renderGraphTabSet(graphsByLocale.zh, 'zh', locale !== 'zh')}`,
+    locale,
+    true,
+  );
+}
+
+function parseArgs(argv) {
+  const args = { input: null, output: null, scope: null, locale: null };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--input') args.input = argv[++index];
+    else if (arg === '--output') args.output = argv[++index];
+    else if (arg === '--scope') args.scope = argv[++index];
+    else if (arg === '--locale') args.locale = argv[++index];
+    else if (arg === '--help' || arg === '-h') {
+      console.log('Usage: render-harness-graph.mjs (--input <graph.json> | --scope <root|engine|canvas-workspace|all>) --output <graph.html> [--locale <en|zh>]');
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if ((!args.input && !args.scope) || (args.input && args.scope)) {
+    throw new Error('provide exactly one of --input or --scope');
+  }
+  if (!args.output) throw new Error('--output is required');
+  if (args.locale && !['en', 'zh'].includes(args.locale)) throw new Error('--locale must be en or zh');
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const input = args.scope
+    ? (args.scope === 'all'
+      ? { en: createAllScopeGraphs('en'), zh: createAllScopeGraphs('zh') }
+      : createScopeGraph(args.scope, args.locale || 'en'))
+    : { ...JSON.parse(fs.readFileSync(path.resolve(args.input), 'utf8')), ...(args.locale ? { locale: args.locale } : {}) };
+  const output = path.resolve(args.output);
+  fs.mkdirSync(path.dirname(output), { recursive: true });
+  fs.writeFileSync(output, args.scope === 'all'
+    ? renderBilingualHarnessGraphTabs(input, args.locale || 'en')
+    : renderHarnessGraph(input));
+  console.log(output);
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) main();

--- a/harness/skills/visualize-harness/scripts/render-harness-graph.test.mjs
+++ b/harness/skills/visualize-harness/scripts/render-harness-graph.test.mjs
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import {
+  renderHarnessGraph,
+  renderBilingualHarnessGraphTabs,
+  renderHarnessGraphTabs,
+  validateHarnessData,
+} from './render-harness-graph.mjs';
+import { createAllScopeGraphs, createScopeGraph } from './scope-graphs.mjs';
+
+function sampleData() {
+  return {
+    title: 'Engine <Harness>',
+    subtitle: 'Progressive reading for root, package, or app scopes.',
+    scope: 'packages/engine',
+    metrics: [
+      { value: '9', label: 'built-in plugins' },
+      { value: '36', label: 'tools' },
+    ],
+    entryNodes: [
+      {
+        title: 'Root AGENTS.md',
+        detail: 'Find the workspace owner.',
+      },
+      {
+        title: 'packages/engine/AGENTS.md',
+        detail: 'Read local constraints and routes.',
+      },
+    ],
+    branches: [
+      {
+        id: 'public-api',
+        label: 'Public API',
+        intent: ['Inspect exports'],
+        sources: ['harness/knowledge/contracts.md', 'src/index.ts'],
+        reads: ['Two public barrels'],
+        evidence: ['Four main-barrel omissions', '</script><script>alert(1)</script>'],
+        level: 4,
+      },
+    ],
+    evidenceLevels: [
+      { title: 'Entry', detail: 'Rules' },
+      { title: 'Knowledge', detail: 'Facts' },
+      { title: 'Source', detail: 'Implementation' },
+      { title: 'Checks', detail: 'Behavior' },
+    ],
+    boundary: 'Do not read .env or user data automatically.',
+  };
+}
+
+describe('validateHarnessData', () => {
+  it('accepts a complete harness graph', () => {
+    expect(validateHarnessData(sampleData())).toEqual(sampleData());
+  });
+
+  it('rejects an empty branch list', () => {
+    const data = sampleData();
+    data.branches = [];
+
+    expect(() => validateHarnessData(data)).toThrow('branches must contain at least one item');
+  });
+
+  it('rejects evidence levels outside the declared range', () => {
+    const data = sampleData();
+    data.branches[0].level = 5;
+
+    expect(() => validateHarnessData(data)).toThrow('branches[0].level must be between 1 and 4');
+  });
+});
+
+describe('renderHarnessGraph', () => {
+  it('renders a complete interactive HTML document and escapes embedded data', () => {
+    const html = renderHarnessGraph(sampleData());
+
+    expect(html).toContain('<!doctype html>');
+    expect(html).toContain('<title>Engine &lt;Harness&gt;</title>');
+    expect(html).toContain('id="intent-grid"');
+    expect(html).toContain("button.addEventListener('click'");
+    expect(html).toContain('public-api');
+    expect(html).not.toContain('</script><script>alert(1)</script>');
+    expect(html).toContain('\\u003c/script\\u003e\\u003cscript\\u003ealert(1)\\u003c/script\\u003e');
+  });
+
+  it('renders Chinese interface copy when the input locale is zh', () => {
+    const data = sampleData();
+    data.locale = 'zh';
+
+    const html = renderHarnessGraph(data);
+
+    expect(html).toContain('<html lang="zh-CN">');
+    expect(html).toContain('选择任务意图以展开阅读路径');
+    expect(html).toContain('具体证据');
+  });
+});
+
+describe('createScopeGraph', () => {
+  it.each(['root', 'engine', 'canvas-workspace'])('builds a complete English graph for %s', (scope) => {
+    const graph = createScopeGraph(scope);
+
+    expect(validateHarnessData(graph)).toBe(graph);
+    expect(graph.locale).toBe('en');
+    expect(graph.branches.length).toBeGreaterThan(0);
+    expect(graph.metrics.length).toBeGreaterThan(0);
+  });
+
+  it('builds Chinese scope content and rejects unknown scopes', () => {
+    const graph = createScopeGraph('canvas-workspace', 'zh');
+
+    expect(graph.title).toContain('阅读图');
+    expect(graph.branches[0].label).toContain('修改');
+    expect(() => createScopeGraph('remote-server')).toThrow('Unknown scope');
+  });
+
+  it('combines all built-in scopes in one tabbed document', () => {
+    const html = renderHarnessGraphTabs(createAllScopeGraphs('zh'), 'zh');
+
+    expect(html).toContain('仓库根目录');
+    expect(html).toContain('Canvas Workspace');
+    expect(html).toContain('role="tablist"');
+    expect(html).toContain('srcdoc=');
+  });
+
+  it('switches all scopes between English and Chinese inside one document', () => {
+    const html = renderBilingualHarnessGraphTabs({
+      en: createAllScopeGraphs('en'),
+      zh: createAllScopeGraphs('zh'),
+    }, 'zh');
+
+    expect(html).toContain('data-language="en"');
+    expect(html).toContain('data-language="zh"');
+    expect(html).toContain('selectScope(locale, selectedScope)');
+    expect(html).toContain('修改某个工作区');
+    expect(html).toContain('Change a workspace');
+  });
+});

--- a/harness/skills/visualize-harness/scripts/scope-graphs.mjs
+++ b/harness/skills/visualize-harness/scripts/scope-graphs.mjs
@@ -1,0 +1,132 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+const scopes = new Set(['root', 'engine', 'canvas-workspace']);
+
+function countFiles(relativePath, predicate = () => true) {
+  const directory = path.join(repoRoot, relativePath);
+  let count = 0;
+  const visit = (current) => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const child = path.join(current, entry.name);
+      if (entry.isDirectory()) visit(child);
+      else if (predicate(entry.name)) count += 1;
+    }
+  };
+  visit(directory);
+  return count;
+}
+
+function countDirectories(relativePath) {
+  return fs.readdirSync(path.join(repoRoot, relativePath), { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .length;
+}
+
+function scopeData(locale, english, chinese) {
+  return locale === 'zh' ? chinese : english;
+}
+
+function branch(id, locale, english, chinese) {
+  return { id, ...scopeData(locale, english, chinese) };
+}
+
+function rootGraph(locale) {
+  const workspaceCount = countDirectories('packages') + 3;
+  const validationCount = workspaceCount;
+  return {
+    title: scopeData(locale, 'Repository Harness Reading Graph', '仓库 Harness 阅读图'),
+    subtitle: scopeData(locale, 'Routes from root rules to workspace-owned evidence.', '从根规则通向各工作区证据的阅读路径。'),
+    scope: 'root',
+    metrics: [
+      { value: String(workspaceCount), label: scopeData(locale, 'active workspaces', '活跃工作区') },
+      { value: String(validationCount), label: scopeData(locale, 'validation definitions', '校验定义') },
+      { value: String(countFiles('harness/skills', (name) => name === 'SKILL.md')), label: scopeData(locale, 'root harness skills', '根 Harness 技能') },
+      { value: '5', label: scopeData(locale, 'harness surfaces', 'Harness 表面') },
+    ],
+    entryNodes: scopeData(locale,
+      [{ title: 'AGENTS.md', detail: 'Repository-wide routing, constraints, and acceptance.' }, { title: 'harness/README.md', detail: 'Progressive route into the owning workspace.' }],
+      [{ title: 'AGENTS.md', detail: '仓库级路由、约束与验收标准。' }, { title: 'harness/README.md', detail: '渐进式进入实际拥有该任务的工作区。' }]),
+    branches: [
+      branch('workspace-change', locale,
+        { label: 'Change a workspace', intent: ['Find the owning package or app', 'Use local validation first'], sources: ['pnpm-workspace.yaml', '<workspace>/AGENTS.md', '<workspace>/harness/validate/validation.yaml'], reads: ['Workspace membership is owned by pnpm-workspace.yaml', 'Local contracts and commands belong to the workspace'], evidence: ['Run node scripts/harness/run-harness-check.mjs', 'Report commands actually run'], level: 4 },
+        { label: '修改某个工作区', intent: ['定位拥有该功能的包或应用', '优先使用本地校验'], sources: ['pnpm-workspace.yaml', '<workspace>/AGENTS.md', '<workspace>/harness/validate/validation.yaml'], reads: ['pnpm-workspace.yaml 是工作区成员的唯一来源', '局部契约和命令由工作区拥有'], evidence: ['运行 node scripts/harness/run-harness-check.mjs', '仅报告实际执行的命令'], level: 4 }),
+      branch('cross-workspace-contract', locale,
+        { label: 'Change a shared contract', intent: ['Identify downstream consumers', 'Apply root impact escalation'], sources: ['harness/validate/validation.yaml', 'packages/engine/harness/knowledge/contracts.md', 'consumer AGENTS.md files'], reads: ['Root owns cross-workspace impact rules', 'Consumer checks supplement local validation'], evidence: ['Runner prints reminder-only escalation rules', 'Run affected consumer checks deliberately'], level: 4 },
+        { label: '修改跨工作区契约', intent: ['识别下游消费者', '应用根级影响升级规则'], sources: ['harness/validate/validation.yaml', 'packages/engine/harness/knowledge/contracts.md', '消费者 AGENTS.md 文件'], reads: ['根目录拥有跨工作区影响规则', '消费者检查补充本地校验'], evidence: ['Runner 会输出仅提醒的升级规则', '有意识地运行受影响消费者检查'], level: 4 }),
+    ],
+  };
+}
+
+function engineGraph(locale) {
+  return {
+    title: scopeData(locale, 'Engine Harness Reading Graph', 'Engine Harness 阅读图'),
+    subtitle: scopeData(locale, 'Routes for the reusable Pulse Coder runtime.', '可复用 Pulse Coder 运行时的阅读路径。'),
+    scope: 'packages/engine',
+    metrics: [
+      { value: String(countDirectories('packages/engine/src/built-in')), label: scopeData(locale, 'built-in plugin directories', '内置插件目录') },
+      { value: String(countFiles('packages/engine/src/tools', (name) => name.endsWith('.ts'))), label: scopeData(locale, 'tool source files', '工具源码文件') },
+      { value: String(countFiles('packages/engine/harness/knowledge', (name) => name.endsWith('.md'))), label: scopeData(locale, 'knowledge documents', '知识文档') },
+      { value: '2', label: scopeData(locale, 'public barrels', '公开导出桶') },
+    ],
+    entryNodes: scopeData(locale,
+      [{ title: 'AGENTS.md', detail: 'Root constraints and cross-consumer impact.' }, { title: 'packages/engine/AGENTS.md', detail: 'Engine contracts, extension points, and checks.' }],
+      [{ title: 'AGENTS.md', detail: '根级约束与跨消费者影响。' }, { title: 'packages/engine/AGENTS.md', detail: 'Engine 契约、扩展点与检查。' }]),
+    branches: [
+      branch('public-api', locale,
+        { label: 'Change a public API', intent: ['Protect both public barrels', 'Check downstream consumers'], sources: ['harness/knowledge/contracts.md', 'src/index.ts', 'src/built-in/index.ts'], reads: ['The public API has two export barrels', 'CLI, remote server, canvas, ACP, and plugins consume Engine contracts'], evidence: ['Build Engine', 'Apply root enginePublicApiChange escalation'], level: 4 },
+        { label: '修改公开 API', intent: ['保护两个公开导出桶', '检查下游消费者'], sources: ['harness/knowledge/contracts.md', 'src/index.ts', 'src/built-in/index.ts'], reads: ['公开 API 有两个导出桶', 'CLI、远程服务、Canvas、ACP 与插件消费 Engine 契约'], evidence: ['构建 Engine', '应用根级 enginePublicApiChange 升级规则'], level: 4 }),
+      branch('tool-or-plugin', locale,
+        { label: 'Add a tool or built-in plugin', intent: ['Use extension points before core-loop edits', 'Preserve merge and loading order'], sources: ['harness/knowledge/tools-reference.md', 'harness/knowledge/plugin-system.md', 'src/tools/index.ts', 'src/built-in/index.ts'], reads: ['Tools must be non-blocking and shell-safe', 'Hosts can disable default plugins and assemble their own list'], evidence: ['Run focused tests', 'Run describe-engine after a build'], level: 4 },
+        { label: '新增工具或内置插件', intent: ['先使用扩展点，后考虑修改核心循环', '保持合并与加载顺序'], sources: ['harness/knowledge/tools-reference.md', 'harness/knowledge/plugin-system.md', 'src/tools/index.ts', 'src/built-in/index.ts'], reads: ['工具必须非阻塞且 Shell 安全', '宿主可禁用默认插件并自组装列表'], evidence: ['运行聚焦测试', '构建后运行 describe-engine'], level: 4 }),
+    ],
+  };
+}
+
+function canvasGraph(locale) {
+  return {
+    title: scopeData(locale, 'Pulse Canvas Harness Reading Graph', 'Pulse Canvas Harness 阅读图'),
+    subtitle: scopeData(locale, 'Routes for the Electron workbench and its privileged host boundaries.', 'Electron 工作台及其特权宿主边界的阅读路径。'),
+    scope: 'apps/canvas-workspace',
+    metrics: [
+      { value: String(countFiles('apps/canvas-workspace/harness/knowledge', (name) => name.endsWith('.md'))), label: scopeData(locale, 'knowledge documents', '知识文档') },
+      { value: String(countFiles('apps/canvas-workspace/harness/skills', (name) => name === 'SKILL.md')), label: scopeData(locale, 'local action skills', '本地操作技能') },
+      { value: String(countFiles('apps/canvas-workspace/src/main/__tests__', (name) => name.endsWith('.test.ts'))), label: scopeData(locale, 'main-process test files', '主进程测试文件') },
+      { value: '4', label: scopeData(locale, 'process surfaces', '进程表面') },
+    ],
+    entryNodes: scopeData(locale,
+      [{ title: 'AGENTS.md', detail: 'Root boundaries and validation routing.' }, { title: 'apps/canvas-workspace/AGENTS.md', detail: 'Electron app owner, knowledge, tools, and local checks.' }],
+      [{ title: 'AGENTS.md', detail: '根级边界与校验路由。' }, { title: 'apps/canvas-workspace/AGENTS.md', detail: 'Electron 应用所有者、知识、工具与本地检查。' }]),
+    branches: [
+      branch('cross-process-boundary', locale,
+        { label: 'Change a cross-process API', intent: ['Keep renderer privileges constrained', 'Preserve IPC and preload contracts'], sources: ['harness/knowledge/conventions/architecture-boundaries.md', 'src/preload/index.ts', 'src/shared/', 'src/main/__tests__/import-boundaries.test.ts'], reads: ['Renderer reaches privilege only through window.canvasWorkspace', 'Shared contracts stay runtime-neutral'], evidence: ['Run typecheck', 'Run import-boundary and app tests'], level: 4 },
+        { label: '修改跨进程 API', intent: ['限制渲染进程权限', '保持 IPC 与 preload 契约'], sources: ['harness/knowledge/conventions/architecture-boundaries.md', 'src/preload/index.ts', 'src/shared/', 'src/main/__tests__/import-boundaries.test.ts'], reads: ['渲染进程只能经由 window.canvasWorkspace 获取特权能力', '共享契约保持运行时中立'], evidence: ['运行 typecheck', '运行导入边界与应用测试'], level: 4 }),
+      branch('canvas-node-extension', locale,
+        { label: 'Add a canvas node capability', intent: ['Choose plugin versus host node path', 'Keep node contracts synchronized'], sources: ['harness/skills/add-canvas-node/SKILL.md', 'harness/knowledge/plugin-node-mf2.md', 'src/shared/canvas.ts', 'src/renderer/src/utils/nodeFactory.ts'], reads: ['Plugin nodes are the default extension path', 'Host node types are reserved for deeper main-process integration'], evidence: ['Run node harness/tools/describe-canvas.mjs', 'Run typecheck and test'], level: 4 },
+        { label: '新增 Canvas 节点能力', intent: ['选择插件或宿主节点路径', '保持节点契约同步'], sources: ['harness/skills/add-canvas-node/SKILL.md', 'harness/knowledge/plugin-node-mf2.md', 'src/shared/canvas.ts', 'src/renderer/src/utils/nodeFactory.ts'], reads: ['插件节点是默认扩展路径', '宿主节点类型仅用于更深的主进程集成'], evidence: ['运行 node harness/tools/describe-canvas.mjs', '运行 typecheck 与 test'], level: 4 }),
+      branch('agent-tool-or-security-change', locale,
+        { label: 'Change Agent tools or execution reach', intent: ['Assess privilege expansion', 'Treat web and disk input as untrusted'], sources: ['harness/knowledge/security-posture.md', 'src/main/agent/canvas-agent.ts', 'src/main/agent/tools/'], reads: ['Agent tools run with desktop-user main-process privileges', 'There is no human approval gate around tool calls'], evidence: ['Review security posture', 'Run focused tests; do not infer sandbox coverage'], level: 4 },
+        { label: '修改 Agent 工具或执行范围', intent: ['评估权限扩大', '将网页和磁盘输入视为不可信'], sources: ['harness/knowledge/security-posture.md', 'src/main/agent/canvas-agent.ts', 'src/main/agent/tools/'], reads: ['Agent 工具以桌面用户主进程权限运行', '工具调用没有人工审批门'], evidence: ['审阅安全态势', '运行聚焦测试；不要推断存在沙箱保护'], level: 4 }),
+    ],
+  };
+}
+
+export function createScopeGraph(scope, locale = 'en') {
+  if (!scopes.has(scope)) throw new Error(`Unknown scope: ${scope}. Use root, engine, or canvas-workspace.`);
+  if (!['en', 'zh'].includes(locale)) throw new Error(`Unknown locale: ${locale}. Use en or zh.`);
+  const graph = scope === 'root' ? rootGraph(locale) : scope === 'engine' ? engineGraph(locale) : canvasGraph(locale);
+  return {
+    ...graph,
+    locale,
+    evidenceLevels: scopeData(locale,
+      [{ title: 'Entry', detail: 'Routing rules' }, { title: 'Knowledge', detail: 'Current constraints' }, { title: 'Source', detail: 'Implementation and contracts' }, { title: 'Checks', detail: 'Static, test, and runtime evidence' }],
+      [{ title: '入口', detail: '路由规则' }, { title: '知识', detail: '当前约束' }, { title: '源码', detail: '实现与契约' }, { title: '检查', detail: '静态、测试与运行时证据' }]),
+    boundary: scopeData(locale, 'This graph uses repository files only. It does not read secrets, user data, or claim unrun checks passed.', '此图仅使用仓库文件，不读取密钥或用户数据，也不会声称未运行的检查已通过。'),
+  };
+}
+
+export function createAllScopeGraphs(locale = 'en') {
+  return ['root', 'engine', 'canvas-workspace'].map((scope) => createScopeGraph(scope, locale));
+}

--- a/harness/validate/README.md
+++ b/harness/validate/README.md
@@ -13,9 +13,9 @@ This directory is an index plus optional root impact rules. Package-level valida
 | Acceptance standards, reproducible commands | Root `AGENTS.md` §5 |
 | Named failure captures and their guards | Root `AGENTS.md` §6 |
 | Manual runner | `scripts/harness/run-harness-check.mjs` |
-| Honest gap: no automatic trigger (CI/hooks), no mechanical checks | Root `AGENTS.md` §4 ("Gap to close") + `harness/ROADMAP.md` |
-| Candidate mechanical checks | Future checks protocol once the rules are stable enough to mechanize |
-| Runner phases remaining (mechanical checks, opt-in pre-push, CI) | `harness/ROADMAP.md` |
+| Honest gap: no automatic trigger (CI/hooks), no semantic contradiction/test-effectiveness checks | Root `AGENTS.md` §4 ("Gap to close") + `harness/ROADMAP.md` |
+| Structural mechanical checks | `scripts/harness/check-harness.mjs` |
+| Runner phases remaining (opt-in pre-push, CI) | `harness/ROADMAP.md` |
 
 ## Honest reality
 

--- a/harness/validate/validation.yaml
+++ b/harness/validate/validation.yaml
@@ -14,6 +14,12 @@ pathRules:
     required:
       - node scripts/harness/check-harness.mjs
 
+  - name: harness-visualizer
+    paths:
+      - harness/skills/visualize-harness/**
+    required:
+      - pnpm exec vitest run harness/skills/visualize-harness/scripts/render-harness-graph.test.mjs
+
   - name: root-workspace-config
     paths:
       - package.json


### PR DESCRIPTION
## Summary

- add a repository harness visualization skill that renders standalone interactive HTML reading graphs
- add built-in scans for the repository root, Engine, and Canvas Workspace, including an `all` view with scope tabs
- add in-page English/Chinese switching, preserve the active scope while switching languages, and bind renderer tests to harness validation

## Why

Maintainers need a concise, evidence-backed way to navigate harness rules without manually reconstructing routes across root and workspace documents.

## Validation

- `pnpm exec vitest run harness/skills/visualize-harness/scripts/render-harness-graph.test.mjs`
- `node scripts/harness/run-harness-check.mjs`
