### PR TITLE
fix(canvas): preserve float bar clicks in hand mode

### DIFF
--- a/apps/canvas-workspace/harness/knowledge/renderer-surfaces.md
+++ b/apps/canvas-workspace/harness/knowledge/renderer-surfaces.md
@@ -117,6 +117,11 @@ The workbench has exactly two side regions plus a modal tier:
    keeps local values.
 3. **Docks are non-modal; settings are modal.** Backdrops only exist in
    the modal tier.
+4. **Canvas chrome owns its pointer events.** Root canvas gesture handlers
+   must let `.canvas-bottom-chrome` targets return before the hand/pan branch;
+   otherwise a bubbling `mousedown` can call `preventDefault()` and suppress
+   the toolbar button's follow-up `click`. The regression lives in
+   `Canvas/hooks/useCanvasMouseHandlers.test.tsx`.
 
 ## Layering scale
 

--- a/apps/canvas-workspace/src/renderer/src/components/canvas/Canvas/hooks/useCanvasMouseHandlers.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/canvas/Canvas/hooks/useCanvasMouseHandlers.test.tsx
@@ -47,6 +47,78 @@ describe('canvas interaction shield selection', () => {
   });
 });
 
+describe('canvas chrome pointer routing', () => {
+  let root: Root;
+  let host: HTMLElement;
+  let hook: ReturnType<typeof useCanvasMouseHandlers>;
+  let canvasMouseDown: ReturnType<typeof vi.fn>;
+
+  const Probe = () => {
+    hook = useCanvasMouseHandlers({
+      canvasId: 'canvas-1',
+      activeTool: 'hand',
+      containerRef: { current: null },
+      suppressBlankClickRef: { current: false },
+      setSelectedNodeIds: vi.fn(),
+      setSelectedEdgeId: vi.fn(),
+      contextMenu: null,
+      closeContextMenu: vi.fn(),
+      isBlankCanvasTarget: () => false,
+      canvasMouseDown,
+      canvasMouseMove: vi.fn(),
+      canvasMouseUp: vi.fn(),
+      moving: false,
+      panning: false,
+      onDragStart: vi.fn(),
+      onDragMove: vi.fn(() => false),
+      onDragEnd: vi.fn(),
+      onDragCancel: vi.fn(),
+      onResizeCancel: vi.fn(),
+      resizingId: null,
+      onResizeStart: vi.fn(),
+      onResizeMove: vi.fn(() => false),
+      onResizeEnd: vi.fn(() => false),
+      edgeInteractionState: null,
+      marquee: { active: false, begin: vi.fn() },
+      shapeToolActive: false,
+      shapeDraft: null,
+      commitHistory: vi.fn(),
+      onNodesChange: vi.fn(),
+    });
+    return null;
+  };
+
+  beforeEach(() => {
+    canvasMouseDown = vi.fn();
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    act(() => root.render(<Probe />));
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+  });
+
+  it('does not route float bar clicks into hand-tool panning', () => {
+    const chrome = document.createElement('div');
+    chrome.className = 'canvas-bottom-chrome';
+    const button = document.createElement('button');
+    chrome.appendChild(button);
+
+    act(() => {
+      hook.handleRootMouseDown({
+        button: 0,
+        altKey: false,
+        target: button,
+      } as unknown as React.MouseEvent);
+    });
+
+    expect(canvasMouseDown).not.toHaveBeenCalled();
+  });
+});
+
 describe('useCanvasMouseHandlers resize completion', () => {
   let root: Root;
   let host: HTMLElement;

--- a/apps/canvas-workspace/src/renderer/src/components/canvas/Canvas/hooks/useCanvasMouseHandlers.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/canvas/Canvas/hooks/useCanvasMouseHandlers.ts
@@ -60,6 +60,9 @@ const isEdgeDragging = (state: EdgeInteractionState | null) =>
   || state?.kind === 'move-bend'
   || state?.kind === 'move-edge';
 
+const isCanvasChromeTarget = (target: EventTarget | null): boolean =>
+  target instanceof Element && target.closest('.canvas-bottom-chrome') !== null;
+
 export const getCanvasInteractionShieldState = ({
   activeTool,
   directInteractionActive,
@@ -181,6 +184,11 @@ export const useCanvasMouseHandlers = ({
 
   const handleRootMouseDown = useCallback(
     (e: React.MouseEvent) => {
+      // Bottom chrome owns its buttons, but the mousedown still bubbles to
+      // the canvas root. In hand mode, routing that event into useCanvas
+      // calls preventDefault() and suppresses the button's follow-up click.
+      if (isCanvasChromeTarget(e.target)) return;
+
       // Pan gestures (middle-click, alt-drag, hand tool) take priority
       // over marquee — useCanvas owns those flows and they should keep
       // working from anywhere on the canvas, blank or not.

--- a/apps/canvas-workspace/src/renderer/src/components/shell/Sidebar/LayerItem.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/shell/Sidebar/LayerItem.tsx
@@ -107,7 +107,7 @@ export const LayerItem = ({
             <span className="sidebar-layer-spacer" aria-hidden="true" />
           )}
           <span className="sidebar-layer-icon">
-            <NodeTypeIcon type={node.type} colorize={!isSelected} />
+            <NodeTypeIcon type={node.type} />
           </span>
           <input
             ref={renameLayerInputRef}
@@ -145,7 +145,7 @@ export const LayerItem = ({
             <span className="sidebar-layer-spacer" aria-hidden="true" />
           )}
           <span className="sidebar-layer-icon">
-            <NodeTypeIcon type={node.type} colorize={!isSelected} />
+            <NodeTypeIcon type={node.type} />
           </span>
           <span className="sidebar-layer-name">
             {isContainer


### PR DESCRIPTION
## Summary

- keep floating toolbar buttons clickable while hand/pan mode is active
- add a regression test for bubbled mousedown handling
- remove selection-driven colorization from layer node icons

## Root cause

The canvas root treated bubbled mousedown events as pan gestures in hand mode and called preventDefault(), which prevented Chromium from synthesizing the toolbar button click. This was intermittent because it depended on hand mode or temporary Space-pan being active.

## Validation

- focused useCanvasMouseHandlers Vitest: 13 passed
- renderer typecheck via the harness: passed
- real Electron harness: clicking “Add Coding Agent” in hand mode increased the node count from 4 to 5
- harness coverage: harnessGaps: 0
- full canvas-workspace test: 11 failures remain in 3 unrelated environment/navigation/provider cases (localhost EPERM, Settings navigation, and LinkDrawer provider)