### PR TITLE
fix(canvas): resume user_ask after app and Feishu replies

### DIFF
--- a/apps/canvas-workspace/harness/knowledge/chat-sessions.md
+++ b/apps/canvas-workspace/harness/knowledge/chat-sessions.md
@@ -73,6 +73,15 @@ Key invariants and their guards:
 
 - A conversation key is `scopeSessionStoreId(scope) + sessionId`; the store
   mapping is `shared/conversation-runtime.ts` (`conversationKey`).
+- Clarification answers must cross both registries: the conversation runtime
+  accepts the surface reply, and `createConversationRunner` forwards that answer
+  to `CanvasAgent.answerClarification` to release the engine's run-owned wait.
+  `CanvasAgent.chat` treats its clarification callback as a notification; merely
+  returning a promise from that callback does not resume the tool. Publish the
+  external notification only after the conversation wait is registered/active.
+  Guards: `conversation-runtime/conversation-runner.test.ts` and the channel
+  `__tests__/bridge.test.ts` use the real registry's notification-only contract,
+  including reply/stop and topic isolation (not an awaitable mock callback).
 - Runtime queue/abort/clarification/persist are exercised in
   `conversation-runtime/conversation-runtime.test.ts` and
   `conversation-runtime/service-conversation-runtime.test.ts` (parallel runs,

--- a/apps/canvas-workspace/src/main/agent/conversation-runtime/conversation-runner.test.ts
+++ b/apps/canvas-workspace/src/main/agent/conversation-runtime/conversation-runner.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { CanvasAgent } from '../canvas-agent';
+import { ClarificationRegistry } from '../clarification-registry';
+import { createConversationRunner } from './conversation-runner';
+import { ConversationRuntime } from './conversation-runtime';
+
+function setup() {
+  const engineWaits = new ClarificationRegistry();
+  const trace: string[] = [];
+  // Preserve CanvasAgent.chat's real notification-only contract: the engine
+  // waits in its own registry, not on the callback's returned promise.
+  const agent = {
+    chat: vi.fn<Parameters<CanvasAgent['chat']>, ReturnType<CanvasAgent['chat']>>(async (
+      message, _text, _call, _result, _workspaces, notify,
+      _context, _attachments, _start, _delta, _end, _roleStart, _roleEnd, signal,
+    ) => {
+      const answer = await engineWaits.wait(
+        { id: message, question: 'Which option?', timeout: 0 },
+        request => { trace.push(`asked:${request.id}`); notify?.(request); },
+        signal,
+      );
+      trace.push(`engine-resumed:${answer}`);
+      return { response: `answer:${answer}`, stopped: signal?.aborted };
+    }),
+    answerClarification: vi.fn((id: string, answer: string) => engineWaits.answer(id, answer)),
+  };
+  const runtime = new ConversationRuntime({
+    key: { storeId: 'ws-a', sessionId: 'session-a' },
+    loadMessages: async () => [],
+    persist: async () => undefined,
+    runTurn: createConversationRunner(agent as unknown as CanvasAgent),
+  });
+  return { runtime, engineWaits, agent, trace };
+}
+
+describe('conversation runner clarification round-trip', () => {
+  it('resumes the engine wait after the conversation accepts the user reply', async () => {
+    const { runtime, engineWaits, agent, trace } = setup();
+    await runtime.open();
+    const turn = runtime.sendAndWait({ message: 'ask-1' });
+    try {
+      await vi.waitFor(() => expect(runtime.getPendingClarification()?.id).toBe('ask-1'));
+      expect(runtime.answerClarification('ask-1', '中文 answer')).toBe(true);
+      expect(runtime.getPendingClarification()).toBeNull();
+      await vi.waitFor(() => expect(trace).toContain('engine-resumed:中文 answer'), { timeout: 200 });
+      expect(agent.answerClarification).toHaveBeenCalledWith('ask-1', '中文 answer');
+      await expect(turn).resolves.toMatchObject({ response: 'answer:中文 answer' });
+      expect(engineWaits.latest()).toBeNull();
+      expect(runtime.getSnapshot().status).toBe('idle');
+    } finally {
+      runtime.abort();
+      await turn;
+    }
+  });
+
+  it('registers the wait before delivering an external question notification', async () => {
+    const { runtime, trace } = setup();
+    await runtime.open();
+    let matched: boolean | undefined;
+    const turn = runtime.sendAndWait({ message: 'ask-fast' }, {
+      onClarificationRequest: request => {
+        matched = runtime.answerClarification(request.id, 'instant');
+      },
+    });
+    try {
+      await vi.waitFor(() => expect(matched).toBe(true), { timeout: 200 });
+      await vi.waitFor(() => expect(trace).toContain('engine-resumed:instant'), { timeout: 200 });
+      await expect(turn).resolves.toMatchObject({ response: 'answer:instant' });
+    } finally {
+      runtime.abort();
+      await turn;
+    }
+  });
+
+  it('cancels both waits and rejects late replies after stop', async () => {
+    const { runtime, engineWaits } = setup();
+    await runtime.open();
+    const turn = runtime.sendAndWait({ message: 'ask-stop' });
+    await vi.waitFor(() => expect(runtime.getPendingClarification()?.id).toBe('ask-stop'));
+    runtime.abort();
+    await turn;
+    expect(runtime.answerClarification('ask-stop', 'late')).toBe(false);
+    expect(engineWaits.latest()).toBeNull();
+  });
+});

--- a/apps/canvas-workspace/src/main/agent/conversation-runtime/conversation-runner.ts
+++ b/apps/canvas-workspace/src/main/agent/conversation-runtime/conversation-runner.ts
@@ -24,7 +24,18 @@ export function createConversationRunner(agent: CanvasAgent): ConversationRuntim
       (data) => ctx.onToolCall?.(data),
       (data) => ctx.onToolResult?.(data),
       ctx.mentionedWorkspaceIds,
-      (request) => ctx.onClarificationRequest?.(request),
+      (request) => {
+        // CanvasAgent.chat treats this callback as a notification and waits in
+        // its run registry. Forward the conversation-owned answer back to that
+        // registry; returning the promise alone leaves the engine blocked.
+        const answer = ctx.onClarificationRequest?.(request);
+        if (answer) {
+          void answer.then(
+            value => { agent.answerClarification(request.id, value); },
+            () => { agent.answerClarification(request.id, request.defaultAnswer ?? 'No'); },
+          );
+        }
+      },
       {
         ...ctx.requestContext,
         expectedConversationSessionId: ctx.expectedSessionId,

--- a/apps/canvas-workspace/src/main/agent/conversation-runtime/conversation-runtime.ts
+++ b/apps/canvas-workspace/src/main/agent/conversation-runtime/conversation-runtime.ts
@@ -337,12 +337,12 @@ export class ConversationRuntime {
           this.publish();
         },
         onClarificationRequest: (req) => {
-          external?.onClarificationRequest?.(req);
           return this.clarifications.wait(
             req,
             (request) => {
               this.clarification = { ...request };
               this.publish();
+              external?.onClarificationRequest?.(request);
             },
             this.controller?.signal,
           );

--- a/apps/canvas-workspace/src/plugins/main/channel/__tests__/bridge.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/__tests__/bridge.test.ts
@@ -7,6 +7,7 @@ import type {
   PluginStore,
 } from '../../../types';
 import type { CanvasAgent } from '../../../../main/agent/canvas-agent';
+import { ClarificationRegistry } from '../../../../main/agent/clarification-registry';
 import { ConversationRuntimeService } from '../../../../main/agent/conversation-runtime/conversation-service';
 import { buildAgentPrompt, ChannelBridge } from '../core/bridge';
 import type {
@@ -103,7 +104,9 @@ type AgentPlan = (ctx: {
 
 function makeRuntime(plan: AgentPlan): ConversationRuntimeService {
   const sessions = new Map<string, unknown[]>();
+  const clarifications = new ClarificationRegistry();
   const agent = {
+    answerClarification: (id: string, answer: string) => clarifications.answer(id, answer),
     chat: vi.fn(async (...args: unknown[]) => {
       const message = args[0] as string;
       const onClarification = args[5] as ((req: { id: string; question: string }) => Promise<string> | void) | undefined;
@@ -115,7 +118,11 @@ function makeRuntime(plan: AgentPlan): ConversationRuntimeService {
         message,
         sessionId: requestContext?.expectedConversationSessionId ?? '',
         signal,
-        clarify: onClarification,
+        // Like CanvasAgent.chat, wait in the agent registry rather than
+        // incorrectly awaiting the notification callback's return value.
+        clarify: onClarification
+          ? request => clarifications.wait(request, onClarification, signal)
+          : undefined,
       });
     }),
     stopRelay: vi.fn(() => false),


### PR DESCRIPTION
## Problem / root cause
Both the Canvas chat UI and Feishu accept a `user_ask` reply, but the engine never resumes. `ConversationRuntime` resolves its own clarification registry while `CanvasAgent.chat` is still waiting in its run registry. The runner returned the answer promise to a notification-only callback, which ignored it.

## Changes
- Forward the conversation answer to `CanvasAgent.answerClarification` using the exact request ID; fail closed on a rejected answer promise.
- Notify external surfaces only after the conversation wait is registered and active, preventing immediate replies from missing their resolver and queued questions from being shown prematurely.
- Add runner round-trip, immediate-reply, and abort/late-reply regression tests using the real `ClarificationRegistry`.
- Correct the channel test double to preserve the production notification-only contract (the previous awaitable mock hid the bug); retain topic isolation coverage.
- Record the callback ownership invariant in chat lifecycle knowledge.

## Verification
- Before fix: new regression suite **2 failed / 1 passed**: surface answer accepted but engine did not resume; immediate answer failed to match.
- After fix: scoped standard Harness acceptance **6/6 commands passed**.
- Full Canvas suite: **511 files / 3012 tests passed**.
- Conversation-bound acceptance: **68 tests passed**.
- Canvas typecheck and production build passed; existing large-chunk build warnings remain.
- Real Electron app, isolated temporary home, deterministic local Responses API model: submit prompt through the actual composer → `user_ask` question displayed → enter `中文答案已收到` and click Reply → question disappears, tool completes, assistant displays `RESUMED: 中文答案已收到`. Mock server received that exact function-call output. Before/after screenshots were captured and visually inspected, with no visible clipping or layout regression.
- Sibling sweep: renderer conversation IPC and Feishu bridge share the fixed adapter; legacy service answers already go directly to the agent registry and were left unchanged. Registry abort, timeout and serialized-approval tests remain green.

## Remaining verification
A live Feishu account round-trip was not performed; Feishu/channel routing and topic isolation are covered by the automated bridge tests. This PR does not update/restart the user's installed app or publish a release.
