### PR TITLE
release(canvas): 0.1.20

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.18",
+  "version": "0.1.20",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- bump Pulse Canvas from 0.1.18 to 0.1.20
- record the stable arm64 release already published to R2 and the download page

## Release notes

- Fix restoration of the most recent Canvas conversation on reopen.
- Improve Google sign-in compatibility in embedded webviews.
- Restore browser tabs and their references across restarts.
- Add browsing-history and search suggestions to the address bar.

## Validation

- canvas-workspace typecheck
- canvas-workspace test (189 files, 1326 tests)
- macOS arm64 DMG build
- R2 artifact, blockmap, and manifest upload
- Cloudflare Pages deployment
