### PR TITLE
release(canvas): 0.1.28

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.27",
+  "version": "0.1.28",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
## Pulse Canvas 0.1.28

Artifacts uploaded to R2 and download page deployed.

- manifest: https://downloads.jasperhu.art/pulse-canvas/stable/latest.json
- download page: https://pulse-canvas-download.pages.dev/

### Release notes (zh)
画布视觉焕新：中性默认配色、更安静的画框标签、对齐参考设计的文件卡片、背景与对比度优化。修复双击重命名节点失效的问题。关闭非活跃 dock 标签不再触发自动滚动；Agent 读取/操作网页时不再抢占你当前的标签页，并减少了多余标签的打开；默认浏览器冷启动不再恢复过期标签。Agent 工具改为按需加载，大体积工具结果自动落盘，长会话更稳定。pulse-canvas CLI 新增 doctor 一致性检查与修复、layout 读取/校验和原子批量变更，并修复并发写入冲突。

### Release notes (en)
Refreshed canvas visuals: neutral default palette, quieter frame labels, reference-aligned file cards, and better figure-ground contrast. Restored double-click node renaming. Closing inactive dock tabs no longer auto-scrolls; the agent no longer steals your current tab when reading or operating web pages and opens fewer tabs overall; default-browser cold start no longer restores a stale tab. Agent tools now load on demand and large tool results offload to disk for steadier long sessions. The pulse-canvas CLI adds a doctor consistency check and repair, layout read/validate, atomic batch mutations, and fixes concurrent write races.

After merge: create and push tag `pulse-canvas-v0.1.28` on origin/master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)