### PR TITLE
feat(cli): allow disabling print timeout

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -74,7 +74,7 @@ pulse-coder -p --isolated --timeout 1200 --max-steps 100 --max-tokens 500000 \
   --output-format jsonl --trace-file ./trace.jsonl "fix the issue"
 ```
 
-`-p` 文本模式下引擎/插件日志走 stderr，stdout 只包含回答文本，方便管道消费。`--output-format jsonl` 改为逐行输出 `run_start`、工具、step、压缩与 `run_end` 事件；`--trace-file` 可在文本或 JSONL 模式下额外保存同一轨迹。`--isolated` 关闭 memory、用户配置、外部插件扫描及会发现/持久化用户状态的内建插件，保留核心工具、plan-mode 和 CLI `run_js`，用于可重复的 benchmark 运行。文件系统、网络与进程树的硬隔离仍由 Harbor/SWE-bench 的每题容器负责。超时退出码为 124，SIGINT/SIGTERM 分别为 130/143，token 或 step 预算耗尽为 2。
+`-p` 文本模式下引擎/插件日志走 stderr，stdout 只包含回答文本，方便管道消费。`--output-format jsonl` 改为逐行输出 `run_start`、工具、step、压缩与 `run_end` 事件；`--trace-file` 可在文本或 JSONL 模式下额外保存同一轨迹。`--isolated` 关闭 memory、用户配置、外部插件扫描及会发现/持久化用户状态的内建插件，保留核心工具、plan-mode 和 CLI `run_js`，用于可重复的 benchmark 运行。文件系统、网络与进程树的硬隔离仍由 Harbor/SWE-bench 的每题容器负责。`--timeout 0` 可关闭 CLI 内部计时器；benchmark harness 仍应设置外层硬超时，避免 endpoint 永久挂起。超时退出码为 124，SIGINT/SIGTERM 分别为 130/143，token 或 step 预算耗尽为 2。
 
 Harbor/SWE-bench 的自定义 agent、容器内本地源码安装和对比运行方法见 [`harness/tools/harbor/README.md`](harness/tools/harbor/README.md)。CLI 无需先发布到 npm；adapter 会上传当前已提交的 Git `HEAD`。
 

--- a/packages/cli/src/ui-mode.test.ts
+++ b/packages/cli/src/ui-mode.test.ts
@@ -81,10 +81,18 @@ describe('parseCliArgs', () => {
   });
 
   it('rejects invalid benchmark controls', () => {
-    expect(() => parseCliArgs(['-p', '--timeout', '0', 'hi'], {}, true)).toThrow('--timeout');
+    expect(() => parseCliArgs(['-p', '--timeout', '-1', 'hi'], {}, true)).toThrow('--timeout');
     expect(() => parseCliArgs(['-p', '--max-steps=nope', 'hi'], {}, true)).toThrow('--max-steps');
     expect(() => parseCliArgs(['-p', '--output-format', 'xml', 'hi'], {}, true)).toThrow('--output-format');
     expect(() => parseCliArgs(['-p', '--trace-file'], {}, true)).toThrow('--trace-file');
     expect(() => parseCliArgs(['--isolated'], {}, true)).toThrow('require -p');
+  });
+
+  it('accepts zero timeout as an explicit request to disable the CLI timer', () => {
+    expect(parseCliArgs(['-p', '--timeout', '0', 'hi'], {}, true)).toMatchObject({
+      print: true,
+      prompt: 'hi',
+      timeoutSeconds: 0,
+    });
   });
 });

--- a/packages/cli/src/ui-mode.ts
+++ b/packages/cli/src/ui-mode.ts
@@ -23,6 +23,14 @@ function positiveIntegerFlag(flag: string, value: string | undefined): number {
   return parsed;
 }
 
+function nonNegativeIntegerFlag(flag: string, value: string | undefined): number {
+  const parsed = Number(value);
+  if (!value || !Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${flag} requires a non-negative integer`);
+  }
+  return parsed;
+}
+
 function requiredFlagValue(flag: string, value: string | undefined): string {
   if (!value || value.startsWith('-')) {
     throw new Error(`${flag} requires a value`);
@@ -151,7 +159,9 @@ export function parseCliArgs(
     }
     if (arg === '--timeout' || arg === '--max-steps' || arg === '--max-tokens') {
       const value = args[index + 1];
-      const parsed = positiveIntegerFlag(arg, value);
+      const parsed = arg === '--timeout'
+        ? nonNegativeIntegerFlag(arg, value)
+        : positiveIntegerFlag(arg, value);
       hasPrintOnlyOption = true;
       if (arg === '--timeout') timeoutSeconds = parsed;
       if (arg === '--max-steps') maxSteps = parsed;
@@ -161,7 +171,7 @@ export function parseCliArgs(
     }
     if (arg.startsWith('--timeout=')) {
       hasPrintOnlyOption = true;
-      timeoutSeconds = positiveIntegerFlag('--timeout', arg.slice('--timeout='.length));
+      timeoutSeconds = nonNegativeIntegerFlag('--timeout', arg.slice('--timeout='.length));
       continue;
     }
     if (arg.startsWith('--max-steps=')) {
@@ -219,7 +229,7 @@ export function parseCliArgs(
     verbose,
     ...(model ? { model } : {}),
     ...(isolated ? { isolated } : {}),
-    ...(timeoutSeconds ? { timeoutSeconds } : {}),
+    ...(timeoutSeconds !== undefined ? { timeoutSeconds } : {}),
     ...(maxSteps ? { maxSteps } : {}),
     ...(maxTokens ? { maxTokens } : {}),
     ...(outputFormat ? { outputFormat } : {}),


### PR DESCRIPTION
## Summary

- accept `--timeout 0` in non-interactive print mode
- preserve the explicit zero through CLI argument parsing so no internal timer is created
- keep step and token budgets positive-only
- document that benchmark harnesses should retain an outer hard timeout

## Validation

- `pnpm --filter pulse-coder-cli test` (161 tests)
- `pnpm --filter pulse-coder-cli build`
- `node scripts/harness/run-harness-check.mjs --level standard`
- `pnpm run build`
- sequential core workspace test sweep