### PR TITLE
fix(canvas-workspace): drop redundant default export from MigrationSpinner

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;


### PR DESCRIPTION
## Summary
- Scanned `apps/canvas-workspace` for UI style inconsistencies against its documented conventions (`harness/knowledge/conventions/frontend.md`) and its mechanized style ratchet (`src/main/__tests__/ui-reuse-governance.test.ts`, 18 counters covering button/input/textarea/select reuse, border-radius/color/shadow/z-index tokenization, dropdown/popover/segmented-control reuse).
- The ratchet, file-size governance, and import-boundary governance tests all pass cleanly at their current baselines — no un-tracked drift in the areas this repo mechanically enforces.
- Found one genuine, isolated deviation from the documented component convention ("Export **named arrow-function components**... Avoid `default` exports for components"): `MigrationSpinner/index.tsx` was the only file under `components/` using `export default`, and it was dead code — `App.tsx` already imports the named `MigrationSpinner` export via a lazy `.then()` reshape.
- Removed the unused `export default MigrationSpinner;` line.

Deliberately did **not** touch the large tracked-but-deferred style backlog (1863 hardcoded color literals, 118 border-radius literals, etc.) — `frontend.md` explicitly documents that stock as "deliberately unscheduled" and migrating it requires exemplar-caller migration, visual review, and same-PR baseline updates per the ratchet's own rules. Also left the widespread `<ComponentName>Props` interface naming (19+ files) alone: it's the actual prevailing convention across the codebase, not a deviation, despite the doc technically saying just `Props`.

## Test plan
- [x] `pnpm --filter canvas-workspace typecheck` — passes
- [x] `pnpm --filter canvas-workspace test` — passes except one pre-existing, unrelated failure (`src/main/agent/__tests__/tools-graph.test.ts`, a `canvas_read_tab` tool-registry drift) confirmed present on the base branch before this change
- [x] `ui-reuse-governance.test.ts`, `file-size-governance.test.ts`, `import-boundaries.test.ts` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TitVMeDjLu6whyeb37HWtK

---
_Generated by [Claude Code](https://claude.ai/code/session_01TitVMeDjLu6whyeb37HWtK)_