### PR TITLE
style: lighten Feishu run interaction

### DIFF
--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/card.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/card.test.ts
@@ -48,19 +48,20 @@ describe('feishu card tool list', () => {
     expect(formatToolLabel('read', { docToken: 'doccnXyz' })).toBe('read — doccnXyz');
   });
 
-  it('progress card uses a compact native-like process block with step detail', () => {
+  it('progress card shows the current stage and folds tool details', () => {
     const card = buildProgressCard('working', tools, 20) as { header?: unknown };
     const body = texts(card).join('\n');
     expect(card.header).toBeUndefined();
-    expect(body).toContain('执行过程 · 运行中 · 调用 2 次 · 20s');
-    expect(body).toContain('**当前步骤**');
-    expect(body).toContain('**当前答复**\nworking');
-    // Tool name is bolded; detail and timing follow as secondary segments.
+    expect(body).toContain('**Canvas write node node-2**');
+    expect(body).toContain('运行中 · Called tools 2 times · 20s');
+    expect(body).toContain('Called tools 2 times');
+    expect(body).not.toContain('**当前答复**\nworking');
+    // Tool name is bolded; detail and timing are only inside the folded panel.
     expect(body).toContain('✅ **canvas_read_node** · node-1 · 18s');
     expect(body).toContain('⏳ **canvas_write_node** · node-2');
   });
 
-  it('completed process card collapses into an Agent process row', () => {
+  it('completed process card leaves only a completion row plus folded tool details', () => {
     const card = buildCompletedProcessCard(tools, 20) as {
       header?: unknown;
       body: { elements: Array<Record<string, unknown>> };
@@ -70,9 +71,10 @@ describe('feishu card tool list', () => {
     expect(panel!.expanded).toBe(false);
     expect(card.header).toBeUndefined();
     const body = texts(card).join('\n');
-    expect(body).toContain('执行过程 · 已完成 · 调用 2 次 · 20s');
+    expect(body).toContain('**Completed**');
     expect(body).toContain('已完成 2 个步骤，下面是最终答复。');
-    expect(body).toContain('**执行步骤**');
+    expect(body).toContain('Called tools 2 times');
+    expect(body).not.toContain('执行过程 · 已完成');
     expect(body).toContain('**canvas_read_node** · node-1');
   });
 

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/card.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/card.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 import {
   buildCompletedProcessCard,
   buildDoneCard,
-  buildFinalAnswerCard,
   buildProgressCard,
   buildWorkspacePickerCard,
   formatToolLabel,
@@ -50,7 +49,9 @@ describe('feishu card tool list', () => {
   });
 
   it('progress card uses a compact native-like process block with step detail', () => {
-    const body = texts(buildProgressCard('working', tools, 20)).join('\n');
+    const card = buildProgressCard('working', tools, 20) as { header?: unknown };
+    const body = texts(card).join('\n');
+    expect(card.header).toBeUndefined();
     expect(body).toContain('执行过程 · 运行中 · 调用 2 次 · 20s');
     expect(body).toContain('**当前步骤**');
     expect(body).toContain('**当前答复**\nworking');
@@ -61,27 +62,18 @@ describe('feishu card tool list', () => {
 
   it('completed process card collapses into an Agent process row', () => {
     const card = buildCompletedProcessCard(tools, 20) as {
+      header?: unknown;
       body: { elements: Array<Record<string, unknown>> };
     };
     const panel = card.body.elements.find((e) => e.tag === 'collapsible_panel');
     expect(panel).toBeDefined();
     expect(panel!.expanded).toBe(false);
+    expect(card.header).toBeUndefined();
     const body = texts(card).join('\n');
     expect(body).toContain('执行过程 · 已完成 · 调用 2 次 · 20s');
-    expect(body).toContain('已完成 2 个步骤，最终答复见下一条消息。');
+    expect(body).toContain('已完成 2 个步骤，下面是最终答复。');
     expect(body).toContain('**执行步骤**');
     expect(body).toContain('**canvas_read_node** · node-1');
-  });
-
-  it('final answer card is separate from process details', () => {
-    const card = buildFinalAnswerCard('the answer') as {
-      header: { title: { content: string } };
-      body: { elements: Array<Record<string, unknown>> };
-    };
-    const body = texts(card).join('\n');
-    expect(card.header.title.content).toBe('Pulse 最终答复');
-    expect(body).toContain('the answer');
-    expect(card.body.elements.some((e) => e.tag === 'collapsible_panel')).toBe(false);
   });
 
   it('done card with no tools is just the answer (no panel)', () => {

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/stream.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/stream.test.ts
@@ -120,7 +120,7 @@ describe('FeishuStream', () => {
     expect(latestCard).toContain('Demo');
   });
 
-  it('still sends the final answer card when the completed process patch hangs', async () => {
+  it('still sends the final answer as plain text when the completed process patch hangs', async () => {
     mockedUpdateCard.mockImplementationOnce(() => new Promise(() => undefined));
     const stream = new FeishuStream({} as never, {
       chatId: 'group1',
@@ -133,12 +133,12 @@ describe('FeishuStream', () => {
     await vi.advanceTimersByTimeAsync(10_000);
     await done;
 
-    expect(mockedSendCard).toHaveBeenCalledTimes(2);
-    expect(JSON.stringify(mockedSendCard.mock.calls[1][2])).toContain('final answer');
-    expect(mockedSendText).not.toHaveBeenCalled();
+    expect(mockedSendCard).toHaveBeenCalledTimes(1);
+    expect(mockedSendText).toHaveBeenCalledTimes(1);
+    expect(mockedSendText.mock.calls[0][2]).toBe('final answer');
   });
 
-  it('still sends the final answer card when the completed process update fails', async () => {
+  it('still sends the final answer as plain text when the completed process update fails', async () => {
     mockedUpdateCard.mockRejectedValueOnce(new Error('final failed'));
     const stream = new FeishuStream({} as never, {
       chatId: 'group1',
@@ -150,8 +150,8 @@ describe('FeishuStream', () => {
     await stream.onDone('final answer');
 
     expect(mockedUpdateCard).toHaveBeenCalledTimes(1);
-    expect(mockedSendCard).toHaveBeenCalledTimes(2);
-    expect(JSON.stringify(mockedSendCard.mock.calls[1][2])).toContain('final answer');
-    expect(mockedSendText).not.toHaveBeenCalled();
+    expect(mockedSendCard).toHaveBeenCalledTimes(1);
+    expect(mockedSendText).toHaveBeenCalledTimes(1);
+    expect(mockedSendText.mock.calls[0][2]).toBe('final answer');
   });
 });

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
@@ -35,14 +35,18 @@ function plainText(content: string): object {
   return { tag: 'plain_text', content };
 }
 
-function card(title: string, template: string, elements: object[], forward: boolean): object {
+function card(title: string | undefined, template: string, elements: object[], forward: boolean): object {
   return {
     schema: '2.0',
     config: { enable_forward: forward, wide_screen_mode: true },
-    header: {
-      template,
-      title: plainText(title),
-    },
+    ...(title
+      ? {
+          header: {
+            template,
+            title: plainText(title),
+          },
+        }
+      : {}),
     body: { elements },
   };
 }
@@ -136,7 +140,7 @@ function processPanel(input: {
 }
 
 export function buildThinkingCard(): object {
-  return card('Pulse 执行过程', 'blue', [processPanel({
+  return card(undefined, 'blue', [processPanel({
     status: '准备中',
     note: '已收到请求，正在准备运行环境...',
   })], false);
@@ -147,7 +151,7 @@ export function buildProgressCard(
   tools: ToolEntry[] = [],
   elapsedSec?: number,
 ): object {
-  return card('Pulse 执行过程', 'blue', [processPanel({
+  return card(undefined, 'blue', [processPanel({
     status: '运行中',
     tools,
     elapsedSec,
@@ -157,16 +161,14 @@ export function buildProgressCard(
 }
 
 export function buildCompletedProcessCard(tools: ToolEntry[] = [], elapsedSec?: number): object {
-  return card('Pulse · Completed', 'green', [processPanel({
+  return card(undefined, 'green', [processPanel({
     status: '已完成',
     tools,
     elapsedSec,
-    note: `已完成 ${tools.length} 个步骤，最终答复见下一条消息。`,
-  })], true);
-}
-
-export function buildFinalAnswerCard(text: string): object {
-  return card('Pulse 最终答复', 'green', [md(clamp(text) || '✅ Done')], true);
+    note: tools.length > 0
+      ? `已完成 ${tools.length} 个步骤，下面是最终答复。`
+      : '已完成，下面是最终答复。',
+  })], false);
 }
 
 export function buildDoneCard(text: string, tools: ToolEntry[] = []): object {

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
@@ -76,14 +76,12 @@ function formButton(
   };
 }
 
-/** Render the tool calls as a status list (⏳ running · ✅ done with timing). */
+/** Render the tool calls as a folded status list (details only on demand). */
 function toolLines(tools: ToolEntry[]): string {
   return tools
     .map((t) => {
       const icon = t.done ? '✅' : '⏳';
       const { name, detail } = splitToolLabel(t.label);
-      // Bold the tool name so each row reads as "what" then "on what",
-      // keeping the detail (and timing) visually secondary.
       const segs = [`${icon} **${name || 'tool'}**`];
       if (detail) segs.push(detail);
       if (t.done && typeof t.elapsedSec === 'number') segs.push(`${t.elapsedSec}s`);
@@ -99,82 +97,99 @@ function splitToolLabel(label: string): { name: string; detail: string } {
   return { name: label, detail: '' };
 }
 
-function processSummary(status: string, toolCount: number, elapsedSec?: number): string {
-  const parts = [status, `调用 ${toolCount} 次`];
+function toolCountLine(count: number): string {
+  return `Called tools ${count} ${count === 1 ? 'time' : 'times'}`;
+}
+
+function titleizeToolName(name: string): string {
+  const words = name.replace(/[_-]+/g, ' ').trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return 'Tool';
+  return words.map((word, index) => (
+    index === 0 ? `${word.charAt(0).toUpperCase()}${word.slice(1)}` : word
+  )).join(' ');
+}
+
+function stepTitle(status: string, tools: ToolEntry[]): string {
+  if (status === '已完成') return 'Completed';
+  if (status === '出错') return 'Error';
+  const latest = tools.at(-1);
+  if (!latest) return 'Thinking';
+  const { name, detail } = splitToolLabel(latest.label);
+  const title = titleizeToolName(name);
+  return detail ? `${title} ${detail}` : title;
+}
+
+function stepSubtitle(status: string, toolCount: number, elapsedSec?: number): string {
+  const parts = [status];
+  if (toolCount > 0) parts.push(toolCountLine(toolCount));
   if (typeof elapsedSec === 'number') parts.push(`${elapsedSec}s`);
   return parts.join(' · ');
 }
 
-function currentStepLine(tool?: ToolEntry): string | undefined {
-  if (!tool) return undefined;
-  const { name, detail } = splitToolLabel(tool.label);
-  const icon = tool.done ? '✅' : '⏳';
-  return `**当前步骤**\n${icon} ${name || 'tool'}${detail ? ` · ${detail}` : ''}`;
-}
-
-/** Native-like Agent process block: one compact row when collapsed, details on demand. */
-function processPanel(input: {
-  status: string;
-  tools?: ToolEntry[];
-  elapsedSec?: number;
-  currentAnswer?: string;
-  note?: string;
-}): object {
-  const tools = input.tools ?? [];
-  const detailSections = [
-    input.note,
-    currentStepLine(tools.at(-1)),
-    input.currentAnswer?.trim() ? `**当前答复**\n${clamp(input.currentAnswer.trim())}` : undefined,
-    tools.length > 0 ? `**执行步骤**\n${toolLines(tools)}` : undefined,
-  ].filter((section): section is string => Boolean(section));
-
+function toolPanel(tools: ToolEntry[]): object | undefined {
+  if (tools.length === 0) return undefined;
   return {
     tag: 'collapsible_panel',
     expanded: false,
     header: {
-      title: md(`执行过程 · ${processSummary(input.status, tools.length, input.elapsedSec)}`),
+      title: md(toolCountLine(tools.length)),
       vertical_align: 'center',
     },
-    elements: [md(detailSections.join('\n\n') || '正在初始化运行环境...')],
+    elements: [md(toolLines(tools))],
   };
 }
 
+/** Native-like Agent process block: stage title stays visible; tool details fold away. */
+function processElements(input: {
+  status: string;
+  tools?: ToolEntry[];
+  elapsedSec?: number;
+  note?: string;
+}): object[] {
+  const tools = input.tools ?? [];
+  const title = stepTitle(input.status, tools);
+  const subtitle = stepSubtitle(input.status, tools.length, input.elapsedSec);
+  const elements: object[] = [md(`**${title}**\n${input.note ?? subtitle}`)];
+  const foldedTools = toolPanel(tools);
+  if (foldedTools) elements.push(foldedTools);
+  return elements;
+}
+
 export function buildThinkingCard(): object {
-  return card(undefined, 'blue', [processPanel({
+  return card(undefined, 'blue', processElements({
     status: '准备中',
     note: '已收到请求，正在准备运行环境...',
-  })], false);
+  }), false);
 }
 
 export function buildProgressCard(
-  text: string,
+  _text: string,
   tools: ToolEntry[] = [],
   elapsedSec?: number,
 ): object {
-  return card(undefined, 'blue', [processPanel({
+  return card(undefined, 'blue', processElements({
     status: '运行中',
     tools,
     elapsedSec,
-    currentAnswer: text,
     note: tools.length === 0 ? '正在生成答复...' : undefined,
-  })], false);
+  }), false);
 }
 
 export function buildCompletedProcessCard(tools: ToolEntry[] = [], elapsedSec?: number): object {
-  return card(undefined, 'green', [processPanel({
+  return card(undefined, 'green', processElements({
     status: '已完成',
     tools,
     elapsedSec,
     note: tools.length > 0
       ? `已完成 ${tools.length} 个步骤，下面是最终答复。`
       : '已完成，下面是最终答复。',
-  })], false);
+  }), false);
 }
 
 export function buildDoneCard(text: string, tools: ToolEntry[] = []): object {
   const elements: object[] = [md(clamp(text) || '✅ Done')];
   if (tools.length > 0) {
-    elements.push(processPanel({
+    elements.push(...processElements({
       status: '已完成',
       tools,
       note: `已完成 ${tools.length} 个步骤。`,

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-channel.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-channel.ts
@@ -19,7 +19,6 @@ import {
 import {
   buildCompletedProcessCard,
   buildErrorCard,
-  buildFinalAnswerCard,
   buildProgressCard,
   buildThinkingCard,
   buildWorkspacePickerCard,
@@ -359,7 +358,6 @@ export class FeishuStream implements ChannelStream {
     }
     await this.finalizeWithAnswer(
       () => buildCompletedProcessCard(this.tools, this.elapsedSec()),
-      () => buildFinalAnswerCard(text),
       text,
     );
   }
@@ -469,8 +467,7 @@ export class FeishuStream implements ChannelStream {
 
   private async finalizeWithAnswer(
     processFactory: () => object,
-    answerFactory: () => object,
-    fallbackText: string,
+    answerText: string,
   ): Promise<void> {
     this.finalizing = true;
     this.pendingProgressFactory = null;
@@ -482,21 +479,7 @@ export class FeishuStream implements ChannelStream {
       await this.patchCard(processFactory, 'Feishu completed process card update');
     }
 
-    if (this.cardFailed) {
-      await this.sendFallbackText(fallbackText);
-      return;
-    }
-
-    try {
-      await withTimeout(
-        sendCardMessage(this.client, this.target, answerFactory()),
-        CARD_SEND_TIMEOUT_MS,
-        'Feishu final answer card send',
-      );
-    } catch (err) {
-      console.error('[channel:feishu] final answer card send failed', err);
-      await this.sendFallbackText(fallbackText);
-    }
+    await this.sendFallbackText(answerText || '✅ Done');
   }
 
   private async sendFallbackText(text: string): Promise<void> {

--- a/apps/remote-server/src/adapters/feishu/adapter.ts
+++ b/apps/remote-server/src/adapters/feishu/adapter.ts
@@ -18,7 +18,6 @@ import {
   buildThinkingCard,
   buildProgressCard,
   buildCompletedProcessCard,
-  buildFinalAnswerCard,
   buildErrorCard,
 } from './client.js';
 import { buildFeishuPlatformKey, parseFeishuPlatformKey, resolveFeishuTopicId } from './platform-key.js';
@@ -471,15 +470,13 @@ export class FeishuAdapter implements PlatformAdapter {
 
         const doneContext = buildRunCardContext();
         const processCard = () => buildCompletedProcessCard(doneContext, toolCallSummaries);
-        const finalAnswerCard = () => buildFinalAnswerCard(result);
 
         if (cardMessageId && !isCardUpdateDisabled()) {
           await tryUpdateCard(processCard, 'done', { allowFinal: true });
         }
 
-        await sendCardMessage(larkClient, chatId, idType, finalAnswerCard(), replyOptions).catch(async (err) => {
-          console.error('[feishu] Failed to send final answer card:', err);
-          await sendTextMessage(larkClient, chatId, idType, result || '✅ Done', replyOptions).catch(console.error);
+        await sendTextMessage(larkClient, chatId, idType, result || '✅ Done', replyOptions).catch((err) => {
+          console.error('[feishu] Failed to send final answer text:', err);
         });
 
         if (sourceMessageId && allowReaction) {

--- a/apps/remote-server/src/adapters/feishu/client-card.test.ts
+++ b/apps/remote-server/src/adapters/feishu/client-card.test.ts
@@ -34,28 +34,30 @@ describe('Feishu run cards', () => {
     toolCalls: ['read — AGENTS.md'],
   };
 
-  it('progress card uses a compact native-like process row with collapsible details', () => {
+  it('progress card shows the current stage and folds tool details', () => {
     const card = buildProgressCard(context) as { header?: unknown };
     const body = texts(card).join('\n');
 
     expect(card.header).toBeUndefined();
-    expect(body).toContain('执行过程 · 运行中 · 调用 1 次 · 3s');
-    expect(body).toContain('**当前步骤**');
-    expect(body).toContain('read — AGENTS.md');
-    expect(body).toContain('**当前答复**');
+    expect(body).toContain('**Read AGENTS.md**');
+    expect(body).toContain('运行中 · Called tools 1 time · 3s');
+    expect(body).toContain('Called tools 1 time');
+    expect(body).not.toContain('**当前答复**');
+    expect(body).not.toContain('run-123');
     expect(JSON.stringify(card)).not.toContain('"tag":"button"');
     expect(elements(card).some((item) => item.tag === 'collapsible_panel')).toBe(true);
   });
 
-  it('completed process card folds into the Agent process row and points to the following answer', () => {
+  it('completed process card leaves only a completion row plus folded tool details', () => {
     const card = buildCompletedProcessCard(context, ['read — AGENTS.md']) as { header?: unknown };
     const body = texts(card).join('\n');
 
     expect(card.header).toBeUndefined();
-    expect(body).toContain('执行过程 · 已完成 · 调用 1 次 · 3s');
+    expect(body).toContain('**Completed**');
     expect(body).toContain('已完成 1 个步骤，下面是最终答复。');
+    expect(body).toContain('Called tools 1 time');
+    expect(body).not.toContain('执行过程 · 已完成');
     expect(JSON.stringify(card)).not.toContain('"tag":"button"');
-    expect(body).toContain('**执行步骤**');
     expect(elements(card).some((item) => item.tag === 'collapsible_panel')).toBe(true);
   });
 });

--- a/apps/remote-server/src/adapters/feishu/client-card.test.ts
+++ b/apps/remote-server/src/adapters/feishu/client-card.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildCompletedProcessCard, buildFinalAnswerCard, buildProgressCard } from './client.js';
+import { buildCompletedProcessCard, buildProgressCard } from './client.js';
 
 function texts(card: object): string[] {
   const out: string[] = [];
@@ -35,32 +35,27 @@ describe('Feishu run cards', () => {
   };
 
   it('progress card uses a compact native-like process row with collapsible details', () => {
-    const card = buildProgressCard(context);
+    const card = buildProgressCard(context) as { header?: unknown };
     const body = texts(card).join('\n');
 
+    expect(card.header).toBeUndefined();
     expect(body).toContain('执行过程 · 运行中 · 调用 1 次 · 3s');
     expect(body).toContain('**当前步骤**');
     expect(body).toContain('read — AGENTS.md');
     expect(body).toContain('**当前答复**');
+    expect(JSON.stringify(card)).not.toContain('"tag":"button"');
     expect(elements(card).some((item) => item.tag === 'collapsible_panel')).toBe(true);
   });
 
-  it('completed process card folds into the Agent process row and points to the answer card', () => {
-    const card = buildCompletedProcessCard(context, ['read — AGENTS.md']);
+  it('completed process card folds into the Agent process row and points to the following answer', () => {
+    const card = buildCompletedProcessCard(context, ['read — AGENTS.md']) as { header?: unknown };
     const body = texts(card).join('\n');
 
+    expect(card.header).toBeUndefined();
     expect(body).toContain('执行过程 · 已完成 · 调用 1 次 · 3s');
-    expect(body).toContain('已完成 1 个步骤，最终答复见下一条消息。');
+    expect(body).toContain('已完成 1 个步骤，下面是最终答复。');
+    expect(JSON.stringify(card)).not.toContain('"tag":"button"');
     expect(body).toContain('**执行步骤**');
     expect(elements(card).some((item) => item.tag === 'collapsible_panel')).toBe(true);
-  });
-
-  it('final answer card only contains the user-facing answer', () => {
-    const card = buildFinalAnswerCard('最终结论');
-    const body = texts(card).join('\n');
-
-    expect(body).toContain('最终结论');
-    expect(body).not.toContain('run-123');
-    expect(elements(card).some((item) => item.tag === 'collapsible_panel')).toBe(false);
   });
 });

--- a/apps/remote-server/src/adapters/feishu/client.ts
+++ b/apps/remote-server/src/adapters/feishu/client.ts
@@ -542,54 +542,19 @@ function plainText(content: string): object {
   return { tag: 'plain_text', content };
 }
 
-function buildCard(title: string, template: string, elements: object[], enableForward: boolean): object {
+function buildCard(title: string | undefined, template: string, elements: object[], enableForward: boolean): object {
   return {
     schema: '2.0',
     config: { enable_forward: enableForward, wide_screen_mode: true },
-    header: {
-      template,
-      title: plainText(title),
-    },
+    ...(title
+      ? {
+          header: {
+            template,
+            title: plainText(title),
+          },
+        }
+      : {}),
     body: { elements },
-  };
-}
-
-function runActionButton(
-  command: 'status' | 'stop' | 'retry' | 'new' | 'runId',
-  text: string,
-  context: RunCardContext,
-  type: 'default' | 'primary' | 'danger' = 'default',
-): object {
-  const value = {
-    action: FEISHU_RUN_CARD_ACTION,
-    command,
-    platformKey: context.platformKey,
-    memoryKey: context.memoryKey,
-    streamId: context.streamId,
-    runId: context.runId,
-    prompt: context.prompt,
-  };
-  return {
-    tag: 'button',
-    text: plainText(text),
-    type,
-    width: 'fill',
-    value,
-    behaviors: [{ type: 'callback', value }],
-  };
-}
-
-function buttonRow(buttons: object[]): object {
-  return {
-    tag: 'column_set',
-    flex_mode: 'bisect',
-    horizontal_spacing: '8px',
-    columns: buttons.map((button) => ({
-      tag: 'column',
-      width: 'weighted',
-      weight: 1,
-      elements: [button],
-    })),
   };
 }
 
@@ -636,28 +601,19 @@ function buildProgressElements(context: RunCardContext): object[] {
     context.toolCalls ?? [],
     context.latestToolHint ? undefined : '正在准备执行...',
   )];
-  elements.push(buttonRow([
-    runActionButton('stop', '停止', context, 'danger'),
-  ]));
   return elements;
 }
 
-function buildCompletionActionElements(context: RunCardContext): object[] {
-  return [buttonRow([
-    runActionButton('retry', '重试', context, 'primary'),
-    runActionButton('new', '新会话', context),
-  ])];
-}
 
 export function buildThinkingCard(context: RunCardContext): object {
-  return buildCard('Pulse 执行过程', 'blue', buildProgressElements({
+  return buildCard(undefined, 'blue', buildProgressElements({
     ...context,
     detailText: '已收到请求，正在准备运行环境...',
   }), false);
 }
 
 export function buildProgressCard(context: RunCardContext): object {
-  return buildCard('Pulse 执行过程', 'blue', buildProgressElements(context), false);
+  return buildCard(undefined, 'blue', buildProgressElements(context), false);
 }
 
 export function buildCompletedProcessCard(context: RunCardContext, toolCalls: string[] = []): object {
@@ -666,15 +622,11 @@ export function buildCompletedProcessCard(context: RunCardContext, toolCalls: st
     context,
     '已完成',
     normalizedToolCalls,
-    `已完成 ${normalizedToolCalls.length} 个步骤，最终答复见下一条消息。`,
+    normalizedToolCalls.length > 0
+      ? `已完成 ${normalizedToolCalls.length} 个步骤，下面是最终答复。`
+      : '已完成，下面是最终答复。',
   )];
-  elements.push(...buildCompletionActionElements(context));
-  return buildCard('Pulse · Completed', 'green', elements, true);
-}
-
-export function buildFinalAnswerCard(text: string): object {
-  const finalText = formatCardDetailText(text) || '✅ Done';
-  return buildCard('Pulse 最终答复', 'green', [md(finalText)], true);
+  return buildCard(undefined, 'green', elements, false);
 }
 
 export function buildDoneCard(_text: string, options: DoneCardOptions = {}): object {
@@ -683,8 +635,7 @@ export function buildDoneCard(_text: string, options: DoneCardOptions = {}): obj
   const elements: object[] = [];
 
   if (context) {
-    elements.push(buildRunProcessPanel(context, '已完成', toolCalls, '这张过程卡已完成，最终答复见下一条消息。'));
-    elements.push(...buildCompletionActionElements(context));
+    elements.push(buildRunProcessPanel(context, '已完成', toolCalls, '这张过程卡已完成，下面是最终答复。'));
   } else if (toolCalls.length > 0) {
     elements.push({
       tag: 'collapsible_panel',
@@ -706,8 +657,5 @@ export function buildErrorCard(message: string, context?: RunCardContext): objec
   const elements: object[] = context
     ? [buildRunProcessPanel(context, '出错', context.toolCalls ?? [], errorText)]
     : [md(errorText)];
-  if (context) {
-    elements.push(...buildCompletionActionElements(context));
-  }
   return buildCard('Pulse 运行出错', 'red', elements, false);
 }

--- a/apps/remote-server/src/adapters/feishu/client.ts
+++ b/apps/remote-server/src/adapters/feishu/client.ts
@@ -558,58 +558,111 @@ function buildCard(title: string | undefined, template: string, elements: object
   };
 }
 
-function processSummary(status: string, toolCount: number, elapsed?: string): string {
-  const parts = [status, `调用 ${toolCount} 次`];
+function toolCountLine(count: number): string {
+  return `Called tools ${count} ${count === 1 ? 'time' : 'times'}`;
+}
+
+function titleizeToolName(name: string): string {
+  const words = name.replace(/[_-]+/g, ' ').trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return 'Tool';
+  return words.map((word, index) => (
+    index === 0 ? `${word.charAt(0).toUpperCase()}${word.slice(1)}` : word
+  )).join(' ');
+}
+
+function splitToolSummary(summary: string): { name: string; detail: string } {
+  const label = summary.replace(/^[-*\s]*[🛠️✅⏳❌\s]*/u, '').trim();
+  const dashIndex = label.indexOf(' — ');
+  if (dashIndex >= 0) {
+    return { name: label.slice(0, dashIndex), detail: label.slice(dashIndex + 3) };
+  }
+
+  const toolMatch = label.match(/Calling tool:\s*`([^`]+)`/i);
+  if (!toolMatch) {
+    return { name: label.split('\n')[0] ?? '', detail: '' };
+  }
+
+  const argsMatch = label.match(/Args:\s*`([^`]+)`/i);
+  return {
+    name: toolMatch[1] ?? '',
+    detail: argsMatch?.[1] ? summarizeToolArgs(argsMatch[1]) : '',
+  };
+}
+
+function summarizeToolArgs(rawArgs: string): string {
+  try {
+    const parsed = JSON.parse(rawArgs) as unknown;
+    if (typeof parsed === 'object' && parsed !== null) {
+      const record = parsed as Record<string, unknown>;
+      const candidate = record.path ?? record.filePath ?? record.url ?? record.query ?? record.command ?? record.prompt;
+      if (typeof candidate === 'string' && candidate.trim()) {
+        return clampCardText(candidate.trim().split('/').pop() || candidate.trim(), 80);
+      }
+    }
+  } catch {
+    // Fall through to a short raw preview.
+  }
+  return clampCardText(rawArgs, 80);
+}
+
+function stepTitle(status: string, context: RunCardContext, toolCalls: string[]): string {
+  if (status === '已完成') return 'Completed';
+  if (status === '出错') return 'Error';
+
+  const latestSummary = context.latestToolHint || toolCalls.at(-1);
+  if (!latestSummary) return 'Thinking';
+
+  const { name, detail } = splitToolSummary(latestSummary);
+  const title = titleizeToolName(name);
+  return detail ? `${title} ${detail}` : title;
+}
+
+function stepSubtitle(status: string, toolCount: number, elapsed?: string): string {
+  const parts = [status];
+  if (toolCount > 0) parts.push(toolCountLine(toolCount));
   if (elapsed) parts.push(elapsed);
   return parts.join(' · ');
 }
 
-function buildRunMeta(context: RunCardContext): string {
-  const lines: string[] = [];
-  if (context.runId) lines.push(`**runId**：\`${context.runId}\``);
-  lines.push(`**streamId**：\`${context.streamId}\``);
-  if (context.prompt) lines.push(`**请求**：${clampCardText(context.prompt, 300)}`);
-  return lines.join('\n');
-}
-
-function buildRunProcessPanel(context: RunCardContext, status: string, toolCalls: string[] = [], note?: string): object {
-  const normalizedToolCalls = toolCalls.filter(Boolean);
-  const detailSections = [
-    note,
-    context.latestToolHint ? `**当前步骤**\n${context.latestToolHint}` : undefined,
-    context.detailText?.trim() ? `**当前答复**\n${clampCardText(context.detailText.trim(), 1600)}` : undefined,
-    normalizedToolCalls.length > 0
-      ? `**执行步骤**\n${normalizedToolCalls.map((toolCall, index) => `${index + 1}. ${toolCall}`).join('\n')}`
-      : undefined,
-    buildRunMeta(context),
-  ].filter((section): section is string => Boolean(section));
-
+function toolPanel(toolCalls: string[]): object | undefined {
+  if (toolCalls.length === 0) return undefined;
   return {
     tag: 'collapsible_panel',
     expanded: false,
     header: {
-      title: md(`执行过程 · ${processSummary(status, normalizedToolCalls.length, context.elapsed)}`),
+      title: md(toolCountLine(toolCalls.length)),
     },
-    elements: [md(detailSections.join('\n\n') || '正在准备执行...')],
+    elements: [md(toolCalls.map((toolCall, index) => `${index + 1}. ${toolCall}`).join('\n'))],
   };
 }
 
+function buildRunProcessElements(context: RunCardContext, status: string, toolCalls: string[] = [], note?: string): object[] {
+  const normalizedToolCalls = toolCalls.filter(Boolean);
+  const title = stepTitle(status, context, normalizedToolCalls);
+  const subtitle = stepSubtitle(status, normalizedToolCalls.length, context.elapsed);
+  const elements: object[] = [md(`**${title}**\n${note ?? subtitle}`)];
+  const foldedTools = toolPanel(normalizedToolCalls);
+  if (foldedTools) elements.push(foldedTools);
+  return elements;
+}
+
 function buildProgressElements(context: RunCardContext): object[] {
-  const elements: object[] = [buildRunProcessPanel(
+  return buildRunProcessElements(
     context,
     '运行中',
     context.toolCalls ?? [],
     context.latestToolHint ? undefined : '正在准备执行...',
-  )];
-  return elements;
+  );
 }
 
 
 export function buildThinkingCard(context: RunCardContext): object {
-  return buildCard(undefined, 'blue', buildProgressElements({
-    ...context,
-    detailText: '已收到请求，正在准备运行环境...',
-  }), false);
+  return buildCard(undefined, 'blue', buildRunProcessElements(
+    context,
+    '准备中',
+    context.toolCalls ?? [],
+    '已收到请求，正在准备运行环境...',
+  ), false);
 }
 
 export function buildProgressCard(context: RunCardContext): object {
@@ -618,36 +671,27 @@ export function buildProgressCard(context: RunCardContext): object {
 
 export function buildCompletedProcessCard(context: RunCardContext, toolCalls: string[] = []): object {
   const normalizedToolCalls = toolCalls.filter(Boolean);
-  const elements: object[] = [buildRunProcessPanel(
+  const elements = buildRunProcessElements(
     context,
     '已完成',
     normalizedToolCalls,
     normalizedToolCalls.length > 0
       ? `已完成 ${normalizedToolCalls.length} 个步骤，下面是最终答复。`
       : '已完成，下面是最终答复。',
-  )];
+  );
   return buildCard(undefined, 'green', elements, false);
 }
 
 export function buildDoneCard(_text: string, options: DoneCardOptions = {}): object {
   const context = options.context;
   const toolCalls = options.toolCalls?.filter(Boolean) ?? [];
-  const elements: object[] = [];
-
-  if (context) {
-    elements.push(buildRunProcessPanel(context, '已完成', toolCalls, '这张过程卡已完成，下面是最终答复。'));
-  } else if (toolCalls.length > 0) {
-    elements.push({
-      tag: 'collapsible_panel',
-      expanded: false,
-      header: {
-        title: plainText(`执行过程 · ${processSummary('已完成', toolCalls.length)}`),
-      },
-      elements: [md(toolCalls.map((toolCall, index) => `${index + 1}. ${toolCall}`).join('\n'))],
-    });
-  } else {
-    elements.push(md('这张过程卡已完成，最终答复见下一条消息。'));
-  }
+  const elements = context
+    ? buildRunProcessElements(context, '已完成', toolCalls, '这张过程卡已完成，下面是最终答复。')
+    : buildRunProcessElements({
+      streamId: 'completed',
+      platformKey: '',
+      memoryKey: '',
+    }, '已完成', toolCalls, '这张过程卡已完成，最终答复见下一条消息。');
 
   return buildCard('Pulse · Completed', 'green', elements, true);
 }
@@ -655,7 +699,7 @@ export function buildDoneCard(_text: string, options: DoneCardOptions = {}): obj
 export function buildErrorCard(message: string, context?: RunCardContext): object {
   const errorText = `❌ ${clampCardText(message || 'unknown error', 3000)}`;
   const elements: object[] = context
-    ? [buildRunProcessPanel(context, '出错', context.toolCalls ?? [], errorText)]
+    ? buildRunProcessElements(context, '出错', context.toolCalls ?? [], errorText)
     : [md(errorText)];
   return buildCard('Pulse 运行出错', 'red', elements, false);
 }


### PR DESCRIPTION
## Summary
- Align Feishu run-progress cards with the native Agent interaction observed in the reference GIF: keep the current stage visible as a lightweight row (`Thinking`, `Read AGENTS.md`, `Completed`) instead of a generic process card header.
- Fold tool execution details behind compact `Called tools N time(s)` panels; users can expand the panel to inspect individual tool calls when needed.
- Make the default view more delicate: stage subtitles no longer duplicate tool counts, folded tool rows avoid heavy emoji/numbering, and active runs can show a short unlabeled answer preview without exposing debug labels.
- Keep debug-style metadata (`runId`, `streamId`, prompt metadata) out of the user-facing process view; the final answer remains a normal Feishu reply.

## User-visible behavior
- Running state shows a simple stage title plus short status, closer to the native Agent message feel.
- The answer can start appearing as a small inline preview during execution, while the complete final answer still appears separately after completion.
- Tool history is available on demand, but no longer clutters the chat by default.
- Completion state clearly points users to the following final answer.

## Validation
- `pnpm --dir apps/canvas-workspace exec vitest run src/plugins/main/channel/channels/feishu/__tests__/card.test.ts` ✅ 6 tests passed
- `pnpm --dir apps/remote-server exec vitest run src/adapters/feishu/client-card.test.ts` ✅ 2 tests passed
- `pnpm --filter @pulse-coder/remote-server build` ✅ passed

## Notes
- Broader canvas Feishu stream/full test coverage is still blocked in this isolated worktree by missing package-level dependencies (`@larksuiteoapi/node-sdk`, `electron`, `react`, `zod`), so those checks fail during module resolution before exercising this change.
