### PR TITLE
feat(canvas): refine connector curves and visual weight

### DIFF
--- a/apps/canvas-workspace/harness/skills/validate-canvas-change/SKILL.md
+++ b/apps/canvas-workspace/harness/skills/validate-canvas-change/SKILL.md
@@ -10,11 +10,12 @@ source of truth. Run from the repository root.
 
 ## Choose the Level
 
-- During iteration, run `pnpm run harness` (default `quick`). Keep feedback
+- During iteration, run `node scripts/harness/run-harness-check.mjs` (default
+  `quick`). Keep feedback
   fast and do not run the full performance report.
 - When the change is functionally complete, run
-  `pnpm run harness -- --level standard`.
-- Run `pnpm run harness -- --level release` only for a performance-focused
+  `node scripts/harness/run-harness-check.mjs --level standard`.
+- Run `node scripts/harness/run-harness-check.mjs --level release` only for a performance-focused
   task, a performance-sensitive change, or release evidence.
 - Do not use `--all` as routine acceptance for a local change. It intentionally
   selects `release` and performs a repository-wide sweep.

--- a/apps/canvas-workspace/src/main/agent/__tests__/tools-graph.test.ts
+++ b/apps/canvas-workspace/src/main/agent/__tests__/tools-graph.test.ts
@@ -272,6 +272,31 @@ describe('canvas_create_edge', () => {
       style: 'solid',
     });
   });
+
+  it('normalizes legacy defaults before applying a partial style update', async () => {
+    await setupCanvas({
+      edges: [{
+        id: 'legacy-edge',
+        source: { kind: 'node', nodeId: 'n-file' },
+        target: { kind: 'node', nodeId: 'n-text' },
+        stroke: { color: '#1f2328', width: 2.4, style: 'solid' },
+      }],
+    });
+    const tools = createCanvasTools(wsId);
+
+    const result = JSON.parse(await tools.canvas_update_edge.execute({
+      edgeId: 'legacy-edge',
+      color: '#ff0000',
+    }));
+
+    expect(result.ok).toBe(true);
+    const { data } = await readCanvasFull(wsId);
+    expect((data?.edges?.[0] as CanvasEdge | undefined)?.stroke).toEqual({
+      color: '#ff0000',
+      width: 4,
+      style: 'solid',
+    });
+  });
 });
 
 describe('createGlobalCanvasTools', () => {

--- a/apps/canvas-workspace/src/main/agent/__tests__/tools-graph.test.ts
+++ b/apps/canvas-workspace/src/main/agent/__tests__/tools-graph.test.ts
@@ -73,6 +73,7 @@ import {
   WORKSPACE_NODE_SCHEMA_VERSION,
 } from '../../canvas/nodes/store';
 import { upsertKnowledgeTag } from '../../canvas/nodes/tags';
+import type { CanvasEdge } from '../../../shared/canvas';
 
 const wsId = 'ws-tools-test';
 
@@ -249,6 +250,26 @@ describe('canvas_create_node placement', () => {
       y: result.y,
       width: 120,
       height: 80,
+    });
+  });
+});
+
+describe('canvas_create_edge', () => {
+  it('persists the canonical stroke when no style override is supplied', async () => {
+    await setupCanvas();
+    const tools = createCanvasTools(wsId);
+
+    const result = JSON.parse(await tools.canvas_create_edge.execute({
+      sourceNodeId: 'n-file',
+      targetNodeId: 'n-text',
+    }));
+
+    expect(result.ok).toBe(true);
+    const { data } = await readCanvasFull(wsId);
+    expect((data?.edges?.[0] as CanvasEdge | undefined)?.stroke).toEqual({
+      color: '#2e2e2e',
+      width: 4,
+      style: 'solid',
     });
   });
 });

--- a/apps/canvas-workspace/src/main/agent/tools/edges-tools.ts
+++ b/apps/canvas-workspace/src/main/agent/tools/edges-tools.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod';
 import type { CanvasEdge, CanvasTool, EdgeArrowCap, EdgeEndpoint, EdgeStroke } from './types';
-import { DEFAULT_EDGE_STROKE } from '../../../shared/canvas';
+import {
+  DEFAULT_EDGE_STROKE,
+  resolveEdgeStroke,
+} from '../../../shared/canvas';
 import { loadCanvas, saveCanvas } from './_shared/canvas-io';
 import { broadcastUpdate } from './_shared/broadcast';
 import { buildEndpoint, describeEndpoint, genEdgeId } from './_shared/edges';
@@ -193,22 +196,20 @@ export function createEdgeTools(workspaceId: string): Record<string, CanvasTool>
         const freshIdx = freshEdges.findIndex((e) => e.id === edgeId);
         if (freshIdx === -1) return `Error: edge not found: ${edgeId}`;
         const existing = freshEdges[freshIdx];
+        const existingStroke = resolveEdgeStroke(existing.stroke);
 
         const nextStroke =
           input.color != null || input.width != null || input.style != null
             ? {
                 color:
                   (input.color as string | undefined) ??
-                  existing.stroke?.color ??
-                  DEFAULT_EDGE_STROKE.color,
+                  existingStroke.color,
                 width:
                   (input.width as number | undefined) ??
-                  existing.stroke?.width ??
-                  DEFAULT_EDGE_STROKE.width,
+                  existingStroke.width,
                 style:
                   (input.style as 'solid' | 'dashed' | 'dotted' | undefined) ??
-                  existing.stroke?.style ??
-                  'solid',
+                  existingStroke.style,
               }
             : existing.stroke;
         const next: CanvasEdge = {

--- a/apps/canvas-workspace/src/main/agent/tools/edges-tools.ts
+++ b/apps/canvas-workspace/src/main/agent/tools/edges-tools.ts
@@ -111,14 +111,15 @@ export function createEdgeTools(workspaceId: string): Record<string, CanvasTool>
           return `Error: target node not found: ${target.nodeId}`;
         }
 
-        const stroke: EdgeStroke | undefined =
+        const stroke: EdgeStroke =
           input.color != null || input.width != null || input.style != null
             ? {
                 color: (input.color as string | undefined) ?? DEFAULT_EDGE_STROKE.color,
                 width: (input.width as number | undefined) ?? DEFAULT_EDGE_STROKE.width,
-                style: (input.style as 'solid' | 'dashed' | 'dotted' | undefined) ?? 'solid',
+                style: (input.style as 'solid' | 'dashed' | 'dotted' | undefined) ??
+                  DEFAULT_EDGE_STROKE.style,
               }
-            : undefined;
+            : { ...DEFAULT_EDGE_STROKE };
 
         const edge: CanvasEdge = {
           id: genEdgeId(),

--- a/apps/canvas-workspace/src/main/agent/tools/edges-tools.ts
+++ b/apps/canvas-workspace/src/main/agent/tools/edges-tools.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { CanvasEdge, CanvasTool, EdgeArrowCap, EdgeEndpoint, EdgeStroke } from './types';
+import { DEFAULT_EDGE_STROKE } from '../../../shared/canvas';
 import { loadCanvas, saveCanvas } from './_shared/canvas-io';
 import { broadcastUpdate } from './_shared/broadcast';
 import { buildEndpoint, describeEndpoint, genEdgeId } from './_shared/edges';
@@ -67,10 +68,12 @@ export function createEdgeTools(workspaceId: string): Record<string, CanvasTool>
           .describe('Cap rendered at the target end. Default: "triangle".'),
         arrowTail: z.enum(['none', 'triangle', 'arrow', 'dot', 'bar']).optional()
           .describe('Cap rendered at the source end. Default: "none".'),
-        color: z.string().optional().describe('Stroke color (hex, e.g. "#1f2328").'),
-        width: z.number().optional().describe('Stroke width in px. Default 2.4.'),
+        color: z.string().optional().describe('Stroke color (hex, e.g. "#2e2e2e").'),
+        width: z.number().optional().describe('Stroke width in canvas units. Default 4.'),
         style: z.enum(['solid', 'dashed', 'dotted']).optional().describe('Stroke dash style. Default "solid".'),
-        bend: z.number().optional().describe('Perpendicular peak offset of the curve. 0 (default) = straight line.'),
+        bend: z.number().optional().describe(
+          'Perpendicular peak offset of a manual curve. 0 (default) uses smooth automatic routing for node-bound edges.',
+        ),
         kind: z.string().optional().describe('Optional semantic tag (e.g. "depends-on", "references").'),
         payload: z.record(z.string(), z.unknown()).optional().describe('Free-form extra data attached to the edge.'),
       }),
@@ -111,8 +114,8 @@ export function createEdgeTools(workspaceId: string): Record<string, CanvasTool>
         const stroke: EdgeStroke | undefined =
           input.color != null || input.width != null || input.style != null
             ? {
-                color: (input.color as string | undefined) ?? '#1f2328',
-                width: (input.width as number | undefined) ?? 2.4,
+                color: (input.color as string | undefined) ?? DEFAULT_EDGE_STROKE.color,
+                width: (input.width as number | undefined) ?? DEFAULT_EDGE_STROKE.width,
                 style: (input.style as 'solid' | 'dashed' | 'dotted' | undefined) ?? 'solid',
               }
             : undefined;
@@ -193,8 +196,14 @@ export function createEdgeTools(workspaceId: string): Record<string, CanvasTool>
         const nextStroke =
           input.color != null || input.width != null || input.style != null
             ? {
-                color: (input.color as string | undefined) ?? existing.stroke?.color ?? '#1f2328',
-                width: (input.width as number | undefined) ?? existing.stroke?.width ?? 2.4,
+                color:
+                  (input.color as string | undefined) ??
+                  existing.stroke?.color ??
+                  DEFAULT_EDGE_STROKE.color,
+                width:
+                  (input.width as number | undefined) ??
+                  existing.stroke?.width ??
+                  DEFAULT_EDGE_STROKE.width,
                 style:
                   (input.style as 'solid' | 'dashed' | 'dotted' | undefined) ??
                   existing.stroke?.style ??

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasDemoCanvas.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasDemoCanvas.ts
@@ -109,12 +109,12 @@ export const useCanvasDemoCanvas = ({
   addEdge(createDefaultEdge(
     { kind: 'node', nodeId: goal.id, anchor: 'bottom' },
     { kind: 'node', nodeId: agent.id, anchor: 'auto' },
-    { label: t('canvas.demo.edgeBrief'), stroke: { color: '#2383e2', width: 2.4, style: 'solid' } },
+    { label: t('canvas.demo.edgeBrief'), stroke: { color: '#2383e2', width: 4, style: 'solid' } },
   ));
   addEdge(createDefaultEdge(
     { kind: 'node', nodeId: repo.id, anchor: 'bottom' },
     { kind: 'node', nodeId: agent.id, anchor: 'auto' },
-    { label: t('canvas.demo.edgeContext'), stroke: { color: '#10b981', width: 2.4, style: 'solid' } },
+    { label: t('canvas.demo.edgeContext'), stroke: { color: '#10b981', width: 4, style: 'solid' } },
   ));
 
   makeFrame(leftB, t('canvas.demo.frameResearchTitle'), '#f59e0b');
@@ -146,7 +146,7 @@ export const useCanvasDemoCanvas = ({
   addEdge(createDefaultEdge(
     { kind: 'node', nodeId: source.id, anchor: 'right' },
     { kind: 'node', nodeId: takeaways.id, anchor: 'left' },
-    { label: t('canvas.demo.edgeCapture'), stroke: { color: '#f59e0b', width: 2.4, style: 'solid' } },
+    { label: t('canvas.demo.edgeCapture'), stroke: { color: '#f59e0b', width: 4, style: 'solid' } },
   ));
 
   makeFrame(leftC, t('canvas.demo.frameBrainstormTitle'), '#9575d4');
@@ -185,7 +185,7 @@ export const useCanvasDemoCanvas = ({
   addEdge(createDefaultEdge(
     { kind: 'node', nodeId: ideas.id, anchor: 'bottom' },
     { kind: 'node', nodeId: plan.id, anchor: 'top' },
-    { label: t('canvas.demo.edgePrioritize'), stroke: { color: '#9575d4', width: 2.4, style: 'solid' } },
+    { label: t('canvas.demo.edgePrioritize'), stroke: { color: '#9575d4', width: 4, style: 'solid' } },
   ));
 
   setSelectedNodeIds([goal.id]);

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.test.tsx
@@ -163,3 +163,58 @@ describe('edge interaction preview projection', () => {
     });
   });
 });
+
+describe('default edge presentation', () => {
+  it('renders node-bound edges as anchor-aware cubic curves', () => {
+    const curvedNodes: CanvasNode[] = [
+      {
+        id: 'source',
+        type: 'text',
+        title: 'Source',
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 60,
+        data: { text: 'source' },
+      } as CanvasNode,
+      {
+        id: 'target',
+        type: 'text',
+        title: 'Target',
+        x: 146,
+        y: 102,
+        width: 100,
+        height: 60,
+        data: { text: 'target' },
+      } as CanvasNode,
+    ];
+    const edge: CanvasEdge = {
+      id: 'curved',
+      source: { kind: 'node', nodeId: 'source', anchor: 'right' },
+      target: { kind: 'node', nodeId: 'target', anchor: 'top' },
+      arrowHead: 'none',
+    };
+
+    const html = renderToStaticMarkup(
+      <CanvasEdgesLayer edges={[edge]} nodes={curvedNodes} selectedEdgeId={null} />,
+    );
+
+    expect(html).toContain('d="M 100 30 C 140 30 196 62 196 102"');
+  });
+
+  it('uses Heptabase-like world-space ink with a forgiving screen-space hit target', () => {
+    const edge: CanvasEdge = {
+      id: 'styled',
+      source: { kind: 'point', x: 0, y: 0 },
+      target: { kind: 'point', x: 100, y: 0 },
+      arrowHead: 'none',
+    };
+
+    const html = renderToStaticMarkup(
+      <CanvasEdgesLayer edges={[edge]} nodes={[]} selectedEdgeId={null} />,
+    );
+
+    expect(html).toContain('stroke="transparent" stroke-width="16" vector-effect="non-scaling-stroke"');
+    expect(html).toContain('stroke="#2e2e2e" stroke-width="4"');
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.test.tsx
@@ -208,6 +208,7 @@ describe('default edge presentation', () => {
       source: { kind: 'point', x: 0, y: 0 },
       target: { kind: 'point', x: 100, y: 0 },
       arrowHead: 'none',
+      stroke: { color: '#1f2328', width: 2.4, style: 'solid' },
     };
 
     const html = renderToStaticMarkup(

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.test.tsx
@@ -153,6 +153,7 @@ describe('edge interaction preview projection', () => {
       cursor: { x: 50, y: 30 },
       originBend: 0,
       originOffset: 0,
+      smoothBend: false,
       previewPatch: { bend: -30 },
     };
     expect(applyEdgeInteractionPreview(freeEdge, bendState)).toMatchObject({ bend: -30 });

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
@@ -6,9 +6,11 @@ import type {
   EdgeStroke,
 } from '../types';
 import {
+  edgePathGeometry,
   resolveEndpoint,
   resolveEndpointToward,
 } from '../utils/edgeFactory';
+import { DEFAULT_EDGE_STROKE } from '../../../shared/canvas';
 import type { EdgeInteractionState, Point } from '../hooks/useEdgeInteraction';
 import {
   capId,
@@ -54,13 +56,7 @@ export interface CanvasEdgesLayerProps {
   onBodyContextMenu?: (edgeId: string, e: React.MouseEvent) => void;
 }
 
-const DEFAULT_STROKE: Required<EdgeStroke> = {
-  color: '#1f2328',
-  width: 2.4,
-  style: 'solid',
-};
-
-const HIT_PROXY_WIDTH = 10;
+const HIT_PROXY_WIDTH = 16;
 /** Edges fully outside the focus context fade to this opacity in focus
  * mode — matches the node dim level so the canvas reads as a single
  * cohesive faded layer behind the focused card. */
@@ -82,30 +78,6 @@ const strokeDasharray = (style: EdgeStroke['style']): string | undefined => {
     case 'solid':
     default:       return undefined;
   }
-};
-
-const bendControlPoint = (
-  sx: number, sy: number,
-  tx: number, ty: number,
-  bend: number,
-): { cx: number; cy: number } => {
-  const mx = (sx + tx) / 2;
-  const my = (sy + ty) / 2;
-  if (!bend) return { cx: mx, cy: my };
-  const dx = tx - sx;
-  const dy = ty - sy;
-  const len = Math.hypot(dx, dy) || 1;
-  const nx = dy / len;
-  const ny = -dx / len;
-  // bend = peak offset of rendered curve; control point sits at 2×bend
-  // because a quadratic's t=0.5 value is (M + P1)/2 (see useEdgeInteraction).
-  return { cx: mx + nx * bend * 2, cy: my + ny * bend * 2 };
-};
-
-const buildPathData = (s: Point, t: Point, bend: number): string => {
-  if (!bend) return `M ${s.x} ${s.y} L ${t.x} ${t.y}`;
-  const { cx, cy } = bendControlPoint(s.x, s.y, t.x, t.y, bend);
-  return `M ${s.x} ${s.y} Q ${cx} ${cy} ${t.x} ${t.y}`;
 };
 
 /** Apply render-only drag geometry without mutating the canonical edge. */
@@ -155,7 +127,7 @@ const useMarkerDefs = (edges: CanvasEdge[]) => {
       { id: string; cap: EdgeArrowCap; color: string; side: 'head' | 'tail' }
     >();
     for (const edge of edges) {
-      const color = edge.stroke?.color ?? DEFAULT_STROKE.color;
+      const color = edge.stroke?.color ?? DEFAULT_EDGE_STROKE.color;
       const head = edge.arrowHead ?? 'triangle';
       const tail = edge.arrowTail ?? 'none';
       if (head !== 'none') {
@@ -250,9 +222,9 @@ const CanvasEdgesLayerComponent = ({
       <Markers markers={markers} />
 
       {resolved.map(({ edge, s, t }) => {
-        const bend = edge.bend ?? 0;
-        const d = buildPathData(s, t, bend);
-        const stroke = { ...DEFAULT_STROKE, ...edge.stroke };
+        const geometry = edgePathGeometry(edge, s, t, nodesById);
+        const d = geometry.d;
+        const stroke = { ...DEFAULT_EDGE_STROKE, ...edge.stroke };
         const head = edge.arrowHead ?? 'triangle';
         const tail = edge.arrowTail ?? 'none';
         const isSelected = edge.id === selectedEdgeId;
@@ -327,7 +299,7 @@ const CanvasEdgesLayerComponent = ({
                 fill="none"
                 stroke={SELECTION_COLOR}
                 strokeOpacity={0.35}
-                strokeWidth={(stroke.width ?? DEFAULT_STROKE.width) + 6}
+                strokeWidth={stroke.width + 6}
                 strokeLinecap="round"
               />
             )}
@@ -340,9 +312,9 @@ const CanvasEdgesLayerComponent = ({
                 the handle's ring stays clearly readable. */}
             {isSelected && onHandleMouseDown && (
               <EdgeHandles
-                edge={edge}
                 s={s}
                 t={t}
+                midpoint={geometry.midpoint}
                 onHandleMouseDown={(handle, e) =>
                   onHandleMouseDown(edge.id, handle, e, { s, t })
                 }

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayer.tsx
@@ -6,11 +6,9 @@ import type {
   EdgeStroke,
 } from '../types';
 import {
-  edgePathGeometry,
-  resolveEndpoint,
-  resolveEndpointToward,
+  resolveEdgePathGeometry,
 } from '../utils/edgeFactory';
-import { DEFAULT_EDGE_STROKE } from '../../../shared/canvas';
+import { resolveEdgeStroke } from '../../../shared/canvas';
 import type { EdgeInteractionState, Point } from '../hooks/useEdgeInteraction';
 import {
   capId,
@@ -69,7 +67,6 @@ const FOCUS_CONTEXT_EDGE_OPACITY = 0.45;
  *  at. Without this, the arrow-head marker sits flush against the node
  *  and gets visually swallowed by the node's background/border. tldraw
  *  leaves similar breathing room for the same reason. */
-const ARROW_NODE_GAP = 6;
 
 const strokeDasharray = (style: EdgeStroke['style']): string | undefined => {
   switch (style) {
@@ -99,27 +96,6 @@ export const applyEdgeInteractionPreview = (
   return { ...edge, ...patch };
 };
 
-/**
- * Pull the resolved `end` point back from the node boundary by `gap`
- * canvas units along the straight line from `other` → `end`. Used when
- * the endpoint is node-bound AND has a visible arrow cap, so the cap
- * doesn't render flush against the node (where it visually merges into
- * the node's border/background).
- *
- * Returns `end` unchanged when `gap` is 0 or the two points coincide.
- */
-const insetTowardOther = (end: Point, other: Point, gap: number): Point => {
-  if (gap <= 0) return end;
-  const dx = end.x - other.x;
-  const dy = end.y - other.y;
-  const len = Math.hypot(dx, dy);
-  if (len === 0) return end;
-  return {
-    x: end.x - (dx / len) * gap,
-    y: end.y - (dy / len) * gap,
-  };
-};
-
 const useMarkerDefs = (edges: CanvasEdge[]) => {
   return useMemo(() => {
     const markers = new Map<
@@ -127,7 +103,7 @@ const useMarkerDefs = (edges: CanvasEdge[]) => {
       { id: string; cap: EdgeArrowCap; color: string; side: 'head' | 'tail' }
     >();
     for (const edge of edges) {
-      const color = edge.stroke?.color ?? DEFAULT_EDGE_STROKE.color;
+      const color = resolveEdgeStroke(edge.stroke).color;
       const head = edge.arrowHead ?? 'triangle';
       const tail = edge.arrowTail ?? 'none';
       if (head !== 'none') {
@@ -188,19 +164,13 @@ const CanvasEdgesLayerComponent = ({
   const resolved = useMemo(() => {
     return edges.map((edge) => {
       const renderedEdge = applyEdgeInteractionPreview(edge, interactionState);
-      const approxS = resolveEndpoint(renderedEdge.source, nodesById);
-      const approxT = resolveEndpoint(renderedEdge.target, nodesById);
-      let s = resolveEndpointToward(renderedEdge.source, nodesById, approxT);
-      let t = resolveEndpointToward(renderedEdge.target, nodesById, approxS);
-      const head = renderedEdge.arrowHead ?? 'triangle';
-      const tail = renderedEdge.arrowTail ?? 'none';
-      if (renderedEdge.target.kind === 'node' && head !== 'none') {
-        t = insetTowardOther(t, s, ARROW_NODE_GAP);
-      }
-      if (renderedEdge.source.kind === 'node' && tail !== 'none') {
-        s = insetTowardOther(s, t, ARROW_NODE_GAP);
-      }
-      return { edge: renderedEdge, s, t };
+      const geometry = resolveEdgePathGeometry(renderedEdge, nodesById);
+      return {
+        edge: renderedEdge,
+        s: geometry.sourcePoint,
+        t: geometry.targetPoint,
+        geometry,
+      };
     });
   }, [edges, interactionState, nodesById]);
 
@@ -221,10 +191,9 @@ const CanvasEdgesLayerComponent = ({
     >
       <Markers markers={markers} />
 
-      {resolved.map(({ edge, s, t }) => {
-        const geometry = edgePathGeometry(edge, s, t, nodesById);
+      {resolved.map(({ edge, s, t, geometry }) => {
         const d = geometry.d;
-        const stroke = { ...DEFAULT_EDGE_STROKE, ...edge.stroke };
+        const stroke = resolveEdgeStroke(edge.stroke);
         const head = edge.arrowHead ?? 'triangle';
         const tail = edge.arrowTail ?? 'none';
         const isSelected = edge.id === selectedEdgeId;

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayerParts.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasEdgesLayerParts.tsx
@@ -1,5 +1,4 @@
-import type { CanvasEdge, CanvasNode, EdgeArrowCap } from '../types';
-import { bendHandlePoint } from '../utils/edgeFactory';
+import type { CanvasNode, EdgeArrowCap } from '../types';
 import type { Point } from '../hooks/useEdgeInteraction';
 
 export const SELECTION_COLOR = '#2a7fff';
@@ -60,18 +59,16 @@ export const Markers = ({
 );
 
 export const EdgeHandles = ({
-  edge,
   s,
   t,
+  midpoint,
   onHandleMouseDown,
 }: {
-  edge: CanvasEdge;
   s: Point;
   t: Point;
+  midpoint: Point;
   onHandleMouseDown: (handle: 'source' | 'target' | 'bend', e: React.MouseEvent) => void;
 }) => {
-  const bend = edge.bend ?? 0;
-  const mid = bendHandlePoint(s, t, bend);
   const handleStyle: React.CSSProperties = {
     pointerEvents: 'all',
     cursor: 'grab',
@@ -94,8 +91,8 @@ export const EdgeHandles = ({
         }}
       />
       <circle
-        cx={mid.x}
-        cy={mid.y}
+        cx={midpoint.x}
+        cy={midpoint.y}
         r={HANDLE_RADIUS - 0.5}
         fill="#ffffff"
         stroke={SELECTION_COLOR}

--- a/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/EdgeLabel.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/EdgeLabel.test.tsx
@@ -31,7 +31,6 @@ describe('EdgeLabel', () => {
       id: 'curved',
       source: { kind: 'node', nodeId: 'source', anchor: 'right' },
       target: { kind: 'node', nodeId: 'target', anchor: 'top' },
-      arrowHead: 'none',
       label: 'relationship',
     };
 
@@ -47,6 +46,6 @@ describe('EdgeLabel', () => {
       />,
     );
 
-    expect(html).toContain('left:163px;top:51px');
+    expect(html).toContain('left:159.85px;top:49.95px');
   });
 });

--- a/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/EdgeLabel.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/EdgeLabel.test.tsx
@@ -1,0 +1,52 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import type { CanvasEdge, CanvasNode } from '../../types';
+import { EdgeLabel } from '.';
+
+describe('EdgeLabel', () => {
+  it('sits on the visual midpoint of an automatically routed curve', () => {
+    const nodes: CanvasNode[] = [
+      {
+        id: 'source',
+        type: 'text',
+        title: 'Source',
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 60,
+        data: { text: 'source' },
+      } as CanvasNode,
+      {
+        id: 'target',
+        type: 'text',
+        title: 'Target',
+        x: 146,
+        y: 102,
+        width: 100,
+        height: 60,
+        data: { text: 'target' },
+      } as CanvasNode,
+    ];
+    const edge: CanvasEdge = {
+      id: 'curved',
+      source: { kind: 'node', nodeId: 'source', anchor: 'right' },
+      target: { kind: 'node', nodeId: 'target', anchor: 'top' },
+      arrowHead: 'none',
+      label: 'relationship',
+    };
+
+    const html = renderToStaticMarkup(
+      <EdgeLabel
+        edge={edge}
+        nodes={nodes}
+        transform={{ x: 0, y: 0, scale: 1 }}
+        isEditing={false}
+        onStartEdit={vi.fn()}
+        onCommit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain('left:163px;top:51px');
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/index.tsx
@@ -2,9 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import './index.css';
 import type { CanvasEdge, CanvasNode, CanvasTransform } from '../../types';
 import {
-  edgePathGeometry,
-  resolveEndpoint,
-  resolveEndpointToward,
+  resolveEdgePathGeometry,
 } from '../../utils/edgeFactory';
 import { isImeComposing } from '../../utils/ime';
 
@@ -65,11 +63,7 @@ export const EdgeLabel = ({
 
   const screenPos = useMemo(() => {
     const nodesById = new Map(nodes.map((n) => [n.id, n]));
-    const approxS = resolveEndpoint(edge.source, nodesById);
-    const approxT = resolveEndpoint(edge.target, nodesById);
-    const s = resolveEndpointToward(edge.source, nodesById, approxT);
-    const t = resolveEndpointToward(edge.target, nodesById, approxS);
-    const mid = edgePathGeometry(edge, s, t, nodesById).midpoint;
+    const mid = resolveEdgePathGeometry(edge, nodesById).midpoint;
     return {
       x: mid.x * transform.scale + transform.x,
       y: mid.y * transform.scale + transform.y,

--- a/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import './index.css';
 import type { CanvasEdge, CanvasNode, CanvasTransform } from '../../types';
 import {
-  bendHandlePoint,
+  edgePathGeometry,
   resolveEndpoint,
   resolveEndpointToward,
 } from '../../utils/edgeFactory';
@@ -11,8 +11,8 @@ import { isImeComposing } from '../../utils/ime';
 /**
  * Inline label on an edge.
  *
- * Positioned at the edge's visual midpoint (the bend-handle point, which
- * coincides with the curve at t=0.5 — see `bendHandlePoint`). Rendered in
+ * Positioned at the edge's visual midpoint using the same path geometry
+ * as the SVG edge. Rendered in
  * the overlay layer rather than inside the edges SVG so the label text is
  * a real DOM element — easy to style, wrap, and edit via a plain <input>.
  *
@@ -69,7 +69,7 @@ export const EdgeLabel = ({
     const approxT = resolveEndpoint(edge.target, nodesById);
     const s = resolveEndpointToward(edge.source, nodesById, approxT);
     const t = resolveEndpointToward(edge.target, nodesById, approxS);
-    const mid = bendHandlePoint(s, t, edge.bend ?? 0);
+    const mid = edgePathGeometry(edge, s, t, nodesById).midpoint;
     return {
       x: mid.x * transform.scale + transform.x,
       y: mid.y * transform.scale + transform.y,

--- a/apps/canvas-workspace/src/renderer/src/components/EdgeStylePanel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeStylePanel/index.tsx
@@ -249,7 +249,7 @@ export const EdgeStylePanel = ({
   }, [screenPos.x, screenPos.y, openSection]);
 
   const setStroke = (patch: Partial<EdgeStroke>) => {
-    onUpdate(edge.id, { stroke: { ...edge.stroke, ...patch } });
+    onUpdate(edge.id, { stroke: { ...resolvedStroke, ...patch } });
   };
 
   const toggleSection = (section: Section) =>

--- a/apps/canvas-workspace/src/renderer/src/components/EdgeStylePanel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeStylePanel/index.tsx
@@ -8,13 +8,14 @@ import type {
   EdgeStroke,
 } from '../../types';
 import {
-  bendHandlePoint,
+  edgePathGeometry,
   resolveEndpoint,
   resolveEndpointToward,
 } from '../../utils/edgeFactory';
 import { useMenuKeyboardNav } from '../../hooks/useMenuKeyboardNav';
 import { SwatchRow } from '../ui';
 import { useI18n, type I18nKey } from '../../i18n';
+import { DEFAULT_EDGE_STROKE } from '../../../../shared/canvas';
 
 /**
  * A compact floating panel, shown when an edge is selected, that lets
@@ -48,7 +49,7 @@ type Section = 'color' | 'width' | 'style' | 'head' | 'tail';
 // off-white canvas background at both zoom extremes. First entry matches
 // DEFAULT_STROKE.color in CanvasEdgesLayer.
 const COLORS: string[] = [
-  '#1f2328',
+  DEFAULT_EDGE_STROKE.color,
   '#e5484d',
   '#f76808',
   '#ffba18',
@@ -60,7 +61,7 @@ const COLORS: string[] = [
 const WIDTHS: Array<{ label: string; value: number }> = [
   { label: 'S', value: 1.6 },
   { label: 'M', value: 2.4 },
-  { label: 'L', value: 3.6 },
+  { label: 'L', value: 4 },
 ];
 
 const STYLES: Array<NonNullable<EdgeStroke['style']>> = ['solid', 'dashed', 'dotted'];
@@ -176,9 +177,9 @@ export const EdgeStylePanel = ({
   onRemove,
 }: Props) => {
   const { t } = useI18n();
-  const color = edge.stroke?.color ?? '#1f2328';
-  const width = edge.stroke?.width ?? 2.4;
-  const style = edge.stroke?.style ?? 'solid';
+  const color = edge.stroke?.color ?? DEFAULT_EDGE_STROKE.color;
+  const width = edge.stroke?.width ?? DEFAULT_EDGE_STROKE.width;
+  const style = edge.stroke?.style ?? DEFAULT_EDGE_STROKE.style;
   const head: EdgeArrowCap = edge.arrowHead ?? 'triangle';
   const tail: EdgeArrowCap = edge.arrowTail ?? 'none';
 
@@ -221,7 +222,7 @@ export const EdgeStylePanel = ({
     const approxT = resolveEndpoint(edge.target, nodesById);
     const s = resolveEndpointToward(edge.source, nodesById, approxT);
     const t = resolveEndpointToward(edge.target, nodesById, approxS);
-    const mid = bendHandlePoint(s, t, edge.bend ?? 0);
+    const mid = edgePathGeometry(edge, s, t, nodesById).midpoint;
     return {
       x: mid.x * transform.scale + transform.x,
       y: mid.y * transform.scale + transform.y,

--- a/apps/canvas-workspace/src/renderer/src/components/EdgeStylePanel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeStylePanel/index.tsx
@@ -8,14 +8,15 @@ import type {
   EdgeStroke,
 } from '../../types';
 import {
-  edgePathGeometry,
-  resolveEndpoint,
-  resolveEndpointToward,
+  resolveEdgePathGeometry,
 } from '../../utils/edgeFactory';
 import { useMenuKeyboardNav } from '../../hooks/useMenuKeyboardNav';
 import { SwatchRow } from '../ui';
 import { useI18n, type I18nKey } from '../../i18n';
-import { DEFAULT_EDGE_STROKE } from '../../../../shared/canvas';
+import {
+  DEFAULT_EDGE_STROKE,
+  resolveEdgeStroke,
+} from '../../../../shared/canvas';
 
 /**
  * A compact floating panel, shown when an edge is selected, that lets
@@ -177,9 +178,10 @@ export const EdgeStylePanel = ({
   onRemove,
 }: Props) => {
   const { t } = useI18n();
-  const color = edge.stroke?.color ?? DEFAULT_EDGE_STROKE.color;
-  const width = edge.stroke?.width ?? DEFAULT_EDGE_STROKE.width;
-  const style = edge.stroke?.style ?? DEFAULT_EDGE_STROKE.style;
+  const resolvedStroke = resolveEdgeStroke(edge.stroke);
+  const color = resolvedStroke.color;
+  const width = resolvedStroke.width;
+  const style = resolvedStroke.style;
   const head: EdgeArrowCap = edge.arrowHead ?? 'triangle';
   const tail: EdgeArrowCap = edge.arrowTail ?? 'none';
 
@@ -218,11 +220,7 @@ export const EdgeStylePanel = ({
   // directly to container-relative coordinates.
   const screenPos = useMemo(() => {
     const nodesById = new Map(nodes.map((n) => [n.id, n]));
-    const approxS = resolveEndpoint(edge.source, nodesById);
-    const approxT = resolveEndpoint(edge.target, nodesById);
-    const s = resolveEndpointToward(edge.source, nodesById, approxT);
-    const t = resolveEndpointToward(edge.target, nodesById, approxS);
-    const mid = edgePathGeometry(edge, s, t, nodesById).midpoint;
+    const mid = resolveEdgePathGeometry(edge, nodesById).midpoint;
     return {
       x: mid.x * transform.scale + transform.x,
       y: mid.y * transform.scale + transform.y,

--- a/apps/canvas-workspace/src/renderer/src/hooks/useEdgeInteraction.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useEdgeInteraction.test.tsx
@@ -152,7 +152,7 @@ describe('useEdgeInteraction move gestures', () => {
     expect(updateEdge).toHaveBeenCalledWith('edge-1', { bend: -30 });
   });
 
-  it('seeds the first manual bend from an automatic curve handle without jumping', () => {
+  it('keeps an asymmetric automatic curve cubic on its first manual bend', () => {
     edges = [{
       id: 'edge-1',
       source: { kind: 'node', nodeId: 'node-a', anchor: 'right' },
@@ -160,14 +160,22 @@ describe('useEdgeInteraction move gestures', () => {
       bend: 0,
     }];
     act(() => root.render(<Probe />));
-    act(() => hook.beginMoveBend('edge-1', { x: 0, y: 0 }, { x: 100, y: 0 }, 50, -20));
+    act(() => hook.beginMoveBend(
+      'edge-1',
+      { x: 100, y: 30 },
+      { x: 196, y: 102 },
+      163,
+      51,
+    ));
 
-    move([50, -21]);
+    move([163.6, 50.2]);
 
     expect(hook.state).toMatchObject({
       kind: 'move-bend',
-      previewPatch: { bend: 21 },
+      previewPatch: { curveMode: 'smooth' },
     });
+    if (hook.state?.kind !== 'move-bend') throw new Error('expected move-bend state');
+    expect(hook.state.previewPatch.bend).toBeCloseTo(1);
   });
 
   it('drops an ephemeral move on Escape without writing or committing history', () => {

--- a/apps/canvas-workspace/src/renderer/src/hooks/useEdgeInteraction.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useEdgeInteraction.test.tsx
@@ -152,6 +152,24 @@ describe('useEdgeInteraction move gestures', () => {
     expect(updateEdge).toHaveBeenCalledWith('edge-1', { bend: -30 });
   });
 
+  it('seeds the first manual bend from an automatic curve handle without jumping', () => {
+    edges = [{
+      id: 'edge-1',
+      source: { kind: 'node', nodeId: 'node-a', anchor: 'right' },
+      target: { kind: 'node', nodeId: 'node-b', anchor: 'top' },
+      bend: 0,
+    }];
+    act(() => root.render(<Probe />));
+    act(() => hook.beginMoveBend('edge-1', { x: 0, y: 0 }, { x: 100, y: 0 }, 50, -20));
+
+    move([50, -21]);
+
+    expect(hook.state).toMatchObject({
+      kind: 'move-bend',
+      previewPatch: { bend: 21 },
+    });
+  });
+
   it('drops an ephemeral move on Escape without writing or committing history', () => {
     act(() => hook.beginMoveEdge('edge-1', 10, 10));
     move([30, 40], [50, 60]);

--- a/apps/canvas-workspace/src/renderer/src/hooks/useEdgeInteraction.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useEdgeInteraction.ts
@@ -11,7 +11,7 @@ import {
 const CONNECT_DRAG_MIN_DISTANCE = 6;
 export type Point = { x: number; y: number };
 export type EdgeInteractionPreviewPatch = Partial<
-  Pick<CanvasEdge, 'source' | 'target' | 'bend'>
+  Pick<CanvasEdge, 'source' | 'target' | 'bend' | 'curveMode'>
 >;
 
 /**
@@ -55,6 +55,9 @@ export type EdgeInteractionState =
       /** Base bend plus cursor offset delta avoids a drag-start jump. */
       originBend: number;
       originOffset: number;
+      /** Automatic curves and previously adjusted smooth curves keep cubic
+       * geometry; legacy non-zero bends continue using their quadratic path. */
+      smoothBend: boolean;
       /** Render-only geometry; committed once on mouseup. */
       previewPatch: EdgeInteractionPreviewPatch;
     }
@@ -149,10 +152,17 @@ const movePreviewAt = (
   if (current.kind === 'move-bend') {
     const offset = bendFromCursor(current.s, current.t, pt);
     const bend = current.originBend + (offset - current.originOffset);
+    const previewPatch: EdgeInteractionPreviewPatch =
+      bend === current.originBend
+        ? {}
+        : {
+            bend,
+            ...(current.smoothBend ? { curveMode: 'smooth' as const } : {}),
+          };
     return {
       ...current,
       cursor: pt,
-      previewPatch: bend === current.originBend ? {} : { bend },
+      previewPatch,
     };
   }
 
@@ -423,11 +433,13 @@ export const useEdgeInteraction = ({
     // curve (not just the midpoint handle) feels continuous.
     const originOffset = bendFromCursor(s, t, pt);
     const persistedBend = edge?.bend ?? 0;
-    // Automatic node routing can put the zero-bend handle away from the
-    // straight midpoint. The first manual move switches to the legacy
-    // quadratic representation, so seed it with that visual offset to
-    // avoid a jump while preserving persisted non-zero bend semantics.
-    const originBend = persistedBend === 0 ? originOffset : persistedBend;
+    const isNodeBound =
+      edge?.source.kind === 'node' &&
+      edge.target.kind === 'node';
+    const smoothBend =
+      edge?.curveMode === 'smooth' ||
+      (persistedBend === 0 && isNodeBound);
+    const originBend = persistedBend;
     setInteractionState({
       kind: 'move-bend',
       edgeId,
@@ -436,6 +448,7 @@ export const useEdgeInteraction = ({
       cursor: pt,
       originBend,
       originOffset,
+      smoothBend,
       previewPatch: {},
     });
   }, [edges, setInteractionState, toCanvas]);

--- a/apps/canvas-workspace/src/renderer/src/hooks/useEdgeInteraction.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useEdgeInteraction.ts
@@ -418,11 +418,16 @@ export const useEdgeInteraction = ({
     const pt = toCanvas(clientX, clientY);
     if (!pt) return;
     const edge = edges.find((e) => e.id === edgeId);
-    const originBend = edge?.bend ?? 0;
     // Cursor's offset-from-straight-line at mousedown time — baseline
     // for delta math in handleMove so dragging from anywhere on the
     // curve (not just the midpoint handle) feels continuous.
     const originOffset = bendFromCursor(s, t, pt);
+    const persistedBend = edge?.bend ?? 0;
+    // Automatic node routing can put the zero-bend handle away from the
+    // straight midpoint. The first manual move switches to the legacy
+    // quadratic representation, so seed it with that visual offset to
+    // avoid a jump while preserving persisted non-zero bend semantics.
+    const originBend = persistedBend === 0 ? originOffset : persistedBend;
     setInteractionState({
       kind: 'move-bend',
       edgeId,

--- a/apps/canvas-workspace/src/renderer/src/utils/edgeFactory.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/edgeFactory.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { createDefaultEdge } from './edgeFactory';
+import type { CanvasEdge, CanvasNode } from '../types';
+import { createDefaultEdge, edgePathGeometry } from './edgeFactory';
 
 describe('createDefaultEdge', () => {
   it('stores the canonical high-contrast edge stroke', () => {
@@ -13,5 +14,29 @@ describe('createDefaultEdge', () => {
       width: 4,
       style: 'solid',
     });
+  });
+
+  it('adds a manual bend continuously on top of automatic node routing', () => {
+    const nodes: CanvasNode[] = [
+      { id: 'a', x: 0, y: 0, width: 100, height: 60 } as CanvasNode,
+      { id: 'b', x: 146, y: 102, width: 100, height: 60 } as CanvasNode,
+    ];
+    const nodesById = new Map(nodes.map((node) => [node.id, node]));
+    const edge: CanvasEdge = {
+      id: 'curved',
+      source: { kind: 'node', nodeId: 'a', anchor: 'right' },
+      target: { kind: 'node', nodeId: 'b', anchor: 'top' },
+      bend: 0,
+    };
+    const sourcePoint = { x: 100, y: 30 };
+    const targetPoint = { x: 196, y: 102 };
+    const automatic = edgePathGeometry(edge, sourcePoint, targetPoint, nodesById);
+    const moved = edgePathGeometry({ ...edge, bend: 1 }, sourcePoint, targetPoint, nodesById);
+
+    expect(moved.d).toContain(' C ');
+    expect(Math.hypot(
+      moved.midpoint.x - automatic.midpoint.x,
+      moved.midpoint.y - automatic.midpoint.y,
+    )).toBeCloseTo(1);
   });
 });

--- a/apps/canvas-workspace/src/renderer/src/utils/edgeFactory.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/edgeFactory.test.ts
@@ -36,4 +36,33 @@ describe('createDefaultEdge', () => {
     expect(moved.midpoint.x).toBeCloseTo(148.6);
     expect(moved.midpoint.y).toBeCloseTo(65.2);
   });
+
+  it('moves a new smooth bend continuously from the automatic cubic', () => {
+    const nodes: CanvasNode[] = [
+      { id: 'a', x: 0, y: 0, width: 100, height: 60 } as CanvasNode,
+      { id: 'b', x: 146, y: 102, width: 100, height: 60 } as CanvasNode,
+    ];
+    const nodesById = new Map(nodes.map((node) => [node.id, node]));
+    const edge: CanvasEdge = {
+      id: 'smooth',
+      source: { kind: 'node', nodeId: 'a', anchor: 'right' },
+      target: { kind: 'node', nodeId: 'b', anchor: 'top' },
+      bend: 0,
+    };
+    const sourcePoint = { x: 100, y: 30 };
+    const targetPoint = { x: 196, y: 102 };
+    const automatic = edgePathGeometry(edge, sourcePoint, targetPoint, nodesById);
+    const moved = edgePathGeometry(
+      { ...edge, bend: 1, curveMode: 'smooth' },
+      sourcePoint,
+      targetPoint,
+      nodesById,
+    );
+
+    expect(moved.d).toContain(' C ');
+    expect(Math.hypot(
+      moved.midpoint.x - automatic.midpoint.x,
+      moved.midpoint.y - automatic.midpoint.y,
+    )).toBeCloseTo(1);
+  });
 });

--- a/apps/canvas-workspace/src/renderer/src/utils/edgeFactory.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/edgeFactory.test.ts
@@ -16,7 +16,7 @@ describe('createDefaultEdge', () => {
     });
   });
 
-  it('adds a manual bend continuously on top of automatic node routing', () => {
+  it('preserves the quadratic geometry of existing manual node bends', () => {
     const nodes: CanvasNode[] = [
       { id: 'a', x: 0, y: 0, width: 100, height: 60 } as CanvasNode,
       { id: 'b', x: 146, y: 102, width: 100, height: 60 } as CanvasNode,
@@ -30,13 +30,10 @@ describe('createDefaultEdge', () => {
     };
     const sourcePoint = { x: 100, y: 30 };
     const targetPoint = { x: 196, y: 102 };
-    const automatic = edgePathGeometry(edge, sourcePoint, targetPoint, nodesById);
     const moved = edgePathGeometry({ ...edge, bend: 1 }, sourcePoint, targetPoint, nodesById);
 
-    expect(moved.d).toContain(' C ');
-    expect(Math.hypot(
-      moved.midpoint.x - automatic.midpoint.x,
-      moved.midpoint.y - automatic.midpoint.y,
-    )).toBeCloseTo(1);
+    expect(moved.d).toContain(' Q ');
+    expect(moved.midpoint.x).toBeCloseTo(148.6);
+    expect(moved.midpoint.y).toBeCloseTo(65.2);
   });
 });

--- a/apps/canvas-workspace/src/renderer/src/utils/edgeFactory.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/edgeFactory.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { createDefaultEdge } from './edgeFactory';
+
+describe('createDefaultEdge', () => {
+  it('stores the canonical high-contrast edge stroke', () => {
+    const edge = createDefaultEdge(
+      { kind: 'point', x: 0, y: 0 },
+      { kind: 'point', x: 100, y: 0 },
+    );
+
+    expect(edge.stroke).toEqual({
+      color: '#2e2e2e',
+      width: 4,
+      style: 'solid',
+    });
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/utils/edgeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/edgeFactory.ts
@@ -224,13 +224,13 @@ const endpointOutwardNormal = (
  * bend preserves the existing manually controlled quadratic curve.
  */
 export const edgePathGeometry = (
-  edge: Pick<CanvasEdge, 'source' | 'target' | 'bend'>,
+  edge: Pick<CanvasEdge, 'source' | 'target' | 'bend' | 'curveMode'>,
   s: Point,
   t: Point,
   nodesById: Map<string, CanvasNode>,
 ): EdgePathGeometry => {
   const bend = edge.bend ?? 0;
-  if (bend) {
+  if (bend && edge.curveMode !== 'smooth') {
     const midpoint = bendHandlePoint(s, t, bend);
     const baseMidpoint = bendHandlePoint(s, t, 0);
     const control = {
@@ -248,13 +248,18 @@ export const edgePathGeometry = (
   if (sourceNormal && targetNormal) {
     const distance = Math.hypot(t.x - s.x, t.y - s.y);
     const handleLength = distance / 3;
+    const bendScale = distance === 0 ? 0 : bend * 4 / (3 * distance);
+    const bendOffset = {
+      x: (t.y - s.y) * bendScale,
+      y: -(t.x - s.x) * bendScale,
+    };
     const c1 = {
-      x: s.x + sourceNormal.x * handleLength,
-      y: s.y + sourceNormal.y * handleLength,
+      x: s.x + sourceNormal.x * handleLength + bendOffset.x,
+      y: s.y + sourceNormal.y * handleLength + bendOffset.y,
     };
     const c2 = {
-      x: t.x + targetNormal.x * handleLength,
-      y: t.y + targetNormal.y * handleLength,
+      x: t.x + targetNormal.x * handleLength + bendOffset.x,
+      y: t.y + targetNormal.y * handleLength + bendOffset.y,
     };
     return {
       d: `M ${s.x} ${s.y} C ${c1.x} ${c1.y} ${c2.x} ${c2.y} ${t.x} ${t.y}`,
@@ -265,9 +270,22 @@ export const edgePathGeometry = (
     };
   }
 
+  if (!bend) {
+    return {
+      d: `M ${s.x} ${s.y} L ${t.x} ${t.y}`,
+      midpoint: bendHandlePoint(s, t, 0),
+    };
+  }
+
+  const midpoint = bendHandlePoint(s, t, bend);
+  const baseMidpoint = bendHandlePoint(s, t, 0);
+  const control = {
+    x: midpoint.x * 2 - baseMidpoint.x,
+    y: midpoint.y * 2 - baseMidpoint.y,
+  };
   return {
-    d: `M ${s.x} ${s.y} L ${t.x} ${t.y}`,
-    midpoint: bendHandlePoint(s, t, 0),
+    d: `M ${s.x} ${s.y} Q ${control.x} ${control.y} ${t.x} ${t.y}`,
+    midpoint,
   };
 };
 

--- a/apps/canvas-workspace/src/renderer/src/utils/edgeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/edgeFactory.ts
@@ -9,6 +9,13 @@ export interface EdgePathGeometry {
   midpoint: Point;
 }
 
+export interface ResolvedEdgePathGeometry extends EdgePathGeometry {
+  sourcePoint: Point;
+  targetPoint: Point;
+}
+
+const ARROW_NODE_GAP = 6;
+
 const ANCHOR_NORMALS: Record<Exclude<EdgeAnchor, 'auto'>, UnitVector> = {
   top: { x: 0, y: -1 },
   right: { x: 1, y: 0 },
@@ -223,43 +230,88 @@ export const edgePathGeometry = (
   nodesById: Map<string, CanvasNode>,
 ): EdgePathGeometry => {
   const bend = edge.bend ?? 0;
-  if (bend) {
-    const midpoint = bendHandlePoint(s, t, bend);
-    const baseMidpoint = bendHandlePoint(s, t, 0);
-    const control = {
-      x: midpoint.x * 2 - baseMidpoint.x,
-      y: midpoint.y * 2 - baseMidpoint.y,
+  const sourceNormal = endpointOutwardNormal(edge.source, s, nodesById);
+  const targetNormal = endpointOutwardNormal(edge.target, t, nodesById);
+  if (sourceNormal && targetNormal) {
+    const distance = Math.hypot(t.x - s.x, t.y - s.y);
+    const handleLength = distance / 3;
+    const bendScale = distance === 0 ? 0 : bend * 4 / (3 * distance);
+    const bendOffset = {
+      x: (t.y - s.y) * bendScale,
+      y: -(t.x - s.x) * bendScale,
+    };
+    const c1 = {
+      x: s.x + sourceNormal.x * handleLength + bendOffset.x,
+      y: s.y + sourceNormal.y * handleLength + bendOffset.y,
+    };
+    const c2 = {
+      x: t.x + targetNormal.x * handleLength + bendOffset.x,
+      y: t.y + targetNormal.y * handleLength + bendOffset.y,
     };
     return {
-      d: `M ${s.x} ${s.y} Q ${control.x} ${control.y} ${t.x} ${t.y}`,
-      midpoint,
+      d: `M ${s.x} ${s.y} C ${c1.x} ${c1.y} ${c2.x} ${c2.y} ${t.x} ${t.y}`,
+      midpoint: {
+        x: (s.x + 3 * c1.x + 3 * c2.x + t.x) / 8,
+        y: (s.y + 3 * c1.y + 3 * c2.y + t.y) / 8,
+      },
     };
   }
 
-  const sourceNormal = endpointOutwardNormal(edge.source, s, nodesById);
-  const targetNormal = endpointOutwardNormal(edge.target, t, nodesById);
-  if (!sourceNormal || !targetNormal) {
+  if (!bend) {
     return {
       d: `M ${s.x} ${s.y} L ${t.x} ${t.y}`,
       midpoint: bendHandlePoint(s, t, 0),
     };
   }
 
-  const handleLength = Math.hypot(t.x - s.x, t.y - s.y) / 3;
-  const c1 = {
-    x: s.x + sourceNormal.x * handleLength,
-    y: s.y + sourceNormal.y * handleLength,
-  };
-  const c2 = {
-    x: t.x + targetNormal.x * handleLength,
-    y: t.y + targetNormal.y * handleLength,
+  const midpoint = bendHandlePoint(s, t, bend);
+  const baseMidpoint = bendHandlePoint(s, t, 0);
+  const control = {
+    x: midpoint.x * 2 - baseMidpoint.x,
+    y: midpoint.y * 2 - baseMidpoint.y,
   };
   return {
-    d: `M ${s.x} ${s.y} C ${c1.x} ${c1.y} ${c2.x} ${c2.y} ${t.x} ${t.y}`,
-    midpoint: {
-      x: (s.x + 3 * c1.x + 3 * c2.x + t.x) / 8,
-      y: (s.y + 3 * c1.y + 3 * c2.y + t.y) / 8,
-    },
+    d: `M ${s.x} ${s.y} Q ${control.x} ${control.y} ${t.x} ${t.y}`,
+    midpoint,
+  };
+};
+
+const insetTowardOther = (end: Point, other: Point, gap: number): Point => {
+  if (gap <= 0) return end;
+  const dx = end.x - other.x;
+  const dy = end.y - other.y;
+  const len = Math.hypot(dx, dy);
+  if (len === 0) return end;
+  return {
+    x: end.x - (dx / len) * gap,
+    y: end.y - (dy / len) * gap,
+  };
+};
+
+/**
+ * Resolve the exact path rendered for an edge, including automatic anchors
+ * and the small node gap reserved for visible arrow caps.
+ */
+export const resolveEdgePathGeometry = (
+  edge: CanvasEdge,
+  nodesById: Map<string, CanvasNode>,
+): ResolvedEdgePathGeometry => {
+  const approxS = resolveEndpoint(edge.source, nodesById);
+  const approxT = resolveEndpoint(edge.target, nodesById);
+  let sourcePoint = resolveEndpointToward(edge.source, nodesById, approxT);
+  let targetPoint = resolveEndpointToward(edge.target, nodesById, approxS);
+  const head = edge.arrowHead ?? 'triangle';
+  const tail = edge.arrowTail ?? 'none';
+  if (edge.target.kind === 'node' && head !== 'none') {
+    targetPoint = insetTowardOther(targetPoint, sourcePoint, ARROW_NODE_GAP);
+  }
+  if (edge.source.kind === 'node' && tail !== 'none') {
+    sourcePoint = insetTowardOther(sourcePoint, targetPoint, ARROW_NODE_GAP);
+  }
+  return {
+    sourcePoint,
+    targetPoint,
+    ...edgePathGeometry(edge, sourcePoint, targetPoint, nodesById),
   };
 };
 

--- a/apps/canvas-workspace/src/renderer/src/utils/edgeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/edgeFactory.ts
@@ -230,23 +230,31 @@ export const edgePathGeometry = (
   nodesById: Map<string, CanvasNode>,
 ): EdgePathGeometry => {
   const bend = edge.bend ?? 0;
+  if (bend) {
+    const midpoint = bendHandlePoint(s, t, bend);
+    const baseMidpoint = bendHandlePoint(s, t, 0);
+    const control = {
+      x: midpoint.x * 2 - baseMidpoint.x,
+      y: midpoint.y * 2 - baseMidpoint.y,
+    };
+    return {
+      d: `M ${s.x} ${s.y} Q ${control.x} ${control.y} ${t.x} ${t.y}`,
+      midpoint,
+    };
+  }
+
   const sourceNormal = endpointOutwardNormal(edge.source, s, nodesById);
   const targetNormal = endpointOutwardNormal(edge.target, t, nodesById);
   if (sourceNormal && targetNormal) {
     const distance = Math.hypot(t.x - s.x, t.y - s.y);
     const handleLength = distance / 3;
-    const bendScale = distance === 0 ? 0 : bend * 4 / (3 * distance);
-    const bendOffset = {
-      x: (t.y - s.y) * bendScale,
-      y: -(t.x - s.x) * bendScale,
-    };
     const c1 = {
-      x: s.x + sourceNormal.x * handleLength + bendOffset.x,
-      y: s.y + sourceNormal.y * handleLength + bendOffset.y,
+      x: s.x + sourceNormal.x * handleLength,
+      y: s.y + sourceNormal.y * handleLength,
     };
     const c2 = {
-      x: t.x + targetNormal.x * handleLength + bendOffset.x,
-      y: t.y + targetNormal.y * handleLength + bendOffset.y,
+      x: t.x + targetNormal.x * handleLength,
+      y: t.y + targetNormal.y * handleLength,
     };
     return {
       d: `M ${s.x} ${s.y} C ${c1.x} ${c1.y} ${c2.x} ${c2.y} ${t.x} ${t.y}`,
@@ -257,22 +265,9 @@ export const edgePathGeometry = (
     };
   }
 
-  if (!bend) {
-    return {
-      d: `M ${s.x} ${s.y} L ${t.x} ${t.y}`,
-      midpoint: bendHandlePoint(s, t, 0),
-    };
-  }
-
-  const midpoint = bendHandlePoint(s, t, bend);
-  const baseMidpoint = bendHandlePoint(s, t, 0);
-  const control = {
-    x: midpoint.x * 2 - baseMidpoint.x,
-    y: midpoint.y * 2 - baseMidpoint.y,
-  };
   return {
-    d: `M ${s.x} ${s.y} Q ${control.x} ${control.y} ${t.x} ${t.y}`,
-    midpoint,
+    d: `M ${s.x} ${s.y} L ${t.x} ${t.y}`,
+    midpoint: bendHandlePoint(s, t, 0),
   };
 };
 

--- a/apps/canvas-workspace/src/renderer/src/utils/edgeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/edgeFactory.ts
@@ -1,18 +1,33 @@
 import type { CanvasEdge, CanvasNode, EdgeAnchor, EdgeEndpoint } from '../types';
+import { DEFAULT_EDGE_STROKE } from '../../../shared/canvas';
+
+type Point = { x: number; y: number };
+type UnitVector = { x: number; y: number };
+
+export interface EdgePathGeometry {
+  d: string;
+  midpoint: Point;
+}
+
+const ANCHOR_NORMALS: Record<Exclude<EdgeAnchor, 'auto'>, UnitVector> = {
+  top: { x: 0, y: -1 },
+  right: { x: 1, y: 0 },
+  bottom: { x: 0, y: 1 },
+  left: { x: -1, y: 0 },
+};
 
 let edgeIdCounter = 0;
 export const genEdgeId = (): string => `edge-${Date.now()}-${++edgeIdCounter}`;
 
 /**
  * Create a new edge with sensible defaults:
- *  - no bend (straight line),
+ *  - no manual bend (node-bound edges use automatic smooth routing),
  *  - triangular arrow head on target, nothing on source,
- *  - medium-weight solid black stroke (sits at the middle "M" tick of
- *    EdgeStylePanel's width ladder, so freshly-drawn lines read clearly
- *    on the canvas without jumping out).
+ *  - high-contrast solid stroke matching the large "L" width tick in
+ *    EdgeStylePanel, so it remains legible while zoomed out.
  *
- * Visual defaults mirror tldraw's default arrow. The caller decides the
- * endpoints, kind, label, etc.
+ * Visual defaults mirror Heptabase's canvas-space connector treatment.
+ * The caller decides the endpoints, kind, label, etc.
  */
 export const createDefaultEdge = (
   source: EdgeEndpoint,
@@ -25,7 +40,7 @@ export const createDefaultEdge = (
   bend: 0,
   arrowHead: 'triangle',
   arrowTail: 'none',
-  stroke: { color: '#1f2328', width: 2.4, style: 'solid' },
+  stroke: { ...DEFAULT_EDGE_STROKE },
   updatedAt: Date.now(),
   ...overrides,
 });
@@ -174,6 +189,78 @@ export const bendHandlePoint = (
   const nx = dy / len;
   const ny = -dx / len;
   return { x: mx + nx * bend, y: my + ny * bend };
+};
+
+const endpointOutwardNormal = (
+  endpoint: EdgeEndpoint,
+  point: Point,
+  nodesById: Map<string, CanvasNode>,
+): UnitVector | null => {
+  if (endpoint.kind === 'point') return null;
+  if (endpoint.anchor && endpoint.anchor !== 'auto') return ANCHOR_NORMALS[endpoint.anchor];
+  const node = nodesById.get(endpoint.nodeId);
+  if (!node) return null;
+  const sides: Array<{ distance: number; normal: UnitVector }> = [
+    { distance: Math.abs(point.x - node.x), normal: ANCHOR_NORMALS.left },
+    { distance: Math.abs(point.x - (node.x + node.width)), normal: ANCHOR_NORMALS.right },
+    { distance: Math.abs(point.y - node.y), normal: ANCHOR_NORMALS.top },
+    { distance: Math.abs(point.y - (node.y + node.height)), normal: ANCHOR_NORMALS.bottom },
+  ];
+  return sides.reduce((closest, side) =>
+    side.distance < closest.distance ? side : closest).normal;
+};
+
+/**
+ * Build the visible path and its t=0.5 point from one geometry source.
+ * Node-bound zero-bend edges use cubic handles that leave and enter along
+ * the two anchor normals; free endpoints remain straight, while a non-zero
+ * bend preserves the existing manually controlled quadratic curve.
+ */
+export const edgePathGeometry = (
+  edge: Pick<CanvasEdge, 'source' | 'target' | 'bend'>,
+  s: Point,
+  t: Point,
+  nodesById: Map<string, CanvasNode>,
+): EdgePathGeometry => {
+  const bend = edge.bend ?? 0;
+  if (bend) {
+    const midpoint = bendHandlePoint(s, t, bend);
+    const baseMidpoint = bendHandlePoint(s, t, 0);
+    const control = {
+      x: midpoint.x * 2 - baseMidpoint.x,
+      y: midpoint.y * 2 - baseMidpoint.y,
+    };
+    return {
+      d: `M ${s.x} ${s.y} Q ${control.x} ${control.y} ${t.x} ${t.y}`,
+      midpoint,
+    };
+  }
+
+  const sourceNormal = endpointOutwardNormal(edge.source, s, nodesById);
+  const targetNormal = endpointOutwardNormal(edge.target, t, nodesById);
+  if (!sourceNormal || !targetNormal) {
+    return {
+      d: `M ${s.x} ${s.y} L ${t.x} ${t.y}`,
+      midpoint: bendHandlePoint(s, t, 0),
+    };
+  }
+
+  const handleLength = Math.hypot(t.x - s.x, t.y - s.y) / 3;
+  const c1 = {
+    x: s.x + sourceNormal.x * handleLength,
+    y: s.y + sourceNormal.y * handleLength,
+  };
+  const c2 = {
+    x: t.x + targetNormal.x * handleLength,
+    y: t.y + targetNormal.y * handleLength,
+  };
+  return {
+    d: `M ${s.x} ${s.y} C ${c1.x} ${c1.y} ${c2.x} ${c2.y} ${t.x} ${t.y}`,
+    midpoint: {
+      x: (s.x + 3 * c1.x + 3 * c2.x + t.x) / 8,
+      y: (s.y + 3 * c1.y + 3 * c2.y + t.y) / 8,
+    },
+  };
 };
 
 /**

--- a/apps/canvas-workspace/src/shared/canvas.ts
+++ b/apps/canvas-workspace/src/shared/canvas.ts
@@ -404,6 +404,9 @@ export interface CanvasEdge {
   source: EdgeEndpoint;
   target: EdgeEndpoint;
   bend?: number;
+  /** New manually adjusted smooth curves stay cubic. Absent preserves the
+   * legacy quadratic representation for existing non-zero bends. */
+  curveMode?: 'smooth';
   arrowHead?: EdgeArrowCap;
   arrowTail?: EdgeArrowCap;
   stroke?: EdgeStroke;

--- a/apps/canvas-workspace/src/shared/canvas.ts
+++ b/apps/canvas-workspace/src/shared/canvas.ts
@@ -377,6 +377,21 @@ export const DEFAULT_EDGE_STROKE: Readonly<Required<EdgeStroke>> = {
   style: 'solid',
 };
 
+const LEGACY_DEFAULT_EDGE_STROKE: Readonly<Required<EdgeStroke>> = {
+  color: '#1f2328',
+  width: 2.4,
+  style: 'solid',
+};
+
+export const resolveEdgeStroke = (stroke?: EdgeStroke): Required<EdgeStroke> => {
+  const resolved = { ...DEFAULT_EDGE_STROKE, ...stroke };
+  const isLegacyDefault =
+    resolved.color === LEGACY_DEFAULT_EDGE_STROKE.color &&
+    resolved.width === LEGACY_DEFAULT_EDGE_STROKE.width &&
+    resolved.style === LEGACY_DEFAULT_EDGE_STROKE.style;
+  return isLegacyDefault ? { ...DEFAULT_EDGE_STROKE } : resolved;
+};
+
 /**
  * A connection drawn between two endpoints on the canvas.
  *

--- a/apps/canvas-workspace/src/shared/canvas.ts
+++ b/apps/canvas-workspace/src/shared/canvas.ts
@@ -371,6 +371,12 @@ export interface EdgeStroke {
   style?: 'solid' | 'dashed' | 'dotted';
 }
 
+export const DEFAULT_EDGE_STROKE: Readonly<Required<EdgeStroke>> = {
+  color: '#2e2e2e',
+  width: 4,
+  style: 'solid',
+};
+
 /**
  * A connection drawn between two endpoints on the canvas.
  *

--- a/packages/canvas-cli/src/commands/edge.ts
+++ b/packages/canvas-cli/src/commands/edge.ts
@@ -41,9 +41,9 @@ export function registerEdgeCommands(program: Command): void {
     .option('--arrow-head <cap>', 'Arrow head: none, triangle, arrow, dot, bar')
     .option('--arrow-tail <cap>', 'Arrow tail: none, triangle, arrow, dot, bar')
     .option('--color <hex>', 'Stroke color (hex)')
-    .option('--width <n>', 'Stroke width in pixels', parseFloat)
+    .option('--width <n>', 'Stroke width in canvas units', parseFloat)
     .option('--style <style>', 'Stroke style: solid, dashed, dotted')
-    .option('--bend <n>', 'Curve offset in pixels (0 = straight)', parseFloat)
+    .option('--bend <n>', 'Curve offset in pixels (0 = automatic node routing)', parseFloat)
     .description('Create a new edge between two nodes')
     .action(async function (this: Command, cmdOpts: {
       from: string;

--- a/packages/canvas-cli/src/core/__tests__/edges.test.ts
+++ b/packages/canvas-cli/src/core/__tests__/edges.test.ts
@@ -53,6 +53,11 @@ describe('edges', () => {
       expect(canvas?.edges?.[0].target).toEqual({ kind: 'node', nodeId: nodeBId, anchor: 'auto' });
       expect(canvas?.edges?.[0].label).toBe('depends on');
       expect(canvas?.edges?.[0].kind).toBe('dependency');
+      expect(canvas?.edges?.[0].stroke).toEqual({
+        color: '#2e2e2e',
+        width: 4,
+        style: 'solid',
+      });
     });
 
     it('fails when source node does not exist', async () => {

--- a/packages/canvas-cli/src/core/constants.ts
+++ b/packages/canvas-cli/src/core/constants.ts
@@ -1,8 +1,14 @@
 import { join } from 'path';
 import { homedir } from 'os';
-import type { CreatableNodeType, KnownNodeType, NodeCapability } from './types';
+import type { CreatableNodeType, EdgeStroke, KnownNodeType, NodeCapability } from './types';
 
 export const DEFAULT_STORE_DIR = join(homedir(), '.pulse-coder', 'canvas');
+
+export const DEFAULT_EDGE_STROKE: Readonly<Required<EdgeStroke>> = {
+  color: '#2e2e2e',
+  width: 4,
+  style: 'solid',
+};
 
 export const NODE_CAPABILITIES: Record<KnownNodeType, NodeCapability[]> = {
   file: ['read', 'write'],

--- a/packages/canvas-cli/src/core/edges.ts
+++ b/packages/canvas-cli/src/core/edges.ts
@@ -1,5 +1,6 @@
 import { loadCanvas, commitEdgeMutation } from './store';
 import { notifyCanvasUpdated } from './notifier';
+import { DEFAULT_EDGE_STROKE } from './constants';
 import type {
   CanvasEdge,
   EdgeAnchor,
@@ -46,7 +47,7 @@ export async function createEdge(
     bend: opts.bend ?? 0,
     arrowHead: opts.arrowHead ?? 'triangle',
     arrowTail: opts.arrowTail ?? 'none',
-    stroke: opts.stroke ?? { color: '#1f2328', width: 2.4, style: 'solid' },
+    stroke: opts.stroke ?? { ...DEFAULT_EDGE_STROKE },
     label: opts.label,
     kind: opts.kind,
     payload: opts.payload,

--- a/packages/canvas-cli/src/core/types.ts
+++ b/packages/canvas-cli/src/core/types.ts
@@ -111,7 +111,7 @@ export interface CanvasEdge {
   id: string;
   source: EdgeEndpoint;
   target: EdgeEndpoint;
-  /** Peak perpendicular offset of the rendered curve. 0 = straight line. */
+  /** Peak perpendicular offset of a manual curve. 0 lets the renderer route node-bound edges automatically. */
   bend?: number;
   arrowHead?: EdgeArrowCap;
   arrowTail?: EdgeArrowCap;

--- a/packages/canvas-cli/src/core/types.ts
+++ b/packages/canvas-cli/src/core/types.ts
@@ -113,6 +113,7 @@ export interface CanvasEdge {
   target: EdgeEndpoint;
   /** Peak perpendicular offset of a manual curve. 0 lets the renderer route node-bound edges automatically. */
   bend?: number;
+  curveMode?: 'smooth';
   arrowHead?: EdgeArrowCap;
   arrowTail?: EdgeArrowCap;
   stroke?: EdgeStroke;


### PR DESCRIPTION
## What changed

- Increase the canonical connector stroke to `#2e2e2e` at 4 canvas units, while keeping a 16px screen-space interaction target.
- Route zero-bend node connections with anchor-aware cubic Bézier curves inspired by the inspected Heptabase behavior.
- Keep labels, bend handles, and the style panel on the exact rendered path, including arrow-cap spacing.
- Normalize the legacy default stroke so existing default connectors adopt the new visual weight without overriding intentional custom styles.
- Preserve existing quadratic manual bends and add a persisted smooth mode for continuous automatic-to-manual curve adjustment.
- Keep UI, agent tools, and canvas-cli creation/update defaults aligned.

## Why

The previous 2.4-unit connectors became visually faint at overview zoom levels and straight routing made dense relationship maps feel mechanical. The updated treatment remains readable while zoomed out and gives node-to-node relationships a calmer, more natural flow.

## Validation

- Real Canvas harness inspection at 100% and 38% zoom.
- `pnpm --filter canvas-workspace typecheck`
- `pnpm --filter canvas-workspace build`
- Canvas suite excluding the pre-existing unrelated file-size baseline failure: 237 files, 1569 tests passed.
- `pnpm --filter @pulse-coder/canvas-cli typecheck`
- `pnpm --filter @pulse-coder/canvas-cli build`
- canvas-cli full suite: 21 files, 196 tests passed.
- Repository harness coverage: `harnessGaps: 0`.

## Known unrelated gate

The unfiltered Canvas suite still reports the existing governance mismatch `src/plugins/main/dynamic-app/tools.ts grew from baseline 593 to 596 lines`; this file is outside this PR.