### PR TITLE
fix(canvas): stop the agent from over-opening dock tabs

### DIFF
--- a/apps/canvas-workspace/src/main/agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/agent/canvas-agent.ts
@@ -198,6 +198,8 @@ The following tools are loaded and callable directly. Grouped by intent:
 - UI: \`page_*\` / \`canvas_host_eval\`.
 - **Right-dock tabs**: \`canvas_list_tabs\` discovers link, artifact, node-detail, canvas-preview, and terminal tabs; \`canvas_activate_tab\` brings one to the front; \`canvas_execute_terminal_tab\` runs a command in an open Dock terminal. Continue to use the resource-specific tools for page, artifact, node, and canvas content changes.
 
+**When to open a tab (strict) — \`canvas_open_tab\`:** opening a tab is a **user-visible UI action** — it pops a new tab into the user's dock and spawns a live webview. Do NOT open a tab just to read or research a URL. To get content from a web page, use \`tavily_extract\` (fetch a specific URL) or \`tavily\` (search), and \`canvas_read_webpage\` / \`canvas_read_tab\` for pages already open on the canvas or dock. Only call \`canvas_open_tab\` when the user **explicitly** asks to open / show / pull up a page in their dock, or when they want to interact with a live page (click / fill / navigate via \`page_*\`) that isn't open yet. When in doubt, fetch silently instead of opening a tab.
+
 ## Visualization Tools — visual_render is the DEFAULT
 
 **Default to \`visual_render\` for ANY visual request.** It renders inline in the chat, streams live, and the user can promote it to an artifact themselves if they want to keep it. Don't reach for \`artifact_create\` just because the visual is large or polished — inline can handle dashboards, full pages, complex charts. Inline is the right home for *most* visual answers.

--- a/apps/canvas-workspace/src/main/agent/tools/tab.ts
+++ b/apps/canvas-workspace/src/main/agent/tools/tab.ts
@@ -63,7 +63,7 @@ export function createTabTools(workspaceId: string): Record<string, CanvasTool> 
       description:
         'List open right-dock tabs: link, node-detail, artifact, canvas preview, and terminal. ' +
         'Returns ids for `canvas_read_tab`, `canvas_activate_tab`, and resource-specific tools. ' +
-        'For link tabs, use the tab id with `canvas_open_tab` or enabled page_* controls.',
+        'For a link tab already open here, read it with `canvas_read_tab` (or drive it with enabled page_* controls).',
       inputSchema: z.object({}),
       execute: async (input, ctx) => {
         const targetWorkspaceId = (input.workspaceId as string) || workspaceId;
@@ -102,9 +102,11 @@ export function createTabTools(workspaceId: string): Record<string, CanvasTool> 
       name: 'canvas_open_tab',
       defer_loading: true,
       description:
-        'Open an http(s) URL in a right-dock link tab. Omit tabId to open or reactivate by URL; ' +
-        'pass a link tabId from canvas_list_tabs to navigate that tab in place. ' +
-        'Then list tabs to confirm its id and use canvas_read_tab or enabled page_* controls.',
+        'Open an http(s) URL as a visible right-dock link tab in the user\'s dock (spawns a live webview). ' +
+        'This is a user-facing UI action — use it ONLY when the user explicitly asks to open/show a page, ' +
+        'or when they want to interact with a live page (page_* click/fill/navigate) that is not open yet. ' +
+        'To merely read or research a URL, do NOT open a tab: use tavily_extract / tavily, or canvas_read_webpage / canvas_read_tab for pages already open. ' +
+        'Omit tabId to open or reactivate by URL; pass a link tabId from canvas_list_tabs to navigate that tab in place.',
       inputSchema: z.object({
         url: z.string().describe('The http(s) URL to open.'),
         tabId: z
@@ -129,7 +131,8 @@ export function createTabTools(workspaceId: string): Record<string, CanvasTool> 
       defer_loading: true,
       description:
         'Search right-dock web-tab history by URL/title. All terms match case-insensitively; ' +
-        'results are newest first. Empty query returns recent pages. Reopen with canvas_open_tab.',
+        'results are newest first. Empty query returns recent pages. ' +
+        'If the user explicitly wants a result reopened in their dock, use canvas_open_tab.',
       inputSchema: z.object({
         query: z
           .string()


### PR DESCRIPTION
The Canvas Agent reached for `canvas_open_tab` to read/research URLs
because nothing told it to prefer silent fetching, and the tab tool
descriptions cross-sold an open→list→read workflow.

- System prompt now states a strict rule: opening a tab is a
  user-visible UI action; only open on explicit user intent (or to
  interact with a live page). To read a URL, use tavily_extract/tavily
  or canvas_read_webpage/canvas_read_tab.
- Trim the "then list tabs / reopen with canvas_open_tab" cross-sell
  prose from canvas_list_tabs, canvas_open_tab, and
  canvas_search_history descriptions; canvas_open_tab now describes
  itself as an explicit-intent-only UI action.

Prompt/description only — no logic change.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018UxJhQqLb1sqo8mkCRDwvy