### PR TITLE
fix(canvas): stabilize dock browser interactions

### DIFF
--- a/apps/canvas-workspace/harness/knowledge/dock-browser.md
+++ b/apps/canvas-workspace/harness/knowledge/dock-browser.md
@@ -126,6 +126,17 @@ content/terminal tab, and leaves the pinned chat alone. Escape inside a web
 page stays page-owned so sites can close their own dialogs or exit modes.
 Dock-owned portals count as dock focus for scoped commands such as Find.
 
+Main-process page-control input has one additional focus boundary: after
+`Page.bringToFront`, CDP fill/press actions must focus the owning host
+`<webview>` by the guest WebContents id. Guest DOM focus and `WebContents.focus()`
+alone can leave Chromium's input route on the chat composer, causing
+`Input.insertText` or key events to leak into host UI.
+
+Read-only operations on a dock link tab must use its live registry entry
+directly. They must not call `ensureOperable` when the guest is temporarily
+unmounted, because its fallback activation changes the current workspace hash
+route; return a retryable not-mounted result instead.
+
 ## Page-element selection bridge
 
 Page-element selection in a dock browser tab must reuse the shared iframe

--- a/apps/canvas-workspace/src/main/agent/tools/tab.test.ts
+++ b/apps/canvas-workspace/src/main/agent/tools/tab.test.ts
@@ -3,6 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   tabs: [] as Array<Record<string, unknown>>,
   activateDockTab: vi.fn(async () => true),
+  findDockLinkTab: vi.fn(),
+  getWebContentsForNode: vi.fn(),
+  ensureOperable: vi.fn(),
+  activateWorkspaceWindow: vi.fn(),
   openDockTab: vi.fn(() => true),
   execInSession: vi.fn(async () => ({ ok: true, output: 'tests passed' })),
 }));
@@ -12,7 +16,7 @@ vi.mock('../../dock/tab-store', () => ({
 }));
 vi.mock('../../dock/tab-actions', () => ({
   activateDockTab: mocks.activateDockTab,
-  findDockLinkTab: vi.fn(),
+  findDockLinkTab: mocks.findDockLinkTab,
   openDockTab: mocks.openDockTab,
 }));
 vi.mock('../../terminal/pty-manager', () => ({
@@ -21,9 +25,9 @@ vi.mock('../../terminal/pty-manager', () => ({
 vi.mock('../../terminal/scrollback', () => ({
   getSessionScrollback: vi.fn(),
 }));
-vi.mock('../../webview/registry', () => ({ getWebContentsForNode: vi.fn() }));
-vi.mock('../../webview/ensure-operable', () => ({ ensureOperable: vi.fn() }));
-vi.mock('../../app/window-manager', () => ({ activateWorkspaceWindow: vi.fn() }));
+vi.mock('../../webview/registry', () => ({ getWebContentsForNode: mocks.getWebContentsForNode }));
+vi.mock('../../webview/ensure-operable', () => ({ ensureOperable: mocks.ensureOperable }));
+vi.mock('../../app/window-manager', () => ({ activateWorkspaceWindow: mocks.activateWorkspaceWindow }));
 vi.mock('../../webview/reader', () => ({
   readDOM: vi.fn(),
   readA11y: vi.fn(),
@@ -47,6 +51,9 @@ describe('dock tab interaction tools', () => {
       },
     ];
     mocks.activateDockTab.mockClear();
+    mocks.getWebContentsForNode.mockReset();
+    mocks.ensureOperable.mockReset();
+    mocks.activateWorkspaceWindow.mockReset();
     mocks.openDockTab.mockClear();
     mocks.execInSession.mockClear();
   });
@@ -135,6 +142,21 @@ describe('dock tab interaction tools', () => {
       kind: 'canvas',
       error: expect.stringContaining('workspaceId: "ws-2"'),
     });
+  });
+
+  it('does not activate a workspace when a link tab guest is temporarily unavailable', async () => {
+    mocks.getWebContentsForNode.mockReturnValue(null);
+    mocks.ensureOperable.mockResolvedValue(null);
+
+    const result = JSON.parse(await createTabTools('ws-1').dock_read_tab.execute({
+      kind: 'link',
+      tabId: 'link:youtube',
+      strategy: 'dom',
+    }));
+
+    expect(result).toMatchObject({ ok: false, kind: 'link' });
+    expect(mocks.ensureOperable).not.toHaveBeenCalled();
+    expect(mocks.activateWorkspaceWindow).not.toHaveBeenCalled();
   });
 
   it('does not execute against a non-terminal or stale tab', async () => {

--- a/apps/canvas-workspace/src/main/agent/tools/tab.ts
+++ b/apps/canvas-workspace/src/main/agent/tools/tab.ts
@@ -1,8 +1,6 @@
 import { randomUUID } from 'crypto';
 import { z } from 'zod';
 import { getWebContentsForNode } from '../../webview/registry';
-import { ensureOperable } from '../../webview/ensure-operable';
-import { activateWorkspaceWindow } from '../../app/window-manager';
 import { readDOM, readA11y, captureScreenshot } from '../../webview/reader';
 import { getCurrentVersionContent } from '../../artifacts/store';
 import { getSessionScrollback } from '../../terminal/scrollback';
@@ -284,18 +282,17 @@ export function createTabTools(workspaceId: string): Record<string, CanvasTool> 
         const maxChars = (input.maxChars as number) ?? 12_000;
         const sparseThreshold = 200;
 
-        const wc = await ensureOperable({
-          lookup: () => getWebContentsForNode(targetWorkspaceId, tabId),
-          activate: () => activateWorkspaceWindow(targetWorkspaceId),
-          mode: strategy === 'screenshot' ? 'operate' : 'read',
-        });
+        // A right-dock link tab is already an app-level surface. Reading it
+        // must not activate its workspace when the guest is being remounted;
+        // that would change the user's current route just to inspect a tab.
+        const wc = getWebContentsForNode(targetWorkspaceId, tabId);
         if (!wc) {
           return JSON.stringify({
             ok: false,
             kind,
             error:
               `No active webview for link tab ${tabId} in workspace ${targetWorkspaceId}. ` +
-              'Make sure the tab is open in the dock and has finished loading.',
+              'The tab may be unmounted or still loading; retry after it finishes mounting.',
           });
         }
 

--- a/apps/canvas-workspace/src/main/agent/tools/webpage.test.ts
+++ b/apps/canvas-workspace/src/main/agent/tools/webpage.test.ts
@@ -1,20 +1,50 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const runtimeCall = vi.hoisted(() => vi.fn());
+const mocks = vi.hoisted(() => ({
+  runtimeCall: vi.fn(),
+  getWebContentsForNode: vi.fn(),
+  findDockLinkTab: vi.fn(),
+  ensureOperable: vi.fn(),
+  activateWorkspaceWindow: vi.fn(),
+  readDOMElement: vi.fn(),
+}));
+
+vi.mock('../../webview/registry', () => ({
+  getWebContentsForNode: mocks.getWebContentsForNode,
+}));
+vi.mock('../../dock/tab-actions', () => ({
+  findDockLinkTab: mocks.findDockLinkTab,
+}));
+vi.mock('../../webview/ensure-operable', () => ({
+  ensureOperable: mocks.ensureOperable,
+}));
+vi.mock('../../app/window-manager', () => ({
+  activateWorkspaceWindow: mocks.activateWorkspaceWindow,
+}));
+vi.mock('../../webview/reader', () => ({
+  readDOMElement: mocks.readDOMElement,
+}));
 
 vi.mock('../../runtime/capabilities', () => ({
   PAGE_READINESS_HINT: 'readiness hint',
-  getCanvasCapabilityRuntime: () => ({ call: runtimeCall }),
+  getCanvasCapabilityRuntime: () => ({ call: mocks.runtimeCall }),
 }));
 vi.mock('electron', () => ({ ipcMain: { handle: vi.fn() } }));
 
 import { createWebpageTools } from './webpage';
 
 describe('browser_read_page capability adapter', () => {
-  beforeEach(() => runtimeCall.mockReset());
+  beforeEach(() => {
+    mocks.runtimeCall.mockReset();
+    mocks.getWebContentsForNode.mockReset();
+    mocks.findDockLinkTab.mockReset();
+    mocks.ensureOperable.mockReset();
+    mocks.activateWorkspaceWindow.mockReset();
+    mocks.readDOMElement.mockReset();
+  });
 
   it('preserves the legacy success payload', async () => {
-    runtimeCall.mockResolvedValue({
+    mocks.runtimeCall.mockResolvedValue({
       ok: true,
       value: {
         strategy: 'dom',
@@ -39,7 +69,7 @@ describe('browser_read_page capability adapter', () => {
       textLength: 5,
       hint: 'readiness hint',
     });
-    expect(runtimeCall).toHaveBeenCalledWith(
+    expect(mocks.runtimeCall).toHaveBeenCalledWith(
       'browser.page.read',
       { nodeId: 'web-1', strategy: 'dom' },
       expect.objectContaining({ workspaceId: 'ws-1' }),
@@ -47,7 +77,7 @@ describe('browser_read_page capability adapter', () => {
   });
 
   it('uses the legacy workspace override without leaking it into capability input', async () => {
-    runtimeCall.mockResolvedValue({ ok: true, value: { strategy: 'dom', text: '' } });
+    mocks.runtimeCall.mockResolvedValue({ ok: true, value: { strategy: 'dom', text: '' } });
 
     await createWebpageTools('ws-1').browser_read_page.execute({
       nodeId: 'web-1',
@@ -55,7 +85,7 @@ describe('browser_read_page capability adapter', () => {
       strategy: 'dom',
     });
 
-    expect(runtimeCall).toHaveBeenCalledWith(
+    expect(mocks.runtimeCall).toHaveBeenCalledWith(
       'browser.page.read',
       { nodeId: 'web-1', strategy: 'dom' },
       expect.objectContaining({ workspaceId: 'ws-2' }),
@@ -63,7 +93,7 @@ describe('browser_read_page capability adapter', () => {
   });
 
   it('preserves strategy on read failures', async () => {
-    runtimeCall.mockResolvedValue({
+    mocks.runtimeCall.mockResolvedValue({
       ok: false,
       error: {
         code: 'page_read_failed',
@@ -81,5 +111,27 @@ describe('browser_read_page capability adapter', () => {
       strategy: 'dom',
       error: 'DOM extraction timed out',
     });
+  });
+});
+
+describe('browser_read_dom_selection', () => {
+  it('does not activate a workspace when a dock tab guest is temporarily unavailable', async () => {
+    // The tab can be stale in the current published tab list while its
+    // selection context is still being processed.
+    mocks.findDockLinkTab.mockReturnValue(undefined);
+    mocks.getWebContentsForNode.mockReturnValue(null);
+    mocks.ensureOperable.mockImplementation(async (options: { activate: () => Promise<unknown> }) => {
+      await options.activate();
+      return null;
+    });
+
+    const output = JSON.parse(await createWebpageTools('ws-1').browser_read_dom_selection.execute({
+      nodeId: 'link:youtube',
+      selector: '#video',
+    }));
+
+    expect(output.ok).toBe(false);
+    expect(mocks.activateWorkspaceWindow).not.toHaveBeenCalled();
+    expect(mocks.ensureOperable).not.toHaveBeenCalled();
   });
 });

--- a/apps/canvas-workspace/src/main/agent/tools/webpage.ts
+++ b/apps/canvas-workspace/src/main/agent/tools/webpage.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { getWebContentsForNode } from '../../webview/registry';
 import { ensureOperable } from '../../webview/ensure-operable';
 import { activateWorkspaceWindow } from '../../app/window-manager';
+import { findDockLinkTab } from '../../dock/tab-actions';
 import { readDOMElement } from '../../webview/reader';
 import {
   getCanvasCapabilityRuntime,
@@ -33,17 +34,26 @@ export function createWebpageTools(workspaceId: string): Record<string, CanvasTo
         const targetWorkspaceId = (input.workspaceId as string) || workspaceId;
         const selector = input.selector as string;
         const maxChars = (input.maxChars as number) ?? 12_000;
-        const wc = await ensureOperable({
-          lookup: () => getWebContentsForNode(targetWorkspaceId, nodeId),
-          activate: () => activateWorkspaceWindow(targetWorkspaceId),
-          mode: 'read',
-        });
+        const dockTab = findDockLinkTab(targetWorkspaceId, nodeId);
+        const isDockTab = Boolean(dockTab || nodeId.startsWith('link:'));
+        // A dock tab is already an app-level surface. If its guest is being
+        // remounted, report the stale target instead of activating its
+        // workspace and changing the user's current route just to read it.
+        const wc = isDockTab
+          ? getWebContentsForNode(targetWorkspaceId, nodeId)
+          : await ensureOperable({
+              lookup: () => getWebContentsForNode(targetWorkspaceId, nodeId),
+              activate: () => activateWorkspaceWindow(targetWorkspaceId),
+              mode: 'read',
+            });
         if (!wc) {
           return JSON.stringify({
             ok: false,
             error:
-              `No active webview for node ${nodeId} in workspace ${targetWorkspaceId} ` +
-              `(auto-activation attempted). Make sure the iframe node or web tab still exists and is loaded.`,
+              `No live webview for ${isDockTab ? 'dock link tab' : 'node'} ${nodeId} in workspace ${targetWorkspaceId}. ` +
+              (isDockTab
+                ? 'The tab is not mounted or is being restored; retry after it finishes loading.'
+                : '(auto-activation attempted). Make sure the iframe node still exists and is loaded.'),
           });
         }
         const r = await readDOMElement(wc, selector, maxChars);

--- a/apps/canvas-workspace/src/main/runtime/capabilities/page-capabilities.ts
+++ b/apps/canvas-workspace/src/main/runtime/capabilities/page-capabilities.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { getWebContentsForNode } from '../../webview/registry';
 import { ensureOperable } from '../../webview/ensure-operable';
 import { activateWorkspaceWindow } from '../../app/window-manager';
+import { findDockLinkTab } from '../../dock/tab-actions';
 import { readA11y, readDOM, captureScreenshot } from '../../webview/reader';
 import {
   cdpClickSelector,
@@ -138,16 +139,25 @@ async function readLivePage(workspaceId: string, input: PageReadInput): Promise<
   const strategy = input.strategy ?? 'auto';
   const maxChars = input.maxChars ?? 12_000;
   const sparseThreshold = input.sparseThreshold ?? 200;
-  const wc = await ensureOperable({
-    lookup: () => getWebContentsForNode(workspaceId, input.nodeId),
-    activate: () => activateWorkspaceWindow(workspaceId),
-    mode: strategy === 'screenshot' ? 'operate' : 'read',
-  });
+  const dockTab = findDockLinkTab(workspaceId, input.nodeId);
+  const isDockTab = Boolean(dockTab || input.nodeId.startsWith('link:'));
+  // A dock link tab is already an app-level surface. Do not activate its
+  // workspace just because the guest is temporarily unmounted; that changes
+  // the user's current route while a read is in flight.
+  const wc = isDockTab
+    ? getWebContentsForNode(workspaceId, input.nodeId)
+    : await ensureOperable({
+        lookup: () => getWebContentsForNode(workspaceId, input.nodeId),
+        activate: () => activateWorkspaceWindow(workspaceId),
+        mode: strategy === 'screenshot' ? 'operate' : 'read',
+      });
   if (!wc) {
     throw new CapabilityError(
       'webview_not_found',
       `No active webview for node ${input.nodeId} in workspace ${workspaceId} ` +
-        '(auto-activation attempted). Make sure the iframe node exists and is in URL mode.',
+        (isDockTab
+          ? '(the dock tab is not mounted or is still loading).'
+          : '(auto-activation attempted). Make sure the iframe node exists and is in URL mode.'),
       { strategy },
     );
   }

--- a/apps/canvas-workspace/src/plugins/main/webview-page-control/__tests__/cdp-actions.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/webview-page-control/__tests__/cdp-actions.test.ts
@@ -10,9 +10,15 @@ import type { CdpHost } from '../../../../main/webview/cdp-session';
 
 interface FakeHost extends CdpHost {
   executeJavaScript(code: string, userGesture?: boolean): Promise<unknown>;
+  hostWebContents: {
+    executeJavaScript(code: string, userGesture?: boolean): Promise<unknown>;
+    isDestroyed(): boolean;
+  };
+  id: number;
   focus(): void;
   focusCount: number;
   cdpCalls: Array<{ method: string; params?: Record<string, unknown> }>;
+  hostJsCalls: string[];
   jsCalls: string[];
 }
 
@@ -22,11 +28,21 @@ function makeHost(opts: {
 } = {}): FakeHost {
   let attached = false;
   const cdpCalls: Array<{ method: string; params?: Record<string, unknown> }> = [];
+  const hostJsCalls: string[] = [];
   const jsCalls: string[] = [];
   const host: FakeHost = {
     cdpCalls,
+    hostJsCalls,
     jsCalls,
     focusCount: 0,
+    hostWebContents: {
+      isDestroyed: () => false,
+      async executeJavaScript(code: string) {
+        hostJsCalls.push(code);
+        return true;
+      },
+    },
+    id: 42,
     focus() {
       this.focusCount++;
     },
@@ -206,6 +222,7 @@ describe('cdpPressKey', () => {
     const host = makeHost();
     await cdpPressKey(host, 'a');
     expect(host.focusCount).toBe(1);
+    expect(host.hostJsCalls).toHaveLength(1);
   });
 });
 
@@ -239,6 +256,18 @@ describe('cdpFillSelector', () => {
     });
     await cdpFillSelector(host, 'input#q', 'hello');
     expect(host.focusCount).toBe(1);
+  });
+
+  it('focuses the owning webview element in the embedder before inserting text', async () => {
+    const host = makeHost({
+      jsResponse: { ok: true, tag: 'input', editable: true },
+    });
+
+    await cdpFillSelector(host, 'input#q', 'hello');
+
+    expect(host.hostJsCalls).toHaveLength(1);
+    expect(host.hostJsCalls[0]).toContain('getWebContentsId');
+    expect(host.hostJsCalls[0]).toContain('42');
   });
 
   it('reports JS-side selector failure without touching CDP', async () => {

--- a/apps/canvas-workspace/src/plugins/main/webview-page-control/cdp-actions.ts
+++ b/apps/canvas-workspace/src/plugins/main/webview-page-control/cdp-actions.ts
@@ -98,6 +98,52 @@ interface CdpActionHost extends CdpHost, PageRunner {
    * forces the guest to become the focused widget.
    */
   focus?(): void;
+  /** The embedder renderer that owns a `<webview>` guest. */
+  hostWebContents?: {
+    executeJavaScript(code: string, userGesture?: boolean): Promise<unknown>;
+    isDestroyed(): boolean;
+  };
+  /** Stable id used to find this guest's `<webview>` element in the embedder. */
+  id?: number;
+}
+
+/**
+ * Focus the embedder's `<webview>` element, not only the guest document.
+ *
+ * `WebContents.focus()` and a DOM `focus()` inside the guest can disagree
+ * about Chromium's actual input route for an embedded guest. In that state
+ * CDP `Input.insertText` / `dispatchKeyEvent` can still land in a focused
+ * host input (most visibly the chat composer). The host renderer is the only
+ * place that can focus the `<webview>` widget itself, so resolve it by the
+ * guest id and focus that exact element before sending input.
+ */
+async function focusOwningWebview(host: CdpActionHost): Promise<void> {
+  const embedder = host.hostWebContents;
+  const webContentsId = host.id;
+  if (!embedder || embedder.isDestroyed() || typeof webContentsId !== 'number') return;
+
+  const script = `(function(){
+  try {
+    var id = ${webContentsId};
+    var guests = document.querySelectorAll('webview');
+    for (var i = 0; i < guests.length; i += 1) {
+      var guest = guests[i];
+      try {
+        if (guest.getWebContentsId() !== id) continue;
+        guest.focus();
+        return true;
+      } catch (_) {}
+    }
+  } catch (_) {}
+  return false;
+})()`;
+
+  try {
+    await embedder.executeJavaScript(script, false);
+  } catch {
+    // The guest may be tearing down or the host may be navigating. The CDP
+    // action still has its existing best-effort focus path below.
+  }
 }
 
 interface CenterResult {
@@ -272,6 +318,7 @@ export async function cdpPressKey(
     return await runWithTimeout(
       withCdp(wc, async (send: CdpSender) => {
         await bringPageTargetToFront(send);
+        await focusOwningWebview(wc);
         const baseInit: Record<string, unknown> = {
           key: spec.key,
           code: spec.code,
@@ -389,6 +436,7 @@ export async function cdpFillSelector(
     return await runWithTimeout(
       withCdp(wc, async (send: CdpSender) => {
         await bringPageTargetToFront(send);
+        await focusOwningWebview(wc);
         await send('Input.insertText', { text: value });
         return {
           ok: true,

--- a/apps/canvas-workspace/src/renderer/src/components/dock/LinkDrawer/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/LinkDrawer/index.tsx
@@ -37,7 +37,7 @@ import type { AgentContextDomSelectionRef, AgentContextTabRef } from '../../../t
 import { ExternalLinkIcon, PlusIcon } from "../../icons";
 import { Button, TextField } from "../../ui";
 import { EXPERIMENTAL_FLAG_DEFAULT_BROWSER } from "../../../../../shared/experimental-features";
-import type { ChatDeliveryReceipt } from '../../chat/ChatTargetContext';
+import { useActiveChatTarget, type ChatDeliveryReceipt } from '../../chat/ChatTargetContext';
 import { useChatDeliveryNotifier } from '../../chat/useChatDeliveryNotifier';
 import { TabChatAction } from '../RightDock/TabChatAction';
 import "./index.css";
@@ -109,6 +109,8 @@ export const LinkTabView = ({
   const { t } = useI18n();
   const { notify } = useAppShell();
   const notifyChatDelivery = useChatDeliveryNotifier();
+  const scopeKind = useActiveChatTarget()?.scope?.kind;
+
   const [domPickerActive, setDomPickerActive] = useState(false);
   // When Pulse Canvas is itself the default browser, the "open in system
   // browser" escape hatch loops back into this app — so steer the user to
@@ -365,17 +367,19 @@ export const LinkTabView = ({
           >
             <InspectIcon />
           </Button>
-          <Button
-            variant="icon"
-            size="xs"
-            className="link-drawer__action"
-            aria-label={t('linkDrawer.addToReference')}
-            title={t('linkDrawer.addToReference')}
-            onClick={handleAddToReference}
-            disabled={!browser.currentUrl}
-          >
-            <ReferenceIcon />
-          </Button>
+          {
+            scopeKind === 'workspace' ? <Button
+              variant="icon"
+              size="xs"
+              className="link-drawer__action"
+              aria-label={t('linkDrawer.addToReference')}
+              title={t('linkDrawer.addToReference')}
+              onClick={handleAddToReference}
+              disabled={!browser.currentUrl}
+            >
+              <ReferenceIcon />
+            </Button> : null
+          }
           <Button
             variant="icon"
             size="xs"
@@ -387,17 +391,20 @@ export const LinkTabView = ({
           >
             <ExternalLinkIcon />
           </Button>
-          <Button
-            variant="icon"
-            size="xs"
-            className="link-drawer__action"
-            aria-label={t('linkDrawer.addToCanvas')}
-            onClick={handleAddToCanvas}
-            disabled={!activeWorkspaceId || !browser.currentUrl}
-            title={activeWorkspaceId ? t('linkDrawer.addToCanvas') : t('linkDrawer.noActiveCanvas')}
-          >
-            <PlusIcon size={12} strokeWidth={1.2} />
-          </Button>
+          {
+            scopeKind === 'workspace' ? <Button
+              variant="icon"
+              size="xs"
+              className="link-drawer__action"
+              aria-label={t('linkDrawer.addToCanvas')}
+              onClick={handleAddToCanvas}
+              disabled={!activeWorkspaceId || !browser.currentUrl}
+              title={activeWorkspaceId ? t('linkDrawer.addToCanvas') : t('linkDrawer.noActiveCanvas')}
+            >
+              <PlusIcon size={12} strokeWidth={1.2} />
+            </Button> : null
+          }
+
         </div>
       </header>
       {loading && (


### PR DESCRIPTION
## Summary

- Keep CDP fill and key input routed to the owning dock webview instead of the chat composer.
- Prevent dock link reads and DOM selections from auto-activating a workspace when a guest is temporarily unmounted.
- Include the related LinkDrawer workspace-scope UI update.

## Root cause

Embedded webviews have a host `<webview>` focus boundary. In addition, the generic read fallback could call `activateWorkspaceWindow`, changing the current workspace route while a dock tab was being remounted.

## Validation

- Canvas typecheck passed.
- Targeted webview, tab, page capability, and operability tests passed.
- Canvas production build passed.
- Real dock-tab read verified with the renderer route unchanged before and after the read.
