### PR TITLE
canvas-workspace: fix i18n and export-style inconsistencies

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
@@ -11,23 +11,9 @@ interface AgentShellPathCardProps {
 
 const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps) => {
   const { notify } = useAppShell();
-  const { language, t } = useI18n();
+  const { t } = useI18n();
   const [configuring, setConfiguring] = useState(false);
-  const copy = language === 'zh'
-    ? {
-        title: '终端命令',
-        ready: (profile: string) => `已在 ${profile} 中配置 pulse-canvas。打开新终端后即可使用。`,
-        setup: (profile: string) => `将托管 CLI 目录加入 ${profile}，之后可在新终端中直接运行 pulse-canvas。`,
-        configure: '配置 PATH',
-        unsupported: '自动配置仅支持 zsh、bash 和 fish。请手动执行下面的命令。',
-      }
-    : {
-        title: 'Terminal command',
-        ready: (profile: string) => `pulse-canvas is configured in ${profile}. Open a new terminal to use it.`,
-        setup: (profile: string) => `Add the managed CLI directory to ${profile} so new terminals can run pulse-canvas directly.`,
-        configure: 'Configure PATH',
-        unsupported: 'Automatic setup supports zsh, bash, and fish. Run the command below manually.',
-      };
+  const title = t('agent.shellPathTitle');
 
   const configure = async () => {
     setConfiguring(true);
@@ -37,8 +23,8 @@ const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps
       await onConfigured();
       notify({
         tone: 'success',
-        title: copy.title,
-        description: copy.ready(result.profilePath ?? ''),
+        title,
+        description: t('agent.shellPathReady', { profile: result.profilePath ?? '' }),
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -50,13 +36,13 @@ const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps
 
   return (
     <div className="agent-section-cli">
-      <div className="agent-section-cli-title">{copy.title}</div>
+      <div className="agent-section-cli-title">{title}</div>
       <div className="agent-section-cli-desc">
         {shellPath.configured
-          ? copy.ready(shellPath.profilePath ?? '')
+          ? t('agent.shellPathReady', { profile: shellPath.profilePath ?? '' })
           : shellPath.supported
-            ? copy.setup(shellPath.profilePath ?? '')
-            : copy.unsupported}
+            ? t('agent.shellPathSetup', { profile: shellPath.profilePath ?? '' })
+            : t('agent.shellPathUnsupported')}
       </div>
       <div className="agent-section-cli-cmd-row">
         <code className="agent-section-cli-cmd">
@@ -64,7 +50,7 @@ const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps
         </code>
         {shellPath.supported && !shellPath.configured && (
           <Button variant="secondary" size="sm" onClick={() => void configure()} disabled={configuring}>
-            {copy.configure}{configuring ? '…' : ''}
+            {t('agent.shellPathConfigure')}{configuring ? '…' : ''}
           </Button>
         )}
       </div>

--- a/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
+++ b/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
@@ -1029,6 +1029,12 @@ const en = {
   'agent.installCopy': 'Copy',
   'agent.installCopied': 'Copied',
 
+  'agent.shellPathTitle': 'Terminal command',
+  'agent.shellPathReady': 'pulse-canvas is configured in {profile}. Open a new terminal to use it.',
+  'agent.shellPathSetup': 'Add the managed CLI directory to {profile} so new terminals can run pulse-canvas directly.',
+  'agent.shellPathConfigure': 'Configure PATH',
+  'agent.shellPathUnsupported': 'Automatic setup supports zsh, bash, and fish. Run the command below manually.',
+
   'models.addProvider': 'Add provider',
   'models.providerCount': '{count} models',
   'models.providerName': 'Provider name',
@@ -2779,6 +2785,12 @@ const zh: Record<keyof typeof en, string> = {
   'agent.installVerify': '验证',
   'agent.installCopy': '复制',
   'agent.installCopied': '已复制',
+
+  'agent.shellPathTitle': '终端命令',
+  'agent.shellPathReady': '已在 {profile} 中配置 pulse-canvas。打开新终端后即可使用。',
+  'agent.shellPathSetup': '将托管 CLI 目录加入 {profile}，之后可在新终端中直接运行 pulse-canvas。',
+  'agent.shellPathConfigure': '配置 PATH',
+  'agent.shellPathUnsupported': '自动配置仅支持 zsh、bash 和 fish。请手动执行下面的命令。',
 
   'models.addProvider': '添加 Provider',
   'models.providerCount': '{count} 个模型',


### PR DESCRIPTION
## Summary

Scanned `apps/canvas-workspace` for UI style inconsistencies against the app's documented conventions (`apps/canvas-workspace/harness/knowledge/conventions/frontend.md`) and its mechanized consistency ratchet (`src/main/__tests__/ui-reuse-governance.test.ts`, which gates colors/radii/shadows/z-index/raw form tags/dialog roles/portals/keydown listeners).

**Ratchet result: clean.** All 18 governance counters (plus file-size and import-boundary governance) pass exactly at baseline — no drift, no violations in the areas that mechanism already covers.

Outside the ratchet's scope, two real inconsistencies turned up against the written conventions:

- `components/Settings/AgentShellPathCard.tsx` hand-rolled a `language === 'zh' ? {...} : {...}` object of inline English/Chinese copy, even though the same file already imports and uses `useI18n()`/`t()` for its other strings — directly contradicting frontend.md's "No hardcoded user-facing strings. Use `useI18n()`... rather than inlining English/Chinese text." Moved the five copy strings into the shared message catalog (`agent.shellPath*` keys in `i18n/messages.ts`, both `en`/`zh`) using the existing `{param}` interpolation convention, and simplified the component to call `t()` directly.
- `components/MigrationSpinner/index.tsx` exported both a named component and a redundant `export default`, against frontend.md's "Export named arrow-function components... Avoid `default` exports for components." Confirmed the default export was genuinely dead (its one consumer, `App.tsx`, lazy-loads the *named* export via `.then((module) => ({ default: module.MigrationSpinner }))`) and removed it.

Note: `components/Settings/AgentShellPathCard.tsx` itself still has a top-level `export default` — that one is load-bearing (`AgentSection.tsx` uses `lazy(() => import('./AgentShellPathCard'))`, which requires a real default export), so it was left in place.

A broader `language === 'zh'` inline-copy pattern also exists in 4 other files (`Scheduled/formatters.ts`, `Settings/UpdateSection.tsx`, `WorkspaceNodes/NodeDetailPanel.tsx`, `WorkspaceNodes/NodesPage.tsx`) — left untouched here as a scoped, single-file fix rather than a larger speculative i18n migration; flagging for a future batch if desired.

## Test plan
- [x] `pnpm --filter canvas-workspace typecheck` — passes
- [x] `pnpm --filter canvas-workspace exec vitest run src/main/__tests__/ui-reuse-governance.test.ts src/main/__tests__/file-size-governance.test.ts src/main/__tests__/import-boundaries.test.ts` — all pass, ratchet baseline unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_019YGkiHYjUigcgwHpmRL1Nm)_