### PR TITLE
release(canvas): 0.1.43

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.42",
+  "version": "0.1.43",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump Pulse Canvas to 0.1.43
- publish macOS arm64 DMG and blockmap
- update stable latest.json with bilingual user-facing release notes
- deploy the download page

## Verification
- packaged macOS arm64 DMG successfully
- remote DMG returns HTTP 200 with content-length 97842973
- R2 and Pages manifests report version 0.1.43
- canvas-workspace typecheck passed
- canvas-workspace tests passed after rerunning the loopback suite outside the sandbox (2374/2374)
- Pi Electron smoke passed
- packaged agent tooling smoke passed