### PR TITLE
fix(canvas): remove stray default exports on component modules

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -252,4 +252,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
   );
 };
 
-export default MigrationSpinner;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
@@ -10,7 +10,9 @@ import { useI18n } from '../../i18n';
 import { Button, FieldRow, Select } from '../ui';
 import './AgentSection.css';
 
-const AgentShellPathCard = lazy(() => import('./AgentShellPathCard'));
+const AgentShellPathCard = lazy(() =>
+  import('./AgentShellPathCard').then((m) => ({ default: m.AgentShellPathCard })),
+);
 
 interface AgentSectionProps {
   onClose: () => void;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
@@ -9,7 +9,7 @@ interface AgentShellPathCardProps {
   onConfigured: () => Promise<void>;
 }
 
-const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps) => {
+export const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps) => {
   const { notify } = useAppShell();
   const { language, t } = useI18n();
   const [configuring, setConfiguring] = useState(false);
@@ -71,5 +71,3 @@ const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps
     </div>
   );
 };
-
-export default AgentShellPathCard;


### PR DESCRIPTION
## Summary

Scanned `apps/canvas-workspace` for UI style inconsistencies against the workspace's documented conventions (`harness/knowledge/conventions/frontend.md`) and its mechanized style ratchet (`src/main/__tests__/ui-reuse-governance.test.ts`, which gates hardcoded colors, border-radius/shadow literals, z-index, and blessed-component reuse).

**The ratchet itself passes with zero drift** (all 18 counters exactly match baseline) — no untracked CSS/token/component-reuse debt exists right now. Bulk-normalizing the remaining literal stock is explicitly out of scope per that file's own notes (near-miss radius/shadow values are "a different, pixel-changing operation gated behind a visual diff", not a mechanical sweep).

Outside the ratchet's coverage, I checked the doc's other stated conventions (named arrow-function exports vs. `default`, Props naming, colocated CSS) and found one genuine, well-evidenced inconsistency:

- `frontend.md` says to **avoid `default` exports for components**, and in practice **16 of the codebase's 17 `lazy()`-loaded components** already follow `lazy(() => import('./X').then((m) => ({ default: m.X })))` — importing a named export. Two files were the outliers:
  - `MigrationSpinner/index.tsx` carried an **unused** `export default` alongside its named export; its only caller (`App.tsx`) already imports the named export via `.then()`, so the default was dead code.
  - `Settings/AgentShellPathCard.tsx` had **only** a default export, making its `lazy()` call in `AgentSection.tsx` the sole exception to the established pattern.

## Changes

- `MigrationSpinner/index.tsx`: drop the unused `export default`.
- `Settings/AgentShellPathCard.tsx`: export the component as a named export instead of default.
- `Settings/AgentSection.tsx`: update the `lazy()` import to use `.then((m) => ({ default: m.AgentShellPathCard }))`, matching every other lazy-loaded component in the app.

No behavior change. `typecheck` and the full `canvas-workspace` test suite (including the UI-reuse governance ratchet) pass; one unrelated `history-store.test.ts` flake was confirmed pre-existing (passes in isolation, fails only under full-suite parallel load, reproduces identically on a clean checkout).

## Test plan

- [x] `pnpm --filter canvas-workspace typecheck`
- [x] `pnpm --filter canvas-workspace test` (1 pre-existing unrelated flake in `history-store.test.ts`, confirmed on clean tree)
- [x] `ui-reuse-governance.test.ts` ratchet unaffected (still 18/18 passing, no baseline changes needed)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016SaSHGqpjEGR6BWaRS2EMS


---
_Generated by [Claude Code](https://claude.ai/code/session_016SaSHGqpjEGR6BWaRS2EMS)_