### PR TITLE
fix: route tab find shortcut to active web tab

### DIFF
--- a/apps/canvas-workspace/src/main/app/__tests__/webview-shortcuts.test.ts
+++ b/apps/canvas-workspace/src/main/app/__tests__/webview-shortcuts.test.ts
@@ -84,6 +84,27 @@ describe('webview shortcut relay', () => {
     });
   });
 
+  it('relays find from a dock page to the embedder find bar', async () => {
+    registerGuest('dock-browser');
+    const created = await install();
+    const { contents, hostWebContents } = createGuest();
+    created({}, contents);
+
+    const preventDefault = vi.fn();
+    inputHandlerOf(contents)({ preventDefault }, { type: 'keyDown', key: 'f', control: true });
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(hostWebContents.send).toHaveBeenCalledWith('dock:shortcut', {
+      command: 'find',
+      source: {
+        workspaceId: 'ws-1',
+        nodeId: 'dock-tab-1',
+        webContentsId: 42,
+        surfaceKind: 'dock-browser',
+      },
+    });
+  });
+
   it('leaves browser chords inside canvas-node guests untouched', async () => {
     registerGuest('canvas-node');
     const created = await install();

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/__tests__/useDockKeyboard.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/__tests__/useDockKeyboard.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment happy-dom
 import { act, useRef } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DockShortcutRequest } from '../../../../../../shared/dock-shortcuts';
 import { registerMountedWebviewIdentity } from '../../../node-bodies/IframeNodeBody/webview-identities';
+import { FIND_IN_DOCK_TAB_EVENT } from '../dock-browser-commands';
 import { DockStore } from '../dock-store';
 import { dockTabElementId } from '../dock-tab-ids';
 import { useDockKeyboard } from '../useDockKeyboard';
@@ -82,6 +83,95 @@ describe('useDockKeyboard guest shortcut ownership', () => {
 
     act(() => shortcutListener?.({ command: 'close-tab', source: identity }));
     expect(store.getSnapshot().tabs).toHaveLength(0);
+    unregister();
+  });
+
+  it('opens the active web tab find bar even when host focus is outside the dock', () => {
+    const store = new DockStore();
+    store.setActiveWorkspace('ws1');
+    store.openLink('https://a.example/');
+    const tabId = store.getSnapshot().activeTabId;
+    const onFind = vi.fn();
+
+    const Harness = () => {
+      const dockRef = useRef<HTMLElement>(null);
+      useDockKeyboard({
+        store,
+        visible: true,
+        newTabTitle: 'New tab',
+        dockRef,
+        orderedTabIds: [tabId],
+        onCollapse: () => store.collapse(),
+      });
+      return (
+        <>
+          <button id="outside-dock">Outside</button>
+          <aside ref={dockRef} />
+        </>
+      );
+    };
+
+    mount = document.createElement('div');
+    document.body.appendChild(mount);
+    window.addEventListener(FIND_IN_DOCK_TAB_EVENT, onFind);
+    root = createRoot(mount);
+    act(() => root?.render(<Harness />));
+    mount.querySelector<HTMLButtonElement>('#outside-dock')?.focus();
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'f',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    act(() => window.dispatchEvent(event));
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(onFind).toHaveBeenCalledWith(expect.objectContaining({
+      detail: { workspaceId: 'ws1', tabId },
+    }));
+    window.removeEventListener(FIND_IN_DOCK_TAB_EVENT, onFind);
+  });
+
+  it('opens the active tab find bar from a focused guest Ctrl+F relay', () => {
+    const store = new DockStore();
+    store.setActiveWorkspace('ws1');
+    store.openLink('https://a.example/');
+    const tabId = store.getSnapshot().activeTabId;
+    const identity = {
+      workspaceId: 'ws1',
+      nodeId: tabId,
+      webContentsId: 42,
+      surfaceKind: 'dock-browser' as const,
+    };
+    const unregister = registerMountedWebviewIdentity(identity);
+    const onFind = vi.fn();
+
+    const Harness = () => {
+      const dockRef = useRef<HTMLElement>(null);
+      useDockKeyboard({
+        store,
+        visible: true,
+        newTabTitle: 'New tab',
+        dockRef,
+        orderedTabIds: [tabId],
+        onCollapse: () => store.collapse(),
+      });
+      return <aside ref={dockRef} />;
+    };
+
+    mount = document.createElement('div');
+    document.body.appendChild(mount);
+    window.addEventListener(FIND_IN_DOCK_TAB_EVENT, onFind);
+    root = createRoot(mount);
+    act(() => root?.render(<Harness />));
+
+    act(() => shortcutListener?.({ command: 'find', source: identity }));
+
+    expect(onFind).toHaveBeenCalledWith(expect.objectContaining({
+      detail: { workspaceId: 'ws1', tabId },
+    }));
+    window.removeEventListener(FIND_IN_DOCK_TAB_EVENT, onFind);
     unregister();
   });
 

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/useDockKeyboard.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/useDockKeyboard.ts
@@ -68,19 +68,24 @@ export const useDockKeyboard = ({
       if (event.defaultPrevented || isImeComposing(event)) return;
       const command = resolveDockBrowserCommand(event);
       if (command) {
-        // ⌘F means find-in-page here and find-on-canvas there. Listener order
-        // between the two window handlers is not a contract, so resolve it on
-        // the only unambiguous signal: where focus already is.
+        // ⌘F means find-in-page for the active web tab and find-on-canvas
+        // elsewhere. If focus is already inside dock chrome, the dock owns it.
+        // If the visible active dock tab is a web page, keep browser muscle
+        // memory working even when the host focus is still on the canvas after
+        // a tab activation; otherwise leave it to the canvas search handler.
+        const state = store.getSnapshot();
+        const activeTab = state.tabs.find((tab) => tab.id === state.activeTabId);
         if (
           DOCK_FOCUS_SCOPED_COMMANDS.has(command)
           && !isDockFocusOwner(dockRef)
+          && !(command === 'find' && activeTab?.kind === 'link')
         ) {
           return;
         }
         if (applyDockBrowserCommand(
           command,
           store,
-          store.getSnapshot(),
+          state,
           newTabTitle,
           orderedTabIds,
         )) {


### PR DESCRIPTION
## Summary
- Route Ctrl/Cmd+F to the active dock web tab find bar when a web tab is active, even if host focus is outside the dock
- Preserve the existing dock-webview shortcut relay for focused page guests
- Add regression coverage for both host-focus and webview-relay find shortcut paths

## Validation
- pnpm --filter canvas-workspace exec vitest run src/main/app/__tests__/webview-shortcuts.test.ts src/renderer/src/components/dock/RightDock/__tests__/useDockKeyboard.test.tsx src/shared/dock-shortcuts.test.ts src/renderer/src/components/dock/LinkDrawer/__tests__/find-in-page.test.tsx
