### PR TITLE
style(canvas-workspace): remove default exports from two components

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
@@ -10,7 +10,9 @@ import { useI18n } from '../../i18n';
 import { Button, FieldRow, Select } from '../ui';
 import './AgentSection.css';
 
-const AgentShellPathCard = lazy(() => import('./AgentShellPathCard'));
+const AgentShellPathCard = lazy(() =>
+  import('./AgentShellPathCard').then((module) => ({ default: module.AgentShellPathCard }))
+);
 
 interface AgentSectionProps {
   onClose: () => void;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
@@ -9,7 +9,7 @@ interface AgentShellPathCardProps {
   onConfigured: () => Promise<void>;
 }
 
-const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps) => {
+export const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps) => {
   const { notify } = useAppShell();
   const { language, t } = useI18n();
   const [configuring, setConfiguring] = useState(false);
@@ -71,5 +71,3 @@ const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps
     </div>
   );
 };
-
-export default AgentShellPathCard;


### PR DESCRIPTION
## Summary

Scoped audit of `apps/canvas-workspace` renderer components against the documented style guide (`harness/knowledge/conventions/frontend.md`), which requires:

> Export **named arrow-function components**... Avoid `default` exports for components.

This convention isn't covered by the existing `ui-reuse-governance.test.ts` ratchet (which both pass cleanly with zero drift — the codebase's tracked UI-consistency debt is otherwise well-governed and intentionally deferred, so this PR does not touch that backlog). Grepping for `export default` under `src/renderer/src/components` turned up exactly two component files that violate the named-export rule:

- **`MigrationSpinner/index.tsx`** — already exports the component as `export const MigrationSpinner = ...`, which is what its only caller (`App.tsx`, via `lazy().then(module => ({ default: module.MigrationSpinner }))`) actually imports. The trailing `export default MigrationSpinner;` was dead code that nothing referenced — removed.
- **`Settings/AgentShellPathCard.tsx`** — was default-export-only, loaded via `lazy(() => import('./AgentShellPathCard'))`. Converted to `export const AgentShellPathCard = ...` and updated its one caller (`AgentSection.tsx`) to the same `lazy().then(module => ({ default: module.AgentShellPathCard }))` pattern already established by `MigrationSpinner`'s import site.

No behavior change — both components render identically; this only aligns their export shape with the rest of the codebase and removes a small amount of dead code.

## Test plan
- [x] `pnpm --filter canvas-workspace typecheck` — passes
- [x] `pnpm --filter canvas-workspace test` — 217 test files / 1478 tests pass, 1 skipped (unchanged)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01KfEVCkuFFthhx85Lywc8eX

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfEVCkuFFthhx85Lywc8eX)_