### PR TITLE
feat: open mentioned files in VS Code

### DIFF
--- a/apps/canvas-workspace/src/main/files/manager.ts
+++ b/apps/canvas-workspace/src/main/files/manager.ts
@@ -1,7 +1,9 @@
-import { ipcMain, dialog, BrowserWindow, clipboard, nativeImage } from "electron";
+import { execFile } from "child_process";
+import { ipcMain, dialog, BrowserWindow, clipboard, nativeImage, shell } from "electron";
 import { promises as fs } from "fs";
-import { join, basename } from "path";
+import { join, basename, resolve } from "path";
 import { homedir } from "os";
+import { promisify } from "util";
 import { ensureImagePreview } from './image-preview';
 
 const IGNORED_DIRS = new Set([
@@ -46,9 +48,17 @@ const listDirRecursive = async (
 
 const STORE_DIR = join(homedir(), ".pulse-coder", "canvas");
 const IMAGE_PREVIEW_DIR = join(STORE_DIR, 'image-previews');
+const execFileAsync = promisify(execFile);
 
 const getNotesDir = (workspaceId: string) =>
   join(STORE_DIR, workspaceId, "notes");
+
+const formatError = (err: unknown): string => err instanceof Error ? err.message : String(err);
+
+const vscodeUrlForPath = (filePath: string): string => {
+  const normalized = filePath.replace(/\\/g, '/');
+  return `vscode://file/${encodeURI(normalized)}`;
+};
 
 const sanitizeImageExtension = (value?: string): string => {
   const normalized = (value ?? "png")
@@ -121,6 +131,42 @@ export const setupFileManagerIpc = () => {
         return { ok: true, entries };
       } catch (err) {
         return { ok: false, error: String(err) };
+      }
+    }
+  );
+
+  // Open a project file/folder in VS Code. Prefer the CLI so folders and files
+  // open in the current app window when supported; fall back to VS Code's URL scheme.
+  ipcMain.handle(
+    "file:openInVSCode",
+    async (_event, payload: { filePath?: string }) => {
+      const rawPath = payload.filePath?.trim();
+      if (!rawPath) {
+        return { ok: false, error: "Missing file path" };
+      }
+
+      const filePath = resolve(rawPath);
+      try {
+        await fs.access(filePath);
+      } catch (err) {
+        return { ok: false, filePath, error: `Path is not accessible: ${formatError(err)}` };
+      }
+
+      let lastError = "";
+      for (const command of ["code", "code-insiders"]) {
+        try {
+          await execFileAsync(command, ["--reuse-window", filePath], { windowsHide: true });
+          return { ok: true, filePath, command };
+        } catch (err) {
+          lastError = formatError(err);
+        }
+      }
+
+      try {
+        await shell.openExternal(vscodeUrlForPath(filePath));
+        return { ok: true, filePath, command: "vscode-url" };
+      } catch (err) {
+        return { ok: false, filePath, error: formatError(err) || lastError || "Unable to open VS Code" };
       }
     }
   );

--- a/apps/canvas-workspace/src/preload/bridge/file.ts
+++ b/apps/canvas-workspace/src/preload/bridge/file.ts
@@ -20,6 +20,9 @@ export const createFileApi = (ipcRenderer: IpcRenderer): FileApi => ({
   listDir: (dirPath, maxDepth) =>
     ipcRenderer.invoke("file:listDir", { dirPath, maxDepth }),
 
+  openInVSCode: (filePath) =>
+    ipcRenderer.invoke("file:openInVSCode", { filePath }),
+
   openDialog: () => ipcRenderer.invoke("file:openDialog"),
 
   saveAsDialog: (defaultName, content) =>

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
@@ -53,6 +53,7 @@ interface ChatMessageProps {
   expandedTools: Set<number>;
   nodes?: CanvasNode[];
   workspaceId: string;
+  rootFolder?: string;
   onToggleSection: () => void;
   onToggleToolExpand: (toolId: number) => void;
   onAddImageToCanvas?: (imagePath: string, title?: string) => Promise<void> | void;
@@ -84,6 +85,7 @@ export const ChatMessage = ({
   expandedTools,
   nodes,
   workspaceId,
+  rootFolder,
   onToggleSection,
   onToggleToolExpand,
   onAddImageToCanvas,
@@ -94,15 +96,15 @@ export const ChatMessage = ({
 }: ChatMessageProps) => {
   const assistantHtml = useMemo(
     () => (message.role === 'assistant'
-      ? renderMdWithMentions(message.content, nodes, { streaming: isStreaming })
+      ? renderMdWithMentions(message.content, nodes, { streaming: isStreaming, rootFolder })
       : ''),
-    [message.role, message.content, nodes, isStreaming],
+    [message.role, message.content, nodes, isStreaming, rootFolder],
   );
   const userHtml = useMemo(
     () => (message.role === 'user'
-      ? renderMdWithMentions(message.content, nodes)
+      ? renderMdWithMentions(message.content, nodes, { rootFolder })
       : ''),
-    [message.role, message.content, nodes],
+    [message.role, message.content, nodes, rootFolder],
   );
   // Copy is offered for any settled message (user or assistant) with a body.
   const showCopyToolbar = !isStreaming && !!message.content;

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessages.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessages.tsx
@@ -17,6 +17,7 @@ interface ChatMessagesProps {
   loading: boolean;
   nodes?: CanvasNode[];
   workspaceId: string;
+  rootFolder?: string;
   streamingTools: ToolCallStatus[];
   messageTools: Map<number, ToolCallStatus[]>;
   collapsedSections: Set<number>;
@@ -129,6 +130,7 @@ export const ChatMessages = ({
   loading,
   nodes,
   workspaceId,
+  rootFolder,
   streamingTools,
   messageTools,
   collapsedSections,
@@ -233,6 +235,14 @@ export const ChatMessages = ({
       return;
     }
 
+    // File/folder mention chip → open the referenced project path in VS Code.
+    const fileChip = target.closest('[data-file-path]') as HTMLElement | null;
+    const filePath = fileChip?.dataset.filePath;
+    if (filePath) {
+      void window.canvasWorkspace.file.openInVSCode(filePath);
+      return;
+    }
+
     // Mention chip → focus the canvas node it references.
     const chip = target.closest('.chat-mention-chip--clickable') as HTMLElement | null;
     if (!chip || !onNodeFocus) return;
@@ -269,6 +279,7 @@ export const ChatMessages = ({
               expandedTools={expandedTools}
               nodes={nodes}
               workspaceId={workspaceId}
+              rootFolder={rootFolder}
               onToggleSection={() => onToggleSection(index)}
               onToggleToolExpand={onToggleToolExpand}
               onAddImageToCanvas={onAddImageToCanvas}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageBody.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageBody.tsx
@@ -439,6 +439,7 @@ export const ChatPageBody = ({
           messages={messages}
           loading={loading}
           workspaceId={anchorScopeId}
+          rootFolder={rootFolder}
           streamingTools={streamingTools}
           messageTools={messageTools}
           collapsedSections={collapsedSections}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.tsx
@@ -449,6 +449,7 @@ export const ChatPanel = ({
       messages={messages}
       loading={loading}
       workspaceId={anchorScopeId}
+      rootFolder={rootFolder}
       streamingTools={streamingTools}
       messageTools={messageTools}
       collapsedSections={collapsedSections}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatView.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatView.tsx
@@ -23,6 +23,7 @@ interface ChatViewProps {
   messages: AgentChatMessage[];
   loading: boolean;
   workspaceId: string;
+  rootFolder?: string;
   streamingTools: ToolCallStatus[];
   messageTools: Map<number, ToolCallStatus[]>;
   collapsedSections: Set<number>;
@@ -97,6 +98,7 @@ export const ChatView = ({
   messages,
   loading,
   workspaceId,
+  rootFolder,
   streamingTools,
   messageTools,
   collapsedSections,
@@ -160,6 +162,7 @@ export const ChatView = ({
           loading={loading}
           nodes={nodes}
           workspaceId={workspaceId}
+          rootFolder={rootFolder}
           streamingTools={streamingTools}
           messageTools={messageTools}
           collapsedSections={collapsedSections}
@@ -202,6 +205,11 @@ export const ChatView = ({
         onSelectModel={onSelectModel}
         onOpenModelSettings={onOpenModelSettings}
         onMentionNavigate={(chip) => {
+          const filePath = chip.dataset.filePath;
+          if (filePath) {
+            void window.canvasWorkspace.file.openInVSCode(filePath);
+            return;
+          }
           const nodeId = chip.dataset.nodeId;
           if (nodeId) onNodeFocus?.(nodeId);
         }}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/utils/mentions.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/utils/mentions.test.ts
@@ -24,6 +24,33 @@ describe('chat mention rendering', () => {
     expect(serializeEditable(editable)).toBe(`@[dom:dom-1|${encodeURIComponent(domLabel)}]`);
   });
 
+  it('keeps a file path on file and folder chips for VS Code opening', () => {
+    const fileChip = createMentionChipElement({
+      type: 'file',
+      label: 'src/main.ts',
+      path: '/workspace/project/src/main.ts',
+    });
+    const folderChip = createMentionChipElement({
+      type: 'folder',
+      label: 'src/',
+      path: '/workspace/project/src',
+    });
+
+    expect(fileChip.dataset.filePath).toBe('/workspace/project/src/main.ts');
+    expect(fileChip.classList.contains('chat-mention-chip--clickable')).toBe(true);
+    expect(folderChip.dataset.filePath).toBe('/workspace/project/src');
+    expect(folderChip.classList.contains('chat-mention-chip--clickable')).toBe(true);
+  });
+
+  it('renders folder references with a root path for VS Code opening', () => {
+    const html = renderMdWithMentions('@[folder:src/components] 目录', undefined, {
+      rootFolder: '/workspace/project',
+    });
+
+    expect(html).toContain('data-file-path="/workspace/project/src/components"');
+    expect(html).toContain('chat-mention-chip--clickable');
+  });
+
   it('renders encoded DOM selection labels without leaking a closing bracket', () => {
     const html = renderMdWithMentions(`@[dom:dom-1|${encodeURIComponent(domLabel)}] 这描述了啥`);
 

--- a/apps/canvas-workspace/src/renderer/src/components/chat/utils/mentions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/utils/mentions.ts
@@ -16,6 +16,12 @@ function escapeHtml(value: string): string {
     .replace(/'/g, '&#39;');
 }
 
+function resolveMentionFilePath(rootFolder: string | undefined, relativePath: string): string {
+  const root = rootFolder?.trim().replace(/[\\/]+$/, '') ?? '';
+  const relative = relativePath.trim().replace(/^[\\/]+/, '').replace(/[\\/]+$/, '');
+  return root && relative ? `${root}/${relative}` : '';
+}
+
 export interface SessionMentionRef {
   workspaceId: string;
   sessionId: string;
@@ -135,6 +141,7 @@ export function createMentionChipElement(item: MentionItem, nodes?: CanvasNode[]
   const isWorkspace = item.type === 'workspace';
   const isSkill = item.type === 'skill';
   const isFolder = item.type === 'folder';
+  const isFile = item.type === 'file';
   const isNode = item.type === 'node';
   const isTag = item.type === 'tag';
   const isSession = item.type === 'session';
@@ -165,10 +172,9 @@ export function createMentionChipElement(item: MentionItem, nodes?: CanvasNode[]
     return chip;
   }
 
-  // Canvas-node mentions navigate to the node when clicked; tag them so the
-  // composer's click handler can resolve and focus the target (mirrors how
-  // node chips behave inside sent messages).
-  const isNavigable = isNode && !!item.nodeId;
+  // Canvas-node mentions focus the node; file/folder mentions open their
+  // project path in VS Code when clicked.
+  const isNavigable = (isNode && !!item.nodeId) || ((isFile || isFolder) && !!item.path);
 
   const classes = ['chat-mention-chip', 'chat-mention-chip--input'];
   if (isWorkspace) classes.push('chat-mention-chip--workspace');
@@ -207,6 +213,9 @@ export function createMentionChipElement(item: MentionItem, nodes?: CanvasNode[]
     chip.dataset.mentionKind = 'node';
     if (item.nodeId) chip.dataset.nodeId = item.nodeId;
     if (item.workspaceId) chip.dataset.workspaceId = item.workspaceId;
+  } else if ((isFile || isFolder) && item.path) {
+    chip.dataset.filePath = item.path;
+    chip.title = 'Open in VS Code';
   } else if (isDom && item.domSelection) {
     writeDomSelectionDataset(chip, item.domSelection);
   }
@@ -418,7 +427,7 @@ export function renderUserContent(content: string, nodes?: CanvasNode[]): ReactN
 export function renderMdWithMentions(
   content: string,
   nodes?: CanvasNode[],
-  options?: RenderMarkdownOptions,
+  options?: RenderMarkdownOptions & { rootFolder?: string },
 ): string {
   const html = renderMarkdown(content, options);
 
@@ -435,7 +444,12 @@ export function renderMdWithMentions(
 
     if (rawLabel.startsWith(FOLDER_MENTION_PREFIX)) {
       const folderLabel = rawLabel.slice(FOLDER_MENTION_PREFIX.length);
-      return `<span class="chat-mention-chip chat-mention-chip--folder" data-node-type="folder"><span class="chat-mention-chip-icon"><svg width="12" height="12" viewBox="0 0 14 14" fill="none">${mentionIconSvg('folder')}</svg></span><span class="chat-mention-chip-label">${escapeHtml(folderLabel)}/</span></span>`;
+      const filePath = resolveMentionFilePath(options?.rootFolder, folderLabel);
+      const filePathAttrs = filePath
+        ? ` data-file-path="${escapeHtml(filePath)}" title="Open in VS Code"`
+        : '';
+      const clickableClass = filePath ? ' chat-mention-chip--clickable' : '';
+      return `<span class="chat-mention-chip chat-mention-chip--folder${clickableClass}" data-node-type="folder"${filePathAttrs}><span class="chat-mention-chip-icon"><svg width="12" height="12" viewBox="0 0 14 14" fill="none">${mentionIconSvg('folder')}</svg></span><span class="chat-mention-chip-label">${escapeHtml(folderLabel)}/</span></span>`;
     }
 
     if (rawLabel.startsWith(TAG_MENTION_PREFIX)) {
@@ -463,6 +477,11 @@ export function renderMdWithMentions(
     const node = nodes?.find(item => item.title === rawLabel);
     const nodeType = node?.type ?? 'file';
     const nodeId = node?.id ?? '';
-    return `<span class="chat-mention-chip chat-mention-chip--clickable" data-node-type="${escapeHtml(nodeType)}" data-node-id="${escapeHtml(nodeId)}"><span class="chat-mention-chip-icon"><svg width="12" height="12" viewBox="0 0 14 14" fill="none">${mentionIconSvg(nodeType)}</svg></span><span class="chat-mention-chip-label">${escapeHtml(rawLabel)}</span></span>`;
+    const filePath = node ? '' : resolveMentionFilePath(options?.rootFolder, rawLabel);
+    const filePathAttrs = filePath
+      ? ` data-file-path="${escapeHtml(filePath)}" title="Open in VS Code"`
+      : '';
+    const clickableClass = nodeId || filePath ? ' chat-mention-chip--clickable' : '';
+    return `<span class="chat-mention-chip${clickableClass}" data-node-type="${escapeHtml(nodeType)}" data-node-id="${escapeHtml(nodeId)}"${filePathAttrs}><span class="chat-mention-chip-icon"><svg width="12" height="12" viewBox="0 0 14 14" fill="none">${mentionIconSvg(nodeType)}</svg></span><span class="chat-mention-chip-label">${escapeHtml(rawLabel)}</span></span>`;
   });
 }

--- a/apps/canvas-workspace/src/renderer/src/types/files.ts
+++ b/apps/canvas-workspace/src/renderer/src/types/files.ts
@@ -18,6 +18,9 @@ export interface FileApi {
     dirPath: string,
     maxDepth?: number,
   ) => Promise<{ ok: boolean; entries?: DirEntry[]; error?: string }>;
+  openInVSCode: (
+    filePath: string,
+  ) => Promise<{ ok: boolean; filePath?: string; command?: string; error?: string }>;
   openDialog: () => Promise<{
     ok: boolean;
     canceled?: boolean;


### PR DESCRIPTION
Enable project file and folder mentions to open in VS Code.

- Add guarded Electron IPC with code/code-insiders and vscode URL fallback
- Preserve file paths for composer and historical chat mention chips
- Add mention rendering tests for file and folder paths

Validation:
- canvas-workspace mention tests: 6 passed
- canvas-workspace typecheck: passed
- canvas-workspace Electron build: passed