### PR TITLE
Hide turn context UI temporarily pending user feedback

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
@@ -19,7 +19,7 @@ import {
 } from '../artifacts';
 import { CopyGeneratedImageButton, parseGeneratedImage } from './GeneratedImageActions';
 import { useI18n } from '../../i18n';
-import { ChatTurnContext, ChatTurnOutcome } from './ChatTurnMeta';
+import { ChatTurnOutcome } from './ChatTurnMeta';
 import { ChatLoadingDots, CopyMessageButton } from './ChatMessageActions';
 
 interface ChatMessageProps {
@@ -416,9 +416,6 @@ export const ChatMessage = ({
           className="chat-message-content chat-md"
           dangerouslySetInnerHTML={{ __html: userHtml }}
         />
-      )}
-      {message.role === 'user' && !isEditing && message.contextSnapshot && (
-        <ChatTurnContext snapshot={message.contextSnapshot} />
       )}
       {message.role === 'assistant' && (
         <ChatTurnOutcome

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatTurnMeta.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatTurnMeta.tsx
@@ -82,6 +82,9 @@ const ContextReferences = ({
 // what the composer already displays for the live turn, so every user message
 // carried a row of redundant labels. Only the references — which the composer
 // clears after sending and nothing else records — survive on the turn.
+//
+// Not currently rendered: ChatMessage.tsx no longer calls this — the row saw
+// little user attention, so it's hidden for now without removing the logic.
 export const ChatTurnContext = ({
   snapshot,
 }: {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatMessages.accessibility.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatMessages.accessibility.test.tsx
@@ -368,7 +368,10 @@ describe('ChatMessages accessibility', () => {
     expect(onRegenerate).toHaveBeenCalledWith(0);
   });
 
-  it('renders the exact context snapshot beneath its user turn', async () => {
+  it('does not render turn context beneath its user turn (temporarily hidden)', async () => {
+    // ChatMessage.tsx no longer wires ChatTurnContext up — the row saw little
+    // user attention, so it's hidden for now even when the snapshot carries
+    // references. ChatTurnMeta.tsx keeps the rendering logic intact.
     const el = await renderMessages([{
       role: 'user',
       content: 'Compare these.',
@@ -385,16 +388,7 @@ describe('ChatMessages accessibility', () => {
       },
     }]);
 
-    const snapshot = el.querySelector<HTMLElement>('.chat-turn-context');
-    expect(snapshot?.getAttribute('aria-label')).toBe('Turn context');
-    expect(snapshot?.textContent).toContain('Roadmap');
-    expect(snapshot?.textContent).toContain('#launch');
-    expect(snapshot?.textContent).toContain('Research canvas');
-    // Scope / model / execution restate the composer, so they are deliberately
-    // absent — every user turn used to carry that redundant row.
-    expect(snapshot?.textContent).not.toContain('Product canvas');
-    expect(snapshot?.textContent).not.toContain('GPT-5.6');
-    expect(snapshot?.textContent).not.toContain('Ask first');
+    expect(el.querySelector('.chat-turn-context')).toBeNull();
   });
 
   it('renders no turn context when the snapshot carries no references', async () => {


### PR DESCRIPTION
## Summary
Temporarily hides the turn context snapshot UI that was previously rendered beneath user messages. The rendering logic is preserved in `ChatTurnMeta.tsx` for future re-enablement, but the component is no longer wired up in `ChatMessage.tsx` since the feature saw minimal user engagement.

## Changes
- **ChatMessage.tsx**: Removed the `ChatTurnContext` component import and its conditional rendering beneath user messages
- **ChatTurnMeta.tsx**: Added clarifying comments that `ChatTurnContext` is no longer rendered, though the implementation remains intact
- **ChatMessages.accessibility.test.tsx**: Updated test expectations to verify the turn context element is not present, with documentation explaining the temporary hiding

## Implementation Details
The `ChatTurnContext` component and its logic remain fully functional in `ChatTurnMeta.tsx`, allowing for straightforward re-enablement if user feedback warrants it. The test suite has been updated to reflect the current behavior while preserving the context for future changes.

https://claude.ai/code/session_01YFQMgehMzuuRonPnuAGg7Q