### PR TITLE
release(canvas): 0.1.24

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.22",
+  "version": "0.1.24",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
Publishes Pulse Canvas 0.1.24 for macOS arm64.\n\n- Adds cross-workspace long-term memory and scoped memory reviews\n- Adds periodic in-app memory reports with one-click saving to memory or skills