### PR TITLE
fix(canvas-workspace): drop stray default exports in Settings/MigrationSpinner

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
@@ -10,7 +10,9 @@ import { useI18n } from '../../i18n';
 import { Button, FieldRow, Select } from '../ui';
 import './AgentSection.css';
 
-const AgentShellPathCard = lazy(() => import('./AgentShellPathCard'));
+const AgentShellPathCard = lazy(() =>
+  import('./AgentShellPathCard').then((module) => ({ default: module.AgentShellPathCard })),
+);
 
 interface AgentSectionProps {
   onClose: () => void;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
@@ -9,7 +9,7 @@ interface AgentShellPathCardProps {
   onConfigured: () => Promise<void>;
 }
 
-const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps) => {
+export const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps) => {
   const { notify } = useAppShell();
   const { language, t } = useI18n();
   const [configuring, setConfiguring] = useState(false);
@@ -71,5 +71,3 @@ const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps
     </div>
   );
 };
-
-export default AgentShellPathCard;


### PR DESCRIPTION
## Summary

Scanned `apps/canvas-workspace` for UI style inconsistencies against its own documented conventions (`harness/knowledge/conventions/frontend.md`) and governance tooling (`ui-reuse-governance.test.ts`, `file-size-governance.test.ts`). That governance system is already extremely mature and actively maintained (see `docs/ui-reuse-burndown.md`) — the tracked/ratcheted style debt (raw buttons, hardcoded colors, radius literals, etc.) is deliberately opportunity-ordered by the repo owner and mostly requires visual review this environment can't safely perform, so it's out of scope here.

One concrete, independent, zero-risk violation of the documented component-style convention ("Export **named arrow-function components**... Avoid `default` exports for components") turned up:

- `components/MigrationSpinner/index.tsx` — carried a stray `export default MigrationSpinner` alongside its correct named export. Dead code: its one call site (`App.tsx`) already imports the named export via `.then((module) => ({ default: module.MigrationSpinner }))`. Removed.
- `components/Settings/AgentShellPathCard.tsx` — had **no** named export at all, only `export default`. Added `export const AgentShellPathCard = ...` and removed the default export.
- `components/Settings/AgentSection.tsx` — updated `AgentShellPathCard`'s `lazy()` import to map to the new named export, matching the pattern already used for `MigrationSpinner`.

No behavior change — pure export-shape cleanup with call sites updated to match.

## Why

Two components diverged from the folder's own documented convention: `AgentShellPathCard` had no matching named export, and `MigrationSpinner` carried a dead `export default` nobody used. Fixing both makes every renderer component in `Settings/` and `MigrationSpinner/` follow the single named-export pattern the rest of the codebase already uses (`AgentSection`, `Button`, etc.), so lazy-loaded components are consistently keyed off a named export rather than mixing both styles.

## Verification

- `pnpm --filter canvas-workspace typecheck` — clean
- `pnpm --filter canvas-workspace test` — 282 test files / 1809 passed, 1 pre-existing skip
- `node harness/tools/describe-canvas.mjs` — exit 0, no drift
- Governance suites (`ui-reuse-governance`, `file-size-governance`, `import-boundaries`) — all green, no baseline changes needed (this change isn't ratchet-counted)

---
_Generated by [Claude Code](https://claude.ai/code/session_013u4cgUCTwVsc2x1FS9nMGj)_