### PR TITLE
fix(canvas): activate cold chat agent scopes

### DIFF
--- a/apps/canvas-workspace/src/main/agent/conversation-runtime/conversation-ipc.ts
+++ b/apps/canvas-workspace/src/main/agent/conversation-runtime/conversation-ipc.ts
@@ -55,6 +55,7 @@ export function setupConversationRuntimeIpc(getService: () => CanvasAgentService
         (scope, sessionId, operation) => (
           agentService.sessionMutations.runChat(scope, operation, sessionId)
         ),
+        (scope) => agentService.activateScope(scope),
       );
     }
     return service;

--- a/apps/canvas-workspace/src/main/agent/conversation-runtime/conversation-service.ts
+++ b/apps/canvas-workspace/src/main/agent/conversation-runtime/conversation-service.ts
@@ -23,6 +23,7 @@ export interface ConversationStoreAdapter {
  */
 export class ConversationRuntimeService {
   private readonly registries = new Map<string, ConversationRuntimeRegistry>();
+  private readonly pendingRegistries = new Map<string, Promise<ConversationRuntimeRegistry>>();
 
   constructor(
     private readonly getAgent: (scope: AgentScope) => CanvasAgent | undefined,
@@ -35,26 +36,51 @@ export class ConversationRuntimeService {
       sessionId: string,
       operation: () => Promise<T>,
     ) => Promise<T | null>,
+    private readonly activateScope?: (scope: AgentScope) => Promise<void>,
   ) {}
 
-  private registryFor(scope: AgentScope): ConversationRuntimeRegistry {
+  private async registryFor(scope: AgentScope): Promise<ConversationRuntimeRegistry> {
     const key = scopeKey(scope);
-    let registry = this.registries.get(key);
-    if (!registry) {
-      const agent = this.getAgent(scope);
-      if (!agent) throw new Error(`No active agent for scope ${key}`);
-      const storeId = scopeSessionStoreId(scope);
-      const storeAdapter = this.storeAdapterFactory(storeId, scope);
-      registry = new ConversationRuntimeRegistry({
-        create: (conversationKey) => ({
-          key: conversationKey,
-          loadMessages: () => storeAdapter.loadMessages(conversationKey.sessionId),
-          persist: (messages) => storeAdapter.persist(conversationKey.sessionId, messages),
-          runTurn: createConversationRunner(agent),
-        }),
-      });
-      this.registries.set(key, registry);
+    const existing = this.registries.get(key);
+    if (existing) return existing;
+
+    const pending = this.pendingRegistries.get(key);
+    if (pending) return pending;
+
+    // Conversation IPC can be the first request after app startup. The
+    // legacy chat path activates the scope before reaching the runtime, but
+    // this service must preserve that guarantee for the direct path too.
+    const creation = this.createRegistry(scope, key);
+    this.pendingRegistries.set(key, creation);
+    try {
+      return await creation;
+    } finally {
+      if (this.pendingRegistries.get(key) === creation) {
+        this.pendingRegistries.delete(key);
+      }
     }
+  }
+
+  private async createRegistry(
+    scope: AgentScope,
+    key: string,
+  ): Promise<ConversationRuntimeRegistry> {
+    if (!this.getAgent(scope) && this.activateScope) {
+      await this.activateScope(scope);
+    }
+    const agent = this.getAgent(scope);
+    if (!agent) throw new Error(`No active agent for scope ${key}`);
+    const storeId = scopeSessionStoreId(scope);
+    const storeAdapter = this.storeAdapterFactory(storeId, scope);
+    const registry = new ConversationRuntimeRegistry({
+      create: (conversationKey) => ({
+        key: conversationKey,
+        loadMessages: () => storeAdapter.loadMessages(conversationKey.sessionId),
+        persist: (messages) => storeAdapter.persist(conversationKey.sessionId, messages),
+        runTurn: createConversationRunner(agent),
+      }),
+    });
+    this.registries.set(key, registry);
     return registry;
   }
 
@@ -67,7 +93,7 @@ export class ConversationRuntimeService {
     input?: Omit<ConversationSendInput, 'message'>,
   ): Promise<ChatResponse> {
     try {
-      const registry = this.registryFor(scope);
+      const registry = await this.registryFor(scope);
       const runtime = await registry.open(conversationKey(scope, sessionId));
       const operation = () => runtime.sendAndWait({ message, ...input }, external);
       const result = this.runConversation

--- a/apps/canvas-workspace/src/main/agent/conversation-runtime/service-conversation-runtime.test.ts
+++ b/apps/canvas-workspace/src/main/agent/conversation-runtime/service-conversation-runtime.test.ts
@@ -67,6 +67,49 @@ afterEach(() => {
 });
 
 describe('ConversationRuntimeService.chat', () => {
+  it('activates a cold scope before opening its first conversation', async () => {
+    let activeAgent: typeof mockAgent.agent | undefined;
+    const activateScope = vi.fn(async () => {
+      activeAgent = mockAgent.agent;
+    });
+    const service = new ConversationRuntimeService(
+      () => activeAgent as never,
+      () => makeStoreAdapter(),
+      undefined,
+      activateScope,
+    );
+
+    const result = await service.chat(scope, 'session-a', 'hello');
+
+    expect(result).toMatchObject({ ok: true, response: 'echo:hello' });
+    expect(activateScope).toHaveBeenCalledWith(scope);
+    expect(mockAgent.agent.chat).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces cold activation and registry creation for concurrent conversations', async () => {
+    let activeAgent: typeof mockAgent.agent | undefined;
+    const activateScope = vi.fn(async () => {
+      activeAgent = mockAgent.agent;
+    });
+    const createAdapter = vi.fn(() => makeStoreAdapter());
+    const service = new ConversationRuntimeService(
+      () => activeAgent as never,
+      createAdapter,
+      undefined,
+      activateScope,
+    );
+
+    const [first, second] = await Promise.all([
+      service.chat(scope, 'session-a', 'first'),
+      service.chat(scope, 'session-b', 'second'),
+    ]);
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    expect(activateScope).toHaveBeenCalledTimes(1);
+    expect(createAdapter).toHaveBeenCalledTimes(1);
+  });
+
   it('runs two conversations in one workspace in parallel (independent runtimes)', async () => {
     const service = new ConversationRuntimeService(
       () => mockAgent.agent as never,

--- a/apps/canvas-workspace/src/main/agent/service.ts
+++ b/apps/canvas-workspace/src/main/agent/service.ts
@@ -50,7 +50,7 @@ export class CanvasAgentService {
     (scope) => this.getAgentForScope(scope),
   );
 
-  private async activateScope(scope: AgentScope): Promise<void> {
+  async activateScope(scope: AgentScope): Promise<void> {
     const key = scopeKey(scope);
     if (this.agents.has(key)) return;
     await this.agentActivations.run(key, async () => {


### PR DESCRIPTION
## Summary
- Activate the Canvas Agent before the conversation runtime opens a cold scope.
- Coalesce concurrent cold activation and registry creation for the same scope.
- Add regression coverage for first-send and concurrent conversation startup.

## Validation
- `vitest run apps/canvas-workspace/src/main/agent/conversation-runtime apps/canvas-workspace/src/main/agent/__tests__/service-history.test.ts` — 4 files, 29 tests passed.
- `git diff --check` — passed.
- Canvas typecheck — blocked by existing missing dependencies/assets (`@phosphor-icons/react`, PI agent, Langfuse, static plugin assets, and Vite `ImportMeta.env`).

## Risk
- Low; scoped to conversation runtime initialization and preserves the existing single-flight agent activation path.