### PR TITLE
fix(canvas-workspace): align component style with frontend.md conventions

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEmptyHint/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEmptyHint/index.tsx
@@ -6,7 +6,7 @@ import { useI18n } from '../../i18n';
 import { normalizeReferenceUrl } from '../ReferenceDrawer/utils';
 import './index.css';
 
-interface CanvasEmptyHintProps {
+interface Props {
   onCreateNode: (type: Extract<CanvasNode['type'], 'agent' | 'terminal' | 'file' | 'iframe'>) => void;
   onCreateUrl?: (url: string) => void;
   onCreateDemo?: () => void;
@@ -24,7 +24,7 @@ export const CanvasEmptyHint = ({
   onOpenChat,
   onOpenShortcuts,
   onSetRootFolder,
-}: CanvasEmptyHintProps) => {
+}: Props) => {
   const { t } = useI18n();
   const [urlComposerOpen, setUrlComposerOpen] = useState(false);
   const [urlDraft, setUrlDraft] = useState('');

--- a/apps/canvas-workspace/src/renderer/src/components/ChatFloatingButton/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ChatFloatingButton/index.tsx
@@ -1,7 +1,7 @@
 import './index.css';
 import { AppLogoIcon } from '../icons';
 
-interface ChatFloatingButtonProps {
+interface Props {
   active?: boolean;
   title: string;
   ariaLabel?: string;
@@ -15,7 +15,7 @@ export const ChatFloatingButton = ({
   ariaLabel,
   className,
   onClick,
-}: ChatFloatingButtonProps) => (
+}: Props) => (
   <button
     type="button"
     className={[

--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;

--- a/apps/canvas-workspace/src/renderer/src/components/PluginNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/PluginNodeBody/index.tsx
@@ -7,7 +7,7 @@ import {
 } from '../../../../plugins/renderer';
 import './index.css';
 
-interface PluginNodeBodyProps {
+interface Props {
   node: CanvasNode;
   workspaceId?: string;
   workspaceName?: string;
@@ -44,7 +44,7 @@ export const PluginNodeBody = ({
   isSelected,
   onUpdate,
   readOnly,
-}: PluginNodeBodyProps) => {
+}: Props) => {
   useSyncExternalStore(
     subscribeRendererPluginRegistry,
     getRendererPluginRegistryVersion,

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/index.tsx
@@ -59,7 +59,7 @@ function clampWidth(value: number): number {
   return Math.min(max, Math.max(MIN_WIDTH, value));
 }
 
-interface RightDockProps {
+interface Props {
   activeWorkspaceId: string;
   chatTabEnabled: boolean;
   workspaces: WorkspaceEntry[];
@@ -72,7 +72,7 @@ interface TabIndicatorState {
   visible: boolean;
 }
 
-export const RightDock = ({ activeWorkspaceId, chatTabEnabled, workspaces, onOpenNodePage }: RightDockProps) => {
+export const RightDock = ({ activeWorkspaceId, chatTabEnabled, workspaces, onOpenNodePage }: Props) => {
   const { store, setChatHost, setTerminalHost, pinUrlReference } = useDockContext();
   const state = useRightDockState();
   const { t } = useI18n();

--- a/apps/canvas-workspace/src/renderer/src/components/SelectionToolbar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/SelectionToolbar/index.tsx
@@ -2,7 +2,7 @@ import './index.css';
 import { useI18n } from '../../i18n';
 import type { KeyboardEvent } from 'react';
 
-interface SelectionToolbarProps {
+interface Props {
   selectedCount: number;
   canFocus: boolean;
   focusModeActive: boolean;
@@ -127,7 +127,7 @@ export const SelectionToolbar = ({
   onPinReference,
   onAddToChat,
   onDelete,
-}: SelectionToolbarProps) => {
+}: Props) => {
   const { t } = useI18n();
   if (selectedCount <= 0) return null;
 

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
@@ -26,7 +26,7 @@ export type { WorkbenchController } from './useWorkbenchState';
 const EMPTY_REFERENCES: ReferenceEntry[] = [];
 const ReferenceDrawer = lazy(() => import('../ReferenceDrawer').then((m) => ({ default: m.ReferenceDrawer })));
 const KnowledgeChatPortal = lazy(() => import('./KnowledgeChatPortal').then((m) => ({ default: m.KnowledgeChatPortal })));
-interface WorkbenchProps {
+interface Props {
   activeWorkspaceId: string;
   workspaces: WorkspaceEntry[];
   controller: WorkbenchController;
@@ -39,7 +39,7 @@ interface WorkbenchProps {
   onOpenWorkspaceSettings: (workspaceId: string) => void;
   onSetActiveRootFolder: () => void;
 }
-export const Workbench: React.FC<WorkbenchProps> = ({
+export const Workbench: React.FC<Props> = ({
   activeWorkspaceId,
   workspaces,
   controller,

--- a/apps/canvas-workspace/src/renderer/src/components/WorkspaceTerminalDock/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/WorkspaceTerminalDock/index.tsx
@@ -24,7 +24,7 @@ import {
 import { scheduleBootOverlayDismiss } from './boot-overlay';
 import './index.css';
 
-interface WorkspaceTerminalDockProps {
+interface Props {
   workspaceId: string;
   terminalId?: string;
   terminalTitle?: string;
@@ -80,7 +80,7 @@ export const WorkspaceTerminalDock = ({
   onClose,
   onAgentTypeChange,
   placement = 'bottom',
-}: WorkspaceTerminalDockProps) => {
+}: Props) => {
   const { t } = useI18n();
   const [height, setHeight] = useState(() => clampHeight(readStoredHeight() ?? DEFAULT_HEIGHT));
   const heightRef = useRef(height);


### PR DESCRIPTION
## Summary

Scanned `apps/canvas-workspace` for UI/component style inconsistencies. The app already has a mature, mechanized ratchet (`src/main/__tests__/ui-reuse-governance.test.ts`) covering raw `<button>`/`<input>`/`<textarea>` tags, hardcoded CSS literals (radius/color/shadow/z-index), bespoke overlay/dropdown shapes, and hand-rolled keydown listeners — I confirmed it currently passes exactly (all 18 sub-checks match baseline), so there is no drift in anything that test measures.

This PR fixes two **ungated** conventions from `harness/knowledge/conventions/frontend.md` that had silently drifted, since nothing mechanically enforces them:

- **Dead default export**: `MigrationSpinner/index.tsx` exported both `export const MigrationSpinner = ...` and a trailing `export default MigrationSpinner`. Its sole consumer (`App.tsx`) lazy-loads it via `import('./components/MigrationSpinner').then((m) => ({ default: m.MigrationSpinner }))` — i.e. it remaps the *named* export, so the file's own default export was genuinely unused. Removed it (docs: "avoid `default` exports for components").
- **Props interface naming**: frontend.md says "Name the props interface **`Props`** (local)." Seven single-component `index.tsx` files used `<Component>Props` instead: `Workbench`, `RightDock`, `WorkspaceTerminalDock`, `ChatFloatingButton`, `SelectionToolbar`, `PluginNodeBody`, `CanvasEmptyHint`. Renamed each to `Props` after verifying the interface is purely file-local (no external imports/re-exports referenced it).

### Also investigated, not fixed in this PR

A deeper sweep for hardcoded user-facing strings bypassing `useI18n()` (also an explicit, ungated frontend.md rule) turned up real drift across ~15 components (`ChannelConfigPanel`, `NodeButtons`, `FileNodeBubbleMenu`, `NoteFindBar`, `AgentTeamFrame`, `ChatMessage`, and others) — dozens of hardcoded `title`/`aria-label`/`placeholder`/button-text strings with no i18n import at all in several files. That's a larger, translation-sensitive change (needs new keys in both locales in `i18n/messages.ts`) that deserves its own focused PR with human review of the translations rather than being bundled into this mechanical cleanup. Happy to follow up if wanted.

## Why this improves consistency

Both fixes make the affected files match the documented, established pattern used by the other ~40 components in the same directories, removing dead code and reducing the "which name did this file pick" cognitive tax when reading across components.

## Test plan

- [x] `pnpm --filter canvas-workspace typecheck` — passes
- [x] `pnpm --filter canvas-workspace test` — 189 files / 1328 tests pass, including `ui-reuse-governance.test.ts` (ratchet counters unchanged — this PR touches nothing it measures)
- [x] Verified each renamed `Props` interface has no external references (`grep` across `src/`) before renaming
- [x] Traced `MigrationSpinner`'s sole consumer to confirm the removed `export default` was truly dead

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzvcPPe9VHfZ6UJfNEWQYJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzvcPPe9VHfZ6UJfNEWQYJ)_