### PR TITLE
fix(canvas): close selection and chat interaction gaps

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.selection.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.selection.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment happy-dom
+import { act, createElement, type ComponentProps } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { I18nProvider } from '../../i18n';
+import { RightDockProvider } from '../RightDock';
+import { CanvasOverlays } from './CanvasOverlays';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+type CanvasOverlaysProps = ComponentProps<typeof CanvasOverlays>;
+
+const selectedNode = {
+  id: 'node-1',
+  type: 'text',
+  title: 'Selected note',
+  x: 0,
+  y: 0,
+  width: 240,
+  height: 120,
+  data: { content: 'hello' },
+  updatedAt: 1,
+} as CanvasOverlaysProps['nodes'][number];
+
+const baseProps = (): CanvasOverlaysProps => ({
+  nodes: [selectedNode],
+  contextMenu: null,
+  searchOpen: false,
+  activeTool: 'select',
+  scale: 1,
+  onCreateNode: vi.fn(),
+  onCloseContextMenu: vi.fn(),
+  onOpenShortcuts: vi.fn(),
+  onToolChange: vi.fn(),
+  onAddNode: vi.fn(),
+  onResetTransform: vi.fn(),
+  paletteCommands: [],
+  onSearchSelect: vi.fn(),
+  onCloseSearch: vi.fn(),
+  selectedNodeIds: [],
+  findSearch: { open: false } as CanvasOverlaysProps['findSearch'],
+  findNodesById: new Map(),
+  onFindMatchActivate: vi.fn(),
+  transform: { x: 0, y: 0, scale: 1 },
+});
+
+const clickButton = (host: HTMLElement, label: string) => {
+  const button = host.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`);
+  expect(button).not.toBeNull();
+  act(() => button?.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+};
+
+describe('CanvasOverlays selection actions', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    localStorage.clear();
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+  });
+
+  const render = (overrides: Partial<CanvasOverlaysProps> = {}) => {
+    const props = { ...baseProps(), ...overrides };
+    act(() => {
+      root.render(
+        createElement(
+          I18nProvider,
+          null,
+          createElement(
+            RightDockProvider,
+            null,
+            createElement(CanvasOverlays, props),
+          ),
+        ),
+      );
+    });
+  };
+
+  it('shows selection actions and forwards single-selection commands', () => {
+    const onFitSelection = vi.fn();
+    const onDuplicateSelection = vi.fn();
+    const onToggleFocusMode = vi.fn();
+    const onWrapSelectionInFrame = vi.fn();
+    const onPinReferenceSelection = vi.fn();
+    const onAddSelectionToChat = vi.fn();
+    const onDeleteSelection = vi.fn();
+
+    render({
+      selectedNodeIds: ['node-1'],
+      focusModeAvailable: true,
+      onFitSelection,
+      onDuplicateSelection,
+      onToggleFocusMode,
+      onWrapSelectionInFrame,
+      onPinReferenceSelection,
+      onAddSelectionToChat,
+      onDeleteSelection,
+    });
+
+    expect(host.querySelector('[role="toolbar"][aria-label="Selection actions"]')).not.toBeNull();
+    expect(host.querySelector('.canvas-bottom-chrome--selection')).not.toBeNull();
+
+    clickButton(host, 'Fit the selection in view');
+    clickButton(host, 'Duplicate selection');
+    clickButton(host, 'Focus selection');
+    clickButton(host, 'Wrap in frame');
+    clickButton(host, 'Pin selection as reference');
+    clickButton(host, 'Add selection to chat');
+    clickButton(host, 'Delete selection');
+
+    expect(onFitSelection).toHaveBeenCalledOnce();
+    expect(onDuplicateSelection).toHaveBeenCalledOnce();
+    expect(onToggleFocusMode).toHaveBeenCalledOnce();
+    expect(onWrapSelectionInFrame).toHaveBeenCalledOnce();
+    expect(onPinReferenceSelection).toHaveBeenCalledOnce();
+    expect(onAddSelectionToChat).toHaveBeenCalledOnce();
+    expect(onDeleteSelection).toHaveBeenCalledOnce();
+  });
+
+  it('keeps group available for a multi-selection', () => {
+    const onGroupSelection = vi.fn();
+
+    render({
+      selectedNodeIds: ['node-1', 'node-2'],
+      onGroupSelection,
+    });
+
+    expect(host.querySelector('[role="toolbar"][aria-label="Selection actions"]')).not.toBeNull();
+    clickButton(host, 'Group selection');
+    expect(onGroupSelection).toHaveBeenCalledOnce();
+  });
+
+  it('hides selection actions when the selection is empty', () => {
+    render({ selectedNodeIds: [] });
+
+    expect(host.querySelector('[role="toolbar"][aria-label="Selection actions"]')).toBeNull();
+    expect(host.querySelector('.canvas-bottom-chrome--selection')).toBeNull();
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.test.ts
@@ -33,6 +33,17 @@ describe('CanvasOverlays movement gating', () => {
   });
 });
 
+describe('CanvasOverlays selection layout', () => {
+  it('places selection actions above the existing bottom chrome controls', () => {
+    expect(canvasCss).toMatch(
+      /\.canvas-bottom-chrome--selection \.selection-toolbar\s*\{[^}]*grid-column:\s*1\s*\/\s*-1;[^}]*grid-row:\s*1;/s,
+    );
+    expect(canvasCss).toMatch(
+      /\.canvas-bottom-chrome\.canvas-bottom-chrome--selection \.floating-toolbar,[^{]+canvas-bottom-chrome__right\s*\{[^}]*grid-row:\s*2;/s,
+    );
+  });
+});
+
 describe('CanvasOverlays edge drag projection', () => {
   const edge: CanvasEdge = {
     id: 'edge-1',

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
@@ -9,10 +9,13 @@ import type { UseCanvasSearchReturn } from '../../hooks/useCanvasSearch';
 import { CanvasEmptyHint } from '../CanvasEmptyHint';
 import { EdgeLabel } from '../EdgeLabel';
 import { ChatFloatingButton } from '../ChatFloatingButton';
+import { SelectionToolbar } from '../SelectionToolbar';
 import { useI18n } from '../../i18n';
 import type { CreatableCanvasNodeType } from '../../utils/nodeFactory';
 import type { AddNodeOptions } from '../../hooks/useNodes';
 import { applyEdgeInteractionPreview } from '../CanvasEdgesLayer';
+
+const noop = () => undefined;
 
 const CommandPalette = lazy(() =>
   import('../CommandPalette').then((module) => ({ default: module.CommandPalette })),
@@ -197,6 +200,7 @@ export const CanvasOverlays = ({
   const { t } = useI18n();
   const renderEdgeLabels = shouldRenderEdgeLabels({ moving, editingEdgeLabelId });
   const renderEdgeStylePanel = shouldRenderEdgeStylePanel(moving);
+  const selectionActive = selectedNodeIds.length > 0;
   const overlayEdges = useMemo(
     () => projectEdgeOverlayGeometry(edges, selectedEdge, edgeInteractionState),
     [edgeInteractionState, edges, selectedEdge],
@@ -295,7 +299,33 @@ export const CanvasOverlays = ({
             />
           ))}
 
-      <div className={`canvas-bottom-chrome${moving ? ' canvas-bottom-chrome--moving' : ''}`}>
+      <div
+        className={[
+          'canvas-bottom-chrome',
+          moving ? 'canvas-bottom-chrome--moving' : '',
+          selectionActive ? 'canvas-bottom-chrome--selection' : '',
+        ].filter(Boolean).join(' ')}
+      >
+        {selectionActive && (
+          <SelectionToolbar
+            selectedCount={selectedNodeIds.length}
+            canFocus={selectedNodeIds.length === 1 && !!focusModeAvailable}
+            focusModeActive={!!focusModeActive}
+            canGroup={selectedNodeIds.length > 1}
+            canPinReference={selectedNodeIds.length === 1 && !!onPinReferenceSelection}
+            canAddToChat={selectedNodeIds.length === 1 && !!onAddSelectionToChat}
+            showPinReference={!!onPinReferenceSelection}
+            showAddToChat={!!onAddSelectionToChat}
+            onFitSelection={onFitSelection ?? noop}
+            onDuplicate={onDuplicateSelection ?? noop}
+            onToggleFocus={onToggleFocusMode ?? noop}
+            onGroup={onGroupSelection ?? noop}
+            onWrapFrame={onWrapSelectionInFrame ?? noop}
+            onPinReference={onPinReferenceSelection ?? noop}
+            onAddToChat={onAddSelectionToChat ?? noop}
+            onDelete={onDeleteSelection ?? noop}
+          />
+        )}
         <FloatingToolbar
           activeTool={activeTool}
           onToolChange={onToolChange}

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasSyncEffects.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasSyncEffects.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from 'vitest';
-import { shouldPersistViewportTransform } from './useCanvasSyncEffects';
+// @vitest-environment happy-dom
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { describe, expect, it, vi } from 'vitest';
+import type { CanvasNode } from '../../../types';
+import { shouldPersistViewportTransform, useCanvasSyncEffects } from './useCanvasSyncEffects';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 describe('shouldPersistViewportTransform', () => {
   it('does not persist before the canvas has loaded', () => {
@@ -12,5 +18,56 @@ describe('shouldPersistViewportTransform', () => {
 
   it('persists the settled viewport once the gesture is idle', () => {
     expect(shouldPersistViewportTransform(true, false)).toBe(true);
+  });
+});
+
+describe('useCanvasSyncEffects', () => {
+  it('routes an external node focus request through the public viewport-focus callback', () => {
+    const node: CanvasNode = {
+      id: 'node-1',
+      type: 'text',
+      title: 'Focused node',
+      x: 10,
+      y: 20,
+      width: 240,
+      height: 120,
+      data: {},
+      updatedAt: 1,
+    };
+    const handleNodeViewportFocus = vi.fn();
+    const onFocusComplete = vi.fn();
+    const host = document.createElement('div');
+    document.body.append(host);
+    const root = createRoot(host);
+    const Harness = () => {
+      useCanvasSyncEffects({
+        canvasId: 'canvas-1',
+        loaded: true,
+        nodes: [node],
+        transform: { x: 0, y: 0, scale: 1 },
+        selectedNodeIds: [],
+        nodesRef: { current: [node] },
+        isDraggingRef: { current: false },
+        pendingParentNodesRef: { current: null },
+        hasAutoFittedRef: { current: true },
+        setTransformForSave: vi.fn(),
+        flushSave: vi.fn(),
+        fitAllNodes: vi.fn(),
+        handleNodeViewportFocus,
+        updateNode: vi.fn(),
+        handleExternalDelete: vi.fn(),
+        focusNodeId: node.id,
+        onFocusComplete,
+      });
+      return null;
+    };
+
+    act(() => root.render(createElement(Harness)));
+
+    expect(handleNodeViewportFocus).toHaveBeenCalledWith(node);
+    expect(onFocusComplete).toHaveBeenCalledTimes(1);
+
+    act(() => root.unmount());
+    host.remove();
   });
 });

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasSyncEffects.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/hooks/useCanvasSyncEffects.ts
@@ -27,9 +27,7 @@ interface Options {
   setTransformForSave: (transform: CanvasTransform) => void;
   flushSave: () => void;
   fitAllNodes: (nodes: CanvasNode[]) => void;
-  setSelectedNodeIds: (ids: string[]) => void;
-  setHighlightedId: (id: string | null) => void;
-  handleFocusNode: (node: CanvasNode) => void;
+  handleNodeViewportFocus: (node: CanvasNode) => void;
   updateNode: (id: string, patch: Partial<CanvasNode>) => void;
   handleExternalDelete: (deleteNodeId: string) => void;
   onNodesChange?: (canvasId: string, nodes: CanvasNode[]) => void;
@@ -69,9 +67,7 @@ export const useCanvasSyncEffects = ({
   setTransformForSave,
   flushSave,
   fitAllNodes,
-  setSelectedNodeIds,
-  setHighlightedId,
-  handleFocusNode,
+  handleNodeViewportFocus,
   updateNode,
   handleExternalDelete,
   onNodesChange,
@@ -133,11 +129,7 @@ export const useCanvasSyncEffects = ({
     if (!loaded) return;
     if (!focusNodeId) return;
     const node = nodesRef.current.find((n) => n.id === focusNodeId);
-    if (node) {
-      setSelectedNodeIds([node.id]);
-      setHighlightedId(node.id);
-      handleFocusNode(node);
-    }
+    if (node) handleNodeViewportFocus(node);
     onFocusComplete?.();
   }, [focusNodeId, loaded]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.css
@@ -91,6 +91,17 @@
   container-type: inline-size;
 }
 
+.canvas-bottom-chrome--selection .selection-toolbar {
+  grid-column: 1 / -1;
+  grid-row: 1;
+}
+
+.canvas-bottom-chrome.canvas-bottom-chrome--selection .floating-toolbar,
+.canvas-bottom-chrome--selection .canvas-bottom-chrome__left,
+.canvas-bottom-chrome--selection .canvas-bottom-chrome__right {
+  grid-row: 2;
+}
+
 .canvas-bottom-chrome__left {
   grid-column: 1;
   grid-row: 1;

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.tsx
@@ -357,12 +357,13 @@ export const Canvas = ({
 
   const handleNodeViewportFocus = useCallback((node: CanvasNode) => {
     setSelectedNodeIds([node.id]);
+    setSelectedEdgeId(null);
     setHighlightedId(node.id);
     // In focus mode the dedicated reframe effect handles the zoom with
     // tighter padding/maxScale — calling handleFocusNode here too would
     // produce a double reframe at different scales (visible jitter).
     if (!focus.focusModeActive) handleFocusNode(node);
-  }, [handleFocusNode, focus.focusModeActive, setSelectedNodeIds, setHighlightedId]);
+  }, [handleFocusNode, focus.focusModeActive, setHighlightedId, setSelectedEdgeId, setSelectedNodeIds]);
 
   const { pasteReferenceNodes } = useCanvasReferenceActions({
     addNode,
@@ -575,7 +576,7 @@ export const Canvas = ({
     findHasMatches: search.matches.length > 0,
     contextMenu: ctxMenu.contextMenu,
     setContextMenu: ctxMenu.setContextMenu,
-    setHighlightedId, handleFocusNode,
+    setHighlightedId, handleFocusNode, activeTool, setActiveTool,
     focusModeEnabled: focus.focusModeActive,
     canToggleFocusMode: focus.focusModeAvailable,
     onToggleFocusMode: focus.toggleFocusMode,
@@ -645,8 +646,7 @@ export const Canvas = ({
     pendingParentNodesRef: mouse.pendingParentNodesRef,
     hasAutoFittedRef,
     setTransformForSave, flushSave, fitAllNodes,
-    setSelectedNodeIds, setHighlightedId,
-    handleFocusNode, updateNode,
+    handleNodeViewportFocus, updateNode,
     handleExternalDelete: actions.handleExternalDelete,
     onNodesChange, onSelectionChange,
     focusNodeId, onFocusComplete,

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/__tests__/useChatInsertionBridge.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/__tests__/useChatInsertionBridge.test.tsx
@@ -2,24 +2,44 @@
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { AgentContextDomSelectionRef } from '../../../types';
+import type { AgentContextDomSelectionRef, CanvasNode } from '../../../types';
 import { useChatInsertionBridge } from '../useChatInsertionBridge';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
-describe('useChatInsertionBridge DOM selections', () => {
+describe('useChatInsertionBridge', () => {
   let container: HTMLDivElement;
   let root: Root;
   const openChat = vi.fn();
   let bridge: ReturnType<typeof useChatInsertionBridge>;
+  const node: CanvasNode = {
+    id: 'node-1',
+    type: 'text',
+    title: 'Release notes',
+    x: 0,
+    y: 0,
+    width: 240,
+    height: 120,
+    data: {
+      content: 'Ship the bridge fix',
+      textColor: '#1f2328',
+      backgroundColor: 'transparent',
+      fontSize: 18,
+      autoSize: true,
+    },
+  };
 
   const Harness = () => {
-    bridge = useChatInsertionBridge({ allNodes: {}, openChat });
+    bridge = useChatInsertionBridge({
+      allNodes: { 'workspace-1': [node] },
+      openChat,
+    });
     return null;
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers({ toFake: ['requestAnimationFrame', 'cancelAnimationFrame'] });
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -29,6 +49,41 @@ describe('useChatInsertionBridge DOM selections', () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    vi.useRealTimers();
+  });
+
+  it('holds a node mention until a composer registers after the opening frame', () => {
+    const insert = vi.fn();
+
+    act(() => bridge.handleAddNodeToChat('workspace-1', node.id));
+    expect(openChat).toHaveBeenCalledOnce();
+
+    act(() => vi.advanceTimersByTime(20));
+    expect(insert).not.toHaveBeenCalled();
+
+    act(() => bridge.registerInsertMention('workspace-1', insert));
+    expect(insert).toHaveBeenCalledOnce();
+    expect(insert).toHaveBeenCalledWith(node);
+
+    act(() => vi.advanceTimersByTime(100));
+    expect(insert).toHaveBeenCalledOnce();
+  });
+
+  it('holds a cross-workspace preview mention until the active composer registers', () => {
+    const insert = vi.fn();
+
+    act(() => bridge.handleAddPreviewNodeToChat('workspace-1', 'workspace-2', node));
+    expect(openChat).toHaveBeenCalledOnce();
+
+    act(() => vi.advanceTimersByTime(20));
+    expect(insert).not.toHaveBeenCalled();
+
+    act(() => bridge.registerInsertMention('workspace-1', insert));
+    expect(insert).toHaveBeenCalledOnce();
+    expect(insert).toHaveBeenCalledWith(node, 'workspace-2');
+
+    act(() => vi.advanceTimersByTime(100));
+    expect(insert).toHaveBeenCalledOnce();
   });
 
   it('holds a selection until the workspace composer registers', () => {

--- a/apps/canvas-workspace/src/renderer/src/components/Workbench/useChatInsertionBridge.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Workbench/useChatInsertionBridge.ts
@@ -6,20 +6,45 @@ interface UseChatInsertionBridgeOptions {
   openChat: () => void;
 }
 
+interface PendingNodeMention {
+  node: CanvasNode;
+  sourceWorkspaceId?: string;
+}
+
 export function useChatInsertionBridge({
   allNodes,
   openChat,
 }: UseChatInsertionBridgeOptions) {
   const insertMentionByWorkspaceRef = useRef<Map<string, (node: CanvasNode, sourceWorkspaceId?: string) => void>>(new Map());
+  const pendingNodeMentionsByWorkspaceRef = useRef<Map<string, PendingNodeMention[]>>(new Map());
   const insertDomSelectionByWorkspaceRef = useRef<Map<string, (selection: AgentContextDomSelectionRef) => void>>(new Map());
   const pendingDomSelectionsByWorkspaceRef = useRef<Map<string, AgentContextDomSelectionRef[]>>(new Map());
   const submitDomReviewByWorkspaceRef = useRef<Map<string, (comments: AgentContextDomReviewComment[]) => Promise<boolean>>>(new Map());
 
   const registerInsertMention = useCallback((workspaceId: string, fn: (node: CanvasNode, sourceWorkspaceId?: string) => void) => {
     insertMentionByWorkspaceRef.current.set(workspaceId, fn);
+    const pending = pendingNodeMentionsByWorkspaceRef.current.get(workspaceId) ?? [];
+    pendingNodeMentionsByWorkspaceRef.current.delete(workspaceId);
+    for (const mention of pending) {
+      if (mention.sourceWorkspaceId !== undefined) fn(mention.node, mention.sourceWorkspaceId);
+      else fn(mention.node);
+    }
     return () => {
       insertMentionByWorkspaceRef.current.delete(workspaceId);
     };
+  }, []);
+
+  const insertOrQueueMention = useCallback((workspaceId: string, mention: PendingNodeMention) => {
+    const fn = insertMentionByWorkspaceRef.current.get(workspaceId);
+    if (fn) {
+      if (mention.sourceWorkspaceId !== undefined) fn(mention.node, mention.sourceWorkspaceId);
+      else fn(mention.node);
+      return;
+    }
+    pendingNodeMentionsByWorkspaceRef.current.set(workspaceId, [
+      ...(pendingNodeMentionsByWorkspaceRef.current.get(workspaceId) ?? []),
+      mention,
+    ]);
   }, []);
 
   const registerInsertDomSelectionMention = useCallback((workspaceId: string, fn: (selection: AgentContextDomSelectionRef) => void) => {
@@ -43,35 +68,15 @@ export function useChatInsertionBridge({
     const node = (allNodes[workspaceId] ?? []).find((item) => item.id === nodeId);
     if (!node) return;
     openChat();
-    const tryInsert = () => {
-      const fn = insertMentionByWorkspaceRef.current.get(workspaceId);
-      if (fn) {
-        fn(node);
-        return true;
-      }
-      return false;
-    };
-    if (!tryInsert()) {
-      requestAnimationFrame(() => { tryInsert(); });
-    }
-  }, [allNodes, openChat]);
+    insertOrQueueMention(workspaceId, { node });
+  }, [allNodes, insertOrQueueMention, openChat]);
 
   /** Insert a node from ANOTHER workspace (dock canvas preview) into the
    *  given (active) workspace's composer as a cross-workspace mention. */
   const handleAddPreviewNodeToChat = useCallback((activeWorkspaceId: string, sourceWorkspaceId: string, node: CanvasNode) => {
     openChat();
-    const tryInsert = () => {
-      const fn = insertMentionByWorkspaceRef.current.get(activeWorkspaceId);
-      if (fn) {
-        fn(node, sourceWorkspaceId);
-        return true;
-      }
-      return false;
-    };
-    if (!tryInsert()) {
-      requestAnimationFrame(() => { tryInsert(); });
-    }
-  }, [openChat]);
+    insertOrQueueMention(activeWorkspaceId, { node, sourceWorkspaceId });
+  }, [insertOrQueueMention, openChat]);
 
   const handleAddDomSelectionToChat = useCallback((workspaceId: string, selection: AgentContextDomSelectionRef) => {
     openChat();

--- a/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.test.ts
@@ -1,5 +1,21 @@
-import { describe, expect, it } from 'vitest';
-import { shouldHandleCanvasFindShortcut } from './useCanvasKeyboard';
+// @vitest-environment happy-dom
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { CanvasNode } from '../types';
+import { shouldHandleCanvasFindShortcut, useCanvasKeyboard } from './useCanvasKeyboard';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let host: HTMLDivElement | null = null;
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  host?.remove();
+  root = null;
+  host = null;
+});
 
 const modF = (overrides: Partial<Parameters<typeof shouldHandleCanvasFindShortcut>[0]> = {}) => ({
   ctrlKey: false,
@@ -35,5 +51,132 @@ describe('shouldHandleCanvasFindShortcut', () => {
       .toBe(false);
     expect(shouldHandleCanvasFindShortcut(modF({ key: 'k' }), elementOutsideNote())).toBe(false);
     expect(shouldHandleCanvasFindShortcut(modF({ shiftKey: true }), elementOutsideNote())).toBe(false);
+  });
+});
+
+describe('useCanvasKeyboard', () => {
+  const node = (id: string): CanvasNode => ({
+    id,
+    type: 'text',
+    title: id,
+    x: 0,
+    y: 0,
+    width: 240,
+    height: 120,
+    data: {},
+  });
+
+  const mountKeyboard = (
+    overrides: Partial<Parameters<typeof useCanvasKeyboard>[0]> = {},
+  ) => {
+    const options: Parameters<typeof useCanvasKeyboard>[0] = {
+      canvasId: 'canvas-1',
+      undo: vi.fn(),
+      redo: vi.fn(),
+      nodes: [],
+      selectedNodeIds: [],
+      setSelectedNodeIds: vi.fn(),
+      selectedEdgeId: null,
+      setSelectedEdgeId: vi.fn(),
+      removeEdge: vi.fn(),
+      duplicateNode: vi.fn(),
+      clipboard: null,
+      setClipboard: vi.fn(),
+      pasteNodes: vi.fn(() => []),
+      groupSelectedNodes: vi.fn(),
+      ungroupSelectedNodes: vi.fn(),
+      removeNodes: vi.fn(),
+      moveNodes: vi.fn(),
+      commitHistory: vi.fn(),
+      searchOpen: false,
+      setSearchOpen: vi.fn(),
+      findOpen: false,
+      toggleFindBar: vi.fn(),
+      closeFindBar: vi.fn(),
+      findNext: vi.fn(),
+      findPrev: vi.fn(),
+      findHasMatches: false,
+      contextMenu: null,
+      setContextMenu: vi.fn(),
+      setHighlightedId: vi.fn(),
+      handleFocusNode: vi.fn(),
+      activeTool: 'select',
+      setActiveTool: vi.fn(),
+      ...overrides,
+    };
+    const Harness = () => {
+      useCanvasKeyboard(options);
+      return null;
+    };
+
+    host = document.createElement('div');
+    document.body.append(host);
+    root = createRoot(host);
+    act(() => root?.render(createElement(Harness)));
+  };
+
+  it.each(['connect', 'shape-rect'])(
+    'returns an idle %s tool to select when Escape is pressed',
+    (activeTool) => {
+      const setActiveTool = vi.fn();
+      mountKeyboard({ activeTool, setActiveTool });
+
+      act(() => {
+        window.dispatchEvent(new KeyboardEvent('keydown', {
+          key: 'Escape',
+          bubbles: true,
+          cancelable: true,
+        }));
+      });
+
+      expect(setActiveTool).toHaveBeenCalledWith('select');
+    },
+  );
+
+  it('clears an edge selection when Cmd/Ctrl+A selects every node', () => {
+    const setSelectedNodeIds = vi.fn();
+    const setSelectedEdgeId = vi.fn();
+    mountKeyboard({
+      nodes: [node('node-1'), node('node-2')],
+      selectedEdgeId: 'edge-1',
+      setSelectedNodeIds,
+      setSelectedEdgeId,
+    });
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'a',
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+      }));
+    });
+
+    expect(setSelectedNodeIds).toHaveBeenCalledWith(['node-1', 'node-2']);
+    expect(setSelectedEdgeId).toHaveBeenCalledWith(null);
+  });
+
+  it('clears an edge selection when Cmd/Ctrl+Tab focuses another node', () => {
+    const setSelectedNodeIds = vi.fn();
+    const setSelectedEdgeId = vi.fn();
+    mountKeyboard({
+      nodes: [node('node-1'), node('node-2')],
+      selectedNodeIds: ['node-1'],
+      selectedEdgeId: 'edge-1',
+      setSelectedNodeIds,
+      setSelectedEdgeId,
+    });
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Tab',
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+      }));
+    });
+
+    expect(setSelectedNodeIds).toHaveBeenCalledWith(['node-2']);
+    expect(setSelectedEdgeId).toHaveBeenCalledWith(null);
   });
 });

--- a/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.ts
@@ -82,6 +82,8 @@ interface Options {
   setContextMenu: (menu: null) => void;
   setHighlightedId: (id: string | null) => void;
   handleFocusNode: (node: CanvasNode) => void;
+  activeTool: string;
+  setActiveTool: (tool: string) => void;
   focusModeEnabled?: boolean;
   canToggleFocusMode?: boolean;
   onToggleFocusMode?: () => void;
@@ -101,6 +103,7 @@ export const useCanvasKeyboard = ({
   findOpen, toggleFindBar, closeFindBar, findNext, findPrev, findHasMatches,
   contextMenu, setContextMenu,
   setHighlightedId, handleFocusNode,
+  activeTool, setActiveTool,
   focusModeEnabled = false,
   canToggleFocusMode = false,
   onToggleFocusMode,
@@ -159,6 +162,7 @@ export const useCanvasKeyboard = ({
       if (isMod && e.key === 'a' && !isEditable) {
         e.preventDefault();
         setSelectedNodeIds(nodes.map((n) => n.id));
+        setSelectedEdgeId(null);
         return;
       }
       if (isMod && e.key === 'd' && !isEditable) {
@@ -256,6 +260,10 @@ export const useCanvasKeyboard = ({
         // anything else with selection state.
         if (fullscreenActive) { onExitFullscreen?.(); return; }
         if (focusModeEnabled) { onExitFocusMode?.(); return; }
+        if (activeTool === 'connect' || activeTool.startsWith('shape-')) {
+          setActiveTool('select');
+          return;
+        }
         if (selectedEdgeId) { setSelectedEdgeId(null); return; }
         setSelectedNodeIds([]);
         return;
@@ -276,7 +284,7 @@ export const useCanvasKeyboard = ({
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [canvasId, undo, redo, nodes, selectedNodeIds, setSelectedNodeIds, selectedEdgeId, setSelectedEdgeId, removeEdge, duplicateNode, clipboard, setClipboard, pasteNodes, pasteReferencedNodes, groupSelectedNodes, ungroupSelectedNodes, removeNodes, moveNodes, commitHistory, searchOpen, setSearchOpen, findOpen, toggleFindBar, closeFindBar, findNext, findPrev, findHasMatches, contextMenu, setContextMenu, focusModeEnabled, canToggleFocusMode, onToggleFocusMode, onExitFocusMode, fullscreenActive, onExitFullscreen, keyboardLocked]);
+  }, [canvasId, undo, redo, nodes, selectedNodeIds, setSelectedNodeIds, selectedEdgeId, setSelectedEdgeId, removeEdge, duplicateNode, clipboard, setClipboard, pasteNodes, pasteReferencedNodes, groupSelectedNodes, ungroupSelectedNodes, removeNodes, moveNodes, commitHistory, searchOpen, setSearchOpen, findOpen, toggleFindBar, closeFindBar, findNext, findPrev, findHasMatches, contextMenu, setContextMenu, activeTool, setActiveTool, focusModeEnabled, canToggleFocusMode, onToggleFocusMode, onExitFocusMode, fullscreenActive, onExitFullscreen, keyboardLocked]);
 
   // Cmd/Ctrl+Tab to cycle through nodes (Shift reverses direction)
   useEffect(() => {
@@ -298,6 +306,7 @@ export const useCanvasKeyboard = ({
           }
           const nextNode = nodes[nextIndex];
           setSelectedNodeIds([nextNode.id]);
+          setSelectedEdgeId(null);
           setHighlightedId(nextNode.id);
           // In focus mode the dedicated reframe effect handles the zoom
           // with tighter padding/maxScale; calling handleFocusNode here
@@ -308,5 +317,5 @@ export const useCanvasKeyboard = ({
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [nodes, selectedNodeIds, setSelectedNodeIds, setHighlightedId, handleFocusNode, keyboardLocked, focusModeEnabled]);
+  }, [nodes, selectedNodeIds, setSelectedNodeIds, setSelectedEdgeId, setHighlightedId, handleFocusNode, keyboardLocked, focusModeEnabled]);
 };

--- a/apps/canvas-workspace/src/renderer/src/hooks/useEdgeInteraction.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useEdgeInteraction.test.tsx
@@ -182,13 +182,40 @@ describe('useEdgeInteraction move gestures', () => {
     act(() => hook.beginMoveEdge('edge-1', 10, 10));
     move([30, 40], [50, 60]);
 
+    const bubbleHandler = vi.fn();
+    window.addEventListener('keydown', bubbleHandler);
     act(() => {
-      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      document.body.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      }));
     });
+    window.removeEventListener('keydown', bubbleHandler);
 
     expect(updateEdge).not.toHaveBeenCalled();
     expect(commitHistory).not.toHaveBeenCalled();
     expect(hook.state).toBeNull();
+    expect(bubbleHandler).not.toHaveBeenCalled();
+  });
+
+  it('lets a cancelled connect draft continue to the Escape handler that exits connect mode', () => {
+    act(() => hook.beginConnect(10, 10));
+    expect(hook.state).toMatchObject({ kind: 'connect' });
+
+    const bubbleHandler = vi.fn();
+    window.addEventListener('keydown', bubbleHandler);
+    act(() => {
+      document.body.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      }));
+    });
+    window.removeEventListener('keydown', bubbleHandler);
+
+    expect(hook.state).toBeNull();
+    expect(bubbleHandler).toHaveBeenCalledOnce();
   });
 
   it('does not start a whole-edge move when both endpoints are node-bound', () => {

--- a/apps/canvas-workspace/src/renderer/src/hooks/useEdgeInteraction.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useEdgeInteraction.ts
@@ -331,12 +331,13 @@ export const useEdgeInteraction = ({
     // Window focus loss never delivers the mouseup — finish the gesture
     // like the node-drag handlers do, so the edge isn't left half-dragged.
     const onBlur = () => handleUp();
-    // Escape aborts; capture + stopPropagation keeps the canvas-level
-    // Escape handler from also deselecting on the same press.
+    // Connect cancellation continues to the canvas Escape handler so the tool
+    // exits; editing an existing edge consumes Escape to preserve selection.
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return;
-      e.stopPropagation();
+      const wasConnecting = stateRef.current?.kind === 'connect';
       handleCancel();
+      if (!wasConnecting) e.stopPropagation();
     };
     window.addEventListener('mousemove', onMove);
     window.addEventListener('mouseup', onUp);

--- a/apps/canvas-workspace/src/renderer/src/hooks/useShapeDraw.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useShapeDraw.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useShapeDraw } from './useShapeDraw';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('useShapeDraw', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+  let hook: ReturnType<typeof useShapeDraw>;
+
+  const Probe = () => {
+    hook = useShapeDraw({
+      activeTool: 'shape-rect',
+      screenToCanvas: (x, y) => ({ x, y }),
+      getContainer: () => host,
+      addNode: vi.fn(),
+      updateNode: vi.fn(),
+      onCommitted: vi.fn(),
+    });
+    return null;
+  };
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    document.body.append(host);
+    root = createRoot(host);
+    act(() => root.render(<Probe />));
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+  });
+
+  it('cancels a draft without consuming the Escape needed to exit shape mode', () => {
+    act(() => {
+      hook.handleOverlayMouseDown({
+        button: 0,
+        clientX: 10,
+        clientY: 20,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      } as unknown as React.MouseEvent);
+    });
+    expect(hook.draft).not.toBeNull();
+
+    const bubbleHandler = vi.fn();
+    window.addEventListener('keydown', bubbleHandler);
+    act(() => {
+      document.body.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      }));
+    });
+    window.removeEventListener('keydown', bubbleHandler);
+
+    expect(hook.draft).toBeNull();
+    expect(bubbleHandler).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/hooks/useShapeDraw.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useShapeDraw.ts
@@ -83,11 +83,10 @@ export const useShapeDraw = ({
       setDraft(null);
     };
     // Escape aborts the draft — no shape is committed on the following
-    // mouseup. Capture phase + stopPropagation so the canvas-level Escape
-    // handler doesn't also react to the same press.
+    // mouseup. Let the same key continue to the canvas-level handler so it
+    // can return the active shape tool to select mode in one press.
     const handleKey = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return;
-      e.stopPropagation();
       draftRef.current = null;
       setDraft(null);
     };


### PR DESCRIPTION
## Summary

- preserve node mentions while the chat composer is still mounting
- restore the selection toolbar with a non-overlapping bottom layout
- keep node and edge selection mutually exclusive across focus and keyboard flows
- make one Escape cancel Connect or Shape drafts and return to Select

## Why

Several canvas actions had incomplete UI handoffs: a node mention could be dropped before the composer registered, the existing selection toolbar was no longer mounted, and tool cancellation or external node focus could leave stale interaction state behind.

## User impact

Selecting nodes now exposes the expected actions, adding a node to a closed chat reliably inserts its context, and Connect or Shape mode exits predictably with one Escape.

## Validation

- canvas-workspace typecheck
- canvas-workspace build
- full canvas-workspace test suite: 247 files, 1609 tests
- real-app harness checks for selection toolbar, chat mention insertion, and tool cancellation
- Standards and Spec review