### PR TITLE
fix(canvas): drop redundant default export from MigrationSpinner

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;


### PR DESCRIPTION
## Summary

Scanned `apps/canvas-workspace` for UI style inconsistencies against the workspace's documented conventions (`harness/knowledge/conventions/frontend.md`) and its mechanized ratchet (`src/main/__tests__/ui-reuse-governance.test.ts` — 18/18 passing; colors, radii, shadows, z-index, and component-reuse counters are all exactly at baseline, no drift found there).

Manually auditing the one convention the ratchet doesn't mechanize — "Export named arrow-function components... Avoid `default` exports for components" — turned up a single violation:

- **`src/renderer/src/components/MigrationSpinner/index.tsx`**: the component already declares `export const MigrationSpinner = (...)` (correct, matches every other component in the tree), but also carried a trailing `export default MigrationSpinner;`. This is the only `export default` anywhere in `src/renderer/src/components/**` (verified via full-tree grep). Its sole consumer, `App.tsx`, already uses the named import (`import { MigrationSpinner } from './components/MigrationSpinner'`), so the default export was dead and inconsistent with the rest of the codebase.

**Fix**: removed the redundant `export default` line. No behavior change — verified no file imports the default export.

No other style inconsistencies (spacing, color usage, naming, component structure) were found beyond what the existing ratchet already tracks and holds at zero net growth.

## Test plan

- [x] `npx vitest run src/main/__tests__/ui-reuse-governance.test.ts src/main/__tests__/file-size-governance.test.ts` — 20/20 passing after the change
- [x] Confirmed via grep that no file imports `MigrationSpinner` as a default export

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vTMxRAqyBUjJ1zS2L44Wk

---
_Generated by [Claude Code](https://claude.ai/code/session_011vTMxRAqyBUjJ1zS2L44Wk)_