### PR TITLE
fix(canvas): prevent repeated pending session loads

### DIFF
--- a/apps/canvas-workspace/harness/knowledge/chat-sessions.md
+++ b/apps/canvas-workspace/harness/knowledge/chat-sessions.md
@@ -91,8 +91,10 @@ Key invariants and their guards:
   assistant index rather than whichever assistant happens to be last.
 - Navigation keeps requested and committed conversation keys separate. Rail
   selection and the visible body commit together only after hydration; failed
-  loads retain the previous committed conversation. Per-turn IPC listeners are
-  released on every terminal path.
+  loads retain the previous committed conversation. A pending navigation
+  effect is keyed by its intent, not by callback identity: renderer state
+  updates during hydration must not restart the same `loadSession` request.
+  Per-turn IPC listeners are released on every terminal path.
 - The conversation input contract carries request context, attachments, and
   mentioned workspaces through renderer → IPC → runtime → engine. Persistence
   retains user context/attachments and assistant tools, run id, and role

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatComposerStateKeyed.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatComposerStateKeyed.ts
@@ -83,14 +83,15 @@ export function useChatComposerStateKeyed({
       loaded.expectedSequence,
     );
   }, []);
+  const handleConversationLoadStart = useCallback((scope: AgentScope) => (
+    captureConversationSequences(conversationKeyFromScope(scope, '').storeId)
+  ), []);
 
   const chatSessions = useChatSessions({
     agentScope,
     allWorkspaces,
     onConversationLoaded: handleConversationLoaded,
-    onConversationLoadStart: scope => captureConversationSequences(
-      conversationKeyFromScope(scope, '').storeId,
-    ),
+    onConversationLoadStart: handleConversationLoadStart,
     eagerLoad,
     skipInitialHistory,
   });

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatPagePendingSession.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatPagePendingSession.test.tsx
@@ -71,4 +71,46 @@ describe('useChatPagePendingSession', () => {
     expect(onConsumed).toHaveBeenCalledWith(11, true);
     act(() => root.unmount());
   });
+
+  it('does not restart one pending intent when its load callback changes during a render', async () => {
+    let finishLoad!: (loaded: boolean) => void;
+    const loadSession = vi.fn((_sessionId: string) => new Promise<boolean>((resolve) => {
+      finishLoad = resolve;
+    }));
+    const onConsumed = vi.fn();
+    const Probe = ({ revision }: { revision: number }) => {
+      useChatPagePendingSession({
+        // Mirrors a parent hook rebuilding its callback after loading state
+        // changes. One intent must still own exactly one request.
+        handleLoadSession: async (sessionId) => loadSession(sessionId),
+        onSessionConsumed: onConsumed,
+        pendingSessionId: 'session-b',
+        pendingSessionIntentId: 12,
+        retrySession: vi.fn(async () => undefined),
+        sessionStoreId: 'workspace-a',
+      });
+      return <span>{revision}</span>;
+    };
+    const host = document.createElement('div');
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(<Probe revision={0} />);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      root.render(<Probe revision={1} />);
+      await Promise.resolve();
+    });
+
+    expect(loadSession).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      finishLoad(true);
+      await Promise.resolve();
+    });
+    expect(onConsumed).toHaveBeenCalledOnce();
+    expect(onConsumed).toHaveBeenCalledWith(12, true);
+    act(() => root.unmount());
+  });
 });

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatPagePendingSession.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatPagePendingSession.ts
@@ -25,6 +25,10 @@ export const useChatPagePendingSession = ({
   const failedIntentRef = useRef<{ sessionId: string; workspaceId: string } | null>(null);
   const abandonRef = useRef(onAbandonCurrentTurn);
   abandonRef.current = onAbandonCurrentTurn;
+  const loadSessionRef = useRef(handleLoadSession);
+  loadSessionRef.current = handleLoadSession;
+  const consumedRef = useRef(onSessionConsumed);
+  consumedRef.current = onSessionConsumed;
 
   useEffect(() => {
     if (pendingSessionId === null || pendingSessionIntentId === null) return;
@@ -35,14 +39,14 @@ export const useChatPagePendingSession = ({
     // session-anchored) and the newly shown conversation can send immediately.
     abandonRef.current?.();
     let cancelled = false;
-    void handleLoadSession(pendingSessionId).then((result) => {
+    void loadSessionRef.current(pendingSessionId).then((result) => {
       if (cancelled) return;
       const loaded = result !== false;
       failedIntentRef.current = loaded ? null : intent;
-      onSessionConsumed(pendingSessionIntentId, loaded);
+      consumedRef.current(pendingSessionIntentId, loaded);
     });
     return () => { cancelled = true; };
-  }, [handleLoadSession, onSessionConsumed, pendingSessionId, pendingSessionIntentId, sessionStoreId]);
+  }, [pendingSessionId, pendingSessionIntentId, sessionStoreId]);
 
   return useCallback(async () => {
     const failedIntent = failedIntentRef.current;


### PR DESCRIPTION
## Summary

- keep pending session navigation keyed to its intent instead of callback identity
- stabilize the conversation load-start callback across renderer updates
- add a regression test proving rerenders do not restart the same session load
- document the navigation invariant

## Verification

- node scripts/harness/run-harness-check.mjs --since origin/master
- pnpm --filter canvas-workspace exec vitest run src/renderer/src/components/chat/hooks/useChatPagePendingSession.test.tsx