### PR TITLE
fix(canvas-workspace): remove dead default export from MigrationSpinner

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;


### PR DESCRIPTION
## Summary

Scanned `apps/canvas-workspace` for UI style-guide inconsistencies against `harness/knowledge/conventions/frontend.md` and the mechanically-enforced ratchet in `src/main/__tests__/ui-reuse-governance.test.ts`.

- `MigrationSpinner/index.tsx:255` had a redundant `export default MigrationSpinner;` sitting alongside the already-compliant `export const MigrationSpinner = (): JSX.Element | null => { ... }`. frontend.md requires named arrow-function component exports, not `default`. The default export had **zero importers** (confirmed via grep — `App.tsx` imports `{ MigrationSpinner }` only) — pure dead code. Removed it.

## Why no broader sweep

This codebase already runs a strict, deliberate ratchet system (`ui-reuse-governance.test.ts`, exact-match counters) for exactly the categories a naive style sweep would target: hardcoded color/border-radius/shadow literals, raw `<button>`/`<input>`/`<textarea>` tags, bespoke dropdown/popover shells, tablist/radiogroup roles, and section/field CSS clusters. Its own comments explicitly record several of these as **frozen stock** ("not a sweep, per the deliverable's explicit scope limit") — reducing them requires updating `RATCHET_BASELINE` in the same PR as a deliberate migration decision, not a blind fix-it pass.

Two other candidate categories were surveyed and found to be large, pre-existing, systemic backlogs rather than isolated bugs — not appropriate for an automated cleanup PR:
- **`Props` interface naming** (frontend.md says local prop types should be named `Props`): 90/~172 component files use `FooProps` instead — this is the dominant style, not an outlier.
- **Hardcoded user-facing strings** (frontend.md: "No hardcoded user-facing strings... use `useI18n()`"): only 93/~172 component files even import `useI18n`; several whole files (e.g. `AgentTeamFrame/index.tsx`, `IframeNodeBody/IframeEditor.tsx`) have zero i18n usage.

Both would need a deliberate, scoped migration (like the existing UI-reuse effort) rather than an ad hoc style-inconsistency PR.

**Note:** while verifying, `pnpm --filter canvas-workspace test` on `master` already fails 7 pre-existing tests unrelated to this change (`ui-reuse-governance` ratchet counters `rawButtonTags`/`rawTextareaTags`/`borderRadiusLiterals`/`hardcodedColorLiterals`/`shadowLiterals` have drifted above their baselines, plus one `file-size-governance` and one `import-boundaries` failure). Confirmed via `git stash` that all of these predate this change. Flagging in case it's useful, but left out of scope here since fixing them means either a real code migration or a deliberate baseline update — not part of this style-inconsistency task.

## Test plan

- [x] `pnpm --filter canvas-workspace typecheck` — passes (only a pre-existing, unrelated `tsconfig.node.json` deprecation warning remains)
- [x] Confirmed `MigrationSpinner`'s default export has no importers (grep across `src/`)
- [x] `ui-reuse-governance.test.ts` — this change doesn't touch any ratchet-counted pattern (default exports aren't counted); pre-existing failures on `master` reproduced identically before and after this change

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01H74yv2rDMneoAVJhXEaFAp

---
_Generated by [Claude Code](https://claude.ai/code/session_01H74yv2rDMneoAVJhXEaFAp)_