### PR TITLE
fix(canvas-workspace): load x.com in webview tabs via consistent Firefox identity

### DIFF
--- a/apps/canvas-workspace/harness/knowledge/security-posture.md
+++ b/apps/canvas-workspace/harness/knowledge/security-posture.md
@@ -77,25 +77,36 @@ These make on-disk files an execution or injection surface:
   before its page can run JS; unsafe URLs are denied, OAuth-style popups get
   a real window, everything else is routed to the renderer's preview drawer
   instead of auto-opening.
-- **Google sign-in compat is host-scoped UA identity swapping + popup
-  rerouting** (`src/main/app/google-auth.ts`, `google-auth-popup.ts`):
-  UA-*string* spoofing alone is detectable — Chromium emits UA Client Hints
-  from the real bundled version and accounts.google.com rejects the
-  mismatch. On the exact-match Google auth hosts only, a per-webContents
-  Firefox UA override (suppresses client hints) plus a defaultSession
-  header rewrite presents a consistent Firefox identity
-  (`PULSE_GOOGLE_AUTH_IDENTITY=chrome` disables it — experiment arm only,
-  known-broken on Electron 30). An honest current-Chrome identity was
-  tried on Electron 42 (2026-07-17) and still rejected by `/v3/signin`
-  post-submit; the upgrade was reverted — see the evidence log in
-  google-auth.ts before re-running that loop. The allowlist is exact-match
-  by design — it loosens navigation policy, so suffix lookalikes
-  (`accounts.google.com.evil`) must never qualify. Google's strict
-  full-page flow additionally risk-scores embedded surfaces, so in-place
-  entry legs from `<webview>` guests are rerouted into a top-level
-  BrowserWindow popup on the same session (with the opener page as
-  referrer); the post-login continuation is handed back to the opener
-  webview so the one-shot URL is consumed there.
+- **Host-scoped UA identity swapping is centralized** in
+  `src/main/app/embedded-identity.ts`: UA-*string* spoofing alone
+  (bootstrap.ts's Chrome/140 rewrite) is detectable — Chromium emits UA
+  Client Hints and `navigator.userAgentData` from the real bundled version,
+  and sites that cross-check the two reject or crash on the mismatch. The
+  coordinator owns the ONE per-session `onBeforeSendHeaders` listener and a
+  single per-webContents UA-override manager (one saved-original map, so a
+  contents crossing between host sets never clobbers its restore UA), driven
+  by a list of `EmbeddedIdentityRule`s. Each rule presents a consistent
+  Firefox identity (Firefox emits no client hints) on its hosts via a
+  per-contents UA override plus a header rewrite that strips residual
+  `Sec-CH-*` and pins the Firefox UA. Two rules today:
+  - **Google sign-in** (`google-auth.ts`, `google-auth-popup.ts`): exact-match
+    Google auth hosts. The allowlist is exact-match by design — it also
+    loosens navigation policy in link-policy, so suffix lookalikes
+    (`accounts.google.com.evil`) must never qualify.
+    `PULSE_GOOGLE_AUTH_IDENTITY=chrome` returns a null rule (experiment arm
+    only, known-broken on Electron 30). An honest current-Chrome identity was
+    tried on Electron 42 (2026-07-17) and still rejected by `/v3/signin`
+    post-submit; the upgrade was reverted — see the evidence log in
+    google-auth.ts before re-running that loop. Google's strict full-page flow
+    additionally risk-scores embedded surfaces, so in-place entry legs from
+    `<webview>` guests are rerouted into a top-level BrowserWindow popup on the
+    same session (with the opener page as referrer); the post-login
+    continuation is handed back to the opener webview so the one-shot URL is
+    consumed there.
+  - **x.com** (`x-com-compat.ts`): suffix-match on `x.com`/`twitter.com` (this
+    rule does NOT loosen navigation policy, so suffix matching is safe). Fixes
+    x.com's "Something went wrong" error boundary, which its SPA renders when
+    the UA string and client hints disagree.
 
 ## Containment that DOES exist
 

--- a/apps/canvas-workspace/src/main/app/__tests__/embedded-identity.test.ts
+++ b/apps/canvas-workspace/src/main/app/__tests__/embedded-identity.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const electronMocks = vi.hoisted(() => ({
+  appOn: vi.fn(),
+  onBeforeSendHeaders: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    on: electronMocks.appOn,
+  },
+  session: {
+    defaultSession: {
+      webRequest: {
+        onBeforeSendHeaders: electronMocks.onBeforeSendHeaders,
+      },
+    },
+  },
+}));
+
+type NavHandler = (event: unknown, url: string) => void;
+type DidStartNavigationHandler = (
+  event: unknown,
+  url: string,
+  isInPage: boolean,
+  isMainFrame: boolean,
+) => void;
+
+function createContents(userAgent = 'SpoofedChrome/140') {
+  let currentUserAgent = userAgent;
+  return {
+    on: vi.fn(),
+    getUserAgent: vi.fn(() => currentUserAgent),
+    setUserAgent: vi.fn((next: string) => {
+      currentUserAgent = next;
+    }),
+  };
+}
+
+type Contents = ReturnType<typeof createContents>;
+
+async function install(rules: unknown[]) {
+  const { setupEmbeddedIdentity } = await import('../embedded-identity');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  setupEmbeddedIdentity(rules as any);
+  const createdHandler = electronMocks.appOn.mock.calls.find(
+    ([event]) => event === 'web-contents-created',
+  )?.[1] as ((event: unknown, contents: Contents) => void) | undefined;
+  return createdHandler;
+}
+
+function firefoxRule(id: string, host: string) {
+  return {
+    id,
+    matches: (url: string) => {
+      try {
+        return new URL(url).hostname === host;
+      } catch {
+        return false;
+      }
+    },
+    userAgent: `Mozilla/5.0 Firefox/140.0 (${id})`,
+    headerUrls: [`https://${host}/*`],
+    rewriteHeaders: (headers: Record<string, string>) => {
+      const out: Record<string, string> = {};
+      for (const [k, v] of Object.entries(headers)) {
+        if (k.toLowerCase().startsWith('sec-ch-') || k.toLowerCase() === 'user-agent') continue;
+        out[k] = v;
+      }
+      out['User-Agent'] = `Mozilla/5.0 Firefox/140.0 (${id})`;
+      return out;
+    },
+  };
+}
+
+describe('setupEmbeddedIdentity', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    electronMocks.appOn.mockReset();
+    electronMocks.onBeforeSendHeaders.mockReset();
+  });
+
+  it('installs nothing when given no rules', async () => {
+    await install([]);
+    expect(electronMocks.appOn).not.toHaveBeenCalled();
+    expect(electronMocks.onBeforeSendHeaders).not.toHaveBeenCalled();
+  });
+
+  it('overrides the UA on a matching host and restores it after leaving', async () => {
+    const createdHandler = await install([firefoxRule('x-com', 'x.com')]);
+    const contents = createContents();
+    createdHandler?.({}, contents);
+
+    const willNavigate = contents.on.mock.calls.find(
+      ([event]) => event === 'will-navigate',
+    )?.[1] as NavHandler;
+
+    willNavigate({}, 'https://x.com/home');
+    expect(contents.setUserAgent).toHaveBeenLastCalledWith(expect.stringContaining('Firefox/'));
+
+    // Same-host navigation must not churn the UA (already the target identity).
+    willNavigate({}, 'https://x.com/explore');
+    expect(contents.setUserAgent).toHaveBeenCalledTimes(1);
+
+    // Leaving the host restores the original spoofed UA, not the Firefox one.
+    willNavigate({}, 'https://example.com/');
+    expect(contents.setUserAgent).toHaveBeenLastCalledWith('SpoofedChrome/140');
+  });
+
+  it('applies the override for main-frame did-start-navigation only', async () => {
+    const createdHandler = await install([firefoxRule('x-com', 'x.com')]);
+    const contents = createContents();
+    createdHandler?.({}, contents);
+
+    const didStart = contents.on.mock.calls.find(
+      ([event]) => event === 'did-start-navigation',
+    )?.[1] as DidStartNavigationHandler;
+
+    didStart({}, 'https://x.com/i/subframe', false, false);
+    expect(contents.setUserAgent).not.toHaveBeenCalled();
+
+    didStart({}, 'https://x.com/home', false, true);
+    expect(contents.setUserAgent).toHaveBeenCalledWith(expect.stringContaining('Firefox/'));
+  });
+
+  it('keeps one saved original UA when a contents crosses between two host sets', async () => {
+    const createdHandler = await install([
+      firefoxRule('google', 'accounts.google.com'),
+      firefoxRule('x-com', 'x.com'),
+    ]);
+    const contents = createContents();
+    createdHandler?.({}, contents);
+
+    const willNavigate = contents.on.mock.calls.find(
+      ([event]) => event === 'will-navigate',
+    )?.[1] as NavHandler;
+
+    willNavigate({}, 'https://x.com/home');
+    willNavigate({}, 'https://accounts.google.com/signin');
+    // Different rule, different UA — the override must switch, not stick.
+    expect(contents.setUserAgent).toHaveBeenLastCalledWith(expect.stringContaining('(google)'));
+
+    // Leaving both restores the TRUE original captured on first entry.
+    willNavigate({}, 'https://example.com/');
+    expect(contents.setUserAgent).toHaveBeenLastCalledWith('SpoofedChrome/140');
+  });
+
+  it('registers a single header listener that dispatches by request host', async () => {
+    await install([
+      firefoxRule('google', 'accounts.google.com'),
+      firefoxRule('x-com', 'x.com'),
+    ]);
+
+    expect(electronMocks.onBeforeSendHeaders).toHaveBeenCalledOnce();
+    const [filter, listener] = electronMocks.onBeforeSendHeaders.mock.calls[0] as [
+      { urls: string[] },
+      (
+        details: { url: string; requestHeaders: Record<string, string> },
+        callback: (res: unknown) => void,
+      ) => void,
+    ];
+    expect(filter.urls).toEqual(
+      expect.arrayContaining(['https://accounts.google.com/*', 'https://x.com/*']),
+    );
+
+    const callback = vi.fn();
+    listener(
+      { url: 'https://x.com/home', requestHeaders: { 'User-Agent': 'x', 'Sec-CH-UA': '"Chromium";v="124"' } },
+      callback,
+    );
+    const response = callback.mock.calls[0]?.[0] as { requestHeaders: Record<string, string> };
+    expect(response.requestHeaders['User-Agent']).toContain('(x-com)');
+    expect(response.requestHeaders['Sec-CH-UA']).toBeUndefined();
+  });
+
+  it('passes headers through unchanged for a filtered request no rule claims', async () => {
+    await install([firefoxRule('x-com', 'x.com')]);
+    const [, listener] = electronMocks.onBeforeSendHeaders.mock.calls[0] as [
+      unknown,
+      (
+        details: { url: string; requestHeaders: Record<string, string> },
+        callback: (res: unknown) => void,
+      ) => void,
+    ];
+    const callback = vi.fn();
+    listener({ url: 'https://other.example/', requestHeaders: { A: 'b' } }, callback);
+    const response = callback.mock.calls[0]?.[0] as { requestHeaders: Record<string, string> };
+    expect(response.requestHeaders).toEqual({ A: 'b' });
+  });
+});
+
+describe('firefoxUserAgent', () => {
+  it('builds a platform-appropriate Firefox UA with no client-hint source', async () => {
+    const { firefoxUserAgent } = await import('../embedded-identity');
+    expect(firefoxUserAgent('140.0', 'darwin')).toContain('Macintosh');
+    expect(firefoxUserAgent('140.0', 'win32')).toContain('Windows NT 10.0');
+    expect(firefoxUserAgent('140.0', 'linux')).toContain('X11; Linux x86_64');
+    expect(firefoxUserAgent('140.0', 'linux')).toMatch(/Firefox\/140\.0$/);
+  });
+});

--- a/apps/canvas-workspace/src/main/app/__tests__/google-auth.test.ts
+++ b/apps/canvas-workspace/src/main/app/__tests__/google-auth.test.ts
@@ -1,51 +1,12 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const electronMocks = vi.hoisted(() => ({
-  appOn: vi.fn(),
-  onBeforeSendHeaders: vi.fn(),
-}));
-
+// google-auth imports the shared coordinator, which imports electron. These
+// tests only exercise pure helpers/rules, so a bare mock keeps resolution
+// deterministic outside the Electron runtime.
 vi.mock('electron', () => ({
-  app: {
-    on: electronMocks.appOn,
-  },
-  session: {
-    defaultSession: {
-      webRequest: {
-        onBeforeSendHeaders: electronMocks.onBeforeSendHeaders,
-      },
-    },
-  },
+  app: { on: vi.fn() },
+  session: { defaultSession: { webRequest: { onBeforeSendHeaders: vi.fn() } } },
 }));
-
-type WillNavigateHandler = (event: unknown, url: string) => void;
-type DidStartNavigationHandler = (
-  event: unknown,
-  url: string,
-  isInPage: boolean,
-  isMainFrame: boolean,
-) => void;
-
-function createContents(userAgent = 'SpoofedChrome/140') {
-  let currentUserAgent = userAgent;
-  return {
-    on: vi.fn(),
-    getUserAgent: vi.fn(() => currentUserAgent),
-    setUserAgent: vi.fn((next: string) => {
-      currentUserAgent = next;
-    }),
-  };
-}
-
-async function installCompat() {
-  const { setupGoogleAuthCompat } = await import('../google-auth');
-  setupGoogleAuthCompat();
-  const createdHandler = electronMocks.appOn.mock.calls.find(
-    ([event]) => event === 'web-contents-created',
-  )?.[1];
-  if (typeof createdHandler !== 'function') throw new Error('web-contents-created handler not registered');
-  return createdHandler as (_event: unknown, contents: ReturnType<typeof createContents>) => void;
-}
 
 describe('isGoogleAuthUrl', () => {
   it('matches only the exact Google auth hosts over https', async () => {
@@ -89,82 +50,28 @@ describe('googleAuthUserAgent', () => {
   });
 });
 
-describe('setupGoogleAuthCompat', () => {
-  beforeEach(() => {
-    vi.resetModules();
-    electronMocks.appOn.mockReset();
-    electronMocks.onBeforeSendHeaders.mockReset();
+describe('googleAuthIdentityRule', () => {
+  afterEach(() => {
     delete process.env.PULSE_GOOGLE_AUTH_IDENTITY;
   });
 
-  it('installs nothing in chrome identity mode (honest-identity A/B arm)', async () => {
+  it('describes a Firefox identity scoped to the Google auth hosts', async () => {
+    const { googleAuthIdentityRule } = await import('../google-auth');
+    const rule = googleAuthIdentityRule();
+    expect(rule).not.toBeNull();
+    expect(rule?.userAgent).toContain('Firefox/');
+    expect(rule?.matches('https://accounts.google.com/signin')).toBe(true);
+    expect(rule?.matches('https://x.com/home')).toBe(false);
+    expect(rule?.headerUrls).toContain('https://accounts.google.com/*');
+    // The rewrite pins the same Firefox UA presented per-contents.
+    const rewritten = rule?.rewriteHeaders({ 'Sec-CH-UA': '"Chromium";v="124"' });
+    expect(rewritten?.['User-Agent']).toContain('Firefox/');
+    expect(rewritten?.['Sec-CH-UA']).toBeUndefined();
+  });
+
+  it('returns null for the chrome identity A/B arm (installs no override)', async () => {
     process.env.PULSE_GOOGLE_AUTH_IDENTITY = 'chrome';
-    try {
-      const { setupGoogleAuthCompat } = await import('../google-auth');
-      setupGoogleAuthCompat();
-      expect(electronMocks.appOn).not.toHaveBeenCalled();
-      expect(electronMocks.onBeforeSendHeaders).not.toHaveBeenCalled();
-    } finally {
-      delete process.env.PULSE_GOOGLE_AUTH_IDENTITY;
-    }
-  });
-
-  it('switches to a Firefox UA on Google auth hosts and restores it after leaving', async () => {
-    const createdHandler = await installCompat();
-    const contents = createContents();
-    createdHandler({}, contents);
-
-    const willNavigate = contents.on.mock.calls.find(
-      ([event]) => event === 'will-navigate',
-    )?.[1] as WillNavigateHandler;
-
-    willNavigate({}, 'https://accounts.google.com/signin/v2/identifier');
-    expect(contents.setUserAgent).toHaveBeenLastCalledWith(
-      expect.stringContaining('Firefox/'),
-    );
-
-    // Same-host navigation must not re-save the (already overridden) UA.
-    willNavigate({}, 'https://accounts.google.com/signin/challenge');
-    expect(contents.setUserAgent).toHaveBeenCalledTimes(1);
-
-    // Leaving Google restores the original UA, not the Firefox one.
-    willNavigate({}, 'https://www.notion.so/googlelogin?code=abc');
-    expect(contents.setUserAgent).toHaveBeenLastCalledWith('SpoofedChrome/140');
-  });
-
-  it('applies the override for main-frame did-start-navigation only', async () => {
-    const createdHandler = await installCompat();
-    const contents = createContents();
-    createdHandler({}, contents);
-
-    const didStartNavigation = contents.on.mock.calls.find(
-      ([event]) => event === 'did-start-navigation',
-    )?.[1] as DidStartNavigationHandler;
-
-    didStartNavigation({}, 'https://accounts.google.com/embedded/frame', false, false);
-    expect(contents.setUserAgent).not.toHaveBeenCalled();
-
-    didStartNavigation({}, 'https://accounts.google.com/signin', false, true);
-    expect(contents.setUserAgent).toHaveBeenCalledWith(expect.stringContaining('Firefox/'));
-  });
-
-  it('registers a header rewrite scoped to Google auth hosts', async () => {
-    await installCompat();
-
-    expect(electronMocks.onBeforeSendHeaders).toHaveBeenCalledOnce();
-    const [filter, listener] = electronMocks.onBeforeSendHeaders.mock.calls[0] as [
-      { urls: string[] },
-      (details: { requestHeaders: Record<string, string> }, callback: (res: unknown) => void) => void,
-    ];
-    expect(filter.urls).toContain('https://accounts.google.com/*');
-
-    const callback = vi.fn();
-    listener(
-      { requestHeaders: { 'User-Agent': 'x', 'Sec-CH-UA': '"Chromium";v="124"' } },
-      callback,
-    );
-    const response = callback.mock.calls[0]?.[0] as { requestHeaders: Record<string, string> };
-    expect(response.requestHeaders['User-Agent']).toContain('Firefox/');
-    expect(response.requestHeaders['Sec-CH-UA']).toBeUndefined();
+    const { googleAuthIdentityRule } = await import('../google-auth');
+    expect(googleAuthIdentityRule()).toBeNull();
   });
 });

--- a/apps/canvas-workspace/src/main/app/__tests__/x-com-compat.test.ts
+++ b/apps/canvas-workspace/src/main/app/__tests__/x-com-compat.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// x-com-compat imports the shared coordinator, which imports electron.
+vi.mock('electron', () => ({
+  app: { on: vi.fn() },
+  session: { defaultSession: { webRequest: { onBeforeSendHeaders: vi.fn() } } },
+}));
+
+describe('isXComUrl', () => {
+  it('matches x.com and twitter.com surfaces over https, including subdomains', async () => {
+    const { isXComUrl } = await import('../x-com-compat');
+    expect(isXComUrl('https://x.com/home')).toBe(true);
+    expect(isXComUrl('https://www.x.com/')).toBe(true);
+    expect(isXComUrl('https://api.x.com/1.1/foo.json')).toBe(true);
+    expect(isXComUrl('https://mobile.x.com/')).toBe(true);
+    expect(isXComUrl('https://twitter.com/home')).toBe(true);
+    expect(isXComUrl('https://api.twitter.com/graphql')).toBe(true);
+  });
+
+  it('rejects non-x.com hosts, lookalikes, and non-https', async () => {
+    const { isXComUrl } = await import('../x-com-compat');
+    // Suffix boundary: a host merely ending in the literal string must not pass.
+    expect(isXComUrl('https://x.com.evil.example/')).toBe(false);
+    expect(isXComUrl('https://notx.com/')).toBe(false);
+    expect(isXComUrl('https://xtwitter.com/')).toBe(false);
+    expect(isXComUrl('http://x.com/home')).toBe(false);
+    expect(isXComUrl('https://example.com/')).toBe(false);
+    expect(isXComUrl('not a url')).toBe(false);
+  });
+});
+
+describe('rewriteXComHeaders', () => {
+  it('pins a Firefox UA and strips client-hint headers', async () => {
+    const { rewriteXComHeaders } = await import('../x-com-compat');
+    const rewritten = rewriteXComHeaders({
+      'user-agent': 'Mozilla/5.0 Chrome/140.0.0.0',
+      'Sec-CH-UA': '"Chromium";v="124"',
+      'sec-ch-ua-mobile': '?0',
+      Accept: 'text/html',
+    });
+    expect(rewritten['User-Agent']).toMatch(/Gecko\/20100101 Firefox\/\d+/);
+    expect(rewritten['User-Agent']).not.toContain('Chrome');
+    expect(rewritten.Accept).toBe('text/html');
+    expect(Object.keys(rewritten).some((k) => k.toLowerCase().startsWith('sec-ch-'))).toBe(false);
+    expect(Object.keys(rewritten).filter((k) => k.toLowerCase() === 'user-agent')).toEqual(['User-Agent']);
+  });
+});
+
+describe('xComIdentityRule', () => {
+  it('describes a Firefox identity scoped to x.com/twitter.com hosts', async () => {
+    const { xComIdentityRule } = await import('../x-com-compat');
+    const rule = xComIdentityRule();
+    expect(rule.id).toBe('x-com');
+    expect(rule.userAgent).toContain('Firefox/');
+    expect(rule.matches('https://x.com/home')).toBe(true);
+    expect(rule.matches('https://accounts.google.com/signin')).toBe(false);
+    expect(rule.headerUrls).toEqual(
+      expect.arrayContaining([
+        'https://x.com/*',
+        'https://*.x.com/*',
+        'https://twitter.com/*',
+        'https://*.twitter.com/*',
+      ]),
+    );
+  });
+});

--- a/apps/canvas-workspace/src/main/app/bootstrap.ts
+++ b/apps/canvas-workspace/src/main/app/bootstrap.ts
@@ -74,7 +74,12 @@ import { startLoopDelaySampler } from "../perf/loop-delay";
 import { createWindow } from "./window";
 import { setWindowFactory } from "./window-manager";
 import { setupLinkPolicy } from "./link-policy";
-import { setupGoogleAuthCompat } from "./google-auth";
+import { googleAuthIdentityRule } from "./google-auth";
+import { xComIdentityRule } from "./x-com-compat";
+import {
+  setupEmbeddedIdentity,
+  type EmbeddedIdentityRule,
+} from "./embedded-identity";
 import { setupDeepLinkEarly } from "../default-browser/deep-link";
 import { setupDefaultBrowserIpc } from "../default-browser/ipc";
 
@@ -115,7 +120,11 @@ export function bootstrap({ mainDir }: BootstrapOptions): void {
     startupMark("whenReady");
     startLoopDelaySampler(writeLog);
     spoofUserAgentFallback();
-    setupGoogleAuthCompat();
+    setupEmbeddedIdentity(
+      [googleAuthIdentityRule(), xComIdentityRule()].filter(
+        (rule): rule is EmbeddedIdentityRule => rule !== null
+      )
+    );
     registerPulseCanvasProtocol(writeLog);
     configureAppChrome(paths.iconPath, writeLog);
     // Must run before the window opens: the default menu's Undo/Redo

--- a/apps/canvas-workspace/src/main/app/embedded-identity.ts
+++ b/apps/canvas-workspace/src/main/app/embedded-identity.ts
@@ -1,0 +1,142 @@
+import { app, session, type Session, type WebContents } from "electron";
+
+// Host-scoped browser identity for embedded browsing surfaces (<webview>
+// guests and OAuth popups).
+//
+// bootstrap.ts rewrites the app-wide UA string to a current Chrome
+// (Chrome/140, Electron/product tokens stripped) so services that gate on the
+// UA string alone accept the embedded browser. That rewrite is NOT enough for
+// sites that cross-check the UA string against UA Client Hints (the
+// `Sec-CH-UA*` request headers) or `navigator.userAgentData`: Chromium still
+// derives those from the REAL bundled version, so the claimed Chrome/140 and
+// the emitted client hints disagree. accounts.google.com rejects the mismatch
+// at sign-in; x.com's SPA trips its runtime guard and renders its
+// "Something went wrong" error boundary.
+//
+// The remedy, per host, is a CONSISTENT identity. A Firefox UA emits no client
+// hints, so there is no second identity source to cross-check. Two cooperating
+// layers, both wired here:
+//   1. A per-webContents UA override while a contents is on a matching host —
+//      what page JS sees; an active override also stops client-hint emission
+//      for that contents, so its subresource/API requests stay consistent too.
+//   2. A session-level request-header rewrite for those hosts — pins the wire
+//      UA even for requests created before the per-contents override landed,
+//      and strips residual `Sec-CH-*`.
+//
+// Electron permits exactly ONE onBeforeSendHeaders listener per session, and a
+// single per-contents override manager avoids two managers clobbering each
+// other's saved "original" UA on a contents that crosses between host sets. So
+// EVERY host identity (Google auth, x.com) is wired through this one
+// coordinator rather than registering its own listeners.
+
+export interface EmbeddedIdentityRule {
+  // Stable id, for diagnostics only.
+  id: string;
+  // True for URLs this identity should apply to.
+  matches(url: string): boolean;
+  // UA string presented on matching hosts (page JS + wire).
+  userAgent: string;
+  // webRequest URL match patterns for the session header rewrite. Empty skips
+  // the header layer for this rule (per-contents override only).
+  headerUrls: string[];
+  // Rewrites request headers for matching hosts (strip client hints, pin UA).
+  rewriteHeaders(headers: Record<string, string>): Record<string, string>;
+}
+
+// Build a platform-appropriate Firefox UA. Firefox sends no UA Client Hints,
+// which is the whole point of claiming it — see the module header.
+export function firefoxUserAgent(
+  version: string,
+  platform: NodeJS.Platform = process.platform
+): string {
+  const platformToken =
+    platform === "darwin"
+      ? "Macintosh; Intel Mac OS X 10.15"
+      : platform === "win32"
+        ? "Windows NT 10.0; Win64; x64"
+        : "X11; Linux x86_64";
+  return `Mozilla/5.0 (${platformToken}; rv:${version}) Gecko/20100101 Firefox/${version}`;
+}
+
+// Drop every `Sec-CH-*` client-hint header and the incoming UA, then pin the
+// given UA. Shared by all Firefox-identity rules so the wire identity matches
+// the per-contents override exactly.
+export function stripClientHintsPinUserAgent(
+  requestHeaders: Record<string, string>,
+  userAgent: string
+): Record<string, string> {
+  const rewritten: Record<string, string> = {};
+  for (const [name, value] of Object.entries(requestHeaders)) {
+    const lower = name.toLowerCase();
+    if (lower.startsWith("sec-ch-") || lower === "user-agent") continue;
+    rewritten[name] = value;
+  }
+  rewritten["User-Agent"] = userAgent;
+  return rewritten;
+}
+
+// Must run after app-ready (needs the target session's webRequest). bootstrap
+// calls it from whenReady, before the first window opens.
+export function setupEmbeddedIdentity(
+  rules: EmbeddedIdentityRule[],
+  targetSession: Session = session.defaultSession
+): void {
+  if (rules.length === 0) return;
+
+  // Per-webContents UA override — one manager, one WeakMap, so a contents that
+  // crosses between host sets never has two managers fighting over its saved
+  // original UA.
+  const savedUserAgent = new WeakMap<WebContents, string>();
+
+  app.on("web-contents-created", (_event, contents) => {
+    const applyForUrl = (url: string) => {
+      const rule = rules.find((candidate) => candidate.matches(url));
+      if (rule) {
+        if (!savedUserAgent.has(contents)) {
+          savedUserAgent.set(contents, contents.getUserAgent());
+        }
+        // Set only when the identity actually changes so repeat same-host
+        // navigations don't churn the UA.
+        if (contents.getUserAgent() !== rule.userAgent) {
+          contents.setUserAgent(rule.userAgent);
+        }
+      } else if (savedUserAgent.has(contents)) {
+        const original = savedUserAgent.get(contents);
+        savedUserAgent.delete(contents);
+        if (typeof original === "string") contents.setUserAgent(original);
+      }
+    };
+
+    // will-navigate covers renderer-initiated navigations before the request
+    // leaves; did-start-navigation additionally covers loadURL / a webview's
+    // initial src load and popups. Server-side redirect hops keep whatever UA
+    // the leg started with, which is correct for an OAuth continuation.
+    contents.on("will-navigate", (_navEvent, url) => applyForUrl(url));
+    contents.on(
+      "did-start-navigation",
+      (_navEvent, url, _isInPage, isMainFrame) => {
+        if (isMainFrame) applyForUrl(url);
+      }
+    );
+  });
+
+  // Single session-level request-header rewrite. Electron allows exactly one
+  // onBeforeSendHeaders listener per session; this is the sole registrant on
+  // the target session, dispatching to whichever rule owns the request host.
+  const headerRules = rules.filter((rule) => rule.headerUrls.length > 0);
+  if (headerRules.length === 0) return;
+
+  targetSession.webRequest.onBeforeSendHeaders(
+    { urls: headerRules.flatMap((rule) => rule.headerUrls) },
+    (details, callback) => {
+      const rule = headerRules.find((candidate) =>
+        candidate.matches(details.url)
+      );
+      callback({
+        requestHeaders: rule
+          ? rule.rewriteHeaders(details.requestHeaders)
+          : details.requestHeaders,
+      });
+    }
+  );
+}

--- a/apps/canvas-workspace/src/main/app/google-auth.ts
+++ b/apps/canvas-workspace/src/main/app/google-auth.ts
@@ -1,6 +1,15 @@
-import { app, session } from "electron";
+import {
+  firefoxUserAgent,
+  stripClientHintsPinUserAgent,
+  type EmbeddedIdentityRule,
+} from "./embedded-identity";
 
 // Google sign-in compatibility for embedded browsing surfaces.
+//
+// The per-webContents UA override and the session header rewrite are wired
+// through the shared coordinator in embedded-identity.ts (which owns the
+// single per-session onBeforeSendHeaders listener); this module contributes
+// the Google-auth-host rule and keeps the host allowlist and evidence log.
 //
 // The identity presented on Google's auth hosts is selectable via
 // PULSE_GOOGLE_AUTH_IDENTITY:
@@ -84,26 +93,13 @@ export function isGoogleAuthUrl(raw: string): boolean {
 export function googleAuthUserAgent(
   platform: NodeJS.Platform = process.platform
 ): string {
-  const platformToken =
-    platform === "darwin"
-      ? "Macintosh; Intel Mac OS X 10.15"
-      : platform === "win32"
-        ? "Windows NT 10.0; Win64; x64"
-        : "X11; Linux x86_64";
-  return `Mozilla/5.0 (${platformToken}; rv:${FIREFOX_VERSION}) Gecko/20100101 Firefox/${FIREFOX_VERSION}`;
+  return firefoxUserAgent(FIREFOX_VERSION, platform);
 }
 
 export function rewriteGoogleAuthHeaders(
   requestHeaders: Record<string, string>
 ): Record<string, string> {
-  const rewritten: Record<string, string> = {};
-  for (const [name, value] of Object.entries(requestHeaders)) {
-    const lower = name.toLowerCase();
-    if (lower.startsWith("sec-ch-") || lower === "user-agent") continue;
-    rewritten[name] = value;
-  }
-  rewritten["User-Agent"] = googleAuthUserAgent();
-  return rewritten;
+  return stripClientHintsPinUserAgent(requestHeaders, googleAuthUserAgent());
 }
 
 export function googleAuthIdentityMode(): "firefox" | "chrome" {
@@ -112,56 +108,20 @@ export function googleAuthIdentityMode(): "firefox" | "chrome" {
     : "firefox";
 }
 
-// Must run after app-ready (needs defaultSession); bootstrap calls it from
-// whenReady, before the first window opens.
-export function setupGoogleAuthCompat(): void {
-  if (googleAuthIdentityMode() === "chrome") return;
-
-  const originalUserAgents = new WeakMap<object, string>();
-
-  app.on("web-contents-created", (_event, contents) => {
-    const applyUserAgentForUrl = (url: string) => {
-      if (isGoogleAuthUrl(url)) {
-        if (!originalUserAgents.has(contents)) {
-          originalUserAgents.set(contents, contents.getUserAgent());
-          contents.setUserAgent(googleAuthUserAgent());
-        }
-      } else if (originalUserAgents.has(contents)) {
-        const original = originalUserAgents.get(contents);
-        originalUserAgents.delete(contents);
-        if (typeof original === "string") contents.setUserAgent(original);
-      }
-    };
-
-    // will-navigate covers renderer-initiated navigations before the request
-    // leaves; did-start-navigation additionally covers loadURL/popup initial
-    // loads. Server-side redirect hops keep whatever UA the leg started with,
-    // which is the correct behaviour for an OAuth continuation.
-    contents.on("will-navigate", (_navEvent, url) => {
-      applyUserAgentForUrl(url);
-    });
-    contents.on(
-      "did-start-navigation",
-      (_navEvent, url, _isInPage, isMainFrame) => {
-        if (isMainFrame) applyUserAgentForUrl(url);
-      }
-    );
-  });
-
-  // NOTE: Electron allows exactly ONE onBeforeSendHeaders listener per
-  // session — this is currently the sole registrant on defaultSession. If a
-  // second consumer ever needs request-header access, centralize both here.
-  session.defaultSession.webRequest.onBeforeSendHeaders(
-    {
-      urls: [
-        "https://accounts.google.com/*",
-        "https://accounts.youtube.com/*",
-      ],
-    },
-    (details, callback) => {
-      callback({
-        requestHeaders: rewriteGoogleAuthHeaders(details.requestHeaders),
-      });
-    }
-  );
+// The Google-auth-host identity rule, contributed to the shared coordinator
+// (embedded-identity.ts) from bootstrap's whenReady. Returns null for the
+// "chrome" identity A/B arm, which installs no override at all (known-broken
+// on Electron 30 — see the evidence log above).
+export function googleAuthIdentityRule(): EmbeddedIdentityRule | null {
+  if (googleAuthIdentityMode() === "chrome") return null;
+  return {
+    id: "google-auth",
+    matches: isGoogleAuthUrl,
+    userAgent: googleAuthUserAgent(),
+    headerUrls: [
+      "https://accounts.google.com/*",
+      "https://accounts.youtube.com/*",
+    ],
+    rewriteHeaders: rewriteGoogleAuthHeaders,
+  };
 }

--- a/apps/canvas-workspace/src/main/app/x-com-compat.ts
+++ b/apps/canvas-workspace/src/main/app/x-com-compat.ts
@@ -1,0 +1,72 @@
+import {
+  firefoxUserAgent,
+  stripClientHintsPinUserAgent,
+  type EmbeddedIdentityRule,
+} from "./embedded-identity";
+
+// x.com (Twitter) compatibility for embedded browsing surfaces.
+//
+// Opening x.com in a webview tab renders x.com's "Something went wrong, but
+// don't fret" error boundary instead of the timeline. Root cause is the same
+// UA-vs-client-hint mismatch documented in embedded-identity.ts and
+// google-auth.ts: bootstrap.ts spoofs the UA string to Chrome/140 while
+// Chromium keeps emitting UA Client Hints (and `navigator.userAgentData`) from
+// the real bundled version, and x.com's SPA cross-checks them and throws
+// during init. The "Some privacy related extensions may cause issues" line is
+// x.com's generic init-failure copy, not an actual extension problem — there
+// are no extensions in this Electron shell.
+//
+// Remedy mirrors the Google auth hosts: present a consistent Firefox identity
+// on x.com hosts. Firefox emits no client hints, so there is no second
+// identity source to mismatch, and x.com fully supports the Firefox code path.
+// Wired through the shared embedded-identity coordinator so the one-per-session
+// header listener and the per-contents UA manager stay centralized.
+
+// Domain suffixes covering x.com / twitter.com surfaces: the main app, api.*
+// and mobile.* subdomains, and the twitter.com aliases that redirect to x.com.
+// Unlike the Google auth allowlist, this identity swap does NOT loosen
+// navigation policy, so suffix matching is safe here.
+const X_COM_DOMAINS = ["x.com", "twitter.com"];
+
+// Firefox ESR major, matched to google-auth.ts so both hosts present the same
+// believable, above-floor browser version.
+const FIREFOX_VERSION = "140.0";
+
+export function isXComUrl(raw: string): boolean {
+  try {
+    const { protocol, hostname } = new URL(raw);
+    if (protocol !== "https:") return false;
+    return X_COM_DOMAINS.some(
+      (domain) => hostname === domain || hostname.endsWith(`.${domain}`)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function xComUserAgent(
+  platform: NodeJS.Platform = process.platform
+): string {
+  return firefoxUserAgent(FIREFOX_VERSION, platform);
+}
+
+export function rewriteXComHeaders(
+  requestHeaders: Record<string, string>
+): Record<string, string> {
+  return stripClientHintsPinUserAgent(requestHeaders, xComUserAgent());
+}
+
+export function xComIdentityRule(): EmbeddedIdentityRule {
+  return {
+    id: "x-com",
+    matches: isXComUrl,
+    userAgent: xComUserAgent(),
+    headerUrls: [
+      "https://x.com/*",
+      "https://*.x.com/*",
+      "https://twitter.com/*",
+      "https://*.twitter.com/*",
+    ],
+    rewriteHeaders: rewriteXComHeaders,
+  };
+}


### PR DESCRIPTION
## Problem

Opening x.com in a webview tab renders x.com's **"Something went wrong, but don't fret"** error boundary instead of the timeline (the red "some privacy related extensions may cause issues" line is x.com's generic init-failure copy — there are no extensions in this Electron shell).

Root cause is the same **UA-vs-client-hint mismatch** already diagnosed for Google sign-in:

- `bootstrap.ts` spoofs the app-wide UA string to `Chrome/140` (so services gating on the UA string alone accept the embedded browser).
- Chromium still emits UA Client Hints (`Sec-CH-UA*`) and `navigator.userAgentData` from the **real** bundled version.
- x.com's SPA cross-checks the UA string against the client hints and throws during init → error boundary.

## Fix

Present a **consistent Firefox identity** on `x.com` / `twitter.com` hosts. Firefox emits no UA Client Hints, so there is no second identity source to mismatch, and x.com fully supports the Firefox code path. This mirrors the proven Google-auth remedy.

Because Electron permits **only one `onBeforeSendHeaders` listener per session**, and two independent per-`webContents` UA managers would clobber each other's saved original UA, the Google-auth wiring is generalized into a shared **`embedded-identity`** coordinator that owns:

- the single per-session request-header rewrite listener, and
- one per-`webContents` UA-override manager (single saved-original map),

driven by a list of `EmbeddedIdentityRule`s. Google and x.com each contribute a rule. **Google behavior is unchanged.**

## Changes

- **Add** `src/main/app/embedded-identity.ts` — coordinator + shared Firefox-UA / client-hint-stripping helpers.
- **Add** `src/main/app/x-com-compat.ts` — x.com/twitter.com Firefox identity rule (suffix-match; does not loosen navigation policy).
- **Refactor** `src/main/app/google-auth.ts` — contributes `googleAuthIdentityRule` instead of owning session/web-contents wiring; pure helpers and the evidence log are preserved; the `chrome` A/B arm returns a null rule.
- **Wire** both rules through `setupEmbeddedIdentity` in `bootstrap.ts`.
- **Tests**: move wiring tests to `embedded-identity.test.ts` (incl. a "contents crossing between host sets doesn't clobber the restore UA" regression); add `x-com-compat.test.ts`; keep google-auth pure-helper/rule tests.
- **Docs**: `harness/knowledge/security-posture.md` updated to describe the centralized mechanism and x.com.

## Verification

- `pnpm --filter canvas-workspace typecheck` ✓
- Relevant tests 37 passed (identity modules + `import-boundaries` + `file-size-governance`) ✓
- `node scripts/harness/run-harness-check.mjs --path <changed files>` → 3/3 passed ✓

**Note:** the Electron binary download is policy-blocked in the CI/web environment, so this could not be exercised end-to-end against live x.com in the real app. The fix targets the already-confirmed root-cause class (UA/client-hint inconsistency) with the codebase's already-proven Firefox compensation, covered by unit tests for UA override/restore, header rewrite, and cross-host non-clobbering. If any x.com login sub-domains still need coverage, they can be added to the rule's host set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMosRiS2tLRobr5Liz7Mgi

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMosRiS2tLRobr5Liz7Mgi)_