### PR TITLE
fix(canvas-workspace): align three components with UI conventions

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentRestart.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/AgentNodeBody/AgentRestart.tsx
@@ -163,7 +163,7 @@ export const AgentRestart = ({
               type="button"
               className="agent-secondary-btn"
               onClick={onEdit}
-              title="Edit initial parameters"
+              title={t('agent.editParams')}
             >
               <PencilGlyph />
               {t('agent.editParams')}

--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
@@ -10,7 +10,9 @@ import { useI18n } from '../../i18n';
 import { Button, FieldRow, Select } from '../ui';
 import './AgentSection.css';
 
-const AgentShellPathCard = lazy(() => import('./AgentShellPathCard'));
+const AgentShellPathCard = lazy(() =>
+  import('./AgentShellPathCard').then((module) => ({ default: module.AgentShellPathCard }))
+);
 
 interface AgentSectionProps {
   onClose: () => void;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
@@ -9,7 +9,7 @@ interface AgentShellPathCardProps {
   onConfigured: () => Promise<void>;
 }
 
-const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps) => {
+export const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps) => {
   const { notify } = useAppShell();
   const { language, t } = useI18n();
   const [configuring, setConfiguring] = useState(false);
@@ -71,5 +71,3 @@ const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps
     </div>
   );
 };
-
-export default AgentShellPathCard;


### PR DESCRIPTION
## Summary

A scan of `apps/canvas-workspace` for UI style inconsistencies found the codebase's UI-reuse ratchet (`ui-reuse-governance.test.ts`) green with no undocumented drift, so this PR is intentionally small — three concrete, low-risk violations of the written renderer conventions (`harness/knowledge/conventions/frontend.md`), each verified by reading the surrounding code (not just a grep hit):

- **`MigrationSpinner/index.tsx`**: removed the dead `export default MigrationSpinner;`. `App.tsx` already lazy-imports the *named* export (`.then((m) => ({ default: m.MigrationSpinner }))`), so the default export had zero consumers.
- **`Settings/AgentShellPathCard.tsx`**: switched to a named export (`export const AgentShellPathCard = ...`), per the convention that renderer components use named arrow-function exports, never `default`. Updated the sole `lazy()` call site in `AgentSection.tsx` to match. No behavior change.
- **`AgentNodeBody/AgentRestart.tsx`**: replaced a hardcoded `title="Edit initial parameters"` with `title={t('agent.editParams')}` — the exact same string is already served by that i18n key one line below for the button's visible label, in the same file. Exact-value swap onto an already-used key; no new catalog entry or translation judgment involved.

Other candidates surfaced during the scan (a handful of hardcoded strings in `AgentRestart.tsx`/`AgentPicker.tsx`/`IframeRenderedView.tsx`) were deliberately left out — fixing them would mean inventing new English/Chinese copy, which needs product judgment rather than a mechanical fix.

## Test plan

- [x] `pnpm --filter canvas-workspace typecheck` — clean
- [x] `pnpm exec vitest run src/main/__tests__/ui-reuse-governance.test.ts` — 18/18 pass, no counter regressions (these changes don't touch any gated counter)
- [x] `pnpm exec vitest run src/main/__tests__/import-boundaries.test.ts src/main/__tests__/file-size-governance.test.ts` — pass
- [x] `pnpm --filter canvas-workspace test` — 2188 passed, 1 skipped; the 7 failing suites (`chat-protocol`, `agent-tool-policy`, `engine-plugins`, `external-driver`, `headless-run`, `tools-graph`, `model/config`) all fail identically on `master` before this change (`Failed to load url pulse-coder-orchestrator ... packages/engine/dist/index.js`) — a pre-existing unbuilt-engine-package issue in this environment, unrelated to this diff (verified via `git stash`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EFvGhKnKLo3oSwCTpxXMrG)_