### PR TITLE
fix(cli): bound the streaming live region so the terminal stops flickering

### DIFF
--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -33,7 +33,7 @@ CLI behavior should remain a host layer over the engine. Engine runtime behavior
 | Memory integration | `src/memory-integration.ts` |
 | Host tool registration | `src/runtime-tools.ts`, `src/canvas-runtime-tools.ts`, `src/sandbox/`, `../canvas-cli/AGENTS.md` |
 | Harbor/SWE-bench evaluation | `harness/tools/harbor/README.md`, `harness/tools/harbor/pulse_agent.py` |
-| Focused behavior tests | `src/*.test.ts` |
+| Focused behavior tests | `src/*.test.ts`, `src/ink-app.render.test.tsx` (Ink frame height) |
 
 ## Local Constraints
 
@@ -68,7 +68,7 @@ CLI behavior should remain a host layer over the engine. Engine runtime behavior
 - Assistant text is two-tier: segments finalized because a tool call started are narration (`status: 'info'`, rendered gray, no markdown); only the segment that ends a run renders bright with markdown. The status line's TEXT stays stable during a run (`Running agent · <elapsed>`) — never write per-tool churn into `status`.
 - Terminal text math goes through `src/text-width.ts`: layout truncation measures DISPLAY COLUMNS (CJK/emoji are 2 wide) and cursor movement/deletion steps whole CODE POINTS. `String.length` is wrong for both — never clamp or step by it.
 - Usage counters are per-conversation state: `/new`, `/clear`, `/resume` and deleting the active session must all call `resetUsageCounters()`, or the status line keeps reporting the previous conversation's tokens.
-- Everything rendered BELOW `<Static>` must be bounded by terminal size on BOTH axes, and the axes are coupled — a row window is only correct if untruncated text cannot reflow. Detail + current bounds: `harness/knowledge/live-region-bounding.md`.
+- Everything rendered BELOW `<Static>` must be bounded by terminal size on BOTH axes, and the axes are coupled — a row window is only correct if it either truncates on columns or charges each line its wrapped height. A frame taller than the viewport makes Ink wipe the screen and replay the whole transcript on EVERY frame until it shrinks back, which at streaming rate is the terminal flicker. `src/ink-app.render.test.tsx` pins the frame height against a mock TTY. Detail + current bounds: `harness/knowledge/live-region-bounding.md`.
 - Session files live under `~/.pulse-coder/sessions`; keep local runtime data out of source control and preserve session task-list metadata.
 - Slash command changes should preserve session persistence, queued input, abort handling, and the clarification flow.
 - This package currently has no `typecheck` script; do not document or rely on `pnpm --filter pulse-coder-cli typecheck` until `package.json` adds it.

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -33,7 +33,8 @@ CLI behavior should remain a host layer over the engine. Engine runtime behavior
 | Memory integration | `src/memory-integration.ts` |
 | Host tool registration | `src/runtime-tools.ts`, `src/canvas-runtime-tools.ts`, `src/sandbox/`, `../canvas-cli/AGENTS.md` |
 | Harbor/SWE-bench evaluation | `harness/tools/harbor/README.md`, `harness/tools/harbor/pulse_agent.py` |
-| Focused behavior tests | `src/*.test.ts`, `src/ink-app.render.test.tsx` (Ink frame height) |
+| Focused behavior tests | `src/*.test.ts` |
+| Ink frame height / terminal paint | `src/ink-app.render.test.tsx`, `src/ink-app.screen.test.tsx` |
 
 ## Local Constraints
 
@@ -68,6 +69,8 @@ CLI behavior should remain a host layer over the engine. Engine runtime behavior
 - Assistant text is two-tier: segments finalized because a tool call started are narration (`status: 'info'`, rendered gray, no markdown); only the segment that ends a run renders bright with markdown. The status line's TEXT stays stable during a run (`Running agent · <elapsed>`) — never write per-tool churn into `status`.
 - Terminal text math goes through `src/text-width.ts`: layout truncation measures DISPLAY COLUMNS (CJK/emoji are 2 wide) and cursor movement/deletion steps whole CODE POINTS. `String.length` is wrong for both — never clamp or step by it.
 - Usage counters are per-conversation state: `/new`, `/clear`, `/resume` and deleting the active session must all call `resetUsageCounters()`, or the status line keeps reporting the previous conversation's tokens.
+- The Ink host renders with `incrementalRendering: true`: Ink's default writer erases and repaints the ENTIRE live block on every frame (measured: ~2x the lines and bytes of the incremental writer over a streaming answer), and at 30fps that repaint of the status line and bordered composer is visible as shimmer. `src/ink-app.screen.test.tsx` pins that the incremental writer paints the same screen as the default one.
+- A live region that shrinks must be compensated by matching `<Static>` output, or the composer walks UP the screen and leaves dead rows below it. Ink writes static output in place of the erased live block, so the normal finalize-into-transcript path is already neutral — `src/ink-app.screen.test.tsx` emulates a terminal across a bridge-driven run and fails if the composer jumps up more than a row. Do not "fix" this with reserved padding: holding a high-water height pins the composer mid-run but voids the screen and produces a far bigger jump when the reservation is released.
 - Everything rendered BELOW `<Static>` must be bounded by terminal size on BOTH axes, and the axes are coupled — a row window is only correct if it either truncates on columns or charges each line its wrapped height. A frame taller than the viewport makes Ink wipe the screen and replay the whole transcript on EVERY frame until it shrinks back, which at streaming rate is the terminal flicker. `src/ink-app.render.test.tsx` pins the frame height against a mock TTY. Detail + current bounds: `harness/knowledge/live-region-bounding.md`.
 - Session files live under `~/.pulse-coder/sessions`; keep local runtime data out of source control and preserve session task-list metadata.
 - Slash command changes should preserve session persistence, queued input, abort handling, and the clarification flow.

--- a/packages/cli/harness/knowledge/live-region-bounding.md
+++ b/packages/cli/harness/knowledge/live-region-bounding.md
@@ -4,21 +4,54 @@ Everything rendered BELOW Ink `<Static>` shares one screen with the composer, so
 every such region must be bounded by terminal size. An unbounded `.map()` there
 pushes the composer off screen. Check this when adding any live region.
 
+## Why it is a hard bound, not a nicety
+
+Ink does not merely scroll an over-tall frame. `shouldClearTerminalForFrame`
+(ink 7 `build/ink.js`) makes a frame taller than the viewport write
+`clearTerminal + fullStaticOutput + output` — a full-screen wipe plus a replay
+of the ENTIRE static transcript — and, because the rule also fires on
+`wasOverflowing`, it keeps doing that on every following frame until the output
+shrinks back under the viewport. At the streaming emit rate (33ms, see
+`InkUiBridge.textThrottleMs`) that reads as the terminal flickering and jumping.
+
+The streaming answer (`liveText`) was the region that hit this: it grew with the
+model's output until it outgrew the screen. It now takes only the rows the
+fixed-size regions leave over — `windowLiveTextLines()` in `ink-app.tsx` —
+and the full answer still reaches scrollback when the run finalizes it into
+`<Static>`. `src/ink-app.render.test.tsx` renders the real component into a
+mock TTY and asserts the frame height stays under the viewport (it measured
+207 rows on a 24-row terminal before the bound existed).
+
 ## The two axes are coupled
 
-Rows and columns are not independent budgets. A row window is only correct if
-every row is actually **one physical row** — Ink's default `wrap='wrap'` reflows
-long text onto extra rows, silently breaking a window that was computed assuming
-one row per item. So a region that windows on rows must ALSO truncate its text on
-columns.
+Rows and columns are not independent budgets. Ink's default `wrap='wrap'`
+reflows long text onto extra rows, so a window computed as one row per item is
+silently wrong the moment an item is wider than the terminal. There are exactly
+two correct resolutions, and every region must pick one:
+
+1. **Truncate on columns**, so each item really is one physical row — what the
+   tool labels, picker items and suggestion rows do.
+2. **Charge each item its wrapped height** via `wrappedRowCount()` — what
+   `liveText` does, because truncating streamed prose mid-sentence would be
+   worse than showing fewer lines of it.
+
+Greedy word wrap can need MORE rows than `ceil(width / columns)`
+(`'aaaaaa bbbbbb cccccc'` is three rows at 10 columns, not two), so option 2
+must simulate the wrap rather than divide. Undercounting is what puts the frame
+over the viewport.
 
 `pickerWindowSize` additionally divides by the real per-item height: a picker
 item that renders a preview costs two physical rows, not one.
+
+Wrapping applies to the fixed regions too, not just the windowed ones: the key
+hint and a long draft line each wrap on a narrow terminal, so the rows they are
+charged in the `liveText` budget go through `wrappedRowCount` as well.
 
 ## Current bounds
 
 | Region | Rows | Columns |
 |---|---|---|
+| `liveText` | `windowLiveTextLines`: whatever rows the fixed regions leave, with a "… N earlier lines" head; hidden entirely at zero | counted after wrapping (`wrappedRowCount`), not truncated — prose stays readable |
 | `liveTools` | windowed, with a "… N more running" tail | `truncateLabel(tool.label, terminalColumns - 4)` |
 | Picker items | `pickerWindowSize`, divided by per-item height | label / hint / preview each truncated to the bordered content width |
 | Slash suggestions | capped list length | description truncated against the command's width |
@@ -37,3 +70,7 @@ count bound so a long history cannot flood the transcript.
 All of it measures DISPLAY COLUMNS through `src/text-width.ts` (CJK and emoji are
 two columns wide), never `String.length`. Cursor movement and deletion step whole
 code points through the same module.
+
+Already-rendered text carries ANSI colour codes, which occupy no columns, so
+`stringWidth()` over-counts every styled line. `wrappedRowCount()` strips them
+before measuring; anything else measuring rendered output must do the same.

--- a/packages/cli/harness/knowledge/live-region-bounding.md
+++ b/packages/cli/harness/knowledge/live-region-bounding.md
@@ -22,6 +22,32 @@ and the full answer still reaches scrollback when the run finalizes it into
 mock TTY and asserts the frame height stays under the viewport (it measured
 207 rows on a 24-row terminal before the bound existed).
 
+## Height is not the only thing that reads as instability
+
+Two other effects get reported as "the terminal jumps", and they have different
+causes and different fixes. Measure before treating either as a bound problem.
+
+**Repaint churn.** Ink's default writer erases the whole live block and
+repaints it on every frame — over a streaming answer that measured ~2x the
+lines and bytes of the incremental writer, and at 30fps the status line and
+bordered composer visibly shimmer. `ink-launcher.tsx` therefore renders with
+`incrementalRendering: true`, which rewrites only the lines that changed.
+
+**Composer drift.** The composer sits at the end of the output, so it moves up
+the screen whenever the live region shrinks without matching `<Static>` output,
+leaving dead rows below it. Ink already compensates the normal path: on a frame
+with static output it erases the live block, writes the static rows into that
+same space, then repaints the (shorter) block, so finalizing a streamed segment
+into the transcript is geometry-neutral. Measured over a bridge-driven run, the
+composer's total upward movement is 2 rows — it does not bounce.
+
+Reserving a high-water height and padding the difference looks like the fix and
+is not: it pins the composer mid-run, but it voids most of the screen (the
+transcript gets squeezed into whatever rows the padding leaves) and turns the
+release at run end into a single jump far larger than the drift it removed.
+Measured: 2 rows of drift without the reservation, 13 with it.
+`ink-app.screen.test.tsx` emulates a terminal and pins this.
+
 ## The two axes are coupled
 
 Rows and columns are not independent budgets. Ink's default `wrap='wrap'`

--- a/packages/cli/src/ink-app.render.test.tsx
+++ b/packages/cli/src/ink-app.render.test.tsx
@@ -1,0 +1,197 @@
+import { EventEmitter } from 'node:events';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { InkCliApp, type InkCliController, type InkCliSnapshot } from './ink-app.js';
+
+/**
+ * Frame-height regression guard.
+ *
+ * Ink re-prints the whole screen (`clearTerminal` + a replay of the entire
+ * static transcript) for as long as the live frame is taller than the
+ * viewport — that full-screen wipe at streaming frame rate is the flicker
+ * these tests exist to prevent. So the assertion is on the physical height of
+ * what Ink actually writes, not on any single region's own bound.
+ */
+
+interface Viewport {
+  rows: number;
+  columns: number;
+}
+
+const DEFAULT_VIEWPORT: Viewport = { rows: 24, columns: 80 };
+
+class MockStdout extends EventEmitter {
+  isTTY = true;
+  readonly frames: string[] = [];
+
+  constructor(readonly columns: number, readonly rows: number) {
+    super();
+  }
+
+  write(data: string): boolean {
+    this.frames.push(data);
+    return true;
+  }
+
+  getWindowSize(): [number, number] {
+    return [this.columns, this.rows];
+  }
+}
+
+class MockStdin extends EventEmitter {
+  isTTY = true;
+  setRawMode(): void {}
+  resume(): void {}
+  pause(): void {}
+  setEncoding(): void {}
+  read(): null {
+    return null;
+  }
+  unref(): void {}
+  ref(): void {}
+}
+
+const baseSnapshot: InkCliSnapshot = {
+  sessionId: 'session-1',
+  taskListId: null,
+  mode: 'edit',
+  messages: 4,
+  estimatedTokens: 1200,
+  usageInputTokens: 1200,
+  usageOutputTokens: 400,
+  contextWindowTokens: 64000,
+  modelLabel: 'deepseek_v3',
+  queuedInputs: 0,
+  isProcessing: true,
+  status: 'Running agent',
+  phase: 'Using tool',
+  activeTool: 'bash',
+  toolCalls: 2,
+  completedTools: 1,
+  lastStep: null,
+  runStartedAt: 1_000,
+  picker: null,
+  skills: [],
+  fileIndex: [],
+  events: [],
+  liveText: '',
+  liveTools: [],
+};
+
+const streamedAnswer = (lines: number): string =>
+  Array.from({ length: lines }, (_, index) => `streamed line ${index}`).join('\n');
+
+const createController = (snapshot: InkCliSnapshot): InkCliController => ({
+  getSnapshot: () => snapshot,
+  submitInput: () => {},
+  requestStop: () => {},
+  shutdown: () => {},
+  subscribe: () => () => {},
+});
+
+/**
+ * Physical rows of the tallest frame Ink wrote, ANSI escapes excluded. Ink
+ * brackets each frame with cursor/sync writes, so the content frame is picked
+ * by height rather than by position.
+ */
+const frameHeight = (frames: string[]): number => Math.max(
+  0,
+  ...frames.map(frame => frame
+    .replace(/\x1b\[[0-9;?]*[A-Za-z]/g, '')
+    .replace(/\n$/, '')
+    .split('\n')
+    .length),
+);
+
+const renderFrame = async (snapshot: InkCliSnapshot, viewport: Viewport = DEFAULT_VIEWPORT) => {
+  const ink = await import('ink');
+  const stdout = new MockStdout(viewport.columns, viewport.rows);
+  const instance = ink.render(
+    <InkCliApp
+      controller={createController(snapshot)}
+      runtime={{
+        Box: ink.Box,
+        Text: ink.Text,
+        Static: ink.Static,
+        useApp: ink.useApp,
+        useInput: ink.useInput,
+        usePaste: ink.usePaste,
+        useStdout: ink.useStdout,
+      }}
+    />,
+    {
+      stdout: stdout as never,
+      stdin: new MockStdin() as never,
+      exitOnCtrlC: false,
+      patchConsole: false,
+    },
+  );
+
+  // Let React commit and Ink flush the frame.
+  await new Promise(resolve => setTimeout(resolve, 60));
+  const height = frameHeight(stdout.frames);
+  instance.unmount();
+  return height;
+};
+
+describe('InkCliApp frame height', () => {
+  it('keeps a long streamed answer under the viewport', async () => {
+    const height = await renderFrame({ ...baseSnapshot, liveText: streamedAnswer(200) });
+
+    expect(height).toBeLessThan(DEFAULT_VIEWPORT.rows);
+    // …and still uses the room it has: a window that collapsed to nothing would
+    // pass the bound above while showing no streaming output at all.
+    expect(height).toBeGreaterThan(10);
+  });
+
+  it('charges over-wide streamed lines their wrapped height', async () => {
+    // Every line reflows onto several rows: a budget counting one row per line
+    // would overflow here.
+    const liveText = Array.from({ length: 60 }, (_, index) => `${index} ${'wide '.repeat(50)}`).join('\n');
+
+    expect(await renderFrame({ ...baseSnapshot, liveText })).toBeLessThan(DEFAULT_VIEWPORT.rows);
+  });
+
+  it('gives running tools and a multi-line draft their rows first', async () => {
+    const snapshot: InkCliSnapshot = {
+      ...baseSnapshot,
+      liveText: streamedAnswer(200),
+      liveTools: Array.from({ length: 8 }, (_, index) => ({
+        id: `tool-${index}`,
+        name: 'bash',
+        label: `bash: $ pnpm --filter pulse-coder-cli test ${index}`,
+      })),
+    };
+
+    expect(await renderFrame(snapshot)).toBeLessThan(DEFAULT_VIEWPORT.rows);
+  });
+
+  it('holds the bound on narrow and short terminals', async () => {
+    const snapshot = { ...baseSnapshot, liveText: streamedAnswer(200) };
+
+    // Narrow: the key hint and status line wrap onto extra rows.
+    expect(await renderFrame(snapshot, { rows: 24, columns: 40 })).toBeLessThan(24);
+    // Short: the fixed regions alone nearly fill the screen.
+    expect(await renderFrame(snapshot, { rows: 12, columns: 80 })).toBeLessThan(12);
+    expect(await renderFrame(snapshot, { rows: 8, columns: 60 })).toBeLessThan(8);
+  });
+
+  it('holds the bound while the picker is open', async () => {
+    const snapshot: InkCliSnapshot = {
+      ...baseSnapshot,
+      liveText: streamedAnswer(200),
+      picker: {
+        title: 'Resume a session',
+        items: Array.from({ length: 30 }, (_, index) => ({
+          id: `session-${index}`,
+          label: `Session ${index} · a fairly long session title that fills the row`,
+          hint: '12 msgs · 3h ago',
+          preview: 'last message preview text that also runs long',
+        })),
+      },
+    };
+
+    expect(await renderFrame(snapshot)).toBeLessThan(DEFAULT_VIEWPORT.rows);
+  });
+});

--- a/packages/cli/src/ink-app.render.test.tsx
+++ b/packages/cli/src/ink-app.render.test.tsx
@@ -82,14 +82,6 @@ const baseSnapshot: InkCliSnapshot = {
 const streamedAnswer = (lines: number): string =>
   Array.from({ length: lines }, (_, index) => `streamed line ${index}`).join('\n');
 
-const createController = (snapshot: InkCliSnapshot): InkCliController => ({
-  getSnapshot: () => snapshot,
-  submitInput: () => {},
-  requestStop: () => {},
-  shutdown: () => {},
-  subscribe: () => () => {},
-});
-
 /**
  * Physical rows of the tallest frame Ink wrote, ANSI escapes excluded. Ink
  * brackets each frame with cursor/sync writes, so the content frame is picked
@@ -105,11 +97,34 @@ const frameHeight = (frames: string[]): number => Math.max(
 );
 
 const renderFrame = async (snapshot: InkCliSnapshot, viewport: Viewport = DEFAULT_VIEWPORT) => {
+  const [height] = await renderSequence([snapshot], viewport);
+  return height;
+};
+
+/**
+ * Renders each snapshot in turn through one mounted app and returns the frame
+ * height after each — the app's own state (the live-region reservation) is
+ * carried across the sequence, which a fresh mount per snapshot would lose.
+ */
+const renderSequence = async (snapshots: InkCliSnapshot[], viewport: Viewport = DEFAULT_VIEWPORT) => {
   const ink = await import('ink');
   const stdout = new MockStdout(viewport.columns, viewport.rows);
+  let current = snapshots[0];
+  let publish: ((snapshot: InkCliSnapshot) => void) | undefined;
+  const controller: InkCliController = {
+    getSnapshot: () => current,
+    submitInput: () => {},
+    requestStop: () => {},
+    shutdown: () => {},
+    subscribe: listener => {
+      publish = listener;
+      return () => {};
+    },
+  };
+
   const instance = ink.render(
     <InkCliApp
-      controller={createController(snapshot)}
+      controller={controller}
       runtime={{
         Box: ink.Box,
         Text: ink.Text,
@@ -125,14 +140,23 @@ const renderFrame = async (snapshot: InkCliSnapshot, viewport: Viewport = DEFAUL
       stdin: new MockStdin() as never,
       exitOnCtrlC: false,
       patchConsole: false,
+      // Deliberately NOT the launcher's incrementalRendering: that writer emits
+      // per-line diffs, and these tests measure block geometry — a property of
+      // the React tree, not of which writer ink uses to paint it.
     },
   );
 
-  // Let React commit and Ink flush the frame.
-  await new Promise(resolve => setTimeout(resolve, 60));
-  const height = frameHeight(stdout.frames);
+  const heights: number[] = [];
+  for (const snapshot of snapshots) {
+    current = snapshot;
+    publish?.(snapshot);
+    // Let React commit and Ink flush the frame.
+    await new Promise(resolve => setTimeout(resolve, 60));
+    heights.push(frameHeight(stdout.frames.splice(0)));
+  }
+
   instance.unmount();
-  return height;
+  return heights;
 };
 
 describe('InkCliApp frame height', () => {

--- a/packages/cli/src/ink-app.screen.test.tsx
+++ b/packages/cli/src/ink-app.screen.test.tsx
@@ -1,0 +1,245 @@
+import { EventEmitter } from 'node:events';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { InkCliApp, type InkCliSnapshot } from './ink-app.js';
+import { InkUiBridge } from './ink-ui-bridge.js';
+
+/**
+ * Screen-level guards.
+ *
+ * `ink-app.render.test.tsx` measures the frame's height; this file measures
+ * what the escape sequences actually do to a terminal. Two things only show up
+ * here: whether the composer stays put while a run streams (a live region that
+ * shrinks without matching `<Static>` output walks it up the screen, leaving
+ * dead space below), and whether the launcher's incremental writer paints the
+ * same picture as Ink's default full-repaint writer.
+ */
+
+const ROWS = 24;
+const COLUMNS = 80;
+
+/** Minimal VT emulator for the escape subset ink and log-update emit. */
+class TerminalScreen extends EventEmitter {
+  isTTY = true;
+  rows = ROWS;
+  columns = COLUMNS;
+  private grid: string[] = [''];
+  private row = 0;
+  private col = 0;
+
+  getWindowSize(): [number, number] {
+    return [this.columns, this.rows];
+  }
+
+  write(data: string): boolean {
+    let index = 0;
+    while (index < data.length) {
+      const char = data[index];
+
+      if (char === '\x1b') {
+        const match = /^\x1b\[([0-9;?]*)([A-Za-z])/.exec(data.slice(index));
+        if (!match) {
+          index += 1;
+          continue;
+        }
+        this.applyEscape(match[1], match[2]);
+        index += match[0].length;
+        continue;
+      }
+
+      if (char === '\n') {
+        this.row += 1;
+        this.col = 0;
+        this.lineAt(this.row);
+      } else if (char === '\r') {
+        this.col = 0;
+      } else {
+        const line = this.lineAt(this.row).padEnd(this.col, ' ');
+        this.grid[this.row] = line.slice(0, this.col) + char + line.slice(this.col + 1);
+        this.col += 1;
+      }
+      index += 1;
+    }
+    return true;
+  }
+
+  private applyEscape(params: string, command: string): void {
+    const count = Number.parseInt(params || '1', 10);
+    const amount = Number.isNaN(count) ? 1 : count;
+    switch (command) {
+      case 'A': this.row = Math.max(0, this.row - amount); break;
+      case 'B': this.row += amount; break;
+      case 'G': this.col = Math.max(0, amount - 1); break;
+      case 'E': this.row += amount; this.col = 0; break;
+      case 'K': this.grid[this.row] = params === '2' ? '' : this.lineAt(this.row).slice(0, this.col); break;
+      case 'J': if (params === '2') { this.grid = ['']; this.row = 0; this.col = 0; } break;
+      case 'H': this.row = 0; this.col = 0; break;
+      default: break;
+    }
+  }
+
+  private lineAt(row: number): string {
+    while (this.grid.length <= row) {
+      this.grid.push('');
+    }
+    return this.grid[row];
+  }
+
+  /** Absolute row of the composer's top border, or -1 when it is not painted. */
+  composerRow(): number {
+    return this.grid.findIndex(line => line.includes('╭'));
+  }
+
+  /** What the user can see: the last `rows` lines of everything written. */
+  visible(): string[] {
+    return this.grid.slice(Math.max(0, this.grid.length - this.rows)).map(line => line.trimEnd());
+  }
+}
+
+class MockStdin extends EventEmitter {
+  isTTY = true;
+  setRawMode(): void {}
+  resume(): void {}
+  pause(): void {}
+  setEncoding(): void {}
+  read(): null {
+    return null;
+  }
+  unref(): void {}
+  ref(): void {}
+}
+
+/** A run as the bridge actually drives it, including the `<Static>` writes. */
+const driveRun = (bridge: InkUiBridge, step: () => Promise<void>) => async (): Promise<string[]> => {
+  const labels: string[] = [];
+  const at = async (label: string) => {
+    await step();
+    labels.push(label);
+  };
+
+  bridge.user('please refactor the parser');
+  bridge.startProcessing('Running agent');
+  await at('run start');
+
+  for (let index = 0; index < 14; index += 1) {
+    bridge.text(`Reading the parser module first, note ${index}.\n`);
+  }
+  await at('narration streamed');
+
+  bridge.toolCall('read_file', { filePath: 'src/parser.ts' }, 'call-1');
+  await at('tool call finalizes the narration');
+
+  bridge.toolResult('read_file', 'parsed\n'.repeat(30), 'call-1');
+  await at('tool result');
+
+  for (let index = 0; index < 9; index += 1) {
+    bridge.text(`Second narration line ${index}.\n`);
+  }
+  await at('more narration');
+
+  bridge.toolCall('bash', { command: 'pnpm test' }, 'call-2');
+  await at('second tool call');
+
+  bridge.toolResult('bash', 'ok', 'call-2');
+  await at('second tool result');
+
+  bridge.text('All done — here is the summary of what changed.\n');
+  bridge.runSummary({ messages: 6, estimatedTokens: 1200, mode: 'edit', elapsedMs: 4200, toolCalls: 2 });
+  await at('run end');
+
+  return labels;
+};
+
+const renderRun = async (options: { incrementalRendering: boolean }) => {
+  const ink = await import('ink');
+  const screen = new TerminalScreen();
+  let current: InkCliSnapshot;
+  let publish: ((snapshot: InkCliSnapshot) => void) | undefined;
+  const bridge = new InkUiBridge({
+    onChange: snapshot => {
+      current = snapshot;
+      publish?.(snapshot);
+    },
+    textThrottleMs: 0,
+  });
+  current = bridge.getSnapshot();
+
+  const instance = ink.render(
+    <InkCliApp
+      controller={{
+        getSnapshot: () => current,
+        submitInput: () => {},
+        requestStop: () => {},
+        shutdown: () => {},
+        subscribe: listener => {
+          publish = listener;
+          return () => {};
+        },
+      }}
+      runtime={{
+        Box: ink.Box,
+        Text: ink.Text,
+        Static: ink.Static,
+        useApp: ink.useApp,
+        useInput: ink.useInput,
+        usePaste: ink.usePaste,
+        useStdout: ink.useStdout,
+      }}
+    />,
+    {
+      stdout: screen as never,
+      stdin: new MockStdin() as never,
+      exitOnCtrlC: false,
+      patchConsole: false,
+      incrementalRendering: options.incrementalRendering,
+    },
+  );
+
+  const composerRows: number[] = [];
+  const labels = await driveRun(bridge, async () => {
+    await new Promise(resolve => setTimeout(resolve, 45));
+    composerRows.push(screen.composerRow());
+  })();
+
+  instance.unmount();
+  return { labels, composerRows, visible: screen.visible() };
+};
+
+/** Elapsed seconds and the spinner frame move on wall-clock, not on state. */
+const stableScreen = (lines: string[]): string[] => lines.map(line => line
+  .replace(/\d+m\d+s|\d+(\.\d+)?s\b/g, '<elapsed>')
+  .replace(/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/g, '<spinner>'));
+
+describe('InkCliApp on a terminal', () => {
+  it('keeps the composer anchored through a whole run', async () => {
+    const { labels, composerRows } = await renderRun({ incrementalRendering: true });
+
+    expect(composerRows.every(row => row >= 0)).toBe(true);
+
+    // The composer may only move DOWN (new output pushes it) — an upward move
+    // means the live region shrank without matching <Static> output and left
+    // dead rows below it. One row of slack covers a live tool line retiring
+    // into a one-row trace.
+    const steps = composerRows.slice(1).map((row, index) => row - composerRows[index]);
+    const jumps = steps
+      .map((delta, index) => ({ delta, label: labels[index + 1] }))
+      .filter(step => step.delta < -1);
+
+    expect(jumps).toEqual([]);
+  });
+
+  it('paints the same screen incrementally as it does with a full repaint', async () => {
+    // The launcher enables incrementalRendering to stop the whole live block
+    // being erased and repainted 30 times a second. It must land the user on
+    // exactly the same screen as Ink's default writer.
+    const incremental = await renderRun({ incrementalRendering: true });
+    const full = await renderRun({ incrementalRendering: false });
+
+    // Not a comparison of two blank screens: there is a real UI on both.
+    expect(incremental.visible.some(line => line.includes('╭'))).toBe(true);
+    expect(incremental.visible.filter(Boolean).length).toBeGreaterThan(5);
+
+    expect(stableScreen(incremental.visible)).toEqual(stableScreen(full.visible));
+  });
+});

--- a/packages/cli/src/ink-app.tsx
+++ b/packages/cli/src/ink-app.tsx
@@ -1066,10 +1066,10 @@ export function InkCliApp({ controller, runtime, onExit, initialHistory, onHisto
   const visibleLiveTools = snapshot.liveTools.slice(-maxLiveTools);
   const hiddenLiveToolCount = snapshot.liveTools.length - visibleLiveTools.length;
 
-  // The streaming answer is the only live region without a fixed size, so it
-  // gets whatever rows the fixed ones leave over — never more. Ink flips into
-  // full-screen clear-and-replay for as long as the live output is taller than
-  // the terminal, which is the flicker this budget exists to prevent.
+  // The live region is the only part without a fixed size, so it gets whatever
+  // rows the fixed ones leave over — never more. Ink flips into full-screen
+  // clear-and-replay for as long as the live output is taller than the
+  // terminal, which is the flicker this budget exists to prevent.
   const liveToolRows = visibleLiveTools.length + (hiddenLiveToolCount > 0 ? 1 : 0);
   const statusRows = 2; // marginTop + the line itself
   // Border (2) + paddingX (2); the draft additionally carries a '› ' prefix.
@@ -1086,9 +1086,11 @@ export function InkCliApp({ controller, runtime, onExit, initialHistory, onHisto
       + (hiddenPromptLineCount > 0 ? 1 : 0)
       + fileSuggestions.length + slashSuggestions.length
       + wrappedRowCount(keyHint, terminalColumns);
-  // +1 for the live text's own marginTop, +1 so the frame stays strictly under
-  // the viewport rather than exactly at it.
-  const maxLiveTextRows = terminalRows - (statusRows + liveToolRows + footerRows + 2);
+  // +1 for the region's own marginTop, +1 so the frame stays strictly under the
+  // viewport rather than exactly at it. Running tools are billed first: they
+  // are the "what is happening now" signal and the answer can window.
+  const maxLiveRegionRows = Math.max(0, terminalRows - (statusRows + footerRows + 2));
+  const maxLiveTextRows = maxLiveRegionRows - liveToolRows;
   const liveTextWindow = useMemo(
     () => windowLiveTextLines(liveTextLines, maxLiveTextRows, terminalColumns),
     [liveTextLines, maxLiveTextRows, terminalColumns],

--- a/packages/cli/src/ink-app.tsx
+++ b/packages/cli/src/ink-app.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 import { renderMarkdownAnsi } from './markdown.js';
 import { applyFileReference, detectFileReferenceQuery, filterFileEntries, type FileEntry } from './file-reference.js';
-import { nextCharIndex, prevCharIndex, stringWidth, truncateToWidth } from './text-width.js';
+import { nextCharIndex, prevCharIndex, stringWidth, truncateToWidth, wrappedRowCount } from './text-width.js';
 
 export type InkEventKind = 'user' | 'assistant' | 'tool' | 'result' | 'system' | 'error' | 'log';
 export type InkEventStatus = 'running' | 'success' | 'error' | 'info';
@@ -166,6 +166,8 @@ const SLASH_COMMANDS: SlashCommandSuggestion[] = [
 ];
 
 const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+// Shared so the live-region row budget counts the same string that is rendered.
+const PICKER_HINT = '↑↓ select · Enter confirm · Esc cancel · type to filter';
 const MAX_HISTORY = 100;
 const CTRL_C_CONFIRM_WINDOW_MS = 2000;
 
@@ -471,6 +473,49 @@ export function formatStatusline(snapshot: InkCliSnapshot, maxWidth = Number.POS
  */
 export function truncateLabel(label: string, maxWidth: number): string {
   return truncateToWidth(label, maxWidth);
+}
+
+export interface LiveTextWindow {
+  /** Rendered lines that fit the budget, oldest first. */
+  lines: string[];
+  /** Lines dropped off the top; > 0 means the "… N earlier lines" head shows. */
+  hiddenLineCount: number;
+}
+
+/**
+ * Keeps the streaming answer inside a row budget.
+ *
+ * Ink re-prints the WHOLE screen (`clearTerminal` + a replay of the entire
+ * static transcript) on every frame whose live output is taller than the
+ * terminal, and keeps doing it until the output shrinks back. At streaming
+ * frequency that full-screen wipe is exactly the flicker users see, so the
+ * live answer shows a bounded tail and the finalized event carries the rest
+ * into scrollback.
+ *
+ * Rows are counted after wrapping (`wrappedRowCount`): a budget that assumed
+ * one row per line would be silently blown by the first over-wide paragraph.
+ */
+export function windowLiveTextLines(lines: string[], maxRows: number, columns: number): LiveTextWindow {
+  if (maxRows <= 0 || lines.length === 0) {
+    return { lines: [], hiddenLineCount: lines.length };
+  }
+
+  const costs = lines.map(line => wrappedRowCount(line, columns));
+  const total = costs.reduce((sum, cost) => sum + cost, 0);
+  if (total <= maxRows) {
+    return { lines, hiddenLineCount: 0 };
+  }
+
+  // Truncating costs one row for the "… N earlier lines" head.
+  const budget = maxRows - 1;
+  let used = 0;
+  let start = lines.length;
+  while (start > 0 && used + costs[start - 1] <= budget) {
+    used += costs[start - 1];
+    start -= 1;
+  }
+
+  return { lines: lines.slice(start), hiddenLineCount: start };
 }
 
 export function describeInteractionMode(mode: CliInteractionMode): string {
@@ -966,7 +1011,12 @@ export function InkCliApp({ controller, runtime, onExit, initialHistory, onHisto
   // Round border (2) + paddingX (2).
   const pickerContentWidth = Math.max(20, terminalColumns - 4);
   const promptLines = useMemo(() => renderPromptLines(input, cursor, true), [cursor, input]);
-  const liveMarkdown = useMemo(() => renderMarkdownAnsi(snapshot.liveText), [snapshot.liveText]);
+  // Markdown is rendered over the WHOLE streamed text (fenced code blocks are
+  // stateful across lines) and only then windowed onto the rows still free.
+  const liveTextLines = useMemo(
+    () => (snapshot.liveText ? renderMarkdownAnsi(snapshot.liveText).split('\n') : []),
+    [snapshot.liveText],
+  );
   const slashSuggestions = useMemo(() => getSlashCommandSuggestions(input, cursor, 6, snapshot.skills ?? []), [cursor, input, snapshot.skills]);
   const fileQuery = useMemo(() => detectFileReferenceQuery(input, cursor), [cursor, input]);
   const fileSuggestions = useMemo(
@@ -1016,15 +1066,49 @@ export function InkCliApp({ controller, runtime, onExit, initialHistory, onHisto
   const visibleLiveTools = snapshot.liveTools.slice(-maxLiveTools);
   const hiddenLiveToolCount = snapshot.liveTools.length - visibleLiveTools.length;
 
+  // The streaming answer is the only live region without a fixed size, so it
+  // gets whatever rows the fixed ones leave over — never more. Ink flips into
+  // full-screen clear-and-replay for as long as the live output is taller than
+  // the terminal, which is the flicker this budget exists to prevent.
+  const liveToolRows = visibleLiveTools.length + (hiddenLiveToolCount > 0 ? 1 : 0);
+  const statusRows = 2; // marginTop + the line itself
+  // Border (2) + paddingX (2); the draft additionally carries a '› ' prefix.
+  const boxContentColumns = Math.max(1, terminalColumns - 4);
+  const footerRows = picker
+    // Border (2) + title + items + optional "… N more" + the hint line below.
+    ? 3 + Math.max(1, visiblePickerItems.length * pickerRowsPerItem)
+      + (pickerItems.length > visiblePickerItems.length ? 1 : 0)
+      + wrappedRowCount(PICKER_HINT, terminalColumns)
+    // Border (2) + draft lines + optional head + suggestions + the key hint.
+    // The hint and a long draft line wrap, so both are counted after wrapping —
+    // suggestion rows are already truncated to one row each.
+    : 2 + visiblePromptLines.reduce((rows, line) => rows + wrappedRowCount(line, Math.max(1, boxContentColumns - 2)), 0)
+      + (hiddenPromptLineCount > 0 ? 1 : 0)
+      + fileSuggestions.length + slashSuggestions.length
+      + wrappedRowCount(keyHint, terminalColumns);
+  // +1 for the live text's own marginTop, +1 so the frame stays strictly under
+  // the viewport rather than exactly at it.
+  const maxLiveTextRows = terminalRows - (statusRows + liveToolRows + footerRows + 2);
+  const liveTextWindow = useMemo(
+    () => windowLiveTextLines(liveTextLines, maxLiveTextRows, terminalColumns),
+    [liveTextLines, maxLiveTextRows, terminalColumns],
+  );
+  const hiddenLiveTextCount = liveTextWindow.hiddenLineCount;
+
   return (
     <Box flexDirection="column">
       <Static items={snapshot.events}>
         {(event: InkCliEvent) => <TranscriptEvent key={event.id} event={event} Box={Box} Text={Text} />}
       </Static>
 
-      {snapshot.liveText ? (
+      {/* No visible tail means no room at all — the head alone would just cost
+          a row without showing any of the answer. */}
+      {liveTextWindow.lines.length > 0 ? (
         <Box flexDirection="column" marginTop={1}>
-          <Text>{liveMarkdown}</Text>
+          {hiddenLiveTextCount > 0 ? (
+            <Text color="gray" dimColor>… {hiddenLiveTextCount} earlier line{hiddenLiveTextCount === 1 ? '' : 's'}</Text>
+          ) : null}
+          <Text>{liveTextWindow.lines.join('\n')}</Text>
         </Box>
       ) : null}
 
@@ -1071,7 +1155,7 @@ export function InkCliApp({ controller, runtime, onExit, initialHistory, onHisto
               <Text color="gray">… {pickerItems.length - visiblePickerItems.length} more (↑↓ to scroll)</Text>
             ) : null}
           </Box>
-          <Text color="gray">↑↓ select · Enter confirm · Esc cancel · type to filter</Text>
+          <Text color="gray">{PICKER_HINT}</Text>
         </Box>
       ) : (
         <Box flexDirection="column">

--- a/packages/cli/src/ink-launcher.tsx
+++ b/packages/cli/src/ink-launcher.tsx
@@ -39,6 +39,11 @@ export async function startInkTui(options: StartInkTuiOptions = {}): Promise<voi
       // Console is owned by EngineLogSink — Ink's patchConsole would re-patch
       // console methods after us and pull engine logs back into the frame.
       patchConsole: false,
+      // Ink's default renderer erases the whole live block and repaints it on
+      // every frame; at streaming rate that repaint of the transcript tail,
+      // status line and bordered composer is visible as shimmer. Incremental
+      // mode rewrites only the lines that actually changed.
+      incrementalRendering: true,
     },
   );
 

--- a/packages/cli/src/ink-ui-bridge.test.ts
+++ b/packages/cli/src/ink-ui-bridge.test.ts
@@ -22,6 +22,7 @@ import {
   renderPrompt,
   renderPromptLines,
   shouldAcceptSlashSuggestion,
+  windowLiveTextLines,
   type InkCliSnapshot,
 } from './ink-app.js';
 
@@ -518,6 +519,40 @@ describe('Ink composer editing helpers', () => {
     expect(truncateLabel('short', 20)).toBe('short');
     expect(truncateLabel('a'.repeat(30), 10)).toBe(`${'a'.repeat(9)}…`);
     expect(truncateLabel('abc', 0)).toBe('abc');
+  });
+
+  it('keeps the streaming answer inside its row budget', () => {
+    const lines = Array.from({ length: 40 }, (_, index) => `line ${index}`);
+
+    // Fits: nothing is hidden and the text is passed through untouched.
+    expect(windowLiveTextLines(lines, 40, 80)).toEqual({ lines, hiddenLineCount: 0 });
+
+    // Over budget: the tail survives and one row is left for the "… N earlier
+    // lines" head, so the region occupies exactly the budget and no more.
+    const windowed = windowLiveTextLines(lines, 10, 80);
+    expect(windowed.lines).toEqual(lines.slice(31));
+    expect(windowed.hiddenLineCount).toBe(31);
+    expect(windowed.lines.length + 1).toBe(10);
+    expect(windowed.lines[windowed.lines.length - 1]).toBe('line 39');
+  });
+
+  it('charges wrapped lines their real height when windowing', () => {
+    // Each of these is three physical rows on a 10-column terminal, so a
+    // 7-row budget (6 after the head) fits exactly two of them.
+    const lines = Array.from({ length: 5 }, (_, index) => `${index}${'x'.repeat(29)}`);
+    const windowed = windowLiveTextLines(lines, 7, 10);
+
+    expect(windowed.lines).toHaveLength(2);
+    expect(windowed.hiddenLineCount).toBe(3);
+  });
+
+  it('hides the streaming answer entirely when no rows are left', () => {
+    const lines = ['a', 'b'];
+    expect(windowLiveTextLines(lines, 0, 80)).toEqual({ lines: [], hiddenLineCount: 2 });
+    expect(windowLiveTextLines(lines, -3, 80)).toEqual({ lines: [], hiddenLineCount: 2 });
+    // A single row can only carry the head.
+    expect(windowLiveTextLines(lines, 1, 80)).toEqual({ lines: [], hiddenLineCount: 2 });
+    expect(windowLiveTextLines([], 5, 80)).toEqual({ lines: [], hiddenLineCount: 0 });
   });
 
   it('filters picker items across label, hint, and preview', () => {

--- a/packages/cli/src/ink-ui-bridge.test.ts
+++ b/packages/cli/src/ink-ui-bridge.test.ts
@@ -550,7 +550,7 @@ describe('Ink composer editing helpers', () => {
     const lines = ['a', 'b'];
     expect(windowLiveTextLines(lines, 0, 80)).toEqual({ lines: [], hiddenLineCount: 2 });
     expect(windowLiveTextLines(lines, -3, 80)).toEqual({ lines: [], hiddenLineCount: 2 });
-    // A single row can only carry the head.
+    // A single row would go entirely to the head, showing none of the answer.
     expect(windowLiveTextLines(lines, 1, 80)).toEqual({ lines: [], hiddenLineCount: 2 });
     expect(windowLiveTextLines([], 5, 80)).toEqual({ lines: [], hiddenLineCount: 0 });
   });

--- a/packages/cli/src/text-width.test.ts
+++ b/packages/cli/src/text-width.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { nextCharIndex, prevCharIndex, stringWidth, truncateToWidth } from './text-width.js';
+import { nextCharIndex, prevCharIndex, stringWidth, truncateToWidth, wrappedRowCount } from './text-width.js';
 
 describe('stringWidth', () => {
   it('counts CJK and emoji as two columns', () => {
@@ -38,6 +38,34 @@ describe('truncateToWidth', () => {
   it('is a no-op for degenerate budgets', () => {
     expect(truncateToWidth('abc', 0)).toBe('abc');
     expect(truncateToWidth('abc', 1)).toBe('abc');
+  });
+});
+
+describe('wrappedRowCount', () => {
+  it('counts one row while the line fits', () => {
+    expect(wrappedRowCount('', 20)).toBe(1);
+    expect(wrappedRowCount('exactly twenty chars', 20)).toBe(1);
+    // Rendered markdown carries SGR escapes; measuring them as glyphs would
+    // report a wrap that the terminal never performs.
+    expect(wrappedRowCount('\x1b[1mexactly twenty chars\x1b[0m', 20)).toBe(1);
+    expect(stringWidth('\x1b[1mexactly twenty chars\x1b[0m')).toBeGreaterThan(20);
+  });
+
+  it('counts the rows a greedy word wrap actually produces', () => {
+    // Character math says 2 rows (20 columns / 10); word wrap needs 3.
+    expect(wrappedRowCount('aaaaaa bbbbbb cccccc', 10)).toBe(3);
+    expect(wrappedRowCount('one two three four', 10)).toBe(2);
+  });
+
+  it('hard-splits words wider than the terminal', () => {
+    expect(wrappedRowCount('a'.repeat(25), 10)).toBe(3);
+    // Unspaced CJK is one long word: 30 columns over a 10-column terminal.
+    expect(wrappedRowCount('一二三四五六七八九十十九八七六', 10)).toBe(3);
+  });
+
+  it('degrades to one row for a degenerate width', () => {
+    expect(wrappedRowCount('anything', 0)).toBe(1);
+    expect(wrappedRowCount('anything', Number.POSITIVE_INFINITY)).toBe(1);
   });
 });
 

--- a/packages/cli/src/text-width.ts
+++ b/packages/cli/src/text-width.ts
@@ -72,6 +72,57 @@ export function truncateToWidth(value: string, maxWidth: number): string {
   return `${result}…`;
 }
 
+// SGR sequences colour a glyph without occupying a column of their own, so
+// anything measuring already-rendered (markdown → ANSI) text must drop them
+// first or it over-counts every styled line.
+const ANSI_SGR_PATTERN = /\x1b\[[0-9;]*m/g;
+
+/**
+ * Physical rows one logical line occupies once the terminal wraps it at
+ * `columns`. Greedy word wrap, matching Ink's default `wrap`: a word that does
+ * not fit on a line of its own is hard-split across rows.
+ *
+ * A row budget computed from `String.split('\n').length` is wrong whenever a
+ * line is wider than the terminal — that undercount is what lets a "bounded"
+ * region overflow the screen.
+ */
+export function wrappedRowCount(line: string, columns: number): number {
+  if (!Number.isFinite(columns) || columns <= 0) {
+    return 1;
+  }
+
+  const plain = line.replace(ANSI_SGR_PATTERN, '');
+  if (stringWidth(plain) <= columns) {
+    return 1;
+  }
+
+  let rows = 1;
+  let used = 0;
+  for (const word of plain.split(' ')) {
+    const wordWidth = stringWidth(word);
+    const gap = used > 0 ? 1 : 0;
+    if (used + gap + wordWidth <= columns) {
+      used += gap + wordWidth;
+      continue;
+    }
+
+    if (used > 0) {
+      rows += 1;
+      used = 0;
+    }
+
+    // Words wider than the terminal (long paths, unspaced CJK) fill whole rows.
+    let remaining = wordWidth;
+    while (remaining > columns) {
+      rows += 1;
+      remaining -= columns;
+    }
+    used = remaining;
+  }
+
+  return rows;
+}
+
 /** Index of the code point boundary before `index` (for ←/Backspace). */
 export function prevCharIndex(value: string, index: number): number {
   const position = Math.max(0, Math.min(value.length, index));


### PR DESCRIPTION
The Ink host rendered `liveText` — the streaming assistant answer — below
`<Static>` with no row bound, so it grew with the model's output until it
outgrew the screen.

Ink does not simply scroll an over-tall frame. `shouldClearTerminalForFrame`
(ink 7) makes any frame taller than the viewport write
`clearTerminal + fullStaticOutput + output`: a full-screen wipe plus a replay
of the entire static transcript. Because the rule also fires on
`wasOverflowing`, it keeps doing that on every following frame until the
output shrinks back. At the bridge's 33ms streaming emit rate that is the
flicker and jumping users see. Measured: 207 rows written into a 24-row
terminal.

The streaming answer now takes only the rows the fixed-size regions leave
over, showing a bounded tail with a "… N earlier lines" head; the full answer
still reaches scrollback when the run finalizes it into `<Static>`.

Rows are counted after wrapping rather than truncated on columns, so streamed
prose stays readable. Greedy word wrap can need more rows than
`ceil(width / columns)`, so `wrappedRowCount()` simulates the wrap instead of
dividing — undercounting is exactly what puts a "bounded" region over the
viewport. The key hint and draft lines are charged their wrapped height too,
since both reflow on a narrow terminal.

`ink-app.render.test.tsx` renders the real component into a mock TTY and
asserts the frame height stays under the viewport across long answers,
over-wide lines, running tools, narrow/short terminals, and an open picker.
It fails on the previous code with 207/247/213 rows against a 24-row limit.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Kr8kr9gsSU77CsFeSiLpJf