### PR TITLE
fix(canvas-workspace): remove default exports from renderer components

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
@@ -10,7 +10,9 @@ import { useI18n } from '../../i18n';
 import { Button, FieldRow, Select } from '../ui';
 import './AgentSection.css';
 
-const AgentShellPathCard = lazy(() => import('./AgentShellPathCard'));
+const AgentShellPathCard = lazy(() =>
+  import('./AgentShellPathCard').then((module) => ({ default: module.AgentShellPathCard })),
+);
 
 interface AgentSectionProps {
   onClose: () => void;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
@@ -9,7 +9,7 @@ interface AgentShellPathCardProps {
   onConfigured: () => Promise<void>;
 }
 
-const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps) => {
+export const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps) => {
   const { notify } = useAppShell();
   const { language, t } = useI18n();
   const [configuring, setConfiguring] = useState(false);
@@ -71,5 +71,3 @@ const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps
     </div>
   );
 };
-
-export default AgentShellPathCard;


### PR DESCRIPTION
## Summary

Scanned `apps/canvas-workspace` for UI style inconsistencies against its documented conventions (`apps/canvas-workspace/harness/knowledge/conventions/frontend.md`).

Most of the CSS/JSX-shape style surface (design tokens, blessed `components/ui/` reuse, radius/color/shadow literals) is already governed by a strict, actively-maintained ratchet test (`src/main/__tests__/ui-reuse-governance.test.ts`) that fails on **any** drift — up or down — from its baseline. Checking it, every exact-match, no-visual-review-needed tokenization opportunity documented in that file's history has already been landed; anything left in that stock is explicitly flagged as requiring a visual diff before touching, so it was left alone rather than risk an unreviewed pixel change.

One concrete, mechanical violation of `frontend.md`'s component-style rule ("Export named arrow-function components... Avoid `default` exports for components") was found and fixed:

- `components/MigrationSpinner/index.tsx` had a dangling `export default MigrationSpinner;` — dead code, since its only caller (`App.tsx`) already imports the named export via `lazy()`. Removed it.
- `components/Settings/AgentShellPathCard.tsx` was `export default`-only and loaded via a bare `lazy(() => import(...))`. Converted it to a named export and updated the `lazy()` call site in `AgentSection.tsx` to the same `.then((m) => ({ default: m.X }))` pattern `MigrationSpinner`'s own loader already uses in `App.tsx` — so both lazy-loaded Settings pieces now follow the identical, consistent pattern.

No other default-exported components remain under `src/renderer/src/components/` (`App.tsx`'s own root `export default App` is the standard Vite/React entrypoint pattern and out of scope).

## Why

Consistency: the app's own convention doc explicitly calls out named exports as the standard, and having one component silently default-exported (with dead code duplicating the named export) while another only default-exported created two different consumption patterns for what should be one lazy-loading idiom.

## Test plan

- [x] `pnpm --filter canvas-workspace typecheck` — passes
- [x] `pnpm --filter canvas-workspace test` (vitest) — 276 files / 1787 tests pass, including the `ui-reuse-governance` ratchet (unaffected, as expected — no tag/CSS counters touched) and `file-size-governance`
- [x] No behavior change — pure export-style + import-site consistency fix

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01UqyrVmxaU7ygFym5Emfa6J

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqyrVmxaU7ygFym5Emfa6J)_