### PR TITLE
refactor(canvas): converge chat and dock scope state

### DIFF
--- a/apps/canvas-workspace/harness/knowledge/chat-sessions.md
+++ b/apps/canvas-workspace/harness/knowledge/chat-sessions.md
@@ -172,6 +172,16 @@ Guards: `RightDock/__tests__/dock-chat-availability.test.ts`,
 
 ### Explicit Chat ↔ dock-tab context
 
+Full-page Chat has one semantic owner: App's `ActiveChatTarget` carries the
+conversation `AgentScope`, session id, inherited context, and execution policy.
+The selected Canvas workspace remains separate. Global and scheduled Chat have
+no Canvas write destination; RightDock may retain a real workspace internally
+to host tabs, but that owner never grants Add-to-Canvas or Canvas edit access.
+Session-store sentinels stay behind `scopeSessionStoreId` / storage adapters —
+renderer navigation and unified session groups carry `AgentScope` directly.
+This is an in-memory/IPC contract cleanup only: existing on-disk directories,
+session pointers, and sentinel names remain unchanged.
+
 A content tab being visible beside Chat is never implicit model context. The
 user must add it through `@Tab` or the tab's Ask AI action. Full-page Chat
 initially binds the dock to the visible conversation's workspace scope, so its

--- a/apps/canvas-workspace/harness/knowledge/chat-sessions.md
+++ b/apps/canvas-workspace/harness/knowledge/chat-sessions.md
@@ -175,18 +175,21 @@ Guards: `RightDock/__tests__/dock-chat-availability.test.ts`,
 Full-page Chat has one semantic owner: App's `ActiveChatTarget` carries the
 conversation `AgentScope`, session id, inherited context, and execution policy.
 The selected Canvas workspace remains separate. Global and scheduled Chat have
-no Canvas write destination; RightDock may retain a real workspace internally
-to host tabs, but that owner never grants Add-to-Canvas or Canvas edit access.
+no Canvas write destination; RightDock gives them the shared global Dock scope
+instead of retaining or guessing a real workspace. That scope never grants
+Add-to-Canvas or Canvas edit access.
 Session-store sentinels stay behind `scopeSessionStoreId` / storage adapters —
 renderer navigation and unified session groups carry `AgentScope` directly.
-This is an in-memory/IPC contract cleanup only: existing on-disk directories,
-session pointers, and sentinel names remain unchanged.
+Existing on-disk chat directories, session pointers, and sentinel names remain
+unchanged. Dock web-tab persistence keeps its v1 schema and lazily adds the
+global Dock scope as one more key in the existing session record.
 
 A content tab being visible beside Chat is never implicit model context. The
 user must add it through `@Tab` or the tab's Ask AI action. Full-page Chat
-initially binds the dock to the visible conversation's workspace scope, so its
-Tabs are published under the same workspace that the Agent tools query. Global
-and scheduled conversations fall back to the active Canvas workspace. A
+binds the dock through the single `resolveDockScope` policy: workspace
+conversations use that workspace's Tabs, while global and scheduled
+conversations share a workspace-independent global Dock session. They never
+fall back to the last active Canvas workspace. A
 qualified tab reference may explicitly move the dock to that tab's owning
 workspace without changing the conversation scope; the next conversation
 switch binds it to the newly selected conversation again. Candidates are built

--- a/apps/canvas-workspace/src/main/agent/__tests__/service-history.test.ts
+++ b/apps/canvas-workspace/src/main/agent/__tests__/service-history.test.ts
@@ -95,8 +95,8 @@ describe('CanvasAgentService history', () => {
     expect(scan).toHaveBeenCalledWith(new Set(['__global_chat__']));
 
     expect(groups).toEqual([{
-      workspaceId: '__global_chat__',
-      workspaceName: 'Global Chat',
+      scope: { kind: 'global' },
+      scopeName: 'Global Chat',
       sessions: [{
         sessionId: 'session-current',
         date: '2026-07-29',

--- a/apps/canvas-workspace/src/main/agent/active-session-groups.ts
+++ b/apps/canvas-workspace/src/main/agent/active-session-groups.ts
@@ -51,8 +51,8 @@ export async function appendActiveSessionGroups({
     if (sessions.length === 0) continue;
     includedStoreIds.add(storeId);
     groups.push({
-      workspaceId: storeId,
-      workspaceName: scopeDisplayName(scope, scheduledTitles, workspaceNames),
+      scope,
+      scopeName: scopeDisplayName(scope, scheduledTitles, workspaceNames),
       sessions,
     });
   }

--- a/apps/canvas-workspace/src/main/agent/service.ts
+++ b/apps/canvas-workspace/src/main/agent/service.ts
@@ -315,7 +315,7 @@ export class CanvasAgentService {
   }
 
   /**
-   * List sessions from ALL workspaces, grouped by workspace.
+   * List sessions from every chat scope, grouped by semantic scope.
    * @param workspaceNames — map of workspaceId → display name (from renderer manifest)
    */
   async listAllSessions(
@@ -345,8 +345,8 @@ export class CanvasAgentService {
         : g.sessions;
 
       groups.push({
-        workspaceId: g.workspaceId,
-        workspaceName: scheduledTaskId
+        scope,
+        scopeName: scheduledTaskId
           ? scheduledTitles.get(scheduledTaskId) || scheduledTaskId
           : g.workspaceId === GLOBAL_CHAT_SESSION_STORE_ID
             ? GLOBAL_CHAT_WORKSPACE_NAME

--- a/apps/canvas-workspace/src/main/agent/types.ts
+++ b/apps/canvas-workspace/src/main/agent/types.ts
@@ -358,8 +358,8 @@ export interface SessionSearchHit {
 }
 
 export interface CrossWorkspaceSessionGroup {
-  workspaceId: string;
-  workspaceName: string;
+  scope: AgentScope;
+  scopeName: string;
   sessions: Array<{
     sessionId: string;
     date: string;

--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -208,7 +208,7 @@ const AppContent = () => {
     isOverlayOpen,
     openShortcuts,
   });
-  const { dockWorkspaceId, dockOwnerWorkspaceId, activateDockWorkspace } = useChatDockWorkspace(activeView, activeId, activeChatTarget, selectWorkspace);
+  const { dockWorkspaceId, dockScopeKey, activateDockWorkspace } = useChatDockWorkspace(activeView, activeId, activeChatTarget, selectWorkspace);
   const openSessionInOwningScope = useCallback(async (
     scope: AgentScope,
     sessionId: string,
@@ -575,7 +575,7 @@ const AppContent = () => {
         </PulseRouter>
       </div>
       <GlobalChatLauncher visible={isGlobalChatLauncherVisible(activeView)} />
-      <RightDock workspaces={workspaces} activeWorkspaceId={dockOwnerWorkspaceId} canvasWorkspaceId={dockWorkspaceId} activeIdReady={activeIdReady} chatTabEnabled={isDockChatTabEnabled(activeView)} canvasTabEditingAllowed={isCanvasTabEditingAllowed(activeView, dockWorkspaceId)} onCanvasNodesChange={handleNodesChange} onCanvasSelectionChange={handleSelectionChange} reserveSpace={activeView !== 'skills'} capWidth={activeView !== 'canvas'} pageMinAppWidth={(sidebarCollapsed ? 48 : 240) + 440} onOpenNodePage={openNodePage} onActivateWorkspace={activateDockWorkspace} />
+      <RightDock workspaces={workspaces} activeWorkspaceId={dockScopeKey} canvasWorkspaceId={dockWorkspaceId} activeIdReady={activeIdReady} chatTabEnabled={isDockChatTabEnabled(activeView)} canvasTabEditingAllowed={isCanvasTabEditingAllowed(activeView, dockWorkspaceId)} onCanvasNodesChange={handleNodesChange} onCanvasSelectionChange={handleSelectionChange} reserveSpace={activeView !== 'skills'} capWidth={activeView !== 'canvas'} pageMinAppWidth={(sidebarCollapsed ? 48 : 240) + 440} onOpenNodePage={openNodePage} onActivateWorkspace={activateDockWorkspace} />
       <Suspense fallback={null}><MigrationSpinner /></Suspense>
       <DeferredSettings
         appLoaded={appSettingsLoaded}

--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -96,7 +96,7 @@ const AppContent = () => {
   const routeQuery = routeParams.toString();
   const { notify, updateToast, confirm, openShortcuts, isOverlayOpen } = useAppShell();
   const chatTargetBroker = useChatTargetBroker();
-  const activeChatTarget = useActiveChatTarget();
+  const registeredChatTarget = useActiveChatTarget();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(readSidebarCollapsedPreference);
   const [settingsWorkspaceId, setSettingsWorkspaceId] = useState<string | null>(null);
   const [workspaceSettingsLoaded, setWorkspaceSettingsLoaded] = useState(false);
@@ -197,22 +197,18 @@ const AppContent = () => {
     }
   }, [routePath, detailNodeMatch, setLocation]);
 
-  const {
-    enterChatTarget,
-    enterChatView,
-    exitChatView,
-    initialTarget: chatEntryTarget,
-  } = useChatNavigation({
+  const { activeChatTarget, enterChatTarget, enterChatView, exitChatView, setActiveChatTarget } = useChatNavigation({
     activeView,
     location,
+    scheduledTaskId: routeParams.get('scheduledTask'),
     setLocation,
-    activeTarget: activeChatTarget,
+    activeTarget: registeredChatTarget,
     broker: chatTargetBroker,
     openDockChat: dock.openChat,
     isOverlayOpen,
     openShortcuts,
   });
-  const { dockWorkspaceId, reportChatWorkspace, activateDockWorkspace } = useChatDockWorkspace(activeView, activeId, chatEntryTarget?.scope, selectWorkspace);
+  const { dockWorkspaceId, dockOwnerWorkspaceId, activateDockWorkspace } = useChatDockWorkspace(activeView, activeId, activeChatTarget, selectWorkspace);
   const openSessionInOwningScope = useCallback(async (
     scope: AgentScope,
     sessionId: string,
@@ -544,13 +540,12 @@ const AppContent = () => {
           </PulseRouterView>
           <PulseRouterView name="chat">
             <ChatPage
+              activeChatTarget={activeChatTarget}
+              setActiveChatTarget={setActiveChatTarget}
               allWorkspaces={workspaces}
-              openScheduledTaskId={routeParams.get('scheduledTask')}
-              initialTarget={chatEntryTarget}
               getWorkspaceNodes={getWorkspaceNodes}
               getWorkspaceRootFolder={getWorkspaceRootFolder}
               onWorkspaceContextRequest={ensureWorkspaceNodesLoaded}
-              onWorkspaceScopeChange={reportChatWorkspace}
               onExit={exitChatView}
               onNodeFocus={focusNodeOnCanvas}
               onOpenAppSettings={openAppSettings}
@@ -580,7 +575,7 @@ const AppContent = () => {
         </PulseRouter>
       </div>
       <GlobalChatLauncher visible={isGlobalChatLauncherVisible(activeView)} />
-      <RightDock workspaces={workspaces} activeWorkspaceId={dockWorkspaceId} activeIdReady={activeIdReady} chatTabEnabled={isDockChatTabEnabled(activeView)} canvasTabEditingAllowed={isCanvasTabEditingAllowed(activeView)} onCanvasNodesChange={handleNodesChange} onCanvasSelectionChange={handleSelectionChange} reserveSpace={activeView !== 'skills'} capWidth={activeView !== 'canvas'} pageMinAppWidth={(sidebarCollapsed ? 48 : 240) + 440} onOpenNodePage={openNodePage} onActivateWorkspace={activateDockWorkspace} />
+      <RightDock workspaces={workspaces} activeWorkspaceId={dockOwnerWorkspaceId} canvasWorkspaceId={dockWorkspaceId} activeIdReady={activeIdReady} chatTabEnabled={isDockChatTabEnabled(activeView)} canvasTabEditingAllowed={isCanvasTabEditingAllowed(activeView, dockWorkspaceId)} onCanvasNodesChange={handleNodesChange} onCanvasSelectionChange={handleSelectionChange} reserveSpace={activeView !== 'skills'} capWidth={activeView !== 'canvas'} pageMinAppWidth={(sidebarCollapsed ? 48 : 240) + 440} onOpenNodePage={openNodePage} onActivateWorkspace={activateDockWorkspace} />
       <Suspense fallback={null}><MigrationSpinner /></Suspense>
       <DeferredSettings
         appLoaded={appSettingsLoaded}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatHeader.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatHeader.tsx
@@ -26,7 +26,7 @@ interface ChatHeaderProps {
   onToggleSessionMenu: () => Promise<void>;
   onCloseSessionMenu: () => void;
   onNewSession: () => Promise<void>;
-  onLoadSession: (sessionId: string, sourceWorkspaceId?: string) => Promise<void>;
+  onLoadSession: (sessionId: string) => Promise<void>;
   onOpenOriginalSession?: (session: OtherWorkspaceSession) => void;
   onCopyOtherSession?: (session: OtherWorkspaceSession) => Promise<void>;
   onOpenSettings: () => void;

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.tsx
@@ -1,32 +1,26 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import type { CanvasNode } from '../../types';
 import type { SettingsSection } from '../settings/Settings';
 import type { UnifiedSession } from './ChatSessionsRail';
 import { ChatPageBody } from './ChatPageBody';
 import type { SessionBackEntry } from './SessionBackBar';
 import type { AgentScope, WorkspaceOption } from './types';
-import { scheduledTaskIdFromStoreId } from '../../../../shared/agent-chat';
+import { chatScopeKey, chatSessionKey } from './utils/sessionScope';
 import type {
-  ChatContextSnapshot,
-  ChatExecutionPolicy,
-  ChatTarget,
+  ActiveChatTarget,
+  SetActiveChatTarget,
 } from './ChatTargetContext';
 
 const workspaceIdFromScope = (scope: AgentScope): string | null =>
   scope.kind === 'workspace' ? scope.workspaceId : null;
 
 interface ChatPageProps {
+  activeChatTarget: ActiveChatTarget;
+  setActiveChatTarget: SetActiveChatTarget;
   allWorkspaces: WorkspaceOption[];
-  /** Scheduled task whose chat should be opened on entry (route query). */
-  openScheduledTaskId?: string | null;
-  /** Visible chat target that opened this full-page surface. */
-  initialTarget?: ChatTarget | null;
   getWorkspaceNodes?: (workspaceId: string) => CanvasNode[];
   getWorkspaceRootFolder?: (workspaceId: string) => string | undefined;
   onWorkspaceContextRequest?: (workspaceId: string) => void;
-  /** Reports the workspace that owns the visible conversation. Global and
-   * scheduled conversations report null. */
-  onWorkspaceScopeChange?: (workspaceId: string | null) => void;
   onExit: () => void;
   onNodeFocus?: (workspaceId: string, nodeId: string) => void;
   /** Opens the global Settings drawer focused on the given section. */
@@ -39,7 +33,7 @@ interface ChatPageProps {
  * selects a workspace-owned historical session.
  *
  * Structure:
- *   - Outer ChatPage: owns currentWorkspaceId + pendingSessionId state.
+ *   - App owns ActiveChatTarget; ChatPage owns only transient navigation intent.
  *   - Inner ChatPageBody: stays mounted across scope changes. Its hooks switch
  *     subscriptions and cached state in place, so selecting another workspace
  *     does not recreate the whole chat surface.
@@ -47,116 +41,70 @@ interface ChatPageProps {
  * Mutual exclusion with ChatPanel is enforced at the App level.
  */
 export const ChatPage = ({
+  activeChatTarget,
+  setActiveChatTarget,
   allWorkspaces,
-  openScheduledTaskId,
-  initialTarget,
   getWorkspaceNodes,
   getWorkspaceRootFolder,
   onWorkspaceContextRequest,
-  onWorkspaceScopeChange,
   onExit,
   onNodeFocus,
   onOpenAppSettings,
 }: ChatPageProps) => {
-  const [agentScope, setAgentScope] = useState<AgentScope>(
-    () => initialTarget?.scope ?? { kind: 'global' },
-  );
+  const agentScope = activeChatTarget.scope;
   const [pendingSessionIntent, setPendingSessionIntent] = useState<{
     id: number;
     sessionId: string;
   } | null>(
-    () => initialTarget?.sessionId ? { id: 1, sessionId: initialTarget.sessionId } : null,
+    () => activeChatTarget.sessionId ? { id: 1, sessionId: activeChatTarget.sessionId } : null,
   );
-  const sessionIntentSequenceRef = useRef(initialTarget?.sessionId ? 1 : 0);
-  const pendingSessionIntentRef = useRef<number | null>(initialTarget?.sessionId ? 1 : null);
+  const sessionIntentSequenceRef = useRef(activeChatTarget.sessionId ? 1 : 0);
+  const pendingSessionIntentRef = useRef<number | null>(activeChatTarget.sessionId ? 1 : null);
   const pendingSessionId = pendingSessionIntent?.sessionId ?? null;
   const [selectedSessionKey, setSelectedSessionKey] = useState<string | null>(
-    () => initialTarget?.sessionId
-      ? `${initialTarget.scopeId}:${initialTarget.sessionId}`
+    () => activeChatTarget.sessionId
+      ? chatSessionKey(activeChatTarget.scope, activeChatTarget.sessionId)
       : null,
   );
-  const [contextSnapshot, setContextSnapshot] = useState<ChatContextSnapshot | undefined>(
-    () => initialTarget?.contextSnapshot,
-  );
-  const [executionPolicy, setExecutionPolicy] = useState<ChatExecutionPolicy>(
-    () => initialTarget?.executionPolicy ?? 'auto',
-  );
+  const contextSnapshot = activeChatTarget.contextSnapshot;
+  const executionPolicy = activeChatTarget.executionPolicy;
   const scopeRollbackRef = useRef<{
-    agentScope: AgentScope;
+    activeChatTarget: ActiveChatTarget;
     selectedSessionKey: string | null;
-    contextSnapshot?: ChatContextSnapshot;
-    executionPolicy: ChatExecutionPolicy;
     sessionBackStack: SessionBackEntry[];
   } | null>(null);
   const [railCollapsed, setRailCollapsed] = useState(true);
   // Jump trail for session-ref chip navigation. Owned here so scope changes
   // and thread replacement cannot disturb it.
   const [sessionBackStack, setSessionBackStack] = useState<SessionBackEntry[]>([]);
-  const scopeKey = agentScope.kind === 'workspace'
-    ? `workspace:${agentScope.workspaceId}`
-    : agentScope.kind === 'scheduled'
-      ? `scheduled:${agentScope.taskId}`
-      : 'global';
-
-  useEffect(() => {
-    onWorkspaceScopeChange?.(workspaceIdFromScope(agentScope));
-  }, [agentScope, onWorkspaceScopeChange]);
-
-  // Entry from the run-finished toast: land on the task's own conversation
-  // in this page's rail rather than a separate full-page route.
-  useEffect(() => {
-    if (!openScheduledTaskId) return;
-    scopeRollbackRef.current = null;
-    pendingSessionIntentRef.current = null;
-    sessionIntentSequenceRef.current += 1;
-    setAgentScope({ kind: 'scheduled', taskId: openScheduledTaskId });
-    setPendingSessionIntent(null);
-    setSelectedSessionKey(null);
-    setContextSnapshot(undefined);
-    setExecutionPolicy('scheduled');
-    setSessionBackStack([]);
-  }, [openScheduledTaskId]);
+  const scopeKey = chatScopeKey(agentScope);
 
   // Every session click keeps the body mounted. Cross-scope picks update the
   // scope and pending session together; the body swaps thread data in place.
-  const navigateToSession = useCallback((session: { sessionId: string; workspaceId: string }) => {
+  const navigateToSession = useCallback((session: { sessionId: string; scope: AgentScope }) => {
     const intentId = ++sessionIntentSequenceRef.current;
     pendingSessionIntentRef.current = intentId;
     setPendingSessionIntent({ id: intentId, sessionId: session.sessionId });
-    setSelectedSessionKey(`${session.workspaceId}:${session.sessionId}`);
-    // The rail's `workspaceId` is really a session-STORE id, so the two
-    // sentinel stores (global chat, one per scheduled task) must map back to
-    // their own scope kinds — treating them as workspace ids would activate
-    // an agent against a workspace that does not exist.
-    const scheduledTaskId = scheduledTaskIdFromStoreId(session.workspaceId);
-    const nextScope: AgentScope = scheduledTaskId
-      ? { kind: 'scheduled', taskId: scheduledTaskId }
-      : session.workspaceId === '__global_chat__'
-        ? { kind: 'global' }
-        : { kind: 'workspace', workspaceId: session.workspaceId };
-    const nextScopeKey = nextScope.kind === 'global'
-      ? 'global'
-      : nextScope.kind === 'scheduled'
-        ? `scheduled:${nextScope.taskId}`
-        : `workspace:${nextScope.workspaceId}`;
-    onWorkspaceScopeChange?.(workspaceIdFromScope(nextScope));
+    setSelectedSessionKey(chatSessionKey(session.scope, session.sessionId));
+    const nextScope = session.scope;
+    const nextScopeKey = chatScopeKey(nextScope);
     scopeRollbackRef.current ??= {
-      agentScope, selectedSessionKey, contextSnapshot, executionPolicy, sessionBackStack,
+      activeChatTarget, selectedSessionKey, sessionBackStack,
     };
-    setContextSnapshot(undefined);
-    setExecutionPolicy(nextScope.kind === 'scheduled' ? 'scheduled' : 'auto');
+    setActiveChatTarget({
+      scope: nextScope,
+      sessionId: session.sessionId,
+      executionPolicy: nextScope.kind === 'scheduled' ? 'scheduled' : 'auto',
+    });
     if (nextScopeKey === scopeKey) {
       return;
     }
-    setAgentScope(nextScope);
-  }, [agentScope, contextSnapshot, executionPolicy, onWorkspaceScopeChange, scopeKey, selectedSessionKey, sessionBackStack]);
+  }, [activeChatTarget, scopeKey, selectedSessionKey, sessionBackStack, setActiveChatTarget]);
 
   // Manual rail pick resets the jump trail; chip jumps (onJumpToSession)
   // keep it so the back bar can walk home.
   const handleSelectSession = useCallback((session: UnifiedSession) => {
     setSessionBackStack([]);
-    setContextSnapshot(undefined);
-    setExecutionPolicy(scheduledTaskIdFromStoreId(session.workspaceId) ? 'scheduled' : 'auto');
     navigateToSession(session);
   }, [navigateToSession]);
 
@@ -168,7 +116,7 @@ export const ChatPage = ({
     const entry = sessionBackStack[sessionBackStack.length - 1];
     if (!entry) return;
     setSessionBackStack((prev) => prev.slice(0, -1));
-    navigateToSession({ sessionId: entry.sessionId, workspaceId: entry.workspaceId });
+    navigateToSession({ sessionId: entry.sessionId, scope: entry.scope });
   }, [navigateToSession, sessionBackStack]);
 
   const handleClearBackStack = useCallback(() => {
@@ -182,16 +130,16 @@ export const ChatPage = ({
     const rollback = scopeRollbackRef.current;
     scopeRollbackRef.current = null;
     if (loaded || !rollback) return;
-    onWorkspaceScopeChange?.(workspaceIdFromScope(rollback.agentScope));
-    setAgentScope(rollback.agentScope);
+    setActiveChatTarget(rollback.activeChatTarget);
     setSelectedSessionKey(rollback.selectedSessionKey);
-    setContextSnapshot(rollback.contextSnapshot);
-    setExecutionPolicy(rollback.executionPolicy);
     setSessionBackStack(rollback.sessionBackStack);
-  }, [onWorkspaceScopeChange]);
-  const handleActiveSessionResolved = useCallback((sessionId: string, workspaceId: string) => {
-    setSelectedSessionKey(`${workspaceId}:${sessionId}`);
-  }, []);
+  }, [setActiveChatTarget]);
+  const handleActiveSessionResolved = useCallback((sessionId: string, scope: AgentScope) => {
+    setSelectedSessionKey(chatSessionKey(scope, sessionId));
+    setActiveChatTarget((current) => current.sessionId === sessionId
+      ? current
+      : { ...current, sessionId });
+  }, [setActiveChatTarget]);
 
   const handleToggleRail = useCallback(() => {
     setRailCollapsed((v) => !v);

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageBody.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageBody.tsx
@@ -41,10 +41,10 @@ export interface ChatPageBodyProps {
   /** Session chosen by the user, updated synchronously before its thread loads. */
   selectedSessionKey?: string | null;
   onSessionConsumed: (intentId: number, loaded: boolean) => void;
-  onActiveSessionResolved?: (sessionId: string, workspaceId: string) => void;
+  onActiveSessionResolved?: (sessionId: string, scope: AgentScope) => void;
   onSelectSession: (session: UnifiedSession) => void;
   /** Like onSelectSession but for chip jumps — does NOT reset the back stack. */
-  onJumpToSession?: (session: { sessionId: string; workspaceId: string }) => void;
+  onJumpToSession?: (session: { sessionId: string; scope: AgentScope }) => void;
   /** Top of the parent-owned session back stack (newest jump origin). */
   backEntry?: SessionBackEntry | null;
   onPushBackEntry?: (entry: SessionBackEntry) => void;
@@ -183,7 +183,7 @@ export const ChatPageBody = ({
     retrySession,
     selectMention,
     sendMessage,
-    sessions, sessionsLoading, sessionsStoreId, sessionLoading,
+    sessions, sessionsLoading, sessionsScope, sessionLoading,
     sessionError,
     setClarifyInput,
     setMentionIndex,
@@ -237,12 +237,12 @@ export const ChatPageBody = ({
     // selected rail key in that render gap. Once the intent is consumed, the
     // committed list owner is the authoritative store for this id.
     if (!pendingSessionId && !sessionLoading && activeSessionId) {
-      onActiveSessionResolved?.(activeSessionId, sessionsStoreId);
+      onActiveSessionResolved?.(activeSessionId, sessionsScope);
     }
-  }, [activeSessionId, onActiveSessionResolved, pendingSessionId, sessionLoading, sessionsStoreId]);
+  }, [activeSessionId, onActiveSessionResolved, pendingSessionId, sessionLoading, sessionsScope]);
   const retrySessionTransition = useChatPagePendingSession({
     busyElsewhere, handleLoadSession, onJumpToSession, onSessionConsumed,
-    pendingSessionId, pendingSessionIntentId, retrySession, sessionStoreId,
+    pendingSessionId, pendingSessionIntentId, retrySession, sessionScope: agentScope,
   });
 
   // See ChatPanel for the rationale; treat loading state as configured to
@@ -367,7 +367,7 @@ export const ChatPageBody = ({
     otherSessions,
     selectedSessionKey,
     sessions,
-    sessionsStoreId,
+    sessionsScope,
     pendingSessionKey: sessionLoading ? selectedSessionKey : null,
     disabled: sessionRailDisabled,
     focusInput,

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatSessionsRail.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatSessionsRail.tsx
@@ -7,14 +7,14 @@ import {
 import { Button, TextField } from '../ui';
 import { useI18n } from '../../i18n';
 import { ChatSessionRailItem } from './ChatSessionRailItem';
+import type { AgentScope } from './types';
+import { chatScopeKey, chatSessionKey } from './utils/sessionScope';
 
 const SESSION_PREVIEW_LIMIT = 10;
-const GLOBAL_CHAT_ID = '__global_chat__';
-
 export interface UnifiedSession {
   sessionId: string;
-  workspaceId: string;
-  workspaceName: string;
+  scope: AgentScope;
+  scopeName: string;
   date: string;
   updatedAt?: number;
   messageCount: number;
@@ -61,19 +61,21 @@ export const ChatSessionsRail = ({
   const [searchQuery, setSearchQuery] = useState('');
   const [expandedSessionGroupIds, setExpandedSessionGroupIds] = useState<Set<string>>(new Set());
   const allSessionGroups = useMemo(() => {
-    const groups = new Map<string, { id: string; name: string; sessions: UnifiedSession[] }>();
+    const groups = new Map<string, { id: string; name: string; scope: AgentScope; sessions: UnifiedSession[] }>();
     for (const session of allSessions) {
-      const group = groups.get(session.workspaceId);
+      const scopeId = chatScopeKey(session.scope);
+      const group = groups.get(scopeId);
       if (group) group.sessions.push(session);
-      else groups.set(session.workspaceId, {
-        id: session.workspaceId,
-        name: session.workspaceName,
+      else groups.set(scopeId, {
+        id: scopeId,
+        name: session.scopeName,
+        scope: session.scope,
         sessions: [session],
       });
     }
     return Array.from(groups.values())
       .sort((left, right) => {
-        const globalRank = (group: { id: string }) => group.id === GLOBAL_CHAT_ID ? 0 : 1;
+        const globalRank = (group: { scope: AgentScope }) => group.scope.kind === 'global' ? 0 : 1;
         return globalRank(left) - globalRank(right)
           || left.name.localeCompare(right.name)
           || left.id.localeCompare(right.id);
@@ -178,7 +180,7 @@ export const ChatSessionsRail = ({
         ) : (
           sessionGroups.map((group, groupIndex) => {
             const listId = `${railId}-sessions-${groupIndex}`;
-            const isGlobalGroup = group.id === GLOBAL_CHAT_ID;
+            const isGlobalGroup = group.scope.kind === 'global';
             const collapsed = !isGlobalGroup && !normalizedQuery && collapsedGroupIds.has(group.id);
             const showsAllSessions = Boolean(normalizedQuery) || expandedSessionGroupIds.has(group.id);
             const sessionPreview = group.sessions.slice(0, SESSION_PREVIEW_LIMIT);
@@ -215,7 +217,7 @@ export const ChatSessionsRail = ({
                 <div id={listId} className="chat-page-rail-list" role="list">
                   {!collapsed && visibleSessions.map((session) => (
                     <div
-                      key={`${session.workspaceId}:${session.sessionId}`}
+                      key={chatSessionKey(session.scope, session.sessionId)}
                       className="chat-page-rail-item-row"
                       role="listitem"
                     >
@@ -226,7 +228,7 @@ export const ChatSessionsRail = ({
                         onDeleteSession={onDeleteSession}
                         onTogglePinSession={onTogglePinSession}
                         disabled={disabled}
-                        pending={pendingSessionKey === `${session.workspaceId}:${session.sessionId}`}
+                        pending={pendingSessionKey === chatSessionKey(session.scope, session.sessionId)}
                       />
                     </div>
                   ))}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatTargetContext.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatTargetContext.tsx
@@ -3,7 +3,9 @@ import {
   useContext,
   useRef,
   useSyncExternalStore,
+  type Dispatch,
   type ReactNode,
+  type SetStateAction,
 } from 'react';
 import type {
   AgentContextDomReviewComment,
@@ -22,6 +24,33 @@ export interface ChatContextSnapshot {
   label: string;
   requestContext?: AgentRequestContext;
 }
+
+/**
+ * The conversation selected by the full-page Chat surface. Unlike
+ * `ChatTarget`, this is product state rather than a mounted-composer
+ * registration: it deliberately has no surface/composer/storage identity.
+ */
+export interface ActiveChatTarget {
+  scope: AgentScope;
+  sessionId: string | null;
+  contextSnapshot?: ChatContextSnapshot;
+  executionPolicy: ChatExecutionPolicy;
+}
+
+export type SetActiveChatTarget = Dispatch<SetStateAction<ActiveChatTarget>>;
+
+export const activeChatTargetFromRegisteredTarget = (
+  target: ChatTarget | null,
+): ActiveChatTarget => target ? {
+  scope: target.scope,
+  sessionId: target.sessionId,
+  contextSnapshot: target.contextSnapshot,
+  executionPolicy: target.executionPolicy,
+} : {
+  scope: { kind: 'global' },
+  sessionId: null,
+  executionPolicy: 'auto',
+};
 
 /**
  * Renderer-owned description of the composer a cross-surface action targets.

--- a/apps/canvas-workspace/src/renderer/src/components/chat/SessionBackBar.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/SessionBackBar.tsx
@@ -1,10 +1,10 @@
 import { useI18n } from '../../i18n';
+import type { AgentScope } from './types';
 
 /** One entry in the session back-navigation stack (where a jump started). */
 export interface SessionBackEntry {
   sessionId: string;
-  /** Session-store id — `__global_chat__` for global chat. */
-  workspaceId: string;
+  scope: AgentScope;
   /** Short human label for the session (first user message, trimmed). */
   label: string;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatHeader.cross-scope.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatHeader.cross-scope.test.tsx
@@ -22,7 +22,7 @@ describe('ChatHeader cross-scope sessions', () => {
           sessions={[]}
           otherSessions={[{
             sessionId: 'other-session',
-            sourceWorkspaceId: 'workspace-b',
+            sourceScope: { kind: 'workspace', workspaceId: 'workspace-b' },
             workspaceName: 'Workspace B',
             date: '2026-07-31',
             messageCount: 3,

--- a/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatNewSession.focus.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatNewSession.focus.test.tsx
@@ -40,7 +40,7 @@ const RailHarness = ({ createSession, initiallyAdopted = false }: RailHarnessPro
     otherSessions: [],
     selectedSessionKey: null,
     sessions: [],
-    sessionsStoreId: 'workspace-a',
+    sessionsScope: { kind: 'workspace', workspaceId: 'workspace-a' },
     disabled: false,
     focusInput: () => composerRef.current?.focus(),
     handleNewSession,

--- a/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatPage.scope-switch.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatPage.scope-switch.test.tsx
@@ -1,8 +1,12 @@
 // @vitest-environment happy-dom
-import { act } from 'react';
+import { act, useEffect, useState } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { ChatTarget } from '../ChatTargetContext';
+import {
+  activeChatTargetFromRegisteredTarget,
+  type ActiveChatTarget,
+  type ChatTarget,
+} from '../ChatTargetContext';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -21,12 +25,12 @@ vi.mock('../ChatPageBody', async () => {
       pendingSessionId: string | null;
       pendingSessionIntentId: number | null;
       onSessionConsumed: (intentId: number, loaded: boolean) => void;
-      onJumpToSession?: (session: { sessionId: string; workspaceId: string }) => void;
+      onJumpToSession?: (session: { sessionId: string; scope: { kind: string; workspaceId?: string; taskId?: string } }) => void;
       selectedSessionKey?: string | null;
       onSelectSession: (session: {
         sessionId: string;
-        workspaceId: string;
-        workspaceName: string;
+        scope: { kind: string; workspaceId?: string };
+        scopeName: string;
         date: string;
         messageCount: number;
       }) => void;
@@ -47,13 +51,13 @@ vi.mock('../ChatPageBody', async () => {
               event.preventDefault();
               props.onJumpToSession?.({
                 sessionId: 'session-jump',
-                workspaceId: props.agentScope.workspaceId ?? '__global_chat__',
+                scope: props.agentScope,
               });
             },
             onClick: () => props.onSelectSession({
               sessionId: 'session-b',
-              workspaceId: 'workspace-b',
-              workspaceName: 'Workspace B',
+              scope: { kind: 'workspace', workspaceId: 'workspace-b' },
+              scopeName: 'Workspace B',
               date: '2026-07-29',
               messageCount: 1,
             }),
@@ -73,6 +77,27 @@ vi.mock('../ChatPageBody', async () => {
 
 import { ChatPage } from '../ChatPage';
 
+const TestChatPage = ({
+  initialTarget,
+  onTargetChange,
+  ...props
+}: Omit<React.ComponentProps<typeof ChatPage>, 'activeChatTarget' | 'setActiveChatTarget'> & {
+  initialTarget?: ChatTarget | null;
+  onTargetChange?: (target: ActiveChatTarget) => void;
+}) => {
+  const [activeChatTarget, setActiveChatTarget] = useState(
+    () => activeChatTargetFromRegisteredTarget(initialTarget ?? null),
+  );
+  useEffect(() => onTargetChange?.(activeChatTarget), [activeChatTarget, onTargetChange]);
+  return (
+    <ChatPage
+      {...props}
+      activeChatTarget={activeChatTarget}
+      setActiveChatTarget={setActiveChatTarget}
+    />
+  );
+};
+
 let root: Root | null = null;
 let host: HTMLDivElement | null = null;
 
@@ -87,16 +112,16 @@ afterEach(() => {
 
 describe('ChatPage scope switching', () => {
   it.each([
-    ['__global_chat__', 'global'],
-    ['__scheduled__-task-1', 'scheduled'],
-  ])('routes a %s session reference to its special scope', async (workspaceId, expectedScope) => {
+    [{ kind: 'global' } as const, 'global', 'global'],
+    [{ kind: 'scheduled', taskId: 'task-1' } as const, 'scheduled', 'scheduled:task-1'],
+  ])('routes a $expectedScope session reference to its special scope', async (scope, expectedScope, expectedScopeKey) => {
     host = document.createElement('div');
     document.body.appendChild(host);
     root = createRoot(host);
 
     await act(async () => {
       root?.render(
-        <ChatPage
+        <TestChatPage
           allWorkspaces={[]}
           onExit={vi.fn()}
           onOpenAppSettings={vi.fn()}
@@ -106,19 +131,19 @@ describe('ChatPage scope switching', () => {
 
     act(() => mockState.latestProps?.onJumpToSession?.({
       sessionId: 'referenced-session',
-      workspaceId,
+      scope,
     }));
 
     const body = host.querySelector<HTMLButtonElement>('[data-chat-body]');
     expect(body?.textContent).toBe(expectedScope);
-    expect(body?.dataset.selectedSession).toBe(`${workspaceId}:referenced-session`);
+    expect(body?.dataset.selectedSession).toBe(`${expectedScopeKey}:referenced-session`);
 
     const intentId = mockState.latestProps?.pendingSessionIntentId as number;
     act(() => mockState.latestProps?.onSessionConsumed(intentId, true));
     expect(host.querySelector<HTMLButtonElement>('[data-chat-body]')?.textContent)
       .toBe(expectedScope);
     expect(host.querySelector<HTMLButtonElement>('[data-chat-body]')?.dataset.selectedSession)
-      .toBe(`${workspaceId}:referenced-session`);
+      .toBe(`${expectedScopeKey}:referenced-session`);
   });
 
   it('keeps ChatPageBody mounted when selecting a session in another workspace', async () => {
@@ -128,7 +153,7 @@ describe('ChatPage scope switching', () => {
 
     await act(async () => {
       root?.render(
-        <ChatPage
+        <TestChatPage
           allWorkspaces={[{ id: 'workspace-b', name: 'Workspace B' }]}
           onExit={vi.fn()}
           onOpenAppSettings={vi.fn()}
@@ -147,34 +172,39 @@ describe('ChatPage scope switching', () => {
     const switchedBody = host.querySelector('button');
     expect(switchedBody?.textContent).toBe('workspace-b');
     expect(switchedBody?.dataset.mountId).toBe('1');
-    expect(switchedBody?.dataset.selectedSession).toBe('workspace-b:session-b');
+    expect(switchedBody?.dataset.selectedSession).toBe('workspace:workspace-b:session-b');
     expect(mockState.mountCount).toBe(1);
   });
 
-  it('reports the owning workspace when a cross-workspace session is selected', async () => {
+  it('updates the active Chat target when a cross-workspace session is selected', async () => {
     host = document.createElement('div');
     document.body.appendChild(host);
     root = createRoot(host);
-    const onWorkspaceScopeChange = vi.fn();
+    const onTargetChange = vi.fn();
 
     await act(async () => {
       root?.render(
-        <ChatPage
+        <TestChatPage
           allWorkspaces={[{ id: 'workspace-b', name: 'Workspace B' }]}
-          onWorkspaceScopeChange={onWorkspaceScopeChange}
+          onTargetChange={onTargetChange}
           onExit={vi.fn()}
           onOpenAppSettings={vi.fn()}
         />,
       );
     });
 
-    expect(onWorkspaceScopeChange).toHaveBeenLastCalledWith(null);
+    expect(onTargetChange).toHaveBeenLastCalledWith(expect.objectContaining({
+      scope: { kind: 'global' },
+    }));
 
     await act(async () => {
       host?.querySelector<HTMLButtonElement>('[data-chat-body]')?.click();
     });
 
-    expect(onWorkspaceScopeChange).toHaveBeenLastCalledWith('workspace-b');
+    expect(onTargetChange).toHaveBeenLastCalledWith(expect.objectContaining({
+      scope: { kind: 'workspace', workspaceId: 'workspace-b' },
+      sessionId: 'session-b',
+    }));
   });
 
   it('rolls scope and rail selection back when a cross-scope session load fails', async () => {
@@ -183,7 +213,7 @@ describe('ChatPage scope switching', () => {
     root = createRoot(host);
     await act(async () => {
       root?.render(
-        <ChatPage
+        <TestChatPage
           allWorkspaces={[{ id: 'workspace-b', name: 'Workspace B' }]}
           onExit={vi.fn()}
           onOpenAppSettings={vi.fn()}
@@ -208,11 +238,11 @@ describe('ChatPage scope switching', () => {
     expect(rolledBack?.dataset.selectedSession).toBe('');
   });
 
-  it('restores the reported dock workspace when a cross-scope load fails', async () => {
+  it('restores the active Chat target when a cross-scope load fails', async () => {
     host = document.createElement('div');
     document.body.appendChild(host);
     root = createRoot(host);
-    const onWorkspaceScopeChange = vi.fn();
+    const onTargetChange = vi.fn();
     const initialTarget: ChatTarget = {
       surface: 'dock',
       scope: { kind: 'workspace', workspaceId: 'workspace-a' },
@@ -225,13 +255,13 @@ describe('ChatPage scope switching', () => {
 
     await act(async () => {
       root?.render(
-        <ChatPage
+        <TestChatPage
           allWorkspaces={[
             { id: 'workspace-a', name: 'Workspace A' },
             { id: 'workspace-b', name: 'Workspace B' },
           ]}
           initialTarget={initialTarget}
-          onWorkspaceScopeChange={onWorkspaceScopeChange}
+          onTargetChange={onTargetChange}
           onExit={vi.fn()}
           onOpenAppSettings={vi.fn()}
         />,
@@ -241,12 +271,17 @@ describe('ChatPage scope switching', () => {
     await act(async () => {
       host?.querySelector<HTMLButtonElement>('[data-chat-body]')?.click();
     });
-    expect(onWorkspaceScopeChange).toHaveBeenLastCalledWith('workspace-b');
+    expect(onTargetChange).toHaveBeenLastCalledWith(expect.objectContaining({
+      scope: { kind: 'workspace', workspaceId: 'workspace-b' },
+    }));
 
     await act(async () => {
       host?.querySelector<HTMLButtonElement>('[data-fail-session-load]')?.click();
     });
-    expect(onWorkspaceScopeChange).toHaveBeenLastCalledWith('workspace-a');
+    expect(onTargetChange).toHaveBeenLastCalledWith(expect.objectContaining({
+      scope: { kind: 'workspace', workspaceId: 'workspace-a' },
+      sessionId: 'session-a',
+    }));
   });
 
   it('inherits the scope and context of the chat target that opened the page', async () => {
@@ -265,7 +300,7 @@ describe('ChatPage scope switching', () => {
 
     await act(async () => {
       root?.render(
-        <ChatPage
+        <TestChatPage
           allWorkspaces={[{ id: 'workspace-a', name: 'Workspace A' }]}
           initialTarget={initialTarget}
           onExit={vi.fn()}
@@ -285,45 +320,9 @@ describe('ChatPage scope switching', () => {
       host?.querySelector<HTMLButtonElement>('[data-fail-session-load]')?.click();
     });
     const restored = host.querySelector<HTMLButtonElement>('[data-chat-body]');
-    expect(restored?.dataset.selectedSession).toBe('workspace-a:session-a');
+    expect(restored?.dataset.selectedSession).toBe('workspace:workspace-a:session-a');
     expect(restored?.dataset.contextLabel).toBe('Workspace A');
     expect(restored?.dataset.executionPolicy).toBe('ask');
-  });
-
-  it('clears stale rail selection when an external scheduled target opens', async () => {
-    host = document.createElement('div');
-    document.body.appendChild(host);
-    root = createRoot(host);
-
-    await act(async () => {
-      root?.render(
-        <ChatPage
-          allWorkspaces={[{ id: 'workspace-b', name: 'Workspace B' }]}
-          onExit={vi.fn()}
-          onOpenAppSettings={vi.fn()}
-        />,
-      );
-    });
-    await act(async () => {
-      host?.querySelector('button')?.click();
-    });
-    expect(host.querySelector('button')?.dataset.selectedSession).toBe('workspace-b:session-b');
-
-    await act(async () => {
-      root?.render(
-        <ChatPage
-          allWorkspaces={[{ id: 'workspace-b', name: 'Workspace B' }]}
-          openScheduledTaskId="daily-brief"
-          onExit={vi.fn()}
-          onOpenAppSettings={vi.fn()}
-        />,
-      );
-    });
-
-    const body = host.querySelector('button');
-    expect(body?.textContent).toBe('scheduled');
-    expect(body?.dataset.selectedSession).toBe('');
-    expect(body?.dataset.executionPolicy).toBe('scheduled');
   });
 
   it('ignores a stale completion after a newer parent session intent wins', async () => {
@@ -332,7 +331,7 @@ describe('ChatPage scope switching', () => {
     root = createRoot(host);
     await act(async () => {
       root?.render(
-        <ChatPage
+        <TestChatPage
           allWorkspaces={[
             { id: 'workspace-b', name: 'Workspace B' },
             { id: 'workspace-c', name: 'Workspace C' },
@@ -344,12 +343,12 @@ describe('ChatPage scope switching', () => {
     });
     act(() => mockState.latestProps?.onJumpToSession({
       sessionId: 'session-b',
-      workspaceId: 'workspace-b',
+      scope: { kind: 'workspace', workspaceId: 'workspace-b' },
     }));
     const staleIntent = mockState.latestProps?.pendingSessionIntentId as number;
     act(() => mockState.latestProps?.onJumpToSession({
       sessionId: 'session-c',
-      workspaceId: 'workspace-c',
+      scope: { kind: 'workspace', workspaceId: 'workspace-c' },
     }));
     const newestIntent = mockState.latestProps?.pendingSessionIntentId as number;
     expect(newestIntent).toBeGreaterThan(staleIntent);

--- a/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatSessionsRail.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatSessionsRail.test.tsx
@@ -20,24 +20,24 @@ afterEach(() => {
 const sessions: UnifiedSession[] = [
   {
     sessionId: 'session-a',
-    workspaceId: 'workspace-a',
-    workspaceName: 'Workspace A',
+    scope: { kind: 'workspace', workspaceId: 'workspace-a' },
+    scopeName: 'Workspace A',
     date: '2026-07-29',
     messageCount: 2,
     preview: 'First conversation',
   },
   {
     sessionId: 'session-b',
-    workspaceId: 'workspace-a',
-    workspaceName: 'Workspace A',
+    scope: { kind: 'workspace', workspaceId: 'workspace-a' },
+    scopeName: 'Workspace A',
     date: '2026-07-28',
     messageCount: 1,
     preview: 'Second conversation',
   },
   {
     sessionId: 'session-c',
-    workspaceId: 'workspace-b',
-    workspaceName: 'Workspace B',
+    scope: { kind: 'workspace', workspaceId: 'workspace-b' },
+    scopeName: 'Workspace B',
     date: '2026-07-27',
     messageCount: 1,
     preview: 'Third conversation',
@@ -46,8 +46,8 @@ const sessions: UnifiedSession[] = [
 
 const globalSession: UnifiedSession = {
   sessionId: 'global-session',
-  workspaceId: '__global_chat__',
-  workspaceName: 'Global Chat',
+  scope: { kind: 'global' },
+  scopeName: 'Global Chat',
   date: '2026-07-29',
   messageCount: 1,
   preview: 'Global conversation',
@@ -289,8 +289,8 @@ describe('ChatSessionsRail workspace tree', () => {
     root = createRoot(host);
     const manySessions = Array.from({ length: 15 }, (_, index): UnifiedSession => ({
       sessionId: `session-${index}`,
-      workspaceId: 'workspace-a',
-      workspaceName: 'Workspace A',
+      scope: { kind: 'workspace', workspaceId: 'workspace-a' },
+      scopeName: 'Workspace A',
       date: `2026-07-${String(30 - index).padStart(2, '0')}`,
       messageCount: 1,
       preview: `Conversation ${index + 1}`,
@@ -327,8 +327,8 @@ describe('ChatSessionsRail workspace tree', () => {
     root = createRoot(host);
     const manySessions = Array.from({ length: 15 }, (_, index): UnifiedSession => ({
       sessionId: `session-${index}`,
-      workspaceId: 'workspace-a',
-      workspaceName: 'Workspace A',
+      scope: { kind: 'workspace', workspaceId: 'workspace-a' },
+      scopeName: 'Workspace A',
       date: `2026-07-${String(30 - index).padStart(2, '0')}`,
       messageCount: 1,
       preview: `Conversation ${index + 1}`,
@@ -534,7 +534,7 @@ describe('ChatSessionsRail workspace tree', () => {
               ...session,
               isCurrent: session.sessionId === 'session-a',
             }))}
-            pendingSessionKey="workspace-a:session-a"
+            pendingSessionKey="workspace:workspace-a:session-a"
             onNewSession={vi.fn()}
             onSelectSession={vi.fn()}
           />

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/sessionListGroups.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/sessionListGroups.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import type { CrossWorkspaceSessionGroup } from '../../../../../shared/agent-chat';
+import { partitionSessionGroups } from './sessionListGroups';
+
+const session = {
+  sessionId: 'session-1',
+  date: '2026-08-12',
+  messageCount: 1,
+  isCurrent: true,
+};
+
+describe('partitionSessionGroups', () => {
+  it('preserves explicit scope ownership without decoding storage ids', () => {
+    const groups: CrossWorkspaceSessionGroup[] = [
+      {
+        scopeName: 'Global Chat',
+        scope: { kind: 'global' },
+        sessions: [session],
+      },
+      {
+        scopeName: 'Workspace A',
+        scope: { kind: 'workspace', workspaceId: 'workspace-a' },
+        sessions: [{ ...session, sessionId: 'session-2', isCurrent: false }],
+      },
+    ];
+
+    const result = partitionSessionGroups(groups, { kind: 'global' });
+
+    expect(result.sessions).toEqual([session]);
+    expect(result.otherSessions[0]).toMatchObject({
+      sourceScope: { kind: 'workspace', workspaceId: 'workspace-a' },
+    });
+    expect(result.otherSessions[0]).not.toHaveProperty('sourceWorkspaceId');
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/sessionListGroups.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/sessionListGroups.ts
@@ -1,19 +1,21 @@
 import type { CrossWorkspaceSessionGroup } from '../../../../../shared/agent-chat';
-import type { OtherWorkspaceSession } from '../types';
+import type { AgentScope, OtherWorkspaceSession } from '../types';
+import { chatScopeKey } from '../utils/sessionScope';
 
 export function partitionSessionGroups(
   groups: CrossWorkspaceSessionGroup[],
-  currentStoreId: string,
+  currentScope: AgentScope,
 ) {
   const otherSessions: OtherWorkspaceSession[] = [];
-  const currentGroup = groups.find(group => group.workspaceId === currentStoreId);
+  const currentScopeKey = chatScopeKey(currentScope);
+  const currentGroup = groups.find(group => chatScopeKey(group.scope) === currentScopeKey);
   for (const group of groups) {
     if (group === currentGroup) continue;
     for (const session of group.sessions) {
       otherSessions.push({
         ...session,
-        sourceWorkspaceId: group.workspaceId,
-        workspaceName: group.workspaceName,
+        sourceScope: group.scope,
+        workspaceName: group.scopeName,
       });
     }
   }
@@ -24,7 +26,7 @@ export function partitionSessionGroups(
   });
   return {
     sessions: currentGroup?.sessions ?? [],
-    currentScopeName: currentGroup?.workspaceName ?? null,
+    currentScopeName: currentGroup?.scopeName ?? null,
     otherSessions,
   };
 }

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatNavigation.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatNavigation.test.tsx
@@ -18,6 +18,41 @@ const target: ChatTarget = {
 };
 
 describe('useChatNavigation', () => {
+  it('exposes a scheduled route target on the first render', () => {
+    let firstTarget: ReturnType<typeof useChatNavigation>['activeChatTarget'] | undefined;
+    const broker = {
+      deliver: vi.fn(async () => ({ status: 'unavailable' as const, target: null })),
+      getActiveTarget: () => null,
+      register: vi.fn(),
+      subscribe: vi.fn(),
+    } satisfies ChatTargetBroker;
+    const host = document.createElement('div');
+    const root = createRoot(host);
+    const Harness = () => {
+      const navigation = useChatNavigation({
+        activeView: 'chat',
+        location: '/chat?scheduledTask=daily-brief',
+        scheduledTaskId: 'daily-brief',
+        setLocation: vi.fn(),
+        activeTarget: null,
+        broker,
+        openDockChat: vi.fn(),
+        isOverlayOpen: false,
+        openShortcuts: vi.fn(),
+      });
+      firstTarget ??= navigation.activeChatTarget;
+      return null;
+    };
+
+    act(() => root.render(<Harness />));
+    expect(firstTarget).toEqual({
+      scope: { kind: 'scheduled', taskId: 'daily-brief' },
+      sessionId: null,
+      executionPolicy: 'scheduled',
+    });
+    act(() => root.unmount());
+  });
+
   it('toggles full-page chat back to its source and restores focus', async () => {
     let latest: ReturnType<typeof useChatNavigation> | undefined;
     const deliver: ChatTargetBroker['deliver'] = vi.fn(async () => ({
@@ -59,7 +94,12 @@ describe('useChatNavigation', () => {
         shiftKey: true,
       }));
     });
-    expect(latest?.initialTarget).toEqual(target);
+    expect(latest?.activeChatTarget).toEqual({
+      scope: target.scope,
+      sessionId: target.sessionId,
+      contextSnapshot: target.contextSnapshot,
+      executionPolicy: target.executionPolicy,
+    });
     expect(latest?.isChatView).toBe(true);
 
     await act(async () => {
@@ -163,7 +203,22 @@ describe('useChatNavigation', () => {
     act(() => latest?.enterChatTarget(pageTarget));
 
     expect(location).toBe('/chat');
-    expect(latest?.initialTarget).toEqual(pageTarget);
+    expect(latest?.activeChatTarget).toEqual({
+      scope: pageTarget.scope,
+      sessionId: pageTarget.sessionId,
+      contextSnapshot: pageTarget.contextSnapshot,
+      executionPolicy: pageTarget.executionPolicy,
+    });
+
+    act(() => latest?.setActiveChatTarget((current) => ({
+      ...current,
+      scope: { kind: 'workspace', workspaceId: 'workspace-b' },
+      sessionId: 'session-b',
+    })));
+    expect(latest?.activeChatTarget).toMatchObject({
+      scope: { kind: 'workspace', workspaceId: 'workspace-b' },
+      sessionId: 'session-b',
+    });
 
     act(() => root.unmount());
   });

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatNavigation.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatNavigation.ts
@@ -1,13 +1,16 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type {
+  ActiveChatTarget,
   ChatTarget,
   ChatTargetBroker,
 } from '../ChatTargetContext';
+import { activeChatTargetFromRegisteredTarget } from '../ChatTargetContext';
 import { isImeComposing } from '../../../utils/ime';
 
 interface UseChatNavigationOptions {
   activeView: string;
   location: string;
+  scheduledTaskId?: string | null;
   setLocation: (path: string) => void;
   activeTarget: ChatTarget | null;
   broker: ChatTargetBroker;
@@ -33,6 +36,7 @@ const isEditableTarget = (target: EventTarget | null): boolean => {
 export const useChatNavigation = ({
   activeView,
   location,
+  scheduledTaskId,
   setLocation,
   activeTarget,
   broker,
@@ -40,9 +44,35 @@ export const useChatNavigation = ({
   isOverlayOpen,
   openShortcuts,
 }: UseChatNavigationOptions) => {
-  const [initialTarget, setInitialTarget] = useState<ChatTarget | null>(null);
+  const scheduledTarget = (taskId: string): ActiveChatTarget => ({
+    scope: { kind: 'scheduled', taskId },
+    sessionId: null,
+    executionPolicy: 'scheduled',
+  });
+  const [storedChatTarget, setActiveChatTarget] = useState<ActiveChatTarget>(
+    () => scheduledTaskId
+      ? scheduledTarget(scheduledTaskId)
+      : activeChatTargetFromRegisteredTarget(null),
+  );
+  const appliedScheduledTaskRef = useRef(scheduledTaskId ?? null);
+  const hasPendingScheduledRoute = Boolean(
+    scheduledTaskId && appliedScheduledTaskRef.current !== scheduledTaskId,
+  );
+  const activeChatTarget = hasPendingScheduledRoute
+    ? scheduledTarget(scheduledTaskId!)
+    : storedChatTarget;
   const returnPointRef = useRef<ChatReturnPoint | null>(null);
   const isChatView = activeView === 'chat';
+
+  useLayoutEffect(() => {
+    if (!scheduledTaskId) {
+      appliedScheduledTaskRef.current = null;
+      return;
+    }
+    if (appliedScheduledTaskRef.current === scheduledTaskId) return;
+    appliedScheduledTaskRef.current = scheduledTaskId;
+    setActiveChatTarget(scheduledTarget(scheduledTaskId));
+  }, [scheduledTaskId]);
 
   const enterChatTarget = useCallback((target: ChatTarget | null) => {
     if (activeView === 'chat') return;
@@ -52,7 +82,7 @@ export const useChatNavigation = ({
         ? document.activeElement
         : null,
     };
-    setInitialTarget(target);
+    setActiveChatTarget(activeChatTargetFromRegisteredTarget(target));
     setLocation('/chat');
   }, [activeView, location, setLocation]);
 
@@ -134,7 +164,8 @@ export const useChatNavigation = ({
     enterChatTarget,
     enterChatView,
     exitChatView,
-    initialTarget,
+    activeChatTarget,
+    setActiveChatTarget,
     isChatView,
     openAndFocusDockChat,
   };

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatPageJumpNavigation.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatPageJumpNavigation.test.tsx
@@ -38,7 +38,7 @@ describe('useChatPageJumpNavigation', () => {
 
     expect(onJumpToSession).toHaveBeenCalledWith({
       sessionId: 'target',
-      workspaceId: 'workspace-a',
+      scope: { kind: 'workspace', workspaceId: 'workspace-a' },
     });
     expect(handleLoadSession).not.toHaveBeenCalled();
     act(() => root.unmount());

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatPageJumpNavigation.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatPageJumpNavigation.ts
@@ -6,6 +6,7 @@ import type { SessionBackEntry } from '../SessionBackBar';
 import { buildAnchorElementId, buildChatAnchors } from '../utils/anchors';
 import { sessionTitleText } from '../utils/sessionTitle';
 import { scopeSessionStoreId } from '../../../../../shared/agent-chat';
+import { scopeFromSessionStoreId } from '../utils/sessionScope';
 
 const flashAnchor = (scopeId: string, messageIndex: number, delay = 0) => {
   window.setTimeout(() => {
@@ -23,7 +24,7 @@ interface Options {
   messages: AgentChatMessage[];
   scopeId: string;
   handleLoadSession: (sessionId: string) => Promise<boolean | undefined>;
-  onJumpToSession?: (session: { sessionId: string; workspaceId: string }) => void;
+  onJumpToSession?: (session: { sessionId: string; scope: AgentScope }) => void;
   onPushBackEntry?: (entry: SessionBackEntry) => void;
   onSelectSession: (session: UnifiedSession) => void;
 }
@@ -56,7 +57,7 @@ export const useChatPageJumpNavigation = ({
       if (current.ok && current.sessionId && current.sessionId !== sessionId) {
         onPushBackEntry?.({
           sessionId: current.sessionId,
-          workspaceId: currentSessionStoreId,
+          scope: agentScope,
           label: currentSessionLabel,
         });
       }
@@ -65,14 +66,14 @@ export const useChatPageJumpNavigation = ({
     }
 
     if (onJumpToSession) {
-      onJumpToSession({ sessionId, workspaceId: targetScopeId });
+      onJumpToSession({ sessionId, scope: scopeFromSessionStoreId(targetScopeId) });
     } else if (targetScopeId === currentSessionStoreId) {
       await handleLoadSession(sessionId);
     } else {
       onSelectSession({
         sessionId,
-        workspaceId: targetScopeId,
-        workspaceName: allWorkspaces.find(workspace => workspace.id === targetScopeId)?.name ?? targetScopeId,
+        scope: scopeFromSessionStoreId(targetScopeId),
+        scopeName: allWorkspaces.find(workspace => workspace.id === targetScopeId)?.name ?? targetScopeId,
         date: '',
         messageCount: 0,
         preview: '',

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatPagePendingSession.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatPagePendingSession.test.tsx
@@ -21,7 +21,7 @@ describe('useChatPagePendingSession', () => {
         pendingSessionId: 'session-a',
         pendingSessionIntentId: 7,
         retrySession,
-        sessionStoreId: 'workspace-a',
+        sessionScope: { kind: 'workspace', workspaceId: 'workspace-a' },
       });
       return null;
     };
@@ -36,7 +36,7 @@ describe('useChatPagePendingSession', () => {
     await act(async () => { await retry(); });
     expect(onJumpToSession).toHaveBeenCalledWith({
       sessionId: 'session-a',
-      workspaceId: 'workspace-a',
+      scope: { kind: 'workspace', workspaceId: 'workspace-a' },
     });
     expect(retrySession).not.toHaveBeenCalled();
     act(() => root.unmount());

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatPagePendingSession.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatPagePendingSession.ts
@@ -1,14 +1,15 @@
 import { useCallback, useEffect, useRef } from 'react';
+import type { AgentScope } from '../types';
 
 interface Options {
   busyElsewhere: boolean;
   handleLoadSession: (sessionId: string) => Promise<boolean | undefined>;
-  onJumpToSession?: (session: { sessionId: string; workspaceId: string }) => void;
+  onJumpToSession?: (session: { sessionId: string; scope: AgentScope }) => void;
   onSessionConsumed: (intentId: number, loaded: boolean) => void;
   pendingSessionId: string | null;
   pendingSessionIntentId: number | null;
   retrySession: () => Promise<void>;
-  sessionStoreId: string;
+  sessionScope: AgentScope;
 }
 
 export const useChatPagePendingSession = ({
@@ -19,13 +20,13 @@ export const useChatPagePendingSession = ({
   pendingSessionId,
   pendingSessionIntentId,
   retrySession,
-  sessionStoreId,
+  sessionScope,
 }: Options) => {
-  const failedIntentRef = useRef<{ sessionId: string; workspaceId: string } | null>(null);
+  const failedIntentRef = useRef<{ sessionId: string; scope: AgentScope } | null>(null);
 
   useEffect(() => {
     if (pendingSessionId === null || pendingSessionIntentId === null) return;
-    const intent = { sessionId: pendingSessionId, workspaceId: sessionStoreId };
+    const intent = { sessionId: pendingSessionId, scope: sessionScope };
     if (busyElsewhere) {
       failedIntentRef.current = intent;
       onSessionConsumed(pendingSessionIntentId, false);
@@ -41,7 +42,7 @@ export const useChatPagePendingSession = ({
     });
     return () => { cancelled = true; };
     // busyElsewhere is sampled per intent; a later flip must not abandon the fetch.
-  }, [handleLoadSession, onSessionConsumed, pendingSessionId, pendingSessionIntentId, sessionStoreId]);
+  }, [handleLoadSession, onSessionConsumed, pendingSessionId, pendingSessionIntentId, sessionScope]);
 
   return useCallback(async () => {
     const failedIntent = failedIntentRef.current;

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatPageSessionRail.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatPageSessionRail.ts
@@ -6,7 +6,6 @@ import type {
   WorkspaceOption,
 } from '../types';
 import type { ChatSessionsRailProps, UnifiedSession } from '../ChatSessionsRail';
-import { scopeFromSessionStoreId } from '../utils/sessionScope';
 import { restoreComposerFocusAfterRender } from '../utils/focusRecovery';
 import { useStableSessionRail } from './useStableSessionRail';
 
@@ -18,7 +17,7 @@ interface Options {
   otherSessions: OtherWorkspaceSession[];
   selectedSessionKey: string | null;
   sessions: AgentSessionInfo[];
-  sessionsStoreId: string;
+  sessionsScope: AgentScope;
   pendingSessionKey?: string | null;
   disabled: boolean;
   focusInput: () => void;
@@ -38,7 +37,7 @@ export const useChatPageSessionRail = ({
   otherSessions,
   selectedSessionKey,
   sessions,
-  sessionsStoreId,
+  sessionsScope,
   pendingSessionKey,
   disabled,
   focusInput,
@@ -57,7 +56,7 @@ export const useChatPageSessionRail = ({
     otherSessions,
     selectedSessionKey,
     sessions,
-    sessionsStoreId,
+    sessionsScope,
   });
   const onNewSession = useCallback(async () => {
     if (disabled) return;
@@ -70,16 +69,16 @@ export const useChatPageSessionRail = ({
     if (!disabled) onSelectSession(session);
   }, [disabled, onSelectSession]);
   const onRename = useCallback(async (session: UnifiedSession, title: string) => {
-    await renameSession(session.sessionId, title, scopeFromSessionStoreId(session.workspaceId));
+    await renameSession(session.sessionId, title, session.scope);
   }, [renameSession]);
   const onDelete = useCallback(async (session: UnifiedSession) => {
-    await deleteSession(session.sessionId, scopeFromSessionStoreId(session.workspaceId));
+    await deleteSession(session.sessionId, session.scope);
   }, [deleteSession]);
   const onTogglePin = useCallback(async (session: UnifiedSession) => {
     await toggleSessionPinned(
       session.sessionId,
       !session.isPinned,
-      scopeFromSessionStoreId(session.workspaceId),
+      session.scope,
     );
   }, [toggleSessionPinned]);
 

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatPanelSessionNavigation.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatPanelSessionNavigation.ts
@@ -10,6 +10,7 @@ import type { SessionBackEntry } from '../SessionBackBar';
 import { buildAnchorElementId, buildChatAnchors } from '../utils/anchors';
 import { restoreComposerFocusAfterRender } from '../utils/focusRecovery';
 import { scopeFromSessionStoreId } from '../utils/sessionScope';
+import { scopeSessionStoreId } from '../../../../../shared/agent-chat';
 
 const flashAnchor = (scopeId: string, messageIndex: number, delay = 0) => {
   window.setTimeout(() => {
@@ -33,7 +34,7 @@ interface Options {
   handleNewSession: () => Promise<{ ok: boolean }>;
   handleLoadSession: (
     sessionId: string,
-    sourceWorkspaceId?: string,
+    sourceScope?: AgentScope,
   ) => Promise<boolean | undefined>;
   onOpenSessionInScope?: (scope: AgentScope, sessionId: string, scopeLabel: string) => void;
 }
@@ -90,7 +91,7 @@ export const useChatPanelSessionNavigation = ({
       if (current.ok && currentSessionId && currentSessionId !== sessionId) {
         setBackStack(previous => [...previous, {
           sessionId: currentSessionId,
-          workspaceId: scopeId,
+          scope: agentScope,
           label: sessionTitle,
         }]);
       }
@@ -103,7 +104,7 @@ export const useChatPanelSessionNavigation = ({
     const entry = backStack[backStack.length - 1];
     if (!entry) return;
     setBackStack(previous => previous.slice(0, -1));
-    await jumpToSession(entry.sessionId, entry.workspaceId);
+    await jumpToSession(entry.sessionId, scopeSessionStoreId(entry.scope));
   }, [backStack, jumpToSession]);
   const onNewSession = useCallback(async () => {
     if (busy) return;
@@ -121,7 +122,7 @@ export const useChatPanelSessionNavigation = ({
     if (!onOpenSessionInScope) return;
     closeSessionMenu();
     onOpenSessionInScope(
-      scopeFromSessionStoreId(session.sourceWorkspaceId),
+      session.sourceScope,
       session.sessionId,
       session.workspaceName,
     );
@@ -129,7 +130,7 @@ export const useChatPanelSessionNavigation = ({
   const onCopyOtherSession = useCallback(async (session: OtherWorkspaceSession) => {
     if (busy) return;
     setBackStack([]);
-    await handleLoadSession(session.sessionId, session.sourceWorkspaceId);
+    await handleLoadSession(session.sessionId, session.sourceScope);
   }, [busy, handleLoadSession]);
   const anchors = useMemo(() => buildChatAnchors(messages), [messages]);
   const onJumpAnchor = useCallback(

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatSessions.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatSessions.test.tsx
@@ -120,6 +120,21 @@ afterEach(() => {
 });
 
 describe('useChatSessions — session detail loading', () => {
+  it('imports a global session into a workspace through the storage adapter boundary', async () => {
+    await mount(true);
+    await rerender(true, { kind: 'workspace', workspaceId: 'workspace-a' });
+
+    await act(async () => {
+      await latest!.handleLoadSession('global-session', { kind: 'global' });
+    });
+
+    expect(agent.loadCrossWorkspaceSession).toHaveBeenCalledWith(
+      'workspace-a',
+      '__global_chat__',
+      'global-session',
+    );
+    expect(agent.loadSession).not.toHaveBeenCalled();
+  });
 
   it('keeps the unified rail grouped by its committed scopes during a cross-scope thread load', async () => {
     const workspace = { id: 'workspace-a', name: 'Workspace A' };
@@ -138,8 +153,8 @@ describe('useChatSessions — session detail loading', () => {
       ok: true,
       groups: [
         {
-          workspaceId: '__global_chat__',
-          workspaceName: 'Global Chat',
+          scope: { kind: 'global' },
+          scopeName: 'Global Chat',
           sessions: [{
             sessionId: 'global-session',
             date: '2026-08-08',
@@ -149,8 +164,8 @@ describe('useChatSessions — session detail loading', () => {
           }],
         },
         {
-          workspaceId: workspace.id,
-          workspaceName: workspace.name,
+          scope: { kind: 'workspace', workspaceId: workspace.id },
+          scopeName: workspace.name,
           sessions: [{
             sessionId: 'workspace-session',
             date: '2026-08-07',
@@ -181,9 +196,9 @@ describe('useChatSessions — session detail loading', () => {
         currentScopeName: state.currentScopeName,
         sessionsLoading: state.sessionsLoading,
         otherSessions: state.otherSessions,
-        selectedSessionKey: pending ? `${workspace.id}:workspace-session` : '__global_chat__:global-session',
+        selectedSessionKey: pending ? `workspace:${workspace.id}:workspace-session` : 'global:global-session',
         sessions: state.sessions,
-        sessionsStoreId: state.sessionsStoreId,
+        sessionsScope: state.sessionsScope,
         disabled: false,
         focusInput,
         handleNewSession: state.handleNewSession,
@@ -192,7 +207,9 @@ describe('useChatSessions — session detail loading', () => {
         deleteSession: state.deleteSession,
         toggleSessionPinned: state.toggleSessionPinned,
       });
-      latestRailWorkspaceIds = [...new Set(rail.allSessions.map((session) => session.workspaceId))];
+      latestRailWorkspaceIds = [...new Set(rail.allSessions.map((session) => (
+        session.scope.kind === 'workspace' ? session.scope.workspaceId : session.scope.kind
+      )))];
       return null;
     };
 
@@ -206,7 +223,7 @@ describe('useChatSessions — session detail loading', () => {
         </I18nProvider>,
       );
     });
-    expect(latestRailWorkspaceIds.sort()).toEqual(['__global_chat__', workspace.id].sort());
+    expect(latestRailWorkspaceIds.sort()).toEqual(['global', workspace.id].sort());
 
     await act(async () => {
       root?.render(
@@ -217,7 +234,7 @@ describe('useChatSessions — session detail loading', () => {
     });
     act(() => { void latest!.handleLoadSession('workspace-session'); });
 
-    expect(latestRailWorkspaceIds.sort()).toEqual(['__global_chat__', workspace.id].sort());
+    expect(latestRailWorkspaceIds.sort()).toEqual(['global', workspace.id].sort());
 
     await act(async () => {
       thread.resolve({
@@ -423,8 +440,8 @@ describe('useChatSessions — session detail loading', () => {
       ok: true,
       groups: [
         {
-          workspaceId: '__global_chat__',
-          workspaceName: 'Global Chat',
+          scope: { kind: 'global' },
+          scopeName: 'Global Chat',
           sessions: [{
             sessionId: 'global-current',
             date: '2026-08-08',
@@ -434,8 +451,8 @@ describe('useChatSessions — session detail loading', () => {
           }],
         },
         {
-          workspaceId: 'workspace-a',
-          workspaceName: 'Workspace A',
+          scope: { kind: 'workspace', workspaceId: 'workspace-a' },
+          scopeName: 'Workspace A',
           sessions: [{
             sessionId: 'workspace-session',
             date: '2026-08-07',
@@ -658,8 +675,8 @@ describe('useChatSessions — session detail loading', () => {
         ok: true,
         groups: [
           {
-            workspaceId: '__global_chat__',
-            workspaceName: 'Global Chat',
+            scope: { kind: 'global' },
+            scopeName: 'Global Chat',
             sessions: [{
               sessionId: 'global-a',
               date: '2026-07-29',
@@ -669,8 +686,8 @@ describe('useChatSessions — session detail loading', () => {
             }],
           },
           {
-            workspaceId: 'workspace-a',
-            workspaceName: 'Workspace A',
+            scope: { kind: 'workspace', workspaceId: 'workspace-a' },
+            scopeName: 'Workspace A',
             sessions: [{
               sessionId: 'workspace-a-1',
               date: '2026-07-29',

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatSessions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatSessions.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react
 import type { AgentChatMessage, AgentSessionInfo } from '../../../types';
 import type { AgentScope, OtherWorkspaceSession, WorkspaceOption } from '../types';
 import { useClickOutside } from '../../../hooks/useClickOutside';
-import { scopeSessionStoreId } from '../../../../../shared/agent-chat';
+import { chatScopeKey, scopeSessionStoreId } from '../../../../../shared/agent-chat';
 import { useI18n } from '../../../i18n';
 import {
   beginChatConversationMutation,
@@ -67,11 +67,7 @@ export function useChatSessions({
 }: UseChatSessionsOptions) {
   const { t } = useI18n();
   const workspaceId = agentScope.kind === 'workspace' ? agentScope.workspaceId : undefined;
-  const scopeKey = agentScope.kind === 'workspace'
-    ? `workspace:${agentScope.workspaceId}`
-    : agentScope.kind === 'scheduled'
-      ? `scheduled:${agentScope.taskId}`
-      : 'global';
+  const scopeKey = chatScopeKey(agentScope);
 
   const [sessionMenuOpen, setSessionMenuOpen] = useState(false);
   // Revisited scopes repaint their cached rail immediately.
@@ -82,9 +78,7 @@ export function useChatSessions({
     () => sessionsCache.get(scopeKey)?.otherSessions ?? [],
   );
   // Keep list ownership explicit while a cross-scope thread is opening.
-  const [sessionsStoreId, setSessionsStoreId] = useState(
-    () => scopeSessionStoreId(agentScope),
-  );
+  const [sessionsScope, setSessionsScope] = useState<AgentScope>(agentScope);
   const [currentScopeName, setCurrentScopeName] = useState<string | null>(null);
   // Avoid an empty-state flash before an eager first list fetch.
   const [sessionsLoading, setSessionsLoading] = useState(
@@ -222,7 +216,6 @@ export function useChatSessions({
     const token = ++sessionListRequestRef.current;
     setSessionsLoading(true);
     try {
-      const currentStoreId = scopeSessionStoreId(agentScope);
       const workspaceNameMap: Record<string, string> = {};
       for (const workspace of allWorkspaces ?? []) {
         workspaceNameMap[workspace.id] = workspace.name;
@@ -248,7 +241,7 @@ export function useChatSessions({
 
       if (allResult) {
         if (allResult.ok && allResult.groups) {
-          const partitioned = partitionSessionGroups(allResult.groups, currentStoreId);
+          const partitioned = partitionSessionGroups(allResult.groups, agentScope);
           nextSessions = partitioned.sessions;
           nextOtherSessions = partitioned.otherSessions;
           nextCurrentScopeName = partitioned.currentScopeName;
@@ -263,7 +256,7 @@ export function useChatSessions({
       // the folder tree around the pointer.
       if (nextSessions) {
         setSessions(nextSessions);
-        setSessionsStoreId(scopeSessionStoreId(agentScope));
+        setSessionsScope(agentScope);
       }
       if (nextOtherSessions) setOtherSessions(nextOtherSessions);
       if (nextCurrentScopeName !== undefined) {
@@ -346,23 +339,27 @@ export function useChatSessions({
     }
   }, [agentScope, mutationRef, onConversationMutationStart, onMessagesLoaded, t]);
 
-  const handleLoadSession = useCallback(async (sessionId: string, sourceWorkspaceId?: string) => {
+  const handleLoadSession = useCallback(async (sessionId: string, sourceScope?: AgentScope) => {
     setSessionMenuOpen(false);
 
     const crossWorkspace = !!(
-      sourceWorkspaceId
-      && workspaceId
-      && sourceWorkspaceId !== workspaceId
+      sourceScope
+      && agentScope.kind === 'workspace'
+      && chatScopeKey(sourceScope) !== chatScopeKey(agentScope)
     );
     return await runThreadFetch(
       () => (
         crossWorkspace
-          ? window.canvasWorkspace.agent.loadCrossWorkspaceSession(workspaceId!, sourceWorkspaceId!, sessionId)
+          ? window.canvasWorkspace.agent.loadCrossWorkspaceSession(
+              agentScope.workspaceId,
+              scopeSessionStoreId(sourceScope),
+              sessionId,
+            )
           : window.canvasWorkspace.agent.loadSession({ scope: agentScope }, sessionId)
       ),
       crossWorkspace ? undefined : sessionId,
     );
-  }, [agentScope, runThreadFetch, workspaceId]);
+  }, [agentScope, runThreadFetch]);
 
   /** Adopt the session created by an authoritative main-process branch mutation. */
   const adoptActiveSession = useCallback((sessionId: string) => {
@@ -473,7 +470,7 @@ export function useChatSessions({
   return {
     adoptActiveSession,
     otherSessions,
-    sessionsStoreId,
+    sessionsScope,
     activeSessionId,
     currentScopeName,
     deleteSession,

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useStableSessionRail.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useStableSessionRail.ts
@@ -1,8 +1,8 @@
 import { useMemo, useRef } from 'react';
-import { scopeSessionStoreId } from '../../../../../shared/agent-chat';
 import type { AgentSessionInfo } from '../../../types';
 import type { UnifiedSession } from '../ChatSessionsRail';
 import type { AgentScope, OtherWorkspaceSession, WorkspaceOption } from '../types';
+import { chatScopeKey, chatSessionKey } from '../utils/sessionScope';
 
 interface UseStableSessionRailOptions {
   agentScope: AgentScope;
@@ -12,7 +12,7 @@ interface UseStableSessionRailOptions {
   otherSessions: OtherWorkspaceSession[];
   selectedSessionKey: string | null;
   sessions: AgentSessionInfo[];
-  sessionsStoreId: string;
+  sessionsScope: AgentScope;
 }
 
 /**
@@ -29,41 +29,40 @@ export function useStableSessionRail({
   otherSessions,
   selectedSessionKey,
   sessions,
-  sessionsStoreId,
+  sessionsScope,
 }: UseStableSessionRailOptions): UnifiedSession[] {
   const stableSessionsRef = useRef<UnifiedSession[]>([]);
-  const stableScopeRef = useRef(scopeSessionStoreId(agentScope));
+  const stableScopeRef = useRef(chatScopeKey(agentScope));
   const computedSessions = useMemo(() => {
-    const activeStoreId = scopeSessionStoreId(agentScope);
-    const workspaceId = sessionsStoreId === activeStoreId && agentScope.kind === 'workspace'
-      ? agentScope.workspaceId
-      : sessionsStoreId;
     const workspaceName = currentScopeName
-      ?? (sessionsStoreId === '__global_chat__'
+      ?? (sessionsScope.kind === 'global'
         ? 'Global Chat'
-        : allWorkspaces.find((workspace) => workspace.id === workspaceId)?.name ?? workspaceId);
+        : sessionsScope.kind === 'scheduled'
+          ? sessionsScope.taskId
+          : allWorkspaces.find((workspace) => workspace.id === sessionsScope.workspaceId)?.name
+            ?? sessionsScope.workspaceId);
     const unified: UnifiedSession[] = [
       ...sessions.map((session) => ({
         ...session,
         preview: session.title ?? session.preview,
         isPinned: session.pinned,
-        workspaceId: sessionsStoreId,
-        workspaceName,
+        scope: sessionsScope,
+        scopeName: workspaceName,
         isCurrent: selectedSessionKey
-          ? selectedSessionKey === `${sessionsStoreId}:${session.sessionId}`
+          ? selectedSessionKey === chatSessionKey(sessionsScope, session.sessionId)
           : session.isCurrent,
       })),
       ...otherSessions.map((session) => ({
         sessionId: session.sessionId,
-        workspaceId: session.sourceWorkspaceId,
-        workspaceName: session.workspaceName,
+        scope: session.sourceScope,
+        scopeName: session.workspaceName,
         date: session.date,
         updatedAt: session.updatedAt,
         messageCount: session.messageCount,
         preview: session.title ?? session.preview,
         isPinned: session.pinned,
         isCurrent: selectedSessionKey
-          === `${session.sourceWorkspaceId}:${session.sessionId}`,
+          === chatSessionKey(session.sourceScope, session.sessionId),
       })),
     ];
     return unified.sort((left, right) => (
@@ -71,17 +70,17 @@ export function useStableSessionRail({
       || right.date.localeCompare(left.date)
       || right.sessionId.localeCompare(left.sessionId)
     ));
-  }, [agentScope, allWorkspaces, currentScopeName, otherSessions, selectedSessionKey, sessions, sessionsStoreId]);
+  }, [allWorkspaces, currentScopeName, otherSessions, selectedSessionKey, sessions, sessionsScope]);
 
   return useMemo(() => {
-    const nextScopeId = scopeSessionStoreId(agentScope);
+    const nextScopeId = chatScopeKey(agentScope);
     const scopeChanged = stableScopeRef.current !== nextScopeId;
     if (scopeChanged) stableScopeRef.current = nextScopeId;
     if ((scopeChanged || loading) && stableSessionsRef.current.length > 0) {
       return stableSessionsRef.current.map((session) => ({
         ...session,
         isCurrent: selectedSessionKey
-          ? selectedSessionKey === `${session.workspaceId}:${session.sessionId}`
+          ? selectedSessionKey === chatSessionKey(session.scope, session.sessionId)
           : session.isCurrent,
       }));
     }

--- a/apps/canvas-workspace/src/renderer/src/components/chat/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/types.ts
@@ -107,7 +107,7 @@ export interface ChatPanelProps {
 }
 
 export interface OtherWorkspaceSession extends AgentSessionInfo {
-  sourceWorkspaceId: string;
+  sourceScope: AgentScope;
   workspaceName: string;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/chat/utils/chatPageDockTabs.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/utils/chatPageDockTabs.ts
@@ -7,8 +7,8 @@ const UNBOUND_DOCK_WORKSPACE_ID = '__default__';
 /**
  * Project the actual RightDock beside the full-page chat into explicit
  * `@Tab` candidates. Chat scope and dock ownership are deliberately separate:
- * a global or historical chat may sit beside the currently active workspace's
- * dock, and merely showing a tab never injects it into the request context.
+ * global and scheduled chats share the workspace-independent Dock session,
+ * and merely showing a tab never injects it into the request context.
  */
 export function buildChatPageDockTabRefs(state: DockState): AgentContextTabRef[] {
   const dockWorkspaceId = state.activeTerminalWorkspaceId;

--- a/apps/canvas-workspace/src/renderer/src/components/chat/utils/sessionScope.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/utils/sessionScope.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createChatPageSessionTarget, scopeFromSessionStoreId } from './sessionScope';
+import { chatScopeKey, createChatPageSessionTarget, scopeFromSessionStoreId } from './sessionScope';
 
 describe('scopeFromSessionStoreId', () => {
   it('keeps workspace, global, and scheduled session ownership distinct', () => {
@@ -26,5 +26,12 @@ describe('scopeFromSessionStoreId', () => {
       contextSnapshot: { label: 'Daily brief' },
       executionPolicy: 'scheduled',
     });
+  });
+
+  it('uses semantic renderer keys without leaking storage sentinels', () => {
+    expect(chatScopeKey({ kind: 'global' })).toBe('global');
+    expect(chatScopeKey({ kind: 'scheduled', taskId: 'task-1' })).toBe('scheduled:task-1');
+    expect(chatScopeKey({ kind: 'workspace', workspaceId: 'workspace-1' }))
+      .toBe('workspace:workspace-1');
   });
 });

--- a/apps/canvas-workspace/src/renderer/src/components/chat/utils/sessionScope.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/utils/sessionScope.ts
@@ -1,10 +1,15 @@
 import {
+  chatScopeKey,
   GLOBAL_CHAT_STORE_ID,
   scheduledTaskIdFromStoreId,
   scopeSessionStoreId,
 } from '../../../../../shared/agent-chat';
+export { chatScopeKey } from '../../../../../shared/agent-chat';
 import type { AgentScope } from '../types';
 import type { ChatTarget } from '../ChatTargetContext';
+
+export const chatSessionKey = (scope: AgentScope, sessionId: string): string =>
+  `${chatScopeKey(scope)}:${sessionId}`;
 
 /** Maps the session rail's storage identity back to the owning agent scope. */
 export const scopeFromSessionStoreId = (storeId: string): AgentScope => {

--- a/apps/canvas-workspace/src/renderer/src/components/dock/LinkDrawer/__tests__/dom-selection.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/LinkDrawer/__tests__/dom-selection.test.tsx
@@ -102,7 +102,6 @@ describe('LinkTabView DOM selection', () => {
             activeWorkspaceId="workspace-1"
             onNavigate={() => undefined}
             onGuestNavigate={() => undefined}
-            onAddToReference={() => undefined}
             onAddDomSelectionToChat={onAddDomSelectionToChat}
             tabRef={{
               id: 'link-tab-1',

--- a/apps/canvas-workspace/src/renderer/src/components/dock/LinkDrawer/icons.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/LinkDrawer/icons.tsx
@@ -1,9 +1,3 @@
-export const ReferenceIcon = () => (
-  <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-    <path d="M3 1.75h6v8.5L6 8.3l-3 1.95v-8.5z" stroke="currentColor" strokeWidth="1.15" strokeLinejoin="round" />
-  </svg>
-);
-
 export const InspectIcon = () => (
   <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
     <path

--- a/apps/canvas-workspace/src/renderer/src/components/dock/LinkDrawer/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/LinkDrawer/index.tsx
@@ -14,7 +14,7 @@ import { AddressSuggestionList } from './AddressSuggestions';
 import { LinkTabLoadError } from './LinkTabLoadError';
 import { PageContextMenu } from './PageContextMenu';
 import { FindInPageBar } from './FindInPageBar';
-import { InspectIcon, ReferenceIcon } from './icons';
+import { InspectIcon } from './icons';
 import { useAddressBar } from './useAddressBar';
 import { useFindInPage } from './useFindInPage';
 import { usePageContextMenu } from './usePageContextMenu';
@@ -74,7 +74,6 @@ interface LinkTabViewProps {
   onNavigate: (url: string) => void;
   /** Mirror a guest navigation without resetting a resolved page title. */
   onGuestNavigate: (url: string) => void;
-  onAddToReference: (url: string, title?: string) => void;
   onAddDomSelectionToChat: (selection: AgentContextDomSelectionRef) => Promise<ChatDeliveryReceipt>;
   tabRef?: AgentContextTabRef;
   targetWorkspaceId?: string;
@@ -83,6 +82,8 @@ interface LinkTabViewProps {
    *  next to this one. Distinct from `onNavigate`, which moves this tab. */
   onOpenLink: (url: string, options?: { background?: boolean }) => void;
   activeWorkspaceId: string;
+  /** Canvas write destination. Global/scheduled Chat intentionally passes null. */
+  canvasWorkspaceId?: string | null;
   onRequestClose: () => void;
 }
 
@@ -97,13 +98,13 @@ export const LinkTabView = ({
   onFaviconChange,
   onNavigate,
   onGuestNavigate,
-  onAddToReference,
   onAddDomSelectionToChat,
   tabRef,
   targetWorkspaceId,
   onAddTabToChat,
   onOpenLink,
   activeWorkspaceId,
+  canvasWorkspaceId = activeWorkspaceId,
   onRequestClose,
 }: LinkTabViewProps) => {
   const { t } = useI18n();
@@ -246,19 +247,14 @@ export const LinkTabView = ({
   }, [browser.currentUrl]);
 
   const handleAddToCanvas = useCallback(() => {
-    if (!browser.currentUrl || !activeWorkspaceId) return;
+    if (!browser.currentUrl || !canvasWorkspaceId) return;
     window.dispatchEvent(
       new CustomEvent('canvas:add-iframe-from-url', {
-        detail: { workspaceId: activeWorkspaceId, url: browser.currentUrl },
+        detail: { workspaceId: canvasWorkspaceId, url: browser.currentUrl },
       }),
     );
     onRequestClose();
-  }, [browser.currentUrl, activeWorkspaceId, onRequestClose]);
-
-  const handleAddToReference = useCallback(() => {
-    if (!browser.currentUrl) return;
-    onAddToReference(browser.currentUrl, title);
-  }, [browser.currentUrl, onAddToReference, title]);
+  }, [browser.currentUrl, canvasWorkspaceId, onRequestClose]);
 
   const handlePickDomElement = useCallback(async () => {
     if (!activeWorkspaceId || !tabId || !browser.currentUrl) return;
@@ -369,17 +365,6 @@ export const LinkTabView = ({
             variant="icon"
             size="xs"
             className="link-drawer__action"
-            aria-label={t('linkDrawer.addToReference')}
-            title={t('linkDrawer.addToReference')}
-            onClick={handleAddToReference}
-            disabled={!browser.currentUrl}
-          >
-            <ReferenceIcon />
-          </Button>
-          <Button
-            variant="icon"
-            size="xs"
-            className="link-drawer__action"
             aria-label={t('linkDrawer.openInBrowser')}
             title={t('linkDrawer.openInBrowser')}
             onClick={handleOpenInBrowser}
@@ -387,17 +372,19 @@ export const LinkTabView = ({
           >
             <ExternalLinkIcon />
           </Button>
-          <Button
-            variant="icon"
-            size="xs"
-            className="link-drawer__action"
-            aria-label={t('linkDrawer.addToCanvas')}
-            onClick={handleAddToCanvas}
-            disabled={!activeWorkspaceId || !browser.currentUrl}
-            title={activeWorkspaceId ? t('linkDrawer.addToCanvas') : t('linkDrawer.noActiveCanvas')}
-          >
-            <PlusIcon size={12} strokeWidth={1.2} />
-          </Button>
+          {canvasWorkspaceId ? (
+            <Button
+              variant="icon"
+              size="xs"
+              className="link-drawer__action"
+              aria-label={t('linkDrawer.addToCanvas')}
+              onClick={handleAddToCanvas}
+              disabled={!browser.currentUrl}
+              title={t('linkDrawer.addToCanvas')}
+            >
+              <PlusIcon size={12} strokeWidth={1.2} />
+            </Button>
+          ) : null}
         </div>
       </header>
       {loading && (

--- a/apps/canvas-workspace/src/renderer/src/components/dock/ReferenceDrawer/ArtifactsPicker.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/ReferenceDrawer/ArtifactsPicker.tsx
@@ -3,9 +3,7 @@ import type { ArtifactSummary } from '../../../types';
 import { Button, Popover, SegmentedControl } from '../../ui';
 import { useRightDock } from '../RightDock';
 import { useI18n } from '../../../i18n';
-
-/** Storage scope of global-chat artifacts (not a canvas workspace). */
-const GLOBAL_ARTIFACT_SCOPE = '__global_chat__';
+import { GLOBAL_CHAT_STORE_ID } from '../../../../../shared/agent-chat';
 
 type ArtifactScope = 'current' | 'all';
 
@@ -110,7 +108,7 @@ export const ArtifactsPicker = ({ activeWorkspaceId, workspaceNameById, onPrevie
   }, [activeWorkspaceId]);
 
   const scopeName = (workspaceId: string): string => (
-    workspaceId === GLOBAL_ARTIFACT_SCOPE
+    workspaceId === GLOBAL_CHAT_STORE_ID
       ? t('reference.artifactScopeGlobal')
       : workspaceNameById.get(workspaceId) ?? workspaceId
   );

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/DockPanes.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/DockPanes.tsx
@@ -60,9 +60,9 @@ interface Props {
   setTerminalHost: (element: HTMLDivElement | null) => void;
   terminalHostMounted: boolean;
   activeWorkspaceId: string;
+  canvasWorkspaceId?: string | null;
   workspaces: WorkspaceEntry[];
   onOpenNodePage: (workspaceId: string, nodeId: string) => void;
-  pinUrlReference: (url: string, title?: string) => void;
   onAddDomSelectionToChat: (workspaceId: string, selection: AgentContextDomSelectionRef) => Promise<ChatDeliveryReceipt>;
   onSubmitDomReviewComments?: (
     workspaceId: string,
@@ -93,9 +93,9 @@ export const DockPanes = ({
   setTerminalHost,
   terminalHostMounted,
   activeWorkspaceId,
+  canvasWorkspaceId = activeWorkspaceId,
   workspaces,
   onOpenNodePage,
-  pinUrlReference,
   onAddDomSelectionToChat,
   onSubmitDomReviewComments = async () => false,
   onAddTabToChat = async () => ({ status: 'unavailable', target: null }),
@@ -354,6 +354,7 @@ export const DockPanes = ({
                 mountWebview={isMounted(workspaceId, tab.id)}
                 active={visible}
                 activeWorkspaceId={workspaceId}
+                canvasWorkspaceId={canvasWorkspaceId}
                 onActivate={live ? () => store.activate(tab.id) : undefined}
                 onTitleChange={(title) => (live
                   ? store.setTitle(tab.id, title)
@@ -367,7 +368,6 @@ export const DockPanes = ({
                 onGuestNavigate={(url) => (live
                   ? store.syncLinkUrl(tab.id, url)
                   : store.updateRetainedLinkTab(workspaceId, tab.id, { url }))}
-                onAddToReference={pinUrlReference}
                 onAddDomSelectionToChat={(selection) => onAddDomSelectionToChat(workspaceId, selection)}
                 tabRef={live ? tabRefsById.get(tab.id) : undefined}
                 targetWorkspaceId={activeWorkspaceId}

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/__tests__/DockPanes.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/__tests__/DockPanes.test.tsx
@@ -21,19 +21,25 @@ vi.mock('../TabChatAction', () => ({
 
 // Capture the props each LinkTabView renders with (the real one lazy-loads a
 // live <webview>, which has no place in a happy-dom test).
-const latestLinkTabProps = vi.hoisted(() => new Map<string, { mountWebview?: boolean; active?: boolean }>());
+const latestLinkTabProps = vi.hoisted(() => new Map<string, {
+  mountWebview?: boolean;
+  active?: boolean;
+  canvasWorkspaceId?: string | null;
+}>());
 vi.mock('../../LinkDrawer', () => ({
   LinkTabView: (props: {
     tabId?: string;
     mountWebview?: boolean;
     active?: boolean;
     activeWorkspaceId?: string;
+    canvasWorkspaceId?: string | null;
   }) => {
     // Keyed by workspace too: the same tab id can exist in two workspaces, and
     // retained panes render alongside the live ones.
     if (props.tabId) latestLinkTabProps.set(`${props.activeWorkspaceId}::${props.tabId}`, {
       mountWebview: props.mountWebview,
       active: props.active,
+      canvasWorkspaceId: props.canvasWorkspaceId,
     });
     return null;
   },
@@ -116,7 +122,6 @@ describe('DockPanes split focus', () => {
         activeWorkspaceId="ws1"
         workspaces={[]}
         onOpenNodePage={() => undefined}
-        pinUrlReference={() => undefined}
         onAddDomSelectionToChat={async () => ({ status: 'unavailable', target: null })}
       /></I18nProvider>,
     ));
@@ -150,6 +155,7 @@ describe('DockPanes lazy link-tab webview mount', () => {
     activePaneId: string | null,
     activeWorkspaceId = 'ws1',
     dockVisible = true,
+    canvasWorkspaceId: string | null = activeWorkspaceId,
   ) => {
     flushSync(() => root?.render(
       <I18nProvider><DockPanes
@@ -165,13 +171,28 @@ describe('DockPanes lazy link-tab webview mount', () => {
         setTerminalHost={() => undefined}
         terminalHostMounted={false}
         activeWorkspaceId={activeWorkspaceId}
+        canvasWorkspaceId={canvasWorkspaceId}
         workspaces={[]}
         onOpenNodePage={() => undefined}
-        pinUrlReference={() => undefined}
         onAddDomSelectionToChat={async () => ({ status: 'unavailable', target: null })}
       /></I18nProvider>,
     ));
   };
+
+  it('keeps global Chat link tabs unbound from Canvas actions', async () => {
+    const store = new DockStore();
+    store.setActiveWorkspace('ws1');
+    store.openLink('https://example.com');
+    const [tab] = store.getSnapshot().tabs;
+    mount = document.createElement('div');
+    document.body.appendChild(mount);
+    root = createRoot(mount);
+
+    renderPanes(store, tab.id, 'ws1', true, null);
+
+    await vi.waitFor(() => expect(propsFor(tab.id)).toBeDefined());
+    expect(propsFor(tab.id)?.canvasWorkspaceId).toBeNull();
+  });
 
   it('mounts the webview only for tabs that have been active, and never unmounts', async () => {
     const store = new DockStore();
@@ -357,7 +378,6 @@ describe('DockPanes tabpanel relationships', () => {
         activeWorkspaceId="ws1"
         workspaces={[]}
         onOpenNodePage={() => undefined}
-        pinUrlReference={() => undefined}
         onAddDomSelectionToChat={async () => ({ status: 'unavailable', target: null })}
       /></I18nProvider>,
     ));
@@ -403,7 +423,6 @@ describe('DockPanes tabpanel relationships', () => {
         activeWorkspaceId="ws1"
         workspaces={[]}
         onOpenNodePage={() => undefined}
-        pinUrlReference={() => undefined}
         onAddDomSelectionToChat={async () => ({ status: 'unavailable', target: null })}
       /></I18nProvider>,
     ));
@@ -430,14 +449,14 @@ describe('DockPanes canvas editing host capability', () => {
     document.body.appendChild(mount);
     root = createRoot(mount);
 
-    const render = (dockVisible: boolean) => flushSync(() => root?.render(
+    const render = (dockVisible: boolean, editingAllowed = true) => flushSync(() => root?.render(
       <I18nProvider><DockPanes
         store={store}
         state={store.getSnapshot()}
         activePaneId={tab.id}
         dockVisible={dockVisible}
         chatTabEnabled={false}
-        canvasTabEditingAllowed
+        canvasTabEditingAllowed={editingAllowed}
         onCanvasNodesChange={onCanvasNodesChange}
         onCanvasSelectionChange={onCanvasSelectionChange}
         onSubmitDomReviewComments={onSubmitDomReviewComments}
@@ -450,7 +469,6 @@ describe('DockPanes canvas editing host capability', () => {
         activeWorkspaceId="ws1"
         workspaces={[{ id: 'ws2', name: 'Research' }]}
         onOpenNodePage={() => undefined}
-        pinUrlReference={() => undefined}
         onAddDomSelectionToChat={async () => ({ status: 'unavailable', target: null })}
       /></I18nProvider>,
     ));
@@ -464,6 +482,12 @@ describe('DockPanes canvas editing host capability', () => {
       onSelectionChange: onCanvasSelectionChange,
     });
     expect(store.getSnapshot().tabs[0]).not.toHaveProperty('editingAllowed');
+
+    render(true, false);
+    expect(latestCanvasPreviewProps.get('ws2')).toMatchObject({
+      editingAllowed: false,
+      active: true,
+    });
 
     const comments: AgentContextDomReviewComment[] = [{
       id: 'review-1',
@@ -511,7 +535,6 @@ describe('DockPanes whole-tab Chat actions', () => {
         activeWorkspaceId="ws1"
         workspaces={[]}
         onOpenNodePage={() => undefined}
-        pinUrlReference={() => undefined}
         onAddDomSelectionToChat={async () => ({ status: 'unavailable', target: null })}
         onAddTabToChat={async () => ({ status: 'unavailable', target: null })}
       /></I18nProvider>,

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/__tests__/dock-chat-availability.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/__tests__/dock-chat-availability.test.ts
@@ -28,7 +28,8 @@ describe('dock chat availability', () => {
   });
 
   it('allows dock canvas editing only on the dedicated AI Chat page', () => {
-    expect(isCanvasTabEditingAllowed('chat')).toBe(true);
+    expect(isCanvasTabEditingAllowed('chat', 'workspace-a')).toBe(true);
+    expect(isCanvasTabEditingAllowed('chat', null)).toBe(false);
     for (const view of ['canvas', 'scheduled-task', 'scheduled', 'nodes', 'skills', '/plugin']) {
       expect(isCanvasTabEditingAllowed(view)).toBe(false);
     }

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/__tests__/dock-store.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/__tests__/dock-store.test.ts
@@ -12,6 +12,7 @@ import {
   type DockLinkSessions,
   type DockSessionPersistence,
 } from '../dock-store';
+import { GLOBAL_DOCK_SCOPE_KEY } from '../dock-workspace';
 
 const createSessionPersistence = (initial: DockLinkSessions = {}): {
   persistence: DockSessionPersistence;
@@ -868,6 +869,30 @@ describe('DockStore', () => {
       { kind: 'link', url: 'https://other.example' },
     ]);
     expect(restored.getSnapshot().activeTabId).toBe(linkTabId('https://other.example'));
+  });
+
+  it('keeps global web tabs in a session separate from every workspace', () => {
+    const saved = createSessionPersistence();
+    const dock = new DockStore(saved.persistence);
+    dock.setActiveWorkspace('ws-a');
+    dock.openLink('https://workspace.example');
+
+    dock.setActiveWorkspace(GLOBAL_DOCK_SCOPE_KEY);
+    dock.openLink('https://global.example');
+
+    dock.setActiveWorkspace('ws-a');
+    expect(dock.getSnapshot().tabs).toMatchObject([
+      { kind: 'link', url: 'https://workspace.example' },
+    ]);
+
+    dock.setActiveWorkspace(GLOBAL_DOCK_SCOPE_KEY);
+    expect(dock.getSnapshot().tabs).toMatchObject([
+      { kind: 'link', url: 'https://global.example' },
+    ]);
+    expect(saved.read()).toMatchObject({
+      'ws-a': { tabs: [{ url: 'https://workspace.example' }] },
+      [GLOBAL_DOCK_SCOPE_KEY]: { tabs: [{ url: 'https://global.example' }] },
+    });
   });
 
   it('keeps the last active web tab when a transient preview becomes active', () => {

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/dock-chat-availability.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/dock-chat-availability.ts
@@ -13,8 +13,10 @@ export const isDockChatTabEnabled = (activeView: string): boolean =>
  * This is deliberately narrower than "no dock chat tab": scheduled-task also
  * owns a full-page conversation, but only the dedicated AI Chat page is an
  * editing host. Keep the capability route-derived and fail-closed. */
-export const isCanvasTabEditingAllowed = (activeView: string): boolean =>
-  activeView === 'chat';
+export const isCanvasTabEditingAllowed = (
+  activeView: string,
+  canvasWorkspaceId?: string | null,
+): boolean => activeView === 'chat' && Boolean(canvasWorkspaceId);
 
 /** Whether the route-level Pulse launcher (the floating logo button) renders.
  *

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/dock-link-sessions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/dock-link-sessions.ts
@@ -8,6 +8,8 @@ export interface DockLinkSession {
   expanded?: boolean;
 }
 
+/** Link-tab sessions keyed by a Dock scope key: a real workspace id or the
+ * workspace-independent global Dock key. */
 export type DockLinkSessions = Record<string, DockLinkSession>;
 
 export interface DockSessionPersistence {
@@ -26,14 +28,14 @@ export class DockLinkSessionStore {
     }
   }
 
-  get(workspaceId: string): DockLinkSession | undefined {
-    return this.sessions[workspaceId];
+  get(scopeKey: string): DockLinkSession | undefined {
+    return this.sessions[scopeKey];
   }
 
-  capture(workspaceId: string, tabs: DockPreviewTab[], activeTabId: string, expanded?: boolean): void {
-    if (!workspaceId || workspaceId === '__default__') return;
+  capture(scopeKey: string, tabs: DockPreviewTab[], activeTabId: string, expanded?: boolean): void {
+    if (!scopeKey || scopeKey === '__default__') return;
     const linkTabs = tabs.filter((tab): tab is DockLinkTab => tab.kind === 'link');
-    const previous = this.sessions[workspaceId];
+    const previous = this.sessions[scopeKey];
     const activeLinkId = linkTabs.some((tab) => tab.id === activeTabId)
       ? activeTabId
       : previous?.activeTabId && linkTabs.some((tab) => tab.id === previous.activeTabId)
@@ -41,7 +43,7 @@ export class DockLinkSessionStore {
         : undefined;
     this.sessions = {
       ...this.sessions,
-      [workspaceId]: {
+      [scopeKey]: {
         tabs: linkTabs,
         activeTabId: activeLinkId,
         expanded: expanded ?? previous?.expanded,

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/dock-types.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/dock-types.ts
@@ -3,6 +3,8 @@ import type { WorkspaceEntry } from '../../../hooks/useWorkspaces';
 
 export interface RightDockProps {
   activeWorkspaceId: string;
+  /** Canvas destination for write actions. Null in global/scheduled Chat. */
+  canvasWorkspaceId?: string | null;
   activeIdReady: boolean;
   chatTabEnabled: boolean;
   reserveSpace: boolean;

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/dock-workspace.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/dock-workspace.test.ts
@@ -1,19 +1,30 @@
 import { describe, expect, it } from 'vitest';
-import { resolveDockWorkspaceId } from './dock-workspace';
+import { dockScopeKey, GLOBAL_DOCK_SCOPE_KEY, resolveDockScope } from './dock-workspace';
 
-describe('resolveDockWorkspaceId', () => {
+describe('resolveDockScope', () => {
   it('uses the Chat session workspace on the full-page Chat route', () => {
-    expect(resolveDockWorkspaceId('chat', 'canvas-workspace', 'chat-workspace'))
-      .toBe('chat-workspace');
+    expect(resolveDockScope('chat', 'canvas-workspace', {
+      kind: 'workspace', workspaceId: 'chat-workspace',
+    })).toEqual({ kind: 'workspace', workspaceId: 'chat-workspace' });
   });
 
-  it('falls back to the active Canvas workspace for global Chat', () => {
-    expect(resolveDockWorkspaceId('chat', 'canvas-workspace', null))
-      .toBeNull();
+  it('uses the workspace-independent Dock scope for global Chat', () => {
+    const scope = resolveDockScope('chat', 'canvas-workspace', { kind: 'global' });
+    expect(scope).toEqual({ kind: 'global' });
+    expect(dockScopeKey(scope)).toBe(GLOBAL_DOCK_SCOPE_KEY);
+  });
+
+  it('uses the same workspace-independent Dock scope for scheduled Chat', () => {
+    const scope = resolveDockScope('scheduled-task', 'canvas-workspace', {
+      kind: 'scheduled', taskId: 'task-1',
+    });
+    expect(scope).toEqual({ kind: 'global' });
+    expect(dockScopeKey(scope)).toBe(GLOBAL_DOCK_SCOPE_KEY);
   });
 
   it('ignores retained Chat scope outside the Chat route', () => {
-    expect(resolveDockWorkspaceId('canvas', 'canvas-workspace', 'chat-workspace'))
-      .toBe('canvas-workspace');
+    expect(resolveDockScope('canvas', 'canvas-workspace', {
+      kind: 'workspace', workspaceId: 'chat-workspace',
+    })).toEqual({ kind: 'workspace', workspaceId: 'canvas-workspace' });
   });
 });

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/dock-workspace.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/dock-workspace.test.ts
@@ -9,7 +9,7 @@ describe('resolveDockWorkspaceId', () => {
 
   it('falls back to the active Canvas workspace for global Chat', () => {
     expect(resolveDockWorkspaceId('chat', 'canvas-workspace', null))
-      .toBe('canvas-workspace');
+      .toBeNull();
   });
 
   it('ignores retained Chat scope outside the Chat route', () => {

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/dock-workspace.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/dock-workspace.ts
@@ -1,9 +1,29 @@
-export function resolveDockWorkspaceId(
+import type { AgentScope } from '../../chat/types';
+
+export type DockScope =
+  | { kind: 'global' }
+  | { kind: 'workspace'; workspaceId: string };
+
+/** Internal key for the workspace-independent Dock session. It deliberately
+ * differs from the agent session-store sentinel: Dock routing is UI state,
+ * not chat persistence. */
+export const GLOBAL_DOCK_SCOPE_KEY = '__global_dock__';
+
+export const dockScopeKey = (scope: DockScope): string =>
+  scope.kind === 'workspace' ? scope.workspaceId : GLOBAL_DOCK_SCOPE_KEY;
+
+/** The single policy boundary from page/conversation state to Dock tabs.
+ * If workspace Chat should become global later, only this mapping changes. */
+export function resolveDockScope(
   activeView: string,
   activeCanvasWorkspaceId: string,
-  chatWorkspaceId: string | null,
-): string | null {
-  return activeView === 'chat'
-    ? chatWorkspaceId
-    : activeCanvasWorkspaceId;
+  chatScope: AgentScope,
+): DockScope {
+  if (activeView === 'chat') {
+    return chatScope.kind === 'workspace'
+      ? { kind: 'workspace', workspaceId: chatScope.workspaceId }
+      : { kind: 'global' };
+  }
+  if (activeView === 'scheduled-task') return { kind: 'global' };
+  return { kind: 'workspace', workspaceId: activeCanvasWorkspaceId };
 }

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/dock-workspace.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/dock-workspace.ts
@@ -2,8 +2,8 @@ export function resolveDockWorkspaceId(
   activeView: string,
   activeCanvasWorkspaceId: string,
   chatWorkspaceId: string | null,
-): string {
-  return activeView === 'chat' && chatWorkspaceId
+): string | null {
+  return activeView === 'chat'
     ? chatWorkspaceId
     : activeCanvasWorkspaceId;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/index.tsx
@@ -98,7 +98,7 @@ function persistWidth(value: number): void {
 }
 
 export const RightDock = ({
-  activeWorkspaceId,
+  activeWorkspaceId, canvasWorkspaceId = activeWorkspaceId,
   activeIdReady,
   chatTabEnabled,
   reserveSpace,
@@ -111,7 +111,7 @@ export const RightDock = ({
   onOpenNodePage,
   onActivateWorkspace,
 }: RightDockProps) => {
-  const { store, setChatHost, setTerminalHost, pinUrlReference,
+  const { store, setChatHost, setTerminalHost,
     addDomSelectionToChat, submitDomReviewComments, addTabToChat, startSkillChat } = useDockContext();
   const state = useRightDockState();
   const { t } = useI18n();
@@ -472,10 +472,9 @@ export const RightDock = ({
         setChatHost={setChatHost}
         setTerminalHost={setTerminalHost}
         terminalHostMounted={terminalHostMounted}
-        activeWorkspaceId={activeWorkspaceId}
+        activeWorkspaceId={activeWorkspaceId} canvasWorkspaceId={canvasWorkspaceId}
         workspaces={workspaces}
         onOpenNodePage={onOpenNodePage}
-        pinUrlReference={pinUrlReference}
         onAddDomSelectionToChat={addDomSelectionToChat}
         onSubmitDomReviewComments={submitDomReviewComments}
         onAddTabToChat={addTabToChat}

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/useChatDockWorkspace.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/useChatDockWorkspace.test.tsx
@@ -2,7 +2,7 @@
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { AgentScope } from '../../chat/types';
+import type { ActiveChatTarget } from '../../chat/ChatTargetContext';
 import { useChatDockWorkspace } from './useChatDockWorkspace';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -14,18 +14,18 @@ let latest: ReturnType<typeof useChatDockWorkspace> | null = null;
 const Harness = ({
   activeView,
   activeCanvasWorkspaceId,
-  entryScope,
+  activeChatTarget,
   selectCanvasWorkspace,
 }: {
   activeView: string;
   activeCanvasWorkspaceId: string;
-  entryScope?: AgentScope;
+  activeChatTarget: ActiveChatTarget;
   selectCanvasWorkspace: (workspaceId: string) => void;
 }) => {
   latest = useChatDockWorkspace(
     activeView,
     activeCanvasWorkspaceId,
-    entryScope,
+    activeChatTarget,
     selectCanvasWorkspace,
   );
   return null;
@@ -40,7 +40,7 @@ afterEach(() => {
 });
 
 describe('useChatDockWorkspace', () => {
-  it('tracks the Chat conversation scope and permits an explicit dock override', async () => {
+  it('keeps the Chat canvas target stable while permitting an internal dock-owner override', async () => {
     host = document.createElement('div');
     root = createRoot(host);
     const selectCanvasWorkspace = vi.fn();
@@ -50,18 +50,61 @@ describe('useChatDockWorkspace', () => {
         <Harness
           activeView="chat"
           activeCanvasWorkspaceId="canvas-a"
-          entryScope={{ kind: 'workspace', workspaceId: 'chat-b' }}
+          activeChatTarget={{
+            scope: { kind: 'workspace', workspaceId: 'chat-b' },
+            sessionId: 'session-b',
+            executionPolicy: 'auto',
+          }}
           selectCanvasWorkspace={selectCanvasWorkspace}
         />,
       );
     });
     expect(latest?.dockWorkspaceId).toBe('chat-b');
 
-    act(() => latest?.reportChatWorkspace('chat-c'));
-    expect(latest?.dockWorkspaceId).toBe('chat-c');
+    act(() => latest?.activateDockWorkspace('tab-d'));
+    expect(latest?.dockWorkspaceId).toBe('chat-b');
+    expect(latest?.dockOwnerWorkspaceId).toBe('tab-d');
+    expect(selectCanvasWorkspace).not.toHaveBeenCalled();
+
+    act(() => root?.render(
+      <Harness
+        activeView="chat"
+        activeCanvasWorkspaceId="canvas-a"
+        activeChatTarget={{
+          scope: { kind: 'workspace', workspaceId: 'chat-c' },
+          sessionId: 'session-c',
+          executionPolicy: 'auto',
+        }}
+        selectCanvasWorkspace={selectCanvasWorkspace}
+      />,
+    ));
+    expect(latest?.dockOwnerWorkspaceId).toBe('chat-c');
+  });
+
+  it('keeps global Chat unbound while retaining the Canvas workspace as an internal dock owner', async () => {
+    host = document.createElement('div');
+    root = createRoot(host);
+
+    await act(async () => {
+      root?.render(
+        <Harness
+          activeView="chat"
+          activeCanvasWorkspaceId="canvas-a"
+          activeChatTarget={{
+            scope: { kind: 'global' },
+            sessionId: null,
+            executionPolicy: 'auto',
+          }}
+          selectCanvasWorkspace={vi.fn()}
+        />,
+      );
+    });
+
+    expect(latest?.dockWorkspaceId).toBeNull();
+    expect(latest?.dockOwnerWorkspaceId).toBe('canvas-a');
 
     act(() => latest?.activateDockWorkspace('tab-d'));
-    expect(latest?.dockWorkspaceId).toBe('tab-d');
-    expect(selectCanvasWorkspace).not.toHaveBeenCalled();
+    expect(latest?.dockWorkspaceId).toBeNull();
+    expect(latest?.dockOwnerWorkspaceId).toBe('tab-d');
   });
 });

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/useChatDockWorkspace.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/useChatDockWorkspace.test.tsx
@@ -3,6 +3,7 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ActiveChatTarget } from '../../chat/ChatTargetContext';
+import { GLOBAL_DOCK_SCOPE_KEY } from './dock-workspace';
 import { useChatDockWorkspace } from './useChatDockWorkspace';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -63,7 +64,7 @@ describe('useChatDockWorkspace', () => {
 
     act(() => latest?.activateDockWorkspace('tab-d'));
     expect(latest?.dockWorkspaceId).toBe('chat-b');
-    expect(latest?.dockOwnerWorkspaceId).toBe('tab-d');
+    expect(latest?.dockScopeKey).toBe('tab-d');
     expect(selectCanvasWorkspace).not.toHaveBeenCalled();
 
     act(() => root?.render(
@@ -78,10 +79,10 @@ describe('useChatDockWorkspace', () => {
         selectCanvasWorkspace={selectCanvasWorkspace}
       />,
     ));
-    expect(latest?.dockOwnerWorkspaceId).toBe('chat-c');
+    expect(latest?.dockScopeKey).toBe('chat-c');
   });
 
-  it('keeps global Chat unbound while retaining the Canvas workspace as an internal dock owner', async () => {
+  it('binds global Chat to the workspace-independent Dock session', async () => {
     host = document.createElement('div');
     root = createRoot(host);
 
@@ -101,10 +102,33 @@ describe('useChatDockWorkspace', () => {
     });
 
     expect(latest?.dockWorkspaceId).toBeNull();
-    expect(latest?.dockOwnerWorkspaceId).toBe('canvas-a');
+    expect(latest?.dockScopeKey).toBe(GLOBAL_DOCK_SCOPE_KEY);
 
     act(() => latest?.activateDockWorkspace('tab-d'));
     expect(latest?.dockWorkspaceId).toBeNull();
-    expect(latest?.dockOwnerWorkspaceId).toBe('tab-d');
+    expect(latest?.dockScopeKey).toBe('tab-d');
+  });
+
+  it('binds scheduled Chat to the same workspace-independent Dock session', async () => {
+    host = document.createElement('div');
+    root = createRoot(host);
+
+    await act(async () => {
+      root?.render(
+        <Harness
+          activeView="scheduled-task"
+          activeCanvasWorkspaceId="canvas-a"
+          activeChatTarget={{
+            scope: { kind: 'scheduled', taskId: 'task-1' },
+            sessionId: null,
+            executionPolicy: 'scheduled',
+          }}
+          selectCanvasWorkspace={vi.fn()}
+        />,
+      );
+    });
+
+    expect(latest?.dockWorkspaceId).toBeNull();
+    expect(latest?.dockScopeKey).toBe(GLOBAL_DOCK_SCOPE_KEY);
   });
 });

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/useChatDockWorkspace.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/useChatDockWorkspace.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
-import type { AgentScope } from '../../chat/types';
+import type { ActiveChatTarget } from '../../chat/ChatTargetContext';
+import { chatScopeKey } from '../../../../../shared/agent-chat';
 import { resolveDockWorkspaceId } from './dock-workspace';
 
 /** Keeps the full-page Chat dock aligned with its conversation while leaving
@@ -7,34 +8,43 @@ import { resolveDockWorkspaceId } from './dock-workspace';
 export function useChatDockWorkspace(
   activeView: string,
   activeCanvasWorkspaceId: string,
-  entryScope: AgentScope | undefined,
+  activeChatTarget: ActiveChatTarget,
   selectCanvasWorkspace: (workspaceId: string) => void,
 ) {
-  // undefined means ChatPage has not reported yet, so the entry target seeds
-  // the dock without publishing one frame under the previous Canvas scope.
-  const [reportedWorkspaceId, setReportedWorkspaceId] = useState<string | null | undefined>();
+  const [dockWorkspaceOverride, setDockWorkspaceOverride] = useState<{
+    scopeKey: string;
+    workspaceId: string;
+  } | null>(null);
+  const activeScopeKey = chatScopeKey(activeChatTarget.scope);
 
   useEffect(() => {
-    if (activeView !== 'chat') setReportedWorkspaceId(undefined);
-  }, [activeView]);
+    setDockWorkspaceOverride(null);
+  }, [activeScopeKey, activeView]);
 
-  const entryWorkspaceId = entryScope?.kind === 'workspace' ? entryScope.workspaceId : null;
+  const chatWorkspaceId = activeChatTarget.scope.kind === 'workspace'
+    ? activeChatTarget.scope.workspaceId
+    : null;
   const dockWorkspaceId = resolveDockWorkspaceId(
     activeView,
     activeCanvasWorkspaceId,
-    reportedWorkspaceId === undefined ? entryWorkspaceId : reportedWorkspaceId,
+    chatWorkspaceId,
   );
+  const dockOwnerWorkspaceId = activeView === 'chat'
+    ? (dockWorkspaceOverride?.scopeKey === activeScopeKey
+        ? dockWorkspaceOverride.workspaceId
+        : null) ?? dockWorkspaceId ?? activeCanvasWorkspaceId
+    : dockWorkspaceId ?? activeCanvasWorkspaceId;
   const activateDockWorkspace = useCallback((workspaceId: string) => {
     if (activeView === 'chat') {
-      setReportedWorkspaceId(workspaceId);
+      setDockWorkspaceOverride({ scopeKey: activeScopeKey, workspaceId });
       return;
     }
     selectCanvasWorkspace(workspaceId);
-  }, [activeView, selectCanvasWorkspace]);
+  }, [activeScopeKey, activeView, selectCanvasWorkspace]);
 
   return {
     dockWorkspaceId,
-    reportChatWorkspace: setReportedWorkspaceId,
+    dockOwnerWorkspaceId,
     activateDockWorkspace,
   };
 }

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/useChatDockWorkspace.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/useChatDockWorkspace.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { ActiveChatTarget } from '../../chat/ChatTargetContext';
 import { chatScopeKey } from '../../../../../shared/agent-chat';
-import { resolveDockWorkspaceId } from './dock-workspace';
+import { dockScopeKey, resolveDockScope } from './dock-workspace';
 
 /** Keeps the full-page Chat dock aligned with its conversation while leaving
  * qualified cross-workspace tab activation as an explicit override. */
@@ -21,30 +21,33 @@ export function useChatDockWorkspace(
     setDockWorkspaceOverride(null);
   }, [activeScopeKey, activeView]);
 
-  const chatWorkspaceId = activeChatTarget.scope.kind === 'workspace'
-    ? activeChatTarget.scope.workspaceId
-    : null;
-  const dockWorkspaceId = resolveDockWorkspaceId(
+  const dockScope = resolveDockScope(
     activeView,
     activeCanvasWorkspaceId,
-    chatWorkspaceId,
+    activeChatTarget.scope,
   );
-  const dockOwnerWorkspaceId = activeView === 'chat'
+  const dockWorkspaceId = dockScope.kind === 'workspace'
+    ? dockScope.workspaceId
+    : null;
+  const resolvedDockScopeKey = dockScopeKey(dockScope);
+  const isFullPageChat = activeView === 'chat' || activeView === 'scheduled-task';
+  const activeDockScopeKey = isFullPageChat
     ? (dockWorkspaceOverride?.scopeKey === activeScopeKey
         ? dockWorkspaceOverride.workspaceId
-        : null) ?? dockWorkspaceId ?? activeCanvasWorkspaceId
-    : dockWorkspaceId ?? activeCanvasWorkspaceId;
+        : null) ?? resolvedDockScopeKey
+    : resolvedDockScopeKey;
   const activateDockWorkspace = useCallback((workspaceId: string) => {
-    if (activeView === 'chat') {
+    if (isFullPageChat) {
       setDockWorkspaceOverride({ scopeKey: activeScopeKey, workspaceId });
       return;
     }
     selectCanvasWorkspace(workspaceId);
-  }, [activeScopeKey, activeView, selectCanvasWorkspace]);
+  }, [activeScopeKey, isFullPageChat, selectCanvasWorkspace]);
 
   return {
+    dockScope,
     dockWorkspaceId,
-    dockOwnerWorkspaceId,
+    dockScopeKey: activeDockScopeKey,
     activateDockWorkspace,
   };
 }

--- a/apps/canvas-workspace/src/shared/agent-chat.ts
+++ b/apps/canvas-workspace/src/shared/agent-chat.ts
@@ -18,6 +18,12 @@ export type AgentScope =
   | { kind: 'scheduled'; taskId: string }
   | { kind: 'global' };
 
+export const chatScopeKey = (scope: AgentScope): string => {
+  if (scope.kind === 'global') return 'global';
+  if (scope.kind === 'scheduled') return `scheduled:${scope.taskId}`;
+  return `workspace:${scope.workspaceId}`;
+};
+
 export interface AgentScopeRef {
   scope: AgentScope;
 }
@@ -435,8 +441,8 @@ export interface AgentSessionInfo {
 }
 
 export interface CrossWorkspaceSessionGroup {
-  workspaceId: string;
-  workspaceName: string;
+  scope: AgentScope;
+  scopeName: string;
   sessions: AgentSessionInfo[];
 }
 


### PR DESCRIPTION
## What changed

- replace renderer navigation's workspace-id sentinel state with a typed `ActiveChatTarget` carrying scope, session, context, and execution policy
- make global, workspace, and scheduled session grouping use explicit `AgentScope` contracts
- centralize the page/conversation-to-Dock mapping in `resolveDockScope`
- keep Canvas and workspace Chat on their workspace Dock tabs, while global and scheduled Chat share a workspace-independent Dock session
- keep global/scheduled Canvas actions read-only and prevent fallback to the last active Canvas workspace
- preserve cross-scope session loading through the existing storage-adapter boundary

## Why

AI Chat previously derived behavior from several overlapping values: the active Canvas workspace, special workspace-id sentinels, the selected session, and route-specific effects. That made global and scheduled Chat accidentally inherit a real workspace and made Dock ownership difficult to reason about.

This change makes `ActiveChatTarget` the conversation source of truth and `DockScope` the tab-session source of truth. The policy is now explicit and has one change point if workspace Chat should later use global Dock tabs.

## Impact

- entering AI Chat no longer mutates or depends on the active Canvas workspace
- workspace conversations retain their workspace capabilities and tabs
- global and scheduled conversations share generic web tabs with no Canvas write destination
- existing chat storage paths and sentinels are unchanged
- Dock web-tab persistence remains schema v1; the global Dock session is added lazily as another record key

## Validation

- `pnpm --filter canvas-workspace typecheck`
- `pnpm --filter canvas-workspace exec vitest run src/renderer/src/components/dock/RightDock src/renderer/src/components/chat/hooks/useChatNavigation.test.tsx src/renderer/src/components/chat/__tests__/ChatPage.scope-switch.test.tsx` — 227 tests passed
- `pnpm --filter canvas-workspace test` — 2,488 tests passed
- `node scripts/harness/run-harness-check.mjs --path ... --level quick` — passed
