### PR TITLE
fix(canvas): improve Feishu reply lifecycle

### DIFF
--- a/apps/canvas-workspace/src/plugins/main/channel/__tests__/bridge-startup.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/__tests__/bridge-startup.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { CanvasAgentServiceRef, PluginStore } from '../../../types';
+import { ChannelBridge } from '../core/bridge';
+import { SessionRouter } from '../core/sessions';
+import type { Channel, ChannelStream, InboundHandler, InboundMessage } from '../core/types';
+
+function setup() {
+  let handler: InboundHandler = () => undefined;
+  const stream: ChannelStream = {
+    onText: vi.fn(), onToolCall: vi.fn(), onClarification: vi.fn(),
+    onDone: vi.fn(), onError: vi.fn(),
+  };
+  const channel: Channel = {
+    id: 'feishu', isConfigured: () => true,
+    start: async (onInbound) => { handler = onInbound; }, stop: async () => undefined,
+    openStream: vi.fn(async () => stream), sendText: vi.fn(async () => undefined),
+  };
+  const store: PluginStore = {
+    get: async () => undefined, set: async () => undefined,
+    delete: async () => undefined, list: async () => [],
+  };
+  const service: CanvasAgentServiceRef = {
+    chat: vi.fn(async () => ({ ok: true })),
+    chatWithScope: vi.fn(async () => ({ ok: true, response: 'hello' })),
+    abort: vi.fn(), abortScope: vi.fn(),
+    answerClarification: () => false, answerClarificationForScope: () => false,
+    getStatus: () => ({ ok: true, active: false, messageCount: 0 }),
+    getStatusForScope: () => ({ ok: true, active: false, messageCount: 0 }),
+    getCurrentSessionId: () => null, getCurrentSessionIdForScope: () => null,
+    newSession: async () => ({ ok: true }), newSessionForScope: async () => ({ ok: true }),
+    loadSession: async () => ({ ok: true }), loadSessionForScope: async () => ({ ok: true }),
+    listSessions: async () => [], listSessionsForScope: async () => [],
+    copySessionToScope: async () => ({ ok: true, sessionId: 'copy', messageCount: 0 }),
+  };
+  const bridge = new ChannelBridge(service, store, { runIdleTimeoutMs: 10_000 });
+  let messageId = 0;
+  const send = () => {
+    const message: InboundMessage = {
+      channelId: 'feishu', conversationId: 'dm', userId: 'user', messageId: `${++messageId}`,
+      text: 'hello', isDirect: true, isMention: false, reply: {},
+    };
+    handler(message);
+  };
+  return { bridge, channel, stream, service, send };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('channel startup acknowledgement', () => {
+  it('opens the stream before a slow session selection and keeps the scope busy', async () => {
+    vi.useFakeTimers();
+    const { bridge, channel, stream, service, send } = setup();
+    const events: Array<{ event: string; at: number }> = [];
+    const start = Date.now();
+    vi.mocked(channel.openStream).mockImplementation(async () => {
+      events.push({ event: 'card', at: Date.now() - start });
+      return stream;
+    });
+    vi.spyOn(SessionRouter.prototype, 'ensureSession').mockImplementation(async () => {
+      events.push({ event: 'session-start', at: Date.now() - start });
+      await new Promise((resolve) => setTimeout(resolve, 5_000));
+      events.push({ event: 'session-ready', at: Date.now() - start });
+    });
+    await bridge.addChannel(channel);
+    send();
+    await vi.advanceTimersByTimeAsync(0);
+    const earlyCardCount = vi.mocked(channel.openStream).mock.calls.length;
+    expect(service.chatWithScope).not.toHaveBeenCalled();
+    send();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(channel.sendText).toHaveBeenCalledWith(expect.anything(), expect.stringContaining('Still working'));
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(earlyCardCount).toBe(1);
+    expect(events).toEqual([
+      { event: 'card', at: 0 }, { event: 'session-start', at: 0 }, { event: 'session-ready', at: 5_000 },
+    ]);
+    expect(channel.openStream).toHaveBeenCalledTimes(1);
+    expect(service.chatWithScope).toHaveBeenCalledTimes(1);
+    expect(stream.onDone).toHaveBeenCalledWith('hello');
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('closes the early card with an error if session selection rejects, without starting chat', async () => {
+    vi.useFakeTimers();
+    const { bridge, channel, stream, service, send } = setup();
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.spyOn(SessionRouter.prototype, 'ensureSession').mockRejectedValueOnce(new Error('session failed'));
+    await bridge.addChannel(channel);
+    send();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(channel.openStream).toHaveBeenCalledTimes(1);
+    expect(stream.onError).toHaveBeenCalledWith('session failed');
+    expect(service.chatWithScope).not.toHaveBeenCalled();
+    // Let the independent 1s dedupe persistence debounce finish.
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(vi.getTimerCount()).toBe(0);
+    send();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(service.chatWithScope).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleans up the watchdog and skips session selection if opening the stream fails', async () => {
+    vi.useFakeTimers();
+    const { bridge, channel, service, send } = setup();
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const select = vi.spyOn(SessionRouter.prototype, 'ensureSession').mockResolvedValue();
+    vi.mocked(channel.openStream).mockRejectedValueOnce(new Error('card failed'));
+    await bridge.addChannel(channel);
+    send();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(select).not.toHaveBeenCalled();
+    expect(service.chatWithScope).not.toHaveBeenCalled();
+    // Let the independent 1s dedupe persistence debounce finish.
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(vi.getTimerCount()).toBe(0);
+    send();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(service.chatWithScope).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/bot-identity.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/bot-identity.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const bot = { open_id: 'ou_bot', app_name: 'Pulse' };
+
+function mockBotInfo(payload: unknown): void {
+  vi.stubGlobal('fetch', vi.fn()
+    .mockResolvedValueOnce(new Response(JSON.stringify({
+      code: 0, tenant_access_token: 'test-token', expire: 7200,
+    })))
+    .mockResolvedValueOnce(new Response(JSON.stringify(payload))));
+}
+
+function groupEvent(openId: string): unknown {
+  return {
+    message: {
+      message_id: 'm1', chat_id: 'group1', chat_type: 'group', message_type: 'text',
+      content: JSON.stringify({ text: '@_user_1 hello' }),
+      mentions: [{ key: '@_user_1', id: { open_id: openId }, name: 'Pulse' }],
+    },
+    sender: { sender_id: { open_id: 'ou_sender' } },
+  };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.stubEnv('FEISHU_APP_ID', 'cli_bot');
+  vi.stubEnv('FEISHU_APP_SECRET', 'test-secret');
+  vi.stubEnv('FEISHU_API_BASE_URL', 'https://open.feishu.cn');
+  for (const key of ['OPEN_ID', 'USER_ID', 'UNION_ID', 'NAME']) {
+    vi.stubEnv(`FEISHU_BOT_${key}`, '');
+  }
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe('Feishu bot identity loading', () => {
+  it('reads the bot envelope returned by the bot/v3/info endpoint', async () => {
+    mockBotInfo({ code: 0, msg: 'ok', bot });
+    const { getFeishuBotInfo } = await import('../feishu-client');
+    await expect(getFeishuBotInfo()).resolves.toEqual({ openId: 'ou_bot', appName: 'Pulse' });
+  });
+
+  it('accepts a group mention with the API-loaded identity, but not a same-name user', async () => {
+    mockBotInfo({ code: 0, msg: 'ok', bot });
+    const { loadBotIdentity } = await import('../bot-mention');
+    const { parseInbound } = await import('../feishu-channel');
+    const identity = await loadBotIdentity('cli_bot');
+    expect(parseInbound(groupEvent('ou_bot'), identity)).toMatchObject({
+      text: 'hello', isMention: true, isDirect: false,
+    });
+    expect(parseInbound(groupEvent('ou_other'), identity)).toBeNull();
+  });
+
+  it('preserves the previously supported data envelope', async () => {
+    mockBotInfo({ code: 0, msg: 'ok', data: bot });
+    const { getFeishuBotInfo } = await import('../feishu-client');
+    await expect(getFeishuBotInfo()).resolves.toEqual({ openId: 'ou_bot', appName: 'Pulse' });
+  });
+
+  it('rejects a successful response without a usable bot open_id', async () => {
+    mockBotInfo({ code: 0, msg: 'ok', bot: { app_name: 'Pulse', open_id: ' ' } });
+    const { getFeishuBotInfo } = await import('../feishu-client');
+    await expect(getFeishuBotInfo()).rejects.toThrow('missing bot open_id');
+  });
+
+  it('uses the existing env fallback with a warning for a malformed response', async () => {
+    mockBotInfo({ code: 0, msg: 'ok' });
+    vi.stubEnv('FEISHU_BOT_OPEN_ID', 'ou_fallback');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { loadBotIdentity } = await import('../bot-mention');
+    await expect(loadBotIdentity('cli_bot')).resolves.toMatchObject({ openId: 'ou_fallback' });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('failed to load bot identity'), expect.any(Error),
+    );
+  });
+
+  it('still rejects API errors', async () => {
+    mockBotInfo({ code: 999, msg: 'denied' });
+    const { getFeishuBotInfo } = await import('../feishu-client');
+    await expect(getFeishuBotInfo()).rejects.toThrow('denied');
+  });
+});

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/card.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/card.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import {
-  buildCompletedProcessCard,
   buildDoneCard,
   buildProgressCard,
+  buildThinkingCard,
   buildWorkspacePickerCard,
   formatToolLabel,
   type ToolEntry,
@@ -48,46 +48,68 @@ describe('feishu card tool list', () => {
     expect(formatToolLabel('read', { docToken: 'doccnXyz' })).toBe('read — doccnXyz');
   });
 
-  it('progress card shows the current stage and folds tool details', () => {
-    const card = buildProgressCard('working', tools, 20) as { header?: unknown };
+  it('keeps Working as an expanded process disclosure with a live timeline', () => {
+    const card = buildProgressCard('working', tools, 20) as {
+      header?: unknown;
+      body: { elements: Array<Record<string, unknown>> };
+    };
+    const panel = card.body.elements[0];
     const body = texts(card).join('\n');
     expect(card.header).toBeUndefined();
-    expect(body).toContain('<font color="purple">●</font> **Canvas write node node-2**');
-    expect(body).toContain('<font color="grey">运行中 · 20s</font>');
-    expect(body).toContain('working');
-    expect(body).toContain('<font color="grey">Called tools 2 times</font>');
+    expect(panel.tag).toBe('collapsible_panel');
+    expect(panel.expanded).toBe(true);
+    expect(body).toContain('**Working**');
     expect(body).toContain('<font color="grey">│</font>');
-    expect(JSON.stringify(card)).toContain('"text_size":"heading"');
-    expect(JSON.stringify(card)).toContain('"text_size":"notation"');
-    expect(body).not.toContain('**当前答复**\nworking');
-    // Tool rows stay quiet in the folded panel: grey structure/text, no heavy status color or debug label.
+    expect(body).toContain('<font color="grey">›</font>');
+    expect(body).toContain('<font color="grey">•</font>');
     expect(body).toContain('<font color="grey">Canvas read node · node-1 · 18s</font>');
-    expect(body).toContain('<font color="grey">Canvas write node · node-2</font>');
+    expect(body).toContain('Canvas write node · node-2');
+    expect(body).toContain('working');
+    expect(body).not.toContain('Called tools');
+    expect(JSON.stringify(card)).not.toContain('"text_size":"heading"');
+    expect(JSON.stringify(card)).toContain('"text_size":"normal"');
+    expect(JSON.stringify(card)).toContain('"text_size":"notation"');
   });
 
-  it('completed process card leaves only a completion row plus folded tool details', () => {
-    const card = buildCompletedProcessCard(tools, 20) as {
+  it('does not freeze the live answer after the old 700 character preview limit', () => {
+    const streamed = `${'a'.repeat(760)}tail`;
+    const body = texts(buildProgressCard(streamed)).join('\n');
+    expect(body).toContain('tail');
+  });
+
+  it('thinking and progress cards keep the same stable status geometry', () => {
+    const thinking = texts(buildThinkingCard());
+    const progress = texts(buildProgressCard('', tools));
+    expect(thinking[0]).toBe('**Working**');
+    expect(progress[0]).toBe(thinking[0]);
+  });
+
+  it('done card keeps the final answer below an expanded completed timeline', () => {
+    const card = buildDoneCard('final answer', tools) as {
       header?: unknown;
       body: { elements: Array<Record<string, unknown>> };
     };
     const panel = card.body.elements.find((e) => e.tag === 'collapsible_panel');
     expect(panel).toBeDefined();
-    expect(panel!.expanded).toBe(false);
+    expect(panel!.expanded).toBe(true);
     expect(card.header).toBeUndefined();
     const body = texts(card).join('\n');
-    expect(body).toContain('<font color="grey">●</font> **Completed**');
-    expect(body).toContain('<font color="grey">已完成 2 个步骤，下面是最终答复。</font>');
-    expect(body).toContain('<font color="grey">Called tools 2 times</font>');
-    expect(body).not.toContain('执行过程 · 已完成');
+    expect(body).toContain('**Completed**');
+    expect(body).toContain('final answer');
+    expect(body).toContain('<font color="grey">│</font>');
+    expect(body).toContain('<font color="grey">›</font>');
+    expect(body).toContain('◎ Completed');
+    expect(body).not.toContain('Called tools');
     expect(body).toContain('Canvas read node · node-1');
   });
 
-  it('done card with no tools is just the answer (no panel)', () => {
+  it('done card with no tools keeps status and answer without a panel', () => {
     const card = buildDoneCard('hi', []) as {
       body: { elements: Array<Record<string, unknown>> };
     };
-    expect(card.body.elements).toHaveLength(1);
-    expect(card.body.elements[0].tag).toBe('markdown');
+    expect(card.body.elements).toHaveLength(2);
+    expect(card.body.elements.every(element => element.tag === 'markdown')).toBe(true);
+    expect(texts(card).join('\n')).toContain('hi');
   });
 
   it('workspace picker card uses a workspace dropdown and two submit buttons', () => {

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/stream.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/stream.test.ts
@@ -41,6 +41,25 @@ describe('FeishuStream', () => {
     vi.useRealTimers();
   });
 
+  it('animates the working marker through heartbeat card patches', async () => {
+    const stream = new FeishuStream({} as never, {
+      chatId: 'group1',
+      isGroup: true,
+      triggerMessageId: 'm1',
+    });
+
+    await stream.init();
+    expect(JSON.stringify(mockedSendCard.mock.calls[0][2])).toContain('•');
+
+    await vi.advanceTimersByTimeAsync(1_200);
+    await flushAsync();
+    expect(JSON.stringify(mockedUpdateCard.mock.calls.at(-1)?.[2])).toContain('●');
+
+    await vi.advanceTimersByTimeAsync(1_200);
+    await flushAsync();
+    expect(JSON.stringify(mockedUpdateCard.mock.calls.at(-1)?.[2])).toContain('•');
+  });
+
   it('keeps streaming after a transient card patch failure', async () => {
     mockedUpdateCard
       .mockRejectedValueOnce(new Error('rate limited'))
@@ -60,8 +79,8 @@ describe('FeishuStream', () => {
     await vi.advanceTimersByTimeAsync(800);
     await flushAsync();
 
-    expect(mockedUpdateCard).toHaveBeenCalledTimes(2);
-    expect(JSON.stringify(mockedUpdateCard.mock.calls[1][2])).toContain('second chunk');
+    expect(mockedUpdateCard.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(JSON.stringify(mockedUpdateCard.mock.calls.at(-1)?.[2])).toContain('second chunk');
     expect(mockedSendText).not.toHaveBeenCalled();
   });
 
@@ -90,8 +109,8 @@ describe('FeishuStream', () => {
     await vi.advanceTimersByTimeAsync(10_000);
     await flushAsync();
 
-    expect(mockedUpdateCard).toHaveBeenCalledTimes(2);
-    expect(JSON.stringify(mockedUpdateCard.mock.calls[1][2])).toContain('first second third');
+    expect(mockedUpdateCard.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(JSON.stringify(mockedUpdateCard.mock.calls.at(-1)?.[2])).toContain('first second third');
   });
 
   it('shows tool input progress before the final tool call arrives', async () => {
@@ -120,7 +139,28 @@ describe('FeishuStream', () => {
     expect(latestCard).toContain('Demo');
   });
 
-  it('still sends the final answer as plain text when the completed process patch hangs', async () => {
+  it('finishes by patching the original card with the final answer', async () => {
+    const stream = new FeishuStream({} as never, {
+      chatId: 'group1',
+      isGroup: true,
+      triggerMessageId: 'm1',
+    });
+
+    await stream.init();
+    stream.onText('partial');
+    await vi.advanceTimersByTimeAsync(800);
+    await flushAsync();
+    await stream.onDone('final answer');
+
+    const finalCard = JSON.stringify(mockedUpdateCard.mock.calls.at(-1)?.[2]);
+    expect(finalCard).toContain('Completed');
+    expect(finalCard).toContain('final answer');
+    expect(finalCard).not.toContain('partial');
+    expect(mockedSendCard).toHaveBeenCalledTimes(1);
+    expect(mockedSendText).not.toHaveBeenCalled();
+  });
+
+  it('falls back to plain text when the final card patch hangs', async () => {
     mockedUpdateCard.mockImplementationOnce(() => new Promise(() => undefined));
     const stream = new FeishuStream({} as never, {
       chatId: 'group1',
@@ -138,7 +178,7 @@ describe('FeishuStream', () => {
     expect(mockedSendText.mock.calls[0][2]).toBe('final answer');
   });
 
-  it('still sends the final answer as plain text when the completed process update fails', async () => {
+  it('falls back to plain text when the final card update fails', async () => {
     mockedUpdateCard.mockRejectedValueOnce(new Error('final failed'));
     const stream = new FeishuStream({} as never, {
       chatId: 'group1',

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
@@ -1,8 +1,8 @@
 // Feishu interactive card (schema 2.0) builders for the streamed agent run.
 // One card is created on run start and progressively patched: thinking →
 // progress (accumulated text + a live list of tool calls) → done / error.
-// On done the tool list folds into a collapsible panel so the answer stays
-// front-and-center while the work remains inspectable.
+// Working/Completed is an expanded disclosure containing the live tool timeline;
+// the same card keeps the streamed answer directly below it.
 
 import type { OutboundTarget, WorkspacePicker } from '../../core/types';
 
@@ -33,10 +33,6 @@ function md(content: string, textSize?: 'heading' | 'normal' | 'notation'): obje
 
 function muted(content: string): string {
   return `<font color="grey">${content}</font>`;
-}
-
-function purple(content: string): string {
-  return `<font color="purple">${content}</font>`;
 }
 
 function red(content: string): string {
@@ -96,16 +92,33 @@ function toolLine(tool: ToolEntry): string {
   return segs.join(' · ');
 }
 
-/** Render folded tool details as a quiet vertical timeline. */
-function toolTimeline(tools: ToolEntry[]): string {
-  return tools
-    .flatMap((tool, index) => {
-      const isLast = index === tools.length - 1;
-      const dot = muted(tool.done ? '●' : '◦');
-      const row = `${dot} ${muted(toolLine(tool))}`;
-      return isLast ? [row] : [row, `${muted('│')}`];
-    })
-    .join('\n');
+const DOT_PULSE_FRAMES = ['•', '●', '•', '·'] as const;
+
+function dotPulseFrame(elapsedSec: number): string {
+  return DOT_PULSE_FRAMES[Math.abs(Math.floor(elapsedSec)) % DOT_PULSE_FRAMES.length];
+}
+
+/**
+ * The reference interaction keeps the process visible as one quiet vertical
+ * timeline. Finished rows recede; the current row gets the only moving mark.
+ */
+function toolTimeline(tools: ToolEntry[], elapsedSec: number, running: boolean): string {
+  const pulse = dotPulseFrame(elapsedSec);
+  const rail = muted('│');
+  const liveMark = muted(pulse);
+  const rows = tools.map((tool) => {
+    const completed = tool.done || !running;
+    const status = completed ? muted('›') : liveMark;
+    const label = completed ? muted(toolLine(tool)) : toolLine(tool);
+    return `${rail}  ${status}  ${label}`;
+  });
+
+  if (running && rows.length === 0) {
+    rows.push(liveMark);
+  } else if (!running) {
+    rows.push(`${muted('└')}  ${muted('◎ Completed')}`);
+  }
+  return rows.join('\n');
 }
 
 /** Recover the "name" / "detail" parts of a `formatToolLabel` string. */
@@ -113,10 +126,6 @@ function splitToolLabel(label: string): { name: string; detail: string } {
   const i = label.indexOf(' — ');
   if (i >= 0) return { name: label.slice(0, i), detail: label.slice(i + 3) };
   return { name: label, detail: '' };
-}
-
-function toolCountLine(count: number): string {
-  return `Called tools ${count} ${count === 1 ? 'time' : 'times'}`;
 }
 
 function titleizeToolName(name: string): string {
@@ -127,110 +136,61 @@ function titleizeToolName(name: string): string {
   )).join(' ');
 }
 
-function stepTitle(status: string, tools: ToolEntry[]): string {
-  if (status === '已完成') return 'Completed';
-  if (status === '出错') return 'Error';
-  const latest = tools.at(-1);
-  if (!latest) return 'Thinking';
-  const { name, detail } = splitToolLabel(latest.label);
-  const title = titleizeToolName(name);
-  return detail ? `${title} ${detail}` : title;
+function statusLine(status: 'working' | 'completed'): string {
+  return `**${status === 'working' ? 'Working' : 'Completed'}**`;
 }
 
-function stepSubtitle(status: string, elapsedSec?: number): string {
-  const parts = [status];
-  if (typeof elapsedSec === 'number') parts.push(`${elapsedSec}s`);
-  return parts.join(' · ');
-}
-
-function statusDot(status: string): string {
-  if (status === '出错') return red('●');
-  if (status === '已完成') return muted('●');
-  return purple('●');
-}
-
-function toolPanel(tools: ToolEntry[]): object | undefined {
-  if (tools.length === 0) return undefined;
+/** Working/Completed is itself the disclosure control, like the reference. */
+function processPanel(
+  status: 'working' | 'completed',
+  tools: ToolEntry[],
+  elapsedSec: number,
+): object {
   return {
     tag: 'collapsible_panel',
-    expanded: false,
+    expanded: true,
     header: {
-      title: md(muted(toolCountLine(tools.length)), 'notation'),
+      title: md(statusLine(status), 'normal'),
       vertical_align: 'center',
     },
-    elements: [md(toolTimeline(tools), 'notation')],
+    elements: [md(toolTimeline(tools, elapsedSec, status === 'working'), 'notation')],
   };
 }
 
-/** Native-like Agent process block: stage title stays visible; tool details fold away. */
-function processElements(input: {
-  status: string;
-  tools?: ToolEntry[];
-  elapsedSec?: number;
-  note?: string;
-  answerPreview?: string;
-}): object[] {
-  const tools = input.tools ?? [];
-  const title = stepTitle(input.status, tools);
-  const subtitle = stepSubtitle(input.status, input.elapsedSec);
-  const elements: object[] = [
-    md(`${statusDot(input.status)} **${title}**`, 'heading'),
-    md(muted(input.note ?? subtitle), 'notation'),
-  ];
-  if (input.answerPreview?.trim()) {
-    elements.push(md(clamp(input.answerPreview.trim()).slice(0, 700), 'normal'));
-  }
-  const foldedTools = toolPanel(tools);
-  if (foldedTools) elements.push(foldedTools);
+/** The process stays above the answer while both update in the same card. */
+function liveElements(text: string, tools: ToolEntry[], elapsedSec: number): object[] {
+  const elements: object[] = [processPanel('working', tools, elapsedSec)];
+  if (text.trim()) elements.push(md(clamp(text.trim()), 'normal'));
   return elements;
 }
 
 export function buildThinkingCard(): object {
-  return card(undefined, 'blue', processElements({
-    status: '准备中',
-    note: '已收到请求，正在准备运行环境...',
-  }), false);
+  return card(undefined, 'blue', liveElements('', [], 0), false);
 }
 
 export function buildProgressCard(
   text: string,
   tools: ToolEntry[] = [],
-  elapsedSec?: number,
+  elapsedSec = 0,
 ): object {
-  return card(undefined, 'blue', processElements({
-    status: '运行中',
-    tools,
-    elapsedSec,
-    note: tools.length === 0 ? '正在生成答复...' : undefined,
-    answerPreview: text,
-  }), false);
-}
-
-export function buildCompletedProcessCard(tools: ToolEntry[] = [], elapsedSec?: number): object {
-  return card(undefined, 'green', processElements({
-    status: '已完成',
-    tools,
-    elapsedSec,
-    note: tools.length > 0
-      ? `已完成 ${tools.length} 个步骤，下面是最终答复。`
-      : '已完成，下面是最终答复。',
-  }), false);
+  return card(undefined, 'blue', liveElements(text, tools, elapsedSec), false);
 }
 
 export function buildDoneCard(text: string, tools: ToolEntry[] = []): object {
-  const elements: object[] = [md(clamp(text) || '✅ Done')];
-  if (tools.length > 0) {
-    elements.push(...processElements({
-      status: '已完成',
-      tools,
-      note: `已完成 ${tools.length} 个步骤。`,
-    }));
-  }
-  return card('Pulse 已完成', 'green', elements, true);
+  const elapsedSec = tools.reduce((total, tool) => total + (tool.elapsedSec ?? 0), 0);
+  const elements: object[] = tools.length > 0
+    ? [processPanel('completed', tools, elapsedSec)]
+    : [md(statusLine('completed'), 'normal')];
+  if (text.trim()) elements.push(md(clamp(text.trim()), 'normal'));
+  else elements.push(md(' Done', 'normal'));
+  return card(undefined, 'green', elements, true);
 }
 
 export function buildErrorCard(message: string): object {
-  return card('Pulse 运行出错', 'red', [md(`**状态**：出错\n\n❌ ${message}`)], false);
+  return card(undefined, 'red', [
+    md(`${red('●')} **Error**`, 'heading'),
+    md(message, 'normal'),
+  ], false);
 }
 
 export function buildWorkspacePickerCard(picker: WorkspacePicker, target?: OutboundTarget): object {

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-channel.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-channel.ts
@@ -17,7 +17,7 @@ import {
   type FeishuSendTarget,
 } from './feishu-client';
 import {
-  buildCompletedProcessCard,
+  buildDoneCard,
   buildErrorCard,
   buildProgressCard,
   buildThinkingCard,
@@ -30,7 +30,7 @@ import { loadBotIdentity, messageMentionsBot, type FeishuBotIdentity } from './b
 
 const CHANNEL_ID = 'feishu';
 const PROGRESS_THROTTLE_MS = 800;
-const PROGRESS_HEARTBEAT_MS = 15_000;
+const PROGRESS_HEARTBEAT_MS = 1_200;
 const CARD_SEND_TIMEOUT_MS = 10_000;
 const CARD_UPDATE_TIMEOUT_MS = 10_000;
 
@@ -356,10 +356,7 @@ export class FeishuStream implements ChannelStream {
       t.done = true;
       t.elapsedSec = Math.round((now - t.startedAt) / 1000);
     }
-    await this.finalizeWithAnswer(
-      () => buildCompletedProcessCard(this.tools, this.elapsedSec()),
-      text,
-    );
+    await this.finalize(() => buildDoneCard(text, this.tools), text || '✅ Done');
   }
 
   async onError(message: string): Promise<void> {
@@ -463,23 +460,6 @@ export class FeishuStream implements ChannelStream {
     if (!finalUpdated) {
       await this.sendFallbackText(fallbackText);
     }
-  }
-
-  private async finalizeWithAnswer(
-    processFactory: () => object,
-    answerText: string,
-  ): Promise<void> {
-    this.finalizing = true;
-    this.pendingProgressFactory = null;
-    if (this.updateInFlight) {
-      await this.updateInFlight;
-    }
-
-    if (!this.cardUpdateTimedOut) {
-      await this.patchCard(processFactory, 'Feishu completed process card update');
-    }
-
-    await this.sendFallbackText(answerText || '✅ Done');
   }
 
   private async sendFallbackText(text: string): Promise<void> {

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-client.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-client.ts
@@ -100,17 +100,21 @@ export async function getFeishuBotInfo(): Promise<FeishuBotInfo> {
     );
   }
 
-  const payload = (await response.json()) as FeishuApiResponse<{
-    open_id?: string;
-    app_name?: string;
-  }>;
+  type BotInfo = { open_id?: string; app_name?: string };
+  const payload = (await response.json()) as FeishuApiResponse<BotInfo> & { bot?: BotInfo };
   if (payload.code !== 0) {
     throw new Error(`Failed to get Feishu bot info: ${payload.msg || 'unknown error'}`);
   }
 
+  // bot/v3/info uses a top-level bot envelope, unlike the IM APIs' data envelope.
+  const bot = payload.bot ?? payload.data;
+  const openId = bot?.open_id?.trim();
+  if (!openId) {
+    throw new Error('Failed to get Feishu bot info: missing bot open_id');
+  }
   return {
-    openId: payload.data?.open_id,
-    appName: payload.data?.app_name,
+    openId,
+    appName: bot?.app_name,
   };
 }
 

--- a/apps/canvas-workspace/src/plugins/main/channel/core/bridge.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/core/bridge.ts
@@ -309,25 +309,23 @@ export class ChannelBridge {
       idleTimer = setTimeout(check, this.runIdleTimeoutMs);
     });
 
-    // Give this conversation its own session so topics / chats sharing a
-    // scope keep separate histories. Safe here: runs are serialized per
-    // scope, so nothing else can swap the session mid-turn.
-    try {
-      await this.sessions.ensureSession(scope, msg.conversationId);
-    } catch (err) {
-      console.error(`[channel:${channel.id}] failed to select session`, err);
-    }
-
+    // Acknowledge the accepted turn before any potentially slow session setup.
+    // The scope is already reserved, so another message cannot start a second run.
     let stream: ChannelStream;
     try {
       stream = await channel.openStream(target);
     } catch (err) {
+      finished = true;
+      if (idleTimer) clearTimeout(idleTimer);
       this.activeRuns.delete(runKey);
       console.error(`[channel:${channel.id}] failed to open stream`, err);
       return;
     }
 
     try {
+      // Keep session selection inside the error/finally path: a failed setup
+      // must close the early card, not continue chatting in the wrong session.
+      await this.sessions.ensureSession(scope, msg.conversationId);
       const chat = this.service.chatWithScope(
         scope,
         buildAgentPrompt(msg),


### PR DESCRIPTION
## Summary
- Keep progress and final answers in one card with an expanded tool timeline and heartbeat markers; remove the 700-character live preview cutoff.
- Read the bot-info response envelope correctly so group mentions match the API-loaded identity.
- Send the Working card before session preparation; close setup failures and clean up failed stream startup.
- Add regression coverage for API-to-mention parsing, early acknowledgement, stream completion, and failure handling.

## Validation
- Channel tests: 120 passed.
- Canvas standard harness: 4/4 checks passed, including typecheck and full Canvas tests (2998 passed).
- Deterministic 5-second session-delay fixture confirms card creation moves before session preparation.
- Restarted the development app; Feishu channel and WebSocket report ready.
- Actual Feishu mention/reply timing and visual rendering still require manual verification.