### PR TITLE
fix(canvas): polish chat and sidebar chrome

### DIFF
--- a/apps/canvas-workspace/harness/knowledge/chat-sessions.md
+++ b/apps/canvas-workspace/harness/knowledge/chat-sessions.md
@@ -115,10 +115,10 @@ toggle.
 - An expanded dock still pointing at the chat/terminal tab must be
   re-pointed at a content tab rather than collapsed — collapsing instead
   would make the first click read as a no-op.
-- The button stays visible but disabled when no content tab exists yet (a
-  tab can land mid-conversation, e.g. the agent opening an artifact or
-  preview), and its topbar position must not jump around as that happens.
-  `chat.noDockTabs` labels the disabled state.
+- The button stays visible and actionable even when no content tab exists.
+  Its first click opens the scoped workspace canvas as a read-only preview
+  when possible; global/scheduled scopes and an already-mounted canvas create
+  a blank browser tab instead. Its topbar position must not jump as tabs land.
 
 **Inset rule.** These routes reflow like any other route, through
 `reserveSpace` — the dock inset must NOT be gated on `chatTabEnabled`. Gating

--- a/apps/canvas-workspace/harness/knowledge/chat-sessions.md
+++ b/apps/canvas-workspace/harness/knowledge/chat-sessions.md
@@ -57,6 +57,14 @@ Tests: `hooks/useChatSessions.test.tsx`,
 `hooks/useMentions.submit-veto.test.tsx`, `__tests__/ChatSessionLoading.test.tsx`
 (all under `src/renderer/src/components/chat/`).
 
+## Stopped-turn outcome lifecycle
+
+A stopped turn keeps a compact recovery marker while it remains the latest
+user-visible outcome. Once a later user message moves the conversation on,
+that old marker is hidden; the partial assistant content stays in history.
+Failed-turn outcomes remain visible because their diagnostics and retry state
+are still relevant. Guard: `__tests__/ChatMessages.accessibility.test.tsx`.
+
 ## Stable full-page session rail
 
 The full-page rail is a unified, cross-scope index. Its folder tree must stay

--- a/apps/canvas-workspace/src/main/__tests__/ui-reuse-governance.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/ui-reuse-governance.test.ts
@@ -119,7 +119,9 @@ const RATCHET_BASELINE: Record<string, number> = {
   // 294→293 (model switcher): dropped the menu's "Auto" entry — every
   // message now names the provider+model it runs on, so the implicit
   // default-config row had no selectable meaning left.
-  rawButtonTags: 293,
+  // 293→292 (sidebar chrome): the expanded collapse control now reuses the
+  // blessed icon Button instead of adding another raw micro-button.
+  rawButtonTags: 292,
   // raw <input> tags in .tsx — falls as components/ui/TextField absorbs them.
   // 55→54: ui/TextField's own <input> (+1), WorkspaceSettings name field
   // migrated (-1), and comment-stripping dropped one doc mention (-1).

--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -552,7 +552,6 @@ const AppContent = () => {
               onExit={exitChatView}
               onNodeFocus={focusNodeOnCanvas}
               onOpenAppSettings={openAppSettings}
-              onOpenWorkspaceSettings={openWorkspaceSettings}
             />
           </PulseRouterView>
           <NodesRouteViews enabled={NODES_ENABLED} workspaces={workspaces} detailNode={detailNode} onBack={exitNodeDetailView} onAskAi={handleAskKnowledgeAi} />

--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -82,17 +82,17 @@ const AppContent = () => {
   const activeView: ActiveView =
     routePath === ROUTE_CHAT ? 'chat'
       : routePath === ROUTE_SKILLS ? 'skills'
-      : scheduledTaskMatch ? 'scheduled-task'
-      : routePath === ROUTE_SCHEDULED ? 'scheduled'
-      : nodesRouteActive
-        ? detailNodeMatch
-          ? 'node-detail'
-          : 'nodes'
-        : graphRouteActive
-          ? 'graph'
-          : pluginRoutes.some((r) => r.path === routePath)
-            ? routePath
-            : 'canvas';
+        : scheduledTaskMatch ? 'scheduled-task'
+          : routePath === ROUTE_SCHEDULED ? 'scheduled'
+            : nodesRouteActive
+              ? detailNodeMatch
+                ? 'node-detail'
+                : 'nodes'
+              : graphRouteActive
+                ? 'graph'
+                : pluginRoutes.some((r) => r.path === routePath)
+                  ? routePath
+                  : 'canvas';
   const routeQuery = routeParams.toString();
   const { notify, updateToast, confirm, openShortcuts, isOverlayOpen } = useAppShell();
   const chatTargetBroker = useChatTargetBroker();

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/__tests__/dock-content-tabs.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/__tests__/dock-content-tabs.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { DockStore } from '../dock-store';
-import { canPreviewWorkspaceCanvas, hasDockContentTabs, isDockContentTabVisible } from '../dock-content-tabs';
+import {
+  canPreviewWorkspaceCanvas,
+  hasDockContentTabs,
+  isDockContentTabVisible,
+  toggleFullPageDockContentTabs,
+} from '../dock-content-tabs';
 
 const seeded = (): DockStore => {
   const store = new DockStore();
@@ -63,5 +68,62 @@ describe('canPreviewWorkspaceCanvas', () => {
   it('refuses when there is no workspace to preview (global/scheduled chat)', () => {
     const store = new DockStore();
     expect(canPreviewWorkspaceCanvas(store.getSnapshot(), undefined)).toBe(false);
+  });
+});
+
+describe('toggleFullPageDockContentTabs', () => {
+  const actions = () => ({
+    openCanvasPreview: vi.fn(() => true),
+    newLink: vi.fn(),
+    toggleContentTabs: vi.fn(),
+  });
+
+  it('toggles existing content tabs', () => {
+    const store = seeded();
+    const dockActions = actions();
+    toggleFullPageDockContentTabs(store.getSnapshot(), undefined, dockActions);
+    expect(dockActions.toggleContentTabs).toHaveBeenCalledOnce();
+    expect(dockActions.newLink).not.toHaveBeenCalled();
+  });
+
+  it('opens the scoped workspace canvas when it can be previewed', () => {
+    const store = new DockStore();
+    const dockActions = actions();
+    toggleFullPageDockContentTabs(
+      store.getSnapshot(),
+      { id: 'ws-1', title: 'Workspace one' },
+      dockActions,
+    );
+    expect(dockActions.openCanvasPreview).toHaveBeenCalledWith('ws-1', 'Workspace one');
+    expect(dockActions.newLink).not.toHaveBeenCalled();
+  });
+
+  it('creates a blank tab for global chat or an already-mounted canvas', () => {
+    const store = new DockStore();
+    store.setMountedWorkspaces(['ws-1']);
+    const globalActions = actions();
+    const mountedActions = actions();
+    toggleFullPageDockContentTabs(store.getSnapshot(), undefined, globalActions);
+    toggleFullPageDockContentTabs(
+      store.getSnapshot(),
+      { id: 'ws-1', title: 'Workspace one' },
+      mountedActions,
+    );
+    expect(globalActions.newLink).toHaveBeenCalledOnce();
+    expect(mountedActions.newLink).toHaveBeenCalledOnce();
+    expect(mountedActions.openCanvasPreview).not.toHaveBeenCalled();
+  });
+
+  it('creates a blank tab if the canvas preview is refused at invocation time', () => {
+    const store = new DockStore();
+    const dockActions = actions();
+    dockActions.openCanvasPreview.mockReturnValue(false);
+    toggleFullPageDockContentTabs(
+      store.getSnapshot(),
+      { id: 'ws-1', title: 'Workspace one' },
+      dockActions,
+    );
+    expect(dockActions.openCanvasPreview).toHaveBeenCalledOnce();
+    expect(dockActions.newLink).toHaveBeenCalledOnce();
   });
 });

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/dock-content-tabs.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/dock-content-tabs.ts
@@ -53,3 +53,25 @@ export const canPreviewWorkspaceCanvas = (
   state: DockState,
   workspaceId: string | undefined,
 ): boolean => workspaceId != null && !state.mountedWorkspaceIds.has(workspaceId);
+
+interface FullPageDockActions {
+  openCanvasPreview: (workspaceId: string, title: string) => boolean;
+  newLink: () => void;
+  toggleContentTabs: () => void;
+}
+
+/** Execute the always-actionable full-page chat dock control. */
+export const toggleFullPageDockContentTabs = (
+  state: DockState,
+  workspace: { id: string; title: string } | undefined,
+  actions: FullPageDockActions,
+): void => {
+  if (hasDockContentTabs(state)) {
+    actions.toggleContentTabs();
+    return;
+  }
+  if (workspace && canPreviewWorkspaceCanvas(state, workspace.id)) {
+    if (actions.openCanvasPreview(workspace.id, workspace.title)) return;
+  }
+  actions.newLink();
+};

--- a/apps/canvas-workspace/src/renderer/src/components/RightDock/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/RightDock/index.css
@@ -115,7 +115,8 @@
 }
 
 .right-dock__tabs[data-visible="true"] {
-  max-height: 46px;
+  height: var(--app-topbar-height);
+  max-height: var(--app-topbar-height);
   padding: 8px 8px 8px 10px;
   border-bottom-width: 1px;
   opacity: 1;

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/SidebarCollapsedRail.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/SidebarCollapsedRail.test.tsx
@@ -9,7 +9,7 @@ import { Sidebar } from '.';
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 describe('collapsed sidebar rail', () => {
-  it('keeps the expand control at the bottom of the rail', () => {
+  it('keeps the expand control at the top of the rail', () => {
     const host = document.createElement('div');
     const root = createRoot(host);
     const noop = vi.fn();
@@ -56,8 +56,8 @@ describe('collapsed sidebar rail', () => {
 
     const rail = host.querySelector('.sidebar-collapsed-rail');
     const expandButton = host.querySelector('[aria-label="Expand sidebar"]');
-    expect(rail?.lastElementChild).toBe(expandButton);
-    expect(expandButton?.classList.contains('sidebar-collapsed-btn--bottom')).toBe(true);
+    expect(rail?.firstElementChild).toBe(expandButton);
+    expect(rail?.children[1]?.querySelector('img')?.getAttribute('width')).toBe('20');
 
     act(() => root.unmount());
   });

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/SidebarCollapsedRail.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/SidebarCollapsedRail.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { describe, expect, it, vi } from 'vitest';
+import { I18nProvider } from '../../i18n';
+import { AppShellProvider } from '../AppShellProvider';
+import { Sidebar } from '.';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('collapsed sidebar rail', () => {
+  it('keeps the expand control at the bottom of the rail', () => {
+    const host = document.createElement('div');
+    const root = createRoot(host);
+    const noop = vi.fn();
+
+    act(() => root.render(
+      <I18nProvider>
+        <AppShellProvider>
+          <Sidebar
+            collapsed
+            onToggle={noop}
+            workspaces={[]}
+            folders={[]}
+            activeId=""
+            onSelect={noop}
+            onCreate={noop}
+            onRename={noop}
+            onDelete={noop}
+            onExport={noop}
+            onOpenSettings={noop}
+            onOpenAppSettings={noop}
+            onImport={noop}
+            onCreateFolder={noop}
+            onRenameFolder={noop}
+            onDeleteFolder={noop}
+            onToggleFolder={noop}
+            onMoveWorkspace={noop}
+            onReorderWorkspace={noop}
+            onReorderFolder={noop}
+            activeView="canvas"
+            onEnterChat={noop}
+            onEnterNodes={noop}
+            onEnterGraph={noop}
+            onEnterSkills={noop}
+            onEnterScheduled={noop}
+            nodesEnabled={false}
+            graphEnabled={false}
+            pluginNavItems={[]}
+            onNavigate={noop}
+            onExitChat={noop}
+          />
+        </AppShellProvider>
+      </I18nProvider>,
+    ));
+
+    const rail = host.querySelector('.sidebar-collapsed-rail');
+    const expandButton = host.querySelector('[aria-label="Expand sidebar"]');
+    expect(rail?.lastElementChild).toBe(expandButton);
+    expect(expandButton?.classList.contains('sidebar-collapsed-btn--bottom')).toBe(true);
+
+    act(() => root.unmount());
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/SidebarHeader.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/SidebarHeader.test.tsx
@@ -26,7 +26,6 @@ describe('SidebarHeader', () => {
     const renderHeader = (nodesEnabled: boolean, graphEnabled: boolean) => (
       <I18nProvider>
         <SidebarHeader
-          onToggle={vi.fn()}
           activeView="canvas"
           onEnterChat={vi.fn()}
           onEnterNodes={vi.fn()}
@@ -56,6 +55,7 @@ describe('SidebarHeader', () => {
       .map((element) => element.textContent);
 
     expect(labels()).toEqual(['AI Chat', 'Skills', 'Scheduled']);
+    expect(host.querySelector('[title="Collapse sidebar"]')).toBeNull();
 
     act(() => {
       root?.render(renderHeader(true, true));

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/SidebarHeader.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/SidebarHeader.test.tsx
@@ -26,6 +26,7 @@ describe('SidebarHeader', () => {
     const renderHeader = (nodesEnabled: boolean, graphEnabled: boolean) => (
       <I18nProvider>
         <SidebarHeader
+          onToggle={vi.fn()}
           activeView="canvas"
           onEnterChat={vi.fn()}
           onEnterNodes={vi.fn()}
@@ -54,13 +55,15 @@ describe('SidebarHeader', () => {
     const labels = () => [...host!.querySelectorAll('.sidebar-nav-label')]
       .map((element) => element.textContent);
 
-    expect(labels()).toEqual(['AI Chat', 'Skills', 'Scheduled']);
-    expect(host.querySelector('[title="Collapse sidebar"]')).toBeNull();
+    expect(labels()).toEqual(['Pulse Agent', 'Skills', 'Scheduled']);
+    expect(host.querySelector('[title="Collapse sidebar"]')).not.toBeNull();
+    expect(host.querySelector('.sidebar-brand-mark')).toBeNull();
+    expect(host.querySelector('.sidebar-nav-item img')?.getAttribute('width')).toBe('20');
 
     act(() => {
       root?.render(renderHeader(true, true));
     });
 
-    expect(labels()).toEqual(['AI Chat', 'Nodes', 'Graph', 'Skills', 'Scheduled']);
+    expect(labels()).toEqual(['Pulse Agent', 'Nodes', 'Graph', 'Skills', 'Scheduled']);
   });
 });

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/SidebarHeader.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/SidebarHeader.tsx
@@ -4,7 +4,6 @@ import { CalendarBlank, PuzzlePiece, SidebarSimple } from '@phosphor-icons/react
 import type { NavItem } from '../../../../plugins/types';
 import {
   PlusIcon,
-  AvatarIcon,
   AppLogoIcon,
   WorkspaceIcon,
   FolderIcon,
@@ -21,6 +20,7 @@ export const SidebarToggleIcon = ({ size = 14 }: { size?: number }) => (
 );
 
 interface SidebarHeaderProps {
+  onToggle: () => void;
   activeView: string;
   onEnterChat: () => void;
   onEnterNodes: () => void;
@@ -41,6 +41,7 @@ interface SidebarHeaderProps {
 }
 
 export const SidebarHeader = ({
+  onToggle,
   activeView,
   onEnterChat,
   onEnterNodes,
@@ -91,10 +92,17 @@ export const SidebarHeader = ({
   return (
     <>
       <div className="sidebar-brand-header">
-        <span className="sidebar-brand-mark" aria-hidden="true">
-          <AppLogoIcon size={22} />
-        </span>
         <span className="sidebar-brand">Pulse Canvas</span>
+        <Button
+          variant="icon"
+          size="xs"
+          className="sidebar-section-btn"
+          onClick={onToggle}
+          title={t('sidebar.collapse')}
+          aria-label={t('sidebar.collapse')}
+        >
+          <SidebarToggleIcon size={14} />
+        </Button>
       </div>
 
       <div className="sidebar-nav">
@@ -104,7 +112,7 @@ export const SidebarHeader = ({
           title={t('sidebar.aiChatTitle')}
         >
           <span className="sidebar-nav-icon">
-            <AvatarIcon size={14} />
+            <AppLogoIcon size={20} />
           </span>
           <span className="sidebar-nav-label">{t('sidebar.aiChat')}</span>
         </button>

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/SidebarHeader.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/SidebarHeader.tsx
@@ -38,6 +38,9 @@ interface SidebarHeaderProps {
   onNewWorkspace: () => void;
   onNewFolder: () => void;
   onImportWorkspace: () => void;
+
+  enableSkills?: boolean;
+  enableScheduled?: boolean;
 }
 
 export const SidebarHeader = ({
@@ -59,6 +62,8 @@ export const SidebarHeader = ({
   onNewWorkspace,
   onNewFolder,
   onImportWorkspace,
+  enableScheduled,
+  enableSkills
 }: SidebarHeaderProps) => {
   const { t } = useI18n();
   const addButtonRef = useRef<HTMLButtonElement>(null);
@@ -140,7 +145,7 @@ export const SidebarHeader = ({
             <span className="sidebar-nav-label">{t('sidebar.graph')}</span>
           </button>
         )}
-        <Button
+        {enableSkills ? <Button
           variant="secondary"
           className={`sidebar-nav-item${activeView === 'skills' ? ' sidebar-nav-item--active' : ''}`}
           onClick={onEnterSkills}
@@ -150,18 +155,22 @@ export const SidebarHeader = ({
             <PuzzlePiece size={14} />
           </span>
           <span className="sidebar-nav-label">{t('sidebar.skills')}</span>
-        </Button>
-        <Button
-          variant="secondary"
-          className={`sidebar-nav-item${activeView === 'scheduled' || activeView === 'scheduled-task' ? ' sidebar-nav-item--active' : ''}`}
-          onClick={onEnterScheduled}
-          title={t('sidebar.scheduledTitle')}
-        >
-          <span className="sidebar-nav-icon">
-            <CalendarBlank size={14} />
-          </span>
-          <span className="sidebar-nav-label">{t('sidebar.scheduled')}</span>
-        </Button>
+        </Button> : null}
+
+        {
+          enableScheduled ? <Button
+            variant="secondary"
+            className={`sidebar-nav-item${activeView === 'scheduled' || activeView === 'scheduled-task' ? ' sidebar-nav-item--active' : ''}`}
+            onClick={onEnterScheduled}
+            title={t('sidebar.scheduledTitle')}
+          >
+            <span className="sidebar-nav-icon">
+              <CalendarBlank size={14} />
+            </span>
+            <span className="sidebar-nav-label">{t('sidebar.scheduled')}</span>
+          </Button> : null
+        }
+
         {pluginNavItems.map((item) => {
           const Icon = item.icon;
           return (

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/SidebarHeader.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/SidebarHeader.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useRef } from 'react';
 import type React from 'react';
-import { CalendarBlank, PuzzlePiece } from '@phosphor-icons/react';
+import { CalendarBlank, PuzzlePiece, SidebarSimple } from '@phosphor-icons/react';
 import type { NavItem } from '../../../../plugins/types';
 import {
   PlusIcon,
@@ -17,14 +17,10 @@ import { useMenuKeyboardNav } from '../../hooks/useMenuKeyboardNav';
 import { Button } from '../ui';
 
 export const SidebarToggleIcon = ({ size = 14 }: { size?: number }) => (
-  <svg width={size} height={size} viewBox="0 0 16 16" fill="none">
-    <rect x="1.5" y="2.5" width="13" height="11" rx="2" stroke="currentColor" strokeWidth="1.3" />
-    <path d="M6 2.5v11" stroke="currentColor" strokeWidth="1.3" />
-  </svg>
+  <SidebarSimple size={size} weight="regular" />
 );
 
 interface SidebarHeaderProps {
-  onToggle: () => void;
   activeView: string;
   onEnterChat: () => void;
   onEnterNodes: () => void;
@@ -45,7 +41,6 @@ interface SidebarHeaderProps {
 }
 
 export const SidebarHeader = ({
-  onToggle,
   activeView,
   onEnterChat,
   onEnterNodes,
@@ -100,9 +95,6 @@ export const SidebarHeader = ({
           <AppLogoIcon size={22} />
         </span>
         <span className="sidebar-brand">Pulse Canvas</span>
-        <button className="sidebar-section-btn" onClick={onToggle} title={t('sidebar.collapse')}>
-          <SidebarToggleIcon size={14} />
-        </button>
       </div>
 
       <div className="sidebar-nav">

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
@@ -36,13 +36,10 @@
   margin-top: auto;
   padding: 8px 8px 12px;
   border-top: 1px solid var(--border-light);
-  display: flex;
-  align-items: center;
-  gap: 4px;
 }
 
 .sidebar-footer-btn {
-  flex: 1;
+  width: 100%;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -55,26 +52,6 @@
   font-weight: 600;
   cursor: pointer;
   text-align: left;
-}
-
-.sidebar-footer-icon-btn {
-  width: 28px;
-  height: 28px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex: 0 0 auto;
-  padding: 0;
-  border: none;
-  border-radius: var(--radius-sm);
-  background: transparent;
-  color: var(--text-secondary);
-  cursor: pointer;
-}
-
-.sidebar-footer-icon-btn:hover {
-  background: var(--surface-hover);
-  color: var(--text);
 }
 
 .sidebar-footer-btn:hover {

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
@@ -73,7 +73,7 @@
 }
 
 .sidebar-footer-icon-btn:hover {
-  background: rgba(55, 53, 47, 0.05);
+  background: var(--surface-hover);
   color: var(--text);
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.css
@@ -36,10 +36,13 @@
   margin-top: auto;
   padding: 8px 8px 12px;
   border-top: 1px solid var(--border-light);
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 
 .sidebar-footer-btn {
-  width: 100%;
+  flex: 1;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -52,6 +55,26 @@
   font-weight: 600;
   cursor: pointer;
   text-align: left;
+}
+
+.sidebar-footer-icon-btn {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.sidebar-footer-icon-btn:hover {
+  background: rgba(55, 53, 47, 0.05);
+  color: var(--text);
 }
 
 .sidebar-footer-btn:hover {

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
@@ -64,6 +64,9 @@ interface Props {
   pluginNavItems: ReadonlyArray<NavItem>;
   onNavigate: (path: string) => void;
   onExitChat: () => void;
+
+  enableSkills?: boolean;
+  enableScheduled?: boolean;
 }
 
 const WS_DRAG = 'application/x-workspace-id';
@@ -77,6 +80,8 @@ export const Sidebar = ({
   onEnterNodes, onEnterGraph, nodesEnabled, graphEnabled,
   onEnterSkills,
   onEnterScheduled,
+  enableSkills = true,
+  enableScheduled = true
 }: Props) => {
   const { notify } = useAppShell();
   const { t } = useI18n();
@@ -344,6 +349,8 @@ export const Sidebar = ({
             onNewWorkspace={() => { setShowAddMenu(false); setInlineCreate('workspace'); setInlineCreateValue(''); setInlineCreateFolderId(null); }}
             onNewFolder={() => { setShowAddMenu(false); setInlineCreate('folder'); setInlineCreateValue(''); setInlineCreateFolderId(null); }}
             onImportWorkspace={() => { setShowAddMenu(false); onImport(); }}
+            enableSkills={enableSkills}
+            enableScheduled={enableScheduled}
           />
           <WorkspaceList
             folders={folders} workspaces={workspaces}
@@ -420,24 +427,29 @@ export const Sidebar = ({
           >
             <AppLogoIcon size={20} />
           </button>
-          <Button
-            variant="icon"
-            className={`sidebar-collapsed-btn${activeView === 'skills' ? ' sidebar-collapsed-btn--active' : ''}`}
-            onClick={onEnterSkills}
-            title={t('sidebar.skillsTitle')}
-            aria-label={t('sidebar.skills')}
-          >
-            <PuzzlePiece size={14} />
-          </Button>
-          <Button
-            variant="icon"
-            className={`sidebar-collapsed-btn${activeView === 'scheduled' || activeView === 'scheduled-task' ? ' sidebar-collapsed-btn--active' : ''}`}
-            onClick={onEnterScheduled}
-            title={t('sidebar.scheduledTitle')}
-            aria-label={t('sidebar.scheduled')}
-          >
-            <CalendarBlank size={14} />
-          </Button>
+          {
+            enableSkills ? <Button
+              variant="icon"
+              className={`sidebar-collapsed-btn${activeView === 'skills' ? ' sidebar-collapsed-btn--active' : ''}`}
+              onClick={onEnterSkills}
+              title={t('sidebar.skillsTitle')}
+              aria-label={t('sidebar.skills')}
+            >
+              <PuzzlePiece size={14} />
+            </Button> : null
+          }
+          {
+            enableScheduled ? (<Button
+              variant="icon"
+              className={`sidebar-collapsed-btn${activeView === 'scheduled' || activeView === 'scheduled-task' ? ' sidebar-collapsed-btn--active' : ''}`}
+              onClick={onEnterScheduled}
+              title={t('sidebar.scheduledTitle')}
+              aria-label={t('sidebar.scheduled')}
+            >
+              <CalendarBlank size={14} />
+            </Button>) : null
+          }
+
           <button
             type="button"
             className="sidebar-collapsed-btn"

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
@@ -332,7 +332,7 @@ export const Sidebar = ({
       {!collapsed && (
         <>
           <SidebarHeader
-            onToggle={onToggle} activeView={activeView} onEnterChat={onEnterChat}
+            activeView={activeView} onEnterChat={onEnterChat}
             onEnterNodes={onEnterNodes} onEnterGraph={onEnterGraph}
             onEnterSkills={onEnterSkills}
             onEnterScheduled={onEnterScheduled}
@@ -460,6 +460,15 @@ export const Sidebar = ({
           >
             <SettingsIcon size={14} strokeWidth={1.4} />
             <span>{t('sidebar.settings')}</span>
+          </button>
+          <button
+            type="button"
+            className="sidebar-footer-icon-btn"
+            onClick={onToggle}
+            title={t('sidebar.collapse')}
+            aria-label={t('sidebar.collapse')}
+          >
+            <SidebarToggleIcon size={16} />
           </button>
         </div>
       )}

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
@@ -13,7 +13,7 @@ import { WorkspaceList } from './WorkspaceList';
 import { LayersPanel } from './LayersPanel';
 import { LayerContextMenu } from './LayerContextMenu';
 import { useAppShell } from '../AppShellProvider';
-import { AvatarIcon, SettingsIcon } from '../icons';
+import { AppLogoIcon, SettingsIcon } from '../icons';
 import { Button } from '../ui';
 import { getNodeDisplayLabel } from '../../utils/nodeLabel';
 import { buildCanvasNodeLink } from '../../utils/canvasLinks';
@@ -332,7 +332,7 @@ export const Sidebar = ({
       {!collapsed && (
         <>
           <SidebarHeader
-            activeView={activeView} onEnterChat={onEnterChat}
+            onToggle={onToggle} activeView={activeView} onEnterChat={onEnterChat}
             onEnterNodes={onEnterNodes} onEnterGraph={onEnterGraph}
             onEnterSkills={onEnterSkills}
             onEnterScheduled={onEnterScheduled}
@@ -404,12 +404,21 @@ export const Sidebar = ({
         <div className="sidebar-collapsed-rail">
           <button
             type="button"
+            className="sidebar-collapsed-btn"
+            onClick={onToggle}
+            title={t('sidebar.expand')}
+            aria-label={t('sidebar.expand')}
+          >
+            <SidebarToggleIcon size={14} />
+          </button>
+          <button
+            type="button"
             className={`sidebar-collapsed-btn${activeView === 'chat' ? ' sidebar-collapsed-btn--active' : ''}`}
             onClick={onEnterChat}
             title={t('sidebar.aiChatTitle')}
             aria-label={t('sidebar.aiChat')}
           >
-            <AvatarIcon size={14} />
+            <AppLogoIcon size={20} />
           </button>
           <Button
             variant="icon"
@@ -438,15 +447,6 @@ export const Sidebar = ({
           >
             <SettingsIcon size={14} strokeWidth={1.4} />
           </button>
-          <button
-            type="button"
-            className="sidebar-collapsed-btn sidebar-collapsed-btn--bottom"
-            onClick={onToggle}
-            title={t('sidebar.expand')}
-            aria-label={t('sidebar.expand')}
-          >
-            <SidebarToggleIcon size={14} />
-          </button>
         </div>
       )}
 
@@ -461,15 +461,6 @@ export const Sidebar = ({
           >
             <SettingsIcon size={14} strokeWidth={1.4} />
             <span>{t('sidebar.settings')}</span>
-          </button>
-          <button
-            type="button"
-            className="sidebar-footer-icon-btn"
-            onClick={onToggle}
-            title={t('sidebar.collapse')}
-            aria-label={t('sidebar.collapse')}
-          >
-            <SidebarToggleIcon size={16} />
           </button>
         </div>
       )}

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/index.tsx
@@ -403,14 +403,6 @@ export const Sidebar = ({
       {collapsed && (
         <div className="sidebar-collapsed-rail">
           <button
-            className="sidebar-collapsed-btn"
-            onClick={onToggle}
-            title={t('sidebar.expand')}
-            aria-label={t('sidebar.expand')}
-          >
-            <SidebarToggleIcon size={14} />
-          </button>
-          <button
             type="button"
             className={`sidebar-collapsed-btn${activeView === 'chat' ? ' sidebar-collapsed-btn--active' : ''}`}
             onClick={onEnterChat}
@@ -445,6 +437,15 @@ export const Sidebar = ({
             aria-label={t('sidebar.openSettings')}
           >
             <SettingsIcon size={14} strokeWidth={1.4} />
+          </button>
+          <button
+            type="button"
+            className="sidebar-collapsed-btn sidebar-collapsed-btn--bottom"
+            onClick={onToggle}
+            title={t('sidebar.expand')}
+            aria-label={t('sidebar.expand')}
+          >
+            <SidebarToggleIcon size={14} />
           </button>
         </div>
       )}

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/interaction-polish.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/interaction-polish.css
@@ -1,15 +1,9 @@
 .sidebar-collapsed-rail {
-  flex: 1;
-  min-height: 0;
   padding: 10px 8px;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 6px;
-}
-
-.sidebar-collapsed-btn--bottom {
-  margin-top: auto;
 }
 
 .sidebar-collapsed-btn {

--- a/apps/canvas-workspace/src/renderer/src/components/Sidebar/interaction-polish.css
+++ b/apps/canvas-workspace/src/renderer/src/components/Sidebar/interaction-polish.css
@@ -1,9 +1,15 @@
 .sidebar-collapsed-rail {
+  flex: 1;
+  min-height: 0;
   padding: 10px 8px;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 6px;
+}
+
+.sidebar-collapsed-btn--bottom {
+  margin-top: auto;
 }
 
 .sidebar-collapsed-btn {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessage.tsx
@@ -43,6 +43,8 @@ interface ChatMessageProps {
   onEditUserMessage?: (index: number, newContent: string) => Promise<boolean> | void;
   /** Re-run the user turn that produced this assistant message. */
   onRegenerate?: (index: number) => Promise<boolean> | void;
+  /** Old stopped turns become transcript history once a later user turn exists. */
+  hideStoppedOutcome?: boolean;
   /** Jump to a session/message from a session_search result chip. */
   onSessionJump?: (sessionId: string, workspaceId: string, messageIndex?: number) => void;
 }
@@ -64,6 +66,7 @@ export const ChatMessage = ({
   anchorId,
   onEditUserMessage,
   onRegenerate,
+  hideStoppedOutcome = false,
   onSessionJump,
 }: ChatMessageProps) => {
   const { t } = useI18n();
@@ -417,7 +420,7 @@ export const ChatMessage = ({
           dangerouslySetInnerHTML={{ __html: userHtml }}
         />
       )}
-      {message.role === 'assistant' && (
+      {message.role === 'assistant' && !(hideStoppedOutcome && message.turnStatus === 'stopped') && (
         <ChatTurnOutcome
           status={message.turnStatus}
           errorDetails={message.errorDetails}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessages.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessages.tsx
@@ -311,6 +311,10 @@ export const ChatMessages = ({
   const hasStreamingAssistantMessage = loading
     && messages.length > 0
     && messages[messages.length - 1].role === 'assistant';
+  const latestUserMessageIndex = messages.reduce(
+    (latest, message, index) => (message.role === 'user' ? index : latest),
+    -1,
+  );
 
   return (
     <div className="chat-messages-wrap">
@@ -357,6 +361,7 @@ export const ChatMessages = ({
               anchorId={buildAnchorElementId(workspaceId, index)}
               onEditUserMessage={onEditUserMessage}
               onRegenerate={onRegenerate}
+              hideStoppedOutcome={message.turnStatus === 'stopped' && index < latestUserMessageIndex}
               onSessionJump={onSessionJump}
             />
           );

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.css
@@ -1,7 +1,6 @@
 /* ─── ChatPage container ──────────────────────────────────── */
 
 .chat-page {
-  --chat-page-topbar-height: 49px;
   position: relative;
   flex: 1;
   min-width: 0;
@@ -242,7 +241,7 @@
 .chat-page-topbar {
   display: flex;
   align-items: center;
-  min-height: var(--chat-page-topbar-height);
+  min-height: var(--app-topbar-height);
   box-sizing: border-box;
   padding: 10px 16px;
   border-bottom: 1px solid rgba(0, 0, 0, 0.04);
@@ -444,7 +443,7 @@
 @media (max-width: 1040px) {
   .chat-page-rail-wrapper {
     position: absolute;
-    inset: var(--chat-page-topbar-height) auto 0 0;
+    inset: var(--app-topbar-height) auto 0 0;
     z-index: 4;
     width: min(260px, calc(100% - 72px));
     background: var(--surface);

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.tsx
@@ -25,8 +25,6 @@ interface ChatPageProps {
   onNodeFocus?: (workspaceId: string, nodeId: string) => void;
   /** Opens the global Settings drawer focused on the given section. */
   onOpenAppSettings: (section: SettingsSection) => void;
-  /** Opens per-workspace settings when the chat scope is workspace-bound. */
-  onOpenWorkspaceSettings?: (workspaceId: string) => void;
 }
 
 /**
@@ -52,7 +50,6 @@ export const ChatPage = ({
   onExit,
   onNodeFocus,
   onOpenAppSettings,
-  onOpenWorkspaceSettings,
 }: ChatPageProps) => {
   const [agentScope, setAgentScope] = useState<AgentScope>(
     () => initialTarget?.scope ?? { kind: 'global' },
@@ -218,7 +215,6 @@ export const ChatPage = ({
       railCollapsed={railCollapsed}
       onToggleRail={handleToggleRail}
       onOpenAppSettings={onOpenAppSettings}
-      onOpenWorkspaceSettings={onOpenWorkspaceSettings}
     />
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageBody.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageBody.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, type KeyboardEventHandler, type ReactNode } from 'react';
 import type { CanvasNode } from '../../types';
 import { useRightDock, useRightDockState } from '../RightDock/context';
-import { canPreviewWorkspaceCanvas, hasDockContentTabs, isDockContentTabVisible } from '../RightDock/dock-content-tabs';
+import { isDockContentTabVisible, toggleFullPageDockContentTabs } from '../RightDock/dock-content-tabs';
 import { buildDockTabRefs } from '../RightDock/tabRefs';
 import type { SettingsSection } from '../Settings';
 import './ChatPage.css';
@@ -104,21 +104,21 @@ export const ChatPageBody = ({
   const dock = useRightDock();
   const dockState = useRightDockState();
   // The dock's Tab strip lives beside this page (its chat tab is hidden here),
-  // so the control is a plain show/hide — no navigation. Kept visible
-  // (disabled, not hidden) even with nothing to show: a tab can land
-  // mid-conversation, and its position shouldn't jump as that happens.
+  // so the control is a plain show/hide — no navigation.
   const workspaceId = agentScope.kind === 'workspace' ? agentScope.workspaceId : undefined;
-  const canOpenDefaultDockTab = canPreviewWorkspaceCanvas(dockState, workspaceId);
-  const dockTabsToggleable = hasDockContentTabs(dockState) || canOpenDefaultDockTab;
   const dockTabsVisible = isDockContentTabVisible(dockState);
-  // Zero content tabs yet: default to opening this page's own canvas as a
-  // read-only preview instead of leaving the click a no-op.
+  // The control is always actionable. With no content yet, prefer this
+  // scope's canvas preview; global/scheduled/live-canvas scopes get a fresh
+  // browser tab so the panel still opens on the first click.
   const handleToggleDockTabs = useCallback(() => {
-    if (!hasDockContentTabs(dockState) && workspaceId) {
-      dock.openCanvasPreview(workspaceId, allWorkspaces.find(w => w.id === workspaceId)?.name ?? workspaceId);
-      return;
-    }
-    dock.toggleContentTabs();
+    toggleFullPageDockContentTabs(
+      dockState,
+      workspaceId ? {
+        id: workspaceId,
+        title: allWorkspaces.find(w => w.id === workspaceId)?.name ?? workspaceId,
+      } : undefined,
+      dock,
+    );
   }, [allWorkspaces, dock, dockState, workspaceId]);
   const scopeId = chatScopeId(agentScope);
   const sessionStoreId = scopeSessionStoreId(agentScope);
@@ -396,7 +396,6 @@ export const ChatPageBody = ({
           onNewSession={() => void sessionRail.onNewSession()}
           newSessionDisabled={sessionInteractionDisabled}
           dockTabsVisible={dockTabsVisible}
-          dockTabsToggleable={dockTabsToggleable}
           onToggleDockTabs={handleToggleDockTabs}
         />
         <ChatView

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageBody.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageBody.tsx
@@ -64,8 +64,6 @@ export interface ChatPageBodyProps {
   onToggleRail: () => void;
   /** Opens the global Settings drawer focused on the given section. */
   onOpenAppSettings: (section: SettingsSection) => void;
-  /** Opens per-workspace settings when the chat scope is workspace-bound. */
-  onOpenWorkspaceSettings?: (workspaceId: string) => void;
   /** Fixed-task chats hide the cross-session rail/new-chat controls. */
   fixedChat?: {
     title: string;
@@ -99,7 +97,6 @@ export const ChatPageBody = ({
   railCollapsed,
   onToggleRail,
   onOpenAppSettings,
-  onOpenWorkspaceSettings,
   fixedChat,
 }: ChatPageBodyProps) => {
   const { t } = useI18n();
@@ -138,16 +135,6 @@ export const ChatPageBody = ({
     executionPolicy,
     fixedTitle: fixedChat?.title,
   });
-  const settingsButtonLabel = workspaceId && onOpenWorkspaceSettings
-    ? t('workspaceSettings.ariaLabel')
-    : t('chat.modelSettings');
-  const handleOpenScopeSettings = useCallback(() => {
-    if (workspaceId && onOpenWorkspaceSettings) {
-      onOpenWorkspaceSettings(workspaceId);
-      return;
-    }
-    onOpenAppSettings('models');
-  }, [onOpenAppSettings, onOpenWorkspaceSettings, workspaceId]);
   const {
     abort,
     activeSessionId,
@@ -406,9 +393,6 @@ export const ChatPageBody = ({
           onToggleRail={onToggleRail}
           anchors={anchors}
           onJumpAnchor={handleJumpAnchor}
-          onOpenReplyStyle={() => onOpenAppSettings('reply-style')}
-          onOpenScopeSettings={handleOpenScopeSettings}
-          settingsLabel={settingsButtonLabel}
           onNewSession={() => void sessionRail.onNewSession()}
           newSessionDisabled={sessionInteractionDisabled}
           dockTabsVisible={dockTabsVisible}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageNavigationChrome.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageNavigationChrome.tsx
@@ -32,7 +32,6 @@ interface ChatPageTopbarProps {
   onNewSession: () => void;
   newSessionDisabled: boolean;
   dockTabsVisible: boolean;
-  dockTabsToggleable: boolean;
   onToggleDockTabs: () => void;
 }
 
@@ -45,13 +44,10 @@ export const ChatPageTopbar = ({
   onNewSession,
   newSessionDisabled,
   dockTabsVisible,
-  dockTabsToggleable,
   onToggleDockTabs,
 }: ChatPageTopbarProps) => {
   const { t } = useI18n();
-  const dockTabsLabel = dockTabsToggleable
-    ? (dockTabsVisible ? t('chat.hideDockTabs') : t('chat.showDockTabs'))
-    : t('chat.noDockTabs');
+  const dockTabsLabel = dockTabsVisible ? t('chat.hideDockTabs') : t('chat.showDockTabs');
 
   return (
     <div className="chat-page-topbar">
@@ -92,7 +88,6 @@ export const ChatPageTopbar = ({
         className="chat-panel-action-btn"
         data-active={dockTabsVisible}
         aria-pressed={dockTabsVisible}
-        disabled={!dockTabsToggleable}
         onClick={onToggleDockTabs}
         title={dockTabsLabel}
         aria-label={dockTabsLabel}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageNavigationChrome.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageNavigationChrome.tsx
@@ -1,6 +1,6 @@
 import { ColumnsPlusRight } from '@phosphor-icons/react';
 import { useI18n } from '../../i18n';
-import { PlusIcon, SettingsIcon, SparklesIcon } from '../icons';
+import { PlusIcon } from '../icons';
 import { Button } from '../ui';
 import { ChatAnchors } from './ChatAnchors';
 import { ChatSessionsRail, type ChatSessionsRailProps } from './ChatSessionsRail';
@@ -29,9 +29,6 @@ interface ChatPageTopbarProps {
   onToggleRail: () => void;
   anchors: ChatAnchor[];
   onJumpAnchor: (index: number) => void;
-  onOpenReplyStyle: () => void;
-  onOpenScopeSettings: () => void;
-  settingsLabel: string;
   onNewSession: () => void;
   newSessionDisabled: boolean;
   dockTabsVisible: boolean;
@@ -45,9 +42,6 @@ export const ChatPageTopbar = ({
   onToggleRail,
   anchors,
   onJumpAnchor,
-  onOpenReplyStyle,
-  onOpenScopeSettings,
-  settingsLabel,
   onNewSession,
   newSessionDisabled,
   dockTabsVisible,
@@ -79,26 +73,6 @@ export const ChatPageTopbar = ({
       )}
       <div className="chat-page-topbar-spacer" />
       <ChatAnchors anchors={anchors} onJump={onJumpAnchor} />
-      <Button
-        variant="icon"
-        size="md"
-        className="chat-panel-action-btn"
-        onClick={onOpenReplyStyle}
-        title={t('chat.replyStyleSettings')}
-        aria-label={t('chat.replyStyleSettings')}
-      >
-        <SparklesIcon size={16} strokeWidth={1.25} />
-      </Button>
-      <Button
-        variant="icon"
-        size="md"
-        className="chat-panel-action-btn"
-        onClick={onOpenScopeSettings}
-        title={settingsLabel}
-        aria-label={settingsLabel}
-      >
-        <SettingsIcon size={16} strokeWidth={1.25} />
-      </Button>
       {!fixedTitle && (
         <Button
           variant="icon"

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
@@ -3084,6 +3084,16 @@
   background: color-mix(in srgb, var(--error) 4%, var(--surface));
 }
 
+.chat-turn-outcome--stopped {
+  align-items: center;
+  gap: 5px;
+  margin-top: 6px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  font-size: 11px;
+}
+
 .chat-turn-outcome__icon {
   width: 24px;
   height: 24px;
@@ -3099,6 +3109,18 @@
 .chat-turn-outcome--failed .chat-turn-outcome__icon {
   background: color-mix(in srgb, var(--error) 9%, transparent);
   color: var(--error);
+}
+
+.chat-turn-outcome--stopped .chat-turn-outcome__icon {
+  width: 18px;
+  height: 18px;
+  background: transparent;
+  color: var(--text-muted);
+}
+
+.chat-turn-outcome--stopped .chat-turn-outcome__status {
+  color: var(--text-secondary);
+  font-weight: 550;
 }
 
 .chat-turn-outcome__body,

--- a/apps/canvas-workspace/src/renderer/src/components/chat/RailToggleIcon.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/RailToggleIcon.tsx
@@ -1,7 +1,6 @@
-/** Sidebar-rail toggle glyph for the chat page header (moved out of ChatPageBody for the 500-line gate). */
+import { ListBullets } from '@phosphor-icons/react';
+
+/** Session-list toggle glyph for the chat page header. */
 export const RailToggleIcon = ({ size = 16 }: { size?: number }) => (
-  <svg width={size} height={size} viewBox="0 0 16 16" fill="none">
-    <rect x="1.5" y="2.5" width="13" height="11" rx="2" stroke="currentColor" strokeWidth="1.3" />
-    <path d="M6 2.5v11" stroke="currentColor" strokeWidth="1.3" />
-  </svg>
+  <ListBullets size={size} weight="regular" />
 );

--- a/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatMessages.accessibility.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatMessages.accessibility.test.tsx
@@ -392,6 +392,30 @@ describe('ChatMessages accessibility', () => {
     expect(el.querySelector('[aria-label="Regenerate response"]')).toBeNull();
   });
 
+  it('hides an old stopped outcome after the user has moved the conversation on', async () => {
+    const el = await renderMessages([
+      {
+        role: 'assistant',
+        content: 'Please finish the sign-in in the browser.',
+        timestamp: 1,
+        turnStatus: 'stopped',
+        retryable: true,
+      },
+      {
+        role: 'user',
+        content: 'That is handled. Continue another way.',
+        timestamp: 2,
+      },
+      {
+        role: 'assistant',
+        content: 'Continuing with the updated request.',
+        timestamp: 3,
+      },
+    ]);
+
+    expect(el.querySelector('.chat-turn-outcome--stopped')).toBeNull();
+  });
+
   it('keeps a failed turn friendly while disclosing raw diagnostics on demand', async () => {
     const onRegenerate = vi.fn(async () => true);
     const el = await renderMessages([{

--- a/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatPageNavigationChrome.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatPageNavigationChrome.test.tsx
@@ -28,7 +28,6 @@ describe('ChatPage navigation chrome', () => {
           onNewSession={vi.fn()}
           newSessionDisabled={false}
           dockTabsVisible={false}
-          dockTabsToggleable={false}
           onToggleDockTabs={vi.fn()}
         />
       </I18nProvider>,
@@ -41,7 +40,7 @@ describe('ChatPage navigation chrome', () => {
     expect(toggle?.getAttribute('aria-expanded')).toBe('false');
     expect(host.querySelector('[aria-label="Settings"]')).toBeNull();
     expect(host.querySelectorAll('.chat-page-topbar > .chat-panel-action-btn')).toHaveLength(3);
-    expect(host.querySelector<HTMLButtonElement>('[aria-label="No tabs open yet"]')?.disabled).toBe(true);
+    expect(host.querySelector<HTMLButtonElement>('[aria-label="Show the Tab panel"]')?.disabled).toBe(false);
 
     act(() => root.unmount());
   });

--- a/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatPageNavigationChrome.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatPageNavigationChrome.test.tsx
@@ -25,9 +25,6 @@ describe('ChatPage navigation chrome', () => {
           onToggleRail={vi.fn()}
           anchors={[]}
           onJumpAnchor={vi.fn()}
-          onOpenReplyStyle={vi.fn()}
-          onOpenScopeSettings={vi.fn()}
-          settingsLabel="Settings"
           onNewSession={vi.fn()}
           newSessionDisabled={false}
           dockTabsVisible={false}
@@ -42,6 +39,9 @@ describe('ChatPage navigation chrome', () => {
     expect(railElement?.querySelector('button')).toBeNull();
     const toggle = host.querySelector<HTMLButtonElement>('[aria-controls="chat-page-session-rail"]');
     expect(toggle?.getAttribute('aria-expanded')).toBe('false');
+    expect(host.querySelector('[aria-label="Settings"]')).toBeNull();
+    expect(host.querySelectorAll('.chat-page-topbar > .chat-panel-action-btn')).toHaveLength(3);
+    expect(host.querySelector<HTMLButtonElement>('[aria-label="No tabs open yet"]')?.disabled).toBe(true);
 
     act(() => root.unmount());
   });

--- a/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatPageResponsive.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatPageResponsive.test.ts
@@ -2,6 +2,8 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 const chatPageCss = readFileSync(new URL('../ChatPage.css', import.meta.url), 'utf8');
+const rightDockCss = readFileSync(new URL('../../RightDock/index.css', import.meta.url), 'utf8');
+const rendererCss = readFileSync(new URL('../../../styles.css', import.meta.url), 'utf8');
 
 describe('ChatPage narrow-window layout', () => {
   it('overlays the optional session rail before it can squeeze the conversation column', () => {
@@ -20,13 +22,14 @@ describe('ChatPage narrow-window layout', () => {
       /\.chat-page-main\s*\{[^}]*width:\s*100%;/s,
     );
     expect(narrowRules).toMatch(
-      /\.chat-page-rail-wrapper\s*\{[^}]*inset:\s*var\(--chat-page-topbar-height\) auto 0 0;/s,
+      /\.chat-page-rail-wrapper\s*\{[^}]*inset:\s*var\(--app-topbar-height\) auto 0 0;/s,
     );
+    expect(rendererCss).toMatch(/:root\s*\{[^}]*--app-topbar-height:\s*49px;/s);
     expect(chatPageCss).toMatch(
-      /\.chat-page\s*\{[^}]*--chat-page-topbar-height:\s*49px;/s,
+      /\.chat-page-topbar\s*\{[^}]*min-height:\s*var\(--app-topbar-height\);/s,
     );
-    expect(chatPageCss).toMatch(
-      /\.chat-page-topbar\s*\{[^}]*min-height:\s*var\(--chat-page-topbar-height\);/s,
+    expect(rightDockCss).toMatch(
+      /\.right-dock__tabs\[data-visible="true"\]\s*\{[^}]*height:\s*var\(--app-topbar-height\);[^}]*max-height:\s*var\(--app-topbar-height\);/s,
     );
   });
 });

--- a/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
+++ b/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
@@ -209,8 +209,8 @@ const en = {
 
   'sidebar.collapse': 'Collapse sidebar',
   'sidebar.expand': 'Expand sidebar',
-  'sidebar.aiChatTitle': 'Chat with an agent using the current workspace context (⌘/Ctrl+Shift+L)',
-  'sidebar.aiChat': 'AI Chat',
+  'sidebar.aiChatTitle': 'Open Pulse Agent with the current workspace context (⌘/Ctrl+Shift+L)',
+  'sidebar.aiChat': 'Pulse Agent',
   'sidebar.nodesTitle': 'Workspace nodes',
   'sidebar.nodes': 'Nodes',
   'sidebar.graphTitle': 'Workspace graph',
@@ -1980,8 +1980,8 @@ const zh: Record<keyof typeof en, string> = {
 
   'sidebar.collapse': '收起侧边栏',
   'sidebar.expand': '展开侧边栏',
-  'sidebar.aiChatTitle': '基于当前工作区上下文与 Agent 对话（⌘/Ctrl+Shift+L）',
-  'sidebar.aiChat': 'AI 聊天',
+  'sidebar.aiChatTitle': '使用当前工作区上下文打开 Pulse Agent（⌘/Ctrl+Shift+L）',
+  'sidebar.aiChat': 'Pulse Agent',
   'sidebar.nodesTitle': '工作区节点',
   'sidebar.nodes': '节点',
   'sidebar.graphTitle': '工作区图谱',

--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -111,6 +111,7 @@
   --sidebar-width: 240px;
   --sidebar-collapsed: 48px;
   --titlebar-height: 38px;
+  --app-topbar-height: 49px;
 
   /* ── Coding-agent brand marks ────────────────────────────────────
    * One token per entry in config/agentRegistry.ts, so a surface that


### PR DESCRIPTION
## What changed

- align the full-page chat topbar with the dock tab strip
- hide the unused reply-style and settings actions from the chat topbar
- keep the dock Tabs control enabled and give empty states a usable fallback
- simplify stopped-run presentation after the conversation continues
- unify sidebar icons and move expand/collapse controls to the bottom

## Why

The affected controls were visually inconsistent and, in the empty global-chat state, the dock control was disabled even though the product design expects it to remain actionable.

## Behavior

- existing dock tabs still toggle normally
- workspace chat opens its canvas preview when possible
- global, scheduled, mounted-canvas, or rejected-preview cases open a blank browser tab
- expanded and collapsed sidebar controls now live in the footer area

## Validation

- `pnpm --filter canvas-workspace typecheck`
- Canvas UI reuse and file-size governance tests
- full `canvas-workspace` suite: 378 test files, 2372 tests passed
- standards and spec review: no remaining findings
