### PR TITLE
fix: improve Canvas tool call labels

### DIFF
--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatActivityStatus.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatActivityStatus.tsx
@@ -3,15 +3,9 @@ import { useI18n, type I18nKey } from '../../i18n';
 import { SpinnerIcon } from '../icons';
 import { Button } from '../ui';
 import type { ToolCallStatus } from './types';
-import { displayToolStatus, formatToolLabel } from './ChatToolCalls';
+import { displayToolStatus, formatToolDescription, formatToolLabel } from './ChatToolCalls';
 
 type Translate = (key: I18nKey, params?: Record<string, string | number>) => string;
-
-const toolDescription = (tool: ToolCallStatus): string | null => {
-  if (tool.name !== 'bash' || !tool.args || typeof tool.args !== 'object') return null;
-  const description = (tool.args as { description?: unknown }).description;
-  return typeof description === 'string' && description.trim() ? description.trim() : null;
-};
 
 const activeTool = (tools: ToolCallStatus[]): ToolCallStatus | undefined => (
   [...tools].reverse().find(tool => tool.status === 'running')
@@ -39,7 +33,7 @@ export const describeChatActivity = (
 ): ActivitySnapshot => {
   const current = activeTool(tools);
   if (current) {
-    const label = toolDescription(current) ?? (current.status === 'queued'
+    const label = formatToolDescription(current) ?? (current.status === 'queued'
       ? t('chat.activity.queued')
       : formatToolLabel(current.name, current.status, t));
     return {
@@ -52,7 +46,7 @@ export const describeChatActivity = (
     const latest = tools[tools.length - 1]!;
     const status = displayToolStatus(latest);
     return {
-      label: formatToolLabel(latest.name, status, t),
+      label: formatToolDescription(latest) ?? formatToolLabel(latest.name, status, t),
       startedAt: latest.startedAt,
     };
   }

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatPanel.css
@@ -1986,6 +1986,34 @@
   transform: rotate(180deg);
 }
 
+.chat-tool-call-result-reveal {
+  display: grid;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  transform: translateY(-2px);
+  pointer-events: none;
+  visibility: hidden;
+  transition:
+    grid-template-rows 0.18s cubic-bezier(0.2, 0, 0, 1),
+    opacity 0.14s ease-out,
+    transform 0.18s cubic-bezier(0.2, 0, 0, 1),
+    visibility 0s linear 0.18s;
+}
+
+.chat-tool-call-result-reveal--open {
+  grid-template-rows: 1fr;
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+  visibility: visible;
+  transition-delay: 0s;
+}
+
+.chat-tool-call-result-reveal__inner {
+  min-height: 0;
+  overflow: hidden;
+}
+
 .chat-tool-call-result {
   margin: 2px 0 4px 19px;
   padding: 6px 8px;
@@ -3718,8 +3746,11 @@
   }
 
   .chat-tool-details-reveal,
-  .chat-tool-details-reveal--open {
+  .chat-tool-details-reveal--open,
+  .chat-tool-call-result-reveal,
+  .chat-tool-call-result-reveal--open {
     transition: none;
+    transform: none;
   }
 
   .chat-jump-latest,

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatToolCallDetails.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatToolCallDetails.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { useI18n } from '../../i18n';
 import type { ToolCallStatus } from './types';
 
@@ -68,7 +69,21 @@ const parseSessionRefs = (tool: ToolCallStatus): SessionRef[] | null => {
 export const ChatToolCallDetails = ({ tool, expanded }: Props) => {
   const { t } = useI18n();
   const sessionRefs = parseSessionRefs(tool);
-  const hasDetails = tool.result || tool.error || tool.args !== undefined;
+  const hasDetails = Boolean(tool.result || tool.error || tool.args !== undefined);
+  const [shouldRenderDetails, setShouldRenderDetails] = useState(() => expanded);
+
+  useEffect(() => {
+    if (expanded) {
+      setShouldRenderDetails(true);
+      return undefined;
+    }
+    if (!shouldRenderDetails) return undefined;
+
+    const timeout = window.setTimeout(() => setShouldRenderDetails(false), 180);
+    return () => window.clearTimeout(timeout);
+  }, [expanded, shouldRenderDetails]);
+
+  const renderDetails = hasDetails && (expanded || shouldRenderDetails);
 
   return (
     <>
@@ -104,32 +119,39 @@ export const ChatToolCallDetails = ({ tool, expanded }: Props) => {
           ))}
         </div>
       )}
-      {expanded && hasDetails && (
-        <div className="chat-tool-call-result">
-          {tool.args !== undefined && (
-            <div className="chat-tool-call-section">
-              <div className="chat-tool-call-section-label">
-                {tool.name} · {t('chat.toolCalls.input')}
-              </div>
-              <pre>{formatArgs(tool.args)}</pre>
+      {renderDetails && (
+        <div
+          className={`chat-tool-call-result-reveal${expanded ? ' chat-tool-call-result-reveal--open' : ''}`}
+          aria-hidden={!expanded}
+        >
+          <div className="chat-tool-call-result-reveal__inner">
+            <div className="chat-tool-call-result">
+              {tool.args !== undefined && (
+                <div className="chat-tool-call-section">
+                  <div className="chat-tool-call-section-label">
+                    {tool.name} · {t('chat.toolCalls.input')}
+                  </div>
+                  <pre>{formatArgs(tool.args)}</pre>
+                </div>
+              )}
+              {tool.result && (
+                <div className="chat-tool-call-section">
+                  <div className="chat-tool-call-section-label">{t('chat.toolCalls.output')}</div>
+                  <pre>
+                    {tool.result.length > 2000
+                      ? `${tool.result.slice(0, 2000)}\n${t('chat.toolCalls.truncated')}`
+                      : tool.result}
+                  </pre>
+                </div>
+              )}
+              {tool.error && tool.error !== tool.result && (
+                <div className="chat-tool-call-section chat-tool-call-section--error">
+                  <div className="chat-tool-call-section-label">{t('chat.toolCalls.error')}</div>
+                  <pre>{tool.error}</pre>
+                </div>
+              )}
             </div>
-          )}
-          {tool.result && (
-            <div className="chat-tool-call-section">
-              <div className="chat-tool-call-section-label">{t('chat.toolCalls.output')}</div>
-              <pre>
-                {tool.result.length > 2000
-                  ? `${tool.result.slice(0, 2000)}\n${t('chat.toolCalls.truncated')}`
-                  : tool.result}
-              </pre>
-            </div>
-          )}
-          {tool.error && tool.error !== tool.result && (
-            <div className="chat-tool-call-section chat-tool-call-section--error">
-              <div className="chat-tool-call-section-label">{t('chat.toolCalls.error')}</div>
-              <pre>{tool.error}</pre>
-            </div>
-          )}
+          </div>
         </div>
       )}
     </>

--- a/apps/canvas-workspace/src/renderer/src/components/chat/ChatToolCalls.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/ChatToolCalls.tsx
@@ -48,6 +48,53 @@ function formatToolSignature(name: string, args: any): string {
   return `${name}(${parts.join(', ')})`;
 }
 
+const pickStringArg = (args: Record<string, unknown>, keys: string[]): string | null => {
+  for (const key of keys) {
+    const value = args[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return null;
+};
+
+const quoteInline = (value: string, max = 64): string => JSON.stringify(truncate(value, max));
+
+const describeSearchTarget = (args: Record<string, unknown>): string | null => (
+  pickStringArg(args, ['path'])
+  ?? pickStringArg(args, ['glob'])
+  ?? pickStringArg(args, ['type'])
+);
+
+export function formatToolDescription(tool: Pick<ToolCallStatus, 'name' | 'args'>): string | null {
+  if (!tool.args || typeof tool.args !== 'object') return null;
+  const args = tool.args as Record<string, unknown>;
+  const explicitDescription = pickStringArg(args, ['description']);
+  if (explicitDescription) return explicitDescription;
+
+  const filePath = pickStringArg(args, ['filePath', 'file_path', 'path']);
+  switch (tool.name) {
+    case 'read':
+      return filePath ? `Read ${truncate(filePath, 96)}` : null;
+    case 'write':
+      return filePath ? `Write ${truncate(filePath, 96)}` : null;
+    case 'edit':
+      return filePath ? `Edit ${truncate(filePath, 96)}` : null;
+    case 'grep': {
+      const pattern = pickStringArg(args, ['pattern', 'query']);
+      if (!pattern) return null;
+      const target = describeSearchTarget(args);
+      return target
+        ? `Search ${quoteInline(pattern)} in ${truncate(target, 72)}`
+        : `Search ${quoteInline(pattern)}`;
+    }
+    case 'ls': {
+      const path = pickStringArg(args, ['path']);
+      return path ? `List ${truncate(path, 96)}` : null;
+    }
+    default:
+      return null;
+  }
+}
+
 const TOOL_LABEL_SLUGS: Record<string, string> = {
   canvas_read_context: 'readCanvasContext',
   canvas_read_node: 'readNode',
@@ -193,9 +240,15 @@ export const ChatToolCalls = ({
           && status !== 'queued'
           && !!(tool.result || tool.error || tool.args !== undefined);
         const expanded = expandedTools.has(tool.id);
-        const showRawName = !TOOL_LABEL_SLUGS[tool.name]
+        const description = formatToolDescription(tool);
+        const label = description ?? formatToolLabel(tool.name, status, t);
+        const signature = formatToolSignature(tool.name, tool.args);
+        const showRawName = !description && (
+          !TOOL_LABEL_SLUGS[tool.name]
           || status === 'failed'
-          || status === 'cancelled';
+          || status === 'cancelled'
+        );
+        const headerTitle = description ? `${description} · ${signature}` : signature;
         const headerContent = (
           <>
             <span className="chat-tool-call-icon">
@@ -211,8 +264,8 @@ export const ChatToolCalls = ({
                 </svg>
               )}
             </span>
-            <span className="chat-tool-call-sig" title={formatToolSignature(tool.name, tool.args)}>
-              <span className="chat-tool-call-label">{formatToolLabel(tool.name, status, t)}</span>
+            <span className="chat-tool-call-sig" title={headerTitle}>
+              <span className="chat-tool-call-label">{label}</span>
               {showRawName && <span className="chat-tool-call-name">{tool.name}</span>}
             </span>
             {canToggle && (

--- a/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatMessages.accessibility.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatMessages.accessibility.test.tsx
@@ -179,6 +179,27 @@ describe('ChatMessages accessibility', () => {
     expect(el.querySelector('.chat-activity-status__elapsed')?.textContent).toMatch(/^8s$/);
   });
 
+  it('keeps a settled command description visible in the activity row', async () => {
+    const el = await renderMessages(
+      [{ role: 'assistant', content: '', timestamp: Date.now() }],
+      {
+        loading: true,
+        streamingTools: [{
+          id: 3,
+          name: 'bash',
+          status: 'succeeded',
+          startedAt: Date.now() - 9000,
+          finishedAt: Date.now() - 1000,
+          args: { description: 'Inspect command result summary' },
+          result: '{"output":"done","exitCode":0}',
+        }],
+      },
+    );
+
+    expect(el.querySelector('.chat-activity-status__label')?.textContent)
+      .toBe('Inspect command result summary');
+  });
+
   it.each([
     ['__global_chat__', 'session-global', 3],
     ['__scheduled__-task-1', 'session-scheduled', 4],

--- a/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatToolCalls.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/components/chat/__tests__/ChatToolCalls.test.tsx
@@ -113,6 +113,85 @@ describe('ChatToolCalls tab tool labels', () => {
     expect(host!.querySelectorAll('.chat-tool-call-name')).toHaveLength(0);
   });
 
+  it('uses the bash description as the command row label when available', () => {
+    renderToolCalls([{
+      id: 34,
+      name: 'bash',
+      status: 'succeeded',
+      args: {
+        command: 'gh pr list --search magibook',
+        description: 'Search Feishu docs and chats for magibook CLI references',
+      },
+      result: '{"output":"done","exitCode":0}',
+    }]);
+
+    expect(host!.querySelector('.chat-tool-call-label')?.textContent)
+      .toBe('Search Feishu docs and chats for magibook CLI references');
+    expect(host!.querySelector('.chat-tool-call-name')).toBeNull();
+    expect(host!.querySelector('.chat-tool-call-sig')?.getAttribute('title'))
+      .toContain('gh pr list --search magibook');
+  });
+
+  it('uses key arguments for filesystem and search tool row labels', () => {
+    renderToolCalls([
+      {
+        id: 35,
+        name: 'read',
+        status: 'succeeded',
+        args: { filePath: '/workspace/apps/canvas-workspace/src/App.tsx' },
+        result: 'source',
+      },
+      {
+        id: 36,
+        name: 'write',
+        status: 'succeeded',
+        args: { file_path: '/workspace/tmp/report.md', content: '# Report' },
+        result: 'ok',
+      },
+      {
+        id: 37,
+        name: 'edit',
+        status: 'succeeded',
+        args: { filePath: '/workspace/packages/core/index.ts', oldString: 'before', newString: 'after' },
+        result: 'ok',
+      },
+      {
+        id: 38,
+        name: 'grep',
+        status: 'succeeded',
+        args: { pattern: 'magibook', path: 'apps packages' },
+        result: 'matches',
+      },
+      {
+        id: 39,
+        name: 'ls',
+        status: 'succeeded',
+        args: { path: 'apps/canvas-workspace' },
+        result: 'files',
+      },
+    ]);
+
+    const labels = Array.from(host!.querySelectorAll('.chat-tool-call-label'))
+      .map(element => element.textContent);
+    expect(labels).toEqual([
+      'Read /workspace/apps/canvas-workspace/src/App.tsx',
+      'Write /workspace/tmp/report.md',
+      'Edit /workspace/packages/core/index.ts',
+      'Search "magibook" in apps packages',
+      'List apps/canvas-workspace',
+    ]);
+    expect(host!.textContent).not.toContain('Read file');
+    expect(host!.textContent).not.toContain('Search files');
+    expect(host!.textContent).not.toContain('List directory');
+    expect(host!.querySelectorAll('.chat-tool-call-name')).toHaveLength(0);
+  });
+
+  it('still falls back to localized labels when a tool has no descriptive args', () => {
+    renderToolCalls([{ id: 40, name: 'read', status: 'succeeded' }]);
+
+    expect(host!.querySelector('.chat-tool-call-label')?.textContent).toBe('Read file');
+  });
+
   it('keeps a completed tab result persistently expandable without an undo claim', () => {
     renderToolCalls([{
       id: 42,


### PR DESCRIPTION
Improve Pulse Canvas chat tool call rows and detail interactions.

- Show command descriptions and key file/search arguments in tool call rows
- Animate tool detail expand/collapse with reduced-motion support
- Preserve raw input/output details behind expandable rows
- Add renderer tests for labels, activity status, and detail rendering