### PR TITLE
fix: remove terminal Ask AI banner

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/DockPanes.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/DockPanes.tsx
@@ -138,9 +138,6 @@ export const DockPanes = ({
   // Confirmed on a real workspace switch.
   const ownerWorkspaceId = state.activeTerminalWorkspaceId;
   const tabRefsById = new Map(buildDockTabRefs(state, ownerWorkspaceId).map(tab => [tab.id, tab]));
-  const terminalTabRef = labelledTerminalTabId
-    ? tabRefsById.get(labelledTerminalTabId)
-    : undefined;
   const renderTabChatAction = (tabRef?: AgentContextTabRef) => tabRef ? (
     <div className="right-dock__pane-chat-action">
       <TabChatAction
@@ -230,10 +227,9 @@ export const DockPanes = ({
             if (splitTabId && isTerminalTabId(splitTabId)) store.activate(splitTabId);
           }}
         >
-          {renderTabChatAction(terminalTabRef)}
           <div
             ref={setTerminalHost}
-            className={`right-dock__terminal-host${terminalTabRef ? ' right-dock__terminal-host--with-chat-action' : ''}`}
+            className="right-dock__terminal-host"
           />
         </div>
       )}

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/__tests__/DockPanes.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/__tests__/DockPanes.test.tsx
@@ -480,7 +480,7 @@ describe('DockPanes canvas editing host capability', () => {
 });
 
 describe('DockPanes whole-tab Chat actions', () => {
-  it('offers exact artifact and split-terminal refs without covering terminal content', () => {
+  it('offers exact artifact refs without adding a terminal banner', () => {
     const store = new DockStore();
     store.setActiveWorkspace('ws1');
     store.openArtifact('artifact-scope', 'artifact-1');
@@ -527,20 +527,8 @@ describe('DockPanes whole-tab Chat actions', () => {
         artifactId: 'artifact-1',
       },
     });
-    expect(latestTabChatActionProps.get(TERMINAL_TAB_ID)).toMatchObject({
-      targetWorkspaceId: 'ws1',
-      tab: {
-        id: TERMINAL_TAB_ID,
-        kind: 'terminal',
-        title: 'Build shell',
-        workspaceId: 'ws1',
-        dockWorkspaceId: 'ws1',
-        sessionId: 'workspace-terminal:ws1',
-        isSplit: true,
-      },
-    });
-    expect(mount.querySelector('.right-dock__pane--terminal [data-tab-chat-action]')).not.toBeNull();
-    expect(mount.querySelector('.right-dock__terminal-host--with-chat-action')).not.toBeNull();
+    expect(latestTabChatActionProps.get(TERMINAL_TAB_ID)).toBeUndefined();
+    expect(mount.querySelector('.right-dock__pane--terminal [data-tab-chat-action]')).toBeNull();
     expect(document.getElementById(dockPaneElementId(artifactId))
       ?.querySelector('[data-tab-chat-action]')).not.toBeNull();
   });


### PR DESCRIPTION
Remove the terminal pane Ask AI banner from the right dock.

- Stop rendering the whole-tab chat action above workspace terminal panes
- Keep artifact tab Ask AI actions intact
- Update DockPanes coverage to assert terminal panes no longer render the banner

Validation:
- pnpm --filter canvas-workspace exec vitest run src/renderer/src/components/dock/RightDock/__tests__/DockPanes.test.tsx
- git diff --check

Note: pnpm --filter canvas-workspace typecheck:renderer was attempted but the current local dependency install is missing @phosphor-icons/react and also reports an unrelated ImportMeta.env typing error.