### PR TITLE
feat(canvas): persist file card text colors

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBubbleMenu/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBubbleMenu/index.css
@@ -62,6 +62,97 @@
   background: var(--border);
 }
 
+.note-bubble-color-trigger.ui-btn {
+  position: relative;
+  font-family: var(--font-ui);
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.note-bubble-color-trigger__underline {
+  position: absolute;
+  right: 7px;
+  bottom: 4px;
+  left: 7px;
+  height: 2px;
+  border-radius: var(--radius-sm);
+  background: currentColor;
+}
+
+.note-bubble-color-menu {
+  position: fixed;
+  z-index: var(--layer-note-popover);
+  width: 244px;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  background: var(--surface);
+  box-shadow: var(--shadow-float);
+  font-family: var(--font-ui);
+}
+
+.note-bubble-color-menu__group + .note-bubble-color-menu__group {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+}
+
+.note-bubble-color-menu__label {
+  display: block;
+  margin-bottom: 7px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 620;
+}
+
+.note-bubble-color-menu__swatches {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.note-bubble-color-swatch {
+  position: relative;
+  display: inline-flex;
+  width: 22px;
+  height: 22px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.note-bubble-color-swatch:hover,
+.note-bubble-color-swatch--active {
+  border-color: var(--accent);
+  outline: 1px solid var(--accent);
+}
+
+.note-bubble-color-swatch--highlight {
+  border-color: color-mix(in srgb, var(--text) 18%, transparent);
+}
+
+.note-bubble-color-swatch--clear::before,
+.note-bubble-color-swatch--clear::after {
+  position: absolute;
+  width: 15px;
+  height: 1px;
+  background: var(--text-tertiary);
+  content: '';
+  transform: rotate(45deg);
+}
+
+.note-bubble-color-swatch--clear::after {
+  transform: rotate(-45deg);
+}
+
 .note-bubble-type-menu {
   position: fixed;
   z-index: var(--layer-note-popover);

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBubbleMenu/index.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBubbleMenu/index.test.tsx
@@ -8,6 +8,7 @@ import StarterKit from '@tiptap/starter-kit';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { setCanvasMotion } from '../../hooks/canvasMotion';
 import { I18nProvider } from '../../i18n';
+import { TextColorMark } from '../TextNodeBody/textColorMark';
 import { FileNodeBubbleMenu } from '.';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -40,7 +41,8 @@ describe('FileNodeBubbleMenu', () => {
       extensions: [
         StarterKit.configure({ underline: false }),
         Underline,
-        Highlight,
+        TextColorMark,
+        Highlight.configure({ multicolor: true }),
       ],
       content: '<p>Alpha</p>',
     });
@@ -86,6 +88,59 @@ describe('FileNodeBubbleMenu', () => {
     expect(onCanvasEscape).not.toHaveBeenCalled();
 
     window.removeEventListener('keydown', onCanvasEscape);
+  });
+
+  it('applies text and highlight colors to the selection', () => {
+    host = document.createElement('div');
+    document.body.append(host);
+    editorHost = document.createElement('div');
+    document.body.append(editorHost);
+    editor = new Editor({
+      element: editorHost,
+      extensions: [
+        StarterKit.configure({ underline: false }),
+        Underline,
+        TextColorMark,
+        Highlight.configure({ multicolor: true }),
+      ],
+      content: '<p>Alpha</p>',
+    });
+    editor.commands.setTextSelection({ from: 1, to: 6 });
+    editor.view.focus();
+
+    root = createRoot(host);
+    act(() => root?.render(
+      <I18nProvider>
+        <FileNodeBubbleMenu
+          editor={editor!}
+          bubble={{ x: 120, y: 80, bottom: 100 }}
+          onOpenLinkPrompt={vi.fn()}
+          onClose={vi.fn()}
+        />
+      </I18nProvider>,
+    ));
+
+    const colorButton = document.querySelector<HTMLButtonElement>(
+      '[aria-label="Inline formatting"]',
+    );
+    act(() => colorButton?.click());
+    const redText = document.querySelector<HTMLButtonElement>(
+      '[aria-label="Use Red on selected text"]',
+    );
+    const blueHighlight = document.querySelector<HTMLButtonElement>(
+      '[aria-label="Use Blue highlight on selected text"]',
+    );
+    expect(redText).not.toBeNull();
+    expect(blueHighlight).not.toBeNull();
+    expect(redText?.getAttribute('role')).toBe('menuitemradio');
+    expect(blueHighlight?.getAttribute('role')).toBe('menuitemradio');
+
+    act(() => redText?.click());
+    expect(editor.isActive('textColor', { color: '#e03131' })).toBe(true);
+    expect(redText?.getAttribute('aria-checked')).toBe('true');
+
+    act(() => blueHighlight?.click());
+    expect(editor.isActive('highlight', { color: '#d0ebff' })).toBe(true);
   });
 
   it('formats the selection and changes its block type from the shared command registry', async () => {

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBubbleMenu/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBubbleMenu/index.tsx
@@ -24,6 +24,10 @@ import { subscribeCanvasMotion } from '../../hooks/canvasMotion';
 import { useEscapeClose } from '../../hooks/useEscapeClose';
 import { useI18n } from '../../i18n';
 import { EditorCommandIcon } from '../EditorCommandIcon';
+import {
+  HIGHLIGHT_COLOR_PRESETS,
+  TEXT_COLOR_PRESETS,
+} from '../TextNodeBody/colorPresets';
 import { Button, Popover, Portal } from '../ui';
 import './index.css';
 
@@ -50,8 +54,11 @@ export const FileNodeBubbleMenu = ({
   const { t } = useI18n();
   const menuRef = useRef<HTMLDivElement>(null);
   const typeButtonRef = useRef<HTMLButtonElement>(null);
+  const colorButtonRef = useRef<HTMLButtonElement>(null);
   const typePanelId = useId();
+  const colorPanelId = useId();
   const [typeMenuOpen, setTypeMenuOpen] = useState(false);
+  const [colorMenuOpen, setColorMenuOpen] = useState(false);
   const [, renderTransaction] = useReducer((value: number) => value + 1, 0);
   const [placement, setPlacement] = useState<{
     left: number;
@@ -88,7 +95,7 @@ export const FileNodeBubbleMenu = ({
   // The nested block-type Popover owns Escape while it is open. Otherwise
   // the selection toolbar consumes Escape itself so the same key press does
   // not also reach canvas-level deselection/dismiss handlers.
-  useEscapeClose(!typeMenuOpen, onClose);
+  useEscapeClose(!typeMenuOpen && !colorMenuOpen, onClose);
 
   const currentBlockType = BLOCK_TYPE_COMMANDS.find((command) =>
     command.isBlockTypeActive(editor),
@@ -197,6 +204,133 @@ export const FileNodeBubbleMenu = ({
         )}
 
         <div className="note-bubble-divider" />
+        <Button
+          ref={colorButtonRef}
+          variant="icon"
+          size="sm"
+          className={`note-bubble-btn note-bubble-color-trigger${
+            editor.isActive('textColor') || editor.isActive('highlight')
+              ? ' note-bubble-btn--active'
+              : ''
+          }`}
+          aria-label={t('canvas.textStyle.inlineFormatting')}
+          aria-haspopup="menu"
+          aria-expanded={colorMenuOpen}
+          aria-controls={colorMenuOpen ? colorPanelId : undefined}
+          title={t('canvas.textStyle.inlineFormatting')}
+          onClick={() => setColorMenuOpen((open) => !open)}
+        >
+          <span aria-hidden="true">A</span>
+          <span className="note-bubble-color-trigger__underline" aria-hidden="true" />
+        </Button>
+        {colorMenuOpen && (
+          <Popover
+            anchorRef={colorButtonRef}
+            placement="bottom"
+            align="start"
+            gap={6}
+            className="note-bubble-color-menu"
+            ariaLabel={t('canvas.textStyle.inlineFormatting')}
+            panelId={colorPanelId}
+            autoFocus={false}
+            closeOnCanvasMotion
+            onClose={(reason) => {
+              setColorMenuOpen(false);
+              if (reason === 'escape') {
+                requestAnimationFrame(() => editor.commands.focus());
+              }
+            }}
+          >
+            <div
+              className="note-bubble-color-menu__group"
+              role="group"
+              aria-label={t('canvas.textStyle.selectionTextColor')}
+            >
+              <span className="note-bubble-color-menu__label">
+                {t('canvas.textStyle.selectionTextColor')}
+              </span>
+              <div className="note-bubble-color-menu__swatches">
+                {TEXT_COLOR_PRESETS.map((preset) => {
+                  const active = editor.isActive('textColor', { color: preset.value });
+                  return (
+                    <Button
+                      variant="icon"
+                      size="sm"
+                      key={preset.name}
+                      className={`note-bubble-color-swatch note-bubble-color-swatch--text${
+                        active ? ' note-bubble-color-swatch--active' : ''
+                      }`}
+                      style={{ color: preset.value }}
+                      title={t('canvas.textStyle.selectionTextColorOption', { name: preset.name })}
+                      aria-label={t('canvas.textStyle.selectionTextColorOption', {
+                        name: preset.name,
+                      })}
+                      role="menuitemradio"
+                      aria-checked={active}
+                      onClick={() =>
+                        editor.chain().focus().setMark('textColor', { color: preset.value }).run()
+                      }
+                    >
+                      A
+                    </Button>
+                  );
+                })}
+                <Button
+                  variant="icon"
+                  size="sm"
+                  className="note-bubble-color-swatch note-bubble-color-swatch--clear"
+                  title={t('canvas.textStyle.clearTextColor')}
+                  aria-label={t('canvas.textStyle.clearTextColor')}
+                  role="menuitem"
+                  onClick={() => editor.chain().focus().unsetMark('textColor').run()}
+                />
+              </div>
+            </div>
+            <div
+              className="note-bubble-color-menu__group"
+              role="group"
+              aria-label={t('canvas.textStyle.selectionHighlight')}
+            >
+              <span className="note-bubble-color-menu__label">
+                {t('canvas.textStyle.selectionHighlight')}
+              </span>
+              <div className="note-bubble-color-menu__swatches">
+                {HIGHLIGHT_COLOR_PRESETS.map((preset) => {
+                  const active = editor.isActive('highlight', { color: preset.value });
+                  return (
+                    <Button
+                      variant="icon"
+                      size="sm"
+                      key={preset.name}
+                      className={`note-bubble-color-swatch note-bubble-color-swatch--highlight${
+                        active ? ' note-bubble-color-swatch--active' : ''
+                      }`}
+                      style={{ backgroundColor: preset.value }}
+                      title={t('canvas.textStyle.selectionHighlightOption', { name: preset.name })}
+                      aria-label={t('canvas.textStyle.selectionHighlightOption', {
+                        name: preset.name,
+                      })}
+                      role="menuitemradio"
+                      aria-checked={active}
+                      onClick={() =>
+                        editor.chain().focus().setHighlight({ color: preset.value }).run()
+                      }
+                    />
+                  );
+                })}
+                <Button
+                  variant="icon"
+                  size="sm"
+                  className="note-bubble-color-swatch note-bubble-color-swatch--clear"
+                  title={t('canvas.textStyle.clearHighlight')}
+                  aria-label={t('canvas.textStyle.clearHighlight')}
+                  role="menuitem"
+                  onClick={() => editor.chain().focus().unsetHighlight().run()}
+                />
+              </div>
+            </div>
+          </Popover>
+        )}
         {iconButton(
           t('noteBubble.bold'),
           editor.isActive('bold'),

--- a/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.test.tsx
@@ -5,7 +5,7 @@ import { EditorContent } from '@tiptap/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { FileNodeData } from '../types';
 import { I18nProvider } from '../i18n';
-import { useFileNodeEditor } from './useFileNodeEditor';
+import { getMarkdown, useFileNodeEditor } from './useFileNodeEditor';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -74,13 +74,57 @@ describe('useFileNodeEditor slash ownership', () => {
   });
 });
 
-const EditorHarness = () => {
+describe('useFileNodeEditor rich text colors', () => {
+  it('preserves text and highlight colors through the Markdown roundtrip', async () => {
+    host = document.createElement('div');
+    document.body.append(host);
+    root = createRoot(host);
+
+    await act(async () => {
+      root?.render(
+        <I18nProvider>
+          <EditorHarness initialData={{ filePath: '', content: 'Alpha' }} />
+        </I18nProvider>,
+      );
+      await Promise.resolve();
+    });
+
+    const editor = hookState?.editor;
+    expect(editor).not.toBeNull();
+    act(() => {
+      editor?.commands.setTextSelection({ from: 1, to: 6 });
+      editor?.chain()
+        .setMark('textColor', { color: '#e03131' })
+        .setHighlight({ color: '#d0ebff' })
+        .run();
+    });
+    const markdown = getMarkdown(editor);
+    expect(markdown).toContain('color: #e03131');
+    expect(markdown).toContain('background-color: #d0ebff');
+
+    act(() => root?.unmount());
+    root = createRoot(host);
+    await act(async () => {
+      root?.render(
+        <I18nProvider>
+          <EditorHarness initialData={{ filePath: '', content: markdown }} />
+        </I18nProvider>,
+      );
+      await Promise.resolve();
+    });
+
+    expect(hookState?.editor?.isActive('textColor', { color: '#e03131' })).toBe(true);
+    expect(hookState?.editor?.isActive('highlight', { color: '#d0ebff' })).toBe(true);
+  });
+});
+
+const EditorHarness = ({ initialData = data }: { initialData?: FileNodeData }) => {
   const state = useFileNodeEditor({
-    data,
+    data: initialData,
     nodeIdRef: { current: 'file-1' },
-    dataRef: { current: data },
+    dataRef: { current: initialData },
     workspaceIdRef: { current: 'workspace-1' },
-    prevContentRef: { current: data.content },
+    prevContentRef: { current: initialData.content },
     setModified: vi.fn(),
     persistToFile: vi.fn().mockResolvedValue(undefined),
     onUpdate: vi.fn().mockResolvedValue(undefined),

--- a/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useFileNodeEditor.ts
@@ -30,6 +30,7 @@ import { useNoteInteractionController } from './useNoteInteractionController';
 import { MarkdownSafeImage } from './fileNodeMarkdownImage';
 import { syntaxHighlightLanguages } from '../utils/syntaxHighlightLanguages';
 import { useI18n } from '../i18n';
+import { TextColorMark } from '../components/TextNodeBody/textColorMark';
 import {
   insertImageAtPos,
   insertImageAtSelection,
@@ -203,7 +204,8 @@ export const useFileNodeEditor = ({
       TaskList,
       TaskItem.configure({ nested: true }),
       Underline,
-      Highlight.configure({ multicolor: false }),
+      TextColorMark,
+      Highlight.configure({ multicolor: true }),
       Link.configure({
         openOnClick: false,
         autolink: true,
@@ -218,7 +220,11 @@ export const useFileNodeEditor = ({
       TableHeader,
       TableCell,
       NoteSearchExtension,
-      Markdown.configure({ html: false, transformPastedText: true }),
+      // Text and highlight colors have no CommonMark representation. Keep
+      // those marks losslessly in the backing Markdown as schema-parsed
+      // inline HTML (`span` / `mark`); Tiptap only admits tags and
+      // attributes declared by the registered extensions.
+      Markdown.configure({ html: true, transformPastedText: true }),
     ],
     content: data.content || '',
     editable: !readOnly,


### PR DESCRIPTION
## What changed

- add text-color and multicolor background-highlight controls to the File card selection toolbar
- persist both marks losslessly through the Markdown save/reload roundtrip
- reuse the shared color presets and UI primitives
- add interaction, persistence, and accessibility regression coverage

## Why

File cards exposed basic inline formatting but did not register the text-color mark, configured Highlight as single-color, and disabled the Markdown HTML representation needed to preserve color attributes. As a result, users could neither choose text/background colors nor retain them after reopening a card.

## Impact

Users can now color selected text or apply a colored background highlight in File cards, clear either style, and retain the formatting after save/reload.

## Validation

- `pnpm --filter canvas-workspace typecheck`
- focused editor, toolbar, and UI-governance tests: 23 passed
- `pnpm --filter canvas-workspace build`
- full Canvas test suite: 1,572 passed; one pre-existing file-size governance test remains red for unrelated `dynamic-app/tools.ts` and `useEdgeInteraction.ts` baseline violations
