### PR TITLE
release(canvas): 0.1.53

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.52",
+  "version": "0.1.53",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- release Pulse Canvas 0.1.53 for macOS arm64
- publish bilingual release notes, R2 artifacts, and the updated download page

## Verification

- canvas typecheck passed
- canvas build passed
- PI Electron smoke passed
- packaged agent tooling smoke passed
- remote manifest reports 0.1.53
- versioned DMG URL returns HTTP 200

## Known validation issue

The existing file-size governance test on current master reports two files that grew past their recorded baseline: `feishu-channel.ts` and `icons/index.tsx`. This release commit only changes `apps/canvas-workspace/package.json`.