### PR TITLE
fix(canvas): prefer page-owned find shortcuts

### DIFF
--- a/apps/canvas-workspace/electron.vite.config.ts
+++ b/apps/canvas-workspace/electron.vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, externalizeDepsPlugin } from "electron-vite";
 import react from "@vitejs/plugin-react";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "fs";
+import { fileURLToPath } from "node:url";
 import { visualizer } from "rollup-plugin-visualizer";
 
 const pkg = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8")) as {
@@ -185,9 +186,13 @@ export default defineConfig({
     build: {
       outDir: "dist/preload",
       rollupOptions: {
+        input: {
+          index: fileURLToPath(new URL("./src/preload/index.ts", import.meta.url)),
+          "webview-find": fileURLToPath(new URL("./src/preload/webview-find.ts", import.meta.url)),
+        },
         output: {
           format: "cjs",
-          entryFileNames: "index.js"
+          entryFileNames: "[name].js"
         }
       }
     }

--- a/apps/canvas-workspace/harness/knowledge/dock-browser.md
+++ b/apps/canvas-workspace/harness/knowledge/dock-browser.md
@@ -116,7 +116,18 @@ short-lived timeout races normal mounting.
 Address, reload, and find commands are also qualified by workspace and tab.
 The active `LinkTabView` ignores commands for another guest. Find keeps a
 monotonic request id, ignores stale results, and replays the current query when
-its guest is replaced.
+its guest is replaced. Guest-focused Find is a cancellable default rather than
+an unconditional host shortcut: `src/preload/webview-find.ts` observes the DOM
+keydown through the webview preload, and sends `pulse:dock-find-fallback` only
+when site code neither canceled the default nor stopped event propagation.
+Both signals count because document apps such as Feishu may claim Find with
+`stopPropagation()` alone. This gives those apps first refusal while ordinary
+pages still receive the host find bar.
+The bridge checks in the next task, not a microtask: Electron can flush an
+isolated-preload-world microtask before page-main-world propagation resumes,
+which observes a false unhandled state before Feishu's document listener runs.
+The preload stays main-frame-only; do not enable Node preload execution in
+untrusted child frames merely to broaden shortcut observation.
 
 Browser chords are shared in `src/shared/dock-shortcuts.ts`. Guest-focused
 chords are relayed by main; dock-chrome chords are handled by

--- a/apps/canvas-workspace/harness/knowledge/keyboard-shortcuts.md
+++ b/apps/canvas-workspace/harness/knowledge/keyboard-shortcuts.md
@@ -268,6 +268,18 @@ whitelist through three files, in this order:
    binds") asserts every chord in `WEBVIEW_FORWARDED_CHORDS` still resolves
    through `matchShortcut` for either the `canvas` or `app` owner, so the
    whitelist and the registry cannot drift apart.
+
+Dock-browser Find adds a browser-default layer after this generic rule. Main
+still lets Cmd/Ctrl+F reach the guest, then `src/preload/webview-find.ts` waits
+until the complete cross-world keydown dispatch finishes in the next task. A
+microtask is too early because Electron may flush the isolated preload world
+before continuing page-main-world listeners. A default-prevented or
+propagation-stopped DOM event belongs entirely to the site; an event with
+neither signal sends `pulse:dock-find-fallback` to the active `LinkTabView`,
+which opens Pulse Canvas's floating find bar. Never move Find back into an
+unconditional `before-input-event` interception, or reduce this to only one
+DOM cancellation signal: either regression makes document apps such as Feishu
+open alongside the host find bar.
 2. `src/main/webview/shortcut-forwarding.ts` — `attachShortcutForwarding`
    hooks each guest's `before-input-event` exactly once, tracked in a
    `WeakSet<WebContents>` (`hooked`) so a destroyed guest drops out with no

--- a/apps/canvas-workspace/src/main/app/__tests__/webview-shortcuts.test.ts
+++ b/apps/canvas-workspace/src/main/app/__tests__/webview-shortcuts.test.ts
@@ -84,7 +84,7 @@ describe('webview shortcut relay', () => {
     });
   });
 
-  it('relays find from a dock page to the embedder find bar', async () => {
+  it('leaves find with the page so its DOM handler gets first refusal', async () => {
     registerGuest('dock-browser');
     const created = await install();
     const { contents, hostWebContents } = createGuest();
@@ -93,16 +93,8 @@ describe('webview shortcut relay', () => {
     const preventDefault = vi.fn();
     inputHandlerOf(contents)({ preventDefault }, { type: 'keyDown', key: 'f', control: true });
 
-    expect(preventDefault).toHaveBeenCalledOnce();
-    expect(hostWebContents.send).toHaveBeenCalledWith('dock:shortcut', {
-      command: 'find',
-      source: {
-        workspaceId: 'ws-1',
-        nodeId: 'dock-tab-1',
-        webContentsId: 42,
-        surfaceKind: 'dock-browser',
-      },
-    });
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(hostWebContents.send).not.toHaveBeenCalled();
   });
 
   it('leaves browser chords inside canvas-node guests untouched', async () => {

--- a/apps/canvas-workspace/src/main/app/bootstrap.ts
+++ b/apps/canvas-workspace/src/main/app/bootstrap.ts
@@ -84,6 +84,7 @@ export interface BootstrapOptions {
 
 interface AppPaths {
   preloadPath: string;
+  webviewFindPreloadPath: string;
   rendererIndexPath: string;
   iconPath?: string;
 }
@@ -290,6 +291,7 @@ export function bootstrap({ mainDir }: BootstrapOptions): void {
     const openWindow = () =>
       createWindow({
         preloadPath: paths.preloadPath,
+        webviewFindPreloadPath: paths.webviewFindPreloadPath,
         rendererIndexPath: paths.rendererIndexPath,
         iconPath: paths.iconPath,
         writeLog,
@@ -353,6 +355,7 @@ function resolveAppPaths(mainDir: string): AppPaths {
 
   return {
     preloadPath: resolvedPreloadPath,
+    webviewFindPreloadPath: join(mainDir, "../preload/webview-find.js"),
     rendererIndexPath: join(mainDir, "../renderer/index.html"),
     iconPath: iconCandidates.find((p) => p && existsSync(p)),
   };

--- a/apps/canvas-workspace/src/main/app/webview-shortcuts.ts
+++ b/apps/canvas-workspace/src/main/app/webview-shortcuts.ts
@@ -8,8 +8,9 @@
  * BEFORE the guest's renderer handles the key, so the chord is resolved here
  * against the shared policy and forwarded to the embedder as `dock:shortcut`.
  *
- * Only chords the dock actually owns are intercepted; everything else reaches
- * the page untouched, including ⌘C/⌘V and any site-defined shortcut.
+ * Only unconditional dock commands are intercepted. Find is intentionally
+ * page-first: the guest preload observes the DOM event and opens host Find
+ * only when site code leaves the default unclaimed.
  */
 import { app, type WebContents } from "electron";
 import {
@@ -35,6 +36,11 @@ export function setupWebviewShortcuts(): void {
         altKey: input.alt,
       });
       if (!command) return;
+      // Find is a cancellable browser default, not an unconditional host
+      // command. Let the page receive keydown; the guest preload asks the host
+      // to open its fallback bar only after site code leaves the full DOM
+      // dispatch uncancelled and unstopped.
+      if (command === 'find') return;
       const target = embedderOf(contents);
       if (!target) return;
       event.preventDefault();

--- a/apps/canvas-workspace/src/main/app/window.ts
+++ b/apps/canvas-workspace/src/main/app/window.ts
@@ -5,6 +5,7 @@ import type { WriteLog } from "./logging";
 
 export interface CreateWindowOptions {
   preloadPath: string;
+  webviewFindPreloadPath: string;
   rendererIndexPath: string;
   iconPath?: string;
   writeLog: WriteLog;
@@ -12,6 +13,7 @@ export interface CreateWindowOptions {
 
 export function createWindow({
   preloadPath,
+  webviewFindPreloadPath,
   rendererIndexPath,
   iconPath,
   writeLog,
@@ -33,6 +35,18 @@ export function createWindow({
       // webContents ID to pull rendered DOM text for the Canvas Agent.
       webviewTag: true
     }
+  });
+
+  // Third-party pages keep first refusal on Ctrl/Cmd+F. This isolated preload
+  // observes the page's DOM cancellation/propagation result and asks the host
+  // to open its find bar only when the page did not claim the chord. Keep the
+  // bridge main-frame-only: enabling Node preload execution in third-party
+  // child frames widens the security boundary and is unnecessary for normal
+  // document apps such as Feishu.
+  win.webContents.on('will-attach-webview', (_event, webPreferences) => {
+    webPreferences.preload = webviewFindPreloadPath;
+    webPreferences.contextIsolation = true;
+    webPreferences.nodeIntegration = false;
   });
 
   // The main renderer should never navigate away from the app shell. If a

--- a/apps/canvas-workspace/src/preload/webview-find.test.ts
+++ b/apps/canvas-workspace/src/preload/webview-find.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DOCK_FIND_FALLBACK_CHANNEL } from '../shared/dock-shortcuts';
+
+const electronMocks = vi.hoisted(() => ({ sendToHost: vi.fn() }));
+
+vi.mock('electron', () => ({
+  ipcRenderer: { sendToHost: electronMocks.sendToHost },
+}));
+
+let teardown: (() => void) | undefined;
+
+const loadBridge = async () => {
+  const module = await import('./webview-find');
+  teardown = module.teardownWebviewFindFallbackBridge;
+};
+
+const pressFind = (): KeyboardEvent => {
+  const event = new KeyboardEvent('keydown', {
+    key: 'f',
+    metaKey: true,
+    bubbles: true,
+    cancelable: true,
+  });
+  window.dispatchEvent(event);
+  return event;
+};
+
+const flushFallback = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+beforeEach(() => {
+  vi.resetModules();
+  electronMocks.sendToHost.mockReset();
+});
+
+afterEach(() => {
+  teardown?.();
+  teardown = undefined;
+});
+
+describe('webview find fallback bridge', () => {
+  it('notifies the host when the page leaves Ctrl/Cmd+F unhandled', async () => {
+    await loadBridge();
+
+    pressFind();
+    await flushFallback();
+
+    expect(electronMocks.sendToHost).toHaveBeenCalledOnce();
+    expect(electronMocks.sendToHost).toHaveBeenCalledWith(DOCK_FIND_FALLBACK_CHANNEL);
+  });
+
+  it('stays silent when page code prevents the Find default', async () => {
+    await loadBridge();
+    const claimFind = (event: KeyboardEvent) => event.preventDefault();
+    window.addEventListener('keydown', claimFind);
+
+    const event = pressFind();
+    await flushFallback();
+    window.removeEventListener('keydown', claimFind);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(electronMocks.sendToHost).not.toHaveBeenCalled();
+  });
+
+  it('stays silent when page code stops Find propagation without preventing default', async () => {
+    await loadBridge();
+    const claimFind = (event: KeyboardEvent) => event.stopPropagation();
+    window.addEventListener('keydown', claimFind);
+
+    const event = pressFind();
+    await flushFallback();
+    window.removeEventListener('keydown', claimFind);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(event.cancelBubble).toBe(true);
+    expect(electronMocks.sendToHost).not.toHaveBeenCalled();
+  });
+
+  it('waits past an isolated-world microtask checkpoint for page cancellation', async () => {
+    await loadBridge();
+    const claimFind = (event: KeyboardEvent) => {
+      queueMicrotask(() => event.preventDefault());
+    };
+    window.addEventListener('keydown', claimFind);
+
+    const event = pressFind();
+    await flushFallback();
+    window.removeEventListener('keydown', claimFind);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(electronMocks.sendToHost).not.toHaveBeenCalled();
+  });
+
+  it('ignores shifted, alt-modified, and repeated variants', async () => {
+    await loadBridge();
+    for (const init of [
+      { shiftKey: true },
+      { altKey: true },
+      { repeat: true },
+    ]) {
+      window.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'f',
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+        ...init,
+      }));
+    }
+    await flushFallback();
+
+    expect(electronMocks.sendToHost).not.toHaveBeenCalled();
+  });
+});

--- a/apps/canvas-workspace/src/preload/webview-find.ts
+++ b/apps/canvas-workspace/src/preload/webview-find.ts
@@ -1,0 +1,49 @@
+/**
+ * Browser-like Ctrl/Cmd+F arbitration for dock web pages.
+ *
+ * The page receives the key first. After its synchronous keydown handlers
+ * finish, cancellation or stopped propagation tells us whether the site
+ * claimed Find. Only an unclaimed chord asks the host to show Pulse Canvas's
+ * find-in-page chrome.
+ */
+import { ipcRenderer } from 'electron';
+import { DOCK_FIND_FALLBACK_CHANNEL } from '../shared/dock-shortcuts';
+
+type NotifyUnhandledFind = () => void;
+
+const isFindChord = (event: KeyboardEvent): boolean => (
+  (event.metaKey || event.ctrlKey)
+  && !event.altKey
+  && !event.shiftKey
+  && event.key.toLowerCase() === 'f'
+);
+
+export const installWebviewFindFallbackBridge = (
+  target: Window = window,
+  notifyUnhandledFind: NotifyUnhandledFind = () => {
+    ipcRenderer.sendToHost(DOCK_FIND_FALLBACK_CHANNEL);
+  },
+): (() => void) => {
+  const pendingTimers = new Set<number>();
+  const onKeyDown = (event: KeyboardEvent): void => {
+    if (!isFindChord(event) || event.repeat) return;
+    // Electron's isolated preload world may flush microtasks before the page's
+    // main-world listeners continue. A timer crosses that world boundary and
+    // runs only after the complete keydown dispatch, including slow document
+    // handlers such as Feishu's editor shortcut layer.
+    const timer = target.setTimeout(() => {
+      pendingTimers.delete(timer);
+      if (!event.defaultPrevented && !event.cancelBubble) notifyUnhandledFind();
+    }, 0);
+    pendingTimers.add(timer);
+  };
+
+  target.addEventListener('keydown', onKeyDown, true);
+  return () => {
+    target.removeEventListener('keydown', onKeyDown, true);
+    for (const timer of pendingTimers) target.clearTimeout(timer);
+    pendingTimers.clear();
+  };
+};
+
+export const teardownWebviewFindFallbackBridge = installWebviewFindFallbackBridge();

--- a/apps/canvas-workspace/src/renderer/src/components/dock/LinkDrawer/__tests__/find-in-page.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/LinkDrawer/__tests__/find-in-page.test.tsx
@@ -10,6 +10,7 @@ import {
   consumeDockPageFocusRequest,
   requestDockPageFocus,
 } from '../../RightDock/dock-browser-commands';
+import { DOCK_FIND_FALLBACK_CHANNEL } from '../../../../../../shared/dock-shortcuts';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -244,5 +245,16 @@ describe('useFindInPage', () => {
     act(() => api.close());
 
     expect(restore).toHaveBeenCalledOnce();
+  });
+
+  it('opens the host fallback when the guest reports an unhandled Find chord', () => {
+    const { webview } = createWebview();
+    render(webview);
+    const event = new Event('ipc-message') as Event & { channel?: string };
+    event.channel = DOCK_FIND_FALLBACK_CHANNEL;
+
+    act(() => { webview.dispatchEvent(event); });
+
+    expect(api.open).toBe(true);
   });
 });

--- a/apps/canvas-workspace/src/renderer/src/components/dock/LinkDrawer/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/LinkDrawer/index.css
@@ -248,20 +248,33 @@
   font-size: 11px;
 }
 
-/* Find-in-page bar. Sits between the address chrome and the page, so the
-   match counter stays visible while the guest scrolls its highlights. */
+/* Find-in-page floats over the page like browser chrome. Keeping it inside
+   the webview surface avoids resizing the guest every time Find opens. */
 .link-drawer__find {
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  z-index: var(--layer-canvas-chrome);
   display: flex;
   align-items: center;
   gap: 4px;
-  padding: 4px 8px;
-  border-bottom: 1px solid var(--border);
+  box-sizing: border-box;
+  width: min(360px, calc(100% - 24px));
+  padding: 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
   background: var(--surface);
+  box-shadow: var(--shadow-float);
+}
+
+.link-drawer__find > .ui-textfield {
+  flex: 1;
+  min-width: 0;
 }
 
 .link-drawer__find-input {
-  flex: 1;
   min-width: 0;
+  height: 28px;
 }
 
 .link-drawer__find-count {

--- a/apps/canvas-workspace/src/renderer/src/components/dock/LinkDrawer/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/LinkDrawer/index.tsx
@@ -414,16 +414,6 @@ export const LinkTabView = ({
           aria-label={t('linkDrawer.loadingPage')}
         />
       )}
-      {find.open && (
-        <FindInPageBar
-          query={find.query}
-          matches={find.matches}
-          barRef={find.barRef}
-          onQueryChange={find.onQueryChange}
-          onStep={find.step}
-          onClose={find.close}
-        />
-      )}
       {isGoogleAuthUrl(browser.currentUrl) && (
         <div className="link-drawer__auth-notice" role="status">
           {isDefaultBrowser ? (
@@ -452,6 +442,16 @@ export const LinkTabView = ({
       )}
       <div className="link-drawer__webview-surface">
         <div ref={browser.hostRef} className="link-drawer__webview-host" />
+        {find.open && (
+          <FindInPageBar
+            query={find.query}
+            matches={find.matches}
+            barRef={find.barRef}
+            onQueryChange={find.onQueryChange}
+            onStep={find.step}
+            onClose={find.close}
+          />
+        )}
         {loadState === 'queued' && (
           <div className="link-drawer__queued" role="status">
             <strong>{title || t('node.type.webPage')}</strong>

--- a/apps/canvas-workspace/src/renderer/src/components/dock/LinkDrawer/useFindInPage.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/LinkDrawer/useFindInPage.ts
@@ -10,6 +10,7 @@
  * "step through the existing results".
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { DOCK_FIND_FALLBACK_CHANNEL } from '../../../../../shared/dock-shortcuts';
 import type { EmbeddedWebviewTag } from '../EmbeddedBrowser/types';
 import { cancelDockPageFocusRequest } from '../RightDock/dock-browser-commands';
 
@@ -120,6 +121,16 @@ export const useFindInPage = (
       input?.select();
     });
   }, [active, inputEl, query, search]);
+
+  useEffect(() => {
+    if (!webview) return;
+    const onGuestMessage = (event: Event) => {
+      const channel = (event as Event & { channel?: string }).channel;
+      if (channel === DOCK_FIND_FALLBACK_CHANNEL) openFind();
+    };
+    webview.addEventListener('ipc-message', onGuestMessage);
+    return () => webview.removeEventListener('ipc-message', onGuestMessage);
+  }, [openFind, webview]);
 
   useEffect(() => {
     if (active) return;

--- a/apps/canvas-workspace/src/shared/dock-shortcuts.ts
+++ b/apps/canvas-workspace/src/shared/dock-shortcuts.ts
@@ -7,9 +7,14 @@
  * a main-process relay every browsing shortcut would work only when the dock
  * chrome happened to be focused. `main/app/webview-shortcuts.ts` matches these
  * same chords in `before-input-event` and forwards the resolved command to the
- * renderer, which handles it identically to a locally observed key.
+ * renderer, which handles it identically to a locally observed key. `find` is
+ * the exception: it reaches the page first and falls back through the guest
+ * preload only when the DOM event was not default-prevented.
  */
 import type { WebviewRegistrationIdentity } from './webview-registration';
+
+/** Guest preload → host renderer signal that the page left Ctrl/Cmd+F unhandled. */
+export const DOCK_FIND_FALLBACK_CHANNEL = 'pulse:dock-find-fallback';
 
 export type DockBrowserCommand =
   | 'new-tab'


### PR DESCRIPTION
## Summary
- let embedded pages handle Cmd/Ctrl+F before Pulse Canvas falls back to find-in-page
- add an isolated guest preload that waits for the complete cross-world keydown dispatch
- keep the Pulse find bar as a responsive floating overlay instead of resizing the page
- preserve next, previous, count, Escape, and focus restoration behavior

## Root cause
Electron can flush a preload isolated-world microtask before the page main-world listeners finish. On Feishu, the capture phase still reported an unhandled event, while the document bubble phase later set defaultPrevented. The old bridge sent the fallback IPC too early.

## Verification
- 50 focused shortcut and governance tests passed
- canvas-workspace TypeScript typecheck passed
- full canvas-workspace Electron build passed
- the same patch passed again in an isolated worktree based on origin/master
- live Feishu diagnostics confirmed the cross-world event ordering that the regression test pins
