### PR TITLE
fix(canvas-workspace): drop unused default export from MigrationSpinner

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;


### PR DESCRIPTION
## Summary

Scanned `apps/canvas-workspace` for UI style inconsistencies against its documented conventions (`harness/knowledge/conventions/frontend.md`) and its mechanized style ratchet (`src/main/__tests__/ui-reuse-governance.test.ts`, which gates raw-vs-blessed component usage, hardcoded color/radius/shadow literals, z-index, dialog/dropdown patterns, etc.).

**Governance test result: clean.** All 18 ratchet counters match their baselines exactly — no drift since the last recorded update. This means the categories the ratchet covers (component reuse, color usage, spacing/radius/shadow tokens) currently have no new violations.

**One violation found outside the ratchet's scope:** `frontend.md`'s component-style convention says to export named arrow-function components and "avoid `default` exports for components." `MigrationSpinner/index.tsx` already did the correct named export (`export const MigrationSpinner = ...`), but also carried a trailing `export default MigrationSpinner;` — dead code, since its only consumer (`App.tsx`) lazy-loads it via the named export, not the default.

## Changes

- `apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx`: removed the unused `export default MigrationSpinner;` line.

## Why

Keeps the component's exports consistent with every other component in `src/renderer/src/components/` and the stated convention, with no behavior change (the line was unreferenced).

## Test plan

- [x] `pnpm --filter canvas-workspace exec vitest run src/main/__tests__/ui-reuse-governance.test.ts src/main/__tests__/import-boundaries.test.ts src/main/__tests__/file-size-governance.test.ts` — all 21 tests pass, ratchet counters unchanged
- [x] `pnpm --filter canvas-workspace typecheck` — passes
- [x] Verified via grep that no code imports `MigrationSpinner` via its default export

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2VVk9W8waN6ST88WFbRJt

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2VVk9W8waN6ST88WFbRJt)_