### PR TITLE
fix: open notes in editor by default

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBodyLazy/index.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBodyLazy/index.test.tsx
@@ -1,6 +1,55 @@
+// @vitest-environment happy-dom
+import { act } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { describe, expect, it } from 'vitest';
-import { MarkdownPreview } from '.';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { CanvasNode } from '../../types';
+
+vi.mock('../RightDock', () => ({
+  useRightDock: () => ({ openLink: vi.fn() }),
+}));
+
+vi.mock('../FileNodeBody', () => ({
+  FileNodeBody: () => <div data-testid="mock-file-editor" />,
+}));
+
+import { FileNodeBodyLazy, MarkdownPreview } from '.';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let host: HTMLDivElement | null = null;
+
+const node = {
+  id: 'note-1',
+  type: 'file',
+  title: 'Note',
+  x: 0,
+  y: 0,
+  width: 320,
+  height: 240,
+  data: { content: '# Heading' },
+  updatedAt: 1,
+} as CanvasNode;
+
+const renderFileNodeBodyLazy = async (readOnly = false) => {
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+
+  await act(async () => {
+    root?.render(<FileNodeBodyLazy node={node} onUpdate={vi.fn()} readOnly={readOnly} />);
+  });
+
+  return host;
+};
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  host?.remove();
+  root = null;
+  host = null;
+});
 
 describe('MarkdownPreview', () => {
   it('renders common Markdown structures without injecting raw HTML', () => {
@@ -31,5 +80,21 @@ describe('MarkdownPreview', () => {
 
     expect(html).not.toContain('<br');
     expect(html).toContain('<h2>First</h2><p>Paragraph</p><h2>Second</h2>');
+  });
+});
+
+describe('FileNodeBodyLazy', () => {
+  it('opens writable notes in the editor by default', async () => {
+    const view = await renderFileNodeBodyLazy(false);
+
+    expect(view.querySelector('[data-testid="mock-file-editor"]')).not.toBeNull();
+    expect(view.querySelector('.file-preview')).toBeNull();
+  });
+
+  it('keeps read-only notes in preview mode', async () => {
+    const view = await renderFileNodeBodyLazy(true);
+
+    expect(view.querySelector('[data-testid="mock-file-editor"]')).toBeNull();
+    expect(view.querySelector('.file-preview')).not.toBeNull();
   });
 });

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBodyLazy/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBodyLazy/index.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useState, type ReactNode } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useState, type ReactNode } from 'react';
 import type { CanvasNode, FileNodeData } from '../../types';
 import { dispatchOpenNode, parseNodeLinkHref } from '../../utils/openNodeBridge';
 import { useRightDock } from '../RightDock';
@@ -71,9 +71,14 @@ export const MarkdownPreview = ({ content }: { content: string }) => {
 };
 
 export const FileNodeBodyLazy = (props: Props) => {
-  const [editorLoaded, setEditorLoaded] = useState(false);
+  const [editorLoaded, setEditorLoaded] = useState(() => !props.readOnly);
   const { openLink } = useRightDock();
   const content = (props.node.data as FileNodeData).content ?? '';
+
+  useEffect(() => {
+    if (!props.readOnly) setEditorLoaded(true);
+  }, [props.readOnly]);
+
   const activateEditor = useCallback(() => {
     if (!props.readOnly) setEditorLoaded(true);
   }, [props.readOnly]);


### PR DESCRIPTION
Open editable note nodes directly in the Tiptap editor instead of showing the Markdown preview first.

- Initialize writable file note nodes with the editor loaded
- Preserve preview mode for read-only notes
- Add tests for writable default editor mode and read-only preview mode

Validation:
- vitest run apps/canvas-workspace/src/renderer/src/components/FileNodeBodyLazy/index.test.tsx
- tsc --noEmit -p apps/canvas-workspace/tsconfig.json