### PR TITLE
style(canvas-workspace): normalize import quote style to single quotes

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/DynamicAppNodeBody/Inspector.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/DynamicAppNodeBody/Inspector.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from "react";
-import { useAppShell } from "../AppShellProvider";
+import { useCallback, useEffect, useState } from 'react';
+import { useAppShell } from '../AppShellProvider';
 
 /** What the main-side `get-spec` IPC returns. */
 interface GetSpecOk {

--- a/apps/canvas-workspace/src/renderer/src/components/DynamicAppNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/DynamicAppNodeBody/index.tsx
@@ -16,10 +16,10 @@
  * `window.canvasWorkspace.plugin.invoke('dynamic-app', ...)`.
  */
 
-import { useCallback, useEffect, useState } from "react";
-import "./index.css";
-import { DynamicAppInspector } from "./Inspector";
-import type { CanvasNode, DynamicAppNodeData } from "../../types";
+import { useCallback, useEffect, useState } from 'react';
+import './index.css';
+import { DynamicAppInspector } from './Inspector';
+import type { CanvasNode, DynamicAppNodeData } from '../../types';
 
 interface DynamicAppNodeBodyProps {
   node: CanvasNode;

--- a/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/FrameHeaderControls.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/FrameHeaderControls.tsx
@@ -1,7 +1,7 @@
-import { useCallback, type MouseEvent as ReactMouseEvent } from "react";
-import type { CanvasNode, FrameNodeData } from "../../types";
-import { DropdownShell, SwatchRow } from "../ui";
-import { useI18n } from "../../i18n";
+import { useCallback, type MouseEvent as ReactMouseEvent } from 'react';
+import type { CanvasNode, FrameNodeData } from '../../types';
+import { DropdownShell, SwatchRow } from '../ui';
+import { useI18n } from '../../i18n';
 
 /**
  * Frame header controls (children toggle + color picker).

--- a/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.tsx
@@ -1,9 +1,9 @@
-import "./index.css";
-import type { CanvasNode, FrameNodeData } from "../../types";
-import { AgentTeamFrame } from "../AgentTeamFrame";
-import { NodeTypeBadge } from "../CanvasNodeView/NodeTypeBadge";
-import { useI18n } from "../../i18n";
-import { collectDirectContainerChildren } from "../../utils/frameHierarchy";
+import './index.css';
+import type { CanvasNode, FrameNodeData } from '../../types';
+import { AgentTeamFrame } from '../AgentTeamFrame';
+import { NodeTypeBadge } from '../CanvasNodeView/NodeTypeBadge';
+import { useI18n } from '../../i18n';
+import { collectDirectContainerChildren } from '../../utils/frameHierarchy';
 
 /** Maximum direct-child rows shown in a collapsed frame before "+N more". */
 const COLLAPSED_SUMMARY_MAX = 6;

--- a/apps/canvas-workspace/src/renderer/src/components/LinkDrawer/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/LinkDrawer/index.tsx
@@ -9,21 +9,21 @@
  * `onTitleChange`.
  */
 
-import { useCallback, useEffect, useId, useRef, useState, type FormEvent, type KeyboardEvent } from "react";
-import { useI18n } from "../../i18n";
+import { useCallback, useEffect, useId, useRef, useState, type FormEvent, type KeyboardEvent } from 'react';
+import { useI18n } from '../../i18n';
 import { useEmbeddedBrowser } from '../EmbeddedBrowser/useEmbeddedBrowser';
 import { BrowserNavigationButtons } from '../EmbeddedBrowser/BrowserNavigationButtons';
 import { resolveAddressInput } from '../EmbeddedBrowser/address-input';
 import { AddressSuggestionList, useAddressSuggestions, type AddressSuggestion } from './AddressSuggestions';
 import { useWebviewRegistration } from '../IframeNodeBody/useWebviewRegistration';
 import { useClickOutside } from '../../hooks/useClickOutside';
-import { pickFaviconUrl } from "../IframeNodeBody/utils";
+import { pickFaviconUrl } from '../IframeNodeBody/utils';
 import { useAppShell } from '../AppShellProvider';
 import type { AgentContextDomSelectionRef } from '../../types';
-import { ExternalLinkIcon, PlusIcon } from "../icons";
-import { Button, TextField, clampIndexMove } from "../ui";
-import { EXPERIMENTAL_FLAG_DEFAULT_BROWSER } from "../../../../shared/experimental-features";
-import "./index.css";
+import { ExternalLinkIcon, PlusIcon } from '../icons';
+import { Button, TextField, clampIndexMove } from '../ui';
+import { EXPERIMENTAL_FLAG_DEFAULT_BROWSER } from '../../../../shared/experimental-features';
+import './index.css';
 
 /** Google blocks account sign-in inside embedded browsers (WebView policy);
  *  detect its sign-in host so we can steer the user to the system browser. */

--- a/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NodeContextMenu/index.tsx
@@ -1,8 +1,8 @@
-import "./index.css";
-import { Popover } from "../ui/Popover";
-import { useI18n } from "../../i18n";
-import type { CreatableCanvasNodeType } from "../../utils/nodeFactory";
-import { useRightDock } from "../RightDock";
+import './index.css';
+import { Popover } from '../ui/Popover';
+import { useI18n } from '../../i18n';
+import type { CreatableCanvasNodeType } from '../../utils/nodeFactory';
+import { useRightDock } from '../RightDock';
 
 interface Props {
   x: number;

--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/TextColorPicker.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/TextColorPicker.tsx
@@ -1,7 +1,7 @@
-import { BG_COLOR_PRESETS, TEXT_COLOR_PRESETS } from "./colorPresets";
-import type { CanvasNode, TextNodeData } from "../../types";
-import { DropdownShell, SwatchRow } from "../ui";
-import { useI18n } from "../../i18n";
+import { BG_COLOR_PRESETS, TEXT_COLOR_PRESETS } from './colorPresets';
+import type { CanvasNode, TextNodeData } from '../../types';
+import { DropdownShell, SwatchRow } from '../ui';
+import { useI18n } from '../../i18n';
 
 /**
  * Color pickers for the text-node header (text color + background color).

--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/TextSelectionBubble.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/TextSelectionBubble.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useMemo } from "react";
-import type { Editor } from "@tiptap/react";
-import { BubbleMenu } from "@tiptap/react/menus";
-import { useI18n } from "../../i18n";
-import { HIGHLIGHT_COLOR_PRESETS, TEXT_COLOR_PRESETS } from "./colorPresets";
+import { useCallback, useMemo } from 'react';
+import type { Editor } from '@tiptap/react';
+import { BubbleMenu } from '@tiptap/react/menus';
+import { useI18n } from '../../i18n';
+import { HIGHLIGHT_COLOR_PRESETS, TEXT_COLOR_PRESETS } from './colorPresets';
 
 export const TextSelectionBubble = ({ editor, editing }: { editor: Editor; editing: boolean }) => {
   const { t } = useI18n();

--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.tsx
@@ -1,11 +1,11 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { EditorContent, useEditor } from "@tiptap/react";
-import "./index.css";
-import { TextSelectionBubble } from "./TextSelectionBubble";
-import { createTextNodeExtensions } from "./textNodeExtensions";
-import type { CanvasNode, TextNodeData } from "../../types";
-import { isImeComposing } from "../../utils/ime";
-import { useI18n } from "../../i18n";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { EditorContent, useEditor } from '@tiptap/react';
+import './index.css';
+import { TextSelectionBubble } from './TextSelectionBubble';
+import { createTextNodeExtensions } from './textNodeExtensions';
+import type { CanvasNode, TextNodeData } from '../../types';
+import { isImeComposing } from '../../utils/ime';
+import { useI18n } from '../../i18n';
 
 interface Props {
   node: CanvasNode;

--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/textColorMark.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/textColorMark.ts
@@ -1,4 +1,4 @@
-import { Mark } from "@tiptap/react";
+import { Mark } from '@tiptap/react';
 
 export const TextColorMark = Mark.create({
   name: "textColor",

--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/textNodeExtensions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/textNodeExtensions.ts
@@ -1,9 +1,9 @@
-import Highlight from "@tiptap/extension-highlight";
-import Placeholder from "@tiptap/extension-placeholder";
-import Underline from "@tiptap/extension-underline";
-import StarterKit from "@tiptap/starter-kit";
-import { Markdown } from "tiptap-markdown";
-import { TextColorMark } from "./textColorMark";
+import Highlight from '@tiptap/extension-highlight';
+import Placeholder from '@tiptap/extension-placeholder';
+import Underline from '@tiptap/extension-underline';
+import StarterKit from '@tiptap/starter-kit';
+import { Markdown } from 'tiptap-markdown';
+import { TextColorMark } from './textColorMark';
 
 export const createTextNodeExtensions = (placeholder: string) => [
   // Text nodes stay intentionally lighter than Note cards: enough Markdown

--- a/apps/canvas-workspace/src/renderer/src/components/router/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/router/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo } from 'react';
 
 interface PulseRouterContextValue {
   activeKey: string | undefined;

--- a/apps/canvas-workspace/src/renderer/src/hooks/useCanvas.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useCanvas.ts
@@ -1,10 +1,10 @@
-import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
-import type { CanvasTransform } from "../types";
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
+import type { CanvasTransform } from '../types';
 import {
   HEAVY_EMBED_THRESHOLD,
   setCanvasMotion,
   type CanvasMotionMode,
-} from "./canvasMotion";
+} from './canvasMotion';
 
 const MIN_SCALE = 0.1;
 const MAX_SCALE = 4;

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodeDrag.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodeDrag.ts
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import type { CanvasNode } from "../types";
-import { collectContainerDescendants, isContainerNode } from "../utils/frameHierarchy";
-import { computeSnap, type SnapBox, type SnapLine } from "../utils/canvasSnapping";
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { CanvasNode } from '../types';
+import { collectContainerDescendants, isContainerNode } from '../utils/frameHierarchy';
+import { computeSnap, type SnapBox, type SnapLine } from '../utils/canvasSnapping';
 
 /** Grid spacing (canvas-px) for the fallback grid snap. Lines up with
  *  the existing background `.canvas-grid` so the snap and the visual

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodeResize.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodeResize.ts
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import type { CanvasNode, TextNodeData } from "../types";
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { CanvasNode, TextNodeData } from '../types';
 
 const DEFAULT_MIN_WIDTH = 200;
 const DEFAULT_MIN_HEIGHT = 120;

--- a/apps/canvas-workspace/src/renderer/src/main.tsx
+++ b/apps/canvas-workspace/src/renderer/src/main.tsx
@@ -1,15 +1,15 @@
-import { createRoot } from "react-dom/client";
-import { Router } from "wouter";
-import { useHashLocation } from "wouter/use-hash-location";
-import App from "./App";
-import "./styles.css";
+import { createRoot } from 'react-dom/client';
+import { Router } from 'wouter';
+import { useHashLocation } from 'wouter/use-hash-location';
+import App from './App';
+import './styles.css';
 import {
   activateConfiguredFederatedRendererPlugins,
   activateCanvasPlugins,
   BUILT_IN_RENDERER_PLUGINS,
-} from "../../plugins/renderer";
-import { installPerfMonitor, markOnce } from "./perf/monitor";
-import { installJankMonitor } from "./perf/jank-monitor";
+} from '../../plugins/renderer';
+import { installPerfMonitor, markOnce } from './perf/monitor';
+import { installJankMonitor } from './perf/jank-monitor';
 
 installPerfMonitor();
 installJankMonitor();

--- a/apps/canvas-workspace/src/renderer/src/utils/nodeLabel.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/nodeLabel.ts
@@ -1,4 +1,4 @@
-import type { CanvasNode, MindmapNodeData, PluginNodeData, ReferenceNodeData, TextNodeData } from "../types";
+import type { CanvasNode, MindmapNodeData, PluginNodeData, ReferenceNodeData, TextNodeData } from '../types';
 
 const TEXT_LABEL_MAX_CHARS = 10;
 const MINDMAP_LABEL_MAX_CHARS = 16;


### PR DESCRIPTION
## Summary

Scanned `apps/canvas-workspace` for UI style inconsistencies against the project's documented conventions (`AGENTS.md` hard boundaries + `apps/canvas-workspace/harness/knowledge/conventions/frontend.md`).

**Findings:**

- **Automated ratchet is healthy**: `ui-reuse-governance.test.ts` and `file-size-governance.test.ts` (which already track hardcoded color/radius/shadow/z-index literals, bespoke dropdown shells, segmented roles, etc.) both pass with no drift — no new debt introduced there.
- **Component conventions are followed**: no `export default` components, no `Props`-naming violations found.
- **One real inconsistency**: `AGENTS.md` states the repo-wide hard boundary is "2 spaces, semicolons, single quotes," and 96% of `src/renderer/src` (412 of 429 files) already imports with single quotes (e.g. `import './index.css'`, `from '../../types'`). 17 files (4%) used double-quoted import/export specifiers instead — a leftover from files likely authored/pasted with a different formatter default.

**Fix:** normalized the double-quoted import/export module specifiers in those 17 files to single quotes, matching the rest of the codebase. Only import/export specifier quoting was touched — in-code string literals (e.g. a JSX default prop value like `mode = "create"`) were deliberately left untouched, so this is a pure formatting change with zero behavior or visual diff.

### Files changed
- `src/renderer/src/main.tsx`
- `src/renderer/src/utils/nodeLabel.ts`
- `src/renderer/src/hooks/{useCanvas,useNodeDrag,useNodeResize}.ts`
- `src/renderer/src/components/router/index.tsx`
- `src/renderer/src/components/NodeContextMenu/index.tsx`
- `src/renderer/src/components/LinkDrawer/index.tsx`
- `src/renderer/src/components/FrameNodeBody/{index,FrameHeaderControls}.tsx`
- `src/renderer/src/components/DynamicAppNodeBody/{index,Inspector}.tsx`
- `src/renderer/src/components/TextNodeBody/{index,TextSelectionBubble,TextColorPicker,textColorMark,textNodeExtensions}.{ts,tsx}`

## Test plan

- [x] `pnpm --filter canvas-workspace typecheck` — clean
- [x] `pnpm --filter canvas-workspace test` — 213 test files / 1442 tests passed
- [x] `pnpm --filter canvas-workspace exec vitest run src/main/__tests__/ui-reuse-governance.test.ts src/main/__tests__/file-size-governance.test.ts` — both pass, no baseline drift
- [x] `pnpm --filter canvas-workspace build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vusfcyd1LWAkdmtgqEucc6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vusfcyd1LWAkdmtgqEucc6)_