### PR TITLE
release(canvas): 0.1.56

### DIFF
--- a/apps/canvas-workspace/package.json
+++ b/apps/canvas-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canvas-workspace",
   "private": true,
-  "version": "0.1.55",
+  "version": "0.1.56",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
Release Pulse Canvas 0.1.56 from master at 4a0dbeac, including the local folder workbench from #1004. Users can browse and edit local files, find and replace text, preview Markdown and images, and insert file or folder references into conversations.

This PR changes only the application version. The macOS arm64 DMG, stable manifest with bilingual notes and 12 release-history entries, and download page are published through the local release pipeline. After merge, the annotated pulse-canvas-v0.1.56 tag will point to the merged master commit.

Validation: scoped standard harness checks passed (8/8), including typechecks, all 507 Canvas test files / 2,972 tests, production build, and Pi Electron smoke. Packaged runtime import and CLI/skills installation passed in a temporary home. Package size gates and deep strict signature verification passed (98.3 MB DMG).
