### PR TITLE
release(canvas): 0.1.25

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.24",
+  "version": "0.1.25",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
Published Pulse Canvas 0.1.25 for macOS arm64.

- downloads: https://downloads.jasperhu.art/pulse-canvas/stable/Pulse-Canvas-0.1.25-arm64.dmg

- page: https://pulse-canvas-download.pages.dev/
