### PR TITLE
fix: offload tool outputs to user dir by default

### DIFF
--- a/packages/engine/src/built-in/tool-offload-plugin/index.ts
+++ b/packages/engine/src/built-in/tool-offload-plugin/index.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from 'fs';
+import { homedir } from 'os';
 import path from 'path';
 
 import type { EnginePlugin, EnginePluginContext } from '../../plugin/EnginePlugin.js';
@@ -11,9 +12,10 @@ export type { OffloadStore, OffloadResult, OffloadOptions } from './offload.js';
 export interface ToolOffloadPluginOptions {
   /**
    * Absolute directory to store offloaded results under. Overrides the
-   * env/cwd-based default. Hosts that run the engine off the repo root (e.g.
-   * the Electron app, whose cwd is unpredictable) MUST pass an explicit
-   * user-scoped path so nothing is written into a source tree.
+   * env/user-dir default. Defaults to `TOOL_OFFLOAD_DIR` if set, otherwise
+   * `~/.pulse-coder/offload` — user-scoped so no host (even one with an
+   * unpredictable cwd) ever writes runtime data into a source tree. Hosts that
+   * want per-workspace isolation (e.g. the Canvas app) pass an explicit dir.
    */
   dir?: string;
   /** Payload-size threshold in chars. Defaults to TOOL_OFFLOAD_THRESHOLD. */
@@ -29,7 +31,7 @@ function resolveOffloadDir(dir?: string): string {
       ? TOOL_OFFLOAD_DIR
       : path.resolve(process.cwd(), TOOL_OFFLOAD_DIR);
   }
-  return path.resolve(process.cwd(), '.pulse-coder', 'offload');
+  return path.join(homedir(), '.pulse-coder', 'offload');
 }
 
 /**
@@ -126,9 +128,9 @@ export function createToolOffloadPlugin(options: ToolOffloadPluginOptions = {}):
 }
 
 /**
- * Default instance for the built-in plugin list (env/cwd-based dir). Hosts that
- * construct the engine off the repo root should use {@link createToolOffloadPlugin}
- * with an explicit `dir` instead.
+ * Default instance for the built-in plugin list (env/user-dir based). Hosts
+ * that want per-workspace isolation (e.g. the Canvas app) should use
+ * {@link createToolOffloadPlugin} with an explicit `dir` instead.
  */
 export const builtInToolOffloadPlugin: EnginePlugin = createToolOffloadPlugin();
 

--- a/packages/engine/src/config/index.ts
+++ b/packages/engine/src/config/index.ts
@@ -106,7 +106,7 @@ export const MAX_TOOL_OUTPUT_LENGTH = 30_000;
  * turns / sub-agents read the file on demand via the `read` / `grep` tools.
  *
  * Override the threshold via TOOL_OFFLOAD_THRESHOLD. Override the storage dir via
- * TOOL_OFFLOAD_DIR (defaults to `<cwd>/.pulse-coder/offload`).
+ * TOOL_OFFLOAD_DIR (defaults to `~/.pulse-coder/offload`).
  */
 export const TOOL_OFFLOAD_THRESHOLD = Number(process.env.TOOL_OFFLOAD_THRESHOLD ?? 30_000);
 export const TOOL_OFFLOAD_DIR = (process.env.TOOL_OFFLOAD_DIR ?? '').trim();


### PR DESCRIPTION
Default offload storage moves from `<cwd>/.pulse-coder/offload` to `~/.pulse-coder/offload`, so hosts with an unpredictable cwd (e.g. the Electron app) never write runtime data into a source tree.

- `resolveOffloadDir` falls back to `~/.pulse-coder/offload` (via `homedir()`) instead of `path.resolve(cwd, '.pulse-coder/offload')`
- Explicit `dir` option and `TOOL_OFFLOAD_DIR` env still win over the default — no behavior change for hosts that already pass an explicit dir (canvas-workspace keeps per-workspace isolation)
- Sync doc comments in `ToolOffloadPluginOptions` and `config/index.ts`

Verified: 10 tool-offload plugin tests pass, engine typecheck clean.