### PR TITLE
fix(canvas): stabilize AI chat session switching

### DIFF
--- a/apps/canvas-workspace/harness/knowledge/chat-sessions.md
+++ b/apps/canvas-workspace/harness/knowledge/chat-sessions.md
@@ -57,6 +57,35 @@ Tests: `hooks/useChatSessions.test.tsx`,
 `hooks/useMentions.submit-veto.test.tsx`, `__tests__/ChatSessionLoading.test.tsx`
 (all under `src/renderer/src/components/chat/`).
 
+## Stable full-page session rail
+
+The full-page rail is a unified, cross-scope index. Its folder tree must stay
+structurally stable while the selected conversation changes scope.
+
+- With `allWorkspaces` present, `listAllSessions` is the single list source;
+  do not also fetch `listSessions` and reconcile two snapshots of the same
+  store.
+- `sessionsStoreId` records which scope produced the committed `sessions`
+  array. During a cross-scope thread load it can intentionally differ from
+  `agentScope`; `useStableSessionRail` must group rows by this committed owner,
+  never re-label them using the destination scope early.
+- Folder collapse state is user state. Reconciliation may initialize a new
+  folder or expand the active folder, but must preserve manually expanded
+  siblings and must not mutate state merely because search filtered a folder.
+- While a conversation opens, keep the rail visible and mark only the pending
+  row busy. The full-page body must not add an in-flow opening banner: even a
+  one-frame banner shifts the entire thread. Disabling or replacing the whole
+  rail destroys spatial context.
+- Session and group recency use exact `updatedAt`; the calendar date is only a
+  compatibility fallback. Main excludes active session stores from the global
+  disk scan because their live agents supply the authoritative list.
+
+Guards: `hooks/useChatSessions.test.tsx` composes cross-scope loading with the
+unified rail and pins the one-source list contract;
+`__tests__/ChatSessionsRail.test.tsx` pins expansion preservation, pending-row
+feedback, precise recency ordering, and repeated-preview metadata;
+`src/main/agent/__tests__/service-history.test.ts` pins active-store exclusion.
+
 ## Full-page chat topbar vs dock content tabs
 
 The full-page chat topbar (`chat/ChatPageBody.tsx`, shared by the AI Chat

--- a/apps/canvas-workspace/src/main/agent/__tests__/service-history.test.ts
+++ b/apps/canvas-workspace/src/main/agent/__tests__/service-history.test.ts
@@ -86,11 +86,13 @@ describe('CanvasAgentService history', () => {
   });
 
   it('keeps an active empty-chat scope in the unified session groups', async () => {
-    vi.spyOn(SessionStore, 'listAllWorkspaceSessions').mockResolvedValue([]);
+    const scan = vi.spyOn(SessionStore, 'listAllWorkspaceSessions').mockResolvedValue([]);
     const service = new CanvasAgentService();
     await service.getHistoryForScope({ kind: 'global' });
 
     const groups = await service.listAllSessions({});
+
+    expect(scan).toHaveBeenCalledWith(new Set(['__global_chat__']));
 
     expect(groups).toEqual([{
       workspaceId: '__global_chat__',

--- a/apps/canvas-workspace/src/main/agent/__tests__/session-store.test.ts
+++ b/apps/canvas-workspace/src/main/agent/__tests__/session-store.test.ts
@@ -325,6 +325,29 @@ describe('SessionStore', () => {
     });
   });
 
+  it('uses the exact message time for recency even when a copied archive has a newer mtime', async () => {
+    const workspaceId = 'ws-recency';
+    const store = new SessionStore(workspaceId);
+    await store.startSession();
+    const sessionId = store.getCurrentSession()!.sessionId;
+    const exactUpdatedAt = Date.now() + 60_000;
+    store.addMessage({ role: 'user', content: 'first', timestamp: exactUpdatedAt });
+    await store.startSession();
+
+    const archiveDir = join(root, workspaceId, 'agent-sessions', 'archive');
+    const [archiveFile] = await fs.readdir(archiveDir);
+    const copiedAt = exactUpdatedAt + 60_000;
+    await fs.utimes(
+      join(archiveDir, archiveFile),
+      new Date(copiedAt),
+      new Date(copiedAt),
+    );
+
+    const listed = (await new SessionStore(workspaceId).listArchivedSessions())
+      .find((session) => session.sessionId === sessionId);
+    expect(listed?.updatedAt).toBe(exactUpdatedAt);
+  });
+
   it('persists pin and unpin state for an archived session', async () => {
     const store = new SessionStore('ws-pin');
     await store.startSession();

--- a/apps/canvas-workspace/src/main/agent/active-session-groups.ts
+++ b/apps/canvas-workspace/src/main/agent/active-session-groups.ts
@@ -11,7 +11,7 @@ interface AppendActiveSessionGroupsOptions {
   workspaceNames: Record<string, string>;
 }
 
-const scopeFromServiceKey = (key: string): AgentScope => {
+export const scopeFromServiceKey = (key: string): AgentScope => {
   if (key === 'global') return { kind: 'global' };
   if (key.startsWith('scheduled:')) {
     return { kind: 'scheduled', taskId: key.slice('scheduled:'.length) };

--- a/apps/canvas-workspace/src/main/agent/service.ts
+++ b/apps/canvas-workspace/src/main/agent/service.ts
@@ -6,7 +6,7 @@ import { GLOBAL_CHAT_SESSION_STORE_ID, GLOBAL_CHAT_WORKSPACE_NAME, SessionStore,
 import { scheduledTaskIdFromStoreId, scopeSessionStoreId } from '../../shared/agent-chat';
 import { scheduledTaskTitles } from './scheduled-session-names';
 import { searchSessionTitles } from './session-title-search';
-import { appendActiveSessionGroups } from './active-session-groups';
+import { appendActiveSessionGroups, scopeFromServiceKey } from './active-session-groups';
 import { ScopeActivationGate } from './scope-activation-gate';
 import type { CanvasToolResultEvent } from './engine-stream-callbacks';
 import type { ResolvedCanvasModel } from './model/config';
@@ -323,7 +323,11 @@ export class CanvasAgentService {
   async listAllSessions(
     workspaceNames: Record<string, string>,
   ): Promise<CrossWorkspaceSessionGroup[]> {
-    const diskGroups = await SessionStore.listAllWorkspaceSessions();
+    // Active agents supply the freshest list; do not parse their stores twice.
+    const activeStoreIds = new Set(Array.from(
+      this.agents.keys(), key => scopeSessionStoreId(scopeFromServiceKey(key)),
+    ));
+    const diskGroups = await SessionStore.listAllWorkspaceSessions(activeStoreIds);
     const groups: CrossWorkspaceSessionGroup[] = [];
     const scheduledTitles = await scheduledTaskTitles();
     const includedStoreIds = new Set<string>();
@@ -361,11 +365,12 @@ export class CanvasAgentService {
       workspaceNames,
     });
 
-    // Sort: ensure workspaces with more recent sessions come first
     groups.sort((a, b) => {
-      const aDate = a.sessions[0]?.date ?? '';
-      const bDate = b.sessions[0]?.date ?? '';
-      return bDate.localeCompare(aDate);
+      const aSession = a.sessions[0];
+      const bSession = b.sessions[0];
+      const aUpdatedAt = aSession?.updatedAt ?? (Date.parse(aSession?.date ?? '') || 0);
+      const bUpdatedAt = bSession?.updatedAt ?? (Date.parse(bSession?.date ?? '') || 0);
+      return bUpdatedAt - aUpdatedAt;
     });
 
     return groups;

--- a/apps/canvas-workspace/src/main/agent/session-store-scan.ts
+++ b/apps/canvas-workspace/src/main/agent/session-store-scan.ts
@@ -11,11 +11,28 @@ import {
 export interface AgentSessionListEntry {
   sessionId: string;
   date: string;
+  /** Exact recency used by the rail; unlike `date`, retains time-of-day. */
+  updatedAt: number;
   messageCount: number;
   preview: string;
   title?: string;
   pinned: boolean;
   isCurrent: boolean;
+}
+
+export function sessionUpdatedAt(session: CanvasAgentSession, fileTimestamp = 0): number {
+  const messageTimestamp = (session.messages ?? []).reduce(
+    (latest, message) => Number.isFinite(message.timestamp)
+      ? Math.max(latest, message.timestamp ?? 0)
+      : latest,
+    0,
+  );
+  // File mtimes are only a fallback: imports and harness clones legitimately
+  // rewrite them, which must not make every historical conversation "just now".
+  if (messageTimestamp > 0) return messageTimestamp;
+  const startedAt = Date.parse(session.startedAt ?? '');
+  if (Number.isFinite(startedAt)) return startedAt;
+  return fileTimestamp;
 }
 
 function archiveFileTimestamp(file: string): number {
@@ -34,6 +51,7 @@ export async function archiveSortKey(filePath: string, fileName: string): Promis
 
 export async function scanAllWorkspaceSessions(
   rootDir: string,
+  excludedStoreIds: ReadonlySet<string> = new Set(),
 ): Promise<Array<{ workspaceId: string; sessions: AgentSessionListEntry[] }>> {
   const results: Array<{ workspaceId: string; sessions: AgentSessionListEntry[] }> = [];
   let dirs: string[];
@@ -45,19 +63,22 @@ export async function scanAllWorkspaceSessions(
 
   for (const dir of dirs) {
     if (!isListableSessionStore(dir)) continue;
+    if (excludedStoreIds.has(dir)) continue;
     const sessionsDir = join(rootDir, dir, 'agent-sessions');
     const archiveDir = join(sessionsDir, 'archive');
     const metadata = await readSessionMetadata(join(sessionsDir, 'metadata.json'));
     const sessions: AgentSessionListEntry[] = [];
 
     try {
-      const raw = await fs.readFile(join(sessionsDir, 'current.json'), 'utf-8');
+      const currentPath = join(sessionsDir, 'current.json');
+      const raw = await fs.readFile(currentPath, 'utf-8');
       const data = JSON.parse(raw) as CanvasAgentSession;
       if (data.messages?.length > 0) {
         const firstUserMessage = data.messages.find((message) => message.role === 'user');
         sessions.push({
           sessionId: data.sessionId,
           date: data.startedAt?.slice(0, 10) || '',
+          updatedAt: sessionUpdatedAt(data, await archiveSortKey(currentPath, '')),
           messageCount: data.messages.length,
           preview: firstUserMessage ? sessionPreview(firstUserMessage.content) : '',
           ...listedSessionMetadata(metadata, data.sessionId),
@@ -84,6 +105,7 @@ export async function scanAllWorkspaceSessions(
           const session = {
             sessionId: data.sessionId,
             date: data.startedAt?.slice(0, 10) || file.replace('.json', '').slice(0, 10),
+            updatedAt: sessionUpdatedAt(data, sortKey),
             messageCount: data.messages.length,
             preview: firstUserMessage ? sessionPreview(firstUserMessage.content) : '',
             ...listedSessionMetadata(metadata, data.sessionId),
@@ -105,7 +127,7 @@ export async function scanAllWorkspaceSessions(
     if (sessions.length === 0) continue;
     sessions.sort((left, right) => {
       if (left.isCurrent !== right.isCurrent) return left.isCurrent ? -1 : 1;
-      return right.date.localeCompare(left.date);
+      return right.updatedAt - left.updatedAt || right.date.localeCompare(left.date);
     });
     results.push({ workspaceId: dir, sessions });
   }

--- a/apps/canvas-workspace/src/main/agent/session-store.ts
+++ b/apps/canvas-workspace/src/main/agent/session-store.ts
@@ -17,11 +17,7 @@ import {
   readSessionMetadata,
   removeSessionMetadata,
 } from './session-metadata';
-import {
-  archiveSortKey,
-  scanAllWorkspaceSessions,
-  type AgentSessionListEntry,
-} from './session-store-scan';
+import { archiveSortKey, scanAllWorkspaceSessions, sessionUpdatedAt, type AgentSessionListEntry } from './session-store-scan';
 export type { AgentSessionListEntry } from './session-store-scan';
 // Lazy so tests can redirect storage through the environment.
 const storeDir = (): string =>
@@ -173,6 +169,7 @@ export class SessionStore {
     return [{
       sessionId: current.sessionId,
       date: current.startedAt.slice(0, 10),
+      updatedAt: sessionUpdatedAt(current, await archiveSortKey(this.currentPath, '')),
       messageCount: current.messages.length,
       preview: firstUserMessage ? sessionPreview(firstUserMessage.content) : '',
       ...listedSessionMetadata(metadata, current.sessionId),
@@ -209,6 +206,7 @@ export class SessionStore {
       const sessionsById = new Map<string, {
         sessionId: string;
         date: string;
+        updatedAt: number;
         messageCount: number;
         preview: string;
         title?: string;
@@ -233,6 +231,7 @@ export class SessionStore {
           const session = {
             sessionId: data.sessionId,
             date: data.startedAt?.slice(0, 10) || file.replace('.json', '').slice(0, 10),
+            updatedAt: sessionUpdatedAt(data, sortKey),
             messageCount: data.messages.length,
             preview: firstUserMsg ? sessionPreview(firstUserMsg.content) : '',
             ...listedSessionMetadata(metadata, data.sessionId),
@@ -248,7 +247,7 @@ export class SessionStore {
       }
 
       return Array.from(sessionsById.values())
-        .sort((a, b) => b.sortKey - a.sortKey || b.date.localeCompare(a.date))
+        .sort((a, b) => b.updatedAt - a.updatedAt || b.sortKey - a.sortKey || b.date.localeCompare(a.date))
         .map(({ sortKey: _sortKey, ...session }) => session);
     } catch {
       return [];
@@ -326,8 +325,8 @@ export class SessionStore {
   // ─── Cross-workspace scanning ────────────────────────────────
 
   /** Scan all listable session stores. */
-  static listAllWorkspaceSessions() {
-    return scanAllWorkspaceSessions(storeDir());
+  static listAllWorkspaceSessions(excludedStoreIds?: ReadonlySet<string>) {
+    return scanAllWorkspaceSessions(storeDir(), excludedStoreIds);
   }
 
   /** Read a store's on-disk current id without activating an agent. */

--- a/apps/canvas-workspace/src/main/agent/types.ts
+++ b/apps/canvas-workspace/src/main/agent/types.ts
@@ -333,9 +333,12 @@ export interface CrossWorkspaceSessionGroup {
   sessions: Array<{
     sessionId: string;
     date: string;
+    updatedAt: number;
     messageCount: number;
     preview: string;
     isCurrent: boolean;
+    title?: string;
+    pinned?: boolean;
   }>;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatConversationStatus.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatConversationStatus.tsx
@@ -5,6 +5,8 @@ import './ChatConversationStatus.css';
 
 interface ChatConversationStatusProps {
   sessionLoading?: boolean;
+  /** Where session-opening feedback is presented for this surface. */
+  sessionLoadingFeedback?: 'inline' | 'external';
   /**
    * Whether the thread already has messages on screen. When it doesn't,
    * `ChatMessages` renders `ChatThreadSkeleton` in its place — which already
@@ -23,6 +25,7 @@ interface ChatConversationStatusProps {
 
 export const ChatConversationStatus = ({
   sessionLoading = false,
+  sessionLoadingFeedback = 'inline',
   hasMessages,
   busyElsewhere = false,
   sessionError,
@@ -31,7 +34,9 @@ export const ChatConversationStatus = ({
   disabled = false,
 }: ChatConversationStatusProps) => {
   const { t } = useI18n();
-  const showOpeningBanner = sessionLoading && hasMessages;
+  const showOpeningBanner = sessionLoading
+    && sessionLoadingFeedback === 'inline'
+    && hasMessages;
   if (!showOpeningBanner && !busyElsewhere && !sessionError && !conversationError) return null;
 
   return (

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.css
@@ -180,6 +180,24 @@
   white-space: nowrap;
 }
 
+.chat-page-rail-item-content {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.chat-page-rail-item-meta {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1;
+}
+
 .chat-page-rail-item-count {
   font-size: 11px;
   color: #b4b4b0;

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageBody.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageBody.tsx
@@ -196,7 +196,7 @@ export const ChatPageBody = ({
     retrySession,
     selectMention,
     sendMessage,
-    sessions, sessionsLoading, sessionLoading,
+    sessions, sessionsLoading, sessionsStoreId, sessionLoading,
     sessionError,
     setClarifyInput,
     setMentionIndex,
@@ -253,10 +253,13 @@ export const ChatPageBody = ({
   }, [onWorkspaceContextRequest, workspaceId]);
 
   useEffect(() => {
-    if (!sessionLoading && activeSessionId) {
-      onActiveSessionResolved?.(activeSessionId, scopeId);
+    // Do not let the previous scope's active id overwrite the synchronously
+    // selected rail key in that render gap. Once the intent is consumed, the
+    // committed list owner is the authoritative store for this id.
+    if (!pendingSessionId && !sessionLoading && activeSessionId) {
+      onActiveSessionResolved?.(activeSessionId, sessionsStoreId);
     }
-  }, [activeSessionId, onActiveSessionResolved, scopeId, sessionLoading]);
+  }, [activeSessionId, onActiveSessionResolved, pendingSessionId, sessionLoading, sessionsStoreId]);
 
   const retrySessionTransition = useChatPagePendingSession({
     busyElsewhere, handleLoadSession, onJumpToSession, onSessionConsumed,
@@ -378,6 +381,8 @@ export const ChatPageBody = ({
     otherSessions,
     selectedSessionKey,
     sessions,
+    sessionsStoreId,
+    pendingSessionKey: sessionLoading ? selectedSessionKey : null,
     disabled: sessionInteractionDisabled,
     focusInput,
     handleNewSession,
@@ -413,7 +418,7 @@ export const ChatPageBody = ({
         <ChatView
           className="chat-page-body"
           banner={<>
-            <ChatConversationStatus
+            <ChatConversationStatus sessionLoadingFeedback="external"
               sessionLoading={sessionLoading}
               hasMessages={messages.length > 0}
               busyElsewhere={busyElsewhere}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatSessionRailItem.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatSessionRailItem.tsx
@@ -4,6 +4,7 @@ import {
   CloseIcon,
   ListLinesIcon,
   PencilIcon,
+  SpinnerIcon,
   TrashIcon,
 } from '../icons';
 import { Button, TextField } from '../ui';
@@ -11,6 +12,7 @@ import { useI18n } from '../../i18n';
 import { SessionTitle } from './SessionTitle';
 import type { ChatSessionsRailProps, UnifiedSession } from './ChatSessionsRail';
 import { sessionTitleText } from './utils/sessionTitle';
+import { formatAbsoluteTime, formatRelativeTime } from './utils/time';
 
 interface Props {
   session: UnifiedSession;
@@ -19,6 +21,7 @@ interface Props {
   onDeleteSession?: ChatSessionsRailProps['onDeleteSession'];
   onTogglePinSession?: ChatSessionsRailProps['onTogglePinSession'];
   disabled?: boolean;
+  pending?: boolean;
 }
 
 const PinIcon = ({ filled = false }: { filled?: boolean }) => (
@@ -39,9 +42,12 @@ export const ChatSessionRailItem = ({
   onDeleteSession,
   onTogglePinSession,
   disabled = false,
+  pending = false,
 }: Props) => {
   const { t } = useI18n();
   const title = session.preview ? sessionTitleText(session.preview) : session.date;
+  const updatedAt = session.updatedAt ?? Date.parse(`${session.date}T00:00:00`);
+  const recency = formatRelativeTime(updatedAt) || session.date;
   const [mode, setMode] = useState<'idle' | 'rename' | 'delete'>('idle');
   const [renameValue, setRenameValue] = useState(title);
   const [busy, setBusy] = useState(false);
@@ -168,11 +174,26 @@ export const ChatSessionRailItem = ({
         onClick={() => onSelectSession(session)}
         title={title}
         aria-current={session.isCurrent ? 'page' : undefined}
+        aria-busy={pending ? true : undefined}
         disabled={disabled}
       >
-        {session.isPinned ? <PinIcon filled /> : <ListLinesIcon size={14} />}
-        <span className="chat-page-rail-item-text">
-          {session.preview ? <SessionTitle value={session.preview} /> : session.date}
+        {pending
+          ? <SpinnerIcon size={14} className="chat-spin" />
+          : session.isPinned ? <PinIcon filled /> : <ListLinesIcon size={14} />}
+        <span className="chat-page-rail-item-content">
+          <span className="chat-page-rail-item-text">
+            {session.preview ? <SessionTitle value={session.preview} /> : session.date}
+          </span>
+          <span className="chat-page-rail-item-meta">
+            <time
+              dateTime={Number.isFinite(updatedAt) ? new Date(updatedAt).toISOString() : undefined}
+              title={formatAbsoluteTime(updatedAt)}
+            >
+              {recency}
+            </time>
+            <span aria-hidden="true">·</span>
+            <span>{t('chat.toolCalls.messageCount', { count: session.messageCount })}</span>
+          </span>
         </span>
       </button>
       {hasActions && (

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatSessionsRail.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatSessionsRail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useMemo, useState } from 'react';
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import {
   ChevronRightIcon,
   PlusIcon,
@@ -13,6 +13,7 @@ export interface UnifiedSession {
   workspaceId: string;
   workspaceName: string;
   date: string;
+  updatedAt?: number;
   messageCount: number;
   preview?: string;
   isCurrent?: boolean;
@@ -25,6 +26,8 @@ export interface ChatSessionsRailProps {
   loading?: boolean;
   /** Prevents session mutations/navigation while a thread pointer is changing. */
   disabled?: boolean;
+  /** Selected conversation whose thread is currently being opened. */
+  pendingSessionKey?: string | null;
   onNewSession: () => void | Promise<void>;
   onSelectSession: (session: UnifiedSession) => void;
   onRenameSession?: (session: UnifiedSession, title: string) => void | Promise<void>;
@@ -43,6 +46,7 @@ export const ChatSessionsRail = ({
   allSessions,
   loading = false,
   disabled = false,
+  pendingSessionKey = null,
   onNewSession,
   onSelectSession,
   onRenameSession,
@@ -74,6 +78,7 @@ export const ChatSessionsRail = ({
         ...group,
         sessions: group.sessions.slice().sort((left, right) => (
           Number(Boolean(right.isPinned)) - Number(Boolean(left.isPinned))
+          || (right.updatedAt ?? 0) - (left.updatedAt ?? 0)
           || right.date.localeCompare(left.date)
           || right.sessionId.localeCompare(left.sessionId)
         )),
@@ -93,17 +98,26 @@ export const ChatSessionsRail = ({
       return sessions.length > 0 ? [{ ...group, sessions }] : [];
     });
   }, [allSessionGroups, normalizedQuery]);
-  const activeGroupId = sessionGroups.find((group) => group.sessions.some((session) => session.isCurrent))?.id;
-  const openGroupId = activeGroupId ?? sessionGroups[0]?.id;
+  const activeGroupId = allSessionGroups.find((group) => group.sessions.some((session) => session.isCurrent))?.id;
+  const openGroupId = activeGroupId ?? allSessionGroups[0]?.id;
+  const allGroupIds = useMemo(() => allSessionGroups.map((group) => group.id), [allSessionGroups]);
   const [collapsedGroupIds, setCollapsedGroupIds] = useState<Set<string>>(() => new Set(
-    sessionGroups.filter((group) => group.id !== openGroupId).map((group) => group.id),
+    allGroupIds.filter((groupId) => groupId !== openGroupId),
   ));
+  const knownGroupIdsRef = useRef(new Set(allGroupIds));
   useEffect(() => {
-    if (!openGroupId) return;
-    setCollapsedGroupIds(new Set(
-      sessionGroups.filter((group) => group.id !== openGroupId).map((group) => group.id),
-    ));
-  }, [openGroupId, sessionGroups]);
+    const knownGroupIds = knownGroupIdsRef.current;
+    const nextGroupIds = new Set(allGroupIds);
+    setCollapsedGroupIds((current) => {
+      const next = new Set([...current].filter((groupId) => nextGroupIds.has(groupId)));
+      for (const groupId of allGroupIds) {
+        if (!knownGroupIds.has(groupId) && groupId !== openGroupId) next.add(groupId);
+      }
+      if (openGroupId) next.delete(openGroupId);
+      return next;
+    });
+    knownGroupIdsRef.current = nextGroupIds;
+  }, [allGroupIds, openGroupId]);
   const toggleGroup = (groupId: string) => {
     setCollapsedGroupIds((current) => {
       const next = new Set(current);
@@ -114,7 +128,11 @@ export const ChatSessionsRail = ({
   };
 
   return (
-    <aside className="chat-page-rail" aria-label={t('chat.sessionList')}>
+    <aside
+      className="chat-page-rail"
+      aria-label={t('chat.sessionList')}
+      aria-busy={pendingSessionKey ? true : undefined}
+    >
       <button
         type="button"
         className="chat-page-rail-new"
@@ -181,6 +199,7 @@ export const ChatSessionsRail = ({
                         onDeleteSession={onDeleteSession}
                         onTogglePinSession={onTogglePinSession}
                         disabled={disabled}
+                        pending={pendingSessionKey === `${session.workspaceId}:${session.sessionId}`}
                       />
                     </div>
                   ))}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatConversationStatus.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatConversationStatus.test.tsx
@@ -48,6 +48,27 @@ describe('ChatConversationStatus', () => {
     act(() => root.unmount());
   });
 
+  it('does not insert an opening banner when the session rail already shows the pending conversation', () => {
+    const host = document.createElement('div');
+    const root = createRoot(host);
+    act(() => root.render(
+      <I18nProvider>
+        <ChatConversationStatus
+          sessionLoading
+          hasMessages
+          sessionLoadingFeedback="external"
+          sessionError={{ message: 'Session unavailable' }}
+        />
+      </I18nProvider>,
+    ));
+
+    expect(host.querySelector('[role="status"]')).toBeNull();
+    expect(host.textContent).not.toContain('Opening conversation');
+    expect(host.querySelector('[role="alert"]')?.textContent).toContain('Session unavailable');
+
+    act(() => root.unmount());
+  });
+
   it('shows a conversation update failure without exposing implementation details', () => {
     const host = document.createElement('div');
     const root = createRoot(host);

--- a/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatNewSession.focus.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatNewSession.focus.test.tsx
@@ -40,6 +40,7 @@ const RailHarness = ({ createSession, initiallyAdopted = false }: RailHarnessPro
     otherSessions: [],
     selectedSessionKey: null,
     sessions: [],
+    sessionsStoreId: 'workspace-a',
     disabled: false,
     focusInput: () => composerRef.current?.focus(),
     handleNewSession,

--- a/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatSessionsRail.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatSessionsRail.test.tsx
@@ -142,6 +142,40 @@ describe('ChatSessionsRail workspace tree', () => {
     expect(host.querySelector('.chat-page-rail-item--active')?.textContent).toContain('Second conversation');
   });
 
+  it('preserves manually expanded folders when the current session changes', async () => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    const renderRail = async (value: UnifiedSession[]) => {
+      await act(async () => {
+        root?.render(
+          <I18nProvider>
+            <ChatSessionsRail
+              allSessions={value}
+              onNewSession={vi.fn()}
+              onSelectSession={vi.fn()}
+            />
+          </I18nProvider>,
+        );
+      });
+    };
+
+    await renderRail(sessions.map((session) => ({
+      ...session,
+      isCurrent: session.sessionId === 'session-a',
+    })));
+    let folders = Array.from(host.querySelectorAll<HTMLButtonElement>('.chat-page-rail-folder'));
+    await act(async () => folders[1].click());
+    expect(folders[1].getAttribute('aria-expanded')).toBe('true');
+
+    await renderRail(sessions.map((session) => ({
+      ...session,
+      isCurrent: session.sessionId === 'session-b',
+    })));
+    folders = Array.from(host.querySelectorAll<HTMLButtonElement>('.chat-page-rail-folder'));
+    expect(folders[1].getAttribute('aria-expanded')).toBe('true');
+  });
+
   it('always places Global Chat before workspace folders', async () => {
     host = document.createElement('div');
     document.body.appendChild(host);
@@ -160,6 +194,64 @@ describe('ChatSessionsRail workspace tree', () => {
     });
 
     expect(host.querySelector('.chat-page-rail-folder-name')?.textContent).toBe('Global Chat');
+  });
+
+  it('orders same-day sessions by their precise update time', async () => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+
+    await act(async () => {
+      root?.render(
+        <I18nProvider>
+          <ChatSessionsRail
+            allSessions={[
+              { ...sessions[0], sessionId: 'session-z', preview: 'Older', updatedAt: 100 },
+              { ...sessions[0], sessionId: 'session-a', preview: 'Newer', updatedAt: 200 },
+            ]}
+            onNewSession={vi.fn()}
+            onSelectSession={vi.fn()}
+          />
+        </I18nProvider>,
+      );
+    });
+
+    expect(Array.from(
+      host.querySelectorAll('.chat-page-rail-item-text'),
+      (node) => node.textContent,
+    )).toEqual(['Newer', 'Older']);
+  });
+
+  it('shows recency and message count so repeated previews remain distinguishable', async () => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+
+    await act(async () => {
+      root?.render(
+        <I18nProvider>
+          <ChatSessionsRail
+            allSessions={[
+              { ...sessions[0], sessionId: 'repeat-a', preview: 'Repeated', updatedAt: 100, messageCount: 2 },
+              { ...sessions[0], sessionId: 'repeat-b', preview: 'Repeated', updatedAt: 200, messageCount: 9 },
+            ]}
+            onNewSession={vi.fn()}
+            onSelectSession={vi.fn()}
+          />
+        </I18nProvider>,
+      );
+    });
+
+    const metadata = Array.from(
+      host.querySelectorAll('.chat-page-rail-item-meta'),
+      (node) => node.textContent,
+    );
+    expect(metadata).toHaveLength(2);
+    expect(metadata).toEqual(expect.arrayContaining([
+      expect.stringContaining('2 msgs'),
+      expect.stringContaining('9 msgs'),
+    ]));
+    expect(host.querySelectorAll('.chat-page-rail-item-meta time')).toHaveLength(2);
   });
 
   it('opens the active folder and collapses other folders by default', async () => {
@@ -330,5 +422,33 @@ describe('ChatSessionsRail workspace tree', () => {
     expect(host.querySelector<HTMLInputElement>('.chat-page-rail-search')?.disabled).toBe(true);
     expect(host.querySelector<HTMLButtonElement>('.chat-page-rail-folder')?.disabled).toBe(true);
     expect(host.querySelector<HTMLButtonElement>('.chat-page-rail-item')?.disabled).toBe(true);
+  });
+
+  it('keeps the list visible and marks the selected conversation busy while it opens', async () => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+
+    await act(async () => {
+      root?.render(
+        <I18nProvider>
+          <ChatSessionsRail
+            allSessions={sessions.map((session) => ({
+              ...session,
+              isCurrent: session.sessionId === 'session-a',
+            }))}
+            disabled
+            pendingSessionKey="workspace-a:session-a"
+            onNewSession={vi.fn()}
+            onSelectSession={vi.fn()}
+          />
+        </I18nProvider>,
+      );
+    });
+
+    expect(host.querySelector('.chat-page-rail')?.getAttribute('aria-busy')).toBe('true');
+    expect(host.querySelector('.chat-page-rail-item--active')?.getAttribute('aria-busy')).toBe('true');
+    expect(host.querySelector('.chat-page-rail-item--active .chat-spin')).not.toBeNull();
+    expect(host.textContent).toContain('Second conversation');
   });
 });

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/sessionListGroups.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/sessionListGroups.ts
@@ -1,0 +1,30 @@
+import type { CrossWorkspaceSessionGroup } from '../../../../../shared/agent-chat';
+import type { OtherWorkspaceSession } from '../types';
+
+export function partitionSessionGroups(
+  groups: CrossWorkspaceSessionGroup[],
+  currentStoreId: string,
+) {
+  const otherSessions: OtherWorkspaceSession[] = [];
+  const currentGroup = groups.find(group => group.workspaceId === currentStoreId);
+  for (const group of groups) {
+    if (group === currentGroup) continue;
+    for (const session of group.sessions) {
+      otherSessions.push({
+        ...session,
+        sourceWorkspaceId: group.workspaceId,
+        workspaceName: group.workspaceName,
+      });
+    }
+  }
+  otherSessions.sort((left, right) => {
+    const leftUpdatedAt = left.updatedAt ?? (Date.parse(left.date) || 0);
+    const rightUpdatedAt = right.updatedAt ?? (Date.parse(right.date) || 0);
+    return rightUpdatedAt - leftUpdatedAt;
+  });
+  return {
+    sessions: currentGroup?.sessions ?? [],
+    currentScopeName: currentGroup?.workspaceName ?? null,
+    otherSessions,
+  };
+}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatPageSessionRail.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatPageSessionRail.ts
@@ -18,6 +18,8 @@ interface Options {
   otherSessions: OtherWorkspaceSession[];
   selectedSessionKey: string | null;
   sessions: AgentSessionInfo[];
+  sessionsStoreId: string;
+  pendingSessionKey?: string | null;
   disabled: boolean;
   focusInput: () => void;
   handleNewSession: () => Promise<{ ok: boolean }>;
@@ -36,6 +38,8 @@ export const useChatPageSessionRail = ({
   otherSessions,
   selectedSessionKey,
   sessions,
+  sessionsStoreId,
+  pendingSessionKey,
   disabled,
   focusInput,
   handleNewSession,
@@ -53,6 +57,7 @@ export const useChatPageSessionRail = ({
     otherSessions,
     selectedSessionKey,
     sessions,
+    sessionsStoreId,
   });
   const onNewSession = useCallback(async () => {
     if (disabled) return;
@@ -82,6 +87,7 @@ export const useChatPageSessionRail = ({
     allSessions,
     loading: sessionsLoading,
     disabled,
+    pendingSessionKey,
     onNewSession,
     onSelectSession: onSelect,
     onRenameSession: onRename,

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatSessions.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatSessions.test.tsx
@@ -6,6 +6,7 @@ import type { AgentChatMessage, AgentSessionInfo } from '../../../types';
 import type { AgentScope } from '../types';
 import { I18nProvider } from '../../../i18n';
 import { resetChatSessionsCacheForTests, useChatSessions } from './useChatSessions';
+import { useChatPageSessionRail } from './useChatPageSessionRail';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -38,7 +39,7 @@ function makeAgentMocks() {
     listSessions: vi.fn<[], Promise<{ ok: boolean; sessions: AgentSessionInfo[] }>>(
       async () => ({ ok: true, sessions: [] }),
     ),
-    listAllSessions: vi.fn(async () => ({ ok: true, groups: [] })),
+    listAllSessions: vi.fn(async (): Promise<{ ok: boolean; groups: any[] }> => ({ ok: true, groups: [] })),
   };
 }
 
@@ -60,6 +61,7 @@ function message(content: string): AgentChatMessage {
 let root: Root | null = null;
 let host: HTMLDivElement | null = null;
 let latest: Hook | null = null;
+let latestRailWorkspaceIds: string[] = [];
 let onMessagesLoaded: ReturnType<typeof vi.fn>;
 let agent: ReturnType<typeof makeAgentMocks>;
 
@@ -113,10 +115,119 @@ afterEach(() => {
   root = null;
   host = null;
   latest = null;
+  latestRailWorkspaceIds = [];
   vi.restoreAllMocks();
 });
 
 describe('useChatSessions — session detail loading', () => {
+
+  it('keeps the unified rail grouped by its committed scopes during a cross-scope thread load', async () => {
+    const workspace = { id: 'workspace-a', name: 'Workspace A' };
+    const thread = deferred<ThreadResult>();
+    agent.listSessions.mockResolvedValue({
+      ok: true,
+      sessions: [{
+        sessionId: 'global-session',
+        date: '2026-08-08',
+        messageCount: 1,
+        preview: 'Global session',
+        isCurrent: true,
+      }],
+    });
+    agent.listAllSessions.mockResolvedValue({
+      ok: true,
+      groups: [
+        {
+          workspaceId: '__global_chat__',
+          workspaceName: 'Global Chat',
+          sessions: [{
+            sessionId: 'global-session',
+            date: '2026-08-08',
+            messageCount: 1,
+            preview: 'Global session',
+            isCurrent: true,
+          }],
+        },
+        {
+          workspaceId: workspace.id,
+          workspaceName: workspace.name,
+          sessions: [{
+            sessionId: 'workspace-session',
+            date: '2026-08-07',
+            messageCount: 1,
+            preview: 'Workspace session',
+            isCurrent: false,
+          }],
+        },
+      ],
+    });
+    agent.loadSession.mockReturnValue(thread.promise);
+    const workspaces = [workspace];
+    const focusInput = vi.fn();
+    const onSelectSession = vi.fn();
+
+    const RailProbe = ({ scope, pending }: { scope: AgentScope; pending: boolean }) => {
+      const state = useChatSessions({
+        agentScope: scope,
+        allWorkspaces: workspaces,
+        onMessagesLoaded,
+        eagerLoad: true,
+        skipInitialHistory: pending,
+      });
+      latest = state;
+      const rail = useChatPageSessionRail({
+        agentScope: scope,
+        allWorkspaces: workspaces,
+        currentScopeName: state.currentScopeName,
+        sessionsLoading: state.sessionsLoading,
+        otherSessions: state.otherSessions,
+        selectedSessionKey: pending ? `${workspace.id}:workspace-session` : '__global_chat__:global-session',
+        sessions: state.sessions,
+        sessionsStoreId: state.sessionsStoreId,
+        disabled: false,
+        focusInput,
+        handleNewSession: state.handleNewSession,
+        onSelectSession,
+        renameSession: state.renameSession,
+        deleteSession: state.deleteSession,
+        toggleSessionPinned: state.toggleSessionPinned,
+      });
+      latestRailWorkspaceIds = [...new Set(rail.allSessions.map((session) => session.workspaceId))];
+      return null;
+    };
+
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    await act(async () => {
+      root?.render(
+        <I18nProvider>
+          <RailProbe scope={{ kind: 'global' }} pending={false} />
+        </I18nProvider>,
+      );
+    });
+    expect(latestRailWorkspaceIds.sort()).toEqual(['__global_chat__', workspace.id].sort());
+
+    await act(async () => {
+      root?.render(
+        <I18nProvider>
+          <RailProbe scope={{ kind: 'workspace', workspaceId: workspace.id }} pending />
+        </I18nProvider>,
+      );
+    });
+    act(() => { void latest!.handleLoadSession('workspace-session'); });
+
+    expect(latestRailWorkspaceIds.sort()).toEqual(['__global_chat__', workspace.id].sort());
+
+    await act(async () => {
+      thread.resolve({
+        ok: true,
+        activeSessionId: 'workspace-session',
+        messages: [message('workspace thread')],
+      });
+      await thread.promise;
+    });
+  });
   it('is loading from the first paint until the mount history fetch settles', async () => {
     const history = deferred<ThreadResult>();
     agent.getHistory.mockReturnValue(history.promise);
@@ -305,6 +416,59 @@ describe('useChatSessions — session detail loading', () => {
     expect(agent.listSessions).toHaveBeenCalledTimes(2);
   });
 
+  it('uses the all-sessions response as the single list source for the full-page rail', async () => {
+    const workspaces = [{ id: 'workspace-a', name: 'Workspace A' }];
+    const scope = { kind: 'global' } as const;
+    agent.listAllSessions.mockResolvedValue({
+      ok: true,
+      groups: [
+        {
+          workspaceId: '__global_chat__',
+          workspaceName: 'Global Chat',
+          sessions: [{
+            sessionId: 'global-current',
+            date: '2026-08-08',
+            messageCount: 1,
+            preview: 'Global current',
+            isCurrent: true,
+          }],
+        },
+        {
+          workspaceId: 'workspace-a',
+          workspaceName: 'Workspace A',
+          sessions: [{
+            sessionId: 'workspace-session',
+            date: '2026-08-07',
+            messageCount: 1,
+            preview: 'Workspace session',
+            isCurrent: false,
+          }],
+        },
+      ],
+    });
+
+    const FullPageProbe = () => {
+      latest = useChatSessions({
+        agentScope: scope,
+        allWorkspaces: workspaces,
+        onMessagesLoaded,
+        eagerLoad: true,
+      });
+      return null;
+    };
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    await act(async () => {
+      root?.render(<I18nProvider><FullPageProbe /></I18nProvider>);
+    });
+
+    expect(agent.listAllSessions).toHaveBeenCalledTimes(1);
+    expect(agent.listSessions).not.toHaveBeenCalled();
+    expect(latest?.sessions.map((session) => session.sessionId)).toEqual(['global-current']);
+    expect(latest?.otherSessions.map((session) => session.sessionId)).toEqual(['workspace-session']);
+  });
+
   it('adopts the replacement thread after deleting the active session', async () => {
     await mount();
     onMessagesLoaded.mockClear();
@@ -464,12 +628,10 @@ describe('useChatSessions — session detail loading', () => {
     expect(onMessagesLoaded).toHaveBeenCalledWith([]);
   });
 
-  it('commits the current and cross-workspace session lists atomically', async () => {
-    const currentList = deferred<any>();
+  it('commits the unified current and cross-workspace session response atomically', async () => {
     const allList = deferred<any>();
     const listWorkspaces = [{ id: 'workspace-a', name: 'Workspace A' }];
     const listScope = { kind: 'global' } as const;
-    agent.listSessions.mockReturnValue(currentList.promise);
     agent.listAllSessions.mockReturnValue(allList.promise);
     const ListProbe = () => {
       latest = useChatSessions({
@@ -487,16 +649,6 @@ describe('useChatSessions — session detail loading', () => {
       root?.render(<I18nProvider><ListProbe /></I18nProvider>);
     });
 
-    currentList.resolve({
-      ok: true,
-      sessions: [{
-        sessionId: 'global-a',
-        date: '2026-07-29',
-        messageCount: 1,
-        preview: 'Global A',
-        isCurrent: true,
-      }],
-    });
     await Promise.resolve();
     expect(latest?.sessions).toEqual([]);
     expect(latest?.otherSessions).toEqual([]);
@@ -504,18 +656,31 @@ describe('useChatSessions — session detail loading', () => {
     await act(async () => {
       allList.resolve({
         ok: true,
-        groups: [{
-          workspaceId: 'workspace-a',
-          workspaceName: 'Workspace A',
-          sessions: [{
-            sessionId: 'workspace-a-1',
-            date: '2026-07-29',
-            messageCount: 1,
-            preview: 'Workspace A session',
-          }],
-        }],
+        groups: [
+          {
+            workspaceId: '__global_chat__',
+            workspaceName: 'Global Chat',
+            sessions: [{
+              sessionId: 'global-a',
+              date: '2026-07-29',
+              messageCount: 1,
+              preview: 'Global A',
+              isCurrent: true,
+            }],
+          },
+          {
+            workspaceId: 'workspace-a',
+            workspaceName: 'Workspace A',
+            sessions: [{
+              sessionId: 'workspace-a-1',
+              date: '2026-07-29',
+              messageCount: 1,
+              preview: 'Workspace A session',
+            }],
+          },
+        ],
       });
-      await Promise.all([currentList.promise, allList.promise]);
+      await allList.promise;
     });
 
     expect(latest?.sessions).toHaveLength(1);

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatSessions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatSessions.ts
@@ -11,6 +11,7 @@ import {
   invalidateChatConversationMutation,
   type ChatConversationMutationRef,
 } from './chatConversationMutation';
+import { partitionSessionGroups } from './sessionListGroups';
 
 interface UseChatSessionsOptions {
   agentScope: AgentScope;
@@ -79,6 +80,10 @@ export function useChatSessions({
   );
   const [otherSessions, setOtherSessions] = useState<OtherWorkspaceSession[]>(
     () => sessionsCache.get(scopeKey)?.otherSessions ?? [],
+  );
+  // Keep list ownership explicit while a cross-scope thread is opening.
+  const [sessionsStoreId, setSessionsStoreId] = useState(
+    () => scopeSessionStoreId(agentScope),
   );
   const [currentScopeName, setCurrentScopeName] = useState<string | null>(null);
   // Avoid an empty-state flash before an eager first list fetch.
@@ -217,51 +222,37 @@ export function useChatSessions({
     const token = ++sessionListRequestRef.current;
     setSessionsLoading(true);
     try {
+      const currentStoreId = scopeSessionStoreId(agentScope);
       const workspaceNameMap: Record<string, string> = {};
       for (const workspace of allWorkspaces ?? []) {
         workspaceNameMap[workspace.id] = workspace.name;
       }
-      const [result, allResult] = await Promise.all([
-        window.canvasWorkspace.agent.listSessions({ scope: agentScope }),
-        allWorkspaces
-          ? window.canvasWorkspace.agent.listAllSessions(workspaceNameMap)
-          : Promise.resolve(null),
-      ]);
+      // The all-sessions response already contains the current scope. Asking
+      // for both APIs made the full-page rail scan that store redundantly and
+      // then reconcile two snapshots from the same mutation boundary.
+      const result = allWorkspaces
+        ? null
+        : await window.canvasWorkspace.agent.listSessions({ scope: agentScope });
+      const allResult = allWorkspaces
+        ? await window.canvasWorkspace.agent.listAllSessions(workspaceNameMap)
+        : null;
       if (token !== sessionListRequestRef.current) return;
       let nextSessions: AgentSessionInfo[] | undefined;
       let nextOtherSessions: OtherWorkspaceSession[] | undefined;
       let nextCurrentScopeName: string | null | undefined;
 
-      if (result.ok && result.sessions) {
+      if (result?.ok && result.sessions) {
         nextSessions = result.sessions;
         setActiveSessionId(result.sessions.find(session => session.isCurrent)?.sessionId ?? null);
       }
 
       if (allResult) {
         if (allResult.ok && allResult.groups) {
-          nextCurrentScopeName = null;
-          // Groups are keyed by session-STORE id, which is the workspace id
-          // only for workspace scopes; global chat and each scheduled task
-          // have their own sentinel store. Dedupe on the store id so the
-          // current scope is never listed twice.
-          const currentStoreId = scopeSessionStoreId(agentScope);
-          const flattened: OtherWorkspaceSession[] = [];
-          for (const group of allResult.groups) {
-            if (group.workspaceId === currentStoreId) {
-              nextCurrentScopeName = group.workspaceName;
-              continue;
-            }
-            for (const session of group.sessions) {
-              flattened.push({
-                ...session,
-                sourceWorkspaceId: group.workspaceId,
-                workspaceName: group.workspaceName,
-              });
-            }
-          }
-
-          flattened.sort((left, right) => right.date.localeCompare(left.date));
-          nextOtherSessions = flattened;
+          const partitioned = partitionSessionGroups(allResult.groups, currentStoreId);
+          nextSessions = partitioned.sessions;
+          nextOtherSessions = partitioned.otherSessions;
+          nextCurrentScopeName = partitioned.currentScopeName;
+          setActiveSessionId(nextSessions.find(session => session.isCurrent)?.sessionId ?? null);
         }
       } else {
         nextOtherSessions = [];
@@ -270,7 +261,10 @@ export function useChatSessions({
       // Commit the two halves together. Updating `sessions` before
       // `otherSessions` briefly duplicated the promoted session and rebuilt
       // the folder tree around the pointer.
-      if (nextSessions) setSessions(nextSessions);
+      if (nextSessions) {
+        setSessions(nextSessions);
+        setSessionsStoreId(scopeSessionStoreId(agentScope));
+      }
       if (nextOtherSessions) setOtherSessions(nextOtherSessions);
       if (nextCurrentScopeName !== undefined) {
         setCurrentScopeName(nextCurrentScopeName);
@@ -479,6 +473,7 @@ export function useChatSessions({
   return {
     adoptActiveSession,
     otherSessions,
+    sessionsStoreId,
     activeSessionId,
     currentScopeName,
     deleteSession,

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useStableSessionRail.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useStableSessionRail.ts
@@ -12,6 +12,7 @@ interface UseStableSessionRailOptions {
   otherSessions: OtherWorkspaceSession[];
   selectedSessionKey: string | null;
   sessions: AgentSessionInfo[];
+  sessionsStoreId: string;
 }
 
 /**
@@ -28,25 +29,28 @@ export function useStableSessionRail({
   otherSessions,
   selectedSessionKey,
   sessions,
+  sessionsStoreId,
 }: UseStableSessionRailOptions): UnifiedSession[] {
   const stableSessionsRef = useRef<UnifiedSession[]>([]);
   const stableScopeRef = useRef(scopeSessionStoreId(agentScope));
   const computedSessions = useMemo(() => {
-    const storeId = scopeSessionStoreId(agentScope);
-    const workspaceId = agentScope.kind === 'workspace' ? agentScope.workspaceId : undefined;
+    const activeStoreId = scopeSessionStoreId(agentScope);
+    const workspaceId = sessionsStoreId === activeStoreId && agentScope.kind === 'workspace'
+      ? agentScope.workspaceId
+      : sessionsStoreId;
     const workspaceName = currentScopeName
-      ?? (workspaceId
-        ? allWorkspaces.find((workspace) => workspace.id === workspaceId)?.name ?? workspaceId
-        : 'Global Chat');
+      ?? (sessionsStoreId === '__global_chat__'
+        ? 'Global Chat'
+        : allWorkspaces.find((workspace) => workspace.id === workspaceId)?.name ?? workspaceId);
     const unified: UnifiedSession[] = [
       ...sessions.map((session) => ({
         ...session,
         preview: session.title ?? session.preview,
         isPinned: session.pinned,
-        workspaceId: storeId,
+        workspaceId: sessionsStoreId,
         workspaceName,
         isCurrent: selectedSessionKey
-          ? selectedSessionKey === `${storeId}:${session.sessionId}`
+          ? selectedSessionKey === `${sessionsStoreId}:${session.sessionId}`
           : session.isCurrent,
       })),
       ...otherSessions.map((session) => ({
@@ -54,6 +58,7 @@ export function useStableSessionRail({
         workspaceId: session.sourceWorkspaceId,
         workspaceName: session.workspaceName,
         date: session.date,
+        updatedAt: session.updatedAt,
         messageCount: session.messageCount,
         preview: session.title ?? session.preview,
         isPinned: session.pinned,
@@ -62,10 +67,11 @@ export function useStableSessionRail({
       })),
     ];
     return unified.sort((left, right) => (
-      right.date.localeCompare(left.date)
+      (right.updatedAt ?? 0) - (left.updatedAt ?? 0)
+      || right.date.localeCompare(left.date)
       || right.sessionId.localeCompare(left.sessionId)
     ));
-  }, [agentScope, allWorkspaces, currentScopeName, otherSessions, selectedSessionKey, sessions]);
+  }, [agentScope, allWorkspaces, currentScopeName, otherSessions, selectedSessionKey, sessions, sessionsStoreId]);
 
   return useMemo(() => {
     const nextScopeId = scopeSessionStoreId(agentScope);

--- a/apps/canvas-workspace/src/shared/agent-chat.ts
+++ b/apps/canvas-workspace/src/shared/agent-chat.ts
@@ -397,6 +397,7 @@ export interface AgentTurnContextSnapshot {
 export interface AgentSessionInfo {
   sessionId: string;
   date: string;
+  updatedAt?: number;
   messageCount: number;
   isCurrent: boolean;
   preview?: string;


### PR DESCRIPTION
## What changed

- keep the full-page AI Chat session rail structurally stable across same-scope and cross-scope conversation switches
- preserve manually expanded workspace folders and rail scroll context
- use the unified all-sessions response as the single list source for the full-page rail
- avoid re-scanning active session stores and sort sessions/groups by precise message recency
- keep conversation loading non-visual in the rail: no whole-rail dimming and no transient selected-row spinner
- simplify session rows to a title-only layout by removing the leading icon and recency/message-count columns
- suppress the in-flow “Opening conversation…” banner on the full-page surface so fast switches do not shift the entire thread
- document the stable session-rail contract and add focused regression coverage

## Why

Conversation switching could briefly re-label stale sessions under the destination scope, collapse the rail from multiple folders into one, reset user expansion state, and then rebuild it after the list refresh. Separately, the full-page loading banner occupied 44px in normal flow for one or two frames, visibly pushing the thread down and back up.

A remaining flash came from disabling the whole rail during session loading (the shared disabled style reduced opacity to 0.5) and temporarily replacing the selected row's icon with a spinner. The unified rail now tracks the store that produced its committed session list, preserves user-controlled folder state, and exposes pending state through `aria-busy` without changing the visible row geometry.

## User impact

- no transient 2 → 1 → 2 folder regrouping during cross-workspace switches
- no full-thread vertical flash from the opening banner
- no rail opacity or selected-row spinner flash during conversation switches
- stable scroll position and manually expanded folders
- cleaner, title-only session rows
- less redundant session-store scanning

## Validation

- user verified the final interaction in the app
- real Electron clone regression: cross-workspace switch stayed at 2 folders, 52 rows, and scrollTop 600 throughout
- real Electron DOM sampling after the final fix: 149 samples; opacity stayed at 1, no spinner mounted, leading-icon and metadata counts stayed at 0, and folder/row counts stayed at 2/52
- `pnpm --filter canvas-workspace typecheck`
- `pnpm --filter canvas-workspace build`
- Canvas standard harness: 4/4 checks passed
- full Canvas test suite: 377 files / 2360 tests passed
- harness coverage: `harnessGaps: 0`
- `git diff --check`
