### PR TITLE
feat: support VS Code chat links

### DIFF
--- a/apps/canvas-workspace/src/main/app/__tests__/link-policy.test.ts
+++ b/apps/canvas-workspace/src/main/app/__tests__/link-policy.test.ts
@@ -66,6 +66,19 @@ describe('link policy', () => {
     expect(electronMocks.openExternal).not.toHaveBeenCalled();
   });
 
+  it('opens VS Code protocol links through the OS handler instead of a BrowserWindow', async () => {
+    const createdHandler = await installPolicy();
+    const { contents } = createContents();
+    createdHandler({}, contents);
+
+    const windowOpenHandler = contents.setWindowOpenHandler.mock.calls[0]?.[0] as WindowOpenHandler;
+    const url = 'vscode://file/root/project/src/App.tsx:12:3';
+    const result = windowOpenHandler({ url, disposition: 'new-window' });
+
+    expect(result).toEqual({ action: 'deny' });
+    expect(electronMocks.openExternal).toHaveBeenCalledWith(url);
+  });
+
   it('opens Google auth navigations in the system browser', async () => {
     const createdHandler = await installPolicy();
     const { contents, hostWebContents } = createContents();

--- a/apps/canvas-workspace/src/main/app/__tests__/shell-ipc.test.ts
+++ b/apps/canvas-workspace/src/main/app/__tests__/shell-ipc.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn(),
+  },
+  shell: {
+    openExternal: vi.fn(),
+  },
+}));
+
+describe('shell IPC URL policy', () => {
+  it('allows VS Code editor protocols', async () => {
+    const { isSafeExternalUrl } = await import('../shell-ipc');
+
+    expect(isSafeExternalUrl('vscode://file/root/project/src/App.tsx:12:3')).toBe(true);
+    expect(isSafeExternalUrl('vscode-insiders://file/root/project/src/App.tsx:12:3')).toBe(true);
+  });
+
+  it('continues to reject unsafe local and script protocols', async () => {
+    const { isSafeExternalUrl } = await import('../shell-ipc');
+
+    expect(isSafeExternalUrl('file:///root/project/src/App.tsx')).toBe(false);
+    expect(isSafeExternalUrl('javascript:alert(1)')).toBe(false);
+  });
+});

--- a/apps/canvas-workspace/src/main/app/link-policy.ts
+++ b/apps/canvas-workspace/src/main/app/link-policy.ts
@@ -15,6 +15,11 @@ export function setupLinkPolicy(): void {
     contents.setWindowOpenHandler(({ url, disposition }) => {
       if (!isSafeExternalUrl(url)) return { action: "deny" };
 
+      if (isEditorExternalUrl(url)) {
+        openExternal(url);
+        return { action: "deny" };
+      }
+
       // OAuth-style popups need a real Chromium BrowserWindow (not a <webview>,
       // which Google's embedded-browser policy blocks). The popup inherits the
       // opener's session, so the login cookie lands in the SAME session the
@@ -53,7 +58,7 @@ export function setupLinkPolicy(): void {
         }
         if (crossOrigin && isSafeExternalUrl(url)) {
           event.preventDefault();
-          if (isExternalAuthUrl(url)) {
+          if (isEditorExternalUrl(url) || isExternalAuthUrl(url)) {
             openExternal(url);
           } else {
             forwardLinkToRenderer(contents, url);
@@ -84,6 +89,15 @@ function isLikelySsoHost(hostname: string): boolean {
 
 function isFigmaSamlCallback(url: URL): boolean {
   return isFigmaHost(url.hostname) && /^\/saml\/[^/]+\/consume\/?$/i.test(url.pathname);
+}
+
+function isEditorExternalUrl(raw: string): boolean {
+  try {
+    const protocol = new URL(raw).protocol;
+    return protocol === "vscode:" || protocol === "vscode-insiders:";
+  } catch {
+    return false;
+  }
 }
 
 function isExternalAuthUrl(raw: string): boolean {

--- a/apps/canvas-workspace/src/main/app/shell-ipc.ts
+++ b/apps/canvas-workspace/src/main/app/shell-ipc.ts
@@ -9,7 +9,14 @@
  */
 import { ipcMain, shell } from 'electron';
 
-const ALLOWED_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:']);
+const ALLOWED_PROTOCOLS = new Set([
+  'http:',
+  'https:',
+  'mailto:',
+  'tel:',
+  'vscode:',
+  'vscode-insiders:',
+]);
 
 function isSafeExternalUrl(raw: string): boolean {
   try {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessages.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessages.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type MouseEvent } from 'react';
 import type { AgentChatMessage, CanvasNode } from '../../types';
 import { BotAvatarIcon } from '../icons';
 import { ChatMessage } from './ChatMessage';
@@ -6,6 +6,7 @@ import type { PendingClarification, ToolCallStatus } from './types';
 import { buildAnchorElementId } from './utils/anchors';
 import { useI18n } from '../../i18n';
 import { isImeComposing } from '../../utils/ime';
+import { isVSCodeLink } from './utils/externalLinks';
 
 /** How close (px) to the bottom still counts as "reading the tail" — within
  *  this band the view keeps following the stream; beyond it the user has
@@ -196,7 +197,7 @@ export const ChatMessages = ({
     }
   }, [messages, pendingClarify, streamingTools, scrollToLatest]);
 
-  const handleMessageClick = useCallback(async (event: React.MouseEvent) => {
+  const handleMessageClick = useCallback(async (event: MouseEvent) => {
     const target = event.target as HTMLElement | null;
     if (!target) return;
 
@@ -216,6 +217,18 @@ export const ChatMessages = ({
       } catch {
         /* clipboard unavailable — ignore */
       }
+      return;
+    }
+
+    // VS Code protocol links from markdown should launch the editor through
+    // main-process shell.openExternal; letting target=_blank handle them asks
+    // Electron to create a BrowserWindow for a custom scheme.
+    const link = target.closest<HTMLAnchorElement>('a[href]');
+    const href = link?.getAttribute('href') ?? '';
+    if (href && isVSCodeLink(href)) {
+      event.preventDefault();
+      event.stopPropagation();
+      void window.canvasWorkspace.shell.openExternal(href);
       return;
     }
 

--- a/apps/canvas-workspace/src/renderer/src/components/chat/utils/externalLinks.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/utils/externalLinks.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { isVSCodeLink } from './externalLinks';
+
+describe('chat external links', () => {
+  it('detects VS Code editor protocol links', () => {
+    expect(isVSCodeLink('vscode://file/root/project/src/App.tsx:12:3')).toBe(true);
+    expect(isVSCodeLink('vscode-insiders://file/root/project/src/App.tsx:12:3')).toBe(true);
+  });
+
+  it('ignores non-editor and malformed links', () => {
+    expect(isVSCodeLink('https://example.com')).toBe(false);
+    expect(isVSCodeLink('mailto:dev@example.com')).toBe(false);
+    expect(isVSCodeLink('not a url')).toBe(false);
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/components/chat/utils/externalLinks.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/utils/externalLinks.ts
@@ -1,0 +1,9 @@
+const VSCODE_LINK_PROTOCOLS = new Set(['vscode:', 'vscode-insiders:']);
+
+export function isVSCodeLink(raw: string): boolean {
+  try {
+    return VSCODE_LINK_PROTOCOLS.has(new URL(raw).protocol);
+  } catch {
+    return false;
+  }
+}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/utils/markdown.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/utils/markdown.test.ts
@@ -27,3 +27,19 @@ describe('chat Markdown syntax highlighting', () => {
     expect(html).not.toContain('++>---<');
   });
 });
+
+describe('chat Markdown links', () => {
+  it('preserves VS Code protocol links for editor handoff', () => {
+    const html = renderMarkdown('[open file](vscode://file/root/project/src/App.tsx:12:3)');
+
+    expect(html).toContain('href="vscode://file/root/project/src/App.tsx:12:3"');
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
+  });
+
+  it('preserves VS Code Insiders protocol links for editor handoff', () => {
+    const html = renderMarkdown('[open file](vscode-insiders://file/root/project/src/App.tsx:12:3)');
+
+    expect(html).toContain('href="vscode-insiders://file/root/project/src/App.tsx:12:3"');
+  });
+});


### PR DESCRIPTION
Support VS Code protocol links in Chat Panel markdown.

- Allow `vscode://` and `vscode-insiders://` through the chat external-link path
- Route editor protocol clicks through main-process `shell.openExternal`
- Keep unsafe protocols such as `file:` and `javascript:` blocked
- Add renderer and main-process regression coverage

Validation:
- `/root/pulse-coder/node_modules/.bin/vitest run apps/canvas-workspace/src/renderer/src/components/chat/utils/markdown.test.ts apps/canvas-workspace/src/main/app/__tests__/shell-ipc.test.ts apps/canvas-workspace/src/main/app/__tests__/link-policy.test.ts`
- `pnpm --filter canvas-workspace typecheck`
