### PR TITLE
fix(remote-server): resolve zod v4 record crash masquerading as upstream failure

### DIFF
--- a/apps/remote-server/src/core/tools/lark-cli.test.ts
+++ b/apps/remote-server/src/core/tools/lark-cli.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { larkCliTool } from './lark-cli.js';
+
+describe('larkCliTool inputSchema', () => {
+  it('converts to JSON schema without crashing (zod v4 record regression)', () => {
+    expect(() => z.toJSONSchema(larkCliTool.inputSchema)).not.toThrow();
+  });
+});

--- a/apps/remote-server/src/core/tools/lark-cli.ts
+++ b/apps/remote-server/src/core/tools/lark-cli.ts
@@ -20,7 +20,7 @@ const toolSchema = z.object({
   cwd: z.string().optional().describe('Working directory for the command.'),
   timeoutMs: z.number().int().positive().optional().describe('Timeout in milliseconds. Defaults to 30000.'),
   maxBuffer: z.number().int().positive().optional().describe('Max stdout/stderr buffer in bytes. Defaults to 5MB.'),
-  env: z.record(z.string()).optional().describe('Additional environment variables.'),
+  env: z.record(z.string(), z.string()).optional().describe('Additional environment variables.'),
   binary: z.string().optional().describe('Override lark-cli binary path.'),
 });
 

--- a/packages/engine/src/core/loop.test.ts
+++ b/packages/engine/src/core/loop.test.ts
@@ -417,6 +417,60 @@ describe('loop', () => {
     }
   });
 
+  it('surfaces local crashes (no HTTP status / responseBody) as local errors, not upstream', async () => {
+    const context: Context = {
+      messages: [{ role: 'user', content: 'test' }],
+    };
+    // Simulates the AI SDK's NoOutputGeneratedError: message contains
+    // "No output generated" but there's no status, responseBody, or data.
+    // The original local exception (e.g., a zod schema TypeError) has
+    // already been swallowed by the SDK and logged separately to stderr.
+    const noOutputError = Object.assign(new Error('No output generated. Check the stream for errors.'), {
+      name: 'AI_NoOutputGeneratedError',
+    });
+
+    streamTextAIMock.mockImplementation(() => {
+      throw noOutputError;
+    });
+
+    const result = await loop(context);
+
+    expect(result).toContain('本地代码在准备 LLM 请求时崩溃');
+    expect(result).toContain('AI_NoOutputGeneratedError');
+    expect(result).toContain('No output generated. Check the stream for errors.');
+    expect(result).not.toContain('上游模型没有产出任何输出');
+    expect(streamTextAIMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries no-output-generated errors that carry an upstream responseBody', async () => {
+    vi.useFakeTimers();
+    try {
+      const context: Context = {
+        messages: [{ role: 'user', content: 'test' }],
+      };
+      const upstreamError = Object.assign(new Error('No output generated.'), {
+        responseBody: '{"error":{"message":"Upstream request failed","type":"upstream_error"}}',
+      });
+      streamTextAIMock
+        .mockImplementationOnce(() => { throw upstreamError; })
+        .mockImplementationOnce(() => { throw upstreamError; })
+        .mockReturnValue({
+          text: Promise.resolve('recovered'),
+          steps: Promise.resolve([{ response: { messages: [] } }]),
+          finishReason: Promise.resolve('stop'),
+        });
+
+      const resultPromise = loop(context);
+      await vi.runAllTimersAsync();
+      const result = await resultPromise;
+
+      expect(result).toBe('recovered');
+      expect(streamTextAIMock).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('times out LLM calls that never produce a first chunk', async () => {
     vi.useFakeTimers();
 

--- a/packages/engine/src/core/loop.ts
+++ b/packages/engine/src/core/loop.ts
@@ -796,10 +796,12 @@ export async function loop(context: Context, options?: LoopOptions): Promise<str
         console.warn('[loop] LLM stream produced no output', {
           model: options?.model,
           modelType: options?.modelType,
+          name: error?.name,
           status: error?.status ?? error?.statusCode,
           cause: error?.cause,
           responseBody: error?.responseBody,
           data: error?.data,
+          stack: error?.stack,
         });
       }
 
@@ -889,6 +891,22 @@ function formatUpstreamError(error: any): string | null {
   }
 
   if (combined.includes('no output generated')) {
+    if (isLocalCrash(error)) {
+      const errorName = error?.name ?? 'Error';
+      const errorMessage = error?.message ?? '(empty)';
+      return [
+        '⚠️ 本地代码在准备 LLM 请求时崩溃（非上游错误）。',
+        '',
+        'AI SDK 抛出 "No output generated" 是因为流在产出 token 前就被本地异常打断；原始异常已被 AI SDK 吞掉，但通常会在 pm2 error log 中单独打印（搜 "TypeError" / "SyntaxError" 或本条警告前后的栈）。常见原因：',
+        '- 工具的 zod schema 不兼容当前 zod 版本（例如 zod v4 下误用 `z.record(z.string())` 单参数语法，应改为 `z.record(z.string(), z.string())`）',
+        '- 自定义 provider / transformer 在序列化工具参数或消息时抛错',
+        '- context 中含有无法序列化的对象',
+        '',
+        `错误类型：${errorName}`,
+        `错误消息：${errorMessage}`,
+      ].join('\n');
+    }
+
     const detail = pickFirstNonEmpty(messages, 'no output generated');
     return [
       '⚠️ 上游模型没有产出任何输出。',
@@ -1026,10 +1044,25 @@ function isRetryableError(error: any): boolean {
   }
   // "No output generated" means the upstream opened a stream but produced no
   // tokens before failing — this is a transient condition worth retrying.
+  // Local crashes (TypeError, schema conversion failures, etc.) also surface as
+  // "No output generated" but are deterministic — retrying just burns 3 attempts
+  // and spams the logs, so skip them.
   if (typeof error?.message === 'string' && error.message.toLowerCase().includes('no output generated')) {
-    return true;
+    return !isLocalCrash(error);
   }
   return false;
+}
+
+function isLocalCrash(error: any): boolean {
+  if (!error) return false;
+  const name = error?.name;
+  if (name === 'TypeError' || name === 'SyntaxError' || name === 'ReferenceError' || name === 'RangeError') {
+    return true;
+  }
+  const hasHttpStatus = typeof error?.status === 'number' || typeof error?.statusCode === 'number';
+  const hasResponseBody = typeof error?.responseBody === 'string' && error.responseBody.length > 0;
+  const hasData = error?.data !== undefined;
+  return !hasHttpStatus && !hasResponseBody && !hasData;
 }
 
 function sleep(ms: number, abortSignal?: AbortSignal): Promise<void> {


### PR DESCRIPTION
## Summary

- **Root cause**: `lark-cli` tool 用了 `z.record(z.string())`（zod v3 单参数语法），在 zod v4 下 `toJSONSchema` 会抛 `Cannot read properties of undefined (reading '_zod')`。崩溃发生在 OpenAI tools payload 构造阶段，AI SDK 把它包成 `No output generated`，loop 又格式化成 "⚠️ 上游模型没有产出任何输出"，把排查方向带偏到 provider/key/baseURL。
- **Fix**: `z.record(z.string(), z.string())`（zod v4 正确语法）+ regression test。
- **Hardening**: loop 的错误处理区分"本地崩溃"和"上游空 stream"——`formatUpstreamError` 在无 HTTP status / responseBody / data 时按本地崩溃输出（带 error name + message + 指向 pm2 error log 的提示）；`isRetryableError` 不再重试本地崩溃（重试只会 3 连败刷日志）；`console.warn` 补 `error.name` 和 `error.stack`。

## Evidence

pm2 error log 在 7/10、7/13、7/15、7/16 都有同一 pattern（每次三连发 = `MAX_ERROR_COUNT` 内重试）：

```
TypeError: Cannot read properties of undefined (reading '_zod')
    at process (.../zod/v4/core/to-json-schema.cjs:40:24)
    at Object.recordProcessor (.../zod/v4/core/json-schema-processor.cjs:464:69)
    ...
[loop] LLM stream produced no output {
  model: 'gpt-5.6-sol',
  modelType: 'openai',
  status: undefined,
  cause: undefined,
  responseBody: undefined,
  data: undefined
}
```

最小复现：
```js
import { z } from 'zod'  // v4.3.6
z.toJSONSchema(z.object({ env: z.record(z.string()).optional() }))
// -> TypeError: Cannot read properties of undefined (reading '_zod')
```

## Why intermittent

`lark_cli` 注册了 `defer_loading: true`，只有 LLM 通过 tool-search 把它拉进激活工具集时才会走到 schema->JSON 转换，所以不是每次对话都崩。

## Test plan

- [x] `pnpm --filter pulse-coder-engine test -- --run src/core/loop.test.ts` — 15/15 pass（含 2 个新增回归测试）
- [x] `pnpm --filter @pulse-coder/remote-server test` — 31/31 pass
- [x] `pnpm --filter pulse-coder-engine build` + `pnpm --filter @pulse-coder/remote-server build` 成功
- [x] `pm2 restart remote-server` 后启动正常
- [ ] 在 Models & Providers 面板用 lark_cli 触发一次 tool-search，确认不再报"上游模型没有产出任何输出"

## Files

| File | Change |
|------|--------|
| `apps/remote-server/src/core/tools/lark-cli.ts` | `z.record(z.string())` → `z.record(z.string(), z.string())` |
| `apps/remote-server/src/core/tools/lark-cli.test.ts` | 新增：断言 `z.toJSONSchema(inputSchema)` 不抛 |
| `packages/engine/src/core/loop.ts` | 新增 `isLocalCrash()`；`formatUpstreamError` 区分本地崩溃；`isRetryableError` 跳过本地崩溃；`console.warn` 补 `name`/`stack` |
| `packages/engine/src/core/loop.test.ts` | 新增 2 个回归测试（本地崩溃不重试 / 上游 responseBody 仍重试） |

🤖 Generated with [Claude Code](https://claude.com/claude-code)