### PR TITLE
fix(remote-server): resolve zod v4 record crash that masqueraded as u…

### DIFF
--- a/apps/remote-server/src/core/tools/lark-cli.test.ts
+++ b/apps/remote-server/src/core/tools/lark-cli.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { larkCliTool } from './lark-cli.js';
+
+describe('larkCliTool inputSchema', () => {
+  it('converts to JSON schema without crashing (zod v4 record regression)', () => {
+    expect(() => z.toJSONSchema(larkCliTool.inputSchema)).not.toThrow();
+  });
+});

--- a/apps/remote-server/src/core/tools/lark-cli.ts
+++ b/apps/remote-server/src/core/tools/lark-cli.ts
@@ -20,7 +20,7 @@ const toolSchema = z.object({
   cwd: z.string().optional().describe('Working directory for the command.'),
   timeoutMs: z.number().int().positive().optional().describe('Timeout in milliseconds. Defaults to 30000.'),
   maxBuffer: z.number().int().positive().optional().describe('Max stdout/stderr buffer in bytes. Defaults to 5MB.'),
-  env: z.record(z.string()).optional().describe('Additional environment variables.'),
+  env: z.record(z.string(), z.string()).optional().describe('Additional environment variables.'),
   binary: z.string().optional().describe('Override lark-cli binary path.'),
 });
 

--- a/packages/engine/src/core/loop.test.ts
+++ b/packages/engine/src/core/loop.test.ts
@@ -417,6 +417,60 @@ describe('loop', () => {
     }
   });
 
+  it('surfaces local crashes (no HTTP status / responseBody) as local errors, not upstream', async () => {
+    const context: Context = {
+      messages: [{ role: 'user', content: 'test' }],
+    };
+    // Simulates the AI SDK's NoOutputGeneratedError: message contains
+    // "No output generated" but there's no status, responseBody, or data.
+    // The original local exception (e.g., a zod schema TypeError) has
+    // already been swallowed by the SDK and logged separately to stderr.
+    const noOutputError = Object.assign(new Error('No output generated. Check the stream for errors.'), {
+      name: 'AI_NoOutputGeneratedError',
+    });
+
+    streamTextAIMock.mockImplementation(() => {
+      throw noOutputError;
+    });
+
+    const result = await loop(context);
+
+    expect(result).toContain('本地代码在准备 LLM 请求时崩溃');
+    expect(result).toContain('AI_NoOutputGeneratedError');
+    expect(result).toContain('No output generated. Check the stream for errors.');
+    expect(result).not.toContain('上游模型没有产出任何输出');
+    expect(streamTextAIMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries no-output-generated errors that carry an upstream responseBody', async () => {
+    vi.useFakeTimers();
+    try {
+      const context: Context = {
+        messages: [{ role: 'user', content: 'test' }],
+      };
+      const upstreamError = Object.assign(new Error('No output generated.'), {
+        responseBody: '{"error":{"message":"Upstream request failed","type":"upstream_error"}}',
+      });
+      streamTextAIMock
+        .mockImplementationOnce(() => { throw upstreamError; })
+        .mockImplementationOnce(() => { throw upstreamError; })
+        .mockReturnValue({
+          text: Promise.resolve('recovered'),
+          steps: Promise.resolve([{ response: { messages: [] } }]),
+          finishReason: Promise.resolve('stop'),
+        });
+
+      const resultPromise = loop(context);
+      await vi.runAllTimersAsync();
+      const result = await resultPromise;
+
+      expect(result).toBe('recovered');
+      expect(streamTextAIMock).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('times out LLM calls that never produce a first chunk', async () => {
     vi.useFakeTimers();
 

--- a/packages/engine/src/core/loop.ts
+++ b/packages/engine/src/core/loop.ts
@@ -796,10 +796,12 @@ export async function loop(context: Context, options?: LoopOptions): Promise<str
         console.warn('[loop] LLM stream produced no output', {
           model: options?.model,
           modelType: options?.modelType,
+          name: error?.name,
           status: error?.status ?? error?.statusCode,
           cause: error?.cause,
           responseBody: error?.responseBody,
           data: error?.data,
+          stack: error?.stack,
         });
       }
 
@@ -889,6 +891,22 @@ function formatUpstreamError(error: any): string | null {
   }
 
   if (combined.includes('no output generated')) {
+    if (isLocalCrash(error)) {
+      const errorName = error?.name ?? 'Error';
+      const errorMessage = error?.message ?? '(empty)';
+      return [
+        '⚠️ 本地代码在准备 LLM 请求时崩溃（非上游错误）。',
+        '',
+        'AI SDK 抛出 "No output generated" 是因为流在产出 token 前就被本地异常打断；原始异常已被 AI SDK 吞掉，但通常会在 pm2 error log 中单独打印（搜 "TypeError" / "SyntaxError" 或本条警告前后的栈）。常见原因：',
+        '- 工具的 zod schema 不兼容当前 zod 版本（例如 zod v4 下误用 `z.record(z.string())` 单参数语法，应改为 `z.record(z.string(), z.string())`）',
+        '- 自定义 provider / transformer 在序列化工具参数或消息时抛错',
+        '- context 中含有无法序列化的对象',
+        '',
+        `错误类型：${errorName}`,
+        `错误消息：${errorMessage}`,
+      ].join('\n');
+    }
+
     const detail = pickFirstNonEmpty(messages, 'no output generated');
     return [
       '⚠️ 上游模型没有产出任何输出。',
@@ -1026,10 +1044,25 @@ function isRetryableError(error: any): boolean {
   }
   // "No output generated" means the upstream opened a stream but produced no
   // tokens before failing — this is a transient condition worth retrying.
+  // Local crashes (TypeError, schema conversion failures, etc.) also surface as
+  // "No output generated" but are deterministic — retrying just burns 3 attempts
+  // and spams the logs, so skip them.
   if (typeof error?.message === 'string' && error.message.toLowerCase().includes('no output generated')) {
-    return true;
+    return !isLocalCrash(error);
   }
   return false;
+}
+
+function isLocalCrash(error: any): boolean {
+  if (!error) return false;
+  const name = error?.name;
+  if (name === 'TypeError' || name === 'SyntaxError' || name === 'ReferenceError' || name === 'RangeError') {
+    return true;
+  }
+  const hasHttpStatus = typeof error?.status === 'number' || typeof error?.statusCode === 'number';
+  const hasResponseBody = typeof error?.responseBody === 'string' && error.responseBody.length > 0;
+  const hasData = error?.data !== undefined;
+  return !hasHttpStatus && !hasResponseBody && !hasData;
 }
 
 function sleep(ms: number, abortSignal?: AbortSignal): Promise<void> {


### PR DESCRIPTION
…pstream failure

lark-cli tool used z.record(z.string()) (zod v3 single-arg syntax) which crashes zod v4's toJSONSchema with "Cannot read properties of undefined (reading '_zod')". The crash happens during OpenAI tools payload construction, so the AI SDK wraps it as "No output generated" - which the loop formatted as "上游模型没有产出任何输出", sending operators down the wrong provider/key/baseURL debugging path.

Fix:
- lark-cli.ts: z.record(z.string(), z.string()) (correct zod v4 syntax)
- lark-cli.test.ts: regression test asserting toJSONSchema(inputSchema) works

Also harden the loop's error handling so local crashes are no longer misattributed to the upstream:
- formatUpstreamError: when "no output generated" has no HTTP status / responseBody / data, surface as a local crash with the error name + message and a pointer to the pm2 error log (where the AI SDK leaves the original TypeError stack)
- isRetryableError: don't retry local crashes (deterministic, just burns 3 attempts and spams the logs)
- console.warn for "no output generated" now includes error.name and error.stack

Regression tests in loop.test.ts cover both paths (local crash vs upstream with responseBody).