### PR TITLE
fix(perf): wait for the file editor directly in the typing scenario

### DIFF
--- a/apps/canvas-workspace/scripts/perf/run-scenarios.mjs
+++ b/apps/canvas-workspace/scripts/perf/run-scenarios.mjs
@@ -421,17 +421,22 @@ const ptyStreamScenario = async (cdp) => {
 const typingScenario = async (cdp, repeatCount = 1) => {
   const editorSel = '.canvas-node--file .ProseMirror';
   const previewSel = '.canvas-node--file .file-preview--editable';
-  await waitFor(
+  // Editable file nodes open in the Tiptap editor by default now (#801), so
+  // the editor mounts straight away and the read-only Markdown preview is not
+  // rendered. Older behavior mounted a preview that had to be clicked to cross
+  // the editor boundary — click it if it's still there, but don't require it,
+  // then wait for the editor either way.
+  const hasPreview = await waitFor(
     () => evaluate(cdp, `!!document.querySelector(${JSON.stringify(previewSel)})`),
-    10_000,
-  ).catch(() => { throw new Error(`file preview did not mount (${previewSel})`); });
-  await evaluate(cdp, `document.querySelector(${JSON.stringify(previewSel)})?.click()`);
-  // File nodes now mount a lightweight Markdown preview. The first click
-  // crosses the editor boundary; wait for Tiptap before measuring typing.
+    2_000,
+  ).then(() => true).catch(() => false);
+  if (hasPreview) {
+    await evaluate(cdp, `document.querySelector(${JSON.stringify(previewSel)})?.click()`);
+  }
   await waitFor(
     () => evaluate(cdp, `!!document.querySelector(${JSON.stringify(editorSel)})`),
     10_000,
-  ).catch(() => { throw new Error(`file editor did not mount after preview activation (${editorSel})`); });
+  ).catch(() => { throw new Error(`file editor did not mount (${editorSel})`); });
   const point = await hittablePointIn(cdp, editorSel);
   if (!point) throw new Error(`no unobstructed editor found (${editorSel}) — file nodes missing or fully covered`);
   await waitForCalmFrames(cdp);


### PR DESCRIPTION
## Problem

The **Performance** CI workflow is red on `master` (and on every PR branched from it, e.g. #802). Root cause in the perf logs:

```
[perf:scenarios] file preview did not mount (.canvas-node--file .file-preview--editable)
覆盖:核心 20/47 · 运行时场景已跳过
perf:report → Exit status 1  (10 runtime gates failed)
```

#801 ("open notes in editor by default") changed `FileNodeBodyLazy` to initialize `editorLoaded` to `!readOnly`, so **editable file nodes now mount the Tiptap editor directly** and the read-only Markdown preview (`.file-preview--editable`) is never rendered for them. The perf `typingScenario` still waited for that preview to appear, timed out, and aborted the entire runtime suite — collapsing coverage to 20/47 and failing 10 runtime gates.

The first master push carrying #801 (`b08afe5`) is exactly where this workflow started failing; the same signature appears on that push run and on the PR runs.

## Fix

Make the preview-click step in `typingScenario` optional: click the preview if it is still present (older behavior), otherwise wait for the editor (`.ProseMirror`) directly. This restores the runtime perf scenarios under the new default while staying compatible with the old preview-first flow.

Single-file change to `scripts/perf/run-scenarios.mjs`.

## Validation

`node --check` passes. The Electron perf harness can't run in the dev sandbox (no display/Electron binary), so end-to-end confirmation is the CI Performance re-run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UmrkfgmsTKEvGiWT5MFvnU)_