### PR TITLE
feat(canvas): support cross-mindmap transfers

### DIFF
--- a/apps/canvas-workspace/AGENTS.md
+++ b/apps/canvas-workspace/AGENTS.md
@@ -176,6 +176,10 @@ deploys the external-agent `pulse-canvas` CLI + bundled skills. Do not mix them.
   shorter README node table. Current host node types include `file`,
   `terminal`, `frame`, `group`, `agent`, `text`, `iframe`, `image`, `shape`,
   `mindmap`, `reference`, `dynamic-app`, and `plugin`.
+- Cross-mindmap topic transfers are canvas-level atomic transactions: rekey
+  every moved topic subtree, update both maps in one history snapshot, and
+  degrade bound edges in that same snapshot when a whole source map is removed.
+  Topic components own only drag intent; `useNodes` owns mutation and undo.
 - Plugin nodes use stable host type `plugin` with plugin-owned
   `data.payload`. **New node capabilities default to plugin nodes** (decided
   2026-07-08); extending the host `CanvasNode['type']` union is the

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasRootView.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasRootView.tsx
@@ -8,6 +8,7 @@ import { EdgeContextMenu } from '../EdgeContextMenu';
 import type { CanvasProps } from './types';
 import type { NodeDragOffset, NodeDragPreview } from '../../hooks/useNodeDrag';
 import type { NodeResizePreview } from '../../hooks/useNodeResize';
+import type { MergeMindmapTopicRequest } from '../../utils/mindmapTransfer';
 
 type CanvasRootViewProps = Pick<
   CanvasProps,
@@ -95,6 +96,13 @@ type CanvasRootViewProps = Pick<
   updateEdge: (id: string, patch: any) => void;
   updateNode: (id: string, patch: Partial<CanvasNode>) => void;
   onRemoveNodesLocally: (ids: string[]) => void;
+  onMergeMindmapTopic: (request: MergeMindmapTopicRequest) => boolean;
+  onSplitMindmapTopic: (
+    sourceNodeId: string,
+    sourceTopicId: string,
+    clientX: number,
+    clientY: number,
+  ) => boolean;
 };
 
 export const CanvasRootView = ({
@@ -176,6 +184,8 @@ export const CanvasRootView = ({
   transformLayerRef,
   updateEdge,
   updateNode,
+  onMergeMindmapTopic,
+  onSplitMindmapTopic,
 }: CanvasRootViewProps) => {
   // Right-click menu on a connection. Selecting the edge first keeps the
   // style panel / Delete-key behavior consistent with the menu actions.
@@ -258,6 +268,8 @@ export const CanvasRootView = ({
         onRemoveNodes={onRemoveNodesLocally}
         onSelect={handleSelectNode}
         onExportMindmapImage={actions.handleExportMindmapImage}
+        onMergeMindmapTopic={onMergeMindmapTopic}
+        onSplitMindmapTopic={onSplitMindmapTopic}
         onFocus={handleNodeViewportFocus}
         onReference={onPinReferenceNode}
         onAddToChat={onAddToChat}

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasSurface.tsx
@@ -19,6 +19,7 @@ import type { SnapLine } from '../../utils/canvasSnapping';
 import { ShapePrimitive } from '../../utils/shapeGeometry';
 import { useI18n } from '../../i18n';
 import type { CanvasNodeRenderMode } from '../CanvasNodeView/types';
+import type { MindmapTransferHandlers } from '../../utils/mindmapTransfer';
 import { markOnce } from '../../perf/monitor';
 
 const FIT_TRANSITION =
@@ -73,7 +74,7 @@ interface NodeRenderGroup {
   regular: CanvasNode[];
 }
 
-interface CanvasSurfaceProps {
+interface CanvasSurfaceProps extends MindmapTransferHandlers {
   transform: { x: number; y: number; scale: number };
   transformLayerRef: RefObject<HTMLDivElement>;
   /** Scale as of the last moment the canvas was at rest (useCanvas).
@@ -220,6 +221,8 @@ export const CanvasSurface = ({
   onRemove,
   onRemoveNodes,
   onExportMindmapImage,
+  onMergeMindmapTopic,
+  onSplitMindmapTopic,
   onSelect,
   onFocus,
   onReference,
@@ -276,6 +279,8 @@ export const CanvasSurface = ({
       onRemove={onRemove}
       onRemoveNodes={onRemoveNodes}
       onExportMindmapImage={onExportMindmapImage}
+      onMergeMindmapTopic={onMergeMindmapTopic}
+      onSplitMindmapTopic={onSplitMindmapTopic}
       onSelect={onSelect}
       onFocus={onFocus}
       onReference={onReference}

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -36,6 +36,10 @@ import type { AgentNodeData, CanvasNode, IframeNodeData } from '../../types';
 import type { CanvasProps } from './types';
 import { EXPERIMENTAL_FLAG_AGENT_TEAMS } from '../../../../shared/experimental-features';
 import { WorkspaceActiveProvider } from '../../hooks/useWorkspaceActive';
+import {
+  getSelectionAfterMindmapMerge,
+  type MergeMindmapTopicRequest,
+} from '../../utils/mindmapTransfer';
 
 const PLUGIN_FLAGS =
   (globalThis as { canvasWorkspace?: { pluginFlags?: Record<string, boolean> } })
@@ -174,6 +178,7 @@ export const Canvas = ({
     setTransformForSave, flushSave, commitHistory,
     undo, redo, duplicateNode, pasteNodes,
     groupNodes, ungroupNodes, wrapNodesInFrame,
+    mergeMindmapTopic, splitMindmapTopic,
   } = useNodes(
     canvasId,
     (savedTransform) => {
@@ -187,6 +192,26 @@ export const Canvas = ({
   useEffect(() => { flushSaveRef.current = flushSave; }, [flushSave]);
 
   useEffect(() => { nodesRef.current = nodes; }, [nodes]);
+
+  const handleSplitMindmapTopic = useCallback(
+    (
+      sourceNodeId: string,
+      sourceTopicId: string,
+      clientX: number,
+      clientY: number,
+    ): boolean => {
+      const container = containerRef.current;
+      if (!container) return false;
+      const point = screenToCanvas(clientX, clientY, container);
+      return splitMindmapTopic({
+        sourceNodeId,
+        sourceTopicId,
+        x: point.x - 24,
+        y: point.y - 24,
+      }) !== null;
+    },
+    [screenToCanvas, splitMindmapTopic],
+  );
 
   // React's root wheel listener is passive, so useCanvas.handleWheel cannot
   // suppress Chromium's default ctrl/meta+wheel page zoom (trackpad pinch
@@ -213,6 +238,19 @@ export const Canvas = ({
     handleMarqueeSelect,
     getAllNodes,
   } = useCanvasSelection({ nodesRef });
+
+  const handleMergeMindmapTopic = useCallback(
+    (request: MergeMindmapTopicRequest): boolean => {
+      const nextSelection = getSelectionAfterMindmapMerge(
+        nodesRef.current,
+        request,
+      );
+      const changed = mergeMindmapTopic(request);
+      if (changed && nextSelection) setSelectedNodeIds(nextSelection);
+      return changed;
+    },
+    [mergeMindmapTopic, setSelectedNodeIds],
+  );
 
   const handleRemoveNodesLocally = useCallback((ids: string[]) => {
     if (ids.length === 0) return;
@@ -666,6 +704,8 @@ export const Canvas = ({
       onReferenceToggle={onReferenceToggle}
       onUpdateReferenceSource={onUpdateReferenceSource}
       onRemoveNodesLocally={handleRemoveNodesLocally}
+      onMergeMindmapTopic={handleMergeMindmapTopic}
+      onSplitMindmapTopic={handleSplitMindmapTopic}
       openShortcuts={openShortcuts}
       paletteCommands={paletteCommands}
       referenceDrawerOpen={referenceDrawerOpen}

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/MindmapCanvasNode.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/MindmapCanvasNode.tsx
@@ -1,5 +1,6 @@
 import { useState, type CSSProperties, type MouseEvent } from 'react';
 import type { CanvasNode } from '../../types';
+import type { MergeMindmapTopicRequest } from '../../utils/mindmapTransfer';
 import { MindmapNodeBody } from '../MindmapNodeBody';
 import { NodeContextMenu } from '../NodeContextMenu';
 import { CloseButton, FullscreenButton } from './NodeButtons';
@@ -16,6 +17,13 @@ interface MindmapCanvasNodeProps {
   onAutoResize: (id: string, width: number, height: number) => void;
   onDragStart: (e: MouseEvent, node: CanvasNode) => void;
   onExportMindmapImage: (id: string) => void;
+  onMergeMindmapTopic?: (request: MergeMindmapTopicRequest) => boolean;
+  onSplitMindmapTopic?: (
+    sourceNodeId: string,
+    sourceTopicId: string,
+    clientX: number,
+    clientY: number,
+  ) => boolean;
   onSelect: (id: string, mods?: { shift?: boolean; meta?: boolean }) => void;
   onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
   readOnly: boolean;
@@ -35,6 +43,8 @@ export const MindmapCanvasNode = ({
   onAutoResize,
   onDragStart,
   onExportMindmapImage,
+  onMergeMindmapTopic,
+  onSplitMindmapTopic,
   onSelect,
   onUpdate,
   readOnly,
@@ -70,6 +80,8 @@ export const MindmapCanvasNode = ({
           onUpdate={onUpdate}
           onSelectNode={onSelect}
           onAutoResize={onAutoResize}
+          onMergeTopic={onMergeMindmapTopic}
+          onSplitTopic={onSplitMindmapTopic}
           readOnly={readOnly}
         />
       </div>

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.tsx
@@ -32,6 +32,8 @@ const CanvasNodeViewComponent = ({
   onRemove,
   onRemoveNodes,
   onExportMindmapImage,
+  onMergeMindmapTopic,
+  onSplitMindmapTopic,
   onSelect,
   onFocus,
   onReference,
@@ -174,6 +176,8 @@ const CanvasNodeViewComponent = ({
         onAutoResize={onAutoResize}
         onDragStart={onDragStart}
         onExportMindmapImage={onExportMindmapImage}
+        onMergeMindmapTopic={onMergeMindmapTopic}
+        onSplitMindmapTopic={onSplitMindmapTopic}
         onSelect={onSelect}
         onUpdate={onUpdate}
         readOnly={readOnly}
@@ -253,6 +257,8 @@ export const CanvasNodeView = memo(CanvasNodeViewComponent, (prev, next) => (
   prev.onAddDomSelectionToChat === next.onAddDomSelectionToChat &&
   prev.onSubmitDomReviewComments === next.onSubmitDomReviewComments &&
   prev.onRemoveNodes === next.onRemoveNodes &&
+  prev.onMergeMindmapTopic === next.onMergeMindmapTopic &&
+  prev.onSplitMindmapTopic === next.onSplitMindmapTopic &&
   prev.readOnly === next.readOnly &&
   prev.renderFullFileBody === next.renderFullFileBody &&
   prev.embedded === next.embedded &&

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/types.ts
@@ -2,6 +2,7 @@ import type { MouseEvent, ReactNode } from 'react';
 import type { AgentContextDomReviewComment, AgentContextDomSelectionRef, CanvasNode } from '../../types';
 import type { ResizeEdge } from '../../hooks/useNodeResize';
 import type { NodeDragOffset } from '../../hooks/useNodeDrag';
+import type { MergeMindmapTopicRequest } from '../../utils/mindmapTransfer';
 
 export type CanvasNodeRenderMode = 'full' | 'frame-body' | 'frame-title';
 
@@ -34,6 +35,13 @@ export interface CanvasNodeViewProps {
   onRemove: (id: string) => void;
   onRemoveNodes?: (ids: string[]) => void;
   onExportMindmapImage: (id: string) => void;
+  onMergeMindmapTopic?: (request: MergeMindmapTopicRequest) => boolean;
+  onSplitMindmapTopic?: (
+    sourceNodeId: string,
+    sourceTopicId: string,
+    clientX: number,
+    clientY: number,
+  ) => boolean;
   onSelect: (id: string, mods?: { shift?: boolean; meta?: boolean }) => void;
   onFocus: (node: CanvasNode) => void;
   /** Optional copy for the standard focus icon when a read-only preview opens

--- a/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/MindmapNodeBody.drag.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/MindmapNodeBody.drag.test.tsx
@@ -1,0 +1,279 @@
+// @vitest-environment happy-dom
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { I18nProvider } from '../../i18n';
+import type { CanvasNode, MindmapNodeData, MindmapTopic } from '../../types';
+import { MindmapNodeBody } from '.';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const topic = (
+  id: string,
+  text: string,
+  children: MindmapTopic[] = [],
+): MindmapTopic => ({ id, text, children });
+
+const mindmap = (id: string, root: MindmapTopic): CanvasNode => ({
+  id,
+  type: 'mindmap',
+  title: root.text,
+  x: 0,
+  y: 0,
+  width: 360,
+  height: 200,
+  data: { root, layout: 'right', rev: 0 } satisfies MindmapNodeData,
+});
+
+const source = mindmap(
+  'source-map',
+  topic('source-root', 'Source', [topic('source-branch', 'Branch')]),
+);
+const target = mindmap('target-map', topic('target-root', 'Target'));
+
+describe('MindmapNodeBody drag gestures', () => {
+  let root: Root;
+  let host: HTMLElement;
+  let originalElementsFromPoint: typeof document.elementsFromPoint;
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    originalElementsFromPoint = document.elementsFromPoint;
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+    Object.defineProperty(document, 'elementsFromPoint', {
+      configurable: true,
+      value: originalElementsFromPoint,
+    });
+  });
+
+  const renderMaps = (
+    onMergeTopic = vi.fn(() => true),
+    onSplitTopic = vi.fn(() => true),
+    options: {
+      targetReadOnly?: boolean;
+      separateTargetSurface?: boolean;
+      targetHasMergeHandler?: boolean;
+    } = {},
+  ) => {
+    const targetBody = (
+      <MindmapNodeBody
+        node={target}
+        isSelected
+        onUpdate={vi.fn()}
+        onSelectNode={vi.fn()}
+        onAutoResize={vi.fn()}
+        onMergeTopic={options.targetHasMergeHandler === false ? undefined : onMergeTopic}
+        onSplitTopic={onSplitTopic}
+        readOnly={options.targetReadOnly}
+      />
+    );
+    act(() => {
+      root.render(
+        <I18nProvider>
+          <div className="canvas-transform">
+            <MindmapNodeBody
+              node={source}
+              isSelected
+              onUpdate={vi.fn()}
+              onSelectNode={vi.fn()}
+              onAutoResize={vi.fn()}
+              onMergeTopic={onMergeTopic}
+              onSplitTopic={onSplitTopic}
+            />
+            {options.separateTargetSurface ? null : targetBody}
+          </div>
+          {options.separateTargetSurface
+            ? <div className="canvas-transform">{targetBody}</div>
+            : null}
+        </I18nProvider>,
+      );
+    });
+    return { onMergeTopic, onSplitTopic };
+  };
+
+  it('merges a whole mindmap when its root is dragged onto another root', () => {
+    const { onMergeTopic } = renderMaps();
+    const sourceRoot = host.querySelector<HTMLElement>(
+      '[data-mindmap-node-id="source-map"] [data-topic-id="source-root"]',
+    )!;
+    const targetRoot = host.querySelector<HTMLElement>(
+      '[data-mindmap-node-id="target-map"] [data-topic-id="target-root"]',
+    )!;
+    vi.spyOn(targetRoot, 'getBoundingClientRect').mockReturnValue({
+      x: 300,
+      y: 100,
+      left: 300,
+      top: 100,
+      right: 420,
+      bottom: 140,
+      width: 120,
+      height: 40,
+      toJSON: () => undefined,
+    });
+    Object.defineProperty(document, 'elementsFromPoint', {
+      configurable: true,
+      value: vi.fn(() => [targetRoot]),
+    });
+
+    act(() => {
+      sourceRoot.dispatchEvent(new MouseEvent('mousedown', {
+        bubbles: true,
+        button: 0,
+        clientX: 20,
+        clientY: 20,
+      }));
+      window.dispatchEvent(new MouseEvent('mousemove', {
+        clientX: 340,
+        clientY: 120,
+      }));
+      window.dispatchEvent(new MouseEvent('mouseup', {
+        clientX: 340,
+        clientY: 120,
+      }));
+    });
+
+    expect(onMergeTopic).toHaveBeenCalledWith({
+      sourceNodeId: 'source-map',
+      sourceTopicId: 'source-root',
+      targetNodeId: 'target-map',
+      target: { kind: 'child', parentId: 'target-root' },
+    });
+  });
+
+  it('preserves the first printable character through the full mindmap body', () => {
+    renderMaps();
+    const sourceRoot = host.querySelector<HTMLElement>(
+      '[data-mindmap-node-id="source-map"] [data-topic-id="source-root"]',
+    )!;
+
+    act(() => {
+      sourceRoot.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Z',
+        code: 'KeyZ',
+        bubbles: true,
+        cancelable: true,
+      }));
+    });
+
+    expect(
+      sourceRoot.querySelector<HTMLElement>('.mindmap-topic-text')?.innerText,
+    ).toBe('SourceZ');
+  });
+
+  it.each([
+    { label: 'read-only', targetReadOnly: true, separateTargetSurface: false },
+    { label: 'another canvas surface', targetReadOnly: false, separateTargetSurface: true },
+    {
+      label: 'editable preview without a canvas merge handler',
+      targetReadOnly: false,
+      separateTargetSurface: false,
+      targetHasMergeHandler: false,
+    },
+  ])('rejects a $label mindmap as a merge target', ({
+    targetReadOnly,
+    separateTargetSurface,
+    targetHasMergeHandler,
+  }) => {
+    const onMergeTopic = vi.fn(() => true);
+    renderMaps(onMergeTopic, vi.fn(() => true), {
+      targetReadOnly,
+      separateTargetSurface,
+      targetHasMergeHandler,
+    });
+    const sourceRoot = host.querySelector<HTMLElement>(
+      '[data-mindmap-node-id="source-map"] [data-topic-id="source-root"]',
+    )!;
+    const targetRoot = host.querySelector<HTMLElement>(
+      '[data-mindmap-node-id="target-map"] [data-topic-id="target-root"]',
+    )!;
+    vi.spyOn(targetRoot, 'getBoundingClientRect').mockReturnValue({
+      x: 300,
+      y: 100,
+      left: 300,
+      top: 100,
+      right: 420,
+      bottom: 140,
+      width: 120,
+      height: 40,
+      toJSON: () => undefined,
+    });
+    Object.defineProperty(document, 'elementsFromPoint', {
+      configurable: true,
+      value: vi.fn(() => [targetRoot]),
+    });
+
+    act(() => {
+      sourceRoot.dispatchEvent(new MouseEvent('mousedown', {
+        bubbles: true,
+        button: 0,
+        clientX: 20,
+        clientY: 20,
+      }));
+      window.dispatchEvent(new MouseEvent('mousemove', {
+        clientX: 340,
+        clientY: 120,
+      }));
+      window.dispatchEvent(new MouseEvent('mouseup', {
+        clientX: 340,
+        clientY: 120,
+      }));
+    });
+
+    expect(onMergeTopic).not.toHaveBeenCalled();
+  });
+
+  it('splits a branch when it is dropped outside its mindmap', () => {
+    const { onSplitTopic } = renderMaps();
+    const sourceBody = host.querySelector<HTMLElement>(
+      '[data-mindmap-node-id="source-map"]',
+    )!;
+    const branch = sourceBody.querySelector<HTMLElement>(
+      '[data-topic-id="source-branch"]',
+    )!;
+    vi.spyOn(sourceBody, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 200,
+      bottom: 160,
+      width: 200,
+      height: 160,
+      toJSON: () => undefined,
+    });
+    Object.defineProperty(document, 'elementsFromPoint', {
+      configurable: true,
+      value: vi.fn(() => []),
+    });
+
+    act(() => {
+      branch.dispatchEvent(new MouseEvent('mousedown', {
+        bubbles: true,
+        button: 0,
+        clientX: 60,
+        clientY: 60,
+      }));
+      window.dispatchEvent(new MouseEvent('mousemove', {
+        clientX: 480,
+        clientY: 320,
+      }));
+      window.dispatchEvent(new MouseEvent('mouseup', {
+        clientX: 480,
+        clientY: 320,
+      }));
+    });
+
+    expect(onSplitTopic).toHaveBeenCalledWith(
+      'source-map',
+      'source-branch',
+      480,
+      320,
+    );
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/TopicPill.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/TopicPill.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment happy-dom
+import { act, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { I18nProvider } from '../../i18n';
+import type { LaidOutTopic } from '../../utils/mindmapLayout';
+import { TopicPill } from './TopicPill';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const topic: LaidOutTopic = {
+  id: 'topic-1',
+  parentId: null,
+  depth: 0,
+  x: 0,
+  y: 0,
+  width: 180,
+  height: 32,
+  text: 'Central topic',
+  color: '#5b7cbf',
+  collapsed: false,
+  hasChildren: true,
+};
+
+describe('TopicPill editing', () => {
+  let root: Root;
+  let host: HTMLElement;
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+  });
+
+  it('keeps the first printable character when typing starts from selection', () => {
+    const Harness = () => {
+      const [editing, setEditing] = useState(false);
+      const [initialInput, setInitialInput] = useState<string>();
+      return (
+        <TopicPill
+          topic={topic}
+          isSelected
+          isEditing={editing}
+          initialInput={initialInput}
+          outerCanvasSelected
+          isDragSource={false}
+          dropHint={null}
+          onBeginReorder={vi.fn()}
+          onAddChild={vi.fn()}
+          onSelect={vi.fn()}
+          onEnterEdit={(input) => {
+            setInitialInput(input);
+            setEditing(true);
+          }}
+          onCommitText={vi.fn()}
+          onToggleCollapsed={vi.fn()}
+          onKeyAction={vi.fn()}
+        />
+      );
+    };
+
+    act(() => root.render(<I18nProvider><Harness /></I18nProvider>));
+    const pill = host.querySelector<HTMLElement>('.mindmap-topic');
+    expect(pill).not.toBeNull();
+
+    act(() => {
+      pill!.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'a',
+        code: 'KeyA',
+        bubbles: true,
+        cancelable: true,
+      }));
+    });
+
+    expect(host.querySelector<HTMLElement>('.mindmap-topic-text')?.innerText)
+      .toBe('Central topica');
+    expect(document.activeElement).toBe(host.querySelector('.mindmap-topic-text'));
+  });
+
+  it('commits the current text before Escape returns to selection', () => {
+    const onCommitText = vi.fn();
+    const onKeyAction = vi.fn();
+    act(() => {
+      root.render(
+        <I18nProvider>
+          <TopicPill
+            topic={topic}
+            isSelected
+            isEditing
+            outerCanvasSelected
+            isDragSource={false}
+            dropHint={null}
+            onBeginReorder={vi.fn()}
+            onAddChild={vi.fn()}
+            onSelect={vi.fn()}
+            onEnterEdit={vi.fn()}
+            onCommitText={onCommitText}
+            onToggleCollapsed={vi.fn()}
+            onKeyAction={onKeyAction}
+          />
+        </I18nProvider>,
+      );
+    });
+    const editor = host.querySelector<HTMLElement>('.mindmap-topic-text');
+    expect(editor).not.toBeNull();
+    editor!.innerText = 'Edited topic';
+
+    act(() => {
+      editor!.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Escape',
+        code: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      }));
+    });
+
+    expect(onCommitText).toHaveBeenCalledWith('Edited topic');
+    expect(onKeyAction).toHaveBeenCalledWith({ kind: 'exit' });
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/TopicPill.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/TopicPill.tsx
@@ -15,13 +15,14 @@ interface TopicPillProps {
   topic: LaidOutTopic;
   isSelected: boolean;
   isEditing: boolean;
+  initialInput?: string;
   outerCanvasSelected: boolean;
   isDragSource: boolean;
   dropHint: DropHint;
   onBeginReorder: (e: MouseEvent) => void;
   onAddChild: () => void;
   onSelect: () => void;
-  onEnterEdit: () => void;
+  onEnterEdit: (initialInput?: string) => void;
   onCommitText: (text: string) => void;
   onToggleCollapsed: () => void;
   onKeyAction: (action: KeyAction) => void;
@@ -32,6 +33,7 @@ export const TopicPill = ({
   topic,
   isSelected,
   isEditing,
+  initialInput,
   outerCanvasSelected,
   isDragSource,
   dropHint,
@@ -52,6 +54,9 @@ export const TopicPill = ({
     if (readOnly || !isEditing) return;
     const el = editorRef.current;
     if (!el) return;
+    if (initialInput) {
+      el.innerText = `${topic.text}${initialInput}`;
+    }
     el.focus();
     const range = document.createRange();
     range.selectNodeContents(el);
@@ -61,7 +66,7 @@ export const TopicPill = ({
       sel.removeAllRanges();
       sel.addRange(range);
     }
-  }, [isEditing, readOnly]);
+  }, [initialInput, isEditing, readOnly, topic.text]);
 
   useEffect(() => {
     if (isEditing || readOnly) return;
@@ -81,11 +86,6 @@ export const TopicPill = ({
     if (next !== topic.text) onCommitText(next);
   }, [onCommitText, topic.text, readOnly]);
 
-  const cancel = useCallback(() => {
-    const el = editorRef.current;
-    if (el) el.innerText = topic.text;
-  }, [topic.text]);
-
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (readOnly) return;
@@ -101,7 +101,7 @@ export const TopicPill = ({
       if (isEditing) {
         if (e.key === 'Escape') {
           consume();
-          cancel();
+          commit();
           onKeyAction({ kind: 'exit' });
           return;
         }
@@ -176,11 +176,12 @@ export const TopicPill = ({
             && !e.altKey
             && e.key.toLowerCase() !== 'f'
           ) {
-            onEnterEdit();
+            consume();
+            onEnterEdit(e.key);
           }
       }
     },
-    [cancel, commit, isEditing, onEnterEdit, onKeyAction, topic.hasChildren, topic.text, readOnly],
+    [commit, isEditing, onEnterEdit, onKeyAction, topic.hasChildren, topic.text, readOnly],
   );
 
   const isRoot = topic.depth === 0;

--- a/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/index.tsx
@@ -10,6 +10,8 @@ export const MindmapNodeBody = ({
   onUpdate,
   onSelectNode,
   onAutoResize,
+  onMergeTopic,
+  onSplitTopic,
   readOnly = false,
 }: MindmapNodeBodyProps) => {
   const controller = useMindmapController({
@@ -17,12 +19,16 @@ export const MindmapNodeBody = ({
     onUpdate,
     onSelectNode,
     onAutoResize,
+    onMergeTopic,
+    onSplitTopic,
     readOnly,
   });
 
   return (
     <div
       className={`mindmap-node-body${isSelected ? ' mindmap-node-body--selected' : ''}${isOuterDragging ? ' mindmap-node-body--outer-dragging' : ''}`}
+      data-mindmap-node-id={node.id}
+      data-mindmap-drop-enabled={!readOnly && onMergeTopic ? 'true' : undefined}
     >
       <div
         className="mindmap-viewport"
@@ -63,13 +69,14 @@ export const MindmapNodeBody = ({
               topic={topic}
               isSelected={controller.selectedId === topic.id}
               isEditing={controller.editingId === topic.id}
+              initialInput={controller.editingId === topic.id ? controller.editingInitialInput : undefined}
               outerCanvasSelected={isSelected}
               isDragSource={controller.reorder?.sourceId === topic.id}
               dropHint={controller.getDropHint(topic.id)}
               onBeginReorder={(e) => controller.beginReorder(topic.id, e)}
               onAddChild={() => controller.addChild(topic.id)}
               onSelect={() => controller.selectTopic(topic.id)}
-              onEnterEdit={() => controller.enterTopicEdit(topic.id)}
+              onEnterEdit={(initialInput) => controller.enterTopicEdit(topic.id, initialInput)}
               onCommitText={(text) => controller.renameTopic(topic.id, text)}
               onToggleCollapsed={() => controller.toggleTopicCollapsed(topic.id)}
               onKeyAction={(action) => controller.handleTopicKeyAction(topic.id, action)}

--- a/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/mindmapDrag.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/mindmapDrag.ts
@@ -1,0 +1,247 @@
+import type { MouseEvent as ReactMouseEvent } from 'react';
+import type { MindmapTopic } from '../../types';
+import {
+  isDescendant,
+  moveTopic,
+  type DropTarget,
+  type LaidOutTopic,
+} from '../../utils/mindmapLayout';
+import type { MindmapNodeBodyProps } from './types';
+
+export interface MindmapReorderState {
+  sourceId: string;
+  target: DropTarget | null;
+}
+
+interface StartMindmapDragOptions {
+  sourceId: string;
+  startEvent: ReactMouseEvent;
+  root: MindmapTopic;
+  topics: LaidOutTopic[];
+  nodeId: string;
+  applyRoot: (root: MindmapTopic) => void;
+  setSelectedId: (id: string) => void;
+  setReorder: (state: MindmapReorderState | null) => void;
+  onMergeTopic: MindmapNodeBodyProps['onMergeTopic'];
+  onSplitTopic: MindmapNodeBodyProps['onSplitTopic'];
+}
+
+export const startMindmapDrag = ({
+  sourceId,
+  startEvent,
+  root,
+  topics,
+  nodeId,
+  applyRoot,
+  setSelectedId,
+  setReorder,
+  onMergeTopic,
+  onSplitTopic,
+}: StartMindmapDragOptions) => {
+  const startX = startEvent.clientX;
+  const startY = startEvent.clientY;
+  const threshold = 5;
+  let started = false;
+  const contentEl = startEvent.currentTarget.closest('.mindmap-content') as HTMLElement | null;
+  const sourceBodyEl = startEvent.currentTarget.closest('.mindmap-node-body') as HTMLElement | null;
+  const sourceSurfaceEl = sourceBodyEl?.closest('.canvas-transform');
+  const topicById = new Map(topics.map((topic) => [topic.id, topic]));
+  let externalDropEl: HTMLElement | null = null;
+  type DragHit = {
+    nodeId: string;
+    target: DropTarget;
+    topicEl: HTMLElement;
+  };
+
+  const clearExternalDropHint = () => {
+    externalDropEl?.classList.remove(
+      'mindmap-topic--drop-before',
+      'mindmap-topic--drop-after',
+      'mindmap-topic--drop-child',
+    );
+    externalDropEl = null;
+  };
+
+  const showExternalDropHint = (hit: DragHit | null) => {
+    clearExternalDropHint();
+    if (!hit || hit.nodeId === nodeId) return;
+    const hint = hit.target.kind === 'child' ? 'child' : hit.target.kind;
+    hit.topicEl.classList.add(`mindmap-topic--drop-${hint}`);
+    externalDropEl = hit.topicEl;
+  };
+
+  const resolveTopicElement = (el: Element): HTMLElement | null => {
+    const topicEl = el.closest('.mindmap-topic');
+    return topicEl instanceof HTMLElement ? topicEl : null;
+  };
+
+  const isValidLocalTarget = (targetId: string | null): targetId is string => (
+    !!targetId
+    && targetId !== sourceId
+    && topicById.has(targetId)
+    && !isDescendant(root, sourceId, targetId)
+  );
+
+  const targetFromTopicRect = (
+    targetId: string,
+    rect: DOMRect,
+    clientX: number,
+    clientY: number,
+    isRootTarget: boolean,
+  ): DropTarget => {
+    const relX = (clientX - rect.left) / Math.max(1, rect.width);
+    const relY = (clientY - rect.top) / Math.max(1, rect.height);
+    if (isRootTarget) return { kind: 'child', parentId: targetId };
+    if (relX > 0.66 || clientX > rect.right + 18) {
+      return { kind: 'child', parentId: targetId };
+    }
+    if (relY < 0.5) return { kind: 'before', anchorId: targetId };
+    return { kind: 'after', anchorId: targetId };
+  };
+
+  const hitTest = (clientX: number, clientY: number): DragHit | null => {
+    const stack = document.elementsFromPoint(clientX, clientY);
+    let pillEl: HTMLElement | null = null;
+    for (const el of stack) {
+      if (el instanceof Element) pillEl = resolveTopicElement(el);
+      if (pillEl) break;
+    }
+    if (pillEl) {
+      const targetId = pillEl.getAttribute('data-topic-id');
+      const targetBody = pillEl.closest<HTMLElement>('.mindmap-node-body');
+      const targetNodeId = targetBody?.dataset.mindmapNodeId;
+      const localTarget = targetNodeId === nodeId;
+      const editableSameSurface =
+        targetBody?.dataset.mindmapDropEnabled === 'true'
+        && targetBody.closest('.canvas-transform') === sourceSurfaceEl;
+      if (
+        targetId
+        && targetNodeId
+        && editableSameSurface
+        && (!localTarget || isValidLocalTarget(targetId))
+      ) {
+        return {
+          nodeId: targetNodeId,
+          target: targetFromTopicRect(
+            targetId,
+            pillEl.getBoundingClientRect(),
+            clientX,
+            clientY,
+            pillEl.classList.contains('mindmap-topic--root'),
+          ),
+          topicEl: pillEl,
+        };
+      }
+    }
+
+    if (!contentEl) return null;
+    const contentRect = contentEl.getBoundingClientRect();
+    const withinLooseMindmap =
+      clientX >= contentRect.left - 72
+      && clientX <= contentRect.right + 128
+      && clientY >= contentRect.top - 48
+      && clientY <= contentRect.bottom + 48;
+    if (!withinLooseMindmap) return null;
+
+    let best: { id: string; rect: DOMRect; score: number } | null = null;
+    const topicEls = contentEl.querySelectorAll<HTMLElement>('.mindmap-topic');
+    for (const candidateEl of topicEls) {
+      const targetId = candidateEl.getAttribute('data-topic-id');
+      if (!isValidLocalTarget(targetId)) continue;
+      const rect = candidateEl.getBoundingClientRect();
+      const clampedX = Math.max(rect.left, Math.min(clientX, rect.right));
+      const clampedY = Math.max(rect.top, Math.min(clientY, rect.bottom));
+      const dx = clientX - clampedX;
+      const dy = clientY - clampedY;
+      const rowBias = Math.abs(clientY - (rect.top + rect.height / 2)) * 0.4;
+      const score = Math.hypot(dx, dy) + rowBias;
+      if (!best || score < best.score) best = { id: targetId, rect, score };
+    }
+
+    if (!best || best.score > 180) return null;
+    const topicEl = contentEl.querySelector<HTMLElement>(
+      `.mindmap-topic[data-topic-id="${CSS.escape(best.id)}"]`,
+    );
+    if (!topicEl) return null;
+    return {
+      nodeId,
+      target: targetFromTopicRect(
+        best.id,
+        best.rect,
+        clientX,
+        clientY,
+        best.id === root.id,
+      ),
+      topicEl,
+    };
+  };
+
+  const onMove = (event: MouseEvent) => {
+    if (!started) {
+      if (Math.hypot(event.clientX - startX, event.clientY - startY) < threshold) return;
+      started = true;
+      window.getSelection()?.removeAllRanges();
+      setReorder({ sourceId, target: null });
+    }
+    const hit = hitTest(event.clientX, event.clientY);
+    showExternalDropHint(hit);
+    setReorder({
+      sourceId,
+      target: hit?.nodeId === nodeId ? hit.target : null,
+    });
+  };
+
+  const onUp = (event: MouseEvent) => {
+    cleanup();
+    if (!started) return;
+    const hit = hitTest(event.clientX, event.clientY);
+    setReorder(null);
+    if (hit?.nodeId !== nodeId) {
+      if (hit) {
+        onMergeTopic?.({
+          sourceNodeId: nodeId,
+          sourceTopicId: sourceId,
+          targetNodeId: hit.nodeId,
+          target: hit.target,
+        });
+        return;
+      }
+      if (sourceId !== root.id && sourceBodyEl) {
+        const rect = sourceBodyEl.getBoundingClientRect();
+        const outsideSource =
+          event.clientX < rect.left
+          || event.clientX > rect.right
+          || event.clientY < rect.top
+          || event.clientY > rect.bottom;
+        if (outsideSource) {
+          onSplitTopic?.(nodeId, sourceId, event.clientX, event.clientY);
+        }
+      }
+      return;
+    }
+    if (sourceId === root.id) return;
+    const next = moveTopic(root, sourceId, hit.target);
+    if (next) {
+      applyRoot(next);
+      setSelectedId(sourceId);
+    }
+  };
+
+  const onKey = (event: KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      cleanup();
+      setReorder(null);
+    }
+  };
+
+  function cleanup() {
+    clearExternalDropHint();
+    window.removeEventListener('mousemove', onMove);
+    window.removeEventListener('mouseup', onUp);
+    window.removeEventListener('keydown', onKey);
+  }
+
+  window.addEventListener('mousemove', onMove);
+  window.addEventListener('mouseup', onUp);
+  window.addEventListener('keydown', onKey);
+};

--- a/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/types.ts
@@ -1,4 +1,7 @@
 import type { CanvasNode } from '../../types';
+import type {
+  MergeMindmapTopicRequest,
+} from '../../utils/mindmapTransfer';
 
 export interface MindmapNodeBodyProps {
   node: CanvasNode;
@@ -7,6 +10,13 @@ export interface MindmapNodeBodyProps {
   onUpdate: (id: string, patch: Partial<CanvasNode>) => void;
   onSelectNode: (id: string) => void;
   onAutoResize: (id: string, width: number, height: number) => void;
+  onMergeTopic?: (request: MergeMindmapTopicRequest) => boolean;
+  onSplitTopic?: (
+    sourceNodeId: string,
+    sourceTopicId: string,
+    clientX: number,
+    clientY: number,
+  ) => boolean;
   readOnly?: boolean;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/useMindmapController.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/MindmapNodeBody/useMindmapController.ts
@@ -5,7 +5,6 @@ import {
   useMemo,
   useRef,
   useState,
-  type MouseEvent as ReactMouseEvent,
 } from 'react';
 import type { MindmapNodeData, MindmapTopic } from '../../types';
 import { genTopicId } from '../../utils/nodeFactory';
@@ -14,31 +13,41 @@ import {
   findParent,
   findTopicPath,
   insertChild,
-  isDescendant,
   layoutMindmap,
-  moveTopic,
   setTopicText,
   toggleCollapsed,
-  type DropTarget,
   type LaidOutTopic,
 } from '../../utils/mindmapLayout';
 import type { DropHint, KeyAction, MindmapNodeBodyProps } from './types';
+import {
+  startMindmapDrag,
+  type MindmapReorderState,
+} from './mindmapDrag';
 
 export const useMindmapController = ({
   node,
   onUpdate,
   onSelectNode,
   onAutoResize,
+  onMergeTopic,
+  onSplitTopic,
   readOnly = false,
-}: Pick<MindmapNodeBodyProps, 'node' | 'onUpdate' | 'onSelectNode' | 'onAutoResize' | 'readOnly'>) => {
+}: Pick<
+  MindmapNodeBodyProps,
+  | 'node'
+  | 'onUpdate'
+  | 'onSelectNode'
+  | 'onAutoResize'
+  | 'onMergeTopic'
+  | 'onSplitTopic'
+  | 'readOnly'
+>) => {
   const data = node.data as MindmapNodeData;
   const root = data.root;
   const [selectedId, setSelectedId] = useState<string>(root.id);
   const [editingId, setEditingId] = useState<string | null>(null);
-  const [reorder, setReorder] = useState<{
-    sourceId: string;
-    target: DropTarget | null;
-  } | null>(null);
+  const [editingInitialInput, setEditingInitialInput] = useState<string | undefined>();
+  const [reorder, setReorder] = useState<MindmapReorderState | null>(null);
   const pendingFocusRef = useRef<string | null>(null);
 
   const layout = useMemo(() => layoutMindmap(root), [root]);
@@ -177,134 +186,20 @@ export const useMindmapController = ({
   );
 
   const beginReorder = useCallback(
-    (sourceId: string, startEvent: ReactMouseEvent) => {
-      if (sourceId === root.id) return;
-      const startX = startEvent.clientX;
-      const startY = startEvent.clientY;
-      const threshold = 5;
-      let started = false;
-      const dragRoot = root;
-      const contentEl = startEvent.currentTarget.closest('.mindmap-content') as HTMLElement | null;
-      const topicById = new Map(layout.topics.map((topic) => [topic.id, topic]));
-
-      const resolveTopicElement = (el: Element): HTMLElement | null => {
-        const topicEl = el.closest('.mindmap-topic');
-        return topicEl instanceof HTMLElement ? topicEl : null;
-      };
-
-      const isValidTarget = (targetId: string | null): targetId is string => (
-        !!targetId
-        && targetId !== sourceId
-        && topicById.has(targetId)
-        && !isDescendant(dragRoot, sourceId, targetId)
-      );
-
-      const targetFromTopicRect = (
-        targetId: string,
-        rect: DOMRect,
-        clientX: number,
-        clientY: number,
-      ): DropTarget | null => {
-        if (!isValidTarget(targetId)) return null;
-        const relX = (clientX - rect.left) / Math.max(1, rect.width);
-        const relY = (clientY - rect.top) / Math.max(1, rect.height);
-        if (targetId === dragRoot.id) return { kind: 'child', parentId: targetId };
-        if (relX > 0.66 || clientX > rect.right + 18) return { kind: 'child', parentId: targetId };
-        if (relY < 0.5) return { kind: 'before', anchorId: targetId };
-        return { kind: 'after', anchorId: targetId };
-      };
-
-      const hitTest = (clientX: number, clientY: number): DropTarget | null => {
-        const stack = document.elementsFromPoint(clientX, clientY);
-        let pillEl: HTMLElement | null = null;
-        for (const el of stack) {
-          if (el instanceof Element) {
-            pillEl = resolveTopicElement(el);
-          }
-          if (pillEl) {
-            break;
-          }
-        }
-        if (pillEl) {
-          const targetId = pillEl.getAttribute('data-topic-id');
-          const preciseTarget = targetId
-            ? targetFromTopicRect(targetId, pillEl.getBoundingClientRect(), clientX, clientY)
-            : null;
-          if (preciseTarget) return preciseTarget;
-        }
-
-        if (!contentEl) return null;
-        const contentRect = contentEl.getBoundingClientRect();
-        const withinLooseMindmap =
-          clientX >= contentRect.left - 72
-          && clientX <= contentRect.right + 128
-          && clientY >= contentRect.top - 48
-          && clientY <= contentRect.bottom + 48;
-        if (!withinLooseMindmap) return null;
-
-        let best: { id: string; rect: DOMRect; score: number } | null = null;
-        const topicEls = contentEl.querySelectorAll<HTMLElement>('.mindmap-topic');
-        for (const candidateEl of topicEls) {
-          const targetId = candidateEl.getAttribute('data-topic-id');
-          if (!isValidTarget(targetId)) continue;
-          const rect = candidateEl.getBoundingClientRect();
-          const clampedX = Math.max(rect.left, Math.min(clientX, rect.right));
-          const clampedY = Math.max(rect.top, Math.min(clientY, rect.bottom));
-          const dx = clientX - clampedX;
-          const dy = clientY - clampedY;
-          const rowBias = Math.abs(clientY - (rect.top + rect.height / 2)) * 0.4;
-          const score = Math.hypot(dx, dy) + rowBias;
-          if (!best || score < best.score) {
-            best = { id: targetId, rect, score };
-          }
-        }
-
-        if (!best || best.score > 180) return null;
-        return targetFromTopicRect(best.id, best.rect, clientX, clientY);
-      };
-
-      const onMove = (e: MouseEvent) => {
-        if (!started) {
-          if (Math.hypot(e.clientX - startX, e.clientY - startY) < threshold) return;
-          started = true;
-          window.getSelection()?.removeAllRanges();
-          setReorder({ sourceId, target: null });
-        }
-        const target = hitTest(e.clientX, e.clientY);
-        setReorder((s) => (s ? { ...s, target } : null));
-      };
-
-      const onUp = (e: MouseEvent) => {
-        cleanup();
-        if (!started) return;
-        const target = hitTest(e.clientX, e.clientY);
-        setReorder(null);
-        if (!target) return;
-        const next = moveTopic(dragRoot, sourceId, target);
-        if (next) {
-          applyRoot(next);
-          setSelectedId(sourceId);
-        }
-      };
-
-      const onKey = (e: KeyboardEvent) => {
-        if (e.key === 'Escape') {
-          cleanup();
-          setReorder(null);
-        }
-      };
-
-      function cleanup() {
-        window.removeEventListener('mousemove', onMove);
-        window.removeEventListener('mouseup', onUp);
-        window.removeEventListener('keydown', onKey);
-      }
-
-      window.addEventListener('mousemove', onMove);
-      window.addEventListener('mouseup', onUp);
-      window.addEventListener('keydown', onKey);
-    },
-    [applyRoot, layout.topics, root],
+    (sourceId: string, startEvent: Parameters<typeof startMindmapDrag>[0]['startEvent']) =>
+      startMindmapDrag({
+        sourceId,
+        startEvent,
+        root,
+        topics: layout.topics,
+        nodeId: node.id,
+        applyRoot,
+        setSelectedId,
+        setReorder,
+        onMergeTopic,
+        onSplitTopic,
+      }),
+    [applyRoot, layout.topics, node.id, onMergeTopic, onSplitTopic, root],
   );
 
   useLayoutEffect(() => {
@@ -312,6 +207,7 @@ export const useMindmapController = ({
     if (!pendingId) return;
     if (findTopicPath(root, pendingId)) {
       setSelectedId(pendingId);
+      setEditingInitialInput(undefined);
       setEditingId(pendingId);
       pendingFocusRef.current = null;
     }
@@ -352,8 +248,9 @@ export const useMindmapController = ({
     onSelectNode(node.id);
   }, [node.id, onSelectNode]);
 
-  const enterTopicEdit = useCallback((topicId: string) => {
+  const enterTopicEdit = useCallback((topicId: string, initialInput?: string) => {
     setSelectedId(topicId);
+    setEditingInitialInput(initialInput);
     setEditingId(topicId);
     onSelectNode(node.id);
   }, [node.id, onSelectNode]);
@@ -386,6 +283,7 @@ export const useMindmapController = ({
         moveSelection(topicId, action.dir);
         break;
       case 'exit':
+        setEditingInitialInput(undefined);
         setEditingId(null);
         break;
     }
@@ -403,6 +301,7 @@ export const useMindmapController = ({
     addChild,
     beginReorder,
     editingId,
+    editingInitialInput,
     enterTopicEdit,
     getDropHint,
     handleTopicKeyAction,

--- a/apps/canvas-workspace/src/renderer/src/hooks/useMindmapTransfers.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useMindmapTransfers.ts
@@ -1,0 +1,61 @@
+import { useCallback, type MutableRefObject } from 'react';
+import type { CanvasEdge, CanvasNode } from '../types';
+import { degradeEndpointsForDeletedNode } from '../utils/edgeFactory';
+import {
+  mergeMindmapTopic as mergeMindmapTopicState,
+  splitMindmapTopic as splitMindmapTopicState,
+  type MergeMindmapTopicRequest,
+  type SplitMindmapTopicRequest,
+} from '../utils/mindmapTransfer';
+import { resizeGroupsToChildren } from '../utils/resizeGroupsToChildren';
+import type { CanvasSnapshot } from './useNodeHistory';
+
+interface UseMindmapTransfersOptions {
+  nodesRef: MutableRefObject<CanvasNode[]>;
+  edgesRef: MutableRefObject<CanvasEdge[]>;
+  applyState: (patch: Partial<CanvasSnapshot>, addToHistory?: boolean) => void;
+}
+
+export const useMindmapTransfers = ({
+  nodesRef,
+  edgesRef,
+  applyState,
+}: UseMindmapTransfersOptions) => {
+  const mergeMindmapTopic = useCallback(
+    (request: MergeMindmapTopicRequest): boolean => {
+      const result = mergeMindmapTopicState(nodesRef.current, request);
+      if (!result) return false;
+
+      let nextEdges = edgesRef.current;
+      if (result.removedNodeId) {
+        const victim = nodesRef.current.find(
+          (node) => node.id === result.removedNodeId,
+        );
+        if (victim) {
+          nextEdges = degradeEndpointsForDeletedNode(nextEdges, victim);
+        }
+      }
+      applyState({
+        nodes: resizeGroupsToChildren(result.nodes),
+        edges: nextEdges,
+      });
+      return true;
+    },
+    [applyState, edgesRef, nodesRef],
+  );
+
+  const splitMindmapTopic = useCallback(
+    (request: SplitMindmapTopicRequest): CanvasNode | null => {
+      const result = splitMindmapTopicState(nodesRef.current, request);
+      if (!result) return null;
+      const previousIds = new Set(nodesRef.current.map((node) => node.id));
+      const created = result.nodes.find((node) => !previousIds.has(node.id));
+      if (!created) return null;
+      applyState({ nodes: resizeGroupsToChildren(result.nodes) });
+      return created;
+    },
+    [applyState, nodesRef],
+  );
+
+  return { mergeMindmapTopic, splitMindmapTopic };
+};

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodes.mindmap.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodes.mindmap.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment happy-dom
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  CanvasEdge,
+  CanvasNode,
+  MindmapNodeData,
+  MindmapTopic,
+} from '../types';
+import { useNodes } from './useNodes';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const topic = (
+  id: string,
+  text: string,
+  children: MindmapTopic[] = [],
+): MindmapTopic => ({ id, text, children });
+
+const mindmap = (id: string, root: MindmapTopic, x: number): CanvasNode => ({
+  id,
+  type: 'mindmap',
+  title: root.text,
+  x,
+  y: 20,
+  width: 320,
+  height: 180,
+  data: { root, layout: 'right', rev: 0 } satisfies MindmapNodeData,
+  updatedAt: 1,
+});
+
+const source = mindmap(
+  'source',
+  topic('source-root', 'Source', [topic('branch', 'Branch')]),
+  10,
+);
+const target = mindmap('target', topic('target-root', 'Target'), 500);
+const edge: CanvasEdge = {
+  id: 'edge-1',
+  source: { kind: 'node', nodeId: 'source', anchor: 'right' },
+  target: { kind: 'node', nodeId: 'target', anchor: 'left' },
+};
+
+describe('useNodes mindmap transactions', () => {
+  let root: Root;
+  let host: HTMLElement;
+  let hook: ReturnType<typeof useNodes>;
+  let originalCanvasWorkspace: typeof window.canvasWorkspace;
+
+  const Probe = () => {
+    hook = useNodes('canvas-mindmaps');
+    return null;
+  };
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    originalCanvasWorkspace = window.canvasWorkspace;
+    Object.defineProperty(window, 'canvasWorkspace', {
+      configurable: true,
+      value: {
+        store: {
+          load: vi.fn().mockResolvedValue({
+            ok: true,
+            data: { nodes: [source, target], edges: [edge] },
+          }),
+          save: vi.fn().mockResolvedValue({ ok: true }),
+        },
+      },
+    });
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    await act(async () => {
+      root.render(<Probe />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(hook.loaded).toBe(true);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    Object.defineProperty(window, 'canvasWorkspace', {
+      configurable: true,
+      value: originalCanvasWorkspace,
+    });
+  });
+
+  it('merges a whole map and restores both maps and their edge in one undo', () => {
+    let nextId = 0;
+    act(() => {
+      expect(hook.mergeMindmapTopic({
+        sourceNodeId: 'source',
+        sourceTopicId: 'source-root',
+        targetNodeId: 'target',
+        target: { kind: 'child', parentId: 'target-root' },
+        createTopicId: () => `merged-${++nextId}`,
+      })).toBe(true);
+    });
+
+    expect(hook.nodes.map((node) => node.id)).toEqual(['target']);
+    expect(hook.edges[0].source.kind).toBe('point');
+
+    act(() => {
+      expect(hook.undo()).toBe(true);
+    });
+    expect(hook.nodes.map((node) => node.id)).toEqual(['source', 'target']);
+    expect(hook.edges).toEqual([edge]);
+  });
+
+  it('splits a branch and restores it in one undo', () => {
+    act(() => {
+      expect(hook.splitMindmapTopic({
+        sourceNodeId: 'source',
+        sourceTopicId: 'branch',
+        x: 640,
+        y: 360,
+        createNodeId: () => 'detached',
+      })?.id).toBe('detached');
+    });
+
+    expect(hook.nodes.map((node) => node.id)).toEqual([
+      'source',
+      'target',
+      'detached',
+    ]);
+    expect(
+      (hook.nodes[0].data as MindmapNodeData).root.children,
+    ).toEqual([]);
+
+    act(() => {
+      expect(hook.undo()).toBe(true);
+    });
+    expect(hook.nodes.map((node) => node.id)).toEqual(['source', 'target']);
+    expect(
+      (hook.nodes[0].data as MindmapNodeData).root.children[0].id,
+    ).toBe('branch');
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
@@ -18,6 +18,7 @@ import { count } from '../perf/counters';
 import { degradeEndpointsForDeletedNode } from '../utils/edgeFactory';
 import { useNodeHistory } from './useNodeHistory';
 import { mergeExternalEdgeUpdate } from './external-edge-sync';
+import { useMindmapTransfers } from './useMindmapTransfers';
 
 const SAVE_DEBOUNCE_MS = 800;
 const DEFAULT_CANVAS_ID = 'default';
@@ -144,6 +145,9 @@ export const useNodes = (
     historyRef, historyIndexRef,
     applyNodes, applyEdges, applyState, commitHistory, undo, redo,
   } = useNodeHistory(scheduleSave);
+  const { mergeMindmapTopic, splitMindmapTopic } = useMindmapTransfers({
+    nodesRef, edgesRef, applyState,
+  });
 
   const setTransformForSave = useCallback(
     (t: CanvasTransform) => {
@@ -878,6 +882,8 @@ export const useNodes = (
     updateNode,
     removeNode,
     removeNodes,
+    mergeMindmapTopic,
+    splitMindmapTopic,
     syncDeletedNodes,
     moveNode,
     moveNodes,

--- a/apps/canvas-workspace/src/renderer/src/utils/mindmapTransfer.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/mindmapTransfer.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+import type { CanvasNode, MindmapNodeData, MindmapTopic } from '../types';
+import {
+  getSelectionAfterMindmapMerge,
+  mergeMindmapTopic,
+  splitMindmapTopic,
+} from './mindmapTransfer';
+
+const topic = (
+  id: string,
+  text: string,
+  children: MindmapTopic[] = [],
+): MindmapTopic => ({ id, text, children });
+
+const mindmap = (
+  id: string,
+  root: MindmapTopic,
+  x = 0,
+  y = 0,
+): CanvasNode => ({
+  id,
+  type: 'mindmap',
+  title: root.text,
+  x,
+  y,
+  width: 320,
+  height: 180,
+  data: { root, layout: 'right', rev: 0 } satisfies MindmapNodeData,
+  updatedAt: 1,
+});
+
+const rootOf = (node: CanvasNode): MindmapTopic =>
+  (node.data as MindmapNodeData).root;
+
+describe('mindmap transfers', () => {
+  it('moves a branch into another mindmap and rekeys the full subtree', () => {
+    const source = mindmap('source', topic('source-root', 'Source', [
+      {
+        id: 'collision',
+        text: 'Moved branch',
+        color: '#ef4444',
+        collapsed: true,
+        children: [topic('nested', 'Nested')],
+      },
+      topic('stays', 'Stays'),
+    ]));
+    const target = mindmap('target', topic('target-root', 'Target', [
+      topic('collision', 'Existing'),
+    ]));
+    let nextId = 0;
+
+    const result = mergeMindmapTopic([source, target], {
+      sourceNodeId: 'source',
+      sourceTopicId: 'collision',
+      targetNodeId: 'target',
+      target: { kind: 'child', parentId: 'target-root' },
+      createTopicId: () => `moved-${++nextId}`,
+    });
+
+    expect(result).not.toBeNull();
+    expect(rootOf(result!.nodes[0]).children.map((child) => child.id))
+      .toEqual(['stays']);
+    expect(rootOf(result!.nodes[1]).children).toEqual([
+      topic('collision', 'Existing'),
+      {
+        id: 'moved-1',
+        text: 'Moved branch',
+        color: '#ef4444',
+        collapsed: true,
+        children: [topic('moved-2', 'Nested')],
+      },
+    ]);
+    expect(result!.insertedTopicId).toBe('moved-1');
+    expect(result!.removedNodeId).toBeUndefined();
+  });
+
+  it('merges a whole mindmap by attaching its root and removing its canvas node', () => {
+    const source = mindmap('source', topic('source-root', 'Source', [
+      topic('source-child', 'Child'),
+    ]));
+    const target = mindmap('target', topic('target-root', 'Target'));
+    let nextId = 0;
+
+    const result = mergeMindmapTopic([source, target], {
+      sourceNodeId: 'source',
+      sourceTopicId: 'source-root',
+      targetNodeId: 'target',
+      target: { kind: 'child', parentId: 'target-root' },
+      createTopicId: () => `merged-${++nextId}`,
+    });
+
+    expect(result?.nodes.map((node) => node.id)).toEqual(['target']);
+    expect(rootOf(result!.nodes[0]).children).toEqual([
+      topic('merged-1', 'Source', [topic('merged-2', 'Child')]),
+    ]);
+    expect(result?.removedNodeId).toBe('source');
+  });
+
+  it('detaches a non-root branch into a new mindmap at the drop position', () => {
+    const source = mindmap('source', topic('source-root', 'Source', [
+      topic('branch', 'Branch', [topic('leaf', 'Leaf')]),
+    ]));
+
+    const result = splitMindmapTopic([source], {
+      sourceNodeId: 'source',
+      sourceTopicId: 'branch',
+      x: 640,
+      y: 360,
+      createNodeId: () => 'new-map',
+    });
+
+    expect(result).not.toBeNull();
+    expect(rootOf(result!.nodes[0]).children).toEqual([]);
+    expect(result!.nodes[1]).toMatchObject({
+      id: 'new-map',
+      type: 'mindmap',
+      title: 'Branch',
+      x: 640,
+      y: 360,
+    });
+    expect(rootOf(result!.nodes[1])).toEqual(
+      topic('branch', 'Branch', [topic('leaf', 'Leaf')]),
+    );
+  });
+
+  it('does not split the root away from its existing canvas node', () => {
+    const source = mindmap('source', topic('source-root', 'Source'));
+
+    expect(splitMindmapTopic([source], {
+      sourceNodeId: 'source',
+      sourceTopicId: 'source-root',
+      x: 100,
+      y: 100,
+      createNodeId: () => 'new-map',
+    })).toBeNull();
+  });
+
+  it('selects the target only when a whole source map is removed', () => {
+    const source = mindmap('source', topic('source-root', 'Source', [
+      topic('branch', 'Branch'),
+    ]));
+    const target = mindmap('target', topic('target-root', 'Target'));
+    const base = {
+      sourceNodeId: 'source',
+      targetNodeId: 'target',
+      target: { kind: 'child', parentId: 'target-root' } as const,
+    };
+
+    expect(getSelectionAfterMindmapMerge([source, target], {
+      ...base,
+      sourceTopicId: 'source-root',
+    })).toEqual(['target']);
+    expect(getSelectionAfterMindmapMerge([source, target], {
+      ...base,
+      sourceTopicId: 'branch',
+    })).toBeNull();
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/utils/mindmapTransfer.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/mindmapTransfer.ts
@@ -1,0 +1,191 @@
+import type { CanvasNode, MindmapNodeData, MindmapTopic } from '../types';
+import { createDefaultNode, genTopicId } from './nodeFactory';
+import {
+  deleteTopic,
+  findParent,
+  findTopicPath,
+  insertChild,
+  type DropTarget,
+} from './mindmapLayout';
+
+export interface MergeMindmapTopicRequest {
+  sourceNodeId: string;
+  sourceTopicId: string;
+  targetNodeId: string;
+  target: DropTarget;
+  createTopicId?: () => string;
+}
+
+export interface SplitMindmapTopicRequest {
+  sourceNodeId: string;
+  sourceTopicId: string;
+  x: number;
+  y: number;
+  createNodeId?: () => string;
+}
+
+export interface MindmapTransferHandlers {
+  onMergeMindmapTopic?: (request: MergeMindmapTopicRequest) => boolean;
+  onSplitMindmapTopic?: (sourceNodeId: string, sourceTopicId: string, clientX: number, clientY: number) => boolean;
+}
+
+export interface MindmapTransferResult {
+  nodes: CanvasNode[];
+  insertedTopicId: string;
+  removedNodeId?: string;
+}
+
+const asMindmapData = (node: CanvasNode): MindmapNodeData | null =>
+  node.type === 'mindmap' ? node.data as MindmapNodeData : null;
+
+export const getSelectionAfterMindmapMerge = (
+  nodes: CanvasNode[],
+  request: MergeMindmapTopicRequest,
+): string[] | null => {
+  const source = nodes.find((node) => node.id === request.sourceNodeId);
+  const sourceData = source ? asMindmapData(source) : null;
+  return sourceData?.root.id === request.sourceTopicId
+    ? [request.targetNodeId]
+    : null;
+};
+
+const cloneTopicWithIds = (
+  topic: MindmapTopic,
+  createTopicId: () => string,
+): MindmapTopic => ({
+  id: createTopicId(),
+  text: topic.text,
+  color: topic.color,
+  collapsed: topic.collapsed,
+  children: topic.children.map((child) => cloneTopicWithIds(child, createTopicId)),
+});
+
+const insertAtTarget = (
+  root: MindmapTopic,
+  child: MindmapTopic,
+  target: DropTarget,
+): MindmapTopic | null => {
+  if (target.kind === 'child') {
+    if (!findTopicPath(root, target.parentId)) return null;
+    return insertChild(root, target.parentId, child);
+  }
+
+  const anchorParent = findParent(root, target.anchorId);
+  if (!anchorParent) return null;
+  const anchorIndex = anchorParent.children.findIndex(
+    (candidate) => candidate.id === target.anchorId,
+  );
+  if (anchorIndex < 0) return null;
+  const insertIndex = target.kind === 'before' ? anchorIndex : anchorIndex + 1;
+
+  const walk = (topic: MindmapTopic): MindmapTopic => {
+    if (topic.id === anchorParent.id) {
+      const children = [...topic.children];
+      children.splice(insertIndex, 0, child);
+      return { ...topic, children, collapsed: false };
+    }
+    return { ...topic, children: topic.children.map(walk) };
+  };
+  return walk(root);
+};
+
+const withRoot = (
+  node: CanvasNode,
+  data: MindmapNodeData,
+  root: MindmapTopic,
+): CanvasNode => ({
+  ...node,
+  data: {
+    ...data,
+    root,
+    rev: (data.rev ?? 0) + 1,
+  },
+  updatedAt: Date.now(),
+});
+
+export const mergeMindmapTopic = (
+  nodes: CanvasNode[],
+  request: MergeMindmapTopicRequest,
+): MindmapTransferResult | null => {
+  if (request.sourceNodeId === request.targetNodeId) return null;
+  const sourceNode = nodes.find((node) => node.id === request.sourceNodeId);
+  const targetNode = nodes.find((node) => node.id === request.targetNodeId);
+  if (!sourceNode || !targetNode) return null;
+  const sourceData = asMindmapData(sourceNode);
+  const targetData = asMindmapData(targetNode);
+  if (!sourceData || !targetData) return null;
+
+  const sourcePath = findTopicPath(sourceData.root, request.sourceTopicId);
+  if (!sourcePath) return null;
+  const sourceTopic = sourcePath[sourcePath.length - 1];
+  const insertedTopic = cloneTopicWithIds(
+    sourceTopic,
+    request.createTopicId ?? genTopicId,
+  );
+  const targetRoot = insertAtTarget(targetData.root, insertedTopic, request.target);
+  if (!targetRoot) return null;
+
+  const movingWholeMindmap = request.sourceTopicId === sourceData.root.id;
+  let sourceRoot: MindmapTopic | null = null;
+  if (!movingWholeMindmap) {
+    const removed = deleteTopic(sourceData.root, request.sourceTopicId);
+    if (!removed) return null;
+    sourceRoot = removed.root;
+  }
+
+  const nextNodes: CanvasNode[] = [];
+  for (const node of nodes) {
+    if (node.id === request.sourceNodeId) {
+      if (sourceRoot) nextNodes.push(withRoot(node, sourceData, sourceRoot));
+      continue;
+    }
+    if (node.id === request.targetNodeId) {
+      nextNodes.push(withRoot(node, targetData, targetRoot));
+      continue;
+    }
+    nextNodes.push(node);
+  }
+
+  return {
+    nodes: nextNodes,
+    insertedTopicId: insertedTopic.id,
+    removedNodeId: movingWholeMindmap ? sourceNode.id : undefined,
+  };
+};
+
+export const splitMindmapTopic = (
+  nodes: CanvasNode[],
+  request: SplitMindmapTopicRequest,
+): MindmapTransferResult | null => {
+  const sourceNode = nodes.find((node) => node.id === request.sourceNodeId);
+  if (!sourceNode) return null;
+  const sourceData = asMindmapData(sourceNode);
+  if (!sourceData || request.sourceTopicId === sourceData.root.id) return null;
+
+  const sourcePath = findTopicPath(sourceData.root, request.sourceTopicId);
+  const sourceTopic = sourcePath?.[sourcePath.length - 1];
+  if (!sourceTopic) return null;
+  const removed = deleteTopic(sourceData.root, request.sourceTopicId);
+  if (!removed) return null;
+
+  const detachedNode = createDefaultNode('mindmap', request.x, request.y);
+  detachedNode.id = request.createNodeId?.() ?? detachedNode.id;
+  detachedNode.title = sourceTopic.text || 'Mindmap';
+  detachedNode.data = {
+    root: sourceTopic,
+    layout: sourceData.layout,
+    rev: 0,
+  } satisfies MindmapNodeData;
+
+  return {
+    nodes: [
+      ...nodes.map((node) =>
+        node.id === sourceNode.id
+          ? withRoot(node, sourceData, removed.root)
+          : node
+      ),
+      detachedNode,
+    ],
+    insertedTopicId: sourceTopic.id,
+  };
+};


### PR DESCRIPTION
## Summary

- preserve the first printable character when editing a selected mindmap topic and commit edits on Escape
- support dragging a branch or whole mindmap into another mindmap, plus detaching a branch into a new mindmap
- keep cross-map mutations, node removal, edge degradation, persistence, and undo atomic
- constrain drop targets to editable mindmaps in the same canvas surface and reconcile selection after whole-map merges

## Validation

- `pnpm --filter canvas-workspace typecheck`
- `pnpm --filter canvas-workspace test` (245 files, 1596 tests)
- `node scripts/harness/run-harness-check.mjs --since 382dde68341922e0907f4757344cb206ff98382d`
- real Electron harness: first-character editing, Escape commit, whole-map merge, and Cmd+Z restore