### PR TITLE
fix(canvas): isolate Feishu topics with conversation-owned queues

### DIFF
--- a/apps/canvas-workspace/src/main/agent/conversation-runtime/conversation-ipc.ts
+++ b/apps/canvas-workspace/src/main/agent/conversation-runtime/conversation-ipc.ts
@@ -8,6 +8,30 @@ import { isPerfChatReplayRequest, replayPerfChatStream } from '../perf-chat-repl
 
 let service: ConversationRuntimeService | null = null;
 
+export function getConversationRuntimeService(
+  getService: () => unknown,
+): ConversationRuntimeService {
+  if (!service) {
+    const agentService = getService() as CanvasAgentService;
+    service = new ConversationRuntimeService(
+      (scope) => agentService.getAgentForScope(scope),
+      (_storeId, scope) => ({
+        loadMessages: async (sessionId) => (
+          agentService.sessionMutations.readConversation(scope, sessionId)
+        ),
+        persist: (sessionId, messages) => (
+          agentService.sessionMutations.replaceConversationMessages(scope, sessionId, messages)
+        ),
+      }),
+      (scope, sessionId, operation) => (
+        agentService.sessionMutations.runChat(scope, operation, sessionId)
+      ),
+      (scope) => agentService.activateScope(scope),
+    );
+  }
+  return service;
+}
+
 const resolveScope = (payload: AgentScopeRef): AgentScope => {
   if (payload.scope?.kind === 'global') return { kind: 'global' };
   if (payload.scope?.kind === 'scheduled' && payload.scope.taskId) {
@@ -39,27 +63,7 @@ export interface ConversationRuntimeChatPayload {
  * work unchanged while main owns per-conversation state.
  */
 export function setupConversationRuntimeIpc(getService: () => CanvasAgentService): void {
-  const ensure = (): ConversationRuntimeService => {
-    if (!service) {
-      const agentService = getService();
-      service = new ConversationRuntimeService(
-        (scope) => agentService.getAgentForScope(scope),
-        (_storeId, scope) => ({
-          loadMessages: async (sessionId) => (
-            await agentService.sessionMutations.readConversation(scope, sessionId) ?? []
-          ),
-          persist: (sessionId, messages) => (
-            agentService.sessionMutations.replaceConversationMessages(scope, sessionId, messages)
-          ),
-        }),
-        (scope, sessionId, operation) => (
-          agentService.sessionMutations.runChat(scope, operation, sessionId)
-        ),
-        (scope) => agentService.activateScope(scope),
-      );
-    }
-    return service;
-  };
+  const ensure = (): ConversationRuntimeService => getConversationRuntimeService(getService);
 
   ipcMain.handle(
     'canvas-agent:conversation-chat',

--- a/apps/canvas-workspace/src/main/agent/conversation-runtime/conversation-runtime.ts
+++ b/apps/canvas-workspace/src/main/agent/conversation-runtime/conversation-runtime.ts
@@ -73,6 +73,8 @@ export interface ConversationRuntimeDeps {
   loadMessages: () => Promise<AgentChatMessage[]>;
   /** Persist the conversation's full message list after each settled turn. */
   persist: (messages: AgentChatMessage[]) => Promise<void>;
+  /** Hold the host mutation lease across a complete turn, including persistence. */
+  withTurnLease?: (operation: () => Promise<TurnRunnerResult>) => Promise<TurnRunnerResult>;
   /** Execute one turn against the shared Engine. */
   runTurn: (ctx: TurnRunnerContext) => Promise<TurnRunnerResult>;
 }
@@ -239,6 +241,29 @@ export class ConversationRuntime {
     this.status = 'running';
     this.error = null;
     this.runId = null;
+    this.controller = new AbortController();
+    try {
+      const operation = () => this.executeTurn(input, external);
+      return await (this.deps.withTurnLease ? this.deps.withTurnLease(operation) : operation());
+    } catch (err) {
+      this.error = err instanceof Error ? err.message : String(err);
+      return { response: '', error: this.error };
+    } finally {
+      this.status = 'idle';
+      this.streamingTools = [];
+      this.clarification = null;
+      this.controller = null;
+      this.runId = null;
+      this.publish();
+      // The previous lease must be released before the next queued turn starts.
+      void this.drain();
+    }
+  }
+
+  private async executeTurn(
+    input: ConversationSendInput,
+    external?: ConversationTurnExternal,
+  ): Promise<TurnRunnerResult> {
     this.messages.push({
       role: 'user',
       content: input.message,
@@ -246,7 +271,6 @@ export class ConversationRuntime {
       attachments: input.attachments?.length ? input.attachments : undefined,
       contextSnapshot: input.requestContext?.contextSnapshot,
     });
-    this.controller = new AbortController();
     this.publish();
 
     // Materialize the user turn before invoking the model. This makes a new
@@ -260,7 +284,7 @@ export class ConversationRuntime {
       result = await this.deps.runTurn({
         message: input.message,
         history: this.messages.slice(0, -1),
-        signal: this.controller.signal,
+        signal: this.controller!.signal,
         expectedSessionId: this.key.sessionId,
         mentionedWorkspaceIds: input.mentionedWorkspaceIds,
         requestContext: input.requestContext,
@@ -351,14 +375,6 @@ export class ConversationRuntime {
       result = { ...result, error: this.error };
     }
 
-    this.status = 'idle';
-    this.streamingTools = [];
-    this.clarification = null;
-    this.controller = null;
-    this.runId = null;
-    this.publish();
-
-    this.drain();
     return result;
   }
 

--- a/apps/canvas-workspace/src/main/agent/conversation-runtime/conversation-service.ts
+++ b/apps/canvas-workspace/src/main/agent/conversation-runtime/conversation-service.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import type { AgentScope, CanvasAgentMessage, ChatResponse } from '../types';
 import type { CanvasAgent } from '../canvas-agent';
 import { scopeSessionStoreId } from '../../../shared/agent-chat';
@@ -9,7 +10,7 @@ import { createConversationRunner } from './conversation-runner';
 
 /** Structural store surface the service drives (injectable for tests). */
 export interface ConversationStoreAdapter {
-  loadMessages(sessionId: string): Promise<CanvasAgentMessage[]>;
+  loadMessages(sessionId: string): Promise<CanvasAgentMessage[] | null>;
   persist(sessionId: string, messages: CanvasAgentMessage[]): Promise<void>;
 }
 
@@ -24,6 +25,7 @@ export interface ConversationStoreAdapter {
 export class ConversationRuntimeService {
   private readonly registries = new Map<string, ConversationRuntimeRegistry>();
   private readonly pendingRegistries = new Map<string, Promise<ConversationRuntimeRegistry>>();
+  private readonly stores = new Map<string, ConversationStoreAdapter>();
 
   constructor(
     private readonly getAgent: (scope: AgentScope) => CanvasAgent | undefined,
@@ -72,16 +74,81 @@ export class ConversationRuntimeService {
     if (!agent) throw new Error(`No active agent for scope ${key}`);
     const storeId = scopeSessionStoreId(scope);
     const storeAdapter = this.storeAdapterFactory(storeId, scope);
+    this.stores.set(key, storeAdapter);
     const registry = new ConversationRuntimeRegistry({
-      create: (conversationKey) => ({
-        key: conversationKey,
-        loadMessages: () => storeAdapter.loadMessages(conversationKey.sessionId),
-        persist: (messages) => storeAdapter.persist(conversationKey.sessionId, messages),
-        runTurn: createConversationRunner(agent),
-      }),
+      create: (conversationKey) => {
+        const runTurn = createConversationRunner(agent);
+        return {
+          key: conversationKey,
+          loadMessages: async () => (
+            await storeAdapter.loadMessages(conversationKey.sessionId) ?? []
+          ),
+          persist: (messages) => storeAdapter.persist(conversationKey.sessionId, messages),
+          runTurn,
+          withTurnLease: async (operation) => {
+            if (!this.runConversation) return operation();
+            const result = await this.runConversation(
+              scope,
+              conversationKey.sessionId,
+              operation,
+            );
+            return result ?? {
+              response: '',
+              code: 'CHAT_SCOPE_BUSY',
+              error: 'This conversation is already running.',
+            };
+          },
+        };
+      },
     });
     this.registries.set(key, registry);
     return registry;
+  }
+
+  /** Create a durable session without moving the scope's UI current pointer. */
+  async provisionSession(
+    scope: AgentScope,
+    messages: CanvasAgentMessage[] = [],
+  ): Promise<{ ok: boolean; sessionId?: string; error?: string }> {
+    try {
+      await this.registryFor(scope);
+      const sessionId = randomUUID();
+      const store = this.stores.get(scopeKey(scope));
+      if (!store) throw new Error(`No conversation store for scope ${scopeKey(scope)}`);
+      await store.persist(sessionId, messages);
+      return { ok: true, sessionId };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  /** Check a durable session without moving the scope's UI current pointer. */
+  async hasSession(scope: AgentScope, sessionId: string): Promise<boolean> {
+    await this.registryFor(scope);
+    const store = this.stores.get(scopeKey(scope));
+    if (!store) return false;
+    return (await store.loadMessages(sessionId)) !== null;
+  }
+
+  /** Copy durable history into a new pointer-neutral session in the target scope. */
+  async copySessionToScope(
+    sourceScope: AgentScope,
+    sourceSessionId: string,
+    targetScope: AgentScope,
+  ): Promise<{ ok: boolean; sessionId?: string; messageCount?: number; error?: string }> {
+    try {
+      await this.registryFor(sourceScope);
+      const sourceStore = this.stores.get(scopeKey(sourceScope));
+      if (!sourceStore) throw new Error(`No conversation store for scope ${scopeKey(sourceScope)}`);
+      const messages = await sourceStore.loadMessages(sourceSessionId);
+      if (messages === null) return { ok: false, error: 'Source session not found' };
+      const created = await this.provisionSession(targetScope, messages);
+      return created.ok
+        ? { ok: true, sessionId: created.sessionId, messageCount: messages.length }
+        : created;
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
   }
 
   /** Run one turn against a conversation. The runtime owns the queue. */
@@ -96,9 +163,7 @@ export class ConversationRuntimeService {
       const registry = await this.registryFor(scope);
       const runtime = await registry.open(conversationKey(scope, sessionId));
       const operation = () => runtime.sendAndWait({ message, ...input }, external);
-      const result = this.runConversation
-        ? await this.runConversation(scope, sessionId, operation)
-        : await operation();
+      const result = await operation();
       if (!result) {
         return { ok: false, code: 'CHAT_SCOPE_BUSY', error: 'This conversation is already running.' };
       }
@@ -148,6 +213,7 @@ export class ConversationRuntimeService {
   disposeAll(): void {
     for (const registry of this.registries.values()) registry.disposeAll();
     this.registries.clear();
+    this.stores.clear();
   }
 }
 

--- a/apps/canvas-workspace/src/main/agent/conversation-runtime/service-conversation-runtime.test.ts
+++ b/apps/canvas-workspace/src/main/agent/conversation-runtime/service-conversation-runtime.test.ts
@@ -67,6 +67,71 @@ afterEach(() => {
 });
 
 describe('ConversationRuntimeService.chat', () => {
+  it('holds a per-turn lease through persistence and queues instead of rejecting the next turn', async () => {
+    let leased = false;
+    const leaseStates: boolean[] = [];
+    const adapter = makeStoreAdapter();
+    const persist = adapter.persist;
+    adapter.persist = async (id, messages) => {
+      leaseStates.push(leased);
+      await persist(id, messages);
+    };
+    const service = new ConversationRuntimeService(
+      () => mockAgent.agent as never,
+      () => adapter,
+      async (_scope, _id, operation) => {
+        if (leased) return null;
+        leased = true;
+        try { return await operation(); } finally { leased = false; }
+      },
+    );
+    const results = await Promise.all([
+      service.chat(scope, 'session-a', 'first'),
+      service.chat(scope, 'session-a', 'second'),
+    ]);
+    expect(results.every(result => result.ok)).toBe(true);
+    expect(leaseStates).toEqual([true, true, true, true]);
+    expect(leased).toBe(false);
+  });
+
+  it('provisions and copies durable sessions without touching the UI current pointer', async () => {
+    const stored = new Map<string, CanvasAgentMessage[]>();
+    const service = new ConversationRuntimeService(
+      () => mockAgent.agent as never,
+      () => ({
+        loadMessages: async id => stored.get(id) ?? null,
+        persist: async (id, messages) => { stored.set(id, [...messages]); },
+      }),
+    );
+    const created = await service.provisionSession(scope, [
+      { role: 'user', content: 'history', timestamp: 1 },
+    ]);
+    expect(created.ok).toBe(true);
+    expect(created.sessionId).toBeTruthy();
+    expect(await service.hasSession(scope, created.sessionId!)).toBe(true);
+    expect(await service.hasSession(scope, 'missing')).toBe(false);
+    const copied = await service.copySessionToScope(scope, created.sessionId!, scope);
+    expect(copied).toMatchObject({ ok: true, messageCount: 1 });
+    expect(copied.sessionId).not.toBe(created.sessionId);
+    expect(stored.get(copied.sessionId!)).toEqual([{ role: 'user', content: 'history', timestamp: 1 }]);
+    expect(mockAgent.agent.getCurrentSessionId).not.toHaveBeenCalled();
+    expect(mockAgent.agent.chat).not.toHaveBeenCalled();
+  });
+
+  it('reports provisioning and source-copy failures rather than a usable session id', async () => {
+    const service = new ConversationRuntimeService(
+      () => mockAgent.agent as never,
+      () => ({
+        loadMessages: async () => null,
+        persist: async () => { throw new Error('disk full'); },
+      }),
+    );
+    expect(await service.provisionSession(scope)).toEqual({ ok: false, error: 'disk full' });
+    expect(await service.copySessionToScope(scope, 'missing', scope)).toEqual({
+      ok: false, error: 'Source session not found',
+    });
+  });
+
   it('activates a cold scope before opening its first conversation', async () => {
     let activeAgent: typeof mockAgent.agent | undefined;
     const activateScope = vi.fn(async () => {

--- a/apps/canvas-workspace/src/main/agent/tools/_shared/vision-clients.ts
+++ b/apps/canvas-workspace/src/main/agent/tools/_shared/vision-clients.ts
@@ -71,7 +71,7 @@ export async function analyzeImagesWithOpenAI(args: {
   if (!apiKey) throw new Error('OPENAI_API_KEY environment variable is not set');
 
   const apiUrl = (process.env.OPENAI_API_URL?.trim() || 'https://api.openai.com/v1').replace(/\/$/, '');
-  const model = args.model?.trim() || process.env.OPENAI_VISION_MODEL?.trim() || 'gpt-5.4';
+  const model = args.model?.trim() || process.env.OPENAI_VISION_MODEL?.trim() || 'gpt-5.6-sol';
   const mode = args.visionApiMode ?? 'responses';
   const detail = args.detail ?? 'auto';
 

--- a/apps/canvas-workspace/src/plugins/main/channel/README.md
+++ b/apps/canvas-workspace/src/plugins/main/channel/README.md
@@ -10,7 +10,7 @@ WeCom later is a matter of implementing one interface.
 - Connects to a channel and receives inbound messages.
 - Resolves which canvas workspace a conversation talks to (**explicit, sticky**
   binding — established with a light first-contact picker).
-- Drives `CanvasAgentService.chat()` for that workspace and streams the
+- Drives the host's conversation-owned runtime for that workspace and streams the
   agent's output back into the channel (Feishu: a single interactive card
   that is progressively patched — tool calls accumulate as a live ⏳/✅ list
   that folds into a collapsible panel once the run finishes; images are sent
@@ -83,7 +83,7 @@ so mentioning another person never wakes the bot.
 | `/unbind` | Clear this chat's binding (chat must be re-bound to talk again) |
 | `/default <name\|id>` | Set the workspace suggested for `/bind` (not auto-applied) |
 | `/new` | Start a fresh session |
-| `/stop` | Abort the current run |
+| `/stop` | Abort only this chat/topic's current run |
 | `/sessions` | List sessions (numbered) for the bound workspace |
 | `/session <number\|id>` | Switch this chat to a specific session (sticky) |
 | `/open` | Activate the bound workspace in the canvas (for webview ops; no focus steal) |
@@ -132,21 +132,32 @@ on the group root.
 
 ### Sessions
 
-Each conversation keeps **its own session/history**, even when several
-conversations (a DM, a group, different topics) share one workspace. Canvas
-stores a single *current* session per workspace, so the plugin maps
-`workspace::conversation → sessionId` and swaps the current session to the
-conversation's own before each turn (creating it on first contact). Runs are
-serialized per workspace, so the swap can't race another turn. The map
-persists, so histories survive restarts.
+Each `(scope, channelId, conversationId)` maps to a durable session. The
+plugin provisions and copies sessions through `ConversationRuntimeService`
+without reading or changing the Canvas UI's current-session pointer.
 
-Trade-offs:
+- Different topics in the same workspace run concurrently. Each topic uses
+  the host runtime's FIFO queue, with a short per-topic submission queue to
+  preserve arrival order across asynchronous routing and session creation.
+- Every accepted turn opens a reply card before waiting for provisioning or
+  earlier submissions. Reply targets stay anchored to the triggering message.
+- `/stop`, clarification answers, and watchdog aborts target only that topic's
+  explicit session. Queued turns do not spend their watchdog budget while waiting.
+  `/stop` stops the active turn; already queued messages can continue afterward.
+- Session/workspace-changing commands (`/new`, `/session`, `/use`, `/bind`,
+  `/unbind`) wait for earlier submissions and are rejected while the topic has
+  active/queued turns. Retry after it finishes; they never reinterpret an
+  in-flight session in a different workspace.
+- Failed provisioning or routing persistence does not fall back to the UI's
+  current session. Legacy keys migrate lazily; duplicate legacy mappings fork
+  durable history rather than sharing a live runtime. Already-mixed historical
+  content cannot be reconstructed automatically.
+- The runtime holds the host session-mutation lease for each complete turn,
+  including initial/final persistence, and releases it before draining the queue.
 
-- The workspace's *current* session is shared with the Canvas UI, so the UI
-  for that workspace shows whichever conversation ran last (each session is
-  intact and selectable in the UI's session list).
-- Conversations bound to the same workspace still run one-at-a-time (a second
-  in-flight message sees "still working").
+Session bindings survive restarts; in-memory pending messages do not. This is
+not a durable message broker, and process-crash replay/exactly-once delivery is
+not guaranteed. Workspace UI tools still share a single visible canvas.
 
 ### Canvas activation (for webview ops)
 
@@ -208,7 +219,10 @@ Set `CANVAS_CHANNEL_DEBUG=1` before launch to log each raw inbound event
 ```
 core/                channel-agnostic orchestration
   types.ts           Channel / InboundMessage / ChannelStream contracts
-  bridge.ts          inbound → resolve binding → service.chat() → stream out
+  bridge.ts          inbound → resolve binding → conversation runtime → stream out
+  submission-queue.ts per-topic ordered submission (not model execution)
+  sessions.ts        pointer-neutral durable session routing
+  inbound-prompt.ts  text and local image-path prompt construction
   binding.ts         (channelId, conversationId) → workspaceId, persisted
   commands.ts        slash-command handling
   dedupe.ts          message-id LRU dedupe
@@ -248,8 +262,9 @@ should generalize this layer rather than cloning the `feishu` naming.
 
 The plugin relies on two small extension points on the canvas plugin system:
 
-- `MainCtx.getAgentService()` — drive conversations via the host's
-  `CanvasAgentService` singleton (injected by the host in `bootstrap.ts`).
+- `MainCtx.getAgentService()` plus `getConversationRuntimeService()` — reuse
+  the host's singleton agent and conversation runtime (also used by chat IPC).
+  The channel never calls the legacy scope-wide chat path.
 - `MainCanvasPlugin.deactivate()` — release the long-lived channel
   connection on app shutdown (invoked from `window-all-closed`).
 

--- a/apps/canvas-workspace/src/plugins/main/channel/__tests__/bridge-startup.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/__tests__/bridge-startup.test.ts
@@ -1,47 +1,62 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { CanvasAgentServiceRef, PluginStore } from '../../../types';
+import type { ConversationTurnExternal } from '../../../../main/agent/conversation-runtime/conversation-runtime';
+import type { ConversationRuntimeService } from '../../../../main/agent/conversation-runtime/conversation-service';
 import { ChannelBridge } from '../core/bridge';
-import { SessionRouter } from '../core/sessions';
 import type { Channel, ChannelStream, InboundHandler, InboundMessage } from '../core/types';
 
-function setup() {
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(res => { resolve = res; });
+  return { promise, resolve };
+}
+
+function setup(runtimeOverrides: Record<string, unknown> = {}, options: { runIdleTimeoutMs: number; toolExecTimeoutMs?: number; clarificationTimeoutMs?: number } = { runIdleTimeoutMs: 10_000 }) {
   let handler: InboundHandler = () => undefined;
-  const stream: ChannelStream = {
-    onText: vi.fn(), onToolCall: vi.fn(), onClarification: vi.fn(),
-    onDone: vi.fn(), onError: vi.fn(),
-  };
+  const streams: ChannelStream[] = [];
   const channel: Channel = {
-    id: 'feishu', isConfigured: () => true,
-    start: async (onInbound) => { handler = onInbound; }, stop: async () => undefined,
-    openStream: vi.fn(async () => stream), sendText: vi.fn(async () => undefined),
+    id: 'feishu',
+    isConfigured: () => true,
+    start: async onInbound => { handler = onInbound; },
+    stop: async () => undefined,
+    openStream: vi.fn(async () => {
+      const stream: ChannelStream = {
+        onText: vi.fn(), onToolCall: vi.fn(), onClarification: vi.fn(),
+        onDone: vi.fn(), onError: vi.fn(),
+      };
+      streams.push(stream);
+      return stream;
+    }),
+    sendText: vi.fn(async () => undefined),
   };
   const store: PluginStore = {
-    get: async () => undefined, set: async () => undefined,
-    delete: async () => undefined, list: async () => [],
+    get: async () => undefined,
+    set: async () => undefined,
+    delete: async () => undefined,
+    list: async () => [],
   };
-  const service: CanvasAgentServiceRef = {
-    chat: vi.fn(async () => ({ ok: true })),
-    chatWithScope: vi.fn(async () => ({ ok: true, response: 'hello' })),
-    abort: vi.fn(), abortScope: vi.fn(),
-    answerClarification: () => false, answerClarificationForScope: () => false,
-    getStatus: () => ({ ok: true, active: false, messageCount: 0 }),
-    getStatusForScope: () => ({ ok: true, active: false, messageCount: 0 }),
-    getCurrentSessionId: () => null, getCurrentSessionIdForScope: () => null,
-    newSession: async () => ({ ok: true }), newSessionForScope: async () => ({ ok: true }),
-    loadSession: async () => ({ ok: true }), loadSessionForScope: async () => ({ ok: true }),
-    listSessions: async () => [], listSessionsForScope: async () => [],
-    copySessionToScope: async () => ({ ok: true, sessionId: 'copy', messageCount: 0 }),
-  };
-  const bridge = new ChannelBridge(service, store, { runIdleTimeoutMs: 10_000 });
+  const service = {
+    listSessionsForScope: vi.fn(async () => []),
+  } as unknown as CanvasAgentServiceRef;
+  const runtime = {
+    provisionSession: vi.fn(async () => ({ ok: true, sessionId: 'session' })),
+    hasSession: vi.fn(async () => true),
+    copySessionToScope: vi.fn(),
+    chat: vi.fn(async () => ({ ok: true, response: 'hello' })),
+    abort: vi.fn(() => true),
+    answerClarification: vi.fn(() => false),
+    ...runtimeOverrides,
+  } as unknown as ConversationRuntimeService;
+  const bridge = new ChannelBridge(service, runtime, store, options);
   let messageId = 0;
-  const send = () => {
+  const send = (text?: string) => {
     const message: InboundMessage = {
       channelId: 'feishu', conversationId: 'dm', userId: 'user', messageId: `${++messageId}`,
-      text: 'hello', isDirect: true, isMention: false, reply: {},
+      text: text ?? `hello-${messageId}`, isDirect: true, isMention: false, reply: {},
     };
     handler(message);
   };
-  return { bridge, channel, stream, service, send };
+  return { bridge, channel, streams, runtime, send };
 }
 
 afterEach(() => {
@@ -50,74 +65,197 @@ afterEach(() => {
 });
 
 describe('channel startup acknowledgement', () => {
-  it('opens the stream before a slow session selection and keeps the scope busy', async () => {
+  it('opens a stream for every accepted message before single-flight session provisioning', async () => {
     vi.useFakeTimers();
-    const { bridge, channel, stream, service, send } = setup();
-    const events: Array<{ event: string; at: number }> = [];
-    const start = Date.now();
-    vi.mocked(channel.openStream).mockImplementation(async () => {
-      events.push({ event: 'card', at: Date.now() - start });
-      return stream;
-    });
-    vi.spyOn(SessionRouter.prototype, 'ensureSession').mockImplementation(async () => {
-      events.push({ event: 'session-start', at: Date.now() - start });
-      await new Promise((resolve) => setTimeout(resolve, 5_000));
-      events.push({ event: 'session-ready', at: Date.now() - start });
+    const gate = deferred<{ ok: boolean; sessionId: string }>();
+    const { bridge, channel, streams, runtime, send } = setup({
+      provisionSession: vi.fn(async () => gate.promise),
+      hasSession: vi.fn(async () => false),
     });
     await bridge.addChannel(channel);
-    send();
-    await vi.advanceTimersByTimeAsync(0);
-    const earlyCardCount = vi.mocked(channel.openStream).mock.calls.length;
-    expect(service.chatWithScope).not.toHaveBeenCalled();
-    send();
-    await vi.advanceTimersByTimeAsync(0);
-    expect(channel.sendText).toHaveBeenCalledWith(expect.anything(), expect.stringContaining('Still working'));
-    await vi.advanceTimersByTimeAsync(5_000);
-    expect(earlyCardCount).toBe(1);
-    expect(events).toEqual([
-      { event: 'card', at: 0 }, { event: 'session-start', at: 0 }, { event: 'session-ready', at: 5_000 },
-    ]);
-    expect(channel.openStream).toHaveBeenCalledTimes(1);
-    expect(service.chatWithScope).toHaveBeenCalledTimes(1);
-    expect(stream.onDone).toHaveBeenCalledWith('hello');
-    expect(vi.getTimerCount()).toBe(0);
-  });
 
-  it('closes the early card with an error if session selection rejects, without starting chat', async () => {
-    vi.useFakeTimers();
-    const { bridge, channel, stream, service, send } = setup();
-    vi.spyOn(console, 'error').mockImplementation(() => undefined);
-    vi.spyOn(SessionRouter.prototype, 'ensureSession').mockRejectedValueOnce(new Error('session failed'));
-    await bridge.addChannel(channel);
+    send();
     send();
     await vi.advanceTimersByTimeAsync(0);
-    expect(channel.openStream).toHaveBeenCalledTimes(1);
-    expect(stream.onError).toHaveBeenCalledWith('session failed');
-    expect(service.chatWithScope).not.toHaveBeenCalled();
-    // Let the independent 1s dedupe persistence debounce finish.
+
+    expect(channel.openStream).toHaveBeenCalledTimes(2);
+    expect(runtime.provisionSession).toHaveBeenCalledTimes(1);
+    expect(runtime.chat).not.toHaveBeenCalled();
+    expect(channel.sendText).not.toHaveBeenCalled();
+
+    gate.resolve({ ok: true, sessionId: 'session' });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(channel.openStream).toHaveBeenCalledTimes(2);
+    expect(runtime.chat).toHaveBeenCalledTimes(2);
+    expect(streams.every(stream => vi.mocked(stream.onDone).mock.calls.length === 1)).toBe(true);
     await vi.advanceTimersByTimeAsync(1_000);
     expect(vi.getTimerCount()).toBe(0);
-    send();
-    await vi.advanceTimersByTimeAsync(0);
-    expect(service.chatWithScope).toHaveBeenCalledTimes(1);
   });
 
-  it('cleans up the watchdog and skips session selection if opening the stream fails', async () => {
+  it('does not let an immediate command release an earlier pending submission', async () => {
     vi.useFakeTimers();
-    const { bridge, channel, service, send } = setup();
+    const gate = deferred<{ ok: boolean; sessionId: string }>();
+    const { bridge, channel, runtime, send } = setup({
+      provisionSession: vi.fn(async () => gate.promise),
+    });
+    await bridge.addChannel(channel);
+    send('first');
+    send('/help');
+    send('third');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(channel.sendText).toHaveBeenCalled();
+    expect(channel.openStream).toHaveBeenCalledTimes(2);
+    expect(runtime.chat).not.toHaveBeenCalled();
+    gate.resolve({ ok: true, sessionId: 'session' });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(vi.mocked(runtime.chat).mock.calls.map(call => call[2])).toEqual(['first', 'third']);
+  });
+
+  it('rejects route changes during a topic run while keeping stop immediate', async () => {
+    vi.useFakeTimers();
+    const gate = deferred<{ ok: boolean; response: string }>();
+    const { bridge, channel, runtime, send } = setup({ chat: vi.fn(() => gate.promise) });
+    await bridge.addChannel(channel);
+    send('first');
+    await vi.advanceTimersByTimeAsync(0);
+    for (const command of ['/new', '/use elsewhere', '/unbind', '/bind elsewhere', '/session other']) {
+      send(command);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(vi.mocked(channel.sendText).mock.lastCall?.[1]).toContain('Wait for this topic');
+    }
+    expect(runtime.provisionSession).toHaveBeenCalledTimes(1);
+    send('/stop');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(runtime.abort).toHaveBeenCalledWith({ kind: 'global' }, 'session');
+    gate.resolve({ ok: true, response: 'stopped' });
+    await vi.advanceTimersByTimeAsync(0);
+  });
+
+  it('closes every early stream with an error when provisioning fails', async () => {
+    vi.useFakeTimers();
+    const { bridge, channel, streams, runtime, send } = setup({
+      provisionSession: vi.fn(async () => ({ ok: false, error: 'session failed' })),
+      hasSession: vi.fn(async () => false),
+    });
+    await bridge.addChannel(channel);
+
+    send();
+    send();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(channel.openStream).toHaveBeenCalledTimes(2);
+    expect(runtime.chat).not.toHaveBeenCalled();
+    expect(streams.every(stream => vi.mocked(stream.onError).mock.calls[0]?.[0] === 'session failed')).toBe(true);
+  });
+
+  it('does not provision a session when opening the stream fails', async () => {
+    vi.useFakeTimers();
+    const { bridge, channel, runtime, send } = setup();
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
-    const select = vi.spyOn(SessionRouter.prototype, 'ensureSession').mockResolvedValue();
     vi.mocked(channel.openStream).mockRejectedValueOnce(new Error('card failed'));
     await bridge.addChannel(channel);
+
     send();
     await vi.advanceTimersByTimeAsync(0);
-    expect(select).not.toHaveBeenCalled();
-    expect(service.chatWithScope).not.toHaveBeenCalled();
-    // Let the independent 1s dedupe persistence debounce finish.
-    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(runtime.provisionSession).not.toHaveBeenCalled();
+    expect(runtime.chat).not.toHaveBeenCalled();
+  });
+});
+
+
+describe('channel watchdog guards', () => {
+  it.each([
+    { mode: 'idle', duration: 50, error: 'No agent activity' },
+    { mode: 'tool', duration: 200, error: 'tool ran for' },
+    { mode: 'clarification', duration: 150, error: 'No answer to the question' },
+  ])('bounds $mode waits without aborting early', async ({ mode, duration, error }) => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { bridge, channel, runtime, streams, send } = setup({
+      chat: vi.fn((_scope, _sessionId, _message, callbacks: ConversationTurnExternal) => {
+        callbacks.onText?.('');
+        if (mode === 'tool') callbacks.onToolCall?.({ name: 'slow-tool', toolCallId: 't1' });
+        if (mode === 'clarification') callbacks.onClarificationRequest?.({ id: 'q1', question: 'Which?' });
+        return new Promise(() => undefined);
+      }),
+    }, { runIdleTimeoutMs: 50, toolExecTimeoutMs: 200, clarificationTimeoutMs: 150 });
+    await bridge.addChannel(channel);
+    send();
+    await vi.advanceTimersByTimeAsync(duration - 1);
+    expect(runtime.abort).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runtime.abort).toHaveBeenCalledWith({ kind: 'global' }, 'session');
+    expect(streams[0].onError).toHaveBeenCalledWith(expect.stringContaining(error));
+    await vi.advanceTimersByTimeAsync(1_000); // also flush debounced dedupe persistence
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('fails immediately if the clarification cannot be delivered', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { bridge, channel, runtime, streams, send } = setup({
+      chat: vi.fn((_scope, _sessionId, _message, callbacks: ConversationTurnExternal) => {
+        vi.mocked(streams[0].onClarification).mockRejectedValueOnce(new Error('delivery failed'));
+        callbacks.onClarificationRequest?.({ id: 'q1', question: 'Which?' });
+        return new Promise(() => undefined);
+      }),
+    });
+    await bridge.addChannel(channel);
     send();
     await vi.advanceTimersByTimeAsync(0);
-    expect(service.chatWithScope).toHaveBeenCalledTimes(1);
+    expect(runtime.abort).toHaveBeenCalledWith({ kind: 'global' }, 'session');
+    expect(streams[0].onError).toHaveBeenCalledWith(expect.stringContaining("can't be answered"));
+    await vi.advanceTimersByTimeAsync(1_000); // also flush debounced dedupe persistence
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('does not abort a completed model turn while its final card is still sending', async () => {
+    vi.useFakeTimers();
+    const delivery = deferred<void>();
+    const { bridge, channel, runtime, streams, send } = setup({
+      chat: vi.fn(async (_scope, _sessionId, _message, callbacks: ConversationTurnExternal) => {
+        callbacks.onText?.('done');
+        vi.mocked(streams[0].onDone).mockImplementation(() => delivery.promise);
+        return { ok: true, response: 'done' };
+      }),
+    }, { runIdleTimeoutMs: 50 });
+    await bridge.addChannel(channel);
+    send();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(streams[0].onDone).toHaveBeenCalledWith('done');
+    expect(runtime.abort).not.toHaveBeenCalled();
+    delivery.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+  });
+
+  it('forwards streaming tool input and refreshes the idle budget', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    let callbacks!: ConversationTurnExternal;
+    const { bridge, channel, runtime, streams, send } = setup({
+      chat: vi.fn((_scope, _sessionId, _message, external: ConversationTurnExternal) => {
+        callbacks = external;
+        return new Promise(() => undefined);
+      }),
+    }, { runIdleTimeoutMs: 50 });
+    await bridge.addChannel(channel);
+    send();
+    await vi.advanceTimersByTimeAsync(0);
+    streams[0].onToolInputStart = vi.fn();
+    streams[0].onToolInputDelta = vi.fn();
+    streams[0].onToolInputEnd = vi.fn();
+    callbacks.onToolInputStart?.({ id: 't1', toolName: 'bash' });
+    await vi.advanceTimersByTimeAsync(40);
+    callbacks.onToolInputDelta?.({ id: 't1', delta: 'args' });
+    callbacks.onToolInputEnd?.({ id: 't1' });
+    expect(streams[0].onToolInputStart).toHaveBeenCalledWith({ id: 't1', toolName: 'bash' });
+    expect(streams[0].onToolInputDelta).toHaveBeenCalledWith({ id: 't1', delta: 'args' });
+    expect(streams[0].onToolInputEnd).toHaveBeenCalledWith({ id: 't1' });
+    await vi.advanceTimersByTimeAsync(49);
+    expect(runtime.abort).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runtime.abort).toHaveBeenCalledWith({ kind: 'global' }, 'session');
   });
 });

--- a/apps/canvas-workspace/src/plugins/main/channel/__tests__/bridge.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/__tests__/bridge.test.ts
@@ -6,6 +6,8 @@ import type {
   CanvasAgentServiceRef,
   PluginStore,
 } from '../../../types';
+import type { CanvasAgent } from '../../../../main/agent/canvas-agent';
+import { ConversationRuntimeService } from '../../../../main/agent/conversation-runtime/conversation-service';
 import { buildAgentPrompt, ChannelBridge } from '../core/bridge';
 import type {
   Channel,
@@ -24,54 +26,59 @@ vi.mock('../core/workspaces', () => {
   const label = (w: { id: string; name?: string }) => (w.name ? `${w.name} (${w.id})` : w.id);
   return {
     listWorkspaces: vi.fn(async () => workspaces),
-    resolveWorkspace: vi.fn(async (ref: string) => {
-      const byId = workspaces.find((w) => w.id === ref);
-      if (byId) return byId.id;
-      return workspaces.find((w) => w.name.toLowerCase() === ref.toLowerCase())?.id ?? null;
-    }),
-    resolveWorkspaceRef: vi.fn(async (ref: string) => {
-      if (/^#?\d{1,3}$/.test(ref.trim())) {
-        const n = Number(ref.trim().replace('#', ''));
-        if (n >= 1 && n <= workspaces.length) return workspaces[n - 1].id;
-      }
-      const byId = workspaces.find((w) => w.id === ref);
-      if (byId) return byId.id;
-      return workspaces.find((w) => w.name.toLowerCase() === ref.toLowerCase())?.id ?? null;
-    }),
+    resolveWorkspace: vi.fn(async (ref: string) => workspaces.find(w => w.id === ref)?.id ?? null),
+    resolveWorkspaceRef: vi.fn(async (ref: string) => workspaces.find(w => w.id === ref)?.id ?? null),
     workspaceLabel: label,
     workspaceLabelById: vi.fn(async (id: string) => {
-      const found = workspaces.find((w) => w.id === id);
+      const found = workspaces.find(w => w.id === id);
       return found ? label(found) : id;
     }),
   };
 });
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+  let error: unknown;
+  for (let i = 0; i < 30; i += 1) {
+    try {
+      assertion();
+      return;
+    } catch (err) {
+      error = err;
+      await Promise.resolve();
+      await new Promise(resolve => setTimeout(resolve, 0));
+    }
+  }
+  throw error;
+}
+
 function memoryStore(): PluginStore {
   const map = new Map<string, unknown>();
   return {
-    async get<T>(k: string) {
-      return map.get(k) as T | undefined;
-    },
-    async set<T>(k: string, v: T) {
-      map.set(k, v);
-    },
-    async delete(k: string) {
-      map.delete(k);
-    },
-    async list() {
-      return Array.from(map.keys());
-    },
+    async get<T>(key: string) { return map.get(key) as T | undefined; },
+    async set<T>(key: string, value: T) { map.set(key, value); },
+    async delete(key: string) { map.delete(key); },
+    async list() { return Array.from(map.keys()); },
   };
 }
 
 function fakeService(overrides: Partial<CanvasAgentServiceRef> = {}): CanvasAgentServiceRef {
   return {
-    chat: async (): Promise<AgentChatResult> => ({ ok: true, response: 'hi' }),
-    chatWithScope: async (): Promise<AgentChatResult> => ({ ok: true, response: 'hi' }),
+    chat: vi.fn(async (): Promise<AgentChatResult> => ({ ok: true, response: 'legacy' })),
+    chatWithScope: vi.fn(async (): Promise<AgentChatResult> => ({ ok: true, response: 'legacy' })),
     abort: () => {},
     abortScope: () => {},
-    answerClarification: () => true,
-    answerClarificationForScope: () => true,
+    answerClarification: () => false,
+    answerClarificationForScope: () => false,
     getStatus: (): AgentStatusInfo => ({ ok: true, active: false, messageCount: 0 }),
     getStatusForScope: (): AgentStatusInfo => ({ ok: true, active: false, messageCount: 0 }),
     getCurrentSessionId: () => null,
@@ -82,63 +89,91 @@ function fakeService(overrides: Partial<CanvasAgentServiceRef> = {}): CanvasAgen
     loadSessionForScope: async () => ({ ok: true }),
     listSessions: async (): Promise<AgentSessionInfo[]> => [],
     listSessionsForScope: async (): Promise<AgentSessionInfo[]> => [],
-    copySessionToScope: async () => ({ ok: true, sessionId: 'copied-session', messageCount: 0 }),
+    copySessionToScope: async () => ({ ok: true, sessionId: 'legacy-copy', messageCount: 0 }),
     ...overrides,
   };
 }
 
+type AgentPlan = (ctx: {
+  message: string;
+  sessionId: string;
+  signal: AbortSignal;
+  clarify?: (req: { id: string; question: string }) => Promise<string> | void;
+}) => Promise<{ response: string; stopped?: boolean }>;
+
+function makeRuntime(plan: AgentPlan): ConversationRuntimeService {
+  const sessions = new Map<string, unknown[]>();
+  const agent = {
+    chat: vi.fn(async (...args: unknown[]) => {
+      const message = args[0] as string;
+      const onClarification = args[5] as ((req: { id: string; question: string }) => Promise<string> | void) | undefined;
+      const requestContext = args[6] as { expectedConversationSessionId?: string } | undefined;
+      const onRoleTurnStart = args[11] as (() => void) | undefined;
+      const signal = args[13] as AbortSignal;
+      onRoleTurnStart?.();
+      return plan({
+        message,
+        sessionId: requestContext?.expectedConversationSessionId ?? '',
+        signal,
+        clarify: onClarification,
+      });
+    }),
+    stopRelay: vi.fn(() => false),
+  } as unknown as CanvasAgent;
+  const activeSessions = new Set<string>();
+  return new ConversationRuntimeService(
+    () => agent,
+    () => ({
+      loadMessages: async sessionId => sessions.get(sessionId) as never ?? null,
+      persist: async (sessionId, messages) => { sessions.set(sessionId, [...messages]); },
+    }),
+    async (_scope, sessionId, operation) => {
+      if (activeSessions.has(sessionId)) return null;
+      activeSessions.add(sessionId);
+      try {
+        return await operation();
+      } finally {
+        activeSessions.delete(sessionId);
+      }
+    },
+  );
+}
+
+let messageCounter = 0;
 function msg(text: string, overrides: Partial<InboundMessage> = {}): InboundMessage {
+  messageCounter += 1;
   return {
     channelId: 'feishu',
     conversationId: 'chatA',
     userId: 'u1',
-    messageId: `m-${Math.random()}`,
+    messageId: `m-${messageCounter}`,
     text,
     isMention: false,
     isDirect: true,
-    reply: { chatId: 'chatA', isGroup: false, triggerMessageId: 'm1' },
+    reply: { chatId: 'chatA', isGroup: false, triggerMessageId: `m-${messageCounter}` },
     ...overrides,
   };
-}
-
-async function flushInbound(): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 class FakeChannel implements Channel {
   readonly id = 'feishu';
   handler: InboundHandler | null = null;
-  events: string[] = [];
   sentText: Array<{ target: OutboundTarget; text: string }> = [];
   pickers: Array<{ target: OutboundTarget; picker: WorkspacePicker }> = [];
   streams: FakeStream[] = [];
-  /** When set, a stream's onClarification rejects (simulates an undeliverable question). */
-  failClarification = false;
 
-  isConfigured(): boolean {
-    return true;
-  }
-
-  async start(onInbound: InboundHandler): Promise<void> {
-    this.handler = onInbound;
-  }
-
-  async stop(): Promise<void> {
-    this.handler = null;
-  }
-
-  async openStream(): Promise<ChannelStream> {
-    const stream = new FakeStream(this.events, this.failClarification);
+  isConfigured(): boolean { return true; }
+  async start(onInbound: InboundHandler): Promise<void> { this.handler = onInbound; }
+  async stop(): Promise<void> { this.handler = null; }
+  async openStream(target: OutboundTarget): Promise<ChannelStream> {
+    const stream = new FakeStream(target.conversationId, (target.reply as { triggerMessageId?: string } | null)?.triggerMessageId);
     this.streams.push(stream);
     return stream;
   }
-
   async sendText(target: OutboundTarget, text: string): Promise<void> {
     this.sentText.push({ target, text });
   }
-
   async sendWorkspacePicker(target: OutboundTarget, picker: WorkspacePicker): Promise<void> {
-    this.events.push('picker');
     this.pickers.push({ target, picker });
   }
 }
@@ -147,397 +182,181 @@ class FakeStream implements ChannelStream {
   done: string | null = null;
   errors: string[] = [];
   text = '';
-  toolInputs: string[] = [];
-  toolCalls: Array<{ name: string; args: unknown; toolCallId?: string }> = [];
-  toolResults: Array<{ name: string; result: string; toolCallId?: string }> = [];
-
-  constructor(
-    private readonly events: string[],
-    private readonly failClarification = false,
-  ) {}
-
-  onText(delta: string): void {
-    this.text += delta;
-  }
-
-  onToolCall(name: string, args: unknown, toolCallId?: string): void {
-    this.toolCalls.push({ name, args, toolCallId });
-  }
-
-  onToolResult(result: { name: string; result: string; toolCallId?: string }): void {
-    this.toolResults.push(result);
-  }
-
-  onToolInputStart(data: { id: string; toolName: string }): void {
-    this.toolInputs.push(`start:${data.id}:${data.toolName}`);
-  }
-
-  onToolInputDelta(data: { id: string; delta: string }): void {
-    this.toolInputs.push(`delta:${data.id}:${data.delta}`);
-  }
-
-  onToolInputEnd(data: { id: string }): void {
-    this.toolInputs.push(`end:${data.id}`);
-  }
-
-  async onClarification(): Promise<void> {
-    if (this.failClarification) throw new Error('clarification send failed');
-  }
-
-  onDone(text: string): void {
-    this.events.push('done');
-    this.done = text;
-  }
-
-  onError(message: string): void {
-    this.errors.push(message);
-  }
+  clarification: string | null = null;
+  constructor(readonly conversationId: string, readonly triggerMessageId?: string) {}
+  onText(delta: string): void { this.text += delta; }
+  onToolCall(): void {}
+  onClarification(question: string): void { this.clarification = question; }
+  onDone(text: string): void { this.done = text; }
+  onError(message: string): void { this.errors.push(message); }
 }
 
-describe('ChannelBridge', () => {
+describe('ChannelBridge conversation isolation', () => {
   let channel: FakeChannel;
 
   beforeEach(() => {
+    messageCounter = 0;
     channel = new FakeChannel();
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
-  it('auto-binds an unbound group message to the active workspace and shows the picker', async () => {
-    const service = fakeService({
-      chatWithScope: vi.fn(async () => ({ ok: true, response: 'workspace reply' })),
-      newSessionForScope: vi.fn(async () => ({ ok: true })),
-      getCurrentSessionIdForScope: vi.fn(() => 'workspace-session'),
+  it('runs simultaneous first messages from two topics in one workspace independently', async () => {
+    const started: Array<{ message: string; sessionId: string }> = [];
+    const bothStarted = deferred<void>();
+    const runtime = makeRuntime(async ({ message, sessionId }) => {
+      started.push({ message, sessionId });
+      if (started.length === 2) bothStarted.resolve();
+      await bothStarted.promise;
+      return { response: `reply:${message}` };
     });
-    const bridge = new ChannelBridge(service, memoryStore());
+    const service = fakeService();
+    const bridge = new ChannelBridge(service, runtime, memoryStore());
     await bridge.addChannel(channel);
 
-    channel.handler!(
-      msg('你在吗', {
-        conversationId: 'groupA:threadA',
-        isDirect: false,
-        isMention: true,
-        reply: { chatId: 'groupA', threadId: 'threadA', isGroup: true, triggerMessageId: 'm1' },
-      }),
-    );
-    await flushInbound();
+    channel.handler!(msg('topic-a', {
+      conversationId: 'group:thread-a',
+      isDirect: false,
+      reply: { chatId: 'group', threadId: 'thread-a', isGroup: true, triggerMessageId: 'a' },
+    }));
+    channel.handler!(msg('topic-b', {
+      conversationId: 'group:thread-b',
+      isDirect: false,
+      reply: { chatId: 'group', threadId: 'thread-b', isGroup: true, triggerMessageId: 'b' },
+    }));
 
-    expect(service.chatWithScope).toHaveBeenCalledWith(
-      { kind: 'workspace', workspaceId: 'ws-A' },
-      '你在吗',
-      expect.any(Function),
-      expect.any(Function),
-      expect.any(Function),
-      undefined,
-      expect.any(Function),
-      undefined,
-      undefined,
-      expect.any(Function),
-      expect.any(Function),
-      expect.any(Function),
-    );
-    expect(channel.pickers).toHaveLength(1);
-    expect(channel.pickers[0].target.conversationId).toBe('groupA:threadA');
-    expect(channel.pickers[0].picker.defaultCarry).toBe(true);
-    expect(channel.pickers[0].picker.summary).toContain('Alpha (ws-A)');
-    expect(channel.pickers[0].picker.fallbackText).toContain('Alpha (ws-A)');
-    expect(channel.streams[0].done).toBe('workspace reply');
-    expect(channel.events).toEqual(['done', 'picker']);
+    await waitFor(() => expect(started).toHaveLength(2));
+    expect(new Set(started.map(entry => entry.sessionId)).size).toBe(2);
+    await waitFor(() => expect(channel.streams.every(stream => stream.done)).toBe(true));
+    expect(service.chatWithScope).not.toHaveBeenCalled();
+    expect(channel.sentText.some(entry => entry.text.includes('Still working'))).toBe(false);
   });
 
-  it('still lets an unbound direct chat use the global agent', async () => {
-    const service = fakeService({
-      chatWithScope: vi.fn(async () => ({ ok: true, response: 'global reply' })),
-      newSessionForScope: vi.fn(async () => ({ ok: true })),
-      getCurrentSessionIdForScope: vi.fn(() => 'global-session'),
+  it('queues same-topic messages FIFO without dropping them', async () => {
+    const first = deferred<void>();
+    const starts: string[] = [];
+    const runtime = makeRuntime(async ({ message }) => {
+      starts.push(message);
+      if (message === 'first') await first.promise;
+      return { response: `done:${message}` };
     });
-    const bridge = new ChannelBridge(service, memoryStore());
+    const bridge = new ChannelBridge(fakeService(), runtime, memoryStore());
     await bridge.addChannel(channel);
 
-    channel.handler!(msg('你好'));
-    await flushInbound();
+    channel.handler!(msg('first'));
+    channel.handler!(msg('second'));
+    await waitFor(() => expect(starts).toEqual(['first']));
+    expect(channel.sentText).toHaveLength(0);
 
-    expect(service.chatWithScope).toHaveBeenCalledWith(
-      { kind: 'global' },
-      '你好',
-      expect.any(Function),
-      expect.any(Function),
-      expect.any(Function),
-      undefined,
-      expect.any(Function),
-      undefined,
-      undefined,
-      expect.any(Function),
-      expect.any(Function),
-      expect.any(Function),
-    );
-    expect(channel.pickers).toHaveLength(0);
-    expect(channel.streams[0].done).toBe('global reply');
+    first.resolve();
+    await waitFor(() => expect(starts).toEqual(['first', 'second']));
+    await waitFor(() => expect(['m-1', 'm-2'].map(id => channel.streams.find(stream => stream.triggerMessageId === id)?.done)).toEqual([
+      'done:first',
+      'done:second',
+    ]));
   });
 
-  it('aborts and releases a run when the agent produces no activity', async () => {
-    vi.useFakeTimers();
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const hangingRun = new Promise<AgentChatResult>(() => undefined);
-    const chatWithScope = vi.fn(async () => {
-      if (chatWithScope.mock.calls.length > 1) {
-        return { ok: true, response: 'second reply' };
+  it('resolves the next message scope after an earlier workspace switch commits', async () => {
+    const runtime = makeRuntime(async () => ({ response: 'done' }));
+    const chat = vi.spyOn(runtime, 'chat');
+    const bridge = new ChannelBridge(fakeService(), runtime, memoryStore());
+    await bridge.addChannel(channel);
+    channel.handler!(msg('/use ws-B --fresh'));
+    channel.handler!(msg('after-switch'));
+    await waitFor(() => expect(chat).toHaveBeenCalledTimes(1));
+    expect(chat.mock.calls[0][0]).toEqual({ kind: 'workspace', workspaceId: 'ws-B' });
+    await waitFor(() => expect(channel.streams[0]?.done).toBe('done'));
+  });
+
+  it('routes clarification answers only to the requesting topic', async () => {
+    const starts: string[] = [];
+    const runtime = makeRuntime(async ({ message, clarify }) => {
+      starts.push(message);
+      if (message === 'ask') {
+        const answer = await clarify?.({ id: 'q-a', question: 'which one?' });
+        return { response: `answer:${answer}` };
       }
-      return hangingRun;
+      return { response: `reply:${message}` };
     });
-    const abortScope = vi.fn();
-    const service = fakeService({
-      chatWithScope,
-      abortScope,
-      newSessionForScope: vi.fn(async () => ({ ok: true })),
-      getCurrentSessionIdForScope: vi.fn(() => 'global-session'),
-    });
-    const bridge = new ChannelBridge(service, memoryStore(), { runIdleTimeoutMs: 50 });
+    const bridge = new ChannelBridge(fakeService(), runtime, memoryStore());
     await bridge.addChannel(channel);
 
-    try {
-      channel.handler!(msg('first'));
-      await vi.advanceTimersByTimeAsync(50);
+    channel.handler!(msg('ask', { conversationId: 'topic-a' }));
+    await waitFor(() => expect(channel.streams[0]?.clarification).toBe('which one?'));
+    channel.handler!(msg('not-the-answer', { conversationId: 'topic-b' }));
+    await waitFor(() => expect(starts).toContain('not-the-answer'));
+    expect(channel.streams[0].done).toBeNull();
 
-      expect(abortScope).toHaveBeenCalledWith({ kind: 'global' });
-      expect(channel.streams[0].errors[0]).toContain('No agent activity');
-
-      channel.handler!(msg('second', { messageId: 'second' }));
-      await vi.advanceTimersByTimeAsync(0);
-      await Promise.resolve();
-
-      expect(chatWithScope).toHaveBeenCalledTimes(2);
-      expect(channel.streams[1].done).toBe('second reply');
-    } finally {
-      warnSpy.mockRestore();
-    }
+    channel.handler!(msg('chosen', { conversationId: 'topic-a' }));
+    await waitFor(() => expect(channel.streams[0].done).toBe('answer:chosen'));
+    expect(starts).toEqual(['ask', 'not-the-answer']);
   });
 
-  it('forwards tool input events and treats them as agent activity', async () => {
+  it('times out only the targeted topic while another topic continues', async () => {
     vi.useFakeTimers();
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    let onToolInputDelta: ((data: { id: string; delta: string }) => void) | undefined;
-    const chatWithScope = vi.fn(
-      async (
-        _scope,
-        _message,
-        _onText,
-        onToolCall,
-        onToolResult,
-        _mentioned,
-        _onClarification,
-        _requestContext,
-        _attachments,
-        onToolInputStart,
-        onToolInputDeltaArg,
-        onToolInputEnd,
-      ): Promise<AgentChatResult> => {
-        onToolInputDelta = onToolInputDeltaArg;
-        onToolInputStart?.({ id: 'tool-1', toolName: 'visual_render' });
-        onToolInputDeltaArg?.({ id: 'tool-1', delta: 'abc' });
-        onToolInputEnd?.({ id: 'tool-1' });
-        onToolCall?.({ name: 'visual_render', args: { title: 'Demo' }, toolCallId: 'tool-1' });
-        onToolResult?.({ name: 'visual_render', result: 'ok', toolCallId: 'tool-1' });
-        return new Promise<AgentChatResult>(() => undefined);
-      },
-    );
-    const abortScope = vi.fn();
-    const service = fakeService({
-      chatWithScope,
-      abortScope,
-      newSessionForScope: vi.fn(async () => ({ ok: true })),
-      getCurrentSessionIdForScope: vi.fn(() => 'global-session'),
+    const signals = new Map<string, AbortSignal>();
+    const runtime = makeRuntime(async ({ message, signal }) => {
+      signals.set(message, signal);
+      if (message === 'slow-a') {
+        await new Promise<void>(resolve => signal.addEventListener('abort', () => resolve(), { once: true }));
+        return { response: '', stopped: true };
+      }
+      await new Promise(resolve => setTimeout(resolve, 40));
+      return { response: 'topic-b-done' };
     });
-    const bridge = new ChannelBridge(service, memoryStore(), { runIdleTimeoutMs: 50 });
+    const bridge = new ChannelBridge(fakeService(), runtime, memoryStore(), { runIdleTimeoutMs: 50 });
     await bridge.addChannel(channel);
 
-    try {
-      channel.handler!(msg('first'));
-      await vi.advanceTimersByTimeAsync(0);
-      await Promise.resolve();
+    channel.handler!(msg('slow-a', { conversationId: 'topic-a' }));
+    channel.handler!(msg('slow-b', { conversationId: 'topic-b' }));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(signals.size).toBe(2);
 
-      expect(channel.streams[0].toolInputs).toEqual([
-        'start:tool-1:visual_render',
-        'delta:tool-1:abc',
-        'end:tool-1',
-      ]);
-      expect(channel.streams[0].toolCalls[0]).toEqual({
-        name: 'visual_render',
-        args: { title: 'Demo' },
-        toolCallId: 'tool-1',
-      });
-      expect(channel.streams[0].toolResults[0]).toEqual({
-        name: 'visual_render',
-        result: 'ok',
-        toolCallId: 'tool-1',
-      });
-
-      await vi.advanceTimersByTimeAsync(40);
-      onToolInputDelta?.({ id: 'tool-1', delta: 'still-running' });
-      await vi.advanceTimersByTimeAsync(49);
-      expect(abortScope).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(1);
-      expect(abortScope).toHaveBeenCalledWith({ kind: 'global' });
-    } finally {
-      warnSpy.mockRestore();
-    }
+    await vi.advanceTimersByTimeAsync(50);
+    expect(signals.get('slow-a')?.aborted).toBe(true);
+    expect(signals.get('slow-b')?.aborted).toBe(false);
+    expect(channel.streams.find(stream => stream.conversationId === 'topic-b')?.done).toBe(
+      'topic-b-done',
+    );
   });
 
-  it('does not kill a run while a tool is executing past the idle budget', async () => {
-    vi.useFakeTimers();
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    // A tool whose execute() blocks: onToolCall fires (args complete) but no
-    // onToolResult — exactly the "single slow tool" case the idle watchdog used
-    // to kill mid-run.
-    const chatWithScope = vi.fn(
-      async (_scope, _message, _onText, onToolCall): Promise<AgentChatResult> => {
-        onToolCall?.({ name: 'page_wait_for', args: { nodeId: 'n1' }, toolCallId: 'tool-1' });
-        return new Promise<AgentChatResult>(() => undefined);
-      },
-    );
-    const abortScope = vi.fn();
-    const service = fakeService({
-      chatWithScope,
-      abortScope,
-      newSessionForScope: vi.fn(async () => ({ ok: true })),
-      getCurrentSessionIdForScope: vi.fn(() => 'global-session'),
+  it('continues the same-topic queue after a failed turn', async () => {
+    const starts: string[] = [];
+    const runtime = makeRuntime(async ({ message }) => {
+      starts.push(message);
+      if (message === 'fails') throw new Error('boom');
+      return { response: 'recovered' };
     });
-    const bridge = new ChannelBridge(service, memoryStore(), {
-      runIdleTimeoutMs: 50,
-      toolExecTimeoutMs: 200,
-    });
+    const bridge = new ChannelBridge(fakeService(), runtime, memoryStore());
     await bridge.addChannel(channel);
 
-    try {
-      channel.handler!(msg('first'));
-      await vi.advanceTimersByTimeAsync(0);
-      await Promise.resolve();
+    channel.handler!(msg('fails'));
+    channel.handler!(msg('next'));
 
-      // Well past the idle budget, but the tool is still in flight — survive.
-      await vi.advanceTimersByTimeAsync(199);
-      expect(abortScope).not.toHaveBeenCalled();
-
-      // Once the tool-exec ceiling elapses, recover the scope.
-      await vi.advanceTimersByTimeAsync(1);
-      expect(abortScope).toHaveBeenCalledWith({ kind: 'global' });
-      expect(channel.streams[0].errors[0]).toContain('tool ran for');
-    } finally {
-      warnSpy.mockRestore();
-    }
-  });
-
-  it('fails the run when a clarification question cannot be delivered', async () => {
-    vi.useFakeTimers();
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    channel.failClarification = true;
-    const chatWithScope = vi.fn(
-      async (_scope, _message, _onText, _onToolCall, _onToolResult, _mentioned, onClarification): Promise<AgentChatResult> => {
-        onClarification?.({ id: 'q1', question: 'which one?' });
-        return new Promise<AgentChatResult>(() => undefined);
-      },
-    );
-    const abortScope = vi.fn();
-    const service = fakeService({
-      chatWithScope,
-      abortScope,
-      newSessionForScope: vi.fn(async () => ({ ok: true })),
-      getCurrentSessionIdForScope: vi.fn(() => 'global-session'),
-    });
-    const bridge = new ChannelBridge(service, memoryStore(), {
-      runIdleTimeoutMs: 50,
-      clarificationTimeoutMs: 10_000,
-    });
-    await bridge.addChannel(channel);
-
-    try {
-      channel.handler!(msg('first'));
-      // Undeliverable question fails fast — no need to wait out any budget.
-      await vi.advanceTimersByTimeAsync(1);
-      await Promise.resolve();
-
-      expect(abortScope).toHaveBeenCalledWith({ kind: 'global' });
-      expect(channel.streams[0].errors[0]).toContain("can't be answered");
-    } finally {
-      warnSpy.mockRestore();
-      errSpy.mockRestore();
-    }
-  });
-
-  it('stops a run when a clarification goes unanswered past the budget', async () => {
-    vi.useFakeTimers();
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const chatWithScope = vi.fn(
-      async (_scope, _message, _onText, _onToolCall, _onToolResult, _mentioned, onClarification): Promise<AgentChatResult> => {
-        onClarification?.({ id: 'q1', question: 'which one?' });
-        return new Promise<AgentChatResult>(() => undefined);
-      },
-    );
-    const abortScope = vi.fn();
-    const service = fakeService({
-      chatWithScope,
-      abortScope,
-      newSessionForScope: vi.fn(async () => ({ ok: true })),
-      getCurrentSessionIdForScope: vi.fn(() => 'global-session'),
-    });
-    const bridge = new ChannelBridge(service, memoryStore(), {
-      runIdleTimeoutMs: 50,
-      clarificationTimeoutMs: 200,
-    });
-    await bridge.addChannel(channel);
-
-    try {
-      channel.handler!(msg('first'));
-      await vi.advanceTimersByTimeAsync(0);
-      await Promise.resolve();
-
-      // Parked awaiting an answer — must survive well past the idle budget.
-      await vi.advanceTimersByTimeAsync(199);
-      expect(abortScope).not.toHaveBeenCalled();
-
-      // Once the clarification budget elapses, recover the scope.
-      await vi.advanceTimersByTimeAsync(1);
-      expect(abortScope).toHaveBeenCalledWith({ kind: 'global' });
-      expect(channel.streams[0].errors[0]).toContain('No answer to the question');
-    } finally {
-      warnSpy.mockRestore();
-    }
+    await waitFor(() => expect(starts).toEqual(['fails', 'next']));
+    await waitFor(() => expect(channel.streams.find(stream => stream.triggerMessageId === 'm-1')?.errors[0]).toContain('boom'));
+    expect(channel.streams.find(stream => stream.triggerMessageId === 'm-2')?.done).toBe('recovered');
   });
 });
 
 describe('buildAgentPrompt', () => {
   const withImages = (text: string, imagePaths?: string[]): InboundMessage => ({
-    channelId: 'feishu',
-    conversationId: 'c1',
-    userId: 'u1',
-    messageId: 'm1',
-    text,
-    isMention: false,
-    isDirect: true,
-    reply: {},
-    imagePaths,
+    channelId: 'feishu', conversationId: 'c1', userId: 'u1', messageId: 'm1',
+    text, isMention: false, isDirect: true, reply: {}, imagePaths,
   });
 
-  it('returns the plain text when there are no images', () => {
+  it('returns plain text without images', () => {
     expect(buildAgentPrompt(withImages('hello'))).toBe('hello');
-    expect(buildAgentPrompt(withImages('hello', []))).toBe('hello');
   });
 
-  it('appends an image note with the local paths and tool hint', () => {
+  it('appends local image paths and the image tool hint', () => {
     const prompt = buildAgentPrompt(withImages('what is this?', ['/tmp/a.png', '/tmp/b.jpg']));
     expect(prompt).toContain('what is this?');
     expect(prompt).toContain('image_analyze');
     expect(prompt).toContain('/tmp/a.png');
     expect(prompt).toContain('/tmp/b.jpg');
-    expect(prompt).toContain('2 image(s)');
-  });
-
-  it('uses only the note for an image-only message', () => {
-    const prompt = buildAgentPrompt(withImages('', ['/tmp/a.png']));
-    expect(prompt.startsWith('[The user attached 1 image(s)')).toBe(true);
-    expect(prompt).toContain('/tmp/a.png');
   });
 });

--- a/apps/canvas-workspace/src/plugins/main/channel/__tests__/commands.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/__tests__/commands.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   AgentScope,
   AgentChatResult,
@@ -7,9 +7,9 @@ import type {
   CanvasAgentServiceRef,
   PluginStore,
 } from '../../../types';
+import type { ConversationRuntimeService } from '../../../../main/agent/conversation-runtime/conversation-service';
 import type { CommandReply, InboundMessage } from '../core/types';
 
-// Mock the disk-backed workspace helpers so command tests stay hermetic.
 vi.mock('../core/workspaces', () => {
   const list = [
     { id: 'ws-A', name: 'Alpha', modifiedAt: 2, isActive: false },
@@ -17,24 +17,16 @@ vi.mock('../core/workspaces', () => {
   ];
   const label = (w: { id: string; name?: string }) => (w.name ? `${w.name} (${w.id})` : w.id);
   const resolve = (ref: string) => {
-    const byId = list.find((w) => w.id === ref);
-    if (byId) return byId.id;
-    const byName = list.find((w) => w.name.toLowerCase() === ref.toLowerCase());
-    return byName?.id ?? null;
+    if (/^#?\d{1,3}$/.test(ref.trim())) return list[Number(ref.replace('#', '')) - 1]?.id ?? null;
+    return list.find(w => w.id === ref || w.name.toLowerCase() === ref.toLowerCase())?.id ?? null;
   };
   return {
     listWorkspaces: vi.fn(async () => list),
     resolveWorkspace: vi.fn(async (ref: string) => resolve(ref)),
-    resolveWorkspaceRef: vi.fn(async (ref: string) => {
-      if (/^#?\d{1,3}$/.test(ref.trim())) {
-        const n = Number(ref.trim().replace('#', ''));
-        if (n >= 1 && n <= list.length) return list[n - 1].id;
-      }
-      return resolve(ref);
-    }),
+    resolveWorkspaceRef: vi.fn(async (ref: string) => resolve(ref)),
     workspaceLabel: label,
     workspaceLabelById: vi.fn(async (id: string) => {
-      const found = list.find((w) => w.id === id);
+      const found = list.find(w => w.id === id);
       return found ? label(found) : id;
     }),
   };
@@ -47,83 +39,237 @@ import { SessionRouter } from '../core/sessions';
 function memoryStore(): PluginStore {
   const map = new Map<string, unknown>();
   return {
-    async get<T>(k: string) {
-      return map.get(k) as T | undefined;
-    },
-    async set<T>(k: string, v: T) {
-      map.set(k, v);
-    },
-    async delete(k: string) {
-      map.delete(k);
-    },
-    async list() {
-      return Array.from(map.keys());
-    },
+    async get<T>(key: string) { return map.get(key) as T | undefined; },
+    async set<T>(key: string, value: T) { map.set(key, value); },
+    async delete(key: string) { map.delete(key); },
+    async list() { return Array.from(map.keys()); },
   };
 }
 
 function fakeService(overrides: Partial<CanvasAgentServiceRef> = {}): CanvasAgentServiceRef {
   return {
-    chat: async (): Promise<AgentChatResult> => ({ ok: true, response: 'hi' }),
-    chatWithScope: async (): Promise<AgentChatResult> => ({ ok: true, response: 'hi' }),
+    chat: async (): Promise<AgentChatResult> => ({ ok: true }),
+    chatWithScope: async (): Promise<AgentChatResult> => ({ ok: true }),
     abort: () => {},
     abortScope: () => {},
-    answerClarification: () => true,
-    answerClarificationForScope: () => true,
+    answerClarification: () => false,
+    answerClarificationForScope: () => false,
     getStatus: (): AgentStatusInfo => ({ ok: true, active: false, messageCount: 0 }),
     getStatusForScope: (): AgentStatusInfo => ({ ok: true, active: false, messageCount: 0 }),
-    getCurrentSessionId: () => null,
-    getCurrentSessionIdForScope: () => null,
+    getCurrentSessionId: () => 'ui-current',
+    getCurrentSessionIdForScope: () => 'ui-current',
     newSession: async () => ({ ok: true }),
     newSessionForScope: async () => ({ ok: true }),
     loadSession: async () => ({ ok: true }),
     loadSessionForScope: async () => ({ ok: true }),
     listSessions: async (): Promise<AgentSessionInfo[]> => [],
     listSessionsForScope: async (): Promise<AgentSessionInfo[]> => [],
-    copySessionToScope: async () => ({ ok: true, sessionId: 'copied-session', messageCount: 0 }),
+    copySessionToScope: async () => ({ ok: true, sessionId: 'legacy-copy', messageCount: 0 }),
     ...overrides,
   };
+}
+
+function fakeRuntime(overrides: Partial<{
+  provisionSession: ConversationRuntimeService['provisionSession'];
+  copySessionToScope: ConversationRuntimeService['copySessionToScope'];
+  abort: ConversationRuntimeService['abort'];
+}> = {}): ConversationRuntimeService {
+  let counter = 0;
+  return {
+    provisionSession: vi.fn(async () => ({ ok: true, sessionId: `fresh-${++counter}` })),
+    hasSession: vi.fn(async () => true),
+    copySessionToScope: vi.fn(async () => ({
+      ok: true,
+      sessionId: `copied-${++counter}`,
+      messageCount: 4,
+    })),
+    abort: vi.fn(() => true),
+    ...overrides,
+  } as unknown as ConversationRuntimeService;
 }
 
 function msg(text: string, overrides: Partial<InboundMessage> = {}): InboundMessage {
   return {
-    channelId: 'feishu',
-    conversationId: 'chatA',
-    userId: 'u1',
-    messageId: 'm1',
-    text,
-    isMention: false,
-    isDirect: true,
-    reply: null,
-    ...overrides,
+    channelId: 'feishu', conversationId: 'chatA', userId: 'u1', messageId: 'm1',
+    text, isMention: false, isDirect: true, reply: null, ...overrides,
   };
 }
 
-function text(out: CommandReply | null): string {
-  expect(out?.kind).toBe('text');
-  return out && out.kind === 'text' ? out.text : '';
+function text(reply: CommandReply | null): string {
+  expect(reply?.kind).toBe('text');
+  return reply?.kind === 'text' ? reply.text : '';
 }
 
-function picker(out: CommandReply | null) {
-  expect(out?.kind).toBe('workspace_picker');
-  return out && out.kind === 'workspace_picker' ? out.picker : null;
+function picker(reply: CommandReply | null) {
+  expect(reply?.kind).toBe('workspace_picker');
+  return reply?.kind === 'workspace_picker' ? reply.picker : null;
 }
 
-describe('handleCommand', () => {
+describe('handleCommand explicit conversation sessions', () => {
   let bindings: BindingStore;
+
   beforeEach(() => {
     bindings = new BindingStore(memoryStore());
   });
 
-  const makeDeps = (service: CanvasAgentServiceRef = fakeService()) => ({
+  const makeDeps = (
+    service: CanvasAgentServiceRef = fakeService(),
+    runtime: ConversationRuntimeService = fakeRuntime(),
+  ) => ({
     bindings,
     service,
-    sessionRouter: new SessionRouter(service, memoryStore()),
+    runtime,
+    sessionRouter: new SessionRouter(runtime, memoryStore()),
   });
 
-  it('returns null for ordinary (non-slash) messages', async () => {
-    const out = await handleCommand(msg('hello there'), makeDeps());
-    expect(out).toBeNull();
+  it('returns null for an ordinary message', async () => {
+    expect(await handleCommand(msg('hello'), makeDeps())).toBeNull();
+  });
+
+  it('/new provisions a pointer-neutral session and never calls legacy pointer APIs', async () => {
+    await bindings.bind('feishu', 'chatA', 'ws-A');
+    const service = fakeService({
+      newSessionForScope: vi.fn(async () => ({ ok: true })),
+      getCurrentSessionIdForScope: vi.fn(() => 'ui-current'),
+    });
+    const runtime = fakeRuntime();
+    const deps = makeDeps(service, runtime);
+
+    const out = await handleCommand(msg('/new'), deps);
+
+    expect(runtime.provisionSession).toHaveBeenCalledWith({ kind: 'workspace', workspaceId: 'ws-A' });
+    expect(service.newSessionForScope).not.toHaveBeenCalled();
+    expect(service.getCurrentSessionIdForScope).not.toHaveBeenCalled();
+    expect(await deps.sessionRouter.getConversationSessionId(
+      { kind: 'workspace', workspaceId: 'ws-A' }, 'feishu', 'chatA',
+    )).toBe('fresh-1');
+    expect(text(out)).toMatch(/new session/i);
+  });
+
+  it('/use --fresh keeps the previous workspace when provisioning fails', async () => {
+    await bindings.bind('feishu', 'chatA', 'ws-A');
+    const runtime = fakeRuntime({ provisionSession: async () => ({ ok: false, error: 'disk full' }) });
+    const out = await handleCommand(msg('/use ws-B --fresh'), makeDeps(fakeService(), runtime));
+    expect(text(out)).toContain('disk full');
+    expect(text(out)).not.toContain('✅');
+    expect(await bindings.getBound('feishu', 'chatA')).toBe('ws-A');
+  });
+
+  it('/new reports provisioning failure without mapping the UI current session', async () => {
+    const runtime = fakeRuntime({
+      provisionSession: vi.fn(async () => ({ ok: false, error: 'disk failed' })),
+    });
+    const deps = makeDeps(fakeService(), runtime);
+
+    const out = await handleCommand(msg('/new'), deps);
+
+    expect(text(out)).toContain('disk failed');
+    expect(await deps.sessionRouter.getConversationSessionId(
+      { kind: 'global' }, 'feishu', 'chatA',
+    )).toBeUndefined();
+  });
+
+  it('/stop aborts only this topic active session', async () => {
+    await bindings.bind('feishu', 'chatA', 'ws-A');
+    const runtime = fakeRuntime();
+    const deps = { ...makeDeps(fakeService(), runtime), activeSessionId: 'active-topic-session' };
+
+    await handleCommand(msg('/stop'), deps);
+
+    expect(runtime.abort).toHaveBeenCalledWith(
+      { kind: 'workspace', workspaceId: 'ws-A' },
+      'active-topic-session',
+    );
+  });
+
+  it('/session changes only the conversation mapping and never the UI pointer', async () => {
+    await bindings.bind('feishu', 'chatA', 'ws-A');
+    const loadSessionForScope = vi.fn(async () => ({ ok: true }));
+    const service = fakeService({
+      loadSessionForScope,
+      listSessionsForScope: vi.fn(async () => [
+        { sessionId: 's-current', date: '2026-06-01', messageCount: 4, isCurrent: true },
+        { sessionId: 's-old', date: '2026-05-30', messageCount: 9, isCurrent: false },
+      ]),
+    });
+    const deps = makeDeps(service);
+
+    const out = await handleCommand(msg('/session 2'), deps);
+
+    expect(loadSessionForScope).not.toHaveBeenCalled();
+    expect(await deps.sessionRouter.getConversationSessionId(
+      { kind: 'workspace', workspaceId: 'ws-A' }, 'feishu', 'chatA',
+    )).toBe('s-old');
+    expect(text(out)).toMatch(/Switched to session/i);
+  });
+
+  it('/bind carries the previous global topic through pointer-neutral runtime copy', async () => {
+    const runtime = fakeRuntime();
+    const deps = makeDeps(fakeService(), runtime);
+    await deps.sessionRouter.setConversationSession(
+      { kind: 'global' }, 'feishu', 'chatA', 'global-session',
+    );
+
+    const out = await handleCommand(msg('/bind Alpha'), deps);
+
+    expect(runtime.copySessionToScope).toHaveBeenCalledWith(
+      { kind: 'global' },
+      'global-session',
+      { kind: 'workspace', workspaceId: 'ws-A' },
+    );
+    expect(await bindings.getBound('feishu', 'chatA')).toBe('ws-A');
+    expect(await deps.sessionRouter.getConversationSessionId(
+      { kind: 'workspace', workspaceId: 'ws-A' }, 'feishu', 'chatA',
+    )).toBe('copied-1');
+    expect(text(out)).toContain('Migrated 4 previous messages');
+  });
+
+  it('/use --fresh provisions a new target session without carrying context', async () => {
+    const runtime = fakeRuntime();
+    const deps = makeDeps(fakeService(), runtime);
+    await deps.sessionRouter.setConversationSession(
+      { kind: 'global' }, 'feishu', 'chatA', 'global-session',
+    );
+
+    const out = await handleCommand(msg('/use Alpha --fresh'), deps);
+
+    expect(runtime.copySessionToScope).not.toHaveBeenCalled();
+    expect(runtime.provisionSession).toHaveBeenCalledWith(
+      { kind: 'workspace', workspaceId: 'ws-A' },
+    );
+    expect(await deps.sessionRouter.getConversationSessionId(
+      { kind: 'workspace', workspaceId: 'ws-A' }, 'feishu', 'chatA',
+    )).toBe('fresh-1');
+    expect(text(out)).toContain('Started a fresh session');
+  });
+
+  it('/use --carry copies direct-chat context explicitly', async () => {
+    const runtime = fakeRuntime();
+    const deps = makeDeps(fakeService(), runtime);
+    await deps.sessionRouter.setConversationSession(
+      { kind: 'global' }, 'feishu', 'chatA', 'global-session',
+    );
+
+    const out = await handleCommand(msg('/use Alpha --carry'), deps);
+
+    expect(runtime.copySessionToScope).toHaveBeenCalled();
+    expect(text(out)).toContain('Brought over 4 previous messages');
+  });
+
+  it('/list and /use without a target return the workspace picker', async () => {
+    const deps = makeDeps();
+    expect(picker(await handleCommand(msg('/list'), deps))?.options).toHaveLength(2);
+    expect(picker(await handleCommand(msg('/use'), deps))?.options).toHaveLength(2);
+  });
+
+  it('/open activates a selected workspace without changing session routing', async () => {
+    const activateCanvas = vi.fn(async () => ({ ok: true }));
+    const deps = makeDeps();
+    const out = await handleCommand(msg('/open Alpha'), { ...deps, activateCanvas });
+
+    expect(activateCanvas).toHaveBeenCalledWith('ws-A');
+    expect(await bindings.getBound('feishu', 'chatA')).toBeUndefined();
+    expect(text(out)).toMatch(/activated/i);
   });
 
   it('/bind binds the chat to an existing workspace by id', async () => {
@@ -136,33 +282,6 @@ describe('handleCommand', () => {
     const out = await handleCommand(msg('/bind Alpha'), makeDeps());
     expect(text(out)).toContain('Alpha');
     expect(await bindings.getBound('feishu', 'chatA')).toBe('ws-A');
-  });
-
-  it('/bind migrates the previous global conversation session into the workspace scope', async () => {
-    const service = fakeService({
-      copySessionToScope: vi.fn(async () => ({
-        ok: true,
-        sessionId: 'workspace-session',
-        messageCount: 4,
-      })),
-    });
-    const deps = makeDeps(service);
-    await deps.sessionRouter.setConversationSession({ kind: 'global' }, 'chatA', 'global-session');
-
-    const out = await handleCommand(msg('/bind Alpha'), deps);
-
-    expect(service.copySessionToScope).toHaveBeenCalledWith(
-      { kind: 'global' },
-      'global-session',
-      { kind: 'workspace', workspaceId: 'ws-A' },
-    );
-    expect(
-      await deps.sessionRouter.getConversationSessionId(
-        { kind: 'workspace', workspaceId: 'ws-A' },
-        'chatA',
-      ),
-    ).toBe('workspace-session');
-    expect(text(out)).toContain('Migrated 4 previous messages');
   });
 
   it('/bind rejects an unknown workspace', async () => {
@@ -184,67 +303,6 @@ describe('handleCommand', () => {
     expect(text(out)).toContain('Beta');
   });
 
-  it('/new delegates to the service for the resolved workspace', async () => {
-    await bindings.bind('feishu', 'chatA', 'ws-A');
-    const newSessionForScope = vi.fn(async () => ({ ok: true }));
-    const out = await handleCommand(msg('/new'), makeDeps(fakeService({ newSessionForScope })));
-    expect(newSessionForScope).toHaveBeenCalledWith({ kind: 'workspace', workspaceId: 'ws-A' });
-    expect(text(out)).toMatch(/new session/i);
-  });
-
-  it('/new on an unbound chat starts a global session', async () => {
-    const newSessionForScope = vi.fn(async () => ({ ok: true }));
-    const getCurrentSessionIdForScope = vi.fn(() => 'fresh-global');
-    const deps = makeDeps(fakeService({ newSessionForScope, getCurrentSessionIdForScope }));
-    const out = await handleCommand(msg('/new'), deps);
-    expect(newSessionForScope).toHaveBeenCalledWith({ kind: 'global' });
-    expect(await deps.sessionRouter.getConversationSessionId({ kind: 'global' }, 'chatA')).toBe('fresh-global');
-    expect(text(out)).toMatch(/No workspace/i);
-  });
-
-  it('/stop aborts the resolved workspace', async () => {
-    await bindings.bind('feishu', 'chatA', 'ws-A');
-    const abortScope = vi.fn();
-    await handleCommand(msg('/stop'), makeDeps(fakeService({ abortScope })));
-    expect(abortScope).toHaveBeenCalledWith({ kind: 'workspace', workspaceId: 'ws-A' });
-  });
-
-  it('/stop on an unbound chat aborts global scope', async () => {
-    const abortScope = vi.fn();
-    await handleCommand(msg('/stop'), makeDeps(fakeService({ abortScope })));
-    expect(abortScope).toHaveBeenCalledWith({ kind: 'global' });
-  });
-
-  it('/list shows names and marks the bound workspace', async () => {
-    await bindings.bind('feishu', 'chatA', 'ws-A');
-    const out = await handleCommand(msg('/list'), makeDeps());
-    const p = picker(out);
-    expect(p?.fallbackText).toContain('Alpha (ws-A)');
-    expect(p?.fallbackText).toContain('Beta (ws-B)');
-    expect(p?.fallbackText).toContain('⭐'); // bound workspace marker
-  });
-
-  it('/use with no argument shows the same workspace picker as /list', async () => {
-    const list = await handleCommand(msg('/list'), makeDeps());
-    const use = await handleCommand(msg('/use'), makeDeps());
-    expect(picker(use)).toEqual(picker(list));
-  });
-
-  it('/session switches to the chosen session by number', async () => {
-    await bindings.bind('feishu', 'chatA', 'ws-A');
-    const loadSessionForScope = vi.fn(async () => ({ ok: true }));
-    const listSessionsForScope = vi.fn(async (): Promise<AgentSessionInfo[]> => [
-      { sessionId: 's-current', date: '2026-06-01', messageCount: 4, isCurrent: true },
-      { sessionId: 's-old', date: '2026-05-30', messageCount: 9, isCurrent: false },
-    ]);
-    const out = await handleCommand(
-      msg('/session 2'),
-      makeDeps(fakeService({ loadSessionForScope, listSessionsForScope })),
-    );
-    expect(loadSessionForScope).toHaveBeenCalledWith({ kind: 'workspace', workspaceId: 'ws-A' }, 's-old');
-    expect(text(out)).toMatch(/Switched to session/i);
-  });
-
   it('/session rejects an out-of-range selector', async () => {
     await bindings.bind('feishu', 'chatA', 'ws-A');
     const listSessionsForScope = async (): Promise<AgentSessionInfo[]> => [
@@ -252,14 +310,6 @@ describe('handleCommand', () => {
     ];
     const out = await handleCommand(msg('/session 9'), makeDeps(fakeService({ listSessionsForScope })));
     expect(text(out)).toMatch(/not found/i);
-  });
-
-  it('/open activates the canvas for the bound workspace', async () => {
-    await bindings.bind('feishu', 'chatA', 'ws-A');
-    const activateCanvas = vi.fn(async () => ({ ok: true }));
-    const out = await handleCommand(msg('/open'), { ...makeDeps(), activateCanvas });
-    expect(activateCanvas).toHaveBeenCalledWith('ws-A');
-    expect(text(out)).toMatch(/activated/i);
   });
 
   it('/open reports when activation is unavailable', async () => {
@@ -306,104 +356,6 @@ describe('handleCommand', () => {
     expect(await bindings.getBound('feishu', 'chatA')).toBe('ws-B');
     expect(activateCanvas).toHaveBeenCalledWith('ws-B');
     expect(text(out)).toMatch(/Beta \(ws-B\)/);
-  });
-
-  it('/use in a direct chat does not carry previous global context by default', async () => {
-    const service = fakeService({
-      copySessionToScope: vi.fn(async () => ({
-        ok: true,
-        sessionId: 'workspace-session',
-        messageCount: 7,
-      })),
-    });
-    const deps = makeDeps(service);
-    const activateCanvas = vi.fn(async () => ({ ok: true }));
-    await deps.sessionRouter.setConversationSession({ kind: 'global' }, 'chatA', 'global-session');
-
-    const out = await handleCommand(msg('/use Alpha'), { ...deps, activateCanvas });
-
-    expect(service.copySessionToScope).not.toHaveBeenCalled();
-    expect(text(out)).not.toContain('Brought over');
-    expect(activateCanvas).toHaveBeenCalledWith('ws-A');
-  });
-
-  it('/use in a new group carries previous global context by default', async () => {
-    const service = fakeService({
-      copySessionToScope: vi.fn(async () => ({
-        ok: true,
-        sessionId: 'workspace-session',
-        messageCount: 7,
-      })),
-    });
-    const deps = makeDeps(service);
-    const activateCanvas = vi.fn(async () => ({ ok: true }));
-    await deps.sessionRouter.setConversationSession({ kind: 'global' }, 'chatA', 'global-session');
-
-    const out = await handleCommand(
-      msg('/use Alpha', { isDirect: false, isMention: true }),
-      { ...deps, activateCanvas },
-    );
-
-    expect(service.copySessionToScope).toHaveBeenCalledWith(
-      { kind: 'global' },
-      'global-session',
-      { kind: 'workspace', workspaceId: 'ws-A' },
-    );
-    expect(
-      await deps.sessionRouter.getConversationSessionId(
-        { kind: 'workspace', workspaceId: 'ws-A' },
-        'chatA',
-      ),
-    ).toBe('workspace-session');
-    expect(text(out)).toContain('Brought over 7 previous messages');
-  });
-
-  it('/use --carry carries previous direct chat context explicitly', async () => {
-    const service = fakeService({
-      copySessionToScope: vi.fn(async () => ({
-        ok: true,
-        sessionId: 'workspace-session',
-        messageCount: 7,
-      })),
-    });
-    const deps = makeDeps(service);
-    const activateCanvas = vi.fn(async () => ({ ok: true }));
-    await deps.sessionRouter.setConversationSession({ kind: 'global' }, 'chatA', 'global-session');
-
-    const out = await handleCommand(msg('/use Alpha --carry'), { ...deps, activateCanvas });
-
-    expect(service.copySessionToScope).toHaveBeenCalled();
-    expect(text(out)).toContain('Brought over 7 previous messages');
-  });
-
-  it('/use --fresh starts a fresh session instead of carrying context', async () => {
-    const service = fakeService({
-      copySessionToScope: vi.fn(async () => ({
-        ok: true,
-        sessionId: 'workspace-session',
-        messageCount: 7,
-      })),
-      newSessionForScope: vi.fn(async () => ({ ok: true })),
-      getCurrentSessionIdForScope: vi.fn(() => 'fresh-session'),
-    });
-    const deps = makeDeps(service);
-    const activateCanvas = vi.fn(async () => ({ ok: true }));
-    await deps.sessionRouter.setConversationSession({ kind: 'global' }, 'chatA', 'global-session');
-
-    const out = await handleCommand(
-      msg('/use Alpha --fresh', { isDirect: false, isMention: true }),
-      { ...deps, activateCanvas },
-    );
-
-    expect(service.copySessionToScope).not.toHaveBeenCalled();
-    expect(service.newSessionForScope).toHaveBeenCalledWith({ kind: 'workspace', workspaceId: 'ws-A' });
-    expect(
-      await deps.sessionRouter.getConversationSessionId(
-        { kind: 'workspace', workspaceId: 'ws-A' },
-        'chatA',
-      ),
-    ).toBe('fresh-session');
-    expect(text(out)).toContain('Started a fresh session');
   });
 
   it('/bind accepts a list number', async () => {

--- a/apps/canvas-workspace/src/plugins/main/channel/__tests__/sessions.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/__tests__/sessions.test.ts
@@ -1,176 +1,196 @@
-import { describe, it, expect, vi } from 'vitest';
-import type {
-  AgentScope,
-  AgentChatResult,
-  AgentSessionInfo,
-  AgentStatusInfo,
-  CanvasAgentServiceRef,
-  PluginStore,
-} from '../../../types';
+import { describe, expect, it, vi } from 'vitest';
+import type { AgentScope, PluginStore } from '../../../types';
+import type { ConversationRuntimeService } from '../../../../main/agent/conversation-runtime/conversation-service';
 import { SessionRouter } from '../core/sessions';
 
-function memoryStore(): PluginStore {
-  const map = new Map<string, unknown>();
-  return {
-    async get<T>(k: string) {
-      return map.get(k) as T | undefined;
-    },
-    async set<T>(k: string, v: T) {
-      map.set(k, v);
-    },
-    async delete(k: string) {
-      map.delete(k);
-    },
-    async list() {
-      return Array.from(map.keys());
-    },
-  };
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(res => { resolve = res; });
+  return { promise, resolve };
 }
 
-/**
- * Fake agent service that models one "current session id" per workspace, with
- * an auto-incrementing id on newSession and a swap on loadSession — enough to
- * exercise the router's create/swap logic.
- */
-function fakeService() {
-  const current = new Map<string, string>();
+function memoryStore(initial: Record<string, unknown> = {}) {
+  const values = new Map<string, unknown>(Object.entries(initial));
+  const store: PluginStore = {
+    async get<T>(key: string) { return values.get(key) as T | undefined; },
+    async set<T>(key: string, value: T) { values.set(key, value); },
+    async delete(key: string) { values.delete(key); },
+    async list() { return Array.from(values.keys()); },
+  };
+  return { store, values };
+}
+
+function fakeRuntime(options: {
+  known?: string[];
+  provision?: () => Promise<{ ok: boolean; sessionId?: string; error?: string }>;
+} = {}) {
+  const known = new Set(options.known ?? []);
   let counter = 0;
-  const known = new Set<string>();
-  const key = (scope: AgentScope) =>
-    scope.kind === 'global' ? 'global' : `workspace:${scope.workspaceId}`;
-
-  const service: CanvasAgentServiceRef = {
-    chat: async (): Promise<AgentChatResult> => ({ ok: true }),
-    chatWithScope: async (): Promise<AgentChatResult> => ({ ok: true }),
-    abort: () => {},
-    abortScope: () => {},
-    answerClarification: () => true,
-    answerClarificationForScope: () => true,
-    getStatus: (): AgentStatusInfo => ({ ok: true, active: true, messageCount: 0 }),
-    getStatusForScope: (): AgentStatusInfo => ({ ok: true, active: true, messageCount: 0 }),
-    getCurrentSessionId: (ws) => current.get(ws) ?? null,
-    getCurrentSessionIdForScope: (scope) => current.get(key(scope)) ?? null,
-    newSession: async (ws) => {
-      const id = `s${++counter}`;
-      known.add(id);
-      current.set(ws, id);
-      return { ok: true };
-    },
-    newSessionForScope: async (scope) => {
-      const id = `s${++counter}`;
-      known.add(id);
-      current.set(key(scope), id);
-      return { ok: true };
-    },
-    loadSession: async (ws, sessionId) => {
-      if (!known.has(sessionId)) return { ok: true }; // no-op when missing
-      current.set(ws, sessionId);
-      return { ok: true };
-    },
-    loadSessionForScope: async (scope, sessionId) => {
-      if (!known.has(sessionId)) return { ok: true }; // no-op when missing
-      current.set(key(scope), sessionId);
-      return { ok: true };
-    },
-    listSessions: async (): Promise<AgentSessionInfo[]> => [],
-    listSessionsForScope: async (): Promise<AgentSessionInfo[]> => [],
-    copySessionToScope: async () => ({ ok: true }),
-  };
-
-  return { service, current };
+  const provisionSession = vi.fn(options.provision ?? (async () => {
+    const sessionId = `fresh-${++counter}`;
+    known.add(sessionId);
+    return { ok: true, sessionId };
+  }));
+  const copySessionToScope = vi.fn(async (_source, sessionId: string) => {
+    if (!known.has(sessionId)) return { ok: false, error: 'Source session not found' };
+    const copied = `copy-${++counter}`;
+    known.add(copied);
+    return { ok: true, sessionId: copied, messageCount: 3 };
+  });
+  const runtime = {
+    provisionSession,
+    hasSession: vi.fn(async (_scope, sessionId: string) => known.has(sessionId)),
+    copySessionToScope,
+    abort: vi.fn(() => true),
+  } as unknown as ConversationRuntimeService;
+  return { runtime, known, provisionSession, copySessionToScope };
 }
+
+const workspace: AgentScope = { kind: 'workspace', workspaceId: 'ws1' };
 
 describe('SessionRouter', () => {
-  it('creates a session per conversation and swaps between them', async () => {
-    const { service, current } = fakeService();
-    const router = new SessionRouter(service, memoryStore());
-    const scope: AgentScope = { kind: 'workspace', workspaceId: 'ws1' };
-    const K = 'workspace:ws1';
+  it('provisions independent sessions per channel and conversation without a UI pointer', async () => {
+    const { store } = memoryStore();
+    const { runtime } = fakeRuntime();
+    const router = new SessionRouter(runtime, store);
 
-    await router.ensureSession(scope, 'convA');
-    const sa = current.get(K);
-    expect(sa).toBeTruthy();
+    const a = await router.ensureSession(workspace, 'feishu', 'topic-a');
+    const b = await router.ensureSession(workspace, 'feishu', 'topic-b');
+    const otherChannel = await router.ensureSession(workspace, 'slack', 'topic-a');
 
-    // A different conversation gets its own fresh session.
-    await router.ensureSession(scope, 'convB');
-    const sb = current.get(K);
-    expect(sb).toBeTruthy();
-    expect(sb).not.toBe(sa);
-
-    // Returning to A swaps the current session back to A's, not a new one.
-    await router.ensureSession(scope, 'convA');
-    expect(current.get(K)).toBe(sa);
-
-    // And back to B.
-    await router.ensureSession(scope, 'convB');
-    expect(current.get(K)).toBe(sb);
+    expect(new Set([a, b, otherChannel]).size).toBe(3);
+    expect(await router.ensureSession(workspace, 'feishu', 'topic-a')).toBe(a);
   });
 
-  it('is a no-op when the conversation already owns the current session', async () => {
-    const { service } = fakeService();
-    const newSpy = vi.spyOn(service, 'newSessionForScope');
-    const loadSpy = vi.spyOn(service, 'loadSessionForScope');
-    const router = new SessionRouter(service, memoryStore());
+  it('single-flights concurrent provisioning for the same route', async () => {
+    const gate = deferred<{ ok: boolean; sessionId: string }>();
+    const { runtime, known, provisionSession } = fakeRuntime({
+      provision: async () => {
+        const result = await gate.promise;
+        known.add(result.sessionId);
+        return result;
+      },
+    });
+    const { store } = memoryStore();
+    const router = new SessionRouter(runtime, store);
 
-    await router.ensureSession({ kind: 'workspace', workspaceId: 'ws1' }, 'convA'); // creates s1
-    expect(newSpy).toHaveBeenCalledTimes(1);
+    const first = router.ensureSession(workspace, 'feishu', 'topic-a');
+    const second = router.ensureSession(workspace, 'feishu', 'topic-a');
+    await Promise.resolve();
+    gate.resolve({ ok: true, sessionId: 'one-session' });
 
-    await router.ensureSession({ kind: 'workspace', workspaceId: 'ws1' }, 'convA'); // already current → no work
-    expect(newSpy).toHaveBeenCalledTimes(1);
-    expect(loadSpy).not.toHaveBeenCalled();
+    await expect(Promise.all([first, second])).resolves.toEqual(['one-session', 'one-session']);
+    expect(provisionSession).toHaveBeenCalledTimes(1);
   });
 
-  it('keys per workspace so the same conversation id is distinct across workspaces', async () => {
-    const { service, current } = fakeService();
-    const router = new SessionRouter(service, memoryStore());
+  it('fails closed when provisioning fails instead of binding an old session', async () => {
+    const { store, values } = memoryStore();
+    const { runtime } = fakeRuntime({
+      known: ['old-current'],
+      provision: async () => ({ ok: false, error: 'create failed' }),
+    });
+    const router = new SessionRouter(runtime, store);
 
-    await router.ensureSession({ kind: 'workspace', workspaceId: 'wsX' }, 'conv');
-    const sx = current.get('workspace:wsX');
-    await router.ensureSession({ kind: 'workspace', workspaceId: 'wsY' }, 'conv');
-    const sy = current.get('workspace:wsY');
-
-    expect(sx).toBeTruthy();
-    expect(sy).toBeTruthy();
-    expect(sx).not.toBe(sy);
+    await expect(router.ensureSession(workspace, 'feishu', 'topic-a')).rejects.toThrow('create failed');
+    expect(await router.getConversationSessionId(workspace, 'feishu', 'topic-a')).toBeUndefined();
+    expect(values.get('sessions')).toBeUndefined();
   });
 
-  it('starts a fresh session when the mapped one no longer exists', async () => {
-    const store = memoryStore();
-    // Pre-seed a mapping pointing at a session id the service does not know.
-    await store.set('sessions', { 'workspace:ws1::convA': 'ghost' });
-    const { service, current } = fakeService();
-    const router = new SessionRouter(service, store);
+  it('single-flights initialization and serializes concurrent persistence', async () => {
+    const load = deferred<Record<string, string>>();
+    const persisted: Array<Record<string, string>> = [];
+    const store: PluginStore = {
+      get: vi.fn(async () => load.promise) as PluginStore['get'],
+      set: vi.fn(async (_key, value) => {
+        persisted.push({ ...(value as Record<string, string>) });
+      }),
+      delete: vi.fn(async () => undefined),
+      list: vi.fn(async () => []),
+    };
+    const { runtime, known } = fakeRuntime({ known: ['session-a', 'session-b'] });
+    known.add('session-a');
+    known.add('session-b');
+    const router = new SessionRouter(runtime, store);
 
-    await router.ensureSession({ kind: 'workspace', workspaceId: 'ws1' }, 'convA');
-    // loadSession('ghost') is a no-op, so the router creates a real session.
-    expect(current.get('workspace:ws1')).toBeTruthy();
-    expect(current.get('workspace:ws1')).not.toBe('ghost');
+    const a = router.setConversationSession(workspace, 'feishu', 'topic-a', 'session-a');
+    const b = router.setConversationSession(workspace, 'feishu', 'topic-b', 'session-b');
+    await Promise.resolve();
+    load.resolve({});
+    await Promise.all([a, b]);
+
+    expect(store.get).toHaveBeenCalledTimes(1);
+    expect(persisted.at(-1)).toEqual({
+      'workspace:ws1::feishu::topic-a': 'session-a',
+      'workspace:ws1::feishu::topic-b': 'session-b',
+    });
   });
 
-  it('keeps global conversations in separate sessions', async () => {
-    const { service, current } = fakeService();
-    const router = new SessionRouter(service, memoryStore());
-    const scope: AgentScope = { kind: 'global' };
+  it('reads a legacy scope::conversation mapping and persists the channel-qualified key', async () => {
+    const { store, values } = memoryStore({
+      sessions: { 'workspace:ws1::topic-a': 'legacy-session' },
+    });
+    const { runtime } = fakeRuntime({ known: ['legacy-session'] });
+    const router = new SessionRouter(runtime, store);
 
-    await router.ensureSession(scope, 'convA');
-    const sa = current.get('global');
-    await router.ensureSession(scope, 'convB');
-    const sb = current.get('global');
-    await router.ensureSession(scope, 'convA');
-
-    expect(sa).toBeTruthy();
-    expect(sb).toBeTruthy();
-    expect(sb).not.toBe(sa);
-    expect(current.get('global')).toBe(sa);
+    await expect(router.ensureSession(workspace, 'feishu', 'topic-a')).resolves.toBe('legacy-session');
+    expect(values.get('sessions')).toEqual({
+      'workspace:ws1::topic-a': 'legacy-session',
+      'workspace:ws1::feishu::topic-a': 'legacy-session',
+    });
   });
 
-  it('returns a mapped conversation session without activating the service', async () => {
-    const { service } = fakeService();
-    const router = new SessionRouter(service, memoryStore());
-    const scope: AgentScope = { kind: 'global' };
-    await router.setConversationSession(scope, 'convA', 's-existing');
+  it('forks duplicate historical mappings without deleting the original history', async () => {
+    const { store, values } = memoryStore({
+      sessions: {
+        'workspace:ws1::feishu::topic-a': 'shared-session',
+        'workspace:ws1::feishu::topic-b': 'shared-session',
+      },
+    });
+    const { runtime, copySessionToScope } = fakeRuntime({ known: ['shared-session'] });
+    const router = new SessionRouter(runtime, store);
 
-    expect(await router.getConversationSessionId(scope, 'convA')).toBe('s-existing');
-    expect(await router.getConversationSessionId(scope, 'convB')).toBeUndefined();
+    expect(await router.ensureSession(workspace, 'feishu', 'topic-a')).toBe('shared-session');
+    const isolated = await router.ensureSession(workspace, 'feishu', 'topic-b');
+
+    expect(isolated).toBe('copy-1');
+    expect(copySessionToScope).toHaveBeenCalledWith(workspace, 'shared-session', workspace);
+    expect(values.get('sessions')).toEqual({
+      'workspace:ws1::feishu::topic-a': 'shared-session',
+      'workspace:ws1::feishu::topic-b': 'copy-1',
+    });
+  });
+
+  it('replaces a stale mapping only after a fresh session is durable', async () => {
+    const { store, values } = memoryStore({
+      sessions: { 'workspace:ws1::feishu::topic-a': 'missing-session' },
+    });
+    const { runtime } = fakeRuntime();
+    const router = new SessionRouter(runtime, store);
+
+    await expect(router.ensureSession(workspace, 'feishu', 'topic-a')).resolves.toBe('fresh-1');
+    expect(values.get('sessions')).toEqual({
+      'workspace:ws1::feishu::topic-a': 'fresh-1',
+    });
+  });
+
+  it('retains the previous mapping if saving a replacement fails', async () => {
+    const { store, values } = memoryStore({
+      sessions: { 'workspace:ws1::feishu::topic-a': 'original' },
+    });
+    const { runtime } = fakeRuntime({ known: ['original'] });
+    const router = new SessionRouter(runtime, store);
+    vi.spyOn(store, 'set').mockRejectedValueOnce(new Error('store unavailable'));
+    await expect(router.createFreshSession(workspace, 'feishu', 'topic-a')).rejects.toThrow('store unavailable');
+    expect(await router.getConversationSessionId(workspace, 'feishu', 'topic-a')).toBe('original');
+    expect(values.get('sessions')).toEqual({ 'workspace:ws1::feishu::topic-a': 'original' });
+  });
+
+  it('targets abort to an explicit conversation session', () => {
+    const { store } = memoryStore();
+    const { runtime } = fakeRuntime();
+    const router = new SessionRouter(runtime, store);
+
+    expect(router.abort(workspace, 'session-a')).toBe(true);
+    expect(runtime.abort).toHaveBeenCalledWith(workspace, 'session-a');
   });
 });

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/card.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/card.test.ts
@@ -61,7 +61,7 @@ describe('feishu card tool list', () => {
     expect(body).toContain('**Working**');
     expect(body).toContain('<font color="grey">│</font>');
     expect(body).toContain('<font color="grey">›</font>');
-    expect(body).toContain('<font color="grey">•</font>');
+    expect(body).toContain('<font color="grey">执行中</font>');
     expect(body).toContain('<font color="grey">Canvas read node · node-1 · 18s</font>');
     expect(body).toContain('Canvas write node · node-2');
     expect(body).toContain('working');
@@ -82,6 +82,25 @@ describe('feishu card tool list', () => {
     const progress = texts(buildProgressCard('', tools));
     expect(thinking[0]).toBe('**Working**');
     expect(progress[0]).toBe(thinking[0]);
+  });
+
+  it('replaces the pulsing dot with quiet pending text and delayed elapsed time', () => {
+    expect(texts(buildThinkingCard())[1]).toBe('<font color="grey">正在处理</font>');
+    for (const elapsed of [0, 1, 2, 3, 4]) {
+      expect(texts(buildProgressCard('', [], elapsed))[1]).toBe(texts(buildThinkingCard())[1]);
+    }
+    expect(texts(buildProgressCard('', [], 5))[1]).toContain('正在处理 · 已等待 5 秒');
+    expect(texts(buildProgressCard('', [], 65))[1]).toContain('已等待 1 分 05 秒');
+    expect(texts(buildProgressCard('', [], -5))[1]).toContain('正在处理</font>');
+    expect(texts(buildProgressCard('', [], NaN))[1]).toContain('正在处理</font>');
+  });
+
+  it('keeps active tool markers stable and removes pending copy on completion', () => {
+    expect(texts(buildProgressCard('', tools, 1))).toEqual(texts(buildProgressCard('', tools, 2)));
+    const done = texts(buildDoneCard('answer', tools)).join('\n');
+    expect(done).not.toContain('执行中');
+    expect(done).not.toContain('正在处理');
+    expect(done).not.toContain('已等待');
   });
 
   it('done card keeps the final answer below an expanded completed timeline', () => {

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/stream.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/stream.test.ts
@@ -41,7 +41,7 @@ describe('FeishuStream', () => {
     vi.useRealTimers();
   });
 
-  it('animates the working marker through heartbeat card patches', async () => {
+  it('refreshes pending duration without pulsing glyphs and stops on completion', async () => {
     const stream = new FeishuStream({} as never, {
       chatId: 'group1',
       isGroup: true,
@@ -49,15 +49,23 @@ describe('FeishuStream', () => {
     });
 
     await stream.init();
-    expect(JSON.stringify(mockedSendCard.mock.calls[0][2])).toContain('•');
+    expect(JSON.stringify(mockedSendCard.mock.calls[0][2])).toContain('正在处理');
 
     await vi.advanceTimersByTimeAsync(1_200);
     await flushAsync();
-    expect(JSON.stringify(mockedUpdateCard.mock.calls.at(-1)?.[2])).toContain('●');
+    expect(JSON.stringify(mockedUpdateCard.mock.calls.at(-1)?.[2])).toContain('正在处理');
 
     await vi.advanceTimersByTimeAsync(1_200);
     await flushAsync();
-    expect(JSON.stringify(mockedUpdateCard.mock.calls.at(-1)?.[2])).toContain('•');
+    expect(JSON.stringify(mockedUpdateCard.mock.calls.at(-1)?.[2])).toContain('正在处理');
+    await vi.advanceTimersByTimeAsync(3_600);
+    await flushAsync();
+    expect(JSON.stringify(mockedUpdateCard.mock.calls.at(-1)?.[2])).toContain('已等待 6 秒');
+    await stream.onDone('answer');
+    const patchCount = mockedUpdateCard.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(6_000);
+    expect(mockedUpdateCard).toHaveBeenCalledTimes(patchCount);
+    expect(JSON.stringify(mockedUpdateCard.mock.calls.at(-1)?.[2])).not.toContain('正在处理');
   });
 
   it('keeps streaming after a transient card patch failure', async () => {

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
@@ -92,29 +92,27 @@ function toolLine(tool: ToolEntry): string {
   return segs.join(' · ');
 }
 
-const DOT_PULSE_FRAMES = ['•', '●', '•', '·'] as const;
-
-function dotPulseFrame(elapsedSec: number): string {
-  return DOT_PULSE_FRAMES[Math.abs(Math.floor(elapsedSec)) % DOT_PULSE_FRAMES.length];
+/** Keep pending feedback readable without changing glyph size on every patch. */
+function pendingLabel(elapsedSec: number): string {
+  const seconds = Number.isFinite(elapsedSec) ? Math.max(0, Math.floor(elapsedSec)) : 0;
+  if (seconds < 5) return '正在处理';
+  const duration = seconds < 60
+    ? `${seconds} 秒`
+    : `${Math.floor(seconds / 60)} 分 ${String(seconds % 60).padStart(2, '0')} 秒`;
+  return `正在处理 · 已等待 ${duration}`;
 }
 
-/**
- * The reference interaction keeps the process visible as one quiet vertical
- * timeline. Finished rows recede; the current row gets the only moving mark.
- */
+/** Finished rows recede; active rows use a stable, explicit status label. */
 function toolTimeline(tools: ToolEntry[], elapsedSec: number, running: boolean): string {
-  const pulse = dotPulseFrame(elapsedSec);
   const rail = muted('│');
-  const liveMark = muted(pulse);
   const rows = tools.map((tool) => {
     const completed = tool.done || !running;
-    const status = completed ? muted('›') : liveMark;
-    const label = completed ? muted(toolLine(tool)) : toolLine(tool);
-    return `${rail}  ${status}  ${label}`;
+    const label = completed ? muted(toolLine(tool)) : `${toolLine(tool)}  ${muted('执行中')}`;
+    return `${rail}  ${muted('›')}  ${label}`;
   });
 
   if (running && rows.length === 0) {
-    rows.push(liveMark);
+    rows.push(muted(pendingLabel(elapsedSec)));
   } else if (!running) {
     rows.push(`${muted('└')}  ${muted('◎ Completed')}`);
   }

--- a/apps/canvas-workspace/src/plugins/main/channel/core/bridge.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/core/bridge.ts
@@ -1,17 +1,21 @@
 import type { AgentChatResult, AgentScope, CanvasAgentServiceRef } from '../../../types';
+import type { ConversationRuntimeService } from '../../../../main/agent/conversation-runtime/conversation-service';
 import type { PluginStore } from '../../../types';
 import { BindingStore } from './binding';
 import { buildWorkspacePickerReply, handleCommand } from './commands';
 import { MessageDedupe } from './dedupe';
+import { buildAgentPrompt } from './inbound-prompt';
+export { buildAgentPrompt } from './inbound-prompt';
 import { extractGeneratedImageResult } from './image-result';
 import { SessionRouter } from './sessions';
+import { SubmissionQueue, type SubmissionReservation } from './submission-queue';
 import type { Channel, ChannelStream, CommandReply, InboundMessage, OutboundTarget } from './types';
 import { listWorkspaces, workspaceLabelById } from './workspaces';
 
 interface ActiveRun {
-  channelId: string;
-  conversationId: string;
-  /** Set while the agent is awaiting an answer to a clarification request. */
+  sessionId: string;
+  pendingTurns: number;
+  /** Set while the active turn awaits an answer to a clarification request. */
   pendingClarificationId?: string;
 }
 
@@ -39,15 +43,17 @@ const CLARIFICATION_TIMEOUT_ENV = 'CANVAS_CHANNEL_CLARIFICATION_TIMEOUT_MS';
  * any number of channels, resolves the target agent scope, and drives the
  * Canvas Agent — streaming its output back through the originating channel.
  *
- * Concurrency: at most one in-flight run per scope key. A follow-up message
- * for a busy scope either answers a pending clarification or is rejected with
- * a "still working" notice.
+ * Concurrency: each channel conversation resolves to an explicit durable
+ * session. The existing conversation runtime runs different sessions in
+ * parallel and queues turns for the same session FIFO.
  */
 export class ChannelBridge {
   private readonly bindings: BindingStore;
   private readonly sessions: SessionRouter;
   private readonly dedupe: MessageDedupe;
   private readonly activeRuns = new Map<string, ActiveRun>();
+  /** Orders only runtime submissions; turn execution remains owned by the runtime queue. */
+  private readonly submissions = new SubmissionQueue();
   private readonly channels = new Map<string, Channel>();
   private readonly activateCanvas?: (workspaceId: string) => Promise<{ ok: boolean; error?: string }>;
   private readonly runIdleTimeoutMs: number;
@@ -56,6 +62,7 @@ export class ChannelBridge {
 
   constructor(
     private readonly service: CanvasAgentServiceRef,
+    private readonly runtime: ConversationRuntimeService,
     store: PluginStore,
     options: {
       activateCanvas?: (workspaceId: string) => Promise<{ ok: boolean; error?: string }>;
@@ -65,7 +72,7 @@ export class ChannelBridge {
     } = {},
   ) {
     this.bindings = new BindingStore(store);
-    this.sessions = new SessionRouter(service, store);
+    this.sessions = new SessionRouter(runtime, store);
     // Persist dedupe so a redelivered event that straddles a restart isn't
     // processed twice.
     this.dedupe = new MessageDedupe(500, { store, storeKey: 'dedupe' });
@@ -90,9 +97,10 @@ export class ChannelBridge {
   async addChannel(channel: Channel): Promise<void> {
     this.channels.set(channel.id, channel);
     await channel.start((msg) => {
-      void this.handleInbound(channel, msg).catch((err) => {
+      const submission = this.submissions.reserve(channelConversationKey(msg.channelId, msg.conversationId));
+      void this.handleInbound(channel, msg, submission).catch((err) => {
         console.error(`[channel:${channel.id}] inbound handling failed`, err);
-      });
+      }).finally(submission.release);
     });
   }
 
@@ -106,17 +114,32 @@ export class ChannelBridge {
     this.channels.clear();
   }
 
-  private async handleInbound(channel: Channel, msg: InboundMessage): Promise<void> {
+  private async handleInbound(
+    channel: Channel,
+    msg: InboundMessage,
+    submission: SubmissionReservation,
+  ): Promise<void> {
     await this.dedupe.ensureLoaded();
     if (!this.dedupe.accept(msg.messageId)) return;
 
     const target = { conversationId: msg.conversationId, reply: msg.reply };
-
-    // Slash commands run regardless of workspace binding / busy state.
+    const topicKey = channelConversationKey(msg.channelId, msg.conversationId);
+    // Route changes wait only for earlier submissions, then fail closed while
+    // the topic has active/queued turns. Never pair an old session with a new scope.
+    if (/^\/(?:new|use|bind|unbind|session)(?:\s|$)/i.test(msg.text.trim())) {
+      await submission.previous;
+      if (this.activeRuns.has(topicKey)) {
+        await channel.sendText(target, 'Wait for this topic to finish before changing its session or workspace. /stop is still available.');
+        return;
+      }
+    }
+    const active = this.activeRuns.get(topicKey);
+    // Stop and informational commands remain immediate.
     const commandReply = await handleCommand(msg, {
       bindings: this.bindings,
       service: this.service,
       sessionRouter: this.sessions,
+      activeSessionId: active?.sessionId,
       activateCanvas: this.activateCanvas,
     });
     if (commandReply !== null) {
@@ -126,63 +149,48 @@ export class ChannelBridge {
 
     if (!msg.text.trim() && !msg.imagePaths?.length) return;
 
-    const boundWorkspaceId = await this.bindings.getBound(msg.channelId, msg.conversationId);
+    let boundWorkspaceId = await this.bindings.getBound(msg.channelId, msg.conversationId);
+    let pickerReply: CommandReply | null = null;
     if (!boundWorkspaceId && !msg.isDirect) {
-      const currentWorkspaceId = await this.bindCurrentWorkspaceForGroupFirstContact(msg);
-      const pickerReply = await buildWorkspacePickerReply(msg, {
+      boundWorkspaceId = await this.bindCurrentWorkspaceForGroupFirstContact(msg) ?? undefined;
+      pickerReply = await buildWorkspacePickerReply(msg, {
         bindings: this.bindings,
         service: this.service,
         sessionRouter: this.sessions,
         activateCanvas: this.activateCanvas,
       }, {
         defaultCarry: true,
-        summary: currentWorkspaceId
-          ? `Current chat: using ${await workspaceLabelById(currentWorkspaceId)}.`
+        summary: boundWorkspaceId
+          ? `Current chat: using ${await workspaceLabelById(boundWorkspaceId)}.`
           : undefined,
       });
 
-      if (!currentWorkspaceId) {
+      if (!boundWorkspaceId) {
         await this.sendReply(channel, target, pickerReply);
         return;
       }
-
-      await this.runTurn(channel, msg, { kind: 'workspace', workspaceId: currentWorkspaceId });
-      await this.sendReply(channel, target, pickerReply);
-      return;
     }
 
     const scope: AgentScope = boundWorkspaceId
       ? { kind: 'workspace', workspaceId: boundWorkspaceId }
       : { kind: 'global' };
-    const runKey = agentScopeKey(scope);
-
-    // Busy scope: if THIS conversation is the one awaiting a clarification
-    // answer, route the message as the answer. Otherwise (a different
-    // conversation bound to the same scope, or no pending question) tell
-    // the user to wait — so a clarification can't be answered by an unrelated
-    // chat that happens to share the scope.
-    const existing = this.activeRuns.get(runKey);
-    if (existing) {
-      if (
-        existing.pendingClarificationId &&
-        existing.conversationId === msg.conversationId
-      ) {
-        const matched = this.service.answerClarificationForScope(
-          scope,
-          existing.pendingClarificationId,
-          msg.text,
-        );
-        existing.pendingClarificationId = undefined;
-        if (!matched) {
-          await channel.sendText(target, '⚠️ Could not match your reply to the pending question.');
-        }
-      } else {
-        await channel.sendText(target, '⏳ Still working on the previous message. Send /stop to cancel.');
+    const current = this.activeRuns.get(topicKey);
+    if (current?.pendingClarificationId) {
+      const matched = this.runtime.answerClarification(
+        scope,
+        current.sessionId,
+        current.pendingClarificationId,
+        msg.text,
+      );
+      current.pendingClarificationId = undefined;
+      if (!matched) {
+        await channel.sendText(target, '⚠️ Could not match your reply to the pending question.');
       }
       return;
     }
 
-    await this.runTurn(channel, msg, scope);
+    await this.runTurn(channel, msg, submission);
+    if (pickerReply) await this.sendReply(channel, target, pickerReply);
   }
 
   private async bindCurrentWorkspaceForGroupFirstContact(
@@ -211,15 +219,54 @@ export class ChannelBridge {
   private async runTurn(
     channel: Channel,
     msg: InboundMessage,
-    scope: AgentScope,
+    submission: SubmissionReservation,
   ): Promise<void> {
+    let submitted = false;
+    const markSubmitted = (): void => {
+      if (submitted) return;
+      submitted = true;
+      submission.release();
+    };
     const target = { conversationId: msg.conversationId, reply: msg.reply };
-    const run: ActiveRun = { channelId: msg.channelId, conversationId: msg.conversationId };
-    const runKey = agentScopeKey(scope);
-    this.activeRuns.set(runKey, run);
+    let stream: ChannelStream;
+    try {
+      stream = await channel.openStream(target);
+    } catch (err) {
+      markSubmitted();
+      console.error(`[channel:${channel.id}] failed to open stream`, err);
+      return;
+    }
+
+    await submission.previous;
+    const workspaceId = await this.bindings.getBound(msg.channelId, msg.conversationId);
+    const scope: AgentScope = workspaceId ? { kind: 'workspace', workspaceId } : { kind: 'global' };
+    const runKey = channelConversationKey(msg.channelId, msg.conversationId);
+    let run = this.activeRuns.get(runKey);
+    let sessionId: string;
+    try {
+      sessionId = run?.sessionId ?? await this.sessions.ensureSession(
+        scope,
+        msg.channelId,
+        msg.conversationId,
+      );
+    } catch (err) {
+      markSubmitted();
+      await stream.onError(err instanceof Error ? err.message : String(err));
+      return;
+    }
+    if (!run) {
+      run = { sessionId, pendingTurns: 0 };
+      this.activeRuns.set(runKey, run);
+    }
+    const activeRun = run;
+    activeRun.pendingTurns += 1;
+    let turnClarificationId: string | undefined;
     let finished = false;
     let idleTimer: NodeJS.Timeout | null = null;
     let lastAgentActivityAt = Date.now();
+    // Queued turns do not consume their watchdog budget until the conversation
+    // runtime actually starts them (signalled by the first role-turn callback).
+    let turnStarted = false;
     // A tool's `execute()` blocks without emitting any streaming callback, so
     // we track how many are running (and since when) to grant them the larger
     // tool-exec budget instead of tripping the idle watchdog mid-tool.
@@ -230,6 +277,7 @@ export class ChannelBridge {
     let settleWatchdog: ((result: AgentChatResult) => void) | null = null;
 
     const markAgentActivity = (): void => {
+      turnStarted = true;
       lastAgentActivityAt = Date.now();
     };
 
@@ -249,7 +297,7 @@ export class ChannelBridge {
     const failRun = (message: string): void => {
       if (finished) return;
       console.warn(`[channel:${channel.id}] ${message}`);
-      this.service.abortScope(scope);
+      this.runtime.abort(scope, sessionId);
       settleWatchdog?.({ ok: false, error: message });
     };
 
@@ -259,10 +307,15 @@ export class ChannelBridge {
       const check = (): void => {
         if (finished) return;
 
+        if (!turnStarted) {
+          idleTimer = setTimeout(check, this.runIdleTimeoutMs);
+          return;
+        }
+
         // Parked on a clarification: keep idle fresh (so the run doesn't get
         // idle-killed the instant the answer arrives) but bound the wait so an
         // undelivered/ignored question can't pin the scope forever.
-        if (run.pendingClarificationId) {
+        if (activeRun.pendingClarificationId) {
           lastAgentActivityAt = Date.now();
           const waited = Date.now() - clarificationStartedAt;
           if (waited >= this.clarificationTimeoutMs) {
@@ -309,105 +362,102 @@ export class ChannelBridge {
       idleTimer = setTimeout(check, this.runIdleTimeoutMs);
     });
 
-    // Acknowledge the accepted turn before any potentially slow session setup.
-    // The scope is already reserved, so another message cannot start a second run.
-    let stream: ChannelStream;
-    try {
-      stream = await channel.openStream(target);
-    } catch (err) {
-      finished = true;
-      if (idleTimer) clearTimeout(idleTimer);
-      this.activeRuns.delete(runKey);
-      console.error(`[channel:${channel.id}] failed to open stream`, err);
-      return;
-    }
+    const releaseRun = (): void => {
+      activeRun.pendingTurns -= 1;
+      if (turnClarificationId && activeRun.pendingClarificationId === turnClarificationId) {
+        activeRun.pendingClarificationId = undefined;
+      }
+      if (activeRun.pendingTurns === 0 && this.activeRuns.get(runKey) === activeRun) {
+        this.activeRuns.delete(runKey);
+      }
+    };
 
     try {
-      // Keep session selection inside the error/finally path: a failed setup
-      // must close the early card, not continue chatting in the wrong session.
-      await this.sessions.ensureSession(scope, msg.conversationId);
-      const chat = this.service.chatWithScope(
+      const chat = this.runtime.chat(
         scope,
+        sessionId,
         buildAgentPrompt(msg),
-        (delta) => {
-          if (finished) return;
-          markAgentActivity();
-          void Promise.resolve(stream.onText(delta)).catch(noop);
-        },
-        (toolCall) => {
-          if (finished) return;
-          // Args are complete and `execute()` is about to block — mark the
-          // tool in-flight so the idle watchdog doesn't kill it mid-run.
-          markToolStart();
-          void Promise.resolve(
-            stream.onToolCall(toolCall.name, toolCall.args, toolCall.toolCallId),
-          ).catch(noop);
-        },
-        (toolResult) => {
-          if (finished) return;
-          markToolEnd();
-          const image = extractGeneratedImageResult(toolResult);
-          if (image && stream.onImage) {
-            void Promise.resolve(stream.onImage(image.outputPath, image.mimeType)).catch(noop);
-            return;
-          }
-          if (stream.onToolResult) {
+        {
+          onText: (delta) => {
+            if (finished) return;
+            markAgentActivity();
+            void Promise.resolve(stream.onText(delta)).catch(noop);
+          },
+          onToolCall: (toolCall) => {
+            if (finished) return;
+            markToolStart();
             void Promise.resolve(
-              stream.onToolResult({
-                name: toolResult.name,
-                result: toolResult.result,
-                toolCallId: toolResult.toolCallId,
-              }),
+              stream.onToolCall(toolCall.name, toolCall.args, toolCall.toolCallId),
             ).catch(noop);
-          }
-        },
-        undefined,
-        (req) => {
-          if (finished) return;
-          markAgentActivity();
-          run.pendingClarificationId = req.id;
-          clarificationStartedAt = Date.now();
-          // A question that can't be delivered can never be answered, so fail
-          // the run instead of parking it until the clarification timeout.
-          void Promise.resolve(stream.onClarification(req.question)).catch((err) => {
-            console.error(`[channel:${channel.id}] failed to deliver clarification`, err);
-            if (run.pendingClarificationId === req.id) run.pendingClarificationId = undefined;
-            failRun(
-              "Couldn't deliver the agent's question to the chat, so it can't be answered. " +
-                'Stopped this run.',
-            );
-          });
-        },
-        undefined,
-        undefined,
-        (toolInput) => {
-          if (finished) return;
-          markAgentActivity();
-          if (stream.onToolInputStart) {
-            void Promise.resolve(stream.onToolInputStart(toolInput)).catch(noop);
-          }
-        },
-        (toolInput) => {
-          if (finished) return;
-          markAgentActivity();
-          if (stream.onToolInputDelta) {
-            void Promise.resolve(stream.onToolInputDelta(toolInput)).catch(noop);
-          }
-        },
-        (toolInput) => {
-          if (finished) return;
-          markAgentActivity();
-          if (stream.onToolInputEnd) {
-            void Promise.resolve(stream.onToolInputEnd(toolInput)).catch(noop);
-          }
+          },
+          onToolResult: (toolResult) => {
+            if (finished) return;
+            markToolEnd();
+            const image = extractGeneratedImageResult(toolResult);
+            if (image && stream.onImage) {
+              void Promise.resolve(stream.onImage(image.outputPath, image.mimeType)).catch(noop);
+              return;
+            }
+            if (stream.onToolResult) {
+              void Promise.resolve(
+                stream.onToolResult({
+                  name: toolResult.name,
+                  result: toolResult.result,
+                  toolCallId: toolResult.toolCallId,
+                }),
+              ).catch(noop);
+            }
+          },
+          onClarificationRequest: (req) => {
+            if (finished) return;
+            markAgentActivity();
+            turnClarificationId = req.id;
+            activeRun.pendingClarificationId = req.id;
+            clarificationStartedAt = Date.now();
+            void Promise.resolve(stream.onClarification(req.question)).catch((err) => {
+              console.error(`[channel:${channel.id}] failed to deliver clarification`, err);
+              if (activeRun.pendingClarificationId === req.id) {
+                activeRun.pendingClarificationId = undefined;
+              }
+              failRun(
+                "Couldn't deliver the agent's question to the chat, so it can't be answered. " +
+                  'Stopped this run.',
+              );
+            });
+          },
+          onToolInputStart: (toolInput) => {
+            if (finished) return;
+            markAgentActivity();
+            if (stream.onToolInputStart) {
+              void Promise.resolve(stream.onToolInputStart(toolInput)).catch(noop);
+            }
+          },
+          onToolInputDelta: (toolInput) => {
+            if (finished) return;
+            markAgentActivity();
+            if (stream.onToolInputDelta) {
+              void Promise.resolve(stream.onToolInputDelta(toolInput)).catch(noop);
+            }
+          },
+          onToolInputEnd: (toolInput) => {
+            if (finished) return;
+            markAgentActivity();
+            if (stream.onToolInputEnd) {
+              void Promise.resolve(stream.onToolInputEnd(toolInput)).catch(noop);
+            }
+          },
+          onRoleTurnStart: () => markAgentActivity(),
         },
       );
+      markSubmitted();
       chat.catch((err) => {
         if (finished) {
           console.error(`[channel:${channel.id}] late agent failure after channel timeout`, err);
         }
       });
       const result = await Promise.race([chat, idleTimeout]);
+      finished = true;
+      if (idleTimer) clearTimeout(idleTimer);
 
       if (result.ok) {
         await stream.onDone(result.response?.trim() || '✅ Done');
@@ -415,34 +465,19 @@ export class ChannelBridge {
         await stream.onError(result.error ?? 'Unknown error');
       }
     } catch (err) {
+      finished = true;
+      if (idleTimer) clearTimeout(idleTimer);
       await stream.onError(err instanceof Error ? err.message : String(err));
     } finally {
       finished = true;
       if (idleTimer) clearTimeout(idleTimer);
-      this.activeRuns.delete(runKey);
+      releaseRun();
     }
   }
 }
 
-function agentScopeKey(scope: AgentScope): string {
-  return scope.kind === 'global' ? 'global' : `workspace:${scope.workspaceId}`;
-}
-
-/**
- * Build the prompt handed to the agent. When the inbound message carried
- * images, append a note with their local paths so the agent reads them with
- * `image_analyze` (the vision tool accepts local `imagePaths`). An
- * image-only message becomes just the note.
- */
-export function buildAgentPrompt(msg: InboundMessage): string {
-  const text = msg.text.trim();
-  if (!msg.imagePaths?.length) return text;
-
-  const list = msg.imagePaths.map((path) => `- ${path}`).join('\n');
-  const note =
-    `[The user attached ${msg.imagePaths.length} image(s), saved locally at the path(s) below. ` +
-    `To view or analyze them, call image_analyze with these imagePaths:\n${list}]`;
-  return text ? `${text}\n\n${note}` : note;
+function channelConversationKey(channelId: string, conversationId: string): string {
+  return `${channelId}::${conversationId}`;
 }
 
 function readPositiveIntegerEnv(name: string): number | undefined {

--- a/apps/canvas-workspace/src/plugins/main/channel/core/commands.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/core/commands.ts
@@ -14,6 +14,8 @@ export interface CommandDeps {
   bindings: BindingStore;
   service: CanvasAgentServiceRef;
   sessionRouter: SessionRouter;
+  /** Session currently executing/queued for this topic, if any. */
+  activeSessionId?: string;
   /**
    * Bring the canvas app to the front and open a workspace, for operations
    * that need the UI (e.g. webview/iframe page control). Optional — absent in
@@ -75,17 +77,17 @@ async function scopeLabel(scope: AgentScope): Promise<string> {
 async function migrateConversationSession(
   sourceScope: AgentScope,
   targetScope: AgentScope,
+  channelId: string,
   conversationId: string,
   deps: CommandDeps,
 ): Promise<{ ok: boolean; messageCount?: number; error?: string }> {
-  const sourceSessionId = await deps.sessionRouter.getConversationSessionId(sourceScope, conversationId);
-  if (!sourceSessionId) return { ok: true, messageCount: 0 };
-
-  const copied = await deps.service.copySessionToScope(sourceScope, sourceSessionId, targetScope);
+  const copied = await deps.sessionRouter.copyConversationSession(
+    sourceScope,
+    targetScope,
+    channelId,
+    conversationId,
+  );
   if (!copied.ok) return { ok: false, error: copied.error };
-  if (copied.sessionId) {
-    await deps.sessionRouter.setConversationSession(targetScope, conversationId, copied.sessionId);
-  }
   return { ok: true, messageCount: copied.messageCount ?? 0 };
 }
 
@@ -99,7 +101,7 @@ interface WorkspaceUseResult {
   label: string;
   contextSuffix: string;
   migratedMessageCount?: number;
-  warning?: string;
+  error?: string;
 }
 
 interface WorkspacePickerReplyOptions {
@@ -195,38 +197,47 @@ async function bindConversationToWorkspace(
     ? workspaceScope(previousWorkspaceId)
     : { kind: 'global' };
   const targetScope: AgentScope = workspaceScope(workspaceId);
-  await deps.bindings.bind(msg.channelId, msg.conversationId, workspaceId);
 
   const label = await workspaceLabelById(workspaceId);
   if (options.fresh) {
-    const res = await deps.service.newSessionForScope(targetScope);
-    if (!res.ok) {
+    try {
+      await deps.sessionRouter.createFreshSession(
+        targetScope,
+        msg.channelId,
+        msg.conversationId,
+      );
+    } catch (err) {
       return {
         label,
         contextSuffix: '',
-        warning: `Fresh session could not be started: ${res.error ?? 'unknown error'}`,
+        error: `Fresh session could not be started: ${err instanceof Error ? err.message : String(err)}`,
       };
     }
-    const sessionId = deps.service.getCurrentSessionIdForScope(targetScope);
-    if (sessionId) {
-      await deps.sessionRouter.setConversationSession(targetScope, msg.conversationId, sessionId);
-    }
+    await deps.bindings.bind(msg.channelId, msg.conversationId, workspaceId);
     return { label, contextSuffix: ' Started a fresh session.' };
   }
 
   const shouldMigrate = options.forceMigrate ?? Boolean(options.carry);
   if (!shouldMigrate || sameScope(previousScope, targetScope)) {
+    await deps.bindings.bind(msg.channelId, msg.conversationId, workspaceId);
     return { label, contextSuffix: '' };
   }
 
-  const migrated = await migrateConversationSession(previousScope, targetScope, msg.conversationId, deps);
+  const migrated = await migrateConversationSession(
+    previousScope,
+    targetScope,
+    msg.channelId,
+    msg.conversationId,
+    deps,
+  );
   if (!migrated.ok) {
     return {
       label,
       contextSuffix: '',
-      warning: `Previous chat context could not be migrated: ${migrated.error ?? 'unknown error'}`,
+      error: `Previous chat context could not be migrated: ${migrated.error ?? 'unknown error'}`,
     };
   }
+  await deps.bindings.bind(msg.channelId, msg.conversationId, workspaceId);
   const contextSuffix = migrated.messageCount && migrated.messageCount > 0
     ? ` Brought over ${migrated.messageCount} previous messages.`
     : '';
@@ -249,7 +260,7 @@ export async function handleCommand(
   const [rawCmd, ...rest] = text.slice(1).split(/\s+/);
   const cmd = rawCmd.toLowerCase();
   const arg = rest.join(' ').trim();
-  const { bindings, service, sessionRouter, activateCanvas } = deps;
+  const { bindings, service, sessionRouter, activeSessionId, activateCanvas } = deps;
 
   const requireBound = () => bindings.getBound(msg.channelId, msg.conversationId);
   const currentScope = async (): Promise<AgentScope> => {
@@ -279,9 +290,7 @@ export async function handleCommand(
       const id = await resolveWorkspaceRef(ref);
       if (!id) return textReply(`Workspace not found: ${ref}. Use /list to see available workspaces.`);
       const bound = await bindConversationToWorkspace(msg, deps, id, { forceMigrate: true });
-      if (bound.warning) {
-        return textReply(`✅ This chat is now bound to ${bound.label}.\n⚠️ ${bound.warning}`);
-      }
+      if (bound.error) return textReply(`Failed to bind workspace: ${bound.error}`);
       const suffix = bound.migratedMessageCount && bound.migratedMessageCount > 0
         ? ` Migrated ${bound.migratedMessageCount} previous messages.`
         : '';
@@ -302,11 +311,12 @@ export async function handleCommand(
         carry,
         fresh: parsed.fresh,
       });
+      if (used.error) return textReply(`Failed to switch workspace: ${used.error}`);
       const prefix = parsed.fresh ? 'Using fresh session in' : 'Using';
       if (!activateCanvas) {
         return textReply(
           `✅ ${prefix} ${used.label}.${used.contextSuffix}\n` +
-          `⚠️ Opening the canvas app is not available here.${used.warning ? `\n⚠️ ${used.warning}` : ''}`,
+          `⚠️ Opening the canvas app is not available here.`,
         );
       }
 
@@ -314,7 +324,7 @@ export async function handleCommand(
       const openLine = res.ok
         ? `✅ ${prefix} ${used.label}. Opened in Canvas.${used.contextSuffix}`
         : `✅ ${prefix} ${used.label}.${used.contextSuffix}\n⚠️ Failed to open Canvas: ${res.error ?? 'unknown error'}`;
-      return textReply(used.warning ? `${openLine}\n⚠️ ${used.warning}` : openLine);
+      return textReply(openLine);
     }
 
     case 'unbind': {
@@ -332,18 +342,22 @@ export async function handleCommand(
 
     case 'new': {
       const scope = await currentScope();
-      const res = await service.newSessionForScope(scope);
-      const sessionId = res.ok ? service.getCurrentSessionIdForScope(scope) : null;
-      if (sessionId) {
-        await sessionRouter.setConversationSession(scope, msg.conversationId, sessionId);
+      try {
+        await sessionRouter.createFreshSession(scope, msg.channelId, msg.conversationId);
+        return textReply(`🆕 Started a new session in ${await scopeLabel(scope)}.`);
+      } catch (err) {
+        return textReply(`Failed to start a new session: ${err instanceof Error ? err.message : String(err)}`);
       }
-      return textReply(res.ok
-        ? `🆕 Started a new session in ${await scopeLabel(scope)}.`
-        : `Failed to start a new session: ${res.error}`);
     }
 
     case 'stop': {
-      service.abortScope(await currentScope());
+      const scope = await currentScope();
+      const sessionId = activeSessionId ?? await sessionRouter.getConversationSessionId(
+        scope,
+        msg.channelId,
+        msg.conversationId,
+      );
+      if (sessionId) sessionRouter.abort(scope, sessionId);
       return textReply('🛑 Stop requested.');
     }
 
@@ -351,9 +365,14 @@ export async function handleCommand(
       const scope = await currentScope();
       const list = await service.listSessionsForScope(scope);
       if (list.length === 0) return textReply('No sessions yet.');
+      const selectedSessionId = await sessionRouter.getConversationSessionId(
+        scope,
+        msg.channelId,
+        msg.conversationId,
+      );
       const lines = list
         .slice(0, 15)
-        .map((s, i) => `${i + 1}. ${s.isCurrent ? '(current) ' : ''}${s.date} — ${s.messageCount} msgs`);
+        .map((s, i) => `${i + 1}. ${s.sessionId === selectedSessionId ? '(current) ' : ''}${s.date} — ${s.messageCount} msgs`);
       return textReply(`🗂️ Sessions for ${await scopeLabel(scope)}:\n${lines.join('\n')}\n\nSwitch with /session <number>.`);
     }
 
@@ -370,17 +389,25 @@ export async function handleCommand(
           : list.find((s) => s.sessionId === arg);
       if (!target) return textReply(`Session not found: ${arg}. Use /sessions to list.`);
 
-      if (target.isCurrent) {
-        // Already current, but make sure this conversation owns it going forward.
-        await sessionRouter.setConversationSession(scope, msg.conversationId, target.sessionId);
-        return textReply(`🎯 Already on session ${target.date} (${target.messageCount} msgs).`);
+      try {
+        const previousSessionId = await sessionRouter.getConversationSessionId(
+          scope,
+          msg.channelId,
+          msg.conversationId,
+        );
+        const selectedSessionId = await sessionRouter.setConversationSession(
+          scope,
+          msg.channelId,
+          msg.conversationId,
+          target.sessionId,
+        );
+        const copied = selectedSessionId !== target.sessionId ? ' (isolated copy)' : '';
+        return textReply(previousSessionId === selectedSessionId
+          ? `🎯 Already on session ${target.date} (${target.messageCount} msgs)${copied}.`
+          : `✅ Switched to session ${target.date} (${target.messageCount} msgs)${copied}.`);
+      } catch (err) {
+        return textReply(`Failed to switch session: ${err instanceof Error ? err.message : String(err)}`);
       }
-
-      const res = await service.loadSessionForScope(scope, target.sessionId);
-      if (!res.ok) return textReply(`Failed to switch session: ${res.error ?? 'unknown error'}`);
-      // Pin the choice so the per-conversation router keeps it on later turns.
-      await sessionRouter.setConversationSession(scope, msg.conversationId, target.sessionId);
-      return textReply(`✅ Switched to session ${target.date} (${target.messageCount} msgs).`);
     }
 
     case 'open': {

--- a/apps/canvas-workspace/src/plugins/main/channel/core/inbound-prompt.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/core/inbound-prompt.ts
@@ -1,0 +1,19 @@
+import type { InboundMessage } from './types';
+
+/**
+ * Build the prompt handed to the agent. When the inbound message carried
+ * images, append a note with their local paths so the agent reads them with
+ * `image_analyze` (the vision tool accepts local `imagePaths`). An
+ * image-only message becomes just the note.
+ */
+export function buildAgentPrompt(msg: InboundMessage): string {
+  const text = msg.text.trim();
+  if (!msg.imagePaths?.length) return text;
+
+  const list = msg.imagePaths.map((path) => `- ${path}`).join('\n');
+  const note =
+    `[The user attached ${msg.imagePaths.length} image(s), saved locally at the path(s) below. ` +
+    `To view or analyze them, call image_analyze with these imagePaths:\n${list}]`;
+  return text ? `${text}\n\n${note}` : note;
+}
+

--- a/apps/canvas-workspace/src/plugins/main/channel/core/sessions.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/core/sessions.ts
@@ -1,92 +1,213 @@
-import type { AgentScope, CanvasAgentServiceRef, PluginStore } from '../../../types';
+import type { AgentScope, PluginStore } from '../../../types';
+import type { ConversationRuntimeService } from '../../../../main/agent/conversation-runtime/conversation-service';
 
 const STORE_KEY = 'sessions';
 
 /**
- * Gives each external conversation its own Canvas Agent session, even when
- * several conversations share one agent scope.
- *
- * Canvas keeps a single *current* session per scope; this router maps
- * `scope::conversationId → sessionId` and, before each turn, swaps the scope's
- * current session to the one owned by the conversation (creating it on first
- * contact). Because runs are serialized per scope key, the swap can't race
- * another turn. The map is persisted so conversations keep their history
- * across restarts.
- *
- * Trade-off: the scope's *current* session is shared with the Canvas UI, so
- * the UI for that scope reflects whichever conversation ran last.
+ * Durable `(scope, channel, conversation) -> sessionId` routing for external
+ * chats. Sessions are provisioned and copied through the conversation runtime,
+ * so routing never moves the Canvas UI's current-session pointer.
  */
 export class SessionRouter {
   private map: Record<string, string> = {};
   private loaded = false;
+  private loadFlight: Promise<void> | null = null;
+  private mutationTail: Promise<void> = Promise.resolve();
+  private readonly routeFlights = new Map<string, Promise<string>>();
+  private readonly sessionOwners = new Map<string, string>();
 
   constructor(
-    private readonly service: CanvasAgentServiceRef,
+    private readonly runtime: ConversationRuntimeService,
     private readonly store: PluginStore,
   ) {}
 
   private async ensureLoaded(): Promise<void> {
     if (this.loaded) return;
-    this.map = (await this.store.get<Record<string, string>>(STORE_KEY)) ?? {};
-    this.loaded = true;
+    if (!this.loadFlight) {
+      this.loadFlight = this.store.get<Record<string, string>>(STORE_KEY).then((stored) => {
+        this.map = { ...(stored ?? {}) };
+        this.loaded = true;
+      }).finally(() => {
+        this.loadFlight = null;
+      });
+    }
+    await this.loadFlight;
   }
 
-  private key(scope: AgentScope, conversationId: string): string {
-    const scopeKey = scope.kind === 'global' ? 'global' : `workspace:${scope.workspaceId}`;
-    return `${scopeKey}::${conversationId}`;
+  private scopeKey(scope: AgentScope): string {
+    return scope.kind === 'global' ? 'global' : `workspace:${scope.workspaceId}`;
   }
 
-  /**
-   * Ensure the scope's current session is the one owned by `conversationId`.
-   * Call inside the per-scope run guard, before chat.
-   */
-  async ensureSession(scope: AgentScope, conversationId: string): Promise<void> {
+  private key(scope: AgentScope, channelId: string, conversationId: string): string {
+    return `${this.scopeKey(scope)}::${channelId}::${conversationId}`;
+  }
+
+  private legacyKey(scope: AgentScope, conversationId: string): string {
+    return `${this.scopeKey(scope)}::${conversationId}`;
+  }
+
+  private ownerKey(scope: AgentScope, sessionId: string): string {
+    return `${this.scopeKey(scope)}::${sessionId}`;
+  }
+
+  private runMutation<T>(operation: () => Promise<T>): Promise<T> {
+    const run = this.mutationTail.catch(() => undefined).then(operation);
+    this.mutationTail = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  private async persistMapping(routeKey: string, sessionId: string): Promise<void> {
+    const previous = this.map[routeKey];
+    this.map[routeKey] = sessionId;
+    try {
+      await this.store.set(STORE_KEY, { ...this.map });
+    } catch (err) {
+      if (previous === undefined) delete this.map[routeKey];
+      else this.map[routeKey] = previous;
+      throw err;
+    }
+  }
+
+  private async claimSession(
+    scope: AgentScope,
+    routeKey: string,
+    sessionId: string,
+  ): Promise<string> {
+    const ownerKey = this.ownerKey(scope, sessionId);
+    const owner = this.sessionOwners.get(ownerKey);
+    if (!owner || owner === routeKey) {
+      this.sessionOwners.set(ownerKey, routeKey);
+      return sessionId;
+    }
+
+    // Historical stores could contain duplicate mappings. Fork the durable
+    // history for the later route rather than sharing live runtime state or
+    // deleting either real history.
+    const copied = await this.runtime.copySessionToScope(scope, sessionId, scope);
+    if (!copied.ok || !copied.sessionId) {
+      throw new Error(copied.error ?? 'Could not isolate duplicated session mapping');
+    }
+    this.sessionOwners.set(this.ownerKey(scope, copied.sessionId), routeKey);
+    return copied.sessionId;
+  }
+
+  async ensureSession(
+    scope: AgentScope,
+    channelId: string,
+    conversationId: string,
+  ): Promise<string> {
     await this.ensureLoaded();
-    const key = this.key(scope, conversationId);
-    const desired = this.map[key];
+    const routeKey = this.key(scope, channelId, conversationId);
+    const existing = this.routeFlights.get(routeKey);
+    if (existing) return existing;
 
-    if (desired) {
-      if (this.service.getCurrentSessionIdForScope(scope) === desired) return;
-      await this.service.loadSessionForScope(scope, desired);
-      // loadSession is a no-op when the session no longer exists; confirm it
-      // actually became current, otherwise fall through to a fresh one.
-      if (this.service.getCurrentSessionIdForScope(scope) === desired) return;
-    }
+    const flight = this.runMutation(async () => {
+      const legacyKey = this.legacyKey(scope, conversationId);
+      const mapped = this.map[routeKey] ?? this.map[legacyKey];
+      if (mapped && await this.runtime.hasSession(scope, mapped)) {
+        const claimed = await this.claimSession(scope, routeKey, mapped);
+        if (this.map[routeKey] !== claimed) await this.persistMapping(routeKey, claimed);
+        return claimed;
+      }
 
-    await this.service.newSessionForScope(scope);
-    const fresh = this.service.getCurrentSessionIdForScope(scope);
-    if (fresh) {
-      this.map[key] = fresh;
-      await this.store.set(STORE_KEY, this.map);
+      const created = await this.runtime.provisionSession(scope);
+      if (!created.ok || !created.sessionId) {
+        throw new Error(created.error ?? 'Could not create conversation session');
+      }
+      this.sessionOwners.set(this.ownerKey(scope, created.sessionId), routeKey);
+      await this.persistMapping(routeKey, created.sessionId);
+      return created.sessionId;
+    });
+    this.routeFlights.set(routeKey, flight);
+    try {
+      return await flight;
+    } finally {
+      if (this.routeFlights.get(routeKey) === flight) this.routeFlights.delete(routeKey);
     }
   }
 
-  /**
-   * Point a conversation at a specific existing session id. Used when the
-   * user switches sessions explicitly (e.g. /session N) so the choice sticks
-   * across later turns instead of being overwritten by the mapping.
-   */
+  async createFreshSession(
+    scope: AgentScope,
+    channelId: string,
+    conversationId: string,
+  ): Promise<string> {
+    await this.ensureLoaded();
+    return this.runMutation(async () => {
+      const created = await this.runtime.provisionSession(scope);
+      if (!created.ok || !created.sessionId) {
+        throw new Error(created.error ?? 'Could not create conversation session');
+      }
+      const routeKey = this.key(scope, channelId, conversationId);
+      this.sessionOwners.set(this.ownerKey(scope, created.sessionId), routeKey);
+      await this.persistMapping(routeKey, created.sessionId);
+      return created.sessionId;
+    });
+  }
+
   async setConversationSession(
     scope: AgentScope,
+    channelId: string,
     conversationId: string,
     sessionId: string,
-  ): Promise<void> {
+  ): Promise<string> {
     await this.ensureLoaded();
-    this.map[this.key(scope, conversationId)] = sessionId;
-    await this.store.set(STORE_KEY, this.map);
+    return this.runMutation(async () => {
+      if (!await this.runtime.hasSession(scope, sessionId)) {
+        throw new Error(`Session not found: ${sessionId}`);
+      }
+      const routeKey = this.key(scope, channelId, conversationId);
+      const claimed = await this.claimSession(scope, routeKey, sessionId);
+      await this.persistMapping(routeKey, claimed);
+      return claimed;
+    });
   }
 
-  /**
-   * Return the persisted session id for a conversation/scope pair without
-   * activating or swapping the agent. Used when a channel binds midway through
-   * a global chat and wants to copy that prior conversation into the new
-   * workspace scope.
-   */
   async getConversationSessionId(
     scope: AgentScope,
+    channelId: string,
     conversationId: string,
   ): Promise<string | undefined> {
     await this.ensureLoaded();
-    return this.map[this.key(scope, conversationId)];
+    return this.map[this.key(scope, channelId, conversationId)]
+      ?? this.map[this.legacyKey(scope, conversationId)];
+  }
+
+  async copyConversationSession(
+    sourceScope: AgentScope,
+    targetScope: AgentScope,
+    channelId: string,
+    conversationId: string,
+  ): Promise<{ ok: boolean; sessionId?: string; messageCount?: number; error?: string }> {
+    const sourceSessionId = await this.getConversationSessionId(
+      sourceScope,
+      channelId,
+      conversationId,
+    );
+    if (!sourceSessionId) return { ok: true, messageCount: 0 };
+
+    const copied = await this.runtime.copySessionToScope(
+      sourceScope,
+      sourceSessionId,
+      targetScope,
+    );
+    if (!copied.ok || !copied.sessionId) return copied;
+    try {
+      const sessionId = await this.setConversationSession(
+        targetScope,
+        channelId,
+        conversationId,
+        copied.sessionId,
+      );
+      return { ...copied, sessionId };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  abort(scope: AgentScope, sessionId: string): boolean {
+    return this.runtime.abort(scope, sessionId);
   }
 }

--- a/apps/canvas-workspace/src/plugins/main/channel/core/submission-queue.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/core/submission-queue.ts
@@ -1,0 +1,22 @@
+export interface SubmissionReservation {
+  previous: Promise<void>;
+  release: () => void;
+}
+
+/** Orders submission, never model execution. Early command/failure releases
+ * must still wait for their predecessors or later turns can jump the queue. */
+export class SubmissionQueue {
+  private readonly tails = new Map<string, Promise<void>>();
+
+  reserve(key: string): SubmissionReservation {
+    const previous = this.tails.get(key) ?? Promise.resolve();
+    let release!: () => void;
+    const released = new Promise<void>(resolve => { release = resolve; });
+    const current = Promise.all([previous, released]).then(() => undefined);
+    this.tails.set(key, current);
+    void current.then(() => {
+      if (this.tails.get(key) === current) this.tails.delete(key);
+    });
+    return { previous, release };
+  }
+}

--- a/apps/canvas-workspace/src/plugins/main/channel/index.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/index.ts
@@ -9,6 +9,7 @@ import {
 import { ChannelBridge } from './core/bridge';
 import type { Channel } from './core/types';
 import { activateWorkspaceWindow } from '../../../main/app/window-manager';
+import { getConversationRuntimeService } from '../../../main/agent/conversation-runtime/conversation-ipc';
 
 // Registry of all channel implementations. To add a new channel (Discord,
 // Telegram, WeCom, …) implement the `Channel` interface and add it here —
@@ -67,7 +68,8 @@ export const ChannelMainPlugin: MainCanvasPlugin = {
 
   async activate(ctx: MainCtx): Promise<void> {
     const service = ctx.getAgentService();
-    bridge = new ChannelBridge(service, ctx.store, {
+    const runtime = getConversationRuntimeService(() => service);
+    bridge = new ChannelBridge(service, runtime, ctx.store, {
       activateCanvas: activateWorkspaceWindow,
     });
 

--- a/apps/remote-server/src/core/tools/analyze-image.ts
+++ b/apps/remote-server/src/core/tools/analyze-image.ts
@@ -106,7 +106,7 @@ const toolSchema = z.object({
     .enum(['openai', 'gpt', 'gemini'])
     .optional()
     .describe('Vision provider. Defaults to "openai"/"gpt". Set "gemini" to use Gemini explicitly.'),
-  model: z.string().optional().describe('Vision model name. Defaults to OPENAI_VISION_MODEL or gpt-5.4 for OpenAI; GEMINI_VISION_MODEL or gemini-2.5-flash for Gemini.'),
+  model: z.string().optional().describe('Vision model name. Defaults to OPENAI_VISION_MODEL or gpt-5.6-sol for OpenAI; GEMINI_VISION_MODEL or gemini-2.5-flash for Gemini.'),
   detail: z.enum(['auto', 'low', 'high']).optional().describe('OpenAI image detail level. Only sent for OpenAI/GPT requests. Defaults to "auto".'),
   visionApiMode: z
     .enum(['responses', 'chat_completions', 'auto'])
@@ -134,7 +134,7 @@ interface AnalyzeImageToolContext extends ToolExecutionContext {
 const DEFAULT_GEMINI_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta';
 const DEFAULT_GEMINI_MODEL = 'gemini-2.5-flash';
 const DEFAULT_OPENAI_API_URL = 'https://api.openai.com/v1';
-const DEFAULT_OPENAI_MODEL = 'gpt-5.4';
+const DEFAULT_OPENAI_MODEL = 'gpt-5.6-sol';
 const FIXED_TIMEOUT_MS = 300000;
 const DEFAULT_MAX_IMAGES = 6;
 const DEFAULT_PROMPT = '请按图片顺序描述关键信息，识别文字，提取主体内容，并结合用户上下文回答问题。如果存在多个图片，先分别概述，再总结。';
@@ -148,7 +148,7 @@ interface ResolvedImage {
 export const analyzeImageTool: Tool<AnalyzeImageInput, AnalyzeImageResult> = {
   name: 'analyze_image',
   description:
-    'Analyze one or more local images. Defaults to OpenAI/GPT vision (uses OPENAI_API_KEY plus OPENAI_API_URL, model OPENAI_VISION_MODEL or gpt-5.4) via {apiUrl}/responses input_image. Set provider="gemini" to use Gemini instead. If imagePaths are omitted, automatically uses runContext.latestAttachments from the latest image message.',
+    'Analyze one or more local images. Defaults to OpenAI/GPT vision (uses OPENAI_API_KEY plus OPENAI_API_URL, model OPENAI_VISION_MODEL or gpt-5.6-sol) via {apiUrl}/responses input_image. Set provider="gemini" to use Gemini instead. If imagePaths are omitted, automatically uses runContext.latestAttachments from the latest image message.',
   defer_loading: true,
   inputSchema: toolSchema,
   execute: async (input: AnalyzeImageInput, context?: AnalyzeImageToolContext): Promise<AnalyzeImageResult> => {


### PR DESCRIPTION
## Problem
Feishu topics sharing a workspace were using the legacy workspace-wide chat entry and UI current-session pointer. Simultaneous first contact could bypass the busy guard, reject replies, or persist duplicate topic/session mappings.

## Changes
- Reuse the host's conversation runtime for both Channel and IPC; provision/copy sessions without changing the UI pointer.
- Run separate topic sessions concurrently; order submissions per topic and let the existing runtime queue execute turns FIFO.
- Open reply cards before session provisioning or submission waits; preserve triggering-message reply targets.
- Keep stop, clarification and watchdog actions session-targeted. Disarm watchdogs before final card delivery so an old turn cannot abort its successor.
- Keep host mutation leases around complete turns, including persistence, releasing them before draining the next turn.
- Fail closed on session creation/mapping failure; defer workspace binding until requested session preparation succeeds. Migrate legacy routing keys and fork duplicate mapped histories.
- Reject session/workspace changes while that topic has active/queued turns. Stop and informational commands remain available.
- Split submission ordering and inbound prompt construction out of the bridge (below the 500-line gate); update existing Channel documentation.

## Validation
- Standard scoped harness: **5/5 checks passed**.
- Canvas full suite: **510 test files, 3007 tests passed**.
- Conversation contract/runtime/renderer suite: **65 tests passed**.
- Typecheck, governance guards, IPC/node registry parity: passed.
- Production `pnpm --filter canvas-workspace build`: passed (existing chunk-size warnings).
- `git diff --check`: passed.
- Added red→green regressions for early cards, FIFO across immediate commands, stale scope after switching, persistence lease lifetime, failed fresh-session binding, and late-card watchdog cancellation. Retained command and watchdog behavior coverage.
- Direct self-review against repository standards and the agreed isolation/FIFO/failure-protection requirements; no separate coding agent used for the final work.

## Limitations / manual checks
- No live Feishu end-to-end test or app restart performed; existing installed app is unchanged. No merge/release requested.
- In-memory queued messages are not durable across process crashes/restarts; this is not an exactly-once message broker.
- `/stop` aborts the active topic turn; already queued turns may continue. Session/workspace changes must be retried once the topic becomes idle.
- Historical content already mixed by old mappings cannot be automatically disentangled; forks preserve it rather than deleting history.
- Webview/UI tools still share a single visible canvas. Full release/performance runtime and live two-topic smoke remain manual follow-up.
