### PR TITLE
release(canvas): 0.1.15

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.14",
+  "version": "0.1.15",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {

--- a/apps/canvas-workspace/scripts/perf/package-report.mjs
+++ b/apps/canvas-workspace/scripts/perf/package-report.mjs
@@ -7,8 +7,9 @@ import { evaluatePackageGates } from './package-gates.mjs';
 
 const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const releaseDir = join(appRoot, 'release');
+const packageJson = JSON.parse(readFileSync(join(appRoot, 'package.json'), 'utf-8'));
 const appPath = join(releaseDir, 'mac-arm64/Pulse Canvas.app');
-const dmgPath = join(releaseDir, 'Pulse Canvas-0.1.14-arm64.dmg');
+const dmgPath = join(releaseDir, `Pulse Canvas-${packageJson.version}-arm64.dmg`);
 const resourcesPath = join(appPath, 'Contents/Resources');
 const asarPath = join(resourcesPath, 'app.asar');
 const unpackedPath = join(resourcesPath, 'app.asar.unpacked');


### PR DESCRIPTION
## Summary
- bump Pulse Canvas to 0.1.15
- published macOS arm64 DMG, blockmap, and latest.json to R2
- deployed the download page

## Release notes
ZH: 重做 Nodes 知识工作流，新增节点卡片、筛选、详情页与关系编辑；Pulse AI 侧边栏现在可在工作台全局使用；嵌入网页节点新增浏览导航；优化欢迎页启动、画布交互、聊天流式输出和文件预览体验。

EN: Rebuilt the Nodes knowledge workflow with node cards, filters, detail pages, and relationship editing; made the Pulse AI sidebar available globally in the workbench; added browser navigation for embedded web nodes; improved welcome startup, canvas interactions, streaming chat, and file previews.

## Verification
- node ~/.codex/skills/pulse-canvas-release/scripts/release-pulse-canvas.mjs --version 0.1.15 ...
- pnpm package:mac:arm64 (run by release script)
- uploaded https://downloads.jasperhu.art/pulse-canvas/stable/latest.json
- deployed https://pulse-canvas-download.pages.dev/