### PR TITLE
fix(canvas-workspace): remove redundant default export from MigrationSpinner

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;


### PR DESCRIPTION
## Summary

Scanned `apps/canvas-workspace` for UI style inconsistencies against the app's documented conventions (`harness/knowledge/conventions/frontend.md`) and its mechanized governance gates (`ui-reuse-governance.test.ts`, `import-boundaries.test.ts`, `file-size-governance.test.ts`).

- All three governance suites pass with **zero drift** from their tracked ratchet baselines — no new hardcoded color/radius/shadow/z-index literals, no import-boundary violations, no file-size regressions.
- The one genuine, isolated violation found: `src/renderer/src/components/MigrationSpinner/index.tsx` had a stray `export default MigrationSpinner` after its (correctly-used) named export. `frontend.md` calls for named arrow-function exports and to "avoid `default` exports for components." `App.tsx` already imports the component via the named export (`.then((module) => ({ default: module.MigrationSpinner }))`), so the default export was unreferenced dead code as well as a convention violation.

## Why not a broader sweep

`docs/ui-reuse-burndown.md` documents a large amount of **already-tracked, intentionally-deferred** legacy UI debt (bespoke dropdowns, non-token literals, etc.), governed by a double-direction ratchet that only allows shrinking counters via a deliberate batch process (pinned brief → independent reviewer on a different model → adjudication). That process exists specifically because naive migrations there have previously introduced behavioral regressions (documented misfit rate of 8/13 on one batch). Bulk-fixing that tracked debt in one unsupervised pass would bypass the review process the project has explicitly set up for it, so this PR is scoped to the one clear-cut, zero-risk, non-visual violation instead.

## Changes

- `src/renderer/src/components/MigrationSpinner/index.tsx`: remove the unused `export default MigrationSpinner` line.

## Test plan

- [x] `pnpm --filter canvas-workspace typecheck:renderer` — passes
- [x] `pnpm --filter canvas-workspace test` (ui-reuse-governance, import-boundaries, file-size-governance) — all pass, no counter drift
- [x] Confirmed no other file imports `MigrationSpinner` via its default export

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01UW8dqek5Scxr9fRxMwPjoq)_