### PR TITLE
feat(canvas-workspace): clickable URLs in all terminal surfaces via web-links addon

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -127,6 +127,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^3.0.21",
     "@larksuiteoapi/node-sdk": "^1.59.0",
+    "@xterm/addon-web-links": "^0.12.0",
     "ai": "^6.0.57",
     "fflate": "^0.8.2",
     "happy-dom": "^20.10.6",

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/useAgentNodeController.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/useAgentNodeController.ts
@@ -3,17 +3,18 @@ import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
 import type { AgentNodeData, CanvasNode } from '../../types';
 import { getAgentCommand } from '../../config/agentRegistry';
-import { TERMINAL_OPTIONS } from '../../config/terminalTheme';
 import { buildNodeMentionInsertion } from '../../utils/nodeMention';
 import type { AgentNodeBodyProps, ViewMode } from './types';
 import {
   SCROLLBACK_SAVE_INTERVAL,
   claimTerminalSessionOwner, createDebouncedTerminalRefit, createPtySpawnLifecycle, createTerminalSnapshotPersister,
+  createTerminalWithAddons,
   finalizeTerminalSnapshotBeforeDispose,
   loadRecentCwds,
   pushRecentCwd,
   readTerminalSnapshot,
   syncTerminalFontSizeToCanvas,
+  useOpenTerminalLink,
   writeTerminalOutput,
 } from './utils/terminal';
 
@@ -249,6 +250,7 @@ export const useAgentNodeController = ({
   onUpdateRef.current = onUpdate;
   const getAllNodesRef = useRef(getAllNodes);
   getAllNodesRef.current = getAllNodes;
+  const openTerminalLink = useOpenTerminalLink();
 
   useEffect(() => {
     if (readOnly || isMirrorTerminal || !isTeamManagedAgent) return;
@@ -340,9 +342,7 @@ export const useAgentNodeController = ({
           return;
         }
 
-        const term = new Terminal(TERMINAL_OPTIONS);
-        const fitAddon = new FitAddon();
-        term.loadAddon(fitAddon);
+        const { term, fitAddon } = createTerminalWithAddons(openTerminalLink);
         containerRef.current.replaceChildren();
         term.open(containerRef.current);
         termRef.current = term;
@@ -487,9 +487,7 @@ export const useAgentNodeController = ({
 
       if (readOnly) {
         spawnedRef.current = true;
-        const term = new Terminal(TERMINAL_OPTIONS);
-        const fitAddon = new FitAddon();
-        term.loadAddon(fitAddon);
+        const { term, fitAddon } = createTerminalWithAddons(openTerminalLink);
         containerRef.current.replaceChildren();
         term.open(containerRef.current);
         termRef.current = term;
@@ -508,9 +506,7 @@ export const useAgentNodeController = ({
       spawnedRef.current = true;
       setLoading(true);
 
-      const term = new Terminal(TERMINAL_OPTIONS);
-      const fitAddon = new FitAddon();
-      term.loadAddon(fitAddon);
+      const { term, fitAddon } = createTerminalWithAddons(openTerminalLink);
       containerRef.current.replaceChildren();
       term.open(containerRef.current);
       termRef.current = term;
@@ -909,7 +905,7 @@ export const useAgentNodeController = ({
 
       saveTimerRef.current = setInterval(() => void snapshotPersister.flush().catch(() => undefined), SCROLLBACK_SAVE_INTERVAL);
     },
-    [isMirrorTerminal, rootFolder, workspaceId, readOnly],
+    [isMirrorTerminal, openTerminalLink, rootFolder, workspaceId, readOnly],
   );
 
   useEffect(() => {

--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/utils/terminal.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/utils/terminal.ts
@@ -1,6 +1,9 @@
-import { Terminal } from '@xterm/xterm';
-import type { FitAddon } from '@xterm/addon-fit';
-import { BASE_TERMINAL_FONT_SIZE } from '../../../config/terminalTheme';
+import { useCallback, useContext } from 'react';
+import { Terminal, type ITerminalOptions } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import { WebLinksAddon } from '@xterm/addon-web-links';
+import { BASE_TERMINAL_FONT_SIZE, TERMINAL_OPTIONS } from '../../../config/terminalTheme';
+import { RightDockContext } from '../../RightDock/context';
 import { count } from '../../../perf/counters';
 
 export const SCROLLBACK_SAVE_INTERVAL = 2000;
@@ -373,4 +376,33 @@ export const createDebouncedTerminalRefit = (
       }
     },
   };
+};
+
+/**
+ * URL opener for terminal web links. Prefers a right-dock link tab (same
+ * surface as note/webview link clicks); falls back to the system browser when
+ * mounted outside <RightDockProvider> (bare test renders).
+ */
+export const useOpenTerminalLink = (): ((url: string) => void) => {
+  const dock = useContext(RightDockContext);
+  return useCallback((url: string) => {
+    if (dock) dock.store.openLink(url);
+    else void window.canvasWorkspace.shell.openExternal(url);
+  }, [dock]);
+};
+
+/**
+ * Create a terminal with the shared Fit + WebLinks addons. Each call builds a
+ * fresh WebLinksAddon — an addon instance binds to a single terminal on
+ * activate, so it cannot be shared across terminals.
+ */
+export const createTerminalWithAddons = (
+  openLink: (url: string) => void,
+  options: ITerminalOptions = {},
+): { term: Terminal; fitAddon: FitAddon } => {
+  const term = new Terminal({ ...TERMINAL_OPTIONS, ...options });
+  const fitAddon = new FitAddon();
+  term.loadAddon(fitAddon);
+  term.loadAddon(new WebLinksAddon((_event, uri) => openLink(uri)));
+  return { term, fitAddon };
 };

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/context.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/context.tsx
@@ -24,7 +24,7 @@ interface RightDockContextValue {
   registerAddDomSelectionToChat: (handler: (workspaceId: string, selection: AgentContextDomSelectionRef) => void) => () => void;
 }
 
-const RightDockContext = createContext<RightDockContextValue | null>(null);
+export const RightDockContext = createContext<RightDockContextValue | null>(null);
 
 export const RightDockProvider = ({ children }: { children: ReactNode }) => {
   const store = useMemo(() => new DockStore(

--- a/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/TerminalNodeBody/index.tsx
@@ -4,7 +4,6 @@ import './index.css';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import type { CanvasNode, TerminalNodeData } from '../../types';
-import { TERMINAL_OPTIONS } from '../../config/terminalTheme';
 import { buildNodeMentionInsertion } from '../../utils/nodeMention';
 import { NodeMentionPicker } from '../NodeMentionPicker';
 import {
@@ -13,11 +12,13 @@ import {
   createPtySpawnLifecycle,
   createDebouncedTerminalRefit,
   createTerminalSnapshotPersister,
+  createTerminalWithAddons,
   finalizeTerminalSnapshotBeforeDispose,
   fitTerminalWithCanvasScale,
   readTerminalSnapshot,
   serializeBuffer,
   syncTerminalFontSizeToCanvas,
+  useOpenTerminalLink,
   writeTerminalOutput,
 } from '../AgentNodeBody/utils/terminal';
 import { useI18n } from '../../i18n';
@@ -64,6 +65,7 @@ export const TerminalNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, o
   getAllNodesRef.current = getAllNodes;
   const workspaceIdRef = useRef(workspaceId);
   workspaceIdRef.current = workspaceId;
+  const openTerminalLink = useOpenTerminalLink();
   const initialScrollback = useRef(data.scrollback ?? '');
   const initialCwd = useRef(data.cwd ?? '');
   const initialCommand = useRef(data.initialCommand ?? '');
@@ -113,9 +115,7 @@ export const TerminalNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, o
     if (!containerRef.current || termRef.current || spawnedRef.current) return;
     if (readOnly) {
       spawnedRef.current = true;
-      const term = new Terminal(TERMINAL_OPTIONS);
-      const fitAddon = new FitAddon();
-      term.loadAddon(fitAddon);
+      const { term, fitAddon } = createTerminalWithAddons(openTerminalLink);
       term.open(containerRef.current);
       termRef.current = term;
       fitRef.current = fitAddon;
@@ -132,9 +132,7 @@ export const TerminalNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, o
     }
     spawnedRef.current = true;
 
-    const term = new Terminal(TERMINAL_OPTIONS);
-    const fitAddon = new FitAddon();
-    term.loadAddon(fitAddon);
+    const { term, fitAddon } = createTerminalWithAddons(openTerminalLink);
     term.open(containerRef.current);
     termRef.current = term;
     fitRef.current = fitAddon;
@@ -273,7 +271,7 @@ export const TerminalNodeBody = ({ node, getAllNodes, rootFolder, workspaceId, o
     killSessionRef.current = () => {
       try { api.kill(sessionId, result.leaseId); } finally { sessionOwner.finishFinalization(); }
     };
-  }, [sessionId, rootFolder, readOnly, captureTerminalInput, captureTerminalOutput, startCodingAgentHint]);
+  }, [sessionId, rootFolder, readOnly, openTerminalLink, captureTerminalInput, captureTerminalOutput, startCodingAgentHint]);
 
   useEffect(() => {
     void initTerminal();

--- a/apps/canvas-workspace/src/renderer/src/components/WorkspaceTerminalDock/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/WorkspaceTerminalDock/index.tsx
@@ -5,7 +5,6 @@ import '@xterm/xterm/css/xterm.css';
 import {
   BASE_TERMINAL_FONT_SIZE,
   TERMINAL_FONT_SIZE_STEP,
-  TERMINAL_OPTIONS,
   clampTerminalFontSize,
   readStoredTerminalFontSize,
   storeTerminalFontSize,
@@ -16,6 +15,7 @@ import { NodeMentionPicker } from '../NodeMentionPicker';
 import { useDragResize } from '../ui';
 import { useI18n } from '../../i18n';
 import { TERMINAL_TAB_ID } from '../RightDock/dock-store';
+import { createTerminalWithAddons, useOpenTerminalLink } from '../AgentNodeBody/utils/terminal';
 import {
   appendTerminalOutputTail,
   detectCodingAgentCommand,
@@ -107,6 +107,7 @@ export const WorkspaceTerminalDock = ({
   nodesRef.current = nodes;
   rootFolderRef.current = rootFolder;
   heightRef.current = height;
+  const openTerminalLink = useOpenTerminalLink();
 
   const sessionId = useMemo(
     () => terminalId === TERMINAL_TAB_ID
@@ -226,9 +227,7 @@ export const WorkspaceTerminalDock = ({
     if (!containerRef.current || termRef.current || spawnedRef.current) return;
     spawnedRef.current = true;
 
-    const term = new Terminal({ ...TERMINAL_OPTIONS, fontSize: fontSizeRef.current });
-    const fitAddon = new FitAddon();
-    term.loadAddon(fitAddon);
+    const { term, fitAddon } = createTerminalWithAddons(openTerminalLink, { fontSize: fontSizeRef.current });
     term.open(containerRef.current);
     termRef.current = term;
     fitRef.current = fitAddon;
@@ -309,7 +308,7 @@ export const WorkspaceTerminalDock = ({
       resizeDisposable.dispose();
       api.kill(sessionId);
     };
-  }, [applyFontSize, captureTerminalInput, captureTerminalOutput, dismissBooting, refreshCwd, scheduleFit, sessionId, workspaceId]);
+  }, [applyFontSize, captureTerminalInput, captureTerminalOutput, dismissBooting, openTerminalLink, refreshCwd, scheduleFit, sessionId, workspaceId]);
 
   useEffect(() => {
     if (!open) return;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@larksuiteoapi/node-sdk':
         specifier: ^1.59.0
         version: 1.59.0
+      '@xterm/addon-web-links':
+        specifier: ^0.12.0
+        version: 0.12.0
       ai:
         specifier: ^6.0.57
         version: 6.0.57(zod@4.3.6)
@@ -2156,6 +2159,9 @@ packages:
 
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/addon-web-links@0.12.0':
+    resolution: {integrity: sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==}
 
   '@xterm/xterm@6.0.0':
     resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
@@ -6786,6 +6792,8 @@ snapshots:
   '@xmldom/xmldom@0.8.12': {}
 
   '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/addon-web-links@0.12.0': {}
 
   '@xterm/xterm@6.0.0': {}
 


### PR DESCRIPTION
## 问题

画布终端节点、Agent 节点终端、底部工作区终端输出里的 URL 点击无反应 —— xterm 默认不识别链接，三个终端面都没有加载 web-links addon。

## 改动

- 引入 `@xterm/addon-web-links@^0.12.0`(该版本无 peerDependencies,与项目 xterm 6 无冲突)
- 三个终端面全部接入,点击 URL 在右侧 dock 打开链接标签页(与笔记 / webview 链接同一体验):
  - `TerminalNodeBody`(正常 + readOnly 两条路径)
  - `useAgentNodeController`(mirror / readOnly / spawn 三处)
  - `WorkspaceTerminalDock`
- 共享逻辑收敛到 `AgentNodeBody/utils/terminal.ts`:
  - `useOpenTerminalLink()` — 空安全读取 `RightDockContext`(已导出);有 provider 走 dock 链接标签,裸渲染(测试)兜底 `shell.openExternal`
  - `createTerminalWithAddons(openLink, options?)` — 统一终端构造(Fit + WebLinks);每次调用新建 addon 实例(addon 在 activate 时绑定单个 terminal,不可共享)
- 重构顺带让 `useAgentNodeController.ts` 从 1286 行降到 1280 行,满足文件大小门禁

## 验证

- `pnpm --filter canvas-workspace typecheck` ✅
- `pnpm --filter canvas-workspace test` — 221 文件 / 1499 用例全过 ✅
- `node scripts/harness/run-harness-check.mjs` — 3/3 ✅(含 file-size / ui-reuse 门禁)

🤖 Generated with [Claude Code](https://claude.com/claude-code)