### PR TITLE
Add memory-review skill and memory_adopt adoption channel

### DIFF
--- a/apps/canvas-workspace/AGENTS.md
+++ b/apps/canvas-workspace/AGENTS.md
@@ -86,7 +86,7 @@ deploys the external-agent `pulse-canvas` CLI + bundled skills. Do not mix them.
 | Visual-regression baseline for ui/ pieces | `harness/tools/ui-showcase/README.md`; run `pnpm run visual` / `pnpm run visual:update` |
 | Canvas persistence and migration | `src/main/canvas/store.ts`, `src/main/canvas/storage.ts`, `src/main/canvas/nodes/` (NB: `nodes/` here = knowledge-node records + tags, NOT node types) |
 | Canvas Agent and tools | `src/main/agent/`, `src/main/agent/tools/`, `src/renderer/src/components/chat/` |
-| Agent long-term memory (global + per-workspace) | `src/main/agent/memory-store.ts` (store + prompt injection; explicit-save-only by design), `src/main/agent/tools/memory.ts` (`memory_save` eager, `memory_list`/`memory_forget` deferred), tests in `src/main/agent/__tests__/memory-store.test.ts` |
+| Agent long-term memory (global + per-workspace) | `src/main/agent/memory-store.ts` (store + prompt injection; explicit-save-only by design), `src/main/agent/tools/memory.ts` (`memory_save` eager; `memory_list`/`memory_forget`/`memory_adopt` deferred — `memory_adopt` is the sole cross-workspace write path, reserved for user-confirmed candidates from the `memory-review` default skill), tests in `src/main/agent/__tests__/memory-store.test.ts` + `tools-graph.test.ts` |
 | Add a capability shared by Tool + CLI | `../../harness/skills/add-canvas-capability/SKILL.md`; use `harness/skills/add-agent-tool/SKILL.md` for the optional task-specific Canvas Agent adapter |
 | Agent teams | `src/main/agent-teams/`, `src/renderer/src/components/AgentTeamFrame/` |
 | Runtime-control server | `src/main/runtime/control-server.ts` |

--- a/apps/canvas-workspace/src/main/agent/__tests__/default-skills.test.ts
+++ b/apps/canvas-workspace/src/main/agent/__tests__/default-skills.test.ts
@@ -38,7 +38,9 @@ describe('ensureDefaultSkillsSeeded', () => {
     const skills = await listCanvasSkills({ level: 'global' });
     const byName = Object.fromEntries(skills.map((s) => [s.name, s]));
 
-    expect(Object.keys(byName).sort()).toEqual(['promote-skill', 'save-as-skill', 'suggest-tags']);
+    expect(Object.keys(byName).sort()).toEqual(['memory-review', 'promote-skill', 'save-as-skill', 'suggest-tags']);
+    expect(byName['memory-review'].body).toMatch(/memory_adopt/);
+    expect(byName['memory-review'].body).toMatch(/session_summary/);
     expect(byName['save-as-skill'].description).toMatch(/save.*conversation|reusable skill/i);
     expect(byName['save-as-skill'].body).toMatch(/canvas_save_skill/);
     expect(byName['promote-skill'].body).toMatch(/canvas_promote_skill/);

--- a/apps/canvas-workspace/src/main/agent/__tests__/tools-graph.test.ts
+++ b/apps/canvas-workspace/src/main/agent/__tests__/tools-graph.test.ts
@@ -275,6 +275,7 @@ describe('createGlobalCanvasTools', () => {
       'knowledge_analyze_image',
       'knowledge_read_node',
       'knowledge_search_nodes',
+      'memory_adopt',
       'memory_forget',
       'memory_list',
       'memory_save',
@@ -301,6 +302,57 @@ describe('createGlobalCanvasTools', () => {
     const found = JSON.parse(await tools.canvas_search_nodes.execute({ workspaceId: wsId, query: 'pipeline' }));
     expect(found.ok).toBe(true);
     expect(found.matches.map((m: { id: string }) => m.id)).toEqual(['n-text']);
+  });
+});
+
+describe('memory_adopt', () => {
+  const writeManifest = async (): Promise<void> => {
+    await fs.writeFile(
+      join(sandboxHome, '.pulse-coder', 'canvas', '__workspaces__.json'),
+      JSON.stringify({ workspaces: [{ id: wsId, name: 'Tools Test' }] }),
+      'utf-8',
+    );
+  };
+
+  it('routes confirmed candidates per scope and rejects unknown workspaces item-wise', async () => {
+    await writeManifest();
+    const tools = createCanvasTools(wsId);
+
+    const result = JSON.parse(await tools.memory_adopt.execute({
+      candidates: [
+        { content: 'reply in Chinese', kind: 'preference' },
+        { content: 'API layer uses fetch', kind: 'rule', workspaceId: wsId },
+        { content: 'orphan', workspaceId: 'ws-does-not-exist' },
+      ],
+    }));
+
+    expect(result.ok).toBe(false);
+    expect(result.adopted).toBe(2);
+    expect(result.results[0]).toMatchObject({ ok: true, scope: 'global' });
+    expect(result.results[1]).toMatchObject({ ok: true, scope: wsId });
+    expect(result.results[2].ok).toBe(false);
+    expect(result.results[2].error).toContain('ws-does-not-exist');
+
+    const { listMemory } = await import('../memory-store');
+    expect((await listMemory({ kind: 'global' })).map((e) => e.content)).toEqual(['reply in Chinese']);
+    expect((await listMemory({ kind: 'workspace', workspaceId: wsId })).map((e) => e.content)).toEqual([
+      'API layer uses fetch',
+    ]);
+  });
+
+  it('is the cross-scope exception: global chat can adopt into a workspace', async () => {
+    await writeManifest();
+    const tools = createGlobalCanvasTools();
+
+    const result = JSON.parse(await tools.memory_adopt.execute({
+      candidates: [{ content: 'ws decision from weekly report', kind: 'decision', workspaceId: wsId }],
+    }));
+    expect(result).toMatchObject({ ok: true, adopted: 1 });
+
+    const { listMemory } = await import('../memory-store');
+    expect((await listMemory({ kind: 'workspace', workspaceId: wsId })).map((e) => e.content)).toEqual([
+      'ws decision from weekly report',
+    ]);
   });
 });
 
@@ -522,6 +574,7 @@ describe('deferred tool partition', () => {
       'canvas_search_history',
       'canvas_send_to_agent',
       'canvas_update_edge',
+      'memory_adopt',
       'memory_forget',
       'memory_list',
       'session_search',

--- a/apps/canvas-workspace/src/main/agent/default-skills.ts
+++ b/apps/canvas-workspace/src/main/agent/default-skills.ts
@@ -114,7 +114,45 @@ Works in global chat (the whole system) and inside a single workspace. It is adv
 `,
 };
 
-const DEFAULT_SKILLS: DefaultSkill[] = [SAVE_AS_SKILL, PROMOTE_SKILL, SUGGEST_TAGS];
+const MEMORY_REVIEW: DefaultSkill = {
+  slug: 'memory-review',
+  name: 'memory-review',
+  description:
+    'When the user asks to review a period and distill it into long-term memory — e.g. "帮我盘点这周", "生成记忆周报/记忆报告", "review this week and update your memory" — use this to build the report and adopt only user-confirmed candidates.',
+  body: `# memory-review
+
+Build a period report from chat history, propose memory candidates, and persist ONLY what the user confirms.
+
+## Steps
+
+1. **Pin the period.** Default: last 7 days. Use the user's period if they named one.
+
+2. **Gather (read-only).**
+   - \`session_summary\` for that period — covers every workspace + global chat.
+   - \`memory_list\` — existing entries are your dedupe rubric.
+   - \`canvas_list_workspaces\` — id↔name mapping for scope labels and \`memory_adopt\`.
+
+3. **Draft the report in chat:**
+   - Per-workspace: 2-4 lines of what happened, decisions made, problems solved. Skip idle workspaces.
+   - **Candidates**: a numbered list. Each = ONE distilled statement (≤500 chars) + suggested scope (全局 or workspace name) + kind (preference/fact/decision/rule/note).
+   - Skip anything existing memory already covers; if a candidate supersedes an existing entry, mark it "更新: 替代 [mem-…]".
+   - Precision over recall — propose 3 solid candidates over 10 weak ones. Transient task state is NOT a candidate.
+
+4. **Wait for explicit confirmation.** The user picks numbers ("采纳 1、3"), edits wording, or rejects. Silence or "looks interesting" is NOT confirmation.
+
+5. **Persist via \`memory_adopt\`** with only the approved candidates — \`workspaceId\` from step 2's mapping, omitted for 全局. If a confirmed candidate replaces a stale entry, \`memory_forget\` that entry's id afterwards.
+
+6. **Report back**: what was written to which scope (ids), what was skipped.
+
+## Rules
+
+- **Never call \`memory_adopt\` without the user's explicit approval of those exact candidates in this conversation.**
+- \`memory_adopt\` is the ONLY cross-workspace write path, and only for this flow; routine remembering stays on \`memory_save\`.
+- Never copy raw transcript excerpts into a candidate — always distill to a standalone statement.
+`,
+};
+
+const DEFAULT_SKILLS: DefaultSkill[] = [SAVE_AS_SKILL, PROMOTE_SKILL, SUGGEST_TAGS, MEMORY_REVIEW];
 
 // Exact SHA-256 of the previously bundled suggest-tags SKILL.md. Updating only
 // this byte-for-byte default migrates the obsolete direct-write workflow while

--- a/apps/canvas-workspace/src/main/agent/tools/memory.ts
+++ b/apps/canvas-workspace/src/main/agent/tools/memory.ts
@@ -18,6 +18,7 @@ import {
   type MemoryEntry,
   type MemoryScope,
 } from '../memory-store';
+import { listWorkspaces } from '../../canvas/workspaces';
 import type { CanvasTool } from './types';
 
 type ScopeName = 'global' | 'workspace';
@@ -161,5 +162,61 @@ export function createMemoryTools(workspaceId: string): Record<string, CanvasToo
     },
   };
 
-  return { memory_save, memory_list, memory_forget };
+  const memory_adopt: CanvasTool = {
+    name: 'memory_adopt',
+    defer_loading: true,
+    description:
+      'Batch-write memory candidates the user just explicitly confirmed in a memory review/report (see the memory-review skill). ' +
+      'Each candidate routes to its own scope — this is the ONLY path allowed to write another workspace\'s memory, so call it strictly with user-approved candidates, never for routine saving (that is memory_save).',
+    inputSchema: z.object({
+      candidates: z
+        .array(
+          z.object({
+            content: z.string().min(1).describe('One distilled statement, max 500 chars.'),
+            kind: memoryKindSchema,
+            workspaceId: z.string().optional().describe('Target workspace id from the report; omit for global memory.'),
+          }),
+        )
+        .min(1)
+        .max(20)
+        .describe('Only the candidates the user approved.'),
+    }),
+    execute: async (input: {
+      candidates: Array<{ content: string; kind?: MemoryEntry['kind']; workspaceId?: string }>;
+    }) => {
+      const knownIds = new Set((await listWorkspaces()).workspaces.map((w) => w.id));
+      const results: Array<Record<string, unknown>> = [];
+      for (const candidate of input.candidates) {
+        const targetWs = candidate.workspaceId?.trim();
+        if (targetWs && !knownIds.has(targetWs)) {
+          results.push({
+            ok: false,
+            content: candidate.content,
+            error: `Unknown workspaceId "${targetWs}" — verify it with canvas_list_workspaces.`,
+          });
+          continue;
+        }
+        const scope: MemoryScope = targetWs ? { kind: 'workspace', workspaceId: targetWs } : globalScope;
+        try {
+          const saved = await saveMemory(scope, candidate.content, candidate.kind ?? 'note');
+          results.push({
+            ok: true,
+            scope: targetWs ?? 'global',
+            updatedExisting: saved.updated,
+            id: saved.entry.id,
+          });
+        } catch (err) {
+          results.push({
+            ok: false,
+            content: candidate.content,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+      const adopted = results.filter((r) => r.ok).length;
+      return JSON.stringify({ ok: adopted === results.length, adopted, total: results.length, results });
+    },
+  };
+
+  return { memory_save, memory_list, memory_forget, memory_adopt };
 }


### PR DESCRIPTION
## Summary

First step of the periodic memory-report roadmap: a manually-triggered memory review flow on top of the long-term memory system from #826. Zero scheduling infrastructure — the user asks for a review in chat, confirms candidates, and only then anything is written.

## Key Changes

- **`memory_adopt` tool** (`tools/memory.ts`, deferred, available in both chat scopes): batch-writes memory candidates the user explicitly confirmed in a review. Each candidate routes to its own scope — global, or a named workspace validated against `canvas/workspaces.listWorkspaces()` (unknown ids fail item-wise instead of creating orphan files). This is deliberately the **only** cross-workspace memory write path; `memory_save`'s structural scope lock stays intact.
- **`memory-review` bundled default skill** (`default-skills.ts`): triggered by "帮我盘点这周 / 生成记忆周报 / review this week". Procedure: gather period activity via `session_summary` + existing `memory_list` as the dedupe rubric → draft a per-workspace report with numbered, scope-labeled candidates in chat → wait for explicit user confirmation → persist only approved items via `memory_adopt`, optionally `memory_forget` superseded entries.
- **Guard updates**: eager/deferred partition lists, default-skill seeding expectations.

## Tests

- Scope routing (global + workspace) and item-wise unknown-workspace rejection for `memory_adopt`
- Global chat cross-scope adoption (the sanctioned exception)
- Skill seeding includes `memory-review` with `memory_adopt`/`session_summary` references
- Full suite: 1417 passed; typecheck, describe-canvas registry check, and bundle gate (Gate 7/7, main bundle 558.9 KB vs ~571.6 KB limit) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8wmvAW9wt4sfA2AB7WeXw

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8wmvAW9wt4sfA2AB7WeXw)_