### PR TITLE
release(canvas): 0.1.48

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.47",
+  "version": "0.1.48",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
## Release notes

- Fix page-owned find shortcuts in web tabs.
- Open scheduled task results in the exact workspace and conversation.

## Verification

- `pnpm --filter canvas-workspace test` — 415 files, 2591 tests passed
- macOS arm64 DMG built and uploaded to R2
- `latest.json`, DMG, and Pages download site returned HTTP 200