### PR TITLE
release(canvas): 0.1.38

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.37",
+  "version": "0.1.38",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
## Release

- publish Pulse Canvas 0.1.38 for macOS arm64
- update the app package version
- R2 artifacts, latest.json, and the download page are already deployed

## Verification

- `node scripts/harness/run-harness-check.mjs` (5/5 passed)
- packaged agent tooling smoke passed
- versioned DMG URL returned HTTP 200