### PR TITLE
fix(canvas): recover deleted chat sessions

### DIFF
--- a/apps/canvas-workspace/harness/knowledge/chat-sessions.md
+++ b/apps/canvas-workspace/harness/knowledge/chat-sessions.md
@@ -522,7 +522,12 @@ follows the live pointer, main no longer CAS-compares it at start. Instead the
 renderer's `expectedConversationSessionId` IS the run's anchor: if that
 conversation was deleted while the message was in flight, the turn returns
 `CHAT_SESSION_CHANGED` with the authoritative current session id, and nothing
-is persisted.
+is persisted. The keyed renderer must then fetch authoritative history, hydrate
+that conversation without overwriting a newer live snapshot, and adopt its
+session id; leaving the error on the rejected key strands the optimistic user
+message in a conversation that no longer exists.
+
+Guard: `src/renderer/src/components/chat/hooks/useChatComposerStateKeyed.test.tsx`.
 
 **Switching conversations while a run streams.** The rail stays usable: picking
 another session calls `disposeCurrentTurn` (via `useChatPagePendingSession`'s

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatComposerStateKeyed.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatComposerStateKeyed.test.tsx
@@ -114,6 +114,109 @@ describe('useChatComposerStateKeyed', () => {
     expect(latest?.messages.map(m => m.content)).toEqual(['B loaded']);
   });
 
+  it('restores the authoritative current conversation after a stale-session rejection', async () => {
+    const callbacks = new Map<string, (payload: any) => void>();
+    const listen = (name: string) => (_sessionId: string, callback: (payload: any) => void) => {
+      callbacks.set(name, callback);
+      return () => undefined;
+    };
+    const restoredMessages = [
+      { role: 'user' as const, content: 'latest thread', timestamp: 2 },
+    ];
+    const agent = {
+      loadSession: vi.fn(async () => ({
+        ok: true,
+        activeSessionId: 'session-a',
+        messages: [{ role: 'user' as const, content: 'stale thread', timestamp: 1 }],
+      })),
+      getHistory: vi.fn(async () => ({
+        ok: true,
+        activeSessionId: 'session-b',
+        messages: restoredMessages,
+      })),
+      onTextDelta: listen('text'),
+      onToolCall: listen('tool-call'),
+      onToolResult: listen('tool-result'),
+      onToolInputStart: listen('tool-input-start'),
+      onToolInputDelta: listen('tool-input-delta'),
+      onToolInputEnd: listen('tool-input-end'),
+      onClarifyRequest: listen('clarify'),
+      onChatComplete: listen('complete'),
+      onRoleTurnStart: listen('role-start'),
+      onRoleTurnEnd: listen('role-end'),
+      conversationChat: vi.fn(async () => {
+        callbacks.get('complete')?.({
+          ok: false,
+          code: 'CHAT_SESSION_CHANGED',
+          error: 'This conversation no longer exists. The latest thread was restored.',
+        });
+        return { ok: true, sessionId: 'session-a' };
+      }),
+    };
+    (window as unknown as { canvasWorkspace: unknown }).canvasWorkspace = { agent };
+    const nextRoot = createRoot(host!);
+    root = nextRoot;
+    await act(async () => {
+      nextRoot.render(createElement(I18nProvider, null, createElement(LiveHarness)));
+    });
+    await act(async () => {
+      await latest?.handleLoadSession('session-a');
+    });
+
+    await act(async () => {
+      expect(await latest?.sendMessage('message for deleted thread')).toBe(true);
+      await Promise.resolve();
+    });
+
+    expect(agent.getHistory).toHaveBeenCalledWith({ scope });
+    expect(latest?.activeSessionId).toBe('session-b');
+    expect(latest?.messages).toEqual(restoredMessages);
+    expect(latest?.conversationError)
+      .toBe('This conversation no longer exists. The latest thread was restored.');
+  });
+
+  it('does not let recovery override a newer explicit session load', async () => {
+    let finishRecovery!: (result: {
+      ok: true;
+      activeSessionId: string;
+      messages: Array<{ role: 'user'; content: string; timestamp: number }>;
+    }) => void;
+    const getHistory = vi.fn(() => new Promise(resolve => { finishRecovery = resolve; }));
+    const loadSession = vi.fn(async () => ({
+      ok: true,
+      activeSessionId: 'session-newer',
+      messages: [{ role: 'user' as const, content: 'newer intent', timestamp: 3 }],
+    }));
+    (window as unknown as { canvasWorkspace: unknown }).canvasWorkspace = {
+      agent: { getHistory, loadSession },
+    };
+    const nextRoot = createRoot(host!);
+    root = nextRoot;
+    await act(async () => {
+      nextRoot.render(createElement(I18nProvider, null, createElement(LiveHarness)));
+    });
+
+    let recovering!: Promise<{ sessionId: string; error: string } | null>;
+    await act(async () => {
+      recovering = latest!.recoverChangedSession('Conversation changed');
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await latest!.handleLoadSession('session-newer');
+    });
+    await act(async () => {
+      finishRecovery({
+        ok: true,
+        activeSessionId: 'session-older',
+        messages: [{ role: 'user', content: 'older recovery', timestamp: 2 }],
+      });
+      expect(await recovering).toBeNull();
+    });
+
+    expect(latest?.activeSessionId).toBe('session-newer');
+    expect(latest?.messages.map(message => message.content)).toEqual(['newer intent']);
+  });
+
   it('does not replace a running conversation with stale persisted history', async () => {
     setConversationMessages(keyB, [
       { role: 'user', content: 'live current turn', timestamp: 2 },

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatComposerStateKeyed.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatComposerStateKeyed.ts
@@ -7,7 +7,11 @@ import { useChatSessions } from './useChatSessions';
 import { useConversationRuntimeStream } from './useConversationRuntimeStream';
 import { useMentions } from './useMentions';
 import { conversationKeyFromScope } from './useConversationRuntimeStream';
-import { captureConversationSequences, hydrateConversationMessages } from './conversationStore';
+import {
+  captureConversationSequences,
+  hydrateConversationMessages,
+  setConversationError,
+} from './conversationStore';
 import type { LoadedConversation } from './loadedConversationSink';
 
 interface UseChatComposerStateKeyedOptions {
@@ -59,14 +63,25 @@ export function useChatComposerStateKeyed({
   const conversationKey: ConversationKey | undefined = conversationSessionId
     ? conversationKeyFromScope(agentScope, conversationSessionId)
     : undefined;
+  const changedSessionRecoveryRef = useRef<(
+    error: string,
+  ) => Promise<{ sessionId: string; error: string } | null>>();
+
+  const recoverChangedSession = useCallback(async (error: string) => {
+    const recovered = await changedSessionRecoveryRef.current?.(error);
+    if (!recovered) return;
+    setConversationError(
+      conversationKeyFromScope(agentScope, recovered.sessionId),
+      recovered.error,
+    );
+  }, [agentScope]);
 
   const chatStream = useConversationRuntimeStream({
     agentScope,
     allWorkspaces,
-    modelLabel: canvasModels.selectedLabel,
-    scopeLabel,
     conversationKey,
     visible: conversationVisible,
+    onSessionChanged: recoverChangedSession,
     onTurnComplete: () => {
       if (sessionListRefreshTimerRef.current) window.clearTimeout(sessionListRefreshTimerRef.current);
       sessionListRefreshTimerRef.current = window.setTimeout(() => {
@@ -95,6 +110,7 @@ export function useChatComposerStateKeyed({
     eagerLoad,
     skipInitialHistory,
   });
+  changedSessionRecoveryRef.current = chatSessions.recoverChangedSession;
 
   const loadSessionsRef = useRef(chatSessions.loadSessions);
   loadSessionsRef.current = chatSessions.loadSessions;

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatSessions.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatSessions.ts
@@ -385,18 +385,19 @@ export function useChatSessions({
       return next;
     });
   }, [scopeKey]);
-
   const retrySession = useCallback(async () => {
     const retry = threadRetryRef.current;
     if (retry?.scopeKey === scopeKey) {
       await runThreadFetch(retry.fetchThread, retry.expectedSessionId);
       return;
     }
-    await runThreadFetch(
-      () => window.canvasWorkspace.agent.getHistory({ scope: agentScopeRef.current }),
-    );
+    await runThreadFetch(() => window.canvasWorkspace.agent.getHistory({ scope: agentScopeRef.current }));
   }, [runThreadFetch, scopeKey]);
-
+  const recoverChangedSession = useCallback(async (error: string) => {
+    let recoveredSessionId: string | null | undefined;
+    const recovered = await runThreadFetch(async () => { const result = await window.canvasWorkspace.agent.getHistory({ scope: agentScopeRef.current }); if (result.ok) recoveredSessionId = result.activeSessionId; return result; });
+    return recovered && recoveredSessionId ? { sessionId: recoveredSessionId, error } : null;
+  }, [runThreadFetch]);
   const failSessionMutation = useCallback((result: {
     code?: string;
     error?: string;
@@ -405,7 +406,6 @@ export function useChatSessions({
     setSessionError({ code: result.code, message });
     throw new Error(message);
   }, []);
-
   const renameSession = useCallback(async (
     sessionId: string,
     title: string,
@@ -474,7 +474,6 @@ export function useChatSessions({
       }
     }
   }, [agentScope, failSessionMutation, loadSessions, mutationRef, onConversationLoaded, onConversationMutationStart, onMessagesLoaded, t]);
-
   return {
     adoptActiveSession,
     otherSessions: visibleSessionLists.otherSessions,
@@ -488,6 +487,7 @@ export function useChatSessions({
     closeSessionMenu,
     openSessionMenu,
     renameSession,
+    recoverChangedSession,
     retrySession,
     sessionMenuOpen,
     sessionMenuRef,

--- a/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useConversationRuntimeStream.ts
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/hooks/useConversationRuntimeStream.ts
@@ -25,10 +25,10 @@ import { clearConversationCompletion, recordConversationCompletion, useConversat
 export interface UseConversationRuntimeStreamOptions {
   agentScope: AgentScope;
   allWorkspaces?: WorkspaceOption[];
-  modelLabel?: string;
-  scopeLabel?: string;
   /** Fired on turn complete so the session rail refreshes previews. */
   onTurnComplete?: () => void;
+  /** Restore the authoritative current conversation after a stale-session rejection. */
+  onSessionChanged?: (error: string) => void | Promise<void>;
   /**
    * The conversation whose run state this surface drives. Optional so a
    * parent composer can mount before the session id is known; an empty key
@@ -48,9 +48,8 @@ const EMPTY_KEY: ConversationKey = { storeId: '', sessionId: '' };
 export function useConversationRuntimeStream({
   agentScope,
   allWorkspaces,
-  modelLabel,
-  scopeLabel,
   onTurnComplete,
+  onSessionChanged,
   conversationKey,
   visible = true,
 }: UseConversationRuntimeStreamOptions) {
@@ -65,10 +64,10 @@ export function useConversationRuntimeStream({
   const [messageTools, setMessageTools] = useState<Map<number, ToolCallStatus[]>>(new Map());
   const onTurnCompleteRef = useRef(onTurnComplete);
   onTurnCompleteRef.current = onTurnComplete;
+  const onSessionChangedRef = useRef(onSessionChanged);
+  onSessionChangedRef.current = onSessionChanged;
   const workspaceId = agentScope.kind === 'workspace' ? agentScope.workspaceId : undefined;
   const toolIdCounter = useRef(0);
-  const streamingMsgIdx = useRef(-1);
-
   useConversationVisibility(key, keyed && visible);
 
   useEffect(() => {
@@ -131,7 +130,6 @@ export function useConversationRuntimeStream({
         if (assistantIndex >= 0) return;
         const current = readConversationSnapshot(key).messages;
         assistantIndex = current.length;
-        streamingMsgIdx.current = current.length;
         setConversationMessages(key, [...current, { role: 'assistant', content: '', timestamp: Date.now() }]);
       };
 
@@ -232,10 +230,12 @@ export function useConversationRuntimeStream({
           if (settled) return;
           settled = true;
           if (completeResult.code === 'CHAT_SESSION_CHANGED') {
-            setConversationError(key, completeResult.error ?? 'Conversation changed');
+            const error = completeResult.error ?? 'Conversation changed';
+            setConversationError(key, error);
             setConversationLoading(key, false);
             recordConversationCompletion(key, 'failed', completeResult.runId ?? `${key.storeId}:${sessionId}:${userMessage.timestamp}`, trimmed.slice(0, 60));
             cleanupRunListeners();
+            void onSessionChangedRef.current?.(error);
             return;
           }
           textBatcher.flush();


### PR DESCRIPTION
## Summary

- restore the authoritative current conversation after `CHAT_SESSION_CHANGED`
- route recovery through the existing session-request coordinator so newer user navigation wins
- add regression coverage for restoration and the same-scope navigation race

## Testing

- `node scripts/harness/run-harness-check.mjs --path apps/canvas-workspace/src/renderer/src/components/chat/hooks/useConversationRuntimeStream.ts apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatComposerStateKeyed.ts apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatComposerStateKeyed.test.tsx apps/canvas-workspace/src/renderer/src/components/chat/hooks/useChatSessions.ts apps/canvas-workspace/harness/knowledge/chat-sessions.md`