### PR TITLE
fix: hide chat header action icons

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatHeader.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatHeader.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useId, useRef, type KeyboardEvent, type ReactNode, type RefObject } from 'react';
-import { AvatarIcon, CopyIcon, ExternalLinkIcon, ListLinesIcon, PlusIcon, SettingsIcon, SparklesIcon, SpinnerIcon } from '../icons';
+import { CopyIcon, ExternalLinkIcon, ListLinesIcon, PlusIcon, SpinnerIcon } from '../icons';
 import type { OtherWorkspaceSession } from './types';
 import { useI18n } from '../../i18n';
 import { useMenuKeyboardNav } from '../../hooks/useMenuKeyboardNav';
@@ -53,10 +53,6 @@ export const ChatHeader = ({
   onLoadSession,
   onOpenOriginalSession,
   onCopyOtherSession,
-  onOpenSettings,
-  settingsLabel,
-  onOpenPromptSettings,
-  onOpenRolesSettings,
   onClose,
   anchors,
 }: ChatHeaderProps) => {
@@ -230,32 +226,6 @@ export const ChatHeader = ({
       </div>
       <div className="chat-panel-actions">
         {anchors}
-        {onOpenRolesSettings && (
-          <button
-            className="chat-panel-action-btn"
-            onClick={onOpenRolesSettings}
-            title={t('chat.rolesSettings')}
-            aria-label={t('chat.rolesSettings')}
-          >
-            <AvatarIcon size={16} strokeWidth={1.25} />
-          </button>
-        )}
-        <button
-          className="chat-panel-action-btn"
-          onClick={onOpenPromptSettings}
-          title={t('chat.replyStyleSettings')}
-          aria-label={t('chat.replyStyleSettings')}
-        >
-          <SparklesIcon size={16} strokeWidth={1.25} />
-        </button>
-        <button
-          className="chat-panel-action-btn"
-          onClick={onOpenSettings}
-          title={settingsLabel}
-          aria-label={settingsLabel}
-        >
-          <SettingsIcon size={16} strokeWidth={1.25} />
-        </button>
         <button
           className="chat-panel-action-btn"
           onClick={() => void onNewSession()}


### PR DESCRIPTION
Hide extra chat header action icons while preserving new chat creation.

- Remove roles, reply style, and settings buttons from the chat header actions
- Keep the New AI chat plus button visible
- Drop unused icon imports from ChatHeader

Validation:
- pnpm --filter canvas-workspace exec vitest run src/renderer/src/components/chat/__tests__/ChatHeader.cross-scope.test.tsx src/renderer/src/components/chat/__tests__/ChatAnchors.test.tsx
