### PR TITLE
fix(canvas-workspace): align AgentShellPathCard with component conventions

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
@@ -10,7 +10,9 @@ import { useI18n } from '../../i18n';
 import { Button, FieldRow, Select } from '../ui';
 import './AgentSection.css';
 
-const AgentShellPathCard = lazy(() => import('./AgentShellPathCard'));
+const AgentShellPathCard = lazy(() =>
+  import('./AgentShellPathCard').then((module) => ({ default: module.AgentShellPathCard }))
+);
 
 interface AgentSectionProps {
   onClose: () => void;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
@@ -4,30 +4,15 @@ import { useAppShell } from '../AppShellProvider';
 import { useI18n } from '../../i18n';
 import { Button } from '../ui';
 
-interface AgentShellPathCardProps {
+interface Props {
   shellPath: ShellPathResult;
   onConfigured: () => Promise<void>;
 }
 
-const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps) => {
+export const AgentShellPathCard = ({ shellPath, onConfigured }: Props) => {
   const { notify } = useAppShell();
-  const { language, t } = useI18n();
+  const { t } = useI18n();
   const [configuring, setConfiguring] = useState(false);
-  const copy = language === 'zh'
-    ? {
-        title: '终端命令',
-        ready: (profile: string) => `已在 ${profile} 中配置 pulse-canvas。打开新终端后即可使用。`,
-        setup: (profile: string) => `将托管 CLI 目录加入 ${profile}，之后可在新终端中直接运行 pulse-canvas。`,
-        configure: '配置 PATH',
-        unsupported: '自动配置仅支持 zsh、bash 和 fish。请手动执行下面的命令。',
-      }
-    : {
-        title: 'Terminal command',
-        ready: (profile: string) => `pulse-canvas is configured in ${profile}. Open a new terminal to use it.`,
-        setup: (profile: string) => `Add the managed CLI directory to ${profile} so new terminals can run pulse-canvas directly.`,
-        configure: 'Configure PATH',
-        unsupported: 'Automatic setup supports zsh, bash, and fish. Run the command below manually.',
-      };
 
   const configure = async () => {
     setConfiguring(true);
@@ -37,8 +22,8 @@ const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps
       await onConfigured();
       notify({
         tone: 'success',
-        title: copy.title,
-        description: copy.ready(result.profilePath ?? ''),
+        title: t('agent.shellPathTitle'),
+        description: t('agent.shellPathReady', { profile: result.profilePath ?? '' }),
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -50,13 +35,13 @@ const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps
 
   return (
     <div className="agent-section-cli">
-      <div className="agent-section-cli-title">{copy.title}</div>
+      <div className="agent-section-cli-title">{t('agent.shellPathTitle')}</div>
       <div className="agent-section-cli-desc">
         {shellPath.configured
-          ? copy.ready(shellPath.profilePath ?? '')
+          ? t('agent.shellPathReady', { profile: shellPath.profilePath ?? '' })
           : shellPath.supported
-            ? copy.setup(shellPath.profilePath ?? '')
-            : copy.unsupported}
+            ? t('agent.shellPathSetup', { profile: shellPath.profilePath ?? '' })
+            : t('agent.shellPathUnsupported')}
       </div>
       <div className="agent-section-cli-cmd-row">
         <code className="agent-section-cli-cmd">
@@ -64,12 +49,10 @@ const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps
         </code>
         {shellPath.supported && !shellPath.configured && (
           <Button variant="secondary" size="sm" onClick={() => void configure()} disabled={configuring}>
-            {copy.configure}{configuring ? '…' : ''}
+            {t('agent.shellPathConfigure')}{configuring ? '…' : ''}
           </Button>
         )}
       </div>
     </div>
   );
 };
-
-export default AgentShellPathCard;

--- a/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
+++ b/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
@@ -917,6 +917,11 @@ const en = {
   'agent.removeLegacyDirs': 'Remove legacy dirs',
   'agent.targetsAria': 'Agent integration install targets',
   'agent.close': 'Close',
+  'agent.shellPathTitle': 'Terminal command',
+  'agent.shellPathReady': 'pulse-canvas is configured in {profile}. Open a new terminal to use it.',
+  'agent.shellPathSetup': 'Add the managed CLI directory to {profile} so new terminals can run pulse-canvas directly.',
+  'agent.shellPathConfigure': 'Configure PATH',
+  'agent.shellPathUnsupported': 'Automatic setup supports zsh, bash, and fish. Run the command below manually.',
 
   'experimental.loadFailed': 'Failed to load experimental features',
   'experimental.updateFailed': 'Could not update flag',
@@ -2271,6 +2276,11 @@ const zh: Record<keyof typeof en, string> = {
   'agent.removeLegacyDirs': '移除旧目录',
   'agent.targetsAria': 'Agent 集成安装目标',
   'agent.close': '关闭',
+  'agent.shellPathTitle': '终端命令',
+  'agent.shellPathReady': '已在 {profile} 中配置 pulse-canvas。打开新终端后即可使用。',
+  'agent.shellPathSetup': '将托管 CLI 目录加入 {profile}，之后可在新终端中直接运行 pulse-canvas。',
+  'agent.shellPathConfigure': '配置 PATH',
+  'agent.shellPathUnsupported': '自动配置仅支持 zsh、bash 和 fish。请手动执行下面的命令。',
 
   'experimental.loadFailed': '加载实验功能失败',
   'experimental.updateFailed': '无法更新开关',


### PR DESCRIPTION
## Summary

Scanned `apps/canvas-workspace` against its documented UI style guide (`harness/knowledge/conventions/frontend.md`'s "Component style" and "Copy & i18n" rules) and the mechanized `ui-reuse-governance.test.ts` ratchet. The ratchet itself is currently green (18/18 counters at baseline, no drift), and its own burndown doc (`docs/ui-reuse-burndown.md`) explicitly defers the remaining tracked debt (raw button/input migration, color-literal normalization) to deliberate, visual-diff-gated batches rather than an automated sweep — so this PR does not touch that governed surface.

Outside the ratchet, two files deviated from the documented, un-governed conventions:

- **`AgentShellPathCard.tsx`**: used a default export and a `AgentShellPathCardProps` interface name, against "Export named arrow-function components... avoid default exports" and "name the props interface `Props`". It also hardcoded an inline `language === 'zh' ? {...} : {...}` copy object instead of routing strings through `useI18n()`, against "No hardcoded user-facing strings."
- **`MigrationSpinner/index.tsx`**: carried a redundant, dead `export default` alongside its (already correct, already the only thing imported) named export.

## Changes

- `AgentShellPathCard.tsx`: converted to a named export, renamed the props interface to `Props`, replaced the inline copy object with `t('agent.shellPath*', { profile })` calls.
- `messages.ts`: added the five `agent.shellPath*` keys (en + zh) using the existing `{param}` interpolation pattern, placed alongside the other `agent.*` keys.
- `AgentSection.tsx`: updated the `lazy()` import to pull the named export (`.then((module) => ({ default: module.AgentShellPathCard }))`), matching the pattern already used for `MigrationSpinner` in `App.tsx`.
- `MigrationSpinner/index.tsx`: removed the unused `export default MigrationSpinner`.

No behavior change — same strings render, same lazy-loading shape, same component tree.

## Test plan

- [x] `pnpm --filter canvas-workspace typecheck` — clean
- [x] `pnpm exec vitest run` — 221 test files / 1497 tests passed (1 pre-existing skip), no regressions
- [x] `pnpm exec vitest run src/main/__tests__/ui-reuse-governance.test.ts` — 18/18 still at baseline (this class of fix isn't counter-tracked)
- [x] `node harness/tools/describe-canvas.mjs` — exits 0, no drift

---
_Generated by [Claude Code](https://claude.ai/code/session_016fRJ53G5rmvddvznYRLApv)_