### PR TITLE
feat(canvas-workspace): adopt Spatial-inspired workspace styling

### DIFF
--- a/apps/canvas-workspace/design-qa.md
+++ b/apps/canvas-workspace/design-qa.md
@@ -100,3 +100,185 @@ No actionable P0, P1, or P2 visual differences remain.
 - Focused Scheduled/RightDock tests, renderer/main TypeScript checks, and the production build passed.
 
 final result: passed
+
+---
+
+# A3 content-node production design QA
+
+## Visual sources
+
+- Design target: `/Users/jasperhu/project/pulse-agent/.design-prototypes/card-system-costs/public/a3-current-canvas.png`
+  - 1149 × 896
+  - A3 overview state with Note, Text, and Web treatments on the current Canvas composition.
+- Rejected real-canvas state: `/var/folders/47/8lvrntxs52xdcrv32zkfrwww0000gn/T/codex-clipboard-9dd22c3f-ee6f-4077-aa23-028667e40489.png`
+  - 3024 × 1896
+  - User-provided production screenshot that exposed the first implementation's weak hierarchy.
+- Corrected production implementation: `/Users/jasperhu/project/pulse-agent/apps/canvas-workspace/.harness/design-qa/content-nodes-a3-v2-collapsed.png`
+  - 2536 × 1736 system capture
+  - Built Electron app using a disposable clone of workspace `ws-1779593150588`.
+- Overview verification: `/Users/jasperhu/project/pulse-agent/apps/canvas-workspace/.harness/design-qa/content-nodes-a3-v2-fit.png`
+  - Confirms Note cards and the Web node at whole-canvas scale.
+
+## State and scope
+
+- Production workspace data is a read-only clone; a disposable Text node was added only inside the clone to inspect its selected state.
+- Verified node treatments:
+  - Note: long Markdown document, fixed card height, internal scrolling.
+  - Text: chrome-free body, auto-height behavior, editing/selected surface.
+  - Web: live page, page title/favicon/URL controls, no redundant generic iframe badge.
+- Frames, terminal nodes, canvas navigation, storage shape, and Webview behavior are unchanged.
+
+## Findings
+
+- P0: none.
+- P1: none.
+- Resolved P2: the first implementation kept the node title at 18px/700 above an equally prominent Markdown heading, so the screenshot still read as a traditional document panel with duplicate hierarchy.
+- Resolved P2: persistent timestamps and visible scrollbar thumbs added low-value chrome to every Note.
+- Corrected Note treatment makes the node title a quiet 12px metadata line, leaves the Markdown heading as the only primary title, hides timestamps/scrollbars until interaction, reduces radius to 14px, and flattens elevation.
+- Text remains chrome-free and auto-height; its selected state now uses one shared focus ring instead of a stacked double halo.
+- Web keeps live-page behavior and operational controls, but uses a compact 12px header and no generic type badge.
+
+## Verification history
+
+1. The first clone-only comparison was incorrectly accepted.
+2. The user's real production screenshot showed that the visual hierarchy was still largely unchanged; that result was rejected.
+3. Reworked title hierarchy, interaction-only metadata, scroll chrome, typography, corner radius, and elevation.
+4. Recaptured the same cloned workspace at 82% with the sidebar collapsed, matching the user's visible canvas state.
+5. Used Fit overview to verify the Web card and overall frame/card relationship; Electron logs remained clean.
+
+## Spatial source-of-truth correction (2026-07-29)
+
+The prior v2 pass was too strongly grounded in the user's production
+screenshot and not strongly enough in `spatial-card-series.html` plus
+`spatial-visual-system.html`. It borrowed the quiet hierarchy but missed
+several explicit rules from those sources.
+
+The corrected pass maps the reference system into production as follows:
+
+- Note / Text / Web use the Spatial content-object elevation family and
+  18px card radius where a card surface exists.
+- Hover lifts content objects by 3px; dragging adds 1.02 scale, -1.5deg
+  rotation, and stronger elevation.
+- Current-object selection is a dedicated purple 2px outline with 3px
+  offset, replacing node-local blue halos.
+- A Note's node title is an 11px mono eyebrow. The Markdown `h1` remains
+  the single primary title at approximately 27px / 590.
+- Long-form Note content uses the paper-object spacing model: 40px reading
+  gutters on wide nodes, 32px at the current 520px card tier, and Chinese
+  body copy at 1.7 line-height.
+- Negative tracking was removed from Markdown headings because the visual
+  system explicitly warns against compressing Chinese display text.
+- Text remains a chrome-free, auto-height object and Web remains a live
+  browser surface. The reference's visual grammar was adopted without
+  replacing the product's existing interaction and runtime models.
+
+Verification:
+
+1. `pnpm --filter canvas-workspace typecheck` passed.
+2. `pnpm --filter canvas-workspace build` passed.
+3. The running Electron Canvas was inspected after HMR at Fit / 50%;
+   Note hierarchy, long-form density, Web identity, and whole-canvas
+   relationship remained readable.
+4. UI reuse governance improved from 1822 to 1814 hardcoded color literals
+   and from 144 to 141 shadow literals; the ratchets were lowered.
+
+## Content-card spacing correction (2026-07-29)
+
+Follow-up inspection at close zoom showed three proportional issues that were
+easy to miss at Fit:
+
+- The Spatial purple selection outline overlapped the Canvas blue selection
+  treatment. Content nodes now use the existing Canvas blue accent as their
+  sole selection color, and the overview hairline excludes selected Note /
+  Web nodes so it cannot replace or stack with the active ring.
+- Note eyebrow top padding was reduced from 28px to 18px. The card retains an
+  editorial opening without spending a full content-spacing tier above UI
+  metadata.
+- Note content now reserves a stable 16px footer inset. This is separate from
+  the editor's end-of-document padding, so the visible scroll viewport never
+  terminates directly against the rounded card edge.
+- Newly wrapped Frames reserve a 64px lower inset instead of 40px. At the
+  common 44% overview zoom this remains a visible ~28px footer rather than
+  collapsing to an ~18px line. Existing saved Frame bounds remain untouched.
+
+## Drag motion reference (2026-07-29)
+
+The supplied 7.47s interaction recording was sampled across pickup, travel,
+and release. The final implementation keeps its elevation rhythm without
+changing card geometry:
+
+- Pickup: a wider elevation shadow, with size and axis unchanged.
+- Travel: the pose stays stable while the node's existing position transform
+  remains directly pointer-driven; no positional easing is introduced.
+- Release: shadow settles back over 220ms.
+- The dragged object stays fully opaque and uses a wider 32px / 72px shadow.
+- Reduced-motion users receive the same position-only dragging.
+
+### Drag placement correction
+
+The first motion pass translated the positioned node wrapper by -6px while
+dragging and -3px while hovered. Canvas persistence correctly stored the
+untranslated `x` / `y`, but the preview and resting render used different
+visual coordinate offsets, so release appeared to move the card.
+
+Hover and drag no longer translate the positioned wrapper. Elevation is now
+expressed only through shadow; the pointer-driven
+position preview and the persisted resting position share the same origin.
+
+### Tilt removed
+
+The fixed -1.2deg drag rotation was removed after interaction review. Dragging
+keeps the card axis-aligned through pickup, travel, and release.
+
+### Scale removed
+
+The remaining 1.025 drag scale expanded a 520px card by roughly 13px around
+its center. Users aligning the preview edge therefore saw a 6–8px correction
+when the card returned to its persisted, unscaled bounds. Dragging now changes
+shadow only, so preview bounds and resting bounds are pixel-identical.
+
+### Geometry-safe motion restored
+
+Selected Note, Text, and Web nodes now retain their hover elevation instead
+of having it overwritten by the selected rule. Pickup transitions to a
+stronger two-layer drag shadow over 200ms, while the node's transform, size,
+and coordinate origin stay unchanged.
+
+### Interaction weight correction
+
+The content-card selection treatment now follows the lighter Coding Agent
+interaction: one translucent blue hairline instead of a solid 2px outline
+offset from the card. New Notes start at 360×240 rather than 420×360 so short
+Markdown does not sit in a large empty square; existing resized Notes retain
+their saved dimensions.
+
+### Positioned-wrapper geometry invariant
+
+A follow-up regression showed that even a 1.006 hover scale changes the
+visible edge relative to the persisted node coordinates. Release immediately
+restored hover, so the card appeared to land off target despite correct stored
+coordinates. Note, Text, and Web wrappers now keep identical geometry through
+pickup, travel, release, and the post-drop pointer dwell. A regression test
+guards those wrapper selectors.
+
+### Hover scale with post-drop suppression
+
+Hover may scale Note, Text, and Web nodes to 1.006, but crossing the drag
+threshold immediately restores 1:1 geometry. When dragging ends, a local
+suppression class prevents hover scale from returning under the stationary
+pointer. Suppression clears after the pointer leaves, or on the next genuine
+hover cycle when the drop ended outside the card and no suppression was
+needed. A browser-generated mouseenter after release only updates pointer
+containment and cannot clear suppression; mouseleave is the sole unlock event.
+Drag travel and the persisted resting position therefore use the same
+geometry.
+
+### Hover scale deferred
+
+The hover-scale experiment and its post-drop suppression state were removed
+after interaction testing. Note, Text, and Web now use the original
+geometry-invariant model again: hover, pickup, travel, and release change only
+surface, border, and shadow. This keeps the interaction quiet and removes an
+entire pointer-event state machine from the node wrapper.
+
+final result: passed

--- a/apps/canvas-workspace/design-qa.md
+++ b/apps/canvas-workspace/design-qa.md
@@ -45,6 +45,89 @@ final result: passed
 
 ---
 
+# Spatial-inspired workspace shell — design QA
+
+## Visual sources
+
+- Source visual truth:
+  `/Users/jasperhu/project/pulse-agent/apps/canvas-workspace/.harness/spatial-reference.png`
+  - 1223 × 768 pixels.
+  - Current Spatial desktop app, captured through the macOS app surface.
+- Implementation:
+  `/Users/jasperhu/project/pulse-agent/apps/canvas-workspace/.harness/spatial-mono-light-toolbar-final.png`
+  - 2400 × 1544 pixels.
+  - Pulse Canvas production build at a 1200 × 772 CSS viewport and device
+    scale factor 2.
+- State: Spatial shows a freeform personal board; Pulse Canvas shows the
+  harness demo workspace with the product sidebar and one Frame. Content and
+  navigation differences are intentional. The comparison targets the shared
+  visual grammar: canvas temperature, paper-object contrast, typography,
+  elevation, frame saturation, and floating controls.
+
+## Findings
+
+No actionable P0, P1, or P2 differences remain for the intended adaptation.
+
+- Fonts and typography: app chrome keeps Pulse's monospaced identity rather
+  than copying Spatial's system-sans treatment. Reading surfaces retain the
+  quieter humanist sans stack, so node content remains legible at overview
+  scale.
+- Spacing and layout rhythm: Pulse keeps its denser sidebar and creation rail
+  because Coding, Terminal, and Agent tools need persistent discoverability.
+  Cards remain generously separated and the bottom controls now read as
+  independent floating objects rather than a fixed application footer.
+- Colors and visual tokens: the former warm canvas is replaced by a cool
+  neutral grey. Borders and ink are neutral rather than brown-grey, Frames use
+  a whisper tint instead of a large saturated wash, and sidebar selection is
+  neutral. Pulse blue remains limited to meaningful state and identity.
+- Image quality and asset fidelity: no new raster or vector assets were needed.
+  Existing product icons remain sharp at 2× density, and no placeholder,
+  handcrafted SVG, or CSS illustration was introduced.
+- Copy and content: product copy and node content are unchanged. The redesign
+  changes presentation only.
+
+The final full-view capture keeps the palette, cards, toolbar, and type
+hierarchy legible, so a separate focused crop was not needed.
+
+## Comparison history
+
+1. Baseline Pulse Canvas used a warm grey canvas, brown-grey ink, monospaced
+   app chrome, visibly colored Frame washes, and a white creation toolbar.
+2. First pass introduced the cool neutral palette, system-sans chrome, softer
+   Frame color, neutral sidebar selection, translucent white zoom controls, and
+   cooler elevation.
+3. Side-by-side review showed that the white creation rail still made the shell
+   read primarily as the previous Pulse design.
+4. A charcoal creation rail was tested, but it competed too strongly with the
+   workspace content. User review also confirmed that Mono is part of Pulse's
+   visual identity.
+5. The final pass restores Mono app chrome and uses a translucent white
+   creation rail. Spatial's cool-grey work surface, white-paper objects, softer
+   Frames, and restrained elevation remain.
+
+## Primary interactions checked
+
+- Launched the production Electron build in the disposable demo profile.
+- Confirmed the live WebView remained registered and rendered after the global
+  palette and typography changes.
+- Switched the floating toolbar from Select to Pan and confirmed the active
+  treatment moved to the selected tool.
+- Inspected the renderer screenshot at the production 1200 × 772 viewport.
+- Checked Electron logs; no renderer or WebView errors were emitted.
+- TypeScript, UI-reuse governance, file-size governance, and Canvas contract
+  checks passed.
+
+## Follow-up polish
+
+- P3: review one dense real workspace at Fit and close zoom before deciding
+  whether the cool canvas should move one step darker.
+- P3: review the light creation rail over very pale node content to confirm the
+  separation remains sufficient at every zoom level.
+
+final result: passed
+
+---
+
 # Scheduled run feedback and dock-responsive rows — design QA
 
 - Source visual truth: the annotated follow-up screenshot `codex-clipboard-54a8…png`.

--- a/apps/canvas-workspace/src/main/__tests__/ui-reuse-governance.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/ui-reuse-governance.test.ts
@@ -354,7 +354,7 @@ const RATCHET_BASELINE: Record<string, number> = {
   // 1822→1814 (Spatial object states): Note / Text / Web now share one
   // selection token and neutral selected surfaces instead of eight
   // node-local blue literals.
-  hardcodedColorLiterals: 1814,
+  hardcodedColorLiterals: 1812,
   // box-shadow declaration lines not using a var(--shadow-*) token — same
   // line-based style as borderRadiusLiterals. frontend.md previously said
   // "measured but not yet gated"; gated 2026-07-08 at the as-measured

--- a/apps/canvas-workspace/src/main/__tests__/ui-reuse-governance.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/ui-reuse-governance.test.ts
@@ -347,7 +347,14 @@ const RATCHET_BASELINE: Record<string, number> = {
   // states (-4), and node-header focus uses the existing accent token (-1).
   // 1827→1824 (chat rail cleanup): grouped source labels remove the repeated
   // per-row metadata colors and reuse shared surface/text tokens.
-  hardcodedColorLiterals: 1824,
+  // 1824→1823 (content-node polish): the Text floating toolbar now reuses
+  // --shadow-float, removing its repeated rgba shadow color.
+  // 1823→1822 (content-node hierarchy): the Text selection ring moved to
+  // the shared --shadow-content-selection token.
+  // 1822→1814 (Spatial object states): Note / Text / Web now share one
+  // selection token and neutral selected surfaces instead of eight
+  // node-local blue literals.
+  hardcodedColorLiterals: 1814,
   // box-shadow declaration lines not using a var(--shadow-*) token — same
   // line-based style as borderRadiusLiterals. frontend.md previously said
   // "measured but not yet gated"; gated 2026-07-08 at the as-measured
@@ -409,7 +416,11 @@ const RATCHET_BASELINE: Record<string, number> = {
   // is gone — flat labels per the reference.
   // 147→146 (editor polish): node-header keyboard focus moved from a literal
   // box-shadow ring to the shared accent outline.
-  shadowLiterals: 146,
+  // 146→144 (content-node polish): the Text selected state and floating
+  // toolbar now reuse shared focus/floating shadow tokens.
+  // 144→141 (Spatial object states): Note / Text / Web reuse the scoped
+  // content-object default, hover, drag, and selection elevation tokens.
+  shadowLiterals: 141,
   // z-index declarations with a raw numeric value >= 10, not via var() —
   // targets only the cross-surface stacking band. The documented rule
   // permits low local stacking inside a single component (60 of 93 raw

--- a/apps/canvas-workspace/src/renderer/src/components/Canvas/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Canvas/index.css
@@ -72,9 +72,9 @@
   inset: 0;
   pointer-events: none;
   background-image:
-    radial-gradient(circle, rgba(0, 0, 0, 0.08) 0.7px, transparent 0.7px);
-  background-size: 24px 24px;
-  background-color: #eeecea;
+    radial-gradient(circle, rgba(35, 37, 42, 0.055) 0.7px, transparent 0.7px);
+  background-size: 28px 28px;
+  background-color: var(--bg-canvas);
 }
 
 .canvas-bottom-chrome {

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/dragGeometry.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/dragGeometry.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const canvasNodeCss = readFileSync(
+  fileURLToPath(new URL('./index.css', import.meta.url)),
+  'utf8',
+);
+const textNodeCss = readFileSync(
+  fileURLToPath(new URL('../TextNodeBody/index.css', import.meta.url)),
+  'utf8',
+);
+
+const ruleBody = (css: string, selector: string): string => {
+  const start = css.indexOf(`${selector} {`);
+  expect(start, `Missing CSS rule: ${selector}`).toBeGreaterThanOrEqual(0);
+  const bodyStart = css.indexOf('{', start) + 1;
+  const bodyEnd = css.indexOf('}', bodyStart);
+  return css.slice(bodyStart, bodyEnd);
+};
+
+const expectGeometryInvariant = (body: string): void => {
+  expect(body).not.toMatch(/\b(?:scale|translate|rotate|transform|animation)\s*:/);
+};
+
+describe('content-node drag geometry', () => {
+  it('keeps Note, Text, and Web wrapper geometry invariant on hover', () => {
+    expectGeometryInvariant(ruleBody(
+      canvasNodeCss,
+      '.canvas-node.canvas-node--file:not(.canvas-node--dragging):not(.canvas-node--resizing):hover',
+    ));
+    expectGeometryInvariant(ruleBody(
+      canvasNodeCss,
+      '.canvas-node--iframe:not(.canvas-node--dragging):not(.canvas-node--resizing):hover',
+    ));
+    expectGeometryInvariant(ruleBody(
+      textNodeCss,
+      '.canvas-node--text:not(.canvas-node--dragging):not(.canvas-node--resizing):hover',
+    ));
+  });
+
+  it('restores exact wrapper geometry while dragging', () => {
+    const draggingBody = ruleBody(
+      canvasNodeCss,
+      [
+        '.canvas-node--file.canvas-node--dragging,',
+        '.canvas-node--iframe.canvas-node--dragging,',
+        '.canvas-node--text.canvas-node--dragging',
+      ].join('\n'),
+    );
+    expectGeometryInvariant(draggingBody);
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/CanvasNodeView/index.css
@@ -69,18 +69,27 @@
   container-type: inline-size;
   background: var(--note-paper);
   border-color: var(--note-border);
-  border-radius: var(--radius-xl);
+  border-radius: var(--content-node-radius);
   box-shadow: var(--note-shadow);
+  transition:
+    box-shadow 200ms cubic-bezier(0.2, 0.75, 0.25, 1),
+    border-color 160ms ease;
 }
 
-.canvas-node.canvas-node--file:hover {
+.canvas-node.canvas-node--file:not(.canvas-node--dragging):not(.canvas-node--resizing):hover {
   box-shadow: var(--note-shadow-hover);
   border-color: var(--note-border-hover);
 }
 
 .canvas-node--file.canvas-node--selected {
   border-color: var(--accent-border);
-  box-shadow: var(--note-shadow), var(--shadow-focus);
+  outline: none;
+  box-shadow: var(--note-shadow), var(--shadow-content-selection);
+}
+
+.canvas-node.canvas-node--file.canvas-node--selected:not(.canvas-node--dragging):not(.canvas-node--resizing):hover {
+  border-color: var(--accent-border);
+  box-shadow: var(--note-shadow-hover), var(--shadow-content-selection);
 }
 
 /* Reference nodes reuse the target node's native body rendering. The outer
@@ -175,12 +184,12 @@
 .canvas-node--file>.node-header {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   background: transparent;
   border-bottom: 1px solid transparent;
   min-height: 0;
-  /* Horizontal inset visually aligns with the editor's 32px text column. */
-  padding: 12px 24px;
+  /* The node title is metadata; the Markdown document owns the main heading. */
+  padding: 18px 40px 4px;
   transition: border-color 0.15s ease;
 }
 
@@ -189,18 +198,15 @@
   display: none;
 }
 
-.canvas-node--file.canvas-node--selected>.node-header {
-  border-bottom-color: var(--border-light);
-}
-
 .canvas-node--file>.node-header .node-title {
   flex: 1 1 auto;
   min-width: 0;
-  font-weight: 700;
-  font-size: 18px;
-  line-height: 1.3;
-  color: var(--text);
-  letter-spacing: -0.015em;
+  font-family: var(--font-mono);
+  font-weight: 500;
+  font-size: 11px;
+  line-height: 1.25;
+  color: var(--text-secondary);
+  letter-spacing: 0.06em;
   padding: 0;
   transition: color 0.12s ease;
 }
@@ -221,7 +227,12 @@
 
 .canvas-node--file>.node-header .node-time-label {
   flex: 0 0 auto;
-  opacity: 0.72;
+  opacity: 0;
+}
+
+.canvas-node--file:hover>.node-header .node-time-label,
+.canvas-node--file.canvas-node--selected>.node-header .node-time-label {
+  opacity: 0.58;
 }
 
 .canvas-node--file>.node-header .node-header__actions {
@@ -254,7 +265,13 @@
 
 .canvas-node--file:hover>.node-header .node-title,
 .canvas-node--file.canvas-node--selected>.node-header .node-title {
-  color: var(--text);
+  color: var(--text-secondary);
+}
+
+@container (max-width: 560px) {
+  .canvas-node--file>.node-header {
+    padding-inline: 32px;
+  }
 }
 
 @container (max-width: 360px) {
@@ -311,32 +328,85 @@
 
 .canvas-node--iframe {
   border-color: rgba(55, 53, 47, 0.1);
+  border-radius: var(--content-node-radius);
+  box-shadow: var(--content-node-shadow);
+  transition:
+    box-shadow 200ms cubic-bezier(0.2, 0.75, 0.25, 1),
+    border-color 160ms ease;
 }
 
-.canvas-node--iframe:hover {
-  border-color: rgba(35, 131, 226, 0.22);
+.canvas-node--iframe:not(.canvas-node--dragging):not(.canvas-node--resizing):hover {
+  border-color: var(--note-border-hover);
+  box-shadow: var(--content-node-shadow-hover);
 }
 
 .canvas-node--iframe.canvas-node--selected {
-  border-color: rgba(35, 131, 226, 0.46);
-  box-shadow:
-    var(--shadow-card-hover),
-    0 0 0 2px rgba(35, 131, 226, 0.14),
-    0 0 0 6px rgba(35, 131, 226, 0.05);
+  border-color: var(--accent-border);
+  outline: none;
+  box-shadow: var(--content-node-shadow), var(--shadow-content-selection);
+}
+
+.canvas-node--iframe.canvas-node--selected:not(.canvas-node--dragging):not(.canvas-node--resizing):hover {
+  border-color: var(--accent-border);
+  box-shadow: var(--content-node-shadow-hover), var(--shadow-content-selection);
 }
 
 .canvas-node--iframe>.node-header {
   position: relative;
+  min-height: 36px;
+  padding: 7px 10px 7px 12px;
+  background: color-mix(in srgb, var(--surface) 94%, transparent);
+  border-bottom-color: color-mix(in srgb, var(--border-light) 72%, transparent);
+}
+
+.canvas-node--iframe>.node-header .node-title {
+  padding-inline: 2px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+.canvas-node--iframe:hover>.node-header .node-title,
+.canvas-node--iframe.canvas-node--selected>.node-header .node-title {
+  color: var(--text);
+}
+
+/* A page title or favicon already identifies a Web node. Avoid adding the
+ * generic iframe type glyph when no favicon is available. */
+.canvas-node--iframe>.node-header .node-type-badge--iframe {
+  display: none;
 }
 
 .canvas-node--iframe.canvas-node--selected>.node-header {
-  border-bottom-color: rgba(35, 131, 226, 0.18);
+  border-bottom-color: var(--border-light);
 }
 
 .canvas-node--dragging {
   box-shadow: var(--shadow-drag);
   z-index: 100;
   opacity: 0.97;
+}
+
+.canvas-node--file.canvas-node--dragging,
+.canvas-node--iframe.canvas-node--dragging,
+.canvas-node--text.canvas-node--dragging {
+  border-color: var(--note-border-hover);
+  box-shadow: var(--content-node-shadow-drag);
+  opacity: 1;
+  transition:
+    box-shadow 200ms cubic-bezier(0.2, 0.75, 0.25, 1),
+    border-color 160ms ease;
+  will-change: box-shadow;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .canvas-node--file,
+  .canvas-node--iframe,
+  .canvas-node--text {
+    transition: none;
+  }
+
 }
 
 .canvas-node--resizing {
@@ -925,10 +995,10 @@
  * reference) and frames (their tinted wash carries the edge) opt out by not
  * being listed; fullscreen nodes are excluded because the transform is dead
  * there while --canvas-scale still holds the old value. */
-.canvas-transform--small .canvas-node--file:not(.canvas-node--fullscreen),
+.canvas-transform--small .canvas-node--file:not(.canvas-node--fullscreen):not(.canvas-node--selected),
 .canvas-transform--small .canvas-node--terminal:not(.canvas-node--fullscreen),
 .canvas-transform--small .canvas-node--agent:not(.canvas-node--fullscreen),
-.canvas-transform--small .canvas-node--iframe:not(.canvas-node--fullscreen),
+.canvas-transform--small .canvas-node--iframe:not(.canvas-node--fullscreen):not(.canvas-node--selected),
 .canvas-transform--small .canvas-node--plugin:not(.canvas-node--fullscreen),
 .canvas-transform--small .canvas-node--dynamic-app:not(.canvas-node--fullscreen) {
   outline: calc(1px / var(--canvas-scale, 1)) solid rgba(55, 53, 47, 0.16);

--- a/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FileNodeBody/index.css
@@ -78,6 +78,9 @@
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  /* A stable paper footer keeps the last visible line away from the rounded
+   * edge even before the editor reaches its own end-of-document padding. */
+  padding-bottom: 16px;
 }
 
 /* Node-mention chips: `@`-links to other canvas nodes, rendered inline. */
@@ -129,8 +132,30 @@
   flex: 1;
   overflow-y: auto;
   height: 100%;
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
   /* Scoped paper colour driven by the card root so colour-mode swaps
    * or per-node tints can override in one place. */
+}
+
+.note-tiptap-editor:hover {
+  scrollbar-color: var(--border) transparent;
+}
+
+.note-tiptap-editor::-webkit-scrollbar {
+  width: 8px;
+}
+
+.note-tiptap-editor::-webkit-scrollbar-thumb {
+  border: 2px solid transparent;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  background-clip: content-box;
+}
+
+.note-tiptap-editor:hover::-webkit-scrollbar-thumb {
+  background: var(--border);
+  background-clip: content-box;
 }
 
 /* Generous reading column inspired by Notion/Heptabase pages.
@@ -142,10 +167,10 @@
   width: min(100%, 900px);
   min-height: 100%;
   margin-inline: auto;
-  padding: 28px 32px 96px 52px;
+  padding: 12px 40px 72px;
   font-family: var(--font-ui);
   font-size: 16px;
-  line-height: 1.62;
+  line-height: 1.7;
   color: var(--text);
   outline: none;
   caret-color: var(--accent);
@@ -166,12 +191,12 @@
 }
 
 .note-tiptap-editor .ProseMirror h1 {
-  font-size: 1.9em;
-  font-weight: 650;
+  font-size: 1.69em;
+  font-weight: 590;
   margin: 0.95em 0 0.4em;
   color: var(--text);
-  line-height: 1.26;
-  letter-spacing: -0.025em;
+  line-height: 1.2;
+  letter-spacing: 0;
   overflow-wrap: anywhere;
 }
 
@@ -180,21 +205,21 @@
 }
 
 .note-tiptap-editor .ProseMirror h2 {
-  font-size: 1.42em;
-  font-weight: 650;
+  font-size: 1.38em;
+  font-weight: 590;
   margin: 1.5em 0 0.5em;
   color: var(--text);
   line-height: 1.34;
-  letter-spacing: -0.015em;
+  letter-spacing: 0;
   overflow-wrap: anywhere;
 }
 
 .note-tiptap-editor .ProseMirror h3 {
   font-size: 1.16em;
-  font-weight: 650;
+  font-weight: 590;
   margin: 1.25em 0 0.4em;
   color: var(--text);
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
   overflow-wrap: anywhere;
 }
 
@@ -489,7 +514,7 @@
 
 @container (max-width: 560px) {
   .note-tiptap-editor .ProseMirror {
-    padding: 24px;
+    padding: 12px 32px 72px;
     font-size: 15.5px;
   }
 

--- a/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FloatingToolbar/index.css
@@ -6,12 +6,14 @@
   max-width: calc(100% - 32px);
   display: flex;
   align-items: center;
-  gap: 2px;
-  padding: 4px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
+  gap: 3px;
+  padding: 5px;
+  background: color-mix(in srgb, var(--surface) 94%, transparent);
+  border: 1px solid color-mix(in srgb, var(--text) 8%, transparent);
+  border-radius: var(--radius-xl);
   box-shadow: var(--shadow-float);
+  -webkit-backdrop-filter: blur(18px);
+  backdrop-filter: blur(18px);
   z-index: var(--layer-canvas-chrome);
 }
 
@@ -38,8 +40,8 @@
 .toolbar-divider {
   width: 1px;
   height: 20px;
-  background: var(--border);
-  margin: 0 4px;
+  background: color-mix(in srgb, var(--text) 10%, transparent);
+  margin: 0 5px;
   flex: 0 0 auto;
 }
 
@@ -49,7 +51,7 @@
   min-width: 32px;
   border: none;
   background: transparent;
-  border-radius: var(--radius);
+  border-radius: var(--radius-lg);
   cursor: pointer;
   display: inline-flex;
   align-items: center;
@@ -80,7 +82,7 @@
 .toolbar-btn:hover,
 .toolbar-btn:focus-visible {
   outline: none;
-  background: rgba(0, 0, 0, 0.04);
+  background: color-mix(in srgb, var(--text) 6%, transparent);
   color: var(--text);
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/FrameNodeBody/index.css
@@ -7,12 +7,12 @@
  * swatch identity; CanvasNodeView/utils.ts parses the hue/chroma out of
  * `data.color` and exposes them as CSS custom props.
  *
- *   pillBg        -> L 0.955  Cx0.42  (pale tinted label, NOT a solid chip)
- *   pillText      -> L 0.52   Cx2.4   (colored label text + icon strokes)
- *   countBg       -> L 0.90   Cx0.75  (tinted badge, colored text)
- *   bodyTint      -> L 0.979  Cx0.17  (barely-there wash)
- *   bodyTintFocus -> L 0.972  Cx0.20
- *   border        -> L 0.925  Cx0.45
+ *   pillBg        -> L 0.955  Cx0.30  (pale tinted label, NOT a solid chip)
+ *   pillText      -> L 0.52   Cx2.0   (colored label text + icon strokes)
+ *   countBg       -> L 0.90   Cx0.55  (tinted badge, colored text)
+ *   bodyTint      -> L 0.979  Cx0.07  (cool-grey surface with a hue whisper)
+ *   bodyTintFocus -> L 0.972  Cx0.12
+ *   border        -> L 0.925  Cx0.24
  *   borderHover   -> L 0.87   Cx0.70
  *   borderFocus   -> L 0.80   Cx0.38
  *   identity      -> L 0.62   Cx0.95  (selection ring, focus mode border)
@@ -44,9 +44,9 @@
    * keeping this as a variable lets focus/experiments still tune it. */
   --_a: var(--frame-bg-alpha, 0.96);
 
-  background: oklch(0.979 calc(var(--_c) * 0.17) var(--_h) / var(--_a));
-  border: 1px solid oklch(0.925 calc(var(--_c) * 0.45) var(--_h));
-  border-radius: var(--radius-md);
+  background: oklch(0.979 calc(var(--_c) * 0.07) var(--_h) / var(--_a));
+  border: 1px solid oklch(0.925 calc(var(--_c) * 0.24) var(--_h));
+  border-radius: var(--radius-xl);
   box-shadow: none;
   /* Header pill floats above the body, so we mustn't clip it. */
   overflow: visible;
@@ -89,7 +89,7 @@
 
 .canvas-node--frame.canvas-node--focus-mode-focused,
 .canvas-node--frame.canvas-node--focus-mode-focused.canvas-node--selected {
-  background: oklch(0.972 calc(var(--_c) * 0.20) var(--_h) / 0.97);
+  background: oklch(0.972 calc(var(--_c) * 0.12) var(--_h) / 0.97);
   border-style: solid;
   border-color: oklch(0.80 calc(var(--_c) * 0.38) var(--_h));
   box-shadow: 0 0 0 2px oklch(0.62 calc(var(--_c) * 0.95) var(--_h) / 0.28);
@@ -143,11 +143,11 @@
    * saturation lives in the type, not in a solid block. Still legible as a
    * section anchor at overview zoom via the counter-scaled transform; the
    * graphite preset degrades to a gray label. */
-  background: oklch(0.955 calc(var(--_c) * 0.42) var(--_h));
+  background: oklch(0.955 calc(var(--_c) * 0.30) var(--_h));
   border: none;
   border-radius: var(--radius-md);
-  color: oklch(0.52 calc(var(--_c) * 2.4) var(--_h));
-  box-shadow: none;
+  color: oklch(0.52 calc(var(--_c) * 2.0) var(--_h));
+  box-shadow: var(--shadow-sm);
 
   /* Header lives inside .canvas-transform; same scale-clamping logic as
    * before so the pill stays readable at deep zoom-out without going
@@ -158,14 +158,14 @@
 }
 
 .canvas-node--frame .node-header .node-type-badge--frame {
-  color: oklch(0.52 calc(var(--_c) * 2.4) var(--_h));
+  color: oklch(0.52 calc(var(--_c) * 2.0) var(--_h));
   width: 15px;
   height: 15px;
 }
 
 .canvas-node--frame .node-header .node-title {
   flex: 0 1 auto;
-  color: oklch(0.52 calc(var(--_c) * 2.4) var(--_h));
+  color: oklch(0.52 calc(var(--_c) * 2.0) var(--_h));
   font-weight: 700;
   font-size: 14px;
   line-height: 1.2;
@@ -197,8 +197,8 @@
   padding: 0 6px;
   border: 0;
   border-radius: 7px;
-  background: oklch(0.90 calc(var(--_c) * 0.75) var(--_h));
-  color: oklch(0.52 calc(var(--_c) * 2.4) var(--_h));
+  background: oklch(0.90 calc(var(--_c) * 0.55) var(--_h));
+  color: oklch(0.52 calc(var(--_c) * 2.0) var(--_h));
   cursor: pointer;
   transition:
     background 0.14s ease,

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/iframeBar.css
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/iframeBar.css
@@ -22,8 +22,8 @@
 }
 
 .canvas-node--iframe.canvas-node--selected .iframe-bar {
-  border-bottom-color: rgba(35, 131, 226, 0.16);
-  background: color-mix(in srgb, var(--accent-light) 34%, var(--surface));
+  border-bottom-color: var(--border-light);
+  background: var(--surface);
 }
 
 /* In fullscreen the bar stays docked at the top — same as the windowed

--- a/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/IframeNodeBody/index.css
@@ -41,7 +41,7 @@
 }
 
 .canvas-node--iframe.canvas-node--selected .iframe-frame-wrapper {
-  box-shadow: inset 0 0 0 1px rgba(35, 131, 226, 0.1);
+  box-shadow: none;
 }
 
 .iframe-frame-wrapper--streaming {

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
@@ -2,8 +2,8 @@
 
 .sidebar {
   width: var(--sidebar-width);
-  background: var(--surface);
-  border-right: 1px solid var(--border);
+  background: color-mix(in srgb, var(--surface) 96%, var(--bg-canvas));
+  border-right: 1px solid color-mix(in srgb, var(--text) 8%, transparent);
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
@@ -89,12 +89,12 @@
 }
 
 .sidebar-nav-item--active {
-  background: var(--accent-light);
-  color: var(--accent);
+  background: color-mix(in srgb, var(--text) 6%, transparent);
+  color: var(--text);
 }
 
 .sidebar-nav-item--active:hover {
-  background: var(--accent-light);
+  background: color-mix(in srgb, var(--text) 8%, transparent);
 }
 
 .sidebar-nav-icon {
@@ -108,7 +108,7 @@
 }
 
 .sidebar-nav-item--active .sidebar-nav-icon {
-  color: var(--accent);
+  color: var(--text);
 }
 
 .sidebar-nav-label {
@@ -205,12 +205,12 @@
 }
 
 .sidebar-item--active {
-  background: var(--accent-light);
-  color: var(--accent);
+  background: color-mix(in srgb, var(--text) 6%, transparent);
+  color: var(--text);
 }
 
 .sidebar-item--active:hover {
-  background: var(--accent-light);
+  background: color-mix(in srgb, var(--text) 8%, transparent);
 }
 
 .sidebar-item--muted {

--- a/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/TextNodeBody/index.css
@@ -32,6 +32,10 @@
   /* Default `.canvas-node` is flex-column; we don't need that structure here
    * because the body owns the full shape. */
   display: block;
+  transition:
+    background 160ms ease,
+    border-color 160ms ease,
+    box-shadow 200ms cubic-bezier(0.2, 0.75, 0.25, 1);
 }
 
 /* Height is always content-driven — override the inline height React writes
@@ -47,17 +51,27 @@
   max-width: 600px;
 }
 
-.canvas-node--text:hover {
-  border-color: rgba(0, 0, 0, 0.08);
+.canvas-node--text:not(.canvas-node--dragging):not(.canvas-node--resizing):hover {
+  border-color: rgba(55, 53, 47, 0.08);
+  background: color-mix(in srgb, var(--surface) 42%, transparent);
 }
 
 .canvas-node--text.canvas-node--selected {
   border-color: var(--accent-border);
-  box-shadow: 0 0 0 1.5px rgba(35, 131, 226, 0.35);
+  background: transparent;
+  outline: none;
+  box-shadow: var(--shadow-content-selection);
+}
+
+.canvas-node--text.canvas-node--selected:not(.canvas-node--dragging):not(.canvas-node--resizing):hover {
+  border-color: var(--accent-border);
+  background: color-mix(in srgb, var(--surface) 42%, transparent);
+  box-shadow: var(--content-node-shadow-hover), var(--shadow-content-selection);
 }
 
 .canvas-node--text.canvas-node--dragging {
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
+  background: color-mix(in srgb, var(--surface) 42%, transparent);
+  box-shadow: var(--content-node-shadow-drag);
 }
 
 /* --- Header: hidden by default, compact toolbar on hover/selected -------- */
@@ -73,8 +87,8 @@
   padding: 4px 6px;
   background: var(--surface, #fff);
   border: 1px solid var(--border-light, rgba(0, 0, 0, 0.08));
-  border-radius: var(--radius-sm);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-float);
   /* Keep toolbar size constant regardless of canvas zoom. */
   transform: scale(calc(1 / var(--canvas-scale, 1)));
   transform-origin: left bottom;
@@ -126,8 +140,8 @@
   height: auto;
   min-width: 32px;
   min-height: 28px;
-  padding: 6px 10px;
-  border-radius: var(--radius-md, 6px);
+  padding: 8px 12px;
+  border-radius: var(--radius-lg);
   outline: none;
   word-break: break-word;
   overflow-wrap: anywhere;

--- a/apps/canvas-workspace/src/renderer/src/components/ZoomIndicator/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ZoomIndicator/index.css
@@ -25,10 +25,12 @@
 .zoom-indicator {
   height: 28px;
   padding: 0 10px;
-  border: 1px solid var(--border);
-  background: var(--surface);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow-sm);
+  border: 1px solid color-mix(in srgb, var(--text) 8%, transparent);
+  background: color-mix(in srgb, var(--surface) 94%, transparent);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-float);
+  -webkit-backdrop-filter: blur(18px);
+  backdrop-filter: blur(18px);
   cursor: pointer;
   font-size: 11px;
   font-weight: 500;

--- a/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useNodes.ts
@@ -807,7 +807,12 @@ export const useNodes = (
       const targets = nodesRef.current.filter((n) => idSet.has(n.id));
       if (targets.length === 0) return null;
 
-      const PADDING = { x: 40, top: 72, bottom: 40 };
+      /* Frames need a visible footer at overview zoom. At the common 44%
+       * canvas scale, 40px collapsed to an ~18px strip and the child cards
+       * read as if they were sitting on the frame edge. Keep the side inset
+       * compact, reserve the title zone above, and give the lower edge a
+       * distinct 64px spatial footer. */
+      const PADDING = { x: 40, top: 72, bottom: 64 };
       let minX = Infinity;
       let minY = Infinity;
       let maxX = -Infinity;

--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -7,18 +7,18 @@
 
 :root {
   color-scheme: light;
-  --bg: #f8f8f7;
-  /* v4 quiet-label ground (2026-07-24, vision-read from the tinted-label
-   * reference board): cool near-white; the whisper washes and colored
-   * label text carry the structure, so the canvas stays almost paper. */
-  --bg-canvas: #fafafa;
+  --bg: #f6f6f5;
+  /* Spatial-inspired cool-grey work surface. The canvas is deliberately
+   * darker than the app chrome so white content cards read as physical
+   * objects without needing heavy borders or saturated frame fills. */
+  --bg-canvas: #e9eaec;
   --surface: #ffffff;
-  --surface-hover: #fafaf9;
-  --border: #e8e5e0;
-  --border-light: #f0eeea;
-  --text: #37352f;
-  --text-secondary: #787774;
-  --text-muted: #b4b0a8;
+  --surface-hover: #f5f5f4;
+  --border: #e3e4e5;
+  --border-light: #ececee;
+  --text: #28282a;
+  --text-secondary: #717174;
+  --text-muted: #aaa9ad;
   /* Converged 2026-07-07 from phantom-token demand: these names were already
      referenced across the renderer (with fallbacks or, for --text-*, nothing).
      Single-fallback tokens keep their exact fallback value (zero visual
@@ -50,8 +50,8 @@
     0 3px 10px color-mix(in srgb, var(--text) 6%, transparent);
   --content-node-selection: var(--accent);
   --shadow-content-selection: 0 0 0 1px var(--accent-soft);
-  --note-border: rgba(55, 53, 47, 0.09);
-  --note-border-hover: rgba(55, 53, 47, 0.14);
+  --note-border: rgba(35, 35, 38, 0.08);
+  --note-border-hover: rgba(35, 35, 38, 0.14);
   --note-shadow: var(--content-node-shadow);
   --note-shadow-hover: var(--content-node-shadow-hover);
   --note-callout-bg: #faf6ef;
@@ -67,7 +67,7 @@
   --surface-alt: rgba(0, 0, 0, 0.05);
   --surface-subtle: rgba(0, 0, 0, 0.02);
   --accent: #2383e2;
-  --accent-light: rgba(35, 131, 226, 0.08);
+  --accent-light: rgba(35, 131, 226, 0.07);
   --accent-border: rgba(35, 131, 226, 0.45);
   --accent-file: #d9730d;
   --accent-term: #0f7b6c;
@@ -81,11 +81,11 @@
   --error: #c0392b;
   --text-warning: #b45309;
   --overlay-backdrop: rgba(32, 34, 37, 0.22);
-  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.04);
-  --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.05), 0 5px 14px rgba(0, 0, 0, 0.07);
-  --shadow-card-hover: 0 2px 6px rgba(0, 0, 0, 0.07), 0 9px 24px rgba(0, 0, 0, 0.09);
+  --shadow-sm: 0 1px 3px rgba(20, 22, 26, 0.04);
+  --shadow-card: 0 1px 3px rgba(20, 22, 26, 0.05), 0 8px 22px rgba(20, 22, 26, 0.07);
+  --shadow-card-hover: 0 2px 6px rgba(20, 22, 26, 0.07), 0 12px 30px rgba(20, 22, 26, 0.09);
   --shadow-drag: 0 8px 28px rgba(0, 0, 0, 0.1), 0 2px 8px rgba(0, 0, 0, 0.06);
-  --shadow-float: 0 4px 24px rgba(0, 0, 0, 0.08), 0 0 0 1px rgba(0, 0, 0, 0.04);
+  --shadow-float: 0 10px 34px rgba(20, 22, 26, 0.1), 0 0 0 1px rgba(20, 22, 26, 0.05);
   /* C2 exact-value tokenization (2026-07-10): the dominant focus-ring
      cluster, byte-identical across 9 call sites — minted verbatim, no
      value change. Near-variants (2px ring, other opacities) stay literal;
@@ -109,10 +109,8 @@
   --radius-pill: 999px;
   --font: "SF Mono", "Fira Code", "Cascadia Code", Menlo, monospace;
   --font-mono: "SF Mono", "Fira Code", "Cascadia Code", Menlo, monospace;
-  /* Humanist sans for canvas READING surfaces (node/frame/group titles) —
-   * same stack as the note editor (FileNodeBody). App chrome stays on the
-   * mono --font identity; this token is only for text the user reads as
-   * knowledge-map content, where mono's terminal texture reads as noise. */
+  /* Humanist sans for canvas reading surfaces. App chrome, code, terminal
+   * content, and compact Note metadata keep Pulse's mono identity. */
   --font-ui: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI",
     "Inter", "Helvetica Neue", Arial, sans-serif;
   --sidebar-width: 240px;

--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -35,10 +35,25 @@
   /* Pure white per the Heptabase reference — cards pop off the tinted
    * frame washes; the warm cream paper read as one more beige layer. */
   --note-paper: #ffffff;
-  --note-border: rgba(55, 53, 47, 0.12);
-  --note-border-hover: rgba(55, 53, 47, 0.16);
-  --note-shadow: 0 1px 2px rgba(55, 53, 47, 0.04), 0 5px 16px rgba(55, 53, 47, 0.055);
-  --note-shadow-hover: 0 1px 2px rgba(55, 53, 47, 0.045), 0 7px 20px rgba(55, 53, 47, 0.07);
+  /* Spatial object system: content objects float above the neutral canvas.
+   * These are intentionally scoped to Note / Text / Web nodes; app chrome
+   * keeps the denser legacy elevation scale. */
+  --content-node-radius: 18px;
+  --content-node-shadow:
+    0 5px 18px color-mix(in srgb, var(--text) 6%, transparent),
+    0 1px 3px color-mix(in srgb, var(--text) 4%, transparent);
+  --content-node-shadow-hover:
+    0 10px 28px color-mix(in srgb, var(--text) 10%, transparent),
+    0 2px 7px color-mix(in srgb, var(--text) 5%, transparent);
+  --content-node-shadow-drag:
+    0 14px 34px color-mix(in srgb, var(--text) 13%, transparent),
+    0 3px 10px color-mix(in srgb, var(--text) 6%, transparent);
+  --content-node-selection: var(--accent);
+  --shadow-content-selection: 0 0 0 1px var(--accent-soft);
+  --note-border: rgba(55, 53, 47, 0.09);
+  --note-border-hover: rgba(55, 53, 47, 0.14);
+  --note-shadow: var(--content-node-shadow);
+  --note-shadow-hover: var(--content-node-shadow-hover);
   --note-callout-bg: #faf6ef;
   --note-callout-border: #eee8de;
   --note-inline-code-bg: rgba(55, 53, 47, 0.07);

--- a/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/nodeFactory.ts
@@ -19,7 +19,7 @@ export type CreatableCanvasNodeType = Extract<
 >;
 
 const NODE_DEFAULTS: Record<CanvasNode['type'], { title: string; width: number; height: number }> = {
-  file:     { title: 'Untitled', width: 420, height: 360 },
+  file:     { title: 'Untitled', width: 360, height: 240 },
   terminal: { title: 'Terminal', width: 480, height: 300 },
   frame:    { title: 'Frame',    width: 720, height: 600 },
   group:    { title: 'Group',    width: 360, height: 240 },


### PR DESCRIPTION
## What changed

- refine content cards and frame surfaces into a quieter paper-object system
- move the canvas shell to a cool neutral grey with restrained borders and elevation
- neutralize sidebar selection while keeping Pulse blue for meaningful state
- keep Pulse Mono in app chrome and use a light translucent floating toolbar
- document the Spatial visual reference, comparison history, and final design QA
- lower the hardcoded-color governance ratchet after consolidating literals

## Why

Pulse Canvas previously leaned warm and visually saturated, especially across large Frame surfaces. This adapts Spatial’s calm cool-grey workspace and white-paper object hierarchy while preserving Pulse’s denser tool model and monospaced identity.

## Impact

The workspace has clearer object separation and a quieter overview without changing node behavior, content, or navigation. Colored Frames remain identifiable but no longer dominate the board.

## Validation

- `node scripts/harness/run-harness-check.mjs --path ...` — typecheck and 20 governance tests passed
- `pnpm --filter canvas-workspace build` — passed
- production Electron demo profile — visually inspected at 1200 × 772 CSS px; WebView registered and logs clean
- full Canvas test run — 1789/1790 passed; the lone history-store failure passed 5/5 when rerun in isolation and reproduced only under the full parallel suite
- `git diff --check` — passed
