### PR TITLE
fix: align link actions with browser toolbar

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/IframeRenderedView.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/IframeRenderedView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, type KeyboardEventHandler, type RefObject } from 'react';
 import type { Artifact } from '../../types';
 import { Button } from '../ui/Button';
+import { ExternalLinkIcon } from '../icons';
 import { BrowserNavigationButtons } from '../EmbeddedBrowser/BrowserNavigationButtons';
 import { STREAMING_SHELL } from '../artifacts/streamingShell';
 import { appendDomPickerBridge } from './domPickerBridge';
@@ -210,7 +211,7 @@ export const IframeRenderedView = ({
               title="Open externally"
               aria-label="Open externally"
             >
-              <OpenIcon />
+              <ExternalLinkIcon />
             </Button>
           )}
         </div>
@@ -467,18 +468,6 @@ const ReviewIcon = () => (
       d="M2.5 2h7a1 1 0 011 1v4.2a1 1 0 01-1 1H6.2L3.4 10V8.2h-.9a1 1 0 01-1-1V3a1 1 0 011-1zM3.5 4.2h5M3.5 6h3.2"
       stroke="currentColor"
       strokeWidth="1.15"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </svg>
-);
-
-const OpenIcon = () => (
-  <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-    <path
-      d="M5 2H2.5A.5.5 0 002 2.5v7A.5.5 0 002.5 10h7a.5.5 0 00.5-.5V7M7 2h3v3M5.5 6.5L10 2"
-      stroke="currentColor"
-      strokeWidth="1.2"
       strokeLinecap="round"
       strokeLinejoin="round"
     />

--- a/apps/canvas-workspace/src/renderer/src/components/LinkDrawer/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/LinkDrawer/index.css
@@ -45,58 +45,12 @@
 .link-drawer__actions {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: 4px;
   flex: 0 0 auto;
 }
 
 .link-drawer__action {
-  appearance: none;
-  width: 28px;
-  height: 28px;
-  padding: 0;
-  border: 1px solid rgba(55, 53, 47, 0.12);
-  border-radius: var(--radius-xs);
-  background: #fff;
-  color: #73716c;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition:
-    background 0.14s ease,
-    border-color 0.14s ease,
-    color 0.14s ease,
-    transform 0.2s ease;
-}
-
-.link-drawer__action:hover:not(:disabled) {
-  background: rgba(55, 53, 47, 0.06);
-  border-color: rgba(55, 53, 47, 0.2);
-  color: #37352f;
-  transform: translateY(-1px);
-}
-
-.link-drawer__action:focus-visible {
-  outline: 2px solid rgba(35, 131, 226, 0.38);
-  outline-offset: 2px;
-}
-
-.link-drawer__action--primary {
-  border-color: #2383e2;
-  background: #2383e2;
-  color: #fff;
-  box-shadow: 0 4px 10px rgba(35, 131, 226, 0.18);
-}
-
-.link-drawer__action--primary:hover:not(:disabled) {
-  border-color: #1f76cc;
-  background: #1f76cc;
-}
-
-.link-drawer__action:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
-  box-shadow: none;
+  flex-shrink: 0;
 }
 
 /* ── Webview host ───────────────────────────────────────────────────── */

--- a/apps/canvas-workspace/src/renderer/src/components/LinkDrawer/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/LinkDrawer/index.css
@@ -42,6 +42,63 @@
   color: var(--text);
 }
 
+.link-drawer__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex: 0 0 auto;
+}
+
+.link-drawer__action {
+  appearance: none;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid rgba(55, 53, 47, 0.12);
+  border-radius: var(--radius-xs);
+  background: #fff;
+  color: #73716c;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition:
+    background 0.14s ease,
+    border-color 0.14s ease,
+    color 0.14s ease,
+    transform 0.2s ease;
+}
+
+.link-drawer__action:hover:not(:disabled) {
+  background: rgba(55, 53, 47, 0.06);
+  border-color: rgba(55, 53, 47, 0.2);
+  color: #37352f;
+  transform: translateY(-1px);
+}
+
+.link-drawer__action:focus-visible {
+  outline: 2px solid rgba(35, 131, 226, 0.38);
+  outline-offset: 2px;
+}
+
+.link-drawer__action--primary {
+  border-color: #2383e2;
+  background: #2383e2;
+  color: #fff;
+  box-shadow: 0 4px 10px rgba(35, 131, 226, 0.18);
+}
+
+.link-drawer__action--primary:hover:not(:disabled) {
+  border-color: #1f76cc;
+  background: #1f76cc;
+}
+
+.link-drawer__action:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
 /* ── Webview host ───────────────────────────────────────────────────── */
 
 .link-drawer__webview-host {

--- a/apps/canvas-workspace/src/renderer/src/components/LinkDrawer/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/LinkDrawer/index.tsx
@@ -16,7 +16,7 @@ import { BrowserNavigationButtons } from '../EmbeddedBrowser/BrowserNavigationBu
 import { pickFaviconUrl } from "../IframeNodeBody/utils";
 import { normalizeUrl } from "../IframeNodeBody/utils";
 import { ExternalLinkIcon, PlusIcon } from "../icons";
-import { TextField } from "../ui";
+import { Button, TextField } from "../ui";
 import "./index.css";
 
 interface LinkTabViewProps {
@@ -107,25 +107,28 @@ export const LinkTabView = ({
           />
         </form>
         <div className="link-drawer__actions">
-          <button
-            type="button"
-            className="link-drawer__action link-drawer__action--ghost"
+          <Button
+            variant="icon"
+            size="xs"
+            className="link-drawer__action"
             aria-label={t('linkDrawer.openInBrowser')}
             title={t('linkDrawer.openInBrowser')}
             onClick={handleOpenInBrowser}
+            disabled={!browser.currentUrl}
           >
-            <ExternalLinkIcon size={14} />
-          </button>
-          <button
-            type="button"
-            className="link-drawer__action link-drawer__action--primary"
+            <ExternalLinkIcon />
+          </Button>
+          <Button
+            variant="icon"
+            size="xs"
+            className="link-drawer__action"
             aria-label={t('linkDrawer.addToCanvas')}
             onClick={handleAddToCanvas}
             disabled={!activeWorkspaceId || !browser.currentUrl}
             title={activeWorkspaceId ? t('linkDrawer.addToCanvas') : t('linkDrawer.noActiveCanvas')}
           >
-            <PlusIcon size={13} />
-          </button>
+            <PlusIcon size={12} strokeWidth={1.2} />
+          </Button>
         </div>
       </header>
       <div ref={browser.hostRef} className="link-drawer__webview-host" />

--- a/apps/canvas-workspace/src/renderer/src/components/LinkDrawer/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/LinkDrawer/index.tsx
@@ -4,8 +4,8 @@
  * <webview>; the dock dedupes exact URLs while allowing different links
  * to stay open side by side.
  *
- * Tab chrome, link actions (open in browser / add to canvas), and switching
- * live in components/RightDock; the resolved page title is reported up via
+ * Tab chrome and switching live in components/RightDock; link actions live
+ * beside the address bar, and the resolved page title is reported up via
  * `onTitleChange`.
  */
 
@@ -15,7 +15,8 @@ import { useEmbeddedBrowser } from '../EmbeddedBrowser/useEmbeddedBrowser';
 import { BrowserNavigationButtons } from '../EmbeddedBrowser/BrowserNavigationButtons';
 import { pickFaviconUrl } from "../IframeNodeBody/utils";
 import { normalizeUrl } from "../IframeNodeBody/utils";
-import { Button, TextField } from "../ui";
+import { ExternalLinkIcon, PlusIcon } from "../icons";
+import { TextField } from "../ui";
 import "./index.css";
 
 interface LinkTabViewProps {
@@ -26,9 +27,18 @@ interface LinkTabViewProps {
   onFaviconChange?: (faviconUrl: string) => void;
   /** Navigate this tab while preserving its stable tab identity. */
   onNavigate: (url: string) => void;
+  activeWorkspaceId: string;
+  onRequestClose: () => void;
 }
 
-export const LinkTabView = ({ url, onTitleChange, onFaviconChange, onNavigate }: LinkTabViewProps) => {
+export const LinkTabView = ({
+  url,
+  onTitleChange,
+  onFaviconChange,
+  onNavigate,
+  activeWorkspaceId,
+  onRequestClose,
+}: LinkTabViewProps) => {
   const { t } = useI18n();
   const addressFormRef = useRef<HTMLFormElement>(null);
   const [address, setAddress] = useState(url);
@@ -60,6 +70,21 @@ export const LinkTabView = ({ url, onTitleChange, onFaviconChange, onNavigate }:
     onNavigate(nextUrl);
   }, [address, onNavigate]);
 
+  const handleOpenInBrowser = useCallback(() => {
+    if (!browser.currentUrl) return;
+    void window.canvasWorkspace.shell.openExternal(browser.currentUrl);
+  }, [browser.currentUrl]);
+
+  const handleAddToCanvas = useCallback(() => {
+    if (!browser.currentUrl || !activeWorkspaceId) return;
+    window.dispatchEvent(
+      new CustomEvent('canvas:add-iframe-from-url', {
+        detail: { workspaceId: activeWorkspaceId, url: browser.currentUrl },
+      }),
+    );
+    onRequestClose();
+  }, [browser.currentUrl, activeWorkspaceId, onRequestClose]);
+
   return (
     <>
       <header className="link-drawer__header">
@@ -81,6 +106,27 @@ export const LinkTabView = ({ url, onTitleChange, onFaviconChange, onNavigate }:
             spellCheck={false}
           />
         </form>
+        <div className="link-drawer__actions">
+          <button
+            type="button"
+            className="link-drawer__action link-drawer__action--ghost"
+            aria-label={t('linkDrawer.openInBrowser')}
+            title={t('linkDrawer.openInBrowser')}
+            onClick={handleOpenInBrowser}
+          >
+            <ExternalLinkIcon size={14} />
+          </button>
+          <button
+            type="button"
+            className="link-drawer__action link-drawer__action--primary"
+            aria-label={t('linkDrawer.addToCanvas')}
+            onClick={handleAddToCanvas}
+            disabled={!activeWorkspaceId || !browser.currentUrl}
+            title={activeWorkspaceId ? t('linkDrawer.addToCanvas') : t('linkDrawer.noActiveCanvas')}
+          >
+            <PlusIcon size={13} />
+          </button>
+        </div>
       </header>
       <div ref={browser.hostRef} className="link-drawer__webview-host" />
     </>

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/DockCreationControls.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/DockCreationControls.tsx
@@ -1,7 +1,7 @@
-import { lazy, Suspense, useCallback, useId, useRef, useState } from 'react';
+import { lazy, Suspense, useId, useRef, useState } from 'react';
 import type { WorkspaceEntry } from '../../hooks/useWorkspaces';
 import { useI18n } from '../../i18n';
-import { ExternalLinkIcon, PlusIcon } from '../icons';
+import { PlusIcon } from '../icons';
 import { Button } from '../ui';
 import type { DockStore } from './dock-store';
 
@@ -12,58 +12,7 @@ const NodeDockPicker = lazy(() => (
   import('./NodeDockPicker').then((module) => ({ default: module.NodeDockPicker }))
 ));
 
-interface LinkActionProps {
-  mode: 'link';
-  url: string;
-  activeWorkspaceId: string;
-  onRequestClose: () => void;
-}
-
-const LinkTabActions = ({ url, activeWorkspaceId, onRequestClose }: LinkActionProps) => {
-  const { t } = useI18n();
-
-  const handleOpenInBrowser = useCallback(() => {
-    if (!url) return;
-    void window.canvasWorkspace.shell.openExternal(url);
-  }, [url]);
-
-  const handleAddToCanvas = useCallback(() => {
-    if (!url || !activeWorkspaceId) return;
-    window.dispatchEvent(
-      new CustomEvent('canvas:add-iframe-from-url', {
-        detail: { workspaceId: activeWorkspaceId, url },
-      }),
-    );
-    onRequestClose();
-  }, [url, activeWorkspaceId, onRequestClose]);
-
-  return (
-    <div className="right-dock__link-actions">
-      <button
-        type="button"
-        className="right-dock__link-action right-dock__link-action--ghost"
-        aria-label={t('linkDrawer.openInBrowser')}
-        title={t('linkDrawer.openInBrowser')}
-        onClick={handleOpenInBrowser}
-      >
-        <ExternalLinkIcon size={14} />
-      </button>
-      <button
-        type="button"
-        className="right-dock__link-action right-dock__link-action--primary"
-        aria-label={t('linkDrawer.addToCanvas')}
-        onClick={handleAddToCanvas}
-        disabled={!activeWorkspaceId}
-        title={activeWorkspaceId ? t('linkDrawer.addToCanvas') : t('linkDrawer.noActiveCanvas')}
-      >
-        <PlusIcon size={13} />
-      </button>
-    </div>
-  );
-};
-
-interface CreationProps {
-  mode?: 'create';
+interface Props {
   store: DockStore;
   workspaces: WorkspaceEntry[];
   activeWorkspaceId: string;
@@ -71,14 +20,7 @@ interface CreationProps {
   newTabTitle: string;
 }
 
-type Props = LinkActionProps | CreationProps;
-
-export const DockCreationControls = (props: Props) => {
-  if (props.mode === 'link') {
-    return <LinkTabActions {...props} />;
-  }
-
-  const { store, workspaces, activeWorkspaceId, showTerminal, newTabTitle } = props;
+export const DockCreationControls = ({ store, workspaces, activeWorkspaceId, showTerminal, newTabTitle }: Props) => {
   const { t } = useI18n();
   const [menuOpen, setMenuOpen] = useState(false);
   const [nodePickerOpen, setNodePickerOpen] = useState(false);

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/index.css
@@ -221,8 +221,7 @@
 }
 
 .right-dock__tab:focus-visible,
-.right-dock__tab-close:focus-visible,
-.right-dock__link-action:focus-visible {
+.right-dock__tab-close:focus-visible {
   outline: 2px solid rgba(35, 131, 226, 0.38);
   outline-offset: 2px;
 }
@@ -405,76 +404,6 @@
   animation: right-dock-unread-pulse 1.8s ease-out infinite;
 }
 
-/* Link-preview actions live beside the navigation tabs so the link pane no
- * longer needs a bottom action row. */
-.right-dock__link-actions {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  flex: 0 0 auto;
-  min-width: 0;
-  padding-left: 2px;
-  position: relative;
-  z-index: 1;
-}
-
-.right-dock__link-action {
-  --right-dock-link-action-shadow: 0 6px 14px rgba(35, 131, 226, 0.18);
-  appearance: none;
-  border: 1px solid rgba(55, 53, 47, 0.12);
-  height: 30px;
-  border-radius: var(--radius-md);
-  font: inherit;
-  font-size: 12px;
-  font-weight: 650;
-  line-height: 1;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 5px;
-  white-space: nowrap;
-  cursor: pointer;
-  transition:
-    background 0.14s ease,
-    border-color 0.14s ease,
-    color 0.14s ease,
-    transform 0.2s var(--tab-ease);
-}
-
-.right-dock__link-action--ghost {
-  width: 30px;
-  padding: 0;
-  background: rgba(255, 255, 255, 0.78);
-  color: #73716c;
-}
-
-.right-dock__link-action--ghost:hover:not(:disabled) {
-  background: rgba(55, 53, 47, 0.06);
-  color: #37352f;
-  transform: translateY(-1px);
-}
-
-.right-dock__link-action--primary {
-  width: 30px;
-  padding: 0;
-  border-color: var(--accent);
-  background: var(--accent);
-  color: #fff;
-  box-shadow: var(--right-dock-link-action-shadow);
-}
-
-.right-dock__link-action--primary:hover:not(:disabled) {
-  border-color: #1f76cc;
-  background: #1f76cc;
-  transform: translateY(-1px);
-}
-
-.right-dock__link-action:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
-  box-shadow: none;
-}
-
 .right-dock__new-link,
 .right-dock__collapse {
   appearance: none;
@@ -547,7 +476,6 @@
   .right-dock__tab-dot,
   .right-dock__tab-icon,
   .right-dock__tab-close,
-  .right-dock__link-action,
   .right-dock__collapse {
     transition: none;
   }

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/index.tsx
@@ -15,7 +15,7 @@ import {
 import { useDragResize } from '../ui';
 import { useI18n } from '../../i18n';
 import { AppLogoIcon } from '../icons';
-import { CHAT_TAB_ID, DockStore, isTerminalTabId, type DockPreviewTab, type DockState } from './dock-store';
+import { CHAT_TAB_ID, DockStore, isTerminalTabId, type DockState } from './dock-store';
 import { LinkTabIcon } from './LinkTabIcon';
 import { TerminalDockTab } from './TerminalDockTab';
 import type { WorkspaceEntry } from '../../hooks/useWorkspaces';
@@ -200,10 +200,6 @@ export const RightDock = ({ activeWorkspaceId, chatTabEnabled, workspaces, onOpe
     ? null
     : state.activeTabId;
   const terminalPaneActive = state.terminalTabs.some((tab) => tab.id === activePaneId);
-  const activeLinkTab = state.tabs.find(
-    (tab): tab is Extract<DockPreviewTab, { kind: 'link' }> => tab.id === activePaneId && tab.kind === 'link',
-  );
-
   const [width, setWidth] = useState<number>(() => clampWidth(readStoredWidth() ?? DEFAULT_WIDTH));
 
   const tabsRef = useRef<HTMLDivElement | null>(null);
@@ -418,12 +414,6 @@ export const RightDock = ({ activeWorkspaceId, chatTabEnabled, workspaces, onOpe
             );
           })}
         </div>
-        {activeLinkTab && (
-          <Suspense fallback={null}>
-            <DockCreationControls mode="link" url={activeLinkTab.url} activeWorkspaceId={activeWorkspaceId}
-              onRequestClose={() => store.close(activeLinkTab.id)} />
-          </Suspense>
-        )}
         {visible && (
           <Suspense fallback={null}>
             <DockCreationControls
@@ -486,9 +476,11 @@ export const RightDock = ({ activeWorkspaceId, chatTabEnabled, workspaces, onOpe
               <Suspense fallback={null}>
                 <LinkTabView
                   url={tab.url}
+                  activeWorkspaceId={activeWorkspaceId}
                   onTitleChange={(title) => store.setTitle(tab.id, title)}
                   onFaviconChange={(faviconUrl) => store.setFavicon(tab.id, faviconUrl)}
                   onNavigate={(url) => store.navigateLink(tab.id, url)}
+                  onRequestClose={() => store.close(tab.id)}
                 />
               </Suspense>
             )}

--- a/apps/canvas-workspace/src/renderer/src/components/icons/ExternalLinkIcon.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/icons/ExternalLinkIcon.tsx
@@ -4,11 +4,11 @@ interface Props {
   strokeWidth?: number;
 }
 
-/** Arrow leaving a square — open a resource outside the app. */
-export const ExternalLinkIcon = ({ size = 14, className, strokeWidth = 1.35 }: Props) => (
-  <svg width={size} height={size} viewBox="0 0 14 14" fill="none" className={className}>
+/** Arrow leaving a square — shared with the Web page toolbar. */
+export const ExternalLinkIcon = ({ size = 12, className, strokeWidth = 1.2 }: Props) => (
+  <svg width={size} height={size} viewBox="0 0 12 12" fill="none" className={className}>
     <path
-      d="M5.25 3.25H3.2A1.2 1.2 0 0 0 2 4.45v6.35A1.2 1.2 0 0 0 3.2 12h6.35a1.2 1.2 0 0 0 1.2-1.2V8.75M8 2h4v4M7.25 6.75 12 2"
+      d="M5 2H2.5A.5.5 0 0 0 2 2.5v7a.5.5 0 0 0 .5.5h7a.5.5 0 0 0 .5-.5V7M7 2h3v3M5.5 6.5 10 2"
       stroke="currentColor"
       strokeWidth={strokeWidth}
       strokeLinecap="round"


### PR DESCRIPTION
Move link preview actions beside the address bar and align them with the existing Web toolbar.

- Render open-external and add-to-canvas actions in the LinkDrawer header
- Reuse the Web toolbar xs icon button treatment and shared external-link icon
- Remove obsolete RightDock action rendering and custom action styles
- Use the browser current URL and close the link tab after adding it to canvas

Validation:
- `pnpm --filter canvas-workspace typecheck`
- `pnpm --filter canvas-workspace perf:report -- --bundle-only` (7/7 gates passed)
- Headless Electron verification of the LinkDrawer toolbar layout