### PR TITLE
fix: repair canvas text node rendering

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.tsx
@@ -117,18 +117,20 @@ export const TextNodeBody = ({
     editor.commands.setContent(data.content || "", { emitUpdate: false });
   }, [editor, data.content]);
 
-  // First-mount: empty-content nodes drop straight into editing so typing
-  // works immediately without an extra double-click.
+  // Empty selected nodes drop straight into editing so typing works immediately
+  // after creation. Keep unselected empty nodes idle; otherwise every blank text
+  // node on the canvas mounts an editable ProseMirror instance and paints a
+  // stray caret/placeholder artifact.
   useEffect(() => {
     if (!editor) return;
-    if (!readOnly && data.content === "") {
+    if (!readOnly && isSelected && data.content === "") {
       setEditing(true);
       // Defer focus until editable=true has applied to the DOM.
       const t = setTimeout(() => editor.commands.focus(), 0);
       return () => clearTimeout(t);
     }
     return undefined;
-  }, [editor, readOnly]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [editor, isSelected, readOnly]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Deselection commits the edit — matches tldraw's click-away-to-finalize feel.
   useEffect(() => {

--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBodyLazy/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBodyLazy/index.tsx
@@ -1,5 +1,6 @@
-import { lazy, Suspense, useMemo, useState } from 'react';
+import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import type { CanvasNode, TextNodeData } from '../../types';
+import '../TextNodeBody/index.css';
 import './index.css';
 
 interface Props {
@@ -25,8 +26,14 @@ export const htmlToPreviewText = (html: string): string => {
 
 export const TextNodeBodyLazy = (props: Props) => {
   const data = props.node.data as TextNodeData;
-  const [editorLoaded, setEditorLoaded] = useState(!props.readOnly && data.content === '');
+  const [editorLoaded, setEditorLoaded] = useState(!props.readOnly && props.isSelected && data.content === '');
   const text = useMemo(() => htmlToPreviewText(data.content ?? ''), [data.content]);
+
+  useEffect(() => {
+    if (!props.readOnly && props.isSelected && data.content === '') {
+      setEditorLoaded(true);
+    }
+  }, [data.content, props.isSelected, props.readOnly]);
 
   if (editorLoaded) {
     return (


### PR DESCRIPTION
Fix Canvas text nodes rendering as ordinary cards and showing stray editor artifacts.

- Load text node shell styles in the lazy preview path so unloaded text editor chunks still render with text-node chrome
- Only auto-load/focus the editor for selected empty text nodes, avoiding stray caret/placeholder artifacts on every blank text node
- Preserve direct typing after creating/selecting an empty text node

Validation:
- `NODE_ENV=test pnpm --filter canvas-workspace exec vitest run src/renderer/src/components/TextNodeBodyLazy/index.test.ts`
- `pnpm --filter canvas-workspace typecheck:renderer`

Note:
- `pnpm --filter canvas-workspace build` reached renderer bundling but stopped because the current validation environment is missing Vite's optional `terser` dependency required by `renderer.build.minify = "terser"`.
