### PR TITLE
feat(canvas): stream Feishu progress with turn-scoped stop controls

### DIFF
--- a/apps/canvas-workspace/harness/tools/feishu-replay/README.md
+++ b/apps/canvas-workspace/harness/tools/feishu-replay/README.md
@@ -1,0 +1,61 @@
+# Offline Feishu replay
+
+A no-account, no-network acceptance surface for the channel transport. It runs
+**production `FeishuStream`, `FeishuRunCard`, card builders, and message helpers**
+against an in-memory SDK adapter. No app credentials, bot, model, or Electron
+session is used. `fetch` is blocked and asserted unused.
+
+## Run
+
+From the repository root:
+
+```bash
+pnpm --filter canvas-workspace exec vitest run harness/tools/feishu-replay/replay.test.ts
+node apps/canvas-workspace/harness/tools/feishu-replay/preview.mjs
+```
+
+The tests write `.harness/feishu-replay/trace.json` under Canvas with the source
+hash, accepted request snapshots, and simulated timings. Failed runs invalidate
+the previous HTML; the generator refuses incomplete traces. The resulting
+`index.html` is standalone and may be opened directly, or served over loopback:
+
+```bash
+python3 -m http.server 4318 --bind 127.0.0.1 --directory apps/canvas-workspace/.harness/feishu-replay
+```
+
+Open `http://127.0.0.1:4318`. Use **检查全部场景** to scan all recorded states at
+680px and 375px card widths: text correspondence, overflow, and preservation of
+collapsed panels during component updates. This is an executable browser check,
+not part of the Node/Vitest pass. Capture and inspect the actual page for visual
+review. **播放**, **下一步**, the slider, and the scene selector replay requests.
+There is no timing compression in playback; gaps reflect the simulated clock.
+
+## Evidence boundary
+
+- Protocol model: checks IDs, increasing sequences, text-target existence,
+  nonempty updates, topic routing, transient rejection recovery, slow-update
+  coalescing, terminal timer cleanup, native timeout supersession, legacy
+  permission fallback, two-message ordering, turn-scoped Stop, and long-text delivery.
+- Browser model: renders the small set of components our run cards use with
+  existing `markdown-it`. Unsupported component tags fail generation rather
+  than disappearing. Content patches update a stable DOM node; response patches preserve the separate
+  process disclosure. Clicking the preview Stop button selects a recorded Stop
+  scenario, rather than cancelling a live task. It does **not**
+  recreate Feishu's native typewriter or loading animations; the displayed
+  `streaming_mode` is actual recorded configuration, not evidence of animation.
+- Neither model proves real API acceptance, permission setup, complete platform
+  schema constraints, rate-limit behavior, or client rendering fidelity. The
+  sequence model follows the documented ordering contract; server enforcement
+  remains an external integration check.
+- Permission fallback uses old whole-message patches. Their timeout path still
+  needs independent final text because they do not provide CardKit sequencing.
+  Those legacy timeout regressions remain in the channel's stream tests.
+
+The official editor redirects anonymous visitors to login. The evaluated
+third-party `open-feishu-card@0.14.5` did not include `collapsible_panel` or native
+streaming configuration support in its published renderer. It is therefore not
+used as an acceptance oracle or added as a dependency.
+
+References: [CardKit text updates](https://open.feishu.cn/document/cardkit-v1/card-element/content.md),
+[official editor](https://open.feishu.cn/tool/cardbuilder),
+[third-party package](https://www.npmjs.com/package/open-feishu-card).

--- a/apps/canvas-workspace/harness/tools/feishu-replay/mock-client.ts
+++ b/apps/canvas-workspace/harness/tools/feishu-replay/mock-client.ts
@@ -1,0 +1,148 @@
+import type * as lark from '@larksuiteoapi/node-sdk';
+
+type Json = Record<string, any>;
+export interface Frame {
+  at: number;
+  operation: string;
+  card: Json | null;
+  cards: Array<{ messageId: string; card: Json }>;
+  messageId?: string;
+  text?: string;
+  sequence?: number;
+  elementId?: string;
+}
+
+/** A deliberately partial protocol model, not Feishu's renderer or validator. */
+export class MockFeishu {
+  readonly frames: Frame[] = [];
+  readonly violations: string[] = [];
+  readonly calls: Array<{ operation: string; at: number; payload: Json }> = [];
+  card: Json | null = null;
+  replyCard: Json | null = null;
+  private sentCards = 0;
+  denyCardkit = false;
+  rejectNextContent = false;
+  contentDelay = 0;
+  private sequence = 0;
+  private appliedSequence = 0;
+  private readonly start = Date.now();
+
+  private record(operation: string, payload: Json = {}): void {
+    this.calls.push({ operation, at: Date.now() - this.start, payload: structuredClone(payload) });
+  }
+
+  private capture(operation: string, data: Partial<Frame> = {}): void {
+    const cards = [this.card && { messageId: 'mock-message', card: this.card }, this.replyCard && { messageId: 'mock-reply', card: this.replyCard }].filter(Boolean) as Array<{ messageId: string; card: Json }>;
+    this.frames.push({ at: Date.now() - this.start, operation, card: structuredClone(this.card), cards: structuredClone(cards), messageId: 'mock-message', ...data });
+  }
+
+  private require(condition: unknown, message: string): asserts condition {
+    if (condition) return;
+    this.violations.push(message);
+    throw new Error(message);
+  }
+
+  private visit(value: unknown, fn: (node: Json) => void): void {
+    if (!value || typeof value !== 'object') return;
+    const node = value as Json;
+    fn(node);
+    Object.values(node).forEach(child => {
+      if (Array.isArray(child)) child.forEach(item => this.visit(item, fn));
+      else if (child && typeof child === 'object') this.visit(child, fn);
+    });
+  }
+
+  private validateCard(card: Json): void {
+    this.require(card.schema === '2.0', 'Expected schema 2.0');
+    this.require(Array.isArray(card.body?.elements), 'Missing body.elements');
+    const ids = new Set<string>();
+    this.visit(card, node => {
+      if (!node.element_id) return;
+      this.require(typeof node.element_id === 'string' && node.element_id.length <= 20, 'Invalid element ID');
+      this.require(!ids.has(node.element_id), `Duplicate element ID: ${node.element_id}`);
+      ids.add(node.element_id);
+    });
+  }
+
+  private begin(operation: string, request: Json): void {
+    this.record(operation, request);
+    this.require(request.path.card_id === 'mock-card', 'Wrong card ID');
+    this.require(Number.isInteger(request.data.sequence) && request.data.sequence > this.sequence, 'Sequence did not increase');
+    this.sequence = request.data.sequence;
+  }
+
+  readonly client = {
+    cardkit: { v1: {
+      card: {
+        create: async (request: Json) => {
+          this.record('card.create', request);
+          if (this.denyCardkit) return { code: 99991672, msg: 'mock: missing cardkit permission' };
+          this.card = JSON.parse(request.data.data);
+          this.validateCard(this.card!);
+          return { code: 0, data: { card_id: 'mock-card' } };
+        },
+        settings: async (request: Json) => {
+          this.begin('card.settings', request);
+          Object.assign(this.card!.config, JSON.parse(request.data.settings).config);
+          this.appliedSequence = request.data.sequence;
+          this.capture('card.settings', { sequence: request.data.sequence });
+          return { code: 0 };
+        },
+        update: async (request: Json) => {
+          this.begin('card.update', request);
+          const card = JSON.parse(request.data.card.data);
+          this.validateCard(card);
+          this.card = card;
+          this.appliedSequence = request.data.sequence;
+          this.capture('card.update', { sequence: request.data.sequence });
+          return { code: 0 };
+        },
+      },
+      cardElement: {
+        content: async (request: Json) => {
+          this.begin('element.content', request);
+          if (this.rejectNextContent) {
+            this.rejectNextContent = false;
+            return { code: 200810, msg: 'mock: transient rejection' };
+          }
+          if (this.contentDelay) await new Promise(resolve => setTimeout(resolve, this.contentDelay));
+          if (request.data.sequence <= this.appliedSequence) return { code: 300317 };
+          this.require(this.card?.config?.streaming_mode === true, 'Content update outside streaming mode');
+          let target: Json | undefined;
+          this.visit(this.card, node => { if (node.element_id === request.path.element_id) target = node; });
+          this.require(target && ['markdown', 'plain_text'].includes(target.tag), 'Text element does not exist');
+          this.require(typeof request.data.content === 'string' && request.data.content.length > 0, 'Empty content update');
+          target.content = request.data.content;
+          this.appliedSequence = request.data.sequence;
+          this.capture('element.content', { sequence: request.data.sequence, elementId: request.path.element_id });
+          return { code: 0 };
+        },
+      },
+    } },
+    im: { message: {
+      create: async (request: Json) => this.send('message.create', request),
+      reply: async (request: Json) => this.send('message.reply', request),
+      patch: async (request: Json) => {
+        this.record('message.patch', request);
+        this.require(['mock-message', 'mock-reply'].includes(request.path.message_id), 'Wrong message ID');
+        const card = JSON.parse(request.data.content); this.validateCard(card);
+        if (request.path.message_id === 'mock-reply') this.replyCard = card;
+        else this.card = card;
+        this.capture('message.patch', { messageId: request.path.message_id });
+        return { code: 0 };
+      },
+    } },
+  } as unknown as lark.Client;
+
+  private send(operation: string, request: Json): Json {
+    this.record(operation, request);
+    const data = JSON.parse(request.data.content);
+    if (request.data.msg_type === 'interactive') {
+      if (data.type === 'card') this.require(data.data.card_id === 'mock-card', 'Wrong entity reference');
+      else { this.validateCard(data); if (this.sentCards === 0) this.card = data; else this.replyCard = data; }
+      this.sentCards++;
+      this.capture(operation, { messageId: this.sentCards === 1 ? 'mock-message' : 'mock-reply' });
+    } else this.capture(operation, { text: data.text });
+    return { code: 0, data: { message_id: this.sentCards <= 1 ? 'mock-message' : 'mock-reply' } };
+  }
+}

--- a/apps/canvas-workspace/harness/tools/feishu-replay/preview-client.js
+++ b/apps/canvas-workspace/harness/tools/feishu-replay/preview-client.js
@@ -1,0 +1,124 @@
+(() => {
+  const trace = JSON.parse(document.querySelector('#trace').textContent);
+  const $ = id => document.getElementById(id);
+  const picker = $('scenario');
+  trace.scenarios.forEach((scenario, index) => {
+    const option = document.createElement('option'); option.value = index; option.textContent = scenario.name;
+    picker.appendChild(option);
+  });
+  let position = 0;
+  let timer;
+  const scenario = () => trace.scenarios[Number(picker.value)];
+  function pause() { clearTimeout(timer); timer = undefined; $('play').textContent = '播放'; }
+  function apply(index, incremental = false) {
+    const frames = scenario().frames;
+    const frame = frames[index];
+    if (!incremental) $('card').innerHTML = frame.html;
+    else {
+      for (const entry of frame.renderedCards) {
+        let message = [...$('card').querySelectorAll('[data-message]')].find(node => node.dataset.message === entry.messageId);
+        if (!message) {
+          const template = document.createElement('template'); template.innerHTML = frame.html;
+          message = [...template.content.querySelectorAll('[data-message]')].find(node => node.dataset.message === entry.messageId);
+          $('card').appendChild(message);
+        } else if (entry.messageId === frame.messageId && !frame.text) {
+          if (frame.operation === 'element.content') {
+            const element = [...message.querySelectorAll('[data-element]')].find(node => node.dataset.element === frame.elementId);
+            if (!element) throw new Error('Replay text target is missing');
+            element.innerHTML = frame.texts[frame.elementId];
+          } else if (frame.operation !== 'card.settings') message.querySelector('article').innerHTML = entry.html;
+        }
+      }
+    }
+    $('fallback').replaceChildren();
+    for (const item of frames.slice(0, index + 1).filter(item => item.text)) {
+      const text = document.createElement('p'); text.textContent = item.text; $('fallback').appendChild(text);
+    }
+    position = index; $('position').value = index;
+    $('clock').textContent = `${(frame.at / 1000).toFixed(1)}s · ${index + 1}/${frames.length}`;
+    $('operation').textContent = frame.operation + (frame.elementId ? ` → ${frame.elementId}` : '');
+    const streaming = frame.card?.config?.streaming_mode === true;
+    $('native').textContent = streaming ? 'streaming_mode = true' : 'streaming_mode = false';
+    $('native').dataset.streaming = String(streaming);
+    $('json').textContent = JSON.stringify(frame.cards, null, 2);
+    $('next').disabled = index === frames.length - 1;
+    $('end').disabled = index === frames.length - 1;
+  }
+  function reset() {
+    pause(); $('position').max = scenario().frames.length - 1;
+    $('note').textContent = scenario().note;
+    apply(0);
+  }
+  function tick() {
+    const frames = scenario().frames;
+    if (position === frames.length - 1) return pause();
+    const gap = Math.max(100, frames[position + 1].at - frames[position].at);
+    timer = setTimeout(() => { apply(position + 1, true); tick(); }, gap);
+  }
+  picker.addEventListener('change', reset);
+  $('reset').onclick = reset;
+  $('play').onclick = () => {
+    if (timer) return pause();
+    if (position === scenario().frames.length - 1) apply(0);
+    $('play').textContent = '暂停'; tick();
+  };
+  $('next').onclick = () => { pause(); apply(position + 1, true); };
+  $('end').onclick = () => { pause(); apply(scenario().frames.length - 1); };
+  $('position').oninput = event => { pause(); apply(Number(event.target.value)); };
+  $('width').onclick = () => {
+    const narrow = $('conversation').classList.toggle('narrow');
+    $('width').textContent = narrow ? '切到桌面宽度' : '切到 375px';
+  };
+  $('card').onclick = event => {
+    if (!event.target.closest('[data-stop]')) return;
+    const index = trace.scenarios.findIndex(item => item.name === '停止任务');
+    if (index < 0) return;
+    picker.value = index; reset();
+    const stopping = scenario().frames.findIndex(frame => JSON.stringify(frame.cards).includes('正在停止'));
+    if (stopping >= 0) apply(stopping);
+    $('note').textContent = '正在回放已录制的停止流程；没有真实任务被取消。';
+  };
+  $('verify').onclick = () => {
+    pause();
+    const original = picker.value;
+    const originalPosition = position;
+    const wasNarrow = $('conversation').classList.contains('narrow');
+    let checkedFrames = 0;
+    let preservedPanels = 0;
+    const failures = [];
+    for (const narrow of [false, true]) {
+      $('conversation').classList.toggle('narrow', narrow);
+      for (let item = 0; item < trace.scenarios.length; item++) {
+        picker.value = item; reset();
+        for (let index = 0; index < scenario().frames.length; index++) {
+          const frame = scenario().frames[index];
+          const panel = $('card').querySelector('details');
+          if (panel) panel.open = false;
+          apply(index, index > 0);
+          if (index > 0 && (frame.operation === 'element.content' || frame.operation === 'card.settings' || frame.messageId === 'mock-reply') && panel) {
+            if ($('card').querySelector('details') !== panel || panel.open) failures.push('折叠状态丢失');
+            else preservedPanels++;
+          }
+          // Open content for layout checks, including long code at narrow width.
+          $('card').querySelectorAll('details').forEach(node => { node.open = true; });
+          if ($('card').scrollWidth > $('card').clientWidth + 1) failures.push(`${scenario().name}: 卡片横向溢出`);
+          if ($('conversation').scrollWidth > $('conversation').clientWidth + 1) failures.push(`${scenario().name}: 会话横向溢出`);
+          for (const node of $('card').querySelectorAll('[data-element]')) {
+            const expected = document.createElement('div'); expected.innerHTML = frame.texts[node.dataset.element];
+            if (node.textContent !== expected.textContent) failures.push(`${scenario().name}: 文本与请求不一致`);
+          }
+          checkedFrames++;
+        }
+      }
+    }
+    picker.value = original; reset(); apply(originalPosition);
+    $('conversation').classList.toggle('narrow', wasNarrow);
+    $('checks').hidden = false;
+    $('checks').textContent = JSON.stringify({
+      status: failures.length ? 'failed' : 'passed', scenarios: trace.scenarios.length,
+      checkedFrames, preservedPanels, widths: [680, 375], failures,
+      unverified: ['飞书真实渲染与动画', '服务端完整校验', '真实权限与网络'],
+    }, null, 2);
+  };
+  reset();
+})();

--- a/apps/canvas-workspace/harness/tools/feishu-replay/preview.css
+++ b/apps/canvas-workspace/harness/tools/feishu-replay/preview.css
@@ -1,0 +1,34 @@
+* { box-sizing: border-box; }
+body { margin: 0; background: #f6f7f9; color: #20242b; font: 14px/1.65 -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+main { max-width: 1000px; margin: 36px auto; padding: 0 24px; }
+.eyebrow { font-size: 11px; letter-spacing: .12em; color: #727882; }
+h1 { margin: 4px 0; font-size: 25px; font-weight: 600; }
+header p { margin: 8px 0 24px; color: #626974; }
+.controls { padding: 16px; background: white; border: 1px solid #e0e3e8; border-radius: 8px; }
+label { display: flex; align-items: center; gap: 12px; }
+select, button { font: inherit; color: inherit; background: white; border: 1px solid #d4d8df; border-radius: 5px; padding: 5px 10px; }
+button { cursor: pointer; } button:hover { background: #f1f3f5; } button:disabled { opacity: .45; cursor: default; }
+button:focus-visible, select:focus-visible, input:focus-visible, summary:focus-visible { outline: 2px solid #356fe0; outline-offset: 3px; }
+.buttons { display: flex; flex-wrap: wrap; gap: 8px; margin: 12px 0; }
+.scrubber input { flex: 1; min-width: 40px; } output { font-variant-numeric: tabular-nums; min-width: 100px; text-align: right; }
+.coverage { font-size: 12px; color: #5d6470; margin: 16px 0; }
+#note:not(:empty) { background: #fff3d9; border-left: 3px solid #b8811a; padding: 10px 14px; margin-bottom: 16px; }
+.stage { background: #edf0f4; border: 1px solid #e0e3e8; border-radius: 8px; padding: 24px; }
+#conversation { width: 100%; max-width: 680px; margin: 0 auto; } #conversation.narrow { max-width: 375px; }
+.sender { display: flex; gap: 8px; align-items: center; margin: 0 0 10px; font-size: 12px; }
+.avatar { display: grid; place-items: center; width: 24px; height: 24px; border-radius: 50%; background: #dce3ea; color: #3c4b60; }
+.bot { color: #7b8390; font-size: 11px; }
+.message-card, #fallback p { background: white; border: 1px solid #dfe3e8; border-radius: 6px; padding: 14px 16px; overflow-wrap: anywhere; min-width: 0; }
+#fallback p { margin-top: 12px; }
+#card details { min-width: 0; } summary { cursor: pointer; } #card summary > .text { display: inline; } #card summary p { display: inline; }
+.timeline { margin: 8px 0 12px; padding: 10px 12px; background: #f7f8fa; border-radius: 4px; }
+.text p { margin: 0 0 8px; } .text p:last-child { margin-bottom: 0; }
+.text:empty { display: none; } .notation { font-size: 12px; } .muted { color: #7b818b; } .error { color: #bc3434; }
+.text h2 { font-size: 17px; margin: 12px 0 8px; } .text ul { padding-left: 20px; }
+pre { overflow-x: auto; max-width: 100%; white-space: pre; padding: 10px; background: #f5f6f8; border-radius: 4px; font: 12px/1.5 ui-monospace, monospace; }
+footer { display: flex; justify-content: space-between; flex-wrap: wrap; gap: 8px; font: 11px/1.6 ui-monospace, monospace; color: #737b86; margin: 12px 0; }
+.requests { font-size: 12px; color: #636b77; }
+@media (max-width: 600px) { main { padding: 0 12px; margin: 20px auto; } .stage { padding: 12px; } h1 { font-size: 21px; } }
+
+.message + .message { margin-top: 18px; }
+.stop-button { display: block; margin-top: 12px; color: #c43d3d; border-color: #e4bdbd; padding: 2px 10px; font-size: 12px; }

--- a/apps/canvas-workspace/harness/tools/feishu-replay/preview.mjs
+++ b/apps/canvas-workspace/harness/tools/feishu-replay/preview.mjs
@@ -1,0 +1,49 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import MarkdownIt from 'markdown-it';
+
+const folder = new URL('../../../.harness/feishu-replay/', import.meta.url);
+const trace = JSON.parse(await readFile(new URL('trace.json', folder), 'utf8'));
+if (trace.status !== 'passed') throw new Error('Run the replay tests successfully before generating the preview');
+const md = new MarkdownIt({ html: false, linkify: false, breaks: true });
+const escape = value => String(value).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;');
+const markdown = value => md.render(value ?? '')
+  .replaceAll('&lt;font color=&quot;grey&quot;&gt;', '<span class="muted">')
+  .replaceAll('&lt;font color=&quot;red&quot;&gt;', '<span class="error">')
+  .replaceAll('&lt;/font&gt;', '</span>');
+const supported = new Set(['markdown', 'plain_text', 'collapsible_panel', 'button']);
+function render(node, texts) {
+  if (!supported.has(node.tag)) throw new Error(`Preview does not support ${node.tag}; add coverage explicitly`);
+  if (node.tag === 'button') return `<button class="stop-button" data-stop ${node.disabled ? 'disabled' : ''}>${escape(node.text.content)}</button>`;
+  const id = node.element_id ? ` data-element="${escape(node.element_id)}"` : '';
+  if (node.tag === 'collapsible_panel') {
+    return `<details ${node.expanded ? 'open' : ''}><summary>${render(node.header.title, texts)}</summary><div class="timeline">${node.elements.map(child => render(child, texts)).join('')}</div></details>`;
+  }
+  const content = node.tag === 'markdown' ? markdown(node.content) : escape(node.content);
+  if (node.element_id) texts[node.element_id] = content;
+  return `<div class="text ${escape(node.text_size ?? 'normal')}"${id}>${content}</div>`;
+}
+for (const scenario of trace.scenarios) {
+  for (const frame of scenario.frames) {
+    frame.texts = {};
+    frame.renderedCards = frame.cards.map(({ messageId, card }) => ({ messageId, html: card.body.elements.map(node => render(node, frame.texts)).join('') }));
+    frame.html = frame.renderedCards.map(({ messageId, html }) => `<div class="message" data-message="${escape(messageId)}"><div class="sender"><span class="avatar">P</span>Pulse <span class="bot">测试回放</span></div><article class="message-card">${html}</article></div>`).join('');
+  }
+}
+const css = await readFile(new URL('preview.css', import.meta.url), 'utf8');
+const js = await readFile(new URL('preview-client.js', import.meta.url), 'utf8');
+const data = JSON.stringify(trace).replaceAll('<', '\\u003c');
+const html = `<!doctype html><html lang="zh-CN"><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:; connect-src 'none'">
+<title>飞书卡片 · 离线回放</title><style>${css}</style>
+<body><main><header><span class="eyebrow">PULSE / CHANNEL TEST</span><h1>飞书卡片 · 离线回放</h1>
+<p>真实发送代码产生的请求记录。渲染由本地模拟器完成，无登录、无网络请求。</p></header>
+<section class="controls" aria-label="回放控制"><label>场景 <select id="scenario" aria-label="场景"></select></label>
+<div class="buttons"><button id="reset">回到开始</button><button id="play">播放</button><button id="next">下一步</button><button id="end">完成状态</button><button id="width">切到 375px</button><button id="verify">检查全部场景</button></div>
+<label class="scrubber">事件 <input id="position" type="range" min="0" value="0"><output id="clock"></output></label></section>
+<div class="coverage"><strong>已验证：</strong>真实请求路径、更新顺序、失败恢复、最终内容。<br><strong>未验证：</strong>飞书官方样式与动画、服务端完整校验及真实权限。此页不模拟原生 loading 动画。</div>
+<pre id="checks" aria-live="polite" hidden></pre><div id="note" role="note"></div><section class="stage"><div id="conversation"><div id="card"></div><div id="fallback"></div></div></section>
+<footer><span id="operation"></span><span id="native"></span></footer>
+<details class="requests"><summary>查看当前卡片 JSON</summary><pre id="json"></pre></details>
+</main><script id="trace" type="application/json">${data}</script><script>${js}</script></body></html>`;
+await writeFile(new URL('index.html', folder), html);
+console.log(`Offline preview: ${new URL('index.html', folder).pathname}`);

--- a/apps/canvas-workspace/harness/tools/feishu-replay/replay.test.ts
+++ b/apps/canvas-workspace/harness/tools/feishu-replay/replay.test.ts
@@ -1,0 +1,166 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+import { createHash } from 'node:crypto';
+import { FeishuStream } from '../../../src/plugins/main/channel/channels/feishu/feishu-stream';
+import { FeishuRunActions } from '../../../src/plugins/main/channel/channels/feishu/run-actions';
+import { MockFeishu } from './mock-client';
+
+const output = fileURLToPath(new URL('../../../.harness/feishu-replay/trace.json', import.meta.url));
+let sourceHash = '';
+const traces: Array<{ name: string; note: string; frames: MockFeishu['frames']; calls: MockFeishu['calls'] }> = [];
+const target = { requesterId: 'mock-user', chatId: 'mock-chat', isGroup: true, threadId: 'mock-topic', triggerMessageId: 'mock-trigger' };
+const wait = (ms = 800) => vi.advanceTimersByTimeAsync(ms);
+
+function finish(mock: MockFeishu, name: string, note = '') {
+  expect(mock.violations).toEqual([]);
+  expect(fetch).not.toHaveBeenCalled();
+  for (const call of mock.calls.filter(call => call.operation === 'message.reply')) {
+    expect(call.payload.path.message_id).toBe('mock-trigger');
+    expect(call.payload.data.reply_in_thread).toBe(true);
+  }
+  traces.push({ name, note, frames: mock.frames, calls: mock.calls });
+}
+
+beforeAll(async () => {
+  await mkdir(dirname(output), { recursive: true });
+  await writeFile(new URL('../../../.harness/feishu-replay/index.html', import.meta.url), '<meta charset="utf-8"><p>回放正在验证，完成后请运行 preview.mjs 生成预览。</p>');
+  const hash = createHash('sha256');
+  for (const file of ['feishu-stream.ts', 'run-card.ts', 'card.ts', 'feishu-client.ts', 'run-actions.ts']) {
+    hash.update(file);
+    hash.update(await readFile(new URL(`../../../src/plugins/main/channel/channels/feishu/${file}`, import.meta.url)));
+  }
+  sourceHash = hash.digest('hex');
+  await writeFile(output, JSON.stringify({ status: 'running', scenarios: [] }));
+});
+beforeEach(() => {
+  vi.useFakeTimers(); vi.setSystemTime(0);
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.stubGlobal('fetch', vi.fn(() => { throw new Error('Replay must not access the network'); }));
+});
+afterEach(() => { vi.useRealTimers(); vi.restoreAllMocks(); vi.unstubAllGlobals(); });
+afterAll(async () => {
+  await writeFile(output, JSON.stringify({
+    sourceHash,
+    status: traces.length === 8 ? 'passed' : 'incomplete',
+    boundary: 'Real FeishuStream and client helpers; simulated SDK responses and browser renderer. No account or network.',
+    scenarios: traces,
+  }, null, 2));
+});
+
+describe('offline Feishu event replay', () => {
+  it('replays waiting, streamed input, tools, thinking, answer, and completion', async () => {
+    const mock = new MockFeishu();
+    const stream = new FeishuStream(mock.client, target);
+    await stream.init(); stream.onRunStart(() => {}); await wait(2400);
+    stream.onText('我先检查仓库入口和当前工作区。'); await wait();
+    stream.onToolInputStart({ id: 'tool-1', toolName: 'bash' });
+    stream.onToolInputDelta({ id: 'tool-1', delta: '{"command":"git sta' }); await wait();
+    expect(JSON.stringify(mock.card)).toContain('git sta');
+    stream.onToolInputDelta({ id: 'tool-1', delta: 'tus --short"}' }); await wait();
+    stream.onToolInputEnd({ id: 'tool-1' });
+    stream.onToolCall('bash', { command: 'git status --short' }, 'tool-1'); await wait(1600);
+    stream.onToolResult({ name: 'bash', result: 'clean', toolCallId: 'tool-1' }); await wait();
+    expect(JSON.stringify(mock.card)).toContain('Thinking');
+    stream.onText('仓库状态已确认，正在整理目录说明。\n\n'); await wait();
+    for (const delta of ['仓库', '读取完成。\n\n', '**结论**：', '工作区干净，', '可以开始下一步。']) {
+      stream.onText(delta); await wait();
+    }
+    await stream.onDone('仓库读取完成。\n\n**结论**：工作区干净，可以开始下一步。');
+    expect(mock.card?.config?.streaming_mode).not.toBe(true);
+    expect(JSON.stringify(mock.card)).toContain('Completed');
+    expect(JSON.stringify(mock.card)).toContain('我先检查仓库入口');
+    expect(JSON.stringify(mock.card)).not.toContain('可以开始下一步');
+    expect(JSON.stringify(mock.replyCard)).toContain('可以开始下一步');
+    const count = mock.calls.length; await wait(6000); expect(mock.calls).toHaveLength(count);
+    expect(mock.calls.filter(c => c.operation === 'message.reply')).toHaveLength(2);
+    finish(mock, '完整流程');
+  });
+
+  it('renders an error and closes streaming', async () => {
+    const mock = new MockFeishu(); const stream = new FeishuStream(mock.client, target);
+    await stream.init(); stream.onRunStart(() => {}); stream.onText('正在读取仓库'); await wait();
+    await stream.onError('读取失败，请检查工作区路径。');
+    expect(mock.card?.config?.streaming_mode).not.toBe(true);
+    expect(JSON.stringify(mock.replyCard)).toContain('读取失败');
+    const count = mock.calls.length; await wait(6000); expect(mock.calls).toHaveLength(count);
+    finish(mock, '执行报错');
+  });
+
+  it('falls back to legacy cards without CardKit permission', async () => {
+    const mock = new MockFeishu(); mock.denyCardkit = true;
+    const stream = new FeishuStream(mock.client, target);
+    await stream.init(); stream.onRunStart(() => {}); stream.onText('兼容模式仍然有结果'); await wait();
+    await stream.onDone('兼容模式仍然有结果');
+    expect(mock.calls.some(c => c.operation === 'message.patch')).toBe(true);
+    expect(mock.calls.some(c => c.operation === 'element.content')).toBe(false);
+    finish(mock, '权限不足', '整卡更新降级，不提供原生打字机动画。');
+  });
+
+  it('recovers from a rejected content update without losing accumulated text', async () => {
+    const mock = new MockFeishu(); const stream = new FeishuStream(mock.client, target);
+    await stream.init(); stream.onRunStart(() => {}); mock.rejectNextContent = true;
+    stream.onText('第一段'); await wait(); stream.onText('，第二段'); await wait();
+    expect(JSON.stringify(mock.card)).toContain('第一段，第二段');
+    await stream.onDone('第一段，第二段');
+    const updates = mock.calls.filter(c => c.operation === 'element.content');
+    expect(updates.length).toBeGreaterThanOrEqual(2);
+    finish(mock, '短暂拒绝后恢复');
+  });
+
+  it('coalesces slow updates and delivers completion after the active request', async () => {
+    const mock = new MockFeishu(); const stream = new FeishuStream(mock.client, target);
+    await stream.init(); stream.onRunStart(() => {}); mock.contentDelay = 2400;
+    stream.onText('第一段'); await wait(); stream.onText('第二段'); await wait(); stream.onText('第三段');
+    const done = stream.onDone('最终结果'); await wait(5500); await done;
+    expect(JSON.stringify(mock.replyCard)).toContain('最终结果');
+    expect(mock.calls.filter(c => c.operation === 'element.content')).toHaveLength(2);
+    const count = mock.calls.length; await wait(6000); expect(mock.calls).toHaveLength(count);
+    finish(mock, '慢请求与收尾');
+  });
+
+  it('supersedes a late native request and closes the final card', async () => {
+    const mock = new MockFeishu(); const stream = new FeishuStream(mock.client, target);
+    await stream.init(); stream.onRunStart(() => {}); mock.contentDelay = 15000;
+    stream.onToolCall('read', { path: '/demo/README.md' }, 'tool-1'); stream.onText('旧进度'); await wait();
+    const done = stream.onDone('最终结果'); await wait(10000); await done; await wait(6000);
+    expect(mock.frames.filter(frame => frame.text)).toHaveLength(0);
+    expect(JSON.stringify(mock.replyCard)).toContain('最终结果');
+    expect(mock.card?.config?.streaming_mode).not.toBe(true);
+    expect(mock.calls.filter(c => c.operation === 'element.content')).toHaveLength(1);
+    finish(mock, '请求超时后迟到', '原生 CardKit 使用递增序号收尾，迟到的旧请求不能覆盖最终卡片。');
+  });
+
+  it('keeps long Chinese markdown, code, and tool details inspectable', async () => {
+    const mock = new MockFeishu(); const stream = new FeishuStream(mock.client, target);
+    await stream.init(); stream.onRunStart(() => {});
+    stream.onToolCall('read', { path: '/demo/非常长的中文文件名称用于检查窄屏换行和溢出情况.md' }, 'tool-1'); await wait();
+    const text = '## 检查结果\n\n' + '这是用于检查窄屏显示的说明文字。'.repeat(30) +
+      '\n\n```ts\nconst example = "' + 'long_unbroken_value_'.repeat(12) + '";\n```\n\n- 中文条目\n- English item';
+    stream.onText(text); await wait(); stream.onToolResult({ name: 'read', result: 'ok', toolCallId: 'tool-1' });
+    await stream.onDone(text);
+    expect(JSON.stringify(mock.replyCard)).toContain('English item');
+    finish(mock, '长文本与窄屏');
+  });
+  it('stops only the active originating user turn and removes its button on completion', async () => {
+    const mock = new MockFeishu(); const actions = new FeishuRunActions();
+    const stop = vi.fn(); const stream = new FeishuStream(mock.client, target, actions);
+    await stream.init(); stream.onRunStart(stop); await wait();
+    stream.onText('正在检查仓库结构。'); await wait();
+    const button = mock.replyCard!.body.elements.find((item: any) => item.tag === 'button');
+    const event = { context: { open_message_id: 'mock-reply' }, operator: { open_id: 'mock-user' }, action: { value: button.value } };
+    actions.handle({ ...event, operator: { open_id: 'another-user' } }); expect(stop).not.toHaveBeenCalled();
+    actions.handle(event); expect(stop).toHaveBeenCalledOnce(); await wait();
+    expect(JSON.stringify(mock.replyCard)).toContain('正在停止');
+    await stream.onDone('正在检查仓库结构。', { stopped: true });
+    expect(JSON.stringify(mock.card)).toContain('正在检查仓库结构。');
+    expect(JSON.stringify(mock.card)).toContain('Stopped');
+    expect(JSON.stringify(mock.replyCard)).toContain('已停止');
+    expect(mock.replyCard!.body.elements.some((item: any) => item.tag === 'button')).toBe(false);
+    actions.handle(event); expect(stop).toHaveBeenCalledOnce();
+    finish(mock, '停止任务', '按钮绑定发起人和当前回复；旧按钮不能停止后续任务。');
+  });
+
+});

--- a/apps/canvas-workspace/harness/tools/feishu-replay/tsconfig.json
+++ b/apps/canvas-workspace/harness/tools/feishu-replay/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "target": "ES2022", "module": "ESNext", "moduleResolution": "Bundler",
+    "strict": true, "skipLibCheck": true, "noEmit": true, "types": ["node"]
+  },
+  "include": ["mock-client.ts", "replay.test.ts"]
+}

--- a/apps/canvas-workspace/harness/validate/validation.yaml
+++ b/apps/canvas-workspace/harness/validate/validation.yaml
@@ -348,3 +348,13 @@ pathRules:
       - pnpm --filter canvas-workspace perf:report
     manual:
       - pnpm --filter canvas-workspace perf:webview-load:ab
+
+  # Offline protocol replay plus a standalone, explicitly simulated card preview.
+  - name: feishu-replay
+    paths:
+      - harness/tools/feishu-replay/**
+      - src/plugins/main/channel/channels/feishu/**
+    required:
+      - pnpm --filter canvas-workspace exec tsc --noEmit -p harness/tools/feishu-replay/tsconfig.json
+      - pnpm --filter canvas-workspace exec vitest run harness/tools/feishu-replay/replay.test.ts
+      - node apps/canvas-workspace/harness/tools/feishu-replay/preview.mjs

--- a/apps/canvas-workspace/src/plugins/main/channel/README.md
+++ b/apps/canvas-workspace/src/plugins/main/channel/README.md
@@ -11,10 +11,12 @@ WeCom later is a matter of implementing one interface.
 - Resolves which canvas workspace a conversation talks to (**explicit, sticky**
   binding — established with a light first-contact picker).
 - Drives the host's conversation-owned runtime for that workspace and streams the
-  agent's output back into the channel (Feishu: a single interactive card
-  that is progressively patched — tool calls accumulate as a live ⏳/✅ list
-  that folds into a collapsible panel once the run finishes; images are sent
-  as separate messages).
+  agent's output back into the channel. Feishu sends a native streamed process
+  card, followed by a separate response card. Public assistant text and tool
+  actions remain in chronological order in the process disclosure. The response
+  shows execution status and a Stop button, then becomes the final answer in
+  place. A trailing copy of that final answer is removed from the process log.
+  Images are sent as separate messages.
 - Supports clarification round-trips, abort, and session commands.
 
 The plugin is **inert unless explicitly opted in**. `enabledWhen` requires
@@ -33,9 +35,14 @@ relaunch (the flag is read at plugin registration time).
 1. Create a **self-built app** in the Feishu Open Platform.
 2. Event subscription: choose **long-connection (WebSocket)** mode and
    subscribe to `im.message.receive_v1`. No public URL is needed — the
-   canvas app dials out, so it works behind NAT.
+   canvas app dials out, so it works behind NAT. Configure the card action
+   callback `card.action.trigger` on the same long connection for Stop and
+   workspace-picker buttons.
 3. Grant scopes: `im:message` (receive), `im:message:send_as_bot` (send),
-   and `im:resource` (image upload, optional).
+   `cardkit:card:write` (native streaming),
+   and `im:resource` (image upload, optional). If CardKit entity creation fails
+   (including missing permission), the run falls back to ordinary message-card
+   patches. Native client animation is unavailable in that fallback.
 4. Provide credentials, either way:
 
    - **From the UI (recommended):** Settings → Experimental → turn on
@@ -233,6 +240,9 @@ channels/
     feishu-channel.ts  WSClient long-connection + card ChannelStream
     feishu-client.ts   Lark SDK message/card/image helpers
     card.ts            interactive-card builders + tool hints
+    feishu-stream.ts   event accumulation, throttling, coalescing, timeout fallback
+    run-card.ts        native CardKit entity / element transport, legacy fallback
+    run-actions.ts     per-turn, requester-and-message-checked Stop callbacks
 index.ts             ChannelMainPlugin (registered in built-in.ts)
 ```
 
@@ -270,3 +280,41 @@ The plugin relies on two small extension points on the canvas plugin system:
 
 This plugin is self-contained and does **not** depend on `apps/remote-server`;
 the Feishu helpers are copied, not imported.
+
+### Feishu streaming transport
+
+CardKit uses stable text element IDs and strictly increasing sequence numbers.
+Unchanged text is skipped. Network updates remain throttled and coalesced; the
+client prints appended text every 30 ms using the fast strategy, so it does not
+build up a slow typing backlog. Completion closes streaming mode before replacing
+the final layout. Native timeouts cancel remaining calls in the abandoned progress update; a final
+update with a newer sequence closes streaming and supersedes late progress.
+Legacy message-patch timeouts retain the independent text fallback.
+
+The native path requires `cardkit:card:write`. Contract tests mock CardKit and do
+not prove client rendering, loading animation, or visual cadence. Validate those
+in a real Feishu chat with an authorized test bot after changing the transport.
+See [Feishu streaming cards](https://open.feishu.cn/document/uAjLw4CM/ukzMukzMukzM/feishu-cards/streaming-updates-openapi-overview)
+and [streaming text](https://open.feishu.cn/document/cardkit-v1/card-element/content.md).
+
+For account-free regression checks and a local request replay, use the
+[offline Feishu replay](../../../../harness/tools/feishu-replay/README.md).
+Its browser renderer is a simulation; it does not certify native animations.
+
+### Turn-scoped Stop button
+
+`ChannelStream.onRunStart` supplies a stop closure only when the runtime starts
+that specific queued turn. The reply button remains disabled before that point.
+The Feishu channel checks its ephemeral token, original response message ID, and
+initiating user's open ID before accepting a Stop action. Completed/failed turns
+remove the control; channel shutdown clears the registry. A stale closure also
+checks the bridge turn's `finished` flag, so it cannot abort the next queued turn.
+A successful stop settles as Stopped, removes the button, and preserves the
+process record. The reply card uses ordinary message patches, keeping its button
+outside CardKit's streaming-interaction restrictions.
+
+Regression coverage: channel bridge tests (queued controls, cross-topic stop
+isolation, stale callbacks), run-action tests (identity/message/token checks),
+and the offline replay Stop scenario. Reply-update timeouts use an independent
+final text message because ordinary message patches cannot supersede late
+updates by sequence. Stop tokens are invalidated before final delivery begins.

--- a/apps/canvas-workspace/src/plugins/main/channel/__tests__/bridge-startup.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/__tests__/bridge-startup.test.ts
@@ -224,7 +224,7 @@ describe('channel watchdog guards', () => {
     await bridge.addChannel(channel);
     send();
     await vi.advanceTimersByTimeAsync(100);
-    expect(streams[0].onDone).toHaveBeenCalledWith('done');
+    expect(streams[0].onDone).toHaveBeenCalledWith('done', { stopped: false });
     expect(runtime.abort).not.toHaveBeenCalled();
     delivery.resolve();
     await vi.advanceTimersByTimeAsync(0);

--- a/apps/canvas-workspace/src/plugins/main/channel/__tests__/bridge.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/__tests__/bridge.test.ts
@@ -187,6 +187,9 @@ class FakeChannel implements Channel {
 
 class FakeStream implements ChannelStream {
   done: string | null = null;
+  stopControl?: () => void;
+  stopped = false;
+  onRunStart(stop: () => void): void { this.stopControl = stop; }
   errors: string[] = [];
   text = '';
   clarification: string | null = null;
@@ -194,7 +197,7 @@ class FakeStream implements ChannelStream {
   onText(delta: string): void { this.text += delta; }
   onToolCall(): void {}
   onClarification(question: string): void { this.clarification = question; }
-  onDone(text: string): void { this.done = text; }
+  onDone(text: string, options?: { stopped?: boolean }): void { this.done = text; this.stopped = options?.stopped === true; }
   onError(message: string): void { this.errors.push(message); }
 }
 
@@ -264,6 +267,39 @@ describe('ChannelBridge conversation isolation', () => {
       'done:first',
       'done:second',
     ]));
+  });
+
+  it('binds stop to the active turn and ignores its stale control after the queue advances', async () => {
+    const signals = new Map<string, AbortSignal>();
+    const secondDone = deferred<void>();
+    const runtime = makeRuntime(async ({ message, signal }) => {
+      signals.set(message, signal);
+      if (message === 'first') {
+        await new Promise<void>(resolve => signal.addEventListener('abort', () => resolve(), { once: true }));
+        return { response: '', stopped: true };
+      }
+      await secondDone.promise;
+      return { response: 'finished' };
+    });
+    const bridge = new ChannelBridge(fakeService(), runtime, memoryStore());
+    await bridge.addChannel(channel);
+    channel.handler!(msg('first'));
+    channel.handler!(msg('second'));
+    channel.handler!(msg('other-topic', { conversationId: 'topic-b' }));
+    await waitFor(() => expect(channel.streams).toHaveLength(3));
+    await waitFor(() => expect(signals.has('other-topic')).toBe(true));
+    const first = channel.streams.find(stream => stream.triggerMessageId === 'm-1')!;
+    const second = channel.streams.find(stream => stream.triggerMessageId === 'm-2')!;
+    expect(first.stopControl).toBeDefined(); expect(second.stopControl).toBeUndefined();
+    first.stopControl!();
+    await waitFor(() => expect(second.stopControl).toBeDefined());
+    expect(first.stopped).toBe(true);
+    first.stopControl!();
+    expect(signals.get('second')!.aborted).toBe(false);
+    expect(signals.get('other-topic')!.aborted).toBe(false);
+    secondDone.resolve();
+    await waitFor(() => expect(second.done).toBe('finished'));
+    await bridge.stop();
   });
 
   it('resolves the next message scope after an earlier workspace switch commits', async () => {

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/card.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/card.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  buildReplyCard,
   buildDoneCard,
   buildProgressCard,
   buildThinkingCard,
@@ -103,7 +104,7 @@ describe('feishu card tool list', () => {
     expect(done).not.toContain('已等待');
   });
 
-  it('done card keeps the final answer below an expanded completed timeline', () => {
+  it('done process card keeps commentary inside the completed timeline', () => {
     const card = buildDoneCard('final answer', tools) as {
       header?: unknown;
       body: { elements: Array<Record<string, unknown>> };
@@ -122,13 +123,40 @@ describe('feishu card tool list', () => {
     expect(body).toContain('Canvas read node · node-1');
   });
 
-  it('done card with no tools keeps status and answer without a panel', () => {
+  it('done process card retains its disclosure even without tools', () => {
     const card = buildDoneCard('hi', []) as {
       body: { elements: Array<Record<string, unknown>> };
     };
-    expect(card.body.elements).toHaveLength(2);
-    expect(card.body.elements.every(element => element.tag === 'markdown')).toBe(true);
+    expect(card.body.elements).toHaveLength(1);
+    expect(card.body.elements[0].tag).toBe('collapsible_panel');
     expect(texts(card).join('\n')).toContain('hi');
+  });
+
+  it('reply owns the stop button while active and only the result after completion', () => {
+    const active = JSON.stringify(buildReplyCard('', 'working', 'turn-token'));
+    expect(active).toContain('run.stop'); expect(active).toContain('停止');
+    expect(active).toContain('"disabled":false');
+    expect(JSON.stringify(buildReplyCard('', 'queued', 'turn-token'))).toContain('"disabled":true');
+    const done = JSON.stringify(buildReplyCard('最终回答', 'completed', 'turn-token'));
+    expect(done).toContain('最终回答'); expect(done).not.toContain('button');
+    expect(done).not.toContain('collapsible_panel');
+  });
+
+  it('bounds final reply text to the existing card limit while retaining the latest output', () => {
+    const text = '长'.repeat(20000) + '最终结论';
+    const reply = texts(buildReplyCard(text, 'completed')).join('');
+    expect(reply.length).toBeLessThanOrEqual(8001);
+    expect(reply.endsWith('最终结论')).toBe(true);
+  });
+
+  it('interleaves public commentary with tools in emission order', () => {
+    const content = texts(buildProgressCard('现在整理结果', [
+      { label: 'read', beforeText: '先读入口文件', done: true },
+      { label: 'bash', beforeText: '接着检查仓库状态', done: false },
+    ])).join('\n');
+    expect(content.indexOf('先读入口文件')).toBeLessThan(content.indexOf('Read'));
+    expect(content.indexOf('Read')).toBeLessThan(content.indexOf('接着检查仓库状态'));
+    expect(content.indexOf('Bash')).toBeLessThan(content.indexOf('现在整理结果'));
   });
 
   it('workspace picker card uses a workspace dropdown and two submit buttons', () => {

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/run-actions.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/run-actions.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+import { FeishuRunActions } from '../run-actions';
+
+describe('Feishu turn-scoped stop actions', () => {
+  it('requires the original user and message, then invalidates the token on cleanup', () => {
+    const actions = new FeishuRunActions(); const stop = vi.fn(() => true);
+    const token = actions.token();
+    actions.register(token, { messageId: 'reply-a', requesterId: 'user-a', stop });
+    const event = { context: { open_message_id: 'reply-a' }, operator: { open_id: 'user-a' }, action: { value: { action: 'run.stop', token } } };
+    actions.handle({ ...event, context: { open_message_id: 'reply-b' } });
+    actions.handle({ ...event, operator: { open_id: 'user-b' } });
+    expect(stop).not.toHaveBeenCalled();
+    expect(actions.handle({ event })).toEqual({ toast: { type: 'success', content: '正在停止此任务' } });
+    expect(stop).toHaveBeenCalledOnce();
+    actions.remove(token); actions.handle(event); expect(stop).toHaveBeenCalledOnce();
+  });
+
+  it('clears all controls at channel shutdown and ignores unrelated actions', () => {
+    const actions = new FeishuRunActions(); const stop = vi.fn(() => true);
+    actions.register('token', { messageId: 'reply', requesterId: 'user', stop });
+    actions.clear();
+    actions.handle({ open_message_id: 'reply', open_id: 'user', action: { value: { action: 'run.stop', token: 'token' } } });
+    expect(stop).not.toHaveBeenCalled();
+    expect(actions.handle(null)).toBeNull();
+    expect(actions.handle({ action: { value: { action: 'workspace.use' } } })).toBeNull();
+  });
+});

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/run-card.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/run-card.test.ts
@@ -1,0 +1,141 @@
+import type * as lark from '@larksuiteoapi/node-sdk';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FeishuRunCard } from '../run-card';
+import { buildDoneCard, buildProgressCard, buildThinkingCard, formatStreamingToolLabel } from '../card';
+import { sendCardMessage, updateCardMessage } from '../feishu-client';
+
+vi.mock('../feishu-client', () => ({
+  sendCardMessage: vi.fn(async () => 'message-1'),
+  updateCardMessage: vi.fn(async () => undefined),
+}));
+
+function live(text = ''): object {
+  return { schema: '2.0', config: {}, body: { elements: [{ tag: 'markdown', element_id: 'answer', content: text }] } };
+}
+
+function setup() {
+  const create = vi.fn(async () => ({ code: 0, data: { card_id: 'card-1' } }));
+  const content = vi.fn(async (_request: unknown) => ({ code: 0 }));
+  const settings = vi.fn(async (_request: unknown) => ({ code: 0 }));
+  const update = vi.fn(async (_request: unknown) => ({ code: 0 }));
+  const client = { cardkit: { v1: { card: { create, settings, update }, cardElement: { content } } } };
+  const target = { chatId: 'chat-1', isGroup: true, threadId: 'topic-1', triggerMessageId: 'trigger-1' };
+  const card = new FeishuRunCard(client as unknown as lark.Client, target);
+  return { card, create, content, settings, update, target };
+}
+
+afterEach(() => { vi.restoreAllMocks(); vi.clearAllMocks(); });
+
+describe('native Feishu run card', () => {
+  it('sends the entity to the original topic and streams full text into stable components', async () => {
+    const { card, create, content, target } = setup();
+    await card.open(live());
+    expect(create).toHaveBeenCalledOnce();
+    expect(sendCardMessage).toHaveBeenCalledWith(expect.anything(), target, {
+      type: 'card', data: { card_id: 'card-1' },
+    });
+    await card.update(live('hello '), false);
+    await card.update(live('hello world'), false);
+    const requests = content.mock.calls.map(([request]) => request);
+    expect(requests).toEqual([
+      { path: { card_id: 'card-1', element_id: 'answer' }, data: { content: 'hello ', sequence: 1 } },
+      { path: { card_id: 'card-1', element_id: 'answer' }, data: { content: 'hello world', sequence: 2 } },
+    ]);
+    expect(updateCardMessage).not.toHaveBeenCalled();
+  });
+
+  it('skips unchanged text and closes streaming before the final replacement', async () => {
+    const { card, content, settings, update } = setup();
+    await card.open(live());
+    await card.update(live('answer'), false);
+    await card.update(live('answer'), false);
+    expect(content).toHaveBeenCalledOnce();
+    await card.update(buildDoneCard('answer'), true);
+    expect(settings).toHaveBeenCalledWith({
+      path: { card_id: 'card-1' },
+      data: { sequence: 2, settings: '{"config":{"streaming_mode":false}}' },
+    });
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ sequence: 3 }),
+    }));
+    expect(settings.mock.invocationCallOrder[0]).toBeLessThan(update.mock.invocationCallOrder[0]);
+  });
+
+  it('retries rejected text with a newer sequence, without claiming it was delivered', async () => {
+    const { card, content } = setup();
+    await card.open(live());
+    content.mockResolvedValueOnce({ code: 200810 });
+    await expect(card.update(live('answer'), false)).rejects.toThrow('200810');
+    await card.update(live('answer'), false);
+    expect(content).toHaveBeenLastCalledWith(expect.objectContaining({
+      data: { content: 'answer', sequence: 2 },
+    }));
+  });
+
+  it('falls back before sending if the app lacks CardKit permission', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { card, create } = setup();
+    create.mockRejectedValueOnce(new Error('permission denied'));
+    await card.open(live());
+    expect(sendCardMessage).toHaveBeenCalledOnce();
+    expect(sendCardMessage).toHaveBeenCalledWith(expect.anything(), expect.anything(), live());
+    await card.update(buildDoneCard('answer'), true);
+    expect(updateCardMessage).toHaveBeenCalledOnce();
+  });
+
+  it('does not send a duplicate when entity message sending fails', async () => {
+    const { card } = setup();
+    vi.mocked(sendCardMessage).mockRejectedValueOnce(new Error('send response lost'));
+    await expect(card.open(live())).rejects.toThrow('send response lost');
+    expect(sendCardMessage).toHaveBeenCalledOnce();
+  });
+
+  it('does not send a late card after creation has been abandoned', async () => {
+    const { card, create } = setup();
+    let resolve!: (value: { code: number; data: { card_id: string } }) => void;
+    create.mockImplementationOnce(() => new Promise((done) => { resolve = done; }));
+    const pending = card.open(live());
+    card.abandon();
+    resolve({ code: 0, data: { card_id: 'late-card' } });
+    await expect(pending).rejects.toThrow('abandoned');
+    expect(sendCardMessage).not.toHaveBeenCalled();
+  });
+
+  it('does not resume a final replacement after that final operation also times out', async () => {
+    const { card, settings, update } = setup();
+    await card.open(live());
+    card.abandon();
+    let resolve!: (value: { code: number }) => void;
+    settings.mockImplementationOnce(() => new Promise((done) => { resolve = done; }));
+    const final = card.update(buildDoneCard('answer'), true);
+    card.abandon();
+    resolve({ code: 0 });
+    await expect(final).rejects.toThrow('abandoned');
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('does not issue the rest of a multi-element update after a timeout', async () => {
+    const { card, content } = setup();
+    await card.open(live());
+    let resolve!: (value: { code: number }) => void;
+    content.mockImplementationOnce(() => new Promise((done) => { resolve = done; }));
+    const pending = card.update({ schema: '2.0', config: {}, body: { elements: [
+      { tag: 'markdown', element_id: 'answer', content: 'answer' },
+      { tag: 'markdown', element_id: 'progress', content: 'progress' },
+    ] } }, false);
+    card.abandon();
+    resolve({ code: 0 });
+    await expect(pending).rejects.toThrow('abandoned');
+    expect(content).toHaveBeenCalledOnce();
+  });
+});
+
+describe('streamed tool previews', () => {
+  it('shows partial commands and tolerates split JSON escapes', () => {
+    expect(formatStreamingToolLabel('bash', '{"command":"git sta')).toBe('bash — git sta');
+    expect(formatStreamingToolLabel('bash', '{"command":"git status"}')).toBe('bash — git status');
+    expect(formatStreamingToolLabel('read', '{"path":"/tmp/中文')).toBe('read — 中文');
+    expect(formatStreamingToolLabel('read', '{"path":"\\u4e')).toBeUndefined();
+    expect(formatStreamingToolLabel('read', '{"secret":"hidden')).toBeUndefined();
+  });
+});

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/stream.test.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/__tests__/stream.test.ts
@@ -147,7 +147,7 @@ describe('FeishuStream', () => {
     expect(latestCard).toContain('Demo');
   });
 
-  it('finishes by patching the original card with the final answer', async () => {
+  it('finishes the process card and patches the separate reply with the final answer', async () => {
     const stream = new FeishuStream({} as never, {
       chatId: 'group1',
       isGroup: true,
@@ -161,15 +161,15 @@ describe('FeishuStream', () => {
     await stream.onDone('final answer');
 
     const finalCard = JSON.stringify(mockedUpdateCard.mock.calls.at(-1)?.[2]);
-    expect(finalCard).toContain('Completed');
+    expect(JSON.stringify(mockedUpdateCard.mock.calls.at(-2)?.[2])).toContain('Completed');
     expect(finalCard).toContain('final answer');
     expect(finalCard).not.toContain('partial');
-    expect(mockedSendCard).toHaveBeenCalledTimes(1);
+    expect(mockedSendCard).toHaveBeenCalledTimes(2);
     expect(mockedSendText).not.toHaveBeenCalled();
   });
 
   it('falls back to plain text when the final card patch hangs', async () => {
-    mockedUpdateCard.mockImplementationOnce(() => new Promise(() => undefined));
+    mockedUpdateCard.mockResolvedValueOnce(undefined).mockImplementationOnce(() => new Promise(() => undefined));
     const stream = new FeishuStream({} as never, {
       chatId: 'group1',
       isGroup: true,
@@ -181,13 +181,13 @@ describe('FeishuStream', () => {
     await vi.advanceTimersByTimeAsync(10_000);
     await done;
 
-    expect(mockedSendCard).toHaveBeenCalledTimes(1);
+    expect(mockedSendCard).toHaveBeenCalledTimes(2);
     expect(mockedSendText).toHaveBeenCalledTimes(1);
     expect(mockedSendText.mock.calls[0][2]).toBe('final answer');
   });
 
   it('falls back to plain text when the final card update fails', async () => {
-    mockedUpdateCard.mockRejectedValueOnce(new Error('final failed'));
+    mockedUpdateCard.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('final failed'));
     const stream = new FeishuStream({} as never, {
       chatId: 'group1',
       isGroup: true,
@@ -197,8 +197,8 @@ describe('FeishuStream', () => {
     await stream.init();
     await stream.onDone('final answer');
 
-    expect(mockedUpdateCard).toHaveBeenCalledTimes(1);
-    expect(mockedSendCard).toHaveBeenCalledTimes(1);
+    expect(mockedUpdateCard).toHaveBeenCalledTimes(2);
+    expect(mockedSendCard).toHaveBeenCalledTimes(2);
     expect(mockedSendText).toHaveBeenCalledTimes(1);
     expect(mockedSendText.mock.calls[0][2]).toBe('final answer');
   });

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/card.ts
@@ -1,8 +1,4 @@
-// Feishu interactive card (schema 2.0) builders for the streamed agent run.
-// One card is created on run start and progressively patched: thinking →
-// progress (accumulated text + a live list of tool calls) → done / error.
-// Working/Completed is an expanded disclosure containing the live tool timeline;
-// the same card keeps the streamed answer directly below it.
+// Feishu schema 2.0 builders: a streamed process card and a separate reply card.
 
 import type { OutboundTarget, WorkspacePicker } from '../../core/types';
 
@@ -21,14 +17,16 @@ function clamp(text: string): string {
 export interface ToolEntry {
   /** "name — detail" (no status icon; the renderer adds it). */
   label: string;
+  /** Public assistant commentary emitted before this tool. */
+  beforeText?: string;
   /** True once the tool has returned a result. */
   done: boolean;
   /** Wall-clock duration in seconds, set when done. */
   elapsedSec?: number;
 }
 
-function md(content: string, textSize?: 'heading' | 'normal' | 'notation'): object {
-  return { tag: 'markdown', content, ...(textSize ? { text_size: textSize } : {}) };
+function md(content: string, textSize?: 'heading' | 'normal' | 'notation', id?: string): object {
+  return { tag: 'markdown', content, ...(textSize ? { text_size: textSize } : {}), ...(id ? { element_id: id } : {}) };
 }
 
 function muted(content: string): string {
@@ -87,7 +85,7 @@ function formButton(
 function toolLine(tool: ToolEntry): string {
   const { name, detail } = splitToolLabel(tool.label);
   const segs = [titleizeToolName(name || 'tool')];
-  if (detail) segs.push(detail);
+  if (detail) segs.push(detail.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'));
   if (tool.done && typeof tool.elapsedSec === 'number') segs.push(`${tool.elapsedSec}s`);
   return segs.join(' · ');
 }
@@ -103,18 +101,19 @@ function pendingLabel(elapsedSec: number): string {
 }
 
 /** Finished rows recede; active rows use a stable, explicit status label. */
-function toolTimeline(tools: ToolEntry[], elapsedSec: number, running: boolean): string {
+function toolTimeline(tools: ToolEntry[], elapsedSec: number, running: boolean, text = '', stopped = false): string {
   const rail = muted('│');
   const rows = tools.map((tool) => {
     const completed = tool.done || !running;
     const label = completed ? muted(toolLine(tool)) : `${toolLine(tool)}  ${muted('执行中')}`;
-    return `${rail}  ${muted('›')}  ${label}`;
+    return [tool.beforeText?.trim(), `${rail}  ${muted('›')}  ${label}`].filter(Boolean).join('\n\n');
   });
 
+  if (text.trim()) rows.push(text.trim());
   if (running && rows.length === 0) {
     rows.push(muted(pendingLabel(elapsedSec)));
   } else if (!running) {
-    rows.push(`${muted('└')}  ${muted('◎ Completed')}`);
+    rows.push(`${muted('└')}  ${muted(stopped ? '◎ Stopped' : '◎ Completed')}`);
   }
   return rows.join('\n');
 }
@@ -134,54 +133,57 @@ function titleizeToolName(name: string): string {
   )).join(' ');
 }
 
-function statusLine(status: 'working' | 'completed'): string {
-  return `**${status === 'working' ? 'Working' : 'Completed'}**`;
+function statusLine(status: 'working' | 'thinking' | 'completed' | 'stopped'): string {
+  return `**${{ working: 'Working', thinking: 'Thinking', completed: 'Completed', stopped: 'Stopped' }[status]}**`;
 }
 
 /** Working/Completed is itself the disclosure control, like the reference. */
 function processPanel(
-  status: 'working' | 'completed',
+  status: 'working' | 'completed' | 'stopped',
   tools: ToolEntry[],
   elapsedSec: number,
+  text = '',
 ): object {
   return {
     tag: 'collapsible_panel',
     expanded: true,
     header: {
-      title: md(statusLine(status), 'normal'),
+      title: md(statusLine(status === 'working' && (text.trim() || tools.length > 0) && tools.every(tool => tool.done)
+        ? 'thinking' : status), 'normal', 'process_status'),
       vertical_align: 'center',
     },
-    elements: [md(toolTimeline(tools, elapsedSec, status === 'working'), 'notation')],
+    elements: [md(clamp(toolTimeline(tools, elapsedSec, status === 'working', text, status === 'stopped')), 'notation', 'process_body')],
   };
 }
 
-/** The process stays above the answer while both update in the same card. */
-function liveElements(text: string, tools: ToolEntry[], elapsedSec: number): object[] {
-  const elements: object[] = [processPanel('working', tools, elapsedSec)];
-  if (text.trim()) elements.push(md(clamp(text.trim()), 'normal'));
-  return elements;
-}
-
+/** Streamed text is public progress; final output has its own message. */
 export function buildThinkingCard(): object {
-  return card(undefined, 'blue', liveElements('', [], 0), false);
+  return buildProgressCard('');
 }
 
-export function buildProgressCard(
+export function buildProgressCard(text: string, tools: ToolEntry[] = [], elapsedSec = 0): object {
+  return card(undefined, 'blue', [processPanel('working', tools, elapsedSec, text)], false);
+}
+
+export function buildDoneCard(text: string, tools: ToolEntry[] = [], stopped = false): object {
+  return card(undefined, 'grey', [processPanel(stopped ? 'stopped' : 'completed', tools, 0, text)], true);
+}
+
+export function buildReplyCard(
   text: string,
-  tools: ToolEntry[] = [],
-  elapsedSec = 0,
+  state: 'queued' | 'working' | 'stopping' | 'completed' | 'stopped' | 'error',
+  stopToken?: string,
 ): object {
-  return card(undefined, 'blue', liveElements(text, tools, elapsedSec), false);
-}
-
-export function buildDoneCard(text: string, tools: ToolEntry[] = []): object {
-  const elapsedSec = tools.reduce((total, tool) => total + (tool.elapsedSec ?? 0), 0);
-  const elements: object[] = tools.length > 0
-    ? [processPanel('completed', tools, elapsedSec)]
-    : [md(statusLine('completed'), 'normal')];
-  if (text.trim()) elements.push(md(clamp(text.trim()), 'normal'));
-  else elements.push(md(' Done', 'normal'));
-  return card(undefined, 'green', elements, true);
+  const active = ['queued', 'working', 'stopping'].includes(state);
+  const hint = state === 'queued' ? '正在等待执行…'
+    : state === 'stopping' ? '正在停止…' : '正在执行任务…';
+  const elements = [md(active ? muted(`*${hint}*`) : clamp(text.trim() || '已完成'), 'normal')];
+  if (active && stopToken) {
+    const value = { action: 'run.stop', token: stopToken };
+    elements.push({ tag: 'button', text: plainText('停止'), type: 'danger',
+      disabled: state !== 'working', value, behaviors: [{ type: 'callback', value }] });
+  }
+  return card(undefined, 'grey', elements, !active);
 }
 
 export function buildErrorCard(message: string): object {
@@ -268,6 +270,21 @@ export function buildWorkspacePickerCard(picker: WorkspacePicker, target?: Outbo
 export function formatToolLabel(name: string, args: unknown): string {
   const detail = summarizeArgs(args);
   return detail ? `${name} — ${detail}` : name;
+}
+
+/** Display only known descriptive string fields while tool JSON is incomplete. */
+export function formatStreamingToolLabel(name: string, input: string): string | undefined {
+  const match = input.match(/"(title|name|query|q|path|file|filePath|url|command|cmd)"\s*:\s*"((?:\\.|[^"\\])*)/);
+  if (!match) return undefined;
+  try {
+    const value: unknown = JSON.parse(`"${match[2]}"`);
+    if (typeof value !== 'string' || !value.trim()) return undefined;
+    return formatToolLabel(name, { [match[1]]: value });
+  } catch {
+    // A chunk may end midway through a JSON unicode escape. Keep the previous
+    // preview until the next chunk completes it.
+    return undefined;
+  }
 }
 
 function summarizeArgs(args: unknown): string {

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-channel.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-channel.ts
@@ -11,38 +11,31 @@ import {
   createLarkClient,
   feishuConfigured,
   sendCardMessage,
-  sendImageMessage,
   sendTextMessage,
-  updateCardMessage,
   type FeishuSendTarget,
 } from './feishu-client';
 import {
-  buildDoneCard,
-  buildErrorCard,
-  buildProgressCard,
-  buildThinkingCard,
   buildWorkspacePickerCard,
-  formatToolLabel,
   WORKSPACE_PICKER_SELECT_NAME,
 } from './card';
 import { downloadInboundImages, extractInboundImageKeys } from './inbound-image';
 import { loadBotIdentity, messageMentionsBot, type FeishuBotIdentity } from './bot-mention';
 
+import { FeishuStream } from './feishu-stream';
+import { FeishuRunActions } from './run-actions';
 const CHANNEL_ID = 'feishu';
-const PROGRESS_THROTTLE_MS = 800;
-const PROGRESS_HEARTBEAT_MS = 1_200;
-const CARD_SEND_TIMEOUT_MS = 10_000;
-const CARD_UPDATE_TIMEOUT_MS = 10_000;
+export { FeishuStream } from './feishu-stream';
 
 /**
  * Feishu channel using the SDK's long-connection (WSClient) event stream —
  * the canvas app dials out to Feishu over a WebSocket, so it works behind
  * NAT with no public webhook URL. Inbound text messages are normalized to
- * {@link InboundMessage}; agent output is rendered into a single interactive
- * card that is progressively patched.
+ * {@link InboundMessage}; agent output is rendered into a streamed process
+ * card and a separate response card with turn-scoped controls.
  */
 export class FeishuChannel implements Channel {
   readonly id = CHANNEL_ID;
+  private readonly runActions = new FeishuRunActions();
   private wsClient: lark.WSClient | null = null;
   private client: lark.Client | null = null;
 
@@ -78,12 +71,16 @@ export class FeishuChannel implements Channel {
       },
       'card.action.trigger': async (data: unknown) => {
         logRawCardAction(data);
+        const control = this.runActions.handle(data);
+        if (control) return control;
         const msg = parseCardAction(data);
         if (msg) onInbound(msg);
         return {};
       },
       'interactive_card.action.trigger': async (data: unknown) => {
         logRawCardAction(data);
+        const control = this.runActions.handle(data);
+        if (control) return control;
         const msg = parseCardAction(data);
         if (msg) onInbound(msg);
         return {};
@@ -101,6 +98,7 @@ export class FeishuChannel implements Channel {
     } catch (err) {
       console.error('[channel:feishu] WSClient stop failed', err);
     }
+    this.runActions.clear();
     this.wsClient = null;
     this.client = null;
   }
@@ -122,7 +120,7 @@ export class FeishuChannel implements Channel {
 
   async openStream(target: OutboundTarget): Promise<ChannelStream> {
     if (!this.client) throw new Error('Feishu channel not started');
-    const stream = new FeishuStream(this.client, toSendTarget(target));
+    const stream = new FeishuStream(this.client, toSendTarget(target), this.runActions);
     await stream.init();
     return stream;
   }
@@ -143,6 +141,7 @@ function toSendTarget(target: OutboundTarget): FeishuSendTarget {
   if (reply?.chatId) {
     return {
       chatId: reply.chatId,
+      requesterId: reply.requesterId,
       threadId: reply.threadId,
       isGroup: Boolean(reply.isGroup),
       triggerMessageId: reply.triggerMessageId ?? '',
@@ -150,356 +149,6 @@ function toSendTarget(target: OutboundTarget): FeishuSendTarget {
   }
   // Fallback: treat the conversation id as a bare chat_id (no threading).
   return { chatId: target.conversationId, isGroup: false, triggerMessageId: '' };
-}
-
-/**
- * Renders one agent run into a single Feishu card. Text/tool events are
- * accumulated and flushed to the card on a trailing throttle so we don't
- * exceed Feishu's update-rate limits; images are sent as separate messages.
- */
-interface ToolRun {
-  id?: string;
-  name: string;
-  label: string;
-  startedAt: number;
-  done: boolean;
-  elapsedSec?: number;
-  inputBytes?: number;
-  inputStreaming?: boolean;
-  argsReceived?: boolean;
-}
-
-export class FeishuStream implements ChannelStream {
-  private cardMessageId: string | null = null;
-  private cardFailed = false;
-  private accumulated = '';
-  /** Every tool call this run, accumulated as a live list for the card. */
-  private readonly tools: ToolRun[] = [];
-  private readonly startedAt = Date.now();
-
-  private updateInFlight: Promise<boolean> | null = null;
-  private pendingProgressFactory: (() => object) | null = null;
-  private flushTimer: NodeJS.Timeout | null = null;
-  private heartbeatTimer: NodeJS.Timeout | null = null;
-  private lastFlush = 0;
-  private finalizing = false;
-  private cardUpdateTimedOut = false;
-
-  constructor(
-    private readonly client: lark.Client,
-    private readonly target: FeishuSendTarget,
-  ) {}
-
-  async init(): Promise<void> {
-    try {
-      this.cardMessageId = await withTimeout(
-        sendCardMessage(this.client, this.target, buildThinkingCard()),
-        CARD_SEND_TIMEOUT_MS,
-        'Feishu thinking card send',
-      );
-    } catch (err) {
-      // If the initial card cannot be sent, fall back to text messages.
-      this.cardFailed = true;
-      console.error('[channel:feishu] failed to send thinking card', err);
-      return;
-    }
-    this.startHeartbeat();
-  }
-
-  onText(delta: string): void {
-    this.accumulated += delta;
-    this.scheduleFlush();
-  }
-
-  onToolCall(name: string, args: unknown, toolCallId?: string): void {
-    const existing = toolCallId ? this.findTool(toolCallId) : undefined;
-    if (existing) {
-      existing.id = toolCallId ?? existing.id;
-      existing.name = name;
-      existing.label = formatToolLabel(name, args);
-      existing.inputStreaming = false;
-      existing.argsReceived = true;
-    } else {
-      this.tools.push({
-        id: toolCallId,
-        name,
-        label: formatToolLabel(name, args),
-        startedAt: Date.now(),
-        done: false,
-        argsReceived: true,
-      });
-    }
-    this.scheduleFlush();
-  }
-
-  onToolResult(result: { name: string; result: string; toolCallId?: string }): void {
-    this.markToolDone(result.toolCallId, result.name);
-    this.scheduleFlush();
-  }
-
-  onToolInputStart(data: { id: string; toolName: string }): void {
-    const existing = this.findTool(data.id);
-    if (existing) {
-      existing.id = data.id;
-      existing.name = data.toolName;
-      existing.inputStreaming = true;
-      if (!existing.argsReceived) existing.label = `${data.toolName} — preparing input`;
-    } else {
-      this.tools.push({
-        id: data.id,
-        name: data.toolName,
-        label: `${data.toolName} — preparing input`,
-        startedAt: Date.now(),
-        done: false,
-        inputBytes: 0,
-        inputStreaming: true,
-      });
-    }
-    this.scheduleFlush();
-  }
-
-  onToolInputDelta(data: { id: string; delta: string }): void {
-    const tool = this.findTool(data.id);
-    if (!tool) return;
-    tool.inputBytes = (tool.inputBytes ?? 0) + data.delta.length;
-    if (!tool.argsReceived) {
-      tool.label = `${tool.name} — preparing input ${formatByteCount(tool.inputBytes)}`;
-    }
-    this.scheduleFlush();
-  }
-
-  onToolInputEnd(data: { id: string }): void {
-    const tool = this.findTool(data.id);
-    if (!tool) return;
-    tool.inputStreaming = false;
-    if (!tool.argsReceived) {
-      tool.label = `${tool.name} — prepared input`;
-    }
-    this.scheduleFlush();
-  }
-
-  async onImage(imagePath: string, mimeType?: string): Promise<void> {
-    try {
-      await sendImageMessage(this.client, this.target, imagePath, mimeType);
-      // The image tool's result is consumed by the image relay (no onToolResult
-      // for it), so close out its pending entry here.
-      this.markToolDone();
-      this.scheduleFlush();
-    } catch (err) {
-      console.error('[channel:feishu] failed to send image', err);
-    }
-  }
-
-  /**
-   * Mark the most recent still-running tool as done (preferring one whose
-   * label matches `name`) and record how long it took.
-   */
-  private findTool(toolCallId?: string, name?: string): ToolRun | undefined {
-    if (toolCallId) {
-      const byId = this.tools.find((tool) => tool.id === toolCallId);
-      if (byId) return byId;
-      return undefined;
-    }
-    if (name) {
-      for (let i = this.tools.length - 1; i >= 0; i--) {
-        const tool = this.tools[i];
-        if (!tool.done && tool.name === name) return tool;
-      }
-    }
-    return undefined;
-  }
-
-  private markToolDone(toolCallId?: string, name?: string): void {
-    let idx = -1;
-    if (toolCallId) {
-      idx = this.tools.findIndex((tool) => tool.id === toolCallId && !tool.done);
-    }
-    for (let i = this.tools.length - 1; i >= 0; i--) {
-      if (idx !== -1) break;
-      if (this.tools[i].done) continue;
-      if (idx === -1) idx = i; // fallback: latest running regardless of name
-      if (name && (this.tools[i].name === name || this.tools[i].label.startsWith(name))) {
-        idx = i;
-        break;
-      }
-    }
-    if (idx === -1) return;
-    const t = this.tools[idx];
-    t.done = true;
-    t.elapsedSec = Math.round((Date.now() - t.startedAt) / 1000);
-  }
-
-  async onClarification(question: string): Promise<void> {
-    // Surface the question as its own text message so it stands out from the
-    // streamed card; the user's next message is routed back as the answer.
-    try {
-      await withTimeout(
-        sendTextMessage(this.client, this.target, `❓ ${question}`),
-        CARD_SEND_TIMEOUT_MS,
-        'Feishu clarification send',
-      );
-    } catch (err) {
-      console.error('[channel:feishu] failed to send clarification', err);
-      // Re-throw so the bridge can fail the run: a question the user never
-      // received can never be answered, and parking it would pin the scope.
-      throw err;
-    }
-  }
-
-  async onDone(text: string): Promise<void> {
-    this.cancelTimers();
-    // Any tool without an observed result (e.g. the run ended right after)
-    // shouldn't linger as ⏳ in the folded list.
-    const now = Date.now();
-    for (const t of this.tools) {
-      if (t.done) continue;
-      t.done = true;
-      t.elapsedSec = Math.round((now - t.startedAt) / 1000);
-    }
-    await this.finalize(() => buildDoneCard(text, this.tools), text || '✅ Done');
-  }
-
-  async onError(message: string): Promise<void> {
-    this.cancelTimers();
-    await this.finalize(() => buildErrorCard(message), `❌ Error: ${message}`);
-  }
-
-  private elapsedSec(): number {
-    return Math.round((Date.now() - this.startedAt) / 1000);
-  }
-
-  private scheduleFlush(): void {
-    if (this.cardFailed || this.finalizing || this.flushTimer) return;
-    const wait = Math.max(0, PROGRESS_THROTTLE_MS - (Date.now() - this.lastFlush));
-    this.flushTimer = setTimeout(() => {
-      this.flushTimer = null;
-      this.lastFlush = Date.now();
-      this.enqueueProgress(() => buildProgressCard(this.accumulated, this.tools, this.elapsedSec()));
-    }, wait);
-  }
-
-  private startHeartbeat(): void {
-    if (this.cardFailed || this.heartbeatTimer) return;
-    this.heartbeatTimer = setInterval(() => {
-      if (this.cardFailed || this.finalizing) return;
-      this.lastFlush = Date.now();
-      this.enqueueProgress(() => buildProgressCard(this.accumulated, this.tools, this.elapsedSec()));
-    }, PROGRESS_HEARTBEAT_MS);
-  }
-
-  private cancelTimers(): void {
-    if (this.flushTimer) {
-      clearTimeout(this.flushTimer);
-      this.flushTimer = null;
-    }
-    if (this.heartbeatTimer) {
-      clearInterval(this.heartbeatTimer);
-      this.heartbeatTimer = null;
-    }
-  }
-
-  /**
-   * Keep only the newest progress snapshot while a card patch is in flight.
-   * Feishu patch calls can be slow; queuing every 800ms snapshot can leave the
-   * final answer stuck behind stale updates for minutes.
-   */
-  private enqueueProgress(factory: () => object): void {
-    if (this.cardFailed || this.finalizing) return;
-    this.pendingProgressFactory = factory;
-    this.drainProgressUpdates();
-  }
-
-  private drainProgressUpdates(): void {
-    if (this.updateInFlight || this.cardFailed || this.finalizing) return;
-    const factory = this.pendingProgressFactory;
-    if (!factory) return;
-
-    this.pendingProgressFactory = null;
-    const update = this.patchCard(factory, 'Feishu card update');
-    this.updateInFlight = update;
-    void update.finally(() => {
-      if (this.updateInFlight === update) {
-        this.updateInFlight = null;
-      }
-      this.drainProgressUpdates();
-    });
-  }
-
-  private async patchCard(factory: () => object, label: string): Promise<boolean> {
-    if (this.cardFailed || !this.cardMessageId) return false;
-    try {
-      await withTimeout(
-        updateCardMessage(this.client, this.cardMessageId, factory()),
-        CARD_UPDATE_TIMEOUT_MS,
-        label,
-      );
-      return true;
-    } catch (err) {
-      if (isTimeoutError(err)) this.cardUpdateTimedOut = true;
-      // Treat non-timeout patch failures as transient. Feishu can reject an
-      // individual update because of rate limits or a stale card state; stopping
-      // all later patches makes the bot appear frozen mid-run.
-      console.error('[channel:feishu] card update failed', err);
-      return false;
-    }
-  }
-
-  private async finalize(factory: () => object, fallbackText: string): Promise<void> {
-    this.finalizing = true;
-    this.pendingProgressFactory = null;
-    if (this.updateInFlight) {
-      await this.updateInFlight;
-    }
-
-    // A timed-out card patch may still complete later and overwrite newer card
-    // content. Once that happens, stop trusting this card and send the final
-    // answer as a separate text message instead of racing another patch.
-    const finalUpdated = this.cardUpdateTimedOut
-      ? false
-      : await this.patchCard(factory, 'Feishu final card update');
-    if (!finalUpdated) {
-      await this.sendFallbackText(fallbackText);
-    }
-  }
-
-  private async sendFallbackText(text: string): Promise<void> {
-    try {
-      await withTimeout(
-        sendTextMessage(this.client, this.target, text),
-        CARD_SEND_TIMEOUT_MS,
-        'Feishu fallback text send',
-      );
-    } catch (err) {
-      console.error('[channel:feishu] fallback text send failed', err);
-    }
-  }
-}
-
-class TimeoutError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'TimeoutError';
-  }
-}
-
-function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
-  let timer: NodeJS.Timeout | null = null;
-  const timeout = new Promise<T>((_, reject) => {
-    timer = setTimeout(() => reject(new TimeoutError(label + ' timed out after ' + ms + 'ms')), ms);
-  });
-  return Promise.race([promise, timeout]).finally(() => {
-    if (timer) clearTimeout(timer);
-  });
-}
-
-function isTimeoutError(err: unknown): boolean {
-  return err instanceof TimeoutError || (err instanceof Error && err.name === 'TimeoutError');
-}
-
-function formatByteCount(bytes: number): string {
-  if (bytes < 1024) return `${bytes}B`;
-  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)}KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }
 
 // ── Event parsing ───────────────────────────────────────────────────────────
@@ -620,7 +269,7 @@ function extractMessageText(rawContent: string | undefined, messageType: string 
   }
 }
 
-interface FeishuCardActionEvent {
+export interface FeishuCardActionEvent {
   open_id?: string;
   user_id?: string;
   open_message_id?: string;
@@ -691,6 +340,7 @@ export function parseInbound(data: unknown, botIdentity?: FeishuBotIdentity): In
   const conversationId = topicKey ? `${chatId}:${topicKey}` : chatId;
 
   const reply: FeishuSendTarget = {
+    requesterId: userId,
     chatId,
     threadId: topicKey,
     isGroup,

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-client.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-client.ts
@@ -218,6 +218,8 @@ export async function downloadMessageImage(messageId: string, fileKey: string): 
  *   present on a topic's root message.
  */
 export interface FeishuSendTarget {
+  /** Only the initiating user may stop this reply. */
+  requesterId?: string;
   chatId: string;
   threadId?: string;
   isGroup: boolean;

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-stream.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/feishu-stream.ts
@@ -1,0 +1,439 @@
+import type * as lark from '@larksuiteoapi/node-sdk';
+import type { ChannelStream } from '../../core/types';
+import { sendImageMessage, sendTextMessage, sendCardMessage, updateCardMessage, type FeishuSendTarget } from './feishu-client';
+import { buildReplyCard, buildDoneCard, buildErrorCard, buildProgressCard, buildThinkingCard, formatToolLabel, formatStreamingToolLabel } from './card';
+import { FeishuRunCard } from './run-card';
+import { FeishuRunActions } from './run-actions';
+
+const PROGRESS_THROTTLE_MS = 800;
+const PROGRESS_HEARTBEAT_MS = 1_200;
+const CARD_SEND_TIMEOUT_MS = 10_000;
+const CARD_UPDATE_TIMEOUT_MS = 10_000;
+
+/**
+ * Renders a run into a streamed process card plus a separate response card. Events are
+ * accumulated and flushed to the card on a trailing throttle so we don't
+ * exceed Feishu's update-rate limits; images are sent as separate messages.
+ */
+interface ToolRun {
+  id?: string;
+  name: string;
+  label: string;
+  beforeText?: string;
+  startedAt: number;
+  done: boolean;
+  elapsedSec?: number;
+  inputBytes?: number;
+  inputPreview?: string;
+  inputStreaming?: boolean;
+  argsReceived?: boolean;
+}
+
+export class FeishuStream implements ChannelStream {
+  private cardMessageId: string | null = null;
+  private readonly runCard: FeishuRunCard;
+  private cardFailed = false;
+  private replyMessageId: string | null = null;
+  private replyTimedOut = false;
+  private replySnapshot = '';
+  private stopControl?: () => void;
+  private stopping = false;
+  private started = false;
+  private readonly stopToken: string;
+  private accumulated = '';
+  /** Every tool call this run, accumulated as a live list for the card. */
+  private readonly tools: ToolRun[] = [];
+  private readonly startedAt = Date.now();
+
+  private updateInFlight: Promise<boolean> | null = null;
+  private pendingProgressFactory: (() => object) | null = null;
+  private flushTimer: NodeJS.Timeout | null = null;
+  private heartbeatTimer: NodeJS.Timeout | null = null;
+  private lastFlush = 0;
+  private finalizing = false;
+  private cardUpdateTimedOut = false;
+
+  constructor(
+    private readonly client: lark.Client,
+    private readonly target: FeishuSendTarget,
+    private readonly actions = new FeishuRunActions(),
+  ) {
+    this.runCard = new FeishuRunCard(client, target);
+    this.stopToken = actions.token();
+  }
+
+  async init(): Promise<void> {
+    try {
+      this.cardMessageId = await withTimeout(
+        this.runCard.open(buildThinkingCard()),
+        CARD_SEND_TIMEOUT_MS,
+        'Feishu thinking card send',
+      );
+    } catch (err) {
+      // If the initial card cannot be sent, fall back to text messages.
+      this.runCard.abandon();
+      this.cardFailed = true;
+      console.error('[channel:feishu] failed to send thinking card', err);
+    }
+    try {
+      const reply = this.replyProgress();
+      this.replyMessageId = await withTimeout(sendCardMessage(this.client, this.target, reply), CARD_SEND_TIMEOUT_MS, 'Feishu reply card send');
+      this.replySnapshot = JSON.stringify(reply);
+      if (this.target.requesterId) this.actions.register(this.stopToken, {
+        messageId: this.replyMessageId, requesterId: this.target.requesterId, stop: () => this.requestStop(),
+      });
+    } catch (err) { console.error('[channel:feishu] failed to send reply card', err); }
+    this.startHeartbeat();
+  }
+
+  onRunStart(stop: () => void): void {
+    if (this.finalizing || this.stopping) return;
+    this.started = true;
+    this.stopControl = stop;
+    this.scheduleFlush();
+  }
+
+  private requestStop(): boolean {
+    if (!this.stopControl || this.finalizing || this.stopping) return false;
+    const stop = this.stopControl;
+    this.stopControl = undefined;
+    this.stopping = true;
+    stop();
+    this.scheduleFlush();
+    return true;
+  }
+
+  private replyProgress(): object {
+    return buildReplyCard('', this.stopping ? 'stopping' : this.started ? 'working' : 'queued',
+      this.target.requesterId ? this.stopToken : undefined);
+  }
+
+  private takeCommentary(): string {
+    const text = this.accumulated;
+    this.accumulated = '';
+    return text;
+  }
+
+  onText(delta: string): void {
+    this.accumulated += delta;
+    this.scheduleFlush();
+  }
+
+  onToolCall(name: string, args: unknown, toolCallId?: string): void {
+    const existing = toolCallId ? this.findTool(toolCallId) : undefined;
+    if (existing) {
+      existing.id = toolCallId ?? existing.id;
+      existing.name = name;
+      existing.label = formatToolLabel(name, args);
+      existing.inputStreaming = false;
+      existing.argsReceived = true;
+    } else {
+      this.tools.push({
+        id: toolCallId,
+        name,
+        label: formatToolLabel(name, args),
+        beforeText: this.takeCommentary(),
+        startedAt: Date.now(),
+        done: false,
+        argsReceived: true,
+      });
+    }
+    this.scheduleFlush();
+  }
+
+  onToolResult(result: { name: string; result: string; toolCallId?: string }): void {
+    this.markToolDone(result.toolCallId, result.name);
+    this.scheduleFlush();
+  }
+
+  onToolInputStart(data: { id: string; toolName: string }): void {
+    const existing = this.findTool(data.id);
+    if (existing) {
+      existing.id = data.id;
+      existing.name = data.toolName;
+      existing.inputStreaming = true;
+      if (!existing.argsReceived) existing.label = `${data.toolName} — preparing input`;
+    } else {
+      this.tools.push({
+        id: data.id,
+        name: data.toolName,
+        label: `${data.toolName} — preparing input`,
+        beforeText: this.takeCommentary(),
+        startedAt: Date.now(),
+        done: false,
+        inputBytes: 0,
+        inputStreaming: true,
+      });
+    }
+    this.scheduleFlush();
+  }
+
+  onToolInputDelta(data: { id: string; delta: string }): void {
+    const tool = this.findTool(data.id);
+    if (!tool) return;
+    tool.inputBytes = (tool.inputBytes ?? 0) + Buffer.byteLength(data.delta, 'utf8');
+    tool.inputPreview = ((tool.inputPreview ?? '') + data.delta).slice(0, 8_000);
+    if (!tool.argsReceived) {
+      tool.label = formatStreamingToolLabel(tool.name, tool.inputPreview)
+        ?? `${tool.name} — preparing input ${formatByteCount(tool.inputBytes)}`;
+    }
+    this.scheduleFlush();
+  }
+
+  onToolInputEnd(data: { id: string }): void {
+    const tool = this.findTool(data.id);
+    if (!tool) return;
+    tool.inputStreaming = false;
+    if (!tool.argsReceived && !formatStreamingToolLabel(tool.name, tool.inputPreview ?? '')) {
+      tool.label = `${tool.name} — prepared input`;
+    }
+    this.scheduleFlush();
+  }
+
+  async onImage(imagePath: string, mimeType?: string): Promise<void> {
+    try {
+      await sendImageMessage(this.client, this.target, imagePath, mimeType);
+      // The image tool's result is consumed by the image relay (no onToolResult
+      // for it), so close out its pending entry here.
+      this.markToolDone();
+      this.scheduleFlush();
+    } catch (err) {
+      console.error('[channel:feishu] failed to send image', err);
+    }
+  }
+
+  /**
+   * Mark the most recent still-running tool as done (preferring one whose
+   * label matches `name`) and record how long it took.
+   */
+  private findTool(toolCallId?: string, name?: string): ToolRun | undefined {
+    if (toolCallId) {
+      const byId = this.tools.find((tool) => tool.id === toolCallId);
+      if (byId) return byId;
+      return undefined;
+    }
+    if (name) {
+      for (let i = this.tools.length - 1; i >= 0; i--) {
+        const tool = this.tools[i];
+        if (!tool.done && tool.name === name) return tool;
+      }
+    }
+    return undefined;
+  }
+
+  private markToolDone(toolCallId?: string, name?: string): void {
+    let idx = -1;
+    if (toolCallId) {
+      idx = this.tools.findIndex((tool) => tool.id === toolCallId && !tool.done);
+    }
+    for (let i = this.tools.length - 1; i >= 0; i--) {
+      if (idx !== -1) break;
+      if (this.tools[i].done) continue;
+      if (idx === -1) idx = i; // fallback: latest running regardless of name
+      if (name && (this.tools[i].name === name || this.tools[i].label.startsWith(name))) {
+        idx = i;
+        break;
+      }
+    }
+    if (idx === -1) return;
+    const t = this.tools[idx];
+    t.done = true;
+    t.elapsedSec = Math.round((Date.now() - t.startedAt) / 1000);
+  }
+
+  async onClarification(question: string): Promise<void> {
+    // Surface the question as its own text message so it stands out from the
+    // streamed card; the user's next message is routed back as the answer.
+    try {
+      await withTimeout(
+        sendTextMessage(this.client, this.target, `❓ ${question}`),
+        CARD_SEND_TIMEOUT_MS,
+        'Feishu clarification send',
+      );
+    } catch (err) {
+      console.error('[channel:feishu] failed to send clarification', err);
+      // Re-throw so the bridge can fail the run: a question the user never
+      // received can never be answered, and parking it would pin the scope.
+      throw err;
+    }
+  }
+
+  async onDone(text: string, options?: { stopped?: boolean }): Promise<void> {
+    this.cancelTimers();
+    // Any tool without an observed result (e.g. the run ended right after)
+    // shouldn't linger as ⏳ in the folded list.
+    const now = Date.now();
+    for (const t of this.tools) {
+      if (t.done) continue;
+      t.done = true;
+      t.elapsedSec = Math.round((now - t.startedAt) / 1000);
+    }
+    const stopped = options?.stopped === true || this.stopping;
+    const answer = text.trim();
+    const progress = this.accumulated.trimEnd();
+    const commentary = !stopped && answer && progress.endsWith(answer) ? progress.slice(0, -answer.length) : progress;
+    await this.finalize(() => buildDoneCard(commentary, this.tools, stopped), stopped ? '已停止。' : text || '已完成', stopped ? 'stopped' : 'completed');
+  }
+
+  async onError(message: string): Promise<void> {
+    this.cancelTimers();
+    await this.finalize(() => buildErrorCard(message), `执行失败：${message}`, 'error');
+  }
+
+  private elapsedSec(): number {
+    return Math.round((Date.now() - this.startedAt) / 1000);
+  }
+
+  private scheduleFlush(): void {
+    if (this.finalizing || this.flushTimer) return;
+    const wait = Math.max(0, PROGRESS_THROTTLE_MS - (Date.now() - this.lastFlush));
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = null;
+      this.lastFlush = Date.now();
+      this.enqueueProgress(() => buildProgressCard(this.accumulated, this.tools, this.elapsedSec()));
+    }, wait);
+  }
+
+  private startHeartbeat(): void {
+    if (this.heartbeatTimer) return;
+    this.heartbeatTimer = setInterval(() => {
+      if (this.finalizing) return;
+      this.lastFlush = Date.now();
+      this.enqueueProgress(() => buildProgressCard(this.accumulated, this.tools, this.elapsedSec()));
+    }, PROGRESS_HEARTBEAT_MS);
+  }
+
+  private cancelTimers(): void {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+
+  /**
+   * Keep only the newest progress snapshot while a card patch is in flight.
+   * Feishu patch calls can be slow; queuing every 800ms snapshot can leave the
+   * final answer stuck behind stale updates for minutes.
+   */
+  private enqueueProgress(factory: () => object): void {
+    if (this.finalizing) return;
+    this.pendingProgressFactory = factory;
+    this.drainProgressUpdates();
+  }
+
+  private drainProgressUpdates(): void {
+    if (this.updateInFlight || this.finalizing) return;
+    const factory = this.pendingProgressFactory;
+    if (!factory) return;
+
+    this.pendingProgressFactory = null;
+    const update = Promise.all([this.patchCard(factory, 'Feishu card update'), this.patchReply(this.replyProgress())]).then(results => results.every(Boolean));
+    this.updateInFlight = update;
+    void update.finally(() => {
+      if (this.updateInFlight === update) {
+        this.updateInFlight = null;
+      }
+      this.drainProgressUpdates();
+    });
+  }
+
+  private async patchCard(factory: () => object, label: string): Promise<boolean> {
+    if (this.cardFailed || !this.cardMessageId) return false;
+    try {
+      await withTimeout(
+        this.runCard.update(factory(), this.finalizing),
+        CARD_UPDATE_TIMEOUT_MS,
+        label,
+      );
+      return true;
+    } catch (err) {
+      if (isTimeoutError(err)) {
+        this.cardUpdateTimedOut = true;
+        this.runCard.abandon();
+      }
+      // Treat non-timeout patch failures as transient. Feishu can reject an
+      // individual update because of rate limits or a stale card state; stopping
+      // all later patches makes the bot appear frozen mid-run.
+      console.error('[channel:feishu] card update failed', err);
+      return false;
+    }
+  }
+
+  private async patchReply(card: object): Promise<boolean> {
+    if (!this.replyMessageId || this.replyTimedOut) return false;
+    const snapshot = JSON.stringify(card);
+    if (snapshot === this.replySnapshot) return true;
+    try {
+      await withTimeout(updateCardMessage(this.client, this.replyMessageId, card), CARD_UPDATE_TIMEOUT_MS, 'Feishu reply update');
+      this.replySnapshot = snapshot;
+      return true;
+    } catch (err) {
+      if (isTimeoutError(err)) this.replyTimedOut = true;
+      console.error('[channel:feishu] reply update failed', err);
+      return false;
+    }
+  }
+
+  private async finalize(factory: () => object, fallbackText: string, status: 'completed' | 'stopped' | 'error'): Promise<void> {
+    this.finalizing = true;
+    this.stopControl = undefined;
+    this.actions.remove(this.stopToken);
+    this.pendingProgressFactory = null;
+    if (this.updateInFlight) {
+      await this.updateInFlight;
+    }
+
+    // Legacy message patches have no ordering guarantee. CardKit can safely
+    // supersede a timed-out request with a newer sequence and close loading.
+    const [, replyUpdated] = await Promise.all([
+      this.cardUpdateTimedOut && !this.runCard.hasOrderedUpdates ? false : this.patchCard(factory, 'Feishu final card update'),
+      this.patchReply(buildReplyCard(fallbackText, status)),
+    ]);
+    if (!replyUpdated) {
+      await this.sendFallbackText(fallbackText);
+    }
+  }
+
+  private async sendFallbackText(text: string): Promise<void> {
+    try {
+      await withTimeout(
+        sendTextMessage(this.client, this.target, text),
+        CARD_SEND_TIMEOUT_MS,
+        'Feishu fallback text send',
+      );
+    } catch (err) {
+      console.error('[channel:feishu] fallback text send failed', err);
+    }
+  }
+}
+
+class TimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TimeoutError';
+  }
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: NodeJS.Timeout | null = null;
+  const timeout = new Promise<T>((_, reject) => {
+    timer = setTimeout(() => reject(new TimeoutError(label + ' timed out after ' + ms + 'ms')), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+function isTimeoutError(err: unknown): boolean {
+  return err instanceof TimeoutError || (err instanceof Error && err.name === 'TimeoutError');
+}
+
+function formatByteCount(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/run-actions.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/run-actions.ts
@@ -1,0 +1,30 @@
+import { randomUUID } from 'node:crypto';
+import type { FeishuCardActionEvent } from './feishu-channel';
+
+interface StopAction {
+  messageId: string;
+  requesterId: string;
+  stop: () => boolean;
+}
+
+/** Per-channel ephemeral controls. Never translate old buttons into /stop. */
+export class FeishuRunActions {
+  private readonly actions = new Map<string, StopAction>();
+  token(): string { return randomUUID(); }
+  register(token: string, action: StopAction): void { this.actions.set(token, action); }
+  remove(token: string): void { this.actions.delete(token); }
+  clear(): void { this.actions.clear(); }
+
+  handle(data: unknown): object | null {
+    if (!data || typeof data !== 'object') return null;
+    const envelope = data as FeishuCardActionEvent;
+    const event = envelope.event ?? envelope;
+    const value = event.action?.value ?? event.action?.behaviors?.find(item => item.value)?.value;
+    if (value?.action !== 'run.stop') return null;
+    const action = typeof value.token === 'string' ? this.actions.get(value.token) : undefined;
+    const messageId = event.open_message_id ?? event.message_id ?? event.context?.open_message_id ?? event.context?.message_id;
+    const operator = event.operator?.open_id ?? event.operator?.operator_id?.open_id ?? event.open_id;
+    const accepted = action && messageId === action.messageId && operator === action.requesterId && action.stop();
+    return { toast: { type: accepted ? 'success' : 'info', content: accepted ? '正在停止此任务' : '此任务已结束、尚未开始，或你不是任务发起人' } };
+  }
+}

--- a/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/run-card.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/channels/feishu/run-card.ts
@@ -1,0 +1,127 @@
+import type * as lark from '@larksuiteoapi/node-sdk';
+import { sendCardMessage, updateCardMessage, type FeishuSendTarget } from './feishu-client';
+
+interface CardNode {
+  tag?: string;
+  element_id?: string;
+  content?: string;
+  [key: string]: unknown;
+}
+
+function textElements(card: object): Map<string, string> {
+  const result = new Map<string, string>();
+  const visit = (value: unknown): void => {
+    if (!value || typeof value !== 'object') return;
+    const node = value as CardNode;
+    if (node.element_id && typeof node.content === 'string') {
+      result.set(node.element_id, node.content);
+    }
+    for (const child of Object.values(node)) {
+      if (Array.isArray(child)) child.forEach(visit);
+      else if (child && typeof child === 'object') visit(child);
+    }
+  };
+  visit(card);
+  return result;
+}
+
+function check(result: { code?: number; msg?: string }): void {
+  if (result.code && result.code !== 0) {
+    throw new Error(`Feishu CardKit: ${result.code} ${result.msg ?? 'unknown error'}`);
+  }
+}
+
+/** One transport per run; the stream owns serialization and bounded waits. */
+export class FeishuRunCard {
+  private cardId: string | null = null;
+  private messageId: string | null = null;
+  private sequence = 0;
+  private abandoned = false;
+  private cancellation = 0;
+  private readonly sent = new Map<string, string>();
+
+  constructor(private readonly client: lark.Client, private readonly target: FeishuSendTarget) {}
+
+  abandon(): void {
+    this.abandoned = true;
+    this.cancellation++;
+  }
+
+  get hasOrderedUpdates(): boolean { return this.cardId !== null; }
+
+  private assertActive(): void {
+    if (this.abandoned) throw new Error('Feishu run card operation was abandoned');
+  }
+
+  async open(card: object): Promise<string> {
+    const source = card as { config: object };
+    const streamingCard = {
+      ...source,
+      config: {
+        ...source.config,
+        update_multi: true,
+        streaming_mode: true,
+        streaming_config: {
+          print_frequency_ms: { default: 30 },
+          print_step: { default: 2 },
+          print_strategy: 'fast',
+        },
+      },
+    };
+    // Only entity creation can fall back: no chat message exists yet. Never
+    // send a second card after an ambiguous message-send failure.
+    try {
+      const result = await this.client.cardkit.v1.card.create({
+        data: { type: 'card_json', data: JSON.stringify(streamingCard) },
+      });
+      check(result);
+      if (!result.data?.card_id) throw new Error('Feishu CardKit returned no card id');
+      this.cardId = result.data.card_id;
+    } catch (error) {
+      console.warn('[channel:feishu] native streaming unavailable; using message patches', error);
+    }
+    this.assertActive();
+    this.messageId = await sendCardMessage(this.client, this.target,
+      this.cardId ? { type: 'card', data: { card_id: this.cardId } } : card);
+    for (const [id, text] of textElements(card)) this.sent.set(id, text);
+    return this.messageId;
+  }
+
+  async update(card: object, final: boolean): Promise<void> {
+    if (!this.messageId) throw new Error('Feishu run card is not open');
+    if (!this.cardId) return updateCardMessage(this.client, this.messageId, card);
+    if (!final) this.assertActive();
+    const path = { card_id: this.cardId };
+    if (final) {
+      const cancellation = this.cancellation;
+      // Close the native loading/printing lifecycle before replacing the layout.
+      check(await this.client.cardkit.v1.card.settings({
+        path,
+        data: { sequence: ++this.sequence, settings: JSON.stringify({ config: { streaming_mode: false } }) },
+      }));
+      // A prior progress timeout stops its remaining calls, but a final update
+      // can supersede that request using a newer CardKit sequence. A timeout of
+      // this final operation itself must still prevent a late second request.
+      if (cancellation !== this.cancellation) throw new Error('Feishu final update was abandoned');
+      check(await this.client.cardkit.v1.card.update({
+        path,
+        data: {
+          sequence: ++this.sequence,
+          card: { type: 'card_json', data: JSON.stringify(card) },
+        },
+      }));
+      return;
+    }
+    // Send full accumulated text to stable element IDs. Prefix appends animate
+    // on the client; changing a tool's state replaces only that text component.
+    for (const [element_id, content] of textElements(card)) {
+      this.assertActive();
+      if (!content || this.sent.get(element_id) === content) continue;
+      check(await this.client.cardkit.v1.cardElement.content({
+        path: { ...path, element_id },
+        data: { content, sequence: ++this.sequence },
+      }));
+      this.sent.set(element_id, content);
+    }
+  }
+}

--- a/apps/canvas-workspace/src/plugins/main/channel/core/bridge.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/core/bridge.ts
@@ -277,6 +277,7 @@ export class ChannelBridge {
     let settleWatchdog: ((result: AgentChatResult) => void) | null = null;
 
     const markAgentActivity = (): void => {
+      if (!turnStarted) stream.onRunStart?.(() => { if (!finished) this.runtime.abort(scope, sessionId); });
       turnStarted = true;
       lastAgentActivityAt = Date.now();
     };
@@ -460,7 +461,7 @@ export class ChannelBridge {
       if (idleTimer) clearTimeout(idleTimer);
 
       if (result.ok) {
-        await stream.onDone(result.response?.trim() || '✅ Done');
+        await stream.onDone(result.response?.trim() || '✅ Done', { stopped: 'stopped' in result && result.stopped === true });
       } else {
         await stream.onError(result.error ?? 'Unknown error');
       }

--- a/apps/canvas-workspace/src/plugins/main/channel/core/types.ts
+++ b/apps/canvas-workspace/src/plugins/main/channel/core/types.ts
@@ -68,11 +68,13 @@ export type CommandReply =
 
 /**
  * A live output sink for a single agent run. The channel decides how each
- * event renders (Feishu progressively patches one interactive card). All
+ * event renders (Feishu updates process and response cards independently). All
  * methods may be async; callers await them so a channel can serialize its
  * own writes.
  */
 export interface ChannelStream {
+  /** Called only when this queued turn actually begins; control expires with the turn. */
+  onRunStart?(stop: () => void): void;
   onText(delta: string): void | Promise<void>;
   onToolCall(name: string, args: unknown, toolCallId?: string): void | Promise<void>;
   onToolResult?(result: { name: string; result: string; toolCallId?: string }): void | Promise<void>;
@@ -81,7 +83,7 @@ export interface ChannelStream {
   onToolInputEnd?(data: { id: string }): void | Promise<void>;
   onImage?(imagePath: string, mimeType?: string): void | Promise<void>;
   onClarification(question: string): void | Promise<void>;
-  onDone(text: string): void | Promise<void>;
+  onDone(text: string, options?: { stopped?: boolean }): void | Promise<void>;
   onError(message: string): void | Promise<void>;
 }
 


### PR DESCRIPTION
Feishu agent runs now stream public progress and tool activity into a dedicated process card while keeping the final answer in a separate reply card. The reply provides a Stop button bound to the initiating user, reply message, and active turn; queued and stale controls cannot abort a later turn or another topic.

The channel uses native CardKit text updates with ordered completion and a legacy-card fallback. It preserves bounded final-card text and adds an account-free replay harness for delayed updates, errors, stopping, and narrow layouts.

Validation on an isolated checkout based on the latest master:
- Standard harness acceptance: 8/8 checks passed, including Canvas typecheck, full test suite, replay regressions, and harness integrity.
- Core workspace build and Canvas production build passed.
- Local replay checks cover both 680px and 375px card widths. The replay renderer is a simulation; native Feishu rendering and animation remain unverified.

Native streaming requires `cardkit:card:write`; Stop controls require the `card.action.trigger` callback. Setup and replay commands are documented in the channel README.
