### PR TITLE
release(canvas): 0.1.33

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.32",
+  "version": "0.1.33",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {

--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.31",
+  "version": "0.1.32",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
## Pulse Canvas 0.1.33

- 优化终端中打开外部链接时的确认窗口，并暂时隐藏画布选择工具栏，减少视觉干扰和误触。

发布产物、latest.json 和下载页已完成部署。合并后请在 master 上创建并推送 `pulse-canvas-v0.1.33` tag。