### PR TITLE
fix(canvas): open scheduled results in exact sessions

### DIFF
--- a/apps/canvas-workspace/harness/knowledge/scheduled-tasks.md
+++ b/apps/canvas-workspace/harness/knowledge/scheduled-tasks.md
@@ -3,7 +3,8 @@
 Scheduled is a stable top-level app surface — its own route, not a canvas
 feature — for persisted, user-defined recurring background work: an exact
 next-due main-process timer backed by a 30-minute heartbeat, startup/resume
-catch-up, manual run-now, and one isolated durable Agent chat scope per task.
+catch-up, manual run-now, and one isolated durable Agent session store per
+task. Each attempt owns a fresh conversation session inside that store.
 Getting any piece of this wrong either drops a run silently, replays a missed
 run more than once, or announces a finished background run in a way that
 hijacks the app out from under the user.
@@ -75,21 +76,30 @@ second call against an install that already has one is a no-op.)
 
 ## Run-finished announcement chain
 
+A timer-driven attempt creates a fresh scheduled-scope session in main before
+the model runs. Manual `Run now` is also one main-owned start operation: it
+validates the task, creates the fresh session, durably marks the task running,
+and returns the session id immediately while execution continues. Both paths
+anchor `chatWithScope` to the prepared session id, so changing the scope's
+current-session pointer while a run is active cannot redirect its history.
+
 A finished attempt — success AND failure — is announced by
 `announceRunFinished` (`scheduled/runtime.ts`) as a `scheduled:run-finished`
-push that `useScheduledRunToasts` turns into a STICKY toast
-(`autoCloseMs: 0`). Its action opens the task's conversation in the DOCK's
-Pulse AI tab (`useScheduledRunChatOpener` → `dock.openScheduledChat`), the
-same surface `Run now` uses — acting on a finished run must never navigate
-the whole app onto the AI Chat page and lose what the user was looking at.
+push carrying `taskId`, `sessionId`, and `trigger`. `useScheduledRunToasts`
+turns unattended outcomes into a STICKY toast (`autoCloseMs: 0`); successful
+manual runs stay quiet because their conversation is already visible. Its
+action opens the exact session in the full-page Pulse AI surface through the
+existing `ChatTarget` session navigation (`useScheduledRunChatOpener` →
+`openSessionInOwningScope`). Full-page chat accepts a new target even when it
+is already mounted, so the action never degrades to "open whichever session
+is current for this task."
 
-Routing to `/chat?scheduledTask=<id>` survives only as the fallback for
-views that hide the dock chat tab. `isDockChatTabEnabled`
+If session setup itself failed, there is no exact conversation to open. That
+exception retains the old task-scope fallback: Dock where available, otherwise
+`/chat?scheduledTask=<id>`. `isDockChatTabEnabled`
 (`components/dock/RightDock/dock-chat-availability.ts`, full path
-`src/renderer/src/components/dock/RightDock/dock-chat-availability.ts`) is the
-single predicate behind BOTH that fallback and the dock's `chatTabEnabled`
-prop, because a caller that assumes a dock chat tab where there is none
-swallows the open silently.
+`src/renderer/src/components/dock/RightDock/dock-chat-availability.ts`) remains
+the authority for that fallback only.
 
 The same module derives `isGlobalChatLauncherVisible` — the floating
 Pulse-logo launcher (`RightDock/GlobalChatLauncher.tsx`, full path
@@ -111,6 +121,11 @@ activates an agent against a workspace that does not exist.
 
 `__`-prefixed stores are allowlisted, never blanket-skipped (that is what hid
 scheduled chats from the rail).
+
+Scheduled sessions currently have no automatic retention. Each attempt is
+durable user history; do not add silent age/count deletion without an explicit
+user-controlled retention policy. If high-frequency tasks make rail scanning
+costly, add an indexed/paginated listing path before considering deletion.
 
 ## The removed OS notification (must not return)
 
@@ -166,6 +181,8 @@ Bound tests:
   success AND failure, and no OS notification
 - `src/renderer/src/views/Scheduled/__tests__/useScheduledRunToasts.test.tsx`
   — sticky toast
+- `src/renderer/src/views/Scheduled/__tests__/useScheduledRunChatOpener.test.tsx`
+  — exact completed-session target + session-setup fallback
 - `src/renderer/src/views/Scheduled/__tests__/scheduledChatTarget.test.ts`
   — dock-by-default vs route fallback
 - `src/main/agent/__tests__/scheduled-tools.test.ts`

--- a/apps/canvas-workspace/src/main/__tests__/scheduled-run-notify.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/scheduled-run-notify.test.ts
@@ -14,6 +14,8 @@ const h = vi.hoisted(() => ({
   osNotifications: 0,
   chatResult: { ok: true } as { ok: boolean; error?: string },
   chatThrows: null as Error | null,
+  newSessionCalls: [] as unknown[],
+  chatCalls: [] as unknown[][],
 }));
 
 vi.mock('electron', () => {
@@ -46,11 +48,15 @@ vi.mock('electron', () => {
 
 vi.mock('../agent/ipc', () => ({
   getCanvasAgentService: () => ({
-    chatWithScope: async () => {
+    newSessionForScope: async (scope: unknown) => {
+      h.newSessionCalls.push(scope);
+      return { ok: true, activeSessionId: 'session-1' };
+    },
+    chatWithScope: async (...args: unknown[]) => {
+      h.chatCalls.push(args);
       if (h.chatThrows) throw h.chatThrows;
       return h.chatResult;
     },
-    resolveCurrentSessionId: async () => 'session-1',
   }),
 }));
 
@@ -81,6 +87,8 @@ beforeEach(() => {
   h.osNotifications = 0;
   h.chatResult = { ok: true };
   h.chatThrows = null;
+  h.newSessionCalls.length = 0;
+  h.chatCalls.length = 0;
 });
 
 afterEach(() => {
@@ -89,14 +97,25 @@ afterEach(() => {
 
 describe('scheduled run completion signal', () => {
   it('pushes exactly one in-app announcement when a run succeeds', async () => {
-    const result = await __testing.executeScheduledTask(task);
+    const result = await (__testing.executeScheduledTask as unknown as (
+      task: ScheduledTask,
+      context: { trigger: 'schedule' },
+    ) => Promise<{ sessionId?: string }>)(task, { trigger: 'schedule' });
 
     expect(result).toEqual({ sessionId: 'session-1' });
+    expect(h.newSessionCalls).toEqual([{ kind: 'scheduled', taskId: 'daily-brief' }]);
+    expect(h.chatCalls[0]?.[7]).toMatchObject({ expectedConversationSessionId: 'session-1' });
     assertNoOsNotification();
     expect(runFinishedPushes()).toEqual([
       {
         channel: 'scheduled:run-finished',
-        payload: { taskId: 'daily-brief', title: 'Morning brief', ok: true },
+        payload: {
+          taskId: 'daily-brief',
+          title: 'Morning brief',
+          ok: true,
+          sessionId: 'session-1',
+          trigger: 'schedule',
+        },
       },
     ]);
   });
@@ -104,7 +123,10 @@ describe('scheduled run completion signal', () => {
   it('announces a failed run instead of leaving it silent, and still rethrows', async () => {
     h.chatResult = { ok: false, error: 'model unavailable' };
 
-    await expect(__testing.executeScheduledTask(task)).rejects.toThrow('model unavailable');
+    await expect((__testing.executeScheduledTask as unknown as (
+      task: ScheduledTask,
+      context: { trigger: 'schedule' },
+    ) => Promise<unknown>)(task, { trigger: 'schedule' })).rejects.toThrow('model unavailable');
 
     assertNoOsNotification();
     expect(runFinishedPushes()[0].payload).toEqual({
@@ -112,13 +134,18 @@ describe('scheduled run completion signal', () => {
       title: 'Morning brief',
       ok: false,
       error: 'model unavailable',
+      sessionId: 'session-1',
+      trigger: 'schedule',
     });
   });
 
   it('announces a run that threw before producing a result', async () => {
     h.chatThrows = new Error('engine exploded');
 
-    await expect(__testing.executeScheduledTask(task)).rejects.toThrow('engine exploded');
+    await expect((__testing.executeScheduledTask as unknown as (
+      task: ScheduledTask,
+      context: { trigger: 'schedule' },
+    ) => Promise<unknown>)(task, { trigger: 'schedule' })).rejects.toThrow('engine exploded');
     expect(runFinishedPushes()[0].payload).toMatchObject({ ok: false, error: 'engine exploded' });
   });
 });

--- a/apps/canvas-workspace/src/main/__tests__/scheduled-task-service.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/scheduled-task-service.test.ts
@@ -81,7 +81,10 @@ describe('ScheduledTaskService', () => {
     await service.runDueTasks(now);
 
     expect(execute).toHaveBeenCalledTimes(1);
-    expect(execute).toHaveBeenCalledWith(expect.objectContaining({ id: created.id }));
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({ id: created.id }),
+      { trigger: 'schedule' },
+    );
     expect(await service.getTask(created.id)).toMatchObject({
       lastAttemptAt: now,
       lastSuccessAt: now,
@@ -135,13 +138,80 @@ describe('ScheduledTaskService', () => {
       schedule: { kind: 'interval', intervalMinutes: 30 },
     });
 
-    await service.runTaskNow(task.id);
+    await service.startTaskNow(task.id, async () => 'prepared-manual-session');
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      if ((await service.getTask(task.id))?.status === 'idle') break;
+      await Promise.resolve();
+    }
 
     expect(await service.getTask(task.id)).toMatchObject({
       nextRunAt: start + 35 * 60_000,
       lastSessionId: 'session-manual',
       runCount: 1,
     });
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({ id: task.id }),
+      { trigger: 'manual', sessionId: 'prepared-manual-session' },
+    );
+  });
+
+  it('starts a manual run without waiting for completion', async () => {
+    const start = Date.UTC(2026, 6, 26, 9, 0);
+    let finishExecution: (() => void) | undefined;
+    const execute = vi.fn(() => new Promise<void>((resolve) => {
+      finishExecution = resolve;
+    }));
+    const service = new ScheduledTaskService({ statePath, now: () => start, execute });
+    const task = await service.createTask({
+      title: 'Project pulse',
+      prompt: 'Summarize important workspace changes.',
+      schedule: { kind: 'interval', intervalMinutes: 30 },
+    });
+
+    const started = await service.startTaskNow(task.id, async () => 'main-owned-session');
+
+    expect(started.task.status).toBe('running');
+    expect(started.sessionId).toBe('main-owned-session');
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({ id: task.id }),
+      { trigger: 'manual', sessionId: 'main-owned-session' },
+    );
+
+    finishExecution?.();
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      if ((await service.getTask(task.id))?.status === 'idle') break;
+      await Promise.resolve();
+    }
+    expect((await service.getTask(task.id))?.status).toBe('idle');
+  });
+
+  it('reserves a manual task before preparing its session', async () => {
+    const start = Date.UTC(2026, 6, 26, 9, 0);
+    let finishPreparation: ((sessionId: string) => void) | undefined;
+    let finishExecution: (() => void) | undefined;
+    const execute = vi.fn(() => new Promise<void>((resolve) => {
+      finishExecution = resolve;
+    }));
+    const service = new ScheduledTaskService({ statePath, now: () => start, execute });
+    const task = await service.createTask({
+      title: 'Project pulse',
+      prompt: 'Summarize important workspace changes.',
+      schedule: { kind: 'interval', intervalMinutes: 30 },
+    });
+    const first = service.startTaskNow(task.id, () => new Promise<string>((resolve) => {
+      finishPreparation = resolve;
+    }));
+
+    await expect(service.startTaskNow(task.id, async () => 'orphan-session'))
+      .rejects.toThrow('already running');
+    finishPreparation?.('reserved-session');
+    await expect(first).resolves.toMatchObject({ sessionId: 'reserved-session' });
+
+    finishExecution?.();
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      if ((await service.getTask(task.id))?.status === 'idle') break;
+      await Promise.resolve();
+    }
   });
 
   it('wakes at a newly created task exact due time between heartbeat checks', async () => {

--- a/apps/canvas-workspace/src/main/scheduled/ipc.ts
+++ b/apps/canvas-workspace/src/main/scheduled/ipc.ts
@@ -13,7 +13,7 @@
 
 import { ipcMain } from 'electron';
 import type { ScheduledTaskInput, ScheduledTaskPatch } from '../../shared/scheduled';
-import { getScheduledTaskService } from './runtime';
+import { getScheduledTaskService, startManualScheduledTask } from './runtime';
 
 export function setupScheduledTaskIpc(): void {
   const service = getScheduledTaskService();
@@ -54,14 +54,16 @@ export function setupScheduledTaskIpc(): void {
     }
   });
 
-  ipcMain.handle('scheduled:run-now', async (_event, taskId: string) => {
-    try {
-      const task = await service.runTaskNow(taskId);
-      return task.lastError
-        ? { ok: false, task, error: task.lastError }
-        : { ok: true, task };
-    } catch (error) {
-      return { ok: false, error: error instanceof Error ? error.message : String(error) };
-    }
-  });
+  ipcMain.handle(
+    'scheduled:run-now',
+    async (_event, payload: string | { taskId: string; sessionId?: string }) => {
+      const taskId = typeof payload === 'string' ? payload : payload.taskId;
+      try {
+        const { task, sessionId } = await startManualScheduledTask(taskId);
+        return { ok: true, task, sessionId };
+      } catch (error) {
+        return { ok: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    },
+  );
 }

--- a/apps/canvas-workspace/src/main/scheduled/runtime.ts
+++ b/apps/canvas-workspace/src/main/scheduled/runtime.ts
@@ -1,10 +1,25 @@
 import { BrowserWindow } from 'electron';
 import { getCanvasAgentService } from '../agent/ipc';
-import type { ScheduledRunFinished, ScheduledTask } from '../../shared/scheduled';
+import type {
+  ScheduledRunFinished,
+  ScheduledTask,
+  ScheduledTaskExecutionContext,
+} from '../../shared/scheduled';
 import { describeSchedule } from '../../shared/scheduled';
 import { ScheduledTaskService } from './scheduled-task-service';
 
 let service: ScheduledTaskService | null = null;
+
+const scheduledScope = (taskId: string) => ({ kind: 'scheduled' as const, taskId });
+
+async function createScheduledSession(
+  agentService: ReturnType<typeof getCanvasAgentService>,
+  taskId: string,
+): Promise<string> {
+  const created = await agentService.newSessionForScope(scheduledScope(taskId));
+  if (!created.ok) throw new Error(created.error ?? 'Could not create scheduled run session');
+  return created.activeSessionId;
+}
 
 const taskRunPrompt = (task: ScheduledTask): string => [
   `Scheduled task: ${task.title}`,
@@ -34,15 +49,39 @@ function announceRunFinished(outcome: ScheduledRunFinished): void {
   }
 }
 
-async function executeScheduledTask(task: ScheduledTask): Promise<{ sessionId?: string }> {
+async function executeScheduledTask(
+  task: ScheduledTask,
+  context: ScheduledTaskExecutionContext,
+): Promise<{ sessionId?: string }> {
   const agentService = getCanvasAgentService();
-  const scope = { kind: 'scheduled' as const, taskId: task.id };
+  const scope = scheduledScope(task.id);
+  let sessionId = context.sessionId;
   try {
-    const result = await agentService.chatWithScope(scope, taskRunPrompt(task));
+    // Timer-driven runs have no renderer to prepare a conversation. Give every
+    // attempt a durable session before invoking the model, while manual runs
+    // reuse the session the visible Scheduled page just opened.
+    if (!sessionId) {
+      sessionId = await createScheduledSession(agentService, task.id);
+    }
+    const result = await agentService.chatWithScope(
+      scope,
+      taskRunPrompt(task),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { expectedConversationSessionId: sessionId },
+    );
     if (!result.ok) throw new Error(result.error ?? 'Scheduled task failed');
-    const sessionId = await agentService.resolveCurrentSessionId(scope);
-    announceRunFinished({ taskId: task.id, title: task.title, ok: true });
-    return { sessionId: sessionId ?? undefined };
+    announceRunFinished({
+      taskId: task.id,
+      title: task.title,
+      ok: true,
+      sessionId,
+      trigger: context.trigger,
+    });
+    return { sessionId };
   } catch (error) {
     // A failed run used to be announced nowhere: the throw happened before
     // the announcement, leaving `lastError` in the list as the only trace.
@@ -51,9 +90,22 @@ async function executeScheduledTask(task: ScheduledTask): Promise<{ sessionId?: 
       title: task.title,
       ok: false,
       error: error instanceof Error ? error.message : String(error),
+      ...(sessionId ? { sessionId } : {}),
+      trigger: context.trigger,
     });
     throw error;
   }
+}
+
+/** Main-owned manual start: validate task, create its session, then launch. */
+export async function startManualScheduledTask(
+  taskId: string,
+): Promise<{ task: ScheduledTask; sessionId: string }> {
+  const scheduled = getScheduledTaskService();
+  return scheduled.startTaskNow(
+    taskId,
+    () => createScheduledSession(getCanvasAgentService(), taskId),
+  );
 }
 
 export const __testing = { executeScheduledTask };

--- a/apps/canvas-workspace/src/main/scheduled/scheduled-task-service.ts
+++ b/apps/canvas-workspace/src/main/scheduled/scheduled-task-service.ts
@@ -5,6 +5,7 @@ import { homedir } from 'os';
 import type {
   ScheduledSchedule,
   ScheduledTask,
+  ScheduledTaskExecutionContext,
   ScheduledTaskExecutionResult,
   ScheduledTaskInput,
   ScheduledTaskPatch,
@@ -28,7 +29,10 @@ export const SCHEDULED_CHECK_EVERY_MS = 30 * 60_000;
 export interface ScheduledTaskServiceOptions {
   statePath?: string;
   now?: () => number;
-  execute: (task: ScheduledTask) => Promise<ScheduledTaskExecutionResult | void>;
+  execute: (
+    task: ScheduledTask,
+    context: ScheduledTaskExecutionContext,
+  ) => Promise<ScheduledTaskExecutionResult | void>;
   onChange?: (tasks: ScheduledTask[]) => void;
 }
 
@@ -189,34 +193,89 @@ export class ScheduledTaskService {
     });
   }
 
-  async runTaskNow(taskId: string): Promise<ScheduledTask> {
+  /** Reserves, prepares, and starts one manual run as a single task transaction. */
+  async startTaskNow(
+    taskId: string,
+    prepareSession: () => Promise<string>,
+  ): Promise<{ task: ScheduledTask; sessionId: string }> {
     const task = await this.getTask(taskId);
     if (!task) throw new Error('Scheduled task not found');
-    await this.runTask(task, false, this.now());
-    return (await this.getTask(taskId))!;
+    if (this.running.has(task.id)) throw new Error('Scheduled task is already running');
+    this.running.add(task.id);
+    let sessionId: string;
+    const attemptedAt = this.now();
+    try {
+      sessionId = await prepareSession();
+      await this.markTaskStarted(task, { trigger: 'manual', sessionId }, attemptedAt);
+    } catch (error) {
+      this.running.delete(task.id);
+      await this.emitChange();
+      throw error;
+    }
+    const context: ScheduledTaskExecutionContext = { trigger: 'manual', sessionId };
+    void this.completeTask(task, context, attemptedAt).catch((error) => {
+      console.error(`[scheduled] Manual run failed to settle for ${task.id}:`, error);
+    });
+    return { task: (await this.getTask(taskId))!, sessionId };
   }
 
   async runDueTasks(now = this.now()): Promise<void> {
     const tasks = await this.listTasks();
     for (const task of tasks) {
       if (!task.enabled || task.nextRunAt > now || this.running.has(task.id)) continue;
-      await this.runTask(task, true, now);
+      await this.runTask(task, { trigger: 'schedule' }, now);
     }
   }
 
-  private async runTask(task: ScheduledTask, advanceSchedule: boolean, attemptedAt: number): Promise<void> {
-    if (this.running.has(task.id)) return;
+  private async runTask(
+    task: ScheduledTask,
+    context: ScheduledTaskExecutionContext,
+    attemptedAt: number,
+  ): Promise<void> {
+    if (!await this.beginTask(task, context, attemptedAt)) return;
+    await this.completeTask(task, context, attemptedAt);
+  }
+
+  private async beginTask(
+    task: ScheduledTask,
+    context: ScheduledTaskExecutionContext,
+    attemptedAt: number,
+  ): Promise<boolean> {
+    if (this.running.has(task.id)) return false;
     this.running.add(task.id);
-    await this.mutate((state) => {
+    try {
+      await this.markTaskStarted(task, context, attemptedAt);
+      return true;
+    } catch (error) {
+      this.running.delete(task.id);
+      throw error;
+    }
+  }
+
+  private markTaskStarted(
+    task: ScheduledTask,
+    context: ScheduledTaskExecutionContext,
+    attemptedAt: number,
+  ): Promise<void> {
+    return this.mutate((state) => {
       const current = state.tasks.find((candidate) => candidate.id === task.id);
       if (!current) return;
       current.lastAttemptAt = attemptedAt;
       current.runCount += 1;
       current.lastError = undefined;
-      if (advanceSchedule) current.nextRunAt = computeNextRunAt(current.schedule, attemptedAt);
+      if (context.trigger === 'schedule') {
+        current.nextRunAt = computeNextRunAt(current.schedule, attemptedAt);
+      }
     });
+  }
+
+  private async completeTask(
+    task: ScheduledTask,
+    context: ScheduledTaskExecutionContext,
+    attemptedAt: number,
+  ): Promise<void> {
     try {
-      const result = await this.execute({ ...task, status: 'running' });
+      const result = await this.execute({ ...task, status: 'running' }, context);
       await this.mutate((state) => {
         const current = state.tasks.find((candidate) => candidate.id === task.id);
         if (!current) return;

--- a/apps/canvas-workspace/src/renderer/src/App.tsx
+++ b/apps/canvas-workspace/src/renderer/src/App.tsx
@@ -247,7 +247,7 @@ const AppContent = () => {
     setLocation(path);
   }, [setLocation]);
 
-  useScheduledRunChatOpener({ activeView, chatRoute: ROUTE_CHAT });
+  useScheduledRunChatOpener({ activeView, chatRoute: ROUTE_CHAT, onOpenSessionInScope: openSessionInOwningScope });
 
   const handleSelectWorkspace = useCallback((id: string) => {
     ensureWorkspaceNodesLoaded(id);
@@ -564,11 +564,9 @@ const AppContent = () => {
           <SkillsRouteView activeWorkspaceId={activeId} workspaces={workspaces}
             onSelectWorkspace={(workspaceId) => { ensureWorkspaceNodesLoaded(workspaceId); selectWorkspace(workspaceId); }}
           />
-          <ScheduledRouteViews
-            scheduledTaskId={scheduledTaskMatch ? decodeURIComponent(scheduledTaskMatch[1]) : null}
-            onExitScheduledTask={() => setLocation(ROUTE_SCHEDULED)}
-            onOpenAppSettings={openAppSettings}
-          />
+          <ScheduledRouteViews scheduledTaskId={scheduledTaskMatch ? decodeURIComponent(scheduledTaskMatch[1]) : null}
+            onExitScheduledTask={() => setLocation(ROUTE_SCHEDULED)} onOpenAppSettings={openAppSettings}
+            onOpenSessionInScope={openSessionInOwningScope} />
           {pluginRoutes.map((route) => {
             return (
               <PulseRouterView key={route.path} name={route.path}>

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.tsx
@@ -104,6 +104,7 @@ export const ChatPage = ({
   // and thread replacement cannot disturb it.
   const [sessionBackStack, setSessionBackStack] = useState<SessionBackEntry[]>([]);
   const scopeKey = scopeSessionStoreId(agentScope);
+  const appliedEntryTargetRef = useRef<ChatTarget | null>(initialTarget ?? null);
 
   useEffect(() => {
     onWorkspaceScopeChange?.(workspaceIdFromScope(agentScope));
@@ -126,36 +127,63 @@ export const ChatPage = ({
 
   // Every session click keeps the body mounted. Cross-scope picks update the
   // scope and pending session together; the body swaps thread data in place.
-  const navigateToSession = useCallback((session: { sessionId: string; workspaceId: string }) => {
+  const navigateToSession = useCallback((
+    session: { sessionId: string; workspaceId: string },
+    target?: ChatTarget,
+  ) => {
     const intentId = ++sessionIntentSequenceRef.current;
     pendingSessionIntentRef.current = intentId;
     setPendingSessionIntent({
       id: intentId,
       sessionId: session.sessionId,
-      sessionKey: `${session.workspaceId}:${session.sessionId}`,
+      sessionKey: `${target?.scopeId ?? session.workspaceId}:${session.sessionId}`,
     });
     // The rail's `workspaceId` is really a session-STORE id, so the two
     // sentinel stores (global chat, one per scheduled task) must map back to
     // their own scope kinds — treating them as workspace ids would activate
     // an agent against a workspace that does not exist.
     const scheduledTaskId = scheduledTaskIdFromStoreId(session.workspaceId);
-    const nextScope: AgentScope = scheduledTaskId
+    const nextScope: AgentScope = target?.scope ?? (scheduledTaskId
       ? { kind: 'scheduled', taskId: scheduledTaskId }
       : session.workspaceId === GLOBAL_CHAT_STORE_ID
         ? { kind: 'global' }
-        : { kind: 'workspace', workspaceId: session.workspaceId };
+        : { kind: 'workspace', workspaceId: session.workspaceId });
     const nextScopeKey = scopeSessionStoreId(nextScope);
     onWorkspaceScopeChange?.(workspaceIdFromScope(nextScope));
     scopeRollbackRef.current ??= {
       agentScope, selectedSessionKey, contextSnapshot, executionPolicy, sessionBackStack,
     };
-    setContextSnapshot(undefined);
-    setExecutionPolicy(nextScope.kind === 'scheduled' ? 'scheduled' : 'auto');
+    setContextSnapshot(target?.contextSnapshot);
+    setExecutionPolicy(target?.executionPolicy ?? (nextScope.kind === 'scheduled' ? 'scheduled' : 'auto'));
     if (nextScopeKey === scopeKey) {
       return;
     }
     setAgentScope(nextScope);
   }, [agentScope, contextSnapshot, executionPolicy, onWorkspaceScopeChange, scopeKey, selectedSessionKey, sessionBackStack]);
+
+  // `initialTarget` is also a live cross-surface navigation input. Reuse the
+  // same intent/rollback transition as the session rail so overlapping Toast
+  // opens cannot create a second navigation state machine.
+  useEffect(() => {
+    if (!initialTarget || appliedEntryTargetRef.current === initialTarget) return;
+    appliedEntryTargetRef.current = initialTarget;
+    if (initialTarget.sessionId) {
+      setSessionBackStack([]);
+      navigateToSession({
+        sessionId: initialTarget.sessionId,
+        workspaceId: initialTarget.scopeId,
+      }, initialTarget);
+      return;
+    }
+    sessionIntentSequenceRef.current += 1;
+    pendingSessionIntentRef.current = null;
+    setPendingSessionIntent(null);
+    setSelectedSessionKey(null);
+    setAgentScope(initialTarget.scope);
+    setContextSnapshot(initialTarget.contextSnapshot);
+    setExecutionPolicy(initialTarget.executionPolicy);
+    setSessionBackStack([]);
+  }, [initialTarget, navigateToSession]);
 
   // Manual rail pick resets the jump trail; chip jumps (onJumpToSession)
   // keep it so the back bar can walk home.

--- a/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatPage.scope-switch.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatPage.scope-switch.test.tsx
@@ -308,6 +308,57 @@ describe('ChatPage scope switching', () => {
     expect(restored?.dataset.executionPolicy).toBe('ask');
   });
 
+  it('loads an exact scheduled session when the page target changes after mount', async () => {
+    const initialTarget: ChatTarget = {
+      surface: 'page',
+      scope: { kind: 'global' },
+      scopeId: '__global_chat__',
+      sessionId: 'global-session',
+      composerId: 'page:__global_chat__',
+      contextSnapshot: { label: 'Global chat' },
+      executionPolicy: 'auto',
+    };
+    const scheduledTarget: ChatTarget = {
+      surface: 'page',
+      scope: { kind: 'scheduled', taskId: 'daily-brief' },
+      scopeId: '__scheduled__-daily-brief',
+      sessionId: 'scheduled-run-session',
+      composerId: 'page:__scheduled__-daily-brief',
+      contextSnapshot: { label: 'Morning brief' },
+      executionPolicy: 'scheduled',
+    };
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+
+    await act(async () => {
+      root?.render(
+        <ChatPage
+          allWorkspaces={[]}
+          initialTarget={initialTarget}
+          onExit={vi.fn()}
+          onOpenAppSettings={vi.fn()}
+        />,
+      );
+    });
+    await act(async () => {
+      root?.render(
+        <ChatPage
+          allWorkspaces={[]}
+          initialTarget={scheduledTarget}
+          onExit={vi.fn()}
+          onOpenAppSettings={vi.fn()}
+        />,
+      );
+    });
+
+    const body = host.querySelector<HTMLButtonElement>('[data-chat-body]');
+    expect(body?.textContent).toBe('scheduled');
+    expect(body?.dataset.pendingSession).toBe('__scheduled__-daily-brief:scheduled-run-session');
+    expect(body?.dataset.contextLabel).toBe('Morning brief');
+    expect(body?.dataset.executionPolicy).toBe('scheduled');
+  });
+
   it('clears stale rail selection when an external scheduled target opens', async () => {
     host = document.createElement('div');
     document.body.appendChild(host);

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatNavigation.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatNavigation.test.tsx
@@ -168,6 +168,48 @@ describe('useChatNavigation', () => {
     act(() => root.unmount());
   });
 
+  it('retargets an already-open full-page chat without leaving the page', () => {
+    let latest: ReturnType<typeof useChatNavigation> | undefined;
+    const setLocation = vi.fn();
+    const pageTarget: ChatTarget = {
+      ...target,
+      surface: 'page',
+      scope: { kind: 'scheduled', taskId: 'daily-brief' },
+      scopeId: '__scheduled__-daily-brief',
+      sessionId: 'scheduled-run-session',
+      composerId: 'page:__scheduled__-daily-brief',
+      contextSnapshot: { label: 'Morning brief' },
+      executionPolicy: 'scheduled',
+    };
+    const broker = {
+      deliver: vi.fn(async () => ({ status: 'unavailable' as const, target: null })),
+      getActiveTarget: () => target,
+      register: vi.fn(),
+      subscribe: vi.fn(),
+    } satisfies ChatTargetBroker;
+    const host = document.createElement('div');
+    const root = createRoot(host);
+    const Harness = () => {
+      latest = useChatNavigation({
+        activeView: 'chat',
+        location: '/chat',
+        setLocation,
+        activeTarget: target,
+        broker,
+        openDockChat: vi.fn(),
+        isOverlayOpen: false,
+        openShortcuts: vi.fn(),
+      });
+      return null;
+    };
+    act(() => root.render(<Harness />));
+    act(() => latest?.enterChatTarget(pageTarget));
+
+    expect(latest?.initialTarget).toEqual(pageTarget);
+    expect(setLocation).not.toHaveBeenCalled();
+    act(() => root.unmount());
+  });
+
   it('lets Escape leave full-page chat while the composer owns focus', async () => {
     const setLocation = vi.fn();
     const broker = {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatNavigation.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatNavigation.ts
@@ -45,7 +45,13 @@ export const useChatNavigation = ({
   const isChatView = activeView === 'chat';
 
   const enterChatTarget = useCallback((target: ChatTarget | null) => {
-    if (activeView === 'chat') return;
+    if (activeView === 'chat') {
+      // Completion toasts may target another durable conversation while the
+      // full-page chat is already visible. Publish the target in place rather
+      // than treating the navigation as a no-op.
+      setInitialTarget(target);
+      return;
+    }
     returnPointRef.current = {
       location,
       focus: document.activeElement instanceof HTMLElement

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/context.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/context.tsx
@@ -141,6 +141,7 @@ export function useRightDock(): {
   newLink: () => void;
   openChat: () => void;
   openScheduledChat: (taskId: string) => void;
+  refreshScheduledChat: (taskId: string) => void;
   toggleChat: () => void;
   toggleContentTabs: () => void;
   openTerminal: () => void;
@@ -189,6 +190,7 @@ export function useRightDock(): {
     newLink: () => store.newLink(),
     openChat: () => store.openChat(),
     openScheduledChat: (taskId: string) => store.openScheduledChat(taskId),
+    refreshScheduledChat: (taskId: string) => store.refreshScheduledChat(taskId),
     toggleChat: () => store.toggleChat(),
     toggleContentTabs: () => store.toggleContentTabs(),
     openTerminal: () => store.openTerminal(),

--- a/apps/canvas-workspace/src/renderer/src/views/Scheduled/ScheduledPage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/views/Scheduled/ScheduledPage.tsx
@@ -10,18 +10,21 @@ import {
   Trash,
 } from '@phosphor-icons/react';
 import type { ScheduledTask, ScheduledTaskInput } from '../../../../shared/scheduled';
+import type { AgentScope } from '../../components/chat/types';
 import { useI18n } from '../../i18n';
 import { useAppShell } from '../../components/shell/AppShellProvider';
-import { useDockContext } from '../../components/dock/RightDock/context';
 import { Button, EmptyState } from '../../components/ui';
 import { scheduleLabel, timeLabel } from './formatters';
 import { TaskEditorModal } from './TaskEditorModal';
 import './index.css';
 
-export const ScheduledPage = () => {
+interface Props {
+  onOpenSessionInScope: (scope: AgentScope, sessionId: string, scopeLabel: string) => void | Promise<void>;
+}
+
+export const ScheduledPage = ({ onOpenSessionInScope }: Props) => {
   const { t, language } = useI18n();
   const { notify, confirm } = useAppShell();
-  const { store: dockStore } = useDockContext();
   const [tasks, setTasks] = useState<ScheduledTask[]>([]);
   const [loading, setLoading] = useState(true);
   const [runningTaskIds, setRunningTaskIds] = useState<Set<string>>(() => new Set());
@@ -70,24 +73,18 @@ export const ScheduledPage = () => {
   const runNow = async (task: ScheduledTask) => {
     if (runningTaskIds.has(task.id) || task.status === 'running') return;
     setRunningTaskIds((current) => new Set(current).add(task.id));
-    const scope = { kind: 'scheduled' as const, taskId: task.id };
     try {
-      const session = await window.canvasWorkspace.agent.newSession({ scope });
-      if (!session.ok) {
-        notify({ tone: 'error', title: t('scheduled.runFailed'), description: session.error });
+      const response = await window.canvasWorkspace.scheduled.runNow(task.id);
+      if (!response.ok || !response.sessionId) {
+        notify({ tone: 'error', title: t('scheduled.runFailed'), description: response.error });
         return;
       }
 
-      dockStore.openScheduledChat(task.id);
-      const response = await window.canvasWorkspace.scheduled.runNow(task.id);
-      dockStore.refreshScheduledChat(task.id);
-      if (!response.ok || response.task?.lastError) {
-        notify({
-          tone: 'error',
-          title: t('scheduled.runFailed'),
-          description: response.error ?? response.task?.lastError,
-        });
-      }
+      void onOpenSessionInScope(
+        { kind: 'scheduled', taskId: task.id },
+        response.sessionId,
+        task.title,
+      );
     } finally {
       setRunningTaskIds((current) => {
         const next = new Set(current);

--- a/apps/canvas-workspace/src/renderer/src/views/Scheduled/ScheduledRouteViews.tsx
+++ b/apps/canvas-workspace/src/renderer/src/views/Scheduled/ScheduledRouteViews.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense } from 'react';
+import type { AgentScope } from '../../components/chat/types';
 import type { SettingsSection } from '../../components/settings/Settings';
 import { PulseRouterView } from '../../components/shell/router';
 
@@ -9,17 +10,19 @@ interface Props {
   scheduledTaskId: string | null;
   onExitScheduledTask: () => void;
   onOpenAppSettings: (section: SettingsSection) => void;
+  onOpenSessionInScope: (scope: AgentScope, sessionId: string, scopeLabel: string) => void | Promise<void>;
 }
 
 export const ScheduledRouteViews = ({
   scheduledTaskId,
   onExitScheduledTask,
   onOpenAppSettings,
+  onOpenSessionInScope,
 }: Props) => (
   <>
     <PulseRouterView name="scheduled">
       <Suspense fallback={null}>
-        <ScheduledPage />
+        <ScheduledPage onOpenSessionInScope={onOpenSessionInScope} />
       </Suspense>
     </PulseRouterView>
     <PulseRouterView name="scheduled-task">

--- a/apps/canvas-workspace/src/renderer/src/views/Scheduled/__tests__/ScheduledPage.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/views/Scheduled/__tests__/ScheduledPage.test.tsx
@@ -4,28 +4,18 @@ import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { I18nProvider } from '../../../i18n';
 import { AppShellProvider } from '../../../components/shell/AppShellProvider';
-import { RightDockProvider, useRightDockState } from '../../../components/dock/RightDock';
-import type { DockState } from '../../../components/dock/RightDock/dock-store';
 import { ScheduledPage } from '../ScheduledPage';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 let root: Root | null = null;
 let host: HTMLDivElement | null = null;
-let dockState: DockState | undefined;
-
-const DockStateProbe = () => {
-  dockState = useRightDockState();
-  return null;
-};
+const openSessionInScope = vi.fn();
 
 const renderPage = () => (
   <I18nProvider>
     <AppShellProvider>
-      <RightDockProvider>
-        <DockStateProbe />
-        <ScheduledPage />
-      </RightDockProvider>
+      <ScheduledPage onOpenSessionInScope={openSessionInScope} />
     </AppShellProvider>
   </I18nProvider>
 );
@@ -35,7 +25,7 @@ afterEach(() => {
   host?.remove();
   root = null;
   host = null;
-  dockState = undefined;
+  openSessionInScope.mockReset();
   vi.restoreAllMocks();
 });
 
@@ -84,12 +74,13 @@ describe('ScheduledPage', () => {
   });
 
   it('starts a fresh scheduled session and opens it in Pulse AI', async () => {
-    const runNow = vi.fn(async () => ({ ok: true }));
-    const newSession = vi.fn(async () => ({ ok: true }));
+    const runNow = vi.fn(async () => ({
+      ok: true,
+      sessionId: 'manual-run-session',
+    }));
     Object.defineProperty(window, 'canvasWorkspace', {
       configurable: true,
       value: {
-        agent: { newSession },
         scheduled: {
           list: vi.fn(async () => ({
             ok: true,
@@ -125,26 +116,22 @@ describe('ScheduledPage', () => {
       await Promise.resolve();
       await Promise.resolve();
     });
-    expect(newSession).toHaveBeenCalledWith({
-      scope: { kind: 'scheduled', taskId: 'daily-brief' },
-    });
     expect(runNow).toHaveBeenCalledWith('daily-brief');
-    expect(dockState).toMatchObject({
-      expanded: true,
-      scheduledChatTaskId: 'daily-brief',
-      scheduledChatRevision: 2,
-    });
+    expect(openSessionInScope).toHaveBeenCalledWith(
+      { kind: 'scheduled', taskId: 'daily-brief' },
+      'manual-run-session',
+      'Daily brief',
+    );
   });
 
   it('shows an immediate running state and prevents duplicate manual runs', async () => {
-    let finishRun: ((value: { ok: boolean }) => void) | undefined;
-    const runNow = vi.fn(() => new Promise<{ ok: boolean }>((resolve) => {
-      finishRun = resolve;
+    let finishStart: ((value: { ok: boolean; sessionId: string }) => void) | undefined;
+    const runNow = vi.fn(() => new Promise<{ ok: boolean; sessionId: string }>((resolve) => {
+      finishStart = resolve;
     }));
     Object.defineProperty(window, 'canvasWorkspace', {
       configurable: true,
       value: {
-        agent: { newSession: vi.fn(async () => ({ ok: true })) },
         scheduled: {
           list: vi.fn(async () => ({
             ok: true,
@@ -186,17 +173,17 @@ describe('ScheduledPage', () => {
     expect(runningButton?.textContent).toContain('Running');
     runningButton?.click();
     expect(runNow).toHaveBeenCalledTimes(1);
-    expect(dockState).toMatchObject({
-      expanded: true,
-      scheduledChatTaskId: 'daily-brief',
-      scheduledChatRevision: 1,
-    });
+    expect(openSessionInScope).not.toHaveBeenCalled();
 
     await act(async () => {
-      finishRun?.({ ok: true });
+      finishStart?.({ ok: true, sessionId: 'manual-run-session' });
       await Promise.resolve();
     });
     expect(host.querySelector<HTMLButtonElement>('[aria-label="Run now"]')?.disabled).toBe(false);
-    expect(dockState?.scheduledChatRevision).toBe(2);
+    expect(openSessionInScope).toHaveBeenCalledWith(
+      { kind: 'scheduled', taskId: 'daily-brief' },
+      'manual-run-session',
+      'Daily brief',
+    );
   });
 });

--- a/apps/canvas-workspace/src/renderer/src/views/Scheduled/__tests__/useScheduledRunChatOpener.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/views/Scheduled/__tests__/useScheduledRunChatOpener.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment happy-dom
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ScheduledRunFinished } from '../../../../../shared/scheduled';
+import type { AgentScope } from '../../../components/chat/types';
+import { I18nProvider } from '../../../i18n';
+import { AppShellProvider } from '../../../components/shell/AppShellProvider';
+
+const dock = vi.hoisted(() => ({
+  openScheduledChat: vi.fn(),
+  refreshScheduledChat: vi.fn(),
+}));
+const setLocation = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../components/dock/RightDock', () => ({ useRightDock: () => dock }));
+vi.mock('wouter', () => ({ useLocation: () => ['/', setLocation] }));
+
+import { useScheduledRunChatOpener } from '../useScheduledRunChatOpener';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let host: HTMLDivElement | null = null;
+
+type OpenSession = (
+  scope: AgentScope,
+  sessionId: string,
+  scopeLabel: string,
+) => void | Promise<void>;
+
+const mount = async (onOpenSessionInScope: OpenSession) => {
+  const listeners: Array<(run: ScheduledRunFinished) => void> = [];
+  Object.defineProperty(window, 'canvasWorkspace', {
+    configurable: true,
+    value: {
+      scheduled: {
+        onRunFinished: (callback: (run: ScheduledRunFinished) => void) => {
+          listeners.push(callback);
+          return () => listeners.splice(listeners.indexOf(callback), 1);
+        },
+      },
+    },
+  });
+  const Harness = () => {
+    useScheduledRunChatOpener({
+      activeView: 'canvas',
+      chatRoute: '/chat',
+      onOpenSessionInScope,
+    });
+    return null;
+  };
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+  await act(async () => {
+    root?.render(
+      <I18nProvider>
+        <AppShellProvider>
+          <Harness />
+        </AppShellProvider>
+      </I18nProvider>,
+    );
+  });
+  return (run: ScheduledRunFinished) => act(() => {
+    for (const listener of [...listeners]) listener(run);
+  });
+};
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  host?.remove();
+  root = null;
+  host = null;
+  dock.openScheduledChat.mockReset();
+  dock.refreshScheduledChat.mockReset();
+  setLocation.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe('useScheduledRunChatOpener', () => {
+  it('opens the exact completed session in full-page Pulse AI', async () => {
+    const openSession = vi.fn();
+    const emit = await mount((scope, sessionId, scopeLabel) => {
+      openSession(scope, sessionId, scopeLabel);
+    });
+    emit({
+      taskId: 'daily-brief',
+      title: 'Morning brief',
+      ok: true,
+      sessionId: 'scheduled-run-session',
+      trigger: 'schedule',
+    });
+
+    await act(async () => {
+      document.querySelector<HTMLButtonElement>('.shell-toast__action')?.click();
+    });
+
+    expect(openSession).toHaveBeenCalledWith(
+      { kind: 'scheduled', taskId: 'daily-brief' },
+      'scheduled-run-session',
+      'Morning brief',
+    );
+    expect(dock.openScheduledChat).not.toHaveBeenCalled();
+    expect(dock.refreshScheduledChat).toHaveBeenCalledWith('daily-brief');
+    expect(setLocation).not.toHaveBeenCalled();
+  });
+
+  it('keeps the task-scope dock fallback when session creation failed', async () => {
+    const openSession = vi.fn();
+    const emit = await mount((scope, sessionId, scopeLabel) => {
+      openSession(scope, sessionId, scopeLabel);
+    });
+    emit({
+      taskId: 'daily-brief',
+      title: 'Morning brief',
+      ok: false,
+      error: 'Could not create scheduled run session',
+      trigger: 'schedule',
+    });
+
+    await act(async () => {
+      document.querySelector<HTMLButtonElement>('.shell-toast__action')?.click();
+    });
+
+    expect(openSession).not.toHaveBeenCalled();
+    expect(dock.openScheduledChat).toHaveBeenCalledWith('daily-brief');
+    expect(dock.refreshScheduledChat).toHaveBeenCalledWith('daily-brief');
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/views/Scheduled/__tests__/useScheduledRunToasts.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/views/Scheduled/__tests__/useScheduledRunToasts.test.tsx
@@ -12,13 +12,13 @@ import { useScheduledRunToasts } from '../useScheduledRunToasts';
 let root: Root | null = null;
 let host: HTMLDivElement | null = null;
 
-const Harness = ({ onOpenTask }: { onOpenTask: (taskId: string) => void }) => {
-  useScheduledRunToasts(onOpenTask);
+const Harness = ({ onOpenRun }: { onOpenRun: (run: ScheduledRunFinished) => void }) => {
+  useScheduledRunToasts(onOpenRun);
   return null;
 };
 
 /** Mounts the hook and hands back the main-process push it subscribed with. */
-const mount = async (onOpenTask: (taskId: string) => void) => {
+const mount = async (onOpenRun: (run: ScheduledRunFinished) => void) => {
   let emit: ((run: ScheduledRunFinished) => void) | undefined;
   Object.defineProperty(window, 'canvasWorkspace', {
     configurable: true,
@@ -39,7 +39,7 @@ const mount = async (onOpenTask: (taskId: string) => void) => {
     root?.render(
       <I18nProvider>
         <AppShellProvider>
-          <Harness onOpenTask={onOpenTask} />
+          <Harness onOpenRun={onOpenRun} />
         </AppShellProvider>
       </I18nProvider>,
     );
@@ -61,10 +61,17 @@ afterEach(() => {
 describe('useScheduledRunToasts', () => {
   it('keeps the completion toast up until it is acted on', async () => {
     vi.useFakeTimers();
-    const onOpenTask = vi.fn();
-    const emit = await mount(onOpenTask);
+    const onOpenRun = vi.fn();
+    const emit = await mount(onOpenRun);
 
-    emit({ taskId: 'daily-brief', title: 'Morning brief', ok: true });
+    const completedRun: ScheduledRunFinished = {
+      taskId: 'daily-brief',
+      title: 'Morning brief',
+      ok: true,
+      sessionId: 'session-from-run',
+      trigger: 'schedule',
+    } as ScheduledRunFinished;
+    emit(completedRun);
     expect(toasts()).toHaveLength(1);
     expect(toasts()[0].textContent).toContain('Morning brief');
 
@@ -77,7 +84,21 @@ describe('useScheduledRunToasts', () => {
     expect(action?.textContent).toContain('Open chat');
     await act(async () => { action?.click(); });
 
-    expect(onOpenTask).toHaveBeenCalledWith('daily-brief');
+    expect(onOpenRun).toHaveBeenCalledWith(completedRun);
+    expect(toasts()).toHaveLength(0);
+  });
+
+  it('does not announce a successful manual run the user is already watching', async () => {
+    const emit = await mount(vi.fn());
+
+    emit({
+      taskId: 'daily-brief',
+      title: 'Morning brief',
+      ok: true,
+      sessionId: 'manual-session',
+      trigger: 'manual',
+    } as ScheduledRunFinished);
+
     expect(toasts()).toHaveLength(0);
   });
 
@@ -89,7 +110,9 @@ describe('useScheduledRunToasts', () => {
       title: 'Morning brief',
       ok: false,
       error: 'model unavailable',
-    });
+      sessionId: 'failed-session',
+      trigger: 'schedule',
+    } as ScheduledRunFinished);
 
     expect(toasts()).toHaveLength(1);
     expect(toasts()[0].textContent).toContain('model unavailable');

--- a/apps/canvas-workspace/src/renderer/src/views/Scheduled/useScheduledRunChatOpener.ts
+++ b/apps/canvas-workspace/src/renderer/src/views/Scheduled/useScheduledRunChatOpener.ts
@@ -1,5 +1,7 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useLocation } from 'wouter';
+import type { ScheduledRunFinished } from '../../../../shared/scheduled';
+import type { AgentScope } from '../../components/chat/types';
 import { useRightDock } from '../../components/dock/RightDock';
 import { resolveScheduledChatTarget } from './scheduledChatTarget';
 import { useScheduledRunToasts } from './useScheduledRunToasts';
@@ -9,25 +11,53 @@ interface Options {
   activeView: string;
   /** The AI Chat route, owned by the router host. */
   chatRoute: string;
+  /** Opens one durable conversation in the full-page Pulse AI surface. */
+  onOpenSessionInScope: (
+    scope: AgentScope,
+    sessionId: string,
+    scopeLabel: string,
+  ) => void | Promise<void>;
 }
 
 /**
- * Wires the scheduled-run completion toast to the task's conversation.
- *
- * The conversation opens in the dock's Pulse AI tab — the same surface
- * `Run now` uses — so acting on a finished run never navigates the app away
- * from what the user was doing. Only views that hide the dock chat tab fall
- * back to the AI Chat route (see `resolveScheduledChatTarget`).
+ * Wires the scheduled-run completion toast to the exact conversation that
+ * produced it. Durable runs open in full-page Pulse AI, whose ChatTarget
+ * contract can select a session by id and return to the previous surface.
+ * Task-scope Dock/route navigation survives only for failures that happened
+ * before session setup (see `resolveScheduledChatTarget`).
  */
-export const useScheduledRunChatOpener = ({ activeView, chatRoute }: Options): void => {
+export const useScheduledRunChatOpener = ({
+  activeView,
+  chatRoute,
+  onOpenSessionInScope,
+}: Options): void => {
   const dock = useRightDock();
   const [, setLocation] = useLocation();
-  useScheduledRunToasts(useCallback((taskId: string) => {
-    const target = resolveScheduledChatTarget({ activeView, taskId, chatRoute });
+  useEffect(() => window.canvasWorkspace.scheduled.onRunFinished((run) => {
+    // Refresh is a no-op unless this task is already visible in the Dock. It
+    // keeps Run now live without pulling a background task into view.
+    dock.refreshScheduledChat(run.taskId);
+  }), [dock]);
+  useScheduledRunToasts(useCallback((run: ScheduledRunFinished) => {
+    if (run.sessionId) {
+      void onOpenSessionInScope(
+        { kind: 'scheduled', taskId: run.taskId },
+        run.sessionId,
+        run.title,
+      );
+      return;
+    }
+    // Session setup itself can fail. There is no exact conversation in that
+    // case, so retain the task-scope fallback rather than dropping the action.
+    const target = resolveScheduledChatTarget({
+      activeView,
+      taskId: run.taskId,
+      chatRoute,
+    });
     if (target.kind === 'dock') {
-      dock.openScheduledChat(taskId);
+      dock.openScheduledChat(run.taskId);
       return;
     }
     setLocation(target.path);
-  }, [activeView, chatRoute, dock, setLocation]));
+  }, [activeView, chatRoute, dock, onOpenSessionInScope, setLocation]));
 };

--- a/apps/canvas-workspace/src/renderer/src/views/Scheduled/useScheduledRunToasts.ts
+++ b/apps/canvas-workspace/src/renderer/src/views/Scheduled/useScheduledRunToasts.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import type { ScheduledRunFinished } from '../../../../shared/scheduled';
 import { useI18n } from '../../i18n';
 import { useAppShell } from '../../components/shell/AppShellProvider';
 
@@ -12,16 +13,21 @@ import { useAppShell } from '../../components/shell/AppShellProvider';
  * a toast that expires on a timer reproduces "the run finished and I never
  * saw anything". It stays until dismissed or acted on.
  *
- * `onOpenTask` is held in a ref so callers can pass an inline arrow without
- * resubscribing on every render; routing stays with the caller.
+ * `onOpenRun` is held in a ref so callers can pass an inline arrow without
+ * resubscribing on every render; exact-session routing stays with the caller.
  */
-export const useScheduledRunToasts = (onOpenTask: (taskId: string) => void): void => {
+export const useScheduledRunToasts = (
+  onOpenRun: (run: ScheduledRunFinished) => void,
+): void => {
   const { t } = useI18n();
   const { notify } = useAppShell();
-  const openRef = useRef(onOpenTask);
-  openRef.current = onOpenTask;
+  const openRef = useRef(onOpenRun);
+  openRef.current = onOpenRun;
 
   useEffect(() => window.canvasWorkspace.scheduled.onRunFinished((run) => {
+    // Run now already opens the exact task conversation before it starts.
+    // A second success toast would point away from the result being watched.
+    if (run.trigger === 'manual' && run.ok) return;
     notify({
       tone: run.ok ? 'success' : 'error',
       title: run.ok ? t('scheduled.runFinished', { title: run.title }) : t('scheduled.runFailed'),
@@ -29,7 +35,7 @@ export const useScheduledRunToasts = (onOpenTask: (taskId: string) => void): voi
       autoCloseMs: 0,
       action: {
         label: t('scheduled.openChat'),
-        onClick: () => openRef.current(run.taskId),
+        onClick: () => openRef.current(run),
       },
     });
   }), [notify, t]);

--- a/apps/canvas-workspace/src/shared/scheduled.ts
+++ b/apps/canvas-workspace/src/shared/scheduled.ts
@@ -20,6 +20,7 @@ export type ScheduledSchedule =
 
 export type ScheduledTaskSource = 'user' | 'memory-report';
 export type ScheduledTaskRunStatus = 'idle' | 'running';
+export type ScheduledRunTrigger = 'manual' | 'schedule';
 
 export interface ScheduledTask {
   id: string;
@@ -57,12 +58,21 @@ export interface ScheduledTaskExecutionResult {
   sessionId?: string;
 }
 
+export interface ScheduledTaskExecutionContext {
+  trigger: ScheduledRunTrigger;
+  /** Manual runs create the visible session before invoking the scheduler. */
+  sessionId?: string;
+}
+
 /** Emitted once per finished run attempt — success AND failure. */
 export interface ScheduledRunFinished {
   taskId: string;
   title: string;
   ok: boolean;
   error?: string;
+  /** Exact conversation produced by this attempt, when session setup succeeded. */
+  sessionId?: string;
+  trigger: ScheduledRunTrigger;
 }
 
 export interface ScheduledApi {
@@ -77,7 +87,7 @@ export interface ScheduledApi {
   remove: (taskId: string) => Promise<{ ok: boolean; error?: string }>;
   runNow: (
     taskId: string,
-  ) => Promise<{ ok: boolean; task?: ScheduledTask; error?: string }>;
+  ) => Promise<{ ok: boolean; task?: ScheduledTask; sessionId?: string; error?: string }>;
   onChanged: (callback: (tasks: ScheduledTask[]) => void) => () => void;
   onRunFinished: (callback: (run: ScheduledRunFinished) => void) => () => void;
 }


### PR DESCRIPTION
## Summary

- create and anchor a dedicated conversation session for every scheduled run
- make manual run startup a single main-process transaction and open its exact session in full-page Pulse AI
- carry session and trigger identity through completion toasts, including navigation while Pulse AI is already open
- suppress redundant successful manual-run toasts while retaining failure and session-setup fallbacks

## Verification

- `pnpm --filter canvas-workspace typecheck`
- `pnpm --filter canvas-workspace test` — 414 files, 2585 tests
- `PULSE_CANVAS_PERF_ANALYZE=1 pnpm --filter canvas-workspace build`
- `pnpm --filter canvas-workspace perf:bundle`
- `node scripts/harness/run-harness-check.mjs --path ...` — 4/4 checks
- real Electron harness: after replacing the task's current pointer with an empty decoy session, clicking the completion toast restored the original run session and messages

## Follow-up

Scheduled run sessions remain non-destructive user history. High-frequency tasks can accumulate many sessions; indexed and paginated session listing should be handled separately rather than silently deleting history.
