### PR TITLE
feat: enable image attachments in AI chat

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageBody.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPageBody.tsx
@@ -458,7 +458,7 @@ export const ChatPageBody = ({
           onInput={handleInput}
           onKeyDown={handleComposerKeyDown}
           onPaste={handlePaste}
-          onAttachFiles={agentScope.kind === 'workspace' ? handleAttachFiles : undefined}
+          onAttachFiles={handleAttachFiles}
           onRemoveAttachment={removeAttachment}
           onRetryAttachment={retryAttachment}
           sendDisabled={attachmentSendBlocked || busyElsewhere || Boolean(sessionError)}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.tsx
@@ -452,7 +452,7 @@ export const ChatPanel = ({
       onInput={handleInput}
       onKeyDown={handleComposerKeyDown}
       onPaste={handlePaste}
-      onAttachFiles={agentScope.kind === 'workspace' ? handleAttachFiles : undefined}
+      onAttachFiles={handleAttachFiles}
       onRemoveAttachment={removeAttachment}
       onRetryAttachment={retryAttachment}
       sendDisabled={attachmentSendBlocked || busyElsewhere || Boolean(sessionError)}

--- a/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatPage.dom-review.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatPage.dom-review.test.tsx
@@ -8,7 +8,12 @@ import { ChatTargetProvider, useChatTargetBroker } from '../ChatTargetContext';
 
 const composer = vi.hoisted(() => ({
   focusInput: vi.fn(),
+  handleAttachFiles: vi.fn(),
   sendMessage: vi.fn(async () => true),
+}));
+
+const chatView = vi.hoisted(() => ({
+  latestProps: null as null | Record<string, unknown>,
 }));
 
 vi.mock('../hooks/useChatComposerState', () => ({
@@ -24,6 +29,7 @@ vi.mock('../hooks/useChatComposerState', () => ({
     conversationError: null,
     currentScopeName: null,
     focusInput: composer.focusInput,
+    handleAttachFiles: composer.handleAttachFiles,
     input: '',
     loading: false,
     mentionItems: [],
@@ -65,7 +71,12 @@ vi.mock('../ChatPageNavigationChrome', () => ({
   ChatPageTopbar: () => null,
 }));
 vi.mock('../ChatConversationStatus', () => ({ ChatConversationStatus: () => null }));
-vi.mock('../ChatView', () => ({ ChatView: () => null }));
+vi.mock('../ChatView', () => ({
+  ChatView: (props: Record<string, unknown>) => {
+    chatView.latestProps = props;
+    return null;
+  },
+}));
 
 import { ChatPageBody } from '../ChatPageBody';
 
@@ -130,6 +141,34 @@ describe('ChatPage DOM review delivery', () => {
         ],
       }),
     );
+    act(() => root.unmount());
+  });
+
+  it('keeps image upload available for global AI chat', async () => {
+    chatView.latestProps = null;
+    const host = document.createElement('div');
+    const root = createRoot(host);
+    await act(async () => root.render(
+      <I18nProvider>
+        <ChatTargetProvider>
+          <ChatPageBody
+            agentScope={{ kind: 'global' }}
+            initialPendingSessionId={null}
+            pendingSessionId={null}
+            pendingSessionIntentId={null}
+            onSessionConsumed={vi.fn()}
+            onSelectSession={vi.fn()}
+            allWorkspaces={[]}
+            onExit={vi.fn()}
+            railCollapsed
+            onToggleRail={vi.fn()}
+            onOpenAppSettings={vi.fn()}
+          />
+        </ChatTargetProvider>
+      </I18nProvider>,
+    ));
+
+    expect(chatView.latestProps?.onAttachFiles).toBe(composer.handleAttachFiles);
     act(() => root.unmount());
   });
 });

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useMentions.scope-draft.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useMentions.scope-draft.test.tsx
@@ -104,10 +104,10 @@ describe('scope-keyed composer state', () => {
     expect(latest?.editableRef.current?.textContent).toBe('global draft');
   });
 
-  it('keeps workspace attachments isolated and rejects them in global scope', async () => {
-    const saveImage = vi.fn(async () => ({
+  it('keeps attachments isolated per scope and accepts images in global chat', async () => {
+    const saveImage = vi.fn(async (scopeId: string) => ({
       ok: true,
-      filePath: '/tmp/workspace-image.png',
+      filePath: `/tmp/${scopeId}-image.png`,
     }));
     Object.defineProperty(window, 'canvasWorkspace', {
       configurable: true,
@@ -126,17 +126,26 @@ describe('scope-keyed composer state', () => {
       await vi.waitFor(() => expect(saveImage).toHaveBeenCalledTimes(1));
       await Promise.resolve();
     });
+    expect(saveImage).toHaveBeenLastCalledWith('workspace-a', expect.any(String), 'png');
+    expect(latest?.attachments).toHaveLength(1);
 
     await renderScope({ kind: 'global' });
     expect(latest?.attachments).toEqual([]);
-    act(() => latest?.handleAttachFiles([
-      new File(['image'], 'unsupported.png', { type: 'image/png' }),
-    ]));
-    expect(latest?.attachments).toEqual([]);
+    await act(async () => {
+      latest?.handleAttachFiles([
+        new File(['image'], 'global.png', { type: 'image/png' }),
+      ]);
+    });
+    await act(async () => {
+      await vi.waitFor(() => expect(saveImage).toHaveBeenCalledTimes(2));
+      await Promise.resolve();
+    });
+    expect(saveImage).toHaveBeenLastCalledWith('__global_chat__', expect.any(String), 'png');
+    expect(latest?.attachments).toHaveLength(1);
 
     await renderScope({ kind: 'workspace', workspaceId: 'workspace-a' });
     expect(latest?.attachments).toHaveLength(1);
-    expect(saveImage).toHaveBeenCalledTimes(1);
+    expect(latest?.attachments[0]?.fileName).toBe('context.png');
   });
 
   it('loads Skill candidates per scope instead of reusing another scope cache', async () => {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useMentions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useMentions.ts
@@ -87,7 +87,6 @@ export function useMentions({
   const filesCacheRef = useRef(new Map<string, MentionItem[]>());
   const skillsCacheRef = useRef(new Map<string, MentionItem[]>());
   const workspaceId = agentScope.kind === 'workspace' ? agentScope.workspaceId : undefined;
-  const attachmentsEnabled = agentScope.kind === 'workspace';
   const scopeId = chatScopeId(agentScope);
   const subscribeDraft = useCallback(
     (listener: () => void) => subscribeChatComposerDraft(scopeId, listener),
@@ -118,8 +117,8 @@ export function useMentions({
     setAttachments,
   });
   const handleAttachFiles = useCallback((files: FileList | File[]) => {
-    if (attachmentsEnabled) chatAttachments.handleAttachFiles(files);
-  }, [attachmentsEnabled, chatAttachments.handleAttachFiles]);
+    chatAttachments.handleAttachFiles(files);
+  }, [chatAttachments.handleAttachFiles]);
 
   useLayoutEffect(() => {
     const element = editableRef.current;
@@ -362,7 +361,7 @@ export function useMentions({
 
   const submitCurrentInput = useCallback(async (requestContext?: AgentRequestContext) => {
     if (isSubmitBlocked?.()) return false;
-    if (attachmentsEnabled && chatAttachments.sendBlocked) return false;
+    if (chatAttachments.sendBlocked) return false;
     let ctx = requestContext ?? getRequestContext?.();
     // Tab mentions are collected for both hosts (see withCollectedTabs).
     if (editableRef.current) ctx = withCollectedTabs(editableRef.current, ctx);
@@ -380,17 +379,15 @@ export function useMentions({
         };
       }
     }
-    const readyAttachments = attachmentsEnabled
-      ? attachments.filter(attachment => (
-        attachment.status === undefined || attachment.status === 'ready'
-      ))
-      : [];
+    const readyAttachments = attachments.filter(attachment => (
+      attachment.status === undefined || attachment.status === 'ready'
+    ));
     const ok = await onSubmit(input, ctx, readyAttachments);
     if (ok) {
       clearInput();
     }
     return ok;
-  }, [attachments, attachmentsEnabled, chatAttachments.sendBlocked, clearInput, collectStructuredContext, getRequestContext, input, isSubmitBlocked, onSubmit]);
+  }, [attachments, chatAttachments.sendBlocked, clearInput, collectStructuredContext, getRequestContext, input, isSubmitBlocked, onSubmit]);
 
   const handleKeyDown = useCallback((event: React.KeyboardEvent) => {
     // While an IME composition is active (Chinese/Japanese/Korean input),
@@ -433,7 +430,7 @@ export function useMentions({
 
   const handlePaste = useCallback((event: React.ClipboardEvent) => {
     const imageFiles = Array.from(event.clipboardData.files).filter(file => file.type.startsWith('image/'));
-    if (attachmentsEnabled && imageFiles.length > 0) {
+    if (imageFiles.length > 0) {
       event.preventDefault();
       handleAttachFiles(imageFiles);
       return;
@@ -441,12 +438,12 @@ export function useMentions({
     event.preventDefault();
     const text = event.clipboardData.getData('text/plain');
     document.execCommand('insertText', false, text);
-  }, [attachmentsEnabled, handleAttachFiles]);
+  }, [handleAttachFiles]);
 
   return {
     clearInput,
-    attachments: attachmentsEnabled ? attachments : [],
-    attachmentSendBlocked: attachmentsEnabled && chatAttachments.sendBlocked,
+    attachments,
+    attachmentSendBlocked: chatAttachments.sendBlocked,
     editableRef,
     focusInput,
     handleAttachFiles,


### PR DESCRIPTION
## Summary
- Enable image attachments across AI chat scopes instead of workspace-only chats
- Keep ChatPanel and full-page ChatPage upload controls wired for global and scheduled chat scopes
- Update regression coverage for global chat image uploads and per-scope attachment drafts

## Validation
- pnpm --filter canvas-workspace exec vitest run src/renderer/src/components/chat/hooks/useMentions.scope-draft.test.tsx src/renderer/src/components/chat/__tests__/ChatPage.dom-review.test.tsx src/renderer/src/components/chat/__tests__/ChatInput.execution-attachments.test.tsx src/renderer/src/components/chat/hooks/useChatAttachments.test.tsx
