### PR TITLE
release(canvas): 0.1.46

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.45",
+  "version": "0.1.46",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
Pulse Canvas 0.1.46 release. Built and published the macOS arm64 DMG, uploaded R2 artifacts, updated latest.json, and deployed the download page. Validation passed: canvas-workspace typecheck and 411 test files / 2530 tests. After merge, create and push annotated tag pulse-canvas-v0.1.46 from the merge commit on master.