### PR TITLE
release(canvas): 0.1.17

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.16",
+  "version": "0.1.17",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {

--- a/apps/canvas-workspace/src/main/__tests__/ui-reuse-governance.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/ui-reuse-governance.test.ts
@@ -91,7 +91,9 @@ const RATCHET_BASELINE: Record<string, number> = {
   // card link, and drawer/page detail actions moved onto ui/Button. Ten raw
   // declarations were removed; the new NodeFilters/CardShell and AI review
   // actions all reuse the blessed control, so the decrease is exact.
-  rawButtonTags: 326,
+  // 326→324 (link actions): LinkDrawer's Open Externally and Add to Canvas
+  // actions moved beside the address bar and onto the blessed ui/Button.
+  rawButtonTags: 324,
   // raw <input> tags in .tsx — falls as components/ui/TextField absorbs them.
   // 55→54: ui/TextField's own <input> (+1), WorkspaceSettings name field
   // migrated (-1), and comment-stripping dropped one doc mention (-1).
@@ -320,7 +322,9 @@ const RATCHET_BASELINE: Record<string, number> = {
   // 1881→1879: the duplicate ChatHeader brand mark and its two color literals were removed.
   // 1879→1878: the duplicate Nodes/Graph chat dock and its literal surface color were removed.
   // 1874→1871: release gate cleanup reused the existing accent token and exact-value shadow tokens.
-  hardcodedColorLiterals: 1871,
+  // 1871→1863 (link actions): deleting the bespoke LinkDrawer action chrome
+  // removed eight hardcoded color literals in favor of shared ui/Button styles.
+  hardcodedColorLiterals: 1863,
   // box-shadow declaration lines not using a var(--shadow-*) token — same
   // line-based style as borderRadiusLiterals. frontend.md previously said
   // "measured but not yet gated"; gated 2026-07-08 at the as-measured


### PR DESCRIPTION
## Release notes

- 优化链接预览体验：将“外部打开”和“添加到画布”操作移到浏览器地址栏旁，并统一网页节点的外部链接图标。
- Improved link previews by moving Open Externally and Add to Canvas actions beside the browser address bar, with a consistent external-link icon across web nodes.

## Validation

- `pnpm --filter canvas-workspace perf:package`
- `codesign --verify --deep --strict` passed for the packaged app
- `node scripts/harness/run-harness-check.mjs --path apps/canvas-workspace/package.json --level standard`
- 175 test files / 1240 tests passed