### PR TITLE
Show iframe node title in overview badge alongside hostname

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeToolbar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeToolbar/index.css
@@ -11,6 +11,12 @@
   transition: opacity 120ms ease;
 }
 
+/* Reveal on hover as well as focus so a note reads as "editable now" the
+ * moment you point at it — the same trigger the block handle already uses.
+ * This removes the read→write mode-switch feel (Notion-style: viewing and
+ * editing present the same chrome); the toolbar is absolutely positioned so
+ * showing it never shifts the note's content layout. */
+.note-card:hover .note-toolbar,
 .note-card:focus-within .note-toolbar,
 .note-toolbar[data-open='true'] {
   opacity: 1;

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/IframeOverviewBadge.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/IframeOverviewBadge.tsx
@@ -1,19 +1,26 @@
 import { useEffect, useMemo, useState } from 'react';
 
 /**
- * Overview-zoom identity badge: favicon + hostname for url embeds, a code
- * glyph for html/srcdoc ones. Always in the tree but display:none outside
+ * Overview-zoom identity badge: favicon + title + hostname for url embeds, a
+ * code glyph for html/srcdoc ones. Always in the tree but display:none outside
  * `.canvas-transform--overview` (see index.css) so it costs the compositor
  * nothing at working zoom — the CSS swap keeps the semantic-zoom flip
  * per-gesture, exactly like the placeholder it replaces.
+ *
+ * Layout is two coordinate systems on purpose: the favicon tile is
+ * reverse-scaled to a constant on-screen size, while the text label is laid
+ * out in card-relative units so it always ellipsises to the card width and
+ * never overflows a narrow node (see index.css).
  */
 export const IframeOverviewBadge = ({
   mode,
   url,
+  title,
   faviconUrl,
 }: {
   mode: 'url' | 'html';
   url: string;
+  title?: string;
   faviconUrl?: string;
 }) => {
   const [faviconFailed, setFaviconFailed] = useState(false);
@@ -27,6 +34,16 @@ export const IframeOverviewBadge = ({
       return null;
     }
   }, [mode, url]);
+
+  // Prefer the node title as the primary line (it's what tells cards apart when
+  // many share a host); fall back to the host, then a generic type label. Skip
+  // a title that just echoes the host so the two lines never duplicate.
+  const trimmedTitle = title?.trim() || '';
+  const primary =
+    trimmedTitle && trimmedTitle.toLowerCase() !== (host ?? '').toLowerCase()
+      ? trimmedTitle
+      : host ?? (mode === 'url' ? 'Web page' : 'HTML');
+  const secondary = primary === host ? null : host;
 
   return (
     <div className="iframe-overview-badge" aria-hidden="true">
@@ -45,7 +62,12 @@ export const IframeOverviewBadge = ({
           <CodeIcon />
         )}
       </span>
-      {host ? <span className="iframe-overview-badge-host">{host}</span> : null}
+      <span className="iframe-overview-badge-label">
+        <span className="iframe-overview-badge-title">{primary}</span>
+        {secondary ? (
+          <span className="iframe-overview-badge-host">{secondary}</span>
+        ) : null}
+      </span>
     </div>
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/IframeRenderedView.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/IframeRenderedView.tsx
@@ -50,6 +50,7 @@ interface IframeRenderedViewProps {
   streamIframeRef: RefObject<HTMLIFrameElement>;
   streamingActive: boolean;
   webviewDiscarded: boolean;
+  title?: string;
   url: string;
   webviewHostRef: RefObject<HTMLDivElement>;
   webviewKey: number;
@@ -98,6 +99,7 @@ export const IframeRenderedView = ({
   streamIframeRef,
   streamingActive,
   webviewDiscarded,
+  title,
   url,
   webviewHostRef,
   webviewKey,
@@ -217,7 +219,7 @@ export const IframeRenderedView = ({
       <div className={`iframe-frame-wrapper${streamingActive ? ' iframe-frame-wrapper--streaming' : ''}`}>
         {streamingActive && <div className="iframe-shimmer-bar" />}
         {isResizing && <div className="iframe-pointer-shield" aria-hidden="true" />}
-        <IframeOverviewBadge mode={renderMode} url={url} faviconUrl={faviconUrl} />
+        <IframeOverviewBadge mode={renderMode} url={url} title={title} faviconUrl={faviconUrl} />
         {renderMode === 'url' ? (
           <>
             <div

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.css
@@ -597,12 +597,18 @@
   background: linear-gradient(180deg, var(--accent-light), var(--surface) 55%);
 }
 
-/* Identity badge (IframeOverviewBadge): favicon tile + hostname pill for
- * url embeds, a code glyph for html/srcdoc ones. Hidden outside overview —
+/* Identity badge (IframeOverviewBadge): favicon tile + title/hostname label
+ * for url embeds, a code glyph for html/srcdoc ones. Hidden outside overview —
  * display:none keeps it out of the paint chunks the compositor walks
- * (the Layerize lesson from the idle actions popover). Reverse-scaled as
- * one transform so borders/shadows keep their visual weight at any
- * overview zoom. */
+ * (the Layerize lesson from the idle actions popover).
+ *
+ * Two coordinate systems on purpose: the tile is reverse-scaled to a constant
+ * on-screen size so its border/shadow keep their weight at any overview zoom,
+ * while the text label is laid out in card-relative units (font/padding ÷ the
+ * clamped scale) so it always ellipsises to the card width and never overflows
+ * a narrow node. The favicon tile sits just above centre and the label chip
+ * just below it, so the two read as one page-identity unit instead of a lone
+ * icon floating over a detached bottom bar. */
 .iframe-overview-badge {
   display: none;
 }
@@ -614,50 +620,78 @@
   pointer-events: none;
 }
 
-/* Constant on-screen size via reverse-scale; nudged above center so the
- * hostname caption below reads balanced. */
+/* Constant on-screen size via reverse-scale; nudged above centre so the
+ * title/hostname chip below sits under it and the pair reads centred. */
 .canvas-transform--overview .canvas-node--iframe .iframe-overview-badge-tile {
   position: absolute;
   left: 50%;
-  top: 45%;
+  top: 42%;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 30px;
-  height: 30px;
-  border-radius: var(--radius-md);
+  width: 34px;
+  height: 34px;
+  border-radius: var(--radius-lg);
   background: var(--surface);
   border: 1px solid var(--border);
-  box-shadow: var(--shadow-card);
+  box-shadow: 0 2px 8px rgba(55, 53, 47, 0.1);
   color: var(--text-secondary);
   transform: translate(-50%, -50%) scale(calc(1 / clamp(0.06, var(--canvas-scale, 1), 0.35)));
 }
 
 .iframe-overview-badge-favicon {
-  width: 18px;
-  height: 18px;
+  width: 20px;
+  height: 20px;
   border-radius: var(--radius-sm);
   object-fit: contain;
 }
 
-/* Hostname as a full-width bottom caption, laid out in canvas units so
- * ellipsis follows the card's real width; the size compensation clamps at
- * 0.14 so the label holds ~10px on screen through mid-overview and only
- * then shrinks with the card. */
-.canvas-transform--overview .canvas-node--iframe .iframe-overview-badge-host {
+/* Title + hostname chip: a centred, auto-width rounded label sitting just
+ * below the tile. Laid out in canvas units so ellipsis follows the card's
+ * real width; the size compensation clamps at 0.14 so the label holds its
+ * on-screen size through mid-overview and only then shrinks with the card. */
+.canvas-transform--overview .canvas-node--iframe .iframe-overview-badge-label {
   position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  left: 50%;
+  top: 42%;
+  transform: translate(-50%, calc(24px / clamp(0.14, var(--canvas-scale, 1), 0.35)));
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: calc(1px / clamp(0.14, var(--canvas-scale, 1), 0.35));
+  max-width: 88%;
+  padding: calc(3px / clamp(0.14, var(--canvas-scale, 1), 0.35)) calc(9px / clamp(0.14, var(--canvas-scale, 1), 0.35));
+  border-radius: calc(7px / clamp(0.14, var(--canvas-scale, 1), 0.35));
+  background: var(--surface);
+  /* The chip is laid out in card units (not transform-scaled like the tile),
+   * so its border/shadow must be size-compensated too or they collapse to a
+   * sub-pixel hairline at overview zoom. */
+  border: solid var(--border);
+  border-width: calc(1px / clamp(0.14, var(--canvas-scale, 1), 0.35));
+  box-shadow: 0 calc(1px / clamp(0.14, var(--canvas-scale, 1), 0.35))
+    calc(4px / clamp(0.14, var(--canvas-scale, 1), 0.35)) rgba(55, 53, 47, 0.08);
+  text-align: center;
+}
+
+.canvas-transform--overview .canvas-node--iframe .iframe-overview-badge-title {
+  max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  text-align: center;
-  padding: calc(4px / clamp(0.14, var(--canvas-scale, 1), 0.35)) calc(8px / clamp(0.14, var(--canvas-scale, 1), 0.35));
-  background: var(--surface);
+  color: var(--text);
+  font-size: calc(10.5px / clamp(0.14, var(--canvas-scale, 1), 0.35));
+  font-weight: 650;
+  letter-spacing: 0.01em;
+}
+
+.canvas-transform--overview .canvas-node--iframe .iframe-overview-badge-host {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: var(--text-secondary);
-  font-size: calc(10px / clamp(0.14, var(--canvas-scale, 1), 0.35));
-  font-weight: 600;
+  font-size: calc(8.5px / clamp(0.14, var(--canvas-scale, 1), 0.35));
+  font-weight: 500;
   letter-spacing: 0.01em;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.tsx
@@ -179,6 +179,7 @@ export const IframeNodeBody = ({
         webviewDiscarded={state.webviewDiscarded}
         streamIframeRef={state.streamIframeRef}
         streamingActive={state.streamingActive}
+        title={node.title}
         url={state.url}
         webviewHostRef={state.webviewHostRef}
         webviewKey={state.webviewKey}


### PR DESCRIPTION
## Summary
Enhanced the iframe overview badge to display both the node title and hostname, improving node identification in overview zoom. The badge now shows a two-line label (title + hostname) instead of just the hostname, with improved visual hierarchy and layout.

## Key Changes
- **IframeOverviewBadge component**: Added `title` prop and logic to display it as the primary label, with hostname as secondary. Falls back gracefully when title is missing or duplicates the hostname.
- **Badge layout**: Restructured from a single bottom caption to a centered two-line label positioned below the favicon tile, creating a unified page-identity unit.
- **Visual refinements**:
  - Increased favicon tile size from 30px to 34px with larger border radius
  - Adjusted tile positioning (top: 45% → 42%) to center the tile-label pair
  - Enhanced shadow on tile (custom shadow instead of `--shadow-card` variable)
  - Added proper spacing and typography for title (10.5px, weight 650) and hostname (8.5px, weight 500)
  - Implemented size-compensated borders and shadows on the label chip to maintain visual weight at any zoom level
- **Data flow**: Threaded `title` prop through `IframeRenderedView` and `IframeNodeBody` to pass node title to the badge.
- **Note toolbar**: Added hover trigger alongside focus-within to reveal the toolbar, making notes feel immediately editable on hover (matching the block handle behavior).

## Implementation Details
The badge uses two intentional coordinate systems: the favicon tile is reverse-scaled to maintain constant on-screen size, while the text label is laid out in card-relative units so it always ellipsises to card width and never overflows narrow nodes. This prevents the icon from floating detached from the label at different zoom levels.

https://claude.ai/code/session_015gxLe3NwHeWjWCpaQSGpkV