### PR TITLE
Promote canvas capabilities and improve reference previews

### DIFF
--- a/apps/canvas-workspace/harness/knowledge/main-domain-modules.md
+++ b/apps/canvas-workspace/harness/knowledge/main-domain-modules.md
@@ -121,9 +121,12 @@ Electron app shell.
 
 ### `settings/`
 
-Settings and feature-flag ownership: experimental flag overrides, canvas
-plugin config + IPC, built-in tools config + IPC, plugin manifest icons. If a
-setting becomes domain-specific, it moves into that domain.
+Settings and feature-flag ownership: the shared feature registry resolves
+`experimental`, product-owned `stable`, and enabled-user-only `grandfathered`
+lifecycles; only the applicable entries surface as Experimental overrides.
+This module also owns canvas plugin config + IPC, built-in tools config + IPC,
+and plugin manifest icons. If a setting becomes domain-specific, it moves into
+that domain.
 
 ### `perf/`
 

--- a/apps/canvas-workspace/src/main/__tests__/ui-reuse-governance.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/ui-reuse-governance.test.ts
@@ -103,7 +103,9 @@ const RATCHET_BASELINE: Record<string, number> = {
   // (now forwardRef) so they match the new ArtifactsPicker trigger.
   // 309→306 (editor link prompt): Apply/Remove/Cancel now share ui/Button
   // instead of carrying a fourth bespoke micro-button family.
-  rawButtonTags: 306,
+  // 306→304 (Library preview): source and add-to-canvas reuse the native
+  // node-header icon actions instead of duplicating footer text buttons.
+  rawButtonTags: 304,
   // raw <input> tags in .tsx — falls as components/ui/TextField absorbs them.
   // 55→54: ui/TextField's own <input> (+1), WorkspaceSettings name field
   // migrated (-1), and comment-stripping dropped one doc mention (-1).

--- a/apps/canvas-workspace/src/main/runtime/__tests__/control-server.test.ts
+++ b/apps/canvas-workspace/src/main/runtime/__tests__/control-server.test.ts
@@ -65,15 +65,12 @@ async function fileExists(): Promise<boolean> {
   }
 }
 
-async function setCapabilityRuntimeEnabled(
-  enabled: boolean,
-  pageControlEnabled = false,
-): Promise<void> {
+async function writeStaleDisabledCapabilityOverrides(): Promise<void> {
   const flagPath = `${sandboxHome}/.pulse-coder/canvas/experimental-features.json`;
   await fs.mkdir(`${sandboxHome}/.pulse-coder/canvas`, { recursive: true });
   await fs.writeFile(flagPath, JSON.stringify({
-    'agent-runtime-control': enabled,
-    'webview-page-control': pageControlEnabled,
+    'agent-runtime-control': false,
+    'webview-page-control': false,
   }));
 }
 
@@ -97,7 +94,7 @@ async function postRuntime(
 describe('runtime-control server lifecycle', () => {
   beforeEach(async () => {
     await fs.rm(__test.RUNTIME_DIR, { recursive: true, force: true });
-    await setCapabilityRuntimeEnabled(false);
+    await writeStaleDisabledCapabilityOverrides();
   });
 
   afterEach(async () => {
@@ -176,16 +173,20 @@ describe('runtime-control server lifecycle', () => {
     expect(baseUrl2).toBe(baseUrl1);
   });
 
-  it('keeps capability routes hidden until the experimental flag is enabled', async () => {
+  it('keeps stable capability routes enabled despite stale disabled overrides', async () => {
     await startRuntimeControlServer();
     const runtime = await readRuntimeFile();
 
     const response = await postRuntime(runtime, '/capabilities/list', {});
-    expect(response).toEqual({ status: 404, body: { ok: false, error: 'not found' } });
+    expect(response.status).toBe(200);
+    expect(response.body.capabilities).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: 'browser.page.click' }),
+      expect.objectContaining({ name: 'browser.page.fill' }),
+      expect.objectContaining({ name: 'browser.page.eval', risk: 'unsafe' }),
+    ]));
   });
 
   it('lists and calls allowlisted capabilities over the authenticated runtime', async () => {
-    await setCapabilityRuntimeEnabled(true);
     await startRuntimeControlServer();
     const runtime = await readRuntimeFile();
 
@@ -210,10 +211,10 @@ describe('runtime-control server lifecycle', () => {
         expect.objectContaining({ name: 'host.renderer.eval', risk: 'unsafe' }),
       ]),
     });
-    expect(listed.body.capabilities).not.toEqual(expect.arrayContaining([
+    expect(listed.body.capabilities).toEqual(expect.arrayContaining([
       expect.objectContaining({ name: 'browser.page.click' }),
       expect.objectContaining({ name: 'browser.page.fill' }),
-      expect.objectContaining({ name: 'browser.page.eval' }),
+      expect.objectContaining({ name: 'browser.page.eval', risk: 'unsafe' }),
     ]));
 
     const called = await postRuntime(runtime, '/capabilities/call', {
@@ -237,8 +238,7 @@ describe('runtime-control server lifecycle', () => {
     });
   });
 
-  it('reacts to page-control flag changes in both discovery and execution', async () => {
-    await setCapabilityRuntimeEnabled(true, true);
+  it('validates stable page-control calls before executing them', async () => {
     await startRuntimeControlServer();
     const runtime = await readRuntimeFile();
 
@@ -257,27 +257,9 @@ describe('runtime-control server lifecycle', () => {
       status: 400,
       body: { ok: false, error: { code: 'invalid_input' } },
     });
-
-    await setCapabilityRuntimeEnabled(true, false);
-    const disabled = await postRuntime(runtime, '/capabilities/list', {});
-    expect(disabled.body.capabilities).not.toEqual(expect.arrayContaining([
-      expect.objectContaining({ name: 'browser.page.click' }),
-      expect.objectContaining({ name: 'browser.page.fill' }),
-      expect.objectContaining({ name: 'browser.page.eval' }),
-    ]));
-    const forbidden = await postRuntime(runtime, '/capabilities/call', {
-      workspaceId: 'ws-1',
-      name: 'browser.page.fill',
-      input: { nodeId: 'web-1', selector: 'input', value: 'blocked' },
-    });
-    expect(forbidden).toMatchObject({
-      status: 403,
-      body: { ok: false, error: { code: 'capability_forbidden' } },
-    });
   });
 
   it('searches, updates, and reads Canvas nodes through the runtime protocol', async () => {
-    await setCapabilityRuntimeEnabled(true);
     await writeCanvasFull('ws-runtime', {
       nodes: [{
         id: 'note-1',

--- a/apps/canvas-workspace/src/main/settings/experimental-ipc.ts
+++ b/apps/canvas-workspace/src/main/settings/experimental-ipc.ts
@@ -4,7 +4,8 @@
  * Persists user overrides at
  * `~/.pulse-coder/canvas/experimental-features.json` (override the path
  * with `PULSE_CANVAS_EXPERIMENTAL_FEATURES`). The renderer reads the
- * registered defs + the current resolved values via `experimental:list`,
+ * visible user-configurable defs + the current resolved values via
+ * `experimental:list`,
  * toggles via `experimental:set`, and asks the host to reload after a
  * change via `experimental:reload-window` (changes only take effect on
  * the next preload run).
@@ -18,6 +19,8 @@ import {
   EXPERIMENTAL_FEATURES,
   EXPERIMENTAL_FLAG_AGENT_TEAMS,
   EXPERIMENTAL_FLAG_DEFAULT_BROWSER,
+  canConfigureExperimentalFeature,
+  getVisibleExperimentalFeatures,
   resolveFeatureValues,
 } from '../../shared/experimental-features';
 import { setDefaultBrowser } from '../default-browser/register';
@@ -92,7 +95,7 @@ export function setupExperimentalIpc(): void {
       const overrides = await readOverrides();
       return {
         ok: true,
-        features: EXPERIMENTAL_FEATURES,
+        features: getVisibleExperimentalFeatures(overrides),
         values: resolveFeatureValues(overrides),
         path: getPath(),
       };
@@ -108,10 +111,14 @@ export function setupExperimentalIpc(): void {
         if (!payload || typeof payload.id !== 'string') {
           return { ok: false, error: 'Missing flag id' };
         }
-        if (!EXPERIMENTAL_FEATURES.some((f) => f.id === payload.id)) {
+        const feature = EXPERIMENTAL_FEATURES.find((f) => f.id === payload.id);
+        if (!feature) {
           return { ok: false, error: `Unknown experimental feature: ${payload.id}` };
         }
         const overrides = await readOverrides();
+        if (!canConfigureExperimentalFeature(feature, overrides)) {
+          return { ok: false, error: `Experimental feature is not configurable: ${payload.id}` };
+        }
         const wasEnabled = resolveFeatureValues(overrides)[payload.id] === true;
         overrides[payload.id] = !!payload.enabled;
         await writeOverrides(overrides);

--- a/apps/canvas-workspace/src/plugins/main/webview-page-control/index.ts
+++ b/apps/canvas-workspace/src/plugins/main/webview-page-control/index.ts
@@ -4,9 +4,8 @@
  * Registers a set of canvas-agent tools (`page_eval`, `page_click`,
  * `page_click_at`, `page_fill`, `page_press`, `page_scroll`,
  * `page_wait_for`) that let the agent control pages inside iframe
- * canvas nodes via CDP. Gated by the `webview-page-control` experimental
- * flag — when off, the plugin doesn't activate at all and the agent
- * never sees the tool names.
+ * canvas nodes via CDP. Registered through the `webview-page-control`
+ * feature flag; the current stable lifecycle keeps it enabled.
  *
  * URL policy and CDP infrastructure live in sibling files inside this
  * folder; the only outward dependency is on `main/webview/cdp-session.ts`

--- a/apps/canvas-workspace/src/plugins/main/webview-page-control/policy.ts
+++ b/apps/canvas-workspace/src/plugins/main/webview-page-control/policy.ts
@@ -1,7 +1,7 @@
 /**
- * URL policy for the experimental webview page-control tools.
+ * URL policy for the webview page-control tools.
  *
- * The experimental flag `webview-page-control` decides whether the
+ * The feature flag `webview-page-control` decides whether the
  * `page_*` tools are registered at all. This module decides — per call —
  * whether the **current URL** of the target webview is one the agent is
  * allowed to touch. Tools call {@link evaluateActionPolicy} with the

--- a/apps/canvas-workspace/src/plugins/main/webview-page-control/tools.ts
+++ b/apps/canvas-workspace/src/plugins/main/webview-page-control/tools.ts
@@ -3,7 +3,7 @@
  * keys, wait for selectors, run arbitrary JS.
  *
  * Registered as a canvas plugin (see `./index.ts`); gating on the
- * `webview-page-control` experimental flag is handled by the plugin's
+ * `webview-page-control` feature flag is handled by the plugin's
  * `enabledWhen` — by the time this file's factory is called, the flag
  * is known to be on.
  *
@@ -92,7 +92,7 @@ async function executeStructuredPageCapability(
 }
 
 const baseDescription =
-  'Experimental — requires the `webview-page-control` flag. ' +
+  'Requires the `webview-page-control` capability. ' +
   'Operates on iframe canvas nodes in URL mode AND right-dock web tabs — ' +
   'pass the iframe node id or the link-tab id (from canvas_list_tabs) as `nodeId`. ' +
   'Blocked on file://, chrome://, devtools://, view-source://, and a ' +

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/CanvasNodeHeader.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/CanvasNodeHeader.test.tsx
@@ -93,6 +93,19 @@ describe('CanvasNodeHeader title', () => {
     expect(title.getAttribute('role')).toBeNull();
     expect(title.getAttribute('aria-label')).toBeNull();
   });
+
+  it('uses preview-specific copy for the standard source action icon', () => {
+    renderHeader({
+      focusAction: {
+        ariaLabel: 'Open source',
+        title: 'Open source',
+      },
+    });
+
+    const action = host?.querySelector('.node-focus') as HTMLButtonElement;
+    expect(action.getAttribute('aria-label')).toBe('Open source');
+    expect(action.getAttribute('title')).toBe('Open source');
+  });
 });
 
 function renderHeader(overrides: Partial<Parameters<typeof CanvasNodeHeader>[0]> = {}) {

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/CanvasNodeHeader.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/CanvasNodeHeader.tsx
@@ -26,6 +26,10 @@ import { isReferenceableNode } from '../../utils/referenceNodes';
 
 interface CanvasNodeHeaderProps {
   fullscreenButton: ReactNode;
+  focusAction?: {
+    ariaLabel: string;
+    title: string;
+  };
   containerDescendantCount: number;
   handleClose: (e: MouseEvent) => void;
   handleFocus: (e: MouseEvent) => void;
@@ -82,6 +86,7 @@ const NodeLeadingGlyph = ({ node, faviconUrl }: { node: CanvasNode; faviconUrl?:
 
 export const CanvasNodeHeader = ({
   fullscreenButton,
+  focusAction,
   containerDescendantCount,
   handleClose,
   handleFocus,
@@ -213,9 +218,9 @@ export const CanvasNodeHeader = ({
         ) : null}
         {fullscreenButton}
         <FocusButton
-          ariaLabel={t('workspaceNodes.focusNode', { title: node.title })}
+          ariaLabel={focusAction?.ariaLabel ?? t('workspaceNodes.focusNode', { title: node.title })}
           onClick={handleFocus}
-          title={t('workspaceNodes.focusNode', { title: node.title })}
+          title={focusAction?.title ?? t('workspaceNodes.focusNode', { title: node.title })}
         />
         {readOnly ? null : (
           <CloseButton

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/DefaultCanvasNode.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/DefaultCanvasNode.tsx
@@ -36,6 +36,10 @@ const TextNodeBody = lazy(() => import('../TextNodeBodyLazy').then((m) => ({ def
 interface DefaultCanvasNodeProps {
   classes: string;
   fullscreenButton: ReactNode;
+  focusAction?: {
+    ariaLabel: string;
+    title: string;
+  };
   getAllNodes?: () => CanvasNode[];
   containerDescendantCount: number;
   handleClose: (e: MouseEvent) => void;
@@ -67,6 +71,7 @@ interface DefaultCanvasNodeProps {
   onUngroupSelectedGroups?: () => void;
   onUpdate: (id: string, patch: Partial<CanvasNode>) => void | Promise<void>;
   readOnly: boolean;
+  renderFullFileBody: boolean;
   renderMode?: CanvasNodeRenderMode;
   relativeTime: string | null;
   rootFolder?: string;
@@ -79,6 +84,7 @@ interface DefaultCanvasNodeProps {
 export const DefaultCanvasNode = ({
   classes,
   fullscreenButton,
+  focusAction,
   getAllNodes,
   containerDescendantCount,
   handleClose,
@@ -110,6 +116,7 @@ export const DefaultCanvasNode = ({
   onUngroupSelectedGroups,
   onUpdate,
   readOnly,
+  renderFullFileBody,
   renderMode = 'full',
   relativeTime,
   rootFolder,
@@ -210,6 +217,7 @@ export const DefaultCanvasNode = ({
   const header = (
     <CanvasNodeHeader
       fullscreenButton={fullscreenButton}
+      focusAction={focusAction}
       containerDescendantCount={containerDescendantCount}
       handleClose={handleClose}
       handleFocus={handleFocus}
@@ -254,7 +262,14 @@ export const DefaultCanvasNode = ({
       <div className="node-body" onMouseDown={handleNodeBodyMouseDown}>
         <Suspense fallback={null}>
         {node.type === 'file' ? (
-          <FileNodeBody node={node} onUpdate={onUpdate} workspaceId={workspaceId} getAllNodes={getAllNodes} readOnly={readOnly} />
+          <FileNodeBody
+            node={node}
+            onUpdate={onUpdate}
+            workspaceId={workspaceId}
+            getAllNodes={getAllNodes}
+            readOnly={readOnly}
+            renderFullEditor={renderFullFileBody}
+          />
         ) : node.type === 'terminal' ? (
           <TerminalNodeBody node={node} getAllNodes={getAllNodes} rootFolder={rootFolder} workspaceId={workspaceId} workspaceName={workspaceName} onUpdate={onUpdate} readOnly={readOnly} />
         ) : node.type === 'frame' || node.type === 'group' ? (

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/NodeButtons.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/NodeButtons.tsx
@@ -163,9 +163,8 @@ export const AddToCanvasButton = ({ onClick }: { onClick: (e: MouseEvent) => voi
     title="Add to main canvas"
     aria-label="Add node to the main canvas as a reference"
   >
-    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
-      <rect x="2.6" y="2.6" width="9.4" height="9.4" rx="1.6" stroke="currentColor" strokeWidth="1.35" />
-      <path d="M13.4 9.6v3.8m-1.9-1.9h3.8" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" />
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M8 3.25v9.5M3.25 8h9.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
     </svg>
   </button>
 );

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -24,6 +24,7 @@ const CanvasNodeViewComponent = ({
   isHighlighted,
   isAgentEdited,
   focusState = 'neutral',
+  focusAction,
   onDragStart,
   onResizeStart,
   onUpdate,
@@ -45,6 +46,7 @@ const CanvasNodeViewComponent = ({
   isFullscreen = false,
   onToggleFullscreen,
   readOnly = false,
+  renderFullFileBody = false,
   embedded = false,
   hideHeader = false,
   renderMode = 'full',
@@ -185,6 +187,7 @@ const CanvasNodeViewComponent = ({
     <DefaultCanvasNode
       classes={viewModel.classes}
       fullscreenButton={fullscreenButton}
+      focusAction={focusAction}
       getAllNodes={getAllNodes}
       containerDescendantCount={viewModel.containerDescendantCount}
       handleClose={viewModel.handleClose}
@@ -216,6 +219,7 @@ const CanvasNodeViewComponent = ({
       onUngroupSelectedGroups={onUngroupSelectedGroups}
       onUpdate={onUpdate}
       readOnly={readOnly}
+      renderFullFileBody={renderFullFileBody}
       renderMode={renderMode}
       relativeTime={viewModel.relativeTime}
       rootFolder={rootFolder}
@@ -240,6 +244,7 @@ export const CanvasNodeView = memo(CanvasNodeViewComponent, (prev, next) => (
   prev.isHighlighted === next.isHighlighted &&
   prev.isAgentEdited === next.isAgentEdited &&
   prev.focusState === next.focusState &&
+  prev.focusAction === next.focusAction &&
   prev.isFullscreen === next.isFullscreen &&
   prev.onToggleFullscreen === next.onToggleFullscreen &&
   prev.resolveReferenceNode === next.resolveReferenceNode &&
@@ -249,6 +254,7 @@ export const CanvasNodeView = memo(CanvasNodeViewComponent, (prev, next) => (
   prev.onSubmitDomReviewComments === next.onSubmitDomReviewComments &&
   prev.onRemoveNodes === next.onRemoveNodes &&
   prev.readOnly === next.readOnly &&
+  prev.renderFullFileBody === next.renderFullFileBody &&
   prev.embedded === next.embedded &&
   prev.hideHeader === next.hideHeader &&
   prev.renderMode === next.renderMode

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/types.ts
@@ -36,6 +36,12 @@ export interface CanvasNodeViewProps {
   onExportMindmapImage: (id: string) => void;
   onSelect: (id: string, mods?: { shift?: boolean; meta?: boolean }) => void;
   onFocus: (node: CanvasNode) => void;
+  /** Optional copy for the standard focus icon when a read-only preview opens
+   * its source node rather than focusing the node in the current canvas. */
+  focusAction?: {
+    ariaLabel: string;
+    title: string;
+  };
   onReference?: (nodeId: string) => void;
   onAddToChat?: (nodeId: string) => void;
   /** Place this node on the main canvas as a reference (dock preview only). */
@@ -49,6 +55,9 @@ export interface CanvasNodeViewProps {
   isFullscreen?: boolean;
   onToggleFullscreen?: (nodeId: string) => void;
   readOnly?: boolean;
+  /** Keep file nodes on their full Tiptap renderer while preventing edits.
+   * Used by Library previews so they match the source canvas node exactly. */
+  renderFullFileBody?: boolean;
   embedded?: boolean;
   /** Render only the node body when a surrounding document already owns
    * the title and metadata chrome (for example the node detail page/dock). */

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBodyLazy/index.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBodyLazy/index.test.tsx
@@ -32,13 +32,20 @@ const node = {
   updatedAt: 1,
 } as CanvasNode;
 
-const renderFileNodeBodyLazy = async (readOnly = false) => {
+const renderFileNodeBodyLazy = async (readOnly = false, renderFullEditor = false) => {
   host = document.createElement('div');
   document.body.appendChild(host);
   root = createRoot(host);
 
   await act(async () => {
-    root?.render(<FileNodeBodyLazy node={node} onUpdate={vi.fn()} readOnly={readOnly} />);
+    root?.render(
+      <FileNodeBodyLazy
+        node={node}
+        onUpdate={vi.fn()}
+        readOnly={readOnly}
+        renderFullEditor={renderFullEditor}
+      />,
+    );
   });
 
   return host;
@@ -96,5 +103,12 @@ describe('FileNodeBodyLazy', () => {
 
     expect(view.querySelector('[data-testid="mock-file-editor"]')).toBeNull();
     expect(view.querySelector('.file-preview')).not.toBeNull();
+  });
+
+  it('can use the full editor renderer for a read-only preview', async () => {
+    const view = await renderFileNodeBodyLazy(true, true);
+
+    expect(view.querySelector('[data-testid="mock-file-editor"]')).not.toBeNull();
+    expect(view.querySelector('.file-preview')).toBeNull();
   });
 });

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBodyLazy/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBodyLazy/index.tsx
@@ -10,6 +10,7 @@ interface Props {
   workspaceId?: string;
   getAllNodes?: () => CanvasNode[];
   readOnly?: boolean;
+  renderFullEditor?: boolean;
 }
 
 const FileNodeEditor = lazy(() =>
@@ -71,13 +72,13 @@ export const MarkdownPreview = ({ content }: { content: string }) => {
 };
 
 export const FileNodeBodyLazy = (props: Props) => {
-  const [editorLoaded, setEditorLoaded] = useState(() => !props.readOnly);
+  const [editorLoaded, setEditorLoaded] = useState(() => props.renderFullEditor || !props.readOnly);
   const { openLink } = useRightDock();
   const content = (props.node.data as FileNodeData).content ?? '';
 
   useEffect(() => {
-    if (!props.readOnly) setEditorLoaded(true);
-  }, [props.readOnly]);
+    if (props.renderFullEditor || !props.readOnly) setEditorLoaded(true);
+  }, [props.readOnly, props.renderFullEditor]);
 
   const activateEditor = useCallback(() => {
     if (!props.readOnly) setEditorLoaded(true);

--- a/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/ReferencePreviews.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/ReferenceDrawer/ReferencePreviews.tsx
@@ -235,14 +235,13 @@ export const ReferencePreviewPanel = ({
               node={node}
               drawerWidth={drawerWidth}
               workspaceName={workspaceNameById.get(entry.workspaceId) ?? entry.workspaceNameSnapshot}
+              onAddToCanvas={() => onAddReferenceToCanvas(entry)}
               onFocusNode={() => onFocusNode(entry.workspaceId, entry.nodeId)}
             />
             {isActive && (
               <NodeReferenceFooter
-                entry={entry}
-                onAddReferenceToCanvas={onAddReferenceToCanvas}
+                referenceId={id}
                 onClearAll={onClearAll}
-                onFocusNode={onFocusNode}
                 onRemoveReference={onRemoveReference}
               />
             )}
@@ -256,13 +255,12 @@ export const ReferencePreviewPanel = ({
             node={activeReferenceNode}
             drawerWidth={drawerWidth}
             workspaceName={workspaceNameById.get(activeReference.workspaceId) ?? activeReference.workspaceNameSnapshot}
+            onAddToCanvas={() => onAddReferenceToCanvas(activeReference)}
             onFocusNode={() => onFocusNode(activeReference.workspaceId, activeReference.nodeId)}
           />
           <NodeReferenceFooter
-            entry={activeReference}
-            onAddReferenceToCanvas={onAddReferenceToCanvas}
+            referenceId={getReferenceId(activeReference)}
             onClearAll={onClearAll}
-            onFocusNode={onFocusNode}
             onRemoveReference={onRemoveReference}
           />
         </div>
@@ -289,43 +287,30 @@ export const ReferencePreviewPanel = ({
 };
 
 interface NodeReferenceFooterProps {
-  entry: NodeReferenceEntry;
-  onAddReferenceToCanvas: (entry: NodeReferenceEntry) => void;
+  referenceId: string;
   onClearAll: () => void;
-  onFocusNode: (workspaceId: string, nodeId: string) => void;
   onRemoveReference: (referenceId: string) => void;
+  enable?: boolean;
 }
 
 const NodeReferenceFooter = ({
-  entry,
-  onAddReferenceToCanvas,
+  referenceId,
   onClearAll,
-  onFocusNode,
   onRemoveReference,
+  enable = false
 }: NodeReferenceFooterProps) => {
   const { t } = useI18n();
+
+  if (!enable) {
+    return null;
+  }
 
   return (
     <div className="reference-card-footer">
       <button
         className="reference-drawer-secondary"
         type="button"
-        onClick={() => onFocusNode(entry.workspaceId, entry.nodeId)}
-        title={t('reference.openSource')}
-      >
-        {t('reference.openSource')}
-      </button>
-      <button
-        className="reference-drawer-secondary"
-        type="button"
-        onClick={() => onAddReferenceToCanvas(entry)}
-      >
-        {t('reference.addToCanvas')}
-      </button>
-      <button
-        className="reference-drawer-secondary"
-        type="button"
-        onClick={() => onRemoveReference(getReferenceId(entry))}
+        onClick={() => onRemoveReference(referenceId)}
       >
         {t('reference.unpin')}
       </button>
@@ -379,6 +364,7 @@ interface ReferenceNativeNodePreviewProps {
   node: CanvasNode;
   drawerWidth: number;
   workspaceName?: string;
+  onAddToCanvas: () => void;
   onFocusNode: () => void;
 }
 
@@ -386,8 +372,10 @@ const ReferenceNativeNodePreview = memo(({
   node,
   drawerWidth,
   workspaceName,
+  onAddToCanvas,
   onFocusNode,
 }: ReferenceNativeNodePreviewProps) => {
+  const { t } = useI18n();
   const previewNode = useMemo(
     () => ({
       ...node,
@@ -419,7 +407,13 @@ const ReferenceNativeNodePreview = memo(({
       onExportMindmapImage={() => undefined}
       onSelect={() => undefined}
       onFocus={handleFocus}
+      focusAction={{
+        ariaLabel: t('reference.openSource'),
+        title: t('reference.openSource'),
+      }}
+      onAddToCanvas={() => onAddToCanvas()}
       readOnly
+      renderFullFileBody
     />
   );
 });

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
@@ -53,9 +53,9 @@ interface Props {
   onEnterChat: () => void;
   onEnterNodes: () => void;
   onEnterGraph: () => void;
-  /** When false, the Nodes nav button is hidden (experimental flag off). */
+  /** When false, the Nodes nav button is hidden (feature flag off). */
   nodesEnabled: boolean;
-  /** When false, the Graph nav button is hidden (experimental flag off). */
+  /** When false, the Graph nav button is hidden (feature flag off). */
   graphEnabled: boolean;
   pluginNavItems: ReadonlyArray<NavItem>;
   onNavigate: (path: string) => void;

--- a/apps/canvas-workspace/src/shared/experimental-features.test.ts
+++ b/apps/canvas-workspace/src/shared/experimental-features.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   EXPERIMENTAL_FEATURES,
+  EXPERIMENTAL_FLAG_AGENT_DEBUG_TRACE,
   EXPERIMENTAL_FLAG_AGENT_RUNTIME_CONTROL,
   EXPERIMENTAL_FLAG_AGENT_TEAMS,
   EXPERIMENTAL_FLAG_WEBVIEW_PAGE_CONTROL,
@@ -16,6 +17,11 @@ const promotedFeatureIds = [
   EXPERIMENTAL_FLAG_WORKSPACE_GRAPH,
   EXPERIMENTAL_FLAG_WEBVIEW_PAGE_CONTROL,
   EXPERIMENTAL_FLAG_AGENT_RUNTIME_CONTROL,
+];
+
+const grandfatheredFeatureIds = [
+  EXPERIMENTAL_FLAG_AGENT_DEBUG_TRACE,
+  EXPERIMENTAL_FLAG_AGENT_TEAMS,
 ];
 
 describe('experimental feature lifecycle', () => {
@@ -34,17 +40,20 @@ describe('experimental feature lifecycle', () => {
     }
   });
 
-  it('shows Agent Teams only to users who currently have it enabled', () => {
+  it('shows grandfathered features only to users who currently have them enabled', () => {
     const hiddenIds = getVisibleExperimentalFeatures({}).map((feature) => feature.id);
-    const visibleIds = getVisibleExperimentalFeatures({
-      [EXPERIMENTAL_FLAG_AGENT_TEAMS]: true,
-    }).map((feature) => feature.id);
+    const enabledOverrides = Object.fromEntries(
+      grandfatheredFeatureIds.map((id) => [id, true]),
+    );
+    const visibleIds = getVisibleExperimentalFeatures(enabledOverrides)
+      .map((feature) => feature.id);
+    const values = resolveFeatureValues(enabledOverrides);
 
-    expect(hiddenIds).not.toContain(EXPERIMENTAL_FLAG_AGENT_TEAMS);
-    expect(visibleIds).toContain(EXPERIMENTAL_FLAG_AGENT_TEAMS);
-    expect(resolveFeatureValues({
-      [EXPERIMENTAL_FLAG_AGENT_TEAMS]: true,
-    })[EXPERIMENTAL_FLAG_AGENT_TEAMS]).toBe(true);
+    for (const id of grandfatheredFeatureIds) {
+      expect(hiddenIds).not.toContain(id);
+      expect(visibleIds).toContain(id);
+      expect(values[id]).toBe(true);
+    }
   });
 
   it('allows mutation only for visible experimental features', () => {

--- a/apps/canvas-workspace/src/shared/experimental-features.test.ts
+++ b/apps/canvas-workspace/src/shared/experimental-features.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EXPERIMENTAL_FEATURES,
+  EXPERIMENTAL_FLAG_AGENT_RUNTIME_CONTROL,
+  EXPERIMENTAL_FLAG_AGENT_TEAMS,
+  EXPERIMENTAL_FLAG_WEBVIEW_PAGE_CONTROL,
+  EXPERIMENTAL_FLAG_WORKSPACE_GRAPH,
+  EXPERIMENTAL_FLAG_WORKSPACE_NODES,
+  canConfigureExperimentalFeature,
+  getVisibleExperimentalFeatures,
+  resolveFeatureValues,
+} from './experimental-features';
+
+const promotedFeatureIds = [
+  EXPERIMENTAL_FLAG_WORKSPACE_NODES,
+  EXPERIMENTAL_FLAG_WORKSPACE_GRAPH,
+  EXPERIMENTAL_FLAG_WEBVIEW_PAGE_CONTROL,
+  EXPERIMENTAL_FLAG_AGENT_RUNTIME_CONTROL,
+];
+
+describe('experimental feature lifecycle', () => {
+  it('keeps promoted stable features enabled and out of Experimental', () => {
+    const staleDisabledOverrides = Object.fromEntries(
+      promotedFeatureIds.map((id) => [id, false]),
+    );
+
+    const values = resolveFeatureValues(staleDisabledOverrides);
+    const visibleIds = getVisibleExperimentalFeatures(staleDisabledOverrides)
+      .map((feature) => feature.id);
+
+    for (const id of promotedFeatureIds) {
+      expect(values[id]).toBe(true);
+      expect(visibleIds).not.toContain(id);
+    }
+  });
+
+  it('shows Agent Teams only to users who currently have it enabled', () => {
+    const hiddenIds = getVisibleExperimentalFeatures({}).map((feature) => feature.id);
+    const visibleIds = getVisibleExperimentalFeatures({
+      [EXPERIMENTAL_FLAG_AGENT_TEAMS]: true,
+    }).map((feature) => feature.id);
+
+    expect(hiddenIds).not.toContain(EXPERIMENTAL_FLAG_AGENT_TEAMS);
+    expect(visibleIds).toContain(EXPERIMENTAL_FLAG_AGENT_TEAMS);
+    expect(resolveFeatureValues({
+      [EXPERIMENTAL_FLAG_AGENT_TEAMS]: true,
+    })[EXPERIMENTAL_FLAG_AGENT_TEAMS]).toBe(true);
+  });
+
+  it('allows mutation only for visible experimental features', () => {
+    const stable = EXPERIMENTAL_FEATURES.find(
+      (feature) => feature.id === EXPERIMENTAL_FLAG_WORKSPACE_NODES,
+    )!;
+    const grandfathered = EXPERIMENTAL_FEATURES.find(
+      (feature) => feature.id === EXPERIMENTAL_FLAG_AGENT_TEAMS,
+    )!;
+
+    expect(canConfigureExperimentalFeature(stable, {})).toBe(false);
+    expect(canConfigureExperimentalFeature(grandfathered, {})).toBe(false);
+    expect(canConfigureExperimentalFeature(grandfathered, {
+      [EXPERIMENTAL_FLAG_AGENT_TEAMS]: true,
+    })).toBe(true);
+  });
+});

--- a/apps/canvas-workspace/src/shared/experimental-features.ts
+++ b/apps/canvas-workspace/src/shared/experimental-features.ts
@@ -175,8 +175,7 @@ export function getVisibleExperimentalFeatures(
   overrides: Record<string, boolean>,
 ): ExperimentalFeatureDef[] {
   return EXPERIMENTAL_FEATURES.filter((def) => (
-    def.exposure === 'experimental'
-    || (def.exposure === 'grandfathered' && overrides[def.id] === true)
+    canConfigureExperimentalFeature(def, overrides)
   ));
 }
 

--- a/apps/canvas-workspace/src/shared/experimental-features.ts
+++ b/apps/canvas-workspace/src/shared/experimental-features.ts
@@ -81,7 +81,7 @@ export const EXPERIMENTAL_FEATURES: ExperimentalFeatureDef[] = [
     description:
       'Adds a DevTools route that inspects per-run agent debug traces (chat history, tool calls, raw LLM payloads).',
     defaultEnabled: false,
-    exposure: 'experimental',
+    exposure: 'grandfathered',
   },
   {
     id: EXPERIMENTAL_FLAG_WORKSPACE_NODES,

--- a/apps/canvas-workspace/src/shared/experimental-features.ts
+++ b/apps/canvas-workspace/src/shared/experimental-features.ts
@@ -1,8 +1,9 @@
 /**
  * Experimental feature registry.
  *
- * Add a new entry to {@link EXPERIMENTAL_FEATURES} to surface a toggle in
- * Settings → Experimental. The flag id is read by plugins via
+ * Add a new entry to {@link EXPERIMENTAL_FEATURES} to register its lifecycle.
+ * Entries with `exposure: 'experimental'` surface a toggle in Settings →
+ * Experimental. The flag id is read by plugins via
  * `globalThis.canvasWorkspace.pluginFlags[id]` — so to gate a renderer
  * plugin behind a flag, set the plugin's `enabledWhen` to:
  *
@@ -26,8 +27,18 @@ export interface ExperimentalFeatureDef {
   label: string;
   /** One-sentence description for the Settings UI. */
   description: string;
-  /** Value used when the user has not toggled this flag. */
+  /**
+   * Product-owned value. Experimental/grandfathered features use it when the
+   * user has no override; stable features always use it.
+   */
   defaultEnabled: boolean;
+  /**
+   * Lifecycle controls whether the feature is user-configurable:
+   * - experimental: always shown in Settings → Experimental
+   * - stable: hidden; runtime follows the product-owned default
+   * - grandfathered: shown only while an existing user override is true
+   */
+  exposure: 'experimental' | 'stable' | 'grandfathered';
 }
 
 /**
@@ -60,8 +71,9 @@ export const EXPERIMENTAL_FEATURES: ExperimentalFeatureDef[] = [
     id: EXPERIMENTAL_FLAG_AGENT_RUNTIME_CONTROL,
     label: 'Agent runtime control',
     description:
-      'Lets authenticated local developer tools discover and call an allowlisted set of live application capabilities. Off by default while the runtime interface and permission model are experimental.',
-    defaultEnabled: false,
+      'Lets authenticated local developer tools discover and call an allowlisted set of live application capabilities.',
+    defaultEnabled: true,
+    exposure: 'stable',
   },
   {
     id: EXPERIMENTAL_FLAG_AGENT_DEBUG_TRACE,
@@ -69,27 +81,31 @@ export const EXPERIMENTAL_FEATURES: ExperimentalFeatureDef[] = [
     description:
       'Adds a DevTools route that inspects per-run agent debug traces (chat history, tool calls, raw LLM payloads).',
     defaultEnabled: false,
+    exposure: 'experimental',
   },
   {
     id: EXPERIMENTAL_FLAG_WORKSPACE_NODES,
     label: 'Workspace Nodes page',
     description:
       'A workspace-wide knowledge nodes page showing every node as a filterable grid, plus a per-node detail page. Surfaces a "Nodes" entry in the sidebar.',
-    defaultEnabled: false,
+    defaultEnabled: true,
+    exposure: 'stable',
   },
   {
     id: EXPERIMENTAL_FLAG_WORKSPACE_GRAPH,
     label: 'Workspace Graph page',
     description:
       'A force-directed graph view of all nodes in the workspace with grouped toolbar and suggest-search. Surfaces a "Graph" entry in the sidebar.',
-    defaultEnabled: false,
+    defaultEnabled: true,
+    exposure: 'stable',
   },
   {
     id: EXPERIMENTAL_FLAG_WEBVIEW_PAGE_CONTROL,
     label: 'Webview page control (agent)',
     description:
       'Lets the Canvas Agent control pages inside iframe nodes — click (by selector or pixel coordinates), fill, press keys, scroll, wait for selectors, run arbitrary JS. Clicks and key presses go through Chromium DevTools Protocol (real input events that fire pointer / hover / user-activation handlers) — the OS cursor does not move. Blocked on file://, chrome://, devtools:// and a built-in sensitive-domain list (banks, payments, mainstream login). Customize via ~/.pulse-coder/canvas/webview-action-policy.json. Treat this as giving an LLM access to whatever you are currently logged into.',
-    defaultEnabled: false,
+    defaultEnabled: true,
+    exposure: 'stable',
   },
   {
     id: EXPERIMENTAL_FLAG_DYNAMIC_APP,
@@ -97,6 +113,7 @@ export const EXPERIMENTAL_FEATURES: ExperimentalFeatureDef[] = [
     description:
       'Lets the Canvas Agent create live, server-backed iframe nodes — either polling apps (pull an external JSON endpoint on a schedule, optionally transform, render in LLM-authored HTML) or stateful apps (own their state, accept user mutations via POST actions, persist across restarts; todos / notes / counters / small forms). Each app gets its own loopback HTTP server in the Electron main process. LLM-authored transforms and action handlers run in a vm sandbox (no fetch / require / process; 1s sync timeout). State and spec files live under ~/.pulse-coder/canvas/<workspaceId>/dynamic-apps/. Off by default because this surfaces three new agent tools and a long-running HTTP server.',
     defaultEnabled: false,
+    exposure: 'experimental',
   },
   {
     id: EXPERIMENTAL_FLAG_CHANNELS,
@@ -104,6 +121,7 @@ export const EXPERIMENTAL_FEATURES: ExperimentalFeatureDef[] = [
     description:
       'Drive a workspace’s Canvas Agent from an external chat channel. Feishu (Lark) is supported today via the SDK long-connection (works behind NAT, no public URL). Also requires FEISHU_APP_ID / FEISHU_APP_SECRET env vars set before launch; without them the channel stays inactive even when this flag is on. Inbound messages are bound to a workspace (default + switchable via /bind), the agent runs, and output streams back as an interactive card. Off by default because it opens an outbound connection to Feishu and lets a remote chat drive the agent.',
     defaultEnabled: false,
+    exposure: 'experimental',
   },
   {
     id: EXPERIMENTAL_FLAG_SCHEDULED_MEMORY_REPORT,
@@ -111,6 +129,7 @@ export const EXPERIMENTAL_FEATURES: ExperimentalFeatureDef[] = [
     description:
       'Generates a weekly cross-workspace memory report in the background (activity summary + candidate memories and skills to adopt in chat). The first automatic report arrives after a full week; use the try-it button below to generate one immediately. Reports open in the right dock and are archived under ~/.pulse-coder/canvas/memory/reports/. Off by default because each automatic run calls your configured LLM without an explicit prompt from you. The background run is read-only: adopting candidates always happens in chat with your confirmation.',
     defaultEnabled: false,
+    exposure: 'experimental',
   },
   {
     id: EXPERIMENTAL_FLAG_AGENT_TEAMS,
@@ -118,6 +137,7 @@ export const EXPERIMENTAL_FEATURES: ExperimentalFeatureDef[] = [
     description:
       'Shows the Agent Team canvas entry for experimental multi-agent planning and execution. Existing Agent Team frames can still be opened from saved canvases.',
     defaultEnabled: false,
+    exposure: 'grandfathered',
   },
   {
     id: EXPERIMENTAL_FLAG_DEFAULT_BROWSER,
@@ -125,23 +145,46 @@ export const EXPERIMENTAL_FEATURES: ExperimentalFeatureDef[] = [
     description:
       'Registers Pulse Canvas as your system handler for http/https links, so links opened anywhere on your computer open in an in-app browser tab instead of your real browser. NOT RECOMMENDED: Pulse Canvas is not a full web browser — many sites (logins, banking, anything sending X-Frame-Options / CSP frame-ancestors) will not load in-app, and there are no bookmarks, extensions, profiles, or password autofill. Enabling this also turns on a single-instance lock (a second launch focuses the existing window instead of opening a new one), and your OS may still require you to confirm the switch in System Settings. Restart the app after toggling for it to fully take effect. Only works in a packaged build; leave off unless you specifically want links captured into the canvas. Turning it off unregisters the handler.',
     defaultEnabled: false,
+    exposure: 'experimental',
   },
 ];
 
 /**
- * Merge user overrides on top of registry defaults. Unknown override keys
- * are preserved (so a stale persisted entry from a removed feature does
- * not crash anything), but only registered flags show up in Settings.
+ * Resolve runtime values from lifecycle policy plus user overrides. Stable
+ * features follow their product-owned default; experimental and grandfathered
+ * features allow an existing user override. Unknown keys are preserved so a
+ * stale persisted entry from a removed feature does not crash anything.
  */
 export function resolveFeatureValues(
   overrides: Record<string, boolean>,
 ): Record<string, boolean> {
   const out: Record<string, boolean> = {};
   for (const def of EXPERIMENTAL_FEATURES) {
-    out[def.id] = overrides[def.id] ?? def.defaultEnabled;
+    out[def.id] = def.exposure === 'stable'
+      ? def.defaultEnabled
+      : overrides[def.id] ?? def.defaultEnabled;
   }
   for (const [k, v] of Object.entries(overrides)) {
     if (!(k in out) && typeof v === 'boolean') out[k] = v;
   }
   return out;
+}
+
+/** Return only features that should appear in Settings → Experimental. */
+export function getVisibleExperimentalFeatures(
+  overrides: Record<string, boolean>,
+): ExperimentalFeatureDef[] {
+  return EXPERIMENTAL_FEATURES.filter((def) => (
+    def.exposure === 'experimental'
+    || (def.exposure === 'grandfathered' && overrides[def.id] === true)
+  ));
+}
+
+/** Match the mutation surface to the list shown to the current user. */
+export function canConfigureExperimentalFeature(
+  def: ExperimentalFeatureDef,
+  overrides: Record<string, boolean>,
+): boolean {
+  return def.exposure === 'experimental'
+    || (def.exposure === 'grandfathered' && overrides[def.id] === true);
 }


### PR DESCRIPTION
## Summary

- Introduce lifecycle-aware feature visibility and prevent stale overrides from disabling stable capabilities.
- Update runtime-control tests for stable page-control routes and unsafe capability metadata.
- Reuse native node-header actions in reference previews, including source navigation and add-to-canvas.
- Render read-only file previews with the full editor renderer.
- Update UI governance baselines and regression coverage.

## Testing

- Added and updated runtime-control, canvas header, and file preview tests.