### PR TITLE
fix(canvas-workspace): drop the two lingering default-exported components

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
@@ -10,7 +10,9 @@ import { useI18n } from '../../i18n';
 import { Button, FieldRow, Select } from '../ui';
 import './AgentSection.css';
 
-const AgentShellPathCard = lazy(() => import('./AgentShellPathCard'));
+const AgentShellPathCard = lazy(() =>
+  import('./AgentShellPathCard').then((module) => ({ default: module.AgentShellPathCard })),
+);
 
 interface AgentSectionProps {
   onClose: () => void;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
@@ -9,7 +9,7 @@ interface AgentShellPathCardProps {
   onConfigured: () => Promise<void>;
 }
 
-const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps) => {
+export const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps) => {
   const { notify } = useAppShell();
   const { language, t } = useI18n();
   const [configuring, setConfiguring] = useState(false);
@@ -71,5 +71,3 @@ const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps
     </div>
   );
 };
-
-export default AgentShellPathCard;


### PR DESCRIPTION
## Summary

Scanned `apps/canvas-workspace` for UI style inconsistencies against its own documented conventions (`harness/knowledge/conventions/frontend.md`) and mechanical governance (`ui-reuse-governance.test.ts`, `import-boundaries.test.ts`, `file-size-governance.test.ts`).

**Findings:**
- The `ui-reuse-governance` ratchet (the app's mechanical style/consistency gate — hardcoded colors, un-tokenized radii/shadows, raw buttons/inputs, hand-rolled dropdowns, keydown listeners, etc.) passes with all 18 counters exactly at baseline. No drift, no violations there.
- `frontend.md`'s component-style rule says: *"Export named arrow-function components... Avoid default exports for components."* Scanning `src/renderer/src/components/**/*.tsx` for `export default`, only two components broke this — every other component in the tree already follows the convention:
  - `MigrationSpinner/index.tsx` — the `export default` was dead code; its lazy import in `App.tsx` already resolves the module via the named export (`.then((module) => ({ default: module.MigrationSpinner }))`).
  - `Settings/AgentShellPathCard.tsx` — was the sole remaining default export actually consumed via plain `lazy(() => import(...))`. Converted it to a named export and updated its one call site (`AgentSection.tsx`) to map the lazy import from the named export, mirroring the pattern `MigrationSpinner`/`App.tsx` already use.
- I also checked the `Props` interface-naming convention frontend.md documents (*"Name the props interface `Props`"*) — in practice almost every component in the codebase uses `<ComponentName>Props` instead, so that's the real, dominant, and consistent convention already in place. Renaming to bare `Props` would have gone against the codebase's actual practice, not fixed anything, so I left it alone.

## Changes

- `apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx`: remove the unused `export default`.
- `apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx`: switch to a named export.
- `apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx`: update the lazy import to map from the named export.

No behavior change — purely an export-style normalization.

## Test plan

- [x] `pnpm --filter canvas-workspace typecheck` — clean
- [x] `pnpm exec vitest run` (canvas-workspace) — 263 test files, 1674 passed / 1 skipped, no failures
- [x] `ui-reuse-governance.test.ts`, `import-boundaries.test.ts`, `file-size-governance.test.ts` — all green, ratchet counters unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7jpxzsEnbiDZzMVuehpWQ)_