### PR TITLE
fix(canvas): filter stale workspace chats and fix anchor button styles

### DIFF
--- a/apps/canvas-workspace/harness/knowledge/chat-sessions.md
+++ b/apps/canvas-workspace/harness/knowledge/chat-sessions.md
@@ -328,6 +328,12 @@ node-detail / canvas-preview) beside the chat, and must never navigate — a
 control that routes away from the page the user is reading is not a panel
 toggle.
 
+Shared topbar controls must carry their own button styles: `ChatAnchors` uses
+`ui/Button` (icon, md) rather than relying on the lazily loaded ChatPanel CSS.
+Cold-loading `/chat` does not load that panel stylesheet; a raw trigger otherwise
+falls back to browser-default chrome. Guard: `ChatAnchors/__tests__/ChatAnchors.test.tsx`;
+visual verification must include a populated cold chat route, not only canvas-first navigation.
+
 `RightDock/dock-content-tabs.ts` owns that switch, via
 `store.toggleContentTabs`:
 

--- a/apps/canvas-workspace/src/main/__tests__/ui-reuse-governance.test.ts
+++ b/apps/canvas-workspace/src/main/__tests__/ui-reuse-governance.test.ts
@@ -127,7 +127,8 @@ const RATCHET_BASELINE: Record<string, number> = {
   // settings action buttons while retaining the New chat action.
   // 280→273 (module-first ownership batches): obsolete duplicate controls
   // disappeared as product visuals gained one owning component each.
-  rawButtonTags: 273,
+  // ChatAnchors owns its trigger styling via ui/Button, independent of lazy ChatPanel CSS.
+  rawButtonTags: 272,
   // raw <input> tags in .tsx — falls as components/ui/TextField absorbs them.
   // 55→54: ui/TextField's own <input> (+1), WorkspaceSettings name field
   // migrated (-1), and comment-stripping dropped one doc mention (-1).

--- a/apps/canvas-workspace/src/main/agent/__tests__/service-history.test.ts
+++ b/apps/canvas-workspace/src/main/agent/__tests__/service-history.test.ts
@@ -261,6 +261,38 @@ describe('CanvasAgentService history', () => {
     expect(canvasAgentState.configs).toHaveLength(initialConfigCount + 1);
   });
 
+  it('lists only visible workspace stores while preserving global and scheduled history', async () => {
+    const ids = ['ws-visible', 'ws-removed', '__global_chat__', '__scheduled__-task-1'];
+    for (const workspaceId of ids) {
+      const dir = join(sessionRoot, workspaceId, 'agent-sessions');
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(join(dir, 'current.json'), JSON.stringify({
+        sessionId: `session-${workspaceId}`, workspaceId, createdAt: 1, updatedAt: 2,
+        messages: [{ role: 'user', content: 'saved history', timestamp: 1 }],
+      }));
+    }
+    const service = new CanvasAgentService();
+    const groups = await service.listAllSessions({ 'ws-visible': 'Visible' });
+    expect(groups.map(group => group.workspaceId).sort()).toEqual(
+      ['ws-visible', '__global_chat__', '__scheduled__-task-1'].sort(),
+    );
+    expect(await fs.readFile(join(sessionRoot, 'ws-removed', 'agent-sessions', 'current.json'), 'utf8'))
+      .toContain('saved history');
+    const empty = await service.listAllSessions({});
+    expect(empty.map(group => group.workspaceId).sort()).toEqual(['__global_chat__', '__scheduled__-task-1'].sort());
+  });
+
+  it('does not reintroduce a removed workspace through an active agent', async () => {
+    const service = new CanvasAgentService();
+    await service.activate('ws-visible');
+    await service.activate('ws-removed');
+    const groups = await service.listAllSessions({ 'ws-visible': 'Visible' });
+    expect(groups.map(group => group.workspaceId)).toEqual(['ws-visible']);
+    canvasAgentState.listSessions.mockClear();
+    expect(await service.listAllSessions({})).toEqual([]);
+    expect(canvasAgentState.listSessions).not.toHaveBeenCalled();
+  });
+
   it('hides an active empty-chat scope from the unified session groups', async () => {
     const scan = vi.spyOn(SessionStore, 'listAllWorkspaceSessions').mockResolvedValue([]);
     const service = new CanvasAgentService();
@@ -269,7 +301,7 @@ describe('CanvasAgentService history', () => {
 
     const groups = await service.listAllSessions({});
 
-    expect(scan).toHaveBeenCalledWith(new Set(['__global_chat__']));
+    expect(scan).toHaveBeenCalledWith(new Set(['__global_chat__']), new Set());
 
     expect(groups).toEqual([]);
   });

--- a/apps/canvas-workspace/src/main/agent/active-session-groups.ts
+++ b/apps/canvas-workspace/src/main/agent/active-session-groups.ts
@@ -45,6 +45,7 @@ export async function appendActiveSessionGroups({
 }: AppendActiveSessionGroupsOptions): Promise<void> {
   for (const [key, agent] of agents) {
     const scope = scopeFromServiceKey(key);
+    if (scope.kind === 'workspace' && !Object.prototype.hasOwnProperty.call(workspaceNames, scope.workspaceId)) continue;
     const storeId = scopeSessionStoreId(scope);
     if (includedStoreIds.has(storeId)) continue;
     const sessions = await agent.listSessions();

--- a/apps/canvas-workspace/src/main/agent/service.ts
+++ b/apps/canvas-workspace/src/main/agent/service.ts
@@ -317,8 +317,8 @@ export class CanvasAgentService {
     return this.sessionMutations.loadStoredSession(scope, sessionId, () => loadCanvasAgentSessionFromStore(scope, sessionId));
   }
   /**
-   * List sessions from ALL workspaces, grouped by workspace.
-   * @param workspaceNames — map of workspaceId → display name (from renderer manifest)
+   * List sessions from visible workspaces and global/scheduled scopes.
+   * @param workspaceNames — authoritative visible workspaceId → name map from renderer manifest
    */
   async listAllSessions(
     workspaceNames: Record<string, string>,
@@ -327,7 +327,7 @@ export class CanvasAgentService {
     const activeStoreIds = new Set(Array.from(
       this.agents.keys(), key => scopeSessionStoreId(scopeFromServiceKey(key)),
     ));
-    const diskGroups = await SessionStore.listAllWorkspaceSessions(activeStoreIds);
+    const diskGroups = await SessionStore.listAllWorkspaceSessions(activeStoreIds, new Set(Object.keys(workspaceNames)));
     const groups: CrossWorkspaceSessionGroup[] = [];
     const scheduledTitles = await scheduledTaskTitles();
     const includedStoreIds = new Set<string>();

--- a/apps/canvas-workspace/src/main/agent/session-store-scan.ts
+++ b/apps/canvas-workspace/src/main/agent/session-store-scan.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs';
 import { join } from 'path';
-import { isListableSessionStore } from '../../shared/agent-chat';
+import { GLOBAL_CHAT_STORE_ID, isListableSessionStore, scheduledTaskIdFromStoreId } from '../../shared/agent-chat';
 import { listIndexedSessions } from './session-index';
 import type { AgentSessionListEntry } from './session-file-summary';
 
@@ -9,6 +9,7 @@ export { archiveSortKey, isListableSession, sessionUpdatedAt, type AgentSessionL
 export async function scanAllWorkspaceSessions(
   rootDir: string,
   excludedStoreIds: ReadonlySet<string> = new Set(),
+  visibleWorkspaceIds?: ReadonlySet<string>,
 ): Promise<Array<{ workspaceId: string; sessions: AgentSessionListEntry[] }>> {
   let entries: import('fs').Dirent[];
   try {
@@ -19,7 +20,10 @@ export async function scanAllWorkspaceSessions(
   const storeIds = entries
     .filter(entry => entry.isDirectory())
     .map(entry => entry.name)
-    .filter(dir => isListableSessionStore(dir) && !excludedStoreIds.has(dir));
+    .filter(dir => isListableSessionStore(dir) && !excludedStoreIds.has(dir))
+    // The rail manifest is authoritative; leftover directories are history, not workspaces.
+    .filter(dir => !visibleWorkspaceIds || visibleWorkspaceIds.has(dir)
+      || dir === GLOBAL_CHAT_STORE_ID || Boolean(scheduledTaskIdFromStoreId(dir)));
   const groups = await Promise.all(storeIds.map(async (workspaceId) => {
     const sessionsDir = join(rootDir, workspaceId, 'agent-sessions');
     const sessions = await listIndexedSessions(sessionsDir, join(sessionsDir, 'metadata.json'));

--- a/apps/canvas-workspace/src/main/agent/session-store.ts
+++ b/apps/canvas-workspace/src/main/agent/session-store.ts
@@ -295,8 +295,8 @@ export class SessionStore {
   // ─── Cross-workspace scanning ────────────────────────────────
 
   /** Scan all listable session stores. */
-  static listAllWorkspaceSessions(excludedStoreIds?: ReadonlySet<string>) {
-    return scanAllWorkspaceSessions(storeDir(), excludedStoreIds);
+  static listAllWorkspaceSessions(excludedStoreIds?: ReadonlySet<string>, visibleWorkspaceIds?: ReadonlySet<string>) {
+    return scanAllWorkspaceSessions(storeDir(), excludedStoreIds, visibleWorkspaceIds);
   }
 
   /** Read a store's on-disk current id without activating an agent. */

--- a/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
+++ b/apps/canvas-workspace/src/renderer/src/i18n/messages.ts
@@ -886,6 +886,8 @@ const en = {
   'chat.mention.projectFiles': 'Project Files',
   'chat.mention.projectFolders': 'Project Folders',
   'chat.mention.suggestions': 'Mention suggestions',
+  'chat.mention.searching': 'Searching mentions…',
+  'chat.mention.noResults': 'No matching mentions',
 
   'nodeMention.title': '@ Reference a node',
   'nodeMention.searchPlaceholder': 'Search node names...',
@@ -2798,6 +2800,8 @@ const zh: Record<keyof typeof en, string> = {
   'chat.mention.projectFiles': '项目文件',
   'chat.mention.projectFolders': '项目文件夹',
   'chat.mention.suggestions': '引用建议',
+  'chat.mention.searching': '正在搜索引用…',
+  'chat.mention.noResults': '没有匹配的引用',
 
   'nodeMention.title': '@ 引用节点',
   'nodeMention.searchPlaceholder': '搜索节点名称...',

--- a/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatAnchors/__tests__/ChatAnchors.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatAnchors/__tests__/ChatAnchors.test.tsx
@@ -49,6 +49,19 @@ describe('ChatAnchors', () => {
     expect(host?.innerHTML).toBe('');
   });
 
+  it('owns its icon-button styling without loading ChatPanel CSS', () => {
+    render(
+      <I18nProvider>
+        <ChatAnchors anchors={ANCHORS} onJump={vi.fn()} />
+      </I18nProvider>,
+    );
+    const trigger = host!.querySelector<HTMLButtonElement>('.chat-panel-action-btn')!;
+    expect(trigger.classList.contains('ui-btn')).toBe(true);
+    expect(trigger.classList.contains('ui-btn--icon')).toBe(true);
+    expect(trigger.classList.contains('ui-btn--md')).toBe(true);
+    expect(trigger.querySelector('svg')?.getAttribute('width')).toBe('16');
+  });
+
   it('opens on trigger click and lists anchors in order', () => {
     render(
       <I18nProvider>

--- a/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatAnchors/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatAnchors/index.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useId, useRef, type KeyboardEvent as ReactKeybo
 import './index.css';
 import { ListLinesIcon } from '../../../../components/icons';
 import { useI18n } from '../../../../i18n';
-import { DropdownShell } from '../../../../components/ui';
+import { Button, DropdownShell } from '../../../../components/ui';
 import type { ChatAnchor } from '../utils/anchors';
 
 interface ChatAnchorsProps {
@@ -73,7 +73,9 @@ export const ChatAnchors = ({ anchors, onJump }: ChatAnchorsProps) => {
           openRef.current = open;
           toggleRef.current = toggle;
           return (
-            <button
+            <Button
+              variant="icon"
+              size="md"
               ref={triggerRef}
               type="button"
               className="chat-panel-action-btn"
@@ -98,7 +100,7 @@ export const ChatAnchors = ({ anchors, onJump }: ChatAnchorsProps) => {
               }}
             >
               <ListLinesIcon size={16} />
-            </button>
+            </Button>
           );
         }}
       >

--- a/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatComposer/__tests__/useChatComposerInput.tabs.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatComposer/__tests__/useChatComposerInput.tabs.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { act } from 'react';
+import { act, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { I18nProvider } from '../../../../../i18n';
@@ -52,13 +52,58 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-const renderHook = async () => {
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+};
+
+const setMentionQuery = async (query: string) => {
+  const editable = latest?.editableRef.current;
+  if (!editable) throw new Error('composer did not mount');
+  editable.textContent = `@${query}`;
+  const textNode = editable.firstChild;
+  if (!textNode) throw new Error('composer query did not mount');
+  const range = document.createRange();
+  range.setStart(textNode, query.length + 1);
+  range.collapse(true);
+  const selection = window.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+  act(() => latest?.handleInput());
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+const sessionResult = (query: string) => ({
+  ok: true,
+  hits: [{
+    sessionId: `session-${query}`,
+    workspaceId: 'workspace-product',
+    workspaceName: 'Product',
+    preview: `${query} result`,
+    date: '2026-09-12',
+  }],
+});
+
+const renderHook = async (overrides: {
+  pluginList?: () => Promise<unknown>;
+  searchSessions?: (query: string) => Promise<unknown>;
+} = {}) => {
   Object.defineProperty(window, 'canvasWorkspace', {
     configurable: true,
     value: {
       agentRoles: { list: vi.fn(async () => ({ ok: true, roles: [] })) },
+      agent: {
+        searchSessions: vi.fn(overrides.searchSessions ?? (async () => ({ ok: true, hits: [] }))),
+      },
       pluginMarket: {
-        list: vi.fn(async () => ({
+        list: vi.fn(overrides.pluginList ?? (async () => ({
           ok: true,
           snapshot: {
             updatedAt: 1,
@@ -69,7 +114,7 @@ const renderHook = async () => {
               installState: 'installed',
             }],
           },
-        })),
+        }))),
       },
     },
   });
@@ -133,5 +178,156 @@ describe('global chat dock-tab mentions', () => {
     });
     expect(latest?.mentionItems.some(item => item.type === 'tab' && item.label === 'Roadmap'))
       .toBe(true);
+  });
+
+  it('shows loading before async results and settles loading separately from no results', async () => {
+    const search = deferred<ReturnType<typeof sessionResult>>();
+    await renderHook({ searchSessions: async () => search.promise });
+
+    await setMentionQuery('CPA');
+
+    expect(latest?.mentionOpen).toBe(true);
+    expect(latest?.mentionLoading).toBe(true);
+    expect(latest?.mentionItems).toEqual([]);
+
+    await act(async () => search.resolve(sessionResult('CPA')));
+
+    expect(latest?.mentionLoading).toBe(false);
+    expect(latest?.mentionItems).toEqual([
+      expect.objectContaining({
+        type: 'session',
+        sessionId: 'session-CPA',
+        label: 'CPA result',
+      }),
+    ]);
+
+    const emptySearch = deferred<{ ok: true; hits: [] }>();
+    const searchSessions = window.canvasWorkspace.agent.searchSessions as ReturnType<typeof vi.fn>;
+    searchSessions.mockImplementationOnce(async () => emptySearch.promise);
+    await setMentionQuery('missing');
+
+    expect(latest?.mentionOpen).toBe(true);
+    expect(latest?.mentionLoading).toBe(true);
+    expect(latest?.mentionItems).toEqual([]);
+
+    await act(async () => emptySearch.resolve({ ok: true, hits: [] }));
+
+    expect(latest?.mentionOpen).toBe(true);
+    expect(latest?.mentionLoading).toBe(false);
+    expect(latest?.mentionItems).toEqual([]);
+
+    const preventDefault = vi.fn();
+    await act(async () => {
+      latest?.handleKeyDown({
+        key: 'Enter',
+        shiftKey: false,
+        preventDefault,
+      } as unknown as ReactKeyboardEvent<HTMLDivElement>);
+      await Promise.resolve();
+    });
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(onSubmit).toHaveBeenCalledWith('@missing', undefined, []);
+  });
+
+  it('keeps newer loading and results authoritative across rapid query changes', async () => {
+    const oldSearch = deferred<ReturnType<typeof sessionResult>>();
+    const newSearch = deferred<ReturnType<typeof sessionResult>>();
+    const searchSessions = vi.fn((query: string) => (
+      query === 'old' ? oldSearch.promise : newSearch.promise
+    ));
+    await renderHook({ searchSessions });
+
+    await setMentionQuery('old');
+    expect(searchSessions).toHaveBeenCalledWith('old', 5);
+    expect(latest?.mentionLoading).toBe(true);
+
+    await setMentionQuery('new');
+    expect(searchSessions).toHaveBeenCalledWith('new', 5);
+    expect(latest?.mentionOpen).toBe(true);
+    expect(latest?.mentionLoading).toBe(true);
+
+    await act(async () => oldSearch.resolve(sessionResult('old')));
+    expect(latest?.mentionOpen).toBe(true);
+    expect(latest?.mentionLoading).toBe(true);
+    expect(latest?.mentionItems).toEqual([]);
+
+    await act(async () => newSearch.resolve(sessionResult('new')));
+    expect(latest?.mentionLoading).toBe(false);
+    expect(latest?.mentionItems).toEqual([
+      expect.objectContaining({
+        type: 'session',
+        sessionId: 'session-new',
+        label: 'new result',
+      }),
+    ]);
+  });
+
+  it('keeps a reopened query authoritative after closing a pending search', async () => {
+    const oldSearch = deferred<ReturnType<typeof sessionResult>>();
+    const newSearch = deferred<ReturnType<typeof sessionResult>>();
+    const searchSessions = vi.fn((query: string) => (
+      query === 'old' ? oldSearch.promise : newSearch.promise
+    ));
+    await renderHook({ searchSessions });
+
+    await setMentionQuery('old');
+    act(() => document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true })));
+    expect(latest?.mentionOpen).toBe(false);
+    expect(latest?.mentionLoading).toBe(false);
+
+    await setMentionQuery('new');
+    expect(latest?.mentionOpen).toBe(true);
+    expect(latest?.mentionLoading).toBe(true);
+
+    await act(async () => oldSearch.resolve(sessionResult('old')));
+    expect(latest?.mentionOpen).toBe(true);
+    expect(latest?.mentionLoading).toBe(true);
+    expect(latest?.mentionItems).toEqual([]);
+
+    await act(async () => newSearch.resolve(sessionResult('new')));
+    expect(latest?.mentionLoading).toBe(false);
+    expect(latest?.mentionItems).toEqual([
+      expect.objectContaining({
+        type: 'session',
+        sessionId: 'session-new',
+      }),
+    ]);
+  });
+
+  it('invalidates pending mention state when input is replaced programmatically', async () => {
+    const search = deferred<ReturnType<typeof sessionResult>>();
+    await renderHook({ searchSessions: async () => search.promise });
+    await setMentionQuery('pending');
+
+    act(() => latest?.replaceInput('replacement'));
+    expect(latest?.mentionOpen).toBe(false);
+    expect(latest?.mentionLoading).toBe(false);
+    expect(latest?.mentionItems).toEqual([]);
+
+    await act(async () => search.resolve(sessionResult('pending')));
+    expect(latest?.mentionOpen).toBe(false);
+    expect(latest?.mentionLoading).toBe(false);
+    expect(latest?.mentionItems).toEqual([]);
+  });
+
+  it('closes and invalidates a pending mention search on Escape', async () => {
+    const search = deferred<ReturnType<typeof sessionResult>>();
+    await renderHook({ searchSessions: async () => search.promise });
+    await setMentionQuery('pending');
+    const preventDefault = vi.fn();
+
+    act(() => latest?.handleKeyDown({
+      key: 'Escape',
+      preventDefault,
+    } as unknown as ReactKeyboardEvent<HTMLDivElement>));
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(latest?.mentionOpen).toBe(false);
+    expect(latest?.mentionLoading).toBe(false);
+
+    await act(async () => search.resolve(sessionResult('pending')));
+    expect(latest?.mentionOpen).toBe(false);
+    expect(latest?.mentionLoading).toBe(false);
+    expect(latest?.mentionItems).toEqual([]);
   });
 });

--- a/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatComposer/useChatComposerInput.ts
+++ b/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatComposer/useChatComposerInput.ts
@@ -31,6 +31,7 @@ export function useChatComposerInput({
 }: UseChatComposerInputOptions) {
   const [mentionOpen, setMentionOpen] = useState(false);
   const [mentionItems, setMentionItems] = useState<MentionItem[]>([]);
+  const [mentionLoading, setMentionLoading] = useState(false);
   const [mentionIndex, setMentionIndex] = useState(0);
   const workspaceId = agentScope.kind === 'workspace' ? agentScope.workspaceId : undefined;
   const {
@@ -50,6 +51,7 @@ export function useChatComposerInput({
     mentionBuildSeqRef.current++;
     setMentionOpen(false);
     setMentionItems([]);
+    setMentionLoading(false);
     setMentionIndex(0);
   }, [scopeId]);
   /** Trigger whose query selectMention must replace. */
@@ -78,6 +80,7 @@ export function useChatComposerInput({
     setInput,
     setMentionOpen,
     setMentionItems,
+    setMentionLoading,
     setMentionIndex,
     setAttachments,
   });
@@ -98,7 +101,9 @@ export function useChatComposerInput({
       || !selection.anchorNode
       || selection.anchorNode.nodeType !== Node.TEXT_NODE
     ) {
+      setMentionLoading(false);
       setMentionOpen(false);
+      setMentionItems([]);
       return;
     }
 
@@ -113,7 +118,9 @@ export function useChatComposerInput({
       : atMatch ?? slashMatch;
 
     if (!match) {
+      setMentionLoading(false);
       setMentionOpen(false);
+      setMentionItems([]);
       return;
     }
 
@@ -121,10 +128,17 @@ export function useChatComposerInput({
     mentionTriggerRef.current = trigger;
 
     setMentionIndex(0);
+    setMentionItems([]);
+    setMentionLoading(true);
+    setMentionOpen(true);
     void buildMentionItems(match[1], trigger).then(items => {
       if (buildSeq !== mentionBuildSeqRef.current) return;
       setMentionItems(items);
-      setMentionOpen(items.length > 0);
+      setMentionLoading(false);
+    }).catch(() => {
+      if (buildSeq !== mentionBuildSeqRef.current) return;
+      setMentionItems([]);
+      setMentionLoading(false);
     });
   }, [buildMentionItems]);
 
@@ -137,6 +151,7 @@ export function useChatComposerInput({
       if (editableRef.current?.contains(target)) return;
       if (target.closest('.chat-mention-popup')) return;
       mentionBuildSeqRef.current++;
+      setMentionLoading(false);
       setMentionOpen(false);
     };
     document.addEventListener('mousedown', handleMouseDown);
@@ -184,6 +199,7 @@ export function useChatComposerInput({
 
     setInput(serializeEditable(element));
     mentionBuildSeqRef.current++;
+    setMentionLoading(false);
     setMentionOpen(false);
     element.focus();
   }, [nodes]);
@@ -211,30 +227,33 @@ export function useChatComposerInput({
     // never send the message or move the mention selection.
     if (isImeComposing(event)) return;
 
-    if (mentionOpen && mentionItems.length > 0) {
-      if (event.key === 'ArrowDown') {
-        event.preventDefault();
-        setMentionIndex(index => (index + 1) % mentionItems.length);
-        return;
-      }
-
-      if (event.key === 'ArrowUp') {
-        event.preventDefault();
-        setMentionIndex(index => (index - 1 + mentionItems.length) % mentionItems.length);
-        return;
-      }
-
-      if (event.key === 'Enter' || event.key === 'Tab') {
-        event.preventDefault();
-        selectMention(mentionItems[mentionIndex]);
-        return;
-      }
-
+    if (mentionOpen) {
       if (event.key === 'Escape') {
         event.preventDefault();
         mentionBuildSeqRef.current++;
+        setMentionLoading(false);
         setMentionOpen(false);
         return;
+      }
+
+      if (mentionItems.length > 0) {
+        if (event.key === 'ArrowDown') {
+          event.preventDefault();
+          setMentionIndex(index => (index + 1) % mentionItems.length);
+          return;
+        }
+
+        if (event.key === 'ArrowUp') {
+          event.preventDefault();
+          setMentionIndex(index => (index - 1 + mentionItems.length) % mentionItems.length);
+          return;
+        }
+
+        if (event.key === 'Enter' || event.key === 'Tab') {
+          event.preventDefault();
+          selectMention(mentionItems[mentionIndex]);
+          return;
+        }
       }
     }
 
@@ -274,6 +293,7 @@ export function useChatComposerInput({
     insertTabMention,
     mentionIndex,
     mentionItems,
+    mentionLoading,
     mentionOpen,
     removeAttachment: chatAttachments.removeAttachment,
     retryAttachment: chatAttachments.retryAttachment,

--- a/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatComposer/useEditableInputControl.ts
+++ b/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatComposer/useEditableInputControl.ts
@@ -7,6 +7,7 @@ interface Options {
   setInput: (value: string) => void;
   setMentionOpen: (value: boolean) => void;
   setMentionItems: (value: MentionItem[]) => void;
+  setMentionLoading: (value: boolean) => void;
   setMentionIndex: (value: number) => void;
   setAttachments: (value: ChatImageAttachment[]) => void;
 }
@@ -18,6 +19,7 @@ export const useEditableInputControl = ({
   setInput,
   setMentionOpen,
   setMentionItems,
+  setMentionLoading,
   setMentionIndex,
   setAttachments,
 }: Options) => {
@@ -27,9 +29,10 @@ export const useEditableInputControl = ({
     mentionBuildSeqRef.current++;
     setMentionOpen(false);
     setMentionItems([]);
+    setMentionLoading(false);
     setMentionIndex(0);
     setAttachments([]);
-  }, [editableRef, mentionBuildSeqRef, setAttachments, setInput, setMentionIndex, setMentionItems, setMentionOpen]);
+  }, [editableRef, mentionBuildSeqRef, setAttachments, setInput, setMentionIndex, setMentionItems, setMentionLoading, setMentionOpen]);
 
   const focusInput = useCallback(() => {
     editableRef.current?.focus();
@@ -39,6 +42,7 @@ export const useEditableInputControl = ({
     mentionBuildSeqRef.current++;
     setMentionOpen(false);
     setMentionItems([]);
+    setMentionLoading(false);
     setMentionIndex(0);
     const element = editableRef.current;
     if (element) element.textContent = text;
@@ -50,7 +54,7 @@ export const useEditableInputControl = ({
     const selection = window.getSelection();
     selection?.removeAllRanges();
     selection?.addRange(range);
-  }, [editableRef, mentionBuildSeqRef, setInput, setMentionIndex, setMentionItems, setMentionOpen]);
+  }, [editableRef, mentionBuildSeqRef, setInput, setMentionIndex, setMentionItems, setMentionLoading, setMentionOpen]);
 
   return { clearInput, focusInput, replaceInput };
 };

--- a/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatInput/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatInput/index.tsx
@@ -168,7 +168,9 @@ export const ChatInput = ({
           aria-haspopup="listbox"
           aria-expanded={mentionOpen}
           aria-controls={mentionOpen ? CHAT_MENTION_LISTBOX_ID : undefined}
-          aria-activedescendant={mentionOpen ? chatMentionOptionId(mentionIndex) : undefined}
+          aria-activedescendant={mentionOpen && mentionIndex >= 0
+            ? chatMentionOptionId(mentionIndex)
+            : undefined}
           data-placeholder={placeholder ?? (knowledgeMode
             ? (contextChips.length === 1 && contextChips[0]?.kind === 'node'
               ? t('chat.askCurrentNode')

--- a/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatMentionPopup/__tests__/ChatMentionPopup.test.tsx
+++ b/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatMentionPopup/__tests__/ChatMentionPopup.test.tsx
@@ -63,4 +63,49 @@ describe('ChatMentionPopup', () => {
     expect(options[1].querySelector<HTMLImageElement>('.chat-plugin-brand-icon img')?.src)
       .toContain('arcade');
   });
+
+  it('distinguishes accessible loading and empty states', async () => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+
+    await act(async () => {
+      root?.render(
+        <I18nProvider>
+          <ChatMentionPopup
+            mentionItems={[]}
+            mentionIndex={0}
+            isLoading
+            onSelectMention={vi.fn()}
+            onMentionIndexChange={vi.fn()}
+          />
+        </I18nProvider>,
+      );
+    });
+
+    const listbox = host.querySelector<HTMLElement>('[role="listbox"]');
+    const status = host.querySelector<HTMLElement>('[role="status"]');
+    expect(listbox?.getAttribute('aria-busy')).toBe('true');
+    expect(status?.textContent).toContain('Searching mentions');
+    expect(listbox?.contains(status ?? null)).toBe(false);
+    expect(host.querySelector('.chat-spin')).not.toBeNull();
+    expect(host.textContent).not.toContain('No matching mentions');
+
+    await act(async () => {
+      root?.render(
+        <I18nProvider>
+          <ChatMentionPopup
+            mentionItems={[]}
+            mentionIndex={0}
+            onSelectMention={vi.fn()}
+            onMentionIndexChange={vi.fn()}
+          />
+        </I18nProvider>,
+      );
+    });
+
+    expect(listbox?.getAttribute('aria-busy')).toBe('false');
+    expect(host.querySelector('[role="status"]')?.textContent).toBe('No matching mentions');
+    expect(host.querySelector('.chat-spin')).toBeNull();
+  });
 });

--- a/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatMentionPopup/index.css
+++ b/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatMentionPopup/index.css
@@ -31,6 +31,32 @@
   padding-top: 6px;
 }
 
+.chat-mention-status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 44px;
+  padding: 8px 10px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.chat-mention-status-spinner {
+  display: inline-flex;
+  flex-shrink: 0;
+}
+
+.chat-mention-status .chat-spin {
+  animation: spin 0.7s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-mention-status .chat-spin {
+    animation: none;
+  }
+}
+
 .chat-mention-item {
   display: flex;
   align-items: center;

--- a/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatMentionPopup/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatMentionPopup/index.tsx
@@ -8,10 +8,12 @@ import { useI18n } from '../../../../i18n';
 import { SessionTitle } from '../SessionTitle';
 import { sessionTitleText } from '../utils/sessionTitle';
 import { pluginMentionIconMarkup } from '../utils/pluginMentionIcons';
+import { SpinnerIcon } from '../../../../components/icons';
 
 interface ChatMentionPopupProps {
   mentionItems: MentionItem[];
   mentionIndex: number;
+  isLoading?: boolean;
   onSelectMention: (item: MentionItem) => void;
   onMentionIndexChange: (index: number) => void;
 }
@@ -22,6 +24,7 @@ export const chatMentionOptionId = (index: number): string => `chat-mention-opti
 export const ChatMentionPopup = ({
   mentionItems,
   mentionIndex,
+  isLoading = false,
   onSelectMention,
   onMentionIndexChange,
 }: ChatMentionPopupProps) => {
@@ -36,14 +39,26 @@ export const ChatMentionPopup = ({
   }, [mentionIndex]);
 
   return (
-    <div
-      className="chat-mention-popup"
-      id={CHAT_MENTION_LISTBOX_ID}
-      ref={popupRef}
-      role="listbox"
-      aria-label={t('chat.mention.suggestions')}
-    >
-      {mentionItems.map((item, index) => {
+    <div className="chat-mention-popup" ref={popupRef}>
+      {isLoading ? (
+        <div className="chat-mention-status" role="status" aria-live="polite">
+          <span className="chat-mention-status-spinner" aria-hidden="true">
+            <SpinnerIcon size={14} className="chat-spin" />
+          </span>
+          <span>{t('chat.mention.searching')}</span>
+        </div>
+      ) : mentionItems.length === 0 ? (
+        <div className="chat-mention-status" role="status">
+          {t('chat.mention.noResults')}
+        </div>
+      ) : null}
+      <div
+        id={CHAT_MENTION_LISTBOX_ID}
+        role="listbox"
+        aria-label={t('chat.mention.suggestions')}
+        aria-busy={isLoading}
+      >
+        {!isLoading && mentionItems.map((item, index) => {
         const pluginIcon = item.type === 'plugin'
           ? pluginMentionIconMarkup(item.label, item.pluginIconKey, 16)
           : '';
@@ -115,7 +130,8 @@ export const ChatMentionPopup = ({
             </button>
           </div>
         );
-      })}
+        })}
+      </div>
     </div>
   );
 };

--- a/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatPageBody/useChatPageBodyController.tsx
+++ b/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatPageBody/useChatPageBodyController.tsx
@@ -127,6 +127,7 @@ export const useChatPageBodyController = ({
     loading,
     mentionIndex,
     mentionItems,
+    mentionLoading,
     mentionOpen,
     messageTools,
     messages,
@@ -382,7 +383,7 @@ export const useChatPageBodyController = ({
         : agentScope.kind === 'workspace'
           ? t('chat.askWorkspace', { name: scopeLabel })
           : t('chat.askAnything'),
-      input, attachments, editableRef, mentionOpen, mentionItems, mentionIndex,
+      input, attachments, editableRef, mentionOpen, mentionItems, mentionLoading, mentionIndex,
       onSelectMention: selectMention, onMentionIndexChange: setMentionIndex,
       onInput: handleInput, onKeyDown: handleComposerKeyDown, onPaste: handlePaste,
       onAttachFiles: handleAttachFiles, onRemoveAttachment: removeAttachment,

--- a/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatPanel/useChatPanelController.tsx
+++ b/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatPanel/useChatPanelController.tsx
@@ -125,6 +125,7 @@ export const useChatPanelController = ({
     loading,
     mentionIndex,
     mentionItems,
+    mentionLoading,
     mentionOpen,
     messageTools,
     messages,
@@ -434,7 +435,7 @@ export const useChatPanelController = ({
         knowledgeMode,
     },
     composer: {
-        input, attachments, editableRef, mentionOpen, mentionItems, mentionIndex,
+        input, attachments, editableRef, mentionOpen, mentionItems, mentionLoading, mentionIndex,
         onSelectMention: selectMention, onMentionIndexChange: setMentionIndex,
         onInput: handleInput, onKeyDown: handleComposerKeyDown, onPaste: handlePaste,
         onAttachFiles: handleAttachFiles, onRemoveAttachment: removeAttachment,

--- a/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatView/index.tsx
+++ b/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatView/index.tsx
@@ -28,7 +28,7 @@ export const ChatView = ({ chrome, thread, context, composer }: ChatViewProps) =
     knowledgeMode = false, emptyStateVariant,
   } = context;
   const {
-    inputPlaceholder, input, attachments, editableRef, mentionOpen, mentionItems, mentionIndex,
+    inputPlaceholder, input, attachments, editableRef, mentionOpen, mentionItems, mentionLoading = false, mentionIndex,
     onSelectMention, onMentionIndexChange, onInput, onKeyDown, onPaste, onAttachFiles,
     onRemoveAttachment, onRetryAttachment, sendDisabled = false, interactionDisabled = false,
     runInputDisabled = false, onSubmit, onQueue, queuedInputs, steeringInputId, onSteerQueued,
@@ -129,12 +129,13 @@ export const ChatView = ({ chrome, thread, context, composer }: ChatViewProps) =
           if (nodeId) onNodeFocus?.(nodeId);
         }}
         editableRef={editableRef}
-        mentionOpen={mentionOpen && mentionItems.length > 0}
-        mentionIndex={mentionIndex}
-        mentionPopup={mentionOpen && mentionItems.length > 0 ? (
+        mentionOpen={mentionOpen}
+        mentionIndex={mentionLoading || mentionItems.length === 0 ? -1 : mentionIndex}
+        mentionPopup={mentionOpen ? (
           <ChatMentionPopup
             mentionItems={mentionItems}
             mentionIndex={mentionIndex}
+            isLoading={mentionLoading}
             onSelectMention={onSelectMention}
             onMentionIndexChange={onMentionIndexChange}
           />

--- a/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatView/types.ts
+++ b/apps/canvas-workspace/src/renderer/src/modules/chat/components/ChatView/types.ts
@@ -76,6 +76,7 @@ export interface ChatViewComposer {
   editableRef: RefObject<HTMLDivElement>;
   mentionOpen: boolean;
   mentionItems: MentionItem[];
+  mentionLoading?: boolean;
   mentionIndex: number;
   onSelectMention: (item: MentionItem) => void;
   onMentionIndexChange: (index: number) => void;

--- a/apps/canvas-workspace/src/renderer/src/modules/chat/components/utils/mentions.test.ts
+++ b/apps/canvas-workspace/src/renderer/src/modules/chat/components/utils/mentions.test.ts
@@ -259,7 +259,39 @@ describe('chat mention rendering', () => {
     });
   });
 
-  it('keeps a localized disambiguation label on a tab candidate and its composer chip', () => {
+  it('keeps tab disambiguation in candidates and chip data but hides web-page chip metadata', () => {
+    const [item] = buildTabMentionItems([{
+      id: 'link:workspace-2',
+      kind: 'link',
+      title: 'CPA Manager Plus',
+      url: 'https://example.com/monitoring',
+      dockWorkspaceId: '__global_chat__',
+      isActive: true,
+    }], () => 'Web page · __global_chat__ · Current tab');
+
+    expect(item.description).toBe('Web page · __global_chat__ · Current tab');
+    const chip = createMentionChipElement(item);
+    expect(chip.dataset.nodeType).toBe('iframe');
+    expect(chip.dataset.tabDescription).toBe('Web page · __global_chat__ · Current tab');
+    expect(chip.querySelector('.chat-mention-chip-meta')).toBeNull();
+    expect(chip.getAttribute('aria-label'))
+      .toBe('CPA Manager Plus · Web page · __global_chat__ · Current tab');
+    const editable = document.createElement('div');
+    editable.appendChild(chip);
+    expect(collectTabRefsFromEditable(editable)).toEqual([{
+      id: 'link:workspace-2',
+      kind: 'link',
+      title: 'CPA Manager Plus',
+      url: 'https://example.com/monitoring',
+      dockWorkspaceId: '__global_chat__',
+      workspaceId: undefined,
+      nodeId: undefined,
+      artifactId: undefined,
+      sessionId: undefined,
+    }]);
+  });
+
+  it('keeps inserted metadata visible for non-web tab chips', () => {
     const [item] = buildTabMentionItems([{
       id: 'canvas:workspace-2',
       kind: 'canvas',
@@ -269,13 +301,9 @@ describe('chat mention rendering', () => {
       isActive: true,
     }], () => 'Canvas · Product · Current tab');
 
-    expect(item.description).toBe('Canvas · Product · Current tab');
     const chip = createMentionChipElement(item);
-    expect(chip.dataset.nodeType).toBe('workspace');
     expect(chip.querySelector('.chat-mention-chip-meta')?.textContent)
       .toBe('Canvas · Product · Current tab');
-    expect(chip.getAttribute('aria-label'))
-      .toBe('Roadmap · Canvas · Product · Current tab');
   });
 
   it('renders a tab marker back into a clickable jump chip in the transcript', () => {

--- a/apps/canvas-workspace/src/renderer/src/modules/chat/components/utils/tabMentions.ts
+++ b/apps/canvas-workspace/src/renderer/src/modules/chat/components/utils/tabMentions.ts
@@ -184,7 +184,7 @@ export function buildTabMentionChip(item: MentionItem, nodeType: string): HTMLSp
   labelSpan.className = 'chat-mention-chip-label';
   labelSpan.textContent = label;
   chip.appendChild(labelSpan);
-  if (item.description) {
+  if (item.description && tab.kind !== 'link') {
     const metaSpan = document.createElement('span');
     metaSpan.className = 'chat-mention-chip-meta';
     metaSpan.textContent = item.description;


### PR DESCRIPTION
## Summary
- Treat the visible workspace manifest as authoritative for the chat rail. Filter leftover workspace stores before reading history, and prevent active agents from reintroducing removed workspace groups.
- Explicitly preserve global chat and scheduled-task stores, including when the ordinary workspace manifest is empty. Keep historical files and unfiltered history-search callers unchanged.
- Render the chat anchors trigger with the shared icon Button so cold-loading the chat page does not depend on lazy ChatPanel CSS.

## Scope
Only these two fixes (9 files). Built from origin/master in an isolated worktree; unrelated Dock reading changes and the local overview-card commit are excluded.

## Verification
- Standard Harness acceptance: 5/5 commands passed.
- Full Canvas suite: 514 files, 3038 tests passed.
- Canvas typecheck and production build passed.
- Harness integrity: harnessGaps = 0.
- Regression coverage: removed disk stores, active-agent reintroduction, empty manifest preserving global/scheduled history, and self-styled anchor trigger.
- This MR preparation reran automated checks and build; it did not rerun the earlier manual Electron screenshot scenarios. Webview performance A/B was not run (unrelated to these fixes).

## Rollout
The session filter changes main-process code: a rebuilt app and full restart are needed. No data deletion or migration.