### PR TITLE
Add workspace resolution, node search, and external-caller surface

### DIFF
--- a/apps/canvas-workspace/harness/tools/describe-canvas.mjs
+++ b/apps/canvas-workspace/harness/tools/describe-canvas.mjs
@@ -137,10 +137,22 @@ const cliStorageV2Ts = fs.existsSync(cliStorageV2Path) ? read(cliStorageV2Path) 
 const nodesStoreTs = fs.existsSync(nodesStorePath) ? read(nodesStorePath) : '';
 const storageTs = fs.existsSync(storageTsPath) ? read(storageTsPath) : '';
 
-// Same union-extraction style as section 3, adapted to a `type X = 'a' | 'b'`
-// alias (canvas-cli's NodeType) rather than an inline interface field.
-const cliUnionBlock = cliTypesTs.match(/export type NodeType\s*=\s*([^;]+);/);
-const cliNodeTypes = cliUnionBlock ? [...cliUnionBlock[1].matchAll(/'([a-z-]+)'/g)].map((m) => m[1]) : [];
+// Same union-extraction style as section 3, adapted to canvas-cli's node-type
+// aliases. The CLI splits its literals across `CreatableNodeType` (types it can
+// create) and `KnownNodeType` (all types it reads/models), with the public
+// `NodeType = KnownNodeType | (string & {})` adding the opaque passthrough arm
+// for unmodeled future types. The modeled literal set is the union of the two
+// alias bodies; the `(string & {})` arm intentionally contributes no literal
+// (it IS the "treat unknown types as opaque" behavior this section allows for).
+const litsOf = (block) => (block ? [...block[1].matchAll(/'([a-z-]+)'/g)].map((m) => m[1]) : []);
+const cliCreatableBlock = cliTypesTs.match(/export type CreatableNodeType\s*=\s*([^;]+);/);
+const cliKnownBlock = cliTypesTs.match(/export type KnownNodeType\s*=\s*([^;]+);/);
+// Fallback to a legacy flat `NodeType` alias so this tool still works if the
+// CLI ever collapses the split back into one union.
+const cliLegacyBlock = cliTypesTs.match(/export type NodeType\s*=\s*([^;]+);/);
+const cliNodeTypes = [
+  ...new Set([...litsOf(cliCreatableBlock), ...litsOf(cliKnownBlock), ...litsOf(cliLegacyBlock)]),
+];
 const appOnlyNodeTypes = unionTypes.filter((t) => !cliNodeTypes.includes(t));
 const cliOnlyNodeTypes = cliNodeTypes.filter((t) => !unionTypes.includes(t));
 
@@ -186,14 +198,11 @@ if (appCanvasSchemaVersionV2 === undefined || cliCanvasSchemaVersionV2 === undef
 // type present in the CLI but ABSENT from the app union is NOT allowlisted
 // here — that would mean the app can't even read what the CLI wrote, which
 // is a real bug, not drift to accept.
-const KNOWN_MISMATCH_APP_ONLY_NODE_TYPES = new Set([
-  'text',
-  'iframe',
-  'image',
-  'shape',
-  'dynamic-app',
-  'plugin',
-]);
+// Empty: the CLI now models every app node type it can read (text, iframe,
+// image, shape, dynamic-app, plugin, reference) in its KnownNodeType union, so
+// there is currently no accepted app-only drift. New app-only types added
+// before the CLI mirrors them go here (recorded, not silently skipped).
+const KNOWN_MISMATCH_APP_ONLY_NODE_TYPES = new Set([]);
 
 const unexpectedAppOnlyNodeTypes = appOnlyNodeTypes.filter((t) => !KNOWN_MISMATCH_APP_ONLY_NODE_TYPES.has(t));
 const staleAppOnlyAllowlist = [...KNOWN_MISMATCH_APP_ONLY_NODE_TYPES].filter((t) => !appOnlyNodeTypes.includes(t));

--- a/packages/canvas-cli/AGENTS.md
+++ b/packages/canvas-cli/AGENTS.md
@@ -55,11 +55,22 @@ the root harness files above, then the package source/tests.
 - Keep `restore` narrow: it recovers from v1 snapshots and archives live
   `nodes/` data so the app can migrate cleanly later; it is not a general
   migration tool.
-- `node create` supports `file`, `terminal`, `frame`, `group`, `agent`, and
-  `mindmap`. Terminal/agent nodes created by the CLI have no active PTY session.
-- `reference` is a read-compatible node shape in core types, but not a CLI
-  creation type. Plugin nodes are handled through the Canvas host/plugin tools,
-  not by this package's generic `node create`.
+- Node types split into `CreatableNodeType` (what `node create` accepts:
+  `file`, `terminal`, `frame`, `group`, `agent`, `mindmap`) and the wider
+  `KnownNodeType` read set (`text`, `iframe`, `image`, `shape`, `reference`,
+  `dynamic-app`, `plugin`). `NodeType = KnownNodeType | (string & {})` so a
+  future node type from a newer app still loads and reads as an opaque node
+  rather than breaking `loadCanvas`. Terminal/agent nodes created by the CLI
+  have no active PTY session.
+- The read-only types are surfaced by `readNode`/`context` from persisted
+  `data` only — never by fetching the network or reaching into Electron. `node
+  read` returns full metadata; `context` excerpts `text` and omits heavy fields
+  (iframe `html`/`prompt`, plugin `payload`) to stay prompt-sized. Reading a
+  live URL-iframe page body is explicitly out of scope for `node read` — it
+  would be a separate runtime-authenticated `webview read`.
+- `reference` and plugin nodes are read-compatible shapes, not CLI creation
+  types. Plugin nodes are authored through the Canvas host/plugin tools, not
+  this package's generic `node create`.
 - Live `agent` and `team` commands must keep using the runtime file plus bearer
   auth. Do not bypass runtime authentication or reach into Electron memory from
   this package.

--- a/packages/canvas-cli/AGENTS.md
+++ b/packages/canvas-cli/AGENTS.md
@@ -31,6 +31,7 @@ in `apps/canvas-workspace`; runtime-loadable plugin node behavior belongs in
 | Executable entrypoint | `src/index.ts` |
 | Workspace/node/edge/context commands | `src/commands/workspace.ts`, `src/commands/node.ts`, `src/commands/edge.ts`, `src/commands/context.ts` |
 | Workspace auto-discovery (which canvas a command targets) | `src/core/workspace-resolution.ts`, `src/commands/options.ts` |
+| External-caller surface (status/describe, error contract) | `src/commands/status.ts`, `src/commands/describe.ts`, `src/output.ts` |
 | Live runtime commands | `src/commands/agent.ts`, `src/commands/team.ts`, `src/core/runtime-control.ts` |
 | v2 recovery command | `src/commands/restore.ts` |
 | Public core exports | `src/core/index.ts` |
@@ -83,6 +84,14 @@ the root harness files above, then the package source/tests.
   untrusted canvas.json) to the workspace dir: reads fall back to in-memory
   content (`pathConfined: true`), writes fail with `path_confined`. The guard is
   opt-in so existing app-created nodes (paths under `notes/`) are unaffected.
+- External-caller surface: `status` (non-fatal store/workspace/runtime probe —
+  never exits non-zero for "no workspace") and `describe` (self-describing
+  manifest with `describeVersion`) exist so agents can pre-flight and plan.
+  `context` output carries `contextVersion`; bump it (and `describeVersion`) on
+  any breaking shape change. `node read` takes multiple ids (single → object,
+  many → array with per-id error entries); `node search`/`node list --type`/
+  `context --types` cut round-trips; `node update` owns layout/title (not data).
+  Keep these output shapes and their version fields stable.
 - Live `agent` and `team` commands must keep using the runtime file plus bearer
   auth. Do not bypass runtime authentication or reach into Electron memory from
   this package.

--- a/packages/canvas-cli/AGENTS.md
+++ b/packages/canvas-cli/AGENTS.md
@@ -71,6 +71,18 @@ the root harness files above, then the package source/tests.
 - `reference` and plugin nodes are read-compatible shapes, not CLI creation
   types. Plugin nodes are authored through the Canvas host/plugin tools, not
   this package's generic `node create`.
+- `text` nodes are read+write (their markdown lives inline in `data.content`);
+  `node write` edits them. Other app-produced types stay read-only.
+- Error contract (machine callers): `errorOutput` emits `{ ok, error, code }`
+  JSON on stderr under `--format json` (human `Error:` line otherwise); the
+  format is set once by the cli.ts `preAction` hook via `setActiveFormat`. Core
+  `Result` failures carry an optional `code`; command layer forwards it. Keep
+  `code` values stable — external callers branch on them. New error sites should
+  pass a `code`.
+- `--confine-to-workspace` restricts `file`-node disk paths (from a possibly
+  untrusted canvas.json) to the workspace dir: reads fall back to in-memory
+  content (`pathConfined: true`), writes fail with `path_confined`. The guard is
+  opt-in so existing app-created nodes (paths under `notes/`) are unaffected.
 - Live `agent` and `team` commands must keep using the runtime file plus bearer
   auth. Do not bypass runtime authentication or reach into Electron memory from
   this package.

--- a/packages/canvas-cli/AGENTS.md
+++ b/packages/canvas-cli/AGENTS.md
@@ -30,6 +30,7 @@ in `apps/canvas-workspace`; runtime-loadable plugin node behavior belongs in
 | Current CLI command index | `src/cli.ts` |
 | Executable entrypoint | `src/index.ts` |
 | Workspace/node/edge/context commands | `src/commands/workspace.ts`, `src/commands/node.ts`, `src/commands/edge.ts`, `src/commands/context.ts` |
+| Workspace auto-discovery (which canvas a command targets) | `src/core/workspace-resolution.ts`, `src/commands/options.ts` |
 | Live runtime commands | `src/commands/agent.ts`, `src/commands/team.ts`, `src/core/runtime-control.ts` |
 | v2 recovery command | `src/commands/restore.ts` |
 | Public core exports | `src/core/index.ts` |
@@ -62,6 +63,14 @@ the root harness files above, then the package source/tests.
 - Live `agent` and `team` commands must keep using the runtime file plus bearer
   auth. Do not bypass runtime authentication or reach into Electron memory from
   this package.
+- New commands resolve their workspace through `getWorkspaceCommandOptions`
+  (`src/commands/options.ts`), not by reading `opts.workspace` directly. The
+  fixed discovery order is `--workspace` → `$PULSE_CANVAS_WORKSPACE_ID` →
+  `__workspaces__.json.activeId` → hard error; it never guesses (no
+  "most recent" / "first in list"). Disk commands require a readable
+  `canvas.json`; runtime-mediated (`agent`/`team`) and `restore` pass
+  `{ requireReadableCanvas: false }` since the workspace lives in the app or is
+  the thing being recovered.
 - Changes to command payloads, core exports, node/edge schemas, runtime routes,
   or storage shape are contract changes; use local validation plus the root
   impact overlay when hosts are affected.

--- a/packages/canvas-cli/README.md
+++ b/packages/canvas-cli/README.md
@@ -22,16 +22,22 @@ Binary name: `pulse-canvas`.
 |------|-------------|
 | `--format <json\|text>` | Output format: `json` or `text` (default: `text`) |
 | `--store-dir <path>` | Canvas store directory (default: `~/.pulse-coder/canvas/`) |
-| `-w, --workspace <id>` | Workspace ID (default: `$PULSE_CANVAS_WORKSPACE_ID`) |
+| `-w, --workspace <id>` | Workspace ID (default: active workspace, or `$PULSE_CANVAS_WORKSPACE_ID`) |
 
-The Electron app sets `PULSE_CANVAS_WORKSPACE_ID` for agent nodes automatically, so most commands need no explicit workspace flag.
+**Workspace auto-discovery.** Commands resolve the target workspace in a fixed
+order: `--workspace <id>` → `$PULSE_CANVAS_WORKSPACE_ID` (the Electron app sets
+this for agent nodes automatically) → the app's active workspace
+(`__workspaces__.json.activeId`). If none of these selects a workspace, the
+command errors instead of guessing. Run `pulse-canvas workspace current` to see
+which workspace commands will act on.
 
 ## Commands
 
 ### Workspace
 
 ```bash
-pulse-canvas workspace list                     # List all workspaces
+pulse-canvas workspace list                     # List all workspaces (active one flagged with *)
+pulse-canvas workspace current                  # Show the workspace commands resolve to, and why
 pulse-canvas workspace info <id>                # Node counts, types, last saved
 pulse-canvas workspace create <name>            # Create a new workspace
 pulse-canvas workspace delete <id> --confirm    # Delete (irreversible)
@@ -41,7 +47,7 @@ pulse-canvas workspace recover <id> --dry-run   # Preview without writing
 
 ### Node
 
-All `node` commands require a workspace (via `-w` or `$PULSE_CANVAS_WORKSPACE_ID`).
+`node` commands use the resolved workspace (see **Workspace auto-discovery** above); pass `-w` only to override it.
 
 ```bash
 pulse-canvas node list                          # List nodes with types and capabilities
@@ -65,8 +71,17 @@ Node types and capabilities (the capability map reported by `node list`):
 | `group` | read, write | Container of child nodes; `node write` expects JSON `{label?,color?,childIds?}` |
 | `agent` | read, exec | Agent PTY node (read-only from CLI; use `agent send` for live input) |
 | `mindmap` | read, write | Topic tree; initialize via `--data '{"root":{"text":"...","children":[...]}}'` |
+| `text` | read | Markdown text card (content, font, color) |
+| `iframe` | read | Embedded page (`mode`, `url`, `html`, `prompt`, `artifactId`, `pageTitle`) |
+| `image` | read | Local image (`filePath`) |
+| `shape` | read | Shape with text/style |
+| `dynamic-app` | read | Dynamic app embed (`url`, `dynamicAppId`) |
+| `plugin` | read | Plugin node (`pluginId`, `nodeType`, `version`, `payload`) |
+| `reference` | read | Snapshot reference to another node |
 
-`node create` accepts `file`, `terminal`, `frame`, `group`, `agent`, and `mindmap`. `reference` is a read-only node shape in core types but is not a CLI creation type. `node write` currently supports `file`, `frame`, and `group`; `terminal`/`agent` require a live PTY.
+`node create` accepts only the creatable types: `file`, `terminal`, `frame`, `group`, `agent`, and `mindmap`. The remaining types above are produced by the canvas app and are **read-only** from the CLI — `node read <id> --format json` returns their full persisted metadata. Unrecognized (future) node types still load and read as opaque nodes rather than breaking the CLI. `node write` currently supports `file`, `frame`, and `group`; `terminal`/`agent` require a live PTY.
+
+> **iframe/dynamic-app content.** `node read` returns only what the store persists — for a URL-mode iframe that is the metadata (url, pageTitle, …), not the live web page body, which lives in the running Electron webview rather than the canvas store. Reading the rendered page would need a separate, runtime-authenticated `webview read` command (not yet implemented); plain `node read` never connects to Electron or fetches the network.
 
 ### Edge
 
@@ -93,7 +108,7 @@ pulse-canvas context                # Structured summary of all nodes in the wor
 pulse-canvas context --format json  # Machine-readable for agent consumption
 ```
 
-Returns workspace metadata plus a per-node summary: file paths, frame labels, terminal cwds, agent statuses. This is the recommended entry point for agents — run it first to understand the canvas layout.
+Returns workspace metadata plus a per-node summary: file paths, frame labels, terminal cwds, agent statuses, text excerpts, and iframe/embed metadata. This is the recommended entry point for agents — run it first to understand the canvas layout. To stay prompt-friendly, `context` deliberately excerpts long `text` bodies and omits heavy fields (an iframe's inlined `html`/`prompt`, a plugin's `payload`); fetch the full content of a specific node with `node read <id> --format json`.
 
 > **Runtime requirement — `agent` and `team`.** These two families do not read the JSON store. They require a running `apps/canvas-workspace` instance and authenticate to its loopback runtime-control server using the bearer secret in `~/.pulse-coder/canvas-runtime/canvas-workspace.json`. Without it they fail with `No active canvas-workspace runtime found.` — open the workspace in Pulse Canvas first. All other command families (`workspace`, `node`, `edge`, `context`, `restore`, `install-skills`) operate directly on the store and need no runtime.
 

--- a/packages/canvas-cli/README.md
+++ b/packages/canvas-cli/README.md
@@ -23,6 +23,7 @@ Binary name: `pulse-canvas`.
 | `--format <json\|text>` | Output format: `json` or `text` (default: `text`) |
 | `--store-dir <path>` | Canvas store directory (default: `~/.pulse-coder/canvas/`) |
 | `-w, --workspace <id>` | Workspace ID (default: active workspace, or `$PULSE_CANVAS_WORKSPACE_ID`) |
+| `--confine-to-workspace` | Refuse to read/write file-node paths outside the workspace directory (safer for untrusted canvases) |
 
 **Workspace auto-discovery.** Commands resolve the target workspace in a fixed
 order: `--workspace <id>` → `$PULSE_CANVAS_WORKSPACE_ID` (the Electron app sets
@@ -30,6 +31,15 @@ this for agent nodes automatically) → the app's active workspace
 (`__workspaces__.json.activeId`). If none of these selects a workspace, the
 command errors instead of guessing. Run `pulse-canvas workspace current` to see
 which workspace commands will act on.
+
+**Output & error contract (for machine callers).** Successful `--format json`
+output is a JSON value on **stdout**. On failure the process exits non-zero and,
+in `--format json`, prints a JSON object `{ "ok": false, "error": "…", "code":
+"…" }` on **stderr** (in text mode it's a human `Error: …` line). Branch on the
+stable `code` rather than the message. Common codes: `no_workspace_selected`,
+`workspace_not_found`, `node_not_found`, `edge_not_found`, `invalid_argument`,
+`unsupported`, `path_confined`, `confirmation_required`, and the runtime family
+(`runtime_not_found`, `runtime_unreachable`, `runtime_auth`, …) for `agent`/`team`.
 
 ## Commands
 
@@ -71,7 +81,7 @@ Node types and capabilities (the capability map reported by `node list`):
 | `group` | read, write | Container of child nodes; `node write` expects JSON `{label?,color?,childIds?}` |
 | `agent` | read, exec | Agent PTY node (read-only from CLI; use `agent send` for live input) |
 | `mindmap` | read, write | Topic tree; initialize via `--data '{"root":{"text":"...","children":[...]}}'` |
-| `text` | read | Markdown text card (content, font, color) |
+| `text` | read, write | Markdown text card (content, font, color); `node write` replaces its `content` |
 | `iframe` | read | Embedded page (`mode`, `url`, `html`, `prompt`, `artifactId`, `pageTitle`) |
 | `image` | read | Local image (`filePath`) |
 | `shape` | read | Shape with text/style |
@@ -79,7 +89,7 @@ Node types and capabilities (the capability map reported by `node list`):
 | `plugin` | read | Plugin node (`pluginId`, `nodeType`, `version`, `payload`) |
 | `reference` | read | Snapshot reference to another node |
 
-`node create` accepts only the creatable types: `file`, `terminal`, `frame`, `group`, `agent`, and `mindmap`. The remaining types above are produced by the canvas app and are **read-only** from the CLI — `node read <id> --format json` returns their full persisted metadata. Unrecognized (future) node types still load and read as opaque nodes rather than breaking the CLI. `node write` currently supports `file`, `frame`, and `group`; `terminal`/`agent` require a live PTY.
+`node create` accepts only the creatable types: `file`, `terminal`, `frame`, `group`, `agent`, and `mindmap`. The remaining types above are produced by the canvas app and are **read-only** from the CLI — `node read <id> --format json` returns their full persisted metadata. Unrecognized (future) node types still load and read as opaque nodes rather than breaking the CLI. `node write` supports `file`, `text`, `frame`, and `group`; `terminal`/`agent` require a live PTY. Pass `--confine-to-workspace` so a `file` node whose `filePath` points outside the workspace directory is refused (read falls back to in-memory content, write errors with code `path_confined`) — recommended when the canvas may be untrusted.
 
 > **iframe/dynamic-app content.** `node read` returns only what the store persists — for a URL-mode iframe that is the metadata (url, pageTitle, …), not the live web page body, which lives in the running Electron webview rather than the canvas store. Reading the rendered page would need a separate, runtime-authenticated `webview read` command (not yet implemented); plain `node read` never connects to Electron or fetches the network.
 

--- a/packages/canvas-cli/README.md
+++ b/packages/canvas-cli/README.md
@@ -55,19 +55,37 @@ pulse-canvas workspace recover <id>             # Rebuild file nodes from notes/
 pulse-canvas workspace recover <id> --dry-run   # Preview without writing
 ```
 
+### Status & Describe
+
+```bash
+pulse-canvas status --format json    # Store dir, resolved/active workspace, runtime reachability
+pulse-canvas describe --format json  # Machine-readable manifest: commands, node types, error codes
+```
+
+`status` is the recommended pre-flight for an external caller: it never exits
+non-zero for "no workspace selected" (it reports that as data) and tells you
+whether the Electron runtime is up, i.e. whether the live `agent`/`team`
+commands are usable. `describe` emits a self-describing capability manifest
+(with `describeVersion` and `contextVersion`) so an agent can plan against the
+CLI without hard-coding its surface.
+
 ### Node
 
 `node` commands use the resolved workspace (see **Workspace auto-discovery** above); pass `-w` only to override it.
 
 ```bash
 pulse-canvas node list                          # List nodes with types and capabilities
-pulse-canvas node read <nodeId>                 # Read node content
+pulse-canvas node list --type text              # …filtered to one type
+pulse-canvas node search "checkout"             # Find nodes by title/content (no per-node read)
+pulse-canvas node read <nodeId>                 # Read a node (single id → object)
+pulse-canvas node read <id1> <id2> <id3>        # Batch read (multiple ids → array; misses become per-entry errors)
 pulse-canvas node create --type file --title "Report" --data '{"content":"..."}'
-pulse-canvas node write <nodeId> --content "..."        # interprets \n, \t escapes
+pulse-canvas node write <nodeId> --content "..."        # interprets \n, \t escapes (file/text/frame/group)
 pulse-canvas node write <nodeId> --content "..." --raw  # verbatim, no unescaping
 pulse-canvas node write <nodeId> --file ./result.md     # read content from file
 echo "hello" | pulse-canvas node write <nodeId>         # read from stdin
 pulse-canvas node write <frameId> --content '{"label":"New title","color":"#9575d4"}'  # frame/group: JSON patch
+pulse-canvas node update <nodeId> --x 400 --y 200 --title "Moved"  # reposition/resize/rename (layout only)
 pulse-canvas node delete <nodeId>
 ```
 
@@ -114,9 +132,12 @@ pulse-canvas edge delete <edgeId>
 ### Context
 
 ```bash
-pulse-canvas context                # Structured summary of all nodes in the workspace
-pulse-canvas context --format json  # Machine-readable for agent consumption
+pulse-canvas context                       # Structured summary of all nodes in the workspace
+pulse-canvas context --format json         # Machine-readable for agent consumption
+pulse-canvas context --types file,text     # Only include the listed node types (edges follow)
 ```
+
+The JSON output carries a `contextVersion` field (the output-contract version) so callers can detect an incompatible CLI.
 
 Returns workspace metadata plus a per-node summary: file paths, frame labels, terminal cwds, agent statuses, text excerpts, and iframe/embed metadata. This is the recommended entry point for agents — run it first to understand the canvas layout. To stay prompt-friendly, `context` deliberately excerpts long `text` bodies and omits heavy fields (an iframe's inlined `html`/`prompt`, a plugin's `payload`); fetch the full content of a specific node with `node read <id> --format json`.
 

--- a/packages/canvas-cli/src/cli.ts
+++ b/packages/canvas-cli/src/cli.ts
@@ -7,8 +7,9 @@ import { registerEdgeCommands } from './commands/edge';
 import { registerAgentCommands } from './commands/agent';
 import { registerRestoreCommand } from './commands/restore';
 import { registerTeamCommands } from './commands/team';
+import { ENV_WORKSPACE_ID } from './core/workspace-resolution';
 
-export const ENV_WORKSPACE_ID = 'PULSE_CANVAS_WORKSPACE_ID';
+export { ENV_WORKSPACE_ID };
 
 export function createCli(): Command {
   const program = new Command();
@@ -19,7 +20,10 @@ export function createCli(): Command {
     .version('0.0.1-alpha.1')
     .option('--format <format>', 'Output format: json or text', 'text')
     .option('--store-dir <path>', 'Canvas store directory (default: ~/.pulse-coder/canvas/)')
-    .option('-w, --workspace <id>', `Workspace ID (default: $${ENV_WORKSPACE_ID})`, process.env[ENV_WORKSPACE_ID]);
+    .option(
+      '-w, --workspace <id>',
+      `Workspace ID (default: active workspace, or $${ENV_WORKSPACE_ID})`,
+    );
 
   registerWorkspaceCommands(program);
   registerNodeCommands(program);

--- a/packages/canvas-cli/src/cli.ts
+++ b/packages/canvas-cli/src/cli.ts
@@ -7,6 +7,8 @@ import { registerEdgeCommands } from './commands/edge';
 import { registerAgentCommands } from './commands/agent';
 import { registerRestoreCommand } from './commands/restore';
 import { registerTeamCommands } from './commands/team';
+import { registerStatusCommand } from './commands/status';
+import { registerDescribeCommand } from './commands/describe';
 import { ENV_WORKSPACE_ID } from './core/workspace-resolution';
 import { setActiveFormat } from './output';
 
@@ -39,6 +41,8 @@ export function createCli(): Command {
   });
 
   registerWorkspaceCommands(program);
+  registerStatusCommand(program);
+  registerDescribeCommand(program);
   registerNodeCommands(program);
   registerEdgeCommands(program);
   registerAgentCommands(program);

--- a/packages/canvas-cli/src/cli.ts
+++ b/packages/canvas-cli/src/cli.ts
@@ -8,6 +8,7 @@ import { registerAgentCommands } from './commands/agent';
 import { registerRestoreCommand } from './commands/restore';
 import { registerTeamCommands } from './commands/team';
 import { ENV_WORKSPACE_ID } from './core/workspace-resolution';
+import { setActiveFormat } from './output';
 
 export { ENV_WORKSPACE_ID };
 
@@ -23,7 +24,19 @@ export function createCli(): Command {
     .option(
       '-w, --workspace <id>',
       `Workspace ID (default: active workspace, or $${ENV_WORKSPACE_ID})`,
+    )
+    .option(
+      '--confine-to-workspace',
+      'Refuse to read/write file-node paths outside the workspace directory (safer for untrusted canvases)',
+      false,
     );
+
+  // Resolve the global output format once, before any action runs, so
+  // `errorOutput` can emit structured JSON errors from anywhere without each
+  // call site threading the format through.
+  program.hook('preAction', () => {
+    setActiveFormat(program.opts().format === 'json' ? 'json' : 'text');
+  });
 
   registerWorkspaceCommands(program);
   registerNodeCommands(program);

--- a/packages/canvas-cli/src/commands/__tests__/cli-extras.test.ts
+++ b/packages/canvas-cli/src/commands/__tests__/cli-extras.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { tmpdir, homedir } from 'os';
+import { createCli } from '../../cli';
+import { saveCanvas, saveWorkspaceManifest } from '../../core/store';
+import { ENV_WORKSPACE_ID } from '../../core/workspace-resolution';
+import type { CanvasSaveData } from '../../core/types';
+
+const RUNTIME_FILE = join(homedir(), '.pulse-coder', 'canvas-runtime', 'canvas-workspace.json');
+
+let testDir: string;
+let savedEnv: string | undefined;
+let runtimeBackup: Buffer | null = null;
+
+async function runCli(argv: string[]): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...a) => { stdout.push(a.map(String).join(' ')); });
+  const errSpy = vi.spyOn(console, 'error').mockImplementation((...a) => { stderr.push(a.map(String).join(' ')); });
+  let exitCode: number | null = null;
+  const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    exitCode = code ?? 0;
+    throw new Error(`__exit:${code}`);
+  }) as never);
+  const cli = createCli();
+  cli.exitOverride();
+  try {
+    await cli.parseAsync(argv, { from: 'user' });
+  } catch { /* exitCode carries the signal */ }
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+  exitSpy.mockRestore();
+  return { stdout: stdout.join('\n'), stderr: stderr.join('\n'), exitCode };
+}
+
+const canvasWith = (nodes: CanvasSaveData['nodes']): CanvasSaveData => ({
+  nodes, transform: { x: 0, y: 0, scale: 1 }, savedAt: '2025-01-01T00:00:00.000Z',
+});
+
+beforeEach(async () => {
+  testDir = join(tmpdir(), `canvas-cli-extras-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`);
+  await fs.mkdir(testDir, { recursive: true });
+  savedEnv = process.env[ENV_WORKSPACE_ID];
+  delete process.env[ENV_WORKSPACE_ID];
+  // Isolate from a real runtime file so `status` is deterministic.
+  try { runtimeBackup = await fs.readFile(RUNTIME_FILE); } catch { runtimeBackup = null; }
+  await fs.rm(RUNTIME_FILE, { force: true });
+});
+
+afterEach(async () => {
+  if (savedEnv === undefined) delete process.env[ENV_WORKSPACE_ID];
+  else process.env[ENV_WORKSPACE_ID] = savedEnv;
+  if (runtimeBackup) {
+    await fs.mkdir(join(homedir(), '.pulse-coder', 'canvas-runtime'), { recursive: true });
+    await fs.writeFile(RUNTIME_FILE, runtimeBackup);
+  } else {
+    await fs.rm(RUNTIME_FILE, { force: true });
+  }
+  await fs.rm(testDir, { recursive: true, force: true });
+});
+
+async function seedActive(id: string, nodes: CanvasSaveData['nodes'] = []): Promise<void> {
+  await saveCanvas(id, canvasWith(nodes), testDir, { allowEmpty: true });
+  await saveWorkspaceManifest({ workspaces: [{ id, name: 'WS' }], activeId: id }, testDir);
+}
+
+describe('node read batch', () => {
+  it('returns an array with a per-id error entry for a missing node', async () => {
+    await seedActive('ws', [
+      { id: 't1', type: 'text', title: 'A', x: 0, y: 0, width: 10, height: 10, data: { content: 'aaa' } },
+      { id: 't2', type: 'text', title: 'B', x: 0, y: 0, width: 10, height: 10, data: { content: 'bbb' } },
+    ]);
+    const { stdout, exitCode } = await runCli(['--store-dir', testDir, '--format', 'json', 'node', 'read', 't1', 't2', 'gone']);
+    expect(exitCode).toBe(null);
+    const arr = JSON.parse(stdout) as Array<{ id: string; content?: string; error?: string; code?: string }>;
+    expect(arr).toHaveLength(3);
+    expect(arr[0]).toMatchObject({ id: 't1', content: 'aaa' });
+    expect(arr[2]).toMatchObject({ id: 'gone', code: 'node_not_found' });
+  });
+
+  it('keeps single-id reads as a bare object', async () => {
+    await seedActive('ws', [{ id: 't1', type: 'text', title: 'A', x: 0, y: 0, width: 10, height: 10, data: { content: 'solo' } }]);
+    const { stdout } = await runCli(['--store-dir', testDir, '--format', 'json', 'node', 'read', 't1']);
+    const obj = JSON.parse(stdout) as { type: string; content: string };
+    expect(Array.isArray(obj)).toBe(false);
+    expect(obj).toMatchObject({ type: 'text', content: 'solo' });
+  });
+});
+
+describe('describe', () => {
+  it('emits a machine-readable manifest', async () => {
+    const { stdout, exitCode } = await runCli(['--format', 'json', 'describe']);
+    expect(exitCode).toBe(null);
+    const m = JSON.parse(stdout);
+    expect(m.describeVersion).toBe(1);
+    expect(m.nodeTypes.creatable).toContain('file');
+    expect(m.nodeTypes.known).toContain('iframe');
+    expect(m.errorCodes).toContain('node_not_found');
+    expect(m.commands.map((c: { name: string }) => c.name)).toContain('node');
+  });
+});
+
+describe('status', () => {
+  it('reports store, resolved workspace, and runtime unavailability', async () => {
+    await seedActive('ws-a');
+    const { stdout, exitCode } = await runCli(['--store-dir', testDir, '--format', 'json', 'status']);
+    expect(exitCode).toBe(null);
+    const s = JSON.parse(stdout);
+    expect(s.activeWorkspaceId).toBe('ws-a');
+    expect(s.resolved).toMatchObject({ workspaceId: 'ws-a', source: 'manifest-active' });
+    expect(s.runtime.present).toBe(false);
+    expect(s.runtime.reachable).toBe(false);
+  });
+
+  it('does not exit non-zero when no workspace is selected', async () => {
+    const { stdout, exitCode } = await runCli(['--store-dir', testDir, '--format', 'json', 'status']);
+    expect(exitCode).toBe(null);
+    const s = JSON.parse(stdout);
+    expect(s.resolved.workspaceId).toBeNull();
+    expect(s.resolved.code).toBe('no_workspace_selected');
+  });
+});

--- a/packages/canvas-cli/src/commands/__tests__/error-contract.test.ts
+++ b/packages/canvas-cli/src/commands/__tests__/error-contract.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { createCli } from '../../cli';
+import { saveCanvas, saveWorkspaceManifest } from '../../core/store';
+import { ENV_WORKSPACE_ID } from '../../core/workspace-resolution';
+import type { CanvasSaveData } from '../../core/types';
+
+let testDir: string;
+let savedEnv: string | undefined;
+
+const canvasWith = (nodes: CanvasSaveData['nodes']): CanvasSaveData => ({
+  nodes,
+  transform: { x: 0, y: 0, scale: 1 },
+  savedAt: '2025-01-01T00:00:00.000Z',
+});
+
+async function runCli(argv: string[]): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...a) => { stdout.push(a.map(String).join(' ')); });
+  const errSpy = vi.spyOn(console, 'error').mockImplementation((...a) => { stderr.push(a.map(String).join(' ')); });
+  let exitCode: number | null = null;
+  const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    exitCode = code ?? 0;
+    throw new Error(`__exit:${code}`);
+  }) as never);
+
+  const cli = createCli();
+  cli.exitOverride();
+  try {
+    await cli.parseAsync(argv, { from: 'user' });
+  } catch { /* __exit / commander errors carried via exitCode */ }
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+  exitSpy.mockRestore();
+  return { stdout: stdout.join('\n'), stderr: stderr.join('\n'), exitCode };
+}
+
+beforeEach(async () => {
+  testDir = join(tmpdir(), `canvas-cli-errc-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`);
+  await fs.mkdir(testDir, { recursive: true });
+  savedEnv = process.env[ENV_WORKSPACE_ID];
+  delete process.env[ENV_WORKSPACE_ID];
+});
+
+afterEach(async () => {
+  if (savedEnv === undefined) delete process.env[ENV_WORKSPACE_ID];
+  else process.env[ENV_WORKSPACE_ID] = savedEnv;
+  await fs.rm(testDir, { recursive: true, force: true });
+});
+
+async function seedActive(id: string, nodes: CanvasSaveData['nodes'] = []): Promise<void> {
+  await saveCanvas(id, canvasWith(nodes), testDir, { allowEmpty: true });
+  await saveWorkspaceManifest({ workspaces: [{ id, name: 'WS' }], activeId: id }, testDir);
+}
+
+describe('structured JSON error contract', () => {
+  it('emits {ok:false,error,code} on stderr in --format json (no workspace selected)', async () => {
+    const { stderr, stdout, exitCode } = await runCli(['--store-dir', testDir, '--format', 'json', 'node', 'list']);
+    expect(exitCode).toBe(1);
+    expect(stdout).toBe(''); // stdout stays clean
+    const parsed = JSON.parse(stderr);
+    expect(parsed).toMatchObject({ ok: false, code: 'no_workspace_selected' });
+    expect(typeof parsed.error).toBe('string');
+  });
+
+  it('uses code node_not_found for a missing node', async () => {
+    await seedActive('ws-a');
+    const { stderr, exitCode } = await runCli(['--store-dir', testDir, '--format', 'json', 'node', 'read', 'nope']);
+    expect(exitCode).toBe(1);
+    expect(JSON.parse(stderr)).toMatchObject({ ok: false, code: 'node_not_found' });
+  });
+
+  it('uses code workspace_not_found when an explicit workspace is absent', async () => {
+    const { stderr } = await runCli(['--store-dir', testDir, '--format', 'json', '-w', 'ghost', 'node', 'list']);
+    expect(JSON.parse(stderr)).toMatchObject({ ok: false, code: 'workspace_not_found' });
+  });
+
+  it('reports invalid_argument for a bad node type on create', async () => {
+    await seedActive('ws-a');
+    const { stderr } = await runCli(['--store-dir', testDir, '--format', 'json', 'node', 'create', '--type', 'bogus']);
+    expect(JSON.parse(stderr)).toMatchObject({ ok: false, code: 'invalid_argument' });
+  });
+
+  it('stays human-readable (not JSON) in text mode', async () => {
+    const { stderr, exitCode } = await runCli(['--store-dir', testDir, 'node', 'list']);
+    expect(exitCode).toBe(1);
+    expect(stderr).toMatch(/^Error: /);
+    expect(() => JSON.parse(stderr)).toThrow();
+  });
+});
+
+describe('--confine-to-workspace via the CLI', () => {
+  it('refuses node write to a file node whose path escapes the workspace', async () => {
+    const outside = join(testDir, 'victim.txt');
+    await fs.writeFile(outside, 'original', 'utf-8');
+    await seedActive('ws-a', [
+      { id: 'f1', type: 'file', title: 'F', x: 0, y: 0, width: 100, height: 100, data: { filePath: outside, content: '' } },
+    ]);
+
+    const { stderr, exitCode } = await runCli([
+      '--store-dir', testDir, '--format', 'json', '--confine-to-workspace',
+      'node', 'write', 'f1', '--content', 'HACKED',
+    ]);
+    expect(exitCode).toBe(1);
+    expect(JSON.parse(stderr)).toMatchObject({ ok: false, code: 'path_confined' });
+    expect(await fs.readFile(outside, 'utf-8')).toBe('original');
+  });
+});

--- a/packages/canvas-cli/src/commands/__tests__/workspace-resolution-cli.test.ts
+++ b/packages/canvas-cli/src/commands/__tests__/workspace-resolution-cli.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { createCli } from '../../cli';
+import { saveCanvas, saveWorkspaceManifest } from '../../core/store';
+import { ENV_WORKSPACE_ID } from '../../core/workspace-resolution';
+import type { CanvasSaveData } from '../../core/types';
+
+let testDir: string;
+let savedEnvWorkspace: string | undefined;
+
+const populatedCanvas: CanvasSaveData = {
+  nodes: [
+    { id: 'node-1', type: 'file', title: 'Notes', x: 0, y: 0, width: 100, height: 100, data: { content: 'hi' } },
+  ],
+  transform: { x: 0, y: 0, scale: 1 },
+  savedAt: '2025-01-01T00:00:00.000Z',
+};
+
+/**
+ * Run the real CLI in-process, capturing stdout/stderr and the exit code.
+ * Mirrors the harness in agent.test.ts.
+ */
+async function runCli(argv: string[]): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...args) => {
+    stdout.push(args.map(String).join(' '));
+  });
+  const errSpy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+    stderr.push(args.map(String).join(' '));
+  });
+  let exitCode: number | null = null;
+  const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    exitCode = code ?? 0;
+    throw new Error(`__exit:${code}`);
+  }) as never);
+
+  const cli = createCli();
+  cli.exitOverride();
+  try {
+    await cli.parseAsync(argv, { from: 'user' });
+  } catch {
+    // swallow the __exit throw / commander errors — exitCode carries the signal
+  }
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+  exitSpy.mockRestore();
+  return { stdout: stdout.join('\n'), stderr: stderr.join('\n'), exitCode };
+}
+
+beforeEach(async () => {
+  testDir = join(tmpdir(), `canvas-cli-resolve-cli-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`);
+  await fs.mkdir(testDir, { recursive: true });
+  // Isolate from any real env the test host may carry.
+  savedEnvWorkspace = process.env[ENV_WORKSPACE_ID];
+  delete process.env[ENV_WORKSPACE_ID];
+});
+
+afterEach(async () => {
+  if (savedEnvWorkspace === undefined) delete process.env[ENV_WORKSPACE_ID];
+  else process.env[ENV_WORKSPACE_ID] = savedEnvWorkspace;
+  await fs.rm(testDir, { recursive: true, force: true });
+});
+
+async function seedActiveWorkspace(id: string): Promise<void> {
+  await saveCanvas(id, populatedCanvas, testDir);
+  await saveWorkspaceManifest(
+    { workspaces: [{ id, name: 'Active WS' }], activeId: id },
+    testDir,
+  );
+}
+
+describe('workspace auto-discovery for disk commands', () => {
+  it('`context` succeeds without -w by using the active workspace', async () => {
+    await seedActiveWorkspace('ws-active');
+    const { stdout, exitCode } = await runCli(['--store-dir', testDir, '--format', 'json', 'context']);
+    expect(exitCode).toBe(null);
+    const ctx = JSON.parse(stdout) as { workspaceId?: string };
+    expect(ctx.workspaceId).toBe('ws-active');
+  });
+
+  it('`node list` succeeds without -w by using the active workspace', async () => {
+    await seedActiveWorkspace('ws-active');
+    const { stdout, exitCode } = await runCli(['--store-dir', testDir, '--format', 'json', 'node', 'list']);
+    expect(exitCode).toBe(null);
+    const rows = JSON.parse(stdout) as Array<{ id: string }>;
+    expect(rows.map(r => r.id)).toEqual(['node-1']);
+  });
+
+  it('errors with a selection hint when nothing selects a workspace', async () => {
+    const { stderr, exitCode } = await runCli(['--store-dir', testDir, 'node', 'list']);
+    expect(exitCode).toBe(1);
+    expect(stderr).toMatch(/No workspace selected/);
+  });
+
+  it('honors an explicit -w over the active workspace', async () => {
+    await seedActiveWorkspace('ws-active');
+    await saveCanvas('ws-other', populatedCanvas, testDir);
+    const { stdout, exitCode } = await runCli([
+      '--store-dir', testDir, '--format', 'json', '-w', 'ws-other', 'context',
+    ]);
+    expect(exitCode).toBe(null);
+    expect((JSON.parse(stdout) as { workspaceId?: string }).workspaceId).toBe('ws-other');
+  });
+});
+
+describe('workspace current', () => {
+  it('reports the resolved workspace, its active flag, and the source', async () => {
+    await seedActiveWorkspace('ws-active');
+    const { stdout, exitCode } = await runCli(['--store-dir', testDir, '--format', 'json', 'workspace', 'current']);
+    expect(exitCode).toBe(null);
+    expect(JSON.parse(stdout)).toEqual({
+      id: 'ws-active',
+      name: 'Active WS',
+      active: true,
+      source: 'manifest-active',
+    });
+  });
+
+  it('marks the source as explicit when -w is passed', async () => {
+    await seedActiveWorkspace('ws-active');
+    await saveCanvas('ws-other', populatedCanvas, testDir);
+    const { stdout, exitCode } = await runCli([
+      '--store-dir', testDir, '--format', 'json', '-w', 'ws-other', 'workspace', 'current',
+    ]);
+    expect(exitCode).toBe(null);
+    expect(JSON.parse(stdout)).toMatchObject({ id: 'ws-other', active: false, source: 'explicit' });
+  });
+});
+
+describe('workspace list', () => {
+  it('flags the active workspace', async () => {
+    await seedActiveWorkspace('ws-active');
+    await saveCanvas('ws-idle', populatedCanvas, testDir);
+    const { stdout, exitCode } = await runCli(['--store-dir', testDir, '--format', 'json', 'workspace', 'list']);
+    expect(exitCode).toBe(null);
+    const rows = JSON.parse(stdout) as Array<{ id: string; active: boolean }>;
+    const active = rows.find(r => r.active);
+    expect(active?.id).toBe('ws-active');
+    expect(rows.filter(r => r.active)).toHaveLength(1);
+  });
+});

--- a/packages/canvas-cli/src/commands/agent.ts
+++ b/packages/canvas-cli/src/commands/agent.ts
@@ -1,16 +1,7 @@
 import { Command } from 'commander';
-import { output, errorOutput, type OutputFormat } from '../output';
+import { output, errorOutput } from '../output';
+import { getWorkspaceCommandOptions } from './options';
 import { postRuntime, readRuntime, runtimeAuthHint, type RuntimeInfo } from '../core/runtime-control';
-
-function getOpts(cmd: Command): { format: OutputFormat; workspace: string } {
-  const root = cmd.parent?.parent ?? cmd.parent;
-  const opts = root?.opts() ?? {};
-  const workspace = opts.workspace as string | undefined;
-  if (!workspace) {
-    errorOutput('Workspace ID required. Use --workspace <id> or set $PULSE_CANVAS_WORKSPACE_ID');
-  }
-  return { format: opts.format ?? 'text', workspace };
-}
 
 interface SendResponse {
   ok: boolean;
@@ -39,7 +30,7 @@ export function registerAgentCommands(program: Command): void {
     .requiredOption('--input <text>', 'Text to send to the agent (Enter is appended automatically)')
     .description('Send follow-up input to a running agent node')
     .action(async function (this: Command, nodeId: string, cmdOpts: { input: string }) {
-      const { format, workspace } = getOpts(this);
+      const { format, workspace } = await getWorkspaceCommandOptions(this, { requireReadableCanvas: false });
       const runtime = await readRuntime();
       const { status, body } = await postAgentSend(runtime, workspace, nodeId, cmdOpts.input);
 

--- a/packages/canvas-cli/src/commands/agent.ts
+++ b/packages/canvas-cli/src/commands/agent.ts
@@ -35,11 +35,11 @@ export function registerAgentCommands(program: Command): void {
       const { status, body } = await postAgentSend(runtime, workspace, nodeId, cmdOpts.input);
 
       if (status === 401) {
-        errorOutput(runtimeAuthHint());
+        errorOutput(runtimeAuthHint(), { code: 'runtime_auth' });
       }
       if (!body.ok) {
         const hint = hintForCode(body.code);
-        errorOutput(`${body.error ?? `HTTP ${status}`}${hint ? `\n${hint}` : ''}`);
+        errorOutput(`${body.error ?? `HTTP ${status}`}${hint ? `\n${hint}` : ''}`, { code: body.code ?? 'runtime_error' });
       }
 
       output(body, format, (d) => {

--- a/packages/canvas-cli/src/commands/context.ts
+++ b/packages/canvas-cli/src/commands/context.ts
@@ -1,21 +1,14 @@
 import { Command } from 'commander';
 import { generateContext, formatContextAsText } from '../core/context';
-import { output, errorOutput, type OutputFormat } from '../output';
+import { output, errorOutput } from '../output';
+import { getWorkspaceCommandOptions } from './options';
 
 export function registerContextCommand(program: Command): void {
   program
     .command('context')
     .description('Generate canvas context for agent consumption')
     .action(async function (this: Command) {
-      const root = this.parent;
-      const opts = root?.opts() ?? {};
-      const format: OutputFormat = opts.format ?? 'text';
-      const storeDir: string | undefined = opts.storeDir;
-      const workspace: string | undefined = opts.workspace;
-
-      if (!workspace) {
-        errorOutput('Workspace ID required. Use --workspace <id> or set $PULSE_CANVAS_WORKSPACE_ID');
-      }
+      const { format, storeDir, workspace } = await getWorkspaceCommandOptions(this);
 
       const ctx = await generateContext(workspace, storeDir);
       if (!ctx) errorOutput(`Workspace not found: ${workspace}`);

--- a/packages/canvas-cli/src/commands/context.ts
+++ b/packages/canvas-cli/src/commands/context.ts
@@ -8,10 +8,10 @@ export function registerContextCommand(program: Command): void {
     .command('context')
     .description('Generate canvas context for agent consumption')
     .action(async function (this: Command) {
-      const { format, storeDir, workspace } = await getWorkspaceCommandOptions(this);
+      const { format, storeDir, workspace, confineToWorkspace } = await getWorkspaceCommandOptions(this);
 
-      const ctx = await generateContext(workspace, storeDir);
-      if (!ctx) errorOutput(`Workspace not found: ${workspace}`);
+      const ctx = await generateContext(workspace, storeDir, { confineToWorkspace });
+      if (!ctx) errorOutput(`Workspace not found: ${workspace}`, { code: 'workspace_not_found' });
 
       output(ctx, format, (data) => formatContextAsText(data as NonNullable<typeof ctx>));
     });

--- a/packages/canvas-cli/src/commands/context.ts
+++ b/packages/canvas-cli/src/commands/context.ts
@@ -6,11 +6,16 @@ import { getWorkspaceCommandOptions } from './options';
 export function registerContextCommand(program: Command): void {
   program
     .command('context')
+    .option('--types <list>', 'Comma-separated node types to include (e.g. file,text,iframe)')
     .description('Generate canvas context for agent consumption')
-    .action(async function (this: Command) {
+    .action(async function (this: Command, cmdOpts: { types?: string }) {
       const { format, storeDir, workspace, confineToWorkspace } = await getWorkspaceCommandOptions(this);
 
-      const ctx = await generateContext(workspace, storeDir, { confineToWorkspace });
+      const types = cmdOpts.types
+        ? cmdOpts.types.split(',').map(t => t.trim()).filter(Boolean)
+        : undefined;
+
+      const ctx = await generateContext(workspace, storeDir, { confineToWorkspace, types });
       if (!ctx) errorOutput(`Workspace not found: ${workspace}`, { code: 'workspace_not_found' });
 
       output(ctx, format, (data) => formatContextAsText(data as NonNullable<typeof ctx>));

--- a/packages/canvas-cli/src/commands/describe.ts
+++ b/packages/canvas-cli/src/commands/describe.ts
@@ -1,0 +1,112 @@
+import { Command, Option, Argument } from 'commander';
+import { NODE_CAPABILITIES, DEFAULT_NODE_DIMENSIONS } from '../core/constants';
+import { CONTEXT_SCHEMA_VERSION } from '../core/context';
+import { ENV_WORKSPACE_ID } from '../core/workspace-resolution';
+import { output } from '../output';
+
+/**
+ * Version of the `describe` manifest itself. Bump when the manifest shape
+ * changes so a caller can tell whether it understands the payload.
+ */
+const DESCRIBE_VERSION = 1;
+
+interface CommandInfo {
+  name: string;
+  description: string;
+  arguments: Array<{ name: string; required: boolean; variadic: boolean }>;
+  options: Array<{ flags: string; description: string }>;
+  subcommands: CommandInfo[];
+}
+
+function serializeCommand(cmd: Command): CommandInfo {
+  const args = ((cmd as unknown as { registeredArguments?: Argument[] }).registeredArguments ?? []);
+  return {
+    name: cmd.name(),
+    description: cmd.description(),
+    arguments: args.map((a) => ({
+      name: a.name(),
+      required: (a as unknown as { required: boolean }).required,
+      variadic: (a as unknown as { variadic: boolean }).variadic,
+    })),
+    options: cmd.options.map((o: Option) => ({ flags: o.flags, description: o.description })),
+    subcommands: cmd.commands.map(serializeCommand),
+  };
+}
+
+/**
+ * Error `code` values the CLI emits (in `--format json` failures). Kept here as
+ * the single documented list so external callers can enumerate what they may
+ * need to branch on. Not exhaustive of transient runtime detail, but covers the
+ * stable set.
+ */
+const ERROR_CODES = [
+  'error',
+  'no_workspace_selected',
+  'workspace_not_found',
+  'workspace_unsafe',
+  'workspace_unreadable',
+  'node_not_found',
+  'edge_not_found',
+  'invalid_argument',
+  'unsupported',
+  'path_confined',
+  'confirmation_required',
+  'io_error',
+  'not_found',
+  'runtime_not_found',
+  'runtime_unreadable',
+  'runtime_invalid',
+  'runtime_corrupt',
+  'runtime_unreachable',
+  'runtime_auth',
+  'runtime_error',
+];
+
+export function registerDescribeCommand(program: Command): void {
+  program
+    .command('describe')
+    .description('Emit a machine-readable manifest of commands, node types, and error codes')
+    .action(async function (this: Command) {
+      let root: Command = this;
+      while (root.parent) root = root.parent;
+
+      const manifest = {
+        describeVersion: DESCRIBE_VERSION,
+        name: root.name(),
+        version: root.version(),
+        contextVersion: CONTEXT_SCHEMA_VERSION,
+        workspaceResolutionOrder: ['--workspace', `$${ENV_WORKSPACE_ID}`, 'manifest-active'],
+        globalOptions: root.options.map((o) => ({ flags: o.flags, description: o.description })),
+        nodeTypes: {
+          creatable: Object.keys(DEFAULT_NODE_DIMENSIONS),
+          known: Object.keys(NODE_CAPABILITIES),
+          capabilities: NODE_CAPABILITIES,
+        },
+        errorCodes: ERROR_CODES,
+        commands: root.commands
+          .filter((c) => c.name() !== 'describe')
+          .map(serializeCommand),
+      };
+
+      const format = root.opts().format === 'json' ? 'json' : 'text';
+      output(manifest, format, (data) => {
+        const d = data as typeof manifest;
+        const lines: string[] = [
+          `${d.name} v${d.version}  (describe v${d.describeVersion}, context v${d.contextVersion})`,
+          `Workspace resolution: ${d.workspaceResolutionOrder.join(' → ')}`,
+          '',
+          `Creatable node types: ${d.nodeTypes.creatable.join(', ')}`,
+          `Known node types:     ${d.nodeTypes.known.join(', ')}`,
+          '',
+          'Commands:',
+        ];
+        for (const c of d.commands) {
+          lines.push(`  ${c.name} — ${c.description}`);
+          for (const s of c.subcommands) lines.push(`    ${c.name} ${s.name} — ${s.description}`);
+        }
+        lines.push('', `Error codes: ${d.errorCodes.join(', ')}`);
+        lines.push('', 'Use --format json for the full machine-readable manifest.');
+        return lines.join('\n');
+      });
+    });
+}

--- a/packages/canvas-cli/src/commands/edge.ts
+++ b/packages/canvas-cli/src/commands/edge.ts
@@ -63,23 +63,23 @@ export function registerEdgeCommands(program: Command): void {
 
       const validAnchors: EdgeAnchor[] = ['top', 'right', 'bottom', 'left', 'auto'];
       if (cmdOpts.fromAnchor && !validAnchors.includes(cmdOpts.fromAnchor as EdgeAnchor)) {
-        errorOutput(`Invalid --from-anchor "${cmdOpts.fromAnchor}". Must be: ${validAnchors.join(', ')}`);
+        errorOutput(`Invalid --from-anchor "${cmdOpts.fromAnchor}". Must be: ${validAnchors.join(', ')}`, { code: 'invalid_argument' });
       }
       if (cmdOpts.toAnchor && !validAnchors.includes(cmdOpts.toAnchor as EdgeAnchor)) {
-        errorOutput(`Invalid --to-anchor "${cmdOpts.toAnchor}". Must be: ${validAnchors.join(', ')}`);
+        errorOutput(`Invalid --to-anchor "${cmdOpts.toAnchor}". Must be: ${validAnchors.join(', ')}`, { code: 'invalid_argument' });
       }
 
       const validCaps: EdgeArrowCap[] = ['none', 'triangle', 'arrow', 'dot', 'bar'];
       if (cmdOpts.arrowHead && !validCaps.includes(cmdOpts.arrowHead as EdgeArrowCap)) {
-        errorOutput(`Invalid --arrow-head "${cmdOpts.arrowHead}". Must be: ${validCaps.join(', ')}`);
+        errorOutput(`Invalid --arrow-head "${cmdOpts.arrowHead}". Must be: ${validCaps.join(', ')}`, { code: 'invalid_argument' });
       }
       if (cmdOpts.arrowTail && !validCaps.includes(cmdOpts.arrowTail as EdgeArrowCap)) {
-        errorOutput(`Invalid --arrow-tail "${cmdOpts.arrowTail}". Must be: ${validCaps.join(', ')}`);
+        errorOutput(`Invalid --arrow-tail "${cmdOpts.arrowTail}". Must be: ${validCaps.join(', ')}`, { code: 'invalid_argument' });
       }
 
       const validStyles = ['solid', 'dashed', 'dotted'] as const;
       if (cmdOpts.style && !validStyles.includes(cmdOpts.style as typeof validStyles[number])) {
-        errorOutput(`Invalid --style "${cmdOpts.style}". Must be: ${validStyles.join(', ')}`);
+        errorOutput(`Invalid --style "${cmdOpts.style}". Must be: ${validStyles.join(', ')}`, { code: 'invalid_argument' });
       }
 
       const stroke: EdgeStroke | undefined =
@@ -104,7 +104,7 @@ export function registerEdgeCommands(program: Command): void {
         bend: cmdOpts.bend,
       }, storeDir);
 
-      if (!result.ok) errorOutput(result.error);
+      if (!result.ok) errorOutput(result.error, { code: result.code ?? 'error' });
 
       output(result.data, format, (d) => {
         const r = d as { edgeId: string };
@@ -119,7 +119,7 @@ export function registerEdgeCommands(program: Command): void {
       const { format, storeDir, workspace } = await getWorkspaceCommandOptions(this);
 
       const result = await deleteEdge(workspace, edgeId, storeDir);
-      if (!result.ok) errorOutput(result.error);
+      if (!result.ok) errorOutput(result.error, { code: result.code ?? 'error' });
 
       output({ deleted: edgeId }, format, () => `Deleted edge: ${edgeId}`);
     });

--- a/packages/canvas-cli/src/commands/edge.ts
+++ b/packages/canvas-cli/src/commands/edge.ts
@@ -1,18 +1,9 @@
 import { Command } from 'commander';
 import { loadCanvas } from '../core/store';
 import { createEdge, deleteEdge, listEdges } from '../core/edges';
-import { output, errorOutput, type OutputFormat } from '../output';
+import { output, errorOutput } from '../output';
+import { getWorkspaceCommandOptions } from './options';
 import type { EdgeAnchor, EdgeArrowCap, EdgeStroke } from '../core/types';
-
-function getOpts(cmd: Command): { format: OutputFormat; storeDir?: string; workspace: string } {
-  const root = cmd.parent?.parent ?? cmd.parent;
-  const opts = root?.opts() ?? {};
-  const workspace = opts.workspace as string | undefined;
-  if (!workspace) {
-    errorOutput('Workspace ID required. Use --workspace <id> or set $PULSE_CANVAS_WORKSPACE_ID');
-  }
-  return { format: opts.format ?? 'text', storeDir: opts.storeDir, workspace: workspace! };
-}
 
 export function registerEdgeCommands(program: Command): void {
   const edge = program
@@ -22,7 +13,7 @@ export function registerEdgeCommands(program: Command): void {
   edge.command('list')
     .description('List all edges in the workspace')
     .action(async function (this: Command) {
-      const { format, storeDir, workspace } = getOpts(this);
+      const { format, storeDir, workspace } = await getWorkspaceCommandOptions(this);
 
       const edges = await listEdges(workspace, storeDir);
 
@@ -68,7 +59,7 @@ export function registerEdgeCommands(program: Command): void {
       style?: string;
       bend?: number;
     }) {
-      const { format, storeDir, workspace } = getOpts(this);
+      const { format, storeDir, workspace } = await getWorkspaceCommandOptions(this);
 
       const validAnchors: EdgeAnchor[] = ['top', 'right', 'bottom', 'left', 'auto'];
       if (cmdOpts.fromAnchor && !validAnchors.includes(cmdOpts.fromAnchor as EdgeAnchor)) {
@@ -125,7 +116,7 @@ export function registerEdgeCommands(program: Command): void {
     .argument('<edgeId>', 'Edge ID')
     .description('Delete a canvas edge')
     .action(async function (this: Command, edgeId: string) {
-      const { format, storeDir, workspace } = getOpts(this);
+      const { format, storeDir, workspace } = await getWorkspaceCommandOptions(this);
 
       const result = await deleteEdge(workspace, edgeId, storeDir);
       if (!result.ok) errorOutput(result.error);

--- a/packages/canvas-cli/src/commands/install-skills.ts
+++ b/packages/canvas-cli/src/commands/install-skills.ts
@@ -80,7 +80,7 @@ version: 1.0.0
 
 Interact with canvas workspaces via the \`pulse-canvas\` CLI. The canvas is a shared workspace between humans and agents.
 
-The current workspace ID is available via \`$PULSE_CANVAS_WORKSPACE_ID\` environment variable (auto-set by canvas). All \`node\` and \`context\` commands use it automatically — no need to pass workspace ID explicitly.
+Commands resolve the target workspace automatically, so you rarely pass \`--workspace\`. Resolution order: \`--workspace <id>\` → \`$PULSE_CANVAS_WORKSPACE_ID\` (auto-set by canvas) → the app's active workspace. Run \`pulse-canvas workspace current\` to see which one commands will act on, and \`pulse-canvas workspace list\` to see all workspaces (the active one is flagged).
 
 Whenever \`$PULSE_CANVAS_WORKSPACE_ID\` is set, treat the canvas as required user-provided context. Before planning, coding, reviewing, or answering a workspace task, run \`pulse-canvas context --format json\` and use that result alongside repository files.
 

--- a/packages/canvas-cli/src/commands/node.ts
+++ b/packages/canvas-cli/src/commands/node.ts
@@ -7,6 +7,8 @@ import {
   writeNode,
   createNode,
   deleteNode,
+  updateNode,
+  searchNodes,
 } from '../core/nodes';
 import { output, errorOutput } from '../output';
 import { getWorkspaceCommandOptions } from './options';
@@ -36,19 +38,39 @@ export function unescapeContentArg(s: string): string {
   });
 }
 
+/** Human-readable rendering of a single `readNode` result (text format). */
+function renderNodeText(d: Record<string, unknown>): string {
+  if (d.type === 'file') return String(d.content ?? '');
+  if (d.type === 'text') return String(d.content ?? '');
+  if (d.type === 'terminal') return `Terminal (cwd: ${d.cwd ?? 'unknown'})\n${d.scrollback ?? ''}`;
+  if (d.type === 'frame' || d.type === 'group') {
+    const label = d.type === 'frame' ? 'Frame' : 'Group';
+    return `${label}: ${d.label || '(no label)'}  color: ${d.color ?? ''}`;
+  }
+  if (d.type === 'agent') {
+    return `Agent [${d.agentType ?? 'unknown'}] (${d.status ?? 'idle'})\ncwd: ${d.cwd ?? 'unknown'}\n${d.scrollback ?? ''}`;
+  }
+  return JSON.stringify(d, null, 2);
+}
+
 export function registerNodeCommands(program: Command): void {
   const node = program
     .command('node')
     .description('Manage canvas nodes');
 
   node.command('list')
+    .option('--type <type>', 'Only list nodes of this type')
     .description('List all nodes in the workspace')
-    .action(async function (this: Command) {
+    .action(async function (this: Command, cmdOpts: { type?: string }) {
       const { format, storeDir, workspace } = await getWorkspaceCommandOptions(this);
       const canvas = await loadCanvas(workspace, storeDir);
       if (!canvas) errorOutput(`Workspace not found: ${workspace}`, { code: 'workspace_not_found' });
 
-      const rows = canvas!.nodes.map(n => ({
+      const selected = cmdOpts.type
+        ? canvas!.nodes.filter(n => n.type === cmdOpts.type)
+        : canvas!.nodes;
+
+      const rows = selected.map(n => ({
         id: n.id,
         type: n.type,
         title: n.title,
@@ -65,40 +87,58 @@ export function registerNodeCommands(program: Command): void {
       });
     });
 
+  node.command('search')
+    .argument('<query>', 'Case-insensitive text to find in node titles and content')
+    .option('--type <type>', 'Restrict to a node type')
+    .option('--limit <n>', 'Max results', (v) => parseInt(v, 10))
+    .description('Find nodes by title/content without reading each one')
+    .action(async function (this: Command, query: string, cmdOpts: { type?: string; limit?: number }) {
+      const { format, storeDir, workspace } = await getWorkspaceCommandOptions(this);
+      const canvas = await loadCanvas(workspace, storeDir);
+      if (!canvas) errorOutput(`Workspace not found: ${workspace}`, { code: 'workspace_not_found' });
+
+      const hits = searchNodes(canvas!.nodes, query, { type: cmdOpts.type, limit: cmdOpts.limit });
+
+      output(hits, format, (data) => {
+        const items = data as typeof hits;
+        if (items.length === 0) return `No nodes match "${query}".`;
+        const lines = items.map(h => `  ${h.id}  [${h.type}]  ${h.title}\n    …${h.snippet}…`);
+        return `Matches for "${query}":\n${lines.join('\n')}`;
+      });
+    });
+
   node.command('read')
-    .argument('<nodeId>', 'Node ID')
-    .description('Read a canvas node')
-    .action(async function (this: Command, nodeId: string) {
+    .argument('<nodeId...>', 'Node ID(s) — pass several to batch-read')
+    .description('Read one or more canvas nodes (single id → object, multiple → array)')
+    .action(async function (this: Command, nodeIds: string[]) {
       const { format, storeDir, workspace, confineToWorkspace } = await getWorkspaceCommandOptions(this);
       const canvas = await loadCanvas(workspace, storeDir);
       if (!canvas) errorOutput(`Workspace not found: ${workspace}`, { code: 'workspace_not_found' });
 
-      const canvasNode = canvas!.nodes.find(n => n.id === nodeId);
-      if (!canvasNode) errorOutput(`Node not found: ${nodeId}`, { code: 'node_not_found' });
+      const confineToDir = confineToWorkspace ? getWorkspaceDir(workspace, storeDir) : undefined;
 
-      const result = await readNode(canvasNode!, {
-        confineToDir: confineToWorkspace ? getWorkspaceDir(workspace, storeDir) : undefined,
-      });
+      // Single id keeps the historical single-object shape (and hard-errors on
+      // a miss). Multiple ids return an array; a missing id becomes a per-entry
+      // error so a batch caller still gets every node it can.
+      if (nodeIds.length === 1) {
+        const canvasNode = canvas!.nodes.find(n => n.id === nodeIds[0]);
+        if (!canvasNode) errorOutput(`Node not found: ${nodeIds[0]}`, { code: 'node_not_found' });
+        const result = await readNode(canvasNode!, { confineToDir });
+        output(result, format, (data) => renderNodeText(data as Record<string, unknown>));
+        return;
+      }
 
-      output(result, format, (data) => {
-        const d = data as Record<string, unknown>;
-        if (d.type === 'file') {
-          return String(d.content ?? '');
-        }
-        if (d.type === 'terminal') {
-          return `Terminal (cwd: ${d.cwd ?? 'unknown'})\n${d.scrollback ?? ''}`;
-        }
-        if (d.type === 'frame' || d.type === 'group') {
-          const label = d.type === 'frame' ? 'Frame' : 'Group';
-          return `${label}: ${d.label || '(no label)'}  color: ${d.color ?? ''}`;
-        }
-        if (d.type === 'agent') {
-          return `Agent [${d.agentType ?? 'unknown'}] (${d.status ?? 'idle'})\ncwd: ${d.cwd ?? 'unknown'}\n${d.scrollback ?? ''}`;
-        }
-        if (d.type === 'text') {
-          return String(d.content ?? '');
-        }
-        return JSON.stringify(d, null, 2);
+      const results = await Promise.all(nodeIds.map(async (id) => {
+        const n = canvas!.nodes.find(x => x.id === id);
+        if (!n) return { id, error: `Node not found: ${id}`, code: 'node_not_found' as const };
+        return { id, ...(await readNode(n, { confineToDir })) };
+      }));
+
+      output(results, format, (data) => {
+        const items = data as Array<Record<string, unknown>>;
+        return items
+          .map(d => `## ${d.id}\n${d.error ? `(error: ${d.error})` : renderNodeText(d)}`)
+          .join('\n\n');
       });
     });
 
@@ -186,6 +226,34 @@ export function registerNodeCommands(program: Command): void {
         const r = d as { nodeId: string; type: string; title: string };
         return `Created ${r.type} node: ${r.nodeId} (${r.title})`;
       });
+    });
+
+  node.command('update')
+    .argument('<nodeId>', 'Node ID')
+    .option('--x <n>', 'New X position', parseFloat)
+    .option('--y <n>', 'New Y position', parseFloat)
+    .option('--width <n>', 'New width', parseFloat)
+    .option('--height <n>', 'New height', parseFloat)
+    .option('--title <title>', 'New title')
+    .description('Move, resize, or rename a node (layout/title only; use `node write` for content)')
+    .action(async function (this: Command, nodeId: string, cmdOpts: { x?: number; y?: number; width?: number; height?: number; title?: string }) {
+      const { format, storeDir, workspace } = await getWorkspaceCommandOptions(this);
+
+      const patch = {
+        x: cmdOpts.x,
+        y: cmdOpts.y,
+        width: cmdOpts.width,
+        height: cmdOpts.height,
+        title: cmdOpts.title,
+      };
+      if (Object.values(patch).every(v => v === undefined)) {
+        errorOutput('Provide at least one of --x, --y, --width, --height, --title', { code: 'invalid_argument' });
+      }
+
+      const result = await updateNode(workspace, nodeId, patch, storeDir);
+      if (!result.ok) errorOutput(result.error, { code: result.code ?? 'error' });
+
+      output({ ok: true, nodeId }, format, () => `Updated node: ${nodeId}`);
     });
 
   node.command('delete')

--- a/packages/canvas-cli/src/commands/node.ts
+++ b/packages/canvas-cli/src/commands/node.ts
@@ -10,7 +10,7 @@ import {
 } from '../core/nodes';
 import { output, errorOutput } from '../output';
 import { getWorkspaceCommandOptions } from './options';
-import type { NodeType } from '../core/types';
+import type { CreatableNodeType } from '../core/types';
 
 /**
  * Interpret common escape sequences in a CLI --content argument.
@@ -93,6 +93,9 @@ export function registerNodeCommands(program: Command): void {
         if (d.type === 'agent') {
           return `Agent [${d.agentType ?? 'unknown'}] (${d.status ?? 'idle'})\ncwd: ${d.cwd ?? 'unknown'}\n${d.scrollback ?? ''}`;
         }
+        if (d.type === 'text') {
+          return String(d.content ?? '');
+        }
         return JSON.stringify(d, null, 2);
       });
     });
@@ -144,8 +147,8 @@ export function registerNodeCommands(program: Command): void {
     .action(async function (this: Command, cmdOpts: { type: string; title?: string; x?: number; y?: number; width?: number; height?: number; data?: string }) {
       const { format, storeDir, workspace } = await getWorkspaceCommandOptions(this);
 
-      const validTypes: NodeType[] = ['file', 'terminal', 'frame', 'group', 'agent', 'mindmap'];
-      if (!validTypes.includes(cmdOpts.type as NodeType)) {
+      const validTypes: CreatableNodeType[] = ['file', 'terminal', 'frame', 'group', 'agent', 'mindmap'];
+      if (!validTypes.includes(cmdOpts.type as CreatableNodeType)) {
         errorOutput(`Invalid type "${cmdOpts.type}". Must be: ${validTypes.join(', ')}`);
       }
 
@@ -159,7 +162,7 @@ export function registerNodeCommands(program: Command): void {
       }
 
       const result = await createNode(workspace, {
-        type: cmdOpts.type as NodeType,
+        type: cmdOpts.type as CreatableNodeType,
         title: cmdOpts.title,
         x: cmdOpts.x,
         y: cmdOpts.y,

--- a/packages/canvas-cli/src/commands/node.ts
+++ b/packages/canvas-cli/src/commands/node.ts
@@ -8,7 +8,8 @@ import {
   createNode,
   deleteNode,
 } from '../core/nodes';
-import { output, errorOutput, type OutputFormat } from '../output';
+import { output, errorOutput } from '../output';
+import { getWorkspaceCommandOptions } from './options';
 import type { NodeType } from '../core/types';
 
 /**
@@ -35,16 +36,6 @@ export function unescapeContentArg(s: string): string {
   });
 }
 
-function getOpts(cmd: Command): { format: OutputFormat; storeDir?: string; workspace: string } {
-  const root = cmd.parent?.parent ?? cmd.parent;
-  const opts = root?.opts() ?? {};
-  const workspace = opts.workspace as string | undefined;
-  if (!workspace) {
-    errorOutput('Workspace ID required. Use --workspace <id> or set $PULSE_CANVAS_WORKSPACE_ID');
-  }
-  return { format: opts.format ?? 'text', storeDir: opts.storeDir, workspace };
-}
-
 export function registerNodeCommands(program: Command): void {
   const node = program
     .command('node')
@@ -53,7 +44,7 @@ export function registerNodeCommands(program: Command): void {
   node.command('list')
     .description('List all nodes in the workspace')
     .action(async function (this: Command) {
-      const { format, storeDir, workspace } = getOpts(this);
+      const { format, storeDir, workspace } = await getWorkspaceCommandOptions(this);
       const canvas = await loadCanvas(workspace, storeDir);
       if (!canvas) errorOutput(`Workspace not found: ${workspace}`);
 
@@ -78,7 +69,7 @@ export function registerNodeCommands(program: Command): void {
     .argument('<nodeId>', 'Node ID')
     .description('Read a canvas node')
     .action(async function (this: Command, nodeId: string) {
-      const { format, storeDir, workspace } = getOpts(this);
+      const { format, storeDir, workspace } = await getWorkspaceCommandOptions(this);
       const canvas = await loadCanvas(workspace, storeDir);
       if (!canvas) errorOutput(`Workspace not found: ${workspace}`);
 
@@ -113,7 +104,7 @@ export function registerNodeCommands(program: Command): void {
     .option('--raw', 'Treat --content verbatim without interpreting escape sequences', false)
     .description('Write content to a canvas node')
     .action(async function (this: Command, nodeId: string, cmdOpts: { content?: string; file?: string; raw?: boolean }) {
-      const { format, storeDir, workspace } = getOpts(this);
+      const { format, storeDir, workspace } = await getWorkspaceCommandOptions(this);
 
       let content: string;
       if (cmdOpts.content !== undefined) {
@@ -151,7 +142,7 @@ export function registerNodeCommands(program: Command): void {
     .option('--data <json>', 'Initial data as JSON')
     .description('Create a new canvas node')
     .action(async function (this: Command, cmdOpts: { type: string; title?: string; x?: number; y?: number; width?: number; height?: number; data?: string }) {
-      const { format, storeDir, workspace } = getOpts(this);
+      const { format, storeDir, workspace } = await getWorkspaceCommandOptions(this);
 
       const validTypes: NodeType[] = ['file', 'terminal', 'frame', 'group', 'agent', 'mindmap'];
       if (!validTypes.includes(cmdOpts.type as NodeType)) {
@@ -196,7 +187,7 @@ export function registerNodeCommands(program: Command): void {
     .argument('<nodeId>', 'Node ID')
     .description('Delete a canvas node')
     .action(async function (this: Command, nodeId: string) {
-      const { format, storeDir, workspace } = getOpts(this);
+      const { format, storeDir, workspace } = await getWorkspaceCommandOptions(this);
 
       const result = await deleteNode(workspace, nodeId, storeDir);
       if (!result.ok) errorOutput(result.error);

--- a/packages/canvas-cli/src/commands/node.ts
+++ b/packages/canvas-cli/src/commands/node.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs';
 import { Command } from 'commander';
-import { loadCanvas } from '../core/store';
+import { loadCanvas, getWorkspaceDir } from '../core/store';
 import {
   getNodeCapabilities,
   readNode,
@@ -46,7 +46,7 @@ export function registerNodeCommands(program: Command): void {
     .action(async function (this: Command) {
       const { format, storeDir, workspace } = await getWorkspaceCommandOptions(this);
       const canvas = await loadCanvas(workspace, storeDir);
-      if (!canvas) errorOutput(`Workspace not found: ${workspace}`);
+      if (!canvas) errorOutput(`Workspace not found: ${workspace}`, { code: 'workspace_not_found' });
 
       const rows = canvas!.nodes.map(n => ({
         id: n.id,
@@ -69,14 +69,16 @@ export function registerNodeCommands(program: Command): void {
     .argument('<nodeId>', 'Node ID')
     .description('Read a canvas node')
     .action(async function (this: Command, nodeId: string) {
-      const { format, storeDir, workspace } = await getWorkspaceCommandOptions(this);
+      const { format, storeDir, workspace, confineToWorkspace } = await getWorkspaceCommandOptions(this);
       const canvas = await loadCanvas(workspace, storeDir);
-      if (!canvas) errorOutput(`Workspace not found: ${workspace}`);
+      if (!canvas) errorOutput(`Workspace not found: ${workspace}`, { code: 'workspace_not_found' });
 
       const canvasNode = canvas!.nodes.find(n => n.id === nodeId);
-      if (!canvasNode) errorOutput(`Node not found: ${nodeId}`);
+      if (!canvasNode) errorOutput(`Node not found: ${nodeId}`, { code: 'node_not_found' });
 
-      const result = await readNode(canvasNode!);
+      const result = await readNode(canvasNode!, {
+        confineToDir: confineToWorkspace ? getWorkspaceDir(workspace, storeDir) : undefined,
+      });
 
       output(result, format, (data) => {
         const d = data as Record<string, unknown>;
@@ -107,7 +109,7 @@ export function registerNodeCommands(program: Command): void {
     .option('--raw', 'Treat --content verbatim without interpreting escape sequences', false)
     .description('Write content to a canvas node')
     .action(async function (this: Command, nodeId: string, cmdOpts: { content?: string; file?: string; raw?: boolean }) {
-      const { format, storeDir, workspace } = await getWorkspaceCommandOptions(this);
+      const { format, storeDir, workspace, confineToWorkspace } = await getWorkspaceCommandOptions(this);
 
       let content: string;
       if (cmdOpts.content !== undefined) {
@@ -116,7 +118,7 @@ export function registerNodeCommands(program: Command): void {
         try {
           content = await fs.readFile(cmdOpts.file, 'utf-8');
         } catch (err) {
-          errorOutput(`Cannot read file: ${cmdOpts.file} — ${String(err)}`);
+          errorOutput(`Cannot read file: ${cmdOpts.file} — ${String(err)}`, { code: 'io_error' });
         }
       } else if (!process.stdin.isTTY) {
         // Read from stdin
@@ -126,11 +128,11 @@ export function registerNodeCommands(program: Command): void {
         }
         content = Buffer.concat(chunks).toString('utf-8');
       } else {
-        errorOutput('Provide content via --content, --file, or stdin');
+        errorOutput('Provide content via --content, --file, or stdin', { code: 'invalid_argument' });
       }
 
-      const result = await writeNode(workspace, nodeId, content!, storeDir);
-      if (!result.ok) errorOutput(result.error);
+      const result = await writeNode(workspace, nodeId, content!, storeDir, { confineToWorkspace });
+      if (!result.ok) errorOutput(result.error, { code: result.code ?? 'error' });
 
       output({ ok: true }, format, () => 'OK');
     });
@@ -149,7 +151,7 @@ export function registerNodeCommands(program: Command): void {
 
       const validTypes: CreatableNodeType[] = ['file', 'terminal', 'frame', 'group', 'agent', 'mindmap'];
       if (!validTypes.includes(cmdOpts.type as CreatableNodeType)) {
-        errorOutput(`Invalid type "${cmdOpts.type}". Must be: ${validTypes.join(', ')}`);
+        errorOutput(`Invalid type "${cmdOpts.type}". Must be: ${validTypes.join(', ')}`, { code: 'invalid_argument' });
       }
 
       let data: Record<string, unknown> | undefined;
@@ -157,7 +159,7 @@ export function registerNodeCommands(program: Command): void {
         try {
           data = JSON.parse(cmdOpts.data) as Record<string, unknown>;
         } catch {
-          errorOutput('--data must be valid JSON');
+          errorOutput('--data must be valid JSON', { code: 'invalid_argument' });
         }
       }
 
@@ -171,7 +173,7 @@ export function registerNodeCommands(program: Command): void {
         data,
       }, storeDir);
 
-      if (!result.ok) errorOutput(result.error);
+      if (!result.ok) errorOutput(result.error, { code: result.code ?? 'error' });
 
       if (cmdOpts.type === 'terminal') {
         console.error('Note: Terminal nodes created via CLI have no active PTY session.');
@@ -193,7 +195,7 @@ export function registerNodeCommands(program: Command): void {
       const { format, storeDir, workspace } = await getWorkspaceCommandOptions(this);
 
       const result = await deleteNode(workspace, nodeId, storeDir);
-      if (!result.ok) errorOutput(result.error);
+      if (!result.ok) errorOutput(result.error, { code: result.code ?? 'error' });
 
       output({ deleted: nodeId }, format, () => `Deleted node: ${nodeId}`);
     });

--- a/packages/canvas-cli/src/commands/options.ts
+++ b/packages/canvas-cli/src/commands/options.ts
@@ -1,0 +1,70 @@
+import type { Command } from 'commander';
+import { resolveWorkspaceId, type WorkspaceResolutionSource } from '../core/workspace-resolution';
+import { errorOutput, type OutputFormat } from '../output';
+
+export interface RootOptions {
+  format: OutputFormat;
+  storeDir?: string;
+  /** The `--workspace` flag value, if explicitly passed (undefined otherwise). */
+  workspace?: string;
+}
+
+/**
+ * Walk up to the root `program` and read its global options. Subcommands live
+ * one or two levels below the root (`program → node → list`), so we climb to
+ * the top rather than guessing the depth.
+ */
+export function getRootOptions(cmd: Command): RootOptions {
+  let root: Command = cmd;
+  while (root.parent) root = root.parent;
+  const opts = root.opts();
+  return {
+    format: opts.format ?? 'text',
+    storeDir: opts.storeDir,
+    workspace: opts.workspace,
+  };
+}
+
+export interface WorkspaceCommandOptions extends RootOptions {
+  workspace: string;
+  workspaceSource: WorkspaceResolutionSource;
+}
+
+export interface WorkspaceCommandOptionsConfig {
+  /**
+   * Require the resolved workspace to have a readable local `canvas.json`.
+   * Default `true` — correct for commands that read/write the on-disk store
+   * (node, edge, context). Runtime-mediated commands (agent, team) pass
+   * `false`: the workspace lives in the running app, and the loopback runtime
+   * server is the authority on whether it exists.
+   */
+  requireReadableCanvas?: boolean;
+}
+
+/**
+ * Resolve the global options plus the workspace a command should act on,
+ * applying the shared discovery order (`--workspace` → env → active
+ * workspace). Exits with a friendly error if no workspace can be resolved or
+ * the resolved one is invalid, so command actions can treat the returned
+ * `workspace` as guaranteed-present.
+ */
+export async function getWorkspaceCommandOptions(
+  cmd: Command,
+  config: WorkspaceCommandOptionsConfig = {},
+): Promise<WorkspaceCommandOptions> {
+  const root = getRootOptions(cmd);
+  try {
+    const resolution = await resolveWorkspaceId({
+      explicitId: root.workspace,
+      storeDir: root.storeDir,
+      requireReadableCanvas: config.requireReadableCanvas,
+    });
+    return {
+      ...root,
+      workspace: resolution.workspaceId,
+      workspaceSource: resolution.source,
+    };
+  } catch (err) {
+    errorOutput((err as Error).message);
+  }
+}

--- a/packages/canvas-cli/src/commands/options.ts
+++ b/packages/canvas-cli/src/commands/options.ts
@@ -1,5 +1,9 @@
 import type { Command } from 'commander';
-import { resolveWorkspaceId, type WorkspaceResolutionSource } from '../core/workspace-resolution';
+import {
+  resolveWorkspaceId,
+  WorkspaceResolutionError,
+  type WorkspaceResolutionSource,
+} from '../core/workspace-resolution';
 import { errorOutput, type OutputFormat } from '../output';
 
 export interface RootOptions {
@@ -7,6 +11,8 @@ export interface RootOptions {
   storeDir?: string;
   /** The `--workspace` flag value, if explicitly passed (undefined otherwise). */
   workspace?: string;
+  /** `--confine-to-workspace`: block file-node paths outside the workspace dir. */
+  confineToWorkspace: boolean;
 }
 
 /**
@@ -22,6 +28,7 @@ export function getRootOptions(cmd: Command): RootOptions {
     format: opts.format ?? 'text',
     storeDir: opts.storeDir,
     workspace: opts.workspace,
+    confineToWorkspace: opts.confineToWorkspace === true,
   };
 }
 
@@ -65,6 +72,7 @@ export async function getWorkspaceCommandOptions(
       workspaceSource: resolution.source,
     };
   } catch (err) {
-    errorOutput((err as Error).message);
+    const code = err instanceof WorkspaceResolutionError ? err.code : 'error';
+    errorOutput((err as Error).message, { code });
   }
 }

--- a/packages/canvas-cli/src/commands/restore.ts
+++ b/packages/canvas-cli/src/commands/restore.ts
@@ -35,28 +35,34 @@ import {
   getWorkspaceDir,
   ensureWorkspaceDir,
 } from '../core/store';
+import { resolveWorkspaceId } from '../core/workspace-resolution';
+import { getRootOptions } from './options';
 import { detectSchemaVersion } from '../core/storage-v2';
 import type { CanvasSaveData } from '../core/types';
 import { output, errorOutput, type OutputFormat } from '../output';
 
-function getOpts(cmd: Command): { format: OutputFormat; storeDir?: string; workspace?: string } {
-  const root = cmd.parent?.parent ?? cmd.parent;
-  const opts = root?.opts() ?? {};
-  return {
-    format: opts.format ?? 'text',
-    storeDir: opts.storeDir,
-    workspace: opts.workspace,
-  };
-}
-
-function resolveWorkspaceId(arg: string | undefined, fallback: string | undefined): string {
-  const id = (arg ?? fallback ?? '').trim();
-  if (!id) {
-    errorOutput(
-      'No workspace id. Pass it positionally, via -w/--workspace, or set PULSE_CANVAS_WORKSPACE_ID.',
-    );
+/**
+ * Resolve the workspace `restore` should act on. A positional `[workspaceId]`
+ * wins; otherwise fall back to the shared discovery order (`--workspace` → env
+ * → active workspace). Crucially, `restore` does NOT require a readable
+ * canvas.json — recovering a broken/missing canvas is exactly why it exists.
+ */
+async function resolveRestoreOptions(
+  cmd: Command,
+  positionalArg: string | undefined,
+): Promise<{ format: OutputFormat; storeDir?: string; workspaceId: string }> {
+  const root = getRootOptions(cmd);
+  const positional = positionalArg?.trim();
+  try {
+    const resolution = await resolveWorkspaceId({
+      explicitId: positional || root.workspace,
+      storeDir: root.storeDir,
+      requireReadableCanvas: false,
+    });
+    return { format: root.format, storeDir: root.storeDir, workspaceId: resolution.workspaceId };
+  } catch (err) {
+    errorOutput((err as Error).message);
   }
-  return id;
 }
 
 interface SnapshotEntry {
@@ -311,8 +317,7 @@ export function registerRestoreCommand(program: Command): void {
     .command('list [workspaceId]')
     .description('List available v1 snapshots for a workspace')
     .action(async function (this: Command, workspaceArg?: string) {
-      const { format, storeDir, workspace } = getOpts(this);
-      const workspaceId = resolveWorkspaceId(workspaceArg, workspace);
+      const { format, storeDir, workspaceId } = await resolveRestoreOptions(this, workspaceArg);
       const workspaceDir = getWorkspaceDir(workspaceId, storeDir);
       const snapshots = await listSnapshots(workspaceDir);
 
@@ -347,8 +352,7 @@ export function registerRestoreCommand(program: Command): void {
       workspaceArg: string | undefined,
       cmdOpts: { from: string; dryRun: boolean; yes: boolean },
     ) {
-      const { format, storeDir, workspace } = getOpts(this);
-      const workspaceId = resolveWorkspaceId(workspaceArg, workspace);
+      const { format, storeDir, workspaceId } = await resolveRestoreOptions(this, workspaceArg);
       const workspaceDir = getWorkspaceDir(workspaceId, storeDir);
       await ensureWorkspaceDir(workspaceId, storeDir);
 

--- a/packages/canvas-cli/src/commands/restore.ts
+++ b/packages/canvas-cli/src/commands/restore.ts
@@ -35,7 +35,7 @@ import {
   getWorkspaceDir,
   ensureWorkspaceDir,
 } from '../core/store';
-import { resolveWorkspaceId } from '../core/workspace-resolution';
+import { resolveWorkspaceId, WorkspaceResolutionError } from '../core/workspace-resolution';
 import { getRootOptions } from './options';
 import { detectSchemaVersion } from '../core/storage-v2';
 import type { CanvasSaveData } from '../core/types';
@@ -61,7 +61,8 @@ async function resolveRestoreOptions(
     });
     return { format: root.format, storeDir: root.storeDir, workspaceId: resolution.workspaceId };
   } catch (err) {
-    errorOutput((err as Error).message);
+    const code = err instanceof WorkspaceResolutionError ? err.code : 'error';
+    errorOutput((err as Error).message, { code });
   }
 }
 

--- a/packages/canvas-cli/src/commands/status.ts
+++ b/packages/canvas-cli/src/commands/status.ts
@@ -1,0 +1,73 @@
+import { Command } from 'commander';
+import { DEFAULT_STORE_DIR } from '../core/constants';
+import { loadWorkspaceManifest } from '../core/store';
+import {
+  resolveWorkspaceId,
+  WorkspaceResolutionError,
+  type WorkspaceResolutionSource,
+} from '../core/workspace-resolution';
+import { probeRuntime, runtimeFilePath, type RuntimeStatus } from '../core/runtime-control';
+import { output } from '../output';
+import { getRootOptions } from './options';
+
+interface StatusReport {
+  storeDir: string;
+  activeWorkspaceId: string | null;
+  workspaceCount: number;
+  resolved: {
+    workspaceId: string | null;
+    source: WorkspaceResolutionSource | null;
+    error?: string;
+    code?: string;
+  };
+  runtime: RuntimeStatus & { file: string };
+}
+
+export function registerStatusCommand(program: Command): void {
+  program
+    .command('status')
+    .description('Report store, resolved workspace, and Electron runtime reachability (for external callers)')
+    .action(async function (this: Command) {
+      const { format, storeDir, workspace: explicitId } = getRootOptions(this);
+
+      const manifest = await loadWorkspaceManifest(storeDir);
+
+      // Best-effort resolution — this command must never exit non-zero just
+      // because no workspace is selected; it reports that as data.
+      const resolved: StatusReport['resolved'] = { workspaceId: null, source: null };
+      try {
+        const r = await resolveWorkspaceId({ explicitId, storeDir });
+        resolved.workspaceId = r.workspaceId;
+        resolved.source = r.source;
+      } catch (err) {
+        resolved.error = (err as Error).message;
+        resolved.code = err instanceof WorkspaceResolutionError ? err.code : 'error';
+      }
+
+      const runtime = await probeRuntime();
+
+      const report: StatusReport = {
+        storeDir: storeDir ?? DEFAULT_STORE_DIR,
+        activeWorkspaceId: manifest.activeId ?? null,
+        workspaceCount: (manifest.workspaces ?? []).length,
+        resolved,
+        runtime: { ...runtime, file: runtimeFilePath() },
+      };
+
+      output(report, format, (data) => {
+        const d = data as StatusReport;
+        const lines = [
+          `Store dir:        ${d.storeDir}`,
+          `Workspaces:       ${d.workspaceCount}`,
+          `Active workspace: ${d.activeWorkspaceId ?? '(none)'}`,
+          d.resolved.workspaceId
+            ? `Resolves to:      ${d.resolved.workspaceId} (source: ${d.resolved.source})`
+            : `Resolves to:      (none — ${d.resolved.error ?? 'no workspace selected'})`,
+          d.runtime.reachable
+            ? `Runtime:          reachable at ${d.runtime.baseUrl} (pid ${d.runtime.pid ?? '?'}) — agent/team available`
+            : `Runtime:          not available — ${d.runtime.error ?? 'unknown'}`,
+        ];
+        return lines.join('\n');
+      });
+    });
+}

--- a/packages/canvas-cli/src/commands/team.ts
+++ b/packages/canvas-cli/src/commands/team.ts
@@ -248,8 +248,8 @@ export function registerTeamCommands(program: Command): void {
         plan,
       });
 
-      if (status === 401) errorOutput(runtimeAuthHint());
-      if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`);
+      if (status === 401) errorOutput(runtimeAuthHint(), { code: 'runtime_auth' });
+      if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`, { code: body.code ?? 'runtime_error' });
 
       output(body, format, (data) => {
         const response = data as ProposePlanResponse;
@@ -303,8 +303,8 @@ export function registerTeamCommands(program: Command): void {
         dispatch: cmdOpts.dispatch === true,
       }, cmdOpts.sourceAgent));
 
-      if (status === 401) errorOutput(runtimeAuthHint());
-      if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`);
+      if (status === 401) errorOutput(runtimeAuthHint(), { code: 'runtime_auth' });
+      if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`, { code: body.code ?? 'runtime_error' });
 
       output(body, format, (data) => {
         const response = data as TeamSnapshotResponse;
@@ -327,8 +327,8 @@ export function registerTeamCommands(program: Command): void {
         teamId,
       });
 
-      if (status === 401) errorOutput(runtimeAuthHint());
-      if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`);
+      if (status === 401) errorOutput(runtimeAuthHint(), { code: 'runtime_auth' });
+      if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`, { code: body.code ?? 'runtime_error' });
 
       output(body, format, (data) => {
         const response = data as TeamSnapshotResponse;
@@ -362,8 +362,8 @@ export function registerTeamCommands(program: Command): void {
         summary,
       }, cmdOpts.sourceAgent));
 
-      if (status === 401) errorOutput(runtimeAuthHint());
-      if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`);
+      if (status === 401) errorOutput(runtimeAuthHint(), { code: 'runtime_auth' });
+      if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`, { code: body.code ?? 'runtime_error' });
 
       output(body, format, (data) => {
         const response = data as { task?: { status?: string; title?: string } };
@@ -399,8 +399,8 @@ export function registerTeamCommands(program: Command): void {
         reason,
       }, cmdOpts.sourceAgent));
 
-      if (status === 401) errorOutput(runtimeAuthHint());
-      if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`);
+      if (status === 401) errorOutput(runtimeAuthHint(), { code: 'runtime_auth' });
+      if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`, { code: body.code ?? 'runtime_error' });
 
       output(body, format, () => `Task blocked for ${teamId}.`);
     });
@@ -418,8 +418,8 @@ export function registerTeamCommands(program: Command): void {
         ...(teamId ? { teamId } : {}),
       }) as { status: number; body: TeamStatusResponse };
 
-      if (status === 401) errorOutput(runtimeAuthHint());
-      if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`);
+      if (status === 401) errorOutput(runtimeAuthHint(), { code: 'runtime_auth' });
+      if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`, { code: body.code ?? 'runtime_error' });
 
       output(body, format, (data) => renderTeamStatus(data as TeamStatusResponse));
     });
@@ -448,8 +448,8 @@ export function registerTeamCommands(program: Command): void {
         reason,
       }, cmdOpts.sourceAgent));
 
-      if (status === 401) errorOutput(runtimeAuthHint());
-      if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`);
+      if (status === 401) errorOutput(runtimeAuthHint(), { code: 'runtime_auth' });
+      if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`, { code: body.code ?? 'runtime_error' });
 
       output(body, format, () => `Task cancelled for ${teamId}; its file scope is released.`);
     });
@@ -480,8 +480,8 @@ export function registerTeamCommands(program: Command): void {
         prompt,
       }, cmdOpts.sourceAgent));
 
-      if (status === 401) errorOutput(runtimeAuthHint());
-      if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`);
+      if (status === 401) errorOutput(runtimeAuthHint(), { code: 'runtime_auth' });
+      if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`, { code: body.code ?? 'runtime_error' });
 
       output(body, format, () => `Input requested for ${teamId}.`);
     });
@@ -524,8 +524,8 @@ export function registerTeamCommands(program: Command): void {
         summary,
       }, cmdOpts.sourceAgent));
 
-      if (status === 401) errorOutput(runtimeAuthHint());
-      if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`);
+      if (status === 401) errorOutput(runtimeAuthHint(), { code: 'runtime_auth' });
+      if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`, { code: body.code ?? 'runtime_error' });
 
       output(body, format, () => `Artifact published for ${teamId}: ${cmdOpts.title}.`);
     });
@@ -552,8 +552,8 @@ export function registerTeamCommands(program: Command): void {
         summary,
       }, cmdOpts.sourceAgent));
 
-      if (status === 401) errorOutput(runtimeAuthHint());
-      if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`);
+      if (status === 401) errorOutput(runtimeAuthHint(), { code: 'runtime_auth' });
+      if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`, { code: body.code ?? 'runtime_error' });
 
       output(body, format, () => `Team completed: ${teamId}.`);
     });
@@ -585,8 +585,8 @@ export function registerTeamCommands(program: Command): void {
         content,
       });
 
-      if (status === 401) errorOutput(runtimeAuthHint());
-      if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`);
+      if (status === 401) errorOutput(runtimeAuthHint(), { code: 'runtime_auth' });
+      if (!body.ok) errorOutput(body.error ?? `HTTP ${status}`, { code: body.code ?? 'runtime_error' });
 
       output(body, format, (data) => {
         const response = data as TeamSnapshotResponse;

--- a/packages/canvas-cli/src/commands/team.ts
+++ b/packages/canvas-cli/src/commands/team.ts
@@ -1,15 +1,11 @@
 import { promises as fs } from 'fs';
 import { Command } from 'commander';
-import { errorOutput, output, type OutputFormat } from '../output';
+import { errorOutput, output } from '../output';
+import { getWorkspaceCommandOptions } from './options';
 import { postRuntime, readRuntime, runtimeAuthHint, type RuntimeInfo } from '../core/runtime-control';
 
 const ENV_TEAM_ID = 'PULSE_CANVAS_TEAM_ID';
 const ENV_TEAM_AGENT_ID = 'PULSE_CANVAS_TEAM_AGENT_ID';
-
-interface TeamCommandOpts {
-  format: OutputFormat;
-  workspace: string;
-}
 
 interface ProposePlanResponse {
   ok: boolean;
@@ -153,16 +149,6 @@ const renderTeamStatus = (response: TeamStatusResponse): string => {
 
 const collectOption = (value: string, previous: string[] = []): string[] => [...previous, value];
 
-function getOpts(cmd: Command): TeamCommandOpts {
-  const root = cmd.parent?.parent ?? cmd.parent;
-  const opts = root?.opts() ?? {};
-  const workspace = opts.workspace as string | undefined;
-  if (!workspace) {
-    errorOutput('Workspace ID required. Use --workspace <id> or set $PULSE_CANVAS_WORKSPACE_ID');
-  }
-  return { format: opts.format ?? 'text', workspace };
-}
-
 async function readPlan(cmdOpts: { planFile?: string; planJson?: string }): Promise<unknown> {
   let raw = cmdOpts.planJson;
   if (!raw && cmdOpts.planFile) {
@@ -247,7 +233,7 @@ export function registerTeamCommands(program: Command): void {
         planJson?: string;
       },
     ) {
-      const { format, workspace } = getOpts(this);
+      const { format, workspace } = await getWorkspaceCommandOptions(this, { requireReadableCanvas: false });
       const teamId = cmdOpts.team || process.env[ENV_TEAM_ID];
       if (!teamId) {
         errorOutput(`Team ID required. Pass --team <id> or set $${ENV_TEAM_ID}.`);
@@ -300,7 +286,7 @@ export function registerTeamCommands(program: Command): void {
         dispatch?: boolean;
       },
     ) {
-      const { format, workspace } = getOpts(this);
+      const { format, workspace } = await getWorkspaceCommandOptions(this, { requireReadableCanvas: false });
       const teamId = cmdOpts.team || process.env[ENV_TEAM_ID];
       if (!teamId) errorOutput(`Team ID required. Pass --team <id> or set $${ENV_TEAM_ID}.`);
 
@@ -331,7 +317,7 @@ export function registerTeamCommands(program: Command): void {
     .option('--team <teamId>', `Team ID (default: $${ENV_TEAM_ID})`, process.env[ENV_TEAM_ID])
     .description('Dispatch ready team tasks')
     .action(async function (this: Command, cmdOpts: { team?: string }) {
-      const { format, workspace } = getOpts(this);
+      const { format, workspace } = await getWorkspaceCommandOptions(this, { requireReadableCanvas: false });
       const teamId = cmdOpts.team || process.env[ENV_TEAM_ID];
       if (!teamId) errorOutput(`Team ID required. Pass --team <id> or set $${ENV_TEAM_ID}.`);
 
@@ -364,7 +350,7 @@ export function registerTeamCommands(program: Command): void {
       summaryParts: string[] | undefined,
       cmdOpts: { team?: string; sourceAgent?: string; task?: string; summary?: string },
     ) {
-      const { format, workspace } = getOpts(this);
+      const { format, workspace } = await getWorkspaceCommandOptions(this, { requireReadableCanvas: false });
       const teamId = cmdOpts.team || process.env[ENV_TEAM_ID];
       if (!teamId) errorOutput(`Team ID required. Pass --team <id> or set $${ENV_TEAM_ID}.`);
       const summary = textFromOptionOrParts(cmdOpts.summary, summaryParts, 'Summary');
@@ -401,7 +387,7 @@ export function registerTeamCommands(program: Command): void {
       reasonParts: string[] | undefined,
       cmdOpts: { team?: string; sourceAgent?: string; task?: string; reason?: string },
     ) {
-      const { format, workspace } = getOpts(this);
+      const { format, workspace } = await getWorkspaceCommandOptions(this, { requireReadableCanvas: false });
       const teamId = cmdOpts.team || process.env[ENV_TEAM_ID];
       if (!teamId) errorOutput(`Team ID required. Pass --team <id> or set $${ENV_TEAM_ID}.`);
       const reason = textFromOptionOrParts(cmdOpts.reason, reasonParts, 'Reason');
@@ -423,7 +409,7 @@ export function registerTeamCommands(program: Command): void {
     .option('--team <teamId>', `Team ID (default: $${ENV_TEAM_ID}; omit to list all teams)`, process.env[ENV_TEAM_ID])
     .description('Show read-only team status: agents, session health, tasks, open questions, pending reviews')
     .action(async function (this: Command, cmdOpts: { team?: string }) {
-      const { format, workspace } = getOpts(this);
+      const { format, workspace } = await getWorkspaceCommandOptions(this, { requireReadableCanvas: false });
       const teamId = cmdOpts.team || process.env[ENV_TEAM_ID] || undefined;
 
       const runtime = await readRuntime();
@@ -450,7 +436,7 @@ export function registerTeamCommands(program: Command): void {
       reasonParts: string[] | undefined,
       cmdOpts: { team?: string; sourceAgent?: string; task?: string; reason?: string },
     ) {
-      const { format, workspace } = getOpts(this);
+      const { format, workspace } = await getWorkspaceCommandOptions(this, { requireReadableCanvas: false });
       const teamId = cmdOpts.team || process.env[ENV_TEAM_ID];
       if (!teamId) errorOutput(`Team ID required. Pass --team <id> or set $${ENV_TEAM_ID}.`);
       const reason = textFromOptionOrParts(cmdOpts.reason, reasonParts, 'Reason');
@@ -481,7 +467,7 @@ export function registerTeamCommands(program: Command): void {
       promptParts: string[] | undefined,
       cmdOpts: { team?: string; sourceAgent?: string; task?: string; reason?: string; prompt?: string },
     ) {
-      const { format, workspace } = getOpts(this);
+      const { format, workspace } = await getWorkspaceCommandOptions(this, { requireReadableCanvas: false });
       const teamId = cmdOpts.team || process.env[ENV_TEAM_ID];
       if (!teamId) errorOutput(`Team ID required. Pass --team <id> or set $${ENV_TEAM_ID}.`);
       const prompt = textFromOptionOrParts(cmdOpts.prompt, promptParts, 'Prompt');
@@ -523,7 +509,7 @@ export function registerTeamCommands(program: Command): void {
         summary?: string;
       },
     ) {
-      const { format, workspace } = getOpts(this);
+      const { format, workspace } = await getWorkspaceCommandOptions(this, { requireReadableCanvas: false });
       const teamId = cmdOpts.team || process.env[ENV_TEAM_ID];
       if (!teamId) errorOutput(`Team ID required. Pass --team <id> or set $${ENV_TEAM_ID}.`);
       const summary = (cmdOpts.summary || (summaryParts ?? []).join(' ')).trim() || undefined;
@@ -555,7 +541,7 @@ export function registerTeamCommands(program: Command): void {
       summaryParts: string[] | undefined,
       cmdOpts: { team?: string; sourceAgent?: string; summary?: string },
     ) {
-      const { format, workspace } = getOpts(this);
+      const { format, workspace } = await getWorkspaceCommandOptions(this, { requireReadableCanvas: false });
       const teamId = cmdOpts.team || process.env[ENV_TEAM_ID];
       if (!teamId) errorOutput(`Team ID required. Pass --team <id> or set $${ENV_TEAM_ID}.`);
       const summary = textFromOptionOrParts(cmdOpts.summary, summaryParts, 'Summary');
@@ -584,7 +570,7 @@ export function registerTeamCommands(program: Command): void {
       messageParts: string[] | undefined,
       cmdOpts: { team?: string; to: string; task?: string; message?: string },
     ) {
-      const { format, workspace } = getOpts(this);
+      const { format, workspace } = await getWorkspaceCommandOptions(this, { requireReadableCanvas: false });
       const teamId = cmdOpts.team || process.env[ENV_TEAM_ID];
       if (!teamId) errorOutput(`Team ID required. Pass --team <id> or set $${ENV_TEAM_ID}.`);
       const content = (cmdOpts.message || (messageParts ?? []).join(' ')).trim();

--- a/packages/canvas-cli/src/commands/workspace.ts
+++ b/packages/canvas-cli/src/commands/workspace.ts
@@ -12,14 +12,15 @@ import {
   ensureWorkspaceDir,
 } from '../core/store';
 import { getNodeCapabilities } from '../core/nodes';
+import { resolveWorkspaceId } from '../core/workspace-resolution';
 import { DEFAULT_NODE_DIMENSIONS } from '../core/constants';
 import type { CanvasNode, CanvasSaveData } from '../core/types';
 import { output, errorOutput, type OutputFormat } from '../output';
+import { getRootOptions } from './options';
 
 function getOpts(cmd: Command): { format: OutputFormat; storeDir?: string } {
-  const root = cmd.parent?.parent ?? cmd.parent;
-  const opts = root?.opts() ?? {};
-  return { format: opts.format ?? 'text', storeDir: opts.storeDir };
+  const { format, storeDir } = getRootOptions(cmd);
+  return { format, storeDir };
 }
 
 export function registerWorkspaceCommands(program: Command): void {
@@ -38,13 +39,41 @@ export function registerWorkspaceCommands(program: Command): void {
       const rows = ids.map(id => ({
         id,
         name: nameMap.get(id) ?? id,
+        active: id === manifest.activeId,
       }));
 
       output(rows, format, (data) => {
         const items = data as typeof rows;
         if (items.length === 0) return 'No workspaces found.';
-        const lines = items.map(r => `  ${r.id}  ${r.name}`);
-        return `Workspaces:\n${lines.join('\n')}`;
+        const lines = items.map(r => `  ${r.active ? '*' : ' '} ${r.id}  ${r.name}`);
+        return `Workspaces (* = active):\n${lines.join('\n')}`;
+      });
+    });
+
+  ws.command('current')
+    .description('Show the workspace the CLI resolves to (--workspace → env → active)')
+    .action(async function (this: Command) {
+      const { format, storeDir, workspace: explicitId } = getRootOptions(this);
+      let resolution;
+      try {
+        resolution = await resolveWorkspaceId({ explicitId, storeDir });
+      } catch (err) {
+        errorOutput((err as Error).message);
+      }
+
+      const manifest = await loadWorkspaceManifest(storeDir);
+      const entry = (manifest.workspaces ?? []).find(e => e.id === resolution.workspaceId);
+
+      const info = {
+        id: resolution.workspaceId,
+        name: entry?.name ?? resolution.workspaceId,
+        active: resolution.workspaceId === manifest.activeId,
+        source: resolution.source,
+      };
+
+      output(info, format, (data) => {
+        const d = data as typeof info;
+        return `${d.id}  ${d.name}${d.active ? '  (active)' : ''}  [source: ${d.source}]`;
       });
     });
 

--- a/packages/canvas-cli/src/commands/workspace.ts
+++ b/packages/canvas-cli/src/commands/workspace.ts
@@ -12,7 +12,7 @@ import {
   ensureWorkspaceDir,
 } from '../core/store';
 import { getNodeCapabilities } from '../core/nodes';
-import { resolveWorkspaceId } from '../core/workspace-resolution';
+import { resolveWorkspaceId, WorkspaceResolutionError } from '../core/workspace-resolution';
 import { DEFAULT_NODE_DIMENSIONS } from '../core/constants';
 import type { CanvasNode, CanvasSaveData } from '../core/types';
 import { output, errorOutput, type OutputFormat } from '../output';
@@ -58,7 +58,8 @@ export function registerWorkspaceCommands(program: Command): void {
       try {
         resolution = await resolveWorkspaceId({ explicitId, storeDir });
       } catch (err) {
-        errorOutput((err as Error).message);
+        const code = err instanceof WorkspaceResolutionError ? err.code : 'error';
+        errorOutput((err as Error).message, { code });
       }
 
       const manifest = await loadWorkspaceManifest(storeDir);
@@ -83,7 +84,7 @@ export function registerWorkspaceCommands(program: Command): void {
     .action(async function (this: Command, workspaceId: string) {
       const { format, storeDir } = getOpts(this);
       const canvas = await loadCanvas(workspaceId, storeDir);
-      if (!canvas) errorOutput(`Workspace not found: ${workspaceId}`);
+      if (!canvas) errorOutput(`Workspace not found: ${workspaceId}`, { code: 'workspace_not_found' });
 
       const manifest = await loadWorkspaceManifest(storeDir);
       const entry = (manifest.workspaces ?? []).find(e => e.id === workspaceId);
@@ -135,7 +136,7 @@ export function registerWorkspaceCommands(program: Command): void {
     .action(async function (this: Command, workspaceId: string, cmdOpts: { confirm?: boolean }) {
       const { format, storeDir } = getOpts(this);
       if (!cmdOpts.confirm) {
-        errorOutput('Use --confirm to delete a workspace. This action is irreversible.');
+        errorOutput('Use --confirm to delete a workspace. This action is irreversible.', { code: 'confirmation_required' });
       }
 
       const result = await deleteWorkspace(workspaceId, storeDir);
@@ -170,7 +171,7 @@ export function registerWorkspaceCommands(program: Command): void {
           .filter((e) => e.isFile() && e.name.endsWith('.md'))
           .map((e) => e.name);
       } catch {
-        errorOutput(`Notes directory not found: ${notesDir}`);
+        errorOutput(`Notes directory not found: ${notesDir}`, { code: 'not_found' });
       }
 
       // Note files are written as `{safeTitle}-{nodeId}.md` where nodeId

--- a/packages/canvas-cli/src/core/__tests__/modern-nodes.test.ts
+++ b/packages/canvas-cli/src/core/__tests__/modern-nodes.test.ts
@@ -23,10 +23,14 @@ function makeNode(type: string, data: Record<string, unknown>, title = 'Node'): 
 }
 
 describe('getNodeCapabilities for modern types', () => {
-  it('returns read-only for the app-produced types', () => {
-    for (const t of ['text', 'iframe', 'image', 'shape', 'reference', 'dynamic-app', 'plugin']) {
+  it('returns read-only for the app-produced read-only types', () => {
+    for (const t of ['iframe', 'image', 'shape', 'reference', 'dynamic-app', 'plugin']) {
       expect(getNodeCapabilities(t)).toEqual(['read']);
     }
+  });
+
+  it('reports text as read+write (its markdown is editable from the CLI)', () => {
+    expect(getNodeCapabilities('text')).toEqual(['read', 'write']);
   });
 
   it('falls back to read-only for an unknown future type', () => {

--- a/packages/canvas-cli/src/core/__tests__/modern-nodes.test.ts
+++ b/packages/canvas-cli/src/core/__tests__/modern-nodes.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { readNode, getNodeCapabilities } from '../nodes';
+import { saveCanvas } from '../store';
+import { generateContext } from '../context';
+import type { CanvasNode, CanvasSaveData } from '../types';
+
+let testDir: string;
+
+beforeEach(async () => {
+  testDir = join(tmpdir(), `canvas-cli-modern-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`);
+  await fs.mkdir(testDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await fs.rm(testDir, { recursive: true, force: true });
+});
+
+function makeNode(type: string, data: Record<string, unknown>, title = 'Node'): CanvasNode {
+  return { id: `n-${type}`, type, title, x: 0, y: 0, width: 100, height: 100, data };
+}
+
+describe('getNodeCapabilities for modern types', () => {
+  it('returns read-only for the app-produced types', () => {
+    for (const t of ['text', 'iframe', 'image', 'shape', 'reference', 'dynamic-app', 'plugin']) {
+      expect(getNodeCapabilities(t)).toEqual(['read']);
+    }
+  });
+
+  it('falls back to read-only for an unknown future type', () => {
+    expect(getNodeCapabilities('some-future-node')).toEqual(['read']);
+  });
+});
+
+describe('readNode for modern node types', () => {
+  it('reads a text node with content and styling', async () => {
+    const node = makeNode('text', { content: '# Heading\n\nBody', fontSize: 14, color: '#333', extra: 'ignored' });
+    const result = await readNode(node);
+    expect(result.type).toBe('text');
+    expect(result.content).toBe('# Heading\n\nBody');
+    expect(result.fontSize).toBe(14);
+    expect(result.color).toBe('#333');
+    // Only the declared keys are surfaced.
+    expect(result.extra).toBeUndefined();
+  });
+
+  it('reads an iframe node with its persisted metadata (including html/prompt)', async () => {
+    const node = makeNode('iframe', {
+      mode: 'url',
+      url: 'https://example.com/viz',
+      html: '<html>big body</html>',
+      prompt: 'render a chart',
+      artifactId: 'art-1',
+      pageTitle: 'Trajectory Viz',
+    });
+    const result = await readNode(node);
+    expect(result).toMatchObject({
+      type: 'iframe',
+      mode: 'url',
+      url: 'https://example.com/viz',
+      html: '<html>big body</html>',
+      prompt: 'render a chart',
+      artifactId: 'art-1',
+      pageTitle: 'Trajectory Viz',
+    });
+  });
+
+  it('reads an image node as its local file path only', async () => {
+    const node = makeNode('image', { filePath: '/tmp/pic.png', alt: 'a picture' });
+    const result = await readNode(node);
+    expect(result).toMatchObject({ type: 'image', filePath: '/tmp/pic.png', alt: 'a picture' });
+  });
+
+  it('reads a shape node', async () => {
+    const node = makeNode('shape', { shape: 'rect', text: 'Label', style: { fill: '#fff' } });
+    const result = await readNode(node);
+    expect(result).toMatchObject({ type: 'shape', shape: 'rect', text: 'Label', style: { fill: '#fff' } });
+  });
+
+  it('reads a dynamic-app node', async () => {
+    const node = makeNode('dynamic-app', { url: 'https://app.example', dynamicAppId: 'app-9' });
+    const result = await readNode(node);
+    expect(result).toMatchObject({ type: 'dynamic-app', url: 'https://app.example', dynamicAppId: 'app-9' });
+  });
+
+  it('reads a plugin node with its payload', async () => {
+    const payload = { foo: 'bar', nested: { n: 1 } };
+    const node = makeNode('plugin', { pluginId: 'p1', nodeType: 'chart', version: '2.0', payload });
+    const result = await readNode(node);
+    expect(result).toMatchObject({ type: 'plugin', pluginId: 'p1', nodeType: 'chart', version: '2.0', payload });
+  });
+
+  it('surfaces raw data for an unknown future node type instead of dropping it', async () => {
+    const node = makeNode('future-widget', { anything: 42 });
+    const result = await readNode(node);
+    expect(result.type).toBe('future-widget');
+    expect(result.capabilities).toEqual(['read']);
+    expect(result.data).toEqual({ anything: 42 });
+  });
+});
+
+describe('context stays bounded for large modern nodes', () => {
+  const bigHtml = '<html>' + 'x'.repeat(5000) + '</html>';
+  const longText = 'A'.repeat(500);
+
+  async function seedCanvas(): Promise<void> {
+    const canvas: CanvasSaveData = {
+      nodes: [
+        makeNode('text', { content: longText }, 'Long Note'),
+        makeNode('iframe', {
+          mode: 'html',
+          url: 'https://example.com/page',
+          html: bigHtml,
+          prompt: 'a very long prompt '.repeat(50),
+          pageTitle: 'Path Viz',
+        }, 'Embedded Page'),
+      ],
+      transform: { x: 0, y: 0, scale: 1 },
+      savedAt: '2025-01-01T00:00:00.000Z',
+    };
+    await saveCanvas('ws-modern', canvas, testDir);
+  }
+
+  it('excerpts text and never inlines iframe html/prompt', async () => {
+    await seedCanvas();
+    const ctx = await generateContext('ws-modern', testDir);
+    expect(ctx).not.toBeNull();
+
+    const serialized = JSON.stringify(ctx);
+    // The heavy fields must not leak into context.
+    expect(serialized).not.toContain(bigHtml);
+    expect(serialized).not.toContain('<html>');
+    expect(serialized).not.toContain('a very long prompt a very long prompt');
+    // And the full 500-char text body is not inlined verbatim.
+    expect(serialized).not.toContain(longText);
+
+    const textNode = ctx!.nodes.find(n => n.type === 'text')!;
+    expect(String(textNode.excerpt).length).toBeLessThanOrEqual(201);
+    expect(String(textNode.excerpt).endsWith('…')).toBe(true);
+
+    const iframeNode = ctx!.nodes.find(n => n.type === 'iframe')!;
+    expect(iframeNode.url).toBe('https://example.com/page');
+    expect(iframeNode.mode).toBe('html');
+    expect(iframeNode.pageTitle).toBe('Path Viz');
+    expect(iframeNode.html).toBeUndefined();
+    expect(iframeNode.prompt).toBeUndefined();
+  });
+
+  it('keeps the full text body reachable via readNode (what `node read` uses)', async () => {
+    await seedCanvas();
+    const node = makeNode('text', { content: longText });
+    const full = await readNode(node);
+    expect(full.content).toBe(longText);
+  });
+
+  it('formats new node types (and unknown ones) into the text context', async () => {
+    const { formatContextAsText } = await import('../context');
+    await seedCanvas();
+    const ctx = await generateContext('ws-modern', testDir);
+    const text = formatContextAsText(ctx!);
+    expect(text).toContain('## Text');
+    expect(text).toContain('## Embeds (iframe)');
+    expect(text).toContain('https://example.com/page');
+    // No raw HTML dumped into the human-readable form either.
+    expect(text).not.toContain('<html>');
+  });
+});

--- a/packages/canvas-cli/src/core/__tests__/node-query.test.ts
+++ b/packages/canvas-cli/src/core/__tests__/node-query.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { searchNodes, updateNode } from '../nodes';
+import { saveCanvas, loadCanvas } from '../store';
+import { generateContext, CONTEXT_SCHEMA_VERSION } from '../context';
+import type { CanvasNode, CanvasSaveData } from '../types';
+
+let testDir: string;
+
+beforeEach(async () => {
+  testDir = join(tmpdir(), `canvas-cli-query-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`);
+  await fs.mkdir(testDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await fs.rm(testDir, { recursive: true, force: true });
+});
+
+const node = (id: string, type: string, title: string, data: Record<string, unknown> = {}): CanvasNode =>
+  ({ id, type, title, x: 0, y: 0, width: 100, height: 100, data });
+
+describe('searchNodes', () => {
+  const nodes: CanvasNode[] = [
+    node('a', 'text', 'Alpha', { content: 'needle in a haystack' }),
+    node('b', 'file', 'Beta needle', { content: 'unrelated' }),
+    node('c', 'text', 'Gamma', { content: 'nothing here' }),
+    node('d', 'iframe', 'Needle embed', { url: 'https://x' }),
+  ];
+
+  it('matches title and content, case-insensitively', () => {
+    const hits = searchNodes(nodes, 'NEEDLE');
+    expect(hits.map(h => h.id).sort()).toEqual(['a', 'b', 'd']);
+  });
+
+  it('respects a type filter', () => {
+    const hits = searchNodes(nodes, 'needle', { type: 'text' });
+    expect(hits.map(h => h.id)).toEqual(['a']);
+  });
+
+  it('respects a limit', () => {
+    expect(searchNodes(nodes, 'needle', { limit: 2 })).toHaveLength(2);
+  });
+
+  it('returns a snippet around the match', () => {
+    const [hit] = searchNodes(nodes, 'haystack');
+    expect(hit.snippet).toContain('haystack');
+  });
+});
+
+describe('updateNode', () => {
+  it('moves, resizes, and renames a node without touching data', async () => {
+    const canvas: CanvasSaveData = {
+      nodes: [node('n1', 'text', 'Old', { content: 'keep me' })],
+      transform: { x: 0, y: 0, scale: 1 },
+      savedAt: '2025-01-01T00:00:00.000Z',
+    };
+    await saveCanvas('ws', canvas, testDir);
+
+    const result = await updateNode('ws', 'n1', { x: 300, y: 400, width: 200, title: 'New' }, testDir);
+    expect(result.ok).toBe(true);
+
+    const updated = await loadCanvas('ws', testDir);
+    const n = updated!.nodes[0];
+    expect([n.x, n.y, n.width, n.title]).toEqual([300, 400, 200, 'New']);
+    expect(n.data.content).toBe('keep me');
+  });
+
+  it('reports node_not_found with a code', async () => {
+    await saveCanvas('ws', { nodes: [node('a', 'text', 'A')], transform: { x: 0, y: 0, scale: 1 }, savedAt: '' }, testDir);
+    const result = await updateNode('ws', 'missing', { x: 1 }, testDir);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('node_not_found');
+  });
+});
+
+describe('generateContext filtering + version', () => {
+  async function seed(): Promise<void> {
+    const canvas: CanvasSaveData = {
+      nodes: [
+        node('t1', 'text', 'Note', { content: 'x' }),
+        node('f1', 'file', 'Doc', { content: 'y' }),
+        node('i1', 'iframe', 'Embed', { url: 'https://x' }),
+      ],
+      edges: [
+        { id: 'e1', source: { kind: 'node', nodeId: 't1' }, target: { kind: 'node', nodeId: 'f1' } },
+        { id: 'e2', source: { kind: 'node', nodeId: 't1' }, target: { kind: 'node', nodeId: 'i1' } },
+      ],
+      transform: { x: 0, y: 0, scale: 1 },
+      savedAt: '2025-01-01T00:00:00.000Z',
+    };
+    await saveCanvas('ws', canvas, testDir);
+  }
+
+  it('stamps the context schema version', async () => {
+    await seed();
+    const ctx = await generateContext('ws', testDir);
+    expect(ctx!.contextVersion).toBe(CONTEXT_SCHEMA_VERSION);
+  });
+
+  it('includes only the requested types and drops edges to excluded nodes', async () => {
+    await seed();
+    const ctx = await generateContext('ws', testDir, { types: ['text', 'file'] });
+    expect(ctx!.nodes.map(n => n.type).sort()).toEqual(['file', 'text']);
+    // e1 (t1→f1) both included; e2 (t1→i1) dropped because i1 excluded.
+    expect(ctx!.edges.map(e => e.id)).toEqual(['e1']);
+  });
+});

--- a/packages/canvas-cli/src/core/__tests__/node-security.test.ts
+++ b/packages/canvas-cli/src/core/__tests__/node-security.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { readNode, writeNode } from '../nodes';
+import { saveCanvas, loadCanvas, getWorkspaceDir } from '../store';
+import type { CanvasNode, CanvasSaveData } from '../types';
+
+let testDir: string;
+
+beforeEach(async () => {
+  testDir = join(tmpdir(), `canvas-cli-sec-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`);
+  await fs.mkdir(testDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await fs.rm(testDir, { recursive: true, force: true });
+});
+
+function fileNode(id: string, filePath: string, content = ''): CanvasNode {
+  return { id, type: 'file', title: 'F', x: 0, y: 0, width: 100, height: 100, data: { filePath, content } };
+}
+
+describe('file-node path confinement', () => {
+  it('reads a file whose path is inside the workspace as usual', async () => {
+    const wsDir = getWorkspaceDir('ws-c', testDir);
+    await fs.mkdir(join(wsDir, 'notes'), { recursive: true });
+    const inside = join(wsDir, 'notes', 'n.md');
+    await fs.writeFile(inside, 'inside content', 'utf-8');
+
+    const node = fileNode('n1', inside, 'stale');
+    const result = await readNode(node, { confineToDir: wsDir });
+    expect(result.content).toBe('inside content');
+    expect(result.pathConfined).toBeUndefined();
+  });
+
+  it('does NOT read a file outside the workspace under confinement (no disk leak)', async () => {
+    const wsDir = getWorkspaceDir('ws-c', testDir);
+    const secret = join(testDir, 'secret.txt');
+    await fs.writeFile(secret, 'TOP SECRET', 'utf-8');
+
+    const node = fileNode('n1', secret, 'in-memory only');
+    const result = await readNode(node, { confineToDir: wsDir });
+    expect(result.pathConfined).toBe(true);
+    expect(result.content).toBe('in-memory only');
+    expect(String(result.content)).not.toContain('TOP SECRET');
+  });
+
+  it('still reads the escaping path when confinement is off (default behavior)', async () => {
+    const wsDir = getWorkspaceDir('ws-c', testDir);
+    const outside = join(testDir, 'outside.txt');
+    await fs.writeFile(outside, 'outside content', 'utf-8');
+
+    const node = fileNode('n1', outside, 'stale');
+    const result = await readNode(node); // no confineToDir
+    expect(result.content).toBe('outside content');
+    expect(result.pathConfined).toBeUndefined();
+    // sanity: confinement would have blocked it
+    expect((await readNode(node, { confineToDir: wsDir })).pathConfined).toBe(true);
+  });
+
+  it('refuses to write a file node whose path escapes the workspace under confinement', async () => {
+    const outside = join(testDir, 'victim.txt');
+    await fs.writeFile(outside, 'original', 'utf-8');
+    const canvas: CanvasSaveData = {
+      nodes: [fileNode('n1', outside)],
+      transform: { x: 0, y: 0, scale: 1 },
+      savedAt: '2025-01-01T00:00:00.000Z',
+    };
+    await saveCanvas('ws-w', canvas, testDir);
+
+    const result = await writeNode('ws-w', 'n1', 'HACKED', testDir, { confineToWorkspace: true });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('path_confined');
+    // The outside file must be untouched.
+    expect(await fs.readFile(outside, 'utf-8')).toBe('original');
+  });
+
+  it('allows the write when confinement is off', async () => {
+    const outside = join(testDir, 'victim2.txt');
+    await fs.writeFile(outside, 'original', 'utf-8');
+    const canvas: CanvasSaveData = {
+      nodes: [fileNode('n1', outside)],
+      transform: { x: 0, y: 0, scale: 1 },
+      savedAt: '2025-01-01T00:00:00.000Z',
+    };
+    await saveCanvas('ws-w2', canvas, testDir);
+
+    const result = await writeNode('ws-w2', 'n1', 'new', testDir); // no confinement
+    expect(result.ok).toBe(true);
+    expect(await fs.readFile(outside, 'utf-8')).toBe('new');
+  });
+});
+
+describe('text node write', () => {
+  it('updates a text node content in place', async () => {
+    const canvas: CanvasSaveData = {
+      nodes: [{ id: 't1', type: 'text', title: 'Note', x: 0, y: 0, width: 100, height: 100, data: { content: 'old' } }],
+      transform: { x: 0, y: 0, scale: 1 },
+      savedAt: '2025-01-01T00:00:00.000Z',
+    };
+    await saveCanvas('ws-t', canvas, testDir);
+
+    const result = await writeNode('ws-t', 't1', '# New body', testDir);
+    expect(result.ok).toBe(true);
+
+    const updated = await loadCanvas('ws-t', testDir);
+    expect(updated!.nodes[0].data.content).toBe('# New body');
+  });
+
+  it('reports unsupported with a code for a type that cannot be written', async () => {
+    const canvas: CanvasSaveData = {
+      nodes: [{ id: 'i1', type: 'iframe', title: 'V', x: 0, y: 0, width: 100, height: 100, data: { url: 'x' } }],
+      transform: { x: 0, y: 0, scale: 1 },
+      savedAt: '2025-01-01T00:00:00.000Z',
+    };
+    await saveCanvas('ws-i', canvas, testDir);
+
+    const result = await writeNode('ws-i', 'i1', 'nope', testDir);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('unsupported');
+  });
+});

--- a/packages/canvas-cli/src/core/__tests__/workspace-resolution.test.ts
+++ b/packages/canvas-cli/src/core/__tests__/workspace-resolution.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { saveCanvas, saveWorkspaceManifest, getWorkspaceDir } from '../store';
+import { resolveWorkspaceId, ENV_WORKSPACE_ID } from '../workspace-resolution';
+import type { CanvasSaveData } from '../types';
+
+let testDir: string;
+
+const emptyCanvas: CanvasSaveData = {
+  nodes: [],
+  transform: { x: 0, y: 0, scale: 1 },
+  savedAt: '2025-01-01T00:00:00.000Z',
+};
+
+async function seedWorkspace(id: string): Promise<void> {
+  // saveCanvas writes canvas.json (+ AGENTS.md) so the workspace passes the
+  // readable-canvas validation.
+  await saveCanvas(id, emptyCanvas, testDir, { allowEmpty: true });
+}
+
+beforeEach(async () => {
+  testDir = join(tmpdir(), `canvas-cli-resolve-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`);
+  await fs.mkdir(testDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await fs.rm(testDir, { recursive: true, force: true });
+});
+
+describe('resolveWorkspaceId', () => {
+  it('prefers the explicit id over the environment variable and active workspace', async () => {
+    await seedWorkspace('ws-explicit');
+    await seedWorkspace('ws-env');
+    await seedWorkspace('ws-active');
+    await saveWorkspaceManifest(
+      { workspaces: [{ id: 'ws-active', name: 'Active' }], activeId: 'ws-active' },
+      testDir,
+    );
+
+    const resolution = await resolveWorkspaceId({
+      explicitId: 'ws-explicit',
+      storeDir: testDir,
+      env: { [ENV_WORKSPACE_ID]: 'ws-env' },
+    });
+    expect(resolution).toEqual({ workspaceId: 'ws-explicit', source: 'explicit' });
+  });
+
+  it('prefers the environment variable over the active workspace', async () => {
+    await seedWorkspace('ws-env');
+    await seedWorkspace('ws-active');
+    await saveWorkspaceManifest(
+      { workspaces: [{ id: 'ws-active', name: 'Active' }], activeId: 'ws-active' },
+      testDir,
+    );
+
+    const resolution = await resolveWorkspaceId({
+      storeDir: testDir,
+      env: { [ENV_WORKSPACE_ID]: 'ws-env' },
+    });
+    expect(resolution).toEqual({ workspaceId: 'ws-env', source: 'environment' });
+  });
+
+  it('falls back to the manifest activeId when nothing is passed', async () => {
+    await seedWorkspace('ws-active');
+    await saveWorkspaceManifest(
+      { workspaces: [{ id: 'ws-active', name: 'Active' }], activeId: 'ws-active' },
+      testDir,
+    );
+
+    const resolution = await resolveWorkspaceId({ storeDir: testDir, env: {} });
+    expect(resolution).toEqual({ workspaceId: 'ws-active', source: 'manifest-active' });
+  });
+
+  it('reads the activeId from the store named by --store-dir', async () => {
+    // A second store the resolution should NOT see.
+    const otherDir = join(tmpdir(), `canvas-cli-resolve-other-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`);
+    await fs.mkdir(otherDir, { recursive: true });
+    try {
+      await saveCanvas('ws-other', emptyCanvas, otherDir, { allowEmpty: true });
+      await saveWorkspaceManifest(
+        { workspaces: [{ id: 'ws-other', name: 'Other' }], activeId: 'ws-other' },
+        otherDir,
+      );
+      await seedWorkspace('ws-here');
+      await saveWorkspaceManifest(
+        { workspaces: [{ id: 'ws-here', name: 'Here' }], activeId: 'ws-here' },
+        testDir,
+      );
+
+      const resolution = await resolveWorkspaceId({ storeDir: testDir, env: {} });
+      expect(resolution).toEqual({ workspaceId: 'ws-here', source: 'manifest-active' });
+    } finally {
+      await fs.rm(otherDir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws — never silently substitutes — when the activeId workspace does not exist', async () => {
+    await saveWorkspaceManifest(
+      { workspaces: [{ id: 'ws-gone', name: 'Gone' }], activeId: 'ws-gone' },
+      testDir,
+    );
+
+    await expect(resolveWorkspaceId({ storeDir: testDir, env: {} })).rejects.toThrow(/not found/);
+  });
+
+  it('throws on an unsafe activeId rather than resolving it', async () => {
+    // Write the manifest raw so the unsafe id survives to resolution.
+    await fs.writeFile(
+      join(testDir, '__workspaces__.json'),
+      JSON.stringify({ workspaces: [], activeId: '../escape' }),
+      'utf-8',
+    );
+
+    await expect(resolveWorkspaceId({ storeDir: testDir, env: {} })).rejects.toThrow(/[Uu]nsafe/);
+  });
+
+  it('throws a selection hint when there is no manifest to guess from', async () => {
+    await expect(resolveWorkspaceId({ storeDir: testDir, env: {} })).rejects.toThrow(
+      /No workspace selected/,
+    );
+  });
+
+  it('rejects an explicit id whose canvas.json is missing', async () => {
+    await expect(
+      resolveWorkspaceId({ explicitId: 'ws-nope', storeDir: testDir, env: {} }),
+    ).rejects.toThrow(/not found/);
+  });
+
+  it('skips the readable-canvas check when requireReadableCanvas is false (runtime/restore path)', async () => {
+    // No canvas.json on disk, but the id is safe — runtime-mediated commands
+    // (agent, team) and restore must still resolve it.
+    await saveWorkspaceManifest(
+      { workspaces: [{ id: 'ws-runtime', name: 'Runtime' }], activeId: 'ws-runtime' },
+      testDir,
+    );
+
+    const resolution = await resolveWorkspaceId({
+      storeDir: testDir,
+      env: {},
+      requireReadableCanvas: false,
+    });
+    expect(resolution).toEqual({ workspaceId: 'ws-runtime', source: 'manifest-active' });
+    // And nothing was created on disk.
+    await expect(fs.access(join(getWorkspaceDir('ws-runtime', testDir), 'canvas.json'))).rejects.toThrow();
+  });
+
+  it('recovers an explicit id whose canvas.json is corrupt but has a .bak', async () => {
+    await seedWorkspace('ws-bak');
+    const canvasFile = join(getWorkspaceDir('ws-bak', testDir), 'canvas.json');
+    await fs.copyFile(canvasFile, `${canvasFile}.bak`);
+    await fs.writeFile(canvasFile, '{ truncated', 'utf-8');
+
+    // readFile of the corrupt primary still succeeds (validation checks
+    // readability, not parseability), so this resolves via the primary — but
+    // even a genuinely unreadable primary would fall through to the .bak.
+    const resolution = await resolveWorkspaceId({ explicitId: 'ws-bak', storeDir: testDir, env: {} });
+    expect(resolution).toEqual({ workspaceId: 'ws-bak', source: 'explicit' });
+  });
+});

--- a/packages/canvas-cli/src/core/constants.ts
+++ b/packages/canvas-cli/src/core/constants.ts
@@ -11,9 +11,10 @@ export const NODE_CAPABILITIES: Record<KnownNodeType, NodeCapability[]> = {
   group: ['read', 'write'],
   agent: ['read', 'exec'],
   mindmap: ['read', 'write'],
-  // Read-only types the app produces. The CLI surfaces their persisted
-  // metadata but does not create or mutate them (yet).
-  text: ['read'],
+  // App-produced types. `text` is read+write (its markdown lives inline in
+  // canvas.json, so the CLI can edit it); the rest are read-only — the CLI
+  // surfaces their persisted metadata but does not create or mutate them.
+  text: ['read', 'write'],
   iframe: ['read'],
   image: ['read'],
   shape: ['read'],

--- a/packages/canvas-cli/src/core/constants.ts
+++ b/packages/canvas-cli/src/core/constants.ts
@@ -1,27 +1,34 @@
 import { join } from 'path';
 import { homedir } from 'os';
-import type { NodeType, NodeCapability } from './types';
+import type { CreatableNodeType, KnownNodeType, NodeCapability } from './types';
 
 export const DEFAULT_STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
 
-export const NODE_CAPABILITIES: Record<NodeType, NodeCapability[]> = {
+export const NODE_CAPABILITIES: Record<KnownNodeType, NodeCapability[]> = {
   file: ['read', 'write'],
   terminal: ['read', 'exec'],
   frame: ['read', 'write'],
   group: ['read', 'write'],
   agent: ['read', 'exec'],
   mindmap: ['read', 'write'],
+  // Read-only types the app produces. The CLI surfaces their persisted
+  // metadata but does not create or mutate them (yet).
+  text: ['read'],
+  iframe: ['read'],
+  image: ['read'],
+  shape: ['read'],
   reference: ['read'],
+  'dynamic-app': ['read'],
+  plugin: ['read'],
 };
 
-export const DEFAULT_NODE_DIMENSIONS: Record<NodeType, { title: string; width: number; height: number }> = {
+export const DEFAULT_NODE_DIMENSIONS: Record<CreatableNodeType, { title: string; width: number; height: number }> = {
   file: { title: 'Untitled', width: 420, height: 360 },
   terminal: { title: 'Terminal', width: 480, height: 300 },
   frame: { title: 'Frame', width: 720, height: 600 },
   group: { title: 'Group', width: 360, height: 240 },
   agent: { title: 'Agent', width: 520, height: 380 },
   mindmap: { title: 'Mindmap', width: 640, height: 420 },
-  reference: { title: 'Reference', width: 420, height: 300 },
 };
 
 export const AGENTS_MD_TEMPLATE = `# Canvas Agent Config

--- a/packages/canvas-cli/src/core/context.ts
+++ b/packages/canvas-cli/src/core/context.ts
@@ -38,6 +38,20 @@ function extractDescription(content: string): string {
   return '';
 }
 
+/** Max characters of a text node's body included inline in context. */
+const TEXT_EXCERPT_LEN = 200;
+
+/**
+ * Collapse a (possibly long, possibly multi-line) string to a single-line
+ * excerpt for context. Keeps prompts turning into `pulse-canvas context`
+ * output from ballooning an agent's prompt — the full body stays reachable
+ * via `pulse-canvas node read <id> --format json`.
+ */
+function excerpt(text: string, max = TEXT_EXCERPT_LEN): string {
+  const oneLine = text.replace(/\s+/g, ' ').trim();
+  return oneLine.length > max ? `${oneLine.slice(0, max)}…` : oneLine;
+}
+
 export async function generateContext(
   workspaceId: string,
   storeDir?: string,
@@ -85,6 +99,47 @@ export async function generateContext(
         base.status = (readResult as NodeReadResult & { status?: string }).status ?? 'idle';
         base.cwd = (readResult as NodeReadResult & { cwd?: string }).cwd ?? '';
         break;
+      case 'text': {
+        // Excerpt only — the full markdown stays behind `node read`.
+        const content = (readResult as NodeReadResult & { content?: string }).content ?? '';
+        base.excerpt = excerpt(content);
+        break;
+      }
+      case 'iframe': {
+        // Persisted metadata only — never the inlined `html`/`prompt`, which
+        // can be huge and would blow up an agent's prompt.
+        const r = readResult as NodeReadResult & { mode?: string; url?: string; pageTitle?: string };
+        if (r.mode !== undefined) base.mode = r.mode;
+        if (r.url !== undefined) base.url = r.url;
+        if (r.pageTitle !== undefined) base.pageTitle = r.pageTitle;
+        break;
+      }
+      case 'image': {
+        const r = readResult as NodeReadResult & { filePath?: string; src?: string };
+        base.path = r.filePath ?? r.src ?? '';
+        break;
+      }
+      case 'shape': {
+        const r = readResult as NodeReadResult & { shape?: string; shapeType?: string; text?: string };
+        base.shape = r.shape ?? r.shapeType ?? '';
+        if (r.text) base.text = excerpt(String(r.text), 80);
+        break;
+      }
+      case 'dynamic-app': {
+        const r = readResult as NodeReadResult & { url?: string; dynamicAppId?: string };
+        if (r.url !== undefined) base.url = r.url;
+        if (r.dynamicAppId !== undefined) base.dynamicAppId = r.dynamicAppId;
+        break;
+      }
+      case 'plugin': {
+        // pluginId/nodeType/version identify it; the free-form `payload` is
+        // omitted from context (fetch it with `node read` if needed).
+        const r = readResult as NodeReadResult & { pluginId?: string; nodeType?: string; version?: string };
+        if (r.pluginId !== undefined) base.pluginId = r.pluginId;
+        if (r.nodeType !== undefined) base.pluginNodeType = r.nodeType;
+        if (r.version !== undefined) base.version = r.version;
+        break;
+      }
     }
 
     nodes.push(base);
@@ -167,6 +222,39 @@ export function formatContextAsText(ctx: CanvasContext): string {
       const info = `${node.agentType ?? 'unknown'}, ${node.status ?? 'idle'}`;
       const cwd = node.cwd ? `, cwd: \`${node.cwd}\`` : '';
       lines.push(`- **${node.title}** (${info}${cwd})`);
+    }
+  }
+
+  const textNodes = ctx.nodes.filter(n => n.type === 'text');
+  if (textNodes.length > 0) {
+    lines.push('', '## Text', '');
+    for (const node of textNodes) {
+      const ex = node.excerpt ? ` — ${node.excerpt}` : '';
+      lines.push(`- **${node.title}**${ex}`);
+    }
+  }
+
+  const iframeNodes = ctx.nodes.filter(n => n.type === 'iframe');
+  if (iframeNodes.length > 0) {
+    lines.push('', '## Embeds (iframe)', '');
+    for (const node of iframeNodes) {
+      const where = node.url ? ` \`${node.url}\`` : node.mode ? ` (${node.mode})` : '';
+      const page = node.pageTitle ? ` — ${node.pageTitle}` : '';
+      lines.push(`- **${node.title}**${where}${page}`);
+    }
+  }
+
+  // Any node type not rendered above (image, shape, dynamic-app, plugin,
+  // reference, or a future type this CLI has never seen) still gets listed so
+  // an agent knows it exists.
+  const shownTypes = new Set(['file', 'frame', 'group', 'terminal', 'agent', 'text', 'iframe']);
+  const otherNodes = ctx.nodes.filter(n => !shownTypes.has(n.type));
+  if (otherNodes.length > 0) {
+    lines.push('', '## Other nodes', '');
+    for (const node of otherNodes) {
+      const hint = String(node.url ?? node.path ?? node.pluginId ?? node.shape ?? '');
+      const hintStr = hint ? ` — ${hint}` : '';
+      lines.push(`- **${node.title}** [${node.type}]${hintStr}`);
     }
   }
 

--- a/packages/canvas-cli/src/core/context.ts
+++ b/packages/canvas-cli/src/core/context.ts
@@ -19,7 +19,15 @@ interface ContextEdge {
   kind?: string;
 }
 
+/**
+ * Version of the `context` output shape. Bump on any breaking change to the
+ * fields below so machine consumers can detect an incompatible CLI.
+ */
+export const CONTEXT_SCHEMA_VERSION = 1;
+
 interface CanvasContext {
+  /** Output-contract version (see CONTEXT_SCHEMA_VERSION). */
+  contextVersion: number;
   workspaceId: string;
   workspaceName: string;
   canvasDir: string;
@@ -55,6 +63,8 @@ function excerpt(text: string, max = TEXT_EXCERPT_LEN): string {
 export interface GenerateContextOptions {
   /** Restrict file-node disk reads to the workspace dir (see readNode confineToDir). */
   confineToWorkspace?: boolean;
+  /** If set, include only nodes whose `type` is in this list (edges follow). */
+  types?: string[];
 }
 
 export async function generateContext(
@@ -71,9 +81,12 @@ export async function generateContext(
   const canvasDir = getWorkspaceDir(workspaceId, storeDir);
   const confineToDir = opts.confineToWorkspace ? canvasDir : undefined;
 
+  const typeFilter = opts.types && opts.types.length > 0 ? new Set(opts.types) : null;
+  const sourceNodes = typeFilter ? canvas.nodes.filter(n => typeFilter.has(n.type)) : canvas.nodes;
+
   const nodes: ContextNode[] = [];
 
-  for (const node of canvas.nodes) {
+  for (const node of sourceNodes) {
     const readResult = await readNode(node, { confineToDir });
     const base: ContextNode = {
       id: node.id,
@@ -156,7 +169,17 @@ export async function generateContext(
   const nodeTitleById = new Map<string, string>();
   for (const n of canvas.nodes) nodeTitleById.set(n.id, n.title);
 
-  const edges: ContextEdge[] = (canvas.edges ?? []).map(e => {
+  // Under a type filter, drop edges whose node endpoint was filtered out so
+  // the connection list stays consistent with the shown nodes.
+  const includedIds = typeFilter ? new Set(sourceNodes.map(n => n.id)) : null;
+  const edgeVisible = (e: CanvasEdge): boolean => {
+    if (!includedIds) return true;
+    const srcOk = e.source.kind !== 'node' || includedIds.has(e.source.nodeId);
+    const tgtOk = e.target.kind !== 'node' || includedIds.has(e.target.nodeId);
+    return srcOk && tgtOk;
+  };
+
+  const edges: ContextEdge[] = (canvas.edges ?? []).filter(edgeVisible).map(e => {
     const src = e.source.kind === 'node'
       ? (nodeTitleById.get(e.source.nodeId) ?? e.source.nodeId)
       : `(${e.source.x},${e.source.y})`;
@@ -172,7 +195,7 @@ export async function generateContext(
     };
   });
 
-  return { workspaceId, workspaceName, canvasDir, nodes, edges };
+  return { contextVersion: CONTEXT_SCHEMA_VERSION, workspaceId, workspaceName, canvasDir, nodes, edges };
 }
 
 export function formatContextAsText(ctx: CanvasContext): string {

--- a/packages/canvas-cli/src/core/context.ts
+++ b/packages/canvas-cli/src/core/context.ts
@@ -52,9 +52,15 @@ function excerpt(text: string, max = TEXT_EXCERPT_LEN): string {
   return oneLine.length > max ? `${oneLine.slice(0, max)}…` : oneLine;
 }
 
+export interface GenerateContextOptions {
+  /** Restrict file-node disk reads to the workspace dir (see readNode confineToDir). */
+  confineToWorkspace?: boolean;
+}
+
 export async function generateContext(
   workspaceId: string,
   storeDir?: string,
+  opts: GenerateContextOptions = {},
 ): Promise<CanvasContext | null> {
   const canvas = await loadCanvas(workspaceId, storeDir);
   if (!canvas) return null;
@@ -63,11 +69,12 @@ export async function generateContext(
   const entry = (manifest.workspaces ?? []).find(e => e.id === workspaceId);
   const workspaceName = entry?.name ?? workspaceId;
   const canvasDir = getWorkspaceDir(workspaceId, storeDir);
+  const confineToDir = opts.confineToWorkspace ? canvasDir : undefined;
 
   const nodes: ContextNode[] = [];
 
   for (const node of canvas.nodes) {
-    const readResult = await readNode(node);
+    const readResult = await readNode(node, { confineToDir });
     const base: ContextNode = {
       id: node.id,
       type: node.type,

--- a/packages/canvas-cli/src/core/edges.ts
+++ b/packages/canvas-cli/src/core/edges.ts
@@ -28,14 +28,14 @@ export async function createEdge(
   storeDir?: string,
 ): Promise<Result<{ edgeId: string }>> {
   const canvas = await loadCanvas(workspaceId, storeDir);
-  if (!canvas) return { ok: false, error: `Workspace not found: ${workspaceId}` };
+  if (!canvas) return { ok: false, error: `Workspace not found: ${workspaceId}`, code: 'workspace_not_found' };
 
   // Validate that both source and target nodes exist
   const sourceExists = canvas.nodes.some(n => n.id === opts.sourceNodeId);
-  if (!sourceExists) return { ok: false, error: `Source node not found: ${opts.sourceNodeId}` };
+  if (!sourceExists) return { ok: false, error: `Source node not found: ${opts.sourceNodeId}`, code: 'node_not_found' };
 
   const targetExists = canvas.nodes.some(n => n.id === opts.targetNodeId);
-  if (!targetExists) return { ok: false, error: `Target node not found: ${opts.targetNodeId}` };
+  if (!targetExists) return { ok: false, error: `Target node not found: ${opts.targetNodeId}`, code: 'node_not_found' };
 
   const edgeId = `edge-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
@@ -65,14 +65,14 @@ export async function deleteEdge(
   storeDir?: string,
 ): Promise<Result> {
   const canvas = await loadCanvas(workspaceId, storeDir);
-  if (!canvas) return { ok: false, error: `Workspace not found: ${workspaceId}` };
+  if (!canvas) return { ok: false, error: `Workspace not found: ${workspaceId}`, code: 'workspace_not_found' };
 
   const edges = canvas.edges ?? [];
   const exists = edges.some(e => e.id === edgeId);
-  if (!exists) return { ok: false, error: `Edge not found: ${edgeId}` };
+  if (!exists) return { ok: false, error: `Edge not found: ${edgeId}`, code: 'edge_not_found' };
 
   const result = await commitEdgeMutation(workspaceId, { removeId: edgeId }, storeDir);
-  if (!result) return { ok: false, error: `Edge not found: ${edgeId}` };
+  if (!result) return { ok: false, error: `Edge not found: ${edgeId}`, code: 'edge_not_found' };
   await notifyCanvasUpdated({ workspaceId, nodeIds: [], kind: 'delete' });
 
   return { ok: true, data: undefined };

--- a/packages/canvas-cli/src/core/index.ts
+++ b/packages/canvas-cli/src/core/index.ts
@@ -1,6 +1,7 @@
 export * from './types';
 export * from './constants';
 export * from './store';
+export * from './workspace-resolution';
 export * from './nodes';
 export * from './edges';
 export * from './context';

--- a/packages/canvas-cli/src/core/nodes.ts
+++ b/packages/canvas-cli/src/core/nodes.ts
@@ -61,7 +61,22 @@ function flattenMindmapTopics(topic: MindmapTopic | undefined, depth = 0): strin
 }
 
 export function getNodeCapabilities(type: NodeType): NodeCapability[] {
-  return NODE_CAPABILITIES[type] ?? ['read'];
+  // Cast to a string index so an unrecognized (future) node type falls back to
+  // read-only instead of tripping the closed key set.
+  return (NODE_CAPABILITIES as Record<string, NodeCapability[]>)[type] ?? ['read'];
+}
+
+/**
+ * Pull a small set of keys off a node's `data`, keeping only the ones that
+ * are actually present. Used by the read cases below so the result carries a
+ * node type's persisted metadata without inventing empty fields.
+ */
+function pick(data: Record<string, unknown>, keys: string[]): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of keys) {
+    if (data[key] !== undefined) out[key] = data[key];
+  }
+  return out;
 }
 
 export async function readNode(node: CanvasNode): Promise<NodeReadResult> {
@@ -116,8 +131,55 @@ export async function readNode(node: CanvasNode): Promise<NodeReadResult> {
         text: flattenMindmapTopics(root),
       };
     }
+    case 'text':
+      // Persisted markdown plus its display styling. `content` is the full
+      // body — `node read` returns it in full; `context` only excerpts it.
+      return {
+        type: 'text',
+        capabilities,
+        content: (node.data.content as string) ?? (node.data.text as string) ?? '',
+        ...pick(node.data, ['fontSize', 'fontFamily', 'color', 'textAlign', 'markdown']),
+      };
+    case 'iframe':
+      // Everything the store holds about an embedded page: how it's sourced
+      // (`mode`), where (`url`), any inlined `html`/`prompt`, and the linked
+      // artifact. The live page body is NOT here — see the note in the
+      // package README about a future `webview read`.
+      return {
+        type: 'iframe',
+        capabilities,
+        ...pick(node.data, ['mode', 'url', 'html', 'prompt', 'artifactId', 'pageTitle']),
+      };
+    case 'image':
+      // Only the local file path is persisted; the CLI does not read image
+      // bytes.
+      return {
+        type: 'image',
+        capabilities,
+        ...pick(node.data, ['filePath', 'src', 'alt', 'width', 'height']),
+      };
+    case 'shape':
+      return {
+        type: 'shape',
+        capabilities,
+        ...pick(node.data, ['shape', 'shapeType', 'text', 'style', 'fill', 'stroke', 'color']),
+      };
+    case 'dynamic-app':
+      return {
+        type: 'dynamic-app',
+        capabilities,
+        ...pick(node.data, ['url', 'dynamicAppId']),
+      };
+    case 'plugin':
+      return {
+        type: 'plugin',
+        capabilities,
+        ...pick(node.data, ['pluginId', 'nodeType', 'version', 'payload']),
+      };
     default:
-      return { type: node.type, capabilities };
+      // Unknown/future node type: surface its raw data so an agent can still
+      // reason about it, rather than dropping everything.
+      return { type: node.type, capabilities, data: node.data };
   }
 }
 
@@ -218,7 +280,7 @@ export async function createNode(
   }
 
   const nodeId = `node-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-  const def = DEFAULT_NODE_DIMENSIONS[opts.type];
+  const def = (DEFAULT_NODE_DIMENSIONS as Record<string, { title: string; width: number; height: number }>)[opts.type];
   if (!def) return { ok: false, error: `Unsupported node type: ${opts.type}` };
 
   const auto = autoPlace(canvas.nodes);
@@ -226,7 +288,9 @@ export async function createNode(
   const y = opts.y ?? auto.y;
 
   const inputData = opts.data ?? {};
-  let nodeData: Record<string, unknown>;
+  // Defaults to `{}` for defensive completeness — `def` above already rejects
+  // any non-creatable type before we reach this switch.
+  let nodeData: Record<string, unknown> = {};
   switch (opts.type) {
     case 'file':
       nodeData = { filePath: '', content: (inputData as Record<string, string>).content ?? '', saved: false, modified: false };
@@ -261,13 +325,6 @@ export async function createNode(
       nodeData = { root, layout: 'right', rev: 0 };
       break;
     }
-    case 'reference':
-      nodeData = {
-        titleSnapshot: (inputData as Record<string, string>).titleSnapshot,
-        typeSnapshot: (inputData as Record<string, string>).typeSnapshot,
-        workspaceNameSnapshot: (inputData as Record<string, string>).workspaceNameSnapshot,
-      };
-      break;
   }
 
   // For file nodes, always create a notes file so the node has a valid filePath

--- a/packages/canvas-cli/src/core/nodes.ts
+++ b/packages/canvas-cli/src/core/nodes.ts
@@ -95,6 +95,44 @@ function pick(data: Record<string, unknown>, keys: string[]): Record<string, unk
   return out;
 }
 
+export interface NodeSearchHit {
+  id: string;
+  type: NodeType;
+  title: string;
+  /** Short excerpt around the match (title or in-memory content). */
+  snippet: string;
+}
+
+export interface NodeSearchOptions {
+  type?: string;
+  limit?: number;
+}
+
+/**
+ * Case-insensitive substring search over node titles and their in-memory
+ * `data.content` (file/text nodes). Pure and offline: it does NOT read backing
+ * files from disk, so a file node's on-disk-only body won't match its content
+ * — its title still will. Lets an agent locate nodes without N `node read`
+ * round-trips.
+ */
+export function searchNodes(nodes: CanvasNode[], query: string, opts: NodeSearchOptions = {}): NodeSearchHit[] {
+  const q = query.toLowerCase();
+  const hits: NodeSearchHit[] = [];
+  for (const n of nodes) {
+    if (opts.type && n.type !== opts.type) continue;
+    const title = n.title ?? '';
+    const content = typeof n.data.content === 'string' ? n.data.content : '';
+    const hay = `${title}\n${content}`;
+    const idx = hay.toLowerCase().indexOf(q);
+    if (idx < 0) continue;
+    const start = Math.max(0, idx - 30);
+    const snippet = hay.slice(start, idx + q.length + 60).replace(/\s+/g, ' ').trim();
+    hits.push({ id: n.id, type: n.type, title, snippet });
+    if (opts.limit && hits.length >= opts.limit) break;
+  }
+  return hits;
+}
+
 export async function readNode(node: CanvasNode, opts: ReadNodeOptions = {}): Promise<NodeReadResult> {
   const capabilities = getNodeCapabilities(node.type);
 
@@ -423,6 +461,43 @@ export async function createNode(
       capabilities: getNodeCapabilities(opts.type),
     },
   };
+}
+
+export interface UpdateNodePatch {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  title?: string;
+}
+
+/**
+ * Update a node's layout (position/size) and/or title without touching its
+ * `data`. Lets an agent reposition or rename nodes — the one mutation `node
+ * write` (which owns `data`) doesn't cover.
+ */
+export async function updateNode(
+  workspaceId: string,
+  nodeId: string,
+  patch: UpdateNodePatch,
+  storeDir?: string,
+): Promise<Result> {
+  const canvas = await loadCanvas(workspaceId, storeDir);
+  if (!canvas) return { ok: false, error: `Workspace not found: ${workspaceId}`, code: 'workspace_not_found' };
+
+  const node = canvas.nodes.find(n => n.id === nodeId);
+  if (!node) return { ok: false, error: `Node not found: ${nodeId}`, code: 'node_not_found' };
+
+  if (patch.x !== undefined) node.x = patch.x;
+  if (patch.y !== undefined) node.y = patch.y;
+  if (patch.width !== undefined) node.width = patch.width;
+  if (patch.height !== undefined) node.height = patch.height;
+  if (patch.title !== undefined) node.title = patch.title;
+  node.updatedAt = Date.now();
+
+  await commitNodeMutation(workspaceId, { upsert: node }, storeDir);
+  await notifyCanvasUpdated({ workspaceId, nodeIds: [nodeId], kind: 'update' });
+  return { ok: true, data: undefined };
 }
 
 export async function deleteNode(

--- a/packages/canvas-cli/src/core/nodes.ts
+++ b/packages/canvas-cli/src/core/nodes.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from 'fs';
-import { join } from 'path';
+import { join, resolve, relative, isAbsolute } from 'path';
 import { NODE_CAPABILITIES, DEFAULT_NODE_DIMENSIONS } from './constants';
 import { loadCanvas, saveCanvas, ensureWorkspaceDir, getWorkspaceDir, commitNodeMutation } from './store';
 import { notifyCanvasUpdated } from './notifier';
@@ -66,6 +66,22 @@ export function getNodeCapabilities(type: NodeType): NodeCapability[] {
   return (NODE_CAPABILITIES as Record<string, NodeCapability[]>)[type] ?? ['read'];
 }
 
+/** True if `child` resolves to a path at or under `parent`. */
+function isPathInside(child: string, parent: string): boolean {
+  const rel = relative(resolve(parent), resolve(child));
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+}
+
+export interface ReadNodeOptions {
+  /**
+   * When set, a `file` node whose `filePath` escapes this directory is NOT
+   * read from disk — the in-memory content is returned instead and the result
+   * is flagged `pathConfined: true`. Guards against a crafted/untrusted
+   * canvas.json turning `node read` into arbitrary file read.
+   */
+  confineToDir?: string;
+}
+
 /**
  * Pull a small set of keys off a node's `data`, keeping only the ones that
  * are actually present. Used by the read cases below so the result carries a
@@ -79,21 +95,31 @@ function pick(data: Record<string, unknown>, keys: string[]): Record<string, unk
   return out;
 }
 
-export async function readNode(node: CanvasNode): Promise<NodeReadResult> {
+export async function readNode(node: CanvasNode, opts: ReadNodeOptions = {}): Promise<NodeReadResult> {
   const capabilities = getNodeCapabilities(node.type);
 
   switch (node.type) {
     case 'file': {
       let content = node.data.content ?? '';
-      if (node.data.filePath) {
-        try {
-          content = await fs.readFile(node.data.filePath, 'utf-8');
-        } catch {
-          // fall through to in-memory content
+      const filePath = node.data.filePath;
+      let pathConfined = false;
+      if (filePath) {
+        if (opts.confineToDir && !isPathInside(filePath, opts.confineToDir)) {
+          // Escaping path under confinement: never touch disk, use whatever
+          // content the canvas already holds.
+          pathConfined = true;
+        } else {
+          try {
+            content = await fs.readFile(filePath, 'utf-8');
+          } catch {
+            // fall through to in-memory content
+          }
         }
       }
-      const ext = node.data.filePath?.split('.').pop() ?? '';
-      return { type: 'file', capabilities, path: node.data.filePath ?? '', content, language: ext };
+      const ext = filePath?.split('.').pop() ?? '';
+      const result: NodeReadResult = { type: 'file', capabilities, path: filePath ?? '', content, language: ext };
+      if (pathConfined) result.pathConfined = true;
+      return result;
     }
     case 'terminal':
       return {
@@ -183,21 +209,41 @@ export async function readNode(node: CanvasNode): Promise<NodeReadResult> {
   }
 }
 
+export interface WriteNodeOptions {
+  /**
+   * Refuse to write a `file` node whose `filePath` escapes the workspace
+   * directory. Guards against a crafted/untrusted canvas.json turning
+   * `node write` into an arbitrary-file overwrite.
+   */
+  confineToWorkspace?: boolean;
+}
+
 export async function writeNode(
   workspaceId: string,
   nodeId: string,
   content: string,
   storeDir?: string,
+  opts: WriteNodeOptions = {},
 ): Promise<Result> {
   const canvas = await loadCanvas(workspaceId, storeDir);
-  if (!canvas) return { ok: false, error: `Workspace not found: ${workspaceId}` };
+  if (!canvas) return { ok: false, error: `Workspace not found: ${workspaceId}`, code: 'workspace_not_found' };
 
   const node = canvas.nodes.find(n => n.id === nodeId);
-  if (!node) return { ok: false, error: `Node not found: ${nodeId}` };
+  if (!node) return { ok: false, error: `Node not found: ${nodeId}`, code: 'node_not_found' };
 
   switch (node.type) {
     case 'file': {
       if (node.data.filePath) {
+        if (opts.confineToWorkspace) {
+          const wsDir = getWorkspaceDir(workspaceId, storeDir);
+          if (!isPathInside(node.data.filePath, wsDir)) {
+            return {
+              ok: false,
+              error: `Refusing to write file node: its filePath "${node.data.filePath}" is outside the workspace directory (--confine-to-workspace).`,
+              code: 'path_confined',
+            };
+          }
+        }
         await fs.writeFile(node.data.filePath, content, 'utf-8');
       }
       node.data.content = content;
@@ -205,6 +251,16 @@ export async function writeNode(
       // Re-read canvas.json just before writing so concurrent changes
       // from the Electron renderer (or other canvas-cli invocations) to
       // other nodes are preserved. Only our target node is replaced.
+      await commitNodeMutation(workspaceId, { upsert: node }, storeDir);
+      await notifyCanvasUpdated({ workspaceId, nodeIds: [nodeId], kind: 'update' });
+      return { ok: true, data: undefined };
+    }
+    case 'text': {
+      // Text cards hold their markdown inline in `data.content`; writing is
+      // symmetric with reading them (unlike file nodes there is no backing
+      // file on disk to update).
+      node.data.content = content;
+      node.updatedAt = Date.now();
       await commitNodeMutation(workspaceId, { upsert: node }, storeDir);
       await notifyCanvasUpdated({ workspaceId, nodeIds: [nodeId], kind: 'update' });
       return { ok: true, data: undefined };
@@ -223,15 +279,15 @@ export async function writeNode(
         await notifyCanvasUpdated({ workspaceId, nodeIds: [nodeId], kind: 'update' });
         return { ok: true, data: undefined };
       } catch {
-        return { ok: false, error: 'Container write expects JSON: { label?: string, color?: string, childIds?: string[] }' };
+        return { ok: false, error: 'Container write expects JSON: { label?: string, color?: string, childIds?: string[] }', code: 'invalid_argument' };
       }
     }
     case 'terminal':
-      return { ok: false, error: 'Terminal nodes do not support write. Use canvas_exec to send commands.' };
+      return { ok: false, error: 'Terminal nodes do not support write. Use canvas_exec to send commands.', code: 'unsupported' };
     case 'agent':
-      return { ok: false, error: 'Agent nodes do not support write. Use canvas_exec to send commands.' };
+      return { ok: false, error: 'Agent nodes do not support write. Use canvas_exec to send commands.', code: 'unsupported' };
     default:
-      return { ok: false, error: 'Unknown node type' };
+      return { ok: false, error: `Node type "${node.type}" does not support write from the CLI.`, code: 'unsupported' };
   }
 }
 
@@ -281,7 +337,7 @@ export async function createNode(
 
   const nodeId = `node-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const def = (DEFAULT_NODE_DIMENSIONS as Record<string, { title: string; width: number; height: number }>)[opts.type];
-  if (!def) return { ok: false, error: `Unsupported node type: ${opts.type}` };
+  if (!def) return { ok: false, error: `Unsupported node type: ${opts.type}`, code: 'unsupported' };
 
   const auto = autoPlace(canvas.nodes);
   const x = opts.x ?? auto.x;
@@ -375,15 +431,15 @@ export async function deleteNode(
   storeDir?: string,
 ): Promise<Result> {
   const canvas = await loadCanvas(workspaceId, storeDir);
-  if (!canvas) return { ok: false, error: `Workspace not found: ${workspaceId}` };
+  if (!canvas) return { ok: false, error: `Workspace not found: ${workspaceId}`, code: 'workspace_not_found' };
 
   const exists = canvas.nodes.some(n => n.id === nodeId);
-  if (!exists) return { ok: false, error: `Node not found: ${nodeId}` };
+  if (!exists) return { ok: false, error: `Node not found: ${nodeId}`, code: 'node_not_found' };
 
   // Re-read canvas.json just before writing to preserve concurrent changes
   // to other nodes from the renderer or other canvas-cli invocations.
   const result = await commitNodeMutation(workspaceId, { removeId: nodeId }, storeDir);
-  if (!result) return { ok: false, error: `Node not found: ${nodeId}` };
+  if (!result) return { ok: false, error: `Node not found: ${nodeId}`, code: 'node_not_found' };
   await notifyCanvasUpdated({ workspaceId, nodeIds: [nodeId], kind: 'delete' });
 
   return { ok: true, data: undefined };

--- a/packages/canvas-cli/src/core/runtime-control.ts
+++ b/packages/canvas-cli/src/core/runtime-control.ts
@@ -74,3 +74,72 @@ export async function postRuntime<TBody extends object, TResponse>(
 export function runtimeAuthHint(): string {
   return 'Runtime authentication failed (401). The secret in the runtime file does not match the running canvas-workspace. Restart Pulse Canvas to refresh it.';
 }
+
+/** Absolute path of the runtime-control descriptor file. */
+export function runtimeFilePath(): string {
+  return RUNTIME_FILE;
+}
+
+export interface RuntimeStatus {
+  /** The runtime descriptor file exists on disk. */
+  present: boolean;
+  /** A live HTTP response came back from the advertised baseUrl. */
+  reachable: boolean;
+  baseUrl?: string;
+  pid?: number;
+  /** Why it isn't present/reachable, when applicable. */
+  error?: string;
+}
+
+/**
+ * Non-fatal counterpart to {@link readRuntime}: report whether the Electron
+ * runtime is present and reachable without exiting the process. Used by
+ * `pulse-canvas status` so an external caller can decide up-front whether the
+ * live `agent`/`team` commands are usable.
+ */
+export async function probeRuntime(): Promise<RuntimeStatus> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(RUNTIME_FILE, 'utf-8');
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    return {
+      present: false,
+      reachable: false,
+      error: code === 'ENOENT' ? 'no runtime file (open the workspace in Pulse Canvas)' : String(err),
+    };
+  }
+
+  let info: RuntimeInfo;
+  try {
+    info = JSON.parse(raw) as RuntimeInfo;
+  } catch {
+    return { present: true, reachable: false, error: 'runtime file is corrupt' };
+  }
+  if (!info.baseUrl || !info.secret) {
+    return { present: true, reachable: false, error: 'runtime file missing baseUrl or secret' };
+  }
+
+  // Any HTTP response (even a 401/404) proves the server is up; a transport
+  // error means it isn't. Bounded so `status` never hangs on a stale file.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 1500);
+  try {
+    await fetch(info.baseUrl, {
+      method: 'GET',
+      headers: { authorization: `Bearer ${info.secret}` },
+      signal: controller.signal,
+    });
+    return { present: true, reachable: true, baseUrl: info.baseUrl, pid: info.pid };
+  } catch (err) {
+    return {
+      present: true,
+      reachable: false,
+      baseUrl: info.baseUrl,
+      pid: info.pid,
+      error: `unreachable at ${info.baseUrl}: ${(err as Error).message}`,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/canvas-cli/src/core/runtime-control.ts
+++ b/packages/canvas-cli/src/core/runtime-control.ts
@@ -22,18 +22,19 @@ export async function readRuntime(): Promise<RuntimeInfo> {
       errorOutput(
         'No active canvas-workspace runtime found.\n' +
         'Open this workspace in Pulse Canvas before using live agent/team commands.',
+        { code: 'runtime_not_found' },
       );
     }
-    errorOutput(`Cannot read runtime file (${RUNTIME_FILE}): ${String(err)}`);
+    errorOutput(`Cannot read runtime file (${RUNTIME_FILE}): ${String(err)}`, { code: 'runtime_unreadable' });
   }
   try {
     const info = JSON.parse(raw!) as RuntimeInfo;
     if (!info.baseUrl || !info.secret) {
-      errorOutput('Runtime file is missing baseUrl or secret. Restart Pulse Canvas.');
+      errorOutput('Runtime file is missing baseUrl or secret. Restart Pulse Canvas.', { code: 'runtime_invalid' });
     }
     return info;
   } catch {
-    errorOutput('Runtime file is corrupt. Restart Pulse Canvas.');
+    errorOutput('Runtime file is corrupt. Restart Pulse Canvas.', { code: 'runtime_corrupt' });
   }
 }
 
@@ -56,6 +57,7 @@ export async function postRuntime<TBody extends object, TResponse>(
     errorOutput(
       `Cannot reach canvas-workspace runtime at ${runtime.baseUrl}: ${(err as Error).message}\n` +
       'The Electron app may not be running, or the runtime file is stale.',
+      { code: 'runtime_unreachable' },
     );
   }
 

--- a/packages/canvas-cli/src/core/types.ts
+++ b/packages/canvas-cli/src/core/types.ts
@@ -1,4 +1,38 @@
-export type NodeType = 'file' | 'terminal' | 'frame' | 'group' | 'agent' | 'mindmap' | 'reference';
+/**
+ * Node types the CLI can create via `node create`. These are the only types
+ * with default dimensions and an initializer in `createNode`.
+ */
+export type CreatableNodeType =
+  | 'file'
+  | 'terminal'
+  | 'frame'
+  | 'group'
+  | 'agent'
+  | 'mindmap';
+
+/**
+ * Every node type the CLI understands well enough to read meaningfully —
+ * the creatable set plus read-only types produced by the canvas app
+ * (text, iframe, image, shape, reference, dynamic-app, plugin).
+ */
+export type KnownNodeType =
+  | CreatableNodeType
+  | 'text'
+  | 'iframe'
+  | 'image'
+  | 'shape'
+  | 'reference'
+  | 'dynamic-app'
+  | 'plugin';
+
+/**
+ * The on-disk node type. `KnownNodeType` gives autocomplete and exhaustiveness
+ * for the types we handle explicitly; the `(string & {})` arm keeps the CLI
+ * forward-compatible — a canvas.json written by a newer app with a node type
+ * this CLI has never heard of still parses and reads (as an opaque node)
+ * instead of failing to load.
+ */
+export type NodeType = KnownNodeType | (string & {});
 export type NodeCapability = 'read' | 'write' | 'exec';
 
 /**

--- a/packages/canvas-cli/src/core/types.ts
+++ b/packages/canvas-cli/src/core/types.ts
@@ -156,4 +156,4 @@ export interface NodeReadResult {
 
 export type Result<T = void> =
   | { ok: true; data: T }
-  | { ok: false; error: string };
+  | { ok: false; error: string; code?: string };

--- a/packages/canvas-cli/src/core/workspace-resolution.ts
+++ b/packages/canvas-cli/src/core/workspace-resolution.ts
@@ -23,6 +23,25 @@ export interface WorkspaceResolution {
   source: WorkspaceResolutionSource;
 }
 
+export type WorkspaceResolutionCode =
+  | 'no_workspace_selected'
+  | 'workspace_unsafe'
+  | 'workspace_not_found'
+  | 'workspace_unreadable';
+
+/**
+ * Thrown by {@link resolveWorkspaceId} with a stable `code` so command-layer
+ * error handling can forward a machine-readable identifier to callers.
+ */
+export class WorkspaceResolutionError extends Error {
+  readonly code: WorkspaceResolutionCode;
+  constructor(message: string, code: WorkspaceResolutionCode) {
+    super(message);
+    this.name = 'WorkspaceResolutionError';
+    this.code = code;
+  }
+}
+
 function isEnoent(err: unknown): boolean {
   return !!err && typeof err === 'object' && (err as { code?: string }).code === 'ENOENT';
 }
@@ -47,8 +66,9 @@ async function validateWorkspace(
   requireReadableCanvas = true,
 ): Promise<WorkspaceResolution> {
   if (!isSafeWorkspaceId(workspaceId)) {
-    throw new Error(
+    throw new WorkspaceResolutionError(
       `Unsafe workspace id "${workspaceId}" (from ${describeSource(source)}).`,
+      'workspace_unsafe',
     );
   }
 
@@ -77,14 +97,16 @@ async function validateWorkspace(
     return { workspaceId, source };
   } catch {
     if (primaryErr) {
-      throw new Error(
+      throw new WorkspaceResolutionError(
         `Workspace "${workspaceId}" (from ${describeSource(source)}) has an ` +
         `unreadable canvas.json: ${String(primaryErr)}`,
+        'workspace_unreadable',
       );
     }
-    throw new Error(
+    throw new WorkspaceResolutionError(
       `Workspace "${workspaceId}" (from ${describeSource(source)}) not found ` +
       `at ${dir}.`,
+      'workspace_not_found',
     );
   }
 }
@@ -142,8 +164,9 @@ export async function resolveWorkspaceId(options: {
     return validateWorkspace(manifest.activeId, 'manifest-active', options.storeDir, requireReadableCanvas);
   }
 
-  throw new Error(
+  throw new WorkspaceResolutionError(
     'No workspace selected. Open a workspace in Pulse Canvas, ' +
     `pass --workspace <id>, or set $${ENV_WORKSPACE_ID}.`,
+    'no_workspace_selected',
   );
 }

--- a/packages/canvas-cli/src/core/workspace-resolution.ts
+++ b/packages/canvas-cli/src/core/workspace-resolution.ts
@@ -1,0 +1,149 @@
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { getWorkspaceDir, isSafeWorkspaceId, loadWorkspaceManifest } from './store';
+
+/**
+ * Environment variable the canvas app sets for launched agents so they can
+ * address the workspace they were spawned from without a `--workspace` flag.
+ */
+export const ENV_WORKSPACE_ID = 'PULSE_CANVAS_WORKSPACE_ID';
+
+/**
+ * Where a resolved workspace id came from. Surfaced to callers (and to
+ * `workspace current`) so an agent can tell whether it was pinned explicitly
+ * or fell back to the app's active workspace.
+ */
+export type WorkspaceResolutionSource =
+  | 'explicit'
+  | 'environment'
+  | 'manifest-active';
+
+export interface WorkspaceResolution {
+  workspaceId: string;
+  source: WorkspaceResolutionSource;
+}
+
+function isEnoent(err: unknown): boolean {
+  return !!err && typeof err === 'object' && (err as { code?: string }).code === 'ENOENT';
+}
+
+/**
+ * Confirm a candidate id names a real, readable workspace before any command
+ * acts on it. Checks, in order:
+ *   1. the id is shape-safe (`isSafeWorkspaceId`);
+ *   2. the workspace directory holds a readable `canvas.json` (falling back to
+ *      the rolling `canvas.json.bak` so a mid-flush corruption still resolves,
+ *      matching `loadCanvas`'s self-healing behavior).
+ *
+ * Throws with an actionable message on any failure — notably, when a manifest's
+ * `activeId` points at a workspace that no longer exists we surface that rather
+ * than silently picking a different one (writing to the wrong canvas is worse
+ * than a hard error).
+ */
+async function validateWorkspace(
+  workspaceId: string,
+  source: WorkspaceResolutionSource,
+  storeDir?: string,
+  requireReadableCanvas = true,
+): Promise<WorkspaceResolution> {
+  if (!isSafeWorkspaceId(workspaceId)) {
+    throw new Error(
+      `Unsafe workspace id "${workspaceId}" (from ${describeSource(source)}).`,
+    );
+  }
+
+  const dir = getWorkspaceDir(workspaceId, storeDir);
+
+  // `restore` recovers workspaces whose canvas.json is missing or clobbered,
+  // so it opts out of the readability check — a safe id is enough there.
+  if (!requireReadableCanvas) {
+    return { workspaceId, source };
+  }
+
+  const canvasFile = join(dir, 'canvas.json');
+
+  let primaryErr: unknown = null;
+  try {
+    await fs.readFile(canvasFile, 'utf-8');
+    return { workspaceId, source };
+  } catch (err) {
+    if (!isEnoent(err)) primaryErr = err;
+  }
+
+  // Primary missing or unreadable — accept a recoverable `.bak` snapshot so a
+  // workspace mid-corruption is still addressable (loadCanvas would heal it).
+  try {
+    await fs.readFile(`${canvasFile}.bak`, 'utf-8');
+    return { workspaceId, source };
+  } catch {
+    if (primaryErr) {
+      throw new Error(
+        `Workspace "${workspaceId}" (from ${describeSource(source)}) has an ` +
+        `unreadable canvas.json: ${String(primaryErr)}`,
+      );
+    }
+    throw new Error(
+      `Workspace "${workspaceId}" (from ${describeSource(source)}) not found ` +
+      `at ${dir}.`,
+    );
+  }
+}
+
+function describeSource(source: WorkspaceResolutionSource): string {
+  switch (source) {
+    case 'explicit':
+      return '--workspace';
+    case 'environment':
+      return `$${ENV_WORKSPACE_ID}`;
+    case 'manifest-active':
+      return 'active workspace';
+  }
+}
+
+/**
+ * Resolve which workspace a command should act on. Resolution order is fixed
+ * and deliberately conservative — it never guesses (no "most recently
+ * modified" or "first in the list"), because addressing the wrong canvas
+ * silently corrupts a user's work:
+ *
+ *   1. `--workspace <id>` (explicit)
+ *   2. `$PULSE_CANVAS_WORKSPACE_ID` (environment)
+ *   3. `__workspaces__.json.activeId` (the app's active workspace)
+ *   4. otherwise a hard error telling the caller how to select one.
+ *
+ * Every resolved candidate is validated (`validateWorkspace`) before it is
+ * returned, so callers can trust the id points at a readable workspace.
+ */
+export async function resolveWorkspaceId(options: {
+  explicitId?: string;
+  storeDir?: string;
+  env?: NodeJS.ProcessEnv;
+  /**
+   * Require the resolved workspace to have a readable `canvas.json`. Default
+   * `true`. `restore` sets this `false` because it recovers workspaces whose
+   * canvas.json is precisely what's broken.
+   */
+  requireReadableCanvas?: boolean;
+}): Promise<WorkspaceResolution> {
+  const requireReadableCanvas = options.requireReadableCanvas ?? true;
+
+  const explicit = options.explicitId?.trim();
+  if (explicit) {
+    return validateWorkspace(explicit, 'explicit', options.storeDir, requireReadableCanvas);
+  }
+
+  const environment = (options.env ?? process.env)[ENV_WORKSPACE_ID]?.trim();
+  if (environment) {
+    return validateWorkspace(environment, 'environment', options.storeDir, requireReadableCanvas);
+  }
+
+  const manifest = await loadWorkspaceManifest(options.storeDir);
+  if (manifest.activeId) {
+    return validateWorkspace(manifest.activeId, 'manifest-active', options.storeDir, requireReadableCanvas);
+  }
+
+  throw new Error(
+    'No workspace selected. Open a workspace in Pulse Canvas, ' +
+    `pass --workspace <id>, or set $${ENV_WORKSPACE_ID}.`,
+  );
+}

--- a/packages/canvas-cli/src/output.ts
+++ b/packages/canvas-cli/src/output.ts
@@ -1,5 +1,21 @@
 export type OutputFormat = 'json' | 'text';
 
+/**
+ * The format resolved from the global `--format` flag, set once per invocation
+ * (via a commander `preAction` hook in cli.ts) so `errorOutput` can emit a
+ * machine-readable error even at call sites that don't thread the format
+ * through. Defaults to `text` for the rare error raised before any action runs.
+ */
+let activeFormat: OutputFormat = 'text';
+
+export function setActiveFormat(format: OutputFormat): void {
+  activeFormat = format === 'json' ? 'json' : 'text';
+}
+
+export function getActiveFormat(): OutputFormat {
+  return activeFormat;
+}
+
 export function output(data: unknown, format: OutputFormat, textFn: (d: unknown) => string): void {
   if (format === 'json') {
     console.log(JSON.stringify(data, null, 2));
@@ -8,7 +24,32 @@ export function output(data: unknown, format: OutputFormat, textFn: (d: unknown)
   }
 }
 
-export function errorOutput(message: string): never {
-  console.error(`Error: ${message}`);
-  process.exit(1);
+export interface ErrorOptions {
+  /**
+   * Stable machine-readable identifier for the failure so external callers can
+   * branch on it (e.g. `workspace_not_found`, `runtime_unreachable`). Defaults
+   * to `error`. Surfaced only in `--format json` output.
+   */
+  code?: string;
+  /** Process exit code. Defaults to 1. */
+  exitCode?: number;
+  /** Force a format instead of using the resolved global one. */
+  format?: OutputFormat;
+}
+
+/**
+ * Print an error and exit non-zero. In `--format json` the error is emitted as
+ * a JSON object `{ ok: false, error, code }` on stderr, so a machine consumer
+ * gets parseable output on both the success (stdout) and failure (stderr)
+ * paths; in text mode it stays a human `Error: …` line.
+ */
+export function errorOutput(message: string, opts: ErrorOptions = {}): never {
+  const format = opts.format ?? activeFormat;
+  const code = opts.code ?? 'error';
+  if (format === 'json') {
+    console.error(JSON.stringify({ ok: false, error: message, code }));
+  } else {
+    console.error(`Error: ${message}`);
+  }
+  process.exit(opts.exitCode ?? 1);
 }


### PR DESCRIPTION
## Summary

This PR adds three major features to the canvas-cli to support agent integration and external tooling:

1. **Workspace auto-discovery** – Commands now resolve the target workspace in a fixed priority order: explicit `--workspace` flag → `$PULSE_CANVAS_WORKSPACE_ID` environment variable → active workspace from manifest. This eliminates the need for agents to pass `--workspace` explicitly in most cases.

2. **Node search and modern node-type support** – Adds `searchNodes()` for case-insensitive substring search over node titles and in-memory content, and extends `readNode()` to handle modern read-only types (text, iframe, image, shape, reference, dynamic-app, plugin) with proper metadata extraction.

3. **External-caller surface** – New `status` and `describe` commands provide machine-readable workspace/runtime state and CLI capability introspection. Error responses now include stable `code` fields for programmatic error handling.

## Key Changes

- **`src/core/workspace-resolution.ts`** (new) – Implements `resolveWorkspaceId()` with priority-ordered fallback logic and `WorkspaceResolutionError` for stable error codes.

- **`src/commands/options.ts`** (new) – Centralizes root option parsing (`getRootOptions()`, `getWorkspaceCommandOptions()`) so all commands use consistent workspace resolution.

- **`src/core/nodes.ts`** – Extended `readNode()` with `confineToDir` option to prevent file-node path escapes (security for untrusted canvases). Added `searchNodes()` for offline full-text search. Added `pick()` helper to surface only declared metadata fields per node type. Updated `getNodeCapabilities()` to gracefully handle unknown future node types.

- **`src/core/context.ts`** – Added `CONTEXT_SCHEMA_VERSION` constant and `GenerateContextOptions` for type filtering and workspace confinement. Integrated `confineToWorkspace` flag and text excerpt truncation.

- **`src/commands/status.ts`** (new) – Reports store directory, workspace count, resolved workspace (with source), and Electron runtime reachability. Designed for external callers to probe CLI state without side effects.

- **`src/commands/describe.ts`** (new) – Introspects CLI command structure and documents stable error codes for machine consumers.

- **`src/output.ts`** – Added `setActiveFormat()` / `getActiveFormat()` to track active output format globally, enabling `errorOutput()` to emit JSON errors even at call sites that don't thread format through.

- **`src/core/types.ts`** – Split `NodeType` into `CreatableNodeType` (file, terminal, frame, group, agent, mindmap) and `KnownNodeType` (creatable + read-only app types). Updated `NodeReadResult` to include optional `pathConfined` flag and per-type metadata fields.

- **`src/core/runtime-control.ts`** – Added error codes (`runtime_not_found`, `runtime_unreadable`, `runtime_invalid`, `runtime_corrupt`, `runtime_unreachable`) to all error paths.

- **Command refactoring** – `node.ts`, `edge.ts`, `context.ts`, `agent.ts`, `team.ts`, `workspace.ts`, `restore.ts` now use `getWorkspaceCommandOptions()` for consistent workspace resolution and error handling.

- **Tests** (new) – Added comprehensive test suites:
  - `modern-nodes.test.ts` – Validates read/write for all node types
  - `workspace-resolution.test.ts` – Tests priority-order fallback logic
  - `workspace-resolution-cli.test.ts` – End-to-end CLI workspace resolution
  - `node-security.test.ts` – Verifies path confinement prevents disk leaks
  - `node-query.test.ts` – Tests search and update operations
  - `error-contract.test.ts` – Validates stable error codes in JSON output
  - `cli-extras.test.ts` – Tests status/describe commands and runtime probing

- **Documentation** – Updated README with workspace auto

https://claude.ai/code/session_01XwbMvYRrz4FCEutcJE8M4T