### PR TITLE
Add tool-output offloading plugin for large results

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ This file orients agents working in the Coder repository. It is a thin routing +
 | Change the core loop / hooks | `packages/engine/src/core/loop.ts` |
 | Add/fix an MCP server config | `.pulse-coder/mcp.json` + `packages/engine/src/built-in/mcp-plugin/` |
 | Tune context compaction | `packages/engine/src/core/loop.ts` + env (`CONTEXT_WINDOW_TOKENS`, `COMPACT_*`, `KEEP_LAST_TURNS`) |
+| Offload oversized tool results to disk | `packages/engine/src/built-in/tool-offload-plugin/` + env (`TOOL_OFFLOAD_THRESHOLD`, `TOOL_OFFLOAD_DIR`) |
 | Add a runtime skill | `.pulse-coder/skills/<name>/SKILL.md` |
 | Add a sub-agent | `.pulse-coder/agents/*.md` |
 | Change an orchestration role | `packages/orchestrator/` |

--- a/apps/canvas-workspace/src/main/agent/canvas-agent.ts
+++ b/apps/canvas-workspace/src/main/agent/canvas-agent.ts
@@ -6,11 +6,12 @@
  * access in workspace chat and a read-only allowlist globally. Runs in Electron.
  */
 import { Engine } from 'pulse-coder-engine';
-import { createSkillsPlugin, createMcpPlugin } from 'pulse-coder-engine/built-in';
+import { createSkillsPlugin, createMcpPlugin, createToolOffloadPlugin } from 'pulse-coder-engine/built-in';
 import type { MCPServerStatus } from 'pulse-coder-engine/built-in';
 import type { ModelMessage } from 'ai';
+import { join } from 'path';
 import { resolveCanvasModel } from './model/config';
-import { scopeMcpConfigPath, skillSourceDirs } from './config-scope';
+import { scopeMcpConfigPath, scopeRootDir, skillSourceDirs } from './config-scope';
 import { getCanvasPluginSkillScanPathsSync } from '../settings/canvas-plugins-config';
 import { agentBus } from '../../plugins/main';
 import {
@@ -643,6 +644,12 @@ export class CanvasAgent {
 
     const toolPolicy = createCanvasAgentToolPolicy(this.config.scope);
 
+    // Offload oversized tool results (chiefly uncapped MCP output) to disk so
+    // they don't bloat the context window; the agent reads them on demand via
+    // the read/grep tools. Store under the workspace scope's user dir (never
+    // cwd — the Electron cwd is unpredictable and must not receive runtime data).
+    const offloadDir = join(scopeRootDir(wsScope ?? globalScope), 'offload');
+
     return new Engine({
       disableBuiltInPlugins: true,
       enginePlugins: {
@@ -655,6 +662,7 @@ export class CanvasAgent {
               return createCanvasMcpOAuthProvider(serverName, config.oauth);
             },
           }),
+          createToolOffloadPlugin({ dir: offloadDir }),
         ],
       },
       model: this.config.model,

--- a/packages/engine/src/built-in/index.ts
+++ b/packages/engine/src/built-in/index.ts
@@ -12,6 +12,7 @@ import { builtInRoleSoulPlugin } from './role-soul-plugin';
 import { SubAgentPlugin } from './sub-agent-plugin';
 import { builtInAgentTeamsPlugin } from './agent-teams-plugin';
 import { builtInPtcPlugin } from './ptc-plugin';
+import { builtInToolOffloadPlugin } from './tool-offload-plugin';
 
 /**
  * 默认内置插件列表
@@ -27,6 +28,7 @@ export const builtInPlugins = [
   builtInAgentTeamsPlugin,
   builtInRoleSoulPlugin,
   builtInPtcPlugin,
+  builtInToolOffloadPlugin,
 ];
 
 /**
@@ -59,6 +61,8 @@ export type { TaskStatus, WorkTask, WorkTaskListSnapshot } from './task-tracking
 export { builtInAgentTeamsPlugin } from './agent-teams-plugin';
 export { builtInRoleSoulPlugin } from './role-soul-plugin';
 export { builtInPtcPlugin } from './ptc-plugin';
+export { builtInToolOffloadPlugin } from './tool-offload-plugin';
+export type { OffloadStore, OffloadResult, OffloadOptions } from './tool-offload-plugin';
 export type { TeamRole, TaskGraph, TaskNode, NodeResult, OrchestrationInput as TeamRunInput, OrchestrationResult as TeamRunOutput } from 'pulse-coder-orchestrator';
 export type {
   PlanMode,

--- a/packages/engine/src/built-in/index.ts
+++ b/packages/engine/src/built-in/index.ts
@@ -61,8 +61,8 @@ export type { TaskStatus, WorkTask, WorkTaskListSnapshot } from './task-tracking
 export { builtInAgentTeamsPlugin } from './agent-teams-plugin';
 export { builtInRoleSoulPlugin } from './role-soul-plugin';
 export { builtInPtcPlugin } from './ptc-plugin';
-export { builtInToolOffloadPlugin } from './tool-offload-plugin';
-export type { OffloadStore, OffloadResult, OffloadOptions } from './tool-offload-plugin';
+export { builtInToolOffloadPlugin, createToolOffloadPlugin } from './tool-offload-plugin';
+export type { OffloadStore, OffloadResult, OffloadOptions, ToolOffloadPluginOptions } from './tool-offload-plugin';
 export type { TeamRole, TaskGraph, TaskNode, NodeResult, OrchestrationInput as TeamRunInput, OrchestrationResult as TeamRunOutput } from 'pulse-coder-orchestrator';
 export type {
   PlanMode,

--- a/packages/engine/src/built-in/tool-offload-plugin/index.test.ts
+++ b/packages/engine/src/built-in/tool-offload-plugin/index.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { promises as fs } from 'fs';
+
+import {
+  measurePayloadSize,
+  offloadToolOutput,
+  buildStub,
+  type OffloadStore,
+} from './offload';
+
+describe('measurePayloadSize', () => {
+  it('counts string lengths, ignoring JSON structural overhead', () => {
+    expect(measurePayloadSize('abc')).toBe(3);
+    // Only the string field counts; numbers/keys/braces do not.
+    expect(measurePayloadSize({ content: 'abcd', totalLines: 999 })).toBe(4);
+  });
+
+  it('sums nested strings (arrays + objects)', () => {
+    const value = { results: [{ content: 'aa' }, { content: 'bbb' }] };
+    expect(measurePayloadSize(value)).toBe(5);
+  });
+
+  it('tolerates cycles', () => {
+    const a: any = { s: 'x' };
+    a.self = a;
+    expect(measurePayloadSize(a)).toBe(1);
+  });
+});
+
+describe('offloadToolOutput', () => {
+  const dirs: string[] = [];
+  const makeStore = (): { store: OffloadStore; dir: string } => {
+    const dir = mkdtempSync(join(tmpdir(), 'offload-test-'));
+    dirs.push(dir);
+    const store: OffloadStore = {
+      dir,
+      async write(fileName, content) {
+        const filePath = join(dir, fileName);
+        await fs.writeFile(filePath, content, 'utf-8');
+        return filePath;
+      },
+    };
+    return { store, dir };
+  };
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('leaves small outputs untouched', async () => {
+    const { store } = makeStore();
+    const res = await offloadToolOutput('small', { toolName: 'x', threshold: 100, store });
+    expect(res).toBeNull();
+  });
+
+  it('offloads a large plain string and returns a stub pointing at the file', async () => {
+    const { store } = makeStore();
+    const big = 'A'.repeat(500);
+    const res = await offloadToolOutput(big, { toolName: 'bash', threshold: 100, store });
+    expect(res).not.toBeNull();
+    expect(typeof res!.output).toBe('string');
+    expect(res!.output).toContain('offloaded to disk');
+    expect(res!.output).toContain(res!.path);
+    // Full content is preserved losslessly on disk.
+    expect(readFileSync(res!.path, 'utf-8')).toBe(big);
+  });
+
+  it('preserves object shape by replacing only the dominant string field', async () => {
+    const { store } = makeStore();
+    const output = { content: 'B'.repeat(500), totalLines: 42 };
+    const res = await offloadToolOutput(output, { toolName: 'read', threshold: 100, store });
+    expect(res).not.toBeNull();
+    const out = res!.output as { content: string; totalLines: number };
+    // Metadata survives; only the big field became a stub.
+    expect(out.totalLines).toBe(42);
+    expect(out.content).toContain('offloaded to disk');
+    expect(readFileSync(res!.path, 'utf-8')).toBe('B'.repeat(500));
+  });
+
+  it('offloads whole object as JSON when no single field exceeds threshold', async () => {
+    const { store } = makeStore();
+    // Two medium fields: aggregate 120 > threshold 100, but neither alone > 100.
+    const output = { a: 'a'.repeat(60), b: 'b'.repeat(60) };
+    const res = await offloadToolOutput(output, { toolName: 'tavily', threshold: 100, store });
+    expect(res).not.toBeNull();
+    expect(typeof res!.output).toBe('string');
+    expect(res!.path.endsWith('.json')).toBe(true);
+    const persisted = JSON.parse(readFileSync(res!.path, 'utf-8'));
+    expect(persisted).toEqual(output);
+  });
+
+  it('does not offload an already-capped read result at exactly the threshold', async () => {
+    const { store } = makeStore();
+    // read caps content at MAX_TOOL_OUTPUT_LENGTH; payload equals threshold, not over.
+    const output = { content: 'C'.repeat(30_000), totalLines: 1 };
+    const res = await offloadToolOutput(output, { toolName: 'read', threshold: 30_000, store });
+    expect(res).toBeNull();
+  });
+
+  it('dedupes identical content to the same file name (content hash)', async () => {
+    const { store } = makeStore();
+    const big = 'D'.repeat(500);
+    const first = await offloadToolOutput(big, { toolName: 'mcp', threshold: 100, store });
+    const second = await offloadToolOutput(big, { toolName: 'mcp', threshold: 100, store });
+    expect(first!.path).toBe(second!.path);
+  });
+});
+
+describe('buildStub', () => {
+  it('includes a head/tail preview and omission marker for large content', () => {
+    const content = 'H'.repeat(1000) + 'MIDDLE' + 'T'.repeat(1000);
+    const stub = buildStub({ toolName: 'x', content, filePath: '/tmp/x.txt', previewChars: 50 });
+    expect(stub).toContain('chars omitted');
+    expect(stub).toContain('/tmp/x.txt');
+    expect(stub).not.toContain('MIDDLE');
+  });
+});

--- a/packages/engine/src/built-in/tool-offload-plugin/index.ts
+++ b/packages/engine/src/built-in/tool-offload-plugin/index.ts
@@ -1,0 +1,101 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+import type { EnginePlugin, EnginePluginContext } from '../../plugin/EnginePlugin.js';
+import { TOOL_OFFLOAD_DIR, TOOL_OFFLOAD_THRESHOLD } from '../../config/index.js';
+import { offloadToolOutput, type OffloadStore } from './offload.js';
+
+export { measurePayloadSize, buildStub, offloadToolOutput } from './offload.js';
+export type { OffloadStore, OffloadResult, OffloadOptions } from './offload.js';
+
+function resolveOffloadDir(): string {
+  if (TOOL_OFFLOAD_DIR) {
+    return path.isAbsolute(TOOL_OFFLOAD_DIR)
+      ? TOOL_OFFLOAD_DIR
+      : path.resolve(process.cwd(), TOOL_OFFLOAD_DIR);
+  }
+  return path.resolve(process.cwd(), '.pulse-coder', 'offload');
+}
+
+/**
+ * Filesystem-backed {@link OffloadStore}. Writes are async (the engine runs on
+ * GUI main threads — blocking I/O is forbidden, see AGENTS.md §6) and idempotent:
+ * file names are content hashes, so an existing file with the same name already
+ * holds identical bytes and the write is skipped.
+ */
+function createFsStore(dir: string): OffloadStore {
+  let ensured: Promise<void> | undefined;
+  const ensureDir = () => {
+    if (!ensured) ensured = fs.mkdir(dir, { recursive: true }).then(() => undefined);
+    return ensured;
+  };
+
+  return {
+    dir,
+    async write(fileName, content) {
+      const filePath = path.join(dir, fileName);
+      await ensureDir();
+      try {
+        await fs.access(filePath);
+        // Same content hash ⇒ identical bytes already on disk; skip rewrite.
+        return filePath;
+      } catch {
+        // Not present yet — write it.
+      }
+      await fs.writeFile(filePath, content, 'utf-8');
+      return filePath;
+    },
+  };
+}
+
+/**
+ * Built-in plugin: offloads oversized tool results to disk and replaces them in
+ * the message history with a compact stub, so the model can read the full output
+ * on demand instead of carrying it inline. Centralized in an `afterToolCall`
+ * hook, it covers every tool in the set — built-in, MCP, and plugin tools alike.
+ *
+ * Built-in tools that already cap a single field at MAX_TOOL_OUTPUT_LENGTH
+ * (read/bash/grep) stay below the threshold and are left untouched; the real
+ * beneficiaries are uncapped sources like MCP tools and aggregate results such
+ * as tavily's multi-result arrays.
+ */
+export const builtInToolOffloadPlugin: EnginePlugin = {
+  name: 'pulse-coder-engine/built-in-tool-offload',
+  version: '1.0.0',
+
+  async initialize(context: EnginePluginContext): Promise<void> {
+    const threshold = TOOL_OFFLOAD_THRESHOLD;
+    if (!Number.isFinite(threshold) || threshold <= 0) {
+      context.logger.warn('[ToolOffload] disabled: invalid TOOL_OFFLOAD_THRESHOLD', { threshold });
+      return;
+    }
+
+    const dir = resolveOffloadDir();
+    const store = createFsStore(dir);
+
+    context.registerHook('afterToolCall', async ({ name, output }) => {
+      try {
+        const result = await offloadToolOutput(output, { toolName: name, threshold, store });
+        if (!result) return;
+        context.logger.info('[ToolOffload] offloaded oversized tool output', {
+          tool: name,
+          payloadSize: result.payloadSize,
+          path: result.path,
+        });
+        return { output: result.output };
+      } catch (error) {
+        // Best-effort: never let offloading failure break the tool call. Fall
+        // back to returning the original (large) output unchanged.
+        context.logger.warn('[ToolOffload] offload failed; keeping inline output', {
+          tool: name,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return;
+      }
+    });
+
+    context.logger.info('[ToolOffload] registered afterToolCall offloader', { dir, threshold });
+  },
+};
+
+export default builtInToolOffloadPlugin;

--- a/packages/engine/src/built-in/tool-offload-plugin/index.ts
+++ b/packages/engine/src/built-in/tool-offload-plugin/index.ts
@@ -58,6 +58,16 @@ function createFsStore(dir: string): OffloadStore {
  * (read/bash/grep) stay below the threshold and are left untouched; the real
  * beneficiaries are uncapped sources like MCP tools and aggregate results such
  * as tavily's multi-result arrays.
+ *
+ * Retention policy — cache, NO automatic cleanup (by design). The offload
+ * directory is treated as a content-addressed cache: files are named by content
+ * hash (so identical results dedupe) and are intentionally never swept on a
+ * timer, session end, or size limit. This is deliberate: a stub in the message
+ * history is a durable pointer, and deleting the file it references would make
+ * old sessions/sub-agents lose the full result. Do NOT add a background cleanup
+ * sweep here — if disk pressure ever demands eviction, make it opt-in (env-gated
+ * size/age cap) and pair it with graceful read-degradation for missing files.
+ * The write path is decoupled from any eviction, so adding one later is easy.
  */
 export const builtInToolOffloadPlugin: EnginePlugin = {
   name: 'pulse-coder-engine/built-in-tool-offload',

--- a/packages/engine/src/built-in/tool-offload-plugin/index.ts
+++ b/packages/engine/src/built-in/tool-offload-plugin/index.ts
@@ -8,7 +8,22 @@ import { offloadToolOutput, type OffloadStore } from './offload.js';
 export { measurePayloadSize, buildStub, offloadToolOutput } from './offload.js';
 export type { OffloadStore, OffloadResult, OffloadOptions } from './offload.js';
 
-function resolveOffloadDir(): string {
+export interface ToolOffloadPluginOptions {
+  /**
+   * Absolute directory to store offloaded results under. Overrides the
+   * env/cwd-based default. Hosts that run the engine off the repo root (e.g.
+   * the Electron app, whose cwd is unpredictable) MUST pass an explicit
+   * user-scoped path so nothing is written into a source tree.
+   */
+  dir?: string;
+  /** Payload-size threshold in chars. Defaults to TOOL_OFFLOAD_THRESHOLD. */
+  threshold?: number;
+}
+
+function resolveOffloadDir(dir?: string): string {
+  if (dir) {
+    return path.isAbsolute(dir) ? dir : path.resolve(process.cwd(), dir);
+  }
   if (TOOL_OFFLOAD_DIR) {
     return path.isAbsolute(TOOL_OFFLOAD_DIR)
       ? TOOL_OFFLOAD_DIR
@@ -69,43 +84,52 @@ function createFsStore(dir: string): OffloadStore {
  * size/age cap) and pair it with graceful read-degradation for missing files.
  * The write path is decoupled from any eviction, so adding one later is easy.
  */
-export const builtInToolOffloadPlugin: EnginePlugin = {
-  name: 'pulse-coder-engine/built-in-tool-offload',
-  version: '1.0.0',
+export function createToolOffloadPlugin(options: ToolOffloadPluginOptions = {}): EnginePlugin {
+  return {
+    name: 'pulse-coder-engine/built-in-tool-offload',
+    version: '1.0.0',
 
-  async initialize(context: EnginePluginContext): Promise<void> {
-    const threshold = TOOL_OFFLOAD_THRESHOLD;
-    if (!Number.isFinite(threshold) || threshold <= 0) {
-      context.logger.warn('[ToolOffload] disabled: invalid TOOL_OFFLOAD_THRESHOLD', { threshold });
-      return;
-    }
-
-    const dir = resolveOffloadDir();
-    const store = createFsStore(dir);
-
-    context.registerHook('afterToolCall', async ({ name, output }) => {
-      try {
-        const result = await offloadToolOutput(output, { toolName: name, threshold, store });
-        if (!result) return;
-        context.logger.info('[ToolOffload] offloaded oversized tool output', {
-          tool: name,
-          payloadSize: result.payloadSize,
-          path: result.path,
-        });
-        return { output: result.output };
-      } catch (error) {
-        // Best-effort: never let offloading failure break the tool call. Fall
-        // back to returning the original (large) output unchanged.
-        context.logger.warn('[ToolOffload] offload failed; keeping inline output', {
-          tool: name,
-          error: error instanceof Error ? error.message : String(error),
-        });
+    async initialize(context: EnginePluginContext): Promise<void> {
+      const threshold = options.threshold ?? TOOL_OFFLOAD_THRESHOLD;
+      if (!Number.isFinite(threshold) || threshold <= 0) {
+        context.logger.warn('[ToolOffload] disabled: invalid threshold', { threshold });
         return;
       }
-    });
 
-    context.logger.info('[ToolOffload] registered afterToolCall offloader', { dir, threshold });
-  },
-};
+      const dir = resolveOffloadDir(options.dir);
+      const store = createFsStore(dir);
+
+      context.registerHook('afterToolCall', async ({ name, output }) => {
+        try {
+          const result = await offloadToolOutput(output, { toolName: name, threshold, store });
+          if (!result) return;
+          context.logger.info('[ToolOffload] offloaded oversized tool output', {
+            tool: name,
+            payloadSize: result.payloadSize,
+            path: result.path,
+          });
+          return { output: result.output };
+        } catch (error) {
+          // Best-effort: never let offloading failure break the tool call. Fall
+          // back to returning the original (large) output unchanged.
+          context.logger.warn('[ToolOffload] offload failed; keeping inline output', {
+            tool: name,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return;
+        }
+      });
+
+      context.logger.info('[ToolOffload] registered afterToolCall offloader', { dir, threshold });
+    },
+  };
+}
+
+/**
+ * Default instance for the built-in plugin list (env/cwd-based dir). Hosts that
+ * construct the engine off the repo root should use {@link createToolOffloadPlugin}
+ * with an explicit `dir` instead.
+ */
+export const builtInToolOffloadPlugin: EnginePlugin = createToolOffloadPlugin();
 
 export default builtInToolOffloadPlugin;

--- a/packages/engine/src/built-in/tool-offload-plugin/offload.ts
+++ b/packages/engine/src/built-in/tool-offload-plugin/offload.ts
@@ -1,0 +1,174 @@
+import { createHash } from 'crypto';
+
+/**
+ * Pure offloading logic, decoupled from the filesystem so it can be unit-tested.
+ * The plugin wires a real `fs/promises`-backed {@link OffloadStore}; tests pass
+ * an in-memory one.
+ */
+
+export interface OffloadStore {
+  /** Absolute directory offloaded files live under. Used only for messaging. */
+  dir: string;
+  /**
+   * Persist `content` under `fileName`. Implementations SHOULD be idempotent:
+   * skip the write when a file with identical content already exists (the file
+   * name is a content hash, so same name ⇒ same bytes). Never throw on a
+   * best-effort basis — return the absolute path that was (or would be) written.
+   */
+  write(fileName: string, content: string): Promise<string>;
+}
+
+export interface OffloadOptions {
+  toolName: string;
+  threshold: number;
+  store: OffloadStore;
+  /** Chars kept from the head and from the tail in the inline preview. */
+  previewChars?: number;
+}
+
+export interface OffloadResult {
+  /** The value to hand back to the model in place of the original output. */
+  output: unknown;
+  /** Absolute path the full output was written to. */
+  path: string;
+  /** Textual payload size of the original output. */
+  payloadSize: number;
+}
+
+const DEFAULT_PREVIEW_CHARS = 800;
+
+/**
+ * Sum of the lengths of every string reachable in `value`. This is the amount of
+ * text that actually lands in the model's context — JSON structural characters
+ * (braces, keys, commas) are ignored so a normal, already-capped tool result
+ * isn't offloaded just because of wrapper overhead.
+ */
+export function measurePayloadSize(value: unknown, seen = new Set<object>()): number {
+  if (typeof value === 'string') return value.length;
+  if (value && typeof value === 'object') {
+    if (seen.has(value as object)) return 0;
+    seen.add(value as object);
+    let total = 0;
+    for (const inner of Object.values(value as Record<string, unknown>)) {
+      total += measurePayloadSize(inner, seen);
+    }
+    return total;
+  }
+  return 0;
+}
+
+/** Finds the top-level own string field with the greatest length, if any. */
+function findLargestTopLevelStringField(
+  obj: Record<string, unknown>,
+): { key: string; value: string } | null {
+  let best: { key: string; value: string } | null = null;
+  for (const [key, value] of Object.entries(obj)) {
+    if (typeof value === 'string' && (!best || value.length > best.value.length)) {
+      best = { key, value };
+    }
+  }
+  return best;
+}
+
+function sanitizeToolName(name: string): string {
+  const cleaned = name.replace(/[^a-zA-Z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
+  return cleaned || 'tool';
+}
+
+function contentHash(content: string): string {
+  return createHash('sha256').update(content).digest('hex').slice(0, 16);
+}
+
+function formatCount(n: number): string {
+  return n.toLocaleString('en-US');
+}
+
+/**
+ * Builds the compact stub string that replaces a large payload. Contains a
+ * head/tail preview plus the absolute path and instructions on how to read the
+ * rest on demand.
+ */
+export function buildStub(params: {
+  toolName: string;
+  content: string;
+  filePath: string;
+  previewChars: number;
+}): string {
+  const { toolName, content, filePath, previewChars } = params;
+  const chars = content.length;
+  const lines = content.split('\n').length;
+
+  let previewBlock: string;
+  if (chars <= previewChars * 2) {
+    previewBlock = content;
+  } else {
+    const head = content.slice(0, previewChars);
+    const tail = content.slice(-previewChars);
+    const omitted = chars - previewChars * 2;
+    previewBlock = `${head}\n\n…[${formatCount(omitted)} chars omitted]…\n\n${tail}`;
+  }
+
+  return [
+    `⚠️ Large \`${toolName}\` output offloaded to disk (${formatCount(chars)} chars / ${formatCount(lines)} lines). The full result is NOT in context.`,
+    '',
+    'Preview (head + tail):',
+    previewBlock,
+    '',
+    `Full output saved to: ${filePath}`,
+    'To inspect the rest, use the `read` tool with this filePath (plus offset/limit) or `grep` to search it. Do not read the whole file at once.',
+  ].join('\n');
+}
+
+/**
+ * Offloads `output` to disk when its textual payload exceeds `threshold`.
+ * Returns `null` (no change) when the output is small enough to keep inline.
+ *
+ * Shape preservation: when the output is an object dominated by a single
+ * top-level string field (e.g. `read` → `{ content, totalLines }`), only that
+ * field is replaced with the stub so metadata survives. Otherwise (plain string,
+ * array, or many medium fields) the whole value is serialized to disk and the
+ * output becomes the stub string.
+ */
+export async function offloadToolOutput(
+  output: unknown,
+  opts: OffloadOptions,
+): Promise<OffloadResult | null> {
+  const { toolName, threshold, store } = opts;
+  const previewChars = opts.previewChars ?? DEFAULT_PREVIEW_CHARS;
+
+  const payloadSize = measurePayloadSize(output);
+  if (payloadSize <= threshold) return null;
+
+  const safeName = sanitizeToolName(toolName);
+
+  // Case 1: object with one dominant, over-threshold top-level string field.
+  if (output && typeof output === 'object' && !Array.isArray(output)) {
+    const record = output as Record<string, unknown>;
+    const largest = findLargestTopLevelStringField(record);
+    if (largest && largest.value.length > threshold) {
+      const fileName = `${safeName}-${contentHash(largest.value)}.txt`;
+      const filePath = await store.write(fileName, largest.value);
+      const stub = buildStub({ toolName, content: largest.value, filePath, previewChars });
+      return {
+        output: { ...record, [largest.key]: stub },
+        path: filePath,
+        payloadSize,
+      };
+    }
+  }
+
+  // Case 2: plain string.
+  if (typeof output === 'string') {
+    const fileName = `${safeName}-${contentHash(output)}.txt`;
+    const filePath = await store.write(fileName, output);
+    const stub = buildStub({ toolName, content: output, filePath, previewChars });
+    return { output: stub, path: filePath, payloadSize };
+  }
+
+  // Case 3: array / many-field object — serialize the whole thing as JSON.
+  const json = JSON.stringify(output, null, 2);
+  const fileName = `${safeName}-${contentHash(json)}.json`;
+  const filePath = await store.write(fileName, json);
+  const stub = buildStub({ toolName, content: json, filePath, previewChars });
+  return { output: stub, path: filePath, payloadSize };
+}

--- a/packages/engine/src/config/index.ts
+++ b/packages/engine/src/config/index.ts
@@ -97,6 +97,19 @@ export const MAX_TURNS = 100;
 export const MAX_ERROR_COUNT = 3;
 export const MAX_STEPS = 500;
 export const MAX_TOOL_OUTPUT_LENGTH = 30_000;
+
+/**
+ * Tool-output offloading. When a tool result's textual payload (the sum of all
+ * string lengths in the output, ignoring JSON structural overhead) exceeds this
+ * threshold, the offload plugin persists the full result to disk and replaces it
+ * in the message history with a compact stub (preview + file path). Subsequent
+ * turns / sub-agents read the file on demand via the `read` / `grep` tools.
+ *
+ * Override the threshold via TOOL_OFFLOAD_THRESHOLD. Override the storage dir via
+ * TOOL_OFFLOAD_DIR (defaults to `<cwd>/.pulse-coder/offload`).
+ */
+export const TOOL_OFFLOAD_THRESHOLD = Number(process.env.TOOL_OFFLOAD_THRESHOLD ?? 30_000);
+export const TOOL_OFFLOAD_DIR = (process.env.TOOL_OFFLOAD_DIR ?? '').trim();
 export const LLM_FIRST_CHUNK_TIMEOUT_MS = Number(process.env.LLM_FIRST_CHUNK_TIMEOUT_MS ?? 180_000);
 export const LLM_CALL_TIMEOUT_MS = Number(process.env.LLM_CALL_TIMEOUT_MS ?? 600_000);
 


### PR DESCRIPTION
## Summary
Implements a built-in plugin that automatically offloads oversized tool results to disk, replacing them in the message history with compact stubs containing a preview and file path. This allows the model to read large outputs on demand via `read`/`grep` tools instead of carrying them inline in context.

## Key Changes
- **New offload module** (`packages/engine/src/built-in/tool-offload-plugin/offload.ts`):
  - `measurePayloadSize()`: Sums string lengths in a value (ignoring JSON structural overhead)
  - `offloadToolOutput()`: Core logic that decides when/how to offload based on payload size
  - `buildStub()`: Generates compact preview stubs with head/tail excerpts and file paths
  - Preserves object shape by replacing only dominant string fields; serializes arrays/multi-field objects as JSON

- **Plugin integration** (`packages/engine/src/built-in/tool-offload-plugin/index.ts`):
  - Filesystem-backed `OffloadStore` with idempotent writes (content-hash file names prevent duplicates)
  - Registers `afterToolCall` hook to intercept all tool outputs (built-in, MCP, plugin tools)
  - Graceful error handling: offload failures fall back to inline output without breaking tool calls
  - Configurable via `TOOL_OFFLOAD_THRESHOLD` and `TOOL_OFFLOAD_DIR` environment variables

- **Configuration** (`packages/engine/src/config/index.ts`):
  - Added `TOOL_OFFLOAD_THRESHOLD` (default 30KB) and `TOOL_OFFLOAD_DIR` (default `.pulse-coder/offload`)

- **Plugin registration** (`packages/engine/src/built-in/index.ts`):
  - Registered `builtInToolOffloadPlugin` in the default plugin list

- **Comprehensive tests** (`packages/engine/src/built-in/tool-offload-plugin/index.test.ts`):
  - Tests for payload measurement, offloading logic, shape preservation, deduplication, and stub formatting

## Notable Implementation Details
- **Payload measurement** ignores JSON structural characters (braces, keys, commas) so already-capped tool results (read/bash/grep) stay below threshold
- **Content hashing** (SHA256, 16-char prefix) ensures identical outputs deduplicate to the same file
- **Async, non-blocking** writes required for GUI main-thread execution (see AGENTS.md §6)
- **Best-effort design**: offload failures never break tool execution; the original output is returned unchanged
- **Shape preservation**: when an object has one dominant string field (e.g., `read` → `{ content, totalLines }`), only that field is replaced with the stub so metadata survives

https://claude.ai/code/session_01KZFE8xPN753kYgQBEsh3mz