### PR TITLE
docs(harness): slim canvas-workspace AGENTS.md into harness/knowledge, add router-weight gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ This file orients agents working in the Coder repository. It is a thin routing +
 | Inspect harness coverage | `node scripts/harness/check-harness.mjs` |
 | Run bound checks for a change | `node scripts/harness/run-harness-check.mjs` |
 | Visualize root/package/app harness | `harness/skills/visualize-harness/SKILL.md` |
+| Slim an overweight AGENTS.md / extract inline knowledge | `harness/skills/slim-agents-md/SKILL.md` |
 
 ## 2. Hard boundaries (real values)
 
@@ -115,12 +116,14 @@ Run the commands the affected workspace's `harness/validate/validation.yaml` bin
 - **Unbounded `capturePage` hangs on hidden webview guests**: canvas-workspace's freeze IPC awaited `wc.capturePage()` on a hidden guest — a guest producing no frames never settles the promise, wedging the IPC reply (and the discard sweep's identical fallback would have latched its re-entrancy flag forever, killing all future sweeps). Guard: captures go through the 2s-bounded `captureBoundedSnapshot` (`apps/canvas-workspace/src/main/webview/snapshot.ts`) with a never-settling-capture regression test. Rule: never await Electron `capturePage` unbounded on possibly-hidden/occluded webContents.
 - **Parallel canvas-cli writes destroyed each other's nodes**: every mutation did an unlocked full-canvas read-modify-write; concurrent writers hit tmp-rename ENOENT (per-node writer used a FIXED `<path>.tmp` name), lost updates, and — worst — the v2 orphan sweep deleted per-node files the other writer had just created. Guard: unique tmp names, `withWorkspaceLock` around `commitNode/EdgeMutation`, orphan pruning now opt-in (`pruneUnknownNodeFiles`, restore/repair only), regression suite `packages/canvas-cli/src/core/__tests__/storage-race.test.ts`. Rule: any new canvas write path in the CLI must run inside the workspace lock and must not full-sync-sweep per-node files; app↔CLI concurrency is NOT covered by this lock (per-node `updatedAt` arbitration only) until a shared storage package lands.
 
-- **Menu accelerators silently ate renderer shortcuts**: Electron `role` menu items consume a keystroke in MAIN before any renderer listener sees it. The default `viewMenu` roles took `Cmd+0`/`Cmd+±` for webFrame zoom, so the canvas could not own zoom at all, and the same class had already forced Undo/Redo out of the Edit menu. Guard: `apps/canvas-workspace/src/main/app/menu.ts` builds an explicit View menu without the zoom roles and documents why. Rule: before adding any renderer shortcut, check `menu.ts` for a role that claims the chord — and never add a `role` whose accelerator collides with a registry binding.
-- **Documented-but-unimplemented shortcuts**: three surfaces hand-wrote the same binding (behavior, help overlay, command palette), so `Cmd+Shift+A` shipped advertised-with-no-handler and — because the matcher ignored unlisted modifiers — actually ran select-all. Guard: `apps/canvas-workspace/src/renderer/src/shortcuts/` is the single declaration site and the owning hooks type their handler tables as `Record<ShortcutIdFor<owner>, Handler>`, making the gap a TYPE ERROR; runtime halves are pinned by the `keyboard-shortcuts` rule in that workspace's `harness/validate/validation.yaml`. Rule: a UI surface must never hardcode a chord or its label — derive both from the registry.
+- **Menu accelerators silently ate renderer shortcuts**: Electron `role` menu items win a keystroke in MAIN before any renderer listener sees it — check `menu.ts` for a role claiming the chord before adding any renderer shortcut, and never add a `role` whose accelerator collides with a registry binding.
+  Detail + guards: apps/canvas-workspace/harness/knowledge/keyboard-shortcuts.md.
+- **Documented-but-unimplemented shortcuts**: a UI surface must never hardcode a chord or its label — derive both from the registry; `Cmd+Shift+A` once shipped advertised-with-no-handler and silently ran select-all instead.
+  Detail + guards: apps/canvas-workspace/harness/knowledge/keyboard-shortcuts.md.
 
 Failures are captured in fix commits + regression tests — debug via `git log -- <file>` and focused tests, not by grepping for TODOs.
 
-**Task-end write-back**: before finishing a task, route what it taught you — new fact → the nearest owning doc or workspace `AGENTS.md`; new check → the affected workspace's `harness/validate/validation.yaml`; a cross-module rule that cannot become a check → one line appended to this section. No separate feedback store.
+**Task-end write-back**: before finishing a task, route what it taught you — new fact → the nearest owning doc or workspace `AGENTS.md` — but never inline multi-sentence knowledge into a router table row or constraint bullet: put it in that workspace's `harness/knowledge/` file (create one if missing) and leave a pointer row; new check → the affected workspace's `harness/validate/validation.yaml`; a cross-module rule that cannot become a check → one line appended to this section. No separate feedback store.
 
 ## 7. Security / secrets
 

--- a/apps/canvas-workspace/AGENTS.md
+++ b/apps/canvas-workspace/AGENTS.md
@@ -21,8 +21,7 @@ existing workspace docs or tests. Add new workspace docs only when a behavior
 or operating runbook needs a durable source of truth.
 
 **Local harness layout** — `harness/` is this workspace's repo-harness
-container, aligned with `packages/engine/harness/` (migrated 2026-07-07;
-before that the directory held only the Electron driver):
+container, aligned with `packages/engine/harness/`:
 - `harness/knowledge/` — conventions, main domain map, renderer surfaces,
   plugin node contract, security posture, known defects (moved from `docs/`;
   `docs/` now keeps only project records like perf analyses and roadmaps).
@@ -50,13 +49,7 @@ before that the directory held only the Electron driver):
   `add-canvas-node`, `add-agent-tool`, `add-builtin-main-plugin`,
   `extend-blessed-ui`, `add-ipc-surface` (safe-change procedures for the
   five recurring extension shapes).
-- `harness/spec/` — decision-pending intent, currently **empty** (the
-  success state). Two entries completed their full lifecycle: UI-reuse
-  (2026-07-07: decided → mechanized as `ui-reuse-governance.test.ts` +
-  `components/ui/` → deleted) and node-extension-path (2026-07-08: decided
-  plugin-default → encoded in the `add-canvas-node` skill + this file's
-  node-type constraint above → deleted). Surface definition lives in
-  `packages/engine/harness/spec/README.md`.
+- `harness/spec/` — decision-pending intent; empty is the success state. Surface definition: ../../packages/engine/harness/spec/README.md; resolved entries end as tests/skills, then delete.
 - `harness/validate/validation.yaml` — path→check bindings for the repo runner.
 
 **"skills" disambiguation** — `harness/skills/*/SKILL.md` are procedures for
@@ -79,7 +72,7 @@ deploys the external-agent `pulse-canvas` CLI + bundled skills. Do not mix them.
 | PATH for anything the app spawns | `src/main/shell-path.ts` — a GUI launch inherits a stripped PATH, and every child (agent `bash`, which the engine spawns with NO `env`, MCP stdio servers, the bundled CLI) takes `process.env` verbatim, so a missing binary surfaces as a bare "command not found". Repaired once in `bootstrap.ts` before any spawn: `augmentProcessPath()` (sync, well-known per-user bin dirs incl. `~/.pulse-coder/bin`) then a best-effort `applyLoginShellPath()` (async, timeout-bounded `$SHELL -ilc`, only ever widens). PTY env shares the same bin-dir list — do not fork a second copy. Tests: `src/main/__tests__/shell-path.test.ts` |
 | Main domain map | `harness/knowledge/main-domain-modules.md`, `src/main/index.ts`, `src/main/app/bootstrap.ts` |
 | Renderer routes and full-app surfaces | `harness/knowledge/renderer-surfaces.md`, `src/renderer/src/App.tsx`, `src/renderer/src/components/Workbench/`, `src/renderer/src/components/RightDock/` |
-| Keyboard shortcuts | `src/renderer/src/shortcuts/` is the runtime SSOT — `definitions.ts` (the binding table), `types.ts`, `registry.ts` (matching + platform-correct labels). Behavior lives in the owner's handler table: `hooks/useCanvasKeyboard.ts` (owner `canvas`, gated on the visible unlocked canvas) and `hooks/useAppShortcuts.ts` (owner `app`, every route); both are `Record<ShortcutIdFor<'…'>, Handler>`, so a documented-but-unimplemented shortcut is a TYPE ERROR — that is what previously let `Cmd+Shift+A` ship in the help overlay and the palette with no handler while silently running select-all. Never hand-write a chord condition or a `'Cmd+D'` label again: the lazy `?` overlay (`components/AppShellProvider/ShortcutsDialog.tsx`) exhaustively maps runtime IDs to display metadata and derives combo labels from the registry; palette hints (`Canvas/hooks/useCanvasPaletteCommands.ts`) also derive from the registry. Keep help-only descriptions and gestures behind that lazy boundary instead of adding them to the startup matcher. Matching is EXACT on modifiers. macOS eats `Cmd+H`/`Cmd+Tab` before the renderer — use literal `ctrl: true` there. `editable: 'allow'` is what keeps a chord alive inside a text field or terminal (only for chords with no typing meaning). Menu accelerators in `src/main/app/menu.ts` outrank ALL of this: the Undo/Redo and zoom roles are deliberately gone so the canvas can own `Cmd+Z` and `Cmd+0/±`. Focus black holes are closed at the edges — webview guests forward a narrow whitelist (`src/shared/webview-shortcuts.ts` → `src/main/webview/shortcut-forwarding.ts` → `hooks/useWebviewShortcutBridge.ts`), and a focused terminal keeps Ctrl-chords but yields Cmd-chords and releases focus on double-Escape (`decideTerminalKey` in `AgentNodeBody/utils/terminal.ts`). Bound checks: the `keyboard-shortcuts` rule in `harness/validate/validation.yaml` |
+| Keyboard shortcuts | Read `harness/knowledge/keyboard-shortcuts.md` before adding/changing/removing a shortcut, editing `menu.ts` accelerators, or touching webview/terminal key handling. Key contracts: `shortcuts/definitions.ts`, `shortcuts/registry.ts`, `hooks/useCanvasKeyboard.ts`, `hooks/useAppShortcuts.ts`, `src/main/app/menu.ts`, `src/shared/webview-shortcuts.ts`. Bound tests (`keyboard-shortcuts` rule, `harness/validate/validation.yaml`): `shortcuts/registry.test.ts`, `hooks/useCanvasKeyboard.test.ts`, `hooks/useAppShortcuts.test.ts`, `src/main/webview/__tests__/shortcut-forwarding.test.ts`, `AgentNodeBody/utils/terminalKeys.test.ts`. |
 | Cross-process API bridge | `src/preload/index.ts`, `src/preload/bridge/`, `src/renderer/src/types.ts`, `src/shared/` |
 | Add a capability spanning main + preload + renderer | `harness/skills/add-ipc-surface/SKILL.md` (ordered procedure — contract placement, streaming pattern, bootstrap wire, lockstep rule) |
 | Canvas node/edge schema | `src/shared/canvas.ts` |
@@ -87,18 +80,18 @@ deploys the external-agent `pulse-canvas` CLI + bundled skills. Do not mix them.
 | Current registries (agent tools / IPC pairs / node types) | run `node harness/tools/describe-canvas.mjs` (from this dir; `--json` for machines) |
 | Visual-regression baseline for ui/ pieces | `harness/tools/ui-showcase/README.md`; run `pnpm run visual` / `pnpm run visual:update` |
 | Canvas persistence and migration | `src/main/canvas/store.ts`, `src/main/canvas/storage.ts`, `src/main/canvas/nodes/` (NB: `nodes/` here = knowledge-node records + tags, NOT node types) |
-| Node Detail (knowledge-node detail surface) | ONE panel, `WorkspaceNodes/NodeDetailPanel.tsx`, in TWO hosts: the `/nodes/<ws>/<id>` page (`NodeDetailPage.tsx`) and the dock tab (`RightDock/NodeDetailDockTab.tsx`, `mode="dock"`). The dock is the primary entry — list cards, graph nodes and note mentions all open a tab, the page is the drill-down — so a reading aid that renders only in `mode==='page'` is invisible to most users. Entering a full-page detail MUST go through `RightDock.enterNodePage`: it removes the matching dock tab and collapses only when that matching preview was active; an unrelated active dock tab stays visible, so page promotion never discards the user's other context. Its subject is a `WorkspaceNodeRecord` (knowledge atom, no x/y/w/h), rendered through the real `CanvasNodeView` (`NodeCanvasPreview` adapts record→CanvasNode, `embedded hideHeader`; layout patches are dropped). `nodeDetailDescriptor.ts` is the SSOT for type→surface/layout/capability: File/Text and other document-like records use the generic document layout; Web and Mindmap are rich working surfaces whose real node body fills the remaining area, compact metadata lives behind the header Info inspector, and generic Relations/Info/context-rail chrome stays absent. Web retains its iframe navigation bar; Mindmap retains selected-topic editing, Pointer-event background pan, keyboard pan and an explicit center action. **The adapter must never reject into a node body**: the canvas's own `onUpdate` never rejects, so every body calls it fire-and-forget (TextNodeBody, MindmapNodeBody, IframeNodeBody) — a rejection reached nobody and surfaced as an unhandled rejection, while the pre-fix re-read on failure discarded exactly the edit that had failed to save. A failed record write now HOLDS the optimistic content (external change events are refused while it is held), shows a retry/discard banner, and merges further failures into the same pending patch. FileNodeBody's own `.note-save-status` reports *file* writes — a disjoint failure, so both may show. `workspace-node:read` answers a deleted node with `ok` + NO record: `useWorkspaceNode` exposes that as `missing`, and a host that conflates it with "nothing selected" tells someone their deleted node is merely unselected (the dock tab must also stop advertising the old title). Cross-surface travel is window events, never host callbacks threaded through the shared panel — `useNodeDetailBridges` (page↔canvas, `FOCUS_NODE_ON_CANVAS_EVENT`) and `dispatchOpenNode` for relation rows. The page owns its own Escape (`NodeDetailPage`, bubble-phase + target-gated): `useEscapeClose` is capture-phase and stops propagation, so a page-level subscriber would eat the Escape that closes the tag picker or cancels a title edit. The detail route also hosts the global chat through `KnowledgeChatPortal`; memoize its selected node by the semantic `(workspaceId, nodeId)` pair, never by the route object's identity, or the active-target broker publish causes a parent rerender → unregister/register loop (`Maximum update depth exceeded`). Tests: `__tests__/NodeDetailPanel.test.tsx`, `__tests__/NodeCanvasPreview.test.tsx` (save-failure + rich-presentation guards), `__tests__/nodeDetailStyles.test.ts`, `RightDock/__tests__/dock-store.test.ts`, `__tests__/NodeDetailPage.escape.test.tsx`, `useWorkspaceNodes.test.tsx`, `Workbench/__tests__/ChatDockLifecycle.test.tsx` |
+| Node Detail (knowledge-node detail surface) | Read `harness/knowledge/node-detail.md` before changing the panel/host split, `enterNodePage`, the record→CanvasNode adapter, `nodeDetailDescriptor.ts`, save-failure handling, or missing-node/cross-surface/Escape behavior. Key contracts: `WorkspaceNodes/NodeDetailPanel.tsx`, `WorkspaceNodes/nodeDetailDescriptor.ts`, `WorkspaceNodes/NodeCanvasPreview.tsx`, `RightDock/dock-store.ts`, `WorkspaceNodes/useWorkspaceNodes.ts`, `Workbench/KnowledgeChatPortal.tsx`. Tests: `WorkspaceNodes/__tests__/NodeDetailPanel.test.tsx`, `RightDock/__tests__/dock-store.test.ts`, `Workbench/__tests__/ChatDockLifecycle.test.tsx` |
 | Canvas Agent and tools | `src/main/agent/`, `src/main/agent/tools/`, `src/renderer/src/components/chat/` |
-| xterm sizing for agent/terminal surfaces | `AgentNodeBody/utils/terminal.ts` owns the shared policy for every xterm in the app (agent nodes, terminal nodes, the workspace terminal dock). NEVER call `fitAddon.fit()` directly — go through `fitTerminalIfSane` / `fitTerminalWithCanvasScale`. FitAddon clamps at 2 columns, so a container measured mid-layout (unsized node, hidden/re-parented terminal, `--canvas-scale` in flight) proposes 3–5 columns; a coding agent renders its OWN layout to the PTY width, so applying that hard-wraps every line it prints into a 4-character ribbon that no later re-fit can reflow (xterm reflows only its own soft wraps) and the scrollback persists it. Skipping the bad pass is free: `scheduleTerminalFit`'s ladder (now + 2 frames + 80ms + 240ms) and the debounced ResizeObserver re-fit apply the real geometry. That ladder also `scrollToBottom()`s each pass — mount-time writes land while the terminal is still sizing, which is what left a restored session parked mid-history — but the ResizeObserver path must NOT scroll: it fires while the user reads history. Tests: `AgentNodeBody/utils/terminalFit.test.ts` |
-| AI Chat loading states | Two independent flags, do not conflate: `sessionsLoading` = the session LIST is being fetched (rail spinner in `ChatSessionsRail.tsx`, panel dropdown in `ChatHeader.tsx`); `sessionLoading` = THIS conversation's messages are being fetched (`ChatThreadSkeleton.tsx` in place of the thread, via `ChatView` → `ChatMessages`). Both live in `hooks/useChatSessions.ts`. Every thread-replacing IPC (`getHistory`, `loadSession`, `loadCrossWorkspaceSession`) MUST go through `runThreadFetch`: it owns the flag AND the monotonic request token that drops superseded responses — without it two quick session picks let the slower one overwrite the session the user actually chose, and `handleNewSession` must keep bumping that token so an abandoned load can't repaint a blank new chat. `sessionLoading` is seeded TRUE at mount (effects run after first paint, so a false seed flashes the empty state); `skipInitialHistory: true` therefore obliges the caller to call `handleLoadSession`. A third flag, `useChatStream`'s `loading`, means "the model is generating" — that one drives the three-dot `.chat-loading`, never the skeleton. Sending is vetoed while `sessionLoading` (the mirror of the session switches already blocked while streaming); the veto is `useMentions`' `isSubmitBlocked` because the composer has TWO submit paths — send button and `handleKeyDown`'s Enter — so a guard in a caller's `handleSubmit` alone is a hole. Tests: `hooks/useChatSessions.test.tsx`, `hooks/useMentions.submit-veto.test.tsx`, `__tests__/ChatSessionLoading.test.tsx` |
-| Full-page chat ↔ dock Tabs | The full-page chat topbar (`chat/ChatPageBody.tsx`, shared by the AI Chat page and a scheduled task's chat page) has NO close button; its right-most control shows/hides the dock's CONTENT tabs (link/artifact/node-detail/canvas-preview) beside the chat and must never navigate — a control that routes away from the page the user is reading is not a panel toggle. `RightDock/dock-content-tabs.ts` owns that switch (`store.toggleContentTabs`): `openChat`/`toggleChat` cannot serve these routes because the tab they target is hidden, and an expanded dock still pointing at the chat/terminal tab must be re-pointed at a content tab rather than collapsed, or the first click reads as a no-op. The button stays visible but disabled when no content tab exists yet (a tab can land mid-conversation, e.g. the agent opening an artifact/preview, and its topbar position must not jump around as that happens) — `chat.noDockTabs` labels the disabled state. Those routes reflow like any other (`reserveSpace`) — the dock inset must NOT be gated on `chatTabEnabled`, which is what let a link tab overlay and cover the AI Chat page. Esc and ⌘/Ctrl+Shift+L remain the exits from the AI Chat route. Tests: `RightDock/__tests__/dock-content-tabs.test.ts`, the no-chat-tab inset case in `RightDock/index.test.tsx` |
-| Dock width policy | `RightDock/dock-width.ts`. The canvas may grow the dock to ~95% of the viewport (the canvas reflows behind it); every page route caps it at 50% (`capWidth`), because a page IS the content and a 95% dock leaves a chat thread in a gutter. Keep the two layers separate: `chosenWidth` (dragged + persisted) vs the rendered `clampDockWidth(...)` — clamping the stored value would silently discard a wide canvas dock the first time the user opens a page route, and the clamp handed to `useDockSplitView` must keep a STABLE identity (it is an effect dep; a per-route identity re-clamps on every navigation). `.right-dock` animates `width` on the same curve as `.app-body`'s `margin-right` so a route switch moves page and dock edge together; drag-resize opts out via `.right-dock-resizing`. Tests: `RightDock/__tests__/dock-width.test.ts` + the capped-render case in `RightDock/index.test.tsx` |
-| Multi-role chat (@角色 group chat + relay) | `src/shared/agent-roles.ts` (role contract, `@[role:<id>\|<name>]` marker, speaker-label SSOT, `RoleTurn*Event` stream payloads), `src/main/agent/roles-store.ts` + `agent-roles-ipc.ts` (global library at `~/.pulse-coder/canvas/roles.json`, `agent-roles:*`), `src/main/agent/role-turn.ts` (persona section + BOTH model-history label injection points — live push and session reload MUST stay in lockstep — plus the relay boundary policy `shouldRunRelaySegment`, all pinned by `src/main/agent/__tests__/role-turn.test.ts`). Routing parses ALL role markers from the message text main-side (order-preserving, id-deduped): one → single persona turn, several → a RELAY where each role runs as its own engine segment against the shared history, so segment N+1 reads segment N's labeled reply; edit/regenerate replays re-run the whole turn with zero extra plumbing. Stored content stays clean (【name】 labels exist only on the model-facing copy) and speaker name/color are per-message snapshots that survive role edits/deletes. Stream protocol: every turn emits `role-turn-start/end:{sessionId}` (total=1 for single speakers); `canvas-agent:stop-relay` is the graceful boundary stop (current speaker finishes, queued ones are skipped) — the composer abort stays the hard stop. Agent@agent handoff (P2, opt-in): library switch `allowRoleHandoff` lives in roles.json settings (Settings → Chat Roles card, `agent-roles:settings-get/save`, default OFF, role writes preserve it). When ON, each ROLE segment's reply is scanned for plain-text `@RoleName` (`findRoleNameMentions`: name-based because models never emit internal markers; longest-name-first with span consumption, ASCII case-insensitive) and matches are appended to the SAME turn's queue — policy in `resolveHandoffRoles`: self dropped, already-queued deduped, roles that SPOKE may re-enter, and growth (never the user-named speakers) is capped by `ROLE_RELAY_MAX_SEGMENTS`=30 (Stop relay ends a long discussion early). Appended queue refs carry `namedBy` (RelayBar dashed underline + "由 X 点名" tooltip; the bar can appear mid-turn when a single-role turn grows — pinned in `relayTurnHandlers.test.ts`); default-assistant segments never hand off, and a pending graceful stop freezes the queue. Renderer: `role` mention group, speaker badge in `ChatMessage.tsx`, per-segment bubbles + completion policy in `hooks/relayTurnHandlers.ts` (tested), `RelayBar.tsx` progress strip, `RolesSettings.tsx` behind the Settings `chat-roles` section. Role accents everywhere come from one renderer cache — `hooks/roleMentionItems.ts` (popup entries + id→color map, 5s TTL, `useRoleColors()`, invalidated by Settings save/delete) — and chips recolor by overriding the `--role-accent*` tokens inline per chip (`utils/mentions.ts`), so unknown/deleted role ids fall back to the violet class tokens. Externally-driven roles (local coding agents): `AgentRoleDefinition.external` = `{family:'claude-code'\|'codex', cwd}` routes that role's segments to `src/main/agent/external/` — headless CLI spawn (`claude -p --output-format stream-json`, prompt via stdin, `--resume` continuity keyed per chat-session×role in `~/.pulse-coder/canvas/external-agent-state.json`, stale-resume retries once fresh; tolerant line parser pinned against real-binary shapes incl. unknown event types), reply appended to the shared model history by hand so the label/persist/handoff tail is identical to engine segments. Tool activity is surfaced: both adapters translate their own vocabulary (Claude `tool_use`/`tool_result`; Codex dialect-A `exec_command_*`/`patch_apply_*`/`mcp_tool_call_*`/`web_search_*` and dialect-B `item.started/completed`) into the SAME onToolCall/onToolResult events the engine emits (`external/tool-events.ts`; a result whose call was never seen back-fills one), and the collected calls persist so a reloaded session keeps its chips. The persona prompt is OPTIONAL for external roles (they carry their own CLAUDE.md/AGENTS.md instructions); persona roles still require one. Safety: external roles respond ONLY to direct user @ (`handoffTargetRoles` excludes them as handoff targets/advertised names — pinned in external-driver tests), cwd existence checked with a config-clear error, permissions defer to the CLI's own config (we pass no permission flags). Codex adapter live (`external/codex.ts`): `codex exec --json` / `exec resume <id>`, stdin sentinel `-`, `--skip-git-repo-check`, parser accepts BOTH shipped JSONL dialects (protocol `msg` events + thread events). Probe IPC `agent-roles:external-probe`; env overrides `PULSE_CANVAS_CLAUDE_CODE_CMD`/`PULSE_CANVAS_CODEX_CMD`/`PULSE_CANVAS_EXTERNAL_AGENT_STATE`. Chat entry: `chat_role_list`/`chat_role_save` in `src/main/agent/tools/roles.ts` — app-level, registered UNWRAPPED on both tool factories, `defer_loading`, no delete (scheduled-tools posture); a tool-created role is @-able within the mention popup's 5s roles-cache TTL. |
+| xterm sizing for agent/terminal surfaces | Read `harness/knowledge/terminal-surfaces.md` before changing xterm sizing/fit behavior for agent nodes, terminal nodes, or the workspace terminal dock. Key contracts: `AgentNodeBody/utils/terminal.ts`, `TerminalNodeBody/index.tsx`, `WorkspaceTerminalDock/index.tsx`. Tests: `AgentNodeBody/utils/terminalFit.test.ts` |
+| AI Chat loading states | Read `harness/knowledge/chat-sessions.md` before changing session loading flags (`sessionsLoading` vs `sessionLoading` vs stream `loading`) or the submit veto. Key contracts: `src/renderer/src/components/chat/hooks/useChatSessions.ts`, `hooks/useMentions.ts`, `ChatSessionsRail.tsx`, `ChatHeader.tsx`, `ChatThreadSkeleton.tsx`. Tests: `hooks/useChatSessions.test.tsx`, `hooks/useMentions.submit-veto.test.tsx`, `__tests__/ChatSessionLoading.test.tsx` |
+| Full-page chat ↔ dock Tabs | Read `harness/knowledge/chat-sessions.md` before changing the full-page chat topbar, its dock-content-tabs toggle, or the dock inset rule. Key contracts: `chat/ChatPageBody.tsx`, `RightDock/dock-content-tabs.ts`. Tests: `RightDock/__tests__/dock-content-tabs.test.ts`, `RightDock/index.test.tsx` |
+| Dock width policy | Read `harness/knowledge/chat-sessions.md` before changing right-dock width behavior. Key contract: `RightDock/dock-width.ts`. Tests: `RightDock/__tests__/dock-width.test.ts`, `RightDock/index.test.tsx` |
+| Multi-role chat (@角色 group chat + relay) | Read `harness/knowledge/agent-roles.md` before changing role marker/routing, the relay stream protocol, handoff policy, renderer role rendering, external CLI drivers, or the stopped-vs-failed turn rule. Key contracts: `src/shared/agent-roles.ts`, `src/main/agent/role-turn.ts`, `src/main/agent/roles-store.ts`, `src/main/agent/external/`, `src/main/agent/chat-stop.ts`. Tests: `src/main/agent/__tests__/role-turn.test.ts`, `src/main/agent/__tests__/external-driver.test.ts`, `src/main/agent/segment-execution.test.ts`, `src/main/agent/chat-stop.test.ts`. |
 | Agent long-term memory (global + per-workspace) | `src/main/agent/memory-store.ts` (store + prompt injection; explicit-save-only by design), `src/main/agent/tools/memory.ts` (`memory_save` eager; `memory_list`/`memory_forget`/`memory_adopt` deferred — `memory_adopt` is the sole cross-workspace write path, reserved for user-confirmed candidates from the `memory-review` default skill), tests in `src/main/agent/__tests__/memory-store.test.ts` + `tools-graph.test.ts` |
 | Artifact runtime capabilities (page → host actions) | `src/shared/artifact-capabilities.ts` (trust model + contract), `src/main/artifacts/capability-ipc.ts` (`artifact-capability:invoke`, main-side authoritative validation), `src/renderer/src/components/artifacts/capabilityBridge.ts` + `ArtifactTabView` (host-authored bridge script, postMessage relay, audit toast). Capabilities are declared on the artifact RECORD by creating code (never by the page), gated on a real user gesture in the bridge, and every write surfaces a toast. Current capabilities: `memory.adopt`, `skill.save` (both = the user's click IS the confirmation). Tests: `src/main/artifacts/__tests__/capability-invoke.test.ts` |
 | Artifact pin lifecycle + Library drawer | `src/main/artifacts/ipc.ts` — pin refuses sentinel (`__*`) scopes, dedupes against a live mirror, list/get lazily clear a stale `pinnedNodeId`, delete removes the canvas mirror node; `artifact:list-all` (metadata-only summaries) skips `__*` dirs EXCEPT `__global_chat__` (session-store sentinel rule — a blanket skip silently hides global artifacts). Library drawer = renamed ReferenceDrawer: Pinned entries persist per workspace via the `references` IPC domain (`src/main/references/`, `src/shared/references.ts`, hydrate/save in `Workbench/useReferenceEntries.ts`); Artifacts source tab is `ReferenceDrawer/ArtifactsPicker.tsx` (cross-scope pin disabled by design). Tests: `src/main/artifacts/__tests__/pin-lifecycle.test.ts` |
 | Headless (background) agent runs | `src/main/agent/headless-run.ts` (one-shot bounded Engine run: no session store, `builtInTools:{}` = structurally read-only, wall-clock timeout, never throws), `src/main/agent/memory-report.ts` (first consumer — cross-workspace memory report as self-contained HTML; adoption stays interactive-only; scheduled entry archives to `<memory>/reports/` with rolling retention AND publishes a `__global_chat__`-scoped artifact, surfaced by an OS notification whose click pushes `dock:open-artifact`). Tests: `src/main/agent/__tests__/headless-run.test.ts` |
-| Scheduled tasks | `src/main/scheduled/` — stable top-level Scheduled surface with persisted user-defined tasks, an exact next-due main-process timer backed by a 30-minute heartbeat, startup/resume catch-up, manual run-now, and one isolated durable Agent chat scope per task. Cadence is the `ScheduledSchedule` union in `src/shared/scheduled.ts`: `interval` (relative, minimum 30 minutes, anchored at create/enable/last-attempt) or `daily`/`weekly` at a LOCAL wall-clock `HH:mm`. `computeNextRunAt` is the single next-run authority for all three kinds — use local `Date` field arithmetic there, never fixed millisecond offsets, so absolute slots survive DST. A slot missed while the app was closed runs ONCE on catch-up and then realigns to the next slot (never one run per missed slot); failed attempts consume the current slot rather than hot-looping. Pre-`schedule` records carrying `intervalMinutes` are lifted into the union on read (`migratePersistedTask`); the field is gone from the live contract. The built-in weekly memory-report prompt is seeded idempotently as a disabled Scheduled task on `weekly` Monday 09:00 local; it is no longer an Experimental entry. Seeding is one-shot by design — an install that already carries the task keeps its stored schedule, so the Monday default reaches new installs only. A finished attempt — success AND failure — is announced by `announceRunFinished` (`scheduled/runtime.ts`) as a `scheduled:run-finished` push that `useScheduledRunToasts` turns into a STICKY toast (`autoCloseMs: 0`); its action opens the task's conversation in the DOCK's Pulse AI tab (`useScheduledRunChatOpener` → `dock.openScheduledChat`), the same surface `Run now` uses — acting on a finished run must never navigate the whole app onto the AI Chat page and lose what the user was looking at. Routing to `/chat?scheduledTask=<id>` survives only as the fallback for views that hide the dock chat tab; `isDockChatTabEnabled` (`components/RightDock/dock-chat-availability.ts`) is the single predicate behind BOTH that fallback and the dock's `chatTabEnabled` prop, because a caller that assumes a dock chat tab where there is none swallows the open silently. The same module derives `isGlobalChatLauncherVisible` — the floating Pulse-logo launcher (`RightDock/GlobalChatLauncher.tsx`) shows on every route that has a dock chat tab and no chat chrome of its own, canvas being the one exception; deriving it stopped the Scheduled page from being hand-excluded with no way to reach the agent (`__tests__/dock-chat-availability.test.ts`). Each task's chat is a session STORE (`__scheduled__-<taskId>`), listed in that rail beside workspaces and global chat — `src/shared/agent-chat.ts` owns the store-id vocabulary (`scopeSessionStoreId`, `scheduledTaskIdFromStoreId`, `isListableSessionStore`), and every consumer that maps a listed session back to a scope MUST go through it: a sentinel store id treated as a workspace id activates an agent against a workspace that does not exist. `__`-prefixed stores are allowlisted, never blanket-skipped (that is what hid scheduled chats from the rail). Deliberately in-app only: OS `Notification` was tried and removed (Focus modes, missing notification daemons, unsigned dev builds, and Windows-without-AppUserModelID all drop it silently, and it needed a retained-reference dance to survive GC), so do not reintroduce a second channel — `scheduled-run-notify.test.ts` asserts none is raised. A run finishes while nobody is watching, so the toast must never expire on a timer. IPC contract: `src/shared/scheduled.ts` → `src/preload/bridge/scheduled.ts` → renderer `components/Scheduled/`; list rows are presentational — every action is an explicit button, and the time picker is hour/minute `ui/Select`s, never a native `<input type="time">`. Chat entry: `scheduled_task_list`/`_create`/`_update` in `src/main/agent/tools/scheduled.ts` — app-level, so registered UNWRAPPED on both tool factories, all `defer_loading`, no delete (see `harness/knowledge/security-posture.md` for why); it dynamic-imports `scheduled/runtime` to avoid the tools→runtime→agent-service module cycle. Tests: `src/shared/scheduled.test.ts` (schedule validation + next-run math), `src/main/__tests__/scheduled-task-service.test.ts`, `src/main/__tests__/scheduled-run-notify.test.ts` (completion push, success AND failure, and no OS notification), `components/Scheduled/__tests__/useScheduledRunToasts.test.tsx` (sticky toast), `components/Scheduled/__tests__/scheduledChatTarget.test.ts` (dock-by-default vs route fallback), `src/main/agent/__tests__/scheduled-tools.test.ts`, `components/Scheduled/__tests__/TaskEditorModal.test.tsx` + `ScheduledPage.test.tsx`, plus scheduled-scope coverage in `src/main/agent/__tests__/service-history.test.ts`. |
+| Scheduled tasks | Read `harness/knowledge/scheduled-tasks.md` before changing cadence/DST math, catch-up or `intervalMinutes` migration, the run-finished toast/dock-chat chain, or the scheduled session-store vocabulary. Key contracts: `src/shared/scheduled.ts`, `src/main/scheduled/`, `src/shared/agent-chat.ts`, `components/RightDock/dock-chat-availability.ts`, `src/main/agent/tools/scheduled.ts`. Tests: `src/shared/scheduled.test.ts`, `src/main/__tests__/scheduled-task-service.test.ts`, `src/main/__tests__/scheduled-run-notify.test.ts`, `components/RightDock/__tests__/dock-chat-availability.test.ts`. |
 | Dock web tabs (the embedded browser) | Read `harness/knowledge/dock-browser.md` before changing guest navigation, identity/routing, retention, focus, shortcuts, or tab overflow. Key contracts: `src/shared/webview-registration.ts`, `src/shared/link-open.ts`, `src/shared/dock-shortcuts.ts`; main policy/registry under `src/main/app/` + `src/main/webview/`; renderer ownership under `IframeNodeBody/webview-identities.ts`, `RightDock/`, and `LinkDrawer/`. |
 | Add a capability shared by Tool + CLI | `../../harness/skills/add-canvas-capability/SKILL.md`; use `harness/skills/add-agent-tool/SKILL.md` for the optional task-specific Canvas Agent adapter |
 | Agent teams | `src/main/agent-teams/`, `src/renderer/src/components/AgentTeamFrame/` |
@@ -129,88 +122,38 @@ deploys the external-agent `pulse-canvas` CLI + bundled skills. Do not mix them.
 - Runtime data belongs under user locations such as `~/.pulse-coder/canvas/`,
   `~/.pulse-coder/canvas-runtime/`, and model/settings files. Do not write user
   runtime state into the repository.
-- Packaged builds bundle the existing `@pulse-coder/canvas-cli` under Electron
-  resources. On first launch and after app updates, the app idempotently
-  installs its versioned files under `~/.pulse-coder/tooling/pulse-canvas/`, a
-  no-system-Node wrapper under `~/.pulse-coder/bin/`, and all bundled skills
-  into Pulse/Codex/Claude global skill dirs. Keep startup, Settings repair, and
-  experimental-trigger installs on the shared `AgentToolingManager`; production
-  installation must never depend on a source checkout, `pnpm`, or global link.
-  Treat the CLI + skills as one compatibility bundle. The persisted update
-  policy under the tooling root defaults to following app updates; `ask` and
-  `pinned` retain the active bundle until an explicit Settings update, while
-  damage repair of that active bundle remains automatic from its fingerprinted
-  local payload cache. Runtime payload directories are fingerprint-qualified
-  and immutable across updates so a same-semver replacement cannot overwrite
-  the CLI currently referenced by the launcher. Bundle activation is
-  failure-atomic: a skill, launcher, or active-state write failure must restore
-  the previously active set. Settings may offer an explicit shell-PATH setup for
-  zsh/bash/fish; it appends one marked `~/.pulse-coder/bin` entry only after a
-  user click, never during automatic install/update.
+- Packaged builds install `@pulse-coder/canvas-cli` + all bundled skills as one versioned, fingerprinted compatibility bundle under `~/.pulse-coder/`; route every install/repair/update trigger (startup, Settings repair, experimental-flag triggers) through the shared `AgentToolingManager` / `agent-tooling-queue`, never a source checkout, `pnpm`, or a global link.
+  Guard: `packaged-agent-tooling` rule in `harness/validate/validation.yaml` (`agent-tooling-manager.test.ts`, `agent-tooling-queue.test.ts`, `shell-path.test.ts`, `agent-tooling-package.test.ts`).
+  Detail: `harness/knowledge/packaged-tooling.md`.
 - `harness/tools/driver/` launches the real Electron app. Use `temp`, `demo`,
   or `clone` profiles by default; use `real --allow-real-writes` only after
   explicit user intent because it can mutate real Pulse Canvas data.
   Reopening `demo` without `--reset` preserves its existing manifest and
   imported workspaces; fixture reseeding is a reset operation.
-- Canvas Agent scope activation must stay single-flight in
-  `src/main/agent/service.ts`: chat entry concurrently requests history and
-  session lists, so an unguarded check-then-initialize creates duplicate
-  engines for one scope and makes session switching visibly stall. Guard:
-  `src/main/agent/__tests__/service-history.test.ts`.
-- One chat scope has one authoritative run and one session-mutation lane.
-  `ActiveChatRegistry` owns IPC-visible run identity/abort/reconnect, while
-  `SessionMutationCoordinator` serializes chat against new/load/branch/delete/
-  rename/pin/import mutations; renderer scope activity is only a UX mirror.
-  Current senders must use prepare → subscribe → start: prepare reserves the
-  scope before returning, start upgrades that reservation and freezes the
-  main-resolved model into the persisted turn snapshot. A reservation owns the
-  run's AbortController so hard Stop latches even before start. The renderer
-  also sends its visible conversation-session id; after the mutation lane is
-  idle, main must compare-and-swap that pointer before calling the agent and
-  return the authoritative history on mismatch. Guards: `active-chat-registry.test.ts`,
-  `prepared-chat.test.ts`, `chat-protocol.test.ts`, `chat-session-cas.test.ts`,
-  and `__tests__/service-session-mutation.test.ts`.
-- The renderer has one visible approval card, so main must serialize concurrent
-  clarification requests and start each timeout only when that request becomes
-  visible. Answering one request must reveal, not clear, the next queued
-  request. Guard: `clarification-registry.test.ts`.
-- Conversation pointer changes are fail-closed. Archive publication and the
-  replacement current-session write must complete before the in-memory pointer
-  advances; queued persistence failures must remain observable through
-  `flush()`, while the serialization tail stays usable for repair. Archive
-  filenames must remain collision-safe even when timestamps and titles match.
-  Once a promoted session is durably current, cleanup of its stale archive
-  copies is best-effort: a cleanup failure must not report that the already
-  committed pointer change failed. Deleting the current session reverses that
-  order: stale data copies are removed before publishing the replacement
-  pointer, while post-commit metadata cleanup is best-effort.
+- Canvas Agent scope activation must stay single-flight in `src/main/agent/service.ts`, or an unguarded check-then-initialize creates duplicate engines for one scope and session switching visibly stalls.
+  Guard: `src/main/agent/__tests__/service-history.test.ts`.
+  Detail: `harness/knowledge/chat-sessions.md`.
+- One chat scope has one authoritative run (`ActiveChatRegistry`) and one session-mutation lane (`SessionMutationCoordinator`); senders must use prepare → subscribe → start, and main must CAS the renderer's session pointer before replying.
+  Guard: `active-chat-registry.test.ts`, `prepared-chat.test.ts`, `chat-protocol.test.ts`, `chat-session-cas.test.ts`, `__tests__/service-session-mutation.test.ts` (all under `src/main/agent/`).
+  Detail: `harness/knowledge/chat-sessions.md`.
+- The renderer has one visible approval card, so main must serialize concurrent clarification requests, starting each timeout only once visible; answering one must reveal, not clear, the next queued request.
+  Guard: `clarification-registry.test.ts`.
+  Detail: `harness/knowledge/chat-sessions.md`.
+- Conversation pointer changes are fail-closed: archive publication and the replacement current-session write complete before the in-memory pointer advances, with collision-safe archive filenames; deleting the current session reverses that order, and post-commit cleanup stays best-effort in both directions.
   Guard: `src/main/agent/__tests__/session-store.test.ts`.
-- Chat image uploads are bounded again in main before a prepared run is
-  accepted. Explicitly removing a ready draft attachment deletes its saved
-  file; clearing a successfully sent draft must retain the file because
-  session history references it. A failed turn must persist the live tool-call
-  snapshot and settle unfinished tools so reload matches the streamed UI.
-  Guards: `useChatAttachments.test.tsx`, `chat-protocol.test.ts`, and
-  `chat-failure-persistence.test.ts`.
-- An external-role driver rejection after its AbortSignal fires is a stopped
-  turn, never a failed turn. Preserve streamed partial text, merge live tool
-  events that the rejected driver could not return, and settle unfinished
-  tools as cancelled. Guards: `segment-execution.test.ts` and
-  `chat-stop.test.ts`.
-- The full-screen chat rail is one stable cross-scope projection. Do not swap
-  per-scope list caches into it or fetch a list while `loadSession` is
-  promoting an archive: either path can duplicate/reorder rows under the
-  pointer and move the scroll position. Commit current/other lists together
-  after promotion; guards live in `useChatSessions.test.tsx` and
-  `ChatSessionsRail.test.tsx`.
-- Chat-target registration is synchronously observed at the app root. Props
-  that feed a mounted `ChatPanel` target or its registered handlers must use
-  stable empty collection fallbacks; an inline `[]` makes the target unregister
-  and re-register on every broker-driven root render, reaches React's maximum
-  update depth, and clears the renderer. Workbench's node and selection
-  fallbacks are module constants and are covered by
-  `Workbench/__tests__/ChatDockLifecycle.test.tsx`; knowledge chat applies the
-  same stable-fallback rule, but is not exercised by that guard.
+  Detail: `harness/knowledge/chat-sessions.md`.
+- Chat image uploads are bounded again in main before a prepared run is accepted; removing a ready draft attachment deletes its file, clearing a sent draft retains it, and a failed turn persists its tool-call snapshot with unfinished tools settled.
+  Guard: `useChatAttachments.test.tsx`, `chat-protocol.test.ts`, `chat-failure-persistence.test.ts`.
+  Detail: `harness/knowledge/chat-sessions.md`.
+- An external-role driver rejection after its AbortSignal fires is a stopped turn, never a failed turn.
+  Guard: `segment-execution.test.ts`, `chat-stop.test.ts`.
+  Detail: `harness/knowledge/agent-roles.md` (stopped-vs-failed turn rule).
+- The full-screen chat rail is one stable cross-scope projection: never swap per-scope list caches into it or fetch a list while `loadSession` is promoting an archive; commit current/other lists together after promotion.
+  Guard: `useChatSessions.test.tsx`, `ChatSessionsRail.test.tsx`.
+  Detail: `harness/knowledge/chat-sessions.md`.
+- Chat-target registration is synchronously observed at the app root: props feeding a mounted `ChatPanel` target or its handlers must use stable empty-collection fallbacks, never an inline `[]`, or the target unregisters/re-registers every root render and hits React's max update depth.
+  Guard: `Workbench/__tests__/ChatDockLifecycle.test.tsx` (knowledge chat follows the same rule but isn't covered by this guard).
+  Detail: `harness/knowledge/chat-sessions.md`.
 - The app owns v2 canvas storage migration, PTY sessions, runtime-control
   endpoints, plugin activation, and UI-visible data recovery. The CLI adapts to
   those contracts but does not own them.
@@ -219,27 +162,9 @@ deploys the external-agent `pulse-canvas` CLI + bundled skills. Do not mix them.
   and stale saves merge edges by `updatedAt` without dropping unsaved local
   edges. Guards: `src/main/__tests__/canvas-store-merge.test.ts` and
   `src/renderer/src/hooks/useNodes.external-update.test.ts`.
-- Live-app capabilities belong under `src/main/runtime/capabilities/`; stable
-  Canvas Agent tools may adapt to them without changing their public names or
-  payloads. External `/capabilities/*` routes stay hidden unless the
-  `agent-runtime-control` experimental flag is enabled and always retain the
-  runtime file's bearer-auth boundary. Discovery includes each input JSON
-  schema, and the runtime policy must filter discovery and execution together;
-  Pulse CLI may access `read`/`operate`, never `unsafe`, by default. The shared
-  registry currently exposes browser-tab discovery, live page reads, Canvas
-  node read/search/update, and (only when `webview-page-control` is also
-  enabled) selector-based page click/fill. Arbitrary page JavaScript is the
-  `browser.page.eval` unsafe capability behind the stable deferred `page_eval`
-  Canvas Agent tool and requires both flags for external access. Arbitrary
-  host-renderer JavaScript is the separate `host.renderer.eval` unsafe
-  capability behind the deferred `canvas_host_eval` tool and `pulse-canvas
-  runtime host-eval`; it requires `agent-runtime-control`, checks the selected
-  workspace route before execution, and runs in the host page's main world.
-  It has no direct Node `require`, but it can call the app's renderer-exposed
-  `canvasWorkspace` preload bridge and therefore can trigger privileged main
-  actions. These are the only Pulse CLI `unsafe` exceptions.
-  External node updates are limited to title/content; arbitrary internal
-  `data` patches remain Canvas-Agent-only.
+- Live-app capabilities live under `src/main/runtime/capabilities/` behind tiered access (`read`/`operate`/`unsafe`) and the runtime server's bearer-auth boundary; Pulse CLI gets `read`/`operate` by default, with `browser.page.eval` (`page_eval` tool) and `host.renderer.eval` (`canvas_host_eval` tool / `pulse-canvas runtime host-eval`) as the only `unsafe` exceptions, each independently flag-gated; external Canvas node updates stay limited to title/content.
+  Guard: `src/main/runtime/capabilities/*.test.ts`, `src/main/runtime/__tests__/control-server.test.ts`.
+  Detail: `harness/knowledge/security-posture.md` ("Runtime-control capability tiers and registry").
 - Canvas node and edge shapes are sourced from `src/shared/canvas.ts`, not the
   shorter README node table. Current host node types include `file`,
   `terminal`, `frame`, `group`, `agent`, `text`, `iframe`, `image`, `shape`,
@@ -302,29 +227,13 @@ pnpm --filter canvas-workspace package:linux
 - `src/renderer/src/components/Workbench/`: mounted workspace state and chat
   portal ownership.
 - `src/renderer/src/components/RightDock/`: tabbed right dock for chat and
-  previews. Link tabs register their live webviews under the stable dock tab id;
-  a link tab's webview mounts lazily on first activation (DockPanes gates
-  `LinkTabView`'s `mountWebview`) so restored docks don't spawn one guest
-  process per tab on the cold-start path — once mounted it stays resident until
-  an explicit eligible L3 Memory Saver discard, and agent tools that activate a
-  tab before reading it poll for registration via `main/webview/ensure-operable.ts`.
-  page-element selection must reuse the shared iframe DOM picker/selection
-  context and route the result through Workbench's active-workspace chat bridge.
-  That bridge must queue selections until the target composer registers; opening
-  chat and retrying on the next animation frame is not a reliable mount barrier.
+  previews (link, artifact, node-detail, canvas-preview, terminal tabs).
+  Behavior: `harness/knowledge/dock-browser.md`.
 - `src/shared/canvas.ts`: canonical canvas node, edge, reference, and workspace
   node contracts.
-- `src/main/dock/`: right-dock tab support in main — `tab-store.ts` (renderer
-  tab mirror for `canvas_list_tabs`), `tab-actions.ts` (main→renderer
-  workspace-scoped `dock:activate-tab` push behind `canvas_activate_tab` and
-  the page_* tools' tab targeting, plus the app-level `dock:open-tab` push
-  behind `canvas_open_tab` and the app-level `dock:open-artifact` push used
-  by the scheduled memory report — artifact workspaceId is a storage scope
-  and may be the `__global_chat__` sentinel),
-  `history-store.ts` (web-tab browsing history behind `canvas_search_history`).
-  The renderer projection in `RightDock/tabRefs.ts` is the tab-discovery SSOT:
-  it covers link, artifact, node-detail, canvas-preview, and terminal tabs plus
-  active/visible/split state; terminal commands use `canvas_execute_terminal_tab`.
+- `src/main/dock/`: right-dock tab support in main — `tab-store.ts` (tab
+  mirror), `tab-actions.ts` (tab-activation pushes), `history-store.ts`
+  (browsing history). Detail: `harness/knowledge/dock-browser.md`.
 - `src/main/webview/lifecycle.ts`: shared Canvas-node and right-dock webview
   lifecycle policy. Real-time Feishu/Lark hosts remain eligible for the 1fps
   paint throttle but are exempt from L2 freeze and therefore L3 discard; match

--- a/apps/canvas-workspace/harness/knowledge/agent-roles.md
+++ b/apps/canvas-workspace/harness/knowledge/agent-roles.md
@@ -1,0 +1,504 @@
+# Multi-role chat (agent roles, relay, and external drivers)
+
+Multi-role chat lets the user @-mention one or more named personas ("roles")
+in a single AI Chat message. Addressing several roles turns the turn into a
+RELAY, where each role replies in order and reads the earlier roles' labeled
+replies from the shared history. A role can also be driven externally by a
+local coding-agent CLI (Claude Code or Codex) instead of the built-in
+engine. Read this before changing role-marker parsing or routing, the
+relay/turn stream events, the agent@agent handoff policy, role rendering or
+coloring in the composer/transcript/Settings, the external-driver adapters,
+or how an aborted external-role segment is normalized into a stopped turn.
+
+## Role contract, marker, and speaker-label SSOT
+
+`src/shared/agent-roles.ts` is the shared contract used by both main and
+renderer. Central pieces:
+
+- `AgentRoleDefinition`: `{ id, name, color (#rrggbb), prompt, external?,
+  createdAt, updatedAt }`. `external` is present only for an externally-driven
+  role (see below).
+- Mention marker: `@[role:<id>|<name>]`, built by `buildRoleMentionMarker`
+  and parsed by `parseRoleMentions` / `parseFirstRoleMention`. Per the
+  module's own top-of-file comment: "The main process derives the active
+  role for a turn by parsing the FIRST role marker from the message — there
+  is no separate roleId IPC field, so edit/regenerate flows that replay the
+  original message text keep their role for free."
+- Speaker-label SSOT: `formatSpeakerLabel(name)` returns `【${name}】`, and
+  `labelAssistantContent(content, speakerName)` prepends that label to the
+  content when a speaker name is present. Both model-history
+  label-injection points (see below) go through this helper.
+- Stream payload types: `RoleTurnStartEvent { index, total, speakerRole,
+  queue }`, `RoleTurnEndEvent { index, total, response, runId?,
+  speakerRole }`, and the shared `RoleTurnRoleRef { id, name, color,
+  namedBy? }`.
+- Validation limits shared by UI and store: `AGENT_ROLE_NAME_MAX_LENGTH` =
+  20, `AGENT_ROLE_PROMPT_MAX_LENGTH` = 4000, `AGENT_ROLE_COLORS` (the
+  default swatch palette), `isValidAgentRoleColor`, `sanitizeAgentRoleName`
+  (strips `[`, `]`, `|`, `@`, and newlines because those characters are
+  marker syntax).
+
+## Persistence and IPC (global role library)
+
+`src/main/agent/roles-store.ts` + `src/main/agent/agent-roles-ipc.ts` own
+the role library. It is ONE global library at `~/.pulse-coder/canvas/roles.json`
+shared by every chat scope (per-workspace chats, global chat, scheduled-task
+chats), so a persona defined once is @-mentionable everywhere. The file
+holds both the role array and library-level `settings` (see the handoff
+switch below); `readLibrary`/`writeLibrary` read and write both together,
+and `writeRoles` re-reads `settings` before writing so a role edit/create/
+delete round-trip never clobbers the settings half.
+
+IPC channels, all prefixed `agent-roles:`:
+
+- `agent-roles:list` — all roles.
+- `agent-roles:save` — create (no `id`) or update (with `id`) one role.
+- `agent-roles:delete` — remove one role by id.
+- `agent-roles:settings-get` / `agent-roles:settings-save` — library
+  behavior settings (the agent@agent handoff switch).
+- `agent-roles:external-probe` — health check for a driver family: is its
+  CLI on `PATH`, and which version.
+
+The preload surface is `window.canvasWorkspace.agentRoles`
+(`AgentRolesApi` in `src/shared/agent-roles.ts`), exposing `list`, `save`,
+`remove`, `getSettings`, `saveSettings`, `externalProbe`.
+
+## Persona injection and the relay boundary policy
+
+`src/main/agent/role-turn.ts` owns:
+
+- `formatActiveRoleSection(role, relay?, handoff?)` — the persona section
+  appended to the system prompt when a role speaks: it embeds
+  `role.prompt` inside `<role_persona>` tags, explains the 【Name】 labeling
+  convention, and — when the turn is a relay (`relay.total > 1`) — tells the
+  role its position ("speaker N of total") and instructs it to "Form your
+  OWN judgment first... Disagree openly when you disagree." When the turn
+  supports handoff, it lists the other @-able names and says the role may
+  hand off "ONLY when their perspective is genuinely needed." It also tells
+  the model: "When the user asks for many rounds, deliver them by @-ing the
+  next speaker at the end of your turn; the system keeps the discussion
+  going round by round."
+- `formatRoleHistoryNote()` — appended when the CURRENT turn is the default
+  assistant but the session already has labeled role replies, so the
+  default assistant understands what 【Name】 prefixes mean.
+- BOTH model-history label-injection points, which MUST stay in lockstep:
+  - live push: `applySpeakerLabelToResponseMessages(messages, speakerName)`
+    — mutates the just-produced response messages in place (shared by
+    reference with the live model history, so the NEXT segment reads the
+    label too).
+  - session reload: `sessionMessageToModelMessage(message)`, DEFINED in
+    this same file but INVOKED from `src/main/agent/canvas-agent.ts` at
+    every point session messages are mapped back into model messages
+    (initial restore, branch, delete, load, and general session-load —
+    each site does `.messages.map(sessionMessageToModelMessage)`). The
+    module's own top-of-file comment names this as the session-reload
+    injection point and says both this and the live-push path "go through
+    shared `labelAssistantContent`, guarded by role-turn tests."
+  Diverging these two is exactly what "roles start impersonating each
+  other" — see the module doc comment.
+- The relay boundary policy, `shouldRunRelaySegment(index, { aborted,
+  stopRequested })`: `false` if `aborted`; `false` if `stopRequested &&
+  index > 0`; `true` otherwise. Segment 0 always runs even if a stop was
+  already requested before the turn started.
+- The impersonation guard, `sanitizeRoleSegmentText(text, speakerName,
+  knownRoleNames)` (+ helper `stripSpeakerSelfLabels`): strips a leading
+  self-label and truncates a segment's raw reply at the first line/sentence
+  that starts with another known role's 【Name】 label, because the model
+  sometimes tries to write every speaker's turn inside one segment.
+  `replaceFinalAssistantText(messages, text)` pushes the sanitized text back
+  into the live model history so the trimmed part never reaches the next
+  speaker.
+- `resolveActiveRoles(message)` / `resolveActiveRole(message)` — resolve
+  ALL (or just the first) role markers in a message against the live
+  library, silently dropping stale (deleted-role) mentions.
+
+All of the above is pinned by `src/main/agent/__tests__/role-turn.test.ts`,
+including a dedicated `describe('speaker-label injection points stay in
+lockstep', ...)` block and a `describe('shouldRunRelaySegment (graceful-stop
+boundary)', ...)` block.
+
+## Routing: marker parsing → single turn vs. relay
+
+Routing parses ALL role markers out of the message text on the MAIN side
+(`parseRoleMentions`), order-preserving and id-deduped:
+
+- one role marker → a single persona turn;
+- several role markers → a RELAY, where each role runs as its own engine
+  segment against the shared history, so segment N+1 reads segment N's
+  labeled reply.
+
+Edit/regenerate replays simply re-run the whole turn with zero extra
+plumbing: because there is no separate roleId IPC field, replaying the
+original message text re-parses the same markers and reconstructs the same
+single-turn-or-relay shape for free.
+
+## Speaker attribution: clean storage, per-message snapshot
+
+Stored message content always stays clean — the 【name】 label exists only
+on the MODEL-FACING copy (built by the injection points above), never in
+what gets persisted to session history. Speaker name/color are PER-MESSAGE
+snapshots (`speakerRoleId`, `speakerRoleName`, `speakerRoleColor` on the
+persisted `CanvasAgentMessage` / renderer `AgentChatMessage`), so a message
+keeps showing who said it and in what color even after the role that spoke
+is later renamed, recolored, or deleted from the library.
+
+## Stream protocol and graceful vs. hard stop
+
+Per `src/main/agent/ipc.ts`'s channel doc comment:
+
+- Every turn emits a `role-turn-start` / `role-turn-end` pair PER SEGMENT,
+  on `canvas-agent:role-turn-start:{sessionId}` and
+  `canvas-agent:role-turn-end:{sessionId}` (subscribed in
+  `src/preload/bridge/agent.ts`, pushed from `src/main/agent/prepared-chat.ts`).
+  A single-speaker turn still emits exactly one pair, with `total=1`. A
+  relay emits one pair per speaking role, and `role-turn-start` carries the
+  FULL relay `queue` (so the renderer can draw progress from the very first
+  event).
+- `role-turn-end` fires only for a segment that completed SUCCESSFULLY — a
+  failed segment surfaces through the turn's `canvas-agent:chat-complete`
+  error instead, not through `role-turn-end`.
+- `canvas-agent:stop-relay` is the GRACEFUL boundary stop: the currently
+  speaking segment finishes normally, and only the FUTURE queued segments
+  are skipped. Main-side this is `CanvasAgentService.stopRelayForScope(scope)`
+  → `CanvasAgent.stopRelay()`, which just flips a per-turn `{ stopped:
+  boolean }` flag (`currentRelayStop`) that `shouldRunRelaySegment` reads
+  every loop iteration (see above). Renderer-side it is
+  `hooks/useChatRunControls.ts`'s `stopRelay()`, wired to `RelayBar`'s Stop
+  button (label "停止接龙" / "Stop relay").
+- The composer's own stop control calls `abort()` in the same
+  `useChatRunControls.ts` (→ `canvas-agent:abort`, "interrupt the
+  currently-running chat turn (hard stop)" per the ipc.ts doc comment) —
+  this remains the HARD stop: it fires the turn's `AbortController`
+  immediately, mid-segment, rather than waiting for the current speaker to
+  finish.
+
+## Agent@agent handoff policy (P2, opt-in)
+
+The library-level switch `allowRoleHandoff` (type `AgentRoleLibrarySettings`)
+lives in `roles.json`'s `settings`, edited from Settings → the **Chat
+Roles** section (`RolesSection` in `src/renderer/src/components/chat/RolesSettings.tsx`,
+Settings section id `chat-roles`) through `agent-roles:settings-get` /
+`agent-roles:settings-save`. Default is OFF
+(`DEFAULT_AGENT_ROLE_SETTINGS = { allowRoleHandoff: false }`); role writes
+preserve the setting, since `roles-store.ts`'s `writeRoles` always reads the
+current `settings` before writing the roles array back out.
+
+When ON, each ROLE segment's reply (never the default assistant's — see
+below) is scanned for plain-text `@RoleName` mentions with
+`findRoleNameMentions(text, names)`. This is NAME-based, not
+marker-based, because models write ordinary group-chat `@name` addresses in
+their replies and never emit the internal `@[role:...]` marker syntax.
+Matching is longest-name-first with span consumption (so with roles "评审"
+and "评审员", the text "@评审员" counts only for 评审员) and
+case-insensitive for ASCII names. Matches are appended to the SAME turn's
+relay queue.
+
+The append policy lives in `resolveHandoffRoles(replyText, { speaker,
+libraryRoles, pendingIds, capacity })`:
+
+- the speaker itself is always dropped (never hands off to itself);
+- roles already waiting in the queue are deduped out (not re-added);
+- roles that already SPOKE earlier in the turn MAY re-enter — that is how
+  back-and-forth discussion works;
+- growth is capped: the call site passes `capacity: ROLE_RELAY_MAX_SEGMENTS
+  - segments.length`, so the queue never exceeds `ROLE_RELAY_MAX_SEGMENTS`
+  = 30 total segments. The cap bounds AUTO-GROWTH from handoffs only —
+  user-named speakers (the roles the user originally @-mentioned) are never
+  truncated. "Stop relay" (above) is the way to end a long auto-growing
+  discussion early — the Settings hint literally says "up to 30 turns; Stop
+  relay ends it early."
+
+Auto-appended queue entries carry `namedBy` (the name of the role whose
+reply @-mentioned them in). `RelayBar.tsx` renders those steps with a
+dashed underline —
+`.chat-relay-step--handoff { text-decoration: underline dashed; }` in
+`src/renderer/src/components/chat/ChatPanel.css` — and a tooltip using the
+`roles.relayNamedBy` i18n key ("由 {name} 点名" in the zh locale, "Brought
+in by {name}" in en). Because a handoff can turn what started as a
+single-role turn into a relay mid-turn, the RelayBar can appear AFTER the
+turn has already started — pinned by
+`src/renderer/src/components/chat/hooks/relayTurnHandlers.test.ts`'s case
+"surfaces the bar mid-turn when a handoff grows a single-role turn into a
+relay."
+
+Default-assistant segments (no role — `role` is `null`) never hand off, and
+a pending graceful stop freezes the queue: in `src/main/agent/canvas-agent.ts`
+the handoff scan is gated on `handoffEnabled && role && !relayStop.stopped
+&& !stopped`, so once a stop is requested no further handoffs are appended.
+
+## Renderer surfaces and the role-color cache
+
+- Mention popup: roles form the `'role'` mention-item group and are listed
+  FIRST in the `@` popup — `src/renderer/src/components/chat/hooks/useMentions.ts`'s
+  own comment: "Chat roles lead the popup — addressing a persona is the
+  primary reason to type `@` in a role-enabled conversation."
+- Speaker badge: `src/renderer/src/components/chat/ChatMessage.tsx` renders
+  `message.speakerRoleName` / `message.speakerRoleColor` as the avatar
+  initial and a name badge on assistant messages.
+- Per-segment bubbles + completion policy:
+  `src/renderer/src/components/chat/hooks/relayTurnHandlers.ts`
+  (`createRelayTurnHandlers` opens a fresh attributed bubble on
+  `role-turn-start` and freezes it with the authoritative response +
+  speaker snapshot on `role-turn-end`, so the NEXT segment's deltas can
+  never bleed into a finished one; `applyTurnCompletion` is the
+  final-merge policy at `chat-complete` for whatever segment is still
+  in-flight) — tested by `relayTurnHandlers.test.ts`.
+- Progress strip: `src/renderer/src/components/chat/RelayBar.tsx`.
+- Settings editor: `src/renderer/src/components/chat/RolesSettings.tsx`,
+  behind the Settings **Chat Roles** (`chat-roles`) section.
+
+Role accents everywhere come from ONE renderer cache,
+`src/renderer/src/components/chat/hooks/roleMentionItems.ts`: it caches the
+`@` popup entries plus an id → accent-color map with a 5-SECOND TTL
+(`loadRoleMentionItems`, `cache.at`), exposed to components as
+`useRoleColors()` (and `useRoleNameColors()` for the plain-text `@Name`
+form an agent writes when handing off), and invalidated immediately by
+Settings save/delete (`invalidateRoleMentionItems()`, called from
+`useAgentRoles`'s `save`/`remove` in `RolesSettings.tsx`). Chips recolor by
+overriding the `--role-accent`, `--role-accent-icon`, `--role-accent-soft`
+CSS custom properties INLINE per chip in
+`src/renderer/src/components/chat/utils/mentions.ts`, so an unknown or
+deleted role id simply falls back to the chip class's default violet
+tokens instead of erroring.
+
+## Externally-driven roles (local coding-agent CLIs)
+
+Setting `AgentRoleDefinition.external = { family: 'claude-code' | 'codex',
+cwd? }` (`AgentRoleExternalDriver`, families enumerated in
+`AGENT_ROLE_EXTERNAL_FAMILIES`) routes that role's segments to
+`src/main/agent/external/` instead of the built-in engine:
+`executeCanvasAgentSegment` (`src/main/agent/segment-execution.ts`)
+branches on `options.role?.external` and calls `runExternalRoleSegment`
+(`src/main/agent/external/segment.ts`) instead of `engine.run(...)`.
+
+- Headless CLI spawn: Claude Code runs as `claude -p --output-format
+  stream-json --verbose --include-partial-messages` (`buildClaudeCodeArgs`
+  in `src/main/agent/external/claude-code.ts`), with the prompt piped
+  through STDIN (avoids `ARG_MAX` on long transcripts, per that file's
+  header comment).
+- Session continuity: `--resume <sessionId>` (Claude Code) / `codex exec
+  resume <sessionId>` (Codex), keyed per (chat-session × role) in
+  `~/.pulse-coder/canvas/external-agent-state.json`
+  (`src/main/agent/external/state-store.ts`, `getExternalSessionId` /
+  `saveExternalSessionId` / `clearExternalSessionId`, key
+  `` `${chatSessionId}:${roleId}` ``). A stored id is only reused while the
+  role's `family` AND resolved `cwd` are unchanged — a driver edit starts a
+  fresh CLI session.
+- Stale-resume retry: `runExternalRoleSegment` in
+  `src/main/agent/external/segment.ts` runs once with the stored
+  `sessionId`; if that throws, the run was NOT aborted by the user, and the
+  error message matches `RESUME_FAILURE_RE = /session|conversation|resume/i`,
+  it clears the stored session id and retries exactly once on a fresh
+  session (stale ids are the common cause of a resume failure).
+- Tolerant line parsers: `consumeClaudeStreamLine` /
+  `consumeCodexStreamLine` ignore unknown event/message types by design, so
+  CLI version drift degrades to coarser streaming instead of a crash — the
+  Claude adapter's own comment notes "the real 2.1.220 stream already
+  carries kinds we don't model." Both parsers are pinned against real
+  binary-shaped fixtures (including unrecognized event types) in
+  `src/main/agent/__tests__/external-driver.test.ts`.
+- The reply is appended to the shared model history BY HAND
+  (`segment-execution.ts` pushes `{ role: 'assistant', content: resultText
+  }` into `responseMessages` / `appendMessages` itself, since an external
+  CLI never calls the engine's `onResponse`), so the label/persist/handoff
+  tail downstream is identical to a normal engine segment's.
+- CWD resolution chain (`resolveExternalCwd` in
+  `src/main/agent/external/cwd.ts`, called from `segment.ts` before every
+  run): an explicit `role.external.cwd` pin wins, and if that configured
+  directory does not exist on disk it throws `External role working
+  directory does not exist: <path>` — a config error, never a silent
+  fallback. With no configured cwd: the chat's current workspace root
+  folder (if it exists) is used, so @-ing the same external role from a
+  different workspace runs it against that workspace's project; failing
+  that, a per-role scratch directory
+  `~/.pulse-coder/canvas/agent-home/<roleId>` is auto-created, so a
+  pure-discussion external role needs zero folder preparation.
+
+Tool activity is surfaced: both adapters translate their own event
+vocabulary — Claude's `tool_use` / `tool_result` content blocks; Codex's
+dialect-A `exec_command_begin/end`, `patch_apply_begin/end`,
+`mcp_tool_call_begin/end`, `web_search_begin/end` protocol messages AND
+dialect-B `item.started` / `item.completed` thread events — into the SAME
+`onToolCall` / `onToolResult` shape the built-in engine path emits, via the
+shared helpers `startTool` / `finishTool` in
+`src/main/agent/external/tool-events.ts`. Per that module's own
+"Robustness rule": a result whose call was never seen (dialect drift, a
+begin event this app does not model) still emits a synthetic call first —
+"a chip with an unknown name beats a silent gap." Tool results are
+truncated at `TOOL_RESULT_MAX_CHARS` = 4000 chars
+(`truncateToolResult`). The collected tool calls are mirrored into a
+persistable `CanvasAgentToolCall[]` list as they stream
+(`runExternalRoleSegment` in `segment.ts`), so a reloaded session keeps the
+same chips the live run showed.
+
+The persona prompt is OPTIONAL for external roles — they carry their own
+`CLAUDE.md`/`AGENTS.md` instructions in their working directory, and
+`renderExternalSegmentPrompt` (`src/main/agent/external/prompt.ts`) simply
+omits the `<role_persona>` block when `role.prompt` is empty. Persona
+(non-external) roles still require a non-empty prompt:
+`roles-store.ts`'s `saveAgentRole` throws `'Role prompt is required'` when
+`!prompt && !external`.
+
+### Safety posture
+
+- External roles respond ONLY to a DIRECT user `@` mention. Agent@agent
+  handoff never targets them: `handoffTargetRoles(roles)` in
+  `src/main/agent/role-turn.ts` filters out any role with an `external`
+  driver before it is used to build BOTH the handoff target library and the
+  advertised `@names` list a persona role is told about. Pinned in
+  `src/main/agent/__tests__/external-driver.test.ts`'s `describe('handoff
+  target policy', ...)` — "external roles are never handoff targets;
+  persona roles remain."
+- CWD existence is checked up front with a clear config error (see the CWD
+  resolution chain above) rather than silently substituting a fallback
+  directory for a configured-but-missing path.
+- Permissions defer entirely to the CLI's own local configuration: neither
+  adapter passes any permission/sandbox flag. Per each adapter's header
+  comment, Claude Code "obeys the user's own Claude Code settings for that
+  cwd" and Codex "obeys the user's own Codex config for that machine (same
+  posture as Claude Code)" — this feature never escalates beyond what the
+  user's own local agent config already allows.
+
+### Codex adapter specifics
+
+`src/main/agent/external/codex.ts` is the live Codex adapter:
+`buildCodexArgs` produces `codex exec --json --skip-git-repo-check -`
+(fresh session) or `codex exec resume <sessionId> --json
+--skip-git-repo-check -` (resumed) — the trailing `-` is the stdin sentinel
+that tells Codex to read the prompt from STDIN. `--skip-git-repo-check` is
+required because a role's cwd is a user-chosen directory that may not be a
+git repo; without it `codex exec` refuses to start. `consumeCodexStreamLine`
+accepts BOTH JSONL dialects Codex has shipped: dialect-A protocol events
+(`{ id, msg: { type, ... } }`, e.g. `agent_message_delta`, `task_complete`,
+`session_configured`) and dialect-B thread events (`{ type: 'item.started'
+| 'item.completed' | 'thread.started' | ... }`) — `--json` remains marked
+experimental upstream, hence tolerating both.
+
+### Env overrides and probe
+
+- Probe IPC: `agent-roles:external-probe` → `probeExternalCli(family)` in
+  `src/main/agent/external/runner.ts` runs `<cli> --version` with a 5s
+  timeout and reports the first stdout line as the version.
+- `PULSE_CANVAS_CLAUDE_CODE_CMD` — overrides the Claude Code binary
+  (`claudeCodeCommand()` in `claude-code.ts`, default `claude`).
+- `PULSE_CANVAS_CODEX_CMD` — overrides the Codex binary (`codexCommand()`
+  in `codex.ts`, default `codex`).
+- `PULSE_CANVAS_EXTERNAL_AGENT_STATE` — overrides the resume-state file
+  path (`state-store.ts`, default
+  `~/.pulse-coder/canvas/external-agent-state.json`).
+
+## Chat tool entry (chat_role_list / chat_role_save)
+
+`chat_role_list` / `chat_role_save` in `src/main/agent/tools/roles.ts` let
+the user build @-mentionable roles by describing them in chat instead of
+using the Settings editor. Because the role library is APP-level (one
+global `roles.json` shared by every chat scope), both tools are registered
+UNWRAPPED — i.e. not passed through the workspace-scoped
+`requireWorkspaceId` wrapper — in BOTH tool factories in
+`src/main/agent/tools/index.ts`: `createGlobalCanvasTools()` (global chat)
+and `createCanvasTools(workspaceId)` (per-workspace chat). Both tools are
+`defer_loading`. There is deliberately no `chat_role_delete` — removal
+stays a Settings-only action — the same posture as the scheduled-task
+tools (`chat_role_save`'s own description: "Deleting stays in Settings.").
+`chat_role_save`'s description also restricts it to what the user asked
+for in their own words: "ONLY when the user asked for the role in their
+own words." A role the agent creates this way becomes @-mentionable in the
+popup once the mention cache's 5-second TTL elapses (see the role-color
+cache above).
+
+## Stopped-vs-failed turn rule (external-role abort)
+
+RULE: an external-role driver's rejection that happens AFTER its
+`abortSignal` has fired is a STOPPED turn, never a FAILED turn. The turn
+must preserve whatever partial text had already streamed, merge in any
+live tool events the rejected driver's own return value could not carry,
+and settle unfinished tools as cancelled (not failed).
+
+Mechanism, in `src/main/agent/segment-execution.ts` and
+`src/main/agent/chat-stop.ts`:
+
+- `executeCanvasAgentSegment` wraps both the engine path and the external
+  driver's `runExternalRoleSegment` call in one `try`. `onText` deltas are
+  accumulated into a local `streamedText` as they arrive, independent of
+  whatever the driver call eventually returns or throws. If the call
+  throws AND `options.abortSignal.aborted` is true, the function does NOT
+  rethrow — it returns normally with `resultText: ENGINE_ABORT_SENTINEL`
+  (`chat-stop.ts`'s exported sentinel string, `'Request aborted.'`) and the
+  accumulated `streamedText`. If the abort signal is NOT set, the same
+  rejection rethrows as a real failure.
+- The caller (`src/main/agent/canvas-agent.ts`) turns that into lifecycle
+  state via `resolveSegmentOutcome({ signalAborted, resultText,
+  streamedText })`: `stopped` is true when `signalAborted` OR `resultText
+  === ENGINE_ABORT_SENTINEL`; the returned `rawText` is `streamedText` when
+  stopped (never the sentinel, so the sentinel string is never shown to the
+  user), or `resultText` (falling back to `'(no response)'`) otherwise.
+- Live tool events that the rejected driver's own return value could not
+  carry (because the throw happened before `runExternalRoleSegment`
+  returned its `toolCalls` array) are captured separately: a
+  `createFailedTurnToolTracker` (`src/main/agent/chat-failure-persistence.ts`)
+  is wired as the segment's `onToolCall`/`onToolResult`/`onToolInputStart`/
+  `onToolInputDelta`/`onToolInputEnd` callbacks, so it independently
+  accumulates whatever tool activity streamed before the abort, regardless
+  of how the driver call itself resolves. Its `snapshot()` is reset per
+  segment (`failedTurnTools.reset()`).
+- When `stopped` is true, `settleStoppedToolCalls(toolCalls,
+  failedTurnTools.snapshot())` (`chat-stop.ts`) merges any tool from that
+  tracker snapshot that is not already present in the segment's own
+  `toolCalls` list (matched by `toolCallId`, falling back to `name`), then
+  marks every tool still `'queued'` or `'running'` as `'cancelled'` with
+  `error: 'Operation cancelled by user'` (unless it already carries its own
+  error). Tools that already finished (`'succeeded'`/`'failed'`) are left
+  alone.
+- The persisted assistant message for a stopped segment sets
+  `turnStatus: 'stopped'` and `retryable: true` (never `'failed'`); only an
+  UNEXPECTED error reaching `CanvasAgent`'s outer `catch` (i.e. a real
+  failure, not a recognized abort) produces a `'failed'`-status message via
+  `failedAssistantMessage(error, failedTurnTools.snapshot())`.
+- If the abort lands before ANY segment has started,
+  `persistStoppedBeforeSegment` / `createStoppedBeforeSegmentOutcome`
+  (`chat-stop.ts`) produce the same empty `turnStatus: 'stopped',
+  retryable: true` message directly, without ever touching
+  `ENGINE_ABORT_SENTINEL`-style text.
+
+Guards: `src/main/agent/segment-execution.test.ts` (asserts a driver
+rejection after `abortController.abort()` normalizes to
+`resultText: ENGINE_ABORT_SENTINEL` with the partial `streamedText`
+preserved, and that the in-flight tool call settles as `cancelled` with
+`error: 'Operation cancelled by user'`) and `src/main/agent/chat-stop.test.ts`
+(unit tests for `resolveSegmentOutcome`, `settleStoppedToolCalls`,
+`createStoppedBeforeSegmentOutcome`/`persistStoppedBeforeSegment`, and
+`linkRunAbortSignal`, including "preserves streamed partial text and never
+exposes the engine abort sentinel").
+
+## Evidence
+
+Primary regression suites live in:
+
+- `src/main/agent/__tests__/role-turn.test.ts` — marker resolution, persona
+  sections, `shouldRunRelaySegment`, the impersonation guard, and the
+  lockstep speaker-label injection points.
+- `src/main/agent/__tests__/roles-store.test.ts` — role library
+  persistence, settings survival across role writes.
+- `src/main/agent/__tests__/roles-tools.test.ts` — `chat_role_list` /
+  `chat_role_save`.
+- `src/main/agent/__tests__/external-driver.test.ts` — both stream
+  parsers, tool-activity chip translation for both adapters, the external
+  session-state store, prompt rendering, the claude-code adapter +
+  segment orchestration (fake CLI, including the stale-resume retry and
+  the Ask-mode approval gate), `resolveExternalCwd`'s chain, the Codex
+  stream parser for both dialects and its argv building, and the handoff
+  target policy.
+- `src/main/agent/segment-execution.test.ts` — abort-after-reject
+  normalization for external-role segments.
+- `src/main/agent/chat-stop.test.ts` — the stop/abort helper functions in
+  `chat-stop.ts`.
+- `src/main/agent/chat-failure-persistence.test.ts` — `createFailedTurnToolTracker`
+  and `failedAssistantMessage`.
+- `src/renderer/src/components/chat/hooks/relayTurnHandlers.test.ts` —
+  segment bubble open/freeze on `role-turn-start`/`role-turn-end`, the
+  final-merge policy at `chat-complete`, and the mid-turn RelayBar
+  handoff-growth case.
+- `src/renderer/src/components/chat/hooks/roleMentionItems.test.ts` — the
+  role-color TTL cache, recolor notifications, the external-only
+  no-provider send guard, and the violet fallback on a failed library
+  read.

--- a/apps/canvas-workspace/harness/knowledge/chat-sessions.md
+++ b/apps/canvas-workspace/harness/knowledge/chat-sessions.md
@@ -1,0 +1,260 @@
+# Chat sessions
+
+Scope: the Canvas Agent chat surface's session lifecycle — renderer-side
+loading states, the full-page chat route's relationship to the right dock's
+content tabs, right-dock width behavior, and the main-process layer that
+keeps one authoritative run and one session pointer per chat scope. Read this
+before changing `hooks/useChatSessions.ts`
+(`src/renderer/src/components/chat/hooks/useChatSessions.ts`), the full-page
+chat topbar / dock content-tabs toggle, `RightDock/dock-width.ts`
+(`src/renderer/src/components/RightDock/dock-width.ts`), or
+`src/main/agent/service.ts` and its collaborators (`active-chat-registry.ts`,
+`session-mutation-coordinator.ts`, `prepared-chat.ts`, `chat-session-cas.ts`,
+`clarification-registry.ts`, `session-store.ts`,
+`chat-failure-persistence.ts`, `useChatAttachments.ts`).
+
+## Loading-state flags
+
+Three flags look similar and are not interchangeable.
+
+- `sessionsLoading` — the session LIST is being fetched. Drives the rail
+  spinner in `ChatSessionsRail.tsx` and the panel dropdown in
+  `ChatHeader.tsx`.
+- `sessionLoading` — THIS conversation's messages are being fetched. Drives
+  `ChatThreadSkeleton.tsx` in place of the thread, rendered via `ChatView` →
+  `ChatMessages`.
+- A third, unrelated flag: `useChatStream`'s `loading` means "the model is
+  generating". That one drives the three-dot `.chat-loading` indicator,
+  never the skeleton.
+
+`sessionsLoading` and `sessionLoading` both live in `hooks/useChatSessions.ts`
+(`src/renderer/src/components/chat/hooks/useChatSessions.ts`). Do not
+conflate them.
+
+**`runThreadFetch` and the request token.** Every thread-replacing IPC call —
+`getHistory`, `loadSession`, `loadCrossWorkspaceSession` — MUST go through
+`runThreadFetch`. It owns the `sessionLoading` flag AND a monotonic request
+token that drops superseded responses. Without it, two quick session picks
+let the slower one overwrite the session the user actually chose.
+`handleNewSession` must keep bumping that same token so an abandoned load
+can't repaint a blank new chat over whatever the user has since switched
+into.
+
+**Seeding.** `sessionLoading` is seeded TRUE at mount. Effects run after
+first paint, so a false seed would flash the empty state before the fetch
+even starts. `skipInitialHistory: true` therefore OBLIGES the caller to call
+`handleLoadSession` itself — with the initial history fetch skipped, nothing
+else will ever clear that seeded-true flag.
+
+**Submit veto.** Sending is vetoed while `sessionLoading` is true — the same
+rule that already blocks session switches while streaming. The veto is
+implemented in `useMentions`' `isSubmitBlocked`, not at a single call site,
+because the composer has TWO submit paths: the send button and
+`handleKeyDown`'s Enter key. A guard placed only in a caller's `handleSubmit`
+is a hole — one of the two paths would bypass it.
+
+Tests: `hooks/useChatSessions.test.tsx`,
+`hooks/useMentions.submit-veto.test.tsx`, `__tests__/ChatSessionLoading.test.tsx`
+(all under `src/renderer/src/components/chat/`).
+
+## Full-page chat topbar vs dock content tabs
+
+The full-page chat topbar (`chat/ChatPageBody.tsx`, shared by the AI Chat
+page and a scheduled task's chat page) has NO close button. Its right-most
+control instead shows/hides the dock's CONTENT tabs (link / artifact /
+node-detail / canvas-preview) beside the chat, and must never navigate — a
+control that routes away from the page the user is reading is not a panel
+toggle.
+
+`RightDock/dock-content-tabs.ts` owns that switch, via
+`store.toggleContentTabs`:
+
+- `openChat` / `toggleChat` cannot serve these routes, because the tab they
+  target (the chat/terminal tab) is hidden on this route.
+- An expanded dock still pointing at the chat/terminal tab must be
+  re-pointed at a content tab rather than collapsed — collapsing instead
+  would make the first click read as a no-op.
+- The button stays visible but disabled when no content tab exists yet (a
+  tab can land mid-conversation, e.g. the agent opening an artifact or
+  preview), and its topbar position must not jump around as that happens.
+  `chat.noDockTabs` labels the disabled state.
+
+**Inset rule.** These routes reflow like any other route, through
+`reserveSpace` — the dock inset must NOT be gated on `chatTabEnabled`. Gating
+it on `chatTabEnabled` is what previously let a link tab overlay and cover
+the AI Chat page.
+
+**Exits.** Esc and ⌘/Ctrl+Shift+L remain the exits from the AI Chat route.
+
+Tests: `RightDock/__tests__/dock-content-tabs.test.ts`, plus the no-chat-tab
+inset case inside `RightDock/index.test.tsx`.
+
+## Dock width policy
+
+`RightDock/dock-width.ts` (`src/renderer/src/components/RightDock/dock-width.ts`).
+
+- On the canvas, the dock may grow to ~95% of the viewport — the canvas
+  reflows behind it, so a near-full-screen dock is legitimate there.
+- Every page route caps it at 70% via `capWidth`
+  (`PAGE_MAX_VIEWPORT_RATIO = 0.7`; born at 0.5, widened in #893), because a
+  page IS the content and a 95%-wide dock would leave a chat thread in a
+  gutter.
+
+**Two layers, kept separate.**
+
+- `chosenWidth` — the dragged + persisted width the user chose.
+- The rendered `clampDockWidth(...)` output — derived per route from
+  `chosenWidth`.
+
+Clamping the STORED value (`chosenWidth`) would silently discard a wide
+canvas-mode dock width the first time the user opens a page route. Only the
+rendered width is clamped; the stored preference survives a
+canvas → page → canvas round trip untouched.
+
+**Stable clamp identity.** The clamp function handed to `useDockSplitView`
+must keep a STABLE identity — it is an effect dependency, and a per-route
+identity would re-clamp on every navigation.
+
+**Animation.** `.right-dock` animates `width` on the same curve as
+`.app-body`'s `margin-right`, so a route switch moves the page edge and the
+dock edge together. Drag-resize opts out of that animation via the
+`.right-dock-resizing` class.
+
+Tests: `RightDock/__tests__/dock-width.test.ts`, plus the capped-render case
+inside `RightDock/index.test.tsx`.
+
+## Main-side session integrity
+
+`src/main/agent/service.ts` (`CanvasAgentService`) and its collaborators keep
+one authoritative run and one session pointer per chat scope even when the
+renderer fires concurrent, overlapping requests at it.
+
+### Single-flight scope activation
+
+Canvas Agent scope activation must stay single-flight in
+`src/main/agent/service.ts`. Chat entry concurrently requests history and
+session lists, so an unguarded check-then-initialize would create duplicate
+engines for one scope and make session switching visibly stall.
+
+Guard: `src/main/agent/__tests__/service-history.test.ts`.
+
+### One authoritative run, one session-mutation lane
+
+One chat scope has one authoritative run and one session-mutation lane.
+
+- `ActiveChatRegistry` owns IPC-visible run identity/abort/reconnect.
+- `SessionMutationCoordinator` serializes chat against
+  new/load/branch/delete/rename/pin/import mutations.
+- Renderer scope activity is only a UX mirror of this main-side state; it is
+  not itself authoritative.
+
+**prepare → subscribe → start.** Current senders must use this three-step
+sequence: prepare reserves the scope before returning; start upgrades that
+reservation and freezes the main-resolved model into the persisted turn
+snapshot. A reservation owns the run's `AbortController`, so a hard Stop
+latches even before start.
+
+**Compare-and-swap (CAS) on the session pointer.** The renderer also sends
+its visible conversation-session id. After the mutation lane goes idle, main
+must compare-and-swap that pointer before calling the agent, and return the
+authoritative history on mismatch.
+
+Guards: `active-chat-registry.test.ts`, `prepared-chat.test.ts`,
+`chat-protocol.test.ts`, `chat-session-cas.test.ts`, and
+`__tests__/service-session-mutation.test.ts` (all under `src/main/agent/`).
+
+### Clarification serialization
+
+The renderer has one visible approval card, so main must serialize
+concurrent clarification requests and start each timeout only when that
+request becomes visible. Answering one request must reveal, not clear, the
+next queued request.
+
+Guard: `clarification-registry.test.ts`
+(`src/main/agent/clarification-registry.ts`).
+
+### Fail-closed conversation pointer changes
+
+Conversation pointer changes are fail-closed.
+
+- Archive publication and the replacement current-session write must
+  complete before the in-memory pointer advances.
+- Queued persistence failures must remain observable through `flush()`,
+  while the serialization tail stays usable for repair.
+- Archive filenames must remain collision-safe even when timestamps and
+  titles match.
+- Once a promoted session is durably current, cleanup of its stale archive
+  copies is best-effort: a cleanup failure must not report that the already
+  committed pointer change failed.
+- Deleting the current session reverses that order: stale data copies are
+  removed before publishing the replacement pointer, while post-commit
+  metadata cleanup is best-effort.
+
+Guard: `src/main/agent/__tests__/session-store.test.ts` (source:
+`src/main/agent/session-store.ts`).
+
+### Chat image upload bounds, attachment retention, failed-turn persistence
+
+Chat image uploads are bounded again in main before a prepared run is
+accepted.
+
+- Explicitly removing a ready draft attachment deletes its saved file.
+- Clearing a successfully sent draft must retain the file, because session
+  history references it.
+- A failed turn must persist the live tool-call snapshot and settle
+  unfinished tools so reload matches the streamed UI.
+
+Guards: `useChatAttachments.test.tsx`
+(`src/renderer/src/components/chat/hooks/useChatAttachments.ts`),
+`chat-protocol.test.ts`, and `chat-failure-persistence.test.ts` (both under
+`src/main/agent/`).
+
+### Full-screen chat rail projection
+
+The full-screen chat rail is one stable cross-scope projection.
+
+- Do not swap per-scope list caches into it.
+- Do not fetch a list while `loadSession` is promoting an archive — either
+  path can duplicate/reorder rows under the pointer and move the scroll
+  position.
+- Commit the current and other lists together after promotion.
+
+Guards: `useChatSessions.test.tsx` and `ChatSessionsRail.test.tsx` (both under
+`src/renderer/src/components/chat/`).
+
+### Stable chat-target fallbacks at the app root
+
+Chat-target registration is synchronously observed at the app root. Props
+that feed a mounted `ChatPanel` target or its registered handlers must use
+stable empty-collection fallbacks. An inline `[]` makes the target
+unregister and re-register on every broker-driven root render, reaches
+React's maximum update depth, and clears the renderer.
+
+Workbench's node and selection fallbacks are module constants, and are
+covered by `Workbench/__tests__/ChatDockLifecycle.test.tsx`
+(`src/renderer/src/components/Workbench/__tests__/ChatDockLifecycle.test.tsx`).
+Knowledge chat applies the same stable-fallback rule, but is NOT exercised by
+that guard.
+
+## Evidence
+
+Primary regression suites live in:
+
+- `src/renderer/src/components/chat/hooks/useChatSessions.test.tsx`
+- `src/renderer/src/components/chat/hooks/useMentions.submit-veto.test.tsx`
+- `src/renderer/src/components/chat/__tests__/ChatSessionLoading.test.tsx`
+- `src/renderer/src/components/chat/__tests__/ChatSessionsRail.test.tsx`
+- `src/renderer/src/components/RightDock/__tests__/dock-content-tabs.test.ts`
+- `src/renderer/src/components/RightDock/index.test.tsx`
+- `src/renderer/src/components/RightDock/__tests__/dock-width.test.ts`
+- `src/main/agent/__tests__/service-history.test.ts`
+- `src/main/agent/active-chat-registry.test.ts`
+- `src/main/agent/prepared-chat.test.ts`
+- `src/main/agent/chat-protocol.test.ts`
+- `src/main/agent/chat-session-cas.test.ts`
+- `src/main/agent/__tests__/service-session-mutation.test.ts`
+- `src/main/agent/clarification-registry.test.ts`
+- `src/main/agent/__tests__/session-store.test.ts`
+- `src/renderer/src/components/chat/hooks/useChatAttachments.test.tsx`
+- `src/main/agent/chat-failure-persistence.test.ts`
+- `src/renderer/src/components/Workbench/__tests__/ChatDockLifecycle.test.tsx`

--- a/apps/canvas-workspace/harness/knowledge/dock-browser.md
+++ b/apps/canvas-workspace/harness/knowledge/dock-browser.md
@@ -82,6 +82,12 @@ parent; either operation can cause Chromium to recreate the guest. Hidden
 guest navigations must write through to retained state so restore does not
 navigate back to a stale URL.
 
+`DockPanes` gates `LinkTabView`'s `mountWebview` prop on that same visibility
+check — the concrete mechanism behind first-mount laziness, so a restored
+dock does not spawn one guest process per tab on the cold-start path. Agent
+tools that activate a tab before reading it must poll for registration via
+`main/webview/ensure-operable.ts` rather than assume the guest already exists.
+
 ## Focus and keyboard ownership
 
 `RightDock/dock-browser-commands.ts` owns workspace-and-tab-qualified focus
@@ -102,6 +108,14 @@ web tab without destroying its browsing state, closes a reconstructible
 content/terminal tab, and leaves the pinned chat alone. Escape inside a web
 page stays page-owned so sites can close their own dialogs or exit modes.
 Dock-owned portals count as dock focus for scoped commands such as Find.
+
+## Page-element selection bridge
+
+Page-element selection in a dock browser tab must reuse the shared iframe
+DOM picker/selection context, then route the result through Workbench's
+active-workspace chat bridge. That bridge must queue selections until the
+target composer registers — opening chat and retrying on the next animation
+frame is not a reliable mount barrier.
 
 ## Tabs and discoverability
 
@@ -131,6 +145,23 @@ embedder boundary and are host viewport coordinates, even though Chromium's
 internal context-menu data begins guest-local. Pass those values directly to
 the fixed host portal; adding the webview host rect again double-offsets the
 menu and can make viewport clamping push it far away from the click.
+
+## Main-process tab registry and cross-surface pushes
+
+`src/main/dock/` is the main-process side of right-dock tab support:
+
+- `tab-store.ts` is the renderer tab mirror behind `canvas_list_tabs`.
+- `tab-actions.ts` sends the main→renderer workspace-scoped `dock:activate-tab`
+  push behind `canvas_activate_tab` and the page_* tools' tab targeting, the
+  app-level `dock:open-tab` push behind `canvas_open_tab`, and the app-level
+  `dock:open-artifact` push used by the scheduled memory report — artifact
+  `workspaceId` is a storage scope and may be the `__global_chat__` sentinel.
+- `history-store.ts` holds web-tab browsing history behind
+  `canvas_search_history`.
+
+`RightDock/tabRefs.ts` is the renderer-side tab-discovery SSOT: it covers
+link, artifact, node-detail, canvas-preview, and terminal tabs plus
+active/visible/split state. Terminal commands use `canvas_execute_terminal_tab`.
 
 ## Evidence
 

--- a/apps/canvas-workspace/harness/knowledge/keyboard-shortcuts.md
+++ b/apps/canvas-workspace/harness/knowledge/keyboard-shortcuts.md
@@ -1,0 +1,322 @@
+# Keyboard shortcuts
+
+The workbench's keyboard shortcuts are a cross-layer contract, not a single
+file: a binding declared in the renderer registry must be implemented by
+exactly one owning handler table, must not collide with an Electron menu
+accelerator (which wins before the renderer ever sees the key), must survive
+focus moving into an embedded `<webview>` guest or a focused terminal, and
+must be labeled consistently in the help overlay and the command palette.
+Read this file before adding, renaming, or removing a keyboard shortcut;
+before touching `src/main/app/menu.ts`'s roles or accelerators; before
+touching the webview shortcut-forwarding chain; or before changing terminal
+key handling.
+
+## Registry: the runtime SSOT
+
+`src/renderer/src/shortcuts/` is the runtime source of truth for every
+keyboard binding in the workbench:
+
+- `definitions.ts` — the binding table. Exports the `SHORTCUTS` const
+  (`satisfies Record<string, ShortcutDefinition>`), one entry per shortcut id
+  (e.g. `'canvas.commandPalette'`, `'canvas.zoomIn'`, `'app.toggleSidebar'`).
+  Each definition names an `owner` and a list of `bindings`. Also exports the
+  derived types `ShortcutId` (`keyof typeof SHORTCUTS`) and
+  `ShortcutIdFor<O extends ShortcutOwner>` — the mapped type that narrows
+  `ShortcutId` down to only the ids owned by one layer. This mapped type is
+  the actual mechanism behind the type-error guarantee described in the next
+  section.
+- `types.ts` — shape declarations: `ShortcutOwner` (which layer owns the
+  handler for a shortcut — `'canvas'` for `useCanvasKeyboard`, `'app'` for
+  `useAppShortcuts` in `App.tsx`, and `'document'` for the one binding
+  handled by a native document-level event instead of the keydown
+  dispatcher: `canvas.paste` is declared with `owner: 'document'`, because
+  letting the browser's native `paste` event arbitrate — rather than a
+  keydown handler — is what lets the system clipboard beat a stale canvas
+  clipboard); `KeyBinding` (`key`, `mod`, `ctrl`, `alt`, `shift`, `display`,
+  `hidden`); `ShortcutDefinition` (`owner`, `bindings`, `editable`,
+  `requiresSelection`); `EditablePolicy` (`'block' | 'allow'`); `KeyEventLike`.
+- `registry.ts` — matching + platform-correct labels: `formatBinding` (one
+  binding's display string — `⌘K` on macOS vs `Ctrl+K` elsewhere, via
+  `formatShortcut` in `src/renderer/src/utils/keyboardShortcut.ts`),
+  `formatShortcutId` (a definition's first visible binding, used for palette
+  shortcut hints), `formatAllBindings` (one label per visible binding — the
+  help overlay renders each as its own chip group, because joining them into
+  a single string made it split on `+` and chip `Ctrl+Tab / Ctrl+Shift+Tab`
+  as four separate pieces instead of two combos), and `matchesBinding` /
+  `matchShortcut` (the exact-modifier matcher — see below).
+
+Behavior is deliberately NOT declared in the registry — it lives in the
+owner's handler table, described next. The registry only knows chords,
+labels, and ownership.
+
+## Typed handler tables make a doc-only shortcut a type error
+
+Behavior lives in the owner's handler table:
+
+- `src/renderer/src/hooks/useCanvasKeyboard.ts` (owner `canvas`), gated on
+  the visible unlocked canvas.
+- `src/renderer/src/hooks/useAppShortcuts.ts` (owner `app`), works on every
+  route — split from the canvas layer on purpose, because the canvas layer
+  is gated on the visible unlocked canvas while these must keep working on
+  the chat page and the node pages.
+
+Both are typed `Record<ShortcutIdFor<'…'>, Handler>` — concretely
+`Record<CanvasShortcutId, (event: KeyboardEvent, binding: KeyBinding) =>
+void>` in `useCanvasKeyboard`, and `Record<AppShortcutId, (event:
+KeyboardEvent) => void>` in `useAppShortcuts`. Because `ShortcutIdFor<O>` is
+a mapped type over every id in `definitions.ts`, **a
+documented-but-unimplemented shortcut is a TYPE ERROR**: a definition declared with
+`owner: 'canvas'` that has no matching key in the `useCanvasKeyboard`
+handler object fails `tsc`, and deleting a handler while its definition (and
+therefore its help-overlay row) still exists fails to compile the same way.
+That is what previously let `Cmd+Shift+A` ship in the help overlay and the
+command palette with no handler while silently running select-all.
+
+This is the exact incident recorded at repo root (`AGENTS.md` §6,
+"Documented-but-unimplemented shortcuts"), in full:
+
+> Three surfaces hand-wrote the same binding (behavior, help overlay,
+> command palette), so `Cmd+Shift+A` shipped advertised-with-no-handler and —
+> because the matcher ignored unlisted modifiers — actually ran select-all.
+> Guard: `apps/canvas-workspace/src/renderer/src/shortcuts/` is the single
+> declaration site and the owning hooks type their handler tables as
+> `Record<ShortcutIdFor<owner>, Handler>`, making the gap a TYPE ERROR;
+> runtime halves are pinned by the `keyboard-shortcuts` rule in that
+> workspace's `harness/validate/validation.yaml`. Rule: a UI surface must
+> never hardcode a chord or its label — derive both from the registry.
+
+Never hand-write a chord condition (e.g. a raw `if (event.metaKey &&
+event.key === 'd')`) or a hardcoded label (e.g. a literal `'Cmd+D'` string)
+anywhere in the app again — both must come from the registry
+(`matchShortcut` / `formatBinding` / `formatShortcutId` / `formatAllBindings`).
+
+## Derived labels: help overlay and palette, behind a lazy boundary
+
+Two surfaces render shortcut labels, and both derive them from the registry
+instead of hardcoding strings:
+
+- The lazy `?` overlay, `src/renderer/src/components/AppShellProvider/ShortcutsDialog.tsx`,
+  exhaustively maps runtime shortcut IDs to display metadata — `SHORTCUT_HELP`
+  is itself declared `satisfies Record<ShortcutId, { section, descriptionKey }>`,
+  so it cannot go stale against the registry either — and derives its combo
+  labels from the registry via `formatAllBindings`. The same dialog also
+  renders `GESTURE_HELP`, help-only mouse gestures with no keyboard binding
+  at all (right-click/double-click to open the create menu, scroll to pan,
+  Space+Drag to pan, Ctrl/Cmd+Scroll to zoom, drag-on-blank-canvas for a
+  marquee select, click/Shift-click/Ctrl-Cmd-click for selection, Shift+drag
+  to extend a marquee, Ctrl/Cmd while dragging to disable snap), interleaved
+  into the same sectioned layout (`SECTION_ORDER`: `canvas`, `view`,
+  `selection`, `edit`, `panels`). `ShortcutsDialog` itself is only mounted
+  through `React.lazy(() => import('./ShortcutsDialog'))` in
+  `src/renderer/src/components/AppShellProvider/index.tsx` — it is not
+  loaded until the user opens the `?` overlay.
+- Palette hints, `src/renderer/src/components/Canvas/hooks/useCanvasPaletteCommands.ts`,
+  also derive from the registry: every Cmd+K palette command that has a
+  keyboard equivalent sets its `shortcut` field via
+  `formatShortcutId('canvas.…')` / `formatShortcutId('app.…')` rather than a
+  literal string.
+
+Keep help-only descriptions and gestures behind that lazy boundary (i.e., as
+entries in `ShortcutsDialog.tsx`'s `SHORTCUT_HELP` / `GESTURE_HELP`) instead
+of adding them to the startup matcher (`definitions.ts` and the handler
+tables) — a row that exists only to be documented does not need a
+`ShortcutDefinition` or a handler.
+
+## Matching semantics: exact on modifiers
+
+Matching is EXACT on modifiers. `matchesBinding` in `registry.ts` requires
+every unlisted modifier to be up, not just the listed ones to be down — a
+definition without `shift` does not fire when Shift is held. This exactness
+is what stops `Cmd+Shift+A` from falling into the `Cmd+A` (`canvas.selectAll`)
+branch: the earlier hand-written matcher checked only the modifiers a
+condition happened to mention, so an unlisted Shift fell through silently.
+
+## macOS-eaten chords
+
+macOS eats `Cmd+H` and `Cmd+Tab` before the renderer ever sees them
+(`Cmd+H` is "hide application", `Cmd+Tab` is the app switcher) — use literal
+`ctrl: true` for those bindings, not `mod: true`. In `definitions.ts` this is
+why `canvas.commandPaletteAlt` (the macOS-safe alternate to
+`canvas.commandPalette`'s `Cmd/Ctrl+K`) binds `{ key: 'h', ctrl: true }`, and
+`canvas.cycleNodes` binds `{ key: 'Tab', ctrl: true }` /
+`{ key: 'Tab', ctrl: true, shift: true }` rather than `mod: true` — `Cmd+Tab`
+is the macOS app switcher and never arrives at the renderer. The registry
+test suite (`registry.test.ts`, "keeps macOS-reserved chords off the mod
+modifier") pins this by asserting no binding for key `h` or `Tab` ever sets
+`mod: true`.
+
+## `editable: 'allow'` semantics
+
+`editable: 'allow'` is what keeps a chord alive inside a text field or
+terminal — reserved for chords that have no text-editing meaning, so
+stealing the keystroke from a focused input never costs the user a character
+they meant to type. Both dispatchers (`useCanvasKeyboard`'s `keydown`
+listener and `useAppShortcuts`'s) check `match.definition.editable !==
+'allow'` before applying their "is focus on an editable element" guard, so
+`'allow'` shortcuts are the only ones that still reach their handler while an
+`<input>`, `<textarea>`, or `contentEditable` element has focus. Every other
+definition defaults to `'block'` (the `EditablePolicy` default) and is
+dropped while an editable element is focused. `canvas.find` is a case where
+the handler adds its own narrower guard on top of `editable: 'allow'`: it
+explicitly excludes focus inside `.note-card`, because note cards own their
+own find flow and must not have canvas-level search steal focus from note
+editing, note panels, or note toolbar controls.
+
+## Menu-accelerator precedence
+
+Menu accelerators in `src/main/app/menu.ts` outrank ALL of the
+renderer-side matching described above: Electron consumes a `role` menu
+item's accelerator in the MAIN process before the keystroke ever reaches the
+renderer, so a default role claiming a chord makes that chord permanently
+unavailable to the registry no matter what `definitions.ts` says. The
+Undo/Redo and zoom roles are deliberately gone from the application menu so
+the canvas can own `Cmd+Z` and `Cmd+0/±` (`canvas.undo` /
+`canvas.redo`/`canvas.redoAlt`, and `canvas.zoomReset` / `canvas.zoomIn` /
+`canvas.zoomOut` in `shortcuts/registry.ts`'s definitions).
+
+This is the exact incident recorded at repo root (`AGENTS.md` §6, "Menu
+accelerators silently ate renderer shortcuts"), in full:
+
+> Electron `role` menu items consume a keystroke in MAIN before any renderer
+> listener sees it. The default `viewMenu` roles took `Cmd+0`/`Cmd+±` for
+> webFrame zoom, so the canvas could not own zoom at all, and the same class
+> had already forced Undo/Redo out of the Edit menu. Guard:
+> `apps/canvas-workspace/src/main/app/menu.ts` builds an explicit View menu
+> without the zoom roles and documents why. Rule: before adding any renderer
+> shortcut, check `menu.ts` for a role that claims the chord — and never add
+> a `role` whose accelerator collides with a registry binding.
+
+`menu.ts`'s own header comment documents the same two removals by name: the
+Edit menu's Undo/Redo (`CmdOrCtrl+Z` / `Shift+CmdOrCtrl+Z`) used to swallow
+the canvas's own history — text inputs still get native undo from Chromium
+once the key reaches the page, and the note editor (TipTap) ships its own
+history keymap, so removing the role does not remove undo from text editing,
+only from the canvas-eating accelerator; the View menu's `resetZoom` /
+`zoomIn` / `zoomOut` (`CmdOrCtrl+0` and `+`/`-`) used to zoom the whole UI via
+`webFrame`, which on a canvas app reads as a bug because the user means "zoom
+the canvas" — those keys now reach the renderer and drive the canvas
+transform instead. Today's `View` submenu keeps only `toggleDevTools` and
+`togglefullscreen` (plus `reload`/`forceReload`, gated behind
+`!app.isPackaged` so a stray `Cmd+R` in a packaged build cannot tear down
+every live terminal PTY and webview guest) — no resetZoom/zoomIn/zoomOut
+role remains. The `Edit` submenu keeps only `cut`/`copy`/`paste`
+(`pasteAndMatchStyle` on macOS)/`delete`/`selectAll` — no undo/redo role
+remains. Any future renderer shortcut must check `menu.ts` for a role that
+already claims its chord before relying on that chord reaching the renderer.
+
+## Webview forwarding whitelist chain
+
+Focus black holes are closed at the edges. Once focus moves into an embedded
+`<webview>` guest, host `keydown` listeners stop seeing anything at all — a
+guest is a separate Electron renderer process — so without forwarding, the
+command palette, workspace switching, canvas zoom, and even Escape would all
+go dead, with the mouse as the only way back out. Guests forward a narrow
+whitelist through three files, in this order:
+
+1. `src/shared/webview-shortcuts.ts` — declares `WEBVIEW_FORWARDED_CHORDS`,
+   the whitelist itself, grouped exactly as in source: command palette
+   (`{ key: 'k', mod: true }`) plus its macOS-safe alternate
+   (`{ key: 'h', ctrl: true }`); node cycling (`{ key: 'Tab', ctrl: true }`,
+   `{ key: 'Tab', ctrl: true, shift: true }`); canvas zoom
+   (`{ key: '0', mod: true }`, `{ key: '=', mod: true }`,
+   `{ key: '-', mod: true }`); panels (`{ key: 'a', mod: true, shift: true }`,
+   `{ key: 'e', mod: true, shift: true }`, `{ key: 'l', mod: true, shift: true }`,
+   `{ key: '\\', mod: true }`); workspace switching (`{ key: '1'..'9', mod: true }`,
+   all nine); and bare `Escape` — "the way back out of a guest that has
+   swallowed focus." It also exports `isForwardedShortcut`, the matcher main
+   uses to decide whether to intercept a guest keystroke at all. The list is
+   deliberately narrow: anything a web page might legitimately want — Cmd+F
+   find-in-page, Cmd+C/V, arrow keys, Delete — stays with the guest. It lives
+   in `shared/` because main cannot import the renderer's shortcut registry
+   directly; `registry.test.ts` ("forwards only chords the registry actually
+   binds") asserts every chord in `WEBVIEW_FORWARDED_CHORDS` still resolves
+   through `matchShortcut` for either the `canvas` or `app` owner, so the
+   whitelist and the registry cannot drift apart.
+2. `src/main/webview/shortcut-forwarding.ts` — `attachShortcutForwarding`
+   hooks each guest's `before-input-event` exactly once, tracked in a
+   `WeakSet<WebContents>` (`hooked`) so a destroyed guest drops out with no
+   bookkeeping and re-registering the same node id never stacks duplicate
+   listeners. For a whitelisted chord it calls `event.preventDefault()` on
+   the guest FIRST, before forwarding, so the page cannot also act on the
+   same key on top of the host action (e.g. a page's own Cmd+0 zoom reset, or
+   a web app treating Escape as "close my modal"); it then sends the chord to
+   the host over the `iframe:shortcut` IPC channel
+   (`WEBVIEW_SHORTCUT_CHANNEL`).
+3. `src/renderer/src/hooks/useWebviewShortcutBridge.ts` — receives that IPC
+   payload and re-dispatches it as an ordinary `window` `keydown`
+   (`new KeyboardEvent('keydown', { …, bubbles: true, cancelable: true })`)
+   rather than calling a handler directly. Re-dispatching (instead of calling
+   handlers directly) is deliberate: the canvas and app layers own their own
+   guards (locked canvas, open overlay, focused input), and routing through a
+   real event keeps exactly one set of rules instead of a second,
+   webview-specific code path.
+
+## Terminal key policy
+
+A focused terminal keeps Ctrl-chords but yields Cmd-chords and releases
+focus on double-Escape. The arbitration function is `decideTerminalKey` in
+`src/renderer/src/components/AgentNodeBody/utils/terminal.ts`. A focused
+terminal is otherwise its own keyboard black hole: xterm's helper element is
+a `<textarea>`, so the canvas dispatcher's editable guard silently drops
+every shortcut typed while it has focus, with no route back out. The split
+is asymmetric on purpose: Cmd-chords are safe to steal because a TTY never
+sees Cmd, but Ctrl-chords are the terminal's own language (`Ctrl+C`,
+`Ctrl+K` kill-line, `Ctrl+H` backspace, `Ctrl+\` SIGQUIT) and stay with the
+terminal exactly as they do in a real terminal emulator — which leaves
+Windows/Linux users needing a modifier-free way out. `decideTerminalKey`
+takes the event, the timestamp of the last Escape (`lastEscapeAt`), and the
+current time (`now`), and returns one of three `TerminalKeyDecision`
+values:
+
+- `'terminal'` — let xterm handle it (the default, and the fallback for
+  every non-Escape, non-Cmd key).
+- `'app'` — don't let xterm consume it; the app's shortcut layer handles
+  it. Chosen whenever `event.metaKey && !event.ctrlKey`.
+- `'release-focus'` — release focus back to the canvas. Chosen when
+  `event.key === 'Escape'` (with no Ctrl/Cmd/Alt held) and the previous
+  Escape landed within `TERMINAL_ESCAPE_HATCH_MS` (400ms) of this one — the
+  double-Escape. A single Escape still belongs to the shell (vim depends on
+  it); two in quick succession blur the terminal and hand focus back to the
+  canvas.
+
+## Bound checks
+
+Bound checks: the `keyboard-shortcuts` rule in `harness/validate/validation.yaml`.
+That rule's own comment states the split of responsibility explicitly:
+keyboard shortcuts are a cross-layer contract — bindings in
+`shortcuts/registry`, the canvas + app handler tables, the lazy help overlay
+and palette labels derived from them, the webview forwarding whitelist in
+`shared/`, and the terminal key arbitration. Typecheck already catches a
+documented-but-unimplemented shortcut (the handler tables are exhaustive by
+type); the suites bound by this rule cover the runtime halves instead —
+exact-modifier matching, auto-repeat, Escape ownership, and clipboard
+recency.
+
+The rule's `paths` cover: `src/renderer/src/shortcuts/**`,
+`src/renderer/src/hooks/useCanvasKeyboard.ts`,
+`src/renderer/src/hooks/useAppShortcuts.ts`,
+`src/renderer/src/hooks/useWebviewShortcutBridge.ts`,
+`src/renderer/src/utils/keyboardShortcut.ts`,
+`src/renderer/src/components/AppShellProvider/ShortcutsDialog.tsx`,
+`src/shared/webview-shortcuts.ts`,
+`src/main/webview/shortcut-forwarding.ts`, `src/main/app/menu.ts`, and
+`src/renderer/src/components/AgentNodeBody/utils/terminal.ts`.
+
+Its `quick` step and its `required` step both run:
+
+```
+pnpm --filter canvas-workspace exec vitest run src/renderer/src/shortcuts src/renderer/src/hooks/useCanvasKeyboard.test.ts src/renderer/src/hooks/useAppShortcuts.test.ts src/main/webview/__tests__/shortcut-forwarding.test.ts src/renderer/src/components/AgentNodeBody/utils/terminalKeys.test.ts
+```
+
+`required` additionally runs `pnpm --filter canvas-workspace typecheck`
+first.
+
+## Evidence
+
+Primary regression suites live in:
+
+- `src/renderer/src/shortcuts/registry.test.ts`
+- `src/renderer/src/hooks/useCanvasKeyboard.test.ts`
+- `src/renderer/src/hooks/useAppShortcuts.test.ts`
+- `src/main/webview/__tests__/shortcut-forwarding.test.ts`
+- `src/renderer/src/components/AgentNodeBody/utils/terminalKeys.test.ts`

--- a/apps/canvas-workspace/harness/knowledge/node-detail.md
+++ b/apps/canvas-workspace/harness/knowledge/node-detail.md
@@ -1,0 +1,236 @@
+# Node Detail (knowledge-node detail surface)
+
+Node Detail is the reading/editing surface for a knowledge-node record — a
+knowledge atom (no `x`/`y`/`width`/`height`), not a canvas node with spatial
+layout. Read this before changing the panel/host split, the
+`RightDock.enterNodePage` contract, the record→CanvasNode adapter, the
+`nodeDetailDescriptor.ts` surface table, save-failure handling, deleted-node
+semantics, cross-surface navigation, Escape ownership, or the
+`KnowledgeChatPortal` memoization rule.
+
+## One panel, two hosts — and why the dock is primary
+
+There is ONE panel component,
+`src/renderer/src/components/WorkspaceNodes/NodeDetailPanel.tsx`, rendered by
+TWO hosts:
+
+- the `/nodes/<ws>/<id>` page route
+  (`src/renderer/src/components/WorkspaceNodes/NodeDetailPage.tsx`);
+- the dock tab
+  (`src/renderer/src/components/RightDock/NodeDetailDockTab.tsx`, which
+  renders the panel with `mode="dock"`).
+
+The dock is the primary entry point: list cards, graph nodes, and note
+mentions all open a dock tab — the page is the drill-down from there, not the
+default landing surface. Consequently, a reading aid (or any other piece of
+UI) that renders only when `mode === 'page'` is invisible to most users, who
+never leave the dock. Concretely, `NodeDetailPanel` renders the AI-summary
+"reading aid" inline only in dock mode and hands it to the page's
+`NodeDetailContextRail` (`mode === 'page'`) instead of duplicating the
+page-only condition — the panel is written so the aid is reachable from both
+hosts rather than gated behind the less-visited one.
+
+`NodeDetailPanel` takes a `mode?: 'page' | 'dock'` prop (default `'dock'`)
+and switches several sibling components on it and on the descriptor's
+`layout` (see below): the back button, the inline AI-insight block, whether
+`NodeDetailSupplementary` (Relations/Info disclosures) renders, and whether
+the page-only `NodeDetailContextRail` renders.
+
+## Entering the page: the `RightDock.enterNodePage` contract
+
+Entering a full-page detail MUST go through `RightDock.enterNodePage`
+(`src/renderer/src/components/RightDock/dock-store.ts`). Its contract:
+
+- it removes the matching dock tab (the node's dock preview and its full
+  page are mutually exclusive — the same node should not show twice);
+- it collapses the dock ONLY when that matching preview was the active tab;
+- an unrelated active dock tab stays visible — page promotion must never
+  discard the user's other open context.
+
+In the current implementation this is:
+
+```ts
+enterNodePage(workspaceId: string, nodeId: string): void {
+  const id = nodeDetailTabId(workspaceId, nodeId);
+  const promotedActivePreview = this.state.expanded && this.state.activeTabId === id;
+  this.close(id);
+  if (promotedActivePreview) this.collapse();
+}
+```
+
+Bound test: `src/renderer/src/components/RightDock/__tests__/dock-store.test.ts`.
+
+## Subject and rendering: `WorkspaceNodeRecord` → `CanvasNode`
+
+The panel's subject is a `WorkspaceNodeRecord` (the knowledge atom; no
+`x`/`y`/`width`/`height`), not a `CanvasNode`. It is rendered through the
+real `CanvasNodeView` so a knowledge node reuses the exact same node body
+components the canvas itself uses, rather than a parallel read-only
+renderer:
+
+- `src/renderer/src/components/WorkspaceNodes/NodeCanvasPreview.tsx` adapts
+  record → `CanvasNode` (constructs a `CanvasNode`-shaped object from the
+  record's `id`/`type`/`title`/`data`/`properties`/`links`/`updatedAt`, plus
+  a measured `width`/`height` from a `ResizeObserver`) and renders it via
+  `CanvasNodeView` with `embedded hideHeader`.
+- Layout fields (`x`/`y`/`width`/`height`/ref) live only in this preview —
+  any patch targeting those fields is dropped before it reaches the
+  workspace-node store; only `title`, `data`, `properties`, and `links` are
+  writable (`WritablePatch` in `NodeCanvasPreview.tsx`).
+
+## `nodeDetailDescriptor.ts`: the surface SSOT
+
+`src/renderer/src/components/WorkspaceNodes/nodeDetailDescriptor.ts` is the
+single source of truth for type → surface/layout/capability. Callers never
+pass a second, potentially contradictory presentation string — every host
+asks this one table.
+
+Current shape (`NodeDetailDescriptor`): `surface: 'document' | 'web' |
+'mindmap'`, `layout: 'document' | 'workspace'`, `metadata: 'inline' |
+'inspector'`, `selectEmbeddedNode: boolean`, `backgroundPan: boolean`.
+`getNodeDetailDescriptor(type)` returns `WEB_DETAIL` for `'iframe'`,
+`MINDMAP_DETAIL` for `'mindmap'`, and `DOCUMENT_DETAIL` otherwise.
+
+Policy per type:
+
+- **File/Text and other document-like records** use the generic document
+  layout (`layout: 'document'`, `metadata: 'inline'`) — plain metadata
+  inline, no rich embedded surface.
+- **Web (`iframe`) and Mindmap** are rich working surfaces
+  (`layout: 'workspace'`, `metadata: 'inspector'`): the real node body fills
+  the remaining area, compact metadata lives behind the header Info
+  inspector instead of inline, and generic Relations/Info/context-rail
+  chrome stays absent for these types.
+  - `NodeDetailPanel` derives `isRichDetail = detail.layout === 'workspace'`
+    and gates `NodeDetailSupplementary` (Relations/Info disclosures) and the
+    page-only `NodeDetailContextRail` behind `!isRichDetail`; it also adds
+    `node-detail-panel--rich node-detail-panel--<surface>` classes when rich.
+  - The Info inspector itself lives in
+    `src/renderer/src/components/WorkspaceNodes/NodeDetailHeader.tsx`
+    (`metadata === 'inspector'` branch, backed by
+    `NodeDetailInspector.tsx`).
+- **Web** retains its iframe navigation bar.
+- **Mindmap** retains selected-topic editing, pointer-event background pan,
+  keyboard pan, and an explicit center action — see the `mindmapPan`
+  handlers (`onPointerDown`/`onPointerMove`/`onPointerUp`/
+  `onPointerCancel`/`onLostPointerCapture`/`onKeyDown`, and the center
+  `Button`) wired in `NodeCanvasPreview.tsx` via
+  `src/renderer/src/components/WorkspaceNodes/useMindmapDetailPan.ts`.
+
+## Save failures: the adapter must never reject into a node body
+
+The canvas's own `onUpdate` contract never rejects. Every node body is
+written against that non-rejecting contract and calls `onUpdate`
+fire-and-forget — confirmed in `TextNodeBody`, `MindmapNodeBody`, and
+`IframeNodeBody` (`src/renderer/src/components/TextNodeBody/index.tsx`,
+`src/renderer/src/components/MindmapNodeBody/index.tsx`,
+`src/renderer/src/components/IframeNodeBody/index.tsx`). If
+`NodeCanvasPreview`'s adapter rejected on a failed record write, that
+rejection reached nobody and surfaced only as an unhandled promise
+rejection — worse, the pre-fix behavior of re-reading the stored record on
+failure actively discarded exactly the edit that had failed to save (the one
+thing the user cannot retype from the UI).
+
+The fix, in `commitPatch` / `retryFailedSave` / `discardFailedSave`
+(`src/renderer/src/components/WorkspaceNodes/NodeCanvasPreview.tsx`):
+
+- a failed record write HOLDS the optimistic content on screen (it is never
+  reverted to the last-known-good record);
+- external change events are refused/ignored while a failure is held
+  (`updatePendingRef` / `failedPatchRef` gate the record-sync effect);
+- the panel shows a retry/discard banner
+  (`src/renderer/src/components/WorkspaceNodes/NodeCanvasSaveError.tsx`);
+- a further failure while one is already pending is merged into the same
+  pending patch via `mergePatches`, so retry replays every unsaved change,
+  not just the last keystroke.
+
+`FileNodeBody`'s own `.note-save-status` UI
+(`src/renderer/src/components/FileNodeBody/index.tsx`,
+`src/renderer/src/components/FileNodeBody/index.css`) reports *file* writes
+— a disjoint failure from the *record* write above, so both can be visible
+at once without one hiding the other.
+
+Bound test:
+`src/renderer/src/components/WorkspaceNodes/__tests__/NodeCanvasPreview.test.tsx`
+(save-failure + rich-presentation guards).
+
+## Deleted-node "missing" semantics
+
+The `workspace-node:read` IPC answers a deleted node with `ok: true` and NO
+record — this is indistinguishable from "nothing selected" unless a caller
+tracks it explicitly.
+`src/renderer/src/components/WorkspaceNodes/useWorkspaceNodes.ts`'s
+`useWorkspaceNode` exposes that case as a separate `missing` boolean. A host
+that conflates `missing` with "nothing selected" tells someone their deleted
+node is merely unselected, which is misleading. The dock tab
+(`NodeDetailDockTab.tsx`) must also stop advertising the node's old title
+once it goes missing, rather than leaving a stale title on the tab.
+
+## Cross-surface travel: window events, not host callbacks
+
+Node Detail renders in two hosts (a page route and a dock tab), so neither
+host can own navigation callbacks — cross-surface travel is done with window
+events, never host callbacks threaded down through the shared panel:
+
+- `src/renderer/src/components/WorkspaceNodes/useNodeDetailBridges.ts`
+  (`useNodeDetailBridges`) carries page↔canvas travel, including
+  `FOCUS_NODE_ON_CANVAS_EVENT`;
+- `dispatchOpenNode` (`src/renderer/src/utils/openNodeBridge.ts`) is used for
+  relation rows.
+
+`openNodeBridge.ts` also defines the sibling events `useNodeDetailBridges`
+listens for: `OPEN_NODE_PAGE_EVENT` (`dispatchOpenNodePage`) to drill into a
+node's own page, and `FOCUS_NODE_ON_CANVAS_EVENT`
+(`dispatchFocusNodeOnCanvas`) to leave the knowledge surfaces and frame the
+node on its canvas.
+
+## Escape ownership
+
+The page owns its own Escape handling —
+`src/renderer/src/components/WorkspaceNodes/NodeDetailPage.tsx` adds a
+`window` `keydown` listener in the bubble phase, gated on the event target
+(ignored when the target is an `INPUT`/`TEXTAREA`/`contentEditable` element,
+an open overlay, or an IME composition), and calls `onBack()`.
+
+`src/renderer/src/hooks/useEscapeClose.ts` (`useEscapeClose`) is different by
+design: it listens on `document` in the CAPTURE phase and calls
+`stopPropagation()` — it backs the tag picker in
+`src/renderer/src/components/WorkspaceNodes/NodeTagEditor.tsx`. Capture-phase
+listeners run before any bubble-phase listener sees the event at all, so if
+the page's own Escape subscriber were also capture-phase, it would win that
+race and eat the Escape before it ever reached the tag picker's
+`useEscapeClose` or `NodeTitleEditor.tsx`'s own inline Escape-to-cancel
+`onKeyDown` handler. Keeping the page's handler bubble-phase and
+target-gated is what lets a focused popover or in-progress title edit keep
+first claim on Escape.
+
+## `KnowledgeChatPortal` memoization rule
+
+The detail route also hosts the global chat through
+`src/renderer/src/components/Workbench/KnowledgeChatPortal.tsx`. It must
+memoize its selected node by the semantic `(workspaceId, nodeId)` pair —
+concretely, `useMemo(() => buildKnowledgeChatContext(nodes, tags,
+selectedNode), [nodes, selectedNodeId, selectedWorkspaceId, tags])`, keyed
+off `selectedNode?.nodeId` / `selectedNode?.workspaceId` — never by the
+`selectedNode` object's identity or the identity of the route object it came
+from. If the memo dep were the route/selection object's identity instead of
+the two primitive ids, a fresh object each render would recompute the chat
+context every render; that recomputation is what causes the active-target
+broker publish to trigger a parent rerender, which produces a new object
+again, which unregisters and re-registers the chat target in a loop — surfacing
+as React's "Maximum update depth exceeded".
+
+## Evidence
+
+Bound tests:
+
+- `src/renderer/src/components/WorkspaceNodes/__tests__/NodeDetailPanel.test.tsx`
+- `src/renderer/src/components/WorkspaceNodes/__tests__/NodeCanvasPreview.test.tsx`
+  — save-failure + rich-presentation guards
+- `src/renderer/src/components/WorkspaceNodes/__tests__/nodeDetailStyles.test.ts`
+- `src/renderer/src/components/RightDock/__tests__/dock-store.test.ts`
+- `src/renderer/src/components/WorkspaceNodes/__tests__/NodeDetailPage.escape.test.tsx`
+- `src/renderer/src/components/WorkspaceNodes/useWorkspaceNodes.test.tsx`
+- `src/renderer/src/components/Workbench/__tests__/ChatDockLifecycle.test.tsx`
+  — includes the knowledge-detail chat-target-stability regression for the
+  `KnowledgeChatPortal` memoization rule above

--- a/apps/canvas-workspace/harness/knowledge/packaged-tooling.md
+++ b/apps/canvas-workspace/harness/knowledge/packaged-tooling.md
@@ -1,0 +1,163 @@
+# Packaged CLI + skills tooling (`AgentToolingManager`)
+
+Packaged builds bundle the existing `@pulse-coder/canvas-cli` under Electron
+resources and install it as a versioned, self-contained payload into the
+user's home directory, independent of any system Node or package manager.
+Read this file before changing `src/main/files/agent-tooling-*`,
+`src/main/files/skill-installer.ts`, `src/main/files/shell-path.ts`, or
+anything that triggers a tooling install/repair/update.
+
+## What gets installed, and where
+
+On first launch and after app updates, the app idempotently installs:
+
+- its versioned CLI files under `~/.pulse-coder/tooling/pulse-canvas/`
+  (`toolingRoot()` in `src/main/files/agent-tooling-state.ts`:
+  `join(installRoot, 'tooling', 'pulse-canvas')`, where `installRoot` is
+  `~/.pulse-coder`);
+- a no-system-Node wrapper under `~/.pulse-coder/bin/` (`unixWrapper`/
+  `windowsWrapper` in `src/main/files/agent-tooling-files.ts` — a shell
+  script or batch file that re-execs the packaged Electron host binary with
+  `ELECTRON_RUN_AS_NODE=1`, so invoking the CLI never depends on a
+  system-installed Node);
+- all bundled skills into the Pulse/Codex/Claude global skill dirs
+  (`SKILL_PARENT_DIRS` in `src/main/files/skill-installer.ts`:
+  `~/.pulse-coder/skills`, `~/.claude/skills`, `~/.codex/skills`).
+
+Treat the CLI + skills as one compatibility bundle: they are installed and,
+on failure, rolled back together (see "Failure-atomic bundle activation"
+below) — never ship a change that updates one without the other.
+
+## Production installation must never depend on a source checkout
+
+Production installation must never depend on a source checkout, `pnpm`, or a
+global link. `resolveBundleRoot()` in `skill-installer.ts` enforces the
+split: a packaged app (`app.isPackaged`) always resolves its bundle from
+`process.resourcesPath` (`agent-tooling`); only an unpackaged dev run walks
+upward from the app path looking for `pnpm-workspace.yaml` to find a source
+checkout (`packages/canvas-cli`), and even that falls back to a bundled
+`resources/agent-tooling` path if no checkout is found.
+
+## Trigger points funnel through one shared manager
+
+Keep startup, Settings repair, and experimental-trigger installs on the
+shared `AgentToolingManager` (`createAgentToolingManager` in
+`src/main/files/agent-tooling-manager.ts`). Concretely, three call sites feed
+the same manager:
+
+- **Startup**: `ensureAgentToolingAtStartup` (`skill-installer.ts`), called
+  from `src/main/app/bootstrap.ts`, runs the `'reconcile'` action — but only
+  when `app.isPackaged`. A packaged app treats first launch as its
+  cross-platform install hook: macOS DMGs have no reliable post-install
+  phase, so deployment happens here and repeats idempotently after every app
+  update.
+- **Settings repair**: the `skills:install` IPC handler calls `runInstall()`,
+  which runs the `'repair'` action. The renderer's Settings → Agent section
+  (`AgentSection.tsx`) defaults its install callback to this same `'repair'`
+  action.
+- **Experimental-trigger installs**: toggling the `agent-teams` experimental
+  flag (`EXPERIMENTAL_FLAG_AGENT_TEAMS`) from off to on triggers a
+  fire-and-forget `runInstall()` call from
+  `src/main/settings/experimental-ipc.ts`'s `experimental:set` handler, so
+  the bundled Canvas skills and CLI wrapper install/repair in the background
+  as soon as the feature is enabled, without the user needing to separately
+  visit the Agent repair button.
+
+All three funnel into `createAgentToolingQueue`
+(`src/main/files/agent-tooling-queue.ts`), a single-flight queue over
+`AgentToolingManager.ensureInstalled({ action })`. Any new trigger must call
+through this shared queue rather than `ensureInstalled` directly, or
+concurrent triggers can race each other's installs.
+
+## Update policy: `follow-app` (default) / `ask` / `pinned`
+
+The persisted update policy under the tooling root
+(`~/.pulse-coder/tooling/pulse-canvas/update-policy.json`, read/written by
+`readUpdatePolicy`/`writeUpdatePolicy` in `agent-tooling-state.ts`) defaults
+to following app updates (`'follow-app'`). `'ask'` and `'pinned'` retain the
+active bundle until an explicit Settings update, while damage repair of that
+active bundle remains automatic from its fingerprinted local payload cache
+regardless of which policy is set — an `ask`/`pinned` policy opts out of
+*upgrading* the active bundle, never out of *repairing* it back to what is
+already active.
+
+## Fingerprint-qualified, immutable runtime payload directories
+
+Runtime payload directories are fingerprint-qualified and immutable across
+updates, so a same-semver replacement cannot overwrite the CLI currently
+referenced by the launcher. Concretely (`prepareCliPayload` in
+`src/main/files/agent-tooling-deployment.ts`): each deployed bundle lives
+under `<toolingRoot>/.cache/<fingerprint>/` and
+`<toolingRoot>/.runtime/<fingerprint>/`, where `<fingerprint>` is a sha256
+over the CLI entrypoint plus every bundled skill's `SKILL.md`
+(`fingerprintCliTree` in `agent-tooling-files.ts`). A new deployment writes a
+new fingerprint directory instead of mutating an existing one, so the active
+launcher keeps pointing at the fingerprint directory it was built against
+until activation explicitly repoints it. `isBundleCurrent` validates a
+fingerprint directory's on-disk marker (`BUNDLE_MARKER =
+'.pulse-canvas-bundle.json'`) against a freshly recomputed fingerprint before
+trusting that directory as the automatic-repair cache.
+
+## Failure-atomic bundle activation
+
+Bundle activation is failure-atomic: a skill, launcher, or active-state
+write failure must restore the previously active set. `deployAgentTooling`
+(`src/main/files/agent-tooling-deployment.ts`) snapshots the current
+launcher wrapper and every skill file it is about to overwrite before
+writing anything. If the wrapper write or the active-state write throws
+after skills were already installed, the `catch` block restores the wrapper
+snapshot, rolls back every snapshotted skill file, and restores the previous
+`active.json` state (or clears it if there was none) — all via
+`Promise.allSettled`, so one rollback failure does not block the others.
+
+## Explicit shell-PATH setup is opt-in, never automatic
+
+Settings may offer an explicit shell-PATH setup for zsh/bash/fish
+(`configurePulseCanvasShellPath`/`inspectPulseCanvasShellPath` in
+`src/main/files/shell-path.ts`, surfaced through the Settings UI). It
+appends one marked `~/.pulse-coder/bin` entry (for example
+`export PATH="$HOME/.pulse-coder/bin:$PATH"`, or `fish_add_path
+"$HOME/.pulse-coder/bin"` for fish) only after a user click, never during
+automatic install/update.
+
+## Key files
+
+- `src/main/files/agent-tooling-manager.ts` — `AgentToolingManager` /
+  `createAgentToolingManager`: `status()`, `ensureInstalled({ action })`,
+  `setUpdatePolicy()`.
+- `src/main/files/agent-tooling-state.ts` — `toolingRoot()`, and the
+  update-policy / active-state read-write pair (`update-policy.json`,
+  `active.json`).
+- `src/main/files/agent-tooling-files.ts` — wrapper generation
+  (`unixWrapper`/`windowsWrapper`), `fingerprintCliTree`,
+  `isBundleCurrent`/`isLauncherCurrent`, `atomicWrite` (tmp-write + rename).
+- `src/main/files/agent-tooling-deployment.ts` — `deployAgentTooling`
+  (failure-atomic activation), `prepareCliPayload` (fingerprint cache/runtime
+  directories), `installSkillsTransaction`.
+- `src/main/files/agent-tooling-queue.ts` — `createAgentToolingQueue`, the
+  single-flight action queue shared by every trigger.
+- `src/main/files/skill-installer.ts` — `ensureAgentToolingAtStartup`,
+  `resolveBundleRoot`, `SKILL_PARENT_DIRS`, and the `skills:*` IPC handlers
+  (`install`, `update`, `status`, `configure-path`, `set-update-policy`,
+  `cleanup-legacy`).
+- `src/main/files/shell-path.ts` — shell-PATH inspect/configure helpers.
+- `src/main/settings/experimental-ipc.ts` — the `agent-teams` flag's
+  fire-and-forget install trigger.
+- `src/renderer/src/components/Settings/AgentSection.tsx`,
+  `AgentShellPathCard.tsx` — Settings UI.
+- `src/main/app/bootstrap.ts` — calls `ensureAgentToolingAtStartup` at
+  startup.
+
+## Bound checks
+
+The `packaged-agent-tooling` rule in `harness/validate/validation.yaml`
+binds this whole surface (manager, files, deployment, queue, state,
+skill-installer, shell-path, and the Settings UI files above) to:
+
+- quick/required: `pnpm --filter canvas-workspace exec vitest run
+  src/main/files/agent-tooling-manager.test.ts
+  src/main/files/agent-tooling-queue.test.ts src/main/files/shell-path.test.ts
+  src/main/__tests__/agent-tooling-package.test.ts`
+- manual (release-level, actually packages the app): `pnpm --filter
+  canvas-workspace package:mac:arm64 && node
+  apps/canvas-workspace/harness/tools/smoke-packaged-agent-tooling.mjs`

--- a/apps/canvas-workspace/harness/knowledge/scheduled-tasks.md
+++ b/apps/canvas-workspace/harness/knowledge/scheduled-tasks.md
@@ -1,0 +1,176 @@
+# Scheduled tasks
+
+Scheduled is a stable top-level app surface — its own route, not a canvas
+feature — for persisted, user-defined recurring background work: an exact
+next-due main-process timer backed by a 30-minute heartbeat, startup/resume
+catch-up, manual run-now, and one isolated durable Agent chat scope per task.
+Getting any piece of this wrong either drops a run silently, replays a missed
+run more than once, or announces a finished background run in a way that
+hijacks the app out from under the user.
+
+Main-process home: `src/main/scheduled/` — `ipc.ts` (the `scheduled:*` IPC
+handlers), `runtime.ts` (the service singleton, the unattended-run prompt
+wrapper, and `announceRunFinished`), and `scheduled-task-service.ts` (the
+`ScheduledTaskService` class: persistence, timers, catch-up, migration,
+seeding).
+
+## Cadence and next-run math
+
+Cadence is the `ScheduledSchedule` union in `src/shared/scheduled.ts`:
+
+- `interval` (relative, minimum 30 minutes, anchored at create/enable/
+  last-attempt);
+- `daily` / `weekly` at a LOCAL wall-clock `HH:mm` (`weekly` also carries
+  `weekday: ScheduledWeekday`, 0 = Sunday through 6 = Saturday, matching
+  `Date#getDay()`).
+
+`computeNextRunAt` is the single next-run authority for all three kinds —
+use local `Date` field arithmetic there, never fixed millisecond offsets, so
+absolute slots survive DST.
+
+That "never fixed millisecond offsets" rule is about the two absolute kinds.
+Concretely, in the current `src/shared/scheduled.ts`, the `interval` branch
+of `computeNextRunAt` still adds a plain millisecond delta
+(`from + schedule.intervalMinutes * 60_000`) — correct, because a relative
+cadence is meant to drift with execution time and has no wall-clock slot to
+preserve. The `daily`/`weekly` branches instead build a `Date` from `from`
+and mutate it with field setters (`setHours`, `setDate`), which is what keeps
+the run pinned to the same local clock reading across a DST transition
+instead of silently sliding by an hour. Do not "simplify" the absolute
+branches back to a millisecond-offset computation.
+
+The 30-minute interval floor (and the `HH:mm` shape for `daily`/`weekly`) is
+enforced by `normalizeSchedule` in the same file, before a task is created or
+updated — from both the Scheduled editor and the chat tools.
+
+Each task's chat runs under its own `AgentScope`:
+`{ kind: 'scheduled'; taskId: string }`, one of the three variants defined
+alongside the session-store vocabulary in `src/shared/agent-chat.ts` (see
+below).
+
+## Catch-up and failed-slot semantics
+
+A slot missed while the app was closed runs ONCE on catch-up and then
+realigns to the next slot (never one run per missed slot); failed attempts
+consume the current slot rather than hot-looping.
+
+## Migration of `intervalMinutes`
+
+Pre-`schedule` records carrying `intervalMinutes` are lifted into the union
+on read (`migratePersistedTask`, in `scheduled-task-service.ts`); the field
+is gone from the live contract. `ScheduledTask` itself has no top-level
+`intervalMinutes` — cadence lives only under `schedule: ScheduledSchedule`,
+whose `interval` variant carries `intervalMinutes`. Any code that still reads
+a task's cadence must go through `schedule`, not a legacy top-level field.
+
+## Seeded weekly memory-report task
+
+The built-in weekly memory-report prompt is seeded idempotently as a
+disabled Scheduled task on `weekly` Monday 09:00 local; it is no longer an
+Experimental entry. Seeding is one-shot by design — an install that already
+carries the task keeps its stored schedule, so the Monday default reaches
+new installs only. (This is `ensureMemoryReportTask` in
+`scheduled-task-service.ts`: it seeds a fixed task id, `memory-report`, so a
+second call against an install that already has one is a no-op.)
+
+## Run-finished announcement chain
+
+A finished attempt — success AND failure — is announced by
+`announceRunFinished` (`scheduled/runtime.ts`) as a `scheduled:run-finished`
+push that `useScheduledRunToasts` turns into a STICKY toast
+(`autoCloseMs: 0`). Its action opens the task's conversation in the DOCK's
+Pulse AI tab (`useScheduledRunChatOpener` → `dock.openScheduledChat`), the
+same surface `Run now` uses — acting on a finished run must never navigate
+the whole app onto the AI Chat page and lose what the user was looking at.
+
+Routing to `/chat?scheduledTask=<id>` survives only as the fallback for
+views that hide the dock chat tab. `isDockChatTabEnabled`
+(`components/RightDock/dock-chat-availability.ts`, full path
+`src/renderer/src/components/RightDock/dock-chat-availability.ts`) is the
+single predicate behind BOTH that fallback and the dock's `chatTabEnabled`
+prop, because a caller that assumes a dock chat tab where there is none
+swallows the open silently.
+
+The same module derives `isGlobalChatLauncherVisible` — the floating
+Pulse-logo launcher (`RightDock/GlobalChatLauncher.tsx`, full path
+`src/renderer/src/components/RightDock/GlobalChatLauncher.tsx`) shows on
+every route that has a dock chat tab and no chat chrome of its own, canvas
+being the one exception. Deriving it (rather than an independent route list)
+stopped the Scheduled page from being hand-excluded with no way to reach the
+agent — guarded by
+`src/renderer/src/components/RightDock/__tests__/dock-chat-availability.test.ts`.
+
+## Session-store vocabulary
+
+Each task's chat is a session STORE (`__scheduled__-<taskId>`), listed in
+that rail beside workspaces and global chat. `src/shared/agent-chat.ts` owns
+the store-id vocabulary — `scopeSessionStoreId`, `scheduledTaskIdFromStoreId`,
+`isListableSessionStore` — and every consumer that maps a listed session back
+to a scope MUST go through it: a sentinel store id treated as a workspace id
+activates an agent against a workspace that does not exist.
+
+`__`-prefixed stores are allowlisted, never blanket-skipped (that is what hid
+scheduled chats from the rail).
+
+## The removed OS notification (must not return)
+
+Deliberately in-app only: OS `Notification` was tried and removed (Focus
+modes, missing notification daemons, unsigned dev builds, and
+Windows-without-AppUserModelID all drop it silently, and it needed a
+retained-reference dance to survive GC), so do not reintroduce a second
+channel — `scheduled-run-notify.test.ts`
+(`src/main/__tests__/scheduled-run-notify.test.ts`) asserts none is raised.
+
+A run finishes while nobody is watching, so the toast must never expire on a
+timer (`useScheduledRunToasts` sets `autoCloseMs: 0` for exactly this
+reason).
+
+## IPC contract and UI rules
+
+IPC contract: `src/shared/scheduled.ts` → `src/preload/bridge/scheduled.ts`
+→ renderer `components/Scheduled/` (full path
+`src/renderer/src/components/Scheduled/`).
+
+UI rules for that renderer surface:
+
+- List rows are presentational — every action is an explicit button. (The
+  row used to be one big button, so a stray click on the title or the
+  cadence text opened a chat; the current layout and the reasoning are in
+  `src/renderer/src/components/Scheduled/ScheduledPage.tsx`.)
+- The time picker is hour/minute `ui/Select`s, never a native
+  `<input type="time">`
+  (`src/renderer/src/components/Scheduled/TimeOfDaySelect.tsx`).
+
+## Chat tool entry and the module-cycle note
+
+Chat entry: `scheduled_task_list` / `scheduled_task_create` /
+`scheduled_task_update` in `src/main/agent/tools/scheduled.ts` — app-level,
+so registered UNWRAPPED on both tool factories (`createGlobalCanvasTools()`
+and `createCanvasTools(workspaceId)` in `src/main/agent/tools/index.ts`),
+all `defer_loading`, no delete (see `harness/knowledge/security-posture.md`
+for why).
+
+It dynamic-imports `scheduled/runtime`
+(`await import('../../scheduled/runtime')`) to avoid the
+tools→runtime→agent-service module cycle: `runtime.ts` reaches back into the
+agent service, so importing it eagerly at module load would close a cycle
+through `tools/index → runtime → agent/ipc → service → tools/index`.
+
+## Evidence
+
+Bound tests:
+
+- `src/shared/scheduled.test.ts` — schedule validation + next-run math
+- `src/main/__tests__/scheduled-task-service.test.ts`
+- `src/main/__tests__/scheduled-run-notify.test.ts` — completion push,
+  success AND failure, and no OS notification
+- `src/renderer/src/components/Scheduled/__tests__/useScheduledRunToasts.test.tsx`
+  — sticky toast
+- `src/renderer/src/components/Scheduled/__tests__/scheduledChatTarget.test.ts`
+  — dock-by-default vs route fallback
+- `src/main/agent/__tests__/scheduled-tools.test.ts`
+- `src/renderer/src/components/Scheduled/__tests__/TaskEditorModal.test.tsx`
+- `src/renderer/src/components/Scheduled/__tests__/ScheduledPage.test.tsx`
+- `src/main/agent/__tests__/service-history.test.ts` — scheduled-scope
+  coverage, alongside its main subject
+- `src/renderer/src/components/RightDock/__tests__/dock-chat-availability.test.ts`

--- a/apps/canvas-workspace/harness/knowledge/security-posture.md
+++ b/apps/canvas-workspace/harness/knowledge/security-posture.md
@@ -128,6 +128,52 @@ These make on-disk files an execution or injection surface:
   referrer); the post-login continuation is handed back to the opener
   webview so the one-shot URL is consumed there.
 
+## Runtime-control capability tiers and registry
+
+This elaborates the runtime-control server entry above with the capability
+registry's own contract: file location, access tiers, current contents, and
+the two `unsafe` capabilities in full. The network/bearer-auth boundary
+described there (loopback, ephemeral port, mode-`0600` per-run secret,
+`/capabilities/*` hidden unless `agent-runtime-control` is enabled) applies
+to everything below.
+
+- **Where capabilities live**: `src/main/runtime/capabilities/` (registry,
+  runtime, and per-domain capability modules). Stable Canvas Agent tools may
+  adapt to these capabilities without changing their own public names or
+  payloads — the tool surface the agent sees can stay stable even as the
+  underlying capability registry changes.
+- **Discovery and policy are filtered together**: capability discovery
+  includes each capability's input JSON schema, and the runtime policy must
+  filter discovery and execution through the same check — a capability an
+  actor cannot execute must not be discoverable either.
+- **Access tiers**: every capability is tagged `read`, `operate`, or
+  `unsafe`. Pulse CLI may access `read`/`operate`, never `unsafe`, by
+  default.
+- **Current registry contents**: the shared registry currently exposes
+  browser-tab discovery, live page reads, and Canvas node read/search/update
+  (all `read`/`operate`), plus — only when the `webview-page-control`
+  experimental flag is also enabled — selector-based page click/fill.
+- **`browser.page.eval`** is the `unsafe` capability for arbitrary page
+  JavaScript. It sits behind the stable, deferred `page_eval` Canvas Agent
+  tool, and requires BOTH experimental flags for external (Pulse CLI)
+  access: `agent-runtime-control` to reach `/capabilities/*` externally at
+  all, and `webview-page-control` for the capability's own policy check.
+- **`host.renderer.eval`** is the separate `unsafe` capability for arbitrary
+  host-renderer JavaScript, behind the deferred `canvas_host_eval` Canvas
+  Agent tool and the `pulse-canvas runtime host-eval` CLI command. It
+  requires `agent-runtime-control`, checks the selected workspace route
+  before executing, and runs in the host page's main world — see the
+  containment note above for why the lack of a direct Node `require` still
+  makes it `unsafe` (the `canvasWorkspace` preload bridge reaches privileged
+  main actions).
+- **`browser.page.eval` and `host.renderer.eval` are the ONLY Pulse CLI
+  `unsafe` exceptions.** Every other capability stays within `read`/
+  `operate` for CLI callers.
+- **Canvas node writes stay scoped even for CLI callers**: external
+  (Pulse CLI) node updates through the Canvas node capability are limited to
+  title/content; arbitrary internal `data` patches remain
+  Canvas-Agent-only.
+
 ## Containment that DOES exist
 
 - `contextIsolation: true`; renderer reaches privileged behavior only through

--- a/apps/canvas-workspace/harness/knowledge/terminal-surfaces.md
+++ b/apps/canvas-workspace/harness/knowledge/terminal-surfaces.md
@@ -1,0 +1,103 @@
+# Terminal surface sizing (xterm fit policy)
+
+`src/renderer/src/components/AgentNodeBody/utils/terminal.ts` owns the
+shared sizing policy for every xterm instance in the app: agent nodes,
+terminal nodes, and the workspace terminal dock. Read this file before
+touching how any of those surfaces mount, resize, restore, or scroll a
+terminal.
+
+## Rule: never call `fitAddon.fit()` directly
+
+NEVER call `fitAddon.fit()` directly. Go through `fitTerminalIfSane` or
+`fitTerminalWithCanvasScale` instead (both exported from
+`AgentNodeBody/utils/terminal.ts`). Every real consumer already follows
+this — there is no direct `fitAddon.fit(` call site anywhere else in `src/`.
+
+## Why: FitAddon's column clamp turns into permanent scrollback damage
+
+`FitAddon` floors `availableWidth / cellWidth` and clamps at a minimum of 2
+columns. A container measured mid-layout — a node that has not been sized
+yet, a hidden or freshly re-parented terminal, a `--canvas-scale` change
+still in flight — therefore proposes a nonsense 3–5 column terminal instead
+of rejecting the measurement.
+
+For a plain shell that would just be briefly ugly. For a coding agent it is
+permanent damage: a coding agent renders its OWN layout to the PTY width, so
+applying that 3–5 column fit hard-wraps every line it prints at that moment
+into a 4-character ribbon that no later re-fit can undo — xterm reflows only
+its own soft wraps, not text a remote program already hard-wrapped — and the
+scrollback persists it that way.
+
+Refusing a nonsense fit costs nothing: the terminal simply keeps its
+previous geometry, and the staged re-fits plus the `ResizeObserver` apply
+the real geometry a frame or two later (see the ladder below).
+`fitTerminalIfSane` is the guard that makes this refusal happen — it calls
+`fit.proposeDimensions()` and will not apply a fit unless the proposed
+`cols`/`rows` are finite and `cols` is at least `MIN_FITTABLE_TERMINAL_COLS`
+(20).
+
+## The mount/reattach fit ladder, and its scroll side effect
+
+`scheduleTerminalFit(fitAddon, term, containerEl)` is the mount/reattach fit
+ladder. Geometry settles over the next few frames — the first passes are
+usually the ones `fitTerminalIfSane` rejects — so it re-tries at: now, +2
+animation frames, +80ms, and +240ms.
+
+Every pass in that ladder also calls `term.scrollToBottom()`, and this is
+deliberate, not incidental: mount-time writes (a restored scrollback, or a
+live agent's first output frames) land while the terminal is still sizing,
+and without the scroll they leave a restored session parked mid-history.
+
+The debounced `ResizeObserver`-driven re-fit (`createDebouncedTerminalRefit`,
+trailing-debounce window `TERMINAL_REFIT_DEBOUNCE_MS` = 120ms) applies the
+real geometry on later container-size changes — a canvas-scale animation in
+flight, or a user drag-resizing a node. That path must NOT scroll: it fires
+while the user is actively reading history, and forcing the viewport to the
+bottom there would yank it out from under them. This is the one behavioral
+difference between the two re-fit paths — do not unify them into a single
+"always scroll" or "never scroll" helper.
+
+## Contract (exports of `AgentNodeBody/utils/terminal.ts`)
+
+- `MIN_FITTABLE_TERMINAL_COLS` (20) — floor below which a proposed fit is
+  rejected outright.
+- `fitTerminalIfSane(term, fit)` — the sanity-checked fit primitive; returns
+  whether the terminal now matches its container.
+- `fitTerminalWithCanvasScale(term, fit, containerEl)` — syncs the xterm
+  font size to the cascading `--canvas-scale` CSS variable first, then calls
+  `fitTerminalIfSane`.
+- `fitAndRefreshTerminal(fitAddon, term, containerEl?)` — one fit pass for a
+  canvas-hosted terminal: sync font size (if a container is given), sane-fit,
+  then `term.refresh(...)` the visible rows.
+- `scheduleTerminalFit(fitAddon, term, containerEl?)` — the mount/reattach
+  ladder described above; every pass scrolls to bottom.
+- `createDebouncedTerminalRefit(refit)` — trailing-debounce wrapper for
+  `ResizeObserver`-driven refits (`TERMINAL_REFIT_DEBOUNCE_MS` = 120ms); does
+  not scroll.
+- `readCanvasScale(el)` / `syncTerminalFontSizeToCanvas(term, containerEl)` —
+  read the `--canvas-scale` custom property `CanvasSurface` injects onto
+  `.canvas-transform`, and keep xterm's font size in lock-step with it.
+
+## Consumers (every xterm in the app)
+
+- Agent nodes: `src/renderer/src/components/AgentNodeBody/useAgentNodeController.ts`.
+- Terminal nodes: `src/renderer/src/components/TerminalNodeBody/index.tsx`.
+- The workspace terminal dock: `src/renderer/src/components/WorkspaceTerminalDock/index.tsx`.
+
+All three call into the fit primitives above rather than the raw
+`FitAddon`.
+
+## Related but distinct: terminal keyboard ownership
+
+`terminal.ts` also owns `decideTerminalKey`, the keystroke-arbitration
+policy for a focused terminal (Cmd-chords released to the app, Ctrl-chords
+kept by the shell, double-Escape release-to-canvas). That is a separate
+concern from the sizing policy on this page — it is documented in
+`harness/knowledge/keyboard-shortcuts.md` ("Terminal key policy" section),
+which is also the file to read before touching terminal focus/keyboard
+behavior.
+
+## Evidence
+
+- `src/renderer/src/components/AgentNodeBody/utils/terminalFit.test.ts` —
+  the bound regression suite for this sizing policy.

--- a/harness/skills/slim-agents-md/SKILL.md
+++ b/harness/skills/slim-agents-md/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: slim-agents-md
+description: Use when a root or workspace AGENTS.md has grown overweight — router table rows or constraint bullets carrying multi-sentence mechanism prose instead of short pointers — and needs inline knowledge extracted into harness/knowledge/ without losing any fact. Covers root AGENTS.md and every workspace AGENTS.md.
+---
+
+# Slim an AGENTS.md
+
+Move inline mechanism prose out of a router file (root `AGENTS.md` or a workspace `AGENTS.md`) into that content's owning `harness/knowledge/` file, leaving a short pointer behind. The router keeps routing; the knowledge file keeps the facts. No fact may be lost in the move — this is a relocation, not a summary.
+
+This is the repo action protocol for the extraction already applied once to `apps/canvas-workspace/AGENTS.md` (knowledge moved into `apps/canvas-workspace/harness/knowledge/*.md`; read that file's git history for a full worked example before your first pass). Apply the same procedure to any other workspace `AGENTS.md` — or root `AGENTS.md` itself — once it shows the same weight symptoms.
+
+## When to Use
+
+- A router table row or constraint bullet has grown into multi-sentence mechanism prose (the WHY and the HOW, not just the WHAT and WHERE) — see Measurement for a concrete signal.
+- `node scripts/harness/check-harness.mjs` reports a `router-weight` gap: a line in root or a workspace `AGENTS.md` over `ROUTER_WEIGHT_THRESHOLD` (see that constant's comment in `scripts/harness/check-harness.mjs` for the current value and ratchet plan). It rides the same overlay glob — `harness/**`, `AGENTS.md`, `**/AGENTS.md`, `**/harness/**` — that already runs it for every AGENTS.md/harness change; see the `harness-data` rule in root `harness/validate/validation.yaml`.
+- A maintainer explicitly asks to slim, trim, or extract knowledge from an AGENTS.md file.
+
+Do not use it to manufacture work. Most workspace `AGENTS.md` files are currently well under the ceiling in Measurement — extraction is justified by measured weight, not by a general tidiness impulse.
+
+## The Three-Layer Placement Test
+
+For every candidate row or bullet, classify each fact it carries into exactly one layer. Do not leave a fact sitting in the router once it has a layer-2 or layer-3 home.
+
+1. **Router** (`AGENTS.md`, stays inline) — a routing decision or a one-sentence rule: WHICH file to read for WHAT task, or WHAT outcome a constraint enforces. Short enough to scan in a table row or a one-line bullet.
+2. **Harness-knowledge** (`harness/knowledge/<topic>.md`, extracted) — the WHY and the HOW: mechanism explanation, history, edge cases, the multi-sentence reasoning that makes the rule make sense. If a sentence explains a mechanism rather than naming a destination, it belongs here, not in the router.
+3. **Tests-and-types** (referenced, never restated) — the enforcement that already lives in the codebase: a test file, a type contract, or a `harness/validate/validation.yaml` rule. Point at it (`Guard: <path>`); do not re-explain in prose what the test already proves mechanically. Restating a test's logic in Markdown creates a second, driftable copy of a fact a machine already enforces.
+
+This mirrors root `AGENTS.md` §0 rule 5's own self-check ("Can this be a mechanism — type / lint / test / hook / script — rather than a doc line? If only doc, is the reason stated?"), applied specifically to router weight.
+
+One placement wrinkle: the owning `harness/knowledge/` directory is the content's *subject* workspace, which is not always the file being edited. When root `AGENTS.md` documents a workspace-specific failure (its §6 Failure Capture), the Detail pointer targets that workspace's `harness/knowledge/`, never a new root-level knowledge file — root `harness/knowledge/` is an index only (its own `README.md`: "This directory is an index, not a copy"). Root `AGENTS.md` §6's keyboard-shortcuts entries already point at `apps/canvas-workspace/harness/knowledge/keyboard-shortcuts.md` on this basis; follow the same rule for any other root-level, workspace-specific fact.
+
+## Measurement
+
+Router weight is a proxy for "this row stopped routing and started explaining." Two commands, run from repo root.
+
+Repo-wide scan — which `AGENTS.md` files carry the longest lines right now:
+
+```bash
+for f in $(git ls-files '*/AGENTS.md' 'AGENTS.md'); do
+  echo "$(awk '{print length}' "$f" | sort -rn | head -1)  $f"
+done | sort -rn
+```
+
+Per-file map — once a file is targeted, find its exact offending rows/bullets by line number:
+
+```bash
+awk '{ print length, NR }' <path-to-AGENTS.md> | sort -rn | head -20
+```
+
+Working ceiling: a router table row should read comfortably at or under **700 characters**. The `Dock web tabs` row in `apps/canvas-workspace/AGENTS.md` — the closest thing this repo has to a template row — sits at 460. A constraint bullet's RULE line should be one sentence; needing a second sentence to state the mechanism, not just the outcome, marks a layer-2 candidate.
+
+Treat 700 as a working ceiling for judgment, not a constant to defend. The authoritative, evolving gate is `ROUTER_WEIGHT_THRESHOLD` in `scripts/harness/check-harness.mjs` (810 as of this writing, mid-ratchet down toward 800 once root `AGENTS.md` §6's remaining long bullets move out — read that constant's own comment before quoting a number from this skill). That check measures JS string length (UTF-16 code units); `awk`'s byte-oriented `length` reads slightly higher on lines with em dashes, arrows, or CJK text, which this repo's AGENTS.md files use — treat `awk`'s numbers as directional for finding candidates, and let `check-harness.mjs` make the actual call.
+
+## Extraction Protocol
+
+1. **Read the whole target file** and run Measurement to list candidate rows/bullets.
+2. **Classify each candidate** with the Three-Layer Placement Test. Most rows split: a short routing sentence stays (layer 1), the mechanism explanation moves (layer 2), any test-backed claim gets pointed at instead of restated (layer 3).
+3. **Find or create the owning knowledge file** — `<workspace>/harness/knowledge/<topic>.md` (for a root-level fact about a specific workspace, target that workspace's directory, not root's index-only one — see the placement wrinkle above). Reuse an existing topic file over creating a new one when the subject already has a home: `apps/canvas-workspace/harness/knowledge/chat-sessions.md` backs five different router rows rather than five new files. Create the `harness/knowledge/` directory itself if the workspace has none yet.
+4. **Move the prose verbatim.** Light reformatting into knowledge-file style is fine; deleting specifics, numbers, gotchas, or "why" reasoning is not.
+5. **Verify every concrete path** referenced in both the old prose and the new knowledge file still exists on disk (`Read`/`ls`, or let `check-harness.mjs`'s routing-links check do it — see Verification). A path that no longer resolves is a stale fact, handled by the next step, not silently dropped.
+6. **Flag stale facts; do not silently fix them.** If extraction surfaces a claim that contradicts current source (a renamed file, a described behavior the code no longer matches), leave it visibly flagged in the knowledge file (e.g. a leading "STALE — verify:" note) or call it out to the requester. Silently "correcting" a fact you have not independently verified against source risks encoding a second wrong answer with more confidence than the first.
+7. **Replace the original with a pointer.**
+
+   Table row (model: the `Dock web tabs` row in `apps/canvas-workspace/AGENTS.md`), kept at or under the 700-character ceiling:
+
+   ```
+   | <Task/topic> | Read `harness/knowledge/<topic>.md` before <the specific trigger condition>. Key contracts: `<path-1>`, `<path-2>`. Tests: `<test-1>`, `<test-2>`. |
+   ```
+
+   Constraint bullet (model: the workspace-local chat-sessions/agent-roles bullets in `apps/canvas-workspace/AGENTS.md` §Local Constraints):
+
+   ```
+   - <One-sentence RULE — the outcome/constraint, not the mechanism>.
+     Guard: `<test-file-1>`, `<test-file-2>`.
+     Detail: `harness/knowledge/<topic>.md`.
+   ```
+
+   Root `AGENTS.md` §6 sometimes merges the last two lines into one — `Detail + guards: <path>.` — when the guard list is already itemized inside the linked knowledge file. Both forms are acceptable; do not force the two-line form where it would just repeat what the knowledge file already lists. Omit `Guard:` entirely when nothing currently tests the rule mechanically — do not invent a test reference; an untested rule being weaker than a tested one is worth stating, not worth hiding.
+8. **Re-measure** the touched rows/bullets — confirm the router actually lost weight, not just gained a pointer alongside the old paragraph (see Anti-Regression).
+
+## Verification Protocol
+
+1. **Fact-preservation audit.** Diff against the last known-good state and confirm every removed sentence survived somewhere:
+
+   ```bash
+   git show HEAD:<path-to-AGENTS.md> > /tmp/before.md
+   diff /tmp/before.md <path-to-AGENTS.md>
+   ```
+
+   For every `-` line in that diff, find its content again — inline in the shortened row/bullet, or in the knowledge file's prose. A fact present in neither is a regression, not a simplification.
+2. **Path audit.** Every backticked, repo-path-shaped token in the touched files must resolve on disk. `check-harness.mjs`'s routing-links check does this mechanically for tokens starting with `packages/`, `apps/`, `harness/`, `scripts/`, `docs/`, `.github/`, or `.pulse-coder/`; spot-check anything else by hand (bare tokens like `src/...` are outside that prefix set by design and need a manual look).
+3. **Run the harness check**, repo root:
+
+   ```bash
+   node scripts/harness/check-harness.mjs
+   ```
+
+   Must report `"harnessGaps": 0`. This covers entry/validation coverage, dangling routing links, and router weight (see Anti-Regression). A gap here is authoritative — fix it before finishing, do not explain it away.
+4. **Run the affected workspace's bound checks** only if anything beyond Markdown changed (it usually has not) — its own `harness/validate/validation.yaml` names them. A pure knowledge-extraction pass is typically Markdown-only and needs no build/test/typecheck run, but confirm rather than assume.
+5. **Keep the footprint honest.** `git diff --stat` should show only the files the request actually asked for — a root `AGENTS.md` edit in particular is often scoped to one exact section; do not let a slimming pass sprawl into unrelated parts of the file.
+
+## Anti-Regression
+
+- **Router-weight threshold.** This skill exists to reduce a measured weight, not to relocate prose cosmetically. "Extracted but not shrunk" — copying the paragraph into a knowledge file while leaving the original row just as long, pointer bolted on top — is the failure mode to watch for. Re-run Measurement on the touched rows after every pass and confirm they actually got shorter. Two backstops cover this so it does not rely on one pass of manual discipline: `check-harness.mjs`'s `router-weight` check (a numeric gate that evolves independently of this document — it already moved once, from an implicit "no check" to `ROUTER_WEIGHT_THRESHOLD = 810` with a stated plan to tighten to 800; re-run it, do not assume a threshold documented here is still current) and this skill's own re-measurement step, which gives immediate feedback every time it runs.
+- **The write-back routing rule.** Root `AGENTS.md` §6's write-back sentence — new fact routes to the nearest owning doc, "but never inline multi-sentence knowledge into a router table row or constraint bullet: put it in that workspace's `harness/knowledge/` file (create one if missing) and leave a pointer row" — is what stops a slimmed file from regrowing the same weight one task at a time. This skill is the retrofit for files that are already overweight; the write-back rule is the standing prevention for every task from here on. Keep the two in sync: if this skill's pointer-row or constraint-bullet format changes, check whether §6's sentence needs the same update, and vice versa. A drift between the one-line summary and the full procedure is exactly the duplicate-rule problem root `AGENTS.md` §0 rule 2 (SSOT, no copies) warns about.
+
+## Done When
+
+- Every touched row/bullet is at or under the working ceiling in Measurement, or carries a stated reason it cannot shrink further.
+- Every fact the original prose stated still exists somewhere — inline pointer or knowledge file — confirmed by the fact-preservation audit, not assumed.
+- Every backticked, repo-path-shaped token in the touched files resolves on disk.
+- `node scripts/harness/check-harness.mjs` reports `harnessGaps: 0`.
+- Stale facts found mid-pass are flagged in place, never silently corrected or silently dropped.
+- The diff footprint matches what was actually asked for.

--- a/harness/tools/README.md
+++ b/harness/tools/README.md
@@ -9,7 +9,7 @@ A tool should have stable inputs and outputs, but it does not own final decision
 | Tool | Purpose |
 |---|---|
 | `run-harness-check` (`scripts/harness/run-harness-check.mjs`) | Resolve changed paths to bound validation commands and execute them with a pass/fail report. |
-| `check-harness` (`scripts/harness/check-harness.mjs`) | Drift check: entry/validation coverage per workspace, validation file shape, `--filter` names reference real packages, routing links in harness docs resolve on disk. |
+| `check-harness` (`scripts/harness/check-harness.mjs`) | Drift check: entry/validation coverage per workspace, validation file shape, `--filter` names reference real packages, routing links in harness docs resolve on disk, router-weight (no root/workspace `AGENTS.md` line over threshold — catches inline knowledge that should have moved to `harness/knowledge/`). |
 
 ## Candidate Tool Ideas
 

--- a/scripts/harness/check-harness.mjs
+++ b/scripts/harness/check-harness.mjs
@@ -13,6 +13,10 @@
 //   - routing links:       backticked concrete repo paths in root AGENTS.md,
 //                          harness/*.md, and workspace AGENTS.md files exist
 //                          on disk (placeholders and globs are skipped)
+//   - router-weight:       no line in root or workspace AGENTS.md exceeds
+//                          ROUTER_WEIGHT_THRESHOLD chars — an over-long line
+//                          is inline knowledge that belongs in
+//                          harness/knowledge/ plus a short pointer row
 // Plus the root overlay file, same shape rules.
 //
 // Prints a summary and exits non-zero when gaps exist. The runner
@@ -94,16 +98,46 @@ function checkFilterNames(cmd, label) {
   }
 }
 
+// router-weight: AGENTS.md is a router — knowledge that accumulates inline
+// (instead of living in harness/knowledge/ with a pointer row) makes it
+// unreadable and hard to keep honest. A line length cap is a cheap, mechanical
+// proxy for "this bullet stopped being a pointer and became the knowledge
+// itself." Measured in JS string length (UTF-16 code units), same as the
+// comparison below; byte-counting tools (e.g. `awk`) read slightly higher on
+// lines with multi-byte characters (em dashes, arrows) that are common here.
+//
+// Floor is 800 (round, far under the old fat rows this was written to catch:
+// 1500-5006 chars). Root AGENTS.md's oldest "Failure capture" bullets (see
+// AGENTS.md §6) still run to ~803 chars today, so the bare floor would not
+// pass the current repo. RATCHET: nudged to 810 (just above today's real
+// max) until those bullets move to harness/knowledge/ — tighten back to 800
+// once they do; do not raise it further to silence a new violation.
+const ROUTER_WEIGHT_THRESHOLD = 810;
+
+function checkRouterWeight(rel) {
+  if (!exists(rel)) return;
+  const lines = read(rel).split(/\r?\n/);
+  lines.forEach((line, index) => {
+    if (line.length <= ROUTER_WEIGHT_THRESHOLD) return;
+    gaps.push(
+      `${rel}:${index + 1}: router-weight ${line.length} chars (>${ROUTER_WEIGHT_THRESHOLD}) — move this knowledge into harness/knowledge/ and leave a short pointer row in its place`,
+    );
+  });
+}
+
 let entryCoverage = 0;
 let validationCoverage = 0;
 for (const ws of workspaces) {
-  if (exists(path.posix.join(ws, 'AGENTS.md'))) entryCoverage += 1;
+  const agentsPath = path.posix.join(ws, 'AGENTS.md');
+  if (exists(agentsPath)) entryCoverage += 1;
   else gaps.push(`${ws}: missing AGENTS.md entry`);
+  checkRouterWeight(agentsPath);
   const validationPath = path.posix.join(ws, 'harness/validate/validation.yaml');
   if (exists(validationPath)) validationCoverage += 1;
   checkValidationFile(validationPath, { requireRules: true });
 }
 checkValidationFile('harness/validate/validation.yaml', { requireRules: true });
+checkRouterWeight('AGENTS.md');
 
 // routing-links: a doc that points at a deleted/renamed file is worse than no
 // doc. Only tokens that look like concrete repo paths are checked. Docs also
@@ -138,6 +172,7 @@ console.log(JSON.stringify({
   workspaces: workspaces.length,
   entryCoverage,
   validationCoverage,
+  routerWeightThreshold: ROUTER_WEIGHT_THRESHOLD,
   harnessGaps: gaps.length,
 }, null, 2));
 


### PR DESCRIPTION
Restructure per the Claude-5 context-engineering rules (progressive
disclosure over upfront context; tests as specs; one authoritative home):

- apps/canvas-workspace/AGENTS.md 46.3KB -> 25.6KB (-45%): the five fat
  Knowledge Navigation rows (multi-role chat, scheduled tasks, node
  detail, keyboard shortcuts, chat loading/dock rows) and the verbose
  Local Constraints bullets become pointer rows / RULE+Guard+Detail
  one-liners; knowledge moves to seven new files under
  harness/knowledge/ (agent-roles, chat-sessions, keyboard-shortcuts,
  node-detail, packaged-tooling, scheduled-tasks, terminal-surfaces)
  plus merges into dock-browser.md and security-posture.md.
- Root AGENTS.md: the two keyboard-incident bullets in section 6 shrink
  to rule+pointer (full stories live in keyboard-shortcuts.md); the
  task-end write-back rule now routes multi-sentence knowledge to
  harness/knowledge/ instead of inline table rows; new intent-table row
  for the slim-agents-md skill.
- check-harness.mjs: new router-weight check - any AGENTS.md line over
  810 chars is a harness gap (threshold ratchets to 800 once the last
  long root bullet is extracted); documented in harness/tools/README.md.
- New repo action skill harness/skills/slim-agents-md/SKILL.md encoding
  the extraction/verification procedure for the remaining 13 workspaces.
- Fix stale fact found during extraction: page-route dock cap is 70%
  (PAGE_MAX_VIEWPORT_RATIO widened from 0.5 in #893), not 50%.

Fact preservation verified per domain against git show HEAD (7/7 PASS);
check-harness reports harnessGaps: 0.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014YGmnKE34GbrZ4e4oHHzar