### PR TITLE
fix(canvas-workspace): remove default exports from MigrationSpinner and AgentShellPathCard

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
@@ -10,7 +10,9 @@ import { useI18n } from '../../i18n';
 import { Button, FieldRow, Select } from '../ui';
 import './AgentSection.css';
 
-const AgentShellPathCard = lazy(() => import('./AgentShellPathCard'));
+const AgentShellPathCard = lazy(() =>
+  import('./AgentShellPathCard').then((module) => ({ default: module.AgentShellPathCard })),
+);
 
 interface AgentSectionProps {
   onClose: () => void;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
@@ -9,7 +9,7 @@ interface AgentShellPathCardProps {
   onConfigured: () => Promise<void>;
 }
 
-const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps) => {
+export const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps) => {
   const { notify } = useAppShell();
   const { language, t } = useI18n();
   const [configuring, setConfiguring] = useState(false);
@@ -71,5 +71,3 @@ const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps
     </div>
   );
 };
-
-export default AgentShellPathCard;


### PR DESCRIPTION
## Summary

Scanned `apps/canvas-workspace` against its documented UI/component style guide (`apps/canvas-workspace/harness/knowledge/conventions/frontend.md`, "Component style" section):

> Export **named arrow-function components** ... Avoid `default` exports for components.

Two components violated this and were the only `export default` component declarations in `src/renderer/src/components/**`:

- `MigrationSpinner/index.tsx` — had a named export **and** a redundant `export default`. Dead code: `App.tsx` already lazy-loads it via the named export (`import('./components/MigrationSpinner').then((module) => ({ default: module.MigrationSpinner }))`), so the default export had no live caller.
- `Settings/AgentShellPathCard.tsx` — was default-export-only, with its sole call site (`Settings/AgentSection.tsx`) relying on the default export via `lazy(() => import('./AgentShellPathCard'))`.

## Changes

- Removed the stray `export default MigrationSpinner;` line — no other change needed since every caller already used the named export.
- Converted `AgentShellPathCard` to a named export and updated its one `lazy()` call site in `AgentSection.tsx` to wrap the named export, mirroring the pattern `App.tsx` already uses for `MigrationSpinner`:
  ```ts
  const AgentShellPathCard = lazy(() =>
    import('./AgentShellPathCard').then((module) => ({ default: module.AgentShellPathCard })),
  );
  ```

Scope note: I deliberately did not touch hardcoded color/radius/shadow literals — the workspace's UI-reuse governance docs call those out as a separate, pixel-changing operation requiring a visual diff, not a plain style-consistency fix. No other `export default` component declarations, and no other style-guide violations of this kind, were found in the scan.

## Test plan

- [x] Confirmed via `grep` that no other files import `MigrationSpinner` or `AgentShellPathCard` via a default import that would break.
- [ ] `pnpm --filter canvas-workspace typecheck` / `pnpm --filter canvas-workspace test` — could not run in this sandbox (`node_modules` not installed); please run in CI/locally to confirm.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_012pwt9bh6Qs4GYKF7g2QqWu)_