### PR TITLE
fix: refine canvas dock creation menu

### DIFF
--- a/apps/canvas-workspace/harness/knowledge/keyboard-shortcuts.md
+++ b/apps/canvas-workspace/harness/knowledge/keyboard-shortcuts.md
@@ -193,9 +193,10 @@ listener and `useAppShortcuts`'s) check `match.definition.editable !==
 definition defaults to `'block'` (the `EditablePolicy` default) and is
 dropped while an editable element is focused. `canvas.find` is a case where
 the handler adds its own narrower guard on top of `editable: 'allow'`: it
-explicitly excludes focus inside `.note-card`, because note cards own their
-own find flow and must not have canvas-level search steal focus from note
-editing, note panels, or note toolbar controls.
+explicitly excludes focus inside `.note-card`, iframe-node chrome, and Link
+Drawer browser/find surfaces, because those areas own their own find flow and
+must not have canvas-level search steal focus from note editing, embedded page
+controls, or browser find-in-page.
 
 ## Menu-accelerator precedence
 

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/NewDockTabMenu.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/NewDockTabMenu.tsx
@@ -65,18 +65,6 @@ export const NewDockTabMenu = ({ anchorRef, panelId, showTerminal, onClose, onOp
             <NodeTypeIcon type="frame" size={15} />
             {t('rightDock.openCanvas')}
           </Button>
-          <Button
-            size="sm"
-            className="right-dock__new-tab-item"
-            role="menuitem"
-            onClick={() => {
-              onClose();
-              onNewWebTab();
-            }}
-          >
-            <NodeTypeIcon type="iframe" size={15} />
-            {t('rightDock.newWebTab')}
-          </Button>
           {showTerminal && (
             <Button
               size="sm"
@@ -91,6 +79,18 @@ export const NewDockTabMenu = ({ anchorRef, panelId, showTerminal, onClose, onOp
               {t('rightDock.newTerminalTab')}
             </Button>
           )}
+          <Button
+            size="sm"
+            className="right-dock__new-tab-item"
+            role="menuitem"
+            onClick={() => {
+              onClose();
+              onNewWebTab();
+            }}
+          >
+            <NodeTypeIcon type="iframe" size={15} />
+            {t('rightDock.newWebTab')}
+          </Button>
         </Popover>
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/__tests__/DockCreationControls.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/__tests__/DockCreationControls.test.tsx
@@ -28,6 +28,7 @@ afterEach(() => {
 const renderControls = () => {
   const store = new DockStore();
   const newLink = vi.spyOn(store, 'newLink');
+  const newTerminal = vi.spyOn(store, 'newTerminal');
   mount = document.createElement('div');
   document.body.appendChild(mount);
   root = createRoot(mount);
@@ -46,7 +47,7 @@ const renderControls = () => {
   ));
   const trigger = mount.querySelector<HTMLButtonElement>('[aria-label="New tab"]');
   if (!trigger) throw new Error('Expected the new-tab menu trigger');
-  return { trigger, newLink };
+  return { trigger, newLink, newTerminal };
 };
 
 const waitForMenu = async () => {
@@ -62,7 +63,7 @@ const waitForMenu = async () => {
 
 describe('DockCreationControls new-tab trigger', () => {
   it('uses one menu-button contract for pointer and native keyboard activation', async () => {
-    const { trigger, newLink } = renderControls();
+    const { trigger, newLink, newTerminal } = renderControls();
 
     expect(trigger.getAttribute('aria-haspopup')).toBe('menu');
     expect(trigger.getAttribute('aria-expanded')).toBe('false');
@@ -76,7 +77,22 @@ describe('DockCreationControls new-tab trigger', () => {
     expect(trigger.getAttribute('aria-expanded')).toBe('true');
     expect(trigger.getAttribute('aria-controls')).toBe(menu.id);
 
-    const newWebTab = [...menu.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')]
+    const menuItems = [...menu.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')];
+    expect(menuItems.map((item) => item.textContent)).toEqual([
+      'Open node',
+      'Open canvas',
+      'New terminal',
+      'New web tab',
+    ]);
+
+    const newTerminalTab = menuItems.find((item) => item.textContent === 'New terminal');
+    if (!newTerminalTab) throw new Error('Expected the New terminal menu item');
+    act(() => newTerminalTab.click());
+    expect(newTerminal).toHaveBeenCalledTimes(1);
+
+    act(() => trigger.click());
+    const reopenedMenu = await waitForMenu();
+    const newWebTab = [...reopenedMenu.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')]
       .find((item) => item.textContent === 'New web tab');
     if (!newWebTab) throw new Error('Expected the New web tab menu item');
     act(() => newWebTab.click());

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/__tests__/dock-tab-items.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/__tests__/dock-tab-items.test.ts
@@ -3,7 +3,7 @@ import { getDockTabSwitcherItems } from '../dock-tab-items';
 import { DockStore } from '../dock-store';
 
 describe('getDockTabSwitcherItems', () => {
-  it('uses the same visible tab set as the strip when chat and terminals are unavailable', () => {
+  it('keeps terminal tabs in the switcher even when the chat tab is unavailable', () => {
     const store = new DockStore();
     store.setActiveWorkspace('ws-a');
     store.openTerminal();
@@ -15,7 +15,7 @@ describe('getDockTabSwitcherItems', () => {
       terminalTitle: 'Terminal',
     });
 
-    expect(items.map((item) => item.kind)).toEqual(['link']);
+    expect(items.map((item) => item.kind)).toEqual(['terminal', 'link']);
   });
 
   it('preserves the exact icon metadata used by the tab strip', () => {

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/dock-tab-items.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/dock-tab-items.ts
@@ -24,7 +24,7 @@ export function getDockTabSwitcherItems(
     ...(chatTabEnabled
       ? [{ id: CHAT_TAB_ID, title: chatTitle, kind: 'chat' as const }]
       : []),
-    ...(chatTabEnabled ? state.terminalTabs : []).map((tab) => ({
+    ...state.terminalTabs.map((tab) => ({
       id: tab.id,
       title: tab.title ?? `${terminalTitle} ${tab.ordinal}`,
       kind: 'terminal' as const,

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/index.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react';
 import { useDragResize } from '../../ui';
 import { useI18n } from '../../../i18n';
-import { CHAT_TAB_ID, isTerminalTabId } from './dock-store';
+import { CHAT_TAB_ID } from './dock-store';
 import { useDockContext, useRightDockState } from './context';
 import type { RightDockProps } from './dock-types';
 import { useConsumePendingLinks } from '../../../hooks/useConsumePendingLinks';
@@ -135,28 +135,23 @@ export const RightDock = ({
   useEffect(() => {
     if (chatTabEnabled) return;
     if (state.splitTabId) store.toggleSplitView();
-    if (
-      (state.activeTabId === CHAT_TAB_ID || isTerminalTabId(state.activeTabId))
-      && state.tabs.length > 0
-    ) {
+    if (state.activeTabId === CHAT_TAB_ID && state.tabs.length > 0) {
       store.activate(state.tabs[0].id);
       return;
     }
-    if (state.activeTabId === CHAT_TAB_ID || isTerminalTabId(state.activeTabId)) {
+    if (state.activeTabId === CHAT_TAB_ID) {
       store.collapse();
     }
   }, [chatTabEnabled, state.activeTabId, state.splitTabId, state.tabs, store]);
 
   const hasPreviews = state.tabs.length > 0;
-  const terminalTabsVisible = chatTabEnabled && state.terminalTabs.length > 0;
-  const terminalHostMounted = chatTabEnabled
-    && Object.values(state.terminalTabsByWorkspace).some((workspace) => workspace.tabs.length > 0);
+  const terminalTabsVisible = state.terminalTabs.length > 0;
+  const terminalHostMounted = Object.values(state.terminalTabsByWorkspace).some((workspace) => workspace.tabs.length > 0);
   const tabStripVisible = chatTabEnabled || hasPreviews || terminalTabsVisible;
-  const visible = state.expanded && (chatTabEnabled || hasPreviews);
+  const visible = state.expanded && (chatTabEnabled || hasPreviews || terminalTabsVisible);
   // While the chat tab is unavailable a transient 'chat' active pointer
   // (route guard hasn't run yet) should highlight nothing.
-  const activePaneId = !chatTabEnabled
-    && (state.activeTabId === CHAT_TAB_ID || isTerminalTabId(state.activeTabId))
+  const activePaneId = !chatTabEnabled && state.activeTabId === CHAT_TAB_ID
     ? null
     : state.activeTabId;
   const splitTabId = chatTabEnabled ? state.splitTabId : undefined;
@@ -427,7 +422,7 @@ export const RightDock = ({
               store={store}
               workspaces={workspaces}
               activeWorkspaceId={activeWorkspaceId}
-              showTerminal={chatTabEnabled}
+              showTerminal
               newTabTitle={t('rightDock.newTabTitle')}
               mountedWorkspaceIds={state.mountedWorkspaceIds}
               terminalWorkspaceIds={new Set(Object.keys(state.terminalTabsByWorkspace))}

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/IframeNodeBody/IframeRenderedView.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/IframeNodeBody/IframeRenderedView.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment happy-dom
+import { createElement, createRef, type RefObject } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { I18nProvider } from '../../../i18n';
+import { IframeRenderedView } from './IframeRenderedView';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let host: HTMLDivElement | null = null;
+
+const divRef = () => createRef<HTMLDivElement>() as RefObject<HTMLDivElement>;
+const iframeRef = () => createRef<HTMLIFrameElement>() as RefObject<HTMLIFrameElement>;
+
+const renderUrlView = async () => {
+  host = document.createElement('div');
+  document.body.append(host);
+  root = createRoot(host);
+
+  await act(async () => root?.render(
+    createElement(I18nProvider, null,
+      createElement(IframeRenderedView, {
+        artifact: null,
+        artifactHtml: '',
+        artifactId: null,
+        cancel: vi.fn(),
+        canGoBack: false,
+        canGoForward: false,
+        commit: vi.fn(),
+        discardSnapshot: null,
+        draftUrl: 'https://example.com',
+        faviconUrl: undefined,
+        frameHostRef: divRef(),
+        generating: false,
+        handleOpenExternal: vi.fn(),
+        handleKeyDown: vi.fn(),
+        handleGoBack: vi.fn(),
+        handleGoForward: vi.fn(),
+        handlePickDomElement: vi.fn(),
+        handlePickReviewElement: vi.fn(),
+        handleRegenerate: vi.fn(),
+        handleReload: vi.fn(),
+        html: '',
+        isArtifactMode: false,
+        isResizing: false,
+        loadError: null,
+        loadState: 'ready',
+        localUrl: '',
+        mode: 'url',
+        nodeId: 'iframe-1',
+        openArtifact: vi.fn(),
+        domPickerActive: false,
+        reviewPickerActive: false,
+        readOnly: false,
+        savedPrompt: '',
+        setDraftUrl: vi.fn(),
+        setEditing: vi.fn(),
+        onWakeWebview: vi.fn(),
+        renderIframeRef: iframeRef(),
+        shouldMountInlineFrame: false,
+        streamIframeRef: iframeRef(),
+        streamingActive: false,
+        webviewDiscarded: false,
+        title: 'Example',
+        url: 'https://example.com',
+        webviewHostRef: divRef(),
+        webviewKey: 1,
+        workspaceId: 'workspace-a',
+      }),
+    ),
+  ));
+};
+
+afterEach(async () => {
+  await act(async () => root?.unmount());
+  host?.remove();
+  root = null;
+  host = null;
+});
+
+describe('IframeRenderedView toolbar', () => {
+  it('hides the URL review comment action while preserving other URL actions', async () => {
+    await renderUrlView();
+
+    expect(host?.querySelector('[aria-label="Select DOM for AI Chat"]')).not.toBeNull();
+    expect(host?.querySelector('[aria-label="Open externally"]')).not.toBeNull();
+    expect(host?.querySelector('[aria-label="Add review comment"]')).toBeNull();
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/IframeNodeBody/IframeRenderedView.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/IframeNodeBody/IframeRenderedView.tsx
@@ -59,6 +59,8 @@ interface IframeRenderedViewProps {
   workspaceId?: string;
 }
 
+const SHOW_REVIEW_COMMENT_ACTION = false;
+
 export const IframeRenderedView = ({
   artifact,
   artifactHtml,
@@ -188,7 +190,7 @@ export const IframeRenderedView = ({
             <InspectIcon />
           </Button>
 
-          {mode === 'url' && (
+          {SHOW_REVIEW_COMMENT_ACTION && mode === 'url' && (
             <Button
               type="button"
               variant="icon"

--- a/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.test.ts
@@ -25,32 +25,40 @@ const modF = (overrides: Partial<Parameters<typeof shouldHandleCanvasFindShortcu
   ...overrides,
 });
 
-const elementInNote = () => ({
+const elementInsideSelector = (matchingSelector: string) => ({
   tagName: 'DIV',
-  closest: (selector: string) => (selector === '.note-card' ? { tagName: 'DIV' } : null),
+  closest: (selector: string) => selector.split(',').map((item) => item.trim()).includes(matchingSelector)
+    ? { tagName: 'DIV' }
+    : null,
 });
 
-const elementOutsideNote = (tagName = 'DIV') => ({
+const elementOutsideExcludedSurfaces = (tagName = 'DIV') => ({
   tagName,
   closest: () => null,
 });
 
 describe('shouldHandleCanvasFindShortcut', () => {
-  it('lets note-local find own Cmd/Ctrl+F while focus is inside a note card', () => {
-    expect(shouldHandleCanvasFindShortcut(modF(), elementInNote())).toBe(false);
+  it.each([
+    ['note card', '.note-card'],
+    ['iframe node chrome', '.iframe-body'],
+    ['link drawer header', '.link-drawer__header'],
+    ['link drawer page surface', '.link-drawer__webview-surface'],
+    ['link drawer find bar', '.link-drawer__find'],
+  ])('lets %s own Cmd/Ctrl+F', (_label, selector) => {
+    expect(shouldHandleCanvasFindShortcut(modF(), elementInsideSelector(selector))).toBe(false);
   });
 
-  it('handles Cmd/Ctrl+F outside note cards, including regular editable controls', () => {
-    expect(shouldHandleCanvasFindShortcut(modF(), elementOutsideNote())).toBe(true);
-    expect(shouldHandleCanvasFindShortcut(modF({ ctrlKey: true, metaKey: false }), elementOutsideNote('INPUT')))
+  it('handles Cmd/Ctrl+F outside excluded surfaces, including regular editable controls', () => {
+    expect(shouldHandleCanvasFindShortcut(modF(), elementOutsideExcludedSurfaces())).toBe(true);
+    expect(shouldHandleCanvasFindShortcut(modF({ ctrlKey: true, metaKey: false }), elementOutsideExcludedSurfaces('INPUT')))
       .toBe(true);
   });
 
   it('ignores unrelated or already-handled key events', () => {
-    expect(shouldHandleCanvasFindShortcut(modF({ defaultPrevented: true }), elementOutsideNote()))
+    expect(shouldHandleCanvasFindShortcut(modF({ defaultPrevented: true }), elementOutsideExcludedSurfaces()))
       .toBe(false);
-    expect(shouldHandleCanvasFindShortcut(modF({ key: 'k' }), elementOutsideNote())).toBe(false);
-    expect(shouldHandleCanvasFindShortcut(modF({ shiftKey: true }), elementOutsideNote())).toBe(false);
+    expect(shouldHandleCanvasFindShortcut(modF({ key: 'k' }), elementOutsideExcludedSurfaces())).toBe(false);
+    expect(shouldHandleCanvasFindShortcut(modF({ shiftKey: true }), elementOutsideExcludedSurfaces())).toBe(false);
   });
 });
 

--- a/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.ts
+++ b/apps/canvas-workspace/src/renderer/src/hooks/useCanvasKeyboard.ts
@@ -28,8 +28,16 @@ const isEditableElement = (active: ActiveElementLike | null): boolean => !!activ
   active.isContentEditable === true
 );
 
-const isInsideNoteCard = (active: ActiveElementLike | null): boolean =>
-  !!active?.closest?.('.note-card');
+const CANVAS_FIND_EXCLUDED_SURFACE_SELECTOR = [
+  '.note-card',
+  '.iframe-body',
+  '.link-drawer__header',
+  '.link-drawer__webview-surface',
+  '.link-drawer__find',
+].join(', ');
+
+const isInsideCanvasFindExcludedSurface = (active: ActiveElementLike | null): boolean =>
+  !!active?.closest?.(CANVAS_FIND_EXCLUDED_SURFACE_SELECTOR);
 
 export const shouldHandleCanvasFindShortcut = (
   event: KeyboardShortcutLike,
@@ -39,7 +47,7 @@ export const shouldHandleCanvasFindShortcut = (
   if (!(event.metaKey || event.ctrlKey)) return false;
   if (event.shiftKey) return false;
   if (event.key.toLowerCase() !== 'f') return false;
-  return !isInsideNoteCard(active);
+  return !isInsideCanvasFindExcludedSurface(active);
 };
 
 /** Zoom multiplier per Cmd/Ctrl +/- press. */
@@ -218,9 +226,9 @@ export const useCanvasKeyboard = ({
       setSearchOpen((prev) => !prev);
     },
     'canvas.find': (event) => {
-      // Note cards own their own find flow, so don't let the canvas-level
-      // search steal focus from note editing, note panels, or note toolbar
-      // controls.
+      // Notes and embedded pages own their own find flows, so don't let the
+      // canvas-level search steal focus from their editors, toolbars, or page
+      // chrome.
       if (!shouldHandleCanvasFindShortcut(event, document.activeElement)) return;
       event.preventDefault();
       toggleFindBar();


### PR DESCRIPTION
## Summary
- Let embedded Canvas surfaces keep their own Ctrl/Cmd+F find behavior
- Hide the iframe URL review-comment toolbar action
- Prioritize New terminal in the dock + menu and keep terminal tabs available when the chat tab is hidden

## Validation
- pnpm --filter canvas-workspace exec vitest run src/renderer/src/hooks/useCanvasKeyboard.test.ts src/renderer/src/components/node-bodies/IframeNodeBody/IframeRenderedView.test.ts src/renderer/src/components/dock/RightDock/__tests__/DockCreationControls.test.tsx src/renderer/src/components/dock/RightDock/__tests__/dock-tab-items.test.ts
