### PR TITLE
fix(canvas-workspace): align component exports with named-export convention

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
@@ -10,7 +10,9 @@ import { useI18n } from '../../i18n';
 import { Button, FieldRow, Select } from '../ui';
 import './AgentSection.css';
 
-const AgentShellPathCard = lazy(() => import('./AgentShellPathCard'));
+const AgentShellPathCard = lazy(() =>
+  import('./AgentShellPathCard').then((module) => ({ default: module.AgentShellPathCard }))
+);
 
 interface AgentSectionProps {
   onClose: () => void;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
@@ -9,7 +9,7 @@ interface AgentShellPathCardProps {
   onConfigured: () => Promise<void>;
 }
 
-const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps) => {
+export const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps) => {
   const { notify } = useAppShell();
   const { language, t } = useI18n();
   const [configuring, setConfiguring] = useState(false);
@@ -72,4 +72,3 @@ const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps
   );
 };
 
-export default AgentShellPathCard;


### PR DESCRIPTION
## Summary

Scanned `apps/canvas-workspace` for UI style inconsistencies against its documented conventions (`apps/canvas-workspace/harness/knowledge/conventions/frontend.md`) and the app's mechanical governance suites (`ui-reuse-governance.test.ts`, `file-size-governance.test.ts` — both still pass, no ratchet drift).

The governance suites already gate hardcoded colors, border-radius/shadow literals, and bespoke overlay/dropdown shells, and reported no new violations. The one gap those mechanical checks don't cover is component export style, which `frontend.md` documents explicitly:

> Export **named arrow-function components** ... Avoid `default` exports for components.

Two files under `src/renderer/src/components/` broke that convention — the only two in the whole tree:

- `MigrationSpinner/index.tsx` — already exported `MigrationSpinner` as a named const, but also had a redundant, unused `export default MigrationSpinner;` at the bottom (its one consumer in `App.tsx` already imports the named export).
- `Settings/AgentShellPathCard.tsx` — was default-export only.

## Changes

- Removed the dead `export default` from `MigrationSpinner`.
- Converted `AgentShellPathCard` to a named export and updated its lazy-import call site in `Settings/AgentSection.tsx` to `import('./AgentShellPathCard').then((module) => ({ default: module.AgentShellPathCard }))` — the same pattern `App.tsx` already uses for `MigrationSpinner`'s lazy import.

## Why

Consistent named exports keep every component reachable the same way (direct import or the established `.then((module) => ({ default: module.X }))` lazy-load pattern) and match the convention every other component in the tree already follows, so there's one predictable import shape rather than a special case per file.

## Test plan

- [x] `pnpm exec vitest run src/main/__tests__/ui-reuse-governance.test.ts src/main/__tests__/file-size-governance.test.ts` — pass, no ratchet drift
- [x] Confirmed no other file under `src/renderer/src/components` uses `export default`
- [x] `tsc --noEmit` shows only pre-existing, unrelated errors (missing `pulse-coder-engine/built-in` build output — not caused by this change; `packages/engine` isn't built in this environment)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HPZ9BCRqbikqHUHEzDS6Jj)_