### PR TITLE
release(canvas): 0.1.50

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.49",
+  "version": "0.1.50",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- bump Pulse Canvas to 0.1.50
- publish the macOS arm64 artifact and update manifest/download page
- fix the first Agent message after opening a canvas or knowledge space when the Agent scope has not yet activated

## Validation

- `node scripts/harness/run-harness-check.mjs --path apps/canvas-workspace/package.json --level standard` (8/8 passed; 424 test files, 2668 tests)
- `node apps/canvas-workspace/harness/tools/smoke-packaged-agent-tooling.mjs`
- verified the versioned DMG URL returns HTTP 200
