### PR TITLE
Replace interaction shield overlay with pointer-events toggle

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasMouseHandlers.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasMouseHandlers.test.tsx
@@ -156,6 +156,7 @@ describe('useCanvasMouseHandlers synchronous drag shield', () => {
   let root: Root;
   let host: HTMLElement;
   let container: HTMLDivElement;
+  let guestWebview: HTMLElement;
   let hook: ReturnType<typeof useCanvasMouseHandlers>;
 
   /** happy-dom's native MouseEvent does not set defaultPrevented after
@@ -167,7 +168,10 @@ describe('useCanvasMouseHandlers synchronous drag shield', () => {
     return e as React.MouseEvent;
   };
 
-  const findShield = () => container.querySelector('.canvas-interaction-shield');
+  // The shield no longer inserts a DOM node of its own (see
+  // utils/interactionShield.ts) — it toggles pointer-events directly on
+  // every <webview>/<iframe> guest, so assert on that instead.
+  const isShielded = () => guestWebview.style.pointerEvents === 'none';
 
   const Probe = () => {
     hook = useCanvasMouseHandlers({
@@ -209,6 +213,14 @@ describe('useCanvasMouseHandlers synchronous drag shield', () => {
     container = document.createElement('div');
     host.appendChild(container);
     document.body.appendChild(host);
+    // A stand-in guest, appended as a sibling of `host` rather than inside
+    // it: acquireInteractionShield() queries the whole document for
+    // webview/iframe elements (matching a dock link-tab webview, which
+    // doesn't live inside the canvas container either), and React's
+    // createRoot(host) takes ownership of host's children on first render —
+    // anything appended inside host before that render gets wiped.
+    guestWebview = document.createElement('webview');
+    document.body.appendChild(guestWebview);
     root = createRoot(host);
     act(() => root.render(<Probe />));
   });
@@ -216,55 +228,78 @@ describe('useCanvasMouseHandlers synchronous drag shield', () => {
   afterEach(() => {
     act(() => root.unmount());
     host.remove();
+    guestWebview.remove();
   });
 
-  it('mounts the interaction shield synchronously on drag mousedown', () => {
-    expect(findShield()).toBeNull();
+  it('shields guest elements synchronously on drag mousedown', () => {
+    expect(isShielded()).toBe(false);
     act(() => {
       hook.handleSurfaceDragStart(dragEvent(), { id: 'node-1', x: 0, y: 0, width: 200, height: 100 } as any);
     });
-    expect(findShield()).not.toBeNull();
+    expect(isShielded()).toBe(true);
   });
 
-  it('mounts the shield on resize mousedown too', () => {
+  it('shields guest elements on resize mousedown too', () => {
     act(() => {
       hook.handleSurfaceResizeStart(dragEvent(), 'node-1', 300, 200, 'bottom-right');
     });
-    expect(findShield()).not.toBeNull();
+    expect(isShielded()).toBe(true);
   });
 
-  it('removes the shield on mouseup', () => {
+  it('unshields guest elements on mouseup', () => {
     act(() => {
       hook.handleSurfaceDragStart(dragEvent(), { id: 'node-1', x: 0, y: 0, width: 200, height: 100 } as any);
     });
-    expect(findShield()).not.toBeNull();
+    expect(isShielded()).toBe(true);
     act(() => hook.handleMouseUp());
-    expect(findShield()).toBeNull();
+    expect(isShielded()).toBe(false);
   });
 
-  it('removes the shield on Escape', () => {
+  it('unshields guest elements on Escape', () => {
     act(() => {
       hook.handleSurfaceDragStart(dragEvent(), { id: 'node-1', x: 0, y: 0, width: 200, height: 100 } as any);
     });
-    expect(findShield()).not.toBeNull();
+    expect(isShielded()).toBe(true);
     act(() => {
       window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
     });
-    expect(findShield()).toBeNull();
+    expect(isShielded()).toBe(false);
   });
 
-  it('does not mount the shield on alt-drag (pan gesture)', () => {
+  it('does not shield guests on alt-drag (pan gesture)', () => {
     act(() => {
       hook.handleSurfaceDragStart(dragEvent(true), { id: 'node-1', x: 0, y: 0, width: 200, height: 100 } as any);
     });
-    expect(findShield()).toBeNull();
+    expect(isShielded()).toBe(false);
   });
 
-  it('does not double-mount when drag start fires twice', () => {
+  it('does not double-acquire when drag start fires twice', () => {
     act(() => {
       hook.handleSurfaceDragStart(dragEvent(), { id: 'node-1', x: 0, y: 0, width: 200, height: 100 } as any);
       hook.handleSurfaceResizeStart(dragEvent(), 'node-1', 300, 200, 'bottom-right');
     });
-    expect(container.querySelectorAll('.canvas-interaction-shield').length).toBe(1);
+    expect(isShielded()).toBe(true);
+    // A single mouseup fully unshields — if the second start had acquired
+    // again (refcount 2), one release would leave it still shielded.
+    act(() => hook.handleMouseUp());
+    expect(isShielded()).toBe(false);
+  });
+
+  it('does not swallow a stationary click: guests are unshielded by the time mouseup resolves', () => {
+    // Regression test for the exact bug this rewrite fixes: a plain
+    // mousedown/mouseup with no motion in between (e.g. one half of a
+    // double-click) must not leave any guest — or, in the old
+    // full-viewport-div design, an overlay standing in front of the real
+    // node — as the mouseup hit-test target.
+    act(() => {
+      hook.handleSurfaceDragStart(dragEvent(), { id: 'node-1', x: 0, y: 0, width: 200, height: 100 } as any);
+    });
+    expect(isShielded()).toBe(true);
+    act(() => hook.handleMouseUp());
+    expect(isShielded()).toBe(false);
+    // The guest itself never had its own pointer-events touched beyond the
+    // shield's own set/restore, so a real click at its coordinates would
+    // resolve normally — nothing host-side is left covering it.
+    expect(guestWebview.style.pointerEvents).toBe('');
   });
 });

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasMouseHandlers.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasMouseHandlers.ts
@@ -132,16 +132,16 @@ export const useCanvasMouseHandlers = ({
   // so dragging remains uninterrupted when crossing text.
   const isDraggingRef = useRef(false);
   const [nodeGestureActive, setNodeGestureActive] = useState(false);
-  // Full-window pointer shield mounted synchronously on drag/resize
-  // mousedown via direct DOM — NOT React state. React's commit can lag a
-  // frame or two after the first drag motion, and in that window a fast
-  // drag can reach a webview guest (a canvas iframe node OR a dock link
-  // tab, which lives outside the canvas container) whose process then
-  // swallows the mousemove stream and deadlocks the gesture. Mounting a
-  // real div synchronously at mousedown closes that window. The shared
-  // acquireInteractionShield helper (z-index above the dock) is appended
-  // to the canvas container so the trailing click resolves on the
-  // container exactly like the React-mounted shield.
+  // Guest (webview/iframe) pointer shield acquired synchronously on
+  // drag/resize mousedown via direct DOM — NOT React state. React's commit
+  // can lag a frame or two after the first drag motion, and in that window
+  // a fast drag can reach a webview guest (a canvas iframe node OR a dock
+  // link tab, which lives outside the canvas container) whose process then
+  // swallows the mousemove stream and deadlocks the gesture. The shared
+  // acquireInteractionShield helper closes that window by toggling
+  // pointer-events directly on every guest element (not a full-viewport
+  // overlay — that used to also intercept the trailing mouseup/click on an
+  // unmoved gesture, breaking "double-click a node title to rename").
   const releaseDragShieldRef = useRef<(() => void) | null>(null);
   // True once the current node gesture has produced real motion. A moved
   // drag ends with mouseup on the interaction shield, so the trailing click
@@ -218,7 +218,7 @@ export const useCanvasMouseHandlers = ({
 
   const mountDragShield = () => {
     if (releaseDragShieldRef.current) return;
-    releaseDragShieldRef.current = acquireInteractionShield(containerRef.current ?? document.body);
+    releaseDragShieldRef.current = acquireInteractionShield();
   };
 
   const unmountDragShield = () => {

--- a/apps/canvas-workspace/src/renderer/src/components/ui/__tests__/useDragResize.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ui/__tests__/useDragResize.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useDragResize, type DragResizeOptions } from '../hooks/useDragResize';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -122,29 +122,45 @@ describe('useDragResize', () => {
   });
 
   describe('interaction shield (webview drag deadlock guard)', () => {
-    const findShield = () => document.body.querySelector('.canvas-interaction-shield');
+    // acquireInteractionShield() no longer inserts a DOM node of its own —
+    // it toggles pointer-events directly on every <webview>/<iframe> guest
+    // in the document (see utils/interactionShield.ts) so an unmoved
+    // mousedown/mouseup pair still resolves its trailing click/dblclick on
+    // the real element instead of an overlay. Assert on that instead.
+    let guestWebview: HTMLElement;
 
-    it('mounts the full-window shield synchronously on mousedown and removes it on mouseup', () => {
-      const handle = renderHandle({ axis: 'x', value: 100, min: 0, max: 300, onChange: vi.fn() });
-      expect(findShield()).toBeNull();
-
-      mousedown(handle, 100);
-      expect(findShield()).not.toBeNull();
-
-      mouseup();
-      expect(findShield()).toBeNull();
+    beforeEach(() => {
+      guestWebview = document.createElement('webview');
+      document.body.appendChild(guestWebview);
     });
 
-    it('removes the shield when the component unmounts mid-drag', () => {
+    afterEach(() => {
+      guestWebview.remove();
+    });
+
+    const isShielded = () => guestWebview.style.pointerEvents === 'none';
+
+    it('shields guest elements synchronously on mousedown and unshields on mouseup', () => {
+      const handle = renderHandle({ axis: 'x', value: 100, min: 0, max: 300, onChange: vi.fn() });
+      expect(isShielded()).toBe(false);
+
+      mousedown(handle, 100);
+      expect(isShielded()).toBe(true);
+
+      mouseup();
+      expect(isShielded()).toBe(false);
+    });
+
+    it('unshields guest elements when the component unmounts mid-drag', () => {
       const handle = renderHandle({ axis: 'x', value: 100, min: 0, max: 300, onChange: vi.fn() });
       mousedown(handle, 100);
-      expect(findShield()).not.toBeNull();
+      expect(isShielded()).toBe(true);
 
       act(() => {
         root?.unmount();
       });
       root = null; // already unmounted here; skip the afterEach unmount
-      expect(findShield()).toBeNull();
+      expect(isShielded()).toBe(false);
     });
   });
 });

--- a/apps/canvas-workspace/src/renderer/src/components/ui/hooks/useDragResize.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/ui/hooks/useDragResize.ts
@@ -54,10 +54,10 @@ export const useDragResize = (options: DragResizeOptions): DragResizeHandlers =>
     optionsRef.current.onDragStart?.();
     document.body.style.cursor = axis === 'x' ? 'col-resize' : 'row-resize';
     document.body.style.userSelect = 'none';
-    // Shield the whole window synchronously: the cursor leaves the handle
-    // immediately during a panel resize, and crossing a <webview> guest
-    // (dock link tab, canvas iframe node) would swallow the move stream and
-    // deadlock the drag. Released in `release()` below.
+    // Shield every webview/iframe guest synchronously: the cursor leaves the
+    // handle immediately during a panel resize, and crossing a <webview>
+    // guest (dock link tab, canvas iframe node) would swallow the move
+    // stream and deadlock the drag. Released in `release()` below.
     const releaseShield = acquireInteractionShield();
 
     const onMove = (moveEvent: MouseEvent) => {

--- a/apps/canvas-workspace/src/renderer/src/utils/interactionShield.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/interactionShield.ts
@@ -1,28 +1,44 @@
-// Full-window pointer shield for drag gestures that can cross <webview> /
-// iframe guests. A webview's guest process swallows the mousemove stream
-// once the cursor enters it, deadlocking any host drag that relies on
-// window-level listeners (canvas node drag/resize, dock panel resize).
-// Callers mount the shield synchronously at mousedown — NOT via React
-// state, whose commit can lag a frame behind the first drag motion — so
-// hit-testing stays on the host for the whole gesture.
+// Pointer shield for drag gestures that can cross <webview> / <iframe>
+// guests. A webview's guest process (or a sandboxed iframe) swallows the
+// mousemove stream once the cursor enters it, deadlocking any host drag
+// that relies on window-level listeners (canvas node drag/resize, dock
+// panel resize). Callers acquire the shield synchronously at mousedown —
+// NOT via React state, whose commit can lag a frame behind the first drag
+// motion — so hit-testing stays on the host for the whole gesture.
 //
-// Refcounted single element: independent gestures (a canvas node drag and
-// a dock panel resize) share it, and the last release removes it.
-let shieldEl: HTMLDivElement | null = null;
+// This used to insert one full-viewport `position:fixed` div above
+// everything. That also broke plain clicks: the div, not the node the user
+// actually pressed, became the mouseup hit-test target (mounted at
+// mousedown, and mouseup's target is resolved before any JS handler — ours
+// included — gets a chance to remove it), so the browser never synthesized
+// a trailing click/dblclick when the gesture had no motion in between —
+// silently breaking "double-click a node title to rename" and similar.
+//
+// Setting `pointer-events: none` directly on the guest elements gives the
+// same protection (hit-testing falls through to whatever is beneath the
+// guest — verified against a live <webview>) without ever standing in
+// front of ordinary UI, so an unmoved mousedown/mouseup pair still resolves
+// on the real element.
+//
+// Refcounted: independent gestures (a canvas node drag and a dock panel
+// resize) share one acquisition; the last release restores every touched
+// element's own prior inline pointer-events value.
 let activeUsers = 0;
+let shieldedElements: Array<{ el: HTMLElement; prevPointerEvents: string }> = [];
 
 /**
- * Mount (or share) the interaction shield under `parent` and return an
- * idempotent release function. The shield uses the existing
- * `.canvas-interaction-shield` class (z-index above the dock), so it also
- * covers dock link-tab webviews living outside the canvas container.
+ * Shield every <webview> / <iframe> guest in the document (covers canvas
+ * nodes and dock link tabs alike) and return an idempotent release
+ * function.
  */
-export const acquireInteractionShield = (parent: HTMLElement = document.body): (() => void) => {
+export const acquireInteractionShield = (): (() => void) => {
   activeUsers += 1;
-  if (!shieldEl) {
-    shieldEl = document.createElement('div');
-    shieldEl.className = 'canvas-interaction-shield';
-    parent.appendChild(shieldEl);
+  if (shieldedElements.length === 0) {
+    shieldedElements = Array.from(document.querySelectorAll<HTMLElement>('webview, iframe')).map((el) => ({
+      el,
+      prevPointerEvents: el.style.pointerEvents,
+    }));
+    for (const { el } of shieldedElements) el.style.pointerEvents = 'none';
   }
   let released = false;
   return () => {
@@ -31,8 +47,8 @@ export const acquireInteractionShield = (parent: HTMLElement = document.body): (
     activeUsers -= 1;
     if (activeUsers <= 0) {
       activeUsers = 0;
-      shieldEl?.remove();
-      shieldEl = null;
+      for (const { el, prevPointerEvents } of shieldedElements) el.style.pointerEvents = prevPointerEvents;
+      shieldedElements = [];
     }
   };
 };


### PR DESCRIPTION
## Summary
Refactored the interaction shield mechanism used to prevent webview/iframe guests from swallowing mouse events during drag gestures. Instead of inserting a full-viewport overlay div, the shield now directly toggles `pointer-events: none` on guest elements, eliminating a bug where unmoved click gestures would fail to trigger click/dblclick events.

## Key Changes
- **interactionShield.ts**: Replaced DOM node insertion with direct `pointer-events` style manipulation
  - Removed full-viewport `position:fixed` div approach
  - Now queries document for all `<webview>` and `<iframe>` elements and toggles their `pointer-events` property
  - Maintains refcounting to handle overlapping gestures (canvas drag + dock resize)
  - Restores each element's prior inline `pointer-events` value on release

- **useCanvasMouseHandlers.ts**: Updated to call `acquireInteractionShield()` without parent argument
  - Simplified comment to reflect new pointer-events approach
  - No functional change to drag/resize behavior

- **useDragResize.ts**: Updated to call `acquireInteractionShield()` without parent argument
  - Updated comment to clarify guest-element shielding

- **Test updates**: Refactored test assertions across both test files
  - Replaced `findShield()` DOM queries with `isShielded()` checks on guest element `pointer-events`
  - Added regression test for stationary click handling
  - Updated test descriptions to reflect "shield/unshield guests" terminology

## Implementation Details
The old overlay approach inadvertently became the mouseup hit-test target on unmoved gestures (mouseup target is resolved before JS handlers run), preventing the browser from synthesizing trailing click/dblclick events. The new approach avoids this by never inserting an overlay—hit-testing falls through shielded guests to the actual UI beneath them, so plain clicks still resolve correctly on their intended targets.

https://claude.ai/code/session_016xShVKie4G3FM1dmoaiMng