### PR TITLE
release(canvas): 0.1.55

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.54",
+  "version": "0.1.55",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
## Release Pulse Canvas 0.1.55

User-visible changes since `pulse-canvas-v0.1.54`:

- Simplified settings: hide role editing and new-user dynamic app / default-browser toggles; keep Pi opt-in; unify Assistant and Feishu Bot labels; move maintenance controls into Advanced; show repair diagnostics only when needed.
- Unified canvas node interactions: open web nodes as browser tabs, hide note detail actions, lay out frame colors horizontally, align mindmap controls; require confirmation before removing a whole mindmap.
- Fix: isolate workspace tabs and contain MCP App overlays (scope-owned tab order/focus/split layout/Global Chat sessions; terminals restricted to real workspaces).
- Perf fixtures fit drawable viewport (internal).

Artifacts published to R2 (`pulse-canvas/stable`), download page updated. After merge, tag `pulse-canvas-v0.1.55` will be created on master.