### PR TITLE
Improve chat workspace actions and local file links

### DIFF
--- a/apps/canvas-workspace/src/main/files/manager.ts
+++ b/apps/canvas-workspace/src/main/files/manager.ts
@@ -1,7 +1,7 @@
 import { execFile } from "child_process";
 import { ipcMain, dialog, BrowserWindow, clipboard, nativeImage, shell } from "electron";
 import { promises as fs } from "fs";
-import { join, basename, resolve } from "path";
+import { join, basename, resolve, isAbsolute } from "path";
 import { homedir } from "os";
 import { promisify } from "util";
 import { ensureImagePreview } from './image-preview';
@@ -158,6 +158,30 @@ export const setupFileManagerIpc = () => {
       } catch (err) {
         return { ok: false, filePath, error: formatError(err) || lastError || "Unable to open VS Code" };
       }
+    }
+  );
+
+  // Open an explicit absolute local path with its system-default application.
+  // The renderer only calls this after a user clicks a local Markdown link.
+  ipcMain.handle(
+    "file:openPath",
+    async (_event, payload: { filePath?: string }) => {
+      const rawPath = payload.filePath?.trim();
+      if (!rawPath || !isAbsolute(rawPath)) {
+        return { ok: false, error: "Expected an absolute file path" };
+      }
+
+      const filePath = resolve(rawPath);
+      try {
+        await fs.access(filePath);
+      } catch (err) {
+        return { ok: false, filePath, error: `Path is not accessible: ${formatError(err)}` };
+      }
+
+      const error = await shell.openPath(filePath);
+      return error
+        ? { ok: false, filePath, error }
+        : { ok: true, filePath };
     }
   );
 

--- a/apps/canvas-workspace/src/preload/bridge/file.ts
+++ b/apps/canvas-workspace/src/preload/bridge/file.ts
@@ -23,6 +23,9 @@ export const createFileApi = (ipcRenderer: IpcRenderer): FileApi => ({
   openInVSCode: (filePath) =>
     ipcRenderer.invoke("file:openInVSCode", { filePath }),
 
+  openPath: (filePath) =>
+    ipcRenderer.invoke("file:openPath", { filePath }),
+
   openDialog: () => ipcRenderer.invoke("file:openDialog"),
 
   saveAsDialog: (defaultName, content) =>

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessages.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatMessages.tsx
@@ -15,6 +15,7 @@ import type { PendingClarification, ToolCallStatus } from './types';
 import { buildAnchorElementId } from './utils/anchors';
 import { useI18n } from '../../i18n';
 import { isVSCodeLink } from './utils/externalLinks';
+import { localPathFromHref } from './utils/localFileLinks';
 import { ChatClarificationCard } from './ChatClarificationCard';
 import { useChatMessagesStatus } from './hooks/useChatMessagesStatus';
 import { tabRefFromMentionElement } from './utils/tabMentions';
@@ -285,6 +286,13 @@ export const ChatMessages = ({
     // Electron to create a BrowserWindow for a custom scheme.
     const link = target.closest<HTMLAnchorElement>('a[href]');
     const href = link?.getAttribute('href') ?? '';
+    const localPath = localPathFromHref(href);
+    if (localPath) {
+      event.preventDefault();
+      event.stopPropagation();
+      void window.canvasWorkspace.file.openPath(localPath);
+      return;
+    }
     if (href && isVSCodeLink(href)) {
       event.preventDefault();
       event.stopPropagation();

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.css
@@ -154,8 +154,10 @@
   top: 0;
   z-index: 1;
   width: 100%;
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 26px;
   align-items: center;
+  padding-right: 2px;
   border-radius: var(--radius-xs);
   background: var(--surface);
 }
@@ -163,7 +165,7 @@
 .ui-btn.chat-page-rail-folder {
   appearance: none;
   min-width: 0;
-  flex: 1;
+  width: 100%;
   display: flex;
   align-items: center;
   gap: 6px;
@@ -178,21 +180,31 @@
   text-align: left;
 }
 
+.chat-page-rail-folder-action-slot {
+  position: relative;
+  width: 26px;
+  height: 26px;
+}
+
 .ui-btn.chat-page-rail-folder-new {
-  flex: 0 0 26px;
+  position: absolute;
+  inset: 0;
   width: 26px;
   height: 26px;
   min-height: 26px;
-  margin-right: 2px;
   border: 0;
   background: transparent;
   color: var(--text-muted);
   opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s ease, background-color 0.12s ease, color 0.12s ease;
 }
 
-.chat-page-rail-folder-row:hover .ui-btn.chat-page-rail-folder-new,
+.chat-page-rail-folder-row--actionable:hover .ui-btn.chat-page-rail-folder-new,
+.chat-page-rail-folder-row--actionable:focus-within .ui-btn.chat-page-rail-folder-new,
 .ui-btn.chat-page-rail-folder-new:focus-visible {
   opacity: 1;
+  pointer-events: auto;
 }
 
 .ui-btn.chat-page-rail-folder-new:hover {
@@ -231,9 +243,19 @@
 }
 
 .chat-page-rail-folder-count {
-  flex-shrink: 0;
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
   color: var(--text-muted);
   font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  transition: opacity 0.12s ease;
+}
+
+.chat-page-rail-folder-row--actionable:hover .chat-page-rail-folder-count,
+.chat-page-rail-folder-row--actionable:focus-within .chat-page-rail-folder-count {
+  opacity: 0;
 }
 
 .chat-page-rail-list {
@@ -683,6 +705,15 @@
 }
 
 @media (hover: none) {
+  .chat-page-rail-folder-row--actionable .chat-page-rail-folder-count {
+    opacity: 0;
+  }
+
+  .chat-page-rail-folder-row--actionable .ui-btn.chat-page-rail-folder-new {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
   .chat-page-rail-item-actions {
     position: static;
     flex-shrink: 0;
@@ -699,6 +730,8 @@
   .chat-page-rail-wrapper,
   .chat-page-rail-wrapper--collapsed,
   .chat-page-rail-folder-chevron,
+  .chat-page-rail-folder-count,
+  .ui-btn.chat-page-rail-folder-new,
   .chat-page-rail-item,
   .chat-page-rail-new,
   .chat-page-rail-item-actions {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatSessionsRail.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatSessionsRail.tsx
@@ -223,7 +223,7 @@ export const ChatSessionsRail = ({
                 key={group.id}
               >
                 {!isGlobalGroup && (
-                  <div className="chat-page-rail-folder-row">
+                  <div className={`chat-page-rail-folder-row${group.canCreateDraft && onNewSessionInWorkspace ? ' chat-page-rail-folder-row--actionable' : ''}`}>
                     <Button
                       variant="secondary"
                       size="xs"
@@ -237,23 +237,25 @@ export const ChatSessionsRail = ({
                         className={`chat-page-rail-folder-chevron${collapsed ? '' : ' chat-page-rail-folder-chevron--expanded'}`}
                       />
                       <span className="chat-page-rail-folder-name">{group.name}</span>
+                    </Button>
+                    <span className="chat-page-rail-folder-action-slot">
                       {group.sessions.length > 0 && (
                         <span className="chat-page-rail-folder-count">{group.sessions.length}</span>
                       )}
-                    </Button>
-                    {group.canCreateDraft && onNewSessionInWorkspace && (
-                      <Button
-                        variant="icon"
-                        size="xs"
-                        className="chat-page-rail-folder-new"
-                        disabled={newSessionDisabled}
-                        onClick={(event) => onNewSessionInWorkspace(group.id, event.currentTarget)}
-                        title={t('chat.newChatInWorkspace', { name: group.name })}
-                        aria-label={t('chat.newChatInWorkspace', { name: group.name })}
-                      >
-                        <PlusIcon size={13} strokeWidth={1.4} />
-                      </Button>
-                    )}
+                      {group.canCreateDraft && onNewSessionInWorkspace && (
+                        <Button
+                          variant="icon"
+                          size="xs"
+                          className="chat-page-rail-folder-new"
+                          disabled={newSessionDisabled}
+                          onClick={(event) => onNewSessionInWorkspace(group.id, event.currentTarget)}
+                          title={t('chat.newChatInWorkspace', { name: group.name })}
+                          aria-label={t('chat.newChatInWorkspace', { name: group.name })}
+                        >
+                          <PlusIcon size={13} strokeWidth={1.4} />
+                        </Button>
+                      )}
+                    </span>
                   </div>
                 )}
                 <div id={listId} className="chat-page-rail-list" role="list">

--- a/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatMessages.accessibility.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatMessages.accessibility.test.tsx
@@ -52,6 +52,29 @@ async function renderMessages(
 }
 
 describe('ChatMessages accessibility', () => {
+  it('opens an absolute local Markdown link with the system file handler', async () => {
+    const openPath = vi.fn().mockResolvedValue({ ok: true });
+    Object.defineProperty(window, 'canvasWorkspace', {
+      configurable: true,
+      value: { file: { openPath } },
+    });
+
+    try {
+      const el = await renderMessages([{
+        role: 'assistant',
+        content: '[Harness screenshot](/Users/example/My%20Image.png)',
+        timestamp: 1,
+      }]);
+      const link = el.querySelector<HTMLAnchorElement>('a[href]');
+
+      await act(async () => link?.click());
+
+      expect(openPath).toHaveBeenCalledWith('/Users/example/My Image.png');
+    } finally {
+      delete (window as unknown as { canvasWorkspace?: unknown }).canvasWorkspace;
+    }
+  });
+
   it('exposes a polite conversation log with labelled message speakers', async () => {
     const el = await renderMessages([
       { role: 'user', content: 'Can you review this?', timestamp: 1 },

--- a/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatSessionsRail.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatSessionsRail.test.tsx
@@ -91,6 +91,40 @@ describe('ChatSessionsRail workspace tree', () => {
     expect(onNewSessionInWorkspace).toHaveBeenCalledWith('workspace-empty', newChat);
   });
 
+  it('uses one fixed trailing slot for the session count and workspace action', async () => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+
+    await act(async () => {
+      root?.render(
+        <I18nProvider>
+          <ChatSessionsRail
+            allSessions={sessions}
+            workspaces={[
+              { id: 'workspace-a', name: 'Workspace A' },
+              { id: 'workspace-b', name: 'Workspace B' },
+            ]}
+            onNewSession={vi.fn()}
+            onNewSessionInWorkspace={vi.fn()}
+            onSelectSession={vi.fn()}
+          />
+        </I18nProvider>,
+      );
+    });
+
+    const rows = Array.from(host.querySelectorAll('.chat-page-rail-folder-row'));
+    expect(rows).toHaveLength(2);
+
+    for (const row of rows) {
+      const slot = row.querySelector('.chat-page-rail-folder-action-slot');
+      expect(slot).not.toBeNull();
+      expect(slot?.querySelector('.chat-page-rail-folder-count')).not.toBeNull();
+      expect(slot?.querySelector('.chat-page-rail-folder-new')).not.toBeNull();
+      expect(row.querySelector('.chat-page-rail-folder > .chat-page-rail-folder-count')).toBeNull();
+    }
+  });
+
   it('groups sessions by workspace and lets each folder collapse independently', async () => {
     host = document.createElement('div');
     document.body.appendChild(host);
@@ -111,7 +145,7 @@ describe('ChatSessionsRail workspace tree', () => {
     const folders = Array.from(host.querySelectorAll<HTMLButtonElement>('.chat-page-rail-folder'));
     expect(folders).toHaveLength(2);
     expect(folders[0].textContent).toContain('Workspace A');
-    expect(folders[0].textContent).toContain('2');
+    expect(folders[0].closest('.chat-page-rail-folder-row')?.querySelector('.chat-page-rail-folder-count')?.textContent).toBe('2');
     expect(host.textContent).toContain('First conversation');
     expect(host.textContent).not.toContain('Third conversation');
 

--- a/apps/canvas-workspace/src/renderer/src/components/chat/utils/localFileLinks.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/utils/localFileLinks.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { localPathFromHref } from './localFileLinks';
+
+describe('localPathFromHref', () => {
+  it('accepts absolute POSIX paths from Markdown links', () => {
+    expect(localPathFromHref('/Users/example/My%20Image.png')).toBe('/Users/example/My Image.png');
+  });
+
+  it('accepts file URLs and decodes their path', () => {
+    expect(localPathFromHref('file:///Users/example/My%20Image.png')).toBe('/Users/example/My Image.png');
+  });
+
+  it('accepts Windows absolute paths', () => {
+    expect(localPathFromHref('C:\\Users\\example\\report.pdf')).toBe('C:\\Users\\example\\report.pdf');
+    expect(localPathFromHref('file:///C:/Users/example/report.pdf')).toBe('C:/Users/example/report.pdf');
+  });
+
+  it('does not claim relative or external links', () => {
+    expect(localPathFromHref('images/example.png')).toBeNull();
+    expect(localPathFromHref('https://example.com/image.png')).toBeNull();
+    expect(localPathFromHref('vscode://file/Users/example/app.ts')).toBeNull();
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/components/chat/utils/localFileLinks.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/utils/localFileLinks.ts
@@ -1,0 +1,30 @@
+const decodePath = (value: string): string => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+/** Resolve only explicit local-file links. Relative Markdown links stay web navigation. */
+export const localPathFromHref = (href: string): string | null => {
+  const value = href.trim();
+  if (!value) return null;
+
+  if (/^file:/i.test(value)) {
+    try {
+      const url = new URL(value);
+      if (url.protocol !== 'file:') return null;
+      const pathname = decodePath(url.pathname);
+      return /^\/[A-Za-z]:\//.test(pathname) ? pathname.slice(1) : pathname;
+    } catch {
+      return null;
+    }
+  }
+
+  if (value.startsWith('/') || value.startsWith('\\\\') || /^[A-Za-z]:[\\/]/.test(value)) {
+    return decodePath(value);
+  }
+
+  return null;
+};

--- a/apps/canvas-workspace/src/renderer/src/types/files.ts
+++ b/apps/canvas-workspace/src/renderer/src/types/files.ts
@@ -21,6 +21,9 @@ export interface FileApi {
   openInVSCode: (
     filePath: string,
   ) => Promise<{ ok: boolean; filePath?: string; command?: string; error?: string }>;
+  openPath: (
+    filePath: string,
+  ) => Promise<{ ok: boolean; filePath?: string; error?: string }>;
   openDialog: () => Promise<{
     ok: boolean;
     canceled?: boolean;


### PR DESCRIPTION
## Summary
- keep workspace session counts and the new-chat action in one fixed trailing slot
- swap the count for the plus action on hover/focus without layout movement
- open absolute local Markdown links with the system default app only after an explicit user click
- validate local paths in the main process before opening them

## Verification
- `pnpm --filter pulse-coder-engine build`
- `pnpm --filter canvas-workspace exec vitest run src/renderer/src/components/chat/__tests__/ChatSessionsRail.test.tsx src/renderer/src/components/chat/__tests__/ChatMessages.accessibility.test.tsx src/renderer/src/components/chat/utils/localFileLinks.test.ts src/renderer/src/components/chat/utils/markdown.test.ts` (48 tests)
- `pnpm --filter canvas-workspace typecheck`
- `pnpm --filter canvas-workspace build`
- Electron harness `file.openPath(...)` check returned `ok: true` for a real PNG