### PR TITLE
Always mount TextNodeBody editor for interactive text nodes

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBodyLazy/index.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBodyLazy/index.test.ts
@@ -1,9 +1,0 @@
-import { describe, expect, it } from 'vitest';
-import { htmlToPreviewText } from '.';
-
-describe('htmlToPreviewText', () => {
-  it('extracts text without executing or exposing markup', () => {
-    expect(htmlToPreviewText('<p>Hello <strong>Canvas</strong></p><script>alert(1)</script>'))
-      .toBe('Hello Canvasalert(1)');
-  });
-});

--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBodyLazy/index.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBodyLazy/index.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { CanvasNode } from '../../types';
+
+vi.mock('../TextNodeBody', () => ({
+  TextNodeBody: () => <div data-testid="mock-text-editor" />,
+}));
+
+import { TextNodeBodyLazy, htmlToPreviewText } from '.';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let host: HTMLDivElement | null = null;
+
+const node = {
+  id: 'text-1',
+  type: 'text',
+  title: 'Text',
+  x: 0,
+  y: 0,
+  width: 200,
+  height: 40,
+  data: { content: '<p>Hello <strong>Canvas</strong></p>' },
+  updatedAt: 1,
+} as CanvasNode;
+
+const renderTextNodeBodyLazy = async (props: { isSelected?: boolean; readOnly?: boolean } = {}) => {
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+
+  await act(async () => {
+    root?.render(
+      <TextNodeBodyLazy
+        node={node}
+        onUpdate={vi.fn()}
+        isSelected={props.isSelected ?? false}
+        isResizing={false}
+        onSelect={vi.fn()}
+        onDragStart={vi.fn()}
+        readOnly={props.readOnly ?? false}
+      />,
+    );
+  });
+
+  return host;
+};
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  host?.remove();
+  root = null;
+  host = null;
+});
+
+describe('htmlToPreviewText', () => {
+  it('extracts text without executing or exposing markup', () => {
+    expect(htmlToPreviewText('<p>Hello <strong>Canvas</strong></p><script>alert(1)</script>'))
+      .toBe('Hello Canvasalert(1)');
+  });
+});
+
+describe('TextNodeBodyLazy', () => {
+  it('renders the real styled editor immediately, even when unselected', async () => {
+    const view = await renderTextNodeBodyLazy({ isSelected: false });
+
+    expect(view.querySelector('[data-testid="mock-text-editor"]')).not.toBeNull();
+    expect(view.querySelector('.text-node-preview')).toBeNull();
+  });
+
+  it('keeps read-only text nodes in flattened preview mode', async () => {
+    const view = await renderTextNodeBodyLazy({ readOnly: true });
+
+    expect(view.querySelector('[data-testid="mock-text-editor"]')).toBeNull();
+    expect(view.querySelector('.text-node-preview')).not.toBeNull();
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBodyLazy/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBodyLazy/index.tsx
@@ -26,14 +26,17 @@ export const htmlToPreviewText = (html: string): string => {
 
 export const TextNodeBodyLazy = (props: Props) => {
   const data = props.node.data as TextNodeData;
-  const [editorLoaded, setEditorLoaded] = useState(!props.readOnly && props.isSelected && data.content === '');
+  // Mirrors FileNodeBodyLazy: mount the real (Tiptap-backed) body as soon as
+  // the node is interactive at all, not just once selected. TextNodeBody's own
+  // idle state is already non-editable and cheap to look at — gating it behind
+  // selection bought nothing but a flattened plain-text flash on every unselected
+  // node (rich marks like color/bold/headings only rendered after a click).
+  const [editorLoaded, setEditorLoaded] = useState(() => !props.readOnly);
   const text = useMemo(() => htmlToPreviewText(data.content ?? ''), [data.content]);
 
   useEffect(() => {
-    if (!props.readOnly && props.isSelected && data.content === '') {
-      setEditorLoaded(true);
-    }
-  }, [data.content, props.isSelected, props.readOnly]);
+    if (!props.readOnly) setEditorLoaded(true);
+  }, [props.readOnly]);
 
   if (editorLoaded) {
     return (


### PR DESCRIPTION
## Summary
Changed TextNodeBodyLazy to always mount the real Tiptap-backed editor for non-read-only text nodes, rather than deferring it until selection. This eliminates a visual flash of plain-text preview when clicking unselected nodes.

## Changes
- **Updated initialization logic**: Changed `editorLoaded` state to initialize as `!props.readOnly` instead of only when selected with empty content
- **Simplified effect**: Removed selection-dependent conditions; now only checks `readOnly` status to determine when to load the editor
- **Expanded test coverage**: Migrated from basic unit tests to comprehensive component tests with React DOM rendering, covering both selected/unselected states and read-only mode behavior

## Implementation Details
The change mirrors the pattern used in FileNodeBodyLazy. Since TextNodeBody's idle state is already non-editable and performant, deferring its mount provided no benefit while causing a noticeable UX regression—rich formatting (bold, color, headings) would only render after clicking a node. Now the editor mounts immediately for all interactive nodes, with the preview mode reserved only for read-only text nodes.

https://claude.ai/code/session_01MQVZRQ4ctDaJKCuignevxk