### PR TITLE
feat(canvas-workspace): support Google sign-in in embedded webviews

### DIFF
--- a/apps/canvas-workspace/harness/knowledge/security-posture.md
+++ b/apps/canvas-workspace/harness/knowledge/security-posture.md
@@ -77,6 +77,15 @@ These make on-disk files an execution or injection surface:
   before its page can run JS; unsafe URLs are denied, OAuth-style popups get
   a real window, everything else is routed to the renderer's preview drawer
   instead of auto-opening.
+- **Google sign-in compat is host-scoped UA identity swapping**
+  (`src/main/app/google-auth.ts`): UA-*string* spoofing alone is detectable —
+  Chromium emits UA Client Hints from the real bundled version and
+  accounts.google.com rejects the mismatch. On the exact-match Google auth
+  hosts only, a per-webContents Firefox UA override (suppresses client hints)
+  plus a defaultSession header rewrite makes sign-in pass; link-policy keeps
+  both OAuth legs in-app so the cookie lands in the webview session. The
+  host allowlist is exact-match by design — it loosens navigation policy, so
+  suffix lookalikes (`accounts.google.com.evil`) must never qualify.
 
 ## Containment that DOES exist
 

--- a/apps/canvas-workspace/src/main/app/__tests__/google-auth.test.ts
+++ b/apps/canvas-workspace/src/main/app/__tests__/google-auth.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const electronMocks = vi.hoisted(() => ({
+  appOn: vi.fn(),
+  onBeforeSendHeaders: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    on: electronMocks.appOn,
+  },
+  session: {
+    defaultSession: {
+      webRequest: {
+        onBeforeSendHeaders: electronMocks.onBeforeSendHeaders,
+      },
+    },
+  },
+}));
+
+type WillNavigateHandler = (event: unknown, url: string) => void;
+type DidStartNavigationHandler = (
+  event: unknown,
+  url: string,
+  isInPage: boolean,
+  isMainFrame: boolean,
+) => void;
+
+function createContents(userAgent = 'SpoofedChrome/140') {
+  let currentUserAgent = userAgent;
+  return {
+    on: vi.fn(),
+    getUserAgent: vi.fn(() => currentUserAgent),
+    setUserAgent: vi.fn((next: string) => {
+      currentUserAgent = next;
+    }),
+  };
+}
+
+async function installCompat() {
+  const { setupGoogleAuthCompat } = await import('../google-auth');
+  setupGoogleAuthCompat();
+  const createdHandler = electronMocks.appOn.mock.calls.find(
+    ([event]) => event === 'web-contents-created',
+  )?.[1];
+  if (typeof createdHandler !== 'function') throw new Error('web-contents-created handler not registered');
+  return createdHandler as (_event: unknown, contents: ReturnType<typeof createContents>) => void;
+}
+
+describe('isGoogleAuthUrl', () => {
+  it('matches only the exact Google auth hosts over https', async () => {
+    const { isGoogleAuthUrl } = await import('../google-auth');
+    expect(isGoogleAuthUrl('https://accounts.google.com/signin')).toBe(true);
+    expect(isGoogleAuthUrl('https://accounts.youtube.com/accounts/SetSID')).toBe(true);
+    // Lookalike/suffix hosts must never pass — this check loosens link policy.
+    expect(isGoogleAuthUrl('https://accounts.google.com.evil.example/signin')).toBe(false);
+    expect(isGoogleAuthUrl('https://evilaccounts.google.com.example/')).toBe(false);
+    expect(isGoogleAuthUrl('http://accounts.google.com/signin')).toBe(false);
+    expect(isGoogleAuthUrl('https://www.google.com/')).toBe(false);
+    expect(isGoogleAuthUrl('not a url')).toBe(false);
+  });
+});
+
+describe('rewriteGoogleAuthHeaders', () => {
+  it('replaces the UA with a Firefox identity and strips client-hint headers', async () => {
+    const { rewriteGoogleAuthHeaders } = await import('../google-auth');
+    const rewritten = rewriteGoogleAuthHeaders({
+      'user-agent': 'Mozilla/5.0 Chrome/140.0.0.0',
+      'Sec-CH-UA': '"Chromium";v="124"',
+      'sec-ch-ua-platform': '"macOS"',
+      Accept: 'text/html',
+    });
+
+    expect(rewritten['User-Agent']).toMatch(/Gecko\/20100101 Firefox\/\d+/);
+    expect(rewritten['User-Agent']).not.toContain('Chrome');
+    expect(rewritten.Accept).toBe('text/html');
+    expect(Object.keys(rewritten).some((k) => k.toLowerCase().startsWith('sec-ch-'))).toBe(false);
+    expect(Object.keys(rewritten).filter((k) => k.toLowerCase() === 'user-agent')).toEqual(['User-Agent']);
+  });
+});
+
+describe('googleAuthUserAgent', () => {
+  it('builds a platform-appropriate Firefox UA', async () => {
+    const { googleAuthUserAgent } = await import('../google-auth');
+    expect(googleAuthUserAgent('darwin')).toContain('Macintosh');
+    expect(googleAuthUserAgent('win32')).toContain('Windows NT 10.0');
+    expect(googleAuthUserAgent('linux')).toContain('X11; Linux x86_64');
+    expect(googleAuthUserAgent('linux')).not.toContain('Electron');
+  });
+});
+
+describe('setupGoogleAuthCompat', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    electronMocks.appOn.mockReset();
+    electronMocks.onBeforeSendHeaders.mockReset();
+  });
+
+  it('switches to a Firefox UA on Google auth hosts and restores it after leaving', async () => {
+    const createdHandler = await installCompat();
+    const contents = createContents();
+    createdHandler({}, contents);
+
+    const willNavigate = contents.on.mock.calls.find(
+      ([event]) => event === 'will-navigate',
+    )?.[1] as WillNavigateHandler;
+
+    willNavigate({}, 'https://accounts.google.com/signin/v2/identifier');
+    expect(contents.setUserAgent).toHaveBeenLastCalledWith(
+      expect.stringContaining('Firefox/'),
+    );
+
+    // Same-host navigation must not re-save the (already overridden) UA.
+    willNavigate({}, 'https://accounts.google.com/signin/challenge');
+    expect(contents.setUserAgent).toHaveBeenCalledTimes(1);
+
+    // Leaving Google restores the original UA, not the Firefox one.
+    willNavigate({}, 'https://www.notion.so/googlelogin?code=abc');
+    expect(contents.setUserAgent).toHaveBeenLastCalledWith('SpoofedChrome/140');
+  });
+
+  it('applies the override for main-frame did-start-navigation only', async () => {
+    const createdHandler = await installCompat();
+    const contents = createContents();
+    createdHandler({}, contents);
+
+    const didStartNavigation = contents.on.mock.calls.find(
+      ([event]) => event === 'did-start-navigation',
+    )?.[1] as DidStartNavigationHandler;
+
+    didStartNavigation({}, 'https://accounts.google.com/embedded/frame', false, false);
+    expect(contents.setUserAgent).not.toHaveBeenCalled();
+
+    didStartNavigation({}, 'https://accounts.google.com/signin', false, true);
+    expect(contents.setUserAgent).toHaveBeenCalledWith(expect.stringContaining('Firefox/'));
+  });
+
+  it('registers a header rewrite scoped to Google auth hosts', async () => {
+    await installCompat();
+
+    expect(electronMocks.onBeforeSendHeaders).toHaveBeenCalledOnce();
+    const [filter, listener] = electronMocks.onBeforeSendHeaders.mock.calls[0] as [
+      { urls: string[] },
+      (details: { requestHeaders: Record<string, string> }, callback: (res: unknown) => void) => void,
+    ];
+    expect(filter.urls).toContain('https://accounts.google.com/*');
+
+    const callback = vi.fn();
+    listener(
+      { requestHeaders: { 'User-Agent': 'x', 'Sec-CH-UA': '"Chromium";v="124"' } },
+      callback,
+    );
+    const response = callback.mock.calls[0]?.[0] as { requestHeaders: Record<string, string> };
+    expect(response.requestHeaders['User-Agent']).toContain('Firefox/');
+    expect(response.requestHeaders['Sec-CH-UA']).toBeUndefined();
+  });
+});

--- a/apps/canvas-workspace/src/main/app/__tests__/link-policy.test.ts
+++ b/apps/canvas-workspace/src/main/app/__tests__/link-policy.test.ts
@@ -17,7 +17,7 @@ vi.mock('electron', () => ({
 type WindowOpenHandler = (details: { url: string; disposition: string }) => { action: string };
 type NavigateHandler = (event: { preventDefault(): void }, url: string) => void;
 
-function createContents() {
+function createContents(currentUrl = 'https://www.figma.com/files/recent') {
   const hostWebContents = {
     isDestroyed: vi.fn(() => false),
     send: vi.fn(),
@@ -26,7 +26,7 @@ function createContents() {
     hostWebContents,
     setWindowOpenHandler: vi.fn(),
     getType: vi.fn(() => 'webview'),
-    getURL: vi.fn(() => 'https://www.figma.com/files/recent'),
+    getURL: vi.fn(() => currentUrl),
     on: vi.fn(),
   };
   return { contents, hostWebContents };
@@ -79,7 +79,28 @@ describe('link policy', () => {
     expect(electronMocks.openExternal).toHaveBeenCalledWith(url);
   });
 
-  it('opens Google auth navigations in the system browser', async () => {
+  it('opens Google auth target=_blank links in an in-app window, not the system browser', async () => {
+    // A login link with target=_blank arrives as disposition foreground-tab.
+    // The system browser can't share its session back to the app, so the
+    // cookie from a login completed there would be stranded — these must open
+    // in-app like popups do.
+    const createdHandler = await installPolicy();
+    const { contents } = createContents();
+    createdHandler({}, contents);
+
+    const windowOpenHandler = contents.setWindowOpenHandler.mock.calls[0]?.[0] as WindowOpenHandler;
+    const url = 'https://accounts.google.com/o/oauth2/v2/auth?client_id=notion';
+    const result = windowOpenHandler({ url, disposition: 'foreground-tab' });
+
+    expect(result).toEqual({ action: 'allow' });
+    expect(electronMocks.openExternal).not.toHaveBeenCalled();
+  });
+
+  it('keeps Google auth navigations inside the webview', async () => {
+    // Redirect-mode "Sign in with Google" navigates the webview itself to
+    // accounts.google.com. It must stay in-place: the google-auth compat
+    // layer makes the page pass Google's embedded-browser checks, and the
+    // session cookie has to land in the webview session.
     const createdHandler = await installPolicy();
     const { contents, hostWebContents } = createContents();
     createdHandler({}, contents);
@@ -89,9 +110,38 @@ describe('link policy', () => {
     const url = 'https://accounts.google.com/signin/v2/identifier';
     navigateHandler({ preventDefault }, url);
 
-    expect(preventDefault).toHaveBeenCalledOnce();
-    expect(electronMocks.openExternal).toHaveBeenCalledWith(url);
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(electronMocks.openExternal).not.toHaveBeenCalled();
     expect(hostWebContents.send).not.toHaveBeenCalled();
+  });
+
+  it('keeps the post-login continuation leaving accounts.google.com inside the webview', async () => {
+    const createdHandler = await installPolicy();
+    const { contents, hostWebContents } = createContents('https://accounts.google.com/signin/oauth/consent');
+    createdHandler({}, contents);
+
+    const navigateHandler = contents.on.mock.calls.find(([event]) => event === 'will-navigate')?.[1] as NavigateHandler;
+    const preventDefault = vi.fn();
+    const url = 'https://www.notion.so/googlelogin?code=abc';
+    navigateHandler({ preventDefault }, url);
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(electronMocks.openExternal).not.toHaveBeenCalled();
+    expect(hostWebContents.send).not.toHaveBeenCalled();
+  });
+
+  it('does not treat lookalike Google auth hosts as auth navigations', async () => {
+    const createdHandler = await installPolicy();
+    const { contents, hostWebContents } = createContents();
+    createdHandler({}, contents);
+
+    const navigateHandler = contents.on.mock.calls.find(([event]) => event === 'will-navigate')?.[1] as NavigateHandler;
+    const preventDefault = vi.fn();
+    const url = 'https://accounts.google.com.evil.example/signin';
+    navigateHandler({ preventDefault }, url);
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(hostWebContents.send).toHaveBeenCalledWith('link:open', { url });
   });
 
   it('keeps Figma SAML callbacks inside the webview', async () => {

--- a/apps/canvas-workspace/src/main/app/bootstrap.ts
+++ b/apps/canvas-workspace/src/main/app/bootstrap.ts
@@ -73,6 +73,7 @@ import { startLoopDelaySampler } from "../perf/loop-delay";
 import { createWindow } from "./window";
 import { setWindowFactory } from "./window-manager";
 import { setupLinkPolicy } from "./link-policy";
+import { setupGoogleAuthCompat } from "./google-auth";
 import { setupDeepLinkEarly } from "../default-browser/deep-link";
 import { setupDefaultBrowserIpc } from "../default-browser/ipc";
 
@@ -113,6 +114,7 @@ export function bootstrap({ mainDir }: BootstrapOptions): void {
     startupMark("whenReady");
     startLoopDelaySampler(writeLog);
     spoofUserAgentFallback();
+    setupGoogleAuthCompat();
     registerPulseCanvasProtocol(writeLog);
     configureAppChrome(paths.iconPath, writeLog);
     // Must run before the window opens: the default menu's Undo/Redo
@@ -286,6 +288,11 @@ function spoofUserAgentFallback(): void {
   // version bundled with Electron 30 is now below their supported floor. Strip
   // the Electron / product-name tokens and rewrite the Chrome version to a
   // recent stable release so each webContents looks like current stock Chrome.
+  //
+  // This UA-string rewrite is NOT enough for Google sign-in: Chromium still
+  // emits UA Client Hints derived from the real bundled version, and
+  // accounts.google.com rejects the mismatch. google-auth.ts layers a
+  // Firefox identity over Google's auth hosts to close that gap.
   const SPOOFED_CHROME_MAJOR = "140";
   app.userAgentFallback = app.userAgentFallback
     .replace(/\s?Electron\/\S+/g, "")

--- a/apps/canvas-workspace/src/main/app/google-auth.ts
+++ b/apps/canvas-workspace/src/main/app/google-auth.ts
@@ -1,0 +1,124 @@
+import { app, session } from "electron";
+
+// Google sign-in compatibility for embedded browsing surfaces.
+//
+// Google hard-blocks logins from anything it can fingerprint as an embedded
+// or outdated browser ("This browser or app may not be secure" /
+// `403: disallowed_useragent`). The app-wide UA spoof in bootstrap.ts rewrites
+// the UA *string* to a current Chrome, but Chromium still derives UA Client
+// Hints (`Sec-CH-UA` headers + `navigator.userAgentData`) from the real
+// bundled Chromium version. accounts.google.com requests the full client-hint
+// version list and cross-checks it against the UA string, so Chrome-flavoured
+// spoofing on an older Chromium can never pass there — the two signals always
+// disagree.
+//
+// The reliable workaround (the same one Ferdium/WebCatalog-style Electron
+// shells ship) is to present a *Firefox* identity on Google's account hosts
+// only: Firefox sends no client hints at all, so there is no second signal to
+// contradict the UA string. Two cooperating layers:
+//
+//  1. Per-webContents UA override while a contents is on a Google auth host.
+//     This is what `navigator.userAgent` reports to page JS, and an active
+//     per-contents override also stops Chromium from emitting client hints.
+//  2. Session-level header rewrite for requests to Google auth hosts, which
+//     guarantees the wire-level UA even for requests created before the
+//     per-contents override landed, and strips residual `Sec-CH-*` headers.
+//
+// link-policy.ts owns the navigation/popup routing and consults
+// isGoogleAuthUrl so auth legs stay in-app, where this compat layer applies.
+
+// Exact-match allowlist. accounts.youtube.com participates in the Google
+// sign-in cookie handshake. Keep this exact (no suffix matching): the check
+// loosens navigation policy in link-policy.ts, so `accounts.google.com.evil`
+// must never pass.
+const GOOGLE_AUTH_HOSTS = new Set(["accounts.google.com", "accounts.youtube.com"]);
+
+// Firefox ESR major. Bump occasionally, alongside the Chrome-version spoof in
+// bootstrap.ts, so the claimed browser doesn't age below Google's floor.
+const FIREFOX_VERSION = "140.0";
+
+export function isGoogleAuthUrl(raw: string): boolean {
+  try {
+    const { protocol, hostname } = new URL(raw);
+    return protocol === "https:" && GOOGLE_AUTH_HOSTS.has(hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function googleAuthUserAgent(
+  platform: NodeJS.Platform = process.platform
+): string {
+  const platformToken =
+    platform === "darwin"
+      ? "Macintosh; Intel Mac OS X 10.15"
+      : platform === "win32"
+        ? "Windows NT 10.0; Win64; x64"
+        : "X11; Linux x86_64";
+  return `Mozilla/5.0 (${platformToken}; rv:${FIREFOX_VERSION}) Gecko/20100101 Firefox/${FIREFOX_VERSION}`;
+}
+
+export function rewriteGoogleAuthHeaders(
+  requestHeaders: Record<string, string>
+): Record<string, string> {
+  const rewritten: Record<string, string> = {};
+  for (const [name, value] of Object.entries(requestHeaders)) {
+    const lower = name.toLowerCase();
+    if (lower.startsWith("sec-ch-") || lower === "user-agent") continue;
+    rewritten[name] = value;
+  }
+  rewritten["User-Agent"] = googleAuthUserAgent();
+  return rewritten;
+}
+
+// Must run after app-ready (needs defaultSession); bootstrap calls it from
+// whenReady, before the first window opens.
+export function setupGoogleAuthCompat(): void {
+  const originalUserAgents = new WeakMap<object, string>();
+
+  app.on("web-contents-created", (_event, contents) => {
+    const applyUserAgentForUrl = (url: string) => {
+      if (isGoogleAuthUrl(url)) {
+        if (!originalUserAgents.has(contents)) {
+          originalUserAgents.set(contents, contents.getUserAgent());
+          contents.setUserAgent(googleAuthUserAgent());
+        }
+      } else if (originalUserAgents.has(contents)) {
+        const original = originalUserAgents.get(contents);
+        originalUserAgents.delete(contents);
+        if (typeof original === "string") contents.setUserAgent(original);
+      }
+    };
+
+    // will-navigate covers renderer-initiated navigations before the request
+    // leaves; did-start-navigation additionally covers loadURL/popup initial
+    // loads. Server-side redirect hops keep whatever UA the leg started with,
+    // which is the correct behaviour for an OAuth continuation.
+    contents.on("will-navigate", (_navEvent, url) => {
+      applyUserAgentForUrl(url);
+    });
+    contents.on(
+      "did-start-navigation",
+      (_navEvent, url, _isInPage, isMainFrame) => {
+        if (isMainFrame) applyUserAgentForUrl(url);
+      }
+    );
+  });
+
+  // NOTE: Electron allows exactly ONE onBeforeSendHeaders listener per
+  // session — this is currently the sole registrant on defaultSession. If a
+  // second consumer ever needs request-header access, centralize both here.
+  session.defaultSession.webRequest.onBeforeSendHeaders(
+    {
+      urls: [
+        "https://accounts.google.com/*",
+        "https://accounts.youtube.com/*",
+      ],
+    },
+    (details, callback) => {
+      callback({
+        requestHeaders: rewriteGoogleAuthHeaders(details.requestHeaders),
+      });
+    }
+  );
+}

--- a/apps/canvas-workspace/src/main/app/link-policy.ts
+++ b/apps/canvas-workspace/src/main/app/link-policy.ts
@@ -1,5 +1,6 @@
 import { app, shell, type WebContents } from "electron";
 import { isSafeExternalUrl } from "./shell-ipc";
+import { isGoogleAuthUrl } from "./google-auth";
 
 // Centralized popup policy. Fires for every webContents the app ever creates:
 // the main BrowserWindow, sandboxed iframes within it, and every <webview> tag
@@ -20,22 +21,17 @@ export function setupLinkPolicy(): void {
         return { action: "deny" };
       }
 
-      // OAuth-style popups need a real Chromium BrowserWindow (not a <webview>,
-      // which Google's embedded-browser policy blocks). The popup inherits the
-      // opener's session, so the login cookie lands in the SAME session the
-      // webview uses and the round-trip (opener messaging / window.close)
-      // completes in-app. This is why Google "Sign in with Google" popups are
-      // handled here, above the system-browser fallback, rather than being
-      // pushed to the OS browser (whose session can't flow back to the app).
-      if (disposition === "new-window") {
+      // OAuth-style popups need a real Chromium BrowserWindow. The popup
+      // inherits the opener's session, so the login cookie lands in the SAME
+      // session the webview uses and the round-trip (opener messaging /
+      // window.close) completes in-app. Google auth URLs get this treatment
+      // for EVERY disposition (window.open popups AND target=_blank links):
+      // handing them to the system browser would strand the login cookie in a
+      // session the app can never read. google-auth.ts makes these in-app
+      // surfaces pass Google's embedded-browser checks (Firefox UA identity,
+      // no contradicting client hints).
+      if (disposition === "new-window" || isGoogleAuthUrl(url)) {
         return { action: "allow" };
-      }
-
-      // Non-popup auth navigations (a plain link/redirect to a login host) have
-      // no opener to message back, so hand them to the real system browser.
-      if (isExternalAuthUrl(url)) {
-        openExternal(url);
-        return { action: "deny" };
       }
 
       // Everything else is a "preview this link" intent, route to the side
@@ -58,7 +54,7 @@ export function setupLinkPolicy(): void {
         }
         if (crossOrigin && isSafeExternalUrl(url)) {
           event.preventDefault();
-          if (isEditorExternalUrl(url) || isExternalAuthUrl(url)) {
+          if (isEditorExternalUrl(url)) {
             openExternal(url);
           } else {
             forwardLinkToRenderer(contents, url);
@@ -70,6 +66,13 @@ export function setupLinkPolicy(): void {
 }
 
 function isEmbeddedAuthNavigation(currentRaw: string, nextRaw: string): boolean {
+  // In-place Google sign-in: a webview may navigate INTO a Google auth host
+  // (redirect-mode OAuth) and back OUT of it (the post-login continuation to
+  // the embedding site). Both legs must stay in the webview so the session
+  // cookie lands where the embedded site can use it — kicking either leg to
+  // the system browser strands the login there. google-auth.ts makes the
+  // Google pages pass the embedded-browser checks.
+  if (isGoogleAuthUrl(nextRaw) || isGoogleAuthUrl(currentRaw)) return true;
   try {
     const current = new URL(currentRaw);
     const next = new URL(nextRaw);
@@ -95,15 +98,6 @@ function isEditorExternalUrl(raw: string): boolean {
   try {
     const protocol = new URL(raw).protocol;
     return protocol === "vscode:" || protocol === "vscode-insiders:";
-  } catch {
-    return false;
-  }
-}
-
-function isExternalAuthUrl(raw: string): boolean {
-  try {
-    const { hostname } = new URL(raw);
-    return hostname === "accounts.google.com";
   } catch {
     return false;
   }


### PR DESCRIPTION
Google blocks sign-in when the UA string and UA Client Hints disagree: the app-wide spoof claims Chrome/140 while Chromium 124 (Electron 30) still emits Sec-CH-UA v=124, so accounts.google.com rejected every login ("This browser or app may not be secure" / disallowed_useragent). Link policy also kicked redirect-mode auth navigations to the system browser, stranding the login cookie outside the app session.

Fix, two cooperating layers:
- google-auth.ts: on the exact-match Google auth hosts only, switch the webContents to a Firefox UA (Firefox sends no client hints, so there is no second signal to contradict) and rewrite/strip UA + Sec-CH-* headers on defaultSession as a wire-level guarantee.
- link-policy.ts: open Google auth URLs in-app for every disposition (popup and target=_blank), and let webviews navigate into and out of accounts.google.com in place so both OAuth legs keep the cookie in the webview session. Lookalike hosts (accounts.google.com.evil) stay excluded by exact-match.

Covered by google-auth.test.ts and updated link-policy.test.ts; note added to harness/knowledge/security-posture.md.


Claude-Session: https://claude.ai/code/session_01NGNQY9BmEexg7WDGyhRzS5