### PR TITLE
release(canvas): 0.1.39

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.38",
+  "version": "0.1.39",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
## Release

- Publish Pulse Canvas 0.1.39 for macOS arm64
- Improve AI chat recovery and error states
- Stabilize session switching and remove session-list flashing
- Keep session groups and workspace dock state correct

## Verification

- Release build and DMG packaging succeeded
- R2 artifact and latest.json uploaded; versioned artifact URL returns HTTP 200
- Cloudflare Pages download site deployed
- `node scripts/harness/run-harness-check.mjs` (5/5 commands passed)

## Note

- The additional packaged-agent-tooling smoke timed out waiting for the temporary-HOME CLI wrapper; focused packaged-tooling tests passed and the packaged app launched successfully during diagnosis.