### PR TITLE
fix(canvas-workspace): default-browser cold start no longer restores stale tab

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -132,7 +132,7 @@ const AppContent = () => {
   const {
     workspaces,
     folders,
-    activeId,
+    activeId, activeIdReady,
     selectWorkspace,
     createWorkspace,
     renameWorkspace,
@@ -580,7 +580,7 @@ const AppContent = () => {
         </PulseRouter>
       </div>
       <GlobalChatLauncher visible={activeView !== 'canvas' && activeView !== 'chat'} />
-      <RightDock workspaces={workspaces} activeWorkspaceId={activeId} chatTabEnabled={activeView !== 'chat'} onOpenNodePage={openNodePage} />
+      <RightDock workspaces={workspaces} activeWorkspaceId={activeId} activeIdReady={activeIdReady} chatTabEnabled={activeView !== 'chat'} onOpenNodePage={openNodePage} />
       <Suspense fallback={null}><MigrationSpinner /></Suspense>
       <DeferredSettings
         appLoaded={appSettingsLoaded}

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/index.tsx
@@ -62,12 +62,14 @@ function clampWidth(value: number): number {
 
 interface RightDockProps {
   activeWorkspaceId: string;
+  /** False until `activeWorkspaceId` has resolved past its mount-time placeholder. */
+  activeIdReady: boolean;
   chatTabEnabled: boolean;
   workspaces: WorkspaceEntry[];
   onOpenNodePage: (workspaceId: string, nodeId: string) => void;
 }
 
-export const RightDock = ({ activeWorkspaceId, chatTabEnabled, workspaces, onOpenNodePage }: RightDockProps) => {
+export const RightDock = ({ activeWorkspaceId, activeIdReady, chatTabEnabled, workspaces, onOpenNodePage }: RightDockProps) => {
   const { store, setChatHost, setTerminalHost, pinUrlReference, addDomSelectionToChat } = useDockContext();
   const state = useRightDockState();
   const { t } = useI18n();
@@ -82,7 +84,9 @@ export const RightDock = ({ activeWorkspaceId, chatTabEnabled, workspaces, onOpe
   useDockAgentBridge(store, state, activeWorkspaceId);
 
   // Cold start: drain URLs the OS queued before this dock could subscribe.
-  useConsumePendingLinks((url) => store.openLink(url));
+  // Gated on activeIdReady so the tab lands in the real workspace instead of
+  // the mount-time placeholder (see useConsumePendingLinks for why).
+  useConsumePendingLinks((url) => store.openLink(url), activeIdReady);
 
   useEffect(() => {
     if (chatTabEnabled) return;

--- a/apps/canvas-workspace/src/renderer/src/hooks/useConsumePendingLinks.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useConsumePendingLinks.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment happy-dom
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useConsumePendingLinks } from './useConsumePendingLinks';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let host: HTMLDivElement | null = null;
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  host?.remove();
+  root = null;
+  host = null;
+  delete (globalThis as { canvasWorkspace?: unknown }).canvasWorkspace;
+});
+
+function setConsumePending(consumePending: () => Promise<{ urls: string[] }>): void {
+  (globalThis as { canvasWorkspace?: unknown }).canvasWorkspace = {
+    defaultBrowser: { consumePending },
+  };
+}
+
+function mountProbe(open: (url: string) => void, initialReady: boolean): { setReady: (ready: boolean) => void } {
+  const Probe = ({ ready }: { ready: boolean }) => {
+    useConsumePendingLinks(open, ready);
+    return null;
+  };
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+  act(() => {
+    root?.render(<Probe ready={initialReady} />);
+  });
+  return {
+    setReady: (ready: boolean) => {
+      act(() => {
+        root?.render(<Probe ready={ready} />);
+      });
+    },
+  };
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+describe('useConsumePendingLinks', () => {
+  it('does not drain pending urls while ready is false', async () => {
+    const consumePending = vi.fn().mockResolvedValue({ urls: ['https://example.com'] });
+    setConsumePending(consumePending);
+    const open = vi.fn();
+
+    mountProbe(open, false);
+    await flush();
+
+    expect(consumePending).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it('drains queued urls in order once ready flips true', async () => {
+    const consumePending = vi.fn().mockResolvedValue({ urls: ['https://a.example', 'https://b.example'] });
+    setConsumePending(consumePending);
+    const open = vi.fn();
+
+    const probe = mountProbe(open, false);
+    await flush();
+    expect(open).not.toHaveBeenCalled();
+
+    probe.setReady(true);
+    await flush();
+
+    expect(consumePending).toHaveBeenCalledTimes(1);
+    expect(open.mock.calls.map((call) => call[0])).toEqual(['https://a.example', 'https://b.example']);
+  });
+
+  it('does not re-drain on a later render once already ready', async () => {
+    const consumePending = vi.fn().mockResolvedValue({ urls: ['https://a.example'] });
+    setConsumePending(consumePending);
+    const open = vi.fn();
+
+    const probe = mountProbe(open, true);
+    await flush();
+    expect(consumePending).toHaveBeenCalledTimes(1);
+
+    // A re-render that keeps ready=true (e.g. a sibling state change) must
+    // not trigger a second drain of an already-empty queue.
+    probe.setReady(true);
+    await flush();
+    expect(consumePending).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/hooks/useConsumePendingLinks.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useConsumePendingLinks.ts
@@ -5,9 +5,16 @@ import { useEffect } from 'react';
  * could receive them — a cold start launched by a default-browser link
  * activation. Warm activations arrive over `link:open` instead, so this only
  * covers the launch case. `open` is invoked once per queued URL.
+ *
+ * `ready` must stay false until the caller's active workspace has resolved
+ * past its mount-time placeholder. Draining earlier races the (fast,
+ * in-memory) pending-URL fetch against the (slower, disk-backed) workspace
+ * restore: `open` would create the tab against the placeholder workspace,
+ * which the restore then overwrites with its stale persisted session.
  */
-export function useConsumePendingLinks(open: (url: string) => void): void {
+export function useConsumePendingLinks(open: (url: string) => void, ready: boolean): void {
   useEffect(() => {
+    if (!ready) return;
     let cancelled = false;
     void window.canvasWorkspace.defaultBrowser
       .consumePending()
@@ -19,7 +26,8 @@ export function useConsumePendingLinks(open: (url: string) => void): void {
     return () => {
       cancelled = true;
     };
-    // Intentionally mount-only: pending URLs are drained once at startup.
+    // `open` is intentionally excluded: pending URLs are drained once, the
+    // first time `ready` flips true, not on every identity change of `open`.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [ready]);
 }

--- a/apps/canvas-workspace/src/renderer/src/hooks/useWorkspaces.activeIdReady.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useWorkspaces.activeIdReady.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment happy-dom
+// Regression coverage for the deep-link cold-start race: a default-browser
+// link activation must not land its new tab in the mount-time 'default'
+// placeholder workspace, only to have the real persisted workspace restore
+// wipe it out once the manifest finishes loading. useConsumePendingLinks
+// gates on activeIdReady instead of the raw activeId for exactly this
+// reason — these tests pin the invariant it relies on: activeId is already
+// final by the render where activeIdReady first turns true.
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useWorkspaces } from './useWorkspaces';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let host: HTMLDivElement | null = null;
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  host?.remove();
+  root = null;
+  host = null;
+  delete (globalThis as { canvasWorkspace?: unknown }).canvasWorkspace;
+});
+
+type LogEntry = { activeId: string; activeIdReady: boolean };
+
+function renderWorkspacesProbe(): { log: LogEntry[] } {
+  const log: LogEntry[] = [];
+  const Probe = () => {
+    const { activeId, activeIdReady } = useWorkspaces();
+    log.push({ activeId, activeIdReady });
+    return null;
+  };
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+  act(() => {
+    root?.render(<Probe />);
+  });
+  return { log };
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+describe('useWorkspaces activeIdReady', () => {
+  it('never reports ready while activeId is still the mount-time placeholder', async () => {
+    const load = vi.fn().mockResolvedValue({
+      ok: true,
+      data: {
+        workspaces: [{ id: 'default', name: 'Workspace' }, { id: 'ws-a', name: 'A' }],
+        activeId: 'ws-a',
+      },
+    });
+    (globalThis as { canvasWorkspace?: unknown }).canvasWorkspace = { store: { load, save: vi.fn() } };
+
+    const { log } = renderWorkspacesProbe();
+    expect(log[0]).toEqual({ activeId: 'default', activeIdReady: false });
+
+    await flush();
+
+    const firstReady = log.find((entry) => entry.activeIdReady);
+    expect(firstReady).toEqual({ activeId: 'ws-a', activeIdReady: true });
+  });
+
+  it('still settles activeIdReady when the manifest load rejects', async () => {
+    const load = vi.fn().mockRejectedValue(new Error('disk error'));
+    (globalThis as { canvasWorkspace?: unknown }).canvasWorkspace = { store: { load, save: vi.fn() } };
+
+    const { log } = renderWorkspacesProbe();
+    await flush();
+
+    expect(log.at(-1)).toEqual({ activeId: 'default', activeIdReady: true });
+  });
+
+  it('settles activeIdReady immediately when the store bridge is unavailable', async () => {
+    delete (globalThis as { canvasWorkspace?: unknown }).canvasWorkspace;
+
+    const { log } = renderWorkspacesProbe();
+    await flush();
+
+    expect(log.at(-1)).toEqual({ activeId: 'default', activeIdReady: true });
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/hooks/useWorkspaces.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useWorkspaces.ts
@@ -68,6 +68,11 @@ export const useWorkspaces = () => {
   const [workspaces, setWorkspaces] = useState<WorkspaceEntry[]>([DEFAULT_WORKSPACE]);
   const [folders, setFolders] = useState<FolderEntry[]>([]);
   const [activeId, setActiveId] = useState('default');
+  // `activeId` starts as a placeholder until the persisted manifest load
+  // below settles — consumers that must not act on the placeholder (e.g.
+  // draining deep-link URLs into the right workspace) gate on this instead
+  // of assuming the mount-time value is final.
+  const [activeIdReady, setActiveIdReady] = useState(false);
   const activeIdRef = useRef(activeId);
   activeIdRef.current = activeId;
   const workspacesRef = useRef(workspaces);
@@ -77,7 +82,10 @@ export const useWorkspaces = () => {
 
   useEffect(() => {
     const api = window.canvasWorkspace?.store;
-    if (!api) return;
+    if (!api) {
+      setActiveIdReady(true);
+      return;
+    }
     void api.load(MANIFEST_ID).then((res) => {
       if (res.ok && res.data) {
         const manifest = res.data as unknown as WorkspaceManifest;
@@ -95,7 +103,7 @@ export const useWorkspaces = () => {
       } else {
         void api.save(MANIFEST_ID, { workspaces: [DEFAULT_WORKSPACE], folders: [], activeId: 'default' });
       }
-    });
+    }).catch(() => undefined).finally(() => setActiveIdReady(true));
   }, []);
 
   const saveManifest = useCallback(
@@ -362,6 +370,7 @@ export const useWorkspaces = () => {
     workspaces,
     folders,
     activeId,
+    activeIdReady,
     selectWorkspace,
     createWorkspace,
     renameWorkspace,


### PR DESCRIPTION
Cold-starting Pulse Canvas via a default-browser link activation raced two
independent renderer effects: the (fast, in-memory) pending-URL drain that
opens the clicked link's tab, and the (slower, disk-backed) workspace
manifest load that restores the last-active workspace. Because the manifest
load resolves later, it re-fires RightDock's setActiveWorkspace with the
real workspace id, which unconditionally swaps in that workspace's
persisted link-tab session — wiping out the tab just opened for the link
that launched the app.

Gate pending-URL draining on a new activeIdReady flag from useWorkspaces so
it only runs once the active workspace has resolved past its mount-time
placeholder. The new tab then lands in the already-final workspace and
survives.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LkGMVu1cBXy8eBRDy5PPeD