### PR TITLE
fix(canvas-workspace): align two components with frontend.md conventions

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
@@ -10,7 +10,9 @@ import { useI18n } from '../../i18n';
 import { Button, FieldRow, Select } from '../ui';
 import './AgentSection.css';
 
-const AgentShellPathCard = lazy(() => import('./AgentShellPathCard'));
+const AgentShellPathCard = lazy(() =>
+  import('./AgentShellPathCard').then((module) => ({ default: module.AgentShellPathCard })),
+);
 
 interface AgentSectionProps {
   onClose: () => void;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
@@ -4,30 +4,15 @@ import { useAppShell } from '../AppShellProvider';
 import { useI18n } from '../../i18n';
 import { Button } from '../ui';
 
-interface AgentShellPathCardProps {
+interface Props {
   shellPath: ShellPathResult;
   onConfigured: () => Promise<void>;
 }
 
-const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps) => {
+export const AgentShellPathCard = ({ shellPath, onConfigured }: Props) => {
   const { notify } = useAppShell();
-  const { language, t } = useI18n();
+  const { t } = useI18n();
   const [configuring, setConfiguring] = useState(false);
-  const copy = language === 'zh'
-    ? {
-        title: '终端命令',
-        ready: (profile: string) => `已在 ${profile} 中配置 pulse-canvas。打开新终端后即可使用。`,
-        setup: (profile: string) => `将托管 CLI 目录加入 ${profile}，之后可在新终端中直接运行 pulse-canvas。`,
-        configure: '配置 PATH',
-        unsupported: '自动配置仅支持 zsh、bash 和 fish。请手动执行下面的命令。',
-      }
-    : {
-        title: 'Terminal command',
-        ready: (profile: string) => `pulse-canvas is configured in ${profile}. Open a new terminal to use it.`,
-        setup: (profile: string) => `Add the managed CLI directory to ${profile} so new terminals can run pulse-canvas directly.`,
-        configure: 'Configure PATH',
-        unsupported: 'Automatic setup supports zsh, bash, and fish. Run the command below manually.',
-      };
 
   const configure = async () => {
     setConfiguring(true);
@@ -37,8 +22,8 @@ const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps
       await onConfigured();
       notify({
         tone: 'success',
-        title: copy.title,
-        description: copy.ready(result.profilePath ?? ''),
+        title: t('agent.shellPathTitle'),
+        description: t('agent.shellPathReady', { profile: result.profilePath ?? '' }),
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -50,13 +35,13 @@ const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps
 
   return (
     <div className="agent-section-cli">
-      <div className="agent-section-cli-title">{copy.title}</div>
+      <div className="agent-section-cli-title">{t('agent.shellPathTitle')}</div>
       <div className="agent-section-cli-desc">
         {shellPath.configured
-          ? copy.ready(shellPath.profilePath ?? '')
+          ? t('agent.shellPathReady', { profile: shellPath.profilePath ?? '' })
           : shellPath.supported
-            ? copy.setup(shellPath.profilePath ?? '')
-            : copy.unsupported}
+            ? t('agent.shellPathSetup', { profile: shellPath.profilePath ?? '' })
+            : t('agent.shellPathUnsupported')}
       </div>
       <div className="agent-section-cli-cmd-row">
         <code className="agent-section-cli-cmd">
@@ -64,12 +49,10 @@ const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps
         </code>
         {shellPath.supported && !shellPath.configured && (
           <Button variant="secondary" size="sm" onClick={() => void configure()} disabled={configuring}>
-            {copy.configure}{configuring ? '…' : ''}
+            {t('agent.shellPathConfigure')}{configuring ? '…' : ''}
           </Button>
         )}
       </div>
     </div>
   );
 };
-
-export default AgentShellPathCard;

--- a/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
+++ b/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
@@ -1006,6 +1006,11 @@ const en = {
   'agent.removeLegacyDirs': 'Remove legacy dirs',
   'agent.targetsAria': 'Agent integration install targets',
   'agent.close': 'Close',
+  'agent.shellPathTitle': 'Terminal command',
+  'agent.shellPathReady': 'pulse-canvas is configured in {profile}. Open a new terminal to use it.',
+  'agent.shellPathSetup': 'Add the managed CLI directory to {profile} so new terminals can run pulse-canvas directly.',
+  'agent.shellPathConfigure': 'Configure PATH',
+  'agent.shellPathUnsupported': 'Automatic setup supports zsh, bash, and fish. Run the command below manually.',
 
   'experimental.loadFailed': 'Failed to load experimental features',
   'experimental.updateFailed': 'Could not update flag',
@@ -2557,6 +2562,11 @@ const zh: Record<keyof typeof en, string> = {
   'agent.removeLegacyDirs': '移除旧目录',
   'agent.targetsAria': 'Agent 集成安装目标',
   'agent.close': '关闭',
+  'agent.shellPathTitle': '终端命令',
+  'agent.shellPathReady': '已在 {profile} 中配置 pulse-canvas。打开新终端后即可使用。',
+  'agent.shellPathSetup': '将托管 CLI 目录加入 {profile}，之后可在新终端中直接运行 pulse-canvas。',
+  'agent.shellPathConfigure': '配置 PATH',
+  'agent.shellPathUnsupported': '自动配置仅支持 zsh、bash 和 fish。请手动执行下面的命令。',
 
   'experimental.loadFailed': '加载实验功能失败',
   'experimental.updateFailed': '无法更新开关',


### PR DESCRIPTION
## Summary

Scanned `apps/canvas-workspace` against its own UI style guide
(`harness/knowledge/conventions/frontend.md`) — component export style and
copy/i18n rules — and fixed the two concrete violations found:

- **`Settings/AgentShellPathCard.tsx`** hardcoded an English/Chinese `copy`
  object switched on `language === 'zh'` instead of going through
  `useI18n()`, directly violating the "no hardcoded user-facing strings"
  rule in `frontend.md`. Moved the five strings into the shared message
  catalog (`i18n/messages.ts`, both `en` and `zh` blocks) as
  `agent.shellPath{Title,Ready,Setup,Configure,Unsupported}` and switched
  the component to `t(...)`.
- Both **`AgentShellPathCard`** and **`MigrationSpinner`** shipped a
  `default` export in addition to (or instead of) the named export the
  guide requires ("Export named arrow-function components... Avoid
  `default` exports for components"). `MigrationSpinner`'s default export
  was dead code (its one `lazy()` call site already destructures the named
  export), so it's just removed. `AgentShellPathCard` only had a default
  export, so it's now `export const AgentShellPathCard`, and
  `Settings/AgentSection.tsx`'s `lazy(() => import(...))` call site was
  updated to the same `.then((m) => ({ default: m.X }))` pattern already
  used for `MigrationSpinner`, so no behavior changes.

I also checked the CSS design-token ratchet
(`src/main/__tests__/ui-reuse-governance.test.ts`, which mechanically
enforces `frontend.md`'s "UI reuse" section) — its counters are already at
baseline and the remaining hardcoded-color/shadow/radius stock is
deliberately-deferred, visual-review-gated technical debt per its own
history (see the counter comments), so nothing there is a safe mechanical
fix in this pass.

## Why

Consistent i18n usage and export style are exactly what the workspace's
`AGENTS.md`/`harness/knowledge/conventions/frontend.md` mandate for new and
touched code, and both files were drifting from it.

## Test plan

- [x] `pnpm --filter canvas-workspace typecheck` — passes
- [x] `pnpm --filter canvas-workspace test` — 263 files / 1674 passed, 1 skipped (includes the UI-reuse-governance ratchet, unaffected since no button/input/color-literal counters changed)
- [ ] Manual: open Settings → Agent section and confirm the "Terminal command" card renders/copy is unchanged in both English and Chinese

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019nksPWw1TCH5pbMXVLs2FS


---
_Generated by [Claude Code](https://claude.ai/code/session_019nksPWw1TCH5pbMXVLs2FS)_