### PR TITLE
feat(canvas): support draggable dock tabs

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/TerminalDockTab.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/TerminalDockTab.tsx
@@ -11,7 +11,6 @@ interface TerminalDockTabProps {
   onActivate: (id: string) => void;
   onClose: (id: string) => void;
   onRename: (id: string, title: string) => void;
-  dragState?: 'dragging' | 'before' | 'after';
   onDragStart: (event: DragEvent<HTMLElement>, id: string) => void;
   onDragOver: (event: DragEvent<HTMLElement>, id: string) => void;
   onDrop: (event: DragEvent<HTMLElement>, id: string) => void;
@@ -25,7 +24,6 @@ export const TerminalDockTab = ({
   onActivate,
   onClose,
   onRename,
-  dragState,
   onDragStart,
   onDragOver,
   onDrop,
@@ -89,8 +87,6 @@ export const TerminalDockTab = ({
   return (
     <span
       className="right-dock__tab-shell"
-      data-dragging={dragState === 'dragging' || undefined}
-      data-drop-position={dragState === 'before' || dragState === 'after' ? dragState : undefined}
       onDragOver={(event) => onDragOver(event, tab.id)}
       onDrop={(event) => onDrop(event, tab.id)}
     >

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/TerminalDockTab.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/TerminalDockTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
+import { useEffect, useRef, useState, type DragEvent, type KeyboardEvent } from 'react';
 import { useI18n } from '../../i18n';
 import { AgentIcon } from '../AgentNodeBody/AgentIcon';
 import { NodeTypeIcon } from '../icons';
@@ -11,6 +11,11 @@ interface TerminalDockTabProps {
   onActivate: (id: string) => void;
   onClose: (id: string) => void;
   onRename: (id: string, title: string) => void;
+  dragState?: 'dragging' | 'before' | 'after';
+  onDragStart: (event: DragEvent<HTMLElement>, id: string) => void;
+  onDragOver: (event: DragEvent<HTMLElement>, id: string) => void;
+  onDrop: (event: DragEvent<HTMLElement>, id: string) => void;
+  onDragEnd: () => void;
 }
 
 export const TerminalDockTab = ({
@@ -20,6 +25,11 @@ export const TerminalDockTab = ({
   onActivate,
   onClose,
   onRename,
+  dragState,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  onDragEnd,
 }: TerminalDockTabProps) => {
   const { t } = useI18n();
   const defaultTitle = t('rightDock.terminalNumber', { number: tab.ordinal });
@@ -77,7 +87,13 @@ export const TerminalDockTab = ({
   };
 
   return (
-    <span className="right-dock__tab-shell">
+    <span
+      className="right-dock__tab-shell"
+      data-dragging={dragState === 'dragging' || undefined}
+      data-drop-position={dragState === 'before' || dragState === 'after' ? dragState : undefined}
+      onDragOver={(event) => onDragOver(event, tab.id)}
+      onDrop={(event) => onDrop(event, tab.id)}
+    >
       <button
         ref={(element) => registerTab(tab.id, element)}
         type="button"
@@ -85,6 +101,9 @@ export const TerminalDockTab = ({
         aria-selected={active}
         className={`right-dock__tab right-dock__tab--with-close${active ? ' right-dock__tab--active' : ''}`}
         title={`${title} - ${t('rightDock.renameTerminalHint')}`}
+        draggable={!editing}
+        onDragStart={(event) => onDragStart(event, tab.id)}
+        onDragEnd={onDragEnd}
         onClick={() => onActivate(tab.id)}
         onDoubleClick={startRename}
         onKeyDown={(event) => {

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/__tests__/dock-store.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/__tests__/dock-store.test.ts
@@ -243,6 +243,44 @@ describe('DockStore', () => {
     expect(dock.getSnapshot().activeTabId).toBe(artifactTabId('ws1', 'a2'));
   });
 
+  it('reorders preview tabs before or after a drop target without changing the active tab', () => {
+    const dock = new DockStore();
+    dock.openArtifact('ws1', 'a1');
+    dock.openArtifact('ws1', 'a2');
+    dock.openArtifact('ws1', 'a3');
+    const first = artifactTabId('ws1', 'a1');
+    const second = artifactTabId('ws1', 'a2');
+    const third = artifactTabId('ws1', 'a3');
+
+    dock.reorderTab(first, third, 'after');
+    expect(dock.getSnapshot().tabs.map((tab) => tab.id)).toEqual([second, third, first]);
+    expect(dock.getSnapshot().activeTabId).toBe(third);
+
+    dock.reorderTab(first, second, 'before');
+    expect(dock.getSnapshot().tabs.map((tab) => tab.id)).toEqual([first, second, third]);
+  });
+
+  it('persists the reordered browser-tab session', () => {
+    const saved = createSessionPersistence();
+    const dock = new DockStore(saved.persistence);
+    dock.setActiveWorkspace('ws-a');
+    dock.openLink('https://a.example');
+    dock.openLink('https://b.example');
+    dock.openLink('https://c.example');
+
+    dock.reorderTab(
+      linkTabId('https://c.example'),
+      linkTabId('https://a.example'),
+      'before',
+    );
+
+    expect(saved.read()['ws-a'].tabs.map((tab) => tab.url)).toEqual([
+      'https://c.example',
+      'https://a.example',
+      'https://b.example',
+    ]);
+  });
+
   it('collapse hides the dock but keeps all tabs and the active pointer', () => {
     const dock = new DockStore();
     dock.openArtifact('ws1', 'a1');
@@ -344,6 +382,30 @@ describe('DockStore', () => {
       expanded: false,
       terminalOpen: false,
     });
+  });
+
+  it('reorders terminal tabs within the active workspace', () => {
+    const dock = new DockStore();
+    dock.setActiveWorkspace('ws-a');
+    dock.openTerminal();
+    dock.newTerminal();
+    dock.newTerminal();
+
+    dock.reorderTab(terminalTabId(3), TERMINAL_TAB_ID, 'before');
+    expect(dock.getSnapshot().terminalTabs.map((tab) => tab.id)).toEqual([
+      terminalTabId(3),
+      TERMINAL_TAB_ID,
+      terminalTabId(2),
+    ]);
+    expect(dock.getSnapshot().activeTerminalTabId).toBe(terminalTabId(3));
+
+    dock.setActiveWorkspace('ws-b');
+    dock.setActiveWorkspace('ws-a');
+    expect(dock.getSnapshot().terminalTabs.map((tab) => tab.id)).toEqual([
+      terminalTabId(3),
+      TERMINAL_TAB_ID,
+      terminalTabId(2),
+    ]);
   });
 
   it('keeps terminal tabs scoped to the active workspace', () => {

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/dock-store.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/dock-store.ts
@@ -23,6 +23,7 @@ import {
   isTerminalTabId, linkTabId, nodeDetailTabId, terminalTabId,
 } from './dock-tab-ids';
 import { DockLinkSessionStore, type DockSessionPersistence } from './dock-link-sessions';
+import { reorderTabs, updateTerminalAgentType, type DockTabDropPosition } from './dock-tab-operations';
 import type {
   DockPreviewTab,
   DockState,
@@ -37,7 +38,6 @@ export type { DockLinkSession, DockLinkSessions, DockLinkTab, DockSessionPersist
 export type { DockPreviewTab, DockState, DockTerminalTab, DockTerminalWorkspaceState } from './dock-types';
 const DEFAULT_TERMINAL_WORKSPACE_ID = '__default__';
 const EMPTY_TERMINAL_TABS: DockTerminalTab[] = [];
-
 const INITIAL: DockState = {
   tabs: [],
   activeTabId: CHAT_TAB_ID,
@@ -426,22 +426,22 @@ export class DockStore {
   }
 
   setTerminalAgentType(id: string, agentType?: string, workspaceId = this.state.activeTerminalWorkspaceId): void {
-    const trimmed = agentType?.trim();
+    const next = updateTerminalAgentType(this.getTerminalWorkspace(workspaceId), id, agentType);
+    if (next) this.commitTerminalWorkspace(workspaceId, next);
+  }
+
+  reorderTab(sourceId: string, targetId: string, position: DockTabDropPosition): void {
+    const previewTabs = reorderTabs(this.state.tabs, sourceId, targetId, position);
+    if (previewTabs) {
+      this.commit({ tabs: previewTabs });
+      this.persistActiveLinkSession();
+      return;
+    }
+    const workspaceId = this.state.activeTerminalWorkspaceId;
     const workspace = this.getTerminalWorkspace(workspaceId);
-    const tab = workspace.tabs.find((item) => item.id === id);
-    if (!tab || tab.agentType === trimmed) return;
-    this.commitTerminalWorkspace(workspaceId, {
-      ...workspace,
-      tabs: workspace.tabs.map((item) => {
-        if (item.id !== id) return item;
-        if (!trimmed) {
-          const next = { ...item };
-          delete next.agentType;
-          return next;
-        }
-        return { ...item, agentType: trimmed };
-      }),
-    });
+    const terminalTabs = reorderTabs(workspace.tabs, sourceId, targetId, position);
+    if (!terminalTabs) return;
+    this.commitTerminalWorkspace(workspaceId, { ...workspace, tabs: terminalTabs });
   }
 
   /** Hide the dock; all tabs (and the active pointer) survive. */

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/dock-tab-operations.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/dock-tab-operations.ts
@@ -1,0 +1,40 @@
+import type { DockTerminalWorkspaceState } from './dock-types';
+
+export type DockTabDropPosition = 'before' | 'after';
+
+export const reorderTabs = <T extends { id: string }>(
+  tabs: T[],
+  sourceId: string,
+  targetId: string,
+  position: DockTabDropPosition,
+): T[] | null => {
+  const sourceIndex = tabs.findIndex((tab) => tab.id === sourceId);
+  const targetIndex = tabs.findIndex((tab) => tab.id === targetId);
+  if (sourceIndex === -1 || targetIndex === -1 || sourceIndex === targetIndex) return null;
+
+  const next = tabs.filter((tab) => tab.id !== sourceId);
+  const targetIndexAfterRemoval = next.findIndex((tab) => tab.id === targetId);
+  const insertIndex = targetIndexAfterRemoval + (position === 'after' ? 1 : 0);
+  next.splice(insertIndex, 0, tabs[sourceIndex]);
+  if (next.every((tab, index) => tab.id === tabs[index]?.id)) return null;
+  return next;
+};
+
+export const updateTerminalAgentType = (
+  workspace: DockTerminalWorkspaceState,
+  id: string,
+  agentType?: string,
+): DockTerminalWorkspaceState | null => {
+  const trimmed = agentType?.trim();
+  const tab = workspace.tabs.find((item) => item.id === id);
+  if (!tab || tab.agentType === trimmed) return null;
+  return {
+    ...workspace,
+    tabs: workspace.tabs.map((item) => {
+      if (item.id !== id) return item;
+      if (trimmed) return { ...item, agentType: trimmed };
+      const { agentType: _removed, ...withoutAgentType } = item;
+      return withoutAgentType;
+    }),
+  };
+};

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/index.css
@@ -162,6 +162,37 @@
   z-index: 1;
 }
 
+.right-dock__tab-shell::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  bottom: 3px;
+  width: 2px;
+  border-radius: var(--radius-pill);
+  background: var(--accent);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s ease;
+}
+
+.right-dock__tab-shell[data-drop-position="before"]::after {
+  left: -4px;
+  opacity: 1;
+}
+
+.right-dock__tab-shell[data-drop-position="after"]::after {
+  right: -4px;
+  opacity: 1;
+}
+
+.right-dock__tab-shell[data-dragging="true"] {
+  opacity: 0.48;
+}
+
+.right-dock__tab-shell[data-dragging="true"] .right-dock__tab {
+  cursor: grabbing;
+}
+
 .right-dock__tab {
   appearance: none;
   font: inherit;
@@ -194,6 +225,7 @@
 
 .right-dock__tab--with-close {
   padding-right: 29px;
+  cursor: grab;
 }
 
 .right-dock__tab::before {

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/index.tsx
@@ -14,7 +14,6 @@ import { AppLogoIcon } from '../icons';
 import { CHAT_TAB_ID, isTerminalTabId } from './dock-store';
 import { useDockContext, useRightDockState } from './context';
 import { LinkTabIcon } from './LinkTabIcon';
-import { TerminalDockTab } from './TerminalDockTab';
 import type { WorkspaceEntry } from '../../hooks/useWorkspaces';
 import { useConsumePendingLinks } from '../../hooks/useConsumePendingLinks';
 import { useDockAgentBridge } from './useDockAgentBridge';
@@ -40,6 +39,7 @@ const LinkTabView = lazy(() => import('../LinkDrawer').then((m) => ({ default: m
 const NodeDetailDockTab = lazy(() => import('./NodeDetailDockTab').then((m) => ({ default: m.NodeDetailDockTab })));
 const CanvasPreview = lazy(() => import('./CanvasPreview').then((m) => ({ default: m.CanvasPreview })));
 const DockCreationControls = lazy(() => import('./DockCreationControls').then((m) => ({ default: m.DockCreationControls })));
+const TerminalDockTab = lazy(() => import('./TerminalDockTab').then((m) => ({ default: m.TerminalDockTab })));
 
 function readStoredWidth(): number | null {
   if (typeof window === 'undefined') return null;
@@ -70,11 +70,6 @@ interface TabIndicatorState {
   left: number;
   width: number;
   visible: boolean;
-}
-
-interface TabDropTarget {
-  id: string;
-  position: 'before' | 'after';
 }
 
 export const RightDock = ({ activeWorkspaceId, chatTabEnabled, workspaces, onOpenNodePage }: RightDockProps) => {
@@ -131,47 +126,41 @@ export const RightDock = ({ activeWorkspaceId, chatTabEnabled, workspaces, onOpe
     visible: false,
   });
   const draggedTabIdRef = useRef<string | null>(null);
-  const [draggedTabId, setDraggedTabId] = useState<string | null>(null);
-  const [tabDropTarget, setTabDropTarget] = useState<TabDropTarget | null>(null);
+  const draggedTabShellRef = useRef<HTMLElement | null>(null);
+  const tabDropTargetRef = useRef<HTMLElement | null>(null);
 
-  const clearTabDrag = useCallback(() => {
+  const clearTabDrag = () => {
+    draggedTabShellRef.current?.removeAttribute('data-dragging');
+    tabDropTargetRef.current?.removeAttribute('data-drop-position');
     draggedTabIdRef.current = null;
-    setDraggedTabId(null);
-    setTabDropTarget(null);
-  }, []);
+    draggedTabShellRef.current = null;
+    tabDropTargetRef.current = null;
+  };
 
-  const handleTabDragStart = useCallback((event: DragEvent<HTMLElement>, id: string) => {
+  const handleTabDragStart = (event: DragEvent<HTMLElement>, id: string) => {
+    clearTabDrag();
     draggedTabIdRef.current = id;
-    setDraggedTabId(id);
-    setTabDropTarget(null);
-    event.dataTransfer.effectAllowed = 'move';
-    event.dataTransfer.setData('text/plain', id);
-  }, []);
+    draggedTabShellRef.current = event.currentTarget.parentElement;
+    draggedTabShellRef.current?.setAttribute('data-dragging', 'true');
+  };
 
-  const tabsShareGroup = useCallback((sourceId: string, targetId: string) => {
-    const { tabs, terminalTabs } = store.getSnapshot();
-    return [tabs, terminalTabs].some((group) => (
-      group.some((tab) => tab.id === sourceId) && group.some((tab) => tab.id === targetId)
-    ));
-  }, [store]);
-
-  const handleTabDragOver = useCallback((event: DragEvent<HTMLElement>, targetId: string) => {
+  const handleTabDragOver = (event: DragEvent<HTMLElement>, targetId: string) => {
     const sourceId = draggedTabIdRef.current;
-    if (!sourceId || sourceId === targetId || !tabsShareGroup(sourceId, targetId)) return;
+    if (!sourceId || sourceId === targetId || isTerminalTabId(sourceId) !== isTerminalTabId(targetId)) return;
     event.preventDefault();
     event.dataTransfer.dropEffect = 'move';
     const rect = event.currentTarget.getBoundingClientRect();
     const position = event.clientX < rect.left + rect.width / 2 ? 'before' : 'after';
-    setTabDropTarget((current) => (
-      current?.id === targetId && current.position === position
-        ? current
-        : { id: targetId, position }
-    ));
-  }, [tabsShareGroup]);
+    if (tabDropTargetRef.current !== event.currentTarget) {
+      tabDropTargetRef.current?.removeAttribute('data-drop-position');
+      tabDropTargetRef.current = event.currentTarget;
+    }
+    event.currentTarget.dataset.dropPosition = position;
+  };
 
-  const handleTabDrop = useCallback((event: DragEvent<HTMLElement>, targetId: string) => {
+  const handleTabDrop = (event: DragEvent<HTMLElement>, targetId: string) => {
     const sourceId = draggedTabIdRef.current;
-    if (!sourceId || sourceId === targetId || !tabsShareGroup(sourceId, targetId)) {
+    if (!sourceId || sourceId === targetId || isTerminalTabId(sourceId) !== isTerminalTabId(targetId)) {
       clearTabDrag();
       return;
     }
@@ -180,12 +169,7 @@ export const RightDock = ({ activeWorkspaceId, chatTabEnabled, workspaces, onOpe
     const position = event.clientX < rect.left + rect.width / 2 ? 'before' : 'after';
     store.reorderTab(sourceId, targetId, position);
     clearTabDrag();
-  }, [clearTabDrag, store, tabsShareGroup]);
-
-  const getTabDragState = useCallback((id: string): 'dragging' | 'before' | 'after' | undefined => {
-    if (draggedTabId === id) return 'dragging';
-    return tabDropTarget?.id === id ? tabDropTarget.position : undefined;
-  }, [draggedTabId, tabDropTarget]);
+  };
 
   const registerTab = useCallback((id: string, element: HTMLButtonElement | null) => {
     if (element) {
@@ -342,30 +326,31 @@ export const RightDock = ({ activeWorkspaceId, chatTabEnabled, workspaces, onOpe
               <span className="right-dock__tab-unread" aria-hidden="true" />
             </button>
           )}
-          {terminalTabsVisible && state.terminalTabs.map((tab) => (
-            <TerminalDockTab
-              key={tab.id}
-              tab={tab}
-              active={tab.id === activePaneId}
-              registerTab={registerTab}
-              onActivate={(id) => store.activate(id)}
-              onClose={(id) => store.closeTerminal(id)}
-              onRename={(id, title) => store.renameTerminal(id, title)}
-              dragState={getTabDragState(tab.id)}
-              onDragStart={handleTabDragStart}
-              onDragOver={handleTabDragOver}
-              onDrop={handleTabDrop}
-              onDragEnd={clearTabDrag}
-            />
-          ))}
+          {terminalTabsVisible && (
+            <Suspense fallback={null}>
+              {state.terminalTabs.map((tab) => (
+                <TerminalDockTab
+                  key={tab.id}
+                  tab={tab}
+                  active={tab.id === activePaneId}
+                  registerTab={registerTab}
+                  onActivate={(id) => store.activate(id)}
+                  onClose={(id) => store.closeTerminal(id)}
+                  onRename={(id, title) => store.renameTerminal(id, title)}
+                  onDragStart={handleTabDragStart}
+                  onDragOver={handleTabDragOver}
+                  onDrop={handleTabDrop}
+                  onDragEnd={clearTabDrag}
+                />
+              ))}
+            </Suspense>
+          )}
           {state.tabs.map((tab) => {
             const active = tab.id === activePaneId;
             return (
               <span
                 key={tab.id}
                 className="right-dock__tab-shell"
-                data-dragging={draggedTabId === tab.id || undefined}
-                data-drop-position={tabDropTarget?.id === tab.id ? tabDropTarget.position : undefined}
                 onDragOver={(event) => handleTabDragOver(event, tab.id)}
                 onDrop={(event) => handleTabDrop(event, tab.id)}
               >

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/index.tsx
@@ -6,6 +6,7 @@ import {
   useLayoutEffect,
   useRef,
   useState,
+  type DragEvent,
 } from 'react';
 import { useDragResize } from '../ui';
 import { useI18n } from '../../i18n';
@@ -71,6 +72,11 @@ interface TabIndicatorState {
   visible: boolean;
 }
 
+interface TabDropTarget {
+  id: string;
+  position: 'before' | 'after';
+}
+
 export const RightDock = ({ activeWorkspaceId, chatTabEnabled, workspaces, onOpenNodePage }: RightDockProps) => {
   const { store, setChatHost, setTerminalHost, pinUrlReference } = useDockContext();
   const state = useRightDockState();
@@ -124,6 +130,62 @@ export const RightDock = ({ activeWorkspaceId, chatTabEnabled, workspaces, onOpe
     width: 0,
     visible: false,
   });
+  const draggedTabIdRef = useRef<string | null>(null);
+  const [draggedTabId, setDraggedTabId] = useState<string | null>(null);
+  const [tabDropTarget, setTabDropTarget] = useState<TabDropTarget | null>(null);
+
+  const clearTabDrag = useCallback(() => {
+    draggedTabIdRef.current = null;
+    setDraggedTabId(null);
+    setTabDropTarget(null);
+  }, []);
+
+  const handleTabDragStart = useCallback((event: DragEvent<HTMLElement>, id: string) => {
+    draggedTabIdRef.current = id;
+    setDraggedTabId(id);
+    setTabDropTarget(null);
+    event.dataTransfer.effectAllowed = 'move';
+    event.dataTransfer.setData('text/plain', id);
+  }, []);
+
+  const tabsShareGroup = useCallback((sourceId: string, targetId: string) => {
+    const { tabs, terminalTabs } = store.getSnapshot();
+    return [tabs, terminalTabs].some((group) => (
+      group.some((tab) => tab.id === sourceId) && group.some((tab) => tab.id === targetId)
+    ));
+  }, [store]);
+
+  const handleTabDragOver = useCallback((event: DragEvent<HTMLElement>, targetId: string) => {
+    const sourceId = draggedTabIdRef.current;
+    if (!sourceId || sourceId === targetId || !tabsShareGroup(sourceId, targetId)) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+    const rect = event.currentTarget.getBoundingClientRect();
+    const position = event.clientX < rect.left + rect.width / 2 ? 'before' : 'after';
+    setTabDropTarget((current) => (
+      current?.id === targetId && current.position === position
+        ? current
+        : { id: targetId, position }
+    ));
+  }, [tabsShareGroup]);
+
+  const handleTabDrop = useCallback((event: DragEvent<HTMLElement>, targetId: string) => {
+    const sourceId = draggedTabIdRef.current;
+    if (!sourceId || sourceId === targetId || !tabsShareGroup(sourceId, targetId)) {
+      clearTabDrag();
+      return;
+    }
+    event.preventDefault();
+    const rect = event.currentTarget.getBoundingClientRect();
+    const position = event.clientX < rect.left + rect.width / 2 ? 'before' : 'after';
+    store.reorderTab(sourceId, targetId, position);
+    clearTabDrag();
+  }, [clearTabDrag, store, tabsShareGroup]);
+
+  const getTabDragState = useCallback((id: string): 'dragging' | 'before' | 'after' | undefined => {
+    if (draggedTabId === id) return 'dragging';
+    return tabDropTarget?.id === id ? tabDropTarget.position : undefined;
+  }, [draggedTabId, tabDropTarget]);
 
   const registerTab = useCallback((id: string, element: HTMLButtonElement | null) => {
     if (element) {
@@ -289,12 +351,24 @@ export const RightDock = ({ activeWorkspaceId, chatTabEnabled, workspaces, onOpe
               onActivate={(id) => store.activate(id)}
               onClose={(id) => store.closeTerminal(id)}
               onRename={(id, title) => store.renameTerminal(id, title)}
+              dragState={getTabDragState(tab.id)}
+              onDragStart={handleTabDragStart}
+              onDragOver={handleTabDragOver}
+              onDrop={handleTabDrop}
+              onDragEnd={clearTabDrag}
             />
           ))}
           {state.tabs.map((tab) => {
             const active = tab.id === activePaneId;
             return (
-              <span key={tab.id} className="right-dock__tab-shell">
+              <span
+                key={tab.id}
+                className="right-dock__tab-shell"
+                data-dragging={draggedTabId === tab.id || undefined}
+                data-drop-position={tabDropTarget?.id === tab.id ? tabDropTarget.position : undefined}
+                onDragOver={(event) => handleTabDragOver(event, tab.id)}
+                onDrop={(event) => handleTabDrop(event, tab.id)}
+              >
                 <button
                   ref={(element) => registerTab(tab.id, element)}
                   type="button"
@@ -302,6 +376,9 @@ export const RightDock = ({ activeWorkspaceId, chatTabEnabled, workspaces, onOpe
                   aria-selected={active}
                   className={`right-dock__tab right-dock__tab--with-close${active ? ' right-dock__tab--active' : ''}`}
                   title={tab.title}
+                  draggable
+                  onDragStart={(event) => handleTabDragStart(event, tab.id)}
+                  onDragEnd={clearTabDrag}
                   onClick={() => store.activate(tab.id)}
                 >
                   {tab.kind === 'link' ? (


### PR DESCRIPTION
## What changed

- make right-dock preview, browser, and terminal tabs draggable
- reorder tabs before or after the hovered target with an insertion indicator
- keep the chat tab pinned and keep terminal/preview tabs within their existing groups
- persist reordered browser tabs through the existing per-workspace dock session storage
- add unit coverage for preview ordering, browser-session persistence, and workspace-scoped terminal ordering

## Why

Users can open several browser, preview, and terminal tabs in the right dock, but previously could not arrange them into a useful order.

## User impact

Tabs can now be dragged into a new position. The dragged tab fades, the drop position is shown with a blue insertion line, and browser-tab order survives app restarts.

## Validation

- `pnpm --filter canvas-workspace typecheck`
- `pnpm --filter canvas-workspace build`
- `pnpm --filter canvas-workspace test` — 189 files / 1329 tests passed
- focused RightDock store + UI/file-size governance tests — 56 tests passed
- real Electron demo smoke test: reordered `Terminal 2` before `Terminal 1` and verified the rendered result