### PR TITLE
release(canvas): 0.1.31

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.30",
+  "version": "0.1.31",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- bump Pulse Canvas to 0.1.31
- publish the macOS arm64 DMG and blockmap
- update the stable manifest and download page

## Release notes

支持跨思维导图移动主题；新增按工作区管理的技能库，并优化技能详情与聊天入口；完善定时任务的运行状态、聊天衔接和响应式布局；修复选择、滚动等交互问题。

## Validation

- canvas-workspace standard harness: 4/4 passed
- macOS arm64 package build passed
- packaged agent tooling smoke passed
- R2 artifact and latest.json verified over production URLs
- Cloudflare Pages deployment succeeded