### PR TITLE
feat(canvas-workspace): embed Pi AgentHarness runtime

### DIFF
--- a/apps/canvas-workspace/electron.vite.config.ts
+++ b/apps/canvas-workspace/electron.vite.config.ts
@@ -161,7 +161,16 @@ function localPluginRendererAssetsPlugin() {
 
 export default defineConfig({
   main: {
-    plugins: [externalizeDepsPlugin()],
+    // Bundle the optional Pi backend so Rollup keeps only the two API paths
+    // Canvas actually uses. Leaving these external makes electron-builder
+    // package pi-ai's complete provider SDK dependency tree (AWS, Google,
+    // Mistral, and others) even though those providers are unreachable here.
+    plugins: [externalizeDepsPlugin({
+      exclude: [
+        "@earendil-works/pi-agent-core",
+        "@earendil-works/pi-ai",
+      ],
+    })],
     build: {
       outDir: "dist/main",
       minify: "esbuild"

--- a/apps/canvas-workspace/harness/knowledge/agent-roles.md
+++ b/apps/canvas-workspace/harness/knowledge/agent-roles.md
@@ -268,7 +268,7 @@ cwd? }` (`AgentRoleExternalDriver`, families enumerated in
 `AGENT_ROLE_EXTERNAL_FAMILIES`) routes that role's segments to
 `src/main/agent/external/` instead of the built-in engine, via the turn
 backend boundary (`src/main/agent/backends/`): `executeCanvasAgentSegment`
-(`src/main/agent/segment-execution.ts`) resolves `resolveTurnBackend(role)`
+(`src/main/agent/segment-execution.ts`) resolves `resolveAgentRuntime(role)`
 — a role with an external driver runs on `externalCliTurnBackend`, which
 calls `runExternalRoleSegment` (`src/main/agent/external/segment.ts`);
 everything else runs on `engineTurnBackend` (`engine.run(...)`). The
@@ -278,11 +278,11 @@ BOTH paths (a hard-stopped engine segment preserves its partial text the
 same way an external one does), collects response messages through one
 `recordResponseMessages` recorder, and applies the stopped-vs-failed abort
 normalization below. Each backend declares a capability matrix
-(`nativeCanvasTools`, `clarifications`, `historyFidelity`,
-`sessionResume`) for future per-backend UI degradation; additional native
-backends (e.g. a pi-backed default assistant — see
-`docs/09-agent-backend-boundary.md`) plug in at `resolveTurnBackend`
-without touching the chat pipeline. Guards:
+(`nativeCanvasTools`, `clarifications`, `historyFidelity`, `sessionResume`,
+`steering`, `compaction`). The default assistant can switch to the embedded
+Pi AgentHarness runtime through Settings → Experimental while persona roles
+continue on Engine; see `docs/09-agent-backend-boundary.md`. Deprecated
+`TurnBackend` / `resolveTurnBackend` aliases remain for compatibility. Guards:
 `src/main/agent/segment-execution.test.ts`,
 `src/main/agent/backends/registry.test.ts`.
 

--- a/apps/canvas-workspace/harness/knowledge/agent-roles.md
+++ b/apps/canvas-workspace/harness/knowledge/agent-roles.md
@@ -266,10 +266,25 @@ tokens instead of erroring.
 Setting `AgentRoleDefinition.external = { family: 'claude-code' | 'codex',
 cwd? }` (`AgentRoleExternalDriver`, families enumerated in
 `AGENT_ROLE_EXTERNAL_FAMILIES`) routes that role's segments to
-`src/main/agent/external/` instead of the built-in engine:
-`executeCanvasAgentSegment` (`src/main/agent/segment-execution.ts`)
-branches on `options.role?.external` and calls `runExternalRoleSegment`
-(`src/main/agent/external/segment.ts`) instead of `engine.run(...)`.
+`src/main/agent/external/` instead of the built-in engine, via the turn
+backend boundary (`src/main/agent/backends/`): `executeCanvasAgentSegment`
+(`src/main/agent/segment-execution.ts`) resolves `resolveTurnBackend(role)`
+— a role with an external driver runs on `externalCliTurnBackend`, which
+calls `runExternalRoleSegment` (`src/main/agent/external/segment.ts`);
+everything else runs on `engineTurnBackend` (`engine.run(...)`). The
+executor keeps the backend-AGNOSTIC policies for every backend: it
+pre-wraps `onText` so streamed deltas accumulate into `streamedText` on
+BOTH paths (a hard-stopped engine segment preserves its partial text the
+same way an external one does), collects response messages through one
+`recordResponseMessages` recorder, and applies the stopped-vs-failed abort
+normalization below. Each backend declares a capability matrix
+(`nativeCanvasTools`, `clarifications`, `historyFidelity`,
+`sessionResume`) for future per-backend UI degradation; additional native
+backends (e.g. a pi-backed default assistant — see
+`docs/09-agent-backend-boundary.md`) plug in at `resolveTurnBackend`
+without touching the chat pipeline. Guards:
+`src/main/agent/segment-execution.test.ts`,
+`src/main/agent/backends/registry.test.ts`.
 
 - Headless CLI spawn: Claude Code runs as `claude -p --output-format
   stream-json --verbose --include-partial-messages` (`buildClaudeCodeArgs`

--- a/apps/canvas-workspace/harness/knowledge/chat-sessions.md
+++ b/apps/canvas-workspace/harness/knowledge/chat-sessions.md
@@ -201,13 +201,18 @@ accepted.
 - Explicitly removing a ready draft attachment deletes its saved file.
 - Clearing a successfully sent draft must retain the file, because session
   history references it.
+- Native runtimes must treat the context's final user frame as the complete
+  model-facing current turn. It carries attachment paths and inspection
+  guidance that the plain composer text does not; seed it zero times and
+  prompt it exactly once, including for image-only turns.
 - A failed turn must persist the live tool-call snapshot and settle
   unfinished tools so reload matches the streamed UI.
 
 Guards: `useChatAttachments.test.tsx`
 (`src/renderer/src/components/chat/hooks/useChatAttachments.ts`),
 `chat-protocol.test.ts`, and `chat-failure-persistence.test.ts` (both under
-`src/main/agent/`).
+`src/main/agent/`), plus
+`src/main/agent/backends/pi-agent-harness-backend.test.ts`.
 
 ### Full-screen chat rail projection
 

--- a/apps/canvas-workspace/harness/tools/pi-agent-harness-smoke/main.mjs
+++ b/apps/canvas-workspace/harness/tools/pi-agent-harness-smoke/main.mjs
@@ -1,0 +1,41 @@
+import { app } from 'electron';
+import { AgentHarness, InMemorySessionRepo } from '@earendil-works/pi-agent-core';
+import { createModels, fauxAssistantMessage, fauxProvider } from '@earendil-works/pi-ai';
+
+const timeout = setTimeout(() => {
+  process.stderr.write('Electron pi AgentHarness smoke timed out\n');
+  app.exit(1);
+}, 10_000);
+
+app.whenReady().then(async () => {
+  try {
+    const faux = fauxProvider({ tokensPerSecond: 10_000 });
+    faux.setResponses([fauxAssistantMessage('ELECTRON_PI_OK')]);
+    const models = createModels();
+    models.setProvider(faux.provider);
+    const repo = new InMemorySessionRepo();
+    const session = await repo.create({ id: 'electron-pi-smoke' });
+    const harness = new AgentHarness({
+      session,
+      models,
+      model: faux.getModel(),
+      systemPrompt: 'Electron smoke test',
+    });
+    const response = await harness.prompt('respond');
+    const text = response.content
+      .filter((part) => part.type === 'text')
+      .map((part) => part.text)
+      .join('');
+    process.stdout.write(`${JSON.stringify({
+      electron: process.versions.electron,
+      node: process.versions.node,
+      text,
+    })}\n`);
+    clearTimeout(timeout);
+    app.exit(text === 'ELECTRON_PI_OK' ? 0 : 1);
+  } catch (error) {
+    process.stderr.write(`${error?.stack ?? error}\n`);
+    clearTimeout(timeout);
+    app.exit(1);
+  }
+});

--- a/apps/canvas-workspace/harness/tools/pi-agent-harness-smoke/package.json
+++ b/apps/canvas-workspace/harness/tools/pi-agent-harness-smoke/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "pi-agent-harness-electron-smoke",
+  "private": true,
+  "type": "module",
+  "main": "main.mjs"
+}

--- a/apps/canvas-workspace/harness/validate/validation.yaml
+++ b/apps/canvas-workspace/harness/validate/validation.yaml
@@ -70,6 +70,22 @@ pathRules:
     required:
       - node apps/canvas-workspace/harness/tools/describe-canvas.mjs
 
+  # pi's package metadata currently asks for Node >=22.19 while Electron 30
+  # embeds Node 20.16. Keep both ordinary adapter checks and a real Electron
+  # main-process prompt available as explicit compatibility evidence.
+  - name: pi-agent-harness-runtime
+    paths:
+      - package.json
+      - src/main/agent/backends/pi-*
+      - src/main/agent/model/config.ts
+      - harness/tools/pi-agent-harness-smoke/**
+    quick:
+      - pnpm --filter canvas-workspace exec vitest run src/main/agent/backends/pi-agent-harness-backend.test.ts src/main/agent/backends/pi-model-adapter.test.ts src/main/agent/backends/pi-tool-adapter.test.ts
+      - pnpm --filter canvas-workspace typecheck:main
+    required:
+      - pnpm --filter canvas-workspace build
+      - pnpm --filter canvas-workspace smoke:pi-electron
+
   - name: packaged-agent-tooling
     paths:
       - package.json

--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -126,8 +126,6 @@
     }
   },
   "dependencies": {
-    "@earendil-works/pi-agent-core": "0.83.0",
-    "@earendil-works/pi-ai": "0.83.0",
     "@ai-sdk/openai": "^3.0.21",
     "@larksuiteoapi/node-sdk": "^1.59.0",
     "ai": "^6.0.57",
@@ -139,6 +137,8 @@
     "zod": "^4.0.0"
   },
   "devDependencies": {
+    "@earendil-works/pi-agent-core": "0.83.0",
+    "@earendil-works/pi-ai": "0.83.0",
     "@electron/rebuild": "^4.0.3",
     "@module-federation/runtime": "2.5.1",
     "@phosphor-icons/react": "^2.1.10",

--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -32,6 +32,7 @@
     "perf:webview-load": "node scripts/perf/webview-load-check.mjs",
     "perf:webview-load:ab": "node scripts/perf/webview-load-ab.mjs",
     "setup:electron": "node scripts/setup/ensure-electron.mjs",
+    "smoke:pi-electron": "electron harness/tools/pi-agent-harness-smoke",
     "perf:dashboard": "node scripts/perf/dashboard.mjs",
     "perf:report": "node scripts/perf/report.mjs"
   },
@@ -125,6 +126,8 @@
     }
   },
   "dependencies": {
+    "@earendil-works/pi-agent-core": "0.83.0",
+    "@earendil-works/pi-ai": "0.83.0",
     "@ai-sdk/openai": "^3.0.21",
     "@larksuiteoapi/node-sdk": "^1.59.0",
     "ai": "^6.0.57",

--- a/apps/canvas-workspace/src/main/agent/backends/engine-backend.ts
+++ b/apps/canvas-workspace/src/main/agent/backends/engine-backend.ts
@@ -1,7 +1,7 @@
 import type { ModelMessage } from 'ai';
 
 import { buildEngineStreamCallbacks } from '../engine-stream-callbacks';
-import type { TurnBackend, TurnSegmentRequest, TurnSegmentResult } from './types';
+import type { AgentRuntime, TurnSegmentRequest, TurnSegmentResult } from './types';
 
 const CANVAS_AGENT_MAX_STEPS = 200;
 
@@ -10,13 +10,15 @@ const CANVAS_AGENT_MAX_STEPS = 200;
  * model history, with canvas tools, native clarifications, and compaction
  * write-back through `replaceMessages`.
  */
-export const engineTurnBackend: TurnBackend = {
+export const engineTurnBackend: AgentRuntime = {
   id: 'engine',
   capabilities: {
     nativeCanvasTools: true,
     clarifications: 'native',
     historyFidelity: 'full',
     sessionResume: 'host',
+    steering: 'none',
+    compaction: 'native',
   },
   async runSegment(request: TurnSegmentRequest): Promise<TurnSegmentResult> {
     const resultText = await request.engine.run(request.context, {

--- a/apps/canvas-workspace/src/main/agent/backends/engine-backend.ts
+++ b/apps/canvas-workspace/src/main/agent/backends/engine-backend.ts
@@ -1,0 +1,42 @@
+import type { ModelMessage } from 'ai';
+
+import { buildEngineStreamCallbacks } from '../engine-stream-callbacks';
+import type { TurnBackend, TurnSegmentRequest, TurnSegmentResult } from './types';
+
+const CANVAS_AGENT_MAX_STEPS = 200;
+
+/**
+ * The built-in backend: one `engine.run` per segment against the shared
+ * model history, with canvas tools, native clarifications, and compaction
+ * write-back through `replaceMessages`.
+ */
+export const engineTurnBackend: TurnBackend = {
+  id: 'engine',
+  capabilities: {
+    nativeCanvasTools: true,
+    clarifications: 'native',
+    historyFidelity: 'full',
+    sessionResume: 'host',
+  },
+  async runSegment(request: TurnSegmentRequest): Promise<TurnSegmentResult> {
+    const resultText = await request.engine.run(request.context, {
+      provider: request.modelConfig.provider,
+      model: request.configuredModel ?? request.modelConfig.model,
+      modelType: request.modelConfig.modelType,
+      systemPrompt: request.systemPrompt,
+      maxSteps: CANVAS_AGENT_MAX_STEPS,
+      abortSignal: request.abortSignal,
+      runContext: { executionMode: request.executionMode },
+      onClarificationRequest: request.onClarificationRequest,
+      ...buildEngineStreamCallbacks(request, request.debugTrace),
+      onResponse: (messages: ModelMessage[]) => {
+        request.recordResponseMessages(messages);
+      },
+      onCompacted: (messages: ModelMessage[]) => {
+        request.replaceMessages(messages);
+        request.context.messages = messages;
+      },
+    });
+    return { resultText };
+  },
+};

--- a/apps/canvas-workspace/src/main/agent/backends/external-cli-backend.ts
+++ b/apps/canvas-workspace/src/main/agent/backends/external-cli-backend.ts
@@ -1,0 +1,44 @@
+import type { ModelMessage } from 'ai';
+
+import { runExternalRoleSegment } from '../external/segment';
+import type { TurnBackend, TurnSegmentRequest, TurnSegmentResult } from './types';
+
+/**
+ * The external coding-agent CLI backend (Claude Code / Codex families).
+ * The CLI owns its own session and tool loop; the reply is appended to the
+ * shared model history by hand because an external CLI never calls the
+ * engine's onResponse.
+ */
+export const externalCliTurnBackend: TurnBackend = {
+  id: 'external-cli',
+  capabilities: {
+    nativeCanvasTools: false,
+    clarifications: 'approval',
+    historyFidelity: 'window',
+    sessionResume: 'cli',
+  },
+  async runSegment(request: TurnSegmentRequest): Promise<TurnSegmentResult> {
+    const role = request.role;
+    if (!role?.external) {
+      throw new Error('externalCliTurnBackend requires a role with an external driver');
+    }
+    const external = await runExternalRoleSegment({
+      role,
+      external: role.external,
+      chatSessionId: request.chatSessionId,
+      workspaceRootFolder: request.workspaceRootFolder,
+      history: request.history,
+      currentAsk: request.currentAsk,
+      handoffNames: request.handoffNames,
+      abortSignal: request.abortSignal,
+      executionMode: request.executionMode,
+      onApprovalRequest: request.onClarificationRequest,
+      onText: request.onText,
+      onToolCall: request.onToolCall,
+      onToolResult: request.onToolResult,
+    });
+    const message = { role: 'assistant', content: external.text } as ModelMessage;
+    request.recordResponseMessages([message]);
+    return { resultText: external.text, toolCalls: external.toolCalls };
+  },
+};

--- a/apps/canvas-workspace/src/main/agent/backends/external-cli-backend.ts
+++ b/apps/canvas-workspace/src/main/agent/backends/external-cli-backend.ts
@@ -1,7 +1,7 @@
 import type { ModelMessage } from 'ai';
 
 import { runExternalRoleSegment } from '../external/segment';
-import type { TurnBackend, TurnSegmentRequest, TurnSegmentResult } from './types';
+import type { AgentRuntime, TurnSegmentRequest, TurnSegmentResult } from './types';
 
 /**
  * The external coding-agent CLI backend (Claude Code / Codex families).
@@ -9,13 +9,15 @@ import type { TurnBackend, TurnSegmentRequest, TurnSegmentResult } from './types
  * shared model history by hand because an external CLI never calls the
  * engine's onResponse.
  */
-export const externalCliTurnBackend: TurnBackend = {
+export const externalCliTurnBackend: AgentRuntime = {
   id: 'external-cli',
   capabilities: {
     nativeCanvasTools: false,
     clarifications: 'approval',
     historyFidelity: 'window',
     sessionResume: 'cli',
+    steering: 'none',
+    compaction: 'cli',
   },
   async runSegment(request: TurnSegmentRequest): Promise<TurnSegmentResult> {
     const role = request.role;

--- a/apps/canvas-workspace/src/main/agent/backends/index.ts
+++ b/apps/canvas-workspace/src/main/agent/backends/index.ts
@@ -1,0 +1,26 @@
+import type { AgentRoleDefinition } from '../../../shared/agent-roles';
+import { engineTurnBackend } from './engine-backend';
+import { externalCliTurnBackend } from './external-cli-backend';
+import type { TurnBackend } from './types';
+
+export type {
+  TurnBackend,
+  TurnBackendCapabilities,
+  TurnSegmentRequest,
+  TurnSegmentResult,
+} from './types';
+export { engineTurnBackend } from './engine-backend';
+export { externalCliTurnBackend } from './external-cli-backend';
+
+/**
+ * Pick the backend for one segment. Roles with an external driver run on
+ * their CLI; everything else (default assistant + persona roles) runs on
+ * the built-in engine.
+ *
+ * This is the single extension point for additional native backends
+ * (e.g. a pi-backed default assistant): route here, keep the executor's
+ * abort/stream policies untouched, and declare honest capabilities so the
+ * chat UI can degrade per the backend's capability matrix.
+ */
+export const resolveTurnBackend = (role: AgentRoleDefinition | null): TurnBackend =>
+  role?.external ? externalCliTurnBackend : engineTurnBackend;

--- a/apps/canvas-workspace/src/main/agent/backends/index.ts
+++ b/apps/canvas-workspace/src/main/agent/backends/index.ts
@@ -1,26 +1,56 @@
 import type { AgentRoleDefinition } from '../../../shared/agent-roles';
+import { EXPERIMENTAL_FLAG_PI_AGENT_HARNESS } from '../../../shared/experimental-features';
+import { getExperimentalFlagSync } from '../../settings/experimental-ipc';
 import { engineTurnBackend } from './engine-backend';
 import { externalCliTurnBackend } from './external-cli-backend';
-import type { TurnBackend } from './types';
+import { piAgentHarnessTurnBackend } from './pi-agent-harness-backend';
+import type { AgentRuntime } from './types';
 
 export type {
   TurnBackend,
   TurnBackendCapabilities,
+  AgentRuntime,
+  AgentRuntimeCapabilities,
   TurnSegmentRequest,
   TurnSegmentResult,
 } from './types';
 export { engineTurnBackend } from './engine-backend';
 export { externalCliTurnBackend } from './external-cli-backend';
+export { piAgentHarnessTurnBackend } from './pi-agent-harness-backend';
 
 /**
  * Pick the backend for one segment. Roles with an external driver run on
  * their CLI; everything else (default assistant + persona roles) runs on
  * the built-in engine.
  *
- * This is the single extension point for additional native backends
- * (e.g. a pi-backed default assistant): route here, keep the executor's
+ * This is the single extension point for additional native runtimes:
+ * route here, keep the executor's
  * abort/stream policies untouched, and declare honest capabilities so the
  * chat UI can degrade per the backend's capability matrix.
  */
-export const resolveTurnBackend = (role: AgentRoleDefinition | null): TurnBackend =>
-  role?.external ? externalCliTurnBackend : engineTurnBackend;
+export interface AgentRuntimeSelection {
+  /** Test/dev override. Product selection normally comes from Experimental. */
+  piEnabled?: boolean;
+}
+
+const resolvePiEnabled = (selection: AgentRuntimeSelection): boolean => {
+  if (selection.piEnabled !== undefined) return selection.piEnabled;
+  const env = process.env.PULSE_CANVAS_AGENT_RUNTIME?.trim().toLowerCase();
+  if (env === 'pi') return true;
+  if (env === 'engine') return false;
+  return getExperimentalFlagSync(EXPERIMENTAL_FLAG_PI_AGENT_HARNESS);
+};
+
+export const resolveAgentRuntime = (
+  role: AgentRoleDefinition | null,
+  selection: AgentRuntimeSelection = {},
+): AgentRuntime => {
+  if (role?.external) return externalCliTurnBackend;
+  if (!role && resolvePiEnabled(selection)) {
+    return piAgentHarnessTurnBackend;
+  }
+  return engineTurnBackend;
+};
+
+/** @deprecated Use resolveAgentRuntime. */
+export const resolveTurnBackend = resolveAgentRuntime;

--- a/apps/canvas-workspace/src/main/agent/backends/index.ts
+++ b/apps/canvas-workspace/src/main/agent/backends/index.ts
@@ -3,8 +3,7 @@ import { EXPERIMENTAL_FLAG_PI_AGENT_HARNESS } from '../../../shared/experimental
 import { getExperimentalFlagSync } from '../../settings/experimental-ipc';
 import { engineTurnBackend } from './engine-backend';
 import { externalCliTurnBackend } from './external-cli-backend';
-import { piAgentHarnessTurnBackend } from './pi-agent-harness-backend';
-import type { AgentRuntime } from './types';
+import type { AgentRuntime, TurnSegmentRequest } from './types';
 
 export type {
   TurnBackend,
@@ -16,7 +15,35 @@ export type {
 } from './types';
 export { engineTurnBackend } from './engine-backend';
 export { externalCliTurnBackend } from './external-cli-backend';
-export { piAgentHarnessTurnBackend } from './pi-agent-harness-backend';
+
+let piBackendPromise: Promise<AgentRuntime> | undefined;
+const loadPiAgentHarnessTurnBackend = (): Promise<AgentRuntime> => {
+  piBackendPromise ??= import('./pi-agent-harness-backend')
+    .then(({ piAgentHarnessTurnBackend }) => piAgentHarnessTurnBackend);
+  return piBackendPromise;
+};
+
+/** Keep the experimental Pi runtime out of the default Engine startup chunk. */
+export const piAgentHarnessTurnBackend: AgentRuntime = {
+  id: 'pi-agent-harness',
+  capabilities: {
+    nativeCanvasTools: true,
+    clarifications: 'native',
+    historyFidelity: 'full',
+    sessionResume: 'host',
+    steering: 'native',
+    compaction: 'host',
+  },
+  async runSegment(request: TurnSegmentRequest) {
+    return (await loadPiAgentHarnessTurnBackend()).runSegment(request);
+  },
+  async steer(sessionId, text) {
+    return (await loadPiAgentHarnessTurnBackend()).steer?.(sessionId, text) ?? false;
+  },
+  async followUp(sessionId, text) {
+    return (await loadPiAgentHarnessTurnBackend()).followUp?.(sessionId, text) ?? false;
+  },
+};
 
 /**
  * Pick the backend for one segment. Roles with an external driver run on

--- a/apps/canvas-workspace/src/main/agent/backends/pi-agent-harness-backend.test.ts
+++ b/apps/canvas-workspace/src/main/agent/backends/pi-agent-harness-backend.test.ts
@@ -1,0 +1,624 @@
+import {
+  createModels,
+  fauxAssistantMessage,
+  fauxProvider,
+  fauxThinking,
+  fauxText,
+  fauxToolCall,
+} from '@earendil-works/pi-ai';
+import type { Engine } from 'pulse-coder-engine';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import { createPiAgentHarnessTurnBackend } from './pi-agent-harness-backend';
+
+describe('pi AgentHarness turn backend', () => {
+  it('hydrates host history once and streams the real AgentHarness response', async () => {
+    const faux = fauxProvider({ tokensPerSecond: 10_000 });
+    const models = createModels();
+    models.setProvider(faux.provider);
+    let providerMessages: unknown[] = [];
+    let providerSystemPrompt = '';
+    faux.setResponses([
+      (context) => {
+        providerMessages = [...context.messages];
+        providerSystemPrompt = context.systemPrompt ?? '';
+        return fauxAssistantMessage([
+          fauxThinking('private reasoning frame'),
+          fauxText('PI_HARNESS_OK'),
+        ]);
+      },
+    ]);
+    const backend = createPiAgentHarnessTurnBackend({
+      createModelRuntime: () => ({ models, model: faux.getModel() }),
+    });
+    const recordResponseMessages = vi.fn();
+    const onText = vi.fn();
+    const dispose = vi.fn();
+
+    const result = await backend.runSegment({
+      engine: {
+        getTools: () => ({}),
+        compactContext: async () => ({ didCompact: false }),
+        createToolSession: async () => ({
+          getTools: () => ({}),
+          getSystemPrompt: () => 'Canvas system prompt + Engine policy',
+          executeTool: vi.fn(),
+          dispose,
+        }),
+      } as unknown as Engine,
+      context: {
+        messages: [
+          { role: 'user', content: 'earlier ask' },
+          {
+            role: 'assistant',
+            content: [{
+              type: 'tool-call',
+              toolCallId: 'old-tool-1',
+              toolName: 'canvas_read_context',
+              input: { detail: 'summary' },
+            }],
+          },
+          {
+            role: 'tool',
+            content: [{
+              type: 'tool-result',
+              toolCallId: 'old-tool-1',
+              toolName: 'canvas_read_context',
+              output: { type: 'text', value: 'old canvas context' },
+            }],
+          },
+          { role: 'assistant', content: 'earlier answer' },
+          { role: 'user', content: 'current ask' },
+        ],
+      },
+      role: null,
+      chatSessionId: 'session-1',
+      history: [],
+      currentAsk: 'current ask',
+      handoffNames: [],
+      abortSignal: new AbortController().signal,
+      executionMode: 'auto',
+      onText,
+      modelConfig: {
+        providerType: 'openai',
+        provider: vi.fn(),
+        model: 'faux-model',
+        modelLabel: 'Faux model',
+      },
+      systemPrompt: 'Canvas system prompt',
+      recordResponseMessages,
+      replaceMessages: vi.fn(),
+    });
+
+    expect(result.resultText).toBe('PI_HARNESS_OK');
+    expect(providerSystemPrompt).toBe('Canvas system prompt + Engine policy');
+    expect(providerMessages.filter((message: any) => message.role === 'user')).toHaveLength(2);
+    expect(providerMessages.map((message: any) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'toolResult',
+      'assistant',
+      'user',
+    ]);
+    expect(providerMessages[1]).toMatchObject({
+      role: 'assistant',
+      content: [{
+        type: 'toolCall',
+        id: 'old-tool-1',
+        name: 'canvas_read_context',
+        arguments: { detail: 'summary' },
+      }],
+      stopReason: 'toolUse',
+    });
+    expect(providerMessages[2]).toMatchObject({
+      role: 'toolResult',
+      toolCallId: 'old-tool-1',
+      toolName: 'canvas_read_context',
+      content: [{ type: 'text', text: 'old canvas context' }],
+    });
+    expect(providerMessages.at(-1)).toMatchObject({
+      role: 'user',
+      content: [{ type: 'text', text: 'current ask' }],
+    });
+    expect(onText.mock.calls.flat().join('')).toBe('PI_HARNESS_OK');
+    expect(recordResponseMessages).toHaveBeenCalledWith([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'reasoning', text: 'private reasoning frame' },
+          { type: 'text', text: 'PI_HARNESS_OK' },
+        ],
+      },
+    ]);
+    expect(dispose).toHaveBeenCalledWith('PI_HARNESS_OK');
+  });
+
+  it('loads and executes a deferred Engine tool inside the same AgentHarness run', async () => {
+    const faux = fauxProvider({ tokensPerSecond: 10_000 });
+    const models = createModels();
+    models.setProvider(faux.provider);
+    const updateNode = vi.fn(async (_input: unknown, _context: unknown) => 'updated');
+    let toolsAfterSearch: string[] = [];
+    faux.setResponses([
+      fauxAssistantMessage(
+        fauxToolCall('tool_search_tool_bm25', { query: 'update a node' }, { id: 'search-1' }),
+        { stopReason: 'toolUse' },
+      ),
+      (context) => {
+        toolsAfterSearch = context.tools?.map(tool => tool.name) ?? [];
+        return fauxAssistantMessage(
+          fauxToolCall('canvas_update_node', { id: 'node-1' }, { id: 'update-1' }),
+          { stopReason: 'toolUse' },
+        );
+      },
+      fauxAssistantMessage('updated through pi'),
+    ]);
+    const backend = createPiAgentHarnessTurnBackend({
+      createModelRuntime: () => ({ models, model: faux.getModel() }),
+    });
+    const onToolCall = vi.fn();
+    const onToolResult = vi.fn();
+    const recordResponseMessages = vi.fn();
+    const sourceTools = {
+      tool_search_tool_bm25: {
+        name: 'tool_search_tool_bm25',
+        description: 'Search tools.',
+        inputSchema: z.object({ query: z.string() }),
+        execute: async () => ({
+          type: 'tool_search_tool_search_result',
+          tool_references: [{ type: 'tool_reference', tool_name: 'canvas_update_node' }],
+        }),
+      },
+      canvas_update_node: {
+        name: 'canvas_update_node',
+        description: 'Update a node.',
+        inputSchema: z.object({ id: z.string() }),
+        defer_loading: true,
+        execute: updateNode,
+      },
+    };
+    const visible = new Set(['tool_search_tool_bm25']);
+    const dispose = vi.fn();
+    const executeTool = vi.fn(async (name: keyof typeof sourceTools, input: unknown, context: unknown) => {
+      if (!visible.has(name)) throw new Error(`Unavailable tool: ${name}`);
+      if (name === 'tool_search_tool_bm25') {
+        const output = await sourceTools.tool_search_tool_bm25.execute();
+        visible.add('canvas_update_node');
+        return output;
+      }
+      return sourceTools.canvas_update_node.execute(input as never, context as never);
+    });
+
+    const result = await backend.runSegment({
+      engine: {
+        // Simulate a beforeRun policy adding a tool that is absent from the
+        // Engine's static registry. Pi must use the policy session definition.
+        getTools: () => ({ tool_search_tool_bm25: sourceTools.tool_search_tool_bm25 }),
+        compactContext: async () => ({ didCompact: false }),
+        createToolSession: async () => ({
+          getRegisteredTools: () => sourceTools,
+          getTools: () => Object.fromEntries(
+            Object.entries(sourceTools).filter(([name]) => visible.has(name)),
+          ),
+          getSystemPrompt: () => 'Canvas system prompt',
+          executeTool,
+          dispose,
+        }),
+      } as unknown as Engine,
+      context: { messages: [{ role: 'user', content: 'update node-1' }] },
+      role: null,
+      chatSessionId: 'session-tools',
+      history: [],
+      currentAsk: 'update node-1',
+      handoffNames: [],
+      abortSignal: new AbortController().signal,
+      executionMode: 'auto',
+      onText: vi.fn(),
+      onToolCall,
+      onToolResult,
+      modelConfig: {
+        providerType: 'openai',
+        provider: vi.fn(),
+        model: 'faux-model',
+        modelLabel: 'Faux model',
+      },
+      systemPrompt: 'Canvas system prompt',
+      recordResponseMessages,
+      replaceMessages: vi.fn(),
+    });
+
+    expect(toolsAfterSearch).toContain('canvas_update_node');
+    expect(updateNode).toHaveBeenCalledWith(
+      { id: 'node-1' },
+      expect.objectContaining({ toolCallId: 'update-1' }),
+    );
+    expect(result.resultText).toBe('updated through pi');
+    expect(result.toolCalls).toEqual([
+      expect.objectContaining({ name: 'tool_search_tool_bm25', status: 'succeeded' }),
+      expect.objectContaining({ name: 'canvas_update_node', status: 'succeeded' }),
+    ]);
+    expect(onToolCall).toHaveBeenCalledTimes(2);
+    expect(onToolResult).toHaveBeenCalledTimes(2);
+    const recordedMessages = recordResponseMessages.mock.calls
+      .flatMap(([messages]) => messages) as any[];
+    expect(recordedMessages.map(message => message.role)).toEqual([
+      'assistant',
+      'tool',
+      'assistant',
+      'tool',
+      'assistant',
+    ]);
+    expect(recordedMessages[1].content[0].output).toMatchObject({
+      type: 'json',
+      value: { type: 'tool_search_tool_search_result' },
+    });
+    expect(executeTool).toHaveBeenCalledTimes(2);
+    expect(dispose).toHaveBeenCalledWith('updated through pi');
+  });
+
+  it('uses host compaction and writes the compacted history back before prompting pi', async () => {
+    const faux = fauxProvider({ tokensPerSecond: 10_000 });
+    const models = createModels();
+    models.setProvider(faux.provider);
+    let providerMessages: unknown[] = [];
+    faux.setResponses([(context) => {
+      providerMessages = [...context.messages];
+      return fauxAssistantMessage('compacted answer');
+    }]);
+    const compactedMessages = [
+      { role: 'user' as const, content: 'compacted summary' },
+      { role: 'user' as const, content: 'current ask' },
+    ];
+    const replaceMessages = vi.fn();
+    const backend = createPiAgentHarnessTurnBackend({
+      createModelRuntime: () => ({ models, model: faux.getModel() }),
+    });
+
+    await backend.runSegment({
+      engine: {
+        getTools: () => ({}),
+        compactContext: async () => ({ didCompact: true, newMessages: compactedMessages }),
+        createToolSession: async () => ({
+          getTools: () => ({}),
+          getSystemPrompt: () => 'Canvas system prompt',
+          executeTool: vi.fn(),
+          dispose: vi.fn(),
+        }),
+      } as unknown as Engine,
+      context: {
+        messages: [
+          { role: 'user', content: 'very old context' },
+          { role: 'user', content: 'current ask' },
+        ],
+      },
+      role: null,
+      chatSessionId: 'session-compaction',
+      history: [],
+      currentAsk: 'current ask',
+      handoffNames: [],
+      abortSignal: new AbortController().signal,
+      executionMode: 'auto',
+      onText: vi.fn(),
+      modelConfig: {
+        providerType: 'openai',
+        provider: vi.fn(),
+        model: 'faux-model',
+        modelLabel: 'Faux model',
+      },
+      systemPrompt: 'Canvas system prompt',
+      recordResponseMessages: vi.fn(),
+      replaceMessages,
+    });
+
+    expect(replaceMessages).toHaveBeenCalledWith(compactedMessages);
+    expect(providerMessages.map((message: any) => message.content)).toEqual([
+      'compacted summary',
+      [{ type: 'text', text: 'current ask' }],
+    ]);
+  });
+
+  it('forwards steering into the active AgentHarness run', async () => {
+    const faux = fauxProvider({ tokensPerSecond: 100 });
+    const models = createModels();
+    models.setProvider(faux.provider);
+    const providerTurns: unknown[][] = [];
+    faux.setResponses([
+      (context) => {
+        providerTurns.push([...context.messages]);
+        return fauxAssistantMessage('initial answer');
+      },
+      (context) => {
+        providerTurns.push([...context.messages]);
+        return fauxAssistantMessage('revised answer');
+      },
+    ]);
+    const backend = createPiAgentHarnessTurnBackend({
+      createModelRuntime: () => ({ models, model: faux.getModel() }),
+    });
+    let steerResult: Promise<boolean> | undefined;
+
+    const run = backend.runSegment({
+      engine: {
+        getTools: () => ({}),
+        compactContext: async () => ({ didCompact: false }),
+        createToolSession: async () => ({
+          getTools: () => ({}),
+          getSystemPrompt: () => 'Canvas system prompt',
+          executeTool: vi.fn(),
+          dispose: vi.fn(),
+        }),
+      } as unknown as Engine,
+      context: { messages: [{ role: 'user', content: 'initial ask' }] },
+      role: null,
+      chatSessionId: 'session-steer',
+      history: [],
+      currentAsk: 'initial ask',
+      handoffNames: [],
+      abortSignal: new AbortController().signal,
+      executionMode: 'auto',
+      onText: () => {
+        steerResult ??= backend.steer!('session-steer', 'please revise');
+      },
+      modelConfig: {
+        providerType: 'openai',
+        provider: vi.fn(),
+        model: 'faux-model',
+        modelLabel: 'Faux model',
+      },
+      systemPrompt: 'Canvas system prompt',
+      recordResponseMessages: vi.fn(),
+      replaceMessages: vi.fn(),
+    });
+
+    const result = await run;
+    expect(await steerResult).toBe(true);
+    expect(providerTurns).toHaveLength(2);
+    expect(providerTurns[1].at(-1)).toMatchObject({
+      role: 'user',
+      content: [{ type: 'text', text: 'please revise' }],
+    });
+    expect(result.resultText).toBe('revised answer');
+    expect(await backend.followUp!('missing-session', 'later')).toBe(false);
+  });
+
+  it('surfaces provider failures instead of persisting an empty success', async () => {
+    const faux = fauxProvider({ tokensPerSecond: 10_000 });
+    const models = createModels();
+    models.setProvider(faux.provider);
+    faux.setResponses([
+      fauxAssistantMessage('', {
+        stopReason: 'error',
+        errorMessage: 'upstream rejected the request',
+      }),
+    ]);
+    const dispose = vi.fn();
+    const recordResponseMessages = vi.fn();
+    const backend = createPiAgentHarnessTurnBackend({
+      createModelRuntime: () => ({ models, model: faux.getModel() }),
+    });
+
+    await expect(backend.runSegment({
+      engine: {
+        getTools: () => ({}),
+        compactContext: async () => ({ didCompact: false }),
+        createToolSession: async () => ({
+          getTools: () => ({}),
+          getSystemPrompt: () => 'Canvas system prompt',
+          executeTool: vi.fn(),
+          dispose,
+        }),
+      } as unknown as Engine,
+      context: { messages: [{ role: 'user', content: 'fail' }] },
+      role: null,
+      chatSessionId: 'session-error',
+      history: [],
+      currentAsk: 'fail',
+      handoffNames: [],
+      abortSignal: new AbortController().signal,
+      executionMode: 'auto',
+      onText: vi.fn(),
+      modelConfig: {
+        providerType: 'openai',
+        provider: vi.fn(),
+        model: 'faux-model',
+        modelLabel: 'Faux model',
+      },
+      systemPrompt: 'Canvas system prompt',
+      recordResponseMessages,
+      replaceMessages: vi.fn(),
+    })).rejects.toThrow('upstream rejected the request');
+
+    expect(recordResponseMessages).not.toHaveBeenCalled();
+    expect(dispose).toHaveBeenCalledWith('');
+  });
+
+  it('closes the Engine tool session when pi tool setup fails', async () => {
+    const faux = fauxProvider({ tokensPerSecond: 10_000 });
+    const models = createModels();
+    models.setProvider(faux.provider);
+    const dispose = vi.fn();
+    const backend = createPiAgentHarnessTurnBackend({
+      createModelRuntime: () => ({ models, model: faux.getModel() }),
+    });
+
+    await expect(backend.runSegment({
+      engine: {
+        getTools: () => ({
+          malformed: {
+            name: 'malformed',
+            description: 'Malformed test tool.',
+            inputSchema: undefined,
+            execute: vi.fn(),
+          },
+        }),
+        compactContext: async () => ({ didCompact: false }),
+        createToolSession: async () => ({
+          getTools: () => ({ malformed: {} }),
+          getSystemPrompt: () => 'Canvas system prompt',
+          executeTool: vi.fn(),
+          dispose,
+        }),
+      } as unknown as Engine,
+      context: { messages: [{ role: 'user', content: 'fail setup' }] },
+      role: null,
+      chatSessionId: 'session-setup-error',
+      history: [],
+      currentAsk: 'fail setup',
+      handoffNames: [],
+      abortSignal: new AbortController().signal,
+      executionMode: 'auto',
+      onText: vi.fn(),
+      modelConfig: {
+        providerType: 'openai',
+        provider: vi.fn(),
+        model: 'faux-model',
+        modelLabel: 'Faux model',
+      },
+      systemPrompt: 'Canvas system prompt',
+      recordResponseMessages: vi.fn(),
+      replaceMessages: vi.fn(),
+    })).rejects.toThrow();
+
+    expect(dispose).toHaveBeenCalledWith('');
+  });
+
+  it('syncs policy visibility after a tool execution fails', async () => {
+    const faux = fauxProvider({ tokensPerSecond: 10_000 });
+    const models = createModels();
+    models.setProvider(faux.provider);
+    let visibleAfterFailure: string[] = [];
+    faux.setResponses([
+      fauxAssistantMessage(
+        fauxToolCall('unstable_tool', {}, { id: 'unstable-1' }),
+        { stopReason: 'toolUse' },
+      ),
+      (context) => {
+        visibleAfterFailure = context.tools?.map(tool => tool.name) ?? [];
+        return fauxAssistantMessage('recovered');
+      },
+    ]);
+    const backend = createPiAgentHarnessTurnBackend({
+      createModelRuntime: () => ({ models, model: faux.getModel() }),
+    });
+    const sourceTools = {
+      unstable_tool: {
+        name: 'unstable_tool',
+        description: 'Fails once and is then revoked by policy.',
+        inputSchema: z.object({}),
+        execute: vi.fn(),
+      },
+    };
+    let visible = true;
+
+    const result = await backend.runSegment({
+      engine: {
+        getTools: () => sourceTools,
+        compactContext: async () => ({ didCompact: false }),
+        createToolSession: async () => ({
+          getRegisteredTools: () => sourceTools,
+          getTools: () => visible ? sourceTools : {},
+          getSystemPrompt: () => 'Canvas system prompt',
+          executeTool: async () => {
+            visible = false;
+            throw new Error('tool failed');
+          },
+          dispose: vi.fn(),
+        }),
+      } as unknown as Engine,
+      context: { messages: [{ role: 'user', content: 'run unstable tool' }] },
+      role: null,
+      chatSessionId: 'session-tool-error-policy',
+      history: [],
+      currentAsk: 'run unstable tool',
+      handoffNames: [],
+      abortSignal: new AbortController().signal,
+      executionMode: 'auto',
+      onText: vi.fn(),
+      modelConfig: {
+        providerType: 'openai',
+        provider: vi.fn(),
+        model: 'faux-model',
+        modelLabel: 'Faux model',
+      },
+      systemPrompt: 'Canvas system prompt',
+      recordResponseMessages: vi.fn(),
+      replaceMessages: vi.fn(),
+    });
+
+    expect(result.resultText).toBe('recovered');
+    expect(visibleAfterFailure).not.toContain('unstable_tool');
+  });
+
+  it('serializes multiple pi tool calls through the stateful policy session', async () => {
+    const faux = fauxProvider({ tokensPerSecond: 10_000 });
+    const models = createModels();
+    models.setProvider(faux.provider);
+    faux.setResponses([
+      fauxAssistantMessage([
+        fauxToolCall('first_tool', {}, { id: 'first-1' }),
+        fauxToolCall('second_tool', {}, { id: 'second-1' }),
+      ], { stopReason: 'toolUse' }),
+      fauxAssistantMessage('both complete'),
+    ]);
+    const backend = createPiAgentHarnessTurnBackend({
+      createModelRuntime: () => ({ models, model: faux.getModel() }),
+    });
+    const sourceTools = Object.fromEntries(['first_tool', 'second_tool'].map(name => [name, {
+      name,
+      description: `${name} description`,
+      inputSchema: z.object({}),
+      execute: vi.fn(),
+    }]));
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const executionOrder: string[] = [];
+
+    const result = await backend.runSegment({
+      engine: {
+        getTools: () => sourceTools,
+        compactContext: async () => ({ didCompact: false }),
+        createToolSession: async () => ({
+          getRegisteredTools: () => sourceTools,
+          getTools: () => sourceTools,
+          getSystemPrompt: () => 'Canvas system prompt',
+          executeTool: async (name: string) => {
+            inFlight += 1;
+            maxInFlight = Math.max(maxInFlight, inFlight);
+            executionOrder.push(`start:${name}`);
+            await new Promise(resolve => setTimeout(resolve, 5));
+            executionOrder.push(`end:${name}`);
+            inFlight -= 1;
+            return name;
+          },
+          dispose: vi.fn(),
+        }),
+      } as unknown as Engine,
+      context: { messages: [{ role: 'user', content: 'run both' }] },
+      role: null,
+      chatSessionId: 'session-sequential-tools',
+      history: [],
+      currentAsk: 'run both',
+      handoffNames: [],
+      abortSignal: new AbortController().signal,
+      executionMode: 'auto',
+      onText: vi.fn(),
+      modelConfig: {
+        providerType: 'openai',
+        provider: vi.fn(),
+        model: 'faux-model',
+        modelLabel: 'Faux model',
+      },
+      systemPrompt: 'Canvas system prompt',
+      recordResponseMessages: vi.fn(),
+      replaceMessages: vi.fn(),
+    });
+
+    expect(result.resultText).toBe('both complete');
+    expect(maxInFlight).toBe(1);
+    expect(executionOrder).toEqual([
+      'start:first_tool', 'end:first_tool',
+      'start:second_tool', 'end:second_tool',
+    ]);
+  });
+});

--- a/apps/canvas-workspace/src/main/agent/backends/pi-agent-harness-backend.test.ts
+++ b/apps/canvas-workspace/src/main/agent/backends/pi-agent-harness-backend.test.ts
@@ -134,6 +134,69 @@ describe('pi AgentHarness turn backend', () => {
     expect(dispose).toHaveBeenCalledWith('PI_HARNESS_OK');
   });
 
+  it('prompts once with the host attachment envelope for the current user turn', async () => {
+    const faux = fauxProvider({ tokensPerSecond: 10_000 });
+    const models = createModels();
+    models.setProvider(faux.provider);
+    let providerMessages: any[] = [];
+    faux.setResponses([(context) => {
+      providerMessages = [...context.messages];
+      return fauxAssistantMessage('image received');
+    }]);
+    const attachmentPrompt = [
+      'describe this image',
+      '',
+      'User attached image files for this turn:',
+      '1. /tmp/pi-attachment.png (pi-attachment.png, mime=image/png)',
+      'Use canvas_analyze_image with imagePaths when you need to inspect these images.',
+    ].join('\n');
+    const backend = createPiAgentHarnessTurnBackend({
+      createModelRuntime: () => ({ models, model: faux.getModel() }),
+    });
+
+    await backend.runSegment({
+      engine: {
+        getTools: () => ({}),
+        compactContext: async () => ({ didCompact: false }),
+        createToolSession: async () => ({
+          getTools: () => ({}),
+          getSystemPrompt: () => 'Canvas system prompt',
+          executeTool: vi.fn(),
+          dispose: vi.fn(),
+        }),
+      } as unknown as Engine,
+      context: { messages: [{ role: 'user', content: attachmentPrompt }] },
+      role: null,
+      chatSessionId: 'session-attachment',
+      history: [],
+      // Canvas stores the richer model-facing envelope in context while the
+      // plain composer text remains the host's currentAsk value.
+      currentAsk: 'describe this image',
+      handoffNames: [],
+      abortSignal: new AbortController().signal,
+      executionMode: 'auto',
+      onText: vi.fn(),
+      modelConfig: {
+        providerType: 'openai',
+        provider: vi.fn(),
+        model: 'faux-model',
+        modelLabel: 'Faux model',
+      },
+      systemPrompt: 'Canvas system prompt',
+      recordResponseMessages: vi.fn(),
+      replaceMessages: vi.fn(),
+    });
+
+    const userMessages = providerMessages.filter(message => message.role === 'user');
+    expect(userMessages).toHaveLength(1);
+    expect(userMessages[0].content).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining('/tmp/pi-attachment.png'),
+      }),
+    ]));
+  });
+
   it('loads and executes a deferred Engine tool inside the same AgentHarness run', async () => {
     const faux = fauxProvider({ tokensPerSecond: 10_000 });
     const models = createModels();

--- a/apps/canvas-workspace/src/main/agent/backends/pi-agent-harness-backend.test.ts
+++ b/apps/canvas-workspace/src/main/agent/backends/pi-agent-harness-backend.test.ts
@@ -238,6 +238,10 @@ describe('pi AgentHarness turn backend', () => {
       expect.objectContaining({ name: 'tool_search_tool_bm25', status: 'succeeded' }),
       expect.objectContaining({ name: 'canvas_update_node', status: 'succeeded' }),
     ]);
+    expect(JSON.parse(result.toolCalls?.[0]?.result ?? '{}')).toMatchObject({
+      type: 'tool_search_tool_search_result',
+      tool_references: [{ tool_name: 'canvas_update_node' }],
+    });
     expect(onToolCall).toHaveBeenCalledTimes(2);
     expect(onToolResult).toHaveBeenCalledTimes(2);
     const recordedMessages = recordResponseMessages.mock.calls

--- a/apps/canvas-workspace/src/main/agent/backends/pi-agent-harness-backend.ts
+++ b/apps/canvas-workspace/src/main/agent/backends/pi-agent-harness-backend.ts
@@ -193,10 +193,11 @@ const seedHistory = async (
   session: Awaited<ReturnType<InMemorySessionRepo['create']>>,
   request: TurnSegmentRequest,
   model: PiModelRuntime['model'],
+  currentPrompt: string,
 ): Promise<void> => {
   const messages = request.context.messages;
   const last = messages.at(-1);
-  const history = last?.role === 'user' && messageText(last.content) === request.currentAsk
+  const history = last?.role === 'user' && messageText(last.content) === currentPrompt
     ? messages.slice(0, -1)
     : messages;
   for (const message of history) {
@@ -246,10 +247,19 @@ export function createPiAgentHarnessTurnBackend(
         request.replaceMessages(compacted.newMessages);
         request.context.messages = compacted.newMessages;
       }
+      // Canvas stores the complete model-facing current turn in context. For
+      // image attachments that envelope includes local paths and inspection
+      // guidance, while `currentAsk` remains only the composer text (and may
+      // be empty for an image-only turn). Prompt Pi with the host envelope and
+      // exclude that same frame from seeded history so it is sent exactly once.
+      const lastHostMessage = request.context.messages.at(-1);
+      const currentPrompt = lastHostMessage?.role === 'user'
+        ? messageText(lastHostMessage.content)
+        : request.currentAsk;
       const modelRuntime = createModelRuntime(request.modelConfig);
       const repo = new InMemorySessionRepo();
       const session = await repo.create({ id: request.chatSessionId });
-      await seedHistory(session, request, modelRuntime.model);
+      await seedHistory(session, request, modelRuntime.model, currentPrompt);
       const toolSession = await request.engine.createToolSession(
         request.context,
         {
@@ -336,7 +346,7 @@ export function createPiAgentHarnessTurnBackend(
           if (
             currentPromptPending
             && event.message.role === 'user'
-            && messageText(event.message.content) === request.currentAsk
+            && messageText(event.message.content) === currentPrompt
           ) {
             currentPromptPending = false;
           } else {
@@ -394,7 +404,7 @@ export function createPiAgentHarnessTurnBackend(
       let resultText = '';
       let runError: unknown;
       try {
-        const response = await harness.prompt(request.currentAsk);
+        const response = await harness.prompt(currentPrompt);
         if (response.stopReason === 'error') {
           throw new Error(response.errorMessage || 'Pi AgentHarness provider request failed');
         }

--- a/apps/canvas-workspace/src/main/agent/backends/pi-agent-harness-backend.ts
+++ b/apps/canvas-workspace/src/main/agent/backends/pi-agent-harness-backend.ts
@@ -1,0 +1,416 @@
+import {
+  AgentHarness,
+  InMemorySessionRepo,
+  type AgentMessage,
+} from '@earendil-works/pi-agent-core';
+import type { AssistantMessage } from '@earendil-works/pi-ai';
+import type { ModelMessage } from 'ai';
+
+import { unwrapToolOutput } from '../engine-stream-callbacks';
+import type { CanvasAgentToolCall } from '../types';
+import { createPiModelRuntime, type PiModelRuntime } from './pi-model-adapter';
+import { adaptEngineToolsForPi } from './pi-tool-adapter';
+import type { AgentRuntime, TurnSegmentRequest, TurnSegmentResult } from './types';
+
+interface PiAgentHarnessBackendOptions {
+  createModelRuntime?: (config: TurnSegmentRequest['modelConfig']) => PiModelRuntime;
+}
+
+const EMPTY_USAGE: AssistantMessage['usage'] = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+const messageText = (content: unknown): string => {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .map(part => part && typeof part === 'object' && (part as any).type === 'text'
+      ? String((part as any).text ?? '')
+      : '')
+    .join('');
+};
+
+const toolOutputText = (output: unknown): string => {
+  const value = unwrapToolOutput(output);
+  if (typeof value === 'string') return value;
+  if (value === undefined) return '';
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
+const toPiHistoryMessages = (
+  message: ModelMessage,
+  model: PiModelRuntime['model'],
+): AgentMessage[] => {
+  const timestamp = Date.now();
+  if (message.role === 'user') {
+    return [{ role: 'user', content: messageText(message.content), timestamp }];
+  }
+  if (message.role === 'system') {
+    const text = messageText(message.content);
+    return text
+      ? [{ role: 'user', content: `[System context]\n${text}`, timestamp }]
+      : [];
+  }
+  if (message.role === 'assistant') {
+    const source = Array.isArray(message.content) ? message.content : [];
+    const content: AssistantMessage['content'] = [];
+    if (typeof message.content === 'string') {
+      content.push({ type: 'text', text: message.content });
+    } else {
+      for (const part of source as any[]) {
+        if (part?.type === 'text') {
+          content.push({ type: 'text', text: String(part.text ?? '') });
+        } else if (part?.type === 'reasoning') {
+          content.push({ type: 'thinking', thinking: String(part.text ?? part.reasoning ?? '') });
+        } else if (part?.type === 'tool-call') {
+          content.push({
+            type: 'toolCall',
+            id: String(part.toolCallId ?? ''),
+            name: String(part.toolName ?? ''),
+            arguments: (part.input && typeof part.input === 'object') ? part.input : {},
+          });
+        }
+      }
+    }
+    return [{
+      role: 'assistant',
+      content,
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      usage: EMPTY_USAGE,
+      stopReason: content.some(part => part.type === 'toolCall') ? 'toolUse' : 'stop',
+      timestamp,
+    }];
+  }
+  if (message.role === 'tool' && Array.isArray(message.content)) {
+    return message.content.flatMap((part: any) => {
+      if (part?.type !== 'tool-result') return [];
+      const outputType = part.output?.type;
+      return [{
+        role: 'toolResult' as const,
+        toolCallId: String(part.toolCallId ?? ''),
+        toolName: String(part.toolName ?? ''),
+        content: [{ type: 'text' as const, text: toolOutputText(part.output) }],
+        details: part.output,
+        isError: outputType === 'error-text' || outputType === 'error-json',
+        timestamp,
+      }];
+    });
+  }
+  return [];
+};
+
+const assistantText = (message: AssistantMessage): string => message.content
+  .map(block => block.type === 'text' ? block.text : '')
+  .join('');
+
+const jsonValue = (value: unknown): unknown | undefined => {
+  if (value === undefined) return undefined;
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return undefined;
+  }
+};
+
+const fromPiMessage = (message: AgentMessage): ModelMessage | undefined => {
+  if (message.role === 'user') {
+    return { role: 'user', content: messageText(message.content) };
+  }
+  if (message.role === 'assistant') {
+    if (message.stopReason === 'error') return undefined;
+    if (message.content.every(part => part.type === 'text')) {
+      return { role: 'assistant', content: assistantText(message) };
+    }
+    return {
+      role: 'assistant',
+      content: message.content.map((part) => {
+        if (part.type === 'text') return { type: 'text', text: part.text };
+        if (part.type === 'thinking') return { type: 'reasoning', text: part.thinking };
+        return {
+          type: 'tool-call',
+          toolCallId: part.id,
+          toolName: part.name,
+          input: part.arguments,
+        };
+      }),
+    } as ModelMessage;
+  }
+  if (message.role === 'toolResult') {
+    const structuredDetails = jsonValue(message.details);
+    const hasImage = message.content.some(part => part.type === 'image');
+    const output = !message.isError && structuredDetails !== undefined && !hasImage
+      ? { type: 'json' as const, value: structuredDetails }
+      : hasImage
+        ? {
+            type: 'content' as const,
+            value: message.content.map(part => part.type === 'text'
+              ? { type: 'text' as const, text: part.text }
+              : {
+                  type: 'image-data' as const,
+                  data: part.data,
+                  mediaType: part.mimeType,
+                }),
+          }
+        : {
+            type: message.isError ? 'error-text' as const : 'text' as const,
+            value: message.content.map(part => part.type === 'text' ? part.text : '').join('\n'),
+          };
+    return {
+      role: 'tool',
+      content: [{
+        type: 'tool-result',
+        toolCallId: message.toolCallId,
+        toolName: message.toolName,
+        output,
+      }],
+    } as ModelMessage;
+  }
+  return undefined;
+};
+
+const resolvePolicySystemPrompt = (
+  policyPrompt: ReturnType<Awaited<ReturnType<TurnSegmentRequest['engine']['createToolSession']>>['getSystemPrompt']>,
+  fallback: string,
+): string => {
+  if (typeof policyPrompt === 'string') return policyPrompt;
+  if (typeof policyPrompt === 'function') return policyPrompt();
+  if (policyPrompt?.append) return `${fallback}\n\n${policyPrompt.append}`;
+  return fallback;
+};
+
+const seedHistory = async (
+  session: Awaited<ReturnType<InMemorySessionRepo['create']>>,
+  request: TurnSegmentRequest,
+  model: PiModelRuntime['model'],
+): Promise<void> => {
+  const messages = request.context.messages;
+  const last = messages.at(-1);
+  const history = last?.role === 'user' && messageText(last.content) === request.currentAsk
+    ? messages.slice(0, -1)
+    : messages;
+  for (const message of history) {
+    for (const converted of toPiHistoryMessages(message, model)) {
+      await session.appendMessage(converted);
+    }
+  }
+};
+
+/** Embedded pi AgentHarness implementation of the Canvas turn seam. */
+export function createPiAgentHarnessTurnBackend(
+  options: PiAgentHarnessBackendOptions = {},
+): AgentRuntime {
+  const createModelRuntime = options.createModelRuntime ?? createPiModelRuntime;
+  const activeHarnesses = new Map<string, AgentHarness>();
+  return {
+    id: 'pi-agent-harness',
+    capabilities: {
+      nativeCanvasTools: true,
+      clarifications: 'native',
+      historyFidelity: 'full',
+      sessionResume: 'host',
+      steering: 'native',
+      compaction: 'host',
+    },
+    async steer(sessionId, text) {
+      const harness = activeHarnesses.get(sessionId);
+      if (!harness) return false;
+      await harness.steer(text);
+      return true;
+    },
+    async followUp(sessionId, text) {
+      const harness = activeHarnesses.get(sessionId);
+      if (!harness) return false;
+      await harness.followUp(text);
+      return true;
+    },
+    async runSegment(request: TurnSegmentRequest): Promise<TurnSegmentResult> {
+      if (request.abortSignal.aborted) throw new Error('Pi AgentHarness run aborted');
+      // Canvas remains the cross-runtime session SSOT. Reuse its established
+      // compaction policy before hydrating pi, then persist the replacement.
+      const compacted = await request.engine.compactContext(request.context, {
+        provider: request.modelConfig.provider,
+        model: request.configuredModel ?? request.modelConfig.model,
+      });
+      if (compacted.didCompact && compacted.newMessages) {
+        request.replaceMessages(compacted.newMessages);
+        request.context.messages = compacted.newMessages;
+      }
+      const modelRuntime = createModelRuntime(request.modelConfig);
+      const repo = new InMemorySessionRepo();
+      const session = await repo.create({ id: request.chatSessionId });
+      await seedHistory(session, request, modelRuntime.model);
+      const toolSession = await request.engine.createToolSession(
+        request.context,
+        {
+          runContext: { executionMode: request.executionMode },
+          model: request.configuredModel ?? request.modelConfig.model,
+          systemPrompt: request.systemPrompt,
+        },
+      );
+
+      let harness!: AgentHarness;
+      const policyToolRegistry = () => ({
+        ...request.engine.getTools(),
+        ...(toolSession.getRegisteredTools?.() ?? {}),
+        ...toolSession.getTools(),
+      });
+      const syncHarnessTools = async () => {
+        const next = adaptEngineToolsForPi({
+          tools: policyToolRegistry(),
+          activeToolNames: Object.keys(toolSession.getTools()),
+          executeTool: executePolicyTool,
+          executionContext: {
+            abortSignal: request.abortSignal,
+            onClarificationRequest: request.onClarificationRequest,
+            runContext: { executionMode: request.executionMode },
+          },
+        });
+        await harness.setTools(next.tools, next.activeToolNames);
+      };
+      const executePolicyTool = async (
+        name: string,
+        input: unknown,
+        context: Parameters<typeof toolSession.executeTool>[2],
+      ) => {
+        let failed = false;
+        try {
+          return await toolSession.executeTool(name, input, context);
+        } catch (error) {
+          failed = true;
+          throw error;
+        } finally {
+          try {
+            await syncHarnessTools();
+          } catch (syncError) {
+            if (!failed) throw syncError;
+          }
+        }
+      };
+      try {
+        const adapted = adaptEngineToolsForPi({
+          tools: policyToolRegistry(),
+          activeToolNames: Object.keys(toolSession.getTools()),
+          executeTool: executePolicyTool,
+          executionContext: {
+            abortSignal: request.abortSignal,
+            onClarificationRequest: request.onClarificationRequest,
+            runContext: { executionMode: request.executionMode },
+          },
+        });
+        harness = new AgentHarness({
+          session,
+          models: modelRuntime.models,
+          model: modelRuntime.model,
+          systemPrompt: () => resolvePolicySystemPrompt(
+            toolSession.getSystemPrompt(),
+            request.systemPrompt,
+          ),
+          tools: adapted.tools,
+          activeToolNames: adapted.activeToolNames,
+        });
+      } catch (error) {
+        try {
+          await toolSession.dispose('');
+        } catch {
+          // Preserve the setup failure as the actionable error.
+        }
+        throw error;
+      }
+      activeHarnesses.set(request.chatSessionId, harness);
+      const toolCalls: CanvasAgentToolCall[] = [];
+      const byId = new Map<string, CanvasAgentToolCall>();
+      let currentPromptPending = true;
+      const unsubscribe = harness.subscribe((event) => {
+        if (event.type === 'message_end') {
+          if (
+            currentPromptPending
+            && event.message.role === 'user'
+            && messageText(event.message.content) === request.currentAsk
+          ) {
+            currentPromptPending = false;
+          } else {
+            const converted = fromPiMessage(event.message);
+            if (converted) request.recordResponseMessages([converted]);
+          }
+        }
+        if (event.type === 'message_update' && event.assistantMessageEvent.type === 'text_delta') {
+          request.onText(event.assistantMessageEvent.delta);
+        }
+        if (event.type === 'tool_execution_start') {
+          const tool: CanvasAgentToolCall = {
+            id: toolCalls.length + 1,
+            name: event.toolName,
+            args: event.args,
+            status: 'running',
+            toolCallId: event.toolCallId,
+          };
+          toolCalls.push(tool);
+          byId.set(event.toolCallId, tool);
+          request.onToolInputStart?.({ id: event.toolCallId, toolName: event.toolName });
+          request.onToolInputDelta?.({ id: event.toolCallId, delta: JSON.stringify(event.args) });
+          request.onToolInputEnd?.({ id: event.toolCallId });
+          request.onToolCall?.({
+            name: event.toolName,
+            args: event.args,
+            toolCallId: event.toolCallId,
+          });
+        }
+        if (event.type === 'tool_execution_end') {
+          const result = unwrapToolOutput(event.result?.content ?? event.result);
+          const tool = byId.get(event.toolCallId);
+          if (tool) {
+            tool.status = event.isError ? 'failed' : 'succeeded';
+            tool.result = result;
+            if (event.isError) tool.error = result;
+          }
+          request.onToolResult?.({
+            name: event.toolName,
+            result,
+            toolCallId: event.toolCallId,
+            status: event.isError ? 'failed' : 'succeeded',
+            error: event.isError ? result : undefined,
+          });
+        }
+      });
+      const abort = () => { void harness.abort(); };
+      request.abortSignal.addEventListener('abort', abort, { once: true });
+      let resultText = '';
+      let runError: unknown;
+      try {
+        const response = await harness.prompt(request.currentAsk);
+        if (response.stopReason === 'error') {
+          throw new Error(response.errorMessage || 'Pi AgentHarness provider request failed');
+        }
+        resultText = assistantText(response);
+        return { resultText, toolCalls };
+      } catch (error) {
+        runError = error;
+        throw error;
+      } finally {
+        request.abortSignal.removeEventListener('abort', abort);
+        unsubscribe();
+        if (activeHarnesses.get(request.chatSessionId) === harness) {
+          activeHarnesses.delete(request.chatSessionId);
+        }
+        try {
+          await toolSession.dispose(resultText);
+        } catch (disposeError) {
+          if (!runError) throw disposeError;
+        }
+      }
+    },
+  };
+}
+
+export const piAgentHarnessTurnBackend = createPiAgentHarnessTurnBackend();

--- a/apps/canvas-workspace/src/main/agent/backends/pi-agent-harness-backend.ts
+++ b/apps/canvas-workspace/src/main/agent/backends/pi-agent-harness-backend.ts
@@ -367,7 +367,13 @@ export function createPiAgentHarnessTurnBackend(
           });
         }
         if (event.type === 'tool_execution_end') {
-          const result = unwrapToolOutput(event.result?.content ?? event.result);
+          // Pi wraps tool output for the model as content blocks, while
+          // `details` retains the Engine tool's original structured result.
+          // Persist the latter so rich chat renderers can parse visuals and
+          // generated-image metadata after streaming and across reloads.
+          const result = unwrapToolOutput(
+            event.result?.details ?? event.result?.content ?? event.result,
+          );
           const tool = byId.get(event.toolCallId);
           if (tool) {
             tool.status = event.isError ? 'failed' : 'succeeded';

--- a/apps/canvas-workspace/src/main/agent/backends/pi-model-adapter.test.ts
+++ b/apps/canvas-workspace/src/main/agent/backends/pi-model-adapter.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { createPiModelRuntime } from './pi-model-adapter';
+
+describe('createPiModelRuntime', () => {
+  it('maps a Canvas OpenAI-compatible model without writing pi config files', async () => {
+    const runtime = createPiModelRuntime({
+      providerId: 'gateway',
+      providerName: 'Gateway',
+      providerType: 'openai',
+      model: 'vendor/model-x',
+      modelLabel: 'Model X',
+      provider: (() => undefined) as never,
+      connection: {
+        baseURL: 'https://gateway.example/v1',
+        apiKey: 'secret',
+        headers: { 'x-tenant': 'canvas' },
+      },
+    });
+
+    expect(runtime.model).toMatchObject({
+      id: 'vendor/model-x',
+      name: 'Model X',
+      provider: 'canvas-gateway',
+      api: 'openai-responses',
+      baseUrl: 'https://gateway.example/v1',
+    });
+    expect(runtime.models.getModel('canvas-gateway', 'vendor/model-x')).toBe(runtime.model);
+    await expect(runtime.models.getAuth(runtime.model)).resolves.toMatchObject({
+      auth: {
+        apiKey: 'secret',
+        baseUrl: 'https://gateway.example/v1',
+        headers: { 'x-tenant': 'canvas' },
+      },
+      source: 'Pulse Canvas model config',
+    });
+  });
+
+  it('uses the Anthropic messages transport for Claude providers', () => {
+    const runtime = createPiModelRuntime({
+      providerType: 'claude',
+      model: 'claude-test',
+      modelLabel: 'Claude Test',
+      provider: (() => undefined) as never,
+      connection: {},
+    });
+
+    expect(runtime.model.api).toBe('anthropic-messages');
+    expect(runtime.model.baseUrl).toBe('https://api.anthropic.com');
+  });
+});

--- a/apps/canvas-workspace/src/main/agent/backends/pi-model-adapter.ts
+++ b/apps/canvas-workspace/src/main/agent/backends/pi-model-adapter.ts
@@ -1,0 +1,75 @@
+import { anthropicMessagesApi } from '@earendil-works/pi-ai/api/anthropic-messages.lazy';
+import { openAIResponsesApi } from '@earendil-works/pi-ai/api/openai-responses.lazy';
+import {
+  createModels,
+  createProvider,
+  type Api,
+  type Model,
+  type Models,
+} from '@earendil-works/pi-ai';
+
+import {
+  DEFAULT_CLAUDE_BASE_URL,
+  DEFAULT_OPENAI_BASE_URL,
+  type ResolvedCanvasModel,
+} from '../model/config';
+
+export interface PiModelRuntime {
+  models: Models;
+  model: Model<Api>;
+}
+
+const providerIdFor = (config: ResolvedCanvasModel): string => {
+  const suffix = (config.providerId ?? config.providerType)
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-');
+  return `canvas-${suffix}`;
+};
+
+/** Build an in-memory pi provider directly from Canvas model configuration. */
+export function createPiModelRuntime(config: ResolvedCanvasModel): PiModelRuntime {
+  const providerId = providerIdFor(config);
+  const isClaude = config.providerType === 'claude';
+  // @ai-sdk/openai v3's callable provider (used by Canvas Engine) defaults
+  // to the Responses API. Use the same transport here for real parity.
+  const api = isClaude ? 'anthropic-messages' : 'openai-responses';
+  const baseUrl = config.connection?.baseURL
+    ?? (isClaude ? DEFAULT_CLAUDE_BASE_URL : DEFAULT_OPENAI_BASE_URL);
+  const model: Model<Api> = {
+    id: config.model,
+    name: config.modelLabel,
+    api,
+    provider: providerId,
+    baseUrl,
+    reasoning: false,
+    input: ['text', 'image'],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 16_384,
+    headers: config.connection?.headers,
+  };
+  const provider = createProvider({
+    id: providerId,
+    name: config.providerName ?? 'Pulse Canvas',
+    baseUrl,
+    headers: config.connection?.headers,
+    auth: {
+      apiKey: {
+        name: 'Pulse Canvas model config',
+        resolve: async () => ({
+          auth: {
+            apiKey: config.connection?.apiKey,
+            baseUrl,
+            headers: config.connection?.headers,
+          },
+          source: 'Pulse Canvas model config',
+        }),
+      },
+    },
+    models: [model],
+    api: isClaude ? anthropicMessagesApi() : openAIResponsesApi(),
+  });
+  const models = createModels();
+  models.setProvider(provider);
+  return { models, model };
+}

--- a/apps/canvas-workspace/src/main/agent/backends/pi-tool-adapter.test.ts
+++ b/apps/canvas-workspace/src/main/agent/backends/pi-tool-adapter.test.ts
@@ -1,0 +1,159 @@
+import { jsonSchema } from 'ai';
+import { z } from 'zod';
+import { describe, expect, it, vi } from 'vitest';
+
+import { adaptEngineToolsForPi } from './pi-tool-adapter';
+
+describe('adaptEngineToolsForPi', () => {
+  it('exposes eager tools initially and preserves Canvas execution context', async () => {
+    const execute = vi.fn(async (_input, context) => ({ ok: true, mode: context?.runContext?.executionMode }));
+    const executeTool = vi.fn(async (_name, input, context) => execute(input, context));
+    const signal = new AbortController().signal;
+    const onClarificationRequest = vi.fn();
+
+    const adapted = adaptEngineToolsForPi({
+      tools: {
+        canvas_read_context: {
+          name: 'canvas_read_context',
+          description: 'Read the canvas context.',
+          inputSchema: z.object({ detail: z.enum(['summary', 'full']) }),
+          execute,
+        },
+        canvas_update_node: {
+          name: 'canvas_update_node',
+          description: 'Update a node.',
+          inputSchema: z.object({ id: z.string() }),
+          defer_loading: true,
+          execute: vi.fn(),
+        },
+      },
+      executionContext: {
+        abortSignal: signal,
+        onClarificationRequest,
+        runContext: { executionMode: 'ask' },
+      },
+      executeTool,
+    });
+
+    expect(adapted.activeToolNames).toEqual(['canvas_read_context']);
+    expect(adapted.tools.map(tool => tool.name)).toEqual([
+      'canvas_read_context',
+      'canvas_update_node',
+    ]);
+    expect(adapted.tools.every(tool => tool.executionMode === 'sequential')).toBe(true);
+
+    const readTool = adapted.tools[0];
+    const result = await readTool.execute('call-1', { detail: 'summary' }, signal, undefined, undefined);
+
+    expect(executeTool).toHaveBeenCalledWith(
+      'canvas_read_context',
+      { detail: 'summary' },
+      expect.objectContaining({
+        abortSignal: signal,
+        onClarificationRequest,
+        runContext: { executionMode: 'ask' },
+        toolCallId: 'call-1',
+      }),
+    );
+    expect(result.content).toEqual([{ type: 'text', text: '{"ok":true,"mode":"ask"}' }]);
+  });
+
+  it('maps Engine tool-search references to pi native deferred-tool activation', async () => {
+    const sourceTools = {
+      tool_search_tool_bm25: {
+        name: 'tool_search_tool_bm25',
+        description: 'Search tools.',
+        inputSchema: z.object({ query: z.string() }),
+        execute: async () => ({
+          type: 'tool_search_tool_search_result',
+          tool_references: [
+            { type: 'tool_reference', tool_name: 'canvas_update_node' },
+            { type: 'tool_reference', tool_name: 'missing_tool' },
+          ],
+        }),
+      },
+      canvas_update_node: {
+        name: 'canvas_update_node',
+        description: 'Update a node.',
+        inputSchema: z.object({ id: z.string() }),
+        defer_loading: true,
+        execute: vi.fn(),
+      },
+    };
+    const adapted = adaptEngineToolsForPi({
+      tools: sourceTools,
+      executeTool: async (name, input, context) => {
+        return sourceTools[name as keyof typeof sourceTools].execute(input as never, context as never);
+      },
+      executionContext: {},
+    });
+
+    const result = await adapted.tools[0].execute(
+      'search-1',
+      { query: 'update node' },
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expect(result.addedToolNames).toEqual(['canvas_update_node']);
+  });
+
+  it('adapts AI SDK JSON schemas used by MCP tools', () => {
+    const adapted = adaptEngineToolsForPi({
+      tools: {
+        mcp_deepwiki_ask_question: {
+          name: 'mcp_deepwiki_ask_question',
+          description: 'Ask DeepWiki.',
+          inputSchema: jsonSchema({
+            type: 'object',
+            properties: { question: { type: 'string' } },
+            required: ['question'],
+          }),
+          execute: vi.fn(),
+        },
+      },
+      executeTool: vi.fn(),
+      executionContext: {},
+    });
+
+    expect(adapted.tools[0].parameters).toEqual({
+      type: 'object',
+      properties: { question: { type: 'string' } },
+      required: ['question'],
+    });
+  });
+
+  it('preserves image content returned by Canvas tools', async () => {
+    const adapted = adaptEngineToolsForPi({
+      tools: {
+        canvas_screenshot: {
+          name: 'canvas_screenshot',
+          description: 'Capture the canvas.',
+          inputSchema: z.object({}),
+          execute: vi.fn(),
+        },
+      },
+      executeTool: async () => ({
+        type: 'content',
+        value: [
+          { type: 'text', text: 'snapshot' },
+          { type: 'image-data', data: 'aGVsbG8=', mediaType: 'image/jpeg' },
+        ],
+      }),
+      executionContext: {},
+    });
+
+    const result = await adapted.tools[0].execute(
+      'image-1',
+      {},
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(result.content).toEqual([
+      { type: 'text', text: 'snapshot' },
+      { type: 'image', data: 'aGVsbG8=', mimeType: 'image/jpeg' },
+    ]);
+  });
+});

--- a/apps/canvas-workspace/src/main/agent/backends/pi-tool-adapter.ts
+++ b/apps/canvas-workspace/src/main/agent/backends/pi-tool-adapter.ts
@@ -1,0 +1,124 @@
+import type { AgentHarnessTool } from '@earendil-works/pi-agent-core';
+import type { TSchema } from '@earendil-works/pi-ai';
+import { asSchema, type FlexibleSchema } from 'ai';
+
+import type { CanvasToolExecutionContext } from '../tools';
+
+interface PiSourceTool {
+  name: string;
+  description: string;
+  inputSchema: FlexibleSchema;
+  defer_loading?: boolean;
+  execute(input: unknown, context?: CanvasToolExecutionContext): Promise<unknown>;
+}
+
+export interface AdaptEngineToolsForPiOptions {
+  tools: Record<string, PiSourceTool>;
+  /** Execute through EngineToolSession so hooks and policy remain authoritative. */
+  executeTool(
+    name: string,
+    input: unknown,
+    context: CanvasToolExecutionContext,
+  ): Promise<unknown>;
+  executionContext: CanvasToolExecutionContext;
+  /** Policy-filtered initial visibility. Defaults to non-deferred tools. */
+  activeToolNames?: string[];
+  activateTools?: (toolNames: string[]) => Promise<void>;
+}
+
+export interface AdaptedPiTools {
+  tools: Array<AgentHarnessTool<undefined>>;
+  activeToolNames: string[];
+}
+
+const formatToolOutput = (output: unknown): string => {
+  if (typeof output === 'string') return output;
+  if (output === undefined) return '';
+  try {
+    return JSON.stringify(output);
+  } catch {
+    return String(output);
+  }
+};
+
+const formatToolContent = (output: unknown) => {
+  const record = output && typeof output === 'object' ? output as any : undefined;
+  const candidates = record?.type === 'content' && Array.isArray(record.value)
+    ? record.value
+    : Array.isArray(record?.content)
+      ? record.content
+      : undefined;
+  if (!candidates) return [{ type: 'text' as const, text: formatToolOutput(output) }];
+  const content = candidates.flatMap((part: any) => {
+    if (part?.type === 'text') {
+      return [{ type: 'text' as const, text: String(part.text ?? '') }];
+    }
+    if (
+      (part?.type === 'image' || part?.type === 'image-data' || part?.type === 'media')
+      && typeof part.data === 'string'
+    ) {
+      return [{
+        type: 'image' as const,
+        data: part.data,
+        mimeType: String(part.mimeType ?? part.mediaType ?? 'image/png'),
+      }];
+    }
+    return [];
+  });
+  return content.length > 0
+    ? content
+    : [{ type: 'text' as const, text: formatToolOutput(output) }];
+};
+
+const referencedToolNames = (
+  output: unknown,
+  availableNames: ReadonlySet<string>,
+): string[] | undefined => {
+  if (!output || typeof output !== 'object') return undefined;
+  const references = (output as any).tool_references;
+  if (!Array.isArray(references)) return undefined;
+  const names = references
+    .map(reference => typeof reference?.tool_name === 'string' ? reference.tool_name : '')
+    .filter((name, index, all) => availableNames.has(name) && all.indexOf(name) === index);
+  return names.length > 0 ? names : undefined;
+};
+
+/**
+ * Adapt the Engine/Canvas tool registry to AgentHarness without creating a
+ * second capability registry. Deferred tools remain registered but inactive;
+ * the runtime can activate them after tool-search returns references.
+ */
+export function adaptEngineToolsForPi(
+  options: AdaptEngineToolsForPiOptions,
+): AdaptedPiTools {
+  const entries = Object.entries(options.tools);
+  const availableNames = new Set(entries.map(([name]) => name));
+  return {
+    activeToolNames: options.activeToolNames ?? entries
+      .filter(([, tool]) => !tool.defer_loading)
+      .map(([name]) => name),
+    tools: entries.map(([name, tool]) => ({
+      name,
+      label: name,
+      description: tool.description,
+      parameters: asSchema(tool.inputSchema).jsonSchema as TSchema,
+      // EngineToolSession is a stateful policy transcript: each execution
+      // closes one LLM step, records a result, and refreshes the next table.
+      executionMode: 'sequential',
+      execute: async (toolCallId, params, signal) => {
+        const output = await options.executeTool(name, params, {
+          ...options.executionContext,
+          abortSignal: signal ?? options.executionContext.abortSignal,
+          toolCallId,
+        });
+        const addedToolNames = referencedToolNames(output, availableNames);
+        if (addedToolNames) await options.activateTools?.(addedToolNames);
+        return {
+          content: formatToolContent(output),
+          details: output,
+          addedToolNames,
+        };
+      },
+    })),
+  };
+}

--- a/apps/canvas-workspace/src/main/agent/backends/registry.test.ts
+++ b/apps/canvas-workspace/src/main/agent/backends/registry.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AgentRoleDefinition } from '../../../shared/agent-roles';
+import { engineTurnBackend, externalCliTurnBackend, resolveTurnBackend } from './index';
+
+const personaRole: AgentRoleDefinition = {
+  id: 'persona',
+  name: 'Persona',
+  color: '#2383e2',
+  prompt: 'Speak as the persona.',
+  createdAt: 0,
+  updatedAt: 0,
+};
+
+const externalRole: AgentRoleDefinition = {
+  ...personaRole,
+  id: 'external',
+  name: 'External',
+  prompt: '',
+  external: { family: 'claude-code' },
+};
+
+describe('resolveTurnBackend', () => {
+  it('routes the default assistant (null role) to the engine backend', () => {
+    expect(resolveTurnBackend(null)).toBe(engineTurnBackend);
+  });
+
+  it('routes persona roles to the engine backend', () => {
+    expect(resolveTurnBackend(personaRole)).toBe(engineTurnBackend);
+  });
+
+  it('routes externally-driven roles to the external CLI backend', () => {
+    expect(resolveTurnBackend(externalRole)).toBe(externalCliTurnBackend);
+  });
+});
+
+describe('backend capability matrices', () => {
+  it('declares the engine backend as the full-fidelity native backend', () => {
+    expect(engineTurnBackend.capabilities).toEqual({
+      nativeCanvasTools: true,
+      clarifications: 'native',
+      historyFidelity: 'full',
+      sessionResume: 'host',
+    });
+  });
+
+  it('declares the external CLI backend as window-fidelity with CLI-owned sessions', () => {
+    expect(externalCliTurnBackend.capabilities).toEqual({
+      nativeCanvasTools: false,
+      clarifications: 'approval',
+      historyFidelity: 'window',
+      sessionResume: 'cli',
+    });
+  });
+});

--- a/apps/canvas-workspace/src/main/agent/backends/registry.test.ts
+++ b/apps/canvas-workspace/src/main/agent/backends/registry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { AgentRoleDefinition } from '../../../shared/agent-roles';
+import type { TurnSegmentRequest } from './types';
 import {
   engineTurnBackend,
   externalCliTurnBackend,
@@ -43,6 +44,12 @@ describe('resolveAgentRuntime', () => {
     expect(resolveAgentRuntime(null, { piEnabled: true })).toBe(piAgentHarnessTurnBackend);
     expect(resolveAgentRuntime(personaRole, { piEnabled: true })).toBe(engineTurnBackend);
     expect(resolveTurnBackend(null, { piEnabled: true })).toBe(piAgentHarnessTurnBackend);
+  });
+
+  it('loads the Pi implementation on the first Pi segment', async () => {
+    await expect(piAgentHarnessTurnBackend.runSegment({
+      abortSignal: AbortSignal.abort(),
+    } as TurnSegmentRequest)).rejects.toThrow('Pi AgentHarness run aborted');
   });
 });
 

--- a/apps/canvas-workspace/src/main/agent/backends/registry.test.ts
+++ b/apps/canvas-workspace/src/main/agent/backends/registry.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
 import type { AgentRoleDefinition } from '../../../shared/agent-roles';
-import { engineTurnBackend, externalCliTurnBackend, resolveTurnBackend } from './index';
+import {
+  engineTurnBackend,
+  externalCliTurnBackend,
+  piAgentHarnessTurnBackend,
+  resolveAgentRuntime,
+  resolveTurnBackend,
+} from './index';
 
 const personaRole: AgentRoleDefinition = {
   id: 'persona',
@@ -20,9 +26,9 @@ const externalRole: AgentRoleDefinition = {
   external: { family: 'claude-code' },
 };
 
-describe('resolveTurnBackend', () => {
+describe('resolveAgentRuntime', () => {
   it('routes the default assistant (null role) to the engine backend', () => {
-    expect(resolveTurnBackend(null)).toBe(engineTurnBackend);
+    expect(resolveAgentRuntime(null, { piEnabled: false })).toBe(engineTurnBackend);
   });
 
   it('routes persona roles to the engine backend', () => {
@@ -31,6 +37,12 @@ describe('resolveTurnBackend', () => {
 
   it('routes externally-driven roles to the external CLI backend', () => {
     expect(resolveTurnBackend(externalRole)).toBe(externalCliTurnBackend);
+  });
+
+  it('routes the default assistant to AgentHarness when explicitly enabled', () => {
+    expect(resolveAgentRuntime(null, { piEnabled: true })).toBe(piAgentHarnessTurnBackend);
+    expect(resolveAgentRuntime(personaRole, { piEnabled: true })).toBe(engineTurnBackend);
+    expect(resolveTurnBackend(null, { piEnabled: true })).toBe(piAgentHarnessTurnBackend);
   });
 });
 
@@ -41,6 +53,8 @@ describe('backend capability matrices', () => {
       clarifications: 'native',
       historyFidelity: 'full',
       sessionResume: 'host',
+      steering: 'none',
+      compaction: 'native',
     });
   });
 
@@ -50,6 +64,19 @@ describe('backend capability matrices', () => {
       clarifications: 'approval',
       historyFidelity: 'window',
       sessionResume: 'cli',
+      steering: 'none',
+      compaction: 'cli',
+    });
+  });
+
+  it('declares pi as a native Canvas runtime with host-owned history and compaction', () => {
+    expect(piAgentHarnessTurnBackend.capabilities).toEqual({
+      nativeCanvasTools: true,
+      clarifications: 'native',
+      historyFidelity: 'full',
+      sessionResume: 'host',
+      steering: 'native',
+      compaction: 'host',
     });
   });
 });

--- a/apps/canvas-workspace/src/main/agent/backends/types.ts
+++ b/apps/canvas-workspace/src/main/agent/backends/types.ts
@@ -2,6 +2,7 @@ import type { ModelMessage } from 'ai';
 import type { Engine } from 'pulse-coder-engine';
 
 import type { AgentRoleDefinition } from '../../../shared/agent-roles';
+import type { AgentClarificationRequest } from '../../../shared/agent-chat';
 import type { ResolvedCanvasModel } from '../model/config';
 import type {
   CanvasAgentDebugTrace,
@@ -18,16 +19,12 @@ import type { CanvasToolResultEvent } from '../engine-stream-callbacks';
  * collection, and stopped-vs-failed abort normalization — so a backend only
  * runs the model turn and reports what it produced.
  *
- * Implementations today: the built-in engine (`engine-backend.ts`) and the
- * external coding-agent CLIs (`external-cli-backend.ts`). A future native
- * backend (e.g. pi) plugs in here without touching the chat pipeline.
+ * Implementations today: the built-in Engine, embedded Pi AgentHarness, and
+ * external coding-agent CLIs. New runtimes plug in here without touching the
+ * chat pipeline.
  */
 
-type ClarificationHandler = (request: {
-  id: string;
-  question: string;
-  context?: string;
-}) => Promise<string>;
+type ClarificationHandler = (request: AgentClarificationRequest) => Promise<string>;
 
 export interface TurnSegmentRequest {
   /** Engine instance for the built-in backend; unused by CLI backends. */
@@ -71,7 +68,7 @@ export interface TurnSegmentResult {
   toolCalls?: CanvasAgentToolCall[];
 }
 
-export interface TurnBackendCapabilities {
+export interface AgentRuntimeCapabilities {
   /** Canvas tools (canvas_read_context, node creation, …) run natively. */
   nativeCanvasTools: boolean;
   /** How user-in-the-loop questions surface: engine clarification cards,
@@ -82,10 +79,23 @@ export interface TurnBackendCapabilities {
   historyFidelity: 'full' | 'window';
   /** Who owns resumable conversation state across segments. */
   sessionResume: 'host' | 'cli';
+  /** Whether an in-flight run accepts pi-style steer/follow-up input. */
+  steering: 'native' | 'none';
+  /** Which layer owns context compaction. */
+  compaction: 'native' | 'host' | 'cli';
 }
 
-export interface TurnBackend {
+export interface AgentRuntime {
   id: 'engine' | 'external-cli' | (string & {});
-  capabilities: TurnBackendCapabilities;
+  capabilities: AgentRuntimeCapabilities;
   runSegment(request: TurnSegmentRequest): Promise<TurnSegmentResult>;
+  /** Queue an instruction at the next safe boundary of an active run. */
+  steer?(sessionId: string, text: string): Promise<boolean>;
+  /** Queue a new turn after the current active run settles. */
+  followUp?(sessionId: string, text: string): Promise<boolean>;
 }
+
+/** @deprecated Use AgentRuntime; retained while callers migrate names. */
+export type TurnBackend = AgentRuntime;
+/** @deprecated Use AgentRuntimeCapabilities. */
+export type TurnBackendCapabilities = AgentRuntimeCapabilities;

--- a/apps/canvas-workspace/src/main/agent/backends/types.ts
+++ b/apps/canvas-workspace/src/main/agent/backends/types.ts
@@ -1,0 +1,91 @@
+import type { ModelMessage } from 'ai';
+import type { Engine } from 'pulse-coder-engine';
+
+import type { AgentRoleDefinition } from '../../../shared/agent-roles';
+import type { ResolvedCanvasModel } from '../model/config';
+import type {
+  CanvasAgentDebugTrace,
+  CanvasAgentMessage,
+  CanvasAgentToolCall,
+} from '../types';
+import type { CanvasToolResultEvent } from '../engine-stream-callbacks';
+
+/**
+ * The turn-backend boundary: everything that can execute ONE chat segment
+ * (default assistant, persona role, or externally-driven role) behind the
+ * same request/result shape. `executeCanvasAgentSegment` owns the
+ * backend-agnostic policies — streamed-text accumulation, response-message
+ * collection, and stopped-vs-failed abort normalization — so a backend only
+ * runs the model turn and reports what it produced.
+ *
+ * Implementations today: the built-in engine (`engine-backend.ts`) and the
+ * external coding-agent CLIs (`external-cli-backend.ts`). A future native
+ * backend (e.g. pi) plugs in here without touching the chat pipeline.
+ */
+
+type ClarificationHandler = (request: {
+  id: string;
+  question: string;
+  context?: string;
+}) => Promise<string>;
+
+export interface TurnSegmentRequest {
+  /** Engine instance for the built-in backend; unused by CLI backends. */
+  engine: Engine;
+  context: { messages: ModelMessage[] };
+  role: AgentRoleDefinition | null;
+  chatSessionId: string;
+  workspaceRootFolder?: string;
+  history: CanvasAgentMessage[];
+  currentAsk: string;
+  handoffNames: string[];
+  abortSignal: AbortSignal;
+  executionMode: 'auto' | 'ask';
+  onClarificationRequest?: ClarificationHandler;
+  /** Always provided: the executor pre-wraps it so every delta is
+   *  accumulated into the segment's `streamedText` before forwarding. */
+  onText: (delta: string) => void;
+  onToolCall?: (data: { name: string; args: any; toolCallId?: string }) => void;
+  onToolResult?: (data: CanvasToolResultEvent) => void;
+  onToolInputStart?: (data: { id: string; toolName: string }) => void;
+  onToolInputDelta?: (data: { id: string; delta: string }) => void;
+  onToolInputEnd?: (data: { id: string }) => void;
+  modelConfig: ResolvedCanvasModel;
+  configuredModel?: string;
+  systemPrompt: string;
+  debugTrace?: CanvasAgentDebugTrace;
+  /**
+   * Record messages the segment produced: appends to the live model history
+   * AND to the executor's per-segment collection in one call, so partial
+   * output survives an abort exactly like before the boundary existed.
+   */
+  recordResponseMessages: (messages: ModelMessage[]) => void;
+  /** Engine compaction write-back (host history replacement). */
+  replaceMessages: (messages: ModelMessage[]) => void;
+}
+
+export interface TurnSegmentResult {
+  resultText: string;
+  /** Tool calls carried by backends that never touch the engine's
+   *  onToolCall persistence path (external CLIs). */
+  toolCalls?: CanvasAgentToolCall[];
+}
+
+export interface TurnBackendCapabilities {
+  /** Canvas tools (canvas_read_context, node creation, …) run natively. */
+  nativeCanvasTools: boolean;
+  /** How user-in-the-loop questions surface: engine clarification cards,
+   *  Ask-mode approval gate, or not at all. */
+  clarifications: 'native' | 'approval' | 'none';
+  /** Whether the backend consumes the full model history or a rendered
+   *  discussion window. */
+  historyFidelity: 'full' | 'window';
+  /** Who owns resumable conversation state across segments. */
+  sessionResume: 'host' | 'cli';
+}
+
+export interface TurnBackend {
+  id: 'engine' | 'external-cli' | (string & {});
+  capabilities: TurnBackendCapabilities;
+  runSegment(request: TurnSegmentRequest): Promise<TurnSegmentResult>;
+}

--- a/apps/canvas-workspace/src/main/agent/engine.d.ts
+++ b/apps/canvas-workspace/src/main/agent/engine.d.ts
@@ -7,11 +7,20 @@ declare module 'pulse-coder-engine' {
   export type LLMProviderFactory = (model: string) => any;
   export function buildProvider(type: ModelType, options?: any): LLMProviderFactory;
 
+  export interface EngineToolSession {
+    getRegisteredTools(): Record<string, any>;
+    getTools(): Record<string, any>;
+    getSystemPrompt(): string | (() => string) | { append: string } | undefined;
+    executeTool(name: string, input: unknown, context?: any): Promise<unknown>;
+    dispose(result?: string): Promise<void>;
+  }
+
   export class Engine {
     constructor(options?: any);
     initialize(): Promise<void>;
     run(context: any, options?: any): Promise<string>;
     getTools(): Record<string, any>;
+    createToolSession(context: any, options?: any): Promise<EngineToolSession>;
     getService<T>(name: string): T | undefined;
     compactContext(context: any, options?: any): Promise<any>;
   }

--- a/apps/canvas-workspace/src/main/agent/model/config.ts
+++ b/apps/canvas-workspace/src/main/agent/model/config.ts
@@ -85,6 +85,8 @@ export interface ResolvedCanvasModel {
   model: string;
   modelLabel: string;
   modelType?: ModelType;
+  /** Main-memory only; never expose through status IPC or debug traces. */
+  connection?: { baseURL?: string; apiKey?: string; headers?: Record<string, string> };
 }
 export interface FetchCanvasModelsInput {
   providerId?: string;
@@ -92,8 +94,8 @@ export interface FetchCanvasModelsInput {
 }
 
 const DEFAULT_CANVAS_MODEL = 'gpt-4o';
-const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
-const DEFAULT_CLAUDE_BASE_URL = 'https://api.anthropic.com';
+export const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
+export const DEFAULT_CLAUDE_BASE_URL = 'https://api.anthropic.com';
 
 function normalizeStr(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
@@ -571,16 +573,8 @@ export async function resolveCanvasModel(): Promise<ResolvedCanvasModel> {
   const config = sanitizeConfig(await readConfig());
   const resolved = resolveEffectiveFields(config);
   const provider = resolved.providerType === 'claude'
-    ? buildProvider('claude', {
-        apiKey: resolved.apiKey,
-        baseURL: resolved.baseURL,
-        headers: resolved.headers,
-      })
-    : createOpenAI({
-        apiKey: resolved.apiKey,
-        baseURL: resolved.baseURL,
-        headers: resolved.headers,
-      });
+    ? buildProvider('claude', { apiKey: resolved.apiKey, baseURL: resolved.baseURL, headers: resolved.headers })
+    : createOpenAI({ apiKey: resolved.apiKey, baseURL: resolved.baseURL, headers: resolved.headers });
 
   return {
     providerId: resolved.provider?.id,
@@ -591,6 +585,7 @@ export async function resolveCanvasModel(): Promise<ResolvedCanvasModel> {
     modelLabel: normalizeProviderModels(resolved.provider?.models)
       .find((entry) => entry.id === resolved.model)?.name ?? resolved.model,
     modelType: resolved.providerType === 'claude' ? 'claude' : 'openai',
+    connection: { baseURL: resolved.baseURL, apiKey: resolved.apiKey, headers: resolved.headers },
   };
 }
 

--- a/apps/canvas-workspace/src/main/agent/segment-execution.test.ts
+++ b/apps/canvas-workspace/src/main/agent/segment-execution.test.ts
@@ -71,4 +71,77 @@ describe('executeCanvasAgentSegment', () => {
       error: 'Operation cancelled by user',
     })]);
   });
+
+  it('accumulates engine-path text deltas so a hard stop preserves the partial', async () => {
+    const abortController = new AbortController();
+    const onText = vi.fn();
+    const engine = {
+      run: vi.fn(async (_context: unknown, loopOptions: any) => {
+        loopOptions.onText?.('engine partial');
+        abortController.abort();
+        return ENGINE_ABORT_SENTINEL;
+      }),
+    } as unknown as Engine;
+
+    const result = await executeCanvasAgentSegment({
+      engine,
+      context: { messages: [] },
+      role: null,
+      chatSessionId: 'session-2',
+      history: [],
+      currentAsk: 'continue',
+      handoffNames: [],
+      abortSignal: abortController.signal,
+      executionMode: 'auto',
+      onText,
+      modelConfig: {
+        providerType: 'openai',
+        provider: vi.fn(),
+        model: 'test-model',
+        modelLabel: 'Test model',
+      },
+      systemPrompt: 'system',
+      appendMessages: vi.fn(),
+      replaceMessages: vi.fn(),
+    });
+
+    expect(result.resultText).toBe(ENGINE_ABORT_SENTINEL);
+    expect(result.streamedText).toBe('engine partial');
+    expect(onText).toHaveBeenCalledWith('engine partial');
+  });
+
+  it('collects engine onResponse messages through the shared recorder', async () => {
+    const appended: unknown[] = [];
+    const engine = {
+      run: vi.fn(async (_context: unknown, loopOptions: any) => {
+        loopOptions.onResponse?.([{ role: 'assistant', content: 'done' }]);
+        return 'done';
+      }),
+    } as unknown as Engine;
+
+    const result = await executeCanvasAgentSegment({
+      engine,
+      context: { messages: [] },
+      role: null,
+      chatSessionId: 'session-3',
+      history: [],
+      currentAsk: 'go',
+      handoffNames: [],
+      abortSignal: new AbortController().signal,
+      executionMode: 'auto',
+      modelConfig: {
+        providerType: 'openai',
+        provider: vi.fn(),
+        model: 'test-model',
+        modelLabel: 'Test model',
+      },
+      systemPrompt: 'system',
+      appendMessages: messages => appended.push(...messages),
+      replaceMessages: vi.fn(),
+    });
+
+    expect(result.resultText).toBe('done');
+    expect(result.responseMessages).toEqual([{ role: 'assistant', content: 'done' }]);
+    expect(appended).toEqual([{ role: 'assistant', content: 'done' }]);
+  });
 });

--- a/apps/canvas-workspace/src/main/agent/segment-execution.test.ts
+++ b/apps/canvas-workspace/src/main/agent/segment-execution.test.ts
@@ -1,5 +1,5 @@
 import type { Engine } from 'pulse-coder-engine';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { AgentRoleDefinition } from '../../shared/agent-roles';
 import { createFailedTurnToolTracker } from './chat-failure-persistence';
@@ -12,6 +12,16 @@ vi.mock('./external/segment', () => ({ runExternalRoleSegment }));
 import { executeCanvasAgentSegment } from './segment-execution';
 
 describe('executeCanvasAgentSegment', () => {
+  beforeEach(() => {
+    // These cases pin the Engine/external executor contracts. Keep them
+    // independent from a developer's active Pi experimental setting.
+    vi.stubEnv('PULSE_CANVAS_AGENT_RUNTIME', 'engine');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('normalizes an aborted external driver into stopped text and cancelled live tools', async () => {
     const abortController = new AbortController();
     const toolTracker = createFailedTurnToolTracker();

--- a/apps/canvas-workspace/src/main/agent/segment-execution.ts
+++ b/apps/canvas-workspace/src/main/agent/segment-execution.ts
@@ -9,11 +9,8 @@ import type {
   CanvasAgentToolCall,
 } from './types';
 import type { CanvasToolResultEvent } from './engine-stream-callbacks';
-import { buildEngineStreamCallbacks } from './engine-stream-callbacks';
-import { runExternalRoleSegment } from './external/segment';
+import { resolveTurnBackend } from './backends';
 import { ENGINE_ABORT_SENTINEL } from './chat-stop';
-
-const CANVAS_AGENT_MAX_STEPS = 200;
 
 type ClarificationHandler = (request: {
   id: string;
@@ -47,6 +44,20 @@ interface ExecuteCanvasAgentSegmentOptions {
   replaceMessages: (messages: ModelMessage[]) => void;
 }
 
+/**
+ * Execute one chat segment on whichever backend the role routes to
+ * (`resolveTurnBackend`). This executor owns the backend-AGNOSTIC policies,
+ * which must behave identically for every backend:
+ *
+ * - `streamedText` accumulation, independent of what the backend returns or
+ *   throws (the stopped-vs-failed rule needs the partial text).
+ * - Response-message collection: backends report produced messages through
+ *   `recordResponseMessages`, which appends to the live model history AND
+ *   the per-segment collection, so partial output survives an abort.
+ * - Abort normalization: a rejection after `abortSignal` fired is a STOPPED
+ *   turn (`ENGINE_ABORT_SENTINEL`), never a failure — see
+ *   harness/knowledge/agent-roles.md (stopped-vs-failed turn rule).
+ */
 export async function executeCanvasAgentSegment(
   options: ExecuteCanvasAgentSegmentOptions,
 ): Promise<{
@@ -62,52 +73,20 @@ export async function executeCanvasAgentSegment(
     streamedText += delta;
     options.onText?.(delta);
   };
+  const recordResponseMessages = (messages: ModelMessage[]) => {
+    options.appendMessages(messages);
+    responseMessages.push(...messages);
+  };
 
+  const backend = resolveTurnBackend(options.role);
   try {
-    let resultText: string;
-    if (options.role?.external) {
-      const external = await runExternalRoleSegment({
-        role: options.role,
-        external: options.role.external,
-        chatSessionId: options.chatSessionId,
-        workspaceRootFolder: options.workspaceRootFolder,
-        history: options.history,
-        currentAsk: options.currentAsk,
-        handoffNames: options.handoffNames,
-        abortSignal: options.abortSignal,
-        executionMode: options.executionMode,
-        onApprovalRequest: options.onClarificationRequest,
-        onText: handleText,
-        onToolCall: options.onToolCall,
-        onToolResult: options.onToolResult,
-      });
-      resultText = external.text;
-      externalToolCalls = external.toolCalls;
-      const message = { role: 'assistant', content: resultText } as ModelMessage;
-      options.appendMessages([message]);
-      responseMessages.push(message);
-    } else {
-      resultText = await options.engine.run(options.context, {
-        provider: options.modelConfig.provider,
-        model: options.configuredModel ?? options.modelConfig.model,
-        modelType: options.modelConfig.modelType,
-        systemPrompt: options.systemPrompt,
-        maxSteps: CANVAS_AGENT_MAX_STEPS,
-        abortSignal: options.abortSignal,
-        runContext: { executionMode: options.executionMode },
-        onClarificationRequest: options.onClarificationRequest,
-        ...buildEngineStreamCallbacks(options, options.debugTrace),
-        onResponse: (messages: ModelMessage[]) => {
-          options.appendMessages(messages);
-          responseMessages.push(...messages);
-        },
-        onCompacted: (messages: ModelMessage[]) => {
-          options.replaceMessages(messages);
-          options.context.messages = messages;
-        },
-      });
-    }
-    return { resultText, streamedText, responseMessages, externalToolCalls };
+    const result = await backend.runSegment({
+      ...options,
+      onText: handleText,
+      recordResponseMessages,
+    });
+    externalToolCalls = result.toolCalls;
+    return { resultText: result.resultText, streamedText, responseMessages, externalToolCalls };
   } catch (error) {
     if (!options.abortSignal.aborted) throw error;
     return {

--- a/apps/canvas-workspace/src/main/agent/segment-execution.ts
+++ b/apps/canvas-workspace/src/main/agent/segment-execution.ts
@@ -2,6 +2,7 @@ import type { ModelMessage } from 'ai';
 import type { Engine } from 'pulse-coder-engine';
 
 import type { AgentRoleDefinition } from '../../shared/agent-roles';
+import type { AgentClarificationRequest } from '../../shared/agent-chat';
 import type { ResolvedCanvasModel } from './model/config';
 import type {
   CanvasAgentDebugTrace,
@@ -9,14 +10,10 @@ import type {
   CanvasAgentToolCall,
 } from './types';
 import type { CanvasToolResultEvent } from './engine-stream-callbacks';
-import { resolveTurnBackend } from './backends';
+import { resolveAgentRuntime } from './backends';
 import { ENGINE_ABORT_SENTINEL } from './chat-stop';
 
-type ClarificationHandler = (request: {
-  id: string;
-  question: string;
-  context?: string;
-}) => Promise<string>;
+type ClarificationHandler = (request: AgentClarificationRequest) => Promise<string>;
 
 interface ExecuteCanvasAgentSegmentOptions {
   engine: Engine;
@@ -46,7 +43,7 @@ interface ExecuteCanvasAgentSegmentOptions {
 
 /**
  * Execute one chat segment on whichever backend the role routes to
- * (`resolveTurnBackend`). This executor owns the backend-AGNOSTIC policies,
+ * (`resolveAgentRuntime`). This executor owns the runtime-agnostic policies,
  * which must behave identically for every backend:
  *
  * - `streamedText` accumulation, independent of what the backend returns or
@@ -78,7 +75,7 @@ export async function executeCanvasAgentSegment(
     responseMessages.push(...messages);
   };
 
-  const backend = resolveTurnBackend(options.role);
+  const backend = resolveAgentRuntime(options.role);
   try {
     const result = await backend.runSegment({
       ...options,

--- a/apps/canvas-workspace/src/renderer/src/components/artifacts/parseToolResultPayload.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/artifacts/parseToolResultPayload.ts
@@ -1,0 +1,20 @@
+/** Parse a direct Engine result or Pi's persisted text-content envelope. */
+export function parseToolResultPayload<T>(raw?: string): T | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return parsed as T;
+    const text = parsed
+      .filter((part): part is { type: 'text'; text: string } => (
+        !!part
+        && typeof part === 'object'
+        && (part as { type?: unknown }).type === 'text'
+        && typeof (part as { text?: unknown }).text === 'string'
+      ))
+      .map(part => part.text)
+      .join('');
+    return text ? JSON.parse(text) as T : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/canvas-workspace/src/renderer/src/components/artifacts/parseVisualToolResult.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/artifacts/parseVisualToolResult.ts
@@ -10,6 +10,7 @@
 import type { ArtifactType } from '../../types';
 import type { InlineVisualPayload } from './ChatInlineVisual';
 import type { ArtifactCardPayload } from './ChatArtifactCard';
+import { parseToolResultPayload } from './parseToolResultPayload';
 
 export type VisualToolResult =
   | { kind: 'visual_render'; payload: InlineVisualPayload }
@@ -27,13 +28,8 @@ interface ParsedShape {
 }
 
 export function parseVisualToolResult(toolName: string, raw?: string): VisualToolResult | null {
-  if (!raw) return null;
-  let parsed: ParsedShape;
-  try {
-    parsed = JSON.parse(raw) as ParsedShape;
-  } catch {
-    return null;
-  }
+  const parsed = parseToolResultPayload<ParsedShape>(raw);
+  if (!parsed) return null;
   if (parsed?.ok === false) return null;
 
   const kind = parsed.kind;

--- a/apps/canvas-workspace/src/renderer/src/components/chat/GeneratedImageActions.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/GeneratedImageActions.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback, useState } from 'react';
 import { toFileUrl } from '../../utils/fileUrl';
 import { copyTextToClipboard } from '../../utils/clipboard';
+import { parseToolResultPayload } from '../artifacts/parseToolResultPayload';
 
 export interface GeneratedImagePayload {
   ok?: boolean;
@@ -12,13 +13,8 @@ export interface GeneratedImagePayload {
 }
 
 export const parseGeneratedImage = (result?: string): GeneratedImagePayload | null => {
-  if (!result) return null;
-  try {
-    const parsed = JSON.parse(result) as GeneratedImagePayload;
-    return parsed?.ok && parsed?.type === 'generated_image' && parsed.outputPath ? parsed : null;
-  } catch {
-    return null;
-  }
+  const parsed = parseToolResultPayload<GeneratedImagePayload>(result);
+  return parsed?.ok && parsed.type === 'generated_image' && parsed.outputPath ? parsed : null;
 };
 
 export const CopyGeneratedImageButton = memo(({ imagePath }: { imagePath: string }) => {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatRichToolResults.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatRichToolResults.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseVisualToolResult } from '../../artifacts/parseVisualToolResult';
+import { parseGeneratedImage } from '../GeneratedImageActions';
+
+const piTextEnvelope = (payload: unknown): string => JSON.stringify([{
+  type: 'text',
+  text: JSON.stringify(payload),
+}]);
+
+describe('persisted rich tool results', () => {
+  it('restores an inline visual from a Pi text-content envelope', () => {
+    const payload = {
+      ok: true,
+      kind: 'visual_render',
+      type: 'html' as const,
+      title: 'Inline HTML',
+      content: '<main>kept after streaming</main>',
+    };
+
+    expect(parseVisualToolResult('visual_render', piTextEnvelope(payload))).toEqual({
+      kind: 'visual_render',
+      payload: {
+        type: 'html',
+        title: 'Inline HTML',
+        content: '<main>kept after streaming</main>',
+      },
+    });
+  });
+
+  it('restores a generated image from a Pi text-content envelope', () => {
+    const payload = {
+      ok: true,
+      type: 'generated_image',
+      title: 'Generated image',
+      outputPath: '/tmp/generated.png',
+      mimeType: 'image/png',
+    };
+
+    expect(parseGeneratedImage(piTextEnvelope(payload))).toEqual(payload);
+  });
+});

--- a/apps/canvas-workspace/src/shared/experimental-features.test.ts
+++ b/apps/canvas-workspace/src/shared/experimental-features.test.ts
@@ -4,6 +4,7 @@ import {
   EXPERIMENTAL_FLAG_AGENT_DEBUG_TRACE,
   EXPERIMENTAL_FLAG_AGENT_RUNTIME_CONTROL,
   EXPERIMENTAL_FLAG_AGENT_TEAMS,
+  EXPERIMENTAL_FLAG_PI_AGENT_HARNESS,
   EXPERIMENTAL_FLAG_WEBVIEW_PAGE_CONTROL,
   EXPERIMENTAL_FLAG_WORKSPACE_GRAPH,
   EXPERIMENTAL_FLAG_WORKSPACE_NODES,
@@ -63,11 +64,19 @@ describe('experimental feature lifecycle', () => {
     const grandfathered = EXPERIMENTAL_FEATURES.find(
       (feature) => feature.id === EXPERIMENTAL_FLAG_AGENT_TEAMS,
     )!;
+    const piHarness = EXPERIMENTAL_FEATURES.find(
+      (feature) => feature.id === EXPERIMENTAL_FLAG_PI_AGENT_HARNESS,
+    )!;
 
     expect(canConfigureExperimentalFeature(stable, {})).toBe(false);
     expect(canConfigureExperimentalFeature(grandfathered, {})).toBe(false);
     expect(canConfigureExperimentalFeature(grandfathered, {
       [EXPERIMENTAL_FLAG_AGENT_TEAMS]: true,
     })).toBe(true);
+    expect(canConfigureExperimentalFeature(piHarness, {})).toBe(true);
+    expect(resolveFeatureValues({})[EXPERIMENTAL_FLAG_PI_AGENT_HARNESS]).toBe(false);
+    expect(resolveFeatureValues({
+      [EXPERIMENTAL_FLAG_PI_AGENT_HARNESS]: true,
+    })[EXPERIMENTAL_FLAG_PI_AGENT_HARNESS]).toBe(true);
   });
 });

--- a/apps/canvas-workspace/src/shared/experimental-features.ts
+++ b/apps/canvas-workspace/src/shared/experimental-features.ts
@@ -64,8 +64,17 @@ export const EXPERIMENTAL_FLAG_CHANNELS = 'chat-channels';
 export const EXPERIMENTAL_FLAG_AGENT_TEAMS = 'agent-teams';
 export const EXPERIMENTAL_FLAG_DEFAULT_BROWSER = 'default-browser';
 export const EXPERIMENTAL_FLAG_AGENT_RUNTIME_CONTROL = 'agent-runtime-control';
+export const EXPERIMENTAL_FLAG_PI_AGENT_HARNESS = 'pi-agent-harness';
 
 export const EXPERIMENTAL_FEATURES: ExperimentalFeatureDef[] = [
+  {
+    id: EXPERIMENTAL_FLAG_PI_AGENT_HARNESS,
+    label: 'Pi AgentHarness runtime',
+    description:
+      'Runs the default Canvas assistant on the embedded pi AgentHarness while preserving Canvas tools, policies, model settings, and host-owned chat history.',
+    defaultEnabled: false,
+    exposure: 'experimental',
+  },
   {
     id: EXPERIMENTAL_FLAG_AGENT_RUNTIME_CONTROL,
     label: 'Agent runtime control',

--- a/docs/09-agent-backend-boundary.md
+++ b/docs/09-agent-backend-boundary.md
@@ -16,18 +16,19 @@ normalization) is backend-agnostic already. The only engine-specific seam is
 dispatched two ways (built-in engine vs external CLI drivers). The boundary
 formalizes that dispatch; nothing above it changes.
 
-## Phase 1 — TurnBackend boundary (SHIPPED with this doc)
+## Unified AgentRuntime boundary
 
 `src/main/agent/backends/`:
 
-- `types.ts` — `TurnBackend { id, capabilities, runSegment(request) }`,
-  `TurnSegmentRequest/Result`, and `TurnBackendCapabilities`
+- `types.ts` — `AgentRuntime { id, capabilities, runSegment(request) }`,
+  `TurnSegmentRequest/Result`, and `AgentRuntimeCapabilities`
   (`nativeCanvasTools`, `clarifications: native|approval|none`,
   `historyFidelity: full|window`, `sessionResume: host|cli`).
 - `engine-backend.ts` — the engine.run branch, verbatim.
 - `external-cli-backend.ts` — the external CLI branch, verbatim.
-- `index.ts` — `resolveTurnBackend(role)`: external driver → CLI backend,
-  else engine. The single extension point for new backends.
+- `index.ts` — `resolveAgentRuntime(role)`: external driver → CLI runtime;
+  default assistant → Engine or Pi; persona roles → Engine. Deprecated
+  `TurnBackend` / `resolveTurnBackend` aliases keep the first seam compatible.
 
 The executor keeps the backend-agnostic policies: `streamedText`
 accumulation (now on BOTH paths — previously the engine path skipped the
@@ -35,57 +36,61 @@ accumulator, so a hard-stopped engine segment lost its partial text from
 the persisted session, contradicting agent-roles.md; code now matches the
 documented rule), one `recordResponseMessages` recorder, and abort
 normalization. Guards: `segment-execution.test.ts` (3 cases),
-`backends/registry.test.ts` (5 cases).
+`backends/registry.test.ts`.
 
-## Phase 2 — pi as an external role family (cheap, optional but useful)
+## Embedded Pi AgentHarness runtime (shipped)
 
-Add `family: 'pi'` to `AGENT_ROLE_EXTERNAL_FAMILIES` with a `pi.ts` adapter
-beside `claude-code.ts`/`codex.ts`:
+The default assistant can run on embedded
+`@earendil-works/pi-agent-core@0.83.0`; this intentionally does not depend on
+`pi-coding-agent`, spawn a CLI, write Pi config files, or run an HTTP/SSE tool
+bridge. Enable **Pi AgentHarness runtime** in Settings → Experimental. For
+automation, `PULSE_CANVAS_AGENT_RUNTIME=pi|engine` overrides the persisted
+choice.
 
-- Spawn: `pi --mode json -p <prompt via stdin>` (LDJSON events), or RPC
-  mode if session flags require it.
-- Events: map pi's `message_update` deltas → `onText`;
-  `tool_execution_start/end` → the shared `startTool`/`finishTool` helpers.
-- Resume: pi session id per (chat-session × role) in the existing
-  external-agent-state store.
-- Env override `PULSE_CANVAS_PI_CMD`; probe via `pi --version`.
+- Canvas model configuration remains the credential/model SSOT. The adapter
+  creates an in-memory Pi provider with the same model, base URL, headers, and
+  API key. OpenAI providers use `openai-responses`, matching
+  `@ai-sdk/openai` v3's callable-provider default; Anthropic providers use
+  `anthropic-messages`. A real request against the configured custom gateway
+  caught and pinned this distinction.
+- Canvas/Engine remains the tool registry and policy SSOT. All tools are
+  registered with Pi, but initial visibility comes from
+  `Engine.createToolSession()`. Every execution returns through that session,
+  preserving schema validation, before/after tool hooks, ask-mode/PTC,
+  dynamic policy prompts, skills, MCP tools, and deferred-tool loading.
+- Canvas's full host history is supplied rather than a rendered discussion
+  window. Text, reasoning, assistant tool-call frames, structured tool
+  results, and image tool results map back to Canvas. Historical user image
+  and file parts are not yet rehydrated into Pi, so `historyFidelity: full`
+  describes host-history ownership, not byte-for-byte multimodal fidelity.
+  Canvas owns cross-turn persistence and compaction; Pi owns its within-turn
+  model/tool loop. This avoids two competing durable session stores.
+- Pi text/tool events feed the existing Canvas stream and persistence path.
+  Abort is linked to `AgentHarness.abort()`. Active runs expose native
+  `steer()` / `followUp()` on the runtime contract for host integrations;
+  the current Canvas UI has no steering control yet.
+- Provider failures are raised as failed Canvas turns rather than persisted as
+  empty successes.
 
-Value: @pi vs @engine in ONE group chat = immediate harness feel
-comparison (persona-window fidelity), zero new surfaces. Measures raw
-harness quality, NOT native integration depth — say so wherever results
-are shown.
+The current capability matrix is:
 
-## Phase 3 — pi as a native default backend
+| Runtime | Native Canvas tools | Clarification | History | Compaction | Steering |
+|---|---:|---|---|---|---|
+| Engine | yes | native | full / host | native | none |
+| Pi AgentHarness | yes | native through Engine tools | full / host | host | native |
+| External CLI role | no | approval | window / CLI | CLI | none |
 
-`piTurnBackend` implementing `TurnBackend`, selected for the DEFAULT
-assistant (null role) by per-scope config behind an experimental flag
-(dev instrument, not a product feature — per the focus plan's
-no-orchestration-platform stance).
+## Compatibility evidence
 
-Two integration options, decided at implementation time:
+Upstream Pi packages declare Node `>=22.19.0`, while Electron 30.5.1 embeds
+Node 20.16.0. The production Canvas bundle builds, and
+`pnpm --filter canvas-workspace smoke:pi-electron` launches a real Electron
+main process, constructs `AgentHarness + InMemorySessionRepo + fauxProvider`,
+and must print `ELECTRON_PI_OK`. The smoke is bound in the Canvas harness
+validation because package metadata alone cannot answer runtime compatibility.
 
-1. **SDK embed (preferred for depth)** — `@earendil-works/pi-agent-core`
-   in the Electron main process: `new Agent({ initialState: {
-   systemPrompt, model, tools, messages } })`. Canvas tools
-   (`createCanvasTools(workspaceId)`) adapt to pi `AgentTool`s (same
-   process, same functions). Pi events (`message_update`,
-   `tool_execution_*`) map onto the request's `onText`/`onToolCall`/
-   `onToolResult`. `agent.abort()` wires to the segment's AbortSignal.
-   System prompt and injected workspace context carry over unchanged
-   (they're strings we already assemble). Capability matrix:
-   `nativeCanvasTools: true, clarifications: 'none' (first cut),
-   historyFidelity: 'full' (map ModelMessage ↔ AgentMessage),
-   sessionResume: 'host'`.
-2. **RPC subprocess (preferred for isolation)** — pi's RPC mode with
-   JSONL framing; keeps pi's dependency tree out of the app bundle;
-   costs message mapping over a process boundary and per-turn spawn/
-   session management.
-
-Open items tracked for Phase 3: ModelMessage↔AgentMessage mapping
-(tool-call frames especially), clarify/approval story (pi has no native
-clarification — capability matrix drives UI degradation), model parity
-config (pin the SAME provider+model on both backends or comparisons are
-meaningless), and compaction ownership (pi-internal vs host).
+This proves the paths Canvas uses today; it does not erase the upstream engine
+range. Re-run the smoke whenever Pi or Electron is upgraded.
 
 ## Benchmark lane (parallel, headless — no UI coupling)
 

--- a/docs/09-agent-backend-boundary.md
+++ b/docs/09-agent-backend-boundary.md
@@ -1,0 +1,97 @@
+# Agent Backend Boundary — pi as a native backend
+
+Date: 2026-08-02
+Goal: make the Canvas Agent's native chat run on a swappable turn backend,
+so pi (earendil-works/pi) can power the default assistant next to the
+built-in engine — first for side-by-side feel, then for measured
+benchmarking (see `08-engine-harness-gap-vs-pi.md`).
+
+## Why this boundary is the right cut
+
+All chat integrity machinery (ActiveChatRegistry, SessionMutationCoordinator,
+session CAS, clarification queue, session-store, stopped-vs-failed
+normalization) is backend-agnostic already. The only engine-specific seam is
+"execute one segment", owned by `executeCanvasAgentSegment`
+(`apps/canvas-workspace/src/main/agent/segment-execution.ts`), which already
+dispatched two ways (built-in engine vs external CLI drivers). The boundary
+formalizes that dispatch; nothing above it changes.
+
+## Phase 1 — TurnBackend boundary (SHIPPED with this doc)
+
+`src/main/agent/backends/`:
+
+- `types.ts` — `TurnBackend { id, capabilities, runSegment(request) }`,
+  `TurnSegmentRequest/Result`, and `TurnBackendCapabilities`
+  (`nativeCanvasTools`, `clarifications: native|approval|none`,
+  `historyFidelity: full|window`, `sessionResume: host|cli`).
+- `engine-backend.ts` — the engine.run branch, verbatim.
+- `external-cli-backend.ts` — the external CLI branch, verbatim.
+- `index.ts` — `resolveTurnBackend(role)`: external driver → CLI backend,
+  else engine. The single extension point for new backends.
+
+The executor keeps the backend-agnostic policies: `streamedText`
+accumulation (now on BOTH paths — previously the engine path skipped the
+accumulator, so a hard-stopped engine segment lost its partial text from
+the persisted session, contradicting agent-roles.md; code now matches the
+documented rule), one `recordResponseMessages` recorder, and abort
+normalization. Guards: `segment-execution.test.ts` (3 cases),
+`backends/registry.test.ts` (5 cases).
+
+## Phase 2 — pi as an external role family (cheap, optional but useful)
+
+Add `family: 'pi'` to `AGENT_ROLE_EXTERNAL_FAMILIES` with a `pi.ts` adapter
+beside `claude-code.ts`/`codex.ts`:
+
+- Spawn: `pi --mode json -p <prompt via stdin>` (LDJSON events), or RPC
+  mode if session flags require it.
+- Events: map pi's `message_update` deltas → `onText`;
+  `tool_execution_start/end` → the shared `startTool`/`finishTool` helpers.
+- Resume: pi session id per (chat-session × role) in the existing
+  external-agent-state store.
+- Env override `PULSE_CANVAS_PI_CMD`; probe via `pi --version`.
+
+Value: @pi vs @engine in ONE group chat = immediate harness feel
+comparison (persona-window fidelity), zero new surfaces. Measures raw
+harness quality, NOT native integration depth — say so wherever results
+are shown.
+
+## Phase 3 — pi as a native default backend
+
+`piTurnBackend` implementing `TurnBackend`, selected for the DEFAULT
+assistant (null role) by per-scope config behind an experimental flag
+(dev instrument, not a product feature — per the focus plan's
+no-orchestration-platform stance).
+
+Two integration options, decided at implementation time:
+
+1. **SDK embed (preferred for depth)** — `@earendil-works/pi-agent-core`
+   in the Electron main process: `new Agent({ initialState: {
+   systemPrompt, model, tools, messages } })`. Canvas tools
+   (`createCanvasTools(workspaceId)`) adapt to pi `AgentTool`s (same
+   process, same functions). Pi events (`message_update`,
+   `tool_execution_*`) map onto the request's `onText`/`onToolCall`/
+   `onToolResult`. `agent.abort()` wires to the segment's AbortSignal.
+   System prompt and injected workspace context carry over unchanged
+   (they're strings we already assemble). Capability matrix:
+   `nativeCanvasTools: true, clarifications: 'none' (first cut),
+   historyFidelity: 'full' (map ModelMessage ↔ AgentMessage),
+   sessionResume: 'host'`.
+2. **RPC subprocess (preferred for isolation)** — pi's RPC mode with
+   JSONL framing; keeps pi's dependency tree out of the app bundle;
+   costs message mapping over a process boundary and per-turn spawn/
+   session management.
+
+Open items tracked for Phase 3: ModelMessage↔AgentMessage mapping
+(tool-call frames especially), clarify/approval story (pi has no native
+clarification — capability matrix drives UI degradation), model parity
+config (pin the SAME provider+model on both backends or comparisons are
+meaningless), and compaction ownership (pi-internal vs host).
+
+## Benchmark lane (parallel, headless — no UI coupling)
+
+Task suite run against BOTH backends headlessly: engine via
+`headless-run.ts`/engine API, pi via `pi -p`/`--mode json`. Deterministic
+checks + one judge, results to a runs JSONL, pass-rate lift per engine
+change with pi as the fixed external baseline (vitest-evals pattern per
+the 08 doc). This lane measures harness quality on a level field and does
+not depend on Phases 2–3.

--- a/packages/engine/harness/knowledge/contracts.md
+++ b/packages/engine/harness/knowledge/contracts.md
@@ -10,7 +10,7 @@ Engine code should stay host-agnostic. Prefer an extension point before changing
 
 - Package exports: `.`, `./src`, `./types`, and `./built-in`.
 - Main exports: `Engine`, `PulseAgent`, `loop`, AI helpers, compaction helpers, provider builders, shared runtime types, built-in tools, and built-in plugins.
-- Public types include `EngineOptions`, `LoopOptions`, `LoopHooks`, `CompactionEvent`, `EnginePlugin`, `EnginePluginContext`, `Tool`, `ToolExecutionContext`, `Context`, and `ClarificationRequest`.
+- Public types include `EngineOptions`, `EngineToolSession`, `LoopOptions`, `LoopHooks`, `CompactionEvent`, `EnginePlugin`, `EnginePluginContext`, `Tool`, `ToolExecutionContext`, `Context`, and `ClarificationRequest`.
 - Built-in plugin exports under `pulse-coder-engine/built-in` are consumed directly by canvas and other hosts. The two barrels are asymmetric: `src/index.ts` re-exports 8 plugin instances but NOT `builtInToolSearchPlugin` or `SubAgentPlugin`, which only `src/built-in/index.ts` exports. Consumers reach those two through `./built-in`; a public-surface change should not blindly pattern-match the existing top-level list.
 
 ## Runtime Contracts
@@ -29,6 +29,13 @@ Engine code should stay host-agnostic. Prefer an extension point before changing
   `output`. Host safety policies should use this boundary when a denied call
   must become a normal tool result without executing the underlying tool.
 - Tools should keep explicit schemas where possible and preserve `ToolExecutionContext` propagation, including `runContext`, clarification callbacks, abort signal, and `toolCallId`.
+- `Engine.createToolSession()` is the policy-safe boundary for an external
+  model harness. `getRegisteredTools()` exposes the post-`beforeRun` registry
+  (including deferred definitions), while `getTools()` exposes only the
+  current `beforeLLMCall`-filtered table. The session also exposes the
+  policy-adjusted prompt; execution still performs schema validation and the
+  normal before/after tool hooks. Callers must always `dispose()` it so
+  `afterLLMCall` / `afterRun` lifecycle hooks close.
 - Preserve `.pulse-coder/*` as the preferred runtime config root and `.coder/*` compatibility unless there is an explicit migration plan.
 
 ## Extension Boundary
@@ -50,7 +57,7 @@ Use these before editing the loop:
 | `packages/acp` | `ClarificationRequest` (type-only) | src |
 | `packages/plugin-kit` | `EnginePlugin`, `EnginePluginContext`, `SystemPromptOption`, `Tool`, `ToolExecutionContext`, `OnCompactedEvent`; its `src/memory` module adds `OnCompactedInput`, its `src/langfuse` module adds `Context` | src |
 | `apps/remote-server` | `Engine`, `Context`, `ClarificationRequest`, `Tool`, `ToolExecutionContext`, `buildProvider`, `CompactionEvent`, `LLMProviderFactory`; `./built-in`: all built-in plugins + `SubAgentPlugin`, hand-assembled with `disableBuiltInPlugins: true` | package exports (dist); no typecheck script |
-| `apps/canvas-workspace` | `Engine`, `GenerateImageTool`, `buildProvider`, `LLMProviderFactory`, `ModelType`; `./built-in`: `createSkillsPlugin`, `createMcpPlugin`, `mcpAuth`, OAuth types (hand-assembled, skills+MCP only) | hand-written shim `src/main/agent/engine.d.ts` for the base module (loose `any` types); `./built-in` relies on real dist types |
+| `apps/canvas-workspace` | `Engine`, `EngineToolSession`, `GenerateImageTool`, `buildProvider`, `LLMProviderFactory`, `ModelType`; `./built-in`: `createSkillsPlugin`, `createMcpPlugin`, `mcpAuth`, OAuth types (hand-assembled, skills+MCP only) | hand-written shim `src/main/agent/engine.d.ts` for the base module (loose `any` types); `./built-in` relies on real dist types |
 
 Consumer hazards:
 

--- a/packages/engine/harness/validate/validation.yaml
+++ b/packages/engine/harness/validate/validation.yaml
@@ -21,4 +21,4 @@ pathRules:
       - src/built-in/**
       - src/tools/index.ts
     required:
-      - node harness/tools/describe-engine.mjs --json
+      - node packages/engine/harness/tools/describe-engine.mjs --json

--- a/packages/engine/src/Engine.tools.test.ts
+++ b/packages/engine/src/Engine.tools.test.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 
 import { Engine } from './Engine.js';
 import { ReadTool } from './tools/index.js';
+import { builtInToolSearchPlugin } from './built-in/tool-search-plugin/index.js';
+import { builtInPtcPlugin } from './built-in/ptc-plugin/index.js';
 
 const createLogger = () => ({
   debug: vi.fn(),
@@ -32,5 +34,236 @@ describe('Engine built-in tool policy', () => {
     await engine.initialize();
 
     expect(Object.keys(engine.getTools()).sort()).toEqual(['host_answer', 'read']);
+  });
+
+  it('executes a selected tool through the same before/after hook chain', async () => {
+    const execute = vi.fn(async ({ question }: { question: string }) => `answer:${question}`);
+    const beforeRun = vi.fn();
+    const beforeLLMCall = vi.fn(({ systemPrompt }) => ({
+      systemPrompt: `${systemPrompt}:policy`,
+    }));
+    const afterLLMCall = vi.fn();
+    const afterRun = vi.fn();
+    const plugin = {
+      name: 'test/tool-hooks',
+      version: '1.0.0',
+      async initialize(context: any) {
+        context.registerHook('beforeRun', beforeRun);
+        context.registerHook('beforeLLMCall', beforeLLMCall);
+        context.registerHook('afterLLMCall', afterLLMCall);
+        context.registerHook('afterRun', afterRun);
+        context.registerHook('beforeToolCall', async ({ input, toolContext }: any) => ({
+          input: { question: `${input.question}-before` },
+          toolContext: { ...toolContext, marker: 'hooked' },
+        }));
+        context.registerHook('afterToolCall', async ({ output }: any) => ({
+          output: `${output}-after`,
+        }));
+      },
+    };
+    const engine = new Engine({
+      disableBuiltInPlugins: true,
+      enginePlugins: { plugins: [plugin], scan: false },
+      userConfigPlugins: { scan: false },
+      builtInTools: {},
+      tools: {
+        host_answer: {
+          name: 'host_answer',
+          description: 'Answer a host-specific question.',
+          inputSchema: z.object({ question: z.string() }),
+          execute,
+        },
+      },
+      logger: createLogger(),
+    });
+    await engine.initialize();
+
+    const session = await engine.createToolSession(
+      { messages: [] },
+      { systemPrompt: 'base' },
+    );
+    expect(session.getRegisteredTools()).toHaveProperty('host_answer');
+    expect(session.getSystemPrompt()).toBe('base:policy');
+    const output = await session.executeTool(
+      'host_answer',
+      { question: 'hello' },
+      { runContext: { executionMode: 'ask' } },
+    );
+
+    expect(output).toBe('answer:hello-before-after');
+    expect(execute).toHaveBeenCalledWith(
+      { question: 'hello-before' },
+      expect.objectContaining({ marker: 'hooked' }),
+    );
+    await session.dispose('done');
+    expect(beforeRun).toHaveBeenCalledTimes(1);
+    expect(beforeLLMCall).toHaveBeenCalledTimes(2);
+    expect(afterLLMCall).toHaveBeenCalledTimes(2);
+    expect(afterRun).toHaveBeenCalledWith(expect.objectContaining({ result: 'done' }));
+  });
+
+  it('rejects invalid direct tool input before execution', async () => {
+    const execute = vi.fn();
+    const engine = new Engine({
+      disableBuiltInPlugins: true,
+      enginePlugins: { scan: false },
+      userConfigPlugins: { scan: false },
+      builtInTools: {},
+      tools: {
+        host_answer: {
+          name: 'host_answer',
+          description: 'Answer a host-specific question.',
+          inputSchema: z.object({ question: z.string() }),
+          execute,
+        },
+      },
+      logger: createLogger(),
+    });
+    await engine.initialize();
+
+    const session = await engine.createToolSession({ messages: [] });
+    await expect(session.executeTool('host_answer', { question: 42 }))
+      .rejects.toThrow(/invalid input/i);
+    expect(execute).not.toHaveBeenCalled();
+    await session.dispose();
+  });
+
+  it('closes the run lifecycle when session initialization or LLM close fails', async () => {
+    const initAfterRun = vi.fn();
+    const initEngine = new Engine({
+      disableBuiltInPlugins: true,
+      enginePlugins: {
+        scan: false,
+        plugins: [{
+          name: 'test/init-lifecycle',
+          version: '1.0.0',
+          async initialize(context: any) {
+            context.registerHook('beforeLLMCall', () => {
+              throw new Error('initial visibility failed');
+            });
+            context.registerHook('afterRun', initAfterRun);
+          },
+        }],
+      },
+      userConfigPlugins: { scan: false },
+      builtInTools: {},
+      logger: createLogger(),
+    });
+    await initEngine.initialize();
+    await expect(initEngine.createToolSession({ messages: [] }))
+      .rejects.toThrow('initial visibility failed');
+    expect(initAfterRun).toHaveBeenCalledTimes(1);
+
+    const closeAfterRun = vi.fn();
+    const closeEngine = new Engine({
+      disableBuiltInPlugins: true,
+      enginePlugins: {
+        scan: false,
+        plugins: [{
+          name: 'test/close-lifecycle',
+          version: '1.0.0',
+          async initialize(context: any) {
+            context.registerHook('afterLLMCall', () => {
+              throw new Error('close failed');
+            });
+            context.registerHook('afterRun', closeAfterRun);
+          },
+        }],
+      },
+      userConfigPlugins: { scan: false },
+      builtInTools: {},
+      logger: createLogger(),
+    });
+    await closeEngine.initialize();
+    const session = await closeEngine.createToolSession({ messages: [] });
+    await expect(session.dispose()).rejects.toThrow('close failed');
+    expect(closeAfterRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps deferred tools hidden until an external tool session searches for them', async () => {
+    const deferredExecute = vi.fn(async () => 'created');
+    const engine = new Engine({
+      disableBuiltInPlugins: true,
+      enginePlugins: { plugins: [builtInToolSearchPlugin], scan: false },
+      userConfigPlugins: { scan: false },
+      builtInTools: {},
+      tools: {
+        immediate_read: {
+          name: 'immediate_read',
+          description: 'Read immediate context.',
+          inputSchema: z.object({}),
+          execute: async () => 'read',
+        },
+        artifact_create: {
+          name: 'artifact_create',
+          description: 'Create an artifact.',
+          inputSchema: z.object({ title: z.string() }),
+          execute: deferredExecute,
+          defer_loading: true,
+        },
+      },
+      logger: createLogger(),
+    });
+    await engine.initialize();
+
+    const session = await engine.createToolSession({ messages: [] });
+    expect(Object.keys(session.getTools())).toEqual(expect.arrayContaining([
+      'immediate_read',
+      'tool_search_tool_bm25',
+    ]));
+    expect(session.getTools()).not.toHaveProperty('artifact_create');
+    await expect(session.executeTool('artifact_create', { title: 'Early' }))
+      .rejects.toThrow(/unavailable/i);
+
+    const searchResult = await session.executeTool('tool_search_tool_bm25', {
+      query: 'create artifact',
+    }, { toolCallId: 'search-1' });
+    expect(searchResult).toMatchObject({
+      tool_references: [{ tool_name: 'artifact_create' }],
+    });
+    expect(session.getTools()).toHaveProperty('artifact_create');
+    await expect(session.executeTool('artifact_create', { title: 'Ready' }))
+      .resolves.toBe('created');
+    await session.dispose('done');
+  });
+
+  it('applies PTC visibility and runtime restrictions to external tool sessions', async () => {
+    const engine = new Engine({
+      disableBuiltInPlugins: true,
+      enginePlugins: {
+        plugins: [{ ...builtInPtcPlugin, version: `${builtInPtcPlugin.version}-tool-session` }],
+        scan: false,
+      },
+      userConfigPlugins: { scan: false },
+      builtInTools: {},
+      tools: {
+        guarded_tool: {
+          name: 'guarded_tool',
+          description: 'Caller-restricted tool.',
+          inputSchema: z.object({}),
+          allowed_callers: ['trusted_caller'],
+          execute: async () => 'ok',
+        },
+      },
+      logger: createLogger(),
+    });
+    await engine.initialize();
+
+    const blocked = await engine.createToolSession(
+      { messages: [] },
+      { runContext: { callerSelectors: ['other_caller'] } },
+    );
+    expect(blocked.getTools()).not.toHaveProperty('guarded_tool');
+    await blocked.dispose();
+
+    const allowed = await engine.createToolSession(
+      { messages: [] },
+      { runContext: { callerSelectors: ['trusted_caller'] } },
+    );
+    expect(allowed.getTools()).toHaveProperty('guarded_tool');
+    await expect(allowed.executeTool('guarded_tool', {}, {
+      runContext: { callerSelectors: ['other_caller'] },
+    })).rejects.toThrow(/not allowed/i);
+    await allowed.dispose();
   });
 });

--- a/packages/engine/src/Engine.ts
+++ b/packages/engine/src/Engine.ts
@@ -1,4 +1,5 @@
-import type { Context, Tool, LLMProviderFactory, SystemPromptOption, ToolHooks, ILogger, PulseEngineInstance, ModelType } from './shared/types';
+import { asSchema } from 'ai';
+import type { Context, Tool, ToolExecutionContext, LLMProviderFactory, SystemPromptOption, ToolHooks, ILogger, PulseEngineInstance, ModelType } from './shared/types';
 import type { LoopOptions, LoopHooks } from './core/loop';
 import type { EnginePluginLoadOptions } from './plugin/EnginePlugin.js';
 import type { UserConfigPluginLoadOptions } from './plugin/UserConfigPlugin.js';
@@ -10,6 +11,19 @@ import { BuiltinToolsMap } from './tools/index.js';
 import { PluginManager } from './plugin/PluginManager.js';
 import { builtInPlugins } from './built-in/index.js';
 import { buildProvider } from './config/index.js';
+
+export interface EngineToolSession {
+  /** Post-beforeRun registry, including tools that are currently deferred. */
+  getRegisteredTools(): Record<string, Tool>;
+  /** Current policy-filtered tools visible to the external model harness. */
+  getTools(): Record<string, Tool>;
+  /** Current policy-adjusted prompt for the external model harness. */
+  getSystemPrompt(): SystemPromptOption | undefined;
+  /** Execute a currently visible tool and advance per-step policy state. */
+  executeTool(name: string, input: unknown, toolContext?: ToolExecutionContext): Promise<unknown>;
+  /** Close outstanding model/plugin lifecycle hooks. Idempotent. */
+  dispose(result?: string): Promise<void>;
+}
 
 /**
  * 引擎配置选项
@@ -323,6 +337,197 @@ export class Engine {
    */
   getTools(): Record<string, any> {
     return { ...this.tools };
+  }
+
+  /**
+   * Create a policy-aware tool session for an external model harness.
+   * beforeRun runs once; beforeLLMCall filters the visible table initially and
+   * after every tool result. This preserves deferred loading, PTC filtering,
+   * dynamic skill descriptions, and the normal tool hook boundary.
+   */
+  async createToolSession(
+    context: Context,
+    options: {
+      runContext?: Record<string, any>;
+      model?: string;
+      systemPrompt?: SystemPromptOption;
+    } = {},
+  ): Promise<EngineToolSession> {
+    const policyContext: Context = { ...context, messages: [...context.messages] };
+    let tools: Record<string, Tool> = { ...this.tools };
+    let systemPrompt = options.systemPrompt ?? this.options.systemPrompt;
+    const hooks = this.collectLoopHooks();
+    let visibleTools: Record<string, Tool> = {};
+    let visibleSystemPrompt = systemPrompt;
+    let llmCallOpen = false;
+    let disposed = false;
+    let afterRunCalled = false;
+
+    const finishRun = async (result: string) => {
+      if (afterRunCalled) return;
+      afterRunCalled = true;
+      for (const hook of this.pluginManager.getHooks('afterRun')) {
+        await hook({ context: policyContext, result });
+      }
+    };
+    const closeLLMCall = async (finishReason: string) => {
+      if (!llmCallOpen) return;
+      llmCallOpen = false;
+      for (const hook of hooks.afterLLMCall ?? []) {
+        await hook({
+          context: policyContext,
+          finishReason,
+          text: '',
+          model: options.model ?? this.options.model,
+        });
+      }
+    };
+    const refreshVisibleTools = async () => {
+      let nextTools = tools;
+      let nextPrompt = systemPrompt;
+      for (const hook of hooks.beforeLLMCall ?? []) {
+        const result = await hook({
+          context: policyContext,
+          systemPrompt: nextPrompt,
+          tools: nextTools,
+          runContext: options.runContext,
+          model: options.model ?? this.options.model,
+        });
+        if (result && 'systemPrompt' in result && result.systemPrompt !== undefined) {
+          nextPrompt = result.systemPrompt;
+        }
+        if (result && 'tools' in result && result.tools !== undefined) {
+          nextTools = result.tools;
+        }
+      }
+      visibleTools = nextTools;
+      visibleSystemPrompt = nextPrompt;
+      llmCallOpen = true;
+    };
+
+    try {
+      for (const hook of this.pluginManager.getHooks('beforeRun')) {
+        const result = await hook({
+          context: policyContext,
+          systemPrompt,
+          tools,
+          runContext: options.runContext,
+          model: options.model ?? this.options.model,
+        });
+        if (result && 'systemPrompt' in result && result.systemPrompt !== undefined) {
+          systemPrompt = result.systemPrompt;
+        }
+        if (result && 'tools' in result && result.tools !== undefined) {
+          tools = result.tools;
+        }
+      }
+      await refreshVisibleTools();
+    } catch (error) {
+      try {
+        await finishRun('');
+      } catch {
+        // Preserve the initialization error as the actionable failure.
+      }
+      throw error;
+    }
+
+    return {
+      getRegisteredTools: () => ({ ...tools }),
+      getTools: () => ({ ...visibleTools }),
+      getSystemPrompt: () => visibleSystemPrompt,
+      executeTool: async (name, input, toolContext) => {
+        if (disposed) throw new Error('Engine tool session is disposed');
+        const tool = visibleTools[name];
+        if (!tool || typeof tool.execute !== 'function') {
+          throw new Error(`Unknown or unavailable tool: ${name}`);
+        }
+        await closeLLMCall('tool-calls');
+        let output: unknown;
+        try {
+          output = await this.executeResolvedTool(tool, name, input, {
+            context: policyContext,
+            toolContext,
+          });
+        } catch (error) {
+          await refreshVisibleTools();
+          throw error;
+        }
+
+        const toolCallId = toolContext?.toolCallId ?? `external:${name}`;
+        policyContext.messages.push({
+          role: 'tool',
+          content: [{
+            type: 'tool-result',
+            toolCallId,
+            toolName: name,
+            output: { type: 'json', value: output },
+          }],
+        } as any);
+        await refreshVisibleTools();
+        return output;
+      },
+      dispose: async (result = '') => {
+        if (disposed) return;
+        disposed = true;
+        try {
+          await closeLLMCall('stop');
+        } finally {
+          await finishRun(result);
+        }
+      },
+    };
+  }
+
+  private async executeResolvedTool(
+    tool: Tool,
+    name: string,
+    input: unknown,
+    options: { context: Context; toolContext?: ToolExecutionContext },
+  ): Promise<unknown> {
+    const schema = asSchema(tool.inputSchema);
+    let validatedInput = input;
+    if (schema.validate) {
+      const result = await schema.validate(input);
+      if (!result.success) {
+        throw new Error(`Invalid input for tool ${name}: ${result.error.message}`);
+      }
+      validatedInput = result.value;
+    }
+
+    const hooks = this.collectLoopHooks();
+    let finalInput = validatedInput;
+    let finalToolContext = options.toolContext;
+    let shortCircuitOutput: unknown;
+    let shortCircuited = false;
+    for (const hook of hooks.beforeToolCall ?? []) {
+      const result = await hook({
+        context: options.context,
+        name,
+        input: finalInput,
+        toolContext: finalToolContext,
+      });
+      if (result && 'input' in result) finalInput = result.input;
+      if (result && 'toolContext' in result) finalToolContext = result.toolContext;
+      if (result && 'output' in result) {
+        shortCircuitOutput = result.output;
+        shortCircuited = true;
+        break;
+      }
+    }
+
+    let output = shortCircuited
+      ? shortCircuitOutput
+      : await tool.execute(finalInput, finalToolContext);
+    for (const hook of hooks.afterToolCall ?? []) {
+      const result = await hook({
+        context: options.context,
+        name,
+        input: finalInput,
+        output,
+      });
+      if (result && 'output' in result) output = result.output;
+    }
+    return output;
   }
 
   /**

--- a/packages/engine/src/built-in/tool-search-plugin/tool-search-plugin.ts
+++ b/packages/engine/src/built-in/tool-search-plugin/tool-search-plugin.ts
@@ -309,6 +309,15 @@ export const builtInToolSearchPlugin: EnginePlugin = {
       };
     });
 
+    // External model harnesses do not append results to Engine's transcript,
+    // so load discovered tools at the shared execution boundary as well.
+    context.registerHook('afterToolCall', ({ name, output }) => {
+      if (name !== regexTool.name && name !== bm25Tool.name) return;
+      const references = (output as ToolSearchResultPayload | undefined)?.tool_references;
+      if (!Array.isArray(references)) return;
+      service.addLoadedTools(references.map(reference => reference.tool_name));
+    });
+
     context.registerHook('afterLLMCall', ({ context: runContext, finishReason }) => {
       if (finishReason !== 'tool-calls') {
         return;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,5 +1,6 @@
 export { Engine } from './Engine.js';
 export { Engine as PulseAgent } from './Engine.js'; // 添加 PulseAgent 别名
+export type { EngineToolSession } from './Engine.js';
 
 // 插件系统导出
 export type {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -23,6 +23,12 @@ importers:
       '@ai-sdk/openai':
         specifier: ^3.0.21
         version: 3.0.21(zod@4.3.6)
+      '@earendil-works/pi-agent-core':
+        specifier: 0.83.0
+        version: 0.83.0(ws@8.21.0)(zod@4.3.6)
+      '@earendil-works/pi-ai':
+        specifier: 0.83.0
+        version: 0.83.0(ws@8.21.0)(zod@4.3.6)
       '@larksuiteoapi/node-sdk':
         specifier: ^1.59.0
         version: 1.59.0
@@ -53,7 +59,7 @@ importers:
         version: 4.0.3
       '@module-federation/runtime':
         specifier: 2.5.1
-        version: 2.5.1
+        version: 2.5.1(node-fetch@3.3.2)
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -228,7 +234,7 @@ importers:
         version: 20.19.33
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -250,7 +256,7 @@ importers:
         version: 25.0.10
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -272,7 +278,7 @@ importers:
         version: 25.0.10
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -291,7 +297,7 @@ importers:
         version: 25.0.10
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -331,7 +337,7 @@ importers:
         version: 25.0.10
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -411,7 +417,7 @@ importers:
         version: 25.0.10
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -471,6 +477,112 @@ packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@anthropic-ai/sdk@0.91.1':
+    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    resolution: {integrity: sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.977.4':
+    resolution: {integrity: sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.65':
+    resolution: {integrity: sha512-lJT2aRw9wCV8jPHyFJjdZLD4HTydL6/22AnCSOB8e/LqOc55nEJGLHkJQeSxhn8QiqyjFwPKQFtMw0ovjRUY/g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.67':
+    resolution: {integrity: sha512-N7fw/15hSwI/CPxe5ohOyb7O4ge9f5me1gVIn8OIkBRB0squ8OJqQyDyH/HoL+Sb1W5xdC88jVC+bHkw73iu+Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.10':
+    resolution: {integrity: sha512-Zh9XRaPnDN9buO7GfWBubS22R6Nq5D6hbyYEMN05LiOnXugm/8WDjUx6y756bSPbdn3aJB2qG4zFW3bN82QhoQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.72':
+    resolution: {integrity: sha512-zZapIKwaHp7TdTf9hbH1I3CVUdEupmt7FXO/BoTQGC+4h6NkXKWpqF2p5WyfpjurDLHCpSyh+BzMlAg8arqWLA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.76':
+    resolution: {integrity: sha512-1yzLmRiYSgGC25v7ZZEwJn/auhHHTIHgFOmzL2f36hf1+7jSLcX+1QrAz4760WEzPiiQl8xmlpFhHfl2OoyVzA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.65':
+    resolution: {integrity: sha512-e5DbbNteOSalN58U83G6kFa4ECLEuGbGqNBHIXE7zYXA/m4GHblIGjFbSH7wYv6gBV8iNSDcRZBKfQZF5vF9nw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.9':
+    resolution: {integrity: sha512-0V0u4t+KBku9fbh5CPCaC5hUWwSzDafp8nCuDy817zWbp2gz80jO44rMQkiwnZ+k54B+tjAtzRy00DJRGTKGBg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.71':
+    resolution: {integrity: sha512-e4dwiRltGAaQ+2yxw57Hj0l/BF3BHiG14+QpYE7bGYBlpAq/fkIri2BDhjWon8c0mhhtd2txQBAkQb9BcTStFg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/eventstream-handler-node@3.972.31':
+    resolution: {integrity: sha512-/BRzvkp46mF6eXBL/l9WKPQQfifLlUPaWli6n9/T/WDLUg8he7TCyuNFnk6RvHP5j5W/kMj5Gxw7W778LJaXDA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-eventstream@3.972.26':
+    resolution: {integrity: sha512-2eIvouTZoxPu5ClHY6ij13De1yhY8Rmllt0dlGeBNXX3wmR7fU1pvMCGb50fKm1GxcuntWK0t1T0cMjTyDoUQA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-websocket@3.972.47':
+    resolution: {integrity: sha512-UcPdY05u3TzvDah86NG6B9FgePYU6bXO7CRQIzQrieFL5xBBGajM7g1lCngmP4WA8EPed/kgT5CvM28cqSlBbA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.39':
+    resolution: {integrity: sha512-wU5NPnj62Sb7A8xn/Zb+xThe05P3otNtDl37iOIi5DDMeCesNeCckaG+eXWGUs12Z9R34I8CD05TaTe6SIa61g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.43':
+    resolution: {integrity: sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1048.0':
+    resolution: {integrity: sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1100.0':
+    resolution: {integrity: sha512-THf3MkgY3fNJZ3zdgSenLqR7gSE68KccCj1RCKretlG73Ppszvues02VpCUO9NlB/tZDC483FvGCld+AiPCkvg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.2':
+    resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.8':
+    resolution: {integrity: sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.37':
+    resolution: {integrity: sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -549,6 +661,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -566,6 +682,15 @@ packages:
 
   '@chevrotain/types@11.1.2':
     resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
+
+  '@earendil-works/pi-agent-core@0.83.0':
+    resolution: {integrity: sha512-RorGp9OH5l3ElpuC5a5ZQ2eWcchZGXflXRzVGkV99y3y6tT+LLNyxoYIdVKvTKWEObwhExeQbTH0fI2tE4iX4g==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-ai@0.83.0':
+    resolution: {integrity: sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
 
   '@electron/asar@3.4.1':
     resolution: {integrity: sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==}
@@ -915,6 +1040,15 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
+  '@google/genai@1.52.0':
+    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
   '@hono/node-server@1.19.9':
     resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
     engines: {node: '>=18.14.1'}
@@ -980,6 +1114,14 @@ packages:
   '@mermaid-js/parser@1.1.1':
     resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
 
+  '@mistralai/mistralai@2.2.6':
+    resolution: {integrity: sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+
   '@module-federation/error-codes@2.5.1':
     resolution: {integrity: sha512-3KIR8XbEW0Y+Fn8IAnxzDWMvXQWiS40Z1TE/Fft9aTeXP9dDAM7AiVhjTh5yF2csAwHSt/1LJVZbiCmS13mE8A==}
 
@@ -1016,6 +1158,10 @@ packages:
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
 
   '@peculiar/asn1-schema@2.8.0':
     resolution: {integrity: sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==}
@@ -1214,6 +1360,46 @@ packages:
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
+
+  '@smithy/core@3.31.1':
+    resolution: {integrity: sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.16':
+    resolution: {integrity: sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.13':
+    resolution: {integrity: sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.7.3':
+    resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.9.13':
+    resolution: {integrity: sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.12':
+    resolution: {integrity: sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.16.1':
+    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1608,6 +1794,9 @@ packages:
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
@@ -1794,6 +1983,9 @@ packages:
   bezier-js@6.1.4:
     resolution: {integrity: sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==}
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
@@ -1810,6 +2002,9 @@ packages:
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@1.1.13:
     resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
@@ -1832,6 +2027,9 @@ packages:
 
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -2223,6 +2421,10 @@ packages:
   dagre-d3-es@7.0.14:
     resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   dayjs@1.11.20:
     resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
@@ -2299,6 +2501,10 @@ packages:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
   dir-compare@4.2.0:
     resolution: {integrity: sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==}
 
@@ -2329,6 +2535,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
@@ -2474,6 +2683,9 @@ packages:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
     engines: {node: '>=0.10.0'}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
     engines: {node: '>= 10.17.0'}
@@ -2500,6 +2712,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
 
   fflate@0.8.3:
     resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
@@ -2541,6 +2757,10 @@ packages:
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -2588,6 +2808,14 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gaxios@7.3.0:
+    resolution: {integrity: sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -2652,6 +2880,14 @@ packages:
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
+
+  google-auth-library@10.9.1:
+    resolution: {integrity: sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -2731,6 +2967,10 @@ packages:
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
 
   immutable@4.3.8:
     resolution: {integrity: sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==}
@@ -2912,8 +3152,15 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -2934,6 +3181,12 @@ packages:
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   kapsule@1.16.3:
     resolution: {integrity: sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==}
@@ -3209,6 +3462,15 @@ packages:
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   node-gyp@11.5.0:
     resolution: {integrity: sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -3277,6 +3539,18 @@ packages:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
 
+  openai@6.26.0:
+    resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   ora@5.4.1:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
     engines: {node: '>=10'}
@@ -3300,11 +3574,18 @@ packages:
     resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
     engines: {node: '>=18'}
 
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
+  partial-json@0.1.7:
+    resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
   patch-console@2.0.0:
     resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
@@ -3656,6 +3937,10 @@ packages:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   rimraf@2.6.3:
     resolution: {integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
@@ -3999,6 +4284,9 @@ packages:
   truncate-utf8-bytes@1.0.2:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
@@ -4047,6 +4335,9 @@ packages:
   type-fest@5.6.0:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
     engines: {node: '>=20'}
+
+  typebox@1.3.7:
+    resolution: {integrity: sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -4180,6 +4471,10 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   webcrypto-core@1.9.2:
     resolution: {integrity: sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==}
 
@@ -4286,6 +4581,11 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -4315,6 +4615,11 @@ packages:
 
   yoga-layout@3.2.1:
     resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -4378,6 +4683,226 @@ snapshots:
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.1.2
+
+  '@anthropic-ai/sdk@0.91.1(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/util-locate-window': 3.965.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.974.2
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/credential-provider-node': 3.972.76
+      '@aws-sdk/eventstream-handler-node': 3.972.31
+      '@aws-sdk/middleware-eventstream': 3.972.26
+      '@aws-sdk/middleware-websocket': 3.972.47
+      '@aws-sdk/token-providers': 3.1048.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.977.4':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/xml-builder': 3.972.37
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.31.1
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.65':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.67':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.10':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/credential-provider-env': 3.972.65
+      '@aws-sdk/credential-provider-http': 3.972.67
+      '@aws-sdk/credential-provider-login': 3.972.72
+      '@aws-sdk/credential-provider-process': 3.972.65
+      '@aws-sdk/credential-provider-sso': 3.973.9
+      '@aws-sdk/credential-provider-web-identity': 3.972.71
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.72':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.76':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.65
+      '@aws-sdk/credential-provider-http': 3.972.67
+      '@aws-sdk/credential-provider-ini': 3.973.10
+      '@aws-sdk/credential-provider-process': 3.972.65
+      '@aws-sdk/credential-provider-sso': 3.973.9
+      '@aws-sdk/credential-provider-web-identity': 3.972.71
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.65':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.9':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/token-providers': 3.1100.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.71':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/eventstream-handler-node@3.972.31':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-eventstream@3.972.26':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-websocket@3.972.47':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.39':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/signature-v4-multi-region': 3.996.43
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.43':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1048.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1100.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.2':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.8':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.37':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -4473,6 +4998,8 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/runtime@7.29.7': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -4499,6 +5026,42 @@ snapshots:
   '@braintree/sanitize-url@7.1.2': {}
 
   '@chevrotain/types@11.1.2': {}
+
+  '@earendil-works/pi-agent-core@0.83.0(ws@8.21.0)(zod@4.3.6)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.83.0(ws@8.21.0)(zod@4.3.6)
+      diff: 8.0.4
+      ignore: 7.0.5
+      typebox: 1.3.7
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-ai@0.83.0(ws@8.21.0)(zod@4.3.6)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.3.6)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      openai: 6.26.0(ws@8.21.0)(zod@4.3.6)
+      partial-json: 0.1.7
+      typebox: 1.3.7
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
 
   '@electron/asar@3.4.1':
     dependencies:
@@ -4769,6 +5332,17 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
+  '@google/genai@1.52.0':
+    dependencies:
+      google-auth-library: 10.9.1
+      p-retry: 4.6.2
+      protobufjs: 7.5.4
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@hono/node-server@1.19.9(hono@4.11.9)':
     dependencies:
       hono: 4.11.9
@@ -4859,24 +5433,38 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
+  '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/semantic-conventions': 1.43.0
+      ws: 8.21.0
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@module-federation/error-codes@2.5.1': {}
 
-  '@module-federation/runtime-core@2.5.1':
+  '@module-federation/runtime-core@2.5.1(node-fetch@3.3.2)':
     dependencies:
       '@module-federation/error-codes': 2.5.1
-      '@module-federation/sdk': 2.5.1
+      '@module-federation/sdk': 2.5.1(node-fetch@3.3.2)
     transitivePeerDependencies:
       - node-fetch
 
-  '@module-federation/runtime@2.5.1':
+  '@module-federation/runtime@2.5.1(node-fetch@3.3.2)':
     dependencies:
       '@module-federation/error-codes': 2.5.1
-      '@module-federation/runtime-core': 2.5.1
-      '@module-federation/sdk': 2.5.1
+      '@module-federation/runtime-core': 2.5.1(node-fetch@3.3.2)
+      '@module-federation/sdk': 2.5.1(node-fetch@3.3.2)
     transitivePeerDependencies:
       - node-fetch
 
-  '@module-federation/sdk@2.5.1': {}
+  '@module-federation/sdk@2.5.1(node-fetch@3.3.2)':
+    optionalDependencies:
+      node-fetch: 3.3.2
 
   '@noble/hashes@1.4.0': {}
 
@@ -4897,6 +5485,8 @@ snapshots:
       semver: 7.7.4
 
   '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@peculiar/asn1-schema@2.8.0':
     dependencies:
@@ -5037,6 +5627,59 @@ snapshots:
   '@sinclair/typebox@0.27.10': {}
 
   '@sindresorhus/is@4.6.0': {}
+
+  '@smithy/core@3.31.1':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.13':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.7.3':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.9.13':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.12':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/types@4.16.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -5488,6 +6131,8 @@ snapshots:
     dependencies:
       '@types/node': 20.19.33
 
+  '@types/retry@0.12.0': {}
+
   '@types/trusted-types@2.0.7':
     optional: true
 
@@ -5710,6 +6355,8 @@ snapshots:
 
   bezier-js@6.1.4: {}
 
+  bignumber.js@9.3.1: {}
+
   binary-extensions@2.3.0:
     optional: true
 
@@ -5727,6 +6374,8 @@ snapshots:
 
   boolean@3.2.0:
     optional: true
+
+  bowser@2.14.1: {}
 
   brace-expansion@1.1.13:
     dependencies:
@@ -5755,6 +6404,8 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   buffer-crc32@0.2.13: {}
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -6192,6 +6843,8 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.18.1
 
+  data-uri-to-buffer@4.0.1: {}
+
   dayjs@1.11.20: {}
 
   debug@4.4.3:
@@ -6256,6 +6909,8 @@ snapshots:
 
   diff-sequences@29.6.3: {}
 
+  diff@8.0.4: {}
+
   dir-compare@4.2.0:
     dependencies:
       minimatch: 3.1.5
@@ -6294,6 +6949,10 @@ snapshots:
       readable-stream: 2.3.8
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   ejs@3.1.10:
     dependencies:
@@ -6506,6 +7165,8 @@ snapshots:
     dependencies:
       is-extendable: 0.1.1
 
+  extend@3.0.2: {}
+
   extract-zip@2.0.1:
     dependencies:
       debug: 4.4.3
@@ -6529,6 +7190,11 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
 
   fflate@0.8.3: {}
 
@@ -6588,6 +7254,10 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   fs-constants@1.0.0: {}
 
   fs-extra@10.1.0:
@@ -6640,6 +7310,22 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gaxios@7.3.0:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.3.0
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   gensync@1.0.0-beta.2: {}
 
@@ -6726,6 +7412,19 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
     optional: true
+
+  google-auth-library@10.9.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.3.0
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
 
@@ -6820,6 +7519,8 @@ snapshots:
       safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
+
+  ignore@7.0.5: {}
 
   immutable@4.3.8:
     optional: true
@@ -6972,7 +7673,16 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
 
   json-schema-traverse@1.0.0: {}
 
@@ -6992,6 +7702,17 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   kapsule@1.16.3:
     dependencies:
@@ -7270,6 +7991,14 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
   node-gyp@11.5.0:
     dependencies:
       env-paths: 2.2.1
@@ -7351,6 +8080,11 @@ snapshots:
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
 
+  openai@6.26.0(ws@8.21.0)(zod@4.3.6):
+    optionalDependencies:
+      ws: 8.21.0
+      zod: 4.3.6
+
   ora@5.4.1:
     dependencies:
       bl: 4.1.0
@@ -7377,9 +8111,16 @@ snapshots:
 
   p-map@7.0.4: {}
 
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
   package-json-from-dist@1.0.1: {}
 
   package-manager-detector@1.6.0: {}
+
+  partial-json@0.1.7: {}
 
   patch-console@2.0.0: {}
 
@@ -7466,6 +8207,15 @@ snapshots:
       postcss: 8.5.6
       tsx: 4.21.0
       yaml: 2.8.2
+
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.9.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.6.1
+      postcss: 8.5.6
+      tsx: 4.21.0
+      yaml: 2.9.0
 
   postcss@8.5.6:
     dependencies:
@@ -7769,6 +8519,8 @@ snapshots:
       signal-exit: 3.0.7
 
   retry@0.12.0: {}
+
+  retry@0.13.1: {}
 
   rimraf@2.6.3:
     dependencies:
@@ -8154,6 +8906,8 @@ snapshots:
     dependencies:
       utf8-byte-length: 1.0.5
 
+  ts-algebra@2.0.0: {}
+
   ts-dedent@2.2.0: {}
 
   ts-interface-checker@0.1.13: {}
@@ -8172,6 +8926,34 @@ snapshots:
       joycon: 3.1.1
       picocolors: 1.1.1
       postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2)
+      resolve-from: 5.0.0
+      rollup: 4.57.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.6
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.2)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.2
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.9.0)
       resolve-from: 5.0.0
       rollup: 4.57.1
       source-map: 0.7.6
@@ -8207,6 +8989,8 @@ snapshots:
   type-fest@5.6.0:
     dependencies:
       tagged-tag: 1.0.0
+
+  typebox@1.3.7: {}
 
   typescript@5.9.3: {}
 
@@ -8392,6 +9176,8 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
+  web-streams-polyfill@3.3.3: {}
+
   webcrypto-core@1.9.2:
     dependencies:
       '@peculiar/asn1-schema': 2.8.0
@@ -8477,6 +9263,8 @@ snapshots:
 
   yaml@2.8.2: {}
 
+  yaml@2.9.0: {}
+
   yargs-parser@21.1.1: {}
 
   yargs-parser@22.0.0: {}
@@ -8510,5 +9298,9 @@ snapshots:
   yocto-queue@1.2.2: {}
 
   yoga-layout@3.2.1: {}
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   zod@4.3.6: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,12 +23,6 @@ importers:
       '@ai-sdk/openai':
         specifier: ^3.0.21
         version: 3.0.21(zod@4.3.6)
-      '@earendil-works/pi-agent-core':
-        specifier: 0.83.0
-        version: 0.83.0(ws@8.21.0)(zod@4.3.6)
-      '@earendil-works/pi-ai':
-        specifier: 0.83.0
-        version: 0.83.0(ws@8.21.0)(zod@4.3.6)
       '@larksuiteoapi/node-sdk':
         specifier: ^1.59.0
         version: 1.59.0
@@ -54,6 +48,12 @@ importers:
         specifier: ^4.0.0
         version: 4.3.6
     devDependencies:
+      '@earendil-works/pi-agent-core':
+        specifier: 0.83.0
+        version: 0.83.0(ws@8.21.0)(zod@4.3.6)
+      '@earendil-works/pi-ai':
+        specifier: 0.83.0
+        version: 0.83.0(ws@8.21.0)(zod@4.3.6)
       '@electron/rebuild':
         specifier: ^4.0.3
         version: 4.0.3


### PR DESCRIPTION
## Summary
- add a Canvas-owned `AgentRuntime` seam with Engine, embedded Pi AgentHarness, and external CLI adapters
- embed `@earendil-works/pi-agent-core@0.83.0` behind an experimental toggle while keeping Engine as the default and fallback
- reuse Canvas model credentials in memory and route the complete Engine tool registry, skills, MCP tools, deferred loading, ask/PTC policy, hooks, session history, compaction, streaming, abort, and runtime steering through `EngineToolSession`
- preserve structured/reasoning/image tool frames and serialize tool execution so the stateful Engine policy lifecycle stays deterministic

## Verification
- Canvas: 366 test files / 2286 tests passed, typecheck passed, production build passed
- Engine: 58 tests passed, typecheck passed, DTS build passed
- repository harness: 10/10 checks passed, harnessGaps 0
- Electron smoke: Electron 30.5.1 / Node 20.16.0 prints `ELECTRON_PI_OK`
- configured real OpenAI-compatible gateway returned `PI_REAL_PROVIDER_OK` through the embedded Pi runtime; no key or gateway config is committed
- downstream Engine API checks: CLI tests, agent-teams typecheck, ACP build, plugin-kit build, and remote-server build passed

## Known boundaries
- upstream Pi packages declare Node >=22.19.0; the committed Electron smoke proves only the APIs used by Canvas on Electron 30 / Node 20.16
- historical user image/file parts are not yet rehydrated into Pi
- steer/followUp are available on the runtime contract; Canvas UI controls are not included
- standalone ACP typecheck still hits its pre-existing TS6059 cross-package rootDir issue; ACP build passes and affected ACP paths are unchanged