### PR TITLE
release(canvas): 0.1.49

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.48",
+  "version": "0.1.49",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
## Release 0.1.49

Pulse Canvas stable 0.1.49 (macOS arm64).

### Changes
- **Agent 插件市场**：应用内浏览并安装精选插件
- **聊天 @ 提及**：聊天中 @ 提及已安装插件并显示图标
- 插件来源精选并固定到不可变版本，安装更安全

### Release artifacts
- R2: https://downloads.jasperhu.art/pulse-canvas/stable/latest.json
- Download page: https://pulse-canvas-download.pages.dev/

Merge 后在 master 上打 `pulse-canvas-v0.1.49` tag。