### PR TITLE
release(canvas): 0.1.26

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.25",
+  "version": "0.1.26",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
Published Pulse Canvas 0.1.26 for macOS arm64.

- downloads: https://downloads.jasperhu.art/pulse-canvas/stable/Pulse-Canvas-0.1.26-arm64.dmg

- page: https://pulse-canvas-download.pages.dev/

---

Release notes (中文):

- 性能优化：恢复含多个 Dock 链接标签页（如多个飞书文档）的工作区时冷启动明显加快。未激活的标签页现在仅在首次切到时才加载页面，不再一次性启动所有标签页进程；之前多个重型页面同时加载会把单个页面的可交互时间拉长到 20–30 秒。已加载过的标签页切回时不会重新加载。
- 性能优化：限制 webview 同时启动的数量，并延迟加载屏外的 webview 节点主体，降低启动时的资源争抢。
- 问题修复：飞书文档 webview 保持活跃，不再被错误降级；保留 webview 加载任务，避免部分页面加载被中断。

Release notes (English):

- Performance: Cold start is noticeably faster when restoring a workspace with multiple dock link tabs (e.g. several Lark docs). Inactive tabs now load their page only when first activated instead of all at once - previously, several heavy pages loading together stretched each page's time-to-content to 20-30s. Tabs that have already loaded do not reload when you switch back.
- Performance: Bounded concurrent webview startup and lazily load off-screen webview node bodies to reduce resource contention during startup.
- Fixes: Feishu doc webviews now stay active instead of being over-throttled, and webview load leases are retained so page loads no longer get dropped.
