### PR TITLE
fix: include node manager bins in shell path

### DIFF
--- a/apps/canvas-workspace/src/main/__tests__/shell-path.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/shell-path.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { delimiter, join } from 'path';
-import { homedir } from 'os';
+import { homedir, tmpdir } from 'os';
+import { mkdir, mkdtemp, rm } from 'fs/promises';
 
 /**
  * A GUI-launched Electron app inherits a stripped PATH, and the engine's
@@ -27,6 +28,7 @@ vi.mock('child_process', () => ({
 }));
 
 import {
+  discoverNodeVersionManagerBinDirs,
   applyLoginShellPath,
   augmentProcessPath,
   mergePath,
@@ -62,6 +64,28 @@ describe('mergePath', () => {
 
   it('drops empty segments', () => {
     expect(uniquePath(['', '/usr/bin', '', '/usr/bin'])).toEqual(['/usr/bin']);
+  });
+});
+
+describe('node version manager bin dirs', () => {
+  it('discovers nvm and fnm global npm bin directories synchronously', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'pulse-shell-path-home-'));
+    try {
+      const nvmV20 = join(home, '.nvm', 'versions', 'node', 'v20.18.1', 'bin');
+      const nvmV22 = join(home, '.nvm', 'versions', 'node', 'v22.22.0', 'bin');
+      const fnmV21 = join(home, '.fnm', 'node-versions', 'v21.7.3', 'installation', 'bin');
+      await mkdir(nvmV20, { recursive: true });
+      await mkdir(nvmV22, { recursive: true });
+      await mkdir(fnmV21, { recursive: true });
+
+      expect(discoverNodeVersionManagerBinDirs(home)).toEqual([
+        nvmV22,
+        nvmV20,
+        fnmV21,
+      ]);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
   });
 });
 

--- a/apps/canvas-workspace/src/main/shell-path.ts
+++ b/apps/canvas-workspace/src/main/shell-path.ts
@@ -22,6 +22,7 @@
 import { execFile } from 'child_process';
 import { delimiter, join } from 'path';
 import { homedir, platform } from 'os';
+import { existsSync, readdirSync } from 'fs';
 
 const LOGIN_SHELL_TIMEOUT_MS = 3000;
 
@@ -51,6 +52,9 @@ export const commonPosixBinDirs = (): string[] => {
     join(home, '.yarn', 'bin'),
     join(home, '.bun', 'bin'),
     join(home, '.cargo', 'bin'),
+    join(home, '.volta', 'bin'),
+    join(home, '.asdf', 'shims'),
+    ...discoverNodeVersionManagerBinDirs(home),
     join(home, 'Library', 'pnpm'),
     '/opt/homebrew/bin',
     '/opt/homebrew/sbin',
@@ -58,6 +62,47 @@ export const commonPosixBinDirs = (): string[] => {
     '/usr/local/sbin',
   ];
 };
+
+export const discoverNodeVersionManagerBinDirs = (home: string): string[] => [
+  ...listVersionedBinDirs(join(home, '.nvm', 'versions', 'node'), ['bin']),
+  ...listVersionedBinDirs(join(home, '.fnm', 'node-versions'), ['installation/bin', 'bin']),
+];
+
+function listVersionedBinDirs(root: string, suffixes: string[]): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(root, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort(compareVersionDirDesc);
+  } catch {
+    return [];
+  }
+
+  const dirs: string[] = [];
+  for (const entry of entries) {
+    for (const suffix of suffixes) {
+      const dir = join(root, entry, suffix);
+      if (existsSync(dir)) dirs.push(dir);
+    }
+  }
+  return dirs;
+}
+
+function compareVersionDirDesc(a: string, b: string): number {
+  const left = parseVersionDir(a);
+  const right = parseVersionDir(b);
+  for (let index = 0; index < Math.max(left.length, right.length); index += 1) {
+    const diff = (right[index] ?? 0) - (left[index] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return b.localeCompare(a);
+}
+
+function parseVersionDir(value: string): number[] {
+  const match = value.match(/\d+(?:\.\d+)*/);
+  return match ? match[0].split('.').map((part) => Number(part) || 0) : [];
+}
 
 /** Existing PATH first, so a user-configured entry always wins a conflict. */
 export const mergePath = (existing: string | undefined, extra: string[]): string =>


### PR DESCRIPTION
## Summary
- Add synchronous discovery of nvm/fnm Node version bin directories to the Canvas main-process PATH repair.
- Include Volta and asdf shim directories in the common spawned-process PATH.
- Add regression coverage for nvm/fnm global npm bin discovery so CLI tools like lark-cli resolve without waiting for login-shell probing.

## Validation
- `pnpm install --frozen-lockfile --ignore-scripts` ✅ dependency links prepared for isolated worktree
- `pnpm --filter canvas-workspace exec vitest run src/main/__tests__/shell-path.test.ts` ✅ 10 tests passed
- `pnpm --filter pulse-coder-engine build` ✅ generated engine dist/types required by canvas typecheck
- `pnpm --filter canvas-workspace typecheck` ✅ passed
- `node apps/canvas-workspace/harness/tools/describe-canvas.mjs` ✅ passed
- `pnpm --filter canvas-workspace exec vitest run src/main/__tests__/ui-reuse-governance.test.ts src/main/__tests__/file-size-governance.test.ts` ✅ 20 tests passed
- `pnpm --filter canvas-workspace test` ⚠️ unrelated existing/environment failures remain: Electron binary install error in Electron-dependent suites, history-store IPC assertion, and LinkDrawer ChatTargetProvider test setup. The changed shell-path suite passes in the full run.

## Risk
Low; scoped to PATH augmentation for spawned Canvas child processes. Existing PATH entries still take precedence.