### PR TITLE
fix: refine chat rail busy state

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.css
@@ -32,6 +32,8 @@
 
 .chat-page-rail {
   --chat-a11y-secondary: #73726e;
+  --chat-rail-busy-accent: var(--accent);
+  position: relative;
   width: 260px;
   height: 100%;
   flex-shrink: 0;
@@ -42,6 +44,59 @@
   overflow: hidden;
   background: #fff;
   box-sizing: border-box;
+}
+
+.chat-page-rail--interaction-paused::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 8px;
+  right: 8px;
+  height: 2px;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    color-mix(in srgb, var(--chat-rail-busy-accent) 16%, transparent) 24%,
+    var(--chat-rail-busy-accent) 50%,
+    color-mix(in srgb, var(--chat-rail-busy-accent) 16%, transparent) 76%,
+    transparent 100%
+  );
+  opacity: 0.72;
+  pointer-events: none;
+  animation: chat-page-rail-busy-line 1.4s ease-in-out infinite;
+}
+
+@keyframes chat-page-rail-busy-line {
+  0%, 100% {
+    transform: scaleX(0.45);
+  }
+
+  50% {
+    transform: scaleX(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-page-rail--interaction-paused::before {
+    animation: none;
+  }
+}
+
+.chat-page-rail-new[aria-disabled="true"] {
+  background: var(--surface-alt);
+  color: var(--text-secondary);
+  cursor: not-allowed;
+  outline: 1px solid color-mix(in srgb, var(--chat-rail-busy-accent) 14%, transparent);
+  outline-offset: -1px;
+}
+
+.chat-page-rail-new[aria-disabled="true"]:hover {
+  background: var(--surface-alt);
+}
+
+.chat-page-rail-new[aria-disabled="true"] svg {
+  color: var(--text-muted);
 }
 
 .chat-page-rail-new {
@@ -196,6 +251,31 @@
 
 .chat-page-rail-item--active {
   background: rgba(55, 53, 47, 0.08);
+}
+
+.chat-page-rail-item[aria-disabled="true"] {
+  color: var(--text-secondary);
+  cursor: not-allowed;
+}
+
+.chat-page-rail-item[aria-disabled="true"]:hover {
+  background: transparent;
+}
+
+.chat-page-rail-item--active[aria-disabled="true"],
+.chat-page-rail-item--active[aria-disabled="true"]:hover {
+  background: color-mix(in srgb, var(--chat-rail-busy-accent) 8%, var(--surface));
+  color: var(--text);
+  outline: 1px solid color-mix(in srgb, var(--chat-rail-busy-accent) 22%, transparent);
+  outline-offset: -1px;
+}
+
+.chat-page-rail--interaction-paused .chat-page-rail-folder-name {
+  color: var(--text-secondary);
+}
+
+.chat-page-rail--interaction-paused .chat-page-rail-folder-count {
+  color: var(--chat-a11y-secondary);
 }
 
 .chat-page-rail-item svg {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatSessionRailItem.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatSessionRailItem.tsx
@@ -166,11 +166,14 @@ export const ChatSessionRailItem = ({
       <button
         type="button"
         className={`chat-page-rail-item${session.isCurrent ? ' chat-page-rail-item--active' : ''}`}
-        onClick={() => onSelectSession(session)}
+        onClick={() => {
+          if (disabled) return;
+          onSelectSession(session);
+        }}
         title={title}
         aria-current={session.isCurrent ? 'page' : undefined}
         aria-busy={pending ? true : undefined}
-        disabled={disabled}
+        aria-disabled={disabled ? true : undefined}
       >
         <span className="chat-page-rail-item-content">
           <span className="chat-page-rail-item-text">

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatSessionsRail.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatSessionsRail.tsx
@@ -139,17 +139,22 @@ export const ChatSessionsRail = ({
     });
   };
 
+  const railBusy = disabled || Boolean(pendingSessionKey);
+
   return (
     <aside
-      className="chat-page-rail"
+      className={`chat-page-rail${disabled ? ' chat-page-rail--interaction-paused' : ''}`}
       aria-label={t('chat.sessionList')}
-      aria-busy={pendingSessionKey ? true : undefined}
+      aria-busy={railBusy ? true : undefined}
     >
       <button
         type="button"
         className="chat-page-rail-new"
-        onClick={() => void onNewSession()}
-        disabled={disabled}
+        onClick={() => {
+          if (disabled) return;
+          void onNewSession();
+        }}
+        aria-disabled={disabled ? true : undefined}
       >
         <PlusIcon size={14} strokeWidth={1.3} />
         <span>{t('chat.newChat')}</span>
@@ -162,7 +167,6 @@ export const ChatSessionsRail = ({
         onChange={(event) => setSearchQuery(event.target.value)}
         aria-label={t('chat.searchSessions')}
         placeholder={t('chat.searchSessions')}
-        disabled={disabled}
       />
 
       <div className="chat-page-rail-scroll">
@@ -202,7 +206,6 @@ export const ChatSessionsRail = ({
                     onClick={() => toggleGroup(group.id)}
                     aria-expanded={!collapsed}
                     aria-controls={listId}
-                    disabled={disabled}
                   >
                     <ChevronRightIcon
                       size={11}
@@ -241,7 +244,6 @@ export const ChatSessionsRail = ({
                         else next.add(group.id);
                         return next;
                       })}
-                      disabled={disabled}
                     >
                       {showsAllSessions
                         ? t('chat.showFewerSessions')

--- a/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatSessionsRail.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatSessionsRail.test.tsx
@@ -495,7 +495,7 @@ describe('ChatSessionsRail workspace tree', () => {
     expect(testHost.querySelector('.chat-page-rail-item-actions')).toBeNull();
   });
 
-  it('disables new, search, folder, and session controls while a thread is opening', async () => {
+  it('keeps session rail readable while preventing session changes during generation', async () => {
     host = document.createElement('div');
     document.body.appendChild(host);
     root = createRoot(host);
@@ -515,10 +515,31 @@ describe('ChatSessionsRail workspace tree', () => {
       );
     });
 
-    expect(host.querySelector<HTMLButtonElement>('.chat-page-rail-new')?.disabled).toBe(true);
-    expect(host.querySelector<HTMLInputElement>('.chat-page-rail-search')?.disabled).toBe(true);
-    expect(host.querySelector<HTMLButtonElement>('.chat-page-rail-folder')?.disabled).toBe(true);
-    expect(host.querySelector<HTMLButtonElement>('.chat-page-rail-item')?.disabled).toBe(true);
+    const rail = host.querySelector<HTMLElement>('.chat-page-rail');
+    const newSession = host.querySelector<HTMLButtonElement>('.chat-page-rail-new');
+    const search = host.querySelector<HTMLInputElement>('.chat-page-rail-search');
+    const folders = Array.from(host.querySelectorAll<HTMLButtonElement>('.chat-page-rail-folder'));
+    const firstSession = host.querySelector<HTMLButtonElement>('.chat-page-rail-item');
+
+    expect(rail?.getAttribute('aria-busy')).toBe('true');
+    expect(rail?.classList.contains('chat-page-rail--interaction-paused')).toBe(true);
+    expect(newSession?.disabled).toBe(false);
+    expect(newSession?.getAttribute('aria-disabled')).toBe('true');
+    expect(search?.disabled).toBe(false);
+    expect(folders[0].disabled).toBe(false);
+    expect(firstSession?.disabled).toBe(false);
+    expect(firstSession?.getAttribute('aria-disabled')).toBe('true');
+
+    await act(async () => {
+      newSession?.click();
+      firstSession?.click();
+      folders[1].click();
+    });
+
+    expect(onNewSession).not.toHaveBeenCalled();
+    expect(onSelectSession).not.toHaveBeenCalled();
+    expect(folders[1].getAttribute('aria-expanded')).toBe('true');
+    expect(host.textContent).toContain('Third conversation');
   });
 
   it('keeps the list visible and marks the selected conversation busy while it opens', async () => {


### PR DESCRIPTION
Improve the Chat page session rail busy state during generation.

- Keep session rail text readable by replacing native disabled session buttons with aria-disabled click guards
- Leave search, folder expand/collapse, and show-more controls usable while blocking new/session switches
- Add a subtle busy indicator and active-row treatment using existing design tokens
- Update ChatSessionsRail coverage for the generation state

Validation:
- pnpm --dir apps/canvas-workspace exec vitest run src/renderer/src/components/chat/__tests__/ChatSessionsRail.test.tsx
- pnpm --dir apps/canvas-workspace exec vitest run src/main/__tests__/ui-reuse-governance.test.ts
- git diff --check

Note: pnpm --filter canvas-workspace typecheck still fails in this worktree on existing environment/dependency issues such as @phosphor-icons/react resolution and ImportMeta.env typing, with no errors in the changed files.