### PR TITLE
canvas-workspace: fix default-export inconsistency in two components

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
@@ -10,7 +10,9 @@ import { useI18n } from '../../i18n';
 import { Button, FieldRow, Select } from '../ui';
 import './AgentSection.css';
 
-const AgentShellPathCard = lazy(() => import('./AgentShellPathCard'));
+const AgentShellPathCard = lazy(() =>
+  import('./AgentShellPathCard').then((module) => ({ default: module.AgentShellPathCard })),
+);
 
 interface AgentSectionProps {
   onClose: () => void;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
@@ -9,7 +9,7 @@ interface AgentShellPathCardProps {
   onConfigured: () => Promise<void>;
 }
 
-const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps) => {
+export const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps) => {
   const { notify } = useAppShell();
   const { language, t } = useI18n();
   const [configuring, setConfiguring] = useState(false);
@@ -71,5 +71,3 @@ const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps
     </div>
   );
 };
-
-export default AgentShellPathCard;


### PR DESCRIPTION
## Summary

Scanned `apps/canvas-workspace` against its documented UI/component conventions (`harness/knowledge/conventions/frontend.md`) and the codebase's own mechanical UI-consistency gate (`src/main/__tests__/ui-reuse-governance.test.ts`, which ratchets raw `<button>`/`<input>` tags, hardcoded colors, border-radius/shadow/z-index literals, bespoke overlay/dropdown shells, etc.).

The governance ratchet test passes with **zero drift** — every counter matches its baseline exactly, so there's no CSS-token/component-reuse regression to fix. Broadening the check to the "Component style" convention in `frontend.md` ("export named arrow-function components... avoid default exports for components") turned up exactly two components in the whole renderer tree using `export default`:

- `Settings/AgentShellPathCard.tsx` — only exported as `default`.
- `MigrationSpinner/index.tsx` — already exported the real, used API as a named export (`export const MigrationSpinner`), but also carried a second, unreferenced `export default` (its only consumer, `App.tsx`, already re-wraps the named export for `lazy()`).

## Changes

- `AgentShellPathCard.tsx`: export as `export const AgentShellPathCard`, drop the `export default`.
- `AgentSection.tsx`: update the `lazy()` call site to re-wrap the named export (`.then((module) => ({ default: module.AgentShellPathCard }))`) — the same pattern `App.tsx` already uses for `MigrationSpinner`, so both lazy-loaded components now follow one consistent shape.
- `MigrationSpinner/index.tsx`: remove the dead `export default` (unused — its consumer already imports the named export).

## Why

Keeps every renderer component on the one documented export convention instead of two competing shapes, and removes a dead/misleading export that could tempt a future default-import call site to diverge from the pattern.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx vitest run` — no new failures; the 11 pre-existing failing suites (missing `pulse-coder-engine`/`pulse-coder-agent-teams` build artifacts in this fresh checkout) reproduce identically on `master` with these changes stashed, confirming they're unrelated to this diff
- [x] `ui-reuse-governance.test.ts`, `file-size-governance.test.ts`, `import-boundaries.test.ts` — all pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01C9bgQfHnEEJbWhKoC6neLD)_