### PR TITLE
fix(engine): hard-block mutating tools in planning mode

### DIFF
--- a/packages/cli/src/ink/ink-controller.ts
+++ b/packages/cli/src/ink/ink-controller.ts
@@ -116,6 +116,15 @@ export class InkCoderController implements InkCliController {
     await goalIntegration.initialize();
     await this.agent.initialize();
 
+    // Surface planning-mode tool rejections (hard-blocked mutating tools /
+    // non-read-only bash commands) so the user knows why nothing happened.
+    this.agent.events.on('disallowed_tool_attempt_in_planning', (event: any) => {
+      const { toolName, category } = event?.payload ?? {};
+      if (toolName) {
+        this.ui.warn(`Planning mode blocked ${toolName}${category ? ` (${category})` : ''}`);
+      }
+    });
+
     const pluginStatus = this.agent.getPluginStatus();
     this.ui.showPluginStatus(pluginStatus.enginePlugins.length);
 

--- a/packages/cli/src/readline/readline-host.ts
+++ b/packages/cli/src/readline/readline-host.ts
@@ -68,6 +68,15 @@ export class CoderCLI {
     await goalIntegration.initialize();
     await this.agent.initialize();
 
+    // Surface planning-mode tool rejections (hard-blocked mutating tools /
+    // non-read-only bash commands) so the user knows why nothing happened.
+    this.agent.events.on('disallowed_tool_attempt_in_planning', (event: any) => {
+      const { toolName, category } = event?.payload ?? {};
+      if (toolName) {
+        this.tui.warn(`Planning mode blocked ${toolName}${category ? ` (${category})` : ''}`);
+      }
+    });
+
     // 显示插件状态
     const pluginStatus = this.agent.getPluginStatus();
     this.tui.showPluginStatus(pluginStatus.enginePlugins.length);

--- a/packages/engine/harness/knowledge/security-posture.md
+++ b/packages/engine/harness/knowledge/security-posture.md
@@ -22,7 +22,7 @@ These make on-disk config an execution surface, not just data:
 
 ## What little gating exists (and its limits)
 
-- **plan-mode** removes only `write`/`edit` from the tool list in planning mode — `bash`, MCP, and sub-agent tools remain callable. It is an LLM-instruction mechanism, not a security boundary.
+- **plan-mode** (since 2026-08-16) hard-blocks mutating tools in planning mode at the `beforeToolCall` boundary: any tool classified `write`/`execute` is short-circuited with a synthetic rejection, and `bash` runs a read-only command classifier (`plan-mode-plugin/readonly-command.ts`) so only the built-in read-only set (`ls`, `cat`, `echo`, `pwd`, `head`, `tail`, `grep`, `find`, `wc`, `which`, `diff`, `stat`, `du`, `cd`, read-only `git`) executes. It is a *policy boundary for the LLM loop*, still not a sandbox: it assumes the engine process itself is trusted, and its mutating classification falls back to name inference for unknown tools (`KNOWN_TOOL_META` + regex). It is not human-in-the-loop and does not cover executing mode.
 - **ptc `allowed_callers`** is an exposure filter, not an approval gate, and it UNIONS typed + untyped allowlists (declaring both broadens access). Registered last in the pipeline, so it only sees tools earlier stages left.
 - Neither is human-in-the-loop.
 

--- a/packages/engine/harness/spec/gating-posture.md
+++ b/packages/engine/harness/spec/gating-posture.md
@@ -10,13 +10,11 @@ The engine's *current* containment story is fully described in `knowledge/securi
 
 **Why it needs a decision.** This is the single most load-bearing assumption for every embedder. If it is a contract, it should be stated as one (and the skills/knowledge can point embedders at it with confidence). If it is a gap, adding an approval hook later changes the tool-execution path for all hosts and is a breaking behavior change — better decided before more consumers hard-code "no gate exists." Either answer is legitimate; leaving it implicit means each host re-derives it by reading source.
 
-## 2. plan-mode: declared policy ≠ enforced policy
+## 2. plan-mode: declared policy ≠ enforced policy — RESOLVED 2026-08-16
 
-**Current state.** The planning-mode policy object declares `disallowedCategories: ['write', 'execute']` (`src/built-in/plan-mode-plugin/index.ts:64`). But the code that actually removes tools keys off a hardcoded name set `DISALLOWED_TOOLS_IN_PLANNING = new Set(['write', 'edit'])` (`:103`, applied at `:110`) — tool *names*, not categories. So in planning mode `write` and `edit` are removed, while `bash` and other `execute`-category tools stay callable, even though the declared policy says `execute` is disallowed. The `disallowedCategories` value is consumed only by `observePotentialPolicyViolation` (`:370`), which merely *emits an event* — it blocks nothing.
+**Resolved.** Planning mode now hard-blocks by `disallowedCategories`: `beforeToolCall` short-circuits any tool whose category is `write`/`execute` with a synthetic rejected result, and `bash` additionally runs a read-only command classifier (`src/built-in/plan-mode-plugin/readonly-command.ts`) so read-only commands (`ls`, `grep`, `find`, `git status`, ...) stay available while everything else is blocked. Top-level tools stay stable (no more name-based removal of `write`/`edit`). `disallowedToolAttemptInPlanning` events are still emitted for hosts (CLI prints a warning). The declared policy is now the enforced policy.
 
-**Open question.** Which is the intended planning-mode policy — the declared one (`execute` should also be withheld, so the enforcement set is wrong) or the enforced one (only `write`/`edit` should go, so the declared `disallowedCategories` is misleading)?
-
-**Why it needs a decision.** The two are contradictory and both are shipped. A host reading `disallowedCategories: ['write','execute']` reasonably believes `bash` is blocked in planning mode; it is not. This is a divergence between spec-as-written-in-code and behavior — resolving it is a policy call (how locked-down should planning mode be?), not an obvious bug fix, because either side could be the intended truth.
+**Remaining nuance (documented, not a divergence):** mutating vs read-only is a category call for every tool. Tools without explicit metadata fall back to name-inference (`KNOWN_TOOL_META` + regex); `generate_image` was added explicitly as `write`. A future tool whose name does not hint at mutation will be classified `other` and NOT blocked in planning mode — add it to `KNOWN_TOOL_META` when that is wrong.
 
 ## 3. ptc `allowed_callers` unions typed + untyped allowlists
 
@@ -28,4 +26,4 @@ The engine's *current* containment story is fully described in `knowledge/securi
 
 ---
 
-**Verification.** Confirmed against source on the working branch (2026-07-07): plan-mode declared vs enforced (`plan-mode-plugin/index.ts:64` vs `:103,110`; observation-only consumer at `:370`); ptc union (`ptc-plugin.ts:71,183-184`, `addCallerToken` into a shared `Set`). The zero-gating posture is the standing description in `knowledge/security-posture.md`.
+**Verification.** Confirmed against source on the working branch (2026-07-07): plan-mode declared vs enforced (`plan-mode-plugin/index.ts:64` vs `:103,110`; observation-only consumer at `:370`); ptc union (`ptc-plugin.ts:71,183-184`, `addCallerToken` into a shared `Set`). The zero-gating posture is the standing description in `knowledge/security-posture.md`. Plan-mode item #2 was resolved 2026-08-16 with the hard-blocking beforeToolCall + read-only bash classifier; ptc union and the zero-gating posture questions remain open.

--- a/packages/engine/src/Engine.ts
+++ b/packages/engine/src/Engine.ts
@@ -1,4 +1,5 @@
 import { asSchema } from 'ai';
+import type { EventEmitter } from 'events';
 import type { Context, Tool, ToolExecutionContext, LLMProviderFactory, SystemPromptOption, ToolHooks, ILogger, PulseEngineInstance, ModelType } from './shared/types';
 import type { LoopOptions, LoopHooks } from './core/loop';
 import type { EnginePluginLoadOptions } from './plugin/EnginePlugin.js';
@@ -161,6 +162,14 @@ export class Engine {
     return {
       tools: this.tools,
     };
+  }
+
+  /**
+   * Shared EventEmitter used by built-in plugins (plan-mode events,
+   * hook timing, ...). Hosts can subscribe to surface events to the user.
+   */
+  get events(): EventEmitter {
+    return this.pluginManager.getEvents();
   }
 
   constructor(options?: EngineOptions) {

--- a/packages/engine/src/built-in/plan-mode-plugin/index.test.ts
+++ b/packages/engine/src/built-in/plan-mode-plugin/index.test.ts
@@ -1,0 +1,163 @@
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import { Engine } from '../../Engine.js';
+import { builtInPlanModePlugin } from './index.js';
+import type { PlanModeEvent } from './index.js';
+import { WriteTool } from '../../tools/index.js';
+
+const createLogger = () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+});
+
+const makeEngine = async () => {
+  const engine = new Engine({
+    disableBuiltInPlugins: true,
+    enginePlugins: { plugins: [builtInPlanModePlugin], scan: false },
+    userConfigPlugins: { scan: false },
+    builtInTools: {
+      read: {
+        name: 'read',
+        description: 'Read a file.',
+        inputSchema: z.object({ path: z.string() }),
+        execute: async ({ path }: { path: string }) => ({ content: `content of ${path}` }),
+      },
+      write: WriteTool,
+      bash: {
+        name: 'bash',
+        description: 'Execute a bash command.',
+        inputSchema: z.object({ command: z.string() }),
+        execute: async ({ command }: { command: string }) => {
+          // Never really executes in tests; this fake records the call so the
+          // test can prove planning mode blocked it BEFORE execution.
+          return { output: `EXECUTED:${command}`, exitCode: 0 };
+        },
+      },
+      generate_image: {
+        name: 'generate_image',
+        description: 'Generate an image.',
+        inputSchema: z.object({ prompt: z.string() }),
+        execute: async () => ({ ok: true }),
+      },
+    },
+    logger: createLogger(),
+  });
+  await engine.initialize();
+  return engine;
+};
+
+describe('built-in plan mode hard blocking', () => {
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('blocks mutating tools in planning mode with a synthetic result', async () => {
+    const engine = await makeEngine();
+    expect(engine.setMode('planning')).toBe(true);
+
+    const session = await engine.createToolSession({ messages: [] });
+    const output = (await session.executeTool('write', {
+      filePath: '/tmp/plan-mode-blocked.txt',
+      content: 'nope',
+    })) as { success?: boolean; blockedByPlanMode?: boolean; error?: string };
+
+    expect(output.blockedByPlanMode).toBe(true);
+    expect(output.success).toBe(false);
+    expect(output.error).toContain('planning mode');
+  });
+
+  it('blocks generate_image (mutating disk write) in planning mode', async () => {
+    const engine = await makeEngine();
+    engine.setMode('planning');
+
+    const session = await engine.createToolSession({ messages: [] });
+    const output = (await session.executeTool('generate_image', {
+      prompt: 'a cat',
+    })) as { blockedByPlanMode?: boolean };
+
+    expect(output.blockedByPlanMode).toBe(true);
+  });
+
+  it('allows read tools in planning mode', async () => {
+    const engine = await makeEngine();
+    engine.setMode('planning');
+
+    const session = await engine.createToolSession({ messages: [] });
+    const output = await session.executeTool('read', { path: 'src/index.ts' });
+    expect(output).toEqual({ content: 'content of src/index.ts' });
+  });
+
+  it('blocks non-read-only bash commands in planning mode', async () => {
+    const engine = await makeEngine();
+    engine.setMode('planning');
+
+    const session = await engine.createToolSession({ messages: [] });
+    const output = (await session.executeTool('bash', {
+      command: 'rm -rf /tmp/plan-mode-rm',
+    })) as { output?: string; error?: string; exitCode?: number };
+
+    expect(output.exitCode).toBe(1);
+    expect(output.error).toContain('Blocked by planning mode');
+    expect(output.output).toBe('');
+  });
+
+  it('allows read-only bash commands in planning mode', async () => {
+    const engine = await makeEngine();
+    engine.setMode('planning');
+
+    const session = await engine.createToolSession({ messages: [] });
+    const output = (await session.executeTool('bash', {
+      command: 'ls -la',
+    })) as { output?: string; exitCode?: number };
+
+    // Fake bash echoes EXECUTED:... — proves it was NOT blocked.
+    expect(output.output).toContain('EXECUTED:ls -la');
+  });
+
+  it('allows mutating tools in executing mode', async () => {
+    const engine = await makeEngine();
+    engine.setMode('executing');
+
+    const session = await engine.createToolSession({ messages: [] });
+    const output = (await session.executeTool('write', {
+      filePath: '/tmp/plan-mode-executing.txt',
+      content: 'allowed',
+    })) as { success?: boolean };
+
+    expect(output.success).toBe(true);
+  });
+
+  it('emits disallowed_tool_attempt_in_planning when a tool is blocked', async () => {
+    const engine = await makeEngine();
+    engine.setMode('planning');
+
+    const events: PlanModeEvent[] = [];
+    engine.events.on('disallowed_tool_attempt_in_planning', (event: PlanModeEvent) => {
+      events.push(event);
+    });
+
+    const session = await engine.createToolSession({ messages: [] });
+    await session.executeTool('bash', { command: 'rm -rf /tmp/x' });
+
+    expect(events.length).toBe(1);
+    expect(events[0].payload).toMatchObject({
+      toolName: 'bash',
+      category: 'execute',
+    });
+  });
+
+  it('does not block read-only bash in planning mode with compound commands', async () => {
+    const engine = await makeEngine();
+    engine.setMode('planning');
+
+    const session = await engine.createToolSession({ messages: [] });
+    const output = (await session.executeTool('bash', {
+      command: 'cd src && grep -r TODO .',
+    })) as { output?: string };
+
+    expect(output.output).toContain('EXECUTED:cd src && grep -r TODO .');
+  });
+});

--- a/packages/engine/src/built-in/plan-mode-plugin/index.ts
+++ b/packages/engine/src/built-in/plan-mode-plugin/index.ts
@@ -3,6 +3,7 @@ import type { ModelMessage } from 'ai';
 
 import type { SystemPromptOption } from '../../shared/types';
 import type { EnginePlugin, EnginePluginContext } from '../../plugin/EnginePlugin';
+import { isReadonlyBashCommand } from './readonly-command.js';
 
 export type PlanMode = 'planning' | 'executing';
 export type PlanIntentLabel = 'PLAN_ONLY' | 'EXECUTE_NOW' | 'UNCLEAR';
@@ -100,23 +101,6 @@ const NEGATIVE_PATTERNS: RegExp[] = [
 
 const PLAN_PATTERNS: RegExp[] = [/先计划/i, /先分析/i, /先出方案/i, /plan\s+first/i, /analysis\s+first/i];
 
-const DISALLOWED_TOOLS_IN_PLANNING = new Set(['write', 'edit']);
-
-function filterPlanningTools(tools: Record<string, any>): Record<string, any> {
-  let removed = false;
-  const filtered: Record<string, any> = {};
-
-  for (const [name, tool] of Object.entries(tools)) {
-    if (DISALLOWED_TOOLS_IN_PLANNING.has(name)) {
-      removed = true;
-      continue;
-    }
-    filtered[name] = tool;
-  }
-
-  return removed ? filtered : tools;
-}
-
 function appendSystemPrompt(base: SystemPromptOption | undefined, append: string): SystemPromptOption {
   if (!append.trim()) {
     return base ?? { append: '' };
@@ -137,6 +121,26 @@ function appendSystemPrompt(base: SystemPromptOption | undefined, append: string
   const currentAppend = base.append.trim();
   return {
     append: currentAppend ? `${currentAppend}\n\n${append}` : append
+  };
+}
+
+/** Synthetic tool result for a non-bash mutating tool blocked in planning mode. */
+function buildBlockedToolResult(toolName: string, category: ToolCategory): unknown {
+  return {
+    success: false,
+    blockedByPlanMode: true,
+    error: `Tool "${toolName}" (${category}) is blocked in planning mode. ` +
+      'Planning mode allows read/search only. Switch to executing mode to run this tool.',
+  };
+}
+
+/** Synthetic bash tool result for a non-read-only command blocked in planning mode. */
+function buildBlockedBashResult(reason: string): unknown {
+  return {
+    output: '',
+    error: `Blocked by planning mode: ${reason}. ` +
+      'Only the built-in read-only command set (ls, cat, echo, pwd, head, tail, grep, find, wc, which, diff, stat, du, cd, read-only git) is available while planning.',
+    exitCode: 1,
   };
 }
 
@@ -185,6 +189,11 @@ const KNOWN_TOOL_META: Record<string, Omit<ToolMeta, 'name'>> = {
     category: 'other',
     risk: 'low',
     description: 'Ask the user a targeted clarification question.'
+  },
+  generate_image: {
+    category: 'write',
+    risk: 'medium',
+    description: 'Generate an image and write it to local disk.'
   },
   task_create: {
     category: 'other',
@@ -520,7 +529,10 @@ export const builtInPlanModePlugin: EnginePlugin = {
   async initialize(context: EnginePluginContext): Promise<void> {
     const service = new BuiltInPlanModeService(context.logger, context.events, 'executing');
 
-    // Inject plan-mode system prompt before each LLM call
+    // Inject plan-mode system prompt before each LLM call. Top-level tools
+    // stay stable — the hard boundary is beforeToolCall below, not tool
+    // removal, so write/edit remain visible and the model learns from the
+    // synthetic rejection why a mutating call is not allowed.
     context.registerHook('beforeLLMCall', ({ context: runContext, tools, systemPrompt }) => {
       const mode = service.getMode();
       if (mode === 'executing') {
@@ -528,23 +540,49 @@ export const builtInPlanModePlugin: EnginePlugin = {
       }
 
       const transition = service.processContextMessages(runContext.messages);
-      const filteredTools = filterPlanningTools(tools);
-      const append = service.buildPromptAppend(Object.keys(filteredTools), transition);
+      const append = service.buildPromptAppend(Object.keys(tools), transition);
       const finalSystemPrompt = appendSystemPrompt(systemPrompt, append);
 
-      if (filteredTools === tools) {
-        return { systemPrompt: finalSystemPrompt };
-      }
-
-      return {
-        systemPrompt: finalSystemPrompt,
-        tools: filteredTools
-      };
+      return { systemPrompt: finalSystemPrompt };
     });
 
-    // Observe tool calls for policy violations in planning mode
+    // Hard-block mutating tools in planning mode. The hook returns a synthetic
+    // tool result (short-circuit) instead of throwing, so the model sees WHY
+    // the call was rejected and can self-correct (switch to read-only tools or
+    // ask to enter executing mode). The same boundary covers tool-search
+    // invocations, MCP tools, and sub-agent tools because every execution path
+    // (loop.ts wrapToolsWithHooks, Engine.executeResolvedTool) passes through
+    // beforeToolCall hooks.
     context.registerHook('beforeToolCall', ({ name, input }) => {
-      service.observePotentialPolicyViolation(name, input);
+      if (service.getMode() !== 'planning') {
+        return;
+      }
+
+      const meta = service.getToolMetadata([name])[0];
+      const policy = service.getModePolicy('planning');
+
+      // bash is special: read-only commands (ls, grep, find, git status, ...)
+      // stay available for exploration; anything else is blocked.
+      if (name === 'bash') {
+        const command = (input as { command?: unknown } | undefined)?.command;
+        if (typeof command !== 'string' || command.trim() === '') {
+          service.observePotentialPolicyViolation(name, input);
+          return { output: buildBlockedBashResult('command is missing or empty') };
+        }
+        const verdict = isReadonlyBashCommand(command);
+        if (!verdict.allowed) {
+          service.observePotentialPolicyViolation(name, input);
+          return { output: buildBlockedBashResult(verdict.reason ?? 'not provably read-only') };
+        }
+        return;
+      }
+
+      if (policy.disallowedCategories.includes(meta.category)) {
+        service.observePotentialPolicyViolation(name, input);
+        return {
+          output: buildBlockedToolResult(name, meta.category),
+        };
+      }
     });
 
     context.registerService('planMode', service);

--- a/packages/engine/src/built-in/plan-mode-plugin/readonly-command.test.ts
+++ b/packages/engine/src/built-in/plan-mode-plugin/readonly-command.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import { isReadonlyBashCommand } from './readonly-command.js';
+
+describe('isReadonlyBashCommand', () => {
+  describe('read-only commands are allowed', () => {
+    it('allows each built-in read-only command', () => {
+      for (const cmd of [
+        'ls',
+        'ls -la',
+        'cat src/index.ts',
+        'echo hello',
+        'pwd',
+        'head -n 20 src/index.ts',
+        'tail -f /dev/null',
+        'grep -r "TODO" src',
+        'wc -l src/*.py',
+        'which node',
+        'diff a.txt b.txt',
+        'stat src/index.ts',
+        'du -sh .',
+      ]) {
+        expect(isReadonlyBashCommand(cmd).allowed, cmd).toBe(true);
+      }
+    });
+
+    it('allows unquoted globs on commands whose every flag is read-only', () => {
+      expect(isReadonlyBashCommand('ls *.ts').allowed).toBe(true);
+      expect(isReadonlyBashCommand('wc -l src/*.py').allowed).toBe(true);
+      expect(isReadonlyBashCommand('cat src/*.json').allowed).toBe(true);
+    });
+
+    it('allows compound segments when each part is read-only', () => {
+      expect(isReadonlyBashCommand('cd packages/api && ls').allowed).toBe(true);
+      expect(isReadonlyBashCommand('cd src; grep -r TODO .').allowed).toBe(true);
+      expect(isReadonlyBashCommand('ls | head -n 5').allowed).toBe(true);
+      expect(isReadonlyBashCommand('ls && pwd && echo ok').allowed).toBe(true);
+    });
+
+    it('allows redirect to /dev/null', () => {
+      expect(isReadonlyBashCommand('grep -r pattern . 2>/dev/null').allowed).toBe(true);
+      expect(isReadonlyBashCommand('ls > /dev/null').allowed).toBe(true);
+    });
+
+    it('allows quoted strings', () => {
+      expect(isReadonlyBashCommand("echo 'hello world'").allowed).toBe(true);
+      expect(isReadonlyBashCommand('echo "hello world"').allowed).toBe(true);
+    });
+
+    it('allows read-only git forms', () => {
+      for (const cmd of [
+        'git status',
+        'git status --short',
+        'git diff',
+        'git log --oneline -5',
+        'git show HEAD',
+        'git blame src/index.ts',
+        'git ls-files',
+        'git rev-parse --show-toplevel',
+        'git remote -v',
+        'git branch',
+        'git --version',
+        'git -C /tmp status',
+      ]) {
+        expect(isReadonlyBashCommand(cmd).allowed, cmd).toBe(true);
+      }
+    });
+
+    it('allows cd into the workspace', () => {
+      expect(isReadonlyBashCommand('cd packages/engine && ls').allowed).toBe(true);
+      expect(isReadonlyBashCommand('cd .').allowed).toBe(true);
+    });
+  });
+
+  describe('mutating commands are blocked', () => {
+    it('blocks commands outside the read-only set', () => {
+      for (const cmd of [
+        'rm -rf /',
+        'rm src/index.ts',
+        'mkdir foo',
+        'touch file.txt',
+        'mv a.txt b.txt',
+        'cp a.txt b.txt',
+        'curl http://example.com',
+        'wget http://example.com',
+        'sort file.txt',
+        'sed -i s/x/y/g file.txt',
+        'npm install',
+        'pnpm build',
+        'bash -c "rm -rf /"',
+        'python -c "print(1)"',
+        'node script.js',
+        'git add .',
+        'git commit -m "x"',
+        'git push origin main',
+        'git checkout main',
+        'git reset --hard',
+        'git clean -fd',
+      ]) {
+        expect(isReadonlyBashCommand(cmd).allowed, cmd).toBe(false);
+      }
+    });
+
+    it('blocks output redirection to a real file', () => {
+      expect(isReadonlyBashCommand('echo hi > out.txt').allowed).toBe(false);
+      expect(isReadonlyBashCommand('ls >> log.txt').allowed).toBe(false);
+      expect(isReadonlyBashCommand('echo hi 2> err.txt').allowed).toBe(false);
+    });
+
+    it('blocks find with write-capable flags', () => {
+      for (const cmd of [
+        'find . -name "*.js" -delete',
+        'find . -name "*.js" -exec rm {} \\;',
+        'find . -name "*.js" -ok rm {} \\;',
+        'find . -name "*.js" -touch',
+      ]) {
+        expect(isReadonlyBashCommand(cmd).allowed, cmd).toBe(false);
+      }
+    });
+
+    it('allows find without write flags but blocks find with globs', () => {
+      expect(isReadonlyBashCommand('find . -name "*.js"').allowed).toBe(true);
+      expect(isReadonlyBashCommand('find . -name *.js').allowed).toBe(false);
+    });
+
+    it('blocks command substitution and backticks', () => {
+      expect(isReadonlyBashCommand('ls $(pwd)').allowed).toBe(false);
+      expect(isReadonlyBashCommand('echo $(rm -rf /)').allowed).toBe(false);
+      expect(isReadonlyBashCommand('echo `ls`').allowed).toBe(false);
+      expect(isReadonlyBashCommand('echo "$(cat /etc/passwd)"').allowed).toBe(false);
+    });
+
+    it('blocks cd leaving the workspace', () => {
+      expect(isReadonlyBashCommand('cd /etc && ls').allowed).toBe(false);
+      expect(isReadonlyBashCommand('cd .. && ls').allowed).toBe(false);
+      expect(isReadonlyBashCommand('cd ~ && ls').allowed).toBe(false);
+    });
+
+    it('blocks cd combined with output redirection', () => {
+      expect(isReadonlyBashCommand('cd src && ls > out.txt').allowed).toBe(false);
+    });
+
+    it('blocks unparseable commands (fail closed)', () => {
+      expect(isReadonlyBashCommand("echo 'unbalanced").allowed).toBe(false);
+      expect(isReadonlyBashCommand('echo \\').allowed).toBe(false);
+      expect(isReadonlyBashCommand(''.padEnd(10001, 'a')).allowed).toBe(false);
+    });
+
+    it('blocks empty or missing commands', () => {
+      expect(isReadonlyBashCommand('').allowed).toBe(false);
+      expect(isReadonlyBashCommand('   ').allowed).toBe(false);
+    });
+  });
+});

--- a/packages/engine/src/built-in/plan-mode-plugin/readonly-command.ts
+++ b/packages/engine/src/built-in/plan-mode-plugin/readonly-command.ts
@@ -1,0 +1,383 @@
+/**
+ * Read-only bash command classifier for planning mode.
+ *
+ * Mirrors Claude Code's built-in read-only command set (see
+ * code.claude.com/docs/en/permissions#read-only-commands): a fixed list of
+ * commands runs without approval in every mode; everything else needs
+ * authorization. Planning mode has no authorization flow, so the classifier
+ * FAILS CLOSED — any command it cannot confidently prove read-only is blocked.
+ *
+ * The classifier is a pure function. It deliberately does not execute
+ * anything, so it never blocks the event loop and never has a side effect.
+ */
+import path from 'node:path';
+
+export interface ReadonlyCommandResult {
+  allowed: boolean;
+  /** Present when blocked; names the specific rule that failed. */
+  reason?: string;
+}
+
+export interface ReadonlyCommandOptions {
+  /**
+   * Working directory used to decide whether a `cd` target stays inside the
+   * workspace. Defaults to `process.cwd()` when omitted.
+   */
+  cwd?: string;
+}
+
+/** Commands that run without approval in every mode (Claude Code built-in set). */
+const READONLY_COMMANDS = new Set([
+  'ls',
+  'cat',
+  'echo',
+  'pwd',
+  'head',
+  'tail',
+  'grep',
+  'find',
+  'wc',
+  'which',
+  'diff',
+  'stat',
+  'du',
+  'cd',
+]);
+
+/**
+ * git subcommands that are read-only forms. Anything else (`add`, `commit`,
+ * `push`, `checkout`, `reset`, `clean`, ...) is blocked in planning mode.
+ */
+const GIT_READONLY_SUBCOMMANDS = new Set([
+  'status',
+  'diff',
+  'log',
+  'show',
+  'blame',
+  'ls-files',
+  'ls-tree',
+  'grep',
+  'rev-parse',
+  'describe',
+  'remote',
+  'branch',
+  'tag',
+  'stash',
+  'config',
+  'help',
+  'version',
+]);
+
+/**
+ * find flags that write, execute, or mutate the filesystem. The presence of
+ * any of these makes a `find` command non-read-only.
+ */
+const FIND_WRITE_FLAGS = new Set([
+  '-delete',
+  '-exec',
+  '-execdir',
+  '-ok',
+  '-okdir',
+  '-fprint',
+  '-fprintf',
+  '-fls',
+  '-fprint0',
+  '-touch',
+]);
+
+const MAX_COMMAND_LENGTH = 10_000;
+
+interface ShellSegment {
+  /** argv tokens for the segment, with quoting metadata stripped. */
+  argv: string[];
+  /** True when any token was quoted or escaped (glob characters inside are inert). */
+  hasQuotedParts: boolean;
+  /** True when an unquoted glob character (`*`, `?`, `[`) appears. */
+  hasUnquotedGlob: boolean;
+  /** Output redirect targets other than /dev/null, e.g. `> out.txt`, `2>> log`. */
+  outputRedirects: string[];
+  /** True when a command substitution `$(...)` or backtick appears anywhere. */
+  hasCommandSubstitution: boolean;
+}
+
+/**
+ * Lightweight shell word splitter. It tracks quotes, escapes, glob markers,
+ * redirects, and command substitutions well enough to classify read-only
+ * commands; it is NOT a full shell parser. Anything ambiguous is surfaced so
+ * the caller can fail closed.
+ */
+function tokenize(command: string): { segments: ShellSegment[]; parseError?: string } {
+  const segments: ShellSegment[] = [];
+  let argv: string[] = [];
+  let current = '';
+  let hasQuotedParts = false;
+  let hasUnquotedGlob = false;
+  let hasCommandSubstitution = false;
+  let redirects: string[] = [];
+  let inRedirectTarget = false;
+  let quote: '"' | "'" | null = null;
+  let escaped = false;
+
+  const flushWord = () => {
+    if (current) {
+      argv.push(current);
+      current = '';
+    }
+  };
+
+  const flushSegment = () => {
+    flushWord();
+    segments.push({
+      argv,
+      hasQuotedParts,
+      hasUnquotedGlob,
+      outputRedirects: redirects,
+      hasCommandSubstitution,
+    });
+    argv = [];
+    redirects = [];
+    hasQuotedParts = false;
+    hasUnquotedGlob = false;
+    hasCommandSubstitution = false;
+    inRedirectTarget = false;
+  };
+
+  for (let i = 0; i < command.length; i += 1) {
+    const ch = command[i];
+
+    if (escaped) {
+      current += ch;
+      hasQuotedParts = true;
+      escaped = false;
+      continue;
+    }
+
+    if (ch === '\\') {
+      escaped = true;
+      continue;
+    }
+
+    if (quote === "'") {
+      current += ch;
+      hasQuotedParts = true;
+      if (ch === "'") quote = null;
+      continue;
+    }
+
+    if (quote === '"') {
+      current += ch;
+      hasQuotedParts = true;
+      if (ch === '"') {
+        quote = null;
+      } else if (ch === '$' && command[i + 1] === '(') {
+        hasCommandSubstitution = true;
+      } else if (ch === '`') {
+        hasCommandSubstitution = true;
+      }
+      continue;
+    }
+
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      hasQuotedParts = true;
+      current += ch;
+      continue;
+    }
+
+    // Command substitution markers outside quotes are dangerous; fail closed.
+    if ((ch === '$' && command[i + 1] === '(') || ch === '`') {
+      hasCommandSubstitution = true;
+      current += ch;
+      continue;
+    }
+
+    // Redirect operators. `>` `>>` `2>` `2>>` `&>` `&>>` `<` are structure.
+    if (ch === '>' || ch === '<') {
+      // A bare fd digit (`2>`, `1>>`) belongs to the operator, not the argv.
+      if (/^\d+$/.test(current)) {
+        current = '';
+      } else {
+        flushWord();
+      }
+      // Consume the whole redirect operator (`>>`, `2>`, `&>>`).
+      let operator = ch;
+      while (
+        i + 1 < command.length &&
+        (command[i + 1] === '>' || command[i + 1] === '<' || command[i + 1] === '&')
+      ) {
+        operator += command[i + 1];
+        i += 1;
+      }
+      if (operator.includes('>')) {
+        inRedirectTarget = true;
+      }
+      continue;
+    }
+
+    if (inRedirectTarget) {
+      if (/\s/.test(ch)) continue;
+      // Next unquoted word is the redirect target.
+      let target = '';
+      while (i < command.length && !/[\s|&;<>]/.test(command[i])) {
+        target += command[i];
+        i += 1;
+      }
+      i -= 1;
+      redirects.push(target);
+      inRedirectTarget = false;
+      continue;
+    }
+
+    if (ch === '|' || ch === '&' || ch === ';') {
+      flushSegment();
+      // Skip a following duplicate operator (`||`, `&&`, `|&`).
+      if (command[i + 1] === ch || (ch === '&' && command[i + 1] === '&')) i += 1;
+      continue;
+    }
+
+    if (/\s/.test(ch)) {
+      flushWord();
+      continue;
+    }
+
+    if (ch === '*' || ch === '?' || ch === '[') {
+      hasUnquotedGlob = true;
+    }
+
+    current += ch;
+  }
+
+  if (quote) {
+    return { segments: [], parseError: 'unbalanced quotes' };
+  }
+  if (escaped) {
+    return { segments: [], parseError: 'trailing escape' };
+  }
+
+  flushSegment();
+  return { segments };
+}
+
+/** True when `cmd` is one of the built-in read-only commands. */
+function isReadonlyCommand(cmd: string): boolean {
+  return READONLY_COMMANDS.has(cmd);
+}
+
+function isSafeGit(argv: string[]): boolean {
+  // Walk from argv[1]: skip global flags; `-C <path>` consumes its value.
+  // The first non-flag token is the subcommand. `git --version`, `git help`,
+  // and bare `git` are fine.
+  let i = 1;
+  while (i < argv.length) {
+    const arg = argv[i];
+    if (arg === '-C' && i + 1 < argv.length) {
+      i += 2;
+      continue;
+    }
+    if (arg.startsWith('-')) {
+      i += 1;
+      continue;
+    }
+    return GIT_READONLY_SUBCOMMANDS.has(arg);
+  }
+  return true;
+}
+
+function hasFindWriteFlag(argv: string[]): boolean {
+  return argv.some((arg) => FIND_WRITE_FLAGS.has(arg));
+}
+
+function isInsideWorkspace(target: string, cwd: string): boolean {
+  if (target === '.' || target === './') return true;
+  if (target === '-' || target.startsWith('$')) return false;
+  // `~` expands to $HOME in the shell; path.resolve would treat it as a plain
+  // directory name and wrongly resolve it inside the workspace.
+  if (target === '~' || target.startsWith('~/')) return false;
+  try {
+    const resolved = path.resolve(cwd, target);
+    const root = path.resolve(cwd);
+    return resolved === root || resolved.startsWith(root + path.sep);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Classify a bash command string.
+ *
+ * Returns `{ allowed: true }` only when every segment provably stays inside
+ * the built-in read-only set with no write-capable flags, no output redirect
+ * (other than `/dev/null`), no command substitution, no unquoted glob on a
+ * write-capable command, and no `cd` leaving the workspace. Everything else —
+ * including anything the tokenizer cannot parse — is `{ allowed: false }`.
+ */
+export function isReadonlyBashCommand(command: string, options?: ReadonlyCommandOptions): ReadonlyCommandResult {
+  if (!command || !command.trim()) {
+    return { allowed: false, reason: 'empty command' };
+  }
+  if (command.length > MAX_COMMAND_LENGTH) {
+    return { allowed: false, reason: `command exceeds ${MAX_COMMAND_LENGTH} characters; treat as non-read-only` };
+  }
+
+  const cwd = options?.cwd ?? process.cwd();
+  const { segments, parseError } = tokenize(command);
+  if (parseError) {
+    return { allowed: false, reason: `unparseable command (${parseError})` };
+  }
+
+  for (const segment of segments) {
+    if (segment.argv.length === 0) continue;
+
+    if (segment.hasCommandSubstitution) {
+      return { allowed: false, reason: 'command substitution is not read-only' };
+    }
+
+    // Output redirects write a file (or open one for writing).
+    if (segment.outputRedirects.some((target) => target !== '/dev/null')) {
+      return { allowed: false, reason: 'output redirection writes a file' };
+    }
+
+    const cmd = segment.argv[0];
+
+    if (cmd === 'cd') {
+      // `cd` alone or into a workspace subdirectory is fine; leaving the
+      // workspace, or combining with a redirect, is not.
+      const target = segment.argv[1];
+      if (segment.outputRedirects.length > 0) {
+        return { allowed: false, reason: 'cd with output redirection is not read-only' };
+      }
+      if (target !== undefined && !isInsideWorkspace(target, cwd)) {
+        return { allowed: false, reason: 'cd outside the workspace is not read-only' };
+      }
+      continue;
+    }
+
+    if (cmd === 'git') {
+      if (!isSafeGit(segment.argv)) {
+        return { allowed: false, reason: 'git subcommand is not read-only' };
+      }
+      if (segment.hasUnquotedGlob) {
+        // Glob could expand to a flag like `-delete` on other commands; for
+        // git, be conservative.
+        return { allowed: false, reason: 'git with unquoted glob is not treated as read-only' };
+      }
+      continue;
+    }
+
+    if (!isReadonlyCommand(cmd)) {
+      return { allowed: false, reason: `command \`${cmd}\` is not in the read-only set` };
+    }
+
+    if (cmd === 'find' && hasFindWriteFlag(segment.argv)) {
+      return { allowed: false, reason: 'find with a write/execute flag is not read-only' };
+    }
+
+    if (segment.hasUnquotedGlob && cmd === 'find') {
+      // find has write-capable flags (-delete, -exec), so an unquoted glob
+      // could expand into one of them.
+      return { allowed: false, reason: 'find with unquoted glob is not treated as read-only' };
+    }
+  }
+
+  return { allowed: true };
+}

--- a/packages/engine/src/plugin/PluginManager.ts
+++ b/packages/engine/src/plugin/PluginManager.ts
@@ -472,6 +472,13 @@ export class PluginManager {
   }
 
   /**
+   * 事件发射器（插件上下文共享同一个实例）
+   */
+  getEvents(): EventEmitter {
+    return this.events;
+  }
+
+  /**
    * 获取插件状态
    */
   getStatus() {


### PR DESCRIPTION
fix(engine): hard-block mutating tools in planning mode

Planning mode previously removed write/edit from the tool list and only
observed policy violations (logged + emitted an event) without blocking
them - mutating calls still executed. Now beforeToolCall short-circuits
any tool classified write/execute with a synthetic rejected result, and
bash runs a read-only command classifier (Claude Code's built-in set:
ls, cat, echo, pwd, head, tail, grep, find, wc, which, diff, stat, du,
cd, read-only git) so read-only exploration stays available while
rm -rf, npm install, output redirection, command substitution, and
unparseable commands are blocked.

Top-level tools stay stable (no more name-based removal); indirect
calls (MCP, sub-agent, future tool-search invoke) all pass through the
same beforeToolCall boundary. generate_image is now explicitly classified
write. CLI hosts subscribe to disallowed_tool_attempt_in_planning and
print a yellow warning so the user knows why a call was blocked.

Resolves the plan-mode declared-vs-enforced divergence tracked in
harness/spec/gating-posture.md (item 2).