### PR TITLE
feat: split Feishu answer cards

### DIFF
--- a/apps/canvas-workspace/src/plugins/main/channel/__tests__/parse-inbound.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/__tests__/parse-inbound.test.ts
@@ -81,6 +81,20 @@ describe('parseInbound', () => {
     expect(out).toBeNull();
   });
 
+  it('group mention with user_id is accepted by name when bot identity only has open_id', () => {
+    const out = parseInbound(
+      event({
+        chatType: 'group',
+        chatId: 'gA',
+        mentions: [{ key: '@_user_bot', id: { user_id: 'bot_user' }, name: 'Pulse' }],
+        text: '@Pulse do it',
+      }),
+      { appId: 'cli_bot', openId: 'ou_bot', name: 'Pulse' },
+    );
+    expect(out).not.toBeNull();
+    expect(out!.text).toBe('do it');
+  });
+
   it('group @-mention strips the mention and marks isMention', () => {
     const out = parseInbound(
       event({ chatType: 'group', chatId: 'gA', mentions: [BOT_MENTION], text: '@bot do it' }),
@@ -155,6 +169,30 @@ describe('parseInbound', () => {
     expect(out!.conversationId).toBe('gT:th1');
     expect(out!.text).toBe('晚上好');
     expect(out!.isDirect).toBe(false);
+  });
+
+  it('topic group post at-tags keep their ids when mentions are omitted', () => {
+    const out = parseInbound(
+      event({
+        chatType: 'topic_group',
+        chatId: 'gT',
+        threadId: 'th1',
+        messageType: 'post',
+        mentions: undefined,
+        content: {
+          content: [
+            [
+              { tag: 'at', user_name: 'Pulse', user_id: 'bot_user' },
+              { tag: 'text', text: ' 晚上好' },
+            ],
+          ],
+        },
+      }),
+      BOT,
+    );
+    expect(out).not.toBeNull();
+    expect(out!.conversationId).toBe('gT:th1');
+    expect(out!.text).toBe('晚上好');
   });
 
   it('topic group: each thread is its own conversation, replies route in-thread', () => {

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/card.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/card.test.ts
@@ -51,7 +51,7 @@ describe('feishu card tool list', () => {
 
   it('progress card uses a compact native-like process block with step detail', () => {
     const body = texts(buildProgressCard('working', tools, 20)).join('\n');
-    expect(body).toContain('启动 Agent · 运行中 · Called tools 2 times · 20s');
+    expect(body).toContain('执行过程 · 运行中 · 调用 2 次 · 20s');
     expect(body).toContain('**当前步骤**');
     expect(body).toContain('**当前答复**\nworking');
     // Tool name is bolded; detail and timing follow as secondary segments.
@@ -67,7 +67,7 @@ describe('feishu card tool list', () => {
     expect(panel).toBeDefined();
     expect(panel!.expanded).toBe(false);
     const body = texts(card).join('\n');
-    expect(body).toContain('启动 Agent · 已完成 · Called tools 2 times · 20s');
+    expect(body).toContain('执行过程 · 已完成 · 调用 2 次 · 20s');
     expect(body).toContain('已完成 2 个步骤，最终答复见下一条消息。');
     expect(body).toContain('**执行步骤**');
     expect(body).toContain('**canvas_read_node** · node-1');

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/card.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/card.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import {
+  buildCompletedProcessCard,
   buildDoneCard,
+  buildFinalAnswerCard,
   buildProgressCard,
   buildWorkspacePickerCard,
   formatToolLabel,
@@ -52,20 +54,32 @@ describe('feishu card tool list', () => {
     // Tool name is bolded; detail and timing follow as secondary segments.
     expect(body).toContain('✅ **canvas_read_node** · node-1 · 18s');
     expect(body).toContain('⏳ **canvas_write_node** · node-2');
-    expect(body).toContain('⏱️ 20s');
+    expect(body).toContain('**耗时**：20s');
   });
 
-  it('done card folds the tool list into a collapsible panel', () => {
-    const card = buildDoneCard('the answer', tools) as {
+  it('completed process card folds the tool list into a collapsible panel', () => {
+    const card = buildCompletedProcessCard(tools, 20) as {
       body: { elements: Array<Record<string, unknown>> };
     };
     const panel = card.body.elements.find((e) => e.tag === 'collapsible_panel');
     expect(panel).toBeDefined();
     expect(panel!.expanded).toBe(false);
     const body = texts(card).join('\n');
-    expect(body).toContain('the answer');
-    expect(body).toContain('🛠️ 2 tool calls');
+    expect(body).toContain('**状态**：已完成');
+    expect(body).toContain('已完成 2 个步骤。');
+    expect(body).toContain('执行详情 (2)');
     expect(body).toContain('**canvas_read_node** · node-1');
+  });
+
+  it('final answer card is separate from process details', () => {
+    const card = buildFinalAnswerCard('the answer') as {
+      header: { title: { content: string } };
+      body: { elements: Array<Record<string, unknown>> };
+    };
+    const body = texts(card).join('\n');
+    expect(card.header.title.content).toBe('Pulse 最终答复');
+    expect(body).toContain('the answer');
+    expect(card.body.elements.some((e) => e.tag === 'collapsible_panel')).toBe(false);
   });
 
   it('done card with no tools is just the answer (no panel)', () => {

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/card.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/card.test.ts
@@ -49,15 +49,17 @@ describe('feishu card tool list', () => {
     expect(formatToolLabel('read', { docToken: 'doccnXyz' })).toBe('read — doccnXyz');
   });
 
-  it('progress card lists every tool with running/done status', () => {
+  it('progress card uses a compact native-like process block with step detail', () => {
     const body = texts(buildProgressCard('working', tools, 20)).join('\n');
+    expect(body).toContain('启动 Agent · 运行中 · Called tools 2 times · 20s');
+    expect(body).toContain('**当前步骤**');
+    expect(body).toContain('**当前答复**\nworking');
     // Tool name is bolded; detail and timing follow as secondary segments.
     expect(body).toContain('✅ **canvas_read_node** · node-1 · 18s');
     expect(body).toContain('⏳ **canvas_write_node** · node-2');
-    expect(body).toContain('**耗时**：20s');
   });
 
-  it('completed process card folds the tool list into a collapsible panel', () => {
+  it('completed process card collapses into an Agent process row', () => {
     const card = buildCompletedProcessCard(tools, 20) as {
       body: { elements: Array<Record<string, unknown>> };
     };
@@ -65,9 +67,9 @@ describe('feishu card tool list', () => {
     expect(panel).toBeDefined();
     expect(panel!.expanded).toBe(false);
     const body = texts(card).join('\n');
-    expect(body).toContain('**状态**：已完成');
-    expect(body).toContain('已完成 2 个步骤。');
-    expect(body).toContain('执行详情 (2)');
+    expect(body).toContain('启动 Agent · 已完成 · Called tools 2 times · 20s');
+    expect(body).toContain('已完成 2 个步骤，最终答复见下一条消息。');
+    expect(body).toContain('**执行步骤**');
     expect(body).toContain('**canvas_read_node** · node-1');
   });
 

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/stream.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/stream.test.ts
@@ -120,7 +120,7 @@ describe('FeishuStream', () => {
     expect(latestCard).toContain('Demo');
   });
 
-  it('falls back when a card patch hangs', async () => {
+  it('still sends the final answer card when the completed process patch hangs', async () => {
     mockedUpdateCard.mockImplementationOnce(() => new Promise(() => undefined));
     const stream = new FeishuStream({} as never, {
       chatId: 'group1',
@@ -133,14 +133,12 @@ describe('FeishuStream', () => {
     await vi.advanceTimersByTimeAsync(10_000);
     await done;
 
-    expect(mockedSendText).toHaveBeenCalledWith(
-      expect.anything(),
-      { chatId: 'group1', isGroup: true, triggerMessageId: 'm1' },
-      'final answer',
-    );
+    expect(mockedSendCard).toHaveBeenCalledTimes(2);
+    expect(JSON.stringify(mockedSendCard.mock.calls[1][2])).toContain('final answer');
+    expect(mockedSendText).not.toHaveBeenCalled();
   });
 
-  it('sends final text fallback when the final card update fails', async () => {
+  it('still sends the final answer card when the completed process update fails', async () => {
     mockedUpdateCard.mockRejectedValueOnce(new Error('final failed'));
     const stream = new FeishuStream({} as never, {
       chatId: 'group1',
@@ -152,10 +150,8 @@ describe('FeishuStream', () => {
     await stream.onDone('final answer');
 
     expect(mockedUpdateCard).toHaveBeenCalledTimes(1);
-    expect(mockedSendText).toHaveBeenCalledWith(
-      expect.anything(),
-      { chatId: 'group1', isGroup: true, triggerMessageId: 'm1' },
-      'final answer',
-    );
+    expect(mockedSendCard).toHaveBeenCalledTimes(2);
+    expect(JSON.stringify(mockedSendCard.mock.calls[1][2])).toContain('final answer');
+    expect(mockedSendText).not.toHaveBeenCalled();
   });
 });

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/bot-mention.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/bot-mention.ts
@@ -47,10 +47,22 @@ function mergeBotIdentity(base: FeishuBotIdentity, info: FeishuBotInfo): FeishuB
 }
 
 function normalizedIdentityValues(identity: FeishuBotIdentity | undefined): Set<string> {
-  const values = [identity?.appId, identity?.openId, identity?.userId, identity?.unionId]
-    .map((value) => value?.trim().toLowerCase())
-    .filter((value): value is string => Boolean(value));
-  return new Set(values);
+  return new Set(Object.values(normalizedIdentityByKind(identity)));
+}
+
+function normalizedIdentityByKind(identity: FeishuBotIdentity | undefined): Record<string, string> {
+  const pairs: Array<[string, string | undefined]> = [
+    ['app_id', identity?.appId],
+    ['open_id', identity?.openId],
+    ['user_id', identity?.userId],
+    ['union_id', identity?.unionId],
+  ];
+  const out: Record<string, string> = {};
+  for (const [kind, value] of pairs) {
+    const normalized = value?.trim().toLowerCase();
+    if (normalized) out[kind] = normalized;
+  }
+  return out;
 }
 
 function normalizedBotName(identity: FeishuBotIdentity | undefined): string | null {
@@ -64,49 +76,71 @@ function mentionName(mention: unknown): string | null {
   return typeof value === 'string' && value.trim() ? value.trim() : null;
 }
 
-function collectStringFields(value: unknown, out: string[]): void {
-  if (!value) return;
-  if (typeof value === 'string') {
-    if (value.trim()) out.push(value.trim());
-    return;
-  }
-  if (Array.isArray(value)) {
-    for (const item of value) collectStringFields(item, out);
-    return;
-  }
-  if (typeof value !== 'object') return;
-
-  for (const nested of Object.values(value as Record<string, unknown>)) {
-    collectStringFields(nested, out);
-  }
+interface MentionIdField {
+  kind: string;
+  value: string;
 }
 
-function collectMentionIdFields(mention: unknown): string[] {
+function normalizeIdKind(kind: string): string {
+  return kind
+    .replace(/[A-Z]/g, (char) => `_${char.toLowerCase()}`)
+    .replace(/^_/, '')
+    .toLowerCase();
+}
+
+function pushStringField(kind: string, value: unknown, out: MentionIdField[]): void {
+  if (typeof value !== 'string') return;
+  const normalized = value.trim().toLowerCase();
+  if (normalized) out.push({ kind: normalizeIdKind(kind), value: normalized });
+}
+
+function collectMentionIdFields(mention: unknown): MentionIdField[] {
   if (!mention || typeof mention !== 'object') return [];
   const record = mention as Record<string, unknown>;
-  const values: string[] = [];
-  collectStringFields(record.id, values);
-  collectStringFields(record.open_id, values);
-  collectStringFields(record.user_id, values);
-  collectStringFields(record.union_id, values);
+  const values: MentionIdField[] = [];
+  const nestedId = record.id;
+  if (nestedId && typeof nestedId === 'object' && !Array.isArray(nestedId)) {
+    const nested = nestedId as Record<string, unknown>;
+    for (const key of ['app_id', 'appId', 'open_id', 'openId', 'user_id', 'userId', 'union_id', 'unionId']) {
+      pushStringField(key, nested[key], values);
+    }
+  } else {
+    pushStringField('id', nestedId, values);
+  }
+  for (const key of ['app_id', 'appId', 'open_id', 'openId', 'user_id', 'userId', 'union_id', 'unionId']) {
+    pushStringField(key, record[key], values);
+  }
   return values;
 }
 
 function mentionMatchesBot(mention: unknown, identity: FeishuBotIdentity | undefined): boolean {
   const ids = normalizedIdentityValues(identity);
+  const idsByKind = normalizedIdentityByKind(identity);
   const name = normalizedBotName(identity);
   if (ids.size === 0 && !name) return false;
 
   const idValues = collectMentionIdFields(mention);
-  if (ids.size > 0 && idValues.length > 0) {
-    return idValues.some((value) => ids.has(value.trim().toLowerCase()));
+  const comparableIds = idValues.filter((field) => field.kind in idsByKind);
+  if (comparableIds.length > 0) {
+    return comparableIds.some((field) => idsByKind[field.kind] === field.value);
+  }
+  const genericIds = idValues.filter((field) => field.kind === 'id');
+  if (genericIds.length > 0) {
+    return genericIds.some((field) => ids.has(field.value));
   }
 
   return Boolean(name && mentionName(mention)?.toLowerCase() === name);
 }
 
+function markerIdFields(attrs: string): MentionIdField[] {
+  return Array.from(attrs.matchAll(/\b([\w:-]+)\s*=\s*["']([^"']+)["']/g))
+    .map((attr) => ({ kind: normalizeIdKind(attr[1]), value: attr[2].trim().toLowerCase() }))
+    .filter((field) => Boolean(field.value));
+}
+
 function hasBotMentionMarker(text: string, identity: FeishuBotIdentity | undefined): boolean {
   const ids = normalizedIdentityValues(identity);
+  const idsByKind = normalizedIdentityByKind(identity);
   const name = normalizedBotName(identity);
   if (ids.size === 0 && !name) return false;
 
@@ -114,11 +148,15 @@ function hasBotMentionMarker(text: string, identity: FeishuBotIdentity | undefin
   let match: RegExpExecArray | null;
   while ((match = markerPattern.exec(text))) {
     const [, attrs, label] = match;
-    const attrValues = Array.from(attrs.matchAll(/\b[\w:-]+\s*=\s*["']([^"']+)["']/g))
-      .map((attr) => attr[1].trim().toLowerCase())
-      .filter(Boolean);
-    if (ids.size > 0 && attrValues.length > 0) {
-      if (attrValues.some((value) => ids.has(value))) return true;
+    const attrValues = markerIdFields(attrs);
+    const comparableIds = attrValues.filter((field) => field.kind in idsByKind);
+    if (comparableIds.length > 0) {
+      if (comparableIds.some((field) => idsByKind[field.kind] === field.value)) return true;
+      continue;
+    }
+    const genericIds = attrValues.filter((field) => field.kind === 'id');
+    if (genericIds.length > 0) {
+      if (genericIds.some((field) => ids.has(field.value))) return true;
       continue;
     }
 

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
@@ -96,7 +96,7 @@ function splitToolLabel(label: string): { name: string; detail: string } {
 }
 
 function processSummary(status: string, toolCount: number, elapsedSec?: number): string {
-  const parts = [status, `Called tools ${toolCount} ${toolCount === 1 ? 'time' : 'times'}`];
+  const parts = [status, `调用 ${toolCount} 次`];
   if (typeof elapsedSec === 'number') parts.push(`${elapsedSec}s`);
   return parts.join(' · ');
 }
@@ -128,7 +128,7 @@ function processPanel(input: {
     tag: 'collapsible_panel',
     expanded: false,
     header: {
-      title: md(`启动 Agent · ${processSummary(input.status, tools.length, input.elapsedSec)}`),
+      title: md(`执行过程 · ${processSummary(input.status, tools.length, input.elapsedSec)}`),
       vertical_align: 'center',
     },
     elements: [md(detailSections.join('\n\n') || '正在初始化运行环境...')],
@@ -136,7 +136,7 @@ function processPanel(input: {
 }
 
 export function buildThinkingCard(): object {
-  return card('Pulse Agent', 'blue', [processPanel({
+  return card('Pulse 执行过程', 'blue', [processPanel({
     status: '准备中',
     note: '已收到请求，正在准备运行环境...',
   })], false);
@@ -147,7 +147,7 @@ export function buildProgressCard(
   tools: ToolEntry[] = [],
   elapsedSec?: number,
 ): object {
-  return card('Pulse Agent', 'blue', [processPanel({
+  return card('Pulse 执行过程', 'blue', [processPanel({
     status: '运行中',
     tools,
     elapsedSec,

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
@@ -95,28 +95,51 @@ function splitToolLabel(label: string): { name: string; detail: string } {
   return { name: label, detail: '' };
 }
 
-/** A collapsed panel holding the finished tool list (shown on the done card). */
-function toolPanel(tools: ToolEntry[]): object {
-  const n = tools.length;
+function processSummary(status: string, toolCount: number, elapsedSec?: number): string {
+  const parts = [status, `Called tools ${toolCount} ${toolCount === 1 ? 'time' : 'times'}`];
+  if (typeof elapsedSec === 'number') parts.push(`${elapsedSec}s`);
+  return parts.join(' · ');
+}
+
+function currentStepLine(tool?: ToolEntry): string | undefined {
+  if (!tool) return undefined;
+  const { name, detail } = splitToolLabel(tool.label);
+  const icon = tool.done ? '✅' : '⏳';
+  return `**当前步骤**\n${icon} ${name || 'tool'}${detail ? ` · ${detail}` : ''}`;
+}
+
+/** Native-like Agent process block: one compact row when collapsed, details on demand. */
+function processPanel(input: {
+  status: string;
+  tools?: ToolEntry[];
+  elapsedSec?: number;
+  currentAnswer?: string;
+  note?: string;
+}): object {
+  const tools = input.tools ?? [];
+  const detailSections = [
+    input.note,
+    currentStepLine(tools.at(-1)),
+    input.currentAnswer?.trim() ? `**当前答复**\n${clamp(input.currentAnswer.trim())}` : undefined,
+    tools.length > 0 ? `**执行步骤**\n${toolLines(tools)}` : undefined,
+  ].filter((section): section is string => Boolean(section));
+
   return {
     tag: 'collapsible_panel',
     expanded: false,
     header: {
-      title: md(`执行详情 (${n})`),
+      title: md(`启动 Agent · ${processSummary(input.status, tools.length, input.elapsedSec)}`),
       vertical_align: 'center',
     },
-    elements: [md(toolLines(tools))],
+    elements: [md(detailSections.join('\n\n') || '正在初始化运行环境...')],
   };
 }
 
-function statusLine(status: string, elapsedSec?: number): string {
-  return typeof elapsedSec === 'number'
-    ? `**状态**：${status}\n**耗时**：${elapsedSec}s`
-    : `**状态**：${status}`;
-}
-
 export function buildThinkingCard(): object {
-  return card('Pulse 正在处理', 'blue', [md(`${statusLine('准备中')}\n\n已收到请求，正在准备运行环境...`)], false);
+  return card('Pulse Agent', 'blue', [processPanel({
+    status: '准备中',
+    note: '已收到请求，正在准备运行环境...',
+  })], false);
 }
 
 export function buildProgressCard(
@@ -124,27 +147,22 @@ export function buildProgressCard(
   tools: ToolEntry[] = [],
   elapsedSec?: number,
 ): object {
-  const elements: object[] = [md(statusLine('运行中', elapsedSec))];
-  const latestTool = tools.at(-1);
-  if (latestTool) {
-    const { name, detail } = splitToolLabel(latestTool.label);
-    const icon = latestTool.done ? '✅' : '⏳';
-    elements.push(md(`**当前步骤**：${icon} ${name || 'tool'}${detail ? ` · ${detail}` : ''}`));
-  } else {
-    elements.push(md('正在生成答复...'));
-  }
-  if (text.trim()) {
-    elements.push(md(`**当前答复**\n${clamp(text.trim())}`));
-  }
-  if (tools.length > 0) elements.push(toolPanel(tools));
-  return card('Pulse 正在处理', 'blue', elements, false);
+  return card('Pulse Agent', 'blue', [processPanel({
+    status: '运行中',
+    tools,
+    elapsedSec,
+    currentAnswer: text,
+    note: tools.length === 0 ? '正在生成答复...' : undefined,
+  })], false);
 }
 
 export function buildCompletedProcessCard(tools: ToolEntry[] = [], elapsedSec?: number): object {
-  const lines = [statusLine('已完成', elapsedSec), `已完成 ${tools.length} 个步骤。`];
-  const elements: object[] = [md(lines.join('\n\n'))];
-  if (tools.length > 0) elements.push(toolPanel(tools));
-  return card('Pulse · Completed', 'green', elements, true);
+  return card('Pulse · Completed', 'green', [processPanel({
+    status: '已完成',
+    tools,
+    elapsedSec,
+    note: `已完成 ${tools.length} 个步骤，最终答复见下一条消息。`,
+  })], true);
 }
 
 export function buildFinalAnswerCard(text: string): object {
@@ -152,8 +170,14 @@ export function buildFinalAnswerCard(text: string): object {
 }
 
 export function buildDoneCard(text: string, tools: ToolEntry[] = []): object {
-  const elements: object[] = [md(`**状态**：已完成\n\n${clamp(text) || '✅ Done'}`)];
-  if (tools.length > 0) elements.push(toolPanel(tools));
+  const elements: object[] = [md(clamp(text) || '✅ Done')];
+  if (tools.length > 0) {
+    elements.push(processPanel({
+      status: '已完成',
+      tools,
+      note: `已完成 ${tools.length} 个步骤。`,
+    }));
+  }
   return card('Pulse 已完成', 'green', elements, true);
 }
 

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
@@ -35,10 +35,14 @@ function plainText(content: string): object {
   return { tag: 'plain_text', content };
 }
 
-function card(elements: object[], forward: boolean): object {
+function card(title: string, template: string, elements: object[], forward: boolean): object {
   return {
     schema: '2.0',
-    config: { enable_forward: forward },
+    config: { enable_forward: forward, wide_screen_mode: true },
+    header: {
+      template,
+      title: plainText(title),
+    },
     body: { elements },
   };
 }
@@ -98,15 +102,21 @@ function toolPanel(tools: ToolEntry[]): object {
     tag: 'collapsible_panel',
     expanded: false,
     header: {
-      title: md(`🛠️ ${n} tool call${n === 1 ? '' : 's'}`),
+      title: md(`执行详情 (${n})`),
       vertical_align: 'center',
     },
     elements: [md(toolLines(tools))],
   };
 }
 
+function statusLine(status: string, elapsedSec?: number): string {
+  return typeof elapsedSec === 'number'
+    ? `**状态**：${status}\n**耗时**：${elapsedSec}s`
+    : `**状态**：${status}`;
+}
+
 export function buildThinkingCard(): object {
-  return card([md('Pulse is thinking…')], false);
+  return card('Pulse 正在处理', 'blue', [md(`${statusLine('准备中')}\n\n已收到请求，正在准备运行环境...`)], false);
 }
 
 export function buildProgressCard(
@@ -114,22 +124,41 @@ export function buildProgressCard(
   tools: ToolEntry[] = [],
   elapsedSec?: number,
 ): object {
-  const parts: string[] = [];
-  if (text.trim()) parts.push(clamp(text.trim()));
-  if (tools.length > 0) parts.push(toolLines(tools));
-  if (parts.length === 0) parts.push('Pulse is thinking…');
-  if (typeof elapsedSec === 'number') parts.push(`---\n⏱️ ${elapsedSec}s`);
-  return card([md(parts.join('\n\n'))], false);
+  const elements: object[] = [md(statusLine('运行中', elapsedSec))];
+  const latestTool = tools.at(-1);
+  if (latestTool) {
+    const { name, detail } = splitToolLabel(latestTool.label);
+    const icon = latestTool.done ? '✅' : '⏳';
+    elements.push(md(`**当前步骤**：${icon} ${name || 'tool'}${detail ? ` · ${detail}` : ''}`));
+  } else {
+    elements.push(md('正在生成答复...'));
+  }
+  if (text.trim()) {
+    elements.push(md(`**当前答复**\n${clamp(text.trim())}`));
+  }
+  if (tools.length > 0) elements.push(toolPanel(tools));
+  return card('Pulse 正在处理', 'blue', elements, false);
+}
+
+export function buildCompletedProcessCard(tools: ToolEntry[] = [], elapsedSec?: number): object {
+  const lines = [statusLine('已完成', elapsedSec), `已完成 ${tools.length} 个步骤。`];
+  const elements: object[] = [md(lines.join('\n\n'))];
+  if (tools.length > 0) elements.push(toolPanel(tools));
+  return card('Pulse · Completed', 'green', elements, true);
+}
+
+export function buildFinalAnswerCard(text: string): object {
+  return card('Pulse 最终答复', 'green', [md(clamp(text) || '✅ Done')], true);
 }
 
 export function buildDoneCard(text: string, tools: ToolEntry[] = []): object {
-  const elements: object[] = [md(clamp(text) || '✅ Done')];
+  const elements: object[] = [md(`**状态**：已完成\n\n${clamp(text) || '✅ Done'}`)];
   if (tools.length > 0) elements.push(toolPanel(tools));
-  return card(elements, true);
+  return card('Pulse 已完成', 'green', elements, true);
 }
 
 export function buildErrorCard(message: string): object {
-  return card([md(`❌ Error: ${message}`)], false);
+  return card('Pulse 运行出错', 'red', [md(`**状态**：出错\n\n❌ ${message}`)], false);
 }
 
 export function buildWorkspacePickerCard(picker: WorkspacePicker, target?: OutboundTarget): object {

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-channel.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-channel.ts
@@ -17,8 +17,9 @@ import {
   type FeishuSendTarget,
 } from './feishu-client';
 import {
-  buildDoneCard,
+  buildCompletedProcessCard,
   buildErrorCard,
+  buildFinalAnswerCard,
   buildProgressCard,
   buildThinkingCard,
   buildWorkspacePickerCard,
@@ -356,7 +357,11 @@ export class FeishuStream implements ChannelStream {
       t.done = true;
       t.elapsedSec = Math.round((now - t.startedAt) / 1000);
     }
-    await this.finalize(() => buildDoneCard(text, this.tools), text);
+    await this.finalizeWithAnswer(
+      () => buildCompletedProcessCard(this.tools, this.elapsedSec()),
+      () => buildFinalAnswerCard(text),
+      text,
+    );
   }
 
   async onError(message: string): Promise<void> {
@@ -462,6 +467,38 @@ export class FeishuStream implements ChannelStream {
     }
   }
 
+  private async finalizeWithAnswer(
+    processFactory: () => object,
+    answerFactory: () => object,
+    fallbackText: string,
+  ): Promise<void> {
+    this.finalizing = true;
+    this.pendingProgressFactory = null;
+    if (this.updateInFlight) {
+      await this.updateInFlight;
+    }
+
+    if (!this.cardUpdateTimedOut) {
+      await this.patchCard(processFactory, 'Feishu completed process card update');
+    }
+
+    if (this.cardFailed) {
+      await this.sendFallbackText(fallbackText);
+      return;
+    }
+
+    try {
+      await withTimeout(
+        sendCardMessage(this.client, this.target, answerFactory()),
+        CARD_SEND_TIMEOUT_MS,
+        'Feishu final answer card send',
+      );
+    } catch (err) {
+      console.error('[channel:feishu] final answer card send failed', err);
+      await this.sendFallbackText(fallbackText);
+    }
+  }
+
   private async sendFallbackText(text: string): Promise<void> {
     try {
       await withTimeout(
@@ -531,6 +568,17 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+function escapeHtmlText(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function escapeHtmlAttr(value: string): string {
+  return escapeHtmlText(value).replace(/"/g, '&quot;');
+}
+
 function mentionString(mention: unknown, key: 'key' | 'name'): string | null {
   if (!mention || typeof mention !== 'object') return null;
   const value = (mention as Record<string, unknown>)[key];
@@ -569,7 +617,19 @@ function collectPostText(node: unknown, out: string[]): void {
   const tag = typeof record.tag === 'string' ? record.tag : '';
   if (tag === 'at') {
     const userName = typeof record.user_name === 'string' ? record.user_name.trim() : '';
-    out.push(userName ? `@${userName}` : '@');
+    const attrs = ['open_id', 'user_id', 'union_id']
+      .map((key) => {
+        const value = record[key];
+        return typeof value === 'string' && value.trim()
+          ? `${key}="${escapeHtmlAttr(value.trim())}"`
+          : null;
+      })
+      .filter((value): value is string => Boolean(value));
+    if (attrs.length > 0) {
+      out.push(`<at ${attrs.join(' ')}>${escapeHtmlText(userName)}</at>`);
+    } else {
+      out.push(userName ? `@${userName}` : '@');
+    }
     return;
   }
   if (typeof record.text === 'string' && record.text.trim()) {

--- a/apps/remote-server/src/adapters/feishu/adapter.ts
+++ b/apps/remote-server/src/adapters/feishu/adapter.ts
@@ -17,7 +17,8 @@ import {
   updateCardMessage,
   buildThinkingCard,
   buildProgressCard,
-  buildDoneCard,
+  buildCompletedProcessCard,
+  buildFinalAnswerCard,
   buildErrorCard,
 } from './client.js';
 import { buildFeishuPlatformKey, parseFeishuPlatformKey, resolveFeishuTopicId } from './platform-key.js';
@@ -468,22 +469,18 @@ export class FeishuAdapter implements PlatformAdapter {
         finalized = true;
         await updateChain;
 
-        const doneCard = () => buildDoneCard(result, { toolCalls: toolCallSummaries, context: buildRunCardContext() });
+        const doneContext = buildRunCardContext();
+        const processCard = () => buildCompletedProcessCard(doneContext, toolCallSummaries);
+        const finalAnswerCard = () => buildFinalAnswerCard(result);
 
-        if (cardMessageId) {
-          if (!isCardUpdateDisabled()) {
-            const ok = await tryUpdateCard(doneCard, 'done', { allowFinal: true });
-            if (ok) {
-              return;
-            }
-          }
-
-          await sendCardMessage(larkClient, chatId, idType, doneCard(), replyOptions).catch((err) => {
-            console.error('[feishu] Failed to send done card fallback:', err);
-          });
-        } else {
-          await sendTextMessage(larkClient, chatId, idType, result || '✅ Done', replyOptions).catch(console.error);
+        if (cardMessageId && !isCardUpdateDisabled()) {
+          await tryUpdateCard(processCard, 'done', { allowFinal: true });
         }
+
+        await sendCardMessage(larkClient, chatId, idType, finalAnswerCard(), replyOptions).catch(async (err) => {
+          console.error('[feishu] Failed to send final answer card:', err);
+          await sendTextMessage(larkClient, chatId, idType, result || '✅ Done', replyOptions).catch(console.error);
+        });
 
         if (sourceMessageId && allowReaction) {
           addMessageReaction(sourceMessageId, 'DONE').catch((reactionErr) => {

--- a/apps/remote-server/src/adapters/feishu/client-card.test.ts
+++ b/apps/remote-server/src/adapters/feishu/client-card.test.ts
@@ -34,24 +34,24 @@ describe('Feishu run cards', () => {
     toolCalls: ['read — AGENTS.md'],
   };
 
-  it('progress card separates status, current step, current answer, and collapsible details', () => {
+  it('progress card uses a compact native-like process row with collapsible details', () => {
     const card = buildProgressCard(context);
     const body = texts(card).join('\n');
 
-    expect(body).toContain('**状态**：运行中');
+    expect(body).toContain('启动 Agent · 运行中 · Called tools 1 time · 3s');
     expect(body).toContain('**当前步骤**');
     expect(body).toContain('read — AGENTS.md');
     expect(body).toContain('**当前答复**');
     expect(elements(card).some((item) => item.tag === 'collapsible_panel')).toBe(true);
   });
 
-  it('completed process card folds execution detail and points to the next answer card', () => {
+  it('completed process card folds into the Agent process row and points to the answer card', () => {
     const card = buildCompletedProcessCard(context, ['read — AGENTS.md']);
     const body = texts(card).join('\n');
 
-    expect(body).toContain('**状态**：已完成');
-    expect(body).toContain('已完成 1 个步骤。');
-    expect(body).toContain('**工具调用**');
+    expect(body).toContain('启动 Agent · 已完成 · Called tools 1 time · 3s');
+    expect(body).toContain('已完成 1 个步骤，最终答复见下一条消息。');
+    expect(body).toContain('**执行步骤**');
     expect(elements(card).some((item) => item.tag === 'collapsible_panel')).toBe(true);
   });
 

--- a/apps/remote-server/src/adapters/feishu/client-card.test.ts
+++ b/apps/remote-server/src/adapters/feishu/client-card.test.ts
@@ -38,7 +38,7 @@ describe('Feishu run cards', () => {
     const card = buildProgressCard(context);
     const body = texts(card).join('\n');
 
-    expect(body).toContain('启动 Agent · 运行中 · Called tools 1 time · 3s');
+    expect(body).toContain('执行过程 · 运行中 · 调用 1 次 · 3s');
     expect(body).toContain('**当前步骤**');
     expect(body).toContain('read — AGENTS.md');
     expect(body).toContain('**当前答复**');
@@ -49,7 +49,7 @@ describe('Feishu run cards', () => {
     const card = buildCompletedProcessCard(context, ['read — AGENTS.md']);
     const body = texts(card).join('\n');
 
-    expect(body).toContain('启动 Agent · 已完成 · Called tools 1 time · 3s');
+    expect(body).toContain('执行过程 · 已完成 · 调用 1 次 · 3s');
     expect(body).toContain('已完成 1 个步骤，最终答复见下一条消息。');
     expect(body).toContain('**执行步骤**');
     expect(elements(card).some((item) => item.tag === 'collapsible_panel')).toBe(true);

--- a/apps/remote-server/src/adapters/feishu/client-card.test.ts
+++ b/apps/remote-server/src/adapters/feishu/client-card.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildCompletedProcessCard, buildFinalAnswerCard, buildProgressCard } from './client.js';
+
+function texts(card: object): string[] {
+  const out: string[] = [];
+  const walk = (node: unknown): void => {
+    if (!node || typeof node !== 'object') return;
+    const record = node as Record<string, unknown>;
+    if (record.tag === 'markdown' && typeof record.content === 'string') out.push(record.content);
+    for (const value of Object.values(record)) {
+      if (Array.isArray(value)) value.forEach(walk);
+      else walk(value);
+    }
+  };
+  walk(card);
+  return out;
+}
+
+function elements(card: object): Array<Record<string, unknown>> {
+  return (card as { body: { elements: Array<Record<string, unknown>> } }).body.elements;
+}
+
+describe('Feishu run cards', () => {
+  const context = {
+    platformKey: 'feishu:group:g1',
+    memoryKey: 'feishu:user:u1',
+    streamId: 'm1',
+    runId: 'run-123',
+    prompt: '帮我检查逻辑',
+    elapsed: '3s',
+    latestToolHint: 'read — AGENTS.md',
+    detailText: 'partial answer',
+    toolCalls: ['read — AGENTS.md'],
+  };
+
+  it('progress card separates status, current step, current answer, and collapsible details', () => {
+    const card = buildProgressCard(context);
+    const body = texts(card).join('\n');
+
+    expect(body).toContain('**状态**：运行中');
+    expect(body).toContain('**当前步骤**');
+    expect(body).toContain('read — AGENTS.md');
+    expect(body).toContain('**当前答复**');
+    expect(elements(card).some((item) => item.tag === 'collapsible_panel')).toBe(true);
+  });
+
+  it('completed process card folds execution detail and points to the next answer card', () => {
+    const card = buildCompletedProcessCard(context, ['read — AGENTS.md']);
+    const body = texts(card).join('\n');
+
+    expect(body).toContain('**状态**：已完成');
+    expect(body).toContain('已完成 1 个步骤。');
+    expect(body).toContain('**工具调用**');
+    expect(elements(card).some((item) => item.tag === 'collapsible_panel')).toBe(true);
+  });
+
+  it('final answer card only contains the user-facing answer', () => {
+    const card = buildFinalAnswerCard('最终结论');
+    const body = texts(card).join('\n');
+
+    expect(body).toContain('最终结论');
+    expect(body).not.toContain('run-123');
+    expect(elements(card).some((item) => item.tag === 'collapsible_panel')).toBe(false);
+  });
+});

--- a/apps/remote-server/src/adapters/feishu/client.ts
+++ b/apps/remote-server/src/adapters/feishu/client.ts
@@ -594,7 +594,7 @@ function buttonRow(buttons: object[]): object {
 }
 
 function processSummary(status: string, toolCount: number, elapsed?: string): string {
-  const parts = [status, `Called tools ${toolCount} ${toolCount === 1 ? 'time' : 'times'}`];
+  const parts = [status, `调用 ${toolCount} 次`];
   if (elapsed) parts.push(elapsed);
   return parts.join(' · ');
 }
@@ -623,7 +623,7 @@ function buildRunProcessPanel(context: RunCardContext, status: string, toolCalls
     tag: 'collapsible_panel',
     expanded: false,
     header: {
-      title: md(`启动 Agent · ${processSummary(status, normalizedToolCalls.length, context.elapsed)}`),
+      title: md(`执行过程 · ${processSummary(status, normalizedToolCalls.length, context.elapsed)}`),
     },
     elements: [md(detailSections.join('\n\n') || '正在准备执行...')],
   };
@@ -637,38 +637,27 @@ function buildProgressElements(context: RunCardContext): object[] {
     context.latestToolHint ? undefined : '正在准备执行...',
   )];
   elements.push(buttonRow([
-    runActionButton('status', '状态', context, 'primary'),
     runActionButton('stop', '停止', context, 'danger'),
-  ]));
-  elements.push(buttonRow([
-    runActionButton('runId', '查看 runId', context),
-    runActionButton('new', '新会话', context),
   ]));
   return elements;
 }
 
 function buildCompletionActionElements(context: RunCardContext): object[] {
-  return [
-    buttonRow([
-      runActionButton('retry', '重试', context, 'primary'),
-      runActionButton('new', '新会话', context),
-    ]),
-    buttonRow([
-      runActionButton('status', '状态', context),
-      runActionButton('runId', '查看 runId', context),
-    ]),
-  ];
+  return [buttonRow([
+    runActionButton('retry', '重试', context, 'primary'),
+    runActionButton('new', '新会话', context),
+  ])];
 }
 
 export function buildThinkingCard(context: RunCardContext): object {
-  return buildCard('Pulse Agent', 'blue', buildProgressElements({
+  return buildCard('Pulse 执行过程', 'blue', buildProgressElements({
     ...context,
     detailText: '已收到请求，正在准备运行环境...',
   }), false);
 }
 
 export function buildProgressCard(context: RunCardContext): object {
-  return buildCard('Pulse Agent', 'blue', buildProgressElements(context), false);
+  return buildCard('Pulse 执行过程', 'blue', buildProgressElements(context), false);
 }
 
 export function buildCompletedProcessCard(context: RunCardContext, toolCalls: string[] = []): object {
@@ -701,7 +690,7 @@ export function buildDoneCard(_text: string, options: DoneCardOptions = {}): obj
       tag: 'collapsible_panel',
       expanded: false,
       header: {
-        title: plainText(`启动 Agent · ${processSummary('已完成', toolCalls.length)}`),
+        title: plainText(`执行过程 · ${processSummary('已完成', toolCalls.length)}`),
       },
       elements: [md(toolCalls.map((toolCall, index) => `${index + 1}. ${toolCall}`).join('\n'))],
     });

--- a/apps/remote-server/src/adapters/feishu/client.ts
+++ b/apps/remote-server/src/adapters/feishu/client.ts
@@ -594,19 +594,43 @@ function buttonRow(buttons: object[]): object {
 }
 
 function buildRunMeta(context: RunCardContext, status: string): string {
-  const lines = [`**状态**: ${status}`];
-  if (context.elapsed) lines.push(`**耗时**: ${context.elapsed}`);
-  if (context.runId) lines.push(`**runId**: \`${context.runId}\``);
-  lines.push(`**streamId**: \`${context.streamId}\``);
-  if (context.prompt) lines.push(`**请求**: ${clampCardText(context.prompt, 300)}`);
+  const lines = [`**状态**：${status}`];
+  if (context.elapsed) lines.push(`**耗时**：${context.elapsed}`);
+  if (context.runId) lines.push(`**runId**：\`${context.runId}\``);
+  lines.push(`**streamId**：\`${context.streamId}\``);
+  if (context.prompt) lines.push(`**请求**：${clampCardText(context.prompt, 300)}`);
   return lines.join('\n');
+}
+
+function buildRunDetailPanel(context: RunCardContext, toolCalls: string[] = []): object {
+  const detailSections = [buildRunMeta(context, context.elapsed ? '已记录' : '运行记录')];
+  const detailText = formatCardDetailText(context.latestToolHint, context.detailText);
+  if (detailText) detailSections.push(`**输出片段**\n${detailText}`);
+  if (toolCalls.length > 0) {
+    detailSections.push(`**工具调用**\n${toolCalls.map((toolCall, index) => `${index + 1}. ${toolCall}`).join('\n')}`);
+  }
+  return {
+    tag: 'collapsible_panel',
+    expanded: false,
+    header: {
+      title: plainText(`执行详情${toolCalls.length > 0 ? ` (${toolCalls.length})` : ''}`),
+    },
+    elements: [md(detailSections.join('\n\n'))],
+  };
 }
 
 function buildProgressElements(context: RunCardContext): object[] {
   const elements: object[] = [md(buildRunMeta(context, '运行中'))];
-  const detailText = formatCardDetailText(context.latestToolHint, context.detailText);
-  if (detailText) {
-    elements.push(md(detailText));
+  if (context.latestToolHint) {
+    elements.push(md(`**当前步骤**\n${context.latestToolHint}`));
+  } else {
+    elements.push(md('正在准备执行...'));
+  }
+  if (context.detailText?.trim()) {
+    elements.push(md(`**当前答复**\n${clampCardText(context.detailText.trim(), 1600)}`));
+  }
+  if (context.toolCalls?.length || context.runId || context.prompt) {
+    elements.push(buildRunDetailPanel(context, context.toolCalls ?? []));
   }
   elements.push(buttonRow([
     runActionButton('status', '状态', context, 'primary'),
@@ -643,39 +667,45 @@ export function buildProgressCard(context: RunCardContext): object {
   return buildCard('Pulse 正在处理', 'blue', buildProgressElements(context), false);
 }
 
+export function buildCompletedProcessCard(context: RunCardContext, toolCalls: string[] = []): object {
+  const normalizedToolCalls = toolCalls.filter(Boolean);
+  const elements: object[] = [md(`${buildRunMeta(context, '已完成')}\n\n已完成 ${normalizedToolCalls.length} 个步骤。`)];
+  elements.push(buildRunDetailPanel(context, normalizedToolCalls));
+  elements.push(...buildCompletionActionElements(context));
+  return buildCard('Pulse · Completed', 'green', elements, true);
+}
+
+export function buildFinalAnswerCard(text: string): object {
+  const finalText = formatCardDetailText(text) || '✅ Done';
+  return buildCard('Pulse 最终答复', 'green', [md(finalText)], true);
+}
+
 export function buildDoneCard(text: string, options: DoneCardOptions = {}): object {
   const context = options.context;
-  const elements: object[] = [md(formatCardDetailText(text) || '✅ Done')];
-  if (context) {
-    elements.unshift(md(buildRunMeta(context, '已完成')));
-  }
   const toolCalls = options.toolCalls?.filter(Boolean) ?? [];
+  const elements: object[] = [md(`**状态**：已完成\n\n这张过程卡已完成，最终答复见下一条消息。`)];
 
-  if (toolCalls.length > 0) {
+  if (context) {
+    elements.push(buildRunDetailPanel(context, toolCalls));
+    elements.push(...buildCompletionActionElements(context));
+  } else if (toolCalls.length > 0) {
     elements.push({
       tag: 'collapsible_panel',
       expanded: false,
       header: {
-        title: plainText(`工具调用明细 (${toolCalls.length})`),
+        title: plainText(`执行详情 (${toolCalls.length})`),
       },
       elements: [md(toolCalls.map((toolCall, index) => `${index + 1}. ${toolCall}`).join('\n'))],
     });
   }
 
-  if (context) {
-    elements.push(...buildCompletionActionElements(context));
-  }
-
-  return buildCard('Pulse 已完成', 'green', elements, true);
+  return buildCard('Pulse · Completed', 'green', elements, true);
 }
 
 export function buildErrorCard(message: string, context?: RunCardContext): object {
-  const elements: object[] = [];
+  const elements: object[] = [md(`**状态**：出错\n\n❌ ${clampCardText(message || 'unknown error', 3000)}`)];
   if (context) {
-    elements.push(md(buildRunMeta(context, '出错')));
-  }
-  elements.push(md(`❌ Error: ${clampCardText(message || 'unknown error', 3000)}`));
-  if (context) {
+    elements.push(buildRunDetailPanel(context));
     elements.push(...buildCompletionActionElements(context));
   }
   return buildCard('Pulse 运行出错', 'red', elements, false);

--- a/apps/remote-server/src/adapters/feishu/client.ts
+++ b/apps/remote-server/src/adapters/feishu/client.ts
@@ -593,45 +593,49 @@ function buttonRow(buttons: object[]): object {
   };
 }
 
-function buildRunMeta(context: RunCardContext, status: string): string {
-  const lines = [`**状态**：${status}`];
-  if (context.elapsed) lines.push(`**耗时**：${context.elapsed}`);
+function processSummary(status: string, toolCount: number, elapsed?: string): string {
+  const parts = [status, `Called tools ${toolCount} ${toolCount === 1 ? 'time' : 'times'}`];
+  if (elapsed) parts.push(elapsed);
+  return parts.join(' · ');
+}
+
+function buildRunMeta(context: RunCardContext): string {
+  const lines: string[] = [];
   if (context.runId) lines.push(`**runId**：\`${context.runId}\``);
   lines.push(`**streamId**：\`${context.streamId}\``);
   if (context.prompt) lines.push(`**请求**：${clampCardText(context.prompt, 300)}`);
   return lines.join('\n');
 }
 
-function buildRunDetailPanel(context: RunCardContext, toolCalls: string[] = []): object {
-  const detailSections = [buildRunMeta(context, context.elapsed ? '已记录' : '运行记录')];
-  const detailText = formatCardDetailText(context.latestToolHint, context.detailText);
-  if (detailText) detailSections.push(`**输出片段**\n${detailText}`);
-  if (toolCalls.length > 0) {
-    detailSections.push(`**工具调用**\n${toolCalls.map((toolCall, index) => `${index + 1}. ${toolCall}`).join('\n')}`);
-  }
+function buildRunProcessPanel(context: RunCardContext, status: string, toolCalls: string[] = [], note?: string): object {
+  const normalizedToolCalls = toolCalls.filter(Boolean);
+  const detailSections = [
+    note,
+    context.latestToolHint ? `**当前步骤**\n${context.latestToolHint}` : undefined,
+    context.detailText?.trim() ? `**当前答复**\n${clampCardText(context.detailText.trim(), 1600)}` : undefined,
+    normalizedToolCalls.length > 0
+      ? `**执行步骤**\n${normalizedToolCalls.map((toolCall, index) => `${index + 1}. ${toolCall}`).join('\n')}`
+      : undefined,
+    buildRunMeta(context),
+  ].filter((section): section is string => Boolean(section));
+
   return {
     tag: 'collapsible_panel',
     expanded: false,
     header: {
-      title: plainText(`执行详情${toolCalls.length > 0 ? ` (${toolCalls.length})` : ''}`),
+      title: md(`启动 Agent · ${processSummary(status, normalizedToolCalls.length, context.elapsed)}`),
     },
-    elements: [md(detailSections.join('\n\n'))],
+    elements: [md(detailSections.join('\n\n') || '正在准备执行...')],
   };
 }
 
 function buildProgressElements(context: RunCardContext): object[] {
-  const elements: object[] = [md(buildRunMeta(context, '运行中'))];
-  if (context.latestToolHint) {
-    elements.push(md(`**当前步骤**\n${context.latestToolHint}`));
-  } else {
-    elements.push(md('正在准备执行...'));
-  }
-  if (context.detailText?.trim()) {
-    elements.push(md(`**当前答复**\n${clampCardText(context.detailText.trim(), 1600)}`));
-  }
-  if (context.toolCalls?.length || context.runId || context.prompt) {
-    elements.push(buildRunDetailPanel(context, context.toolCalls ?? []));
-  }
+  const elements: object[] = [buildRunProcessPanel(
+    context,
+    '运行中',
+    context.toolCalls ?? [],
+    context.latestToolHint ? undefined : '正在准备执行...',
+  )];
   elements.push(buttonRow([
     runActionButton('status', '状态', context, 'primary'),
     runActionButton('stop', '停止', context, 'danger'),
@@ -657,20 +661,24 @@ function buildCompletionActionElements(context: RunCardContext): object[] {
 }
 
 export function buildThinkingCard(context: RunCardContext): object {
-  return buildCard('Pulse 正在处理', 'blue', buildProgressElements({
+  return buildCard('Pulse Agent', 'blue', buildProgressElements({
     ...context,
     detailText: '已收到请求，正在准备运行环境...',
   }), false);
 }
 
 export function buildProgressCard(context: RunCardContext): object {
-  return buildCard('Pulse 正在处理', 'blue', buildProgressElements(context), false);
+  return buildCard('Pulse Agent', 'blue', buildProgressElements(context), false);
 }
 
 export function buildCompletedProcessCard(context: RunCardContext, toolCalls: string[] = []): object {
   const normalizedToolCalls = toolCalls.filter(Boolean);
-  const elements: object[] = [md(`${buildRunMeta(context, '已完成')}\n\n已完成 ${normalizedToolCalls.length} 个步骤。`)];
-  elements.push(buildRunDetailPanel(context, normalizedToolCalls));
+  const elements: object[] = [buildRunProcessPanel(
+    context,
+    '已完成',
+    normalizedToolCalls,
+    `已完成 ${normalizedToolCalls.length} 个步骤，最终答复见下一条消息。`,
+  )];
   elements.push(...buildCompletionActionElements(context));
   return buildCard('Pulse · Completed', 'green', elements, true);
 }
@@ -680,32 +688,36 @@ export function buildFinalAnswerCard(text: string): object {
   return buildCard('Pulse 最终答复', 'green', [md(finalText)], true);
 }
 
-export function buildDoneCard(text: string, options: DoneCardOptions = {}): object {
+export function buildDoneCard(_text: string, options: DoneCardOptions = {}): object {
   const context = options.context;
   const toolCalls = options.toolCalls?.filter(Boolean) ?? [];
-  const elements: object[] = [md(`**状态**：已完成\n\n这张过程卡已完成，最终答复见下一条消息。`)];
+  const elements: object[] = [];
 
   if (context) {
-    elements.push(buildRunDetailPanel(context, toolCalls));
+    elements.push(buildRunProcessPanel(context, '已完成', toolCalls, '这张过程卡已完成，最终答复见下一条消息。'));
     elements.push(...buildCompletionActionElements(context));
   } else if (toolCalls.length > 0) {
     elements.push({
       tag: 'collapsible_panel',
       expanded: false,
       header: {
-        title: plainText(`执行详情 (${toolCalls.length})`),
+        title: plainText(`启动 Agent · ${processSummary('已完成', toolCalls.length)}`),
       },
       elements: [md(toolCalls.map((toolCall, index) => `${index + 1}. ${toolCall}`).join('\n'))],
     });
+  } else {
+    elements.push(md('这张过程卡已完成，最终答复见下一条消息。'));
   }
 
   return buildCard('Pulse · Completed', 'green', elements, true);
 }
 
 export function buildErrorCard(message: string, context?: RunCardContext): object {
-  const elements: object[] = [md(`**状态**：出错\n\n❌ ${clampCardText(message || 'unknown error', 3000)}`)];
+  const errorText = `❌ ${clampCardText(message || 'unknown error', 3000)}`;
+  const elements: object[] = context
+    ? [buildRunProcessPanel(context, '出错', context.toolCalls ?? [], errorText)]
+    : [md(errorText)];
   if (context) {
-    elements.push(buildRunDetailPanel(context));
     elements.push(...buildCompletionActionElements(context));
   }
   return buildCard('Pulse 运行出错', 'red', elements, false);


### PR DESCRIPTION
Align Feishu bot messages with a process-card plus final-answer-card flow.

- Update canvas-workspace Feishu cards to show running status, completed process summaries, collapsible execution details, and a separate final answer card
- Update remote-server Feishu cards to patch the original process card to Completed before sending a clean final answer card
- Preserve process-card action buttons while keeping final answer cards button-free
- Improve Feishu mention parsing coverage and add card/stream regression tests

Validation:
- pnpm --filter canvas-workspace exec vitest run src/plugins/main/channel/channels/feishu/__tests__/card.test.ts src/plugins/main/channel/channels/feishu/__tests__/stream.test.ts src/plugins/main/channel/__tests__/parse-inbound.test.ts
- pnpm --filter @pulse-coder/remote-server exec vitest run src/adapters/feishu/client-card.test.ts