### PR TITLE
fix(canvas-workspace): fix UI style-guide drift (exports, CSS colocation, i18n)

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/App.css
+++ b/apps/canvas-workspace/src/renderer/src/App.css
@@ -32,25 +32,3 @@
 .right-dock-resizing .app-body {
   transition: none;
 }
-
-.canvas-viewport {
-  flex: 1;
-  position: relative;
-  overflow: hidden;
-  height: 100%;
-  min-height: 0;
-}
-
-.canvas-host {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-}
-
-.canvas-host__main {
-  position: relative;
-  flex: 1 1 auto;
-  min-height: 0;
-}

--- a/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentTeamFrame/index.tsx
@@ -23,7 +23,7 @@ import type {
   FrameNodeData,
 } from '../../types';
 
-interface AgentTeamFrameProps {
+interface Props {
   node: CanvasNode;
   getAllNodes?: () => CanvasNode[];
   onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
@@ -303,7 +303,7 @@ export const AgentTeamFrame = ({
   workspaceId,
   workspaceName,
   readOnly = false,
-}: AgentTeamFrameProps) => {
+}: Props) => {
   const data = node.data as FrameNodeData;
   const teamId = data.agentTeamId;
   const workspaceActive = useWorkspaceActive();

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasAlignmentGuides/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasAlignmentGuides/index.css
@@ -1,0 +1,11 @@
+.canvas-alignment-guides {
+  position: absolute;
+  /* Anchor at the canvas origin and let SVG draw negative
+     coordinates — the guide may extend "before" the origin. */
+  left: 0;
+  top: 0;
+  width: 1px;
+  height: 1px;
+  overflow: visible;
+  pointer-events: none;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasAlignmentGuides/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasAlignmentGuides/index.tsx
@@ -1,3 +1,4 @@
+import './index.css';
 import type { SnapLine } from '../../utils/canvasSnapping';
 
 interface Props {
@@ -25,20 +26,7 @@ export const CanvasAlignmentGuides = ({ lines, scale }: Props) => {
   const strokeWidth = STROKE_PX / Math.max(scale, 0.0001);
 
   return (
-    <svg
-      className="canvas-alignment-guides"
-      style={{
-        position: 'absolute',
-        // Anchor at the canvas origin and let SVG draw negative
-        // coordinates — the guide may extend "before" the origin.
-        left: 0,
-        top: 0,
-        width: 1,
-        height: 1,
-        overflow: 'visible',
-        pointerEvents: 'none',
-      }}
-    >
+    <svg className="canvas-alignment-guides">
       {lines.map((line, i) => {
         if (line.axis === 'x') {
           return (

--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;

--- a/apps/canvas-workspace/src/renderer/src/components/NoteFindBar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NoteFindBar/index.tsx
@@ -12,6 +12,7 @@ import {
   type NoteSearchOptions,
 } from '../../editor/noteSearchExtension';
 import { isImeComposing } from '../../utils/ime';
+import { useI18n } from '../../i18n';
 
 interface Props {
   editor: Editor;
@@ -19,6 +20,7 @@ interface Props {
 }
 
 export const NoteFindBar = ({ editor, onClose }: Props) => {
+  const { t } = useI18n();
   const [query, setQuery] = useState('');
   const [replacement, setReplacement] = useState('');
   const [showReplace, setShowReplace] = useState(false);
@@ -68,25 +70,25 @@ export const NoteFindBar = ({ editor, onClose }: Props) => {
         <button
           className="note-find-toggle"
           onClick={() => setShowReplace((v) => !v)}
-          title={showReplace ? 'Hide replace' : 'Show replace'}
+          title={showReplace ? t('noteFind.hideReplace') : t('noteFind.showReplace')}
         >
           {showReplace ? '▾' : '▸'}
         </button>
         <input
           ref={inputRef}
           className={`note-find-input${invalid ? ' note-find-input--invalid' : ''}`}
-          placeholder="Find"
+          placeholder={t('noteFind.findPlaceholder')}
           value={query}
           onChange={(e) => runSearch(e.target.value)}
           onKeyDown={handleKeyDown}
         />
-        <div className="note-find-toggles" role="group" aria-label="Search options">
+        <div className="note-find-toggles" role="group" aria-label={t('noteFind.searchOptions')}>
           <button
             type="button"
             className={`note-find-opt${options.caseSensitive ? ' note-find-opt--on' : ''}`}
             aria-pressed={options.caseSensitive}
-            aria-label="Match case"
-            title="Match case"
+            aria-label={t('noteFind.matchCase')}
+            title={t('noteFind.matchCase')}
             onMouseDown={(e) => e.preventDefault()}
             onClick={() => toggleOption('caseSensitive')}
           >
@@ -96,8 +98,8 @@ export const NoteFindBar = ({ editor, onClose }: Props) => {
             type="button"
             className={`note-find-opt${options.wholeWord ? ' note-find-opt--on' : ''}`}
             aria-pressed={options.wholeWord}
-            aria-label="Whole word"
-            title="Whole word"
+            aria-label={t('noteFind.wholeWord')}
+            title={t('noteFind.wholeWord')}
             onMouseDown={(e) => e.preventDefault()}
             onClick={() => toggleOption('wholeWord')}
           >
@@ -107,8 +109,8 @@ export const NoteFindBar = ({ editor, onClose }: Props) => {
             type="button"
             className={`note-find-opt${options.regex ? ' note-find-opt--on' : ''}`}
             aria-pressed={options.regex}
-            aria-label="Use regular expression"
-            title="Regular expression"
+            aria-label={t('noteFind.regex')}
+            title={t('noteFind.regex')}
             onMouseDown={(e) => e.preventDefault()}
             onClick={() => toggleOption('regex')}
           >
@@ -117,7 +119,7 @@ export const NoteFindBar = ({ editor, onClose }: Props) => {
         </div>
         <span
           className="note-find-count"
-          title={invalid ? 'Invalid regular expression' : undefined}
+          title={invalid ? t('noteFind.invalidRegex') : undefined}
         >
           {invalid ? '!' : total > 0 ? `${current}/${total}` : query ? '0/0' : ''}
         </span>
@@ -125,7 +127,7 @@ export const NoteFindBar = ({ editor, onClose }: Props) => {
           className="note-find-nav"
           onClick={() => navigateNoteSearch(editor.view, -1)}
           disabled={total === 0}
-          title="Previous (Shift+Enter)"
+          title={t('noteFind.previous')}
         >
           ‹
         </button>
@@ -133,11 +135,11 @@ export const NoteFindBar = ({ editor, onClose }: Props) => {
           className="note-find-nav"
           onClick={() => navigateNoteSearch(editor.view, 1)}
           disabled={total === 0}
-          title="Next (Enter)"
+          title={t('noteFind.next')}
         >
           ›
         </button>
-        <button className="note-find-close" onClick={onClose} title="Close (Esc)">
+        <button className="note-find-close" onClick={onClose} title={t('noteFind.close')}>
           ×
         </button>
       </div>
@@ -146,7 +148,7 @@ export const NoteFindBar = ({ editor, onClose }: Props) => {
           <span className="note-find-toggle note-find-toggle--spacer" />
           <input
             className="note-find-input"
-            placeholder="Replace"
+            placeholder={t('noteFind.replacePlaceholder')}
             value={replacement}
             onChange={(e) => setReplacement(e.target.value)}
             onKeyDown={(e) => {
@@ -165,14 +167,14 @@ export const NoteFindBar = ({ editor, onClose }: Props) => {
             onClick={() => replaceCurrentMatch(editor.view, replacement)}
             disabled={total === 0}
           >
-            Replace
+            {t('noteFind.replace')}
           </button>
           <button
             className="note-find-action"
             onClick={() => replaceAllMatches(editor.view, replacement)}
             disabled={total === 0}
           >
-            All
+            {t('noteFind.replaceAll')}
           </button>
         </div>
       )}

--- a/apps/canvas-workspace/src/renderer/src/components/NoteOutline/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/NoteOutline/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import './index.css';
 import type { Editor } from '@tiptap/react';
+import { useI18n } from '../../i18n';
 
 interface HeadingItem {
   pos: number;
@@ -35,6 +36,7 @@ interface Props {
 }
 
 export const NoteOutline = ({ editor, onClose }: Props) => {
+  const { t } = useI18n();
   const [headings, setHeadings] = useState<HeadingItem[]>(() => computeHeadings(editor));
   const [activePos, setActivePos] = useState<number | null>(null);
 
@@ -73,18 +75,18 @@ export const NoteOutline = ({ editor, onClose }: Props) => {
   return (
     <div className="note-outline" onMouseDown={(e) => e.stopPropagation()}>
       <div className="note-outline-head">
-        <span className="note-outline-title">Outline</span>
+        <span className="note-outline-title">{t('noteOutline.title')}</span>
         <button
           className="note-outline-close"
           onClick={onClose}
-          title="Close outline"
-          aria-label="Close outline"
+          title={t('noteOutline.close')}
+          aria-label={t('noteOutline.close')}
         >
           ×
         </button>
       </div>
       {headings.length === 0 ? (
-        <div className="note-outline-empty">No headings yet</div>
+        <div className="note-outline-empty">{t('noteOutline.empty')}</div>
       ) : (
         <ul className="note-outline-list">
           {headings.map((h, i) => (
@@ -95,9 +97,9 @@ export const NoteOutline = ({ editor, onClose }: Props) => {
                   h.pos === activePos ? ' note-outline-item--active' : ''
                 }`}
                 onClick={() => goTo(h.pos)}
-                title={h.text || 'Untitled'}
+                title={h.text || t('app.untitledWorkspace')}
               >
-                {h.text || 'Untitled'}
+                {h.text || t('app.untitledWorkspace')}
               </button>
             </li>
           ))}

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/index.tsx
@@ -60,14 +60,14 @@ function clampWidth(value: number): number {
   return Math.min(max, Math.max(MIN_WIDTH, value));
 }
 
-interface RightDockProps {
+interface Props {
   activeWorkspaceId: string;
   chatTabEnabled: boolean;
   workspaces: WorkspaceEntry[];
   onOpenNodePage: (workspaceId: string, nodeId: string) => void;
 }
 
-export const RightDock = ({ activeWorkspaceId, chatTabEnabled, workspaces, onOpenNodePage }: RightDockProps) => {
+export const RightDock = ({ activeWorkspaceId, chatTabEnabled, workspaces, onOpenNodePage }: Props) => {
   const { store, setChatHost, setTerminalHost, pinUrlReference, addDomSelectionToChat } = useDockContext();
   const state = useRightDockState();
   const { t } = useI18n();

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
@@ -10,7 +10,9 @@ import { useI18n } from '../../i18n';
 import { Button, FieldRow, Select } from '../ui';
 import './AgentSection.css';
 
-const AgentShellPathCard = lazy(() => import('./AgentShellPathCard'));
+const AgentShellPathCard = lazy(() =>
+  import('./AgentShellPathCard').then((module) => ({ default: module.AgentShellPathCard }))
+);
 
 interface AgentSectionProps {
   onClose: () => void;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
@@ -4,30 +4,22 @@ import { useAppShell } from '../AppShellProvider';
 import { useI18n } from '../../i18n';
 import { Button } from '../ui';
 
-interface AgentShellPathCardProps {
+interface Props {
   shellPath: ShellPathResult;
   onConfigured: () => Promise<void>;
 }
 
-const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps) => {
+export const AgentShellPathCard = ({ shellPath, onConfigured }: Props) => {
   const { notify } = useAppShell();
-  const { language, t } = useI18n();
+  const { t } = useI18n();
   const [configuring, setConfiguring] = useState(false);
-  const copy = language === 'zh'
-    ? {
-        title: '终端命令',
-        ready: (profile: string) => `已在 ${profile} 中配置 pulse-canvas。打开新终端后即可使用。`,
-        setup: (profile: string) => `将托管 CLI 目录加入 ${profile}，之后可在新终端中直接运行 pulse-canvas。`,
-        configure: '配置 PATH',
-        unsupported: '自动配置仅支持 zsh、bash 和 fish。请手动执行下面的命令。',
-      }
-    : {
-        title: 'Terminal command',
-        ready: (profile: string) => `pulse-canvas is configured in ${profile}. Open a new terminal to use it.`,
-        setup: (profile: string) => `Add the managed CLI directory to ${profile} so new terminals can run pulse-canvas directly.`,
-        configure: 'Configure PATH',
-        unsupported: 'Automatic setup supports zsh, bash, and fish. Run the command below manually.',
-      };
+  const copy = {
+    title: t('settings.shellPath.title'),
+    ready: (profile: string) => t('settings.shellPath.ready', { profile }),
+    setup: (profile: string) => t('settings.shellPath.setup', { profile }),
+    configure: t('settings.shellPath.configure'),
+    unsupported: t('settings.shellPath.unsupported'),
+  };
 
   const configure = async () => {
     setConfiguring(true);
@@ -71,5 +63,3 @@ const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps
     </div>
   );
 };
-
-export default AgentShellPathCard;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/index.tsx
@@ -110,13 +110,13 @@ const SECTIONS: SectionDef[] = [
   },
 ];
 
-interface SettingsProps {
+interface Props {
   open: boolean;
   initialSection: SettingsSection;
   onClose: () => void;
 }
 
-export const Settings = ({ open, initialSection, onClose }: SettingsProps) => {
+export const Settings = ({ open, initialSection, onClose }: Props) => {
   const { t } = useI18n();
   const [activeSection, setActiveSection] = useState<SettingsSection>(initialSection);
   const canvasModels = useCanvasModels();

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/index.css
@@ -1,0 +1,21 @@
+.canvas-viewport {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+  height: 100%;
+  min-height: 0;
+}
+
+.canvas-host {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.canvas-host__main {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+}

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/index.tsx
@@ -1,5 +1,6 @@
 import React, { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import './index.css';
 import { Canvas } from '../Canvas';
 import { FileNodeEditorRegistryProvider } from '../../hooks/useFileNodeEditorRegistry';
 import { ChatPanelLazy as ChatPanel } from '../chat/lazy';

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
@@ -16,8 +16,10 @@ import {
   parseVisualToolResult,
 } from '../artifacts';
 import { CopyGeneratedImageButton, parseGeneratedImage } from './GeneratedImageActions';
+import { useI18n } from '../../i18n';
 
 const CopyMessageButton = memo(({ content }: { content: string }) => {
+  const { t } = useI18n();
   const [copied, setCopied] = useState(false);
   const handleCopy = useCallback(async () => {
     try {
@@ -32,8 +34,8 @@ const CopyMessageButton = memo(({ content }: { content: string }) => {
     <button
       type="button"
       className={`chat-message-toolbar-btn chat-message-toolbar-btn--icon${copied ? ' chat-message-toolbar-btn--copied' : ''}`}
-      title={copied ? 'Copied!' : 'Copy message (markdown source)'}
-      aria-label="Copy message"
+      title={copied ? t('chatMessage.copied') : t('chatMessage.copy')}
+      aria-label={t('chatMessage.copyAriaLabel')}
       onClick={handleCopy}
     >
       {copied ? <CheckIcon size={12} strokeWidth={1.8} /> : <CopyIcon size={12} />}
@@ -94,6 +96,7 @@ export const ChatMessage = ({
   onRegenerate,
   onSessionJump,
 }: ChatMessageProps) => {
+  const { t } = useI18n();
   const assistantHtml = useMemo(
     () => (message.role === 'assistant'
       ? renderMdWithMentions(message.content, nodes, { streaming: isStreaming, rootFolder })
@@ -429,8 +432,8 @@ export const ChatMessage = ({
             <button
               type="button"
               className="chat-message-toolbar-btn chat-message-toolbar-btn--icon"
-              title="Edit & resend"
-              aria-label="Edit and resend"
+              title={t('chatMessage.editResend')}
+              aria-label={t('chatMessage.editResendAriaLabel')}
               onClick={handleStartEdit}
             >
               <PencilIcon size={12} />
@@ -440,8 +443,8 @@ export const ChatMessage = ({
             <button
               type="button"
               className="chat-message-toolbar-btn chat-message-toolbar-btn--icon"
-              title="Regenerate response"
-              aria-label="Regenerate response"
+              title={t('chatMessage.regenerate')}
+              aria-label={t('chatMessage.regenerate')}
               onClick={handleRegenerate}
             >
               <RefreshIcon size={12} />

--- a/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
+++ b/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
@@ -1350,6 +1350,38 @@ const en = {
   'migration.toast.pollutionDesc': 'Migration was refused to prevent data loss. Use canvas-cli restore or refer to the docs to recover.',
   'migration.toast.auditTitle': 'Storage corruption detected in workspace "{workspaceId}"',
   'migration.toast.auditDesc': '{count} node(s) still have their real data in nodes/, but canvas.json was clobbered by a legacy tool. Run `canvas-cli restore apply {workspaceId} --from <snapshot>` to recover.',
+
+  'settings.shellPath.title': 'Terminal command',
+  'settings.shellPath.ready': 'pulse-canvas is configured in {profile}. Open a new terminal to use it.',
+  'settings.shellPath.setup': 'Add the managed CLI directory to {profile} so new terminals can run pulse-canvas directly.',
+  'settings.shellPath.configure': 'Configure PATH',
+  'settings.shellPath.unsupported': 'Automatic setup supports zsh, bash, and fish. Run the command below manually.',
+
+  'noteFind.hideReplace': 'Hide replace',
+  'noteFind.showReplace': 'Show replace',
+  'noteFind.findPlaceholder': 'Find',
+  'noteFind.searchOptions': 'Search options',
+  'noteFind.matchCase': 'Match case',
+  'noteFind.wholeWord': 'Whole word',
+  'noteFind.regex': 'Use regular expression',
+  'noteFind.invalidRegex': 'Invalid regular expression',
+  'noteFind.previous': 'Previous (Shift+Enter)',
+  'noteFind.next': 'Next (Enter)',
+  'noteFind.close': 'Close (Esc)',
+  'noteFind.replacePlaceholder': 'Replace',
+  'noteFind.replace': 'Replace',
+  'noteFind.replaceAll': 'All',
+
+  'noteOutline.title': 'Outline',
+  'noteOutline.close': 'Close outline',
+  'noteOutline.empty': 'No headings yet',
+
+  'chatMessage.copy': 'Copy message (markdown source)',
+  'chatMessage.copied': 'Copied!',
+  'chatMessage.copyAriaLabel': 'Copy message',
+  'chatMessage.editResend': 'Edit & resend',
+  'chatMessage.editResendAriaLabel': 'Edit and resend',
+  'chatMessage.regenerate': 'Regenerate response',
 } as const;
 
 const zh: Record<keyof typeof en, string> = {
@@ -2689,6 +2721,38 @@ const zh: Record<keyof typeof en, string> = {
   'migration.toast.pollutionDesc': '已拒绝执行迁移以防止数据丢失。请使用 canvas-cli restore 或参考文档恢复。',
   'migration.toast.auditTitle': '工作区 "{workspaceId}" 检测到存储污染',
   'migration.toast.auditDesc': '{count} 个节点的真实数据仍在 nodes/ 中，但 canvas.json 已被旧版工具破坏。请使用 `canvas-cli restore apply {workspaceId} --from <snapshot>` 恢复。',
+
+  'settings.shellPath.title': '终端命令',
+  'settings.shellPath.ready': '已在 {profile} 中配置 pulse-canvas。打开新终端后即可使用。',
+  'settings.shellPath.setup': '将托管 CLI 目录加入 {profile}，之后可在新终端中直接运行 pulse-canvas。',
+  'settings.shellPath.configure': '配置 PATH',
+  'settings.shellPath.unsupported': '自动配置仅支持 zsh、bash 和 fish。请手动执行下面的命令。',
+
+  'noteFind.hideReplace': '隐藏替换',
+  'noteFind.showReplace': '显示替换',
+  'noteFind.findPlaceholder': '查找',
+  'noteFind.searchOptions': '搜索选项',
+  'noteFind.matchCase': '区分大小写',
+  'noteFind.wholeWord': '全字匹配',
+  'noteFind.regex': '使用正则表达式',
+  'noteFind.invalidRegex': '正则表达式无效',
+  'noteFind.previous': '上一个 (Shift+Enter)',
+  'noteFind.next': '下一个 (Enter)',
+  'noteFind.close': '关闭 (Esc)',
+  'noteFind.replacePlaceholder': '替换',
+  'noteFind.replace': '替换',
+  'noteFind.replaceAll': '全部',
+
+  'noteOutline.title': '大纲',
+  'noteOutline.close': '关闭大纲',
+  'noteOutline.empty': '暂无标题',
+
+  'chatMessage.copy': '复制消息（Markdown 源码）',
+  'chatMessage.copied': '已复制！',
+  'chatMessage.copyAriaLabel': '复制消息',
+  'chatMessage.editResend': '编辑并重新发送',
+  'chatMessage.editResendAriaLabel': '编辑并重新发送',
+  'chatMessage.regenerate': '重新生成回复',
 };
 
 export const messages = {


### PR DESCRIPTION
## Summary

Scanned `apps/canvas-workspace`'s React renderer against its own style guide (`apps/canvas-workspace/harness/knowledge/conventions/frontend.md`) and fixed the genuine drift found. The token-literal side of the style guide (colors/radius/shadows/z-index) is already mechanically enforced by `ui-reuse-governance.test.ts`, which currently passes with no drift — this PR only covers what that ratchet doesn't check.

- **Component exports/naming** (`c800df4`, `57f2ef4`): `frontend.md` requires named arrow-function exports (no `export default`) and a local `Props` interface name.
  - `MigrationSpinner` had a redundant `export default` alongside its named export.
  - `AgentTeamFrame`, `RightDock`, `Settings`, and `AgentShellPathCard` used `*Props`-named interfaces instead of the local `Props` convention; `AgentShellPathCard` also used `export default` — its `lazy()` import site in `AgentSection.tsx` is updated to match.
- **CSS colocation** (`0f09e6c`): `frontend.md` requires colocated `index.css`, imported from the component.
  - `CanvasAlignmentGuides` had a fixed inline `style={{...}}` object with no dynamic values — moved to a new colocated `index.css`.
  - `Workbench` had no `index.css` at all; its `.canvas-viewport`/`.canvas-host`/`.canvas-host__main` rules lived in the unrelated top-level `App.css` and are used nowhere else — moved into a new `Workbench/index.css`. No values changed.
- **i18n** (`57f2ef4`): `frontend.md` forbids hardcoded user-facing strings in favor of `useI18n()`.
  - `AgentShellPathCard` hand-rolled its own bilingual `copy` object instead of using the message catalog.
  - `NoteFindBar`, `NoteOutline`, and `ChatMessage`'s toolbar buttons had no `useI18n()` wiring at all for their titles/aria-labels/placeholders.
  - Added the missing keys (en + zh) to `i18n/messages.ts`; reused the existing `app.untitledWorkspace` key for `NoteOutline`'s "Untitled" fallback instead of adding a duplicate.

Out of scope (flagged but not fixed here, too large/risky for a mechanical pass): `AgentTeamFrame/index.tsx` is ~2,232 lines with no controller-hook/sub-component split, and `settings-config/SkillsManager.tsx` (498 lines) lacks the controller-hook pattern its sibling `McpManager` uses. Both would need a real refactor, not a drive-by fix.

## Test plan

- [x] `pnpm --filter canvas-workspace typecheck` — passes, including a per-commit check (each of the 3 commits typechecks in isolation)
- [x] `pnpm --filter canvas-workspace test` — 217 test files / 1477 passed, 1 pre-existing skip
- [x] `ui-reuse-governance.test.ts` / `file-size-governance.test.ts` / `import-boundaries.test.ts` — all pass, no ratchet regressions
- [x] `pnpm --filter canvas-workspace build` — succeeds

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017sYvfV7HoXkN7echk3DF2Q

---
_Generated by [Claude Code](https://claude.ai/code/session_017sYvfV7HoXkN7echk3DF2Q)_