### PR TITLE
fix: load restored chat history on open

### DIFF
--- a/apps/canvas-workspace/src/main/agent/__tests__/service-history.test.ts
+++ b/apps/canvas-workspace/src/main/agent/__tests__/service-history.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const canvasAgentState = vi.hoisted(() => ({
+  initialize: vi.fn(async () => undefined),
+  getHistory: vi.fn(() => [{ role: 'user', content: 'previous chat', timestamp: 1 }]),
+  instances: [] as Array<{ initialize: () => Promise<void>; getHistory: () => unknown[] }>,
+}));
+
+vi.mock('../canvas-agent', () => ({
+  CanvasAgent: vi.fn().mockImplementation(() => {
+    const instance = {
+      initialize: canvasAgentState.initialize,
+      getHistory: canvasAgentState.getHistory,
+    };
+    canvasAgentState.instances.push(instance);
+    return instance;
+  }),
+}));
+
+import { CanvasAgentService } from '../service';
+
+describe('CanvasAgentService history', () => {
+  it('activates the agent before reading history', async () => {
+    const service = new CanvasAgentService();
+
+    const messages = await service.getHistoryForScope({ kind: 'workspace', workspaceId: 'ws-history' });
+
+    expect(canvasAgentState.initialize).toHaveBeenCalledTimes(1);
+    expect(canvasAgentState.getHistory).toHaveBeenCalledTimes(1);
+    expect(messages).toEqual([{ role: 'user', content: 'previous chat', timestamp: 1 }]);
+  });
+});

--- a/apps/canvas-workspace/src/main/agent/ipc.ts
+++ b/apps/canvas-workspace/src/main/agent/ipc.ts
@@ -236,8 +236,13 @@ export function setupCanvasAgentIpc(): void {
 
   ipcMain.handle(
     'canvas-agent:history',
-    (_event, payload: AgentScopeRef) => {
-      return { ok: true, messages: svc.getHistoryForScope(resolveAgentScope(payload)) };
+    async (_event, payload: AgentScopeRef) => {
+      try {
+        const messages = await svc.getHistoryForScope(resolveAgentScope(payload));
+        return { ok: true, messages };
+      } catch (err) {
+        return { ok: false, error: String(err) };
+      }
     },
   );
 

--- a/apps/canvas-workspace/src/main/agent/service.ts
+++ b/apps/canvas-workspace/src/main/agent/service.ts
@@ -214,11 +214,12 @@ export class CanvasAgentService {
   /**
    * Get conversation history for the current session.
    */
-  getHistory(workspaceId: string): CanvasAgentMessage[] {
+  async getHistory(workspaceId: string): Promise<CanvasAgentMessage[]> {
     return this.getHistoryForScope(workspaceScope(workspaceId));
   }
 
-  getHistoryForScope(scope: AgentScope): CanvasAgentMessage[] {
+  async getHistoryForScope(scope: AgentScope): Promise<CanvasAgentMessage[]> {
+    await this.activateScope(scope);
     const agent = this.getAgent(scope);
     return agent?.getHistory() ?? [];
   }


### PR DESCRIPTION
Ensure opening the Canvas chat panel shows the restored previous session immediately.

Follow-up to #806: the session restore worked when an agent was activated, but the panel's initial history load returned an empty list when no agent was active yet.

- Activate the scoped agent before reading chat history
- Await history loading in the IPC handler and return errors consistently
- Add a regression test for history-triggered activation

Validation:
- /root/pulse-coder/node_modules/.bin/vitest run src/main/agent/__tests__/session-store.test.ts src/main/agent/__tests__/service-history.test.ts