### PR TITLE
release(canvas): 0.1.21

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.20",
+  "version": "0.1.21",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- bump Pulse Canvas to 0.1.21
- publish macOS arm64 DMG and blockmap
- update stable latest.json and download page

## Release notes

- Dock tabs now support drag-to-reorder and side-by-side split view
- In-page web navigation no longer triggers redundant reloads

## Validation

- `node scripts/harness/run-harness-check.mjs --level standard`
- macOS arm64 packaging and R2 upload completed
- remote latest.json reports 0.1.21