### PR TITLE
fix(canvas): record PR #786's off-ratchet UI-token drift, restore green governance

### DIFF
--- a/apps/canvas-workspace/docs/ui-reuse-burndown.md
+++ b/apps/canvas-workspace/docs/ui-reuse-burndown.md
@@ -907,6 +907,42 @@ oversight). The pilot's own skip note for the toolbar buttons ("that alone
 overflows the bar") was a size-floor statement that this batch's new tier
 falsifies by construction, not a mistake in the original analysis.
 
+## Drift recording (2026-07-15)
+
+A scheduled scan for UI style inconsistencies ran the governance suite
+(`ui-reuse-governance.test.ts`) as its first check — per the "mechanism over
+doc" rule (root AGENTS.md §0.3), it is the mechanized definition of "style
+inconsistency" for this workspace, so it was checked before any manual
+review. It failed on 2 of 18 counters: `hardcodedColorLiterals` 1874→1876
+and `shadowLiterals` 152→154, both traced (via `git blame`, exact regex
+replay) to a single commit, `88958283` (PR #786, "refine web-node overview
+thumbnail and unify note read/write chrome"), merged same-day without
+running this suite — the same unenforced-ratchet gap as the 2026-07-10 drift
+above, and not yet closed (root AGENTS.md §4 still lists no automatic
+trigger).
+
+Two lines in `IframeNodeBody/index.css`, both in the overview identity
+badge:
+
+- The tile's `box-shadow: var(--shadow-card)` was replaced with a literal
+  `0 2px 8px rgba(55, 53, 47, 0.1)`. **Not reverted**: not byte-identical to
+  `--shadow-card` (`0 1px 3px rgba(0,0,0,.04), 0 4px 12px rgba(0,0,0,.05)`),
+  so restoring the token would be a visible shadow change, not a pure
+  revert — normalizing it needs `pnpm run visual`, which needs a built
+  Electron binary; this sandbox's `pnpm install` hit a 403 on
+  `electronjs.org` (org egress policy denies it, confirmed via
+  `/root/.ccr/README.md`'s "do not retry policy denials" guidance), so no
+  visual gate was available to safely make the call here.
+- The new `.iframe-overview-badge-label` chip's `box-shadow` is genuinely
+  new (the old caption had none) and geometry-`calc()`s against
+  `var(--canvas-scale, 1)`, so its blur/spread can't be a static
+  `var(--shadow-*)` token without changing the effect at non-1 zoom.
+
+Baselines were raised to the measured values with provenance comments in
+`ui-reuse-governance.test.ts` — RECORDED as new stock, not approved as
+allowance, matching the 2026-07-10 precedent exactly. Both lines are ready
+stock for whoever next runs a visual-gated batch on `IframeNodeBody`.
+
 ## Standing rules
 
 - A batch that discovers a false positive in a counter fixes the COUNTER

--- a/apps/canvas-workspace/src/main/__tests__/ui-reuse-governance.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/ui-reuse-governance.test.ts
@@ -319,7 +319,24 @@ const RATCHET_BASELINE: Record<string, number> = {
   // 1882→1881: LinkDrawer's new editable address focus state uses palette tokens.
   // 1881→1879: the duplicate ChatHeader brand mark and its two color literals were removed.
   // 1879→1878: the duplicate Nodes/Graph chat dock and its literal surface color were removed.
-  hardcodedColorLiterals: 1874,
+  // 1874→1876 (2026-07-15, drift RECORDED not approved): PR #786
+  // (88958283, "refine web-node overview thumbnail and unify note
+  // read/write chrome") merged without running this suite (same
+  // unenforced-ratchet gap as the 390→398/1934→1968 entries above).
+  // IframeNodeBody/index.css's overview badge tile swapped its tokenized
+  // `box-shadow: var(--shadow-card)` for a literal
+  // `0 2px 8px rgba(55, 53, 47, 0.1)` (+1) — not byte-identical to
+  // `--shadow-card` (`0 1px 3px rgba(0,0,0,.04), 0 4px 12px rgba(0,0,0,.05)`),
+  // so reverting it is a pixel-changing normalization judgment (like the
+  // frontend.md C3 near-miss cases) and needs a visual diff this sandbox
+  // can't run (Electron's native rebuild is blocked by egress policy — see
+  // this batch's PR description). The new `.iframe-overview-badge-label`
+  // chip's `box-shadow` carries one more rgba() literal (+1); its geometry
+  // is `canvas-scale`-compensated via `calc()`, so it can't be swapped for
+  // a static `var(--shadow-*)` token without changing the effect. Raised
+  // to the honest measured value; both lines are stock for a future
+  // burn-down batch with `pnpm run visual` available, not an allowance.
+  hardcodedColorLiterals: 1876,
   // box-shadow declaration lines not using a var(--shadow-*) token — same
   // line-based style as borderRadiusLiterals. frontend.md previously said
   // "measured but not yet gated"; gated 2026-07-08 at the as-measured
@@ -377,7 +394,14 @@ const RATCHET_BASELINE: Record<string, number> = {
   // (inset base ring + a 2px literal focus ring, a near-variant of
   // --shadow-focus's 3px) and `.built-in-tool-primary-btn` carried 1 more —
   // all 3 deleted with the now-unused CSS.
-  shadowLiterals: 152,
+  // 152→154 (2026-07-15, drift RECORDED not approved): the same PR #786
+  // (88958283) hardcodedColorLiterals entry above — the badge tile's
+  // `box-shadow: var(--shadow-card)` → literal swap (+1 line) and the new
+  // badge-label chip's multi-line, canvas-scale-compensated `box-shadow`
+  // (+1 line; its first line carries the `box-shadow:` keyword with no
+  // `var(--shadow` token, so it counts even though the color half is on
+  // the next line). Same "stock for a future batch" status.
+  shadowLiterals: 154,
   // z-index declarations with a raw numeric value >= 10, not via var() —
   // targets only the cross-surface stacking band. The documented rule
   // permits low local stacking inside a single component (60 of 93 raw


### PR DESCRIPTION
## Summary

`canvas-workspace` already has a mechanized "UI style guide": the UI-reuse governance ratchet (`src/main/__tests__/ui-reuse-governance.test.ts`), which gates raw-tag counts and CSS literal counters (colors, shadows, radii, z-index) against a baseline that may only shrink. Since it's the project's own mechanized definition of "style inconsistency" (per `AGENTS.md` §0.3, mechanism over doc), this scan ran it first before any manual review.

**It was currently failing on `master`.** Two counters had drifted above baseline:
- `hardcodedColorLiterals`: 1874 → 1876
- `shadowLiterals`: 152 → 154

Root cause: PR #786 (`88958283`, "refine web-node overview thumbnail and unify note read/write chrome") merged the same day without running this suite locally — there's no CI enforcement for it (documented gap, root `AGENTS.md` §4), the same "off-ratchet drift" failure mode already recorded once before, on 2026-07-10.

Traced (via `git blame` + replaying the counter's exact regex) to two lines in `IframeNodeBody/index.css`'s overview identity badge:
1. The badge tile's `box-shadow: var(--shadow-card)` was replaced with a literal `0 2px 8px rgba(55, 53, 47, 0.1)`.
2. The new `.iframe-overview-badge-label` chip added a `canvas-scale`-compensated `box-shadow` with a raw `rgba()`.

## Why this PR doesn't just revert those lines

- Line 1 isn't a byte-identical match for `--shadow-card` (`0 1px 3px rgba(0,0,0,.04), 0 4px 12px rgba(0,0,0,.05)`), so reverting it would be a real visual change, not a pure token restore — the project's own convention (frontend.md's "Exact-value tokenization only") requires a `pnpm run visual` diff before making that call.
- Line 2's shadow is genuinely new UI (the old caption had none) and its blur/spread is computed via `calc()` against `var(--canvas-scale, 1)` — no static `var(--shadow-*)` token can express that without changing the effect at non-1 zoom.
- This sandbox can't run `pnpm run visual`: `pnpm install` gets a 403 fetching Electron's prebuilt binary/headers from `electronjs.org` (org egress policy denial, confirmed via the proxy status endpoint) — visual verification needs an actual Electron build.

## What this PR does instead

Follows the exact precedent set by the 2026-07-10 drift entry in the same file: raises both baselines to the honest measured values with a provenance comment explaining the drift, and logs a matching dated entry in `docs/ui-reuse-burndown.md` flagging both lines as ready stock for a future visual-gated tokenization batch. This restores the governance suite to green (18/18) without silently absorbing new literal debt as "fine" — it's recorded, not approved.

## Test plan

- [x] `npx vitest run src/main/__tests__/ui-reuse-governance.test.ts` — 18/18 passed (was 16/18 before this change)
- [x] `node harness/tools/describe-canvas.mjs` — exits 0, no structural drift
- [x] `npx vitest run` (full suite) — 1141/1145 passed; the 4 remaining failures are pre-existing environment issues in this sandbox (blocked Electron binary download, unbuilt `pulse-coder-engine` workspace link), unrelated to this change and not touching any file it edits
- [ ] `pnpm run visual` — not run (see above); left as follow-up work, explicitly called out in the burndown doc

https://claude.ai/code/session_011LkLA6bN1trS25afww4tCq


---
_Generated by [Claude Code](https://claude.ai/code/session_011LkLA6bN1trS25afww4tCq)_