### PR TITLE
feat(canvas): make skills representation-aware

### DIFF
--- a/packages/canvas-cli/skills/canvas-bootstrap/SKILL.md
+++ b/packages/canvas-cli/skills/canvas-bootstrap/SKILL.md
@@ -1,15 +1,23 @@
 ---
 name: canvas-bootstrap
-description: Deep-research a topic and build a structured Pulse Canvas workspace with approved research depth, source-backed findings, progressive or final canvas creation, spatially organized frames, content nodes, and connections. Use when the user asks to bootstrap, generate, research, organize, or build an AI-created canvas.
+description: Build or reorganize a structured Pulse Canvas workspace. Use create mode when the user asks to bootstrap, generate, research, or build an AI-created canvas with source-backed findings. Use organize-existing mode when the user asks to tidy,整理,重排,归类,优化布局, improve readability, or organize an existing whole canvas without adding new research.
 ---
 
-# Canvas Bootstrap
+# Canvas Bootstrap and Organization
 
-Turn a topic into a source-backed Pulse Canvas workspace. This skill is an orchestrator: use a user-approved research skill or the bundled `canvas-deep-research` protocol for evidence gathering, then use canvas layout tools for geometry.
+Create a source-backed Pulse Canvas workspace or organize an existing whole canvas. In create mode, orchestrate approved research and layout. In organize-existing mode, preserve content and improve information architecture and geometry.
+
+## Choose the Mode
+
+- `create`: the user wants a new research-backed canvas or substantial new content. Follow Phases 0-7.
+- `organize-existing`: the user wants existing canvas content grouped, renamed, resized, connected, or laid out more clearly. Follow **Organize an Existing Canvas**, then Phase 6 and Phase 7.
+- `frame-research`: the user wants to enrich or verify one existing frame. Use `canvas-frame-research` instead.
+
+Do not make an organize-only request pass through the research depth gate.
 
 ## Core Contract
 
-- Ask for research depth first unless the user already provided it.
+- In `create` mode, ask for research depth first unless the user already provided it.
 - After depth is chosen, show a research plan and wait for user modification or approval.
 - Do not start substantial research before the plan is approved.
 - Do not create canvas nodes before approval. Optional live-board creation also requires approval.
@@ -18,6 +26,105 @@ Turn a topic into a source-backed Pulse Canvas workspace. This skill is an orche
 - Keep content and layout separate: research determines what belongs on the canvas; layout tools determine where it goes.
 - Use the user's language for user-facing questions, plans, summaries, and node content unless the user requests otherwise.
 - If the user asks to expand, enrich, verify, or research inside an existing frame, use `canvas-frame-research` instead of this whole-canvas bootstrap flow.
+
+## Organize an Existing Canvas
+
+Use this flow for `organize-existing` mode. Do not browse or add research unless the user separately asks for it.
+
+### 1. Read Before Moving
+
+Resolve the current or named workspace, then inspect:
+
+```bash
+'/Users/jasperhu/.pulse-coder/bin/pulse-canvas' context --workspace <id> --format json
+'/Users/jasperhu/.pulse-coder/bin/pulse-canvas' layout read --workspace <id> --format json
+'/Users/jasperhu/.pulse-coder/bin/pulse-canvas' edge list --workspace <id> --format json
+```
+
+Build an inventory of:
+
+- frames and geometric membership
+- unframed or ambiguously framed nodes
+- node titles, types, dimensions, and content density
+- overlaps, straddling, overflow, extreme whitespace, and narrow cards
+- existing connections and long crossing edges
+- visual hierarchy, source/reference material, and likely reading path
+
+Treat frame membership as spatial, not only semantic. Do not assume a nearby card belongs in a frame when its content is ambiguous.
+
+### 2. Diagnose the Board
+
+Separate problems into three layers:
+
+- **information architecture**: unclear groups, weak or generic frame names, duplicated categories, missing overview, scattered sources
+- **editorial shape**: article-sized cards, vague titles, multiple claims per card, no visible thesis or conclusion
+- **geometry**: overlaps, inconsistent gaps, uniform card sizing, stretched frames, edge crossings, poor Fit-view aspect ratio
+
+Default to geometry and grouping changes only. Preserve node ids, card wording, rich-text marks, links, and existing evidence. Rewriting, splitting, merging, deleting, or creating cards requires explicit approval.
+
+### 3. Propose the Reorganization
+
+For more than a trivial move, present a compact plan before mutation:
+
+- frames to retain, rename, merge, split, or create
+- cards that will move between frames
+- representation changes, such as a mindmap overview, HTML comparison, or image evidence
+- size hierarchy for thesis, evidence, annotation, and source cards
+- edge changes, if any
+- items intentionally left untouched
+
+Call out ambiguous cards separately. Ask for approval before moving unrelated existing nodes or changing editorial content.
+
+### 4. Choose the Representation
+
+Keep file cards as the default for atomic claims and searchable, editable prose. Introduce richer node types only when the representation materially improves understanding:
+
+- **Mindmap**: use for a true hierarchy, taxonomy, decomposition, or branching question. It is especially useful as a collapsible overview that links to detailed cards. Do not force timelines, debates, or many-to-many relationships into a tree.
+- **HTML/iframe**: use as an interactive explanation when manipulating a concept helps the reader understand causality, relationships, trade-offs, sequence, scale, or counterfactual outcomes. Good forms include parameter-driven models, step-through processes, explorable diagrams, comparison controls, and timeline scrubbing. A dashboard qualifies only when its interaction teaches something; static metric display does not. Keep it self-contained and pair it with a short searchable note containing the main conclusion. Do not turn ordinary prose into a miniature website.
+- **Image**: use for diagrams, photographs, scanned evidence, source screenshots, or generated visual explanations. Add a descriptive title/alt text and visible provenance. Never rasterize editable text merely to make the board look polished.
+- **Frames + cards + edges**: retain for spatial arguments, evidence maps, workflows, and non-hierarchical relationships.
+
+Prefer a hybrid board when useful: a mindmap as the overview, file cards for evidence and explanation, one HTML node for interactive understanding, and images for visual source material.
+
+Every HTML node must have an explicit learning contract:
+
+- the question or concept the interaction should clarify
+- controls that map to meaningful conceptual variables
+- immediate visual feedback that exposes what changed and why
+- a useful default state and short in-node guidance
+- a nearby searchable card summarizing the durable takeaway
+
+Representation changes are content-shape changes. In organize-existing mode, do not replace or delete the original cards until the user approves the conversion and the new representation has been verified.
+
+Creation path:
+
+- Create mindmaps through `canvas_create_node` or the CLI `mindmap` node type.
+- Create HTML through Canvas runtime `canvas_create_node` with `type: "iframe"` and `data.mode: "html"`, or create an HTML artifact and pin it to the canvas.
+- Create images through `canvas_create_node` with an absolute `data.filePath`, `canvas_generate_image`, or image paste/import.
+- The external Canvas CLI cannot generically create app-produced iframe or image nodes. Do not invent a CLI fallback; use the live Canvas runtime or keep a file-card placeholder with the intended representation clearly marked.
+
+### 5. Apply Safely
+
+- Prefer one atomic `apply` plan with `baseRevision` for node moves/resizes and edge changes.
+- Run `--dry-run` before the real apply.
+- Run all mutations sequentially and pin `--workspace <id>`.
+- Use `layout frame-grid` only after the intended children of a frame are settled.
+- Arrange top-level frames manually into a readable overview; do not force every board into the same grid.
+- Keep source/reference cards on the right or bottom periphery.
+- Use at most three accent frame colors; keep auxiliary frames neutral.
+- Prefer short local edges. Preserve meaningful existing labels.
+
+### 6. Validate Preservation
+
+Before and after counts must match for organize-only work unless the approved plan explicitly changes them:
+
+- node count
+- edge count
+- frame count
+- titled-card count
+- rich-text/color-bearing card count when available
+
+Run `layout validate`, inspect Fit view, and read representative cards at 100%. If the board is technically valid but the reading path remains unclear, revise the top-level frame arrangement instead of shrinking everything further.
 
 ## Phase 0: Depth Gate
 
@@ -166,8 +273,11 @@ If research materially changes the approved plan, show the changed structure and
 Node type strategy:
 
 - Overview layer: use summary-style note nodes for the research question, key conclusions, reading path, and strongest takeaways.
+- Hierarchy layer: use a mindmap when the content is genuinely tree-shaped and benefits from collapse/expand navigation.
 - Structure layer: use frames, shapes, and edges to show categories, comparisons, timelines, dependencies, tensions, and hierarchy.
 - Detail layer: use note or file nodes for deeper explanations, evidence, assumptions, and per-topic analysis.
+- Interactive-understanding layer: use one or a small number of HTML/iframe nodes for explorable models, simulations, step-through explanations, counterfactuals, or relationship discovery; keep ordinary prose and durable conclusions in file cards.
+- Image layer: use image nodes for diagrams, photos, visual evidence, and generated explanations, with descriptive titles and provenance.
 - Source layer: use source or web nodes when available; otherwise use source-summary note nodes. Keep source ids visible.
 - Open-question layer: use note nodes for unresolved questions, conflicts, weak evidence, and areas that need future human judgment.
 - Action layer: omit by default. Leave follow-up tasks for the user to add later unless explicitly requested.

--- a/packages/canvas-cli/skills/canvas-deep-research/SKILL.md
+++ b/packages/canvas-cli/skills/canvas-deep-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: canvas-deep-research
-description: Source-backed research workflow for Pulse Canvas bootstrapping, due diligence, technical/product/market landscape analysis, current-state research, and any canvas task where Codex must gather reliable evidence before producing an artifact. Use when canvas-bootstrap needs a bundled research protocol, or when the user asks to research reliable sources before creating or organizing a canvas.
+description: Source-backed, representation-aware research workflow for Pulse Canvas bootstrapping, due diligence, technical/product/market landscape analysis, current-state research, and canvas tasks that need reliable evidence before artifact creation. Use when canvas-bootstrap or canvas-frame-research needs a research brief with sources, uncertainty, and justified candidates for cards, mindmaps, interactive HTML, images, or spatial relationships.
 ---
 
 # Canvas Deep Research
@@ -115,9 +115,19 @@ research_brief:
         to: "Frame or node title"
         label: "Relationship"
         kind: "flow | dependency | reference | contrast"
+    representations:
+      - type: "file | mindmap | html | image | frames-edges"
+        purpose: "Why this representation improves understanding"
+        source_ids: ["S1"]
+        learning_question: "Required for HTML; what should interaction clarify?"
+        interaction:
+          variables: ["Meaningful variable a user can change"]
+          feedback: "What changes visibly and what relationship it reveals"
+          takeaway: "Durable conclusion to preserve in a searchable card"
+        fallback: "Simpler representation if the preferred node type is unavailable"
 ```
 
-Keep `canvas_candidates` concise. It is a handoff, not a final layout.
+Keep `canvas_candidates` concise. Omit fields that do not apply. It is a handoff, not a final layout or an instruction to create every proposed representation.
 
 ## Canvas Handoff Rules
 
@@ -129,3 +139,8 @@ When another skill such as `canvas-bootstrap` will create a canvas:
 - Include source ids inside each node summary so final canvas content can cite evidence.
 - Include only meaningful edges; avoid connecting everything to everything.
 - Mark draft, uncertain, or assumption-heavy nodes clearly.
+- Recommend a mindmap only for a genuine hierarchy, taxonomy, decomposition, or branching question.
+- Recommend HTML only when manipulating meaningful variables can clarify causality, relationships, trade-offs, sequence, scale, or counterfactual outcomes. Static display alone is not sufficient.
+- Recommend images for visual evidence, diagrams, photographs, or explanations that materially benefit from visual form. Include provenance or the evidence source.
+- Keep ordinary prose and durable conclusions in file cards. Do not rasterize editable text or propose rich nodes merely for decoration.
+- Let the downstream canvas skill make the final representation and layout decision.

--- a/packages/canvas-cli/skills/canvas-frame-research/SKILL.md
+++ b/packages/canvas-cli/skills/canvas-frame-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: canvas-frame-research
-description: Extend an existing Pulse Canvas frame with local, source-backed research while preserving the surrounding canvas. Use when the user asks to research, enrich, expand, verify, update, or add sources/details inside a selected or named frame, rather than bootstrapping a whole new canvas.
+description: Extend an existing Pulse Canvas frame with local, source-backed research and an appropriate mix of cards, mindmaps, interactive HTML, images, and relationships while preserving the surrounding canvas. Use when the user asks to research, enrich, expand, verify, update, visualize, or add sources/details inside a selected or named frame rather than bootstrapping a whole new canvas.
 ---
 
 # Canvas Frame Research
@@ -86,20 +86,36 @@ Default node budget:
 Layer the information from shallow to deep:
 
 - Overview layer: one short summary or "what changed" note when useful.
+- Hierarchy layer: a mindmap when the finding is genuinely tree-shaped.
 - Structure layer: shapes or small structural notes for categories, comparison axes, timelines, or relationships.
 - Detail layer: note or file nodes for deeper analysis.
+- Interactive-understanding layer: one HTML node when manipulating meaningful variables clarifies causality, relationships, trade-offs, sequence, scale, or counterfactual outcomes.
+- Image layer: diagrams, photographs, screenshots, or generated explanations when visual form carries evidence or understanding.
 - Source layer: source or web nodes when available; otherwise source-summary notes.
 - Open-question layer: note nodes for unresolved claims, conflicts, or weak evidence.
 - Action layer: omit by default. Let the user add follow-up tasks later unless explicitly requested.
+
+Choose the simplest representation that teaches the finding:
+
+- Keep ordinary prose, claims, and durable conclusions in file cards.
+- Use a mindmap only for hierarchy, taxonomy, decomposition, or branching.
+- Use HTML as an interactive explanation, not decorative presentation. Define its learning question, conceptual controls, visible feedback, default guidance, and durable takeaway before creating it.
+- Use images for visual evidence or explanation, with a descriptive title and visible provenance.
+- Use cards and edges for debates, evidence maps, workflows, and many-to-many relationships.
+
+For HTML, create a nearby searchable card containing the conclusion and source ids. Rich nodes count against the frame's node budget; do not add them on top of redundant cards.
 
 ## Phase 4: Create Local Nodes
 
 Preferred Canvas Agent path:
 
 1. Create new nodes with `placement: { mode: "inside_frame", frameId: "<target-frame-id>" }`.
-2. Use source/web node types when the runtime supports them; otherwise use note/file nodes with source ids.
-3. Connect only meaningful local relationships with `canvas_create_edge`.
-4. Avoid duplicating existing child nodes. Update or extend an existing node when that is cleaner.
+2. Create mindmaps with `canvas_create_node` and a recursive `data.root`.
+3. Create interactive HTML with `canvas_create_node` using `type: "iframe"` and `data.mode: "html"`, or create an HTML artifact and pin it inside the frame.
+4. Create images from an absolute local path with `canvas_create_node`, or use `canvas_generate_image` when the user requests a generated explanation.
+5. Use source/web node types when the runtime supports them; otherwise use note/file nodes with source ids.
+6. Connect only meaningful local relationships with `canvas_create_edge`.
+7. Avoid duplicating existing child nodes. Update or extend an existing node when that is cleaner.
 
 Fallback CLI path:
 
@@ -108,6 +124,8 @@ pulse-canvas node create --type file --title "<node>" --data '{"content":"..."}'
 ```
 
 Use manual coordinates only when layout tools are unavailable.
+
+The CLI can create mindmaps but cannot generically create app-produced iframe or image nodes. If the live Canvas runtime is unavailable, keep the evidence in a file card and report the deferred representation instead of inventing a CLI workaround.
 
 ## Phase 5: Layout Only the Frame
 
@@ -125,6 +143,7 @@ Move individual nodes with `node update` if validation flags them. Do not reorga
 Tell the user:
 
 - what was added or updated
+- why each rich representation was chosen
 - which sources support the new claims
 - what remains uncertain
 - whether anything should become a new sibling frame instead of staying local
@@ -138,3 +157,5 @@ Tell the user:
 5. Action-oriented nodes are opt-in, not default.
 6. Layout is local to the target frame.
 7. If the frame becomes crowded, suggest splitting into a sibling frame instead of forcing more nodes inside.
+8. Mindmaps remain tree-shaped; HTML interactions have a learning contract and were exercised; images include provenance.
+9. Durable conclusions remain searchable in file cards even when HTML or images carry the explanation.

--- a/packages/canvas-cli/skills/canvas/SKILL.md
+++ b/packages/canvas-cli/skills/canvas/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: canvas
-description: Operate Pulse Canvas workspaces — read user-curated context, write results, create nodes
-version: 1.0.0
+description: "Operate Pulse Canvas workspaces through the CLI and live Canvas runtime: read user-curated context, write results, create cards, frames, mindmaps, interactive HTML, and images, connect nodes, and verify rendered output. Use for direct Canvas inspection or mutation after a planning/research skill has chosen the intended representation."
 ---
 
 # Pulse Canvas
@@ -40,7 +39,30 @@ pulse-canvas node write <nodeId> --content "..."
 pulse-canvas node create --type file --title "Report" --data '{"content":"..."}'
 ```
 
-Supported `--type` values: `file`, `terminal`, `frame`, `agent`, `mindmap`.
+CLI-supported `--type` values: `file`, `terminal`, `frame`, `group`, `agent`, `mindmap`.
+
+### Choose CLI or Live Canvas Runtime
+
+Use the CLI for disk-backed reads, cards, frames/groups, agents/terminals, mindmaps, edges, layout, and atomic plans.
+
+The CLI can read app-produced `text`, `iframe`, and `image` nodes and can write existing text nodes, but it does not generically create iframe or image nodes. Do not invent a CLI representation for them.
+
+When native Canvas Agent tools are available, use the live runtime for richer nodes:
+
+- `canvas_create_node` with `type: "iframe"` and `data.mode: "html"` for a self-contained interactive explanation.
+- `artifact_create` followed by `artifact_pin_to_canvas` when the HTML should remain a versioned artifact.
+- `canvas_create_node` with `type: "image"` and an absolute `data.filePath` for an existing image.
+- `canvas_generate_image` when the user explicitly asks to generate a visual explanation.
+- `canvas_create_node` with `type: "mindmap"` and recursive `data.root` for hierarchy, taxonomy, decomposition, or branching.
+
+Keep ordinary prose and durable conclusions in file cards. HTML should clarify a stated learning question through meaningful controls and visible feedback; images should have descriptive titles and provenance.
+
+After creating a rich node:
+
+1. Read it back with a native Canvas read tool or `node read`.
+2. For HTML, exercise the important control or state transition and confirm the visible result.
+3. For images, verify the file loads and the title/alt/provenance is present.
+4. Check the surrounding frame and Fit view so the rich node supports rather than overwhelms the reading path.
 
 #### Mindmap
 


### PR DESCRIPTION
## What changed

- add an `organize-existing` mode to `canvas-bootstrap` for restructuring an existing board without forcing a research workflow
- teach Canvas planning skills when to use file cards, mindmaps, interactive HTML, images, or frames and edges
- add representation candidates and HTML learning contracts to deep-research handoffs
- make frame-local research choose, create, and verify rich node types without reorganizing unrelated canvas content
- document the boundary between CLI-creatable nodes and iframe/image creation through the live Canvas runtime

## Why

Canvas skills previously defaulted too heavily to file cards and grids. They did not consistently distinguish hierarchical understanding, interactive understanding, visual evidence, and spatial many-to-many relationships. The updated workflow chooses the simplest representation that materially improves understanding while keeping durable conclusions searchable.

## Impact

Agents can organize or enrich canvases with more appropriate node types while preserving existing content, provenance, and layout boundaries. Interactive HTML now requires an explicit learning question, meaningful controls, visible feedback, and a nearby durable takeaway.

## Validation

- `quick_validate.py` passed for all four bundled skill directories
- `node scripts/harness/run-harness-check.mjs --path ...` completed at quick/docs-only level
- `git diff --check` passed