### PR TITLE
perf(canvas-workspace): lazy-mount dock link-tab webviews on first activation

### DIFF
--- a/apps/canvas-workspace/AGENTS.md
+++ b/apps/canvas-workspace/AGENTS.md
@@ -223,6 +223,11 @@ pnpm --filter canvas-workspace package:linux
   portal ownership.
 - `src/renderer/src/components/RightDock/`: tabbed right dock for chat and
   previews. Link tabs register their live webviews under the stable dock tab id;
+  a link tab's webview mounts lazily on first activation (DockPanes gates
+  `LinkTabView`'s `mountWebview`) so restored docks don't spawn one guest
+  process per tab on the cold-start path — once mounted it stays mounted, and
+  agent tools that activate a tab before reading it poll for the registration
+  via `main/webview/ensure-operable.ts`.
   page-element selection must reuse the shared iframe DOM picker/selection
   context and route the result through Workbench's active-workspace chat bridge.
   That bridge must queue selections until the target composer registers; opening

--- a/apps/canvas-workspace/src/renderer/src/components/LinkDrawer/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/LinkDrawer/index.tsx
@@ -42,6 +42,11 @@ interface LinkTabViewProps {
   /** Dock tab id — used as the webview registry key so the Canvas Agent can
    *  read this tab's live page via `canvas_read_tab`. */
   tabId?: string;
+  /** Gate the <webview> mount. Restored docks render every tab's pane stacked
+   *  (only the active one is visible), so mounting unconditionally spins up a
+   *  guest process + navigation per tab on the cold-start critical path.
+   *  DockPanes flips this on first activation; once true it stays true. */
+  mountWebview?: boolean;
   onActivate?: () => void;
   onTitleChange?: (title: string) => void;
   /** Page favicon, reported once the webview resolves it, so the tab icon
@@ -61,6 +66,7 @@ export const LinkTabView = ({
   url,
   title,
   tabId,
+  mountWebview = true,
   onActivate,
   onTitleChange,
   onFaviconChange,
@@ -86,6 +92,7 @@ export const LinkTabView = ({
   const lastVisitedUrlRef = useRef('');
   const browser = useEmbeddedBrowser({
     className: 'link-drawer__webview',
+    enabled: mountWebview,
     onFocus: onActivate,
     onFaviconChange: (favicons) => {
       const favicon = pickFaviconUrl(favicons);

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/DockPanes.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/DockPanes.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, type CSSProperties, type MouseEventHandler } from 'react';
+import { lazy, Suspense, useRef, type CSSProperties, type MouseEventHandler } from 'react';
 import { useI18n } from '../../i18n';
 import type { WorkspaceEntry } from '../../hooks/useWorkspaces';
 import type { AgentContextDomSelectionRef } from '../../types';
@@ -47,6 +47,17 @@ export const DockPanes = ({
 }: Props) => {
   const { t } = useI18n();
   const splitActive = Boolean(splitTabId);
+  // Lazy-mount link-tab webviews. Every tab's pane renders stacked (inactive
+  // ones are `visibility: hidden`), so mounting each LinkTabView's <webview>
+  // unconditionally spins up a guest process + navigation per restored tab on
+  // the cold-start critical path — N heavy pages competing at the worst
+  // moment. Mount a tab's webview only once it has been VISIBLE (active or
+  // split); after that it stays mounted, so switching back never reloads.
+  // Agent tools that activate a tab before reading it already poll for the
+  // webview registration (main/webview/ensure-operable.ts).
+  const mountedLinkTabsRef = useRef(new Set<string>());
+  if (activePaneId) mountedLinkTabsRef.current.add(activePaneId);
+  if (splitTabId) mountedLinkTabsRef.current.add(splitTabId);
   const style = {
     '--split-content-width': `${splitContentWidth}px`,
     '--split-divider-width': `${splitDividerWidth}px`,
@@ -125,6 +136,7 @@ export const DockPanes = ({
                 url={tab.url}
                 title={tab.title}
                 tabId={tab.id}
+                mountWebview={mountedLinkTabsRef.current.has(tab.id)}
                 activeWorkspaceId={activeWorkspaceId}
                 onActivate={() => store.activate(tab.id)}
                 onTitleChange={(title) => store.setTitle(tab.id, title)}

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/__tests__/DockPanes.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/__tests__/DockPanes.test.tsx
@@ -1,13 +1,27 @@
 // @vitest-environment happy-dom
 import { flushSync } from 'react-dom';
 import { createRoot, type Root } from 'react-dom/client';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DockPanes } from '../DockPanes';
 import { CHAT_TAB_ID, DockStore, TERMINAL_TAB_ID } from '../dock-store';
 import { I18nProvider } from '../../../i18n';
 
+// Capture the props each LinkTabView renders with (the real one lazy-loads a
+// live <webview>, which has no place in a happy-dom test).
+const latestLinkTabProps = vi.hoisted(() => new Map<string, { mountWebview?: boolean }>());
+vi.mock('../../LinkDrawer', () => ({
+  LinkTabView: (props: { tabId?: string; mountWebview?: boolean }) => {
+    if (props.tabId) latestLinkTabProps.set(props.tabId, { mountWebview: props.mountWebview });
+    return null;
+  },
+}));
+
 let root: Root | null = null;
 let mount: HTMLDivElement | null = null;
+
+beforeEach(() => {
+  latestLinkTabProps.clear();
+});
 
 afterEach(() => {
   flushSync(() => root?.unmount());
@@ -54,5 +68,55 @@ describe('DockPanes split focus', () => {
       new FocusEvent('focusin', { bubbles: true }),
     );
     expect(store.getSnapshot().activeTabId).toBe(CHAT_TAB_ID);
+  });
+});
+
+describe('DockPanes lazy link-tab webview mount', () => {
+  const renderPanes = (store: DockStore, activePaneId: string | null) => {
+    flushSync(() => root?.render(
+      <I18nProvider><DockPanes
+        store={store}
+        state={store.getSnapshot()}
+        activePaneId={activePaneId}
+        splitContentWidth={320}
+        splitDividerWidth={6}
+        onDividerMouseDown={() => undefined}
+        setChatHost={() => undefined}
+        setTerminalHost={() => undefined}
+        terminalHostMounted={false}
+        activeWorkspaceId="ws1"
+        workspaces={[]}
+        onOpenNodePage={() => undefined}
+        pinUrlReference={() => undefined}
+        onAddDomSelectionToChat={() => undefined}
+      /></I18nProvider>,
+    ));
+  };
+
+  it('mounts the webview only for tabs that have been active, and never unmounts', async () => {
+    const store = new DockStore();
+    store.openLink('https://a.example/');
+    store.openLink('https://b.example/');
+    const [tabA, tabB] = store.getSnapshot().tabs;
+    // Startup-restore shape: several restored link tabs, only one active.
+    store.activate(tabA.id);
+
+    mount = document.createElement('div');
+    document.body.appendChild(mount);
+    root = createRoot(mount);
+    renderPanes(store, tabA.id);
+
+    await vi.waitFor(() => expect(latestLinkTabProps.size).toBe(2));
+    expect(latestLinkTabProps.get(tabA.id)?.mountWebview).toBe(true);
+    expect(latestLinkTabProps.get(tabB.id)?.mountWebview).toBe(false);
+
+    // Activating the second tab mounts its webview...
+    renderPanes(store, tabB.id);
+    await vi.waitFor(() => expect(latestLinkTabProps.get(tabB.id)?.mountWebview).toBe(true));
+
+    // ...and switching away keeps it mounted (no reload on return).
+    renderPanes(store, tabA.id);
+    await vi.waitFor(() => expect(latestLinkTabProps.get(tabA.id)?.mountWebview).toBe(true));
+    expect(latestLinkTabProps.get(tabB.id)?.mountWebview).toBe(true);
   });
 });


### PR DESCRIPTION
## 问题

启动后画布内嵌网页（如飞书文档）要等 20-30s 才加载出来。根因：右 dock 恢复 N 个 link tab 时，每个 tab 的 pane 都会渲染（非活跃 pane 仅被 CSS `visibility: hidden` 遮住），`LinkTabView` 无条件挂载 `<webview>` —— 启动瞬间 spawn N 个 guest 进程同时导航，与 app bootstrap 互相抢 CPU/网络，把每个页面的可交互时间拉长数倍。

## 修复

dock link tab 的 webview 改为**首次激活时才挂载**，挂载后保持常驻（切走再切回不重新加载）：

- `LinkDrawer/index.tsx` — `LinkTabView` 新增 `mountWebview` prop（默认 `true`），接到 `useEmbeddedBrowser` 已有的 `enabled` 门
- `RightDock/DockPanes.tsx` — 用 ref 记录曾经可见（active 或 split）的 tab id，只有这类 tab 才挂载 webview
- `RightDock/__tests__/DockPanes.test.tsx` — 新增用例：恢复多个 tab 时仅 active 的挂载；激活第二个才挂载；切走后保持挂载
- `AGENTS.md` — 补充该行为契约

实测场景（3 画布节点 + 7 dock tab）：启动 guest 进程数从 ~10 降到 ~4。

## 兼容性

Agent 工具链路不受影响：`canvas_read_tab` / `page_*` 工具激活 tab 后本就通过 `main/webview/ensure-operable.ts` 轮询等待 webview 注册（最长 8s），懒挂载落在该等待窗口内。

## 验证

- `pnpm --filter canvas-workspace typecheck` ✅
- `pnpm --filter canvas-workspace test`（214 文件 / 1462 用例）✅
- `node scripts/harness/run-harness-check.mjs` quick 校验（含 file-size / ui-reuse 门禁）✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)