### PR TITLE
Hide selection toolbar pending product review

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.selection.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.selection.test.ts
@@ -44,12 +44,6 @@ const baseProps = (): CanvasOverlaysProps => ({
   transform: { x: 0, y: 0, scale: 1 },
 });
 
-const clickButton = (host: HTMLElement, label: string) => {
-  const button = host.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`);
-  expect(button).not.toBeNull();
-  act(() => button?.dispatchEvent(new MouseEvent('click', { bubbles: true })));
-};
-
 describe('CanvasOverlays selection actions', () => {
   let host: HTMLDivElement;
   let root: Root;
@@ -83,58 +77,30 @@ describe('CanvasOverlays selection actions', () => {
     });
   };
 
-  it('shows selection actions and forwards single-selection commands', () => {
-    const onFitSelection = vi.fn();
-    const onDuplicateSelection = vi.fn();
-    const onToggleFocusMode = vi.fn();
-    const onWrapSelectionInFrame = vi.fn();
-    const onPinReferenceSelection = vi.fn();
-    const onAddSelectionToChat = vi.fn();
-    const onDeleteSelection = vi.fn();
-
+  it('stays hidden for a single selection', () => {
     render({
       selectedNodeIds: ['node-1'],
       focusModeAvailable: true,
-      onFitSelection,
-      onDuplicateSelection,
-      onToggleFocusMode,
-      onWrapSelectionInFrame,
-      onPinReferenceSelection,
-      onAddSelectionToChat,
-      onDeleteSelection,
+      onFitSelection: vi.fn(),
+      onDuplicateSelection: vi.fn(),
+      onToggleFocusMode: vi.fn(),
+      onWrapSelectionInFrame: vi.fn(),
+      onPinReferenceSelection: vi.fn(),
+      onAddSelectionToChat: vi.fn(),
+      onDeleteSelection: vi.fn(),
     });
 
-    expect(host.querySelector('[role="toolbar"][aria-label="Selection actions"]')).not.toBeNull();
-    expect(host.querySelector('.canvas-bottom-chrome--selection')).not.toBeNull();
-
-    clickButton(host, 'Fit the selection in view');
-    clickButton(host, 'Duplicate selection');
-    clickButton(host, 'Focus selection');
-    clickButton(host, 'Wrap in frame');
-    clickButton(host, 'Pin selection as reference');
-    clickButton(host, 'Add selection to chat');
-    clickButton(host, 'Delete selection');
-
-    expect(onFitSelection).toHaveBeenCalledOnce();
-    expect(onDuplicateSelection).toHaveBeenCalledOnce();
-    expect(onToggleFocusMode).toHaveBeenCalledOnce();
-    expect(onWrapSelectionInFrame).toHaveBeenCalledOnce();
-    expect(onPinReferenceSelection).toHaveBeenCalledOnce();
-    expect(onAddSelectionToChat).toHaveBeenCalledOnce();
-    expect(onDeleteSelection).toHaveBeenCalledOnce();
+    expect(host.querySelector('[role="toolbar"][aria-label="Selection actions"]')).toBeNull();
+    expect(host.querySelector('.canvas-bottom-chrome--selection')).toBeNull();
   });
 
-  it('keeps group available for a multi-selection', () => {
-    const onGroupSelection = vi.fn();
-
+  it('stays hidden for a multi-selection', () => {
     render({
       selectedNodeIds: ['node-1', 'node-2'],
-      onGroupSelection,
+      onGroupSelection: vi.fn(),
     });
 
-    expect(host.querySelector('[role="toolbar"][aria-label="Selection actions"]')).not.toBeNull();
-    clickButton(host, 'Group selection');
-    expect(onGroupSelection).toHaveBeenCalledOnce();
+    expect(host.querySelector('[role="toolbar"][aria-label="Selection actions"]')).toBeNull();
   });
 
   it('hides selection actions when the selection is empty', () => {

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/CanvasOverlays.tsx
@@ -9,13 +9,10 @@ import type { UseCanvasSearchReturn } from '../../hooks/useCanvasSearch';
 import { CanvasEmptyHint } from '../CanvasEmptyHint';
 import { EdgeLabel } from '../EdgeLabel';
 import { ChatFloatingButton } from '../ChatFloatingButton';
-import { SelectionToolbar } from '../SelectionToolbar';
 import { useI18n } from '../../i18n';
 import type { CreatableCanvasNodeType } from '../../utils/nodeFactory';
 import type { AddNodeOptions } from '../../hooks/useNodes';
 import { applyEdgeInteractionPreview } from '../CanvasEdgesLayer';
-
-const noop = () => undefined;
 
 const CommandPalette = lazy(() =>
   import('../CommandPalette').then((module) => ({ default: module.CommandPalette })),
@@ -200,7 +197,6 @@ export const CanvasOverlays = ({
   const { t } = useI18n();
   const renderEdgeLabels = shouldRenderEdgeLabels({ moving, editingEdgeLabelId });
   const renderEdgeStylePanel = shouldRenderEdgeStylePanel(moving);
-  const selectionActive = selectedNodeIds.length > 0;
   const overlayEdges = useMemo(
     () => projectEdgeOverlayGeometry(edges, selectedEdge, edgeInteractionState),
     [edgeInteractionState, edges, selectedEdge],
@@ -303,29 +299,10 @@ export const CanvasOverlays = ({
         className={[
           'canvas-bottom-chrome',
           moving ? 'canvas-bottom-chrome--moving' : '',
-          selectionActive ? 'canvas-bottom-chrome--selection' : '',
         ].filter(Boolean).join(' ')}
       >
-        {selectionActive && (
-          <SelectionToolbar
-            selectedCount={selectedNodeIds.length}
-            canFocus={selectedNodeIds.length === 1 && !!focusModeAvailable}
-            focusModeActive={!!focusModeActive}
-            canGroup={selectedNodeIds.length > 1}
-            canPinReference={selectedNodeIds.length === 1 && !!onPinReferenceSelection}
-            canAddToChat={selectedNodeIds.length === 1 && !!onAddSelectionToChat}
-            showPinReference={!!onPinReferenceSelection}
-            showAddToChat={!!onAddSelectionToChat}
-            onFitSelection={onFitSelection ?? noop}
-            onDuplicate={onDuplicateSelection ?? noop}
-            onToggleFocus={onToggleFocusMode ?? noop}
-            onGroup={onGroupSelection ?? noop}
-            onWrapFrame={onWrapSelectionInFrame ?? noop}
-            onPinReference={onPinReferenceSelection ?? noop}
-            onAddToChat={onAddSelectionToChat ?? noop}
-            onDelete={onDeleteSelection ?? noop}
-          />
-        )}
+        {/* Selection toolbar hidden for now (product call on 2026-07-27);
+          selection-related props above stay wired for a future re-enable. */}
         <FloatingToolbar
           activeTool={activeTool}
           onToolChange={onToolChange}


### PR DESCRIPTION
## Summary
Temporarily hides the selection toolbar component while awaiting product feedback from a scheduled review. The underlying selection-related callback props remain wired in the component to facilitate future re-enablement.

## Changes
- Removed `SelectionToolbar` component rendering from `CanvasOverlays.tsx`
- Removed the `selectionActive` state variable and related conditional CSS class
- Removed the `noop` utility function (no longer needed)
- Updated test suite to reflect hidden toolbar behavior:
  - Changed "shows selection actions" test to "stays hidden for a single selection"
  - Changed "keeps group available for a multi-selection" test to "stays hidden for a multi-selection"
  - Removed button click assertions and callback verification
  - Removed helper function `clickButton` used only in these tests
- Added explanatory comment noting the toolbar is hidden pending product review (2026-07-27)

## Implementation Details
All selection-related callback props (`onFitSelection`, `onDuplicateSelection`, `onToggleFocusMode`, etc.) remain in the component signature and are still passed through, allowing the toolbar to be re-enabled without requiring prop changes.

https://claude.ai/code/session_01NFLgvJCBhKWjvrv1sbEGfG