### PR TITLE
feat(canvas): adopt product typography system

### DIFF
--- a/apps/canvas-workspace/harness/tools/ui-showcase/src/main.tsx
+++ b/apps/canvas-workspace/harness/tools/ui-showcase/src/main.tsx
@@ -1,3 +1,4 @@
+import '@fontsource-variable/lexend/wght.css';
 import { createRoot } from 'react-dom/client';
 import { Showcase } from './Showcase';
 // The real renderer's global stylesheet — defines every CSS custom

--- a/apps/canvas-workspace/harness/tools/ui-showcase/src/main.tsx
+++ b/apps/canvas-workspace/harness/tools/ui-showcase/src/main.tsx
@@ -1,4 +1,3 @@
-import '@fontsource-variable/lexend/wght.css';
 import { createRoot } from 'react-dom/client';
 import { Showcase } from './Showcase';
 // The real renderer's global stylesheet — defines every CSS custom

--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -129,6 +129,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.21",
+    "@fontsource-variable/lexend": "5.3.0",
     "@larksuiteoapi/node-sdk": "^1.59.0",
     "ai": "^6.0.57",
     "fflate": "^0.8.2",

--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -129,7 +129,6 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.21",
-    "@fontsource-variable/lexend": "5.3.0",
     "@larksuiteoapi/node-sdk": "^1.59.0",
     "ai": "^6.0.57",
     "fflate": "^0.8.2",
@@ -142,6 +141,7 @@
   "devDependencies": {
     "@earendil-works/pi-agent-core": "0.83.0",
     "@earendil-works/pi-ai": "0.83.0",
+    "@fontsource-variable/lexend": "5.3.0",
     "@electron/rebuild": "^4.0.3",
     "@langfuse/otel": "^5.10.0",
     "@langfuse/tracing": "^5.10.0",

--- a/apps/canvas-workspace/src/renderer/src/components/artifacts/artifacts.css
+++ b/apps/canvas-workspace/src/renderer/src/components/artifacts/artifacts.css
@@ -190,7 +190,7 @@
 
 .chat-inline-visual__btn--primary {
   color: #37352f;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .chat-inline-visual__header {
@@ -205,7 +205,7 @@
 
 .chat-inline-visual__label {
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: #8a8a87;
@@ -309,7 +309,7 @@
 
 .chat-inline-visual__mermaid-error-title {
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: #8b2f2a;
   margin-bottom: 4px;
 }
@@ -387,7 +387,7 @@
 .chat-artifact-card__title {
   display: block;
   font-size: 13px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: #37352f;
   white-space: nowrap;
   overflow: hidden;
@@ -439,7 +439,7 @@
 
 .artifact-drawer__type-badge {
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: #6b6b68;
@@ -555,7 +555,7 @@
 
 .artifact-drawer__mermaid-error-title {
   font-size: 13px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: #8b2f2a;
   margin-bottom: 6px;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/artifacts/artifacts.css
+++ b/apps/canvas-workspace/src/renderer/src/components/artifacts/artifacts.css
@@ -190,7 +190,7 @@
 
 .chat-inline-visual__btn--primary {
   color: #37352f;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
 }
 
 .chat-inline-visual__header {
@@ -205,7 +205,7 @@
 
 .chat-inline-visual__label {
   font-size: 11px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: #8a8a87;
@@ -309,13 +309,13 @@
 
 .chat-inline-visual__mermaid-error-title {
   font-size: 12px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: #8b2f2a;
   margin-bottom: 4px;
 }
 
 .chat-inline-visual__mermaid-error-detail {
-  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+  font-family: var(--font-mono);
   font-size: 11px;
   color: rgba(139, 47, 42, 0.85);
   white-space: pre-wrap;
@@ -387,7 +387,7 @@
 .chat-artifact-card__title {
   display: block;
   font-size: 13px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: #37352f;
   white-space: nowrap;
   overflow: hidden;
@@ -439,7 +439,7 @@
 
 .artifact-drawer__type-badge {
   font-size: 10px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: #6b6b68;
@@ -555,13 +555,13 @@
 
 .artifact-drawer__mermaid-error-title {
   font-size: 13px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: #8b2f2a;
   margin-bottom: 6px;
 }
 
 .artifact-drawer__mermaid-error-detail {
-  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+  font-family: var(--font-mono);
   font-size: 12px;
   color: rgba(139, 47, 42, 0.85);
   white-space: pre-wrap;

--- a/apps/canvas-workspace/src/renderer/src/components/canvas/Canvas/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/canvas/Canvas/index.css
@@ -216,7 +216,7 @@
 }
 
 .canvas-gesture-hud__main {
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .canvas-gesture-hud__meta {
@@ -231,7 +231,7 @@
   background: rgba(35, 131, 226, 0.1);
   color: var(--accent);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 /* Focus-mode backdrop. Lives inside `.canvas-transform` (see

--- a/apps/canvas-workspace/src/renderer/src/components/canvas/Canvas/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/canvas/Canvas/index.css
@@ -216,7 +216,7 @@
 }
 
 .canvas-gesture-hud__main {
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
 }
 
 .canvas-gesture-hud__meta {
@@ -231,7 +231,7 @@
   background: rgba(35, 131, 226, 0.1);
   color: var(--accent);
   font-size: 10px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
 }
 
 /* Focus-mode backdrop. Lives inside `.canvas-transform` (see

--- a/apps/canvas-workspace/src/renderer/src/components/canvas/CanvasEmptyHint/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/canvas/CanvasEmptyHint/index.css
@@ -40,7 +40,7 @@
   margin-bottom: 6px;
   color: var(--accent);
   font-size: 10px;
-  font-weight: 800;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -49,7 +49,7 @@
   margin: 0 0 8px;
   color: var(--text);
   font-size: 20px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
 }
 
 .hint-sub {
@@ -92,7 +92,7 @@
   margin-bottom: 10px;
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
@@ -117,7 +117,7 @@
 
 .canvas-empty-action__label {
   font-size: 13px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
 }
 
 .canvas-empty-action__description {

--- a/apps/canvas-workspace/src/renderer/src/components/canvas/CanvasEmptyHint/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/canvas/CanvasEmptyHint/index.css
@@ -40,7 +40,7 @@
   margin-bottom: 6px;
   color: var(--accent);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -49,7 +49,7 @@
   margin: 0 0 8px;
   color: var(--text);
   font-size: 20px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .hint-sub {
@@ -92,7 +92,7 @@
   margin-bottom: 10px;
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
@@ -117,7 +117,7 @@
 
 .canvas-empty-action__label {
   font-size: 13px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .canvas-empty-action__description {

--- a/apps/canvas-workspace/src/renderer/src/components/canvas/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/canvas/CanvasNodeView/index.css
@@ -160,7 +160,7 @@
   background: transparent;
   color: var(--accent);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -196,7 +196,7 @@
 .canvas-node--file>.node-header .node-title {
   flex: 1 1 auto;
   min-width: 0;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   font-size: 18px;
   line-height: 1.3;
   color: var(--text);
@@ -544,7 +544,7 @@
 .reference-node-missing__title {
   color: var(--text);
   font-size: 13px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .reference-node-missing__meta {
@@ -655,7 +655,7 @@
   flex: 1;
   font-family: var(--font-ui);
   font-size: 13px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   outline: none;
   white-space: nowrap;
   overflow: hidden;
@@ -677,7 +677,7 @@
 /* Agent status label pill */
 .node-status-label {
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.02em;
   padding: 1px 6px;
   border-radius: var(--radius-pill);
@@ -818,7 +818,7 @@
   border-radius: var(--radius-pill);
   padding: 2px 7px;
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1.2;
   letter-spacing: 0;
 }
@@ -1298,7 +1298,7 @@
   flex: 0 1 auto;
   max-width: 120px;
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: color-mix(in srgb, var(--group-color, #A594E0) 68%, #111111);
   padding: 0 2px;
   letter-spacing: 0;
@@ -1326,7 +1326,7 @@
   color: color-mix(in srgb, var(--group-color, #A594E0) 74%, #111111);
   cursor: pointer;
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1;
   padding: 4px 7px;
   transition: background 0.12s ease, color 0.12s ease;
@@ -1355,7 +1355,7 @@
   padding: 0 5px;
   border-radius: var(--radius-pill);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: color-mix(in srgb, var(--group-color, #A594E0) 75%, #111111);
   background: color-mix(in srgb, var(--group-color, #A594E0) 14%, transparent);
 }
@@ -1400,7 +1400,7 @@
   top: -22px;
   left: 0;
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.03em;
   text-transform: uppercase;
   color: #7c5cff;

--- a/apps/canvas-workspace/src/renderer/src/components/canvas/CanvasNodeView/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/canvas/CanvasNodeView/index.css
@@ -160,7 +160,7 @@
   background: transparent;
   color: var(--accent);
   font-size: 10px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -196,7 +196,7 @@
 .canvas-node--file>.node-header .node-title {
   flex: 1 1 auto;
   min-width: 0;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   font-size: 18px;
   line-height: 1.3;
   color: var(--text);
@@ -544,7 +544,7 @@
 .reference-node-missing__title {
   color: var(--text);
   font-size: 13px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
 }
 
 .reference-node-missing__meta {
@@ -655,7 +655,7 @@
   flex: 1;
   font-family: var(--font-ui);
   font-size: 13px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   outline: none;
   white-space: nowrap;
   overflow: hidden;
@@ -677,7 +677,7 @@
 /* Agent status label pill */
 .node-status-label {
   font-size: 10px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.02em;
   padding: 1px 6px;
   border-radius: var(--radius-pill);
@@ -818,7 +818,7 @@
   border-radius: var(--radius-pill);
   padding: 2px 7px;
   font-size: 10px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   line-height: 1.2;
   letter-spacing: 0;
 }
@@ -1298,7 +1298,7 @@
   flex: 0 1 auto;
   max-width: 120px;
   font-size: 11px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: color-mix(in srgb, var(--group-color, #A594E0) 68%, #111111);
   padding: 0 2px;
   letter-spacing: 0;
@@ -1326,7 +1326,7 @@
   color: color-mix(in srgb, var(--group-color, #A594E0) 74%, #111111);
   cursor: pointer;
   font-size: 10px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   line-height: 1;
   padding: 4px 7px;
   transition: background 0.12s ease, color 0.12s ease;
@@ -1355,7 +1355,7 @@
   padding: 0 5px;
   border-radius: var(--radius-pill);
   font-size: 10px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: color-mix(in srgb, var(--group-color, #A594E0) 75%, #111111);
   background: color-mix(in srgb, var(--group-color, #A594E0) 14%, transparent);
 }
@@ -1400,7 +1400,7 @@
   top: -22px;
   left: 0;
   font-size: 10px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.03em;
   text-transform: uppercase;
   color: #7c5cff;

--- a/apps/canvas-workspace/src/renderer/src/components/canvas/CommandPalette/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/canvas/CommandPalette/index.css
@@ -75,7 +75,7 @@
 .command-palette-section-label {
   padding: 8px 18px 4px;
   font-size: 10px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.6px;
   text-transform: uppercase;
   color: var(--text-muted);
@@ -147,7 +147,7 @@
 
 .command-palette-badge {
   font-size: 10px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   text-transform: uppercase;
   padding: 2px 6px;
   border-radius: var(--radius-xs);

--- a/apps/canvas-workspace/src/renderer/src/components/canvas/CommandPalette/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/canvas/CommandPalette/index.css
@@ -75,7 +75,7 @@
 .command-palette-section-label {
   padding: 8px 18px 4px;
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.6px;
   text-transform: uppercase;
   color: var(--text-muted);
@@ -147,7 +147,7 @@
 
 .command-palette-badge {
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-transform: uppercase;
   padding: 2px 6px;
   border-radius: var(--radius-xs);

--- a/apps/canvas-workspace/src/renderer/src/components/canvas/FloatingToolbar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/canvas/FloatingToolbar/index.css
@@ -306,7 +306,7 @@
   overflow: hidden;
   color: var(--text);
   font-size: 12px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
   line-height: 1.15;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -365,7 +365,7 @@
     background: rgba(255, 255, 255, 0.98);
     color: var(--accent);
     font-size: 11px;
-    font-weight: 600;
+    font-weight: var(--font-weight-medium);
     line-height: 1;
     white-space: nowrap;
     box-shadow:

--- a/apps/canvas-workspace/src/renderer/src/components/canvas/FloatingToolbar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/canvas/FloatingToolbar/index.css
@@ -306,7 +306,7 @@
   overflow: hidden;
   color: var(--text);
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1.15;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -365,7 +365,7 @@
     background: rgba(255, 255, 255, 0.98);
     color: var(--accent);
     font-size: 11px;
-    font-weight: var(--font-weight-medium);
+    font-weight: 500;
     line-height: 1;
     white-space: nowrap;
     box-shadow:

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.css
@@ -245,7 +245,7 @@
   overflow: hidden;
   color: var(--text-secondary);
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -456,7 +456,7 @@
   overflow: hidden;
   color: var(--text);
   font-size: 13px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPage.css
@@ -245,7 +245,7 @@
   overflow: hidden;
   color: var(--text-secondary);
   font-size: 11px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -456,7 +456,7 @@
   overflow: hidden;
   color: var(--text);
   font-size: 13px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
@@ -37,7 +37,7 @@
   gap: 8px;
   max-width: 280px;
   font-size: 14px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: #37352f;
   border: none;
   background: transparent;
@@ -320,7 +320,7 @@
 .chat-empty-greeting {
   font-size: 20px;
   line-height: 1.25;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   color: #37352f;
   margin-bottom: 22px;
   letter-spacing: 0;
@@ -934,7 +934,7 @@
 }
 
 .chat-context-chip-hash {
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   font-size: 12px;
   color: #8a8780;
 }
@@ -1055,7 +1055,7 @@
 
 .chat-clarify-label {
   font-size: 11px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: #8a8a87;
@@ -1156,7 +1156,7 @@
 .chat-md h3,
 .chat-md h4 {
   margin: 12px 0 4px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   line-height: 1.4;
 }
 
@@ -1187,7 +1187,7 @@
 }
 
 .chat-md code {
-  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+  font-family: var(--font-mono);
   font-size: 0.9em;
   background: rgba(55, 53, 47, 0.06);
   padding: 1px 4px;
@@ -1232,7 +1232,7 @@
 }
 
 .chat-md strong {
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
 }
 
 .chat-md table {
@@ -1251,7 +1251,7 @@
 
 .chat-md th {
   background: rgba(55, 53, 47, 0.04);
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
 }
 
 /* Tables can run wider than the panel; let them scroll instead of
@@ -1274,7 +1274,7 @@
   border-radius: var(--radius-md);
   background: #fafaf8;
   overflow: hidden;
-  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+  font-family: var(--font-mono);
 }
 
 .chat-code-block-header {
@@ -1292,7 +1292,7 @@
 .chat-code-block-lang {
   text-transform: lowercase;
   letter-spacing: 0.04em;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
 }
 
 .chat-code-block-copy {
@@ -1300,7 +1300,7 @@
   background: transparent;
   color: rgba(55, 53, 47, 0.5);
   font-size: 11px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   padding: 2px 8px;
   border-radius: var(--radius-xs);
   cursor: pointer;
@@ -1402,7 +1402,7 @@
 }
 
 .hljs-strong {
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
 }
 
 /* ─── Per-message hover toolbar (timestamp + copy / edit / regen) ── */
@@ -1471,7 +1471,7 @@
   background: #fff;
   color: rgba(55, 53, 47, 0.55);
   font-size: 11px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   padding: 3px 9px;
   border-radius: var(--radius-sm);
   cursor: pointer;
@@ -1601,13 +1601,13 @@
 
 .chat-mermaid-error-title {
   font-size: 12px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: #8b2f2a;
   margin-bottom: 4px;
 }
 
 .chat-mermaid-error-detail {
-  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+  font-family: var(--font-mono);
   font-size: 11px;
   color: rgba(139, 47, 42, 0.85);
   white-space: pre-wrap;
@@ -1795,7 +1795,7 @@
 }
 
 .chat-tool-call-sig {
-  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', Menlo, monospace;
+  font-family: var(--font-mono);
   font-size: 11.5px;
   color: rgba(55, 53, 47, 0.55);
   overflow: hidden;
@@ -1845,7 +1845,7 @@
 
 .chat-tool-call-result pre {
   margin: 0;
-  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', Menlo, monospace;
+  font-family: var(--font-mono);
   font-size: 11px;
   line-height: 1.5;
   color: rgba(55, 53, 47, 0.6);
@@ -1860,7 +1860,7 @@
 }
 
 .chat-tool-call-section-label {
-  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', Menlo, monospace;
+  font-family: var(--font-mono);
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -1905,7 +1905,7 @@
 }
 
 .chat-session-ref-name {
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: rgba(55, 53, 47, 0.85);
   white-space: nowrap;
 }
@@ -2030,7 +2030,7 @@
 .chat-mention-group-header {
   padding: 10px 10px 4px;
   font-size: 10px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   text-transform: uppercase;
   letter-spacing: 0.6px;
   color: rgba(55, 53, 47, 0.4);
@@ -2308,7 +2308,7 @@
 }
 
 .chat-mention-chip-hash {
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   font-size: 11px;
   line-height: 1;
 }
@@ -2464,7 +2464,7 @@
 .chat-attachment-retry {
   color: var(--accent);
   font-size: 11px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
 }
 
 .chat-attachment-retry:disabled,
@@ -2790,7 +2790,7 @@
   align-items: center;
   gap: 6px;
   font-size: 12px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
   cursor: pointer;
   /* Wide enough for "provider / model" — the old 132px cut a bare model name
      to a few characters, which is the whole reason the provider had to be
@@ -2951,14 +2951,14 @@
   padding: 9px 9px 5px;
   font-size: 10px;
   line-height: 1;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.055em;
   text-transform: uppercase;
   color: rgba(55, 53, 47, 0.42);
 }
 
 .chat-model-menu-provider-head span:last-child {
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0;
   text-transform: none;
   color: rgba(55, 53, 47, 0.34);
@@ -3018,7 +3018,7 @@
 
 .chat-model-menu-title {
   font-size: 13px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
 }
 
 .chat-model-menu-subtitle,
@@ -3043,7 +3043,7 @@
 .chat-model-menu-action {
   justify-content: center;
   font-size: 12px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
   color: #2383e2;
 }
 
@@ -3181,7 +3181,7 @@
   gap: 5px;
   align-self: flex-start;
   font-size: 11px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   line-height: 1.4;
   margin: 1px 0 4px;
   padding: 1.5px 9px 1.5px 7px;
@@ -3201,7 +3201,7 @@
 /* Role reply avatar: colored initial instead of the default bot mark. */
 .chat-message-avatar--role {
   border: none;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   font-size: 12.5px;
   line-height: 1;
   user-select: none;
@@ -3245,7 +3245,7 @@
 }
 
 .chat-relay-step--speaking {
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
 }
 
 /* Auto-appended (agent@agent) queue entries: dashed underline + a "由 X
@@ -3399,7 +3399,7 @@
 
 .chat-turn-outcome__status {
   color: var(--text);
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
 }
 
 .chat-turn-outcome__description {
@@ -3470,7 +3470,7 @@
 
 .chat-turn-context__reference-label {
   flex-shrink: 0;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
 }
 
 .chat-turn-context__chips {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
@@ -37,7 +37,7 @@
   gap: 8px;
   max-width: 280px;
   font-size: 14px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: #37352f;
   border: none;
   background: transparent;
@@ -320,7 +320,7 @@
 .chat-empty-greeting {
   font-size: 20px;
   line-height: 1.25;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: #37352f;
   margin-bottom: 22px;
   letter-spacing: 0;
@@ -934,7 +934,7 @@
 }
 
 .chat-context-chip-hash {
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   font-size: 12px;
   color: #8a8780;
 }
@@ -1055,7 +1055,7 @@
 
 .chat-clarify-label {
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: #8a8a87;
@@ -1156,7 +1156,7 @@
 .chat-md h3,
 .chat-md h4 {
   margin: 12px 0 4px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1.4;
 }
 
@@ -1232,7 +1232,7 @@
 }
 
 .chat-md strong {
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .chat-md table {
@@ -1251,7 +1251,7 @@
 
 .chat-md th {
   background: rgba(55, 53, 47, 0.04);
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 /* Tables can run wider than the panel; let them scroll instead of
@@ -1292,7 +1292,7 @@
 .chat-code-block-lang {
   text-transform: lowercase;
   letter-spacing: 0.04em;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .chat-code-block-copy {
@@ -1300,7 +1300,7 @@
   background: transparent;
   color: rgba(55, 53, 47, 0.5);
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   padding: 2px 8px;
   border-radius: var(--radius-xs);
   cursor: pointer;
@@ -1402,7 +1402,7 @@
 }
 
 .hljs-strong {
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 /* ─── Per-message hover toolbar (timestamp + copy / edit / regen) ── */
@@ -1471,7 +1471,7 @@
   background: #fff;
   color: rgba(55, 53, 47, 0.55);
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   padding: 3px 9px;
   border-radius: var(--radius-sm);
   cursor: pointer;
@@ -1601,7 +1601,7 @@
 
 .chat-mermaid-error-title {
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: #8b2f2a;
   margin-bottom: 4px;
 }
@@ -1905,7 +1905,7 @@
 }
 
 .chat-session-ref-name {
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: rgba(55, 53, 47, 0.85);
   white-space: nowrap;
 }
@@ -2030,7 +2030,7 @@
 .chat-mention-group-header {
   padding: 10px 10px 4px;
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.6px;
   color: rgba(55, 53, 47, 0.4);
@@ -2308,7 +2308,7 @@
 }
 
 .chat-mention-chip-hash {
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   font-size: 11px;
   line-height: 1;
 }
@@ -2464,7 +2464,7 @@
 .chat-attachment-retry {
   color: var(--accent);
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .chat-attachment-retry:disabled,
@@ -2790,7 +2790,7 @@
   align-items: center;
   gap: 6px;
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   cursor: pointer;
   /* Wide enough for "provider / model" — the old 132px cut a bare model name
      to a few characters, which is the whole reason the provider had to be
@@ -2951,14 +2951,14 @@
   padding: 9px 9px 5px;
   font-size: 10px;
   line-height: 1;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.055em;
   text-transform: uppercase;
   color: rgba(55, 53, 47, 0.42);
 }
 
 .chat-model-menu-provider-head span:last-child {
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0;
   text-transform: none;
   color: rgba(55, 53, 47, 0.34);
@@ -3018,7 +3018,7 @@
 
 .chat-model-menu-title {
   font-size: 13px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .chat-model-menu-subtitle,
@@ -3043,7 +3043,7 @@
 .chat-model-menu-action {
   justify-content: center;
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: #2383e2;
 }
 
@@ -3181,7 +3181,7 @@
   gap: 5px;
   align-self: flex-start;
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1.4;
   margin: 1px 0 4px;
   padding: 1.5px 9px 1.5px 7px;
@@ -3201,7 +3201,7 @@
 /* Role reply avatar: colored initial instead of the default bot mark. */
 .chat-message-avatar--role {
   border: none;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   font-size: 12.5px;
   line-height: 1;
   user-select: none;
@@ -3245,7 +3245,7 @@
 }
 
 .chat-relay-step--speaking {
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 /* Auto-appended (agent@agent) queue entries: dashed underline + a "由 X
@@ -3399,7 +3399,7 @@
 
 .chat-turn-outcome__status {
   color: var(--text);
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .chat-turn-outcome__description {
@@ -3470,7 +3470,7 @@
 
 .chat-turn-context__reference-label {
   flex-shrink: 0;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .chat-turn-context__chips {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ModelCatalog/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ModelCatalog/index.css
@@ -17,7 +17,7 @@
 
 .chat-model-catalog-head strong {
   font-size: 12px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
 }
 
 .chat-model-catalog-head span {
@@ -85,7 +85,7 @@
   background: var(--surface);
   color: var(--accent);
   font-size: 11px;
-  font-weight: 800;
+  font-weight: var(--font-weight-medium);
   flex-shrink: 0;
 }
 
@@ -106,7 +106,7 @@
 .chat-model-model-row-copy strong {
   color: var(--text);
   font-size: 12px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
 }
 
 .chat-model-model-row-copy small {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ModelCatalog/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ModelCatalog/index.css
@@ -17,7 +17,7 @@
 
 .chat-model-catalog-head strong {
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .chat-model-catalog-head span {
@@ -85,7 +85,7 @@
   background: var(--surface);
   color: var(--accent);
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   flex-shrink: 0;
 }
 
@@ -106,7 +106,7 @@
 .chat-model-model-row-copy strong {
   color: var(--text);
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .chat-model-model-row-copy small {

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ModelSettings.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ModelSettings.css
@@ -70,7 +70,7 @@
 
 .chat-model-provider-tab-text strong {
   font-size: 13px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .chat-model-provider-tab-text small {
@@ -158,7 +158,7 @@
 
 .chat-model-preset__title {
   font-size: 13px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .chat-model-preset__description {
@@ -175,7 +175,7 @@
 
 .chat-model-field span {
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: rgba(55, 53, 47, 0.55);
 }
 
@@ -257,7 +257,7 @@
 
 .chat-model-field .chat-model-protocol-title {
   font-size: 13px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: #37352f;
   letter-spacing: 0;
   text-transform: none;
@@ -300,7 +300,7 @@
   color: #37352f;
   padding: 0 11px;
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   cursor: pointer;
   display: inline-flex;
   align-items: center;

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ModelSettings.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ModelSettings.css
@@ -70,7 +70,7 @@
 
 .chat-model-provider-tab-text strong {
   font-size: 13px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
 }
 
 .chat-model-provider-tab-text small {
@@ -158,7 +158,7 @@
 
 .chat-model-preset__title {
   font-size: 13px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
 }
 
 .chat-model-preset__description {
@@ -175,7 +175,7 @@
 
 .chat-model-field span {
   font-size: 11px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   color: rgba(55, 53, 47, 0.55);
 }
 
@@ -257,14 +257,14 @@
 
 .chat-model-field .chat-model-protocol-title {
   font-size: 13px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
   color: #37352f;
   letter-spacing: 0;
   text-transform: none;
 }
 
 .chat-model-field .chat-model-protocol-sub {
-  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', Menlo, monospace;
+  font-family: var(--font-mono);
   font-size: 11px;
   color: rgba(55, 53, 47, 0.5);
   font-weight: 500;
@@ -300,7 +300,7 @@
   color: #37352f;
   padding: 0 11px;
   font-size: 12px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
   cursor: pointer;
   display: inline-flex;
   align-items: center;

--- a/apps/canvas-workspace/src/renderer/src/components/chat/RolesSettings.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/RolesSettings.css
@@ -63,7 +63,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   font-size: 12px;
   flex-shrink: 0;
   user-select: none;
@@ -78,7 +78,7 @@
 
 .chat-roles-row-name {
   font-size: 12.5px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: var(--text);
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/chat/RolesSettings.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/RolesSettings.css
@@ -63,7 +63,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   font-size: 12px;
   flex-shrink: 0;
   user-select: none;
@@ -78,7 +78,7 @@
 
 .chat-roles-row-name {
   font-size: 12.5px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: var(--text);
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/dock/LinkDrawer/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/LinkDrawer/index.css
@@ -79,7 +79,7 @@
 
 .link-drawer__suggestion-copy strong {
   font-size: 12px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: var(--text);
   white-space: nowrap;
   overflow: hidden;

--- a/apps/canvas-workspace/src/renderer/src/components/dock/LinkDrawer/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/LinkDrawer/index.css
@@ -79,7 +79,7 @@
 
 .link-drawer__suggestion-copy strong {
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: var(--text);
   white-space: nowrap;
   overflow: hidden;

--- a/apps/canvas-workspace/src/renderer/src/components/dock/ReferenceDrawer/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/ReferenceDrawer/index.css
@@ -106,7 +106,7 @@
 .reference-drawer-kicker {
   color: var(--text-muted);
   font-size: 9px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.04em;
   text-transform: none;
 }
@@ -114,7 +114,7 @@
 .reference-drawer-header h2 {
   margin-top: 1px;
   font-size: 13px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1.2;
   color: var(--text);
   letter-spacing: -0.01em;
@@ -157,7 +157,7 @@
   background: var(--surface);
   color: var(--text);
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   cursor: pointer;
   white-space: nowrap;
   transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease, opacity 0.12s ease;
@@ -225,7 +225,7 @@
 .reference-workspace-picker-label {
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .reference-workspace-select {
@@ -244,7 +244,7 @@
     var(--surface);
   color: var(--text);
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   cursor: pointer;
   text-align: left;
   transition:
@@ -335,7 +335,7 @@
 .reference-workspace-option--selected {
   background: rgba(35, 131, 226, 0.1);
   color: var(--accent);
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .reference-workspace-option-check {
@@ -418,7 +418,7 @@
 .reference-picker-item-type {
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   min-width: 44px;
@@ -464,7 +464,7 @@
 .reference-url-label {
   color: var(--text-secondary);
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .reference-url-input {
@@ -545,7 +545,7 @@
   background: transparent;
   color: var(--text-secondary);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-align: left;
   cursor: pointer;
   text-transform: none;
@@ -581,7 +581,7 @@
   background: rgba(0, 0, 0, 0.045);
   color: var(--text-secondary);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1;
   flex: 0 0 auto;
 }
@@ -685,7 +685,7 @@
   background: rgba(0, 0, 0, 0.035);
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -694,7 +694,7 @@
 .reference-group-item-type {
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   max-width: 70px;
@@ -784,7 +784,7 @@
   border-radius: 5px;
   padding: 4px 7px;
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   cursor: pointer;
   white-space: nowrap;
   transition: background 0.12s ease, color 0.12s ease, opacity 0.12s ease;
@@ -863,7 +863,7 @@
 .reference-selected-hint span {
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-transform: none;
   letter-spacing: 0;
 }
@@ -871,7 +871,7 @@
 .reference-selected-hint strong {
   color: var(--text);
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -990,7 +990,7 @@
 .reference-url-card-kicker {
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
@@ -999,7 +999,7 @@
   margin: 4px 0 10px;
   color: var(--text);
   font-size: 18px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1.25;
   word-break: break-word;
 }
@@ -1096,7 +1096,7 @@
 .reference-artifact-type {
   flex: none;
   font-size: 9px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.04em;
   padding: 1px 5px;
   border-radius: var(--radius-xs);
@@ -1106,7 +1106,7 @@
 
 .reference-artifact-title {
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/apps/canvas-workspace/src/renderer/src/components/dock/ReferenceDrawer/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/ReferenceDrawer/index.css
@@ -106,7 +106,7 @@
 .reference-drawer-kicker {
   color: var(--text-muted);
   font-size: 9px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.04em;
   text-transform: none;
 }
@@ -114,7 +114,7 @@
 .reference-drawer-header h2 {
   margin-top: 1px;
   font-size: 13px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
   line-height: 1.2;
   color: var(--text);
   letter-spacing: -0.01em;
@@ -157,7 +157,7 @@
   background: var(--surface);
   color: var(--text);
   font-size: 11px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   cursor: pointer;
   white-space: nowrap;
   transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease, opacity 0.12s ease;
@@ -225,7 +225,7 @@
 .reference-workspace-picker-label {
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
 }
 
 .reference-workspace-select {
@@ -244,7 +244,7 @@
     var(--surface);
   color: var(--text);
   font-size: 12px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   cursor: pointer;
   text-align: left;
   transition:
@@ -335,7 +335,7 @@
 .reference-workspace-option--selected {
   background: rgba(35, 131, 226, 0.1);
   color: var(--accent);
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
 }
 
 .reference-workspace-option-check {
@@ -418,7 +418,7 @@
 .reference-picker-item-type {
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   min-width: 44px;
@@ -464,7 +464,7 @@
 .reference-url-label {
   color: var(--text-secondary);
   font-size: 11px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
 }
 
 .reference-url-input {
@@ -545,7 +545,7 @@
   background: transparent;
   color: var(--text-secondary);
   font-size: 10px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   text-align: left;
   cursor: pointer;
   text-transform: none;
@@ -581,7 +581,7 @@
   background: rgba(0, 0, 0, 0.045);
   color: var(--text-secondary);
   font-size: 10px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   line-height: 1;
   flex: 0 0 auto;
 }
@@ -685,7 +685,7 @@
   background: rgba(0, 0, 0, 0.035);
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -694,7 +694,7 @@
 .reference-group-item-type {
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   max-width: 70px;
@@ -784,7 +784,7 @@
   border-radius: 5px;
   padding: 4px 7px;
   font-size: 11px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   cursor: pointer;
   white-space: nowrap;
   transition: background 0.12s ease, color 0.12s ease, opacity 0.12s ease;
@@ -863,7 +863,7 @@
 .reference-selected-hint span {
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   text-transform: none;
   letter-spacing: 0;
 }
@@ -871,7 +871,7 @@
 .reference-selected-hint strong {
   color: var(--text);
   font-size: 12px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -990,7 +990,7 @@
 .reference-url-card-kicker {
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
@@ -999,7 +999,7 @@
   margin: 4px 0 10px;
   color: var(--text);
   font-size: 18px;
-  font-weight: 680;
+  font-weight: var(--font-weight-medium);
   line-height: 1.25;
   word-break: break-word;
 }
@@ -1096,7 +1096,7 @@
 .reference-artifact-type {
   flex: none;
   font-size: 9px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.04em;
   padding: 1px 5px;
   border-radius: var(--radius-xs);
@@ -1106,7 +1106,7 @@
 
 .reference-artifact-title {
   font-size: 12px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/canvas-preview.css
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/canvas-preview.css
@@ -76,7 +76,7 @@
   padding: 2px 6px;
   color: var(--text-secondary);
   font-size: 11px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
   line-height: 1;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/canvas-preview.css
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/canvas-preview.css
@@ -76,7 +76,7 @@
   padding: 2px 6px;
   color: var(--text-secondary);
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/index.css
@@ -292,7 +292,7 @@
   background: transparent;
   border-color: transparent;
   color: #37352f;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   transform: translateY(-1px);
   animation: right-dock-tab-rise 0.22s var(--tab-ease);
 }
@@ -595,7 +595,7 @@
   background: var(--surface);
   color: var(--text);
   font-size: 11px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   line-height: 1;
   white-space: nowrap;
   box-shadow: var(--shadow-float);

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/index.css
@@ -292,7 +292,7 @@
   background: transparent;
   border-color: transparent;
   color: #37352f;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   transform: translateY(-1px);
   animation: right-dock-tab-rise 0.22s var(--tab-ease);
 }
@@ -595,7 +595,7 @@
   background: var(--surface);
   color: var(--text);
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1;
   white-space: nowrap;
   box-shadow: var(--shadow-float);

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/node-dock-picker.css
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/node-dock-picker.css
@@ -8,7 +8,7 @@
 .node-dock-picker__item--disabled { opacity: 0.5; cursor: not-allowed; }
 .node-dock-picker__item--disabled:hover { background: transparent; }
 .node-dock-picker__copy { min-width: 0; flex: 1; display: flex; flex-direction: column; gap: 2px; }
-.node-dock-picker__copy strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; font-weight: var(--font-weight-medium); }
+.node-dock-picker__copy strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; font-weight: 500; }
 .node-dock-picker__copy small, .node-dock-picker__tags { color: var(--text-muted); font-size: 11px; }
 .node-dock-picker__tags { max-width: 150px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .node-dock-picker__empty { padding: 28px 16px; text-align: center; color: var(--text-muted); font-size: 13px; }

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/node-dock-picker.css
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/node-dock-picker.css
@@ -8,7 +8,7 @@
 .node-dock-picker__item--disabled { opacity: 0.5; cursor: not-allowed; }
 .node-dock-picker__item--disabled:hover { background: transparent; }
 .node-dock-picker__copy { min-width: 0; flex: 1; display: flex; flex-direction: column; gap: 2px; }
-.node-dock-picker__copy strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; font-weight: 600; }
+.node-dock-picker__copy strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; font-weight: var(--font-weight-medium); }
 .node-dock-picker__copy small, .node-dock-picker__tags { color: var(--text-muted); font-size: 11px; }
 .node-dock-picker__tags { max-width: 150px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .node-dock-picker__empty { padding: 28px 16px; text-align: center; color: var(--text-muted); font-size: 13px; }

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/skill-detail.css
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/skill-detail.css
@@ -23,7 +23,7 @@
 .skill-detail__label {
   color: var(--text-muted);
   font-size: 9px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -32,7 +32,7 @@
   margin: 16px 0 0;
   color: var(--text);
   font-size: 18px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
 }
 
 .skill-detail__description {
@@ -131,7 +131,7 @@
 .skill-detail__markdown h4 {
   margin: 1.6em 0 0.55em;
   color: var(--text);
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
   line-height: 1.3;
 }
 
@@ -248,7 +248,7 @@
 .skill-detail__markdown th {
   color: var(--text);
   background: var(--bg);
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
   white-space: nowrap;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/skill-detail.css
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/skill-detail.css
@@ -23,7 +23,7 @@
 .skill-detail__label {
   color: var(--text-muted);
   font-size: 9px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -32,7 +32,7 @@
   margin: 16px 0 0;
   color: var(--text);
   font-size: 18px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .skill-detail__description {
@@ -131,7 +131,7 @@
 .skill-detail__markdown h4 {
   margin: 1.6em 0 0.55em;
   color: var(--text);
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1.3;
 }
 
@@ -248,7 +248,7 @@
 .skill-detail__markdown th {
   color: var(--text);
   background: var(--bg);
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   white-space: nowrap;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/terminal-tab.css
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/terminal-tab.css
@@ -36,7 +36,7 @@
   color: #37352f;
   font: inherit;
   font-size: 12px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   line-height: 20px;
   padding: 0 5px;
   outline: none;

--- a/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/terminal-tab.css
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/RightDock/terminal-tab.css
@@ -36,7 +36,7 @@
   color: #37352f;
   font: inherit;
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 20px;
   padding: 0 5px;
   outline: none;

--- a/apps/canvas-workspace/src/renderer/src/components/dock/WorkspaceTerminalDock/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/WorkspaceTerminalDock/index.css
@@ -97,7 +97,7 @@
 
 .workspace-terminal-dock__title strong {
   font-size: 12px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
 }
 
 .workspace-terminal-dock--pane .workspace-terminal-dock__title strong {
@@ -254,7 +254,7 @@
   background: rgba(236, 253, 245, 0.76);
   color: #0f766e;
   font: inherit;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
 }
 
 .workspace-terminal-dock__mention-hint-close {

--- a/apps/canvas-workspace/src/renderer/src/components/dock/WorkspaceTerminalDock/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/dock/WorkspaceTerminalDock/index.css
@@ -97,7 +97,7 @@
 
 .workspace-terminal-dock__title strong {
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .workspace-terminal-dock--pane .workspace-terminal-dock__title strong {
@@ -254,7 +254,7 @@
   background: rgba(236, 253, 245, 0.76);
   color: #0f766e;
   font: inherit;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .workspace-terminal-dock__mention-hint-close {

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/AgentNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/AgentNodeBody/index.css
@@ -27,10 +27,7 @@
   --agent-success: #10b981;
   --agent-success-soft: rgba(16, 185, 129, 0.12);
   --agent-danger: #e03e3e;
-  --agent-sans:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC",
-    "Hiragino Sans", "Microsoft YaHei", Roboto, "Helvetica Neue", Arial,
-    sans-serif;
+  --agent-sans: var(--font-sans);
 }
 
 .agent-body-wrap {
@@ -112,7 +109,7 @@
   border-radius: var(--radius-sm);
   background: rgba(255, 255, 255, 0.92);
   color: var(--agent-muted);
-  font: 700 11px var(--agent-sans);
+  font: var(--font-weight-medium) 11px var(--agent-sans);
   cursor: pointer;
   padding: 0 8px;
 }
@@ -159,7 +156,7 @@
 .agent-team-lead-console__header span {
   color: var(--agent-accent);
   font-size: 10px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0;
   text-transform: uppercase;
 }
@@ -168,7 +165,7 @@
   overflow: hidden;
   color: var(--agent-text);
   font-size: 12px;
-  font-weight: 800;
+  font-weight: var(--font-weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -181,7 +178,7 @@
   color: #285b95;
   padding: 3px 8px;
   font-size: 10px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   text-transform: capitalize;
 }
 
@@ -258,7 +255,7 @@
   overflow: hidden;
   color: var(--agent-text);
   font-size: 14px;
-  font-weight: 800;
+  font-weight: var(--font-weight-medium);
   line-height: 1.25;
   letter-spacing: -0.01em;
   text-overflow: ellipsis;
@@ -275,7 +272,7 @@
   background: rgba(15, 23, 42, 0.05);
   color: var(--agent-muted);
   font-size: 10px;
-  font-weight: 800;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.02em;
 }
 
@@ -342,7 +339,7 @@
 .agent-team-managed__fact > span {
   color: var(--agent-muted);
   font-size: 10px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.03em;
   text-transform: uppercase;
 }
@@ -353,7 +350,7 @@
   color: var(--agent-text);
   font-family: var(--font-mono);
   font-size: 11px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   line-height: 1.45;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -366,7 +363,7 @@
   overflow: hidden;
   font-family: inherit;
   font-size: 12px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
   line-height: 1.4;
   white-space: normal;
   -webkit-box-orient: vertical;
@@ -389,7 +386,7 @@
   border-radius: var(--radius-md);
   background: rgba(35, 131, 226, 0.06);
   color: var(--agent-accent);
-  font: 800 12px var(--agent-sans);
+  font: var(--font-weight-medium) 12px var(--agent-sans);
   cursor: pointer;
   padding: 0 12px;
   transition: background 0.15s ease, border-color 0.15s ease;
@@ -417,7 +414,7 @@
   padding: 4px 10px;
   border-radius: var(--radius-pill);
   font-size: 11px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   font-family: var(--agent-sans);
   white-space: nowrap;
 }
@@ -469,7 +466,7 @@
 
 .agent-section-title {
   font-size: 13px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: var(--agent-text);
   font-family: var(--agent-sans);
 }
@@ -515,7 +512,7 @@
 .agent-team-lead-setup-summary span {
   color: var(--agent-muted);
   font-size: 10px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   text-transform: uppercase;
 }
 
@@ -525,7 +522,7 @@
   color: var(--agent-text);
   font-family: var(--font-mono);
   font-size: 11px;
-  font-weight: 750;
+  font-weight: var(--font-weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -625,7 +622,7 @@
 .agent-cli-warning strong {
   color: #6f3d00;
   font-size: 12px;
-  font-weight: 750;
+  font-weight: var(--font-weight-medium);
 }
 
 .agent-cli-warning .agent-text-link {
@@ -654,7 +651,7 @@
   overflow: hidden;
   color: var(--agent-text);
   font-size: 12px;
-  font-weight: 800;
+  font-weight: var(--font-weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -681,7 +678,7 @@
 .agent-install-command > span {
   color: var(--agent-muted);
   font-size: 10px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.02em;
   text-transform: uppercase;
 }
@@ -708,7 +705,7 @@
   border-radius: 7px;
   background: rgba(35, 131, 226, 0.06);
   color: var(--agent-accent);
-  font: 800 10.5px var(--agent-sans);
+  font: var(--font-weight-medium) 10.5px var(--agent-sans);
   cursor: pointer;
 }
 
@@ -784,7 +781,7 @@
 
 .agent-recent-label {
   font-size: 9px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   color: var(--agent-faint);
   letter-spacing: 0.5px;
   text-transform: uppercase;
@@ -877,7 +874,7 @@
   background: var(--agent-accent);
   color: #ffffff;
   font-size: 14px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   font-family: var(--agent-sans);
   cursor: pointer;
   flex-shrink: 0;
@@ -910,7 +907,7 @@
   background: var(--surface);
   color: var(--agent-accent);
   font-size: 13px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   font-family: var(--agent-sans);
   cursor: pointer;
   flex-shrink: 0;
@@ -987,7 +984,7 @@
 }
 
 .agent-info-load {
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
 }
 
 .agent-info-load-dot {
@@ -1231,7 +1228,7 @@
 .agent-saved-row-meta {
   font-size: 11px;
   color: var(--agent-accent);
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   font-family: var(--agent-sans);
 }
 
@@ -1305,7 +1302,7 @@
 
 .agent-details-label {
   font-size: 10px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.4px;
   text-transform: uppercase;
   color: var(--agent-faint);
@@ -1374,6 +1371,6 @@
   line-height: 1;
   background: rgba(55, 53, 47, 0.06);
   border-radius: var(--radius-xs);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: var(--font-mono);
   color: rgba(55, 53, 47, 0.7);
 }

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/AgentNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/AgentNodeBody/index.css
@@ -109,7 +109,7 @@
   border-radius: var(--radius-sm);
   background: rgba(255, 255, 255, 0.92);
   color: var(--agent-muted);
-  font: var(--font-weight-medium) 11px var(--agent-sans);
+  font: 500 11px var(--agent-sans);
   cursor: pointer;
   padding: 0 8px;
 }
@@ -156,7 +156,7 @@
 .agent-team-lead-console__header span {
   color: var(--agent-accent);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0;
   text-transform: uppercase;
 }
@@ -165,7 +165,7 @@
   overflow: hidden;
   color: var(--agent-text);
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -178,7 +178,7 @@
   color: #285b95;
   padding: 3px 8px;
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-transform: capitalize;
 }
 
@@ -255,7 +255,7 @@
   overflow: hidden;
   color: var(--agent-text);
   font-size: 14px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1.25;
   letter-spacing: -0.01em;
   text-overflow: ellipsis;
@@ -272,7 +272,7 @@
   background: rgba(15, 23, 42, 0.05);
   color: var(--agent-muted);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.02em;
 }
 
@@ -339,7 +339,7 @@
 .agent-team-managed__fact > span {
   color: var(--agent-muted);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.03em;
   text-transform: uppercase;
 }
@@ -350,7 +350,7 @@
   color: var(--agent-text);
   font-family: var(--font-mono);
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1.45;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -363,7 +363,7 @@
   overflow: hidden;
   font-family: inherit;
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1.4;
   white-space: normal;
   -webkit-box-orient: vertical;
@@ -386,7 +386,7 @@
   border-radius: var(--radius-md);
   background: rgba(35, 131, 226, 0.06);
   color: var(--agent-accent);
-  font: var(--font-weight-medium) 12px var(--agent-sans);
+  font: 500 12px var(--agent-sans);
   cursor: pointer;
   padding: 0 12px;
   transition: background 0.15s ease, border-color 0.15s ease;
@@ -414,7 +414,7 @@
   padding: 4px 10px;
   border-radius: var(--radius-pill);
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   font-family: var(--agent-sans);
   white-space: nowrap;
 }
@@ -466,7 +466,7 @@
 
 .agent-section-title {
   font-size: 13px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: var(--agent-text);
   font-family: var(--agent-sans);
 }
@@ -512,7 +512,7 @@
 .agent-team-lead-setup-summary span {
   color: var(--agent-muted);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-transform: uppercase;
 }
 
@@ -522,7 +522,7 @@
   color: var(--agent-text);
   font-family: var(--font-mono);
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -622,7 +622,7 @@
 .agent-cli-warning strong {
   color: #6f3d00;
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .agent-cli-warning .agent-text-link {
@@ -651,7 +651,7 @@
   overflow: hidden;
   color: var(--agent-text);
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -678,7 +678,7 @@
 .agent-install-command > span {
   color: var(--agent-muted);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.02em;
   text-transform: uppercase;
 }
@@ -705,7 +705,7 @@
   border-radius: 7px;
   background: rgba(35, 131, 226, 0.06);
   color: var(--agent-accent);
-  font: var(--font-weight-medium) 10.5px var(--agent-sans);
+  font: 500 10.5px var(--agent-sans);
   cursor: pointer;
 }
 
@@ -781,7 +781,7 @@
 
 .agent-recent-label {
   font-size: 9px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: var(--agent-faint);
   letter-spacing: 0.5px;
   text-transform: uppercase;
@@ -874,7 +874,7 @@
   background: var(--agent-accent);
   color: #ffffff;
   font-size: 14px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   font-family: var(--agent-sans);
   cursor: pointer;
   flex-shrink: 0;
@@ -907,7 +907,7 @@
   background: var(--surface);
   color: var(--agent-accent);
   font-size: 13px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   font-family: var(--agent-sans);
   cursor: pointer;
   flex-shrink: 0;
@@ -984,7 +984,7 @@
 }
 
 .agent-info-load {
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .agent-info-load-dot {
@@ -1228,7 +1228,7 @@
 .agent-saved-row-meta {
   font-size: 11px;
   color: var(--agent-accent);
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   font-family: var(--agent-sans);
 }
 
@@ -1302,7 +1302,7 @@
 
 .agent-details-label {
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.4px;
   text-transform: uppercase;
   color: var(--agent-faint);

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/AgentTeamFrame/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/AgentTeamFrame/index.css
@@ -35,7 +35,7 @@
   color: var(--text);
   cursor: pointer;
   padding: 0 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   white-space: nowrap;
 }
 
@@ -93,7 +93,7 @@
 
 .agent-team-frame__title {
   font-size: 14px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -101,7 +101,7 @@
 
 .agent-team-frame__phase-label {
   color: var(--text-secondary);
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .agent-team-frame__mission {
@@ -123,7 +123,7 @@
   background: rgba(238, 242, 247, 0.92);
   color: #3d5071;
   font-family: inherit;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   padding: 2px 7px;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -166,7 +166,7 @@
   color: #1f6f45;
   padding: 4px 9px;
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-transform: capitalize;
 }
 
@@ -223,7 +223,7 @@
   border-radius: var(--radius-pill);
   padding: 2px 7px;
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .agent-team-agent-pill__role--lead {
@@ -240,7 +240,7 @@
   min-width: 0;
   overflow: hidden;
   color: var(--text);
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-overflow: ellipsis;
 }
 
@@ -301,7 +301,7 @@
   background: #eef2f7;
   color: #3d5071;
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   padding: 2px 8px;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -337,7 +337,7 @@
 .agent-team-empty-panel__eyebrow {
   color: var(--text-secondary);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-transform: uppercase;
 }
 
@@ -441,7 +441,7 @@
   border-radius: 9px;
   background: linear-gradient(180deg, #5f94e6, #4f84d8);
   color: #fff;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   box-shadow: 0 6px 14px rgba(47, 102, 184, 0.24);
   transition: filter 0.15s ease, box-shadow 0.15s ease;
 }
@@ -468,7 +468,7 @@
   min-width: 140px;
   border-radius: var(--radius-lg);
   font-size: 13px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.02em;
   height: 36px;
 }
@@ -520,7 +520,7 @@
 .agent-team-lead-dock__head strong {
   overflow: hidden;
   font-size: 14px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -650,7 +650,7 @@
 .agent-team-graph-panel__head strong {
   overflow: hidden;
   font-size: 14px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -751,7 +751,7 @@
   background: rgba(245, 249, 255, 0.94);
   color: var(--text-secondary);
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   padding: 0 12px 0 5px;
   text-transform: uppercase;
   box-shadow: 0 6px 16px rgba(31, 54, 88, 0.05);
@@ -788,7 +788,7 @@
   background: rgba(238, 245, 255, 0.96);
   color: #285b95;
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.02em;
   text-transform: uppercase;
   box-shadow: 0 4px 12px rgba(31, 54, 88, 0.05);
@@ -851,7 +851,7 @@
   overflow: hidden;
   color: var(--text);
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1.25;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -865,7 +865,7 @@
   overflow: hidden;
   color: var(--text-secondary);
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .agent-team-dag-node__meta > span:first-child {
@@ -933,7 +933,7 @@
   overflow: hidden;
   color: var(--text);
   font-size: 15px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -1005,7 +1005,7 @@
   color: #7fa8dd;
   content: "→";
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   box-shadow: 0 4px 12px rgba(31, 54, 88, 0.08);
 }
 
@@ -1019,7 +1019,7 @@
   background: rgba(238, 245, 255, 0.94);
   color: var(--text-secondary);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   padding: 3px 8px 3px 4px;
   text-transform: uppercase;
 }
@@ -1081,7 +1081,7 @@
   overflow: hidden;
   color: var(--text);
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1.3;
   text-overflow: ellipsis;
   white-space: normal;
@@ -1118,7 +1118,7 @@
   background: #eef5ff;
   color: #285b95;
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1.2;
   padding: 2px 6px;
   text-overflow: ellipsis;
@@ -1168,7 +1168,7 @@
   background: #edf4ff;
   color: #335c91;
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   padding: 2px 6px;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1279,7 +1279,7 @@
 .agent-team-graph-detail__head strong {
   color: var(--text);
   font-size: 13px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1.32;
 }
 
@@ -1312,7 +1312,7 @@
   background: #eef2f7;
   color: #3d5071;
   font-family: inherit;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   padding: 2px 6px;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1336,7 +1336,7 @@
   background: #f4f6f9;
   color: var(--text-secondary);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   padding: 7px;
 }
 
@@ -1383,7 +1383,7 @@
 .agent-team-agent-detail__task span {
   color: var(--text-secondary);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .agent-team-agent-detail__output {
@@ -1433,7 +1433,7 @@
   overflow: hidden;
   color: var(--text);
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -1544,7 +1544,7 @@
   overflow: hidden;
   color: var(--text);
   font-size: 13px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -1577,7 +1577,7 @@
   flex: 0 0 auto;
   color: var(--text-secondary);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.02em;
 }
@@ -1626,7 +1626,7 @@
   background: #eef2f7;
   color: #3d5071;
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   padding: 2px 6px;
 }
 
@@ -1777,7 +1777,7 @@
 .agent-team-task-row__title {
   overflow: hidden;
   color: var(--text);
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -1812,7 +1812,7 @@
   color: #285b95;
   background: #e9f2ff;
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .agent-team-detail {
@@ -1831,7 +1831,7 @@
   color: #285b95;
   background: #e9f2ff;
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .agent-team-detail__status--proposed,
@@ -1896,7 +1896,7 @@
 .agent-team-detail__facts strong {
   color: var(--text-secondary);
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .agent-team-detail__description,
@@ -1939,7 +1939,7 @@
   color: #285b95;
   background: #e9f2ff;
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-overflow: ellipsis;
 }
 
@@ -2052,7 +2052,7 @@
   padding: 7px 8px;
   border-radius: 7px;
   background: rgba(250, 251, 253, 0.9);
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .agent-team-plan-preview__item--task {
@@ -2085,13 +2085,13 @@
   background: #eef2f7;
   padding: 2px 6px;
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .agent-team-plan-preview__item > span {
   color: var(--text-secondary);
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .agent-team-plan-preview__deps {
@@ -2105,7 +2105,7 @@
 .agent-team-plan-preview__deps-label {
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-transform: uppercase;
 }
 
@@ -2118,7 +2118,7 @@
   color: #285b95;
   background: #e9f2ff;
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   padding: 2px 6px;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -2259,7 +2259,7 @@
 
 .agent-team-checkpoint-banner__copy strong {
   font-size: 13px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: #5a440f;
 }
 
@@ -2344,7 +2344,7 @@
 .agent-team-agent-inspector__head strong {
   overflow: hidden;
   font-size: 15px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -2398,7 +2398,7 @@
   background: #f4f6f9;
   color: var(--text-secondary);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   padding: 7px 4px;
 }
 
@@ -2470,7 +2470,7 @@
   overflow: hidden;
   color: var(--text);
   font-size: 13px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -2526,7 +2526,7 @@
   overflow: hidden;
   color: var(--text);
   font-size: 15px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -2551,7 +2551,7 @@
   background: #f5f7fa;
   color: var(--text-secondary);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .agent-team-agent-inspector__activity-grid strong {
@@ -2651,7 +2651,7 @@
 .agent-team-artifact-viewer__header strong {
   overflow: hidden;
   font-size: 14px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/AgentTeamFrame/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/AgentTeamFrame/index.css
@@ -35,7 +35,7 @@
   color: var(--text);
   cursor: pointer;
   padding: 0 10px;
-  font-weight: 800;
+  font-weight: var(--font-weight-medium);
   white-space: nowrap;
 }
 
@@ -93,7 +93,7 @@
 
 .agent-team-frame__title {
   font-size: 14px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -101,7 +101,7 @@
 
 .agent-team-frame__phase-label {
   color: var(--text-secondary);
-  font-weight: 800;
+  font-weight: var(--font-weight-medium);
 }
 
 .agent-team-frame__mission {
@@ -123,7 +123,7 @@
   background: rgba(238, 242, 247, 0.92);
   color: #3d5071;
   font-family: inherit;
-  font-weight: 800;
+  font-weight: var(--font-weight-medium);
   padding: 2px 7px;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -166,7 +166,7 @@
   color: #1f6f45;
   padding: 4px 9px;
   font-size: 11px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   text-transform: capitalize;
 }
 
@@ -223,7 +223,7 @@
   border-radius: var(--radius-pill);
   padding: 2px 7px;
   font-size: 10px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
 }
 
 .agent-team-agent-pill__role--lead {
@@ -240,7 +240,7 @@
   min-width: 0;
   overflow: hidden;
   color: var(--text);
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   text-overflow: ellipsis;
 }
 
@@ -301,7 +301,7 @@
   background: #eef2f7;
   color: #3d5071;
   font-size: 11px;
-  font-weight: 800;
+  font-weight: var(--font-weight-medium);
   padding: 2px 8px;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -337,7 +337,7 @@
 .agent-team-empty-panel__eyebrow {
   color: var(--text-secondary);
   font-size: 10px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   text-transform: uppercase;
 }
 
@@ -441,7 +441,7 @@
   border-radius: 9px;
   background: linear-gradient(180deg, #5f94e6, #4f84d8);
   color: #fff;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   box-shadow: 0 6px 14px rgba(47, 102, 184, 0.24);
   transition: filter 0.15s ease, box-shadow 0.15s ease;
 }
@@ -468,7 +468,7 @@
   min-width: 140px;
   border-radius: var(--radius-lg);
   font-size: 13px;
-  font-weight: 800;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.02em;
   height: 36px;
 }
@@ -520,7 +520,7 @@
 .agent-team-lead-dock__head strong {
   overflow: hidden;
   font-size: 14px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -650,7 +650,7 @@
 .agent-team-graph-panel__head strong {
   overflow: hidden;
   font-size: 14px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -751,7 +751,7 @@
   background: rgba(245, 249, 255, 0.94);
   color: var(--text-secondary);
   font-size: 11px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   padding: 0 12px 0 5px;
   text-transform: uppercase;
   box-shadow: 0 6px 16px rgba(31, 54, 88, 0.05);
@@ -788,7 +788,7 @@
   background: rgba(238, 245, 255, 0.96);
   color: #285b95;
   font-size: 11px;
-  font-weight: 800;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.02em;
   text-transform: uppercase;
   box-shadow: 0 4px 12px rgba(31, 54, 88, 0.05);
@@ -851,7 +851,7 @@
   overflow: hidden;
   color: var(--text);
   font-size: 12px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   line-height: 1.25;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -865,7 +865,7 @@
   overflow: hidden;
   color: var(--text-secondary);
   font-size: 11px;
-  font-weight: 800;
+  font-weight: var(--font-weight-medium);
 }
 
 .agent-team-dag-node__meta > span:first-child {
@@ -933,7 +933,7 @@
   overflow: hidden;
   color: var(--text);
   font-size: 15px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -1005,7 +1005,7 @@
   color: #7fa8dd;
   content: "→";
   font-size: 12px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   box-shadow: 0 4px 12px rgba(31, 54, 88, 0.08);
 }
 
@@ -1019,7 +1019,7 @@
   background: rgba(238, 245, 255, 0.94);
   color: var(--text-secondary);
   font-size: 10px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   padding: 3px 8px 3px 4px;
   text-transform: uppercase;
 }
@@ -1081,7 +1081,7 @@
   overflow: hidden;
   color: var(--text);
   font-size: 12px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   line-height: 1.3;
   text-overflow: ellipsis;
   white-space: normal;
@@ -1118,7 +1118,7 @@
   background: #eef5ff;
   color: #285b95;
   font-size: 10px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   line-height: 1.2;
   padding: 2px 6px;
   text-overflow: ellipsis;
@@ -1168,7 +1168,7 @@
   background: #edf4ff;
   color: #335c91;
   font-size: 10px;
-  font-weight: 800;
+  font-weight: var(--font-weight-medium);
   padding: 2px 6px;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1279,7 +1279,7 @@
 .agent-team-graph-detail__head strong {
   color: var(--text);
   font-size: 13px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   line-height: 1.32;
 }
 
@@ -1312,7 +1312,7 @@
   background: #eef2f7;
   color: #3d5071;
   font-family: inherit;
-  font-weight: 800;
+  font-weight: var(--font-weight-medium);
   padding: 2px 6px;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1336,7 +1336,7 @@
   background: #f4f6f9;
   color: var(--text-secondary);
   font-size: 10px;
-  font-weight: 800;
+  font-weight: var(--font-weight-medium);
   padding: 7px;
 }
 
@@ -1383,7 +1383,7 @@
 .agent-team-agent-detail__task span {
   color: var(--text-secondary);
   font-size: 10px;
-  font-weight: 800;
+  font-weight: var(--font-weight-medium);
 }
 
 .agent-team-agent-detail__output {
@@ -1433,7 +1433,7 @@
   overflow: hidden;
   color: var(--text);
   font-size: 12px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -1544,7 +1544,7 @@
   overflow: hidden;
   color: var(--text);
   font-size: 13px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -1577,7 +1577,7 @@
   flex: 0 0 auto;
   color: var(--text-secondary);
   font-size: 10px;
-  font-weight: 800;
+  font-weight: var(--font-weight-medium);
   text-transform: uppercase;
   letter-spacing: 0.02em;
 }
@@ -1626,7 +1626,7 @@
   background: #eef2f7;
   color: #3d5071;
   font-size: 10px;
-  font-weight: 800;
+  font-weight: var(--font-weight-medium);
   padding: 2px 6px;
 }
 
@@ -1777,7 +1777,7 @@
 .agent-team-task-row__title {
   overflow: hidden;
   color: var(--text);
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -1812,7 +1812,7 @@
   color: #285b95;
   background: #e9f2ff;
   font-size: 10px;
-  font-weight: 800;
+  font-weight: var(--font-weight-medium);
 }
 
 .agent-team-detail {
@@ -1831,7 +1831,7 @@
   color: #285b95;
   background: #e9f2ff;
   font-size: 11px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
 }
 
 .agent-team-detail__status--proposed,
@@ -1896,7 +1896,7 @@
 .agent-team-detail__facts strong {
   color: var(--text-secondary);
   font-size: 11px;
-  font-weight: 800;
+  font-weight: var(--font-weight-medium);
 }
 
 .agent-team-detail__description,
@@ -1939,7 +1939,7 @@
   color: #285b95;
   background: #e9f2ff;
   font-size: 11px;
-  font-weight: 800;
+  font-weight: var(--font-weight-medium);
   text-overflow: ellipsis;
 }
 
@@ -2052,7 +2052,7 @@
   padding: 7px 8px;
   border-radius: 7px;
   background: rgba(250, 251, 253, 0.9);
-  font-weight: 800;
+  font-weight: var(--font-weight-medium);
 }
 
 .agent-team-plan-preview__item--task {
@@ -2085,13 +2085,13 @@
   background: #eef2f7;
   padding: 2px 6px;
   font-size: 10px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
 }
 
 .agent-team-plan-preview__item > span {
   color: var(--text-secondary);
   font-size: 11px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
 }
 
 .agent-team-plan-preview__deps {
@@ -2105,7 +2105,7 @@
 .agent-team-plan-preview__deps-label {
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   text-transform: uppercase;
 }
 
@@ -2118,7 +2118,7 @@
   color: #285b95;
   background: #e9f2ff;
   font-size: 10px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   padding: 2px 6px;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -2259,7 +2259,7 @@
 
 .agent-team-checkpoint-banner__copy strong {
   font-size: 13px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: #5a440f;
 }
 
@@ -2344,7 +2344,7 @@
 .agent-team-agent-inspector__head strong {
   overflow: hidden;
   font-size: 15px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -2398,7 +2398,7 @@
   background: #f4f6f9;
   color: var(--text-secondary);
   font-size: 10px;
-  font-weight: 800;
+  font-weight: var(--font-weight-medium);
   padding: 7px 4px;
 }
 
@@ -2470,7 +2470,7 @@
   overflow: hidden;
   color: var(--text);
   font-size: 13px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -2526,7 +2526,7 @@
   overflow: hidden;
   color: var(--text);
   font-size: 15px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -2551,7 +2551,7 @@
   background: #f5f7fa;
   color: var(--text-secondary);
   font-size: 10px;
-  font-weight: 800;
+  font-weight: var(--font-weight-medium);
 }
 
 .agent-team-agent-inspector__activity-grid strong {
@@ -2651,7 +2651,7 @@
 .agent-team-artifact-viewer__header strong {
   overflow: hidden;
   font-size: 14px;
-  font-weight: 900;
+  font-weight: var(--font-weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/DynamicAppNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/DynamicAppNodeBody/index.css
@@ -26,7 +26,7 @@
   padding: 2px 8px;
   border-radius: var(--radius-lg);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.4px;
   line-height: 1;

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/DynamicAppNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/DynamicAppNodeBody/index.css
@@ -26,7 +26,7 @@
   padding: 2px 8px;
   border-radius: var(--radius-lg);
   font-size: 10px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   text-transform: uppercase;
   letter-spacing: 0.4px;
   line-height: 1;
@@ -125,7 +125,7 @@
   overflow: auto;
   padding: 10px 12px;
   font-size: 11px;
-  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+  font-family: var(--font-mono);
 }
 
 .dynamic-app-inspector-pre {
@@ -137,7 +137,7 @@
 
 .dynamic-app-inspector-empty {
   color: #6e7781;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  font-family: var(--font-ui);
   font-size: 12px;
   font-style: italic;
 }
@@ -158,7 +158,7 @@
   color: #1f2328;
   cursor: pointer;
   text-align: left;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  font-family: var(--font-ui);
 }
 
 .dynamic-app-inspector-action:hover:not(:disabled) {

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/FileNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/FileNodeBody/index.css
@@ -167,7 +167,7 @@
 
 .note-tiptap-editor .ProseMirror h1 {
   font-size: 1.9em;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   margin: 0.95em 0 0.4em;
   color: var(--text);
   line-height: 1.26;
@@ -181,7 +181,7 @@
 
 .note-tiptap-editor .ProseMirror h2 {
   font-size: 1.42em;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   margin: 1.5em 0 0.5em;
   color: var(--text);
   line-height: 1.34;
@@ -191,7 +191,7 @@
 
 .note-tiptap-editor .ProseMirror h3 {
   font-size: 1.16em;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   margin: 1.25em 0 0.4em;
   color: var(--text);
   letter-spacing: -0.01em;
@@ -203,7 +203,7 @@
 }
 
 .note-tiptap-editor .ProseMirror strong {
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .note-tiptap-editor .ProseMirror em {
@@ -371,7 +371,7 @@
 
 .note-tiptap-editor .ProseMirror th {
   background: rgba(55, 53, 47, 0.035);
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-align: left;
 }
 
@@ -425,7 +425,7 @@
 .note-tiptap-editor .ProseMirror .hljs-name,
 .note-tiptap-editor .ProseMirror .hljs-strong {
   color: #a626a4;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .note-tiptap-editor .ProseMirror .hljs-string,

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/FileNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/FileNodeBody/index.css
@@ -167,7 +167,7 @@
 
 .note-tiptap-editor .ProseMirror h1 {
   font-size: 1.9em;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
   margin: 0.95em 0 0.4em;
   color: var(--text);
   line-height: 1.26;
@@ -181,7 +181,7 @@
 
 .note-tiptap-editor .ProseMirror h2 {
   font-size: 1.42em;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
   margin: 1.5em 0 0.5em;
   color: var(--text);
   line-height: 1.34;
@@ -191,7 +191,7 @@
 
 .note-tiptap-editor .ProseMirror h3 {
   font-size: 1.16em;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
   margin: 1.25em 0 0.4em;
   color: var(--text);
   letter-spacing: -0.01em;
@@ -203,7 +203,7 @@
 }
 
 .note-tiptap-editor .ProseMirror strong {
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
 }
 
 .note-tiptap-editor .ProseMirror em {
@@ -371,7 +371,7 @@
 
 .note-tiptap-editor .ProseMirror th {
   background: rgba(55, 53, 47, 0.035);
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   text-align: left;
 }
 
@@ -425,7 +425,7 @@
 .note-tiptap-editor .ProseMirror .hljs-name,
 .note-tiptap-editor .ProseMirror .hljs-strong {
   color: #a626a4;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
 }
 
 .note-tiptap-editor .ProseMirror .hljs-string,

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/FileNodeBodyLazy/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/FileNodeBodyLazy/index.css
@@ -5,8 +5,7 @@
   overflow: auto;
   padding: 22px 32px 56px;
   color: var(--text);
-  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI",
-    "Inter", "Helvetica Neue", Arial, sans-serif;
+  font-family: var(--font-ui);
   font-size: 14.5px;
   line-height: 1.7;
   cursor: default;

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/FrameNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/FrameNodeBody/index.css
@@ -166,7 +166,7 @@
 .canvas-node--frame .node-header .node-title {
   flex: 0 1 auto;
   color: oklch(0.52 calc(var(--_c) * 2.4) var(--_h));
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   font-size: 14px;
   line-height: 1.2;
   letter-spacing: 0;
@@ -272,9 +272,9 @@
 
 .frame-children-count {
   min-width: 0;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: var(--font-mono);
   font-size: 12.5px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   line-height: 1;
   text-align: center;
   transition: transform 0.18s ease;
@@ -441,7 +441,7 @@
 .frame-children-summary__more {
   padding: 3px 4px 0 28px;
   font-size: 12px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   opacity: 0.7;
   white-space: nowrap;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/FrameNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/FrameNodeBody/index.css
@@ -166,7 +166,7 @@
 .canvas-node--frame .node-header .node-title {
   flex: 0 1 auto;
   color: oklch(0.52 calc(var(--_c) * 2.4) var(--_h));
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   font-size: 14px;
   line-height: 1.2;
   letter-spacing: 0;
@@ -274,7 +274,7 @@
   min-width: 0;
   font-family: var(--font-mono);
   font-size: 12.5px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1;
   text-align: center;
   transition: transform 0.18s ease;
@@ -441,7 +441,7 @@
 .frame-children-summary__more {
   padding: 3px 4px 0 28px;
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   opacity: 0.7;
   white-space: nowrap;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/IframeNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/IframeNodeBody/index.css
@@ -188,7 +188,7 @@
 .iframe-load-error-title {
   margin-bottom: 6px;
   font-size: 13px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
 }
 
 .iframe-load-error-message {
@@ -229,7 +229,7 @@
 
 .iframe-empty-label {
   font-size: 12px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: var(--text);
 }
 
@@ -260,7 +260,7 @@
   background: rgba(35, 131, 226, 0.08);
   color: var(--accent);
   font-size: 11px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   cursor: pointer;
   transition: background 0.1s, color 0.1s;
 }
@@ -360,7 +360,7 @@
   border-radius: var(--radius-sm);
   padding: 8px 10px;
   font-size: 12px;
-  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-family: var(--font-mono);
   color: var(--text);
   background: var(--surface);
   outline: none;
@@ -380,7 +380,7 @@
 .iframe-bar-badge {
   flex-shrink: 0;
   font-size: 9px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   padding: 1px 5px;
@@ -489,7 +489,7 @@
   color: #fff;
   box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28);
   font-size: 11px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   line-height: 20px;
   text-align: center;
   cursor: pointer;
@@ -521,7 +521,7 @@
   overflow: hidden;
   color: #111827;
   font-size: 11px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -573,7 +573,7 @@
   box-shadow: 0 12px 30px rgba(15, 23, 42, 0.18);
   color: #111827;
   font-size: 12px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   pointer-events: auto;
 }
 
@@ -715,7 +715,7 @@
   white-space: nowrap;
   color: var(--text);
   font-size: calc(10.5px / clamp(0.14, var(--canvas-scale, 1), 0.35));
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.01em;
 }
 
@@ -771,7 +771,7 @@
   border: 1px solid var(--border);
   color: var(--text-secondary);
   font-size: 11px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   box-shadow: var(--shadow-card);
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/IframeNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/IframeNodeBody/index.css
@@ -188,7 +188,7 @@
 .iframe-load-error-title {
   margin-bottom: 6px;
   font-size: 13px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .iframe-load-error-message {
@@ -229,7 +229,7 @@
 
 .iframe-empty-label {
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: var(--text);
 }
 
@@ -260,7 +260,7 @@
   background: rgba(35, 131, 226, 0.08);
   color: var(--accent);
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   cursor: pointer;
   transition: background 0.1s, color 0.1s;
 }
@@ -380,7 +380,7 @@
 .iframe-bar-badge {
   flex-shrink: 0;
   font-size: 9px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   padding: 1px 5px;
@@ -489,7 +489,7 @@
   color: #fff;
   box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28);
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 20px;
   text-align: center;
   cursor: pointer;
@@ -521,7 +521,7 @@
   overflow: hidden;
   color: #111827;
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -573,7 +573,7 @@
   box-shadow: 0 12px 30px rgba(15, 23, 42, 0.18);
   color: #111827;
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   pointer-events: auto;
 }
 
@@ -715,7 +715,7 @@
   white-space: nowrap;
   color: var(--text);
   font-size: calc(10.5px / clamp(0.14, var(--canvas-scale, 1), 0.35));
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.01em;
 }
 
@@ -771,7 +771,7 @@
   border: 1px solid var(--border);
   color: var(--text-secondary);
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   box-shadow: var(--shadow-card);
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/MindmapNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/MindmapNodeBody/index.css
@@ -225,7 +225,7 @@
   box-shadow: 0 1px 4px rgba(15, 23, 42, 0.12);
   cursor: pointer;
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 20px;
   padding: 0 6px;
   transition: background 120ms ease, border-color 120ms ease, color 120ms ease, transform 120ms ease;

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/MindmapNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/MindmapNodeBody/index.css
@@ -225,7 +225,7 @@
   box-shadow: 0 1px 4px rgba(15, 23, 42, 0.12);
   cursor: pointer;
   font-size: 12px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   line-height: 20px;
   padding: 0 6px;
   transition: background 120ms ease, border-color 120ms ease, color 120ms ease, transform 120ms ease;

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/NodeMentionPicker/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/NodeMentionPicker/index.css
@@ -93,7 +93,7 @@
 
 .node-mention-badge {
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   padding: 2px 6px;
   border-radius: var(--radius-xs);
   flex-shrink: 0;

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/NodeMentionPicker/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/NodeMentionPicker/index.css
@@ -93,7 +93,7 @@
 
 .node-mention-badge {
   font-size: 10px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   padding: 2px 6px;
   border-radius: var(--radius-xs);
   flex-shrink: 0;

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/PluginNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/PluginNodeBody/index.css
@@ -29,7 +29,7 @@
 
 .plugin-node-body__eyebrow {
   font-size: 11px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--accent);
@@ -38,7 +38,7 @@
 .plugin-node-body__title {
   font-size: 18px;
   line-height: 1.2;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
 }
 
 .plugin-node-body__meta {

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/PluginNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/PluginNodeBody/index.css
@@ -29,7 +29,7 @@
 
 .plugin-node-body__eyebrow {
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--accent);
@@ -38,7 +38,7 @@
 .plugin-node-body__title {
   font-size: 18px;
   line-height: 1.2;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .plugin-node-body__meta {

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/ShapeNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/ShapeNodeBody/index.css
@@ -114,7 +114,7 @@
 
 .shape-style-label {
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--text-muted, #6e7681);

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/ShapeNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/ShapeNodeBody/index.css
@@ -114,7 +114,7 @@
 
 .shape-style-label {
   font-size: 11px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--text-muted, #6e7681);

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/TerminalNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/TerminalNodeBody/index.css
@@ -76,7 +76,7 @@
   background: rgba(236, 253, 245, 0.76);
   color: #0f766e;
   font: inherit;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
 }
 
 .terminal-mention-hint__close {

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/TerminalNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/TerminalNodeBody/index.css
@@ -76,7 +76,7 @@
   background: rgba(236, 253, 245, 0.76);
   color: #0f766e;
   font: inherit;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .terminal-mention-hint__close {

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/TextNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/TextNodeBody/index.css
@@ -224,7 +224,7 @@
 .text-node-body h2,
 .text-node-body h3 {
   margin: 0;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0;
   line-height: 1.2;
 }
@@ -242,7 +242,7 @@
 }
 
 .text-node-body strong {
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
 }
 
 .text-node-body em {
@@ -261,7 +261,7 @@
 }
 
 .text-node-body code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 0.9em;
   padding: 0.08em 0.35em;
   border-radius: var(--radius-xs);
@@ -273,7 +273,7 @@
   padding: 8px 10px;
   border-radius: var(--radius-sm);
   background: rgba(0, 0, 0, 0.05);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 0.9em;
   overflow-x: auto;
 }
@@ -381,7 +381,7 @@
 
 .text-selection-bubble__button--clear {
   width: 30px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0;
 }
 
@@ -392,7 +392,7 @@
   border-radius: var(--radius-sm);
   padding: 0;
   font-size: 12px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   line-height: 1;
 }
 
@@ -482,7 +482,7 @@
 
 .text-color-dot-glyph {
   font-size: 9px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   line-height: 1;
   color: rgba(0, 0, 0, 0.55);
   font-family: var(--font);

--- a/apps/canvas-workspace/src/renderer/src/components/node-bodies/TextNodeBody/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/node-bodies/TextNodeBody/index.css
@@ -224,7 +224,7 @@
 .text-node-body h2,
 .text-node-body h3 {
   margin: 0;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0;
   line-height: 1.2;
 }
@@ -242,7 +242,7 @@
 }
 
 .text-node-body strong {
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .text-node-body em {
@@ -381,7 +381,7 @@
 
 .text-selection-bubble__button--clear {
   width: 30px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0;
 }
 
@@ -392,7 +392,7 @@
   border-radius: var(--radius-sm);
   padding: 0;
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1;
 }
 
@@ -482,7 +482,7 @@
 
 .text-color-dot-glyph {
   font-size: 9px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1;
   color: rgba(0, 0, 0, 0.55);
   font-family: var(--font);

--- a/apps/canvas-workspace/src/renderer/src/components/note-editor/NoteFindBar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/note-editor/NoteFindBar/index.css
@@ -76,7 +76,7 @@
   cursor: pointer;
   color: var(--text-muted);
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1;
   display: flex;
   align-items: center;

--- a/apps/canvas-workspace/src/renderer/src/components/note-editor/NoteFindBar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/note-editor/NoteFindBar/index.css
@@ -76,7 +76,7 @@
   cursor: pointer;
   color: var(--text-muted);
   font-size: 11px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   line-height: 1;
   display: flex;
   align-items: center;

--- a/apps/canvas-workspace/src/renderer/src/components/note-editor/NoteMentionMenu/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/note-editor/NoteMentionMenu/index.css
@@ -32,7 +32,7 @@
 .note-mention-menu-badge {
   flex-shrink: 0;
   font-size: 9px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   text-transform: uppercase;
   letter-spacing: 0.03em;
   padding: 1px 5px;

--- a/apps/canvas-workspace/src/renderer/src/components/note-editor/NoteMentionMenu/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/note-editor/NoteMentionMenu/index.css
@@ -32,7 +32,7 @@
 .note-mention-menu-badge {
   flex-shrink: 0;
   font-size: 9px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.03em;
   padding: 1px 5px;

--- a/apps/canvas-workspace/src/renderer/src/components/note-editor/NoteOutline/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/note-editor/NoteOutline/index.css
@@ -25,7 +25,7 @@
 
 .note-outline-title {
   font-size: 11px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -90,7 +90,7 @@
 
 .note-outline-item--h1 {
   padding-left: 6px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
 }
 .note-outline-item--h2 {
   padding-left: 16px;

--- a/apps/canvas-workspace/src/renderer/src/components/note-editor/NoteOutline/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/note-editor/NoteOutline/index.css
@@ -25,7 +25,7 @@
 
 .note-outline-title {
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -90,7 +90,7 @@
 
 .note-outline-item--h1 {
   padding-left: 6px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 .note-outline-item--h2 {
   padding-left: 16px;

--- a/apps/canvas-workspace/src/renderer/src/components/note-editor/SlashCommandMenu/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/note-editor/SlashCommandMenu/index.css
@@ -48,7 +48,7 @@
   padding: 5px 8px 4px;
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/note-editor/SlashCommandMenu/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/note-editor/SlashCommandMenu/index.css
@@ -48,7 +48,7 @@
   padding: 5px 8px 4px;
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/settings/Settings/AgentSection.css
+++ b/apps/canvas-workspace/src/renderer/src/components/settings/Settings/AgentSection.css
@@ -35,7 +35,7 @@
 
 .agent-section-card-title {
   font-size: 14px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: #37352f;
   margin-bottom: 4px;
 }
@@ -92,7 +92,7 @@
   margin-bottom: 3px;
   color: var(--text);
   font-size: 12px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
 }
 
 .agent-section-policy-select {
@@ -127,7 +127,7 @@
   margin-bottom: 3px;
   color: var(--accent);
   font-size: 12.5px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
 }
 
 .agent-section-update-desc {
@@ -155,7 +155,7 @@
 
 .agent-section-warning-title {
   font-size: 12.5px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: #92400e;
   margin-bottom: 3px;
 }
@@ -201,7 +201,7 @@
 
 .agent-section-cli-title {
   font-size: 12.5px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: #1f4e8a;
 }
 
@@ -233,7 +233,7 @@
   padding: 8px 10px;
   border-radius: var(--radius-sm);
   word-break: break-all;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: var(--font-mono);
 }
 
 .agent-section-results {
@@ -256,7 +256,7 @@
 
 .agent-section-result-icon {
   font-size: 13px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   line-height: 1.4;
   flex-shrink: 0;
   width: 16px;

--- a/apps/canvas-workspace/src/renderer/src/components/settings/Settings/AgentSection.css
+++ b/apps/canvas-workspace/src/renderer/src/components/settings/Settings/AgentSection.css
@@ -35,7 +35,7 @@
 
 .agent-section-card-title {
   font-size: 14px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: #37352f;
   margin-bottom: 4px;
 }
@@ -92,7 +92,7 @@
   margin-bottom: 3px;
   color: var(--text);
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .agent-section-policy-select {
@@ -127,7 +127,7 @@
   margin-bottom: 3px;
   color: var(--accent);
   font-size: 12.5px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .agent-section-update-desc {
@@ -155,7 +155,7 @@
 
 .agent-section-warning-title {
   font-size: 12.5px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: #92400e;
   margin-bottom: 3px;
 }
@@ -201,7 +201,7 @@
 
 .agent-section-cli-title {
   font-size: 12.5px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: #1f4e8a;
 }
 
@@ -256,7 +256,7 @@
 
 .agent-section-result-icon {
   font-size: 13px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1.4;
   flex-shrink: 0;
   width: 16px;

--- a/apps/canvas-workspace/src/renderer/src/components/settings/Settings/BuiltInToolsSection.css
+++ b/apps/canvas-workspace/src/renderer/src/components/settings/Settings/BuiltInToolsSection.css
@@ -31,7 +31,7 @@
 
 .built-in-tools-title {
   font-size: 14px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: #37352f;
   margin-bottom: 4px;
 }
@@ -49,7 +49,7 @@
   background: rgba(35, 131, 226, 0.08);
   color: #1f76cc;
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   padding: 5px 10px;
 }
 
@@ -113,7 +113,7 @@
 
 .built-in-tool-name {
   font-size: 13.5px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: #37352f;
 }
 
@@ -129,7 +129,7 @@
   border-radius: var(--radius-pill);
   padding: 4px 9px;
   font-size: 11.5px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1.2;
 }
 
@@ -206,7 +206,7 @@
  * migrated to ui/Button, which has no borderless "ghost" variant. */
 .built-in-tool-secondary-btn {
   font-size: 12.5px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   border-radius: var(--radius-sm);
   min-height: 32px;
   padding: 7px 8px;

--- a/apps/canvas-workspace/src/renderer/src/components/settings/Settings/BuiltInToolsSection.css
+++ b/apps/canvas-workspace/src/renderer/src/components/settings/Settings/BuiltInToolsSection.css
@@ -31,7 +31,7 @@
 
 .built-in-tools-title {
   font-size: 14px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: #37352f;
   margin-bottom: 4px;
 }
@@ -49,7 +49,7 @@
   background: rgba(35, 131, 226, 0.08);
   color: #1f76cc;
   font-size: 12px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   padding: 5px 10px;
 }
 
@@ -113,7 +113,7 @@
 
 .built-in-tool-name {
   font-size: 13.5px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: #37352f;
 }
 
@@ -129,7 +129,7 @@
   border-radius: var(--radius-pill);
   padding: 4px 9px;
   font-size: 11.5px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   line-height: 1.2;
 }
 
@@ -206,7 +206,7 @@
  * migrated to ui/Button, which has no borderless "ghost" variant. */
 .built-in-tool-secondary-btn {
   font-size: 12.5px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   border-radius: var(--radius-sm);
   min-height: 32px;
   padding: 7px 8px;

--- a/apps/canvas-workspace/src/renderer/src/components/settings/Settings/ChannelConfigPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/settings/Settings/ChannelConfigPanel.css
@@ -17,7 +17,7 @@
 }
 
 .channel-config-title {
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   font-size: 13px;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/settings/Settings/ChannelConfigPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/settings/Settings/ChannelConfigPanel.css
@@ -17,7 +17,7 @@
 }
 
 .channel-config-title {
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   font-size: 13px;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/settings/Settings/ExperimentalSection.css
+++ b/apps/canvas-workspace/src/renderer/src/components/settings/Settings/ExperimentalSection.css
@@ -16,7 +16,7 @@
 
 .experimental-section-intro-title {
   font-size: 14px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: #37352f;
   margin-bottom: 4px;
 }
@@ -106,7 +106,7 @@
 
 .experimental-section-item-label {
   font-size: 13.5px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: #37352f;
   margin-bottom: 3px;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/settings/Settings/ExperimentalSection.css
+++ b/apps/canvas-workspace/src/renderer/src/components/settings/Settings/ExperimentalSection.css
@@ -16,7 +16,7 @@
 
 .experimental-section-intro-title {
   font-size: 14px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: #37352f;
   margin-bottom: 4px;
 }
@@ -106,7 +106,7 @@
 
 .experimental-section-item-label {
   font-size: 13.5px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: #37352f;
   margin-bottom: 3px;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/settings/Settings/LanguageSection/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/settings/Settings/LanguageSection/index.css
@@ -65,7 +65,7 @@
 
 .language-section-option-label {
   font-size: 14px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .language-section-option-sub {

--- a/apps/canvas-workspace/src/renderer/src/components/settings/Settings/LanguageSection/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/settings/Settings/LanguageSection/index.css
@@ -65,7 +65,7 @@
 
 .language-section-option-label {
   font-size: 14px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
 }
 
 .language-section-option-sub {

--- a/apps/canvas-workspace/src/renderer/src/components/settings/Settings/UpdateSection.css
+++ b/apps/canvas-workspace/src/renderer/src/components/settings/Settings/UpdateSection.css
@@ -94,7 +94,7 @@
 .updates-section-status-title {
   color: #37352f;
   font-size: 13.5px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1.35;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/settings/Settings/UpdateSection.css
+++ b/apps/canvas-workspace/src/renderer/src/components/settings/Settings/UpdateSection.css
@@ -94,7 +94,7 @@
 .updates-section-status-title {
   color: #37352f;
   font-size: 13.5px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   line-height: 1.35;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/settings/Settings/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/settings/Settings/index.css
@@ -30,7 +30,7 @@
   padding: 0 10px 4px;
   color: rgba(55, 53, 47, 0.58);
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1.2;
   letter-spacing: 0.05em;
   text-transform: uppercase;
@@ -70,7 +70,7 @@
 
 .settings-rail-label {
   font-size: 13px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1.2;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/settings/Settings/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/settings/Settings/index.css
@@ -30,7 +30,7 @@
   padding: 0 10px 4px;
   color: rgba(55, 53, 47, 0.58);
   font-size: 11px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   line-height: 1.2;
   letter-spacing: 0.05em;
   text-transform: uppercase;
@@ -70,7 +70,7 @@
 
 .settings-rail-label {
   font-size: 13px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   line-height: 1.2;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/settings/WorkspaceSettings/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/settings/WorkspaceSettings/index.css
@@ -37,7 +37,7 @@
 
 .workspace-settings-section-title {
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.07em;
   text-transform: uppercase;
   color: rgba(55, 53, 47, 0.55);

--- a/apps/canvas-workspace/src/renderer/src/components/settings/WorkspaceSettings/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/settings/WorkspaceSettings/index.css
@@ -37,7 +37,7 @@
 
 .workspace-settings-section-title {
   font-size: 10px;
-  font-weight: 750;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.07em;
   text-transform: uppercase;
   color: rgba(55, 53, 47, 0.55);

--- a/apps/canvas-workspace/src/renderer/src/components/settings/settings-config/settings-config.css
+++ b/apps/canvas-workspace/src/renderer/src/components/settings/settings-config/settings-config.css
@@ -49,7 +49,7 @@
   align-items: center;
   justify-content: center;
   font-size: 12.5px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: rgba(35, 131, 226, 0.9);
   pointer-events: none;
   z-index: 2;
@@ -90,7 +90,7 @@
 
 .cfg-field > span {
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: rgba(55, 53, 47, 0.55);
   letter-spacing: 0.01em;
 }
@@ -195,7 +195,7 @@
 
 .cfg-list-title {
   font-size: 13px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: #37352f;
   display: flex;
   align-items: center;
@@ -220,7 +220,7 @@
  * unknown (gray) — the engine hasn't tried this server yet. */
 .cfg-health {
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   border-radius: var(--radius-xs);
   padding: 1px 6px;
   letter-spacing: 0.02em;
@@ -388,7 +388,7 @@
 
 .cfg-plugin-config-title {
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: rgba(55, 53, 47, 0.55);
   margin: 0 0 8px;
 }
@@ -511,7 +511,7 @@
 
 .cfg-inherited-title {
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.01em;
   color: rgba(55, 53, 47, 0.55);
 }
@@ -539,7 +539,7 @@
 
 .cfg-shadow-warn {
   font-size: 10.5px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: rgba(180, 130, 0, 0.95);
   background: rgba(255, 196, 0, 0.1);
   border: 1px solid rgba(180, 130, 0, 0.2);

--- a/apps/canvas-workspace/src/renderer/src/components/settings/settings-config/settings-config.css
+++ b/apps/canvas-workspace/src/renderer/src/components/settings/settings-config/settings-config.css
@@ -49,7 +49,7 @@
   align-items: center;
   justify-content: center;
   font-size: 12.5px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
   color: rgba(35, 131, 226, 0.9);
   pointer-events: none;
   z-index: 2;
@@ -90,7 +90,7 @@
 
 .cfg-field > span {
   font-size: 11px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   color: rgba(55, 53, 47, 0.55);
   letter-spacing: 0.01em;
 }
@@ -195,7 +195,7 @@
 
 .cfg-list-title {
   font-size: 13px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: #37352f;
   display: flex;
   align-items: center;
@@ -220,7 +220,7 @@
  * unknown (gray) — the engine hasn't tried this server yet. */
 .cfg-health {
   font-size: 10px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   border-radius: var(--radius-xs);
   padding: 1px 6px;
   letter-spacing: 0.02em;
@@ -388,7 +388,7 @@
 
 .cfg-plugin-config-title {
   font-size: 11px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   color: rgba(55, 53, 47, 0.55);
   margin: 0 0 8px;
 }
@@ -511,7 +511,7 @@
 
 .cfg-inherited-title {
   font-size: 11px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.01em;
   color: rgba(55, 53, 47, 0.55);
 }
@@ -539,7 +539,7 @@
 
 .cfg-shadow-warn {
   font-size: 10.5px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: rgba(180, 130, 0, 0.95);
   background: rgba(255, 196, 0, 0.1);
   border: 1px solid rgba(180, 130, 0, 0.2);

--- a/apps/canvas-workspace/src/renderer/src/components/shell/AppShellProvider/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/shell/AppShellProvider/index.css
@@ -65,7 +65,7 @@
 
 .shell-toast__title {
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: var(--text);
 }
 
@@ -102,7 +102,7 @@
   background: rgba(0, 0, 0, 0.06);
   color: var(--text-primary);
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   padding: 4px 10px;
   border-radius: var(--radius-sm);
   cursor: pointer;
@@ -139,7 +139,7 @@
   margin-bottom: 10px;
   border-radius: var(--radius-pill);
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: var(--text-secondary);
   background: rgba(0, 0, 0, 0.04);
 }
@@ -180,7 +180,7 @@
   color: var(--text);
   cursor: pointer;
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   transition: background 0.12s ease, border-color 0.12s ease, transform 0.12s ease;
 }
 
@@ -241,7 +241,7 @@
 
 .shell-shortcuts__section-title {
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--text-muted);
@@ -290,7 +290,7 @@
   border-radius: var(--radius-md);
   background: #ffffff;
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: var(--text);
   white-space: nowrap;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/shell/AppShellProvider/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/shell/AppShellProvider/index.css
@@ -65,7 +65,7 @@
 
 .shell-toast__title {
   font-size: 12px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: var(--text);
 }
 
@@ -102,7 +102,7 @@
   background: rgba(0, 0, 0, 0.06);
   color: var(--text-primary);
   font-size: 12px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   padding: 4px 10px;
   border-radius: var(--radius-sm);
   cursor: pointer;
@@ -139,7 +139,7 @@
   margin-bottom: 10px;
   border-radius: var(--radius-pill);
   font-size: 11px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: var(--text-secondary);
   background: rgba(0, 0, 0, 0.04);
 }
@@ -180,7 +180,7 @@
   color: var(--text);
   cursor: pointer;
   font-size: 12px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   transition: background 0.12s ease, border-color 0.12s ease, transform 0.12s ease;
 }
 
@@ -241,7 +241,7 @@
 
 .shell-shortcuts__section-title {
   font-size: 11px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--text-muted);
@@ -290,7 +290,7 @@
   border-radius: var(--radius-md);
   background: #ffffff;
   font-size: 11px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   color: var(--text);
   white-space: nowrap;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/shell/MigrationSpinner/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/shell/MigrationSpinner/index.css
@@ -40,7 +40,7 @@
 }
 
 .migration-spinner__count {
-  font-family: ui-monospace, "JetBrains Mono", Menlo, Consolas, monospace;
+  font-family: var(--font-ui);
   font-size: 11.5px;
   color: #6b7280;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/shell/Sidebar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/shell/Sidebar/index.css
@@ -49,7 +49,7 @@
   background: transparent;
   color: var(--text-secondary);
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   cursor: pointer;
   text-align: left;
 }
@@ -140,7 +140,7 @@
 
 .sidebar-brand {
   font-size: 13px;
-  font-weight: var(--font-weight-emphasis);
+  font-weight: 600;
   color: var(--text);
   letter-spacing: -0.01em;
   flex: 1;
@@ -171,7 +171,7 @@
 
 .sidebar-section-title {
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;

--- a/apps/canvas-workspace/src/renderer/src/components/shell/Sidebar/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/shell/Sidebar/index.css
@@ -49,7 +49,7 @@
   background: transparent;
   color: var(--text-secondary);
   font-size: 12px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   cursor: pointer;
   text-align: left;
 }
@@ -140,7 +140,7 @@
 
 .sidebar-brand {
   font-size: 13px;
-  font-weight: 600;
+  font-weight: var(--font-weight-emphasis);
   color: var(--text);
   letter-spacing: -0.01em;
   flex: 1;
@@ -171,7 +171,7 @@
 
 .sidebar-section-title {
   font-size: 11px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;

--- a/apps/canvas-workspace/src/renderer/src/components/ui/Button/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ui/Button/index.css
@@ -12,7 +12,7 @@
   border-radius: var(--radius);
   font-family: inherit;
   font-size: 12px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
   white-space: nowrap;
   cursor: pointer;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/ui/Button/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ui/Button/index.css
@@ -12,7 +12,7 @@
   border-radius: var(--radius);
   font-family: inherit;
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   white-space: nowrap;
   cursor: pointer;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/ui/Drawer/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ui/Drawer/index.css
@@ -45,7 +45,7 @@
 
 .ui-drawer-kicker {
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.07em;
   text-transform: uppercase;
   color: rgba(55, 53, 47, 0.42);

--- a/apps/canvas-workspace/src/renderer/src/components/ui/Drawer/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ui/Drawer/index.css
@@ -45,7 +45,7 @@
 
 .ui-drawer-kicker {
   font-size: 10px;
-  font-weight: 750;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.07em;
   text-transform: uppercase;
   color: rgba(55, 53, 47, 0.42);

--- a/apps/canvas-workspace/src/renderer/src/components/ui/EmptyState/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ui/EmptyState/index.css
@@ -26,7 +26,7 @@
    * renders identically to the default div. */
   margin: 0;
   font-size: 14px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
   color: var(--text);
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/ui/EmptyState/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ui/EmptyState/index.css
@@ -26,7 +26,7 @@
    * renders identically to the default div. */
   margin: 0;
   font-size: 14px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: var(--text);
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/ui/FieldRow/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ui/FieldRow/index.css
@@ -10,7 +10,7 @@
 
 .ui-fieldrow__label {
   font-size: 12px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   color: var(--text-secondary);
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/ui/FieldRow/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ui/FieldRow/index.css
@@ -10,7 +10,7 @@
 
 .ui-fieldrow__label {
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: var(--text-secondary);
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/ui/SectionHeader/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ui/SectionHeader/index.css
@@ -1,4 +1,4 @@
-/* ui/SectionHeader — title (15px/700) + optional muted description (12px).
+/* ui/SectionHeader — title (15px/500) + optional muted description (12px).
  * Metrics lifted from the byte-identical Settings/UpdateSection.css and
  * Settings/LanguageSection/index.css `-title`/`-desc` rules. */
 
@@ -10,8 +10,8 @@
 }
 
 .ui-section-header__title {
-  font-size: 15px;
-  font-weight: 700;
+  font-size: var(--font-size-title);
+  font-weight: var(--font-weight-medium);
   color: var(--text);
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/ui/SectionHeader/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ui/SectionHeader/index.css
@@ -10,8 +10,8 @@
 }
 
 .ui-section-header__title {
-  font-size: var(--font-size-title);
-  font-weight: var(--font-weight-medium);
+  font-size: 15px;
+  font-weight: 500;
   color: var(--text);
 }
 

--- a/apps/canvas-workspace/src/renderer/src/components/ui/SegmentedControl/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ui/SegmentedControl/index.css
@@ -22,7 +22,7 @@
   background: transparent;
   color: var(--text-secondary);
   font-size: 11.5px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   cursor: pointer;
   white-space: nowrap;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/ui/SegmentedControl/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ui/SegmentedControl/index.css
@@ -22,7 +22,7 @@
   background: transparent;
   color: var(--text-secondary);
   font-size: 11.5px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   cursor: pointer;
   white-space: nowrap;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/ui/TextField/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ui/TextField/index.css
@@ -12,7 +12,7 @@
 
 .ui-textfield__label {
   font-size: 11px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   color: rgba(55, 53, 47, 0.55);
   letter-spacing: 0.01em;
 }

--- a/apps/canvas-workspace/src/renderer/src/components/ui/TextField/index.css
+++ b/apps/canvas-workspace/src/renderer/src/components/ui/TextField/index.css
@@ -12,7 +12,7 @@
 
 .ui-textfield__label {
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   color: rgba(55, 53, 47, 0.55);
   letter-spacing: 0.01em;
 }

--- a/apps/canvas-workspace/src/renderer/src/config/terminalLinkHandler.ts
+++ b/apps/canvas-workspace/src/renderer/src/config/terminalLinkHandler.ts
@@ -60,7 +60,7 @@ function confirmNavigate(url: string): Promise<boolean> {
       maxHeight: '96px',
       overflowY: 'auto',
       fontSize: '12px',
-      fontFamily: "'SF Mono', Menlo, 'Cascadia Code', monospace",
+      fontFamily: "'SF Mono', SFMono-Regular, Menlo, Monaco, Consolas, monospace",
       background: 'rgba(0, 0, 0, 0.04)',
       borderRadius: '8px',
       padding: '8px 10px',

--- a/apps/canvas-workspace/src/renderer/src/config/terminalTheme.ts
+++ b/apps/canvas-workspace/src/renderer/src/config/terminalTheme.ts
@@ -43,7 +43,7 @@ export const TERMINAL_OPTIONS: ITerminalOptions = {
   fontSize: BASE_TERMINAL_FONT_SIZE,
   lineHeight: 1.4,
   letterSpacing: 0,
-  fontFamily: "'SF Mono', 'Fira Code', Menlo, 'Cascadia Code', monospace",
+  fontFamily: "'SF Mono', SFMono-Regular, Menlo, Monaco, Consolas, monospace",
   // CLI output often paints secondary lines with the SGR dim attribute or a
   // grey (brightBlack), which on this near-white background blends almost
   // into the surface and becomes unreadable. Enforce a minimum contrast so

--- a/apps/canvas-workspace/src/renderer/src/main.tsx
+++ b/apps/canvas-workspace/src/renderer/src/main.tsx
@@ -1,3 +1,4 @@
+import '@fontsource-variable/lexend/wght.css';
 import { createRoot } from "react-dom/client";
 import { Router } from "wouter";
 import { useHashLocation } from "wouter/use-hash-location";

--- a/apps/canvas-workspace/src/renderer/src/main.tsx
+++ b/apps/canvas-workspace/src/renderer/src/main.tsx
@@ -1,4 +1,3 @@
-import '@fontsource-variable/lexend/wght.css';
 import { createRoot } from "react-dom/client";
 import { Router } from "wouter";
 import { useHashLocation } from "wouter/use-hash-location";

--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -8,9 +8,6 @@
   font-weight: 100 900;
   src: url("@fontsource-variable/lexend/files/lexend-latin-wght-normal.woff2")
     format("woff2-variations");
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
-    U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
-    U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 /* Allow --canvas-scale to be animated via CSS transition */
@@ -127,12 +124,6 @@
   --font: var(--font-sans);
   --font-ui: var(--font-sans);
   --font-mono: "SF Mono", SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  --font-size-ui: 13px;
-  --font-size-title: 15px;
-  --font-size-page-title: 24px;
-  --font-weight-regular: 400;
-  --font-weight-medium: 500;
-  --font-weight-emphasis: 600;
   --sidebar-width: 240px;
   --sidebar-collapsed: 48px;
   --titlebar-height: 38px;
@@ -199,8 +190,8 @@ body {
   color: var(--text);
   overflow: hidden;
   -webkit-font-smoothing: antialiased;
-  font-size: var(--font-size-ui);
-  font-weight: var(--font-weight-regular);
+  font-size: 13px;
+  font-weight: 400;
 }
 
 h1,
@@ -211,7 +202,7 @@ h5,
 h6,
 strong,
 b {
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 button,

--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -103,14 +103,21 @@
   --radius-xs: 4px;
   --radius-xl: 12px;
   --radius-pill: 999px;
-  --font: "SF Mono", "Fira Code", "Cascadia Code", Menlo, monospace;
-  --font-mono: "SF Mono", "Fira Code", "Cascadia Code", Menlo, monospace;
-  /* Humanist sans for canvas READING surfaces (node/frame/group titles) —
-   * same stack as the note editor (FileNodeBody). App chrome stays on the
-   * mono --font identity; this token is only for text the user reads as
-   * knowledge-map content, where mono's terminal texture reads as noise. */
-  --font-ui: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI",
-    "Inter", "Helvetica Neue", Arial, sans-serif;
+  /* Product typography: Lexend is bundled by Vite from Fontsource, while
+   * PingFang remains the native macOS CJK face. Code, paths, and terminal
+   * surfaces opt into the separate mono token. --font stays as a compatibility
+   * alias for the existing renderer styles that mean "UI text". */
+  --font-sans: "Lexend Variable", "PingFang SC", -apple-system,
+    BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font: var(--font-sans);
+  --font-ui: var(--font-sans);
+  --font-mono: "SF Mono", SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  --font-size-ui: 13px;
+  --font-size-title: 15px;
+  --font-size-page-title: 24px;
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-emphasis: 600;
   --sidebar-width: 240px;
   --sidebar-collapsed: 48px;
   --titlebar-height: 38px;
@@ -177,7 +184,19 @@ body {
   color: var(--text);
   overflow: hidden;
   -webkit-font-smoothing: antialiased;
-  font-size: 14px;
+  font-size: var(--font-size-ui);
+  font-weight: var(--font-weight-regular);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+strong,
+b {
+  font-weight: var(--font-weight-medium);
 }
 
 button,

--- a/apps/canvas-workspace/src/renderer/src/styles.css
+++ b/apps/canvas-workspace/src/renderer/src/styles.css
@@ -1,3 +1,18 @@
+/* The app only uses Lexend for English and numeric UI text. CJK falls through
+ * to the native system face, so bundling Latin Extended and Vietnamese would
+ * add unused fonts to every packaged app. */
+@font-face {
+  font-family: "Lexend Variable";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 100 900;
+  src: url("@fontsource-variable/lexend/files/lexend-latin-wght-normal.woff2")
+    format("woff2-variations");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
+    U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
+    U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
 /* Allow --canvas-scale to be animated via CSS transition */
 @property --canvas-scale {
   syntax: '<number>';

--- a/apps/canvas-workspace/src/renderer/src/typography.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/typography.test.ts
@@ -5,12 +5,11 @@ import { describe, expect, it } from 'vitest';
 
 const rendererRoot = fileURLToPath(new URL('.', import.meta.url));
 const globalCss = readFileSync(join(rendererRoot, 'styles.css'), 'utf8');
-const mainSource = readFileSync(join(rendererRoot, 'main.tsx'), 'utf8');
 const graphPageSource = readFileSync(join(rendererRoot, 'views/WorkspaceNodes/GraphPage.tsx'), 'utf8');
 const mindmapExportSource = readFileSync(join(rendererRoot, 'utils/mindmapExport.ts'), 'utf8');
 const canvasPackage = JSON.parse(
   readFileSync(join(rendererRoot, '../../../package.json'), 'utf8'),
-) as { dependencies?: Record<string, string> };
+) as { devDependencies?: Record<string, string> };
 
 const collectCssFiles = (directory: string): string[] => readdirSync(directory, { withFileTypes: true })
   .flatMap((entry) => {
@@ -30,9 +29,11 @@ describe('renderer typography system', () => {
     expect(globalCss).toContain('--font-weight-emphasis: 600');
   });
 
-  it('bundles Lexend locally through the renderer entrypoint', () => {
-    expect(canvasPackage.dependencies?.['@fontsource-variable/lexend']).toBeTruthy();
-    expect(mainSource).toContain("import '@fontsource-variable/lexend/wght.css'");
+  it('bundles only the Latin Lexend variable font at build time', () => {
+    expect(canvasPackage.devDependencies?.['@fontsource-variable/lexend']).toBeTruthy();
+    expect(globalCss).toContain('@fontsource-variable/lexend/files/lexend-latin-wght-normal.woff2');
+    expect(globalCss).not.toContain('lexend-latin-ext-wght-normal.woff2');
+    expect(globalCss).not.toContain('lexend-vietnamese-wght-normal.woff2');
   });
 
   it('uses the product font for canvas labels and waits for it before image export', () => {

--- a/apps/canvas-workspace/src/renderer/src/typography.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/typography.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync, readdirSync } from 'node:fs';
-import { extname, join } from 'node:path';
+import { extname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
@@ -21,12 +21,8 @@ describe('renderer typography system', () => {
   it('keeps the product, mono, size, and weight tokens explicit', () => {
     expect(globalCss).toContain('--font-sans: "Lexend Variable", "PingFang SC"');
     expect(globalCss).toContain('--font-mono: "SF Mono", SFMono-Regular');
-    expect(globalCss).toContain('--font-size-ui: 13px');
-    expect(globalCss).toContain('--font-size-title: 15px');
-    expect(globalCss).toContain('--font-size-page-title: 24px');
-    expect(globalCss).toContain('--font-weight-regular: 400');
-    expect(globalCss).toContain('--font-weight-medium: 500');
-    expect(globalCss).toContain('--font-weight-emphasis: 600');
+    expect(globalCss).toMatch(/body\s*\{[^}]*font-size:\s*13px;[^}]*font-weight:\s*400;/s);
+    expect(globalCss).toMatch(/h1,[\s\S]*?strong,[\s\S]*?b\s*\{[^}]*font-weight:\s*500;/s);
   });
 
   it('bundles only the Latin Lexend variable font at build time', () => {
@@ -47,9 +43,26 @@ describe('renderer typography system', () => {
   it('does not reintroduce heavy literal weights into renderer styles', () => {
     for (const path of collectCssFiles(rendererRoot)) {
       const css = readFileSync(path, 'utf8');
-      expect(css, path).not.toMatch(/^\s*font-weight:\s*(?:[6-9]\d{2}|bold);/m);
+      expect(css, path).not.toMatch(/^\s*font-weight:\s*(?:[7-9]\d{2}|bold);/m);
       expect(css, path).not.toMatch(/^\s*font:\s*[6-9]\d{2}\b/m);
     }
+  });
+
+  it('reserves 600 weight for page titles and the product brand', () => {
+    const allowed = new Set([
+      'components/shell/Sidebar/index.css',
+      'views/PluginMarket/index.css',
+      'views/Scheduled/index.css',
+      'views/SkillsLibrary/index.css',
+      'views/WorkspaceNodes/index.css',
+    ]);
+    const declarations = collectCssFiles(rendererRoot).flatMap((path) => {
+      const css = readFileSync(path, 'utf8');
+      const count = css.match(/^\s*font-weight:\s*600;/gm)?.length ?? 0;
+      return Array.from({ length: count }, () => relative(rendererRoot, path));
+    });
+    expect(new Set(declarations)).toEqual(allowed);
+    expect(declarations).toHaveLength(allowed.size);
   });
 
   it.each([
@@ -59,7 +72,7 @@ describe('renderer typography system', () => {
     'views/WorkspaceNodes/index.css',
   ])('uses the page-title scale in %s', (relativePath) => {
     const css = readFileSync(join(rendererRoot, relativePath), 'utf8');
-    expect(css).toContain('font-size: var(--font-size-page-title)');
-    expect(css).toContain('font-weight: var(--font-weight-emphasis)');
+    expect(css).toContain('font-size: 24px');
+    expect(css).toContain('font-weight: 600');
   });
 });

--- a/apps/canvas-workspace/src/renderer/src/typography.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/typography.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { extname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const rendererRoot = fileURLToPath(new URL('.', import.meta.url));
+const globalCss = readFileSync(join(rendererRoot, 'styles.css'), 'utf8');
+const mainSource = readFileSync(join(rendererRoot, 'main.tsx'), 'utf8');
+const graphPageSource = readFileSync(join(rendererRoot, 'views/WorkspaceNodes/GraphPage.tsx'), 'utf8');
+const mindmapExportSource = readFileSync(join(rendererRoot, 'utils/mindmapExport.ts'), 'utf8');
+const canvasPackage = JSON.parse(
+  readFileSync(join(rendererRoot, '../../../package.json'), 'utf8'),
+) as { dependencies?: Record<string, string> };
+
+const collectCssFiles = (directory: string): string[] => readdirSync(directory, { withFileTypes: true })
+  .flatMap((entry) => {
+    const path = join(directory, entry.name);
+    return entry.isDirectory() ? collectCssFiles(path) : extname(entry.name) === '.css' ? [path] : [];
+  });
+
+describe('renderer typography system', () => {
+  it('keeps the product, mono, size, and weight tokens explicit', () => {
+    expect(globalCss).toContain('--font-sans: "Lexend Variable", "PingFang SC"');
+    expect(globalCss).toContain('--font-mono: "SF Mono", SFMono-Regular');
+    expect(globalCss).toContain('--font-size-ui: 13px');
+    expect(globalCss).toContain('--font-size-title: 15px');
+    expect(globalCss).toContain('--font-size-page-title: 24px');
+    expect(globalCss).toContain('--font-weight-regular: 400');
+    expect(globalCss).toContain('--font-weight-medium: 500');
+    expect(globalCss).toContain('--font-weight-emphasis: 600');
+  });
+
+  it('bundles Lexend locally through the renderer entrypoint', () => {
+    expect(canvasPackage.dependencies?.['@fontsource-variable/lexend']).toBeTruthy();
+    expect(mainSource).toContain("import '@fontsource-variable/lexend/wght.css'");
+  });
+
+  it('uses the product font for canvas labels and waits for it before image export', () => {
+    expect(graphPageSource).toContain('"Lexend Variable", "PingFang SC"');
+    expect(graphPageSource).not.toContain('"SF Mono", "Fira Code"');
+    expect(mindmapExportSource).toContain('await Promise.all([');
+    expect(mindmapExportSource).toContain('document.fonts.load(`400 14px');
+    expect(mindmapExportSource).toContain('document.fonts.load(`500 20px');
+  });
+
+  it('does not reintroduce heavy literal weights into renderer styles', () => {
+    for (const path of collectCssFiles(rendererRoot)) {
+      const css = readFileSync(path, 'utf8');
+      expect(css, path).not.toMatch(/^\s*font-weight:\s*(?:[6-9]\d{2}|bold);/m);
+      expect(css, path).not.toMatch(/^\s*font:\s*[6-9]\d{2}\b/m);
+    }
+  });
+
+  it.each([
+    'views/SkillsLibrary/index.css',
+    'views/Scheduled/index.css',
+    'views/PluginMarket/index.css',
+    'views/WorkspaceNodes/index.css',
+  ])('uses the page-title scale in %s', (relativePath) => {
+    const css = readFileSync(join(rendererRoot, relativePath), 'utf8');
+    expect(css).toContain('font-size: var(--font-size-page-title)');
+    expect(css).toContain('font-weight: var(--font-weight-emphasis)');
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/utils/mindmapExport.ts
+++ b/apps/canvas-workspace/src/renderer/src/utils/mindmapExport.ts
@@ -3,6 +3,7 @@ import { layoutMindmap, type MindmapLayout, type LaidOutTopic } from './mindmapL
 
 const EXPORT_MARGIN = 28;
 const EXPORT_SCALE = 2;
+const MINDMAP_EXPORT_FONT_FAMILY = '"Lexend Variable", "PingFang SC", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
 
 export interface MindmapImageExport {
   data: string;
@@ -35,7 +36,7 @@ const drawTopic = (ctx: CanvasRenderingContext2D, topic: LaidOutTopic) => {
 
   ctx.save();
   ctx.fillStyle = '#1f2328';
-  ctx.font = `${fontWeight} ${fontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif`;
+  ctx.font = `${fontWeight} ${fontSize}px ${MINDMAP_EXPORT_FONT_FAMILY}`;
   ctx.textBaseline = 'middle';
   ctx.textAlign = isRoot ? 'center' : 'left';
 
@@ -135,6 +136,13 @@ const drawBranches = (ctx: CanvasRenderingContext2D, layout: MindmapLayout) => {
 };
 
 export const exportMindmapNodeToPng = async (node: CanvasNode): Promise<MindmapImageExport> => {
+  if (document.fonts) {
+    await Promise.all([
+      document.fonts.load(`400 14px ${MINDMAP_EXPORT_FONT_FAMILY}`, 'Aa 中文'),
+      document.fonts.load(`500 20px ${MINDMAP_EXPORT_FONT_FAMILY}`, 'Aa 中文'),
+    ]);
+  }
+
   const data = node.data as MindmapNodeData;
   const layout = layoutMindmap(data.root);
   const width = Math.ceil(layout.width + EXPORT_MARGIN * 2);

--- a/apps/canvas-workspace/src/renderer/src/views/PluginMarket/index.css
+++ b/apps/canvas-workspace/src/renderer/src/views/PluginMarket/index.css
@@ -37,15 +37,15 @@
 .plugin-market__intro > div:first-child > span {
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
 .plugin-market__intro h1 {
   margin: 7px 0 0;
-  font-size: var(--font-size-page-title);
-  font-weight: var(--font-weight-emphasis);
+  font-size: 24px;
+  font-weight: 600;
   line-height: 1.2;
   text-wrap: balance;
 }
@@ -85,7 +85,7 @@
 .plugin-market__section-heading h2 {
   margin: 0;
   font-size: 14px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .plugin-market__section-heading span {

--- a/apps/canvas-workspace/src/renderer/src/views/PluginMarket/index.css
+++ b/apps/canvas-workspace/src/renderer/src/views/PluginMarket/index.css
@@ -37,15 +37,15 @@
 .plugin-market__intro > div:first-child > span {
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
 .plugin-market__intro h1 {
   margin: 7px 0 0;
-  font-size: 22px;
-  font-weight: 600;
+  font-size: var(--font-size-page-title);
+  font-weight: var(--font-weight-emphasis);
   line-height: 1.2;
   text-wrap: balance;
 }
@@ -85,7 +85,7 @@
 .plugin-market__section-heading h2 {
   margin: 0;
   font-size: 14px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
 }
 
 .plugin-market__section-heading span {

--- a/apps/canvas-workspace/src/renderer/src/views/PluginMarket/list.css
+++ b/apps/canvas-workspace/src/renderer/src/views/PluginMarket/list.css
@@ -15,7 +15,7 @@
   padding-bottom: 9px;
   border-bottom: 1px solid var(--border);
   font-size: 14px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   line-height: 1.3;
 }
 
@@ -105,7 +105,7 @@
 .plugin-market__listing-title strong {
   overflow: hidden;
   font-size: 13px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/apps/canvas-workspace/src/renderer/src/views/PluginMarket/list.css
+++ b/apps/canvas-workspace/src/renderer/src/views/PluginMarket/list.css
@@ -15,7 +15,7 @@
   padding-bottom: 9px;
   border-bottom: 1px solid var(--border);
   font-size: 14px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1.3;
 }
 
@@ -105,7 +105,7 @@
 .plugin-market__listing-title strong {
   overflow: hidden;
   font-size: 13px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/apps/canvas-workspace/src/renderer/src/views/PluginMarket/modal.css
+++ b/apps/canvas-workspace/src/renderer/src/views/PluginMarket/modal.css
@@ -39,7 +39,7 @@
 .plugin-market-detail__identity small {
   color: var(--text-muted);
   font-size: 9px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -202,7 +202,7 @@
 .plugin-market-detail__source small {
   color: var(--text-muted);
   font-size: 9px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
 }
 
 .plugin-market-detail__source code {

--- a/apps/canvas-workspace/src/renderer/src/views/PluginMarket/modal.css
+++ b/apps/canvas-workspace/src/renderer/src/views/PluginMarket/modal.css
@@ -39,7 +39,7 @@
 .plugin-market-detail__identity small {
   color: var(--text-muted);
   font-size: 9px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -202,7 +202,7 @@
 .plugin-market-detail__source small {
   color: var(--text-muted);
   font-size: 9px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .plugin-market-detail__source code {

--- a/apps/canvas-workspace/src/renderer/src/views/Scheduled/index.css
+++ b/apps/canvas-workspace/src/renderer/src/views/Scheduled/index.css
@@ -20,7 +20,7 @@
 .scheduled-editor__header > span {
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -28,7 +28,8 @@
 .scheduled-page__header h1 {
   margin: 7px 0 0;
   color: var(--text);
-  font-size: 22px;
+  font-size: var(--font-size-page-title);
+  font-weight: var(--font-weight-emphasis);
   line-height: 1.2;
 }
 
@@ -166,7 +167,7 @@
 .scheduled-editor__prompt-heading > span {
   color: var(--text-muted);
   font-size: 11px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.01em;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/views/Scheduled/index.css
+++ b/apps/canvas-workspace/src/renderer/src/views/Scheduled/index.css
@@ -20,7 +20,7 @@
 .scheduled-editor__header > span {
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -28,8 +28,8 @@
 .scheduled-page__header h1 {
   margin: 7px 0 0;
   color: var(--text);
-  font-size: var(--font-size-page-title);
-  font-weight: var(--font-weight-emphasis);
+  font-size: 24px;
+  font-weight: 600;
   line-height: 1.2;
 }
 
@@ -167,7 +167,7 @@
 .scheduled-editor__prompt-heading > span {
   color: var(--text-muted);
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.01em;
 }
 

--- a/apps/canvas-workspace/src/renderer/src/views/SkillsLibrary/index.css
+++ b/apps/canvas-workspace/src/renderer/src/views/SkillsLibrary/index.css
@@ -36,7 +36,7 @@
 .skills-library__modal-header span {
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -44,8 +44,8 @@
 .skills-library__header h1 {
   margin: 7px 0 0;
   color: var(--text);
-  font-size: var(--font-size-page-title);
-  font-weight: var(--font-weight-emphasis);
+  font-size: 24px;
+  font-weight: 600;
   line-height: 1.2;
 }
 
@@ -319,7 +319,7 @@
 .skills-library__save-target > span {
   color: var(--text-secondary);
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .skills-library__save-target .ui-segmented__option {

--- a/apps/canvas-workspace/src/renderer/src/views/SkillsLibrary/index.css
+++ b/apps/canvas-workspace/src/renderer/src/views/SkillsLibrary/index.css
@@ -36,7 +36,7 @@
 .skills-library__modal-header span {
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -44,7 +44,8 @@
 .skills-library__header h1 {
   margin: 7px 0 0;
   color: var(--text);
-  font-size: 22px;
+  font-size: var(--font-size-page-title);
+  font-weight: var(--font-weight-emphasis);
   line-height: 1.2;
 }
 
@@ -318,7 +319,7 @@
 .skills-library__save-target > span {
   color: var(--text-secondary);
   font-size: 11px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
 }
 
 .skills-library__save-target .ui-segmented__option {

--- a/apps/canvas-workspace/src/renderer/src/views/WorkspaceNodes/GraphPage.tsx
+++ b/apps/canvas-workspace/src/renderer/src/views/WorkspaceNodes/GraphPage.tsx
@@ -488,7 +488,7 @@ export const GraphPage = ({
     if (shouldShowLabel && isHighlighted) {
       const label = node.label || nodeId;
       const fontSize = Math.max(8, 11 / globalScale);
-      ctx.font = `${fontSize}px "SF Mono", "Fira Code", Menlo, monospace`;
+      ctx.font = `${fontSize}px "Lexend Variable", "PingFang SC", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif`;
       const textWidth = ctx.measureText(label).width;
       const paddingX = 4;
       const paddingY = 2.5;

--- a/apps/canvas-workspace/src/renderer/src/views/WorkspaceNodes/NodeCards.css
+++ b/apps/canvas-workspace/src/renderer/src/views/WorkspaceNodes/NodeCards.css
@@ -95,7 +95,7 @@
   border-color: transparent;
   background: transparent;
   color: var(--accent);
-  font-weight: 620;
+  font-weight: var(--font-weight-medium);
 }
 
 .knowledge-node-filter-ai-scope.ui-btn:hover:not(:disabled) {
@@ -147,7 +147,7 @@
 
 .knowledge-node-filter-popover__header strong {
   font-size: 12px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
 }
 
 .knowledge-node-filter-section {
@@ -161,7 +161,7 @@
   padding: 5px 9px 4px;
   color: var(--nodes-faint);
   font-size: 9px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
@@ -188,7 +188,7 @@
 
 .knowledge-node-filter-option.is-selected {
   background: var(--nodes-surface-soft);
-  font-weight: 620;
+  font-weight: var(--font-weight-medium);
 }
 
 .knowledge-node-filter-option:focus-visible {
@@ -315,7 +315,7 @@
   -webkit-line-clamp: 2;
   color: var(--nodes-text);
   font-size: 14px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
   line-height: 1.38;
   letter-spacing: -0.01em;
   overflow-wrap: anywhere;
@@ -394,7 +394,7 @@
   box-shadow: var(--shadow-sm);
   color: var(--nodes-muted);
   font-size: 10px;
-  font-weight: 620;
+  font-weight: var(--font-weight-medium);
   line-height: 1;
 }
 
@@ -476,7 +476,7 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
 }
 
 .knowledge-card-preview__ai-summary-copy {
@@ -600,7 +600,7 @@
   background: var(--nodes-surface);
   color: var(--nodes-text);
   font-size: 10px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
   line-height: 1.35;
   transform: translateY(-50%);
 }

--- a/apps/canvas-workspace/src/renderer/src/views/WorkspaceNodes/NodeCards.css
+++ b/apps/canvas-workspace/src/renderer/src/views/WorkspaceNodes/NodeCards.css
@@ -95,7 +95,7 @@
   border-color: transparent;
   background: transparent;
   color: var(--accent);
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .knowledge-node-filter-ai-scope.ui-btn:hover:not(:disabled) {
@@ -147,7 +147,7 @@
 
 .knowledge-node-filter-popover__header strong {
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .knowledge-node-filter-section {
@@ -161,7 +161,7 @@
   padding: 5px 9px 4px;
   color: var(--nodes-faint);
   font-size: 9px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
@@ -188,7 +188,7 @@
 
 .knowledge-node-filter-option.is-selected {
   background: var(--nodes-surface-soft);
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .knowledge-node-filter-option:focus-visible {
@@ -315,7 +315,7 @@
   -webkit-line-clamp: 2;
   color: var(--nodes-text);
   font-size: 14px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1.38;
   letter-spacing: -0.01em;
   overflow-wrap: anywhere;
@@ -394,7 +394,7 @@
   box-shadow: var(--shadow-sm);
   color: var(--nodes-muted);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1;
 }
 
@@ -476,7 +476,7 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .knowledge-card-preview__ai-summary-copy {
@@ -600,7 +600,7 @@
   background: var(--nodes-surface);
   color: var(--nodes-text);
   font-size: 10px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1.35;
   transform: translateY(-50%);
 }

--- a/apps/canvas-workspace/src/renderer/src/views/WorkspaceNodes/NodeDetailDocument.css
+++ b/apps/canvas-workspace/src/renderer/src/views/WorkspaceNodes/NodeDetailDocument.css
@@ -138,7 +138,7 @@
   margin: 0;
   color: var(--nodes-faint);
   font-size: 9px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -346,7 +346,7 @@
   background: transparent;
   font-family: inherit;
   font-size: clamp(30px, 4vw, 38px);
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1.16;
   letter-spacing: -0.035em;
   overflow-wrap: anywhere;
@@ -436,7 +436,7 @@
   margin: 0;
   color: var(--nodes-faint);
   font-size: 9px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -484,7 +484,7 @@
   align-items: center;
   gap: 5px;
   font-size: 9px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
@@ -549,7 +549,7 @@
 
 .node-detail-panel--dock:not(.node-detail-panel--rich) .node-detail-panel__document-title {
   font-size: 18px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   line-height: 1.3;
 }
 
@@ -576,7 +576,7 @@
   list-style: none;
   color: var(--nodes-muted);
   font-size: 11px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   cursor: pointer;
   user-select: none;
 }
@@ -699,7 +699,7 @@
 .node-relation-editor__field-label {
   color: var(--nodes-faint);
   font-size: 9px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }

--- a/apps/canvas-workspace/src/renderer/src/views/WorkspaceNodes/NodeDetailDocument.css
+++ b/apps/canvas-workspace/src/renderer/src/views/WorkspaceNodes/NodeDetailDocument.css
@@ -138,7 +138,7 @@
   margin: 0;
   color: var(--nodes-faint);
   font-size: 9px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -346,7 +346,7 @@
   background: transparent;
   font-family: inherit;
   font-size: clamp(30px, 4vw, 38px);
-  font-weight: 720;
+  font-weight: var(--font-weight-medium);
   line-height: 1.16;
   letter-spacing: -0.035em;
   overflow-wrap: anywhere;
@@ -436,7 +436,7 @@
   margin: 0;
   color: var(--nodes-faint);
   font-size: 9px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -484,7 +484,7 @@
   align-items: center;
   gap: 5px;
   font-size: 9px;
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
@@ -549,7 +549,7 @@
 
 .node-detail-panel--dock:not(.node-detail-panel--rich) .node-detail-panel__document-title {
   font-size: 18px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
   line-height: 1.3;
 }
 
@@ -576,7 +576,7 @@
   list-style: none;
   color: var(--nodes-muted);
   font-size: 11px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   cursor: pointer;
   user-select: none;
 }
@@ -699,7 +699,7 @@
 .node-relation-editor__field-label {
   color: var(--nodes-faint);
   font-size: 9px;
-  font-weight: 650;
+  font-weight: var(--font-weight-medium);
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }

--- a/apps/canvas-workspace/src/renderer/src/views/WorkspaceNodes/index.css
+++ b/apps/canvas-workspace/src/renderer/src/views/WorkspaceNodes/index.css
@@ -104,7 +104,8 @@
 
 .workspace-nodes-page__header h1 {
   margin: 0;
-  font-size: 28px;
+  font-size: var(--font-size-page-title);
+  font-weight: var(--font-weight-emphasis);
   line-height: 1.2;
   letter-spacing: 0;
 }
@@ -129,7 +130,7 @@
   height: 32px;
   padding: 0 11px;
   font-size: 12px;
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   cursor: pointer;
 }
 
@@ -446,7 +447,7 @@
   border: none;
   background: transparent;
   color: var(--nodes-text);
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
   cursor: pointer;
 }
 
@@ -584,7 +585,7 @@
 }
 
 .node-detail-panel__property-row strong {
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -685,7 +686,7 @@
 }
 
 .workspace-node-chip--toolbar-action {
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
 }
 
 .workspace-graph-toolbar__more {

--- a/apps/canvas-workspace/src/renderer/src/views/WorkspaceNodes/index.css
+++ b/apps/canvas-workspace/src/renderer/src/views/WorkspaceNodes/index.css
@@ -104,8 +104,8 @@
 
 .workspace-nodes-page__header h1 {
   margin: 0;
-  font-size: var(--font-size-page-title);
-  font-weight: var(--font-weight-emphasis);
+  font-size: 24px;
+  font-weight: 600;
   line-height: 1.2;
   letter-spacing: 0;
 }
@@ -130,7 +130,7 @@
   height: 32px;
   padding: 0 11px;
   font-size: 12px;
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   cursor: pointer;
 }
 
@@ -447,7 +447,7 @@
   border: none;
   background: transparent;
   color: var(--nodes-text);
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   cursor: pointer;
 }
 
@@ -585,7 +585,7 @@
 }
 
 .node-detail-panel__property-row strong {
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -686,7 +686,7 @@
 }
 
 .workspace-node-chip--toolbar-action {
-  font-weight: var(--font-weight-medium);
+  font-weight: 500;
 }
 
 .workspace-graph-toolbar__more {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       '@ai-sdk/openai':
         specifier: ^3.0.21
         version: 3.0.21(zod@4.3.6)
-      '@fontsource-variable/lexend':
-        specifier: 5.3.0
-        version: 5.3.0
       '@larksuiteoapi/node-sdk':
         specifier: ^1.59.0
         version: 1.59.0
@@ -57,6 +54,9 @@ importers:
       '@earendil-works/pi-ai':
         specifier: 0.83.0
         version: 0.83.0(ws@8.21.0)(zod@4.3.6)
+      '@fontsource-variable/lexend':
+        specifier: 5.3.0
+        version: 5.3.0
       '@electron/rebuild':
         specifier: ^4.0.3
         version: 4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^3.0.21
         version: 3.0.21(zod@4.3.6)
+      '@fontsource-variable/lexend':
+        specifier: 5.3.0
+        version: 5.3.0
       '@larksuiteoapi/node-sdk':
         specifier: ^1.59.0
         version: 1.59.0
@@ -1048,6 +1051,9 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource-variable/lexend@5.3.0':
+    resolution: {integrity: sha512-3SXtiZ8rFbT0oaPzEboCG5RM3jtyhpNxandh1jWNLqvrJRfV/eP3R+GGw+o5e3hS1uqmAGutKxSvaWG5oyrimA==}
 
   '@google/genai@1.52.0':
     resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
@@ -5430,6 +5436,8 @@ snapshots:
       '@floating-ui/utils': 0.2.11
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fontsource-variable/lexend@5.3.0': {}
 
   '@google/genai@1.52.0':
     dependencies:


### PR DESCRIPTION
## Summary

- bundle Lexend Variable locally and introduce shared 13px / 15px / 24px typography tokens
- use PingFang SC for Chinese text and reserve SF Mono for code, paths, and terminal surfaces
- normalize renderer weights around 400 / 500, with 600 limited to page titles and the product brand
- align canvas-rendered labels and wait for Lexend before raster image export
- add regression coverage for the local font import, font stacks, type scale, and weight constraints

## Testing

- `node scripts/harness/run-harness-check.mjs --level standard` in an isolated clean worktree, 13/13 checks passed
- full Canvas suite: 425 test files, 2676 tests passed
- real Electron harness visual smoke, including computed Lexend/PingFang stacks and 13px / 400 body typography

## Notes

- `pnpm --filter canvas-workspace visual` was not run because the committed Playwright baselines are Linux-only and the current host is macOS.