### PR TITLE
refactor(canvas): strip redundant chat chrome, name the run mode on the scheduled pill

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatInput.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatInput.tsx
@@ -95,7 +95,7 @@ export const ChatInput = ({
   const hasSendableContent = Boolean(input.trim() || readyAttachments.length > 0);
   const canSend = hasSendableContent && !sendDisabled && !attachmentSendBlocked;
   const executionLabel = executionMode === 'scheduled'
-    ? t('chat.execution.scheduled')
+    ? t('chat.execution.scheduledAuto')
     : executionMode === 'ask'
       ? t('chat.execution.ask')
       : t('chat.execution.auto');

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
@@ -688,7 +688,7 @@
   transition: background 0.1s, color 0.1s;
 }
 
-.chat-execution-mode-btn:hover {
+.chat-execution-mode-btn:not(.chat-execution-mode-btn--readonly):hover {
   background: rgba(55, 53, 47, 0.06);
   color: #37352f;
 }
@@ -703,9 +703,13 @@
   opacity: 0.5;
 }
 
+/* Not interactive: the label is two facts joined by a separator, so it must
+   never wrap in a narrow dock composer, and it must not offer a hover
+   affordance the way the auto/ask toggle does. */
 .chat-execution-mode-btn--readonly {
   cursor: default;
   font-weight: 500;
+  white-space: nowrap;
 }
 
 .chat-send-btn {
@@ -3074,31 +3078,13 @@
   text-align: left;
 }
 
-.chat-turn-context__meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px 12px;
-  margin: 0;
-}
-
-.chat-turn-context__meta > div {
-  display: inline-flex;
-  gap: 4px;
-}
-
-.chat-turn-context__meta dt {
-  font-weight: 650;
-}
-
-.chat-turn-context__meta dd {
-  margin: 0;
-  color: var(--text);
-}
-
 .chat-turn-context__references {
   display: flex;
   align-items: baseline;
   gap: 6px;
+}
+
+.chat-turn-context__references + .chat-turn-context__references {
   margin-top: 5px;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatTurnMeta.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatTurnMeta.tsx
@@ -78,15 +78,25 @@ const ContextReferences = ({
   );
 };
 
+// Scope / model / execution are deliberately NOT shown here: all three restate
+// what the composer already displays for the live turn, so every user message
+// carried a row of redundant labels. Only the references — which the composer
+// clears after sending and nothing else records — survive on the turn.
 export const ChatTurnContext = ({
   snapshot,
 }: {
   snapshot: AgentTurnContextSnapshot;
 }) => {
   const { t } = useI18n();
-  const executionLabel = snapshot.executionMode === 'auto'
-    ? t('chat.execution.auto')
-    : t('chat.execution.ask');
+  const references = [
+    { key: 'nodes', label: t('chat.turn.nodes'), values: (snapshot.selectedNodes ?? []).map(node => node.title) },
+    { key: 'tags', label: t('chat.turn.tags'), values: (snapshot.tags ?? []).map(tag => `#${tag.name}`) },
+    { key: 'canvases', label: t('chat.turn.canvases'), values: (snapshot.canvases ?? []).map(canvas => canvas.name) },
+    { key: 'elements', label: t('chat.turn.elements'), values: (snapshot.domSelections ?? []).map(selection => selection.label) },
+    { key: 'tabs', label: t('chat.turn.tabs'), values: (snapshot.tabs ?? []).map(tab => tab.title) },
+  ].filter(entry => entry.values.length > 0);
+
+  if (references.length === 0) return null;
 
   return (
     <div
@@ -94,40 +104,9 @@ export const ChatTurnContext = ({
       role="group"
       aria-label={t('chat.turn.context')}
     >
-      <dl className="chat-turn-context__meta">
-        <div>
-          <dt>{t('chat.turn.scope')}</dt>
-          <dd>{snapshot.scopeLabel}</dd>
-        </div>
-        <div>
-          <dt>{t('chat.turn.model')}</dt>
-          <dd>{snapshot.modelLabel}</dd>
-        </div>
-        <div>
-          <dt>{t('chat.turn.execution')}</dt>
-          <dd>{executionLabel}</dd>
-        </div>
-      </dl>
-      <ContextReferences
-        label={t('chat.turn.nodes')}
-        values={(snapshot.selectedNodes ?? []).map(node => node.title)}
-      />
-      <ContextReferences
-        label={t('chat.turn.tags')}
-        values={(snapshot.tags ?? []).map(tag => `#${tag.name}`)}
-      />
-      <ContextReferences
-        label={t('chat.turn.canvases')}
-        values={(snapshot.canvases ?? []).map(canvas => canvas.name)}
-      />
-      <ContextReferences
-        label={t('chat.turn.elements')}
-        values={(snapshot.domSelections ?? []).map(selection => selection.label)}
-      />
-      <ContextReferences
-        label={t('chat.turn.tabs')}
-        values={(snapshot.tabs ?? []).map(tab => tab.title)}
-      />
+      {references.map(entry => (
+        <ContextReferences key={entry.key} label={entry.label} values={entry.values} />
+      ))}
     </div>
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatInput.execution-attachments.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatInput.execution-attachments.test.tsx
@@ -83,9 +83,11 @@ describe('ChatInput execution and attachment states', () => {
       </I18nProvider>,
     ));
 
-    const policy = host.querySelector('[aria-label="Execution mode: Scheduled"]');
+    // The locked pill must name the run mode too: "Scheduled" alone reads as a
+    // third execution mode, which it is not — the run is still `auto`.
+    const policy = host.querySelector('[aria-label="Execution mode: Scheduled · Automatic"]');
     expect(policy?.tagName).toBe('SPAN');
-    expect(policy?.textContent).toBe('Scheduled');
+    expect(policy?.textContent).toBe('Scheduled · Automatic');
     expect(toggle).not.toHaveBeenCalled();
 
     act(() => root.unmount());

--- a/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatMessages.accessibility.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatMessages.accessibility.test.tsx
@@ -387,13 +387,30 @@ describe('ChatMessages accessibility', () => {
 
     const snapshot = el.querySelector<HTMLElement>('.chat-turn-context');
     expect(snapshot?.getAttribute('aria-label')).toBe('Turn context');
-    expect(snapshot?.textContent).toContain('Scope');
-    expect(snapshot?.textContent).toContain('Product canvas');
-    expect(snapshot?.textContent).toContain('Model');
-    expect(snapshot?.textContent).toContain('GPT-5.6');
-    expect(snapshot?.textContent).toContain('Ask first');
     expect(snapshot?.textContent).toContain('Roadmap');
     expect(snapshot?.textContent).toContain('#launch');
     expect(snapshot?.textContent).toContain('Research canvas');
+    // Scope / model / execution restate the composer, so they are deliberately
+    // absent — every user turn used to carry that redundant row.
+    expect(snapshot?.textContent).not.toContain('Product canvas');
+    expect(snapshot?.textContent).not.toContain('GPT-5.6');
+    expect(snapshot?.textContent).not.toContain('Ask first');
+  });
+
+  it('renders no turn context when the snapshot carries no references', async () => {
+    const el = await renderMessages([{
+      role: 'user',
+      content: 'Just a question.',
+      timestamp: 1,
+      contextSnapshot: {
+        scope: { kind: 'workspace', workspaceId: 'workspace-1' },
+        scopeLabel: 'Product canvas',
+        executionMode: 'auto',
+        modelLabel: 'GPT-5.6',
+        capturedAt: 1,
+      },
+    }]);
+
+    expect(el.querySelector('.chat-turn-context')).toBeNull();
   });
 });

--- a/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
+++ b/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
@@ -645,6 +645,10 @@ const en = {
   'chat.execution.auto': 'Automatic',
   'chat.execution.ask': 'Ask first',
   'chat.execution.scheduled': 'Scheduled',
+  // The composer pill is the only place the two facts must be read together:
+  // the toggle is locked because this is a scheduled task, and the run itself
+  // is still `auto`. The compact target bar keeps the short form.
+  'chat.execution.scheduledAuto': 'Scheduled · Automatic',
   'chat.executionModeLabel': 'Execution mode: {mode}',
   'chat.messageInput': 'Message',
   'chat.openingConversation': 'Opening conversation…',
@@ -693,9 +697,6 @@ const en = {
   'chat.addImageFailed': 'Could not add the image to the canvas: {error}',
   'chat.unknownError': 'Unknown error',
   'chat.turn.context': 'Turn context',
-  'chat.turn.scope': 'Scope',
-  'chat.turn.model': 'Model',
-  'chat.turn.execution': 'Execution',
   'chat.turn.nodes': 'Nodes',
   'chat.turn.tags': 'Tags',
   'chat.turn.canvases': 'Canvases',
@@ -2331,6 +2332,7 @@ const zh: Record<keyof typeof en, string> = {
   'chat.execution.auto': '自动执行',
   'chat.execution.ask': '执行前询问',
   'chat.execution.scheduled': '定时任务',
+  'chat.execution.scheduledAuto': '定时任务 · 自动执行',
   'chat.executionModeLabel': '执行模式：{mode}',
   'chat.messageInput': '消息',
   'chat.openingConversation': '正在打开对话…',
@@ -2379,9 +2381,6 @@ const zh: Record<keyof typeof en, string> = {
   'chat.addImageFailed': '无法将图片添加到画布：{error}',
   'chat.unknownError': '未知错误',
   'chat.turn.context': '本轮上下文',
-  'chat.turn.scope': '范围',
-  'chat.turn.model': '模型',
-  'chat.turn.execution': '执行方式',
   'chat.turn.nodes': '节点',
   'chat.turn.tags': '标签',
   'chat.turn.canvases': '画布',


### PR DESCRIPTION
Removes chat UI that restated information already on screen, and fixes a label pair that read as a contradiction.

## Why

Reported from a scheduled-task chat and a global chat:

1. **Every user message carried a `Scope / Model / Execution` row.** All three restate what the composer already shows for the live turn — scope is the topbar title, model is the model selector, execution is the pill next to it. They only ever carry information on old turns where the setting differed, and they appeared on *every* message.

2. **The composer's locked pill said "Scheduled" while the turn right above it said "Automatic"**, reading as a contradiction. `Scheduled` is not a third execution mode — it is a scope marker occupying the auto/ask toggle's slot for scheduled-task chats (`sessionScope.ts`, `ChatPage.tsx`). The wire contract is still `'auto' | 'ask'` (`src/shared/agent-chat.ts`, `src/main/agent/types.ts`), so the run really is `auto`; both labels were correct but contradicted each other on screen.

3. **The `ChatTargetBar` above the thread was the same duplication one level up** — its execution label repeated the composer pill sitting directly below it, and its scope label repeated the session rail.

## What changed

### Commit 1 — turn meta + scheduled pill

**`ChatTurnMeta.tsx`**
- Removed the `Scope / Model / Execution` `<dl>`.
- Kept the per-turn references (nodes, tags, canvases, elements, tabs) — the composer clears those after sending and nothing else records them.
- `ChatTurnContext` now returns `null` when a snapshot has no references (the common case), instead of leaving an empty `border-top` divider under each message.

**`ChatInput.tsx`**
- New `chat.execution.scheduledAuto` key: `Scheduled · Automatic` / `定时任务 · 自动执行`, so the locked pill names both facts.
- Read-only pill gets `white-space: nowrap`; the hover highlight is scoped to the interactive variant (`:not(.chat-execution-mode-btn--readonly):hover`) so a non-clickable label stops offering a click affordance.

### Commit 2 — remove `ChatTargetBar`

- Deleted the component, its CSS, and its test; unmounted from both surfaces it lived on (`ChatPageBody`, `ChatPanel`).
- `ChatContextSnapshot.contextLabels` existed only to feed this bar (its doc comment read "Labels shown in the scope bar"), so it is dropped from the target contract along with its two producers. `requestContext` remains the send-time SSOT it always was.
- The `ChatDockLifecycle` guard used `contextLabels` to make the target identity depend on nodes/selection; the memo deps already do that, so the fixture keeps the same coverage with the comment restated.

### Dead-key cleanup

`chat.turn.scope` / `.model` / `.execution`, `chat.targetSummary`, and `chat.execution.scheduled` lost their last callers — removed from both locales, along with the `.chat-turn-context__meta*` CSS. `.chat-turn-context__references` top margin moved to an adjacent-sibling selector so the first reference row no longer gets a stray offset.

## Validation

- `pnpm --filter canvas-workspace exec vitest run src/renderer/src/components/chat src/renderer/src/components/Workbench src/renderer/src/components/LinkDrawer` → 56 files / 224 tests pass
- `pnpm --filter canvas-workspace typecheck` → pass
- `node scripts/harness/run-harness-check.mjs` → 2/2 pass

Test changes: `ChatInput.execution-attachments.test.tsx` asserts the new pill label; `ChatMessages.accessibility.test.tsx` asserts the references survive and the three identifiers are absent, plus a new case covering "no references → no turn context rendered".

Note: the `ui-reuse-governance` ratchet caught an intermediate version of this diff — a hardcoded `#6f6e69` in a read-only hover rule pushed `hardcodedColorLiterals` from 1812 to 1813. The baseline was **not** raised; the rule was restructured into the `:not()` selector above so no new color literal is needed.