### PR TITLE
release(canvas): 0.1.52

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.51",
+  "version": "0.1.52",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {

--- a/apps/canvas-workspace/src/main/__tests__/scheduled-task-service.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/scheduled-task-service.test.ts
@@ -204,6 +204,7 @@ describe('ScheduledTaskService', () => {
 
     await expect(service.startTaskNow(task.id, async () => 'orphan-session'))
       .rejects.toThrow('already running');
+    await vi.waitFor(() => expect(finishPreparation).toBeTypeOf('function'));
     finishPreparation?.('reserved-session');
     await expect(first).resolves.toMatchObject({ sessionId: 'reserved-session' });
 

--- a/apps/canvas-workspace/src/main/scheduled/scheduled-task-service.ts
+++ b/apps/canvas-workspace/src/main/scheduled/scheduled-task-service.ts
@@ -198,17 +198,22 @@ export class ScheduledTaskService {
     taskId: string,
     prepareSession: () => Promise<string>,
   ): Promise<{ task: ScheduledTask; sessionId: string }> {
-    const task = await this.getTask(taskId);
-    if (!task) throw new Error('Scheduled task not found');
-    if (this.running.has(task.id)) throw new Error('Scheduled task is already running');
-    this.running.add(task.id);
+    // Reserve by the caller-owned id before the first await. Two concurrent
+    // disk reads may settle out of order, so reserving after getTask() lets
+    // the later request win and makes the original request fail instead.
+    if (this.running.has(taskId)) throw new Error('Scheduled task is already running');
+    this.running.add(taskId);
+    let task: ScheduledTask;
     let sessionId: string;
     const attemptedAt = this.now();
     try {
+      const storedTask = await this.getTask(taskId);
+      if (!storedTask) throw new Error('Scheduled task not found');
+      task = storedTask;
       sessionId = await prepareSession();
       await this.markTaskStarted(task, { trigger: 'manual', sessionId }, attemptedAt);
     } catch (error) {
-      this.running.delete(task.id);
+      this.running.delete(taskId);
       await this.emitChange();
       throw error;
     }


### PR DESCRIPTION
## Release

Pulse Canvas 0.1.52 (stable, macOS arm64).

## User-visible changes

- Greatly reduced wait times for the home screen, conversation history, and new chats, with Agent warmup beginning as users type.
- Improved stability for large and cross-workspace session histories.
- Fixed MCP App positioning during Dock transitions and resizing.

## Release validation

- Standard repository gate: 9/9 passed.
- Public DMG SHA-256 matches the local artifact: `7a594700c8a0b448a9ed36ae6aea17e202718c1f8c8b167a9c1f94ce07672ee5`.
- Mounted public DMG reports version/build `0.1.52`; strict deep code-sign verification passed.
- R2 `latest.json` and the Cloudflare Pages download site both serve 0.1.52.

Also fixes a manual scheduled-task race found by the release gate: concurrent starts now reserve synchronously before session preparation.
