### PR TITLE
test(canvas): verify WebView input focus routing

### DIFF
--- a/apps/canvas-workspace/harness/tools/driver/README.md
+++ b/apps/canvas-workspace/harness/tools/driver/README.md
@@ -105,6 +105,7 @@ pnpm --filter canvas-workspace harness click --text "Settings"
 pnpm --filter canvas-workspace harness click --selector ".some-css-selector"
 pnpm --filter canvas-workspace harness fill --selector "input[name=q]" "hello"
 pnpm --filter canvas-workspace harness press "Meta+K"
+pnpm --filter canvas-workspace harness verify-webview-input-focus --json
 pnpm --filter canvas-workspace harness eval-renderer "location.href"
 pnpm --filter canvas-workspace harness logs
 pnpm --filter canvas-workspace harness close
@@ -146,8 +147,13 @@ produce an image. It supports:
 - log tailing
 - temp/demo/clone/real profiles
 
-Future layers can add app-specific state IPC, webview-node CDP commands,
-fixture web servers, scenario scripts, and CI-friendly smoke runners.
+Future layers can add app-specific state IPC, more guest-WebView scenarios,
+fixture web servers, and CI-friendly smoke runners.
+
+`verify-webview-input-focus` is the first guest-WebView regression scenario.
+With the demo profile it focuses a host renderer input, inserts text into the
+local WebView fixture through CDP, and fails unless the guest receives the text
+while the host remains empty. It does not access the network or real user data.
 
 ## Code Layout
 

--- a/apps/canvas-workspace/harness/tools/driver/src/__tests__/cdp.test.mjs
+++ b/apps/canvas-workspace/harness/tools/driver/src/__tests__/cdp.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { CdpClient } from '../cdp.mjs';
+import { CdpClient, getTargets } from '../cdp.mjs';
 
 describe('CdpClient events', () => {
   it('routes protocol events and supports unsubscribe', () => {
@@ -33,5 +33,16 @@ describe('CdpClient events', () => {
 
     await expect(event).rejects.toThrow('CDP client closed');
     expect(client.listeners.size).toBe(0);
+  });
+});
+
+describe('getTargets', () => {
+  it('returns renderer and guest WebView targets for scenario selection', async () => {
+    const targets = [{ type: 'page', url: 'app://renderer' }, { type: 'webview', url: 'file:///fixture.html' }];
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => targets })));
+
+    await expect(getTargets({ cdpPort: 9222 })).resolves.toEqual(targets);
+
+    vi.unstubAllGlobals();
   });
 });

--- a/apps/canvas-workspace/harness/tools/driver/src/cdp.mjs
+++ b/apps/canvas-workspace/harness/tools/driver/src/cdp.mjs
@@ -142,9 +142,7 @@ export class CdpClient {
 }
 
 export async function getPageTarget(session) {
-  const res = await fetch(`http://127.0.0.1:${session.cdpPort}/json/list`);
-  if (!res.ok) throw new Error(`CDP target list failed: HTTP ${res.status}`);
-  const targets = await res.json();
+  const targets = await getTargets(session);
   const page = targets.find((target) =>
     target.type === 'page' &&
     target.webSocketDebuggerUrl &&
@@ -154,12 +152,29 @@ export async function getPageTarget(session) {
   return page;
 }
 
+export async function getTargets(session) {
+  const res = await fetch(`http://127.0.0.1:${session.cdpPort}/json/list`);
+  if (!res.ok) throw new Error(`CDP target list failed: HTTP ${res.status}`);
+  return res.json();
+}
+
 export async function waitForPageTarget(session, timeoutMs) {
   return waitFor(() => getPageTarget(session), timeoutMs);
 }
 
 export async function withPage(session, fn) {
   const target = await getPageTarget(session);
+  const cdp = new CdpClient(target.webSocketDebuggerUrl);
+  await cdp.connect();
+  try {
+    return await fn(cdp, target);
+  } finally {
+    cdp.close();
+  }
+}
+
+export async function withTarget(target, fn) {
+  if (!target?.webSocketDebuggerUrl) throw new Error('CDP target has no debugger WebSocket URL.');
   const cdp = new CdpClient(target.webSocketDebuggerUrl);
   await cdp.connect();
   try {

--- a/apps/canvas-workspace/harness/tools/driver/src/cli.mjs
+++ b/apps/canvas-workspace/harness/tools/driver/src/cli.mjs
@@ -11,6 +11,7 @@ import {
   pressCommand,
   snapshotUiCommand,
   statusCommand,
+  verifyWebviewInputFocusCommand,
 } from './commands.mjs';
 
 export const HELP = `
@@ -28,6 +29,7 @@ Usage:
   pnpm --filter canvas-workspace harness click --xy <x,y>
   pnpm --filter canvas-workspace harness fill --selector <css> <text>
   pnpm --filter canvas-workspace harness press <key-or-combo>
+  pnpm --filter canvas-workspace harness verify-webview-input-focus [--json]
   pnpm --filter canvas-workspace harness logs [--lines 80]
   pnpm --filter canvas-workspace harness close [--cleanup]
 
@@ -43,6 +45,12 @@ Start options:
   --flag <id>                   enable an experimental flag, repeatable
   --enable-webview-page-control shortcut for --flag webview-page-control
   --json                        print machine-readable output
+
+WebView focus verification options:
+  --host-selector <css>         focused host input (default: layer search)
+  --guest-selector <css>        guest input (default: #guest-input)
+  --target <url-or-title-part>  guest target match (default: webview-input-fixture)
+  --text <value>                inserted sentinel text
 `;
 
 export async function main(args) {
@@ -82,6 +90,9 @@ export async function main(args) {
         break;
       case 'press':
         await pressCommand(rawArgs);
+        break;
+      case 'verify-webview-input-focus':
+        await verifyWebviewInputFocusCommand(rawArgs);
         break;
       case 'logs':
         await logsCommand(rawArgs);

--- a/apps/canvas-workspace/harness/tools/driver/src/commands.mjs
+++ b/apps/canvas-workspace/harness/tools/driver/src/commands.mjs
@@ -1,6 +1,6 @@
 import { promises as fs } from 'node:fs';
 import { parseArgs } from './args.mjs';
-import { getPageTarget, withPage } from './cdp.mjs';
+import { getPageTarget, getTargets, withPage, withTarget } from './cdp.mjs';
 import { HarnessError } from './errors.mjs';
 import { assertPoint, parseKeyCombo } from './input.mjs';
 import { onboardHashRoute, openOnboard } from './navigation.mjs';
@@ -152,4 +152,65 @@ export async function resetArtifactsCommand(rawArgs) {
   const session = await requireSession();
   await fs.rm(session.artifactsDir, { recursive: true, force: true });
   printResult(opts.json, { removed: session.artifactsDir }, [`Removed artifacts: ${session.artifactsDir}`]);
+}
+
+function targetMatches(target, needle) {
+  const value = String(needle ?? '').toLowerCase();
+  return String(target.url ?? '').toLowerCase().includes(value)
+    || String(target.title ?? '').toLowerCase().includes(value);
+}
+
+export async function verifyWebviewInputFocusCommand(rawArgs) {
+  const { opts } = parseArgs(rawArgs);
+  const session = await requireLiveSession();
+  const hostSelector = opts['host-selector'] ?? '.sidebar-layer-search-input';
+  const guestSelector = opts['guest-selector'] ?? '#guest-input';
+  const targetNeedle = opts.target ?? 'webview-input-fixture';
+  const text = opts.text ?? 'webview-focus-check';
+
+  const hostBefore = await evaluateRenderer(session, `(${focusAndClearExpression})(${JSON.stringify(hostSelector)})`);
+  if (!hostBefore?.ok) throw new HarnessError(hostBefore?.error ?? `Could not focus host input ${hostSelector}`);
+
+  const targets = await getTargets(session);
+  const guest = targets.find((target) => target.webSocketDebuggerUrl && targetMatches(target, targetNeedle));
+  if (!guest) throw new HarnessError(`No guest WebView target matching ${JSON.stringify(targetNeedle)}.`);
+
+  // Mirror the product's `webContents.focus()` guard by focusing the owning
+  // <webview> element from the host renderer. Page.bringToFront (and even
+  // Target.activateTarget) alone does not transfer Chromium's input route.
+  const webviewFocused = await evaluateRenderer(session, `(() => {
+    const needle = ${JSON.stringify(targetNeedle)}.toLowerCase();
+    const el = Array.from(document.querySelectorAll('webview')).find((candidate) =>
+      String(candidate.getURL?.() || candidate.src || '').toLowerCase().includes(needle));
+    if (!el) return false;
+    el.focus();
+    return true;
+  })()`);
+  if (!webviewFocused) throw new HarnessError(`No host <webview> element matching ${JSON.stringify(targetNeedle)}.`);
+
+  const guestValue = await withTarget(guest, async (cdp) => {
+    await cdp.send('Page.bringToFront');
+    const prepared = await cdp.send('Runtime.evaluate', {
+      expression: `(${focusAndClearExpression})(${JSON.stringify(guestSelector)})`,
+      returnByValue: true,
+      awaitPromise: true,
+    });
+    if (!prepared?.result?.value?.ok) {
+      throw new HarnessError(prepared?.result?.value?.error ?? `Could not focus guest input ${guestSelector}`);
+    }
+    await cdp.send('Input.insertText', { text });
+    const value = await cdp.send('Runtime.evaluate', {
+      expression: `document.querySelector(${JSON.stringify(guestSelector)})?.value ?? null`,
+      returnByValue: true,
+    });
+    return value?.result?.value;
+  });
+
+  const hostValue = await evaluateRenderer(session,
+    `(() => { const el = document.querySelector(${JSON.stringify(hostSelector)}); return el?.value ?? el?.textContent ?? null; })()`);
+  const result = { ok: guestValue === text && !hostValue, guestValue, hostValue, target: guest.url };
+  if (!result.ok) {
+    throw new HarnessError(`WebView input focus leaked: ${JSON.stringify(result)}`);
+  }
+  printResult(opts.json, result, ['WebView input stayed in the guest target; host input remained empty.']);
 }

--- a/apps/canvas-workspace/harness/tools/driver/src/profiles.mjs
+++ b/apps/canvas-workspace/harness/tools/driver/src/profiles.mjs
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs';
 import { promises as fs } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { HARNESS_DIR, STORE_RELATIVE_DIR } from './config.mjs';
 import { HarnessError } from './errors.mjs';
 
@@ -65,6 +66,14 @@ async function seedDemoHome(home) {
     '- Use clone or real profiles when a specific workspace is needed.',
   ].join('\n');
   await fs.writeFile(notePath, noteContent, 'utf8');
+  const webviewFixturePath = join(workspaceDir, 'webview-input-fixture.html');
+  await fs.writeFile(webviewFixturePath, [
+    '<!doctype html>',
+    '<meta charset="utf-8">',
+    '<title>Harness WebView Input Fixture</title>',
+    '<label for="guest-input">Guest input</label>',
+    '<input id="guest-input" autocomplete="off">',
+  ].join('\n'), 'utf8');
   await fs.writeFile(join(storeDir, '__workspaces__.json'), JSON.stringify({
     workspaces: [{ id: workspaceId, name: 'Harness Demo' }],
     folders: [],
@@ -99,12 +108,12 @@ async function seedDemoHome(home) {
       {
         id: 'node-harness-web',
         type: 'iframe',
-        title: 'Example Webview',
+        title: 'WebView Input Fixture',
         x: 680,
         y: 150,
         width: 560,
         height: 320,
-        data: { url: 'https://example.com', html: '', mode: 'url', prompt: '' },
+        data: { url: pathToFileURL(webviewFixturePath).href, html: '', mode: 'url', prompt: '' },
         updatedAt: now,
       },
     ],

--- a/apps/canvas-workspace/harness/validate/validation.yaml
+++ b/apps/canvas-workspace/harness/validate/validation.yaml
@@ -21,6 +21,10 @@ pathRules:
       - harness/tools/driver/**
     required:
       - pnpm --filter canvas-workspace test
+    manual:
+      - pnpm --filter canvas-workspace harness start --profile demo --reset --force --enable-webview-page-control --json
+      - pnpm --filter canvas-workspace harness verify-webview-input-focus --json
+      - pnpm --filter canvas-workspace harness close --cleanup --json
 
   # Static source-of-truth checks for the app's agent-tool registry, IPC
   # handle/invoke pairs, canvas node union/factory, and storage schema parity.


### PR DESCRIPTION
## What changed

- add CDP discovery and connection support for guest WebView targets
- seed the demo harness profile with a deterministic local input fixture
- add `verify-webview-input-focus` to focus a host control, type into the guest, and assert that input does not leak back to the host
- bind the scenario into the canvas-workspace manual validation instructions

## Why

Web page input could be reported as successful while Chromium routed the text into the host Canvas chat composer. Unit tests confirmed that focus methods were called, but did not reproduce the real Electron host/guest focus boundary.

The new scenario provides a network-independent regression check for that boundary. During verification it also confirmed that `Page.bringToFront` alone is insufficient; the owning WebView must receive focus, matching the product's `webContents.focus()` guard.

## Validation

- `pnpm --filter canvas-workspace exec vitest run harness/tools/driver/src/__tests__`
- `node scripts/harness/check-harness.mjs` (`harnessGaps: 0`)
- real Electron demo run: guest value `webview-focus-check`, host value empty
