### PR TITLE
fix(canvas): align sidebar and layer icons

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/icons/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/icons/index.tsx
@@ -132,6 +132,41 @@ export const PulseGlyphIcon = ({ size = 18, className, strokeWidth = 36 }: IconP
   </svg>
 );
 
+/** Plugin icon — puzzle-piece shape tuned to the sidebar's 16×16 line-icon family. */
+export const PluginIcon = ({ size = 14, className, strokeWidth = 1.3, style }: IconProps) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className} style={style}>
+    <path
+      d="M6.25 2.8H9.2v1.05a1.25 1.25 0 102.5 0V2.8h1.15c.75 0 1.35.6 1.35 1.35V6.5h-1.05a1.25 1.25 0 100 2.5h1.05v2.85c0 .75-.6 1.35-1.35 1.35H10.5v-1.05a1.25 1.25 0 10-2.5 0v1.05H5.15c-.75 0-1.35-.6-1.35-1.35V9.5H2.75a1.25 1.25 0 110-2.5H3.8V4.15c0-.75.6-1.35 1.35-1.35h1.1z"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+/** Scheduled task icon — tuned to the sidebar's 16×16 line-icon family. */
+export const ScheduledIcon = ({ size = 14, className, strokeWidth = 1.3, style }: IconProps) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className} style={style}>
+    <rect
+      x="2.5"
+      y="3.2"
+      width="11"
+      height="10.3"
+      rx="2"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+    />
+    <path
+      d="M5 2.3v2.4M11 2.3v2.4M2.8 6.4h10.4M5.2 9.1h2.1M5.2 11.2h4.6"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
 export const TrashIcon = ({ size = 14, className, strokeWidth = 1.3 }: IconProps) => (
   <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className}>
     <path d="M3 4.5h10" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" />

--- a/apps/canvas-workspace/src/renderer/src/components/shell/Sidebar/LayerItem.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/shell/Sidebar/LayerItem.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment happy-dom
+import { createRef } from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { CanvasNode } from '../../../types';
+import { I18nProvider } from '../../../i18n';
+import { LayerItem } from './LayerItem';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let host: HTMLDivElement | null = null;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  host?.remove();
+  root = null;
+  host = null;
+});
+
+const imageNode: CanvasNode = {
+  id: 'image-1',
+  type: 'image',
+  title: 'Diagram screenshot',
+  x: 0,
+  y: 0,
+  width: 240,
+  height: 160,
+  data: { filePath: '/tmp/diagram.png' },
+};
+
+describe('LayerItem', () => {
+  it('keeps layer node icons monochrome even when the row is not selected', () => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+
+    act(() => {
+      root?.render(
+        <I18nProvider>
+          <LayerItem
+            tree={{ node: imageNode, children: [] }}
+            collapsedLayers={new Set()}
+            searchActive={false}
+            selectedNodeIds={new Set()}
+            onFocus={vi.fn()}
+            onContextMenu={vi.fn()}
+            onToggleCollapse={vi.fn()}
+            onRegisterLayerButton={vi.fn()}
+            onLayerKeyDown={vi.fn()}
+            renamingLayerId={null}
+            renameLayerValue=""
+            renameLayerInputRef={createRef<HTMLInputElement>()}
+            onRenameChange={vi.fn()}
+            onRenameCommit={vi.fn()}
+            onRenameCancel={vi.fn()}
+          />
+        </I18nProvider>,
+      );
+    });
+
+    const icon = host.querySelector('.sidebar-layer-icon svg');
+    expect(icon?.getAttribute('class')).toBe('canvas-node-icon');
+    expect(icon?.getAttribute('style')).toBeNull();
+  });
+});

--- a/apps/canvas-workspace/src/renderer/src/components/shell/Sidebar/LayerItem.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/shell/Sidebar/LayerItem.tsx
@@ -107,7 +107,7 @@ export const LayerItem = ({
             <span className="sidebar-layer-spacer" aria-hidden="true" />
           )}
           <span className="sidebar-layer-icon">
-            <NodeTypeIcon type={node.type} colorize={!isSelected} />
+            <NodeTypeIcon type={node.type} />
           </span>
           <input
             ref={renameLayerInputRef}
@@ -145,7 +145,7 @@ export const LayerItem = ({
             <span className="sidebar-layer-spacer" aria-hidden="true" />
           )}
           <span className="sidebar-layer-icon">
-            <NodeTypeIcon type={node.type} colorize={!isSelected} />
+            <NodeTypeIcon type={node.type} />
           </span>
           <span className="sidebar-layer-name">
             {isContainer

--- a/apps/canvas-workspace/src/renderer/src/components/shell/Sidebar/SidebarCollapsedRail.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/shell/Sidebar/SidebarCollapsedRail.test.tsx
@@ -58,6 +58,8 @@ describe('collapsed sidebar rail', () => {
     const expandButton = host.querySelector('[aria-label="Expand sidebar"]');
     expect(rail?.firstElementChild).toBe(expandButton);
     expect(rail?.children[1]?.querySelector('img')?.getAttribute('width')).toBe('20');
+    expect(rail?.children[2]?.querySelector('svg')?.getAttribute('viewBox')).toBe('0 0 16 16');
+    expect(rail?.children[3]?.querySelector('svg')?.getAttribute('viewBox')).toBe('0 0 16 16');
 
     act(() => root.unmount());
   });

--- a/apps/canvas-workspace/src/renderer/src/components/shell/Sidebar/SidebarHeader.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/shell/Sidebar/SidebarHeader.test.tsx
@@ -59,6 +59,9 @@ describe('SidebarHeader', () => {
     expect(host.querySelector('[title="Collapse sidebar"]')).not.toBeNull();
     expect(host.querySelector('.sidebar-brand-mark')).toBeNull();
     expect(host.querySelector('.sidebar-nav-item img')?.getAttribute('width')).toBe('20');
+    const navButtons = host.querySelectorAll('.sidebar-nav-item');
+    expect(navButtons[1]?.querySelector('.sidebar-nav-icon svg')?.getAttribute('viewBox')).toBe('0 0 16 16');
+    expect(navButtons[2]?.querySelector('.sidebar-nav-icon svg')?.getAttribute('viewBox')).toBe('0 0 16 16');
 
     act(() => {
       root?.render(renderHeader(true, true));

--- a/apps/canvas-workspace/src/renderer/src/components/shell/Sidebar/SidebarHeader.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/shell/Sidebar/SidebarHeader.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useRef } from 'react';
 import type React from 'react';
-import { CalendarBlank, PuzzlePiece, SidebarSimple } from '@phosphor-icons/react';
+import { SidebarSimple } from '@phosphor-icons/react';
 import type { NavItem } from '../../../../../plugins/types';
 import {
   PlusIcon,
@@ -10,6 +10,8 @@ import {
   ImportIcon,
   KnowledgeStoreIcon,
   NodeGraphIcon,
+  PluginIcon,
+  ScheduledIcon,
 } from '../../icons';
 import { useI18n } from '../../../i18n';
 import { useMenuKeyboardNav } from '../../../hooks/useMenuKeyboardNav';
@@ -152,7 +154,7 @@ export const SidebarHeader = ({
           title={t('sidebar.skillsTitle')}
         >
           <span className="sidebar-nav-icon">
-            <PuzzlePiece size={14} />
+            <PluginIcon size={15} />
           </span>
           <span className="sidebar-nav-label">{t('sidebar.skills')}</span>
         </Button> : null}
@@ -165,7 +167,7 @@ export const SidebarHeader = ({
             title={t('sidebar.scheduledTitle')}
           >
             <span className="sidebar-nav-icon">
-              <CalendarBlank size={14} />
+              <ScheduledIcon size={15} />
             </span>
             <span className="sidebar-nav-label">{t('sidebar.scheduled')}</span>
           </Button> : null

--- a/apps/canvas-workspace/src/renderer/src/components/shell/Sidebar/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/shell/Sidebar/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, useCallback, type DragEvent, type MouseEvent as ReactMouseEvent } from 'react';
-import { CalendarBlank, PuzzlePiece } from '@phosphor-icons/react';
+
 import { useClickOutside } from '../../../hooks/useClickOutside';
 import type { NavItem } from '../../../../../plugins/types';
 import type { WorkspaceEntry, FolderEntry } from '../../../hooks/useWorkspaces';
@@ -13,7 +13,7 @@ import { WorkspaceList } from './WorkspaceList';
 import { LayersPanel } from './LayersPanel';
 import { LayerContextMenu } from './LayerContextMenu';
 import { useAppShell } from '../AppShellProvider';
-import { AppLogoIcon, SettingsIcon } from '../../icons';
+import { AppLogoIcon, PluginIcon, ScheduledIcon, SettingsIcon } from '../../icons';
 import { Button } from '../../ui';
 import { getNodeDisplayLabel } from '../../../utils/nodeLabel';
 import { buildCanvasNodeLink } from '../../../utils/canvasLinks';
@@ -435,7 +435,7 @@ export const Sidebar = ({
               title={t('sidebar.skillsTitle')}
               aria-label={t('sidebar.skills')}
             >
-              <PuzzlePiece size={14} />
+              <PluginIcon size={15} />
             </Button> : null
           }
           {
@@ -446,7 +446,7 @@ export const Sidebar = ({
               title={t('sidebar.scheduledTitle')}
               aria-label={t('sidebar.scheduled')}
             >
-              <CalendarBlank size={14} />
+              <ScheduledIcon size={15} />
             </Button>) : null
           }
 


### PR DESCRIPTION
Align Canvas sidebar and layer icon styling.

## Summary
- Keep Pulse Agent on the original app logo while replacing Plugins and Scheduled with matching line icons.
- Reuse the updated icons in both expanded sidebar and collapsed rail states.
- Render Layers node type icons in monochrome for visual consistency.
- Add focused coverage for sidebar icon rendering and layer icon color behavior.

## Validation
- `git diff --check`
- `NODE_ENV=test pnpm --filter canvas-workspace exec vitest run src/renderer/src/components/shell/Sidebar/SidebarHeader.test.tsx src/renderer/src/components/shell/Sidebar/SidebarCollapsedRail.test.tsx src/renderer/src/components/shell/Sidebar/LayerItem.test.tsx`
- `node /root/.codex/skills/canvas-fix-verify/scripts/canvas-verify.mjs smoke --name sidebar-plugins-scheduled-icons --profile demo`

## Screenshot
- `/root/.pulse-coder/worktrees/pulse-coder/wt-review-master-two-ui-changes/apps/canvas-workspace/.harness/verification/2026-09-01T13-01-11-348Z-sidebar-plugins-scheduled-icons.png`
