### PR TITLE
fix(canvas-workspace): reference panel height, title sync, and empty-state overlay

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.tsx
@@ -17,6 +17,7 @@ export const IframeNodeBody = ({
   isResizing,
   onAddDomSelectionToChat,
   onSubmitDomReviewComments,
+  onPageTitleChange,
   readOnly = false,
 }: IframeNodeBodyProps) => {
   const { openArtifact } = useRightDock();
@@ -31,6 +32,7 @@ export const IframeNodeBody = ({
     node,
     workspaceId,
     onUpdate,
+    onPageTitleChange,
     isResizing,
     readOnly,
   });

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/types.ts
@@ -11,5 +11,9 @@ export interface IframeNodeBodyProps {
   isResizing?: boolean;
   onAddDomSelectionToChat?: (selection: AgentContextDomSelectionRef) => void;
   onSubmitDomReviewComments?: (comments: AgentContextDomReviewComment[]) => Promise<boolean>;
+  // Read-only embeds can't persist the guest page title through onUpdate
+  // (it's typically a noop there); this lets the host own persistence —
+  // e.g. the reference drawer writes it back onto the URL reference entry.
+  onPageTitleChange?: (title: string) => void;
   readOnly?: boolean;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/useIframeNodeState.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/useIframeNodeState.test.tsx
@@ -59,6 +59,7 @@ let originalIntersectionObserver: typeof IntersectionObserver | undefined;
 let mockWebview: (HTMLElement & { executeJavaScript: ReturnType<typeof vi.fn> }) | null;
 let discardCallback: ((payload: DiscardPayload) => void) | null;
 let hookState: ReturnType<typeof useIframeNodeState> | null = null;
+let harnessOptions: { readOnly: boolean; onPageTitleChange?: (title: string) => void };
 
 beforeEach(() => {
   MockIntersectionObserver.instances = [];
@@ -71,6 +72,7 @@ beforeEach(() => {
   mockWebview = null;
   discardCallback = null;
   hookState = null;
+  harnessOptions = { readOnly: false };
   Object.defineProperty(window, 'canvasWorkspace', {
     configurable: true,
     value: {
@@ -191,6 +193,28 @@ describe('useIframeNodeState', () => {
     expect(hookState?.webviewDiscarded).toBe(false);
     expect(unregisterWebview).not.toHaveBeenCalled();
   });
+
+  // Regression: the reference-drawer URL preview is readOnly, so the guest's
+  // page title never reached any persistence path and the entry kept showing
+  // the hostname. readOnly must forward the sanitized title instead.
+  it('forwards the guest page title in readOnly mode via onPageTitleChange', async () => {
+    const onPageTitleChange = vi.fn();
+    harnessOptions = { readOnly: true, onPageTitleChange };
+    await renderHookHarness();
+    flushSync(() => {
+      for (const observer of MockIntersectionObserver.instances) observer.trigger(true);
+    });
+    await flushEffects();
+    expect(mockWebview).not.toBeNull();
+
+    const titleEvent = new Event('page-title-updated');
+    Object.assign(titleEvent, { title: '  pulse-agent:   A repo about coding agent.  ' });
+    flushSync(() => {
+      mockWebview?.dispatchEvent(titleEvent);
+    });
+
+    expect(onPageTitleChange).toHaveBeenCalledWith('pulse-agent: A repo about coding agent.');
+  });
 });
 
 async function renderHookHarness(): Promise<void> {
@@ -209,7 +233,8 @@ function IframeHookHarness() {
     node: iframeNode,
     workspaceId: 'workspace-1',
     onUpdate: vi.fn(),
-    readOnly: false,
+    onPageTitleChange: harnessOptions.onPageTitleChange,
+    readOnly: harnessOptions.readOnly,
   });
   hookState = state;
 

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/useIframeNodeState.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/useIframeNodeState.ts
@@ -16,10 +16,10 @@ import {
   BLANK_PAGE_URL,
   getFriendlyLoadErrorMessage,
   normalizeUrl,
-  pickFaviconUrl,
   prettyTitle,
-  sanitizePageTitle,
   shouldSyncIframeTitle,
+  syncBrowserFavicon,
+  syncBrowserPageTitle,
 } from './utils';
 import { isImeComposing } from '../../utils/ime';
 import { useWebviewBackgroundThrottle } from './useWebviewBackgroundThrottle';
@@ -30,6 +30,7 @@ export const useIframeNodeState = ({
   node,
   workspaceId,
   onUpdate,
+  onPageTitleChange,
   readOnly = false,
 }: IframeNodeBodyProps) => {
   const data = node.data as IframeNodeData;
@@ -114,29 +115,19 @@ export const useIframeNodeState = ({
   const frameHostRef = useRef<HTMLDivElement>(null);
   const shouldMountInlineFrame = useDeferredVisibleMount(frameHostRef, '200px', `${mode}|${streamingActive}`);
 
-  const handleBrowserTitleChange = useCallback((title: string) => {
-    if (editing || readOnly) return;
-    const rawTitle = sanitizePageTitle(title);
-    const nextTitle = url === BLANK_PAGE_URL && rawTitle === BLANK_PAGE_URL ? 'Blank page' : rawTitle;
-    if (!nextTitle || nextTitle === node.title) return;
-    const latestData = latestDataRef.current;
-    if (!shouldSyncIframeTitle(node.title, latestData, url)) return;
+  const handleBrowserTitleChange = useCallback(
+    (title: string) => syncBrowserPageTitle(title, {
+      editing, readOnly, node, url, latestDataRef, onUpdate, onPageTitleChange,
+    }),
+    [editing, node, onPageTitleChange, onUpdate, readOnly, url],
+  );
 
-    const nextData = { ...latestData, pageTitle: nextTitle };
-    latestDataRef.current = nextData;
-    onUpdate(node.id, { title: nextTitle, data: nextData });
-  }, [editing, node.id, node.title, onUpdate, readOnly, url]);
-
-  const handleBrowserFaviconChange = useCallback((favicons: string[]) => {
-    if (editing || readOnly) return;
-    const faviconUrl = pickFaviconUrl(favicons);
-    if (!faviconUrl) return;
-    const latestData = latestDataRef.current;
-    if (latestData.faviconUrl === faviconUrl) return;
-    const nextData = { ...latestData, faviconUrl };
-    latestDataRef.current = nextData;
-    onUpdate(node.id, { data: nextData });
-  }, [editing, node.id, onUpdate, readOnly]);
+  const handleBrowserFaviconChange = useCallback(
+    (favicons: string[]) => syncBrowserFavicon(favicons, {
+      editing, readOnly, node, url, latestDataRef, onUpdate,
+    }),
+    [editing, node, onUpdate, readOnly, url],
+  );
 
   const browser = useEmbeddedBrowser({
     className: 'iframe-frame',

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/utils.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/utils.ts
@@ -1,4 +1,4 @@
-import type { IframeNodeData } from '../../types';
+import type { CanvasNode, IframeNodeData } from '../../types';
 
 export const BLANK_PAGE_URL = 'about:blank';
 
@@ -48,6 +48,45 @@ export function pickFaviconUrl(favicons: string[] | undefined): string {
       return false;
     }
   }) ?? '';
+}
+
+export interface BrowserMetaSyncContext {
+  editing: boolean;
+  readOnly: boolean;
+  node: CanvasNode;
+  url: string;
+  latestDataRef: { current: IframeNodeData };
+  onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
+  onPageTitleChange?: (title: string) => void;
+}
+
+export function syncBrowserPageTitle(title: string, ctx: BrowserMetaSyncContext): void {
+  const rawTitle = sanitizePageTitle(title);
+  // Read-only embeds (e.g. the reference-drawer URL preview) never reach the
+  // onUpdate path — forward the guest title so the host can persist it.
+  if (ctx.readOnly) {
+    if (rawTitle) ctx.onPageTitleChange?.(rawTitle);
+    return;
+  }
+  if (ctx.editing) return;
+  const nextTitle = ctx.url === BLANK_PAGE_URL && rawTitle === BLANK_PAGE_URL ? 'Blank page' : rawTitle;
+  if (!nextTitle || nextTitle === ctx.node.title) return;
+  const latestData = ctx.latestDataRef.current;
+  if (!shouldSyncIframeTitle(ctx.node.title, latestData, ctx.url)) return;
+  const nextData = { ...latestData, pageTitle: nextTitle };
+  ctx.latestDataRef.current = nextData;
+  ctx.onUpdate(ctx.node.id, { title: nextTitle, data: nextData });
+}
+
+export function syncBrowserFavicon(favicons: string[], ctx: BrowserMetaSyncContext): void {
+  if (ctx.editing || ctx.readOnly) return;
+  const faviconUrl = pickFaviconUrl(favicons);
+  if (!faviconUrl) return;
+  const latestData = ctx.latestDataRef.current;
+  if (latestData.faviconUrl === faviconUrl) return;
+  const nextData = { ...latestData, faviconUrl };
+  ctx.latestDataRef.current = nextData;
+  ctx.onUpdate(ctx.node.id, { data: nextData });
 }
 
 export function getFriendlyLoadErrorMessage(

--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/ReferencePreviews.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/ReferencePreviews.tsx
@@ -20,6 +20,7 @@ interface ReferencePreviewPanelProps {
   onFocusNode: (workspaceId: string, nodeId: string) => void;
   onOpenUrl: (url: string) => void;
   onRemoveReference: (referenceId: string) => void;
+  onUrlReferenceTitle?: (referenceId: string, title: string) => void;
   workspaceNameById: Map<string, string>;
 }
 
@@ -54,6 +55,7 @@ export const ReferencePreviewPanel = ({
   onFocusNode,
   onOpenUrl,
   onRemoveReference,
+  onUrlReferenceTitle,
   workspaceNameById,
 }: ReferencePreviewPanelProps) => {
   const { t } = useI18n();
@@ -172,7 +174,11 @@ export const ReferencePreviewPanel = ({
                 className="reference-url-slot"
                 style={ref.id === activeReferenceId ? ACTIVE_SLOT_STYLE : INACTIVE_SLOT_STYLE}
               >
-                <ReferenceUrlWebPreview reference={ref} drawerWidth={drawerWidth} />
+                <ReferenceUrlWebPreview
+                  reference={ref}
+                  drawerWidth={drawerWidth}
+                  onPageTitleChange={onUrlReferenceTitle}
+                />
               </div>
             ))}
           </div>
@@ -325,12 +331,20 @@ const NodeReferenceFooter = ({
 interface ReferenceUrlWebPreviewProps {
   reference: UrlReferenceEntry;
   drawerWidth: number;
+  onPageTitleChange?: (referenceId: string, title: string) => void;
 }
 
-const ReferenceUrlWebPreview = memo(({ reference, drawerWidth }: ReferenceUrlWebPreviewProps) => {
+const ReferenceUrlWebPreview = memo(({ reference, drawerWidth, onPageTitleChange }: ReferenceUrlWebPreviewProps) => {
   const previewNode = useMemo(
     () => createUrlPreviewNode(reference, drawerWidth),
     [reference, drawerWidth],
+  );
+  // The preview is readOnly, so the guest's page-title-updated can't flow
+  // through onUpdate; this writes it back onto the reference entry (what the
+  // entry list row displays).
+  const handlePageTitleChange = useCallback(
+    (title: string) => onPageTitleChange?.(reference.id, title),
+    [onPageTitleChange, reference.id],
   );
 
   return (
@@ -339,6 +353,7 @@ const ReferenceUrlWebPreview = memo(({ reference, drawerWidth }: ReferenceUrlWeb
         node={previewNode}
         onUpdate={() => undefined}
         isResizing={false}
+        onPageTitleChange={handlePageTitleChange}
         readOnly
       />
     </div>

--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.css
@@ -923,12 +923,15 @@
   z-index: 2;
 }
 
+/* Insets must match .reference-url-card--persistent / .reference-native-card--persistent
+   exactly: those previews stay mounted (webviews kept alive) underneath, and
+   any mismatch lets a strip of the mounted card peek out around the hint. */
 .reference-pick-hint--overlay {
   position: absolute;
-  top: 16px;
-  right: 18px;
-  bottom: 16px;
-  left: 18px;
+  top: 4px;
+  right: 14px;
+  bottom: 12px;
+  left: 14px;
   margin: 0;
   display: flex;
   align-items: center;
@@ -1018,9 +1021,19 @@
   text-decoration: underline;
 }
 
+/* The .canvas-node wrapper is absolutely positioned with inline width/height
+   from getNodeWrapperStyle, so a plain `flex: 1` never applies here — the
+   preview stayed pinned at the 420px preview-node height with dead space
+   above the footer. The card owns the geometry in the drawer: neutralize the
+   absolute box (relative keeps it the containing block for node chrome) and
+   let it flex to the card minus the footer. */
 .reference-native-card > .canvas-node {
-  flex: 1;
+  position: relative !important;
+  width: auto !important;
+  height: auto !important;
+  flex: 1 1 auto;
   min-height: 0;
+  align-self: stretch;
   border: 0;
   border-radius: 0;
   background: var(--surface);

--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/index.tsx
@@ -26,6 +26,7 @@ interface ReferenceDrawerProps {
   onClearAll: () => void;
   onAddReference: (workspaceId: string, nodeId: string) => void;
   onAddUrlReference: (url: string, title?: string) => void;
+  onUrlReferenceTitle?: (referenceId: string, title: string) => void;
   onFocusNode: (workspaceId: string, nodeId: string) => void;
   onAddReferenceToCanvas: (entry: NodeReferenceEntry) => void;
   onWorkspaceNodesRequest: (workspaceId: string) => void;
@@ -47,6 +48,7 @@ export const ReferenceDrawer = ({
   onClearAll,
   onAddReference,
   onAddUrlReference,
+  onUrlReferenceTitle,
   onFocusNode,
   onAddReferenceToCanvas,
   onWorkspaceNodesRequest,
@@ -156,6 +158,7 @@ export const ReferenceDrawer = ({
               onFocusNode={onFocusNode}
               onOpenUrl={state.openUrl}
               onRemoveReference={onRemoveReference}
+              onUrlReferenceTitle={onUrlReferenceTitle}
               workspaceNameById={state.workspaceNameById}
             />
           </>

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
@@ -6,24 +6,23 @@ import { ChatPanelLazy as ChatPanel } from '../chat/lazy';
 import { isDockChatVisible, isDockTerminalVisible, useRightDock, useRightDockChatHost, useRightDockState } from '../RightDock';
 import { buildDockTabRefs } from '../RightDock/tabRefs';
 import { createReferenceNodeDataSnapshot } from '../ReferenceDrawer/utils';
-import type { NodeReferenceEntry as NodeReferenceEntryForCanvas, ReferenceEntry } from '../ReferenceDrawer/types';
+import type { NodeReferenceEntry as NodeReferenceEntryForCanvas } from '../ReferenceDrawer/types';
 import type { SettingsSection } from '../Settings';
 import type { WorkspaceEntry } from '../../hooks/useWorkspaces';
 import type { WorkbenchController } from './useWorkbenchState';
 import type { CanvasNode, ReferenceNodeData } from '../../types';
 import { createDefaultNode } from '../../utils/nodeFactory';
-import { getNodeDisplayLabel } from '../../utils/nodeLabel';
 import type { CanvasClipboard, CanvasNodePatchRequest } from '../../types/ui-interaction';
 import { isReferenceableNode, isReferenceableNodeType } from '../../utils/referenceNodes';
 import { useMountedWorkspaceIds } from './useMountedWorkspaceIds';
 import { useChatInsertionBridge } from './useChatInsertionBridge';
 import { useEvictAndPreview, usePeekNode, usePreviewNodeActionBridge } from './usePreviewNodeActionBridge';
+import { useReferenceEntries } from './useReferenceEntries';
 import { WorkspaceTerminalPortal } from './WorkspaceTerminalPortal';
 import { useLoadedChatWorkspaceIds } from './useLoadedChatWorkspaceIds';
 import type { KnowledgeChatRouteContext } from './knowledgeChatContext';
 export { useWorkbenchState } from './useWorkbenchState';
 export type { WorkbenchController } from './useWorkbenchState';
-const EMPTY_REFERENCES: ReferenceEntry[] = [];
 const ReferenceDrawer = lazy(() => import('../ReferenceDrawer').then((m) => ({ default: m.ReferenceDrawer })));
 const KnowledgeChatPortal = lazy(() => import('./KnowledgeChatPortal').then((m) => ({ default: m.KnowledgeChatPortal })));
 interface WorkbenchProps {
@@ -73,10 +72,6 @@ export const Workbench: React.FC<WorkbenchProps> = ({
   const chatPanelOpen = isDockChatVisible(dockState);
   const loadedChatWorkspaceIds = useLoadedChatWorkspaceIds(chatPanelOpen, activeWorkspaceId);
   const terminalDockOpen = isDockTerminalVisible(dockState);
-  const [referenceDrawerOpen, setReferenceDrawerOpen] = useState(false);
-  const [referenceDrawerLoaded, setReferenceDrawerLoaded] = useState(false);
-  const [referencesByWorkspace, setReferencesByWorkspace] = useState<Record<string, ReferenceEntry[]>>({});
-  const [activeReferenceIdByWorkspace, setActiveReferenceIdByWorkspace] = useState<Record<string, string | undefined>>({});
   const [canvasClipboard, setCanvasClipboard] = useState<CanvasClipboard | null>(null);
   const [nodePatchRequest, setNodePatchRequest] = useState<CanvasNodePatchRequest | undefined>();
   const patchRequestIdRef = useRef(0);
@@ -84,110 +79,29 @@ export const Workbench: React.FC<WorkbenchProps> = ({
   // Publish the live-mounted set so the dock never previews an already-live canvas.
   useEffect(() => { dock.setMountedWorkspaces(mountedWorkspaceIds); }, [dock, mountedWorkspaceIds]);
   useEvictAndPreview({ mountedWorkspaceIds, evictWorkspace, terminalTabsByWorkspace: dockState.terminalTabsByWorkspace, openCanvasPreview: dock.openCanvasPreview });
-  useEffect(() => { if (referenceDrawerOpen) setReferenceDrawerLoaded(true); }, [referenceDrawerOpen]);
+  const {
+    activeReference,
+    activeReferenceNode,
+    clearAllReferences,
+    pinReferenceNode,
+    pinReferenceUrl,
+    referenceDrawerLoaded,
+    referenceDrawerOpen,
+    references,
+    removeReference,
+    setActiveReference,
+    setReferenceDrawerOpen,
+    updateUrlReferenceTitle,
+  } = useReferenceEntries({ activeWorkspaceId, allNodes, workspaces });
   useEffect(() => {
     for (const node of activeNodes) {
       const ref = node.ref;
       if (ref?.kind === 'workspace-node') ensureWorkspaceNodesLoaded(ref.workspaceId);
     }
   }, [activeNodes, ensureWorkspaceNodesLoaded]);
-  const references = referencesByWorkspace[activeWorkspaceId] ?? EMPTY_REFERENCES;
-  const activeReferenceId = activeReferenceIdByWorkspace[activeWorkspaceId];
-  const activeReference = activeReferenceId
-    ? references.find((entry) => (entry.kind === 'url' ? entry.id : `${entry.workspaceId}:${entry.nodeId}`) === activeReferenceId)
-    : undefined;
-  const activeReferenceNode = activeReference && activeReference.kind === 'node'
-    ? (allNodes[activeReference.workspaceId] ?? []).find((node) => node.id === activeReference.nodeId)
-    : undefined;
-  const removeReference = useCallback((referenceId: string) => {
-    setReferencesByWorkspace((prev) => {
-      const current = prev[activeWorkspaceId] ?? [];
-      const next = current.filter((entry) => (entry.kind === 'url' ? entry.id : `${entry.workspaceId}:${entry.nodeId}`) !== referenceId);
-      if (next.length === current.length) return prev;
-      return { ...prev, [activeWorkspaceId]: next };
-    });
-    setActiveReferenceIdByWorkspace((prev) => {
-      if (prev[activeWorkspaceId] !== referenceId) return prev;
-      return { ...prev, [activeWorkspaceId]: undefined };
-    });
-  }, [activeWorkspaceId]);
-  const clearAllReferences = useCallback(() => {
-    setReferencesByWorkspace((prev) => {
-      if (!prev[activeWorkspaceId]?.length) return prev;
-      return { ...prev, [activeWorkspaceId]: [] };
-    });
-    setActiveReferenceIdByWorkspace((prev) => ({
-      ...prev,
-      [activeWorkspaceId]: undefined,
-    }));
-  }, [activeWorkspaceId]);
-
-  const setActiveReference = useCallback((nodeId: string | undefined) => {
-    setActiveReferenceIdByWorkspace((prev) => ({
-      ...prev,
-      [activeWorkspaceId]: nodeId,
-    }));
-  }, [activeWorkspaceId]);
   // Reference "jump to node" peeks at other workspaces in the dock preview
   // instead of yanking the main canvas over (falls back when unpreviewable).
   const peekNode = usePeekNode({ activeWorkspaceId, workspaces, openCanvasPreview: dock.openCanvasPreview, onSelectWorkspace, requestNodeFocus });
-  useEffect(() => {
-    const current = referencesByWorkspace[activeWorkspaceId];
-    if (!current?.length) return;
-    const knownByWorkspace = new Map<string, Set<string>>();
-    for (const [workspaceId, snapshot] of Object.entries(allNodes)) {
-      knownByWorkspace.set(workspaceId, new Set(snapshot.map((node) => node.id)));
-    }
-    const filtered = current.filter((entry) => (
-      entry.kind === 'url'
-      || knownByWorkspace.get(entry.workspaceId)?.has(entry.nodeId)
-      || !Object.prototype.hasOwnProperty.call(allNodes, entry.workspaceId)
-    ));
-    if (filtered.length === current.length) return;
-    setReferencesByWorkspace((prev) => ({ ...prev, [activeWorkspaceId]: filtered }));
-    setActiveReferenceIdByWorkspace((prev) => {
-      const currentActive = prev[activeWorkspaceId];
-      if (currentActive && filtered.some((entry) => (entry.kind === 'url' ? entry.id : `${entry.workspaceId}:${entry.nodeId}`) === currentActive)) return prev;
-      const nextActive = filtered[0] ? (filtered[0].kind === 'url' ? filtered[0].id : `${filtered[0].workspaceId}:${filtered[0].nodeId}`) : undefined;
-      return { ...prev, [activeWorkspaceId]: nextActive };
-    });
-  }, [activeWorkspaceId, allNodes, referencesByWorkspace]);
-
-  const pinReferenceNode = useCallback((workspaceId: string, nodeId: string, sourceNode?: CanvasNode) => {
-    setReferencesByWorkspace((prev) => {
-      const current = prev[activeWorkspaceId] ?? [];
-      const exists = current.some((entry) => entry.kind === 'node' && entry.workspaceId === workspaceId && entry.nodeId === nodeId);
-      if (exists) return prev;
-      const workspace = workspaces.find((item) => item.id === workspaceId);
-      const node = (allNodes[workspaceId] ?? []).find((item) => item.id === nodeId) ?? sourceNode;
-      const entry: ReferenceEntry = {
-        kind: 'node',
-        workspaceId,
-        nodeId,
-        titleSnapshot: node ? getNodeDisplayLabel(node) : undefined,
-        typeSnapshot: node?.type,
-        workspaceNameSnapshot: workspace?.name,
-      };
-      return { ...prev, [activeWorkspaceId]: [...current, entry] };
-    });
-    setActiveReferenceIdByWorkspace((prev) => ({ ...prev, [activeWorkspaceId]: `${workspaceId}:${nodeId}` }));
-    setReferenceDrawerOpen(true);
-  }, [activeWorkspaceId, allNodes, workspaces]);
-
-  const pinReferenceUrl = useCallback((url: string, title?: string) => {
-    const id = `url:${url}`;
-    setReferencesByWorkspace((prev) => {
-      const current = prev[activeWorkspaceId] ?? [];
-      const exists = current.some((entry) => 'kind' in entry && entry.kind === 'url' && entry.url === url);
-      if (exists) return prev;
-      const entry: ReferenceEntry = { kind: 'url', id, url, title };
-      return { ...prev, [activeWorkspaceId]: [...current, entry] };
-    });
-    setActiveReferenceIdByWorkspace((prev) => ({ ...prev, [activeWorkspaceId]: id }));
-    setReferenceDrawerOpen(true);
-  }, [activeWorkspaceId]);
-
-  useEffect(() => dock.registerPinUrlReference(pinReferenceUrl), [dock, pinReferenceUrl]);
 
   const {
     handleAddDomSelectionToChat,
@@ -198,6 +112,8 @@ export const Workbench: React.FC<WorkbenchProps> = ({
     registerInsertMention,
     registerSubmitDomReviewComments,
   } = useChatInsertionBridge({ allNodes, openChat: dock.openChat });
+
+  useEffect(() => dock.registerPinUrlReference(pinReferenceUrl), [dock, pinReferenceUrl]);
 
   useEffect(() => dock.registerAddDomSelectionToChat(handleAddDomSelectionToChat), [dock, handleAddDomSelectionToChat]);
 
@@ -407,6 +323,7 @@ export const Workbench: React.FC<WorkbenchProps> = ({
               onClearAll={clearAllReferences}
               onAddReference={pinReferenceNode}
               onAddUrlReference={pinReferenceUrl}
+              onUrlReferenceTitle={updateUrlReferenceTitle}
               onFocusNode={peekNode}
               onAddReferenceToCanvas={addReferenceToCanvas}
               onWorkspaceNodesRequest={ensureWorkspaceNodesLoaded}

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/useReferenceEntries.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/useReferenceEntries.ts
@@ -1,0 +1,159 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { CanvasNode } from '../../types';
+import type { WorkspaceEntry } from '../../hooks/useWorkspaces';
+import { getNodeDisplayLabel } from '../../utils/nodeLabel';
+import type { ReferenceEntry } from '../ReferenceDrawer/types';
+
+const EMPTY_REFERENCES: ReferenceEntry[] = [];
+
+interface UseReferenceEntriesParams {
+  activeWorkspaceId: string;
+  allNodes: Record<string, CanvasNode[]>;
+  workspaces: WorkspaceEntry[];
+}
+
+// Owns the reference drawer's pinned-entry state: the per-workspace entry
+// lists, the active selection, and the drawer open flag. Entry mutations
+// (pin/remove/clear/title sync) all live here so Workbench stays a wiring
+// layer.
+export const useReferenceEntries = ({
+  activeWorkspaceId,
+  allNodes,
+  workspaces,
+}: UseReferenceEntriesParams) => {
+  const [referenceDrawerOpen, setReferenceDrawerOpen] = useState(false);
+  const [referenceDrawerLoaded, setReferenceDrawerLoaded] = useState(false);
+  const [referencesByWorkspace, setReferencesByWorkspace] = useState<Record<string, ReferenceEntry[]>>({});
+  const [activeReferenceIdByWorkspace, setActiveReferenceIdByWorkspace] = useState<Record<string, string | undefined>>({});
+
+  useEffect(() => { if (referenceDrawerOpen) setReferenceDrawerLoaded(true); }, [referenceDrawerOpen]);
+
+  const references = referencesByWorkspace[activeWorkspaceId] ?? EMPTY_REFERENCES;
+  const activeReferenceId = activeReferenceIdByWorkspace[activeWorkspaceId];
+  const activeReference = activeReferenceId
+    ? references.find((entry) => (entry.kind === 'url' ? entry.id : `${entry.workspaceId}:${entry.nodeId}`) === activeReferenceId)
+    : undefined;
+  const activeReferenceNode = activeReference && activeReference.kind === 'node'
+    ? (allNodes[activeReference.workspaceId] ?? []).find((node) => node.id === activeReference.nodeId)
+    : undefined;
+
+  const removeReference = useCallback((referenceId: string) => {
+    setReferencesByWorkspace((prev) => {
+      const current = prev[activeWorkspaceId] ?? [];
+      const next = current.filter((entry) => (entry.kind === 'url' ? entry.id : `${entry.workspaceId}:${entry.nodeId}`) !== referenceId);
+      if (next.length === current.length) return prev;
+      return { ...prev, [activeWorkspaceId]: next };
+    });
+    setActiveReferenceIdByWorkspace((prev) => {
+      if (prev[activeWorkspaceId] !== referenceId) return prev;
+      return { ...prev, [activeWorkspaceId]: undefined };
+    });
+  }, [activeWorkspaceId]);
+
+  const clearAllReferences = useCallback(() => {
+    setReferencesByWorkspace((prev) => {
+      if (!prev[activeWorkspaceId]?.length) return prev;
+      return { ...prev, [activeWorkspaceId]: [] };
+    });
+    setActiveReferenceIdByWorkspace((prev) => ({
+      ...prev,
+      [activeWorkspaceId]: undefined,
+    }));
+  }, [activeWorkspaceId]);
+
+  const setActiveReference = useCallback((nodeId: string | undefined) => {
+    setActiveReferenceIdByWorkspace((prev) => ({
+      ...prev,
+      [activeWorkspaceId]: nodeId,
+    }));
+  }, [activeWorkspaceId]);
+
+  // Drop node entries whose source node no longer exists (once that
+  // workspace's nodes are known); url entries always survive.
+  useEffect(() => {
+    const current = referencesByWorkspace[activeWorkspaceId];
+    if (!current?.length) return;
+    const knownByWorkspace = new Map<string, Set<string>>();
+    for (const [workspaceId, snapshot] of Object.entries(allNodes)) {
+      knownByWorkspace.set(workspaceId, new Set(snapshot.map((node) => node.id)));
+    }
+    const filtered = current.filter((entry) => (
+      entry.kind === 'url'
+      || knownByWorkspace.get(entry.workspaceId)?.has(entry.nodeId)
+      || !Object.prototype.hasOwnProperty.call(allNodes, entry.workspaceId)
+    ));
+    if (filtered.length === current.length) return;
+    setReferencesByWorkspace((prev) => ({ ...prev, [activeWorkspaceId]: filtered }));
+    setActiveReferenceIdByWorkspace((prev) => {
+      const currentActive = prev[activeWorkspaceId];
+      if (currentActive && filtered.some((entry) => (entry.kind === 'url' ? entry.id : `${entry.workspaceId}:${entry.nodeId}`) === currentActive)) return prev;
+      const nextActive = filtered[0] ? (filtered[0].kind === 'url' ? filtered[0].id : `${filtered[0].workspaceId}:${filtered[0].nodeId}`) : undefined;
+      return { ...prev, [activeWorkspaceId]: nextActive };
+    });
+  }, [activeWorkspaceId, allNodes, referencesByWorkspace]);
+
+  const pinReferenceNode = useCallback((workspaceId: string, nodeId: string, sourceNode?: CanvasNode) => {
+    setReferencesByWorkspace((prev) => {
+      const current = prev[activeWorkspaceId] ?? [];
+      const exists = current.some((entry) => entry.kind === 'node' && entry.workspaceId === workspaceId && entry.nodeId === nodeId);
+      if (exists) return prev;
+      const workspace = workspaces.find((item) => item.id === workspaceId);
+      const node = (allNodes[workspaceId] ?? []).find((item) => item.id === nodeId) ?? sourceNode;
+      const entry: ReferenceEntry = {
+        kind: 'node',
+        workspaceId,
+        nodeId,
+        titleSnapshot: node ? getNodeDisplayLabel(node) : undefined,
+        typeSnapshot: node?.type,
+        workspaceNameSnapshot: workspace?.name,
+      };
+      return { ...prev, [activeWorkspaceId]: [...current, entry] };
+    });
+    setActiveReferenceIdByWorkspace((prev) => ({ ...prev, [activeWorkspaceId]: `${workspaceId}:${nodeId}` }));
+    setReferenceDrawerOpen(true);
+  }, [activeWorkspaceId, allNodes, workspaces]);
+
+  const pinReferenceUrl = useCallback((url: string, title?: string) => {
+    const id = `url:${url}`;
+    setReferencesByWorkspace((prev) => {
+      const current = prev[activeWorkspaceId] ?? [];
+      const exists = current.some((entry) => 'kind' in entry && entry.kind === 'url' && entry.url === url);
+      if (exists) return prev;
+      const entry: ReferenceEntry = { kind: 'url', id, url, title };
+      return { ...prev, [activeWorkspaceId]: [...current, entry] };
+    });
+    setActiveReferenceIdByWorkspace((prev) => ({ ...prev, [activeWorkspaceId]: id }));
+    setReferenceDrawerOpen(true);
+  }, [activeWorkspaceId]);
+
+  // The read-only URL preview can't persist the guest's page title through
+  // the node onUpdate path, so the preview forwards it and we write it back
+  // onto the reference entry (its title is what the entry list row shows).
+  const updateUrlReferenceTitle = useCallback((referenceId: string, title: string) => {
+    setReferencesByWorkspace((prev) => {
+      const current = prev[activeWorkspaceId] ?? [];
+      let changed = false;
+      const next = current.map((entry) => {
+        if (entry.kind !== 'url' || entry.id !== referenceId || entry.title === title) return entry;
+        changed = true;
+        return { ...entry, title };
+      });
+      return changed ? { ...prev, [activeWorkspaceId]: next } : prev;
+    });
+  }, [activeWorkspaceId]);
+
+  return {
+    activeReference,
+    activeReferenceNode,
+    clearAllReferences,
+    pinReferenceNode,
+    pinReferenceUrl,
+    referenceDrawerLoaded,
+    referenceDrawerOpen,
+    references,
+    removeReference,
+    setActiveReference,
+    setReferenceDrawerOpen,
+    updateUrlReferenceTitle,
+  };
+};


### PR DESCRIPTION
Fixes three issues in the Reference panel:

1. **网页高度没有占满**: native node previews (e.g. DeepWiki iframe reference) now fill the drawer card above the footer instead of staying pinned at the preview node's fixed 420px height.
2. **没有读到网页名称**: URL reference entries now receive the guest page title from the readOnly webview preview, so the entry row shows the real page title instead of only the hostname.
3. **关闭网页空状态样式问题**: the pick-hint overlay now exactly covers still-mounted persistent preview cards; no card chrome peeks through.

Also extracts Workbench reference-entry state into  to keep file-size governance green, and adds a regression test for readOnly title forwarding.

Validation:
- `pnpm --filter canvas-workspace typecheck` ✅
- `useIframeNodeState.test.tsx` ✅ (4 tests)
- `pnpm run harness --level standard` ✅ (217 files, 1479 tests)
- Manual Electron harness verified title sync, height fill, and empty-state overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)