### PR TITLE
fix(canvas): avoid reloading guest-driven navigation

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/EmbeddedBrowser/useEmbeddedBrowser.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/EmbeddedBrowser/useEmbeddedBrowser.test.tsx
@@ -2,7 +2,7 @@
 import { flushSync } from 'react-dom';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { useState } from 'react';
+import { useSyncExternalStore } from 'react';
 import { useEmbeddedBrowser } from './useEmbeddedBrowser';
 import type { EmbeddedWebviewTag } from './types';
 
@@ -69,18 +69,56 @@ describe('useEmbeddedBrowser', () => {
     expect(onTitleChange).toHaveBeenCalledWith('Example page');
   });
 
-  it('does not reload a guest when the parent persists a URL reported by did-navigate', () => {
+  it('does not reload a guest when an external store synchronously persists did-navigate', () => {
+    const store = createUrlStore('https://example.com');
     mount = document.createElement('div');
     document.body.appendChild(mount);
     root = createRoot(mount);
-    flushSync(() => root?.render(<ControlledHarness />));
+    flushSync(() => root?.render(<ExternalStoreHarness store={store} />));
 
     const setAttribute = vi.spyOn(webview, 'setAttribute');
-    const event = new Event('did-navigate') as Event & { url: string };
+    const event = new Event('did-navigate-in-page') as Event & { url: string };
     event.url = 'https://example.com/next';
-    flushSync(() => webview.dispatchEvent(event));
+    webview.dispatchEvent(event);
 
     expect(setAttribute).not.toHaveBeenCalledWith('src', 'https://example.com/next');
+  });
+
+  it('loads a URL that comes from an external navigation command', () => {
+    const store = createUrlStore('https://example.com');
+    mount = document.createElement('div');
+    document.body.appendChild(mount);
+    root = createRoot(mount);
+    flushSync(() => root?.render(<ExternalStoreHarness store={store} />));
+
+    const setAttribute = vi.spyOn(webview, 'setAttribute');
+    flushSync(() => store.set('https://example.com/external'));
+
+    expect(setAttribute).toHaveBeenCalledWith('src', 'https://example.com/external');
+  });
+
+  it('ignores duplicate same-URL in-page navigation while reporting real URL changes', () => {
+    const onNavigate = vi.fn();
+    mount = document.createElement('div');
+    document.body.appendChild(mount);
+    root = createRoot(mount);
+    flushSync(() => root?.render(<Harness onNavigate={onNavigate} />));
+
+    const mainNavigation = new Event('did-navigate') as Event & { url: string };
+    mainNavigation.url = 'https://example.com';
+    flushSync(() => webview.dispatchEvent(mainNavigation));
+
+    const duplicateInPageNavigation = new Event('did-navigate-in-page') as Event & { url: string };
+    duplicateInPageNavigation.url = 'https://example.com';
+    flushSync(() => webview.dispatchEvent(duplicateInPageNavigation));
+
+    const changedInPageNavigation = new Event('did-navigate-in-page') as Event & { url: string };
+    changedInPageNavigation.url = 'https://example.com/pulls';
+    flushSync(() => webview.dispatchEvent(changedInPageNavigation));
+
+    expect(onNavigate).toHaveBeenNthCalledWith(1, 'https://example.com');
+    expect(onNavigate).toHaveBeenNthCalledWith(2, 'https://example.com/pulls');
+    expect(onNavigate).toHaveBeenCalledTimes(2);
   });
 
   it('reports focus entering the webview guest', () => {
@@ -110,11 +148,33 @@ const Harness = ({ onNavigate }: { onNavigate: (url: string) => void }) => {
   );
 };
 
-const ControlledHarness = () => {
-  const [url, setUrl] = useState('https://example.com');
+interface UrlStore {
+  getSnapshot: () => string;
+  set: (url: string) => void;
+  subscribe: (listener: () => void) => () => void;
+}
+
+const createUrlStore = (initialUrl: string): UrlStore => {
+  let url = initialUrl;
+  const listeners = new Set<() => void>();
+  return {
+    getSnapshot: () => url,
+    set: (nextUrl) => {
+      url = nextUrl;
+      listeners.forEach((listener) => listener());
+    },
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+};
+
+const ExternalStoreHarness = ({ store }: { store: UrlStore }) => {
+  const url = useSyncExternalStore(store.subscribe, store.getSnapshot);
   const browser = useEmbeddedBrowser({
     className: 'test-webview',
-    onNavigate: setUrl,
+    onNavigate: store.set,
     url,
   });
   return <div ref={browser.hostRef} />;

--- a/apps/canvas-workspace/src/renderer/src/components/EmbeddedBrowser/useEmbeddedBrowser.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/EmbeddedBrowser/useEmbeddedBrowser.ts
@@ -54,6 +54,8 @@ export const useEmbeddedBrowser = ({
   callbacksRef.current = { onFaviconChange, onFocus, onNavigate, onTitleChange };
   const urlRef = useRef(url);
   urlRef.current = url;
+  const guestUrlRef = useRef(url);
+  const lastReportedUrlRef = useRef(url);
 
   useLayoutEffect(() => {
     if (!enabled) {
@@ -71,6 +73,7 @@ export const useEmbeddedBrowser = ({
     element.className = className;
     host.appendChild(element);
     setWebview(element);
+    guestUrlRef.current = urlRef.current;
     setCurrentUrl(urlRef.current);
     setCanGoBack(false);
     setCanGoForward(false);
@@ -85,6 +88,15 @@ export const useEmbeddedBrowser = ({
       const detail = event as Event & { isMainFrame?: boolean; url?: string };
       if (detail.isMainFrame === false) return;
       if (detail.url) {
+        // Record the guest's live URL before mirroring it to the external
+        // store. useSyncExternalStore can commit that prop update before this
+        // handler's React state update, so currentUrl is not a safe guard.
+        guestUrlRef.current = detail.url;
+        if (event.type === 'did-navigate-in-page' && detail.url === lastReportedUrlRef.current) {
+          syncNavigation();
+          return;
+        }
+        lastReportedUrlRef.current = detail.url;
         setCurrentUrl(detail.url);
         callbacksRef.current.onNavigate?.(detail.url);
       }
@@ -146,15 +158,15 @@ export const useEmbeddedBrowser = ({
 
   useLayoutEffect(() => {
     if (!webview) return;
-    // A did-navigate event already moved this live guest. When the parent
-    // mirrors that URL into persisted tab state, do not assign src again and
-    // accidentally reload the page we just reached.
-    if (url === currentUrl) return;
+    // Guest navigation is mirrored into persisted tab state. Only a URL that
+    // differs from the live guest is an external navigation command.
+    if (url === guestUrlRef.current) return;
+    guestUrlRef.current = url;
     if (webview.getAttribute('src') !== url) webview.setAttribute('src', url);
     setCurrentUrl(url);
     setLoadState(url ? 'loading' : 'idle');
     setLoadError(null);
-  }, [currentUrl, url, webview]);
+  }, [url, webview]);
 
   const goBack = useCallback(() => {
     if (webview?.canGoBack()) webview.goBack();


### PR DESCRIPTION
## Problem

Navigating inside an embedded web tab (for example, GitHub pulls → a pull request) completed the site's in-page navigation and then performed a second hard load. Direct refresh only loaded once.

## Root cause

`did-navigate-in-page` updates the live guest URL and synchronously mirrors it into the RightDock external store. The prop-sync layout effect could observe the new persisted `url` before React committed `currentUrl`, treat it as an external navigation command, and assign the same URL to the webview `src`, triggering the hard reload.

## Fix

- Track the live guest URL synchronously in a ref before notifying the external store.
- Run prop-to-webview synchronization only when the external `url` prop changes.
- Preserve same-URL in-page event deduplication.
- Add regression coverage for guest-driven store persistence and genuine external navigation commands.

## Verification

- Real built-app harness: GitHub `/pulls` → PR #820 now stays on the in-page navigation path; the former second `did-start-loading → did-navigate` hard-navigation sequence is gone.
- `pnpm --filter canvas-workspace test` — 191 files / 1338 tests passed.
- `pnpm --filter canvas-workspace typecheck` — passed.
- Repository harness — 2/2 bound checks passed.
