### PR TITLE
fix(canvas-workspace): drop stray default exports in AgentShellPathCard/MigrationSpinner

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/MigrationSpinner/index.tsx
@@ -251,5 +251,3 @@ export const MigrationSpinner = (): JSX.Element | null => {
     </div>
   );
 };
-
-export default MigrationSpinner;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentSection.tsx
@@ -10,7 +10,9 @@ import { useI18n } from '../../i18n';
 import { Button, FieldRow, Select } from '../ui';
 import './AgentSection.css';
 
-const AgentShellPathCard = lazy(() => import('./AgentShellPathCard'));
+const AgentShellPathCard = lazy(() =>
+  import('./AgentShellPathCard').then((module) => ({ default: module.AgentShellPathCard })),
+);
 
 interface AgentSectionProps {
   onClose: () => void;

--- a/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/Settings/AgentShellPathCard.tsx
@@ -9,7 +9,7 @@ interface AgentShellPathCardProps {
   onConfigured: () => Promise<void>;
 }
 
-const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps) => {
+export const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps) => {
   const { notify } = useAppShell();
   const { language, t } = useI18n();
   const [configuring, setConfiguring] = useState(false);
@@ -71,5 +71,3 @@ const AgentShellPathCard = ({ shellPath, onConfigured }: AgentShellPathCardProps
     </div>
   );
 };
-
-export default AgentShellPathCard;


### PR DESCRIPTION
## Summary

Scanned `apps/canvas-workspace` for UI style/consistency violations against the workspace's documented conventions (`harness/knowledge/conventions/frontend.md`) and its mechanically-enforced ratchet (`src/main/__tests__/ui-reuse-governance.test.ts`, which tracks hardcoded color/radius/shadow literals, raw `<button>`/`<input>` tags, bespoke overlay shells, etc.).

The governance ratchet is currently exactly at its locked baseline (18/18 checks pass, no drift), so there's no tokenization/reuse backlog to burn down safely without the visual-review rigor that system's own history requires. Widening the search to conventions the ratchet doesn't mechanically cover turned up one real, narrow inconsistency:

- `frontend.md`'s "Component style" section requires **named arrow-function exports**, explicitly: *"Avoid `default` exports for components."*
- Two components violated this — `MigrationSpinner` and `AgentShellPathCard` — while a third, functionally identical call site (`App.tsx` lazy-loading `MigrationSpinner`) already demonstrates the correct pattern: import the named export and re-wrap it as `{ default: module.X }` for `React.lazy`.
- `AgentSection.tsx`, however, lazy-loaded `AgentShellPathCard` straight off its `export default` — an inconsistent pattern between two otherwise identical lazy-component call sites in the same app.

## Changes

- `components/Settings/AgentShellPathCard.tsx`: `const AgentShellPathCard = ...` → `export const AgentShellPathCard = ...`; removed the trailing `export default`.
- `components/Settings/AgentSection.tsx`: updated the `lazy(() => import(...))` call to resolve the named export (matching `App.tsx`'s existing `MigrationSpinner` pattern) instead of the default export.
- `components/MigrationSpinner/index.tsx`: removed the now-dead `export default MigrationSpinner;` — the component was already exported as `export const MigrationSpinner`, and its only consumer (`App.tsx`) already imports the named export.

No behavior change — both components render identically; only the export/import shape changed.

## Test plan

- [x] `pnpm --filter canvas-workspace typecheck` — clean (required building `pulse-coder-engine` first; pre-existing unrelated `pulse-coder-engine/built-in` resolution errors on `master` are gone once that package is built, confirmed by diffing typecheck output against `master` with the same build step).
- [x] `pnpm --filter canvas-workspace test -- src/main/__tests__/ui-reuse-governance.test.ts src/main/__tests__/file-size-governance.test.ts` — 20/20 pass, ratchet unchanged.
- [x] `pnpm --filter canvas-workspace test` (full suite) — same 5 pre-existing failures as `master` (missing native `pty.node` prebuild, unbuilt `agent-teams/runtime`, one unrelated `SidebarHeader` i18n test), none touching the changed files.
- [x] Verified via `grep` that no other file references either component by its old default-export shape.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KoSxEyr5SXqJPmHNkNgsLV

---
_Generated by [Claude Code](https://claude.ai/code/session_01KoSxEyr5SXqJPmHNkNgsLV)_