### PR TITLE
style: refine Feishu agent progress details

### DIFF
--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/card.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/card.test.ts
@@ -52,7 +52,7 @@ describe('feishu card tool list', () => {
     const card = buildProgressCard('working', tools, 20) as { header?: unknown };
     const body = texts(card).join('\n');
     expect(card.header).toBeUndefined();
-    expect(body).toContain('<font color="blue">●</font> **Canvas write node node-2**');
+    expect(body).toContain('<font color="purple">●</font> **Canvas write node node-2**');
     expect(body).toContain('<font color="grey">运行中 · 20s</font>');
     expect(body).toContain('working');
     expect(body).toContain('<font color="grey">Called tools 2 times</font>');
@@ -60,9 +60,9 @@ describe('feishu card tool list', () => {
     expect(JSON.stringify(card)).toContain('"text_size":"heading"');
     expect(JSON.stringify(card)).toContain('"text_size":"notation"');
     expect(body).not.toContain('**当前答复**\nworking');
-    // Tool rows stay quiet in the folded panel: no heavy status emoji or debug label.
-    expect(body).toContain('Canvas read node · node-1 · 18s');
-    expect(body).toContain('Canvas write node · node-2');
+    // Tool rows stay quiet in the folded panel: grey structure/text, no heavy status color or debug label.
+    expect(body).toContain('<font color="grey">Canvas read node · node-1 · 18s</font>');
+    expect(body).toContain('<font color="grey">Canvas write node · node-2</font>');
   });
 
   it('completed process card leaves only a completion row plus folded tool details', () => {
@@ -75,7 +75,7 @@ describe('feishu card tool list', () => {
     expect(panel!.expanded).toBe(false);
     expect(card.header).toBeUndefined();
     const body = texts(card).join('\n');
-    expect(body).toContain('<font color="green">●</font> **Completed**');
+    expect(body).toContain('<font color="grey">●</font> **Completed**');
     expect(body).toContain('<font color="grey">已完成 2 个步骤，下面是最终答复。</font>');
     expect(body).toContain('<font color="grey">Called tools 2 times</font>');
     expect(body).not.toContain('执行过程 · 已完成');

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/card.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/card.test.ts
@@ -52,10 +52,13 @@ describe('feishu card tool list', () => {
     const card = buildProgressCard('working', tools, 20) as { header?: unknown };
     const body = texts(card).join('\n');
     expect(card.header).toBeUndefined();
-    expect(body).toContain('**Canvas write node node-2**');
-    expect(body).toContain('运行中 · 20s');
+    expect(body).toContain('<font color="blue">●</font> **Canvas write node node-2**');
+    expect(body).toContain('<font color="grey">运行中 · 20s</font>');
     expect(body).toContain('working');
-    expect(body).toContain('Called tools 2 times');
+    expect(body).toContain('<font color="grey">Called tools 2 times</font>');
+    expect(body).toContain('<font color="grey">│</font>');
+    expect(JSON.stringify(card)).toContain('"text_size":"heading"');
+    expect(JSON.stringify(card)).toContain('"text_size":"notation"');
     expect(body).not.toContain('**当前答复**\nworking');
     // Tool rows stay quiet in the folded panel: no heavy status emoji or debug label.
     expect(body).toContain('Canvas read node · node-1 · 18s');
@@ -72,9 +75,9 @@ describe('feishu card tool list', () => {
     expect(panel!.expanded).toBe(false);
     expect(card.header).toBeUndefined();
     const body = texts(card).join('\n');
-    expect(body).toContain('**Completed**');
-    expect(body).toContain('已完成 2 个步骤，下面是最终答复。');
-    expect(body).toContain('Called tools 2 times');
+    expect(body).toContain('<font color="green">●</font> **Completed**');
+    expect(body).toContain('<font color="grey">已完成 2 个步骤，下面是最终答复。</font>');
+    expect(body).toContain('<font color="grey">Called tools 2 times</font>');
     expect(body).not.toContain('执行过程 · 已完成');
     expect(body).toContain('Canvas read node · node-1');
   });

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/card.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/card.test.ts
@@ -53,12 +53,13 @@ describe('feishu card tool list', () => {
     const body = texts(card).join('\n');
     expect(card.header).toBeUndefined();
     expect(body).toContain('**Canvas write node node-2**');
-    expect(body).toContain('运行中 · Called tools 2 times · 20s');
+    expect(body).toContain('运行中 · 20s');
+    expect(body).toContain('working');
     expect(body).toContain('Called tools 2 times');
     expect(body).not.toContain('**当前答复**\nworking');
-    // Tool name is bolded; detail and timing are only inside the folded panel.
-    expect(body).toContain('✅ **canvas_read_node** · node-1 · 18s');
-    expect(body).toContain('⏳ **canvas_write_node** · node-2');
+    // Tool rows stay quiet in the folded panel: no heavy status emoji or debug label.
+    expect(body).toContain('Canvas read node · node-1 · 18s');
+    expect(body).toContain('Canvas write node · node-2');
   });
 
   it('completed process card leaves only a completion row plus folded tool details', () => {
@@ -75,7 +76,7 @@ describe('feishu card tool list', () => {
     expect(body).toContain('已完成 2 个步骤，下面是最终答复。');
     expect(body).toContain('Called tools 2 times');
     expect(body).not.toContain('执行过程 · 已完成');
-    expect(body).toContain('**canvas_read_node** · node-1');
+    expect(body).toContain('Canvas read node · node-1');
   });
 
   it('done card with no tools is just the answer (no panel)', () => {

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/stream.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/stream.test.ts
@@ -107,7 +107,7 @@ describe('FeishuStream', () => {
     await vi.advanceTimersByTimeAsync(800);
     await flushAsync();
 
-    expect(JSON.stringify(mockedUpdateCard.mock.calls[0][2])).toContain('visual_render');
+    expect(JSON.stringify(mockedUpdateCard.mock.calls[0][2])).toContain('Visual render');
     expect(JSON.stringify(mockedUpdateCard.mock.calls[0][2])).toContain('preparing input 6B');
 
     stream.onToolCall('visual_render', { title: 'Demo' }, 'tool-1');
@@ -116,7 +116,7 @@ describe('FeishuStream', () => {
     await flushAsync();
 
     const latestCard = JSON.stringify(mockedUpdateCard.mock.calls.at(-1)?.[2]);
-    expect(latestCard).toContain('visual_render');
+    expect(latestCard).toContain('Visual render');
     expect(latestCard).toContain('Demo');
   });
 

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
@@ -76,13 +76,12 @@ function formButton(
   };
 }
 
-/** Render the tool calls as a folded status list (details only on demand). */
+/** Render folded tool details in the same quiet style as native Agent call rows. */
 function toolLines(tools: ToolEntry[]): string {
   return tools
     .map((t) => {
-      const icon = t.done ? '✅' : '⏳';
       const { name, detail } = splitToolLabel(t.label);
-      const segs = [`${icon} **${name || 'tool'}**`];
+      const segs = [titleizeToolName(name || 'tool')];
       if (detail) segs.push(detail);
       if (t.done && typeof t.elapsedSec === 'number') segs.push(`${t.elapsedSec}s`);
       return segs.join(' · ');
@@ -119,9 +118,8 @@ function stepTitle(status: string, tools: ToolEntry[]): string {
   return detail ? `${title} ${detail}` : title;
 }
 
-function stepSubtitle(status: string, toolCount: number, elapsedSec?: number): string {
+function stepSubtitle(status: string, elapsedSec?: number): string {
   const parts = [status];
-  if (toolCount > 0) parts.push(toolCountLine(toolCount));
   if (typeof elapsedSec === 'number') parts.push(`${elapsedSec}s`);
   return parts.join(' · ');
 }
@@ -145,11 +143,15 @@ function processElements(input: {
   tools?: ToolEntry[];
   elapsedSec?: number;
   note?: string;
+  answerPreview?: string;
 }): object[] {
   const tools = input.tools ?? [];
   const title = stepTitle(input.status, tools);
-  const subtitle = stepSubtitle(input.status, tools.length, input.elapsedSec);
-  const elements: object[] = [md(`**${title}**\n${input.note ?? subtitle}`)];
+  const subtitle = stepSubtitle(input.status, input.elapsedSec);
+  const preview = input.answerPreview?.trim()
+    ? `\n\n${clamp(input.answerPreview.trim()).slice(0, 700)}`
+    : '';
+  const elements: object[] = [md(`**${title}**\n${input.note ?? subtitle}${preview}`)];
   const foldedTools = toolPanel(tools);
   if (foldedTools) elements.push(foldedTools);
   return elements;
@@ -163,7 +165,7 @@ export function buildThinkingCard(): object {
 }
 
 export function buildProgressCard(
-  _text: string,
+  text: string,
   tools: ToolEntry[] = [],
   elapsedSec?: number,
 ): object {
@@ -172,6 +174,7 @@ export function buildProgressCard(
     tools,
     elapsedSec,
     note: tools.length === 0 ? '正在生成答复...' : undefined,
+    answerPreview: text,
   }), false);
 }
 

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
@@ -35,12 +35,12 @@ function muted(content: string): string {
   return `<font color="grey">${content}</font>`;
 }
 
-function blue(content: string): string {
-  return `<font color="blue">${content}</font>`;
+function purple(content: string): string {
+  return `<font color="purple">${content}</font>`;
 }
 
-function green(content: string): string {
-  return `<font color="green">${content}</font>`;
+function red(content: string): string {
+  return `<font color="red">${content}</font>`;
 }
 
 function plainText(content: string): object {
@@ -101,8 +101,8 @@ function toolTimeline(tools: ToolEntry[]): string {
   return tools
     .flatMap((tool, index) => {
       const isLast = index === tools.length - 1;
-      const dot = tool.done ? green('●') : blue('●');
-      const row = `${dot} ${toolLine(tool)}`;
+      const dot = muted(tool.done ? '●' : '◦');
+      const row = `${dot} ${muted(toolLine(tool))}`;
       return isLast ? [row] : [row, `${muted('│')}`];
     })
     .join('\n');
@@ -143,6 +143,12 @@ function stepSubtitle(status: string, elapsedSec?: number): string {
   return parts.join(' · ');
 }
 
+function statusDot(status: string): string {
+  if (status === '出错') return red('●');
+  if (status === '已完成') return muted('●');
+  return purple('●');
+}
+
 function toolPanel(tools: ToolEntry[]): object | undefined {
   if (tools.length === 0) return undefined;
   return {
@@ -168,7 +174,7 @@ function processElements(input: {
   const title = stepTitle(input.status, tools);
   const subtitle = stepSubtitle(input.status, input.elapsedSec);
   const elements: object[] = [
-    md(`${input.status === '已完成' ? green('●') : blue('●')} **${title}**`, 'heading'),
+    md(`${statusDot(input.status)} **${title}**`, 'heading'),
     md(muted(input.note ?? subtitle), 'notation'),
   ];
   if (input.answerPreview?.trim()) {

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
@@ -27,8 +27,20 @@ export interface ToolEntry {
   elapsedSec?: number;
 }
 
-function md(content: string): object {
-  return { tag: 'markdown', content };
+function md(content: string, textSize?: 'heading' | 'normal' | 'notation'): object {
+  return { tag: 'markdown', content, ...(textSize ? { text_size: textSize } : {}) };
+}
+
+function muted(content: string): string {
+  return `<font color="grey">${content}</font>`;
+}
+
+function blue(content: string): string {
+  return `<font color="blue">${content}</font>`;
+}
+
+function green(content: string): string {
+  return `<font color="green">${content}</font>`;
 }
 
 function plainText(content: string): object {
@@ -76,15 +88,22 @@ function formButton(
   };
 }
 
-/** Render folded tool details in the same quiet style as native Agent call rows. */
-function toolLines(tools: ToolEntry[]): string {
+function toolLine(tool: ToolEntry): string {
+  const { name, detail } = splitToolLabel(tool.label);
+  const segs = [titleizeToolName(name || 'tool')];
+  if (detail) segs.push(detail);
+  if (tool.done && typeof tool.elapsedSec === 'number') segs.push(`${tool.elapsedSec}s`);
+  return segs.join(' · ');
+}
+
+/** Render folded tool details as a quiet vertical timeline. */
+function toolTimeline(tools: ToolEntry[]): string {
   return tools
-    .map((t) => {
-      const { name, detail } = splitToolLabel(t.label);
-      const segs = [titleizeToolName(name || 'tool')];
-      if (detail) segs.push(detail);
-      if (t.done && typeof t.elapsedSec === 'number') segs.push(`${t.elapsedSec}s`);
-      return segs.join(' · ');
+    .flatMap((tool, index) => {
+      const isLast = index === tools.length - 1;
+      const dot = tool.done ? green('●') : blue('●');
+      const row = `${dot} ${toolLine(tool)}`;
+      return isLast ? [row] : [row, `${muted('│')}`];
     })
     .join('\n');
 }
@@ -130,10 +149,10 @@ function toolPanel(tools: ToolEntry[]): object | undefined {
     tag: 'collapsible_panel',
     expanded: false,
     header: {
-      title: md(toolCountLine(tools.length)),
+      title: md(muted(toolCountLine(tools.length)), 'notation'),
       vertical_align: 'center',
     },
-    elements: [md(toolLines(tools))],
+    elements: [md(toolTimeline(tools), 'notation')],
   };
 }
 
@@ -148,10 +167,13 @@ function processElements(input: {
   const tools = input.tools ?? [];
   const title = stepTitle(input.status, tools);
   const subtitle = stepSubtitle(input.status, input.elapsedSec);
-  const preview = input.answerPreview?.trim()
-    ? `\n\n${clamp(input.answerPreview.trim()).slice(0, 700)}`
-    : '';
-  const elements: object[] = [md(`**${title}**\n${input.note ?? subtitle}${preview}`)];
+  const elements: object[] = [
+    md(`${input.status === '已完成' ? green('●') : blue('●')} **${title}**`, 'heading'),
+    md(muted(input.note ?? subtitle), 'notation'),
+  ];
+  if (input.answerPreview?.trim()) {
+    elements.push(md(clamp(input.answerPreview.trim()).slice(0, 700), 'normal'));
+  }
   const foldedTools = toolPanel(tools);
   if (foldedTools) elements.push(foldedTools);
   return elements;

--- a/apps/remote-server/src/adapters/feishu/client-card.test.ts
+++ b/apps/remote-server/src/adapters/feishu/client-card.test.ts
@@ -40,7 +40,8 @@ describe('Feishu run cards', () => {
 
     expect(card.header).toBeUndefined();
     expect(body).toContain('**Read AGENTS.md**');
-    expect(body).toContain('运行中 · Called tools 1 time · 3s');
+    expect(body).toContain('运行中 · 3s');
+    expect(body).toContain('partial answer');
     expect(body).toContain('Called tools 1 time');
     expect(body).not.toContain('**当前答复**');
     expect(body).not.toContain('run-123');

--- a/apps/remote-server/src/adapters/feishu/client-card.test.ts
+++ b/apps/remote-server/src/adapters/feishu/client-card.test.ts
@@ -39,7 +39,7 @@ describe('Feishu run cards', () => {
     const body = texts(card).join('\n');
 
     expect(card.header).toBeUndefined();
-    expect(body).toContain('<font color="blue">●</font> **Read AGENTS.md**');
+    expect(body).toContain('<font color="purple">●</font> **Read AGENTS.md**');
     expect(body).toContain('<font color="grey">运行中 · 3s</font>');
     expect(body).toContain('partial answer');
     expect(body).toContain('<font color="grey">Called tools 1 time</font>');
@@ -56,7 +56,7 @@ describe('Feishu run cards', () => {
     const body = texts(card).join('\n');
 
     expect(card.header).toBeUndefined();
-    expect(body).toContain('<font color="green">●</font> **Completed**');
+    expect(body).toContain('<font color="grey">●</font> **Completed**');
     expect(body).toContain('<font color="grey">已完成 1 个步骤，下面是最终答复。</font>');
     expect(body).toContain('<font color="grey">Called tools 1 time</font>');
     expect(body).not.toContain('执行过程 · 已完成');

--- a/apps/remote-server/src/adapters/feishu/client-card.test.ts
+++ b/apps/remote-server/src/adapters/feishu/client-card.test.ts
@@ -39,10 +39,12 @@ describe('Feishu run cards', () => {
     const body = texts(card).join('\n');
 
     expect(card.header).toBeUndefined();
-    expect(body).toContain('**Read AGENTS.md**');
-    expect(body).toContain('运行中 · 3s');
+    expect(body).toContain('<font color="blue">●</font> **Read AGENTS.md**');
+    expect(body).toContain('<font color="grey">运行中 · 3s</font>');
     expect(body).toContain('partial answer');
-    expect(body).toContain('Called tools 1 time');
+    expect(body).toContain('<font color="grey">Called tools 1 time</font>');
+    expect(JSON.stringify(card)).toContain('"text_size":"heading"');
+    expect(JSON.stringify(card)).toContain('"text_size":"notation"');
     expect(body).not.toContain('**当前答复**');
     expect(body).not.toContain('run-123');
     expect(JSON.stringify(card)).not.toContain('"tag":"button"');
@@ -54,9 +56,9 @@ describe('Feishu run cards', () => {
     const body = texts(card).join('\n');
 
     expect(card.header).toBeUndefined();
-    expect(body).toContain('**Completed**');
-    expect(body).toContain('已完成 1 个步骤，下面是最终答复。');
-    expect(body).toContain('Called tools 1 time');
+    expect(body).toContain('<font color="green">●</font> **Completed**');
+    expect(body).toContain('<font color="grey">已完成 1 个步骤，下面是最终答复。</font>');
+    expect(body).toContain('<font color="grey">Called tools 1 time</font>');
     expect(body).not.toContain('执行过程 · 已完成');
     expect(JSON.stringify(card)).not.toContain('"tag":"button"');
     expect(elements(card).some((item) => item.tag === 'collapsible_panel')).toBe(true);

--- a/apps/remote-server/src/adapters/feishu/client.ts
+++ b/apps/remote-server/src/adapters/feishu/client.ts
@@ -534,8 +534,20 @@ function formatCardDetailText(...parts: Array<string | undefined>): string {
   return clampCardText(normalizedParts.join('\n\n'));
 }
 
-function md(content: string): object {
-  return { tag: 'markdown', content };
+function md(content: string, textSize?: 'heading' | 'normal' | 'notation'): object {
+  return { tag: 'markdown', content, ...(textSize ? { text_size: textSize } : {}) };
+}
+
+function muted(content: string): string {
+  return `<font color="grey">${content}</font>`;
+}
+
+function blue(content: string): string {
+  return `<font color="blue">${content}</font>`;
+}
+
+function green(content: string): string {
+  return `<font color="green">${content}</font>`;
 }
 
 function plainText(content: string): object {
@@ -629,15 +641,25 @@ function renderToolLine(toolCall: string): string {
   return detail ? `${title} · ${detail}` : title;
 }
 
+function toolTimeline(toolCalls: string[]): string {
+  return toolCalls
+    .flatMap((toolCall, index) => {
+      const isLast = index === toolCalls.length - 1;
+      const row = `${green('●')} ${renderToolLine(toolCall)}`;
+      return isLast ? [row] : [row, muted('│')];
+    })
+    .join('\n');
+}
+
 function toolPanel(toolCalls: string[]): object | undefined {
   if (toolCalls.length === 0) return undefined;
   return {
     tag: 'collapsible_panel',
     expanded: false,
     header: {
-      title: md(toolCountLine(toolCalls.length)),
+      title: md(muted(toolCountLine(toolCalls.length)), 'notation'),
     },
-    elements: [md(toolCalls.map(renderToolLine).join('\n'))],
+    elements: [md(toolTimeline(toolCalls), 'notation')],
   };
 }
 
@@ -645,10 +667,13 @@ function buildRunProcessElements(context: RunCardContext, status: string, toolCa
   const normalizedToolCalls = toolCalls.filter(Boolean);
   const title = stepTitle(status, context, normalizedToolCalls);
   const subtitle = stepSubtitle(status, context.elapsed);
-  const preview = status === '运行中' && context.detailText?.trim()
-    ? `\n\n${clampCardText(context.detailText.trim(), 700)}`
-    : '';
-  const elements: object[] = [md(`**${title}**\n${note ?? subtitle}${preview}`)];
+  const elements: object[] = [
+    md(`${status === '已完成' ? green('●') : blue('●')} **${title}**`, 'heading'),
+    md(muted(note ?? subtitle), 'notation'),
+  ];
+  if (status === '运行中' && context.detailText?.trim()) {
+    elements.push(md(clampCardText(context.detailText.trim(), 700), 'normal'));
+  }
   const foldedTools = toolPanel(normalizedToolCalls);
   if (foldedTools) elements.push(foldedTools);
   return elements;

--- a/apps/remote-server/src/adapters/feishu/client.ts
+++ b/apps/remote-server/src/adapters/feishu/client.ts
@@ -617,11 +617,16 @@ function stepTitle(status: string, context: RunCardContext, toolCalls: string[])
   return detail ? `${title} ${detail}` : title;
 }
 
-function stepSubtitle(status: string, toolCount: number, elapsed?: string): string {
+function stepSubtitle(status: string, elapsed?: string): string {
   const parts = [status];
-  if (toolCount > 0) parts.push(toolCountLine(toolCount));
   if (elapsed) parts.push(elapsed);
   return parts.join(' · ');
+}
+
+function renderToolLine(toolCall: string): string {
+  const { name, detail } = splitToolSummary(toolCall);
+  const title = titleizeToolName(name || 'tool');
+  return detail ? `${title} · ${detail}` : title;
 }
 
 function toolPanel(toolCalls: string[]): object | undefined {
@@ -632,15 +637,18 @@ function toolPanel(toolCalls: string[]): object | undefined {
     header: {
       title: md(toolCountLine(toolCalls.length)),
     },
-    elements: [md(toolCalls.map((toolCall, index) => `${index + 1}. ${toolCall}`).join('\n'))],
+    elements: [md(toolCalls.map(renderToolLine).join('\n'))],
   };
 }
 
 function buildRunProcessElements(context: RunCardContext, status: string, toolCalls: string[] = [], note?: string): object[] {
   const normalizedToolCalls = toolCalls.filter(Boolean);
   const title = stepTitle(status, context, normalizedToolCalls);
-  const subtitle = stepSubtitle(status, normalizedToolCalls.length, context.elapsed);
-  const elements: object[] = [md(`**${title}**\n${note ?? subtitle}`)];
+  const subtitle = stepSubtitle(status, context.elapsed);
+  const preview = status === '运行中' && context.detailText?.trim()
+    ? `\n\n${clampCardText(context.detailText.trim(), 700)}`
+    : '';
+  const elements: object[] = [md(`**${title}**\n${note ?? subtitle}${preview}`)];
   const foldedTools = toolPanel(normalizedToolCalls);
   if (foldedTools) elements.push(foldedTools);
   return elements;

--- a/apps/remote-server/src/adapters/feishu/client.ts
+++ b/apps/remote-server/src/adapters/feishu/client.ts
@@ -542,12 +542,12 @@ function muted(content: string): string {
   return `<font color="grey">${content}</font>`;
 }
 
-function blue(content: string): string {
-  return `<font color="blue">${content}</font>`;
+function purple(content: string): string {
+  return `<font color="purple">${content}</font>`;
 }
 
-function green(content: string): string {
-  return `<font color="green">${content}</font>`;
+function red(content: string): string {
+  return `<font color="red">${content}</font>`;
 }
 
 function plainText(content: string): object {
@@ -635,6 +635,12 @@ function stepSubtitle(status: string, elapsed?: string): string {
   return parts.join(' · ');
 }
 
+function statusDot(status: string): string {
+  if (status === '出错') return red('●');
+  if (status === '已完成') return muted('●');
+  return purple('●');
+}
+
 function renderToolLine(toolCall: string): string {
   const { name, detail } = splitToolSummary(toolCall);
   const title = titleizeToolName(name || 'tool');
@@ -645,7 +651,7 @@ function toolTimeline(toolCalls: string[]): string {
   return toolCalls
     .flatMap((toolCall, index) => {
       const isLast = index === toolCalls.length - 1;
-      const row = `${green('●')} ${renderToolLine(toolCall)}`;
+      const row = `${muted('●')} ${muted(renderToolLine(toolCall))}`;
       return isLast ? [row] : [row, muted('│')];
     })
     .join('\n');
@@ -668,7 +674,7 @@ function buildRunProcessElements(context: RunCardContext, status: string, toolCa
   const title = stepTitle(status, context, normalizedToolCalls);
   const subtitle = stepSubtitle(status, context.elapsed);
   const elements: object[] = [
-    md(`${status === '已完成' ? green('●') : blue('●')} **${title}**`, 'heading'),
+    md(`${statusDot(status)} **${title}**`, 'heading'),
     md(muted(note ?? subtitle), 'notation'),
   ];
   if (status === '运行中' && context.detailText?.trim()) {


### PR DESCRIPTION
## Summary
- Refine the Feishu Agent progress card to feel closer to the reference native Agent GIF.
- Add visual hierarchy: current stage uses heading-sized markdown, status/note/tool-count text uses smaller notation text, and muted grey color keeps secondary information quiet.
- Add colored stage markers: blue dot for active stages and green dot for completed stages.
- Render folded tool details as a lightweight vertical timeline with muted connector lines, instead of a flat debug-like list.
- Keep the earlier polish: no duplicated tool count in the visible stage row, no heavy emoji/numbering in tool details, and a short unlabeled answer preview while running.

## User-visible behavior
- Running cards look more like: blue-dot `Read AGENTS.md` + grey `运行中 · 3s` + a small answer preview.
- Tool details remain under `Called tools N time(s)`, and expand into a timeline-style progression.
- Completed cards switch to a green-dot `Completed` row with muted completion copy.
- Debug metadata remains hidden from the default process view.

## Validation
- `pnpm --dir apps/canvas-workspace exec vitest run src/plugins/main/channel/channels/feishu/__tests__/card.test.ts` ✅ 6 tests passed
- `pnpm --dir apps/remote-server exec vitest run src/adapters/feishu/client-card.test.ts` ✅ 2 tests passed
- `pnpm --filter @pulse-coder/remote-server build` ✅ passed

## Notes
- This is a follow-up because #988 was already merged; the finer polish commits are not included in `origin/master` yet.
