### PR TITLE
fix(canvas): make imports and edge sync lossless

### DIFF
--- a/apps/canvas-workspace/AGENTS.md
+++ b/apps/canvas-workspace/AGENTS.md
@@ -141,9 +141,16 @@ deploys the external-agent `pulse-canvas` CLI + bundled skills. Do not mix them.
 - `harness/tools/driver/` launches the real Electron app. Use `temp`, `demo`,
   or `clone` profiles by default; use `real --allow-real-writes` only after
   explicit user intent because it can mutate real Pulse Canvas data.
+  Reopening `demo` without `--reset` preserves its existing manifest and
+  imported workspaces; fixture reseeding is a reset operation.
 - The app owns v2 canvas storage migration, PTY sessions, runtime-control
   endpoints, plugin activation, and UI-visible data recovery. The CLI adapts to
   those contracts but does not own them.
+- External canvas-store synchronization must treat edges as first-class state:
+  watcher events carry edge ids, renderer reloads must accept edge-only events,
+  and stale saves merge edges by `updatedAt` without dropping unsaved local
+  edges. Guards: `src/main/__tests__/canvas-store-merge.test.ts` and
+  `src/renderer/src/hooks/useNodes.external-update.test.ts`.
 - Live-app capabilities belong under `src/main/runtime/capabilities/`; stable
   Canvas Agent tools may adapt to them without changing their public names or
   payloads. External `/capabilities/*` routes stay hidden unless the

--- a/apps/canvas-workspace/harness/tools/driver/src/__tests__/profiles.test.mjs
+++ b/apps/canvas-workspace/harness/tools/driver/src/__tests__/profiles.test.mjs
@@ -1,0 +1,32 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { STORE_RELATIVE_DIR } from '../config.mjs';
+import { seedDemoHome } from '../profiles.mjs';
+
+const homes = [];
+
+afterEach(async () => {
+  await Promise.all(homes.splice(0).map((home) => rm(home, { recursive: true, force: true })));
+});
+
+describe('seedDemoHome', () => {
+  it('preserves an existing manifest and imported workspaces without reset', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'pulse-canvas-profile-test-'));
+    homes.push(home);
+    const storeDir = join(home, STORE_RELATIVE_DIR);
+    await mkdir(storeDir, { recursive: true });
+    const manifestPath = join(storeDir, '__workspaces__.json');
+    const original = JSON.stringify({
+      workspaces: [{ id: 'imported', name: 'Imported board' }],
+      folders: [],
+      activeId: 'imported',
+    }, null, 2);
+    await writeFile(manifestPath, original);
+
+    await seedDemoHome(home, { force: false });
+
+    expect(await readFile(manifestPath, 'utf8')).toBe(original);
+  });
+});

--- a/apps/canvas-workspace/harness/tools/driver/src/profiles.mjs
+++ b/apps/canvas-workspace/harness/tools/driver/src/profiles.mjs
@@ -15,7 +15,7 @@ export async function prepareProfile(profile, opts) {
   if (profile === 'demo') {
     const home = join(HARNESS_DIR, 'demo-home');
     if (opts.reset) await fs.rm(home, { recursive: true, force: true });
-    await seedDemoHome(home);
+    await seedDemoHome(home, { force: opts.reset === true });
     return { home, workspaceId: 'harness-demo', cleanupHome: false };
   }
 
@@ -49,10 +49,13 @@ export async function writeExperimentalFlags(flags, artifactsDir) {
   return flagsPath;
 }
 
-async function seedDemoHome(home) {
+export async function seedDemoHome(home, { force = false } = {}) {
   const storeDir = join(home, STORE_RELATIVE_DIR);
   const workspaceId = 'harness-demo';
   const workspaceDir = join(storeDir, workspaceId);
+  const manifestPath = join(storeDir, '__workspaces__.json');
+  const canvasPath = join(workspaceDir, 'canvas.json');
+  if (!force && existsSync(manifestPath)) return;
   const notesDir = join(workspaceDir, 'notes');
   await fs.mkdir(notesDir, { recursive: true });
   const notePath = join(notesDir, 'Harness_Demo-node-harness-note.md');
@@ -74,13 +77,13 @@ async function seedDemoHome(home) {
     '<label for="guest-input">Guest input</label>',
     '<input id="guest-input" autocomplete="off">',
   ].join('\n'), 'utf8');
-  await fs.writeFile(join(storeDir, '__workspaces__.json'), JSON.stringify({
+  await fs.writeFile(manifestPath, JSON.stringify({
     workspaces: [{ id: workspaceId, name: 'Harness Demo' }],
     folders: [],
     activeId: workspaceId,
   }, null, 2));
   const now = Date.now();
-  await fs.writeFile(join(workspaceDir, 'canvas.json'), JSON.stringify({
+  await fs.writeFile(canvasPath, JSON.stringify({
     schemaVersion: 1,
     nodes: [
       {

--- a/apps/canvas-workspace/src/main/__tests__/canvas-store-merge.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/canvas-store-merge.test.ts
@@ -8,7 +8,11 @@ vi.mock('electron', () => ({
   dialog: { showMessageBox: vi.fn() },
 }));
 
-import { preserveMainOwnedQueueFields } from '../canvas/store';
+import {
+  preserveMainOwnedQueueFields,
+} from '../canvas/store';
+import { mergeExternalEdges } from '../canvas/edge-sync';
+import type { CanvasEdge } from '../../shared/canvas';
 
 type MergeNode = Parameters<typeof preserveMainOwnedQueueFields>[0];
 
@@ -83,5 +87,39 @@ describe('preserveMainOwnedQueueFields', () => {
     const fileMemory = { ...plainAgentMemory, type: 'file' as const };
     const fileDisk = { ...plainAgentDisk, type: 'file' as const };
     expect(preserveMainOwnedQueueFields(fileMemory, fileDisk)).toBe(fileMemory);
+  });
+});
+
+const edge = (id: string, updatedAt: number, label = id): CanvasEdge => ({
+  id,
+  source: { kind: 'point', x: 0, y: 0 },
+  target: { kind: 'point', x: 100, y: 100 },
+  label,
+  updatedAt,
+});
+
+describe('mergeExternalEdges', () => {
+  it('keeps an edge added by an external writer when the renderer saves stale edges', () => {
+    const merged = mergeExternalEdges(
+      [edge('known', 10)],
+      [edge('known', 10), edge('external', 20)],
+      new Set(['known']),
+    );
+
+    expect(merged.map((item) => item.id)).toEqual(['known', 'external']);
+  });
+
+  it('uses updatedAt to preserve the newer external edge version', () => {
+    const merged = mergeExternalEdges(
+      [edge('known', 10, 'stale')],
+      [edge('known', 20, 'fresh')],
+      new Set(['known']),
+    );
+
+    expect(merged[0].label).toBe('fresh');
+  });
+
+  it('does not resurrect an edge deleted by the renderer', () => {
+    expect(mergeExternalEdges([], [edge('known', 10)], new Set(['known']))).toEqual([]);
   });
 });

--- a/apps/canvas-workspace/src/main/__tests__/workspace-import.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/workspace-import.test.ts
@@ -1,0 +1,83 @@
+import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  createWorkspaceExportArchive,
+  createWorkspaceExportPayload,
+} from '../canvas/workspace-export-archive';
+import { importWorkspaceArchiveToStore } from '../canvas/workspace-import';
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('importWorkspaceArchiveToStore', () => {
+  it('registers a successful import and rewrites portable file paths', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'pulse-canvas-import-'));
+    roots.push(root);
+    const sourcePath = join(root, 'workspace.pulsecanvas.zip');
+    const payload = createWorkspaceExportPayload({
+      exportedAt: '2026-07-26T00:00:00.000Z',
+      workspace: { id: 'source', name: 'Imported board' },
+      canvas: {
+        nodes: [{
+          id: 'card',
+          type: 'file',
+          data: { filePath: 'pulsecanvas://workspace/notes/card.md' },
+        }],
+      },
+      files: [{
+        relativePath: 'notes/card.md',
+        encoding: 'base64',
+        content: Buffer.from('# Card').toString('base64'),
+      }],
+    });
+    await writeFile(sourcePath, createWorkspaceExportArchive(payload));
+    const storeDir = join(root, 'store');
+
+    const result = await importWorkspaceArchiveToStore({
+      sourcePath,
+      storeDir,
+      workspaceId: 'ws-imported',
+      agentsTemplate: '# Agents',
+    });
+
+    expect(result.workspaceName).toBe('Imported board');
+    const canvas = JSON.parse(await readFile(join(storeDir, 'ws-imported', 'canvas.json'), 'utf8'));
+    expect(canvas.nodes[0].data.filePath).toBe(join(storeDir, 'ws-imported', 'notes', 'card.md'));
+    const manifest = JSON.parse(await readFile(join(storeDir, '__workspaces__.json'), 'utf8'));
+    expect(manifest).toMatchObject({
+      activeId: 'ws-imported',
+      workspaces: [{ id: 'ws-imported', name: 'Imported board' }],
+    });
+  });
+
+  it('publishes the workspace only after every archive file is written', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'pulse-canvas-import-'));
+    roots.push(root);
+    const sourcePath = join(root, 'broken.pulsecanvas.zip');
+    const payload = createWorkspaceExportPayload({
+      exportedAt: '2026-07-26T00:00:00.000Z',
+      workspace: { id: 'source', name: 'Broken import' },
+      canvas: { nodes: [] },
+      files: [
+        { relativePath: 'notes', encoding: 'base64', content: Buffer.from('file').toString('base64') },
+        { relativePath: 'notes/nested.md', encoding: 'base64', content: Buffer.from('nested').toString('base64') },
+      ],
+    });
+    await writeFile(sourcePath, createWorkspaceExportArchive(payload));
+    const storeDir = join(root, 'store');
+
+    await expect(importWorkspaceArchiveToStore({
+      sourcePath,
+      storeDir,
+      workspaceId: 'ws-imported',
+      agentsTemplate: '# Agents',
+    })).rejects.toThrow();
+
+    expect(await readdir(storeDir)).toEqual([]);
+  });
+});

--- a/apps/canvas-workspace/src/main/agent/tools/edges-tools.ts
+++ b/apps/canvas-workspace/src/main/agent/tools/edges-tools.ts
@@ -33,6 +33,7 @@ export function createEdgeTools(workspaceId: string): Record<string, CanvasTool>
             source: describeEndpoint(e.source, nodesById),
             target: describeEndpoint(e.target, nodesById),
             label: e.label,
+            labelStyle: e.labelStyle,
             kind: e.kind,
             arrowHead: e.arrowHead ?? 'triangle',
             arrowTail: e.arrowTail ?? 'none',
@@ -67,6 +68,9 @@ export function createEdgeTools(workspaceId: string): Record<string, CanvasTool>
         targetX: z.number().optional().describe('Free-point target X (canvas coords).'),
         targetY: z.number().optional().describe('Free-point target Y (canvas coords).'),
         label: z.string().optional().describe('Optional short label displayed on the edge.'),
+        labelColor: z.string().optional().describe('Optional CSS color for the edge label text.'),
+        labelBackgroundColor: z.string().optional()
+          .describe('Optional CSS background color for the edge label chip.'),
         arrowHead: z.enum(['none', 'triangle', 'arrow', 'dot', 'bar']).optional()
           .describe('Cap rendered at the target end. Default: "triangle".'),
         arrowTail: z.enum(['none', 'triangle', 'arrow', 'dot', 'bar']).optional()
@@ -133,6 +137,13 @@ export function createEdgeTools(workspaceId: string): Record<string, CanvasTool>
           arrowTail: (input.arrowTail as EdgeArrowCap | undefined) ?? 'none',
           stroke,
           label: input.label as string | undefined,
+          labelStyle:
+            input.labelColor != null || input.labelBackgroundColor != null
+              ? {
+                  color: input.labelColor as string | undefined,
+                  backgroundColor: input.labelBackgroundColor as string | undefined,
+                }
+              : undefined,
           kind: input.kind as string | undefined,
           payload: input.payload as Record<string, unknown> | undefined,
           updatedAt: Date.now(),
@@ -171,6 +182,8 @@ export function createEdgeTools(workspaceId: string): Record<string, CanvasTool>
       inputSchema: z.object({
         edgeId: z.string().describe('The ID of the edge to update.'),
         label: z.string().optional(),
+        labelColor: z.string().optional(),
+        labelBackgroundColor: z.string().optional(),
         kind: z.string().optional(),
         payload: z.record(z.string(), z.unknown()).optional(),
         arrowHead: z.enum(['none', 'triangle', 'arrow', 'dot', 'bar']).optional(),
@@ -215,6 +228,17 @@ export function createEdgeTools(workspaceId: string): Record<string, CanvasTool>
         const next: CanvasEdge = {
           ...existing,
           label: input.label !== undefined ? (input.label as string) : existing.label,
+          labelStyle:
+            input.labelColor != null || input.labelBackgroundColor != null
+              ? {
+                  color:
+                    (input.labelColor as string | undefined) ??
+                    existing.labelStyle?.color,
+                  backgroundColor:
+                    (input.labelBackgroundColor as string | undefined) ??
+                    existing.labelStyle?.backgroundColor,
+                }
+              : existing.labelStyle,
           kind: input.kind !== undefined ? (input.kind as string) : existing.kind,
           payload:
             input.payload !== undefined

--- a/apps/canvas-workspace/src/main/agent/tools/types.ts
+++ b/apps/canvas-workspace/src/main/agent/tools/types.ts
@@ -55,6 +55,7 @@ export interface CanvasEdge {
   arrowTail?: EdgeArrowCap;
   stroke?: EdgeStroke;
   label?: string;
+  labelStyle?: { color?: string; backgroundColor?: string };
   kind?: string;
   payload?: Record<string, unknown>;
   updatedAt?: number;

--- a/apps/canvas-workspace/src/main/canvas/edge-sync.ts
+++ b/apps/canvas-workspace/src/main/canvas/edge-sync.ts
@@ -1,0 +1,44 @@
+import { promises as fs } from 'node:fs';
+
+export interface SyncableEdge {
+  id: string;
+  label?: string;
+  updatedAt?: number;
+}
+
+export const edgesToMap = <T extends SyncableEdge>(
+  edges: T[] | undefined,
+): Map<string, T> => new Map((edges ?? []).map((edge) => [edge.id, edge]));
+
+export const readOnDiskEdgeMap = async <T extends SyncableEdge>(
+  filePath: string,
+): Promise<Map<string, T>> => {
+  try {
+    const parsed = JSON.parse(await fs.readFile(filePath, 'utf-8')) as { edges?: T[] };
+    return edgesToMap(parsed.edges);
+  } catch {
+    return new Map<string, T>();
+  }
+};
+
+export const mergeExternalEdges = <T extends SyncableEdge>(
+  memoryEdges: T[],
+  diskEdges: T[],
+  known: ReadonlySet<string>,
+): T[] => {
+  const diskById = edgesToMap(diskEdges);
+  const memoryIds = new Set(memoryEdges.map((edge) => edge.id));
+  const merged: T[] = [];
+  for (const memoryEdge of memoryEdges) {
+    const diskEdge = diskById.get(memoryEdge.id);
+    if (!diskEdge) {
+      if (!known.has(memoryEdge.id)) merged.push(memoryEdge);
+      continue;
+    }
+    merged.push((diskEdge.updatedAt ?? 0) > (memoryEdge.updatedAt ?? 0) ? diskEdge : memoryEdge);
+  }
+  for (const diskEdge of diskEdges) {
+    if (!memoryIds.has(diskEdge.id) && !known.has(diskEdge.id)) merged.push(diskEdge);
+  }
+  return merged;
+};

--- a/apps/canvas-workspace/src/main/canvas/store.ts
+++ b/apps/canvas-workspace/src/main/canvas/store.ts
@@ -1,7 +1,7 @@
 import type { Dirent } from "fs";
 import { ipcMain, BrowserWindow, dialog } from "electron";
 import { promises as fs, watch as fsWatch, FSWatcher } from "fs";
-import { join, basename, dirname, relative, resolve, sep, isAbsolute } from "path";
+import { join, basename, dirname, relative, sep, isAbsolute } from "path";
 import { homedir } from "os";
 import {
   atomicWriteJson,
@@ -22,7 +22,6 @@ import {
   createWorkspaceExportArchive,
   createWorkspaceExportPayload,
   isSafeRelativePath,
-  parseWorkspaceExportFile,
   type WorkspaceExportFile,
 } from "./workspace-export-archive";
 import {
@@ -31,6 +30,12 @@ import {
   collectExternalWorkspaceFiles,
   confirmSkippedExternalFilesExport,
 } from "./workspace-export-external-files";
+import {
+  importWorkspaceArchiveToStore,
+  relativePathFromPortableUrl,
+  rewriteCanvasFilePaths,
+} from './workspace-import';
+import { edgesToMap, mergeExternalEdges, readOnDiskEdgeMap, type SyncableEdge } from './edge-sync';
 
 /**
  * Extra fields the canvas-store side attaches to migration-progress events
@@ -118,31 +123,6 @@ const toPortableRelativePath = (filePath: string, workspaceDir: string): string 
 const portableUrlForRelativePath = (relativePath: string): string =>
   `${PORTABLE_WORKSPACE_URL_PREFIX}${encodeURI(relativePath)}`;
 
-const relativePathFromPortableUrl = (value: string): string | null => {
-  if (!value.startsWith(PORTABLE_WORKSPACE_URL_PREFIX)) return null;
-  return decodeURI(value.slice(PORTABLE_WORKSPACE_URL_PREFIX.length));
-};
-
-const rewriteCanvasFilePaths = (
-  value: unknown,
-  mapper: (filePath: string) => string,
-): unknown => {
-  if (Array.isArray(value)) {
-    return value.map((item) => rewriteCanvasFilePaths(item, mapper));
-  }
-  if (!value || typeof value !== 'object') return value;
-
-  const out: Record<string, unknown> = {};
-  for (const [key, item] of Object.entries(value)) {
-    if (key === 'filePath' && typeof item === 'string') {
-      out[key] = mapper(item);
-    } else {
-      out[key] = rewriteCanvasFilePaths(item, mapper);
-    }
-  }
-  return out;
-};
-
 const collectWorkspaceFiles = async (workspaceDir: string): Promise<WorkspaceExportFile[]> => {
   const files: WorkspaceExportFile[] = [];
 
@@ -202,6 +182,21 @@ const createUniqueImportedWorkspaceId = async (): Promise<string> => {
     }
   }
   return `ws-imported-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+};
+
+export const importWorkspaceFromPath = async (sourcePath: string) => {
+  const workspaceId = await createUniqueImportedWorkspaceId();
+  const imported = await importWorkspaceArchiveToStore({
+    sourcePath, storeDir: STORE_DIR, workspaceId, agentsTemplate: AGENTS_MD_TEMPLATE,
+  });
+  const restoredData = imported.canvas as CanvasSaveData;
+  knownNodeIds.set(workspaceId, new Set(
+    (restoredData.nodes ?? []).map((node) => node.id).filter((id): id is string => Boolean(id)),
+  ));
+  knownEdgeIds.set(workspaceId, new Set((restoredData.edges ?? []).map((edge) => edge.id)));
+  lastSnapshot.set(workspaceId, nodesToMap(restoredData.nodes));
+  lastEdgeSnapshot.set(workspaceId, edgesToMap(restoredData.edges));
+  return imported;
 };
 
 /** Manifest stays as a flat file; all other workspaces live in subdirectories. */
@@ -275,8 +270,11 @@ interface CanvasNode {
   [k: string]: unknown;
 }
 
+type CanvasEdge = SyncableEdge;
+
 interface CanvasSaveData {
   nodes?: CanvasNode[];
+  edges?: CanvasEdge[];
   [k: string]: unknown;
 }
 
@@ -317,6 +315,7 @@ const migrateNotePaths = async (
  * from "user deleted a node" (ID was seen, now missing from memory).
  */
 const knownNodeIds = new Map<string, Set<string>>();
+const knownEdgeIds = new Map<string, Set<string>>();
 
 /**
  * Merge external changes (e.g. from canvas-cli) into the data being saved.
@@ -347,7 +346,7 @@ const SKIP_WRITE = Symbol('canvas-store:skip-write');
 type MergeResult = CanvasSaveData | typeof SKIP_WRITE;
 
 type DiskReadOutcome =
-  | { kind: 'ok'; nodes: CanvasNode[] }
+  | { kind: 'ok'; nodes: CanvasNode[]; edges: CanvasEdge[] }
   | { kind: 'missing' }
   | { kind: 'unparseable'; err: unknown }
   | { kind: 'ioerror'; err: unknown };
@@ -375,7 +374,8 @@ const readDiskCanvas = async (
       const result = await readCanvasFull(id);
       if (result.data === null) return { kind: 'missing' };
       const nodes = Array.isArray(result.data.nodes) ? (result.data.nodes as CanvasNode[]) : [];
-      return { kind: 'ok', nodes };
+      const edges = Array.isArray(result.data.edges) ? (result.data.edges as CanvasEdge[]) : [];
+      return { kind: 'ok', nodes, edges };
     } catch (err) {
       // Parse failure almost always means we caught another writer
       // (canvas-cli mid-flush). A brief backoff almost always lands on
@@ -573,6 +573,8 @@ const mergeExternalNodes = async (
   }
 
   const diskNodes = disk.nodes;
+  const memoryEdges = Array.isArray(inMemoryData.edges) ? inMemoryData.edges : [];
+  const diskEdges = disk.edges;
 
   // Hard safety: never let a save with an empty node list clobber a
   // non-empty on-disk canvas. This shields against early-lifecycle
@@ -676,6 +678,7 @@ const mergeExternalNodes = async (
   return {
     ...inMemoryData,
     nodes: [...mergedExisting, ...externalNewNodes, ...preservedMissing],
+    edges: mergeExternalEdges(memoryEdges, diskEdges, knownEdgeIds.get(id) ?? new Set<string>()),
   };
 };
 
@@ -730,6 +733,7 @@ const withSaveLock = async <T>(id: string, fn: () => Promise<T>): Promise<T> => 
 const watchers = new Map<string, FSWatcher>();
 const watcherDebounce = new Map<string, NodeJS.Timeout>();
 const lastSnapshot = new Map<string, Map<string, CanvasNode>>();
+const lastEdgeSnapshot = new Map<string, Map<string, CanvasEdge>>();
 
 const nodesToMap = (nodes: CanvasNode[] | undefined): Map<string, CanvasNode> => {
   const m = new Map<string, CanvasNode>();
@@ -762,9 +766,9 @@ const readOnDiskNodeMap = async (
   }
 };
 
-const diffSnapshots = (
-  before: Map<string, CanvasNode>,
-  after: Map<string, CanvasNode>,
+const diffSnapshots = <T extends { updatedAt?: number }>(
+  before: Map<string, T>,
+  after: Map<string, T>,
 ): string[] => {
   const ids = new Set<string>();
   for (const [id, node] of after) {
@@ -784,11 +788,12 @@ const diffSnapshots = (
   return Array.from(ids);
 };
 
-const broadcastExternalUpdate = (workspaceId: string, nodeIds: string[]) => {
+const broadcastExternalUpdate = (workspaceId: string, nodeIds: string[], edgeIds: string[] = []) => {
   const payload = {
     type: 'canvas:updated' as const,
     workspaceId,
     nodeIds,
+    edgeIds,
     source: 'fs-watch' as const,
   };
   for (const win of BrowserWindow.getAllWindows()) {
@@ -809,17 +814,21 @@ const handleWatcherFire = async (workspaceId: string): Promise<void> => {
     return;
   }
   const newMap = nodesToMap(data.nodes);
+  const newEdgeMap = edgesToMap(data.edges);
   const oldMap = lastSnapshot.get(workspaceId) ?? new Map<string, CanvasNode>();
+  const oldEdgeMap = lastEdgeSnapshot.get(workspaceId) ?? new Map<string, CanvasEdge>();
   const changedIds = diffSnapshots(oldMap, newMap);
-  if (changedIds.length === 0) return;
+  const changedEdgeIds = diffSnapshots(oldEdgeMap, newEdgeMap);
+  if (changedIds.length === 0 && changedEdgeIds.length === 0) return;
   lastSnapshot.set(workspaceId, newMap);
+  lastEdgeSnapshot.set(workspaceId, newEdgeMap);
   // Keep knownNodeIds aligned with disk so `mergeExternalNodes` Rule 2
   // (disk-only never-seen → append) doesn't re-add nodes that the
   // watcher has already observed.
   const known = knownNodeIds.get(workspaceId) ?? new Set<string>();
   for (const id of newMap.keys()) known.add(id);
   knownNodeIds.set(workspaceId, known);
-  broadcastExternalUpdate(workspaceId, changedIds);
+  broadcastExternalUpdate(workspaceId, changedIds, changedEdgeIds);
 };
 
 const startWorkspaceWatcher = (workspaceId: string): void => {
@@ -1119,6 +1128,7 @@ const stopWorkspaceWatcher = (workspaceId: string): void => {
     watcherDebounce.delete(workspaceId);
   }
   lastSnapshot.delete(workspaceId);
+  lastEdgeSnapshot.delete(workspaceId);
   stopNodesWatcher(workspaceId);
 };
 
@@ -1154,6 +1164,9 @@ export const setupCanvasStoreIpc = () => {
             // (see the broadcast below).
             const rendererMemoryMap = nodesToMap(
               (payload.data as CanvasSaveData).nodes,
+            );
+            const rendererMemoryEdgeMap = edgesToMap(
+              (payload.data as CanvasSaveData).edges,
             );
             // First merge against current disk state. This picks up any
             // CLI-added nodes (Rule 2) and resolves per-node conflicts
@@ -1199,6 +1212,7 @@ export const setupCanvasStoreIpc = () => {
             // node as changed on every save in v2 mode.
             const onDiskMap = await readOnDiskNodeMap(payload.id);
             lastSnapshot.set(payload.id, onDiskMap);
+            lastEdgeSnapshot.set(payload.id, await readOnDiskEdgeMap(getFilePath(payload.id)));
             // Same idea for v2 per-node files: snapshot their exact
             // bytes so the nodes/ watcher's debounced fire can diff
             // against them and suppress the echo of our own write.
@@ -1211,6 +1225,7 @@ export const setupCanvasStoreIpc = () => {
             // for the pickedUp broadcast below — that comparison is
             // memory-vs-memory, not against the watcher snapshot.
             const mergedMap = nodesToMap(merged.nodes);
+            const mergedEdgeMap = edgesToMap(merged.edges);
             // Now that the write has landed, mark every persisted id as
             // known so subsequent `mergeExternalNodes` calls can tell
             // "memory-only node the user just created" (not in known →
@@ -1238,6 +1253,14 @@ export const setupCanvasStoreIpc = () => {
               }
             }
             knownNodeIds.set(payload.id, knownForWs);
+            const knownEdgesForWs = knownEdgeIds.get(payload.id) ?? new Set<string>();
+            for (const edge of merged.edges ?? []) knownEdgesForWs.add(edge.id);
+            for (const id of Array.from(knownEdgesForWs)) {
+              if (!mergedEdgeMap.has(id) && !rendererMemoryEdgeMap.has(id)) {
+                knownEdgesForWs.delete(id);
+              }
+            }
+            knownEdgeIds.set(payload.id, knownEdgesForWs);
             // If the merge result differs from the renderer's memory,
             // the CLI made changes between the renderer's last sync
             // and this save, and we just silently absorbed them into
@@ -1247,8 +1270,9 @@ export const setupCanvasStoreIpc = () => {
             // manual reload). Push the diff back explicitly so its
             // in-memory state catches up.
             const pickedUp = diffSnapshots(rendererMemoryMap, mergedMap);
-            if (pickedUp.length > 0) {
-              broadcastExternalUpdate(payload.id, pickedUp);
+            const pickedUpEdges = diffSnapshots(rendererMemoryEdgeMap, mergedEdgeMap);
+            if (pickedUp.length > 0 || pickedUpEdges.length > 0) {
+              broadcastExternalUpdate(payload.id, pickedUp, pickedUpEdges);
             }
           });
         }
@@ -1314,12 +1338,16 @@ export const setupCanvasStoreIpc = () => {
             );
             knownNodeIds.set(payload.id, known);
           }
+          if (Array.isArray(data.edges) && !knownEdgeIds.has(payload.id)) {
+            knownEdgeIds.set(payload.id, new Set(data.edges.map((edge) => edge.id)));
+          }
           // Seed / refresh the watcher's last-known snapshot using the
           // on-disk shape (layout-only for v2, full for v1). Starting the
           // watcher here means we only watch workspaces the user has
           // actually opened, and the canvas.json file is guaranteed to
           // exist by this point.
           lastSnapshot.set(payload.id, await readOnDiskNodeMap(payload.id));
+          lastEdgeSnapshot.set(payload.id, await readOnDiskEdgeMap(getFilePath(payload.id)));
           startWorkspaceWatcher(payload.id);
           // For v2 workspaces, also seed the per-node content snapshot
           // and start watching nodes/ so per-node data edits (canvas-cli
@@ -1466,46 +1494,27 @@ export const setupCanvasStoreIpc = () => {
         return { ok: false, canceled: true };
       }
 
-      const raw = await fs.readFile(result.filePaths[0]);
-      const imported = parseWorkspaceExportFile(raw);
-      const workspaceId = await createUniqueImportedWorkspaceId();
-      const workspaceName = imported.workspace.name.trim() || 'Imported Workspace';
-      const workspaceDir = getWorkspaceDir(workspaceId);
-      await fs.mkdir(workspaceDir, { recursive: true });
-
-      for (const file of imported.files) {
-        const targetPath = resolve(workspaceDir, file.relativePath);
-        const rel = relative(workspaceDir, targetPath);
-        if (rel.startsWith('..') || isAbsolute(rel)) {
-          throw new Error(`Workspace export contains an unsafe file path: ${file.relativePath}`);
-        }
-        await fs.mkdir(dirname(targetPath), { recursive: true });
-        await fs.writeFile(targetPath, Buffer.from(file.content, 'base64'));
-      }
-
-      const restoredCanvas = rewriteCanvasFilePaths(imported.canvas, (filePath) => {
-        const relativePath = relativePathFromPortableUrl(filePath);
-        if (!relativePath) return filePath;
-        if (!isSafeRelativePath(relativePath)) return filePath;
-        return join(workspaceDir, relativePath);
-      });
-      await ensureWorkspaceDir(workspaceId);
-      await atomicWriteCanvasJson(getFilePath(workspaceId), JSON.stringify(restoredCanvas, null, 2));
-
-      const restoredData = restoredCanvas as CanvasSaveData;
-      if (Array.isArray(restoredData.nodes)) {
-        knownNodeIds.set(
-          workspaceId,
-          new Set(restoredData.nodes.map((n) => n.id).filter((id): id is string => Boolean(id))),
-        );
-        lastSnapshot.set(workspaceId, nodesToMap(restoredData.nodes));
-      }
-
-      return { ok: true, workspaceId, workspaceName, fileCount: imported.files.length };
+      const { canvas: _canvas, ...imported } = await importWorkspaceFromPath(result.filePaths[0]);
+      return { ok: true, ...imported };
     } catch (err) {
       return { ok: false, error: err instanceof Error ? err.message : String(err) };
     }
   });
+
+  ipcMain.handle(
+    'canvas:importWorkspaceFromPath',
+    async (_event, payload: { filePath: string }) => {
+      try {
+        if (!payload || typeof payload.filePath !== 'string' || payload.filePath.trim() === '') {
+          return { ok: false, error: 'filePath is required' };
+        }
+        const { canvas: _canvas, ...imported } = await importWorkspaceFromPath(payload.filePath);
+        return { ok: true, ...imported };
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) };
+      }
+    },
+  );
 
   ipcMain.handle(
     'canvas:delete',
@@ -1514,6 +1523,7 @@ export const setupCanvasStoreIpc = () => {
         if (payload.id === MANIFEST_ID) return { ok: false, error: 'Cannot delete manifest' };
         stopWorkspaceWatcher(payload.id);
         knownNodeIds.delete(payload.id);
+        knownEdgeIds.delete(payload.id);
         const dir = getWorkspaceDir(payload.id);
         await fs.rm(dir, { recursive: true, force: true });
         // Also remove old flat file if it still exists

--- a/apps/canvas-workspace/src/main/canvas/workspace-import.ts
+++ b/apps/canvas-workspace/src/main/canvas/workspace-import.ts
@@ -1,0 +1,114 @@
+import { promises as fs } from 'node:fs';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import {
+  isSafeRelativePath,
+  parseWorkspaceExportFile,
+} from './workspace-export-archive';
+import { atomicWriteJson, readJsonWithRecovery } from './storage';
+
+const PORTABLE_WORKSPACE_URL_PREFIX = 'pulsecanvas://workspace/';
+
+export const relativePathFromPortableUrl = (value: string): string | null => {
+  if (!value.startsWith(PORTABLE_WORKSPACE_URL_PREFIX)) return null;
+  return decodeURI(value.slice(PORTABLE_WORKSPACE_URL_PREFIX.length));
+};
+
+export const rewriteCanvasFilePaths = (
+  value: unknown,
+  mapper: (filePath: string) => string,
+): unknown => {
+  if (Array.isArray(value)) return value.map((item) => rewriteCanvasFilePaths(item, mapper));
+  if (!value || typeof value !== 'object') return value;
+  return Object.fromEntries(Object.entries(value).map(([key, item]) => [
+    key,
+    key === 'filePath' && typeof item === 'string'
+      ? mapper(item)
+      : rewriteCanvasFilePaths(item, mapper),
+  ]));
+};
+
+export interface WorkspaceImportOptions {
+  sourcePath: string;
+  storeDir: string;
+  workspaceId: string;
+  agentsTemplate: string;
+}
+
+export interface ImportedWorkspace {
+  workspaceId: string;
+  workspaceName: string;
+  fileCount: number;
+  canvas: unknown;
+}
+
+export const importWorkspaceArchiveToStore = async ({
+  sourcePath,
+  storeDir,
+  workspaceId,
+  agentsTemplate,
+}: WorkspaceImportOptions): Promise<ImportedWorkspace> => {
+  const imported = parseWorkspaceExportFile(await fs.readFile(sourcePath));
+  const finalDir = join(storeDir, workspaceId);
+  const stagingDir = join(
+    storeDir,
+    `.import-${workspaceId}-${process.pid}-${Math.random().toString(36).slice(2, 8)}`,
+  );
+
+  await fs.mkdir(storeDir, { recursive: true });
+  await fs.mkdir(stagingDir);
+  try {
+    for (const file of imported.files) {
+      const targetPath = resolve(stagingDir, file.relativePath);
+      const rel = relative(stagingDir, targetPath);
+      if (rel.startsWith('..') || isAbsolute(rel)) {
+        throw new Error(`Workspace export contains an unsafe file path: ${file.relativePath}`);
+      }
+      await fs.mkdir(dirname(targetPath), { recursive: true });
+      await fs.writeFile(targetPath, Buffer.from(file.content, 'base64'));
+    }
+
+    const restoredCanvas = rewriteCanvasFilePaths(imported.canvas, (filePath) => {
+      const relativePath = relativePathFromPortableUrl(filePath);
+      if (!relativePath || !isSafeRelativePath(relativePath)) return filePath;
+      return join(finalDir, ...relativePath.split('/').filter(Boolean));
+    });
+    await fs.writeFile(join(stagingDir, 'canvas.json'), JSON.stringify(restoredCanvas, null, 2));
+    const agentsPath = join(stagingDir, 'AGENTS.md');
+    try {
+      await fs.access(agentsPath);
+    } catch {
+      await fs.writeFile(agentsPath, agentsTemplate, 'utf8');
+    }
+    await fs.rename(stagingDir, finalDir);
+
+    const result = {
+      workspaceId,
+      workspaceName: imported.workspace.name.trim() || 'Imported Workspace',
+      fileCount: imported.files.length,
+      canvas: restoredCanvas,
+    };
+    const manifestPath = join(storeDir, '__workspaces__.json');
+    const manifestRead = await readJsonWithRecovery(manifestPath);
+    if (manifestRead.kind === 'unrecoverable') throw manifestRead.err;
+    const manifest = manifestRead.kind === 'ok' && manifestRead.data && typeof manifestRead.data === 'object'
+      ? manifestRead.data as {
+        workspaces?: Array<{ id: string; name: string }>;
+        folders?: unknown[];
+        activeId?: string;
+      }
+      : {};
+    const workspaces = Array.isArray(manifest.workspaces) ? manifest.workspaces : [];
+    workspaces.push({ id: workspaceId, name: result.workspaceName });
+    await atomicWriteJson(manifestPath, JSON.stringify({
+      ...manifest,
+      workspaces,
+      folders: Array.isArray(manifest.folders) ? manifest.folders : [],
+      activeId: workspaceId,
+    }, null, 2), { rollingBackup: true });
+    return result;
+  } catch (error) {
+    await fs.rm(stagingDir, { recursive: true, force: true });
+    await fs.rm(finalDir, { recursive: true, force: true });
+    throw error;
+  }
+};

--- a/apps/canvas-workspace/src/preload/bridge/store.ts
+++ b/apps/canvas-workspace/src/preload/bridge/store.ts
@@ -26,6 +26,9 @@ export const createStoreApi = (ipcRenderer: IpcRenderer): CanvasWorkspaceApi["st
   importWorkspace: () =>
     ipcRenderer.invoke("canvas:importWorkspace"),
 
+  importWorkspaceFromPath: (filePath) =>
+    ipcRenderer.invoke("canvas:importWorkspaceFromPath", { filePath }),
+
   listPollutedWorkspaces: () =>
     ipcRenderer.invoke("canvas:listPollutedWorkspaces"),
 

--- a/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/EdgeLabel.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/EdgeLabel.test.tsx
@@ -48,4 +48,32 @@ describe('EdgeLabel', () => {
 
     expect(html).toContain('left:159.85px;top:49.95px');
   });
+
+  it('renders imported label foreground and background colors', () => {
+    const edge: CanvasEdge = {
+      id: 'styled',
+      source: { kind: 'point', x: 0, y: 0 },
+      target: { kind: 'point', x: 100, y: 0 },
+      label: 'supports',
+      labelStyle: {
+        color: '#7c2d12',
+        backgroundColor: '#ffedd5',
+      },
+    };
+
+    const html = renderToStaticMarkup(
+      <EdgeLabel
+        edge={edge}
+        nodes={[]}
+        transform={{ x: 0, y: 0, scale: 1 }}
+        isEditing={false}
+        onStartEdit={vi.fn()}
+        onCommit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain('color:#7c2d12');
+    expect(html).toContain('background-color:#ffedd5');
+  });
 });

--- a/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/EdgeLabel/index.tsx
@@ -92,6 +92,8 @@ export const EdgeLabel = ({
       style={{
         left: screenPos.x,
         top: screenPos.y,
+        color: edge.labelStyle?.color,
+        backgroundColor: edge.labelStyle?.backgroundColor,
         ['--edge-label-scale' as string]: labelScale,
       }}
       onMouseDown={(e) => e.stopPropagation()}

--- a/apps/canvas-workspace/src/renderer/src/hooks/external-edge-sync.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/external-edge-sync.ts
@@ -1,0 +1,27 @@
+import type { CanvasEdge } from '../types';
+
+export const mergeExternalEdgeUpdate = (
+  current: CanvasEdge[],
+  disk: CanvasEdge[],
+  changedIds: ReadonlySet<string>,
+  persistedIds: ReadonlySet<string>,
+): CanvasEdge[] => {
+  if (changedIds.size === 0) return current;
+  const diskById = new Map(disk.map((edge) => [edge.id, edge]));
+  const seen = new Set<string>();
+  const next: CanvasEdge[] = [];
+  for (const edge of current) {
+    seen.add(edge.id);
+    if (!changedIds.has(edge.id)) {
+      next.push(edge);
+      continue;
+    }
+    const diskEdge = diskById.get(edge.id);
+    if (diskEdge) next.push(diskEdge);
+    else if (!persistedIds.has(edge.id)) next.push(edge);
+  }
+  for (const id of changedIds) {
+    if (!seen.has(id) && diskById.has(id)) next.push(diskById.get(id)!);
+  }
+  return next;
+};

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodes.external-update.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodes.external-update.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { shouldReloadForExternalUpdate } from './useNodes';
+import { mergeExternalEdgeUpdate } from './external-edge-sync';
+
+describe('shouldReloadForExternalUpdate', () => {
+  it('reloads for an edge-only external update', () => {
+    expect(shouldReloadForExternalUpdate({
+      workspaceId: 'ws',
+      nodeIds: [],
+      edgeIds: ['edge-1'],
+      source: 'fs-watch',
+    })).toBe(true);
+  });
+
+  it('ignores an empty external update', () => {
+    expect(shouldReloadForExternalUpdate({
+      workspaceId: 'ws',
+      nodeIds: [],
+      edgeIds: [],
+      source: 'fs-watch',
+    })).toBe(false);
+  });
+});
+
+describe('mergeExternalEdgeUpdate', () => {
+  it('keeps a locally-created unsaved edge while applying an external edge create', () => {
+    const local = {
+      id: 'local',
+      source: { kind: 'point' as const, x: 0, y: 0 },
+      target: { kind: 'point' as const, x: 10, y: 10 },
+    };
+    const external = {
+      id: 'external',
+      source: { kind: 'point' as const, x: 20, y: 20 },
+      target: { kind: 'point' as const, x: 30, y: 30 },
+    };
+
+    expect(mergeExternalEdgeUpdate(
+      [local],
+      [external],
+      new Set(['external']),
+      new Set(),
+    ).map((edge) => edge.id)).toEqual(['local', 'external']);
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
@@ -17,9 +17,20 @@ import { resizeGroupsToChildren } from '../utils/resizeGroupsToChildren';
 import { count } from '../perf/counters';
 import { degradeEndpointsForDeletedNode } from '../utils/edgeFactory';
 import { useNodeHistory } from './useNodeHistory';
+import { mergeExternalEdgeUpdate } from './external-edge-sync';
 
 const SAVE_DEBOUNCE_MS = 800;
 const DEFAULT_CANVAS_ID = 'default';
+
+type ExternalUpdateEvent = {
+  workspaceId: string;
+  nodeIds: string[];
+  edgeIds?: string[];
+  source: string;
+};
+
+export const shouldReloadForExternalUpdate = (event: ExternalUpdateEvent): boolean =>
+  event.nodeIds.length > 0 || (event.edgeIds?.length ?? 0) > 0;
 
 export interface AddNodeOptions {
   fileName?: string;
@@ -69,6 +80,7 @@ export const useNodes = (
    * as a CLI delete and wipe it from the canvas.
    */
   const persistedIdsRef = useRef<Set<string>>(new Set());
+  const persistedEdgeIdsRef = useRef<Set<string>>(new Set());
 
   const doSave = useCallback(() => {
     if (!loadedRef.current) {
@@ -102,6 +114,7 @@ export const useNodes = (
       // it's safe for the external-update handler to treat future
       // disk-absence of these ids as "deleted elsewhere".
       for (const n of snapshot) persistedIdsRef.current.add(n.id);
+      for (const edge of edgeSnapshot) persistedEdgeIdsRef.current.add(edge.id);
     }).catch((err) => {
       console.warn('[canvas] save failed:', err);
       onSaveErrorRef.current?.();
@@ -160,7 +173,7 @@ export const useNodes = (
 
     const unsubscribe = storeApi.onExternalUpdate(async (event) => {
       if (event.workspaceId !== canvasId) return;
-      if (!Array.isArray(event.nodeIds) || event.nodeIds.length === 0) return;
+      if (!shouldReloadForExternalUpdate(event)) return;
       // Drop events that arrive before the initial load completes —
       // the upcoming load will read the latest disk state anyway, and
       // operating on an empty nodesRef here would corrupt the view.
@@ -224,14 +237,17 @@ export const useNodes = (
       nodesRef.current = nextNodes;
       setNodes(nextNodes);
 
-      // Edges for Step 1: treat disk as authoritative. CLI-side edge mutations
-      // are rare compared to node changes, and the external-update event
-      // currently carries no edge-level granularity. Replacing wholesale
-      // keeps us in sync for the common cases (CLI added/removed an edge,
-      // or a bound node was deleted elsewhere and edges were degraded).
       const diskEdges = Array.isArray(result.data.edges) ? result.data.edges : [];
-      edgesRef.current = diskEdges;
-      setEdges(diskEdges);
+      const changedEdgeIds = new Set(event.edgeIds ?? []);
+      const nextEdges = mergeExternalEdgeUpdate(
+        edgesRef.current,
+        diskEdges,
+        changedEdgeIds,
+        persistedEdgeIdsRef.current,
+      );
+      for (const edge of diskEdges) persistedEdgeIdsRef.current.add(edge.id);
+      edgesRef.current = nextEdges;
+      setEdges(nextEdges);
 
       // Mark the affected nodes as externally-edited for 2.5s so the Canvas
       // component can render a transient highlight.
@@ -317,6 +333,7 @@ export const useNodes = (
       return;
     }
     persistedIdsRef.current = new Set();
+    persistedEdgeIdsRef.current = new Set();
     void api.load(canvasId).then((result) => {
       if (result.ok && result.data) {
         const saved = result.data;
@@ -332,6 +349,7 @@ export const useNodes = (
         // the external-update handler can tell future deletes apart
         // from locally-added unsaved nodes.
         for (const n of loadedNodes) persistedIdsRef.current.add(n.id);
+        for (const edge of loadedEdges) persistedEdgeIdsRef.current.add(edge.id);
         if (saved.transform && onRestoreTransformRef.current) {
           onRestoreTransformRef.current(saved.transform);
         }

--- a/apps/canvas-workspace/src/renderer/src/types/workspace-api.ts
+++ b/apps/canvas-workspace/src/renderer/src/types/workspace-api.ts
@@ -90,6 +90,13 @@ export interface CanvasWorkspaceApi {
       fileCount?: number;
       error?: string;
     }>;
+    importWorkspaceFromPath: (filePath: string) => Promise<{
+      ok: boolean;
+      workspaceId?: string;
+      workspaceName?: string;
+      fileCount?: number;
+      error?: string;
+    }>;
     /**
      * Returns workspaces whose canvas.json was clobbered by a v1-unaware
      * writer. Renderer surfaces sticky alerts for each; recovery is via
@@ -105,6 +112,7 @@ export interface CanvasWorkspaceApi {
       callback: (event: {
         workspaceId: string;
         nodeIds: string[];
+        edgeIds?: string[];
         kind?: 'create' | 'update' | 'delete';
         source: string;
       }) => void,

--- a/apps/canvas-workspace/src/shared/canvas.ts
+++ b/apps/canvas-workspace/src/shared/canvas.ts
@@ -371,6 +371,11 @@ export interface EdgeStroke {
   style?: 'solid' | 'dashed' | 'dotted';
 }
 
+export interface EdgeLabelStyle {
+  color?: string;
+  backgroundColor?: string;
+}
+
 export const DEFAULT_EDGE_STROKE: Readonly<Required<EdgeStroke>> = {
   color: '#2e2e2e',
   width: 4,
@@ -411,6 +416,7 @@ export interface CanvasEdge {
   arrowTail?: EdgeArrowCap;
   stroke?: EdgeStroke;
   label?: string;
+  labelStyle?: EdgeLabelStyle;
   kind?: string;
   payload?: Record<string, unknown>;
   /** Epoch millis of last mutation; used for cross-process merge. */

--- a/packages/canvas-cli/src/core/__tests__/apply.test.ts
+++ b/packages/canvas-cli/src/core/__tests__/apply.test.ts
@@ -50,7 +50,14 @@ describe('applyPlan: atomic batch', () => {
         // NOTE: creatable types mirror `node create` (text/iframe/image are
         // the A5 gap, to be extended in BOTH paths through the parity gate).
         { action: 'create', type: 'file', id: 'card-b', title: 'Card B', content: 'body B' },
-        { action: 'createEdge', id: 'e1', from: 'card-a', to: 'card-b', label: 'supports' },
+        {
+          action: 'createEdge',
+          id: 'e1',
+          from: 'card-a',
+          to: 'card-b',
+          label: 'supports',
+          labelStyle: { color: '#7c2d12', backgroundColor: '#ffedd5' },
+        },
       ],
     }, { storeDir: testDir });
 
@@ -63,6 +70,10 @@ describe('applyPlan: atomic batch', () => {
     const canvas = await loadCanvas(wsId, testDir);
     expect(canvas?.nodes.map(n => n.id).sort()).toEqual(['card-a', 'card-b', 'seed']);
     expect(canvas?.edges?.map(e => e.id)).toEqual(['e1']);
+    expect(canvas?.edges?.[0]).toMatchObject({
+      labelStyle: { color: '#7c2d12', backgroundColor: '#ffedd5' },
+    });
+    expect(canvas?.edges?.[0].updatedAt).toEqual(expect.any(Number));
     // File node got a real backing markdown file with the plan's content.
     const cardA = canvas?.nodes.find(n => n.id === 'card-a');
     expect(String(cardA?.data.filePath)).toContain(join(wsDir, 'notes'));

--- a/packages/canvas-cli/src/core/apply.ts
+++ b/packages/canvas-cli/src/core/apply.ts
@@ -67,6 +67,7 @@ export interface ApplyCreateEdgeOp {
   from: string;
   to: string;
   label?: string;
+  labelStyle?: CanvasEdge['labelStyle'];
   kind?: string;
   bend?: number;
 }
@@ -256,8 +257,10 @@ export async function applyPlan(
             id,
             source: { kind: 'node', nodeId: op.from },
             target: { kind: 'node', nodeId: op.to },
+            updatedAt: Date.now(),
           };
           if (op.label !== undefined) edge.label = op.label;
+          if (op.labelStyle !== undefined) edge.labelStyle = op.labelStyle;
           if (op.kind !== undefined) edge.kind = op.kind;
           if (op.bend !== undefined) edge.bend = op.bend;
           edges.push(edge);

--- a/packages/canvas-cli/src/core/edges.ts
+++ b/packages/canvas-cli/src/core/edges.ts
@@ -15,6 +15,7 @@ export interface CreateEdgeOptions {
   sourceAnchor?: EdgeAnchor;
   targetAnchor?: EdgeAnchor;
   label?: string;
+  labelStyle?: CanvasEdge['labelStyle'];
   kind?: string;
   arrowHead?: EdgeArrowCap;
   arrowTail?: EdgeArrowCap;
@@ -49,6 +50,7 @@ export async function createEdge(
     arrowTail: opts.arrowTail ?? 'none',
     stroke: opts.stroke ?? { ...DEFAULT_EDGE_STROKE },
     label: opts.label,
+    labelStyle: opts.labelStyle,
     kind: opts.kind,
     payload: opts.payload,
     updatedAt: Date.now(),

--- a/packages/canvas-cli/src/core/types.ts
+++ b/packages/canvas-cli/src/core/types.ts
@@ -107,6 +107,11 @@ export interface EdgeStroke {
   style?: 'solid' | 'dashed' | 'dotted';
 }
 
+export interface EdgeLabelStyle {
+  color?: string;
+  backgroundColor?: string;
+}
+
 export interface CanvasEdge {
   id: string;
   source: EdgeEndpoint;
@@ -118,6 +123,7 @@ export interface CanvasEdge {
   arrowTail?: EdgeArrowCap;
   stroke?: EdgeStroke;
   label?: string;
+  labelStyle?: EdgeLabelStyle;
   /** Optional semantic tag for downstream consumers (agent, layout, etc). */
   kind?: string;
   /** Free-form extension slot mirroring `CanvasNodeData`. */


### PR DESCRIPTION
## What changed

- Treat canvas edges as first-class external-sync state: watcher events carry edge ids, the renderer handles edge-only updates, and stale renderer saves merge edge changes by `updatedAt`.
- Preserve unsaved local edges while applying external edge updates.
- Add dialog-free, failure-atomic workspace import through the preload bridge; imports stage files before publication, rewrite portable paths, and register the workspace manifest.
- Keep existing demo-profile manifests and imported workspaces unless the harness is explicitly started with `--reset`.
- Add edge-label foreground/background styling across the shared schema, renderer, Canvas Agent tools, and canvas-cli atomic apply path.
- Add regression coverage and record the cross-process synchronization rule in the workspace agent guidance.

## Why

Heptabase migrations could write edges successfully to disk while the open renderer ignored edge-only changes. A later renderer save then wrote its stale empty edge list back to disk. Harness restarts could also reseed the demo manifest and hide imported workspaces, while scripted imports had no supported dialog-free transaction boundary.

## Impact

Programmatic whiteboard migration no longer requires direct canvas-store surgery or an app restart. Imported edges and label styles remain visible and survive subsequent saves, and harness restarts preserve migrated workspaces by default.

## Validation

- `pnpm --filter canvas-workspace typecheck`
- Focused Canvas Workspace regressions: 14/14 passed
- `pnpm --filter @pulse-coder/canvas-cli typecheck`
- Focused canvas-cli apply regressions: 9/9 passed
- Full canvas-cli suite: 196/196 passed
- Canvas Workspace and canvas-cli production builds passed
- IPC contract snapshot: 148 handlers / 148 preload invokes
- Harness coverage: `harnessGaps: 0`

## Known target-branch validation noise

The full Canvas Workspace run otherwise passed 1581/1583 tests. One browsing-history timing test passed when rerun alone. The file-size governance test still reports two unchanged files already present at the same line counts on `master`: `src/plugins/main/dynamic-app/tools.ts` (596) and `src/renderer/src/hooks/useEdgeInteraction.ts` (513). This branch does not modify either file.