### PR TITLE
fix(canvas-workspace): drop stray default exports on two components

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
@@ -10,7 +10,9 @@ import { useI18n } from '../../i18n';
 import { Button, FieldRow, Select } from '../ui';
 import './AgentSection.css';
 
-const AgentShellPathCard = lazy(() => import('./AgentShellPathCard'));
+const AgentShellPathCard = lazy(() =>
+  import('./AgentShellPathCard').then((module) => ({ default: module.AgentShellPathCard }))
+);
 
 interface AgentSectionProps {
   onClose: () => void;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
@@ -4,12 +4,12 @@ import { useAppShell } from '../AppShellProvider';
 import { useI18n } from '../../i18n';
 import { Button } from '../ui';
 
-interface AgentShellPathCardProps {
+interface Props {
   shellPath: ShellPathResult;
   onConfigured: () => Promise<void>;
 }
 
-const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps) => {
+export const AgentShellPathCard = ({ shellPath, onConfigured }: Props) => {
   const { notify } = useAppShell();
   const { language, t } = useI18n();
   const [configuring, setConfiguring] = useState(false);
@@ -71,5 +71,3 @@ const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps
     </div>
   );
 };
-
-export default AgentShellPathCard;


### PR DESCRIPTION
## Summary

Scanned `apps/canvas-workspace` for UI style inconsistencies against the project's documented conventions (`apps/canvas-workspace/harness/knowledge/conventions/frontend.md`) and the `ui-reuse-governance`/`file-size-governance` ratchet tests. The ratchet tests currently pass with no new regressions, and the tracked reuse debt is already deliberately baselined and documented case-by-case in `docs/ui-reuse-burndown.md` — not something to bulk-"fix" without the same per-case visual review the repo's history shows it requires.

One genuine, isolated inconsistency did stand out: **`MigrationSpinner`** and **`AgentShellPathCard`** were the only two components (out of 600+ `.tsx` files under `src/renderer/src/components/`) using `export default`, when the documented convention is to "Export named arrow-function components... Avoid `default` exports for components."

- `MigrationSpinner/index.tsx`: dropped the trailing `export default MigrationSpinner;` — it already exports a named `MigrationSpinner` and the only consumer (`App.tsx`) already imports it by name via `lazy(() => import(...).then(m => ({ default: m.MigrationSpinner })))`, so the default export was dead code.
- `Settings/AgentShellPathCard.tsx`: changed to a named export (`export const AgentShellPathCard`), renamed its local `AgentShellPathCardProps` interface to `Props` (matching the file's own single-component convention), and updated the one lazy-import call site in `Settings/AgentSection.tsx` to map the named export the same way `MigrationSpinner`'s caller does.

No behavior changes — purely export-shape/naming consistency.

## Why

Keeps the codebase's component export style uniform, per `frontend.md`'s "Component style" section, and removes now-dead default-export code paths.

## Test plan

- [x] `pnpm --filter canvas-workspace typecheck` — passes
- [x] `npx vitest run src/main/__tests__/ui-reuse-governance.test.ts src/main/__tests__/file-size-governance.test.ts src/main/__tests__/import-boundaries.test.ts` — all pass
- [x] Verified no other `.tsx` component under `src/renderer/src/components/` still uses `export default`
- [x] Verified no other import site references the removed default exports

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Q8AjLQmf3WpQTt8h1GQrUh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8AjLQmf3WpQTt8h1GQrUh)_