### PR TITLE
Improve session reference titles

### DIFF
--- a/apps/canvas-workspace/src/main/agent/__tests__/session-preview.test.ts
+++ b/apps/canvas-workspace/src/main/agent/__tests__/session-preview.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { sessionPreview } from '../session-preview';
+
+describe('sessionPreview', () => {
+  it('preserves a complete leading DOM marker while truncating only the prose', () => {
+    const marker = '@[dom:dom-mqfcp3zq-16g73y|span%3A%203%20items]';
+
+    expect(sessionPreview(`${marker} 这块区域描述了啥，并说明其中的交互`, 8))
+      .toBe(`${marker} 这块区域描述了啥`);
+  });
+});

--- a/apps/canvas-workspace/src/main/agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/agent/canvas-agent.ts
@@ -20,6 +20,7 @@ import {
 } from './context-builder';
 import { createCanvasAgentToolPolicy } from './tool-policy';
 import { SessionStore } from './session-store';
+import { sessionPreview } from './session-preview';
 import { formatPromptProfileForSystem, getPromptProfile } from './prompt-profile';
 import { readWorkspaceDoc, readWorkspaceMeta, WORKSPACE_DOC_FILENAME } from './workspace-meta';
 import { createCanvasMcpOAuthProvider } from './mcp/oauth';
@@ -1041,7 +1042,7 @@ export class CanvasAgent {
         date: current.startedAt.slice(0, 10),
         messageCount: current.messages.length,
         isCurrent: true,
-        preview: firstUserMsg ? firstUserMsg.content.slice(0, 50) : '',
+        preview: firstUserMsg ? sessionPreview(firstUserMsg.content) : '',
       });
     }
 

--- a/apps/canvas-workspace/src/main/agent/service.ts
+++ b/apps/canvas-workspace/src/main/agent/service.ts
@@ -12,6 +12,7 @@ import { homedir } from 'os';
 import { CanvasAgent, type CanvasClarificationRequest } from './canvas-agent';
 import type { MCPServerStatus } from 'pulse-coder-engine/built-in';
 import { GLOBAL_CHAT_SESSION_STORE_ID, GLOBAL_CHAT_WORKSPACE_NAME, SessionStore } from './session-store';
+import { sessionPreview } from './session-preview';
 import type {
   AgentRequestContext,
   AgentScope,
@@ -372,7 +373,7 @@ export class CanvasAgentService {
         date: session.startedAt?.slice(0, 10) ?? '',
         isCurrent: entry.isCurrent,
         messageCount: session.messages.length,
-        preview: title.slice(0, 60),
+        preview: sessionPreview(title, 60),
       });
       if (hits.length >= limit) break;
     }

--- a/apps/canvas-workspace/src/main/agent/session-preview.ts
+++ b/apps/canvas-workspace/src/main/agent/session-preview.ts
@@ -1,0 +1,13 @@
+const LEADING_MENTION_RE = /^\s*(@\[((?:[^\]]|\](?=\]))+)\])/;
+
+/**
+ * Keep a leading composer marker intact so the renderer can turn it into a
+ * reference chip. Only the prose after it is length-limited for list density.
+ */
+export function sessionPreview(content: string, proseMaxLength = 50): string {
+  const leadingMention = content.match(LEADING_MENTION_RE);
+  if (!leadingMention) return content.slice(0, proseMaxLength);
+
+  const prose = content.slice(leadingMention[0].length).trimStart();
+  return `${leadingMention[1]}${prose ? ` ${prose.slice(0, proseMaxLength)}` : ''}`;
+}

--- a/apps/canvas-workspace/src/main/agent/session-store.ts
+++ b/apps/canvas-workspace/src/main/agent/session-store.ts
@@ -20,7 +20,7 @@ import type {
   CanvasAgentMessage,
   CanvasAgentSession,
 } from './types';
-
+import { sessionPreview } from './session-preview';
 // Read lazily (not a module-level const derived at import time) so tests can
 // point it at an isolated tmpdir via the env var without needing vi.mock.
 const storeDir = (): string =>
@@ -178,7 +178,7 @@ export class SessionStore {
             sessionId: data.sessionId,
             date: data.startedAt?.slice(0, 10) || file.replace('.json', '').slice(0, 10),
             messageCount: data.messages.length,
-            preview: firstUserMsg ? firstUserMsg.content.slice(0, 50) : '',
+            preview: firstUserMsg ? sessionPreview(firstUserMsg.content) : '',
             sortKey,
           };
           const existing = sessionsById.get(data.sessionId);
@@ -321,7 +321,7 @@ export class SessionStore {
             sessionId: data.sessionId,
             date: data.startedAt?.slice(0, 10) || '',
             messageCount: data.messages.length,
-            preview: firstUserMsg ? firstUserMsg.content.slice(0, 50) : '',
+            preview: firstUserMsg ? sessionPreview(firstUserMsg.content) : '',
             isCurrent: true,
           });
         }
@@ -352,7 +352,7 @@ export class SessionStore {
               sessionId: data.sessionId,
               date: data.startedAt?.slice(0, 10) || file.replace('.json', '').slice(0, 10),
               messageCount: data.messages.length,
-              preview: firstUserMsg ? firstUserMsg.content.slice(0, 50) : '',
+              preview: firstUserMsg ? sessionPreview(firstUserMsg.content) : '',
               isCurrent: false,
               sortKey,
             };

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatHeader.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatHeader.tsx
@@ -3,9 +3,10 @@ import { CloseIcon, ListLinesIcon, PlusIcon, SettingsIcon, SparklesIcon, Spinner
 import type { OtherWorkspaceSession } from './types';
 import { useI18n } from '../../i18n';
 import { useMenuKeyboardNav } from '../../hooks/useMenuKeyboardNav';
+import { SessionTitle } from './SessionTitle';
 
 interface ChatHeaderProps {
-  title: string;
+  title: ReactNode;
   sessionMenuOpen: boolean;
   sessionMenuRef: RefObject<HTMLDivElement>;
   /** True while the session list is being (re)fetched. */
@@ -146,7 +147,9 @@ export const ChatHeader = ({
                     >
                       <ListLinesIcon size={14} />
                       <span className="chat-session-menu-item-text">
-                        {session.preview || (session.isCurrent ? t('chat.currentChat') : session.date)}
+                        {session.preview
+                          ? <SessionTitle value={session.preview} />
+                          : (session.isCurrent ? t('chat.currentChat') : session.date)}
                       </span>
                       <span className="chat-session-menu-item-count">{session.messageCount}</span>
                     </button>
@@ -169,7 +172,7 @@ export const ChatHeader = ({
                     >
                       <ListLinesIcon size={14} />
                       <span className="chat-session-menu-item-text">
-                        {session.preview || session.date}
+                        {session.preview ? <SessionTitle value={session.preview} /> : session.date}
                       </span>
                       <span className="chat-session-menu-item-ws">{session.workspaceName}</span>
                       <span className="chat-session-menu-item-count">{session.messageCount}</span>

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMentionPopup.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMentionPopup.tsx
@@ -3,6 +3,8 @@ import { MENTION_GROUP_LABEL_KEY, getMentionGroupKey } from './constants';
 import type { MentionItem } from './types';
 import { MentionNodeIcon } from './utils/mentions';
 import { useI18n } from '../../i18n';
+import { SessionTitle } from './SessionTitle';
+import { sessionTitleText } from './utils/sessionTitle';
 
 interface ChatMentionPopupProps {
   mentionItems: MentionItem[];
@@ -51,7 +53,8 @@ export const ChatMentionPopup = ({
               <div className="chat-mention-group-header">{t(MENTION_GROUP_LABEL_KEY[groupKey])}</div>
             )}
             <button
-              className={`chat-mention-item${index === mentionIndex ? ' chat-mention-item--active' : ''}`}
+              className={`chat-mention-item${item.type === 'session' ? ' chat-mention-item--session' : ''}${index === mentionIndex ? ' chat-mention-item--active' : ''}`}
+              title={item.type === 'session' && item.description ? `${sessionTitleText(item.label)} · ${item.description}` : undefined}
               onMouseDown={(event) => {
                 event.preventDefault();
                 onSelectMention(item);
@@ -65,7 +68,9 @@ export const ChatMentionPopup = ({
                     : <MentionNodeIcon size={14} nodeType={nodeType} />}
                 </span>
               )}
-              <span className="chat-mention-item-label">{item.label}</span>
+              <span className="chat-mention-item-label">
+                {item.type === 'session' ? <SessionTitle value={item.label} /> : item.label}
+              </span>
               {item.description && (
                 <span className="chat-mention-item-description">{item.description}</span>
               )}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageBody.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageBody.tsx
@@ -6,6 +6,7 @@ import './ChatPage.css';
 import './ChatPanel.css';
 import { ChatAnchors } from './ChatAnchors';
 import { ChatSessionsRail, type UnifiedSession } from './ChatSessionsRail';
+import { sessionTitleText } from './utils/sessionTitle';
 import { ChatView } from './ChatView';
 import { SessionBackBar, type SessionBackEntry } from './SessionBackBar';
 import { useChatComposerState } from './hooks/useChatComposerState';
@@ -248,7 +249,7 @@ export const ChatPageBody = ({
   const currentSessionLabel = useMemo(() => {
     const firstUser = messages.find((m) => m.role === 'user')?.content.trim();
     if (!firstUser) return '';
-    const cleaned = firstUser.replace(/@\[[^\]]+\]/g, '').replace(/\s+/g, ' ').trim();
+    const cleaned = sessionTitleText(firstUser);
     return cleaned.length > 24 ? `${cleaned.slice(0, 23)}…` : cleaned;
   }, [messages]);
 

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
@@ -1867,6 +1867,51 @@
   color: rgba(55, 53, 47, 0.45);
 }
 
+/* Session results lead with the first user message, while workspace and date
+   remain available as compact disambiguating metadata. */
+.chat-mention-item--session .chat-mention-item-label {
+  flex: 2;
+}
+
+.chat-mention-item--session .chat-mention-item-description {
+  flex: 1;
+}
+
+/* Session previews retain structured references, but render them as compact
+   labels instead of leaking their serialized `@[...]` form and internal ids. */
+.chat-session-title {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.chat-session-title-reference {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  min-width: 0;
+  max-width: 132px;
+  padding: 1px 5px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xs);
+  color: var(--text-secondary);
+  background: var(--surface-subtle);
+  flex-shrink: 1;
+  overflow: hidden;
+}
+
+.chat-session-title-reference svg {
+  flex-shrink: 0;
+}
+
+.chat-session-title-reference span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /* ─── @ Mention chips (inline in messages) ──────────────── */
 
 .chat-mention-chip {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEventHa
 import { DOM_MENTION_PREFIX } from './constants';
 import { ChatAnchors } from './ChatAnchors';
 import { ChatHeader } from './ChatHeader';
+import { SessionTitle } from './SessionTitle';
+import { sessionTitleText } from './utils/sessionTitle';
 import './ChatPanel.css';
 import './DomMention.css';
 import { ChatView } from './ChatView';
@@ -223,19 +225,16 @@ export const ChatPanel = ({
 
   requestContextRef.current = requestContext;
 
+  const firstUserMessage = useMemo(() => messages.find(message => message.role === 'user')?.content.trim(), [messages]);
+
   const sessionTitle = useMemo(() => {
-    const firstUserMessage = messages.find(message => message.role === 'user')?.content.trim();
     if (!firstUserMessage) return t('chat.newAiChat');
-    const cleaned = firstUserMessage
-      .replace(/@\[[^\]]+\]/g, '')
-      .replace(/\s+/g, ' ')
-      .trim();
     const fallback = requestContext.scope === 'selected_nodes'
       ? t('chat.quick.organizeSelection')
       : t('chat.quick.analyzeRelations');
-    const title = cleaned || fallback;
+    const title = sessionTitleText(firstUserMessage) || fallback;
     return title.length > 24 ? `${title.slice(0, 23)}…` : title;
-  }, [messages, requestContext.scope, t]);
+  }, [firstUserMessage, requestContext.scope, t]);
 
   // status.apiKeyPresent is the main process's resolved verdict — false means
   // no provider with a key is configured. Treat undefined (still loading) as
@@ -432,7 +431,7 @@ export const ChatPanel = ({
           sessions={sessions}
           sessionsLoading={sessionsLoading}
           otherSessions={otherSessions}
-          title={sessionTitle}
+          title={firstUserMessage ? <SessionTitle value={firstUserMessage} /> : sessionTitle}
           onToggleSessionMenu={openSessionMenu}
           onCloseSessionMenu={closeSessionMenu}
           onNewSession={handleNewSessionFromMenu}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatSessionsRail.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatSessionsRail.tsx
@@ -1,5 +1,7 @@
 import { ListLinesIcon, PlusIcon } from '../icons';
 import { useI18n } from '../../i18n';
+import { SessionTitle } from './SessionTitle';
+import { sessionTitleText } from './utils/sessionTitle';
 
 export interface UnifiedSession {
   sessionId: string;
@@ -51,11 +53,11 @@ export const ChatSessionsRail = ({
                 key={`${session.workspaceId}:${session.sessionId}`}
                 className={`chat-page-rail-item${session.isCurrent ? ' chat-page-rail-item--active' : ''}`}
                 onClick={() => onSelectSession(session)}
-                title={`${session.workspaceName} · ${session.preview || session.date}`}
+                title={`${session.workspaceName} · ${session.preview ? sessionTitleText(session.preview) : session.date}`}
               >
                 <ListLinesIcon size={14} />
                 <span className="chat-page-rail-item-text">
-                  {session.preview || session.date}
+                  {session.preview ? <SessionTitle value={session.preview} /> : session.date}
                 </span>
                 <span className="chat-page-rail-item-ws">{session.workspaceName}</span>
               </button>

--- a/apps/canvas-workspace/src/renderer/src/components/chat/SessionTitle.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/SessionTitle.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { sessionTitleText } from './utils/sessionTitle';
+
+describe('sessionTitleText', () => {
+  it('uses a DOM reference label without exposing its internal id', () => {
+    const title = sessionTitleText('@[dom:dom-mqfcp3zq-16g73y|span%3A%203%20items] 这块区域描述了啥');
+
+    expect(title).toBe('span: 3 items 这块区域描述了啥');
+    expect(title).not.toContain('dom-mqfcp3zq-16g73y');
+  });
+
+  it('handles legacy labels with a bracketed suffix without leaving a stray bracket', () => {
+    expect(sessionTitleText('@[dom:dom-1|header: Fancy Builder [...truncated]] 这块区域描述了啥'))
+      .toBe('header: Fancy Builder [...truncated] 这块区域描述了啥');
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/components/chat/SessionTitle.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/SessionTitle.tsx
@@ -1,0 +1,35 @@
+import { Fragment } from 'react';
+import { DOM_MENTION_PREFIX } from './constants';
+import { MentionNodeIcon } from './utils/mentions';
+import { sessionTitleParts, sessionTitleText } from './utils/sessionTitle';
+
+interface Props {
+  value: string;
+}
+
+/**
+ * Renders serialized composer mentions as compact references rather than
+ * exposing their storage marker and internal id in a session title.
+ */
+export const SessionTitle = ({ value }: Props) => {
+  const parts = sessionTitleParts(value);
+
+  if (parts.length === 0) return <>{value}</>;
+
+  return (
+    <span className="chat-session-title" aria-label={sessionTitleText(value)}>
+      {parts.map((part, index) => part.marker ? (
+        <span
+          className="chat-session-title-reference"
+          key={`${part.marker}-${index}`}
+          title={part.text}
+        >
+          <MentionNodeIcon size={12} nodeType={part.marker.startsWith(DOM_MENTION_PREFIX) ? 'dom' : 'file'} />
+          <span>{part.text}</span>
+        </span>
+      ) : (
+        <Fragment key={`${part.text}-${index}`}>{part.text}</Fragment>
+      ))}
+    </span>
+  );
+};

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useMentions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useMentions.ts
@@ -224,10 +224,12 @@ export function useMentions({
       ? items.filter(item => item.label.toLowerCase().includes(normalizedQuery))
       : items;
 
-    // Past chat sessions, matched by TITLE (first user message + workspace
-    // name) — deliberately not message content, to keep the per-keystroke
-    // cost low. Only surfaced when the user typed a query — the default
-    // (empty) popup stays nodes/files/canvases only.
+    // Past chat sessions, matched by the first user message plus workspace
+    // name — deliberately not message content, to keep the per-keystroke
+    // cost low. Put that distinctive first message in the result title;
+    // workspace and date are supporting metadata. Only surface sessions when
+    // the user typed a query — the default (empty) popup stays
+    // nodes/files/canvases only.
     if (normalizedQuery) {
       try {
         const result = await window.canvasWorkspace.agent.searchSessions(query, 5);
@@ -235,10 +237,10 @@ export function useMentions({
           for (const hit of result.hits) {
             filtered.push({
               type: 'session',
-              label: `${hit.workspaceName} · ${hit.date}`,
+              label: hit.preview || hit.date,
               sessionId: hit.sessionId,
               workspaceId: hit.workspaceId,
-              description: hit.preview,
+              description: `${hit.workspaceName} · ${hit.date}`,
             });
           }
         }

--- a/apps/canvas-workspace/src/renderer/src/components/chat/utils/mentions.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/utils/mentions.test.ts
@@ -37,4 +37,17 @@ describe('chat mention rendering', () => {
     expect(html).toContain(domLabel);
     expect(html).not.toContain('</span>]');
   });
+
+  it('uses a readable title when a selected session is inserted as a reference', () => {
+    const chip = createMentionChipElement({
+      type: 'session',
+      label: '@[dom:dom-1|td%3A%20Latest%20commit] 这块区域描述了啥',
+      sessionId: 'session-1',
+      workspaceId: 'workspace-1',
+    });
+
+    expect(chip.dataset.mention).toBe('session:workspace-1:session-1:|td: Latest commit 这块区域描述了啥');
+    expect(chip.textContent).toContain('td: Latest commit 这块区域描述了啥');
+    expect(chip.textContent).not.toContain('dom-1');
+  });
 });

--- a/apps/canvas-workspace/src/renderer/src/components/chat/utils/mentions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/utils/mentions.ts
@@ -5,6 +5,7 @@ import type { MentionItem, WorkspaceOption } from '../types';
 import { renderMarkdown, type RenderMarkdownOptions } from './markdown';
 import { MENTION_RE, encodeMentionPart, pipedMentionLabel } from './mentionMarkers';
 import { readDomSelectionDataset, writeDomSelectionDataset } from './domMentionData';
+import { sessionTitleText } from './sessionTitle';
 
 function escapeHtml(value: string): string {
   return value
@@ -146,9 +147,10 @@ export function createMentionChipElement(item: MentionItem, nodes?: CanvasNode[]
   // and the sent message renders them as clickable jump chips.
   if (isSession && item.sessionId && item.workspaceId) {
     const idx = typeof item.messageIndex === 'number' && item.messageIndex >= 0 ? String(item.messageIndex) : '';
+    const sessionLabel = sessionTitleText(item.label);
     chip.className = 'chat-mention-chip chat-mention-chip--input chat-mention-chip--session';
     chip.contentEditable = 'false';
-    chip.dataset.mention = `${SESSION_MENTION_PREFIX}${item.workspaceId}:${item.sessionId}:${idx}|${item.label}`;
+    chip.dataset.mention = `${SESSION_MENTION_PREFIX}${item.workspaceId}:${item.sessionId}:${idx}|${sessionLabel}`;
     chip.dataset.nodeType = 'session';
 
     const iconSpan = document.createElement('span');
@@ -158,7 +160,7 @@ export function createMentionChipElement(item: MentionItem, nodes?: CanvasNode[]
 
     const labelSpan = document.createElement('span');
     labelSpan.className = 'chat-mention-chip-label';
-    labelSpan.textContent = item.label;
+    labelSpan.textContent = sessionLabel;
     chip.appendChild(labelSpan);
     return chip;
   }

--- a/apps/canvas-workspace/src/renderer/src/components/chat/utils/sessionTitle.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/utils/sessionTitle.ts
@@ -1,0 +1,38 @@
+import { DOM_MENTION_PREFIX } from '../constants';
+import { MENTION_RE, pipedMentionLabel } from './mentionMarkers';
+
+export interface SessionTitlePart {
+  text: string;
+  marker?: string;
+}
+
+function markerLabel(rawMarker: string): string {
+  if (rawMarker.startsWith(DOM_MENTION_PREFIX)) {
+    return pipedMentionLabel(rawMarker, DOM_MENTION_PREFIX, 'DOM selection');
+  }
+  const pipeIndex = rawMarker.indexOf('|');
+  return pipeIndex >= 0 ? rawMarker.slice(pipeIndex + 1) : rawMarker;
+}
+
+export function sessionTitleParts(value: string): SessionTitlePart[] {
+  const parts: SessionTitlePart[] = [];
+  let lastIndex = 0;
+
+  value.replace(MENTION_RE, (marker, rawMarker: string, offset: number) => {
+    if (offset > lastIndex) parts.push({ text: value.slice(lastIndex, offset) });
+    parts.push({ text: markerLabel(rawMarker), marker: rawMarker });
+    lastIndex = offset + marker.length;
+    return marker;
+  });
+  if (lastIndex < value.length) parts.push({ text: value.slice(lastIndex) });
+  return parts;
+}
+
+/** Readable fallback for a native title tooltip or accessibility label. */
+export function sessionTitleText(value: string): string {
+  return sessionTitleParts(value)
+    .map((part) => part.text)
+    .join('')
+    .replace(/\s+/g, ' ')
+    .trim();
+}


### PR DESCRIPTION
## What changed
- Render DOM-backed session titles as readable reference chips instead of serialized marker text.
- Keep reference markers intact while truncating only the accompanying prose.
- Use the same readable label when a selected session is inserted into the composer.

## Why
Session search results, selected-session headers, and composer references previously exposed internal DOM ids or rendered inconsistent titles.

## Validation
- pnpm --filter canvas-workspace typecheck
- Focused session-title, session-preview, and mention tests
- Canvas workspace quick harness checks